### PR TITLE
feat(suggestions): plan + biopreparado post-create asset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.31",
+  "version": "0.12.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v74';
+const CACHE_NAME = 'chagra-v75';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -9,10 +9,13 @@ import MapPicker from './MapPicker';
 import FarmMap from './FarmMap';
 import SpeciesSelect from './SpeciesSelect';
 import GuildSuggestions from './GuildSuggestions';
+import BiopreparadoSuggestionModal from './BiopreparadoSuggestionModal';
 import { geoJsonToWkt } from '../utils/geo';
 import { MapPin, LocateFixed } from 'lucide-react';
 import { useGeolocation } from '../hooks/useGeolocation';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
+import { findBiopreparadosByIngredient } from '../db/catalogDB';
+import { generatePlanForPlant } from '../services/planGeneratorService';
 
 // Thumb foto de planta para cards. Sub-componente porque usePhotoUrl no
 // puede llamarse dentro de un map() condicional (regla de hooks).
@@ -193,6 +196,10 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   const { request: requestGeo } = useGeolocation();
 
   const [showMapPicker, setShowMapPicker] = useState(false);
+  // Sugerencias post-create. Miguel UX 2026-05-03: cuando user agrega
+  // material (melaza/suero) al inventario, sugerir biopreparados que pueda
+  // hacer con ese ingrediente. State del modal: { ingredientName, biopreparados[] }
+  const [biopreparadoSuggestion, setBiopreparadoSuggestion] = useState(null);
   const [currentZoneId, setCurrentZoneId] = useState(null); // drill-down Fase 17.2
   const [viewMode, setViewMode] = useState('list'); // 'list' | 'map' (Fase 17.3)
 
@@ -416,6 +423,34 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       }
 
       window.dispatchEvent(new CustomEvent('taskAdded'));
+
+      // Sugerencias post-create según tipo de asset (Fase 21 — high-impact wiring)
+      if (activeTab === 'material' && formData.name?.trim()) {
+        findBiopreparadosByIngredient(formData.name.trim())
+          .then((recipes) => {
+            if (recipes.length > 0) {
+              setBiopreparadoSuggestion({
+                ingredientName: formData.name.trim(),
+                biopreparados: recipes,
+              });
+            }
+          })
+          .catch((err) => console.warn('[AssetsDashboard] biopreparado suggestion failed:', err));
+      } else if (activeTab === 'plant' && formData.speciesId) {
+        generatePlanForPlant({
+          assetId: assetUUIDs[0],
+          speciesSlug: formData.speciesId,
+          plantingDate: new Date().toISOString(),
+        }).then((plan) => {
+          if (plan?.steps?.length > 0) {
+            window.dispatchEvent(new CustomEvent('chagraToast', {
+              detail: {
+                message: `Plan de alimentación sugerido para ${formData.name} (${plan.steps.length} pasos). Ver en Bodega → Planes.`,
+              },
+            }));
+          }
+        }).catch((err) => console.warn('[AssetsDashboard] plan generation failed:', err));
+      }
 
       // Limpieza de UI solo tras éxito del commit IDB
       resetForm();
@@ -1135,6 +1170,15 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             setShowMapPicker(false);
           }}
           onCancel={() => setShowMapPicker(false)}
+        />
+      )}
+
+      {/* Modal sugerencia biopreparados post-create material (Miguel UX 2026-05-03) */}
+      {biopreparadoSuggestion && (
+        <BiopreparadoSuggestionModal
+          ingredientName={biopreparadoSuggestion.ingredientName}
+          biopreparados={biopreparadoSuggestion.biopreparados}
+          onClose={() => setBiopreparadoSuggestion(null)}
         />
       )}
     </div>

