### PR TITLE
feat(help): 3 starter species cycle-content + CycleContentRenderer (ADR-032)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.42",
+  "version": "0.12.43",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/cycle-content/fresa.json
+++ b/public/cycle-content/fresa.json
@@ -1,0 +1,158 @@
+{
+  "species_slug": "fresa",
+  "scientific_name": "Fragaria × ananassa Duch.",
+  "common_names": ["fresa", "frutilla"],
+  "family": "Rosaceae",
+  "agrovoc_concept": "c_7411",
+  "difficulty": "starter_premium",
+  "tiempo_a_cosecha_dias": { "min": 90, "tipico": 120, "max": 180 },
+  "diferenciador_colombiano": "Cundinamarca produce el 73% de la fresa nacional. Industria de viveros locales en Sibaté y Mosquera ofrece plántula Albión adaptada. La amplitud térmica andina ecuatorial (18-25°C día / 8-13°C noche) favorece dulzura y antocianinas — perfil nutracéutico superior a cultivares de baja latitud. Práctica arraigada de productores cundinamarqueses: renovar cultivo cada 2 años con estolones propios.",
+  "leccion_agroecologica": "Cultivo puente entre agricultura sexual (lechuga) y asexual (café/aguacate por injerto). Enseña propagación vegetativa por estolón — clonación natural visible y manejable. Imperativo de higiene del microclima edáfico y función irreemplazable de cobertura muerta (mulch) para separar fruto del suelo.",
+  "thermal_zone_decisions": {
+    "calido": "Marginal. Estrés térmico + ataque crítico de ácaros. NO recomendable para producción agroecológica.",
+    "templado": "Rango operativo. Norte de Santander, parte de Antioquia. Ciclo más corto pero compromete calibre del fruto.",
+    "frio": "ÓPTIMO Cundinamarca (Sibaté, Mosquera, Madrid, Facatativá), Boyacá. Amplitud térmica favorece dulzura. Albión es la variedad dominante en Mosquera.",
+    "paramo": "Marginal salvo en macrotúnel. Riesgo de congelamiento de exudados radiculares >2800 msnm."
+  },
+  "preparacion_tierra": {
+    "matera": {
+      "volumen_min_litros": 4,
+      "volumen_ideal_litros": 8,
+      "profundidad_cm": 18,
+      "mezcla": "35% tierra negra + 35% compost maduro + 20% cascarilla quemada + 10% humus de lombriz",
+      "ph_objetivo": "5.8-6.5 (ligeramente ácido)",
+      "drenaje": "Crítico — capa gruesa de gravilla + perforaciones múltiples. Encharcamiento mata la planta",
+      "reposicion_ciclos": 1
+    },
+    "campo": {
+      "estructura": "Eras elevadas 1.20m × 0.15m alto",
+      "incorporacion": "10-15 t/ha gallinaza compostada 2 meses antes (ICA 1980s; vigente)",
+      "mulch": "Plástico negro o vegetal (cisco de café, paja) — OBLIGATORIO para aislar fruto del sustrato",
+      "riego": "Por goteo, NO aspersión (favorece Botrytis)",
+      "densidad": "50000-60000 plantas/ha (distancia 30×40 cm)"
+    }
+  },
+  "milestones": [
+    {
+      "fase": "pre_siembra_propagacion",
+      "dias_relativos": "-60 a -7",
+      "criterio_observable": "Estolones primarios emitiendo raíces vigorosas en planta madre frigoconservada o en almácigo de vivero",
+      "accion_clave": "Separación del estolón. Inmersión 5 min en solución preventiva (caldo bordelés diluido o agua + Trichoderma)"
+    },
+    {
+      "fase": "trasplante",
+      "dias_relativos": "0",
+      "criterio_observable": "Masa radicular densa y blanca, 4 hojas extendidas, corona consolidada",
+      "accion_clave": "Siembra MILIMÉTRICA a ras de suelo. CRÍTICO: el meristemo apical (corona) NO se entierra (necrosis fúngica) ni se expone (desecación). Profundidad 6 cm desde corte de raíz"
+    },
+    {
+      "fase": "vegetativo_formativo",
+      "dias_relativos": "15 a 60",
+      "criterio_observable": "Emisión temprana de botones florales y nuevos estolones",
+      "accion_clave": "Poda formativa: supresión MANUAL y TOTAL de las primeras flores para inducir engrosamiento de la corona. Aplicaciones foliares B+Ca para mejorar cuajado posterior"
+    },
+    {
+      "fase": "fructificacion",
+      "dias_relativos": "60 a 90",
+      "criterio_observable": "Cuajado de frutos esféricos verdes, transmutando a blanco",
+      "accion_clave": "Despliegue de cobertura muerta (cascarilla, paja) para aislar fruta emergente del sustrato"
+    },
+    {
+      "fase": "cosecha_continua",
+      "dias_relativos": "90 a 180+",
+      "criterio_observable": "Receptáculo engrosado con pigmentación roja en 3/4 de su área",
+      "accion_clave": "Recolección sutil. Limitar manipulación térmica y mecánica del fruto. Cosechas semanales por 12-18 meses bajo manejo agroecológico"
+    }
+  ],
+  "failure_modes": [
+    {
+      "razon": "Botrytis cinerea (moho gris)",
+      "cuando": "Fructificación",
+      "sintoma": "Masa miceliar grisácea y algodonosa sobre flores y drupas",
+      "agente_causal": "Alta humedad relativa estancada",
+      "mitigacion": "Mulch obligatorio, aclareo foliar para ventilación, distancia adecuada, recolección de frutos caídos, Trichoderma drench preventivo",
+      "frecuencia": "muy_comun"
+    },
+    {
+      "razon": "Pudrición de corona por enterramiento",
+      "cuando": "Post-trasplante inmediato",
+      "sintoma": "Follaje central marchito, raíces oscurecidas, muerte rápida de la planta",
+      "agente_causal": "Asfixia o enterramiento patológico del meristemo apical",
+      "mitigacion": "Eras elevadas con drenaje profundo. Respeto absoluto al nivel del cuello en la siembra (corona a ras)",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Araña roja (Tetranychus urticae)",
+      "cuando": "Periodos secos / verano",
+      "sintoma": "Decoloración bronceada y mate en hojas, telarañas microscópicas en envés",
+      "agente_causal": "Plaga favorecida por microclimas áridos",
+      "mitigacion": "Liberación de ácaros fitoseidos depredadores (Phytoseiulus persimilis, Amblyseius spp.), aspersión de extracto ajo-ají, sombra parcial",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Sphaerotheca macularis (oídio)",
+      "cuando": "Vegetativo a fructificación",
+      "sintoma": "Manchas pulverulentas blancas en hojas y frutos",
+      "agente_causal": "Hongo biotrofo, condiciones secas con noches frescas",
+      "mitigacion": "Caldo sulfocálcico al 1.5%, variedades resistentes (Albión moderada), evitar exceso de N",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Verticillium dahliae (marchitez vascular)",
+      "cuando": "Cualquier estadio",
+      "sintoma": "Marchitez progresiva, taponamiento del xilema",
+      "agente_causal": "Hongo edáfico de larga persistencia",
+      "mitigacion": "Rotación obligatoria — NO sembrar fresa después de tomate, papa, berenjena, pimentón. Solarización del lote.",
+      "frecuencia": "ocasional"
+    }
+  ],
+  "companions": [
+    { "especie": "Borago officinalis (borraja)", "razon": "Atrae polinizadores (sírfidos, abejorros) — efecto sobre cuajado", "evidencia": "literatura agronomica" },
+    { "especie": "Tagetes patula (caléndula francesa)", "razon": "Producción de tiofenos nematicidas — control de Meloidogyne", "evidencia": "evidencia experimental" },
+    { "especie": "Allium sativum (ajo)", "razon": "Repelente de ácaros y áfidos; supresión moderada de Fusarium", "evidencia": "tradicion + literatura" },
+    { "especie": "Mentha piperita (menta)", "razon": "Compuestos volátiles desestabilizan radar olfativo de trips y áfidos", "evidencia": "literatura agronomica" },
+    { "especie": "Spinacia oleracea (espinaca)", "razon": "Complementariedad radicular + ventana fenológica fría", "evidencia": "tradicion" }
+  ],
+  "antagonistas": [
+    { "especie": "Solanum lycopersicum (tomate)", "razon": "Comparten Verticillium dahliae" },
+    { "especie": "Solanum tuberosum (papa)", "razon": "Mismo Verticillium" },
+    { "especie": "Solanum melongena (berenjena)", "razon": "Mismo Verticillium" },
+    { "especie": "Brassica oleracea (repollo, brócoli)", "razon": "Compite agresivamente por nitrógeno + modifica desfavorablemente el consorcio bacteriano de la rizósfera" }
+  ],
+  "biopreparados": [
+    { "nombre": "Bocashi", "uso": "200 g/planta al trasplante; 50 g/planta al inicio de cada pico de floración", "fuente": "extrapolacion literatura cubana/mexicana" },
+    { "nombre": "Biol", "uso": "Dilución 5% foliar quincenal en floración", "fuente": "manuales agroecologicos colombianos" },
+    { "nombre": "Supermagro", "uso": "Complemento mensual al 3%", "fuente": "extrapolacion (gap G-B DR-034)" },
+    { "nombre": "Caldo sulfocálcico", "uso": "1% preventivo cada 15 días en época húmeda (control oídio + ácaros)", "fuente": "Cabrera Marulanda et al. 2018 (referencia cruzable desde café/broca)" },
+    { "nombre": "Caldo bordelés", "uso": "0.5% aspersiones espaciadas. EVITAR durante floración", "fuente": "manuales agroecologicos" }
+  ],
+  "cosecha_estimada_kg_por_planta": {
+    "agroecologico_acumulado_12_18_meses": { "min": 0.42, "tipico": 0.6, "max": 1.0 },
+    "por_variedad": {
+      "albion": { "tipico_g_ciclo": 420 },
+      "san_andreas": { "tipico_g_ciclo": 636 },
+      "camino_real": { "tipico_g_ciclo": 507 }
+    },
+    "anti_overpromise": "Cifras superiores divulgadas por agroindustria provienen de sistemas con suelo esterilizado por bromuro de metilo + fertirriego sintético. Métricas hipertróficas inaplicables al ecosistema vivo de la granja orgánica."
+  },
+  "reproduccion": {
+    "tipo_principal": "vegetativa_estolon",
+    "metodo": "99% propagación por estolón. Tras la primera fructificación (mes 6 aprox.), planta madre produce estolones; enraízan en almácigo a 10 cm en cuadrícula durante 30-40 días, luego trasplante a sitio definitivo.",
+    "frigoconservacion": "Plantas madre a 2-4°C por 30-45 días aumentan vigor de estolones — práctica industrial replicable parcialmente en finca con cuarto frío",
+    "hormona_natural_enraizante": "Extracto de sauce (Salix spp.) al 10% por 12h, o miel diluida 1:10",
+    "esqueje": "División de corona posible cuando planta madre desarrolla varias coronas",
+    "injerto": "No aplica",
+    "semilla": "Solo en mejoramiento genético (no operacional). Híbridos F1 segregan en F2 — inviable",
+    "viroses_riesgo": "XLM, Strawberry mottle virus si planta madre infectada. Comprar plántula certificada cada 4 ciclos"
+  },
+  "fuentes_principales": [
+    { "tipo": "peer_reviewed_institucional", "referencia": "Fischer, López-Valencia, Sánchez-Gómez y Acuña-Caita 2018. Ciencia y Tecnología Agropecuaria 19(1):163-178 — caracterización fisicoquímica de variedades en Sibaté (Agrosavia)" },
+    { "tipo": "institucional", "referencia": "Agrosavia ICA hdl.handle.net/20.500.12324/19076 — Manual fresa Cundinamarca" },
+    { "tipo": "peer_reviewed", "referencia": "Revista Colombiana de Ciencias Hortícolas Vol. 8 No. 1 2014 — costos campo abierto vs macrotúnel" },
+    { "tipo": "tesis", "referencia": "UTEA Tesis 2024 — comparativo Albión 420 g, San Andreas 636 g, Camino Real 507 g/planta" },
+    { "tipo": "marco_economico", "referencia": "Finagro/Agrosavia 2018 — Marco de Referencia Agroeconómico Fresa Albión, costo establecimiento Cundinamarca COP 85 millones/ha" }
+  ],
+  "convergencia_dr_034": "3/3 LLMs convergen. Divergencia menor en tier (DeepSeek starter, Gemini + Claude starter_premium) — adoptado starter_premium 2/3.",
+  "curacion_status": "draft_3_llm_consolidated",
+  "curacion_pendiente": ["Validacion agronomo Cundinamarca/Antioquia para datos cuantitativos kg/planta agroecologica colombiana sin biocidas (gap G-A DR-034)", "Curacion presencial 4h secuencia DR-034 — tercera prioridad Claude web (E.x estolon + frigoconservacion, E.ix preparacion matera/macrotunel)"]
+}

