### PR TITLE
feat(adr-033): PestMonitoringWindow C.1 — Yela & Holyoak 1997

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.43",
+  "version": "0.12.44",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v86';
+const CACHE_NAME = 'chagra-v87';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/EnvironmentalCard.jsx
+++ b/src/components/EnvironmentalCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import AltitudeBadge from './AltitudeBadge';
 import SkyBadge from './common/SkyBadge';
+import PestMonitoringWindow from './PestMonitoringWindow';
 
 /**
  * EnvironmentalCard — card colapsable con info ambiental (DR-030 QW2).
@@ -11,23 +12,31 @@ import SkyBadge from './common/SkyBadge';
  * útil para el agrónomo experto pero ruido para el operador 0-contexto.
  * Progressive disclosure: oculta por default, expand on demand.
  *
+ * En ventana de luna nueva ± 3 días renderiza también PestMonitoringWindow
+ * (feature C.1 ADR-033 — Yela & Holyoak 1997). Fuera de esa ventana,
+ * el componente devuelve null y no aparece — sin polución visual.
+ *
  * Refs:
- *   - Decisión: deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md (D2)
+ *   - Decisión UX: deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md (D2)
+ *   - Política lunar: ADR-033 Opción C estricta
  */
 export default function EnvironmentalCard() {
   return (
-    <section
-      aria-label="Información ambiental: altitud y efemérides"
-      className="w-full px-4 py-3 bg-slate-900/60 border-b border-slate-800 flex flex-wrap items-center gap-3"
-    >
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">Altitud</span>
-        <AltitudeBadge />
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">Cielo</span>
-        <SkyBadge />
-      </div>
-    </section>
+    <div className="w-full bg-slate-900/60 border-b border-slate-800">
+      <section
+        aria-label="Información ambiental: altitud y efemérides"
+        className="px-4 py-3 flex flex-wrap items-center gap-3"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">Altitud</span>
+          <AltitudeBadge />
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">Cielo</span>
+          <SkyBadge />
+        </div>
+      </section>
+      <PestMonitoringWindow />
+    </div>
   );
 }

