### PR TITLE
feat(pipeline): intake GitHub Issue → draft PR automático (ADR-018 gaps 3+4+7+8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/claude-code-request.yml
+++ b/.github/ISSUE_TEMPLATE/claude-code-request.yml
@@ -1,0 +1,95 @@
+name: Claude Code Request
+description: Feature, bug fix, o tarea para ser tomada por el pipeline automático (OpenFang → GH Issue → code-gen agent → PR)
+title: "[<TIPO>] <descripción corta>"
+labels: ["claude-code-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Este issue dispara el pipeline automático `claude-code-request.yml`. El runner crea una rama, deja un stub, y abre draft PR. El agente de code-generation (aider con GLM-5, instalado en alpha runner futuro) ejecuta cuando el operador lo invoca.
+
+        Ver ADR-018 en `Chagra-strategy/adrs/` para el principio de mitigación de burnout vía automatización.
+
+  - type: dropdown
+    id: tipo
+    attributes:
+      label: Tipo (conventional commit prefix)
+      options:
+        - feat
+        - fix
+        - chore
+        - docs
+        - refactor
+        - perf
+        - test
+        - style
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Área principal afectada
+      options:
+        - ui
+        - catalog
+        - voice
+        - telemetry
+        - map
+        - auth
+        - sync
+        - build
+        - docs
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción
+      description: Qué cambia y por qué. Contexto si aplica.
+      placeholder: "Ej. Añadir botón 'Exportar CSV' en vista Estadísticas que descargue observaciones filtradas por zona y rango de fechas."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de aceptación
+      description: Lista verificable de lo que debe funcionar al terminar
+      placeholder: |
+        - [ ] Botón visible en `EstadisticasView`
+        - [ ] Click genera CSV válido con columnas: fecha, zona, especie, cantidad
+        - [ ] Funciona offline (usa IndexedDB)
+        - [ ] `npm run build` + `audit:bundle` verdes
+        - [ ] Sin modificar `dbCore.js`
+    validations:
+      required: true
+
+  - type: textarea
+    id: restrictions
+    attributes:
+      label: Restricciones / rutas prohibidas
+      description: Archivos o áreas que NO deben tocarse
+      placeholder: "No modificar src/db/dbCore.js, syncManager.js, payloadService.js, public/sw.js"
+      value: "No modificar src/db/dbCore.js, syncManager.js, payloadService.js, public/sw.js. No bumpear version ni CACHE_NAME."
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Prioridad
+      options:
+        - baja (puede esperar semanas)
+        - media (esta iteración)
+        - alta (blocker operativo)
+      default: 1
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional
+      description: Capturas de pantalla, links, observaciones del operador. Opcional.

--- a/.github/workflows/claude-code-request.yml
+++ b/.github/workflows/claude-code-request.yml
@@ -1,0 +1,149 @@
+name: Claude Code Request
+
+# Ver ADR-018 (Chagra-strategy/adrs/ADR-018-burnout-mitigation-automation.md)
+#
+# Trigger: issue labeled "claude-code-request". Crea rama, deja stub con el
+# body del issue, abre DRAFT PR. El agente de code-generation (aider + GLM-5
+# en alpha runner futuro) consume este stub y lo reemplaza por commits reales
+# cuando se invoca manualmente (post-demo setup).
+#
+# HUMAN-IN-LOOP POR DISEÑO:
+# - PR nace siempre como draft
+# - Workflow NUNCA hace merge
+# - Label 'ready-to-generate' pendiente para disparar code-gen (futuro)
+# - Notifica al operador por Telegram al abrir el draft PR
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  bootstrap-branch:
+    if: github.event.label.name == 'claude-code-request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse issue metadata
+        id: parse
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          # Derivar slug compatible con git branch
+          SLUG=$(echo "$ISSUE_TITLE" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/\[[^]]*\]//g' \
+            | tr -cd 'a-z0-9 -' \
+            | tr -s ' ' '-' \
+            | sed -E 's/^-+|-+$//g' \
+            | cut -c1-40)
+          if [ -z "$SLUG" ]; then SLUG="request"; fi
+          BRANCH="feat/issue-${ISSUE_NUM}-${SLUG}"
+          {
+            echo "issue_num=$ISSUE_NUM"
+            echo "branch=$BRANCH"
+            echo "slug=$SLUG"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create request stub branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.parse.outputs.branch }}
+          ISSUE_NUM: ${{ steps.parse.outputs.issue_num }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          git config user.name "claude-code-bot"
+          git config user.email "noreply-claude-code@chagra.bio"
+          git checkout -b "$BRANCH"
+          mkdir -p .requests
+          STUB=".requests/issue-${ISSUE_NUM}.md"
+          {
+            echo "# Request #${ISSUE_NUM}"
+            echo
+            echo "- Issue: ${ISSUE_URL}"
+            echo "- Title: ${ISSUE_TITLE}"
+            echo "- Author: @${ISSUE_AUTHOR}"
+            echo "- Status: awaiting code-generation"
+            echo
+            echo "## Body"
+            echo
+            echo "${ISSUE_BODY}"
+            echo
+            echo "---"
+            echo
+            echo "**Esto es un stub.** El agente de code-generation (aider + GLM-5 en alpha runner) reemplazará este archivo y/o hará los cambios solicitados cuando sea invocado con la label \`ready-to-generate\` (flujo futuro)."
+          } > "$STUB"
+          git add "$STUB"
+          git commit -m "chore(request): bootstrap branch for issue #${ISSUE_NUM}"
+          git push -u origin "$BRANCH"
+
+      - name: Open draft PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${{ steps.parse.outputs.branch }}" \
+            --title "[WIP] ${{ github.event.issue.title }}" \
+            --body "Closes #${{ steps.parse.outputs.issue_num }}
+
+          **Draft PR generado automáticamente** por \`claude-code-request.yml\`. Pendiente de code-generation.
+
+          ## Siguiente paso
+
+          Cuando el agente de code-gen (aider + GLM-5) esté activo en alpha runner, añadir la label \`ready-to-generate\` a este PR para disparar la ejecución. Hasta entonces, este PR queda como stub.
+
+          ## Gates humanos
+
+          - Este PR **NO se mergea automáticamente** bajo ninguna condición.
+          - El operador revisa diff manualmente tras CI verde.
+          - Si quiere auto-merge por nominación explícita, añadir label \`squash-on-merge\`." \
+            --draft)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ steps.parse.outputs.issue_num }}" --body "🤖 Solicitud recibida.
+
+          - Rama: \`${{ steps.parse.outputs.branch }}\`
+          - Draft PR: ${{ steps.pr.outputs.pr_url }}
+
+          El agente de code-generation lo recoge cuando el operador añada la label \`ready-to-generate\` al PR (flujo futuro post-demo). Gates humanos garantizan que no se mergea sin revisión."
+
+      - name: Notify Telegram (non-blocking)
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          ISSUE_NUM: ${{ steps.parse.outputs.issue_num }}
+          BRANCH: ${{ steps.parse.outputs.branch }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            echo "Telegram secrets not set; skipping notification (non-blocking)"
+            exit 0
+          fi
+          MSG="🤖 *Claude Code request* #${ISSUE_NUM}
+          Repo: ${{ github.repository }}
+          Branch: \`${BRANCH}\`
+          PR: ${PR_URL}
+          Estado: draft, esperando code-gen"
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -d "chat_id=${TELEGRAM_CHAT_ID}" \
+            -d "parse_mode=Markdown" \
+            --data-urlencode "text=${MSG}" \
+            || echo "Telegram notification failed (ignored)"


### PR DESCRIPTION
## Summary

Implementa el **intake automatizado de solicitudes** (gaps 3, 4, 7, 8 del plan de orquestación Telegram→OpenFang→PR). Parte del principio ADR-018 burnout mitigation vía automation aggressive (pendiente de escribir post-demo).

### Gaps cerrados en este PR

| Gap | Entregable | Status |
|---|---|---|
| **3** Issue template estructurado | `.github/ISSUE_TEMPLATE/claude-code-request.yml` con campos tipo/scope/acceptance/restrictions/priority | ✅ |
| **4** Workflow que crea branch + draft PR | `.github/workflows/claude-code-request.yml` trigger on `issues.labeled: claude-code-request` | ✅ |
| **7** Notificación Telegram del operador | Step final del workflow con `curl` a Bot API (non-blocking si secrets no están) | ✅ |
| **8** Gates humanos obligatorios | Workflow nace draft, never auto-merge, label `ready-to-generate` pendiente de wire con code-gen futuro | ✅ |

### Gaps pendientes (post-demo)

| Gap | Pendiente de | Cuándo |
|---|---|---|
| **1** Manifest OpenFang con clasificación | Edit `modules/ai/openfang/guatoc-manifest.toml` + rebuild alpha | Post-demo |
| **2** GitHub PAT para OpenFang | Crear fine-grained PAT, guardar en SOPS | Post-demo, necesita operador |
| **5** Code-gen agent en alpha runner | Instalar aider-chat con endpoint Z.ai GLM-5 | Post-demo |
| **6** Wire Z.ai API key al runner | GH secret + job env | Post-demo, necesita operador |

## Configuración requerida (operador)

Post-merge de este PR, añadir a **Settings → Secrets and variables → Actions** del repo:

- `TELEGRAM_BOT_TOKEN` — el token del bot de OpenFang (reusable desde el SOPS en alpha)
- `TELEGRAM_CHAT_ID` — el chat ID del operador (user_id 208512105 per manifest)

Si estos secretos no están configurados, el workflow **sigue funcionando** (crea rama + draft PR + comment en issue); solo no envía notificación a Telegram.

## Cómo probar

Cuando el operador quiera validar el flujo end-to-end:

1. Abre issue nuevo usando el template "Claude Code Request"
2. Rellena tipo, scope, descripción, criterios de aceptación
3. Submit — GitHub asigna la label `claude-code-request` automáticamente
4. Workflow dispara en ~10s:
   - Crea branch `feat/issue-N-<slug>`
   - Deja stub en `.requests/issue-N.md`
   - Abre draft PR con `Closes #N`
   - Comenta en issue
   - Notifica Telegram si secrets están

El PR queda en draft **esperando** que el operador añada label `ready-to-generate` (flujo code-gen pendiente de gaps 1/2/5/6).

## Seguridad

- Workflow no tiene permisos de merge (solo `contents: write`, `pull-requests: write`, `issues: write`).
- Todo PR creado **nace draft**.
- Operador es el único que promociona/mergea.
- `GITHUB_TOKEN` scope estándar de Actions, no elevado.
- Label dispara el workflow, pero cualquier usuario con permisos sobre issues puede aplicarla; mitigación futura: workflow verifica author.login es owner-team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)