### PR TITLE
feat(voice): tracking_mode en VoiceCapture — voz honra individual vs aggregate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.24",
+  "version": "0.12.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v67';
+const CACHE_NAME = 'chagra-v68';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -6,6 +6,7 @@ import { extractEntities } from '../services/entityExtractor';
 import { syncManager } from '../services/syncManager';
 import { savePayload } from '../services/payloadService';
 import { ENV } from '../config/env';
+import { resolveSpeciesDefaults } from '../config/speciesDefaults';
 import Sparkline from './common/Sparkline';
 import AIStreamPanel from './common/AIStreamPanel';
 import VoiceConfirmation from './VoiceConfirmation';
@@ -282,7 +283,34 @@ export default function VoiceCapture({ onSave }) {
     let savedCount = 0;
     const errors = [];
 
+    // ADR-030 Bloque A Regla 1: expandir entities individual+qty>1 en N entities
+    // con qty=1 cada una. Cada entity resultante crea 1 asset+log inline (UUID
+    // único). Para entities aggregate o single (qty=1), comportamiento sin cambio.
+    const expandedEntities = [];
     for (const entity of confirmedEntities) {
+      const defaults = entity.cropSlug ? resolveSpeciesDefaults(entity.cropSlug) : null;
+      const trackingMode = defaults?.tracking_mode || 'individual';  // default conservativo
+      const qty = parseInt(entity.quantity, 10) || 1;
+
+      if (trackingMode === 'individual' && qty > 1) {
+        // Expandir a N entities con qty=1 cada una, name indexado "X #1", "X #2"...
+        const padLen = String(qty).length;
+        for (let i = 0; i < qty; i++) {
+          const indexedName = `${entity.canonical || entity.crop} #${String(i + 1).padStart(padLen, '0')}`;
+          expandedEntities.push({
+            ...entity,
+            quantity: 1,
+            canonical: indexedName,  // sobreescribe canonical para el inlinePlant.attributes.name
+            _individualIndex: i + 1,
+            _individualTotal: qty,
+          });
+        }
+      } else {
+        expandedEntities.push(entity);
+      }
+    }
+
+    for (const entity of expandedEntities) {
       try {
         const payload = buildSeedingPayload(entity);
         const result = await savePayload('seeding', payload);


### PR DESCRIPTION
## Summary

Cierra gap consumer-side voz para tracking_mode. Voz ahora honra catalog v3.2 igual que AssetsDashboard form (PR #141).

| Voz dice | Antes | Ahora |
|---|---|---|
| "Sembré 100 cafés" | 1 asset qty=100 ❌ | **100 assets "Café #001..#100"** ✓ |
| "Sembré 100 fresas" | 1 asset qty=100 | 1 asset qty=100 ✓ igual (aggregate) |
| "5 cafés y 30 lechugas" | 1+1 assets | 5 individual + 1 aggregate ✓ mixed bag |
| "Sembré 1 gulupa" | 1 asset | 1 asset ✓ |

## Cambios

- `VoiceCapture.jsx` import `resolveSpeciesDefaults`
- `handleConfirmSave` pre-expande entities individual+qty>1 → N entities qty=1 con name indexado padded
- Default conservativo 'individual' si species no en catálogo

## Pendiente próximo

- Mass-insert UI confirm pre-creación (queue/034)

🤖 Generated with [Claude Code](https://claude.com/claude-code)