### PR TITLE
fix(topbar): eliminar botón Settings duplicado (Lili #115)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.7",
+  "version": "0.12.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v50';
+const CACHE_NAME = 'chagra-v51';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { CircleUser, Mic, Plus, Settings, ChevronDown, ChevronUp, Home } from 'lucide-react';
+import { CircleUser, Mic, Plus, ChevronDown, ChevronUp, Home } from 'lucide-react';
 import { version as APP_VERSION } from '../../package.json';
 import EnvironmentalCard from './EnvironmentalCard';
 
@@ -109,14 +109,10 @@ export default function TopBar({ onNavigate, onLogout }) {
         >
           <Plus size={22} aria-hidden="true" strokeWidth={2.5} />
         </button>
-        <button
-          type="button"
-          onClick={() => onNavigate('perfil')}
-          aria-label="Configuración"
-          className="p-2 rounded-lg bg-slate-800/60 hover:bg-slate-700/60 active:bg-slate-700 text-slate-300 min-h-[44px] min-w-[44px] flex items-center justify-center"
-        >
-          <Settings size={20} aria-hidden="true" />
-        </button>
+        {/* Botón Settings (icono ⚙) eliminado — Lili #115: era duplicado del
+            botón operator name de arriba (ambos onNavigate('perfil')). El
+            operator name button es más explícito + el NAV_TILE Perfil del
+            dashboard sigue accesible. */}
 
         {/* Salir (mantiene el comportamiento actual) */}
         <button


### PR DESCRIPTION
## Summary
Closes #115 — TopBar tenía 2 botones navegando a 'perfil' (\`operator name\` + \`Settings ⚙\`). Eliminado el de Settings, el de operator name (más explícito) queda como entry primario.

## Cambio
- \`src/components/TopBar.jsx\`: removed Settings button (líneas 112-119) + import \`Settings\` ícono.
- Resultado: TopBar más limpio, mismo número de entry points pero sin duplicación funcional.

## Test plan
- [x] \`npm run build\` pasa
- [ ] Manual: tap operator name → navega a perfil ✓
- [ ] Manual: tap NAV_TILE Perfil dashboard → navega a perfil ✓
- [ ] Manual: TopBar ya NO muestra ícono Settings ⚙

🤖 Generated with [Claude Code](https://claude.com/claude-code)