### PR TITLE
fix: Plan Generator auto + UX _pending clarificado (queue bug operador 2026-05-07)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.53",
+  "version": "0.12.54",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.54",
+  "version": "0.12.56",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.55",
+  "version": "0.12.53",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v98';
+const CACHE_NAME = 'chagra-v96';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v96';
+const CACHE_NAME = 'chagra-v97';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v97';
+const CACHE_NAME = 'chagra-v99';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
## Summary
Cierra 2 bugs reportados por el operador 2026-05-07 que el DR-035 + ADR-035 dejaron como norte arquitectónico para resolver:

1. **Plan Generator NO se disparaba al sembrar por voz** — solo desde formulario manual
2. **Bodega mostraba '_pending' forever** — UX confuso, no distinguía no-network vs sync_error

## Implementación
Cursor IDE + Sonnet 4.6 (Privacy Mode), 5 archivos tocados, 2 commits separados.

### fix(voice): hook post-success en payloadService
- Si \`type === 'seeding'\` Y hay planta inline → dispara \`generatePlanForPlant\` async
- Re-emite \`syncCompleted\` con \`detail.planGenerated\`
- VoiceCapture listener → toast UI

### fix(inventory): \`_pendingReason\` distingue causas
- \`no_network\` / \`no_token\` → badge azul informativo (\"Guardado local · sync pendiente\")
- \`sync_error\` → mantiene border-dashed+opacity actual (sí es problema)

## Test
- \`npx eslint\` archivos modificados: 0 warnings
- \`npm run build\`: OK

## Refs
- ADR-035 plant feeding plan + inventory architecture (Chagra-strategy main)
- DR-035 cierre 2026-05-07 (Chagra-strategy main)

🤖 Cursor IDE (Sonnet 4.6 Privacy Mode), supervised by Claude Opus stg