### PR TITLE
feat(feedback): audio capture en FieldFeedback + watchdog submit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.18",
+  "version": "0.12.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v61';
+const CACHE_NAME = 'chagra-v62';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -3,64 +3,181 @@
  * field tester) reporte fricciones UX inline durante el test.
  *
  * - Botón fixed bottom-right, no intrusivo
- * - Click → modal con: textarea + tag auto (URL actual + viewport)
+ * - Click → modal con: textarea + botón 🎤 grabar + tag auto (URL + viewport)
  * - Submit → persiste en LOGS store con type='field-feedback' (reusa
- *   schema v7 sin migration)
+ *   schema v7 sin migration). Audio blob inline en el entry (IndexedDB
+ *   acepta Blob nativamente).
  * - Bulk export futuro: script `npm run export:feedback` extrae todo
  *   y crea GitHub Issues en repo Chagra
+ *
+ * Audio capture (Lili — voto operador 2026-05-02): grabar es más rápido
+ * que tipear "hice click acá y pasó X" en el campo. Reusa useVoiceRecorder
+ * (mismo hook que VoiceCapture) — sin pipeline Whisper/qwen, solo Blob
+ * crudo persistido para review humano post-sesión.
  *
  * Sin dependencia de html2canvas — Lili saca screenshot iPhone manual y
  * adjunta luego si quiere. Mantiene bundle liviano.
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { openDB, STORES } from '../db/dbCore';
+import useVoiceRecorder from '../hooks/useVoiceRecorder';
 
 const FAB_SIZE = 52;
 const COLOR_PRIMARY = '#0E92A6';
 const COLOR_ACCENT = '#4ED4E5';
