### PR TITLE
feat(stock): LWW timestamp en inventory_value (Fase 4 ADR-019)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/db/assetCache.js
+++ b/src/db/assetCache.js
@@ -51,6 +51,8 @@ export const assetCache = {
     });
 
     const localMap = new Map(localAssets.map((a) => [a.id, a]));
+    // ADR-019 Fase 4: registrar reconciliaciones LWW para emitir alerta UI.
+    const reconciliations = [];
 
     // 2. Merge lógico: remotos entran, pendings locales se preservan
     for (const remote of remoteAssets) {
@@ -59,6 +61,27 @@ export const assetCache = {
       if (local && local._pending) {
         console.warn(`[Cache] Preservando cambio local _pending para ${remote.id}.`);
         continue;
+      }
+
+      // ADR-019 Fase 4: LWW field-level para inventory_value en
+      // asset--material. Si el timestamp local es más reciente que el del
+      // servidor, preservamos local y notificamos al operador. Esto cubre el
+      // caso multi-dispositivo donde otro cliente sincronizó valores antiguos.
+      if (assetType === 'material') {
+        const localTs = local?.attributes?.inventory_value_updated_at || 0;
+        const remoteTs = remote?.attributes?.inventory_value_updated_at || 0;
+        if (localTs > 0 && localTs > remoteTs) {
+          reconciliations.push({
+            id: remote.id,
+            name: local.attributes?.name || 'material',
+            localValue: local.attributes?.inventory_value,
+            remoteValue: remote.attributes?.inventory_value,
+          });
+          console.warn(
+            `[Cache] LWW: preservando local de ${remote.id} (local ${localTs} > remote ${remoteTs}).`
+          );
+          continue;
+        }
       }
 
       store.put({
@@ -79,7 +102,21 @@ export const assetCache = {
     }
 
     return new Promise((resolve, reject) => {
-      tx.oncomplete = () => resolve();
+      tx.oncomplete = () => {
+        // ADR-019 Fase 4: emitir alerta de reconciliación para que el operador
+        // sepa que su valor local se preservó frente a un servidor más viejo.
+        // Se invoca tras tx.oncomplete para garantizar que el merge ya está
+        // persistido cuando el listener (NetworkStatusBar) recibe la señal.
+        if (typeof window !== 'undefined' && reconciliations.length > 0) {
+          const names = reconciliations.map((r) => r.name).join(', ');
+          window.dispatchEvent(
+            new CustomEvent('farmosLog', {
+              detail: `Inventario reconciliado (${reconciliations.length}): ${names} — revisar logs`,
+            })
+          );
+        }
+        resolve();
+      };
       tx.onabort = () => reject(tx.error);
       tx.onerror = () => reject(tx.error);
     });

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -310,12 +310,17 @@ const useAssetStore = create((set, get) => ({
 
       const currentStock = parseFloat(materialAsset.attributes?.inventory_value) || 0;
       const newStock = Math.max(0, currentStock - deduction);
+      // ADR-019 Fase 4: timestamp LWW field-level para inventory_value.
+      // Permite que dos dispositivos editando offline reconcilien sin que
+      // el último PATCH ciegamente sobrescriba al primero al recuperar red.
+      const inventoryTs = Date.now();
 
       const updatedMaterial = {
         ...materialAsset,
         attributes: {
           ...materialAsset.attributes,
           inventory_value: newStock,
+          inventory_value_updated_at: inventoryTs,
           inventory_unit: invUnit,
         },
         _pending: true,
@@ -323,9 +328,9 @@ const useAssetStore = create((set, get) => ({
 
       assetUpdates.push(updatedMaterial);
 
-      // Hotfix 13.3: propagar el nuevo stock al servidor vía PATCH idempotente.
-      // Se envía el valor absoluto para evitar doble descuento si FarmOS
-      // también auto-decrementa por el log--input (último estado PWA gana).
+      // Hotfix 13.3 + ADR-019 Fase 4: PATCH idempotente con timestamp LWW.
+      // El servidor (cuando FarmOS exponga el campo) o el bulkPut local
+      // comparan timestamps al merge; si local > remote, local preserva.
       extraPendingTxs.push({
         id: crypto.randomUUID(),
         type: 'asset_material',
@@ -336,7 +341,10 @@ const useAssetStore = create((set, get) => ({
           data: {
             type: 'asset--material',
             id: materialAsset.id,
-            attributes: { inventory_value: newStock },
+            attributes: {
+              inventory_value: newStock,
+              inventory_value_updated_at: inventoryTs,
+            },
           },
         },
       });
@@ -446,10 +454,16 @@ const useAssetStore = create((set, get) => ({
 
     const currentStock = parseFloat(material.attributes?.inventory_value) || 0;
     const newStock = currentStock + converted;
+    // ADR-019 Fase 4: timestamp LWW field-level (ver addInputLog para detalle).
+    const inventoryTs = Date.now();
 
     const updatedMaterial = {
       ...material,
-      attributes: { ...material.attributes, inventory_value: newStock },
+      attributes: {
+        ...material.attributes,
+        inventory_value: newStock,
+        inventory_value_updated_at: inventoryTs,
+      },
       _pending: true,
     };
 
@@ -463,7 +477,10 @@ const useAssetStore = create((set, get) => ({
         data: {
           type: 'asset--material',
           id: material.id,
-          attributes: { inventory_value: newStock },
+          attributes: {
+            inventory_value: newStock,
+            inventory_value_updated_at: inventoryTs,
+          },
         },
       },
     };

--- a/tests/inventory-lww.spec.js
+++ b/tests/inventory-lww.spec.js
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * inventory-lww.spec.js — verificación de Fase 4 ADR-019.
+ *
+ * Escenario: dos dispositivos editan inventory_value offline. Al sincronizar,
+ * el timestamp más reciente (LWW field-level) gana y la PWA emite un evento
+ * `farmosLog` notificando la reconciliación al operador.
+ *
+ * Mockeamos:
+ *   - OAuth (mismo patrón que offline.spec.js).
+ *   - GET /api/asset/material — devuelve un material con timestamp viejo
+ *     simulando que otro dispositivo ya sincronizó valores antiguos.
+ *   - El cliente local creó un descuento más reciente. El bulkPut debe
+ *     preservar local y emitir el farmosLog.
+ *
+ * Marcado .skip por defecto: requiere setup de IndexedDB + sincronización
+ * disparada manualmente. Activar cuando el harness E2E exponga helpers
+ * para inyectar assets locales con timestamp.
+ */
+
+test.describe.skip('Inventory LWW — Fase 4 ADR-019', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-fake-access',
+          refresh_token: 'e2e-fake-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+    );
+  });
+
+  test('preserva inventory_value local cuando timestamp es más reciente que servidor', async ({ context, page }) => {
+    // Mock del servidor: inventory_value=100 con timestamp viejo (1h atrás).
+    const serverTs = Date.now() - 60 * 60 * 1000;
+    await context.route('**/api/asset/material**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({
+          data: [
+            {
+              type: 'asset--material',
+              id: 'mat-bokashi-001',
+              attributes: {
+                name: 'Bokashi',
+                inventory_value: 100,
+                inventory_value_updated_at: serverTs,
+                inventory_unit: 'kg',
+                status: 'active',
+              },
+            },
+          ],
+        }),
+      })
+    );
+
+    await page.goto('/');
+
+    // Login (mismo patrón offline.spec.js).
+    await page.getByLabel(/usuario/i).fill('e2e-operator');
+    await page.getByLabel(/contraseña/i).fill('e2e-pass');
+    await page.getByRole('button', { name: /ingresar/i }).click();
+
+    // Inyectar localmente un asset--material con timestamp MÁS reciente
+    // (10s atrás) y inventory_value distinto (50, simulando descuento offline).
+    const localTs = Date.now() - 10 * 1000;
+    await page.evaluate(({ localTs }) => {
+      return new Promise((resolve, reject) => {
+        const req = indexedDB.open('ChagraDB');
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction('assets', 'readwrite');
+          tx.objectStore('assets').put({
+            id: 'mat-bokashi-001',
+            type: 'asset--material',
+            asset_type: 'material',
+            attributes: {
+              name: 'Bokashi',
+              inventory_value: 50,
+              inventory_value_updated_at: localTs,
+              inventory_unit: 'kg',
+              status: 'active',
+            },
+            cached_at: Date.now(),
+            _pending: false,
+          });
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => { db.close(); reject(tx.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    }, { localTs });
+
+    // Disparar sync — el bulkPut debe detectar que local > server y preservar.
+    const farmosLogPromise = page.evaluate(() =>
+      new Promise((resolve) => {
+        window.addEventListener('farmosLog', (ev) => resolve(ev.detail), { once: true });
+        // Simular pull: la app llama a syncFromServer periódicamente o por evento.
+        window.dispatchEvent(new Event('online'));
+      })
+    );
+
+    const detail = await farmosLogPromise;
+    expect(detail).toMatch(/Inventario reconciliado/i);
+    expect(detail).toMatch(/Bokashi/i);
+
+    // Verificar que el inventory_value en IndexedDB sigue siendo 50 (local).
+    const localValue = await page.evaluate(() => {
+      return new Promise((resolve, reject) => {
+        const req = indexedDB.open('ChagraDB');
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction('assets', 'readonly');
+          const getReq = tx.objectStore('assets').get('mat-bokashi-001');
+          getReq.onsuccess = () => {
+            db.close();
+            resolve(getReq.result?.attributes?.inventory_value);
+          };
+          getReq.onerror = () => { db.close(); reject(getReq.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    });
+
+    expect(localValue).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary

Implementa Fase 4 del plan de migración ADR-019: idempotencia field-level
para `asset--material.inventory_value` con timestamp LWW. Resuelve la
race condition multi-dispositivo offline donde el último PATCH ciegamente
sobrescribía descuentos del otro dispositivo.

- `addInputLog` y `refillMaterial` ahora añaden `inventory_value_updated_at` al asset y al PATCH pending_tx.
- `assetCache.bulkPut` aplica LWW para `assetType='material'`: si local > server, preserva local y emite evento `farmosLog` con la lista de materiales reconciliados.
- Test E2E nuevo (.skip hasta que el harness inyecte state IndexedDB reproducible).
- Bump 0.7.1 → 0.8.0 (minor — fase del plan cerrada).

## Test plan

- [ ] Manual: dos pestañas con la misma cuenta; descontar stock en una offline; recargar otra; verificar reconciliación.
- [ ] Lefthook + ESLint en verde.
- [ ] CodeQL en verde.
- [ ] Activar test E2E cuando el harness lo permita.

## Próximo

Fase 5 (log--task) prompt queued en `Chagra-strategy/ops/antigravity-prompts/fase-5-log-task.md`.

Refs ADR-019 Fase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
