### PR TITLE
feat(workflow): pivot claude-code → opencode (free tier)

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -135,21 +135,30 @@ jobs:
           OUTPUT_FILE: ${{ runner.temp }}/claude-output.json
         run: |
           set -o pipefail
-          # claude-code --print: modo no-interactivo, exit cuando termina.
-          # --permission-mode acceptEdits: edita sin pedir approval (no hay humano).
-          # --allowed-tools: whitelist explícita de tools permitidos.
-          # --output-format json: log estructurado para audit.
-          # NOTA: path absoluto a /run/current-system/sw/bin/ porque el user
-          # claude-runner del systemd service tiene PATH minimal y no incluye
-          # los binarios del system profile. Workaround temporal hasta que
-          # claude-code-runner.nix agregue claude-code a services.github-runners.<n>.path.
-          /run/current-system/sw/bin/claude-code \
-            --print \
-            --permission-mode acceptEdits \
-            --allowed-tools "Read,Edit,Write,Bash(npm:*),Bash(git:*),Bash(gh:*),Bash(node:*),Bash(jq:*),Glob,Grep" \
-            --disallowed-tools "WebFetch,WebSearch" \
-            --output-format json \
-            < "$PROMPT_FILE" \
+          # PIVOT 2026-05-09: backend cambiado de claude-code (Anthropic) a
+          # opencode (multi-provider). Razones:
+          # - Operador no tiene balance Anthropic API pay-per-use.
+          # - Intentos previos vía litellm-proxy a GLM-4.6: GLM no soporta
+          #   tool-call format Anthropic → emite tool calls como TEXTO →
+          #   step "Commit and push" fallaba porque no había edits reales.
+          # - opencode/big-pickle (free tier opencode.ai) hace tool calls
+          #   correctos sin auth.
+          # Detalles arquitecturales: guatoc-nixos modules/ai/claude-code-runner.nix
+          # (mantiene `claude-code` en extraPackages como backup para
+          # reactivación si operador habilita billing Anthropic API).
+          #
+          # opencode run flags:
+          # --dir: working directory donde opencode opera (incluye cd to repo)
+          # --dangerously-skip-permissions: equivalente a --permission-mode acceptEdits
+          # -m opencode/big-pickle: modelo free tier opencode.ai (sin API key)
+          # --format json: streaming JSON events para audit chain
+          # message como argv positional (opencode no acepta stdin como prompt)
+          opencode run \
+            --dir "$GITHUB_WORKSPACE" \
+            --dangerously-skip-permissions \
+            -m opencode/big-pickle \
+            --format json \
+            "$(cat "$PROMPT_FILE")" \
             > "$OUTPUT_FILE"
           echo "output=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
           # Detectar pedido explícito de clarificación.


### PR DESCRIPTION
## Summary

Step \`Run Claude Code\` del workflow \`claude-code-generate.yml\` cambia de invocar \`claude-code\` (Anthropic CLI con billing pay-per-use) a \`opencode run\` (multi-provider con free tier built-in opencode.ai).

PR companion: guatoc-nixos PR #77 (agrega \`pkgs.opencode\` al PATH del runner + quita Anthropic env vars).

## Razones (cadena del bridge bot — 13 bugs encadenados resueltos hoy)

- **Bug 12**: operador no tiene balance Anthropic API pay-per-use. Plan Max OAuth no compartible al user claude-runner del runner self-hosted.
- **Pivot intermedio fallido** (claude-code → litellm-proxy → GLM-4.6 vía z.ai): GLM no soporta tool-call format Anthropic. Modelo emite tool calls como TEXTO, no como function calls reales → step \"Commit and push changes\" fallaba con \"Claude no produjo cambios\".
- **opencode/big-pickle** (free tier opencode.ai built-in): hace tool calls correctos sin auth. Validado 2026-05-09 con prompt \"Crea hello.txt con 'mundo'\" → archivo creado real con tool \`Write\`.

## Cambios

\`\`\`diff
- /run/current-system/sw/bin/claude-code \\
-   --print \\
-   --permission-mode acceptEdits \\
-   --allowed-tools \"Read,Edit,Write,Bash(npm:*),Bash(git:*),Bash(gh:*),Bash(node:*),Bash(jq:*),Glob,Grep\" \\
-   --disallowed-tools \"WebFetch,WebSearch\" \\
-   --output-format json \\
-   < \"\$PROMPT_FILE\" \\
+ opencode run \\
+   --dir \"\$GITHUB_WORKSPACE\" \\
+   --dangerously-skip-permissions \\
+   -m opencode/big-pickle \\
+   --format json \\
+   \"\$(cat \"\$PROMPT_FILE\")\" \\
    > \"\$OUTPUT_FILE\"
\`\`\`

Mapeo de flags:
| claude-code | opencode | Notas |
|---|---|---|
| \`--print\` | (default con \`run\`) | non-interactive |
| \`--permission-mode acceptEdits\` | \`--dangerously-skip-permissions\` | auto-approve permissions |
| \`--allowed-tools \"...\"\` | (no equivalente) | tradeoff documentado abajo |
| \`--disallowed-tools \"WebFetch,WebSearch\"\` | (no equivalente) | tradeoff documentado abajo |
| \`--output-format json\` | \`--format json\` | streaming JSON events |
| stdin redirect | argv positional | opencode no acepta stdin como prompt |

Path absoluto \`/run/current-system/sw/bin/\` no es necesario porque guatoc-nixos PR #77 agrega \`opencode\` al PATH del runner systemd service.

## Tradeoff: pérdida de whitelist granular de tools

opencode no expone \`--allowed-tools\` / \`--disallowed-tools\` con la sintaxis de claude-code (ej. \`Bash(npm:*)\`). Mitigaciones:

- Runner aislado por systemd: user dedicado \`claude-runner\`, \`ReadWritePaths=[/var/lib/claude-runner]\`, no \`/etc\`, no \`/home/kortux\`, no SOPS keys
- Bot opera solo sobre repo público AGPL Chagra (ADR-020 boundary anti-leak)
- Workflow timeout 20min/job, gate humano en label \`ready-to-generate\`
- Step \"Commit and push\" valida que hubo edits reales, sino falla

## Test plan post-merge

1. Mergear primero guatoc-nixos PR #77 + \`sudo nixos-rebuild switch --flake .#alpha\`
2. Mergear ESTE PR a main de Chagra
3. \`gh pr update-branch 229\` (incorporar este fix al smoke test PR)
4. \`gh pr edit 229 --remove-label ready-to-generate && sleep 3 && gh pr edit 229 --add-label ready-to-generate\` 
5. Esperar run del workflow:
   - Step \"Run Claude Code\" debe completar success (opencode invoke OK)
   - Step \"Commit and push changes\" debe completar success (big-pickle hizo edits reales al test file)
   - PR #229 recibe commit con tests unitarios para \`detectAndTruncateRepetition\`

## Rollback / reactivación a claude-code

Cuando operador habilite billing Anthropic API directa:
1. Revertir este commit (claude-code sigue en \`extraPackages\` del runner como backup en guatoc-nixos)
2. Rotar SOPS \`claude-code-anthropic-key\` al value real Anthropic
3. Re-agregar \`EnvironmentFile + ReadOnlyPaths\` en module guatoc-nixos
4. Rebuild

## Cross-refs

- guatoc-nixos PR #77 — companion (extraPackages opencode + remove Anthropic env vars)
- Memoria operador: \`~/.claude/projects/-home-kortux-Chagra/memory/reference_bridge_telegram_runner.md\` (13 bugs históricos)
- Smoke test: PR #229 (tests unitarios repetitionGuard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)