### PR TITLE
feat(ux): MicFab global izquierda con label (DR-030 QW4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v33';
+const CACHE_NAME = 'chagra-v34';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { version as APP_VERSION } from '../package.json';
 import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
 import FieldFeedback from './components/FieldFeedback';
+import MicFab from './components/MicFab';
 import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
 import AltitudeBadge from './components/AltitudeBadge';
@@ -343,6 +344,7 @@ export default function App() {
       </Suspense>
       {/* FAB feedback inline para field testing — siempre visible salvo loading */}
       {currentView !== 'loading' && currentView !== 'login' && <FieldFeedback />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && <MicFab onNavigate={navigate} />}
       {toast && (
         <div
           role={toast.isError ? 'alert' : 'status'}

--- a/src/components/MicFab.jsx
+++ b/src/components/MicFab.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Mic } from 'lucide-react';
+
+/**
+ * MicFab — Floating Action Button global para captura por voz (DR-030 QW4).
+ *
+ * FAB extendido (pill con ícono + label) anclado abajo-IZQUIERDA. La derecha
+ * está ocupada por FieldFeedback (💬). El label visible permanente "Voz"
+ * mitiga el problema clásico del FAB iOS: discoverability cero sin
+ * affordance textual (Apple HIG no formaliza el FAB; la mitigación
+ * convergida en el DR triple es etiquetarlo siempre).
+ *
+ * Visible en todas las rutas excepto loading/login (mismo patrón que
+ * FieldFeedback). Toca → navigate('voz') abre VoiceCapture screen.
+ *
+ * Refs: deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md (D1)
+ */
+export default function MicFab({ onNavigate }) {
+  const COLOR_PRIMARY = '#84cc16';   // lime-500 (matches NAV_TILE 'voz' accent)
+  const COLOR_ACCENT = '#bef264';    // lime-300
+
+  return (
+    <button
+      type="button"
+      aria-label="Capturar por voz"
+      title="Registrar por voz"
+      onClick={() => onNavigate('voz')}
+      style={{
+        position: 'fixed',
+        bottom: 'max(18px, env(safe-area-inset-bottom))',
+        left: 18,
+        minHeight: 56,
+        paddingLeft: 20,
+        paddingRight: 24,
+        paddingTop: 8,
+        paddingBottom: 8,
+        borderRadius: 28,
+        border: `2px solid ${COLOR_ACCENT}`,
+        background: `linear-gradient(135deg, ${COLOR_PRIMARY} 0%, #4d7c0f 100%)`,
+        color: '#0f172a',
+        fontSize: 16,
+        fontWeight: 800,
+        cursor: 'pointer',
+        boxShadow: `0 4px 16px rgba(0,0,0,0.4), 0 0 14px ${COLOR_ACCENT}55`,
+        zIndex: 9000,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+      }}
+    >
+      <Mic size={22} strokeWidth={2.5} aria-hidden="true" />
+      <span>Voz</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Síntoma trigger

La voz hoy vive como **tile en el grid de navegación** (`{ id: 'voz', label: 'Voz', icon: Mic }`) — un destino, no una acción. El usuario tiene que ir al dashboard, scrollear, encontrar el tile entre los 9, tocarlo, y recién ahí dictar. La voz es una *modalidad de entrada*, no una *pantalla*.

## Summary

FAB extendido (pill con ícono `Mic` + label "Voz") anclado abajo-IZQUIERDA, visible en todas las rutas excepto `loading`/`login`/`voz`. La derecha está ocupada por `FieldFeedback` (💬). Ambos FABs coexisten sin solaparse.

Tap → `onNavigate('voz')` abre `VoiceCapture` screen actual.

## Changes

| Archivo | Cambio |
|---------|--------|
| `src/components/MicFab.jsx` (nuevo) | FAB extendido, lime accent matches NAV tile 'voz', respeta `env(safe-area-inset-bottom)` iOS |
| `src/App.jsx` | import MicFab + render global condicional |
| `package.json` | `0.10.2` → `0.10.3` |
| `public/sw.js` | `chagra-v33` → `chagra-v34` |

## Decisión de diseño D1 (de la síntesis del DR)

Claude + DeepSeek convergieron en izquierda; Gemini propuso centro-extendido. **Picked**: izquierda con label visible (mezcla — adopta el label de Gemini sobre la posición de Claude+DeepSeek).

Razón: la primaria de Chagra es *Capturar planta*, no *Voz*. Centro-extendido se reserva históricamente para acción primaria única (Compose en Inbox). El label visible permanente mitiga el problema clásico del FAB iOS (Apple HIG no formaliza FAB; discoverability cero sin affordance textual).

## Caveats

- Conversión de `VoiceCapture` de screen completo a bottom-sheet queda para QW posterior — esta PR sólo destraba la accesibilidad global.
- Ocultar al teclado activo (M3 best practice) no implementado aún — requiere listener `visualViewport` que añade complejidad. Para QW post.

## Test plan

- [x] `npm run build` verde sin warnings nuevos
- [x] SOP §2 check: cero secrets/IPs/URLs hardcodeados
- [x] FAB no choca con FieldFeedback (izquierda vs derecha)
- [x] Oculto en `loading`/`login`/`voz`
- [ ] CodeQL `Analyze` debe pasar
- [ ] Playwright `offline.spec.js` debe pasar
- [ ] Manual iPhone Safari: FAB visible en dashboard + en cualquier formulario; tap abre VoiceCapture
- [ ] Re-test Lili: aceptación = no necesita ir al grid para acceder a voz

## Refs

- Decisión: `Chagra-strategy/deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md` (D1)
- Síntesis 3 LLMs: `Chagra-strategy/historico/2026-04-30-dr-chagra-ux-clarity.md`
- Shipping order: QW1+QW3 (#68 ✅) → QW5 (#69 ✅) → **QW4 (esta PR)** → QW2

## Próximo

QW2 (top-bar persistente con identidad operador). **Pre-requisito**: card-sort n≥5 con usuarios 0-contexto colombianos para validar vocabulario tiles ("Bitácora", "Hoy en finca", "Plagas", etc — hipótesis cultural sin n>1 validado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)