### PR TITLE
chore(anti-leak): scrub strategic content + extend PROHIBITED + lefthook

### DIFF
--- a/.github/ISSUE_TEMPLATE/claude-code-request.yml
+++ b/.github/ISSUE_TEMPLATE/claude-code-request.yml
@@ -1,14 +1,12 @@
 name: Claude Code Request
-description: Feature, bug fix, o tarea para ser tomada por el pipeline automático (OpenFang → GH Issue → code-gen agent → PR)
+description: Feature, bug fix, o tarea para ser tomada por el pipeline automatizado (GH Issue → code-gen agent → draft PR)
 title: "[<TIPO>] <descripción corta>"
 labels: ["claude-code-request"]
 body:
   - type: markdown
     attributes:
       value: |
-        Este issue dispara el pipeline automático `claude-code-request.yml`. El runner crea una rama, deja un stub, y abre draft PR. El agente de code-generation (aider con GLM-5, instalado en alpha runner futuro) ejecuta cuando el operador lo invoca.
-
-        Ver ADR-018 en `Chagra-strategy/adrs/` para el principio de mitigación de burnout vía automatización.
+        Este issue dispara el pipeline automático `claude-code-request.yml`. El runner crea una rama, deja un stub, y abre draft PR. Un agente de code-generation ejecuta cuando el operador lo invoca.
 
   - type: dropdown
     id: tipo

--- a/.github/workflows/claude-code-request.yml
+++ b/.github/workflows/claude-code-request.yml
@@ -1,16 +1,15 @@
 name: Claude Code Request
 
-# Ver ADR-018 (Chagra-strategy/adrs/ADR-018-burnout-mitigation-automation.md)
+# Pipeline automatizado de intake.
 #
 # Trigger: issue labeled "claude-code-request". Crea rama, deja stub con el
-# body del issue, abre DRAFT PR. El agente de code-generation (aider + GLM-5
-# en alpha runner futuro) consume este stub y lo reemplaza por commits reales
-# cuando se invoca manualmente (post-demo setup).
+# body del issue, abre DRAFT PR. Un agente de code-generation consume este
+# stub y lo reemplaza por commits reales cuando se invoca manualmente.
 #
 # HUMAN-IN-LOOP POR DISEÑO:
 # - PR nace siempre como draft
 # - Workflow NUNCA hace merge
-# - Label 'ready-to-generate' pendiente para disparar code-gen (futuro)
+# - Label 'ready-to-generate' pendiente para disparar code-gen
 # - Notifica al operador por Telegram al abrir el draft PR
 
 on:
@@ -82,7 +81,7 @@ jobs:
             echo
             echo "---"
             echo
-            echo "**Esto es un stub.** El agente de code-generation (aider + GLM-5 en alpha runner) reemplazará este archivo y/o hará los cambios solicitados cuando sea invocado con la label \`ready-to-generate\` (flujo futuro)."
+            echo "**Esto es un stub.** El agente de code-generation reemplazará este archivo y/o hará los cambios solicitados cuando sea invocado con la label \`ready-to-generate\` (flujo futuro)."
           } > "$STUB"
           git add "$STUB"
           git commit -m "chore(request): bootstrap branch for issue #${ISSUE_NUM}"
@@ -103,7 +102,7 @@ jobs:
 
           ## Siguiente paso
 
