### PR TITLE
fix(workflow): claude → claude-code (binary name in self-hosted runner)

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -135,11 +135,11 @@ jobs:
           OUTPUT_FILE: ${{ runner.temp }}/claude-output.json
         run: |
           set -o pipefail
-          # claude --print: modo no-interactivo, exit cuando termina.
+          # claude-code --print: modo no-interactivo, exit cuando termina.
           # --permission-mode acceptEdits: edita sin pedir approval (no hay humano).
           # --allowed-tools: whitelist explícita de tools permitidos.
           # --output-format json: log estructurado para audit.
-          claude \
+          claude-code \
             --print \
             --permission-mode acceptEdits \
             --allowed-tools "Read,Edit,Write,Bash(npm:*),Bash(git:*),Bash(gh:*),Bash(node:*),Bash(jq:*),Glob,Grep" \


### PR DESCRIPTION
## Summary
- `claude-code-generate.yml` invocaba el binario `claude`, pero el runner self-hosted expone el ejecutable como `claude-code`
- El step `Run Claude Code` fallaba en 1.7s con exit 1 sin stderr visible (bash -e abort silencioso al no hallar binario en PATH)
- Cambio: 2 líneas (1 código + 1 comentario)

## Contexto

Séptimo bug de una cadena de fallas en el bridge bot Telegram → claude-code-runner. Los 6 anteriores ya están mergeados:

| Bug | PR / Acción |
|---|---|
| 1+2 | guatoc-nixos PR #74 (openfang token + SOPS format) |
| 3 | Chagra PR #219 (runs-on labels) |
| 4 | Chagra PR #221 (`if:` con vars.OPERATOR_LOGIN) |
| 5 | Concurrency lock manual cancel |
| 6 | yaml stale en HEAD del PR de smoke test → fix vía `gh pr update-branch` |

Tras el debug en alpha hoy: el runner finalmente agarra jobs (steps 1-4 success). El step 5 `Run Claude Code` falla por el nombre del binario. Este fix es lo último que falta.

## Validación post-merge
1. `gh pr update-branch <PR-smoke-test>` para incorporar este fix al HEAD del PR de validación
2. Re-aplicar label `ready-to-generate` al PR de smoke test
3. El runner debería completar el step `Run Claude Code` (en vez de fallar en 1.7s) y avanzar a `Commit and push changes`

## Test plan
- [ ] CodeQL gate verde
- [ ] Playwright gate verde
- [ ] Post-merge: bridge bot completa end-to-end por primera vez (smoke test PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)