### PR TITLE
feat(insertion): Fase 1 fotos — wire getPhotoUrl en SpeciesSelect + cards + timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.21",
+  "version": "0.12.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/placeholder-species.svg
+++ b/public/placeholder-species.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" fill="#0f172a"/>
+  <rect x="1" y="1" width="198" height="198" fill="none" stroke="#1e293b" stroke-width="2"/>
+  <g transform="translate(100,110)" fill="#334155">
+    <path d="M0,30 Q-25,15 -28,-5 Q-32,-25 -10,-25 Q5,-25 0,-5 Z"/>
+    <path d="M0,30 Q25,15 28,-5 Q32,-25 10,-25 Q-5,-25 0,-5 Z" opacity="0.85"/>
+    <rect x="-1.5" y="20" width="3" height="20" rx="1"/>
+  </g>
+  <text x="100" y="170" text-anchor="middle" font-family="monospace" font-size="11" fill="#475569" letter-spacing="2">SIN FOTO</text>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v64';
+const CACHE_NAME = 'chagra-v65';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo } from 'react';
-import { Sprout, Droplets, Apple, Leaf, RefreshCw, Clock, Bot, Sparkles, Check, X } from 'lucide-react';
+import { Sprout, Droplets, Apple, Leaf, RefreshCw, Clock, Bot, Sparkles, Check, X, Camera } from 'lucide-react';
 import { useLogStore } from '../store/useLogStore';
 import { parseAiInference, parseAiReview } from '../utils/aiInferenceParser';
 import { savePayload } from '../services/payloadService';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