-          Cuando el agente de code-gen (aider + GLM-5) esté activo en alpha runner, añadir la label \`ready-to-generate\` a este PR para disparar la ejecución. Hasta entonces, este PR queda como stub.
+          Cuando el agente de code-gen esté activo, añadir la label \`ready-to-generate\` a este PR para disparar la ejecución. Hasta entonces, este PR queda como stub.
 
           ## Gates humanos
 
@@ -122,7 +121,7 @@ jobs:
           - Rama: \`${{ steps.parse.outputs.branch }}\`
           - Draft PR: ${{ steps.pr.outputs.pr_url }}
 
-          El agente de code-generation lo recoge cuando el operador añada la label \`ready-to-generate\` al PR (flujo futuro post-demo). Gates humanos garantizan que no se mergea sin revisión."
+          El agente de code-generation lo recoge cuando el operador añada la label \`ready-to-generate\` al PR (flujo futuro). Gates humanos garantizan que no se mergea sin revisión."
 
       - name: Notify Telegram (non-blocking)
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,24 @@ Este repo es público AGPL-3.0. NO importar estáticamente de `chagra-pro`. Inte
 ## Anti-leak
 
 - Sin URLs internas, IPs RFC1918, tokens, secretos, hostnames operativos. Ver `CONTRIBUTING.md` reglas 1-7.
-- Pre-commit `lefthook` corre escaneo + ESLint `--max-warnings=0` + bloqueo de imports estáticos a `chagra-pro`.
+- Pre-commit `lefthook` corre escaneo + ESLint `--max-warnings=0` + bloqueo de imports estáticos a `chagra-pro` + `strategic-content-scan`.
 - Post-build `npm run audit:bundle` verifica `dist/` contra `oss-pro/PROHIBITED_IN_PUBLIC.md`.
+
+## Contenido estratégico — boundary
+
+Más allá de identificadores técnicos, **no introducir contenido descriptivo de**:
+
+- **Modelo de negocio** (pricing, tiers, revenue, cap table, valuación, founding team).
+- **Estrategia / roadmap futuro** que telegrafía Pro o monetización antes de release público.
+- **Identidad personal** del operador o trabajadores (nombres reales hardcoded; usar env var `VITE_PRIMARY_WORKER_NAME` o equivalente, default genérico).
+- **Infraestructura operativa propia** (nombres de hosts internos, agentes, código-gen pipelines internos).
+- **ADRs estratégicos** por nombre o resumen: ADR-009/010/014/017/018 son privados. Las **referencias por número son OK**; añadir el título o un resumen entre paréntesis es leak.
+
+ADRs OK-públicos (técnicos/legales): ADR-002, ADR-008, ADR-011, ADR-013, ADR-015, ADR-019.
+
+Lista universal de patterns en `oss-pro/PROHIBITED_IN_PUBLIC.md`. Identificadores específicos (nombres internos de agentes, infra propia) viven en `chagra-pro/PROHIBITED_INTERNAL.md` y se cargan en lefthook si `CHAGRA_PRO_PATH` está set localmente.
+
+Cuando dudes si algo es estratégico, default privado y consulta. El leak histórico de la industria (Anthropic 2026-03-31, sourcemap) cuesta menos como precaución que como remediation.
 
 ## Merge gates obligatorios
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -26,7 +26,7 @@ pre-commit:
         [ -z "$files" ] && exit 0
         # Filtra archivos de reglas + docs que legítimamente discuten los
         # patterns como texto de normativa.
-        filtered=$(echo "$files" | tr ' ' '\n' | grep -vE "^(oss-pro/PROHIBITED|lefthook\.yml|oss-pro/README\.md|CONTRIBUTING\.md)" || true)
+        filtered=$(echo "$files" | tr ' ' '\n' | grep -vE "^(oss-pro/PROHIBITED|lefthook\.yml|oss-pro/README\.md|CONTRIBUTING\.md|AGENTS\.md)" || true)
         [ -z "$filtered" ] && exit 0
         hits=$(echo "$filtered" | xargs grep -lnE "\b10\.[0-9]+\.[0-9]+\.[0-9]+|\b192\.168\.[0-9]+\.[0-9]+|\b172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|guatoc-nixos" 2>/dev/null || true)
         if [ -n "$hits" ]; then
@@ -34,6 +34,40 @@ pre-commit:
           echo "$hits"
           echo "Ver CONTRIBUTING.md §1-§2"
           exit 1
+        fi
+
+    strategic-content-scan:
+      tags: security
+      glob: "*.{md,js,jsx,ts,tsx,json,yaml,yml}"
+      run: |
+        files="{staged_files}"
+        [ -z "$files" ] && exit 0
+        # Filtra archivos de reglas + docs que legítimamente discuten los
+        # patterns como texto de normativa.
+        filtered=$(echo "$files" | tr ' ' '\n' | grep -vE "^(oss-pro/PROHIBITED|lefthook\.yml|oss-pro/README\.md|CONTRIBUTING\.md|AGENTS\.md)" || true)
+        [ -z "$filtered" ] && exit 0
+        # Patrones universales — identificadores específicos (codenames de
+        # agentes propios, infra interna) viven en chagra-pro/PROHIBITED_INTERNAL.md
+        # y se cargan adicionalmente si CHAGRA_PRO_PATH está set.
+        hits=$(echo "$filtered" | xargs grep -lEi "burnout|cap[.-]table|founding[.-]team|valuation|mollison[._-]?adapt|lawton[._-]?curated|ADR-(009|010|014|017|018)\s*\(" 2>/dev/null || true)
+        if [ -n "$hits" ]; then
+          echo "✗ Contenido estratégico filtrado al público en:"
+          echo "$hits"
+          echo "Ver oss-pro/PROHIBITED_IN_PUBLIC.md sección 'Contenido estratégico'"
+          exit 1
+        fi
+        # Carga PROHIBITED_INTERNAL si está disponible (dev local con Pro path)
+        if [ -n "$CHAGRA_PRO_PATH" ] && [ -f "$CHAGRA_PRO_PATH/PROHIBITED_INTERNAL.md" ]; then
+          while IFS= read -r pat; do
+            [ -z "$pat" ] && continue
+            hit=$(echo "$filtered" | xargs grep -lE "$pat" 2>/dev/null || true)
+            if [ -n "$hit" ]; then
+              echo "✗ Identifier interno en bundle público:"
+              echo "  Pattern: $pat"
+              echo "  En: $hit"
+              exit 1
+            fi
+          done < <(awk '/^- `[^`]+`/{ gsub(/^- `|`.*$/,""); print }' "$CHAGRA_PRO_PATH/PROHIBITED_INTERNAL.md")
         fi
 
     pro-import-scan:

--- a/oss-pro/PROHIBITED_IN_PUBLIC.md
+++ b/oss-pro/PROHIBITED_IN_PUBLIC.md
@@ -48,12 +48,30 @@ Ver ADR-015 (guatoc-ecohub/Chagra-strategy) para contexto — incidente Anthropi
 - `\b192\.168\.[0-9]{1,3}\.[0-9]{1,3}\b` — IP completa RFC 1918 (rango 192.168/16)
 - `chagra\.guatoc\.co` — dominio operativo del backend (frontend público usa rutas relativas `/api/...`, nunca hostname)
 
+## Contenido estratégico (lista universal)
+
+Patrones que describen estrategia, modelo de negocio, infraestructura
+operativa propia o identidad personal y nunca deben aparecer en el público.
+Identificadores específicos (codenames de agentes propios, infra interna)
+viven en `chagra-pro/PROHIBITED_INTERNAL.md` para no telegrafiar.
+
+- `burnout` — telegrafía contexto personal/operativo del operador
+- `cap[.-]table`, `founding[.-]team`, `valuation` — info societaria
+- `mollison[._-]?adapt`, `lawton[._-]?curated` — copyright tercero adaptado
+- `ADR-(009|010|014|017|018)\s*\(` — referencia descriptiva a ADRs
+  estratégicos (con paréntesis explicando contenido). Citar el número
+  como referencia es OK; añadir título o resumen es leak.
+- Identidad personal del operador o trabajadores hardcoded en código.
+  Usar env var `VITE_PRIMARY_WORKER_NAME` (o equivalente) con default
+  genérico tipo 'Trabajador'.
+
 ## Qué NO está prohibido (pero requiere cuidado)
 
 Nombres y textos perfectamente aceptables en el público:
 - `gremio`, `roles_in_guild`, `companions`, `antagonists` — lenguaje del dominio público del catálogo
 - `Chagra Pro` mencionado en docs (`README`, `CONTRIBUTING`, ADRs linkeados) — referencia al repo hermano
-- Variables `VITE_PRO_MODULES_PATH` — es el mecanismo declarado para dev local con chagra-pro presente
+- Variables `VITE_PRO_MODULES_PATH`, `VITE_PRIMARY_WORKER_NAME` — mecanismos declarados para configuración por deploy
+- ADR-002, ADR-008, ADR-011, ADR-013, ADR-015, ADR-019 — son técnicos/legales y pueden referenciarse en código y docs (incluso con título o resumen breve)
 
 ## Actualización
 

--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -184,7 +184,7 @@ export default function AssetTimeline({ assetId }) {
                               '[AI_REVIEW]',
                               `target_log_id: ${log.id}`,
                               `verdict: ${verdict}`,
-                              `reviewer_id: ${PRIMARY_WORKER_NAME}`, // TODO: reemplazar por auth user_id cuando ADR-016 conecte la consola de curación
+                              `reviewer_id: ${PRIMARY_WORKER_NAME}`, // TODO: reemplazar por auth user_id cuando el flujo de validación tenga identidades formales
                               `reviewed_at: ${new Date().toISOString()}`,
                               'notes: Revisión desde timeline local'
                             ].join('\n'),

--- a/src/config/workerConfig.js
+++ b/src/config/workerConfig.js
@@ -1,5 +1,10 @@
 /**
  * workerConfig.js — Identidad del operario principal.
  * Centraliza el nombre para evitar hardcoding en componentes y rutas.
+ *
+ * Configurable por deploy via env var VITE_PRIMARY_WORKER_NAME (Vite la
+ * inyecta en build-time). Default genérico 'Trabajador' protege el bundle
+ * público contra leak de identidad personal.
  */
-export const PRIMARY_WORKER_NAME = 'Javier';
+export const PRIMARY_WORKER_NAME =
+  import.meta.env.VITE_PRIMARY_WORKER_NAME || 'Trabajador';

--- a/tests/invasive.spec.js
+++ b/tests/invasive.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-// TODO(adr-019-phase1): este E2E está pendiente de validación end-to-end en CI.
-// Antigravity reportó que no pudo correrlo localmente (falta libgbm.so.1) y al
+// TODO: este E2E está pendiente de validación end-to-end en CI.
+// El agente de code-gen no pudo correrlo localmente (falta libgbm.so.1) y al
 // inspeccionarlo encontramos selectores y regex que matcheaban texto inexistente.
 // Quedan arreglados los más obvios (regex de notas, sugerencia nativa); el resto
 // requiere ejecución real en runner Playwright para iterar. Marcado .skip hasta


### PR DESCRIPTION
## Summary

Sanity check del repo público: scrub de contenido que telegrafía estrategia, infra operativa propia, o identidad personal hardcoded. Establece política going-forward via PROHIBITED + lefthook + AGENTS.md.

### Scrub current state
- `workerConfig.js`: PRIMARY_WORKER_NAME ahora env var `VITE_PRIMARY_WORKER_NAME`, default 'Trabajador'.
- 4 archivos con referencias descriptivas a ADRs estratégicos y a infra de code-gen específica → neutralizadas.
- Comentarios de tests con nombre específico de agente → 'agente code-gen'.

### Going-forward enforcement
- `oss-pro/PROHIBITED_IN_PUBLIC.md`: nueva sección 'Contenido estratégico'.
- `lefthook.yml`: nuevo hook `strategic-content-scan` + carga de PROHIBITED_INTERNAL si `CHAGRA_PRO_PATH` está set.
- `AGENTS.md`: sección 'Contenido estratégico — boundary' con lista de ADRs OK vs LEAK + regla de identidad personal.

### No history rewrite
Commits anteriores quedan; costo del force-push desproporcionado al leak.

Refs ADR-002, ADR-015. Política formalizada como ADR-020 en strategy (commit separado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
