### PR TITLE
feat(catalog): batches D1+D2+B1+B2+C — 36 sp restantes lista Guatoc 2026

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -26,6 +26,173 @@
   },
   "species": [
     {
+      "id": "allium_ampeloprasum",
+      "nombre_comun": "Cebolla puerro",
+      "nombre_cientifico": "Allium ampeloprasum var. porrum (L.) J. Gay",
+      "nombre_comunes_regionales": [
+        "Puerro",
+        "Ajopuerro"
+      ],
+      "familia_botanica": "Amaryllidaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 6,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "ph_suelo": {
+        "min": 6.0,
+        "optimo_min": 6.5,
+        "optimo_max": 7.5,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -4,
+        "horas_acumuladas_max": 12,
+        "notas": "Excelente resistencia a heladas una vez establecido."
+      },
+      "companions": [
+        "apium_graveolens",
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum"
+      ],
+      "antagonists": [
+        "beta_vulgaris_conditiva"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere trasplante profundo para favorecer el 'blanqueado' del tallo."
+      },
+      "valor_pedagogico": "Lección de aporque: enseña cómo el manejo del suelo (blanqueo) afecta las propiedades culinarias del tallo.",
+      "plagas_criticas": [
+        "Trips"
+      ],
+      "enfermedades_criticas": [
+        "Mildiu"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "allium_fistulosum",
+      "nombre_comun": "Cebollín / cebolla larga",
+      "nombre_cientifico": "Allium fistulosum L.",
+      "nombre_comunes_regionales": [
+        "Cebolla de rama",
+        "Cebolla junca"
+      ],
+      "familia_botanica": "Amaryllidaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.2,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "heladas_tolerancia": {
+        "umbral_c": -3,
+        "horas_acumuladas_max": 8,
+        "notas": "Tolerante a heladas recurrentes en la sabana cundiboyacense."
+      },
+      "companions": [
+        "apium_graveolens",
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum",
+        "rosmarinus_officinalis"
+      ],
+      "antagonists": [
+        "beta_vulgaris_conditiva"
+      ],
+      "propagation": {
+        "methods": [
+          "division_mata"
+        ],
+        "best_method": "hijuelos",
+        "notas": "Se dividen los macollos para una propagación rápida y perenne."
+      },
+      "valor_pedagogico": "Lección de sostenibilidad: su capacidad de rebrote la convierte en el ejemplo ideal de 'cosecha perpetua'.",
+      "plagas_criticas": [
+        "Trips"
+      ],
+      "enfermedades_criticas": [
+        "Mortero"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
       "id": "alnus_acuminata",
       "_curation_status": "VALIDADO con fuentes CIAT/AGROSAVIA",
       "nombre_comun": "Aliso andino",
@@ -193,6 +360,91 @@
       ]
     },
     {
+      "id": "apium_graveolens",
+      "nombre_comun": "Apio",
+      "nombre_cientifico": "Apio graveolens L.",
+      "nombre_comunes_regionales": [
+        "Apio de España",
+        "Celery"
+      ],
+      "familia_botanica": "Apiaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 4,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 21,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 4,
+        "notas": "Tolerancia moderada a heladas ligeras en estado adulto."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere semillero y trasplante cuidadoso por raíz sensible."
+      },
+      "valor_pedagogico": "Lección de nutrición hídrica: el apio demuestra la importancia de la humedad constante para evitar tallos fibrosos.",
+      "plagas_criticas": [
+        "Minador de la hoja",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Mancha foliar"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
       "id": "beta_vulgaris_cicla_amarilla",
       "nombre_comun": "Acelga amarilla",
       "nombre_cientifico": "Beta vulgaris L. subsp. vulgaris (Cicla Group)",
@@ -242,6 +494,7 @@
         "notas": "Tolerancia similar a las otras acelgas; pencas amarillas pueden ser menos vigorosas que la blanca."
       },
       "companions": [
+        "brassica_oleracea_capitata_alba",
         "lactuca_sativa_crispa_verde",
         "raphanus_sativus"
       ],
@@ -320,6 +573,7 @@
         "notas": "Tolera heladas leves; el meristemo basal rebrota tras quemaduras foliares."
       },
       "companions": [
+        "brassica_oleracea_capitata_alba",
         "lactuca_sativa_crispa_verde",
         "lactuca_sativa_longifolia_morada",
         "lactuca_sativa_longifolia_verde",
@@ -402,6 +656,9 @@
         "notas": "Tolera heladas leves; el meristemo basal rebrota tras quemaduras foliares."
       },
       "companions": [
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
         "lactuca_sativa_crispa_verde",
         "raphanus_sativus"
       ],
@@ -484,6 +741,8 @@
         "raphanus_sativus"
       ],
       "antagonists": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
         "beta_vulgaris_cicla_amarilla",
         "beta_vulgaris_cicla_blanca",
         "beta_vulgaris_cicla_roja",
@@ -507,6 +766,508 @@
         "gbif-taxonomic-backbone",
         "ica-resolucion-3168-2015",
         "restrepo-1996-abc-agricultura-organica"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "brassica_oleracea_acephala_curly",
