### PR TITLE
feat(catalog): migrar catálogo OSS al repo público (ADR-025 + ADR-026)

### DIFF
--- a/catalog/AMBIGUITIES_RESOLUTION.md
+++ b/catalog/AMBIGUITIES_RESOLUTION.md
@@ -1,0 +1,42 @@
+# Schema v3 — Ambigüedades identificadas y resolución
+
+Basado en análisis del seed v3.0 de Claude. Decisiones aplicables desde v0.7.0. Fuente canónica: **ADR-013**.
+
+| AMB | Problema | Decisión | Enforcement |
+|-----|----------|----------|-------------|
+| **01** | `gremio` singular vs `roles_in_guild` array | Deprecar `gremio`; `roles_in_guild[0]` = primario. Tabla `species_roles(species_id, role, priority)` en SQLite | Migración automática en build v0.7.0 |
+| **02** | `category` vs `roles_in_guild` | `category` = identidad (monoval cerrado); `roles_in_guild` = capacidades (array abierto) | Doc en schema; validator verifica coherencia con AMB-16 |
+| **03** | `thermal_zones` (arr) vs `thermal_zone` (enum sing) | Campo `thermal_zones: string[]`; enum `thermal_zone` con valores para el array | schema JSON |
+| **04** | `radiacion`/`agua` (es) vs `light_requirement`/`water_requirement` (en) | Español: `radiacion`, `agua`. Enums `radiacion_requirement`, `agua_requirement` | schema JSON |
+| **05** | `estrato` en anuales | Opcional; enum amplía con `rastrero`. Obligatorio si perenne/árbol | validator (ADR-012) |
+| **06** | `altitud_msnm` orden | `min_absoluto ≤ optimo_min ≤ optimo_max ≤ max_absoluto` | validator JSON Schema if/then |
+| **07** | `heladas_tolerancia_h` unidad | Objeto `heladas_tolerancia: { umbral_c, horas_acumuladas, tipo: "radiacion\|adveccion" }` | schema JSON |
+| **08** | `production` sin enum | Enum `harvest_type: fruto\|grano\|tuberculo\|hoja\|flor\|raiz\|tallo\|biomasa\|semilla\|latex\|corteza\|rizoma` | schema JSON |
+| **09** | Rangos NPK string vs objeto | Objetos `{ min, max }`; unidad implícita en nombre de campo (`*_ppm`, `*_c`, `*_pct`) | schema JSON |
+| **10** | Simetría companions/antagonists | Script `validate-catalog.ts` falla CI si asimétrico | CI (ADR-012) |
+| **11** | `saber_origen.validacion_cientifica` string libre | Catálogo `sources.yml` con ids; campo `source_ids: string[]` | validator |
+| **12** | `biopreparados_por_etapa` strings libres | Catálogo `biopreparados.yml` con ids; referencia `{ biopreparado_id, dosis, momento }` | validator |
+| **13** | Referencias cruzadas sin validación | Validator verifica todo id referenciado existe | CI (ADR-012) |
+| **14** | `prompt_sugerido_ia_externa_*` múltiples | Agrupar en `prompts_ia_externa: { diagnostico_fitosanitario, cromatografia, plan_siembra, diagnostico_nutricional, restauracion }` | schema JSON |
+| **15** | `manejo_por_escala` keys vs `scale_viability` | Validator exige `keys(manejo_por_escala) ⊆ scale_viability` | CI |
+| **16** | `category: especies_invasoras` vs `conservation_status: invasor` | Triple enforcement: `category == especies_invasoras ⇔ conservation_status == invasor ⇔ cultivable == false` | validator |
+
+## Bloqueadoras antes de curación a escala
+
+Sólo se escala curación de catálogo (>30 especies adicionales) **después** de que estas 5 estén enforcadas en CI:
+
+- AMB-01 (separación `gremio`/`roles_in_guild`)
+- AMB-08 (rangos como objetos)
+- AMB-10 (simetría validator)
+- AMB-11 (sources canónicas)
+- AMB-13 (referencias cruzadas)
+
+Sin estas cerradas, cada PR agrega inconsistencias que luego son costosas de corregir.
+
+## Próximos pasos
+
+1. Implementar `schema/*.schema.json` completos con if/then para AMB-06, AMB-15, AMB-16.
+2. Escribir `scripts/validate-catalog.ts`.
+3. Migrar las 80 spp actuales al schema v3 resuelto (ver `scripts/migrate-species-defaults-to-v3.ts`).
+4. Incorporar las especies curadas del seed v3.0 de Claude (papa criolla, aliso, ortiga, 3 páramo, 4 invasoras, 1 gremio-receta, 4 lab tests).
+5. Publicar guía para curadores externos en `CONTRIBUTING.md`.

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,13 +1,63 @@
 # Chagra — Catálogo agroecológico público
 
-Este catálogo se distribuye bajo **CC-BY-SA 4.0** (no bajo AGPL-3.0 del código). Ver `LICENSE.md` de este directorio.
+**Licencia:** CC-BY-SA 4.0 (no bajo AGPL-3.0 del código). Ver `LICENSE.md` en este directorio.
 
-**Fuentes originales** (source-of-truth): las 4 entradas JSON de este directorio se mantienen sincronizadas con el repo privado `guatoc-ecohub/Chagra-strategy` donde se hace la curaduría. Los cambios validados fluyen desde allí hacia aquí con atribución.
+**Source of truth canónico:** este directorio en el repo público `guatoc-ecohub/Chagra`. Decisión formalizada en **ADR-026** (Scope público/privado del catálogo) y **ADR-025** (Format reconciliation markdown ↔ JSON).
 
-**Schema**: `schema-v3.1.json` (JSON Schema draft-07). Validador en `guatoc-ecohub/Chagra-strategy/scripts/validate-catalog.mjs`.
+## Estructura
 
-**Build**: `npm run build:catalog` produce `public/catalog.sqlite` consumido por el runtime.
+| Archivo | Rol |
+|---------|-----|
+| `schema-v3.1.json` | JSON Schema draft-07 con definición formal de `species`, `biopreparado`, `source` |
+| `chagra-catalog-seed-v3.1.json` | Seed canónico — consumido por la PWA via `npm run build:catalog` → `public/catalog.sqlite` |
+| `chagra-catalog-seed-v3.0.json` | Versión histórica preservada (referencia para `migrate-v30-to-v31.mjs`) |
+| `biopreparados-seed.json` | Catálogo de biopreparados agroecológicos |
+| `sources-seed.json` | Fuentes científicas referenciadas por `species[].source_ids` |
+| `AMBIGUITIES_RESOLUTION.md` | Las 11 ambigüedades del schema v3 resueltas (ADR-013) |
+| `LICENSE.md` | CC-BY-SA 4.0 con atribución requerida |
 
-**Atribución**: al usar, modificar o redistribuir este catálogo, cite:
-> Chagra Strategy (2026). Chagra species catalog v3.1. CC-BY-SA 4.0.
-> https://github.com/guatoc-ecohub/Chagra
+## Pipeline ADR-025 (markdown frontmatter → JSON)
+
+Las fichas narrativas viven en `docs/species/[NN]-[id].md`. Cuando una ficha tiene frontmatter YAML completo cubriendo el schema v3.1, el script `scripts/md-fichas-to-catalog-json.mjs` la migra al seed JSON. Fichas legacy sin frontmatter se conservan saltadas (warning, no error).
+
+```bash
+# Regenerar JSON desde fichas markdown
+node scripts/md-fichas-to-catalog-json.mjs
+
+# Validar coherencia (CI mode — no escribe)
+node scripts/md-fichas-to-catalog-json.mjs --check
+
+# Validar JSON contra schema + reglas semánticas (AMB-05/10/11/13/14/15)
+node scripts/validate-catalog.mjs
+
+# Build SQLite WASM consumible por la PWA
+npm run build:catalog
+```
+
+## Convención de IDs
+
+`species[].id` sigue patrón `género_especie` snake_case estable. Ej: `persea_americana`, `coffea_arabica`, `inga_edulis`.
+
+`source_ids` sigue patrón `<institucion>-<año>-<slug>`. Ej: `agrosavia-2020-aguacate`, `humboldt-2020-frailejones`, `restrepo-1996-abc-agricultura-organica`.
+
+## Validación humana (ADR-016)
+
+Cada `species[]` lleva campo `validation_level`:
+- `claude_draft` — generada por LLM, sin revisar
+- `operator_reviewed` — el operador la verificó
+- `agronomist_validated` — un agrónomo con registro profesional la firmó (campo `validated_by[]`)
+- `community_attested` — saber tradicional documentado y atestiguado por custodios
+
+Las contribuciones externas vía PR DEBEN venir con `validation_level: claude_draft` o superior + `source_ids[]` poblado.
+
+## Atribución requerida
+
+Al usar, modificar o redistribuir este catálogo, cite:
+
+> Chagra (2026). Chagra species catalog v3.1. CC-BY-SA 4.0. https://github.com/guatoc-ecohub/Chagra
+
+## Boundary OSS / Pro
+
+Este catálogo (capas 1-2 de ADR-026) es **OSS público**. Los componentes Pro (gremios receta curados, planes nutrición optimizados, casos exitosos documentados, presets certificación) viven en repo privado `chagra-pro` cuando se construyan, NO aquí.
+
+Test rápido para saber si un campo nuevo va aquí o a Pro: ver ADR-026 §regla nuclear y §sub-i 5 reglas operativas.

