### PR TITLE
feat(photo): getPhotoForLog + fix logId persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.31",
+  "version": "0.12.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v74';
+const CACHE_NAME = 'chagra-v75';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/photoService.js
+++ b/src/services/photoService.js
@@ -173,6 +173,34 @@ export async function getPhotoUrl({ assetId, speciesSlug } = {}) {
 }
 
 /**
+ * Busca la foto más reciente adjunta a un log específico.
+ *
+ * Útil para componentes que muestran un evento (ej. BitacoraEntryDetail)
+ * y necesitan recuperar la imagen sin re-capturarla — habilita features
+ * como "analizar foto vieja con IA" sin extender el shape del log.
+ *
+ * @param {string} logId — id del log--task / log--seeding / log--observation
+ * @returns {Promise<{url: string, blob: Blob, source: 'user'|'missing', revoke?: () => void}>}
+ *          source='missing' si no hay foto registrada para ese log.
+ */
+export async function getPhotoForLog(logId) {
+  if (!logId) return { url: null, blob: null, source: 'missing' };
+  if (typeof logId !== 'string') return { url: null, blob: null, source: 'missing' };
+
+  const photo = await findLatestUserPhoto({ logId });
+  if (!photo || !photo.blob) {
+    return { url: null, blob: null, source: 'missing' };
+  }
+  const url = URL.createObjectURL(photo.blob);
+  return {
+    url,
+    blob: photo.blob,
+    source: 'user',
+    revoke: () => URL.revokeObjectURL(url),
+  };
+}
+
+/**
  * Lista todas las fotos del usuario para una especie (todas las instalaciones
  * o cultivos del usuario en su finca).
  */
@@ -271,7 +299,7 @@ function canvasToBlob(canvas, type, quality) {
   });
 }
 
-async function findLatestUserPhoto({ assetId, speciesSlug }) {
+async function findLatestUserPhoto({ assetId, speciesSlug, logId }) {
   const db = await openDB();
   const tx = db.transaction(STORES.MEDIA_CACHE, 'readonly');
   const store = tx.objectStore(STORES.MEDIA_CACHE);
@@ -288,7 +316,8 @@ async function findLatestUserPhoto({ assetId, speciesSlug }) {
       const v = cursor.value;
       if (
         (assetId && v.assetId === assetId) ||
-        (speciesSlug && v.speciesSlug === speciesSlug)
+        (speciesSlug && v.speciesSlug === speciesSlug) ||
+        (logId && v.logId === logId)
       ) {
         matches.push(v);
       }

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -674,12 +674,15 @@ const useAssetStore = create((set, get) => ({
     let photoRefId = null;
     try {
       const { savePhoto } = await import('../services/photoService');
+      // logId top-level (no en meta) para que findLatestUserPhoto / getPhotoForLog
+      // puedan filtrar. Bug previo: meta.attachedToLog se descartaba en savePhoto
+      // (record solo respeta meta.capturedAt/gps/notes).
       const saved = await savePhoto({
         blob: photoBlob,
+        logId: targetLogId,
         speciesSlug: null,
         meta: {
           capturedAt: new Date().toISOString(),
-          attachedToLog: targetLogId,
         },
       });
       photoRefId = saved?.id || saved?._photoRefId || null;


### PR DESCRIPTION
## Summary

Extiende photoService para queries de foto por logId. Habilita features tipo "analizar foto vieja de bitácora con IA" sin re-capturar.

### Nuevo

- `photoService.getPhotoForLog(logId)` → `{ url, blob, source, revoke }` (source 'missing' si no hay foto)
- `findLatestUserPhoto` (interno) acepta filtro `logId` además de `assetId`/`speciesSlug`

### Bug fix

`useAssetStore.attachPhotoToLog` pasaba `meta.attachedToLog` pero `savePhoto` solo persiste `meta.capturedAt/gps/notes` (línea 102-118 photoService). Sin el field `logId` top-level, las fotos adjuntadas a logs quedaban sin link queryable — solo recuperables vía parsing del `notes.value` pattern `[PHOTO_ATTACHMENT]` desde AssetTimeline.

### Limitación

Fotos históricas adjuntadas pre-fix necesitarán migration o fallback parsing notes → pendiente decidir si vale el costo del backfill.

### Próximo

PR follow-up: cablear `getPhotoForLog` en BitacoraEntryDetail para que el botón "Analizar con IA" del PR #154 funcione con fotos viejas.

## Test plan

- [ ] Adjuntar foto a un evento bitácora → cerrar app → volver al evento → `getPhotoForLog(entry.id)` devuelve la foto
- [ ] Evento sin foto → `getPhotoForLog` devuelve `source: 'missing'`
- [ ] Foto adjunta queda con `logId` top-level en media_cache (verificar en devtools IndexedDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)