### PR TITLE
feat(adaptive): TaskScreen pre-fill priority + zona último uso

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.31",
+  "version": "0.12.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v74';
+const CACHE_NAME = 'chagra-v75';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/TaskScreen.jsx
+++ b/src/components/TaskScreen.jsx
@@ -5,6 +5,24 @@ import DateField from './DateField';
 import StatusBadge from './StatusBadge';
 import { TASK_STATUSES } from '../constants/assetStatuses';
 
+// Autopilot A (2026-05-03): pre-fill priority + location desde último uso.
+// Reduce friction al crear tareas repetitivas (riego matinal, monitoreo,
+// poda) sin imponer — el usuario sigue editando libremente.
+const LAST_USED_KEY = 'chagra:taskscreen_last';
+function readLastUsed() {
+    try {
+        const raw = localStorage.getItem(LAST_USED_KEY);
+        if (!raw) return null;
+        const obj = JSON.parse(raw);
+        // Sanity check: rechaza si más viejo que 30 días para que el "último"
+        // no contamine UX si el usuario abandonó la app.
+        if (obj.ts && Date.now() - obj.ts > 30 * 24 * 60 * 60 * 1000) return null;
+        return obj;
+    } catch {
+        return null;
+    }
+}
+
 function TaskScreen({ onBack, onSave, initialData }) {
     const plants = useAssetStore((s) => s.plants);
     const structures = useAssetStore((s) => s.structures);
@@ -22,17 +40,25 @@ function TaskScreen({ onBack, onSave, initialData }) {
     // existente. Si no, crear nueva. Lili #106.
     const isEdit = !!initialData?.id;
 
-    const [formData, setFormData] = useState(() => ({
-        name: initialData?.name || initialData?.attributes?.name || '',
-        assetId: initialData?.asset_id || '',
-        locationId: '',
-        notes: initialData?.attributes?.notes?.value || '',
-        due: initialData?.attributes?.timestamp
-            ? initialData.attributes.timestamp.split('T')[0]
-            : new Date().toISOString().split('T')[0],
-        severity: initialData?.severity || 'medium',
-        status: initialData?.attributes?.status || initialData?.status || 'pending'
-    }));
+    const [formData, setFormData] = useState(() => {
+        // En edit mode no aplicamos last-used (ya hay datos canónicos del log).
+        const lastUsed = isEdit ? null : readLastUsed();
+        // Solo aplicamos last-used location si la zona aún existe (evita
+        // referencias zombi a lands borradas).
+        const lastLocationStillExists = lastUsed?.locationId
+            && lands.some((l) => l.id === lastUsed.locationId);
+        return {
+            name: initialData?.name || initialData?.attributes?.name || '',
+            assetId: initialData?.asset_id || '',
+            locationId: lastLocationStillExists ? lastUsed.locationId : '',
+            notes: initialData?.attributes?.notes?.value || '',
+            due: initialData?.attributes?.timestamp
+                ? initialData.attributes.timestamp.split('T')[0]
+                : new Date().toISOString().split('T')[0],
+            severity: initialData?.severity || lastUsed?.severity || 'medium',
+            status: initialData?.attributes?.status || initialData?.status || 'pending'
+        };
+    });
 
     const [isSaving, setIsSaving] = useState(false);
 
@@ -63,6 +89,15 @@ function TaskScreen({ onBack, onSave, initialData }) {
                 onSave('Tarea actualizada (Offline-First)', false);
             } else {
                 await addTaskLog(taskData);
+                // Persistir last-used solo en create (no en edit) para que
+                // la próxima tarea nueva pre-fillee con prioridad + zona usadas.
+                try {
+                    localStorage.setItem(LAST_USED_KEY, JSON.stringify({
+                        severity: formData.severity,
+                        locationId: formData.locationId || null,
+                        ts: Date.now(),
+                    }));
+                } catch { /* localStorage no disponible / quota — silent */ }
                 onSave('Tarea agendada exitosamente (Offline-First)', false);
             }
             setTimeout(() => onBack(), 500);


### PR DESCRIPTION
## Summary

Pre-fill de prioridad + zona en TaskScreen leyendo localStorage `chagra:taskscreen_last` (severity + locationId + ts). Reduce friction para tareas repetitivas (riego matinal, monitoreo, poda).

### Reglas defensivas

- **Solo create mode** — `isEdit=true` ignora last-used (datos canónicos del log)
- **TTL 30 días** — last-used más viejo se descarta (evita contaminación tras abandono)
- **Zone existence check** — `locationId` solo aplica si la zona aún existe (evita refs zombi a lands borradas)
- **Persist on success** — solo en `addTaskLog` exitoso, no en `updateTaskLog`
- **Silent fail** — quota / no disponible no rompe UX

Adaptive context #6 del inventario unwired features (2026-05-03).

## Test plan

- [ ] Crear tarea con severity='high' + zona X → guardar → crear nueva → pre-fill 'high' + zona X
- [ ] Editar tarea existente → no pre-fill (datos canónicos)
- [ ] Borrar zona X → crear nueva tarea → locationId vacío (zone existence check)
- [ ] Limpiar localStorage → crear tarea → defaults estándar (medium + sin zona)

🤖 Generated with [Claude Code](https://claude.com/claude-code)