### PR TITLE
feat(ui): panel cyberpunk para generaciones de IA (v0.6.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v16';
+const CACHE_NAME = 'chagra-v17';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/EvidenceCapture.jsx
+++ b/src/components/EvidenceCapture.jsx
@@ -5,7 +5,7 @@ import { mediaCache } from '../db/mediaCache';
 import { analyzeFoliage } from '../services/aiService';
 import { proximityCheck } from '../utils/spatialAnalysis';
 import { wktToGeoJson } from '../utils/geo';
-import StreamingText from './common/StreamingText';
+import AIStreamPanel from './common/AIStreamPanel';
 
 /**
  * EvidenceCapture — Captura con diagnóstico IA y evolución histórica (Fase 20.2b).
@@ -244,15 +244,13 @@ export const EvidenceCapture = ({
       )}
 
       {diagnosing && (
-        <div className="p-3 rounded-lg bg-slate-900 border border-slate-800 space-y-2">
-          <div className="flex items-center gap-2 text-xs text-slate-300 font-bold">
-            <Loader2 size={14} className="animate-spin text-lime-400" />
-            Analizando follaje…
-          </div>
-          <div className="text-[11px] font-mono text-lime-300 break-all min-h-[2.5rem] whitespace-pre-wrap">
-            <StreamingText text={liveDiagnosis} active />
-          </div>
-        </div>
+        <AIStreamPanel
+          text={liveDiagnosis}
+          active
+          label="Analizando follaje"
+          accent="morpho"
+          meta={<span className="font-mono">gemma3:4b · visión</span>}
+        />
       )}
 
       {/* Botón de captura */}

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -3,7 +3,7 @@ import { Info } from 'lucide-react';
 import { assetCache } from '../db/assetCache';
 import { FARM_CONFIG } from '../config/defaults';
 import Sparkline from './common/Sparkline';
-import StreamingText from './common/StreamingText';
+import AIStreamPanel from './common/AIStreamPanel';
 import { streamOllama } from '../services/ollamaStream';
 
 // Constantes de Infraestructura Segura (API Gateway Local)
@@ -46,9 +46,12 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
   const [sensorHistory, setSensorHistory] = useState({});
   const [aiMeta, setAiMeta] = useState(null); // { model, evalDuration, totalDuration }
   // Texto acumulado del LLM durante el analisis agronomico (streaming NDJSON).
-  // Se muestra con efecto typewriter mientras aiStatus === 'thinking' y se
-  // consolida en aiAlert cuando el stream termina.
+  // Se muestra con efecto typewriter mientras aiStatus === 'thinking'.
   const [liveAnalysis, setLiveAnalysis] = useState('');
+  // Texto final consolidado de la IA tras terminar el stream. Se separa de
+  // aiAlert (que solo contiene reglas deterministas) para que el AIStreamPanel
+  // lo renderice en su propio bloque cyberpunk diferenciado.
+  const [aiFinalText, setAiFinalText] = useState('');
 
   // Variables de Entorno (Requeridas en el archivo .env)
   const HA_TOKEN = import.meta.env.VITE_HA_ACCESS_TOKEN;
@@ -246,6 +249,7 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
     setLoading(true);
     setError(null);
     setLiveAnalysis('');
