### PR TITLE
fix(ai): swap qwen3.5:4b → gemma3:4b — Ollama 0.23.1 cuelga con qwen35 arch

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -124,7 +124,7 @@ export default function AgentScreen({ onBack }) {
     try {
       return await streamOllama(
         OLLAMA_URL,
-        { model: 'qwen3.5:4b', messages },
+        { model: 'gemma3:4b', messages },
         (_chunk, fullText) => setStreamingContent(fullText),
       );
     } catch (e) {

--- a/src/components/GuildSuggestions.jsx
+++ b/src/components/GuildSuggestions.jsx
@@ -115,8 +115,7 @@ export const GuildSuggestions = ({ speciesId, onSelectCompanion }) => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          model: 'qwen3.5:4b',
-          think: false,
+          model: 'gemma3:4b',
           stream: false,
           messages: [
             { role: 'system', content: 'Asistente de diseño de gremios agroecológicos. Responde SOLO en JSON válido, sin texto adicional.' },

--- a/src/components/HelpVoiceQuestion.jsx
+++ b/src/components/HelpVoiceQuestion.jsx
@@ -155,8 +155,7 @@ Formato: párrafo breve (máximo unas 8 oraciones). Sin listas largas salvo que 
       full = await streamOllama(
         OLLAMA_CHAT_URL,
         {
-          model: ENV.NLU_MODEL || 'qwen3.5:4b',
-          think: false,
+          model: ENV.NLU_MODEL || 'gemma3:4b',
           messages: [
             { role: 'system', content: system },
             { role: 'user', content: userMsg },

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -16,7 +16,7 @@ import { detectAndTruncateRepetition } from '../utils/repetitionGuard';
  * Flujo:
  *   1. Suscripción WebSocket a Home Assistant para sensores configurados.
  *   2. Detección de valor anormal (umbral por especie/zona).
- *   3. Streaming de análisis agronómico via Ollama (qwen3.5:4b o gemma3:4b).
+ *   3. Streaming de análisis agronómico via Ollama (gemma3:4b).
  *   4. Acción dispatched por operador → log--maintenance + cooldown idempotente.
  *
  * LLM constraints (v0.7.2):
@@ -472,8 +472,7 @@ export default function TelemetryAlerts() {
         const content = await streamOllama(
           `${OLLAMA_URL}/api/chat`,
           {
-            model: 'qwen3.5:4b',
-            think: false,
+            model: 'gemma3:4b',
             messages: [
               { role: 'system', content: 'Asistente agronómico para finca agroecológica andina (2400msnm). PROHIBIDO recomendar agroquímicos sintéticos. Solo biopreparados orgánicos (biol, caldo sulfocálcico, caldo bordelés, purín de ortiga, compost tea, microorganismos de montaña, Trichoderma). Responde en máximo 3 frases concisas, sin superlativos, sin repetir información.' },
               { role: 'user', content: userPrompt },
@@ -488,7 +487,7 @@ export default function TelemetryAlerts() {
             onDone: (parsed) => {
               if (parentSignal?.aborted) return;
               setAiMeta({
-                model: parsed.model || 'qwen3.5:4b',
+                model: parsed.model || 'gemma3:4b',
                 totalDuration: parsed.total_duration ? (parsed.total_duration / 1e9).toFixed(1) : null,
                 evalCount: parsed.eval_count || null,
                 promptTokens: parsed.prompt_eval_count || null,

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -53,7 +53,7 @@ const STATE_DONE = 'done';
 /**
  * VoiceCapture, UI principal del módulo de ingreso acústico.
  *
- * Pipeline: grabar → transcribir (Whisper) → extraer (qwen3.5:4b) → revisar
+ * Pipeline: grabar → transcribir (Whisper) → extraer (gemma3:4b) → revisar
  * humano (VoiceConfirmation) → encolar en pending_transactions.
  *
  * Si transcripción o extracción fallan con error de red, ofrece encolar el
@@ -557,7 +557,7 @@ export default function VoiceCapture({ onSave }) {
                 active
                 label="Extrayendo entidades"
                 accent="muzo"
-                meta={<span className="font-mono">qwen3.5:4b</span>}
+                meta={<span className="font-mono">gemma3:4b</span>}
               />
             </div>
           )}

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -18,5 +18,5 @@ export const ENV = {
   // Modelos de inferencia (configurables sin recompilar).
   // Cambia en .env cuando bumpees el modelo en el Nodo Alpha.
   STT_MODEL: import.meta.env.VITE_STT_MODEL || 'base',
-  NLU_MODEL: import.meta.env.VITE_NLU_MODEL || 'qwen3.5:4b',
+  NLU_MODEL: import.meta.env.VITE_NLU_MODEL || 'gemma3:4b',
 };

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -1,5 +1,5 @@
 /**
- * entityExtractor.js — Extracción de entidades agrícolas vía Ollama / qwen3.5:4b.
+ * entityExtractor.js — Extracción de entidades agrícolas vía Ollama / gemma3:4b.
  *
  * Toma una transcripción en español y devuelve un array estricto de
  * { crop, quantity, location }. Aplica AbortController (timeout 20s) y
@@ -8,13 +8,17 @@
  * Desde v0.6.0 consume la respuesta en streaming NDJSON a través de
  * `streamOllama` y acepta `onToken` para que la UI muestre el JSON
  * apareciendo carácter-a-carácter mientras el modelo genera.
+ *
+ * 2026-05-13: swap qwen3.5:4b → gemma3:4b. qwen35 architecture cuelga
+ * determinísticamente en Ollama 0.23.1 (timeout >120s, retorna 500).
+ * gemma3:4b responde ~10s con calidad equivalente para extracción JSON.
  */
 
 import { streamOllama } from './ollamaStream';
 
 const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
-const MODEL = 'qwen3.5:4b';
-// qwen3 puede tardar 25-35s en CPU incluso con thinking desactivado.
+const MODEL = 'gemma3:4b';
+// gemma3:4b en CPU responde ~10-15s para extracción JSON con format:json.
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;
 
@@ -119,10 +123,6 @@ export async function extractEntities(text, { onToken } = {}) {
       {
         model: MODEL,
         format: 'json',
-        // qwen3 tiene "thinking mode" siempre activo por default; consume
-        // todos los num_predict razonando antes de emitir content y deja
-        // content="". think:false desactiva esa cadena de razonamiento.
-        think: false,
         messages: [
           { role: 'system', content: SYSTEM_PROMPT },
           { role: 'user', content: text },


### PR DESCRIPTION
## Summary

- **Bloqueante crítico pre-Diana 2026-05-19**: el asistente IA quedaba colgado en \"Pensando...\" porque `qwen3.5:4b` retorna 500 después de 90-120s en Ollama 0.23.1 (alpha).
- Swap a `gemma3:4b` (ya operativo, ~10s respuesta) en los 5 puntos donde la PWA llama al modelo NLU.
- Diagnóstico confirmado con \`curl /api/chat\` directo: gemma3 200 OK, qwen3.5 500 timeout. Log Ollama muestra \`operator() double registration of ggml_uncaught_exception\` durante el load de qwen35 architecture.
- Re-pull del modelo no soluciona (es bug del runtime, no de pesos).

## Archivos

- \`src/config/env.js\` — NLU_MODEL default → 'gemma3:4b'.
- \`src/components/AgentScreen/AgentScreen.jsx\` — asistente IA principal.
- \`src/services/entityExtractor.js\` — extracción de entidades + nota del swap.
- \`src/components/TelemetryAlerts.jsx\` — análisis IA telemetría sensores.
- \`src/components/GuildSuggestions.jsx\` — sugerencias de gremio.
- \`src/components/HelpVoiceQuestion.jsx\` — fallback consistency.
- \`src/components/VoiceCapture.jsx\` — metadata UI + comentario pipeline.
- Removido \`think: false\` flag de payloads (era específico qwen3 thinking mode; gemma3 no lo necesita).

## Test plan

- [ ] CI: lint + Playwright + CodeQL deben pasar.
- [ ] Post-merge: deploy automático vía workflow self-hosted.
- [ ] En PROD chagra.guatoc.co: grabar audio en asistente IA, verificar que ya no queda en \"Pensando...\".
- [ ] Verificar extracción de entidades funciona con \"Sembré 5 tomates en el invernadero\".
- [ ] Verificar TelemetryAlerts genera análisis si sensores disponibles.

## Follow-ups identificados (no en este PR)

- Bump Ollama 0.23.1 → 0.24+ en NixOS alpha — investigar si versión reciente arregla el bug qwen35.
- Benchmark de qwen2.5-coder:7b (4.7GB) y llama3.x para decidir si vale la pena un modelo mayor o quedar con gemma3:4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)