### PR TITLE
feat(r5): botón "Consultar IA externa" con prompt contextualizado

### DIFF
--- a/src/components/GuildSuggestions.jsx
+++ b/src/components/GuildSuggestions.jsx
@@ -4,6 +4,8 @@ import { getSuggestedCompanions, buildGuildPrompt } from '../services/guildServi
 import { SPECIES_DEFAULTS } from '../config/speciesDefaults';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { registry } from '../core/moduleRegistry';
+import ExternalAiButton from './common/ExternalAiButton';
+import { buildGuildExternalPrompt } from '../services/externalAiPromptBuilder';
 
 /**
  * GuildSuggestions — Panel de compañeros sugeridos y antagonistas (Fase 18).
@@ -154,15 +156,29 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
 
       {/* Capa 3 — Consulta IA en vivo (siempre disponible, OSS) */}
       <div>
-        <button
-          type="button"
-          onClick={handleAiQuery}
-          disabled={aiLoading || !navigator.onLine}
-          className="text-xs px-3 py-2 rounded-lg bg-purple-900/30 text-purple-400 border border-purple-800 hover:bg-purple-800/40 disabled:opacity-50 flex items-center gap-1.5 transition-colors"
-        >
-          {aiLoading ? <Loader2 size={12} className="animate-spin" /> : <Sparkles size={12} />}
-          {aiLoading ? 'Consultando Gemma 4…' : 'Consultar Gremio IA'}
-        </button>
+        <div className="flex items-center gap-2 flex-wrap">
+          <button
+            type="button"
+            onClick={handleAiQuery}
+            disabled={aiLoading || !navigator.onLine}
+            className="text-xs px-3 py-2 rounded-lg bg-purple-900/30 text-purple-400 border border-purple-800 hover:bg-purple-800/40 disabled:opacity-50 flex items-center gap-1.5 transition-colors"
+          >
+            {aiLoading ? <Loader2 size={12} className="animate-spin" /> : <Sparkles size={12} />}
+            {aiLoading ? 'Consultando Gemma 4…' : 'Consultar Gremio IA'}
+          </button>
+
+          <ExternalAiButton
+            buildPrompt={buildGuildExternalPrompt}
+            context={{
+              speciesName,
+              estrato: defaults.estrato,
+              companions: companions.map((c) => c.name),
+              antagonists: antagonists.map((a) => a.name),
+              thermalZones: defaults.thermalZones || [],
+              altitudMsnm: defaults.altitud_msnm?.optimo_min,
+            }}
+          />
+        </div>
 
         {aiError && (
           <p className="text-[10px] text-red-400 mt-1">{aiError}</p>

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -6,6 +6,8 @@ import AIStreamPanel from './common/AIStreamPanel';
 import IoTSensorCard from './IoTSensorCard';
 import ChagraGrowLoader from './ChagraGrowLoader';
 import { streamOllama } from '../services/ollamaStream';
+import ExternalAiButton from './common/ExternalAiButton';
+import { buildDiagnosticExternalPrompt } from '../services/externalAiPromptBuilder';
 
 // Constantes de Infraestructura Segura (API Gateway Local)
 const HA_URL = '/api/ha';
@@ -33,7 +35,7 @@ const getTemperatureColor = (temperature) => {
   return 'text-red-500'; // Calor crítico
 };
 
-export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
+export default function TelemetryAlerts() {
   const [sensors, setSensors] = useState({
     invernaderoHumidity: null,
     invernaderoTemperature: null,
@@ -266,9 +268,9 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
 
       if (!invernaderoHum.ok || !invernaderoTemp.ok || !tabacoHum.ok || !tabacoTemp.ok) {
         const failedSensor = !invernaderoHum.ok ? 'Invernadero Zona A Humedad' :
-                          !invernaderoTemp.ok ? 'Invernadero Zona A Temperatura' :
-                          !tabacoHum.ok ? 'Matera Tabaco Humedad' :
-                          'Matera Tabaco Temperatura';
+          !invernaderoTemp.ok ? 'Invernadero Zona A Temperatura' :
+            !tabacoHum.ok ? 'Matera Tabaco Humedad' :
+              'Matera Tabaco Temperatura';
         throw new Error(`Fallo al conectar con sensor: ${failedSensor}. Verifique Home Assistant.`);
       }
 
@@ -434,8 +436,8 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
         const userPrompt = (() => {
           const fmt = (h, t) => isNaN(h) && isNaN(t) ? 'sin datos (sensor offline)'
             : isNaN(h) ? `${t}°C (humedad sin dato)`
-            : isNaN(t) ? `${h}% humedad (temp sin dato)`
-            : `${h}% humedad, ${t}°C`;
+              : isNaN(t) ? `${h}% humedad (temp sin dato)`
+                : `${h}% humedad, ${t}°C`;
           const alertsLine = alerts.length > 0
             ? 'Alertas: ' + alerts.map(a => a.replace(/[^\w\s%°.,()/áéíóú]/g, '')).join('. ')
             : 'Sin alertas.';
@@ -538,6 +540,7 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
     const ctrl = new AbortController();
     fetchTelemetryAndAnalyze(ctrl.signal);
     return () => ctrl.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -598,7 +601,7 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
         </div>
         <div className="flex justify-between items-start mb-2">
           <span className="font-black text-morpho block text-xs uppercase tracking-widest">Analisis Agronomico</span>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             {aiStatus === 'thinking' && (
               <span className="text-orchid text-2xs font-bold bg-orchid/10 px-2 py-1 rounded flex items-center gap-1 border border-orchid/30">
                 <ChagraGrowLoader size={20} />
@@ -624,6 +627,19 @@ export default function TelemetryAlerts({ lastFarmOsLog, onNavigate }) {
             )}
             {!loading && aiAlert && (
               <span className="text-muzo text-2xs font-bold bg-muzo/10 px-2 py-1 rounded border border-muzo/30">Reglas activas</span>
+            )}
+            {(aiStatus === 'error' || aiStatus === 'empty' || aiStatus === 'done') && (
+              <ExternalAiButton
+                buildPrompt={buildDiagnosticExternalPrompt}
+                label="Copiar prompt para IA externa"
+                context={{
+                  speciesName: 'cultivo en monitoreo',
+                  altitudMsnm: FARM_CONFIG.ALTITUD_MSNM,
+                  municipio: FARM_CONFIG.MUNICIPIO,
+                  thermalZones: FARM_CONFIG.THERMAL_ZONES || [],
+                  sintomas: aiAlert || '',
+                }}
+              />
             )}
           </div>
         </div>

--- a/src/components/common/ExternalAiButton.jsx
+++ b/src/components/common/ExternalAiButton.jsx
@@ -1,0 +1,126 @@
+/**
+ * ExternalAiButton.jsx — R5
+ * Botón reutilizable que copia un prompt portátil al clipboard.
+ * Si el clipboard API falla, muestra un modal con textarea seleccionable.
+ * AGPL-3.0 © Chagra
+ */
+
+import React, { useState } from 'react';
+import { Clipboard, Share2, X } from 'lucide-react';
+
+const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true';
+
+const TOAST_NORMAL = '✓ Prompt copiado. Pégalo en Gemini, ChatGPT o Claude.';
+const TOAST_DEMO = '✓ Prompt copiado para demostrar portabilidad. Pégalo en Gemini gratis o ChatGPT.';
+
+/** Pequeño modal de fallback cuando clipboard API no está disponible */
+function ClipboardFallbackModal({ prompt, onClose }) {
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Copiar prompt manualmente"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+            onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+        >
+            <div className="bg-slate-900 border border-slate-700 rounded-2xl p-5 max-w-lg w-full shadow-2xl">
+                <div className="flex items-center justify-between mb-3">
+                    <h2 className="text-sm font-bold text-slate-200">Copiar prompt manualmente</h2>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="text-slate-400 hover:text-slate-200 transition-colors"
+                        aria-label="Cerrar"
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+                <p className="text-xs text-slate-400 mb-2">Selecciona todo con <kbd className="bg-slate-800 px-1 rounded">Ctrl+A</kbd> y copia con <kbd className="bg-slate-800 px-1 rounded">Ctrl+C</kbd></p>
+                <textarea
+                    readOnly
+                    value={prompt}
+                    className="w-full h-48 text-xs bg-slate-800 text-slate-300 border border-slate-700 rounded-lg p-3 resize-none font-mono"
+                    onFocus={(e) => e.target.select()}
+                    aria-label="Prompt para IA externa"
+                />
+            </div>
+        </div>
+    );
+}
+
+/**
+ * ExternalAiButton — Componente reutilizable R5.
+ *
+ * Props:
+ *   - context: { speciesName, scientificName, companions, ... } pasado al builder
+ *   - buildPrompt: fn(context) → string — constructor de prompt apropiado
+ *   - label: texto del botón (por defecto 'Copiar para IA externa')
+ *   - variant: 'share' | 'clipboard' — selección de icono (por defecto 'clipboard')
+ *   - className: clases CSS adicionales
+ */
+export function ExternalAiButton({ context, buildPrompt, label = 'Copiar para IA externa', variant = 'clipboard', className = '' }) {
+    const [toast, setToast] = useState(null);
+    const [fallbackPrompt, setFallbackPrompt] = useState(null);
+
+    const handleClick = async () => {
+        const prompt = buildPrompt(context);
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            try {
+                await navigator.clipboard.writeText(prompt);
+                const msg = isDemoMode ? TOAST_DEMO : TOAST_NORMAL;
+                setToast(msg);
+                setTimeout(() => setToast(null), 3500);
+
+                // Telemetría mínima: increment en sync_meta (best-effort, no bloquea)
+                try {
+                    const meta = JSON.parse(localStorage.getItem('chagra:sync_meta') || '{}');
+                    meta.external_ai_prompt_count = (meta.external_ai_prompt_count || 0) + 1;
+                    localStorage.setItem('chagra:sync_meta', JSON.stringify(meta));
+                } catch { /* telemetría no crítica */ }
+
+                return;
+            } catch {
+                /* fallback below */
+            }
+        }
+
+        // Clipboard API no disponible o permission denied → modal
+        setFallbackPrompt(prompt);
+    };
+
+    const Icon = variant === 'share' ? Share2 : Clipboard;
+
+    return (
+        <>
+            <div className="relative inline-flex flex-col items-start">
+                <button
+                    type="button"
+                    id="external-ai-prompt-btn"
+                    onClick={handleClick}
+                    title="Genera un prompt completo para copiar en Gemini, ChatGPT o Claude"
+                    className={`text-xs px-3 py-2 rounded-lg bg-amber-900/30 text-amber-400 border border-amber-800 hover:bg-amber-800/40 flex items-center gap-1.5 transition-colors ${className}`}
+                >
+                    <Icon size={12} />
+                    {label}
+                </button>
+
+                {toast && (
+                    <span
+                        role="status"
+                        aria-live="polite"
+                        className="absolute top-full mt-1 left-0 z-20 text-[10px] text-amber-300 bg-amber-900/80 border border-amber-700 px-2.5 py-1 rounded-lg whitespace-nowrap shadow-lg"
+                    >
+                        {toast}
+                    </span>
+                )}
+            </div>
+
+            {fallbackPrompt && (
+                <ClipboardFallbackModal prompt={fallbackPrompt} onClose={() => setFallbackPrompt(null)} />
+            )}
+        </>
+    );
+}
+
+export default ExternalAiButton;

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,4 +1,21 @@
+const DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';
+
 export const FARM_CONFIG = {
   LOCATION_ID: import.meta.env.VITE_DEFAULT_LOCATION_ID || '',
   FARM_NAME: import.meta.env.VITE_DEFAULT_FARM_NAME || 'Finca Principal',
+  // Contexto geoagronómico usado por builders de IA externa (R5) y etiquetas UI.
+  // En demo-mode se cortocircuita a constantes del guión Ministerio
+  // (Escuela San Francisco, Choachí, páramo); en prod se leen de env.
+  ALTITUD_MSNM: DEMO_MODE
+    ? 3050
+    : (Number(import.meta.env.VITE_FARM_ALTITUD_MSNM) || null),
+  MUNICIPIO: DEMO_MODE
+    ? 'Choachí, Cundinamarca'
+    : (import.meta.env.VITE_FARM_MUNICIPIO || null),
+  THERMAL_ZONES: DEMO_MODE
+    ? ['paramo']
+    : (import.meta.env.VITE_FARM_THERMAL_ZONES || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
 };

--- a/src/services/externalAiPromptBuilder.js
+++ b/src/services/externalAiPromptBuilder.js
@@ -1,0 +1,140 @@
+/**
+ * externalAiPromptBuilder.js — R5
+ * Construye prompts portables para IA externa (Gemini, ChatGPT, Claude).
+ * Puro: sin efectos secundarios, sin llamadas de red.
+ * AGPL-3.0 © Chagra
+ */
+
+/**
+ * Construye un prompt de gremio agroecológico.
+ * @param {Object} ctx - Contexto de la especie y el gremio
+ * @param {string} ctx.speciesName - Nombre común de la especie
+ * @param {string} [ctx.scientificName] - Nombre científico
+ * @param {string} [ctx.estrato] - Estrato (bajo, medio, alto)
+ * @param {string[]} [ctx.companions] - IDs o nombres de compañeros ya considerados
+ * @param {string[]} [ctx.antagonists] - IDs o nombres de antagonistas conocidos
+ * @param {string[]} [ctx.thermalZones] - Pisos térmicos (frio, templado, etc.)
+ * @param {number} [ctx.altitudMsnm] - Altitud en metros sobre el nivel del mar
+ * @param {string} [ctx.municipio] - Municipio/departamento
+ */
+export function buildGuildExternalPrompt(ctx) {
+    const {
+        speciesName = 'especie desconocida',
+        scientificName,
+        estrato,
+        companions = [],
+        antagonists = [],
+        thermalZones = [],
+        altitudMsnm,
+        municipio,
+    } = ctx;
+
+    const zonaTermica = thermalZones.length > 0 ? thermalZones.join(', ') : 'no especificado';
+    const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
+    const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
+    const companionsStr = companions.length > 0 ? companions.join(', ') : 'ninguno aún';
+    const antagonistsStr = antagonists.length > 0 ? antagonists.join(', ') : 'ninguno conocido';
+    const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;
+    const estratoStr = estrato ? `Estrato: ${estrato}` : '';
+
+    return `Actúa como agrónomo colombiano especializado en agroecología y diseño de gremios.
+
+CONTEXTO:
+- Ubicación: ${ubicacion} (piso térmico ${zonaTermica})
+- Especie principal: ${especieFull}
+${estratoStr ? `- ${estratoStr}` : ''}- Companions ya considerados: ${companionsStr}
+- Antagonists conocidos: ${antagonistsStr}
+
+PREGUNTA:
+Sugiere 5 compañeros adicionales para esta especie en un gremio agroecológico colombiano, priorizando fijación de N, repelencia de plagas, cobertura de suelo, y atractor de polinizadores. Para cada compañero: (a) nombre científico, (b) rol ecológico específico, (c) distancia óptima de siembra, (d) compatibilidad con mi piso térmico.
+
+Responde SOLO en JSON válido: array de objetos con keys name, scientific_name, role, distance_m, notes.`.trim();
+}
+
+/**
+ * Construye un prompt de diagnóstico fitosanitario.
+ * @param {Object} ctx - Contexto ambiental y del cultivo
+ * @param {string} ctx.speciesName - Nombre común de la especie
+ * @param {string} [ctx.scientificName] - Nombre científico
+ * @param {string[]} [ctx.thermalZones] - Pisos térmicos
+ * @param {number} [ctx.altitudMsnm] - Altitud en msnm
+ * @param {string} [ctx.municipio] - Municipio/departamento
+ * @param {number} [ctx.humedad] - Humedad relativa %
+ * @param {number} [ctx.temperatura] - Temperatura °C
+ * @param {number} [ctx.lluvia] - Precipitación mm últimos días
+ * @param {string} [ctx.sintomas] - Síntomas observados por el usuario
+ * @param {string} [ctx.fase] - Fase fenológica
+ * @param {number} [ctx.diasDesdeSiembra] - Días desde la siembra
+ */
+export function buildDiagnosticExternalPrompt(ctx) {
+    const {
+        speciesName = 'cultivo',
+        scientificName,
+        thermalZones = [],
+        altitudMsnm,
+        municipio,
+        humedad,
+        temperatura,
+        lluvia,
+        sintomas = '[usuario describe síntomas aquí]',
+        fase,
+        diasDesdeSiembra,
+    } = ctx;
+
+    const zonaTermica = thermalZones.length > 0 ? thermalZones.join(', ') : 'no especificado';
+    const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
+    const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
+    const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;
+
+    const condLines = [];
+    if (humedad != null) condLines.push(`HR ${humedad}%`);
+    if (temperatura != null) condLines.push(`temperatura media ${temperatura}°C`);
+    if (lluvia != null) condLines.push(`precipitación acumulada ${lluvia}mm`);
+    const condStr = condLines.length > 0 ? condLines.join(', ') : 'datos no disponibles';
+
+    const faseStr = (fase || diasDesdeSiembra != null)
+        ? `${fase ? `fase fenológica ${fase}` : ''}${diasDesdeSiembra != null ? `, ${diasDesdeSiembra} días desde siembra` : ''}`
+        : 'fase no especificada';
+
+    return `Actúa como fitopatólogo colombiano especializado en agroecología andina.
+
+CULTIVO: ${especieFull}, ${faseStr}
+UBICACIÓN: ${ubicacion}, piso térmico ${zonaTermica}
+CONDICIONES ÚLTIMOS 7 DÍAS: ${condStr}
+SÍNTOMAS OBSERVADOS: ${sintomas}
+
+TAREA:
+Realiza un diagnóstico diferencial priorizando causas más probables a esta altitud y condiciones. Para cada hipótesis, propón:
+(a) prueba casera de confirmación
+(b) biopreparado agroecológico de tratamiento (NO agroquímicos sintéticos; respetar normativa IFOAM)
+(c) medida preventiva para ciclos futuros`.trim();
+}
+
+/**
+ * Construye un prompt genérico para consulta abierta.
+ * @param {Object} ctx
+ */
+export function buildOpenExternalPrompt(ctx) {
+    const {
+        speciesName = 'especie',
+        scientificName,
+        thermalZones = [],
+        altitudMsnm,
+        municipio,
+        pregunta = '[Escribe tu pregunta aquí]',
+    } = ctx;
+
+    const zonaTermica = thermalZones.length > 0 ? thermalZones.join(', ') : 'no especificado';
+    const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
+    const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
+    const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;
+
+    return `Actúa como agrónomo colombiano especializado en agroecología en piso térmico ${zonaTermica}.
+
+CONTEXTO:
+- Ubicación: ${ubicacion}
+- Especie: ${especieFull}
+
+PREGUNTA:
+${pregunta}`.trim();
+}

--- a/tests/external-ai-prompt.spec.js
+++ b/tests/external-ai-prompt.spec.js
@@ -1,0 +1,79 @@
+/**
+ * external-ai-prompt.spec.js
+ * Unit tests del servicio externalAiPromptBuilder (no E2E, no requiere browser).
+ * Se ejecutan con Node.js directamente.
+ */
+
+import assert from 'node:assert/strict';
+import { buildGuildExternalPrompt, buildDiagnosticExternalPrompt, buildOpenExternalPrompt } from '../src/services/externalAiPromptBuilder.js';
+
+// --- buildGuildExternalPrompt ---
+{
+    const prompt = buildGuildExternalPrompt({
+        speciesName: 'Papa criolla',
+        scientificName: 'Solanum tuberosum Grupo Phureja',
+        estrato: 'bajo',
+        companions: ['Aliso andino', 'Ortiga'],
+        antagonists: ['Tomate de árbol'],
+        thermalZones: ['frio'],
+        altitudMsnm: 2600,
+        municipio: 'Zipaquirá, Cundinamarca',
+    });
+
+    assert.ok(prompt.includes('Papa criolla'), 'debe incluir nombre común');
+    assert.ok(prompt.includes('Solanum tuberosum'), 'debe incluir nombre científico');
+    assert.ok(prompt.includes('Aliso andino'), 'debe incluir companions');
+    assert.ok(prompt.includes('Tomate de árbol'), 'debe incluir antagonistas');
+    assert.ok(prompt.includes('2600'), 'debe incluir altitud');
+    assert.ok(prompt.includes('frio'), 'debe incluir piso térmico');
+    assert.ok(prompt.includes('JSON'), 'debe pedir JSON válido');
+    console.log('✓ buildGuildExternalPrompt: OK');
+}
+
+// --- buildGuildExternalPrompt context vacío ---
+{
+    const prompt = buildGuildExternalPrompt({});
+    assert.ok(typeof prompt === 'string', 'debe devolver string con context vacío');
+    assert.ok(prompt.length > 0, 'debe tener contenido');
+    console.log('✓ buildGuildExternalPrompt context vacío: OK');
+}
+
+// --- buildDiagnosticExternalPrompt ---
+{
+    const prompt = buildDiagnosticExternalPrompt({
+        speciesName: 'Papa criolla',
+        scientificName: 'Solanum tuberosum Grupo Phureja',
+        thermalZones: ['frio'],
+        altitudMsnm: 2600,
+        municipio: 'Bogotá',
+        humedad: 85,
+        temperatura: 14,
+        lluvia: 12,
+        sintomas: 'manchas blancas en el envés de las hojas',
+        fase: 'tuberización',
+        diasDesdeSiembra: 60,
+    });
+
+    assert.ok(prompt.includes('fitopatólogo'), 'debe posicionarse como fitopatólogo');
+    assert.ok(prompt.includes('85'), 'debe incluir humedad relativa');
+    assert.ok(prompt.includes('tuberización'), 'debe incluir fase fenológica');
+    assert.ok(prompt.includes('IFOAM'), 'debe mencionar normativa IFOAM');
+    console.log('✓ buildDiagnosticExternalPrompt: OK');
+}
+
+// --- buildOpenExternalPrompt ---
+{
+    const prompt = buildOpenExternalPrompt({
+        speciesName: 'Ortiga',
+        thermalZones: ['templado'],
+        altitudMsnm: 1800,
+        pregunta: '¿Cuándo se recomienda hacer el primer corte?',
+    });
+
+    assert.ok(prompt.includes('Ortiga'), 'debe incluir especie');
+    assert.ok(prompt.includes('templado'), 'debe incluir zona térmica');
+    assert.ok(prompt.includes('¿Cuándo'), 'debe incluir la pregunta del usuario');
+    console.log('✓ buildOpenExternalPrompt: OK');
+}
+
+console.log('\n✅ Todos los tests pasaron.\n');


### PR DESCRIPTION
## Summary

Implementa **R5** del master plan (v0.7.1, ~5 dp): botón reutilizable que genera un prompt contextualizado y lo copia al portapapeles para pegarlo en Gemini / ChatGPT / Claude. Esencial para el guión del demo Ministerio minuto 18 ("Si una escuela no tiene GPU, no importa. Genera un prompt que funciona en Gemini gratis").

## Cambios

### Nuevos
- `src/services/externalAiPromptBuilder.js` — 3 builders puros, sin side-effects:
  - `buildGuildExternalPrompt(context)` — consulta de gremio agroecológico.
  - `buildDiagnosticExternalPrompt(context)` — diagnóstico fitosanitario.
  - `buildOpenExternalPrompt(context)` — consulta abierta.
- `src/components/common/ExternalAiButton.jsx` — botón reutilizable:
  - Clipboard API + fallback modal con textarea seleccionable.
  - Toast ephemeral (3.5s).
  - Toast extendido en `VITE_DEMO_MODE=true`.
  - Telemetría mínima en `localStorage.chagra:sync_meta.external_ai_prompt_count`.
- `tests/external-ai-prompt.spec.js` — 4 unit tests puros Node (sin Playwright).

### Modificados
- `src/components/GuildSuggestions.jsx` — botón "Copiar para IA externa" junto al "Consultar Gremio IA" existente (coexistencia, no reemplazo).
- `src/components/TelemetryAlerts.jsx` — botón "Copiar prompt para IA externa" aparece cuando `aiStatus` ∈ `{error, empty, done}`. Se oculta durante `thinking` por diseño (no duplica el loader).
- `src/config/defaults.js` — `FARM_CONFIG` gana 3 keys: `ALTITUD_MSNM`, `MUNICIPIO`, `THERMAL_ZONES`. En `VITE_DEMO_MODE=true` se cortocircuitan a los valores del guión (3050 msnm, Choachí Cundinamarca, páramo). En producción se leen de `VITE_FARM_*` env vars. Fix del riesgo flagueado por Antigravity: sin estas keys el prompt de diagnóstico salía sin ubicación.

## Verificación

- [x] `npm install` limpio
- [x] `npm run build` verde
- [x] `npm run audit:bundle` — 0 hits contra 13 literales + 17 regex (7 pub + 6 int + regex)
- [x] ESLint: clean en todos los archivos del PR
- [x] Unit tests: 4/4 pass (`node --test tests/external-ai-prompt.spec.js`)
- [x] Lefthook pre-commit: pass (secret-scan, infra-refs, pro-imports, eslint, conventional)

## Cómo probar

**En DEMO_MODE:**
```bash
VITE_DEMO_MODE=true npm run dev
# Abrir Home → Analisis Agronomico → esperar a que aiStatus quede en 'done' o 'error'
# Click "Copiar prompt para IA externa" → pegar en un editor → verificar que incluye:
#   - Altitud: 3050 msnm
#   - Ubicación: Choachí, Cundinamarca
#   - Piso térmico: paramo
```

**Fuera de DEMO:**
```bash
VITE_FARM_ALTITUD_MSNM=2600 VITE_FARM_MUNICIPIO="Duitama, Boyacá" VITE_FARM_THERMAL_ZONES="frio" npm run dev
```

**Fallback sin Clipboard API:**
Navegador sin permiso de clipboard (o bloqueado por política) → automáticamente aparece modal con textarea seleccionable.

## Riesgos / notas

- Minuto 18 del guión queda funcional de punta a punta solo con `VITE_DEMO_MODE=true` en el build del demo. Sin esa flag, requiere las 3 env vars `VITE_FARM_*` pobladas.
- El botón no se muestra durante `aiStatus=thinking` para evitar confusión con el loader Ollama en vivo. Diseño intencional.
- Telemetría está en localStorage, no IndexedDB. No se sincroniza con FarmOS. Cuando el agregador público (fase B del plan maestro) esté listo, migrar a `sync_meta` real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)