### PR TITLE
feat(sky): badge luna+sol header, prompt sin hardcode bosque andino

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v29';
+const CACHE_NAME = 'chagra-v30';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import PendingTasksWidget from './components/PendingTasksWidget';
 import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
 import AltitudeBadge from './components/AltitudeBadge';
+import SkyBadge from './components/common/SkyBadge';
 
 // Lazy-loaded route components
 const TelemetryAlerts = lazy(() => import('./components/TelemetryAlerts'));
@@ -125,6 +126,7 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
           Chagra
           <span className="text-[10px] text-slate-500 font-mono font-normal">v{APP_VERSION}</span>
           <AltitudeBadge />
+          <SkyBadge />
         </h1>
         <div className="flex items-center gap-2">
           <button onClick={onLogout} aria-label="Cerrar sesión" className="text-slate-400 hover:text-white px-4 min-h-[44px] bg-slate-800 rounded text-sm">Salir</button>

--- a/src/components/common/SkyBadge.jsx
+++ b/src/components/common/SkyBadge.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { lunarPhase, solarTimes, formatLocalHM, formatDayLength } from '../../utils/skyEphemeris';
+import { FARM_CONFIG } from '../../config/defaults';
+
+/**
+ * SkyBadge — fase lunar + horas solares en el header.
+ *
+ * Muestra: 🌗 Cuarto · ☀ 5:42-17:53
+ * Hover/title revela detalle: nombre completo, iluminación, día/noche, día.
+ *
+ * Cálculo determinístico local (utils/skyEphemeris). Se refresca cada hora.
+ * No emite recomendaciones agronómicas (literatura no robusta).
+ */
+export default function SkyBadge() {
+  const [snapshot, setSnapshot] = useState(() => computeSnapshot());
+
+  useEffect(() => {
+    const id = setInterval(() => setSnapshot(computeSnapshot()), 60 * 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { lunar, solar } = snapshot;
+  const lunarTitle = `${lunar.name} · ${Math.round(lunar.illumination * 100)}% iluminación · ${Math.round(lunar.daysSinceNewMoon)}d desde luna nueva`;
+  const solarTitle = solar.sunrise && solar.sunset
+    ? `Salida ${formatLocalHM(solar.sunrise)} · puesta ${formatLocalHM(solar.sunset)} · día ${formatDayLength(solar.dayLengthMinutes)} · ${solar.isDaylight ? 'sol arriba' : 'sol abajo'}`
+    : 'Coordenadas no configuradas — sin cálculo solar';
+
+  return (
+    <span
+      className="text-[10px] text-slate-500 font-mono font-normal inline-flex items-center gap-1 ml-1"
+      aria-label="Información lunar y solar"
+    >
+      <span title={lunarTitle} className="inline-flex items-center gap-0.5 cursor-help">
+        <span aria-hidden="true">{lunar.icon}</span>
+        <span className="hidden sm:inline">{shortLunarName(lunar.name)}</span>
+      </span>
+      {solar.sunrise && (
+        <span title={solarTitle} className="inline-flex items-center gap-0.5 cursor-help">
+          <span aria-hidden="true">{solar.isDaylight ? '☀' : '🌙'}</span>
+          <span>{formatLocalHM(solar.sunrise)}-{formatLocalHM(solar.sunset)}</span>
+        </span>
+      )}
+    </span>
+  );
+}
+
+function computeSnapshot() {
+  const now = new Date();
+  const lat = FARM_CONFIG.LATITUDE;
+  const lon = FARM_CONFIG.LONGITUDE;
+  const lunar = lunarPhase(now, { latitude: lat ?? 0 });
+  const solar = lat != null && lon != null
+    ? solarTimes(now, lat, lon)
+    : { sunrise: null, sunset: null, solarNoon: null, dayLengthMinutes: 0, isDaylight: false };
+  return { lunar, solar };
+}
+
+function shortLunarName(name) {
+  return name
+    .replace('Luna ', '')
+    .replace('Cuarto ', '¼ ')
+    .replace('Gibosa ', 'Gibosa ');
+}

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -18,4 +18,12 @@ export const FARM_CONFIG = {
         .split(',')
         .map((s) => s.trim())
         .filter(Boolean),
+  // Coordenadas usadas por skyEphemeris (sunrise/sunset). Default Choachí.
+  // En prod se sobreescriben con VITE_FARM_LAT / VITE_FARM_LON.
+  LATITUDE: DEMO_MODE
+    ? 4.526
+    : (Number(import.meta.env.VITE_FARM_LAT) || 4.526),
+  LONGITUDE: DEMO_MODE
+    ? -73.922
+    : (Number(import.meta.env.VITE_FARM_LON) || -73.922),
 };

--- a/src/services/guildService.js
+++ b/src/services/guildService.js
@@ -12,6 +12,7 @@
 
 import { SPECIES_DEFAULTS } from '../config/speciesDefaults';
 import { CROP_TAXONOMY } from '../config/taxonomy';
+import { FARM_CONFIG } from '../config/defaults';
 
 // Flatten de todas las especies con su grupo para resolución rápida.
 const ALL_SPECIES = Object.entries(CROP_TAXONOMY).flatMap(([groupId, group]) =>
@@ -128,7 +129,16 @@ export const getSuggestedCompanions = (speciesId) => {
  * El caller envía esto a /api/ollama/api/generate y parsea el JSON response.
  */
 export const buildGuildPrompt = (speciesName, estrato) => {
-  return `Basado en principios de agroecología de Jairo Restrepo y permacultura (diseño de gremios), sugiere 3 plantas acompañantes para ${speciesName} en estrato ${estrato} en clima frío tropical andino (2000-2800 msnm, Cundinamarca). Responde SOLO en formato JSON array: [{"name":"Nombre común (Nombre científico)","reason":"Razón agroecológica breve"}]. No añadas texto fuera del JSON.`;
+  // Contexto geoagronómico desde FARM_CONFIG. Sin hardcode a bosque andino:
+  // el asistente debe atender el rango colombiano completo del páramo
+  // (>3000m) al nivel del mar.
+  const altitud = FARM_CONFIG.ALTITUD_MSNM;
+  const zonas = (FARM_CONFIG.THERMAL_ZONES || []).join(', ') || 'no especificada';
+  const municipio = FARM_CONFIG.MUNICIPIO || 'Colombia';
+  const ctxAltitud = altitud != null
+    ? `a ${altitud} msnm (piso térmico: ${zonas})`
+    : `(piso térmico: ${zonas})`;
+  return `Basado en principios de agroecología de Jairo Restrepo y permacultura (diseño de gremios), sugiere 3 plantas acompañantes para ${speciesName} en estrato ${estrato} en ${municipio} ${ctxAltitud}. Considera el rango colombiano completo desde el páramo (>3000m) hasta el nivel del mar al evaluar compañeros viables. Responde SOLO en formato JSON array: [{"name":"Nombre común (Nombre científico)","reason":"Razón agroecológica breve"}]. No añadas texto fuera del JSON.`;
 };
 
 export default getSuggestedCompanions;

--- a/src/utils/skyEphemeris.js
+++ b/src/utils/skyEphemeris.js
@@ -1,0 +1,151 @@
+/**
+ * skyEphemeris.js — Cálculos puros de fase lunar y horas solares.
+ *
+ * Algoritmos determinísticos sin dependencias externas (offline-first).
+ * Precisión esperada: lunar ±12h, solar ±2min. Suficiente para etiquetas
+ * informativas en header. NO apto para tareas astronómicas precisas.
+ *
+ * Sin sugerencias agronómicas en este módulo: solo cálculo. La UI puede
+ * agregar contexto si emerge evidencia robusta peer-reviewed.
+ */
+
+const SYNODIC_MONTH = 29.530588853; // días, ciclo lunar promedio
+const KNOWN_NEW_MOON = new Date('2000-01-06T18:14:00Z').getTime();
+const MS_PER_DAY = 86_400_000;
+const DEG = Math.PI / 180;
+
+function phaseNameFromFraction(f) {
+  if (f < 0.025 || f > 0.975) return 'Luna nueva';
+  if (f < 0.225) return 'Luna creciente';
+  if (f < 0.275) return 'Cuarto creciente';
+  if (f < 0.475) return 'Gibosa creciente';
+  if (f < 0.525) return 'Luna llena';
+  if (f < 0.725) return 'Gibosa menguante';
+  if (f < 0.775) return 'Cuarto menguante';
+  return 'Luna menguante';
+}
+
+const NORTH_ICONS = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'];
+const SOUTH_ICONS = ['🌑', '🌘', '🌗', '🌖', '🌕', '🌔', '🌓', '🌒'];
+
+function phaseIcon(f, southern = false) {
+  const set = southern ? SOUTH_ICONS : NORTH_ICONS;
+  if (f < 0.025 || f > 0.975) return set[0];
+  if (f < 0.225) return set[1];
+  if (f < 0.275) return set[2];
+  if (f < 0.475) return set[3];
+  if (f < 0.525) return set[4];
+  if (f < 0.725) return set[5];
+  if (f < 0.775) return set[6];
+  return set[7];
+}
+
+/**
+ * Calcula la fase lunar para una fecha dada.
+ * @param {Date} date Fecha (default: ahora).
+ * @param {{ latitude?: number }} opts Si latitude < 0, usa íconos hemisferio sur.
+ * @returns {{
+ *   fraction: number, illumination: number, name: string, icon: string,
+ *   daysSinceNewMoon: number, daysToFullMoon: number, daysToNewMoon: number
+ * }}
+ */
+export function lunarPhase(date = new Date(), { latitude = 0 } = {}) {
+  const elapsedDays = (date.getTime() - KNOWN_NEW_MOON) / MS_PER_DAY;
+  const cyclePosition = ((elapsedDays % SYNODIC_MONTH) + SYNODIC_MONTH) % SYNODIC_MONTH;
+  const fraction = cyclePosition / SYNODIC_MONTH;
+  const illumination = (1 - Math.cos(2 * Math.PI * fraction)) / 2;
+
+  const daysToFullMoon = ((0.5 - fraction + 1) % 1) * SYNODIC_MONTH;
+  const daysToNewMoon = ((1 - fraction) % 1) * SYNODIC_MONTH;
+
+  return {
+    fraction,
+    illumination,
+    name: phaseNameFromFraction(fraction),
+    icon: phaseIcon(fraction, latitude < 0),
+    daysSinceNewMoon: cyclePosition,
+    daysToFullMoon,
+    daysToNewMoon,
+  };
+}
+
+/**
+ * Calcula horas locales de salida/puesta del sol para fecha + lat/lon.
+ * Algoritmo NOAA simplificado. Precisión ~±2 min para latitudes templadas;
+ * en zonas polares (|lat| > 66.5°) puede devolver null para día/noche extendidas.
+ *
+ * @param {Date} date Fecha local.
+ * @param {number} latitude Grados, +N / -S.
+ * @param {number} longitude Grados, +E / -W.
+ * @returns {{
+ *   sunrise: Date|null, sunset: Date|null, solarNoon: Date|null,
+ *   dayLengthMinutes: number, isDaylight: boolean
+ * }}
+ */
+export function solarTimes(date, latitude, longitude) {
+  const yearStart = Date.UTC(date.getFullYear(), 0, 0);
+  const dayOfYear = Math.floor((date.getTime() - yearStart) / MS_PER_DAY);
+
+  // Solar declination (radians)
+  const decl = 23.45 * DEG * Math.sin(2 * Math.PI * (284 + dayOfYear) / 365);
+
+  // Hour angle at sunrise/sunset
+  const latRad = latitude * DEG;
+  const cosH = -Math.tan(latRad) * Math.tan(decl);
+
+  if (cosH > 1) {
+    return { sunrise: null, sunset: null, solarNoon: null, dayLengthMinutes: 0, isDaylight: false };
+  }
+  if (cosH < -1) {
+    return { sunrise: null, sunset: null, solarNoon: null, dayLengthMinutes: 24 * 60, isDaylight: true };
+  }
+  const H = Math.acos(cosH);
+  const halfDayMinutes = (H / DEG) * 4;
+
+  // Equation of time approximation (minutes)
+  const B = 2 * Math.PI * (dayOfYear - 81) / 364;
+  const eot = 9.87 * Math.sin(2 * B) - 7.53 * Math.cos(B) - 1.5 * Math.sin(B);
+
+  // Solar noon in minutes UTC
+  const solarNoonUTC = 720 - 4 * longitude - eot;
+  const sunriseMinUTC = solarNoonUTC - halfDayMinutes;
+  const sunsetMinUTC = solarNoonUTC + halfDayMinutes;
+
+  const baseUTC = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const sunrise = new Date(baseUTC + sunriseMinUTC * 60_000);
+  const sunset = new Date(baseUTC + sunsetMinUTC * 60_000);
+  const solarNoon = new Date(baseUTC + solarNoonUTC * 60_000);
+
+  const now = date.getTime();
+  const isDaylight = now >= sunrise.getTime() && now <= sunset.getTime();
+
+  return {
+    sunrise,
+    sunset,
+    solarNoon,
+    dayLengthMinutes: 2 * halfDayMinutes,
+    isDaylight,
+  };
+}
+
+/**
+ * Formatea una fecha como HH:MM en hora local (24h).
+ */
+export function formatLocalHM(date) {
+  if (!date) return '—';
+  return date.toLocaleTimeString('es-CO', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+/**
+ * Formatea minutos como "Xh Ym".
+ */
+export function formatDayLength(minutes) {
+  if (!Number.isFinite(minutes) || minutes <= 0) return '—';
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes - h * 60);
+  return `${h}h ${m.toString().padStart(2, '0')}m`;
+}


### PR DESCRIPTION
* SkyBadge — fase lunar (icono + nombre corto) + horas solares (sunrise→sunset hora local). Cálculo determinístico en utils/skyEphemeris.js sin deps; precisión ~±2min solar / ±12h lunar, suficiente para etiqueta informativa. Hover/title revela detalle (iluminación, día desde luna nueva, longitud del día, sol arriba/abajo). Icons hemisférico-aware via FARM_CONFIG.LATITUDE.
* defaults.js — nuevas FARM_CONFIG.LATITUDE / LONGITUDE (Choachí 4.526, -73.922 default; override via VITE_FARM_LAT / VITE_FARM_LON).
* guildService.buildGuildPrompt — eliminada hardcode "clima frío tropical andino (2000-2800 msnm, Cundinamarca)". Ahora lee FARM_CONFIG (altitud, zonas, municipio) e instruye considerar rango colombiano completo del páramo (>3000m) al nivel del mar.
* SIN sugerencias agronómicas por fase lunar v1: literatura peer-reviewed inconsistente. Badge solo info contextual.
* bump 0.8.2 → 0.8.3 + CACHE_NAME chagra-v29 → chagra-v30.