### PR TITLE
feat(ui): estilo HUD para IoT + ejes legibles en sparklines + breath 30s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v17';
+const CACHE_NAME = 'chagra-v18';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/IoTSensorCard.jsx
+++ b/src/components/IoTSensorCard.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { Activity } from 'lucide-react';
+import Sparkline from './common/Sparkline';
+
+/**
+ * IoTSensorCard — card de lectura de sensor IoT en estilo HUD industrial.
+ *
+ * Objetivo visual: distinguir claramente la telemetria IoT (datos crudos,
+ * frios, deterministas) del panel cyberpunk de IA (generativo, orchid,
+ * terminal CRT verde). Se usa un esquema "control de nave": acento morpho
+ * cyan lateral, esquinas diagonales recortadas via clip-path, tipografia
+ * monoespaciada para los readouts numericos y labels tecnicos.
+ *
+ * Props:
+ *   - title               string    encabezado descriptivo ("INVERNADERO — ZONA A").
+ *   - deviceId            string    identificador tecnico en mono ("matera_cocina · zigbee").
+ *   - humidity, temperature          valores crudos de Home Assistant (string|null).
+ *   - humidityHistory, temperatureHistory   arrays de HA history para las sparklines.
+ *   - getHumidityColor, getTemperatureColor   helpers que devuelven clase Tailwind
+ *                                             de color segun el valor (critico/optimo/etc).
+ */
+export default function IoTSensorCard({
+  title,
+  deviceId,
+  humidity,
+  temperature,
+  humidityHistory,
+  temperatureHistory,
+  getHumidityColor,
+  getTemperatureColor,
+}) {
+  const online = humidity !== null && humidity !== undefined && humidity !== 'unavailable';
+  // Clip-path recorta la esquina superior-derecha en diagonal (~14px),
+  // estetica HUD de pantalla de control industrial.
+  const hudClip = {
+    clipPath:
+      'polygon(0 0, calc(100% - 14px) 0, 100% 14px, 100% 100%, 0 100%)',
+  };
+
+  return (
+    <div
+      className="relative bg-slate-900/60 border-l-[3px] border-morpho/70 shadow-[inset_1px_0_0_rgba(6,182,212,0.25)]"
+      style={hudClip}
+    >
+      {/* Esquina HUD: linea diagonal que sigue el clip-path para que se vea como corte neon */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute top-0 right-0 w-[20px] h-[20px]"
+        style={{
+          background:
+            'linear-gradient(225deg, rgba(6,182,212,0.8) 0%, rgba(6,182,212,0.8) 1.5px, transparent 2px)',
+        }}
+      />
+
+      <div className="p-3 pr-4">
+        {/* Header con status dot + title + device ID */}
+        <div className="flex items-start justify-between gap-2 mb-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5 mb-0.5">
+              <span
+                aria-hidden="true"
+                className={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${
+                  online ? 'bg-morpho motion-safe:animate-pulse' : 'bg-slate-600'
+                }`}
+              />
+              <span className="text-morpho/90 text-2xs font-bold tracking-[0.2em] uppercase">
+                {title}
+              </span>
+            </div>
+            <span className="block text-[10px] text-slate-500 font-mono tracking-wide truncate">
+              {deviceId}
+            </span>
+          </div>
+          <span className="text-[9px] text-morpho/60 font-mono uppercase tracking-widest shrink-0">
+            <Activity size={10} className="inline mb-0.5 mr-0.5" />
+            IoT
+          </span>
+        </div>
+
+        {/* Readouts numericos grandes en mono */}
+        <div className="grid grid-cols-2 gap-3 mb-3">
+          <div className="bg-slate-950/60 border border-slate-800 rounded px-2.5 py-1.5">
+            <span className="block text-[9px] text-slate-500 font-mono tracking-widest uppercase mb-0.5">
+              Humedad
+            </span>
+            <div className="flex items-baseline gap-1">
+              <span
+                className={`text-2xl font-black font-mono tabular-nums leading-none ${getHumidityColor(humidity)}`}
+              >
+                {humidity ?? '---'}
+              </span>
+              <span className="text-xs text-slate-500 font-mono">%</span>
+            </div>
+          </div>
+          <div className="bg-slate-950/60 border border-slate-800 rounded px-2.5 py-1.5">
+            <span className="block text-[9px] text-slate-500 font-mono tracking-widest uppercase mb-0.5">
+              Temperatura
+            </span>
+            <div className="flex items-baseline gap-1">
+              <span
+                className={`text-2xl font-black font-mono tabular-nums leading-none ${getTemperatureColor(temperature)}`}
+              >
+                {temperature ?? '---'}
+              </span>
+              <span className="text-xs text-slate-500 font-mono">°C</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Sparklines con ejes legibles (envueltos en contenedor
+            `text-slate-400` para que los labels de ejes del SVG, que
+            usan currentColor, sean grises mientras el trazo mantiene
+            su color semantico). */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="text-slate-400 flex items-center gap-1.5">
+            <span className="text-[9px] text-morpho/70 font-mono shrink-0 tracking-wider">H%</span>
+            <Sparkline
+              data={humidityHistory}
+              color="#3b82f6"
+              timeLabel="24h"
+              unit="%"
+              width={140}
+              height={44}
+            />
+          </div>
+          <div className="text-slate-400 flex items-center gap-1.5">
+            <span className="text-[9px] text-morpho/70 font-mono shrink-0 tracking-wider">T°</span>
+            <Sparkline
+              data={temperatureHistory}
+              color="#f97316"
+              timeLabel="24h"
+              unit="°"
+              width={140}
+              height={44}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Info } from 'lucide-react';
 import { assetCache } from '../db/assetCache';
 import { FARM_CONFIG } from '../config/defaults';
-import Sparkline from './common/Sparkline';
 import AIStreamPanel from './common/AIStreamPanel';
+import IoTSensorCard from './IoTSensorCard';
 import { streamOllama } from '../services/ollamaStream';
 
 // Constantes de Infraestructura Segura (API Gateway Local)
@@ -564,72 +564,31 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
         </div>
       )}
 
-      <div className="space-y-4 mb-6">
-        <div className="p-4 bg-slate-800 rounded-2xl">
-          <div className="flex justify-between items-center">
-            <div>
-              <span className="text-slate-400 font-bold uppercase tracking-wider text-xs block">Invernadero — Zona A</span>
-              <span className="text-slate-300 text-sm">Matera Cocina</span>
-            </div>
-            <div className="flex gap-4">
-              <div className="text-right">
-                <span className="text-slate-400 font-bold uppercase tracking-wider text-xs block">Hum</span>
-                <span className={`text-2xl font-black ${getHumidityColor(sensors.invernaderoHumidity)}`}>
-                  {sensors.invernaderoHumidity || '---'}%
-                </span>
-              </div>
-              <div className="text-right">
-                <span className="text-slate-400 font-bold uppercase tracking-wider text-xs block">Temp</span>
-                <span className={`text-2xl font-black ${getTemperatureColor(sensors.invernaderoTemperature)}`}>
-                  {sensors.invernaderoTemperature || '---'}°C
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="flex gap-3 mt-2 pt-2 border-t border-slate-700/50">
-            <div className="flex-1 flex items-center gap-2">
-              <span className="text-slate-500 text-2xs font-mono shrink-0">H%</span>
-              <Sparkline data={sensorHistory['sensor.matera_cocina_humidity']} color="#3b82f6" />
-            </div>
-            <div className="flex-1 flex items-center gap-2">
-              <span className="text-slate-500 text-2xs font-mono shrink-0">T°</span>
-              <Sparkline data={sensorHistory['sensor.matera_cocina_temperature']} color="#f97316" />
-            </div>
-          </div>
-        </div>
-
-        <div className="p-4 bg-slate-800 rounded-2xl">
-          <div className="flex justify-between items-center">
-            <div>
-              <span className="text-slate-400 font-bold uppercase tracking-wider text-xs block">Matera Tabaco</span>
-              <span className="text-slate-300 text-sm">Cocina · Hobeian ZG-303Z</span>
-            </div>
-            <div className="flex gap-4">
-              <div className="text-right">
-                <span className="text-slate-400 font-bold uppercase tracking-wider text-xs block">Hum</span>
-                <span className={`text-2xl font-black ${getHumidityColor(sensors.tabacoHumidity)}`}>
-                  {sensors.tabacoHumidity || '---'}%
-                </span>
-              </div>
-              <div className="text-right">
-                <span className="text-slate-400 font-bold uppercase tracking-wider text-xs block">Temp</span>
-                <span className={`text-2xl font-black ${getTemperatureColor(sensors.tabacoTemperature)}`}>
-                  {sensors.tabacoTemperature || '---'}°C
-                </span>
-              </div>
-            </div>
-          </div>
-          <div className="flex gap-3 mt-2 pt-2 border-t border-slate-700/50">
-            <div className="flex-1 flex items-center gap-2">
-              <span className="text-slate-500 text-2xs font-mono shrink-0">H%</span>
-              <Sparkline data={sensorHistory['sensor.hobeian_zg_303z_humidity']} color="#3b82f6" />
-            </div>
-            <div className="flex-1 flex items-center gap-2">
-              <span className="text-slate-500 text-2xs font-mono shrink-0">T°</span>
-              <Sparkline data={sensorHistory['sensor.hobeian_zg_303z_temperature']} color="#f97316" />
-            </div>
-          </div>
-        </div>
+      {/* Telemetria IoT — estilo HUD industrial, tipografia monoespaciada,
+          borde left accent morpho (cyan) para diferenciar visualmente del
+          panel cyberpunk de IA (orchid). Status dot parpadea sutilmente
+          como signo de conexion viva al sensor. */}
+      <div className="space-y-3 mb-6">
+        <IoTSensorCard
+          title="INVERNADERO — ZONA A"
+          deviceId="matera_cocina · zigbee"
+          humidity={sensors.invernaderoHumidity}
+          temperature={sensors.invernaderoTemperature}
+          humidityHistory={sensorHistory['sensor.matera_cocina_humidity']}
+          temperatureHistory={sensorHistory['sensor.matera_cocina_temperature']}
+          getHumidityColor={getHumidityColor}
+          getTemperatureColor={getTemperatureColor}
+        />
+        <IoTSensorCard
+          title="MATERA TABACO"
+          deviceId="cocina · hobeian_zg_303z"
+          humidity={sensors.tabacoHumidity}
+          temperature={sensors.tabacoTemperature}
+          humidityHistory={sensorHistory['sensor.hobeian_zg_303z_humidity']}
+          temperatureHistory={sensorHistory['sensor.hobeian_zg_303z_temperature']}
+          getHumidityColor={getHumidityColor}
+          getTemperatureColor={getTemperatureColor}
+        />
       </div>
 
       <div className={`p-5 rounded-xl relative overflow-hidden border-l-8 shadow-neon-morpho ${loading ? 'bg-morpho/5 border-morpho' : 'bg-orchid/5 border-orchid'}`}>

--- a/src/components/common/Sparkline.jsx
+++ b/src/components/common/Sparkline.jsx
@@ -1,20 +1,29 @@
 import React from 'react';
 
 /**
- * Sparkline SVG inline — renderiza una serie numérica (0..N) sin dependencias.
+ * Sparkline SVG inline — renderiza una serie numerica (0..N) sin dependencias.
+ *
+ * Desde v0.6.3 incluye ejes mas legibles:
+ *   - Guias horizontales sutiles en min/mid/max del rango.
+ *   - Labels Y con valores min y max (fuera del area de trazo).
+ *   - Label X con la ventana temporal (ej. "24h") si se pasa `timeLabel`.
+ *   - Valor actual destacado sobre el ultimo punto.
  *
  * Acepta:
- *   values: number[]                   — array crudo de números
- *   data:   Array<{ state: string|number }>  — compat con formato HA history
+ *   values: number[]                           — array crudo de numeros.
+ *   data:   Array<{ state: string|number }>    — compat con formato HA history.
  *
- * Props opcionales: color, height, width, showLastValue, lastValueDecimals.
+ * Props opcionales: color, height, width, timeLabel, unit, showLastValue,
+ * lastValueDecimals.
  */
 export default function Sparkline({
   values,
   data,
   color = '#22d3ee',
-  height = 32,
-  width = 120,
+  height = 48,
+  width = 160,
+  timeLabel = '24h',
+  unit = '',
   showLastValue = true,
   lastValueDecimals = 1,
 }) {
@@ -34,31 +43,84 @@ export default function Sparkline({
   const min = Math.min(...series);
   const max = Math.max(...series);
   const range = max - min || 1;
-  const step = width / (series.length - 1);
+
+  // Padding interno: izquierda para labels Y, abajo para label X.
+  const padL = 22;
+  const padR = 4;
+  const padT = 4;
+  const padB = 12;
+
+  const plotW = width - padL - padR;
+  const plotH = height - padT - padB;
+  const step = plotW / (series.length - 1);
 
   const points = series
-    .map((v, i) => `${i * step},${height - ((v - min) / range) * (height - 4) - 2}`)
+    .map((v, i) => {
+      const x = padL + i * step;
+      const y = padT + plotH - ((v - min) / range) * plotH;
+      return `${x},${y}`;
+    })
     .join(' ');
 
   const lastVal = series[series.length - 1];
-  const lastX = (series.length - 1) * step;
-  const lastY = height - ((lastVal - min) / range) * (height - 4) - 2;
+  const lastX = padL + (series.length - 1) * step;
+  const lastY = padT + plotH - ((lastVal - min) / range) * plotH;
+
+  const midY = padT + plotH / 2;
+  const topY = padT;
+  const bottomY = padT + plotH;
 
   return (
-    <svg width={width} height={height} className="inline-block" viewBox={`0 0 ${width} ${height}`}>
+    <svg
+      width={width}
+      height={height}
+      className="inline-block"
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      {/* Guias horizontales tenues en min/mid/max */}
+      <line x1={padL} y1={topY} x2={width - padR} y2={topY} stroke="currentColor" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.2" />
+      <line x1={padL} y1={midY} x2={width - padR} y2={midY} stroke="currentColor" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.15" />
+      <line x1={padL} y1={bottomY} x2={width - padR} y2={bottomY} stroke="currentColor" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.2" />
+
+      {/* Labels Y (max arriba, min abajo) */}
+      <text x={padL - 3} y={topY + 3} fill="currentColor" fontSize="8" textAnchor="end" opacity="0.7" className="font-mono">
+        {max.toFixed(0)}
+      </text>
+      <text x={padL - 3} y={bottomY + 1} fill="currentColor" fontSize="8" textAnchor="end" opacity="0.7" className="font-mono">
+        {min.toFixed(0)}
+      </text>
+
+      {/* Label X (ventana temporal) abajo-derecha */}
+      {timeLabel && (
+        <text x={width - padR} y={height - 1} fill="currentColor" fontSize="7.5" textAnchor="end" opacity="0.55" className="font-mono">
+          {timeLabel}
+        </text>
+      )}
+
+      {/* Serie */}
       <polyline
         fill="none"
         stroke={color}
-        strokeWidth="1.5"
+        strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"
         points={points}
-        opacity="0.8"
+        opacity="0.95"
       />
+
+      {/* Ultimo punto + valor */}
       <circle cx={lastX} cy={lastY} r="2.5" fill={color} />
       {showLastValue && (
-        <text x={lastX - 4} y={lastY - 5} fill={color} fontSize="7" fontWeight="bold" textAnchor="end">
-          {lastVal.toFixed(lastValueDecimals)}
+        <text
+          x={lastX - 4}
+          y={Math.max(padT + 7, lastY - 4)}
+          fill={color}
+          fontSize="8.5"
+          fontWeight="bold"
+          textAnchor="end"
+          className="font-mono"
+        >
+          {lastVal.toFixed(lastValueDecimals)}{unit}
         </text>
       )}
     </svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -83,31 +83,30 @@ export default {
                     '50%':      { opacity: '0.97' },
                     '80%':      { opacity: '0.99' },
                 },
-                // Flash de negativo fotografico (invert + hue-rotate). Breve,
-                // ~400ms. Usado como (a) pulso de "IA viva" cada 8s durante el
-                // stream, y (b) transicion inicial antes del rayo de cierre.
+                // Flash de negativo fotografico (invert + hue-rotate). Usado
+                // como transicion inicial del cierre del stream, ~1s.
                 negativeFlash: {
                     '0%':   { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
-                    '15%':  { filter: 'invert(1) hue-rotate(180deg) saturate(140%)' },
-                    '55%':  { filter: 'invert(1) hue-rotate(200deg) saturate(120%)' },
-                    '80%':  { filter: 'invert(0.25) hue-rotate(60deg) saturate(110%)' },
+                    '20%':  { filter: 'invert(1) hue-rotate(180deg) saturate(150%)' },
+                    '60%':  { filter: 'invert(1) hue-rotate(200deg) saturate(130%)' },
+                    '85%':  { filter: 'invert(0.3) hue-rotate(70deg) saturate(110%)' },
                     '100%': { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
                 },
-                // Loop continuo: latido periodico de "IA viva". Ventana amplia
-                // (~18% del ciclo de 8s = 1.4s de flash) con una "S" de
-                // intensidad para que sea claramente visible: invert pico al
-                // 90%, decae gradualmente al volver al verde fosforo.
+                // Latido de "IA viva" — loop de 30s con flash amplio de
+                // negativo en los ultimos 9% del ciclo (~2.7s). Periodo
+                // largo para no molestar, ventana amplia para que sea
+                // claramente perceptible cada vez.
                 negativeBreath: {
-                    '0%, 82%, 100%': { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
-                    '86%':           { filter: 'invert(0.7) hue-rotate(120deg) saturate(130%)' },
-                    '90%':           { filter: 'invert(1) hue-rotate(180deg) saturate(160%)' },
-                    '94%':           { filter: 'invert(0.7) hue-rotate(120deg) saturate(130%)' },
-                    '97%':           { filter: 'invert(0.25) hue-rotate(60deg)' },
+                    '0%, 91%, 100%': { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
+                    '93%':           { filter: 'invert(0.6) hue-rotate(120deg) saturate(130%)' },
+                    '95.5%':         { filter: 'invert(1) hue-rotate(180deg) saturate(170%)' },
+                    '98%':           { filter: 'invert(0.6) hue-rotate(120deg) saturate(130%)' },
+                    '99.5%':         { filter: 'invert(0.2) hue-rotate(45deg)' },
                 },
-                // Destello luminoso que recorre el perimetro del panel.
-                // Sincronizado con negativeBreath (ambos 8s). Usa pathLength=1
-                // en el SVG para normalizar el dash-offset a 0..-1 y que la
-                // animacion sea independiente de las dimensiones del rect.
+                // Destello luminoso que recorre el perimetro del panel,
+                // sincronizado con negativeBreath. pathLength=1 normaliza
+                // el dash-offset a 0..-1 → el destello recorre el
+                // perimetro exactamente una vez por ciclo.
                 borderMarch: {
                     '0%':   { strokeDashoffset: '0' },
                     '100%': { strokeDashoffset: '-1' },
@@ -121,13 +120,13 @@ export default {
                 'spark-burst': 'sparkBurst 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards',
                 'crt-blink':   'crtBlink 1.1s steps(1) infinite',
                 'crt-flicker': 'crtFlicker 4s ease-in-out infinite',
-                // "IA viva" — pulso periodico cada 8s durante el stream.
-                'negative-breath': 'negativeBreath 8s ease-in-out infinite',
-                // Transicion de cierre: flash previo al rayo (700ms).
-                'negative-flash':  'negativeFlash 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
+                // "IA viva" — latido de 30s mientras el panel este visible.
+                'negative-breath': 'negativeBreath 30s ease-in-out infinite',
+                // Transicion de cierre: flash previo al rayo (1s).
+                'negative-flash':  'negativeFlash 1000ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
                 // Destello que recorre el borde del panel, sincronizado con
-                // negative-breath: 8s linear infinite.
-                'border-march':    'borderMarch 8s linear infinite',
+                // negative-breath: 30s linear infinite.
+                'border-march':    'borderMarch 30s linear infinite',
             },
         },
     },


### PR DESCRIPTION
Tres mejoras visuales coordinadas en el home dashboard:

1. IoTSensorCard (nuevo componente): cards de sensores rediseñadas con estilo HUD industrial (distinto al panel cyberpunk de IA).
   - Borde left accent morpho (cyan 3px) + inset shadow.
   - Esquina superior-derecha recortada en diagonal (clip-path) emulando pantalla de control industrial.
   - Header con status dot parpadeante (online/offline) + titulo en tracking 0.2em uppercase + device ID en mono gris.
   - Readouts numericos en font mono tabular-nums (monoespaciado) dentro de sub-cajas slate-950/60 con borde.
   - Badge "IoT" con icono Activity en esquina superior-derecha. La estetica es deliberadamente fria/tecnica para contrastar con la IA (terminal CRT verde fosforo, cyberpunk orchid).

2. Sparkline con ejes legibles: antes solo mostraba la linea + valor final. Ahora incluye:
   - Guias horizontales tenues en min/mid/max (stroke-dasharray).
   - Labels Y en font mono: max arriba-izquierda, min abajo-izquierda.
   - Label X abajo-derecha con ventana temporal ("24h").
   - Valor actual con unidad (%, °) sobre el ultimo punto.
   - Tamano default aumentado a 160x48 para dar espacio al texto sin romper el layout anterior.

3. Latido "IA viva" (negativeBreath) reprogramado:
   - Ciclo 8s -> 30s: menos invasivo, mas de signo vital que de efecto constante. El usuario lo ve cada 30s cuando el panel esta visible (streaming o ya completado).
   - Ventana del flash ampliada de 4% a 9% del ciclo (~2.7s).
   - Rampa "S" con cinco keyframes (0.6 -> 1.0 -> 0.6 -> 0.2) para transicion suave y claramente perceptible.
   - negativeFlash del cierre extendido de 700ms a 1000ms.
   - borderMarch tambien a 30s, sincronizado con el breath.

Bump 0.6.2 -> 0.6.3. SW cache v17 -> v18.