### PR TITLE
feat: 3 temas en perfil + log--task migration ADR-019 fase 5 (v0.9.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback } from 'react';
-import { Warehouse, MapPin, Eye, Package, Clock, ClipboardList, CheckCircle, WifiOff, Leaf, Mic, AlertCircle } from 'lucide-react';
+import { Warehouse, MapPin, Eye, Package, Clock, ClipboardList, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, User } from 'lucide-react';
 import localforage from 'localforage';
+import { useTheme } from './hooks/useTheme';
 
 import { isAuthenticated, logoutUser } from './services/authService';
 import useAssetStore from './store/useAssetStore';
@@ -26,6 +27,7 @@ const ObservationScreen = lazy(() => import('./components/ObservationScreen'));
 const InvasiveObservationLog = lazy(() => import('./components/InvasiveObservationLog'));
 const MaintenanceScreen = lazy(() => import('./components/MaintenanceScreen'));
 const TaskLogScreen = lazy(() => import('./components/TaskLogScreen'));
+const TaskScreen = lazy(() => import('./components/TaskScreen'));
 const AssetsDashboard = lazy(() => import('./components/AssetsDashboard'));
 const WorkerHistory = lazy(() => import('./components/WorkerHistory'));
 const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').then(m => ({ default: m.InventoryDashboard })));
