### PR TITLE
fix(ai-prompts): derivar piso térmico desde altitud cuando falta thermal_zones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.38",
+  "version": "0.12.39",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.39",
+  "version": "0.12.40",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v82';
+const CACHE_NAME = 'chagra-v83';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v81';
+const CACHE_NAME = 'chagra-v82';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/common/ExternalAiButton.jsx
+++ b/src/components/common/ExternalAiButton.jsx
@@ -7,6 +7,7 @@
 
 import React, { useState } from 'react';
 import { Clipboard, Share2, X } from 'lucide-react';
+import { getDeviceAltitude } from '../../services/altitudeService';
 
 const isDemoMode = import.meta.env.VITE_DEMO_MODE === 'true';
 
@@ -63,7 +64,26 @@ export function ExternalAiButton({ context, buildPrompt, label = 'Copiar para IA
     const [fallbackPrompt, setFallbackPrompt] = useState(null);
 
     const handleClick = async () => {
-        const prompt = buildPrompt(context);
+        // Enriquecer context con altitud detectada por GPS si no viene
+        // explícita (Miguel 2026-05-04: el AltitudeBadge mostraba 2550 msnm
+        // pero el prompt decía "altitud no especificada" porque
+        // FARM_CONFIG.ALTITUD_MSNM solo lee env, no GPS).
+        let enrichedContext = context;
+        if (context && (context.altitudMsnm == null)) {
+            try {
+                const detected = await getDeviceAltitude();
+                if (typeof detected === 'number' && Number.isFinite(detected)) {
+                    enrichedContext = { ...context, altitudMsnm: detected };
+                }
+            } catch (err) {
+                // Silent fail — getDeviceAltitude tiene su propio fallback;
+                // si retorna null el builder cae a "altitud no especificada"
+                // que es el comportamiento previo aceptable.
+                console.warn('[ExternalAiButton] altitude resolution failed:', err);
+            }
+        }
+
+        const prompt = buildPrompt(enrichedContext);
 
         if (navigator.clipboard && navigator.clipboard.writeText) {
             try {

--- a/src/services/externalAiPromptBuilder.js
+++ b/src/services/externalAiPromptBuilder.js
@@ -6,6 +6,47 @@
  */
 
 /**
+ * Deriva piso térmico colombiano a partir de altitud en msnm.
+ * Clasificación IDEAM / Caldas modificado:
+ *   - cálido: 0-1000 msnm
+ *   - templado: 1000-2000 msnm
+ *   - frío: 2000-3000 msnm
+ *   - páramo: 3000-3600 msnm
+ *   - glacial: >3600 msnm
+ *
+ * Permite que los prompts incluyan piso térmico aunque
+ * VITE_FARM_THERMAL_ZONES no esté configurado — la altitud sola
+ * basta para inferirlo (Miguel 2026-05-04: "veo en chagra 2550 pero
+ * el prompt dice piso térmico no especificado").
+ *
+ * @param {number} altitudMsnm
+ * @returns {string|null} slug del piso térmico o null si no se puede inferir
+ */
+export function deriveThermalZoneFromAltitud(altitudMsnm) {
+    if (typeof altitudMsnm !== 'number' || !Number.isFinite(altitudMsnm) || altitudMsnm < 0) {
+        return null;
+    }
+    if (altitudMsnm < 1000) return 'cálido';
+    if (altitudMsnm < 2000) return 'templado';
+    if (altitudMsnm < 3000) return 'frío';
+    if (altitudMsnm < 3600) return 'páramo';
+    return 'glacial';
+}
+
+/**
+ * Resuelve thermal zones efectivos: usa thermalZones explícitos si existen,
+ * sino deriva desde altitud. Devuelve array para mantener compatibilidad con
+ * builders que asumen array.
+ */
+function resolveThermalZones(thermalZones, altitudMsnm) {
+    if (Array.isArray(thermalZones) && thermalZones.length > 0) {
+        return thermalZones;
+    }
+    const derived = deriveThermalZoneFromAltitud(altitudMsnm);
+    return derived ? [derived] : [];
+}
+
+/**
  * Construye un prompt de gremio agroecológico.
  * @param {Object} ctx - Contexto de la especie y el gremio
  * @param {string} ctx.speciesName - Nombre común de la especie
@@ -29,7 +70,8 @@ export function buildGuildExternalPrompt(ctx) {
         municipio,
     } = ctx;
 
-    const zonaTermica = thermalZones.length > 0 ? thermalZones.join(', ') : 'no especificado';
+    const resolvedZones = resolveThermalZones(thermalZones, altitudMsnm);
+    const zonaTermica = resolvedZones.length > 0 ? resolvedZones.join(', ') : 'no especificado';
     const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
     const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
     const companionsStr = companions.length > 0 ? companions.join(', ') : 'ninguno aún';
@@ -81,7 +123,8 @@ export function buildDiagnosticExternalPrompt(ctx) {
         diasDesdeSiembra,
     } = ctx;
 
-    const zonaTermica = thermalZones.length > 0 ? thermalZones.join(', ') : 'no especificado';
+    const resolvedZones = resolveThermalZones(thermalZones, altitudMsnm);
+    const zonaTermica = resolvedZones.length > 0 ? resolvedZones.join(', ') : 'no especificado';
     const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
     const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
     const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;
@@ -124,7 +167,8 @@ export function buildOpenExternalPrompt(ctx) {
         pregunta = '[Escribe tu pregunta aquí]',
     } = ctx;
 
-    const zonaTermica = thermalZones.length > 0 ? thermalZones.join(', ') : 'no especificado';
+    const resolvedZones = resolveThermalZones(thermalZones, altitudMsnm);
+    const zonaTermica = resolvedZones.length > 0 ? resolvedZones.join(', ') : 'no especificado';
     const altitudStr = altitudMsnm ? `${altitudMsnm} msnm` : 'altitud no especificada';
     const ubicacion = [altitudStr, municipio].filter(Boolean).join(', ');
     const especieFull = scientificName ? `${scientificName} (${speciesName})` : speciesName;


### PR DESCRIPTION
## Summary

Miguel 2026-05-04: el prompt de IA externa decía *"agrónomo colombiano especializado en agroecología en piso térmico **no especificado**"* aunque chagra muestra altitud 2550 msnm.

## Causa

`VITE_FARM_THERMAL_ZONES` no configurado en su env → `FARM_CONFIG.THERMAL_ZONES` queda vacío → builders caen a "no especificado" aunque `ALTITUD_MSNM` (2550) sí existe.

## Fix

Helper `deriveThermalZoneFromAltitud(msnm)` usa clasificación **IDEAM / Caldas modificado** para Colombia:

| msnm | Piso térmico |
|---|---|
| 0-1000 | cálido |
| 1000-2000 | templado |
| **2000-3000** | **frío** ← 2550 cae aquí |
| 3000-3600 | páramo |
| >3600 | glacial |

Helper `resolveThermalZones(thermalZones, altitudMsnm)` prefiere thermal_zones explícitos si existen, sino deriva desde altitud.

Aplicado a los 3 builders user-facing:
- `buildGuildExternalPrompt`
- `buildDiagnosticExternalPrompt`
- `buildOpenExternalPrompt`

## Resultado

Prompt para Miguel ahora dice *"agrónomo colombiano especializado en agroecología en piso térmico **frío**"* en lugar de "no especificado". Implícito en altitud, sin requerir config env adicional.

## Test plan

- [ ] Plant detail con altitud 2550 → "Copiar prompt para IA externa" → prompt menciona "piso térmico frío"
- [ ] Plant detail demo mode (3050 msnm) → prompt menciona "páramo"
- [ ] Si VITE_FARM_THERMAL_ZONES está configurado explícito → respeta el valor (no override)
- [ ] Plant detail sin altitud + sin thermal_zones → fallback "no especificado"

🤖 Generated with [Claude Code](https://claude.com/claude-code)