### PR TITLE
fix(cors): use same-origin API endpoint via Nginx proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.95",
+  "version": "0.12.96",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -8,6 +8,6 @@
     "estado": "activo",
     "altitud": 2550,
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",
-    "farmos_endpoint": "https://guatoc.farmos.net"
+    "farmos_endpoint": ""
   }
 ]

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v137';
+const CACHE_NAME = 'chagra-v138';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/fincaActiveStore.js
+++ b/src/services/fincaActiveStore.js
@@ -23,7 +23,7 @@ const useFincaActiveStore = create(
                 const state = get();
                 const finca = state.fincas.find(f => f.slug === state.activeFincaSlug);
                 // Default a Guatoc si no hay coincidencia (seguridad v2-strict)
-                return finca?.farmos_endpoint || 'https://guatoc.farmos.net';
+                return finca?.farmos_endpoint || '';
             },
 
             getActiveFinca: () => {


### PR DESCRIPTION
## Summary
- Cambia `farmos_endpoint` a `''` (mismo origen) en `fincas-publicas.json`
- Actualiza fallback en `fincaActiveStore.js` a `''`

## Por qué
La PWA llamaba directo a `https://guatoc.farmos.net/api/...` causando CORS errors (`Redirect is not allowed for a preflight request`). El Nginx de `chagra.guatoc.co` ya proxea `/api/` a FarmOS internamente, así que usando rutas relativas se evita el problema.

## Verificación
- `npm run build` OK
- Pre-commit hooks (eslint, security scans) OK