### PR TITLE
feat(plan): D5+D6+D7 suggestion steps en planGenerator (catálogo v3.1 → UI accionable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v43';
+const CACHE_NAME = 'chagra-v44';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/planGeneratorService.js
+++ b/src/services/planGeneratorService.js
@@ -3,6 +3,147 @@ import { openDB, STORES } from '../db/dbCore.js';
 import { appendEvent, getStock } from './inventoryService.js';
 import { createInventoryEvent, EVENT_TYPES } from './inventoryEvents.js';
 
+// Mapeo de companions/antagonists D6 (árboles) + D7 (microorganismos) a
+// sugerencias accionables específicas que el operador puede aplicar al plan.
+// Cada entry produce un suggestion step (no es step obligatorio del template,
+// es enriquecimiento basado en relaciones documentadas en el catálogo v3.1).
+//
+// Razón: post catálogo v3.1 (60 sp) los entries D6/D7 venían como data orfana
+// en companions/antagonists arrays — el plan los listaba pero sin acción
+// concreta. Esta función traduce relaciones simbólicas en steps ejecutables.
+const D6_D7_SUGGESTION_RECIPES = {
+  // === D7 microorganismos benéficos (bioinsumos) ===
+  trichoderma_harzianum: {
+    type: 'biocontrol_suggestion',
+    label: 'Aplicar Trichoderma harzianum al sustrato',
+    note: 'Biofungicida preventivo contra Fusarium/Rhizoctonia/Pythium. Dosis: 5g/L agua. Aplicar al trasplante + cada 30-60 días en raíces.',
+    timing: 'pre_planting_or_30d_intervals',
+    cost_tier: 'low',
+  },
+  bacillus_subtilis: {
+    type: 'biocontrol_suggestion',
+    label: 'Aplicar Bacillus subtilis foliar',
+    note: 'PGPR + fungicida foliar. Dosis: 5g/L agua, spray cada 15 días. Ideal para brassicas + solanáceas.',
+    timing: '15d_intervals',
+    cost_tier: 'low',
+  },
+  beauveria_bassiana: {
+    type: 'biocontrol_suggestion',
+    label: 'Aplicar Beauveria bassiana contra plagas',
+    note: 'Insecticida biológico (broca, ácaros, áfidos). Dosis: 2g/L agua, spray foliar al detectar plaga o preventivo cada 21 días en frutales.',
+    timing: 'on_pest_or_21d_intervals',
+    cost_tier: 'medium',
+  },
+  eisenia_fetida: {
+    type: 'amendment_suggestion',
+    label: 'Aplicar humus de lombriz al sustrato',
+    note: 'Fertilizante orgánico premium. Dosis: 200-500g/m² al trasplante + 100g cada 60 días. Vermicultura propia o adquirir Eisenia fetida.',
+    timing: 'planting_and_60d_intervals',
+    cost_tier: 'low',
+  },
+  pleurotus_ostreatus: {
+    type: 'companion_crop_suggestion',
+    label: 'Cultivo asociado: Pleurotus ostreatus bajo sombra',
+    note: 'Hongo ostra cultivable en sustratos lignocelulósicos. Aprovechar sombra de árboles D6 cercanos. Ciclo 14-30 días.',
+    timing: 'continuous',
+    cost_tier: 'medium',
+  },
+  lentinula_edodes: {
+    type: 'companion_crop_suggestion',
+    label: 'Cultivo asociado: Shiitake en troncos',
+    note: 'Adaptable Choachí piso medio-alto bajo techo. Cultivo en troncos de Quercus humboldtii (roble negro D6).',
+    timing: 'continuous',
+    cost_tier: 'medium',
+  },
+  // === D6 árboles (companion / antagonist agroforestal) ===
+  aliso: {
+    type: 'agroforestry_suggestion',
+    label: 'Considerar Aliso (Alnus acuminata) cerca',
+    note: 'Fija nitrógeno via Frankia + sombra rápida. Distancia recomendada: 5-8 m del cultivo. Companion universal para cereales/brassicas/frutales.',
+    timing: 'long_term_planning',
+    cost_tier: 'low',
+  },
+  cedro_andino: {
+    type: 'agroforestry_warning',
+    label: '⚠ Evitar plantar bajo Cedro andino (Cedrela montana)',
+    note: 'Alelopatía documentada con cultivos de ciclo corto. Distancia mínima: 15 m. CITES II en peligro — proteger ejemplares existentes pero no asociar.',
+    timing: 'planning_check',
+    cost_tier: 'n/a',
+  },
+  encenillo: {
+    type: 'agroforestry_suggestion',
+    label: 'Asociación con Encenillo (Weinmannia tomentosa)',
+    note: 'Páramo bajo dosel — favorece regeneración natural. Compatible con frailejón. Distancia: 8-10 m.',
+    timing: 'long_term_planning',
+    cost_tier: 'low',
+  },
+  // === D5 biopreparados (recetas en catalog) ===
+  ortiga: {
+    type: 'biopreparation_suggestion',
+    label: 'Aplicar purín de ortiga (Urtica dioica)',
+    note: 'Fertilizante + fungicida natural. Receta: 1 kg planta fresca en 10 L agua, fermentar 2 semanas, dilución 1:10 para abono foliar.',
+    timing: '15d_intervals',
+    cost_tier: 'minimal',
+  },
+  cola_de_caballo: {
+    type: 'biopreparation_suggestion',
+    label: 'Aplicar Cola de caballo preventivo',
+    note: 'Fungicida natural (sílice). Receta: 100g planta seca en 1L agua, decocción 30min, dilución 1:5 spray preventivo botrytis/oídio cada 15 días.',
+    timing: '15d_intervals',
+    cost_tier: 'minimal',
+  },
+  calendula: {
+    type: 'companion_crop_suggestion',
+    label: 'Sembrar Caléndula como companion',
+    note: 'Atrae polinizadores + repele nematodos del suelo. Companion universal. Receta floral: 100g flores frescas en 1L agua, infusión 24h, riego foliar.',
+    timing: 'continuous',
+    cost_tier: 'minimal',
+  },
+};
+
+/**
+ * Genera suggestion steps adicionales basados en companions/antagonists
+ * documentados que tengan recetas en D6_D7_SUGGESTION_RECIPES.
+ *
+ * @param {object} speciesData - entry del catalog
+ * @param {number} pDate - planting date timestamp
+ * @returns {Array} suggestion steps con flag `is_suggestion: true`
+ */
+function enrichSuggestionsFromCompanions(speciesData, pDate) {
+  const suggestions = [];
+  const seen = new Set();
+
+  // Companions: extract slugs (puede ser array de strings o objects con .id)
+  const extractSlug = (entry) => typeof entry === 'string' ? entry : entry?.id;
+
+  const companions = (speciesData.companions || []).map(extractSlug).filter(Boolean);
+  const antagonists = (speciesData.antagonists || []).map(extractSlug).filter(Boolean);
+
+  for (const slug of [...companions, ...antagonists]) {
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    const recipe = D6_D7_SUGGESTION_RECIPES[slug];
+    if (!recipe) continue;
+
+    suggestions.push({
+      id: ulid(),
+      // Las suggestions no tienen scheduled_date fijo: se anclan al pDate +
+      // 7 días (margen de revisión post-trasplante por parte del operador).
+      scheduled_date: pDate + 7 * 86400000,
+      action_type: recipe.type,
+      label: recipe.label,
+      notes: recipe.note,
+      timing: recipe.timing,
+      cost_tier: recipe.cost_tier,
+      related_slug: slug,
+      status: 'suggested',  // distinto de 'pending' del template — operador decide aplicar o ignorar
+      is_suggestion: true,
+    });
+  }
+
+  return suggestions;
+}
+
 export async function generatePlanForPlant({ assetId, speciesSlug, plantingDate, climateZone, lunarPhase }) {
     // Query from sqlite directly using the global helper if present, else fallback.
     // Using the window.__chagraCatalog is usually available in the app context, or we can fetch.
@@ -95,6 +236,13 @@ export async function generatePlanForPlant({ assetId, speciesSlug, plantingDate,
         };
     }));
 
