### PR TITLE
fix(help): badge 'Borrador' amigable + sanitize jerga DR-034 user-facing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.62",
+  "version": "0.12.63",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v105';
+const CACHE_NAME = 'chagra-v106';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CycleContentRenderer.jsx
+++ b/src/components/CycleContentRenderer.jsx
@@ -1,5 +1,25 @@
 import React, { useEffect, useState } from 'react';
-import { Sprout, AlertTriangle, Users, Beaker, Mountain, BookOpen, Loader2 } from 'lucide-react';
+import { Sprout, AlertTriangle, Users, Beaker, Mountain, BookOpen, Loader2, FileEdit } from 'lucide-react';
+
+/**
+ * Sanitiza strings de fuente para ocultar jerga interna DR-034 al usuario
+ * (audiencia incluye niños 11+ usando Chagra como herramienta educativa).
+ * Elimina patterns como "(gap G-X DR-034)" / " DR-034" / "(extrapolación a X)"
+ * preservando el resto. Si queda vacío post-cleanup, retorna null.
+ */
+function cleanSource(src) {
+  if (!src || typeof src !== 'string') return null;
+  let out = src
+    .replace(/\(gap\s+G-[0-9A-Z]+\s+DR-\d+\)/gi, '')
+    .replace(/\bDR-\d+\b/gi, '')
+    .replace(/\(extrapolaci[oó]n[^)]*\)/gi, '(datos extrapolados)')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([.,;])/g, '$1')
+    .replace(/^[\s·,;]+|[\s·,;]+$/g, '')
+    .trim();
+  if (!out) return null;
+  return out;
+}
 
 const FREQ_BADGE = {
   muy_comun: { label: 'Muy común', cls: 'bg-rose-900/40 text-rose-300 border-rose-800/60' },
@@ -193,13 +213,16 @@ export default function CycleContentRenderer({ slug, onClose }) {
       {Array.isArray(data.biopreparados) && data.biopreparados.length > 0 && (
         <Block icon={Beaker} title="Biopreparados" tone="emerald">
           <ul className="space-y-1 text-xs">
-            {data.biopreparados.map((b, i) => (
-              <li key={i}>
-                <span className="font-bold text-emerald-300">{b.nombre}</span>
-                <span className="text-slate-400">, {b.uso}</span>
-                {b.fuente && <span className="text-[10px] text-slate-600 italic"> · {b.fuente}</span>}
-              </li>
-            ))}
+            {data.biopreparados.map((b, i) => {
+              const fuenteClean = cleanSource(b.fuente);
+              return (
+                <li key={i}>
+                  <span className="font-bold text-emerald-300">{b.nombre}</span>
+                  <span className="text-slate-400">, {b.uso}</span>
+                  {fuenteClean && <span className="text-[10px] text-slate-600 italic"> · {fuenteClean}</span>}
+                </li>
+              );
+            })}
           </ul>
         </Block>
       )}
@@ -213,15 +236,20 @@ export default function CycleContentRenderer({ slug, onClose }) {
         </Block>
       )}
 
-      {data.curacion_status && (
-        <div className="p-2 rounded-lg bg-slate-900 border border-slate-800 text-[10px] text-slate-500 italic">
-          <p>Estado: <strong className="text-slate-400">{data.curacion_status}</strong></p>
-          {Array.isArray(data.curacion_pendiente) && data.curacion_pendiente.length > 0 && (
-            <ul className="mt-1 list-disc pl-4 space-y-0.5">
-              {data.curacion_pendiente.map((p, i) => <li key={i}>{p}</li>)}
-            </ul>
-          )}
-          {data.convergencia_dr_034 && <p className="mt-1">{data.convergencia_dr_034}</p>}
+      {data.curacion_status && data.curacion_status !== 'curated' && (
+        <div className="mt-1 p-3 rounded-xl bg-amber-900/15 border border-amber-700/40 flex items-start gap-2">
+          <FileEdit size={14} className="text-amber-400 shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap mb-1">
+              <span className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-amber-300 bg-amber-900/40 border border-amber-700/50 rounded-full px-2 py-0.5">
+                📝 Borrador
+              </span>
+              <span className="text-[10px] text-amber-400/80 font-bold uppercase tracking-wider">Pendiente curación técnica</span>
+            </div>
+            <p className="text-xs text-amber-100 leading-relaxed">
+              Estos datos están basados en literatura agroecológica colombiana revisada y rangos conservadores. Falta validarlos con un agrónomo en campo. Si los aplicas, observa con cuidado y registra en bitácora — tus notas aportan a la curación.
+            </p>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Bug operador 2026-05-08

> 'pienso que niños de 11 años van a usar chagra como herramienta educativa y veo que hay muchas cosas que tienen valor pero esa información aunque entiendo el sentido es confusa podemos usar la etiqueta borrador para todo que indica pendiente de curacion tecnica'

> 'extrapolacion (gap G-B DR-034) esto tiene informacion de DR que dudo mucho algun lector entienda o encuentre valor'

## Causa

`CycleContentRenderer.jsx:216-226` mostraba directo al usuario:
- `Estado: draft_3_llm_consolidated`
- `Validacion agronomo Cundinamarca/Antioquia... (gap G-A DR-034)`
- `3/3 LLMs convergen. Divergencia menor en tier...`

Y en el bloque biopreparados, el campo `fuente` mostraba:
- `extrapolacion (gap G-B DR-034)`
- `Boudet et al. 2017 (extrapolación a chonto Colombia con cuidado)`

Esa metadata es interna del corpus DR-034 (proceso de validación entre LLMs + queue de curación con agrónomos). Para el usuario regular y especialmente para audiencia infantil-educativa (Julieta 11 años), es jerga sin valor.

## Fix

### 1. Función `cleanSource()` para sanitizar fuente bibliográfica

```js
function cleanSource(src) {
  if (!src || typeof src !== 'string') return null;
  let out = src
    .replace(/\(gap\s+G-[0-9A-Z]+\s+DR-\d+\)/gi, '')
    .replace(/\bDR-\d+\b/gi, '')
    .replace(/\(extrapolaci[oó]n[^)]*\)/gi, '(datos extrapolados)')
    // ... limpieza spaces residuales
    .trim();
  return out || null;
}
```

Preserva citas académicas legítimas (Boudet 2017, Cabrera 2018) que SÍ aportan. Quita los `(gap G-X DR-034)` que son ruido interno.

### 2. Badge 'Borrador' amigable reemplaza bloque metadata footer

**Antes**: `Estado: draft_3_llm_consolidated` + lista de gaps técnicos.

**Después**:
```
📝 Borrador · Pendiente curación técnica

Estos datos están basados en literatura agroecológica colombiana
revisada y rangos conservadores. Falta validarlos con un agrónomo
en campo. Si los aplicas, observa con cuidado y registra en bitácora
— tus notas aportan a la curación.
```

Honesto sobre el estado borrador, sin jerga. Invita al operador a contribuir desde Bitácora (anti pasividad). Tono `tú` cercano (P1).

### 3. JSON intacto (regla 5 'antes de eliminar pregúntame')

Los campos `curacion_status` / `curacion_pendiente` / `convergencia_dr_034` siguen en los JSON corpus para uso interno + agentes. Solo cambia el render user-facing.

### 4. Badge solo visible cuando `curacion_status !== 'curated'`

Cuando una especie pase a estado `curated` (post validación agrónomo), el badge desaparece automáticamente.

## Aplicación de principios UX

- **P1** tono `tú` cercano ✓
- **P2** densidad — eliminar jerga ruido ✓
- **P4** conversacional pero verificable — admite borrador con honestidad ✓
- **P6** identidad sin postureo — `'3/3 LLMs convergen'` era postureo técnico ✓

## Test plan

- [x] ESLint: 0 errors, 0 warnings
- [ ] Manual: abrir HelpCycleSection → expandir lechuga
  - Bloque metadata jerga ya NO aparece
  - Badge '📝 Borrador' amber sí aparece con mensaje educativo
  - En biopreparados, citas académicas sí (Boudet 2017) pero `(gap G-X DR-034)` no
- [ ] Repetir para fresa + tomate_chonto

🤖 Generated with [Claude Code](https://claude.com/claude-code)