### PR TITLE
fix(api): mapping FarmOS 3.x → 4.x bundles (task→activity, planting→seeding, person gone)

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -37,11 +37,90 @@ const fetchWithTimeout = async (resource, options = {}) => {
   }
 };
 
+/**
+ * Mapping de bundles legacy de FarmOS 3.x → FarmOS 4.x.
+ * FarmOS 4.x renombró:
+ *   - log/task     → log/activity (los "tasks" se modelan como activities)
+ *   - log/planting → log/seeding (los "plantings" se llaman seedings)
+ *   - asset/person → NO EXISTE (los users de FarmOS 4.x son `users`, no assets;
+ *                    Chagra debe migrar gradualmente a usar /user en su lugar)
+ * Aplicado 2026-05-13 tras install fresh FarmOS 4.x en alpha.
+ *
+ * Este mapping es transición: el cliente sigue usando los nombres viejos
+ * internamente (log--task, log--planting) por compatibilidad con código
+ * existente; sólo la URL outgoing se traduce. Roadmap: migrar el cliente
+ * a los nombres canónicos FarmOS 4.x en sprint post-Diana.
+ */
+const FARMOS_BUNDLE_RENAMES = [
+  { legacy: '/api/log/task',     modern: '/api/log/activity' },
+  { legacy: '/api/log/planting', modern: '/api/log/seeding'  },
+];
+
+// Mapping bidireccional de `type` field en payloads JSON:API.
+// El cliente Chagra usa nombres legacy internamente (log--task, log--planting);
+// el servidor FarmOS 4.x usa los modernos (log--activity, log--seeding).
+const TYPE_LEGACY_TO_MODERN = {
+  'log--task':     'log--activity',
+  'log--planting': 'log--seeding',
+};
+const TYPE_MODERN_TO_LEGACY = {
+  'log--activity': 'log--task',
+  'log--seeding':  'log--planting',
+};
+
+/**
+ * Walk recursivo de un objeto/array y aplica el mapping a campos `type` string.
+ * NO modifica el input — devuelve copia transformada.
+ */
+const remapTypes = (node, mapping) => {
+  if (Array.isArray(node)) return node.map((x) => remapTypes(x, mapping));
+  if (node && typeof node === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'type' && typeof v === 'string' && mapping[v]) {
+        out[k] = mapping[v];
+      } else {
+        out[k] = remapTypes(v, mapping);
+      }
+    }
+    return out;
+  }
+  return node;
+};
+
+const remapLegacyBundleUrl = (endpoint) => {
+  for (const { legacy, modern } of FARMOS_BUNDLE_RENAMES) {
+    if (endpoint.startsWith(legacy)) {
+      // Substituir solo el prefijo, preservar query string y demás.
+      return modern + endpoint.slice(legacy.length);
+    }
+  }
+  return endpoint;
+};
+
+// Endpoints que NO existen en FarmOS 4.x — devolver respuesta vacía graceful
+// en lugar de 404 que confunde al operador con error rojo en consola.
+const FARMOS_BUNDLE_GONE = [
+  '/api/asset/person',  // FarmOS 4.x no tiene asset/person; users = /user
+];
+
+const isGoneBundle = (endpoint) =>
+  FARMOS_BUNDLE_GONE.some((prefix) => endpoint.startsWith(prefix));
+
 export const fetchFromFarmOS = async (endpoint, options = {}) => {
   if (import.meta.env.VITE_DEMO_MODE === 'true') {
     console.log(`[DEMO] blocked FarmOS call to ${endpoint}`);
     return {};
   }
+
+  // Bundles inexistentes en FarmOS 4.x — graceful empty respuesta.
+  if (isGoneBundle(endpoint)) {
+    console.info(`[API] Bundle obsoleto en FarmOS 4.x ignorado: ${endpoint}`);
+    return { data: [], jsonapi: { version: '1.0' } };
+  }
+
+  // Mapping de bundles renombrados FarmOS 3.x → 4.x.
+  const mappedEndpoint = remapLegacyBundleUrl(endpoint);
 
   const token = await getAccessToken();
   if (!token) {
@@ -65,12 +144,26 @@ export const fetchFromFarmOS = async (endpoint, options = {}) => {
     delete headers['Content-Type'];
   }
 
+  // Outgoing: mapear `type: log--task` → `log--activity` etc. en el body
+  // JSON antes de enviar al server. NO toca FormData (que usa multipart).
+  let outgoingBody = options.body;
+  if (!isFormData && typeof outgoingBody === 'string' && outgoingBody.includes('"type"')) {
+    try {
+      const parsed = JSON.parse(outgoingBody);
+      const remapped = remapTypes(parsed, TYPE_LEGACY_TO_MODERN);
+      outgoingBody = JSON.stringify(remapped);
+    } catch (_) {
+      // Body no es JSON parseable — dejar como está.
+    }
+  }
+
   try {
     const { useFincaActiveStore } = await import('./fincaActiveStore.js');
     const baseUrl = useFincaActiveStore.getState().getActiveEndpoint();
-    const response = await fetchWithTimeout(`${baseUrl}${endpoint}`, {
+    const response = await fetchWithTimeout(`${baseUrl}${mappedEndpoint}`, {
       ...options,
       method: options.method || 'GET',
+      body: outgoingBody,
       headers
     });
 
@@ -92,7 +185,11 @@ export const fetchFromFarmOS = async (endpoint, options = {}) => {
       error.detail = errorDetail;  // raw preservado para debug en console
       throw error;
     }
-    return await response.json();
+    // Incoming: mapear `type: log--activity` → `log--task` etc. en la
+    // respuesta JSON:API antes de devolver al caller. Mantiene compat
+    // con el resto del cliente que sigue esperando nombres legacy.
+    const data = await response.json();
+    return remapTypes(data, TYPE_MODERN_TO_LEGACY);
   } catch (error) {
     if (error.name === 'AbortError') console.error('[Network] Timeout excedido en solicitud a FarmOS:', endpoint);
     throw error;


### PR DESCRIPTION
Resuelve los 404 de /api/log/task, /api/log/planting, /api/asset/person tras install fresh FarmOS 4.x. Mapping centralizado en apiService.js bidireccional (URL outgoing + body type field + response type field) — el resto del cliente no requiere cambios.