--- a/src/components/PestMonitoringWindow.jsx
+++ b/src/components/PestMonitoringWindow.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { Bug } from 'lucide-react';
+import { lunarPhase } from '../utils/skyEphemeris';
+import { pestMonitoringMessage } from '../services/lunarPestService';
+import { FARM_CONFIG } from '../config/defaults';
+
+/**
+ * PestMonitoringWindow — Feature C.1 ADR-033.
+ *
+ * Aparece SOLO en ventana de luna nueva ± 3 días con texto informativo
+ * sobre muestreo nocturno con trampa de luz (Yela & Holyoak 1997 — capturas
+ * 2-4× mayores). Fuera de la ventana, NO renderiza nada (return null).
+ *
+ * Compatible con política Opción C estricta:
+ *   - Solo Nivel 2 evidencia entomológica (NO biodinámica, NO calendario lunar)
+ *   - NO badge "saber tradicional", NO toggle, NO modal preventivo
+ *   - Mensaje neutro opt-in: si no tiene trampa, ignora
+ *
+ * Refs: ADR-033, dr-033-mistral-tiebreak.md, services/lunarPestService.js
+ */
+export default function PestMonitoringWindow() {
+  const [message, setMessage] = useState(() => computeMessage());
+
+  useEffect(() => {
+    const id = setInterval(() => setMessage(computeMessage()), 60 * 60 * 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (!message) return null;
+
+  return (
+    <aside
+      role="note"
+      aria-label="Ventana de muestreo nocturno con trampa de luz"
+      className="mx-4 mb-3 rounded-xl border border-indigo-800/50 bg-indigo-950/30 p-3 flex items-start gap-3"
+    >
+      <span aria-hidden="true" className="text-2xl shrink-0 leading-none">{'🌑'}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <Bug size={14} className="text-indigo-300 shrink-0" />
+          <h3 className="text-sm font-bold text-indigo-200">{message.headline}</h3>
+          <span className="text-[10px] text-indigo-400 font-mono">· {message.sub}</span>
+        </div>
+        <p className="text-xs text-slate-300 mt-1 leading-relaxed">{message.body}</p>
+        <p className="text-[10px] text-slate-500 italic mt-1">{message.caveat}</p>
+        <p className="text-[10px] text-slate-600 mt-0.5">Evidencia Nivel 2 · {message.citation}</p>
+      </div>
+    </aside>
+  );
+}
+
+function computeMessage() {
+  const lat = FARM_CONFIG.LATITUDE ?? 0;
+  const lunar = lunarPhase(new Date(), { latitude: lat });
+  return pestMonitoringMessage(lunar);
+}

--- a/src/services/lunarPestService.js
+++ b/src/services/lunarPestService.js
@@ -1,0 +1,99 @@
+/**
+ * lunarPestService.js — Ventana de monitoreo de plagas nocturnas según fase lunar.
+ *
+ * EVIDENCIA — Nivel 2 entomológica robusta:
+ *   Yela & Holyoak 1997 *Environmental Entomology* — capturas en trampas de luz
+ *   nocturna son 2-4× mayores en luna nueva vs luna llena. La luz lunar reduce
+ *   la atracción relativa de la trampa (la luna compite con la fuente artificial).
+ *
+ *   Dacke et al. 2003 *Nature* — polarización lunar en insectos.
+ *   Foster 2019, Freas 2024 — replicación robusta en escarabajos / hormigas
+ *   nocturnas.
+ *
+ * USO AGRONÓMICO:
+ *   Esta ventana NO es recomendación de tratamiento. Es información de muestreo:
+ *   si el operador YA tiene trampa de luz nocturna instalada (o quiere instalar
+ *   una temporalmente para sampling), la ventana de luna nueva ± 3 días captura
+ *   2-4× más individuos → mejor estimación de presión de plaga.
+ *
+ *   Operadores SIN trampa de luz: la información es neutra, no obliga.
+ *
+ * POLÍTICA — ADR-033 Opción C estricta:
+ *   - Esta es la ÚNICA feature lunar habilitada en Chagra
+ *   - Solo Nivel 2 evidencia (entomológica, no agroecológica genérica)
+ *   - NO sugiere "siembre/coseche/podar en X fase" (eso es Nivel 3 folclore)
+ *   - NO emite badge "🌙 saber tradicional"
+ *
+ * REFS: ADR-033, dr-033-mistral-tiebreak.md
+ */
+
+const NEW_MOON_WINDOW_DAYS = 3; // ±3 días alrededor de luna nueva
+
+/**
+ * Determina si estamos en ventana óptima de muestreo nocturno con trampa de luz.
+ *
+ * @param {{ daysSinceNewMoon: number, daysToNewMoon: number, fraction: number }} lunar
+ *   Output de `lunarPhase()` de skyEphemeris.
+ * @returns {{
+ *   inWindow: boolean,
+ *   daysToCenter: number,        // días al centro de la ventana (0 = luna nueva exacta)
+ *   centerDirection: 'past'|'future'|'now',
+ *   captureMultiplier: string,   // texto descriptivo "2-4×"
+ *   evidenceLevel: 2,
+ *   evidenceCitation: string,
+ * }}
+ */
+export function pestMonitoringWindow(lunar) {
+  if (!lunar || typeof lunar.daysSinceNewMoon !== 'number') {
+    return null;
+  }
+
+  const daysSince = lunar.daysSinceNewMoon;
+  const daysTo = lunar.daysToNewMoon;
+
+  // Distancia al centro (luna nueva). Tomar el menor entre "días desde la última"
+  // y "días hasta la próxima".
+  const distanceFromNewMoon = Math.min(daysSince, daysTo);
+
+  const inWindow = distanceFromNewMoon <= NEW_MOON_WINDOW_DAYS;
+
+  let centerDirection = 'now';
+  if (daysSince < daysTo) centerDirection = 'past';
+  else if (daysTo < daysSince) centerDirection = 'future';
+
+  return {
+    inWindow,
+    daysToCenter: distanceFromNewMoon,
+    centerDirection,
+    captureMultiplier: '2-4×',
+    evidenceLevel: 2,
+    evidenceCitation: 'Yela & Holyoak 1997 Environmental Entomology',
+  };
+}
+
+/**
+ * Construye el mensaje informativo (corto) cuando estamos en ventana.
+ * Devuelve null si NO estamos en ventana.
+ */
+export function pestMonitoringMessage(lunar) {
+  const w = pestMonitoringWindow(lunar);
+  if (!w?.inWindow) return null;
+
+  const daysRounded = Math.round(w.daysToCenter);
+  const phaseHint =
+    w.centerDirection === 'now' || daysRounded === 0
+      ? 'Luna nueva esta noche'
+      : w.centerDirection === 'past'
+        ? `${daysRounded} ${daysRounded === 1 ? 'día' : 'días'} después de luna nueva`
+        : `Luna nueva en ${daysRounded} ${daysRounded === 1 ? 'día' : 'días'}`;
+
+  return {
+    headline: '🌑 Ventana de muestreo nocturno',
+    sub: phaseHint,
+    body:
+      'Si tiene trampa de luz nocturna instalada o quiere instalarla temporalmente, ' +
+      'esta ventana captura 2-4× más individuos. Mejor estimación de presión de plaga.',
+    caveat: 'No es recomendación de tratamiento — es muestreo. Si no tiene trampa, ignore.',
+    citation: w.evidenceCitation,
+  };
+}


### PR DESCRIPTION
## Summary

Implementa la **única feature lunar habilitada** por ADR-033 Opción C estricta. Cierra el ciclo del DR-033 con código concreto.

Renderiza un aside informativo SOLO en ventana **luna nueva ± 3 días** sobre muestreo nocturno con trampa de luz. Fuera de la ventana, el componente devuelve null — sin polución visual.

## Política enforced

- ✅ Solo Nivel 2 evidencia entomológica (Yela & Holyoak 1997 *Environmental Entomology* — capturas 2-4× mayores en luna nueva)
- ❌ NO recomendación de tratamiento, solo info de muestreo opt-in
- ❌ NO badge "saber tradicional", NO toggle, NO modal preventivo

## Archivos

- `src/services/lunarPestService.js` (nuevo) — lógica pura, testeable
- `src/components/PestMonitoringWindow.jsx` (nuevo) — auto-refresh cada hora, paleta índigo (diferenciada del verde Chagra para señalar info contextual no crítica)
- `src/components/EnvironmentalCard.jsx` — wire bajo SkyBadge

## Test plan

- [ ] Build limpio (✅ verificado local 9.20s)
- [ ] ESLint clean (✅ verificado local)
- [ ] Render manual: forzar `KNOWN_NEW_MOON` en dev mostrar mensaje
- [ ] Verificar que fuera de ventana NO aparece nada

🤖 Generated with [Claude Code](https://claude.com/claude-code)