### PR TITLE
hotfix(sw): passthrough chunks hasheados, fix white screen producción

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.46",
+  "version": "0.12.47",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.45",
+  "version": "0.12.46",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v89';
+const CACHE_NAME = 'chagra-v90';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v88';
+const CACHE_NAME = 'chagra-v89';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
@@ -19,76 +19,85 @@ self.addEventListener('install', (event) => {
   );
 });
 
-// Activación del Service Worker
+// Activación: borra caches viejos + toma control inmediato + notifica clients
+// para que recarguen (evita white screen post-deploy con chunks hash viejos).
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys()
-      .then(cacheNames => {
-        return Promise.all(
-          cacheNames.map(cacheName => {
-            if (cacheName !== CACHE_NAME) {
-              return caches.delete(cacheName);
-            }
-          })
-        );
-      })
+      .then(cacheNames => Promise.all(
+        cacheNames.map(cacheName => {
+          if (cacheName !== CACHE_NAME) {
+            return caches.delete(cacheName);
+          }
+          return undefined;
+        })
+      ))
       .then(() => self.clients.claim())
+      .then(() => self.clients.matchAll({ type: 'window' }))
+      .then(clients => {
+        // Notifica a clients que hay un SW nuevo activo. El cliente decide
+        // si recarga (típicamente sí, para asegurar bundle/chunks frescos).
+        clients.forEach(client => {
+          client.postMessage({ type: 'SW_UPDATED', version: CACHE_NAME });
+        });
+      })
   );
 });
 
-// Estrategia de caché: Network First para API, Cache First para estáticos
+// Estrategia de caché:
+//   - /assets/* (chunks Vite con hash en filename): PASSTHROUGH puro. Vite
+//     genera nombres immutables (index-XXXXX.js); el browser HTTP cache los
+//     maneja eficientemente. NUNCA interceptar en SW: si el deploy cambió
+//     los hashes y el SW tiene refs viejos, intentar cargar un chunk que
+//     ya no existe causa fallback a index.html (MIME text/html) → white
+//     screen. Es el bug que provocó el incidente 2026-05-06.
+//   - Static shell (HTML/manifest/icons): Stale-While-Revalidate
+//   - Otros GET: Network-First con fallback cache
+//   - POST/PUT/DELETE: pasthrough sin caché
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Para recursos estáticos: Cache First
+  // PASSTHROUGH para chunks hasheados de Vite. NO interceptar.
+  if (url.pathname.startsWith('/assets/')) {
+    return; // browser maneja directamente
+  }
+
+  // Static shell: Stale-While-Revalidate (sirve cache rápido, refresca async)
   if (ASSETS_TO_CACHE.some(path => url.pathname === path)) {
     event.respondWith(
-      caches.match(event.request)
-        .then(cachedResponse => {
-          if (cachedResponse) {
-            return cachedResponse;
+      caches.match(event.request).then(cachedResponse => {
+        const networkFetch = fetch(event.request).then(response => {
+          if (event.request.method === 'GET' && response.ok) {
+            const respClone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, respClone));
           }
-          return fetch(event.request).then(response => {
-            // Solo cachear respuestas GET exitosas
-            if (event.request.method === 'GET' && response.ok) {
-              return caches.open(CACHE_NAME).then(cache => {
-                cache.put(event.request, response.clone());
-                return response;
-              });
-            }
-            return response;
-          });
-        })
+          return response;
+        }).catch(() => cachedResponse);
+        return cachedResponse || networkFetch;
+      })
     );
     return;
   }
 
-  // Para API: Network First con fallback (solo cachear GET)
+  // GET (API u otros): Network-First con fallback cache
   if (event.request.method === 'GET') {
     event.respondWith(
       fetch(event.request)
         .then(response => {
           if (response.ok) {
-            return caches.open(CACHE_NAME).then(cache => {
-              cache.put(event.request, response.clone());
-              return response;
-            });
+            const respClone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, respClone));
           }
           return response;
         })
-        .catch(() => {
-          return caches.match(event.request);
-        })
+        .catch(() => caches.match(event.request))
     );
     return;
   }
 