+// Watchdog: si IndexedDB.add() cuelga (Android Chrome bajo presión OPFS
+// reportado por Miguel 2026-05-02), forzamos fallback localStorage para
+// evitar el "ciclo eterno" del botón Enviar.
+const SUBMIT_TIMEOUT_MS = 8000;
+
+const formatDuration = (ms) => {
+  const s = Math.floor(ms / 1000);
+  return `${s}s`;
+};
 
 export default function FieldFeedback() {
   const [open, setOpen] = useState(false);
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  // Audio state — el hook gestiona MediaRecorder + permisos + hard limit 30s.
+  const { isRecording, audioLevel, durationMs, error: recorderError, start, stop, reset, hardLimitMs } = useVoiceRecorder();
+  const [audioBlob, setAudioBlob] = useState(null);
+  const [audioMime, setAudioMime] = useState('');
+  const [audioDur, setAudioDur] = useState(0);
+  const [audioUrl, setAudioUrl] = useState(null);
+
+  // Cleanup blob URL al cerrar/desmontar (evita leak memory).
+  useEffect(() => {
+    return () => {
+      if (audioUrl) URL.revokeObjectURL(audioUrl);
+    };
+  }, [audioUrl]);
+
+  const handleStartRecord = async () => {
+    setErrorMsg('');
+    try {
+      await start();
+    } catch (err) {
+      setErrorMsg(err?.message || 'No se pudo activar el micrófono');
+    }
+  };
+
+  const handleStopRecord = async () => {
+    try {
+      const result = await stop();
+      if (result?.blob) {
+        if (audioUrl) URL.revokeObjectURL(audioUrl);
+        const url = URL.createObjectURL(result.blob);
+        setAudioBlob(result.blob);
+        setAudioMime(result.mimeType);
+        setAudioDur(result.durationMs);
+        setAudioUrl(url);
+      }
+    } catch (err) {
+      setErrorMsg(err?.message || 'Error finalizando grabación');
+    }
+  };
+
+  const handleDiscardAudio = () => {
+    if (audioUrl) URL.revokeObjectURL(audioUrl);
+    setAudioBlob(null);
+    setAudioMime('');
+    setAudioDur(0);
+    setAudioUrl(null);
+    reset();
+  };
+
+  const handleClose = () => {
+    if (isRecording) stop();
+    handleDiscardAudio();
+    setOpen(false);
+    setText('');
+    setSubmitted(false);
+    setErrorMsg('');
+  };
+
+  const persistWithTimeout = (entry) => {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const watchdog = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error('IndexedDB timeout (8s) — fallback'));
+        }
+      }, SUBMIT_TIMEOUT_MS);
+
+      (async () => {
+        try {
+          const db = await openDB();
+          const tx = db.transaction(STORES.LOGS, 'readwrite');
+          const store = tx.objectStore(STORES.LOGS);
+          await new Promise((res, rej) => {
+            const req = store.add(entry);
+            req.onsuccess = res;
+            req.onerror = () => rej(req.error);
+          });
+          if (!settled) {
+            settled = true;
+            clearTimeout(watchdog);
+            resolve();
+          }
+        } catch (err) {
+          if (!settled) {
+            settled = true;
+            clearTimeout(watchdog);
+            reject(err);
+          }
+        }
+      })();
+    });
+  };
 
   const handleSubmit = async (e) => {
     e?.preventDefault?.();
-    if (!text.trim() || submitting) return;
+    const hasText = text.trim().length > 0;
+    const hasAudio = !!audioBlob;
+    if (!hasText && !hasAudio) return;
+    if (submitting) return;
+
     setSubmitting(true);
+    setErrorMsg('');
+    const entry = {
+      id: `field-feedback-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      type: 'field-feedback',
+      timestamp: new Date().toISOString(),
+      notes: text.trim(),
+      audio: hasAudio
+        ? {
+            blob: audioBlob,
+            mimeType: audioMime,
+            durationMs: audioDur,
+            sizeBytes: audioBlob.size,
+          }
+        : null,
+      ctx: {
+        url: window.location.pathname + window.location.hash,
+        viewport: `${window.innerWidth}×${window.innerHeight}`,
+        ua: navigator.userAgent.slice(0, 200),
+        online: navigator.onLine,
+      },
+    };
+
     try {
-      const db = await openDB();
-      const tx = db.transaction(STORES.LOGS, 'readwrite');
-      const store = tx.objectStore(STORES.LOGS);
-      const entry = {
-        id: `field-feedback-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        type: 'field-feedback',
-        timestamp: new Date().toISOString(),
-        notes: text.trim(),
-        ctx: {
-          url: window.location.pathname + window.location.hash,
-          viewport: `${window.innerWidth}×${window.innerHeight}`,
-          ua: navigator.userAgent.slice(0, 200),
-          online: navigator.onLine,
-        },
-      };
-      await new Promise((resolve, reject) => {
-        const req = store.add(entry);
-        req.onsuccess = resolve;
-        req.onerror = () => reject(req.error);
-      });
+      await persistWithTimeout(entry);
       setSubmitted(true);
       setText('');
+      handleDiscardAudio();
       // No auto-cierre: Lili reportó 2026-05-01 que el modal cerraba
       // antes de que pudiera leer "Guardado", se sentía como bug. Ahora
       // el botón vuelve a "Enviar" pero el modal persiste hasta que el
       // user cierre con × o tap fuera (permite enviar feedback en cadena).
-      setTimeout(() => {
-        setSubmitted(false);
-      }, 1400);
+      setTimeout(() => setSubmitted(false), 1400);
     } catch (err) {
-      // Fallback: persistir en localStorage si IndexedDB falla
+      // Fallback: persistir text en localStorage si IndexedDB falla o cuelga.
+      // Audio NO se persiste en localStorage (binario + cuota 5MB rompe).
       try {
         const stored = JSON.parse(localStorage.getItem('field_feedback_fallback') || '[]');
         stored.push({
@@ -68,18 +185,26 @@ export default function FieldFeedback() {
           text,
           url: window.location.pathname,
           err: String(err),
+          audioLost: hasAudio,
         });
         localStorage.setItem('field_feedback_fallback', JSON.stringify(stored));
         setSubmitted(true);
         setText('');
-        setTimeout(() => { setSubmitted(false); }, 1400);
+        handleDiscardAudio();
+        if (hasAudio) {
+          setErrorMsg('Texto guardado en fallback. Audio se perdió (storage degradado).');
+        }
+        setTimeout(() => setSubmitted(false), 1400);
       } catch {
-        alert('No se pudo guardar el feedback (storage lleno?). Anotalo manual y reportá.');
+        setErrorMsg('No se pudo guardar el feedback (storage lleno?). Anotalo manual.');
       }
     } finally {
       setSubmitting(false);
     }
   };