+import { usePhotoUrl } from '../hooks/usePhotoUrl';
 
 /**
  * AssetTimeline — Línea de tiempo agroecológica de un activo (plant).
@@ -78,6 +79,62 @@ const extractNotes = (log) => {
   if (!raw) return '';
   if (typeof raw === 'string') return raw;
   return raw.value || '';
+};
+
+// Detector PHOTO_ATTACHMENT (Fase 1 wiring): los logs de adjuntar foto a un
+// evento se modelan como log--task con marker [PHOTO_ATTACHMENT] +
+// target_log_id + photo_ref (id numérico en media_cache). Patrón append-only
+// definido en useAssetStore.attachPhotoToLog.
+const parsePhotoAttachment = (notes) => {
+  if (!notes || !notes.includes('[PHOTO_ATTACHMENT]')) return null;
+  const photoRefMatch = notes.match(/photo_ref:\s*(\d+)/);
+  const targetMatch = notes.match(/target_log_id:\s*(\S+)/);
+  if (!photoRefMatch) return null;
+  return {
+    photoId: Number(photoRefMatch[1]),
+    targetLogId: targetMatch ? targetMatch[1] : null,
+  };
+};
+
+// Sub-componente con su propio hook usePhotoUrl para no llamarlo dentro del map().
+const PhotoAttachmentThumb = ({ photoId, timestamp, pending }) => {
+  const photo = usePhotoUrl({ photoId });
+  return (
+    <li
+      className={`relative p-3 rounded-xl border bg-fuchsia-900/10 border-fuchsia-700/40 ${pending ? 'opacity-60' : ''}`}
+    >
+      <span className="absolute -left-[26px] top-4 w-4 h-4 rounded-full bg-fuchsia-900 border-2 border-fuchsia-700 flex items-center justify-center">
+        <Camera size={10} className="text-fuchsia-400" />
+      </span>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          {photo.loading ? (
+            <div className="w-16 h-16 rounded bg-slate-800 shrink-0 animate-pulse" />
+          ) : photo.url ? (
+            <img
+              src={photo.url}
+              alt="Foto adjunta al evento"
+              className="w-16 h-16 rounded object-cover bg-slate-800 shrink-0"
+              loading="lazy"
+            />
+          ) : (
+            <div className="w-16 h-16 rounded bg-slate-800 shrink-0 flex items-center justify-center text-slate-600">
+              <Camera size={20} />
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <span className="text-xs font-bold text-fuchsia-400 block">Foto adjunta</span>
+            <p className="text-xs text-slate-500 mt-0.5">
+              {photo.source === 'specific' ? 'Evidencia visual capturada' : 'Foto no encontrada en cache local'}
+            </p>
+          </div>
+        </div>
+        <span className="text-xs text-slate-500 shrink-0 whitespace-nowrap">
+          {timestamp ? new Date(timestamp * 1000).toLocaleDateString('es-CO', { day: '2-digit', month: 'short' }) : '—'}
+        </span>
+      </div>
+    </li>
+  );
 };
 
 const extractQuantity = (log) => {
@@ -159,6 +216,22 @@ export default function AssetTimeline({ assetId }) {
                   const notes = extractNotes(log);
                   const aiData = parseAiInference(notes);
                   const isAi = !!aiData;
+
+                  // Fase 1 wiring fotos (Lili #88): si es un log [PHOTO_ATTACHMENT],
+                  // renderizamos el sub-componente con thumb cargado desde media_cache
+                  // en lugar del entry genérico. Short-circuit evita render condicional
+                  // del hook (regla de hooks).
+                  const photoAttachment = parsePhotoAttachment(notes);
+                  if (photoAttachment) {
+                    return (
+                      <PhotoAttachmentThumb
+                        key={log.id}
+                        photoId={photoAttachment.photoId}
+                        timestamp={log.timestamp}
+                        pending={log._pending}
+                      />
+                    );
+                  }
 
                   // Búsqueda de review (crossing logic)
                   const reviewLog = isAi ? monthLogs.find(l => {

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -12,6 +12,31 @@ import GuildSuggestions from './GuildSuggestions';
 import { geoJsonToWkt } from '../utils/geo';
 import { MapPin, LocateFixed } from 'lucide-react';
 import { useGeolocation } from '../hooks/useGeolocation';
+import { usePhotoUrl } from '../hooks/usePhotoUrl';
+
+// Thumb foto de planta para cards. Sub-componente porque usePhotoUrl no
+// puede llamarse dentro de un map() condicional (regla de hooks).
+// Si no hay foto de usuario para este asset, cae al placeholder (Fase 1
+// — Fase 3 hidratará /catalog-photos/<slug>.jpg con fotos GBIF top-uso).
+// eslint-disable-next-line no-unused-vars -- FallbackIcon SE USA en JSX, eslint react-jsx detection falla en este config
+function PlantCardThumb({ asset, colors, FallbackIcon }) {
+  const photo = usePhotoUrl({ assetId: asset?.id });
+  if (photo.loading || !photo.url) {
+    return (
+      <div className={`p-2.5 rounded-lg ${colors.light} shrink-0`}>
+        <FallbackIcon size={20} className={colors.text} />
+      </div>
+    );
+  }
+  return (
+    <img
+      src={photo.url}
+      alt={asset?.attributes?.name || 'Planta'}
+      className="w-12 h-12 rounded-lg object-cover bg-slate-900 shrink-0 border border-slate-700"
+      loading="lazy"
+    />
+  );
+}
 
 // Catálogos de dominio agroecológico
 const STRUCTURE_EXAMPLES = [
@@ -890,9 +915,13 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
                       onClick={() => setSelectedAsset(asset.id)}
                       className="flex items-center gap-3 flex-1 min-w-0 text-left hover:opacity-80 transition-opacity"
                     >
-                      <div className={`p-2.5 rounded-lg ${colors.light} shrink-0`}>
-                        <TabIcon size={20} className={colors.text} />
-                      </div>
+                      {activeTab === 'plant' ? (
+                        <PlantCardThumb asset={asset} colors={colors} FallbackIcon={TabIcon} />
+                      ) : (
+                        <div className={`p-2.5 rounded-lg ${colors.light} shrink-0`}>
+                          <TabIcon size={20} className={colors.text} />
+                        </div>
+                      )}
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
                           <h4 className="font-bold text-slate-200 truncate text-base">{name}</h4>

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -3,6 +3,7 @@ import { Search, ChevronDown, X } from 'lucide-react';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { resolveSpeciesDefaults } from '../config/speciesDefaults';
 import { fuzzyFilter } from '../utils/fuzzySearch';
+import { usePhotoUrl } from '../hooks/usePhotoUrl';
 
 /**
  * SpeciesSelect — Selector de especie con fuzzy search y autocompletado de defaults.
@@ -30,7 +31,23 @@ const ALL_SPECIES = Object.entries(CROP_TAXONOMY).flatMap(([groupId, group]) =>
 export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
+  const [selectedSpeciesId, setSelectedSpeciesId] = useState(null);
   const wrapperRef = useRef(null);
+
+  // Lookup speciesId desde el value persistido (al re-abrir formulario con datos).
+  // Se prefiere el id explicit del último handleSelect; si no, intenta match exact.
+  useEffect(() => {
+    if (selectedSpeciesId) return;
+    if (!value) return;
+    const match = ALL_SPECIES.find((sp) => sp.name === value);
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- lookup síncrono local, no causa cascading renders (skip si match falla)
+    if (match) setSelectedSpeciesId(match.id);
+  }, [value, selectedSpeciesId]);
+
+  // Foto guía del catálogo según especie elegida (Fase 1 wiring photoService).
+  // Si no hay foto del catálogo en /catalog-photos/<slug>.jpg cae al placeholder.
+  // En el futuro Fase 3 se hidrata el directorio con ~20 fotos top-uso desde GBIF.
+  const photo = usePhotoUrl({ speciesSlug: selectedSpeciesId });
 
   // Cerrar dropdown al clickar fuera
   useEffect(() => {
@@ -49,6 +66,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
   );
 
   const handleSelect = (species) => {
+    setSelectedSpeciesId(species.id);
     onChange(species.name, species.id);
     setQuery('');
     setOpen(false);
@@ -69,6 +87,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
 
   const handleClear = () => {
     onChange('', null);
+    setSelectedSpeciesId(null);
     setQuery('');
   };
 
@@ -144,6 +163,31 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
               </button>
             ))
           )}
+        </div>
+      )}
+
+      {/* Foto guía del catálogo (Fase 1 wiring photoService).
+          Aparece solo si el operario eligió una especie del fuzzy search.
+          Si hay foto del usuario para la misma especie en otra mata se
+          prioriza esa (4-tier resolver de getPhotoUrl). */}
+      {selectedSpeciesId && photo.url && !photo.loading && (
+        <div className="mt-2 flex items-center gap-2 p-2 rounded-lg bg-slate-900 border border-slate-800">
+          <img
+            src={photo.url}
+            alt={value || 'Foto de la especie'}
+            className="w-12 h-12 rounded object-cover bg-slate-800 shrink-0"
+            loading="lazy"
+          />
+          <div className="flex-1 min-w-0">
+            <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold">
+              {photo.source === 'user'
+                ? 'Tu última foto de esta especie'
+                : photo.source === 'catalog'
+                  ? 'Foto del catálogo'
+                  : 'Sin foto aún — la primera que tomes queda como referencia'}
+            </p>
+            <p className="text-xs text-slate-300 truncate">{value}</p>
+          </div>
         </div>
       )}
 

