### PR TITLE
fix(ui): improve error handling, fix agent fab visibility, and enhance crop extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.94",
+  "version": "0.12.95",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v136';
+const CACHE_NAME = 'chagra-v137';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { Sparkles } from 'lucide-react';
-import useIdleVisibility from '../hooks/useIdleVisibility';
 
 export default function AgentFab({ onNavigate }) {
-  const isVisible = useIdleVisibility(2000);
-
-  if (!isVisible) return null;
-
   return (
     <button
       type="button"
@@ -15,7 +10,7 @@ export default function AgentFab({ onNavigate }) {
       onClick={() => onNavigate('agente')}
       style={{
         position: 'fixed',
-        bottom: 'max(18px, env(safe-area-inset-bottom))',
+        bottom: 'max(90px, calc(env(safe-area-inset-bottom) + 90px))',
         right: 18,
         width: 56,
         height: 56,

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -45,9 +45,11 @@ export const fetchFromFarmOS = async (endpoint, options = {}) => {
 
   const token = await getAccessToken();
   if (!token) {
-    console.error('[API] Token no disponible. Redirigiendo a login.');
-    if (typeof window !== 'undefined') window.location.hash = '#login';
-    throw new Error('Token no disponible. Reautentique desde el login.');
+    const isLoginPage = typeof window !== 'undefined' && window.location.hash === '#login';
+    if (!isLoginPage) {
+      console.warn('[API] Token no disponible. Continuando en modo offline.');
+    }
+    throw new Error('Token no disponible.');
   }
 
   const isFormData = options.body instanceof FormData;

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -35,10 +35,12 @@ Reglas:
 - Si el lugar no se menciona, usa "" como location (NO omitas la entrada por eso).
 - VERBOS: el operador puede decir "sembré", "planté", "puse", "trasplante", "metí", "agregué" — todos se interpretan como registro de planta nueva. El verbo en sí no es la entidad; lo que importa es {cultivo, cantidad, lugar}.
 - MULTI-ESPECIE en una grabacion: si el operador menciona varios cultivos separados por "y", "luego", "tambien", "ademas", devuelve UN OBJETO POR CADA CULTIVO. Cada uno hereda la location si solo se menciona al final aplicable a todos.
+- Nombres de frutas y cultivos son LITERALES. Si el operador dice "banano", el crop debe ser "banano". Si dice "manzana", el crop debe ser "manzana". NO cambiar, traducir ni sustituir nunca.
+- Cultivos comunes colombianos: banano, platano, cafe, yuca, papaya, mango, limon, mandarina, naranja, aguacate, tomate, lechuga, cilantro, yerbabuena.
 - Nunca inventes datos que no estan en la transcripcion.
 - Si no puedes extraer ninguna entidad valida, devuelve [].
 
-Ejemplos:
+Ejemplos de cultivos colombianos:
 Input: "Sembre cinco tomates en el invernadero"
 Output: [{"crop":"tomate","quantity":5,"location":"invernadero"}]
 
@@ -60,7 +62,22 @@ Output: [{"crop":"guayabo","quantity":2,"location":"entrada"}]
 Input: "Puse cinco aguacates en el patio"
 Output: [{"crop":"aguacate","quantity":5,"location":"patio"}]
 
-Input: "Hoy tuve un buen dia"
+Input: "Sembre quince bananos"
+Output: [{"crop":"banano","quantity":15,"location":""}]
+
+Input: "Plante tres platanos en la zona norte"
+Output: [{"crop":"platano","quantity":3,"location":"zona norte"}]
+
+Input: "Sembre diez mangos y veinte papayas"
+Output: [{"crop":"mango","quantity":10,"location":""},{"crop":"papaya","quantity":20,"location":""}]
+
+Input: "Puse cuatro limones en el huerto"
+Output: [{"crop":"limon","quantity":4,"location":"huerto"}]
+
+Input: "Sembre dos yucas en el solar"
+Output: [{"crop":"yuca","quantity":2,"location":"solar"}]
+
+Input: "Hoy tive un buen dia"
 Output: []`;
 
 // location puede venir vacia cuando el operador no menciona el lugar;


### PR DESCRIPTION
## Summary
- **apiService.js**: Log warning instead of redirecting to login when token unavailable (fixes "Failed to fetch" UI errors)
- **AgentFab.jsx**: Remove `useIdleVisibility`, always visible, moved up to avoid overlap with MicFab (fixes "Agent IA button not visible")
- **entityExtractor.js**: Add Colombian crops (banano, platano, yuca, papaya, etc.) to prevent qwen3.5 hallucinations confusing 'banano' with 'manzana' (fixes voice registration error)

## Testing
- [x] ESLint passes (0 errors)
- [x] Build succeeds
- [ ] Deploy to stg and verify AgentFab visible
- [ ] Test voice registration with "sembré bananos" to verify crop extraction