+    // Enriquecer con sugerencias D5/D6/D7 (biopreparados + árboles
+    // agroforestales + microorganismos benéficos). Estos NO son steps
+    // obligatorios del template — son recomendaciones derivadas de
+    // companions/antagonists del catálogo v3.1 que el operador puede
+    // aceptar (cambia status a 'pending') o ignorar.
+    const suggestions = enrichSuggestionsFromCompanions(speciesData, pDate);
+
     return await savePlan({
         id: planId,
         asset_id: assetId,
@@ -104,6 +252,7 @@ export async function generatePlanForPlant({ assetId, speciesSlug, plantingDate,
         companions: speciesData.companions || [],
         antagonists: speciesData.antagonists || [],
         steps,
+        suggestions,
     });
 }
 


### PR DESCRIPTION
## Síntoma trigger

Post catálogo v3.1 cerrado en 60 sp, los entries **D5 biopreparados** + **D6 árboles** + **D7 microorganismos** quedaban como data orfana en `companions`/`antagonists` arrays. El plan los listaba pero sin acción concreta. Cierra el loop end-to-end catálogo → UI.

## Changes

### `D6_D7_SUGGESTION_RECIPES` (nuevo dict)

11 entries del catálogo v3.1 mapeados a suggestion steps con label + dosis + timing + cost_tier:

| Slug catálogo | Tipo suggestion | Acción concreta |
|---------------|-----------------|-----------------|
| `trichoderma_harzianum` | biocontrol | 5g/L sustrato cada 30-60d |
| `bacillus_subtilis` | biocontrol | 5g/L foliar cada 15d |
| `beauveria_bassiana` | biocontrol | 2g/L cada 21d frutales |
| `eisenia_fetida` | amendment | 200-500g/m² humus |
| `pleurotus_ostreatus` | companion_crop | bajo sombra árboles D6 |
| `lentinula_edodes` | companion_crop | en troncos roble negro |
| `aliso` | agroforestry | fija N₂, distancia 5-8m |
| `cedro_andino` | ⚠ warning | alelopatía, distancia 15m |
| `encenillo` | agroforestry | páramo bajo dosel |
| `ortiga` | biopreparation | purín 1:10 cada 15d |
| `cola_de_caballo` | biopreparation | fungicida sílice |
| `calendula` | companion_crop | polinizadores + nematodos |

### `enrichSuggestionsFromCompanions(speciesData, pDate)`

Extrae slugs de companions + antagonists, lookup en RECIPES, emite suggestion steps con:
- `is_suggestion: true`
- `status: 'suggested'` (vs `'pending'` del template)
- `scheduled_date: pDate + 7d` (margen revisión post-trasplante)

### `generatePlanForPlant` integrado

Adjunta `suggestions` al plan guardado (nuevo campo en `savePlan`).

## Ejemplo de output post-merge

```
Plan para tomate (companions: bacillus_subtilis, calendula | antagonist: cedro_andino):
  Steps obligatorios: 5 (template feeding plan tomate)
  Suggestions: 3
    🌿 Aplicar Bacillus subtilis foliar
    🌼 Sembrar Caléndula como companion
    ⚠ Evitar plantar bajo Cedro andino
```

## Test plan

- [x] `npm run build` verde (5.46s, sin warnings nuevos)
- [x] SOP §2 check: cero secrets/IPs/URLs hardcodeados
- [x] Lefthook auto-bump (PR #77) bumpeará automáticamente
- [ ] Manual: crear plan para tomate con cedro_andino en antagonists → ver warning step
- [ ] Manual: crear plan para frutal con beauveria_bassiana en companions → ver suggestion step

## Out of scope (siguiente PR)

`PlanEditor.jsx` debe renderizar sección `suggestions` con CTA "Aplicar al plan" que clone a `steps` + cambie status. Esta PR solo provee la data backend; UI viene aparte.

## Refs

- Catálogo v3.1 (60 sp): PR #76 mergeado
- planGenerator base scaleNotes/companions/antagonists raw: PR #74 mergeado (Antigravity)
- Esta PR: el bridge funcional catálogo → planUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)