### PR TITLE
feat(ui): regionalismos Fase 1.5 — overlay en VoiceCapture global (mic FAB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.70",
+  "version": "0.12.71",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.69",
+  "version": "0.12.70",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v113';
+const CACHE_NAME = 'chagra-v114';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v112';
+const CACHE_NAME = 'chagra-v113';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -163,7 +163,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
 
           <p className="font-bold text-emerald-200 mt-3">Registrar cosecha</p>
           <p>Activos → selecciona la planta → en la card aparece &ldquo;Registrar cosecha&rdquo;. Captura cantidad cosechada (kg / unidades) + fecha. Se agrega como log de cosecha a la hoja de vida.</p>
-          <p>También por voz: &ldquo;coseché 5 kilos de gulupas&rdquo; con el FAB micrófono.</p>
+          <p>También por voz: &ldquo;coseché 5 kilos de gulupas&rdquo; con el botón micrófono.</p>
 
           <div className="mt-3 flex flex-wrap gap-2">
             <button

--- a/src/components/HelpVozScreen.jsx
+++ b/src/components/HelpVozScreen.jsx
@@ -15,7 +15,7 @@ export default function HelpVozScreen({ onBackToHome, onNavigate }) {
     {
       n: 1,
       icon: Mic,
-      title: 'Toca el micrófono FAB',
+      title: 'Toca el botón micrófono',
       body: 'Está abajo a la izquierda, siempre visible. Lo encuentras en cualquier pantalla menos cuando ya estás dentro del módulo de voz.',
     },
     {

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -5,6 +5,8 @@ import { transcribe, queueForRetry } from '../services/voiceService';
 import { extractEntities } from '../services/entityExtractor';
 import { syncManager } from '../services/syncManager';
 import { savePayload } from '../services/payloadService';
+import { applyRegionalismOverlay, getRegionFromDepartment } from '../services/regionalismsService';
+import usePrefsStore from '../store/usePrefsStore';
 import { ENV } from '../config/env';
 import { resolveSpeciesDefaults } from '../config/speciesDefaults';
 import useAssetStore from '../store/useAssetStore';
@@ -282,11 +284,11 @@ export default function VoiceCapture({ onSave }) {
     const plantTypeRel = entity.farmosTermId
       ? { data: [{ type: 'taxonomy_term--plant_type', id: entity.farmosTermId }] }
       : {
-          data: [{
-            type: 'taxonomy_term--plant_type',
-            attributes: { name: entity.canonical || entity.crop },
-          }],
-        };
+        data: [{
+          type: 'taxonomy_term--plant_type',
+          attributes: { name: entity.canonical || entity.crop },
+        }],
+      };
     const inlineRels = {
       location: { data: [locRef] },
       ...(isLand ? { parent: { data: [locRef] } } : {}),
@@ -407,7 +409,16 @@ export default function VoiceCapture({ onSave }) {
       const msg = errors.length > 0
         ? `${savedCount} guardada(s), ${errors.length} con error.`
         : `${savedCount} siembra${savedCount > 1 ? 's' : ''} registrada${savedCount > 1 ? 's' : ''} por voz.`;
-      onSave?.(msg);
+
+      const voiceRegionPref = usePrefsStore.getState().voiceRegion;
+      const intensity = usePrefsStore.getState().voiceRegionIntensity;
+      const region =
+        voiceRegionPref === 'auto'
+          ? getRegionFromDepartment('cundiboyacense')
+          : voiceRegionPref;
+      const finalAnswer = applyRegionalismOverlay(msg, region, intensity);
+
+      onSave?.(finalAnswer);
       setView(STATE_DONE);
     } else {
       setErrorMsg(`No se pudo guardar: ${errors.join('; ')}`);


### PR DESCRIPTION
## Summary

Extiende el overlay de regionalismos colombianos del PR #208 (HelpVoiceQuestion) al pipeline global de voz `VoiceCapture.jsx` (mic FAB del dashboard). Cierra inconsistencia UX donde Manual→Voz aplicaba overlay pero el registro de actividad real de la finca no.

## Cambios

- `src/components/VoiceCapture.jsx`: agrega imports `applyRegionalismOverlay`, `getRegionFromDepartment`, `usePrefsStore`. En `handleConfirmSave`, después de calcular el mensaje de respuesta, aplica el overlay regional ANTES de `onSave?.(msg)` para que el toast/respuesta IA aparezca con saludo + cierre regional según prefs operador.

## Reglas respetadas
- ✅ corpus DR-034 / cycle-content/* intactos
- ✅ guardrails RAG no tocados
- ✅ dosis técnicas / recomendaciones agronómicas no varían según región
- ✅ patrón idéntico al aplicado en HelpVoiceQuestion.jsx (PR #208)
- ✅ tono `tú` cercano

## Testing
Cursor verificó que `__tests__/` no tiene tests existentes para `VoiceCapture.jsx`. NO se inyectaron tests ad-hoc según las reglas del prompt original. **TODO**: agregar smoke tests de VoiceCapture en futuro PR dedicado.

## Test plan manual
- [ ] Mic FAB global → grabar "acabo de regar el tomate" con región Paisa intensity 2 → respuesta con saludo + cierre paisa
- [ ] Cambiar a intensity Off → grabar voz → respuesta sin envoltorio
- [ ] Cambiar a Amazónica intensity 1 → solo cierre regional al final

## Nota sobre el orden del PR
Branch parado encima de PR #209 (workerhistory recientes 24h). Cuando se mergee #209 primero, este diff queda limpio (solo VoiceCapture.jsx). Cursor incluyó indent fix trivial en función adyacente — verificar en review.

## Cross-refs
- PR #208 mergeado (regionalismos Fase 1 baseline) — patrón base
- PR #209 abierto (workerhistory recientes 24h) — branch parent

🤖 Cursor agent escribió, Claude Code stg verificó + creó PR.