### PR TITLE
legal(catalog): CC BY-SA 4.0 → CC BY-NC-SA 4.0 — Vector C anti-robo (ADR-043)

### DIFF
--- a/catalog/.zenodo.json
+++ b/catalog/.zenodo.json
@@ -18,7 +18,7 @@
   "upload_type": "dataset",
   "publication_date": "2026-05-14",
   "access_right": "open",
-  "license": "CC-BY-SA-4.0",
+  "license": "CC-BY-NC-SA-4.0",
   "keywords": [
     "agroecología",
     "Colombia",

--- a/catalog/CITATION.cff
+++ b/catalog/CITATION.cff
@@ -5,7 +5,7 @@ abstract: "Catálogo agroecológico estructurado para la PWA Chagra con especies
 type: dataset
 version: "3.1.0"
 date-released: 2026-05-14
-license: CC-BY-SA-4.0
+license: CC-BY-NC-SA-4.0
 repository-code: "https://github.com/guatoc-ecohub/Chagra"
 url: "https://chagra.guatoc.co"
 authors:
@@ -41,5 +41,5 @@ preferred-citation:
       affiliation: Guatoc
   year: 2026
   version: "3.1.0"
-  license: CC-BY-SA-4.0
+  license: CC-BY-NC-SA-4.0
   url: "https://github.com/guatoc-ecohub/Chagra/tree/main/catalog"

--- a/catalog/LICENSE.md
+++ b/catalog/LICENSE.md
@@ -1,5 +1,69 @@
-Creative Commons Attribution-ShareAlike 4.0 International Public License
+# Chagra Catálogo — Licencia CC BY-NC-SA 4.0
 
-By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions...
+**Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License**
 
-(See https://creativecommons.org/licenses/by-sa/4.0/legalcode for the full license text.)
+Copyright © 2026 Guatoc · Chagra Catálogo Agroecológico Colombiano
+
+Este catálogo de especies, fuentes y biopreparados (los archivos JSON
+`chagra-catalog-seed-v3.1.json`, `sources-seed.json`, `biopreparados-seed.json`
+y el contenido derivado en este directorio `catalog/`) se distribuye bajo
+los términos de la licencia **Creative Commons Attribution-NonCommercial-ShareAlike
+4.0 International (CC BY-NC-SA 4.0)**.
+
+Atribución obligatoria: **"Chagra catálogo, Guatoc, v3.1, 2026"**.
+
+Resumen humano (no jurídicamente vinculante — el texto legal está en el enlace abajo):
+
+- ✅ **Compartir** — copiar y redistribuir el material en cualquier medio y formato
+- ✅ **Adaptar** — remezclar, transformar y construir sobre el material
+- ⚠️ **Atribución (BY)** — Debe dar crédito a Guatoc + Chagra catálogo, proporcionar
+  un enlace a la licencia, e indicar si se realizaron cambios. Puede hacerlo de
+  cualquier manera razonable, pero no de forma que sugiera que el licenciador
+  lo respalda a usted o a su uso.
+- ⛔ **No Comercial (NC)** — No puede utilizar el material para una finalidad
+  comercial. Para usos comerciales (incluyendo integración en software propietario
+  vendido, productos SaaS con sello propio que monetizan estos datos, o servicios
+  agtech que cobren por acceso a los datos), debe solicitar **licencia dual
+  comercial** a Guatoc en `contacto@guatoc.co`.
+- 🔁 **Compartir Igual (SA)** — Si remezcla, transforma o construye sobre el
+  material, debe distribuir sus contribuciones bajo la **misma licencia** que
+  el original.
+
+Texto legal completo: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+
+## Excepción para uso institucional sin ánimo de lucro
+
+El uso por entidades académicas (universidades + grupos investigación CTI&I),
+ONGs sin ánimo de lucro, cooperativas agrarias de economía solidaria, jardines
+botánicos públicos, y entidades del Estado colombiano (MinAgricultura,
+MinAmbiente, IAvH, Agrosavia, ICA, ADR, ANT, jardines botánicos municipales)
+se considera **NO COMERCIAL bajo esta licencia siempre que:**
+
+1. Mantengan la atribución completa "Chagra catálogo, Guatoc, v3.1, 2026"
+2. No reempaqueten los datos como propios sin atribución
+3. No los cedan a terceros con ánimo de lucro sin autorización Guatoc
+4. Si publican obras derivadas (e.g., análisis académicos, datasets ampliados),
+   las publiquen también bajo CC BY-NC-SA 4.0 (cláusula ShareAlike)
+
+## Migración desde CC BY-SA 4.0 (2026-05-14)
+
+Versiones anteriores de este catálogo se distribuían bajo CC BY-SA 4.0. Se
+migró a CC BY-NC-SA 4.0 el 2026-05-14 conforme decisión documentada en
+**ADR-043** del repo `Chagra-strategy` (motivo: Vector C anti-robo —
+prevenir absorción extractiva del catálogo por entidades comerciales o
+contratistas estatales sin atribución ni licencia dual).
+
+Las obras derivadas creadas bajo la licencia anterior (CC BY-SA 4.0) antes
+de 2026-05-14 mantienen sus términos originales. Las nuevas derivaciones
+deben cumplir CC BY-NC-SA 4.0.
+
+## DOI Zenodo
+
+Este catálogo tiene DOI registrado en Zenodo (ver `.zenodo.json` + `CITATION.cff`)
+para timestamping autoral verificable + trazabilidad internacional.
+
+## Contacto licencia dual / autorización comercial
+
+Para usos comerciales que excedan la licencia CC BY-NC-SA 4.0, escribir a:
+
+**contacto@guatoc.co** — Guatoc · Chagra Catálogo

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -1,6 +1,6 @@
 # Chagra — Catálogo agroecológico público
 
-**Licencia:** CC-BY-SA 4.0 (no bajo AGPL-3.0 del código). Ver `LICENSE.md` en este directorio.
+**Licencia:** CC BY-NC-SA 4.0 (catálogo) · AGPL-3.0 (código de la PWA). Ver `LICENSE.md` en este directorio. Migrado desde CC BY-SA 4.0 el 2026-05-14 (Vector C anti-robo, ADR-043). Atribución obligatoria: "Chagra catálogo, Guatoc, v3.1, 2026". Uso institucional sin ánimo de lucro contemplado como NO COMERCIAL bajo esta licencia.
 
 **Source of truth canónico:** este directorio en el repo público `guatoc-ecohub/Chagra`. Decisión formalizada en **ADR-026** (Scope público/privado del catálogo) y **ADR-025** (Format reconciliation markdown ↔ JSON).
 
@@ -14,7 +14,7 @@
 | `biopreparados-seed.json` | Catálogo de biopreparados agroecológicos |
 | `sources-seed.json` | Fuentes científicas referenciadas por `species[].source_ids` |
 | `AMBIGUITIES_RESOLUTION.md` | Las 11 ambigüedades del schema v3 resueltas (ADR-013) |
-| `LICENSE.md` | CC-BY-SA 4.0 con atribución requerida |
+| `LICENSE.md` | CC BY-NC-SA 4.0 con atribución requerida (migrado 2026-05-14) |
 
 ## Pipeline ADR-025 (markdown frontmatter → JSON)
 


### PR DESCRIPTION
## Summary

Migra licencia catálogo agroecológico de **CC BY-SA 4.0** → **CC BY-NC-SA 4.0** (NonCommercial-ShareAlike) según decisión documentada en ADR-043 (Chagra-strategy). Vector C anti-robo del master audit valor real producto 2026-05-14.

## Cambios

- \`catalog/LICENSE.md\`: texto CC BY-NC-SA 4.0 completo + excepción uso institucional sin ánimo de lucro
- \`catalog/README.md\`: refs actualizadas (línea licencia + tabla)
- \`catalog/.zenodo.json\`: \`license: "CC-BY-NC-SA-4.0"\`
- \`catalog/CITATION.cff\`: \`license: CC-BY-NC-SA-4.0\`

## Excepción uso institucional sin ánimo de lucro (documentada en LICENSE.md)

Permite SIN cobro:
- ✅ Universidades + grupos investigación CT&I (UNAL, Pontificia, EAFIT, IES)
- ✅ ONGs sin ánimo de lucro
- ✅ Cooperativas agrarias economía solidaria
- ✅ Jardines botánicos públicos
- ✅ Entidades Estado colombiano (MinAgri, MinAmbiente, IAvH, Agrosavia, ICA, ADR, ANT)
- ✅ SWISSAID + cooperación internacional no lucrativa

Requiere licencia dual:
- ❌ Bayer / John Deere / AgWorld integración propietaria
- ❌ Contratistas estatales que cobran licencias por software cerrado con estos datos
- ❌ Start-ups agtech reempaquetan como propio
- ❌ SaaS B2B agtech monetiza acceso sin licencia dual

## Por qué

3 factores en master audit 2026-05-14:

1. **Crisis fiscal Agrosavia 2026** (protestas laborales abril) → cacería datasets gratuitos
2. **Catálogo es 0% usado en RAG conversacional** pero bundled como SQLite extraíble → activo "extraíble" sin atribución
3. **Diana Posada 2026-05-19** abre interlocución que podría capturar contratista estatal sin atribución

## Test plan

- [ ] \`python3 -m json.tool catalog/.zenodo.json\` parsea OK
- [ ] \`cffconvert --validate -i catalog/CITATION.cff\` valida CFF schema 1.2.0 (opcional)
- [ ] README.md renderiza correctamente en GitHub UI
- [ ] LICENSE.md cubre los 4 escenarios típicos uso (académico / cooperativa solidaria / Estado / privado comercial)

## Continuidad

NO retroactivo — derivaciones anteriores a 2026-05-14 mantienen CC BY-SA 4.0. Nuevas derivaciones desde 2026-05-14 cumplen NC-SA.

## Referencias

- ADR-043 (Chagra-strategy) — decisión completa
- audit/2026-05-14-valor-real-producto/00-master-audit.md sección Vector C
- DR Claude radiografía Agrosavia crisis fiscal
- ADR-026 scope público/privado catálogo (vigente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)