### PR TITLE
fix(ui): home header compacto + sparklines 2-col en desktop + Inverna…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.10",
+  "version": "0.6.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v25';
+const CACHE_NAME = 'chagra-v27';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -106,19 +106,24 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
 
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-white flex flex-col overflow-hidden">
-      <header className="p-4 border-b border-slate-800 shrink-0 flex justify-between items-center bg-slate-900/50 backdrop-blur-md sticky top-0 z-50 pt-[env(safe-area-inset-top)]">
-        <div className="flex flex-col gap-1">
-          <h1 className="font-bold text-2xl flex items-center gap-2">
-            <span className="w-2 h-2 bg-muzo rounded-full shadow-neon-muzo"></span>
-            Chagra
-          </h1>
-          <span className="text-xs text-slate-500 font-mono">v{APP_VERSION}</span>
-        </div>
+      {/* Header compacto (v0.6.12): padding vertical reducido + titulo/version
+          inline en una sola linea para ganar viewport en el home. El boton
+          Salir mantiene 44px minimo (WCAG AA 2.5.5). El top usa max() para
+          respetar safe-area-inset-top en iOS con notch. */}
+      <header
+        className="px-4 py-2 border-b border-slate-800 shrink-0 flex justify-between items-center bg-slate-900/50 backdrop-blur-md sticky top-0 z-50"
+        style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top))' }}
+      >
+        <h1 className="font-bold text-xl flex items-baseline gap-2">
+          <span className="w-2 h-2 bg-muzo rounded-full shadow-neon-muzo self-center" aria-hidden="true"></span>
+          Chagra
+          <span className="text-[10px] text-slate-500 font-mono font-normal">v{APP_VERSION}</span>
+        </h1>
         <div className="flex items-center gap-2">
-          <button onClick={onLogout} aria-label="Cerrar sesión" className="text-slate-400 hover:text-white px-4 py-3 min-h-[44px] bg-slate-800 rounded">Salir</button>
+          <button onClick={onLogout} aria-label="Cerrar sesión" className="text-slate-400 hover:text-white px-4 min-h-[44px] bg-slate-800 rounded text-sm">Salir</button>
         </div>
       </header>
