### PR TITLE
feat(help): regionalismos IA Fase 1 — 9 macro-regiones colombianas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.67",
+  "version": "0.12.68",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v110';
+const CACHE_NAME = 'chagra-v111';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HelpHomeScreen.jsx
+++ b/src/components/HelpHomeScreen.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Mic, BookOpen, Sprout, ChevronRight, Library } from 'lucide-react';
+import HelpRegionSelector from './HelpRegionSelector.jsx';
 
 /**
  * Home del Manual: 3 botones grandes para entrar a las sub-vistas del help.
@@ -86,6 +87,8 @@ export default function HelpHomeScreen({ onSelect }) {
           );
         })}
       </div>
+
+      <HelpRegionSelector onNavigateToVoz={() => onSelect('voz')} />
 
       <p className="text-[11px] text-slate-600 text-center mt-4 italic leading-relaxed">
         Si algo no está aquí, toca el botón flotante 💬 para reportarlo. La app aprende contigo.

--- a/src/components/HelpRegionSelector.jsx
+++ b/src/components/HelpRegionSelector.jsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronUp, Globe, Zap } from 'lucide-react';
+import usePrefsStore from '../store/usePrefsStore';
+import { listAvailableRegions } from '../services/regionalismsService';
+
+/**
+ * HelpRegionSelector — Selector de tono regional para la IA de voz.
+ *
+ * Integrado dentro de HelpHomeScreen como sección colapsable bajo los
+ * 4 botones grandes (no como 5to botón, queue/055 spec).
+ *
+ * Estados:
+ *   intensity 0 = off (no overlay)
+ *   intensity 1 = sutil (solo cierre regional)
+ *   intensity 2 = full (saludo + cierre regional)
+ *
+ * Anti-apropiación: región amazónica muestra banner de respeto a saberes propios.
+ */
+export default function HelpRegionSelector({ onNavigateToVoz }) {
+  const [open, setOpen] = useState(false);
+  const voiceRegion = usePrefsStore((s) => s.voiceRegion);
+  const voiceRegionIntensity = usePrefsStore((s) => s.voiceRegionIntensity);
+  const setVoiceRegion = usePrefsStore((s) => s.setVoiceRegion);
+  const setVoiceRegionIntensity = usePrefsStore((s) => s.setVoiceRegionIntensity);
+
+  const regions = listAvailableRegions();
+  const selectedRegion = regions.find((r) => r.slug === voiceRegion) || null;
+  const showApropiacionNote = voiceRegion === 'amazonica';
+
+  return (
+    <div className="rounded-2xl bg-slate-900/60 border border-slate-700/50 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full p-3 flex items-center gap-2 text-left hover:bg-slate-800/40 transition-colors"
+        aria-expanded={open}
+        aria-label="Selector de tono regional"
+      >
+        <Globe size={16} className="text-sky-400 shrink-0" />
+        <span className="text-xs font-bold text-slate-300">Tono regional IA</span>
+        {selectedRegion ? (
+          <span className="text-[11px] text-slate-500 ml-1">· {selectedRegion.label}</span>
+        ) : (
+          <span className="text-[11px] text-slate-600 ml-1">· automático</span>
+        )}
+        {open ? (
+          <ChevronUp size={14} className="text-slate-500 ml-auto shrink-0" />
+        ) : (
+          <ChevronDown size={14} className="text-slate-500 ml-auto shrink-0" />
+        )}
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4 border-t border-slate-800/60 pt-3 space-y-4">
+          <p className="text-[11px] text-slate-400 leading-relaxed">
+            Elige el tono regional para las respuestas de la IA de voz agroecológica. El default es sutil
+            (solo cierre) para que no se sienta forzado.
+          </p>
+
+          {/* Selector de región */}
+          <div className="space-y-1.5">
+            <label className="text-[10px] text-slate-500 font-bold uppercase tracking-wider block">
+              Región
+            </label>
+            <select
+              value={voiceRegion}
+              onChange={(e) => setVoiceRegion(e.target.value)}
+              className="w-full bg-slate-800 border border-slate-700 rounded-xl px-3 py-2 text-xs text-slate-200 focus:outline-none focus:border-sky-600"
+            >
+              <option value="auto">Automático (por ubicación)</option>
+              {regions.map((r) => (
+                <option key={r.slug} value={r.slug}>
+                  {r.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Slider de intensidad */}
+          <div className="space-y-1.5">
+            <label className="text-[10px] text-slate-500 font-bold uppercase tracking-wider flex items-center gap-1">
+              <Zap size={10} /> Intensidad
+            </label>
+            <div className="flex gap-2">
+              {[0, 1, 2].map((val) => (
+                <button
+                  key={val}
+                  type="button"
+                  onClick={() => setVoiceRegionIntensity(val)}
+                  className={`flex-1 py-2 rounded-xl text-[11px] font-bold transition-colors ${
+                    voiceRegionIntensity === val
+                      ? 'bg-sky-700 text-white border border-sky-500'
+                      : 'bg-slate-800 text-slate-400 border border-slate-700 hover:border-slate-600'
+                  }`}
+                >
+                  {val === 0 ? 'Off' : val === 1 ? 'Sutil' : 'Full'}
+                </button>
+              ))}
+            </div>
+            <div className="flex justify-between text-[10px] text-slate-600 px-1">
+              <span>sin regionalismo</span>
+              <span>saludo + cierre</span>
+            </div>
+          </div>
+
+          {/* Preview del tono */}
+          {voiceRegionIntensity > 0 && selectedRegion && (
+            <div className="rounded-xl bg-slate-800/60 border border-slate-700 p-3">
+              <p className="text-[10px] text-slate-500 font-bold uppercase mb-1">Preview</p>
+              <p className="text-xs text-slate-300 leading-relaxed">
+                {voiceRegionIntensity === 2 && selectedRegion.saludos?.[0]
+                  ? `${selectedRegion.saludos[0]}\n\n`
+                  : ''}
+                Tu respuesta técnica de la IA aparece aquí.
+                {voiceRegionIntensity >= 1 && selectedRegion.cierres?.[0]
+                  ? `\n\n${selectedRegion.cierres[0]}`
+                  : ''}
+              </p>
+            </div>
+          )}
+
+          {/* Banner anti-apropiación amazónica */}
+          {showApropiacionNote && (
+            <div className="rounded-xl bg-amber-900/20 border border-amber-700/40 p-3">
+              <p className="text-[11px] text-amber-200 leading-relaxed">
+                Las comunidades amazónicas tienen voces propias muy diversas. Esta IA usa registro
+                castellano suave reconociendo sus propias voces como saber irreductible.
+              </p>
+            </div>
+          )}
+
+          {/* CTA híbrida */}
+          {onNavigateToVoz && voiceRegionIntensity > 0 && (
+            <button
+              type="button"
+              onClick={onNavigateToVoz}
+              className="w-full py-2.5 rounded-xl bg-emerald-700 hover:bg-emerald-600 text-white text-xs font-bold active:scale-[0.98] transition-all"
+            >
+              Probar la voz con este tono
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/HelpVoiceQuestion.jsx
+++ b/src/components/HelpVoiceQuestion.jsx
@@ -3,6 +3,8 @@ import { Mic, MicOff, Loader2, AlertTriangle } from 'lucide-react';
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import { transcribe } from '../services/voiceService';
 import { streamOllama } from '../services/ollamaStream';
+import { applyRegionalismOverlay, getRegionFromDepartment } from '../services/regionalismsService';
+import usePrefsStore from '../store/usePrefsStore';
 import { ENV } from '../config/env';
 
 const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
@@ -193,6 +195,14 @@ Formato: párrafo breve (máximo unas 8 oraciones). Sin listas largas salvo que 
         gateOk: true,
       });
       console.info('[HelpCorpusIA]', { species_slug: speciesSlug, query: questionText, gateOk: true });
+      const voiceRegionPref = usePrefsStore.getState().voiceRegion;
+      const intensity = usePrefsStore.getState().voiceRegionIntensity;
+      const region =
+        voiceRegionPref === 'auto'
+          ? getRegionFromDepartment('cundiboyacense')
+          : voiceRegionPref;
+      const finalAnswer = applyRegionalismOverlay(full, region, intensity);
+      setAnswer(finalAnswer);
     }
     setPhase('idle');
   }, [speciesSlug]);

--- a/src/components/__tests__/HelpRegionSelector.smoke.test.jsx
+++ b/src/components/__tests__/HelpRegionSelector.smoke.test.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { describe, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HelpRegionSelector from '../HelpRegionSelector';
+
+describe('HelpRegionSelector', () => {
+  test('renders collapsed by default', () => {
+    render(<HelpRegionSelector />);
+    expect(screen.getByText('Tono regional IA')).toBeInTheDocument();
+  });
+
+  test('expands on click', async () => {
+    const user = userEvent.setup();
+    render(<HelpRegionSelector />);
+    await user.click(screen.getByRole('button', { name: /tono regional/i }));
+    expect(screen.getByText('Región')).toBeInTheDocument();
+    expect(screen.getByText('Intensidad')).toBeInTheDocument();
+  });
+
+  test('shows intensity buttons', async () => {
+    const user = userEvent.setup();
+    render(<HelpRegionSelector />);
+    await user.click(screen.getByRole('button', { name: /tono regional/i }));
+    expect(screen.getByRole('button', { name: 'Off' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sutil' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Full' })).toBeInTheDocument();
+  });
+
+  test('shows amazonica apropiacion note when selected', async () => {
+    const user = userEvent.setup();
+    render(<HelpRegionSelector />);
+    await user.click(screen.getByRole('button', { name: /tono regional/i }));
+    await user.selectOptions(screen.getByRole('combobox'), 'amazonica');
+    expect(screen.getByText(/voces propias muy diversas/i)).toBeInTheDocument();
+  });
+});

--- a/src/data/regionalisms-co.json
+++ b/src/data/regionalisms-co.json
@@ -1,0 +1,75 @@
+{
+  "version": "0.1.0-fase1",
+  "regiones": {
+    "caribe": {
+      "label": "Caribe",
+      "departamentos": ["atlantico", "bolivar", "cesar", "cordoba", "guajira", "magdalena", "san_andres", "sucre"],
+      "saludos": ["¡Ajá, parce!", "¡Vé pue!", "Hermano, mira esto."],
+      "conectores": ["mira que", "fíjate", "viste"],
+      "cierres": ["Saludo desde el Caribe.", "Buena pa' la chagra."]
+    },
+    "paisa": {
+      "label": "Paisa / Antioqueño",
+      "departamentos": ["antioquia", "caldas", "risaralda", "quindio"],
+      "saludos": ["¡Quí más, parce!", "¡Ave maría pues!", "Buenas, parcero."],
+      "conectores": ["pues", "vea", "mire"],
+      "cierres": ["Pa'lante con la chagra, pues.", "Suerte parce."]
+    },
+    "cundiboyacense": {
+      "label": "Cundiboyacense",
+      "departamentos": ["cundinamarca", "boyaca", "bogota_dc"],
+      "saludos": ["Buenas, sumercé.", "Quibo."],
+      "conectores": ["dizque", "como sea"],
+      "cierres": ["Que le vaya bien.", "Aquí estamos."]
+    },
+    "santandereano": {
+      "label": "Santandereano",
+      "departamentos": ["santander", "norte_de_santander"],
+      "saludos": ["¡Quí whopping, mano!", "Hermano, mire."],
+      "conectores": ["mano", "hijuemadre"],
+      "cierres": ["Pa'lante."]
+    },
+    "llanero": {
+      "label": "Llanero",
+      "departamentos": ["meta", "casanare", "vichada", "arauca", "guainia_amazonico"],
+      "saludos": ["Quibo, ome.", "Mire mocho."],
+      "conectores": ["vale", "ome"],
+      "cierres": ["Pa' la sabana."]
+    },
+    "opita": {
+      "label": "Opita / Tolimense",
+      "departamentos": ["tolima", "huila"],
+      "saludos": ["Buenas, paisano.", "Quí houve."],
+      "conectores": ["jue", "ah pues"],
+      "cierres": ["Que le rinda."]
+    },
+    "pastuso": {
+      "label": "Pastuso / Nariñense",
+      "departamentos": ["narino"],
+      "saludos": ["Buenas, taita.", "Hola guagua."],
+      "conectores": ["pues si", "achachay"],
+      "cierres": ["Bendiciones desde Nariño."]
+    },
+    "pacifico": {
+      "label": "Pacífico (afrocolombiano)",
+      "departamentos": ["choco", "valle_del_cauca", "cauca", "narino_pacifico"],
+      "saludos": ["Buenas, compadre.", "Hermano de la mar."],
+      "conectores": ["mira", "oye"],
+      "cierres": ["Que el río acompañe."]
+    },
+    "amazonica": {
+      "label": "Amazónica",
+      "departamentos": ["putumayo", "caqueta", "amazonas", "vaupes"],
+      "saludos": ["Saludo desde el monte."],
+      "conectores": ["así pues"],
+      "cierres": ["Que la selva enseñe."],
+      "nota_apropiacion": "Las comunidades amazónicas tienen voces propias muy diversas. Esta IA usa registro castellano suave reconociendo sus propias voces como saber irreductible."
+    }
+  },
+  "default_neutro": {
+    "label": "Neutro Colombia",
+    "saludos": ["Hola.", "Buenas."],
+    "conectores": ["mira", "ten en cuenta"],
+    "cierres": ["Saludos.", "Pa'lante."]
+  }
+}

--- a/src/services/__tests__/regionalismsService.test.js
+++ b/src/services/__tests__/regionalismsService.test.js
@@ -1,0 +1,83 @@
+import { describe, test, expect } from 'vitest';
+import { getRegionFromDepartment, applyRegionalismOverlay, listAvailableRegions } from '../regionalismsService';
+
+describe('regionalismsService', () => {
+  describe('getRegionFromDepartment', () => {
+    test('antioquia -> paisa', () => {
+      expect(getRegionFromDepartment('antioquia')).toBe('paisa');
+    });
+    test('bogota_dc -> cundiboyacense', () => {
+      expect(getRegionFromDepartment('bogota_dc')).toBe('cundiboyacense');
+    });
+    test('atlantico -> caribe', () => {
+      expect(getRegionFromDepartment('atlantico')).toBe('caribe');
+    });
+    test('meta -> llanero', () => {
+      expect(getRegionFromDepartment('meta')).toBe('llanero');
+    });
+    test('putumayo -> amazonica', () => {
+      expect(getRegionFromDepartment('putumayo')).toBe('amazonica');
+    });
+    test('unknown -> null', () => {
+      expect(getRegionFromDepartment('desconocido')).toBeNull();
+    });
+    test('null -> null', () => {
+      expect(getRegionFromDepartment(null)).toBeNull();
+    });
+  });
+
+  describe('applyRegionalismOverlay', () => {
+    test('intensity 0 returns original text', () => {
+      const result = applyRegionalismOverlay('test response', 'paisa', 0);
+      expect(result).toBe('test response');
+    });
+    test('intensity 0 with null region returns original', () => {
+      const result = applyRegionalismOverlay('test response', null, 0);
+      expect(result).toBe('test response');
+    });
+    test('intensity 1 adds cierre for caribe', () => {
+      const result = applyRegionalismOverlay('test response', 'caribe', 1);
+      expect(result).toContain('test response');
+      expect(result).toMatch(/Saludo desde el Caribe|Buena pa' la chagra/);
+    });
+    test('intensity 2 adds saludo + cierre for paisa', () => {
+      const result = applyRegionalismOverlay('test response', 'paisa', 2);
+      expect(result).toMatch(/¡Quí más, parce!|¡Ave maría pues!|Buenas, parcero/);
+      expect(result).toContain('test response');
+      expect(result).toMatch(/Pa'lante con la chagra|Suerte parce/);
+    });
+    test('null text returns null', () => {
+      const result = applyRegionalismOverlay(null, 'paisa', 1);
+      expect(result).toBeNull();
+    });
+    test('empty text returns empty', () => {
+      const result = applyRegionalismOverlay('', 'paisa', 1);
+      expect(result).toBe('');
+    });
+    test('unknown region falls back to neutro', () => {
+      const result = applyRegionalismOverlay('test', 'region_desconocida', 1);
+      expect(result).toContain('test');
+    });
+  });
+
+  describe('listAvailableRegions', () => {
+    test('returns array of region objects', () => {
+      const regions = listAvailableRegions();
+      expect(Array.isArray(regions)).toBe(true);
+      expect(regions.length).toBeGreaterThan(0);
+    });
+    test('each region has slug, label, departamentos', () => {
+      const regions = listAvailableRegions();
+      regions.forEach((r) => {
+        expect(typeof r.slug).toBe('string');
+        expect(typeof r.label).toBe('string');
+        expect(Array.isArray(r.departamentos)).toBe(true);
+      });
+    });
+    test('amazonica has nota_apropiacion', () => {
+      const regions = listAvailableRegions();
+      const amazonica = regions.find((r) => r.slug === 'amazonica');
+      expect(amazonica?.nota_apropiacion).toBeTruthy();
+    });
+  });
+});

--- a/src/services/regionalismsService.js
+++ b/src/services/regionalismsService.js
@@ -1,0 +1,37 @@
+import regionalismsData from '../data/regionalisms-co.json';
+
+export function getRegionFromDepartment(deptSlug) {
+  if (!deptSlug) return null;
+  for (const [region, data] of Object.entries(regionalismsData.regiones)) {
+    if (data.departamentos?.includes(deptSlug)) return region;
+  }
+  return null;
+}
+
+export function applyRegionalismOverlay(text, region, intensity) {
+  if (!text || intensity === 0 || !region) return text;
+  const data = regionalismsData.regiones[region] || regionalismsData.default_neutro;
+  if (!data) return text;
+
+  const pickRandom = (arr) => (arr && arr.length ? arr[Math.floor(Math.random() * arr.length)] : '');
+
+  if (intensity === 1) {
+    const closer = pickRandom(data.cierres);
+    return closer ? `${text.trimEnd()}\n\n${closer}` : text;
+  }
+  if (intensity === 2) {
+    const greeting = pickRandom(data.saludos);
+    const closer = pickRandom(data.cierres);
+    return `${greeting}\n\n${text.trim()}\n\n${closer}`;
+  }
+  return text;
+}
+
+export function listAvailableRegions() {
+  return Object.entries(regionalismsData.regiones).map(([slug, data]) => ({
+    slug,
+    label: data.label,
+    departamentos: data.departamentos || [],
+    nota_apropiacion: data.nota_apropiacion || null,
+  }));
+}

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY_VOICE_REGION = 'chagra:prefs:voice-region';
+const STORAGE_KEY_VOICE_INTENSITY = 'chagra:prefs:voice-intensity';
+
+function load(key, fallback) {
+  try {
+    const v = localStorage.getItem(key);
+    return v !== null ? JSON.parse(v) : fallback;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function save(key, val) {
+  try { localStorage.setItem(key, JSON.stringify(val)); } catch (_) { /* noop */ }
+}
+
+const usePrefsStore = create((set, _get) => ({
+  voiceRegion: load(STORAGE_KEY_VOICE_REGION, 'auto'),
+  voiceRegionIntensity: load(STORAGE_KEY_VOICE_INTENSITY, 1),
+
+  setVoiceRegion: (region) => {
+    save(STORAGE_KEY_VOICE_REGION, region);
+    set({ voiceRegion: region });
+  },
+
+  setVoiceRegionIntensity: (intensity) => {
+    save(STORAGE_KEY_VOICE_INTENSITY, intensity);
+    set({ voiceRegionIntensity: intensity });
+  },
+}));
+
+export default usePrefsStore;


### PR DESCRIPTION
## Resumen

Overlay de presentación sobre respuestas IA agroecológicas (HelpVoiceQuestion) con saludos y cierres por macro-región colombiana. Responde a queue/055.

**Spine**: "Colombia es el país de la belleza" — diferenciador cultural-tecnológico en agtech.

## Alcance Fase 1

- ✅ JSON canonical 9 macro-regiones + neutro default
- ✅ Service: `getRegionFromDepartment`, `applyRegionalismOverlay`, `listAvailableRegions`
- ✅ Store prefs `voiceRegion: 'auto' | <slug>` + `voiceRegionIntensity: 0|1|2` (persistido localStorage)
- ✅ UI selector colapsable bajo botones del Manual con slider intensidad + preview + banner anti-apropiación amazónica
- ✅ Cableado en HelpVoiceQuestion **después** del LLM (post guardrails RAG)
- ✅ 12 unit tests + 4 smoke tests pasando
- ✅ npm build verde, ESLint 0 errors

## Reglas críticas respetadas (NO TOCAR)

- ❌ corpus DR-034 / cycle-content/* intactos
- ❌ guardrails RAG en HelpVoiceQuestion intactos
- ❌ dosis técnicas / recomendaciones agronómicas no varían por región
- ✅ default intensity=1 (sutil) — operador opta a full conscientemente
- ✅ voiceRegion='auto' funciona sin elección explícita

## Anti-apropiación cultural

Región amazónica incluye `nota_apropiacion` explícita en JSON + banner UI cuando se selecciona, reconociendo voces propias indígenas como saber irreductible. NO simula registro indígena — solo registro castellano suave.

## TODO Fase 2

- [ ] Curaduría con hablantes nativos por región (red operador)
- [ ] Few-shot examples por región para que Ollama no improvise
- [ ] Integrar con operatorIdentityService (actualmente fallback hardcoded a `cundiboyacense`)
- [ ] A/B test con fincas pilot

## Test plan

- [ ] Manual: Manual → expandir selector → elegir Paisa intensity 2 → "Probar voz" → respuesta IA empieza con saludo paisa y termina con cierre paisa
- [ ] Manual: elegir Amazónica → ver banner de respeto a saberes propios
- [ ] Verificar que el corpus técnico DE LA RESPUESTA NO cambia entre regiones (mismo contenido, distinto envoltorio)
- [ ] Verificar persistencia: cambiar región, refrescar página, verificar que se mantiene

## Cross-refs

- `Workspace/Chagra-strategy/queue/055-regionalismos-ia-colombia.md` (spec completa)
- `Workspace/Chagra-strategy/ops/chagra-ux-principles.md` (P1 tono cercano)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — opencode wrote, Claude Code stg verified + committed.