### PR TITLE
fix(ci): rsync con --no-perms y --chmod=F644 (re-aplicacion)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,19 @@ jobs:
           VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
 
       - name: Deploy to production
-        # -O (--omit-dir-times): necesario porque el destino es propiedad de
-        # 'kortux' (grupo compartido chagra-deploy con setgid 2775). El runner
-        # está en el grupo y puede escribir/renombrar, pero utime() sobre dirs
-        # ajenos requiere ser owner → sin -O rsync emite "failed to set times"
-        # y aborta con exit 23. Los times de archivos sí se preservan normal.
-        run: rsync -avzO --delete --no-group --chmod=D755,F644 dist/ /mnt/fast/appdata/farmos-pwa/
+        # El destino /mnt/fast/appdata/farmos-pwa es propiedad de 'kortux'
+        # (grupo compartido chagra-deploy con setgid 2775). El runner pertenece
+        # al grupo y puede escribir/renombrar archivos, pero utime/chmod/chown
+        # sobre dirs ajenos requiere ser owner → rsync aborta con exit 23 si
+        # intenta preservar esas propiedades.
+        #
+        # Flags defensivos para este destino multi-owner:
+        #   -O              omit-dir-times (no utime sobre dirs existentes)
+        #   --no-perms      no sync de perms con el source (dirs mantienen 2775)
+        #   --no-group      no preservar grupo del source
+        #   --chmod=F644    perms explicitos SOLO en archivos nuevos; dirs
+        #                   nuevos heredan el setgid del padre (= chagra-deploy)
+        run: rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ /mnt/fast/appdata/farmos-pwa/
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
Reaplica el fix del commit 04a492a que debio incluirse en el squash del PR #9 pero quedo fuera (main solo recibio el commit inicial con -O).

El deploy seguia fallando tras el primer fix con:
  rsync: [generator] failed to set permissions on
  "/mnt/fast/appdata/farmos-pwa/.": Operation not permitted (1)

Dos disparadores distintos intentaban chmod() sobre dirs ajenos: (a) -a incluye -p que sincroniza perms con el source, (b) --chmod=D755 fuerza 755 incluso a dirs existentes con 2775 (setgid chagra-deploy).

Solucion:
- Anadir --no-perms: rsync no compara/sincroniza perms con el source.
- Reducir --chmod=F644 (quitar D755): chmod explicito solo a archivos nuevos. Dirs nuevos heredan setgid del padre preservando multi-owner.