### PR TITLE
fix(ux): foto al top + photoService unificado (DR-030 QW1+QW3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v31';
+const CACHE_NAME = 'chagra-v32';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ArrowLeft, Camera, MapPin } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
+import { captureAndCompress, savePhoto } from '../services/photoService';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
 
 const ASSET_TYPES = [
@@ -37,20 +38,23 @@ export default function PlantAssetLog({ onBack, onSave }) {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
-  const handlePhotoCapture = (e) => {
+  const handlePhotoCapture = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    // Validación explícita de MIME: el atributo `accept="image/*"` del input es
-    // solo una pista UX y puede bypassearse. Restringir a image/* antes de
-    // generar el blob URL evita que un SVG/HTML con scripts embebidos llegue a
-    // un <img src={blob:...}> y cierra la regla CodeQL js/xss-through-dom.
+    // Validación MIME (cierra CodeQL js/xss-through-dom).
     if (!file.type.startsWith('image/')) {
       onSave('Archivo no es una imagen válida', true);
       return;
     }
-    setPhoto(file);
-    if (photoUrl) URL.revokeObjectURL(photoUrl);
-    setPhotoUrl(URL.createObjectURL(file));
+    try {
+      const { blob } = await captureAndCompress(file);
+      setPhoto(blob);
+      if (photoUrl) URL.revokeObjectURL(photoUrl);
+      setPhotoUrl(URL.createObjectURL(blob));
+    } catch (err) {
+      console.error('Error comprimir foto:', err);
+      onSave('Error procesando foto', true);
+    }
   };
 
   const captureLocation = () => {
@@ -91,13 +95,29 @@ export default function PlantAssetLog({ onBack, onSave }) {
 
     setIsSaving(true);
     try {
+      let photoRefId = null;
+      if (photo) {
+        try {
+          photoRefId = await savePhoto({
+            blob: photo,
+            speciesSlug: formData.species
+              ? formData.species.toLowerCase().replace(/\s+/g, '_')
+              : null,
+            meta: {
+              capturedAt: new Date().toISOString(),
+              gps: location ? { lat: location.lat, lon: location.lon } : null,
+            },
+          });
+        } catch (err) {
+          console.error('Error guardar foto en media_cache:', err);
+          onSave('Foto no se pudo guardar localmente', true);
+          setIsSaving(false);
+          return;
+        }
+      }
+
       const payload = {
-        _multipartFile: photo ? {
-          name: photo.name,
-          type: photo.type,
-          size: photo.size,
-          file: photo
-        } : null,
+        _photoRefId: photoRefId,
 
         data: {
           type: "asset--plant",
@@ -141,6 +161,21 @@ export default function PlantAssetLog({ onBack, onSave }) {
       </header>
 
       <div className="flex-1 p-5 flex flex-col gap-6 pb-24">
+        {/* Hero foto — primer paso del flujo (DR-030 QW3) */}
+        <div className="flex flex-col gap-2">
+          <span className="text-xl font-bold">Foto de la planta</span>
+          <label className="flex flex-col items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 cursor-pointer min-h-[140px] overflow-hidden relative">
+            {sanitizeBlobUrl(photoUrl) ? (
+              <img src={sanitizeBlobUrl(photoUrl)} alt="Preview" className="absolute inset-0 w-full h-full object-cover opacity-60" />
+            ) : null}
+            <div className="z-10 flex flex-col items-center gap-2 drop-shadow-md">
+              <Camera size={48} />
+              <span className="text-xl font-bold">{photo ? '📸 Cambiar foto' : '📸 Foto de la planta'}</span>
+            </div>
+            <input type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          </label>
+        </div>
+
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Tipo de Activo</span>
           <select name="assetType" value={formData.assetType} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none">
@@ -177,20 +212,6 @@ export default function PlantAssetLog({ onBack, onSave }) {
               <p className="font-mono mt-1 whitespace-nowrap">{location.wkt}</p>
             </div>
           )}
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <span className="text-xl font-bold">Fotografía del Activo</span>
-          <label className="flex flex-col items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 cursor-pointer min-h-[120px] overflow-hidden relative">
-            {sanitizeBlobUrl(photoUrl) ? (
-              <img src={sanitizeBlobUrl(photoUrl)} alt="Preview" className="absolute inset-0 w-full h-full object-cover opacity-60" />
-            ) : null}
-            <div className="z-10 flex flex-col items-center gap-2 drop-shadow-md">
-              <Camera size={48} />
-              <span className="text-xl font-bold">{photo ? 'Cambiar Foto' : 'Tomar Foto'}</span>
-            </div>
-            <input type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
-          </label>
         </div>
 
         <button

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, Camera, MapPin } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
+import { captureAndCompress, savePhoto } from '../services/photoService';
+import { sanitizeBlobUrl } from '../utils/blobUrl';
 
 export default function SeedingLog({ onBack, onSave, initialData = {} }) {
   const [formData, setFormData] = useState({
@@ -11,6 +13,7 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
     quantity: initialData.quantity || ''
   });
   const [photo, setPhoto] = useState(null);
+  const [photoUrl, setPhotoUrl] = useState(null);
   const [isRecording, setIsRecording] = useState(false);
   const [coordinates, setCoordinates] = useState(initialData.coordinates ? [initialData.coordinates] : []);
   const [notes, setNotes] = useState(initialData.notes || '');
@@ -22,11 +25,30 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current);
       }
+      if (photoUrl) URL.revokeObjectURL(photoUrl);
     };
-  }, []);
+  }, [photoUrl]);
 
   const handleInput = (e) => {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const handlePhotoCapture = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      onSave('Archivo no es una imagen válida', true);
+      return;
+    }
+    try {
+      const { blob } = await captureAndCompress(file);
+      setPhoto(blob);
+      if (photoUrl) URL.revokeObjectURL(photoUrl);
+      setPhotoUrl(URL.createObjectURL(blob));
+    } catch (err) {
+      console.error('Error comprimir foto:', err);
+      onSave('Error procesando foto', true);
+    }
   };
 
   const toggleRecording = () => {
@@ -58,14 +80,37 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
 
     setIsSaving(true);
     try {
+      let photoRefId = null;
+      if (photo) {
+        try {
+          photoRefId = await savePhoto({
+            blob: photo,
+            speciesSlug: formData.crop
+              ? formData.crop.toLowerCase().replace(/\s+/g, '_')
+              : null,
+            meta: {
+              capturedAt: new Date().toISOString(),
+              gps: coordinates.length > 0
+                ? { lat: coordinates[0][1], lon: coordinates[0][0] }
+                : null,
+            },
+          });
+        } catch (err) {
+          console.error('Error guardar foto en media_cache:', err);
+          onSave('Foto no se pudo guardar localmente', true);
+          setIsSaving(false);
+          return;
+        }
+      }
+
       const payload = {
+        _photoRefId: photoRefId,
         data: {
           type: "log--seeding",
           attributes: {
             name: `Siembra de ${formData.crop} - ${formData.variety || 'N/A'}`,
             timestamp: new Date(formData.date).toISOString().split('.')[0] + '+00:00',
             status: "done",
-            _localPhotoName: photo ? photo.name : null,
             ...(coordinates.length >= 3 ? {
               geometry: {
                 type: "Polygon",
@@ -96,6 +141,8 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
 
       setFormData({ date: new Date().toISOString().split('T')[0], crop: '', variety: '', quantity: '' });
       setPhoto(null);
+      if (photoUrl) URL.revokeObjectURL(photoUrl);
+      setPhotoUrl(null);
       setCoordinates([]);
       setTimeout(() => onBack(), 500);
     } catch (error) {
@@ -116,6 +163,21 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
       </header>
 
       <div className="flex-1 p-5 flex flex-col gap-6 pb-24">
+        {/* Hero foto — primer paso del flujo (DR-030 QW3) */}
+        <div className="flex flex-col gap-2">
+          <span className="text-xl font-bold">Foto de la planta</span>
+          <label className="flex flex-col items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 cursor-pointer min-h-[140px] overflow-hidden relative">
+            {sanitizeBlobUrl(photoUrl) ? (
+              <img src={sanitizeBlobUrl(photoUrl)} alt="Preview" className="absolute inset-0 w-full h-full object-cover opacity-60" />
+            ) : null}
+            <div className="z-10 flex flex-col items-center gap-2 drop-shadow-md">
+              <Camera size={48} />
+              <span className="text-xl font-bold">{photo ? '📸 Cambiar foto' : '📸 Foto de la planta'}</span>
+            </div>
+            <input type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          </label>
+        </div>
+
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Fecha</span>
           <input type="date" name="date" value={formData.date} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]" />
@@ -140,15 +202,6 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
           <span className="text-xl font-bold">Cantidad de Plántulas</span>
           <input type="number" name="quantity" min="1" value={formData.quantity} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]" />
         </label>
-
-        <div className="flex flex-col gap-2">
-          <span className="text-xl font-bold">Evidencia Fotográfica</span>
-          <label className="flex items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 text-2xl cursor-pointer min-h-[80px]">
-            <Camera size={36} />
-            <span className="truncate">{photo ? photo.name : 'Tomar Foto'}</span>
-            <input type="file" accept="image/*" capture="environment" onChange={e => setPhoto(e.target.files[0])} className="hidden" />
-          </label>
-        </div>
 
         <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Mapeo Geoespacial</span>


### PR DESCRIPTION
## Síntoma trigger

2026-04-30 — Lili (primera usuaria, 0 contexto previo, iPhone 16 Pro Max) leyendo handoff doc, pregunta literal **"EN LA APP DONDE DEBO AGREGAR LA FOTO DE LA PLANTA"**.

Auditoría code-only reveló 3 implementaciones paralelas de foto (`_multipartFile` / `_localPhotoName` / `mediaCache`) + bloque foto al fondo del scroll de SeedingLog y PlantAssetLog. DR triple (Claude + DeepSeek + Gemini) convergió 90% en plan macro — decisión final en `Chagra-strategy/deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md`.

## Summary

Primera fase del DR-030: **QW1 (migración photoService) + QW3 (foto al top + rename)**. Sin tocar arquitectura mayor (PlantCapture unificado, top-bar, FAB voz, empty-state), apunta al alivio inmediato de Lili.

- **QW1**: `PlantAssetLog` y `SeedingLog` consumen `photoService.captureAndCompress()` + `savePhoto()`. Foto comprimida a ≤500 KB / 1600 px JPEG antes de persistir en `media_cache` IndexedDB. Reemplaza `_multipartFile` (PlantAssetLog) y `_localPhotoName` (SeedingLog) por `_photoRefId` apuntando al record.
- **QW3**: bloque foto reposicionado al **top del scroll** (antes estaba al final). Label `Tomar Foto` → `📸 Foto de la planta`; `Cambiar Foto` → `📸 Cambiar foto`. Heading unificado "Foto de la planta".

## Changes

| Archivo | Cambio |
|---------|--------|
| `src/components/PlantAssetLog.jsx` | photoService cableado, foto al top, rename |
| `src/components/SeedingLog.jsx` | photoService cableado, foto al top, rename |
| `package.json` | `0.10.0` → `0.10.1` (patch UX) |
| `public/sw.js` | `CACHE_NAME` `chagra-v31` → `chagra-v32` |

`payloadService.js:98` mantiene `delete payload._multipartFile` defensivo durante 1 release (no causa daño, se limpia en QW posterior).

## Test plan

- [x] `npm run build` verde local sin warnings nuevos
- [x] `git diff --staged` SOP §2 check: cero URLs/IPs/tokens/secrets hardcodeados
- [x] No quedan refs a `_multipartFile` / `_localPhotoName` excepto el `delete` defensivo en payloadService
- [ ] CodeQL `Analyze` debe pasar
- [ ] Playwright `offline.spec.js` debe pasar (la captura de foto es offline-first; el blob va a IndexedDB sin red)
- [ ] Manual iPhone Safari: tomar foto desde SeedingLog y PlantAssetLog, verificar que el preview aparece, el guardado completa, y la imagen sale en la cola de pendientes
- [ ] Re-test Lili sábado/domingo: aceptación = NO pregunta "¿dónde está la foto?", localiza el botón en ≤5 s

## Refs

- DR síntesis 3 LLMs verbatim: `Chagra-strategy/historico/2026-04-30-dr-chagra-ux-clarity.md`
- Decisión final: `Chagra-strategy/deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md`
- Plan completo: `QW1 → QW3 → QW5 → QW4 → QW2`. Esta PR cubre QW1+QW3.

## Próximo

QW5 (empty-state dashboard 3 CTA hero) — branch `fix/ux-clarity-empty-state` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)