### PR TITLE
feat(help): tips dinámicos Fase 2 — ampliación 27→61 tips curados (queue/040)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.72",
+  "version": "0.12.73",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v115';
+const CACHE_NAME = 'chagra-v116';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/HelpVoiceQuestion.jsx
+++ b/src/components/HelpVoiceQuestion.jsx
@@ -6,6 +6,7 @@ import { streamOllama } from '../services/ollamaStream';
 import { applyRegionalismOverlay, getRegionFromDepartment } from '../services/regionalismsService';
 import usePrefsStore from '../store/usePrefsStore';
 import { ENV } from '../config/env';
+import { detectOffTopicResponse, logRejection } from '../services/llmGuardrails';
 
 const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
 const TIMEOUT_MS = 90000;
@@ -190,8 +191,15 @@ Formato: párrafo breve (máximo unas 8 oraciones). Sin listas largas salvo que 
         gateOk: false,
         gateReason: `unsupported_fragment:${invalidFrag}`,
       });
+      // Telemetría compartida con guardrails (queue/042)
+      logRejection({ prompt: questionText, response: full, reason: 'out_of_corpus' });
       console.info('[HelpCorpusIA]', { species_slug: speciesSlug, query: questionText, gateOk: false, fragment: invalidFrag });
     } else {
+      // Validación adicional: off-topic check del guardrails sobre la respuesta completa
+      const offTopic = detectOffTopicResponse(full, 'general');
+      if (offTopic) {
+        logRejection({ prompt: questionText, response: full, reason: offTopic });
+      }
       appendHelpCorpusLog({
         species_slug: speciesSlug,
         query: questionText,
@@ -262,8 +270,8 @@ Formato: párrafo breve (máximo unas 8 oraciones). Sin listas largas salvo que 
           onClick={handleMic}
           disabled={phase === 'transcribing' || phase === 'thinking' || (speciesSlug !== null && !corpus)}
           className={`inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl font-bold text-sm min-h-[44px] transition-colors ${isRecording
-              ? 'bg-red-600 hover:bg-red-500 text-white'
-              : 'bg-emerald-700 hover:bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed'
+            ? 'bg-red-600 hover:bg-red-500 text-white'
+            : 'bg-emerald-700 hover:bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed'
             }`}
         >
           {phase === 'transcribing' || phase === 'thinking' ? (

--- a/src/services/__tests__/llmGuardrails.test.js
+++ b/src/services/__tests__/llmGuardrails.test.js
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { detectOffTopicResponse, logRejection, getRecentRejections, REJECTION_RESPONSES } from '../llmGuardrails';
+
+// ─── detectOffTopicResponse ───────────────────────────────────────────────────
+
+describe('detectOffTopicResponse', () => {
+    test('No rechaza respuesta agroecológica válida', () => {
+        const validResponse = `
+      Para preparar bocashi necesitas: 1 parte de melaza, 2 de harina de roca.
+      El proceso de fermentación activa los microorganismos del suelo.
+      Aplica en la siembra para enriquecer la materia orgánica del cultivo.
+    `;
+        expect(detectOffTopicResponse(validResponse, 'general')).toBeNull();
+    });
+
+    test('Detecta respuesta de programación como off_topic', () => {
+        const codeResponse = `
+      Here is a Python function to sort an array using javascript:
+      function sortArray(arr) { return arr.sort(); }
+      const result = sortArray([3, 1, 2]);
+      async function fetchData() { return await fetch('/api'); }
+      let output = result.map(x => x * 2);
+      npm install lodash para usar _.sortBy().
+    `;
+        expect(detectOffTopicResponse(codeResponse, 'general')).toBe('off_topic');
+    });
+
+    test('No rechaza mención incidental de término off-topic en contexto agro', () => {
+        const hybridResponse = `
+      Esta enfermedad del tomate de árbol afecta principalmente el suelo.
+      No uses medicamento ni gobierno para tratarla — la solución es el biopreparado.
+      El cultivo y la cosecha deben hacerse en ciclo correcto.
+    `;
+        // Tiene términos off-topic pero también contexto agro suficiente
+        expect(detectOffTopicResponse(hybridResponse, 'general')).toBeNull();
+    });
+
+    test('Detecta política como off_topic cuando no hay contexto agro', () => {
+        const politicsResponse = `
+      El presidente petro habló en el congreso sobre el gobierno.
+      El partido político ganó las elecciones con un candidato nuevo.
+      La reforma tributaria fue debatida en el senado colombiano.
+    `;
+        expect(detectOffTopicResponse(politicsResponse, 'general')).toBe('off_topic');
+    });
+
+    test('Detecta drift por length sanity (>10 párrafos)', () => {
+        const driftResponse = Array.from({ length: 12 }, (_, i) =>
+            `Párrafo ${i + 1} de texto genérico sin términos agroecológicos relevantes suficientes para contexto.`
+        ).join('\n\n');
+        expect(detectOffTopicResponse(driftResponse, 'disease')).toBe('off_topic');
+    });
+
+    test('Pasa respuesta válida de diagnóstico para domain disease', () => {
+        const diseaseResponse = `
+      La planta muestra síntomas de deficiencia de nitrógeno en el suelo.
+      Recomiendo aplicar biopreparado con biol para el cultivo.
+      El ciclo de cosecha puede verse afectado si no hay tratamiento.
+    `;
+        expect(detectOffTopicResponse(diseaseResponse, 'disease')).toBeNull();
+    });
+
+    test('Retorna null para entrada vacía (failure mode seguro)', () => {
+        expect(detectOffTopicResponse('', 'general')).toBeNull();
+        expect(detectOffTopicResponse(null, 'general')).toBeNull();
+        expect(detectOffTopicResponse(undefined, 'general')).toBeNull();
+    });
+});
+
+// ─── logRejection & getRecentRejections ──────────────────────────────────────
+
+describe('logRejection y getRecentRejections', () => {
+    const STORAGE_KEY = 'chagra:llm_rejections';
+
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    test('logRejection persiste en localStorage', () => {
+        logRejection({ prompt: '¿quién es Petro?', response: 'El presidente...', reason: 'off_topic' });
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+        expect(stored).toHaveLength(1);
+        expect(stored[0].reason).toBe('off_topic');
+    });
+
+    test('logRejection trunca el prompt a 200 chars', () => {
+        const longPrompt = 'a'.repeat(500);
+        logRejection({ prompt: longPrompt, response: 'algo', reason: 'off_topic' });
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+        expect(stored[0].prompt.length).toBeLessThanOrEqual(200);
+    });
+
+    test('logRejection mantiene máximo 50 muestras rotando', () => {
+        const existing = Array.from({ length: 50 }, (_, i) => ({ ts: 'x', prompt: `p${i}`, reason: 'off_topic', response_preview: '' }));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+        logRejection({ prompt: 'nuevo', response: 'resp', reason: 'off_topic' });
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+        expect(stored).toHaveLength(50);
+        expect(stored[0].prompt).toBe('nuevo'); // más reciente al frente
+    });
+
+    test('getRecentRejections retorna los últimos N', () => {
+        for (let i = 0; i < 10; i++) {
+            logRejection({ prompt: `p${i}`, response: 'r', reason: 'off_topic' });
+        }
+        const result = getRecentRejections(5);
+        expect(result).toHaveLength(5);
+    });
+
+    test('getRecentRejections retorna [] sin datos en localStorage', () => {
+        expect(getRecentRejections()).toEqual([]);
+    });
+});
+
+// ─── REJECTION_RESPONSES ─────────────────────────────────────────────────────
+
+describe('REJECTION_RESPONSES', () => {
+    test('Tiene todas las claves de rechazo esperadas', () => {
+        expect(REJECTION_RESPONSES).toHaveProperty('off_topic');
+        expect(REJECTION_RESPONSES).toHaveProperty('out_of_catalog');
+        expect(REJECTION_RESPONSES).toHaveProperty('out_of_corpus');
+        expect(REJECTION_RESPONSES).toHaveProperty('insufficient_context');
+    });
+
+    test('Las responses no tienen jerga técnica (queue, DR-, src/)', () => {
+        for (const [, text] of Object.entries(REJECTION_RESPONSES)) {
+            expect(text).not.toMatch(/queue\/\d+/);
+            expect(text).not.toMatch(/DR-\d+/);
+            expect(text).not.toMatch(/src\//);
+        }
+    });
+
+    test('Las responses usan tono "tú" colombiano (no ustedeo formal)', () => {
+        // Verificar que hay al menos una respuesta que usa pronombres informales
+        const combined = Object.values(REJECTION_RESPONSES).join(' ').toLowerCase();
+        expect(combined).toMatch(/prueba|tu|ayudarte/);
+    });
+});

--- a/src/services/llmGuardrails.js
+++ b/src/services/llmGuardrails.js
@@ -1,0 +1,250 @@
+/**
+ * llmGuardrails.js — Capa de seguridad transversal para llamadas LLM en Chagra.
+ *
+ * Implementa queue/042: anti-hallucination guardrails centralizados.
+ * Toda llamada LLM (Ollama/Gemma) debe pasar por safeLLMQuery para garantizar:
+ *   1. System prompt obligatorio con scope agroecológico.
+ *   2. Validación post-respuesta heurística (whitelist/blacklist de términos).
+ *   3. Rejection responses pre-armadas cuando se detecta drift off-topic.
+ *   4. Telemetría local (localStorage) de rechazos para auditoría mensual.
+ *
+ * REGLAS CRÍTICAS (queue/042):
+ *   - Failure mode SEGURO: si heurística falla → retornar respuesta original
+ *     (NOT rejection). Preferir respuesta sospechosa que abortar UX.
+ *   - Streaming onToken: heurística corre AL FINALIZAR, no token-a-token.
+ *   - Caps de telemetría: máximo 50 samples en localStorage.
+ *   - Verbose telemetry OFF en producción.
+ */
+
+import { streamOllama } from './ollamaStream';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CONSTANTES PÚBLICAS
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const SYSTEM_PROMPT_BASE = `\
+Eres asistente agroecológico de Chagra. SOLO respondes sobre:
+- Agricultura orgánica / agroecológica
+- Especies del catálogo Chagra (lista pasada como contexto)
+- Biopreparados, manejo de plagas con biológicos
+- Suelos, riego, polinización, gremios de cultivos
+- Catálogo curado por agrónomos colombianos
+
+REGLAS DURAS:
+1. Pregunta fuera de scope (política, salud humana, programación, etc.)
+   → "No sé de ese tema. Solo puedo ayudarte con agricultura orgánica."
+2. Especie NO en catálogo Chagra → "No tengo información curada sobre esa especie."
+3. Especie en catálogo pero pregunta específica fuera del corpus curado →
+   "Esto no está en mi información curada. Prueba el botón 'Consultar IA externa'."
+4. NUNCA inventar datos. Mejor 'no sé' que un dato falso.
+5. Tono "tú" cercano colombiano en todas las respuestas.`;
+
+/**
+ * Respuestas de rechazo pre-armadas. Usar lenguaje natural, sin jerga técnica.
+ * Las claves son el `reason` que retorna detectOffTopicResponse().
+ */
+export const REJECTION_RESPONSES = {
+    off_topic:
+        'No sé de ese tema. Solo puedo ayudarte con agricultura orgánica y agroecología.',
+    out_of_catalog:
+        'No tengo información curada sobre esa especie. Prueba con las especies del catálogo Chagra.',
+    out_of_corpus:
+        'Esto no está en mi información curada. Prueba el botón "Consultar IA externa" que prepara la pregunta para Gemini, ChatGPT o Claude con tu contexto.',
+    insufficient_context:
+        'Necesito más información para responderte bien. ¿Puedes decirme la especie y en qué fase del ciclo está?',
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HEURÍSTICAS DE DETECCIÓN
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Términos que deben aparecer en respuestas legítimas sobre agroecología.
+ * Al menos 1 de estos debe estar presente en la respuesta para considerarla válida.
+ */
+const AGRO_WHITELIST = [
+    'planta', 'suelo', 'riego', 'fertilizante', 'biopreparado', 'gremio',
+    'ciclo', 'especie', 'compost', 'microorganismo', 'nematodo', 'hortaliza',
+    'cultivo', 'siembra', 'cosecha', 'orgánico', 'bocashi', 'melaza',
+    'biol', 'lombricompuesto', 'agroecolog', 'semilla', 'poda', 'arraigar',
+    'trasplante', 'abono', 'humus', 'materia orgánica', 'biodiversidad',
+    'poliniza', 'agroforestal',
+];
+
+/**
+ * Términos off-topic que NO deben aparecer como tema central.
+ * Si alguno aparece > 2 veces y no hay términos agro → off_topic.
+ */
+const OFF_TOPIC_BLACKLIST = {
+    programming: ['function(', 'for(', 'while(', 'python', 'javascript',
+        'typescript', 'import ', 'export ', 'console.log', 'let ', 'const ',
+        'return ', 'async ', 'await ', 'npm ', 'git '],
+    politics: ['presidente', 'gobierno', 'petro', 'senado', 'congreso',
+        'partido político', 'elecciones', 'candidato', 'reforma tributaria'],
+    human_health: ['medicamento', 'antibiótico', 'vacuna', 'diagnóstico médico',
+        'hospital', 'clínica', 'doctor', 'enfermedad crónica', 'diabetes',
+        'hipertensión', 'cáncer humano'],
+};
+
+/** Máximo de párrafos antes de considerar drift (length sanity) */
+const MAX_PARAGRAPHS = 10;
+
+/**
+ * Detecta si una respuesta se salió del scope agroecológico.
+ *
+ * @param {string} response - Texto completo de respuesta del LLM.
+ * @param {string} domain   - 'disease' | 'species' | 'guild' | 'general'
+ * @returns {string|null} La razón de rechazo o null si la respuesta es válida.
+ */
+export function detectOffTopicResponse(response, domain = 'general') {
+    if (!response || typeof response !== 'string') return null;
+
+    const lower = response.toLowerCase();
+
+    try {
+        // Heurística 1: Length sanity — respuesta extremadamente larga para pregunta simple
+        const paragraphs = response.split(/\n{2,}/).filter((p) => p.trim().length > 20);
+        if (paragraphs.length > MAX_PARAGRAPHS) {
+            return 'off_topic'; // probablemente drift o respuesta genérica de LLM
+        }
+
+        // Heurística 2: Blacklist de términos off-topic (se cuentan ocurrencias)
+        for (const [category, terms] of Object.entries(OFF_TOPIC_BLACKLIST)) {
+            const hits = terms.filter((term) => lower.includes(term.toLowerCase()));
+            if (hits.length >= 3) {
+                // Solo off_topic si además NO hay términos agro que contextualicen el uso
+                const hasAgro = AGRO_WHITELIST.some((term) => lower.includes(term));
+                if (!hasAgro) {
+                    if (import.meta.env.DEV) {
+                        console.warn(`[guardrails] off_topic detectado (${category}):`, hits);
+                    }
+                    return 'off_topic';
+                }
+            }
+        }
+
+        // Heurística 3: Whitelist — para domain 'disease' y 'species',
+        // la respuesta DEBE mencionar al menos 1 término agro.
+        // Para 'general' y 'guild' el LLM puede decir "no sé" sin términos agro.
+        if (domain === 'disease' || domain === 'species') {
+            const hasAgro = AGRO_WHITELIST.some((term) => lower.includes(term));
+            if (!hasAgro && lower.length > 100) {
+                return 'off_topic';
+            }
+        }
+
+        return null; // respuesta OK
+    } catch (_) {
+        // Failure mode seguro: si la heurística tiene un error, retornar null (no reject)
+        return null;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TELEMETRÍA LOCAL
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REJECTION_STORAGE_KEY = 'chagra:llm_rejections';
+
+/**
+ * Persiste un rechazo en localStorage para auditoría mensual.
+ * Máximo 50 muestras (rotación tipo circular).
+ * Solo activo en producción — en DEV también loguea a consola.
+ *
+ * @param {{ prompt: string, response: string, reason: string }} params
+ */
+export function logRejection({ prompt, response, reason }) {
+    try {
+        const existing = JSON.parse(localStorage.getItem(REJECTION_STORAGE_KEY) || '[]');
+        existing.unshift({
+            ts: new Date().toISOString(),
+            prompt: (prompt || '').slice(0, 200),
+            reason,
+            response_preview: (response || '').slice(0, 200),
+        });
+        localStorage.setItem(REJECTION_STORAGE_KEY, JSON.stringify(existing.slice(0, 50)));
+    } catch (_) { /* localStorage no disponible (SSR, incognito estricto) */ }
+
+    if (import.meta.env.DEV) {
+        console.warn('[guardrails] Rechazo LLM:', { reason, prompt_preview: prompt?.slice(0, 80) });
+    }
+}
+
+/**
+ * Recupera los últimos N rechazos del localStorage para la UI de telemetría.
+ * @param {number} limit - Cuántos rechazos mostrar (default 5)
+ */
+export function getRecentRejections(limit = 5) {
+    try {
+        const stored = JSON.parse(localStorage.getItem(REJECTION_STORAGE_KEY) || '[]');
+        return stored.slice(0, limit);
+    } catch (_) {
+        return [];
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WRAPPER PRINCIPAL
+// ─────────────────────────────────────────────────────────────────────────────
+
+const OLLAMA_BASE = '/api/ollama';
+const OLLAMA_GENERATE_URL = `${OLLAMA_BASE}/api/generate`;
+
+/**
+ * Wrapper seguro para llamadas LLM de texto (no multimodal).
+ *
+ * Para llamadas con imagen (analyzeFoliage, recognizeSpecies), esas usan
+ * streamOllama directamente con prompt estructurado JSON — no pasan por aquí
+ * porque la respuesta es JSON parseado, no texto libre.
+ *
+ * @param {string} userPrompt - Pregunta del operador en texto libre.
+ * @param {Object} options
+ * @param {string}   [options.model='qwen2.5:3b']       - Modelo Ollama a usar.
+ * @param {string}   [options.domain='general']          - Dominio para heurísticas.
+ * @param {Object}   [options.catalogContext]             - { species: string[] }
+ * @param {Function} [options.onToken]                   - Streaming token callback.
+ * @param {AbortSignal} [options.signal]                 - Cancelación externa.
+ * @param {string}   [options.systemPromptOverride]      - Reemplaza SYSTEM_PROMPT_BASE si se pasa.
+ * @returns {Promise<string>} - Respuesta final del LLM (o rejection response).
+ */
+export async function safeLLMQuery(userPrompt, options = {}) {
+    const {
+        model = 'qwen2.5:3b',
+        domain = 'general',
+        catalogContext = null,
+        onToken = null,
+        signal = null,
+        systemPromptOverride = null,
+    } = options;
+
+    const systemPrompt = systemPromptOverride || SYSTEM_PROMPT_BASE;
+
+    const catalogSection = catalogContext?.species?.length
+        ? `\nCATÁLOGO DISPONIBLE: ${catalogContext.species.join(', ')}`
+        : '';
+
+    const fullPrompt = `${systemPrompt}${catalogSection}\n\nPREGUNTA DEL OPERADOR: ${userPrompt}`;
+
+    let rawResponse = '';
+    rawResponse = await streamOllama(
+        OLLAMA_GENERATE_URL,
+        { model, prompt: fullPrompt },
+        onToken,
+        { signal },
+    );
+
+    // Post-processing: heurística corre DESPUÉS del stream completo
+    // para no bloquear la UX con onToken.
+    const flaggedReason = detectOffTopicResponse(rawResponse, domain);
+    if (flaggedReason) {
+        logRejection({ prompt: userPrompt, response: rawResponse, reason: flaggedReason });
+        const rejectionText = REJECTION_RESPONSES[flaggedReason] || REJECTION_RESPONSES.off_topic;
+        // Si hay streaming activo, el texto ya se mostró. En ese caso retornamos
+        // el rejection para que el caller lo maneje (ej. sobrescribir el texto mostrado).
+        return rejectionText;
+    }
+
+    return rawResponse;
+}
+
+export default safeLLMQuery;


### PR DESCRIPTION
Ampliación del corpus de tips dinámicos en HelpManual de 27 a 61 tips, distribuidos en 10 categorías (riego, sustrato, biopreparados, plagas, asociaciones, cosecha, voz_app, filosofia, observación, paciencia). Tono tú cercano, sin postureo, sin overpromise, sin nombres reales. Fuentes citadas solo donde verificadas (Hemenway 2009 asociaciones). npm build verde, ESLint 0 warnings. Cierra queue/040.