### PR TITLE
fix(workflow): runner labels match self-hosted en alpha

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -47,7 +47,7 @@ jobs:
       && (github.event.sender.login == github.repository_owner
           || github.event.sender.login == vars.CLAUDE_BOT_LOGIN)
       && github.event.pull_request.draft == true
-    runs-on: [self-hosted, alpha, claude-runner]
+    runs-on: [self-hosted, claude-runner]
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
Fix de 1 línea para que claude-code-generate.yml requiera solo [self-hosted, claude-runner]. Diagnóstico en commit body. Cierra cuello de botella del bridge bot Telegram → claude-code-runner (paso 9 que quedaba queued indefinido).