### PR TITLE
fix(field-feedback): no auto-close del modal post-submit

### DIFF
--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -52,9 +52,12 @@ export default function FieldFeedback() {
       });
       setSubmitted(true);
       setText('');
+      // No auto-cierre: Lili reportó 2026-05-01 que el modal cerraba
+      // antes de que pudiera leer "Guardado", se sentía como bug. Ahora
+      // el botón vuelve a "Enviar" pero el modal persiste hasta que el
+      // user cierre con × o tap fuera (permite enviar feedback en cadena).
       setTimeout(() => {
         setSubmitted(false);
-        setOpen(false);
       }, 1400);
     } catch (err) {
       // Fallback: persistir en localStorage si IndexedDB falla
@@ -69,7 +72,7 @@ export default function FieldFeedback() {
         localStorage.setItem('field_feedback_fallback', JSON.stringify(stored));
         setSubmitted(true);
         setText('');
-        setTimeout(() => { setSubmitted(false); setOpen(false); }, 1400);
+        setTimeout(() => { setSubmitted(false); }, 1400);
       } catch {
         alert('No se pudo guardar el feedback (storage lleno?). Anotalo manual y reportá.');
       }


### PR DESCRIPTION
## Summary
- Quita auto-close del modal de FieldFeedback después de submit exitoso
- Mantiene visual feedback "✓ Guardado" por 1.4s
- User cierra explícitamente con × o tap fuera

## Por qué
Lili reportó 2026-05-01: el modal se cerraba antes de que pudiera leer "Guardado", se sentía como bug ("me deja escribir el comentario pero cuando avanzo después de un segundo se cierra").

## Test plan
- [ ] Abrir modal, escribir feedback, submit → verificar que modal NO se cierra solo
- [ ] Modal persiste con botón "✓ Guardado" verde durante 1.4s, después vuelve a "Enviar"
- [ ] Verificar que se puede enviar otro feedback sin reabrir modal
- [ ] Cerrar manualmente con × o tap fuera funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)