### PR TITLE
feat(voice): unificar con Sembrar + species canonica via CROP_TAXONOM…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v12';
+const CACHE_NAME = 'chagra-v13';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -4,6 +4,7 @@ import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../services/voiceService';
 import { extractEntities } from '../services/entityExtractor';
 import { syncManager } from '../services/syncManager';
+import { savePayload } from '../services/payloadService';
 import { ENV } from '../config/env';
 import Sparkline from './common/Sparkline';
 import VoiceConfirmation from './VoiceConfirmation';
@@ -113,47 +114,95 @@ export default function VoiceCapture({ onSave }) {
     await runPipeline(result.blob, result.durationMs);
   }, [stop, runPipeline]);
 
+  // Construye un log--seeding identico al de SeedingLog/AssetsDashboard:
+  // - Inline asset--plant en relationships.asset (payloadService crea el
+  //   asset primero y reemplaza con su UUID antes de POSTear el log).
+  // - quantity--standard inline (medida count, etiqueta "Plantulas").
+  // - location apuntando a structure o land segun resolvio el usuario.
+  // - plant_type relationship si la especie cruzo con FarmOS taxonomy.
+  const buildSeedingPayload = useCallback((entity) => {
+    const inlinePlant = {
+      type: 'asset--plant',
+      attributes: {
+        name: entity.canonical || entity.crop,
+        status: 'active',
+        notes: {
+          value: `Origen: registro por voz. Transcripcion: "${transcription}".`,
+          format: 'plain_text',
+        },
+      },
+      ...(entity.farmosTermId ? {
+        relationships: {
+          plant_type: {
+            data: [{ type: 'taxonomy_term--plant_type', id: entity.farmosTermId }],
+          },
+        },
+      } : {}),
+    };
+
+    return {
+      data: {
+        type: 'log--seeding',
+        attributes: {
+          name: `Siembra: ${entity.crop} (x${entity.quantity}) [voz]`,
+          timestamp: Math.floor(Date.now() / 1000),
+          status: 'done',
+          notes: {
+            value: `Registro por voz. Cantidad declarada: ${entity.quantity}. Transcripcion: "${transcription}".`,
+            format: 'plain_text',
+          },
+        },
+        relationships: {
+          asset: { data: [inlinePlant] },
+          location: {
+            data: [{ type: entity.location.type, id: entity.location.id }],
+          },
+          quantity: {
+            data: [{
+              type: 'quantity--standard',
+              attributes: {
+                measure: 'count',
+                value: { decimal: String(entity.quantity) },
+                label: 'Plantulas',
+              },
+            }],
+          },
+        },
+      },
+    };
+  }, [transcription]);
+
   const handleConfirmSave = useCallback(async (confirmedEntities) => {
     setIsSaving(true);
-    try {
-      for (const entity of confirmedEntities) {
-        const transaction = {
-          type: 'asset_plant',
-          endpoint: '/api/asset/plant',
-          payload: {
-            data: {
-              type: 'asset--plant',
-              attributes: {
-                name: `${entity.crop} (voz ×${entity.quantity})`,
-                status: 'active',
-                notes: {
-                  value: `Registro por voz. Transcripción: "${transcription}". Cantidad declarada: ${entity.quantity}.`,
-                  format: 'plain_text',
-                },
-              },
-              relationships: {
-                location: { data: [{ type: entity.location.type, id: entity.location.id }] },
-              },
-            },
-          },
-          _meta: {
-            source: 'voice',
-            quantity: entity.quantity,
-            transcription,
-            createdAt: new Date().toISOString(),
-          },
-        };
-        await syncManager.saveTransaction(transaction);
+    let savedCount = 0;
+    const errors = [];
+
+    for (const entity of confirmedEntities) {
+      try {
+        const payload = buildSeedingPayload(entity);
+        const result = await savePayload('seeding', payload);
+        if (result.success || (result.message || '').toLowerCase().includes('local')) {
+          savedCount++;
+        } else {
+          errors.push(`${entity.crop}: ${result.message || 'desconocido'}`);
+        }
+      } catch (err) {
+        errors.push(`${entity.crop}: ${err.message}`);
       }
-      onSave?.(`${confirmedEntities.length} registro${confirmedEntities.length > 1 ? 's' : ''} encolado${confirmedEntities.length > 1 ? 's' : ''} para sincronización.`);
-      setView(STATE_DONE);
-    } catch (err) {
-      setErrorMsg(`Error guardando transacciones: ${err.message}`);
-      setView(STATE_ERROR);
-    } finally {
-      setIsSaving(false);
     }
-  }, [transcription, onSave]);
+
+    setIsSaving(false);
+    if (savedCount > 0) {
+      const msg = errors.length > 0
+        ? `${savedCount} guardada(s), ${errors.length} con error.`
+        : `${savedCount} siembra${savedCount > 1 ? 's' : ''} registrada${savedCount > 1 ? 's' : ''} por voz.`;
+      onSave?.(msg);
+      setView(STATE_DONE);
+    } else {
+      setErrorMsg(`No se pudo guardar: ${errors.join('; ')}`);
+      setView(STATE_ERROR);
+    }
+  }, [buildSeedingPayload, onSave]);
 
   const recorderErr = recorderError;
   const remainingMs = Math.max(0, hardLimitMs - durationMs);

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -2,7 +2,8 @@ import React, { useMemo, useState } from 'react';
 import { Check, X, Trash2, AlertTriangle, Wand2 } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
