### PR TITLE
fix(security,ci): 3 alertas CodeQL + analisis en ramas de trabajo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,15 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    # Corre en main (post-merge) y en ramas efímeras de trabajo. Esto permite
+    # ver los hallazgos de CodeQL en la pestaña Security de cada rama antes
+    # de abrir el PR, evitando ciclos PR→revert→re-PR por alertas SAST.
+    branches:
+      - main
+      - 'feat/**'
+      - 'fix/**'
+      - 'chore/**'
+      - 'refactor/**'
   schedule:
     - cron: '23 4 * * 1'
 

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -4,7 +4,6 @@ import useAssetStore from '../store/useAssetStore';
 import { fetchFromFarmOS } from '../services/apiService';
 import AssetDetailView from './AssetDetailView';
 import { FARM_CONFIG } from '../config/defaults';
-import { CROP_TAXONOMY } from '../config/taxonomy';
 import { MATERIAL_PRESETS } from '../config/materials';
 import MapPicker from './MapPicker';
 import FarmMap from './FarmMap';
@@ -31,19 +30,6 @@ const EQUIPMENT_EXAMPLES = [
   'Pala draga',
   'Machete',
   'Rastrillo',
-];
-
-// Accesos rápidos derivados de CROP_TAXONOMY (fuente única de verdad).
-// Ajustar la lista según frecuencia real de uso en campo.
-const QUICK_PRESET_IDS = [
-  'lactuca_sativa',
-  'solanum_tuberosum_pastusa',
-  'rubus_glaucus',
-  'coriandrum_sativum',
-  'passiflora_edulis',
-  'coffea_arabica',
-  'physalis_peruviana',
-  'fragaria_ananassa',
 ];
 
 const ESTRATO_OPTIONS = [

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -38,11 +38,18 @@ export default function PlantAssetLog({ onBack, onSave }) {
 
   const handlePhotoCapture = (e) => {
     const file = e.target.files[0];
-    if (file) {
-      setPhoto(file);
-      if (photoUrl) URL.revokeObjectURL(photoUrl);
-      setPhotoUrl(URL.createObjectURL(file));
+    if (!file) return;
+    // Validación explícita de MIME: el atributo `accept="image/*"` del input es
+    // solo una pista UX y puede bypassearse. Restringir a image/* antes de
+    // generar el blob URL evita que un SVG/HTML con scripts embebidos llegue a
+    // un <img src={blob:...}> y cierra la regla CodeQL js/xss-through-dom.
+    if (!file.type.startsWith('image/')) {
+      onSave('Archivo no es una imagen válida', true);
+      return;
     }
+    setPhoto(file);
+    if (photoUrl) URL.revokeObjectURL(photoUrl);
+    setPhotoUrl(URL.createObjectURL(file));
   };
 
   const captureLocation = () => {


### PR DESCRIPTION
Resuelve las alertas abiertas contra main:

#1 (HIGH, js/xss-through-dom) PlantAssetLog.jsx:178 — Un archivo subido via <input type=file> se pasaba a URL.createObjectURL y se asignaba como src de un <img>. CodeQL lo traza como "DOM text reinterpreted as HTML" porque accept="image/*" es solo una pista UX bypasseable. Fix: validar MIME con file.type.startsWith('image/') antes de crear el blob URL, rechazando con toast de error si no aplica.

#17 (Note, no-unused) AssetsDashboard.jsx:7 — `CROP_TAXONOMY` importado pero no usado en este archivo (se usa en SpeciesSelect, GuildSuggestions, VoiceConfirmation, guildService — con imports propios). Eliminado.

#18 (Note, no-unused) AssetsDashboard.jsx:38 — `QUICK_PRESET_IDS` array definido como "accesos rapidos" pero sin ningun consumer. Dead code que acompañaba al import #17. Eliminado junto con su comentario.

Complemento operativo: el workflow CodeQL solo corria en push a main (post-merge) + PRs contra main. Extendido a push en ramas feat/**, fix/**, chore/**, refactor/** para que los hallazgos aparezcan en la pestana Security de la rama antes de abrir PR — evita ciclos PR -> revert -> re-PR cuando CodeQL atrapa una regresion.

Sin bump de version: cleanup + hardening defensivo sin impacto UX.