### PR TITLE
feat(agent): add text-to-speech for IA responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.92",
+  "version": "0.12.93",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v134';
+const CACHE_NAME = 'chagra-v135';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe } from '../../services/voiceService';
 import { addTurn, getFullHistory, getContextString } from '../../services/conversationMemory';
 import { retrieve } from '../../services/ragRetriever';
 import { parseIntent, formatIntentDescription } from '../../services/agentIntentParser';
+import { speak, stop, init as initTTS } from '../../services/ttsService';
 import ChatHistory from './ChatHistory';
 import SuggestedActions from './SuggestedActions';
 import ActionConfirmModal from '../ActionConfirmModal';
@@ -28,6 +29,7 @@ export default function AgentScreen({ onBack }) {
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [error, setError] = useState('');
   const [actionModal, setActionModal] = useState({ isOpen: false, intent: null, llmResponse: '' });
+  const [ttsEnabled, setTtsEnabled] = useState(true);
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -42,12 +44,14 @@ export default function AgentScreen({ onBack }) {
   }, [operatorId]);
 
   useEffect(() => {
+    initTTS();
     loadHistory();
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
     return () => {
+      stop();
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
@@ -181,6 +185,11 @@ export default function AgentScreen({ onBack }) {
       await addTurn(operatorId, { role: 'assistant', content: response });
       setMessages((prev) => [...prev, assistantMessage]);
 
+      if (ttsEnabled && response) {
+        stop();
+        speak(response, { rate: 0.9, pitch: 1.0 });
+      }
+
       if (intent && intent.toolName === 'crear_log') {
         setActionModal({
           isOpen: true,
@@ -251,6 +260,21 @@ export default function AgentScreen({ onBack }) {
             Asistente IA
           </h1>
         </div>
+        <button
+          type="button"
+          onClick={() => {
+            if (ttsEnabled) {
+              stop();
+            }
+            setTtsEnabled(!ttsEnabled);
+          }}
+          className={`p-2 rounded-full transition-colors ${
+            ttsEnabled ? 'bg-violet-900/40 text-violet-400' : 'bg-slate-800 text-slate-500'
+          }`}
+          title={ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
+        >
+          {ttsEnabled ? <Volume2 size={16} /> : <VolumeX size={16} />}
+        </button>
         <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-[10px] ${
           isOnline ? 'bg-emerald-900/40 text-emerald-400' : 'bg-red-900/40 text-red-400'
         }`}>

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -1,0 +1,136 @@
+/**
+ * ttsService.js — Text-to-Speech usando Web Speech API.
+ *
+ * Proporciona síntesis de voz para las respuestas del agente IA.
+ * Usa la API nativa del navegador (speechSynthesis).
+ */
+
+let voices = [];
+let voicesLoaded = false;
+
+function loadVoices() {
+  return new Promise((resolve) => {
+    if (voicesLoaded) {
+      resolve(voices);
+      return;
+    }
+
+    const setVoices = () => {
+      voices = window.speechSynthesis?.getVoices() || [];
+      voicesLoaded = voices.length > 0;
+      resolve(voices);
+    };
+
+    if (window.speechSynthesis) {
+      setVoices();
+      window.speechSynthesis.onvoiceschanged = () => {
+        setVoices();
+      };
+    } else {
+      resolve([]);
+    }
+  });
+}
+
+export async function getVoices() {
+  if (!voicesLoaded) {
+    await loadVoices();
+  }
+  return voices;
+}
+
+export function getSpanishVoice() {
+  const spanish = voices.find(
+    (v) => v.lang.startsWith('es') && v.name.toLowerCase().includes('female')
+  );
+  if (spanish) return spanish;
+
+  const anySpanish = voices.find((v) => v.lang.startsWith('es'));
+  if (anySpanish) return anySpanish;
+
+  const defaultVoice = voices.find(
+    (v) => v.name.toLowerCase().includes('google') && v.lang.startsWith('es')
+  );
+  if (defaultVoice) return defaultVoice;
+
+  return voices[0] || null;
+}
+
+export function speak(text, options = {}) {
+  if (!window.speechSynthesis) {
+    console.warn('[TTS] speechSynthesis not supported');
+    return null;
+  }
+
+  stop();
+
+  const utterance = new SpeechSynthesisUtterance(text);
+
+  const {
+    rate = 0.9,
+    pitch = 1.0,
+    volume = 0.8,
+    voice = null,
+  } = options;
+
+  utterance.rate = rate;
+  utterance.pitch = pitch;
+  utterance.volume = volume;
+
+  if (voice) {
+    utterance.voice = voice;
+  } else {
+    const spanishVoice = getSpanishVoice();
+    if (spanishVoice) {
+      utterance.voice = spanishVoice;
+    }
+  }
+
+  utterance.lang = 'es-CO';
+
+  window.speechSynthesis.speak(utterance);
+
+  return utterance;
+}
+
+export function stop() {
+  if (window.speechSynthesis) {
+    window.speechSynthesis.cancel();
+  }
+}
+
+export function pause() {
+  if (window.speechSynthesis) {
+    window.speechSynthesis.pause();
+  }
+}
+
+export function resume() {
+  if (window.speechSynthesis) {
+    window.speechSynthesis.resume();
+  }
+}
+
+export function isSpeaking() {
+  return window.speechSynthesis?.speaking || false;
+}
+
+export function isPaused() {
+  return window.speechSynthesis?.paused || false;
+}
+
+export function init() {
+  loadVoices();
+}
+
+export default {
+  speak,
+  stop,
+  pause,
+  resume,
+  isSpeaking,
+  isPaused,
+  getVoices,
+  getSpanishVoice,
+  init,
+};


### PR DESCRIPTION
## Summary
- Add `ttsService.js` using Web Speech API
- AgentScreen now speaks responses aloud when TTS is enabled
- Toggle button in header to enable/disable voice

## Features
- Auto-speak IA responses using Spanish voice
- Toggle button (speaker icon) to mute/unmute
- Uses browser's native speechSynthesis API
- Graceful fallback if TTS not supported

## Testing
- npm run build ✅
- npm run lint ✅