### PR TITLE
fix(ui): ChagraGrowLoader invisible por timing de keyframes — v0.6.15

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,10 +78,16 @@ jobs:
         continue-on-error: true
 
       - name: Bump SW cache version
+        # Patrón ERE sin literal 'v' — el cache en prod alterna entre
+        # 'chagra-v<N>' (el que viene del repo) y 'chagra-<sha>' (el que
+        # este paso deja tras cada deploy). Un patrón que requiera 'v'
+        # solo matchearía el primer caso, y a partir del segundo deploy
+        # el cache quedaría pegado al sha del deploy inicial. Con [0-9a-z]+
+        # matchea ambas formas y el bump funciona en cada deploy.
         run: |
           SW_FILE=/mnt/fast/appdata/farmos-pwa/sw.js
           if [ -f "$SW_FILE" ]; then
             COMMIT_SHORT=$(git rev-parse --short HEAD)
-            sed -i "s/chagra-v[0-9a-z]*/chagra-${COMMIT_SHORT}/" "$SW_FILE"
+            sed -i -E "s/chagra-[0-9a-z]+/chagra-${COMMIT_SHORT}/" "$SW_FILE"
             echo "SW cache bumped to chagra-${COMMIT_SHORT}"
           fi

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.6.14",
+  "version": "0.6.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v28';
+const CACHE_NAME = 'chagra-v29';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/ChagraGrowLoader.jsx
+++ b/src/components/ChagraGrowLoader.jsx
@@ -302,6 +302,14 @@ const KEYFRAMES_CSS = `
   98%, 100% { opacity: 0; }
 }
 
+/* Defensivo: que transform-origin en px se interprete contra el viewBox del
+   SVG (80x80) y no contra el bbox del elemento. Es el default en browsers
+   modernos, pero lo declaramos explícito para evitar divergencias. */
+.cgl-svg,
+.cgl-svg * {
+  transform-box: view-box;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cgl-svg * {
     animation-duration: 0.001s !important;
@@ -326,6 +334,13 @@ function ensureStylesInjected() {
   style.textContent = KEYFRAMES_CSS;
   document.head.appendChild(style);
 }
+
+// Inyección en module-load (no en useEffect). Si esperamos al useEffect,
+// el primer pintado ocurre con los @keyframes ausentes: Chrome/Firefox/Safari
+// no reaplican la animación cuando los keyframes llegan después y el SVG
+// queda congelado en el frame 0 (opacity:0, scale:0 → invisible). El guard
+// typeof document mantiene SSR-safety.
+ensureStylesInjected();
 
 // ============================================================================
 // HELPER


### PR DESCRIPTION
Dos fixes: el loader no pintaba en prod (bug) y el sed del deploy quedaba pegado tras el primer push (bug latente).

1) ChagraGrowLoader.jsx:
   - Inyección del <style> con los @keyframes movida a module-load (fuera del useEffect). El timing anterior inyectaba los keyframes tras el primer render; Chrome/Firefox/Safari no reaplican la animación cuando los keyframes llegan después, así que el SVG quedaba congelado en el frame 0 (opacity:0, scale:0 → invisible). El useEffect se mantiene como fallback defensivo idempotente.
   - Agrega 'transform-box: view-box' en .cgl-svg y descendientes. Es el default en navegadores modernos pero lo declaramos explícito para blindarlo contra divergencias históricas de Safari/Firefox en SVG.

2) .github/workflows/deploy.yml:
   - sed del "Bump SW cache version" pasa a ERE sin requerir literal 'v'. El patrón 'chagra-v[0-9a-z]*' anterior solo matcheaba el primer deploy (cuando el archivo viene del repo con 'chagra-vN'); tras ese deploy quedaba 'chagra-<sha>' sin 'v' y deploys subsecuentes no actualizaban más el cache — los clientes viejos seguían sirviendo assets stale indefinidamente.

Bump: 0.6.14 → 0.6.15. sw.js CACHE_NAME v28 → v29.