### PR TITLE
fix(forms): prevenir doble-submit en logs de campo (v0.5.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v9';
+const CACHE_NAME = 'chagra-v10';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v10';
+const CACHE_NAME = 'chagra-v11';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HarvestLog.jsx
+++ b/src/components/HarvestLog.jsx
@@ -33,6 +33,7 @@ export default function HarvestLog({ onBack, onSave }) {
     unit: 'Kilogramos',
     notes: ''
   });
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleInput = (e) => {
     const { name, value } = e.target;
@@ -52,12 +53,14 @@ export default function HarvestLog({ onBack, onSave }) {
   };
 
   const handleSave = async () => {
-    try {
-      if (!formData.subArea || !formData.quantity || !formData.product) {
-        onSave('Completa Sub-área, Producto y Cantidad', true);
-        return;
-      }
+    if (isSaving) return;
+    if (!formData.subArea || !formData.quantity || !formData.product) {
+      onSave('Completa Sub-área, Producto y Cantidad', true);
+      return;
+    }
 
+    setIsSaving(true);
+    try {
       const payload = {
         data: {
           type: "log--harvest",
@@ -93,6 +96,8 @@ export default function HarvestLog({ onBack, onSave }) {
     } catch (error) {
       console.error('Error en HarvestLog handleSave:', error);
       onSave('Error al guardar registro', true);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -155,8 +160,13 @@ export default function HarvestLog({ onBack, onSave }) {
           <textarea name="notes" rows="3" value={formData.notes} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-xl text-white min-h-[80px] placeholder-slate-500" placeholder="Ej: Fruta de tamaño pequeño o picada..." />
         </label>
 
-        <button onClick={handleSave} className="mt-4 p-6 rounded-xl bg-orange-600 active:bg-orange-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-orange-800">
-          Guardar Cosecha
+        <button
+          onClick={handleSave}
+          disabled={isSaving}
+          aria-busy={isSaving}
+          className="mt-4 p-6 rounded-xl bg-orange-600 active:bg-orange-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-orange-800 disabled:opacity-60 disabled:active:bg-orange-600"
+        >
+          {isSaving ? 'Guardando…' : 'Guardar Cosecha'}
         </button>
       </div>
     </div>

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -12,6 +12,7 @@ function ObservationScreen({ onBack, onSave }) {
   });
   const [photo, setPhoto] = useState(null);
   const [photoUrl, setPhotoUrl] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
 
   const handleInput = (e) => {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -27,12 +28,14 @@ function ObservationScreen({ onBack, onSave }) {
   };
 
   const handleSave = async () => {
-    try {
-      if (!formData.description || !formData.locationId) {
-        onSave('Completa descripcion y ubicacion', true);
-        return;
-      }
+    if (isSaving) return;
+    if (!formData.description || !formData.locationId) {
+      onSave('Completa descripcion y ubicacion', true);
+      return;
+    }
 
+    setIsSaving(true);
+    try {
       const payload = {
         data: {
           type: "log--observation",
@@ -73,6 +76,8 @@ function ObservationScreen({ onBack, onSave }) {
     } catch (error) {
       console.error('Error en ObservationScreen handleSave:', error);
       onSave('Error al guardar registro', true);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -130,8 +135,13 @@ function ObservationScreen({ onBack, onSave }) {
           </button>
         </label>
 
-        <button onClick={handleSave} className="mt-4 p-6 rounded-xl bg-purple-600 active:bg-purple-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-purple-800">
-          Guardar Observacion
+        <button
+          onClick={handleSave}
+          disabled={isSaving}
+          aria-busy={isSaving}
+          className="mt-4 p-6 rounded-xl bg-purple-600 active:bg-purple-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-purple-800 disabled:opacity-60 disabled:active:bg-purple-600"
+        >
+          {isSaving ? 'Guardando…' : 'Guardar Observacion'}
         </button>
       </div>
     </div>

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -24,6 +24,7 @@ export default function PlantAssetLog({ onBack, onSave }) {
   const [photoUrl, setPhotoUrl] = useState(null);
   const [location, setLocation] = useState(null);
   const [isLocating, setIsLocating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -74,43 +75,52 @@ export default function PlantAssetLog({ onBack, onSave }) {
   };
 
   const handleSave = async () => {
+    if (isSaving) return;
     if (!formData.species || !location) {
       onSave('Completa Especie/Nombre y captura la coordenada', true);
       return;
     }
 
-    const payload = {
-      _multipartFile: photo ? {
-        name: photo.name,
-        type: photo.type,
-        size: photo.size,
-        file: photo
-      } : null,
+    setIsSaving(true);
+    try {
+      const payload = {
+        _multipartFile: photo ? {
+          name: photo.name,
+          type: photo.type,
+          size: photo.size,
+          file: photo
+        } : null,
 
-      data: {
-        type: "asset--plant",
-        attributes: {
-          name: `${formData.species} - ${formData.variety || 'N/A'}`,
-          status: "active",
-          intrinsic_geometry: location.wkt,
-          notes: `Estado Sanitario: ${formData.healthStatus}`
-        },
-        relationships: {
-          plant_type: {
-            data: [{ type: "taxonomy_term--plant_type", id: formData.assetType }]
+        data: {
+          type: "asset--plant",
+          attributes: {
+            name: `${formData.species} - ${formData.variety || 'N/A'}`,
+            status: "active",
+            intrinsic_geometry: location.wkt,
+            notes: `Estado Sanitario: ${formData.healthStatus}`
           },
+          relationships: {
+            plant_type: {
+              data: [{ type: "taxonomy_term--plant_type", id: formData.assetType }]
+            },
+          }
         }
-      }
-    };
+      };
 
-    const result = await savePayload('plant_asset', payload);
-    onSave(result.message, !result.success);
+      const result = await savePayload('plant_asset', payload);
+      onSave(result.message, !result.success);
 
-    setFormData({ assetType: 'type-1', species: '', variety: '', healthStatus: 'Sano' });
-    setPhoto(null);
-    if (photoUrl) URL.revokeObjectURL(photoUrl);
-    setPhotoUrl(null);
-    setLocation(null);
+      setFormData({ assetType: 'type-1', species: '', variety: '', healthStatus: 'Sano' });
+      setPhoto(null);
+      if (photoUrl) URL.revokeObjectURL(photoUrl);
+      setPhotoUrl(null);
+      setLocation(null);
+    } catch (error) {
+      console.error('Error en PlantAssetLog handleSave:', error);
+      onSave('Error al guardar activo', true);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -175,8 +185,13 @@ export default function PlantAssetLog({ onBack, onSave }) {
           </label>
         </div>
 
-        <button onClick={handleSave} className="mt-4 p-6 rounded-xl bg-purple-600 active:bg-purple-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-purple-800">
-          Guardar Activo
+        <button
+          onClick={handleSave}
+          disabled={isSaving}
+          aria-busy={isSaving}
+          className="mt-4 p-6 rounded-xl bg-purple-600 active:bg-purple-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-purple-800 disabled:opacity-60 disabled:active:bg-purple-600"
+        >
+          {isSaving ? 'Guardando…' : 'Guardar Activo'}
         </button>
       </div>
     </div>

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -12,6 +12,7 @@ export default function SeedingLog({ onBack, onSave }) {
   const [photo, setPhoto] = useState(null);
   const [isRecording, setIsRecording] = useState(false);
   const [coordinates, setCoordinates] = useState([]);
+  const [isSaving, setIsSaving] = useState(false);
   const watchIdRef = useRef(null);
 
   useEffect(() => {
@@ -47,12 +48,14 @@ export default function SeedingLog({ onBack, onSave }) {
   };
 
   const handleSave = async () => {
-    try {
-      if (!formData.crop || !formData.quantity) {
-        onSave('Completa Cultivo y Cantidad', true);
-        return;
-      }
+    if (isSaving) return;
+    if (!formData.crop || !formData.quantity) {
+      onSave('Completa Cultivo y Cantidad', true);
+      return;
+    }
 
+    setIsSaving(true);
+    try {
       const payload = {
         data: {
           type: "log--seeding",
@@ -93,6 +96,8 @@ export default function SeedingLog({ onBack, onSave }) {
     } catch (error) {
       console.error('Error en SeedingLog handleSave:', error);
       onSave('Error al guardar registro', true);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -144,8 +149,13 @@ export default function SeedingLog({ onBack, onSave }) {
           {isRecording && <div className="text-yellow-400 font-bold text-xl text-center animate-pulse mt-2">Grabando ruta... {coordinates.length} puntos registrados</div>}
         </div>
 
-        <button onClick={handleSave} className="mt-4 p-6 rounded-xl bg-green-600 active:bg-green-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-green-800">
-          Guardar Registro
+        <button
+          onClick={handleSave}
+          disabled={isSaving}
+          aria-busy={isSaving}
+          className="mt-4 p-6 rounded-xl bg-green-600 active:bg-green-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-green-800 disabled:opacity-60 disabled:active:bg-green-600"
+        >
+          {isSaving ? 'Guardando…' : 'Guardar Registro'}
         </button>
       </div>
     </div>

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -12,25 +12,41 @@ const MODEL = 'qwen3.5:4b';
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;
 
-const SYSTEM_PROMPT = `Eres un extractor de entidades agrícolas. Recibes una transcripción en español de un operador agroecológico. Devuelves EXCLUSIVAMENTE un array JSON válido, sin texto adicional, sin markdown, sin explicación.
+const SYSTEM_PROMPT = `Eres un extractor de entidades agricolas. Recibes una transcripcion en espanol de un operador registrando siembras. Devuelves EXCLUSIVAMENTE un array JSON valido, sin texto adicional, sin markdown.
 
-Schema estricto:
+Schema:
 [
   {
-    "crop": "<nombre del cultivo en minúsculas, singular>",
+    "crop": "<cultivo en minusculas>",
     "quantity": <entero positivo>,
-    "location": "<nombre del lugar tal como lo dice el operador>"
+    "location": "<lugar tal como lo dice el operador, o cadena vacia '' si no se menciona>"
   }
 ]
 
-Si no puedes extraer ninguna entidad válida, devuelve [].
-Nunca inventes datos. Si la cantidad no se menciona, omite la entrada.`;
+Reglas:
+- Convierte numerales en palabra a entero: "dos"=2, "tres"=3, "diez"=10, "veinte"=20.
+- Si la cantidad no se menciona, omite la entrada completa.
+- Si el lugar no se menciona, usa "" como location (NO omitas la entrada por eso).
+- Nunca inventes datos que no estan en la transcripcion.
+- Si no puedes extraer ninguna entidad valida, devuelve [].
 
+Ejemplos:
+Input: "Sembre cinco tomates en el invernadero"
+Output: [{"crop":"tomate","quantity":5,"location":"invernadero"}]
+
+Input: "Sembre tres arandanos"
+Output: [{"crop":"arandano","quantity":3,"location":""}]
+
+Input: "Hoy tuve un buen dia"
+Output: []`;
+
+// location puede venir vacia cuando el operador no menciona el lugar;
+// la UI resuelve al DEFAULT_LOCATION_ID en ese caso (ver VoiceConfirmation).
 const isValidEntity = (e) =>
   e &&
   typeof e.crop === 'string' && e.crop.trim().length > 0 &&
   Number.isInteger(e.quantity) && e.quantity > 0 &&
-  typeof e.location === 'string' && e.location.trim().length > 0;
+  typeof e.location === 'string';
 
 const parseJsonTolerant = (raw) => {
   if (typeof raw !== 'string') return null;
@@ -99,7 +115,7 @@ export async function extractEntities(text) {
       .map((e) => ({
         crop: e.crop.toLowerCase().trim(),
         quantity: Math.floor(e.quantity),
-        location: e.location.trim(),
+        location: (e.location || '').trim(),
       }));
   } catch (err) {
     if (err.name === 'AbortError') {


### PR DESCRIPTION
## Summary

Resuelve hallazgo **P1** de [`AUDIT_0.4.6.md §2`](../blob/main/AUDIT_0.4.6.md#2-flujos-de-ui-incompletos): los botones de guardar en `HarvestLog`, `SeedingLog`, `PlantAssetLog` y `ObservationScreen` no se deshabilitaban durante `await savePayload(...)`, permitiendo **doble-submit offline** con duplicados en `IndexedDB.pending_transactions` — lo cual después replicaba el registro duplicado a FarmOS al sincronizar.

## Cambios

Patrón uniforme aplicado a los 4 componentes:

```jsx
const [isSaving, setIsSaving] = useState(false);

const handleSave = async () => {
  if (isSaving) return;              // guard de reentrada
  // validaciones early-return...
  setIsSaving(true);
  try { /* savePayload + reset form */ }
  catch (error) { /* toast error */ }
  finally { setIsSaving(false); }    // garantiza reset incluso ante excepción
};
```

Botón con:
- `disabled={isSaving}` + `aria-busy={isSaving}`
- Texto dinámico: `isSaving ? "Guardando…" : "Guardar Registro"`
- Clase `disabled:opacity-60 disabled:active:bg-<color>-600` (evita flash visual en doble-tap)

`PlantAssetLog` adicionalmente gana el `try/catch` que le faltaba por completo (antes cualquier excepción en `savePayload` escapaba al console sin toast al usuario).

## SemVer

- `package.json`: `0.5.3 → 0.5.4` (patch, bug fix).
- `public/sw.js`: `chagra-v10 → chagra-v11` (invalidación de cache para forzar refresh en clientes).

## Merge-gate esperado (SOP §5)

- [ ] `Analyze (javascript-typescript)` — sin regresión SAST.
- [ ] `Offline-first E2E` — pasa (el test no depende de estos componentes pero valida que la cola `pending_transactions` sigue comportándose).
- [ ] Branch protection respetado.

## Test plan manual

- [ ] Offline: abrir `SeedingLog`, completar, **dar doble-tap rápido** al botón — debe registrar **1 sola** siembra en IndexedDB.
- [ ] Online: mismo test — 1 solo POST a FarmOS.
- [ ] Verificar que durante `Guardando…` el botón se ve opaco y no responde a clicks.
- [ ] Error forzado (cortar red durante savePayload): botón vuelve a estado normal tras el toast de error, permite reintentar.
- [ ] Idem para `HarvestLog`, `PlantAssetLog`, `ObservationScreen`.

## Dependencia

Basado sobre `b54a684` (v0.5.3, fix voice prompt). Si el PR de v0.5.3 se mergea primero, éste hace fast-forward limpio. Si éste se mergea primero, trae ambos commits juntos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)