-  // Para otros métodos (POST, PUT, DELETE): Network First sin caché
+  // POST/PUT/DELETE: passthrough sin caché
   event.respondWith(
-    fetch(event.request)
-      .catch(() => {
-        return caches.match(event.request);
-      })
+    fetch(event.request).catch(() => caches.match(event.request))
   );
 });
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -82,17 +82,24 @@ if ('serviceWorker' in navigator) {
     if (event.data?.type === 'SYNC_REQUESTED') {
       syncManager.syncAll();
     }
-    // SW_UPDATED: el SW activó una versión nueva (post-deploy con chunks
-    // hash distintos). Recargamos UNA VEZ para que el cliente pida los
-    // chunks nuevos. Sin este reload el browser puede quedarse con HTML
-    // cached referenciando chunks viejos que ya no existen, causando
-    // white screen (incidente 2026-05-06, ver public/sw.js).
-    if (event.data?.type === 'SW_UPDATED') {
-      const reloadKey = '__sw_reload_done_' + event.data.version;
-      if (!sessionStorage.getItem(reloadKey)) {
-        sessionStorage.setItem(reloadKey, '1');
-        window.location.reload();
-      }
+  });
+
+  // Auto-reload cuando el SW nuevo toma control (controllerchange).
+  // Pattern Workbox estándar para evitar white screen post-deploy:
+  //   - Si NO había controller previo, es first install (no reload)
+  //   - Si HABÍA controller y cambió a otro = update real, recargar UNA VEZ
+  // Sin este reload el browser puede quedarse con HTML cached que referencia
+  // chunks Vite con hashes viejos que ya no existen post-deploy → todos los
+  // chunks fallan → white screen (incidente 2026-05-06, ver public/sw.js).
+  let initialControllerRegistered = !!navigator.serviceWorker.controller;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (initialControllerRegistered) {
+      // Era un update real (no first install). Recargar para HTML fresh +
+      // chunk refs nuevos.
+      window.location.reload();
+    } else {
+      // First install. Marcamos para que próximos controllerchange sí recarguen.
+      initialControllerRegistered = true;
     }
   });
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -82,6 +82,18 @@ if ('serviceWorker' in navigator) {
     if (event.data?.type === 'SYNC_REQUESTED') {
       syncManager.syncAll();
     }
+    // SW_UPDATED: el SW activó una versión nueva (post-deploy con chunks
+    // hash distintos). Recargamos UNA VEZ para que el cliente pida los
+    // chunks nuevos. Sin este reload el browser puede quedarse con HTML
+    // cached referenciando chunks viejos que ya no existen, causando
+    // white screen (incidente 2026-05-06, ver public/sw.js).
+    if (event.data?.type === 'SW_UPDATED') {
+      const reloadKey = '__sw_reload_done_' + event.data.version;
+      if (!sessionStorage.getItem(reloadKey)) {
+        sessionStorage.setItem(reloadKey, '1');
+        window.location.reload();
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## URGENTE — producción white screen

Console errors reportados por operador:
\`\`\`
Failed to load 'https://chagra.guatoc.co/assets/index-BB9R9QYB.js'.
A ServiceWorker intercepted the request and encountered an
unexpected error. sw.js:68:11
\`\`\`

## Root cause

SW interceptaba `/assets/*` (chunks Vite con hash). Tras deploy con hashes nuevos, los chunks viejos no existen, server responde `index.html`, browser falla al cargar HTML como JS module → white screen total.

## Fix

1. **Passthrough `/assets/*`** en SW (Vite garantiza inmutabilidad por hash; browser HTTP cache es óptimo)
2. **Static shell SWR** (Stale-While-Revalidate)
3. **SW_UPDATED postMessage** al activar; cliente recarga UNA VEZ por versión (sessionStorage guard)
4. **CACHE_NAME v89** invalida cache antigua

## Recovery automático

Primer load post-merge: SW v89 activa → dispara SW_UPDATED → main.jsx recarga → HTML fresh con chunk refs válidos.

Manual fallback (si automático falla): DevTools → Application → Unregister SW + Clear site data + hard reload.

## Test plan

- [ ] Build limpio (✅ 5.84s local)
- [ ] curl chagra.guatoc.co devuelve HTML con chunk refs nuevos
- [ ] DevTools muestra SW v89 activo
- [ ] Console clean post-load