### PR TITLE
perf(rag): manifest cycle-content evita N-3 fetches 404 en primera carga (audit #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "node scripts/generate-cycle-content-manifest.mjs",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,0 +1,8 @@
+{
+  "generated_at": "2026-05-14T03:21:49.549Z",
+  "slugs": [
+    "fresa",
+    "lechuga",
+    "tomate_chonto"
+  ]
+}

--- a/scripts/generate-cycle-content-manifest.mjs
+++ b/scripts/generate-cycle-content-manifest.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * generate-cycle-content-manifest.mjs
+ *
+ * Genera public/cycle-content/manifest.json listando los slugs JSON que
+ * SÍ existen en el corpus RAG. ragRetriever.js usa este manifest para
+ * iterar SOLO sobre archivos presentes en lugar de N fetches del
+ * CROP_TAXONOMY entero (~80% de los cuales caían en 404).
+ *
+ * Bug observado: la primera carga del AgentScreen disparaba ~N fetches
+ * a /cycle-content/{slug}.json sin verificación previa. Solo 3-N
+ * archivos existen físicamente (fresa, lechuga, tomate_chonto), las
+ * demás devolvían 404 mitigado con content-type guard (PR #277) pero
+ * con latencia importante en mobile rural. Audit pre-Diana hallazgo #8.
+ *
+ * Script idempotente. Corre antes de `vite build` vía npm prebuild.
+ */
+
+import { readdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CYCLE_CONTENT_DIR = join(__dirname, '..', 'public', 'cycle-content');
+const MANIFEST_PATH = join(CYCLE_CONTENT_DIR, 'manifest.json');
+
+if (!existsSync(CYCLE_CONTENT_DIR)) {
+  console.warn(`[manifest] ${CYCLE_CONTENT_DIR} no existe — skipeando.`);
+  process.exit(0);
+}
+
+const files = readdirSync(CYCLE_CONTENT_DIR)
+  .filter((f) => f.endsWith('.json') && f !== 'manifest.json')
+  .map((f) => f.replace(/\.json$/, ''))
+  .sort();
+
+const manifest = {
+  generated_at: new Date().toISOString(),
+  slugs: files,
+};
+
+writeFileSync(MANIFEST_PATH, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`[manifest] ${MANIFEST_PATH} — ${files.length} slug(s): ${files.join(', ')}`);

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -80,10 +80,38 @@ function flattenDoc(doc, prefix = '') {
   return passages;
 }
 
+/**
+ * Lee public/cycle-content/manifest.json para saber qué slugs JSON
+ * existen físicamente. Sin manifest, el loader iteraba el CROP_TAXONOMY
+ * entero (~30+ species) haciendo fetch a cada slug → mayoría 404 +
+ * fallback SPA HTML (mitigado por content-type guard) → latencia mobile
+ * rural. Audit pre-Diana hallazgo #8.
+ *
+ * El manifest se genera en build time (scripts/generate-cycle-content-manifest.mjs).
+ * Si el manifest no existe o falla la carga, fallback al comportamiento
+ * legacy (iterar CROP_TAXONOMY).
+ */
+async function loadManifest() {
+  try {
+    const res = await fetch(`${CORPUS_PATH}manifest.json`);
+    if (!res.ok) return null;
+    const ct = res.headers.get('content-type') || '';
+    if (!ct.includes('json')) return null;
+    const data = await res.json();
+    if (!Array.isArray(data?.slugs)) return null;
+    return data.slugs;
+  } catch (_) {
+    return null;
+  }
+}
+
 async function loadCorpus() {
   if (corpusCache) return corpusCache;
 
-  const species = Object.values(CROP_TAXONOMY).flatMap((group) =>
+  // Manifest first: si existe, itera solo los slugs presentes.
+  // Fallback: iterar CROP_TAXONOMY (legacy, con N-3 fetches fallidos).
+  const manifestSlugs = await loadManifest();
+  const species = manifestSlugs ?? Object.values(CROP_TAXONOMY).flatMap((group) =>
     group.species.map((sp) => sp.id)
   );
   const docs = [];


### PR DESCRIPTION
## Summary

Bug audit pre-Diana #8: `ragRetriever.js` `loadCorpus()` iteraba `CROP_TAXONOMY` (30+ species) fetcheando \`/cycle-content/{slug}.json\` para cada uno. Solo 3 archivos existen físicamente (fresa, lechuga, tomate_chonto). El resto devolvía 404 (mitigado parcial con content-type guard PR #277, pero latencia N requests se notaba en mobile rural).

## Cambios

- **\`scripts/generate-cycle-content-manifest.mjs\`** (nuevo): lista archivos JSON en \`public/cycle-content/\` y genera \`manifest.json\` con array de slugs presentes. Idempotente, corre antes de cada \`vite build\`.
- **\`package.json\`**: hook \`prebuild\` invoca el script. Cada \`npm run build\` regenera el manifest automáticamente cuando Lili añade species — NO requiere actualización manual.
- **\`src/services/ragRetriever.js\`**: nueva \`loadManifest()\` lee \`/cycle-content/manifest.json\`. Si existe, \`loadCorpus()\` itera SOLO esos slugs. Fallback graceful al comportamiento legacy si el manifest no está (deploys viejos, dev sin build).
- **\`public/cycle-content/manifest.json\`** (artefacto generado, checked-in intencionalmente para que el dev server inicial funcione sin build previo).

## Resultado

Primera carga AgentScreen: N fetches (~30, ~27 con 404) → exactamente N_slugs fetches (3 hoy). Latencia mobile rural mejora significativamente.

## Test plan

- [ ] CI lint + Playwright.
- [ ] Manual: AgentScreen primera carga, DevTools Network → verificar que solo se fetcha fresa/lechuga/tomate_chonto + manifest.json (no más 404 a /cycle-content/banano.json etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)