### PR TITLE
feat(task): foundation log--task — Fase 5 ADR-019 (parcial — backend API)

### DIFF
--- a/src/services/payloadService.js
+++ b/src/services/payloadService.js
@@ -7,6 +7,8 @@ const resolveEndpoint = (type) =>
   type === 'plant_asset' ? '/api/asset/plant' :
   type === 'input' ? '/api/log/input' :
   type === 'harvest' ? '/api/log/harvest' :
+  type === 'observation' ? '/api/log/observation' :
+  type === 'task' ? '/api/log/task' :
   '/api/log/seeding';
 
 export const savePayload = async (type, payload) => {
@@ -129,7 +131,7 @@ export const savePayload = async (type, payload) => {
               console.warn(`  [${i}] ${e.title || 'Error'}: ${e.detail || '(sin detalle)'}${e.source?.pointer ? ` @ ${e.source.pointer}` : ''}`),
             );
           }
-        } catch (_) {
+        } catch {
           console.warn('[payloadService] Error body (raw):', error.detail.slice(0, 500));
         }
       }

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import { assetCache, openDB, STORES } from '../db/assetCache';
 import { logCache } from '../db/logCache';
 import { useLogStore } from './useLogStore';
+import { newId } from '../utils/id';
+import { savePayload } from '../services/payloadService';
 
 /**
  * Store global de Activos (Zustand)
@@ -502,6 +504,107 @@ const useAssetStore = create((set, get) => ({
       console.error('[Store] Fallo en refillMaterial:', error);
       throw error;
     }
+  },
+
+  // ADR-019 Fase 5: Crear una nueva tarea como log--task pendiente.
+  // El bundle log--task usa ULID conforme ADR-019 (lex-orderable, optimiza
+  // indexación IndexedDB). Reemplaza el patrón anterior de pending_tasks
+  // como snapshot del servidor — ahora las tareas son entidades de primera
+  // clase que se pueden crear offline y se sincronizan via la cola normal
+  // de pending_transactions.
+  //
+  // taskData: { name, notes, assetIds[], locationId, due }
+  // Retorna { success, message } de savePayload (encolado offline o exitoso online).
+  addTaskLog: async (taskData) => {
+    const logId = newId('log--task');
+    const ts = new Date().toISOString().split('.')[0] + '+00:00';
+
+    const relationships = {};
+    if (taskData.assetIds?.length) {
+      relationships.asset = {
+        data: taskData.assetIds.map((id) => ({ type: 'asset--plant', id })),
+      };
+    }
+    if (taskData.locationId) {
+      relationships.location = {
+        data: [{ type: 'asset--land', id: taskData.locationId }],
+      };
+    }
+
+    const payload = {
+      data: {
+        type: 'log--task',
+        id: logId,
+        attributes: {
+          name: taskData.name || 'Tarea',
+          timestamp: taskData.due || ts,
+          status: 'pending',
+          ...(taskData.notes && {
+            notes: { value: taskData.notes, format: 'plain_text' },
+          }),
+        },
+        ...(Object.keys(relationships).length > 0 && { relationships }),
+      },
+    };
+
+    // Optimistic local: el log aparece en la timeline al instante.
+    const optimisticLog = {
+      id: logId,
+      type: 'log--task',
+      asset_id: taskData.assetIds?.[0] || null,
+      timestamp: Math.floor(Date.now() / 1000),
+      name: payload.data.attributes.name,
+      status: 'pending',
+      attributes: payload.data.attributes,
+      relationships,
+      _pending: true,
+    };
+
+    try {
+      await logCache.put(optimisticLog);
+      if (taskData.assetIds?.[0]) {
+        useLogStore.getState().loadLogsForAsset(taskData.assetIds[0]);
+      }
+    } catch (logErr) {
+      console.warn('[Store] Fallo persistir log--task optimista (no bloqueante):', logErr);
+    }
+
+    return savePayload('task', payload);
+  },
+
+  // ADR-019 Fase 5: Completar una tarea sin mutar el log original (Regla 1).
+  // Crea un SEGUNDO log--task con marker [TASK_COMPLETION] en notes.value
+  // apuntando al log--task original via target_task_id. Patrón consistente
+  // con [AI_REVIEW] de Fase 3 — la timeline cruza ambos logs y muestra el
+  // estado actual sin necesidad de mutar el primero.
+  //
+  // verdict: 'completed' | 'cancelled' | 'rescheduled'
+  completeTaskLog: async (originalTaskId, verdict = 'completed', notes = '') => {
+    const logId = newId('log--task');
+    const ts = new Date().toISOString().split('.')[0] + '+00:00';
+
+    const noteLines = [
+      '[TASK_COMPLETION]',
+      `target_task_id: ${originalTaskId}`,
+      `verdict: ${verdict}`,
+      `completed_at: ${new Date().toISOString()}`,
+    ];
+    if (notes) noteLines.push('', '--- Nota ---', notes);
+
+    const payload = {
+      data: {
+        type: 'log--task',
+        id: logId,
+        attributes: {
+          name: `Tarea ${verdict === 'completed' ? 'completada' : verdict}`,
+          timestamp: ts,
+          status: 'done',
+          notes: { value: noteLines.join('\n'), format: 'plain_text' },
+        },
+      },
+    };
+
+    return savePayload('task', payload);
   },
 
   // Obtener todos los assets como lista plana


### PR DESCRIPTION
## Summary

Foundation de Fase 5 — última del plan ADR-019. Backend API listo, UI integration en próximo chunk.

- Fix drive-by: `payloadService.resolveEndpoint` ahora maneja `'observation'` y `'task'` correctamente. Fase 1 caía silenciosamente al default `/api/log/seeding` para observation (bug latente — test era .skip).
- `addTaskLog(taskData)`: crea `log--task` con ULID, optimistic local + savePayload dispatch.
- `completeTaskLog(taskId, verdict, notes)`: crea SEGUNDO log--task con marker `[TASK_COMPLETION]` apuntando al original. Patrón inmutable (Regla 1) consistente con `[AI_REVIEW]` de Fase 3.

**No incluye** UI de creación ni refactor de `pending_tasks` snapshot. Eso es el próximo chunk; prompt para Antigravity en `Chagra-strategy/ops/antigravity-prompts/fase-5-log-task.md` (sections B y C).

## Merge order entre los 3 PRs abiertos

- PR #45 Fase 4 → bump 0.8.0
- PR #46 Telemetry → bump 0.7.2
- Este PR → sin bump (defer)

Sugerencia merge: #46 → main 0.7.2; #45 rebased → main 0.8.0; este rebased + bump 0.8.1.

Refs ADR-019 Fase 5 (parcial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
