### PR TITLE
fix(ui): eliminar em dashes (—) en strings UI, David Loka feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,19 @@ Lista universal de patterns en `oss-pro/PROHIBITED_IN_PUBLIC.md`. Identificadore
 
 Cuando dudes si algo es estratégico, default privado y consulta. El leak histórico de la industria (Anthropic 2026-03-31, sourcemap) cuesta menos como precaución que como remediation.
 
+## Estilo de copy UI, sin em dashes
+
+**NO usar em dashes (`—`, U+2014) en strings UI** (JSX text content, props como `title=`, `aria-label=`, toasts, mensajes al usuario). Razón: David Loka 2026-05-06 lo identificó como fingerprint repetitivo de Claude AI ("ese hpta tiene una fijación con eso"). Reemplazar por:
+
+- `,` cuando es continuación de oración
+- `.` cuando es cierre + nueva idea
+- `:` cuando introduce un concepto
+- `(...)` cuando es nota lateral
+
+**Excepciones aceptables**: `'—'` como placeholder de empty state ("no hay valor aún"), comments JSDoc/JS internos no visibles al usuario.
+
+Auditoría: tras barrido inicial de PR #176 quedan <10 ocurrencias legítimas en JSX. Antes de mergear cualquier PR con texto UI nuevo, correr `grep -rn " — " src/**/*.jsx` y verificar que no se reintroduce el patrón.
+
 ## Merge gates obligatorios
 
 - `CodeQL / Analyze` — SAST.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.44",
+  "version": "0.12.45",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v87';
+const CACHE_NAME = 'chagra-v88';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,11 +53,11 @@ const LoadingFallback = () => (
   </div>
 );
 
-// NAV tiles — vocabulario user-facing post DR-030 QW2 (decisión D3+D4 del DR).
+// NAV tiles, vocabulario user-facing post DR-030 QW2 (decisión D3+D4 del DR).
 // Tile "Voz" eliminada: ya está accesible global vía MicFab abajo-izquierda
 // (QW4). Iconos canónicos: Sprout para plantas, NotebookPen para bitácora.
 // Card-sort n>=5 con usuarios 0-contexto colombianos pendiente para
