### PR TITLE
fix(lint): resolve ESLint errors blocking deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.86",
+  "version": "0.12.87",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v128';
+const CACHE_NAME = 'chagra-v129';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceTelemetryScreen.jsx
+++ b/src/components/VoiceTelemetryScreen.jsx
@@ -72,7 +72,10 @@ export default function VoiceTelemetryScreen({ onBack }) {
     setMetrics(aggregateVoiceMetrics());
   }, []);
 
-  useEffect(() => { refresh(); }, [refresh]);
+  useEffect(() => {
+    const timer = setTimeout(refresh, 0);
+    return () => clearTimeout(timer);
+  }, [refresh]);
 
   const handleExport = (format) => {
     const data = exportVoiceTelemetry(format);
@@ -292,7 +295,7 @@ export default function VoiceTelemetryScreen({ onBack }) {
   );
 }
 
-function SummaryCard({ label, value, sub, icon: Icon, color }) {
+function SummaryCard({ label, value, sub, color }) {
   return (
     <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-4 flex flex-col gap-1">
       <span className="text-[10px] text-slate-500 uppercase font-bold tracking-wider">{label}</span>


### PR DESCRIPTION
## Summary
- Arregla error `setState` síncrono en useEffect (VoiceTelemetryScreen.jsx:75)
- Remueve parámetro `icon` sin usar en SummaryCard (VoiceTelemetryScreen.jsx:295)

Estos errores bloquean el workflow de deploy.

## Testing
\`\`\`bash
npm run lint -- --max-warnings 20
\`\`\`