### PR TITLE
fix(a11y): aria-label='Nueva tarea' en TaskLogScreen — desbloquea E2E #299

### DIFF
--- a/src/components/TaskLogScreen.jsx
+++ b/src/components/TaskLogScreen.jsx
@@ -100,8 +100,12 @@ function TaskLogScreen({ onBack, onNewTask }) {
               <span className="text-sm">Offline</span>
             </div>
           )}
-          <button onClick={onNewTask} className="p-3 bg-muzo rounded-full active:bg-muzo-glow min-h-[56px] min-w-[56px] flex justify-center items-center shrink-0 border border-slate-700 shadow-neon-muzo">
-            <span className="text-3xl font-black text-slate-950">+</span>
+          <button
+            onClick={onNewTask}
+            aria-label="Nueva tarea"
+            className="p-3 bg-muzo rounded-full active:bg-muzo-glow min-h-[56px] min-w-[56px] flex justify-center items-center shrink-0 border border-slate-700 shadow-neon-muzo"
+          >
+            <span className="text-3xl font-black text-slate-950" aria-hidden="true">+</span>
           </button>
           <button onClick={syncTasks} disabled={isSyncing} className="p-2 bg-slate-800 rounded-full active:bg-slate-700 min-h-[40px] min-w-[40px] flex justify-center items-center shrink-0 border border-slate-600">
             <RefreshCw size={16} className={isSyncing ? 'animate-spin' : ''} />

--- a/tests/task-log.spec.js
+++ b/tests/task-log.spec.js
@@ -62,8 +62,10 @@ test.describe('ADR-019 Fase 5: log--task & Inmutabilidad', () => {
         // 1. Navegar a nueva tarea — usar aria-label exacto del tile (no regex /tareas/i
         // que matchea 3 botones: refresh, Campo, Cola). Tile dashboard "Tareas: Cola
         // de pendientes" es el que abre TaskLogScreen donde vive el botón "+".
+        // El botón "+" ahora tiene aria-label="Nueva tarea" (el span '+' es
+        // aria-hidden) — accessible name calculation con sólo `+` era frágil.
         await page.getByLabel('Tareas: Cola de pendientes').click();
-        await page.getByRole('button', { name: '+' }).click();
+        await page.getByRole('button', { name: 'Nueva tarea' }).click();
 
         // 2. Llenar formulario — TaskScreen.jsx:83 usa placeholder
         // "Ej: Riego fertiorgánico". El label "Título de la Operación"


### PR DESCRIPTION
## Summary

- E2E task-log.spec.js fallaba con `page.getByRole('button', { name: '+' })`: accessible name calc sobre span único con '+' es frágil en Playwright.
- Fix accesible: aria-label='Nueva tarea' explícito + span '+' marcado aria-hidden. Mejora A11Y (lectores anuncian 'Nueva tarea' en vez de '+').
- Test actualizado a getByRole con name='Nueva tarea'.

## Test plan

- [ ] CI: Playwright task-log.spec.js debe pasar.
- [ ] Visual: el botón sigue mostrando '+' en el header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)