### PR TITLE
feat(ai): AgentScreen → llama.cpp + OLMoE vía OpenAI SSE adapter

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -5,7 +5,7 @@ import { transcribe } from '../../services/voiceService';
 import { addTurn, getFullHistory, getContextString } from '../../services/conversationMemory';
 import { retrieve } from '../../services/ragRetriever';
 import { parseIntent, formatIntentDescription } from '../../services/agentIntentParser';
-import { streamOllama } from '../../services/ollamaStream';
+import { streamOpenAI } from '../../services/openaiStream';
 import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable } from '../../services/ttsService';
 import ChatHistory from './ChatHistory';
 import SuggestedActions from './SuggestedActions';
@@ -13,7 +13,11 @@ import ActionConfirmModal from '../ActionConfirmModal';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
 
-const OLLAMA_URL = '/api/ollama/api/chat';
+// llama-server nativo expone API OpenAI-compatible en /api/llamacpp/ (proxy
+// Nginx alpha → 127.0.0.1:11435). Migrado desde /api/ollama/ según DR
+// hardware-llm-optimization CLOSED 2026-05-11: OLMoE-1B-7B Q4_K_M sobre
+// llama.cpp nativo (Flash Attention + KV cache q8_0 + AVX2 host-specific).
+const LLM_URL = '/api/llamacpp/v1/chat/completions';
 
 const STATE_IDLE = 'idle';
 const STATE_RECORDING = 'recording';
