### PR TITLE
feat(privacy): activar Capa 1 HMAC en login (ADR-027.v)

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Sprout } from 'lucide-react';
 import { authenticateUser } from '../services/authService';
+import { setCurrentOperator } from '../services/operatorIdentityService';
 import { version as APP_VERSION } from '../../package.json';
 import ChagraGrowLoader from './ChagraGrowLoader';
 import LegalLinks from './LegalLinks';
@@ -18,11 +19,23 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
 
     setLoading(true);
     const result = await authenticateUser(creds.username, creds.password);
-    setLoading(false);
 
     if (result.success) {
+      // Activar Capa 1 HMAC (ADR-027.v): computa operator_id_hash determinista
+      // vía HMAC-SHA256(username, PBKDF2(account_uuid_master, "chagra-salt-v1"))
+      // y persiste en localStorage. Los consumidores (InventoryDashboard,
+      // RecountDrawer, PlanEditor) dejan de usar 'default-hash-0...' fallback.
+      try {
+        await setCurrentOperator(creds.username);
+      } catch (err) {
+        // No bloquear login si falla crypto (browser sin Web Crypto API).
+        // Componentes hacen fallback a default-hash. Tracking warning silenciosa.
+        console.warn('[LoginScreen] setCurrentOperator failed:', err);
+      }
+      setLoading(false);
       onLoginSuccess();
     } else {
+      setLoading(false);
       onSave(result.error || 'Error autenticando', true);
     }
   };


### PR DESCRIPTION
## Summary

Activa el módulo Capa 1 HMAC implementado en \`operatorIdentityService.js\` (ADR-027.v) invocando \`setCurrentOperator(username)\` en el login exitoso.

- \`src/components/LoginScreen.jsx\`: importa \`setCurrentOperator\` + invocación en \`handleLogin\` si \`authenticateUser\` retorna success.
- try/catch defensivo si browser no soporta Web Crypto API → no rompe login.
- 3 consumidores actuales (\`InventoryDashboard.jsx\`, \`RecountDrawer.jsx\`, \`PlanEditor.jsx\`) dejan de usar \`'default-hash-0...'\` fallback.

## Por qué

Audit valor real producto 2026-05-14 (\`Chagra-strategy/audit/2026-05-14-valor-real-producto/02-correcciones-audit.md\`) detectó que el módulo HMAC-SHA256 + PBKDF2 estaba **implementado pero dormido**. \`grep -rn setCurrentOperator src/\` retornaba 0 invocaciones fuera del propio servicio.

Activarlo hace defendible la promesa ADR-041 "Capa 1 HMAC implementada" ante Diana Posada (reunión 2026-05-19 MinAgricultura) sin tener que re-frasear a "arquitectura documentada Fase 1".

## Test plan

- [ ] Login con credenciales válidas → verificar \`localStorage.getItem('chagra:current_operator_hash')\` ≠ null + 64 chars hex
- [ ] Login con credenciales inválidas → no setea hash (current_operator_hash unchanged)
- [ ] Logout → \`clearCurrentOperator()\` ya estaba implementado, verificar limpieza
- [ ] InventoryDashboard.jsx después de login → consumir hash real, no 'default-hash-0...'
- [ ] Playwright E2E: tests existentes no deberían romper (cobertura indirecta via auth flow)

## Referencias

- ADR-027.v Habeas Data Ley 1581 Capa 1 pseudonimización determinista
- audit/2026-05-14-valor-real-producto/02-correcciones-audit.md
- \`src/services/operatorIdentityService.js\` (módulo ya existente, sin cambios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)