@@ -33,6 +35,7 @@ const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
 const BiodiversidadView = lazy(() => import('./components/BiodiversidadView'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
+const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 
 localforage.config({
   name: 'Chagra',
@@ -58,6 +61,7 @@ const NAV_TILES = [
   { id: 'biodiversidad', label: 'Biodiversidad', icon: Leaf, accent: 'emerald', desc: 'Ecosistema, estratos y gremios' },
   { id: 'reportar_invasora', label: 'Invasoras', icon: AlertCircle, accent: 'amber', desc: 'Reporte de especies invasoras' },
   { id: 'voz', label: 'Voz', icon: Mic, accent: 'lime', desc: 'Registro por dictado (v0.5.0)' },
+  { id: 'perfil', label: 'Perfil', icon: Palette, accent: 'indigo', desc: 'Temas y configuración' },
 ];
 
 // Mapa de accents → clases Tailwind (para que el JIT genere los estilos).
@@ -192,6 +196,7 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
 });
 
 export default function App() {
+  useTheme();
   const [currentView, setCurrentView] = useState('loading');
   const [currentViewData, setCurrentViewData] = useState(null);
   const [toast, setToast] = useState(null);
@@ -276,7 +281,9 @@ export default function App() {
       case 'mantenimiento':
         return <MaintenanceScreen onBack={() => navigate('dashboard')} onSave={showToast} />;
       case 'task_log':
-        return <TaskLogScreen onBack={() => navigate('dashboard')} />;
+        return <TaskLogScreen onBack={() => navigate('dashboard')} onNewTask={() => navigate('new_task')} />;
+      case 'new_task':
+        return <TaskScreen onBack={() => navigate('task_log')} onSave={showToast} />;
       case 'javier':
         return (
           <ScreenShell title={`Campo — ${PRIMARY_WORKER_NAME}`} icon={Eye} onBack={() => navigate('dashboard')}>
@@ -310,6 +317,8 @@ export default function App() {
             <VoiceCapture onSave={showToast} />
           </ScreenShell>
         );
+      case 'perfil':
+        return <ProfileScreen onBack={() => navigate('dashboard')} />;
       default:
         return <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>;
     }

--- a/src/components/PendingTasksWidget.jsx
+++ b/src/components/PendingTasksWidget.jsx
@@ -14,25 +14,16 @@ export default function PendingTasksWidget() {
     setError(null);
 
     try {
-      // Obtener tareas reales de FarmOS (con caché offline)
+      // Fase 5: Obtener tareas reales del store unificado (log--task)
       const pendingTasks = await syncManager.fetchPendingTasksFromFarmOS();
-      console.log('📋 Tareas pendientes descargadas de FarmOS:', pendingTasks.length);
       setTasks(pendingTasks);
+
       // Calcular edad del caché a partir del registro más fresco
-      const freshest = pendingTasks.reduce((acc, t) => Math.max(acc, t.cachedAt || 0), 0);
+      const freshest = pendingTasks.reduce((acc, t) => Math.max(acc, t.cached_at || 0), 0);
       if (freshest > 0) setCacheAgeMinutes(Math.floor((Date.now() - freshest) / 60000));
     } catch (err) {
       console.error('Error obteniendo tareas pendientes:', err);
       setError('Error al cargar tareas');
-      // Fallback: intentar obtener del caché local
-      try {
-        const cachedTasks = await syncManager.getPendingTasks();
-        setTasks(cachedTasks);
-        const freshest = cachedTasks.reduce((acc, t) => Math.max(acc, t.cachedAt || 0), 0);
-        if (freshest > 0) setCacheAgeMinutes(Math.floor((Date.now() - freshest) / 60000));
-      } catch (cacheError) {
-        console.error('Error obteniendo tareas caché:', cacheError);
-      }
     } finally {
       setIsLoading(false);
     }

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { User, Palette } from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import ThemeSelector from './common/ThemeSelector';
+import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
+
+export default function ProfileScreen({ onBack }) {
+    return (
+        <ScreenShell
+            title="Perfil de Usuario"
+            icon={User}
+            onBack={onBack}
+        >
+            <div className="flex flex-col gap-6 pb-8">
+                {/* ID Card / User Info */}
+                <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-6 flex flex-col items-center">
+                    <div className="w-20 h-20 bg-slate-800 rounded-full flex items-center justify-center mb-4 border-2 border-emerald-500/30">
+                        <User size={40} className="text-emerald-400" />
+                    </div>
+                    <h2 className="text-2xl font-black text-white">{PRIMARY_WORKER_NAME}</h2>
+                    <p className="text-xs text-slate-500 uppercase tracking-widest font-bold mt-1">Operador de Campo</p>
+                </div>
+
+                {/* Theme Section */}
+                <div className="space-y-4">
+                    <div className="flex items-center gap-2 px-1">
+                        <Palette size={18} className="text-emerald-400" />
+                        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Personalización</h3>
+                    </div>
+                    <ThemeSelector />
+                </div>
+
+                {/* App Info Footer */}
+                <div className="mt-8 pt-6 border-t border-slate-800/50 text-center">
+                    <p className="text-[10px] text-slate-600 font-mono tracking-tighter uppercase">
+                        Chagra Eco-OS • v0.8.4
+                    </p>
+                    <p className="text-[9px] text-slate-700 mt-1 max-w-[200px] mx-auto leading-tight">
+                        Diseñado para la soberanía alimentaria y la regeneración ecosistémica.
+                    </p>
+                </div>
+            </div>
+        </ScreenShell>
+    );
+}

--- a/src/components/TaskLogScreen.jsx
+++ b/src/components/TaskLogScreen.jsx
@@ -2,50 +2,40 @@ import React, { useState, useEffect } from 'react';
 import { ArrowLeft, CheckCircle, Clock, Wifi, WifiOff, RefreshCw } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 
-function TaskLogScreen({ onBack }) {
+function TaskLogScreen({ onBack, onNewTask }) {
   const [tasks, setTasks] = useState([]);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [isSyncing, setIsSyncing] = useState(false);
 
   const fetchPendingTasks = async () => {
     try {
-      // Aquí se conectaría a FarmOS para obtener tareas pendientes
-      // Por ahora simulamos tareas locales
-      await syncManager.getSyncStats();
-      setTasks([
-        {
-          id: 1,
-          title: 'Riego Invernadero 1',
-          description: 'Ejecutar riego programado',
-          status: 'pending',
-          priority: 'high',
-          date: new Date().toISOString()
-        },
-        {
-          id: 2,
-          title: 'Aplicación de biopreparado preventivo',
-          description: 'Aplicar caldo sulfocálcico al cultivo de tabaco',
-          status: 'pending',
-          priority: 'medium',
-          date: new Date().toISOString()
-        }
-      ]);
+      const pendingTasks = await syncManager.getPendingTasks();
+      setTasks(pendingTasks);
     } catch (error) {
       console.error('Error obteniendo tareas pendientes:', error);
     }
   };
 
   const toggleTaskStatus = async (taskId) => {
-    setTasks(prev => prev.map(task =>
-      task.id === taskId ? { ...task, status: task.status === 'completed' ? 'pending' : 'completed' } : task
-    ));
+    // Fase 5: completar tarea via useAssetStore.completeTaskLog (inmutable)
+    try {
+      const useAssetStore = (await import('../store/useAssetStore')).default;
+      await useAssetStore.getState().completeTaskLog(taskId);
+      // Refrescar lista local
+      setTasks(prev => prev.filter(t => t.id !== taskId));
+    } catch (err) {
+      console.error('Error completando tarea:', err);
+    }
   };
 
   const syncTasks = async () => {
     setIsSyncing(true);
-    await syncManager.syncAll();
-    setIsSyncing(false);
-    await fetchPendingTasks();
+    try {
+      await syncManager.syncAll();
+      await fetchPendingTasks();
+    } finally {
+      setIsSyncing(false);
+    }
   };
 
   useEffect(() => {
@@ -110,6 +100,9 @@ function TaskLogScreen({ onBack }) {
               <span className="text-sm">Offline</span>
             </div>
           )}
+          <button onClick={onNewTask} className="p-3 bg-muzo rounded-full active:bg-muzo-glow min-h-[56px] min-w-[56px] flex justify-center items-center shrink-0 border border-slate-700 shadow-neon-muzo">
+            <span className="text-3xl font-black text-slate-950">+</span>
+          </button>
           <button onClick={syncTasks} disabled={isSyncing} className="p-2 bg-slate-800 rounded-full active:bg-slate-700 min-h-[40px] min-w-[40px] flex justify-center items-center shrink-0 border border-slate-600">
             <RefreshCw size={16} className={isSyncing ? 'animate-spin' : ''} />
           </button>
@@ -124,9 +117,8 @@ function TaskLogScreen({ onBack }) {
 
         <div className="space-y-3">
           {tasks.map(task => (
-            <div key={task.id} className={`p-4 rounded-xl border-2 transition-all ${
-              task.status === 'completed' ? 'bg-slate-900/50 border-slate-800' : 'bg-slate-900 border-slate-700'
-            }`}>
+            <div key={task.id} className={`p-4 rounded-xl border-2 transition-all ${task.status === 'completed' ? 'bg-slate-900/50 border-slate-800' : 'bg-slate-900 border-slate-700'
+              }`}>
               <div className="flex justify-between items-start gap-3">
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-2">
@@ -145,11 +137,10 @@ function TaskLogScreen({ onBack }) {
                 <button
                   onClick={() => toggleTaskStatus(task.id)}
                   disabled={task.status === 'synced' || !isOnline}
-                  className={`p-2 rounded-lg flex items-center justify-center gap-2 transition-all ${
-                    task.status === 'completed'
-                      ? 'bg-green-700 text-white'
-                      : 'bg-slate-700 text-slate-300 active:bg-slate-600'
-                  } ${task.status === 'synced' ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  className={`p-2 rounded-lg flex items-center justify-center gap-2 transition-all ${task.status === 'completed'
+                    ? 'bg-green-700 text-white'
+                    : 'bg-slate-700 text-slate-300 active:bg-slate-600'
+                    } ${task.status === 'synced' ? 'opacity-50 cursor-not-allowed' : ''}`}
                 >
                   <CheckCircle size={16} />
                 </button>

--- a/src/components/TaskScreen.jsx
+++ b/src/components/TaskScreen.jsx
@@ -1,0 +1,181 @@
+import React, { useState, useMemo } from 'react';
+import { ArrowLeft, Calendar, FileText, Tag, Briefcase, Layout } from 'lucide-react';
+import useAssetStore from '../store/useAssetStore';
+
+function TaskScreen({ onBack, onSave }) {
+    const plants = useAssetStore((s) => s.plants);
+    const structures = useAssetStore((s) => s.structures);
+    const lands = useAssetStore((s) => s.lands);
+    const addTaskLog = useAssetStore((s) => s.addTaskLog);
+
+    const allAssets = useMemo(() => [
+        ...plants.map(p => ({ id: p.id, name: p.attributes?.name || p.name, type: 'plant' })),
+        ...structures.map(s => ({ id: s.id, name: s.attributes?.name || s.name, type: 'structure' })),
+        ...lands.map(l => ({ id: l.id, name: l.attributes?.name || l.name, type: 'land' }))
+    ], [plants, structures, lands]);
+
+    const [formData, setFormData] = useState({
+        name: '',
+        assetId: '',
+        locationId: '',
+        notes: '',
+        due: new Date().toISOString().split('T')[0],
+        severity: 'medium'
+    });
+
+    const [isSaving, setIsSaving] = useState(false);
+
+    const handleInput = (e) => {
+        setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    };
+
+    const handleSave = async () => {
+        if (!formData.name) {
+            onSave('El nombre de la tarea es obligatorio', true);
+            return;
+        }
+
+        setIsSaving(true);
+        try {
+            const taskData = {
+                name: formData.name,
+                notes: formData.notes,
+                assetIds: formData.assetId ? [formData.assetId] : [],
+                locationId: formData.locationId || null,
+                due: new Date(formData.due).toISOString().split('.')[0] + '+00:00',
+                severity: formData.severity
+            };
+
+            await addTaskLog(taskData);
+            onSave('Tarea agendada exitosamente (Offline-First)', false);
+            setTimeout(() => onBack(), 500);
+        } catch (error) {
+            console.error('[TaskScreen] Error saving task:', error);
+            onSave('Error al agendar tarea', true);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    return (
+        <div className="h-[100dvh] w-full bg-slate-950 text-slate-100 flex flex-col overflow-y-auto">
+            <header className="p-4 sticky top-0 bg-slate-950/80 backdrop-blur-md border-b border-slate-800 flex items-center gap-4 z-10 shrink-0 shadow-lg">
+                <button
+                    onClick={onBack}
+                    className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[56px] min-w-[56px] flex justify-center items-center shrink-0 border border-slate-700"
+                >
+                    <ArrowLeft size={32} />
+                </button>
+                <h2 className="text-3xl font-black tracking-tight">Agendar Tarea</h2>
+            </header>
+
+            <div className="flex-1 p-5 flex flex-col gap-6 pb-24 max-w-2xl mx-auto w-full">
+                <section className="space-y-4">
+                    <label className="flex flex-col gap-2">
+                        <span className="text-sm font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
+                            <FileText size={14} /> Título de la Operación
+                        </span>
+                        <input
+                            type="text"
+                            name="name"
+                            value={formData.name}
+                            onChange={handleInput}
+                            placeholder="Ej: Riego fertiorgánico"
+                            className="p-4 rounded-xl bg-slate-900 border-2 border-slate-800 focus:border-muzo outline-none text-2xl text-white transition-all shadow-inner"
+                        />
+                    </label>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <label className="flex flex-col gap-2">
+                            <span className="text-sm font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
+                                <Tag size={14} /> Prioridad
+                            </span>
+                            <select
+                                name="severity"
+                                value={formData.severity}
+                                onChange={handleInput}
+                                className="p-4 rounded-xl bg-slate-900 border-2 border-slate-800 text-xl text-white appearance-none"
+                            >
+                                <option value="low">Baja (Rutinaria)</option>
+                                <option value="medium">Media (Preventiva)</option>
+                                <option value="high">Alta (Urgente)</option>
+                                <option value="critical">Crítica (Emergencia)</option>
+                            </select>
+                        </label>
+
+                        <label className="flex flex-col gap-2">
+                            <span className="text-sm font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
+                                <Calendar size={14} /> Fecha Programada
+                            </span>
+                            <input
+                                type="date"
+                                name="due"
+                                value={formData.due}
+                                onChange={handleInput}
+                                className="p-4 rounded-xl bg-slate-900 border-2 border-slate-800 text-xl text-white"
+                            />
+                        </label>
+                    </div>
+                </section>
+
+                <section className="p-4 rounded-2xl bg-slate-900/50 border border-slate-800 space-y-4">
+                    <label className="flex flex-col gap-2">
+                        <span className="text-sm font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
+                            <Briefcase size={14} /> Activo Objetivo
+                        </span>
+                        <select
+                            name="assetId"
+                            value={formData.assetId}
+                            onChange={handleInput}
+                            className="p-4 rounded-xl bg-slate-800 border border-slate-700 text-lg text-white appearance-none"
+                        >
+                            <option value="">Seleccionar activo (opcional)</option>
+                            {allAssets.map(a => (
+                                <option key={a.id} value={a.id}>{a.name} ({a.type})</option>
+                            ))}
+                        </select>
+                    </label>
+
+                    <label className="flex flex-col gap-2">
+                        <span className="text-sm font-bold uppercase tracking-wider text-slate-500 flex items-center gap-2">
+                            <Layout size={14} /> Ubicación
+                        </span>
+                        <select
+                            name="locationId"
+                            value={formData.locationId}
+                            onChange={handleInput}
+                            className="p-4 rounded-xl bg-slate-800 border border-slate-700 text-lg text-white appearance-none"
+                        >
+                            <option value="">Seleccionar ubicación (opcional)</option>
+                            {lands.map(l => (
+                                <option key={l.id} value={l.id}>{l.attributes?.name || l.name}</option>
+                            ))}
+                        </select>
+                    </label>
+                </section>
+
+                <label className="flex flex-col gap-2">
+                    <span className="text-sm font-bold uppercase tracking-wider text-slate-500">Notas Adicionales</span>
+                    <textarea
+                        name="notes"
+                        value={formData.notes}
+                        onChange={handleInput}
+                        rows="3"
+                        placeholder="Instrucciones específicas para el operario..."
+                        className="p-4 rounded-xl bg-slate-900 border-2 border-slate-800 text-lg text-white outline-none focus:border-slate-600"
+                    />
+                </label>
+
+                <button
+                    onClick={handleSave}
+                    disabled={isSaving}
+                    className="mt-4 p-6 rounded-xl bg-muzo text-slate-950 text-2xl font-black shadow-neon-muzo active:scale-95 transition-all disabled:opacity-50 disabled:grayscale"
+                >
+                    {isSaving ? 'AGENDANDO...' : 'PROGRAMAR TAREA'}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default TaskScreen;

--- a/src/components/WorkerDashboard.jsx
+++ b/src/components/WorkerDashboard.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { MapPin, CheckCircle, Clock, Loader2, Navigation, RefreshCw, Eye, Wrench, Apple } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
-import { logCache } from '../db/logCache';
-import { assetCache } from '../db/assetCache';
+import { syncManager } from '../services/syncManager';
 import { wktToGeoJson } from '../utils/geo';
 import { haversineDistance, getCoords } from '../utils/spatialAnalysis';
 import FarmMap from './FarmMap';
@@ -49,14 +48,16 @@ export const WorkerDashboard = () => {
   const loadTasks = async () => {
     setLoading(true);
     try {
-      const allLogs = await logCache.getAll();
-      const pending = allLogs.filter((l) => {
-        const s = l.status || l.attributes?.status;
-        if (s !== 'pending') return false;
+      // Fase 5 ADR-019: Usar el selector unificado que ya filtra completados
+      const pending = await syncManager.getPendingTasks();
+
+      // Filtrar por las que tienen geometría (prioridad WorkerDashboard)
+      const geoTasks = pending.filter(l => {
         const geo = l.attributes?.intrinsic_geometry;
         return !!(typeof geo === 'object' ? geo?.value : geo);
       });
-      setTasks(pending);
+
+      setTasks(geoTasks);
     } catch (err) {
       console.error('[WorkerDashboard] Error cargando tareas:', err);
     } finally {
@@ -93,44 +94,23 @@ export const WorkerDashboard = () => {
     })
     .sort((a, b) => a.distance - b.distance);
 
-  // Marcar como completada (PATCH status=done)
+  // Marcar como completada (Fase 5: Append-only [TASK_COMPLETION] log)
   const handleComplete = async (taskId) => {
     setCompleting(taskId);
     try {
-      const task = tasks.find((t) => t.id === taskId);
-      if (!task) return;
+      // 1. Crear log de completado (inmutable)
+      await useAssetStore.getState().completeTaskLog(taskId, 'completed');
 
-      const logType = task.type || 'log--activity';
-      const suffix = logType.split('--')[1] || 'activity';
-
-      // Actualizar en logCache local
-      await logCache.put({ ...task, status: 'done', attributes: { ...task.attributes, status: 'done' } });
-
-      // Encolar PATCH al servidor
-      const pendingTx = {
-        id: crypto.randomUUID(),
-        remoteId: taskId,
-        type: `asset_${suffix}`, // usa prefijo para activar el listener syncCompleted
-        endpoint: `/api/log/${suffix}/${taskId}`,
-        method: 'PATCH',
-        payload: {
-          data: {
-            type: logType,
-            id: taskId,
-            attributes: { status: 'done', timestamp: Math.floor(Date.now() / 1000) },
-          },
-        },
-      };
-
-      await assetCache.commitOptimisticUpdate([], [pendingTx]);
-      navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
-
-      // Refrescar lista
+      // 2. Refrescar lista local (quitando la tarea)
       setTasks((prev) => prev.filter((t) => t.id !== taskId));
-      window.dispatchEvent(new CustomEvent('syncComplete', { detail: { message: 'Tarea completada.' } }));
+
+      window.dispatchEvent(new CustomEvent('syncComplete', { detail: { message: 'Tarea finalizada.' } }));
+
+      // Forzar sync
+      navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
     } catch (err) {
       console.error('[WorkerDashboard] Error completando tarea:', err);
-      window.dispatchEvent(new CustomEvent('syncError', { detail: { message: 'No se pudo marcar la tarea.' } }));
+      window.dispatchEvent(new CustomEvent('syncError', { detail: { message: 'No se pudo registrar el completado.' } }));
     } finally {
       setCompleting(null);
     }

--- a/src/components/common/ThemeSelector.jsx
+++ b/src/components/common/ThemeSelector.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useTheme } from '../../hooks/useTheme';
+
+const THEMES = [
+    { id: 'biopunk', label: 'Biopunk (clásico)', desc: 'El tema original. Acentos neón.' },
+    { id: 'dark-sober', label: 'Oscuro sobrio', desc: 'Modo oscuro discreto sin neón.' },
+    { id: 'light', label: 'Claro', desc: 'Tema claro para uso diurno.' },
+    { id: 'auto', label: 'Automático', desc: 'Cambia entre claro y oscuro según la hora.' },
+];
+
+export default function ThemeSelector() {
+    const { theme, setTheme } = useTheme();
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-col gap-2">
+                {THEMES.map((t) => (
+                    <button
+                        key={t.id}
+                        onClick={() => setTheme(t.id)}
+                        className={`w-full p-4 rounded-xl text-left border-2 transition-all active:scale-95 ${theme === t.id
+                                ? 'border-emerald-500 bg-emerald-900/20'
+                                : 'border-slate-800 bg-slate-900/40 hover:border-slate-700'
+                            }`}
+                    >
+                        <div className="flex justify-between items-center mb-1">
+                            <span className={`text-base font-black ${theme === t.id ? 'text-emerald-400' : 'text-slate-100'}`}>
+                                {t.label}
+                            </span>
+                            {theme === t.id && (
+                                <div className="w-2 h-2 bg-emerald-500 rounded-full shadow-[0_0_8px_rgba(16,185,129,0.6)]"></div>
+                            )}
+                        </div>
+                        <span className="block text-xs text-slate-400 leading-relaxed">
+                            {t.desc}
+                        </span>
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -25,7 +25,7 @@ export const STORES = {
   SYNC_META: 'sync_meta',
   LOGS: 'logs',
   PENDING_TX: 'pending_transactions',
-  PENDING_TASKS: 'pending_tasks',
+  PENDING_TASKS: 'pending_tasks', // @deprecated: usar LOGS con type='log--task'
   MEDIA_CACHE: 'media_cache',
   PENDING_VOICE: 'pending_voice_recordings',
 };

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,43 @@
+import { useEffect, useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'chagra:theme';
+const VALID = ['biopunk', 'dark-sober', 'light', 'auto'];
+
+function applyTheme(theme) {
+    // Si "auto", resolver según hora local
+    let resolved = theme;
+    if (theme === 'auto') {
+        const hour = new Date().getHours();
+        resolved = (hour >= 18 || hour < 6) ? 'dark-sober' : 'light';
+    }
+
+    if (resolved === 'biopunk') {
+        document.documentElement.removeAttribute('data-theme');
+    } else {
+        document.documentElement.setAttribute('data-theme', resolved);
+    }
+    return resolved;
+}
+
+export function useTheme() {
+    const [theme, setThemeState] = useState(() => {
+        return localStorage.getItem(STORAGE_KEY) || 'biopunk';
+    });
+
+    useEffect(() => {
+        applyTheme(theme);
+        if (theme === 'auto') {
+            // Re-evaluar cada 10 min para auto-switching
+            const id = setInterval(() => applyTheme('auto'), 10 * 60 * 1000);
+            return () => clearInterval(id);
+        }
+    }, [theme]);
+
+    const setTheme = useCallback((next) => {
+        if (!VALID.includes(next)) return;
+        localStorage.setItem(STORAGE_KEY, next);
+        setThemeState(next);
+    }, []);
+
+    return { theme, setTheme };
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import './config/env'; // Validación de env vars al startup
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import './styles/themes.css'
 import App from './App.jsx'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { syncManager } from './services/syncManager'

--- a/src/services/syncManager.js
+++ b/src/services/syncManager.js
@@ -1,5 +1,8 @@
 import { sendToFarmOS, fetchFromFarmOS } from './apiService';
 import { openDB, STORES } from '../db/dbCore';
+import { logCache } from '../db/logCache';
+import { newId } from '../utils/id';
+import { getCompletedTaskIds } from '../utils/taskCompletionParser';
 
 const STORE_NAME = 'pending_transactions';
 const TASKS_STORE_NAME = 'pending_tasks';
@@ -19,6 +22,57 @@ class SyncManager {
   // interfaz pública initDB() para no romper callers existentes.
   async initDB() {
     this.db = await openDB();
+    // Ejecutar migración de tareas legacy si es necesario
+    await this.migrateLegacyTasks();
+  }
+
+  /**
+   * Fase 5 ADR-019: Migrar registros de pending_tasks (snapshot) a log--task (entidades).
+   */
+  async migrateLegacyTasks() {
+    if (!this.db) return;
+    const migrationFlag = 'chagra:migration:taskLogV1';
+    if (localStorage.getItem(migrationFlag)) return;
+
+    try {
+      const legacyTasks = await new Promise((resolve, reject) => {
+        const tx = this.db.transaction([TASKS_STORE_NAME], 'readonly');
+        const req = tx.objectStore(TASKS_STORE_NAME).getAll();
+        req.onsuccess = () => resolve(req.result || []);
+        req.onerror = () => reject(req.error);
+      });
+
+      if (legacyTasks.length > 0) {
+        console.info(`[Migration] Promocionando ${legacyTasks.length} tareas legacy a log--task…`);
+        for (const task of legacyTasks) {
+          const logTask = {
+            id: task.id || newId('log--task'),
+            type: 'log--task',
+            status: task.status || 'pending',
+            timestamp: task.timestamp || Math.floor(Date.now() / 1000),
+            name: task.title || task.name || 'Tarea migrada',
+            attributes: {
+              name: task.title || task.name || 'Tarea migrada',
+              status: task.status || 'pending',
+              timestamp: task.timestamp || Math.floor(Date.now() / 1000),
+              notes: {
+                value: `[MIGRATION] ${task.description || ''}`,
+                format: 'plain_text'
+              }
+            },
+            relationships: task.originalData?.relationships || { asset: { data: [] } },
+            _pending: false,
+            _migrated: true
+          };
+          await logCache.put(logTask);
+        }
+      }
+
+      localStorage.setItem(migrationFlag, 'completed');
+      console.info('[Migration] Tareas migradas con éxito.');
+    } catch (err) {
+      console.warn('[Migration] Error migrando tareas (no crítico, se reintentará FarmOS pull):', err);
+    }
   }
 
   // Guardar transacción pendiente
@@ -167,7 +221,7 @@ class SyncManager {
           mediaCache.purgeStale().catch((e) =>
             console.warn('[SyncManager] Purge de media stale fallido:', e)
           );
-        } catch (e) { /* noop */ }
+        } catch { /* noop */ }
 
         // Fase 11.2: pull preventivo de logs recientes tras tanda exitosa.
         try {
@@ -424,38 +478,38 @@ class SyncManager {
     });
   }
 
-  // Obtener tareas pendientes de IndexedDB (caché offline)
+  // Obtener tareas pendientes del store unificado (Fase 5 ADR-019)
   async getPendingTasks() {
-    if (!this.db) await this.initDB();
+    // Redirigir al store unificado filtrando por status=pending
+    const allLogs = await logCache.getByType('log--task');
+    const completedIds = getCompletedTaskIds(allLogs);
 
-    return new Promise((resolve, reject) => {
-      const transaction = this.db.transaction([TASKS_STORE_NAME], 'readonly');
-      const store = transaction.objectStore(TASKS_STORE_NAME);
-      const request = store.getAll();
-
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error);
-    });
+    return allLogs
+      .filter(l => l.status === 'pending' && !completedIds.has(l.id))
+      .map(l => ({
+        ...l,
+        title: l.name,
+        deadline: this.calculateDeadlineFromTimestamp(l.timestamp),
+        severity: this.calculateSeverityFromNotes(l.attributes?.notes?.value || '')
+      }));
   }
 
-  // Guardar tareas pendientes en IndexedDB mediante upsert por id.
-  // Preserva registros locales que no estén en el snapshot de red (idempotencia de lectura).
+  // Guardar tareas pendientes en IndexedDB mediante el store unificado.
   async savePendingTasks(tasks) {
-    if (!this.db) await this.initDB();
-
-    return new Promise((resolve, reject) => {
-      const transaction = this.db.transaction([TASKS_STORE_NAME], 'readwrite');
-      const store = transaction.objectStore(TASKS_STORE_NAME);
-      const now = Date.now();
-
-      for (const task of tasks) {
-        store.put({ ...task, cachedAt: now });
-      }
-
-      transaction.oncomplete = () => resolve(tasks);
-      transaction.onerror = () => reject(transaction.error);
-      transaction.onabort = () => reject(transaction.error);
-    });
+    // Wrapper para compatibilidad legacy. Mapea al nuevo bulkPut.
+    for (const task of tasks) {
+      const normalized = task.originalData || {
+        id: task.id,
+        type: 'log--task',
+        attributes: {
+          name: task.title,
+          status: task.status,
+          timestamp: task.timestamp,
+        }
+      };
+      await logCache.put(normalized);
+    }
+    return tasks;
   }
 
   // Fetch tareas pendientes desde FarmOS API
@@ -470,103 +524,59 @@ class SyncManager {
       const oneWeekAgo = Math.floor((now.getTime() - (7 * 24 * 60 * 60 * 1000)) / 1000);
       const oneWeekFuture = Math.floor((now.getTime() + (7 * 24 * 60 * 60 * 1000)) / 1000);
 
-      // FarmOS v2 filtra timestamps como UNIX seconds (enteros), no ISO 8601
       const endpoint = '/api/log/activity?' +
+        'include=quantity&' +
         'filter[date_range][condition][path]=timestamp&' +
         'filter[date_range][condition][operator]=BETWEEN&' +
         'filter[date_range][condition][value][0]=' + oneWeekAgo + '&' +
         'filter[date_range][condition][value][1]=' + oneWeekFuture;
-      console.log(`🔍 Consultando endpoint FarmOS: ${import.meta.env.VITE_FARMOS_URL}${endpoint}`);
+
       const response = await fetchFromFarmOS(endpoint);
 
-      const tasks = [];
-
       if (response.data && Array.isArray(response.data)) {
-        console.log(`📦 Respuesta de FarmOS: ${response.data.length} registros encontrados`);
-        response.data.forEach(log => {
-          const attributes = log.attributes || {};
-          const timestamp = attributes.timestamp || '';
-          const logStatus = attributes.status || 'pending';
-
-          // Fase 8.5: conservar tanto pendientes como completadas en el caché local
-          // para alimentar WorkerHistory en modo offline.
-
-          // Determinar severidad basada en el tipo de log y notas
-          // notes puede ser string, objeto { value: "..." }, o null
-          const notesRaw = attributes.notes;
-          const notesText = (typeof notesRaw === 'object' && notesRaw !== null && notesRaw.value)
-            ? notesRaw.value
-            : (typeof notesRaw === 'string' ? notesRaw : '');
-
-          let severity = 'medium';
-          if (notesText) {
-            const notesLower = notesText.toLowerCase();
-            if (notesLower.includes('emergencia') || notesLower.includes('crítico') || notesLower.includes('urgente')) {
-              severity = 'critical';
-            } else if (notesLower.includes('importante') || notesLower.includes('prioridad')) {
-              severity = 'high';
-            } else if (notesLower.includes('preventivo') || notesLower.includes('rutinario') || notesLower.includes('monitoreo')) {
-              severity = 'low';
-            }
-          }
-
-          // Calcular deadline — FarmOS v2 devuelve timestamp como UNIX seconds
-          const tsValue = typeof timestamp === 'number' ? timestamp * 1000 : Date.parse(timestamp) || 0;
-          const taskDate = new Date(tsValue);
-          const nowDate = new Date();
-          const daysDiff = Math.floor((nowDate - taskDate) / (1000 * 60 * 60 * 24));
-
-          let deadline = '';
-          if (daysDiff < 0) {
-            // Tarea futura
-            const absDaysDiff = Math.abs(daysDiff);
-            if (absDaysDiff === 0) {
-              const hours = taskDate.getHours().toString().padStart(2, '0');
-              const minutes = taskDate.getMinutes().toString().padStart(2, '0');
-              deadline = `Hoy ${hours}:${minutes}`;
-            } else if (absDaysDiff === 1) {
-              deadline = 'Mañana';
-            } else if (absDaysDiff <= 7) {
-              deadline = `En ${absDaysDiff} días`;
-            } else {
-              deadline = 'Próximamente';
-            }
-          } else if (daysDiff === 0) {
-            // Tarea para hoy
-            const hours = taskDate.getHours().toString().padStart(2, '0');
-            const minutes = taskDate.getMinutes().toString().padStart(2, '0');
-            deadline = `Hoy ${hours}:${minutes}`;
-          } else if (daysDiff === 1) {
-            deadline = 'Vencido (Ayer)';
-          } else {
-            deadline = `Vencido hace ${daysDiff} días`;
-          }
-
-          tasks.push({
-            id: log.id,
-            title: attributes.name || 'Tarea sin título',
-            deadline: deadline,
-            severity: logStatus === 'done' ? 'completed' : severity,
-            status: logStatus,
-            timestamp: typeof timestamp === 'number' ? timestamp : Math.floor(Date.parse(timestamp) / 1000) || 0,
-            originalData: log
-          });
-        });
-      } else {
-        console.log('⚠️ Respuesta de FarmOS vacía o sin data:', response);
+        // Normalizar y guardar como log--task en el store unificado
+        const normalized = response.data.map(remote => ({
+          ...remote,
+          type: 'log--task' // Forzamos el tipo para el cache local
+        }));
+        await logCache.bulkPut('log--task', normalized, response.included);
       }
 
-      // Guardar en caché
-      await this.savePendingTasks(tasks);
-
-      return tasks;
+      return this.getPendingTasks();
     } catch (error) {
       console.error('Error obteniendo tareas de FarmOS:', error);
-
-      // Fallback: usar tareas caché en IndexedDB
-      console.log('Usando tareas caché en IndexedDB');
       return this.getPendingTasks();
     }
+  }
+
+  // Helpers extraídos para limpieza del modelo (Fase 5)
+  calculateSeverityFromNotes(notesText) {
+    if (!notesText) return 'medium';
+    const notesLower = notesText.toLowerCase();
+    if (notesLower.includes('emergencia') || notesLower.includes('crítico') || notesLower.includes('urgente')) return 'critical';
+    if (notesLower.includes('importante') || notesLower.includes('prioridad')) return 'high';
+    if (notesLower.includes('preventivo') || notesLower.includes('rutinario') || notesLower.includes('monitoreo')) return 'low';
+    return 'medium';
+  }
+
+  calculateDeadlineFromTimestamp(timestamp) {
+    const tsValue = typeof timestamp === 'number' ? timestamp * 1000 : Date.parse(timestamp) || 0;
+    if (!tsValue) return 'Pendiente';
+    const taskDate = new Date(tsValue);
+    const nowDate = new Date();
+    const daysDiff = Math.floor((nowDate - taskDate) / (1000 * 60 * 60 * 24));
+
+    if (daysDiff < 0) {
+      const absDaysDiff = Math.abs(daysDiff);
+      if (absDaysDiff === 0) return `Hoy ${taskDate.getHours().toString().padStart(2, '0')}:${taskDate.getMinutes().toString().padStart(2, '0')}`;
+      if (absDaysDiff === 1) return 'Mañana';
+      return absDaysDiff <= 7 ? `En ${absDaysDiff} días` : 'Próximamente';
+    } else if (daysDiff === 0) {
+      return `Hoy ${taskDate.getHours().toString().padStart(2, '0')}:${taskDate.getMinutes().toString().padStart(2, '0')}`;
+    } else if (daysDiff === 1) {
+      return 'Vencido (Ayer)';
+    }
+    return `Vencido hace ${daysDiff} días`;
   }
 }
 

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -604,6 +604,27 @@ const useAssetStore = create((set, get) => ({
       },
     };
 
+    // Optimistic local: igual que addTaskLog, persistir en logCache para
+    // que aparezca en timeline + selectores derivados al instante. Sin
+    // esto el log de completado queda solo en pending_transactions hasta
+    // sync, y la UI sigue mostrando la tarea como pending.
+    const optimisticLog = {
+      id: logId,
+      type: 'log--task',
+      asset_id: null,
+      timestamp: Math.floor(Date.now() / 1000),
+      name: payload.data.attributes.name,
+      status: 'done',
+      attributes: payload.data.attributes,
+      _pending: true,
+    };
+
+    try {
+      await logCache.put(optimisticLog);
+    } catch (logErr) {
+      console.warn('[Store] Fallo persistir completion log optimista:', logErr);
+    }
+
     return savePayload('task', payload);
   },
 

--- a/src/store/useLogStore.js
+++ b/src/store/useLogStore.js
@@ -40,7 +40,7 @@ export const useLogStore = create((set, get) => ({
     set({ isSyncing: true });
 
     const startTime = Math.floor(Date.now() / 1000) - days * 24 * 60 * 60;
-    const types = ['log--seeding', 'log--planting', 'log--harvest', 'log--input'];
+    const types = ['log--seeding', 'log--planting', 'log--harvest', 'log--input', 'log--task', 'log--observation'];
 
     try {
       await Promise.all(types.map(async (type) => {
@@ -73,6 +73,20 @@ export const useLogStore = create((set, get) => ({
       set({ isSyncing: false });
     }
   },
+
+  /**
+   * Obtiene todas las tareas pendientes del store unificado.
+   */
+  getPendingTasks: async () => {
+    try {
+      const allLogs = await logCache.getByType('log--task');
+      // Filtramos por status 'pending'. Nota: el sync manager normaliza remote.status
+      return allLogs.filter(l => l.status === 'pending');
+    } catch (err) {
+      console.error('[LogStore] Error en getPendingTasks:', err);
+      return [];
+    }
+  }
 }));
 
 // Listener global: libera el flag _pending de logs confirmados por el servidor

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,0 +1,130 @@
+/* src/styles/themes.css */
+
+/* 1. Root variables for each theme */
+
+[data-theme="dark-sober"] {
+  --color-bg-primary: #0a0a0a;
+  --color-bg-secondary: #0f172a;
+  --color-text-primary: #e5e5e5;
+  --color-text-secondary: #a3a3a3;
+  --color-accent: #475569; /* slate-600 — sin neón */
+  --color-border: #1e293b;
+  --color-card: #111827;
+}
+
+[data-theme="light"] {
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f8fafc;
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #475569;
+  --color-accent: #059669; /* emerald-600 */
+  --color-border: #e2e8f0;
+  --color-card: #f1f5f9;
+}
+
+/* 2. Global Overrides for Tailwind hardcoded classes */
+
+/* --- BACKGROUNDS --- */
+[data-theme="dark-sober"] .bg-slate-950,
+[data-theme="dark-sober"] .bg-slate-900 {
+  background-color: var(--color-bg-primary) !important;
+}
+
+[data-theme="light"] .bg-slate-950,
+[data-theme="light"] .bg-slate-900 {
+  background-color: var(--color-bg-primary) !important;
+}
+
+[data-theme="dark-sober"] .bg-slate-900\/50,
+[data-theme="dark-sober"] .bg-slate-900\/60 {
+  background-color: rgba(10, 10, 10, 0.6) !important;
+}
+
+[data-theme="light"] .bg-slate-900\/50,
+[data-theme="light"] .bg-slate-900\/60 {
+  background-color: rgba(248, 250, 252, 0.6) !important;
+}
+
+[data-theme] .bg-biopunk-pattern {
+  background-image: none !important;
+}
+
+/* --- TEXT COLORS --- */
+[data-theme="dark-sober"] .text-white,
+[data-theme="dark-sober"] .text-slate-100,
+[data-theme="dark-sober"] .text-slate-200 {
+  color: var(--color-text-primary) !important;
+}
+
+[data-theme="light"] .text-white,
+[data-theme="light"] .text-slate-100,
+[data-theme="light"] .text-slate-200 {
+  color: var(--color-text-primary) !important;
+}
+
+[data-theme="light"] .text-slate-400,
+[data-theme="light"] .text-slate-500 {
+  color: var(--color-text-secondary) !important;
+}
+
+/* --- ACCENTS & GLOWS --- */
+[data-theme="dark-sober"] .text-muzo-glow {
+  color: var(--color-text-primary) !important;
+  text-shadow: none !important;
+}
+
+[data-theme="light"] .text-muzo-glow {
+  color: var(--color-accent) !important;
+  text-shadow: none !important;
+}
+
+[data-theme] .shadow-neon-muzo,
+[data-theme] .shadow-neon-morpho,
+[data-theme] .shadow-neon-orchid,
+[data-theme] .shadow-neon-frog {
+  box-shadow: none !important;
+}
+
+/* --- BORDERS --- */
+[data-theme="dark-sober"] .border-slate-800,
+[data-theme="dark-sober"] .border-slate-700 {
+  border-color: var(--color-border) !important;
+}
+
+[data-theme="light"] .border-slate-800,
+[data-theme="light"] .border-slate-700 {
+  border-color: var(--color-border) !important;
+}
+
+/* --- COMPONENTS SPECIFIC OVERRIDES --- */
+
+/* Input/Select */
+[data-theme="light"] input, 
+[data-theme="light"] select, 
+[data-theme="light"] textarea {
+  background-color: white !important;
+  color: var(--color-text-primary) !important;
+  border-color: var(--color-border) !important;
+}
+
+/* Action Buttons */
+[data-theme="light"] .bg-slate-800 {
+  background-color: var(--color-bg-secondary) !important;
+  color: var(--color-text-primary) !important;
+}
+
+/* ScreenShell and Header */
+[data-theme="light"] header {
+  background-color: white !important;
+  border-color: var(--color-border) !important;
+}
+
+/* Dashboard Tiles - Adjusting for Light Theme */
+[data-theme="light"] .bg-slate-900\/60 {
+  background-color: white !important;
+  border-color: var(--color-border) !important;
+}
+
+[data-theme="light"] .divide-slate-800 > * {
+  border-color: var(--color-border) !important;
+}

--- a/src/utils/taskCompletionParser.js
+++ b/src/utils/taskCompletionParser.js
@@ -1,0 +1,38 @@
+/**
+ * taskCompletionParser.js — Procesamiento semántico de logs de completado (ADR-019).
+ * AGPL-3.0 © Chagra
+ */
+
+/**
+ * Escanea una lista de logs para identificar qué tareas han sido completadas.
+ * @param {Array} logs - Lista de logs (log--task)
+ * @returns {Set<string>} Conjunto de IDs de tareas originales que ya no están pendientes.
+ */
+export function getCompletedTaskIds(logs) {
+    const completedIds = new Set();
+
+    for (const log of logs) {
+        const notes = log.attributes?.notes?.value || '';
+        if (notes.includes('[TASK_COMPLETION]')) {
+            const match = notes.match(/target_task_id:\s*([a-zA-Z0-9_-]+)/);
+            if (match && match[1]) {
+                // En un sistema append-only, la presencia de este marcador 
+                // indica que la tarea original ya no debe mostrarse como pendiente.
+                completedIds.add(match[1]);
+            }
+        }
+    }
+
+    return completedIds;
+}
+
+/**
+ * Parsea el veredicto de un log de completado.
+ * @param {string} notes - Notas del log.
+ * @returns {string|null} 'completed', 'cancelled', 'rescheduled' o null.
+ */
+export function parseVerdict(notes) {
+    if (!notes.includes('[TASK_COMPLETION]')) return null;
+    const match = notes.match(/verdict:\s*([a-z]+)/);
+    return match ? match[1] : null;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -42,54 +42,54 @@ export default {
             // Animaciones cyberpunk + CRT para bloques de generacion por IA (v0.6.2+).
             keyframes: {
                 scanline: {
-                    '0%':   { transform: 'translateY(-100%)', opacity: '0' },
-                    '10%':  { opacity: '0.55' },
-                    '90%':  { opacity: '0.55' },
+                    '0%': { transform: 'translateY(-100%)', opacity: '0' },
+                    '10%': { opacity: '0.55' },
+                    '90%': { opacity: '0.55' },
                     '100%': { transform: 'translateY(3000%)', opacity: '0' },
                 },
                 glitchIn: {
-                    '0%':   { opacity: '0', transform: 'translateY(8px) scale(0.985)', filter: 'blur(4px) saturate(180%)' },
-                    '40%':  { opacity: '0.7', transform: 'translateY(-2px)', filter: 'blur(1px) saturate(150%)' },
-                    '70%':  { opacity: '0.95', transform: 'translateY(1px)', filter: 'blur(0.5px) saturate(120%)' },
+                    '0%': { opacity: '0', transform: 'translateY(8px) scale(0.985)', filter: 'blur(4px) saturate(180%)' },
+                    '40%': { opacity: '0.7', transform: 'translateY(-2px)', filter: 'blur(1px) saturate(150%)' },
+                    '70%': { opacity: '0.95', transform: 'translateY(1px)', filter: 'blur(0.5px) saturate(120%)' },
                     '100%': { opacity: '1', transform: 'translateY(0) scale(1)', filter: 'blur(0) saturate(100%)' },
                 },
                 neonPulse: {
                     '0%,100%': { boxShadow: '0 0 8px rgba(217,70,239,0.35), inset 0 0 8px rgba(217,70,239,0.08)' },
-                    '50%':     { boxShadow: '0 0 20px rgba(217,70,239,0.75), inset 0 0 14px rgba(217,70,239,0.22)' },
+                    '50%': { boxShadow: '0 0 20px rgba(217,70,239,0.75), inset 0 0 14px rgba(217,70,239,0.22)' },
                 },
                 // Cierre del stream: rayo horizontal lento + burst expansivo.
                 // Duraciones extendidas (~1.4s / 1.2s) para un efecto mas
                 // satisfactorio que marque claramente el fin de la generacion.
                 sparkFlash: {
-                    '0%':   { opacity: '0', transform: 'translateX(-20%) scaleX(0.2)', filter: 'blur(12px)' },
-                    '15%':  { opacity: '1' },
-                    '70%':  { opacity: '0.7' },
+                    '0%': { opacity: '0', transform: 'translateX(-20%) scaleX(0.2)', filter: 'blur(12px)' },
+                    '15%': { opacity: '1' },
+                    '70%': { opacity: '0.7' },
                     '100%': { opacity: '0', transform: 'translateX(120%) scaleX(1.4)', filter: 'blur(6px)' },
                 },
                 sparkBurst: {
-                    '0%':   { opacity: '0', transform: 'scale(0.5)' },
-                    '20%':  { opacity: '1', transform: 'scale(1.1)' },
-                    '60%':  { opacity: '0.8', transform: 'scale(1.4)' },
+                    '0%': { opacity: '0', transform: 'scale(0.5)' },
+                    '20%': { opacity: '1', transform: 'scale(1.1)' },
+                    '60%': { opacity: '0.8', transform: 'scale(1.4)' },
                     '100%': { opacity: '0', transform: 'scale(2.2)' },
                 },
                 // Block cursor estilo terminal IBM 3270 / VT100 (parpadeo duro).
                 crtBlink: {
-                    '0%, 49%':   { opacity: '1' },
+                    '0%, 49%': { opacity: '1' },
                     '50%, 100%': { opacity: '0' },
                 },
                 // Flicker sutil del texto fosforo — tubo CRT antiguo.
                 crtFlicker: {
                     '0%, 100%': { opacity: '1' },
-                    '50%':      { opacity: '0.97' },
-                    '80%':      { opacity: '0.99' },
+                    '50%': { opacity: '0.97' },
+                    '80%': { opacity: '0.99' },
                 },
                 // Flash de negativo fotografico (invert + hue-rotate). Usado
                 // como transicion inicial del cierre del stream, ~1s.
                 negativeFlash: {
-                    '0%':   { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
-                    '20%':  { filter: 'invert(1) hue-rotate(180deg) saturate(150%)' },
-                    '60%':  { filter: 'invert(1) hue-rotate(200deg) saturate(130%)' },
-                    '85%':  { filter: 'invert(0.3) hue-rotate(70deg) saturate(110%)' },
+                    '0%': { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
+                    '20%': { filter: 'invert(1) hue-rotate(180deg) saturate(150%)' },
+                    '60%': { filter: 'invert(1) hue-rotate(200deg) saturate(130%)' },
+                    '85%': { filter: 'invert(0.3) hue-rotate(70deg) saturate(110%)' },
                     '100%': { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
                 },
                 // Latido de "IA viva" — loop de 30s con flash amplio de
@@ -98,37 +98,43 @@ export default {
                 // claramente perceptible cada vez.
                 negativeBreath: {
                     '0%, 91%, 100%': { filter: 'invert(0) hue-rotate(0deg) saturate(100%)' },
-                    '93%':           { filter: 'invert(0.6) hue-rotate(120deg) saturate(130%)' },
-                    '95.5%':         { filter: 'invert(1) hue-rotate(180deg) saturate(170%)' },
-                    '98%':           { filter: 'invert(0.6) hue-rotate(120deg) saturate(130%)' },
-                    '99.5%':         { filter: 'invert(0.2) hue-rotate(45deg)' },
+                    '93%': { filter: 'invert(0.6) hue-rotate(120deg) saturate(130%)' },
+                    '95.5%': { filter: 'invert(1) hue-rotate(180deg) saturate(170%)' },
+                    '98%': { filter: 'invert(0.6) hue-rotate(120deg) saturate(130%)' },
+                    '99.5%': { filter: 'invert(0.2) hue-rotate(45deg)' },
                 },
                 // Destello luminoso que recorre el perimetro del panel,
                 // sincronizado con negativeBreath. pathLength=1 normaliza
                 // el dash-offset a 0..-1 → el destello recorre el
                 // perimetro exactamente una vez por ciclo.
                 borderMarch: {
-                    '0%':   { strokeDashoffset: '0' },
+                    '0%': { strokeDashoffset: '0' },
                     '100%': { strokeDashoffset: '-1' },
                 },
             },
             animation: {
-                'scanline':    'scanline 2.4s linear infinite',
-                'glitch-in':   'glitchIn 480ms cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-                'neon-pulse':  'neonPulse 2.2s ease-in-out infinite',
+                'scanline': 'scanline 2.4s linear infinite',
+                'glitch-in': 'glitchIn 480ms cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+                'neon-pulse': 'neonPulse 2.2s ease-in-out infinite',
                 'spark-flash': 'sparkFlash 1400ms cubic-bezier(0.16, 1, 0.3, 1) forwards',
                 'spark-burst': 'sparkBurst 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards',
-                'crt-blink':   'crtBlink 1.1s steps(1) infinite',
+                'crt-blink': 'crtBlink 1.1s steps(1) infinite',
                 'crt-flicker': 'crtFlicker 4s ease-in-out infinite',
                 // "IA viva" — latido de 30s mientras el panel este visible.
                 'negative-breath': 'negativeBreath 30s ease-in-out infinite',
                 // Transicion de cierre: flash previo al rayo (1s).
-                'negative-flash':  'negativeFlash 1000ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
+                'negative-flash': 'negativeFlash 1000ms cubic-bezier(0.22, 1, 0.36, 1) forwards',
                 // Destello que recorre el borde del panel, sincronizado con
                 // negative-breath: 30s linear infinite.
-                'border-march':    'borderMarch 30s linear infinite',
+                'border-march': 'borderMarch 30s linear infinite',
             },
         },
     },
-    plugins: [],
+    darkMode: ['class', '[data-theme="dark-sober"]'],
+    plugins: [
+        function ({ addVariant }) {
+            addVariant('theme-light', '[data-theme="light"] &');
+            addVariant('theme-dark-sober', '[data-theme="dark-sober"] &');
+        },
+    ],
 }

--- a/tests/task-log.spec.js
+++ b/tests/task-log.spec.js
@@ -59,8 +59,10 @@ test.describe('ADR-019 Fase 5: log--task & Inmutabilidad', () => {
     });
 
     test('crea tarea con ULID y verifica inmutabilidad al completar', async ({ page }) => {
-        // 1. Navegar a nueva tarea
-        await page.getByRole('button', { name: /tareas/i }).click();
+        // 1. Navegar a nueva tarea — usar aria-label exacto del tile (no regex /tareas/i
+        // que matchea 3 botones: refresh, Campo, Cola). Tile dashboard "Tareas: Cola
+        // de pendientes" es el que abre TaskLogScreen donde vive el botón "+".
+        await page.getByLabel('Tareas: Cola de pendientes').click();
         await page.getByRole('button', { name: '+' }).click();
 
         // 2. Llenar formulario
@@ -77,8 +79,12 @@ test.describe('ADR-019 Fase 5: log--task & Inmutabilidad', () => {
         expect(taskLog.type).toBe('log--task');
         expect(taskLog.status).toBe('pending');
 
-        // 4. Completar tarea desde el dashboard de operario (Javier/Campo)
-        await page.getByRole('button', { name: /campo|javier/i }).click();
+        // 4. Completar tarea desde el dashboard de operario (Javier/Campo).
+        // Volver al dashboard primero (cerrar TaskLogScreen vía botón Atrás)
+        // luego abrir el tile "Campo: Tareas por proximidad" con aria-label
+        // exacto para evitar strict-mode violation contra otros buttons.
+        await page.getByRole('button', { name: /atrás|volver/i }).first().click();
+        await page.getByLabel(/^Campo: Tareas por proximidad/).click();
 
         // Simular que el operario ya tiene la tarea en vista (esto requiere que la tarea tenga geo, 
         // pero para el test de inmutabilidad podemos disparar el completado vía consola si la UI es esquiva)

--- a/tests/task-log.spec.js
+++ b/tests/task-log.spec.js
@@ -83,15 +83,10 @@ test.describe('ADR-019 Fase 5: log--task & Inmutabilidad', () => {
         expect(taskLog.type).toBe('log--task');
         expect(taskLog.status).toBe('pending');
 
-        // 4. Completar tarea desde el dashboard de operario (Javier/Campo).
-        // Volver al dashboard primero (cerrar TaskLogScreen vía botón Atrás)
-        // luego abrir el tile "Campo: Tareas por proximidad" con aria-label
-        // exacto para evitar strict-mode violation contra otros buttons.
-        await page.getByRole('button', { name: /atrás|volver/i }).first().click();
-        await page.getByLabel(/^Campo: Tareas por proximidad/).click();
-
-        // Simular que el operario ya tiene la tarea en vista (esto requiere que la tarea tenga geo, 
-        // pero para el test de inmutabilidad podemos disparar el completado vía consola si la UI es esquiva)
+        // 4. Completar tarea via store (la UI tras Programar auto-redirige a
+        // TaskLogScreen vía setTimeout(onBack, 500); no hace falta navegar a
+        // Campo. Disparamos completeTaskLog directo por consola — el assert
+        // de inmutabilidad no depende de la UI de operario).
         await page.evaluate(async (taskId) => {
             const useAssetStore = (await import('/src/store/useAssetStore.js')).default;
             await useAssetStore.getState().completeTaskLog(taskId, 'completed', 'Test finalizado');

--- a/tests/task-log.spec.js
+++ b/tests/task-log.spec.js
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+
+const DB_NAME = 'ChagraDB';
+const LOGS_STORE = 'logs';
+const PENDING_TASKS_STORE = 'pending_tasks';
+
+// Helper para interactuar con IndexedDB
+const runOnDB = (page, storeName, action, data = null) =>
+    page.evaluate(
+        ({ dbName, storeName, action, data }) =>
+            new Promise((resolve, reject) => {
+                const req = indexedDB.open(dbName);
+                req.onsuccess = () => {
+                    const db = req.result;
+                    if (!db.objectStoreNames.contains(storeName)) {
+                        db.close();
+                        resolve(null);
+                        return;
+                    }
+                    const tx = db.transaction(storeName, action === 'get' ? 'readonly' : 'readwrite');
+                    const store = tx.objectStore(storeName);
+                    let request;
+                    if (action === 'get') request = store.get(data);
+                    else if (action === 'getAll') request = store.getAll();
+                    else if (action === 'put') request = store.put(data);
+                    else if (action === 'count') request = store.count();
+
+                    request.onsuccess = () => {
+                        db.close();
+                        resolve(request.result);
+                    };
+                    request.onerror = () => {
+                        db.close();
+                        reject(request.error);
+                    };
+                };
+                req.onerror = () => reject(req.error);
+            }),
+        { dbName: DB_NAME, storeName, action, data }
+    );
+
+test.describe('ADR-019 Fase 5: log--task & Inmutabilidad', () => {
+    test.beforeEach(async ({ context, page }) => {
+        // Mock Auth
+        await context.route('**/oauth/token', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({ access_token: 'e2e-token' }),
+            })
+        );
+        await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+
+        await page.goto('/');
+        await page.getByLabel(/usuario/i).fill('operator');
+        await page.getByLabel(/contraseña/i).fill('pass');
+        await page.getByRole('button', { name: /ingresar/i }).click();
+        await expect(page.getByText(/chagra/i).first()).toBeVisible();
+    });
+
+    test('crea tarea con ULID y verifica inmutabilidad al completar', async ({ page }) => {
+        // 1. Navegar a nueva tarea
+        await page.getByRole('button', { name: /tareas/i }).click();
+        await page.getByRole('button', { name: '+' }).click();
+
+        // 2. Llenar formulario
+        const taskTitle = `E2E-Task-${Date.now()}`;
+        await page.getByPlaceholder(/título/i).fill(taskTitle);
+        await page.getByRole('button', { name: /programar/i }).click();
+
+        // 3. Verificar creación en IndexedDB y formato ULID (26 chars)
+        const allLogs = await runOnDB(page, LOGS_STORE, 'getAll');
+        const taskLog = allLogs.find(l => l.name === taskTitle);
+
+        expect(taskLog).toBeDefined();
+        expect(taskLog.id.length).toBe(26); // ULID length
+        expect(taskLog.type).toBe('log--task');
+        expect(taskLog.status).toBe('pending');
+
+        // 4. Completar tarea desde el dashboard de operario (Javier/Campo)
+        await page.getByRole('button', { name: /campo|javier/i }).click();
+
+        // Simular que el operario ya tiene la tarea en vista (esto requiere que la tarea tenga geo, 
+        // pero para el test de inmutabilidad podemos disparar el completado vía consola si la UI es esquiva)
+        await page.evaluate(async (taskId) => {
+            const useAssetStore = (await import('/src/store/useAssetStore.js')).default;
+            await useAssetStore.getState().completeTaskLog(taskId, 'completed', 'Test finalizado');
+        }, taskLog.id);
+
+        // 5. ASSERT INMUTABILIDAD: El log original NO debe haber cambiado
+        const originalLogAfter = await runOnDB(page, LOGS_STORE, 'get', taskLog.id);
+        expect(originalLogAfter.status).toBe('pending');
+        expect(originalLogAfter.attributes.status).toBe('pending');
+
+        // 6. ASSERT APPEND-ONLY: Debe existir un SEGUNDO log con el marker de completado
+        const allLogsAfter = await runOnDB(page, LOGS_STORE, 'getAll');
+        const completionLog = allLogsAfter.find(l =>
+            l.attributes?.notes?.value?.includes('[TASK_COMPLETION]') &&
+            l.attributes?.notes?.value?.includes(taskLog.id)
+        );
+
+        expect(completionLog).toBeDefined();
+        expect(completionLog.id).not.toBe(taskLog.id);
+        expect(completionLog.status).toBe('done');
+    });
+
+    test('migra datos de pending_tasks legacy a logs inmutables con [MIGRATION]', async ({ page }) => {
+        // 1. Inyectar tarea legacy ANTES de que la app inicialice la migración (o forzar re-run)
+        const legacyId = 'legacy-uuid-123';
+        await runOnDB(page, PENDING_TASKS_STORE, 'put', {
+            id: legacyId,
+            title: 'Tarea Antigua Legacy',
+            description: 'Esta tarea viene del modelo snapshot',
+            status: 'pending',
+            timestamp: 1600000000
+        });
+
+        // 2. Limpiar flag de migración para forzar ejecución
+        await page.evaluate(() => localStorage.removeItem('chagra:migration:taskLogV1'));
+
+        // 3. Recargar para disparar migrateLegacyTasks en initDB
+        await page.reload();
+        await expect(page.getByText(/chagra/i).first()).toBeVisible();
+
+        // 4. Verificar migración
+        const migratedLog = await runOnDB(page, LOGS_STORE, 'get', legacyId);
+        expect(migratedLog).toBeDefined();
+        expect(migratedLog.type).toBe('log--task');
+        expect(migratedLog.attributes.notes.value).toContain('[MIGRATION]');
+        expect(migratedLog.attributes.notes.value).toContain('Esta tarea viene del modelo snapshot');
+
+        // 5. Verificar que el flag de localStorage se marcó
+        const flag = await page.evaluate(() => localStorage.getItem('chagra:migration:taskLogV1'));
+        expect(flag).toBe('completed');
+    });
+});

--- a/tests/task-log.spec.js
+++ b/tests/task-log.spec.js
@@ -65,9 +65,13 @@ test.describe('ADR-019 Fase 5: log--task & Inmutabilidad', () => {
         await page.getByLabel('Tareas: Cola de pendientes').click();
         await page.getByRole('button', { name: '+' }).click();
 
-        // 2. Llenar formulario
+        // 2. Llenar formulario — TaskScreen.jsx:83 usa placeholder
+        // "Ej: Riego fertiorgánico". El label "Título de la Operación"
+        // es un <span> dentro del <label>, no asociado vía htmlFor →
+        // getByLabel(/título/) no lo resuelve. Usamos getByRole('textbox')
+        // del primer input.
         const taskTitle = `E2E-Task-${Date.now()}`;
-        await page.getByPlaceholder(/título/i).fill(taskTitle);
+        await page.getByRole('textbox').first().fill(taskTitle);
         await page.getByRole('button', { name: /programar/i }).click();
 
         // 3. Verificar creación en IndexedDB y formato ULID (26 chars)

--- a/tests/themes.spec.js
+++ b/tests/themes.spec.js
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Themes — Perfil de usuario y persistencia', () => {
+    test.beforeEach(async ({ context }) => {
+        // Mock de auth para entrar directo al dashboard
+        await context.route('**/oauth/token', (route) =>
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    access_token: 'e2e-fake-access',
+                    refresh_token: 'e2e-fake-refresh',
+                    expires_in: 3600,
+                    token_type: 'Bearer',
+                }),
+            })
+        );
+        await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+    });
+
+    test('cambia tema a claro y persiste tras recarga', async ({ page }) => {
+        await page.goto('/');
+
+        // Login
+        await page.getByLabel(/usuario/i).fill('e2e-operator');
+        await page.getByLabel(/contraseña/i).fill('e2e-pass');
+        await page.getByRole('button', { name: /ingresar/i }).click();
+
+        // Entrar a Perfil
+        await page.click('button:has-text("Perfil")');
+        await expect(page.getByText(/Personalización/i)).toBeVisible();
+
+        // Seleccionar tema "Claro"
+        await page.click('button:has-text("Claro")');
+
+        // Verificar atributo en <html>
+        await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+        // Recargar y verificar persistencia
+        await page.reload();
+        await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+        // Volver a Biopunk
+        await page.click('button:has-text("Perfil")');
+        await page.click('button:has-text("Biopunk")');
+        await expect(page.locator('html')).not.toHaveAttribute('data-theme');
+    });
+
+    test('tema oscuro sobrio aplica el atributo correcto', async ({ page }) => {
+        await page.goto('/');
+        await page.getByLabel(/usuario/i).fill('e2e-operator');
+        await page.getByLabel(/contraseña/i).fill('e2e-pass');
+        await page.getByRole('button', { name: /ingresar/i }).click();
+
+        await page.click('button:has-text("Perfil")');
+        await page.click('button:has-text("Oscuro sobrio")');
+
+        await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark-sober');
+    });
+});


### PR DESCRIPTION
## Resumen

Bundle de 2 features ejecutadas por Antigravity desde los prompts:
- \`Chagra-strategy/ops/antigravity-prompts/themes-perfil-usuario.md\` (T8)
- Plan ADR-019 Fase 5 log--task (revisado y aprobado en sesión 2026-04-25/26).

## Themes (T8)

3 temas disponibles + auto-switching:
- \`biopunk\` — default actual, **NO se toca** (no-op visual).
- \`dark-sober\` — modo oscuro discreto sin neón.
- \`light\` — modo claro diurno.
- \`auto\` — alterna light (06–18h) / dark-sober (resto).

Selector en \`Perfil\` (nuevo tile). Persiste en \`localStorage:chagra:theme\`.

## Log-Task ADR-019 Fase 5

Migración de \`pending_tasks\` snapshot legacy → \`log--task\` entidad de primera clase:
- **Inmutabilidad**: completar tarea genera SEGUNDO log con metadata \`[TASK_COMPLETION]\`, no muta el original.
- **ULIDs**: nuevas tareas usan \`newId('log--task')\`.
- **Auto-migration**: legacy \`pending_tasks\` → \`log--task\` con tag \`[MIGRATION]\` al boot.
- **Selector**: \`syncManager.getPendingTasks()\` cruza logs en runtime para derivar pendientes.

## Bump

\`0.8.3 → 0.9.0\` (minor — 2 features paralelas).

## Test plan

- [x] ESLint clean en archivos nuevos/modificados.
- [x] \`npm run build\` verde local.
- [ ] CI Playwright + CodeQL verdes.
- [ ] Smoke mobile post-merge:
  - Cambiar tema desde Perfil → recargar → tema persiste.
  - Crear tarea offline desde TaskScreen → aparece en widget.
  - Completar tarea → segundo log generado, original intacto.
  - Verificar migración: si había pending_tasks legacy, aparecen como log--task con \`[MIGRATION]\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)