### PR TITLE
fix(agent-screen): AbortController 90s en callLLM (fix "thinking" infinito)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -115,6 +115,14 @@ export default function AgentScreen({ onBack }) {
     await handleActionApprove(params);
   };
 
+  // Bug reportado 2026-05-15: el botón quedaba en "thinking" indefinido si
+  // la red/proxy colgaba sin emitir tokens (nginx tiene proxy_read_timeout
+  // 120s pero el fetch no lleva señal de aborto, así que ante un cuelgue
+  // silencioso el `finally` que resetea STATE_IDLE nunca dispara).
+  // Solución: AbortController con timeout 90s — antes que nginx cierre la
+  // conexión por su lado, fuerza AbortError → catch → finally → IDLE.
+  const LLM_TIMEOUT_MS = 90000;
+
   const callLLM = async (query, contextMemory, contextCorpus) => {
     const systemPrompt = getSystemPrompt();
     const corpusContext = contextCorpus.length > 0
@@ -127,6 +135,9 @@ export default function AgentScreen({ onBack }) {
       { role: 'user', content: query },
     ];
 
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS);
+
     try {
       return await streamOpenAI(
         LLM_URL,
@@ -137,6 +148,7 @@ export default function AgentScreen({ onBack }) {
           max_tokens: 512,
         },
         (_chunk, fullText) => setStreamingContent(fullText),
+        { signal: controller.signal },
       );
     } catch (e) {
       if (e.name === 'AbortError') {
@@ -154,6 +166,8 @@ export default function AgentScreen({ onBack }) {
         throw new Error(`Error al consultar IA (codigo: ${status})`);
       }
       throw new Error('IA no disponible, intenta de nuevo en un momento');
+    } finally {
+      clearTimeout(timer);
     }
   };
 


### PR DESCRIPTION
## Summary
- Bug reportado 2026-05-15 (operador): el botón Send en AgentScreen quedaba en "thinking" indefinido. Nunca aparecía respuesta de IA, ni siquiera mensaje del usuario en el chat (regresión vs versión previa donde el user message sí aparecía).
- Diagnóstico (sesión catalog autopilot): backend Ollama vivo, gemma3:4b cargado, curl directo `/api/ollama/v1/chat/completions` responde en ~10s con SSE válido. Problema 100% client-side: `streamOpenAI` no recibía AbortSignal → fetch hangueado ante cualquier silencio del proxy → `finally` que reset `STATE_IDLE` nunca dispara → state stuck en `THINKING`.
- Fix: AbortController con timeout 90s (margen sobre nginx `proxy_read_timeout 120s`), `clearTimeout` en finally.

## Por qué este patch (vs subir nginx timeout o cambiar modelo)
- nginx ya está bien (10s response time observado).
- gemma3:4b funciona (bench 15 t/s, calidad Tier A en chat).
- El gap real es el cliente sin abort.
- Cambio mínimo: 14 líneas, surface única (callLLM).

Diagnóstico completo en `Chagra-strategy/ops/diag-llm-2026-05-15.md` (H3 confirmada).

## Test plan
- [ ] Local: forzar timeout cortando red mid-stream → ver "Tiempo agotado, conexión lenta" + state vuelve a IDLE.
- [ ] Happy path: enviar mensaje → respuesta llega en <10s, streaming visible, no false-positive de aborto.
- [ ] Regresión: mensajes del usuario siguen apareciendo en chat antes de la respuesta (línea 169 setMessages).
- [ ] CodeQL + Playwright verdes.

## Hipótesis pendientes (no cubiertas por este PR)
- H1: Service Worker cache stale en navegador → operador limpia Storage.
- H2: IndexedDB upgrade v12 bloqueado → operador verifica DevTools → Application → IDB.
- H4: Vite bundle stale → hard refresh.

Aplicar este PR cubre el WORST CASE (stuck thinking). Si tras el merge el operador sigue sin ver respuestas, ejecutar el playbook de `diag-llm-2026-05-15.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)