### PR TITLE
docs: closing dedication in README and HelpManual

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,11 @@ Cualquier contribución al módulo de sincronización (`syncManager`) debe asegu
 
 Este proyecto está licenciado bajo los términos de la licencia **GNU AGPLv3**.
 // Smoke test claude-code-runner — 2026-05-01
+
+---
+
+For the next custodian.
+She'll know which parts to keep.
+
+Este código existe por una sola persona.
+Lo demás es ingeniería y TDAH a tope.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.51",
+  "version": "0.12.52",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v94';
+const CACHE_NAME = 'chagra-v95';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HelpManual.jsx
+++ b/src/components/HelpManual.jsx
@@ -394,6 +394,9 @@ export default function HelpManual({ onBack, onNavigate }) {
         <p className="text-xs text-slate-600 text-center mt-4 italic">
           Manual v1.2, última actualización 2026-05-04 (acento colombiano cordial + correcciones)
         </p>
+        <p className="text-xs text-slate-500 text-center mt-2 italic">
+          Este código existe por una sola persona. Lo demás es ingeniería y TDAH a tope.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Cierre personal en README + HelpManual footer.

Sin nombres ni datos identificables — frase general autorizada por la regla anti-leak (memoria operacional 2026-05-07).

## Files
- README.md: 4 líneas al final, después de License
- src/components/HelpManual.jsx: 1 línea italic al final del componente

🤖 Generated with [Claude Code](https://claude.com/claude-code)