### PR TITLE
fix(insertion): plant invisible en zona drill-down + audio loop iOS defensive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.27",
+  "version": "0.12.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v70';
+const CACHE_NAME = 'chagra-v71';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -385,6 +385,11 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
         id,
         type: `asset--${activeTab}`,
         attributes: assetAttributes,
+        // Bug fix 2026-05-03: incluir relationships en optimistic asset.
+        // Sin esto, getParentLandId(asset) retorna null y el drill-down por
+        // zona filtra la planta aunque SÍ está guardada en IDB. Usuario
+        // creaba zona + agregaba planta dentro y "no aparecía".
+        ...(baseRels ? { relationships: baseRels } : {}),
         _pending: true,
         _createdAt: Date.now(),
       });

--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -465,6 +465,8 @@ export default function FieldFeedback() {
                   </div>
                   <audio
                     controls
+                    loop={false}
+                    preload="metadata"
                     src={audioUrl}
                     style={{ width: '100%', height: 32 }}
                   />


### PR DESCRIPTION
Bug crítico pre-Lili field test: optimistic asset omitía relationships → drill-down filter ocultaba la planta aunque se guardaba bien en IDB. Fix 1 línea. Plus defensive audio loop=false + preload metadata para iOS.