### PR TITLE
feat(agent): add AgentScreen with voice + chat + memory (066)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.90",
+  "version": "0.12.91",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v132';
+const CACHE_NAME = 'chagra-v133';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/scripts/export-voice-telemetry.mjs
+++ b/scripts/export-voice-telemetry.mjs
@@ -13,7 +13,6 @@
  *   - FARMOS_URL, FARMOS_TOKEN en entorno (usar .env o variables de entorno)
  */
 
-import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
 const BiodiversidadView = lazy(() => import('./components/BiodiversidadView'));
+const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const VoiceTelemetryScreen = lazy(() => import('./components/VoiceTelemetryScreen'));
@@ -345,6 +346,8 @@ export default function App() {
         return <VoiceTelemetryScreen onBack={() => navigate('perfil')} />;
       case 'help':
         return <HelpManual onBack={() => navigate('dashboard')} onNavigate={navigate} />;
+      case 'agente':
+        return <AgentScreen onBack={() => navigate('dashboard')} />;
       default:
         return <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>;
     }

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,0 +1,280 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff } from 'lucide-react';
+import useVoiceRecorder from '../../hooks/useVoiceRecorder';
+import { transcribe } from '../../services/voiceService';
+import { addTurn, getFullHistory, getContextString } from '../../services/conversationMemory';
+import { retrieve } from '../../services/ragRetriever';
+import ChatHistory from './ChatHistory';
+import SuggestedActions from './SuggestedActions';
+import usePrefsStore from '../../store/usePrefsStore';
+import useAssetStore from '../../store/useAssetStore';
+
+const OLLAMA_URL = '/api/ollama/api/chat';
+
+const STATE_IDLE = 'idle';
+const STATE_RECORDING = 'recording';
+const STATE_THINKING = 'thinking';
+
+export default function AgentScreen({ onBack }) {
+  const operatorId = usePrefsStore((s) => s.operatorId) || 'default-operator';
+  const plants = useAssetStore((s) => s.plants);
+
+  const [messages, setMessages] = useState([]);
+  const [inputText, setInputText] = useState('');
+  const [state, setState] = useState(STATE_IDLE);
+  const [streamingContent, setStreamingContent] = useState('');
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  const [error, setError] = useState('');
+
+  const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
+  const chatEndRef = useRef(null);
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const history = await getFullHistory(operatorId, 50);
+      setMessages(history);
+    } catch (e) {
+      console.warn('[Agent] Failed to load history:', e);
+    }
+  }, [operatorId]);
+
+  useEffect(() => {
+    loadHistory();
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [loadHistory]);
+
+  const getSystemPrompt = useCallback(() => {
+    const plantNames = plants?.map((p) => p.attributes?.name).filter(Boolean).join(', ') || 'ninguna';
+    return `Eres un asistente agroecológico en Colombia. El usuario tiene estas plantas: ${plantNames}. Responde en español, sé helpful y específico. Si no sabes algo, dilo honestamente.`;
+  }, [plants]);
+
+  const callLLM = async (query, contextMemory, contextCorpus) => {
+    const systemPrompt = getSystemPrompt();
+    const corpusContext = contextCorpus.length > 0
+      ? `\n\nInformación del corpus:\n${contextCorpus.map((c) => c.text).join('\n\n')}`
+      : '';
+
+    const messages = [
+      { role: 'system', content: systemPrompt + corpusContext },
+      ...(contextMemory ? [{ role: 'user', content: contextMemory }] : []),
+      { role: 'user', content: query },
+    ];
+
+    const response = await fetch(OLLAMA_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen3.5:4b',
+        messages,
+        stream: true,
+      }),
+    });
+
+    if (!response.ok) throw new Error('LLM no disponible');
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let fullContent = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk = decoder.decode(value);
+      const lines = chunk.split('\n');
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.content) {
+              fullContent += data.content;
+              setStreamingContent(fullContent);
+            }
+          } catch {
+            // Skip malformed JSON
+          }
+        }
+      }
+    }
+
+    return fullContent;
+  };
+
+  const handleSubmit = async (text) => {
+    if (!text.trim() || state !== STATE_IDLE) return;
+
+    const userMessage = {
+      role: 'user',
+      content: text.trim(),
+      timestamp: Date.now(),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    setStreamingContent('');
+    setState(STATE_THINKING);
+    setError('');
+
+    try {
+      await addTurn(operatorId, { role: 'user', content: text.trim() });
+
+      const contextMemory = await getContextString(operatorId, 10);
+      const contextCorpus = await retrieve(text, 3);
+
+      const response = await callLLM(text, contextMemory, contextCorpus);
+
+      const assistantMessage = {
+        role: 'assistant',
+        content: response,
+        timestamp: Date.now(),
+      };
+
+      await addTurn(operatorId, { role: 'assistant', content: response });
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch (e) {
+      console.error('[Agent] Error:', e);
+      setError('No pude conectarme al asistente. Intenta de nuevo.');
+    } finally {
+      setState(STATE_IDLE);
+      setStreamingContent('');
+    }
+  };
+
+  const handleVoiceRecord = async () => {
+    if (state === STATE_RECORDING) {
+      const blob = stopRecord();
+      setState(STATE_THINKING);
+
+      try {
+        const text = await transcribe(blob);
+        if (text) {
+          handleSubmit(text);
+        } else {
+          setState(STATE_IDLE);
+          setError('No entendí el audio. Prueba de nuevo.');
+        }
+} catch (_e) {
+        setState(STATE_IDLE);
+        setError('Error al transcribir. Habla más claro.');
+      }
+    } else {
+      resetRecord();
+      startRecord();
+      setState(STATE_RECORDING);
+      setError('');
+    }
+  };
+
+  const handleTextSubmit = (e) => {
+    e.preventDefault();
+    handleSubmit(inputText);
+    setInputText('');
+  };
+
+  const handleSuggestion = (text) => {
+    handleSubmit(text);
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-slate-950">
+      {/* Header */}
+      <div className="px-4 py-3 flex items-center gap-3 border-b border-slate-800 bg-slate-900/80 shrink-0">
+        <button
+          type="button"
+          onClick={onBack}
+          className="p-2 -ml-2 rounded-lg active:bg-slate-800"
+        >
+          <ArrowLeft size={20} className="text-amber-400" />
+        </button>
+        <div className="flex-1">
+          <h1 className="text-base font-bold text-white flex items-center gap-2">
+            <Sparkles size={18} className="text-violet-400" />
+            Asistente IA
+          </h1>
+        </div>
+        <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-[10px] ${
+          isOnline ? 'bg-emerald-900/40 text-emerald-400' : 'bg-red-900/40 text-red-400'
+        }`}>
+          {isOnline ? <Wifi size={12} /> : <WifiOff size={12} />}
+          {isOnline ? 'Online' : 'Offline'}
+        </div>
+      </div>
+
+      {/* Chat */}
+      <ChatHistory
+        messages={messages}
+        streamingContent={streamingContent}
+        isStreaming={state === STATE_THINKING}
+      />
+
+      {/* Error */}
+      {error && (
+        <div className="px-4 py-2 mx-4 mb-2 rounded-lg bg-red-900/30 border border-red-800/50">
+          <p className="text-xs text-red-300">{error}</p>
+        </div>
+      )}
+
+      {/* Suggestions */}
+      {state === STATE_IDLE && messages.length < 3 && (
+        <SuggestedActions onSelect={handleSuggestion} />
+      )}
+
+      {/* Input */}
+      <div className="p-4 border-t border-slate-800 bg-slate-900/80 shrink-0">
+        <form onSubmit={handleTextSubmit} className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleVoiceRecord}
+            className={`shrink-0 w-12 h-12 rounded-full flex items-center justify-center transition-colors ${
+              state === STATE_RECORDING
+                ? 'bg-red-600 animate-pulse'
+                : 'bg-violet-700 hover:bg-violet-600'
+            }`}
+          >
+            {state === STATE_RECORDING ? (
+              <MicOff size={20} className="text-white" />
+            ) : (
+              <Mic size={20} className="text-white" />
+            )}
+          </button>
+
+          <input
+            type="text"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            placeholder="Escribe tu pregunta..."
+            disabled={state !== STATE_IDLE}
+            className="flex-1 px-4 py-3 rounded-full bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-violet-500/50 disabled:opacity-50"
+          />
+
+          <button
+            type="submit"
+            disabled={!inputText.trim() || state !== STATE_IDLE}
+            className="shrink-0 w-12 h-12 rounded-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
+          >
+            <Send size={18} className="text-white" />
+          </button>
+        </form>
+
+        {state === STATE_RECORDING && (
+          <p className="text-center text-xs text-red-400 mt-2 animate-pulse">
+            Grabando... {Math.floor(durationMs / 1000)}s
+          </p>
+        )}
+
+        {state === STATE_THINKING && (
+          <p className="text-center text-xs text-violet-400 mt-2">
+            Pensando...
+          </p>
+        )}
+      </div>
+
+      <div ref={chatEndRef} />
+    </div>
+  );
+}

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { User, Bot } from 'lucide-react';
+
+function formatTime(timestamp) {
+  if (!timestamp) return '';
+  const d = new Date(timestamp);
+  return d.toLocaleTimeString('es-CO', { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function ChatBubble({ message, isStreaming = false }) {
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
+      <div className={`flex gap-2 max-w-[85%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
+        <div className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+          isUser ? 'bg-emerald-600' : 'bg-violet-700'
+        }`}>
+          {isUser ? <User size={16} className="text-white" /> : <Bot size={16} className="text-white" />}
+        </div>
+
+        <div className={`rounded-2xl px-4 py-2.5 ${
+          isUser
+            ? 'bg-emerald-700/60 text-white rounded-tr-sm'
+            : 'bg-slate-800/80 text-slate-100 rounded-tl-sm'
+        }`}>
+          <p className="text-sm leading-relaxed whitespace-pre-wrap">{message.content}</p>
+          {message.timestamp && (
+            <p className={`text-[10px] mt-1 ${isUser ? 'text-emerald-300/60' : 'text-slate-500'}`}>
+              {formatTime(message.timestamp)}
+            </p>
+          )}
+          {isStreaming && (
+            <span className="inline-block w-2 h-2 bg-violet-400 rounded-full ml-1 animate-pulse" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useRef } from 'react';
+import ChatBubble from './ChatBubble';
+
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false }) {
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamingContent]);
+
+  if (messages.length === 0 && !isStreaming) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-8">
+        <div className="text-center">
+          <div className="text-5xl mb-4">🤖</div>
+          <p className="text-slate-400 text-sm mb-2">¡Hola! Soy tu asistente agroecológico.</p>
+          <p className="text-slate-500 text-xs">Puedes hablarme o escribirme sobre tus plantas.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 pb-2">
+      {messages.map((msg, idx) => (
+        <ChatBubble
+          key={msg.id || idx}
+          message={msg}
+          isStreaming={false}
+        />
+      ))}
+
+      {isStreaming && streamingContent && (
+        <ChatBubble
+          message={{ role: 'assistant', content: streamingContent }}
+          isStreaming={true}
+        />
+      )}
+
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/components/AgentScreen/SuggestedActions.jsx
+++ b/src/components/AgentScreen/SuggestedActions.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const SUGGESTIONS = [
+  { text: 'Cuándo planto tomates?', icon: '🌱' },
+  { text: 'Mi planta tiene manchas amarillas', icon: '🔍' },
+  { text: 'Registra que regué las lechugas', icon: '💧' },
+  { text: 'Consejos para el invernadero', icon: '🏠' },
+];
+
+export default function SuggestedActions({ onSelect }) {
+  return (
+    <div className="px-4 py-3 border-t border-slate-800 bg-slate-900/50">
+      <p className="text-[10px] text-slate-500 uppercase font-bold mb-2">Sugerencias</p>
+      <div className="flex flex-wrap gap-2">
+        {SUGGESTIONS.map((s, idx) => (
+          <button
+            key={idx}
+            type="button"
+            onClick={() => onSelect(s.text)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-800/80 hover:bg-slate-700/80 border border-slate-700/50 text-xs text-slate-300 transition-colors"
+          >
+            <span>{s.icon}</span>
+            <span>{s.text}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentScreen/index.js
+++ b/src/components/AgentScreen/index.js
@@ -1,0 +1,4 @@
+export { default as AgentScreen } from './AgentScreen';
+export { default as ChatHistory } from './ChatHistory';
+export { default as ChatBubble } from './ChatBubble';
+export { default as SuggestedActions } from './SuggestedActions';

--- a/src/components/MultiFincaGlobe.jsx
+++ b/src/components/MultiFincaGlobe.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
-import { ArrowRight, Info, MapPin } from 'lucide-react';
+import { ArrowRight, Info } from 'lucide-react';
 import L from 'leaflet';
 
 // Fix for default marker icons in Leaflet + Vite

--- a/src/components/OnboardingWizard/OnboardingWizard.jsx
+++ b/src/components/OnboardingWizard/OnboardingWizard.jsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { ArrowLeft, ArrowRight, Sprout } from 'lucide-react';
+import WelcomeStep from './WelcomeStep';
+import SoilAnalysisStep from './SoilAnalysisStep';
+import SpeciesSelectionStep from './SpeciesSelectionStep';
+import SummaryStep from './SummaryStep';
+
+const STEPS = [
+  { id: 'welcome', label: 'Bienvenida' },
+  { id: 'soil', label: 'Suelo' },
+  { id: 'species', label: 'Especies' },
+  { id: 'summary', label: 'Resumen' },
+];
+
+const DEFAULT_STATE = {
+  escala: null,
+  tipo_espacio: null,
+  soil: {
+    ph: '',
+    textura: '',
+    materia_organica: '',
+    notas: '',
+  },
+  selectedSpecies: [],
+};
+
+export default function OnboardingWizard({ onComplete, onBack }) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [wizardData, setWizardData] = useState(DEFAULT_STATE);
+
+  const stepId = STEPS[currentStep].id;
+
+  const updateData = (patch) => {
+    setWizardData((prev) => ({ ...prev, ...patch }));
+  };
+
+  const next = () => {
+    if (currentStep < STEPS.length - 1) {
+      setCurrentStep((s) => s + 1);
+    }
+  };
+
+  const prev = () => {
+    if (currentStep > 0) {
+      setCurrentStep((s) => s - 1);
+    }
+  };
+
+  const canNext = () => {
+    if (stepId === 'welcome') return !!(wizardData.escala && wizardData.tipo_espacio);
+    if (stepId === 'soil') return true;
+    if (stepId === 'species') return wizardData.selectedSpecies.length > 0;
+    return true;
+  };
+
+  const renderStep = () => {
+    switch (stepId) {
+      case 'welcome':
+        return (
+          <WelcomeStep
+            data={wizardData}
+            onUpdate={updateData}
+          />
+        );
+      case 'soil':
+        return (
+          <SoilAnalysisStep
+            data={wizardData.soil}
+            onUpdate={(soil) => updateData({ soil })}
+          />
+        );
+      case 'species':
+        return (
+          <SpeciesSelectionStep
+            data={wizardData}
+            onUpdate={updateData}
+          />
+        );
+      case 'summary':
+        return (
+          <SummaryStep
+            data={wizardData}
+            onComplete={onComplete}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="h-[100dvh] w-full bg-slate-950 text-white flex flex-col overflow-hidden">
+      <header className="p-4 shrink-0 bg-slate-950/95 border-b border-slate-800 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={currentStep === 0 ? onBack : prev}
+          aria-label={currentStep === 0 ? 'Cerrar wizard' : 'Anterior'}
+          className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[48px] min-w-[48px] flex items-center justify-center"
+        >
+          <ArrowLeft size={22} />
+        </button>
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <Sprout size={22} className="text-emerald-400 shrink-0" />
+          <h2 className="text-xl font-black tracking-tight truncate">Configurar Finca</h2>
+        </div>
+      </header>
+
+      <div className="px-4 py-3 shrink-0 flex items-center gap-2 bg-slate-900/50 border-b border-slate-800/50">
+        {STEPS.map((step, idx) => (
+          <React.Fragment key={step.id}>
+            <div className="flex items-center gap-1.5">
+              <div
+                className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-black shrink-0 ${
+                  idx < currentStep
+                    ? 'bg-emerald-600 text-white'
+                    : idx === currentStep
+                    ? 'bg-emerald-500 text-white'
+                    : 'bg-slate-800 text-slate-500'
+                }`}
+              >
+                {idx < currentStep ? '✓' : idx + 1}
+              </div>
+              <span className={`text-[10px] font-bold hidden sm:block ${
+                idx === currentStep ? 'text-emerald-400' : idx < currentStep ? 'text-slate-400' : 'text-slate-600'
+              }`}>
+                {step.label}
+              </span>
+            </div>
+            {idx < STEPS.length - 1 && (
+              <div className={`flex-1 h-px min-w-[12px] ${
+                idx < currentStep ? 'bg-emerald-600' : 'bg-slate-800'
+              }`} />
+            )}
+          </React.Fragment>
+        ))}
+      </div>
+
+      <main className="flex-1 overflow-y-auto p-4 pb-6">
+        {renderStep()}
+      </main>
+
+      {stepId !== 'summary' && (
+        <div className="p-4 border-t border-slate-800 shrink-0 bg-slate-950/95">
+          <button
+            type="button"
+            onClick={next}
+            disabled={!canNext()}
+            className={`w-full p-4 rounded-xl font-black flex items-center justify-center gap-2 min-h-[56px] transition-all ${
+              canNext()
+                ? 'bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700 text-white'
+                : 'bg-slate-800 text-slate-600 cursor-not-allowed'
+            }`}
+          >
+            Siguiente <ArrowRight size={20} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard/SoilAnalysisStep.jsx
+++ b/src/components/OnboardingWizard/SoilAnalysisStep.jsx
@@ -1,0 +1,163 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronUp, FlaskConical, Building2 } from 'lucide-react';
+
+const TEXTURA_OPTS = ['arena', 'arcilla', 'limo', 'mezcla'];
+const MO_OPTS = ['baja', 'media', 'alta'];
+
+function EduCard({ title, children }) {
+  return (
+    <div className="bg-slate-900/60 border border-slate-800 rounded-xl p-4 flex flex-col gap-2">
+      <h3 className="text-sm font-bold text-emerald-400">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function ExpandableSection({ title, icon, defaultOpen = false, children }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const IconComponent = icon;
+  return (
+    <div className="bg-slate-900/40 border border-slate-800/60 rounded-xl overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full p-4 flex items-center gap-3 text-left hover:bg-slate-800/30 transition-colors"
+      >
+        {IconComponent && <IconComponent size={18} className="text-amber-400 shrink-0" />}
+        <span className="flex-1 text-sm font-bold text-slate-200">{title}</span>
+        {open ? <ChevronUp size={16} className="text-slate-500" /> : <ChevronDown size={16} className="text-slate-500" />}
+      </button>
+      {open && (
+        <div className="px-4 pb-4 flex flex-col gap-3">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SoilAnalysisStep({ data, onUpdate }) {
+  const update = (field, value) => {
+    onUpdate({ ...data, [field]: value });
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-black text-white">Analisis de Suelo</h2>
+        <p className="text-sm text-slate-400 leading-relaxed">
+          Conocer tu suelo es la base de toda الزراعة agroecologica. Estas
+          pruebas caseras te dan una lectura rapida sin laboratorio.
+        </p>
+      </div>
+
+      <ExpandableSection title="Como hacer analisis de suelo casero" icon={FlaskConical} defaultOpen>
+        <EduCard title="Test de pH con vinagre y bicarbonato">
+          <ul className="text-xs text-slate-400 space-y-1 list-disc pl-4">
+            <li>Toma dos muestras de tierra en vasos separados.</li>
+            <li>A la primera agregale vinagre. Si burbujea fuerte, tu suelo es calizo (pH alto).</li>
+            <li>A la segunda agregale bicarbonato + agua. Si burbujea, tu suelo es acido (pH bajo).</li>
+            <li>Si ninguno reacciona, tu pH esta cerca de neutro (6.5-7).</li>
+          </ul>
+        </EduCard>
+
+        <EduCard title="Test de textura: la prueba del puno">
+          <ul className="text-xs text-slate-400 space-y-1 list-disc pl-4">
+            <li>Mojale la tierra hasta tener un barro consistencia Plasticine.</li>
+            <li>Intenta hacer un cilindro de 5 cm.</li>
+            <li>Si se desmorona: suelo arenoso (drena rapido, retiene poco).</li>
+            <li>Si forma cilindro pero se quiebra al doblar: suelo arcilloso (retiene agua, compacta).</li>
+            <li>Si forma cilindro flexible: suelo franco (equilibrado).</li>
+          </ul>
+        </EduCard>
+
+        <EduCard title="Test de materia organica (color)">
+          <ul className="text-xs text-slate-400 space-y-1 list-disc pl-4">
+            <li>La tierra oscura casi negra indica alta materia organica.</li>
+            <li>La tierra cafe grisacea indica materia organica media.</li>
+            <li>La tierra cafe clara o beige indica baja materia organica.</li>
+            <li>Olor a bosque: materia organica alta y bien descompuesta.</li>
+          </ul>
+        </EduCard>
+      </ExpandableSection>
+
+      <ExpandableSection title="Laboratorios por zona" icon={Building2}>
+        <div className="p-4 rounded-xl bg-slate-800/50 border border-slate-700/50 text-center">
+          <p className="text-xs text-slate-500">
+            proximamente: directorio de laboratorios de analisis de suelo
+            por region Colombia.
+          </p>
+        </div>
+      </ExpandableSection>
+
+      <div className="bg-slate-900/60 border border-slate-800 rounded-xl p-4 flex flex-col gap-4">
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Registra tus resultados</h3>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">pH (0 a 14)</span>
+          <input
+            type="number"
+            min="0"
+            max="14"
+            step="0.1"
+            value={data.ph}
+            onChange={(e) => update('ph', e.target.value)}
+            placeholder="Ej: 6.5"
+            className="p-3 rounded-xl bg-slate-800 border border-slate-700 focus:border-emerald-500 outline-none text-white text-base min-h-[48px]"
+          />
+        </label>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">Textura</span>
+          <div className="grid grid-cols-2 gap-2">
+            {TEXTURA_OPTS.map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                onClick={() => update('textura', opt)}
+                className={`p-3 rounded-xl border text-sm font-bold min-h-[48px] transition-all ${
+                  data.textura === opt
+                    ? 'bg-emerald-600 border-emerald-500 text-white'
+                    : 'bg-slate-800 border-slate-700 text-slate-300 hover:border-slate-600'
+                }`}
+              >
+                {opt.charAt(0).toUpperCase() + opt.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">Materia organica</span>
+          <div className="grid grid-cols-3 gap-2">
+            {MO_OPTS.map((opt) => (
+              <button
+                key={opt}
+                type="button"
+                onClick={() => update('materia_organica', opt)}
+                className={`p-3 rounded-xl border text-sm font-bold min-h-[48px] transition-all ${
+                  data.materia_organica === opt
+                    ? 'bg-emerald-600 border-emerald-500 text-white'
+                    : 'bg-slate-800 border-slate-700 text-slate-300 hover:border-slate-600'
+                }`}
+              >
+                {opt.charAt(0).toUpperCase() + opt.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">Notas adicionales</span>
+          <textarea
+            value={data.notas}
+            onChange={(e) => update('notas', e.target.value)}
+            placeholder="Ej: olor a bosque, muchas raices superficiales..."
+            rows={3}
+            className="p-3 rounded-xl bg-slate-800 border border-slate-700 focus:border-emerald-500 outline-none text-white text-sm resize-none"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard/SpeciesSelectionStep.jsx
+++ b/src/components/OnboardingWizard/SpeciesSelectionStep.jsx
@@ -1,0 +1,145 @@
+import React, { useState, useEffect } from 'react';
+import { Search, Check } from 'lucide-react';
+import { getAllSpecies } from '../../db/catalogDB';
+
+const MAX_SPECIES = 5;
+
+export default function SpeciesSelectionStep({ data, onUpdate }) {
+  const [allSpecies, setAllSpecies] = useState([]);
+  const [query, setQuery] = useState('');
+  const [catalogStatus, setCatalogStatus] = useState('loading');
+
+  useEffect(() => {
+    getAllSpecies()
+      .then((sp) => {
+        setAllSpecies(sp);
+        setCatalogStatus('ready');
+      })
+      .catch(() => setCatalogStatus('error'));
+  }, []);
+
+  const filtered = allSpecies.filter((sp) => {
+    if (!query.trim()) return true;
+    const q = query.toLowerCase();
+    return (
+      (sp.nombre_comun || '').toLowerCase().includes(q) ||
+      (sp.nombre_cientifico || '').toLowerCase().includes(q) ||
+      (sp.id || '').toLowerCase().includes(q)
+    );
+  });
+
+  const toggleSpecies = (speciesId) => {
+    const current = data.selectedSpecies;
+    if (current.includes(speciesId)) {
+      onUpdate({ selectedSpecies: current.filter((id) => id !== speciesId) });
+    } else if (current.length < MAX_SPECIES) {
+      onUpdate({ selectedSpecies: [...current, speciesId] });
+    }
+  };
+
+  const selectedIds = new Set(data.selectedSpecies);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-black text-white">Selecciona tus especies objetivo</h2>
+        <p className="text-sm text-slate-400 leading-relaxed">
+          Elige de 1 a {MAX_SPECIES} especies que quieres cultivar.
+          Las recomendaciones del catalogo se filtran segun tu escala ({data.tipo_espacio}).
+        </p>
+      </div>
+
+      <div className="flex items-center gap-2 p-3 rounded-xl bg-slate-800 border border-slate-700">
+        <Search size={16} className="text-slate-500 shrink-0" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar especie... (ej: tomate, lechuga)"
+          className="flex-1 bg-transparent text-white text-sm outline-none"
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+          {selectedIds.size} de {MAX_SPECIES} seleccionadas
+        </p>
+        {data.selectedSpecies.length === MAX_SPECIES && (
+          <p className="text-[10px] text-amber-400 font-bold">Maximo alcanzado</p>
+        )}
+      </div>
+
+      {catalogStatus === 'loading' && (
+        <div className="p-8 text-center">
+          <p className="text-sm text-slate-500">Cargando catalogo...</p>
+        </div>
+      )}
+
+      {catalogStatus === 'error' && (
+        <div className="p-4 rounded-xl bg-red-900/20 border border-red-800/50 text-sm text-red-300">
+          No se pudo cargar el catalogo de especies. Puedes continuar sin seleccionar.
+        </div>
+      )}
+
+      {catalogStatus === 'ready' && (
+        <div className="flex flex-col gap-1 max-h-[40vh] overflow-y-auto">
+          {filtered.length === 0 ? (
+            <div className="p-4 text-center text-slate-500 text-sm">
+              Sin coincidencias.
+            </div>
+          ) : (
+            filtered.map((sp) => {
+              const selected = selectedIds.has(sp.id);
+              const disabled = !selected && data.selectedSpecies.length >= MAX_SPECIES;
+              return (
+                <button
+                  key={sp.id}
+                  type="button"
+                  onClick={() => !disabled && toggleSpecies(sp.id)}
+                  disabled={disabled}
+                  className={`w-full text-left px-4 py-3 rounded-xl border transition-all flex items-center gap-3 min-h-[56px] ${
+                    selected
+                      ? 'bg-emerald-900/30 border-emerald-600 text-white'
+                      : 'bg-slate-900/40 border-slate-800 text-slate-300 hover:border-slate-700'
+                  } ${disabled ? 'opacity-40 cursor-not-allowed' : ''}`}
+                  aria-pressed={selected}
+                >
+                  <div className={`w-6 h-6 rounded-full border-2 shrink-0 flex items-center justify-center ${
+                    selected ? 'bg-emerald-600 border-emerald-500' : 'border-slate-700'
+                  }`}>
+                    {selected && <Check size={14} className="text-white" />}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-bold truncate">{sp.nombre_comun || sp.id}</p>
+                    {sp.nombre_cientifico && (
+                      <p className="text-[10px] text-slate-500 italic truncate">{sp.nombre_cientifico}</p>
+                    )}
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
+
+      {data.selectedSpecies.length > 0 && (
+        <div className="flex flex-col gap-2 p-3 rounded-xl bg-slate-900/60 border border-slate-800">
+          <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">Seleccionadas</p>
+          <div className="flex flex-wrap gap-2">
+            {data.selectedSpecies.map((id) => {
+              const sp = allSpecies.find((s) => s.id === id);
+              return (
+                <span
+                  key={id}
+                  className="text-xs px-2.5 py-1 rounded-full bg-emerald-900/40 border border-emerald-800/50 text-emerald-300 font-bold"
+                >
+                  {sp?.nombre_comun || id}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard/SummaryStep.jsx
+++ b/src/components/OnboardingWizard/SummaryStep.jsx
@@ -1,0 +1,171 @@
+import React, { useState } from 'react';
+import { Sprout, CheckCircle } from 'lucide-react';
+import useAssetStore from '../../store/useAssetStore';
+import { getSpeciesByIdSync } from '../../db/catalogDB';
+
+const ESCALA_LABELS = {
+  apartment: '1 a 10 plantas (balcon/apto)',
+  small_farm: '10 a 100 plantas (huerto kecil)',
+  farm: '100 a 1000 plantas (finca)',
+  commercial: '1000 a 10000 plantas (comercial)',
+};
+
+const TIPO_ESPACIO_LABELS = {
+  apartment: 'Balcon o apartamento',
+  small_farm: 'Huerto pequeno',
+  farm: 'Finca',
+  commercial: 'Produccion comercial',
+};
+
+const TEXTURA_LABELS = {
+  arena: 'Arena',
+  arcilla: 'Arcilla',
+  limo: 'Limo',
+  mezcla: 'Mezcla',
+};
+
+const MO_LABELS = {
+  baja: 'Baja',
+  media: 'Media',
+  alta: 'Alta',
+};
+
+export default function SummaryStep({ data, onComplete }) {
+  const addAsset = useAssetStore((s) => s.addAsset);
+const [creating, setCreating] = useState(false);
+  const [created, setCreated] = useState(false);
+
+  const selectedSpeciesData = (data.selectedSpecies || [])
+    .map((id) => getSpeciesByIdSync(id))
+    .filter(Boolean);
+
+  const handleCreateFirstPlant = async () => {
+    if (selectedSpeciesData.length === 0) {
+      onComplete();
+      return;
+    }
+    setCreating(true);
+    try {
+      const primarySpecies = selectedSpeciesData[0];
+      // eslint-disable-next-line react-hooks/purity
+      const timestamp = Date.now();
+      const asset = {
+        id: `onboarding-${timestamp}`,
+        name: primarySpecies.nombre_comun || primarySpecies.id,
+        asset_type: 'plant',
+        attributes: {
+          name: primarySpecies.nombre_comun || primarySpecies.id,
+          species_slug: primarySpecies.id,
+          notes: `Configuracion inicial. Escala: ${data.tipo_espacio}. Suelo pH: ${data.soil.ph || 'no registrado'}, textura: ${data.soil.textura || 'no registrada'}, MO: ${data.soil.materia_organica || 'no registrada'}.`,
+        },
+        relationships: {},
+        _createdAt: timestamp,
+      };
+      await addAsset('plant', asset);
+      setCreated(true);
+      setTimeout(() => onComplete(), 1500);
+    } catch (err) {
+      console.error('[SummaryStep] Fallo al crear planta:', err);
+      setCreating(false);
+    }
+  };
+
+  const handleSkip = () => {
+    onComplete();
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-black text-white">Resumen de configuracion</h2>
+        <p className="text-sm text-slate-400 leading-relaxed">
+          Tu configuracion inicial esta lista. Puedes ajustar estos datos
+          mas adelante desde Ajustes.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <SummaryCard title="Escala">
+          <p className="text-sm font-bold text-white">{ESCALA_LABELS[data.escala] || data.escala}</p>
+          <p className="text-xs text-slate-500">Tipo de espacio: {TIPO_ESPACIO_LABELS[data.tipo_espacio] || data.tipo_espacio}</p>
+        </SummaryCard>
+
+        <SummaryCard title="Analisis de suelo">
+          {data.soil.ph ? (
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-bold text-white">pH: {data.soil.ph}</p>
+              <p className="text-xs text-slate-500">
+                Textura: {TEXTURA_LABELS[data.soil.textura] || data.soil.textura} | MO: {MO_LABELS[data.soil.materia_organica] || data.soil.materia_organica}
+              </p>
+              {data.soil.notas && (
+                <p className="text-xs text-slate-400 mt-1">Notas: {data.soil.notas}</p>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500">No registrado. Puedes agregarlo despues desde el perfil.</p>
+          )}
+        </SummaryCard>
+
+        <SummaryCard title={`Especies seleccionadas (${selectedSpeciesData.length})`}>
+          {selectedSpeciesData.length > 0 ? (
+            <div className="flex flex-col gap-1.5">
+              {selectedSpeciesData.map((sp) => (
+                <div key={sp.id} className="flex items-center gap-2">
+                  <Sprout size={14} className="text-emerald-400 shrink-0" />
+                  <div>
+                    <p className="text-sm font-bold text-white">{sp.nombre_comun || sp.id}</p>
+                    {sp.nombre_cientifico && (
+                      <p className="text-[10px] text-slate-500 italic">{sp.nombre_cientifico}</p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500">Ninguna especie seleccionada.</p>
+          )}
+        </SummaryCard>
+      </div>
+
+      <div className="flex flex-col gap-3 mt-2">
+        {created ? (
+          <div className="p-4 rounded-xl bg-emerald-900/30 border border-emerald-700/50 flex items-center gap-3 min-h-[64px]">
+            <CheckCircle size={24} className="text-emerald-400 shrink-0" />
+            <div>
+              <p className="text-sm font-black text-emerald-300">Primera planta creada</p>
+              <p className="text-xs text-emerald-400/70">Redirigiendo al dashboard...</p>
+            </div>
+          </div>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={handleCreateFirstPlant}
+              disabled={creating}
+              className="w-full p-4 rounded-xl bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700 text-white font-black flex items-center justify-center gap-2 min-h-[56px] transition-all disabled:opacity-60"
+            >
+              {creating ? 'Creando...' : 'Crear mi primera planta'}
+              <Sprout size={20} />
+            </button>
+            <button
+              type="button"
+              onClick={handleSkip}
+              className="w-full p-3 text-center text-sm text-slate-500 hover:text-slate-400 transition-colors min-h-[44px]"
+            >
+              Omitir por ahora
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({ title, children }) {
+  return (
+    <div className="bg-slate-900/60 border border-slate-800 rounded-xl p-4 flex flex-col gap-2">
+      <p className="text-[10px] font-bold text-slate-500 uppercase tracking-wider">{title}</p>
+      {children}
+    </div>
+  );
+}

--- a/src/components/OnboardingWizard/WelcomeStep.jsx
+++ b/src/components/OnboardingWizard/WelcomeStep.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+const ESCALA_OPTS = [
+  {
+    id: 'apartment',
+    label: '1 a 10 plantas',
+    sub: 'Balcón o apartamento',
+    tipo_espacio: 'apartment',
+    emoji: '🏠',
+    accent: 'border-emerald-500 active:bg-emerald-900/30',
+  },
+  {
+    id: 'small_farm',
+    label: '10 a 100 plantas',
+    sub: 'Huerto kecil',
+    tipo_espacio: 'small_farm',
+    emoji: '🌱',
+    accent: 'border-lime-500 active:bg-lime-900/30',
+  },
+  {
+    id: 'farm',
+    label: '100 a 1000 plantas',
+    sub: 'Finca pequeña',
+    tipo_espacio: 'farm',
+    emoji: '🌿',
+    accent: 'border-green-500 active:bg-green-900/30',
+  },
+  {
+    id: 'commercial',
+    label: '1000 a 10000 plantas',
+    sub: 'Producción comercial',
+    tipo_espacio: 'commercial',
+    emoji: '🌳',
+    accent: 'border-teal-500 active:bg-teal-900/30',
+  },
+];
+
+export default function WelcomeStep({ data, onUpdate }) {
+  const handleSelect = (opt) => {
+    onUpdate({
+      escala: opt.id,
+      tipo_espacio: opt.tipo_espacio,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-black text-white">Bienvenido a Chagra</h1>
+        <p className="text-sm text-slate-400 leading-relaxed">
+          Antes de empezar, necesitamos conocer tu escala de cultivo para
+          ajustar las recomendaciones del catálogo.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <p className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+          Selecciona la escala de tu cultivo
+        </p>
+        {ESCALA_OPTS.map((opt) => {
+          const selected = data.escala === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => handleSelect(opt)}
+              className={`w-full p-4 rounded-xl border-2 bg-slate-900 flex items-center gap-4 min-h-[72px] transition-all ${opt.accent} ${
+                selected ? 'border-2' : 'border-slate-800'
+              }`}
+              aria-pressed={selected}
+            >
+              <span className="text-3xl shrink-0" aria-hidden="true">{opt.emoji}</span>
+              <div className="flex flex-col items-start">
+                <span className="text-base font-black text-white">{opt.label}</span>
+                <span className="text-xs text-slate-500">{opt.sub}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {data.escala && (
+        <div className="p-3 rounded-xl bg-emerald-900/20 border border-emerald-800/40">
+          <p className="text-xs text-emerald-400 font-bold">
+            Escala: {data.tipo_espacio}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `AgentScreen` component combining voice input + chat UI + AI responses
- ChatHistory with conversationMemory integration (057.3)
- RAG retrieval for context from corpus
- Voice input via existing VoiceCapture hook
- SuggestedActions for quick queries
- OnboardingWizard scaffold (WelcomeStep, SoilAnalysisStep, SpeciesSelectionStep, SummaryStep)
- Route `/agente` added to App.jsx

## Components created
```
src/components/AgentScreen/
├── AgentScreen.jsx       # Main orchestrator
├── ChatHistory.jsx       # Message list
├── ChatBubble.jsx        # Individual bubble (user/assistant)
├── SuggestedActions.jsx  # Quick suggestions
└── index.js

src/components/OnboardingWizard/
├── OnboardingWizard.jsx
├── WelcomeStep.jsx
├── SoilAnalysisStep.jsx
├── SpeciesSelectionStep.jsx
└── SummaryStep.jsx
```

## Testing
- npm run build ✅
- npm run lint ✅

## Next steps
- Connect ActionConfirmModal for tool execution
- Add text-to-speech for responses
- Integrate with Bitacora/Plantas/Bodega