### PR TITLE
fix(eslint): limpiar imports unused (CodeQL alerts) + StorageEvent → CustomEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.22",
+  "version": "0.12.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v65';
+const CACHE_NAME = 'chagra-v66';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,8 @@ const LoginScreen = lazy(() => import('./components/LoginScreen'));
 const HarvestLog = lazy(() => import('./components/HarvestLog'));
 const SeedingLog = lazy(() => import('./components/SeedingLog'));
 const InputLog = lazy(() => import('./components/InputLog'));
-const PlantAssetLog = lazy(() => import('./components/PlantAssetLog'));
+// PlantAssetLog @deprecated 2026-05-02 — case 'plant_asset' redirige a
+// AssetsDashboard rich form. Import removido para limpiar dead code (CodeQL #38).
 const ObservationScreen = lazy(() => import('./components/ObservationScreen'));
 const InvasiveObservationLog = lazy(() => import('./components/InvasiveObservationLog'));
 const MaintenanceScreen = lazy(() => import('./components/MaintenanceScreen'));

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Wrench, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { fetchFromFarmOS } from '../services/apiService';
 import AssetDetailView from './AssetDetailView';

--- a/src/components/InvasiveObservationLog.jsx
+++ b/src/components/InvasiveObservationLog.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { ArrowLeft, Camera, MapPin, AlertCircle, CheckCircle } from 'lucide-react';
+import { ArrowLeft, AlertCircle, CheckCircle } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
 import { getAllSpecies } from '../db/catalogDB';
 import PhotoCaptureField from './PhotoCaptureField';

--- a/src/components/PlantAssetLog.jsx
+++ b/src/components/PlantAssetLog.jsx
@@ -11,7 +11,7 @@
  * lo importa.
  */
 import React, { useState, useEffect, useCallback } from 'react';
-import { ArrowLeft, Camera, MapPin } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
 import { savePhoto } from '../services/photoService';
 import GeolocationButton from './GeolocationButton';

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -38,16 +38,22 @@ export default function ProfileScreen({ onBack }) {
   );
   const [savedFlash, setSavedFlash] = useState(false);
 
-  // Persistir cambios al storage en cada modificación + emitir storage
-  // event manual (para que TopBar y otros listeners se actualicen).
+  // Persistir cambios al storage en cada modificación + emitir custom event
+  // (CodeQL flag #36/#37 contra StorageEvent ctor — migrado a CustomEvent
+  // que es el patrón canónico para same-tab pub/sub. TopBar escucha ambos
+  // 'storage' (cross-tab nativo) y 'chagra:operator-update' (same-tab).
   useEffect(() => {
     localStorage.setItem('chagra:operator:name', name);
-    window.dispatchEvent(new StorageEvent('storage', { key: 'chagra:operator:name', newValue: name }));
+    window.dispatchEvent(new CustomEvent('chagra:operator-update', {
+      detail: { key: 'chagra:operator:name', value: name },
+    }));
   }, [name]);
 
   useEffect(() => {
     localStorage.setItem('chagra:operator:role', role);
-    window.dispatchEvent(new StorageEvent('storage', { key: 'chagra:operator:role', newValue: role }));
+    window.dispatchEvent(new CustomEvent('chagra:operator-update', {
+      detail: { key: 'chagra:operator:role', value: role },
+    }));
   }, [role]);
 
   const handleSave = () => {

--- a/src/components/StatusBadge.jsx
+++ b/src/components/StatusBadge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PLANT_STATUSES, TASK_STATUSES, PEST_STATUSES, STATUS_MAP } from '../constants/assetStatuses';
+import { PLANT_STATUSES, STATUS_MAP } from '../constants/assetStatuses';
 
 const StatusBadge = ({ status, type, editable = false, onChange, className = "" }) => {
     // Backward compatibility: map "active" to "growing" for plants

--- a/src/components/TaskScreen.jsx
+++ b/src/components/TaskScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { ArrowLeft, Calendar, FileText, Tag, Briefcase, Layout } from 'lucide-react';
+import { ArrowLeft, FileText, Tag, Briefcase, Layout } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import DateField from './DateField';
 import StatusBadge from './StatusBadge';

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -43,15 +43,25 @@ export default function TopBar({ onNavigate, onLogout }) {
       : 'Operador'
   );
 
-  // Re-leer si cambia desde otro tab (sync entre instancias PWA).
+  // Re-leer si cambia desde otro tab (storage event nativo) O desde el mismo
+  // tab via ProfileScreen (chagra:operator-update CustomEvent).
   useEffect(() => {
     const onStorage = (e) => {
       if (e.key === 'chagra:operator:name') {
         setOperatorName(e.newValue || 'Operador');
       }
     };
+    const onOperatorUpdate = (e) => {
+      if (e.detail?.key === 'chagra:operator:name') {
+        setOperatorName(e.detail.value || 'Operador');
+      }
+    };
     window.addEventListener('storage', onStorage);
-    return () => window.removeEventListener('storage', onStorage);
+    window.addEventListener('chagra:operator-update', onOperatorUpdate);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener('chagra:operator-update', onOperatorUpdate);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
Resuelve 8 alertas CodeQL: 6 unused imports + 2 superfluous trailing args en StorageEvent ctor. ESLint config root cause documentado para follow-up.