### PR TITLE
chore(public): regenerar fincas-publicas.json — farmos_endpoint Guatoc corregido

### DIFF
--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -2,12 +2,13 @@
   {
     "slug": "guatoc",
     "nombre": "Guatoc",
-    "operador": "Miguel Guerrero",
-    "coords": [4.5167, -73.9333],
+    "coords": [
+      4.5167,
+      -73.9333
+    ],
     "biocultural_zone": "andino_alto_páramo",
     "estado": "activo",
-    "altitud": 2550,
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",
-    "farmos_endpoint": ""
+    "farmos_endpoint": "https://farmos.guatoc.co"
   }
 ]


### PR DESCRIPTION
Output regenerado por scripts/build-fincas-publicas-json.mjs tras sync del yaml source en Chagra-strategy. Solo Guatoc cambia visible: farmos_endpoint 'https://guatoc.farmos.net' → 'https://farmos.guatoc.co'. Las otras 3 fincas piloto (Naranjalia, Roca Blanca, Los Sitios) siguen visibility: unlisted y no aparecen en este JSON public.