### PR TITLE
feat(ui): add AgentFab for easy access to IA assistant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.93",
+  "version": "0.12.94",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v135';
+const CACHE_NAME = 'chagra-v136';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import PendingTasksWidget from './components/PendingTasksWidget';
 import SyncProgressIndicator from './components/common/SyncProgressIndicator';
 import FieldFeedback from './components/FieldFeedback';
 import MicFab from './components/MicFab';
+import AgentFab from './components/AgentFab';
 import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
 import IosInstallBanner from './components/IosInstallBanner';
@@ -363,6 +364,7 @@ export default function App() {
       {/* FAB feedback inline para field testing, siempre visible salvo loading */}
       {currentView !== 'loading' && currentView !== 'login' && <FieldFeedback />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && <MicFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <AgentFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
       {currentView !== 'loading' && currentView !== 'login' && <SyncProgressIndicator />}
       {toast && (

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Sparkles } from 'lucide-react';
+import useIdleVisibility from '../hooks/useIdleVisibility';
+
+export default function AgentFab({ onNavigate }) {
+  const isVisible = useIdleVisibility(2000);
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      type="button"
+      aria-label="Asistente IA"
+      title="Hablar con el asistente IA"
+      onClick={() => onNavigate('agente')}
+      style={{
+        position: 'fixed',
+        bottom: 'max(18px, env(safe-area-inset-bottom))',
+        right: 18,
+        width: 56,
+        height: 56,
+        borderRadius: '50%',
+        border: '2px solid #a78bfa',
+        background: 'linear-gradient(135deg, #7c3aed 0%, #4c1d95 100%)',
+        color: 'white',
+        cursor: 'pointer',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.4), 0 0 14px #a78bfa55',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 40,
+      }}
+    >
+      <Sparkles size={24} />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `AgentFab` floating button (violet sparkles) on bottom-right
- Visible on all screens except login/voice/agent
- Opens AgentScreen when clicked

## Fix
- Now Agent IA is accessible via FAB button (violet, right side)
- MicFab stays on left (voice capture)
- FieldFeedback stays (feedback)

## Testing
- npm run build ✅
- npm run lint ✅

## Notes
- CORS errors from FarmOS are infrastructure-side (FarmOS config needed)
- "Failed to fetch" errors are expected when not authenticated - app works offline