### PR TITLE
fix: regenerar fincas-publicas.json restaurando operador + altitud (hotfix #305)

### DIFF
--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -2,10 +2,12 @@
   {
     "slug": "guatoc",
     "nombre": "Guatoc",
+    "operador": "Miguel Guerrero",
     "coords": [
       4.5167,
       -73.9333
     ],
+    "altitud": 2400,
     "biocultural_zone": "andino_alto_páramo",
     "estado": "activo",
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",


### PR DESCRIPTION
Hotfix de la regresión visible introducida por PR #305 que perdió los campos operador y altitud que FincaCard.jsx + MultiFincaGlobe.jsx renderean. JSON ahora restaura Miguel Guerrero como operador de Guatoc y altitud 2400 msnm (era 2550 antes — corregido desde yaml source 2400).