### PR TITLE
fix(workflow): if generate usa vars.OPERATOR_LOGIN

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -44,7 +44,7 @@ jobs:
     # Triple gate: label correcta + actor whitelisted + PR sigue draft.
     if: |
       github.event.label.name == 'ready-to-generate'
-      && (github.event.sender.login == github.repository_owner
+      && (github.event.sender.login == vars.OPERATOR_LOGIN
           || github.event.sender.login == vars.CLAUDE_BOT_LOGIN)
       && github.event.pull_request.draft == true
     runs-on: [self-hosted, claude-runner]


### PR DESCRIPTION
Fix bridge runner que quedaba queued indefinido por if condition que evaluaba sender.login == repository_owner (la org, no el user). Nueva var OPERATOR_LOGIN=kortux + cambio de 1 línea en if. Seguridad preservada (whitelist explícita).