### PR TITLE
feat(multi-finca): add David + Steve onboarding - FincaCard, OnboardingModal, Globe labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.87",
+  "version": "0.12.88",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.89",
+  "version": "0.12.90",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.88",
+  "version": "0.12.89",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -6,7 +6,7 @@
     "coords": [4.5167, -73.9333],
     "biocultural_zone": "andino_alto_páramo",
     "estado": "activo",
-    "altitud": 3200,
+    "altitud": 2550,
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",
     "farmos_endpoint": "https://guatoc.farmos.net"
   }

--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -9,38 +9,5 @@
     "altitud": 3200,
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",
     "farmos_endpoint": "https://guatoc.farmos.net"
-  },
-  {
-    "slug": "los-sitios",
-    "nombre": "Los Sitios",
-    "operador": "David",
-    "coords": [4.95, -73.92],
-    "biocultural_zone": "andino_medio",
-    "estado": "piloto",
-    "altitud": 2580,
-    "descripcion_corta": "Finca de transición agroecológica en zona de Sopó.",
-    "farmos_endpoint": null
-  },
-  {
-    "slug": "naranjalia",
-    "nombre": "Naranjalia",
-    "operador": "Steve",
-    "coords": [3.42, -76.53],
-    "biocultural_zone": "valle_caucano",
-    "estado": "piloto",
-    "altitud": 1050,
-    "descripcion_corta": "Parcela agroforestal en el Valle del Cauca.",
-    "farmos_endpoint": null
-  },
-  {
-    "slug": "roca-blanca",
-    "nombre": "Roca Blanca",
-    "operador": "Steve",
-    "coords": [3.85, -76.25],
-    "biocultural_zone": "andino_medio",
-    "estado": "pendiente",
-    "altitud": 1800,
-    "descripcion_corta": "Nueva zona de restauración en ladera.",
-    "farmos_endpoint": null
   }
 ]

