### PR TITLE
fix(voice): toast bitácora condicional según online/offline path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.58",
+  "version": "0.12.59",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v101';
+const CACHE_NAME = 'chagra-v102';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -70,6 +70,11 @@ export default function VoiceCapture({ onSave }) {
   const [errorMsg, setErrorMsg] = useState('');
   const [pendingCount, setPendingCount] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
+  // Path tracking: true si AL MENOS UNA entity cayó al fallback offline
+  // (savePayload retorna message con "local"). Decide el copy de STATE_DONE
+  // — sólo apunta a Bitácora → Pendientes cuando realmente hay algo
+  // pendiente; si todas se sincronizaron directo con FarmOS, no mentimos.
+  const [syncedOffline, setSyncedOffline] = useState(false);
   // Timestamp del momento en que el operador habló. Capturado al detener
   // la grabación restando la duración del audio. Se propaga al log--seeding
   // (timestamp Unix) y al asset--plant._createdAt (millis JS) para que la
@@ -126,6 +131,7 @@ export default function VoiceCapture({ onSave }) {
     setErrorMsg('');
     setReprocessingId(null);
     setLiveStream('');
+    setSyncedOffline(false);
     setView(STATE_IDLE);
   }, [reset]);
 
@@ -369,12 +375,15 @@ export default function VoiceCapture({ onSave }) {
       }
     }
 
+    let hadOfflinePath = false;
     for (const entity of expandedEntities) {
       try {
         const payload = buildSeedingPayload(entity);
         const result = await savePayload('seeding', payload);
-        if (result.success || (result.message || '').toLowerCase().includes('local')) {
+        const isOfflineFallback = (result.message || '').toLowerCase().includes('local');
+        if (result.success || isOfflineFallback) {
           savedCount++;
+          if (isOfflineFallback) hadOfflinePath = true;
         } else {
           errors.push(`${entity.crop}: ${result.message || 'desconocido'}`);
         }
@@ -385,6 +394,7 @@ export default function VoiceCapture({ onSave }) {
 
     setIsSaving(false);
     if (savedCount > 0) {
+      setSyncedOffline(hadOfflinePath);
       // Reproceso exitoso: purgar la grabación de pending_voice para que no
       // reaparezca en el banner en futuras sesiones.
       if (reprocessingId != null) {
@@ -547,7 +557,11 @@ export default function VoiceCapture({ onSave }) {
           <div className="text-center max-w-xs">
             <p className="text-base font-bold text-green-300">Registro guardado ✓</p>
             <p className="text-xs text-slate-400 mt-1">
-              Se sincronizará con FarmOS cuando haya conexión. Mientras tanto, lo encontrás en <strong className="text-slate-200">Bitácora → Pendientes</strong>.
+              {syncedOffline ? (
+                <>Se sincronizará con FarmOS cuando haya conexión. Mientras tanto, lo encuentra en <strong className="text-slate-200">Bitácora → Recientes</strong>.</>
+              ) : (
+                <>Sincronizado con FarmOS.</>
+              )}
             </p>
           </div>
           <div className="flex flex-wrap gap-2 justify-center">
@@ -557,12 +571,14 @@ export default function VoiceCapture({ onSave }) {
             >
               <Mic size={18} /> Nueva grabación
             </button>
-            <button
-              onClick={() => window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'historial' } }))}
-              className="px-6 py-3 min-h-[44px] bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2 text-slate-200"
-            >
-              Ver en Bitácora
-            </button>
+            {syncedOffline && (
+              <button
+                onClick={() => window.dispatchEvent(new CustomEvent('chagraNavigate', { detail: { view: 'historial' } }))}
+                className="px-6 py-3 min-h-[44px] bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2 text-slate-200"
+              >
+                Ver en Bitácora
+              </button>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Contexto

Operador 2026-05-07: registró siembra por voz online y al ir a Bitácora → Pendientes no había nada — feature parecía desconectado.

## Causa raíz

`payloadService.savePayload()` tiene dos paths:
- **Online success**: `sendToFarmOS` OK → log directo a FarmOS, **no entra** a `pendingTransactions`
- **Offline fallback**: `syncManager.saveTransaction` → log encolado en IndexedDB, sí aparece en bitácora

`WorkerHistory` solo lee de `pendingTransactions`. El `STATE_DONE` de VoiceCapture mostraba SIEMPRE el copy "Bitácora → Pendientes" + botón "Ver en Bitácora", lo cual mentía cuando el path fue online-direct.

## Fix mínima

- Nuevo `useState` `syncedOffline` tracking del path real
- Detección post-`savePayload`: `result.message.toLowerCase().includes('local')` = offline fallback
- Render `STATE_DONE` condicional:
  - Online: `"Sincronizado con FarmOS."`
  - Offline: `"Se sincronizará con FarmOS cuando haya conexión. Mientras tanto, lo encuentra en Bitácora → Recientes."`
- Botón "Ver en Bitácora" solo aparece cuando `syncedOffline === true`
- Reset `syncedOffline` en `resetAll`

## Scope no incluido (delegado a opencode)

El operador sospecha (con razón) que **NO es el único componente afectado**. Otros candidatos sospechosos: `InputLogForm`, `AssetsDashboard`, `SpeciesSelect`, `AssetDetailView`. Audit + fix patrón en bulk + sección "Recientes 24h" completa en `WorkerHistory` (logs online + offline) → tarea opencode separate (prompt en `Chagra-strategy/prompts/tasks/2026-05-08-opencode-bitacora-disconnect-audit-fix.md`).

## Test plan

- [x] ESLint clean en `VoiceCapture.jsx`
- [ ] Manual offline: DevTools throttle Offline → grabar voz → verificar copy "Bitácora → Recientes" + botón presente → click navega a Bitácora → log visible en Recientes
- [ ] Manual online: grabar voz online → verificar copy "Sincronizado con FarmOS" + botón ausente

🤖 Generated with [Claude Code](https://claude.com/claude-code)