--- a/public/cycle-content/lechuga.json
+++ b/public/cycle-content/lechuga.json
@@ -1,0 +1,153 @@
+{
+  "species_slug": "lechuga",
+  "scientific_name": "Lactuca sativa L.",
+  "common_names": ["lechuga", "Batavia", "crespa", "romana", "mantequilla"],
+  "family": "Asteraceae",
+  "agrovoc_concept": "c_4347",
+  "difficulty": "starter",
+  "tiempo_a_cosecha_dias": { "min": 60, "tipico": 70, "max": 90 },
+  "diferenciador_colombiano": "La Sabana de Bogotá (2500-2700 msnm) es uno de los pocos lugares del mundo donde se produce lechuga durante todo el año sin invernadero, gracias a la estabilidad térmica andina ecuatorial. Permite Batavia, crespa y romana sin vernalización forzada.",
+  "leccion_agroecologica": "Es el cultivo escuela por excelencia. Ciclo corto (60-90 días) permite al operador novato observar germinación, trasplante, desarrollo, plagas, y cosecha en una temporada. Enseña gestión milimétrica de humedad edáfica y velocidad de ciclo.",
+  "thermal_zone_decisions": {
+    "calido": "Marginal. Si se cultiva, usar variedades crespa termorresistentes (Lemos Neto et al. 2018: Red Salad Bowl, Crespa Lollo Bionda). Sombreado al 30%, riego por goteo dos veces al día. Riesgo: espigado prematuro por temperaturas >25°C.",
+    "templado": "Rango operativo amplio. Permite Batavia, crespa y romana. Cundinamarca medio (Sibaté, La Calera), Antioquia oriental, Boyacá medio. Ciclo total 60-80 días.",
+    "frio": "Óptimo absoluto. Sabana de Bogotá, altiplano cundiboyacense, Nariño alto. Ciclo más largo (75-90 días) pero plantas más densas, mejor sabor.",
+    "paramo": "Posible solo en variedades crespa muy rústicas con cobertura plástica/macrotúnel. Ciclo se alarga a 90-120 días. Marginal económicamente."
+  },
+  "preparacion_tierra": {
+    "matera": {
+      "volumen_min_litros": 5,
+      "volumen_ideal_litros": 8,
+      "profundidad_cm": 15,
+      "mezcla": "40% tierra negra + 30% compost maduro + 20% cascarilla de arroz quemada o fibra de coco + 10% humus de lombriz",
+      "drenaje": "Capa de gravilla 2 cm en fondo + perforaciones múltiples",
+      "reposicion_ciclos": 2
+    },
+    "campo": {
+      "descompactacion": "Bieldo a 25 cm, sin inversión del prisma del suelo",
+      "incorporacion": "2-3 kg/m² compost o bocashi maduro",
+      "encalado": "1-2 kg cal dolomita/m² si pH < 5.8",
+      "barbecho_dias": 30,
+      "abono_verde": "Vicia, alverja forrajera"
+    }
+  },
+  "milestones": [
+    {
+      "fase": "pre_siembra",
+      "dias_relativos": "-15 a -3",
+      "criterio_observable": "Sustrato semillero hidratado a capacidad de campo",
+      "accion_clave": "Mezcla cascarilla de arroz + tierra. Hidratación 6-12h de semillas en agua a temperatura ambiente"
+    },
+    {
+      "fase": "germinacion",
+      "dias_relativos": "0 a 7",
+      "criterio_observable": "Emergencia uniforme de cotiledones bilobulados verdes pálidos",
+      "accion_clave": "Mantenimiento humedad superficial fina (nebulización), evitar impacto cinético de gotas grandes. Temperatura óptima 18-20°C"
+    },
+    {
+      "fase": "trasplante",
+      "dias_relativos": "25 a 35",
+      "criterio_observable": "5-6 hojas verdaderas y altura 8 cm desde cuello hasta ápice",
+      "accion_clave": "Trasplante al atardecer. Hidratar bandeja 2h antes. Hueco profundidad equivalente al cepellón sin enterrar el cuello. Riego inmediato + sombreado parcial 48h"
+    },
+    {
+      "fase": "desarrollo_vegetativo",
+      "dias_relativos": "35 a 60",
+      "criterio_observable": "Tasa de expansión foliar máxima, formación de roseta. Acogollado en Batavia/romana",
+      "accion_clave": "Aplicación de biofertilizantes foliares quincenal (biol al 5%). Monitoreo intensivo del turgor foliar. Mulch para estabilizar humedad"
+    },
+    {
+      "fase": "cosecha",
+      "dias_relativos": "60 a 90",
+      "criterio_observable": "Diámetro comercial alcanzado, pre-elongación del tallo (antes del espigado)",
+      "accion_clave": "Corte basal limpio con cuchillo, temprano en la mañana. Empacado inmediato en contenedores rígidos para evitar magulladuras"
+    }
+  ],
+  "failure_modes": [
+    {
+      "razon": "Espigado prematuro (bolting)",
+      "cuando": "Vegetativo tardío",
+      "sintoma": "Elongación abrupta del tallo, roseta se pierde, sabor amargo (lactucopicrina)",
+      "agente_causal": "Estrés térmico (>25°C) o hídrico/nitrogenado",
+      "mitigacion": "Variedades tolerantes (Batavia Salinas, romana Parris Island), siembra en época fresca, mulch para estabilizar humedad",
+      "frecuencia": "muy_comun"
+    },
+    {
+      "razon": "Tip burn (necrosis marginal)",
+      "cuando": "Desarrollo vegetativo",
+      "sintoma": "Necrosis marginal de hojas jóvenes, aspecto de quemadura",
+      "agente_causal": "Deficiencia localizada de Ca por exceso de N o riegos desbalanceados",
+      "mitigacion": "Estabilización de pulsos de riego, aspersión foliar de calcio orgánico quelatado, mulch",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Damping-off (estrangulamiento basal)",
+      "cuando": "Germinación / semillero",
+      "sintoma": "Necrosis del cuello, colapso repentino de la plántula",
+      "agente_causal": "Pythium / Rhizoctonia por exceso de humedad y sustrato no desinfectado",
+      "mitigacion": "Solarización del sustrato, Trichoderma harzianum nativo, riego matutino, reducir lámina de riego",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Babosas y caracoles",
+      "cuando": "Trasplante a cosecha",
+      "sintoma": "Agujeros irregulares en hojas, baba plateada en el envés o suelo",
+      "agente_causal": "Moluscos gasterópodos nocturnos",
+      "mitigacion": "Trampas de cerveza, ceniza perimetral, conservación de carábidos depredadores, recolección manual nocturna",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Mildiu velloso",
+      "cuando": "Desarrollo vegetativo",
+      "sintoma": "Manchas amarillas en haz con micelio blanco-violáceo en envés",
+      "agente_causal": "Bremia lactucae, alta humedad relativa y rocío persistente",
+      "mitigacion": "Variedades resistentes (Bl:29-41EU Enza Zaden), distancia adecuada entre plantas, caldo bordelés preventivo 0.5%",
+      "frecuencia": "ocasional"
+    }
+  ],
+  "companions": [
+    { "especie": "Allium cepa (cebolla)", "razon": "Compuestos azufrados disuaden herbívoros foliares; complementariedad radicular (cebolla profunda, lechuga superficial)", "evidencia": "tradicion + literatura agronomica" },
+    { "especie": "Daucus carota (zanahoria)", "razon": "Complementariedad radicular (zanahoria pivotante)", "evidencia": "manuales agroecologicos andinos" },
+    { "especie": "Raphanus sativus (rábano)", "razon": "Cultivo de ciclo ultracorto (21 días) que se cosecha antes del acogollado de la lechuga", "evidencia": "tradicion" },
+    { "especie": "Spinacia oleracea (espinaca)", "razon": "Comparte ventana fenológica fría", "evidencia": "tradicion" },
+    { "especie": "Brassica oleracea (coles)", "razon": "Sinergia documentada en literatura agronómica internacional", "evidencia": "literatura internacional" }
+  ],
+  "antagonistas": [
+    { "especie": "Foeniculum vulgare (hinojo)", "razon": "Aleloquímicos agresivos inhiben germinación y expansión celular de la lechuga" },
+    { "especie": "Apium graveolens (apio)", "razon": "Competencia hídrica + atracción de plagas comunes (umbelíferas)" },
+    { "especie": "Helianthus annuus (girasol)", "razon": "Alelopatía (juglona-like)" }
+  ],
+  "biopreparados": [
+    { "nombre": "Bocashi", "uso": "Pre-siembra: 1.5-2 kg/m² incorporado 10-12 días antes del trasplante", "fuente": "Boudet et al. 2017; Tolentino et al. 2023 (extrapolación desde tomate)" },
+    { "nombre": "Biol / lombrifertilizante líquido", "uso": "Aspersión foliar al 5% cada 10 días desde día 10 post-trasplante", "fuente": "Castellanos, Rincón y Argüello 2015 — biofertilizante en lechuga Sabana de Bogotá" },
+    { "nombre": "Caldo sulfocálcico", "uso": "Preventivo en mildiu, dilución 1:80 (0.5L en bomba 20L) cada 15 días en época húmeda", "fuente": "extrapolación desde Cabrera Marulanda et al. 2018" },
+    { "nombre": "Té de compost", "uso": "Dilución 1:5 quincenal foliar", "fuente": "manuales agroecologicos colombianos" },
+    { "nombre": "Trichoderma harzianum", "uso": "Inoculación del sustrato semillero pre-trasplante para prevenir damping-off", "fuente": "Agrosavia + literatura colombiana" }
+  ],
+  "cosecha_estimada_kg_por_planta": {
+    "agroecologico_promedio": { "min": 0.3, "tipico": 0.45, "max": 0.6 },
+    "por_variedad": {
+      "batavia": { "tipico": 0.5 },
+      "crespa": { "tipico": 0.32 },
+      "romana": { "tipico": 0.45 }
+    },
+    "anti_overpromise": "Literatura comercial reporta 800-1000 g, valores que requieren riego tecnificado, sustrato recambiado y nutrición sintética. Chagra opera en modo agroecológico — rangos conservadores."
+  },
+  "reproduccion": {
+    "tipo_principal": "sexual",
+    "metodo": "Semilla botánica. Termodormancia se rompe con almacenamiento seco a 4-10°C por 30 días. Viabilidad bien guardada (cámara fría, 10% humedad): 3-5 años.",
+    "esqueje": "No aplica operacionalmente",
+    "injerto": "No aplica",
+    "guardar_semilla_propia": "Posible para variedades abiertas. NO aconsejable en híbridos comerciales (segregación F2)"
+  },
+  "fuentes_principales": [
+    { "tipo": "institucional", "referencia": "Agrosavia — Modelo productivo lechuga Sabana de Bogotá" },
+    { "tipo": "peer_reviewed", "referencia": "Lemos Neto et al. 2018, Revista Colombiana de Ciencias Hortícolas 12(3) — termorresistencia variedades crespa" },
+    { "tipo": "peer_reviewed", "referencia": "Castellanos, Rincón y Argüello 2015 — biofertilizante en lechuga Sabana de Bogotá" },
+    { "tipo": "taxonomica", "referencia": "Bernal, Gradstein y Celis 2016. Catálogo de Plantas y Líquenes de Colombia. UNAL. ISBN 978-958-775-727-9" },
+    { "tipo": "centro_demostrativo", "referencia": "Centro Agroecológico Ceagro San Pablo (Madrid, Cundinamarca) — 6.83 kg/m² variedad Arizona bajo riego por goteo + cobertura + fertilización organomineral" }
+  ],
+  "convergencia_dr_034": "3/3 LLMs (Claude web + Gemini DR + DeepSeek V3) convergen en lechuga como starter species cultivo escuela. Datos consolidados sin Mistral tiebreak por convergencia alta.",
+  "curacion_status": "draft_3_llm_consolidated",
+  "curacion_pendiente": ["Validacion agronomo Guatoc / extension rural Cundinamarca para datos cuantitativos kg/planta agroecologica colombiana sin biocidas (gap G-A DR-034)"]
+}