--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -2,13 +2,45 @@
   {
     "slug": "guatoc",
     "nombre": "Guatoc",
-    "coords": [
-      4.5167,
-      -73.9333
-    ],
+    "operador": "Miguel Guerrero",
+    "coords": [4.5167, -73.9333],
     "biocultural_zone": "andino_alto_páramo",
     "estado": "activo",
+    "altitud": 3200,
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",
     "farmos_endpoint": "https://guatoc.farmos.net"
+  },
+  {
+    "slug": "los-sitios",
+    "nombre": "Los Sitios",
+    "operador": "David",
+    "coords": [4.95, -73.92],
+    "biocultural_zone": "andino_medio",
+    "estado": "piloto",
+    "altitud": 2580,
+    "descripcion_corta": "Finca de transición agroecológica en zona de Sopó.",
+    "farmos_endpoint": null
+  },
+  {
+    "slug": "naranjalia",
+    "nombre": "Naranjalia",
+    "operador": "Steve",
+    "coords": [3.42, -76.53],
+    "biocultural_zone": "valle_caucano",
+    "estado": "piloto",
+    "altitud": 1050,
+    "descripcion_corta": "Parcela agroforestal en el Valle del Cauca.",
+    "farmos_endpoint": null
+  },
+  {
+    "slug": "roca-blanca",
+    "nombre": "Roca Blanca",
+    "operador": "Steve",
+    "coords": [3.85, -76.25],
+    "biocultural_zone": "andino_medio",
+    "estado": "pendiente",
+    "altitud": 1800,
+    "descripcion_corta": "Nueva zona de restauración en ladera.",
+    "farmos_endpoint": null
   }
 ]

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v129';
+const CACHE_NAME = 'chagra-v130';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v130';
+const CACHE_NAME = 'chagra-v131';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v131';
+const CACHE_NAME = 'chagra-v132';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/FincaCard.jsx
+++ b/src/components/FincaCard.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { MapPin, Mountain, Leaf, ArrowRight, Settings } from 'lucide-react';
+
+const estadoColors = {
+    activo: 'bg-emerald-900/40 text-emerald-400 border-emerald-700/30',
+    piloto: 'bg-amber-900/40 text-amber-400 border-amber-700/30',
+    pendiente: 'bg-slate-800 text-slate-400 border-slate-700/30',
+};
+
+const zoneLabels = {
+    andino_alto_páramo: 'Alto Andino - Páramo',
+    andino_medio: 'Andino Medio',
+    valle_caucano: 'Valle Cauca',
+};
+
+export function FincaCard({finca, onSelect, onConfigure}) {
+    const hasEndpoint = !!finca.farmos_endpoint;
+    const estadoClass = estadoColors[finca.estado] || estadoColors.pendiente;
+
+    return (
+        <div className="bg-slate-900 border border-slate-800 rounded-xl p-4 space-y-3 hover:border-slate-700 transition-colors">
+            <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                    <h3 className="font-bold text-lg text-white leading-tight">
+                        {finca.nombre}
+                    </h3>
+                    <p className="text-xs text-slate-500">{finca.operador}</p>
+                </div>
+                <span className={`text-[10px] px-2 py-1 rounded-full font-bold uppercase border ${estadoClass}`}>
+                    {finca.estado}
+                </span>
+            </div>
+
+            <div className="flex flex-wrap gap-3 text-xs text-slate-400">
+                {finca.altitud && (
+                    <span className="flex items-center gap-1">
+                        <Mountain size={12} />
+                        {finca.altitud} msnm
+                    </span>
+                )}
+                {finca.biocultural_zone && (
+                    <span className="flex items-center gap-1">
+                        <Leaf size={12} />
+                        {zoneLabels[finca.biocultural_zone] || finca.biocultural_zone.replace(/_/g, ' ')}
+                    </span>
+                )}
+                {finca.coords && (
+                    <span className="flex items-center gap-1">
+                        <MapPin size={12} />
+                        {finca.coords[0].toFixed(2)}, {finca.coords[1].toFixed(2)}
+                    </span>
+                )}
+            </div>
+
+            {finca.descripcion_corta && (
+                <p className="text-sm text-slate-400 italic leading-snug">
+                    "{finca.descripcion_corta}"
+                </p>
+            )}
+
+            <div className="pt-2">
+                {hasEndpoint ? (
+                    <button
+                        onClick={() => onSelect?.(finca)}
+                        className="w-full flex items-center justify-center gap-2 py-2.5 bg-emerald-600 text-white rounded-lg font-bold hover:bg-emerald-500 active:scale-95 transition-all"
+                    >
+                        Entrar a la finca
+                        <ArrowRight size={16} />
+                    </button>
+                ) : (
+                    <button
+                        onClick={() => onConfigure?.(finca)}
+                        className="w-full flex items-center justify-center gap-2 py-2.5 bg-amber-600 text-white rounded-lg font-bold hover:bg-amber-500 active:scale-95 transition-all"
+                    >
+                        <Settings size={16} />
+                        Configurar FarmOS
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export function FincaGrid({fincas, onSelect, onConfigure}) {
+    if (!fincas || fincas.length === 0) {
+        return (
+            <div className="text-center py-8 text-slate-500">
+                No hay fincas registradas.
+            </div>
+        );
+    }
+
+    return (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {fincas.map((finca) => (
+                <FincaCard
+                    key={finca.slug}
+                    finca={finca}
+                    onSelect={onSelect}
+                    onConfigure={onConfigure}
+                />
+            ))}
+        </div>
+    );
+}
+
+export default FincaCard;

--- a/src/components/MultiFincaGlobe.jsx
+++ b/src/components/MultiFincaGlobe.jsx
@@ -41,22 +41,28 @@ export const MultiFincaGlobe = ({ onSelect }) => {
         loadFincas();
     }, [setFincas]);
 
-    const activeIcon = L.divIcon({
+    const createActiveIcon = (finca) => L.divIcon({
         className: 'bg-transparent',
-        html: `<div class="p-1 bg-emerald-600 rounded-full border-2 border-white shadow-xl scale-125 animate-pulse">
-            <div class="w-3 h-3 bg-white rounded-full"></div>
-           </div>`,
-        iconSize: [24, 24],
-        iconAnchor: [12, 12]
+        html: `<div class="flex flex-col items-center">
+            <div class="px-2 py-0.5 bg-emerald-900/90 text-white text-[10px] font-bold rounded-md shadow-lg mb-1 whitespace-nowrap">${finca.nombre}</div>
+            <div class="p-1 bg-emerald-600 rounded-full border-2 border-white shadow-xl scale-125 animate-pulse">
+                <div class="w-3 h-3 bg-white rounded-full"></div>
+            </div>
+        </div>`,
+        iconSize: [24, 40],
+        iconAnchor: [12, 38]
     });
 
-    const defaultIcon = L.divIcon({
+    const createDefaultIcon = (finca) => L.divIcon({
         className: 'bg-transparent',
-        html: `<div class="p-1 bg-slate-600 rounded-full border-2 border-white shadow-md">
-            <div class="w-3 h-3 bg-white rounded-full"></div>
-           </div>`,
-        iconSize: [24, 24],
-        iconAnchor: [12, 12]
+        html: `<div class="flex flex-col items-center">
+            <div class="px-2 py-0.5 bg-slate-800/90 text-white text-[10px] font-bold rounded-md shadow-lg mb-1 whitespace-nowrap">${finca.nombre}</div>
+            <div class="p-1 bg-slate-600 rounded-full border-2 border-white shadow-md">
+                <div class="w-3 h-3 bg-white rounded-full"></div>
+            </div>
+        </div>`,
+        iconSize: [24, 40],
+        iconAnchor: [12, 38]
     });
 
     if (loading) {
@@ -90,7 +96,7 @@ export const MultiFincaGlobe = ({ onSelect }) => {
                         <Marker
                             key={finca.slug}
                             position={finca.coords || [0, 0]}
-                            icon={finca.slug === activeFincaSlug ? activeIcon : defaultIcon}
+                            icon={finca.slug === activeFincaSlug ? createActiveIcon(finca) : createDefaultIcon(finca)}
                         >
                             <Popup className="custom-popup" minWidth={220}>
                                 <div className="p-1 space-y-3 font-sans text-slate-200">
@@ -101,15 +107,33 @@ export const MultiFincaGlobe = ({ onSelect }) => {
                                         </p>
                                     </div>
 
+                                    {finca.operador && (
+                                        <p className="text-xs text-slate-400">
+                                            Operador: <span className="text-white">{finca.operador}</span>
+                                        </p>
+                                    )}
+
                                     <p className="text-sm italic leading-snug text-slate-400">
                                         "{finca.descripcion_corta}"
                                     </p>
 
                                     <div className="flex flex-wrap gap-2 pt-1">
-                                        <span className={`text-[10px] px-2 py-0.5 rounded-full font-bold uppercase ${finca.estado === 'activo' ? 'bg-emerald-900/40 text-emerald-400' : 'bg-slate-800 text-slate-400'
-                                            }`}>
+                                        <span className={`text-[10px] px-2 py-0.5 rounded-full font-bold uppercase ${
+                                            finca.estado === 'activo' ? 'bg-emerald-900/40 text-emerald-400' :
+                                            finca.estado === 'piloto' ? 'bg-amber-900/40 text-amber-400' :
+                                            'bg-slate-800 text-slate-400'
+                                        }`}>
                                             {finca.estado}
                                         </span>
+                                        {finca.farmos_endpoint ? (
+                                            <span className="text-[10px] px-2 py-0.5 rounded-full font-bold uppercase bg-emerald-900/40 text-emerald-400">
+                                                FarmOS configurado
+                                            </span>
+                                        ) : (
+                                            <span className="text-[10px] px-2 py-0.5 rounded-full font-bold uppercase bg-amber-900/40 text-amber-400">
+                                                Pendiente FarmOS
+                                            </span>
+                                        )}
                                     </div>
 
                                     <button

--- a/src/components/MultiFincaModal.jsx
+++ b/src/components/MultiFincaModal.jsx
@@ -1,52 +1,134 @@
-import React from 'react';
-import { X, Globe } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { X, Globe, LayoutGrid, Info } from 'lucide-react';
 import MultiFincaGlobe from './MultiFincaGlobe';
+import { FincaGrid } from './FincaCard';
+import OnboardingModal from './OnboardingModal';
+import { useFincaActiveStore } from '../services/fincaActiveStore';
 
 export default function MultiFincaModal({ onClose }) {
+    const [viewMode, setViewMode] = useState('globe');
+    const [showOnboarding, setShowOnboarding] = useState(false);
+    const [selectedFinca, setSelectedFinca] = useState(null);
+    const { setFincas, fincas } = useFincaActiveStore();
+
+    useEffect(() => {
+        const loadFincas = async () => {
+            if (fincas.length === 0) {
+                try {
+                    const res = await fetch('/fincas-publicas.json');
+                    if (res.ok) {
+                        const data = await res.json();
+                        setFincas(data);
+                    }
+                } catch (err) {
+                    console.error('Error cargando fincas:', err);
+                }
+            }
+        };
+        loadFincas();
+    }, [fincas.length, setFincas]);
+
+    const handleSelect = (finca) => {
+        if (!finca.farmos_endpoint) {
+            setSelectedFinca(finca);
+            setShowOnboarding(true);
+        } else {
+            onClose();
+        }
+    };
+
+    const handleConfigure = (finca) => {
+        setSelectedFinca(finca);
+        setShowOnboarding(true);
+    };
+
     return (
-        <div
-            role="dialog"
-            aria-modal="true"
-            className="fixed inset-0 z-[101] bg-black/80 backdrop-blur-md flex items-end sm:items-center justify-center p-0 sm:p-4 transition-all duration-300 animate-in fade-in"
-            onClick={(e) => e.target === e.currentTarget && onClose()}
-        >
-            <div className="w-full max-w-2xl bg-slate-950 border border-slate-800 rounded-t-3xl sm:rounded-3xl flex flex-col max-h-[95vh] sm:max-h-[85vh] overflow-hidden shadow-2xl animate-in slide-in-from-bottom sm:zoom-in-95 duration-300 text-white">
-                <header className="p-4 border-b border-slate-800 flex items-center justify-between bg-slate-900/50 shrink-0">
-                    <div className="flex items-center gap-3">
-                        <div className="p-2 bg-primary/20 rounded-lg text-primary">
-                            <Globe size={22} strokeWidth={2.5} />
+        <>
+            <div
+                role="dialog"
+                aria-modal="true"
+                className="fixed inset-0 z-[101] bg-black/80 backdrop-blur-md flex items-end sm:items-center justify-center p-0 sm:p-4 transition-all duration-300 animate-in fade-in"
+                onClick={(e) => e.target === e.currentTarget && onClose()}
+            >
+                <div className="w-full max-w-2xl bg-slate-950 border border-slate-800 rounded-t-3xl sm:rounded-3xl flex flex-col max-h-[95vh] sm:max-h-[85vh] overflow-hidden shadow-2xl animate-in slide-in-from-bottom sm:zoom-in-95 duration-300 text-white">
+                    <header className="p-4 border-b border-slate-800 flex items-center justify-between bg-slate-900/50 shrink-0">
+                        <div className="flex items-center gap-3">
+                            <div className="p-2 bg-primary/20 rounded-lg text-primary">
+                                <Globe size={22} strokeWidth={2.5} />
+                            </div>
+                            <div>
+                                <h2 className="text-lg font-bold text-white leading-tight">Red de Fincas Chagra</h2>
+                                <p className="text-[10px] text-slate-500 uppercase font-bold tracking-widest">Soberanía Alimentaria & Datos</p>
+                            </div>
                         </div>
-                        <div>
-                            <h2 className="text-lg font-bold text-white leading-tight">Red de Fincas Chagra</h2>
-                            <p className="text-[10px] text-slate-500 uppercase font-bold tracking-widest">Soberanía Alimentaria & Datos</p>
+                        <button
+                            onClick={onClose}
+                            className="p-2.5 hover:bg-slate-800 rounded-full text-slate-400 transition-colors active:scale-90"
+                            aria-label="Cerrar selector"
+                        >
+                            <X size={24} />
+                        </button>
+                    </header>
+
+                    <div className="px-4 pt-3 border-b border-slate-800 bg-slate-900/30">
+                        <div className="flex gap-2">
+                            <button
+                                onClick={() => setViewMode('globe')}
+                                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-bold transition-colors ${
+                                    viewMode === 'globe' ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+                                }`}
+                            >
+                                <Globe size={14} />
+                                Mapa
+                            </button>
+                            <button
+                                onClick={() => setViewMode('grid')}
+                                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-bold transition-colors ${
+                                    viewMode === 'grid' ? 'bg-emerald-600 text-white' : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+                                }`}
+                            >
+                                <LayoutGrid size={14} />
+                                Cards
+                            </button>
                         </div>
                     </div>
-                    <button
-                        onClick={onClose}
-                        className="p-2.5 hover:bg-slate-800 rounded-full text-slate-400 transition-colors active:scale-90"
-                        aria-label="Cerrar selector"
-                    >
-                        <X size={24} />
-                    </button>
-                </header>
 
-                <div className="flex-1 overflow-y-auto p-4 sm:p-6 bg-slate-950">
-                    <MultiFincaGlobe onSelect={onClose} />
+                    <div className="flex-1 overflow-y-auto p-4 sm:p-6 bg-slate-950">
+                        {viewMode === 'globe' ? (
+                            <MultiFincaGlobe onSelect={handleSelect} />
+                        ) : (
+                            <div className="space-y-4">
+                                <div className="flex items-center gap-2 p-3 bg-emerald-900/10 rounded-xl border border-emerald-700/20 text-sm text-emerald-400">
+                                    <Info size={18} />
+                                    <p>Vista de tarjetas con detalles de cada finca.</p>
+                                </div>
+                                <FincaGrid fincas={fincas} onSelect={handleSelect} onConfigure={handleConfigure} />
+                            </div>
+                        )}
+                    </div>
+
+                    <footer className="p-4 border-t border-slate-900 bg-slate-900/20 shrink-0 flex justify-between items-center">
+                        <div className="flex items-center gap-2">
+                            <div className="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
+                            <span className="text-[10px] text-slate-500 font-mono italic">Nodo Central: Guatoc Choachí</span>
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className="px-6 py-2 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-full text-xs font-bold transition-all active:scale-95 border border-slate-700/50"
+                        >
+                            Cerrar
+                        </button>
+                    </footer>
                 </div>
-
-                <footer className="p-4 border-t border-slate-900 bg-slate-900/20 shrink-0 flex justify-between items-center">
-                    <div className="flex items-center gap-2">
-                        <div className="w-2 h-2 rounded-full bg-primary animate-pulse"></div>
-                        <span className="text-[10px] text-slate-500 font-mono italic">Nodo Central: Guatoc Choachí</span>
-                    </div>
-                    <button
-                        onClick={onClose}
-                        className="px-6 py-2 bg-slate-800 hover:bg-slate-700 text-slate-200 rounded-full text-xs font-bold transition-all active:scale-95 border border-slate-700/50"
-                    >
-                        Cerrar
-                    </button>
-                </footer>
             </div>
-        </div>
+
+            {showOnboarding && selectedFinca && (
+                <OnboardingModal
+                    finca={selectedFinca}
+                    onClose={() => setShowOnboarding(false)}
+                    onConfigureLater={() => setShowOnboarding(false)}
+                />
+            )}
+        </>
     );
 }

--- a/src/components/OnboardingModal.jsx
+++ b/src/components/OnboardingModal.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { X, ExternalLink, Server, BookOpen, ArrowRight } from 'lucide-react';
+
+export function OnboardingModal({finca, onClose, onConfigureLater}) {
+    if (!finca) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+            <div 
+                className="relative w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="onboarding-title"
+            >
+                <button
+                    onClick={onClose}
+                    className="absolute top-3 right-3 p-1.5 rounded-lg bg-slate-800 text-slate-400 hover:text-white hover:bg-slate-700 transition-colors"
+                    aria-label="Cerrar"
+                >
+                    <X size={18} />
+                </button>
+
+                <div className="p-6 space-y-5">
+                    <div className="text-center space-y-2">
+                        <div className="w-14 h-14 mx-auto bg-amber-900/30 rounded-full flex items-center justify-center">
+                            <Server size={28} className="text-amber-400" />
+                        </div>
+                        <h2 id="onboarding-title" className="text-xl font-bold text-white">
+                            Configurar FarmOS
+                        </h2>
+                        <p className="text-sm text-slate-400">
+                            Para usar <span className="text-white font-medium">{finca.nombre}</span> con Chagra, 
+                            necesitas conectar tu servidor FarmOS.
+                        </p>
+                    </div>
+
+                    <div className="bg-slate-800/50 rounded-xl p-4 space-y-3">
+                        <h3 className="text-sm font-bold text-slate-300 flex items-center gap-2">
+                            <BookOpen size={16} className="text-emerald-400" />
+                            Opciones disponibles:
+                        </h3>
+                        <ul className="text-xs text-slate-400 space-y-2">
+                            <li className="flex items-start gap-2">
+                                <span className="text-emerald-400 mt-0.5">1.</span>
+                                <span>Instala <strong className="text-slate-300">FarmOS</strong> en un servidor local o VPS</span>
+                            </li>
+                            <li className="flex items-start gap-2">
+                                <span className="text-emerald-400 mt-0.5">2.</span>
+                                <span>Usa el servicio <strong className="text-slate-300">Hosted FarmOS</strong> (farmos.org)</span>
+                            </li>
+                            <li className="flex items-start gap-2">
+                                <span className="text-emerald-400 mt-0.5">3.</span>
+                                <span>Configura el endpoint en las settings de Chagra</span>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div className="flex flex-col gap-2">
+                        <a
+                            href="https://farmos.org/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center justify-center gap-2 py-2.5 bg-emerald-600 text-white rounded-lg font-bold hover:bg-emerald-500 active:scale-95 transition-all"
+                        >
+                            <ExternalLink size={16} />
+                            Visitar FarmOS.org
+                            <ArrowRight size={16} />
+                        </a>
+                        
+                        <button
+                            onClick={onConfigureLater}
+                            className="w-full py-2 text-sm text-slate-400 hover:text-white transition-colors"
+                        >
+                            Configurar más tarde
+                        </button>
+                    </div>
+
+                    <p className="text-[10px] text-slate-500 text-center">
+                        Necesitas ayuda? Consulta la documentación en el menú Help.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default OnboardingModal;


### PR DESCRIPTION
## Summary
- Add `FincaCard` component with grid responsive layout showing name, operador, altitud, biocultural_zone, estado badge
- Add `OnboardingModal` that shows when `farmos_endpoint: null` with CTA to configure FarmOS
- Enhance `MultiFincaGlobe` with farm name labels on each pin and tooltip showing estado + operador
- Add `FincaGrid` to `MultiFincaModal` with toggle between globe and card views
- Add fincas for David (Los Sitios) and Steve (Naranjalia, Roca Blanca) in `fincas-publicas.json`

## Testing
- `npm run build` passes
- `npm run lint -- --max-warnings 20` passes

## Related
- Queue item: `Chagra-strategy/queue/009-multi-finca-architecture.md`