### PR TITLE
feat(ux): empty-state cold-start 3 CTA hero (DR-030 QW5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v32';
+const CACHE_NAME = 'chagra-v33';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m
 const BiodiversidadView = lazy(() => import('./components/BiodiversidadView'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
+const OnboardingHero = lazy(() => import('./components/OnboardingHero'));
 
 localforage.config({
   name: 'Chagra',
@@ -138,7 +139,16 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
         </div>
       </header>
       <main className="flex-1 px-4 pt-3 pb-4 flex flex-col overflow-y-auto gap-3 bg-biopunk-pattern">
-        <TelemetryAlerts lastFarmOsLog={lastLogMessage} />
+        {/* DR-030 QW5: cold-start empty-state.
+            plantsCount === 0 → OnboardingHero con 3 CTA hero (📸/🎤/✍).
+            Sin plantas registradas, la telemetría densa es ruido informacional;
+            la suprimimos a favor del onboarding directo. Cuando hay ≥1 planta
+            registrada, vuelve el dashboard normal con TelemetryAlerts. */}
+        {plantsCount === 0 ? (
+          <OnboardingHero onNavigate={onNavigate} />
+        ) : (
+          <TelemetryAlerts lastFarmOsLog={lastLogMessage} />
+        )}
 
         {/* Contadores de inventario consolidados: un solo container con
             divisores verticales entre columnas, en vez de 4 tarjetas

--- a/src/components/OnboardingHero.jsx
+++ b/src/components/OnboardingHero.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Camera, Mic, Pencil } from 'lucide-react';
+
+/**
+ * OnboardingHero — empty-state cold-start del dashboard (DR-030 QW5).
+ *
+ * Se renderiza cuando plantsCount === 0 (sin plantas registradas localmente).
+ * Reemplaza la telemetría densa de TelemetryAlerts (que sin sensores cableados
+ * y sin contexto agronómico es ruido informacional para usuario 0-contexto).
+ *
+ * 3 CTA hero, equivalentes en peso visual, mapean a las 3 modalidades de
+ * captura disponibles. La foto va primero por convención camera-first
+ * (Pl@ntNet/Seek), pero las 3 son first-class — el usuario elige sin
+ * jerarquía impuesta.
+ *
+ * Refs: deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md
+ */
+export default function OnboardingHero({ onNavigate }) {
+  const ctas = [
+    {
+      id: 'plant_asset',
+      icon: Camera,
+      emoji: '📸',
+      label: 'Foto',
+      desc: 'Tomar foto de una planta',
+      accent: 'border-purple-500 active:bg-purple-900/30 text-purple-300',
+    },
+    {
+      id: 'voz',
+      icon: Mic,
+      emoji: '🎤',
+      label: 'Voz',
+      desc: 'Dictar registro',
+      accent: 'border-lime-500 active:bg-lime-900/30 text-lime-300',
+    },
+    {
+      id: 'sembrar',
+      icon: Pencil,
+      emoji: '✍',
+      label: 'Escribir',
+      desc: 'Formulario manual',
+      accent: 'border-emerald-500 active:bg-emerald-900/30 text-emerald-300',
+    },
+  ];
+
+  return (
+    <section
+      aria-label="Comenzar a registrar plantas"
+      className="w-full bg-slate-900/50 border border-slate-800 rounded-xl p-5 flex flex-col gap-4"
+    >
+      <div className="flex flex-col gap-1">
+        <h2 className="text-2xl font-black text-white">
+          Tu finca está lista para tu primera planta
+        </h2>
+        <p className="text-sm text-slate-400">
+          Elegí cómo registrar la primera. Las tres rutas guardan lo mismo.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {ctas.map((cta) => (
+          <button
+            key={cta.id}
+            type="button"
+            onClick={() => onNavigate(cta.id)}
+            aria-label={`${cta.label}: ${cta.desc}`}
+            className={`flex flex-col items-center justify-center gap-2 p-6 rounded-xl bg-slate-950 border-2 ${cta.accent} min-h-[140px] transition-colors`}
+          >
+            <span className="text-4xl" aria-hidden="true">
+              {cta.emoji}
+            </span>
+            <span className="text-2xl font-black">{cta.label}</span>
+            <span className="text-xs text-slate-500">{cta.desc}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Síntoma trigger

Cuando Lili (primera usuaria, 0 plantas registradas) abrió Chagra, el primer pantallazo era telemetría densa (humedad/temp Invernadero+Matera + análisis IA + botones Riego) que sólo cobra sentido con sensores cableados + contexto agronómico. Para usuario 0-contexto sin sensores, eso es **ruido informacional** que oculta el verdadero punto de entrada.

## Summary

Cuando `plantsCount === 0`, `DashboardView` reemplaza `<TelemetryAlerts />` por un `<OnboardingHero />` nuevo con **3 CTA grandes equivalentes** (📸 Foto / 🎤 Voz / ✍ Escribir). Sin imponer jerarquía, sin tutorial — la primitiva "registrar tu primera planta" tiene 3 caminos paralelos.

Cuando hay ≥1 planta, vuelve el dashboard normal. Counters + tiles siguen visibles en ambos modos (no rompemos navegación lateral).

## Changes

| Archivo | Cambio |
|---------|--------|
| `src/components/OnboardingHero.jsx` (nuevo) | 3 CTA hero accesibles, aria-label específico, responsive 1/3 col |
| `src/App.jsx` | lazy import + condicional `plantsCount === 0` en DashboardView |
| `package.json` | `0.10.1` → `0.10.2` |
| `public/sw.js` | `chagra-v32` → `chagra-v33` |

## Targets de los CTA

- 📸 **Foto** → `onNavigate('plant_asset')` (flujo PlantAssetLog camera-first del #68)
- 🎤 **Voz** → `onNavigate('voz')` (VoiceCapture screen)
- ✍ **Escribir** → `onNavigate('sembrar')` (SeedingLog formulario)

## Caveat

La lógica usa sólo `plantsCount` para distinguir cold-start. La distinción más fina (`plants===0 && sensors===0` vs `plants===0 && sensors>0`) queda para QW posterior — requiere conocer status de auth HA (`sensorCount === 'unknown'` cuando `HA_LONG_LIVED_TOKEN` no está configurado en oracle), no sólo el conteo. Esto es safe-by-default: si tenés sensores cableados pero ningún registro de planta aún, igual ves el hero (que es lo que querrías para arrancar a registrar).

## Test plan

- [x] `npm run build` verde sin warnings nuevos
- [x] SOP §2 check: cero secrets/IPs/URLs hardcodeados
- [x] Componente con `aria-label` específico por CTA + label legible para sun-readability
- [ ] CodeQL `Analyze` debe pasar
- [ ] Playwright `offline.spec.js` debe pasar
- [ ] Manual iPhone Safari: login fresh → ver 3 CTA hero arriba (no telemetría) → tap 📸 → llega a PlantAssetLog camera-first
- [ ] Manual: registrar 1 planta → volver a dashboard → ver telemetría normal de vuelta
- [ ] Re-test Lili sábado/domingo: aceptación = NO pregunta "¿dónde empiezo?"

## Refs

- Decisión: `Chagra-strategy/deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md`
- Síntesis 3 LLMs verbatim: `Chagra-strategy/historico/2026-04-30-dr-chagra-ux-clarity.md`
- Shipping order: QW1+QW3 (#68 ✅) → **QW5 (esta PR)** → QW4 → QW2

## Próximo

QW4 (Mic FAB global abajo-izquierda con label visible) — branch `feat/mic-fab-global` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)