### PR TITLE
fix(ci): rsync con --omit-dir-times para destino multi-owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,12 @@ jobs:
           VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
 
       - name: Deploy to production
-        run: rsync -avz --delete --no-group --chmod=D755,F644 dist/ /mnt/fast/appdata/farmos-pwa/
+        # -O (--omit-dir-times): necesario porque el destino es propiedad de
+        # 'kortux' (grupo compartido chagra-deploy con setgid 2775). El runner
+        # está en el grupo y puede escribir/renombrar, pero utime() sobre dirs
+        # ajenos requiere ser owner → sin -O rsync emite "failed to set times"
+        # y aborta con exit 23. Los times de archivos sí se preservan normal.
+        run: rsync -avzO --delete --no-group --chmod=D755,F644 dist/ /mnt/fast/appdata/farmos-pwa/
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
El deploy fallaba con "failed to set times: Operation not permitted" sobre los directorios de /mnt/fast/appdata/farmos-pwa, que son propiedad de kortux (grupo compartido chagra-deploy con setgid 2775). El runner ahora pertenece al grupo (fix paralelo en guatoc-nixos), pero utime() sobre dirs ajenos requiere ser owner o root — no basta con permisos de escritura.

Fix: flag -O (--omit-dir-times) que skippea solo timestamps de directorios. Los times de los archivos siguen preservándose normal.

Sin este cambio rsync aborta con exit 23 aunque los archivos hayan transferido correctamente, cortando los steps posteriores del workflow (verify, HA webhook, SW cache bump).