### PR TITLE
fix(voice,map): refresh post-seeding + modo walk para polígonos (v0.6.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v19';
+const CACHE_NAME = 'chagra-v20';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/MapPicker.jsx
+++ b/src/components/MapPicker.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
-import { X, MapPin, LocateFixed, Check, Undo2 } from 'lucide-react';
+import { X, MapPin, LocateFixed, Check, Undo2, Footprints, Square } from 'lucide-react';
 import { latLngToPoint, latLngsToPolygon } from '../utils/geo';
 
 /**
@@ -39,8 +39,13 @@ export const MapPicker = ({
   const containerRef = useRef(null);
   const mapRef = useRef(null);
   const layerRef = useRef(null); // capa de la geometría dibujada
+  const watchIdRef = useRef(null); // id del watchPosition cuando traza caminando
   const [points, setPoints] = useState([]); // polígono en construcción
   const [marker, setMarker] = useState(null); // punto actual
+  // Modo "trazar caminando": usa navigator.geolocation.watchPosition para
+  // ir sumando vertices al polígono mientras el operario recorre el
+  // perimetro del area (ej. un invernadero). Solo disponible en mode=polygon.
+  const [isWalking, setIsWalking] = useState(false);
 
   // Inicializar Leaflet una sola vez al montar
   useEffect(() => {
@@ -107,9 +112,62 @@ export const MapPicker = ({
       map.remove();
       mapRef.current = null;
       layerRef.current = null;
+      // Cleanup del watchPosition si quedo activo al desmontar
+      if (watchIdRef.current !== null && navigator.geolocation) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Toggle del modo "trazar caminando": al activar, arranca un watchPosition
+  // con alta precision que va anadiendo vertices al polygon a medida que el
+  // GPS reporta nuevas coordenadas (tipicamente cada 1-3s segun el dispositivo).
+  // Desactivar detiene la captura — el polygon queda con los vertices
+  // acumulados y el usuario puede editarlo con Undo / Cerrar polígono.
+  const toggleWalkRecording = () => {
+    if (mode !== 'polygon') return;
+    if (isWalking) {
+      if (watchIdRef.current !== null && navigator.geolocation) {
+        navigator.geolocation.clearWatch(watchIdRef.current);
+        watchIdRef.current = null;
+      }
+      setIsWalking(false);
+      return;
+    }
+    if (!navigator.geolocation) {
+      console.warn('[MapPicker] Geolocalización no disponible para modo walk');
+      return;
+    }
+    // Limpia cualquier vertice previo y arranca la captura
+    setPoints([]);
+    const map = mapRef.current;
+    if (layerRef.current) {
+      map.removeLayer(layerRef.current);
+      layerRef.current = null;
+    }
+    setIsWalking(true);
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      (pos) => {
+        const latlng = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+        setPoints((prev) => {
+          const next = [...prev, latlng];
+          if (layerRef.current) map.removeLayer(layerRef.current);
+          if (next.length >= 2) {
+            layerRef.current = L.polyline(next, { color: '#10b981', weight: 4, opacity: 0.85 }).addTo(map);
+          }
+          map.panTo([latlng.lat, latlng.lng]);
+          return next;
+        });
+      },
+      (err) => {
+        console.error('[MapPicker] Error watchPosition:', err.message);
+        setIsWalking(false);
+      },
+      { enableHighAccuracy: true, maximumAge: 2000, timeout: 15000 },
+    );
+  };
 
   const handleFinishPolygon = () => {
     if (points.length < 3) return;
@@ -178,10 +236,16 @@ export const MapPicker = ({
             {mode === 'point' ? 'Marcar ubicación' : 'Definir área'}
           </h3>
           {mode === 'polygon' && (
-            <span className="text-xs text-slate-400 ml-2">
+            <span className="text-xs text-slate-400 ml-2 flex items-center gap-1.5">
               {points.length < 3
                 ? `${points.length}/3 vértices mínimos`
                 : `${points.length} vértices`}
+              {isWalking && (
+                <span className="text-emerald-400 font-bold flex items-center gap-1">
+                  <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 motion-safe:animate-pulse" />
+                  REC
+                </span>
+              )}
             </span>
           )}
         </div>
@@ -205,12 +269,29 @@ export const MapPicker = ({
           >
             <LocateFixed size={16} /> Mi ubicación
           </button>
+          {mode === 'polygon' && (
+            <button
+              type="button"
+              onClick={toggleWalkRecording}
+              className={`px-3 py-2 rounded-lg text-sm font-bold flex items-center gap-2 transition-colors ${
+                isWalking
+                  ? 'bg-emerald-700 hover:bg-emerald-600 text-white shadow-[0_0_15px_rgba(16,185,129,0.4)] motion-safe:animate-pulse'
+                  : 'bg-slate-800 hover:bg-slate-700 text-slate-200'
+              }`}
+              aria-pressed={isWalking}
+              aria-label={isWalking ? 'Detener trazado caminando' : 'Trazar caminando'}
+            >
+              {isWalking ? <Square size={16} /> : <Footprints size={16} />}
+              {isWalking ? 'Detener' : 'Caminar'}
+            </button>
+          )}
           {mode === 'polygon' && points.length > 0 && (
             <>
               <button
                 type="button"
                 onClick={handleUndo}
-                className="px-3 py-2 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-lg text-sm font-bold flex items-center gap-2"
+                disabled={isWalking}
+                className="px-3 py-2 bg-slate-800 hover:bg-slate-700 disabled:opacity-40 text-slate-200 rounded-lg text-sm font-bold flex items-center gap-2"
               >
                 <Undo2 size={16} /> Deshacer
               </button>
@@ -218,7 +299,8 @@ export const MapPicker = ({
                 <button
                   type="button"
                   onClick={handleFinishPolygon}
-                  className="px-3 py-2 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-lg text-sm font-bold"
+                  disabled={isWalking}
+                  className="px-3 py-2 bg-slate-800 hover:bg-slate-700 disabled:opacity-40 text-slate-200 rounded-lg text-sm font-bold"
                 >
                   Cerrar polígono
                 </button>

--- a/src/services/payloadService.js
+++ b/src/services/payloadService.js
@@ -72,6 +72,14 @@ export const savePayload = async (type, payload) => {
       const result = await sendToFarmOS(endpoint, payload);
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('farmosLog', { detail: payload.data.attributes.name }));
+        // Bug fix v0.6.5: el path online-directo tambien debe emitir
+        // syncCompleted para que useAssetStore refresque los assets
+        // relacionados (ej. la planta inline creada durante un seeding).
+        // Sin esto, voz crea la planta en FarmOS pero el store local
+        // no se entera hasta un refresh manual.
+        window.dispatchEvent(new CustomEvent('syncCompleted', {
+          detail: { type, id: result?.data?.id },
+        }));
       }
       return { success: true, message: 'Guardado y sincronizado con servidor', data: result };
     } catch (error) {

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -491,19 +491,44 @@ const useAssetStore = create((set, get) => ({
 // Listener global: al recibir confirmación de sincronización exitosa,
 // liberar el flag _pending del asset y disparar un pull dirigido que lo
 // sobrescriba con el objeto oficial del servidor (Hotfix 10.3 — Opción C).
+//
+// Bug fix v0.6.5: logs que crean assets inline (seeding con asset--plant
+// anidado, planting, input con materiales inline) también deben disparar
+// pull de los assets relacionados. Sin esto, la planta creada por voz
+// existe en FarmOS pero no aparece en el store hasta un refresh manual.
 if (typeof window !== 'undefined') {
+  // Tipos de log que pueden crear assets inline como side-effect. Al
+  // completar la sync exitosa, refrescamos el store del tipo de asset
+  // asociado para que aparezca en Activos/Home sin refresh manual.
+  const LOG_TO_ASSET_TYPE = {
+    seeding: 'plant',
+    planting: 'plant',
+    harvest: 'plant',
+    input: 'plant',
+  };
+
   window.addEventListener('syncCompleted', async (event) => {
     const { type, id } = event.detail || {};
-    if (!type || (!type.startsWith('asset_') && !type.startsWith('delete_'))) return;
+    if (!type) return;
+
+    const isAssetOp = type.startsWith('asset_') || type.startsWith('delete_');
+    const logAssetType = LOG_TO_ASSET_TYPE[type];
+    if (!isAssetOp && !logAssetType) return;
 
     try {
-      const assetType = type.split('_')[1]; // 'asset_plant' → 'plant', 'delete_plant' → 'plant'
+      // 'asset_plant'/'delete_plant' → 'plant'. Para logs, mapa directo.
+      const assetType = isAssetOp ? type.split('_')[1] : logAssetType;
 
       // 1. Liberación del flag _pending del asset local confirmado
-      const localAsset = await assetCache.getAsset(id);
-      if (localAsset) {
-        await assetCache.put(localAsset.asset_type || assetType, { ...localAsset, _pending: false });
-        console.log(`[Sync] Activo ${id} liberado para actualización oficial.`);
+      // (solo aplica a asset_ / delete_ — logs no tienen asset local).
+      if (isAssetOp) {
+        const localAsset = await assetCache.getAsset(id);
+        if (localAsset) {
+          await assetCache.put(localAsset.asset_type || assetType, { ...localAsset, _pending: false });
+          console.log(`[Sync] Activo ${id} liberado para actualización oficial.`);
+        }
+      } else {
+        console.log(`[Sync] Log ${type}/${id} sincronizado — pull ${assetType} para captar inlines.`);
       }
 
       // 2. Pull dirigido al tipo afectado (no refresca los 4 tipos)


### PR DESCRIPTION
Dos bugs arreglados:

**Bug A — Plantas creadas por voz no aparecen en Activos hasta refresh**

Flujo previo:
1. VoiceCapture.buildSeedingPayload construye log--seeding con asset--plant inline (sin id) en relationships.asset.data.
2. payloadService.savePayload resuelve el inline: POST /api/asset/plant → recibe UUID, reemplaza la ref, POST /api/log/seeding.
3. FarmOS persiste ambos correctamente.
4. El store local NO se entera — ni dispara syncCompleted en el path online-directo, ni el listener del store reacciona a type='seeding'.
5. Resultado: la planta existe en FarmOS pero la UI de Activos no la muestra hasta refrescar manualmente.

Fix en dos capas:
- payloadService.js: emitir CustomEvent 'syncCompleted' tras éxito del path online-directo con { type, id: result.data.id }, igualando el comportamiento del path offline (syncManager ya lo emite).
- useAssetStore.js: extender el listener de syncCompleted con un mapa LOG_TO_ASSET_TYPE que traduce logs que crean assets inline (seeding/planting/harvest/input → 'plant') y dispara pull dirigido del tipo de asset correspondiente. Los logs NO tocan _pending flags (no hay asset local para liberar), solo refrescan el store.

Tras este fix, voz crea la planta y aparece inmediatamente en Activos sin necesidad de refresh.

**Bug B — Modo "trazar caminando" perdido en MapPicker**

En versiones previas existia una variante que permitia trazar el perimetro de un poligono caminando (watchPosition acumulando vertices en tiempo real). Aun existe latente en SeedingLog.jsx pero nunca se expuso en MapPicker.

Fix: agregado modo walk a MapPicker (solo cuando mode='polygon'):
- Botón "Caminar" con icono Footprints — al activarlo arranca navigator.geolocation.watchPosition con enableHighAccuracy y va acumulando vertices en tiempo real, panTo automatico al ultimo punto.
- Indicador visual: el botón cambia a "Detener" (icono Square) con halo emerald pulsante; header muestra "REC" junto al contador de vertices mientras graba.
- Undo / Cerrar polígono quedan deshabilitados mientras se graba.
- clearWatch automatico al desmontar el componente o detener.
- La polyline en vivo se dibuja emerald-500 para diferenciar del trazo manual (blue-500).

Bump 0.6.4 -> 0.6.5. SW cache v19 -> v20.