-import { bestFuzzyMatch } from '../utils/entityMatcher';
+import { CROP_TAXONOMY } from '../config/taxonomy';
+import { bestFuzzyMatch, similarity } from '../utils/entityMatcher';
 
 /**
  * VoiceConfirmation — pantalla obligatoria de revisión humana del array de
@@ -44,8 +45,22 @@ export default function VoiceConfirmation({
     return opts;
   }, [structures, lands]);
 
-  // Especies conocidas: taxonomy_term--plant_type del cache offline.
-  const plantTypeTerms = useMemo(
+  // Catalogo local de especies: fuente unica de verdad (CROP_TAXONOMY) +
+  // cross-reference con taxonomy_term--plant_type de FarmOS para obtener UUID.
+  const allCropSpecies = useMemo(() => {
+    const all = [];
+    Object.entries(CROP_TAXONOMY).forEach(([groupKey, group]) => {
+      group.species.forEach((sp) => {
+        // sp.name viene como "Arandano (Vaccinium corymbosum)" — separamos
+        // el nombre comun del cientifico para mejorar el match.
+        const commonName = sp.name.split('(')[0].trim();
+        all.push({ ...sp, commonName, group: group.label, groupKey });
+      });
+    });
+    return all;
+  }, []);
+
+  const farmosPlantTypes = useMemo(
     () => (taxonomyTerms || []).filter((t) => t.type === 'taxonomy_term--plant_type'),
     [taxonomyTerms]
   );
@@ -60,11 +75,29 @@ export default function VoiceConfirmation({
     return null;
   };
 
-  // Resuelve cultivo via fuzzy match contra taxonomia ("sarandano" -> "arandano").
+  // Resuelve cultivo en dos pasos:
+  //   1. fuzzy match contra CROP_TAXONOMY local (siempre disponible).
+  //   2. cross-reference del nombre canonico con taxonomyTerms de FarmOS
+  //      para obtener el UUID que se usa en plant_type relationship.
   const resolveCrop = (rawCrop) => {
-    const hit = bestFuzzyMatch(rawCrop, plantTypeTerms, (t) => t.attributes?.name || '', 0.7);
-    if (hit) return { name: hit.match.attributes?.name || rawCrop, id: hit.match.id, score: hit.score };
-    return { name: rawCrop, id: null, score: null };
+    const hit = bestFuzzyMatch(rawCrop, allCropSpecies, (s) => s.commonName, 0.7);
+    if (!hit) {
+      return {
+        crop: rawCrop, canonical: null, cropSlug: null,
+        farmosTermId: null, score: null, group: null,
+      };
+    }
+    const farmosMatch = farmosPlantTypes.find(
+      (t) => similarity(t.attributes?.name || '', hit.match.commonName) > 0.85
+    );
+    return {
+      crop: hit.match.commonName,             // "Arandano"
+      canonical: hit.match.name,              // "Arandano (Vaccinium corymbosum)"
+      cropSlug: hit.match.id,                 // "vaccinium_corymbosum"
+      farmosTermId: farmosMatch?.id || null,  // UUID de FarmOS si existe
+      score: hit.score,
+      group: hit.match.group,                 // "Frutales y Perennes"
+    };
   };
 
   const [rows, setRows] = useState(() =>
@@ -72,10 +105,13 @@ export default function VoiceConfirmation({
       const resolvedLoc = resolveLocation(e.location);
       const resolvedCrop = resolveCrop(e.crop || '');
       return {
-        crop: resolvedCrop.name,
+        crop: resolvedCrop.crop,
         cropOriginal: e.crop || '',
-        cropTermId: resolvedCrop.id,
+        cropCanonical: resolvedCrop.canonical,
+        cropSlug: resolvedCrop.cropSlug,
+        farmosTermId: resolvedCrop.farmosTermId,
         cropScore: resolvedCrop.score,
+        cropGroup: resolvedCrop.group,
         quantity: e.quantity || 1,
         rawLocation: e.location || '',
         locationId: resolvedLoc?.id || '',
@@ -96,8 +132,10 @@ export default function VoiceConfirmation({
   const handleConfirm = () => {
     if (!allValid || isSaving) return;
     const payload = rows.map((r) => ({
-      crop: r.crop.trim().toLowerCase(),
-      cropTermId: r.cropTermId || null,
+      crop: (r.crop || '').trim(),
+      canonical: r.cropCanonical || r.crop,
+      cropSlug: r.cropSlug || null,
+      farmosTermId: r.farmosTermId || null,
       quantity: Math.floor(Number(r.quantity)),
       location: { id: r.locationId, type: r.locationType },
       rawLocation: r.rawLocation,
@@ -136,21 +174,35 @@ export default function VoiceConfirmation({
           </div>
 
           <label className="flex flex-col gap-1">
-            <span className="text-2xs font-bold text-slate-400 uppercase flex items-center gap-1">
+            <span className="text-2xs font-bold text-slate-400 uppercase flex items-center gap-1 flex-wrap">
               Cultivo
               {row.cropScore != null && (
                 <span className="normal-case font-normal text-lime-400/70 inline-flex items-center gap-1">
-                  <Wand2 size={10} /> detectado ({Math.round(row.cropScore * 100)}%)
+                  <Wand2 size={10} /> match {Math.round(row.cropScore * 100)}%
+                </span>
+              )}
+              {row.farmosTermId && (
+                <span className="normal-case font-normal text-emerald-400/70 text-2xs">
+                  · taxonomy ✓
                 </span>
               )}
             </span>
             <input
               type="text"
               value={row.crop}
-              onChange={(e) => updateRow(i, { crop: e.target.value, cropTermId: null, cropScore: null })}
+              onChange={(e) => updateRow(i, {
+                crop: e.target.value,
+                cropCanonical: null, cropSlug: null, farmosTermId: null,
+                cropScore: null, cropGroup: null,
+              })}
               className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
               disabled={isSaving}
             />
+            {row.cropCanonical && (
+              <span className="text-2xs text-lime-300/80 normal-case font-normal">
+                {row.cropCanonical}{row.cropGroup ? ` · ${row.cropGroup}` : ''}
+              </span>
+            )}
             {row.cropOriginal && row.cropOriginal.toLowerCase() !== row.crop.toLowerCase() && (
               <span className="text-2xs text-slate-500 normal-case font-normal">
                 Dijo: "{row.cropOriginal}" → mapeado a especie conocida.


### PR DESCRIPTION
…Y (v0.5.6)

Dos problemas reportados:
1. El mapeo a especie no era visible: mi fuzzy match iba contra taxonomyTerms (cache de FarmOS), que puede estar vacio o no contener "Arandano". Resultado: "sarandano" se mostraba tal cual.
2. El payload de voz creaba asset--plant aislado, no log--seeding. Inconsistente con SeedingLog y AssetsDashboard, que crean ambos en una sola transaccion atomica via savePayload.

Cambios:
- VoiceConfirmation: fuzzy match doble.
  * Paso 1: contra CROP_TAXONOMY local (50+ especies, siempre disponible).
  * Paso 2: cross-reference del nombre canonico contra taxonomyTerms para obtener el UUID FarmOS si existe.
  * UI muestra: nombre comun + chip "match X%" + chip "taxonomy ✓" cuando hay UUID, + linea con binomio cientifico y grupo botanico.
- VoiceCapture.handleConfirmSave reescrito:
  * Construye log--seeding con asset--plant inline en relationships.asset (payloadService crea el plant primero y lo enlaza).
  * quantity--standard inline (measure: count, label: "Plantulas").
  * plant_type relationship cuando farmosTermId resuelve.
  * Llama savePayload('seeding', payload) en lugar de syncManager.saveTransaction({type: 'asset_plant'}).
  * Manejo de errores granular: cuenta exitos vs fallos por entrada.

Bump 0.5.5 -> 0.5.6. SW cache chagra-v12 -> chagra-v13.