### PR TITLE
fix(guild): cebollín no sugería companions (allium_fistulosum + schoenoprasum faltaban)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.48",
+  "version": "0.12.49",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v91';
+const CACHE_NAME = 'chagra-v92';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/config/speciesDefaults.js
+++ b/src/config/speciesDefaults.js
@@ -83,6 +83,15 @@ export const SPECIES_DEFAULTS = {
   calendula_officinalis:  { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'atrayente_polinizadores', production: 'flor', cycleMonths: 3, companions: ['solanum_lycopersicum', 'brassica_oleracea_capitata'], antagonists: [] },
   tropaeolum_majus:       { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'flor', cycleMonths: 3, companions: ['cucurbita_maxima', 'malus_domestica', 'passiflora_edulis'], antagonists: [] },
   allium_cepa:            { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'bulbo', cycleMonths: 4, companions: ['daucus_carota', 'lactuca_sativa', 'fragaria_ananassa'], antagonists: ['phaseolus_vulgaris', 'pisum_sativum', 'vicia_faba'] },
+  // Cebolla larga / cebollín / "cebolla de rama" — cosecha por hoja-tallo,
+  // ciclo más rápido que cabezona (~90 días). Mismos antagonistas Allium
+  // (alelopatía azufrada vs leguminosas). Bug reportado por operador
+  // sembrando "cebollín en el invernadero" via voz: la especie estaba en
+  // taxonomy.js pero no en speciesDefaults → GuildSuggestions devolvía null.
+  allium_fistulosum:      { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'hoja',  cycleMonths: 3, companions: ['daucus_carota', 'lactuca_sativa', 'fragaria_ananassa', 'beta_vulgaris_cicla', 'spinacia_oleracea'], antagonists: ['phaseolus_vulgaris', 'pisum_sativum', 'vicia_faba'] },
+  // Cebollín francés / chives — herbácea perenne, hojas tubulares finas,
+  // rebrota tras corte. Companion clásico de tomate y zanahoria.
+  allium_schoenoprasum:   { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'hoja',  cycleMonths: null, companions: ['daucus_carota', 'fragaria_ananassa', 'solanum_lycopersicum', 'lactuca_sativa'], antagonists: ['phaseolus_vulgaris', 'pisum_sativum'] },
   rosmarinus_officinalis: { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'hoja', cycleMonths: null, companions: ['brassica_oleracea_capitata', 'daucus_carota'], antagonists: [] },
   artemisia_absinthium:   { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'hoja', cycleMonths: null, companions: [], antagonists: ['lactuca_sativa', 'pisum_sativum'] },
   ruta_graveolens:        { category: 'medicinales_alelopaticas', estrato: 'bajo', gremio: 'repelente_plagas', production: 'hoja', cycleMonths: null, companions: [], antagonists: ['ocimum_basilicum'] },

--- a/src/services/__tests__/guildService.test.js
+++ b/src/services/__tests__/guildService.test.js
@@ -103,6 +103,41 @@ describe('guildService — filtros funcionales (ADR-034 feedback usuario externo
     });
   });
 
+  describe('Cebolla larga / cebollín (allium_fistulosum) — bug operador 2026-05-06', () => {
+    const result = getSuggestedCompanions('allium_fistulosum');
+
+    it('SÍ retorna companions (no vacío) — antes faltaba en speciesDefaults', () => {
+      expect(result.companions.length).toBeGreaterThan(0);
+    });
+
+    it('SÍ retorna antagonistas (legumbres por alelopatía Allium)', () => {
+      const ids = result.antagonists.map((a) => a.id);
+      expect(ids).toContain('phaseolus_vulgaris');
+    });
+
+    it('NO sugiere perennes de gran porte (filtro ADR-034)', () => {
+      const ids = result.companions.map((c) => c.id);
+      expect(ids).not.toContain('coffea_arabica');
+      expect(ids).not.toContain('passiflora_edulis');
+      expect(ids).not.toContain('solanum_betaceum');
+    });
+  });
+
+  describe('Cebollín francés / chives (allium_schoenoprasum)', () => {
+    const result = getSuggestedCompanions('allium_schoenoprasum');
+
+    it('SÍ retorna companions', () => {
+      expect(result.companions.length).toBeGreaterThan(0);
+    });
+
+    it('SÍ incluye Capa 1 explícita (tomate, fresa, zanahoria)', () => {
+      const ids = result.companions.map((c) => c.id);
+      expect(ids).toContain('solanum_lycopersicum');
+      expect(ids).toContain('fragaria_ananassa');
+      expect(ids).toContain('daucus_carota');
+    });
+  });
+
   describe('Edge cases', () => {
     it('Especie inexistente devuelve listas vacías', () => {
       const result = getSuggestedCompanions('especie_inexistente_xyz');


### PR DESCRIPTION
Bug operador sembrando 'cebollín en el invernadero' por voz.

## Root cause
`allium_fistulosum` + `allium_schoenoprasum` estaban en `taxonomy.js` pero NO en `speciesDefaults.js`. `GuildSuggestions` línea 103 retorna null si no hay defaults → componente entero invisible (sin companions, sin botón Gemma).

## Fix
Agregar ambos defaults coherentes con `allium_cepa` (mismos antagonistas legumbres, companions hortalizas/raíces).

## Test plan
- [x] 20/20 tests pasan
- [x] Build limpio (4.96s)
- [ ] Manual: voz 'cebollín invernadero' muestra companions + botón Gemma