### PR TITLE
feat(ux): auto-hide FABs tras 2s sin interacción (issue #178)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.47",
+  "version": "0.12.48",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v90';
+const CACHE_NAME = 'chagra-v91';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -21,6 +21,7 @@
 import { useState, useEffect } from 'react';
 import { openDB, STORES } from '../db/dbCore';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
+import useIdleVisibility from '../hooks/useIdleVisibility';
 
 const FAB_SIZE = 52;
 const COLOR_PRIMARY = '#0E92A6';
@@ -40,6 +41,10 @@ export default function FieldFeedback() {
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  // Auto-hide tras 2s sin interacción (feedback usuario externo 2026-05-06,
+  // bug #2: FAB tapaba widgets en home). El modal abierto NO se ve afectado
+  // — solo el FAB fab-button colapsado es lo que se oculta.
+  const isFabVisible = useIdleVisibility(2000);
   const [errorMsg, setErrorMsg] = useState('');
 
   // Audio state, el hook gestiona MediaRecorder + permisos + hard limit 30s.
@@ -208,7 +213,7 @@ export default function FieldFeedback() {
 
   return (
     <>
-      {/* FAB button */}
+      {/* FAB button (auto-hide 2s idle) */}
       <button
         type="button"
         aria-label="Reportar feedback"
@@ -232,6 +237,9 @@ export default function FieldFeedback() {
           alignItems: 'center',
           justifyContent: 'center',
           padding: 0,
+          opacity: isFabVisible ? 1 : 0,
+          pointerEvents: isFabVisible ? 'auto' : 'none',
+          transition: 'opacity 250ms ease',
         }}
       >
         💬

--- a/src/components/MicFab.jsx
+++ b/src/components/MicFab.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Mic } from 'lucide-react';
+import useIdleVisibility from '../hooks/useIdleVisibility';
 
 /**
  * MicFab, Floating Action Button global para captura por voz (DR-030 QW4).
@@ -13,11 +14,16 @@ import { Mic } from 'lucide-react';
  * Visible en todas las rutas excepto loading/login (mismo patrón que
  * FieldFeedback). Toca → navigate('voz') abre VoiceCapture screen.
  *
+ * Auto-hide tras 2s sin interacción (feedback usuario externo 2026-05-06,
+ * bug #2 baseline): los FAB tapaban el widget "Cola de tareas" en home.
+ * Reaparecen con cualquier mousemove/touch/scroll/keydown.
+ *
  * Refs: deepresearch/chagra-ux/decisions/ux-clarity-2026-05.md (D1)
  */
 export default function MicFab({ onNavigate }) {
   const COLOR_PRIMARY = '#84cc16';   // lime-500 (matches NAV_TILE 'voz' accent)
   const COLOR_ACCENT = '#bef264';    // lime-300
+  const isVisible = useIdleVisibility(2000);
 
   return (
     <button
@@ -46,6 +52,9 @@ export default function MicFab({ onNavigate }) {
         display: 'flex',
         alignItems: 'center',
         gap: 10,
+        opacity: isVisible ? 1 : 0,
+        pointerEvents: isVisible ? 'auto' : 'none',
+        transition: 'opacity 250ms ease',
       }}
     >
       <Mic size={22} strokeWidth={2.5} aria-hidden="true" />

--- a/src/hooks/useIdleVisibility.js
+++ b/src/hooks/useIdleVisibility.js
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * useIdleVisibility — devuelve `isVisible` (boolean) que pasa a `false`
+ * tras `idleMs` sin interacción del usuario, y vuelve a `true` con
+ * cualquier mousemove / touch / scroll / keydown / click.
+ *
+ * Caso de uso: auto-hide de FABs flotantes para no tapar contenido cuando
+ * el operador está leyendo/observando una pantalla quieta. Reaparecen al
+ * mínimo movimiento.
+ *
+ * Spec usuario externo (feedback 2026-05-06, bug #2 baseline): los FAB
+ * tapaban el widget Cola de tareas en el dashboard home. Solución
+ * convergente: auto-hide tras 2s sin interacción.
+ *
+ * Implementación:
+ *   - Listeners pasivos en window (mousemove, touchstart, touchmove,
+ *     scroll, keydown, click).
+ *   - Tras `idleMs` sin eventos, isVisible = false.
+ *   - Cualquier evento reset el timer + isVisible = true.
+ *   - Cleanup en unmount: remueve listeners + clear timer.
+ *
+ * Uso típico:
+ *   const isVisible = useIdleVisibility(2000);
+ *   <button style={{ opacity: isVisible ? 1 : 0,
+ *                    pointerEvents: isVisible ? 'auto' : 'none',
+ *                    transition: 'opacity 250ms ease' }}>
+ *
+ * @param {number} idleMs Milisegundos sin actividad antes de ocultar (default 2000)
+ * @returns {boolean} isVisible
+ */
+export default function useIdleVisibility(idleMs = 2000) {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    let timer;
+
+    const reset = () => {
+      setIsVisible(true);
+      clearTimeout(timer);
+      timer = setTimeout(() => setIsVisible(false), idleMs);
+    };
+
+    // Iniciar el timer al montar (sin actividad inicial → ocultar tras idleMs)
+    reset();
+
+    const events = ['mousemove', 'touchstart', 'touchmove', 'scroll', 'keydown', 'click'];
+    events.forEach((evt) => window.addEventListener(evt, reset, { passive: true }));
+
+    return () => {
+      clearTimeout(timer);
+      events.forEach((evt) => window.removeEventListener(evt, reset));
+    };
+  }, [idleMs]);
+
+  return isVisible;
+}


### PR DESCRIPTION
Bug #2 baseline (usuario externo 2026-05-06): los FAB Voz + FieldFeedback tapaban el widget Cola de tareas en home.

## Solución
Hook `useIdleVisibility` reusable + aplicado a ambos FAB con opacity transition + pointer-events none cuando invisible.

## Test plan
- [x] Build limpio (2.95s local)
- [ ] CI gates verde
- [ ] Manual: Home → 2s sin tocar → FAB fade out → tocar pantalla → fade in
- [ ] Modal de FieldFeedback abierto: NO afectado

Closes #178