### PR TITLE
fix(help): scroll-into-view + ChevronDown indicator en cambio de especie

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.58",
+  "version": "0.12.59",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v101';
+const CACHE_NAME = 'chagra-v102';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HelpCycleSection.jsx
+++ b/src/components/HelpCycleSection.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { GraduationCap, Mic } from 'lucide-react';
+import React, { useState, useRef, useEffect } from 'react';
+import { GraduationCap, Mic, ChevronDown } from 'lucide-react';
 import CycleContentRenderer from './CycleContentRenderer.jsx';
 import HelpVoiceQuestion from './HelpVoiceQuestion.jsx';
 
@@ -30,6 +30,18 @@ const PLACEHOLDER_CYCLES = [
  */
 export default function HelpCycleSection() {
   const [selectedSlug, setSelectedSlug] = useState('lechuga');
+  const contentRef = useRef(null);
+  const isFirstRender = useRef(true);
+
+  // Tras cambio de especie: scroll al contenido + key forzando re-mount.
+  // Skip on mount para no mover la vista al abrir Ayuda.
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [selectedSlug]);
 
   return (
     <div className="border rounded-xl border-amber-700/40 bg-slate-900/80 p-4 mb-6 shadow-[0_0_20px_rgba(245,158,11,0.08)]">
@@ -55,23 +67,34 @@ export default function HelpCycleSection() {
         Disponibles ahora
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-        {STARTER_CYCLES.map((c) => (
-          <button
-            key={c.slug}
-            type="button"
-            onClick={() => setSelectedSlug(c.slug)}
-            className={`p-3 rounded-lg text-left min-h-[64px] border transition-colors ${
-              selectedSlug === c.slug
-                ? 'bg-emerald-900/35 border-emerald-500/60 ring-1 ring-emerald-500/30'
-                : 'bg-slate-950/60 border-emerald-900/30 hover:bg-slate-800/80'
-            }`}
-          >
-            <p className="font-bold text-emerald-300 text-sm">
-              {c.emoji} {c.label}
-            </p>
-            <p className="text-[11px] text-slate-500 mt-0.5">{c.sub}</p>
-          </button>
-        ))}
+        {STARTER_CYCLES.map((c) => {
+          const isSelected = selectedSlug === c.slug;
+          return (
+            <button
+              key={c.slug}
+              type="button"
+              onClick={() => setSelectedSlug(c.slug)}
+              aria-pressed={isSelected}
+              className={`relative p-3 rounded-lg text-left min-h-[64px] border transition-colors ${
+                isSelected
+                  ? 'bg-emerald-900/35 border-emerald-500/60 ring-1 ring-emerald-500/30'
+                  : 'bg-slate-950/60 border-emerald-900/30 hover:bg-slate-800/80'
+              }`}
+            >
+              <p className="font-bold text-emerald-300 text-sm">
+                {c.emoji} {c.label}
+              </p>
+              <p className="text-[11px] text-slate-500 mt-0.5">{c.sub}</p>
+              {isSelected && (
+                <ChevronDown
+                  size={16}
+                  aria-hidden="true"
+                  className="absolute -bottom-2 left-1/2 -translate-x-1/2 text-emerald-400 animate-bounce"
+                />
+              )}
+            </button>
+          );
+        })}
       </div>
 
       <p className="text-[11px] text-orange-400/90 font-bold uppercase tracking-wider mt-4 mb-2">
@@ -94,8 +117,11 @@ export default function HelpCycleSection() {
         ))}
       </div>
 
-      <div className="mt-4 rounded-xl bg-slate-950/70 border border-emerald-800/40 overflow-hidden">
-        <CycleContentRenderer slug={selectedSlug} />
+      <div
+        ref={contentRef}
+        className="mt-4 rounded-xl bg-slate-950/70 border border-emerald-500/40 overflow-hidden ring-1 ring-emerald-500/20 scroll-mt-4"
+      >
+        <CycleContentRenderer key={selectedSlug} slug={selectedSlug} />
       </div>
 
       <HelpVoiceQuestion speciesSlug={selectedSlug} />


### PR DESCRIPTION
## Bug operador 2026-05-08

> 'cuando abro el tomate abajo abre la información pero sale muy lejos a veces no se ve, debería abrirse dentro del mismo tomate, una animación o algo que lo diferencie'

Aplica a las 3 especies starter (lechuga, fresa, tomate_chonto), no solo el tomate — bug estructural del componente, no específico al item.

## Causa

En `HelpCycleSection.jsx`, el contenido (`CycleContentRenderer`) se renderiza **después** del grid de tabs (línea ~99 `mt-4 rounded-xl ... overflow-hidden`). En mobile o si el usuario está scrolleado, click en un card de especie deja el contenido fuera del viewport. Sin animación ni indicador visual, parece que no pasó nada.

## Fix

1. **scrollIntoView smooth** al container del CycleContentRenderer cuando `selectedSlug` cambia (`useEffect` con guard `isFirstRender` para evitar scroll on mount).
2. **ChevronDown animate-bounce** en el card seleccionado, apuntando hacia abajo donde se desplegó el contenido — indicador visual claro.
3. **Border/ring emerald-500/40** reforzado en el container del contenido + `scroll-mt-4` para offset.
4. **key={selectedSlug}** en CycleContentRenderer fuerza re-mount al cambiar (efecto natural de transición percibida).
5. **aria-pressed** en cards starter (a11y).

## Verificación

- [x] ESLint: 0 errors, 0 warnings
- [ ] Manual: en mobile, click en cada uno de los 3 starters → contenido scrolls al viewport + chevron aparece bouncing en card seleccionado
- [ ] Manual: al abrir Ayuda inicialmente, NO scrolla (isFirstRender guard funciona)

🤖 Generated with [Claude Code](https://claude.com/claude-code)