### PR TITLE
fix(plant-asset): remove useless conditional gps meta (CodeQL #29)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.2",
+  "version": "0.12.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v45';
+const CACHE_NAME = 'chagra-v46';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -105,7 +105,10 @@ export default function PlantAssetLog({ onBack, onSave }) {
               : null,
             meta: {
               capturedAt: new Date().toISOString(),
-              gps: location ? { lat: location.lat, lon: location.lon } : null,
+              // location SIEMPRE truthy aquí — el guard `if (!location) return`
+              // de arriba garantiza no llegar a este bloque sin coords. CodeQL
+              // #29 flagged `location ? {...} : null` como useless conditional.
+              gps: { lat: location.lat, lon: location.lon },
             },
           });
         } catch (err) {


### PR DESCRIPTION
## Summary
CodeQL alert #29 — "Useless conditional" en \`src/components/PlantAssetLog.jsx:108\`.

## Análisis
El guard upstream (línea 84):
\`\`\`js
if (!formData.species || !location) {
  onSave('Completa Especie/Nombre y captura la coordenada', true);
  return;
}
\`\`\`
garantiza \`location\` truthy en el bloque savePhoto. El ternary \`location ? {...} : null\` nunca evalúa la rama null → analyzer correcto.

## Fix
\`\`\`diff
- gps: location ? { lat: location.lat, lon: location.lon } : null,
+ gps: { lat: location.lat, lon: location.lon },
\`\`\`
+ comment inline explicando el guard upstream para futuros lectores.

## Test plan
- [x] \`npm run build\` pasa
- [ ] CodeQL re-scan tras merge debería cerrar alert #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)