-      <main className="flex-1 p-4 flex flex-col overflow-y-auto gap-4 bg-biopunk-pattern">
+      <main className="flex-1 px-4 pt-3 pb-4 flex flex-col overflow-y-auto gap-3 bg-biopunk-pattern">
         <TelemetryAlerts lastFarmOsLog={lastLogMessage} />
 
         {/* Contadores de inventario consolidados: un solo container con

--- a/src/components/IoTSensorCard.jsx
+++ b/src/components/IoTSensorCard.jsx
@@ -126,13 +126,13 @@ export default function IoTSensorCard({
           </div>
         </div>
 
-        {/* Sparklines de 24h con ejes legibles. Cada grafica en su propio
-            contenedor con label del parametro en mono para que queden a
-            ancho completo y el texto no compita con el trazo. Los labels
-            internos del SVG (min/max/mid/temporal) usan currentColor →
-            heredan slate-300 del wrapper para buen contraste. */}
-        <div className="space-y-2">
-          <div className="text-slate-300">
+        {/* Sparklines de 24h: en mobile apilados (grid-cols-1), en desktop
+            md+ lado a lado (grid-cols-2) para aprovechar el ancho disponible
+            y reducir la altura total de la tarjeta. Sparkline es ahora
+            fluido (width="100%" capado por viewBox) y escala con el
+            contenedor preservando aspect ratio. */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-2">
+          <div className="text-slate-300 min-w-0">
             <div className="flex items-baseline gap-2 mb-0.5">
               <span className="text-[10px] text-morpho/80 font-mono tracking-widest uppercase">Humedad</span>
               <span className="text-[9px] text-slate-500 font-mono">últimas 24h</span>
@@ -144,9 +144,10 @@ export default function IoTSensorCard({
               unit="%"
               width={320}
               height={72}
+              responsive
             />
           </div>
-          <div className="text-slate-300">
+          <div className="text-slate-300 min-w-0">
             <div className="flex items-baseline gap-2 mb-0.5">
               <span className="text-[10px] text-morpho/80 font-mono tracking-widest uppercase">Temperatura</span>
               <span className="text-[9px] text-slate-500 font-mono">últimas 24h</span>
@@ -158,6 +159,7 @@ export default function IoTSensorCard({
               unit="°"
               width={320}
               height={72}
+              responsive
             />
           </div>
         </div>

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -264,8 +264,8 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
       ]);
 
       if (!invernaderoHum.ok || !invernaderoTemp.ok || !tabacoHum.ok || !tabacoTemp.ok) {
-        const failedSensor = !invernaderoHum.ok ? 'Zona A Humedad' :
-                          !invernaderoTemp.ok ? 'Zona A Temperatura' :
+        const failedSensor = !invernaderoHum.ok ? 'Invernadero Zona A Humedad' :
+                          !invernaderoTemp.ok ? 'Invernadero Zona A Temperatura' :
                           !tabacoHum.ok ? 'Matera Tabaco Humedad' :
                           'Matera Tabaco Temperatura';
         throw new Error(`Fallo al conectar con sensor: ${failedSensor}. Verifique Home Assistant.`);
@@ -280,8 +280,8 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
 
       // Detección de sensores no disponibles (unavailable, null, unknown)
       const sensorReadings = [
-        { name: 'Zona A Humedad', data: invernaderoHumData, key: 'Matera Cocina' },
-        { name: 'Zona A Temperatura', data: invernaderoTempData, key: 'Matera Cocina' },
+        { name: 'Invernadero Zona A Humedad', data: invernaderoHumData, key: 'Invernadero Zona A' },
+        { name: 'Invernadero Zona A Temperatura', data: invernaderoTempData, key: 'Invernadero Zona A' },
         { name: 'Matera Tabaco Humedad', data: tabacoHumData, key: 'Matera Tabaco' },
         { name: 'Matera Tabaco Temperatura', data: tabacoTempData, key: 'Matera Tabaco' },
       ];
@@ -399,11 +399,11 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
 
       const alerts = [];
 
-      // Invernadero - Zona A (ex Invernadero 1; sensor renombrado a matera_cocina)
-      if (inv1Hum < 40) alerts.push(`🚨 ALERTA: Humedad crítica en Zona A (${inv1Hum}%). Riego inmediato requerido.`);
-      if (inv1Hum > 80) alerts.push(`💧 Exceso de humedad en Zona A (${inv1Hum}%). Riesgo de hongos patógenos. Ventilar.`);
-      if (inv1Temp > 30) alerts.push(`🔥 Temperatura elevada en Zona A (${inv1Temp}°C). Activar ventilación.`);
-      if (inv1Temp < 5) alerts.push(`❄️ Temperatura baja en Zona A (${inv1Temp}°C). Riesgo de helada. Proteger cultivos.`);
+      // Invernadero Zona A (formato abierto a Zona B, Zona C… en el futuro).
+      if (inv1Hum < 40) alerts.push(`🚨 ALERTA: Humedad crítica en Invernadero Zona A (${inv1Hum}%). Riego inmediato requerido.`);
+      if (inv1Hum > 80) alerts.push(`💧 Exceso de humedad en Invernadero Zona A (${inv1Hum}%). Riesgo de hongos patógenos. Ventilar.`);
+      if (inv1Temp > 30) alerts.push(`🔥 Temperatura elevada en Invernadero Zona A (${inv1Temp}°C). Activar ventilación.`);
+      if (inv1Temp < 5) alerts.push(`❄️ Temperatura baja en Invernadero Zona A (${inv1Temp}°C). Riesgo de helada. Proteger cultivos.`);
 
       // Matera Tabaco (ubicada en cocina)
       if (tabHum < 40) alerts.push(`🚨 ALERTA: Humedad crítica en Matera Tabaco (${tabHum}%). Riego inmediato requerido.`);
@@ -414,7 +414,7 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
       // Baseline si todo está en rango
       const ruleAnalysis = alerts.length > 0
         ? alerts.join('\n')
-        : `✅ Condiciones estables. Zona A: ${inv1Hum}%H/${inv1Temp}°C. Matera Tabaco: ${tabHum}%H/${tabTemp}°C.`;
+        : `✅ Condiciones estables. Invernadero Zona A: ${inv1Hum}%H/${inv1Temp}°C. Matera Tabaco: ${tabHum}%H/${tabTemp}°C.`;
 
       // Mostrar reglas INMEDIATAMENTE — sin esperar IA. Prepeende aviso de
       // sensores offline (si hay alguno) para que quede visible incluso si la
@@ -540,9 +540,9 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
   }, []);
 
   return (
-    <div className="p-6 rounded-3xl bg-slate-900 border border-morpho/30 shadow-neon-morpho mb-8">
-      <h3 className="text-2xl font-black mb-4 flex items-center gap-2">
-        <span className="w-3 h-3 bg-muzo rounded-full motion-safe:animate-pulse"></span>
+    <div className="px-5 py-4 rounded-3xl bg-slate-900 border border-morpho/30 shadow-neon-morpho mb-6">
+      <h3 className="text-lg font-black mb-3 flex items-center gap-2">
+        <span className="w-2.5 h-2.5 bg-muzo rounded-full motion-safe:animate-pulse"></span>
         Observabilidad Agronómica
       </h3>
 

--- a/src/components/common/Sparkline.jsx
+++ b/src/components/common/Sparkline.jsx
@@ -25,6 +25,7 @@ export default function Sparkline({
   unit = '',
   showLastValue = true,
   lastValueDecimals = 1,
+  responsive = false,
 }) {
   let series;
   if (Array.isArray(values)) {
@@ -36,7 +37,10 @@ export default function Sparkline({
   }
 
   if (series.length < 2) {
-    return <div style={{ width, height }} className="bg-slate-700/30 rounded animate-pulse" />;
+    const placeholderStyle = responsive
+      ? { width: '100%', maxWidth: width, height }
+      : { width, height };
+    return <div style={placeholderStyle} className="bg-slate-700/30 rounded animate-pulse" />;
   }
 
   const min = Math.min(...series);
@@ -87,12 +91,19 @@ export default function Sparkline({
   const chipX = width - padR - chipW;
   const chipY = padT - 2;
 
+  // Modo responsive (v0.6.12): ancho fluido capado por el viewBox; el SVG
+  // escala con el contenedor preservando aspect-ratio. Esto permite colocar
+  // dos sparklines lado a lado en desktop sin overflow en mobile.
+  const svgWidthAttr = responsive ? '100%' : width;
+  const svgStyle = responsive ? { maxWidth: width, display: 'block' } : undefined;
+
   return (
     <svg
-      width={width}
+      width={svgWidthAttr}
       height={height}
       className="inline-block"
       viewBox={`0 0 ${width} ${height}`}
+      style={svgStyle}
     >
       <defs>
         <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
…dero Zona A (v0.6.12)

- App.jsx: header del home reducido a py-2 con titulo/version inline para revelar el panel de Observabilidad desde el tope sin scroll (mobile y web).
- TelemetryAlerts.jsx: padding px-5/py-4 y h3 text-lg para recuperar viewport en el card principal. Reglas y offline labels renombrados a "Invernadero Zona A" (formato que admite Zona B, Zona C… a futuro).
- IoTSensorCard.jsx: sparklines por sensor pasan de apilados (space-y-2) a grid md:grid-cols-2 para aprovechar el ancho en desktop y reducir la altura total de la tarjeta.
- Sparkline.jsx: prop `responsive` → SVG con width="100%" y style maxWidth del viewBox; escala con el contenedor preservando aspect ratio.

CACHE_NAME: chagra-v25 → chagra-v27.