### PR TITLE
fix(ci): umask 022 + chmod post-rsync para archivos con perms correctos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,18 @@ jobs:
         #   --no-group      no preservar grupo del source
         #   --chmod=F644    perms explicitos SOLO en archivos nuevos; dirs
         #                   nuevos heredan el setgid del padre (= chagra-deploy)
-        run: rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ /mnt/fast/appdata/farmos-pwa/
+        #
+        # `umask 022` antes del rsync: el servicio systemd del runner hereda
+        # umask 077 y rsync respeta el umask del proceso padre; sin este
+        # `umask 022`, los archivos nuevos quedaban 600 a pesar del --chmod,
+        # lo que bloqueaba a Nginx (403 Forbidden) y dejaba prod con pantalla
+        # blanca tras cada deploy. El chmod posterior es defensa en
+        # profundidad: se aplica solo a archivos cuyo owner es runner (los
+        # que creo este deploy), no toca dirs ajenos.
+        run: |
+          umask 022
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ /mnt/fast/appdata/farmos-pwa/
+          find /mnt/fast/appdata/farmos-pwa -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
Tras mergear el fix previo (--no-perms + --chmod=F644), los deploys seguian dejando los archivos en 600 y Nginx devolvia 403 → pantalla blanca en prod hasta correr 'sudo chmod -R a+rX' manualmente.

Causa raiz: el servicio systemd del runner (github-runner-chagra-deploy) hereda umask 077 del systemd root. rsync respeta el umask del proceso padre al crear archivos nuevos, y el flag --chmod del rsync sin --perms SOLO aplica a archivos que rsync esta actualizando con contenido mas reciente — los archivos creados ex nihilo heredan el umask 077 y quedan 600, bloqueando lectura por Nginx.

Fix en dos capas:

1. `umask 022` antes del rsync: fuerza el umask del shell del step GitHub Actions a 022, rsync crea archivos nuevos con 644 por default (el bit de grupo y world se permiten).

2. Chmod post-rsync como defensa en profundidad: find los archivos cuyo owner es runner (solo los que este deploy creo, nunca toca dirs ajenos ni archivos de otros users) con perms != 644 y los normaliza. `|| true` asegura que el step no falle si no hay archivos huerfanos.

Con esto, los deploys futuros NO requieren chmod manual post-merge.