### PR TITLE
fix(ux): contexto storytelling en Bio-Eficiencia + voz + bitácora (Lili #107 #108 #110)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.10",
+  "version": "0.12.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v53';
+const CACHE_NAME = 'chagra-v54';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/InputLogForm.jsx
+++ b/src/components/InputLogForm.jsx
@@ -49,6 +49,16 @@ export const InputLogForm = ({ assetId, onComplete }) => {
         notes: formData.notes,
       });
       setFormData((prev) => ({ ...prev, value: '', notes: '' }));
+      // Lili #108: feedback explícito de dónde queda guardada la info.
+      // Antes el form solo limpiaba sin decir nada → user no sabía si
+      // realmente se guardó ni dónde verlo.
+      window.dispatchEvent(new CustomEvent('syncSuccess', {
+        detail: {
+          message: 'Aplicación registrada en Bitácora',
+          actionLabel: 'Ver Bitácora',
+          actionView: 'historial',
+        },
+      }));
       if (onComplete) onComplete();
     } catch (err) {
       console.error('[InputLogForm] Error registrando insumo:', err);
@@ -90,10 +100,12 @@ export const InputLogForm = ({ assetId, onComplete }) => {
             ))}
           </select>
           {selectedInfo && (
-            <span className="text-[10px] text-slate-400 flex items-center gap-1 px-1 mt-1">
-              <Info size={10} className="shrink-0" />
-              <span>{selectedInfo.desc}</span>
-            </span>
+            <div className="text-xs text-slate-300 flex items-start gap-2 px-2 py-2 mt-1 rounded-lg bg-slate-800/60 border border-slate-700/50">
+              <Info size={14} className="shrink-0 text-blue-400 mt-0.5" />
+              <span className="leading-snug">
+                {selectedInfo.desc || 'Sin descripción registrada — agregar en config/materials.js'}
+              </span>
+            </div>
           )}
         </div>
 

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -457,13 +457,26 @@ export default function VoiceCapture({ onSave }) {
       {view === STATE_DONE && (
         <div className="flex flex-col items-center gap-4 py-8">
           <Save size={48} className="text-green-400" />
-          <p className="text-sm text-green-300 text-center">Registro guardado en la cola de sincronización.</p>
-          <button
-            onClick={resetAll}
-            className="px-6 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 rounded-xl font-bold flex items-center gap-2"
-          >
-            <Mic size={18} /> Nueva grabación
-          </button>
+          <div className="text-center max-w-xs">
+            <p className="text-base font-bold text-green-300">Registro guardado ✓</p>
+            <p className="text-xs text-slate-400 mt-1">
+              Se sincronizará con FarmOS cuando haya conexión. Mientras tanto, lo encontrás en <strong className="text-slate-200">Bitácora → Pendientes</strong>.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 justify-center">
+            <button
+              onClick={resetAll}
+              className="px-6 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 rounded-xl font-bold flex items-center gap-2"
+            >
+              <Mic size={18} /> Nueva grabación
+            </button>
+            <button
+              onClick={() => window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'historial' } }))}
+              className="px-6 py-3 min-h-[44px] bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2 text-slate-200"
+            >
+              Ver en Bitácora
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
3 issues UX storytelling: hacer visible "dónde queda" la información + clarificar contexto biopreparados.

| # | Cambio |
|---|---|
| **#107** | InputLogForm: \`selectedInfo.desc\` promovido a card visible (text-xs en lugar de text-[10px]) + fallback explícito |
| **#108** | InputLogForm: dispatch syncSuccess con actionLabel "Ver Bitácora" tras registro |
| **#110** | VoiceCapture STATE_DONE: mensaje claro + botón "Ver en Bitácora" |

## Test plan
- [x] \`npm run build\` pasa
- [ ] Manual: form Aplicación insumo muestra desc del biopreparado legible
- [ ] Manual: tras grabar voz → tap "Ver en Bitácora" → navega historial
- [ ] Re-test Lili confirma menos confusión

🤖 Generated with [Claude Code](https://claude.com/claude-code)