### PR TITLE
feat(agent): add intent parser + action confirm modal integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.91",
+  "version": "0.12.92",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v133';
+const CACHE_NAME = 'chagra-v134';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -4,8 +4,10 @@ import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe } from '../../services/voiceService';
 import { addTurn, getFullHistory, getContextString } from '../../services/conversationMemory';
 import { retrieve } from '../../services/ragRetriever';
+import { parseIntent, formatIntentDescription } from '../../services/agentIntentParser';
 import ChatHistory from './ChatHistory';
 import SuggestedActions from './SuggestedActions';
+import ActionConfirmModal from '../ActionConfirmModal';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
 
@@ -25,6 +27,7 @@ export default function AgentScreen({ onBack }) {
   const [streamingContent, setStreamingContent] = useState('');
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [error, setError] = useState('');
+  const [actionModal, setActionModal] = useState({ isOpen: false, intent: null, llmResponse: '' });
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -54,6 +57,45 @@ export default function AgentScreen({ onBack }) {
     const plantNames = plants?.map((p) => p.attributes?.name).filter(Boolean).join(', ') || 'ninguna';
     return `Eres un asistente agroecológico en Colombia. El usuario tiene estas plantas: ${plantNames}. Responde en español, sé helpful y específico. Si no sabes algo, dilo honestamente.`;
   }, [plants]);
