### PR TITLE
fix(catalog): retry-on-fail + loading/error states + eager preload (v0.8.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { isAuthenticated, logoutUser } from './services/authService';
 import useAssetStore from './store/useAssetStore';
 import { fetchFromFarmOS } from './services/apiService';
 import { PRIMARY_WORKER_NAME } from './config/workerConfig';
+import { initCatalog } from './db/catalogDB';
 import { version as APP_VERSION } from '../package.json';
 import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
@@ -220,6 +221,18 @@ export default function App() {
       navigate(isAuth ? 'dashboard' : 'login');
     });
   }, [navigate]);
+
+  // Preload del catálogo SQLite WASM en background (v0.8.2). Inicializa la
+  // DB cuando la app arranca para que la primera apertura de los flows que
+  // consultan el catálogo (InvasiveObservationLog, NativeSubstituteSuggestion,
+  // etc.) no espere el download del .sqlite (~135KB) ni la inicialización
+  // del WASM. Si falla, el catalogDB log lo registra y los componentes
+  // muestran su propio empty/error state.
+  useEffect(() => {
+    initCatalog().catch((err) => {
+      console.warn('[App] Catálogo no se pudo preload (los componentes lo reintentarán al usarlos):', err);
+    });
+  }, []);
 
   const showToast = useCallback((message, isError = false) => {
     setToast({ message, isError });

--- a/src/components/InvasiveObservationLog.jsx
+++ b/src/components/InvasiveObservationLog.jsx
@@ -17,6 +17,10 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
         locationId: initialLocationId || '',
     });
     const [speciesList, setSpeciesList] = useState([]);
+    // 'loading' | 'ready' | 'error' — refleja el estado del fetch del catálogo.
+    // Sin esto, un fallo silencioso dejaba el selector vacío sin diagnóstico
+    // y el usuario quedaba bloqueado (no podía guardar).
+    const [catalogStatus, setCatalogStatus] = useState('loading');
     const [photo, setPhoto] = useState(null);
     const [photoUrl, setPhotoUrl] = useState(null);
     const [location, setLocation] = useState(initialWkt ? { wkt: initialWkt } : null);
