### PR TITLE
fix(workflow): absolute path to claude-code (PATH issue in self-hosted runner)

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -139,7 +139,11 @@ jobs:
           # --permission-mode acceptEdits: edita sin pedir approval (no hay humano).
           # --allowed-tools: whitelist explícita de tools permitidos.
           # --output-format json: log estructurado para audit.
-          claude-code \
+          # NOTA: path absoluto a /run/current-system/sw/bin/ porque el user
+          # claude-runner del systemd service tiene PATH minimal y no incluye
+          # los binarios del system profile. Workaround temporal hasta que
+          # claude-code-runner.nix agregue claude-code a services.github-runners.<n>.path.
+          /run/current-system/sw/bin/claude-code \
             --print \
             --permission-mode acceptEdits \
             --allowed-tools "Read,Edit,Write,Bash(npm:*),Bash(git:*),Bash(gh:*),Bash(node:*),Bash(jq:*),Glob,Grep" \


### PR DESCRIPTION
## Summary
- Step \`Run Claude Code\` fallaba con exit 127 (command not found) aunque Bug 7 ya corrigió el nombre del binario
- Causa: el user \`claude-runner\` del systemd service tiene PATH minimal que NO incluye \`/run/current-system/sw/bin/\` donde NixOS expone los binarios del system profile
- Fix: usar path absoluto al binario (workaround temporal)

## Bug 9 de la cadena del bridge bot

Es el segundo fix en cascada hoy. El primero (#227) corrigió \`claude\` → \`claude-code\`. Este corrige \`claude-code\` → \`/run/current-system/sw/bin/claude-code\`.

## Tradeoff aceptado

**Workaround vs fix correcto**: el fix arquitectural correcto sería extender el \`PATH\` del systemd service en guatoc-nixos (\`modules/ai/claude-code-runner.nix\`) agregando claude-code a \`services.github-runners.<name>.path\`. Eso requiere PR + merge + nixos-rebuild en alpha — más latencia.

Este PR usa path absoluto como workaround para validar el bridge end-to-end inmediatamente. Comentario inline en el yaml documenta que es temporal y pendiente revertir cuando el module NixOS se actualice.

## Test plan

- [ ] CodeQL gate verde
- [ ] Playwright gate verde
- [ ] Post-merge: \`gh pr update-branch 229\` actualiza PR de smoke test con este fix
- [ ] Re-aplicar \`ready-to-generate\` al PR #229
- [ ] Step \`Run Claude Code\` corre exitosamente (no más exit 127)
- [ ] Bridge completa end-to-end: claude-code procesa el prompt, hace push de tests, comenta en PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)