### PR TITLE
fix(ci): generate workflow timeout 20→60min (Nemotron CPU bottleneck)

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -48,7 +48,14 @@ jobs:
           || github.event.sender.login == vars.CLAUDE_BOT_LOGIN)
       && github.event.pull_request.draft == true
     runs-on: [self-hosted, claude-runner]
-    timeout-minutes: 20
+    # 2026-05-15: bump 20→60min. Causa raíz observada: en runs.list de 3h se
+    # vieron 161 jobs disparados con resultado 2 success + 37 cancelled.
+    # journalctl github-runner-claude-code reveló patrón exacto: cada job
+    # cancelado dura 20m20s (timeout hit). Nemotron (qwen2.5-coder-7b en CPU
+    # Ryzen 4600G UMA) con prompts grandes (batch 3-5 incluyen datos
+    # verificados extraídos del JSON existente) no alcanza el budget. 60min
+    # cubre el peor caso observado en bench batch 1 (~10-15min típico).
+    timeout-minutes: 60
 
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
## Summary
- Pipeline catalog autopilot batch 3-5 (118 PRs) quedó **0 success en 3h, 37+ cancelados**. Diagnóstico via `journalctl github-runner-claude-code` reveló patrón exacto: **cada job cancelado dura 20m20s** = hit del cap `timeout-minutes: 20`, no fallo del modelo.
- Nemotron (qwen2.5-coder-7b CPU Ryzen 4600G UMA) con prompts batch 3-5 — que incluyen "DATOS VERIFICADOS" extraídos del JSON + few-shots Tier A — exceden 20min. Bench batch 1 (prompts simples) corría ~10-15min.
- Fix: bump `timeout-minutes` 20→60. Cubre peor caso observado con margen.

## Evidencia (journalctl alpha)

```
08:59:30 → 09:20:05  20m35s  Canceled
09:20:10 → 09:40:43  20m33s  Canceled
09:40:47 → 10:01:18  20m31s  Canceled
... cada 20m20s exactos sin parar
```

## Test plan
- [ ] CodeQL + Playwright verdes.
- [ ] Tras merge, re-trigger UN PR de batch 3 (re-aplicar ready-to-generate) y verificar que el generate completa <60min con content visible.
- [ ] Si batch 3 fluye sin canceladas, el resto se procesará serialmente.
- [ ] Follow-up post-cierre batch 5: evaluar slimming de prompts (quitar DATOS VERIFICADOS, dejar solo species_id + objetivo) para volver a 30min cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)