--- a/catalog/chagra-catalog-seed-v3.0.json
+++ b/catalog/chagra-catalog-seed-v3.0.json
@@ -1,0 +1,1080 @@
+{
+  "schema_version": "3.0",
+  "seed_version": "0.1.0",
+  "generated_at": "2026-04-21",
+  "generated_by": "Claude (Anthropic) — asesor técnico; TODOS los datos requieren validación final por agrónomo colombiano humano antes de uso en producción ministerial o restauración real de páramo.",
+
+  "_meta": {
+    "tipo_documento": "semilla de catálogo",
+    "alcance": "10 especies completamente pobladas + 1 gremio-receta + lab tests piso frío + plan de ejecución por fases",
+    "advertencia": "Este archivo NO contiene las 600+ especies solicitadas. Ver '_plan_de_ejecucion_por_fases' para la ruta completa. Generar 600+ especies en una sola pasada llevaría a inventar fuentes, umbrales y saberes ancestrales, violando las reglas de rigor y trazabilidad del prompt original."
+  },
+
+  "answer_to_data_model_question": {
+    "elegido": "b",
+    "opcion": "roles_in_guild como array del enum roles_in_guild",
+    "matiz": "Mantener 'category' como enum cerrado y monovaluado que captura la identidad taxonómica-funcional principal (como la UI y la comunidad piensan la especie). Usar 'roles_in_guild' como array que captura TODAS las funciones ecológicas en diseño de gremios, con el orden del array indicando prioridad (primer elemento = rol dominante).",
+    "justificacion_resumida": "(a) flags booleanos no captura prioridad y genera explosión de columnas al crecer el enum; (c) categoría múltiple rompe normalización y complica queries. (b) captura cardinalidad arbitraria con un solo campo, se mapea bien a IndexedDB multiEntry o SQLite WASM con tabla denormalizada species_roles(species_id, role, priority), permite agregar roles sin migración de schema IDB, y el orden del array es información útil sin campo extra.",
+    "implementacion_sqlite_recomendada": "Tabla species con data_json completo + tabla species_roles(species_id, role, priority) denormalizada con índice compuesto (role, thermal_zone) para la query característica 'especies del piso X que sirven de rol Y ordenadas por prioridad'. En IndexedDB: índice multiEntry sobre roles_in_guild."
+  },
+
+  "ambiguedades_detectadas_en_schema_v3": [
+    {
+      "id": "AMB-01",
+      "campo": "gremio vs roles_in_guild",
+      "problema": "El enum 'gremio' (singular) ya existe con 7 valores; 'roles_in_guild' (array, plural) introduce 9 valores que se solapan. Redundancia e inconsistencia potencial si una especie tiene gremio='fijador_nitrogeno' y roles_in_guild=['crop'].",
+      "propuesta": "Opción A: deprecar 'gremio', dejar solo 'roles_in_guild' donde roles_in_guild[0] es el rol primario. Opción B: interpretar 'gremio' como rol estructural ecológico (dosel, estrato) y 'roles_in_guild' como función en diseño humano (crop, fence). Recomiendo Opción A por simplicidad."
+    },
+    {
+      "id": "AMB-02",
+      "campo": "thermal_zones (plural, array) vs enum thermal_zone (singular)",
+      "problema": "El campo en el ejemplo es plural con array; el enum propuesto es singular.",
+      "propuesta": "Renombrar el enum a 'thermal_zones' plural y mantener valores: calido|templado|frio|paramo."
+    },
+    {
+      "id": "AMB-03",
+      "campo": "radiacion vs light_requirement, agua vs water_requirement",
+      "problema": "Los campos en el ejemplo usan nombres en español (radiacion, agua); los enums nuevos proponen inglés (light_requirement, water_requirement).",
+      "propuesta": "Mantener todo en español para consistencia con category, estrato, gremio existentes. Enums: radiacion=[sol_pleno,sombra_parcial,sombra_filtrada,sombra_densa], agua=[bajo,medio,alto,pantanoso]."
+    },
+    {
+      "id": "AMB-04",
+      "campo": "estrato aplicado a anuales",
+      "problema": "El enum emergente|alto|medio|bajo es del diseño de dosel perenne. No tiene sentido claro para una lechuga.",
+      "propuesta": "Hacer 'estrato' opcional cuando category ∈ {hortalizas_hoja, hortalizas_fruto_flor, tuberculos_raices} y aplicarlo obligatoriamente a category ∈ {frutales_perennes, abonos_verdes_coberturas, cercas vivas}."
+    },
+    {
+      "id": "AMB-05",
+      "campo": "altitud_msnm con 4 niveles",
+      "problema": "min_absoluto, optimo_min, optimo_max, max_absoluto sin validador. Orden lógico debe imponerse.",
+      "propuesta": "Validador en build: min_absoluto <= optimo_min <= optimo_max <= max_absoluto. Rechazar PR que viole."
+    },
+    {
+      "id": "AMB-06",
+      "campo": "heladas_tolerancia_h",
+      "problema": "Unidad ambigua.",
+      "propuesta": "Reemplazar por objeto heladas_tolerancia: {umbral_c: -2, horas_acumuladas_max: 4, notas: '...'}."
+    },
+    {
+      "id": "AMB-07",
+      "campo": "production",
+      "problema": "Campo sin enum definido; valores libres.",
+      "propuesta": "Enum harvest_type: [fruto, grano, tuberculo, hoja, flor, raiz, tallo, biomasa, semilla, latex, corteza, bulbo]."
+    },
+    {
+      "id": "AMB-08",
+      "campo": "Rangos NPK como string 'min-max'",
+      "problema": "Inconsistente con altitud_msnm que usa objeto. Dificulta cálculos.",
+      "propuesta": "Homogeneizar a objeto {min: N, max: N, unidad: 'ppm'}."
+    },
+    {
+      "id": "AMB-09",
+      "campo": "biopreparados_por_etapa como strings libres",
+      "problema": "Variantes ortográficas inevitables. Dificulta integración con catálogo de biopreparados.",
+      "propuesta": "Catálogo auxiliar biopreparados[] con ids. Campo actual referencia: [{biopreparado_id: 'bocashi', dosis: '2kg/m2'}, ...]."
+    },
+    {
+      "id": "AMB-10",
+      "campo": "Simetría de companions/antagonists sin validación",
+      "problema": "Regla exige simetría pero no hay script de validación.",
+      "propuesta": "scripts/validate-catalog.ts en CI: falla si A tiene B en companions pero B no tiene A; igual para antagonists."
+    },
+    {
+      "id": "AMB-11",
+      "campo": "saber_origen.validacion_cientifica como string libre",
+      "problema": "Pérdida de trazabilidad; typos; no se puede linkear a fuente real.",
+      "propuesta": "Catálogo auxiliar sources[] con ids {id, doi, isbn, url, autores, año, titulo, revista}. Campo actual: validacion_cientifica_source_ids: ['cip-2018-catalogo', 'agrosavia-sol-andina-2016']."
+    },
+    {
+      "id": "AMB-12",
+      "campo": "prompt_sugerido_ia_externa_* múltiples variantes",
+      "problema": "Campos paralelos sin estructura unificada.",
+      "propuesta": "Objeto prompts_ia_externa: {diagnostico_fitosanitario: '...', cromatografia: '...', plan_siembra: '...', diagnostico_nutricional: '...'}."
+    },
+    {
+      "id": "AMB-13",
+      "campo": "Referencias cruzadas (companions, antagonists, recommended_covers, recommended_fences) sin validación",
+      "problema": "Typos silenciosos: si escribes 'vicia_fava' en lugar de 'vicia_faba', no hay error.",
+      "propuesta": "Validador build verifica que TODA referencia exista como id en el catálogo."
+    },
+    {
+      "id": "AMB-14",
+      "campo": "conservation_status='invasor' vs category='especies_invasoras'",
+      "problema": "Duplicidad con posible inconsistencia.",
+      "propuesta": "Regla: si conservation_status='invasor' entonces category='especies_invasoras' y cultivable=false. Validar en build."
+    },
+    {
+      "id": "AMB-15",
+      "campo": "manejo_por_escala como keys de objeto vs scale_viability como array enum",
+      "problema": "Dos estructuras paralelas con los mismos valores.",
+      "propuesta": "scale_viability: array con las escalas donde 'viable:true' (para queries rápidas). manejo_por_escala: objeto con los detalles de manejo (keys deben coincidir con scale_viability + pueden incluir escalas no viables con motivo)."
+    },
+    {
+      "id": "AMB-16",
+      "campo": "sources como strings libres al final",
+      "problema": "Mismo problema que AMB-11; no trazable.",
+      "propuesta": "Igual que AMB-11: sources_ids referencia catálogo auxiliar."
+    }
+  ],
+
+  "new_enums_proposed": {
+    "thermal_zones": ["calido", "templado", "frio", "paramo"],
+    "radiacion": ["sol_pleno", "sombra_parcial", "sombra_filtrada", "sombra_densa"],
+    "agua": ["bajo", "medio", "alto", "pantanoso"],
+    "propagation_method": ["semilla", "esqueje", "acodo", "injerto", "rizoma", "tuberculo", "estolon", "division_mata", "bulbo", "espora", "micropropagacion", "pseudobulbo"],
+    "conservation_status": ["cultivo_comun", "nativo_silvestre", "nativo_protegido", "en_peligro", "endemica_critica", "invasor"],
+    "roles_in_guild": ["crop", "nitrogen_fixer", "dynamic_accumulator", "ground_cover", "pest_repellent", "pollinator_attractor", "biomass_producer", "living_fence", "invasive", "windbreak", "nurse_plant"],
+    "fence_function": ["rompevientos", "delimitacion", "atrayente_polinizadores", "forraje", "melifera", "sombra", "refugio_fauna"],
+    "cover_habitus": ["rastrero", "rosetado", "estolonifero", "suculento", "dosel_rapido", "trepadora_baja"],
+    "scale_viability": ["apartamento", "huerto_casero", "invernadero_mediano", "produccion", "restauracion"],
+    "harvest_type": ["fruto", "grano", "tuberculo", "hoja", "flor", "raiz", "tallo", "biomasa", "semilla", "latex", "corteza", "bulbo"]
+  },
+
+  "task_a_extended_existing": {
+    "solanum_phureja": {
+      "_curation_status": "VALIDADO con fuentes verificadas AGROSAVIA + UNAL",
+      "id": "solanum_phureja",
+      "nombre_comun": "Papa criolla",
+      "nombre_comunes_regionales": ["papa criolla", "papa amarilla", "papa chaucha", "yema de huevo"],
+      "nombre_cientifico": "Solanum tuberosum L. Grupo Phureja (Juz. & Bukasov)",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": ["frio"],
+      "estrato": "bajo",
+      "gremio": "productivo_principal",
+      "roles_in_guild": ["crop"],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "production": "tuberculo",
+      "cycleMonths": 4,
+      "variedades_registradas_ica": [
+        {"nombre": "Criolla Colombia", "registro": "ICA 1994", "fuente": "Rodríguez, Ñústez & Estrada 2009, Agronomía Colombiana 27(3): 289-303"},
+        {"nombre": "AGROSAVIA Sol Andina (antes Corpoica Sol Andina)", "registro": "ICA 2016", "zona": "Altiplano cundiboyacense 2400-3000 msnm", "rendimiento_t_ha": 29},
+        {"nombre": "AGROSAVIA Estrella", "zona": "Nariño + Cundiboyacense", "rendimiento_t_ha_narino": 20.3, "rendimiento_t_ha_altiplano": 27.7},
+        {"nombre": "AGROSAVIA Alhaja", "registro": "ICA Resolución 00017702 de 2019", "zona": "Nudo de los Pastos, Nariño"},
+        {"nombre": "AGROSAVIA Oyanza", "zona": "Nariño"},
+        {"nombre": "Criolla Latina / Criolla Paisa / Criolla Colombia", "zona": "Antioquia", "fuente": "Rodríguez, Ñústez & Estrada 2009"}
+      ],
+      "altitud_msnm": {"min_absoluto": 1800, "optimo_min": 2400, "optimo_max": 3000, "max_absoluto": 3200},
+      "_nota_altitud": "Rango optimo 2400-3000 msnm verificado para AGROSAVIA Sol Andina (Boyacá, Cundinamarca). Fuera de rango, rendimiento cae significativamente. Fuente: AGROSAVIA Ficha técnica Sol Andina.",
+      "temperatura_c": {"helada_letal": -2, "optimo_min": 10, "optimo_max": 18, "max_tolerable": 24},
+      "humedad_relativa_pct": {"min": 60, "optimo": 80, "max": 95},
+      "ph_suelo": {"min": 5.0, "optimo_min": 5.5, "optimo_max": 6.5, "max": 7.0},
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {"umbral_c": -1, "horas_acumuladas_max": 4, "notas": "Heladas nocturnas <−2°C dañan follaje severamente; variedades nativas del altiplano son más tolerantes que Grupo Phureja."},
+      "companions": ["vicia_faba", "alnus_acuminata", "minthostachys_mollis", "lupinus_mutabilis", "chenopodium_quinoa"],
+      "antagonists": ["solanum_lycopersicum", "rubus_glaucus", "cucurbita_maxima"],
+      "_nota_antagonists": "Solanaceae entre sí comparten Phytophthora infestans y Ralstonia solanacearum → rotación obligatoria. Cucurbitáceas son hospedantes alternativos de áfidos vectores.",
+      "recommended_covers": ["vicia_sativa", "oxalis_megalorrhiza", "trifolium_repens"],
+      "recommended_fences": ["sambucus_peruviana", "dodonaea_viscosa", "alnus_acuminata"],
+      "propagation": {
+        "methods": ["tuberculo", "semilla"],
+        "best_method": "tuberculo",
+        "protocol_resumen": "Tubérculos-semilla certificados de 40-80g pre-brotados 30 días en oscuridad parcial a 10-15°C para brotes de 1-2cm. Surco a 25-30cm profundidad, distancia 1m entre surcos x 30cm entre plantas. Aporque a los 45 días y 75 días.",
+        "tiempo_a_establecimiento_dias": 21,
+        "notas": "Semilla botánica (TPS) solo para mejoramiento genético. Productores tradicionales usan tubérculo propio con riesgo de acumular virus (PVY, PLRV); renovación de semilla certificada cada 3 ciclos recomendada.",
+        "fuente": "Ñústez & Rodríguez 2024 'Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca'. Editorial UNAL. ISBN 9789585054929."
+      },
+      "manejo_por_escala": {
+        "apartamento": {"viable": true, "nota": "Contenedor mín 30L profundidad 40cm; usar variedad criolla (Grupo Phureja) por porte compacto. 1 tubérculo por contenedor.", "tips": ["Luz directa 6h/día mínimo", "Sustrato: 50% compost maduro + 30% tierra franca + 20% cascarilla arroz quemada", "Aporque simulado agregando sustrato a medida que crece"]},
+        "huerto_casero": {"viable": true, "nota": "Cama 1m x 3m produce 15-20 plantas. Rotar anualmente con leguminosas (Vicia faba, Lupinus mutabilis) o Chenopodium quinoa.", "tips": ["Separación 30-40cm", "Aporque 2 veces por ciclo", "Cosecha 120 días post-siembra"]},
+        "invernadero_mediano": {"viable": true, "nota": "Posible bajo cubierta pero susceptible a Alternaria y tizón tardío por humedad sostenida. Prefiere campo abierto.", "tips": ["Ventilación agresiva", "Riego por goteo, nunca aspersión"]},
+        "produccion": {"viable": true, "nota": "Rotación obligatoria c/3 años mínimo con leguminosas o cereales de grano. Rendimiento 25-30 t/ha con AGROSAVIA Sol Andina.", "tips": ["Monitoreo semanal de gota (Phytophthora infestans) en épocas húmedas", "Caldo bordelés preventivo"]},
+        "restauracion": {"viable": false, "nota": "Cultivo domesticado; no aplicable a restauración silvestre. En zonas de sustitución de actividades prohibidas en páramo (Ley 1930/2018 art. 10), la papa criolla queda en la zona de transición agropecuaria bajo impacto, NO en páramo propiamente dicho."}
+      },
+      "scale_viability": ["apartamento", "huerto_casero", "invernadero_mediano", "produccion"],
+      "plan_nutricion_base": {
+        "N_ppm": {"vegetativo": {"min": 150, "max": 200, "unidad": "ppm"}, "tuberizacion": {"min": 100, "max": 150, "unidad": "ppm"}, "llenado": {"min": 80, "max": 120, "unidad": "ppm"}},
+        "P_ppm": {"vegetativo": {"min": 30, "max": 50, "unidad": "ppm"}, "tuberizacion": {"min": 40, "max": 60, "unidad": "ppm"}, "llenado": {"min": 50, "max": 70, "unidad": "ppm"}},
+        "K_ppm": {"vegetativo": {"min": 150, "max": 200, "unidad": "ppm"}, "tuberizacion": {"min": 200, "max": 250, "unidad": "ppm"}, "llenado": {"min": 250, "max": 300, "unidad": "ppm"}},
+        "Ca_ppm": {"min": 150, "max": 200, "unidad": "ppm"},
+        "Mg_ppm": {"min": 50, "max": 80, "unidad": "ppm"},
+        "micronutrientes_criticos": ["B", "Zn", "Mn"],
+        "biopreparados_por_etapa": {
+          "pre_siembra": [{"biopreparado_id": "bocashi", "dosis": "2 kg/m2", "notas": "aplicar 15 días antes de siembra"}, {"biopreparado_id": "cal_dolomita", "dosis": "según pH medido", "condicion": "solo si pH<5.5"}],
+          "vegetativo": [{"biopreparado_id": "biol", "dosis": "1:10 en agua", "frecuencia_dias": 15}, {"biopreparado_id": "purin_ortiga", "dosis": "1:10 en agua", "frecuencia_dias": 21}],
+          "tuberizacion": [{"biopreparado_id": "lixiviado_frutas", "dosis": "1:20", "frecuencia_dias": 15}, {"biopreparado_id": "caldo_sulfocalcico", "dosis": "1:100 preventivo", "condicion": "épocas húmedas"}],
+          "llenado": [{"biopreparado_id": "te_compost", "dosis": "1:5", "frecuencia_dias": 10}, {"biopreparado_id": "humus_liquido", "dosis": "1:10", "frecuencia_dias": 15}]
+        },
+        "sintomas_deficiencia_comunes": [
+          {"sintoma": "amarillamiento hojas viejas", "causa_probable": "N", "correccion": "purín ortiga foliar + bocashi al pie"},
+          {"sintoma": "manchas moradas en envés hoja joven", "causa_probable": "P", "correccion": "harina de hueso o roca fosfórica al suelo"},
+          {"sintoma": "quemado de bordes hojas medias", "causa_probable": "K", "correccion": "ceniza de madera 100g/planta o sulfato K"},
+          {"sintoma": "tuberización pobre + tubérculos pequeños", "causa_probable": "K + Mg", "correccion": "ceniza + sal de Epsom"}
+        ],
+        "frecuencia_cromatografia": "pre-siembra + tuberización",
+        "referencias_cientificas": [
+          "Pérez, Rodríguez & Gómez 2008, Agronomía Colombiana 26(3): 477-486",
+          "Ñústez & Rodríguez 2024, Editorial UNAL ISBN 9789585054929",
+          "AGROSAVIA Ficha Técnica Sol Andina"
+        ]
+      },
+      "tests_suelo_recomendados": [
+        {"tipo": "ph_casero", "rango_objetivo": "5.5-6.5", "frecuencia": "pre-siembra"},
+        {"tipo": "cromatografia_pfeiffer", "frecuencia": "pre-siembra + tuberización", "objetivo": "verificar actividad microbiana en andisoles; patrón radial esperado: zona interior densa = buena MO; zona exterior con bordes dentados = actividad microbiana activa"},
+        {"tipo": "biotest_lombriz", "frecuencia": "anual", "objetivo": "confirmar vida edáfica; >10 individuos por cuadrante 30x30x20cm indica suelo saludable"},
+        {"tipo": "test_percolacion", "frecuencia": "pre-siembra", "objetivo": "verificar drenaje; agua debe percolar 2.5-5 cm/h en andisoles"}
+      ],
+      "plagas_criticas": [
+        {"nombre_cientifico": "Phthorimaea operculella", "nombre_comun": "Polilla guatemalteca", "umbral_accion": "5% tubérculos dañados en muestreo", "control_biologico": ["asociar minthostachys_mollis a 1m perimetro", "Trichogramma pretiosum sueltas 100mil/ha"], "control_cultural": ["aporque profundo", "no dejar tubérculos en campo post-cosecha"]},
+        {"nombre_cientifico": "Premnotrypes vorax", "nombre_comun": "Gusano blanco de la papa", "umbral_accion": "1 adulto/trampa lumínica/semana", "control_biologico": ["trampas con feromona de agregación", "Beauveria bassiana aplicada al suelo"], "control_cultural": ["rotación estricta 3 años", "barreras físicas en campo"]}
+      ],
+      "enfermedades_criticas": [
+        {"nombre_cientifico": "Phytophthora infestans", "nombre_comun": "Tizón tardío / Gota", "condiciones_favorables": "HR>80% + temp 15-20°C + lluvia sostenida >3 días", "prevencion": ["rotación 3 años con no-solanáceas", "distanciamiento 1m entre surcos para ventilación", "caldo bordelés preventivo semanal en épocas húmedas"], "biopreparados_curativos": [{"biopreparado_id": "trichoderma_harzianum_suelo", "dosis": "1kg/ha"}, {"biopreparado_id": "bacillus_subtilis_foliar", "dosis": "1L/ha de caldo 10^9 UFC/ml"}], "riesgo_perdida_pct": "hasta 100% si no se maneja"},
+        {"nombre_cientifico": "Rhizoctonia solani", "nombre_comun": "Costra negra", "condiciones_favorables": "suelos fríos + húmedos + materia orgánica mal descompuesta", "prevencion": ["semilla certificada", "Trichoderma en pre-siembra"], "biopreparados_curativos": [{"biopreparado_id": "trichoderma_harzianum_suelo"}]}
+      ],
+      "prompts_ia_externa": {
+        "diagnostico_fitosanitario": "Actúa como fitopatólogo colombiano especializado en solanáceas andinas.\nCultivo: Solanum tuberosum Grupo Phureja (papa criolla), variedad {VARIEDAD}, fase fenológica {FASE}, {DIAS} días desde siembra.\nUbicación: {ALTITUD} msnm, {MUNICIPIO}/{DEPARTAMENTO}, piso térmico frío.\nCondiciones últimos 7 días: HR {HR}%, temperatura media {TEMP}°C, precipitación acumulada {MM}mm.\nSíntomas observados: {USUARIO_DESCRIBE}.\nHistorial de manejo reciente: {ULTIMAS_ACCIONES}.\n\nProcede con diagnóstico diferencial priorizando causas más probables a esta altitud y condiciones. Para cada hipótesis, propón: (a) prueba casera de confirmación, (b) biopreparado agroecológico de tratamiento (NO agroquímicos sintéticos; referir a normativa IFOAM), (c) medida preventiva para ciclos futuros.",
+        "cromatografia_pfeiffer": "Eres experto en cromatografía circular de Pfeiffer aplicada a andisoles colombianos.\nContexto: papa criolla planeada, altitud {ALTITUD} msnm, pH medido {PH}, MO estimada {MO_PCT}%, preparación del cromatograma: {COMO_PREPARO}.\n\nAnaliza por zonas (central, interior, exterior, bordes) patrones radiales, colores y dentaduras. Reporta actividad microbiana, complejo arcillo-húmico, disponibilidad de nutrientes, salud edáfica general. Sugiere 3 enmiendas prioritarias en formato agroecológico con dosis por m2.",
+        "plan_siembra": "Actúa como agrónomo agroecológico colombiano.\nTengo {AREA_M2} m2 a {ALTITUD} msnm en {MUNICIPIO}. Quiero sembrar papa criolla variedad {VARIEDAD} asociada con {COMPAÑEROS}. Fecha planeada de siembra: {FECHA}. Suelo: pH {PH}, textura {TEXTURA}, MO {MO_PCT}%.\n\nDame: (a) marco de plantación óptimo, (b) secuencia de labores con fechas relativas, (c) plan de riego estimado por etapa, (d) plan de fertilización orgánica por etapa, (e) calendario de monitoreo de plagas y enfermedades específico a esta altitud y época del año."
+      },
+      "rol_ecologico": "Cultivo tradicional campesino andino, domesticado hace ~8.000 años en región Titicaca. Clave en soberanía alimentaria andina. Monocultivos degradan andisoles vía pérdida de materia orgánica y ruptura del complejo arcillo-húmico; rotación con leguminosas de altura (haba, chocho, tarwi) es obligatoria para sostenibilidad.",
+      "valor_pedagogico": "Permite enseñar rotaciones, fitosanidad, trofobiosis, soberanía de semilla, asociación con leguminosas fijadoras de nitrógeno, manejo de andisoles andinos.",
+      "saber_origen": {
+        "pueblo": "Pueblos andinos prehispánicos (dispersión Aymara, Quechua, Muisca, Pasto)",
+        "region": "Andes centrales y septentrionales; en Colombia: altiplano cundiboyacense, Nariño, Cauca, Antioquia",
+        "practica_original": "Cultivo en aynokas (turnos comunales rotativos), almacenamiento en pirwa, rotación con chenopodiáceas (quinua) y leguminosas (chocho). Selección participativa de variedades según textura, color de piel y pulpa, sabor.",
+        "validacion_cientifica_source_ids": ["cip-2006-ghislain", "rodriguez-nustez-2009", "agrosavia-sol-andina"]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "Umbrales térmicos y altitudinales consolidados contra AGROSAVIA Ficha Técnica Sol Andina y manual Ñústez & Rodríguez 2024. Variaciones por cultivar ±1-2°C en helada letal y ±200 msnm en rangos óptimos. Necesita validación por agrónomo humano antes de deploy ministerial.",
+      "sources_ids": [
+        "agrosavia-sol-andina",
+        "agrosavia-estrella",
+        "agrosavia-alhaja-ica-17702-2019",
+        "nustez-rodriguez-2024-unal",
+        "rodriguez-nustez-estrada-2009",
+        "perez-rodriguez-gomez-2008",
+        "cip-2006-ghislain"
+      ]
+    },
+
+    "alnus_acuminata": {
+      "_curation_status": "VALIDADO con fuentes CIAT/AGROSAVIA",
+      "id": "alnus_acuminata",
+      "nombre_comun": "Aliso andino",
+      "nombre_comunes_regionales": ["aliso", "cerezo (cordillera oriental)", "jaul (algunas zonas)"],
+      "nombre_cientifico": "Alnus acuminata Kunth",
+      "familia_botanica": "Betulaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": ["frio", "paramo"],
+      "estrato": "alto",
+      "gremio": "fijador_nitrogeno",
+      "roles_in_guild": ["nitrogen_fixer", "living_fence", "windbreak", "biomass_producer", "nurse_plant"],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "production": "biomasa",
+      "cycleMonths": null,
+      "habito": "arbol deciduo semicaducifolio, 15-25m altura",
+      "altitud_msnm": {"min_absoluto": 1800, "optimo_min": 2200, "optimo_max": 3200, "max_absoluto": 3600},
+      "temperatura_c": {"helada_letal": -6, "optimo_min": 8, "optimo_max": 18, "max_tolerable": 24},
+      "humedad_relativa_pct": {"min": 60, "optimo": 80, "max": 95},
+      "ph_suelo": {"min": 4.5, "optimo_min": 5.5, "optimo_max": 6.8, "max": 7.5},
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno a moderado",
+      "companions": ["solanum_phureja", "vicia_faba", "lupinus_mutabilis", "pennisetum_clandestinum_manejado"],
+      "antagonists": [],
+      "recommended_covers": ["trifolium_repens", "vicia_sativa"],
+      "recommended_fences": ["sambucus_peruviana", "dodonaea_viscosa"],
+      "fence_function": ["rompevientos", "delimitacion", "sombra", "refugio_fauna"],
+      "densidad_siembra_fence_m": 2.5,
+      "propagation": {
+        "methods": ["semilla", "esqueje"],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla recolectada de amentos maduros (marzo-mayo en cordillera oriental). Estratificación fría opcional 30 días. Germinación en bandejas con sustrato: 60% tierra negra + 30% arena + 10% compost maduro. Trasplante a bolsa negra 1.5kg a las 6 semanas. Plantación definitiva a los 4-6 meses (altura 30-40cm).",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Actinorrícica: forma nódulos fijadores de N con Frankia alni. Inoculación con suelo de aliso adulto acelera establecimiento.",
+        "fuente": "CIAT 1995 'El aliso (Alnus acuminata) en sistemas silvopastoriles'; Corpoica (AGROSAVIA) varios"
+      },
+      "manejo_por_escala": {
+        "apartamento": {"viable": false, "nota": "Árbol de 15-25m no apto para apartamento."},
+        "huerto_casero": {"viable": true, "nota": "Como cerca viva o sombra puntual. Un solo árbol por huerto pequeño.", "tips": ["Plantar en esquina noroeste para sombra de tarde sin bloqueo solar mañanero", "Podas anuales para mantener forma"]},
+        "invernadero_mediano": {"viable": false, "nota": "Inviable bajo cubierta por tamaño."},
+        "produccion": {"viable": true, "nota": "Ideal para sistemas silvopastoriles (20-40 árboles/ha) o como linderos entre lotes. Fija 150-300 kg N/ha/año según densidad y edad.", "tips": ["Densidad 10x10m o lindero a 2.5m", "Podas de formación años 2-3 y posteriores cada 3 años"]},
+        "restauracion": {"viable": true, "nota": "ESPECIE CLAVE para restauración de bosque alto andino y bordes de páramo. Nurse plant para especies de sotobosque. Recuperación de taludes degradados.", "tips": ["Plantación asociada a Weinmannia tomentosa y Escallonia paniculata", "Densidad restauración: 1100 individuos/ha (3x3m)", "Protección contra ganado primeros 3 años"]}
+      },
+      "scale_viability": ["huerto_casero", "produccion", "restauracion"],
+      "plan_nutricion_base": null,
+      "_nota_nutricion": "Como árbol fijador de N, no requiere plan de fertilización estándar. Aporta N al sistema. Solo monitoreo de P y K en suelos muy pobres durante establecimiento.",
+      "tests_suelo_recomendados": [
+        {"tipo": "ph_casero", "rango_objetivo": "5.5-6.8", "frecuencia": "pre-siembra"},
+        {"tipo": "conteo_nodulos", "frecuencia": "año 1 post-establecimiento", "objetivo": "verificar nodulación por Frankia alni; objetivo >20 nódulos en raíz principal a 30cm profundidad"}
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_restauracion": "Actúa como ecólogo de restauración de bosque alto andino colombiano.\nÁrea: {AREA_HA} ha a {ALTITUD} msnm en {MUNICIPIO}, pendiente {PENDIENTE}%, suelo degradado por {HISTORIAL_USO}. Quiero restaurar con Alnus acuminata como especie nodriza asociada a {ESPECIES_OBJETIVO}.\n\nDiseña: (a) marco de plantación y espaciamiento, (b) secuencia de establecimiento por fases (pioneras 1-3 años, secundarias 3-8 años, climácicas 8+ años), (c) protocolo de protección contra ganado, (d) indicadores de éxito de restauración a 1, 3, 5 años."
+      },
+      "rol_ecologico": "Especie nodriza clave en restauración de bosque alto andino. Fija nitrógeno simbiótico con actinomiceto Frankia alni. Hojas ricas en N mejoran el mantillo. Madera usada tradicionalmente para herramientas, construcciones rurales y leña. Corteza con taninos para curtiembre.",
+      "valor_pedagogico": "Enseña fijación simbiótica de N (con actinomiceto, no rizobio); rol de especies nodrizas en restauración; sistemas silvopastoriles andinos.",
+      "saber_origen": {
+        "pueblo": "Pueblos andinos (uso generalizado Muisca, Pasto, Inga)",
+        "region": "Andes colombianos 1800-3600 msnm",
+        "practica_original": "Uso en linderos tradicionales de aynokas, sombra para ganado, leña, reparación de taludes ribereños. Asociación con cultivos de frío (papa, maíz de altura, haba).",
+        "validacion_cientifica_source_ids": ["ciat-1995-alnus", "agrosavia-silvopastoriles"]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "Especie nativa andina ampliamente documentada. Datos consolidados.",
+      "sources_ids": ["ciat-1995-alnus", "agrosavia-silvopastoriles", "humboldt-flora-alto-andina"]
+    },
+
+    "urtica_dioica": {
+      "_curation_status": "VALIDADO con fuentes académicas generales; NOTA: Urtica dioica sensu stricto es europea. En Colombia las especies nativas son Urtica urens y Urtica leptophylla. CONFIRMAR con taxónomo cuál es la que el catálogo actual tiene.",
+      "id": "urtica_dioica",
+      "nombre_comun": "Ortiga",
+      "nombre_comunes_regionales": ["ortiga mayor", "pringamosa (confusión con otras Urticaceae)", "chichicaste (regional)"],
+      "nombre_cientifico": "Urtica dioica L.",
+      "familia_botanica": "Urticaceae",
+      "_nota_taxonomica": "Urtica dioica L. es nativa de Europa y Asia, naturalizada en Colombia. Especies nativas andinas: Urtica urens L., Urtica leptophylla Kunth, Urtica magellanica Juss. ex Poir. La mayoría de usos tradicionales colombianos corresponden a U. dioica naturalizada y U. urens.",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": ["templado", "frio"],
+      "estrato": "bajo",
+      "gremio": "acumulador_dinamico",
+      "roles_in_guild": ["dynamic_accumulator", "pest_repellent", "pollinator_attractor", "biomass_producer"],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "production": "hoja",
+      "cycleMonths": null,
+      "habito": "herbácea perenne 1-2m",
+      "altitud_msnm": {"min_absoluto": 1500, "optimo_min": 2000, "optimo_max": 3000, "max_absoluto": 3500},
+      "temperatura_c": {"helada_letal": -8, "optimo_min": 12, "optimo_max": 20, "max_tolerable": 28},
+      "humedad_relativa_pct": {"min": 50, "optimo": 75, "max": 95},
+      "ph_suelo": {"min": 5.5, "optimo_min": 6.0, "optimo_max": 7.2, "max": 7.8},
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "companions": ["solanum_phureja", "rubus_glaucus", "rosmarinus_officinalis"],
+      "antagonists": [],
+      "recommended_covers": ["trifolium_repens"],
+      "recommended_fences": [],
+      "propagation": {
+        "methods": ["semilla", "rizoma", "division_mata"],
+        "best_method": "rizoma",
+        "protocol_resumen": "Extraer trozos de rizoma de 10-15cm con al menos 2-3 yemas. Plantar a 5cm profundidad en sustrato húmedo rico en MO. Rebrote en 10-15 días. Alternativa: semilla en bandeja (germinación 14-21 días).",
+        "tiempo_a_establecimiento_dias": 30,
+        "notas": "Propagación agresiva: contenerla con barrera física de 30cm profundidad en huertos pequeños."
+      },
+      "manejo_por_escala": {
+        "apartamento": {"viable": true, "nota": "Contenedor aislado mín 10L; no dejar rizomas escapar a otros contenedores.", "tips": ["Macerar hojas para purín enzimatico casero", "Cosechar solo hojas jóvenes con guante"]},
+        "huerto_casero": {"viable": true, "nota": "Sector dedicado de 1-2 m2 aislado por barrera física. Producción de purín para todo el huerto.", "tips": ["Cortar a 10cm para rebrote vigoroso", "Secar hojas al aire para té medicinal"]},
+        "invernadero_mediano": {"viable": true, "nota": "Útil como reservorio de fauna benéfica (parasitoides de áfidos).", "tips": ["Sector perimetral; no en camas de producción"]},
+        "produccion": {"viable": true, "nota": "Cultivo dedicado para producción de purín y biomasa. 1000 m2 alimenta purín para 10 ha productivas.", "tips": ["Manejo mecánico de corte; secado para almacenamiento"]},
+        "restauracion": {"viable": false, "nota": "No es especie nativa colombiana (U. dioica sensu stricto); para restauración preferir U. leptophylla o U. urens."}
+      },
+      "scale_viability": ["apartamento", "huerto_casero", "invernadero_mediano", "produccion"],
+      "plan_nutricion_base": {
+        "N_ppm": {"general": {"min": 100, "max": 200, "unidad": "ppm"}},
+        "P_ppm": {"general": {"min": 20, "max": 40, "unidad": "ppm"}},
+        "K_ppm": {"general": {"min": 100, "max": 200, "unidad": "ppm"}},
+        "Ca_ppm": {"min": 150, "max": 250, "unidad": "ppm"},
+        "notas": "Acumuladora dinámica de Ca, Fe, Si, K. Requiere MO alta para expresión máxima de compuestos activos (ácido fórmico, histamina, serotonina en pelos urticantes).",
+        "biopreparados_por_etapa": {
+          "establecimiento": [{"biopreparado_id": "compost_maduro", "dosis": "3kg/m2"}],
+          "crecimiento": [{"biopreparado_id": "te_compost", "dosis": "1:5", "frecuencia_dias": 30}]
+        },
+        "frecuencia_cromatografia": "anual",
+        "referencias_cientificas": ["Restrepo 1996 ABC de agricultura orgánica y panes de piedra", "Pamplona Roger 2006 Enciclopedia plantas medicinales"]
+      },
+      "usos_medicinales_tradicionales": [
+        {"uso": "diurético", "parte": "hojas jóvenes en infusión", "validacion": "pendiente curación por farmacognosta"},
+        {"uso": "antiinflamatorio para artritis", "parte": "hojas frescas aplicación tópica controlada", "precaucion": "efecto urticante deseado en tratamientos antiguos; consentimiento del paciente obligatorio"},
+        {"uso": "galactogogo tradicional", "parte": "infusión hojas secas", "validacion": "pendiente"}
+      ],
+      "usos_agroecologicos": [
+        {"uso": "purín enzimático", "preparacion": "1kg hojas frescas en 10L agua lluvia, fermentar 7-10 días tapado", "aplicacion": "diluir 1:10 foliar como estimulante y repelente de pulgones"},
+        {"uso": "macerado antifúngico preventivo", "preparacion": "1kg hojas en 10L agua 24h sin fermentar", "aplicacion": "diluir 1:5 al suelo"},
+        {"uso": "activador de compostaje", "preparacion": "capa 5cm entre capas de compost", "efecto": "acelera mineralización por alto contenido N"}
+      ],
+      "tests_suelo_recomendados": [
+        {"tipo": "ph_casero", "rango_objetivo": "6.0-7.2", "frecuencia": "pre-siembra"},
+        {"tipo": "cromatografia_pfeiffer", "frecuencia": "anual", "objetivo": "verificar salud de suelo rico en MO"}
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_biopreparado": "Actúa como agroecólogo colombiano.\nTengo {M2} m2 de ortiga (Urtica dioica) establecida. Quiero producir purín enzimático para aplicar en {AREA_CULTIVO_HA} ha de {CULTIVO}.\n\nDame (a) cantidad de biomasa a cosechar, (b) protocolo de fermentación paso a paso, (c) dilución y frecuencia de aplicación, (d) efectos esperados y límites del biopreparado (qué SÍ hace vs qué NO hace)."
+      },
+      "rol_ecologico": "Acumuladora dinámica de nutrientes. Atractora de sírfidos (parasitoides de pulgones). Alimento de larvas de mariposas. Planta indicadora de suelos ricos en N.",
+      "valor_pedagogico": "Enseña acumulación dinámica, elaboración de biopreparados caseros, control biológico por reservorio de fauna benéfica.",
+      "saber_origen": {
+        "pueblo": "Uso campesino generalizado en Colombia (introducida en época colonial); uso médico tradicional en múltiples regiones",
+        "region": "Andes colombianos 1500-3500 msnm",
+        "practica_original": "Infusión medicinal, purín para huerta, activador de compost, aplicación tópica para artritis",
+        "validacion_cientifica_source_ids": ["restrepo-1996-abc-agricultura-organica"]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "ATENCIÓN: confirmar taxonomía (U. dioica vs U. leptophylla vs U. urens) con agrónomo/botánico antes de distribuir. Los umbrales dados aplican a U. dioica sensu lato; pueden variar para especies nativas andinas.",
+      "sources_ids": ["restrepo-1996-abc-agricultura-organica", "pamplona-roger-2006-plantas-medicinales"]
+    }
+  },
+
+  "task_c_paramo_conservation": {
+    "espeletia_grandiflora": {
+      "_curation_status": "VALIDADO; especie símbolo de páramo andino colombiano; datos verificados en Instituto Humboldt + PNN Chingaza + NaturaLista Colombia",
+      "id": "espeletia_grandiflora",
+      "nombre_comun": "Frailejón mayor",
+      "nombre_comunes_regionales": ["frailejón", "frailejón orejas de burro"],
+      "nombre_cientifico": "Espeletia grandiflora Humb. & Bonpl.",
+      "autor_ano": "Humboldt & Bonpland, 1808",
+      "publicacion_original": "Plantae Aequinoctiales 2: 10. 1808",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "_nota_categoria": "La categoría 'medicinales_alelopaticas' no captura el rol de 'especie clave de ecosistema'. Recomendación: crear categoría 'nativas_restauracion' o similar. Ver ambigüedad AMB-14.",
+      "thermal_zones": ["paramo"],
+      "estrato": "medio",
+      "gremio": "productor_biomasa",
+      "roles_in_guild": ["biomass_producer", "nurse_plant"],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "_nota_conservacion_normativa": "Protegida por Resolución 383 de 2010 del MADS (Libro Rojo Plantas de Colombia) y Ley 1930 de 2018 (Gestión Integral de Páramos). Prohibido cortar, transplantar o dañar sin permiso ambiental.",
+      "production": null,
+      "cycleMonths": null,
+      "habito": "roseta caulescente perenne, 1-3m altura en adultos",
+      "longevidad_años": "50+ (algunos individuos >100 años)",
+      "tasa_crecimiento_cm_año": {"min": 0.8, "optimo": 1.0, "max": 1.5},
+      "altitud_msnm": {"min_absoluto": 2800, "optimo_min": 3200, "optimo_max": 3800, "max_absoluto": 4200},
+      "temperatura_c": {"helada_letal": -15, "optimo_min": 2, "optimo_max": 10, "max_tolerable": 18},
+      "humedad_relativa_pct": {"min": 70, "optimo": 90, "max": 100},
+      "ph_suelo": {"min": 4.0, "optimo_min": 4.5, "optimo_max": 5.5, "max": 6.0},
+      "radiacion": "sol_pleno",
+      "_nota_radiacion": "Alta radiación UV de altura; tolerada por hojas con indumento denso (tricomas plateados).",
+      "agua": "alto",
+      "drenaje_requerido": "bueno en turberas; suelos bien drenados",
+      "companions": ["chusquea_tessellata", "calamagrostis_effusa", "hypericum_laricifolium"],
+      "antagonists": [],
+      "recommended_covers": [],
+      "recommended_fences": [],
+      "propagation": {
+        "methods": ["semilla"],
+        "best_method": "semilla",
+        "protocol_resumen": "Recolección de aquenios de inflorescencias maduras (temporada seca local, diciembre-febrero en cordillera oriental). Siembra en sustrato de turba de páramo: tierra de subpáramo 50% + arena 30% + materia orgánica 20%. Germinación lenta: 30-90 días. Trasplante a bolsa a los 4-6 meses cuando tenga 4-6 hojas verdaderas. Plantación definitiva >12 meses cuando tenga 15-20cm altura.",
+        "tiempo_a_establecimiento_dias": 180,
+        "notas": "Tasa de germinación natural baja (5-20%); trasplante de plántulas silvestres (si permisos ambientales lo autorizan) más efectivo. Protocolo de reubicación validado por Rojas-Zamora et al. 2013 en PNN Chingaza para restauración ecológica."
+      },
+      "manejo_por_escala": {
+        "apartamento": {"viable": false, "nota": "Especie de páramo no replicable en condiciones urbanas."},
+        "huerto_casero": {"viable": false, "nota": "Solo en parcelas situadas en piso térmico de páramo con permisos."},
+        "invernadero_mediano": {"viable": false, "nota": "Especie no apta a cubierta; requiere radiación UV de altura y temperaturas frías sostenidas."},
+        "produccion": {"viable": false, "nota": "No apta para producción comercial. Legalmente protegida."},
+        "restauracion": {"viable": true, "nota": "ESPECIE CLAVE para restauración de páramo. Protocolo de reubicación validado. Requiere permiso de autoridad ambiental (CAR correspondiente).", "protocolo_restauracion": "Ver Rojas-Zamora et al. 2013; exclusión ganadera obligatoria mínimo 3 años; siembra en pastizales dominados por Calamagrostis con gradiente de altitud conocido; densidad 100-400 individuos/ha según nivel de degradación; monitoreo anual de supervivencia y crecimiento."}
+      },
+      "scale_viability": ["restauracion"],
+      "plan_nutricion_base": null,
+      "tests_suelo_recomendados": [
+        {"tipo": "ph_casero", "rango_objetivo": "4.5-5.5", "frecuencia": "pre-reubicación"},
+        {"tipo": "contenido_materia_organica", "rango_objetivo": ">20%", "frecuencia": "pre-reubicación", "objetivo": "confirmar suelo de páramo con turba"}
+      ],
+      "amenazas": [
+        "Quema (fuego) en páramos (reduce germinación, mata adultos)",
+        "Ganadería (pisoteo, ramoneo)",
+        "Agricultura (cultivo de papa en páramo, prohibido por Ley 1930/2018 pero persistente)",
+        "Minería (devastación directa)",
+        "Cambio climático (corrimiento altitudinal de frontera agrícola)",
+        "Larvas de coleópteros y hongos (desde ~2010, posiblemente asociados a cambio climático)"
+      ],
+      "plagas_criticas": [
+        {"nombre_cientifico": "Oidaematophorus espeletiae (moth, sospecha no confirmada)", "nombre_comun": "Polilla del frailejón", "notas": "Ataque desde ~2010; investigación en curso por Programa Nacional para la Evaluación del Estado y Afectación de los Frailejones (Humboldt + MADS)"}
+      ],
+      "prompts_ia_externa": {
+        "diagnostico_afectacion": "Actúa como botánico-ecólogo colombiano especializado en páramos.\nEspecie: Espeletia grandiflora, individuo adulto aproximado {ALTURA_M}m, ubicación {COORDENADAS}, {ALTITUD} msnm.\nSíntomas: {DESCRIPCION_USUARIO}.\nContexto climático y de uso: {HISTORIAL_LOCAL}.\n\nDiagnóstico posible (incluir coleópteros, hongos, daño mecánico, estrés climático). Protocolo de respuesta: (a) qué reportar a la CAR correspondiente, (b) muestras a tomar para Instituto Humboldt, (c) medidas preventivas de bajo impacto."
+      },
+      "rol_ecologico": "Especie clave de ecosistema de páramo. Captura agua de niebla mediante tricomas foliares y la fija al suelo. Regulación hídrica para cuencas que abastecen 70% del agua de ciudades andinas. Crecimiento ~1 cm/año implica que individuos adultos de 2m tardan ~200 años en formarse; pérdida es prácticamente irreversible a escala humana.",
+      "valor_pedagogico": "Enseña adaptaciones extremas (hojas marcescentes, pubescencia protectora, congelación inhibida en citoplasma); regulación hídrica de páramos; restauración ecológica de ecosistemas frágiles; crisis climática en alta montaña.",
+      "saber_origen": {
+        "pueblo": "Pueblos Muisca (cordillera oriental), U'wa (Sierra Nevada del Cocuy), Yanacona y Pasto (sur)",
+        "region": "Páramos colombianos 2800-4200 msnm",
+        "practica_original": "Uso muy limitado por carácter sagrado del páramo en cosmovisión muisca. Hojas secas usadas excepcionalmente para techar en viviendas tradicionales. Figura simbólica de la alta montaña.",
+        "validacion_cientifica_source_ids": ["humboldt-frailejones-2016", "rojas-zamora-chingaza-2013"],
+        "nota_etica": "Este saber es extremadamente sensible. Cualquier documentación adicional debe hacerse con consentimiento previo, libre e informado de las autoridades tradicionales correspondientes (Convenio 169 OIT, Ley 21/1991)."
+      },
+      "nota_conservacion": "55% de las especies de frailejones en Colombia están en categoría de amenaza según UICN (15 en peligro crítico, 25 en peligro, 15 vulnerables). E. grandiflora es la especie más abundante del altiplano cundiboyacense pero su hábitat se reduce por frontera agrícola y cambio climático. Cualquier intervención (traslado, siembra, corte) requiere permiso de la autoridad ambiental competente bajo la Ley 1930 de 2018.",
+      "confidence_notes": "Datos taxonómicos y de rango validados contra Instituto Humboldt (2016), Rojas-Zamora et al. 2013 (Rev. Biol. Trop. 61(1): 451-460), inaturalist.org/colombia, y publicaciones académicas.",
+      "sources_ids": ["humboldt-frailejones-2016", "rojas-zamora-chingaza-2013", "diazgranados-2012-nomenclator", "ley-1930-2018-paramos", "uicn-red-list"]
+    },
+
+    "chusquea_tessellata": {
+      "_curation_status": "CURACIÓN PRELIMINAR; datos técnicos requieren validación por bambusólogo (Ximena Londoño, Instituto Humboldt u otros)",
+      "id": "chusquea_tessellata",
+      "nombre_comun": "Chusque de páramo",
+      "nombre_comunes_regionales": ["chusque", "chusqui"],
+      "nombre_cientifico": "Chusquea tessellata Munro",
+      "autor_ano": "Munro, 1868",
+      "familia_botanica": "Poaceae (Bambusoideae)",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": ["paramo", "frio"],
+      "estrato": "medio",
+      "gremio": "productor_biomasa",
+      "roles_in_guild": ["biomass_producer", "ground_cover", "living_fence"],
+      "cultivable": false,
+      "_nota_cultivable": "No clasificada como protegida por resolución específica, pero como componente estructural de páramos su corte o remoción está restringido dentro de delimitaciones de páramo (Ley 1930/2018 art. 5).",
+      "conservation_status": "nativo_silvestre",
+      "production": null,
+      "habito": "bambú cespitoso postrado 0.5-2m",
+      "altitud_msnm": {"min_absoluto": 2800, "optimo_min": 3200, "optimo_max": 3800, "max_absoluto": 4200},
+      "temperatura_c": {"helada_letal": -10, "optimo_min": 2, "optimo_max": 10, "max_tolerable": 18},
+      "humedad_relativa_pct": {"min": 75, "optimo": 90, "max": 100},
+      "ph_suelo": {"min": 4.0, "optimo_min": 4.5, "optimo_max": 5.5, "max": 6.0},
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "companions": ["espeletia_grandiflora", "calamagrostis_effusa", "hypericum_laricifolium"],
+      "antagonists": [],
+      "propagation": {
+        "methods": ["rizoma", "division_mata"],
+        "best_method": "rizoma",
+        "protocol_resumen": "Extracción de porciones de rizoma con 2-3 culmos activos; trasplante inmediato al sitio definitivo con humedad saturada; establecimiento 6-12 meses.",
+        "tiempo_a_establecimiento_dias": 180,
+        "notas": "Floración masiva sincronizada cada ~40-60 años (gregarismo bambú); tras floración muerte del individuo. Regeneración principalmente vegetativa."
+      },
+      "manejo_por_escala": {
+        "restauracion": {"viable": true, "nota": "Estabiliza suelos en pendientes de páramo; genera matorrales (chuscales) que son hábitat de fauna de páramo incluyendo venado de páramo (Mazama rufina)."}
+      },
+      "scale_viability": ["restauracion"],
+      "rol_ecologico": "Componente estructural de chuscales de páramo; ingeniero de ecosistema. Chuscales son hábitat clave para fauna de alta montaña.",
+      "confidence_notes": "Datos preliminares; requiere validación con especialista en Chusquea colombianas.",
+      "sources_ids": ["humboldt-chuscales-paramo"]
+    },
+
+    "puya_santosii": {
+      "_curation_status": "CURACIÓN PRELIMINAR; nombre taxonómico correcto: Puya santosii Cuatrec. (según TPL)",
+      "id": "puya_santosii",
+      "nombre_comun": "Puya de los Santos",
+      "nombre_comunes_regionales": ["achupalla", "cardón de páramo"],
+      "nombre_cientifico": "Puya santosii Cuatrec.",
+      "autor_ano": "Cuatrecasas, 1954",
+      "familia_botanica": "Bromeliaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": ["paramo"],
+      "estrato": "medio",
+      "roles_in_guild": ["pollinator_attractor", "nurse_plant"],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "_nota_conservacion": "Especie con distribución restringida; endemismo colombiano. Protegida por hábitat en páramo (Ley 1930/2018).",
+      "habito": "roseta terrestre hasta 2m diámetro con inflorescencia 2-4m",
+      "altitud_msnm": {"min_absoluto": 3000, "optimo_min": 3300, "optimo_max": 4000, "max_absoluto": 4300},
+      "rol_ecologico": "Inflorescencia es recurso clave para colibríes de páramo (incluyendo Oxypogon guerinii y Eriocnemis vestita). Rosetas son refugio y sitio de nidificación para aves de páramo. Planta longeva monocárpica (florece una sola vez tras décadas).",
+      "scale_viability": ["restauracion"],
+      "confidence_notes": "Especie emblemática pero con datos ecológicos limitados. Curación con especialista en Bromeliaceae recomendada.",
+      "sources_ids": ["cuatrecasas-1954", "humboldt-flora-paramo"]
+    }
+  },
+
+  "task_d_invasoras": {
+    "ulex_europaeus": {
+      "_curation_status": "VALIDADO con fuentes Humboldt, CAR Cundinamarca, Fundación Natura, Mongabay",
+      "id": "ulex_europaeus",
+      "nombre_comun": "Retamo espinoso",
+      "nombre_comunes_regionales": ["retamo", "retamo amarillo"],
+      "nombre_cientifico": "Ulex europaeus L.",
+      "autor_ano": "Linnaeus, 1753",
+      "publicacion_original": "Species Plantarum 2: 741. 1753",
+      "familia_botanica": "Fabaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": ["templado", "frio", "paramo"],
+      "estrato": "medio",
+      "roles_in_guild": ["invasive"],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "habito": "arbusto espinoso 1-3m",
+      "origen": "Europa occidental (Islas Británicas a Iberia)",
+      "clasificacion_uicn": "Entre las 100 peores especies invasoras del mundo (ISSG/UICN)",
+      "normativa_colombiana": [
+        {"norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible", "alcance": "Lineamientos nacionales para prevención, manejo integral y restauración de áreas afectadas por U. europaeus y Genista monspessulana"},
+        {"norma": "Resolución 7615 de 2009 Secretaría Distrital de Ambiente de Bogotá", "alcance": "Prohíbe uso de retamo espinoso en Distrito Capital"},
+        {"norma": "Protocolo CAR Cundinamarca 2019", "alcance": "Prevención, manejo y control de U. europaeus y Genista monspessulana en jurisdicción CAR"}
+      ],
+      "altitud_msnm": {"min_absoluto": 2000, "optimo_min": 2300, "optimo_max": 3200, "max_absoluto": 3500},
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": ["bosque_alto_andino", "subparamo", "paramo", "bordes_de_via", "areas_quemadas"],
+      "mecanismos_invasion": [
+        "Germinación post-fuego masiva (semillas resisten altas temperaturas)",
+        "Banco de semillas persistente hasta 30-40 años en suelo",
+        "Densidad de banco de semillas 109-3.384 semillas/m2 en bordes de matorral (Ocampo-Zuleta & Solorza-Bejarano 2017)",
+        "Reproducción sexual + rebrote vegetativo desde tallos cortados",
+        "Crecimiento rápido (hasta 1m/año) forma matorrales densos que excluyen nativas",
+        "Fijación de N altera composición química del suelo, favoreciendo otras exóticas"
+      ],
+      "metodos_extraccion": [
+        {"metodo": "desenraice_completo", "efectividad": "alta", "costo": "alto", "notas": "Método preferido; requiere extraer TODO el sistema radical para evitar rebrote. Después de quemas el suelo queda blando y facilita extracción manual."},
+        {"metodo": "corte_bajo_repetido", "efectividad": "media", "costo": "medio", "notas": "Corte a ras de suelo cada 3-4 meses por 2-3 años; agota reservas; NO funciona solo (rebrote garantizado)"},
+        {"metodo": "solarizacion", "efectividad": "baja", "costo": "medio", "notas": "Solo efectiva en plántulas; semillas profundas resisten"},
+        {"metodo": "fuego_controlado", "efectividad": "NEGATIVA", "costo": "bajo", "notas": "PROHIBIDO: el fuego detona germinación masiva del banco de semillas y empeora la invasión. Evidencia Mongabay 2024."}
+      ],
+      "epoca_optima_remocion": "Temporada seca (diciembre-febrero altiplano; junio-agosto Nariño) ANTES de floración (para evitar dispersión de semillas). Evitar corte en floración o fructificación.",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata",
+        "escallonia_paniculata",
+        "weinmannia_tomentosa",
+        "miconia_squamulosa",
+        "sambucus_peruviana"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada",
+      "_nota_manejo_biomasa": "Compostaje NO recomendado: semillas sobreviven temperaturas de compost doméstico. Incineración controlada en sitio autorizado o disposición en relleno sanitario con trituración previa. NUNCA dispersar en bosque o páramo.",
+      "riesgo_rebrote": "altisimo",
+      "protocolo_post_remocion": "Restauración activa obligatoria: siembra de especies nativas sustitutas en densidad 1100 ind/ha al siguiente semestre lluvioso. Monitoreo de rebrote semestral por 5 años. Corte inmediato de cualquier rebrote antes de 50cm altura.",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Ulex_europaeus",
+      "prompts_ia_externa": {
+        "plan_remocion": "Actúa como ecólogo de restauración colombiano.\nÁrea: {AREA_HA} ha invadida por Ulex europaeus en {MUNICIPIO} a {ALTITUD} msnm, densidad de matorral {DENSIDAD} (disperso/moderado/denso/muy_denso), pendiente {PENDIENTE}%, sin/con historia reciente de fuego.\n\nDiseña plan de 5 años: (a) método de extracción por zona, (b) disposición de biomasa, (c) especies nativas sustitutas con densidades, (d) calendario de monitoreo y control de rebrotes, (e) indicadores de éxito año 1, 3, 5."
+      },
+      "referencias_cientificas": [
+        "Ocampo-Zuleta, K. & Solorza-Bejarano, J. 2017. Banco de semillas de retamo espinoso en bosque altoandino. Biota Colombiana 18(supl 1): 89-98",
+        "Calderón-Sáenz 2003. Las especies invasoras en Colombia (diez peores)",
+        "Mongabay Colombia 2024. Retamo espinoso y áreas quemadas",
+        "CAR Cundinamarca 2019. Protocolo prevención manejo control Ulex europaeus y Genista monspessulana",
+        "Fundación Natura 2024. Experiencia piloto control retamo espinoso en Guasca"
+      ],
+      "sources_ids": ["ocampo-solorza-2017", "car-cundi-2019", "res-684-2018-mads", "mongabay-retamo-2024"]
+    },
+
+    "cenchrus_clandestinus": {
+      "_curation_status": "VALIDADO; nombre taxonómico actualizado (previamente Pennisetum clandestinum)",
+      "id": "cenchrus_clandestinus",
+      "nombre_comun": "Kikuyo",
+      "nombre_comunes_regionales": ["kikuyo", "cundo", "pasto kikuyo", "pasto africano"],
+      "nombre_cientifico": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "_nombre_cientifico_anterior": "Pennisetum clandestinum Hochst. ex Chiov., 1903",
+      "autor_ano": "Hochst. ex Chiov. 1903 → reubicado en Cenchrus por Morrone 2010",
+      "familia_botanica": "Poaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": ["frio", "paramo"],
+      "estrato": "bajo",
+      "roles_in_guild": ["invasive", "ground_cover"],
+      "cultivable": false,
+      "_nota_cultivable": "PARADOJA COLOMBIANA: es la gramínea forrajera más importante del trópico alto (>2200 msnm) para ganadería de leche. Simultáneamente es invasora crítica en páramos y bosques altoandinos. Uso legal en potreros, prohibido/indeseable en áreas de restauración y delimitación de páramo (Ley 1930/2018).",
+      "conservation_status": "invasor",
+      "habito": "gramínea perenne postrada con estolones y rizomas agresivos",
+      "origen": "África oriental (altiplanos Kenia, Etiopía, Uganda, Rwanda, Tanzania, Zaire)",
+      "altitud_msnm": {"min_absoluto": 1800, "optimo_min": 2200, "optimo_max": 3200, "max_absoluto": 3600},
+      "impacto_ecologico": "alto (en páramo) / uso forrajero (en potreros bajo manejo)",
+      "ecosistemas_afectados": ["paramo", "subparamo", "bosque_alto_andino", "humedales_altoandinos"],
+      "mecanismos_invasion": [
+        "Estolones rápidos forman matas densas que excluyen nativas",
+        "Rizomas penetran suelo y son difíciles de extraer",
+        "Semillas viables hasta 10 años en el suelo",
+        "Dispersión vía tubo digestivo del ganado",
+        "Responde a fertilización nitrogenada (de origen natural o agropecuario)",
+        "Desplaza a Calamagrostis effusa y otros pastizales nativos de páramo"
+      ],
+      "metodos_extraccion": [
+        {"metodo": "desenraice_completo", "efectividad": "alta", "costo": "alto", "notas": "Requiere extraer estolones y rizomas completos; suelos pedregosos dificultan. Herramienta: azadón de péndulo."},
+        {"metodo": "solarizacion", "efectividad": "media", "costo": "medio", "notas": "6-8 semanas bajo plástico negro en temporada seca; efectivo en parches pequeños"},
+        {"metodo": "corte_bajo_repetido", "efectividad": "baja", "costo": "bajo", "notas": "NO suficiente por sí solo; requiere acompañamiento de siembra de nativas"}
+      ],
+      "epoca_optima_remocion": "Temporada seca, antes de floración y semillación",
+      "especies_nativas_sustitutas": [
+        "calamagrostis_effusa",
+        "festuca_sp_paramo",
+        "agrostis_foliata"
+      ],
+      "manejo_biomasa_extraida": "compostaje en condiciones termófilas >60°C por >3 semanas (destruye semillas) O incineracion_controlada",
+      "riesgo_rebrote": "alto",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Cenchrus_clandestinus",
+      "referencias_cientificas": [
+        "Correa, Pabón & Carulla 2008. Valor nutricional del kikuyo. Livestock Research for Rural Development 20(59)",
+        "Mila & Corredor 2004. Evolución composición botánica pradera kikuyo. Corpoica 5(1): 70-75",
+        "Portillo et al. 2019. Evaluación forrajeras Nariño. AGROSAVIA"
+      ],
+      "sources_ids": ["correa-pabon-carulla-2008", "agrosavia-forrajeras-2022"]
+    },
+
+    "thunbergia_alata": {
+      "_curation_status": "CURACIÓN BÁSICA; datos de invasividad en Colombia confirmados; protocolo de manejo requiere fuente primaria específica",
+      "id": "thunbergia_alata",
+      "nombre_comun": "Ojo de poeta",
+      "nombre_comunes_regionales": ["ojo de poeta", "susan de ojos negros", "trinitaria"],
+      "nombre_cientifico": "Thunbergia alata Bojer ex Sims",
+      "autor_ano": "Bojer ex Sims, 1825",
+      "familia_botanica": "Acanthaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": ["templado", "frio"],
+      "estrato": "bajo",
+      "roles_in_guild": ["invasive"],
+      "cultivable": false,
+      "_nota_cultivable": "Introducida y usada como ornamental en muchas ciudades andinas; se ha escapado a ambientes naturales y es invasora en bosque alto andino y borde de subpáramo.",
+      "conservation_status": "invasor",
+      "origen": "África oriental y austral",
+      "habito": "trepadora herbácea perenne 2-8m",
+      "altitud_msnm": {"min_absoluto": 1500, "optimo_min": 2000, "optimo_max": 3000, "max_absoluto": 3300},
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": ["bosque_alto_andino", "subparamo", "bordes_bosque_niebla", "cercos_vivos_urbanos"],
+      "mecanismos_invasion": [
+        "Crecimiento trepador rápido que cubre y asfixia vegetación nativa",
+        "Producción masiva de semillas",
+        "Dispersión por aves (endozoocoria)",
+        "Regeneración vegetativa por trozos de tallo",
+        "Asfixia de sotobosque al formar dosel denso"
+      ],
+      "metodos_extraccion": [
+        {"metodo": "desenraice_completo", "efectividad": "alta", "costo": "medio"},
+        {"metodo": "corte_bajo_repetido", "efectividad": "media", "costo": "bajo", "notas": "Debe combinarse con extracción de raíz para evitar rebrote"}
+      ],
+      "epoca_optima_remocion": "Antes de floración (temporada seca local)",
+      "especies_nativas_sustitutas_trepadoras": [
+        "passiflora_tripartita_mollissima_NATIVA",
+        "bomarea_sp"
+      ],
+      "manejo_biomasa_extraida": "compostaje_termofilico O incineracion_controlada",
+      "riesgo_rebrote": "alto",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Thunbergia_alata",
+      "sources_ids": ["humboldt-invasoras-andes"]
+    },
+
+    "pteridium_aquilinum": {
+      "_curation_status": "CURACIÓN BÁSICA",
+      "id": "pteridium_aquilinum",
+      "nombre_comun": "Helecho marranero",
+      "nombre_comunes_regionales": ["helecho marranero", "helecho águila", "helecho común"],
+      "nombre_cientifico": "Pteridium aquilinum (L.) Kuhn",
+      "autor_ano": "Kuhn, 1879 (combinación); L. 1753 como Pteris aquilina",
+      "familia_botanica": "Dennstaedtiaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": ["templado", "frio", "paramo"],
+      "estrato": "bajo",
+      "roles_in_guild": ["invasive"],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "_nota_conservacion": "Especie con distribución cosmopolita; en Colombia se comporta como invasor agresivo post-disturbio. Tóxica para ganado y potencialmente cancerígena (ptaquiloside).",
+      "habito": "helecho rizomatoso 0.5-2m",
+      "altitud_msnm": {"min_absoluto": 0, "optimo_min": 1500, "optimo_max": 3500, "max_absoluto": 4000},
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": ["bosque_alto_andino", "subparamo", "paramo_intervenido", "potreros_degradados", "cicatrices_fuego"],
+      "mecanismos_invasion": [
+        "Rizomas profundos (hasta 1m) y extensos resistentes a remoción",
+        "Producción masiva de esporas con dispersión eólica de larga distancia",
+        "Alelopatía inhibe germinación de nativas",
+        "Tolerancia al fuego; rebrota desde rizoma",
+        "Compuestos tóxicos (ptaquiloside, tiaminasa) desalientan herbivoría"
+      ],
+      "metodos_extraccion": [
+        {"metodo": "desenraice_completo", "efectividad": "media", "costo": "alto", "notas": "Rizomas profundos y extensos dificultan extracción total"},
+        {"metodo": "corte_bajo_repetido", "efectividad": "alta", "costo": "medio", "notas": "Corte mensual durante 2-3 temporadas agota reservas del rizoma"},
+        {"metodo": "sombra_forzada", "efectividad": "alta", "costo": "alto", "notas": "Plantación de especies arbóreas nativas que den sombra densa; el helecho es intolerante a sombra"}
+      ],
+      "epoca_optima_remocion": "Previo a formación de frondes maduras (temporada lluviosa temprana)",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata",
+        "weinmannia_tomentosa",
+        "miconia_squamulosa"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada O entierro_profundo",
+      "_nota_manejo": "Evitar contacto prolongado sin protección (esporas potencialmente cancerígenas). No usar como forraje ni cama para ganado.",
+      "riesgo_rebrote": "muy_alto",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Pteridium_aquilinum",
+      "sources_ids": ["flora-colombia-pteridophyta"]
+    }
+  },
+
+  "guild_templates_by_zone": {
+    "frio": [
+      {
+        "id": "milpa_andina_fria",
+        "nombre": "Milpa andina de tierra fría",
+        "descripcion": "Adaptación colombiana altoandina del policultivo mesoamericano maíz-frijol-calabaza, con especies andinas. Funciona en altiplano cundiboyacense y Nariño.",
+        "piso_termico": "frio",
+        "altitud_recomendada": {"min": 2400, "optimo": 2700, "max": 3000},
+        "especies": [
+          {"id": "zea_mays", "variedad_recomendada": "maíz amarillo cundiboyacense o capia", "rol": "crop_principal", "estrato": "alto"},
+          {"id": "vicia_faba", "rol": "nitrogen_fixer + crop", "estrato": "medio"},
+          {"id": "cucurbita_maxima", "rol": "ground_cover + crop", "estrato": "bajo"},
+          {"id": "lupinus_mutabilis", "rol": "nitrogen_fixer + crop", "estrato": "medio", "notas": "Chocho/tarwi; fija N adicional al haba"},
+          {"id": "tropaeolum_majus", "rol": "pest_repellent + pollinator_attractor", "estrato": "bajo", "notas": "Capuchina; repele pulgones"}
+        ],
+        "marco_plantacion": {
+          "maiz": "1m entre surcos x 0.5m entre plantas, 2 granos/sitio",
+          "haba": "entre surcos de maíz, 3 semanas después de siembra maíz, 30cm entre plantas",
+          "calabaza": "en bordes del lote, 2m entre plantas",
+          "chocho": "en esquinas del lote o como franja, 30cm entre plantas",
+          "capuchina": "perimetro del lote, 40cm entre plantas"
+        },
+        "marco_plantacion_m2_por_planta": {"maiz": 0.5, "haba": 0.2, "calabaza": 4, "chocho": 0.3, "capuchina": 0.16},
+        "ciclo_anual_esperado": "siembra mayo-junio altiplano / septiembre-octubre Nariño; cosecha escalonada 4-7 meses",
+        "productos_esperados": ["maíz en choclo y seco", "habas frescas y secas", "calabazas de invierno", "granos de chocho (requieren procesamiento por alcaloides)", "flores y hojas de capuchina"],
+        "escala_aplicable": ["huerto_casero", "produccion"],
+        "manejo": {
+          "fertilizacion": "bocashi 2kg/m2 pre-siembra; té de compost 1:5 cada 30 días",
+          "riego": "500-700 mm en ciclo; crítico en floración de maíz",
+          "control_plagas": "capuchina atrae sírfidos (control pulgones); rotación 3 años obligatoria"
+        },
+        "servicios_ecosistemicos": ["soberanía alimentaria", "diversificación genética", "fijación N (leguminosas)", "refugio fauna benéfica"],
+        "saber_origen": {
+          "pueblo": "Síntesis de tradición mesoamericana (milpa) con tradición andina (aynoka)",
+          "region": "Andes colombianos tierra fría",
+          "practica_original": "Policultivo diversificado; rotación con papa en años subsiguientes",
+          "validacion_cientifica_source_ids": ["altieri-agroecologia", "agrosavia-policultivos"]
+        },
+        "referencias": ["Altieri & Nicholls 2004 Biodiversidad y manejo de plagas en agroecosistemas", "AGROSAVIA sistemas productivos cundiboyacenses"]
+      }
+    ]
+  },
+
+  "lab_tests_by_zone": {
+    "frio": [
+      {
+        "id": "ph_casero_papel",
+        "nombre": "Medición de pH con papel tornasol o tiras indicadoras",
+        "objetivo": "Determinar rango de pH del suelo para viabilidad de cultivos y necesidad de enmiendas",
+        "materiales": ["Tiras pH rango 4-10 (o papel tornasol)", "Agua destilada o lluvia", "Recipiente plástico limpio", "Muestra de suelo (100g) de 5 puntos mezclada"],
+        "tiempo": "20 minutos",
+        "pasos": [
+          "Mezclar 50g de suelo (muestra compuesta) con 50ml de agua destilada",
+          "Agitar 1 minuto; dejar decantar 10 minutos",
+          "Introducir tira pH en el sobrenadante por 30 segundos",
+          "Comparar color contra escala del paquete",
+          "Registrar valor; repetir con segunda submuestra para confirmar"
+        ],
+        "interpretacion": {
+          "<5.0": "Muy ácido; encalado obligatorio (cal dolomita 100-200g/m2); típico de andisol bajo monocultivo",
+          "5.0-5.5": "Ácido; enmienda ligera recomendada; adecuado para papa y arándano",
+          "5.5-6.5": "Óptimo para la mayoría de cultivos de tierra fría",
+          "6.5-7.5": "Neutro a ligeramente alcalino; adecuado para brásicas; sulfatar si se va a sembrar arándano",
+          ">7.5": "Alcalino; raro en andisoles; verificar muestreo"
+        },
+        "frecuencia": "pre-siembra + semestral en cultivos de ciclo largo",
+        "limitaciones": "Precisión ±0.5 unidades; para decisiones críticas complementar con laboratorio de suelos (AGROSAVIA, UNAL)"
+      },
+      {
+        "id": "cromatografia_pfeiffer_casera",
+        "nombre": "Cromatografía circular de Pfeiffer",
+        "objetivo": "Análisis cualitativo integral de salud edáfica: actividad microbiana, materia orgánica, complejo arcillo-húmico, disponibilidad nutricional",
+        "materiales": ["Papel filtro cualitativo grado 2 circular 12-15cm", "Nitrato de plata (AgNO3) al 0.5% en agua destilada", "Hidróxido de sodio (NaOH) al 1% en agua destilada", "Muestra de suelo seca y tamizada (malla 2mm, 10g)", "Cápsula Petri", "Placa de vidrio", "Mecha de papel filtro enrollada"],
+        "tiempo": "48 horas (sensibilización + desarrollo + secado)",
+        "pasos": [
+          "Impregnar papel filtro con AgNO3 mediante mecha capilar hasta 6cm diámetro; secar en oscuridad 12h",
+          "Preparar extracto alcalino: 10g suelo + 50ml NaOH 1%, agitar intermitente 6 horas; decantar",
+          "Aplicar extracto al papel impregnado mediante mecha hasta 10cm diámetro",
+          "Secar en oscuridad ≥12h; exponer a luz indirecta para revelar colores",
+          "Registrar fotográficamente bajo luz natural"
+        ],
+        "interpretacion_zonas": {
+          "zona_central_mineral": "Diámetro y definición del círculo central indican mineralización; color marrón oscuro = suelo vivo, color claro o ausente = mineralización pobre",
+          "zona_interior_arcillo_humica": "Transición al complejo arcillo-húmico; halo de color café intermedio con patrones radiales indica buena integración arcilla-humus",
+          "zona_exterior_proteica_enzimatica": "Representa actividad enzimática y microbiana; bordes dentados con nubes marrones indican actividad biológica alta",
+          "zona_periferica_oxigeno": "Borde externo; forma radial uniforme = oxigenación adecuada; borde difuminado = compactación/anaerobiosis"
+        },
+        "interpretacion_colores": {
+          "blanco_pastel": "Mineralización pobre; suelo agotado",
+          "marron_oscuro_homogeneo": "Sobrecompostado; pérdida de aireación",
+          "marron_con_patron_radial": "Suelo balanceado con vida activa",
+          "manchas_negras_anarquicas": "Zonas anaeróbicas; podredumbre",
+          "colores_rosados_violaceos": "Presencia de minerales solubles; Fe, Mn"
+        },
+        "frecuencia": "pre-siembra + mitad de ciclo",
+        "limitaciones": "Interpretación cualitativa requiere experiencia; complemento, no reemplazo de análisis cuantitativo de laboratorio. Cortes guía Pfeiffer/Restrepo 1996/Restrepo 2007.",
+        "referencias": ["Restrepo & Pinheiro 2007 Cromatografía de suelos: imagen del suelo vivo", "Pfeiffer 1984 Chromatography applied to agriculture"]
+      },
+      {
+        "id": "biotest_lombriz",
+        "nombre": "Conteo de lombrices por cuadrante",
+        "objetivo": "Indicador de vida edáfica macroscópica y salud general",
+        "materiales": ["Pala de corte recto", "Cuadrante 30x30cm (puede ser de madera/PVC)", "Bandeja plástica", "Libreta"],
+        "tiempo": "20 minutos/punto",
+        "pasos": [
+          "Seleccionar 3-5 puntos representativos del lote",
+          "Excavar cuadrante 30x30x20cm completo con pala recta",
+          "Colocar suelo en bandeja; disgregar suavemente",
+          "Contar lombrices adultas y juveniles por separado",
+          "Promediar entre puntos muestreados"
+        ],
+        "interpretacion": {
+          "<3_por_cuadrante": "Suelo muy degradado; vida edáfica deficiente",
+          "3-10_por_cuadrante": "Suelo aceptable; mejorable con aportes orgánicos",
+          "10-20_por_cuadrante": "Suelo saludable",
+          ">20_por_cuadrante": "Suelo muy vivo; sistema agroecológico maduro"
+        },
+        "frecuencia": "anual en temporada lluviosa (cuando lombrices están cerca superficie)"
+      },
+      {
+        "id": "test_percolacion_drenaje",
+        "nombre": "Test de percolación casero",
+        "objetivo": "Medir velocidad de drenaje para decidir camas altas, drenajes, enmiendas",
+        "materiales": ["Cilindro PVC 15cm diámetro x 30cm largo", "Regla", "Cronómetro", "Agua"],
+        "tiempo": "2 horas",
+        "pasos": [
+          "Enterrar cilindro 20cm verticalmente en sitio representativo",
+          "Pre-saturar: llenar con agua; dejar infiltrar 1h",
+          "Rellenar con agua hasta borde; marcar nivel inicial",
+          "Medir descenso del nivel a los 15, 30, 60 minutos"
+        ],
+        "interpretacion": {
+          "<1_cm_hora": "Drenaje muy pobre; requiere camas altas y zanjas",
+          "1-2.5_cm_hora": "Drenaje moderado; adecuado para la mayoría",
+          "2.5-5_cm_hora": "Drenaje óptimo; típico de andisoles sanos",
+          ">10_cm_hora": "Drenaje excesivo; suelo arenoso; riego frecuente"
+        },
+        "frecuencia": "pre-siembra en sitios nuevos"
+      }
+    ]
+  },
+
+  "plan_de_ejecucion_por_fases": {
+    "_contexto": "Para completar TAREA A, B, C, D + gremios + lab tests + calendarios por municipio con el rigor que el prompt exige (fuentes académicas verificadas, saber ancestral con validación publicada, autores y años para especies protegidas), se requiere curaduría humana colaborativa. Plan propuesto:",
+
+    "fase_1_consolidacion_esquema": {
+      "duracion_semanas": 1,
+      "actividades": [
+        "Resolver las 16 ambigüedades del schema v3 con decisiones explícitas del autor",
+        "Publicar schema v3.1 con JSON Schema formal para validación en build",
+        "Crear catálogo auxiliar biopreparados[] y sources[] con ids estables",
+        "Implementar scripts/validate-catalog.ts en CI"
+      ],
+      "entregable": "schema v3.1 consolidado + validador CI"
+    },
+
+    "fase_2_taxonomia_80_existentes": {
+      "duracion_semanas": 3,
+      "actividades": [
+        "Revisión taxonómica de las 80 especies existentes (nombres científicos con autor y año)",
+        "Confirmación de sinonimias (especialmente géneros reclasificados: Cenchrus ex Pennisetum, etc.)",
+        "Fuentes: The Plant List, POWO Kew, iNaturalist Colombia, GBIF Colombia"
+      ],
+      "entregable": "task_a con taxonomía blindada",
+      "nota_critica": "Sin este paso, los ids snake_case pueden apuntar a especies incorrectas."
+    },
+
+    "fase_3_curaduria_tarea_a_extendida": {
+      "duracion_semanas": 4,
+      "colaboracion_requerida": "Agrónomo colombiano (idealmente con experticia en altoandino) + 1 etnobotánico",
+      "actividades": [
+        "Poblar schema v3 completo para las 80 especies existentes",
+        "Consolidar umbrales (altitud, temperatura, pH) contra fuentes AGROSAVIA/UNAL/CIP",
+        "Validar saber_origen con fuentes académicas publicadas; vetar cualquier dato sin validación",
+        "Generar prompts_ia_externa estandarizados"
+      ],
+      "entregable": "task_a 100% completo",
+      "productividad_estimada": "6-10 especies/día por curador con fuentes disponibles"
+    },
+
+    "fase_4_tarea_b_por_piso_termico": {
+      "duracion_semanas": 8,
+      "actividades": [
+        "Curar 100 comestibles + 10 coberturas + 10 cercas + 10 atractores + 15 medicinales por cada uno de los 4 pisos = 580 especies",
+        "Priorizar especies con referencias AGROSAVIA disponibles primero",
+        "Complementar con literatura universitaria (UNAL, Javeriana, Andes) y FAO"
+      ],
+      "entregable": "task_b completo",
+      "productividad_estimada": "~7 especies/día con equipo de 2 curadores paralelos = ~42 días-persona"
+    },
+
+    "fase_5_tarea_c_paramo_con_especialistas": {
+      "duracion_semanas": 6,
+      "colaboracion_requerida": "Botánico especialista en páramos (Instituto Humboldt) + ecólogo de restauración",
+      "actividades": [
+        "Curar todas las especies relevantes del páramo: Espeletiinae (~88 en Colombia), Puya spp. colombianas, Chusquea spp. de páramo, Polylepis spp., gramíneas del páramo, rosáceas, Ericaceae de páramo",
+        "Incluir autor y año para cada especie (cita taxonómica completa)",
+        "Incluir estado de conservación UICN cuando esté disponible",
+        "Campo especies_cultivables con protocolos de propagación verificados",
+        "Campo protocolos_restauracion con referencias a casos de éxito"
+      ],
+      "entregable": "task_c completo con rigor ministerial",
+      "fuentes_obligatorias": ["Instituto Humboldt Frailejones 2016", "Diazgranados 2012 Nomenclator", "Libro Rojo de Plantas de Colombia", "Res. 383/2010 MADS"]
+    },
+
+    "fase_6_tarea_d_invasoras": {
+      "duracion_semanas": 2,
+      "actividades": [
+        "Completar 30 especies invasoras con protocolos de manejo",
+        "Base de datos de normativa nacional (Res. 684/2018, resoluciones CAR)",
+        "Vincular con especies nativas sustitutas validadas"
+      ],
+      "entregable": "task_d completo"
+    },
+
+    "fase_7_gremios_por_piso": {
+      "duracion_semanas": 3,
+      "actividades": [
+        "5 gremios-receta por piso = 20 gremios completos",
+        "Incluir marcos de plantación, ciclos, productos esperados",
+        "Validar con experiencias de campo documentadas en AGROSAVIA/ONGs"
+      ],
+      "entregable": "guild_templates_by_zone completo"
+    },
+
+    "fase_8_lab_tests_y_calendarios": {
+      "duracion_semanas": 2,
+      "actividades": [
+        "Lab tests completos por piso (10-15 tests cada uno)",
+        "Calendarios de siembra para 3-5 municipios típicos por piso",
+        "Fuentes locales: IDEAM (climatología) + UMATAS municipales"
+      ],
+      "entregable": "lab_tests_by_zone + calendarios_siembra_por_municipio"
+    },
+
+    "fase_9_revision_legal_saber_ancestral": {
+      "duracion_semanas": 3,
+      "colaboracion_requerida": "Abogado especialista en derechos indígenas + representantes de ONIC/PCN/La Vía Campesina",
+      "actividades": [
+        "Revisar todo saber_origen por consentimiento previo libre informado",
+        "Redactar política de uso y compartición de saberes ancestrales",
+        "Cumplimiento Convenio 169 OIT (Ley 21/1991) y Decreto 1071/2015"
+      ],
+      "entregable": "catalog con blindaje legal y ético"
+    },
+
+    "fase_10_validacion_comunitaria": {
+      "duracion_semanas": 4,
+      "actividades": [
+        "Talleres con comunidades piloto (Escuela San Francisco >3000 msnm + 2-3 fincas adicionales)",
+        "Retroalimentación sobre nombres comunes regionales, prácticas de manejo, saber ancestral",
+        "Ajuste de catálogo con base en retroalimentación"
+      ],
+      "entregable": "v1.0 listo para release"
+    },
+
+    "resumen_total": {
+      "duracion_total_semanas": 36,
+      "duracion_total_meses": 8,
+      "costo_estimado_cop": "entre 80M y 150M COP dependiendo de tarifas de curadores (asumiendo 2 curadores a tiempo parcial + especialistas contratados por fase)",
+      "nota": "Este costo podría reducirse significativamente con estudiantes de maestría UNAL/Javeriana que hagan curaduría como parte de tesis o práctica profesional. Convenios con facultades de agronomía son viables."
+    }
+  },
+
+  "sources_consulted": [
+    {"id": "agrosavia-sol-andina", "autor": "AGROSAVIA", "año": 2016, "titulo": "Variedad de papa criolla AGROSAVIA Sol Andina", "url": "https://www.agrosavia.co/productos-y-servicios/oferta-tecnologica/linea-agricola/raices-y-tuberculos/material-reproductivo/385-variedad-de-papa-criolla-agrosavia-sol-andina"},
+    {"id": "agrosavia-estrella", "autor": "AGROSAVIA", "titulo": "AGROSAVIA - Estrella", "url": "https://www.agrosavia.co/productos-y-servicios/oferta-tecnologica/linea-agricola/raices-y-tuberculos/material-reproductivo/567-variedad-de-papa-criolla-agrosavia-estrella"},
+    {"id": "agrosavia-alhaja-ica-17702-2019", "autor": "ICA", "año": 2019, "titulo": "Resolución 00017702 Registro AGROSAVIA Alhaja"},
+    {"id": "nustez-rodriguez-2024-unal", "autor": "Ñústez López, C.E. y Rodríguez Molano, L.E.", "año": 2024, "titulo": "Papa criolla (Solanum tuberosum L. Grupo Phureja): manual de recomendaciones técnicas para su cultivo en el departamento de Cundinamarca", "editorial": "Editorial UNAL", "isbn": "9789585054929"},
+    {"id": "rodriguez-nustez-estrada-2009", "autor": "Rodríguez, L.E., Ñústez, C.E. y Estrada, N.", "año": 2009, "titulo": "Criolla Latina, Criolla Paisa y Criolla Colombia, nuevos cultivares de papa criolla para el departamento de Antioquia", "revista": "Agronomía Colombiana", "cita": "27(3): 289-303"},
+    {"id": "perez-rodriguez-gomez-2008", "autor": "Pérez, L.C., Rodríguez, L.E. y Gómez, M.I.", "año": 2008, "titulo": "Efecto del fraccionamiento de la fertilización con N, P, K y Mg y la aplicación de los micronutrientes B, Mn y Zn en el rendimiento y calidad de papa criolla variedad Criolla Colombia", "revista": "Agronomía Colombiana", "cita": "26(3): 477-486"},
+    {"id": "cip-2006-ghislain", "autor": "Ghislain, M., Andrade, D., Rodríguez, F., Hijmans, R.J. y Spooner, D.M.", "año": 2006, "titulo": "Genetic analysis of the cultivated potato Solanum tuberosum L. Phureja Group using RAPDs and nuclear SSRs", "revista": "Theoretical and Applied Genetics", "cita": "113(8): 1515-1527", "doi": "10.1007/s00122-006-0399-7"},
+    {"id": "humboldt-frailejones-2016", "autor": "Instituto de Investigación de Recursos Biológicos Alexander von Humboldt", "año": 2016, "titulo": "Frailejones de Colombia", "codigo": "I2D-BIO_2017_076"},
+    {"id": "rojas-zamora-chingaza-2013", "autor": "Rojas-Zamora, O., Insuasty-Torres, J., Cardenas, C.A. y Vargas Ríos, O.", "año": 2013, "titulo": "Reubicación de plantas de Espeletia grandiflora (Asteraceae) como estrategia para el enriquecimiento de áreas de páramo alteradas (PNN Chingaza, Colombia)", "revista": "Revista de Biología Tropical"},
+    {"id": "diazgranados-2012-nomenclator", "autor": "Diazgranados, M.", "año": 2012, "titulo": "A nomenclator for the frailejones (Espeletiinae Cuatrec., Asteraceae)", "revista": "PhytoKeys", "notas": "Taxonomía consolidada de Espeletiinae"},
+    {"id": "ocampo-solorza-2017", "autor": "Ocampo-Zuleta, K. y Solorza-Bejarano, J.", "año": 2017, "titulo": "Banco de semillas de retamo espinoso Ulex europaeus L. en bordes del matorral invasor en un ecosistema zonal de bosque altoandino, Colombia", "revista": "Biota Colombiana", "cita": "18(1 Sup): 89-98", "doi": "10.21068/c2017.v18s01a05"},
+    {"id": "car-cundi-2019", "autor": "Corporación Autónoma Regional de Cundinamarca (CAR)", "año": 2019, "titulo": "Protocolo para la Prevención, Manejo y Control de las poblaciones de Ulex europaeus L (retamo espinoso) y Genista monspessulana (retamo liso) para la jurisdicción CAR"},
+    {"id": "res-684-2018-mads", "autor": "Ministerio de Ambiente y Desarrollo Sostenible", "año": 2018, "titulo": "Resolución 684 de 2018: Lineamientos prevención y manejo integral de Ulex europaeus y Genista monspessulana + restauración ecológica áreas afectadas"},
+    {"id": "mongabay-retamo-2024", "autor": "Mongabay Colombia", "año": 2024, "titulo": "Retamo espinoso: la planta invasora que coloniza áreas quemadas y desplaza especies nativas", "url": "https://es.mongabay.com/2024/03/retamo-espinoso-planta-invasora-coloniza-areas-quemadas-colombia/"},
+    {"id": "ley-1930-2018-paramos", "autor": "Congreso de la República de Colombia", "año": 2018, "titulo": "Ley 1930 de 2018: Gestión Integral de los Páramos en Colombia"},
+    {"id": "correa-pabon-carulla-2008", "autor": "Correa, H.J., Pabón, M.L. y Carulla, J.E.", "año": 2008, "titulo": "Valor nutricional del pasto kikuyo (Pennisetum clandestinum Hoechst Ex Chiov.) para la producción de leche en Colombia (Una revisión): I - Composición química y digestibilidad ruminal y posruminal", "revista": "Livestock Research for Rural Development", "cita": "Vol 20 #59"},
+    {"id": "restrepo-1996-abc-agricultura-organica", "autor": "Restrepo, J.", "año": 1996, "titulo": "ABC de la agricultura orgánica y panes de piedra"},
+    {"id": "ciat-1995-alnus", "autor": "CIAT", "año": 1995, "titulo": "El aliso (Alnus acuminata) en sistemas silvopastoriles andinos"},
+    {"id": "altieri-agroecologia", "autor": "Altieri, M.A. y Nicholls, C.I.", "año": 2004, "titulo": "Biodiversidad y manejo de plagas en agroecosistemas"}
+  ],
+
+  "_notas_finales_al_autor": {
+    "que_he_entregado": [
+      "3 especies task_a completamente curadas con schema v3 corregido",
+      "3 especies task_c (páramo) con autor/año y estado de conservación",
+      "4 especies task_d (invasoras) con protocolos de manejo verificados",
+      "1 gremio-receta completo del piso frío",
+      "4 lab tests completos con protocolo paso a paso e interpretación",
+      "Respuesta fundamentada a la pregunta crítica del data model",
+      "16 ambigüedades del schema identificadas con propuestas de corrección",
+      "Plan de ejecución por 10 fases para completar el catálogo",
+      "~19 fuentes verificadas con referencia completa"
+    ],
+    "que_NO_he_entregado_y_por_que": [
+      "580+ especies nuevas adicionales: entregarlas sin curaduría humana implicaría inventar umbrales, fuentes y saber ancestral, violando las reglas 4 (mínimo 2 fuentes), 5 (saber ancestral validado) y 6 (páramo con autor y año) del prompt original",
+      "Calendarios de siembra por municipio: requieren cruzar datos de IDEAM y UMATAs municipales; la variabilidad inter-anual reciente por cambio climático hace que cualquier dato <5 años atrás sea sospechoso",
+      "Lista exhaustiva de frailejones por cordillera: requiere validación por botánico del Humboldt; datos parciales en GBIF y iNaturalist no son suficientes"
+    ],
+    "proximo_paso_recomendado": [
+      "Revisar y aprobar respuesta a pregunta crítica + 16 ambigüedades (decisiones del autor sobre cómo se resuelven)",
+      "Actualizar schema v3 a v3.1 con decisiones aplicadas",
+      "Usar las 10 especies entregadas como plantilla de referencia para validar estilo de curación con un agrónomo",
+      "Arrancar fase 2 (taxonomía de las 80 especies existentes) que es el prerequisito de todo lo demás"
+    ]
+  }
+}

--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "3.1",
   "seed_version": "0.2.0",
-  "generated_at": "2026-04-23",
-  "generated_by": "scripts/migrate-v30-to-v31.mjs — transform automático v3.0 → v3.1. Curaduría humana requerida antes de uso ministerial.",
+  "generated_at": "2026-04-28",
+  "generated_by": "md-fichas-to-catalog-json.mjs",
   "_meta": {
     "fuente_migracion": "chagra-catalog-seed-v3.0.json",
     "ambiguedades_resueltas": [
@@ -25,6 +25,345 @@
     "advertencia": "Validar con: node scripts/validate-catalog.mjs --seed-mode. Refs a species aún no migradas aparecen como warnings."
   },
   "species": [
+    {
+      "id": "alnus_acuminata",
+      "_curation_status": "VALIDADO con fuentes CIAT/AGROSAVIA",
+      "nombre_comun": "Aliso andino",
+      "nombre_comunes_regionales": [
+        "aliso",
+        "cerezo (cordillera oriental)",
+        "jaul (algunas zonas)"
+      ],
+      "nombre_cientifico": "Alnus acuminata Kunth",
+      "familia_botanica": "Betulaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "living_fence",
+        "windbreak",
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "cycleMonths": null,
+      "habito": "arbol deciduo semicaducifolio, 15-25m altura",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 8,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "humedad_relativa_pct": {
+        "min": 60,
+        "optimo": 80,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.5,
+        "optimo_max": 6.8,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "companions": [
+        "solanum_phureja",
+        "vicia_faba",
+        "lupinus_mutabilis",
+        "pennisetum_clandestinum_manejado"
+      ],
+      "antagonists": [],
+      "recommended_covers": [
+        "trifolium_repens",
+        "vicia_sativa"
+      ],
+      "recommended_fences": [
+        "sambucus_peruviana",
+        "dodonaea_viscosa"
+      ],
+      "fence_function": [
+        "rompevientos",
+        "delimitacion",
+        "sombra",
+        "refugio_fauna"
+      ],
+      "densidad_siembra_fence_m": 2.5,
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla recolectada de amentos maduros (marzo-mayo en cordillera oriental). Estratificación fría opcional 30 días. Germinación en bandejas con sustrato: 60% tierra negra + 30% arena + 10% compost maduro. Trasplante a bolsa negra 1.5kg a las 6 semanas. Plantación definitiva a los 4-6 meses (altura 30-40cm).",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Actinorrícica: forma nódulos fijadores de N con Frankia alni. Inoculación con suelo de aliso adulto acelera establecimiento.",
+        "fuente": "CIAT 1995 'El aliso (Alnus acuminata) en sistemas silvopastoriles'; Corpoica (AGROSAVIA) varios"
+      },
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol de 15-25m no apto para apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Como cerca viva o sombra puntual. Un solo árbol por huerto pequeño.",
+          "tips": [
+            "Plantar en esquina noroeste para sombra de tarde sin bloqueo solar mañanero",
+            "Podas anuales para mantener forma"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta por tamaño."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Ideal para sistemas silvopastoriles (20-40 árboles/ha) o como linderos entre lotes. Fija 150-300 kg N/ha/año según densidad y edad.",
+          "tips": [
+            "Densidad 10x10m o lindero a 2.5m",
+            "Podas de formación años 2-3 y posteriores cada 3 años"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "ESPECIE CLAVE para restauración de bosque alto andino y bordes de páramo. Nurse plant para especies de sotobosque. Recuperación de taludes degradados.",
+          "tips": [
+            "Plantación asociada a Weinmannia tomentosa y Escallonia paniculata",
+            "Densidad restauración: 1100 individuos/ha (3x3m)",
+            "Protección contra ganado primeros 3 años"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plan_nutricion_base": null,
+      "_nota_nutricion": "Como árbol fijador de N, no requiere plan de fertilización estándar. Aporta N al sistema. Solo monitoreo de P y K en suelos muy pobres durante establecimiento.",
+      "tests_suelo_recomendados": [
+        {
+          "tipo": "ph_casero",
+          "rango_objetivo": "5.5-6.8",
+          "frecuencia": "pre-siembra"
+        },
+        {
+          "tipo": "conteo_nodulos",
+          "frecuencia": "año 1 post-establecimiento",
+          "objetivo": "verificar nodulación por Frankia alni; objetivo >20 nódulos en raíz principal a 30cm profundidad"
+        }
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_restauracion": "Actúa como ecólogo de restauración de bosque alto andino colombiano.\nÁrea: {AREA_HA} ha a {ALTITUD} msnm en {MUNICIPIO}, pendiente {PENDIENTE}%, suelo degradado por {HISTORIAL_USO}. Quiero restaurar con Alnus acuminata como especie nodriza asociada a {ESPECIES_OBJETIVO}.\n\nDiseña: (a) marco de plantación y espaciamiento, (b) secuencia de establecimiento por fases (pioneras 1-3 años, secundarias 3-8 años, climácicas 8+ años), (c) protocolo de protección contra ganado, (d) indicadores de éxito de restauración a 1, 3, 5 años."
+      },
+      "rol_ecologico": "Especie nodriza clave en restauración de bosque alto andino. Fija nitrógeno simbiótico con actinomiceto Frankia alni. Hojas ricas en N mejoran el mantillo. Madera usada tradicionalmente para herramientas, construcciones rurales y leña. Corteza con taninos para curtiembre.",
+      "valor_pedagogico": "Enseña fijación simbiótica de N (con actinomiceto, no rizobio); rol de especies nodrizas en restauración; sistemas silvopastoriles andinos.",
+      "saber_origen": {
+        "pueblo": "Pueblos andinos (uso generalizado Muisca, Pasto, Inga)",
+        "region": "Andes colombianos 1800-3600 msnm",
+        "practica_original": "Uso en linderos tradicionales de aynokas, sombra para ganado, leña, reparación de taludes ribereños. Asociación con cultivos de frío (papa, maíz de altura, haba).",
+        "validacion_cientifica_source_ids": [
+          "ciat-1995-alnus",
+          "agrosavia-silvopastoriles"
+        ]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "Especie nativa andina ampliamente documentada. Datos consolidados.",
+      "harvest_type": "biomasa",
+      "validation_level": "operator_reviewed",
+      "source_ids": [
+        "ciat-1995-alnus",
+        "agrosavia-silvopastoriles",
+        "humboldt-flora-alto-andina"
+      ]
+    },
+    {
+      "id": "cenchrus_clandestinus",
+      "_curation_status": "VALIDADO; nombre taxonómico actualizado (previamente Pennisetum clandestinum)",
+      "nombre_comun": "Kikuyo",
+      "nombre_comunes_regionales": [
+        "kikuyo",
+        "cundo",
+        "pasto kikuyo",
+        "pasto africano"
+      ],
+      "nombre_cientifico": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "_nombre_cientifico_anterior": "Pennisetum clandestinum Hochst. ex Chiov., 1903",
+      "autor_ano": "Hochst. ex Chiov. 1903 → reubicado en Cenchrus por Morrone 2010",
+      "familia_botanica": "Poaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "_nota_cultivable": "PARADOJA COLOMBIANA: es la gramínea forrajera más importante del trópico alto (>2200 msnm) para ganadería de leche. Simultáneamente es invasora crítica en páramos y bosques altoandinos. Uso legal en potreros, prohibido/indeseable en áreas de restauración y delimitación de páramo (Ley 1930/2018).",
+      "conservation_status": "invasor",
+      "habito": "gramínea perenne postrada con estolones y rizomas agresivos",
+      "origen": "África oriental (altiplanos Kenia, Etiopía, Uganda, Rwanda, Tanzania, Zaire)",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "impacto_ecologico": "alto (en páramo) / uso forrajero (en potreros bajo manejo)",
+      "ecosistemas_afectados": [
+        "paramo",
+        "subparamo",
+        "bosque_alto_andino",
+        "humedales_altoandinos"
+      ],
+      "mecanismos_invasion": [
+        "Estolones rápidos forman matas densas que excluyen nativas",
+        "Rizomas penetran suelo y son difíciles de extraer",
+        "Semillas viables hasta 10 años en el suelo",
+        "Dispersión vía tubo digestivo del ganado",
+        "Responde a fertilización nitrogenada (de origen natural o agropecuario)",
+        "Desplaza a Calamagrostis effusa y otros pastizales nativos de páramo"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Requiere extraer estolones y rizomas completos; suelos pedregosos dificultan. Herramienta: azadón de péndulo."
+        },
+        {
+          "metodo": "solarizacion",
+          "efectividad": "media",
+          "costo": "medio",
+          "notas": "6-8 semanas bajo plástico negro en temporada seca; efectivo en parches pequeños"
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "baja",
+          "costo": "bajo",
+          "notas": "NO suficiente por sí solo; requiere acompañamiento de siembra de nativas"
+        }
+      ],
+      "epoca_optima_remocion": "Temporada seca, antes de floración y semillación",
+      "especies_nativas_sustitutas": [
+        "calamagrostis_effusa",
+        "festuca_sp_paramo",
+        "agrostis_foliata"
+      ],
+      "manejo_biomasa_extraida": "compostaje en condiciones termófilas >60°C por >3 semanas (destruye semillas) O incineracion_controlada",
+      "riesgo_rebrote": "alto",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Cenchrus_clandestinus",
+      "referencias_cientificas": [
+        "Correa, Pabón & Carulla 2008. Valor nutricional del kikuyo. Livestock Research for Rural Development 20(59)",
+        "Mila & Corredor 2004. Evolución composición botánica pradera kikuyo. Corpoica 5(1): 70-75",
+        "Portillo et al. 2019. Evaluación forrajeras Nariño. AGROSAVIA"
+      ],
+      "validation_level": "operator_reviewed",
+      "source_ids": [
+        "correa-pabon-carulla-2008",
+        "agrosavia-forrajeras-2022"
+      ]
+    },
+    {
+      "id": "pteridium_aquilinum",
+      "_curation_status": "CURACIÓN BÁSICA",
+      "nombre_comun": "Helecho marranero",
+      "nombre_comunes_regionales": [
+        "helecho marranero",
+        "helecho águila",
+        "helecho común"
+      ],
+      "nombre_cientifico": "Pteridium aquilinum (L.) Kuhn",
+      "autor_ano": "Kuhn, 1879 (combinación); L. 1753 como Pteris aquilina",
+      "familia_botanica": "Dennstaedtiaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "_nota_conservacion": "Especie con distribución cosmopolita; en Colombia se comporta como invasor agresivo post-disturbio. Tóxica para ganado y potencialmente cancerígena (ptaquiloside).",
+      "habito": "helecho rizomatoso 0.5-2m",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 3500,
+        "max_absoluto": 4000
+      },
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo_intervenido",
+        "potreros_degradados",
+        "cicatrices_fuego"
+      ],
+      "mecanismos_invasion": [
+        "Rizomas profundos (hasta 1m) y extensos resistentes a remoción",
+        "Producción masiva de esporas con dispersión eólica de larga distancia",
+        "Alelopatía inhibe germinación de nativas",
+        "Tolerancia al fuego; rebrota desde rizoma",
+        "Compuestos tóxicos (ptaquiloside, tiaminasa) desalientan herbivoría"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "media",
+          "costo": "alto",
+          "notas": "Rizomas profundos y extensos dificultan extracción total"
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "alta",
+          "costo": "medio",
+          "notas": "Corte mensual durante 2-3 temporadas agota reservas del rizoma"
+        },
+        {
+          "metodo": "sombra_forzada",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Plantación de especies arbóreas nativas que den sombra densa; el helecho es intolerante a sombra"
+        }
+      ],
+      "epoca_optima_remocion": "Previo a formación de frondes maduras (temporada lluviosa temprana)",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata",
+        "weinmannia_tomentosa",
+        "miconia_squamulosa"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada O entierro_profundo",
+      "_nota_manejo": "Evitar contacto prolongado sin protección (esporas potencialmente cancerígenas). No usar como forraje ni cama para ganado.",
+      "riesgo_rebrote": "muy_alto",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Pteridium_aquilinum",
+      "validation_level": "operator_reviewed",
+      "source_ids": [
+        "flora-colombia-pteridophyta"
+      ]
+    },
     {
       "id": "solanum_phureja",
       "_curation_status": "VALIDADO con fuentes verificadas AGROSAVIA + UNAL",
@@ -445,7 +784,9 @@
       },
       "nota_conservacion": null,
       "confidence_notes": "Umbrales térmicos y altitudinales consolidados contra AGROSAVIA Ficha Técnica Sol Andina y manual Ñústez & Rodríguez 2024. Variaciones por cultivar ±1-2°C en helada letal y ±200 msnm en rangos óptimos. Necesita validación por agrónomo humano antes de deploy ministerial.",
-      "sources_ids": [
+      "harvest_type": "tuberculo",
+      "validation_level": "operator_reviewed",
+      "source_ids": [
         "agrosavia-sol-andina",
         "agrosavia-estrella",
         "agrosavia-alhaja-ica-17702-2019",
@@ -453,176 +794,199 @@
         "rodriguez-nustez-estrada-2009",
         "perez-rodriguez-gomez-2008",
         "cip-2006-ghislain"
-      ],
-      "harvest_type": "tuberculo",
-      "validation_level": "operator_reviewed"
+      ]
     },
     {
-      "id": "alnus_acuminata",
-      "_curation_status": "VALIDADO con fuentes CIAT/AGROSAVIA",
-      "nombre_comun": "Aliso andino",
+      "id": "thunbergia_alata",
+      "_curation_status": "CURACIÓN BÁSICA; datos de invasividad en Colombia confirmados; protocolo de manejo requiere fuente primaria específica",
+      "nombre_comun": "Ojo de poeta",
       "nombre_comunes_regionales": [
-        "aliso",
-        "cerezo (cordillera oriental)",
-        "jaul (algunas zonas)"
+        "ojo de poeta",
+        "susan de ojos negros",
+        "trinitaria"
       ],
-      "nombre_cientifico": "Alnus acuminata Kunth",
-      "familia_botanica": "Betulaceae",
-      "category": "abonos_verdes_coberturas",
+      "nombre_cientifico": "Thunbergia alata Bojer ex Sims",
+      "autor_ano": "Bojer ex Sims, 1825",
+      "familia_botanica": "Acanthaceae",
+      "category": "especies_invasoras",
       "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "_nota_cultivable": "Introducida y usada como ornamental en muchas ciudades andinas; se ha escapado a ambientes naturales y es invasora en bosque alto andino y borde de subpáramo.",
+      "conservation_status": "invasor",
+      "origen": "África oriental y austral",
+      "habito": "trepadora herbácea perenne 2-8m",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "bordes_bosque_niebla",
+        "cercos_vivos_urbanos"
+      ],
+      "mecanismos_invasion": [
+        "Crecimiento trepador rápido que cubre y asfixia vegetación nativa",
+        "Producción masiva de semillas",
+        "Dispersión por aves (endozoocoria)",
+        "Regeneración vegetativa por trozos de tallo",
+        "Asfixia de sotobosque al formar dosel denso"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "medio"
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "media",
+          "costo": "bajo",
+          "notas": "Debe combinarse con extracción de raíz para evitar rebrote"
+        }
+      ],
+      "epoca_optima_remocion": "Antes de floración (temporada seca local)",
+      "especies_nativas_sustitutas_trepadoras": [
+        "passiflora_tripartita_mollissima_NATIVA",
+        "bomarea_sp"
+      ],
+      "manejo_biomasa_extraida": "compostaje_termofilico O incineracion_controlada",
+      "riesgo_rebrote": "alto",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Thunbergia_alata",
+      "validation_level": "operator_reviewed",
+      "source_ids": [
+        "humboldt-invasoras-andes"
+      ]
+    },
+    {
+      "id": "ulex_europaeus",
+      "_curation_status": "VALIDADO con fuentes Humboldt, CAR Cundinamarca, Fundación Natura, Mongabay",
+      "nombre_comun": "Retamo espinoso",
+      "nombre_comunes_regionales": [
+        "retamo",
+        "retamo amarillo"
+      ],
+      "nombre_cientifico": "Ulex europaeus L.",
+      "autor_ano": "Linnaeus, 1753",
+      "publicacion_original": "Species Plantarum 2: 741. 1753",
+      "familia_botanica": "Fabaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
         "frio",
         "paramo"
       ],
-      "estrato": "alto",
+      "estrato": "medio",
       "roles_in_guild": [
-        "nitrogen_fixer",
-        "living_fence",
-        "windbreak",
-        "biomass_producer",
-        "nurse_plant"
+        "invasive"
       ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "cycleMonths": null,
-      "habito": "arbol deciduo semicaducifolio, 15-25m altura",
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "habito": "arbusto espinoso 1-3m",
+      "origen": "Europa occidental (Islas Británicas a Iberia)",
+      "clasificacion_uicn": "Entre las 100 peores especies invasoras del mundo (ISSG/UICN)",
+      "normativa_colombiana": [
+        {
+          "norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible",
+          "alcance": "Lineamientos nacionales para prevención, manejo integral y restauración de áreas afectadas por U. europaeus y Genista monspessulana"
+        },
+        {
+          "norma": "Resolución 7615 de 2009 Secretaría Distrital de Ambiente de Bogotá",
+          "alcance": "Prohíbe uso de retamo espinoso en Distrito Capital"
+        },
+        {
+          "norma": "Protocolo CAR Cundinamarca 2019",
+          "alcance": "Prevención, manejo y control de U. europaeus y Genista monspessulana en jurisdicción CAR"
+        }
+      ],
       "altitud_msnm": {
-        "min_absoluto": 1800,
-        "optimo_min": 2200,
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
         "optimo_max": 3200,
-        "max_absoluto": 3600
+        "max_absoluto": 3500
       },
-      "temperatura_c": {
-        "helada_letal": -6,
-        "optimo_min": 8,
-        "optimo_max": 18,
-        "max_tolerable": 24
-      },
-      "humedad_relativa_pct": {
-        "min": 60,
-        "optimo": 80,
-        "max": 95
-      },
-      "ph_suelo": {
-        "min": 4.5,
-        "optimo_min": 5.5,
-        "optimo_max": 6.8,
-        "max": 7.5
-      },
-      "radiacion": "sol_pleno",
-      "agua": "alto",
-      "drenaje_requerido": "bueno_a_moderado",
-      "companions": [
-        "solanum_phureja",
-        "vicia_faba",
-        "lupinus_mutabilis",
-        "pennisetum_clandestinum_manejado"
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo",
+        "bordes_de_via",
+        "areas_quemadas"
       ],
-      "antagonists": [],
-      "recommended_covers": [
-        "trifolium_repens",
-        "vicia_sativa"
+      "mecanismos_invasion": [
+        "Germinación post-fuego masiva (semillas resisten altas temperaturas)",
+        "Banco de semillas persistente hasta 30-40 años en suelo",
+        "Densidad de banco de semillas 109-3.384 semillas/m2 en bordes de matorral (Ocampo-Zuleta & Solorza-Bejarano 2017)",
+        "Reproducción sexual + rebrote vegetativo desde tallos cortados",
+        "Crecimiento rápido (hasta 1m/año) forma matorrales densos que excluyen nativas",
+        "Fijación de N altera composición química del suelo, favoreciendo otras exóticas"
       ],
-      "recommended_fences": [
-        "sambucus_peruviana",
-        "dodonaea_viscosa"
-      ],
-      "fence_function": [
-        "rompevientos",
-        "delimitacion",
-        "sombra",
-        "refugio_fauna"
-      ],
-      "densidad_siembra_fence_m": 2.5,
-      "propagation": {
-        "methods": [
-          "semilla",
-          "esqueje"
-        ],
-        "best_method": "semilla",
-        "protocol_resumen": "Semilla recolectada de amentos maduros (marzo-mayo en cordillera oriental). Estratificación fría opcional 30 días. Germinación en bandejas con sustrato: 60% tierra negra + 30% arena + 10% compost maduro. Trasplante a bolsa negra 1.5kg a las 6 semanas. Plantación definitiva a los 4-6 meses (altura 30-40cm).",
-        "tiempo_a_establecimiento_dias": 45,
-        "notas": "Actinorrícica: forma nódulos fijadores de N con Frankia alni. Inoculación con suelo de aliso adulto acelera establecimiento.",
-        "fuente": "CIAT 1995 'El aliso (Alnus acuminata) en sistemas silvopastoriles'; Corpoica (AGROSAVIA) varios"
-      },
-      "manejo_por_escala": {
-        "apartamento": {
-          "viable": false,
-          "nota": "Árbol de 15-25m no apto para apartamento."
-        },
-        "huerto_casero": {
-          "viable": true,
-          "nota": "Como cerca viva o sombra puntual. Un solo árbol por huerto pequeño.",
-          "tips": [
-            "Plantar en esquina noroeste para sombra de tarde sin bloqueo solar mañanero",
-            "Podas anuales para mantener forma"
-          ]
-        },
-        "invernadero_mediano": {
-          "viable": false,
-          "nota": "Inviable bajo cubierta por tamaño."
-        },
-        "produccion": {
-          "viable": true,
-          "nota": "Ideal para sistemas silvopastoriles (20-40 árboles/ha) o como linderos entre lotes. Fija 150-300 kg N/ha/año según densidad y edad.",
-          "tips": [
-            "Densidad 10x10m o lindero a 2.5m",
-            "Podas de formación años 2-3 y posteriores cada 3 años"
-          ]
-        },
-        "restauracion": {
-          "viable": true,
-          "nota": "ESPECIE CLAVE para restauración de bosque alto andino y bordes de páramo. Nurse plant para especies de sotobosque. Recuperación de taludes degradados.",
-          "tips": [
-            "Plantación asociada a Weinmannia tomentosa y Escallonia paniculata",
-            "Densidad restauración: 1100 individuos/ha (3x3m)",
-            "Protección contra ganado primeros 3 años"
-          ]
-        }
-      },
-      "scale_viability": [
-        "huerto_casero",
-        "produccion",
-        "restauracion"
-      ],
-      "plan_nutricion_base": null,
-      "_nota_nutricion": "Como árbol fijador de N, no requiere plan de fertilización estándar. Aporta N al sistema. Solo monitoreo de P y K en suelos muy pobres durante establecimiento.",
-      "tests_suelo_recomendados": [
+      "metodos_extraccion": [
         {
-          "tipo": "ph_casero",
-          "rango_objetivo": "5.5-6.8",
-          "frecuencia": "pre-siembra"
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Método preferido; requiere extraer TODO el sistema radical para evitar rebrote. Después de quemas el suelo queda blando y facilita extracción manual."
         },
         {
-          "tipo": "conteo_nodulos",
-          "frecuencia": "año 1 post-establecimiento",
-          "objetivo": "verificar nodulación por Frankia alni; objetivo >20 nódulos en raíz principal a 30cm profundidad"
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "media",
+          "costo": "medio",
+          "notas": "Corte a ras de suelo cada 3-4 meses por 2-3 años; agota reservas; NO funciona solo (rebrote garantizado)"
+        },
+        {
+          "metodo": "solarizacion",
+          "efectividad": "baja",
+          "costo": "medio",
+          "notas": "Solo efectiva en plántulas; semillas profundas resisten"
+        },
+        {
+          "metodo": "fuego_controlado",
+          "efectividad": "NEGATIVA",
+          "costo": "bajo",
+          "notas": "PROHIBIDO: el fuego detona germinación masiva del banco de semillas y empeora la invasión. Evidencia Mongabay 2024."
         }
       ],
-      "plagas_criticas": [],
-      "enfermedades_criticas": [],
+      "epoca_optima_remocion": "Temporada seca (diciembre-febrero altiplano; junio-agosto Nariño) ANTES de floración (para evitar dispersión de semillas). Evitar corte en floración o fructificación.",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata",
+        "escallonia_paniculata",
+        "weinmannia_tomentosa",
+        "miconia_squamulosa",
+        "sambucus_peruviana"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada",
+      "_nota_manejo_biomasa": "Compostaje NO recomendado: semillas sobreviven temperaturas de compost doméstico. Incineración controlada en sitio autorizado o disposición en relleno sanitario con trituración previa. NUNCA dispersar en bosque o páramo.",
+      "riesgo_rebrote": "altisimo",
+      "protocolo_post_remocion": "Restauración activa obligatoria: siembra de especies nativas sustitutas en densidad 1100 ind/ha al siguiente semestre lluvioso. Monitoreo de rebrote semestral por 5 años. Corte inmediato de cualquier rebrote antes de 50cm altura.",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Ulex_europaeus",
       "prompts_ia_externa": {
-        "plan_restauracion": "Actúa como ecólogo de restauración de bosque alto andino colombiano.\nÁrea: {AREA_HA} ha a {ALTITUD} msnm en {MUNICIPIO}, pendiente {PENDIENTE}%, suelo degradado por {HISTORIAL_USO}. Quiero restaurar con Alnus acuminata como especie nodriza asociada a {ESPECIES_OBJETIVO}.\n\nDiseña: (a) marco de plantación y espaciamiento, (b) secuencia de establecimiento por fases (pioneras 1-3 años, secundarias 3-8 años, climácicas 8+ años), (c) protocolo de protección contra ganado, (d) indicadores de éxito de restauración a 1, 3, 5 años."
+        "plan_remocion": "Actúa como ecólogo de restauración colombiano.\nÁrea: {AREA_HA} ha invadida por Ulex europaeus en {MUNICIPIO} a {ALTITUD} msnm, densidad de matorral {DENSIDAD} (disperso/moderado/denso/muy_denso), pendiente {PENDIENTE}%, sin/con historia reciente de fuego.\n\nDiseña plan de 5 años: (a) método de extracción por zona, (b) disposición de biomasa, (c) especies nativas sustitutas con densidades, (d) calendario de monitoreo y control de rebrotes, (e) indicadores de éxito año 1, 3, 5."
       },
-      "rol_ecologico": "Especie nodriza clave en restauración de bosque alto andino. Fija nitrógeno simbiótico con actinomiceto Frankia alni. Hojas ricas en N mejoran el mantillo. Madera usada tradicionalmente para herramientas, construcciones rurales y leña. Corteza con taninos para curtiembre.",
-      "valor_pedagogico": "Enseña fijación simbiótica de N (con actinomiceto, no rizobio); rol de especies nodrizas en restauración; sistemas silvopastoriles andinos.",
-      "saber_origen": {
-        "pueblo": "Pueblos andinos (uso generalizado Muisca, Pasto, Inga)",
-        "region": "Andes colombianos 1800-3600 msnm",
-        "practica_original": "Uso en linderos tradicionales de aynokas, sombra para ganado, leña, reparación de taludes ribereños. Asociación con cultivos de frío (papa, maíz de altura, haba).",
-        "validacion_cientifica_source_ids": [
-          "ciat-1995-alnus",
-          "agrosavia-silvopastoriles"
-        ]
-      },
-      "nota_conservacion": null,
-      "confidence_notes": "Especie nativa andina ampliamente documentada. Datos consolidados.",
-      "sources_ids": [
-        "ciat-1995-alnus",
-        "agrosavia-silvopastoriles",
-        "humboldt-flora-alto-andina"
+      "referencias_cientificas": [
+        "Ocampo-Zuleta, K. & Solorza-Bejarano, J. 2017. Banco de semillas de retamo espinoso en bosque altoandino. Biota Colombiana 18(supl 1): 89-98",
+        "Calderón-Sáenz 2003. Las especies invasoras en Colombia (diez peores)",
+        "Mongabay Colombia 2024. Retamo espinoso y áreas quemadas",
+        "CAR Cundinamarca 2019. Protocolo prevención manejo control Ulex europaeus y Genista monspessulana",
+        "Fundación Natura 2024. Experiencia piloto control retamo espinoso en Guasca"
       ],
-      "harvest_type": "biomasa",
-      "validation_level": "operator_reviewed"
+      "validation_level": "operator_reviewed",
+      "source_ids": [
+        "ocampo-solorza-2017",
+        "car-cundi-2019",
+        "res-684-2018-mads",
+        "mongabay-retamo-2024"
+      ]
     },
     {
       "id": "urtica_dioica",
@@ -853,559 +1217,12 @@
       },
       "nota_conservacion": null,
       "confidence_notes": "ATENCIÓN: confirmar taxonomía (U. dioica vs U. leptophylla vs U. urens) con agrónomo/botánico antes de distribuir. Los umbrales dados aplican a U. dioica sensu lato; pueden variar para especies nativas andinas.",
-      "sources_ids": [
+      "harvest_type": "hoja",
+      "validation_level": "operator_reviewed",
+      "source_ids": [
         "restrepo-1996-abc-agricultura-organica",
         "pamplona-roger-2006-plantas-medicinales"
-      ],
-      "harvest_type": "hoja",
-      "validation_level": "operator_reviewed"
-    },
-    {
-      "id": "ulex_europaeus",
-      "_curation_status": "VALIDADO con fuentes Humboldt, CAR Cundinamarca, Fundación Natura, Mongabay",
-      "nombre_comun": "Retamo espinoso",
-      "nombre_comunes_regionales": [
-        "retamo",
-        "retamo amarillo"
-      ],
-      "nombre_cientifico": "Ulex europaeus L.",
-      "autor_ano": "Linnaeus, 1753",
-      "publicacion_original": "Species Plantarum 2: 741. 1753",
-      "familia_botanica": "Fabaceae",
-      "category": "especies_invasoras",
-      "thermal_zones": [
-        "templado",
-        "frio",
-        "paramo"
-      ],
-      "estrato": "medio",
-      "roles_in_guild": [
-        "invasive"
-      ],
-      "cultivable": false,
-      "conservation_status": "invasor",
-      "habito": "arbusto espinoso 1-3m",
-      "origen": "Europa occidental (Islas Británicas a Iberia)",
-      "clasificacion_uicn": "Entre las 100 peores especies invasoras del mundo (ISSG/UICN)",
-      "normativa_colombiana": [
-        {
-          "norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible",
-          "alcance": "Lineamientos nacionales para prevención, manejo integral y restauración de áreas afectadas por U. europaeus y Genista monspessulana"
-        },
-        {
-          "norma": "Resolución 7615 de 2009 Secretaría Distrital de Ambiente de Bogotá",
-          "alcance": "Prohíbe uso de retamo espinoso en Distrito Capital"
-        },
-        {
-          "norma": "Protocolo CAR Cundinamarca 2019",
-          "alcance": "Prevención, manejo y control de U. europaeus y Genista monspessulana en jurisdicción CAR"
-        }
-      ],
-      "altitud_msnm": {
-        "min_absoluto": 2000,
-        "optimo_min": 2300,
-        "optimo_max": 3200,
-        "max_absoluto": 3500
-      },
-      "impacto_ecologico": "alto",
-      "ecosistemas_afectados": [
-        "bosque_alto_andino",
-        "subparamo",
-        "paramo",
-        "bordes_de_via",
-        "areas_quemadas"
-      ],
-      "mecanismos_invasion": [
-        "Germinación post-fuego masiva (semillas resisten altas temperaturas)",
-        "Banco de semillas persistente hasta 30-40 años en suelo",
-        "Densidad de banco de semillas 109-3.384 semillas/m2 en bordes de matorral (Ocampo-Zuleta & Solorza-Bejarano 2017)",
-        "Reproducción sexual + rebrote vegetativo desde tallos cortados",
-        "Crecimiento rápido (hasta 1m/año) forma matorrales densos que excluyen nativas",
-        "Fijación de N altera composición química del suelo, favoreciendo otras exóticas"
-      ],
-      "metodos_extraccion": [
-        {
-          "metodo": "desenraice_completo",
-          "efectividad": "alta",
-          "costo": "alto",
-          "notas": "Método preferido; requiere extraer TODO el sistema radical para evitar rebrote. Después de quemas el suelo queda blando y facilita extracción manual."
-        },
-        {
-          "metodo": "corte_bajo_repetido",
-          "efectividad": "media",
-          "costo": "medio",
-          "notas": "Corte a ras de suelo cada 3-4 meses por 2-3 años; agota reservas; NO funciona solo (rebrote garantizado)"
-        },
-        {
-          "metodo": "solarizacion",
-          "efectividad": "baja",
-          "costo": "medio",
-          "notas": "Solo efectiva en plántulas; semillas profundas resisten"
-        },
-        {
-          "metodo": "fuego_controlado",
-          "efectividad": "NEGATIVA",
-          "costo": "bajo",
-          "notas": "PROHIBIDO: el fuego detona germinación masiva del banco de semillas y empeora la invasión. Evidencia Mongabay 2024."
-        }
-      ],
-      "epoca_optima_remocion": "Temporada seca (diciembre-febrero altiplano; junio-agosto Nariño) ANTES de floración (para evitar dispersión de semillas). Evitar corte en floración o fructificación.",
-      "especies_nativas_sustitutas": [
-        "alnus_acuminata",
-        "escallonia_paniculata",
-        "weinmannia_tomentosa",
-        "miconia_squamulosa",
-        "sambucus_peruviana"
-      ],
-      "manejo_biomasa_extraida": "incineracion_controlada",
-      "_nota_manejo_biomasa": "Compostaje NO recomendado: semillas sobreviven temperaturas de compost doméstico. Incineración controlada en sitio autorizado o disposición en relleno sanitario con trituración previa. NUNCA dispersar en bosque o páramo.",
-      "riesgo_rebrote": "altisimo",
-      "protocolo_post_remocion": "Restauración activa obligatoria: siembra de especies nativas sustitutas en densidad 1100 ind/ha al siguiente semestre lluvioso. Monitoreo de rebrote semestral por 5 años. Corte inmediato de cualquier rebrote antes de 50cm altura.",
-      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Ulex_europaeus",
-      "prompts_ia_externa": {
-        "plan_remocion": "Actúa como ecólogo de restauración colombiano.\nÁrea: {AREA_HA} ha invadida por Ulex europaeus en {MUNICIPIO} a {ALTITUD} msnm, densidad de matorral {DENSIDAD} (disperso/moderado/denso/muy_denso), pendiente {PENDIENTE}%, sin/con historia reciente de fuego.\n\nDiseña plan de 5 años: (a) método de extracción por zona, (b) disposición de biomasa, (c) especies nativas sustitutas con densidades, (d) calendario de monitoreo y control de rebrotes, (e) indicadores de éxito año 1, 3, 5."
-      },
-      "referencias_cientificas": [
-        "Ocampo-Zuleta, K. & Solorza-Bejarano, J. 2017. Banco de semillas de retamo espinoso en bosque altoandino. Biota Colombiana 18(supl 1): 89-98",
-        "Calderón-Sáenz 2003. Las especies invasoras en Colombia (diez peores)",
-        "Mongabay Colombia 2024. Retamo espinoso y áreas quemadas",
-        "CAR Cundinamarca 2019. Protocolo prevención manejo control Ulex europaeus y Genista monspessulana",
-        "Fundación Natura 2024. Experiencia piloto control retamo espinoso en Guasca"
-      ],
-      "sources_ids": [
-        "ocampo-solorza-2017",
-        "car-cundi-2019",
-        "res-684-2018-mads",
-        "mongabay-retamo-2024"
-      ],
-      "validation_level": "operator_reviewed"
-    },
-    {
-      "id": "cenchrus_clandestinus",
-      "_curation_status": "VALIDADO; nombre taxonómico actualizado (previamente Pennisetum clandestinum)",
-      "nombre_comun": "Kikuyo",
-      "nombre_comunes_regionales": [
-        "kikuyo",
-        "cundo",
-        "pasto kikuyo",
-        "pasto africano"
-      ],
-      "nombre_cientifico": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
-      "_nombre_cientifico_anterior": "Pennisetum clandestinum Hochst. ex Chiov., 1903",
-      "autor_ano": "Hochst. ex Chiov. 1903 → reubicado en Cenchrus por Morrone 2010",
-      "familia_botanica": "Poaceae",
-      "category": "especies_invasoras",
-      "thermal_zones": [
-        "frio",
-        "paramo"
-      ],
-      "estrato": "bajo",
-      "roles_in_guild": [
-        "invasive",
-        "ground_cover"
-      ],
-      "cultivable": false,
-      "_nota_cultivable": "PARADOJA COLOMBIANA: es la gramínea forrajera más importante del trópico alto (>2200 msnm) para ganadería de leche. Simultáneamente es invasora crítica en páramos y bosques altoandinos. Uso legal en potreros, prohibido/indeseable en áreas de restauración y delimitación de páramo (Ley 1930/2018).",
-      "conservation_status": "invasor",
-      "habito": "gramínea perenne postrada con estolones y rizomas agresivos",
-      "origen": "África oriental (altiplanos Kenia, Etiopía, Uganda, Rwanda, Tanzania, Zaire)",
-      "altitud_msnm": {
-        "min_absoluto": 1800,
-        "optimo_min": 2200,
-        "optimo_max": 3200,
-        "max_absoluto": 3600
-      },
-      "impacto_ecologico": "alto (en páramo) / uso forrajero (en potreros bajo manejo)",
-      "ecosistemas_afectados": [
-        "paramo",
-        "subparamo",
-        "bosque_alto_andino",
-        "humedales_altoandinos"
-      ],
-      "mecanismos_invasion": [
-        "Estolones rápidos forman matas densas que excluyen nativas",
-        "Rizomas penetran suelo y son difíciles de extraer",
-        "Semillas viables hasta 10 años en el suelo",
-        "Dispersión vía tubo digestivo del ganado",
-        "Responde a fertilización nitrogenada (de origen natural o agropecuario)",
-        "Desplaza a Calamagrostis effusa y otros pastizales nativos de páramo"
-      ],
-      "metodos_extraccion": [
-        {
-          "metodo": "desenraice_completo",
-          "efectividad": "alta",
-          "costo": "alto",
-          "notas": "Requiere extraer estolones y rizomas completos; suelos pedregosos dificultan. Herramienta: azadón de péndulo."
-        },
-        {
-          "metodo": "solarizacion",
-          "efectividad": "media",
-          "costo": "medio",
-          "notas": "6-8 semanas bajo plástico negro en temporada seca; efectivo en parches pequeños"
-        },
-        {
-          "metodo": "corte_bajo_repetido",
-          "efectividad": "baja",
-          "costo": "bajo",
-          "notas": "NO suficiente por sí solo; requiere acompañamiento de siembra de nativas"
-        }
-      ],
-      "epoca_optima_remocion": "Temporada seca, antes de floración y semillación",
-      "especies_nativas_sustitutas": [
-        "calamagrostis_effusa",
-        "festuca_sp_paramo",
-        "agrostis_foliata"
-      ],
-      "manejo_biomasa_extraida": "compostaje en condiciones termófilas >60°C por >3 semanas (destruye semillas) O incineracion_controlada",
-      "riesgo_rebrote": "alto",
-      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Cenchrus_clandestinus",
-      "referencias_cientificas": [
-        "Correa, Pabón & Carulla 2008. Valor nutricional del kikuyo. Livestock Research for Rural Development 20(59)",
-        "Mila & Corredor 2004. Evolución composición botánica pradera kikuyo. Corpoica 5(1): 70-75",
-        "Portillo et al. 2019. Evaluación forrajeras Nariño. AGROSAVIA"
-      ],
-      "sources_ids": [
-        "correa-pabon-carulla-2008",
-        "agrosavia-forrajeras-2022"
-      ],
-      "validation_level": "operator_reviewed"
-    },
-    {
-      "id": "thunbergia_alata",
-      "_curation_status": "CURACIÓN BÁSICA; datos de invasividad en Colombia confirmados; protocolo de manejo requiere fuente primaria específica",
-      "nombre_comun": "Ojo de poeta",
-      "nombre_comunes_regionales": [
-        "ojo de poeta",
-        "susan de ojos negros",
-        "trinitaria"
-      ],
-      "nombre_cientifico": "Thunbergia alata Bojer ex Sims",
-      "autor_ano": "Bojer ex Sims, 1825",
-      "familia_botanica": "Acanthaceae",
-      "category": "especies_invasoras",
-      "thermal_zones": [
-        "templado",
-        "frio"
-      ],
-      "estrato": "bajo",
-      "roles_in_guild": [
-        "invasive"
-      ],
-      "cultivable": false,
-      "_nota_cultivable": "Introducida y usada como ornamental en muchas ciudades andinas; se ha escapado a ambientes naturales y es invasora en bosque alto andino y borde de subpáramo.",
-      "conservation_status": "invasor",
-      "origen": "África oriental y austral",
-      "habito": "trepadora herbácea perenne 2-8m",
-      "altitud_msnm": {
-        "min_absoluto": 1500,
-        "optimo_min": 2000,
-        "optimo_max": 3000,
-        "max_absoluto": 3300
-      },
-      "impacto_ecologico": "alto",
-      "ecosistemas_afectados": [
-        "bosque_alto_andino",
-        "subparamo",
-        "bordes_bosque_niebla",
-        "cercos_vivos_urbanos"
-      ],
-      "mecanismos_invasion": [
-        "Crecimiento trepador rápido que cubre y asfixia vegetación nativa",
-        "Producción masiva de semillas",
-        "Dispersión por aves (endozoocoria)",
-        "Regeneración vegetativa por trozos de tallo",
-        "Asfixia de sotobosque al formar dosel denso"
-      ],
-      "metodos_extraccion": [
-        {
-          "metodo": "desenraice_completo",
-          "efectividad": "alta",
-          "costo": "medio"
-        },
-        {
-          "metodo": "corte_bajo_repetido",
-          "efectividad": "media",
-          "costo": "bajo",
-          "notas": "Debe combinarse con extracción de raíz para evitar rebrote"
-        }
-      ],
-      "epoca_optima_remocion": "Antes de floración (temporada seca local)",
-      "especies_nativas_sustitutas_trepadoras": [
-        "passiflora_tripartita_mollissima_NATIVA",
-        "bomarea_sp"
-      ],
-      "manejo_biomasa_extraida": "compostaje_termofilico O incineracion_controlada",
-      "riesgo_rebrote": "alto",
-      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Thunbergia_alata",
-      "sources_ids": [
-        "humboldt-invasoras-andes"
-      ],
-      "validation_level": "operator_reviewed",
-      "especies_nativas_sustitutas": [
-        "espeletia_grandiflora",
-        "weinmannia_tomentosa",
-        "vaccinium_meridionale"
       ]
-    },
-    {
-      "id": "pteridium_aquilinum",
-      "_curation_status": "CURACIÓN BÁSICA",
-      "nombre_comun": "Helecho marranero",
-      "nombre_comunes_regionales": [
-        "helecho marranero",
-        "helecho águila",
-        "helecho común"
-      ],
-      "nombre_cientifico": "Pteridium aquilinum (L.) Kuhn",
-      "autor_ano": "Kuhn, 1879 (combinación); L. 1753 como Pteris aquilina",
-      "familia_botanica": "Dennstaedtiaceae",
-      "category": "especies_invasoras",
-      "thermal_zones": [
-        "templado",
-        "frio",
-        "paramo"
-      ],
-      "estrato": "bajo",
-      "roles_in_guild": [
-        "invasive"
-      ],
-      "cultivable": false,
-      "conservation_status": "invasor",
-      "_nota_conservacion": "Especie con distribución cosmopolita; en Colombia se comporta como invasor agresivo post-disturbio. Tóxica para ganado y potencialmente cancerígena (ptaquiloside).",
-      "habito": "helecho rizomatoso 0.5-2m",
-      "altitud_msnm": {
-        "min_absoluto": 0,
-        "optimo_min": 1500,
-        "optimo_max": 3500,
-        "max_absoluto": 4000
-      },
-      "impacto_ecologico": "alto",
-      "ecosistemas_afectados": [
-        "bosque_alto_andino",
-        "subparamo",
-        "paramo_intervenido",
-        "potreros_degradados",
-        "cicatrices_fuego"
-      ],
-      "mecanismos_invasion": [
-        "Rizomas profundos (hasta 1m) y extensos resistentes a remoción",
-        "Producción masiva de esporas con dispersión eólica de larga distancia",
-        "Alelopatía inhibe germinación de nativas",
-        "Tolerancia al fuego; rebrota desde rizoma",
-        "Compuestos tóxicos (ptaquiloside, tiaminasa) desalientan herbivoría"
-      ],
-      "metodos_extraccion": [
-        {
-          "metodo": "desenraice_completo",
-          "efectividad": "media",
-          "costo": "alto",
-          "notas": "Rizomas profundos y extensos dificultan extracción total"
-        },
-        {
-          "metodo": "corte_bajo_repetido",
-          "efectividad": "alta",
-          "costo": "medio",
-          "notas": "Corte mensual durante 2-3 temporadas agota reservas del rizoma"
-        },
-        {
-          "metodo": "sombra_forzada",
-          "efectividad": "alta",
-          "costo": "alto",
-          "notas": "Plantación de especies arbóreas nativas que den sombra densa; el helecho es intolerante a sombra"
-        }
-      ],
-      "epoca_optima_remocion": "Previo a formación de frondes maduras (temporada lluviosa temprana)",
-      "especies_nativas_sustitutas": [
-        "alnus_acuminata",
-        "weinmannia_tomentosa",
-        "miconia_squamulosa"
-      ],
-      "manejo_biomasa_extraida": "incineracion_controlada O entierro_profundo",
-      "_nota_manejo": "Evitar contacto prolongado sin protección (esporas potencialmente cancerígenas). No usar como forraje ni cama para ganado.",
-      "riesgo_rebrote": "muy_alto",
-      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Pteridium_aquilinum",
-      "sources_ids": [
-        "flora-colombia-pteridophyta"
-      ],
-      "validation_level": "operator_reviewed"
-    },
-    {
-      "_curation_status": "BORRADOR_IA",
-      "id": "weinmannia_tomentosa",
-      "nombre_comun": "Encenillo",
-      "nombre_cientifico": "Weinmannia tomentosa L.f.",
-      "familia_botanica": "Cunoniaceae",
-      "category": "abonos_verdes_coberturas",
-      "thermal_zones": [
-        "frio",
-        "paramo"
-      ],
-      "estrato": "alto",
-      "roles_in_guild": [
-        "nurse_plant",
-        "biomass_producer"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 2400,
-        "optimo_min": 2800,
-        "optimo_max": 3400,
-        "max_absoluto": 3800
-      },
-      "sources_ids": [
-        "humboldt-flora-alto-andina"
-      ],
-      "validation_level": "claude_draft",
-      "harvest_type": "biomasa"
-    },
-    {
-      "_curation_status": "BORRADOR_IA",
-      "id": "espeletia_grandiflora",
-      "nombre_comun": "Frailejón grande",
-      "nombre_cientifico": "Espeletia grandiflora Humb. & Bonpl.",
-      "familia_botanica": "Asteraceae",
-      "category": "arboles_sombra",
-      "thermal_zones": [
-        "paramo"
-      ],
-      "estrato": "medio",
-      "roles_in_guild": [
-        "nurse_plant",
-        "biomass_producer"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 3200,
-        "optimo_min": 3400,
-        "optimo_max": 4000,
-        "max_absoluto": 4200
-      },
-      "sources_ids": [
-        "humboldt-2016-frailejones"
-      ],
-      "validation_level": "claude_draft",
-      "harvest_type": "biomasa"
-    },
-    {
-      "_curation_status": "BORRADOR_IA",
-      "id": "vaccinium_meridionale",
-      "nombre_comun": "Agraz andino",
-      "nombre_cientifico": "Vaccinium meridionale Swartz",
-      "familia_botanica": "Ericaceae",
-      "category": "frutales_perennes",
-      "thermal_zones": [
-        "frio",
-        "paramo"
-      ],
-      "estrato": "bajo",
-      "roles_in_guild": [
-        "understorey_crop",
-        "pollinator_attractor"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 2500,
-        "optimo_min": 2800,
-        "optimo_max": 3500,
-        "max_absoluto": 3800
-      },
-      "sources_ids": [
-        "humboldt-flora-alto-andina"
-      ],
-      "validation_level": "claude_draft",
-      "harvest_type": "fruto"
-    },
-    {
-      "_curation_status": "BORRADOR_IA",
-      "id": "miconia_squamulosa",
-      "nombre_comun": "Tuno esmeraldo",
-      "nombre_cientifico": "Miconia squamulosa (Sm.) Triana",
-      "familia_botanica": "Melastomataceae",
-      "category": "arboles_sombra",
-      "thermal_zones": [
-        "templado",
-        "frio"
-      ],
-      "estrato": "medio",
-      "roles_in_guild": [
-        "nurse_plant",
-        "biomass_producer"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 1800,
-        "optimo_min": 2200,
-        "optimo_max": 3200,
-        "max_absoluto": 3400
-      },
-      "sources_ids": [
-        "humboldt-flora-alto-andina"
-      ],
-      "validation_level": "claude_draft",
-      "harvest_type": "biomasa"
-    },
-    {
-      "_curation_status": "BORRADOR_IA",
-      "id": "escallonia_paniculata",
-      "nombre_comun": "Rodamonte",
-      "nombre_cientifico": "Escallonia paniculata (Ruiz & Pav.) Roem. & Schult.",
-      "familia_botanica": "Escalloniaceae",
-      "category": "abonos_verdes_coberturas",
-      "thermal_zones": [
-        "frio",
-        "paramo"
-      ],
-      "estrato": "medio",
-      "roles_in_guild": [
-        "living_fence",
-        "nurse_plant"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 2400,
-        "optimo_min": 2800,
-        "optimo_max": 3500,
-        "max_absoluto": 3800
-      },
-      "sources_ids": [
-        "humboldt-flora-alto-andina"
-      ],
-      "validation_level": "claude_draft",
-      "harvest_type": "biomasa"
-    },
-    {
-      "_curation_status": "BORRADOR_IA",
-      "id": "calamagrostis_effusa",
-      "nombre_comun": "Paja de páramo",
-      "nombre_cientifico": "Calamagrostis effusa (Kunth) Steud.",
-      "familia_botanica": "Poaceae",
-      "category": "abonos_verdes_coberturas",
-      "thermal_zones": [
-        "paramo"
-      ],
-      "estrato": "bajo",
-      "roles_in_guild": [
-        "ground_cover",
-        "erosion_control"
-      ],
-      "cultivable": true,
-      "conservation_status": "nativo_silvestre",
-      "altitud_msnm": {
-        "min_absoluto": 3000,
-        "optimo_min": 3400,
-        "optimo_max": 4200,
-        "max_absoluto": 4600
-      },
-      "sources_ids": [
-        "humboldt-flora-alto-andina"
-      ],
-      "validation_level": "claude_draft",
-      "harvest_type": "biomasa"
     }
   ],
   "biopreparados": [

--- a/catalog/schema-v3.1.json
+++ b/catalog/schema-v3.1.json
@@ -38,7 +38,7 @@
         "cultivable",
         "conservation_status",
         "altitud_msnm",
-        "sources_ids"
+        "source_ids"
       ],
       "properties": {
         "_curation_status": {
@@ -86,8 +86,8 @@
         },
         "estrato": {
           "type": "string",
-          "enum": ["emergente", "alto", "medio", "bajo"],
-          "description": "Obligatorio en frutales_perennes/abonos_verdes_coberturas/cercas_vivas; opcional en anuales/herbáceas. Regla AMB-04 aplicada por scripts/validate-catalog.mjs."
+          "enum": ["emergente", "alto", "medio", "bajo", "rastrero"],
+          "description": "Obligatorio en frutales_perennes/abonos_verdes_coberturas/cercas_vivas; opcional en anuales/herbáceas. AMB-05: 'rastrero' para anuales <20cm (cobertura, mulching vivo). Regla aplicada por scripts/validate-catalog.mjs."
         },
         "roles_in_guild": {
           "type": "array",
@@ -352,11 +352,11 @@
         },
         "nota_conservacion": { "type": ["string", "null"] },
         "confidence_notes": { "type": "string" },
-        "sources_ids": {
+        "source_ids": {
           "type": "array",
           "items": { "type": "string" },
           "minItems": 1,
-          "description": "Refs a sources[].id — obligatorio al menos una (AMB-16). CI valida que todos existan."
+          "description": "Refs a sources[].id — obligatorio al menos una (AMB-11 master plan §3). CI valida que todos existan en sources-seed.json."
         },
         "especies_nativas_sustitutas": {
           "type": "array",

--- a/docs/species/01-aguacate-hass.md
+++ b/docs/species/01-aguacate-hass.md
@@ -1,0 +1,135 @@
+---
+ulid: 01HZ-AGUACATE-HASS
+nombre_cientifico: Persea americana Mill. cv. 'Hass'
+nombres_comunes:
+  - es: aguacate Hass
+    region: Colombia
+  - es: palta Hass
+    region: andina
+familia: Lauraceae
+piso_termico_optimo: templado
+pisos_termicos_tolerados: [templado]
+altitud_m: { min: 1700, max: 2400 }
+categorias: [frutal]
+estado_introduccion: introducida
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: medio
+publicable_libro: false
+fuentes_principales:
+  - tipo: libro
+    cita: Bernal H., Díaz C. (2005). *Materiales locales y mejorados del cultivo del aguacate en Colombia*. CORPOICA.
+    nivel_confianza: alto
+  - tipo: extension
+    cita: Agrosavia. Manual técnico aguacate Hass para zona andina colombiana.
+    url: https://www.agrosavia.co/
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF Backbone Taxonomy
+    url: https://www.gbif.org/species/2853020
+    nivel_confianza: alto
+---
+
+# Aguacate Hass — *Persea americana* cv. Hass
+
+## 1. Descripción agroecológica
+
+Cultivar comercial dominante en exportación colombiana. Árbol perenne, copa redondeada, 8–15 m de altura en libre crecimiento. En sistemas bien manejados se mantiene a 4–5 m con poda formativa. Fruto característico: cáscara rugosa que oscurece a casi negro al madurar, pulpa cremosa, semilla relativamente pequeña, contenido graso 18–22%. Ciclo bienal natural si no se balancea carga.
+
+## 2. Requerimientos agroclimáticos
+
+| Variable | Rango óptimo | Tolera | Notas |
+|---|---|---|---|
+| Temperatura (°C) | 18–24 | 12–28 | <12°C reduce cuaje; heladas dañan flor |
+| Precipitación (mm/año) | 1.000–1.600 | 800–2.000 | Necesita período seco para inducir floración |
+| Suelo (textura) | Franco-arenoso a franco | mediana | Drenaje obligatorio — anegamiento mata raíz |
+| pH del suelo | 5.5–6.5 | 5.0–7.0 | Sensible a aluminio en suelos ácidos andinos |
+| Sombra (%) | 0–10 (productivo) | hasta 30 (joven) | Adulto requiere plena luz |
+
+## 3. Asociaciones agroecológicas
+
+### 3.1 Positivas
+- **Polinizadores**: abejas (*Apis mellifera*), abejas sin aguijón (*Tetragonisca angustula*), moscas. Mejorar con setos florales de aromáticas + leguminosas en hileras.
+- **Coberturas**: maní forrajero (*Arachis pintoi*), kudzú tropical, vetiver para taludes — fija N + protege suelo.
+- **Sombrío hijuelo**: guamo (*Inga* spp.) durante primeros 2 años de establecimiento.
+
+### 3.2 Negativas / alelopatías
+- Eucalipto (*Eucalyptus globulus*): reduce infiltración + alelopatía. Distancia mínima 30 m.
+- Plantas con alta demanda hídrica que compitan en zona radicular superficial.
+
+## 4. Usos múltiples
+
+- **Alimentario**: pulpa fresca, aceite, derivados (guacamole, aceite cosmético).
+- **Madera**: poda — leña liviana.
+- **Cobertura suelo**: hojarasca abundante, materia orgánica al descomponerse.
+
+## 5. Plagas y enfermedades comunes
+
+| Plaga / enfermedad | Síntoma | Manejo agroecológico |
+|---|---|---|
+| *Phytophthora cinnamomi* (pudrición radicular) | Marchitez progresiva, raíz necrótica | Drenaje + Trichoderma + suelos vivos |
+| Trips (*Frankliniella* spp.) | Bronceado en flor y fruto joven | Extractos de ajo-ají + barrera aromática |
+| Áfidos / cochinillas | Melaza + fumagina | Aceite agrícola horticultural + control biológico (catarinas) |
+
+## 6. Reproducción y propagación
+
+- Patrón: semilla criolla resistente o portainjerto antillano-mexicano. Germinación 30–45 días con tratamiento térmico (50°C, 30 min).
+- Injerto: de hendidura o yema, 6–9 meses post-germinación. Únicamente material certificado ICA.
+- Distancia siembra: 7×7 m (200 árb/ha) para sistemas tradicionales; 5×5 m con poda intensiva.
+- Ventana siembra: inicio de lluvias para establecer raíz antes de período seco.
+
+## 7. Suggestion engine integration
+
+Inventario disparador:
+- Si `inventario tiene melaza + microorganismos nativos` + `aguacate en establecimiento` → sugerir aplicación foliar MM diluido al 1% mensual primer año (efecto promotor crecimiento + supresor patógenos).
+- Si `observación de plaga = Phytophthora` → activar protocolo Trichoderma + drenaje + ajuste pH al 6.0.
+
+## 8. Reconocimiento visual
+
+- Cáscara: rugosa tipo "pebble", verde oscuro madura a negro.
+- Forma: ovada, pera-pera.
+- Hojas: lanceoladas, anís al estrujar (común a la especie).
+- Confundible con: otros cultivares Persea (Lorena, Choquette) — distinguir por cáscara lisa o tamaño mayor.
+- Disponibilidad Pl@ntNet: alta cobertura (cultivo comercial global).
+
+## 9. Proveedores verificados
+
+| Tipo | Proveedor | Verificación |
+|---|---|---|
+| Plántula injertada | Agrosavia C.I. La Selva (Antioquia) | Registro ICA disponible (verificar lista oficial) |
+| Plántula injertada | Vivero Macanas — Jardín Antioquia | ICA 101434 |
+| Plántula injertada | Vivero Tierra Negra — El Retiro | ICA 14939, 110493 |
+
+Ver `deepresearch/knowledge/suppliers-colombia-2026-seed.md` para la lista completa.
+
+## 10. Notas legales y compliance
+
+- Material vegetal con registro ICA obligatorio para movilización interregional.
+- Variedad Hass: no patentada (dominio público), pero plantas certificadas requieren cumplimiento ICA.
+- Exportación a UE/USA requiere protocolo fitosanitario (Phytophthora-free).
+
+## 11. Limitaciones del conocimiento documentado
+
+- **Datos de rendimiento por piso térmico específico colombiano** son aproximados; varían fuertemente por microclima.
+- **Manejo orgánico de Phytophthora** en suelos andinos altos (>2200 m) tiene literatura limitada — más estudios necesarios.
+- **Comportamiento bajo escenarios de cambio climático** (aumento +1°C en piso templado) no está bien caracterizado.
+- **Asociación con microorganismos nativos andinos** requiere experimentación en finca laboratorio.
+
+**Validación pendiente**: agroecólogo certificado debe revisar dosis específicas de bioinsumos + protocolo de control orgánico de Phytophthora + asociaciones polinizador-floración local antes de promover esta ficha a `publicable_libro: true`.
+
+## 12. Régimen del dominio
+
+Operación de aguacate Hass en mundo de **cola pesada**:
+
+- ✅ Un evento de Phytophthora puede dominar pérdida anual (>40% árboles afectados → pérdida total parcela).
+- ✅ Mercado de exportación tiene cola pesada en precios (años de prima alta vs. años de glut).
+- ✅ Inversión inicial alta + retorno a 4-5 años = riesgo concentrado.
+
+**Estrategia coherente**: policultivo + sombrío hijuelo + cobertura permanente + monitoreo activo Phytophthora + diversificación de mercados.
+
+## Referencias canónicas
+
+- Bernal H., Díaz C. (2005). CORPOICA. Materiales locales y mejorados.
+- Agrosavia (s.f.). Manual técnico aguacate Hass.
+- Whiley A.W., Schaffer B., Wolstenholme B.N. (2002). *The Avocado: Botany, Production and Uses*. CABI.
+- ICA. Lista oficial de viveros registrados.

--- a/docs/species/02-cafe-arabigo.md
+++ b/docs/species/02-cafe-arabigo.md
@@ -1,0 +1,79 @@
+---
+ulid: 01HZ-CAFE-ARABIGO
+nombre_cientifico: Coffea arabica L.
+nombres_comunes:
+  - es: café arábigo
+    region: Colombia
+familia: Rubiaceae
+piso_termico_optimo: templado
+pisos_termicos_tolerados: [templado]
+altitud_m: { min: 1200, max: 2000 }
+categorias: [frutal]
+estado_introduccion: introducida
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: medio
+publicable_libro: false
+fuentes_principales:
+  - tipo: extension
+    cita: Cenicafé (FNC). *Manual del cafetero colombiano*.
+    url: https://www.cenicafe.org/
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF Backbone Taxonomy
+    url: https://www.gbif.org/species/2895315
+    nivel_confianza: alto
+---
+
+# Café arábigo — *Coffea arabica*
+
+## 1. Descripción agroecológica
+Arbusto perenne 3–5 m. Ciclo productivo 25–30 años con manejo. Cultivar dominante en zona andina colombiana — variedades Castillo, Caturra, Colombia, Cenicafé 1 son las más sembradas tras la roya. Floración inducida por estrés hídrico controlado. Cosecha principal abril–junio + traviesa octubre–diciembre.
+
+## 2. Requerimientos
+- T°: 18–22°C. Lluvia: 1.500–2.500 mm/año.
+- Suelo: franco-arenoso, profundo, drenado. pH 5.0–6.0. Sensible a aluminio.
+- Sombra: tradicional 30–50% bajo guamo/nogal cafetero; semi-tecnificado 0–30%.
+
+## 3. Asociaciones
+**Positivas**: guamo (*Inga edulis*) sombrío + N fix; nogal cafetero (*Cordia alliodora*); plátano dominico inicial; *Inga densiflora* refugio mariposas; abejas sin aguijón polinización facultativa.
+**Negativas**: eucalipto (alelopatía + agua), pino (acidificación) — distancia mínima 30 m.
+
+## 4. Usos
+- Grano comercial (espresso, especialidad single origin).
+- Pulpa: compostable, rica en N — abono verde post-cosecha.
+- Mucílago: fermento → biofertilizante líquido.
+
+## 5. Plagas/enfermedades
+- *Hemileia vastatrix* (roya): variedades resistentes (Castillo, Cenicafé 1).
+- Broca (*Hypothenemus hampei*): trampas + *Beauveria bassiana* (Bassicore SC ICA).
+- Cochinilla rosada: control biológico con *Cryptolaemus*.
+
+## 6. Reproducción
+Semilla certificada FNC + chapola en almácigo. Trasplante 5–7 meses. Distancia 1.5×2 m (3.300 plantas/ha) tradicional. Producción comercial año 2–3.
+
+## 7. Suggestion engine
+- Si `inventario = pulpa de café + cal` → sugerir compostaje 90 días + harina de roca.
+- Si `observación = manchas amarillas hojas` → eval visual roya + pH suelo.
+
+## 8. Reconocimiento
+Hojas brillantes opuestas, fruto cereza rojo/amarillo. Confundible con *Coffea canephora* (robusta) — distinguir por tamaño hoja + altitud (robusta <800 m).
+
+## 9. Proveedores
+Almácigos certificados FNC + Cenicafé. Variedades resistentes a roya disponibles vía Cooperativas de Caficultores de cada departamento.
+
+## 10. Compliance
+Movilización requiere ICA. Programa Federación Nacional de Cafeteros regula calidad.
+
+## 11. Limitaciones
+- **Sombreado óptimo** en zonas específicas colombianas requiere estudio local — varía por subregión (Quindío vs Caldas vs Nariño).
+- **Café orgánico** para denominaciones (UE / Rainforest / Fair Trade) requiere protocolo certificación bianual.
+- **Asociaciones con microorganismos nativos** subexploradas en literatura.
+- Validación experta pendiente para promover ficha a publicable.
+
+## 12. Régimen del dominio
+**Cola pesada**: precio commodity tiene cola pesada (años con primas vs glut), roya fue evento power-law histórico. **Estrategia**: variedades resistentes + sombrío + diversificación cosecha (especialidad + comercial) + adopción Restrepo.
+
+## Referencias
+- Cenicafé (2013). *Manual del cafetero colombiano*. Tomos I-III.
+- DaMatta F.M. (2004). Ecophysiological constraints on coffee. *Field Crops Research* 86:99–114.

--- a/docs/species/03-mora-castilla.md
+++ b/docs/species/03-mora-castilla.md
@@ -1,0 +1,81 @@
+---
+ulid: 01HZ-MORA-CASTILLA
+nombre_cientifico: Rubus glaucus Benth.
+nombres_comunes:
+  - es: mora de Castilla
+    region: andina colombiana
+  - es: mora andina
+familia: Rosaceae
+piso_termico_optimo: frio
+pisos_termicos_tolerados: [templado, frio]
+altitud_m: { min: 1800, max: 3200 }
+categorias: [frutal]
+estado_introduccion: nativa
+estado_conservacion_iucn: LC
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: medio
+publicable_libro: false
+fuentes_principales:
+  - tipo: extension
+    cita: Agrosavia. *Manual del cultivo de mora de Castilla*.
+    url: https://www.agrosavia.co/
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF Backbone Taxonomy
+    url: https://www.gbif.org/species/2997840
+    nivel_confianza: alto
+---
+
+# Mora de Castilla — *Rubus glaucus*
+
+## 1. Descripción
+Arbusto trepador-rastrero perenne, tallos espinosos (ramoneo). Especie nativa andina con alta variabilidad genética en Colombia. Producción casi continua año redondo en zonas óptimas. Vida productiva económica 6-8 años con manejo.
+
+## 2. Requerimientos
+- T°: 11–18°C. Lluvia: 1.500–2.500 mm/año bien distribuidos.
+- Suelo: franco a franco-arcilloso, alto contenido MO (>5%). pH 5.2–6.0.
+- Sombra: 0–25%. Plena luz para producción comercial.
+
+## 3. Asociaciones
+**Positivas**: cobertura de leguminosas (trébol blanco, vetiver para taludes), barreras vivas con sauco (*Sambucus peruviana*) para protección viento + alimento aves benéficas.
+**Negativas**: ninguna documentada relevante en sistemas tradicionales.
+
+## 4. Usos
+- Fruto fresco + procesado (pulpa, mermelada, vino artesanal, helado).
+- Hojas: tisana medicinal tradicional (astringente, mineralizante).
+- Cobertura de talud: control de erosión.
+
+## 5. Plagas/enfermedades
+- Antracnosis (*Colletotrichum gloeosporioides*): poda sanitaria + Trichoderma.
+- Mosca de la fruta: trampas hidrolizado + envoltura individual frutos.
+- Ácaros: extractos azufre + neem.
+
+## 6. Reproducción
+Estaca enraizada (más rápida) o acodo punta. Distancia 2×3 m. Tutoreado en espaldera doble alambre.
+
+## 7. Suggestion engine
+- `Inventario = melaza + estiércol bovino` + `mora plantada` → sugerir biofertilizante foliar quincenal.
+- `Observación = manchas oscuras frutos` → diagnóstico antracnosis → poda sanitaria + Trichoderma.
+
+## 8. Reconocimiento
+Hojas trifoliadas, envés blanquecino-glauco (de ahí *glaucus*). Frutos drupéolas que pasan de rojo a negro al madurar. Confundible con *Rubus rosifolius* — distinguir por tamaño hoja + altitud.
+
+## 9. Proveedores
+Agrosavia C.I. La Selva tiene material seleccionado. Viveros municipales en Cundinamarca/Boyacá/Antioquia (verificar registro ICA local).
+
+## 10. Compliance
+Movilización plántulas requiere ICA. Especie nativa: protección de variedades regionales criollas — preferible usar materiales locales sobre clones importados.
+
+## 11. Limitaciones
+- **Variabilidad criolla** poco documentada — datos productivos varían fuertemente por accesión.
+- **Manejo orgánico de antracnosis** en condiciones de alta humedad andina requiere estudio local.
+- **Polinización** mayormente autógama pero con visitantes (abejas, abejorros) — efecto en producción no cuantificado en zonas específicas.
+- Validación experta pendiente.
+
+## 12. Régimen del dominio
+**Cola pesada moderada**: heladas tardías destruyen floración (evento puntual = pérdida campaña). **Estrategia**: diversificar zonas de plantación + cobertura de microclima + monitoreo IDEAM previsiones.
+
+## Referencias
+- Agrosavia (s.f.). *Manual mora de Castilla*.
+- Franco G., Gallego J.L. (2002). *Las moras*. CORPOICA.

--- a/docs/species/04-canavalia.md
+++ b/docs/species/04-canavalia.md
@@ -1,0 +1,82 @@
+---
+ulid: 01HZ-CANAVALIA
+nombre_cientifico: Canavalia ensiformis (L.) DC.
+nombres_comunes:
+  - es: canavalia
+  - es: frijol espada
+  - es: jack bean
+    region: anglosajón
+familia: Fabaceae
+piso_termico_optimo: calido
+pisos_termicos_tolerados: [calido, templado]
+altitud_m: { min: 0, max: 1800 }
+categorias: [leguminosa, abono_verde, trampa]
+estado_introduccion: introducida (americana, naturalizada)
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: medio
+publicable_libro: false
+fuentes_principales:
+  - tipo: libro
+    cita: Restrepo Rivera J. (2007). *Manual práctico ABC de la agricultura orgánica*.
+    nivel_confianza: alto
+  - tipo: paper
+    cita: CIAT (1995). Canavalia as cover crop in tropical agroforestry.
+    url: https://hdl.handle.net/10568/55043
+    nivel_confianza: alto
+---
+
+# Canavalia — *Canavalia ensiformis*
+
+## 1. Descripción
+Leguminosa anual erecta o semi-trepadora. Una de las coberturas vivas + abonos verdes más usadas en agricultura tropical. Crecimiento explosivo (4–8 semanas alcanza cobertura completa). Fija N atmosférico vía simbiosis con *Bradyrhizobium*. Tolerante a sequía y suelos pobres.
+
+## 2. Requerimientos
+- T°: 20–30°C. Lluvia: 700–2.000 mm.
+- Suelo: muy adaptable, hasta suelos compactados degradados. pH 4.5–7.5.
+- Sol: pleno. Tolera sombra moderada (cultivo en callejones).
+
+## 3. Asociaciones
+**Positivas**:
+- Maíz: rotación o asociación intercalar — suprime arvenses + suelo a maíz siguiente.
+- Yuca: cobertura entre plantas en establecimiento.
+- Café joven: cobertura entre filas primer año.
+**Negativas**: pastos agresivos (kikuyo, pangola) compiten en establecimiento.
+
+## 4. Usos
+- **Abono verde**: incorporar al inicio de floración (60–90 días) → ~80–150 kg N/ha al suelo.
+- **Cobertura viva**: protección suelo + supresión arvenses.
+- **Forraje**: hojas tiernas (cuidado: contiene canavanina, tóxica en dosis altas, controlar consumo).
+- **Trampa nematodos**: efecto nematicida sobre *Meloidogyne* spp. documentado.
+
+## 5. Plagas/enfermedades
+Pocas plagas significativas — la canavanina es disuasiva. *Cercospora* puede aparecer en exceso humedad.
+
+## 6. Reproducción
+Semilla. ~30–40 kg/ha al voleo o líneas a 30 cm. Inocular con *Bradyrhizobium* específico mejora 30–50% fijación.
+
+## 7. Suggestion engine
+- `Suelo degradado + piso cálido + época lluvias inminente` → sugerir siembra canavalia 90 días pre-cultivo principal.
+- `Inventario = semilla canavalia + maíz` → sugerir asociación intercalar (maíz + canavalia entre filas).
+
+## 8. Reconocimiento
+Hojas trifoliadas pinnadas, foliolos ovados grandes. Vainas planas espadiformes 20–35 cm. Semillas ovaladas blancas con hilio oscuro.
+
+## 9. Proveedores
+Bancos de semilla campesinos (RESNATUR, Custodios). Comercial: pocos viveros — buscar redes Cosurca, Aldea Mística, Custodios de Semillas de Vida.
+
+## 10. Compliance
+Semilla pre-comercial: trazabilidad recomendada para certificaciones orgánicas. Sin restricciones ICA específicas a nivel campesino.
+
+## 11. Limitaciones
+- **Toxicidad para forraje**: dosis seguras para bovinos requieren más estudio en condiciones colombianas.
+- **Cepas inoculantes** específicas para suelos andinos colombianos no comerciales — campesino captura microorganismos locales (cf. ficha MM).
+- **Comportamiento en pisos templado-frío** menos documentado — transferir con precaución.
+
+## 12. Régimen del dominio
+**Gaussiano** — abono verde robusto, downside acotado (si falla, perdido es la semilla + tiempo). **Estrategia**: usar como infraestructura agroecológica de bajo riesgo, complemento perfecto a sistemas con baja tasa de M.O.
+
+## Referencias
+- Restrepo Rivera J. (2007). *Manual ABC agricultura orgánica*.
+- CIAT (varios). Programa de cobertura viva trópico.
+- FAO/AGROVOC ID `9b4bb52a` (canavalia).

--- a/docs/species/05-frijol-mortino.md
+++ b/docs/species/05-frijol-mortino.md
@@ -1,0 +1,87 @@
+---
+ulid: 01HZ-FRIJOL-MORTINO
+nombre_cientifico: Phaseolus coccineus L.
+nombres_comunes:
+  - es: frijol Mortiño
+    region: Boyacá / Cundinamarca
+  - es: frijol bola roja
+    region: Antioquia
+  - es: frijol cargabello
+    region: Nariño
+familia: Fabaceae
+piso_termico_optimo: frio
+pisos_termicos_tolerados: [templado, frio]
+altitud_m: { min: 1800, max: 2800 }
+categorias: [leguminosa, grano]
+estado_introduccion: introducida (mesoamericana, adaptada a Andes hace siglos)
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: medio
+publicable_libro: false
+fuentes_principales:
+  - tipo: extension
+    cita: Agrosavia. Banco Germoplasma frijol — colección *P. coccineus* andina.
+    url: https://www.agrosavia.co/
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF Backbone Taxonomy
+    url: https://www.gbif.org/species/5350443
+    nivel_confianza: alto
+---
+
+# Frijol Mortiño — *Phaseolus coccineus*
+
+## 1. Descripción
+Frijol perenne (en condiciones favorables) o anual robusto, trepador vigoroso. Especie distinta a *Phaseolus vulgaris* — flores grandes rojo-naranja, semillas grandes (peso 100 g típicamente >120 g). Adaptado a zona andina fría con noches frescas. Variedad campesina con alto valor cultural en zonas trigueras-cebaderas.
+
+## 2. Requerimientos
+- T°: 12–22°C. Lluvia: 800–1.500 mm bien distribuidos.
+- Suelo: franco, alto MO. pH 5.5–6.8.
+- Sol: pleno con tutor. Tolera heladas suaves intermitentes mejor que *P. vulgaris*.
+
+## 3. Asociaciones
+**Positivas (milpa andina tradicional)**:
+- Maíz andino (capio, púrpura): tutor natural.
+- Calabaza zapallo: cobertura suelo.
+- Quinua: ciclo complementario.
+**Negativas**: ajos, cebollas largas (alelopatía suave).
+
+## 4. Usos
+- **Grano seco**: alimento alto proteína (>22%). Consumo tradicional como sopa.
+- **Vainas verdes inmaduras**: comestibles.
+- **Flor**: comestible, polinizador atrayente.
+- **Semilla criolla**: valor patrimonial cultural.
+
+## 5. Plagas/enfermedades
+- Antracnosis (*Colletotrichum lindemuthianum*): rotación + variedades resistentes locales.
+- Mosaico común: vector áfido — control biológico + variedades tolerantes.
+- *Phytophthora*: drenaje obligatorio.
+
+## 6. Reproducción
+Semilla (criolla preferiblemente). Tutoreado obligatorio (tutores 2.5–3 m). Distancia 0.8×0.4 m con maíz asociado o 1.5 m si solo.
+
+## 7. Suggestion engine
+- `Inventario = semilla mortiño + maíz capio + zapallo` → sugerir milpa tradicional 3 hermanas andina.
+- `Observación = manchas oscuras hundidas vainas` → diagnóstico antracnosis → poda + Trichoderma + rotación próximo ciclo.
+
+## 8. Reconocimiento
+Flores grandes rojas (a veces blancas en variantes), planta vigorosa con cabellera de zarcillos. Confundible con *P. vulgaris* — distinguir por tamaño flor + hipocotilo subterráneo (Mortiño tiene cotiledones que NO emergen).
+
+## 9. Proveedores
+Bancos de semillas campesinos andinos (Custodios de Semillas de Vida — Nariño). Agrosavia — accesiones del Banco Germoplasma. **NO recomendar viveros comerciales que vendan híbridos foráneos** — preservar variedades locales.
+
+## 10. Compliance
+Semilla criolla: protección bajo Ley 1518 (acceso recursos genéticos) si se comercializa. Intercambio campesino tradicional: legítimo culturalmente, sin restricciones ICA actuales.
+
+## 11. Limitaciones
+- **Manejo orgánico antracnosis** en zonas húmedas frías requiere más estudio.
+- **Polinización**: depende parcialmente de abejorros nativos (*Bombus* spp.) — colapso de polinizadores afecta. Cuantificación local necesaria.
+- **Variedades criollas**: caracterización agronómica formal incompleta — reto y oportunidad.
+
+## 12. Régimen del dominio
+**Cola pesada** en preservación: cada variedad criolla perdida es irreversible. **Estrategia**: bancos de semillas comunitarios + intercambio activo + documentación + multiplicación distribuida (no centralizada).
+
+## Referencias
+- Agrosavia (s.f.). Banco Germoplasma Vegetal — *Phaseolus*.
+- Beebe S. et al. (varios). CIAT trabajos en *P. coccineus*.
+- Red Custodios de Semillas de Vida (RESNATUR).

--- a/docs/species/06-tarwi-lupino.md
+++ b/docs/species/06-tarwi-lupino.md
@@ -1,0 +1,90 @@
+---
+ulid: 01HZ-TARWI-LUPINO
+nombre_cientifico: Lupinus mutabilis Sweet
+nombres_comunes:
+  - es: tarwi
+    region: andina
+  - es: chocho
+    region: peruana / boliviana
+  - es: lupino andino
+familia: Fabaceae
+piso_termico_optimo: frio
+pisos_termicos_tolerados: [frio, paramo]
+altitud_m: { min: 2200, max: 3800 }
+categorias: [leguminosa, grano, abono_verde]
+estado_introduccion: nativa
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: medio
+publicable_libro: false
+fuentes_principales:
+  - tipo: paper
+    cita: Caicedo C., Peralta E. (2001). *El cultivo de chocho*. INIAP.
+    nivel_confianza: alto
+  - tipo: extension
+    cita: FAO. *Lupinus mutabilis (chocho/tarwi): cultivo andino subexplotado*.
+    url: http://www.fao.org/3/T0646E/T0646E0e.htm
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF
+    url: https://www.gbif.org/species/2964471
+    nivel_confianza: alto
+---
+
+# Tarwi / Chocho — *Lupinus mutabilis*
+
+## 1. Descripción
+Leguminosa anual de páramo y zona alta andina, cultivada hace miles de años (pre-incaica) en Colombia, Ecuador, Perú, Bolivia. Una de las leguminosas con MAYOR contenido proteico vegetal conocido (35–45% en grano seco). Fija N atmosférico de manera eficiente (>80 kg N/ha). Subutilizada por el alto contenido de alcaloides amargos en variedades silvestres — requiere desamargado tradicional (lavado prolongado).
+
+## 2. Requerimientos
+- T°: 7–14°C. Lluvia: 350–800 mm.
+- Suelo: tolerante a suelos pobres ácidos. pH 4.5–6.5.
+- Sol: pleno. Resistente a heladas hasta -2°C en estado adulto.
+
+## 3. Asociaciones
+**Positivas (sistema andino tradicional)**:
+- Quinua: ciclos paralelos, suelos similares.
+- Papa nativa: rotación previa a siembra papa (mejora suelo).
+- Cebada / centeno: rotación cereal.
+**Negativas**: pastos kikuyo (compite vigorosamente).
+
+## 4. Usos
+- **Grano desamargado**: alimento alto-proteína. Tradicional en *cebiche serrano* (Ecuador), *salpicón andino*, harinas mezcla.
+- **Abono verde**: si solo busca N, incorporar a floración (~120 días) → ~80–120 kg N/ha.
+- **Aceite de semilla**: ~18% — uso cosmético / consumo.
+- **Variedades dulces (sin alcaloides)**: requieren manejo cuidadoso porque pierden defensa contra plagas.
+
+## 5. Plagas/enfermedades
+- Antracnosis (*Colletotrichum lupini*): variedades resistentes + rotación.
+- Roya: aplicación de extracto cola de caballo + sulfato de cobre orgánico.
+- Mosca minadora: control biológico.
+
+## 6. Reproducción
+Semilla. ~80 kg/ha. Distancia 0.6×0.3 m. Sin tutor (porte erecto). No requiere riego salvo zonas extremo secas.
+
+## 7. Suggestion engine
+- `Suelo degradado piso frío + necesita N` → sugerir tarwi como rotación previa a papa/cereal.
+- `Inventario = grano amargo recién cosechado` → activar protocolo desamargado tradicional (3-5 días lavado en agua corriente o 6-7 días aguas estancadas con cambios diarios).
+
+## 8. Reconocimiento
+Hojas digitadas (5–11 foliolos), forma palmar característica. Flores azules-violetas vistosas. Vainas pubescentes. Semillas planas redondeadas, blancas o jaspeadas.
+
+## 9. Proveedores
+Bancos andinos: Custodios de Semillas de Vida (Nariño), redes de papa nativa que tradicionalmente conservan tarwi. INIAP Ecuador tiene variedades mejoradas accesibles.
+
+## 10. Compliance
+Recurso genético andino tradicional. Acceso bajo Convenio Andino sobre Recursos Genéticos. Comercio transfronterizo (Ecuador-Colombia) tradicional pero formalmente requiere permisos ICA.
+
+## 11. Limitaciones
+- **Variedades dulces colombianas**: poco material disponible. Agrosavia no tiene programa activo — INIAP Ecuador es referencia.
+- **Manejo de alcaloides**: protocolo desamargado seguro requiere validación científica para producto comercial (FAO ha publicado guías).
+- **Datos productivos colombianos** son escasos vs Perú/Ecuador/Bolivia.
+- **Reincorporación cultural**: cultivo perdido en muchas zonas Colombia. Re-introducción requiere acompañamiento social.
+
+## 12. Régimen del dominio
+**Cola pesada cultural**: el conocimiento tradicional de manejo está en pocos custodios envejecidos — riesgo de extinción de saberes. **Estrategia**: documentación oral + multiplicación distribuida + integración a sistemas escolares rurales.
+
+## Referencias
+- Caicedo C., Peralta E. (2001). INIAP. *El cultivo de chocho*.
+- FAO. *Lupinus mutabilis: a subexploited Andean crop*.
+- López-Bellido L. (1994). *El cultivo del altramuz*. Mundi-Prensa (paralelo europeo).

--- a/docs/species/07-aliso.md
+++ b/docs/species/07-aliso.md
@@ -1,0 +1,93 @@
+---
+ulid: 01HZ-ALISO
+nombre_cientifico: Alnus acuminata Kunth
+nombres_comunes:
+  - es: aliso andino
+  - es: aliso
+    region: Andes colombianos
+  - es: cerezo
+    region: zona cafetera (impreciso)
+familia: Betulaceae
+piso_termico_optimo: frio
+pisos_termicos_tolerados: [templado, frio]
+altitud_m: { min: 1500, max: 3300 }
+categorias: [maderable, sombrio, abono_verde]
+estado_introduccion: nativa
+estado_conservacion_iucn: LC
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: alto
+publicable_libro: false
+fuentes_principales:
+  - tipo: paper
+    cita: Russo R.O., Berlyn G.P. (1990). *The use of Alnus acuminata...*. Agroforestry Systems.
+    nivel_confianza: alto
+  - tipo: libro
+    cita: CONIF (Corporación Nacional de Investigación y Fomento Forestal). Manual silvicultural aliso.
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF
+    url: https://www.gbif.org/species/2876189
+    nivel_confianza: alto
+---
+
+# Aliso — *Alnus acuminata*
+
+## 1. Descripción
+Árbol caducifolio (en parte) andino nativo, 15–25 m altura, copa abierta. Especie clave en restauración ecológica de los Andes — fija nitrógeno atmosférico vía simbiosis con *Frankia* (actinomiceto), aporta hojarasca abundante rica en N, prospera en suelos pobres y orillas de quebrada. Sucesión secundaria pionera intermedia: prepara suelo para especies clímax (roble, encenillo).
+
+## 2. Requerimientos
+- T°: 8–18°C. Lluvia: 1.000–3.000 mm.
+- Suelo: muy adaptable, prospera en suelos degradados, ácidos, drenados o húmedos. pH 4.5–7.0.
+- Sol: pleno. Tolerante a viento, helada moderada.
+
+## 3. Asociaciones
+**Positivas**:
+- Pasto kikuyo / brachiaria: silvopastoril clásico colombiano (sombra + N al pasto).
+- Café (zona templada-fría >1700 m): sombrío productivo.
+- Mora de Castilla: barrera viva + cortavientos.
+- Bosques mixtos: facilita establecimiento de roble (*Quercus humboldtii*), encenillo (*Weinmannia*), pino romerón.
+**Negativas**: pino patula adyacente (pino acidifica + alelopatía suave).
+
+## 4. Usos
+- **Madera**: liviana-mediana, blanda, buena para tableros, embalaje, cajonería, palillos. Durabilidad limitada al exterior.
+- **Leña**: rápido secado, calorífico medio.
+- **Sombrío silvopastoril**: dosel disperso permite pasto productivo.
+- **Restauración**: especie estrella para reforestación participativa páramos baja altitud + cuencas degradadas.
+- **Hojarasca**: abono verde forestal — relación C/N favorable acelera descomposición + libera N.
+
+## 5. Plagas/enfermedades
+- Larvas defoliadoras (*Lepidópteros*): control biológico (*Trichogramma*) + parasitoides.
+- Hongos foliares: rara vez problema en sistemas con biodiversidad.
+- Pudrición radicular en suelos compactados con anegamiento prolongado.
+
+## 6. Reproducción
+- Semilla: estratos cálidos no germinan bien; cosechar antes de dispersión natural. Pretratar 24h agua tibia.
+- Estaca: enraiza con dificultad media. Acodo aéreo factible.
+- Distancia: silvopastoril 8×8 m a 12×12 m. Reforestación denso 3×3 m.
+
+## 7. Suggestion engine
+- `Suelo degradado piso frío + objetivo restauración` → sugerir aliso como pionero, asociado con pioneras complementarias (chilco, sauco).
+- `Inventario = hojarasca aliso fresca + necesita compost N` → activar protocolo compostaje rápido (proporción 3 partes hojarasca verde aliso : 1 carbono seco, en pilas de 1.5 m).
+
+## 8. Reconocimiento
+Hojas alternas, ovado-lanceoladas, márgenes aserrados. Inflorescencia: amentos colgantes (machos) + estróbilos pequeños cónicos (hembras) que se vuelven leñosos. Confundible con *Alnus jorullensis* (más mexicana) — distinguir por amentos.
+
+## 9. Proveedores
+Viveros forestales CARs (CAR Cundinamarca, CVS Córdoba, Corpoamazonia). Programas reforestación municipal. CONIF / Agrosavia colaboraron históricamente.
+
+## 10. Compliance
+Especie nativa: aprovechamiento maderable requiere permisos ANLA / CAR. Reforestación en cuencas: programas con incentivos (Pago por Servicios Ambientales, Visión Amazonia).
+
+## 11. Limitaciones
+- **Cepas de Frankia colombianas** específicas no comerciales — el árbol captura naturalmente del suelo si hay otros alisos cerca, pero plantaciones nuevas en suelos sin historia toman 6–12 meses para infectarse.
+- **Variedad genética**: poca caracterización formal de ecotipos por subregión andina.
+- **Manejo silvopastoril óptimo**: densidad x edad para máximo balance pasto-madera-N requiere experimentación local.
+
+## 12. Régimen del dominio
+**Gaussiano largo plazo**: árbol de larga vida con servicios acumulativos. **Estrategia**: asegurar cobertura permanente + diversidad de edades + integración con pioneras complementarias para sucesión robusta.
+
+## Referencias
+- Russo R.O., Berlyn G.P. (1990). *Agroforestry Systems* 11:65–72.
+- CONIF (varios). Manual silvicultural especies andinas.
+- Carlson P.J., Farmer R.E. (1971). *Silvical characteristics of Alnus*.

--- a/docs/species/08-guamo.md
+++ b/docs/species/08-guamo.md
@@ -1,0 +1,94 @@
+---
+ulid: 01HZ-GUAMO
+nombre_cientifico: Inga edulis Mart.
+nombres_comunes:
+  - es: guamo
+    region: Colombia
+  - es: guamo bejuco / guamo macheto / guamo santafereño (variantes locales)
+  - es: pacae
+    region: amazónica
+familia: Fabaceae (subfam. Mimosoideae)
+piso_termico_optimo: templado
+pisos_termicos_tolerados: [calido, templado]
+altitud_m: { min: 200, max: 2000 }
+categorias: [frutal, sombrio, abono_verde, maderable]
+estado_introduccion: nativa (Andes-Amazonas)
+estado_conservacion_iucn: LC
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: alto
+publicable_libro: false
+fuentes_principales:
+  - tipo: paper
+    cita: Pennington T.D. (1997). *The Genus Inga: Botany*. Royal Botanic Gardens, Kew.
+    nivel_confianza: alto
+  - tipo: extension
+    cita: Cenicafé. *Manejo del sombrío con guamo en cafetales*.
+    url: https://www.cenicafe.org/
+    nivel_confianza: alto
+  - tipo: base_datos
+    cita: GBIF
+    url: https://www.gbif.org/species/5350023
+    nivel_confianza: alto
+---
+
+# Guamo / Cachimbo — *Inga edulis*
+
+## 1. Descripción
+Árbol leguminoso nativo neotropical, 8–15 m altura, copa amplia con ramificación baja. Especie estrella del sombrío de café tradicional colombiano. Fija nitrógeno (asociación con *Rhizobium*). Crecimiento rápido. Hojarasca abundante con relación C/N favorable.
+
+## 2. Requerimientos
+- T°: 18–28°C. Lluvia: 1.200–3.000 mm.
+- Suelo: muy adaptable. pH 4.5–7.5.
+- Sol: pleno o sombra parcial joven.
+
+## 3. Asociaciones
+**Positivas (clásica)**:
+- Café arábigo: sombrío productivo, regulación temperatura/humedad cafetal, aporte N.
+- Cacao en zonas cálidas: igual rol.
+- Plátano: sucesión vertical en sistemas multiestrato.
+- Polinizadores nocturnos (murciélagos, polillas) atraídos a flores grandes blancas.
+**Negativas**: ninguna documentada relevante.
+
+## 4. Usos
+- **Sombrío productivo**: clásico del café colombiano.
+- **Fruto pulpa**: vainas largas con pulpa algodonosa dulce comestible (mucho consumo regional).
+- **Madera**: leña + postes + cabos herramientas. Densidad media.
+- **Hojarasca**: abono verde forestal — descomposición rápida libera N rápidamente.
+- **Polinizadores**: refugio para abejas + murciélagos polinizadores.
+
+## 5. Plagas/enfermedades
+- Trips en floración: control biológico + extractos botánicos.
+- *Phellinus* en árboles viejos: poda sanitaria.
+- Generalmente robusto.
+
+## 6. Reproducción
+- Semilla: germinación rápida (1–2 semanas), corta viabilidad (recalcitrante — sembrar fresca).
+- No rebrota bien de estaca.
+- Distancia: sombrío café 8×8 m a 12×12 m. Reforestación 3×3 m.
+
+## 7. Suggestion engine
+- `Café joven en establecimiento + piso templado` → sugerir guamo intercalar 8×8 m sombrío permanente.
+- `Inventario = vainas guamo cosechadas + cocina` → opciones culinarias (consumo fresco, jugo, bebida fermentada tradicional).
+
+## 8. Reconocimiento
+Hojas pinnadas alternas con foliolos pares y estípulas (raquis con glándulas características). Flores blancas grandes en cabezuelas. Vainas largas verdes-amarillentas (15–30 cm). Confundible con otras *Inga* — distinguir por glándulas raquis + tamaño vaina.
+
+## 9. Proveedores
+Viveros municipales zonas cafeteras. Cenicafé tiene material recomendado. CARs regionales (CVC, CRQ, Corpocaldas). Bancos campesinos cafeteros locales.
+
+## 10. Compliance
+Nativa — preferida en programas PSA + reforestación cuencas. Aprovechamiento maderable: permiso CAR para tala (no se aplica a poda silvopastoril normal).
+
+## 11. Limitaciones
+- **Selección de procedencia**: existen muchos ecotipos *Inga edulis* — material local mejor adaptado pero no formalmente caracterizado.
+- **Manejo de sombrío óptimo en café**: porcentaje varía por subregión cafetera y altitud, no hay receta única.
+- **Aprovechamiento polinizador murciélagos**: subexplotado culturalmente; servicio invisibilizado.
+
+## 12. Régimen del dominio
+**Gaussiano**: árbol robusto de larga vida con servicios acumulativos. **Estrategia**: integración multiestrato + diversidad genética en plantaciones (mezclar varias *Inga*) + retención individuos viejos como semillaron.
+
+## Referencias
+- Pennington T.D. (1997). *The Genus Inga*. Kew.
+- Cenicafé. Boletín técnico sombrío.
+- Beer J. et al. (1998). *Shade management in coffee and cacao plantations*. Agroforestry Systems.

--- a/docs/species/09-trichoderma.md
+++ b/docs/species/09-trichoderma.md
@@ -1,0 +1,114 @@
+---
+ulid: 01HZ-TRICHODERMA-HARZIANUM
+nombre_cientifico: Trichoderma harzianum Rifai
+nombres_comunes:
+  - es: Trichoderma
+  - es: hongo benéfico Trichoderma
+familia: Hypocreaceae (Hongos: Ascomycota)
+piso_termico_optimo: universal
+pisos_termicos_tolerados: [calido, templado, frio]
+altitud_m: { min: 0, max: 3500 }
+categorias: [microorganismo]
+estado_introduccion: nativa cosmopolita (presente naturalmente en suelos sanos andinos)
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: alto
+publicable_libro: false
+fuentes_principales:
+  - tipo: paper
+    cita: Harman G.E. et al. (2004). *Trichoderma species — opportunistic, avirulent plant symbionts*. Nature Reviews Microbiology 2:43–56.
+    url: https://doi.org/10.1038/nrmicro797
+    nivel_confianza: alto
+  - tipo: extension
+    cita: Agrosavia Tricotec® WG — *Trichoderma koningiopsis* cepa Th003. Registro ICA No. 12164.
+    nivel_confianza: alto
+  - tipo: paper
+    cita: Mukherjee P.K. et al. (2013). *Trichoderma research in the genome era*. Annu. Rev. Phytopathology 51:105–129.
+    nivel_confianza: alto
+---
+
+# *Trichoderma harzianum*
+
+## 1. Descripción agroecológica
+Hongo filamentoso (Ascomycota) ubicuo en suelos del mundo, especialmente en zonas con alta materia orgánica. Pieza nuclear del control biológico agroecológico. Funciones documentadas:
+- **Antagonismo a patógenos** (mycoparasitismo): coloniza y degrada hifas de *Phytophthora*, *Fusarium*, *Pythium*, *Rhizoctonia*, *Sclerotinia*.
+- **Inducción de resistencia sistémica** (ISR) en plantas hospederas.
+- **Promoción del crecimiento** vía producción de auxinas + solubilización de fósforo + ácido siderofóricos.
+- **Mejoramiento del suelo**: descomposición de materia orgánica, mejora estructura.
+
+## 2. Requerimientos del medio
+- T°: 15–30°C óptimo (algunas cepas hasta 35°C).
+- pH suelo: 4.5–7.5 (más activa en pH 5.5–6.5 — coincidente con suelos andinos).
+- Humedad: 40–60% suelo. Inhibido por anegamiento prolongado.
+- Sol: indirecto/sombra para aplicación foliar (UV mata esporas).
+
+## 3. Asociaciones agroecológicas
+**Sinérgico con**:
+- Micorrizas arbusculares (*Glomus* spp.): trabajan complementariamente — micorriza extiende exploración radicular, Trichoderma protege.
+- *Bacillus subtilis* / *Pseudomonas fluorescens*: bacterias PGPR, sinergias documentadas.
+- Compost maduro / lombricompost: vehículo natural.
+**Antagónico con**:
+- Algunos hongos comestibles (*Pleurotus*, *Lentinula*) — competidor agresivo. **NO inocular Trichoderma en sustrato destinado a hongos comestibles.**
+
+## 4. Usos múltiples
+- **Tratamiento de semilla**: inmersión en suspensión Trichoderma 30 min antes de siembra.
+- **Aplicación al suelo**: vehículo lombricompost o compost. Dosis típica: 10⁶–10⁸ esporas/g sustrato.
+- **Aplicación foliar**: con coadyuvante (melaza al 1%) — aplicar al atardecer.
+- **Compostaje**: acelera + suprime patógenos durante proceso.
+- **Recuperación suelos degradados** post-erosión, post-incendio.
+
+## 5. Plagas/enfermedades CONTROLADAS
+- *Phytophthora* spp. (pudrición radicular en aguacate, papaya, frutales).
+- *Fusarium oxysporum* (marchitez tomate, fríjol, papa).
+- *Rhizoctonia solani* (damping-off plántulas).
+- *Sclerotinia sclerotiorum* (moho blanco).
+- *Pythium* spp. (caída de plántulas).
+
+## 6. Reproducción / multiplicación
+
+### Comercial:
+- **Tricotec® WG** (Agrosavia, *T. koningiopsis* Th003, ICA 12164).
+- **BioTrichum** (VerdeVidaVerde, ICA 6301).
+
+### Casera (multiplicación finca):
+1. Inóculo de *T. harzianum* comercial 100 g.
+2. Sustrato: arroz cocido al dente (1 kg) + 2 cucharadas melaza, esterilizado en olla a presión 30 min.
+3. Inocular en bolsa estéril, sellar.
+4. Incubar 7–14 días a 25°C, agitando cada 3 días.
+5. Colonia esporulada (verde oliva característico) — listo para usar.
+6. Aplicar fresco o conservar refrigerado <30 días.
+
+## 7. Suggestion engine integration
+- `Inventario = melaza + arroz + Trichoderma comercial` → activar protocolo multiplicación casera (1 kg sustrato × 100 g inóculo).
+- `Observación = plántulas con damping-off` → sugerir Trichoderma + drenaje + ajuste pH.
+- `Catalog tiene aguacate Hass + cultivo nuevo` → sugerir tratamiento Trichoderma al trasplante.
+- **NO sugerir** si destino es producción Pleurotus.
+
+## 8. Reconocimiento visual
+Coloniza sustratos formando colonia algodonosa blanca que se vuelve verde oliva-claro a medida que esporula. Colonias en placa: crecimiento radial rápido, anillos zonados. Microscopía: conidióforos ramificados con fiálides cortas, conidias verdes pequeñas (<5 μm) en racimos.
+
+## 9. Proveedores verificados Colombia
+| Proveedor | Cepa | Registro ICA |
+|---|---|---|
+| Agrosavia (Tricotec® WG) | *T. koningiopsis* Th003 | 12164 |
+| VerdeVidaVerde (BioTrichum) | *Trichoderma* spp. | 6301 |
+| Sanoplant Colombia | varias | verificar |
+| Biodyne Colombia | varias | desde 1989 |
+
+## 10. Compliance
+Bioinsumo registrado ICA. Etiquetado obligatorio: cepa, concentración, fecha vencimiento. **NO** se permite venta de cepas no registradas comercialmente; intercambio campesino casero es legítimo personal-uso.
+
+## 11. Limitaciones
+- **Cepas comerciales** son optimizadas para condiciones generales — eficiencia en suelos andinos específicos varía.
+- **Multiplicación casera** tiene riesgo de contaminación cruzada — esterilización rigurosa requerida.
+- **Compatibilidad con fungicidas químicos** (incluso orgánicos como cobre): limitada — espaciado >7 días recomendado.
+- **Toxicología** humana: *T. harzianum* es generalmente seguro, pero personas inmunosuprimidas deben evitar exposición intensa.
+
+## 12. Régimen del dominio
+**Gaussiano**: bioinsumo robusto con downside acotado. Si la cepa muere, no causa daño. **Estrategia**: integración rutinaria a programa fitosanitario + multiplicación distribuida + diversificación de cepas.
+
+## Referencias canónicas
+- Harman G.E. et al. (2004). *Nature Reviews Microbiology* 2:43–56.
+- Mukherjee P.K. et al. (2013). *Annu. Rev. Phytopathology* 51:105–129.
+- Agrosavia. Ficha técnica Tricotec® WG.
+- Howell C.R. (2003). *Plant Disease* 87:4–10. Mechanisms employed by Trichoderma.

--- a/docs/species/10-microorganismos-de-montana.md
+++ b/docs/species/10-microorganismos-de-montana.md
@@ -1,0 +1,132 @@
+---
+ulid: 01HZ-MM-MICROORGANISMOS-MONTANA
+nombre_cientifico: consorcio microbiano (no especie única)
+nombres_comunes:
+  - es: MM
+  - es: Microorganismos de Montaña
+  - es: BLOC
+    region: protocolo CAR-Cundinamarca
+  - es: bocashi líquido
+    region: variante mesoamericana
+familia: consorcio (Lactobacillus + Saccharomyces + Bacillus + Trichoderma nativo + actinomicetos + otros)
+piso_termico_optimo: universal (capturar in situ del piso de uso)
+pisos_termicos_tolerados: [calido, templado, frio, paramo]
+altitud_m: { min: 0, max: 4000 }
+categorias: [microorganismo, abono_verde]
+estado_introduccion: nativa (capturados localmente del bosque cercano a la finca)
+ultima_revision: 2026-04-26
+revisor: borrador-pendiente-validacion-agroecologo
+nivel_confianza_global: alto
+publicable_libro: false
+fuentes_principales:
+  - tipo: libro
+    cita: Restrepo Rivera J. (2007). *Manual práctico ABC de la agricultura orgánica*. SIMAS.
+    nivel_confianza: alto
+  - tipo: extension
+    cita: Manual JICA-ICA *Microorganismos eficientes y de montaña en agricultura tropical*.
+    nivel_confianza: alto
+  - tipo: paper
+    cita: Higa T. (1991). *Effective Microorganisms — A new dimension in agriculture and environment*. INFRC, Atami.
+    nivel_confianza: medio (publicación gris pero foundational)
+---
+
+# Microorganismos de Montaña (MM) — consorcio nativo
+
+## 1. Descripción agroecológica
+**No es una especie sino un consorcio microbiano** capturado de bosque nativo cercano a la finca y multiplicado por el campesino en sustratos a base de carbohidratos (melaza/panela) + medio sólido (semolina/arroz). Diferencia clave vs EM (Effective Microorganisms patentado por Higa): los MM se capturan localmente, son específicos del bioma de la finca, no requieren licencia ni patente. Filosofía: "el bosque cercano sabe lo que tu finca necesita".
+
+Composición típica (variable según bosque y altitud): bacterias ácido-lácticas (*Lactobacillus* spp.), levaduras (*Saccharomyces*), bacilos (*Bacillus subtilis*, *B. coagulans*), actinomicetos (*Streptomyces*), Trichoderma nativos, hongos descomponedores variados.
+
+## 2. Requerimientos del medio
+- Captura: hojarasca + suelo orgánico de bosque maduro (altura/piso correspondiente al destino de uso).
+- Sustrato sólido: semolina/arroz triturado/salvado + melaza diluida sin cloro.
+- Fermentación: anaeróbica controlada 30 días, T° ambiente (15–28°C óptima).
+- Activación líquida: 5 kg sólido + 100 L agua sin cloro + 4 L melaza + trampa gases, 4–8 días.
+
+## 3. Asociaciones agroecológicas
+**Sinérgico con**:
+- Compost / lombricompost: MM acelera maduración + suprime patógenos.
+- Biofertilizantes minerales orgánicos (harinas roca, biochar): vehículo activador.
+- *Beauveria bassiana* / Trichoderma comerciales: complementan defensa.
+
+**Antagónico**:
+- Fungicidas químicos sintéticos: aniquilan consorcio.
+- Cloro residual del agua: mata cultivo (filtrar 24h o usar agua lluvia).
+- Hongos comestibles destinados a producción comercial (cuidado en sustratos compartidos).
+
+## 4. Usos múltiples
+- **Activador biológico de suelo**: dilución 1:100 a 1:500, aplicación quincenal-mensual al pie planta.
+- **Acelerador compostaje**: 1 L MM líquido por m³ pila.
+- **Inóculo sustratos germinación**: dilución 1:1000, riego inicial.
+- **Foliar bioestimulante**: dilución 1:100 con coadyuvante atenuador UV.
+- **Tratamiento bocashi**: incorporar al volteo.
+- **Recuperación suelos degradados**: post-incendio, post-deslizamiento.
+
+## 5. Patógenos suprimidos (documentados)
+- *Phytophthora* spp.
+- *Fusarium oxysporum*
+- *Rhizoctonia solani*
+- *Sclerotinia*
+- Olores anaerobios (vía bacterias ácido-lácticas)
+
+## 6. Protocolo de multiplicación (Restrepo)
+
+### Fase sólida
+1. Recolectar 40 kg hojarasca en descomposición de bosque nativo cercano (mismo piso térmico de la finca).
+2. Mezclar con 40 kg semolina o salvado de arroz (fuente carbohidratos).
+3. Diluir 1 galón (3.8 L) melaza en agua sin cloro hasta humedecer mezcla a 30–40% (prueba del puño: aglutina sin escurrir).
+4. Compactar vigorosamente por capas en caneca 200L hermética (expulsar aire).
+5. Sellar con bolsa interior + tapa hermética.
+6. Reposo 30 días T° ambiente.
+
+### Fase líquida (activación)
+1. Extraer 5 kg MM sólido fermentado.
+2. Bolsa permeable (tipo bolsa de té grande).
+3. Sumergir en 100 L agua sin cloro + 4 L melaza diluida.
+4. **Trampa de gases obligatoria** (botella con agua, manguera) — sin esta, la presión rompe el recipiente.
+5. Reposo 4–8 días, T° 18–25°C.
+6. Listo cuando aroma agridulce + pH 3.0–4.0 + turbidez característica.
+
+### Pruebas de calidad
+- Olor: agridulce láctico, NO putrefacto.
+- pH: 3.0–4.0.
+- Color: amarillento-marrón claro.
+- Si: olor pútrido, color negro, pH >5 → **descartar, contaminado**.
+
+## 7. Suggestion engine integration
+- `Inventario = melaza + bosque cercano + recipiente hermético` + `piso térmico de finca` → activar protocolo MM completo (Caso 1 de ADR-022).
+- `Inventario = MM líquido activado + cultivo en establecimiento` → sugerir aplicación foliar 1:100 al atardecer cada 15 días.
+- **Caso bloqueante**: si el operador NO menciona trampa de gases en ejecución → ALERTA seguridad (presión puede fisurar recipiente).
+
+## 8. Reconocimiento visual
+Sustrato sólido fermentado: olor láctico característico (similar yogurt). Color marrón claro a amarillo. Filamentos blancos (micelio actinomicetos) visibles. NO debe oler a putrefacción ni tener moho negro.
+
+Líquido: amarillento-marrón claro, ligeramente turbio, aroma agridulce pronunciado, ligera espuma natural.
+
+## 9. Proveedores
+**No se compran — se hacen.** Pero los componentes:
+- Melaza: agroquímicos rurales, ingenios azucareros (a granel barato).
+- Semolina/salvado: molinos de arroz locales.
+- Inóculo Trichoderma para potenciar (opcional): Agrosavia Tricotec® WG (ICA 12164).
+- Bosque nativo: requerimiento operacional, no comercial.
+
+## 10. Compliance
+**Producción finca para uso propio**: legítimo culturalmente, sin restricciones ICA.
+**Comercialización**: requiere registro ICA bioinsumo (estandarización compleja por variabilidad consorcio). En la práctica, redes campesinas intercambian sin formalización.
+**Etiqueta de seguridad**: necesario indicar fecha producción + lote + advertencia "no apto consumo humano".
+
+## 11. Limitaciones
+- **Variabilidad inherente**: cada lote ligeramente distinto — no es un producto industrial estandarizado. Esa es su FORTALEZA (adaptación local) y su DEBILIDAD (no escalable comercialmente como tal).
+- **Caracterización microbiológica formal**: pocos lotes han sido secuenciados (16S rRNA). Investigación pendiente Colombia.
+- **Sin estándares ICA específicos**: zona gris regulatoria — uso personal-finca legal, comercial requiere transformar producto a "biofertilizante registrado".
+- **Riesgo contaminación**: si la captura es de bosque degradado o usa agua clorada, el consorcio es deficiente o tóxico. Validación experta en cada lote es ideal pero impráctica.
+- **Toxicidad humana**: bajo riesgo en uso normal, pero bacterias en alta densidad pueden causar problemas si se ingieren — uso estrictamente agrícola.
+
+## 12. Régimen del dominio
+**Gaussiano** — bioinsumo robusto, downside acotado al costo de los insumos (~$100k COP por lote 200L). Pero **cola pesada en oportunidad**: una finca con MM activos incorporados durante años acumula resiliencia que es difícil de replicar rápidamente. **Estrategia**: rutinizar producción + diversificar bosques de captura (sucesión + páramo + bosque secundario) + intercambiar lotes con vecinos para aumentar diversidad.
+
+## Referencias canónicas
+- Restrepo Rivera J. (2007). *Manual ABC agricultura orgánica*. SIMAS, Nicaragua.
+- Higa T. (1991). *EM technology*. INFRC, Atami.
+- Manual ICA-JICA (varios). Microorganismos eficientes en agricultura tropical.
+- Agrosavia (ficha técnica adyacente, no específica MM).

--- a/docs/species/README.md
+++ b/docs/species/README.md
@@ -1,0 +1,34 @@
+# Fichas de especies — corpus base Chagra
+
+Cada `.md` aquí sigue `../species-ficha-template.md`. Estado actual:
+
+- 🟡 **Borrador** — datos correctos verificables institucionalmente (Agrosavia, ICA, GBIF, FAO) pero **pendientes de validación por agroecólogo certificado** antes de marcarse `publicable_libro: true`.
+- 🟢 **Validado** — agroecólogo certificado revisó y firmó (`revisor` en frontmatter).
+- 🔴 **Stale** — re-revisión requerida (`ultima_revision` >12 meses).
+
+**Workflow para promover a `validado`**:
+
+1. Operador o curador completa secciones 1–12 con citas verificables.
+2. Sección 11 (Limitaciones) DEBE estar llena. Sin ella → no avanza.
+3. PR con cambio en `nivel_confianza_global: alto` + `publicable_libro: true`.
+4. Revisor agroecólogo aprueba (puede ser asíncrono via comentarios PR).
+5. Merge → ficha disponible para libro y producto Pro.
+
+Frontmatter consume el catálogo de Chagra (IndexedDB / SQLite) — el campo `ulid` se genera al crear la ficha y se mantiene estable para joins.
+
+## Las 10 fichas iniciales (Fase 0 ADR-022)
+
+| Categoría | Especie | Piso | Estado |
+|-----------|---------|------|--------|
+| Frutal | Aguacate Hass — *Persea americana* | Templado | 🟡 borrador |
+| Frutal | Café arábigo — *Coffea arabica* | Templado | 🟡 borrador |
+| Frutal | Mora de Castilla — *Rubus glaucus* | Frío | 🟡 borrador |
+| Leguminosa cobertura | Canavalia — *Canavalia ensiformis* | Cálido | 🟡 borrador |
+| Leguminosa frijol | Frijol Mortiño — *Phaseolus coccineus* | Frío | 🟡 borrador |
+| Leguminosa grano andino | Tarwi (Lupino) — *Lupinus mutabilis* | Frío | 🟡 borrador |
+| Forestal | Aliso — *Alnus acuminata* | Frío | 🟡 borrador |
+| Forestal sombrío | Guamo / Cachimbo — *Inga edulis* | Templado | 🟡 borrador |
+| Microorganismo | Trichoderma harzianum | Universal | 🟡 borrador |
+| Microorganismo | Microorganismos de Montaña (MM) | Universal | 🟡 borrador |
+
+Próximos lotes (fase 1 ADR-022): hortalizas templado/frío + raíces andinas + aromáticas.

--- a/docs/suppliers/colombia-2026.md
+++ b/docs/suppliers/colombia-2026.md
@@ -1,0 +1,137 @@
+---
+name: Lista seed de proveedores agroecológicos Colombia 2026 — fuentes verificables
+status: seed (pre-DR)
+decided_at: 2026-04-26
+audit_priority: HIGH
+register: power-laws — un proveedor mal-listado destruye credibilidad
+---
+
+# Suppliers Colombia — seed list (a expandir vía DR #2)
+
+> **Estatus**: este documento es un **seed pre-DR** con fuentes institucionales que el DR #2 (Knowledge & Capabilities, Área 2) usará como punto de partida para construir la lista verificada definitiva.
+> **Regla inviolable**: NINGÚN proveedor entra a la lista oficial sin **fuente pública verificable** (URL institucional, registro ICA público, certificación pública, contacto institucional confirmable).
+
+---
+
+## Fuentes institucionales para verificar proveedores
+
+### 1. ICA — Instituto Colombiano Agropecuario
+
+- URL: https://www.ica.gov.co/
+- **Registro de viveros**: viveros con licencia ICA están en bases de datos públicas regionales. Verificar antes de listar cualquier proveedor de plántulas frutales y forestales.
+- **Registro de productores de semillas**: certificación obligatoria para semillas comerciales.
+- **Certificaciones BPA** (Buenas Prácticas Agrícolas): productores certificados son listados.
+
+### 2. Agrosavia — Corporación Colombiana de Investigación Agropecuaria
+
+- URL: https://www.agrosavia.co/
+- **Banco de germoplasma**: variedades nativas y mejoradas con trazabilidad genética.
+- **Centros de investigación regional** (Tibaitatá, La Suiza, Palmira, etc.): productores y multiplicadores asociados.
+- **Cartillas técnicas**: identifican proveedores recomendados por Agrosavia para cada cultivo.
+
+### 3. Corporaciones Autónomas Regionales (CAR)
+
+- Cada región tiene su CAR (CAR Cundinamarca, CVS Córdoba, CVC Valle, etc.).
+- **Viveros municipales y comunitarios**: programas de reforestación con especies nativas.
+- Verificar lista activa en página oficial de cada CAR.
+
+### 4. Redes campesinas y de mujeres con presencia pública
+
+> **Nota**: incluir solo si la red tiene página oficial, RUT verificable, o aparece en publicaciones de Agrosavia / MinAgricultura / FAO.
+
+- **Red Colombiana de Reservas Naturales de la Sociedad Civil (RESNATUR)**: https://www.resnatur.org.co/
+- **Red Agroecológica Nacional (RECAB / RENAF)**: revisar páginas activas 2026.
+- **Red de Mujeres Rurales Colombianas**: programas con apoyo MinAgricultura.
+- **Bancos de semillas locales reconocidos** (ej. Custodios de Semillas, Corporación Custodios, Casas Campesinas).
+
+### 5. Distribuidores comerciales con trazabilidad
+
+> Solo listar tras verificar registro mercantil + presencia pública sostenida (≥3 años).
+
+- **Coljap**, **Ecofuturo**, **Soluciones Ambientales SAS**, **Bioterral**, etc. — verificar uno a uno.
+- Distribuidores de microorganismos comerciales (Trichoderma harzianum, Bacillus subtilis, micorrizas comerciales).
+
+### 6. Bancos de germoplasma internacionales con presencia o accesibilidad en Colombia
+
+- **CIAT / Alliance Bioversity-CIAT** (Palmira): germoplasma de fríjol, yuca, forrajes tropicales.
+- **CIP** (Centro Internacional de la Papa, presencia regional): variedades de papa y andinos.
+- **GBIF Colombia**: nodo nacional con datos de biodiversidad.
+
+---
+
+## Plantilla de entrada por proveedor
+
+Cuando el DR #2 valide un proveedor, agregarlo a `suppliers-colombia-2026.md` (lista oficial, archivo aparte que se crea al cerrar DR) con esta plantilla:
+
+```yaml
+---
+ulid: <ULID>
+nombre_legal: <razón social registrada>
+nombre_comercial: <si difiere>
+tipo:
+  - plantulas | semillas | abonos_organicos | microorganismos_comerciales | microorganismos_nativos | herramientas | germoplasma_nativo
+ubicacion:
+  departamento: <Cundinamarca | Antioquia | …>
+  municipio: <…>
+  coordenadas_aprox: { lat: , lng: }  # solo si público
+cobertura_despacho:
+  - departamentos: [..]
+  - regiones: [andina | caribe | pacifica | orinoquia | amazonia]
+  - alcance: [local | regional | nacional]
+certificaciones:
+  - tipo: registro_ICA | BPA | organico_BCS | agrosavia_alianza | RESNATUR | otra
+    numero: <si público>
+    expira: YYYY-MM-DD
+    url_verificacion: <URL pública>
+    estado: vigente | expirada | en_renovacion | desconocido
+contacto_publico:
+  url: <URL oficial>
+  telefono: <si público>
+  email: <si público>
+rangos_precios_2026:
+  - producto: <plántula aguacate Hass>
+    precio_cop: { min: , max: }
+    fecha_referencia: YYYY-MM-DD
+fuentes_de_verificacion:
+  - tipo: ica_registro | agrosavia_publicacion | resnatur_directorio | publicacion_oficial
+    cita: <APA o URL>
+    fecha_consulta: YYYY-MM-DD
+nivel_confianza: alto | medio | bajo
+estado_listado: vigente | suspendido | retirado
+ultima_verificacion: YYYY-MM-DD
+proxima_verificacion: YYYY-MM-DD  # +90 días por defecto (cadencia trimestral)
+notas_operador: <observaciones de uso real, opcional>
+incidentes_documentados: <si hubo problemas, opcional>
+---
+```
+
+---
+
+## Workflow de verificación trimestral (ver `ops/calendar-tasks.md`)
+
+1. Leer cada entrada vigente.
+2. Para cada una: ir a `url_verificacion` o consultar institución oficial.
+3. Si certificación sigue vigente → actualizar `ultima_verificacion`, recalcular `proxima_verificacion`.
+4. Si expiró sin renovar → cambiar `estado_listado: suspendido`, alertar al operador.
+5. Si proveedor cambió de razón social, ubicación o cobertura → actualizar.
+6. Si hay incidente documentado (queja, contaminación, mala calidad) → documentar en `incidentes_documentados`, considerar `retirado`.
+7. Commit del cambio con mensaje `chore(suppliers): refresh trimestral YYYY-MM`.
+
+---
+
+## Anti-checklist
+
+- ❌ NO listar proveedor sin URL pública oficial.
+- ❌ NO listar proveedor con certificación expirada como vigente.
+- ❌ NO incluir contactos privados sin consentimiento (ADR-020 capa 3).
+- ❌ NO recomendar proveedor sin que aparezca en la lista oficial verificada.
+- ❌ NO publicar lista al libro/producto OSS sin pasar por revisión ICA / Agrosavia / agroecólogo asociado.
+
+---
+
+## Referencias
+
+- DR #2: `deepresearch/architecture/dr-prompt-knowledge-and-capabilities-2026.md` Área 2.
+- Plantilla ficha especie (consume esta lista): `deepresearch/knowledge/species-ficha-template.md`.
+- ADR-020 anti-leak: `deepresearch/architecture/ADR-020-anti-leak-content-boundary.md`.
+- Calendario operativo: `ops/calendar-tasks.md` — entrada `refresh proveedores trimestral`.

--- a/scripts/md-fichas-to-catalog-json.mjs
+++ b/scripts/md-fichas-to-catalog-json.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * md-fichas-to-catalog-json.mjs
+ * ================================================================
+ * Reconcilia el catálogo según ADR-025: markdown narrativo con
+ * frontmatter YAML (source of truth) → JSON estructurado committed
+ * para fast-load PWA + CI validation.
+ *
+ * Uso:
+ *   node scripts/md-fichas-to-catalog-json.mjs
+ *   node scripts/md-fichas-to-catalog-json.mjs --check  (no escribe)
+ *
+ * Lee:  docs/species/[0-9]*-*.md  (ignora README.md y -template.md)
+ * Lee:  catalog/sources-seed.json     (preserva sin tocar)
+ * Lee:  catalog/biopreparados-seed.json  (preserva sin tocar)
+ * Escribe: catalog/chagra-catalog-seed-v3.1.json
+ *
+ * Comportamiento:
+ *   - Si una ficha NO tiene frontmatter completo, la SALTA con warning
+ *     (no rompe build — coexistencia con fichas legacy hasta migración)
+ *   - Las fichas saltadas NO entran al JSON; el JSON conserva las especies
+ *     del seed actual que NO tengan ficha markdown asociada
+ *   - Fichas con frontmatter sobrescriben la entrada con id correspondiente
+ *     en el JSON
+ *
+ * Exit codes:
+ *   0 — OK (incluso con warnings)
+ *   1 — Error fatal de IO o JSON inválido
+ *   2 — Modo --check + cambios detectados (CI fail)
+ *
+ * Dependencia: ninguna fuera de stdlib Node. Frontmatter parser
+ * minimal inline para evitar requerir npm install.
+ *
+ * Estado (2026-04-28): script funcional pero las fichas en docs/species/
+ * todavía son legacy markdown SIN frontmatter ADR-025 completo. Hasta
+ * migrarlas, el seed JSON manual sigue siendo source of truth efectivo.
+ * Cuando una ficha se migra a frontmatter completo, el script empieza
+ * a emitirla al JSON (sobrescribiendo la versión manual del seed).
+ * ================================================================
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, dirname, join, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const SPECIES_DIR = join(ROOT, 'docs/species');
+const SEED_PATH = join(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+
+const args = process.argv.slice(2);
+const CHECK_MODE = args.includes('--check');
+
+function info(msg) { console.log(`[ok] ${msg}`); }
+function warn(msg) { console.warn(`\x1b[33m[warn]\x1b[0m ${msg}`); }
+function fail(code, msg) { console.error(`\x1b[31m[fail]\x1b[0m ${msg}`); process.exit(code); }
+
+// ----------------------------------------------------------------
+// Frontmatter YAML parser minimal (subset suficiente para fichas).
+// Soporta: scalars (string/number/bool), arrays inline + multi-line,
+// objects multi-line con indent 2-space, comentarios #.
+// NO soporta: anchors, multi-doc, tipos custom, flow style complex.
+// Para frontmatter más complejo, instalar `gray-matter` via npm.
+// ----------------------------------------------------------------
+
+function parseFrontmatter(content) {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return { frontmatter: null, body: content };
+  const yaml = match[1];
+  const body = content.slice(match[0].length);
+  return { frontmatter: parseYAML(yaml), body };
+}
+
+function parseYAML(yaml) {
+  // Implementación minimal — para producción usar js-yaml o gray-matter
+  // Suficiente para frontmatter de schema v3.1 con campos planos + objetos
+  // simples + arrays. Si falla, return null y el script salta la ficha
+  // con warning (defense-in-depth).
+  try {
+    const lines = yaml.split('\n').filter(l => !l.trim().startsWith('#'));
+    const obj = {};
+    parseLines(lines, 0, 0, obj);
+    return obj;
+  } catch (e) {
+    return null;
+  }
+}
+
+function parseLines(lines, i, baseIndent, target) {
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim()) { i++; continue; }
+    const indent = line.match(/^( *)/)[0].length;
+    if (indent < baseIndent) return i;
+    const trimmed = line.trim();
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) { i++; continue; }
+    const key = trimmed.slice(0, colonIdx).trim();
+    const valRaw = trimmed.slice(colonIdx + 1).trim();
+    if (valRaw === '' || valRaw === null) {
+      // Multi-line value: object or array
+      const next = lines[i + 1] || '';
+      const nextIndent = next.match(/^( *)/)[0].length;
+      if (next.trim().startsWith('-')) {
+        // Array
+        const arr = [];
+        let j = i + 1;
+        while (j < lines.length && lines[j].match(/^( *)/)[0].length === nextIndent && lines[j].trim().startsWith('-')) {
+          arr.push(parseScalar(lines[j].trim().slice(1).trim()));
+          j++;
+        }
+        target[key] = arr;
+        i = j;
+      } else if (nextIndent > indent) {
+        const subObj = {};
+        i = parseLines(lines, i + 1, nextIndent, subObj);
+        target[key] = subObj;
+      } else {
+        target[key] = null;
+        i++;
+      }
+    } else if (valRaw.startsWith('[') && valRaw.endsWith(']')) {
+      // Inline array
+      const inner = valRaw.slice(1, -1).trim();
+      target[key] = inner ? inner.split(',').map(s => parseScalar(s.trim())) : [];
+      i++;
+    } else {
+      target[key] = parseScalar(valRaw);
+      i++;
+    }
+  }
+  return i;
+}
+
+function parseScalar(s) {
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (s === 'null' || s === '~') return null;
+  if (/^-?\d+$/.test(s)) return parseInt(s, 10);
+  if (/^-?\d+\.\d+$/.test(s)) return parseFloat(s);
+  // Strip quotes
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// ----------------------------------------------------------------
+// Main pipeline
+// ----------------------------------------------------------------
+
+function main() {
+  if (!existsSync(SPECIES_DIR)) {
+    warn(`docs/species/ no existe — nada que procesar. Creando estructura base.`);
+    // Salir limpio, no es error
+    process.exit(0);
+  }
+
+  const seed = JSON.parse(readFileSync(SEED_PATH, 'utf8'));
+  const seedSpeciesById = new Map((seed.species || []).map(s => [s.id, s]));
+
+  const fichas = readdirSync(SPECIES_DIR)
+    .filter(f => /^\d+-.+\.md$/.test(f) && f !== 'README.md');
+
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const ficha of fichas) {
+    const fullPath = join(SPECIES_DIR, ficha);
+    const content = readFileSync(fullPath, 'utf8');
+    const { frontmatter } = parseFrontmatter(content);
+
+    if (!frontmatter || !frontmatter.id) {
+      warn(`${ficha}: sin frontmatter o sin campo 'id' — saltada (legacy ficha narrativa)`);
+      skipped++;
+      continue;
+    }
+
+    // Fichas con frontmatter sobrescriben entrada del seed
+    seedSpeciesById.set(frontmatter.id, frontmatter);
+    migrated++;
+    info(`${ficha} → species[${frontmatter.id}]`);
+  }
+
+  // Reconstruir species[] ordenado alfabéticamente por id (output determinístico)
+  const species = Array.from(seedSpeciesById.values()).sort((a, b) =>
+    (a.id || '').localeCompare(b.id || ''));
+
+  const newSeed = { ...seed, species };
+
+  // Update generated_at metadata si existe
+  if (newSeed.generated_at !== undefined) {
+    newSeed.generated_at = new Date().toISOString().slice(0, 10);
+    newSeed.generated_by = 'md-fichas-to-catalog-json.mjs';
+  }
+
+  const newJSON = JSON.stringify(newSeed, null, 2) + '\n';
+  const oldJSON = readFileSync(SEED_PATH, 'utf8');
+
+  if (CHECK_MODE) {
+    if (newJSON === oldJSON) {
+      info(`Catalog sync ✓ (${migrated} migradas, ${skipped} saltadas, ${seedSpeciesById.size} total species)`);
+      process.exit(0);
+    } else {
+      fail(2, `Catalog drift detectado — corre sin --check para regenerar`);
+    }
+  }
+
+  if (newJSON === oldJSON) {
+    info(`Catalog sin cambios (${migrated} migradas, ${skipped} saltadas, ${seedSpeciesById.size} total)`);
+  } else {
+    writeFileSync(SEED_PATH, newJSON);
+    info(`Catalog regenerado: ${SEED_PATH}`);
+    info(`  ${migrated} fichas migradas, ${skipped} saltadas, ${seedSpeciesById.size} species totales`);
+  }
+}
+
+try {
+  main();
+} catch (e) {
+  fail(1, e.message);
+}

--- a/scripts/migrate-v30-to-v31.mjs
+++ b/scripts/migrate-v30-to-v31.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * migrate-v30-to-v31.mjs
+ * ================================================================
+ * Migra el catálogo v3.0 (chagra-catalog-seed-v3.0.json) al shape
+ * v3.1 resolviendo las 16 ambigüedades:
+ *
+ *   AMB-01: elimina `gremio`, conserva `roles_in_guild[]`
+ *   AMB-03: ya estaba en español, pass-through
+ *   AMB-07: `production` (string) → `harvest_type` (enum)
+ *   AMB-06, 08: heladas_tolerancia y NPK ya eran objetos en v3.0
+ *   AMB-11, 16: sources ya eran source_ids en v3.0
+ *   AMB-14: aplica regla de consistencia si hay mismatch
+ *
+ * Output: chagra-catalog-seed-v3.1.json con:
+ *   { schema_version: "3.1", species, biopreparados, sources }
+ *
+ * Los arrays biopreparados[] y sources[] se cargan desde sus seeds
+ * separados. Esto hace el catálogo v3.1 self-contained y validable.
+ *
+ * Uso:
+ *   node scripts/migrate-v30-to-v31.mjs
+ * ================================================================
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const V30_PATH = join(ROOT, 'catalog/chagra-catalog-seed-v3.0.json');
+const BIOPREPARADOS_SEED = join(ROOT, 'catalog/biopreparados-seed.json');
+const SOURCES_SEED = join(ROOT, 'catalog/sources-seed.json');
+const OUT_PATH = join(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+
+const v30 = JSON.parse(readFileSync(V30_PATH, 'utf8'));
+const biopreparadosSeed = JSON.parse(readFileSync(BIOPREPARADOS_SEED, 'utf8'));
+const sourcesSeed = JSON.parse(readFileSync(SOURCES_SEED, 'utf8'));
+
+const speciesV30 = v30.task_a_extended_existing || {};
+
+// --- Mapeo de valores de production (v3.0) a harvest_type (v3.1) ---
+const HARVEST_TYPE_MAP = {
+  fruto: 'fruto',
+  frutos: 'fruto',
+  grano: 'grano',
+  granos: 'grano',
+  tuberculo: 'tuberculo',
+  tuberculos: 'tuberculo',
+  hoja: 'hoja',
+  hojas: 'hoja',
+  flor: 'flor',
+  flores: 'flor',
+  raiz: 'raiz',
+  raices: 'raiz',
+  tallo: 'tallo',
+  biomasa: 'biomasa',
+  semilla: 'semilla',
+  semillas: 'semilla',
+  latex: 'latex',
+  corteza: 'corteza',
+  bulbo: 'bulbo',
+  hongo: 'hongo',
+};
+
+function mapHarvestType(production) {
+  if (!production) return undefined;
+  const key = String(production).toLowerCase().trim();
+  return HARVEST_TYPE_MAP[key] || undefined;
+}
+
+function migrateSpecies(sp) {
+  const out = { ...sp };
+
+  // AMB-01: drop gremio
+  delete out.gremio;
+
+  // AMB-07: production → harvest_type
+  if (out.production !== undefined) {
+    const ht = mapHarvestType(out.production);
+    if (ht) out.harvest_type = ht;
+    delete out.production;
+  }
+
+  // Normalizar valores legacy de drenaje_requerido con espacios
+  if (typeof out.drenaje_requerido === 'string') {
+    out.drenaje_requerido = out.drenaje_requerido.trim().toLowerCase().replace(/\s+/g, '_');
+  }
+
+  // AMB-14: regla de consistencia invasor
+  if (out.conservation_status === 'invasor') {
+    if (out.category !== 'especies_invasoras') {
+      console.warn(`[${out.id}] ajustando category a especies_invasoras (AMB-14)`);
+      out.category = 'especies_invasoras';
+    }
+    if (out.cultivable !== false) {
+      console.warn(`[${out.id}] ajustando cultivable=false (AMB-14)`);
+      out.cultivable = false;
+    }
+  }
+
+  // Asegurar roles_in_guild[] presente (AMB-01 defensivo: si venía de
+  // v3.0 sin roles_in_guild pero con gremio, mapear).
+  if (!out.roles_in_guild || out.roles_in_guild.length === 0) {
+    out.roles_in_guild = ['crop']; // default defensivo
+    console.warn(`[${out.id}] roles_in_guild estaba vacío, default a ['crop']`);
+  }
+
+  // ADR-016: nivel de validación. Las 7 especies del v3.0 que migramos
+  // ya tenían _curation_status "VALIDADO ..." escrito a mano por el
+  // operador; las consideramos operator_reviewed hasta que un agrónomo
+  // con identidad registrada las valide formalmente.
+  if (!out.validation_level) {
+    out.validation_level = 'operator_reviewed';
+  }
+
+  return out;
+}
+
+const migratedSpecies = [];
+for (const [id, sp] of Object.entries(speciesV30)) {
+  if (!sp || typeof sp !== 'object') continue;
+  migratedSpecies.push(migrateSpecies({ id, ...sp }));
+}
+
+// También recoger las invasoras que en v3.0 podrían estar en otra sección
+if (Array.isArray(v30.task_d_invasoras)) {
+  for (const inv of v30.task_d_invasoras) {
+    migratedSpecies.push(migrateSpecies(inv));
+  }
+} else if (v30.task_d_invasoras && typeof v30.task_d_invasoras === 'object') {
+  for (const [id, inv] of Object.entries(v30.task_d_invasoras)) {
+    if (!inv || typeof inv !== 'object') continue;
+    migratedSpecies.push(migrateSpecies({ id, ...inv }));
+  }
+}
+
+const output = {
+  schema_version: '3.1',
+  seed_version: '0.2.0',
+  generated_at: new Date().toISOString().slice(0, 10),
+  generated_by: 'scripts/migrate-v30-to-v31.mjs — transform automático v3.0 → v3.1. Curaduría humana requerida antes de uso ministerial.',
+  _meta: {
+    fuente_migracion: 'chagra-catalog-seed-v3.0.json',
+    ambiguedades_resueltas: [
+      'AMB-01: gremio eliminado, roles_in_guild único campo',
+      'AMB-02: thermal_zones plural array (ya era en v3.0)',
+      'AMB-03: español en todos los campos (ya era en v3.0)',
+      'AMB-05: altitud_msnm chain validada por validate-catalog.mjs',
+      'AMB-06: heladas_tolerancia como objeto (ya era en v3.0)',
+      'AMB-07: production (string) → harvest_type (enum)',
+      'AMB-08: NPK como objeto {min,max,unidad} (ya era en v3.0)',
+      'AMB-09: biopreparados_seed.json catálogo auxiliar con 15 ids',
+      'AMB-10: simetría companions/antagonists validada por CI',
+      'AMB-11/16: sources_seed.json catálogo auxiliar con ~30 fuentes',
+      'AMB-12: prompts_ia_externa objeto con 5 slots estándar',
+      'AMB-13: cross-refs validadas por CI (seed-mode downgrade a warning)',
+      'AMB-14: consistencia invasor aplicada en migración',
+      'AMB-15: scale_viability + manejo_por_escala con CI de coherencia',
+    ],
+    alcance_seed: `${migratedSpecies.length} especies migradas desde v3.0. Las DRs por piso térmico poblarán hasta ~400 especies totales (100 × 4 pisos).`,
+    advertencia: 'Validar con: node scripts/validate-catalog.mjs --seed-mode. Refs a species aún no migradas aparecen como warnings.',
+  },
+  species: migratedSpecies,
+  biopreparados: biopreparadosSeed.biopreparados,
+  sources: sourcesSeed.sources,
+};
+
+writeFileSync(OUT_PATH, JSON.stringify(output, null, 2) + '\n');
+console.log(`✓ Migrado ${migratedSpecies.length} especies → ${OUT_PATH}`);
+console.log(`  biopreparados: ${output.biopreparados.length}`);
+console.log(`  sources: ${output.sources.length}`);

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * validate-catalog.mjs
+ * ================================================================
+ * Validador del catálogo Chagra contra schema v3.1 + 5 validadores
+ * de consistencia de las ambigüedades resueltas (AMB-05, 10, 13,
+ * 14, 15) del v3.0.
+ *
+ * Uso:
+ *   node scripts/validate-catalog.mjs <catalog.json> [schema.json]
+ *
+ * Defaults:
+ *   catalog = catalog/chagra-catalog-seed-v3.1.json
+ *   schema  = catalog/schema-v3.1.json
+ *
+ * Exit codes:
+ *   0 — OK
+ *   1 — fallo de JSON Schema (AJV)
+ *   2 — fallo de validador semántico (AMB-05/10/13/14/15)
+ *   3 — archivo no encontrado o JSON inválido
+ *
+ * Dependencias: ninguna fuera de stdlib Node. Implementa un subset
+ * mínimo de JSON Schema (enough para v3.1) para evitar requerir npm
+ * install en Chagra-strategy (que no tiene package.json). Si el
+ * schema crece en complejidad, migrar a AJV:
+ *   npm i -D ajv
+ * y reemplazar validateAgainstSchema() por ajv.compile(schema).
+ * ================================================================
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const SEED_MODE = args.includes('--seed-mode');
+const positional = args.filter((a) => !a.startsWith('--'));
+const [catalogArg, schemaArg] = positional;
+const CATALOG_PATH = catalogArg
+  ? resolve(catalogArg)
+  : join(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+const SCHEMA_PATH = schemaArg
+  ? resolve(schemaArg)
+  : join(ROOT, 'catalog/schema-v3.1.json');
+
+function die(code, msg) {
+  console.error(`\x1b[31m✗ ${msg}\x1b[0m`);
+  process.exit(code);
+}
+
+function ok(msg) { console.log(`\x1b[32m✓\x1b[0m ${msg}`); }
+function warn(msg) { console.warn(`\x1b[33m⚠ ${msg}\x1b[0m`); }
+
+function loadJSON(path) {
+  if (!existsSync(path)) die(3, `Archivo no encontrado: ${path}`);
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    die(3, `JSON inválido en ${path}: ${e.message}`);
+  }
+}
+
+// ----------------------------------------------------------------
+// Validador de JSON Schema mínimo (draft-07 subset para v3.1).
+// Solo lo necesario: type, enum, const, required, properties,
+// items, additionalProperties, pattern, minItems, uniqueItems,
+// minimum/maximum, $ref (a #/definitions/*), allOf, if/then.
+// ----------------------------------------------------------------
+
+function resolveRef(schema, ref) {
+  if (!ref.startsWith('#/')) throw new Error(`$ref externo no soportado: ${ref}`);
+  const parts = ref.slice(2).split('/');
+  let node = schema;
+  for (const p of parts) {
+    node = node?.[p];
+    if (node === undefined) throw new Error(`$ref no resoluble: ${ref}`);
+  }
+  return node;
+}
+
+function validate(value, schemaNode, rootSchema, path, errors) {
+  if (schemaNode.$ref) {
+    const deref = resolveRef(rootSchema, schemaNode.$ref);
+    validate(value, deref, rootSchema, path, errors);
+    return;
+  }
+
+  if (schemaNode.const !== undefined && value !== schemaNode.const) {
+    errors.push(`${path}: esperado const ${JSON.stringify(schemaNode.const)}, got ${JSON.stringify(value)}`);
+  }
+
+  if (schemaNode.enum && !schemaNode.enum.includes(value)) {
+    errors.push(`${path}: valor "${value}" no está en enum [${schemaNode.enum.join(', ')}]`);
+  }
+
+  if (schemaNode.type) {
+    const types = Array.isArray(schemaNode.type) ? schemaNode.type : [schemaNode.type];
+    const actual = value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;
+    const matches = types.some((t) => {
+      if (t === 'number' || t === 'integer') return actual === 'number';
+      return actual === t;
+    });
+    if (!matches) errors.push(`${path}: tipo esperado ${types.join('|')}, got ${actual}`);
+  }
+
+  if (schemaNode.pattern && typeof value === 'string') {
+    const re = new RegExp(schemaNode.pattern);
+    if (!re.test(value)) errors.push(`${path}: "${value}" no matches pattern ${schemaNode.pattern}`);
+  }
+
+  if (typeof value === 'number') {
+    if (schemaNode.minimum !== undefined && value < schemaNode.minimum) {
+      errors.push(`${path}: ${value} < minimum ${schemaNode.minimum}`);
+    }
+    if (schemaNode.maximum !== undefined && value > schemaNode.maximum) {
+      errors.push(`${path}: ${value} > maximum ${schemaNode.maximum}`);
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (schemaNode.minItems !== undefined && value.length < schemaNode.minItems) {
+      errors.push(`${path}: array tiene ${value.length} items, mínimo ${schemaNode.minItems}`);
+    }
+    if (schemaNode.uniqueItems) {
+      const seen = new Set();
+      for (const v of value) {
+        const k = JSON.stringify(v);
+        if (seen.has(k)) { errors.push(`${path}: items no únicos (duplicado: ${k})`); break; }
+        seen.add(k);
+      }
+    }
+    if (schemaNode.items) {
+      value.forEach((v, i) => validate(v, schemaNode.items, rootSchema, `${path}[${i}]`, errors));
+    }
+  }
+
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    if (schemaNode.required) {
+      for (const k of schemaNode.required) {
+        if (!(k in value)) errors.push(`${path}: missing required "${k}"`);
+      }
+    }
+    if (schemaNode.properties) {
+      for (const [k, subSchema] of Object.entries(schemaNode.properties)) {
+        if (k in value) validate(value[k], subSchema, rootSchema, `${path}.${k}`, errors);
+      }
+    }
+    if (schemaNode.additionalProperties === false && schemaNode.properties) {
+      const known = new Set(Object.keys(schemaNode.properties));
+      for (const k of Object.keys(value)) {
+        if (!known.has(k)) errors.push(`${path}: propiedad adicional no permitida "${k}"`);
+      }
+    }
+    if (schemaNode.additionalProperties && typeof schemaNode.additionalProperties === 'object') {
+      const known = new Set(Object.keys(schemaNode.properties || {}));
+      for (const [k, v] of Object.entries(value)) {
+        if (!known.has(k)) validate(v, schemaNode.additionalProperties, rootSchema, `${path}.${k}`, errors);
+      }
+    }
+  }
+
+  if (schemaNode.allOf) {
+    for (const clause of schemaNode.allOf) {
+      if (clause.if && clause.then) {
+        const ifErrors = [];
+        validate(value, clause.if, rootSchema, path, ifErrors);
+        if (ifErrors.length === 0) {
+          validate(value, clause.then, rootSchema, path, errors);
+        }
+      } else {
+        validate(value, clause, rootSchema, path, errors);
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------
+// Validadores semánticos (AMB-05, 10, 13, 14, 15)
+// ----------------------------------------------------------------
+
+function validateAmb05_altitudChain(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const a = sp.altitud_msnm;
+    if (!a) continue;
+    if (!(a.min_absoluto <= a.optimo_min && a.optimo_min <= a.optimo_max && a.optimo_max <= a.max_absoluto)) {
+      errors.push(`AMB-05 [${sp.id}]: altitud_msnm viola min_absoluto ≤ optimo_min ≤ optimo_max ≤ max_absoluto (${JSON.stringify(a)})`);
+    }
+  }
+  return errors;
+}
+
+function validateAmb10_companionsSymmetry(catalog) {
+  const errors = [];
+  const byId = new Map((catalog.species || []).map((s) => [s.id, s]));
+  for (const sp of catalog.species || []) {
+    for (const coId of sp.companions || []) {
+      const co = byId.get(coId);
+      if (!co) continue;
+      if (!(co.companions || []).includes(sp.id)) {
+        errors.push(`AMB-10 [${sp.id}]: tiene ${coId} en companions pero ${coId} no tiene ${sp.id} de vuelta`);
+      }
+    }
+    for (const anId of sp.antagonists || []) {
+      const an = byId.get(anId);
+      if (!an) continue;
+      if (!(an.antagonists || []).includes(sp.id)) {
+        errors.push(`AMB-10 [${sp.id}]: tiene ${anId} en antagonists pero ${anId} no tiene ${sp.id} de vuelta`);
+      }
+    }
+  }
+  return errors;
+}
+
+function validateAmb13_crossRefs(catalog, seedMode) {
+  const errors = [];
+  const warnings = [];
+  const speciesIds = new Set((catalog.species || []).map((s) => s.id));
+  const biopreparadoIds = new Set((catalog.biopreparados || []).map((b) => b.id));
+  const sourceIds = new Set((catalog.sources || []).map((s) => s.id));
+
+  // En seed mode (<=100 especies), las refs cruzadas a especies aún no
+  // migradas se degradan a warning. Refs a biopreparados/sources (catálogos
+  // pequeños controlados) siempre son errores duros.
+  const speciesRefTarget = seedMode ? warnings : errors;
+
+  for (const sp of catalog.species || []) {
+    const speciesRefFields = [
+      ['companions', sp.companions],
+      ['antagonists', sp.antagonists],
+      ['recommended_covers', sp.recommended_covers],
+      ['recommended_fences', sp.recommended_fences],
+      ['especies_nativas_sustitutas', sp.especies_nativas_sustitutas],
+    ];
+    for (const [field, refs] of speciesRefFields) {
+      for (const r of refs || []) {
+        if (!speciesIds.has(r)) speciesRefTarget.push(`AMB-13 [${sp.id}.${field}]: id "${r}" no existe en species[]`);
+      }
+    }
+
+    for (const sid of sp.source_ids || []) {
+      if (!sourceIds.has(sid)) errors.push(`AMB-11 [${sp.id}.source_ids]: source_id "${sid}" no existe en sources[]`);
+    }
+    for (const sid of sp.saber_origen?.validacion_cientifica_source_ids || []) {
+      if (!sourceIds.has(sid)) errors.push(`AMB-13 [${sp.id}.saber_origen.validacion_cientifica_source_ids]: source_id "${sid}" no existe en sources[]`);
+    }
+
+    const etapas = sp.plan_nutricion_base?.biopreparados_por_etapa || {};
+    for (const [etapa, items] of Object.entries(etapas)) {
+      for (const it of items || []) {
+        if (it.biopreparado_id && !biopreparadoIds.has(it.biopreparado_id)) {
+          errors.push(`AMB-13 [${sp.id}.plan_nutricion_base.biopreparados_por_etapa.${etapa}]: biopreparado_id "${it.biopreparado_id}" no existe en biopreparados[]`);
+        }
+      }
+    }
+
+    const enfermedades = sp.enfermedades_criticas || [];
+    for (const enf of enfermedades) {
+      for (const b of enf.biopreparados_curativos || []) {
+        if (b.biopreparado_id && !biopreparadoIds.has(b.biopreparado_id)) {
+          errors.push(`AMB-13 [${sp.id}.enfermedades_criticas]: biopreparado_id "${b.biopreparado_id}" no existe`);
+        }
+      }
+    }
+  }
+
+  for (const bp of catalog.biopreparados || []) {
+    for (const sid of bp.source_ids || []) {
+      if (!sourceIds.has(sid)) errors.push(`AMB-13 [biopreparados.${bp.id}.source_ids]: source_id "${sid}" no existe en sources[]`);
+    }
+  }
+
+  return { errors, warnings };
+}
+
+function validateAmb14_invasorConsistency(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    if (sp.conservation_status === 'invasor') {
+      if (sp.category !== 'especies_invasoras') {
+        errors.push(`AMB-14 [${sp.id}]: conservation_status=invasor pero category=${sp.category} (debe ser especies_invasoras)`);
+      }
+      if (sp.cultivable !== false) {
+        errors.push(`AMB-14 [${sp.id}]: conservation_status=invasor pero cultivable=${sp.cultivable} (debe ser false)`);
+      }
+    }
+    if (sp.category === 'especies_invasoras' && sp.conservation_status !== 'invasor') {
+      errors.push(`AMB-14 [${sp.id}]: category=especies_invasoras pero conservation_status=${sp.conservation_status} (debe ser invasor)`);
+    }
+  }
+  return errors;
+}
+
+function validateAmb15_scaleCoherence(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    if (!sp.scale_viability || !sp.manejo_por_escala) continue;
+    const viableArray = new Set(sp.scale_viability);
+    const manejoKeys = Object.entries(sp.manejo_por_escala);
+    const viableInManejo = new Set(manejoKeys.filter(([, v]) => v.viable === true).map(([k]) => k));
+
+    for (const scale of viableArray) {
+      if (!viableInManejo.has(scale)) {
+        errors.push(`AMB-15 [${sp.id}]: scale_viability incluye "${scale}" pero manejo_por_escala.${scale}.viable no es true`);
+      }
+    }
+    for (const scale of viableInManejo) {
+      if (!viableArray.has(scale)) {
+        errors.push(`AMB-15 [${sp.id}]: manejo_por_escala.${scale}.viable=true pero "${scale}" no está en scale_viability`);
+      }
+    }
+  }
+  return errors;
+}
+
+// ----------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------
+
+console.log('Chagra Catalog Validator v3.1');
+console.log(`  catalog: ${CATALOG_PATH}`);
+console.log(`  schema:  ${SCHEMA_PATH}`);
+console.log('');
+
+const schema = loadJSON(SCHEMA_PATH);
+const catalog = loadJSON(CATALOG_PATH);
+
+// 1. JSON Schema
+const schemaErrors = [];
+validate(catalog, schema, schema, '$', schemaErrors);
+if (schemaErrors.length) {
+  for (const e of schemaErrors) console.error(`  ✗ schema: ${e}`);
+  die(1, `${schemaErrors.length} errores de JSON Schema`);
+}
+ok('JSON Schema v3.1 — PASS');
+
+// 2. Validadores semánticos
+const semanticChecks = [
+  ['AMB-05 altitud chain', (c) => ({ errors: validateAmb05_altitudChain(c), warnings: [] })],
+  ['AMB-10 companions/antagonists symmetry', (c) => {
+    const arr = validateAmb10_companionsSymmetry(c);
+    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+  }],
+  ['AMB-13 cross-refs existencia', (c) => validateAmb13_crossRefs(c, SEED_MODE)],
+  ['AMB-14 invasor consistency', (c) => ({ errors: validateAmb14_invasorConsistency(c), warnings: [] })],
+  ['AMB-15 scale_viability ↔ manejo_por_escala', (c) => ({ errors: validateAmb15_scaleCoherence(c), warnings: [] })],
+];
+
+if (SEED_MODE) console.log('  mode:    SEED (refs a species ausentes = warnings)\n');
+
+const allSemanticErrors = [];
+for (const [label, fn] of semanticChecks) {
+  const { errors, warnings } = fn(catalog);
+  if (errors.length) {
+    console.error(`  ✗ ${label}: ${errors.length} error(es)`);
+    for (const e of errors) console.error(`    ${e}`);
+    allSemanticErrors.push(...errors);
+  } else if (warnings.length) {
+    warn(`${label}: ${warnings.length} warning(s) — refs a species aún no migradas`);
+    for (const w of warnings.slice(0, 5)) console.warn(`    ${w}`);
+    if (warnings.length > 5) console.warn(`    ... +${warnings.length - 5} más`);
+  } else {
+    ok(label);
+  }
+}
+
+if (allSemanticErrors.length) die(2, `${allSemanticErrors.length} errores semánticos`);
+
+console.log('');
+console.log('\x1b[32m✓ Catálogo válido\x1b[0m');
+console.log(`  ${(catalog.species || []).length} especies, ${(catalog.biopreparados || []).length} biopreparados, ${(catalog.sources || []).length} sources`);
+process.exit(0);


### PR DESCRIPTION
## Summary

Implementa los planes §implementación de **ADR-026** (catalog scope OSS/Pro) + **ADR-025** (format reconciliation markdown ↔ JSON). Migra el catalog de Chagra-strategy (privado) a este repo público con licencia CC-BY-SA 4.0.

Cierra el bloqueador #1 \"Catalog v3.1 unstaged\" + desbloquea poblamiento masivo de especies para tier Comunidad.

## Por qué

- **Coherencia:** ADR-008 ya prescribe catálogo público CC-BY-SA. Hasta ahora vivía en repo privado, contradiciendo licencia declarada.
- **Pitch v2 sostenible:** \"código libre que puedes auditar\" requiere que el catálogo sea efectivamente auditable.
- **Partnerships:** Agrosavia/ICA/MADR/viceministerio prefieren OSS público para integraciones.
- **Steve onboarding:** la PWA (\`chagra.guatoc.co\`) carga catalog desde \`/catalog/\`. Hasta hoy era versión vendoreada desactualizada — ahora es source canónico con fixes ADR-025 (typo source_ids + estrato rastrero).

## Cambios

### \`/catalog/\` actualizado a versión post-ADR-025

- \`schema-v3.1.json\` — typo \`sources_ids\` → \`source_ids\` corregido + \`rastrero\` agregado al enum estrato
- \`chagra-catalog-seed-v3.1.json\` — 7 especies con \`validation_level\` por especie, source_ids corregidos
- \`chagra-catalog-seed-v3.0.json\` — preservado para migration script
- \`biopreparados-seed.json\` + \`sources-seed.json\` — sin cambios estructurales
- \`AMBIGUITIES_RESOLUTION.md\` — referencia ADR-013
- \`README.md\` — reescrito con pipeline ADR-025/026 + convenciones IDs + validation_level

### \`/scripts/\` con herramientas de catalog

- \`validate-catalog.mjs\` — validador completo (JSON Schema + AMB-05/10/11/13/14/15)
- \`migrate-v30-to-v31.mjs\` — migración del seed antiguo
- **NUEVO** \`md-fichas-to-catalog-json.mjs\` — pipeline ADR-025: fichas markdown con frontmatter YAML completo → species[] del JSON seed. Defensivo: salta fichas legacy con warning, no rompe build.

### \`/docs/species/\` con 10 fichas iniciales (Fase 0 ADR-022)

Aguacate Hass, café arábigo, mora de Castilla, canavalia, frijol mortiño, tarwi/lupino, aliso, guamo, Trichoderma, Microorganismos de Montaña. Bajo CC-BY-SA 4.0.

**Estado:** legacy markdown sin frontmatter exhaustivo todavía. El script \`md-fichas-to-catalog-json.mjs\` las salta con warning hasta que se migren a frontmatter ADR-025 completo. Mientras tanto, el JSON seed manual sigue siendo source of truth efectivo (path defensivo, sin riesgo de romper build).

### \`/docs/suppliers/colombia-2026.md\`

Proveedores agrícolas verificados Colombia 2026 — referencia para campos \`source_ids\` y planning regional.

## Validación post-migración

\`\`\`
$ node scripts/validate-catalog.mjs
✓ JSON Schema v3.1 — PASS
✓ AMB-05 altitud chain
✗ AMB-10 + AMB-13 errores pre-existentes (refs a especies de Fase 2 ADR-022 aún no agregadas)

$ node scripts/md-fichas-to-catalog-json.mjs
[warn] 01-aguacate-hass.md: sin frontmatter → saltada (legacy ficha narrativa)
... [10 saltadas]
[ok] Catalog regenerado: 0 fichas migradas, 10 saltadas, 7 species totales
\`\`\`

Errores AMB-10/13 son **deuda conocida** (refs a especies de Fase 2 que se cierran al poblar) — NO introducidos por esta migración.

## Decisión OSS/Pro per ADR-026

| Capa | Ubicación | Licencia |
|------|-----------|----------|
| Schema + 100 fichas base + scripts | **este repo (Chagra)** | CC-BY-SA 4.0 |
| Gremios receta curados | \`chagra-pro/\` futuro | comercial |
| Planes nutrición optimizados | \`chagra-pro/\` futuro | comercial |
| Casos exitosos documentados | \`chagra-pro/\` futuro | comercial |
| Pre-sets certificación | \`chagra-pro/\` futuro | comercial |

## Test plan

- [ ] Review schema diff (typo + rastrero confirmados)
- [ ] Review fichas markdown migradas (10 fichas en \`docs/species/\`)
- [ ] Validar \`npm run build:catalog\` sigue funcionando con seed actualizado
- [ ] Mergear

## Próximos pasos derivados

1. **PR follow-up Chagra-strategy:** remover archivos migrados (catalog/, scripts/validate-catalog.mjs, scripts/migrate-v30-to-v31.mjs, deepresearch/knowledge/species/, deepresearch/knowledge/suppliers-colombia-2026-seed.md)
2. **Bootstrap prompt de poblamiento:** generar 20-30 frutales colombianos (aguacate Hass, café, mora, lulo, gulupa, granadilla, durazno, naranja, mandarina, limón, guayaba, papaya, plátano hartón) para soportar tier Comunidad inicial con Steve + 9 usuarios
3. **Steve onboarding (Opción C):** crear cuenta Steve en FarmOS de Guatoc + agregar sus fincas como assets adicionales + autorización Ley 1581
4. **Migrar las 10 fichas legacy a frontmatter ADR-025 exhaustivo:** cuando haya tiempo, NO bloqueante (script es defensivo)