+
+  const submitDisabled = submitting || (!text.trim() && !audioBlob) || isRecording;
+  const recordingPct = Math.min(100, (durationMs / hardLimitMs) * 100);
 
   return (
     <>
@@ -116,7 +241,7 @@ export default function FieldFeedback() {
         <div
           role="dialog"
           aria-modal="true"
-          onClick={(e) => e.target === e.currentTarget && setOpen(false)}
+          onClick={(e) => e.target === e.currentTarget && handleClose()}
           style={{
             position: 'fixed',
             inset: 0,
@@ -151,7 +276,7 @@ export default function FieldFeedback() {
               </div>
               <button
                 type="button"
-                onClick={() => setOpen(false)}
+                onClick={handleClose}
                 style={{ background: 'transparent', border: 'none', color: '#8b9cab', fontSize: 18, cursor: 'pointer' }}
               >
                 ×
@@ -171,7 +296,7 @@ export default function FieldFeedback() {
               placeholder="Qué pasó, qué confundió, qué cambiarías…"
               style={{
                 width: '100%',
-                minHeight: 110,
+                minHeight: 90,
                 padding: '0.7rem',
                 background: '#111824',
                 border: `1px solid #1a3a4a`,
@@ -186,25 +311,198 @@ export default function FieldFeedback() {
               onBlur={(e) => { e.target.style.borderColor = '#1a3a4a'; }}
             />
 
+            {/* Audio capture row */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.5rem',
+                padding: '0.6rem',
+                background: '#0d1421',
+                border: `1px solid ${isRecording ? '#ef4444' : '#1a3a4a'}`,
+                borderRadius: 4,
+              }}
+            >
+              {!audioBlob && !isRecording && (
+                <button
+                  type="button"
+                  onClick={handleStartRecord}
+                  style={{
+                    background: 'transparent',
+                    color: COLOR_ACCENT,
+                    border: `1px dashed ${COLOR_ACCENT}66`,
+                    padding: '0.6rem',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    fontSize: '0.78rem',
+                    letterSpacing: '0.05em',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '0.4rem',
+                  }}
+                >
+                  🎤 Grabar audio (máx {hardLimitMs / 1000}s)
+                </button>
+              )}
+
+              {isRecording && (
+                <>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: '0.5rem',
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.4rem',
+                        color: '#ef4444',
+                        fontSize: '0.78rem',
+                        fontWeight: 700,
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: '50%',
+                          background: '#ef4444',
+                          boxShadow: '0 0 8px #ef4444',
+                          animation: 'pulse 1s ease-in-out infinite',
+                        }}
+                      />
+                      REC {formatDuration(durationMs)}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleStopRecord}
+                      style={{
+                        background: '#ef4444',
+                        color: '#fff',
+                        border: 'none',
+                        padding: '0.4rem 0.8rem',
+                        borderRadius: 4,
+                        cursor: 'pointer',
+                        fontSize: '0.72rem',
+                        letterSpacing: '0.1em',
+                        fontWeight: 600,
+                      }}
+                    >
+                      ■ DETENER
+                    </button>
+                  </div>
+                  {/* Level meter visual */}
+                  <div
+                    style={{
+                      height: 4,
+                      background: '#1a3a4a',
+                      borderRadius: 2,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: `${Math.max(2, audioLevel * 100)}%`,
+                        height: '100%',
+                        background: '#ef4444',
+                        transition: 'width 80ms linear',
+                      }}
+                    />
+                  </div>
+                  {/* Time progress */}
+                  <div
+                    style={{
+                      height: 2,
+                      background: '#1a3a4a',
+                      borderRadius: 1,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        width: `${recordingPct}%`,
+                        height: '100%',
+                        background: COLOR_ACCENT,
+                      }}
+                    />
+                  </div>
+                </>
+              )}
+
+              {audioBlob && !isRecording && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.4rem' }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      fontSize: '0.72rem',
+                      color: '#8b9cab',
+                    }}
+                  >
+                    <span style={{ color: '#22c55e' }}>
+                      ✓ Audio · {formatDuration(audioDur)} · {(audioBlob.size / 1024).toFixed(0)}KB
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleDiscardAudio}
+                      style={{
+                        background: 'transparent',
+                        color: '#8b9cab',
+                        border: 'none',
+                        cursor: 'pointer',
+                        fontSize: '0.72rem',
+                        textDecoration: 'underline',
+                      }}
+                    >
+                      descartar
+                    </button>
+                  </div>
+                  <audio
+                    controls
+                    src={audioUrl}
+                    style={{ width: '100%', height: 32 }}
+                  />
+                </div>
+              )}
+
+              {recorderError && !isRecording && (
+                <p style={{ fontSize: '0.7rem', color: '#fca5a5', margin: 0 }}>
+                  Mic: {recorderError}
+                </p>
+              )}
+            </div>
+
+            {errorMsg && (
+              <p style={{ fontSize: '0.7rem', color: '#fca5a5', margin: 0 }}>
+                {errorMsg}
+              </p>
+            )}
+
             <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'space-between', alignItems: 'center' }}>
               <span style={{ fontSize: '0.62rem', color: '#4a5664', letterSpacing: '0.08em' }}>
                 Tip: tomá screenshot iPhone para anexar después
               </span>
               <button
                 type="submit"
