### PR TITLE
feat(voice): Compañeros Sugeridos (motor de gremios) en confirmacion …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.7",
+  "version": "0.6.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v22';
+const CACHE_NAME = 'chagra-v24';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -4,6 +4,7 @@ import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { bestFuzzyMatch, similarity } from '../utils/entityMatcher';
+import GuildSuggestions from './GuildSuggestions';
 
 /**
  * VoiceConfirmation — pantalla obligatoria de revisión humana del array de
@@ -124,6 +125,33 @@ export default function VoiceConfirmation({
 
   const updateRow = (i, patch) => setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
   const removeRow = (i) => setRows((prev) => prev.filter((_, idx) => idx !== i));
+
+  // Agrega una nueva fila a partir de un "compañero sugerido" (capas de
+  // GuildSuggestions). Resuelve la especie contra CROP_TAXONOMY para
+  // obtener canonical/slug/termId y hereda la ubicacion de la fila origen
+  // para que el operario no tenga que volver a seleccionarla.
+  const addCompanionRow = (companionName, sourceIdx) => {
+    const source = rows[sourceIdx] || {};
+    const resolved = resolveCrop(companionName);
+    setRows((prev) => [
+      ...prev,
+      {
+        crop: resolved.crop || companionName,
+        cropOriginal: companionName,
+        cropCanonical: resolved.canonical,
+        cropSlug: resolved.cropSlug,
+        farmosTermId: resolved.farmosTermId,
+        cropScore: resolved.score,
+        cropGroup: resolved.group,
+        quantity: 1,
+        rawLocation: source.rawLocation || '',
+        locationId: source.locationId || '',
+        locationType: source.locationType || 'asset--land',
+        locationMatchedName: source.locationMatchedName || null,
+        locationScore: source.locationScore || null,
+      },
+    ]);
+  };
 
   const allValid = rows.length > 0 && rows.every(
     (r) => r.crop.trim().length > 0 && Number.isInteger(Number(r.quantity)) && Number(r.quantity) > 0 && r.locationId
@@ -250,6 +278,20 @@ export default function VoiceConfirmation({
               ))}
             </select>
           </label>
+
+          {/* Compañeros sugeridos (motor de gremios). Solo aparece cuando
+              la especie matcheo contra CROP_TAXONOMY (cropSlug presente),
+              igual que en el flujo manual de AssetsDashboard. Al clicar un
+              compañero se agrega una nueva entrada al array de rows con
+              la misma ubicacion heredada — siembra rapida de policultivo. */}
+          {row.cropSlug && (
+            <div className="mt-2 pt-3 border-t border-slate-800">
+              <GuildSuggestions
+                speciesId={row.cropSlug}
+                onSelectCompanion={(name) => addCompanionRow(name, i)}
+              />
+            </div>
+          )}
         </div>
       ))}
 


### PR DESCRIPTION
…de voz

Agrega al flujo de voz el mismo widget GuildSuggestions que aparece en la inserción manual (AssetsDashboard). Cuando la especie extraida por el LLM matchea contra CROP_TAXONOMY (cropSlug presente en la row), se renderiza bajo la fila:
  - Compañeros directos (capa 1: speciesDefaults.companions)
  - Complementos estructurales (capa 2: estrato + gremio)
  - Incompatibles con warning
  - Boton "Consultar Gremio IA" que invoca qwen3.5:4b para sugerencias contextuales con streaming (ya resuelto en Fase 18).

Nuevo addCompanionRow(name, sourceIdx):
  - Resuelve el nombre del compañero contra CROP_TAXONOMY via resolveCrop (misma logica que la row inicial).
  - Hereda la ubicacion de la fila origen → siembra rapida de policultivo sin volver a seleccionar la zona.
  - Quantity default 1 (ajustable manual).
  - Se agrega al array de rows, pasa por validacion allValid y se incluye en el payload final onConfirm.

Version: bump 0.6.6 -> 0.6.9 (rama salio de origin/main donde 0.6.7/0.6.8 aun no estan mergeados; al mergear este PR con el stack del 422 fix, los bumps se resuelven en orden). SW cache v21 -> v24.