@@ -122,16 +126,21 @@ export default function AgentScreen({ onBack }) {
     ];
 
     try {
-      return await streamOllama(
-        OLLAMA_URL,
-        { model: 'gemma3:4b', messages },
+      return await streamOpenAI(
+        LLM_URL,
+        {
+          model: 'olmoe-1b-7b-instruct',
+          messages,
+          temperature: 0.7,
+          max_tokens: 512,
+        },
         (_chunk, fullText) => setStreamingContent(fullText),
       );
     } catch (e) {
       if (e.name === 'AbortError') {
         throw new Error('Tiempo agotado, conexion lenta');
       }
-      const match = e.message.match(/^Ollama (\d+)/);
+      const match = e.message.match(/^LLM (\d+)/);
       if (match) {
         const status = parseInt(match[1], 10);
         if (status === 401 || status === 403) {

--- a/src/services/openaiStream.js
+++ b/src/services/openaiStream.js
@@ -1,0 +1,146 @@
+/**
+ * openaiStream.js — Cliente SSE para backends OpenAI-compatibles (v0.13.0).
+ *
+ * Reemplaza a ollamaStream.js para consumidores que apuntan a /api/llamacpp/
+ * (llama-server nativo, ver DR hardware-llm 2026-05-11) o cualquier otro
+ * backend que exponga /v1/chat/completions estándar OpenAI.
+ *
+ * Formato de respuesta SSE (Server-Sent Events) — distinto al NDJSON de Ollama:
+ *
+ *   data: {"choices":[{"delta":{"content":"hola"}}],"model":"olmoe"}\n\n
+ *   data: {"choices":[{"delta":{"content":" mundo"}}]}\n\n
+ *   data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{...}}\n\n
+ *   data: [DONE]\n\n
+ *
+ * Cada chunk inicia con `data: ` y termina con doble newline. El último
+ * mensaje literal es `data: [DONE]\n\n` (sin JSON, marca el fin). El chunk
+ * antes de `[DONE]` puede contener `usage` (tokens consumidos) y
+ * `finish_reason` ('stop', 'length', 'tool_calls', etc.) — equivalente al
+ * objeto `{ done: true, ... }` de Ollama.
+ *
+ * Requiere que el proxy (Nginx) desactive buffering sobre /api/llamacpp/:
+ *   proxy_buffering off;
+ *   proxy_cache off;
+ *   chunked_transfer_encoding on;
+ * (configurado en hosts/alpha/default.nix, mismo patrón que /api/ollama/).
+ */
+
+const SSE_DATA_PREFIX = 'data: ';
+
+const parseSSEData = (rawData) => {
+  const trimmed = rawData.trim();
+  if (!trimmed || trimmed === '[DONE]') return null;
+  try { return JSON.parse(trimmed); } catch (_) { return null; }
+};
+
+const extractDeltaContent = (parsed) => {
+  if (!parsed || !Array.isArray(parsed.choices)) return '';
+  const choice = parsed.choices[0];
+  if (!choice) return '';
+  // streaming: delta.content (token incremental)
+  if (choice.delta && typeof choice.delta.content === 'string') {
+    return choice.delta.content;
+  }
+  // non-stream fallback: message.content (respuesta completa de una)
+  if (choice.message && typeof choice.message.content === 'string') {
+    return choice.message.content;
+  }
+  return '';
+};
+
+const isDoneChunk = (parsed) =>
+  parsed && Array.isArray(parsed.choices) &&
+  parsed.choices.some((c) => c?.finish_reason);
+
+/**
+ * Invoca un endpoint OpenAI-compatible en modo streaming y emite cada token.
+ *
+ * @param {string}   url       endpoint (ej. '/api/llamacpp/v1/chat/completions').
+ * @param {Object}   body      payload OpenAI (model, messages, temperature, etc).
+ *                             El flag `stream` se sobreescribe a true.
+ * @param {Function} [onToken] callback (chunk, fullText) por cada delta.content.
+ * @param {Object}   [options]
+ * @param {AbortSignal} [options.signal] señal de aborto.
+ * @param {Function}    [options.onDone] callback con el último chunk parseado
+ *        (incluye `usage` y `finish_reason` si el backend lo emite).
+ * @returns {Promise<string>} texto completo concatenado.
+ * @throws {Error} si fetch falla, no-2xx, o body no streameable.
+ */
+export async function streamOpenAI(url, body, onToken, { signal, onDone } = {}) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'text/event-stream',
+    },
+    body: JSON.stringify({ ...body, stream: true }),
+    signal,
+  });
+
+  if (!response.ok) {
+    let detail = '';
+    try { detail = await response.text(); } catch (_) { /* noop */ }
+    const { buildCleanErrorMessage } = await import('./sanitizeError.js');
+    const ctype = response.headers?.get?.('content-type') || '';
+    throw new Error(buildCleanErrorMessage('LLM', response.status, response.statusText, detail, ctype));
+  }
+  if (!response.body) {
+    throw new Error('Respuesta sin body streameable (¿buffering del proxy?)');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let fullText = '';
+  let lastParsed = null;
+  let done = false;
+
+  try {
+    while (!done) {
+      const { value, done: streamDone } = await reader.read();
+      if (streamDone) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE separa eventos por doble newline. Cada evento puede tener
+      // múltiples líneas pero para chat completions siempre es una sola
+      // línea `data: {...}`.
+      let sep;
+      while ((sep = buffer.indexOf('\n\n')) !== -1) {
+        const eventBlock = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+
+        for (const line of eventBlock.split('\n')) {
+          if (!line.startsWith(SSE_DATA_PREFIX)) continue;
+          const rawData = line.slice(SSE_DATA_PREFIX.length);
+          if (rawData.trim() === '[DONE]') {
+            done = true;
+            break;
+          }
+          const parsed = parseSSEData(rawData);
+          if (!parsed) continue;
+          lastParsed = parsed;
+          const chunk = extractDeltaContent(parsed);
+          if (chunk) {
+            fullText += chunk;
+            if (onToken) onToken(chunk, fullText);
+          }
+          if (isDoneChunk(parsed)) {
+            // Algunos backends emiten finish_reason ANTES del [DONE]
+            // literal; usage/eval_count viene en este último chunk.
+          }
+        }
+        if (done) break;
+      }
+    }
+  } finally {
+    try { reader.releaseLock(); } catch (_) { /* noop */ }
+  }
+
+  if (onDone && lastParsed) {
+    try { onDone(lastParsed); } catch (_) { /* noop */ }
+  }
+
+  return fullText;
+}
+
+export default streamOpenAI;


### PR DESCRIPTION
## Summary

Primer consumer del backend **llama.cpp nativo** (puerto 11435, OpenAI-compat) introducido por DR hardware-llm-optimization CLOSED 2026-05-11. AgentScreen es el chat principal del operador.

Resto de componentes (entityExtractor, TelemetryAlerts, GuildSuggestions, HelpVoiceQuestion) siguen con Ollama+gemma3:4b hasta validar empíricamente OLMoE vs gemma3 en este flujo.

## Cambios

- **Nuevo**: \`src/services/openaiStream.js\` — cliente SSE OpenAI-compat (\`/v1/chat/completions\`). Distinto a \`ollamaStream\` NDJSON: parse \`data: {...}\n\n\` + literal \`data: [DONE]\n\n\`. Extrae \`delta.content\` del array \`choices\`. Callbacks \`onToken\` + \`onDone\` (último chunk expone usage / finish_reason).
- **\`src/components/AgentScreen/AgentScreen.jsx\`**:
  - import \`streamOllama\` → \`streamOpenAI\`
  - URL \`/api/ollama/api/chat\` → \`/api/llamacpp/v1/chat/completions\`
  - body \`{ model: 'gemma3:4b', messages }\` → \`{ model: 'olmoe-1b-7b-instruct', messages, temperature: 0.7, max_tokens: 512 }\`
  - Error matcher: \`/^Ollama (\\d+)/\` → \`/^LLM (\\d+)/\` (genérico)

## Backend (NO en este PR, repo guatoc-nixos)

- \`hosts/alpha/default.nix\`: location \`^~ /api/llamacpp/\` → 127.0.0.1:11435 (proxy_buffering off + chunked + timeout 300s SSE).
- \`modules/ai/llamacpp-native.nix\`: ya existía + 3 fixes aplicados:
  - URL modelo \`allenai/...SFT-GGUF\` (401, no existe) → \`bartowski/OLMoE-1B-7B-0924-Instruct-GGUF\` (Q4_K_M verificado).
  - \`systemd.tmpfiles.rules\` antes del service (\`WorkingDirectory\` chdir() ANTES de ExecStartPre → 200/CHDIR loop infinito).
  - \`TimeoutStartSec=30min\` (default 90s rompe primera descarga ~4.2 GiB a 6 MB/s ≈ 12 min).

## Rollback

Revertir este PR. Backend Ollama+gemma3:4b queda intacto en el resto de componentes; AgentScreen volvería a usarlo.

## Validación post-merge

- \`nixos-rebuild switch --flake .#alpha\` aplica módulo + nginx proxy.
- \`llamacpp-server\` descarga OLMoE-1B-7B Q4_K_M (~4.2 GiB primera vez).
- \`curl http://127.0.0.1:11435/v1/models\` debe devolver el modelo.
- AgentScreen UI: grabar audio + esperar respuesta. RTF esperado 30-37 t/s según DR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)