-                disabled={submitting || !text.trim()}
+                disabled={submitDisabled}
                 style={{
                   background: submitted ? '#22c55e' : COLOR_PRIMARY,
                   color: '#fff',
                   border: 'none',
                   padding: '0.55rem 1rem',
                   borderRadius: 4,
-                  cursor: submitting || !text.trim() ? 'not-allowed' : 'pointer',
+                  cursor: submitDisabled ? 'not-allowed' : 'pointer',
                   fontSize: '0.75rem',
                   letterSpacing: '0.18em',
                   textTransform: 'uppercase',
                   fontWeight: 600,
-                  opacity: !text.trim() ? 0.5 : 1,
+                  opacity: submitDisabled ? 0.5 : 1,
                   transition: 'background 200ms ease',
                 }}
               >
@@ -214,6 +512,13 @@ export default function FieldFeedback() {
           </form>
         </div>
       )}
+
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
     </>
   );
 }


### PR DESCRIPTION
## Summary

- 🎤 Audio capture en el modal del FAB 💬 (`FieldFeedback`). Reusa `useVoiceRecorder` (hard limit 30s, mismo hook que `VoiceCapture`) — sin pipeline Whisper/qwen, audio crudo persistido inline.
- Submit acepta **texto solo, audio solo, o ambos**. Antes requería texto.
- Watchdog 8s en submit → fallback localStorage si IndexedDB cuelga (no solo si lanza error).
- Cleanup `URL.revokeObjectURL` al cerrar/descartar.

## Why

Lili 2026-05-02: "el reporte de fallos debería ser un botón donde el operario grabe un mensaje 'hice click aquí y pasó esto' — tipear bug reports en campo es fricción que mata el feedback".

Plus: Miguel reportó que en Android la "segunda pantalla" del feedback "se cuelga sin hacer nada". El `setSubmitting(true)` quedaba colgado si IndexedDB hangs (no si lanza error). Watchdog 8s lo destranca.

## Test plan

- [x] `npm run build` verde local.
- [x] `npm run lint` verde local.
- [ ] Desktop Chrome: tap 💬 → 🎤 graba → stop → preview audio reproduce → Enviar persiste.
- [ ] Móvil iPhone Safari: idem (verificar permisos mic + audio/mp4 fallback funciona).
- [ ] Móvil Android Chrome: idem (verificar audio/webm + watchdog si IndexedDB lento).
- [ ] Caso solo-texto sigue funcionando como antes.
- [ ] Caso solo-audio (sin texto) persiste y muestra "✓ Guardado".
- [ ] Cerrar modal mientras graba → aborta + descarta blob.

## Storage shape

Entry en `STORES.LOGS` con `type='field-feedback'`:
\`\`\`js
{
  id, type, timestamp, notes,
  audio: { blob: Blob, mimeType, durationMs, sizeBytes } | null,
  ctx: { url, viewport, ua, online }
}
\`\`\`

Para extraer audio bulk en el futuro: el script `npm run export:feedback` debe iterar entries y emitir blobs con nombre \`{id}.{ext}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)