--- a/src/hooks/usePhotoUrl.js
+++ b/src/hooks/usePhotoUrl.js
@@ -1,0 +1,82 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * El hook hace async fetch desde IndexedDB (photoService.getPhotoUrl /
+ * getPhotoById) y necesita seteear state tras cada await. Es el patrón
+ * "fetch + setState in effect" estándar; sin alternativa razonable salvo
+ * useReducer (overkill aquí) o suspense (no aplicable a IndexedDB sync).
+ * El alive flag previene memory leaks por unmount durante el await.
+ */
+import { useEffect, useState } from 'react';
+import { getPhotoUrl, getPhotoById } from '../services/photoService';
+
+/**
+ * usePhotoUrl — Hook que envuelve photoService para resolver URLs de foto
+ * desde React. Maneja el ciclo Blob ObjectURL + revoke automático al
+ * desmontar o cambiar parámetros.
+ *
+ * Tres modos de uso:
+ *   - { assetId, speciesSlug }: resuelve la mejor foto disponible (4-tier
+ *     fallback definido en photoService.getPhotoUrl).
+ *   - { speciesSlug }: usa solo el catálogo / placeholder (útil para
+ *     SpeciesSelect cuando aún no hay asset creado).
+ *   - { photoId }: trae UNA foto específica de media_cache por id (usado
+ *     por AssetTimeline para renderizar PHOTO_ATTACHMENT markers).
+ *
+ * Retorna { url, source, loading } donde source es 'user' | 'catalog'
+ * | 'placeholder' | 'specific' (cuando vino de photoId).
+ */
+export function usePhotoUrl({ assetId, speciesSlug, photoId } = {}) {
+  const [state, setState] = useState({
+    url: null,
+    source: null,
+    loading: true,
+  });
+
+  useEffect(() => {
+    let alive = true;
+    let revokeFn = null;
+    setState((s) => ({ ...s, loading: true }));
+
+    const run = async () => {
+      try {
+        if (photoId != null) {
+          const result = await getPhotoById(photoId);
+          if (!alive) {
+            result?.revoke?.();
+            return;
+          }
+          if (result) {
+            revokeFn = result.revoke;
+            setState({ url: result.url, source: 'specific', loading: false });
+          } else {
+            setState({ url: null, source: 'missing', loading: false });
+          }
+          return;
+        }
+
+        const result = await getPhotoUrl({ assetId, speciesSlug });
+        if (!alive) {
+          result?.revoke?.();
+          return;
+        }
+        revokeFn = result.revoke || null;
+        setState({ url: result.url, source: result.source, loading: false });
+      } catch (err) {
+        if (alive) {
+          console.warn('[usePhotoUrl] Error:', err?.message || err);
+          setState({ url: null, source: 'error', loading: false });
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      alive = false;
+      if (revokeFn) revokeFn();
+    };
+  }, [assetId, speciesSlug, photoId]);
+
+  return state;
+}
+
+export default usePhotoUrl;

--- a/src/services/photoService.js
+++ b/src/services/photoService.js
@@ -26,7 +26,7 @@ import { openDB, STORES } from '../db/dbCore';
 const MAX_DIMENSION = 1600;       // px en el lado mayor
 const TARGET_QUALITY = 0.82;      // JPEG quality
 const MAX_BYTES = 500 * 1024;     // 500 KB target después de compress
-const PLACEHOLDER_URL = '/placeholder-species.jpg';
+const PLACEHOLDER_URL = '/placeholder-species.svg';
 const CATALOG_PHOTOS_BASE = '/catalog-photos';
 
 /**
@@ -188,6 +188,36 @@ export async function listUserPhotosBySpecies(speciesSlug) {
       resolve(all.filter((p) => p.speciesSlug === speciesSlug));
     };
     req.onerror = () => resolve([]);
+  });
+}
+
+/**
+ * Lee una foto específica de media_cache por su id.
+ * Usado por AssetTimeline para renderizar PHOTO_ATTACHMENT markers
+ * (cada [PHOTO_ATTACHMENT] log apunta a un media_cache.id vía photo_ref).
+ *
+ * @param {number} photoId
+ * @returns {Promise<{url: string, revoke: () => void} | null>}
+ */
+export async function getPhotoById(photoId) {
+  if (photoId == null) return null;
+  const numericId = typeof photoId === 'string' ? Number(photoId) : photoId;
+  if (Number.isNaN(numericId)) return null;
+  const db = await openDB();
+  const tx = db.transaction(STORES.MEDIA_CACHE, 'readonly');
+  const store = tx.objectStore(STORES.MEDIA_CACHE);
+  return new Promise((resolve) => {
+    const req = store.get(numericId);
+    req.onsuccess = () => {
+      const rec = req.result;
+      if (!rec || !rec.blob) {
+        resolve(null);
+        return;
+      }
+      const url = URL.createObjectURL(rec.blob);
+      resolve({ url, revoke: () => URL.revokeObjectURL(url) });
+    };
+    req.onerror = () => resolve(null);
   });
 }
 


### PR DESCRIPTION
## Summary

Fase 1 del plan multifase módulo inserción de plantas (acordado 2026-05-02). El service `photoService.getPhotoUrl()` ya tenía cadena de 4 fallbacks (asset → species override → catálogo → placeholder) pero **cero consumidores**. Esta PR cabela el service en 3 puntos donde Lili y David ven foto.

## Cambios

- **Placeholder**: `/public/placeholder-species.svg` (planta estilizada + "SIN FOTO"). `photoService.PLACEHOLDER_URL` → `.svg`.
- **`photoService.getPhotoById(id)`**: nueva función para fetchar foto específica desde media_cache (necesaria para `[PHOTO_ATTACHMENT]` timeline render).
- **Hook `usePhotoUrl`** (`src/hooks/usePhotoUrl.js`): wrapper React de photoService. Maneja Blob ObjectURL + revoke en unmount. 3 modos: best-photo / catalog-only / specific-by-id.
- **`SpeciesSelect.jsx`**: al elegir especie del fuzzy search, muestra thumbnail debajo del input con label contextual ("Tu última foto" / "Foto del catálogo" / "Sin foto aún — la primera que tomes queda como referencia"). La hoja de vida arranca antes de crear el asset.
- **`AssetTimeline.jsx`**: detector regex `[PHOTO_ATTACHMENT]` renderiza sub-componente `PhotoAttachmentThumb` con thumb 64×64 inline. Antes el log--task con marker caía al DEFAULT_CONFIG (icono Leaf genérico).
- **`AssetsDashboard.jsx`**: cards de plantas (tab='plant') ahora muestran thumb 48×48 en lugar del icono. Otros tabs siguen con icono.

## Decisiones tomadas (memoria 2026-05-02)

- **NO hay cross-farm photo sharing**. Foto = privada al asset y la finca. La foto del catálogo es solo guía visual al elegir especie.
- **Hoja de vida por mata individual** (10 matas en balcón → 10 hojas de vida).
- Modelo quantity (1-asset-qty=N vs N-asset-qty=1) NO se decide en esta PR — es DR-032 separado, esta Fase 1 es ortogonal.

## NO cubre (Fase 2-6 del plan)

- Modelo quantity → DR-032 pendiente
- Bundle catalog photos GBIF → Fase 3
- Schema v3.2 photo_url + spacing_cm → Fase 4
- Mass insert + CSV → Fase 5 (bloqueada por DR-032)
- Tab Fotos + fenofase → Fase 6

## Test plan

- [x] `npm run build` verde local.
- [x] `npm run lint` verde local.
- [ ] Crear planta nueva → SpeciesSelect → elegir Gulupa → ver thumbnail "SIN FOTO" debajo (placeholder).
- [ ] Adjuntar foto via Bitácora → volver a card de plantas → ver thumbnail real reemplazó al placeholder.
- [ ] AssetTimeline muestra eventos `[PHOTO_ATTACHMENT]` con thumbnail inline.
- [ ] Otras tabs (structure/equipment/material) siguen mostrando icono normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)