### PR TITLE
fix(security): resolver alerts de CodeQL en main (v0.5.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v11';
+const CACHE_NAME = 'chagra-v12';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
@@ -102,8 +102,13 @@ self.addEventListener('sync', (event) => {
   }
 });
 
-// Escuchar mensajes del cliente
+// Escuchar mensajes del cliente (solo same-origin).
 self.addEventListener('message', (event) => {
+  // Defensa en profundidad: aunque los SW solo reciben mensajes de clientes
+  // bajo su scope, verificamos origin explicitamente para cumplir el
+  // contrato de CodeQL js/missing-origin-check y bloquear cualquier
+  // mensaje cross-origin que llegue via postMessage en el futuro.
+  if (event.origin && event.origin !== self.location.origin) return;
   if (event.data && event.data.type === 'REGISTER_SYNC') {
     if (self.registration.sync) {
       self.registration.sync.register('sync-pending-transactions');

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -46,10 +46,6 @@ const QUICK_PRESET_IDS = [
   'fragaria_ananassa',
 ];
 
-const DYNAMIC_PRESETS = Object.values(CROP_TAXONOMY)
-  .flatMap((group) => group.species)
-  .filter((species) => QUICK_PRESET_IDS.includes(species.id));
-
 const ESTRATO_OPTIONS = [
   { value: 'emergente', label: 'Emergente (>25m)', desc: 'Capa superior del dosel' },
   { value: 'alto', label: 'Alto (10-25m)', desc: 'Árboles frutales, maderables' },

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { hasError: false, error: null, errorInfo: null };
+    this.state = { hasError: false, error: null };
   }
 
   static getDerivedStateFromError(error) {
@@ -13,11 +13,10 @@ export class ErrorBoundary extends React.Component {
   componentDidCatch(error, errorInfo) {
     console.error('[ErrorBoundary] Error capturado:', error);
     console.error('[ErrorBoundary] Stack de componentes:', errorInfo?.componentStack);
-    this.setState({ errorInfo });
   }
 
   handleReset = () => {
-    this.setState({ hasError: false, error: null, errorInfo: null });
+    this.setState({ hasError: false, error: null });
   };
 
   handleReload = () => {

--- a/src/components/FarmMap.jsx
+++ b/src/components/FarmMap.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import useAssetStore from '../store/useAssetStore';
-import { useLogStore } from '../store/useLogStore';
 import { wktToGeoJson } from '../utils/geo';
 import { logCache } from '../db/logCache';
 

--- a/src/components/MaintenanceScreen.jsx
+++ b/src/components/MaintenanceScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ArrowLeft, Wrench, Camera } from 'lucide-react';
+import { ArrowLeft, Camera } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 
 function MaintenanceScreen({ onBack, onSave }) {

--- a/src/components/MapPicker.jsx
+++ b/src/components/MapPicker.jsx
@@ -3,7 +3,6 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { X, MapPin, LocateFixed, Check, Undo2 } from 'lucide-react';
 import { latLngToPoint, latLngsToPolygon } from '../utils/geo';
-import { FARM_CONFIG } from '../config/defaults';
 
 /**
  * MapPicker — Modal de selección/dibujo de geometría (Fase 17.3).

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ArrowLeft, MapPin, Camera } from 'lucide-react';
+import { ArrowLeft, Camera } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 
 function ObservationScreen({ onBack, onSave }) {

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -174,7 +174,7 @@ export default function PlantAssetLog({ onBack, onSave }) {
         <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Fotografía del Activo</span>
           <label className="flex flex-col items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 cursor-pointer min-h-[120px] overflow-hidden relative">
-            {photoUrl ? (
+            {photoUrl && photoUrl.startsWith('blob:') ? (
               <img src={photoUrl} alt="Preview" className="absolute inset-0 w-full h-full object-cover opacity-60" />
             ) : null}
             <div className="z-10 flex flex-col items-center gap-2 drop-shadow-md">

--- a/src/components/TaskLogScreen.jsx
+++ b/src/components/TaskLogScreen.jsx
@@ -1,14 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { ArrowLeft, CheckCircle, Clock, Wifi, WifiOff, RefreshCw } from 'lucide-react';
+import { ArrowLeft, CheckCircle, Clock } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
-
-// Iconos reactivos para estado de sincronización
-const SyncIcon = ({ isOnline, isSyncing }) => {
-  if (isSyncing) {
-    return <RefreshCw size={14} className="animate-spin text-blue-400" />;
-  }
-  return isOnline ? <Wifi size={14} className="text-green-400" /> : <WifiOff size={14} className="text-red-400" />;
-};
 
 function TaskLogScreen({ onBack }) {
   const [tasks, setTasks] = useState([]);
@@ -19,7 +11,7 @@ function TaskLogScreen({ onBack }) {
     try {
       // Aquí se conectaría a FarmOS para obtener tareas pendientes
       // Por ahora simulamos tareas locales
-      const localTasks = await syncManager.getSyncStats();
+      await syncManager.getSyncStats();
       setTasks([
         {
           id: 1,

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -33,11 +33,9 @@ const STATE_DONE = 'done';
  * Blob en pending_voice_recordings para reintento posterior.
  */
 export default function VoiceCapture({ onSave }) {
-  const { isRecording, audioLevel, amplitudeHistory, durationMs, error: recorderError, start, stop, reset, hardLimitMs } = useVoiceRecorder();
+  const { audioLevel, amplitudeHistory, durationMs, error: recorderError, start, stop, reset, hardLimitMs } = useVoiceRecorder();
 
   const [view, setView] = useState(STATE_IDLE);
-  const [lastBlob, setLastBlob] = useState(null);
-  const [lastBlobDuration, setLastBlobDuration] = useState(0);
   const [transcription, setTranscription] = useState('');
   const [entities, setEntities] = useState([]);
   const [errorMsg, setErrorMsg] = useState('');
@@ -61,8 +59,6 @@ export default function VoiceCapture({ onSave }) {
 
   const resetAll = useCallback(() => {
     reset();
-    setLastBlob(null);
-    setLastBlobDuration(0);
     setTranscription('');
     setEntities([]);
     setErrorMsg('');
@@ -114,8 +110,6 @@ export default function VoiceCapture({ onSave }) {
       setView(STATE_ERROR);
       return;
     }
-    setLastBlob(result.blob);
-    setLastBlobDuration(result.durationMs);
     await runPipeline(result.blob, result.durationMs);
   }, [stop, runPipeline]);
 

--- a/src/components/WorkerDashboard.jsx
+++ b/src/components/WorkerDashboard.jsx
@@ -3,8 +3,7 @@ import { MapPin, CheckCircle, Clock, Loader2, Navigation, RefreshCw, Eye, Wrench
 import useAssetStore from '../store/useAssetStore';
 import { logCache } from '../db/logCache';
 import { assetCache } from '../db/assetCache';
-import { mediaCache } from '../db/mediaCache';
-import { wktToGeoJson, geoJsonToWkt } from '../utils/geo';
+import { wktToGeoJson } from '../utils/geo';
 import { haversineDistance, getCoords } from '../utils/spatialAnalysis';
 import FarmMap from './FarmMap';
 import EvidenceCapture from './EvidenceCapture';

--- a/src/services/assetService.js
+++ b/src/services/assetService.js
@@ -40,7 +40,7 @@ export const renameWorker = async (oldName, newName) => {
       return { success: false, error: 'not_found' };
     }
 
-    const result = await sendToFarmOS(`/api/asset/person/${person.id}`, {
+    await sendToFarmOS(`/api/asset/person/${person.id}`, {
       data: {
         type: 'asset--person',
         id: person.id,


### PR DESCRIPTION
Limpieza completa de los 16 alerts de CodeQL en main tras el merge de v0.5.4 (#4) y v0.5.4-forms (#2).

SECURITY (High + Medium):
- PlantAssetLog: anadir guard explicito photoUrl.startsWith('blob:') antes de renderizar <img src>. Cierra alert #1 (DOM-text->HTML). Runtime ya era seguro (URL.createObjectURL siempre produce blob:), pero el data-flow analysis de CodeQL no lo deducia.
- sw.js: anadir verificacion event.origin === self.location.origin en el handler de message. Cierra alert #2 (missing origin check).

WARNING:
- ErrorBoundary: remover state.errorInfo (set en componentDidCatch pero nunca renderizado). El stack ya se loggea en consola.

NOTES (10 unused imports/vars):
- VoiceCapture: remover isRecording, lastBlob, lastBlobDuration (state que nunca se leia, solo se seteaba).
- WorkerDashboard: remover mediaCache + geoJsonToWkt imports.
- TaskLogScreen: remover SyncIcon component + localTasks var.
- ObservationScreen: remover MapPin import.
- MaintenanceScreen: remover Wrench import.
- MapPicker: remover FARM_CONFIG import.
- FarmMap: remover useLogStore import.
- AssetsDashboard: remover DYNAMIC_PRESETS const.
- assetService: remover var "result" sin lectura.

Bump 0.5.4 -> 0.5.5. SW cache chagra-v11 -> chagra-v12.