--- a/src/components/BiopreparadoSuggestionModal.jsx
+++ b/src/components/BiopreparadoSuggestionModal.jsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { X, Beaker, Clock, ChevronDown, ChevronRight, BookOpen } from 'lucide-react';
+
+/**
+ * BiopreparadoSuggestionModal — Modal sugerencia de biopreparados para un
+ * ingrediente que el operador acaba de agregar al inventario.
+ *
+ * Trigger: post-create asset--material en AssetsDashboard.handleSave si
+ * findBiopreparadosByIngredient(material.name) devuelve >= 1 receta.
+ *
+ * UX: lista colapsable de biopreparados que pueden hacerse con ese material.
+ * Tap en uno expande receta (proceso_resumen + tiempo + ingredientes
+ * faltantes que el operador necesitaría).
+ *
+ * Miguel UX 2026-05-03: "si el usuario agrega a la bodega melaza o suero
+ * de leche chagra automaticamente sugiere la creacion de biopreparado o
+ * en caso de que no sugiere y enseña como se hace".
+ *
+ * Props:
+ *   - ingredientName: string del material que disparó la sugerencia
+ *   - biopreparados: array de biopreparado objects desde catalogDB
+ *   - onClose: callback cierre modal
+ */
+export default function BiopreparadoSuggestionModal({ ingredientName, biopreparados, onClose }) {
+  const [expandedId, setExpandedId] = useState(null);
+
+  if (!biopreparados || biopreparados.length === 0) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+      className="fixed inset-0 z-[100] bg-black/70 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4"
+    >
+      <div className="w-full max-w-lg bg-slate-950 border border-emerald-800/50 rounded-t-2xl sm:rounded-2xl flex flex-col max-h-[85vh] overflow-hidden">
+        {/* Header */}
+        <header className="p-4 bg-gradient-to-r from-emerald-900/40 to-emerald-950/40 border-b border-emerald-800/40 flex items-start gap-3 shrink-0">
+          <Beaker size={22} className="text-emerald-400 mt-0.5 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-bold text-emerald-300">¡Tenés {ingredientName}!</h3>
+            <p className="text-xs text-slate-400 mt-0.5">
+              Con esto podés preparar {biopreparados.length} biopreparado{biopreparados.length > 1 ? 's' : ''} agroecológico{biopreparados.length > 1 ? 's' : ''}:
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="p-2 hover:bg-slate-800 rounded text-slate-400 shrink-0"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        {/* Body — lista colapsable de biopreparados */}
+        <div className="flex-1 overflow-y-auto p-3 space-y-2">
+          {biopreparados.map((bp) => {
+            const isOpen = expandedId === bp.id;
+            return (
+              <div
+                key={bp.id}
+                className="rounded-xl border border-slate-800 bg-slate-900 overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => setExpandedId(isOpen ? null : bp.id)}
+                  className="w-full p-3 flex items-center gap-3 hover:bg-slate-800/60 active:bg-slate-800 text-left min-h-[56px]"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-bold text-white truncate">{bp.nombre}</p>
+                    <p className="text-[11px] text-slate-500">
+                      {bp.tipo} · {bp.tiempo_elaboracion_dias ? `${bp.tiempo_elaboracion_dias} días` : 'tiempo variable'}
+                      {Array.isArray(bp.proposito) && ` · ${bp.proposito.slice(0, 2).join(', ')}`}
+                    </p>
+                  </div>
+                  {isOpen ? <ChevronDown size={16} className="text-slate-500" /> : <ChevronRight size={16} className="text-slate-500" />}
+                </button>
+
+                {isOpen && (
+                  <div className="px-4 pb-4 pt-1 text-xs text-slate-300 space-y-3 border-t border-slate-800">
+                    {bp.ingredientes && bp.ingredientes.length > 0 && (
+                      <div>
+                        <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">Ingredientes</p>
+                        <div className="flex flex-wrap gap-1">
+                          {bp.ingredientes.map((ing, i) => {
+                            const isMatch = ing.toLowerCase().includes(ingredientName.toLowerCase());
+                            return (
+                              <span
+                                key={i}
+                                className={`text-[11px] px-2 py-0.5 rounded ${
+                                  isMatch
+                                    ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-800'
+                                    : 'bg-slate-800 text-slate-400'
+                                }`}
+                              >
+                                {ing}
+                              </span>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
+                    {bp.proceso_resumen && (
+                      <div>
+                        <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1 flex items-center gap-1">
+                          <BookOpen size={10} /> Proceso
+                        </p>
+                        <p className="text-xs text-slate-300 leading-relaxed">{bp.proceso_resumen}</p>
+                      </div>
+                    )}
+                    <div className="flex flex-wrap gap-3 text-[10px] text-slate-500">
+                      {bp.tiempo_elaboracion_dias && (
+                        <span className="inline-flex items-center gap-1">
+                          <Clock size={10} /> Elaboración: {bp.tiempo_elaboracion_dias} días
+                        </span>
+                      )}
+                      {bp.vida_util_dias && (
+                        <span>Vida útil: {bp.vida_util_dias} días</span>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <footer className="p-3 border-t border-slate-800 shrink-0">
+          <p className="text-[10px] text-slate-600 italic text-center">
+            Recetas curadas por catálogo Chagra. Las cantidades exactas y proporciones se especificarán en futuros field guides.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -146,11 +146,58 @@ export async function getNativeSubstitutesForInvasive(invasiveId, options = {}) 
     return results;
 }
 
+/**
+ * Lista todos los biopreparados del catálogo.
+ * @returns {Promise<Array<biopreparado>>}
+ */
+export async function getAllBiopreparados() {
+    if (!dbInstance) await initCatalog();
+    const rows = dbInstance.exec({
+        sql: 'SELECT data FROM biopreparados ORDER BY nombre',
+        rowMode: 'object',
+    });
+    return rows.map((r) => JSON.parse(r.data));
+}
+
+/**
+ * Encuentra biopreparados que usan un ingrediente específico (Miguel UX
+ * 2026-05-03: cuando user agrega melaza a bodega, sugerir Bocashi/Biol/etc).
+ *
+ * Match fuzzy: normaliza ambos lados (lowercase + sin tildes) y comprueba
+ * substring. Maneja sinónimos comunes (suero ↔ suero de leche, leche
+ * ↔ suero de leche).
+ *
+ * @param {string} ingredientName — nombre del material como lo añadió user
+ * @returns {Promise<Array<biopreparado>>}
+ */
+export async function findBiopreparadosByIngredient(ingredientName) {
+    if (!ingredientName || typeof ingredientName !== 'string') return [];
+    if (!dbInstance) await initCatalog();
+    const norm = (s) => (s || '')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .trim();
+    const target = norm(ingredientName);
+    if (target.length < 3) return [];
+
+    const all = await getAllBiopreparados();
+    return all.filter((bp) => {
+        if (!Array.isArray(bp.ingredientes)) return false;
+        return bp.ingredientes.some((ing) => {
+            const ingNorm = norm(ing);
+            return ingNorm.includes(target) || target.includes(ingNorm);
+        });
+    });
+}
+
 if (import.meta.env.DEV) {
     if (typeof window !== 'undefined') {
         window.__chagraCatalog = {
             initCatalog,
             getAllSpecies,
+            getAllBiopreparados,
+            findBiopreparadosByIngredient,
             getSpeciesByThermalZone,
             getNativeSubstitutesForInvasive
         };


### PR DESCRIPTION
## Summary

- AssetsDashboard.handleSave dispara post-create:
  - **planta**: `generatePlanForPlant` async, toast con N pasos del plan sugerido
  - **material**: `findBiopreparadosByIngredient`, modal con recetas que usan ese ingrediente
- BiopreparadoSuggestionModal nuevo: lista colapsable, ingredientes con highlight de match, proceso_resumen + tiempo
- catalogDB: `getAllBiopreparados` + `findBiopreparadosByIngredient` (fuzzy match normalizado)

## Origen

Miguel UX 2026-05-03 (autopilot inventario unwired features, item #1+#2 high-impact):
> si agrego planta de manzana debo tener disponible el plan de alimentación sugerido; si el usuario agrega a la bodega melaza o suero de leche automáticamente sugiere la creación de biopreparado o en caso de que no sugiere y enseña cómo se hace

## Test plan

- [ ] Crear material "melaza" → modal sugiere Bocashi/Biol/etc
- [ ] Crear material "suero de leche" → modal sugiere biopreparados con suero
- [ ] Crear material random ("clavos") → no aparece modal
- [ ] Crear planta con speciesId → toast "Plan de alimentación sugerido para X (N pasos)"
- [ ] Modal biopreparado: expand/collapse cards, chip ingrediente match en verde
- [ ] Cierre modal con tap fuera, X, o ESC

🤖 Generated with [Claude Code](https://claude.com/claude-code)