### PR TITLE
fix(voice): await stopRecord() promise, handle null blob, guard RAG content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.97",
+  "version": "0.12.98",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v139';
+const CACHE_NAME = 'chagra-v140';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -210,7 +210,12 @@ export default function AgentScreen({ onBack }) {
 
   const handleVoiceRecord = async () => {
     if (state === STATE_RECORDING) {
-      const blob = stopRecord();
+      const blob = await stopRecord();
+      if (!blob) {
+        setState(STATE_IDLE);
+        setError('No se capturó audio. Intenta de nuevo.');
+        return;
+      }
       setState(STATE_THINKING);
 
       try {

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -92,6 +92,8 @@ async function loadCorpus() {
     try {
       const res = await fetch(`${CORPUS_PATH}${slug}.json`);
       if (!res.ok) continue;
+      const ct = res.headers.get('content-type') || '';
+      if (!ct.includes('json')) continue;
       const data = await res.json();
       const passages = flattenDoc(data);
       passages.forEach((p) => {


### PR DESCRIPTION
## Summary
- **AgentScreen.jsx**: add `await` before `stopRecord()` (was returning Promise instead of blob), add null blob guard
- **ragRetriever.js**: check `content-type` header before parsing JSON to avoid crash on HTML responses (SPA fallback)

This is the actual fix for the transcribe bug — the previous PR #276 only changed the error message formatting but missed the `await`.

## Verificación
- `npm run build` OK
- Pre-commit hooks OK