### PR TITLE
feat(ci): CodeQL SAST + Playwright E2E offline-first — merge-gate bloqueante

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL SAST
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,46 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Offline-first E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+        env:
+          CI: '1'
+          VITE_FARMOS_URL: ''
+          VITE_FARMOS_CLIENT_ID: farm
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ dist-ssr
 .env
 .env.local
 .claude/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/AI_PIPELINE_SOP.md
+++ b/AI_PIPELINE_SOP.md
@@ -2,7 +2,7 @@
 
 **Repositorio:** Chagra (PWA offline-first, público)
 **Última revisión:** 2026-04-16
-**Versión en producción:** 0.4.6
+**Versión en producción:** 0.5.1
 
 ---
 
@@ -109,8 +109,38 @@ git push origin main
 
 ---
 
-## 5. Referencias Cruzadas
+## 5. Merge-Gate de Seguridad y Comportamiento (QA/DevSecOps)
+
+Toda Pull Request hacia `main` debe atravesar dos merge-checks **obligatorios y bloqueantes**. Ningún PR puede fusionarse si alguno de los siguientes workflows falla, está pendiente o es omitido:
+
+### 5.1 SAST — CodeQL (`.github/workflows/codeql.yml`)
+
+- Motor: GitHub CodeQL nativo, lenguaje `javascript-typescript`.
+- Conjunto de queries: `security-extended` + `security-and-quality`.
+- Dispara en `pull_request` contra `main`, `push` a `main`, y cron semanal.
+- Falla el PR ante inyección (XSS, código, path traversal), secretos expuestos en código, uso inseguro de `eval`/`innerHTML`, y patrones de credenciales hardcodeadas.
+
+### 5.2 E2E — Playwright (`.github/workflows/playwright.yml`)
+
+- Framework: `@playwright/test` (Chromium, headless, 1 worker en CI).
+- Test canónico obligatorio: `tests/offline.spec.js` — valida el contrato offline-first:
+  1. `context.setOffline(true)` antes de guardar una siembra.
+  2. Persiste una transacción en IndexedDB store `pending_transactions` (esquema v6, ver `src/db/dbCore.js`).
+  3. `context.setOffline(false)` y verificación de transición del indicador a estado `Online` + `Sync/Pendientes`.
+- El build de Vite y el servidor dev se arrancan vía `webServer` en `playwright.config.js`.
+
+### 5.3 Regla de bloqueo
+
+> **Dictamen:** un PR con `CodeQL / Analyze` ❌ o `Playwright E2E / Offline-first E2E` ❌ **no puede** mergearse a `main`. El mantenedor debe configurar ambos checks como *Required* en las reglas de protección de rama (`Settings → Branches → main → Require status checks to pass`). El único atajo permitido es revertir el PR, no hacer bypass.
+
+Cualquier cambio sobre `src/db/dbCore.js`, `src/services/syncManager.js`, `src/services/payloadService.js` o `public/sw.js` **debe** incluir actualización del test E2E correspondiente si la superficie offline cambia.
+
+---
+
+## 6. Referencias Cruzadas
 
 - Auditoría técnica v0.4.6: `AUDIT_0.4.6.md`
 - Arquitectura de voz v0.5.0: `ARCHITECTURE_VOICE_0.5.0.md`