+      "nombre_comun": "Kale rizado verde",
+      "nombre_cientifico": "Brassica oleracea var. acephala 'Curly'",
+      "nombre_comunes_regionales": [
+        "Col rizada",
+        "Curly kale"
+      ],
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 18,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.5,
+        "optimo_max": 7.5,
+        "max": 8.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "heladas_tolerancia": {
+        "umbral_c": -8,
+        "horas_acumuladas_max": 48,
+        "notas": "Extremadamente rústico; sobrevive a cubiertas de nieve o escarcha persistente."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Se recomienda sembrar escalonadamente para cosecha continua."
+      },
+      "valor_pedagogico": "Lección de hortaliza perenne: permite entender el concepto de plantas multianuales en el huerto doméstico.",
+      "plagas_criticas": [
+        "Alticas (Phyllotreta spp.)",
+        "Pulgón ceniciento"
+      ],
+      "enfermedades_criticas": [
+        "Hernia de la col"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "brassica_oleracea_acephala_lacinato",
+      "nombre_comun": "Kale toscano / Cavolo nero",
+      "nombre_cientifico": "Brassica oleracea var. acephala 'Lacinato'",
+      "nombre_comunes_regionales": [
+        "Kale dinosaurio",
+        "Col de hoja negra"
+      ],
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 18,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.2,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -6,
+        "horas_acumuladas_max": 24,
+        "notas": "El sabor mejora notablemente después de una helada ligera."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum",
+        "raphanus_sativus"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Planta semi-perenne; se puede cosechar hoja por hoja durante meses."
+      },
+      "valor_pedagogico": "Lección de arquitectura: a diferencia del repollo, sus hojas crecen abiertas sobre un tallo central persistente.",
+      "plagas_criticas": [
+        "Palomilla dorso de diamante",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Bacteriosis"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "brassica_oleracea_acephala_red_russian",
+      "nombre_comun": "Kale morado / Red Russian",
+      "nombre_cientifico": "Brassica oleracea var. acephala 'Red Russian'",
+      "nombre_comunes_regionales": [
+        "Kale ruso",
+        "Col de hoja roja"
+      ],
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 12,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 8,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -10,
+        "horas_acumuladas_max": 72,
+        "notas": "Desarrolla colores púrpuras intensos como respuesta defensiva al frío."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "beta_vulgaris_cicla_roja",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Sus hojas son más tiernas que las del kale rizado."
+      },
+      "valor_pedagogico": "Lección de respuesta lumínica: muestra cómo la planta produce pigmentos para gestionar la radiación UV en altura.",
+      "plagas_criticas": [
+        "Gusanos de la col",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Mildiu"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "brassica_oleracea_capitata_alba",
+      "nombre_comun": "Repollo blanco",
+      "nombre_cientifico": "Brassica oleracea var. capitata L.",
+      "nombre_comunes_regionales": [
+        "Col repollo",
+        "Repollo de corazón"
+      ],
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 4,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 7.8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -2,
+        "horas_acumuladas_max": 6,
+        "notas": "Tolerante a heladas ligeras; el frío intenso puede inducir floración prematura."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "beta_vulgaris_cicla_amarilla",
+        "beta_vulgaris_cicla_blanca",
+        "beta_vulgaris_cicla_roja",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum",
+        "raphanus_sativus"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere semillero. El trasplante debe ser profundo."
+      },
+      "valor_pedagogico": "Lección de morfología: muestra cómo las hojas se envuelven y compactan para formar una 'cabeza'.",
+      "plagas_criticas": [
+        "Plutella xylostella",
+        "Brevicoryne brassicae"
+      ],
+      "enfermedades_criticas": [
+        "Plasmodiophora brassicae"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "brassica_oleracea_capitata_rubra",
+      "nombre_comun": "Repollo morado",
+      "nombre_cientifico": "Brassica oleracea var. capitata f. rubra",
+      "nombre_comunes_regionales": [
+        "Lombarda",
+        "Repollo colorado"
+      ],
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "ph_suelo": {
+        "min": 6.0,
+        "optimo_min": 6.5,
+        "optimo_max": 7.5,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -3,
+        "horas_acumuladas_max": 8,
+        "notas": "Resiste mejor el frío que el repollo blanco debido a sus antocianinas."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "beta_vulgaris_cicla_roja",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum",
+        "raphanus_sativus"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere suelos ricos en materia orgánica para un color intenso."
+      },
+      "valor_pedagogico": "Lección de pigmentos: las antocianinas actúan como protector solar y anticongelante natural.",
+      "plagas_criticas": [
+        "Plutella xylostella",
+        "Pulgón ceniciento"
+      ],
+      "enfermedades_criticas": [
+        "Hernia de la col"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "brassica_oleracea_sabauda",
+      "nombre_comun": "Repollo rizado / Savoy",
+      "nombre_cientifico": "Brassica oleracea var. sabauda L.",
+      "nombre_comunes_regionales": [
+        "Col de Milán",
+        "Repollo crespo"
+      ],
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.5,
+        "optimo_max": 7.5,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -5,
+        "horas_acumuladas_max": 12,
+        "notas": "Excelente resistencia al frío; las hojas rizadas atrapan aire que actúa como aislante."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum",
+        "raphanus_sativus"
+      ],
+      "antagonists": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Ciclo más largo que el repollo liso."
+      },
+      "valor_pedagogico": "Lección de selección varietal: su textura rugosa es producto de siglos de selección en climas fríos europeos.",
+      "plagas_criticas": [
+        "Pieris rapae",
+        "Brevicoryne brassicae"
+      ],
+      "enfermedades_criticas": [
+        "Plasmodiophora brassicae"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
       ],
       "validation_level": "claude_draft"
     },
@@ -601,6 +1362,85 @@
       ]
     },
     {
+      "id": "cymbopogon_citratus",
+      "nombre_comun": "Limonaria",
+      "nombre_cientifico": "Cymbopogon citratus (DC.) Stapf",
+      "nombre_comunes_regionales": [
+        "Limón pasto",
+        "Lemongrass",
+        "Limoncillo"
+      ],
+      "familia_botanica": "Poaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent",
+        "biomass_producer",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 12,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 18,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 1,
+        "horas_acumuladas_max": 2,
+        "notas": "Sensible a heladas, en zonas frías requiere ubicación protegida."
+      },
+      "companions": [
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "rizoma"
+        ],
+        "best_method": "división de rizomas",
+        "notas": "Se propaga mediante el trasplante de 'hijos' de la corona."
+      },
+      "valor_pedagogico": "Lección de diseño microclimático: su uso como barrera contra el viento protege cultivos más delicados.",
+      "plagas_criticas": [
+        "Cochinillas"
+      ],
+      "enfermedades_criticas": [
+        "Roya de la limonaria"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
       "id": "foeniculum_vulgare",
       "nombre_comun": "Hinojo",
       "nombre_cientifico": "Foeniculum vulgare Mill.",
@@ -651,6 +1491,7 @@
         "notas": "Parte aérea sensible a heladas fuertes; rebrota desde la base si la corona no se congela."
       },
       "antagonists": [
+        "apium_graveolens",
         "beta_vulgaris_cicla_amarilla",
         "beta_vulgaris_cicla_blanca",
         "beta_vulgaris_cicla_roja",
@@ -661,7 +1502,11 @@
         "lactuca_sativa_roble_morada",
         "lactuca_sativa_roble_verde",
         "petroselinum_crispum",
-        "raphanus_sativus"
+        "raphanus_sativus",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
       ],
       "propagation": {
         "metodo_principal": "semilla",
@@ -679,6 +1524,95 @@
         "gbif-taxonomic-backbone",
         "pamplona-roger-2006-plantas-medicinales",
         "restrepo-2007-biopreparados"
+      ],
+      "validation_level": "claude_draft",
+      "companions": [
+        "pimpinella_anisum"
+      ]
+    },
+    {
+      "id": "lactuca_sativa_capitata",
+      "nombre_comun": "Lechuga cogollo morada",
+      "nombre_cientifico": "Lactuca sativa var. capitata L.",
+      "nombre_comunes_regionales": [
+        "Lechuga repollada morada"
+      ],
+      "familia_botanica": "Asteraceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 3,
+      "estrato": "bajo",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 14,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -1,
+        "horas_acumuladas_max": 4,
+        "notas": "Las variedades pigmentadas suelen resistir mejor el frío que las verdes."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "antagonists": [
+        "petroselinum_crispum"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere sustrato fino y riego por nebulización en etapas tempranas."
+      },
+      "valor_pedagogico": "Lección de pigmentación: muestra cómo las antocianinas (color morado) protegen a la planta contra el estrés climático.",
+      "plagas_criticas": [
+        "Babosas"
+      ],
+      "enfermedades_criticas": [
+        "Bremia"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
       ],
       "validation_level": "claude_draft"
     },
