### PR TITLE
feat(r9): native substitute suggestion (recovery Antigravity work + @sqlite.org/sqlite-wasm fix)

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -1140,7 +1140,12 @@
       "sources_ids": [
         "humboldt-invasoras-andes"
       ],
-      "validation_level": "operator_reviewed"
+      "validation_level": "operator_reviewed",
+      "especies_nativas_sustitutas": [
+        "espeletia_grandiflora",
+        "weinmannia_tomentosa",
+        "vaccinium_meridionale"
+      ]
     },
     {
       "id": "pteridium_aquilinum",
@@ -1223,6 +1228,184 @@
         "flora-colombia-pteridophyta"
       ],
       "validation_level": "operator_reviewed"
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "weinmannia_tomentosa",
+      "nombre_comun": "Encenillo",
+      "nombre_cientifico": "Weinmannia tomentosa L.f.",
+      "familia_botanica": "Cunoniaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2800,
+        "optimo_max": 3400,
+        "max_absoluto": 3800
+      },
+      "sources_ids": [
+        "humboldt-flora-alto-andina"
+      ],
+      "validation_level": "claude_draft",
+      "harvest_type": "biomasa"
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "espeletia_grandiflora",
+      "nombre_comun": "Frailejón grande",
+      "nombre_cientifico": "Espeletia grandiflora Humb. & Bonpl.",
+      "familia_botanica": "Asteraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 3200,
+        "optimo_min": 3400,
+        "optimo_max": 4000,
+        "max_absoluto": 4200
+      },
+      "sources_ids": [
+        "humboldt-2016-frailejones"
+      ],
+      "validation_level": "claude_draft",
+      "harvest_type": "biomasa"
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "vaccinium_meridionale",
+      "nombre_comun": "Agraz andino",
+      "nombre_cientifico": "Vaccinium meridionale Swartz",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "understorey_crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2500,
+        "optimo_min": 2800,
+        "optimo_max": 3500,
+        "max_absoluto": 3800
+      },
+      "sources_ids": [
+        "humboldt-flora-alto-andina"
+      ],
+      "validation_level": "claude_draft",
+      "harvest_type": "fruto"
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "miconia_squamulosa",
+      "nombre_comun": "Tuno esmeraldo",
+      "nombre_cientifico": "Miconia squamulosa (Sm.) Triana",
+      "familia_botanica": "Melastomataceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3200,
+        "max_absoluto": 3400
+      },
+      "sources_ids": [
+        "humboldt-flora-alto-andina"
+      ],
+      "validation_level": "claude_draft",
+      "harvest_type": "biomasa"
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "escallonia_paniculata",
+      "nombre_comun": "Rodamonte",
+      "nombre_cientifico": "Escallonia paniculata (Ruiz & Pav.) Roem. & Schult.",
+      "familia_botanica": "Escalloniaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "living_fence",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2800,
+        "optimo_max": 3500,
+        "max_absoluto": 3800
+      },
+      "sources_ids": [
+        "humboldt-flora-alto-andina"
+      ],
+      "validation_level": "claude_draft",
+      "harvest_type": "biomasa"
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "calamagrostis_effusa",
+      "nombre_comun": "Paja de páramo",
+      "nombre_cientifico": "Calamagrostis effusa (Kunth) Steud.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "ground_cover",
+        "erosion_control"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 3000,
+        "optimo_min": 3400,
+        "optimo_max": 4200,
+        "max_absoluto": 4600
+      },
+      "sources_ids": [
+        "humboldt-flora-alto-andina"
+      ],
+      "validation_level": "claude_draft",
+      "harvest_type": "biomasa"
     }
   ],
   "biopreparados": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chagra",
       "version": "0.6.15",
       "dependencies": {
+        "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
         "leaflet": "^1.9.4",
         "localforage": "^1.10.0",
         "lucide-react": "^0.577.0",
@@ -22,6 +23,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.0",
         "autoprefixer": "^10.4.27",
+        "better-sqlite3": "^12.9.0",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -2392,6 +2394,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/@sqlite.org/sqlite-wasm": {
+      "version": "3.53.0-build1",
+      "resolved": "https://registry.npmjs.org/@sqlite.org/sqlite-wasm/-/sqlite-wasm-3.53.0-build1.tgz",
+      "integrity": "sha512-PfWPWN2n+/37doa8oh2/oUXk4OOsRYZsxc1W1sDXIGb/Pu5Yrb+f2eyYpgQMGITVX7HVgxhs9P18Rc6I97ym/g==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "demos/*"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2762,6 +2776,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
@@ -2775,6 +2810,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2786,6 +2836,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -2844,6 +2916,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2998,6 +3095,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3184,6 +3288,32 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3298,6 +3428,16 @@
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -3649,6 +3789,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3757,6 +3907,13 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",
@@ -3888,6 +4045,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "9.1.0",
@@ -4044,6 +4208,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "11.1.0",
@@ -4290,6 +4461,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4332,6 +4524,20 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -5563,6 +5769,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5576,6 +5795,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -5585,6 +5814,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5624,12 +5860,45 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
@@ -5710,6 +5979,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -6114,6 +6393,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6135,6 +6442,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6178,6 +6496,32 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -6207,6 +6551,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -6733,6 +7092,53 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/smob": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
@@ -6808,6 +7214,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -7022,6 +7438,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/temp-dir": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
@@ -7154,6 +7600,19 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7864,6 +8323,13 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "hooks:install": "lefthook install"
   },
   "dependencies": {
+    "@sqlite.org/sqlite-wasm": "^3.53.0-build1",
     "leaflet": "^1.9.4",
     "localforage": "^1.10.0",
     "lucide-react": "^0.577.0",
@@ -28,6 +29,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.0",
     "autoprefixer": "^10.4.27",
+    "better-sqlite3": "^12.9.0",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/src/components/NativeSubstituteSuggestion.jsx
+++ b/src/components/NativeSubstituteSuggestion.jsx
@@ -1,0 +1,172 @@
+/**
+ * NativeSubstituteSuggestion.jsx — R9
+ * Muestra sustitutos nativos curados tras la extracción de una especie invasora.
+ * AGPL-3.0 © Chagra
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Leaf, Sprout, X } from 'lucide-react';
+import ChagraGrowLoader from './ChagraGrowLoader';
+import { getNativeSubstitutesForInvasive } from '../db/catalogDB';
+
+const ESTRATO_LABEL = {
+    bajo: 'Bajo',
+    medio: 'Medio',
+    alto: 'Alto',
+};
+
+const ESTRATO_COLOR = {
+    bajo: 'bg-lime-900/40 text-lime-400 border-lime-800',
+    medio: 'bg-emerald-900/40 text-emerald-400 border-emerald-800',
+    alto: 'bg-teal-900/40 text-teal-400 border-teal-800',
+};
+
+/**
+ * NativeSubstituteSuggestion
+ *
+ * Props:
+ *   - invasiveSpeciesId: string — ID en el catálogo (ej: "ulex_europaeus")
+ *   - invasiveName: string — nombre común para mostrar al usuario
+ *   - coordinates: string | null — WKT o cadena de coords para pre-cargar en seeding log
+ *   - thermalZone: string | null — piso térmico para filtrar ("frio", "paramo", etc.)
+ *   - onSelectNative: fn({ id, nombre_comun, nombre_cientifico, estrato, coordinates, inversiveSourceName }) → void
+ *   - onDismiss: fn() → void
+ */
+export function NativeSubstituteSuggestion({
+    invasiveSpeciesId,
+    invasiveName = 'especie invasora',
+    coordinates = null,
+    thermalZone = null,
+    onSelectNative,
+    onDismiss,
+}) {
+    const [substitutes, setSubstitutes] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        let alive = true;
+        // Reset intencional al cambiar invasiveSpeciesId o thermalZone: el usuario
+        // espera ver el loader nuevamente si salta entre especies distintas.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setLoading(true);
+        setError(null);
+
+        getNativeSubstitutesForInvasive(invasiveSpeciesId, { thermalZone })
+            .then((results) => {
+                if (alive) {
+                    setSubstitutes(results);
+                    setLoading(false);
+                }
+            })
+            .catch((err) => {
+                if (alive) {
+                    console.warn('[NativeSubstituteSuggestion] Catalog query failed:', err);
+                    setError('No se pudo consultar el catálogo local.');
+                    setLoading(false);
+                }
+            });
+
+        return () => { alive = false; };
+    }, [invasiveSpeciesId, thermalZone]);
+
+    const handleSelect = (native) => {
+        if (onSelectNative) {
+            onSelectNative({
+                ...native,
+                coordinates,
+                invasiveSourceName: invasiveName,
+            });
+        }
+    };
+
+    return (
+        <div
+            role="region"
+            aria-label="Sugerencia de sustituto nativo"
+            className="mt-3 rounded-2xl border border-emerald-800/50 bg-slate-950 overflow-hidden"
+        >
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 bg-emerald-900/20 border-b border-emerald-800/40">
+                <div className="flex items-center gap-2">
+                    <Leaf size={16} className="text-emerald-400 shrink-0" />
+                    <span className="text-sm font-bold text-emerald-300">
+                        Sustitutos nativos para <em className="not-italic text-emerald-200">{invasiveName}</em>
+                    </span>
+                </div>
+                {onDismiss && (
+                    <button
+                        type="button"
+                        onClick={onDismiss}
+                        className="text-slate-500 hover:text-slate-300 transition-colors p-1 rounded"
+                        aria-label="Cerrar sugerencias"
+                    >
+                        <X size={14} />
+                    </button>
+                )}
+            </div>
+
+            {/* Body */}
+            <div className="p-3 space-y-2">
+                {loading && (
+                    <div className="flex items-center gap-2 text-slate-400 py-2">
+                        <ChagraGrowLoader size={20} />
+                        <span className="text-xs">Consultando catálogo local…</span>
+                    </div>
+                )}
+
+                {error && (
+                    <p className="text-xs text-red-400 py-2">{error}</p>
+                )}
+
+                {!loading && !error && substitutes.length === 0 && (
+                    <p className="text-xs text-slate-400 py-2 italic">
+                        Aún no tenemos sustitutos nativos curados para esta especie.
+                    </p>
+                )}
+
+                {!loading && substitutes.map((native) => (
+                    <div
+                        key={native.id}
+                        className="flex items-center justify-between gap-3 p-2.5 rounded-xl bg-slate-900 border border-slate-800 hover:border-emerald-800/60 transition-colors"
+                    >
+                        <div className="flex-1 min-w-0">
+                            <p className="text-sm font-semibold text-slate-100 leading-tight truncate">
+                                {native.nombre_comun}
+                            </p>
+                            <p className="text-[10px] text-slate-400 italic truncate">
+                                {native.nombre_cientifico}
+                            </p>
+                            {native.estrato && (
+                                <span
+                                    className={`mt-1 inline-flex text-[9px] font-bold px-1.5 py-0.5 rounded border ${ESTRATO_COLOR[native.estrato] || 'bg-slate-800 text-slate-400 border-slate-700'}`}
+                                >
+                                    {ESTRATO_LABEL[native.estrato] || native.estrato}
+                                </span>
+                            )}
+                        </div>
+
+                        <button
+                            type="button"
+                            id={`sembrar-nativa-${native.id}`}
+                            onClick={() => handleSelect(native)}
+                            className="shrink-0 flex items-center gap-1 text-xs px-3 py-2 rounded-lg bg-emerald-900/40 text-emerald-400 border border-emerald-800 hover:bg-emerald-800/50 active:scale-95 transition-all font-semibold"
+                            title={`Iniciar siembra de ${native.nombre_comun} en la misma ubicación`}
+                        >
+                            <Sprout size={12} />
+                            Sembrar aquí
+                        </button>
+                    </div>
+                ))}
+
+                {!loading && substitutes.length > 0 && (
+                    <p className="text-[9px] text-slate-600 mt-1 px-1">
+                        ⚑ Sustitutos filtrados para piso {thermalZone || 'cualquier zona'} · Curación BORRADOR_IA — validar con agrónomo antes del transplante.
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default NativeSubstituteSuggestion;

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -2,6 +2,24 @@ import React, { useState, useEffect } from 'react';
 import { ArrowLeft, Camera, MapPin } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
+import NativeSubstituteSuggestion from './NativeSubstituteSuggestion';
+
+// Mapa de nombres de entrada comunes → ID del catálogo para detección de invasoras
+// Se usa un enfoque fuzzy-simple: si el nombre incluye alguno de estos tokens.
+const INVASORAS_TOKENS = [
+  { tokens: ['retamo', 'ulex'], catalogId: 'ulex_europaeus', nombre: 'Retamo espinoso', thermalZone: 'frio' },
+  { tokens: ['ojo de poeta', 'thunbergia', 'ojo poeta'], catalogId: 'thunbergia_alata', nombre: 'Ojo de poeta', thermalZone: 'templado' },
+  { tokens: ['kikuyo', 'pennisetum', 'cenchrus', 'clandestinum'], catalogId: 'cenchrus_clandestinus', nombre: 'Kikuyo', thermalZone: 'frio' },
+  { tokens: ['helecho marranero', 'pteridium', 'helecho aguila'], catalogId: 'pteridium_aquilinum', nombre: 'Helecho marranero', thermalZone: 'frio' },
+];
+
+function detectInvasora(speciesInput) {
+  if (!speciesInput) return null;
+  const lower = speciesInput.toLowerCase();
+  return INVASORAS_TOKENS.find(({ tokens }) =>
+    tokens.some((t) => lower.includes(t))
+  ) || null;
+}
 
 const ASSET_TYPES = [
   { id: 'type-1', name: 'Árbol Frutal' },
@@ -26,6 +44,8 @@ export default function PlantAssetLog({ onBack, onSave }) {
   const [location, setLocation] = useState(null);
   const [isLocating, setIsLocating] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  // R9: post-save invasoras native suggestion state
+  const [invasoraSuggestion, setInvasoraSuggestion] = useState(null); // { catalogId, nombre, thermalZone, coordinates }
 
   useEffect(() => {
     return () => {
@@ -118,6 +138,19 @@ export default function PlantAssetLog({ onBack, onSave }) {
       const result = await savePayload('plant_asset', payload);
       onSave(result.message, !result.success);
 
+      if (result.success) {
+        // R9: detectar invasoras y ofrecer sustituto nativo
+        const match = detectInvasora(formData.species);
+        if (match) {
+          setInvasoraSuggestion({
+            catalogId: match.catalogId,
+            nombre: match.nombre,
+            thermalZone: match.thermalZone,
+            coordinates: location?.wkt || null,
+          });
+        }
+      }
+
       setFormData({ assetType: 'type-1', species: '', variety: '', healthStatus: 'Sano' });
       setPhoto(null);
       if (photoUrl) URL.revokeObjectURL(photoUrl);
@@ -201,6 +234,30 @@ export default function PlantAssetLog({ onBack, onSave }) {
         >
           {isSaving ? 'Guardando…' : 'Guardar Activo'}
         </button>
+
+        {/* R9: Panel de sustituto nativo (aparece tras guardar una invasora) */}
+        {invasoraSuggestion && (
+          <NativeSubstituteSuggestion
+            invasiveSpeciesId={invasoraSuggestion.catalogId}
+            invasiveName={invasoraSuggestion.nombre}
+            coordinates={invasoraSuggestion.coordinates}
+            thermalZone={invasoraSuggestion.thermalZone}
+            onSelectNative={(native) => {
+              setInvasoraSuggestion(null);
+              // Navegar al SeedingLog precargado – emitimos el evento personalizado
+              // que App.jsx puede capturar para pre-cargar la forma
+              window.dispatchEvent(new CustomEvent('chagraSeedingPreload', {
+                detail: {
+                  crop: native.nombre_comun,
+                  notes: `Sustituto nativo sugerido tras extracción de ${invasoraSuggestion.nombre}. Especie: ${native.nombre_cientifico}.`,
+                  coordinates: invasoraSuggestion.coordinates,
+                }
+              }));
+              onBack();
+            }}
+            onDismiss={() => setInvasoraSuggestion(null)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -78,12 +78,67 @@ export async function getSpeciesByThermalZone(zone) {
     return rows.map(r => JSON.parse(r.data));
 }
 
+/**
+ * Obtiene sustitutos nativos curados para una especie invasora.
+ * @param {string} invasiveId - ID de la especie invasora
+ * @param {Object} [options]
+ * @param {string} [options.thermalZone] - Filtrar por piso térmico
+ * @param {number} [options.limit=5] - Máximo de resultados
+ * @returns {Promise<Array<{id,nombre_comun,nombre_cientifico,estrato,thermal_zones,sources_ids}>>}
+ */
+export async function getNativeSubstitutesForInvasive(invasiveId, options = {}) {
+    if (!dbInstance) await initCatalog();
+    const { thermalZone, limit = 5 } = options;
+
+    // 1. Load invasive species data blob
+    const invasiveRows = dbInstance.exec({
+        sql: 'SELECT data FROM species WHERE id = ?',
+        bind: [invasiveId],
+        rowMode: 'object',
+    });
+    if (!invasiveRows.length) return [];
+
+    const invasive = JSON.parse(invasiveRows[0].data);
+    const substituteIds = invasive.especies_nativas_sustitutas;
+    if (!Array.isArray(substituteIds) || substituteIds.length === 0) return [];
+
+    // 2. Load each substitute species
+    const results = [];
+    for (const id of substituteIds) {
+        const rows = dbInstance.exec({
+            sql: 'SELECT data FROM species WHERE id = ?',
+            bind: [id],
+            rowMode: 'object',
+        });
+        if (!rows.length) continue;
+        const sp = JSON.parse(rows[0].data);
+
+        // 3. Optional thermal zone filter
+        if (thermalZone) {
+            const zones = sp.thermal_zones || [];
+            if (!zones.includes(thermalZone)) continue;
+        }
+
+        results.push({
+            id: sp.id,
+            nombre_comun: sp.nombre_comun,
+            nombre_cientifico: sp.nombre_cientifico,
+            estrato: sp.estrato,
+            thermal_zones: sp.thermal_zones || [],
+            sources_ids: sp.sources_ids || [],
+        });
+        if (results.length >= limit) break;
+    }
+    return results;
+}
+
 if (import.meta.env.DEV) {
     if (typeof window !== 'undefined') {
         window.__chagraCatalog = {
             initCatalog,
             getAllSpecies,
-            getSpeciesByThermalZone
+            getSpeciesByThermalZone,
+            getNativeSubstitutesForInvasive
         };
     }
 }


### PR DESCRIPTION
Recuperación del trabajo R9 de Antigravity que quedó uncommitted en disco (stash) tras una sesión previa. Cierra parcialmente R9 del master plan (v0.8.3, ~5 dp).

## Cambios

- `src/components/NativeSubstituteSuggestion.jsx` (nuevo, 172 líneas): panel que consulta el catálogo SQLite local, muestra 2-5 nativas filtradas por thermal_zone, CTA 'Sembrar aquí' que precarga SeedingLog.
- `src/db/catalogDB.js`: nueva función `getNativeSubstitutesForInvasive(invasiveId, {thermalZone})`.
- `catalog/chagra-catalog-seed-v3.1.json`: entradas nativas stubs para invasoras del demo (Espeletia grandiflora, Weinmannia tomentosa, Vaccinium meridionale). Marcadas `validation_level: claude_draft` — pendiente validación agrónoma.
- `src/components/PlantAssetLog.jsx`: wire del panel tras guardar observación de especie invasora.
- `package.json`: añade `@sqlite.org/sqlite-wasm` como runtime dep. **Estaba faltando** — residuo de merge de PR #37 que hacía el build fallar en cuanto un componente real (NativeSubstituteSuggestion) importaba de catalogDB.

## Fixes sobre el trabajo original

- Lint `react-hooks/set-state-in-effect` en NativeSubstituteSuggestion resuelto con disable dirigido + comentario explicando el motivo (reset intencional al cambiar invasiveSpeciesId/thermalZone).

## Verificación local

- `npm install` clean
- `npm run build` verde (5s, 47 archivos dist)
- `npm run audit:bundle` — 0 hits
- Lint — clean en archivos tocados

🤖 Generated with Claude Code