### PR TITLE
chore(workflow): opencode model big-pickle → nemotron-3-super-free

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -147,16 +147,23 @@ jobs:
           # (mantiene `claude-code` en extraPackages como backup para
           # reactivación si operador habilita billing Anthropic API).
           #
+          # PIVOT 2026-05-14: big-pickle reportó cola larga + silent failures
+          # post auditoría master valor real producto. Cambio a nemotron-3-super-free
+          # (Nvidia Nemotron Super 3, free tier 2026, fuerte JSON + reasoning
+          # científico estructurado, mejor para species + valor_pedagogico
+          # narrativo). Fallback alternativos: minimax-m2.5-free (long-context),
+          # hy3-preview-free (Hyper-Yarn 3 preview).
+          #
           # opencode run flags:
           # --dir: working directory donde opencode opera (incluye cd to repo)
           # --dangerously-skip-permissions: equivalente a --permission-mode acceptEdits
-          # -m opencode/big-pickle: modelo free tier opencode.ai (sin API key)
+          # -m opencode/nemotron-3-super-free: Nvidia Nemotron Super free tier
           # --format json: streaming JSON events para audit chain
           # message como argv positional (opencode no acepta stdin como prompt)
           opencode run \
             --dir "$GITHUB_WORKSPACE" \
             --dangerously-skip-permissions \
-            -m opencode/big-pickle \
+            -m opencode/nemotron-3-super-free \
             --format json \
             "$(cat "$PROMPT_FILE")" \
             > "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary

Cambia el modelo opencode default en claude-code-generate.yml de \`big-pickle\` a \`nemotron-3-super-free\` (Nvidia Nemotron Super 3 free tier 2026).

## Por qué

Audit valor real producto 2026-05-14 detectó que big-pickle:
- Cola larga sin notificación de fallo
- PR #390 Polylepis test QUEUED 15+ min sin que el workflow Generate inicie
- 10 PRs catalog en ready-to-generate sin runs ejecutados post 05:30Z

Nvidia Nemotron Super 3 es candidato:
- JSON output estructurado fuerte (relevante para schema v3.1 species)
- Reasoning científico (relevante para valor_pedagogico + Tier A sources)
- Free tier sin API key

## Test plan

Después de merge, reabrir Issue Polylepis quadrijuga single-species test, aplicar \`ready-to-generate\` label, monitor con \`gh run watch\` hasta:
- Si Nemotron genera species cumpliendo 6 ítems self-check (valor_pedagogico ≥200 chars, source Tier A, altitud coherente, etc) → pipeline rescatado
- Si Nemotron también falla → pivotar a opencode/minimax-m2.5-free, o último recurso humano+LLM (Lili agroecóloga + plantilla LLM-asistida).

## Referencias

- audit/2026-05-14-valor-real-producto/00-master-audit.md (Chagra-strategy)
- audit/2026-05-14-valor-real-producto/03-multifinca-status-y-valuacion.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)