### PR TITLE
fix(api): sanitize HTML body en errores FarmOS+Ollama (leak operador)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.64",
+  "version": "0.12.65",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v107';
+const CACHE_NAME = 'chagra-v108';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -54,9 +54,15 @@ export const fetchFromFarmOS = async (endpoint, options = {}) => {
         if (typeof window !== 'undefined') window.location.hash = '#login';
       }
       const errorDetail = await response.text().catch(() => '');
-      const error = new Error(`FarmOS API Error ${response.status}: ${response.statusText} - ${errorDetail}`);
+      // Sanitize body antes de pegarlo al .message — Drupal/cloudflared a
+      // veces devuelven HTML completo (página 404/502) que bloatea el toast
+      // del operador (bug 2026-05-08).
+      const { buildCleanErrorMessage } = await import('./sanitizeError.js');
+      const ctype = response.headers?.get?.('content-type') || '';
+      const cleanMsg = buildCleanErrorMessage('FarmOS API Error', response.status, response.statusText, errorDetail, ctype);
+      const error = new Error(cleanMsg);
       error.status = response.status;
-      error.detail = errorDetail;
+      error.detail = errorDetail;  // raw preservado para debug en console
       throw error;
     }
     return await response.json();

--- a/src/services/ollamaStream.js
+++ b/src/services/ollamaStream.js
@@ -58,7 +58,11 @@ export async function streamOllama(url, body, onToken, { signal, onDone } = {}) 
   if (!response.ok) {
     let detail = '';
     try { detail = await response.text(); } catch (_) { /* noop */ }
-    throw new Error(`Ollama ${response.status}: ${detail.slice(0, 200)}`);
+    // Sanitize body antes de exponer — cloudflared 502 / Ollama down devuelven
+    // HTML completo que el slice(200) leakea al UI (bug HelpVoiceQuestion 2026-05-08).
+    const { buildCleanErrorMessage } = await import('./sanitizeError.js');
+    const ctype = response.headers?.get?.('content-type') || '';
+    throw new Error(buildCleanErrorMessage('Ollama', response.status, response.statusText, detail, ctype));
   }
   if (!response.body) {
     throw new Error('Respuesta sin body streameable (¿buffering del proxy?)');

--- a/src/services/sanitizeError.js
+++ b/src/services/sanitizeError.js
@@ -1,0 +1,90 @@
+/**
+ * sanitizeError.js
+ *
+ * Helpers para limpiar response bodies de upstream antes de mostrarlos al
+ * usuario. Caso de uso real: cloudflared / Drupal / Ollama devuelven HTML
+ * cuando hay 404/502/etc. Si pegamos ese body al toast / banner / log
+ * persisted, el operador ve `<!DOCTYPE html> <html lang="es" dir="ltr">...`
+ * que es ruido cognitivo + leaks de implementación + viola anti-ladrillo
+ * (chagra-ux-principles P2 + P4).
+ *
+ * Bugs operador 2026-05-08:
+ *  - BitacoraEntryDetail mostraba HTML completo de página 404 Drupal/FarmOS
+ *  - HelpVoiceQuestion mostraba HTML completo de página 502 cloudflared/Ollama
+ *
+ * Estrategia:
+ *  1. Detectar si el body es HTML (starts with <!DOCTYPE / <html / contiene <body
+ *     en los primeros 500 chars). Si lo es → descartar body, devolver null.
+ *  2. Detectar si es JSON:API error (FarmOS/Drupal). Si lo es → extraer
+ *     errors[0].detail clean.
+ *  3. Detectar si es JSON simple {error: "..."} / {message: "..."} y extraer.
+ *  4. Si nada coincide → texto plano truncado a MAX_DETAIL_CHARS.
+ */
+
+const MAX_DETAIL_CHARS = 240;
+
+/**
+ * Sanitiza un response body string antes de mostrarlo al usuario.
+ * Returns clean detail string (≤240 chars) o null si el body era HTML
+ * sin info útil.
+ *
+ * @param {string|null|undefined} rawBody — response.text() crudo
+ * @param {string} [contentType] — opcional, content-type header
+ * @returns {string|null}
+ */
+export function sanitizeErrorDetail(rawBody, contentType = '') {
+  if (!rawBody || typeof rawBody !== 'string') return null;
+  const head = rawBody.slice(0, 500).trim();
+
+  const isHtml =
+    /^<!DOCTYPE/i.test(head) ||
+    /^<html\b/i.test(head) ||
+    /<body\b/i.test(head) ||
+    (contentType && /text\/html/i.test(contentType));
+
+  if (isHtml) {
+    return null;
+  }
+
+  // JSON:API spec (FarmOS/Drupal): { errors: [{ detail, title, status, ... }] }
+  if (/^\s*\{/.test(head) && (contentType.includes('json') || /"errors"|"error"|"message"|"detail"/.test(head))) {
+    try {
+      const parsed = JSON.parse(rawBody);
+      if (Array.isArray(parsed?.errors) && parsed.errors.length > 0) {
+        const first = parsed.errors[0];
+        const detail = first?.detail || first?.title || first?.message;
+        if (detail) return String(detail).slice(0, MAX_DETAIL_CHARS);
+      }
+      const directDetail = parsed?.detail || parsed?.error || parsed?.message;
+      if (directDetail) return String(directDetail).slice(0, MAX_DETAIL_CHARS);
+    } catch (_) {
+      // JSON malformado, caer a fallback texto plano
+    }
+  }
+
+  // Plain text — truncar y limpiar tags HTML residuales
+  const cleaned = rawBody
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return null;
+  return cleaned.slice(0, MAX_DETAIL_CHARS);
+}
+
+/**
+ * Construye un Error message clean a partir de status + statusText + body.
+ * Si el body es HTML descartable, devuelve solo `Error <status>: <statusText>`.
+ *
+ * @param {string} prefix — "FarmOS API Error" o "Ollama" o similar
+ * @param {number} status — HTTP status code
+ * @param {string} statusText — HTTP status text
+ * @param {string|null} rawBody — response body string
+ * @param {string} [contentType] — content-type header
+ * @returns {string}
+ */
+export function buildCleanErrorMessage(prefix, status, statusText, rawBody, contentType = '') {
+  const cleaned = sanitizeErrorDetail(rawBody, contentType);
+  const base = `${prefix} ${status}${statusText ? `: ${statusText}` : ''}`;
+  if (!cleaned) return base;
+  return `${base} — ${cleaned}`;
+}


### PR DESCRIPTION
## Bugs operador 2026-05-08

**Bug 1**: BitacoraEntryDetail (Siembra: Apio voz) mostraba HTML completo de página 404 Drupal pegado al texto:
> 'Guardado local. Pendiente de sincronización (FarmOS API Error 404: - <!DOCTYPE html> <html lang="es"...'

**Bug 2**: HelpVoiceQuestion mostraba HTML página 502 cuando cloudflared/Ollama caído:
> 'Ollama 502: <!DOCTYPE html> <!--[if lt IE 7]> <html class="no-js ie6 oldie"...'

## Causa raíz unificada

- `apiService.js:57` concatenaba `response.text()` raw al `.message` del Error: `new Error(`FarmOS API Error :  - `)`
- `ollamaStream.js:61` hacía `detail.slice(0, 200)` directo del body HTML

Ambos pegaban HTML body al UI sin sanitize.

## Fix

Nuevo `src/services/sanitizeError.js` con 2 helpers:
- `sanitizeErrorDetail(rawBody, contentType)`: detecta HTML (DOCTYPE/html/body) y descarta. Si JSON:API → `errors[0].detail`. Si JSON simple → `.detail/.error/.message`. Fallback texto plano + strip tags + truncar 240 chars.
- `buildCleanErrorMessage(prefix, status, statusText, body, ctype)`: compone mensaje clean.

Aplicado en:
- `apiService.js` — error message via `buildCleanErrorMessage`. `error.detail` raw preservado para debug console.
- `ollamaStream.js` — throw con clean message.

## Resultado UX

| Antes | Después |
|---|---|
| `FarmOS API Error 404: Not Found - <!DOCTYPE html> <html lang="es" dir="ltr"> <head>...` (2-3KB HTML) | `FarmOS API Error 404: Not Found` |
| `Ollama 502: <!DOCTYPE html> <!--[if lt IE 7]>...` | `Ollama 502: Bad Gateway` |
| `FarmOS API Error 422: ... [JSON:API body]` | `FarmOS API Error 422: Unprocessable Entity — campo X es requerido` |

## Aplicación principios

- **P2 densidad** anti-ladrillo: errores compactos, no body dump
- **P4 conversacional pero verificable**: error compresible, raw preservado en `error.detail` para devs

## Test plan

- [x] ESLint 0 errors
- [ ] Manual reproducir Bug 1: forzar 404 (e.g. revocar permisos FarmOS) → Bitácora muestra mensaje clean
- [ ] Manual reproducir Bug 2: parar Ollama (`systemctl stop ollama` en alpha) → HelpVoiceQuestion mensaje clean

## Bug 3 separado (NO incluido)

Bug 3 (NLU empty extract con frase válida 'Agregue 5 fresas, 3 y nojo y 2 apio en el invernadero.') es problema de calidad NLU qwen3.5:4b, no de UI/sanitize. Lo paso a opencode con prompt detallado en próxima ronda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)