### PR TITLE
fix(lint): unblock CI — react-hooks/immutability + setState-in-effect + unused-vars

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,14 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
+    // Configs Node (playwright/vite/etc.) — requieren globals.node.
+    files: ['*.config.{js,mjs,ts}', 'playwright.config.js', 'vite.config.js'],
+    languageOptions: {
+      globals: { ...globals.node },
+      sourceType: 'module',
+    },
+  },
+  {
     files: ['**/*.{js,jsx}'],
     extends: [
       js.configs.recommended,
@@ -23,7 +31,12 @@ export default defineConfig([
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', {
+        varsIgnorePattern: '^[A-Z_]',
+        argsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+      }],
       // ADR-002: ningún import estático desde chagra-pro en el repo público.
       // Módulos Pro se cargan vía src/core/loadProModules.js (dynamic import).
       'no-restricted-imports': ['error', {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback } from 'react';
-import { Warehouse, MapPin, Eye, Package, Clock, ClipboardList, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, User } from 'lucide-react';
+import { Warehouse, MapPin, Eye, Package, Clock, ClipboardList, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette } from 'lucide-react';
 import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -188,6 +188,10 @@ export default function AssetsDashboard({ onBack }) {
       }
     };
     init();
+    // hydrate y syncFromServer vienen del store Zustand (referencias estables);
+    // incluirlos dispararía init en cada render. Sync único al montar es lo
+    // correcto.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Extrae el id del parent land desde las relationships JSON:API del asset.

--- a/src/components/ChagraGrowLoader.jsx
+++ b/src/components/ChagraGrowLoader.jsx
@@ -1,3 +1,10 @@
+/* eslint-disable react-refresh/only-export-components --
+ * Este archivo exporta el componente ChagraGrowLoader junto con sus
+ * constantes/metadata (THERMAL_ZONES, SPECIES, DEFAULT_SPECIES_BY_ZONE,
+ * SPECIES_META, thermalZoneFromAltitude). Mover esos exports a otro
+ * archivo rompería la cohesión semántica del módulo (la metadata está
+ * tightly-coupled al componente que la usa). HMR fast-refresh queda
+ * degradado en este archivo a cambio de cohesión. */
 /**
  * ChagraGrowLoader.jsx
  * ========================================================================

--- a/src/components/FarmMap.jsx
+++ b/src/components/FarmMap.jsx
@@ -115,7 +115,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
           savedZoom = parsed.zoom;
         }
       }
-    } catch (e) { /* noop */ }
+    } catch (_e) { /* noop */ }
 
     const map = L.map(containerRef.current, {
       center: savedCenter,
@@ -141,7 +141,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
       try {
         const c = map.getCenter();
         localStorage.setItem(MAP_STATE_KEY, JSON.stringify({ lat: c.lat, lng: c.lng, zoom: map.getZoom() }));
-      } catch (e) { /* noop */ }
+      } catch (_e) { /* noop */ }
     };
     map.on('moveend', saveViewport);
     map.on('zoomend', saveViewport);
@@ -322,7 +322,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
         console.warn('[FarmMap] fitBounds falló:', err.message);
       }
     }
-  }, [plants, structures, lands, focusZoneId, showTasks, pendingTasks]);
+  }, [plants, structures, lands, focusZoneId, showTasks, pendingTasks, onTaskComplete]);
 
   return (
     <div className="relative w-full h-full">

--- a/src/components/NetworkStatusBar.jsx
+++ b/src/components/NetworkStatusBar.jsx
@@ -35,14 +35,18 @@ export default function NetworkStatusBar() {
         setVisible(true);
         setTimeout(() => setVisible(false), 3000);
       }
-    } catch (err) {
+    } catch (_err) {
       // DB no inicializada aún, ignorar
     }
-  }, [status, syncedCount]);
+  }, [status]);
 
   useEffect(() => {
-    // Polling ligero del estado de sincronización
+    // Polling ligero del estado de sincronización. La llamada inmediata es
+    // intencional: sin ella el estado visible queda 1.5s desfasado al montar.
+    // El polling NO causa cascading renders porque cada setState dentro de
+    // refreshStats está guardado por comparación previa.
     const interval = setInterval(refreshStats, 1500);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     refreshStats();
     return () => clearInterval(interval);
   }, [refreshStats]);
@@ -58,7 +62,7 @@ export default function NetworkStatusBar() {
         const stats = await syncManager.getSyncStats();
         const countBefore = stats.pendingCount;
         setSyncedCount(countBefore);
-      } catch (e) { /* noop */ }
+      } catch (_e) { /* noop */ }
     };
 
     const handleOffline = () => {

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -60,6 +60,10 @@ export default function VoiceCapture({ onSave }) {
     } catch (_) { /* noop */ }
   }, []);
 
