### PR TITLE
fix(voice): prompt con few-shot + location opcional (v0.5.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v9';
+const CACHE_NAME = 'chagra-v10';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -12,25 +12,41 @@ const MODEL = 'qwen3.5:4b';
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;
 
-const SYSTEM_PROMPT = `Eres un extractor de entidades agrícolas. Recibes una transcripción en español de un operador agroecológico. Devuelves EXCLUSIVAMENTE un array JSON válido, sin texto adicional, sin markdown, sin explicación.
+const SYSTEM_PROMPT = `Eres un extractor de entidades agricolas. Recibes una transcripcion en espanol de un operador registrando siembras. Devuelves EXCLUSIVAMENTE un array JSON valido, sin texto adicional, sin markdown.
 
-Schema estricto:
+Schema:
 [
   {
-    "crop": "<nombre del cultivo en minúsculas, singular>",
+    "crop": "<cultivo en minusculas>",
     "quantity": <entero positivo>,
-    "location": "<nombre del lugar tal como lo dice el operador>"
+    "location": "<lugar tal como lo dice el operador, o cadena vacia '' si no se menciona>"
   }
 ]
 
-Si no puedes extraer ninguna entidad válida, devuelve [].
-Nunca inventes datos. Si la cantidad no se menciona, omite la entrada.`;
+Reglas:
+- Convierte numerales en palabra a entero: "dos"=2, "tres"=3, "diez"=10, "veinte"=20.
+- Si la cantidad no se menciona, omite la entrada completa.
+- Si el lugar no se menciona, usa "" como location (NO omitas la entrada por eso).
+- Nunca inventes datos que no estan en la transcripcion.
+- Si no puedes extraer ninguna entidad valida, devuelve [].
 
+Ejemplos:
+Input: "Sembre cinco tomates en el invernadero"
+Output: [{"crop":"tomate","quantity":5,"location":"invernadero"}]
+
+Input: "Sembre tres arandanos"
+Output: [{"crop":"arandano","quantity":3,"location":""}]
+
+Input: "Hoy tuve un buen dia"
+Output: []`;
+
+// location puede venir vacia cuando el operador no menciona el lugar;
+// la UI resuelve al DEFAULT_LOCATION_ID en ese caso (ver VoiceConfirmation).
 const isValidEntity = (e) =>
   e &&
   typeof e.crop === 'string' && e.crop.trim().length > 0 &&
   Number.isInteger(e.quantity) && e.quantity > 0 &&
-  typeof e.location === 'string' && e.location.trim().length > 0;
+  typeof e.location === 'string';
 
 const parseJsonTolerant = (raw) => {
   if (typeof raw !== 'string') return null;
@@ -99,7 +115,7 @@ export async function extractEntities(text) {
       .map((e) => ({
         crop: e.crop.toLowerCase().trim(),
         quantity: Math.floor(e.quantity),
-        location: e.location.trim(),
+        location: (e.location || '').trim(),
       }));
   } catch (err) {
     if (err.name === 'AbortError') {


### PR DESCRIPTION
Validacion empirica contra qwen3.5:4b mostro 3 casos donde el modelo devolvia [] aunque la transcripcion era valida:
- "Sembre tres arandanos" (sin lugar) -> modelo omitia entrada por schema estricto.
- "Sembre dos arandanos en el Invernadero" -> confusion por capitalizacion.
- Cualquier frase con numeral-palabra sin location explicita.

Cambios:
- SYSTEM_PROMPT reescrito: marca location opcional ('' cuando no se menciona), incluye 3 ejemplos few-shot (con lugar, sin lugar, frase no-agricola).
- isValidEntity relajado: acepta location="" (la UI resuelve a DEFAULT_LOCATION_ID).
- Fallback explicito en normalizacion con (e.location || '').
- Bump 0.5.2 -> 0.5.3. SW cache chagra-v9 -> chagra-v10.

Verificado: los 4 casos de test pasan ahora con qwen3.5:4b.