### PR TITLE
feat(quick-wins): pre-react loader + dismiss persistente + bitácora honesty (pre-demo David)

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,70 @@
     <meta name="apple-mobile-web-app-title" content="Chagra" />
 
     <title>Chagra</title>
+
+    <!-- Pre-React loader inline (issue #121): evita flash blanco al
+         arrancar PWA fría antes de que React + Suspense pinten el
+         ChagraGrowLoader. Sale del DOM cuando React monta el root. -->
+    <style>
+      html, body { background: #020617; margin: 0; }
+      #pre-loader {
+        position: fixed; inset: 0;
+        display: flex; flex-direction: column;
+        align-items: center; justify-content: center;
+        background: #020617;
+        color: #34d399;
+        font-family: system-ui, -apple-system, sans-serif;
+        z-index: 9999;
+        transition: opacity 200ms ease-out;
+      }
+      #pre-loader .pl-emoji {
+        font-size: 48px; line-height: 1;
+        animation: pl-grow 1.6s ease-in-out infinite;
+      }
+      #pre-loader .pl-text {
+        margin-top: 14px;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: #6ee7b7;
+        opacity: 0.85;
+      }
+      @keyframes pl-grow {
+        0%, 100% { transform: scale(0.85); opacity: 0.7; }
+        50%      { transform: scale(1.05); opacity: 1; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #pre-loader .pl-emoji { animation: none; }
+      }
+    </style>
   </head>
   <body>
+    <div id="pre-loader" aria-label="Cargando Chagra">
+      <span class="pl-emoji" aria-hidden="true">🌱</span>
+      <span class="pl-text">Chagra</span>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      // Quita el pre-loader cuando React monta su primer render.
+      (function () {
+        var root = document.getElementById('root');
+        var loader = document.getElementById('pre-loader');
+        if (!root || !loader) return;
+        var done = function () {
+          loader.style.opacity = '0';
+          setTimeout(function () { loader.remove(); }, 220);
+        };
+        var obs = new MutationObserver(function () {
+          if (root.children.length > 0) {
+            obs.disconnect();
+            done();
+          }
+        });
+        obs.observe(root, { childList: true });
+        setTimeout(function () { obs.disconnect(); done(); }, 5000);
+      })();
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.65",
+  "version": "0.12.66",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v108';
+const CACHE_NAME = 'chagra-v109';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/NetworkStatusBar.jsx
+++ b/src/components/NetworkStatusBar.jsx
@@ -2,6 +2,17 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Wifi, WifiOff, RefreshCw, CheckCircle, AlertTriangle, X } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 
+// Helpers de dismiss persistente por sesión — top-level para que sean
+// estables y no requieran dependencias en useCallback.
+const dismissKey = (st, count) => `chagra:netStatus:dismissed:${st}:${count}`;
+const isDismissedInSession = (st, count) => {
+  try { return sessionStorage.getItem(dismissKey(st, count)) === '1'; }
+  catch (_) { return false; }
+};
+const markDismissedInSession = (st, count) => {
+  try { sessionStorage.setItem(dismissKey(st, count), '1'); } catch (_) { /* noop */ }
+};
+
 const STATUS = {
   ONLINE: 'online',
   OFFLINE: 'offline',
@@ -24,10 +35,10 @@ export default function NetworkStatusBar() {
 
       if (stats.isSyncing) {
         setStatus(STATUS.SYNCING);
-        setVisible(true);
+        if (!isDismissedInSession(STATUS.SYNCING, stats.pendingCount)) setVisible(true);
       } else if (!stats.isOnline) {
         setStatus(STATUS.OFFLINE);
-        setVisible(true);
+        if (!isDismissedInSession(STATUS.OFFLINE, stats.pendingCount)) setVisible(true);
       } else if (stats.pendingCount === 0 && status === STATUS.SYNCING) {
         // Transición de syncing a synced
         setSyncedCount((prev) => prev || 1);
@@ -115,6 +126,7 @@ export default function NetworkStatusBar() {
   };
   const dismiss = (e) => {
     e.stopPropagation();
+    markDismissedInSession(status, pendingCount);
     setVisible(false);
   };
 

--- a/src/components/WorkerHistory.jsx
+++ b/src/components/WorkerHistory.jsx
@@ -203,11 +203,17 @@ export default function WorkerHistory({ onBack, onEntryClick }) {
         {/* Registros Recientes (pending_transactions) */}
         {activeSection === 'recientes' && !isLoading && (
           <>
+            {/* Honesty note: por ahora esta vista solo muestra pendientes
+                offline. Próxima versión cubrirá también recientes online
+                (ver prompt opencode bitácora-disconnect-audit Parte C). */}
+            <p className="text-[11px] text-slate-500 italic px-2 py-2 leading-relaxed">
+              Por ahora muestra los registros pendientes de sincronizar offline. Si grabaste algo con conexión, ya está sincronizado y lo encuentras en <strong className="text-slate-300">Activos</strong>. Pronto verás también recientes online aquí.
+            </p>
             {pendingTx.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-12 text-slate-500">
                 <Cloud size={48} className="mb-3 opacity-30" />
                 <p className="text-lg">Sin registros pendientes</p>
-                <p className="text-sm mt-1">Los registros de esta sesión aparecerán aquí</p>
+                <p className="text-sm mt-1">Cuando registres algo sin red, aparece aquí hasta sincronizar</p>
               </div>
             ) : (
               pendingTx.map((tx, idx) => {


### PR DESCRIPTION
## 3 Quick wins pre-demo David 2026-05-08

### 1. Pre-React inline loader (issue #121)

`index.html` con `<div id="pre-loader">` — emoji 🌱 animado CSS antes de que React arranque. MutationObserver detecta primer render del root y lo remueve con fade 200ms. Fallback 5s + respeta `prefers-reduced-motion`.

### 2. NetworkStatusBar dismiss persistente por sesión

Tap X guarda flag en `sessionStorage[`chagra:netStatus:dismissed:${status}:${count}`]`. Banner NO re-aparece en el mismo state hasta que cambie (nueva pendiente entra → count cambia → flag reset).

### 3. WorkerHistory honesty note Recientes

Header explícito + empty state mejorado. Aplica P4 + P6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)