### PR TITLE
feat(adaptive): InputLogForm pre-fill biopreparado más reciente

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.33",
+  "version": "0.12.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v76';
+const CACHE_NAME = 'chagra-v77';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/InputLogForm.jsx
+++ b/src/components/InputLogForm.jsx
@@ -3,6 +3,23 @@ import { Droplets, Send, Info } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { MATERIAL_PRESETS, UNIT_OPTIONS } from '../config/materials';
 
+// Autopilot #11 (2026-05-03): pre-fill biopreparado más reciente usado por
+// el operador. Reduce friction en aplicaciones repetitivas (bocashi semanal,
+// biol cada riego). Operador siempre puede cambiar — solo es default smart.
+const RECENT_KEY = 'chagra:inputlog_last_material';
+function readRecentMaterial() {
+  try {
+    const stored = localStorage.getItem(RECENT_KEY);
+    if (!stored) return null;
+    // Validar que el material aún existe en MATERIAL_PRESETS (puede haber
+    // sido removido en un release). Si no, fallback a default.
+    const exists = MATERIAL_PRESETS.find((m) => m.name === stored);
+    return exists ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * InputLogForm — Registro de aplicación de bio-insumos (Fase 11.8 / refactor 12.4).
  *
@@ -17,11 +34,16 @@ export const InputLogForm = ({ assetId, onComplete }) => {
   const addInputLog = useAssetStore((state) => state.addInputLog);
   const [loading, setLoading] = useState(false);
 
-  const [formData, setFormData] = useState({
-    material: MATERIAL_PRESETS[0].name,
-    value: '',
-    unit: MATERIAL_PRESETS[0].unit,
-    notes: '',
+  const [formData, setFormData] = useState(() => {
+    const recent = readRecentMaterial();
+    const initialMaterial = recent || MATERIAL_PRESETS[0].name;
+    const preset = MATERIAL_PRESETS.find((m) => m.name === initialMaterial) || MATERIAL_PRESETS[0];
+    return {
+      material: initialMaterial,
+      value: '',
+      unit: preset.unit,
+      notes: '',
+    };
   });
 
   // Auto-ajuste de unidad al cambiar el material seleccionado.
@@ -48,6 +70,10 @@ export const InputLogForm = ({ assetId, onComplete }) => {
         unit: formData.unit,
         notes: formData.notes,
       });
+      // Persistir material usado para próxima apertura del form
+      try {
+        localStorage.setItem(RECENT_KEY, formData.material);
+      } catch { /* localStorage quota / no disponible — silent */ }
       setFormData((prev) => ({ ...prev, value: '', notes: '' }));
       // Lili #108: feedback explícito de dónde queda guardada la info.
       // Antes el form solo limpiaba sin decir nada → user no sabía si


### PR DESCRIPTION
## Summary

Pre-fill del selector de biopreparado con el último material usado por el operador. Reduce friction en aplicaciones repetitivas (bocashi semanal, biol cada riego, microorganismos forestales mensual).

### Reglas defensivas

- **Validación contra MATERIAL_PRESETS** — si el material recordado ya no existe en config (release removió biopreparado), fallback a default. Evita selector con valor inválido
- **Persiste solo en submit exitoso** — form abandonado no contamina el "último usado"
- **Silent fail** si localStorage quota / no disponible
- **No imposición** — operador siempre puede cambiar; es default smart

Adaptive context #11 del inventario unwired features (2026-05-03).

## Test plan

- [ ] Aplicar Bocashi a planta → cerrar modal → reabrir → selector pre-fill Bocashi
- [ ] Aplicar Biol → cerrar → reabrir → selector pre-fill Biol (último gana)
- [ ] Limpiar localStorage → reabrir → selector default (MATERIAL_PRESETS[0])
- [ ] Bug fixture: si MATERIAL_PRESETS removiera "Bocashi" entre versiones, el localStorage stale no rompe — fallback a default

🤖 Generated with [Claude Code](https://claude.com/claude-code)