+  // Sync inicial de pending count en montaje + cuando cambia la callback.
+  // setState resultante es benigno: la próxima render no re-dispara este
+  // efecto (refreshPendingCount es estable por useCallback).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { refreshPendingCount(); }, [refreshPendingCount]);
 
   useEffect(() => {

--- a/src/components/WorkerHistory.jsx
+++ b/src/components/WorkerHistory.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { ArrowLeft, CheckCircle, Clock, RefreshCw, Wifi, WifiOff, CloudOff, Cloud, Sprout, Apple, TreePine, Building2, Wrench, Leaf, Droplets, Eye } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 
@@ -51,31 +51,7 @@ export default function WorkerHistory({ onBack }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isOnline, setIsOnline] = useState(navigator.onLine);
 
-  useEffect(() => {
-    loadData();
-
-    const onOnline = () => setIsOnline(true);
-    const onOffline = () => setIsOnline(false);
-    window.addEventListener('online', onOnline);
-    window.addEventListener('offline', onOffline);
-
-    const onTaskAdded = () => loadPendingTransactions();
-    window.addEventListener('taskAdded', onTaskAdded);
-
-    return () => {
-      window.removeEventListener('online', onOnline);
-      window.removeEventListener('offline', onOffline);
-      window.removeEventListener('taskAdded', onTaskAdded);
-    };
-  }, []);
-
-  const loadData = async () => {
-    setIsLoading(true);
-    await Promise.all([loadPendingTransactions(), loadCompletedTasks()]);
-    setIsLoading(false);
-  };
-
-  const loadPendingTransactions = async () => {
+  const loadPendingTransactions = useCallback(async () => {
     try {
       await syncManager.initDB();
       const all = await syncManager.getPendingTransactions();
@@ -84,9 +60,9 @@ export default function WorkerHistory({ onBack }) {
     } catch (err) {
       console.error('Error cargando transacciones pendientes:', err);
     }
-  };
+  }, []);
 
-  const loadCompletedTasks = async () => {
+  const loadCompletedTasks = useCallback(async () => {
     // Fase 8.5: consulta unificada al caché local de IndexedDB.
     // El pull de red ya incluye tareas done (ver syncManager.fetchPendingTasksFromFarmOS).
     // Si hay conexión, refrescamos antes de leer el store; si no, leemos directo.
@@ -106,7 +82,35 @@ export default function WorkerHistory({ onBack }) {
     } catch (err) {
       console.error('Error cargando tareas completadas:', err);
     }
-  };
+  }, []);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    await Promise.all([loadPendingTransactions(), loadCompletedTasks()]);
+    setIsLoading(false);
+  }, [loadPendingTransactions, loadCompletedTasks]);
+
+  useEffect(() => {
+    // Sync inicial: hidratar la vista al montar el componente.
+    // setIsLoading + setPendingTx resultantes son la sincronización
+    // legítima entre IndexedDB (sistema externo) y React state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    loadData();
+
+    const onOnline = () => setIsOnline(true);
+    const onOffline = () => setIsOnline(false);
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOffline);
+
+    const onTaskAdded = () => loadPendingTransactions();
+    window.addEventListener('taskAdded', onTaskAdded);
+
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOffline);
+      window.removeEventListener('taskAdded', onTaskAdded);
+    };
+  }, [loadData, loadPendingTransactions]);
 
   const formatTimestamp = (ts) => {
     if (!ts) return '';

--- a/src/components/common/AIStreamPanel.jsx
+++ b/src/components/common/AIStreamPanel.jsx
@@ -40,21 +40,28 @@ export default function AIStreamPanel({
   //   closing   — transicion de cierre inicial: flash de negativo (500ms)
   //               que invierte colores momentaneamente, anuncia el fin.
   //   finished  — rayo + burst de cierre (1400/1200ms), fase final visual.
-  const [phase, setPhase] = useState(active ? 'streaming' : 'idle');
+  // Phase machine: cuando active=true, derivamos 'streaming' directo de la prop
+  // (evita cascading renders de setState-in-effect). Solo persistimos en state
+  // las transiciones temporizadas closing → finished → idle del cierre.
+  const [closingPhase, setClosingPhase] = useState('idle'); // 'closing' | 'finished' | 'idle'
   const prevActive = useRef(active);
+  const phase = active ? 'streaming' : closingPhase;
 
   useEffect(() => {
-    if (active) {
-      setPhase('streaming');
-    } else if (prevActive.current && text) {
-      // streaming -> closing (700ms negative-flash) -> finished (1400ms) -> idle
-      setPhase('closing');
+    if (!active && prevActive.current && text) {
+      // streaming -> closing (700ms negative-flash) -> finished (1400ms) -> idle.
+      // Set inicial sincrónico está acotado: sólo se ejecuta cuando active
+      // pasa de true→false con texto presente, y la condición prevActive
+      // garantiza que no se re-dispare en el siguiente render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setClosingPhase('closing');
       const closingTimer = setTimeout(() => {
-        setPhase('finished');
+        setClosingPhase('finished');
       }, 700);
       const resetTimer = setTimeout(() => {
-        setPhase('idle');
+        setClosingPhase('idle');
       }, 700 + 1400);
+      prevActive.current = active;
       return () => {
         clearTimeout(closingTimer);
         clearTimeout(resetTimer);

--- a/src/hooks/useVoiceRecorder.js
+++ b/src/hooks/useVoiceRecorder.js
@@ -53,7 +53,7 @@ export default function useVoiceRecorder() {
 
   useEffect(() => () => cleanup(), [cleanup]);
 
-  const sampleAmplitude = useCallback(() => {
+  const sampleAmplitude = useCallback(function sample() {
     const analyser = analyserRef.current;
     if (!analyser) return;
     const buf = new Uint8Array(analyser.fftSize);
@@ -71,7 +71,7 @@ export default function useVoiceRecorder() {
       next.push(level);
       return next;
     });
-    rafRef.current = requestAnimationFrame(sampleAmplitude);
+    rafRef.current = requestAnimationFrame(sample);
   }, []);
 
   const stop = useCallback(() => {


### PR DESCRIPTION
## Resumen

CI bloqueada por 26 errores ESLint tras bump del plugin react-hooks a versión con reglas más estrictas (react-hooks/immutability, react-hooks/set-state-in-effect, react-refresh/only-export-components). PR resuelve todos sin refactor estructural innecesario.

## Cambios

### Configuración
- \`eslint.config.js\`: añade \`argsIgnorePattern\`, \`caughtErrorsIgnorePattern\`, \`destructuredArrayIgnorePattern\` con \`^_\` (alinea con convención del codebase). Override Node globals para \`*.config.js\` (playwright/vite).

### Fixes funcionales (no cosméticos)
- \`useVoiceRecorder.js\`: \`sampleAmplitude\` → named function expression \`function sample()\`. Referencia recursiva vía requestAnimationFrame ahora resuelve al nombre interno → satisface \`react-hooks/immutability\`.
- \`WorkerHistory.jsx\`: \`loadData/loadPendingTransactions/loadCompletedTasks\` → \`useCallback\` declaradas antes del \`useEffect\` que las consume.
- \`AIStreamPanel.jsx\`: phase machine derivado de \`active+closingPhase\` en vez de set síncrono cuando active=true. Solo persisten en state las transiciones temporizadas closing→finished→idle.

### Disable comments puntuales (con justificación inline)
- \`NetworkStatusBar.jsx\`, \`VoiceCapture.jsx\`, \`AssetsDashboard.jsx\`, \`WorkerHistory.jsx\`: \`set-state-in-effect\` en sync inicial al montar (cascade acotada, refactor sería over-engineering).
- \`ChagraGrowLoader.jsx\`: file-level disable de \`only-export-components\` con justificación de cohesión semántica entre componente y metadata.

### Cosméticos
- \`catch (e/err)\` → \`catch (_e/_err)\` en bloques noop (FarmMap, NetworkStatusBar).
- \`App.jsx\`: quita import \`User\` no usado de lucide-react → cierra CodeQL alert #27.
- \`FarmMap.jsx\`: agrega \`onTaskComplete\` a deps de useEffect.
- \`NetworkStatusBar.jsx\`: quita dependencia innecesaria \`syncedCount\` en useCallback.

## Resultado

- ✅ \`npm run lint -- --max-warnings 0\` (lefthook strict): **0 errors, 0 warnings**.
- ✅ \`npm run build\`: **built in 8.82s**.
- ✅ Cierra CodeQL alert #27 (\`User\` import unused).

## Régimen del dominio

Gaussiano — fix lineal de bugs identificados con downside acotado. NO se introducen abstracciones nuevas ni refactors estructurales (alineado con principio anti-over-engineering del operador).

## Test plan

- [x] Lint local strict pasa.
- [x] Build local pasa.
- [ ] CI Playwright (no testeado localmente — requiere libgbm faltante en NixOS dev).
- [ ] CodeQL re-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)