### PR TITLE
feat(routing): redirect plant_asset to rich AssetsDashboard form (Lili #113)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.17",
+  "version": "0.12.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v60';
+const CACHE_NAME = 'chagra-v61';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -277,7 +277,10 @@ export default function App() {
       case 'insumos':
         return <InputLog onBack={() => navigate('dashboard')} onSave={showToast} />;
       case 'plant_asset':
-        return <PlantAssetLog onBack={() => navigate('dashboard')} onSave={showToast} />;
+        // Lili #113 — desaparece el form plano. Redirige al rich form de
+        // AssetsDashboard tab=plant que ya tiene SpeciesSelect, GuildSuggestions
+        // y autofill estrato/gremio/producción (mismo modelo que el flujo voz).
+        return <AssetsDashboard onBack={() => navigate('dashboard')} initialTab="plant" initialShowForm />;
       case 'observacion':
         return <ObservationScreen onBack={() => navigate('dashboard')} onSave={showToast} />;
       case 'reportar_invasora':

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -146,7 +146,7 @@ const TAB_LABELS = {
   material: 'Insumo',
 };
 
-export default function AssetsDashboard({ onBack }) {
+export default function AssetsDashboard({ onBack, initialTab, initialShowForm = false }) {
   const {
     plants, structures, equipment, materials, lands,
     isLoading, error, lastSync,
@@ -160,9 +160,14 @@ export default function AssetsDashboard({ onBack }) {
   const [currentZoneId, setCurrentZoneId] = useState(null); // drill-down Fase 17.2
   const [viewMode, setViewMode] = useState('list'); // 'list' | 'map' (Fase 17.3)
 
-  const [activeTab, setActiveTab] = useState('plant');
+  // Lili #113 + decisión 2026-05-02 (deprecar PlantAssetLog plano):
+  // initialTab + initialShowForm permiten que App.jsx case 'plant_asset' redirija
+  // aquí con el form rich abierto directo en tab=plant. Antes el TopBar `+`
+  // navegaba al PlantAssetLog plano que NO usaba SpeciesSelect/GuildSuggestions/
+  // autofill — rich form vivía escondido detrás de Plantas → Siembras → Nuevo.
+  const [activeTab, setActiveTab] = useState(initialTab || 'plant');
   const [searchQuery, setSearchQuery] = useState('');
-  const [showForm, setShowForm] = useState(false);
+  const [showForm, setShowForm] = useState(initialShowForm);
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState(INITIAL_FORM_STATE);
 

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -1,3 +1,15 @@
+/**
+ * @deprecated Lili #113 (2026-05-02) — formulario plano en desuso.
+ *
+ * El routing `case 'plant_asset'` en App.jsx ahora redirige a
+ * `<AssetsDashboard initialTab="plant" initialShowForm />` que sí usa
+ * SpeciesSelect (CROP_TAXONOMY 72+ sp), GuildSuggestions (companion plants)
+ * y autofill estrato/gremio/producción.
+ *
+ * Este archivo se mantiene por backwards-compat de imports + para que
+ * AG/CI no rompan. NO enlazar desde UI nueva. Borrar en v0.6.0 si nada
+ * lo importa.
+ */
 import React, { useState, useEffect, useCallback } from 'react';
 import { ArrowLeft, Camera, MapPin } from 'lucide-react';
 import { savePayload } from '../services/payloadService';


### PR DESCRIPTION
## Summary

- `case 'plant_asset'` (TopBar `+` plantas) ahora redirige a `<AssetsDashboard initialTab="plant" initialShowForm />` en vez del form plano `PlantAssetLog`.
- AssetsDashboard acepta `initialTab` + `initialShowForm` para permitir entrar directo al rich form en tab=plant.
- `PlantAssetLog.jsx` queda marcado `@deprecated` (mantengo archivo por backwards-compat de imports — borrar en v0.6.0 si nada lo enlaza).

## Why

Lili (field test 2026-05-01): "el que reciclaste último de ingreso que viene super plano es el que menos me gusta — desaprovecha toda la inteligencia y todo el modelado de datos que hemos realizado".

El rich form (SpeciesSelect 72+ sp, GuildSuggestions, autofill estrato/gremio/producción) ya existía en AssetsDashboard tab=plant pero estaba escondido detrás de Plantas → Siembras → Nuevo. Esta PR lo hace el flujo default sin duplicar UX.

Cierra #113.

## Test plan

- [ ] Build verde (`npm run build`) — verificado local.
- [ ] Lint verde — verificado local.
- [ ] TopBar `+` desde dashboard abre form rich con SpeciesSelect, no el plano.
- [ ] Plantas → Siembras → Nuevo sigue funcionando como antes.
- [ ] Resto de routes (`activos`, `sembrar`, etc.) intactas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)