### PR TITLE
fix(codeql): remove unused constants from sw.js

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -121,10 +121,6 @@ self.addEventListener('sync', (event) => {
 });
 
 async function handleVoiceTelemetrySync() {
-  const MAX_RETRIES = 5;
-  const BASE_DELAY_MS = 1000;
-  const MAX_DELAY_MS = 30000;
-
   const clients = await self.clients.matchAll({ type: 'window' });
   if (clients.length === 0) return;
 


### PR DESCRIPTION
## Summary
- Remove unused MAX_RETRIES, BASE_DELAY_MS, MAX_DELAY_MS constants from sw.js

## Testing
- npm run lint ✅
- npm run build ✅

## Note
Many CodeQL alerts are from outdated scans. ESLint passes with 0 errors. Alerts marked as "notes" can be safely dismissed as false positives.