### PR TITLE
chore(privacy): sanitizar referencias persona/empresa tercero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Cuando dudes si algo es estratégico, default privado y consulta. El leak histó
 
 ## Estilo de copy UI, sin em dashes
 
-**NO usar em dashes (`—`, U+2014) en strings UI** (JSX text content, props como `title=`, `aria-label=`, toasts, mensajes al usuario). Razón: David Loka 2026-05-06 lo identificó como fingerprint repetitivo de Claude AI ("ese hpta tiene una fijación con eso"). Reemplazar por:
+**NO usar em dashes (`—`, U+2014) en strings UI** (JSX text content, props como `title=`, `aria-label=`, toasts, mensajes al usuario). Razón: un usuario externo lo identificó como fingerprint repetitivo de Claude AI (feedback 2026-05-06). Reemplazar por:
 
 - `,` cuando es continuación de oración
 - `.` cuando es cierre + nueva idea

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.47",
+  "version": "0.12.48",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v90';
+const CACHE_NAME = 'chagra-v91';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/guildService.test.js
+++ b/src/services/__tests__/guildService.test.js
@@ -1,7 +1,7 @@
 /**
  * guildService.test.js — Tests del companion suggester (ADR-034).
  *
- * Caso baseline: bug reportado por David Loka 2026-05-06 — Espinaca sugería
+ * Caso baseline: bug reportado por usuario externo 2026-05-06 — Espinaca sugería
  * companions agronómicamente incompatibles (Café, Tomate árbol, Gulupa,
  * Granadilla, Curuba). Estos tests blindan que el fix funcional no se rompa.
  */
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest';
 import { getSuggestedCompanions } from '../guildService.js';
 
-describe('guildService — filtros funcionales (ADR-034 David Loka feedback)', () => {
+describe('guildService — filtros funcionales (ADR-034 feedback usuario externo)', () => {
   describe('Espinaca (estrato bajo, ciclo anual 60d, sun-loving)', () => {
     const result = getSuggestedCompanions('spinacia_oleracea');
     const companionIds = result.companions.map((c) => c.id);

--- a/src/services/guildService.js
+++ b/src/services/guildService.js
@@ -7,7 +7,7 @@
  *      funcionales (ciclo + sombra + porte).
  *   3. Cognitiva: inferencia via Ollama/Gemma 4 (delegada al caller).
  *
- * Filtros funcionales en Capa 2 (ADR-034 — feedback David Loka 2026-05-06):
+ * Filtros funcionales en Capa 2 (ADR-034 — feedback usuario externo 2026-05-06):
  *   - Compatibilidad de ciclo: hortalizas anuales (<12 meses) no aceptan
  *     companions perennes (>=24 meses o cycleMonths null).
  *   - Compatibilidad de sombra: especies sun-loving (estrato bajo + ciclo
@@ -56,7 +56,7 @@ const COMPLEMENTARY_ROLES = {
  * (estrato bajo + ciclo corto), estas se excluyen como companions estructurales
  * aunque tengan estrato/gremio complementario.
  *
- * Curado a mano post-feedback David Loka. Lista incremental: agregar especie
+ * Curado a mano post-feedback usuario externo. Lista incremental: agregar especie
  * cuando se detecte que da sombra problemática a herbáceas.
  */
 const SHADE_PROJECTION_HIGH = new Set([


### PR DESCRIPTION
Cleanup post-incidente leak nombres personales en repo público AGPL.

## Cambios

- AGENTS.md: 'David Loka' + cita literal -> 'usuario externo'
- src/services/guildService.js: 2 referencias en JSDoc
- src/services/__tests__/guildService.test.js: header + describe block

## Por qué solo archivos vivos

Git history viejo (PR #176, #177) queda con referencias en commit messages. NO se reescribe history pública sin force-push (rompe forks/clones). Esto sanitiza la superficie viva (filesystem actual + nuevos clones).

## Lección durable

Nombres de personas externas + empresas + citas verbatim NUNCA en repos públicos. Memory operator actualizada con regla anti-leak terceros.

## Test plan

- [x] Build limpio (12.89s local)
- [x] Tests guildService 15/15 pasan
- [x] Sin cambio funcional, solo prosa