--- a/public/cycle-content/tomate_chonto.json
+++ b/public/cycle-content/tomate_chonto.json
@@ -1,0 +1,163 @@
+{
+  "species_slug": "tomate_chonto",
+  "scientific_name": "Solanum lycopersicum L. cv. chonto",
+  "synonyms_obsoletas": ["Lycopersicon esculentum Mill."],
+  "common_names": ["tomate chonto", "tomate larga vida tipo chonto"],
+  "family": "Solanaceae",
+  "agrovoc_concept": "c_7787",
+  "difficulty": "intermediate",
+  "tiempo_a_cosecha_dias": { "min": 85, "tipico": 100, "max": 130 },
+  "diferenciador_colombiano": "El tipo varietal CHONTO es identidad culinaria colombiana — fruto ovalado-redondeado 80-180 g, dual mesa-procesado, base ineludible del HOGAO. UNAL Palmira (Vallejo, Estrada, Burbano) ha desarrollado líneas con gen sp (crecimiento determinado) que reducen 47% la mano de obra en tutorado vs hábito indeterminado tradicional. Migración masiva de campo abierto a invernaderos rústicos de guadua y plástico estabilizó rendimientos. 80% de producción concentrada en Cundinamarca, Norte de Santander, Valle del Cauca, Caldas, Huila, Risaralda y Antioquia.",
+  "leccion_agroecologica": "Cultivo aprendiz de poda — bisagra educativa entre hortalizas y frutales perennes. Enseña manejo arquitectónico de la planta: tutorado, deschuponada semanal, descopado al alcanzar 1.8m. La sanidad NO se logra persiguiendo patógenos, sino alterando la geometría de la planta para forzar circulación de aire que inhiba germinación de esporas fúngicas.",
+  "thermal_zone_decisions": {
+    "calido": "Producción a campo abierto tradicional. Variedades Río Grande, Pacal, Bachué adaptadas. Mayor presión de mosca blanca y begomovirus. Rendimiento promedio nacional 26 t/ha.",
+    "templado": "ÓPTIMO para chonto Santa Cruz. Rango 1200-2200 msnm con isotermas 15-25°C provee la cinética metabólica exacta. Marinilla y El Peñol (Antioquia oriental) zona pionera. Boyacá Alto Ricaurte (Sutamarchán, Tinjacá) polo emergente bajo invernadero.",
+    "frio": "Producción casi exclusivamente bajo invernadero. Sabana de Bogotá. Polinización resuelta con introducción del abejorro nativo Bombus atratus. Aborto floral por temperaturas <10°C nocturnas — riesgo de cara de gato.",
+    "paramo": "No aplica — colapso fisiológico térmico"
+  },
+  "preparacion_tierra": {
+    "matera": {
+      "volumen_min_litros": 20,
+      "volumen_ideal_litros": 30,
+      "profundidad_cm": 35,
+      "mezcla": "30% tierra + 30% compost + 25% cascarilla quemada + 15% humus de lombriz",
+      "ph_objetivo": "6.0-6.8",
+      "tutorado_obligatorio": true,
+      "estructura_tutor": "Estaca de 1.8-2 m, hilo en V o malla. Iniciar día 15 post-trasplante",
+      "drenaje": "Profundo — sistema radical alcanza 60 cm"
+    },
+    "campo": {
+      "descompactacion": "Profunda 35 cm",
+      "incorporacion": "30-40 t/ha gallinaza compostada o bocashi maduro",
+      "encalado": "Dolomítico si pH < 6",
+      "surcos": "1.2-1.5 m entre surcos",
+      "distancia_plantas": "0.5 m",
+      "tutorado_campo": "Espaldera colombiana — poste cada 4 m + alambre superior + hilo individual",
+      "rotacion_critica": "ICA Antioquia (1980, 1981) demuestra que el limitante NO es fertilización sino enfermedad y rotación. Barbecho o rotación con leguminosa/maíz mínimo 2 ciclos antes de retornar tomate al lote.",
+      "trichoderma_pre": "Inoculación masiva de camas con Trichoderma spp. semanas antes del trasplante — destruye hifas de Fusarium y Rhizoctonia"
+    }
+  },
+  "milestones": [
+    {
+      "fase": "germinacion_y_semillero",
+      "dias_relativos": "-30 a -20",
+      "criterio_observable": "Semillero esterilizado térmicamente o solarizado. Bandejas 200-294 alvéolos sustrato turba+lombricompuesto",
+      "accion_clave": "Inoculación profiláctica de Trichoderma. Temperatura óptima germinación 22-25°C"
+    },
+    {
+      "fase": "trasplante",
+      "dias_relativos": "0",
+      "criterio_observable": "Plántula altura 10-12 cm, 4-5 hojas verdaderas, tallo lignificado en base, sistema radical bien desarrollado",
+      "accion_clave": "ENTERRAMIENTO PROFUNDO del tallo inferior — provoca emisión de raíces adventicias en el tallo. Tutor + hilo iniciado día 15"
+    },
+    {
+      "fase": "desarrollo_vegetativo",
+      "dias_relativos": "20 a 50",
+      "criterio_observable": "Ramificación axilar profusa (chupones)",
+      "accion_clave": "DESCHUPONADA SEMANAL — sustracción manual sistemática de brotes laterales. Amarre a hilos tutores verticales"
+    },
+    {
+      "fase": "floracion_y_cuaje",
+      "dias_relativos": "45 a 75",
+      "criterio_observable": "Corola amarilla plenamente abierta, senescencia del cáliz, primera floración 30-45 días post-trasplante",
+      "accion_clave": "Facilitar vibración mecánica o entomológica (Bombus atratus en invernadero) para dehiscer las anteras poricidas"
+    },
+    {
+      "fase": "fructificacion_y_cosecha",
+      "dias_relativos": "65 a 130",
+      "criterio_observable": "Viraje del espectro cromático verde al estado 4 (rosa/rojo)",
+      "accion_clave": "Recolección cíclica escalonada usando recipientes de paredes rígidas. Descopado al alcanzar 1.8m o sexto-séptimo racimo. Plantas indeterminadas pueden sostener hasta 10 racimos / 7 meses bajo invernadero"
+    }
+  ],
+  "failure_modes": [
+    {
+      "razon": "Pudrición apical (blossom end rot)",
+      "cuando": "Expansión del fruto",
+      "sintoma": "Mancha necrótica coriácea, hundida y oscura en cicatriz pistilar",
+      "agente_causal": "Falla en translocación de calcio inducida por estrés hídrico transitorio",
+      "mitigacion": "Sincronización impecable de riegos diarios + aportes tempranos de roca calcárea + mulch para estabilizar humedad",
+      "frecuencia": "muy_comun"
+    },
+    {
+      "razon": "Tizón tardío (Phytophthora infestans)",
+      "cuando": "Vegetativo a cosecha",
+      "sintoma": "Manchas oleosas que se necrosan, micelio blanco en envés foliar, frutos con manchas pardas",
+      "agente_causal": "Condiciones frescas-húmedas (frío, templado alto)",
+      "mitigacion": "Caldo bordelés preventivo 0.5%, distanciamiento 1.5m entre surcos, evitar mojado foliar (riego por goteo). NO sembrar cerca de cultivos de papa",
+      "frecuencia": "muy_comun"
+    },
+    {
+      "razon": "Mosca blanca (Trialeurodes vaporariorum) + Fumagina",
+      "cuando": "Vegetativo a cosecha",
+      "sintoma": "Follaje recubierto de costras de polvo negro (fumagina), clorosis severa generalizada",
+      "agente_causal": "Excreción de melaza por mosca blanca permite crecimiento de hongos saprófitos",
+      "mitigacion": "Trampas cromáticas amarillas DENSAS, aspersión de fermento M-5 al 10-20%, encierro fitosanitario en invernadero",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Begomovirus (PYMV / TYLCV)",
+      "cuando": "Cualquier estadio",
+      "sintoma": "Enanismo, hojas amarillentas con enrollamiento ascendente, cuajado pobre",
+      "agente_causal": "Transmitidos por Bemisia tabaci. Hospederos arvenses: Desmodium, Amaranthus, Lantana camara (Vaca-Vaca et al. 2012 UNAL Palmira)",
+      "mitigacion": "Control de mosca blanca. Eliminación de arvenses hospederas en bordes del lote. Variedades con tolerancia (Tequila, Calima)",
+      "frecuencia": "comun"
+    },
+    {
+      "razon": "Marchitez vascular (Fusarium / Verticillium)",
+      "cuando": "Crecimiento vegetativo",
+      "sintoma": "Clorosis asimétrica progresiva, taponamiento del xilema, colapso estructural irreversible",
+      "agente_causal": "Hongos edáficos habitantes crónicos",
+      "mitigacion": "Rotación inter-anual de familias botánicas (evitar solanáceas consecutivas). Uso de Trichoderma. Variedades resistentes con genes I/Ve",
+      "frecuencia": "ocasional"
+    }
+  ],
+  "companions": [
+    { "especie": "Ocimum basilicum (albahaca)", "razon": "Eugenoles y linaloles evaporados desestabilizan señales quimiotácticas de dípteros. Priming sistémico de respuesta a heridas mediado por compuestos volátiles", "evidencia": "Suzuki et al. NIH PMC11263239 — evidencia experimental publicada" },
+    { "especie": "Calendula officinalis + Tagetes patula (caléndulas)", "razon": "Plantas trampa para nemátodos Meloidogyne. Atracción de polinizadores", "evidencia": "literatura experimental" },
+    { "especie": "Daucus carota (zanahoria)", "razon": "Complementariedad radicular", "evidencia": "tradicion" },
+    { "especie": "Allium cepa + sativum (cebolla, ajo)", "razon": "Repelencia de áfidos por compuestos azufrados", "evidencia": "tradicion + literatura" },
+    { "especie": "Borago officinalis (borraja)", "razon": "Repele Manduca quinquemaculata (gusano cachón)", "evidencia": "literatura agronomica" }
+  ],
+  "antagonistas": [
+    { "especie": "Foeniculum vulgare (hinojo)", "razon": "Alelopatía severa" },
+    { "especie": "Solanum tuberosum (papa)", "razon": "Comparte Phytophthora infestans — corredor epidemiológico crítico" },
+    { "especie": "Solanum melongena (berenjena), Capsicum annuum (pimentón)", "razon": "Solanáceas — comparten Begomovirus + tizón + Fusarium" },
+    { "especie": "Cucumis sativus (pepino)", "razon": "Vectores comunes (mosca blanca, ácaros)" },
+    { "especie": "Juglans (nogal)", "razon": "Juglona alelopática" }
+  ],
+  "biopreparados": [
+    { "nombre": "M-5 (insecticida orgánico)", "uso": "Decocción anaeróbica de ajo + ají + cebolla + aromáticas + alcohol fermentados 30 días. Asperjar canopia al 5-20% (400 ml a 2 L por bomba 20 L)", "fuente": "manuales agroecologicos colombianos" },
+    { "nombre": "Bocashi", "uso": "1.5-3 t/ha pre-siembra. Boudet et al. 2017 reporta 54 t/ha con 2.99 t/ha bocashi", "fuente": "Boudet et al. 2017 (extrapolación a chonto Colombia con cuidado)" },
+    { "nombre": "Biol", "uso": "5% foliar quincenal en vegetativo y floración temprana", "fuente": "Agrosavia/Asohofrucol 2024 proyecto Cundinamarca-Boyacá" },
+    { "nombre": "Caldo sulfocálcico", "uso": "1% preventivo en oídio y ácaros. NO aplicar en floración (toxicidad sobre polinizadores)", "fuente": "manuales agroecologicos" },
+    { "nombre": "Microorganismos eficientes (EM autóctonos)", "uso": "25 cc/aplicación cada 14 días — aumenta rendimiento y altura", "fuente": "Alarcón et al. 2020" },
+    { "nombre": "Trichoderma harzianum / asperellum", "uso": "Drench radicular pre-trasplante para suprimir Fusarium/Rhizoctonia", "fuente": "Agrosavia + literatura colombiana" }
+  ],
+  "cosecha_estimada_kg_por_planta": {
+    "campo_abierto_agroecologico": { "min": 3, "tipico": 4.5, "max": 6 },
+    "invernadero_tecnificado": { "min": 6, "tipico": 9, "max": 12 },
+    "anti_overpromise": "Proyecciones >12 kg/planta corresponden a cultivares de larga vida bajo fertirriego hidropónico mecanizado — quimera en entorno orgánico de matriz sólida y polinización natural. Una hectárea típica chonto rinde 26 t/año a campo, hasta 80 t/año bajo invernadero (Agrosavia 2018)."
+  },
+  "reproduccion": {
+    "tipo_principal": "sexual_semilla",
+    "metodo": "Autógama mayoritaria (~5% alogamia). Viabilidad de semilla guardada en frasco hermético seco: 4-6 años.",
+    "guardar_semilla_propia": "Posible para variedades ABIERTAS (Río Grande, Santa Cruz, Bachué). Inviable en híbridos F1 comerciales (segregación)",
+    "esqueje": "Técnicamente posible — chupón axilar enraíza en agua o sustrato húmedo en 7-10 días. Útil para multiplicar planta excepcional, NO operacional comercialmente. Las plantas resultantes heredan reloj biológico acortado y caen en vigor",
+    "injerto": "Práctica creciente en producción tecnificada — patrones híbridos Solanum lycopersicum × S. habrochaites resistentes a nematodos/Fusarium. Marginal en agroecología familiar (gap G-02 DR-034)"
+  },
+  "fuentes_principales": [
+    { "tipo": "institucional", "referencia": "Agrosavia 2018. El cultivo de tomate bajo invernadero. ISBN 978-958-740-120-2 (485 pp)" },
+    { "tipo": "peer_reviewed", "referencia": "Burbano y Vallejo 2017. Revista Colombiana de Ciencias Hortícolas 11(1):63-71 — gen sp en chonto" },
+    { "tipo": "peer_reviewed", "referencia": "Vaca-Vaca et al. 2012. Acta Agronómica UNAL Palmira — begomovirus tomate hospederos arvenses" },
+    { "tipo": "institucional", "referencia": "DANE-SIPSA dic 2014 — 17 variedades comerciales colombianas (Santa Cruz, Río Grande, Calima, Tequila, Chévere, Cumanday, Bonus, Andino, Santa Clara, Quindío Colombia, Carina, Atala, Boshara, Pacal, Colibrí, San Isidro, Bachué)" },
+    { "tipo": "institucional", "referencia": "Salinas Ospina 1991. Agrosavia hdl 33611 — Chonto Santa Cruz manejo" },
+    { "tipo": "ica_historico", "referencia": "ICA Antioquia 1980-1981 — 18 ensayos publicados Marinilla-El Peñol. Demuestran que el limitante es enfermedad + rotación, NO fertilización" }
+  ],
+  "convergencia_dr_034": "3/3 LLMs convergen en chonto como intermediate + tutorado obligatorio + albahaca companion validado + Phytophthora infestans riesgo principal + identidad culinaria colombiana.",
+  "curacion_status": "draft_3_llm_consolidated",
+  "curacion_pendiente": [
+    "Curacion presencial 4h DR-034 — DeepSeek T.iii primera prioridad: Tomate Chonto sub-preguntas E.ii (failure modes) + E.v (biopreparados)",
+    "Variedades regionales tomate chonto comparativas exhaustivas — gap G-D DR-034. Consultar Agrosavia 2018 ISBN 978-958-740-120-2",
+    "Esquejes en variedad Chonto Colombia — gap G-02 DR-034. Verificar investigacion Burbano/Vallejo UNAL Palmira"
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v85';
+const CACHE_NAME = 'chagra-v86';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CycleContentRenderer.jsx
+++ b/src/components/CycleContentRenderer.jsx
@@ -1,0 +1,272 @@
+import React, { useEffect, useState } from 'react';
+import { Sprout, AlertTriangle, Users, Beaker, Mountain, BookOpen, Loader2 } from 'lucide-react';
+
+const FREQ_BADGE = {
+  muy_comun: { label: 'Muy común', cls: 'bg-rose-900/40 text-rose-300 border-rose-800/60' },
+  comun: { label: 'Común', cls: 'bg-amber-900/40 text-amber-300 border-amber-800/60' },
+  ocasional: { label: 'Ocasional', cls: 'bg-slate-800 text-slate-400 border-slate-700' },
+};
+
+const ZONE_LABEL = {
+  calido: '🌴 Cálido (<1200 msnm)',
+  templado: '🌳 Templado (1200-2200 msnm)',
+  frio: '🌲 Frío (2200-2800 msnm)',
+  paramo: '🏔️ Páramo (>2800 msnm)',
+};
+
+const DIFFICULTY_BADGE = {
+  starter: { label: 'Starter · cultivo escuela', cls: 'bg-emerald-900/40 text-emerald-300 border-emerald-800/60' },
+  starter_premium: { label: 'Starter Premium · requiere precisión', cls: 'bg-emerald-900/40 text-emerald-200 border-emerald-700/60' },
+  intermediate: { label: 'Intermediate · tutorado obligatorio', cls: 'bg-amber-900/40 text-amber-200 border-amber-700/60' },
+  advanced: { label: 'Advanced · perenne / injerto', cls: 'bg-orange-900/40 text-orange-200 border-orange-700/60' },
+};
+
+/**
+ * CycleContentRenderer — Lazy loader + renderer del corpus curado por especie.
+ *
+ * Lee `/public/cycle-content/<slug>.json` (consolidado DR-034 3/3 LLMs +
+ * curación pendiente Guatoc / Agrosavia / Cenicafé).
+ *
+ * Datos vienen del DR-034 cerrado 2026-05-06 (ADR-032). NO mezclar con
+ * folclore/biodinámica — política ADR-033 Opción C estricta.
+ */
+export default function CycleContentRenderer({ slug, onClose }) {
+  const [state, setState] = useState({ slug: null, data: null, error: null });
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetch(`${import.meta.env.BASE_URL}cycle-content/${slug}.json`, { signal: ctrl.signal })
+      .then((r) => {
+        if (!r.ok) throw new Error(`No se encontró el ciclo de ${slug}`);
+        return r.json();
+      })
+      .then((j) => setState({ slug, data: j, error: null }))
+      .catch((e) => { if (e.name !== 'AbortError') setState({ slug, data: null, error: e.message }); });
+    return () => ctrl.abort();
+  }, [slug]);
+
+  const isLoading = state.slug !== slug;
+  const data = isLoading ? null : state.data;
+  const error = isLoading ? null : state.error;
+
+  if (error) {
+    return (
+      <div className="p-4 rounded-xl bg-rose-900/20 border border-rose-800/50">
+        <p className="text-sm text-rose-300">{error}</p>
+        <button type="button" onClick={onClose} className="mt-2 text-xs underline text-slate-400">Volver</button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="p-6 flex items-center justify-center gap-2 text-slate-400">
+        <Loader2 size={18} className="animate-spin" />
+        <span className="text-sm">Cargando corpus de {slug}…</span>
+      </div>
+    );
+  }
+
+  const diff = DIFFICULTY_BADGE[data.difficulty] ?? { label: data.difficulty, cls: 'bg-slate-800 text-slate-300 border-slate-700' };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h3 className="text-lg font-bold text-emerald-300">{data.common_names?.[0] ?? data.species_slug}</h3>
+            <p className="text-xs italic text-slate-500">{data.scientific_name}</p>
+          </div>
+          {onClose && (
+            <button type="button" onClick={onClose} className="text-xs text-slate-400 hover:text-slate-200 underline">Cerrar</button>
+          )}
+        </div>
+        <span className={`inline-block mt-2 px-2 py-0.5 rounded-full text-[10px] font-bold border ${diff.cls}`}>{diff.label}</span>
+        {data.tiempo_a_cosecha_dias && (
+          <span className="ml-2 text-[11px] text-slate-400">
+            ⏱ {data.tiempo_a_cosecha_dias.min}–{data.tiempo_a_cosecha_dias.max} días (típico {data.tiempo_a_cosecha_dias.tipico})
+          </span>
+        )}
+      </div>
+
+      {data.diferenciador_colombiano && (
+        <Block icon={Mountain} title="Diferenciador colombiano" tone="emerald">
+          <p className="text-xs text-slate-300 leading-relaxed">{data.diferenciador_colombiano}</p>
+        </Block>
+      )}
+
+      {data.leccion_agroecologica && (
+        <Block icon={BookOpen} title="Lección agroecológica" tone="emerald">
+          <p className="text-xs text-slate-300 leading-relaxed">{data.leccion_agroecologica}</p>
+        </Block>
+      )}
+
+      {data.thermal_zone_decisions && (
+        <Block icon={Mountain} title="Decisiones por piso térmico" tone="slate">
+          <ul className="space-y-2 text-xs">
+            {Object.entries(data.thermal_zone_decisions).map(([zone, txt]) => (
+              <li key={zone} className="border-l-2 border-emerald-700/60 pl-2">
+                <p className="font-bold text-slate-200">{ZONE_LABEL[zone] ?? zone}</p>
+                <p className="text-slate-400 leading-relaxed">{txt}</p>
+              </li>
+            ))}
+          </ul>
+        </Block>
+      )}
+
+      {Array.isArray(data.milestones) && data.milestones.length > 0 && (
+        <Block icon={Sprout} title="Hitos del ciclo" tone="emerald">
+          <ol className="space-y-2 text-xs">
+            {data.milestones.map((m, i) => (
+              <li key={i} className="rounded-lg p-2 bg-slate-900 border border-slate-800">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-bold text-emerald-300 capitalize">{(m.fase || '').replace(/_/g, ' ')}</span>
+                  <span className="text-[10px] text-slate-500">día {m.dias_relativos}</span>
+                </div>
+                {m.criterio_observable && <p className="text-slate-400 mt-0.5"><strong className="text-slate-300">Observe:</strong> {m.criterio_observable}</p>}
+                {m.accion_clave && <p className="text-slate-400 mt-0.5"><strong className="text-slate-300">Haga:</strong> {m.accion_clave}</p>}
+              </li>
+            ))}
+          </ol>
+        </Block>
+      )}
+
+      {Array.isArray(data.failure_modes) && data.failure_modes.length > 0 && (
+        <Block icon={AlertTriangle} title="Razones comunes de fracaso" tone="amber">
+          <p className="text-[10px] text-slate-500 italic mb-2">Documentado para que falle menos. Cuando le pase alguno, no se sienta solo — está en el manual.</p>
+          <ul className="space-y-2 text-xs">
+            {data.failure_modes.map((f, i) => {
+              const badge = FREQ_BADGE[f.frecuencia] ?? FREQ_BADGE.ocasional;
+              return (
+                <li key={i} className="rounded-lg p-2 bg-slate-900 border border-slate-800">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="font-bold text-amber-200">{f.razon}</span>
+                    <span className={`px-1.5 py-0.5 rounded-full text-[9px] border ${badge.cls}`}>{badge.label}</span>
+                  </div>
+                  {f.cuando && <p className="text-[10px] text-slate-500 mt-0.5">aparece en: {f.cuando}</p>}
+                  {f.sintoma && <p className="text-slate-400 mt-1"><strong className="text-slate-300">Síntoma:</strong> {f.sintoma}</p>}
+                  {f.mitigacion && <p className="text-slate-400 mt-0.5"><strong className="text-slate-300">Prevención:</strong> {f.mitigacion}</p>}
+                </li>
+              );
+            })}
+          </ul>
+        </Block>
+      )}
+
+      {Array.isArray(data.companions) && data.companions.length > 0 && (
+        <Block icon={Users} title="Compañeros validados" tone="emerald">
+          <ul className="space-y-1 text-xs">
+            {data.companions.map((c, i) => (
+              <li key={i}>
+                <span className="font-bold text-emerald-300">{c.especie}</span>
+                <span className="text-slate-400"> — {c.razon}</span>
+                {c.evidencia && <span className="text-[10px] text-slate-600"> · {c.evidencia}</span>}
+              </li>
+            ))}
+          </ul>
+        </Block>
+      )}
+
+      {Array.isArray(data.antagonistas) && data.antagonistas.length > 0 && (
+        <Block icon={Users} title="No los siembre cerca" tone="rose">
+          <ul className="space-y-1 text-xs">
+            {data.antagonistas.map((a, i) => (
+              <li key={i}>
+                <span className="font-bold text-rose-300">{a.especie}</span>
+                <span className="text-slate-400"> — {a.razon}</span>
+              </li>
+            ))}
+          </ul>
+        </Block>
+      )}
+
+      {Array.isArray(data.biopreparados) && data.biopreparados.length > 0 && (
+        <Block icon={Beaker} title="Biopreparados" tone="emerald">
+          <ul className="space-y-1 text-xs">
+            {data.biopreparados.map((b, i) => (
+              <li key={i}>
+                <span className="font-bold text-emerald-300">{b.nombre}</span>
+                <span className="text-slate-400"> — {b.uso}</span>
+                {b.fuente && <span className="text-[10px] text-slate-600 italic"> · {b.fuente}</span>}
+              </li>
+            ))}
+          </ul>
+        </Block>
+      )}
+
+      {data.cosecha_estimada_kg_por_planta && (
+        <Block icon={Sprout} title="Cosecha estimada (rangos conservadores)" tone="emerald">
+          <RangeRenderer data={data.cosecha_estimada_kg_por_planta} />
+          {data.cosecha_estimada_kg_por_planta.anti_overpromise && (
+            <p className="text-[10px] text-amber-300/80 italic mt-2 leading-relaxed">⚠️ {data.cosecha_estimada_kg_por_planta.anti_overpromise}</p>
+          )}
+        </Block>
+      )}
+
+      {data.curacion_status && (
+        <div className="p-2 rounded-lg bg-slate-900 border border-slate-800 text-[10px] text-slate-500 italic">
+          <p>Estado: <strong className="text-slate-400">{data.curacion_status}</strong></p>
+          {Array.isArray(data.curacion_pendiente) && data.curacion_pendiente.length > 0 && (
+            <ul className="mt-1 list-disc pl-4 space-y-0.5">
+              {data.curacion_pendiente.map((p, i) => <li key={i}>{p}</li>)}
+            </ul>
+          )}
+          {data.convergencia_dr_034 && <p className="mt-1">{data.convergencia_dr_034}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// eslint-disable-next-line no-unused-vars -- Icon SE USA en JSX más abajo, eslint react-jsx detection falla con destructuring rename
+function Block({ icon: Icon, title, tone, children }) {
+  const ring = {
+    emerald: 'border-emerald-800/40 bg-emerald-900/10',
+    amber: 'border-amber-800/40 bg-amber-900/10',
+    rose: 'border-rose-800/40 bg-rose-900/10',
+    slate: 'border-slate-800 bg-slate-900/40',
+  }[tone] ?? 'border-slate-800 bg-slate-900/40';
+
+  return (
+    <section className={`rounded-xl p-3 border ${ring}`}>
+      <header className="flex items-center gap-2 mb-2">
+        <Icon size={14} className="text-emerald-400" />
+        <h4 className="text-xs font-bold uppercase tracking-wider text-emerald-300">{title}</h4>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function RangeRenderer({ data }) {
+  const entries = Object.entries(data).filter(([k]) => k !== 'anti_overpromise');
+  return (
+    <ul className="space-y-1 text-xs">
+      {entries.map(([k, v]) => {
+        if (v && typeof v === 'object' && !Array.isArray(v)) {
+          if ('min' in v || 'tipico' in v || 'max' in v) {
+            const parts = [];
+            if (v.min != null) parts.push(`mín ${v.min}`);
+            if (v.tipico != null) parts.push(`típico ${v.tipico}`);
+            if (v.max != null) parts.push(`máx ${v.max}`);
+            return <li key={k}><strong className="text-slate-200 capitalize">{k.replace(/_/g, ' ')}:</strong> <span className="text-slate-400">{parts.join(' · ')}</span></li>;
+          }
+          // Nested object (por_variedad)
+          return (
+            <li key={k}>
+              <strong className="text-slate-200 capitalize">{k.replace(/_/g, ' ')}:</strong>
+              <ul className="pl-4 mt-0.5 space-y-0.5">
+                {Object.entries(v).map(([vk, vv]) => (
+                  <li key={vk} className="text-slate-400 text-[11px]">
+                    {vk}: {typeof vv === 'object' ? Object.entries(vv).map(([kk, vvv]) => `${kk} ${vvv}`).join(', ') : String(vv)}
+                  </li>
+                ))}
+              </ul>
+            </li>
+          );
+        }
+        return null;
+      })}
+    </ul>
+  );
+}

--- a/src/components/HelpManual.jsx
+++ b/src/components/HelpManual.jsx
@@ -1,5 +1,17 @@
 import React, { useState } from 'react';
 import { ArrowLeft, ChevronDown, ChevronRight, BookOpen, Sprout, Mic, Camera, MapPin, Bug, Apple, MessageCircle, AlertTriangle, Wrench, Sparkles, GraduationCap, Clock } from 'lucide-react';
+import CycleContentRenderer from './CycleContentRenderer.jsx';
+
+const STARTER_CYCLES = [
+  { slug: 'lechuga', emoji: '🥬', label: 'Lechuga', sub: 'Starter · 60-90 días · frío/templado' },
+  { slug: 'fresa', emoji: '🍓', label: 'Fresa', sub: 'Starter Premium · 90-180 días · frío' },
+  { slug: 'tomate_chonto', emoji: '🍅', label: 'Tomate Chonto', sub: 'Intermediate · 90-130 días · templado' },
+];
+
+const PLACEHOLDER_CYCLES = [
+  { emoji: '☕', label: 'Café arábica', sub: 'Advanced · 3 años · curación humana presencial pendiente', tone: 'orange' },
+  { emoji: '🥑', label: 'Aguacate Hass', sub: 'Advanced · 3-5 años · injerto + selección patrón pendiente', tone: 'orange' },
+];
 
 /**
  * HelpManual — Manual de usuario integrado en la PWA.
@@ -38,6 +50,7 @@ const Section = ({ icon: Icon, title, children, defaultOpen = false }) => {
 };
 
 export default function HelpManual({ onBack }) {
+  const [openCycle, setOpenCycle] = useState(null);
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-white flex flex-col overflow-y-auto">
       {/* Header */}
@@ -241,53 +254,61 @@ export default function HelpManual({ onBack }) {
           </ul>
         </Section>
 
-        {/* Sección Aprende sembrando — scaffold queue/039.
-            Contenido real viene del DR-034 (5 especies × ciclo completo) +
-            curación agrónomo Guatoc/Agrosavia. Por ahora cards placeholder
-            que comunican intención + plan. Cuando DR-034 cierre, se reemplazan
-            placeholders con corpus curado en /public/cycle-content/<slug>.json
-            lazy-loaded. */}
-        <Section icon={GraduationCap} title="🌿 Aprende sembrando — ciclo de 5 especies (próximamente)">
+        {/* Sección Aprende sembrando — corpus curado desde /public/cycle-content/.
+            Datos consolidados DR-034 cerrado 2026-05-06 (3/3 LLMs convergencia
+            alta) + ADR-032 plan curación starter species. Política ADR-033
+            Opción C estricta — solo Nivel 2 evidencia, NO folclore. */}
+        <Section icon={GraduationCap} title="🌿 Aprende sembrando — ciclo agroecológico" defaultOpen={false}>
           <p className="text-sm leading-relaxed">
-            <strong className="text-emerald-300">Esta sección está en construcción.</strong> Va a ser el punto de partida educativo para quien empieza desde cero — no solo cómo usar Chagra, sino cómo cultivar.
+            <strong className="text-emerald-300">Punto de partida educativo</strong> para quien empieza desde cero — no solo cómo usar Chagra, sino cómo cultivar.
           </p>
 
           <p className="text-xs text-slate-400 leading-relaxed mt-2">
-            Cubrirá el <strong>ciclo completo</strong> de 5 especies prioritarias para Colombia, desde preparación de tierra hasta propagación del próximo ciclo:
+            Toque una especie para ver el ciclo completo: preparación de tierra, hitos día a día, razones comunes de fracaso, compañeros validados, biopreparados y rangos conservadores de cosecha.
           </p>
 
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3">
-            <div className="p-3 rounded-lg bg-slate-900 border border-slate-800">
-              <p className="font-bold text-emerald-300 text-sm">🥬 Lechuga</p>
-              <p className="text-[11px] text-slate-500 mt-0.5">Starter · 60-90 días · frío/templado</p>
-            </div>
-            <div className="p-3 rounded-lg bg-slate-900 border border-slate-800">
-              <p className="font-bold text-emerald-300 text-sm">🍓 Fresa</p>
-              <p className="text-[11px] text-slate-500 mt-0.5">Starter · 90-180 días · frío/templado</p>
-            </div>
-            <div className="p-3 rounded-lg bg-slate-900 border border-slate-800">
-              <p className="font-bold text-amber-300 text-sm">🍅 Tomate Chonto</p>
-              <p className="text-[11px] text-slate-500 mt-0.5">Intermediate · 90-120 días · cálido/templado</p>
-            </div>
-            <div className="p-3 rounded-lg bg-slate-900 border border-slate-800">
-              <p className="font-bold text-orange-300 text-sm">☕ Café arábica</p>
-              <p className="text-[11px] text-slate-500 mt-0.5">Advanced · 3 años · templado/frío 1200-1900 msnm</p>
-            </div>
-            <div className="p-3 rounded-lg bg-slate-900 border border-slate-800 sm:col-span-2">
-              <p className="font-bold text-orange-300 text-sm">🥑 Aguacate Hass</p>
-              <p className="text-[11px] text-slate-500 mt-0.5">Advanced · 3-5 años · templado 1500-2500 msnm · injerto</p>
-            </div>
+          <h4 className="text-xs uppercase tracking-wider text-emerald-400 font-bold mt-4 mb-2">Disponibles ahora</h4>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            {STARTER_CYCLES.map((c) => (
+              <button
+                key={c.slug}
+                type="button"
+                onClick={() => setOpenCycle(c.slug)}
+                className="p-3 rounded-lg bg-slate-900 border border-emerald-800/50 hover:bg-slate-800 active:bg-slate-700 text-left min-h-[64px]"
+              >
+                <p className="font-bold text-emerald-300 text-sm">{c.emoji} {c.label}</p>
+                <p className="text-[11px] text-slate-500 mt-0.5">{c.sub}</p>
+                <p className="text-[10px] text-emerald-500 mt-1">Ver ciclo →</p>
+              </button>
+            ))}
           </div>
 
+          <h4 className="text-xs uppercase tracking-wider text-orange-400 font-bold mt-4 mb-2">Pendientes — curación humana presencial</h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {PLACEHOLDER_CYCLES.map((c) => (
+              <div key={c.label} className="p-3 rounded-lg bg-slate-900 border border-slate-800 opacity-70">
+                <p className="font-bold text-orange-300 text-sm">{c.emoji} {c.label}</p>
+                <p className="text-[11px] text-slate-500 mt-0.5">{c.sub}</p>
+              </div>
+            ))}
+          </div>
+
+          {openCycle && (
+            <div className="mt-4 p-3 rounded-xl bg-slate-950/80 border border-emerald-800/50">
+              <CycleContentRenderer slug={openCycle} onClose={() => setOpenCycle(null)} />
+            </div>
+          )}
+
           <div className="mt-4 p-3 rounded-xl bg-emerald-900/15 border border-emerald-800/40">
-            <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold mb-2">Cada ciclo cubrirá</p>
+            <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold mb-2">Cada ciclo cubre</p>
             <ul className="text-xs text-slate-300 space-y-1 list-disc pl-5">
               <li><strong>Preparación de tierra</strong> — matera (mezcla recomendada) vs campo abierto (descompactación + biopreparados)</li>
-              <li><strong>Germinación</strong> — semilla, esqueje, acodo, división, injerto (según especie)</li>
-              <li><strong>Trasplante</strong> — cuándo, técnica, sombreado post</li>
-              <li><strong>Desarrollo + cosecha</strong> — hitos observables día por día</li>
-              <li><strong>Propagación</strong> — qué guardar para el próximo ciclo</li>
-              <li><strong>Razones comunes de fracaso</strong> — top 5 por especie con prevención agroecológica</li>
+              <li><strong>Germinación + propagación</strong> — semilla, esqueje, acodo, división, injerto (según especie)</li>
+              <li><strong>Hitos del ciclo</strong> — día por día, criterio observable + acción clave</li>
+              <li><strong>Razones comunes de fracaso</strong> — top 5 con prevención agroecológica + frecuencia esperada</li>
+              <li><strong>Compañeros validados</strong> y antagonistas — qué NO sembrar cerca</li>
+              <li><strong>Biopreparados</strong> — bocashi, biol, caldo sulfocálcico, M-5, Trichoderma</li>
+              <li><strong>Rangos conservadores</strong> de cosecha — anti-overpromise vs literatura comercial</li>
             </ul>
           </div>
 
@@ -299,7 +320,7 @@ export default function HelpManual({ onBack }) {
           </div>
 
           <p className="text-[10px] text-slate-600 italic mt-3">
-            Curación de contenido pendiente — DR-034 + revisión de agrónomo Guatoc/Agrosavia. Aviso por novedades cuando esté disponible.
+            Corpus consolidado DR-034 (Claude web + Gemini DR + DeepSeek V3 — convergencia 3/3) + plan curación humana presencial 4h por especie advanced (Aguacate → Café → Tomate). Datos calibrados anti-overpromise — rangos agroecológicos colombianos, NO hidroponía.
           </p>
         </Section>
 


### PR DESCRIPTION
## Summary

Implementación sprint inmediato ADR-032 — plan curación starter species. Reemplaza placeholder cards de HelpManual con corpus consolidado DR-034 (3/3 LLMs convergencia alta) lazy-loaded desde JSON.

## Especies cubiertas

- **🥬 Lechuga** (`starter`, 60-90 días) — Batavia + Crespa + Romana
- **🍓 Fresa** (`starter_premium`, 90-180 días) — Albión + Monterey + Camino Real
- **🍅 Tomate Chonto** (`intermediate`, 90-130 días) — Santa Cruz + Río Grande + Bachué

Las advanced (☕ Café + 🥑 Aguacate) quedan placeholder con etiqueta "curación humana presencial pendiente" — orden secuenciado en ADR-032: Aguacate Hass → Café arábica → Tomate Chonto (4h cada una con Agrosavia/Cenicafé).

## Política ADR-033 enforced

Renderer **solo Nivel 2 evidencia** científica (Opción C estricta). NO toggle lunar, NO badge folclore, NO field `failure_modes_traditional`. `tradicion_local` block en strategy repo storage es interno only.

## Test plan

- [ ] Build compila limpio (verificado local: 21.98s, HelpManual chunk 34kb)
- [ ] ESLint clean (verificado local)
- [ ] Click en una starter card en HelpManual → carga lazy + renderiza bloques semánticos
- [ ] Anti-overpromise visible en bloque cosecha (ej. lechuga muestra 0.3-0.6 kg/planta + warning sobre 800-1000g comercial)
- [ ] Fail mode badges (muy_común / común / ocasional) renderan con paleta amber/rose

## Próximos sprints

- Validación agrónomo Guatoc/Agrosavia para datos cuantitativos kg/planta agroecológica colombiana sin biocidas (gap G-A DR-034)
- Curación presencial 4h secuencia: Aguacate Hass → Café arábica → Tomate Chonto
- Cuando se valide, los JSON se actualizan in-place; el renderer no cambia

🤖 Generated with [Claude Code](https://claude.com/claude-code)