### PR TITLE
feat(inventory): event sourcing ADR-027 Alt E + 8 eventos canónicos

### DIFF
--- a/src/components/InventoryAuditTrail.jsx
+++ b/src/components/InventoryAuditTrail.jsx
@@ -1,0 +1,146 @@
+/**
+ * InventoryAuditTrail — bitácora completa de events por item.
+ *
+ * Cumple ADR-019: muestra TODOS los events incluyendo los "perdidos" en la
+ * proyección (counted que reanchoró logs anteriores, idempotency duplicados).
+ *
+ * UX: scrollable timeline con badges por event_type. Hover muestra detalle.
+ */
+
+import { useEffect, useState } from 'react';
+import { getEventsForItem } from '../services/inventoryService.js';
+import { EVENT_TYPES } from '../services/inventoryEvents.js';
+
+const TYPE_BADGES = {
+  [EVENT_TYPES.RECEIVED]:    { label: 'recibido',    color: '#22c55e', sign: '+' },
+  [EVENT_TYPES.CONSUMED]:    { label: 'consumido',   color: '#0E92A6', sign: '−' },
+  [EVENT_TYPES.TRANSFORMED]: { label: 'transformado', color: '#a78bfa', sign: '↺' },
+  [EVENT_TYPES.COUNTED]:     { label: 'conteo',      color: '#f59e0b', sign: '⚓' },
+  [EVENT_TYPES.ADJUSTED]:    { label: 'ajuste',      color: '#fb923c', sign: '±' },
+  [EVENT_TYPES.TRANSFERRED]: { label: 'movido',      color: '#60a5fa', sign: '→' },
+  [EVENT_TYPES.LOST]:        { label: 'perdido',     color: '#ef4444', sign: '✗' },
+  [EVENT_TYPES.PRODUCED]:    { label: 'producido',   color: '#22c55e', sign: '+' },
+};
+
+function formatTimestamp(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleString('es-CO', { dateStyle: 'short', timeStyle: 'short' });
+}
+
+function deltaForEvent(event) {
+  const p = event.payload || {};
+  switch (event.event_type) {
+    case EVENT_TYPES.RECEIVED:
+    case EVENT_TYPES.PRODUCED:
+      return `+${p.delta} ${p.unit || ''}`;
+    case EVENT_TYPES.CONSUMED:
+    case EVENT_TYPES.LOST:
+      return `${p.delta} ${p.unit || ''}`; // delta es negativo
+    case EVENT_TYPES.ADJUSTED:
+      return `${p.delta > 0 ? '+' : ''}${p.delta} (${p.reason})`;
+    case EVENT_TYPES.COUNTED:
+      return `= ${p.counted_qty} ${p.unit || ''}`;
+    case EVENT_TYPES.TRANSFORMED:
+      return `inputs ${(p.inputs || []).length} → outputs ${(p.outputs || []).length}`;
+    case EVENT_TYPES.TRANSFERRED:
+      return `${p.qty} ${p.unit || ''} → ${p.to_location_id?.slice(0, 8)}`;
+    default:
+      return '—';
+  }
+}
+
+export default function InventoryAuditTrail({ itemId }) {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!itemId) return;
+    let mounted = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const evts = await getEventsForItem(itemId);
+        if (mounted) setEvents(evts);
+      } catch (e) {
+        if (mounted) setError(e.message || 'Error cargando bitácora');
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, [itemId]);
+
+  if (loading) return <div>Cargando bitácora…</div>;
+  if (error) return <div style={{ color: 'var(--err)' }}>{error}</div>;
+  if (events.length === 0) {
+    return (
+      <p style={{ color: 'var(--fg-dim)', fontSize: '0.85rem', textAlign: 'center', padding: '1rem' }}>
+        Sin events registrados para este item.
+      </p>
+    );
+  }
+
+  // Mostrar más recientes primero
+  const sorted = [...events].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+  return (
+    <section style={{ padding: '1rem', maxWidth: 720, margin: '0 auto' }}>
+      <h3 style={{ marginBottom: '1rem', fontSize: '1rem' }}>
+        Bitácora · {itemId} ({events.length} events)
+      </h3>
+      <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {sorted.map((event) => {
+          const badge = TYPE_BADGES[event.event_type] || { label: event.event_type, color: '#666', sign: '?' };
+          return (
+            <li
+              key={event.id}
+              style={{
+                display: 'flex',
+                gap: '0.75rem',
+                padding: '0.75rem 0',
+                borderBottom: '1px solid var(--border, #30363d)',
+              }}
+              title={`ULID: ${event.id}\nDevice: ${event.device_id_lex_hash} (seq ${event.sequence_number})\nIdempotency: ${event.idempotency_key}\nOperator: ${event.operator_id_hash.slice(0, 12)}…`}
+            >
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: '50%',
+                  background: badge.color,
+                  color: 'white',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: '0.85rem',
+                  fontWeight: 700,
+                  flexShrink: 0,
+                }}
+              >
+                {badge.sign}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                  <strong style={{ fontSize: '0.85rem', color: badge.color }}>{badge.label}</strong>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--fg-dim, #8b949e)' }}>
+                    {formatTimestamp(event.timestamp)}
+                  </span>
+                </div>
+                <div style={{ fontSize: '0.9rem', fontFamily: 'monospace', marginTop: '0.25rem' }}>
+                  {deltaForEvent(event)}
+                </div>
+                {event.notes && (
+                  <div style={{ fontSize: '0.8rem', color: 'var(--fg-dim, #8b949e)', marginTop: '0.25rem', fontStyle: 'italic' }}>
+                    "{event.notes}"
+                  </div>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/RecountDrawer.jsx
+++ b/src/components/RecountDrawer.jsx
@@ -1,0 +1,185 @@
+/**
+ * RecountDrawer — drawer modal para emitir un evento `inventory_counted`.
+ *
+ * UX clave: el conteo manual NO destruye el log histórico. Reanchora el
+ * stock al valor manual en T, descartando contribuciones anteriores en la
+ * proyección. Pero los events anteriores siguen visibles en la bitácora
+ * (AuditTrail).
+ *
+ * El operador entiende:
+ *   "Estoy diciendo que AHORA hay X kg. Lo que el sistema decía antes
+ *    queda registrado pero NO afecta el cálculo desde este momento."
+ */
+
+import { useState } from 'react';
+import { appendEvent } from '../services/inventoryService.js';
+import { createInventoryEvent, EVENT_TYPES, VALID_UNITS } from '../services/inventoryEvents.js';
+import { getCurrentOperatorHash } from '../services/operatorIdentityService.js';
+
+export default function RecountDrawer({ itemId, currentQty, currentUnit, onClose, onSubmitted }) {
+  const [countedQty, setCountedQty] = useState(currentQty ?? 0);
+  const [unit, setUnit] = useState(currentUnit || 'kg');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const operatorHash = getCurrentOperatorHash();
+      if (!operatorHash) {
+        throw new Error('No hay operador activo. Login requerido.');
+      }
+      const event = await createInventoryEvent(
+        EVENT_TYPES.COUNTED,
+        {
+          item_id: itemId,
+          counted_qty: Number(countedQty),
+          unit,
+          notes: notes.trim() || undefined,
+        },
+        { operator_id_hash: operatorHash }
+      );
+      await appendEvent(event);
+      onSubmitted?.(event);
+      onClose?.();
+    } catch (e) {
+      setError(e.message || 'Error al persistir conteo');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.6)',
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--card-bg, #0e1116)',
+          padding: '1.5rem',
+          borderTopLeftRadius: 16,
+          borderTopRightRadius: 16,
+          width: '100%',
+          maxWidth: 520,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header style={{ marginBottom: '1rem' }}>
+          <h2 style={{ margin: 0, fontSize: '1.1rem' }}>Conteo manual</h2>
+          <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--fg-dim, #8b949e)' }}>
+            <strong>{itemId}</strong> — esto reanchora el stock SIN borrar logs.
+          </p>
+        </header>
+
+        <form onSubmit={handleSubmit}>
+          <label style={{ display: 'block', marginBottom: '1rem' }}>
+            <span style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem' }}>
+              Cantidad real contada físicamente
+            </span>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              value={countedQty}
+              onChange={(e) => setCountedQty(e.target.value)}
+              required
+              autoFocus
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                fontSize: '1.4rem',
+                fontWeight: 600,
+                background: 'transparent',
+                border: '1px solid var(--border, #30363d)',
+                borderRadius: 6,
+                color: 'inherit',
+              }}
+            />
+          </label>
+
+          <label style={{ display: 'block', marginBottom: '1rem' }}>
+            <span style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem' }}>
+              Unidad
+            </span>
+            <select
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                background: 'transparent',
+                border: '1px solid var(--border, #30363d)',
+                borderRadius: 6,
+                color: 'inherit',
+              }}
+            >
+              {[...VALID_UNITS].sort().map((u) => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </label>
+
+          <label style={{ display: 'block', marginBottom: '1rem' }}>
+            <span style={{ display: 'block', fontSize: '0.85rem', marginBottom: '0.25rem' }}>
+              Nota (opcional, ej: "post deterioro abr 2026")
+            </span>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              maxLength={500}
+              rows={2}
+              style={{
+                width: '100%',
+                padding: '0.5rem',
+                background: 'transparent',
+                border: '1px solid var(--border, #30363d)',
+                borderRadius: 6,
+                color: 'inherit',
+                fontFamily: 'inherit',
+              }}
+            />
+          </label>
+
+          {error && (
+            <div role="alert" style={{ color: 'var(--err, #ef4444)', marginBottom: '1rem' }}>
+              {error}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <button type="button" onClick={onClose} disabled={submitting}>
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              style={{
+                background: 'var(--accent, #0E92A6)',
+                color: 'white',
+                fontWeight: 600,
+              }}
+            >
+              {submitting ? 'Guardando…' : 'Reanchorar stock'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -5,7 +5,7 @@
  * manuales previas en assetCache.js y syncManager.js, evitando race conditions
  * de `onupgradeneeded` duplicado y garantizando una sola versión activa.
  *
- * Esquema v6:
+ * Esquema v7 (2026-04-29):
  *   - assets               (keyPath: id; indexes: asset_type, cached_at)
  *   - taxonomy_terms       (keyPath: id; indexes: type)
  *   - sync_meta            (keyPath: key)
@@ -13,11 +13,14 @@
  *   - pending_tasks        (keyPath: id; indexes: timestamp, status)
  *   - logs                 (keyPath: id; indexes: asset_id, timestamp, type)
  *   - media_cache          (keyPath: id, autoIncrement; indexes: logId, createdAt)
- *   - pending_voice_recordings (v0.5.0: keyPath: id, autoIncrement; indexes: createdAt, status)
+ *   - pending_voice_recordings (v0.5.0: keyPath: id, autoIncrement)
+ *   - inventory_events     (v7 ADR-027.i+ii: keyPath: id ULID; indexes:
+ *                           item_id, timestamp, event_type, idempotency_key)
+ *   - inventory_stock_snapshot (v7: materialized view, keyPath: item_id)
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 6;
+export const DB_VERSION = 7;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -28,6 +31,8 @@ export const STORES = {
   PENDING_TASKS: 'pending_tasks', // @deprecated: usar LOGS con type='log--task'
   MEDIA_CACHE: 'media_cache',
   PENDING_VOICE: 'pending_voice_recordings',
+  INVENTORY_EVENTS: 'inventory_events',
+  INVENTORY_STOCK: 'inventory_stock_snapshot',
 };
 
 let dbInstance = null;
@@ -98,6 +103,24 @@ export const openDB = async () => {
         const store = db.createObjectStore(STORES.PENDING_VOICE, { keyPath: 'id', autoIncrement: true });
         store.createIndex('createdAt', 'createdAt', { unique: false });
         store.createIndex('status', 'status', { unique: false });
+      }
+
+      // v7: inventory_events — log append-only ADR-019 + ADR-027.i+ii.
+      // Append-only inmutable. Reconciliación post-sync por timestamp +
+      // device_id_lex_hash + sequence_number.
+      if (!db.objectStoreNames.contains(STORES.INVENTORY_EVENTS)) {
+        const store = db.createObjectStore(STORES.INVENTORY_EVENTS, { keyPath: 'id' });
+        store.createIndex('item_id', 'payload.item_id', { unique: false });
+        store.createIndex('timestamp', 'timestamp', { unique: false });
+        store.createIndex('event_type', 'event_type', { unique: false });
+        store.createIndex('idempotency_key', 'idempotency_key', { unique: false });
+      }
+
+      // v7: inventory_stock_snapshot — materialized view derivada de
+      // inventory_events. Reconstruible desde scratch en cualquier momento
+      // (cumple ADR-019 — log es source of truth, esto es solo cache O(1)).
+      if (!db.objectStoreNames.contains(STORES.INVENTORY_STOCK)) {
+        db.createObjectStore(STORES.INVENTORY_STOCK, { keyPath: 'item_id' });
       }
     };
 

--- a/src/pages/InventoryPage.jsx
+++ b/src/pages/InventoryPage.jsx
@@ -1,0 +1,97 @@
+/**
+ * InventoryPage — orquesta los 3 componentes del flujo inventario.
+ *
+ * Estado local:
+ *   - selectedItemId: cuál ítem está siendo editado / inspeccionado
+ *   - viewMode: 'dashboard' | 'audit' — dashboard por default, audit al click
+ *   - recountTarget: si != null, abre el RecountDrawer
+ *
+ * Refresh strategy: después de cada appendEvent exitoso, recargar el
+ * componente Dashboard cambiando una `refreshKey` que dispara su useEffect.
+ *
+ * Para integrar en App.jsx:
+ *   import InventoryPage from './pages/InventoryPage';
+ *   ...
+ *   <Route path="/inventario" element={<InventoryPage />} />
+ *
+ * Role-gate recomendado (no implementado acá):
+ *   - Solo usuarios con rol 'operador' o superior
+ *   - Owner ve todos los items
+ *   - Operadores comunes ven solo items que aplican a sus parcelas (futuro)
+ */
+
+import { useState, useCallback } from 'react';
+import InventoryDashboard from '../components/InventoryDashboard.jsx';
+import InventoryAuditTrail from '../components/InventoryAuditTrail.jsx';
+import RecountDrawer from '../components/RecountDrawer.jsx';
+
+export default function InventoryPage() {
+  const [selectedItemId, setSelectedItemId] = useState(null);
+  const [viewMode, setViewMode] = useState('dashboard');
+  const [recountTarget, setRecountTarget] = useState(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleRecount = useCallback((itemId) => {
+    setRecountTarget({ itemId });
+  }, []);
+
+  const handleRecountSubmitted = useCallback(() => {
+    setRefreshKey((k) => k + 1);
+    setRecountTarget(null);
+  }, []);
+
+  const handleViewAudit = useCallback((itemId) => {
+    setSelectedItemId(itemId);
+    setViewMode('audit');
+  }, []);
+
+  const handleBackToDashboard = useCallback(() => {
+    setSelectedItemId(null);
+    setViewMode('dashboard');
+  }, []);
+
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--bg, #0e1116)' }}>
+      {viewMode === 'dashboard' ? (
+        <>
+          <header style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--border, #30363d)' }}>
+            <h1 style={{ margin: 0, fontSize: '1.2rem' }}>Inventario</h1>
+            <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--fg-dim, #8b949e)' }}>
+              Stock en vivo · ADR-027 event sourcing · Local-first
+            </p>
+          </header>
+          <InventoryDashboard
+            key={refreshKey}
+            onRecount={handleRecount}
+            onViewAudit={handleViewAudit}
+          />
+        </>
+      ) : (
+        <>
+          <header style={{ padding: '1rem 1.5rem', borderBottom: '1px solid var(--border, #30363d)', display: 'flex', alignItems: 'center', gap: '1rem' }}>
+            <button onClick={handleBackToDashboard} aria-label="Volver al dashboard">
+              ← Volver
+            </button>
+            <h1 style={{ margin: 0, fontSize: '1.1rem' }}>Bitácora · {selectedItemId}</h1>
+          </header>
+          <InventoryAuditTrail itemId={selectedItemId} />
+          <div style={{ padding: '1rem', textAlign: 'center' }}>
+            <button onClick={() => handleRecount(selectedItemId)}>
+              ± Conteo manual de este item
+            </button>
+          </div>
+        </>
+      )}
+
+      {recountTarget && (
+        <RecountDrawer
+          itemId={recountTarget.itemId}
+          currentQty={recountTarget.currentQty}
+          currentUnit={recountTarget.currentUnit}
+          onClose={() => setRecountTarget(null)}
+          onSubmitted={handleRecountSubmitted}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/services/__tests__/inventoryService.fixture.test.js
+++ b/src/services/__tests__/inventoryService.fixture.test.js
@@ -1,0 +1,180 @@
+/**
+ * inventoryService — tests fixture de la proyección pura.
+ *
+ * Verifica las garantías de ADR-027 Alt E:
+ *   1. Determinismo: dos runs sobre los mismos events producen el mismo stock.
+ *   2. Conteo manual reanchora correctamente (LWW honesto).
+ *   3. Idempotency dedupe: events duplicados no doblan el stock.
+ *   4. Orden canónico (timestamp + device + sequence) consistente.
+ *
+ * Estos tests NO requieren IndexedDB — son sobre la función pura projectStock().
+ * Para integration tests con IndexedDB, ver e2e Playwright tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { projectStock, compareEventOrder } from '../inventoryService.js';
+import { EVENT_TYPES } from '../inventoryEvents.js';
+
+// Helper — construye un event con defaults sanos
+function evt(eventType, payload, opts = {}) {
+  return {
+    id: opts.id || crypto.randomUUID().replace(/-/g, '').slice(0, 26).toUpperCase(),
+    event_type: eventType,
+    timestamp: opts.timestamp || new Date().toISOString(),
+    device_id_lex_hash: opts.device || 'AAAA0000',
+    sequence_number: opts.seq ?? 1,
+    operator_id_hash: 'a'.repeat(64),
+    idempotency_key: opts.idempotency_key || `${eventType}:${payload.item_id || 'x'}:${Math.random()}`,
+    payload,
+    schema_version: '1',
+  };
+}
+
+describe('projectStock — determinismo', () => {
+  it('un solo received → stock igual al delta', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra' }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost-A').quantity).toBe(50);
+    expect(stock.get('compost-A').unit).toBe('kg');
+  });
+
+  it('received + consumed → suma correcta', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00' }),
+      evt(EVENT_TYPES.CONSUMED, { item_id: 'compost-A', delta: -15, unit: 'kg' },
+        { timestamp: '2026-04-29T10:00:00-05:00' }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost-A').quantity).toBe(35);
+  });
+
+  it('orden de input no afecta el output (insertion-order independence)', () => {
+    const e1 = evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra' },
+      { timestamp: '2026-04-29T08:00:00-05:00', seq: 1 });
+    const e2 = evt(EVENT_TYPES.CONSUMED, { item_id: 'compost-A', delta: -15, unit: 'kg' },
+      { timestamp: '2026-04-29T10:00:00-05:00', seq: 2 });
+    const e3 = evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 30, unit: 'kg', source: 'cosecha' },
+      { timestamp: '2026-04-29T12:00:00-05:00', seq: 3 });
+
+    const order1 = projectStock([e1, e2, e3]);
+    const order2 = projectStock([e3, e1, e2]);
+    const order3 = projectStock([e2, e3, e1]);
+
+    expect(order1.get('compost-A').quantity).toBe(65);
+    expect(order2.get('compost-A').quantity).toBe(65);
+    expect(order3.get('compost-A').quantity).toBe(65);
+  });
+});
+
+describe('projectStock — counted reanchora', () => {
+  it('counted descarta contribuciones anteriores y reancla', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00', seq: 1 }),
+      evt(EVENT_TYPES.CONSUMED, { item_id: 'compost-A', delta: -15, unit: 'kg' },
+        { timestamp: '2026-04-29T10:00:00-05:00', seq: 2 }),
+      // Operador cuenta físicamente: solo hay 30 kg (debió haber 35)
+      evt(EVENT_TYPES.COUNTED, { item_id: 'compost-A', counted_qty: 30, unit: 'kg', notes: 'recount post deterioro' },
+        { timestamp: '2026-04-29T14:00:00-05:00', seq: 3 }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost-A').quantity).toBe(30);
+  });
+
+  it('counted seguido de consumed → counted gana hasta el counted, después acumula', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00', seq: 1 }),
+      evt(EVENT_TYPES.COUNTED, { item_id: 'compost-A', counted_qty: 40, unit: 'kg' },
+        { timestamp: '2026-04-29T10:00:00-05:00', seq: 2 }),
+      evt(EVENT_TYPES.CONSUMED, { item_id: 'compost-A', delta: -10, unit: 'kg' },
+        { timestamp: '2026-04-29T12:00:00-05:00', seq: 3 }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost-A').quantity).toBe(30);
+  });
+});
+
+describe('projectStock — idempotency dedupe', () => {
+  it('events duplicados con misma idempotency_key NO doblan el stock', () => {
+    const sharedKey = 'inventory_received:compost-A:compra:proveedor-X:2026-04-29';
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra', provider_ref: 'proveedor-X' },
+        { timestamp: '2026-04-29T08:00:00-05:00', idempotency_key: sharedKey, seq: 1 }),
+      // Mismo event re-enviado por sync retry — debe ser dedupe
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra', provider_ref: 'proveedor-X' },
+        { timestamp: '2026-04-29T08:00:00-05:00', idempotency_key: sharedKey, seq: 2 }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost-A').quantity).toBe(50); // NO 100
+  });
+
+  it('events con diferente idempotency_key SÍ se acumulan (compras distintas)', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 50, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00', idempotency_key: 'k-1', seq: 1 }),
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost-A', delta: 30, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T09:00:00-05:00', idempotency_key: 'k-2', seq: 2 }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost-A').quantity).toBe(80);
+  });
+});
+
+describe('projectStock — transformed (compost, biopreparados)', () => {
+  it('transformed resta inputs y suma outputs', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'gallinaza', delta: 40, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00', seq: 1 }),
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'cascarilla-arroz', delta: 40, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:30:00-05:00', seq: 2 }),
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'melaza', delta: 4, unit: 'litro', source: 'compra' },
+        { timestamp: '2026-04-29T09:00:00-05:00', seq: 3 }),
+      // Bocashi — transformación atómica
+      evt(EVENT_TYPES.TRANSFORMED, {
+        inputs: [
+          { item_id: 'gallinaza', delta_consumido: 40, unit: 'kg' },
+          { item_id: 'cascarilla-arroz', delta_consumido: 40, unit: 'kg' },
+          { item_id: 'melaza', delta_consumido: 4, unit: 'litro' },
+        ],
+        outputs: [
+          { item_id: 'bocashi', delta_producido: 80, unit: 'kg' },
+        ],
+        recipe_id: 'recipe-bocashi-v1',
+      }, { timestamp: '2026-04-29T10:00:00-05:00', seq: 4 }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('gallinaza').quantity).toBe(0);
+    expect(stock.get('cascarilla-arroz').quantity).toBe(0);
+    expect(stock.get('melaza').quantity).toBe(0);
+    expect(stock.get('bocashi').quantity).toBe(80);
+  });
+});
+
+describe('projectStock — orden canónico (timestamp + device + sequence)', () => {
+  it('mismo timestamp pero distinto device → orden lexicográfico', () => {
+    const events = [
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost', delta: 10, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00', device: 'BBBB1111', seq: 1 }),
+      evt(EVENT_TYPES.RECEIVED, { item_id: 'compost', delta: 5, unit: 'kg', source: 'compra' },
+        { timestamp: '2026-04-29T08:00:00-05:00', device: 'AAAA0000', seq: 1 }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('compost').quantity).toBe(15);
+    // El orden canónico debe ser determinista — A antes que B
+    expect(stock.get('compost').last_event_id).toBe(events[0].id); // timestamp ties → device 'BBBB1111' is later
+  });
+
+  it('compareEventOrder es determinista', () => {
+    const a = evt(EVENT_TYPES.RECEIVED, { item_id: 'x', delta: 1, unit: 'kg', source: 'compra' },
+      { timestamp: '2026-04-29T08:00:00-05:00', device: 'AAAA0000', seq: 1 });
+    const b = evt(EVENT_TYPES.RECEIVED, { item_id: 'x', delta: 1, unit: 'kg', source: 'compra' },
+      { timestamp: '2026-04-29T08:00:00-05:00', device: 'AAAA0000', seq: 2 });
+    expect(compareEventOrder(a, b)).toBeLessThan(0);
+    expect(compareEventOrder(b, a)).toBeGreaterThan(0);
+    expect(compareEventOrder(a, a)).toBe(0);
+  });
+});

--- a/src/services/inventoryEvents.js
+++ b/src/services/inventoryEvents.js
@@ -1,0 +1,264 @@
+/**
+ * inventoryEvents — runtime validators + factory para los 8 tipos canónicos
+ * de eventos de inventario (ADR-027.i + ADR-027.ii).
+ *
+ * NO usa Zod (dependencia externa) — validación inline minimal pero estricta.
+ * El log es append-only inmutable: una vez escrito, NUNCA se modifica.
+ *
+ * Para corregir un error operacional → emitir `inventory_adjusted` con razón.
+ * Para reanchorar stock manual → emitir `inventory_counted` (LWW honesto).
+ */
+
+import { ulid } from 'ulid';
+
+// ─── Enums canónicos ─────────────────────────────────────────────────
+
+export const EVENT_TYPES = Object.freeze({
+  RECEIVED: 'inventory_received',
+  CONSUMED: 'inventory_consumed',
+  TRANSFORMED: 'inventory_transformed',
+  COUNTED: 'inventory_counted',
+  ADJUSTED: 'inventory_adjusted',
+  TRANSFERRED: 'inventory_transferred',
+  LOST: 'inventory_lost',
+  PRODUCED: 'inventory_produced',
+});
+
+export const VALID_EVENT_TYPES = new Set(Object.values(EVENT_TYPES));
+
+export const VALID_UNITS = new Set([
+  'kg', 'g', 'litro', 'ml', 'unidad', 'm2', 'paquete', 'bolsa', 'galon',
+]);
+
+export const VALID_RECEIVED_SOURCES = new Set([
+  'compra', 'cosecha', 'donacion', 'transferencia_in',
+]);
+
+export const VALID_ADJUSTED_REASONS = new Set([
+  'error_registro', 'recategorizacion', 'correccion_unidad',
+]);
+
+export const VALID_LOST_CAUSES = new Set([
+  'derrame', 'plaga', 'vencimiento', 'daño_climatico', 'roedor', 'desconocido',
+]);
+
+// ─── Validación ──────────────────────────────────────────────────────
+
+class ValidationError extends Error {
+  constructor(field, expected, got) {
+    super(`Invalid ${field}: expected ${expected}, got ${JSON.stringify(got)}`);
+    this.field = field;
+    this.expected = expected;
+    this.got = got;
+  }
+}
+
+function assertString(field, value, opts = {}) {
+  if (typeof value !== 'string') throw new ValidationError(field, 'string', value);
+  if (opts.minLen != null && value.length < opts.minLen) throw new ValidationError(field, `string len ≥ ${opts.minLen}`, value);
+  if (opts.maxLen != null && value.length > opts.maxLen) throw new ValidationError(field, `string len ≤ ${opts.maxLen}`, value);
+  if (opts.regex && !opts.regex.test(value)) throw new ValidationError(field, `regex ${opts.regex}`, value);
+  if (opts.oneOf && !opts.oneOf.has(value)) throw new ValidationError(field, `one of ${[...opts.oneOf].join('|')}`, value);
+}
+
+function assertNumber(field, value, opts = {}) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new ValidationError(field, 'finite number', value);
+  if (opts.min != null && value < opts.min) throw new ValidationError(field, `number ≥ ${opts.min}`, value);
+  if (opts.max != null && value > opts.max) throw new ValidationError(field, `number ≤ ${opts.max}`, value);
+  if (opts.integer && !Number.isInteger(value)) throw new ValidationError(field, 'integer', value);
+}
+
+function assertNonEmptyArray(field, value) {
+  if (!Array.isArray(value) || value.length === 0) throw new ValidationError(field, 'non-empty array', value);
+}
+
+const ULID_REGEX = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const ISO_DATETIME_OFFSET_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2}|Z)$/;
+
+// ─── Validador de payload por event_type ─────────────────────────────
+
+function validatePayload(eventType, payload) {
+  if (typeof payload !== 'object' || payload == null) {
+    throw new ValidationError('payload', 'object', payload);
+  }
+  switch (eventType) {
+    case EVENT_TYPES.RECEIVED:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertNumber('payload.delta', payload.delta, { min: 0 });
+      assertString('payload.unit', payload.unit, { oneOf: VALID_UNITS });
+      assertString('payload.source', payload.source, { oneOf: VALID_RECEIVED_SOURCES });
+      if (payload.provider_ref != null) assertString('payload.provider_ref', payload.provider_ref, { maxLen: 200 });
+      break;
+
+    case EVENT_TYPES.CONSUMED:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertNumber('payload.delta', payload.delta, { max: 0 }); // negativo
+      assertString('payload.unit', payload.unit, { oneOf: VALID_UNITS });
+      if (payload.application_log_ref != null) assertString('payload.application_log_ref', payload.application_log_ref);
+      break;
+
+    case EVENT_TYPES.TRANSFORMED:
+      assertNonEmptyArray('payload.inputs', payload.inputs);
+      assertNonEmptyArray('payload.outputs', payload.outputs);
+      payload.inputs.forEach((inp, i) => {
+        assertString(`payload.inputs[${i}].item_id`, inp.item_id, { minLen: 1 });
+        assertNumber(`payload.inputs[${i}].delta_consumido`, inp.delta_consumido, { min: 0 });
+        assertString(`payload.inputs[${i}].unit`, inp.unit, { oneOf: VALID_UNITS });
+      });
+      payload.outputs.forEach((out, i) => {
+        assertString(`payload.outputs[${i}].item_id`, out.item_id, { minLen: 1 });
+        assertNumber(`payload.outputs[${i}].delta_producido`, out.delta_producido, { min: 0 });
+        assertString(`payload.outputs[${i}].unit`, out.unit, { oneOf: VALID_UNITS });
+      });
+      if (payload.recipe_id != null) assertString('payload.recipe_id', payload.recipe_id);
+      break;
+
+    case EVENT_TYPES.COUNTED:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertNumber('payload.counted_qty', payload.counted_qty, { min: 0 });
+      assertString('payload.unit', payload.unit, { oneOf: VALID_UNITS });
+      if (payload.notes != null) assertString('payload.notes', payload.notes, { maxLen: 500 });
+      break;
+
+    case EVENT_TYPES.ADJUSTED:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertNumber('payload.delta', payload.delta);
+      assertString('payload.reason', payload.reason, { oneOf: VALID_ADJUSTED_REASONS });
+      break;
+
+    case EVENT_TYPES.TRANSFERRED:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertString('payload.from_location_id', payload.from_location_id, { minLen: 1 });
+      assertString('payload.to_location_id', payload.to_location_id, { minLen: 1 });
+      assertNumber('payload.qty', payload.qty, { min: 0 });
+      break;
+
+    case EVENT_TYPES.LOST:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertNumber('payload.delta', payload.delta, { max: 0 });
+      assertString('payload.cause', payload.cause, { oneOf: VALID_LOST_CAUSES });
+      if (payload.evidence_photo_ref != null) assertString('payload.evidence_photo_ref', payload.evidence_photo_ref);
+      break;
+
+    case EVENT_TYPES.PRODUCED:
+      assertString('payload.item_id', payload.item_id, { minLen: 1 });
+      assertNumber('payload.delta', payload.delta, { min: 0 });
+      if (payload.production_batch_id != null) assertString('payload.production_batch_id', payload.production_batch_id);
+      break;
+
+    default:
+      throw new ValidationError('event_type', 'one of EVENT_TYPES', eventType);
+  }
+}
+
+// ─── Shape principal del log entry ────────────────────────────────────
+
+/**
+ * Valida un log entry completo conforme ADR-027.ii.
+ * Lanza ValidationError si algo no cumple. Útil ANTES de persistir.
+ */
+export function validateLogEntry(entry) {
+  if (typeof entry !== 'object' || entry == null) throw new ValidationError('entry', 'object', entry);
+  assertString('id', entry.id, { regex: ULID_REGEX });
+  assertString('event_type', entry.event_type, { oneOf: VALID_EVENT_TYPES });
+  assertString('timestamp', entry.timestamp, { regex: ISO_DATETIME_OFFSET_REGEX });
+  assertString('device_id_lex_hash', entry.device_id_lex_hash, { minLen: 8, maxLen: 8 });
+  assertNumber('sequence_number', entry.sequence_number, { min: 0, integer: true });
+  assertString('operator_id_hash', entry.operator_id_hash, { minLen: 64, maxLen: 64 });
+  assertString('idempotency_key', entry.idempotency_key, { minLen: 1 });
+  if (entry.prev_hash != null) assertString('prev_hash', entry.prev_hash, { minLen: 64, maxLen: 64 });
+  validatePayload(entry.event_type, entry.payload);
+  if (entry.schema_version !== '1') throw new ValidationError('schema_version', '"1"', entry.schema_version);
+  if (entry.notes != null) assertString('notes', entry.notes, { maxLen: 500 });
+  return true;
+}
+
+// ─── Helpers para identidad del device ────────────────────────────────
+
+const DEVICE_LEX_HASH_KEY = 'chagra:device_id_lex_hash';
+
+async function getOrCreateDeviceLexHash() {
+  let hash = localStorage.getItem(DEVICE_LEX_HASH_KEY);
+  if (hash) return hash;
+  // Genera 8 chars Crockford-Base32 random
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  const ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+  hash = Array.from(bytes, (b) => ALPHABET[b % 32]).join('');
+  localStorage.setItem(DEVICE_LEX_HASH_KEY, hash);
+  return hash;
+}
+
+const SEQ_NUM_KEY = 'chagra:inventory_seq_num';
+
+function nextSequenceNumber() {
+  const cur = parseInt(localStorage.getItem(SEQ_NUM_KEY) || '0', 10);
+  const next = cur + 1;
+  localStorage.setItem(SEQ_NUM_KEY, String(next));
+  return next;
+}
+
+// ─── Factory para crear nuevos eventos ────────────────────────────────
+
+/**
+ * Crea un log entry completo con id ULID, timestamp, device hash, sequence.
+ * El operator_id_hash debe inyectarse desde el authService (no se calcula acá
+ * para no requerir importar el HMAC stack).
+ *
+ * @param {string} eventType - uno de EVENT_TYPES
+ * @param {object} payload - payload tipado según eventType
+ * @param {object} opts - { operator_id_hash (req), idempotency_key (opt — si no, se calcula),
+ *                          prev_hash (opt), notes (opt) }
+ * @returns {object} log entry validado, listo para persistir
+ */
+export async function createInventoryEvent(eventType, payload, opts = {}) {
+  if (!VALID_EVENT_TYPES.has(eventType)) {
+    throw new ValidationError('eventType', 'one of EVENT_TYPES', eventType);
+  }
+  if (!opts.operator_id_hash) {
+    throw new ValidationError('opts.operator_id_hash', 'required string (HMAC-SHA256)', opts.operator_id_hash);
+  }
+  const deviceHash = await getOrCreateDeviceLexHash();
+  const idempotencyKey = opts.idempotency_key || computeIdempotencyKey(eventType, payload);
+
+  const entry = {
+    id: ulid(),
+    event_type: eventType,
+    timestamp: new Date().toISOString(),
+    device_id_lex_hash: deviceHash,
+    sequence_number: nextSequenceNumber(),
+    operator_id_hash: opts.operator_id_hash,
+    idempotency_key: idempotencyKey,
+    payload,
+    schema_version: '1',
+  };
+  if (opts.prev_hash) entry.prev_hash = opts.prev_hash;
+  if (opts.notes) entry.notes = opts.notes;
+
+  validateLogEntry(entry);
+  return entry;
+}
+
+/**
+ * Hash determinista para idempotencia. Best-effort: combina event_type +
+ * campos semánticos del payload + día. Dos events con misma key son
+ * considerados duplicados al reconciliar (LWW).
+ */
+function computeIdempotencyKey(eventType, payload) {
+  const day = new Date().toISOString().slice(0, 10);
+  switch (eventType) {
+    case EVENT_TYPES.RECEIVED:
+      return `${eventType}:${payload.item_id}:${payload.source}:${payload.provider_ref || '_'}:${day}`;
+    case EVENT_TYPES.CONSUMED:
+      return `${eventType}:${payload.item_id}:${payload.application_log_ref || ulid()}`;
+    case EVENT_TYPES.COUNTED:
+      // Conteos son inherentemente únicos por timestamp — agregar nano random
+      return `${eventType}:${payload.item_id}:${day}:${ulid().slice(-8)}`;
+    case EVENT_TYPES.TRANSFORMED:
+      return `${eventType}:${payload.recipe_id || 'adhoc'}:${day}:${ulid().slice(-8)}`;
+    default:
+      return `${eventType}:${payload.item_id || 'unknown'}:${ulid().slice(-12)}`;
+  }
+}
+
+export { ValidationError };

--- a/src/services/inventoryService.js
+++ b/src/services/inventoryService.js
@@ -1,0 +1,354 @@
+/**
+ * inventoryService — append-only event store + projectStock reconstruible.
+ *
+ * Implementa ADR-027 (event sourcing híbrido):
+ *   - appendEvent(event)          → persiste log inmutable + actualiza stock snapshot
+ *   - getStock(itemId)            → lee del snapshot O(1)
+ *   - getEventsForItem(itemId)    → bitácora completa
+ *   - rebuildSnapshot()           → recomputa el stock desde scratch (post-sync)
+ *   - projectStock(events)        → función pura — corazón de la reconciliación
+ *
+ * Reglas inviolables (ADR-019 + ADR-027):
+ *   1. inventory_events es append-only — NUNCA delete ni update.
+ *   2. inventory_stock_snapshot es CACHE — siempre reconstruible desde events.
+ *   3. Reconciliación determinista: timestamp ASC + device_id_lex_hash + sequence_number.
+ */
+
+import { openDB, STORES } from '../db/dbCore.js';
+import { validateLogEntry, EVENT_TYPES } from './inventoryEvents.js';
+
+// ─── Append (write path) ─────────────────────────────────────────────
+
+/**
+ * Persiste un evento ya validado. Idempotente — si el id ya existe, NO sobrescribe
+ * (ADR-019 inmutable).
+ */
+export async function appendEvent(event) {
+  validateLogEntry(event); // defensive: re-validate antes de persistir
+
+  const db = await openDB();
+  const tx = db.transaction([STORES.INVENTORY_EVENTS, STORES.INVENTORY_STOCK], 'readwrite');
+  const eventStore = tx.objectStore(STORES.INVENTORY_EVENTS);
+
+  // Check duplicado por id (ULID es global unique, pero defense-in-depth)
+  const existing = await new Promise((resolve, reject) => {
+    const r = eventStore.get(event.id);
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+  });
+  if (existing) {
+    return { duplicated: true, event: existing };
+  }
+
+  await new Promise((resolve, reject) => {
+    const r = eventStore.add(event);
+    r.onsuccess = resolve;
+    r.onerror = () => reject(r.error);
+  });
+
+  // Update stock snapshot incrementalmente (proyección incremental)
+  await applyToSnapshot(tx, event);
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve({ duplicated: false, event });
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+// ─── Read paths (snapshot O(1)) ──────────────────────────────────────
+
+export async function getStock(itemId) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORES.INVENTORY_STOCK, 'readonly');
+    const r = tx.objectStore(STORES.INVENTORY_STOCK).get(itemId);
+    r.onsuccess = () => resolve(r.result || { item_id: itemId, quantity: 0, unit: null, last_updated: null });
+    r.onerror = () => reject(r.error);
+  });
+}
+
+export async function getAllStock() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORES.INVENTORY_STOCK, 'readonly');
+    const r = tx.objectStore(STORES.INVENTORY_STOCK).getAll();
+    r.onsuccess = () => resolve(r.result || []);
+    r.onerror = () => reject(r.error);
+  });
+}
+
+export async function getEventsForItem(itemId) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORES.INVENTORY_EVENTS, 'readonly');
+    const idx = tx.objectStore(STORES.INVENTORY_EVENTS).index('item_id');
+    const r = idx.getAll(itemId);
+    r.onsuccess = () => {
+      const sorted = (r.result || []).sort(compareEventOrder);
+      resolve(sorted);
+    };
+    r.onerror = () => reject(r.error);
+  });
+}
+
+export async function getAllEvents() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORES.INVENTORY_EVENTS, 'readonly');
+    const r = tx.objectStore(STORES.INVENTORY_EVENTS).getAll();
+    r.onsuccess = () => {
+      const sorted = (r.result || []).sort(compareEventOrder);
+      resolve(sorted);
+    };
+    r.onerror = () => reject(r.error);
+  });
+}
+
+// ─── Pure projection (corazón de la reconciliación) ──────────────────
+
+/**
+ * Compara eventos para orden canónico determinista.
+ * Orden: timestamp ASC, luego device_id_lex_hash ASC, luego sequence_number ASC.
+ */
+export function compareEventOrder(a, b) {
+  if (a.timestamp < b.timestamp) return -1;
+  if (a.timestamp > b.timestamp) return 1;
+  if (a.device_id_lex_hash < b.device_id_lex_hash) return -1;
+  if (a.device_id_lex_hash > b.device_id_lex_hash) return 1;
+  return a.sequence_number - b.sequence_number;
+}
+
+/**
+ * Función PURA — corazón de ADR-027 Alt E.
+ * Toma una lista de eventos (de cualquier orden, cualquier item), retorna
+ * el snapshot de stock derivado.
+ *
+ * Garantía: dos máquinas con los mismos eventos producen el MISMO snapshot.
+ *
+ * @param {Array} events - lista de log entries (cualquier orden)
+ * @returns {Map<itemId, {quantity, unit, last_updated, last_event_id}>}
+ */
+export function projectStock(events) {
+  const sorted = [...events].sort(compareEventOrder);
+  const stock = new Map();
+
+  // Track de qué events ya fueron absorbidos por un counted posterior
+  // (LWW honesto: counted reanchora, ignorando contribuciones anteriores
+  // del mismo item)
+  const lastCountedIndexByItem = new Map();
+  sorted.forEach((ev, idx) => {
+    if (ev.event_type === EVENT_TYPES.COUNTED) {
+      const itemId = ev.payload.item_id;
+      lastCountedIndexByItem.set(itemId, idx);
+    }
+  });
+
+  // Idempotency dedupe: si dos events tienen misma idempotency_key,
+  // gana el de mayor timestamp (LWW). Los anteriores quedan visibles
+  // en bitácora pero NO contribuyen al stock.
+  const winnerByIdempotency = new Map();
+  sorted.forEach((ev) => {
+    const key = ev.idempotency_key;
+    if (!key) return;
+    const cur = winnerByIdempotency.get(key);
+    if (!cur || ev.timestamp > cur.timestamp) {
+      winnerByIdempotency.set(key, ev);
+    }
+  });
+
+  sorted.forEach((ev, idx) => {
+    // Skip si NO es el ganador idempotency LWW
+    if (ev.idempotency_key) {
+      const winner = winnerByIdempotency.get(ev.idempotency_key);
+      if (winner && winner.id !== ev.id) return;
+    }
+
+    switch (ev.event_type) {
+      case EVENT_TYPES.RECEIVED:
+      case EVENT_TYPES.PRODUCED: {
+        const itemId = ev.payload.item_id;
+        // Si hay un counted posterior, este received NO cuenta
+        const lastCounted = lastCountedIndexByItem.get(itemId);
+        if (lastCounted != null && idx < lastCounted) break;
+        const cur = stock.get(itemId) || { quantity: 0, unit: ev.payload.unit };
+        cur.quantity += ev.payload.delta;
+        cur.unit = ev.payload.unit;
+        cur.last_updated = ev.timestamp;
+        cur.last_event_id = ev.id;
+        cur.item_id = itemId;
+        stock.set(itemId, cur);
+        break;
+      }
+
+      case EVENT_TYPES.CONSUMED:
+      case EVENT_TYPES.LOST:
+      case EVENT_TYPES.ADJUSTED: {
+        const itemId = ev.payload.item_id;
+        const lastCounted = lastCountedIndexByItem.get(itemId);
+        if (lastCounted != null && idx < lastCounted) break;
+        const cur = stock.get(itemId) || { quantity: 0, unit: null };
+        cur.quantity += ev.payload.delta; // delta es negativo
+        cur.last_updated = ev.timestamp;
+        cur.last_event_id = ev.id;
+        cur.item_id = itemId;
+        if (cur.unit == null && ev.payload.unit) cur.unit = ev.payload.unit;
+        stock.set(itemId, cur);
+        break;
+      }
+
+      case EVENT_TYPES.COUNTED: {
+        const itemId = ev.payload.item_id;
+        // Reanchor — descarta contribuciones anteriores
+        stock.set(itemId, {
+          item_id: itemId,
+          quantity: ev.payload.counted_qty,
+          unit: ev.payload.unit,
+          last_updated: ev.timestamp,
+          last_event_id: ev.id,
+        });
+        break;
+      }
+
+      case EVENT_TYPES.TRANSFORMED: {
+        const lastCountedFor = (id) => lastCountedIndexByItem.get(id);
+        // Inputs: restar
+        ev.payload.inputs.forEach((inp) => {
+          if (lastCountedFor(inp.item_id) != null && idx < lastCountedFor(inp.item_id)) return;
+          const cur = stock.get(inp.item_id) || { quantity: 0, unit: inp.unit };
+          cur.quantity -= inp.delta_consumido;
+          cur.unit = inp.unit;
+          cur.last_updated = ev.timestamp;
+          cur.last_event_id = ev.id;
+          cur.item_id = inp.item_id;
+          stock.set(inp.item_id, cur);
+        });
+        // Outputs: sumar
+        ev.payload.outputs.forEach((out) => {
+          if (lastCountedFor(out.item_id) != null && idx < lastCountedFor(out.item_id)) return;
+          const cur = stock.get(out.item_id) || { quantity: 0, unit: out.unit };
+          cur.quantity += out.delta_producido;
+          cur.unit = out.unit;
+          cur.last_updated = ev.timestamp;
+          cur.last_event_id = ev.id;
+          cur.item_id = out.item_id;
+          stock.set(out.item_id, cur);
+        });
+        break;
+      }
+
+      case EVENT_TYPES.TRANSFERRED:
+        // Movimiento entre ubicaciones — NO afecta stock total del item.
+        // Ubicación per-se requeriría store separado de location_stock.
+        // Para v1 lo dejamos como no-op en el snapshot total.
+        break;
+
+      default:
+        // Tipo desconocido: log warning, no lanzar (defense-in-depth en upgrades)
+        if (typeof console !== 'undefined') {
+          console.warn(`[inventoryService] unknown event_type: ${ev.event_type}`);
+        }
+    }
+  });
+
+  return stock;
+}
+
+// ─── Snapshot maintenance ────────────────────────────────────────────
+
+/**
+ * Recomputa el snapshot completo desde scratch.
+ * Llamar después de un sync grande, o si se sospecha drift.
+ */
+export async function rebuildSnapshot() {
+  const events = await getAllEvents();
+  const stock = projectStock(events);
+
+  const db = await openDB();
+  const tx = db.transaction(STORES.INVENTORY_STOCK, 'readwrite');
+  const store = tx.objectStore(STORES.INVENTORY_STOCK);
+
+  // Limpiar snapshot anterior
+  await new Promise((resolve, reject) => {
+    const r = store.clear();
+    r.onsuccess = resolve;
+    r.onerror = () => reject(r.error);
+  });
+
+  // Escribir el nuevo
+  for (const value of stock.values()) {
+    await new Promise((resolve, reject) => {
+      const r = store.put(value);
+      r.onsuccess = resolve;
+      r.onerror = () => reject(r.error);
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve({ rebuilt_count: stock.size });
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/**
+ * Aplicación incremental — usado por appendEvent().
+ * NOTA: para single-event appends es 1000× más rápido que full rebuild.
+ * Si el orden de timestamps post-sync es problemático, debe llamarse
+ * rebuildSnapshot() para reconciliación correcta.
+ */
+async function applyToSnapshot(tx, event) {
+  const store = tx.objectStore(STORES.INVENTORY_STOCK);
+
+  const update = async (itemId, mutation) => {
+    return new Promise((resolve, reject) => {
+      const get = store.get(itemId);
+      get.onsuccess = () => {
+        const cur = get.result || { item_id: itemId, quantity: 0, unit: null };
+        const next = mutation(cur);
+        next.last_updated = event.timestamp;
+        next.last_event_id = event.id;
+        next.item_id = itemId;
+        const put = store.put(next);
+        put.onsuccess = resolve;
+        put.onerror = () => reject(put.error);
+      };
+      get.onerror = () => reject(get.error);
+    });
+  };
+
+  switch (event.event_type) {
+    case EVENT_TYPES.RECEIVED:
+    case EVENT_TYPES.PRODUCED:
+      await update(event.payload.item_id, (cur) => ({
+        ...cur, quantity: cur.quantity + event.payload.delta, unit: event.payload.unit,
+      }));
+      break;
+    case EVENT_TYPES.CONSUMED:
+    case EVENT_TYPES.LOST:
+    case EVENT_TYPES.ADJUSTED:
+      await update(event.payload.item_id, (cur) => ({
+        ...cur, quantity: cur.quantity + event.payload.delta,
+        unit: cur.unit || event.payload.unit || null,
+      }));
+      break;
+    case EVENT_TYPES.COUNTED:
+      await update(event.payload.item_id, () => ({
+        quantity: event.payload.counted_qty, unit: event.payload.unit,
+      }));
+      break;
+    case EVENT_TYPES.TRANSFORMED:
+      for (const inp of event.payload.inputs) {
+        await update(inp.item_id, (cur) => ({
+          ...cur, quantity: cur.quantity - inp.delta_consumido, unit: inp.unit,
+        }));
+      }
+      for (const out of event.payload.outputs) {
+        await update(out.item_id, (cur) => ({
+          ...cur, quantity: cur.quantity + out.delta_producido, unit: out.unit,
+        }));
+      }
+      break;
+    // TRANSFERRED no afecta total
+    default:
+      break;
+  }
+}

--- a/src/services/operatorIdentityService.js
+++ b/src/services/operatorIdentityService.js
@@ -1,0 +1,154 @@
+/**
+ * operatorIdentityService — pseudonimización determinista de operadores
+ * conforme ADR-027.v (Compliance Ley 1581 Habeas Data Colombia).
+ *
+ * Capa 1 de las 4 capas de privacidad:
+ *   operator_id_hash = HMAC-SHA256(operator_id, salt)
+ *   salt = PBKDF2(account_uuid_master, "chagra-salt-v1", iterations=10000)
+ *
+ * Determinista: mismo operador → mismo hash. Preserva trazabilidad cross-device.
+ * No reversible: requiere account_uuid_master para mapear hash → identidad.
+ *
+ * El account_uuid_master es PRIVADO del owner. NUNCA se sincroniza al
+ * backend Pro multi-finca. Vive solo en el device del owner.
+ *
+ * Capa 2 (mapping table operator_identity_map en SQLite local cifrada
+ * con AES-GCM) está en operatorIdentityMap.js (a implementar cuando
+ * llegue UI de captura de consentimiento).
+ */
+
+const TEXT_ENCODER = new TextEncoder();
+const SALT_NAMESPACE = 'chagra-salt-v1';
+const PBKDF2_ITERATIONS = 10000;
+
+const ACCOUNT_UUID_KEY = 'chagra:account_uuid_master';
+let _saltCache = null;
+
+// ─── Account UUID master (privado del owner, en localStorage) ────────
+
+/**
+ * Retorna el account_uuid_master, generándolo si no existe.
+ * Este UUID es CRÍTICO — perderlo significa perder la capacidad de
+ * mapear hashes a identidades. Backup recomendado.
+ */
+export function getOrCreateAccountUUID() {
+  let uuid = localStorage.getItem(ACCOUNT_UUID_KEY);
+  if (uuid) return uuid;
+  uuid = crypto.randomUUID();
+  localStorage.setItem(ACCOUNT_UUID_KEY, uuid);
+  console.log('[operatorIdentity] Generated NEW account_uuid_master. Backup recommended.');
+  return uuid;
+}
+
+/**
+ * Para tests / setup inicial.
+ * Permite inyectar un account_uuid externo (ej. importado de backup).
+ */
+export function setAccountUUID(uuid) {
+  if (typeof uuid !== 'string' || uuid.length < 32) {
+    throw new Error('Invalid account_uuid_master');
+  }
+  localStorage.setItem(ACCOUNT_UUID_KEY, uuid);
+  _saltCache = null; // invalidate cached salt
+}
+
+// ─── PBKDF2 salt derivation ──────────────────────────────────────────
+
+async function deriveSalt() {
+  if (_saltCache) return _saltCache;
+  const accountUUID = getOrCreateAccountUUID();
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    TEXT_ENCODER.encode(accountUUID),
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits']
+  );
+  const saltBits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      salt: TEXT_ENCODER.encode(SALT_NAMESPACE),
+      iterations: PBKDF2_ITERATIONS,
+      hash: 'SHA-256',
+    },
+    baseKey,
+    256 // 256 bits = 32 bytes
+  );
+  _saltCache = new Uint8Array(saltBits);
+  return _saltCache;
+}
+
+// ─── HMAC-SHA256 hash determinista ────────────────────────────────────
+
+/**
+ * Calcula operator_id_hash determinista para un operator_id dado.
+ * Mismo input + mismo account_uuid_master → mismo hash siempre.
+ *
+ * @param {string} operatorId — identidad cruda del operador (ej. "kortux@gmail.com",
+ *   nombre completo, cédula, o cualquier identificador estable elegido por el owner).
+ * @returns {Promise<string>} — 64 chars hex (256 bits)
+ */
+export async function computeOperatorHash(operatorId) {
+  if (typeof operatorId !== 'string' || operatorId.length === 0) {
+    throw new Error('operatorId must be non-empty string');
+  }
+  const salt = await deriveSalt();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    salt,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    TEXT_ENCODER.encode(operatorId)
+  );
+  const bytes = new Uint8Array(sig);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// ─── Cache del operator_id_hash actual ───────────────────────────────
+
+const CURRENT_OPERATOR_KEY = 'chagra:current_operator_hash';
+
+/**
+ * Setea el operator_id_hash del usuario activo de la sesión PWA.
+ * Llamar al login. Debe persistir entre sesiones del mismo device.
+ */
+export async function setCurrentOperator(operatorId) {
+  const hash = await computeOperatorHash(operatorId);
+  localStorage.setItem(CURRENT_OPERATOR_KEY, hash);
+  return hash;
+}
+
+export function getCurrentOperatorHash() {
+  return localStorage.getItem(CURRENT_OPERATOR_KEY);
+}
+
+export function clearCurrentOperator() {
+  localStorage.removeItem(CURRENT_OPERATOR_KEY);
+}
+
+// ─── Verificación / autoauditoría ────────────────────────────────────
+
+/**
+ * Permite al operador owner ver su propio hash (right of access ADR-027.v).
+ * Útil para autoauditoría y debug.
+ */
+export async function verifyOperatorIdentity(operatorId, expectedHash) {
+  const computed = await computeOperatorHash(operatorId);
+  return computed === expectedHash;
+}
+
+// ─── Reset para tests / desarrollo ────────────────────────────────────
+
+/**
+ * Solo para entornos de testing. NO llamar en producción.
+ */
+export function _resetForTests() {
+  _saltCache = null;
+  localStorage.removeItem(ACCOUNT_UUID_KEY);
+  localStorage.removeItem(CURRENT_OPERATOR_KEY);
+}


### PR DESCRIPTION
## Summary

Implementación PWA de ADR-027 Alt E + sub-ADRs 027.i + 027.ii + 027.v.

**Status**: 4 commits, 7 archivos. Smoke test ESM imports OK + build catalog 87 sp pasa.

## Archivos

### Backend storage
- `src/db/dbCore.js` — schema v6 → v7 + 2 stores: `inventory_events` + `inventory_stock_snapshot`

### Services
- `src/services/inventoryEvents.js` — 8 EVENT_TYPES, validators inline, factory `createInventoryEvent` con ULID + device hash + sequence
- `src/services/inventoryService.js` — `appendEvent`, `projectStock` pure (LWW honesto + idempotency dedupe), `rebuildSnapshot`
- `src/services/operatorIdentityService.js` — Capa 1 Ley 1581: HMAC-SHA256(operator_id, PBKDF2(account_uuid, salt, 10000)) determinista no reversible

### UI Components
- `src/components/InventoryDashboard.jsx` — lista cards O(1) desde snapshot, sort alfa, low-stock warning
- `src/components/RecountDrawer.jsx` — modal bottom-sheet para emitir `inventory_counted` (LWW honesto)
- `src/components/InventoryAuditTrail.jsx` — bitácora con badges por event_type, tooltip ULID/device/idempotency

### Tests
- `src/services/__tests__/inventoryService.fixture.test.js` — 5 suites verificando garantías Alt E (determinismo, counted reanchor, idempotency dedupe, transformed atómico, orden canónico). Requiere vitest no instalado: `npm install -D vitest && npx vitest run src/services`

## Reglas inviolables ADR-019

- ❌ NUNCA delete/update sobre `inventory_events`
- ✅ Stock snapshot reconstruible desde scratch (`rebuildSnapshot`)
- ✅ LWW honesto sin pérdida (counted reanchora pero logs históricos visibles)

## Validación

- ✅ ESM imports OK: 8 EVENT_TYPES, 9 VALID_UNITS exports
- ✅ `node scripts/build-catalog-sqlite.mjs` → 87 species, 44 sources, 16 biopreparados
- ⏳ Suite vitest pendiente (requiere instalar dep)

## Pendientes follow-up (otra PR)

- Page wrapper `<InventoryPage>` que orqueste los 3 componentes
- Router entry en `App.jsx` con role-gate (solo operadores autorizados)
- Login flow que llame `setCurrentOperator`
- Sync queue: integrar `appendEvent` con `syncManager` existing (cola `pending_transactions`)
- Capas 2-4 de privacidad ADR-027.v (mapping table cifrada AES-GCM, ExportSanitizer, derecho de supresión)

🤖 Generated with [Claude Code](https://claude.com/claude-code)