+
+  const handleActionApprove = async (params) => {
+    const { intent } = actionModal;
+    const addLog = useAssetStore.getState().addLog;
+
+    if (intent && intent.toolName === 'crear_log' && addLog) {
+      const assetId = params.asset_id || plants?.[0]?.id;
+      if (assetId) {
+        await addLog(assetId, {
+          type: intent.logType,
+          attributes: {
+            notes: params.notes || formatIntentDescription(intent),
+            timestamp: new Date().toISOString(),
+            ...(params.quantity && params.unit && { quantity: { value: params.quantity, unit: params.unit } }),
+          },
+          relationships: {
+            asset: { data: { type: 'asset', id: assetId } },
+          },
+        });
+
+        const successMsg = {
+          role: 'assistant',
+          content: `Listo. He registrado la ${intent.logType.replace('log--', '')} en tu bitácora.`,
+          timestamp: Date.now(),
+        };
+        setMessages((prev) => [...prev, successMsg]);
+      }
+    }
+
+    setActionModal({ isOpen: false, intent: null, llmResponse: '' });
+  };
+
+  const handleActionReject = () => {
+    setActionModal({ isOpen: false, intent: null, llmResponse: '' });
+  };
+
+  const handleActionEdit = async (params) => {
+    await handleActionApprove(params);
+  };
 
   const callLLM = async (query, contextMemory, contextCorpus) => {
     const systemPrompt = getSystemPrompt();
@@ -128,6 +170,8 @@ export default function AgentScreen({ onBack }) {
 
       const response = await callLLM(text, contextMemory, contextCorpus);
 
+      const { intent } = parseIntent(text);
+
       const assistantMessage = {
         role: 'assistant',
         content: response,
@@ -136,6 +180,16 @@ export default function AgentScreen({ onBack }) {
 
       await addTurn(operatorId, { role: 'assistant', content: response });
       setMessages((prev) => [...prev, assistantMessage]);
+
+      if (intent && intent.toolName === 'crear_log') {
+        setActionModal({
+          isOpen: true,
+          intent,
+          llmResponse: response,
+        });
+        setState(STATE_IDLE);
+        return;
+      }
     } catch (e) {
       console.error('[Agent] Error:', e);
       setError('No pude conectarme al asistente. Intenta de nuevo.');
@@ -275,6 +329,19 @@ export default function AgentScreen({ onBack }) {
       </div>
 
       <div ref={chatEndRef} />
+
+      {/* Action Confirmation Modal */}
+      <ActionConfirmModal
+        isOpen={actionModal.isOpen}
+        toolName={actionModal.intent?.toolName || ''}
+        description={actionModal.intent ? formatIntentDescription(actionModal.intent) : ''}
+        parameters={actionModal.intent?.parameters || {}}
+        intent={actionModal.intent}
+        llm_response={actionModal.llmResponse}
+        onApprove={handleActionApprove}
+        onReject={handleActionReject}
+        onEdit={handleActionEdit}
+      />
     </div>
   );
 }

--- a/src/services/agentIntentParser.js
+++ b/src/services/agentIntentParser.js
@@ -1,0 +1,134 @@
+/**
+ * agentIntentParser.js — Detecta intenciones accionables del usuario en texto.
+ *
+ * Analiza el input del usuario para detectar si quiere realizar una accion
+ * en Chagra (crear log, registrar cosecha, agendar riego, etc.)
+ */
+
+const ACTION_PATTERNS = [
+  {
+    id: 'registrar_cosecha',
+    patterns: [
+      /(?:reg(?:istr(?:ar|e|o))?[:\s]+(?:(?:la\s+)?cosecha|(?:\d+)\s*(?:kg|kilos?|libras?|unidades?|piezas?)(?:\s+de)?\s*\w+))/i,
+      /(?:cosech(?:ar?|e|aste))/i,
+      /(?:recolect(?:ar?|e|aste))/i,
+      /(?:recog(?:i|iste|er)\s+(?:las?|el|los)\s+\w+)/i,
+    ],
+    toolName: 'crear_log',
+    logType: 'log--harvest',
+    extract: (text) => {
+      const qtyMatch = text.match(/(\d+(?:\.\d+)?)\s*(kg|kilos?|libras?|unidades?|piezas?|g)/i);
+      const qty = qtyMatch ? parseFloat(qtyMatch[1]) : 1;
+      const unit = qtyMatch ? qtyMatch[2].toLowerCase().replace(/kilo(s)?/, 'kg').replace(/libras?/, 'lb').replace(/piezas?/, 'unidades') : 'unidades';
+      const plantMatch = text.match(/(?:de|del)\s+(\w+)/i);
+      return { quantity: qty, unit, plantHint: plantMatch ? plantMatch[1] : null };
+    },
+  },
+  {
+    id: 'registrar_riego',
+    patterns: [
+      /(?:reg(?:istr(?:ar|e|o))?[:\s]+(?:el\s+)?riego)/i,
+      /(?:reg(?:ué?|ar?|aste)\s+(?:las?|el|los)\s+\w+)/i,
+      /(?:regar\s+(?:las?|el|los)\s+\w+)/i,
+    ],
+    toolName: 'crear_log',
+    logType: 'log--input',
+    extract: (text) => {
+      const qtyMatch = text.match(/(\d+(?:\.\d+)?)\s*(ml|L|litros?|galones?|baldes?)/i);
+      return {
+        quantity: qtyMatch ? parseFloat(qtyMatch[1]) : null,
+        unit: qtyMatch ? qtyMatch[2].toLowerCase().replace(/litros?/, 'L').replace(/galones?/, 'L').replace(/baldes?/, 'L') : 'L',
+        notes: 'Riego registrado via asistente de voz',
+      };
+    },
+  },
+  {
+    id: 'registrar_observacion',
+    patterns: [
+      /(?:observ(?:ar?|é|aste|ación))/i,
+      /(?:not(?:ar?|é|aste))/i,
+      /(?:vi\s+(?:que|como|un|una|el|la|los|las))/i,
+    ],
+    toolName: 'crear_log',
+    logType: 'log--observation',
+    extract: (text) => {
+      const cleanText = text.replace(/^(?:observ(?:ar?|é|aste|ación)|not(?:ar?|é|aste)|vi\s+)/i, '').trim();
+      return { notes: cleanText || 'Observación registrada via asistente' };
+    },
+  },
+  {
+    id: 'registrar_aplicacion',
+    patterns: [
+      /(?:aplic(?:ar?|é|aste))/i,
+      /(?:aplicaci[oó]n\s+de)/i,
+      /(?:fertiliz(?:ar?|é|aste))/i,
+      /(?:abon(?:ar?|é|aste))/i,
+    ],
+    toolName: 'crear_log',
+    logType: 'log--input',
+    extract: (text) => {
+      const productMatch = text.match(/(?:de\s+)?(\w+(?:\s+\w+)?)/i);
+      return {
+        notes: `Aplicación: ${productMatch ? productMatch[1] : 'producto no especificado'}`,
+        quantity: null,
+        unit: null,
+      };
+    },
+  },
+];
+
+/**
+ * Analiza el texto del usuario y detecta si hay una intencion accionable.
+ * @param {string} text - Texto del usuario
+ * @returns {{ intent: Object|null, confidence: number }}
+ */
+export function parseIntent(text) {
+  if (!text || typeof text !== 'string') return { intent: null, confidence: 0 };
+
+  for (const action of ACTION_PATTERNS) {
+    for (const pattern of action.patterns) {
+      if (pattern.test(text)) {
+        const params = action.extract(text);
+        return {
+          intent: {
+            id: action.id,
+            toolName: action.toolName,
+            logType: action.logType,
+            parameters: params,
+            originalText: text,
+          },
+          confidence: 0.8,
+        };
+      }
+    }
+  }
+
+  return { intent: null, confidence: 0 };
+}
+
+/**
+ * Formatea los parametros detectados para mostrar en el modal de confirmacion.
+ * @param {Object} intent
+ * @returns {string}
+ */
+export function formatIntentDescription(intent) {
+  const { id, parameters } = intent;
+
+  switch (id) {
+    case 'registrar_cosecha':
+      return `Registrar cosecha de ${parameters.quantity} ${parameters.unit}${parameters.plantHint ? ` de ${parameters.plantHint}` : ''}`;
+    case 'registrar_riego':
+      return `Registrar riego${parameters.quantity ? ` (${parameters.quantity} ${parameters.unit})` : ''}`;
+    case 'registrar_observacion':
+      return `Registrar observación: "${parameters.notes}"`;
+    case 'registrar_aplicacion':
+      return `Registrar aplicación: ${parameters.notes}`;
+    default:
+      return `Ejecutar acción: ${id}`;
+  }
+}
+
+export default {
+  parseIntent,
+  formatIntentDescription,
+};


### PR DESCRIPTION
## Summary
- Add `agentIntentParser.js` service to detect actionable intents from user text
- Integrate `ActionConfirmModal` with `AgentScreen`
- When user says "registra que coseché", "registra que regué", etc., show confirmation modal before executing

## Intent patterns detected
- Registrar cosecha (kg, unidades)
- Registrar riego
- Registrar observación
- Registrar aplicación de fertilizante

## Testing
- npm run build ✅
- npm run lint ✅

## Next steps
- Add more intent patterns based on usage
- Integrate with asset selector when multiple plants exist