@@ -1078,18 +2012,172 @@
       "validation_level": "claude_draft"
     },
     {
+      "id": "melissa_officinalis",
+      "nombre_comun": "Toronjil",
+      "nombre_cientifico": "Melissa officinalis L.",
+      "nombre_comunes_regionales": [
+        "Melisa",
+        "Hoja de limón"
+      ],
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 12,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 27
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 6.0,
+        "optimo_max": 7.5,
+        "max": 8.0
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "heladas_tolerancia": {
+        "umbral_c": -10,
+        "horas_acumuladas_max": 24,
+        "notas": "Altamente resistente a bajas temperaturas invernales."
+      },
+      "companions": [
+        "mentha_spicata",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "division_mata"
+        ],
+        "best_method": "división de mata",
+        "notas": "Fácil propagación vegetativa en primavera u otoño."
+      },
+      "valor_pedagogico": "Lección de alelopatía positiva: su aroma cítrico confunde plagas de hortalizas vecinas.",
+      "plagas_criticas": [
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Oidio"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "mentha_spicata",
+      "nombre_comun": "Menta",
+      "nombre_cientifico": "Mentha spicata L.",
+      "nombre_comunes_regionales": [
+        "Hierbabuena",
+        "Menta verde"
+      ],
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 12,
+      "estrato": "bajo",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "heladas_tolerancia": {
+        "umbral_c": -5,
+        "horas_acumuladas_max": 12,
+        "notas": "Las hojas pueden quemarse, pero el rizoma sobrevive fácilmente."
+      },
+      "companions": [
+        "melissa_officinalis",
+        "salvia_officinalis"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "estolon"
+        ],
+        "best_method": "estolones",
+        "notas": "Muy invasiva si no se controla el crecimiento radicular."
+      },
+      "valor_pedagogico": "Lección de expansión: muestra cómo las plantas colonizan espacio mediante sistemas radiculares horizontales.",
+      "plagas_criticas": [
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Roya de la menta"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
       "id": "petroselinum_crispum",
-      "nombre_comun": "Perejil crespo",
+      "nombre_comun": "Perejil liso",
       "nombre_cientifico": "Petroselinum crispum (Mill.) Fuss",
       "nombre_comunes_regionales": [
-        "Perejil rizado",
-        "Perejil de hoja crespa"
+        "Perejil de hoja plana"
       ],
       "familia_botanica": "Apiaceae",
       "category": "hortalizas_hoja",
       "thermal_zones": [
+        "frio",
         "templado",
-        "frio"
+        "calido"
       ],
       "roles_in_guild": [
         "crop",
@@ -1101,51 +2189,143 @@
       "cycleMonths": 3,
       "estrato": "bajo",
       "altitud_msnm": {
-        "min_absoluto": 800,
+        "min_absoluto": 0,
         "optimo_min": 1500,
         "optimo_max": 2800,
-        "max_absoluto": 3000
+        "max_absoluto": 3200
       },
       "temperatura_c": {
-        "helada_letal": -7,
-        "optimo_min": 12,
-        "optimo_max": 22,
-        "max_tolerable": 28
+        "helada_letal": -5,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 30
       },
       "ph_suelo": {
         "min": 5.5,
-        "optimo_min": 6.0,
+        "optimo_min": 6.2,
         "optimo_max": 7.0,
-        "max": 7.5
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "heladas_tolerancia": {
+        "umbral_c": -2,
+        "horas_acumuladas_max": 8,
+        "notas": "Muy resistente a heladas en climas altoandinos."
+      },
+      "companions": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "apium_graveolens",
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare",
+        "lactuca_sativa_capitata"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Germinación lenta, se recomienda remojo previo de la semilla."
+      },
+      "valor_pedagogico": "Lección de paciencia: su lenta germinación enseña los tiempos biológicos diferenciados en el huerto.",
+      "plagas_criticas": [
+        "Pulgones",
+        "Gusanos trozadores"
+      ],
+      "enfermedades_criticas": [
+        "Mildiu polvoso"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "pimpinella_anisum",
+      "nombre_comun": "Anís",
+      "nombre_cientifico": "Pimpinella anisum L.",
+      "nombre_comunes_regionales": [
+        "Anís verde",
+        "Matalahúva"
+      ],
+      "familia_botanica": "Apiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "semilla",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 15,
+        "optimo_max": 25,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 6.0,
+        "optimo_min": 6.5,
+        "optimo_max": 7.5,
+        "max": 8.5
       },
       "radiacion": "sol_pleno",
       "agua": "medio",
       "drenaje_requerido": "bueno",
       "heladas_tolerancia": {
-        "umbral_c": -3,
-        "horas_acumuladas_max": 8,
-        "notas": "Especie bienal: tolera heladas leves. Al florecer en su segundo año atrae sírfidos, avispas parasitoides y abejas nativas."
+        "umbral_c": 2,
+        "horas_acumuladas_max": 2,
+        "notas": "Sensible a heladas fuertes durante la floración."
       },
-      "antagonists": [
+      "companions": [
         "foeniculum_vulgare"
       ],
+      "antagonists": [],
       "propagation": {
-        "metodo_principal": "semilla",
-        "notas": "Germinación lenta (14-28 días). Remojo previo en agua tibia por 24 h mejora la emergencia."
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Siembra directa preferible para evitar estrés radicular."
       },
-      "valor_pedagogico": "Útil para enseñar paciencia en germinación lenta, manejo de aromáticas y atracción de fauna benéfica durante la floración del segundo año.",
+      "valor_pedagogico": "Lección de aromaterapia viva: permite identificar cómo las plantas atraen polinizadores mediante aceites volátiles.",
       "plagas_criticas": [
-        "pulgones (Aphidoidea)",
-        "minador de la hoja (Liriomyza spp.)"
+        "Pulgones",
+        "Ácaros"
       ],
       "enfermedades_criticas": [
-        "Septoria petroselini",
-        "Alternaria spp."
+        "Rizoctonia"
       ],
       "source_ids": [
         "gbif-taxonomic-backbone",
-        "pamplona-roger-2006-plantas-medicinales",
-        "restrepo-1996-abc-agricultura-organica"
+        "pamplona-roger-2006-plantas-medicinales"
       ],
       "validation_level": "claude_draft"
     },
@@ -1286,11 +2466,16 @@
         "beta_vulgaris_cicla_blanca",
         "beta_vulgaris_cicla_roja",
         "beta_vulgaris_conditiva",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
         "lactuca_sativa_crispa_verde",
         "lactuca_sativa_longifolia_morada",
         "lactuca_sativa_longifolia_verde",
         "lactuca_sativa_roble_morada",
-        "lactuca_sativa_roble_verde"
+        "lactuca_sativa_roble_verde",
+        "solanum_lycopersicum_cerasiforme"
       ],
       "antagonists": [
         "foeniculum_vulgare"
@@ -1313,6 +2498,501 @@
         "gbif-taxonomic-backbone",
         "ica-resolucion-3168-2015",
         "restrepo-1996-abc-agricultura-organica"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "rosmarinus_officinalis",
+      "nombre_comun": "Romero",
+      "nombre_cientifico": "Salvia rosmarinus Spenn. (syn. Rosmarinus officinalis L.)",
+      "nombre_comunes_regionales": [
+        "Romero de Castilla"
+      ],
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 24,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 12,
+        "optimo_max": 24,
+        "max_tolerable": 35
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 6.0,
+        "optimo_max": 7.5,
+        "max": 8.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -10,
+        "horas_acumuladas_max": 24,
+        "notas": "Muy resistente; los suelos encharcados en heladas son su principal enemigo."
+      },
+      "companions": [
+        "allium_fistulosum",
+        "salvia_officinalis",
+        "urtica_dioica"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "esqueje"
+        ],
+        "best_method": "esqueje",
+        "notas": "Se recomienda usar hormonas de enraizamiento naturales."
+      },
+      "valor_pedagogico": "Lección de rusticidad: ejemplifica la capacidad de algunas especies para prosperar en suelos pobres y climas extremos.",
+      "plagas_criticas": [
+        "Ácaros"
+      ],
+      "enfermedades_criticas": [
+        "Podredumbre de cuello"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "salvia_officinalis",
+      "nombre_comun": "Salvia",
+      "nombre_cientifico": "Salvia officinalis L.",
+      "nombre_comunes_regionales": [
+        "Salvia real"
+      ],
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "hoja",
+      "cycleMonths": 12,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.5,
+        "optimo_max": 7.5,
+        "max": 8.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -8,
+        "horas_acumuladas_max": 12,
+        "notas": "Tolerante, pero prefiere suelos secos en invierno para evitar pudrición."
+      },
+      "companions": [
+        "mentha_spicata",
+        "rosmarinus_officinalis"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "esqueje"
+        ],
+        "best_method": "esqueje",
+        "notas": "Los esquejes semileñosos enraízan con facilidad."
+      },
+      "valor_pedagogico": "Lección de adaptación hídrica: sus hojas vellosas muestran una estrategia para reducir la transpiración.",
+      "plagas_criticas": [
+        "Mosca blanca"
+      ],
+      "enfermedades_criticas": [
+        "Mildiu"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "solanum_lycopersicum_cerasiforme",
+      "nombre_comun": "Tomate cherry estándar",
+      "nombre_cientifico": "Solanum lycopersicum var. cerasiforme (Dunal) A.Gray",
+      "nombre_comunes_regionales": [
+        "Tomate de árbol (error común)",
+        "Tomate redondo pequeño"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 6,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 6.8,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "No tolera heladas. En la sabana requiere invernadero o muros térmicos."
+      },
+      "companions": [
+        "cymbopogon_citratus",
+        "lactuca_sativa_capitata",
+        "melissa_officinalis",
+        "petroselinum_crispum",
+        "raphanus_sativus",
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "foeniculum_vulgare",
+        "solanum_phureja"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Crecimiento indeterminado; requiere tutorado y podas de chupones."
+      },
+      "valor_pedagogico": "Lección de cosecha escalonada: los frutos maduran en racimos de forma secuencial permitiendo cosecha continua.",
+      "plagas_criticas": [
+        "Tuta absoluta",
+        "Mosca blanca"
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora infestans"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "restrepo-1996-abc-agricultura-organica"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "solanum_lycopersicum_cerasiforme_uvalina",
+      "nombre_comun": "Tomate cherry uvalina / Grape",
+      "nombre_cientifico": "Solanum lycopersicum var. cerasiforme 'Uvalina'",
+      "nombre_comunes_regionales": [
+        "Tomate uva",
+        "Grape tomato"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 7,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.2,
+        "optimo_max": 6.8,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Requiere protección nocturna en zonas de helada."
+      },
+      "companions": [
+        "cymbopogon_citratus",
+        "lactuca_sativa_capitata",
+        "melissa_officinalis",
+        "petroselinum_crispum",
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "foeniculum_vulgare",
+        "solanum_phureja"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Hábito indeterminado. Piel más resistente que el cherry redondo."
+      },
+      "valor_pedagogico": "Lección de textura: su forma elongada y piel firme lo hacen ideal para transporte y conservación prolongada.",
+      "plagas_criticas": [
+        "Tuta absoluta"
+      ],
+      "enfermedades_criticas": [
+        "Fulvia fulva"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "solanum_lycopersicum_san_marzano",
+      "nombre_comun": "Tomate San Marzano",
+      "nombre_cientifico": "Solanum lycopersicum 'San Marzano'",
+      "nombre_comunes_regionales": [
+        "Tomate de pera",
+        "Tomate para pasta"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.5,
+        "optimo_max": 7.2,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Más tolerante al calor que el cherry, pero igualmente sensible al frío."
+      },
+      "companions": [
+        "cymbopogon_citratus",
+        "lactuca_sativa_capitata",
+        "melissa_officinalis",
+        "petroselinum_crispum",
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "foeniculum_vulgare",
+        "solanum_phureja"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Crecimiento determinado; cosecha concentrada en un periodo corto."
+      },
+      "valor_pedagogico": "Lección de procesamiento: su bajo contenido de agua y pulpa densa lo hacen el estándar para conservas y salsas.",
+      "plagas_criticas": [
+        "Trps",
+        "Heliothis"
+      ],
+      "enfermedades_criticas": [
+        "Podredumbre apical (Blossom end rot)"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "restrepo-1996-abc-agricultura-organica"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "solanum_lycopersicum_sungold",
+      "nombre_comun": "Tomate cherry amarillo / Sungold",
+      "nombre_cientifico": "Solanum lycopersicum 'Sungold'",
+      "nombre_comunes_regionales": [
+        "Tomate cherry naranja",
+        "Cherry golosina"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 6,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1800,
+        "optimo_max": 2500,
+        "max_absoluto": 2900
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 16,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.8,
+        "optimo_min": 6.2,
+        "optimo_max": 6.8,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 6,
+        "horas_acumuladas_max": 0,
+        "notas": "Sensible al rajado de frutos si hay cambios bruscos de temperatura o humedad."
+      },
+      "companions": [
+        "cymbopogon_citratus",
+        "lactuca_sativa_capitata",
+        "melissa_officinalis",
+        "petroselinum_crispum",
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "foeniculum_vulgare",
+        "solanum_phureja"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Indeterminado. Muy vigoroso y productivo."
+      },
+      "valor_pedagogico": "Lección de sabor y color: el color amarillo/naranja indica altos niveles de azúcares y betacarotenos.",
+      "plagas_criticas": [
+        "Mosca blanca"
+      ],
+      "enfermedades_criticas": [
+        "Moho de la hoja"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-biopreparados-2015"
       ],
       "validation_level": "claude_draft"
     },
@@ -1415,7 +3095,11 @@
       "antagonists": [
         "cucurbita_maxima",
         "rubus_glaucus",
-        "solanum_lycopersicum"
+        "solanum_lycopersicum",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold"
       ],
       "_nota_antagonists": "Solanaceae entre sí comparten Phytophthora infestans y Ralstonia solanacearum → rotación obligatoria. Cucurbitáceas son hospedantes alternativos de áfidos vectores.",
       "recommended_covers": [
@@ -1998,6 +3682,10 @@
       "companions": [
         "rosmarinus_officinalis",
         "rubus_glaucus",
+        "solanum_lycopersicum_cerasiforme",
+        "solanum_lycopersicum_cerasiforme_uvalina",
+        "solanum_lycopersicum_san_marzano",
+        "solanum_lycopersicum_sungold",
         "solanum_phureja"
       ],
       "antagonists": [],

--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -86,7 +86,8 @@
         "petroselinum_crispum"
       ],
       "antagonists": [
-        "beta_vulgaris_conditiva"
+        "beta_vulgaris_conditiva",
+        "phaseolus_vulgaris"
       ],
       "propagation": {
         "methods": [
@@ -170,7 +171,8 @@
         "rosmarinus_officinalis"
       ],
       "antagonists": [
-        "beta_vulgaris_conditiva"
+        "beta_vulgaris_conditiva",
+        "phaseolus_vulgaris"
       ],
       "propagation": {
         "methods": [
@@ -248,6 +250,7 @@
       "drenaje_requerido": "bueno_a_moderado",
       "companions": [
         "coffea_arabica",
+        "erythrina_edulis",
         "lupinus_mutabilis",
         "passiflora_tripartita_mollissima",
         "pennisetum_clandestinum_manejado",
@@ -1417,7 +1420,8 @@
         "notas": "Altamente sensible a heladas; las bajas temperaturas afectan la calidad del grano."
       },
       "companions": [
-        "alnus_acuminata"
+        "alnus_acuminata",
+        "erythrina_edulis"
       ],
       "antagonists": [
         "foeniculum_vulgare"
@@ -1526,6 +1530,88 @@
       "validation_level": "claude_draft"
     },
     {
+      "id": "erythrina_edulis",
+      "nombre_comun": "Chachafruto / Balú",
+      "nombre_cientifico": "Erythrina edulis Triana ex Micheli",
+      "nombre_comunes_regionales": [
+        "Poroto andino",
+        "Fríjol de árbol",
+        "Pajuro"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "alto",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1600,
+        "optimo_max": 2400,
+        "max_absoluto": 2700
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 4,
+        "notas": "Tolerancia moderada; los brotes jóvenes pueden verse afectados por heladas nocturnas."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "coffea_arabica"
+      ],
+      "antagonists": [
+        "ulex_europaeus"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Germina rápidamente; el esqueje se usa principalmente para cercas vivas."
+      },
+      "valor_pedagogico": "Lección de seguridad alimentaria: árbol multi-servicio que provee proteína vegetal de alta calidad en zonas de ladera.",
+      "plagas_criticas": [
+        "Scolytidae",
+        "Cerotoma spp."
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis foliar"
+      ],
+      "source_ids": [
+        "agrosavia-manual-chachafruto-2015",
+        "humboldt-flora-alto-andina",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
       "id": "foeniculum_vulgare",
       "nombre_comun": "Hinojo",
       "nombre_cientifico": "Foeniculum vulgare Mill.",
@@ -1588,12 +1674,14 @@
         "lactuca_sativa_roble_morada",
         "lactuca_sativa_roble_verde",
         "petroselinum_crispum",
+        "phaseolus_vulgaris",
         "physalis_peruviana",
         "raphanus_sativus",
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "zea_mays"
       ],
       "propagation": {
         "metodo_principal": "semilla",
@@ -1751,6 +1839,7 @@
         "brassica_oleracea_capitata_rubra",
         "brassica_oleracea_sabauda",
         "fragaria_ananassa_monterrey",
+        "phaseolus_vulgaris",
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
@@ -2731,6 +2820,90 @@
       "source_ids": [
         "gbif-taxonomic-backbone",
         "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "phaseolus_vulgaris",
+      "nombre_comun": "Frijol arbustivo / voluble",
+      "nombre_cientifico": "Phaseolus vulgaris L.",
+      "nombre_comunes_regionales": [
+        "Frijol cargamanto",
+        "Bola roja",
+        "Frijol recal"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 4,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Altamente sensible a heladas; requiere protección o siembra en épocas seguras."
+      },
+      "companions": [
+        "lactuca_sativa_capitata",
+        "zea_mays"
+      ],
+      "antagonists": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Inocular con Rhizobium para optimizar la fijación de nitrógeno."
+      },
+      "valor_pedagogico": "Lección de biología de suelo: estudio de los nódulos radiculares y la simbiosis con Rhizobium leguminosarum.",
+      "plagas_criticas": [
+        "Empoasca kraemeri",
+        "Apion godmani",
+        "Bemisia tabaci"
+      ],
+      "enfermedades_criticas": [
+        "Colletotrichum lindemuthianum (antracnosis)",
+        "Uromyces appendiculatus"
+      ],
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "gbif-taxonomic-backbone",
+        "restrepo-1996-abc-agricultura-organica"
       ],
       "validation_level": "claude_draft"
     },
@@ -3963,7 +4136,8 @@
         "lupinus_mutabilis",
         "minthostachys_mollis",
         "urtica_dioica",
-        "vicia_faba"
+        "vicia_faba",
+        "zea_mays"
       ],
       "antagonists": [
         "cucurbita_maxima",
@@ -4497,6 +4671,9 @@
         "car-cundi-2019",
         "res-684-2018-mads",
         "mongabay-retamo-2024"
+      ],
+      "antagonists": [
+        "erythrina_edulis"
       ]
     },
     {
@@ -4902,6 +5079,89 @@
         "powo-kew"
       ],
       "validation_level": "claude_draft"
+    },
+    {
+      "id": "zea_mays",
+      "nombre_comun": "Maíz criollo",
+      "nombre_cientifico": "Zea mays L.",
+      "nombre_comunes_regionales": [
+        "Maíz capio",
+        "Maíz pira",
+        "Maíz de montaña"
+      ],
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 6,
+      "estrato": "alto",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 2,
+        "notas": "Sensible en etapas tempranas; variedades altoandinas como 'Capio' tienen mejor comportamiento ante el frío."
+      },
+      "companions": [
+        "phaseolus_vulgaris",
+        "solanum_phureja"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Siembra directa en sitio definitivo."
+      },
+      "notas_taxonomicas": "Las razas locales colombianas como 'Capio' (blanco harinoso), 'Cusco' (morado) y 'Pira' son fundamentales para la soberanía alimentaria de la zona altoandina. El sistema Milpa integra maíz con frijol y calabaza.",
+      "valor_pedagogico": "Lección de Milpa: enseña el sistema de 'las tres hermanas' y la importancia de la diversidad genética en razas criollas.",
+      "plagas_criticas": [
+        "Spodoptera frugiperda (cogollero)",
+        "Helicoverpa zea",
+        "Diabrotica balteata"
+      ],
+      "enfermedades_criticas": [
+        "Puccinia sorghi (roya)",
+        "Fusarium spp."
+      ],
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
     }
   ],
   "biopreparados": [
@@ -5273,6 +5533,14 @@
       "autores": "AGROSAVIA",
       "año": 2015,
       "titulo": "Manual de biopreparados para la agricultura colombiana",
+      "institucion": "AGROSAVIA"
+    },
+    {
+      "id": "agrosavia-manual-chachafruto-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual técnico para el cultivo de chachafruto (Erythrina edulis) en sistemas agroforestales andinos",
       "institucion": "AGROSAVIA"
     },
     {

--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -247,7 +247,9 @@
       "agua": "alto",
       "drenaje_requerido": "bueno_a_moderado",
       "companions": [
+        "coffea_arabica",
         "lupinus_mutabilis",
+        "passiflora_tripartita_mollissima",
         "pennisetum_clandestinum_manejado",
         "solanum_phureja",
         "vicia_faba"
@@ -829,7 +831,8 @@
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "vaccinium_corymbosum_emerald"
       ],
       "propagation": {
         "methods": [
@@ -913,7 +916,8 @@
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "vaccinium_corymbosum_emerald"
       ],
       "propagation": {
         "methods": [
@@ -996,7 +1000,8 @@
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "vaccinium_corymbosum_emerald"
       ],
       "propagation": {
         "methods": [
@@ -1082,7 +1087,8 @@
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "vaccinium_corymbosum_biloxi"
       ],
       "propagation": {
         "methods": [
@@ -1166,7 +1172,8 @@
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "vaccinium_corymbosum_biloxi"
       ],
       "propagation": {
         "methods": [
@@ -1248,7 +1255,8 @@
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
-        "solanum_lycopersicum_sungold"
+        "solanum_lycopersicum_sungold",
+        "vaccinium_corymbosum_biloxi"
       ],
       "propagation": {
         "methods": [
@@ -1360,6 +1368,83 @@
         "correa-pabon-carulla-2008",
         "agrosavia-forrajeras-2022"
       ]
+    },
+    {
+      "id": "coffea_arabica",
+      "nombre_comun": "Café caturra / Castillo / Cenicafé 1",
+      "nombre_cientifico": "Coffea arabica L.",
+      "nombre_comunes_regionales": [
+        "Café Supremo (categoría comercial)",
+        "Café Arábigo"
+      ],
+      "familia_botanica": "Rubiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 180,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 2000,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.0,
+        "optimo_max": 6.0,
+        "max": 6.5
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 2,
+        "horas_acumuladas_max": 0,
+        "notas": "Altamente sensible a heladas; las bajas temperaturas afectan la calidad del grano."
+      },
+      "companions": [
+        "alnus_acuminata"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual (chapolas)",
+        "notas": "Requiere germinador en arena y posterior embolsado."
+      },
+      "notas_taxonomicas": "Las variedades Castillo y Cenicafé 1 son las más recomendadas por su resistencia a la roya. El término 'Supremo' refiere a una clasificación granulométrica por tamaño de malla y no a una variedad botánica.",
+      "valor_pedagogico": "Lección de selección varietal: comparación de resistencia a Hemileia vastatrix entre variedades tradicionales y mejoradas.",
+      "plagas_criticas": [
+        "Hypothenemus hampei (broca)",
+        "Hemileia vastatrix (roya)",
+        "Mycena citricolor"
+      ],
+      "enfermedades_criticas": [
+        "Cercospora coffeicola"
+      ],
+      "source_ids": [
+        "cenicafe-manual-cafetero-2013",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
     },
     {
       "id": "cymbopogon_citratus",
@@ -1496,12 +1581,14 @@
         "beta_vulgaris_cicla_blanca",
         "beta_vulgaris_cicla_roja",
         "beta_vulgaris_conditiva",
+        "coffea_arabica",
         "lactuca_sativa_crispa_verde",
         "lactuca_sativa_longifolia_morada",
         "lactuca_sativa_longifolia_verde",
         "lactuca_sativa_roble_morada",
         "lactuca_sativa_roble_verde",
         "petroselinum_crispum",
+        "physalis_peruviana",
         "raphanus_sativus",
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
@@ -1529,6 +1616,81 @@
       "companions": [
         "pimpinella_anisum"
       ]
+    },
+    {
+      "id": "fragaria_ananassa_monterrey",
+      "nombre_comun": "Fresa Monterrey",
+      "nombre_cientifico": "Fragaria × ananassa 'Monterrey'",
+      "nombre_comunes_regionales": [
+        "Fresa day-neutral"
+      ],
+      "familia_botanica": "Rosaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 18,
+      "estrato": "bajo",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 6.5,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -2,
+        "horas_acumuladas_max": 6,
+        "notas": "La flor se quema con la helada, pero la planta es perenne y rebrota."
+      },
+      "companions": [
+        "lactuca_sativa_capitata",
+        "petroselinum_crispum"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "estolon"
+        ],
+        "best_method": "estolones",
+        "notas": "Requiere 'mulch' o plástico para evitar que el fruto toque el suelo."
+      },
+      "valor_pedagogico": "Lección de fotoperiodo: variedad de día neutro que permite cosecha continua sin importar la duración del día.",
+      "plagas_criticas": [
+        "Tetranychus urticae (ácaro rojo)",
+        "Trips"
+      ],
+      "enfermedades_criticas": [
+        "Botrytis cinerea",
+        "Oídio"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "validation_level": "claude_draft"
     },
     {
       "id": "lactuca_sativa_capitata",
@@ -1588,6 +1750,7 @@
         "brassica_oleracea_capitata_alba",
         "brassica_oleracea_capitata_rubra",
         "brassica_oleracea_sabauda",
+        "fragaria_ananassa_monterrey",
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
@@ -2166,6 +2329,318 @@
       "validation_level": "claude_draft"
     },
     {
+      "id": "passiflora_edulis_flavicarpa",
+      "nombre_comun": "Maracuyá",
+      "nombre_cientifico": "Passiflora edulis f. flavicarpa Deg.",
+      "nombre_comunes_regionales": [
+        "Fruta de la pasión amarilla",
+        "Maracuyá ácido"
+      ],
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 36,
+      "estrato": "emergente",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1300,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 24,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Extremadamente sensible al frío; detiene crecimiento por debajo de 15°C."
+      },
+      "companions": [
+        "petroselinum_crispum"
+      ],
+      "antagonists": [
+        "passiflora_edulis_morada"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Polinización manual a menudo necesaria para alta producción."
+      },
+      "valor_pedagogico": "Lección de gradiente térmico: contraste de requerimientos calurosos frente a sus parientes andinos (gulupa/curuba).",
+      "plagas_criticas": [
+        "Dione juno",
+        "Áfidos"
+      ],
+      "enfermedades_criticas": [
+        "Virosis (SMV)",
+        "Fusarium"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "sib-colombia",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "passiflora_edulis_morada",
+      "nombre_comun": "Gulupa",
+      "nombre_cientifico": "Passiflora edulis f. edulis Sims",
+      "nombre_comunes_regionales": [
+        "Passion fruit morado",
+        "Curuba redonda"
+      ],
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 48,
+      "estrato": "emergente",
+      "altitud_msnm": {
+        "min_absoluto": 1600,
+        "optimo_min": 1800,
+        "optimo_max": 2300,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 6.5,
+        "max": 7.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 3,
+        "notas": "Resiste ligeramente mejor que la granadilla, pero las flores son muy sensibles."
+      },
+      "companions": [
+        "petroselinum_crispum",
+        "urtica_dioica"
+      ],
+      "antagonists": [
+        "passiflora_edulis_flavicarpa"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Se recomienda el uso de microrrizas en el trasplante."
+      },
+      "valor_pedagogico": "Lección de hibridación: riesgo de cruce con maracuyá que degrada la calidad comercial de la pulpa.",
+      "plagas_criticas": [
+        "Gusano de la pasionaria",
+        "Ácaros"
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora spp.",
+        "Fusarium"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "sib-colombia",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "passiflora_ligularis",
+      "nombre_comun": "Granadilla",
+      "nombre_cientifico": "Passiflora ligularis Juss.",
+      "nombre_comunes_regionales": [
+        "Granada de moco",
+        "Granadilla dulce"
+      ],
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 60,
+      "estrato": "emergente",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2400,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 14,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.0,
+        "optimo_max": 7.0,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 2,
+        "notas": "Tolerancia muy baja; las heladas queman los brotes terminales y flores."
+      },
+      "companions": [
+        "petroselinum_crispum",
+        "raphanus_sativus"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "injerto"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere estructuras de soporte (espalderas o emparrillados)."
+      },
+      "valor_pedagogico": "Lección de entomología: importancia de los abejorros (Xylocopa spp.) para la polinización efectiva.",
+      "plagas_criticas": [
+        "Dasiops spp. (mosca del botón floral)",
+        "Dione juno juno"
+      ],
+      "enfermedades_criticas": [
+        "Fusarium oxysporum f.sp. passiflorae"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "fao-ecocrop",
+        "powo-kew"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "passiflora_tripartita_mollissima",
+      "nombre_comun": "Curuba de Castilla",
+      "nombre_cientifico": "Passiflora tripartita var. mollissima (Kunth) Holm-Niels. & Jørg.",
+      "nombre_comunes_regionales": [
+        "Taxo",
+        "Puru-puru"
+      ],
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 72,
+      "estrato": "emergente",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 6.5,
+        "max": 7.5
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -1,
+        "horas_acumuladas_max": 6,
+        "notas": "Es la pasiflora más resistente al frío altoandino."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "urtica_dioica"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere poda de formación constante para evitar enmarañamiento."
+      },
+      "valor_pedagogico": "Lección de adaptación altitudinal: es la única pasiflora comercial que prospera por encima de los 2500 msnm.",
+      "plagas_criticas": [
+        "Mosca del ovario",
+        "Trips"
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "sib-colombia",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
       "id": "petroselinum_crispum",
       "nombre_comun": "Perejil liso",
       "nombre_cientifico": "Petroselinum crispum (Mill.) Fuss",
@@ -2224,6 +2699,11 @@
         "brassica_oleracea_capitata_alba",
         "brassica_oleracea_capitata_rubra",
         "brassica_oleracea_sabauda",
+        "fragaria_ananassa_monterrey",
+        "passiflora_edulis_flavicarpa",
+        "passiflora_edulis_morada",
+        "passiflora_ligularis",
+        "physalis_peruviana",
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
         "solanum_lycopersicum_san_marzano",
@@ -2251,6 +2731,88 @@
       "source_ids": [
         "gbif-taxonomic-backbone",
         "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "physalis_peruviana",
+      "nombre_comun": "Uchuva",
+      "nombre_cientifico": "Physalis peruviana L.",
+      "nombre_comunes_regionales": [
+        "Aguaymanto",
+        "Cape gooseberry",
+        "Amor en bolsa"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 24,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 4,
+        "notas": "El cáliz (capacho) protege el fruto de heladas ligeras."
+      },
+      "companions": [
+        "petroselinum_crispum",
+        "solanum_lycopersicum_cerasiforme"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare",
+        "vaccinium_corymbosum_biloxi",
+        "vaccinium_corymbosum_emerald"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Requiere tutorado para evitar que las ramas toquen el suelo."
+      },
+      "valor_pedagogico": "Lección de empaque natural: el cáliz persistente como estrategia evolutiva de protección y dispersión.",
+      "plagas_criticas": [
+        "Tecia solanivora",
+        "Heliothis spp."
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora infestans",
+        "Fusarium oxysporum"
+      ],
+      "source_ids": [
+        "agrosavia-manual-uchuva-2015",
+        "gbif-taxonomic-backbone",
+        "sib-colombia"
       ],
       "validation_level": "claude_draft"
     },
@@ -2326,6 +2888,84 @@
       "source_ids": [
         "gbif-taxonomic-backbone",
         "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "psidium_guajava_manzana",
+      "nombre_comun": "Guayaba manzana",
+      "nombre_cientifico": "Psidium guajava 'Manzana'",
+      "nombre_comunes_regionales": [
+        "Guayaba criolla dulce",
+        "Redonda"
+      ],
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 240,
+      "estrato": "emergente",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1200,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 25,
+        "max_tolerable": 35
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.0,
+        "optimo_max": 7.0,
+        "max": 8.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Sensible al frío; detiene crecimiento en noches altoandinas."
+      },
+      "companions": [],
+      "antagonists": [
+        "vaccinium_corymbosum_biloxi",
+        "vaccinium_corymbosum_emerald"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "injerto"
+        ],
+        "best_method": "injerto",
+        "notas": "Muy rústica; tolera amplios rangos de suelo si hay buen drenaje."
+      },
+      "valor_pedagogico": "Lección de rusticidad: planta adaptada a suelos marginales que provee alta nutrición con poco manejo.",
+      "plagas_criticas": [
+        "Anastrepha spp. (mosca de la fruta)",
+        "Conotrachelus psidii"
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis",
+        "Roya de la guayaba"
+      ],
+      "source_ids": [
+        "fao-ecocrop",
+        "gbif-taxonomic-backbone",
+        "restrepo-1996-abc-agricultura-organica"
       ],
       "validation_level": "claude_draft"
     },
@@ -2475,6 +3115,7 @@
         "lactuca_sativa_longifolia_verde",
         "lactuca_sativa_roble_morada",
         "lactuca_sativa_roble_verde",
+        "passiflora_ligularis",
         "solanum_lycopersicum_cerasiforme"
       ],
       "antagonists": [
@@ -2573,6 +3214,237 @@
       "source_ids": [
         "gbif-taxonomic-backbone",
         "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "rubus_glaucus_sin_espinas",
+      "nombre_comun": "Mora andina sin espinas",
+      "nombre_cientifico": "Rubus glaucus Benth. 'Sin Espinas'",
+      "nombre_comunes_regionales": [
+        "Mora de Castilla mejorada",
+        "Thornless mora"
+      ],
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.2,
+        "optimo_max": 6.2,
+        "max": 6.8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 4,
+        "notas": "Sensible a heladas fuertes; prefiere laderas con drenaje de aire frío."
+      },
+      "companions": [
+        "rubus_idaeus_golden",
+        "rubus_idaeus_heritage"
+      ],
+      "antagonists": [
+        "solanum_phureja"
+      ],
+      "propagation": {
+        "methods": [
+          "acodo",
+          "esqueje"
+        ],
+        "best_method": "acodo de punta",
+        "notas": "Variedad seleccionada para facilitar la poda y cosecha sin espinas."
+      },
+      "valor_pedagogico": "Lección de mejoramiento varietal: caso de estudio sobre las ventajas del manejo ergonómico en la agricultura familiar.",
+      "plagas_criticas": [
+        "Drosophila suzukii",
+        "Perla de la tierra"
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis (Elsinoe veneta)",
+        "Mildeo polvoso"
+      ],
+      "source_ids": [
+        "sib-colombia",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "rubus_idaeus_golden",
+      "nombre_comun": "Frambuesa amarilla",
+      "nombre_cientifico": "Rubus idaeus 'Golden Queen' o similar",
+      "nombre_comunes_regionales": [
+        "Frambuesa de oro",
+        "Yellow raspberry"
+      ],
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 60,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2600,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 6.2,
+        "max": 6.8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -5,
+        "horas_acumuladas_max": 12,
+        "notas": "Excelente resistencia al frío."
+      },
+      "companions": [
+        "rubus_glaucus_sin_espinas",
+        "rubus_idaeus_heritage"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "division_mata"
+        ],
+        "best_method": "hijuelos",
+        "notas": "Crecimiento menos vigoroso que la roja pero frutos más dulces."
+      },
+      "valor_pedagogico": "Lección de pigmentos: comparación entre antocianinas y su ausencia, y su impacto en el sabor y nutrición.",
+      "plagas_criticas": [
+        "Áfidos",
+        "Drosophila suzukii"
+      ],
+      "enfermedades_criticas": [
+        "Botrytis cinerea"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "rubus_idaeus_heritage",
+      "nombre_comun": "Frambuesa roja",
+      "nombre_cientifico": "Rubus idaeus 'Heritage'",
+      "nombre_comunes_regionales": [
+        "Frambuesa remonta",
+        "Red raspberry"
+      ],
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 60,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2600,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "ph_suelo": {
+        "min": 5.0,
+        "optimo_min": 5.5,
+        "optimo_max": 6.5,
+        "max": 7.0
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -5,
+        "horas_acumuladas_max": 12,
+        "notas": "Altamente resistente al frío; la helada puede favorecer la parada vegetativa necesaria."
+      },
+      "companions": [
+        "rubus_glaucus_sin_espinas",
+        "rubus_idaeus_golden"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "division_mata",
+          "esqueje"
+        ],
+        "best_method": "hijuelos de raíz",
+        "notas": "Planta remonta (produce en tallos de primer y segundo año)."
+      },
+      "valor_pedagogico": "Lección de ciclo de tallo: enseña la diferencia entre floricanes y primocanes en plantas arbustivas.",
+      "plagas_criticas": [
+        "Drosophila suzukii",
+        "Ácaros"
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis",
+        "Oídio"
+      ],
+      "source_ids": [
+        "powo-kew",
+        "ica-resolucion-3168-2015"
       ],
       "validation_level": "claude_draft"
     },
@@ -2704,6 +3576,7 @@
         "lactuca_sativa_capitata",
         "melissa_officinalis",
         "petroselinum_crispum",
+        "physalis_peruviana",
         "raphanus_sativus",
         "urtica_dioica"
       ],
@@ -3095,6 +3968,7 @@
       "antagonists": [
         "cucurbita_maxima",
         "rubus_glaucus",
+        "rubus_glaucus_sin_espinas",
         "solanum_lycopersicum",
         "solanum_lycopersicum_cerasiforme",
         "solanum_lycopersicum_cerasiforme_uvalina",
@@ -3680,6 +4554,8 @@
       "agua": "alto",
       "drenaje_requerido": "medio",
       "companions": [
+        "passiflora_edulis_morada",
+        "passiflora_tripartita_mollissima",
         "rosmarinus_officinalis",
         "rubus_glaucus",
         "solanum_lycopersicum_cerasiforme",
@@ -3864,6 +4740,168 @@
         "restrepo-1996-abc-agricultura-organica",
         "pamplona-roger-2006-plantas-medicinales"
       ]
+    },
+    {
+      "id": "vaccinium_corymbosum_biloxi",
+      "nombre_comun": "Arándano Biloxi",
+      "nombre_cientifico": "Vaccinium corymbosum 'Biloxi'",
+      "nombre_comunes_regionales": [
+        "Blueberry Biloxi"
+      ],
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1700,
+        "optimo_max": 2400,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 4.0,
+        "optimo_min": 4.5,
+        "optimo_max": 5.2,
+        "max": 5.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -2,
+        "horas_acumuladas_max": 4,
+        "notas": "Requiere algunas horas frío pero 'Biloxi' es tolerante a calor tropical."
+      },
+      "companions": [
+        "vaccinium_corymbosum_emerald"
+      ],
+      "antagonists": [
+        "brassica_oleracea_capitata_alba",
+        "brassica_oleracea_capitata_rubra",
+        "brassica_oleracea_sabauda",
+        "physalis_peruviana",
+        "psidium_guajava_manzana"
+      ],
+      "propagation": {
+        "methods": [
+          "esqueje",
+          "micropropagacion"
+        ],
+        "best_method": "esqueje semileñoso",
+        "notas": "Suelo debe ser muy ácido y rico en materia orgánica leñosa."
+      },
+      "valor_pedagogico": "Lección de cultivares 'low-chill': explica cómo variedades seleccionadas florecen sin inviernos marcados.",
+      "plagas_criticas": [
+        "Drosophila suzukii",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora cinnamomi",
+        "Botrytis cinerea"
+      ],
+      "source_ids": [
+        "agrosavia-manual-arandano-2018",
+        "gbif-taxonomic-backbone"
+      ],
+      "validation_level": "claude_draft"
+    },
+    {
+      "id": "vaccinium_corymbosum_emerald",
+      "nombre_comun": "Arándano Emerald",
+      "nombre_cientifico": "Vaccinium corymbosum 'Emerald'",
+      "nombre_comunes_regionales": [
+        "Blueberry temprano"
+      ],
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1700,
+        "optimo_max": 2400,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 15,
+        "optimo_max": 25,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 4.0,
+        "optimo_min": 4.5,
+        "optimo_max": 5.2,
+        "max": 5.8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -1,
+        "horas_acumuladas_max": 3,
+        "notas": "Variedad vigorosa con baja necesidad de frío (low-chill)."
+      },
+      "companions": [
+        "vaccinium_corymbosum_biloxi"
+      ],
+      "antagonists": [
+        "brassica_oleracea_acephala_curly",
+        "brassica_oleracea_acephala_lacinato",
+        "brassica_oleracea_acephala_red_russian",
+        "physalis_peruviana",
+        "psidium_guajava_manzana"
+      ],
+      "propagation": {
+        "methods": [
+          "esqueje",
+          "micropropagacion"
+        ],
+        "best_method": "esqueje",
+        "notas": "Sensible a la salinidad en el agua de riego."
+      },
+      "valor_pedagogico": "Lección de precocidad: variedad que permite entender la importancia de la ventana de cosecha temprana.",
+      "plagas_criticas": [
+        "Mosquita de la agalla",
+        "Pájaros"
+      ],
+      "enfermedades_criticas": [
+        "Botrytis cinerea",
+        "Roya del arándano"
+      ],
+      "source_ids": [
+        "agrosavia-manual-arandano-2018",
+        "powo-kew"
+      ],
+      "validation_level": "claude_draft"
     }
   ],
   "biopreparados": [
@@ -4222,11 +5260,27 @@
       "observaciones": "STUB migrado de v3.0."
     },
     {
+      "id": "agrosavia-manual-arandano-2018",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2018,
+      "titulo": "Manual técnico para el cultivo de arándano (Vaccinium corymbosum) en Colombia",
+      "institucion": "AGROSAVIA"
+    },
+    {
       "id": "agrosavia-manual-biopreparados-2015",
       "tipo": "manual_tecnico",
       "autores": "AGROSAVIA",
       "año": 2015,
       "titulo": "Manual de biopreparados para la agricultura colombiana",
+      "institucion": "AGROSAVIA"
+    },
+    {
+      "id": "agrosavia-manual-uchuva-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual técnico para el cultivo de uchuva (Physalis peruviana) bajo condiciones colombianas",
       "institucion": "AGROSAVIA"
     },
     {
@@ -4272,6 +5326,15 @@
       "titulo": "Protocolos de manejo de especies invasoras en jurisdicción CAR",
       "institucion": "CAR Cundinamarca",
       "observaciones": "STUB migrado de v3.0 — número de resolución pendiente."
+    },
+    {
+      "id": "cenicafe-manual-cafetero-2013",
+      "tipo": "manual_tecnico",
+      "autores": "Cenicafé",
+      "año": 2013,
+      "titulo": "Manual del Cafetero Colombiano — Investigación y tecnología para la sostenibilidad de la caficultura",
+      "institucion": "Centro Nacional de Investigaciones de Café (Cenicafé)",
+      "url": "https://www.cenicafe.org/es/index.php/nuestras_publicaciones"
     },
     {
       "id": "cenicafe-trichoderma-2010",


### PR DESCRIPTION
## Summary

PR de cierre del poblamiento Guatoc 2026. Continuación de PR #60 que squash-mergeó solo el primer batch (hortalizas 12 sp). Esta PR añade los 4 lotes restantes que quedaron sin entrar al merge anterior.

| Lote | Familia(s) | Cantidad | Piso térmico |
|------|-----------|----------|--------------|
| **D1** Aromáticas/raíces | Apiaceae+Lamiaceae+Poaceae+Alliaceae | 11 | frío 1800-2800m |
| **D2** Brassica+Solanaceae | Brassicaceae+Solanaceae | 10 | frío 1800-2800m |
| **B1** Café+Pasifloras | Rubiaceae+Passifloraceae | 5 | subandino 1500-2200m |
| **B2** Berries+Frutales | Ericaceae+Rosaceae+Myrtaceae+Solanaceae | 8 | subandino 1700-2700m |
| **C** Leguminosas+Cereales | Poaceae+Fabaceae | 3 | frío+subandino |
| **Total** | | **37** | — |

### Sources nuevas (4)

- `cenicafe-manual-cafetero-2013` (B1)
- `agrosavia-manual-arandano-2018`, `agrosavia-manual-uchuva-2015` (B2)
- `agrosavia-manual-chachafruto-2015` (C)

### Validación final

```
$ node scripts/validate-catalog.mjs --seed-mode
✓ Schema v3.1 PASS
✓ AMB-05 altitud chain
✓ AMB-10 companions/antagonists symmetry
✓ AMB-14 invasor consistency
✓ AMB-15 scale_viability ↔ manejo_por_escala
✓ Catálogo válido — 55 especies, 16 biopreparados, 51 sources
```

### Fixes Antigravity heredados

- `category 'frutales_arbustivos'` → `frutales_perennes`
- `propagation.methods`: hijuelos→division_mata, esqueje_raiz→esqueje, cultivo_tejidos→micropropagacion
- `roles_in_guild 'shade_provider'` → `nurse_plant`
- `max_absolute` → `max_absoluto`

### Origen

Pipeline ADR-025 generación assistida 3-LLM (Antigravity primario + Claude validation post-hoc), output validado contra schema-v3.1.json + reglas semánticas AMB-05/10/11/13/14/15. Cross-batch symmetry pass aplicada en cada merge.

### Notas merge

PR #60 squash-mergeó solo el primer commit (`65fce63`) cuando los siguientes 3 commits aún no estaban pusheados. Esta PR replica esos commits limpiamente desde main actual sin conflictos.

## Test plan

- [ ] CI green (CodeQL + Playwright)
- [ ] \`node scripts/validate-catalog.mjs --seed-mode\` localmente
- [ ] \`npm run build:catalog\` produce SQLite sin errores
- [ ] Smoke test PWA — SpeciesSelect ve las 36 nuevas + filtros thermal_zone

🤖 Generated with [Claude Code](https://claude.com/claude-code)