### PR TITLE
docs(testing): TESTING.md — estado y deuda E2E explícita

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,106 @@
+# Testing — Estado y Deuda E2E
+
+Documento canónico del estado de cobertura testing en Chagra. Auditado 2026-05-14 (master audit valor real producto).
+
+---
+
+## Stack testing
+
+- **Unit:** Vitest + @testing-library/react
+- **E2E:** Playwright Chromium (1 worker, retries=2)
+- **CI gates:** CodeQL SAST + Playwright Offline-first E2E (bloqueante merge)
+- **Pre-commit:** lefthook 5 hooks (secret-scan + infra-refs + Pro-import + ESLint + strategic-content)
+
+## Cobertura Vitest unit
+
+12 archivos test, ~708 líneas. Foco infraestructural:
+
+| Servicio | Spec |
+|---|---|
+| `fincaActiveStore` | `fincaActiveStore.test.js` |
+| `guildService` | `guildService.test.js` |
+| `inventoryReconcile` | `inventoryReconcile.test.js`, `inventoryService.fixture.test.js` |
+| `llmGuardrails` | `llmGuardrails.test.js` |
+| `regionalismsService` | `regionalismsService.test.js` |
+| `splitService` | `splitService.test.js` |
+| `HelpVoiceRegionalDemo` smoke | `HelpVoiceRegionalDemo.smoke.test.jsx` |
+
+**Cobertura precaria en core:**
+- `voiceService` (Whisper STT) — sin tests dedicados
+- `entityExtractor` (gemma3:4b JSON output) — sin tests dedicados
+- `VoiceCapture` (flow voz → review) — sin tests dedicados
+- `TelemetryAlerts` (HA proxy) — sin tests dedicados
+- `AgentScreen` (RAG LLM conversational) — sin tests dedicados
+- `operatorIdentityService` (HMAC Capa 1 ADR-027.v) — sin tests dedicados
+
+## Cobertura Playwright E2E
+
+15 spec files total. **2 active + 13 con `.skip` / `.fixme`**.
+
+### Specs ACTIVOS (2)
+
+| Spec | Cobertura | Bloqueante CI |
+|---|---|---|
+| `offline.spec.js` | DB_VERSION v12 + pending_transactions IndexedDB + offline→online sync (test canónico ADR-019) | **SÍ** |
+| `themes.spec.js` | Theme switching UI | NO (passa siempre) |
+| `task-log.spec.js` | Task log + asset log workflow | VERIFICACIÓN_PENDIENTE |
+| `plan-generator.spec.js` | PlanGenerator service flow | VERIFICACIÓN_PENDIENTE |
+| `external-ai-prompt.spec.js` | Externalize AI prompt builder | VERIFICACIÓN_PENDIENTE |
+
+### Specs SKIPPED (13) — deuda E2E explícita
+
+| Spec | Razón skip | Prioridad reactivar | Plazo |
+|---|---|---|---|
+| `asset-status-enum.spec.js` | Issue #90 setup pendiente | P2 backlog | Post-Diana Fase 1 |
+| `telemetry-llm-bounds.spec.js` | Harness completo no listo + cobertura unitaria del repetition guard ya suficiente | P3 backlog | Post Fase 2 |
+| `catalog-sqlite.spec.js` | Test carga 7 especies legacy v3.0; necesita actualización a 175 v3.1 | **P1** (reactivar) | Pre-Fase 1 |
+| `invasive.spec.js` | ADR-019 Phase 1 flujo invasoras+sustitución; requiere runner real iterado | P1 reactivar | Pre-Diana si tiempo |
+| `ai-inference.spec.js` | ADR-019 Phase 3 flujo inferencia + revisión humana; necesita endpoint stubs | **P1** reactivar | Pre-Fase 1 |
+| `date-field.spec.js` | iOS Safari emulation específica | P3 (iOS no es Android-first piloto) | Post Fase 2 |
+| `inventory-lww.spec.js` | ADR-019 Phase 4 LWW IndexedDB; requiere IDB+sync setup | P1 reactivar | Pre-Fase 1 |
+| `photo-capture-field.spec.js` | Componente PhotoCaptureField específico | P2 | Post-Diana |
+| `plant-asset-validation.spec.js` | Issue #89 validación asset; setup pendiente | P2 | Post-Diana |
+| `geolocation-ios.spec.js` | Issue #83 iOS Safari fix | P3 (Android-first) | Post Fase 2 |
+
+### Decisión por spec — pre-Diana / Fase 1
+
+**P1 reactivar Pre-Fase 1** (3 specs críticos):
+
+- `catalog-sqlite.spec.js` — actualizar a v3.1 (177 species, tier sources). Quemar 2-3h dev.
+- `ai-inference.spec.js` — stub endpoints Whisper + Ollama + Kokoro en CI; reactivar flow voz → JSON entity. Quemar 4-6h dev.
+- `inventory-lww.spec.js` — esencial para multi-finca Automerge Fase 1; reactivar antes de codificar federación. Quemar 4-6h.
+
+**P1 reactivar Pre-Diana si hay tiempo** (1 spec):
+
+- `invasive.spec.js` — flujo invasoras + sustitución nativa es palanca pitch Diana ("Resolución 684/2018 MADS + IAvH"). Si Lili tiene 2h sábado-domingo, reactivar. Si no, post-Diana.
+
+**P2/P3 mantener skipped** (9 specs):
+- Documentación clara en este TESTING.md de por qué siguen skipped.
+- No bloquear merge por estos. Reactivar oportunamente.
+
+## CI gates obligatorios merge
+
+Branch protection activa desde 2026-04-26:
+
+1. **CodeQL SAST** — `javascript-typescript` + queries `security-extended` + `security-and-quality`
+2. **Playwright E2E** — `Offline-first E2E` job sobre `tests/offline.spec.js`
+3. **lefthook pre-commit** (local) — bloqueante para developers
+
+## Roadmap testing Fase 1 (post-Diana)
+
+- Reactivar 3 specs P1 (catalog-sqlite + ai-inference + inventory-lww)
+- Agregar tests dedicados core no cubierto: voiceService, entityExtractor, VoiceCapture, AgentScreen, operatorIdentityService
+- Tests E2E multi-finca específicos (finca A escribe → finca B lee vía Automerge P2P)
+- Tests crypto-shred DEK por sujeto (ADR-027.v Capas 2-4)
+- Tests HMAC integration (post PR #391 activación)
+- Cobertura objetivo Fase 1: 60% lines + 80% critical paths
+
+## Verificación pendiente
+
+- ⚠️ `gh api repos/guatoc-ecohub/Chagra/branches/main/protection` reglas exactas no verificadas script automation (gh api JSON parsing error)
+- ⚠️ Tasa pass real Playwright E2E último mes (último deploy fde28c9 → chagra-fde28c9 pass)
+- ⚠️ CodeQL alerts abiertos: `gh api repos/guatoc-ecohub/Chagra/code-scanning/alerts` — requiere chequeo manual
+
+---
+
+**Documento canónico testing. Actualizar cada vez que se reactive/skipped un spec o se agregue cobertura nueva. Referenciado en CONTRIBUTING.md y AGENTS.md.**


### PR DESCRIPTION
## Summary
- Documenta el estado actual de testing y la deuda E2E explícita pendiente en el repo (`TESTING.md`, +106 líneas, nuevo archivo).
- Docs puros: no toca `src/**`, `public/**` ni `index.html` → SOP §3.2 paso 1 no requiere auto-bump de `package.json`/`sw.js` (verificado).

## Test plan
- [x] `git diff --staged | grep -iE "(token|bearer|password|secret|10\.88)"` — único hit es la mención del hook `secret-scan` en el propio doc (falso positivo).
- [ ] CodeQL (SAST) verde (no aplica realmente, sin código nuevo, pero exige el merge-gate §5.1).
- [ ] Playwright `tests/offline.spec.js` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)