### PR TITLE
feat(help): rediseño Manual 3 sub-vistas grandes (queue/039 + UX feedback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+Todas las novedades user-facing de Chagra. Formato basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/), versionado en [SemVer](https://semver.org/lang/es/).
+
+## [Unreleased]
+
+### Added
+- **Manual rediseñado**: 3 sub-vistas grandes (voz / uso / aprende sembrando) en lugar de 12 secciones planas apiladas. Tap targets ≥80px en home, tono `tú` cercano, anti-ladrillo. (PR #202, queue/039 + UX feedback 2026-05-08)
+- **Ayuda interactiva por especie**: accordion individual para lechuga, fresa, tomate chonto. Aguacate y café aparecen con badge `Por agregar` + nota educativa contextual sobre cómo contribuir corpus desde Bitácora. (PR #201)
+- **Voz IA con guardrails RAG estrictos**: Whisper STT + Ollama responde solo con corpus consolidado de la especie como contexto. Detecta dosis fuera de corpus → mensaje "Respuesta inválida, fuera de corpus" (anti-alucinación). (PR #195)
+- **Tips dinámicos rotantes en HelpManual**: 31 tips agroecológicos por categoría (riego, sustrato, plagas, observación, paciencia, errores). (PRs #192, #193)
+
+### Changed
+- **Toast post-voz condicional al path de sync**: si la siembra se sincronizó directo con FarmOS, el copy dice "Sincronizado con FarmOS" (sin link a bitácora). Si quedó offline pendiente, copy "Bitácora → Recientes" + botón visible. Antes mentía siempre asumiendo path offline. (PR #197)
+- **Banner sincronización clickeable + dismissable**: click en el banner de sincronización (offline/syncing/error/pendientes) ahora navega a Bitácora para ver/resolver pendientes. Botón X explícito permite cerrar manualmente. Antes el click no hacía nada y el banner tapaba la TopBar persistente sin opción de cerrar. (PR #200)
+- **Asset sync pagination**: `/api/asset/{type}` ahora trae las 200 más recientes con `sort=-created`, garantizando que plantas recién creadas aparezcan en el dashboard. Antes el endpoint sin `sort` ni `page[limit]` traía solo 50 items en orden indeterminado, perdiendo plantas nuevas en repos con >50 assets. (PR #199)
+- **AssetTimeline virtualizado** con react-virtuoso: paginación temporal por mes, smoothscroll en logs largos. (PR #194)
+- **TypeScript-lite vía JSDoc + checkJs**: typedefs centralizados (`ChagraAsset`, `ChagraLog`, `ChagraInventoryEvent`, `ChagraSpecies`, `ChagraBiopreparado`) sin migrar archivos a `.ts`. 70% del valor de TypeScript pleno. (PR #196)
+
+### Fixed
+- **Plan Generator post-seeding**: cuando agregas planta (manzana, fresa) por voz o formulario, aparece toast con plan de alimentación sugerido. Lo encuentras en Bodega → Planes. (PR #191)
+
+## Sugerencias inteligentes (mayo 2026)
+
+Cambios anteriores a este changelog explícito, todos opt-in (la app sugiere, no impone):
+
+- **Plan de alimentación al crear planta**: cuando agregas una mata (manzana, fresa, etc.), aparece toast con plan sugerido. Está en Bodega → Planes.
+- **Sugerencia de biopreparados al agregar insumo**: si agregas melaza, suero de leche o similares a la bodega, modal sugiere qué biopreparados puedes hacer (Bocashi, Biol) con receta inline.
+- **Companions que ya tienes primero**: en panel de gremios, los compañeros que ya están en tu finca aparecen primero con marca verde. No tienes que comprar, ya los tienes.
+
+## Adaptive defaults (memoria de uso)
+
+- **TaskScreen** recuerda última prioridad + zona usada.
+- **HarvestLog** sugiere cantidad como mediana de cosechas pasadas para esa especie.
+- **InputLogForm** pre-fillea último biopreparado aplicado.
+- **Invasoras**: las relevantes a tu piso térmico aparecen marcadas con ★ primero.
+- **InventoryDashboard**: banner amber cuando hay insumos bajo umbral, low-stock se ordenan primero.
+
+## IA experimental (BETA)
+
+Marcadas con badge BETA: funcionan pero pueden errar. Cada feature tiene botón "Reportar diagnóstico defectuoso" que registra el caso para revisar.
+
+- **Identificar especie por foto** en SpeciesSelect → cámara → IA propone especie + alternativas. Confianza ≥70% auto-selecciona si match el catálogo.
+- **Analizar foto de bitácora con IA**: en cualquier evento con foto adjunta (presente o pasado) aparece botón "Analizar foto con IA" que detecta enfermedades, deficiencias, salud general.
+- Estas features requieren conexión al stack IA local (Ollama gemma3:4b en alpha). Si no responden, está fuera de servicio temporalmente.
+
+## Galería + IA externa
+
+- **Galería de la especie**: en el detalle de cualquier planta, ahora ves todas las fotos del operador para esa especie en tu finca (no cross-farm).
+- **Consultar IA externa**: botón en plant detail copia un prompt completo (especie + piso térmico + altitud) listo para pegar en Gemini, ChatGPT o Claude.
+
+---
+
+Este changelog es vivo. Cada release agrega entradas en la sección `[Unreleased]`; al cortar versión semver se promueve a una entrada con número y fecha. Si encuentras un bug o quieres pedir una mejora, toca el botón flotante 💬 en la app — tu feedback construye Chagra.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.61",
+  "version": "0.12.62",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v104';
+const CACHE_NAME = 'chagra-v105';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HelpCicloScreen.jsx
+++ b/src/components/HelpCicloScreen.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { ArrowLeft, ChevronRight, Clock } from 'lucide-react';
+import HelpCycleSection from './HelpCycleSection.jsx';
+
+/**
+ * Sub-vista del Manual: Aprende sembrando. Wrapper del HelpCycleSection
+ * (accordion por especie ya rediseñado en PR #201) + filosofía + meta-info.
+ */
+export default function HelpCicloScreen({ onBackToHome }) {
+  return (
+    <div className="h-full w-full flex flex-col">
+      {/* Sub-header con back to home del Manual */}
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2 shrink-0 border-b border-slate-800/60 bg-slate-950/60">
+        <button
+          type="button"
+          onClick={onBackToHome}
+          aria-label="Volver al Manual"
+          className="p-2 -ml-2 rounded-lg active:bg-slate-800 min-h-[40px] min-w-[40px] flex items-center justify-center"
+        >
+          <ArrowLeft size={20} className="text-pink-400" />
+        </button>
+        <p className="text-xs uppercase tracking-wider text-pink-400/80 font-bold">Manual</p>
+        <ChevronRight size={14} className="text-slate-600" />
+        <p className="text-xs font-bold text-pink-200">Aprende sembrando</p>
+      </div>
+
+      <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
+        <p className="text-sm text-slate-300 leading-relaxed">
+          Punto de partida educativo para empezar desde cero. No solo cómo usar Chagra: cómo cultivar.
+          Toca cada especie para abrir su corpus consolidado y, si quieres, hazle una pregunta por voz a la IA.
+        </p>
+
+        {/* Accordion principal por especie (PR #201) */}
+        <HelpCycleSection />
+
+        <div className="rounded-xl bg-emerald-900/15 border border-emerald-800/40 p-4">
+          <p className="text-[11px] uppercase tracking-wider text-emerald-400 font-bold mb-2">Cada ciclo cubre</p>
+          <ul className="text-xs text-slate-300 space-y-1.5 list-disc pl-5 leading-relaxed">
+            <li><strong>Preparación de tierra</strong>: matera (mezcla recomendada) vs campo abierto (descompactación + biopreparados)</li>
+            <li><strong>Germinación + propagación</strong>: semilla, esqueje, acodo, división, injerto (según especie)</li>
+            <li><strong>Hitos del ciclo</strong>: día por día, criterio observable + acción clave</li>
+            <li><strong>Razones comunes de fracaso</strong>: top 5 con prevención agroecológica + frecuencia esperada</li>
+            <li><strong>Compañeros validados</strong> y antagonistas: qué NO sembrar cerca</li>
+            <li><strong>Biopreparados</strong>: bocashi, biol, caldo sulfocálcico, M-5, Trichoderma</li>
+            <li><strong>Rangos conservadores de cosecha</strong>: anti-overpromise vs literatura comercial</li>
+          </ul>
+        </div>
+
+        <div className="rounded-xl bg-amber-900/15 border border-amber-800/40 p-4 flex items-start gap-2">
+          <Clock size={16} className="text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-amber-100 leading-relaxed">
+            <strong className="text-amber-300">Filosofía:</strong> no prometemos éxito instantáneo. Sembrar es un proceso de meses-años. Documentamos también lo que NO funcionó para que cada operador aprenda de la pérdida sin estigma. El cementerio de plantas es currículo, no fracaso.
+          </p>
+        </div>
+
+        <p className="text-[10px] text-slate-600 italic mt-2 leading-relaxed">
+          Corpus consolidado DR-034 (Claude web + Gemini DR + DeepSeek V3, convergencia 3/3) + plan curación humana presencial 4h por especie advanced (aguacate → café → tomate). Datos calibrados anti-overpromise, rangos agroecológicos colombianos. NO hidroponía.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/components/HelpHomeScreen.jsx
+++ b/src/components/HelpHomeScreen.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Mic, BookOpen, Sprout, ChevronRight } from 'lucide-react';
+
+/**
+ * Home del Manual: 3 botones grandes para entrar a las sub-vistas del help.
+ * Aplica P5 (ayuda discoverable, no monolítica) + P2 (densidad baja, tap
+ * targets grandes pensando en uso real en campo) + P1 (tono cercano "tú").
+ */
+export default function HelpHomeScreen({ onSelect }) {
+  const cards = [
+    {
+      key: 'voz',
+      icon: Mic,
+      title: 'Cómo usar la voz',
+      sub: 'Habla y deja que Chagra registre tu siembra, cosecha o lo que veas en campo.',
+      accent: 'from-emerald-900/60 to-emerald-950/80',
+      border: 'border-emerald-600/50 hover:border-emerald-400/70',
+      iconBg: 'bg-emerald-700/40 border-emerald-500/50',
+      iconColor: 'text-emerald-300',
+      titleColor: 'text-emerald-100',
+      subColor: 'text-emerald-200/70',
+    },
+    {
+      key: 'uso',
+      icon: BookOpen,
+      title: 'Cómo usar Chagra',
+      sub: 'Inicio rápido, foto, zonas, plagas, cosecha, reportes y problemas comunes.',
+      accent: 'from-amber-900/40 to-amber-950/80',
+      border: 'border-amber-600/40 hover:border-amber-400/70',
+      iconBg: 'bg-amber-700/40 border-amber-500/40',
+      iconColor: 'text-amber-300',
+      titleColor: 'text-amber-100',
+      subColor: 'text-amber-200/70',
+    },
+    {
+      key: 'ciclo',
+      icon: Sprout,
+      title: 'Aprende sembrando',
+      sub: 'Lechuga, fresa, tomate y los próximos. Corpus consolidado y voz IA con guardrails.',
+      accent: 'from-pink-900/40 to-rose-950/80',
+      border: 'border-pink-600/40 hover:border-pink-400/70',
+      iconBg: 'bg-pink-700/30 border-pink-500/40',
+      iconColor: 'text-pink-300',
+      titleColor: 'text-pink-100',
+      subColor: 'text-pink-200/70',
+    },
+  ];
+
+  return (
+    <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
+      <p className="text-sm text-slate-300 leading-relaxed">
+        Una mano rápida para entrar a Chagra. Toca lo que necesites.
+      </p>
+
+      <div className="flex flex-col gap-3">
+        {cards.map((c) => {
+          const Icon = c.icon;
+          return (
+            <button
+              key={c.key}
+              type="button"
+              onClick={() => onSelect(c.key)}
+              className={`rounded-2xl bg-gradient-to-br ${c.accent} border ${c.border} active:scale-[0.99] transition-all p-5 text-left flex items-start gap-4 min-h-[112px] shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/60`}
+            >
+              <span className={`shrink-0 inline-flex items-center justify-center w-14 h-14 rounded-xl border ${c.iconBg}`}>
+                <Icon size={28} className={c.iconColor} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className={`text-lg font-black leading-tight ${c.titleColor}`}>{c.title}</p>
+                <p className={`text-xs mt-1.5 leading-relaxed ${c.subColor}`}>{c.sub}</p>
+              </div>
+              <ChevronRight size={20} className="shrink-0 text-slate-400 self-center" />
+            </button>
+          );
+        })}
+      </div>
+
+      <p className="text-[11px] text-slate-600 text-center mt-4 italic leading-relaxed">
+        Si algo no está aquí, toca el botón flotante 💬 para reportarlo. La app aprende contigo.
+      </p>
+    </main>
+  );
+}

--- a/src/components/HelpManual.jsx
+++ b/src/components/HelpManual.jsx
@@ -1,364 +1,82 @@
 import React, { useState } from 'react';
-import { ArrowLeft, ChevronDown, ChevronRight, BookOpen, Sprout, Mic, Camera, MapPin, Bug, Apple, MessageCircle, AlertTriangle, Wrench, Sparkles, GraduationCap, Clock } from 'lucide-react';
+import { ArrowLeft, BookOpen } from 'lucide-react';
 import HelpTipCard from './HelpTipCard.jsx';
-import HelpCycleSection from './HelpCycleSection.jsx';
+import HelpHomeScreen from './HelpHomeScreen.jsx';
+import HelpVozScreen from './HelpVozScreen.jsx';
+import HelpUsoScreen from './HelpUsoScreen.jsx';
+import HelpCicloScreen from './HelpCicloScreen.jsx';
 
 /**
- * HelpManual, Manual de usuario integrado en la PWA.
+ * HelpManual — Manual de usuario integrado en la PWA.
  *
- * Acceso desde TopBar → botón ? (HelpCircle).
+ * Acceso: TopBar → botón ? (HelpCircle).
  *
- * Diseño: secciones colapsables tipo FAQ. Cada sección breve, lenguaje
- * agroecológico, sin jargón técnico. Pensado para Lili / operario campo
- * que no quiere leer 10 minutos antes de usar.
+ * Rediseño 2026-05-08 (queue/039 + UX feedback): router interno con 3
+ * sub-vistas grandes en lugar de 12 secciones planas apiladas.
  *
- * Cuando hay nueva feature crítica (ej. tracking_mode individual vs
- * aggregate), agregar una sección aquí en el orden lógico de uso.
+ *   Home  → 3 botones grandes (voz / uso / ciclo)
+ *   Voz   → tutorial híbrido + CTA "Probar voz ahora"
+ *   Uso   → FAQs reorganizadas en 6 temas (incluye Reportar bug)
+ *   Ciclo → wrapper de HelpCycleSection (accordion por especie, PR #201)
+ *
+ * Principios aplicados (Workspace/Chagra-strategy/ops/chagra-ux-principles.md):
+ *   P1 tono "tú" cercano (anti-ladrillo)
+ *   P2 densidad — pantalla en campo, tap targets ≥48px (≥80px en home CTAs)
+ *   P3 offline-first sin disculpas
+ *   P4 conversacional pero verificable
+ *   P5 ayuda discoverable, no monolítica
+ *   P6 identidad sin postureo
+ *
+ * Movimientos:
+ *   - "Field test cases para Lili" → Workspace/Chagra-strategy/ops/field-test-cases.md
+ *   - "Novedades mayo 2026"        → Chagra/CHANGELOG.md (root)
  */
-
-// eslint-disable-next-line no-unused-vars -- Icon SE USA en JSX, eslint react-jsx detection falla con destructuring rename
-const Section = ({ icon: Icon, title, children, defaultOpen = false, isNew = false, action = null }) => {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className={`border rounded-xl bg-slate-900/60 overflow-hidden transition-all ${isNew ? 'border-emerald-700/60 shadow-[0_0_18px_rgba(16,185,129,0.18)]' : 'border-slate-800'}`}>
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="w-full p-3 flex items-center gap-3 hover:bg-slate-800/60 active:bg-slate-800 text-left min-h-[56px]"
-      >
-        <span className={`shrink-0 inline-flex items-center justify-center ${open ? 'animate-pulse' : ''}`}>
-          <Icon size={20} className="text-emerald-400" />
-        </span>
-        <span className="text-base font-bold text-white flex-1">{title}</span>
-        {isNew && (
-          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-bold bg-emerald-500/20 text-emerald-300 border border-emerald-600/40 animate-pulse">
-            ✨ NUEVO
-          </span>
-        )}
-        {open ? <ChevronDown size={18} className="text-slate-400" /> : <ChevronRight size={18} className="text-slate-400" />}
-      </button>
-      {open && (
-        <div className="px-4 pb-4 pt-1 text-sm text-slate-300 leading-relaxed space-y-2">
-          {children}
-          {action && (
-            <button
-              type="button"
-              onClick={action.onClick}
-              className="mt-3 w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-emerald-500/15 hover:bg-emerald-500/25 active:bg-emerald-500/35 text-emerald-300 hover:text-emerald-100 border border-emerald-700/50 font-bold text-sm transition-colors min-h-[44px]"
-            >
-              {action.label} <ChevronRight size={16} />
-            </button>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
 export default function HelpManual({ onBack, onNavigate }) {
-  // Helper para construir un quick-action que cierra el manual y navega al
-  // flow real. UX A del PR #188: "leer cómo se hace" + "hacerlo" sin friction.
-  const quickAction = (label, route) => ({
-    label,
-    onClick: () => {
-      if (typeof onNavigate === 'function') onNavigate(route);
-      else if (typeof onBack === 'function') onBack();
-    },
-  });
+  // 'home' | 'voz' | 'uso' | 'ciclo'
+  const [section, setSection] = useState('home');
+
+  // CTAs híbridas (P5): cierran el manual y navegan al flow real.
+  const closeAndNavigate = (route) => {
+    if (typeof onNavigate === 'function') onNavigate(route);
+    else if (typeof onBack === 'function') onBack();
+  };
+
+  const goHome = () => setSection('home');
+
   return (
     <div className="h-[100dvh] w-full bg-slate-950 text-white flex flex-col overflow-y-auto">
-       {/* Header */}
-       <header className="p-4 sticky top-0 bg-slate-950/95 backdrop-blur-md border-b border-slate-800 flex items-center gap-3 z-10 shrink-0 shadow-lg">
-         <button
-           type="button"
-           onClick={onBack}
-           aria-label="Volver"
-           className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex items-center justify-center"
-         >
-           <ArrowLeft size={22} />
-         </button>
-         <div className="flex items-center gap-2 flex-1 min-w-0">
-           <BookOpen size={22} className="text-emerald-400 shrink-0" />
-           <h2 className="text-xl font-black tracking-tight truncate">Manual de uso</h2>
-         </div>
-       </header>
-       
-       {/* Tip del día */}
-       <HelpTipCard />
+      {/* Header global del Manual: back cierra el manual entero */}
+      <header className="p-4 sticky top-0 bg-slate-950/95 backdrop-blur-md border-b border-slate-800 flex items-center gap-3 z-10 shrink-0 shadow-lg">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Cerrar manual"
+          className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex items-center justify-center"
+        >
+          <ArrowLeft size={22} />
+        </button>
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <BookOpen size={22} className="text-emerald-400 shrink-0" />
+          <h2 className="text-xl font-black tracking-tight truncate">Manual de uso</h2>
+        </div>
+      </header>
 
-      <div className="flex-1 p-4 flex flex-col gap-3 max-w-2xl mx-auto w-full pb-12">
-        <HelpCycleSection />
-        <p className="text-sm text-slate-400 leading-relaxed">
-          Guía rápida para registrar su finca o balcón en Chagra. Toque cada
-          sección para abrir/cerrar. Si algo no está aquí, use el botón
-          flotante 💬 para reportarlo.
-        </p>
+      {/* Tip del día siempre visible bajo el header */}
+      <HelpTipCard />
 
-        {/* Sección Inicio Rápido */}
-        <Section icon={Sprout} title="🌱 Inicio rápido, primera vez" defaultOpen={true} action={quickAction('Crear primera planta', 'plant_asset')}>
-          <ol className="list-decimal pl-5 space-y-1.5">
-            <li>Toque el botón <strong className="text-purple-400">+</strong> arriba (header) para registrar su primera planta.</li>
-            <li>Busque la especie escribiendo (ej. &ldquo;gulpa&rdquo; encuentra Gulupa). El sistema autocompleta estrato, gremio y producción.</li>
-            <li>Si tiene foto, súbala desde la cámara o galería.</li>
-            <li>Marque la ubicación: toque mapa o &ldquo;Mi ubicación&rdquo;.</li>
-            <li>Guarde. Aparece en <strong>Activos → Plantas</strong>.</li>
-          </ol>
-          <p className="mt-2 text-xs text-slate-500 italic">
-            ¿Sin red? La app funciona offline, los datos se sincronizan cuando vuelva la conexión.
-          </p>
-        </Section>
-
-        {/* Sección Voz */}
-        <Section icon={Mic} title="🎤 Registrar por voz" action={quickAction('Probar voz ahora', 'voz')}>
-          <p>Toque el <strong className="text-emerald-400">FAB micrófono</strong> abajo a la izquierda (siempre visible).</p>
-          <p>Diga algo natural, ejemplos:</p>
-          <ul className="list-disc pl-5 space-y-1 text-slate-400">
-            <li>&ldquo;Sembré 5 tomates en el invernadero&rdquo;</li>
-            <li>&ldquo;Planté 100 cafés en la parcela tres&rdquo;</li>
-            <li>&ldquo;Puse 10 fresas y 30 lechugas en la cama uno&rdquo; (multi-especie OK)</li>
-          </ul>
-          <p>El sistema transcribe + extrae <strong>cantidad, especie, ubicación</strong>. Antes de guardar le muestra una pantalla de revisión donde puede editar si algo salió mal.</p>
-          <p className="text-xs text-slate-500 italic mt-2">
-            La cantidad importa: 1 café = 1 planta individual. 100 cafés = 100 plantas individuales (cada una con su hoja de vida). 50 lechugas = 1 cama con 50 (agregado, las hortalizas se manejan en grupo).
-          </p>
-        </Section>
-
-        {/* Sección Tracking individual vs aggregate */}
-        <Section icon={Sprout} title="🔢 ¿Por qué a veces me crea N plantas y a veces 1?">
-          <p>Chagra clasifica cada especie según cómo se cultiva normalmente:</p>
-          <div className="grid grid-cols-1 gap-2 mt-2">
-            <div className="bg-emerald-900/20 border border-emerald-800/40 rounded p-2">
-              <p className="font-bold text-emerald-300 text-xs uppercase">Individual (1 asset por planta)</p>
-              <p className="text-xs text-slate-400 mt-1">Frutales, café, plátano, aromáticas, tubérculos. Cada planta merece su hoja de vida, foto y cosechas separadas.</p>
-            </div>
-            <div className="bg-amber-900/20 border border-amber-800/40 rounded p-2">
-              <p className="font-bold text-amber-300 text-xs uppercase">Agregado (1 asset con qty=N)</p>
-              <p className="text-xs text-slate-400 mt-1">Hortalizas en cama, cereales, abonos verdes. Se gestionan por conjunto, no plantilla por plantilla.</p>
-            </div>
-          </div>
-          <p className="mt-2">En el formulario aparece un link sutil <em>&ldquo;Agrupar siembra&rdquo;</em> o <em>&ldquo;Registrar individualmente&rdquo;</em> si quiere cambiar el default.</p>
-        </Section>
-
-        {/* Sección Foto, expandida con foto por especie */}
-        <Section icon={Camera} title="📸 Foto: tomar, adjuntar y foto guía por especie" action={quickAction('Crear planta con foto', 'plant_asset')}>
-          <p><strong>Al crear planta:</strong> el botón cámara abre su cámara o galería. La foto queda en la hoja de vida de esa planta.</p>
-          <p><strong>Adjuntar a evento existente</strong>: entre al evento desde Bitácora/Historial → sección &ldquo;Adjuntar foto a este evento&rdquo;. Útil para documentar después de la siembra.</p>
-
-          <div className="mt-3 p-3 rounded-lg bg-emerald-900/15 border border-emerald-800/30">
-            <p className="text-emerald-300 font-bold text-sm mb-1">🌱 Foto guía por especie (cómo y para qué)</p>
-            <p className="text-xs text-slate-300 leading-relaxed">
-              Al elegir especie en el formulario aparece un thumbnail bajo el input. Función:
-            </p>
-            <ul className="text-xs text-slate-400 list-disc pl-5 space-y-1 mt-2">
-              <li><strong>Su primera foto</strong> de esa especie queda como referencia visual cada vez que abre el form de la misma planta, útil para confirmar &ldquo;sí, esto es lo que sembré&rdquo;.</li>
-              <li><strong>Si nunca tomó foto</strong>, ve un placeholder verde con &ldquo;Agregue una foto&rdquo;. No es error, es invitación: la primera foto que tome ocupa ese lugar para sus próximas siembras de la misma especie.</li>
-              <li>Las fotos NO se comparten con otras fincas (privacidad, decidido 2026-05-02). Solo usted las ve en su cuenta.</li>
-              <li>En el futuro v1.1 cargaremos un &ldquo;banco visual&rdquo; del catálogo (frutos típicos de cada especie desde GBIF/iNaturalist con licencia libre) para que aparezcan ANTES de que tome su propia foto.</li>
-            </ul>
-            <p className="text-xs text-slate-500 italic mt-2">
-              Cómo agregar foto por especie: 1) Form planta nueva → seleccione especie → tome foto. La foto queda asociada al asset Y como referencia visual de la especie. Siguientes siembras de esa especie heredan esa foto como guía.
-            </p>
-          </div>
-
-          <p className="text-xs text-slate-500 italic mt-2">
-            Las fotos se comprimen automáticamente a JPEG ≤500KB para no saturar el almacenamiento. La foto original con metadata se preserva localmente.
-          </p>
-        </Section>
-
-        {/* Sección Vision AI, disease diagnosis + species recognition (BETA) */}
-        <Section icon={Sprout} title="🧬 IA por foto: enfermedades + identificación de especie" isNew action={quickAction('Identificar con IA', 'plant_asset')}>
-          <p>Chagra usa visión AI local (Gemma3 multimodal) para dos funciones distintas, ambas marcadas <strong className="text-amber-400">BETA</strong>:</p>
-
-          <h4 className="text-sm font-bold text-emerald-400 mt-3">📋 Diagnóstico de enfermedades por foto</h4>
-          <p>Analiza una foto de hojas y detecta:</p>
-          <ul className="list-disc pl-5 space-y-1">
-            <li>Posibles enfermedades fitosanitarias</li>
-            <li>Deficiencias nutricionales</li>
-            <li>Score general de salud (0-100)</li>
-            <li>Sugerencia de tratamiento agroecológico</li>
-          </ul>
-          <p className="text-xs mt-2">Disponible en <strong>tres puntos</strong>:</p>
-          <ol className="list-decimal pl-5 space-y-1 text-xs">
-            <li><strong>Campo (Worker mode)</strong> → captura evidencia. Análisis se guarda como <code>log--observation</code> con marker AI; aparece en la línea de tiempo como <em>&ldquo;Inferencia IA&rdquo;</em> y debe confirmar/rechazar (gate humano, ADR-019 Regla 1).</li>
-            <li><strong>Bitácora → entrada con foto adjunta</strong> → sección amber &ldquo;Análisis IA experimental&rdquo; abajo del bloque foto. Botón <em>&ldquo;Analizar foto con IA&rdquo;</em>. Funciona con fotos recién capturadas Y fotos viejas guardadas.</li>
-            <li><strong>Plant detail → sección &ldquo;Consultar IA externa&rdquo;</strong> → genera prompt para pegar en Gemini/ChatGPT/Claude (alternativa cuando el modelo local no responde).</li>
-          </ol>
-
-          <h4 className="text-sm font-bold text-emerald-400 mt-3">🔍 Identificación de especie por foto</h4>
-          <p>En <strong>SpeciesSelect</strong> (al crear planta) → botón <em>&ldquo;Tomar foto para identificar especie&rdquo;</em> abajo del selector. Toma foto, IA propone especie + alternativas:</p>
-          <ul className="list-disc pl-5 space-y-1 text-xs">
-            <li>Confianza ≥ 70% + match en catálogo → auto-selecciona la especie</li>
-            <li>Confianza menor → muestra alternativas con chips para que elija</li>
-            <li>Botón <em>&ldquo;Reportar diagnóstico defectuoso&rdquo;</em> registra el caso para validar</li>
-          </ul>
-
-          <p className="text-xs text-slate-500 italic mt-3">
-            Estas funciones requieren conexión al stack IA local (Ollama gemma3:4b en el Nodo Alpha). Si el modelo no responde, sale mensaje de error con opción de reintentar.
-          </p>
-        </Section>
-
-        {/* Sección Zonas */}
-        <Section icon={MapPin} title="📍 Zonas y ubicación" action={quickAction('Ver mapa de la finca', 'mapa')}>
-          <p>Las plantas viven dentro de <strong>zonas</strong> (parcelas, camas, invernaderos). Antes de plantar muchas, cree las zonas:</p>
-          <ol className="list-decimal pl-5 space-y-1">
-            <li>Activos → tab <strong>&ldquo;Zonas&rdquo;</strong> (icono mapa) → +</li>
-            <li>Nombre (ej. &ldquo;Casa los Sitios&rdquo;) + tipo (parcela / cama / invernadero)</li>
-            <li>Defina el polígono en el mapa o capture punto GPS</li>
-          </ol>
-          <p>Después al crear plantas, seleccione esa zona como contenedor.</p>
-          <p className="text-xs text-slate-500 italic mt-2">
-            <strong>Brave + GPS</strong>: si el mapa abre &ldquo;desubicado&rdquo;, Brave Shields puede estar bloqueando GPS preciso. Toque el escudo en la barra → desactive &ldquo;Block fingerprinting&rdquo; para chagra.guatoc.co.
-          </p>
-        </Section>
-
-        {/* Sección Plagas */}
-        <Section icon={Bug} title="🐛 Reportar plaga / invasora" action={quickAction('Reportar plaga ahora', 'reportar_invasora')}>
-          <p>Toque menú principal → <strong>&ldquo;Plagas&rdquo;</strong>. Seleccione la especie invasora del catálogo, capture foto y geolocalización.</p>
-          <p>Después de guardar, le aparece una pantalla con <strong>sugerencias de especies nativas para reemplazar</strong>, toque &ldquo;Sembrar aquí&rdquo; y va al flow de siembra precargado con la nativa + las coordenadas del invasor.</p>
-        </Section>
-
-        {/* Sección Cosechar */}
-        <Section icon={Apple} title="🍎 Registrar cosecha" action={quickAction('Registrar cosecha', 'cosechar')}>
-          <p>Activos → seleccione la planta → en la card aparece &ldquo;Registrar cosecha&rdquo;. Capture cantidad cosechada (kg / unidades) + fecha. Se agrega como log--harvest a la hoja de vida.</p>
-          <p>También por voz: &ldquo;coseché 5 kilos de gulupas&rdquo; con el FAB micrófono.</p>
-        </Section>
-
-        {/* Sección Feedback */}
-        <Section icon={MessageCircle} title="💬 Reportar bug o sugerir mejora">
-          <p>Botón flotante 💬 abajo a la <strong>derecha</strong> (siempre visible). Puede:</p>
-          <ul className="list-disc pl-5 space-y-1">
-            <li>Escribir texto explicando qué pasó</li>
-            <li>Grabar audio (botón 🎤 dentro del modal): &ldquo;hice click acá y pasó X&rdquo;, sin necesidad de tipear con manos sucias</li>
-            <li>Ambos: texto + audio</li>
-          </ul>
-          <p>El feedback queda guardado localmente y se sincroniza después.</p>
-        </Section>
-
-        {/* Sección Problemas comunes */}
-        <Section icon={Wrench} title="🔧 Problemas comunes">
-          <div className="space-y-3">
-            <div>
-              <p className="font-bold text-amber-300">📍 GPS no encuentra mi ubicación</p>
-              <p className="text-xs text-slate-400">El mapa centra automático al abrir el modal. Si tarda más de 15s o cae en error, toque &ldquo;Reintentar&rdquo;. En Brave: revise Shields fingerprinting.</p>
-            </div>
-            <div>
-              <p className="font-bold text-amber-300">🎤 Voz no transcribe</p>
-              <p className="text-xs text-slate-400">Verifique permiso de micrófono (iOS: Ajustes → Safari → Micrófono → chagra.guatoc.co → Permitir). Necesita conexión activa al servidor de transcripción.</p>
-            </div>
-            <div>
-              <p className="font-bold text-amber-300">📷 La foto no aparece tras adjuntarla</p>
-              <p className="text-xs text-slate-400">Recargue la pantalla, IndexedDB puede tardar en flush. Si persiste, repórtelo via 💬.</p>
-            </div>
-            <div>
-              <p className="font-bold text-amber-300">🌱 Creé planta y no aparece en la zona</p>
-              <p className="text-xs text-slate-400">Verifique que la zona esté seleccionada como &ldquo;contenedora&rdquo; en el formulario. En vista &ldquo;Activos → Plantas → Todas&rdquo; aparecen sin filtro.</p>
-            </div>
-            <div>
-              <p className="font-bold text-amber-300">⚠️ Sin red en campo</p>
-              <p className="text-xs text-slate-400">Todo funciona offline. Los datos se sincronizan automáticamente cuando vuelva a estar online. Indicador en la barra superior.</p>
-            </div>
-          </div>
-        </Section>
-
-        {/* Sección Tips Lili field test */}
-        <Section icon={AlertTriangle} title="🧪 Casos de uso para validar (field test)">
-          <p>Si está en field test, pruebe estos casos puntuales y reporte via 💬:</p>
-          <ul className="list-disc pl-5 space-y-1 text-xs text-slate-400">
-            <li>Crear zona &ldquo;Balcón&rdquo; + agregar planta &ldquo;Gulupa&rdquo; con foto + GPS</li>
-            <li>Voz: &ldquo;Sembré 1 mata de albahaca en la cocina&rdquo;</li>
-            <li>Reportar plaga simulada (ej. retamo) y ver sugerencia nativa</li>
-            <li>Adjuntar foto a un registro pasado desde Bitácora</li>
-            <li>Cosecha por voz: &ldquo;Coseché 3 frutos de fresa&rdquo;</li>
-          </ul>
-        </Section>
-
-        {/* Sección Aprende sembrando, corpus curado desde /public/cycle-content/.
-            Datos consolidados DR-034 cerrado 2026-05-06 (3/3 LLMs convergencia
-            alta) + ADR-032 plan curación starter species. Política ADR-033
-            Opción C estricta, solo Nivel 2 evidencia, NO folclore. */}
-        <Section icon={GraduationCap} title="🌿 Aprende sembrando, ciclo agroecológico" defaultOpen={false} isNew>
-          <p className="text-sm leading-relaxed">
-            <strong className="text-emerald-300">Punto de partida educativo</strong> para quien empieza desde cero, no solo cómo usar Chagra, sino cómo cultivar.
-          </p>
-
-          <p className="text-xs text-slate-400 leading-relaxed mt-2">
-            La versión interactiva está arriba en esta misma pantalla, debajo del tip del día: elija lechuga, fresa o tomate chonto, revise el corpus y, si quiere, haga una pregunta por voz con IA que solo usa ese contenido.
-          </p>
-
-          <div className="mt-4 p-3 rounded-xl bg-emerald-900/15 border border-emerald-800/40">
-            <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold mb-2">Cada ciclo cubre</p>
-            <ul className="text-xs text-slate-300 space-y-1 list-disc pl-5">
-              <li><strong>Preparación de tierra</strong>, matera (mezcla recomendada) vs campo abierto (descompactación + biopreparados)</li>
-              <li><strong>Germinación + propagación</strong>, semilla, esqueje, acodo, división, injerto (según especie)</li>
-              <li><strong>Hitos del ciclo</strong>, día por día, criterio observable + acción clave</li>
-              <li><strong>Razones comunes de fracaso</strong>, top 5 con prevención agroecológica + frecuencia esperada</li>
-              <li><strong>Compañeros validados</strong> y antagonistas, qué NO sembrar cerca</li>
-              <li><strong>Biopreparados</strong>, bocashi, biol, caldo sulfocálcico, M-5, Trichoderma</li>
-              <li><strong>Rangos conservadores</strong> de cosecha, anti-overpromise vs literatura comercial</li>
-            </ul>
-          </div>
-
-          <div className="mt-3 p-3 rounded-xl bg-amber-900/15 border border-amber-800/40 flex items-start gap-2">
-            <Clock size={14} className="text-amber-400 shrink-0 mt-0.5" />
-            <p className="text-[11px] text-amber-200 leading-relaxed">
-              <strong>Filosofía:</strong> NO promete éxito instantáneo. Sembrar es un proceso de meses-años. Documenta también lo que NO funcionó para que cada operador aprenda de la pérdida sin estigma. Coherente con el cementerio de plantas, fracaso como currículo.
-            </p>
-          </div>
-
-          <p className="text-[10px] text-slate-600 italic mt-3">
-            Corpus consolidado DR-034 (Claude web + Gemini DR + DeepSeek V3, convergencia 3/3) + plan curación humana presencial 4h por especie advanced (Aguacate → Café → Tomate). Datos calibrados anti-overpromise, rangos agroecológicos colombianos, NO hidroponía.
-          </p>
-        </Section>
-
-        {/* Sección Novedades v0.12.x, features mergeados sesión 2026-05-03 */}
-        <Section icon={Sparkles} title="✨ Novedades de mayo 2026" isNew>
-          <p className="text-xs text-slate-400 mb-2">
-            Cambios recientes que reducen friction. Todos opt-in / no-imposición:
-            la app no fuerza, solo sugiere.
-          </p>
-
-          <h4 className="text-sm font-bold text-emerald-400 mt-3">Sugerencias inteligentes</h4>
-          <ul className="list-disc pl-5 space-y-1 text-xs">
-            <li><strong>Plan de alimentación al crear planta</strong>: cuando agrega una mata (ej. manzana, fresa), aparece toast con plan de alimentación sugerido. Lo encuentra en <strong>Bodega → Planes</strong>.</li>
-            <li><strong>Sugerencia de biopreparados al agregar insumo</strong>: si agrega melaza, suero de leche o similares a la bodega, modal sugiere qué biopreparados puede hacer (Bocashi, Biol, etc.) con receta inline.</li>
-            <li><strong>Companions que ya tiene primero</strong>: en panel de gremios, los compañeros que ya están en su finca aparecen primero con marca verde. No tiene que comprar, ya los tiene.</li>
-          </ul>
-
-          <h4 className="text-sm font-bold text-emerald-400 mt-3">Adaptive defaults (memoria de uso)</h4>
-          <ul className="list-disc pl-5 space-y-1 text-xs">
-            <li><strong>TaskScreen</strong> recuerda última prioridad + zona usada.</li>
-            <li><strong>HarvestLog</strong> sugiere cantidad como mediana de cosechas pasadas para esa especie.</li>
-            <li><strong>InputLogForm</strong> pre-fillea último biopreparado aplicado.</li>
-            <li><strong>Invasoras</strong>: las relevantes a tu piso térmico aparecen marcadas con ★ primero.</li>
-            <li><strong>InventoryDashboard</strong>: banner amber cuando hay insumos bajo umbral, y los low-stock se ordenan primero.</li>
-          </ul>
-
-          <h4 className="text-sm font-bold text-amber-400 mt-3">IA experimental (BETA)</h4>
-          <p className="text-xs">
-            Marcadas con badge <span className="text-[9px] px-1 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-800/50 font-bold">BETA</span>, funcionan pero pueden errar. Si fallan, hay botón &ldquo;Reportar diagnóstico defectuoso&rdquo; que registra el caso para revisar.
-          </p>
-          <ul className="list-disc pl-5 space-y-1 text-xs mt-1">
-            <li><strong>Identificar especie por foto</strong> en SpeciesSelect → cámara → IA propone especie + alternativas. Confidence ≥70% auto-selecciona si match el catálogo.</li>
-            <li><strong>Analizar foto de bitácora con IA</strong>: en cualquier evento con foto adjunta (presente o pasado) aparece botón &ldquo;Analizar foto con IA&rdquo; que detecta enfermedades, deficiencias, salud general.</li>
-          </ul>
-          <p className="text-[11px] text-slate-500 italic mt-1">
-            Estas features requieren conexión al stack IA local (gemma3:4b). Si no responden, está fuera de servicio temporalmente.
-          </p>
-
-          <h4 className="text-sm font-bold text-emerald-400 mt-3">Galería + IA externa</h4>
-          <ul className="list-disc pl-5 space-y-1 text-xs">
-            <li><strong>Galería de la especie</strong>: en el detalle de cualquier planta, ahora ves todas las fotos del operador para esa especie en tu finca (no cross-farm).</li>
-            <li><strong>Consultar IA externa</strong>: botón en plant detail copia un prompt completo (especie + piso térmico + altitud) listo para pegar en Gemini, ChatGPT o Claude.</li>
-          </ul>
-        </Section>
-
-        <p className="text-xs text-slate-600 text-center mt-4 italic">
-          Manual v1.2, última actualización 2026-05-04 (acento colombiano cordial + correcciones)
-        </p>
-        <p className="text-xs text-slate-500 text-center mt-2 italic">
-          Este código existe por una sola persona. Lo demás es ingeniería y TDAH a tope.
-        </p>
-      </div>
+      {/* Sub-vistas */}
+      {section === 'home' && (
+        <HelpHomeScreen onSelect={setSection} />
+      )}
+      {section === 'voz' && (
+        <HelpVozScreen onBackToHome={goHome} onNavigate={closeAndNavigate} />
+      )}
+      {section === 'uso' && (
+        <HelpUsoScreen onBackToHome={goHome} onNavigate={closeAndNavigate} />
+      )}
+      {section === 'ciclo' && (
+        <HelpCicloScreen onBackToHome={goHome} />
+      )}
     </div>
   );
 }

--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -1,0 +1,232 @@
+import React, { useState } from 'react';
+import {
+  ArrowLeft, ChevronDown, ChevronRight, Sprout, Camera, MapPin, Bug, Apple,
+  MessageCircle, Wrench,
+} from 'lucide-react';
+
+/**
+ * Sub-vista del Manual: cómo usar Chagra (FAQs reorganizadas).
+ *
+ * Reorganización 2026-05-08: 6 temas en lugar de 12 secciones planas.
+ * Tono migrado a "tú" cercano (P1). "Reportar bug" dentro de FAQs (no
+ * cuarto botón). "Field test cases" + "Novedades mayo 2026" salieron
+ * del Manual público (movidos a Chagra-strategy/ops/ + CHANGELOG.md).
+ */
+
+// eslint-disable-next-line no-unused-vars -- Icon SE USA en JSX, eslint react-jsx detection falla con destructuring rename
+const Section = ({ icon: Icon, title, children, defaultOpen = false, isNew = false, action = null }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={`border rounded-xl bg-slate-900/60 overflow-hidden transition-all ${isNew ? 'border-emerald-700/60 shadow-[0_0_18px_rgba(16,185,129,0.18)]' : 'border-slate-800'}`}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className="w-full p-3 flex items-center gap-3 hover:bg-slate-800/60 active:bg-slate-800 text-left min-h-[56px]"
+      >
+        <span className={`shrink-0 inline-flex items-center justify-center ${open ? 'animate-pulse' : ''}`}>
+          <Icon size={20} className="text-emerald-400" />
+        </span>
+        <span className="text-base font-bold text-white flex-1">{title}</span>
+        {isNew && (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-bold bg-emerald-500/20 text-emerald-300 border border-emerald-600/40 animate-pulse">
+            ✨ NUEVO
+          </span>
+        )}
+        {open ? <ChevronDown size={18} className="text-slate-400" /> : <ChevronRight size={18} className="text-slate-400" />}
+      </button>
+      {open && (
+        <div className="px-4 pb-4 pt-1 text-sm text-slate-300 leading-relaxed space-y-2">
+          {children}
+          {action && (
+            <button
+              type="button"
+              onClick={action.onClick}
+              className="mt-3 w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-emerald-500/15 hover:bg-emerald-500/25 active:bg-emerald-500/35 text-emerald-300 hover:text-emerald-100 border border-emerald-700/50 font-bold text-sm transition-colors min-h-[44px]"
+            >
+              {action.label} <ChevronRight size={16} />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
+  // Helper que cierra el manual y navega al flow real (CTA híbrida).
+  const quickAction = (label, route) => ({
+    label,
+    onClick: () => {
+      if (typeof onNavigate === 'function') onNavigate(route);
+    },
+  });
+
+  // Si hay 0 plantas activas, abrir "Inicio rápido" por default. Si ya tiene
+  // plantas, todo cerrado para no abrumar (P2 anti-ladrillo).
+  // Sin acceso al store aquí — usamos defaultOpen=false simple, el operador
+  // expande lo que necesite. Si queremos heurística first-time user en el
+  // futuro, pasar `plantsCount` como prop.
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      {/* Sub-header con back to home del Manual */}
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2 shrink-0 border-b border-slate-800/60 bg-slate-950/60">
+        <button
+          type="button"
+          onClick={onBackToHome}
+          aria-label="Volver al Manual"
+          className="p-2 -ml-2 rounded-lg active:bg-slate-800 min-h-[40px] min-w-[40px] flex items-center justify-center"
+        >
+          <ArrowLeft size={20} className="text-amber-400" />
+        </button>
+        <p className="text-xs uppercase tracking-wider text-amber-400/80 font-bold">Manual</p>
+        <ChevronRight size={14} className="text-slate-600" />
+        <p className="text-xs font-bold text-amber-200">Cómo usar Chagra</p>
+      </div>
+
+      <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-3">
+        <p className="text-sm text-slate-300 leading-relaxed">
+          Toca cada tema para abrir o cerrar. Si algo no está aquí, usa el botón flotante 💬 para reportarlo.
+        </p>
+
+        {/* 1. Inicio rápido */}
+        <Section icon={Sprout} title="🌱 Inicio rápido (primera vez)" action={quickAction('Crear primera planta', 'plant_asset')}>
+          <ol className="list-decimal pl-5 space-y-1.5">
+            <li>Toca el botón <strong className="text-purple-400">+</strong> arriba (header) para registrar tu primera planta.</li>
+            <li>Busca la especie escribiendo (ej. &ldquo;gulpa&rdquo; encuentra Gulupa). Chagra autocompleta estrato, gremio y producción.</li>
+            <li>Si tienes foto, súbela desde la cámara o galería.</li>
+            <li>Marca la ubicación: toca mapa o &ldquo;Mi ubicación&rdquo;.</li>
+            <li>Guarda. Aparece en <strong>Activos → Plantas</strong>.</li>
+          </ol>
+          <div className="mt-3 p-3 rounded-lg bg-emerald-900/20 border border-emerald-800/40">
+            <p className="text-[11px] font-bold text-emerald-300 uppercase mb-1">Por qué a veces crea N plantas y a veces 1</p>
+            <ul className="text-xs text-slate-300 space-y-1 list-disc pl-4 leading-relaxed">
+              <li><strong className="text-emerald-300">Individual</strong>: frutales, café, plátano, aromáticas, tubérculos. Cada planta merece hoja de vida propia.</li>
+              <li><strong className="text-amber-300">Agregado</strong>: hortalizas en cama, cereales, abonos verdes. Se manejan por conjunto.</li>
+            </ul>
+            <p className="text-[11px] text-slate-400 italic mt-2">En el formulario aparece &ldquo;Agrupar siembra&rdquo; o &ldquo;Registrar individualmente&rdquo; si quieres cambiar el default.</p>
+          </div>
+          <p className="text-xs text-slate-500 italic mt-2">
+            ¿Sin red? La app funciona offline. Tus datos se sincronizan cuando vuelva la conexión.
+          </p>
+        </Section>
+
+        {/* 2. Foto + IA */}
+        <Section icon={Camera} title="📸 Foto + IA por foto" action={quickAction('Crear planta con foto', 'plant_asset')}>
+          <p><strong>Al crear planta:</strong> el botón cámara abre tu cámara o galería. La foto queda en la hoja de vida de esa planta.</p>
+          <p><strong>Adjuntar a evento existente</strong>: entra al evento desde Bitácora → sección &ldquo;Adjuntar foto a este evento&rdquo;. Útil para documentar después.</p>
+
+          <div className="mt-3 p-3 rounded-lg bg-emerald-900/15 border border-emerald-800/30">
+            <p className="text-emerald-300 font-bold text-sm mb-1">🌱 Foto guía por especie</p>
+            <ul className="text-xs text-slate-300 list-disc pl-5 space-y-1 leading-relaxed">
+              <li>Tu primera foto de cada especie queda como referencia visual cada vez que abras el form de la misma especie.</li>
+              <li>Si nunca tomaste foto, ves un placeholder verde con &ldquo;Agrega una foto&rdquo;. No es error: es invitación.</li>
+              <li>Las fotos NO se comparten con otras fincas (privacidad). Solo tú las ves en tu cuenta.</li>
+              <li>Las fotos se comprimen automáticamente a JPEG ≤500KB para no saturar el almacenamiento.</li>
+            </ul>
+          </div>
+
+          <div className="mt-3 p-3 rounded-lg bg-amber-900/15 border border-amber-800/30">
+            <p className="text-amber-300 font-bold text-sm mb-1">🧬 IA por foto (BETA)</p>
+            <p className="text-xs text-slate-300 leading-relaxed">Dos funciones, ambas marcadas <strong className="text-amber-300">BETA</strong>:</p>
+            <ul className="text-xs text-slate-300 list-disc pl-5 space-y-1 mt-2 leading-relaxed">
+              <li><strong>Diagnóstico de enfermedades</strong>: en Bitácora → entrada con foto → botón &ldquo;Analizar foto con IA&rdquo;. Detecta enfermedades, deficiencias, score de salud.</li>
+              <li><strong>Identificar especie por foto</strong>: en SpeciesSelect → cámara. IA propone especie + alternativas. Confianza ≥70% auto-selecciona.</li>
+              <li>Si el modelo local no responde, usa <strong>Consultar IA externa</strong> en plant detail (genera prompt para Gemini/ChatGPT/Claude).</li>
+            </ul>
+            <p className="text-[11px] text-slate-400 italic mt-2">
+              Requiere conexión al stack IA local (Ollama gemma3:4b en alpha). Si no está disponible, sale mensaje con opción reintentar.
+            </p>
+          </div>
+        </Section>
+
+        {/* 3. Zonas y ubicación */}
+        <Section icon={MapPin} title="📍 Zonas y ubicación" action={quickAction('Ver mapa de la finca', 'mapa')}>
+          <p>Tus plantas viven dentro de <strong>zonas</strong> (parcelas, camas, invernaderos). Antes de plantar muchas, crea las zonas:</p>
+          <ol className="list-decimal pl-5 space-y-1">
+            <li>Activos → tab <strong>&ldquo;Zonas&rdquo;</strong> (icono mapa) → +</li>
+            <li>Nombre (ej. &ldquo;Casa los Sitios&rdquo;) + tipo (parcela / cama / invernadero)</li>
+            <li>Define el polígono en el mapa o captura punto GPS</li>
+          </ol>
+          <p>Después al crear plantas, selecciona esa zona como contenedor.</p>
+          <p className="text-xs text-slate-500 italic mt-2">
+            <strong>Brave + GPS</strong>: si el mapa abre &ldquo;desubicado&rdquo;, Brave Shields puede estar bloqueando GPS preciso. Toca el escudo en la barra → desactiva &ldquo;Block fingerprinting&rdquo; para chagra.guatoc.co.
+          </p>
+        </Section>
+
+        {/* 4. Plagas y cosechas */}
+        <Section icon={Bug} title="🐛 Plagas y 🍎 cosecha">
+          <p className="font-bold text-emerald-200">Reportar plaga / invasora</p>
+          <p>Toca menú principal → <strong>&ldquo;Plagas&rdquo;</strong>. Selecciona la especie invasora del catálogo, captura foto y geolocalización.</p>
+          <p>Después de guardar te aparece una pantalla con <strong>sugerencias de especies nativas para reemplazar</strong>. Toca &ldquo;Sembrar aquí&rdquo; y vas al flow de siembra precargado con la nativa + las coordenadas del invasor.</p>
+
+          <p className="font-bold text-emerald-200 mt-3">Registrar cosecha</p>
+          <p>Activos → selecciona la planta → en la card aparece &ldquo;Registrar cosecha&rdquo;. Captura cantidad cosechada (kg / unidades) + fecha. Se agrega como log de cosecha a la hoja de vida.</p>
+          <p>También por voz: &ldquo;coseché 5 kilos de gulupas&rdquo; con el FAB micrófono.</p>
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={quickAction('Reportar plaga', 'reportar_invasora').onClick}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-amber-500/15 hover:bg-amber-500/25 text-amber-300 border border-amber-700/50 font-bold text-xs min-h-[40px]"
+            >
+              <Bug size={14} /> Reportar plaga
+            </button>
+            <button
+              type="button"
+              onClick={quickAction('Registrar cosecha', 'cosechar').onClick}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-emerald-500/15 hover:bg-emerald-500/25 text-emerald-300 border border-emerald-700/50 font-bold text-xs min-h-[40px]"
+            >
+              <Apple size={14} /> Registrar cosecha
+            </button>
+          </div>
+        </Section>
+
+        {/* 5. Reportar bug / sugerir mejora — incluido aquí (no cuarto botón) */}
+        <Section icon={MessageCircle} title="💬 Reportar bug o sugerir mejora">
+          <p>Botón flotante 💬 abajo a la <strong>derecha</strong>, siempre visible. Puedes:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Escribir texto explicando qué pasó</li>
+            <li>Grabar audio (botón 🎤 dentro del modal): &ldquo;hice click acá y pasó X&rdquo;, sin tipear con manos sucias</li>
+            <li>Ambos: texto + audio</li>
+          </ul>
+          <p>Tu feedback queda guardado localmente y se sincroniza después.</p>
+          <p className="text-xs text-slate-500 italic mt-2">
+            Cada reporte importa: la app aprende contigo. Si algo es confuso, decirlo es la forma más rápida de arreglarlo.
+          </p>
+        </Section>
+
+        {/* 6. Problemas comunes */}
+        <Section icon={Wrench} title="🔧 Problemas comunes">
+          <div className="space-y-3">
+            <div>
+              <p className="font-bold text-amber-300">📍 GPS no encuentra mi ubicación</p>
+              <p className="text-xs text-slate-400 leading-relaxed">El mapa centra automático al abrir el modal. Si tarda más de 15s o cae en error, toca &ldquo;Reintentar&rdquo;. En Brave: revisa Shields fingerprinting.</p>
+            </div>
+            <div>
+              <p className="font-bold text-amber-300">🎤 Voz no transcribe</p>
+              <p className="text-xs text-slate-400 leading-relaxed">Verifica permiso de micrófono (iOS: Ajustes → Safari → Micrófono → chagra.guatoc.co → Permitir). Necesita conexión activa al servidor de transcripción.</p>
+            </div>
+            <div>
+              <p className="font-bold text-amber-300">📷 La foto no aparece tras adjuntarla</p>
+              <p className="text-xs text-slate-400 leading-relaxed">Recarga la pantalla, IndexedDB puede tardar en flush. Si persiste, repórtalo via 💬.</p>
+            </div>
+            <div>
+              <p className="font-bold text-amber-300">🌱 Creé planta y no aparece en la zona</p>
+              <p className="text-xs text-slate-400 leading-relaxed">Verifica que la zona esté seleccionada como &ldquo;contenedora&rdquo; en el formulario. En vista &ldquo;Activos → Plantas → Todas&rdquo; aparecen sin filtro.</p>
+            </div>
+            <div>
+              <p className="font-bold text-amber-300">⚠️ Sin red en campo</p>
+              <p className="text-xs text-slate-400 leading-relaxed">Todo funciona offline. Tus datos se sincronizan automáticamente cuando vuelvas a estar online. Indicador en la barra superior.</p>
+            </div>
+          </div>
+        </Section>
+
+        <p className="text-[11px] text-slate-600 text-center mt-4 italic leading-relaxed">
+          Manual v2.0 · Rediseño 2026-05-08 · Colombia es el país de la belleza.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/components/HelpVozScreen.jsx
+++ b/src/components/HelpVozScreen.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { ArrowLeft, Mic, Ear, BrainCircuit, CheckCircle2, ChevronRight } from 'lucide-react';
+
+/**
+ * Sub-vista del Manual: cómo usar la voz. Híbrido tutorial + CTA "Probar
+ * voz ahora" que navega al módulo voz real (P5: tutoriales con CTA directo).
+ * Tono "tú" cercano (P1).
+ */
+export default function HelpVozScreen({ onBackToHome, onNavigate }) {
+  const goVoz = () => {
+    if (typeof onNavigate === 'function') onNavigate('voz');
+  };
+
+  const steps = [
+    {
+      n: 1,
+      icon: Mic,
+      title: 'Toca el micrófono FAB',
+      body: 'Está abajo a la izquierda, siempre visible. Lo encuentras en cualquier pantalla menos cuando ya estás dentro del módulo de voz.',
+    },
+    {
+      n: 2,
+      icon: Ear,
+      title: 'Habla natural',
+      body: 'No tienes que hablar como robot. Di lo que sembraste como si le contaras a un amigo: "sembré 5 tomates en el invernadero" o "puse 30 lechugas en la cama uno".',
+    },
+    {
+      n: 3,
+      icon: BrainCircuit,
+      title: 'Chagra entiende y pregunta',
+      body: 'Whisper transcribe + IA extrae cantidad, especie y zona. Si algo queda dudoso te muestra una pantalla de revisión donde corriges antes de guardar.',
+    },
+    {
+      n: 4,
+      icon: CheckCircle2,
+      title: 'Confirma y listo',
+      body: 'Si todo está bien, toca confirmar. El registro va a tu finca. Si era una siembra, además te llega una sugerencia de plan de alimentación para esa planta.',
+    },
+  ];
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      {/* Sub-header con back to home del Manual */}
+      <div className="px-4 pt-3 pb-2 flex items-center gap-2 shrink-0 border-b border-slate-800/60 bg-slate-950/60">
+        <button
+          type="button"
+          onClick={onBackToHome}
+          aria-label="Volver al Manual"
+          className="p-2 -ml-2 rounded-lg active:bg-slate-800 min-h-[40px] min-w-[40px] flex items-center justify-center"
+        >
+          <ArrowLeft size={20} className="text-emerald-400" />
+        </button>
+        <p className="text-xs uppercase tracking-wider text-emerald-400/80 font-bold">Manual</p>
+        <ChevronRight size={14} className="text-slate-600" />
+        <p className="text-xs font-bold text-emerald-200">Cómo usar la voz</p>
+      </div>
+
+      <main className="flex-1 p-4 max-w-2xl mx-auto w-full pb-12 flex flex-col gap-4">
+        <div className="flex items-start gap-3">
+          <span className="shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-emerald-700/40 border border-emerald-500/50">
+            <Mic size={26} className="text-emerald-300" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-2xl font-black text-emerald-100 leading-tight">Habla y registra</h2>
+            <p className="text-sm text-slate-300 leading-relaxed mt-1">
+              La voz es la forma más rápida de registrar tu finca cuando tienes manos sucias o estás caminando entre matas.
+            </p>
+          </div>
+        </div>
+
+        {/* CTA principal arriba — operador puede saltar al módulo directo */}
+        <button
+          type="button"
+          onClick={goVoz}
+          className="rounded-2xl bg-gradient-to-br from-emerald-600 to-emerald-700 hover:from-emerald-500 hover:to-emerald-600 active:scale-[0.99] transition-all p-5 text-left flex items-center gap-3 min-h-[80px] shadow-lg border border-emerald-400/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+        >
+          <span className="shrink-0 inline-flex items-center justify-center w-12 h-12 rounded-xl bg-white/15 border border-white/30">
+            <Mic size={24} className="text-white" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-base font-black text-white leading-tight">Prueba la voz ahora</p>
+            <p className="text-xs text-emerald-100/90 mt-0.5">Si quieres saltarte el tutorial y ver cómo funciona</p>
+          </div>
+          <ChevronRight size={22} className="shrink-0 text-white" />
+        </button>
+
+        {/* Steps */}
+        <div className="flex flex-col gap-2 mt-2">
+          <p className="text-[11px] uppercase tracking-wider text-emerald-400/80 font-bold">Cómo funciona, paso a paso</p>
+          {steps.map((s) => {
+            const Icon = s.icon;
+            return (
+              <div key={s.n} className="rounded-xl bg-slate-900/70 border border-slate-800 p-4 flex gap-3">
+                <span className="shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-900/40 border border-emerald-700/50">
+                  <Icon size={20} className="text-emerald-300" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-bold text-emerald-100 leading-tight">
+                    <span className="text-emerald-400 font-black mr-1.5">{s.n}.</span>
+                    {s.title}
+                  </p>
+                  <p className="text-xs text-slate-300 leading-relaxed mt-1">{s.body}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Ejemplos */}
+        <div className="rounded-xl bg-emerald-950/60 border border-emerald-800/40 p-4 mt-2">
+          <p className="text-[11px] uppercase tracking-wider text-emerald-400 font-bold mb-2">Ejemplos que entiende bien</p>
+          <ul className="text-sm text-slate-200 space-y-1.5 leading-relaxed">
+            <li>&ldquo;Sembré 5 tomates en el invernadero&rdquo;</li>
+            <li>&ldquo;Planté 100 cafés en la parcela tres&rdquo;</li>
+            <li>&ldquo;Puse 10 fresas y 30 lechugas en la cama uno&rdquo; <span className="text-emerald-400/70 text-[11px]">(multi-especie OK)</span></li>
+            <li>&ldquo;Coseché 3 kilos de gulupas&rdquo;</li>
+            <li>&ldquo;Aplicué bocashi a la mata de tomate de ayer&rdquo;</li>
+          </ul>
+        </div>
+
+        {/* Cantidad importa — concepto load-bearing */}
+        <div className="rounded-xl bg-slate-900/70 border border-amber-700/40 p-4">
+          <p className="text-[11px] uppercase tracking-wider text-amber-400 font-bold mb-2">Por qué la cantidad importa</p>
+          <p className="text-sm text-slate-200 leading-relaxed">
+            <strong className="text-emerald-200">1 café = 1 planta individual</strong> con su hoja de vida y cosechas. <strong className="text-emerald-200">100 cafés = 100 plantas individuales</strong>. <strong className="text-amber-200">50 lechugas = 1 cama agregada con qty 50</strong>: las hortalizas viven en grupo. Chagra decide el modo según la especie, pero puedes cambiarlo en la pantalla de revisión.
+          </p>
+        </div>
+
+        {/* Sin red */}
+        <p className="text-xs text-slate-500 italic mt-2 leading-relaxed">
+          ¿Sin red en campo? La voz funciona offline igual. La transcripción local guarda el audio y reintenta cuando vuelves a tener señal.
+        </p>
+
+        {/* CTA bottom secundaria — backup si scrolleó hasta abajo */}
+        <button
+          type="button"
+          onClick={goVoz}
+          className="mt-4 rounded-xl bg-emerald-700/30 hover:bg-emerald-600/40 active:bg-emerald-700/50 border border-emerald-600/50 transition-colors p-3 text-center font-bold text-emerald-200 min-h-[48px]"
+        >
+          <Mic size={16} className="inline mr-1.5" /> Probar voz
+        </button>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumen

Operador 2026-05-08:
> 'el boton de ayuda esta muy cargado pensemos usando las herramientas de la aplicacion como brindar ayuda al usuario quiero que el modulo de voz sea primero segundo como usar chagra las faqs el otro el ciclo quiero botones grandes manejando principio en campo'

Antes: monolito 364 líneas con 12 secciones colapsables apiladas → 'ladrillo'.
Después: router interno con 3 sub-vistas grandes (≥80px botones) priorizadas según el operador: voz → uso → ciclo.

## Estructura

```
HelpManual.jsx (router)
 ├─ home    → HelpHomeScreen.jsx (3 botones grandes)
 ├─ voz     → HelpVozScreen.jsx (tutorial híbrido + CTA 'Probar voz ahora')
 ├─ uso     → HelpUsoScreen.jsx (6 FAQs reorganizadas, incluye Reportar bug)
 └─ ciclo   → HelpCicloScreen.jsx (wrapper de HelpCycleSection accordion)
```

Sub-componentes nuevos:
- `src/components/HelpHomeScreen.jsx`
- `src/components/HelpVozScreen.jsx`
- `src/components/HelpUsoScreen.jsx`
- `src/components/HelpCicloScreen.jsx`

`HelpManual.jsx` reescrito como router (`useState 'home'|'voz'|'uso'|'ciclo'`) + header compartido + HelpTipCard siempre visible.

## Tono — migrado a 'tú' cercano

Operador autorizó cambio de principio (anula decisión 2026-05-04 'usted'):
> 'sobre el usted o tu prefiero el tu por cercania a idea es que la aplicacion no sea un ladrillo agregalo como principio de la auditoria de chagra'

Memoria `feedback_colombian_tone.md` reescrita (REVERSAL).
Nuevo doc `Workspace/Chagra-strategy/ops/chagra-ux-principles.md` con 6 principios:
- **P1** Tono `tú` cercano + anti-ladrillo
- **P2** Densidad — pantalla en campo, no escritorio
- **P3** Offline-first sin disculpas
- **P4** Conversacional pero verificable
- **P5** Ayuda discoverable, no monolítica
- **P6** Identidad sin postureo

## Movimientos (autorizados, regla 5 'antes de eliminar pregúntame')

- ✅ "Field test cases para Lili" → `Workspace/Chagra-strategy/ops/field-test-cases.md` (PR **separada** en strategy, scope distinto)
- ✅ "Novedades mayo 2026" + cambios recientes → `Chagra/CHANGELOG.md` (formato keep-a-changelog, estándar OSS)

NO eliminé contenido sin tener un destino claro. Texto preservado, solo cambia de ubicación.

## CTAs híbridas (P5)

Los botones "Probar voz ahora" / "Crear primera planta" / "Reportar plaga" / "Registrar cosecha" cierran el manual y navegan al flow real (`onNavigate(route)`). Sin friction lectura→ejecución.

## Test plan

- [x] ESLint: 0 errors, 0 warnings en los 5 componentes
- [ ] Manual mobile: tap ❓ → home con 3 botones grandes visible
- [ ] Tap 'Cómo usar la voz' → tutorial híbrido + CTA verde 'Probar voz ahora'
- [ ] Tap CTA 'Probar voz ahora' → cierra manual + navega a /voz
- [ ] Tap 'Cómo usar Chagra' → 6 FAQs cerradas por default, expandir cada una funciona
- [ ] Tap 'Aprende sembrando' → HelpCycleSection accordion (PR #201)
- [ ] Volver al home con back inline en cada sub-vista
- [ ] Cerrar manual entero con back top-bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)