### PR TITLE
feat(guild): filtros funcionales companion suggester (ADR-034 David Loka)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.44",
+  "version": "0.12.45",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v87';
+const CACHE_NAME = 'chagra-v88';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/guildService.test.js
+++ b/src/services/__tests__/guildService.test.js
@@ -1,0 +1,126 @@
+/**
+ * guildService.test.js — Tests del companion suggester (ADR-034).
+ *
+ * Caso baseline: bug reportado por David Loka 2026-05-06 — Espinaca sugería
+ * companions agronómicamente incompatibles (Café, Tomate árbol, Gulupa,
+ * Granadilla, Curuba). Estos tests blindan que el fix funcional no se rompa.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getSuggestedCompanions } from '../guildService.js';
+
+describe('guildService — filtros funcionales (ADR-034 David Loka feedback)', () => {
+  describe('Espinaca (estrato bajo, ciclo anual 60d, sun-loving)', () => {
+    const result = getSuggestedCompanions('spinacia_oleracea');
+    const companionIds = result.companions.map((c) => c.id);
+
+    it('NO sugiere café arábica (perenne, sombra alta)', () => {
+      expect(companionIds).not.toContain('coffea_arabica');
+    });
+
+    it('NO sugiere tomate de árbol (perenne, sombra alta)', () => {
+      expect(companionIds).not.toContain('solanum_betaceum');
+    });
+
+    it('NO sugiere gulupa, granadilla, ni curuba (enredaderas perennes densas)', () => {
+      expect(companionIds).not.toContain('passiflora_edulis');
+      expect(companionIds).not.toContain('passiflora_ligularis');
+      expect(companionIds).not.toContain('passiflora_tarminiana');
+    });
+
+    it('NO sugiere árboles frutales perennes (manzano, peral, durazno, guayaba)', () => {
+      expect(companionIds).not.toContain('malus_domestica');
+      expect(companionIds).not.toContain('pyrus_communis');
+      expect(companionIds).not.toContain('prunus_persica');
+      expect(companionIds).not.toContain('psidium_guajava');
+    });
+
+    it('SÍ sugiere companions explícitos del catálogo (Capa 1)', () => {
+      expect(companionIds).toContain('fragaria_ananassa');
+      expect(companionIds).toContain('pisum_sativum');
+      expect(companionIds).toContain('daucus_carota');
+    });
+  });
+
+  describe('Lechuga (estrato bajo, ciclo anual 60d)', () => {
+    const result = getSuggestedCompanions('lactuca_sativa');
+    const companionIds = result.companions.map((c) => c.id);
+
+    it('NO sugiere café ni frutales perennes', () => {
+      expect(companionIds).not.toContain('coffea_arabica');
+      expect(companionIds).not.toContain('passiflora_edulis');
+      expect(companionIds).not.toContain('solanum_betaceum');
+    });
+  });
+
+  describe('Tomate común (hortaliza fruto, estrato bajo, ciclo 4 meses)', () => {
+    const result = getSuggestedCompanions('solanum_lycopersicum');
+    const companionIds = result.companions.map((c) => c.id);
+
+    it('NO sugiere café ni gulupa (sombra alta sobre hortaliza)', () => {
+      expect(companionIds).not.toContain('coffea_arabica');
+      expect(companionIds).not.toContain('passiflora_edulis');
+    });
+
+    it('SÍ sugiere albahaca (Capa 1, validada)', () => {
+      expect(companionIds).toContain('ocimum_basilicum');
+    });
+  });
+
+  describe('Café arábica (perenne medio, dosel)', () => {
+    const result = getSuggestedCompanions('coffea_arabica');
+    const companionIds = result.companions.map((c) => c.id);
+
+    it('SÍ sugiere companions explícitos del catálogo', () => {
+      expect(companionIds).toContain('zea_mays');
+      expect(companionIds).toContain('phaseolus_vulgaris');
+      expect(companionIds).toContain('psidium_guajava');
+    });
+
+    it('Capa 2 puede sugerir otros perennes compatibles (no está en bloqueo bidireccional)', () => {
+      // Café como target (perenne) sí puede tener otras perennes como companions estructurales
+      // — el bloqueo es asimétrico: solo herbáceas anuales rechazan perennes de sombra alta
+      expect(result.companions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Razones inline mejoradas (transparencia)', () => {
+    const result = getSuggestedCompanions('spinacia_oleracea');
+
+    it('cada companion tiene razón explícita', () => {
+      for (const c of result.companions) {
+        expect(c.reason).toBeTruthy();
+        expect(c.reason.length).toBeGreaterThan(5);
+      }
+    });
+
+    it('Capa 2 menciona criterios usados (estrato, gremio, ciclo)', () => {
+      const layer2 = result.companions.filter((c) => c.score < 100);
+      for (const c of layer2) {
+        // Razón debe mencionar al menos uno de: estrato, gremio, ciclo
+        expect(c.reason.toLowerCase()).toMatch(/estrato|ciclo|gremio|complementa|fijador|repelente|atrayente|productivo|cobertura|acumulador|productor/);
+      }
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('Especie inexistente devuelve listas vacías', () => {
+      const result = getSuggestedCompanions('especie_inexistente_xyz');
+      expect(result.companions).toEqual([]);
+      expect(result.antagonists).toEqual([]);
+    });
+
+    it('No sugiere a la propia especie', () => {
+      const result = getSuggestedCompanions('spinacia_oleracea');
+      const ids = result.companions.map((c) => c.id);
+      expect(ids).not.toContain('spinacia_oleracea');
+    });
+
+    it('Respeta antagonistas explícitos', () => {
+      const result = getSuggestedCompanions('lactuca_sativa');
+      const ids = result.companions.map((c) => c.id);
+      // petroselinum_crispum es antagonista de lactuca_sativa
+      expect(ids).not.toContain('petroselinum_crispum');
+    });
+  });
+});

--- a/src/services/guildService.js
+++ b/src/services/guildService.js
@@ -1,10 +1,18 @@
 /**
- * guildService.js — Motor de gremios y sugerencia de policultivos (Fase 18).
+ * guildService.js — Motor de gremios y sugerencia de policultivos.
  *
  * Tres capas de resolución:
- *   1. Explícita: companions definidos en speciesDefaults.
- *   2. Estructural: nichos vacíos derivados de estrato + gremio (permacultura).
+ *   1. Explícita: companions definidos en speciesDefaults (validados a mano).
+ *   2. Estructural: nichos vacíos derivados de estrato + gremio + filtros
+ *      funcionales (ciclo + sombra + porte).
  *   3. Cognitiva: inferencia via Ollama/Gemma 4 (delegada al caller).
+ *
+ * Filtros funcionales en Capa 2 (ADR-034 — feedback David Loka 2026-05-06):
+ *   - Compatibilidad de ciclo: hortalizas anuales (<12 meses) no aceptan
+ *     companions perennes (>=24 meses o cycleMonths null).
+ *   - Compatibilidad de sombra: especies sun-loving (estrato bajo + ciclo
+ *     corto sin tolerancia a sombra explícita) excluyen candidates con
+ *     `shade_projection: 'high'`.
  *
  * El servicio NUNCA sugiere antagonistas. La validación de incompatibilidad
  * es transversal a las tres capas.
@@ -44,10 +52,87 @@ const COMPLEMENTARY_ROLES = {
 };
 
 /**
+ * Especies que proyectan sombra densa cuando maduran. Si target es sun-loving
+ * (estrato bajo + ciclo corto), estas se excluyen como companions estructurales
+ * aunque tengan estrato/gremio complementario.
+ *
+ * Curado a mano post-feedback David Loka. Lista incremental: agregar especie
+ * cuando se detecte que da sombra problemática a herbáceas.
+ */
+const SHADE_PROJECTION_HIGH = new Set([
+  'coffea_arabica',           // Café — dosel arbustivo 2-3m
+  'solanum_betaceum',         // Tomate de árbol — arbusto 3-4m
+  'passiflora_edulis',        // Gulupa — enredadera densa
+  'passiflora_ligularis',     // Granadilla — enredadera densa
+  'passiflora_tarminiana',    // Curuba — enredadera densa
+  'psidium_guajava',          // Guayaba — árbol 3-6m
+  'malus_domestica',          // Manzano — árbol 3-5m
+  'pyrus_communis',           // Peral — árbol 3-5m
+  'prunus_persica',           // Durazno — árbol 3-5m
+  'ficus_carica',             // Higuera — árbol 3-6m
+  'citrus_limon',             // Limón — árbol 3-5m
+  'acca_sellowiana',          // Feijoa — arbusto 3m
+  'vasconcellea_pubescens',   // Papayuelo — arbusto 4-5m
+]);
+
+/**
+ * Determina si una especie es perenne (vive >= 2 años o ciclo indefinido).
+ * Heurística sobre cycleMonths:
+ *   - null → perenne explícita (café, frutales perennes)
+ *   - >= 24 → bianual+ que en práctica funciona como perenne
+ *   - < 24 → anual o bianual corta
+ */
+function isPerennial(defaults) {
+  if (!defaults) return false;
+  if (defaults.cycleMonths === null || defaults.cycleMonths === undefined) return true;
+  return defaults.cycleMonths >= 24;
+}
+
+/**
+ * Determina si una especie es de ciclo corto (anual rápido <= 12 meses).
+ */
+function isAnnual(defaults) {
+  if (!defaults) return false;
+  if (defaults.cycleMonths === null || defaults.cycleMonths === undefined) return false;
+  return defaults.cycleMonths < 12;
+}
+
+/**
+ * Determina si una especie es estrato bajo + ciclo corto = "hortaliza herbácea".
+ * Estas especies son las más sensibles a companions de gran porte (sombra/competencia).
+ */
+function isHerbaceousLowCycle(defaults) {
+  return defaults.estrato === 'bajo' && isAnnual(defaults);
+}
+
+/**
+ * Filtro funcional: ¿es candidate compatible con target en ciclo + sombra?
+ * Devuelve null si OK, o string con razón de exclusión si rechazado.
+ */
+function checkFunctionalCompatibility(targetDefaults, candidateId, candidateDefaults) {
+  // Filtro 1: target hortaliza herbácea NO puede tener companions perennes de gran porte
+  if (isHerbaceousLowCycle(targetDefaults) && isPerennial(candidateDefaults)) {
+    if (SHADE_PROJECTION_HIGH.has(candidateId)) {
+      return 'sombra excesiva sobre hortaliza';
+    }
+    if (candidateDefaults.estrato === 'medio' || candidateDefaults.estrato === 'alto') {
+      return 'ciclo perenne incompatible con hortaliza anual';
+    }
+  }
+
+  // Filtro 2: target ciclo corto + candidate perenne con shade alta = no
+  if (isAnnual(targetDefaults) && SHADE_PROJECTION_HIGH.has(candidateId)) {
+    return 'sombra densa sobre ciclo anual';
+  }
+
+  return null;
+}
+
+/**
  * Obtiene sugerencias de compañeros para una especie seleccionada.
  *
  * @param {string} speciesId - clave de CROP_TAXONOMY (ej. 'passiflora_edulis')
- * @returns {{ companions: Array<{id, name, reason}>, antagonists: Array<{id, name, reason}> }}
+ * @returns {{ companions: Array<{id, name, reason, score}>, antagonists: Array<{id, name, reason}> }}
  */
 export const getSuggestedCompanions = (speciesId) => {
   const defaults = SPECIES_DEFAULTS[speciesId];
@@ -56,7 +141,8 @@ export const getSuggestedCompanions = (speciesId) => {
   const antagonistSet = new Set(defaults.antagonists || []);
   const results = new Map(); // id → { id, name, reason, score }
 
-  // Capa 1 — Compañeros explícitos (máxima confianza)
+  // Capa 1 — Compañeros explícitos (máxima confianza, no se filtran funcionalmente
+  // porque ya fueron validados a mano por el curador del catálogo).
   for (const cId of (defaults.companions || [])) {
     if (antagonistSet.has(cId)) continue;
     const sp = speciesById.get(cId);
@@ -64,7 +150,7 @@ export const getSuggestedCompanions = (speciesId) => {
     results.set(cId, { id: cId, name: sp.name, reason: 'Compañero directo (relación validada)', score: 100 });
   }
 
-  // Capa 2 — Complementariedad estructural (estrato + gremio)
+  // Capa 2 — Complementariedad estructural (estrato + gremio) con FILTROS FUNCIONALES
   const targetStrata = COMPLEMENTARY_STRATA[defaults.estrato] || [];
   const targetRoles = COMPLEMENTARY_ROLES[defaults.gremio] || [];
 
@@ -76,6 +162,10 @@ export const getSuggestedCompanions = (speciesId) => {
     // Verificar que el candidato no tenga al solicitante como antagonista
     const candidateAntagonists = new Set(candidateDefaults.antagonists || []);
     if (candidateAntagonists.has(speciesId)) continue;
+
+    // Filtro funcional ANTES de scoring estructural (ADR-034)
+    const incompatibilityReason = checkFunctionalCompatibility(defaults, candidateId, candidateDefaults);
+    if (incompatibilityReason) continue;
 
     let score = 0;
     const reasons = [];
@@ -90,6 +180,15 @@ export const getSuggestedCompanions = (speciesId) => {
     if (targetRoles.includes(candidateDefaults.gremio)) {
       score += 40;
       reasons.push(candidateDefaults.gremio.replace(/_/g, ' '));
+    }
+
+    // Bonus por ciclo similar (ambos anuales o ambos perennes) — coherencia temporal
+    if (isAnnual(defaults) && isAnnual(candidateDefaults)) {
+      score += 15;
+      reasons.push('ciclo similar');
+    } else if (isPerennial(defaults) && isPerennial(candidateDefaults)) {
+      score += 15;
+      reasons.push('ambos perennes');
     }
 
     if (score > 0) {
@@ -129,16 +228,13 @@ export const getSuggestedCompanions = (speciesId) => {
  * El caller envía esto a /api/ollama/api/generate y parsea el JSON response.
  */
 export const buildGuildPrompt = (speciesName, estrato) => {
-  // Contexto geoagronómico desde FARM_CONFIG. Sin hardcode a bosque andino:
-  // el asistente debe atender el rango colombiano completo del páramo
-  // (>3000m) al nivel del mar.
   const altitud = FARM_CONFIG.ALTITUD_MSNM;
   const zonas = (FARM_CONFIG.THERMAL_ZONES || []).join(', ') || 'no especificada';
   const municipio = FARM_CONFIG.MUNICIPIO || 'Colombia';
   const ctxAltitud = altitud != null
     ? `a ${altitud} msnm (piso térmico: ${zonas})`
     : `(piso térmico: ${zonas})`;
-  return `Basado en principios de agroecología de Jairo Restrepo y permacultura (diseño de gremios), sugiere 3 plantas acompañantes para ${speciesName} en estrato ${estrato} en ${municipio} ${ctxAltitud}. Considera el rango colombiano completo desde el páramo (>3000m) hasta el nivel del mar al evaluar compañeros viables. Responde SOLO en formato JSON array: [{"name":"Nombre común (Nombre científico)","reason":"Razón agroecológica breve"}]. No añadas texto fuera del JSON.`;
+  return `Basado en principios de agroecología de Jairo Restrepo y permacultura (diseño de gremios), sugiere 3 plantas acompañantes para ${speciesName} en estrato ${estrato} en ${municipio} ${ctxAltitud}. Considera el rango colombiano completo desde el páramo (>3000m) hasta el nivel del mar al evaluar compañeros viables. CRITERIOS FUNCIONALES OBLIGATORIOS: (1) compatibilidad de ciclo (no mezclar hortalizas anuales con perennes de gran porte), (2) compatibilidad de sombra (no sugerir companions que proyecten sombra densa sobre cultivos sun-loving), (3) compatibilidad de estrato. Responde SOLO en formato JSON array: [{"name":"Nombre común (Nombre científico)","reason":"Razón agroecológica breve incluyendo criterios de ciclo + sombra + estrato"}]. No añadas texto fuera del JSON.`;
 };
 
 export default getSuggestedCompanions;


### PR DESCRIPTION
## Summary

David Loka reportó 2026-05-06 que Espinaca sugería companions agronómicamente incompatibles (Café, Tomate árbol, Gulupa, Granadilla, Curuba). Root cause: Capa 2 estructural del guildService validaba solo estrato + gremio sin considerar ciclo de vida ni sombra proyectada.

## Fix

- Set curado de 13 especies de gran porte (`SHADE_PROJECTION_HIGH`)
- Helpers `isPerennial()`, `isAnnual()`, `isHerbaceousLowCycle()`
- Función `checkFunctionalCompatibility()` aplica 2 filtros antes del scoring estructural
- Bonus +15 por ciclo similar (coherencia temporal)
- Razones inline mejoradas (transparencia: "Complementa: estrato bajo, fijador nitrógeno, ciclo similar")
- Prompt Ollama actualizado con criterios funcionales obligatorios

## Test plan

- [x] 15/15 tests pasan en `guildService.test.js` (nuevo)
- [x] Espinaca NO sugiere café/tomate árbol/passifloras/frutales perennes
- [x] Café como target preserva companions (bloqueo asimétrico)
- [x] Build limpio (7.37s local)
- [x] Eslint clean

## Caso de prueba

Resuelve bug #1 del baseline `Chagra-strategy/ops/claude-code-prompts/test-cases/2026-05-06-david-loka-baseline-bugs.md`.

## Schema retrocompatible

NO toca speciesDefaults.js. El set de sombra alta vive en guildService. Si en futuro queremos exponer `shade_projection` como campo oficial del catálogo (schema v3.4), se promueve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)