### PR TITLE
fix(voice): planta inline necesita location/parent — POST 422 bloquea…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.6.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v20';
+const CACHE_NAME = 'chagra-v21';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -195,7 +195,34 @@ export default function VoiceCapture({ onSave }) {
   // - quantity--standard inline (medida count, etiqueta "Plantulas").
   // - location apuntando a structure o land segun resolvio el usuario.
   // - plant_type relationship si la especie cruzo con FarmOS taxonomy.
+  //
+  // Bug fix v0.6.6: la planta inline necesita SUS PROPIAS relationships
+  // location y parent (apuntando a la zona/structure resuelta), no solo el
+  // log. Sin esto FarmOS rechaza el POST inline con 422 Unprocessable
+  // Content y la voz queda registrada como exitosa pero sin persistir nada.
+  // location/parent solo se setean si entity.location es asset--land
+  // (parent es exclusivo de jerarquia land); si es asset--structure, solo
+  // location se permite.
   const buildSeedingPayload = useCallback((entity) => {
+    const locRef = { type: entity.location.type, id: entity.location.id };
+    const isLand = entity.location.type === 'asset--land';
+
+    // Relationships obligatorios de la planta inline:
+    //   - location: zona o structure donde se siembra (siempre).
+    //   - parent:   solo si la location es un land (jerarquia agronomica).
+    //   - plant_type: si el extractor cruzo con la taxonomy de FarmOS.
+    const inlineRels = {
+      location: { data: [locRef] },
+      ...(isLand ? { parent: { data: [locRef] } } : {}),
+      ...(entity.farmosTermId
+        ? {
+            plant_type: {
+              data: [{ type: 'taxonomy_term--plant_type', id: entity.farmosTermId }],
+            },
+          }
+        : {}),
+    };
+
     const inlinePlant = {
       type: 'asset--plant',
       attributes: {
@@ -206,13 +233,7 @@ export default function VoiceCapture({ onSave }) {
           format: 'plain_text',
         },
       },
-      ...(entity.farmosTermId ? {
-        relationships: {
-          plant_type: {
-            data: [{ type: 'taxonomy_term--plant_type', id: entity.farmosTermId }],
-          },
-        },
-      } : {}),
+      relationships: inlineRels,
     };
 
     return {
@@ -229,9 +250,7 @@ export default function VoiceCapture({ onSave }) {
         },
         relationships: {
           asset: { data: [inlinePlant] },
-          location: {
-            data: [{ type: entity.location.type, id: entity.location.id }],
-          },
+          location: { data: [locRef] },
           quantity: {
             data: [{
               type: 'quantity--standard',


### PR DESCRIPTION
…ba (v0.6.6)

Console del usuario:
  POST /api/asset/plant 422 (Unprocessable Content)
  POST /api/asset/plant 422 (Unprocessable Content)
  → la voz mostraba "exitoso" pero las plantas nunca se creaban.

Causa: VoiceCapture.buildSeedingPayload construia el asset--plant inline SOLO con attributes (name, status, notes) y opcionalmente plant_type, sin ningun relationship location/parent. FarmOS rechaza con 422 porque asset--plant requiere location obligatoria. El log--seeding si llevaba location, pero esa es del log, no del asset.

El path online de payloadService.savePayload procesa el inline primero (POST /api/asset/plant) y captura el 422 — pero el catch envia toda la transaccion al fallback offline syncManager. Eso devuelve success=false, PERO VoiceCapture trataba "Guardado local" como savedCount++ porque la condicion era `result.success || result.message.includes('local')` — el fallback decia "Guardado local. Pendiente..." → contaba como exito, toast verde, transcripcion limpia, planta perdida. (Es un bug aparte que deberia revisarse, pero fix de raiz aqui resuelve el sintoma).

Fix: anadir relationships obligatorios a la planta inline:
  - location: la zona/structure resuelta por entity.location (siempre).
  - parent:   misma referencia, solo si la location es asset--land
              (jerarquia agronomica de FarmOS).
  - plant_type: igual que antes, opcional cuando hay term match.

Con esto el POST inline pasa, FarmOS persiste la planta con su zona, luego el POST log--seeding referencia el UUID resuelto, y el listener del store (v0.6.5) hace pull dirigido de plants → aparece en Activos.

Bump 0.6.5 -> 0.6.6. SW cache v20 -> v21.