### PR TITLE
feat(security): eliminar VITE_HA_ACCESS_TOKEN del bundle PWA (audit #2)

### DIFF
--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -78,8 +78,10 @@ export default function TelemetryAlerts() {
   // lo renderice en su propio bloque cyberpunk diferenciado.
   const [aiFinalText, setAiFinalText] = useState('');
 
-  // Variables de Entorno (Requeridas en el archivo .env)
-  const HA_TOKEN = import.meta.env.VITE_HA_ACCESS_TOKEN;
+  // Authorization header se inyecta server-side en Nginx desde SOPS
+  // (audit #2). VITE_HA_ACCESS_TOKEN ya no se lee — el token vivía en el
+  // bundle JS y era leak Ley 1581. Ahora /api/ha/ proxy de chagra.guatoc.co
+  // agrega `proxy_set_header Authorization "Bearer ..."` con el secret.
 
   // Helper de observabilidad (v0.7.2)
   const logTelemetryEvent = (kind, payload = {}, level = 'info') => {
@@ -264,12 +266,6 @@ export default function TelemetryAlerts() {
       return;
     }
 
-    if (!HA_TOKEN) {
-      console.warn('TelemetryAlerts: VITE_HA_ACCESS_TOKEN no configurado en el archivo .env');
-      setError('Telemetria no disponible. Verifica configuracion con el administrador.');
-      return;
-    }
-
     setLoading(true);
     setError(null);
     setLiveAnalysis('');
@@ -277,9 +273,9 @@ export default function TelemetryAlerts() {
     setAiMeta(null);
 
     try {
-      // 1. Ingesta de Datos Domóticos (Home Assistant) - IDs Zigbee físicos
-      const haHeaders = { 'Authorization': `Bearer ${HA_TOKEN}`, 'Content-Type': 'application/json' };
-      const haOpts = { method: 'GET', headers: haHeaders, signal: parentSignal };
+      // 1. Ingesta de Datos Domóticos (Home Assistant) - IDs Zigbee físicos.
+      // Authorization se inyecta server-side via Nginx (audit #2 leak fix).
+      const haOpts = { method: 'GET', headers: { 'Content-Type': 'application/json' }, signal: parentSignal };
       const [invernaderoHum, invernaderoTemp, tabacoHum, tabacoTemp] = await Promise.all([
         fetch(`${HA_URL}/states/sensor.matera_cocina_humidity`, haOpts),
         fetch(`${HA_URL}/states/sensor.matera_cocina_temperature`, haOpts),
@@ -405,7 +401,7 @@ export default function TelemetryAlerts() {
       try {
         const histResp = await fetch(
           `${HA_URL}/history/period/${historyStart}?filter_entity_id=${entityIds.join(',')}&minimal_response&no_attributes`,
-          { headers: { 'Authorization': `Bearer ${HA_TOKEN}`, 'Content-Type': 'application/json' }, signal: parentSignal }
+          { headers: { 'Content-Type': 'application/json' }, signal: parentSignal }
         );
         if (histResp.ok) {
           const histData = await histResp.json();

--- a/src/components/UpdateAvailableBanner.jsx
+++ b/src/components/UpdateAvailableBanner.jsx
@@ -16,7 +16,7 @@ export default function UpdateAvailableBanner() {
       if (reg.waiting) {
         reg.waiting.postMessage({ type: 'SKIP_WAITING' });
       }
-    } catch {}
+    } catch (_) { /* SW not ready — recargar igual abajo */ }
     window.location.reload();
   };
 

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -12,7 +12,8 @@ for (const key of required) {
 export const ENV = {
   FARMOS_URL: import.meta.env.VITE_FARMOS_URL || '',
   FARMOS_CLIENT_ID: import.meta.env.VITE_FARMOS_CLIENT_ID || '',
-  HA_ACCESS_TOKEN: import.meta.env.VITE_HA_ACCESS_TOKEN || '',
+  // HA_ACCESS_TOKEN removido del bundle (audit #2). Authorization se
+  // inyecta server-side por Nginx desde SOPS (ver guatoc-nixos PR #91).
   DEFAULT_LOCATION_ID: import.meta.env.VITE_DEFAULT_LOCATION_ID || '',
   DEFAULT_FARM_NAME: import.meta.env.VITE_DEFAULT_FARM_NAME || 'Finca Principal',
   // Modelos de inferencia (configurables sin recompilar).


### PR DESCRIPTION
## ⚠️ DRAFT — MERGE DESPUÉS DE guatoc-nixos PR #91

Si se mergea este antes que el proxy server-side esté operativo, los browsers con bundle nuevo no enviarán Authorization → HA responde 401 → telemetry roto hasta que backend tenga el secret SOPS.

Orden de merge:
1. **guatoc-nixos PR #91** (HA token server-side proxy + SOPS secret + rebuild en alpha).
2. Verificar \`curl https://chagra.guatoc.co/api/ha/states\` (sin header) → 200.
3. Marcar este PR ready-for-review + mergear.

## Summary

Cierra audit pre-Diana **#2** — token HA hardcoded en bundle JS (leak Ley 1581 + ADR-020).

### Cambios

- **\`TelemetryAlerts.jsx\`**:
  - Removido \`const HA_TOKEN = import.meta.env.VITE_HA_ACCESS_TOKEN;\`.
  - Removido early-return \`if (!HA_TOKEN)\`.
  - Removido \`Authorization: Bearer ${HA_TOKEN}\` de las 2 fetches HA.

- **\`config/env.js\`**: removida entrada \`HA_ACCESS_TOKEN\`.

- **\`UpdateAvailableBanner.jsx\`** (fix lint pre-existente): \`catch {}\` → \`catch (_) { /* noop */ }\` para no-empty.

### Resultado bundle

Antes: \`VITE_HA_ACCESS_TOKEN eyJhbGc...\` embebido literalmente en JS.
Ahora: sin token, fetches a \`/api/ha/\` sin Authorization. Nginx inyecta server-side desde SOPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)