@@ -26,10 +30,27 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
     const [selectedInvasive, setSelectedInvasive] = useState(null);
 
     useEffect(() => {
-        // Cargar especies invasoras del catálogo
-        getAllSpecies().then(all => {
-            setSpeciesList(all.filter(s => s.category === 'especies_invasoras'));
-        });
+        // Cargar especies invasoras del catálogo. Manejo defensivo contra
+        // fallo de inicialización SQLite WASM: si /catalog.sqlite no responde
+        // o OPFS está bloqueado, la promesa rechaza y antes el usuario veía
+        // un selector vacío sin diagnóstico. Ahora exponemos el error.
+        let cancelled = false;
+        getAllSpecies()
+            .then((all) => {
+                if (cancelled) return;
+                const invasoras = all.filter((s) => s.category === 'especies_invasoras');
+                setSpeciesList(invasoras);
+                setCatalogStatus('ready');
+                if (invasoras.length === 0) {
+                    console.warn('[InvasiveObservationLog] Catálogo cargado pero sin especies invasoras (filter category=especies_invasoras devolvió 0).');
+                }
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                console.error('[InvasiveObservationLog] Falló carga del catálogo:', err);
+                setCatalogStatus('error');
+            });
+        return () => { cancelled = true; };
     }, []);
 
     const handleInput = (e) => {
@@ -203,13 +224,33 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
                         name="speciesId"
                         value={formData.speciesId}
                         onChange={handleInput}
-                        className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none"
+                        disabled={catalogStatus !== 'ready' || speciesList.length === 0}
+                        className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none disabled:opacity-50"
                     >
-                        <option value="">Selecciona especie...</option>
-                        {speciesList.map(s => (
-                            <option key={s.id} value={s.id}>{s.nombre_comun}</option>
-                        ))}
+                        {catalogStatus === 'loading' && (
+                            <option value="">Cargando catálogo…</option>
+                        )}
+                        {catalogStatus === 'error' && (
+                            <option value="">Error cargando catálogo — recarga la app</option>
+                        )}
+                        {catalogStatus === 'ready' && speciesList.length === 0 && (
+                            <option value="">No hay especies invasoras en el catálogo</option>
+                        )}
+                        {catalogStatus === 'ready' && speciesList.length > 0 && (
+                            <>
+                                <option value="">Selecciona especie…</option>
+                                {speciesList.map((s) => (
+                                    <option key={s.id} value={s.id}>{s.nombre_comun}</option>
+                                ))}
+                            </>
+                        )}
                     </select>
+                    {catalogStatus === 'error' && (
+                        <p className="text-sm text-red-400 mt-1">
+                            No se pudo cargar el catálogo de especies. Verifica conexión y refresca.
+                            Si persiste, revisa la consola del navegador.
+                        </p>
+                    )}
                 </label>
 
                 <div className="flex flex-col gap-2">

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -3,57 +3,71 @@ import sqlite3InitModule from '@sqlite.org/sqlite-wasm';
 let dbInstance = null;
 let initPromise = null;
 
-export async function initCatalog() {
-    if (initPromise) return initPromise;
-    initPromise = (async () => {
+async function doInit() {
+    const sqlite3 = await sqlite3InitModule({
+        print: console.log,
+        printErr: console.error,
+    });
+    console.log('[SQLite WASM] Engine loaded successfully.');
+
+    const response = await fetch('/catalog.sqlite');
+    if (!response.ok) {
+        throw new Error(`Failed to fetch /catalog.sqlite: HTTP ${response.status} ${response.statusText}`);
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const uint8Array = new Uint8Array(arrayBuffer);
+
+    let db = null;
+    if (sqlite3.opfs && typeof navigator !== 'undefined' && navigator.storage && navigator.storage.getDirectory) {
         try {
-            const sqlite3 = await sqlite3InitModule({
-                print: console.log,
-                printErr: console.error,
-            });
-            console.log('[SQLite WASM] Engine loaded successfully.');
+            const root = await navigator.storage.getDirectory();
+            // Write to OPFS root directory
+            const fileHandle = await root.getFileHandle('catalog.sqlite', { create: true });
+            const writable = await fileHandle.createWritable();
+            await writable.write(uint8Array);
+            await writable.close();
 
-            const response = await fetch('/catalog.sqlite');
-            if (!response.ok) throw new Error('Failed to fetch /catalog.sqlite');
-            const arrayBuffer = await response.arrayBuffer();
-            const uint8Array = new Uint8Array(arrayBuffer);
-
-            let db = null;
-            if (sqlite3.opfs && typeof navigator !== 'undefined' && navigator.storage && navigator.storage.getDirectory) {
-                try {
-                    const root = await navigator.storage.getDirectory();
-                    // Write to OPFS root directory
-                    const fileHandle = await root.getFileHandle('catalog.sqlite', { create: true });
-                    const writable = await fileHandle.createWritable();
-                    await writable.write(uint8Array);
-                    await writable.close();
-
-                    db = new sqlite3.oo1.OpfsDb('/catalog.sqlite');
-                    console.log('[SQLite WASM] Opened SQLite DB backed by OPFS');
-                } catch (e) {
-                    console.warn('[SQLite WASM] Failed to use OPFS cleanly in this thread. Falling back to memory...', e);
-                }
-            }
-
-            if (!db) {
-                // Fallback: transient Memory (deserialization)
-                const p = sqlite3.wasm.allocFromTypedArray(uint8Array);
-                db = new sqlite3.oo1.DB();
-                const deserializeFlag = sqlite3.capi.SQLITE_DESERIALIZE_FREEONCLOSE;
-                const rc = sqlite3.capi.sqlite3_deserialize(
-                    db.pointer, 'main', p, uint8Array.byteLength, uint8Array.byteLength, deserializeFlag
-                );
-                if (rc !== 0) throw new Error('Deserialize failed with code ' + rc);
-                console.log('[SQLite WASM] Opened SQLite DB locally from Memory deserialization');
-            }
-
-            dbInstance = db;
-            return db;
-        } catch (error) {
-            console.error('[SQLite WASM] Failed to initialize catalog db:', error);
-            throw error;
+            db = new sqlite3.oo1.OpfsDb('/catalog.sqlite');
+            console.log('[SQLite WASM] Opened SQLite DB backed by OPFS');
+        } catch (e) {
+            console.warn('[SQLite WASM] Failed to use OPFS cleanly in this thread. Falling back to memory...', e);
         }
-    })();
+    }
+
+    if (!db) {
+        // Fallback: transient Memory (deserialization)
+        const p = sqlite3.wasm.allocFromTypedArray(uint8Array);
+        db = new sqlite3.oo1.DB();
+        const deserializeFlag = sqlite3.capi.SQLITE_DESERIALIZE_FREEONCLOSE;
+        const rc = sqlite3.capi.sqlite3_deserialize(
+            db.pointer, 'main', p, uint8Array.byteLength, uint8Array.byteLength, deserializeFlag
+        );
+        if (rc !== 0) throw new Error('Deserialize failed with code ' + rc);
+        console.log('[SQLite WASM] Opened SQLite DB locally from Memory deserialization');
+    }
+
+    return db;
+}
+
+export async function initCatalog() {
+    // Si dbInstance ya está, devolverlo de inmediato.
+    if (dbInstance) return dbInstance;
+    // Si hay init en vuelo, devolver esa promesa (evita race conditions).
+    if (initPromise) return initPromise;
+
+    initPromise = doInit().then((db) => {
+        dbInstance = db;
+        return db;
+    }).catch((error) => {
+        // Bug fix v0.8.2: si init falla, limpiamos initPromise para permitir
+        // retry en la próxima llamada. Sin esto, una falla inicial (ej.
+        // /catalog.sqlite 404 transitorio, OPFS bloqueado) dejaba el catálogo
+        // permanentemente broken hasta refresh manual.
+        initPromise = null;
+        console.error('[SQLite WASM] Failed to initialize catalog db:', error);
+        throw error;
+    });
+
     return initPromise;
 }
 


### PR DESCRIPTION
## Summary

Fix de 3 bugs encadenados que causaban que el selector de especies invasoras se viera vacío:

1. **catalogDB.initCatalog() no permitía retry** tras fallo — initPromise quedaba como promesa rechazada permanente.
2. **InvasiveObservationLog sin .catch()** — fallo silencioso dejaba speciesList vacío sin diagnóstico.
3. **No había preload del catálogo en App startup** — primera apertura del flow esperaba 135KB de fetch + WASM init.

## Test plan

- [ ] Abrir Reportar invasora → ver "Cargando catálogo..." mientras llega, luego selector con 4 invasoras (Retamo, Ojo de poeta, Kikuyo, Helecho marranero).
- [ ] Si falla la red al primer intento, recargar — debe funcionar (retry permitido).
- [ ] App startup: console muestra '[SQLite WASM] Engine loaded' temprano (preload activo).

Refs ADR-019 Fase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