+    setAiFinalText('');
     setAiMeta(null);
 
     try {
@@ -469,7 +473,9 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
 
         const trimmed = (content || '').trim();
         if (trimmed.length > 10) {
-          setAiAlert(`${offlineNotice}${ruleAnalysis}\n\n🤖 IA: ${trimmed}`);
+          // aiAlert queda con solo reglas; el texto de IA va a aiFinalText y
+          // se renderiza abajo en su propio panel cyberpunk (AIStreamPanel).
+          setAiFinalText(trimmed);
           setAiStatus('done');
         } else {
           console.warn('[Telemetry] IA sin contenido suficiente. Length:', trimmed.length);
@@ -669,25 +675,36 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
             <span className="text-slate-400 text-sm italic font-medium">Analizando datos agronómicos...</span>
           </div>
         ) : (
-          <div className="space-y-2">
+          <div className="space-y-3">
             {aiAlert ? (
-              <div>
+              <>
+                {/* Reglas deterministas (monoespaciadas, sin efectos IA) */}
                 <p className="text-sm leading-relaxed text-slate-200 whitespace-pre-line">
                   {aiAlert}
                 </p>
-                {aiStatus === 'thinking' && (
-                  <div className="mt-3 p-3 rounded-lg bg-slate-900/60 border border-orchid/30">
-                    <div className="text-2xs text-orchid uppercase tracking-widest font-bold mb-1 flex items-center gap-1.5">
-                      <span className="w-1.5 h-1.5 bg-orchid rounded-full motion-safe:animate-pulse"></span>
-                      IA generando
-                    </div>
-                    <div className="text-sm text-slate-200 whitespace-pre-wrap leading-relaxed min-h-[2rem]">
-                      <StreamingText text={liveAnalysis} active />
-                    </div>
-                  </div>
+
+                {/* Bloque de IA (streaming + final) con efectos cyberpunk.
+                    Se muestra durante thinking (con liveAnalysis) y permanece
+                    visible en done (con aiFinalText consolidado). El panel
+                    dispara un spark flash al transicionar active→false. */}
+                {(aiStatus === 'thinking' || (aiStatus === 'done' && aiFinalText)) && (
+                  <AIStreamPanel
+                    text={aiStatus === 'thinking' ? liveAnalysis : aiFinalText}
+                    active={aiStatus === 'thinking'}
+                    label={aiStatus === 'thinking' ? 'IA generando' : 'Análisis IA'}
+                    accent="orchid"
+                    meta={aiMeta && (
+                      <span className="tabular-nums">
+                        {aiMeta.model}
+                        {aiMeta.totalDuration && <> · {aiMeta.totalDuration}s</>}
+                        {aiMeta.evalCount && <> · {aiMeta.evalCount}tk</>}
+                      </span>
+                    )}
+                  />
                 )}
+
                 {renderActionButton()}
-              </div>
+              </>
             ) : (
               <div className="flex items-center gap-2 text-amber-400">
                 <span className="text-xl">⚠️</span>

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -7,7 +7,7 @@ import { syncManager } from '../services/syncManager';
 import { savePayload } from '../services/payloadService';
 import { ENV } from '../config/env';
 import Sparkline from './common/Sparkline';
-import StreamingText from './common/StreamingText';
+import AIStreamPanel from './common/AIStreamPanel';
 import VoiceConfirmation from './VoiceConfirmation';
 
 const formatDuration = (ms) => {
@@ -386,8 +386,14 @@ export default function VoiceCapture({ onSave }) {
             <p className="text-xs text-slate-500 italic max-w-md text-center">"{transcription}"</p>
           )}
           {view === STATE_EXTRACTING && (
-            <div className="w-full max-w-md mt-1 p-3 rounded-lg bg-slate-900 border border-slate-800 text-xs font-mono text-lime-300 break-all min-h-[3.5rem] whitespace-pre-wrap">
-              <StreamingText text={liveStream} active />
+            <div className="w-full max-w-md mt-1">
+              <AIStreamPanel
+                text={liveStream}
+                active
+                label="Extrayendo entidades"
+                accent="muzo"
+                meta={<span className="font-mono">qwen3.5:4b</span>}
+              />
             </div>
           )}
         </div>

--- a/src/components/common/AIStreamPanel.jsx
+++ b/src/components/common/AIStreamPanel.jsx
@@ -1,0 +1,132 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Sparkles, Zap } from 'lucide-react';
+import StreamingText from './StreamingText';
+
+/**
+ * AIStreamPanel — bloque cyberpunk de render para generaciones del LLM.
+ *
+ * Efectos visuales:
+ *   - Entrada con "glitch-in": fade + blur + saturación reducida que se
+ *     estabiliza, diferencia IA de contenidos deterministas (reglas).
+ *   - Scanline: barrido horizontal CRT sobre el panel mientras `active`.
+ *   - Neon-pulse: glow del borde (color según `accent`) en loop mientras
+ *     sigue generando.
+ *   - Cursor pulsante al final del texto (vía StreamingText).
+ *   - Spark de cierre: al detectar la transición active:true → false con
+ *     texto presente, dispara un rayo luminoso horizontal + burst circular
+ *     en el borde derecho (~700ms), marcando el fin de la generación.
+ *
+ * Props:
+ *   - text    string        contenido acumulado (chunk a chunk).
+ *   - active  boolean       true mientras el LLM genera.
+ *   - label   string        header (ej. "IA generando", "Diagnóstico IA").
+ *   - accent  string        'orchid' | 'muzo' | 'morpho' — paleta neon.
+ *   - meta    ReactNode     texto pequeño a la derecha del header (modelo, duración).
+ */
+export default function AIStreamPanel({
+  text = '',
+  active = true,
+  label = 'IA',
+  accent = 'orchid',
+  meta = null,
+}) {
+  const [justFinished, setJustFinished] = useState(false);
+  const prevActive = useRef(active);
+
+  useEffect(() => {
+    if (prevActive.current && !active && text) {
+      setJustFinished(true);
+      const t = setTimeout(() => setJustFinished(false), 750);
+      return () => {
+        clearTimeout(t);
+      };
+    }
+    prevActive.current = active;
+  }, [active, text]);
+
+  const palette = {
+    orchid: {
+      border: 'border-orchid/50',
+      glow: 'shadow-neon-orchid',
+      text: 'text-orchid',
+      fill: 'bg-orchid',
+      fromVia: 'via-orchid/80',
+    },
+    muzo: {
+      border: 'border-muzo/50',
+      glow: 'shadow-neon-muzo',
+      text: 'text-muzo',
+      fill: 'bg-muzo',
+      fromVia: 'via-muzo/80',
+    },
+    morpho: {
+      border: 'border-morpho/50',
+      glow: 'shadow-neon-morpho',
+      text: 'text-morpho',
+      fill: 'bg-morpho',
+      fromVia: 'via-morpho/80',
+    },
+  };
+  const c = palette[accent] || palette.orchid;
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-lg border ${c.border} bg-slate-950/70 motion-safe:animate-glitch-in ${
+        active ? `${c.glow} motion-safe:animate-neon-pulse` : ''
+      }`}
+    >
+      {/* Scanline horizontal que desciende en loop, solo activa durante stream */}
+      {active && (
+        <div
+          aria-hidden="true"
+          className={`pointer-events-none absolute inset-x-0 top-0 h-[1px] bg-gradient-to-r from-transparent ${c.fromVia} to-transparent opacity-60 motion-safe:animate-scanline`}
+        />
+      )}
+
+      {/* Spark de cierre: rayo horizontal que cruza + burst al borde */}
+      {justFinished && (
+        <>
+          <div
+            aria-hidden="true"
+            className={`pointer-events-none absolute inset-y-0 left-0 w-24 ${c.fill} opacity-70 motion-safe:animate-spark-flash`}
+            style={{ filter: 'blur(12px)' }}
+          />
+          <div
+            aria-hidden="true"
+            className={`pointer-events-none absolute top-1/2 right-2 w-3 h-3 -translate-y-1/2 rounded-full ${c.fill} motion-safe:animate-spark-burst`}
+            style={{ filter: 'blur(1px)' }}
+          />
+        </>
+      )}
+
+      <div className="relative p-3">
+        <div className={`flex items-center justify-between mb-1.5 text-2xs uppercase tracking-widest font-bold ${c.text}`}>
+          <div className="flex items-center gap-1.5">
+            <span
+              className={`inline-block w-1.5 h-1.5 rounded-full ${c.fill} ${
+                active ? 'motion-safe:animate-pulse' : ''
+              }`}
+              aria-hidden="true"
+            />
+            {active ? (
+              <span className="flex items-center gap-1">
+                <Zap size={12} aria-hidden="true" />
+                {label}
+              </span>
+            ) : (
+              <span className="flex items-center gap-1">
+                <Sparkles size={12} aria-hidden="true" />
+                {label}
+              </span>
+            )}
+          </div>
+          {meta && <span className="text-slate-400 normal-case tracking-normal font-normal">{meta}</span>}
+        </div>
+
+        <div className="text-sm text-slate-100 leading-relaxed whitespace-pre-wrap min-h-[2rem]">
+          <StreamingText text={text} active={active} cursorClassName={c.text} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,42 @@ export default {
                 'neon-orchid': '0 0 15px rgba(217, 70, 239, 0.4)',
                 'neon-frog': '0 0 15px rgba(234, 179, 8, 0.3)',
             },
+            // Animaciones cyberpunk para bloques de generacion por IA (v0.6.2).
+            keyframes: {
+                scanline: {
+                    '0%':   { transform: 'translateY(-100%)', opacity: '0' },
+                    '10%':  { opacity: '0.55' },
+                    '90%':  { opacity: '0.55' },
+                    '100%': { transform: 'translateY(3000%)', opacity: '0' },
+                },
+                glitchIn: {
+                    '0%':   { opacity: '0', transform: 'translateY(8px) scale(0.985)', filter: 'blur(4px) saturate(180%)' },
+                    '40%':  { opacity: '0.7', transform: 'translateY(-2px)', filter: 'blur(1px) saturate(150%)' },
+                    '70%':  { opacity: '0.95', transform: 'translateY(1px)', filter: 'blur(0.5px) saturate(120%)' },
+                    '100%': { opacity: '1', transform: 'translateY(0) scale(1)', filter: 'blur(0) saturate(100%)' },
+                },
+                neonPulse: {
+                    '0%,100%': { boxShadow: '0 0 8px rgba(217,70,239,0.35), inset 0 0 8px rgba(217,70,239,0.08)' },
+                    '50%':     { boxShadow: '0 0 20px rgba(217,70,239,0.75), inset 0 0 14px rgba(217,70,239,0.22)' },
+                },
+                sparkFlash: {
+                    '0%':   { opacity: '0', transform: 'translateX(-20%) scaleX(0.2)', filter: 'blur(10px)' },
+                    '25%':  { opacity: '1' },
+                    '100%': { opacity: '0', transform: 'translateX(120%) scaleX(1.2)', filter: 'blur(4px)' },
+                },
+                sparkBurst: {
+                    '0%':   { opacity: '0', transform: 'scale(0.6)' },
+                    '40%':  { opacity: '1', transform: 'scale(1.15)' },
+                    '100%': { opacity: '0', transform: 'scale(1.6)' },
+                },
+            },
+            animation: {
+                'scanline':    'scanline 2.4s linear infinite',
+                'glitch-in':   'glitchIn 480ms cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+                'neon-pulse':  'neonPulse 2.2s ease-in-out infinite',
+                'spark-flash': 'sparkFlash 750ms ease-out forwards',
+                'spark-burst': 'sparkBurst 650ms ease-out forwards',
+            },
         },
     },
     plugins: [],


### PR DESCRIPTION
El bloque de IA ahora tiene efectos visuales que lo diferencian de las reglas deterministas y marcan claramente el inicio y fin de la generacion token por token:

- Entrada "glitch-in": fade + blur + saturacion que se estabilizan en 480ms, anuncia que llega contenido generado (no determinista).
- Scanline CRT: linea de luz desciende en loop mientras el LLM genera.
- Neon pulse: glow del borde (orchid/muzo/morpho segun contexto) en loop de 2.2s mientras active=true.
- Cursor pulsante neon al final del texto (StreamingText).
- Spark flash de cierre: al detectar transicion active:true→false con texto presente, dispara un rayo horizontal luminoso que cruza el panel + un burst circular en el borde derecho (~750ms). Marca el final de la generacion de forma clara.

Nuevo componente common/AIStreamPanel.jsx consolida el look. Se aplica en tres superficies:
  - TelemetryAlerts (home): accent orchid, "IA generando / Análisis IA". Las reglas deterministas se separaron del texto de la IA (antes concatenadas en aiAlert con prefijo "🤖 IA:"); ahora viven en un estado aparte y el panel se renderiza debajo.
  - VoiceCapture: accent muzo, durante STATE_EXTRACTING muestra el JSON del extractor fluyendo carácter a carácter.
  - EvidenceCapture: accent morpho, durante diagnosing muestra la respuesta de gemma3 en vivo.

Tailwind extendido con keyframes/animations: scanline, glitchIn, neonPulse, sparkFlash, sparkBurst.

Respeta motion-safe: si el user tiene reduced-motion activo, las animaciones se omiten (panel sigue siendo funcional y legible).

Bump 0.6.1 -> 0.6.2. SW cache v16 -> v17.