+- Pipeline SAST: `.github/workflows/codeql.yml`
+- Pipeline E2E: `.github/workflows/playwright.yml` + `tests/offline.spec.js`
 - Guía de contexto global: `~/.claude/CLAUDE.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chagra",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chagra",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "dependencies": {
         "leaflet": "^1.9.4",
         "localforage": "^1.10.0",
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.59.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
@@ -1956,6 +1957,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -5711,6 +5728,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "leaflet": "^1.9.4",
@@ -18,9 +20,8 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
-    "workbox-build": "^7.4.0",
-    "workbox-window": "^7.4.0",
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.59.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
@@ -31,6 +32,8 @@
     "globals": "^17.4.0",
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "workbox-build": "^7.4.0",
+    "workbox-window": "^7.4.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev -- --port=5173 --strictPort',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -32,11 +32,20 @@ const countPendingTransactions = async (page) =>
     { dbName: DB_NAME, storeName: PENDING_STORE }
   );
 
+const preloadPayloadService = (page) =>
+  page.evaluate(async () => {
+    // Precarga del módulo mientras hay red — tras setOffline el dev server
+    // queda inalcanzable y el dynamic import fallaria.
+    const mod = await import('/src/services/payloadService.js');
+    window.__chagraE2E = { savePayload: mod.savePayload };
+  });
+
 const triggerOfflineSeeding = (page, { crop, quantity }) =>
   page.evaluate(
     async ({ crop, quantity }) => {
-      // Usa el servicio real — no duplica lógica de persistencia.
-      const mod = await import('/src/services/payloadService.js');
+      if (!window.__chagraE2E?.savePayload) {
+        throw new Error('payloadService no fue precargado antes del offline');
+      }
       const payload = {
         data: {
           type: 'log--seeding',
@@ -61,7 +70,7 @@ const triggerOfflineSeeding = (page, { crop, quantity }) =>
           },
         },
       };
-      return mod.savePayload('seeding', payload);
+      return window.__chagraE2E.savePayload('seeding', payload);
     },
     { crop, quantity }
   );
@@ -102,6 +111,9 @@ test.describe('Offline-first — siembra pendiente y reconexión', () => {
     await expect(
       page.getByRole('button', { name: /tareas por proximidad|campo/i })
     ).toBeVisible({ timeout: 15_000 });
+
+    // Precarga del servicio mientras todavia hay red.
+    await preloadPayloadService(page);
 
     // Simula desconexión de red.
     await context.setOffline(true);

--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test';
+
+const DB_NAME = 'ChagraDB';
+const PENDING_STORE = 'pending_transactions';
+
+const countPendingTransactions = async (page) =>
+  page.evaluate(
+    ({ dbName, storeName }) =>
+      new Promise((resolve, reject) => {
+        const req = indexedDB.open(dbName);
+        req.onsuccess = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains(storeName)) {
+            db.close();
+            resolve(0);
+            return;
+          }
+          const tx = db.transaction(storeName, 'readonly');
+          const store = tx.objectStore(storeName);
+          const countReq = store.count();
+          countReq.onsuccess = () => {
+            db.close();
+            resolve(countReq.result);
+          };
+          countReq.onerror = () => {
+            db.close();
+            reject(countReq.error);
+          };
+        };
+        req.onerror = () => reject(req.error);
+      }),
+    { dbName: DB_NAME, storeName: PENDING_STORE }
+  );
+
+const triggerOfflineSeeding = (page, { crop, quantity }) =>
+  page.evaluate(
+    async ({ crop, quantity }) => {
+      // Usa el servicio real — no duplica lógica de persistencia.
+      const mod = await import('/src/services/payloadService.js');
+      const payload = {
+        data: {
+          type: 'log--seeding',
+          attributes: {
+            name: `Siembra de ${crop} - E2E`,
+            timestamp: new Date().toISOString().split('.')[0] + '+00:00',
+            status: 'done',
+          },
+          relationships: {
+            quantity: {
+              data: [
+                {
+                  type: 'quantity--standard',
+                  attributes: {
+                    measure: 'count',
+                    value: { decimal: String(quantity) },
+                    label: 'Plántulas',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      return mod.savePayload('seeding', payload);
+    },
+    { crop, quantity }
+  );
+
+test.describe('Offline-first — siembra pendiente y reconexión', () => {
+  test.beforeEach(async ({ context }) => {
+    // Token OAuth2 sustituido por un fake — nunca tocamos FarmOS real.
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-fake-access',
+          refresh_token: 'e2e-fake-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+    );
+
+    // Cualquier otro tráfico saliente a FarmOS/HA/Ollama se bloquea —
+    // el test depende solo de la capa offline, nunca de red externa.
+    await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+  });
+
+  test('guarda siembra de 10 fresas offline y reporta sincronización al reconectar', async ({
+    context,
+    page,
+  }) => {
+    await page.goto('/');
+
+    // Login vía UI contra endpoint mockeado.
+    await page.getByLabel(/usuario/i).fill('e2e-operator');
+    await page.getByLabel(/contraseña/i).fill('e2e-pass');
+    await page.getByRole('button', { name: /ingresar/i }).click();
+
+    // Confirmamos Dashboard cargado.
+    await expect(
+      page.getByRole('button', { name: /tareas por proximidad|campo/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Simula desconexión de red.
+    await context.setOffline(true);
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+
+    await expect(page.getByText(/sin conexion|offline-first/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Crea transacción de siembra (10 fresas) a través del servicio real.
+    const result = await triggerOfflineSeeding(page, { crop: 'Fresa', quantity: 10 });
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/pendiente|guardado local|sin conexi/i);
+
+    // Se debe haber persistido al menos una transacción en IndexedDB.
+    await expect
+      .poll(() => countPendingTransactions(page), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(1);
+
+    // Reconexión → evento 'online' → NetworkStatusBar entra en SYNCING.
+    await context.setOffline(false);
+    await page.evaluate(() => window.dispatchEvent(new Event('online')));
+
+    await expect(page.getByText(/sincronizando/i)).toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- **CodeQL SAST** (`.github/workflows/codeql.yml`): escaneo nativo de GitHub sobre JS/TS en cada PR→main, push a main y cron semanal. Queries `security-extended` + `security-and-quality` — detecta XSS, inyección, secretos hardcodeados, path traversal.
- **Playwright E2E** (`.github/workflows/playwright.yml` + `tests/offline.spec.js`): prueba crítica del contrato offline-first — `setOffline(true)`, crea siembra de 10 fresas vía `payloadService` real, valida persistencia en IndexedDB `pending_transactions`, reconecta y verifica transición del `NetworkStatusBar` a Sincronizando.
- **SOP §5 merge-gate**: dictamen bloqueante. Ningún PR a `main` puede mergearse si CodeQL o Playwright fallan. El mantenedor debe configurar ambos checks como *Required* en `Settings → Branches → main`.

## Test plan

- [ ] CodeQL workflow corre y pasa sobre este PR (baseline del escaneo sobre el código actual).
- [ ] Playwright workflow instala chromium, arranca `vite dev` y ejecuta `tests/offline.spec.js` en CI sin errores.
- [ ] Verificar reporte HTML de Playwright queda como artifact (retention 14d) ante fallos.
- [ ] Tras merge, configurar ambos checks como *Required* en branch protection de `main`.

## Notas

- Tooling CI puro — no toca `src/`, `public/` ni `dist/`. No dispara `deploy.yml`.
- `e2e-fake-*` y `token_type: Bearer` son mocks literales en el spec, no secretos (verificado con scan SOP §2.6).
- Tráfico saliente a FarmOS / Ollama / HA bloqueado vía `context.route` en `beforeEach` — el test depende solo de la capa offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)