### PR TITLE
fix(security): cierra CodeQL #26 — replace no-op Gibosa→Gibosa

### DIFF
--- a/src/components/common/SkyBadge.jsx
+++ b/src/components/common/SkyBadge.jsx
@@ -59,5 +59,5 @@ function shortLunarName(name) {
   return name
     .replace('Luna ', '')
     .replace('Cuarto ', '¼ ')
-    .replace('Gibosa ', 'Gibosa ');
+    .replace('Gibosa ', 'Gib. ');
 }


### PR DESCRIPTION
## Resumen
Cierra CodeQL alert #26 (\`js/replace-substring-with-itself\`) en \`src/components/common/SkyBadge.jsx:62\`.

## Causa
El código original tenía:

\`\`\`js
.replace('Gibosa ', 'Gibosa ')
\`\`\`

— reemplaza un substring por sí mismo, no-op confuso. Detectado por CodeQL en el primer scan post-merge a main.

## Fix
Cambio a \`'Gib. '\` para abreviar consistente con el patrón \`'¼ '\` que ya se usa para "Cuarto creciente/menguante". Visualmente:

| Fase lunar | Antes | Ahora |
|-----------|-------|-------|
| Gibosa creciente | "Gibosa creciente" | "Gib. creciente" |
| Gibosa menguante | "Gibosa menguante" | "Gib. menguante" |

## Test plan
- [x] ESLint local: clean
- [x] Sin cambios en lógica (solo el string del label visible en hover)
- [ ] CodeQL re-scan en CI marca #26 como resolved
- [ ] Visual smoke test post-merge: SkyBadge muestra "Gib." cuando aplique