### PR TITLE
fix(codeql): remove unused basename import

### DIFF
--- a/scripts/md-fichas-to-catalog-json.mjs
+++ b/scripts/md-fichas-to-catalog-json.mjs
@@ -40,7 +40,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
-import { resolve, dirname, join, basename } from 'node:path';
+import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Closes CodeQL alert #28. `basename` se importaba pero no se usaba en el script. Single-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)