-// validar empíricamente — esta release ships con hipótesis cultural
+// validar empíricamente, esta release ships con hipótesis cultural
 // (lenguaje agronómico colombiano) y se itera post-feedback.
 const NAV_TILES = [
   { id: 'activos', label: 'Plantas', icon: Sprout, accent: 'teal', desc: 'Cultivos, zonas e infraestructura' },
@@ -105,7 +105,7 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
   const hydrate = useAssetStore((s) => s.hydrate);
   const syncFromServer = useAssetStore((s) => s.syncFromServer);
 
-  // T2: Hidratación al montar — llena contadores desde IndexedDB inmediatamente
+  // T2: Hidratación al montar, llena contadores desde IndexedDB inmediatamente
   useEffect(() => {
     hydrate().then(() => {
       if (navigator.onLine) syncFromServer(fetchFromFarmOS);
@@ -137,7 +137,7 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
       {/* Lili #116: estadísticas al header (siempre visibles).
           Antes: el bloque assetCounts vivía dentro del <main scrollable>,
           se perdía al scrollear hacia abajo. Lili pidió "deberían ir al
-          inicio en el header" — ahora es hermano del TopBar (queda fuera
+          inicio en el header", ahora es hermano del TopBar (queda fuera
           del overflow del main, sticky de facto al top siempre). */}
       {plantsCount > 0 && (
         <button
@@ -213,7 +213,7 @@ export default function App() {
   const [toast, setToast] = useState(null);
   const [lastLogMessage, setLastLogMessage] = useState('');
 
-  // navigate(view, data) — único entry point para cambiar vista. Limpia
+  // navigate(view, data), único entry point para cambiar vista. Limpia
   // currentViewData salvo cuando se pasa explícitamente. Sin esto, navegar
   // dashboard → vista_con_initialData → dashboard → misma_vista_otra_vez
   // reusaba el initialData stale (bug latente de UX).
@@ -277,7 +277,7 @@ export default function App() {
       case 'insumos':
         return <InputLog onBack={() => navigate('dashboard')} onSave={showToast} />;
       case 'plant_asset':
-        // Lili #113 — desaparece el form plano. Redirige al rich form de
+        // Lili #113, desaparece el form plano. Redirige al rich form de
         // AssetsDashboard tab=plant que ya tiene SpeciesSelect, GuildSuggestions
         // y autofill estrato/gremio/producción (mismo modelo que el flujo voz).
         return <AssetsDashboard onBack={() => navigate('dashboard')} initialTab="plant" initialShowForm />;
@@ -302,7 +302,7 @@ export default function App() {
         return <TaskScreen onBack={() => navigate('task_log')} onSave={showToast} initialData={currentViewData?.task || currentViewData} />;
       case 'javier':
         return (
-          <ScreenShell title={`Campo — ${PRIMARY_WORKER_NAME}`} icon={Eye} onBack={() => navigate('dashboard')}>
+          <ScreenShell title={`Campo, ${PRIMARY_WORKER_NAME}`} icon={Eye} onBack={() => navigate('dashboard')}>
             <WorkerDashboard />
           </ScreenShell>
         );
@@ -353,7 +353,7 @@ export default function App() {
       <Suspense fallback={<LoadingFallback />}>
         {renderView()}
       </Suspense>
-      {/* FAB feedback inline para field testing — siempre visible salvo loading */}
+      {/* FAB feedback inline para field testing, siempre visible salvo loading */}
       {currentView !== 'loading' && currentView !== 'login' && <FieldFeedback />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && <MicFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -22,7 +22,7 @@ function deriveSpeciesSlug(name) {
 }
 
 // High-impact #4 (2026-05-03): galería cross-asset de fotos para esta especie.
-// Solo del operador en su finca (NO cross-farm — decisión Miguel 2026-05-02).
+// Solo del operador en su finca (NO cross-farm, decisión Miguel 2026-05-02).
 function SpeciesPhotoGallery({ speciesSlug, currentAssetId }) {
   const [photos, setPhotos] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -117,7 +117,7 @@ const PerformancePanel = ({ assetId }) => {
           </div>
           <div className="text-center">
             <p className="text-xl font-bold text-blue-400 tabular-nums">{totalInputWeight}</p>
-            <p className="text-[10px] text-slate-500 uppercase font-bold mt-1" title="Suma normalizada a kg/L base decimal — desglose por categoría debajo">Insumos (kg/L)</p>
+            <p className="text-[10px] text-slate-500 uppercase font-bold mt-1" title="Suma normalizada a kg/L base decimal, desglose por categoría debajo">Insumos (kg/L)</p>
           </div>
         </div>
       </div>
@@ -191,7 +191,7 @@ const CategoryBreakdown = ({ byCategory }) => {
 };
 
 /**
- * AssetDetailView — panel lateral de detalle de un activo (Fase 12.2).
+ * AssetDetailView, panel lateral de detalle de un activo (Fase 12.2).
  *
  * Consume `selectedAssetId` desde el store global. Busca el asset en las
  * cuatro colecciones segmentadas (plants/structures/equipment/materials)
@@ -321,7 +321,7 @@ export const AssetDetailView = () => {
             saving={geoSaving}
           />
 
-          {/* Acción de campo: registro de insumo — solo aplica a plants */}
+          {/* Acción de campo: registro de insumo, solo aplica a plants */}
           {(asset.asset_type === 'plant' || asset.type?.includes('plant')) && (
             <>
               <section>
@@ -357,7 +357,7 @@ export const AssetDetailView = () => {
                 />
               </section>
 
-              {/* Cementerio — fracaso como currículo (memoria
+              {/* Cementerio, fracaso como currículo (memoria
                   project_chagra_educational_dimension). Solo si planta NO está
                   ya marcada como muerta. */}
               {status !== 'dead' && (
@@ -366,7 +366,7 @@ export const AssetDetailView = () => {
                     <Skull size={14} /> Cementerio
                   </h3>
                   <p className="text-xs text-slate-400 mb-3 px-1 leading-relaxed">
-                    Si esta planta murió, márcala aquí. La perdida es dato — capturás la razón y queda como lección para tu próxima siembra.
+                    Si esta planta murió, márcala aquí. La perdida es dato, capturás la razón y queda como lección para tu próxima siembra.
                   </p>
                   <button
                     type="button"
@@ -526,7 +526,7 @@ export const AssetDetailView = () => {
         />
       )}
 
-      {/* Cementerio — workflow marcar planta muerta + capturar razón */}
+      {/* Cementerio, workflow marcar planta muerta + capturar razón */}
       {showCemeteryModal && isPlantType && (
         <PlantCemeteryModal
           plantName={name}

--- a/src/components/AssetTimeline.jsx
+++ b/src/components/AssetTimeline.jsx
@@ -7,7 +7,7 @@ import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
 
 /**
- * AssetTimeline — Línea de tiempo agroecológica de un activo (plant).
+ * AssetTimeline, Línea de tiempo agroecológica de un activo (plant).
  *
  * Consume logs desde useLogStore (alimentado por logCache + pullRecentLogs).
  * Agrupa por mes/año para facilitar lectura secuencial. Los logs _pending

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -20,7 +20,7 @@ import { generatePlanForPlant } from '../services/planGeneratorService';
 // Thumb foto de planta para cards. Sub-componente porque usePhotoUrl no
 // puede llamarse dentro de un map() condicional (regla de hooks).
 // Si no hay foto de usuario para este asset, cae al placeholder (Fase 1
-// — Fase 3 hidratará /catalog-photos/<slug>.jpg con fotos GBIF top-uso).
+//, Fase 3 hidratará /catalog-photos/<slug>.jpg con fotos GBIF top-uso).
 // eslint-disable-next-line no-unused-vars -- FallbackIcon SE USA en JSX, eslint react-jsx detection falla en este config
 function PlantCardThumb({ asset, colors, FallbackIcon }) {
   const photo = usePhotoUrl({ assetId: asset?.id });
@@ -78,12 +78,12 @@ const GREMIO_OPTIONS = [
   { value: 'productivo_principal', label: 'Productivo principal' },
 ];
 
-// Lili #111 #112 #114 — clarificar tabs:
-// - 'Zonas' (land): áreas geográficas con polígono — tab mantenida con
+// Lili #111 #112 #114, clarificar tabs:
+// - 'Zonas' (land): áreas geográficas con polígono, tab mantenida con
 //   descripción explícita en hover/aria.
 // - 'Infraestructura' (structure): construcciones físicas (invernaderos,
-//   bodegas) — diferente de Zonas (que son polígonos abiertos).
-// - 'Herramientas' (equipment): ELIMINADA — Lili "qué finalidad cumple?
+//   bodegas), diferente de Zonas (que son polígonos abiertos).
+// - 'Herramientas' (equipment): ELIMINADA, Lili "qué finalidad cumple?
 //   sin agregar ubicación, sin contexto". Sin caso de uso MVP claro,
 //   removed hasta que se valide demanda real. Si necesario re-agregar
 //   en v1.x con scope definido (asignación a tasks, inventario físico).
@@ -207,7 +207,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   // initialTab + initialShowForm permiten que App.jsx case 'plant_asset' redirija
   // aquí con el form rich abierto directo en tab=plant. Antes el TopBar `+`
   // navegaba al PlantAssetLog plano que NO usaba SpeciesSelect/GuildSuggestions/
-  // autofill — rich form vivía escondido detrás de Plantas → Siembras → Nuevo.
+  // autofill, rich form vivía escondido detrás de Plantas → Siembras → Nuevo.
   const [activeTab, setActiveTab] = useState(initialTab || 'plant');
   const [searchQuery, setSearchQuery] = useState('');
   const [showForm, setShowForm] = useState(initialShowForm);
@@ -443,7 +443,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
 
       window.dispatchEvent(new CustomEvent('taskAdded'));
 
-      // Sugerencias post-create según tipo de asset (Fase 21 — high-impact wiring)
+      // Sugerencias post-create según tipo de asset (Fase 21, high-impact wiring)
       if (activeTab === 'material' && formData.name?.trim()) {
         findBiopreparadosByIngredient(formData.name.trim())
           .then((recipes) => {
@@ -887,7 +887,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
         </div>
       )}
 
-      {/* Vista de mapa global (Fase 17.3) — reemplaza la lista cuando viewMode === 'map' */}
+      {/* Vista de mapa global (Fase 17.3), reemplaza la lista cuando viewMode === 'map' */}
       {viewMode === 'map' && (
         <div className="flex-1 min-h-0">
           <FarmMap
@@ -943,7 +943,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
                   type="button"
                   onClick={() => setCurrentZoneId('__cemetery__')}
                   className="text-slate-400 hover:text-slate-300 hover:underline inline-flex items-center gap-1"
-                  title="Ver plantas que se perdieron — fracaso como currículo"
+                  title="Ver plantas que se perdieron, fracaso como currículo"
                 >
                   🪦 {cemeteryCount}
                 </button>
@@ -986,7 +986,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
               type="button"
               onClick={() => setCurrentZoneId('__cemetery__')}
               className="w-full p-4 rounded-xl bg-slate-900 border border-slate-700 hover:bg-slate-800 text-left transition-colors"
-              title="Plantas perdidas — espacio para revisar lecciones aprendidas"
+              title="Plantas perdidas, espacio para revisar lecciones aprendidas"
             >
               <div className="flex items-center justify-between gap-3">
                 <div className="flex items-center gap-3 min-w-0">
@@ -995,7 +995,7 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
                   </div>
                   <div className="min-w-0">
                     <h4 className="font-bold text-slate-200 truncate">Cementerio</h4>
-                    <p className="text-xs text-slate-500">Lo que se perdió. Sin juicio — son datos para aprender.</p>
+                    <p className="text-xs text-slate-500">Lo que se perdió. Sin juicio, son datos para aprender.</p>
                   </div>
                 </div>
                 <div className="text-right shrink-0">

--- a/src/components/BiodiversidadView.jsx
+++ b/src/components/BiodiversidadView.jsx
@@ -1,5 +1,5 @@
 /**
- * BiodiversidadView — Vista del ecosistema y diversidad biológica de la finca.
+ * BiodiversidadView, Vista del ecosistema y diversidad biológica de la finca.
  *
  * Fondo permanente: ilustración curada "biodiversidad-bg.jpg" con fauna y
  * flora del bosque alto-andino colombiano (oso andino, quetzal, morpho,
@@ -83,7 +83,7 @@ export default function BiodiversidadView({ onBack }) {
         <section className="bg-slate-900/85 backdrop-blur-sm border border-emerald-800/30 rounded-xl p-4">
           <p className="text-sm text-slate-200 leading-snug mb-2">
             <span className="text-emerald-300 font-bold">Biodiversidad de la finca.</span>{' '}
-            Métrica clave del diseño agroforestal sintrópico — más especies en
+            Métrica clave del diseño agroforestal sintrópico, más especies en
             estratos diversos = mayor resiliencia climática, mejor regulación de
             plagas y suelo más vivo.
           </p>

--- a/src/components/BiopreparadoSuggestionModal.jsx
+++ b/src/components/BiopreparadoSuggestionModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { X, Beaker, Clock, ChevronDown, ChevronRight, BookOpen } from 'lucide-react';
 
 /**
- * BiopreparadoSuggestionModal — Modal sugerencia de biopreparados para un
+ * BiopreparadoSuggestionModal, Modal sugerencia de biopreparados para un
  * ingrediente que el operador acaba de agregar al inventario.
  *
  * Trigger: post-create asset--material en AssetsDashboard.handleSave si
@@ -53,7 +53,7 @@ export default function BiopreparadoSuggestionModal({ ingredientName, bioprepara
           </button>
         </header>
 
-        {/* Body — lista colapsable de biopreparados */}
+        {/* Body, lista colapsable de biopreparados */}
         <div className="flex-1 overflow-y-auto p-3 space-y-2">
           {biopreparados.map((bp) => {
             const isOpen = expandedId === bp.id;

--- a/src/components/BitacoraEntryDetail.jsx
+++ b/src/components/BitacoraEntryDetail.jsx
@@ -6,7 +6,7 @@ import { captureAndCompress, getPhotoForLog } from '../services/photoService';
 import { analyzeFoliage } from '../services/aiService';
 
 /**
- * BitacoraEntryDetail — vista detalle de una entrada de Bitácora/Historial.
+ * BitacoraEntryDetail, vista detalle de una entrada de Bitácora/Historial.
  *
  * Lili #104: "Bitácora / Historial: Aquí no permite ingresar a ninguno de
  * los registros pendientes." Faltaba la screen detalle al tap en cualquier
@@ -22,9 +22,9 @@ import { analyzeFoliage } from '../services/aiService';
  * - Botón Editar si la entry es task pendiente (callback edit)
  *
  * Props:
- *   entry: object — la entry a mostrar
- *   onBack: fn — volver a listado
- *   onEdit: fn(entry) — opcional, abrir edit screen (solo para tareas pending)
+ *   entry: object, la entry a mostrar
+ *   onBack: fn, volver a listado
+ *   onEdit: fn(entry), opcional, abrir edit screen (solo para tareas pending)
  */
 function getEntryTitle(entry) {
   return (
@@ -390,7 +390,7 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
                   </span>
                 </div>
                 <p className="text-[11px] text-slate-500 leading-snug">
-                  Detecta enfermedades, deficiencias nutricionales y salud general (gemma3:4b local). Resultados pueden ser inexactos — reporta los falsos positivos para mejorar el feature.
+                  Detecta enfermedades, deficiencias nutricionales y salud general (gemma3:4b local). Resultados pueden ser inexactos, reporta los falsos positivos para mejorar el feature.
                 </p>
                 {aiState === 'idle' && (
                   <button

--- a/src/components/ChagraGrowLoader.jsx
+++ b/src/components/ChagraGrowLoader.jsx
@@ -262,7 +262,7 @@ const KEYFRAMES_CSS = `
   92%, 100% { fill: #d97706; }
 }
 
-/* FRAILEJÓN (crece ~1 cm/año en la realidad — fases vegetativas pausadas,
+/* FRAILEJÓN (crece ~1 cm/año en la realidad, fases vegetativas pausadas,
    floración como culmen súbito). */
 @keyframes cgl-frai-grass {
   0%, 100% { opacity: 0; transform: scaleY(0); }

--- a/src/components/CycleContentRenderer.jsx
+++ b/src/components/CycleContentRenderer.jsx
@@ -22,13 +22,13 @@ const DIFFICULTY_BADGE = {
 };
 
 /**
- * CycleContentRenderer — Lazy loader + renderer del corpus curado por especie.
+ * CycleContentRenderer, Lazy loader + renderer del corpus curado por especie.
  *
  * Lee `/public/cycle-content/<slug>.json` (consolidado DR-034 3/3 LLMs +
  * curación pendiente Guatoc / Agrosavia / Cenicafé).
  *
  * Datos vienen del DR-034 cerrado 2026-05-06 (ADR-032). NO mezclar con
- * folclore/biodinámica — política ADR-033 Opción C estricta.
+ * folclore/biodinámica, política ADR-033 Opción C estricta.
  */
 export default function CycleContentRenderer({ slug, onClose }) {
   const [state, setState] = useState({ slug: null, data: null, error: null });
@@ -133,7 +133,7 @@ export default function CycleContentRenderer({ slug, onClose }) {
 
       {Array.isArray(data.failure_modes) && data.failure_modes.length > 0 && (
         <Block icon={AlertTriangle} title="Razones comunes de fracaso" tone="amber">
-          <p className="text-[10px] text-slate-500 italic mb-2">Documentado para que falle menos. Cuando le pase alguno, no se sienta solo — está en el manual.</p>
+          <p className="text-[10px] text-slate-500 italic mb-2">Documentado para que falle menos. Cuando le pase alguno, no se sienta solo, está en el manual.</p>
           <ul className="space-y-2 text-xs">
             {data.failure_modes.map((f, i) => {
               const badge = FREQ_BADGE[f.frecuencia] ?? FREQ_BADGE.ocasional;
@@ -159,7 +159,7 @@ export default function CycleContentRenderer({ slug, onClose }) {
             {data.companions.map((c, i) => (
               <li key={i}>
                 <span className="font-bold text-emerald-300">{c.especie}</span>
-                <span className="text-slate-400"> — {c.razon}</span>
+                <span className="text-slate-400">, {c.razon}</span>
                 {c.evidencia && <span className="text-[10px] text-slate-600"> · {c.evidencia}</span>}
               </li>
             ))}
@@ -173,7 +173,7 @@ export default function CycleContentRenderer({ slug, onClose }) {
             {data.antagonistas.map((a, i) => (
               <li key={i}>
                 <span className="font-bold text-rose-300">{a.especie}</span>
-                <span className="text-slate-400"> — {a.razon}</span>
+                <span className="text-slate-400">, {a.razon}</span>
               </li>
             ))}
           </ul>
@@ -186,7 +186,7 @@ export default function CycleContentRenderer({ slug, onClose }) {
             {data.biopreparados.map((b, i) => (
               <li key={i}>
                 <span className="font-bold text-emerald-300">{b.nombre}</span>
-                <span className="text-slate-400"> — {b.uso}</span>
+                <span className="text-slate-400">, {b.uso}</span>
                 {b.fuente && <span className="text-[10px] text-slate-600 italic"> · {b.fuente}</span>}
               </li>
             ))}

--- a/src/components/DateField.jsx
+++ b/src/components/DateField.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Calendar } from 'lucide-react';
 
 /**
- * DateField — Wrapper de <input type="date"> optimizado para iOS Safari.
+ * DateField, Wrapper de <input type="date"> optimizado para iOS Safari.
  * Asegura formato YYYY-MM-DD y área táctil de 44px.
  *
  * @param {Object} props

--- a/src/components/EnvironmentalCard.jsx
+++ b/src/components/EnvironmentalCard.jsx
@@ -4,7 +4,7 @@ import SkyBadge from './common/SkyBadge';
 import PestMonitoringWindow from './PestMonitoringWindow';
 
 /**
- * EnvironmentalCard — card colapsable con info ambiental (DR-030 QW2).
+ * EnvironmentalCard, card colapsable con info ambiental (DR-030 QW2).
  *
  * Reúne los badges que vivían inline en el header del DashboardView
  * (AltitudeBadge + SkyBadge) en una card aparte expandible bajo el TopBar.
@@ -13,8 +13,8 @@ import PestMonitoringWindow from './PestMonitoringWindow';
  * Progressive disclosure: oculta por default, expand on demand.
  *
  * En ventana de luna nueva ± 3 días renderiza también PestMonitoringWindow
- * (feature C.1 ADR-033 — Yela & Holyoak 1997). Fuera de esa ventana,
- * el componente devuelve null y no aparece — sin polución visual.
+ * (feature C.1 ADR-033, Yela & Holyoak 1997). Fuera de esa ventana,
+ * el componente devuelve null y no aparece, sin polución visual.
  *
  * Refs:
  *   - Decisión UX: deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md (D2)

--- a/src/components/EvidenceCapture.jsx
+++ b/src/components/EvidenceCapture.jsx
@@ -10,14 +10,14 @@ import { savePayload } from '../services/payloadService';
 import { useGeolocation } from '../hooks/useGeolocation';
 
 /**
- * EvidenceCapture — Captura con diagnóstico IA y evolución histórica (Fase 20.2b).
+ * EvidenceCapture, Captura con diagnóstico IA y evolución histórica (Fase 20.2b).
  *
  * Props:
  *   - logId:          UUID del log
  *   - assetId:        UUID del activo relacionado (para historial)
  *   - assetGeometry:  WKT o GeoJSON de la ubicación del activo
  *   - onCountChange:  callback(count)
- *   - onDiagnosis:    callback(diagnosis) — para toast externo
+ *   - onDiagnosis:    callback(diagnosis), para toast externo
  *   - disabled:       boolean
  */
 export const EvidenceCapture = ({
@@ -123,7 +123,7 @@ export const EvidenceCapture = ({
 
       console.info(`[Evidence] Foto ${mediaId} guardada (${(optimized.size / 1024).toFixed(0)} KB).`);
 
-      // Diagnóstico IA async — solo si no existe diagnóstico cacheado
+      // Diagnóstico IA async, solo si no existe diagnóstico cacheado
       if (navigator.onLine && !diagnosis) {
         setDiagnosing(true);
         setLiveDiagnosis('');

--- a/src/components/FarmMap.jsx
+++ b/src/components/FarmMap.jsx
@@ -6,7 +6,7 @@ import { wktToGeoJson } from '../utils/geo';
 import { logCache } from '../db/logCache';
 
 /**
- * FarmMap — Vista maestra de activos geolocalizados (Fase 17.2).
+ * FarmMap, Vista maestra de activos geolocalizados (Fase 17.2).
  *
  * Lee todos los assets con `attributes.intrinsic_geometry.value` (WKT) desde
  * el store, los parsea con `wktToGeoJson` y los dibuja como capas de Leaflet
@@ -18,17 +18,17 @@ import { logCache } from '../db/logCache';
  *                  Si es null, muestra toda la finca.
  *   - onAssetClick: callback(assetId) al tocar una capa. Integra con detalle/logs.
  *   - onTaskComplete: callback(logId) al completar tarea desde popup del mapa.
- *   - showTasks:  boolean — si true, renderiza capa de tareas pendientes.
+ *   - showTasks:  boolean, si true, renderiza capa de tareas pendientes.
  */
 
 const DEFAULT_CENTER = [4.5306, -73.9247]; // Choachí, Cundinamarca
 const DEFAULT_ZOOM = 15;
 const MAP_STATE_KEY = 'chagra:v1:map_state';
 
-// Estilos por tipo (Fase 17.2 — estilizado por asset_type).
+// Estilos por tipo (Fase 17.2, estilizado por asset_type).
 const STYLES = {
   land: {
-    color: '#92400e', // brown/amber-800 — borde marrón
+    color: '#92400e', // brown/amber-800, borde marrón
     weight: 2,
     fillColor: 'transparent',
     fillOpacity: 0,
@@ -136,7 +136,7 @@ export const FarmMap = ({ focusZoneId = null, onAssetClick, onTaskComplete, show
     mapRef.current = map;
     featureGroupRef.current = L.featureGroup().addTo(map);
 
-    // Persistir viewport al mover/zoom (Fase 17 — topografía compleja)
+    // Persistir viewport al mover/zoom (Fase 17, topografía compleja)
     const saveViewport = () => {
       try {
         const c = map.getCenter();

--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -1,5 +1,5 @@
 /**
- * FieldFeedback — botón flotante 💬 + modal para que Lili (o cualquier
+ * FieldFeedback, botón flotante 💬 + modal para que Lili (o cualquier
  * field tester) reporte fricciones UX inline durante el test.
  *
  * - Botón fixed bottom-right, no intrusivo
@@ -10,12 +10,12 @@
  * - Bulk export futuro: script `npm run export:feedback` extrae todo
  *   y crea GitHub Issues en repo Chagra
  *
- * Audio capture (Lili — voto operador 2026-05-02): grabar es más rápido
+ * Audio capture (Lili, voto operador 2026-05-02): grabar es más rápido
  * que tipear "hice click acá y pasó X" en el campo. Reusa useVoiceRecorder
- * (mismo hook que VoiceCapture) — sin pipeline Whisper/qwen, solo Blob
+ * (mismo hook que VoiceCapture), sin pipeline Whisper/qwen, solo Blob
  * crudo persistido para review humano post-sesión.
  *
- * Sin dependencia de html2canvas — Lili saca screenshot iPhone manual y
+ * Sin dependencia de html2canvas, Lili saca screenshot iPhone manual y
  * adjunta luego si quiere. Mantiene bundle liviano.
  */
 import { useState, useEffect } from 'react';
@@ -42,7 +42,7 @@ export default function FieldFeedback() {
   const [submitted, setSubmitted] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
 
-  // Audio state — el hook gestiona MediaRecorder + permisos + hard limit 30s.
+  // Audio state, el hook gestiona MediaRecorder + permisos + hard limit 30s.
   const { isRecording, audioLevel, durationMs, error: recorderError, start, stop, reset, hardLimitMs } = useVoiceRecorder();
   const [audioBlob, setAudioBlob] = useState(null);
   const [audioMime, setAudioMime] = useState('');
@@ -105,7 +105,7 @@ export default function FieldFeedback() {
       const watchdog = setTimeout(() => {
         if (!settled) {
           settled = true;
-          reject(new Error('IndexedDB timeout (8s) — fallback'));
+          reject(new Error('IndexedDB timeout (8s), fallback'));
         }
       }, SUBMIT_TIMEOUT_MS);
 

--- a/src/components/GuildSuggestions.jsx
+++ b/src/components/GuildSuggestions.jsx
@@ -9,7 +9,7 @@ import ExternalAiButton from './common/ExternalAiButton';
 import { buildGuildExternalPrompt } from '../services/externalAiPromptBuilder';
 
 // Autopilot #8 (2026-05-03): re-rank companions putting existing plants first.
-// Reduce friction de "tengo que comprar otra especie" — mostrar primero las
+// Reduce friction de "tengo que comprar otra especie", mostrar primero las
 // que el operador ya tiene es más accionable.
 function normName(s) {
   return (s || '').toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/\s+#\d+$/, '').trim();
@@ -37,12 +37,12 @@ function isCompanionInFinca(companionName, existingSet) {
 }
 
 /**
- * GuildSuggestions — Panel de compañeros sugeridos y antagonistas (Fase 18).
+ * GuildSuggestions, Panel de compañeros sugeridos y antagonistas (Fase 18).
  *
  * Renderiza resultados de las 3 capas del motor de gremios:
  *   1. Compañeros directos (speciesDefaults.companions)
  *   2. Complementos estructurales (estrato + gremio)
- *   3. Inferencia IA (Ollama/Gemma 4) — bajo demanda
+ *   3. Inferencia IA (Ollama/Gemma 4), bajo demanda
  *
  * Props:
  *   - speciesId:       id de la especie seleccionada
@@ -61,7 +61,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
   const userPlants = useAssetStore((s) => s.plants);
   const existingSpeciesSet = useMemo(() => buildExistingSpeciesSet(userPlants), [userPlants]);
 
-  // Capas 1 + 2: estáticas + estructurales — re-ranked con companions existentes primero.
+  // Capas 1 + 2: estáticas + estructurales, re-ranked con companions existentes primero.
   const { companions, antagonists } = useMemo(() => {
     if (!speciesId) return { companions: [], antagonists: [] };
     const raw = getSuggestedCompanions(speciesId);
@@ -148,7 +148,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
 
   return (
     <div className="space-y-3">
-      {/* Compañeros sugeridos (Capas 1 + 2) — Autopilot #8: existentes primero */}
+      {/* Compañeros sugeridos (Capas 1 + 2), Autopilot #8: existentes primero */}
       {companions.length > 0 && (
         <div>
           <label className="text-xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-1 mb-2">
@@ -200,7 +200,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
         </div>
       )}
 
-      {/* Capa 3 enriquecida — Pro module si está registrado */}
+      {/* Capa 3 enriquecida, Pro module si está registrado */}
       {EnrichedComp && (
         <EnrichedComp
           speciesId={speciesId}
@@ -209,7 +209,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
         />
       )}
 
-      {/* Capa 3 — Consulta IA en vivo (siempre disponible, OSS) */}
+      {/* Capa 3, Consulta IA en vivo (siempre disponible, OSS) */}
       <div>
         <div className="flex items-center gap-2 flex-wrap">
           <button

--- a/src/components/HarvestLog.jsx
+++ b/src/components/HarvestLog.jsx
@@ -6,7 +6,7 @@ import { logCache } from '../db/logCache';
 
 // Autopilot #7 (2026-05-03): mediana de cosechas pasadas como sugerencia
 // de cantidad. Reduce friction en cosechas repetitivas (fresa cada semana,
-// huevo diario) sin imponer — operador siempre puede sobreescribir.
+// huevo diario) sin imponer, operador siempre puede sobreescribir.
 function median(values) {
   if (!Array.isArray(values) || values.length === 0) return null;
   const sorted = values.slice().sort((a, b) => a - b);

--- a/src/components/HelpManual.jsx
+++ b/src/components/HelpManual.jsx
@@ -14,7 +14,7 @@ const PLACEHOLDER_CYCLES = [
 ];
 
 /**
- * HelpManual — Manual de usuario integrado en la PWA.
+ * HelpManual, Manual de usuario integrado en la PWA.
  *
  * Acceso desde TopBar → botón ? (HelpCircle).
  *
@@ -77,7 +77,7 @@ export default function HelpManual({ onBack }) {
         </p>
 
         {/* Sección Inicio Rápido */}
-        <Section icon={Sprout} title="🌱 Inicio rápido — primera vez" defaultOpen={true}>
+        <Section icon={Sprout} title="🌱 Inicio rápido, primera vez" defaultOpen={true}>
           <ol className="list-decimal pl-5 space-y-1.5">
             <li>Toque el botón <strong className="text-purple-400">+</strong> arriba (header) para registrar su primera planta.</li>
             <li>Busque la especie escribiendo (ej. &ldquo;gulpa&rdquo; encuentra Gulupa). El sistema autocompleta estrato, gremio y producción.</li>
@@ -86,7 +86,7 @@ export default function HelpManual({ onBack }) {
             <li>Guarde. Aparece en <strong>Activos → Plantas</strong>.</li>
           </ol>
           <p className="mt-2 text-xs text-slate-500 italic">
-            ¿Sin red? La app funciona offline — los datos se sincronizan cuando vuelva la conexión.
+            ¿Sin red? La app funciona offline, los datos se sincronizan cuando vuelva la conexión.
           </p>
         </Section>
 
@@ -121,7 +121,7 @@ export default function HelpManual({ onBack }) {
           <p className="mt-2">En el formulario aparece un link sutil <em>&ldquo;Agrupar siembra&rdquo;</em> o <em>&ldquo;Registrar individualmente&rdquo;</em> si quiere cambiar el default.</p>
         </Section>
 
-        {/* Sección Foto — expandida con foto por especie */}
+        {/* Sección Foto, expandida con foto por especie */}
         <Section icon={Camera} title="📸 Foto: tomar, adjuntar y foto guía por especie">
           <p><strong>Al crear planta:</strong> el botón cámara abre su cámara o galería. La foto queda en la hoja de vida de esa planta.</p>
           <p><strong>Adjuntar a evento existente</strong>: entre al evento desde Bitácora/Historial → sección &ldquo;Adjuntar foto a este evento&rdquo;. Útil para documentar después de la siembra.</p>
@@ -132,9 +132,9 @@ export default function HelpManual({ onBack }) {
               Al elegir especie en el formulario aparece un thumbnail bajo el input. Función:
             </p>
             <ul className="text-xs text-slate-400 list-disc pl-5 space-y-1 mt-2">
-              <li><strong>Su primera foto</strong> de esa especie queda como referencia visual cada vez que abre el form de la misma planta — útil para confirmar &ldquo;sí, esto es lo que sembré&rdquo;.</li>
-              <li><strong>Si nunca tomó foto</strong>, ve un placeholder verde con &ldquo;Agregue una foto&rdquo;. No es error — es invitación: la primera foto que tome ocupa ese lugar para sus próximas siembras de la misma especie.</li>
-              <li>Las fotos NO se comparten con otras fincas (privacidad — decidido 2026-05-02). Solo usted las ve en su cuenta.</li>
+              <li><strong>Su primera foto</strong> de esa especie queda como referencia visual cada vez que abre el form de la misma planta, útil para confirmar &ldquo;sí, esto es lo que sembré&rdquo;.</li>
+              <li><strong>Si nunca tomó foto</strong>, ve un placeholder verde con &ldquo;Agregue una foto&rdquo;. No es error, es invitación: la primera foto que tome ocupa ese lugar para sus próximas siembras de la misma especie.</li>
+              <li>Las fotos NO se comparten con otras fincas (privacidad, decidido 2026-05-02). Solo usted las ve en su cuenta.</li>
               <li>En el futuro v1.1 cargaremos un &ldquo;banco visual&rdquo; del catálogo (frutos típicos de cada especie desde GBIF/iNaturalist con licencia libre) para que aparezcan ANTES de que tome su propia foto.</li>
             </ul>
             <p className="text-xs text-slate-500 italic mt-2">
@@ -147,7 +147,7 @@ export default function HelpManual({ onBack }) {
           </p>
         </Section>
 
-        {/* Sección Vision AI — disease diagnosis + species recognition (BETA) */}
+        {/* Sección Vision AI, disease diagnosis + species recognition (BETA) */}
         <Section icon={Sprout} title="🧬 IA por foto: enfermedades + identificación de especie">
           <p>Chagra usa visión AI local (Gemma3 multimodal) para dos funciones distintas, ambas marcadas <strong className="text-amber-400">BETA</strong>:</p>
 
@@ -161,7 +161,7 @@ export default function HelpManual({ onBack }) {
           </ul>
           <p className="text-xs mt-2">Disponible en <strong>tres puntos</strong>:</p>
           <ol className="list-decimal pl-5 space-y-1 text-xs">
-            <li><strong>Campo (Worker mode)</strong> → captura evidencia. Análisis se guarda como <code>log--observation</code> con marker AI; aparece en la línea de tiempo como <em>&ldquo;Inferencia IA&rdquo;</em> y debe confirmar/rechazar (gate humano — ADR-019 Regla 1).</li>
+            <li><strong>Campo (Worker mode)</strong> → captura evidencia. Análisis se guarda como <code>log--observation</code> con marker AI; aparece en la línea de tiempo como <em>&ldquo;Inferencia IA&rdquo;</em> y debe confirmar/rechazar (gate humano, ADR-019 Regla 1).</li>
             <li><strong>Bitácora → entrada con foto adjunta</strong> → sección amber &ldquo;Análisis IA experimental&rdquo; abajo del bloque foto. Botón <em>&ldquo;Analizar foto con IA&rdquo;</em>. Funciona con fotos recién capturadas Y fotos viejas guardadas.</li>
             <li><strong>Plant detail → sección &ldquo;Consultar IA externa&rdquo;</strong> → genera prompt para pegar en Gemini/ChatGPT/Claude (alternativa cuando el modelo local no responde).</li>
           </ol>
@@ -196,7 +196,7 @@ export default function HelpManual({ onBack }) {
         {/* Sección Plagas */}
         <Section icon={Bug} title="🐛 Reportar plaga / invasora">
           <p>Toque menú principal → <strong>&ldquo;Plagas&rdquo;</strong>. Seleccione la especie invasora del catálogo, capture foto y geolocalización.</p>
-          <p>Después de guardar, le aparece una pantalla con <strong>sugerencias de especies nativas para reemplazar</strong> — toque &ldquo;Sembrar aquí&rdquo; y va al flow de siembra precargado con la nativa + las coordenadas del invasor.</p>
+          <p>Después de guardar, le aparece una pantalla con <strong>sugerencias de especies nativas para reemplazar</strong>, toque &ldquo;Sembrar aquí&rdquo; y va al flow de siembra precargado con la nativa + las coordenadas del invasor.</p>
         </Section>
 
         {/* Sección Cosechar */}
@@ -210,7 +210,7 @@ export default function HelpManual({ onBack }) {
           <p>Botón flotante 💬 abajo a la <strong>derecha</strong> (siempre visible). Puede:</p>
           <ul className="list-disc pl-5 space-y-1">
             <li>Escribir texto explicando qué pasó</li>
-            <li>Grabar audio (botón 🎤 dentro del modal): &ldquo;hice click acá y pasó X&rdquo; — sin necesidad de tipear con manos sucias</li>
+            <li>Grabar audio (botón 🎤 dentro del modal): &ldquo;hice click acá y pasó X&rdquo;, sin necesidad de tipear con manos sucias</li>
             <li>Ambos: texto + audio</li>
           </ul>
           <p>El feedback queda guardado localmente y se sincroniza después.</p>
@@ -229,7 +229,7 @@ export default function HelpManual({ onBack }) {
             </div>
             <div>
               <p className="font-bold text-amber-300">📷 La foto no aparece tras adjuntarla</p>
-              <p className="text-xs text-slate-400">Recargue la pantalla — IndexedDB puede tardar en flush. Si persiste, repórtelo via 💬.</p>
+              <p className="text-xs text-slate-400">Recargue la pantalla, IndexedDB puede tardar en flush. Si persiste, repórtelo via 💬.</p>
             </div>
             <div>
               <p className="font-bold text-amber-300">🌱 Creé planta y no aparece en la zona</p>
@@ -254,13 +254,13 @@ export default function HelpManual({ onBack }) {
           </ul>
         </Section>
 
-        {/* Sección Aprende sembrando — corpus curado desde /public/cycle-content/.
+        {/* Sección Aprende sembrando, corpus curado desde /public/cycle-content/.
             Datos consolidados DR-034 cerrado 2026-05-06 (3/3 LLMs convergencia
             alta) + ADR-032 plan curación starter species. Política ADR-033
-            Opción C estricta — solo Nivel 2 evidencia, NO folclore. */}
-        <Section icon={GraduationCap} title="🌿 Aprende sembrando — ciclo agroecológico" defaultOpen={false}>
+            Opción C estricta, solo Nivel 2 evidencia, NO folclore. */}
+        <Section icon={GraduationCap} title="🌿 Aprende sembrando, ciclo agroecológico" defaultOpen={false}>
           <p className="text-sm leading-relaxed">
-            <strong className="text-emerald-300">Punto de partida educativo</strong> para quien empieza desde cero — no solo cómo usar Chagra, sino cómo cultivar.
+            <strong className="text-emerald-300">Punto de partida educativo</strong> para quien empieza desde cero, no solo cómo usar Chagra, sino cómo cultivar.
           </p>
 
           <p className="text-xs text-slate-400 leading-relaxed mt-2">
@@ -283,7 +283,7 @@ export default function HelpManual({ onBack }) {
             ))}
           </div>
 
-          <h4 className="text-xs uppercase tracking-wider text-orange-400 font-bold mt-4 mb-2">Pendientes — curación humana presencial</h4>
+          <h4 className="text-xs uppercase tracking-wider text-orange-400 font-bold mt-4 mb-2">Pendientes, curación humana presencial</h4>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {PLACEHOLDER_CYCLES.map((c) => (
               <div key={c.label} className="p-3 rounded-lg bg-slate-900 border border-slate-800 opacity-70">
@@ -302,32 +302,32 @@ export default function HelpManual({ onBack }) {
           <div className="mt-4 p-3 rounded-xl bg-emerald-900/15 border border-emerald-800/40">
             <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold mb-2">Cada ciclo cubre</p>
             <ul className="text-xs text-slate-300 space-y-1 list-disc pl-5">
-              <li><strong>Preparación de tierra</strong> — matera (mezcla recomendada) vs campo abierto (descompactación + biopreparados)</li>
-              <li><strong>Germinación + propagación</strong> — semilla, esqueje, acodo, división, injerto (según especie)</li>
-              <li><strong>Hitos del ciclo</strong> — día por día, criterio observable + acción clave</li>
-              <li><strong>Razones comunes de fracaso</strong> — top 5 con prevención agroecológica + frecuencia esperada</li>
-              <li><strong>Compañeros validados</strong> y antagonistas — qué NO sembrar cerca</li>
-              <li><strong>Biopreparados</strong> — bocashi, biol, caldo sulfocálcico, M-5, Trichoderma</li>
-              <li><strong>Rangos conservadores</strong> de cosecha — anti-overpromise vs literatura comercial</li>
+              <li><strong>Preparación de tierra</strong>, matera (mezcla recomendada) vs campo abierto (descompactación + biopreparados)</li>
+              <li><strong>Germinación + propagación</strong>, semilla, esqueje, acodo, división, injerto (según especie)</li>
+              <li><strong>Hitos del ciclo</strong>, día por día, criterio observable + acción clave</li>
+              <li><strong>Razones comunes de fracaso</strong>, top 5 con prevención agroecológica + frecuencia esperada</li>
+              <li><strong>Compañeros validados</strong> y antagonistas, qué NO sembrar cerca</li>
+              <li><strong>Biopreparados</strong>, bocashi, biol, caldo sulfocálcico, M-5, Trichoderma</li>
+              <li><strong>Rangos conservadores</strong> de cosecha, anti-overpromise vs literatura comercial</li>
             </ul>
           </div>
 
           <div className="mt-3 p-3 rounded-xl bg-amber-900/15 border border-amber-800/40 flex items-start gap-2">
             <Clock size={14} className="text-amber-400 shrink-0 mt-0.5" />
             <p className="text-[11px] text-amber-200 leading-relaxed">
-              <strong>Filosofía:</strong> NO promete éxito instantáneo. Sembrar es un proceso de meses-años. Documenta también lo que NO funcionó para que cada operador aprenda de la pérdida sin estigma. Coherente con el cementerio de plantas — fracaso como currículo.
+              <strong>Filosofía:</strong> NO promete éxito instantáneo. Sembrar es un proceso de meses-años. Documenta también lo que NO funcionó para que cada operador aprenda de la pérdida sin estigma. Coherente con el cementerio de plantas, fracaso como currículo.
             </p>
           </div>
 
           <p className="text-[10px] text-slate-600 italic mt-3">
-            Corpus consolidado DR-034 (Claude web + Gemini DR + DeepSeek V3 — convergencia 3/3) + plan curación humana presencial 4h por especie advanced (Aguacate → Café → Tomate). Datos calibrados anti-overpromise — rangos agroecológicos colombianos, NO hidroponía.
+            Corpus consolidado DR-034 (Claude web + Gemini DR + DeepSeek V3, convergencia 3/3) + plan curación humana presencial 4h por especie advanced (Aguacate → Café → Tomate). Datos calibrados anti-overpromise, rangos agroecológicos colombianos, NO hidroponía.
           </p>
         </Section>
 
-        {/* Sección Novedades v0.12.x — features mergeados sesión 2026-05-03 */}
+        {/* Sección Novedades v0.12.x, features mergeados sesión 2026-05-03 */}
         <Section icon={Sparkles} title="✨ Novedades de mayo 2026">
           <p className="text-xs text-slate-400 mb-2">
-            Cambios recientes que reducen friction. Todos opt-in / no-imposición —
+            Cambios recientes que reducen friction. Todos opt-in / no-imposición:
             la app no fuerza, solo sugiere.
           </p>
 
@@ -335,7 +335,7 @@ export default function HelpManual({ onBack }) {
           <ul className="list-disc pl-5 space-y-1 text-xs">
             <li><strong>Plan de alimentación al crear planta</strong>: cuando agrega una mata (ej. manzana, fresa), aparece toast con plan de alimentación sugerido. Lo encuentra en <strong>Bodega → Planes</strong>.</li>
             <li><strong>Sugerencia de biopreparados al agregar insumo</strong>: si agrega melaza, suero de leche o similares a la bodega, modal sugiere qué biopreparados puede hacer (Bocashi, Biol, etc.) con receta inline.</li>
-            <li><strong>Companions que ya tiene primero</strong>: en panel de gremios, los compañeros que ya están en su finca aparecen primero con marca verde. No tiene que comprar — ya los tiene.</li>
+            <li><strong>Companions que ya tiene primero</strong>: en panel de gremios, los compañeros que ya están en su finca aparecen primero con marca verde. No tiene que comprar, ya los tiene.</li>
           </ul>
 
           <h4 className="text-sm font-bold text-emerald-400 mt-3">Adaptive defaults (memoria de uso)</h4>
@@ -349,7 +349,7 @@ export default function HelpManual({ onBack }) {
 
           <h4 className="text-sm font-bold text-amber-400 mt-3">IA experimental (BETA)</h4>
           <p className="text-xs">
-            Marcadas con badge <span className="text-[9px] px-1 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-800/50 font-bold">BETA</span> — funcionan pero pueden errar. Si fallan, hay botón &ldquo;Reportar diagnóstico defectuoso&rdquo; que registra el caso para revisar.
+            Marcadas con badge <span className="text-[9px] px-1 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-800/50 font-bold">BETA</span>, funcionan pero pueden errar. Si fallan, hay botón &ldquo;Reportar diagnóstico defectuoso&rdquo; que registra el caso para revisar.
           </p>
           <ul className="list-disc pl-5 space-y-1 text-xs mt-1">
             <li><strong>Identificar especie por foto</strong> en SpeciesSelect → cámara → IA propone especie + alternativas. Confidence ≥70% auto-selecciona si match el catálogo.</li>
@@ -367,7 +367,7 @@ export default function HelpManual({ onBack }) {
         </Section>
 
         <p className="text-xs text-slate-600 text-center mt-4 italic">
-          Manual v1.2 — última actualización 2026-05-04 (acento colombiano cordial + correcciones)
+          Manual v1.2, última actualización 2026-05-04 (acento colombiano cordial + correcciones)
         </p>
       </div>
     </div>

--- a/src/components/InformesScreen.jsx
+++ b/src/components/InformesScreen.jsx
@@ -4,7 +4,7 @@ import { ScreenShell } from './common/ScreenShell';
 import { exportTraceabilityCsv } from '../services/exportService';
 
 /**
- * InformesScreen — sección dedicada para descargar reportes de la finca
+ * InformesScreen, sección dedicada para descargar reportes de la finca
  * (Lili #118). Antes los downloads vivían dentro de InventoryDashboard
  * como acción secundaria; Lili pidió: "el informe que se descarga
  * debería ir en otra sección de INFORMES a detalle y especificando todo
@@ -98,7 +98,7 @@ export default function InformesScreen({ onBack }) {
       <div className="flex flex-col gap-4 pb-8">
         <p className="text-sm text-slate-400 leading-relaxed">
           Reportes descargables consolidados de la finca. Cada uno se genera
-          con la data sincronizada al momento — incluye registros pendientes
+          con la data sincronizada al momento, incluye registros pendientes
           de sync con un marcador.
         </p>
 
@@ -110,7 +110,7 @@ export default function InformesScreen({ onBack }) {
           onExport={exportTraceabilityCsv}
         />
 
-        {/* Placeholders próximos reportes — comentado hasta tener implementación */}
+        {/* Placeholders próximos reportes, comentado hasta tener implementación */}
         <div className="rounded-2xl border border-dashed border-slate-700/60 p-5 bg-slate-900/30">
           <h3 className="text-sm font-bold text-slate-500 mb-2">Próximamente</h3>
           <ul className="space-y-1.5 text-xs text-slate-500">

--- a/src/components/InputLogForm.jsx
+++ b/src/components/InputLogForm.jsx
@@ -5,7 +5,7 @@ import { MATERIAL_PRESETS, UNIT_OPTIONS } from '../config/materials';
 
 // Autopilot #11 (2026-05-03): pre-fill biopreparado más reciente usado por
 // el operador. Reduce friction en aplicaciones repetitivas (bocashi semanal,
-// biol cada riego). Operador siempre puede cambiar — solo es default smart.
+// biol cada riego). Operador siempre puede cambiar, solo es default smart.
 const RECENT_KEY = 'chagra:inputlog_last_material';
 function readRecentMaterial() {
   try {
@@ -21,7 +21,7 @@ function readRecentMaterial() {
 }
 
 /**
- * InputLogForm — Registro de aplicación de bio-insumos (Fase 11.8 / refactor 12.4).
+ * InputLogForm, Registro de aplicación de bio-insumos (Fase 11.8 / refactor 12.4).
  *
  * Principios de Jairo Restrepo: trazabilidad exhaustiva de biopreparados,
  * caldos minerales y microorganismos para documentar la nutrición del suelo.
@@ -73,7 +73,7 @@ export const InputLogForm = ({ assetId, onComplete }) => {
       // Persistir material usado para próxima apertura del form
       try {
         localStorage.setItem(RECENT_KEY, formData.material);
-      } catch { /* localStorage quota / no disponible — silent */ }
+      } catch { /* localStorage quota / no disponible, silent */ }
       setFormData((prev) => ({ ...prev, value: '', notes: '' }));
       // Lili #108: feedback explícito de dónde queda guardada la info.
       // Antes el form solo limpiaba sin decir nada → user no sabía si
@@ -129,7 +129,7 @@ export const InputLogForm = ({ assetId, onComplete }) => {
             <div className="text-xs text-slate-300 flex items-start gap-2 px-2 py-2 mt-1 rounded-lg bg-slate-800/60 border border-slate-700/50">
               <Info size={14} className="shrink-0 text-blue-400 mt-0.5" />
               <span className="leading-snug">
-                {selectedInfo.desc || 'Sin descripción registrada — agregar en config/materials.js'}
+                {selectedInfo.desc || 'Sin descripción registrada, agregar en config/materials.js'}
               </span>
             </div>
           )}

--- a/src/components/InvasiveObservationLog.jsx
+++ b/src/components/InvasiveObservationLog.jsx
@@ -1,5 +1,5 @@
 /**
- * InvasiveObservationLog.jsx — Flow de reporte de especies invasoras (ADR-019 Phase 1)
+ * InvasiveObservationLog.jsx, Flow de reporte de especies invasoras (ADR-019 Phase 1)
  * AGPL-3.0 © Chagra
  */
 
@@ -45,7 +45,7 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
         status: 'reported'
     });
     const [speciesList, setSpeciesList] = useState([]);
-    // 'loading' | 'ready' | 'error' — refleja el estado del fetch del catálogo.
+    // 'loading' | 'ready' | 'error', refleja el estado del fetch del catálogo.
     // Sin esto, un fallo silencioso dejaba el selector vacío sin diagnóstico
     // y el usuario quedaba bloqueado (no podía guardar).
     const [catalogStatus, setCatalogStatus] = useState('loading');
@@ -186,7 +186,7 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
                         onSelectNative={(native) => {
                             // ADR-019: solo incluir plant_type si el catálogo lo mapea
                             // explícitamente. native.id (string del catálogo, ej. 'aliso')
-                            // NO es taxonomy_term UUID de FarmOS — un fallback con ese id
+                            // NO es taxonomy_term UUID de FarmOS, un fallback con ese id
                             // crearía referencia fantasma y rompería el sync.
                             const initialData = {
                                 crop: native.nombre_comun,
@@ -241,7 +241,7 @@ export default function InvasiveObservationLog({ onBack, onSave, initialLocation
                             <option value="">Cargando catálogo…</option>
                         )}
                         {catalogStatus === 'error' && (
-                            <option value="">Error cargando catálogo — recarga la app</option>
+                            <option value="">Error cargando catálogo, recarga la app</option>
                         )}
                         {catalogStatus === 'ready' && speciesList.length === 0 && (
                             <option value="">No hay especies invasoras en el catálogo</option>

--- a/src/components/InventoryAuditTrail.jsx
+++ b/src/components/InventoryAuditTrail.jsx
@@ -1,5 +1,5 @@
 /**
- * InventoryAuditTrail — bitácora completa de events por item.
+ * InventoryAuditTrail, bitácora completa de events por item.
  *
  * Cumple ADR-019: muestra TODOS los events incluyendo los "perdidos" en la
  * proyección (counted que reanchoró logs anteriores, idempotency duplicados).

--- a/src/components/InventoryDashboard.jsx
+++ b/src/components/InventoryDashboard.jsx
@@ -15,7 +15,7 @@ function getStockValue(item) {
 }
 
 /**
- * InventoryDashboard — Bodega de biofábrica (Fase 13.2 / refactor 13.6).
+ * InventoryDashboard, Bodega de biofábrica (Fase 13.2 / refactor 13.6).
  *
  * Renderiza el stock de todos los materiales registrados como asset--material.
  * El valor de stock se descuenta reactivamente desde addInputLog cada vez que

--- a/src/components/IoTSensorCard.jsx
+++ b/src/components/IoTSensorCard.jsx
@@ -4,7 +4,7 @@ import Sparkline from './common/Sparkline';
 import Badge from './common/Badge';
 
 /**
- * IoTSensorCard — card de lectura de sensor IoT en estilo HUD industrial.
+ * IoTSensorCard, card de lectura de sensor IoT en estilo HUD industrial.
  *
  * Objetivo visual: distinguir claramente la telemetria IoT (datos crudos,
  * frios, deterministas) del panel cyberpunk de IA (generativo, orchid,
@@ -13,7 +13,7 @@ import Badge from './common/Badge';
  * monoespaciada para los readouts numericos y labels tecnicos.
  *
  * Props:
- *   - title               string    encabezado descriptivo ("INVERNADERO — ZONA A").
+ *   - title               string    encabezado descriptivo ("INVERNADERO, ZONA A").
  *   - deviceId            string    identificador tecnico en mono ("matera_cocina · zigbee").
  *   - humidity, temperature          valores crudos de Home Assistant (string|null).
  *   - humidityHistory, temperatureHistory   arrays de HA history para las sparklines.
@@ -83,7 +83,7 @@ export default function IoTSensorCard({
 
         {/* Readouts numericos grandes en mono. Si el sensor no reporta
             (null/undefined/unavailable/unknown) se muestra un Badge OFFLINE
-            en lugar del numero+unidad — evita concatenaciones sin sentido
+            en lugar del numero+unidad, evita concatenaciones sin sentido
             tipo "---%" o "null°C". */}
         <div className="grid grid-cols-2 gap-3 mb-3">
           <div className="bg-slate-950/60 border border-slate-800 rounded px-2.5 py-1.5 min-h-[56px]">

--- a/src/components/LegalLinks.jsx
+++ b/src/components/LegalLinks.jsx
@@ -1,5 +1,5 @@
 /**
- * LegalLinks.jsx — Acceso a Términos, Privacidad, Soberanía Comunitaria
+ * LegalLinks.jsx, Acceso a Términos, Privacidad, Soberanía Comunitaria
  * y Licencias mediante modales nativos <dialog>. Reutilizable desde Login,
  * Dashboard footer u otros puntos. Texto integral en Chagra-strategy/legal/
  * TERMINOS_Y_CONDICIONES_v0.1_DRAFT.md (pendiente revisión legal).

--- a/src/components/MapPicker.jsx
+++ b/src/components/MapPicker.jsx
@@ -28,14 +28,14 @@ const extractZoneCentroid = (zone) => {
 };
 
 // Threshold para warning de baja precisión. Brave con Shields up devuelve
-// posiciones gruesas (>1km) sin emitir error — el usuario veía "ubicación
+// posiciones gruesas (>1km) sin emitir error, el usuario veía "ubicación
 // capturada" pero el punto estaba a kilómetros del lugar real. Miguel
 // reportó este patrón 2026-05-02. Ahora si accuracy > 500m, mostramos un
 // warning explícito mencionando Brave Shields.
 const LOW_ACCURACY_THRESHOLD_M = 500;
 
 /**
- * MapPicker — Modal de selección/dibujo de geometría (Fase 17.3).
+ * MapPicker, Modal de selección/dibujo de geometría (Fase 17.3).
  *
  * Soporta dos modos:
  *   - mode="point":   click en el mapa o botón "Usar mi ubicación" → POINT.
@@ -44,7 +44,7 @@ const LOW_ACCURACY_THRESHOLD_M = 500;
  * Tiles se cargan desde /tiles/{z}/{x}/{y}.png (servidos por Nginx desde
  * /mnt/fast/appdata/farmos-pwa/tiles para operación offline). Si el Service
  * Worker no ha cacheado los tiles o no existen, Leaflet mostrará el layer
- * vacío — la geometría sigue siendo dibujable y persistible.
+ * vacío, la geometría sigue siendo dibujable y persistible.
  *
  * Props:
  *   - mode:       "point" | "polygon"
@@ -92,7 +92,7 @@ export const MapPicker = ({
   const [isWalking, setIsWalking] = useState(false);
   // Estado machine GPS: idle → locating → located | low-accuracy | failed.
   // Renderizado como banner persistente arriba del mapa para que el operador
-  // sepa qué está pasando — antes "Mi ubicación" silenciaba errores y el
+  // sepa qué está pasando, antes "Mi ubicación" silenciaba errores y el
   // usuario quedaba viendo el mapa en DEFAULT_CENTER sin saber por qué.
   const [gpsStatus, setGpsStatus] = useState('idle');
   const [gpsResult, setGpsResult] = useState(null);
@@ -182,7 +182,7 @@ export const MapPicker = ({
   // Toggle del modo "trazar caminando": al activar, arranca un watchPosition
   // con alta precision que va anadiendo vertices al polygon a medida que el
   // GPS reporta nuevas coordenadas (tipicamente cada 1-3s segun el dispositivo).
-  // Desactivar detiene la captura — el polygon queda con los vertices
+  // Desactivar detiene la captura, el polygon queda con los vertices
   // acumulados y el usuario puede editarlo con Undo / Cerrar polígono.
   const toggleWalkRecording = () => {
     if (mode !== 'polygon') return;
@@ -307,7 +307,7 @@ export const MapPicker = ({
 
   // Auto-locate al abrir el modal (solo si no hay geometría inicial cargada).
   // Con esto el operador ve el mapa centrado en su ubicación apenas abre,
-  // en lugar del DEFAULT_CENTER de Choachí — fixing reporte Miguel 2026-05-02
+  // en lugar del DEFAULT_CENTER de Choachí, fixing reporte Miguel 2026-05-02
   // "sale el mapa muy desubicado y no hace gran cosa".
   useEffect(() => {
     if (initial) return; // respetar geometría pre-cargada
@@ -362,7 +362,7 @@ export const MapPicker = ({
         </button>
       </div>
 
-      {/* GPS status banner — siempre visible para no silenciar errores. */}
+      {/* GPS status banner, siempre visible para no silenciar errores. */}
       {gpsStatus !== 'idle' && (
         <div
           className={`px-4 py-2 text-xs flex items-center gap-2 border-b border-slate-800 ${

--- a/src/components/MicFab.jsx
+++ b/src/components/MicFab.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Mic } from 'lucide-react';
 
 /**
- * MicFab — Floating Action Button global para captura por voz (DR-030 QW4).
+ * MicFab, Floating Action Button global para captura por voz (DR-030 QW4).
  *
  * FAB extendido (pill con ícono + label) anclado abajo-IZQUIERDA. La derecha
  * está ocupada por FieldFeedback (💬). El label visible permanente "Voz"

--- a/src/components/NativeSubstituteSuggestion.jsx
+++ b/src/components/NativeSubstituteSuggestion.jsx
@@ -1,5 +1,5 @@
 /**
- * NativeSubstituteSuggestion.jsx — R9
+ * NativeSubstituteSuggestion.jsx, R9
  * Muestra sustitutos nativos curados tras la extracción de una especie invasora.
  * AGPL-3.0 © Chagra
  */
@@ -31,10 +31,10 @@ const ESTRATO_COLOR = {
  * NativeSubstituteSuggestion
  *
  * Props:
- *   - invasiveSpeciesId: string — ID en el catálogo (ej: "ulex_europaeus")
- *   - invasiveName: string — nombre común para mostrar al usuario
- *   - coordinates: string | null — WKT o cadena de coords para pre-cargar en seeding log
- *   - thermalZone: string | null — piso térmico para filtrar ("frio", "paramo", etc.)
+ *   - invasiveSpeciesId: string, ID en el catálogo (ej: "ulex_europaeus")
+ *   - invasiveName: string, nombre común para mostrar al usuario
+ *   - coordinates: string | null, WKT o cadena de coords para pre-cargar en seeding log
+ *   - thermalZone: string | null, piso térmico para filtrar ("frio", "paramo", etc.)
  *   - onSelectNative: fn({ id, nombre_comun, nombre_cientifico, estrato, coordinates, inversiveSourceName }) → void
  *   - onDismiss: fn() → void
  */
@@ -66,7 +66,7 @@ export function NativeSubstituteSuggestion({
 
         const timeoutId = setTimeout(() => {
             if (alive) {
-                console.warn('[NativeSubstituteSuggestion] Catalog query timeout — likely offline + SW frío.');
+                console.warn('[NativeSubstituteSuggestion] Catalog query timeout, likely offline + SW frío.');
                 setError('Catálogo local tardó demasiado en responder. Probablemente sin red o cargando aún.');
                 setLoading(false);
             }
@@ -218,7 +218,7 @@ export function NativeSubstituteSuggestion({
 
                 {!loading && substitutes.length > 0 && (
                     <p className="text-[9px] text-slate-600 mt-1 px-1">
-                        ⚑ Sustitutos filtrados para piso {thermalZone || 'cualquier zona'} · Curación BORRADOR_IA — validar con agrónomo antes del transplante.
+                        ⚑ Sustitutos filtrados para piso {thermalZone || 'cualquier zona'} · Curación BORRADOR_IA, validar con agrónomo antes del transplante.
                     </p>
                 )}
             </div>

--- a/src/components/OnboardingHero.jsx
+++ b/src/components/OnboardingHero.jsx
@@ -4,7 +4,7 @@ import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
 
 /**
- * OnboardingHero — empty-state cold-start del dashboard (DR-030 QW5).
+ * OnboardingHero, empty-state cold-start del dashboard (DR-030 QW5).
  *
  * Se renderiza cuando plantsCount === 0 (sin plantas registradas localmente).
  * Reemplaza la telemetría densa de TelemetryAlerts (que sin sensores cableados
@@ -12,7 +12,7 @@ import { FARM_CONFIG } from '../config/defaults';
  *
  * 3 CTA hero, equivalentes en peso visual, mapean a las 3 modalidades de
  * captura disponibles. La foto va primero por convención camera-first
- * (Pl@ntNet/Seek), pero las 3 son first-class — el usuario elige sin
+ * (Pl@ntNet/Seek), pero las 3 son first-class, el usuario elige sin
  * jerarquía impuesta.
  *
  * Adaptive (Autopilot 2026-05-06): el copy del header se ajusta al contexto

--- a/src/components/PendingTasksWidget.jsx
+++ b/src/components/PendingTasksWidget.jsx
@@ -3,7 +3,7 @@ import { AlertTriangle, Clock, RefreshCw, Wifi, WifiOff, ChevronUp, ChevronDown,
 import { syncManager } from '../services/syncManager';
 
 /**
- * PendingTasksWidget — Lili #102 + #106.
+ * PendingTasksWidget, Lili #102 + #106.
  *
  * Refactor 2026-05-02 (post field test Lili):
  * - **Footer collapsable** (sticky bottom) en lugar de bloque fijo en
@@ -12,7 +12,7 @@ import { syncManager } from '../services/syncManager';
  * - **Sort por severity** (critical → high → medium → low) y luego
  *   por fecha. Lili: "ordenar por urgencia, urgent rojo arriba".
  * - **Edit button** (lápiz) en cada item para editar tareas pendientes.
- *   Closes #106 — onEdit prop dispatcha navigate('edit_task', {task}).
+ *   Closes #106, onEdit prop dispatcha navigate('edit_task', {task}).
  * - **Empty state** simple cuando 0 pendientes.
  *
  * El componente padre (DashboardView) le pasa onEdit callback que
@@ -36,7 +36,7 @@ export default function PendingTasksWidget({ onEdit }) {
       const pendingTasks = await syncManager.fetchPendingTasksFromFarmOS();
 
       // Sort por severity rank, después por deadline (string compara bien
-      // si son ISO o relativo similar — fallback robusto).
+      // si son ISO o relativo similar, fallback robusto).
       const sorted = [...pendingTasks].sort((a, b) => {
         const sa = SEVERITY_RANK[a.severity] ?? 99;
         const sb = SEVERITY_RANK[b.severity] ?? 99;
@@ -95,7 +95,7 @@ export default function PendingTasksWidget({ onEdit }) {
 
   return (
     <div className="rounded-2xl bg-slate-900 border border-slate-700 shadow-xl mb-4 overflow-hidden">
-      {/* Header colapsable — siempre visible */}
+      {/* Header colapsable, siempre visible */}
       <button
         type="button"
         onClick={() => setExpanded(v => !v)}

--- a/src/components/PestMonitoringWindow.jsx
+++ b/src/components/PestMonitoringWindow.jsx
@@ -5,10 +5,10 @@ import { pestMonitoringMessage } from '../services/lunarPestService';
 import { FARM_CONFIG } from '../config/defaults';
 
 /**
- * PestMonitoringWindow — Feature C.1 ADR-033.
+ * PestMonitoringWindow, Feature C.1 ADR-033.
  *
  * Aparece SOLO en ventana de luna nueva ± 3 días con texto informativo
- * sobre muestreo nocturno con trampa de luz (Yela & Holyoak 1997 — capturas
+ * sobre muestreo nocturno con trampa de luz (Yela & Holyoak 1997, capturas
  * 2-4× mayores). Fuera de la ventana, NO renderiza nada (return null).
  *
  * Compatible con política Opción C estricta:

--- a/src/components/PhotoCaptureField.jsx
+++ b/src/components/PhotoCaptureField.jsx
@@ -4,7 +4,7 @@ import { captureAndCompress } from '../services/photoService';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
 
 /**
- * PhotoCaptureField — Componente reutilizable para captura de fotos en campo.
+ * PhotoCaptureField, Componente reutilizable para captura de fotos en campo.
  * Soporta: captura con cámara, previsualización, compresión automática,
  * re-toma y eliminación (Issue #86, #87).
  *

--- a/src/components/PlanEditor.jsx
+++ b/src/components/PlanEditor.jsx
@@ -15,7 +15,7 @@ export default function PlanEditor({ assetId, speciesSlug, plantingDate, climate
     const [plan, setPlan] = useState(null);
     const [loading, setLoading] = useState(true);
     const { user } = useUserStore();
-    // 'now' como state — lazy init evita la regla react-hooks/purity.
+    // 'now' como state, lazy init evita la regla react-hooks/purity.
     // Refresca cada minuto para que isPast sea preciso sin re-render forzado.
     const [now, setNow] = useState(() => Date.now());
 
@@ -78,7 +78,7 @@ export default function PlanEditor({ assetId, speciesSlug, plantingDate, climate
         return (
             <div className="p-4 border rounded-lg bg-gray-50 text-center shadow-sm">
                 <h3 className="text-lg font-bold mb-2">Plan de Alimentación</h3>
-                <p className="text-gray-600 mb-4">Sin plan — ¿generar uno sugerido?</p>
+                <p className="text-gray-600 mb-4">Sin plan, ¿generar uno sugerido?</p>
                 <button onClick={handleGenerate} className="bg-green-600 text-white px-4 py-2 rounded shadow font-medium hover:bg-green-700 transition">
                     Generar Plan
                 </button>

--- a/src/components/PlantCemeteryModal.jsx
+++ b/src/components/PlantCemeteryModal.jsx
@@ -2,13 +2,13 @@ import React, { useState } from 'react';
 import { X, Skull, AlertTriangle } from 'lucide-react';
 
 /**
- * PlantCemeteryModal — Workflow para marcar planta como muerta + capturar
+ * PlantCemeteryModal, Workflow para marcar planta como muerta + capturar
  * razón + mostrar lección aprendida.
  *
  * Coherente con dirección educativa Chagra (memoria
  * project_chagra_educational_dimension): "fracaso como currículo". El
  * objetivo NO es esconder o estigmatizar la planta muerta, sino tratarla
- * como dato curatorial — el operador aprende de la pérdida.
+ * como dato curatorial, el operador aprende de la pérdida.
  *
  * Workflow:
  * 1. Operador en AssetDetailView de planta activa → tap "Marcar como muerta"
@@ -19,20 +19,20 @@ import { X, Skull, AlertTriangle } from 'lucide-react';
  * Cada razón viene con lección inline para que el operador NO se vaya
  * solo con "perdí mi planta", sino con "perdí mi planta y entendí por qué".
  *
- * Curación preliminar — validar con DR-034 (ciclo de especies). Algunas
+ * Curación preliminar, validar con DR-034 (ciclo de especies). Algunas
  * razones aplican a especies específicas y deben refinarse por piso térmico.
  *
  * Props:
  *   - plantName: string
  *   - onClose: callback cerrar sin marcar
- *   - onConfirm: fn(reason, freeText) — confirma death + persiste
+ *   - onConfirm: fn(reason, freeText), confirma death + persiste
  */
 
 const REASONS = [
   {
     id: 'overwatering',
     label: 'Riego excesivo',
-    lesson: 'Las raíces se pudren cuando el sustrato queda saturado por horas. La regla agroecológica: regar profundo pero menos frecuente. Antes de regar, mete el dedo 3 cm en el sustrato — si está húmedo, espera.',
+    lesson: 'Las raíces se pudren cuando el sustrato queda saturado por horas. La regla agroecológica: regar profundo pero menos frecuente. Antes de regar, mete el dedo 3 cm en el sustrato, si está húmedo, espera.',
   },
   {
     id: 'underwatering',
@@ -47,7 +47,7 @@ const REASONS = [
   {
     id: 'wrong_soil',
     label: 'Sustrato incorrecto (acidez/compactación)',
-    lesson: 'Cada especie tolera un rango de pH y textura. Compactación bloquea oxígeno radicular en 2 semanas. Test casero: si el agua tarda más de 30s en infiltrar, el suelo está compactado — incorpora compost + romper con horca.',
+    lesson: 'Cada especie tolera un rango de pH y textura. Compactación bloquea oxígeno radicular en 2 semanas. Test casero: si el agua tarda más de 30s en infiltrar, el suelo está compactado, incorpora compost + romper con horca.',
   },
   {
     id: 'temperature',
@@ -57,7 +57,7 @@ const REASONS = [
   {
     id: 'light',
     label: 'Luz insuficiente o excesiva',
-    lesson: 'Plantas de sol pleno en sombra se estiran (etiolación) y mueren débiles. Sombra obligatoria en pleno sol queman las hojas. El catálogo Chagra indica radiación óptima por especie — respétala desde la siembra.',
+    lesson: 'Plantas de sol pleno en sombra se estiran (etiolación) y mueren débiles. Sombra obligatoria en pleno sol queman las hojas. El catálogo Chagra indica radiación óptima por especie, respétala desde la siembra.',
   },
   {
     id: 'transplant_shock',
@@ -103,7 +103,7 @@ export default function PlantCemeteryModal({ plantName, onClose, onConfirm }) {
           <div className="flex-1 min-w-0">
             <h3 className="text-sm font-bold text-slate-200">Cementerio: {plantName}</h3>
             <p className="text-xs text-slate-500 mt-0.5">
-              Aprender de la pérdida. Sin juicio — la agricultura agroecológica se construye también desde lo que no funcionó.
+              Aprender de la pérdida. Sin juicio, la agricultura agroecológica se construye también desde lo que no funcionó.
             </p>
           </div>
           <button

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -5,7 +5,7 @@ import ThemeSelector from './common/ThemeSelector';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 
 /**
- * ProfileScreen — perfil del operador.
+ * ProfileScreen, perfil del operador.
  *
  * Lili #120: "debería poderse registrar los datos del 'Trabajador -
  * Operador de Campo'". Antes era display-only con nombre hardcoded.
@@ -39,7 +39,7 @@ export default function ProfileScreen({ onBack }) {
   const [savedFlash, setSavedFlash] = useState(false);
 
   // Persistir cambios al storage en cada modificación + emitir custom event
-  // (CodeQL flag #36/#37 contra StorageEvent ctor — migrado a CustomEvent
+  // (CodeQL flag #36/#37 contra StorageEvent ctor, migrado a CustomEvent
   // que es el patrón canónico para same-tab pub/sub. TopBar escucha ambos
   // 'storage' (cross-tab nativo) y 'chagra:operator-update' (same-tab).
   useEffect(() => {
@@ -66,7 +66,7 @@ export default function ProfileScreen({ onBack }) {
   return (
     <ScreenShell title="Perfil de Usuario" icon={User} onBack={onBack}>
       <div className="flex flex-col gap-6 pb-8">
-        {/* ID Card / User Info — header con datos sintetizados */}
+        {/* ID Card / User Info, header con datos sintetizados */}
         <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-6 flex flex-col items-center">
           <div className="w-20 h-20 bg-slate-800 rounded-full flex items-center justify-center mb-4 border-2 border-emerald-500/30">
             <User size={40} className="text-emerald-400" />

--- a/src/components/RecountDrawer.jsx
+++ b/src/components/RecountDrawer.jsx
@@ -1,5 +1,5 @@
 /**
- * RecountDrawer — drawer modal para emitir un evento `inventory_counted`.
+ * RecountDrawer, drawer modal para emitir un evento `inventory_counted`.
  *
  * UX clave: el conteo manual NO destruye el log histórico. Reanchora el
  * stock al valor manual en T, descartando contribuciones anteriores en la
@@ -83,7 +83,7 @@ export default function RecountDrawer({ itemId, currentQty, currentUnit, onClose
         <header style={{ marginBottom: '1rem' }}>
           <h2 style={{ margin: 0, fontSize: '1.1rem' }}>Conteo manual</h2>
           <p style={{ margin: '0.25rem 0 0', fontSize: '0.85rem', color: 'var(--fg-dim, #8b949e)' }}>
-            <strong>{itemId}</strong> — esto reanchora el stock SIN borrar logs.
+            <strong>{itemId}</strong>, esto reanchora el stock SIN borrar logs.
           </p>
         </header>
 

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -168,7 +168,7 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
       </header>
 
       <div className="flex-1 p-5 flex flex-col gap-6 pb-24">
-        {/* Hero foto — primer paso del flujo (DR-030 QW3) */}
+        {/* Hero foto, primer paso del flujo (DR-030 QW3) */}
         <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto de la planta</span>
           <label className="flex flex-col items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 cursor-pointer min-h-[140px] overflow-hidden relative">

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -9,7 +9,7 @@ import { captureAndCompress } from '../services/photoService';
 import { recognizeSpecies } from '../services/aiService';
 
 /**
- * SpeciesSelect — Selector de especie con fuzzy search y autocompletado de defaults.
+ * SpeciesSelect, Selector de especie con fuzzy search y autocompletado de defaults.
  *
  * Reemplaza el <select> + <optgroup> estático de renderPlantForm. Soporta:
  *   - Fuzzy search: "Gulpa" → "Gulupa (Passiflora edulis f. edulis)"
@@ -22,8 +22,8 @@ import { recognizeSpecies } from '../services/aiService';
  *
  * Props:
  *   - value:      string actual del campo nombre
- *   - onChange:    callback(name: string, speciesId: string|null) — actualiza formData.name
- *   - onAutoFill: callback({ estrato, gremio, production, cycleMonths }) — sugerencia
+ *   - onChange:    callback(name: string, speciesId: string|null), actualiza formData.name
+ *   - onAutoFill: callback({ estrato, gremio, production, cycleMonths }), sugerencia
  */
 
 // Flatten de todas las especies con su grupo para lookup rápido.
@@ -67,13 +67,13 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
   const [selectedSpeciesId, setSelectedSpeciesId] = useState(null);
   const wrapperRef = useRef(null);
 
-  // Últimas 3 especies del usuario — atajos rápidos arriba del fuzzy search.
+  // Últimas 3 especies del usuario, atajos rápidos arriba del fuzzy search.
   // Reduce fricción de escribir/buscar para repeat work (Miguel UX 2026-05-03).
   const plants = useAssetStore((s) => s.plants);
   const recentSpecies = useMemo(() => computeRecentSpecies(plants), [plants]);
 
   // Autopilot H (2026-05-03): identificación de especie por foto via gemma3:4b.
-  // Marcado experimental — confidence ≥0.7 auto-selecciona si match en CROP_TAXONOMY,
+  // Marcado experimental, confidence ≥0.7 auto-selecciona si match en CROP_TAXONOMY,
   // sino muestra alternativas + bug report button para validar.
   const aiInputRef = useRef(null);
   const [aiState, setAiState] = useState('idle'); // idle | running | done | error
@@ -325,7 +325,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
                 ? 'Tu última foto de esta especie'
                 : photo.source === 'catalog'
                   ? 'Foto del catálogo'
-                  : 'Sin foto aún — la primera que tomes queda como referencia'}
+                  : 'Sin foto aún, la primera que tomes queda como referencia'}
             </p>
             <p className="text-xs text-slate-300 truncate">{value}</p>
           </div>
@@ -336,7 +336,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
         Búsqueda aproximada. Los campos de estrato y gremio se sugieren al seleccionar.
       </p>
 
-      {/* Autopilot H — Identificación por foto (experimental gemma3:4b) */}
+      {/* Autopilot H, Identificación por foto (experimental gemma3:4b) */}
       <div className="mt-3 pt-3 border-t border-slate-800">
         <div className="flex items-center gap-2 mb-2">
           <Sparkles size={12} className="text-amber-400" />

--- a/src/components/TaskScreen.jsx
+++ b/src/components/TaskScreen.jsx
@@ -7,7 +7,7 @@ import { TASK_STATUSES } from '../constants/assetStatuses';
 
 // Autopilot A (2026-05-03): pre-fill priority + location desde último uso.
 // Reduce friction al crear tareas repetitivas (riego matinal, monitoreo,
-// poda) sin imponer — el usuario sigue editando libremente.
+// poda) sin imponer, el usuario sigue editando libremente.
 const LAST_USED_KEY = 'chagra:taskscreen_last';
 function readLastUsed() {
     try {
@@ -97,7 +97,7 @@ function TaskScreen({ onBack, onSave, initialData }) {
                         locationId: formData.locationId || null,
                         ts: Date.now(),
                     }));
-                } catch { /* localStorage no disponible / quota — silent */ }
+                } catch { /* localStorage no disponible / quota, silent */ }
                 onSave('Tarea agendada exitosamente (Offline-First)', false);
             }
             setTimeout(() => onBack(), 500);

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -11,7 +11,7 @@ import { buildDiagnosticExternalPrompt } from '../services/externalAiPromptBuild
 import { detectAndTruncateRepetition } from '../utils/repetitionGuard';
 
 /**
- * TelemetryAlerts — análisis agronómico de telemetría IoT con asistencia LLM.
+ * TelemetryAlerts, análisis agronómico de telemetría IoT con asistencia LLM.
  *
  * Flujo:
  *   1. Suscripción WebSocket a Home Assistant para sensores configurados.
@@ -377,7 +377,7 @@ export default function TelemetryAlerts() {
           tabacoTemperature: tabacoTempData.state !== 'unavailable' ? tabacoTempData.state : null,
         });
 
-        // Si TODOS los sensores están caídos, sí hacemos early return — no hay
+        // Si TODOS los sensores están caídos, sí hacemos early return, no hay
         // datos agronómicos que analizar.
         if (unavailableSensors.length === sensorReadings.length) {
           setAiAlert(offlineNotice);
@@ -393,7 +393,7 @@ export default function TelemetryAlerts() {
         tabacoTemperature: tabacoTempData.state
       });
 
-      // Histórico 24h — HA History API (no bloquea análisis)
+      // Histórico 24h, HA History API (no bloquea análisis)
       const historyStart = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
       const entityIds = [
         'sensor.matera_cocina_humidity',
@@ -443,7 +443,7 @@ export default function TelemetryAlerts() {
         ? alerts.join('\n')
         : `✅ Condiciones estables. Invernadero Zona A: ${inv1Hum}%H/${inv1Temp}°C. Matera Tabaco: ${tabHum}%H/${tabTemp}°C.`;
 
-      // Mostrar reglas INMEDIATAMENTE — sin esperar IA. Prepeende aviso de
+      // Mostrar reglas INMEDIATAMENTE, sin esperar IA. Prepeende aviso de
       // sensores offline (si hay alguno) para que quede visible incluso si la
       // IA después falla o tarda.
       if (parentSignal?.aborted) return;
@@ -599,13 +599,13 @@ export default function TelemetryAlerts() {
         </div>
       )}
 
-      {/* Telemetria IoT — estilo HUD industrial, tipografia monoespaciada,
+      {/* Telemetria IoT, estilo HUD industrial, tipografia monoespaciada,
           borde left accent morpho (cyan) para diferenciar visualmente del
           panel cyberpunk de IA (orchid). Status dot parpadea sutilmente
           como signo de conexion viva al sensor. */}
       <div className="space-y-3 mb-6">
         <IoTSensorCard
-          title="INVERNADERO — ZONA A"
+          title="INVERNADERO, ZONA A"
           deviceId="matera_cocina · zigbee"
           humidity={sensors.invernaderoHumidity}
           temperature={sensors.invernaderoTemperature}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -4,11 +4,11 @@ import { version as APP_VERSION } from '../../package.json';
 import EnvironmentalCard from './EnvironmentalCard';
 
 /**
- * TopBar — header persistente con identidad del operador (DR-030 QW2).
+ * TopBar, header persistente con identidad del operador (DR-030 QW2).
  *
  * Reemplaza el header inline del DashboardView que mostraba info ambiental
  * (msnm/luna/sol) sin identidad del operador. La info ambiental NO se
- * elimina — pasa al `<EnvironmentalCard collapsed />` debajo del top-bar
+ * elimina, pasa al `<EnvironmentalCard collapsed />` debajo del top-bar
  * (progressive disclosure: agrónomo experto puede expandir, novato no se
  * satura).
  *
@@ -73,7 +73,7 @@ export default function TopBar({ onNavigate, onLogout }) {
       >
         {/* Logo clickable → Home (DR-030 + Lili #16: botón claro a inicio).
             Patrón estándar PWA: el logo siempre vuelve al dashboard. Lili
-            reportó "navegación rocosa, falta botón claro a inicio" — el
+            reportó "navegación rocosa, falta botón claro a inicio", el
             logo discreto sin affordance hacía que no se descubriera. Ahora
             es <button> con cursor + hover + icono Home explícito. */}
         <button
@@ -128,7 +128,7 @@ export default function TopBar({ onNavigate, onLogout }) {
         >
           <HelpCircle size={22} aria-hidden="true" strokeWidth={2.5} />
         </button>
-        {/* Botón Settings (icono ⚙) eliminado — Lili #115: era duplicado del
+        {/* Botón Settings (icono ⚙) eliminado, Lili #115: era duplicado del
             botón operator name de arriba (ambos onNavigate('perfil')). El
             operator name button es más explícito + el NAV_TILE Perfil del
             dashboard sigue accesible. */}
@@ -144,7 +144,7 @@ export default function TopBar({ onNavigate, onLogout }) {
         </button>
       </header>
 
-      {/* Toggle de info ambiental (msnm/luna/sol) — colapsado por default */}
+      {/* Toggle de info ambiental (msnm/luna/sol), colapsado por default */}
       <button
         type="button"
         onClick={() => setEnvOpen((v) => !v)}

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -47,7 +47,7 @@ const STATE_ERROR = 'error';
 const STATE_DONE = 'done';
 
 /**
- * VoiceCapture — UI principal del módulo de ingreso acústico.
+ * VoiceCapture, UI principal del módulo de ingreso acústico.
  *
  * Pipeline: grabar → transcribir (Whisper) → extraer (qwen3.5:4b) → revisar
  * humano (VoiceConfirmation) → encolar en pending_transactions.

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -8,7 +8,7 @@ import { bestFuzzyMatch, similarity } from '../utils/entityMatcher';
 import GuildSuggestions from './GuildSuggestions';
 
 /**
- * VoiceConfirmation — pantalla obligatoria de revisión humana del array de
+ * VoiceConfirmation, pantalla obligatoria de revisión humana del array de
  * entidades extraídas. Nada se persiste en pending_transactions sin paso por
  * este componente (ARCHITECTURE_VOICE_0.5.0.md §5).
  *
@@ -53,7 +53,7 @@ export default function VoiceConfirmation({
     const all = [];
     Object.entries(CROP_TAXONOMY).forEach(([groupKey, group]) => {
       group.species.forEach((sp) => {
-        // sp.name viene como "Arandano (Vaccinium corymbosum)" — separamos
+        // sp.name viene como "Arandano (Vaccinium corymbosum)", separamos
         // el nombre comun del cientifico para mejorar el match.
         const commonName = sp.name.split('(')[0].trim();
         all.push({ ...sp, commonName, group: group.label, groupKey });
@@ -296,9 +296,9 @@ export default function VoiceConfirmation({
             const trackingMode = defaults?.tracking_mode || 'individual';
             const isIndividualMulti = trackingMode === 'individual' && qty > 1;
             const previewText = isIndividualMulti
-              ? `Se crearán ${qty} activos individuales — cada planta con su propia hoja de vida, foto y cosechas separadas.`
+              ? `Se crearán ${qty} activos individuales, cada planta con su propia hoja de vida, foto y cosechas separadas.`
               : trackingMode === 'aggregate' && qty > 1
-                ? `Se creará 1 activo agregado con cantidad=${qty} (cama corrida — cosecha y eventos al conjunto).`
+                ? `Se creará 1 activo agregado con cantidad=${qty} (cama corrida, cosecha y eventos al conjunto).`
                 : `Se creará 1 activo de ${row.crop || 'esta especie'}.`;
             return (
               <div className={`mt-2 px-2 py-1.5 rounded text-2xs ${
@@ -317,7 +317,7 @@ export default function VoiceConfirmation({
               la especie matcheo contra CROP_TAXONOMY (cropSlug presente),
               igual que en el flujo manual de AssetsDashboard. Al clicar un
               compañero se agrega una nueva entrada al array de rows con
-              la misma ubicacion heredada — siembra rapida de policultivo. */}
+              la misma ubicacion heredada, siembra rapida de policultivo. */}
           {row.cropSlug && (
             <div className="mt-2 pt-3 border-t border-slate-800">
               <GuildSuggestions

--- a/src/components/WorkerDashboard.jsx
+++ b/src/components/WorkerDashboard.jsx
@@ -11,7 +11,7 @@ import StatusBadge from './StatusBadge';
 import { useGeolocation } from '../hooks/useGeolocation';
 
 /**
- * WorkerDashboard — Vista de campo para operario (Fase 20).
+ * WorkerDashboard, Vista de campo para operario (Fase 20).
  *
  * Ordena tareas pendientes por proximidad al GPS del dispositivo, permitiendo
  * al trabajador priorizar por cercanía. Cada tarea tiene un botón "Marcar
@@ -156,7 +156,7 @@ export const WorkerDashboard = () => {
         <div className="p-3 rounded-xl bg-amber-900/20 border border-amber-800/50 flex items-center gap-2">
           <MapPin size={14} className="text-amber-400 shrink-0" />
           <span className="text-xs text-amber-400 font-bold">
-            {noGeoCount} activo{noGeoCount > 1 ? 's' : ''} sin ubicación — registra coordenadas al pasar cerca
+            {noGeoCount} activo{noGeoCount > 1 ? 's' : ''} sin ubicación, registra coordenadas al pasar cerca
           </span>
         </div>
       )}

--- a/src/components/charts/Sparkline.jsx
+++ b/src/components/charts/Sparkline.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 /**
- * Sparkline — micro-gráfica SVG inline (Fase 14.3).
+ * Sparkline, micro-gráfica SVG inline (Fase 14.3).
  *
  * Polyline puro, sin dependencias. Apto para embeds en cards de inventario,
  * timeline de activos y cualquier panel compacto.
  *
  * Props:
- *   - data:       number[] — serie de valores
+ *   - data:       number[], serie de valores
  *   - width:      ancho en px (default 60)
  *   - height:     alto en px (default 20)
  *   - color:      color del trazo (default blue-500)

--- a/src/components/common/AIStreamPanel.jsx
+++ b/src/components/common/AIStreamPanel.jsx
@@ -3,7 +3,7 @@ import { Sparkles, Zap } from 'lucide-react';
 import StreamingText from './StreamingText';
 
 /**
- * AIStreamPanel — bloque cyberpunk de render para generaciones del LLM.
+ * AIStreamPanel, bloque cyberpunk de render para generaciones del LLM.
  *
  * Diferencia el contenido IA del contenido determinista con efectos visuales
  * que evocan una terminal CRT + un HUD cyberpunk:
@@ -22,7 +22,7 @@ import StreamingText from './StreamingText';
  *   - text    string        contenido acumulado (chunk a chunk).
  *   - active  boolean       true mientras el LLM genera.
  *   - label   string        header (ej. "IA generando", "Diagnostico IA").
- *   - accent  string        'orchid' | 'muzo' | 'morpho' — borde/glow/header.
+ *   - accent  string        'orchid' | 'muzo' | 'morpho', borde/glow/header.
  *                           El TEXTO siempre es verde fosforo (look uniforme).
  *   - meta    ReactNode     pequeno texto a la derecha del header.
  */
@@ -34,12 +34,12 @@ export default function AIStreamPanel({
   meta = null,
 }) {
   // Fases del ciclo de vida del panel:
-  //   idle      — sin actividad, estatico.
-  //   streaming — LLM genera (active=true); texto pulsa con negative-breath
+  //   idle     , sin actividad, estatico.
+  //   streaming, LLM genera (active=true); texto pulsa con negative-breath
   //               cada 8s como "latido" de IA viva.
-  //   closing   — transicion de cierre inicial: flash de negativo (500ms)
+  //   closing  , transicion de cierre inicial: flash de negativo (500ms)
   //               que invierte colores momentaneamente, anuncia el fin.
-  //   finished  — rayo + burst de cierre (1400/1200ms), fase final visual.
+  //   finished , rayo + burst de cierre (1400/1200ms), fase final visual.
   // Phase machine: cuando active=true, derivamos 'streaming' directo de la prop
   // (evita cascading renders de setState-in-effect). Solo persistimos en state
   // las transiciones temporizadas closing → finished → idle del cierre.
@@ -115,7 +115,7 @@ export default function AIStreamPanel({
   };
 
   // Text-shadow que simula el bloom del fosforo en tubo CRT.
-  // Solo se aplica durante streaming/closing — el texto final consolidado
+  // Solo se aplica durante streaming/closing, el texto final consolidado
   // usa estilos neutros (font-sans, text-slate-300) para maxima legibilidad.
   const phosphorTextStyle = {
     color: phosphorColor,
@@ -125,7 +125,7 @@ export default function AIStreamPanel({
   };
 
   // Decision UX (v0.6.4+): el texto final mantiene el look terminal CRT
-  // verde fosforo — coherente con la metafora "terminal activa" y el
+  // verde fosforo, coherente con la metafora "terminal activa" y el
   // aspecto unico del panel IA. La variante neutra sans-serif fue revertida
   // por preferencia del usuario.
 

--- a/src/components/common/Badge.jsx
+++ b/src/components/common/Badge.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 /**
- * Badge — etiqueta compacta para estados/labels.
+ * Badge, etiqueta compacta para estados/labels.
  * Diseño Bio-Punk: outlined por default, relleno opcional para enfasis.
  *
  * Props:

--- a/src/components/common/ExternalAiButton.jsx
+++ b/src/components/common/ExternalAiButton.jsx
@@ -1,5 +1,5 @@
 /**
- * ExternalAiButton.jsx — R5
+ * ExternalAiButton.jsx, R5
  * Botón reutilizable que copia un prompt portátil al clipboard.
  * Si el clipboard API falla, muestra un modal con textarea seleccionable.
  * AGPL-3.0 © Chagra
@@ -50,13 +50,13 @@ function ClipboardFallbackModal({ prompt, onClose }) {
 }
 
 /**
- * ExternalAiButton — Componente reutilizable R5.
+ * ExternalAiButton, Componente reutilizable R5.
  *
  * Props:
  *   - context: { speciesName, scientificName, companions, ... } pasado al builder
- *   - buildPrompt: fn(context) → string — constructor de prompt apropiado
+ *   - buildPrompt: fn(context) → string, constructor de prompt apropiado
  *   - label: texto del botón (por defecto 'Copiar para IA externa')
- *   - variant: 'share' | 'clipboard' — selección de icono (por defecto 'clipboard')
+ *   - variant: 'share' | 'clipboard', selección de icono (por defecto 'clipboard')
  *   - className: clases CSS adicionales
  */
 export function ExternalAiButton({ context, buildPrompt, label = 'Copiar para IA externa', variant = 'clipboard', className = '' }) {
@@ -76,7 +76,7 @@ export function ExternalAiButton({ context, buildPrompt, label = 'Copiar para IA
                     enrichedContext = { ...context, altitudMsnm: detected };
                 }
             } catch (err) {
-                // Silent fail — getDeviceAltitude tiene su propio fallback;
+                // Silent fail, getDeviceAltitude tiene su propio fallback;
                 // si retorna null el builder cae a "altitud no especificada"
                 // que es el comportamiento previo aceptable.
                 console.warn('[ExternalAiButton] altitude resolution failed:', err);

--- a/src/components/common/ScreenShell.jsx
+++ b/src/components/common/ScreenShell.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ArrowLeft } from 'lucide-react';
 
 /**
- * ScreenShell — layout común para vistas full-screen (Fase 13.6).
+ * ScreenShell, layout común para vistas full-screen (Fase 13.6).
  *
  * Extrae el patrón repetitivo usado por AssetsDashboard, WorkerHistory y
  * la vista de Bodega. Cumple DRY: header consistente + botón back + área

--- a/src/components/common/SkyBadge.jsx
+++ b/src/components/common/SkyBadge.jsx
@@ -3,7 +3,7 @@ import { lunarPhase, solarTimes, formatLocalHM, formatDayLength } from '../../ut
 import { FARM_CONFIG } from '../../config/defaults';
 
 /**
- * SkyBadge — fase lunar + horas solares en el header.
+ * SkyBadge, fase lunar + horas solares en el header.
  *
  * Muestra: 🌗 Cuarto · ☀ 5:42-17:53
  * Hover/title revela detalle: nombre completo, iluminación, día/noche, día.
@@ -23,7 +23,7 @@ export default function SkyBadge() {
   const lunarTitle = `${lunar.name} · ${Math.round(lunar.illumination * 100)}% iluminación · ${Math.round(lunar.daysSinceNewMoon)}d desde luna nueva`;
   const solarTitle = solar.sunrise && solar.sunset
     ? `Salida ${formatLocalHM(solar.sunrise)} · puesta ${formatLocalHM(solar.sunset)} · día ${formatDayLength(solar.dayLengthMinutes)} · ${solar.isDaylight ? 'sol arriba' : 'sol abajo'}`
-    : 'Coordenadas no configuradas — sin cálculo solar';
+    : 'Coordenadas no configuradas, sin cálculo solar';
 
   return (
     <span

--- a/src/components/common/Sparkline.jsx
+++ b/src/components/common/Sparkline.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 /**
- * Sparkline SVG inline — renderiza una serie numerica (0..N) con enfasis
+ * Sparkline SVG inline, renderiza una serie numerica (0..N) con enfasis
  * en legibilidad sobre fondo oscuro.
  *
  * v0.6.4+: tamano por defecto mas grande, fuentes mayores, area bajo
@@ -9,8 +9,8 @@ import React from 'react';
  * actual, guia central punteada visible.
  *
  * Acepta:
- *   values: number[]                           — array crudo de numeros.
- *   data:   Array<{ state: string|number }>    — compat con formato HA history.
+ *   values: number[]                          , array crudo de numeros.
+ *   data:   Array<{ state: string|number }>   , compat con formato HA history.
  *
  * Props opcionales: color, height, width, timeLabel, unit, showLastValue,
  * lastValueDecimals.

--- a/src/components/common/StreamingText.jsx
+++ b/src/components/common/StreamingText.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 /**
- * StreamingText — renderiza texto en progresion con cursor parpadeante.
+ * StreamingText, renderiza texto en progresion con cursor parpadeante.
  *
  * Se usa para mostrar al usuario la generacion token-por-token del LLM
  * (entity extractor, vision, analisis agronomico). Cuando `active` es
@@ -9,7 +9,7 @@ import React from 'react';
  *
  * Props:
  *   - text: string que se acumula a medida que llegan chunks.
- *   - active: boolean — si false, oculta el cursor (streaming terminado).
+ *   - active: boolean, si false, oculta el cursor (streaming terminado).
  *   - variant: 'line' (default, barra neon fina) | 'block' (cursor
  *              cuadrado estilo terminal IBM / VT100 con parpadeo duro).
  *   - className / cursorClassName: customizacion de estilo.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -35,14 +35,14 @@ syncManager.initDB().then(async () => {
   // Migración de identidad: ejecución única, solo si hay sesión activa.
   if (navigator.onLine && !localStorage.getItem('chagra:v1:rename_done')) {
     getAccessToken().then((token) => {
-      if (!token) return; // Sin sesión — no intentar PATCH sin auth
+      if (!token) return; // Sin sesión, no intentar PATCH sin auth
       renameWorker('Jimmy', PRIMARY_WORKER_NAME).then((result) => {
         if (result.success || result.error === 'not_found') {
           localStorage.setItem('chagra:v1:rename_done', '1');
           console.info('[Migration] Renombrado completado o innecesario.');
         }
       }).catch((e) => console.warn('[Migration] Error renombrando:', e));
-    }).catch(() => { }); // Token expirado — skip silencioso
+    }).catch(() => { }); // Token expirado, skip silencioso
   }
 
   // Pull preventivo inicial de logs si hay red (ventana 30 días).

--- a/src/pages/InventoryPage.jsx
+++ b/src/pages/InventoryPage.jsx
@@ -1,9 +1,9 @@
 /**
- * InventoryPage — orquesta los 3 componentes del flujo inventario.
+ * InventoryPage, orquesta los 3 componentes del flujo inventario.
  *
  * Estado local:
  *   - selectedItemId: cuál ítem está siendo editado / inspeccionado
- *   - viewMode: 'dashboard' | 'audit' — dashboard por default, audit al click
+ *   - viewMode: 'dashboard' | 'audit', dashboard por default, audit al click
  *   - recountTarget: si != null, abre el RecountDrawer
  *
  * Refresh strategy: después de cada appendEvent exitoso, recargar el


### PR DESCRIPTION
## Summary

David Loka reportó 2026-05-06: el em-dash (`—`) repetitivo en strings UI es fingerprint detectable de Claude AI ("ese hpta tiene una fijación con eso"). Barrido global + regla durable.

## Cambios

- **54 archivos JSX**: ` — ` → `, ` (212 ocurrencias automáticas)
- **HelpManual.jsx:330**: fix manual (em-dash al final de línea sin espacio)
- **AGENTS.md**: regla durable nueva documentando el feedback + excepciones legítimas + audit pre-merge

## Excepciones preservadas (10 ocurrencias legítimas)

- `'—'` como placeholder de empty state (no hay valor) en AssetDetailView, AssetTimeline, InventoryAuditTrail, WorkerDashboard, SpeciesSelect, AltitudeBadge
- HarvestLog JSDoc comment interno (no visible al usuario)

## Test plan

- [x] Build limpio (6.20s local)
- [x] grep `' — '` en src/**/*.jsx queda en 0 (excepto excepciones documentadas)
- [x] Regla durable en AGENTS.md previene reintroducción

## Caso de prueba

Resuelve bug #3 del baseline `Chagra-strategy/ops/claude-code-prompts/test-cases/2026-05-06-david-loka-baseline-bugs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)