### PR TITLE
fix(help): lenguaje apto para niño 11 años + nombres comunes primero (cycle-content)

### DIFF
--- a/public/cycle-content/fresa.json
+++ b/public/cycle-content/fresa.json
@@ -7,7 +7,7 @@
   "difficulty": "starter_premium",
   "tiempo_a_cosecha_dias": { "min": 90, "tipico": 120, "max": 180 },
   "diferenciador_colombiano": "Cundinamarca produce el 73% de la fresa nacional. Industria de viveros locales en Sibaté y Mosquera ofrece plántula Albión adaptada. La amplitud térmica andina ecuatorial (18-25°C día / 8-13°C noche) favorece dulzura y antocianinas — perfil nutracéutico superior a cultivares de baja latitud. Práctica arraigada de productores cundinamarqueses: renovar cultivo cada 2 años con estolones propios.",
-  "leccion_agroecologica": "Cultivo puente entre agricultura sexual (lechuga) y asexual (café/aguacate por injerto). Enseña propagación vegetativa por estolón — clonación natural visible y manejable. Imperativo de higiene del microclima edáfico y función irreemplazable de cobertura muerta (mulch) para separar fruto del suelo.",
+  "leccion_agroecologica": "La fresa enseña cómo se hacen nuevas plantas de dos maneras: por semilla (como la lechuga) y por estolones (un tallo rastrero que produce plantas hijas idénticas, igual que el café o el aguacate por injerto). Es importante mantener limpio el ambiente del suelo y cubrirlo con paja (mulch) para que los frutos no toquen la tierra.",
   "thermal_zone_decisions": {
     "calido": "Marginal. Estrés térmico + ataque crítico de ácaros. NO recomendable para producción agroecológica.",
     "templado": "Rango operativo. Norte de Santander, parte de Antioquia. Ciclo más corto pero compromete calibre del fruto.",
@@ -43,7 +43,7 @@
       "fase": "trasplante",
       "dias_relativos": "0",
       "criterio_observable": "Masa radicular densa y blanca, 4 hojas extendidas, corona consolidada",
-      "accion_clave": "Siembra MILIMÉTRICA a ras de suelo. CRÍTICO: el meristemo apical (corona) NO se entierra (necrosis fúngica) ni se expone (desecación). Profundidad 6 cm desde corte de raíz"
+      "accion_clave": "Siembra muy precisa: el centro de la planta (corona, donde nacen las hojas nuevas) queda a ras del suelo. CRÍTICO: NI se entierra (porque le da pudrición por hongos) NI se deja expuesta (porque se seca). La raíz queda enterrada 6 cm desde su corte."
     },
     {
       "fase": "vegetativo_formativo",
@@ -66,58 +66,58 @@
   ],
   "failure_modes": [
     {
-      "razon": "Botrytis cinerea (moho gris)",
+      "razon": "Moho gris (Botrytis cinerea)",
       "cuando": "Fructificación",
-      "sintoma": "Masa miceliar grisácea y algodonosa sobre flores y drupas",
-      "agente_causal": "Alta humedad relativa estancada",
-      "mitigacion": "Mulch obligatorio, aclareo foliar para ventilación, distancia adecuada, recolección de frutos caídos, Trichoderma drench preventivo",
+      "sintoma": "Pelusa gris peluda como algodón sobre las flores y los frutos",
+      "agente_causal": "Demasiada humedad sin que el aire circule",
+      "mitigacion": "Cubre el suelo con paja o mantillo (mulch), corta hojas viejas para que pase el aire, deja espacio entre plantas, recoge los frutos caídos, aplica Trichoderma al suelo como prevención",
       "frecuencia": "muy_comun"
     },
     {
-      "razon": "Pudrición de corona por enterramiento",
-      "cuando": "Post-trasplante inmediato",
-      "sintoma": "Follaje central marchito, raíces oscurecidas, muerte rápida de la planta",
-      "agente_causal": "Asfixia o enterramiento patológico del meristemo apical",
-      "mitigacion": "Eras elevadas con drenaje profundo. Respeto absoluto al nivel del cuello en la siembra (corona a ras)",
+      "razon": "Pudrición del centro de la planta por siembra muy profunda",
+      "cuando": "Justo después de trasplantar",
+      "sintoma": "Hojas del centro marchitas, raíces oscuras, la planta se muere rápido",
+      "agente_causal": "La planta se ahogó porque enterraron el centro donde nacen las hojas nuevas",
+      "mitigacion": "Siembra en camas levantadas con buen drenaje. Deja el centro de la planta (corona) a ras del suelo, sin enterrarlo.",
       "frecuencia": "comun"
     },
     {
       "razon": "Araña roja (Tetranychus urticae)",
-      "cuando": "Periodos secos / verano",
-      "sintoma": "Decoloración bronceada y mate en hojas, telarañas microscópicas en envés",
-      "agente_causal": "Plaga favorecida por microclimas áridos",
-      "mitigacion": "Liberación de ácaros fitoseidos depredadores (Phytoseiulus persimilis, Amblyseius spp.), aspersión de extracto ajo-ají, sombra parcial",
+      "cuando": "Épocas secas o verano",
+      "sintoma": "Hojas de color bronce sin brillo y telarañas muy chiquititas debajo de las hojas",
+      "agente_causal": "Es una plaga que aparece cuando hay mucho calor seco",
+      "mitigacion": "Suelta ácaros buenos que se la comen (Phytoseiulus persimilis, Amblyseius). Rocía extracto de ajo y ají. Pon sombra parcial.",
       "frecuencia": "comun"
     },
     {
-      "razon": "Sphaerotheca macularis (oídio)",
-      "cuando": "Vegetativo a fructificación",
-      "sintoma": "Manchas pulverulentas blancas en hojas y frutos",
-      "agente_causal": "Hongo biotrofo, condiciones secas con noches frescas",
-      "mitigacion": "Caldo sulfocálcico al 1.5%, variedades resistentes (Albión moderada), evitar exceso de N",
+      "razon": "Oídio (Sphaerotheca macularis)",
+      "cuando": "Desde que crece la planta hasta dar fruto",
+      "sintoma": "Manchas blancas como polvo en hojas y frutos",
+      "agente_causal": "Hongo que aparece en días secos con noches frescas",
+      "mitigacion": "Aplica caldo sulfocálcico al 1.5%, usa variedades resistentes (como Albión), no le pongas demasiado abono nitrogenado",
       "frecuencia": "comun"
     },
     {
-      "razon": "Verticillium dahliae (marchitez vascular)",
-      "cuando": "Cualquier estadio",
-      "sintoma": "Marchitez progresiva, taponamiento del xilema",
-      "agente_causal": "Hongo edáfico de larga persistencia",
-      "mitigacion": "Rotación obligatoria — NO sembrar fresa después de tomate, papa, berenjena, pimentón. Solarización del lote.",
+      "razon": "Marchitez vascular (Verticillium dahliae)",
+      "cuando": "En cualquier momento del ciclo",
+      "sintoma": "La planta se va marchitando poco a poco porque el hongo tapa los tubos por donde sube el agua dentro de la planta",
+      "agente_causal": "Hongo del suelo que dura muchos años en el terreno",
+      "mitigacion": "Rotación obligatoria — NO siembres fresa después de tomate, papa, berenjena o pimentón. Cubre el terreno con plástico bajo el sol (solarización).",
       "frecuencia": "ocasional"
     }
   ],
   "companions": [
-    { "especie": "Borago officinalis (borraja)", "razon": "Atrae polinizadores (sírfidos, abejorros) — efecto sobre cuajado", "evidencia": "literatura agronomica" },
-    { "especie": "Tagetes patula (caléndula francesa)", "razon": "Producción de tiofenos nematicidas — control de Meloidogyne", "evidencia": "evidencia experimental" },
-    { "especie": "Allium sativum (ajo)", "razon": "Repelente de ácaros y áfidos; supresión moderada de Fusarium", "evidencia": "tradicion + literatura" },
-    { "especie": "Mentha piperita (menta)", "razon": "Compuestos volátiles desestabilizan radar olfativo de trips y áfidos", "evidencia": "literatura agronomica" },
-    { "especie": "Spinacia oleracea (espinaca)", "razon": "Complementariedad radicular + ventana fenológica fría", "evidencia": "tradicion" }
+    { "especie": "Borraja (Borago officinalis)", "razon": "Atrae abejas y sírfidos que polinizan — ayuda a que cuajen más frutos", "evidencia": "literatura agronomica" },
+    { "especie": "Caléndula francesa (Tagetes patula)", "razon": "Sus raíces sueltan sustancias que matan gusanitos del suelo (nematodos)", "evidencia": "evidencia experimental" },
+    { "especie": "Ajo (Allium sativum)", "razon": "Espanta ácaros y pulgones; ayuda contra el hongo Fusarium", "evidencia": "tradicion + literatura" },
+    { "especie": "Menta (Mentha piperita)", "razon": "Su olor confunde a los trips y pulgones para que no encuentren la fresa", "evidencia": "literatura agronomica" },
+    { "especie": "Espinaca (Spinacia oleracea)", "razon": "Sus raíces no pelean con las de la fresa y comparte la temporada fría", "evidencia": "tradicion" }
   ],
   "antagonistas": [
-    { "especie": "Solanum lycopersicum (tomate)", "razon": "Comparten Verticillium dahliae" },
-    { "especie": "Solanum tuberosum (papa)", "razon": "Mismo Verticillium" },
-    { "especie": "Solanum melongena (berenjena)", "razon": "Mismo Verticillium" },
-    { "especie": "Brassica oleracea (repollo, brócoli)", "razon": "Compite agresivamente por nitrógeno + modifica desfavorablemente el consorcio bacteriano de la rizósfera" }
+    { "especie": "Tomate (Solanum lycopersicum)", "razon": "Comparten el mismo hongo Verticillium dahliae" },
+    { "especie": "Papa (Solanum tuberosum)", "razon": "Comparten el mismo Verticillium" },
+    { "especie": "Berenjena (Solanum melongena)", "razon": "Comparten el mismo Verticillium" },
+    { "especie": "Repollo y brócoli (Brassica oleracea)", "razon": "Le quitan el nitrógeno a la fresa y cambian los microorganismos buenos del suelo" }
   ],
   "biopreparados": [
     { "nombre": "Bocashi", "uso": "200 g/planta al trasplante; 50 g/planta al inicio de cada pico de floración", "fuente": "extrapolacion literatura cubana/mexicana" },

--- a/public/cycle-content/lechuga.json
+++ b/public/cycle-content/lechuga.json
@@ -65,57 +65,57 @@
   ],
   "failure_modes": [
     {
-      "razon": "Espigado prematuro (bolting)",
-      "cuando": "Vegetativo tardío",
-      "sintoma": "Elongación abrupta del tallo, roseta se pierde, sabor amargo (lactucopicrina)",
-      "agente_causal": "Estrés térmico (>25°C) o hídrico/nitrogenado",
-      "mitigacion": "Variedades tolerantes (Batavia Salinas, romana Parris Island), siembra en época fresca, mulch para estabilizar humedad",
+      "razon": "Espigado: la lechuga se va a flor antes de tiempo",
+      "cuando": "Antes de cosechar",
+      "sintoma": "El tallo crece muy rápido hacia arriba, la lechuga pierde su forma redonda y las hojas saben amargas",
+      "agente_causal": "Hace mucho calor (más de 25°C) o le falta agua o tiene demasiado abono nitrogenado",
+      "mitigacion": "Usa variedades que aguantan calor (Batavia Salinas, romana Parris Island). Siembra en temporada fresca. Cubre el suelo con paja para que no se reseque.",
       "frecuencia": "muy_comun"
     },
     {
-      "razon": "Tip burn (necrosis marginal)",
-      "cuando": "Desarrollo vegetativo",
-      "sintoma": "Necrosis marginal de hojas jóvenes, aspecto de quemadura",
-      "agente_causal": "Deficiencia localizada de Ca por exceso de N o riegos desbalanceados",
-      "mitigacion": "Estabilización de pulsos de riego, aspersión foliar de calcio orgánico quelatado, mulch",
+      "razon": "Quemaduras en los bordes de las hojas (Tip burn)",
+      "cuando": "Cuando la planta está creciendo",
+      "sintoma": "Los bordes de las hojas jóvenes se ven como quemados, marrones y secos",
+      "agente_causal": "Le falta calcio porque tiene mucho nitrógeno o porque el riego está desbalanceado",
+      "mitigacion": "Riega de forma regular sin altibajos. Rocía las hojas con calcio orgánico. Cubre el suelo con paja.",
       "frecuencia": "comun"
     },
     {
-      "razon": "Damping-off (estrangulamiento basal)",
-      "cuando": "Germinación / semillero",
-      "sintoma": "Necrosis del cuello, colapso repentino de la plántula",
-      "agente_causal": "Pythium / Rhizoctonia por exceso de humedad y sustrato no desinfectado",
-      "mitigacion": "Solarización del sustrato, Trichoderma harzianum nativo, riego matutino, reducir lámina de riego",
+      "razon": "Caída de plantulitas (Damping-off)",
+      "cuando": "Cuando la semilla acaba de germinar",
+      "sintoma": "El tallo de la plántula se pone delgado en la base y la planta se cae de repente",
+      "agente_causal": "Hongos del suelo (Pythium o Rhizoctonia) por demasiada humedad en sustrato sin desinfectar",
+      "mitigacion": "Calienta el sustrato bajo el sol antes de sembrar (solarización). Usa Trichoderma. Riega en la mañana, no en la tarde. Reduce el agua.",
       "frecuencia": "comun"
     },
     {
       "razon": "Babosas y caracoles",
-      "cuando": "Trasplante a cosecha",
-      "sintoma": "Agujeros irregulares en hojas, baba plateada en el envés o suelo",
-      "agente_causal": "Moluscos gasterópodos nocturnos",
-      "mitigacion": "Trampas de cerveza, ceniza perimetral, conservación de carábidos depredadores, recolección manual nocturna",
+      "cuando": "Desde el trasplante hasta la cosecha",
+      "sintoma": "Hojas con agujeros irregulares y un rastro brillante plateado debajo o en el suelo",
+      "agente_causal": "Salen de noche a comerse las hojas",
+      "mitigacion": "Pon trampas con un poco de cerveza. Rodea las plantas con ceniza. Sal de noche con una linterna a recogerlos.",
       "frecuencia": "comun"
     },
     {
-      "razon": "Mildiu velloso",
-      "cuando": "Desarrollo vegetativo",
-      "sintoma": "Manchas amarillas en haz con micelio blanco-violáceo en envés",
-      "agente_causal": "Bremia lactucae, alta humedad relativa y rocío persistente",
-      "mitigacion": "Variedades resistentes (Bl:29-41EU Enza Zaden), distancia adecuada entre plantas, caldo bordelés preventivo 0.5%",
+      "razon": "Mildiu velloso (hongo Bremia lactucae)",
+      "cuando": "Cuando la planta está creciendo",
+      "sintoma": "Manchas amarillas en la parte de arriba de las hojas y una pelusa blanca con tono morado en la parte de abajo",
+      "agente_causal": "Mucha humedad en el aire y rocío que no se seca",
+      "mitigacion": "Usa variedades resistentes (Bl:29-41EU Enza Zaden). Deja espacio entre plantas. Aplica caldo bordelés al 0.5% como prevención.",
       "frecuencia": "ocasional"
     }
   ],
   "companions": [
-    { "especie": "Allium cepa (cebolla)", "razon": "Compuestos azufrados disuaden herbívoros foliares; complementariedad radicular (cebolla profunda, lechuga superficial)", "evidencia": "tradicion + literatura agronomica" },
-    { "especie": "Daucus carota (zanahoria)", "razon": "Complementariedad radicular (zanahoria pivotante)", "evidencia": "manuales agroecologicos andinos" },
-    { "especie": "Raphanus sativus (rábano)", "razon": "Cultivo de ciclo ultracorto (21 días) que se cosecha antes del acogollado de la lechuga", "evidencia": "tradicion" },
-    { "especie": "Spinacia oleracea (espinaca)", "razon": "Comparte ventana fenológica fría", "evidencia": "tradicion" },
-    { "especie": "Brassica oleracea (coles)", "razon": "Sinergia documentada en literatura agronómica internacional", "evidencia": "literatura internacional" }
+    { "especie": "Cebolla (Allium cepa)", "razon": "Su olor a azufre espanta insectos que se comen las hojas. Sus raíces van más hondo que las de la lechuga, así no pelean por espacio.", "evidencia": "tradicion + literatura agronomica" },
+    { "especie": "Zanahoria (Daucus carota)", "razon": "Su raíz baja recto hacia abajo y no pelea con las raíces de la lechuga", "evidencia": "manuales agroecologicos andinos" },
+    { "especie": "Rábano (Raphanus sativus)", "razon": "Crece muy rápido (21 días) y se cosecha antes de que la lechuga forme su corazón", "evidencia": "tradicion" },
+    { "especie": "Espinaca (Spinacia oleracea)", "razon": "Le gusta el mismo clima fresco que la lechuga", "evidencia": "tradicion" },
+    { "especie": "Coles (Brassica oleracea)", "razon": "Combinación que funciona bien según los libros de agricultura", "evidencia": "literatura internacional" }
   ],
   "antagonistas": [
-    { "especie": "Foeniculum vulgare (hinojo)", "razon": "Aleloquímicos agresivos inhiben germinación y expansión celular de la lechuga" },
-    { "especie": "Apium graveolens (apio)", "razon": "Competencia hídrica + atracción de plagas comunes (umbelíferas)" },
-    { "especie": "Helianthus annuus (girasol)", "razon": "Alelopatía (juglona-like)" }
+    { "especie": "Hinojo (Foeniculum vulgare)", "razon": "Suelta sustancias que no dejan crecer bien a la lechuga" },
+    { "especie": "Apio (Apium graveolens)", "razon": "Compite por agua y atrae plagas comunes" },
+    { "especie": "Girasol (Helianthus annuus)", "razon": "Sus raíces sueltan sustancias que afectan a la lechuga" }
   ],
   "biopreparados": [
     { "nombre": "Bocashi", "uso": "Pre-siembra: 1.5-2 kg/m² incorporado 10-12 días antes del trasplante", "fuente": "Boudet et al. 2017; Tolentino et al. 2023 (extrapolación desde tomate)" },

--- a/public/cycle-content/tomate_chonto.json
+++ b/public/cycle-content/tomate_chonto.json
@@ -34,7 +34,7 @@
       "distancia_plantas": "0.5 m",
       "tutorado_campo": "Espaldera colombiana — poste cada 4 m + alambre superior + hilo individual",
       "rotacion_critica": "ICA Antioquia (1980, 1981) demuestra que el limitante NO es fertilización sino enfermedad y rotación. Barbecho o rotación con leguminosa/maíz mínimo 2 ciclos antes de retornar tomate al lote.",
-      "trichoderma_pre": "Inoculación masiva de camas con Trichoderma spp. semanas antes del trasplante — destruye hifas de Fusarium y Rhizoctonia"
+      "trichoderma_pre": "Aplicar mucho Trichoderma (un hongo bueno) en las camas de siembra, semanas antes del trasplante — el Trichoderma se come a los hongos malos Fusarium y Rhizoctonia"
     }
   },
   "milestones": [
@@ -71,59 +71,59 @@
   ],
   "failure_modes": [
     {
-      "razon": "Pudrición apical (blossom end rot)",
-      "cuando": "Expansión del fruto",
-      "sintoma": "Mancha necrótica coriácea, hundida y oscura en cicatriz pistilar",
-      "agente_causal": "Falla en translocación de calcio inducida por estrés hídrico transitorio",
-      "mitigacion": "Sincronización impecable de riegos diarios + aportes tempranos de roca calcárea + mulch para estabilizar humedad",
+      "razon": "Culo negro del tomate (Pudrición apical / Blossom end rot)",
+      "cuando": "Cuando el fruto está creciendo",
+      "sintoma": "En la puntita del tomate (donde estuvo la flor) aparece una mancha oscura, hundida y dura como cuero",
+      "agente_causal": "Al tomate le falta calcio porque el riego es irregular",
+      "mitigacion": "Riega todos los días a la misma hora sin saltarte ningún día. Echa harina de roca calcárea desde el comienzo. Cubre el suelo con paja para que la humedad sea pareja.",
       "frecuencia": "muy_comun"
     },
     {
       "razon": "Tizón tardío (Phytophthora infestans)",
-      "cuando": "Vegetativo a cosecha",
-      "sintoma": "Manchas oleosas que se necrosan, micelio blanco en envés foliar, frutos con manchas pardas",
-      "agente_causal": "Condiciones frescas-húmedas (frío, templado alto)",
-      "mitigacion": "Caldo bordelés preventivo 0.5%, distanciamiento 1.5m entre surcos, evitar mojado foliar (riego por goteo). NO sembrar cerca de cultivos de papa",
+      "cuando": "Desde que crece hasta la cosecha",
+      "sintoma": "Manchas que parecen aceitosas y se vuelven oscuras. Pelusa blanca debajo de las hojas. Manchas marrones en los frutos.",
+      "agente_causal": "Pasa cuando hace fresco y hay mucha humedad",
+      "mitigacion": "Aplica caldo bordelés al 0.5% como prevención. Deja 1.5 m entre filas de plantas. No mojes las hojas (usa riego por goteo). NO siembres tomate cerca de papa.",
       "frecuencia": "muy_comun"
     },
     {
-      "razon": "Mosca blanca (Trialeurodes vaporariorum) + Fumagina",
-      "cuando": "Vegetativo a cosecha",
-      "sintoma": "Follaje recubierto de costras de polvo negro (fumagina), clorosis severa generalizada",
-      "agente_causal": "Excreción de melaza por mosca blanca permite crecimiento de hongos saprófitos",
-      "mitigacion": "Trampas cromáticas amarillas DENSAS, aspersión de fermento M-5 al 10-20%, encierro fitosanitario en invernadero",
+      "razon": "Mosca blanca (Trialeurodes vaporariorum) + Fumagina (hongo negro)",
+      "cuando": "Desde que crece hasta la cosecha",
+      "sintoma": "Las hojas se ven cubiertas de un polvo negro (fumagina). Las hojas se ponen amarillas por toda la planta.",
+      "agente_causal": "La mosca blanca suelta un líquido dulce sobre las hojas y encima crece un hongo negro",
+      "mitigacion": "Pon muchas trampas amarillas pegajosas. Rocía fermento M-5 al 10-20%. Si tienes invernadero, ciérralo bien.",
       "frecuencia": "comun"
     },
     {
-      "razon": "Begomovirus (PYMV / TYLCV)",
-      "cuando": "Cualquier estadio",
-      "sintoma": "Enanismo, hojas amarillentas con enrollamiento ascendente, cuajado pobre",
-      "agente_causal": "Transmitidos por Bemisia tabaci. Hospederos arvenses: Desmodium, Amaranthus, Lantana camara (Vaca-Vaca et al. 2012 UNAL Palmira)",
-      "mitigacion": "Control de mosca blanca. Eliminación de arvenses hospederas en bordes del lote. Variedades con tolerancia (Tequila, Calima)",
+      "razon": "Virus del enrollado del tomate (Begomovirus PYMV / TYLCV)",
+      "cuando": "En cualquier momento del ciclo",
+      "sintoma": "La planta no crece, las hojas se ponen amarillas y se enrollan hacia arriba, los tomates no se forman bien",
+      "agente_causal": "Lo transmite la mosca blanca (Bemisia tabaci). Vive en malezas vecinas como Desmodium, Amaranthus y Lantana camara",
+      "mitigacion": "Controla la mosca blanca. Quita las malezas alrededor del cultivo. Usa variedades resistentes (Tequila, Calima).",
       "frecuencia": "comun"
     },
     {
-      "razon": "Marchitez vascular (Fusarium / Verticillium)",
-      "cuando": "Crecimiento vegetativo",
-      "sintoma": "Clorosis asimétrica progresiva, taponamiento del xilema, colapso estructural irreversible",
-      "agente_causal": "Hongos edáficos habitantes crónicos",
-      "mitigacion": "Rotación inter-anual de familias botánicas (evitar solanáceas consecutivas). Uso de Trichoderma. Variedades resistentes con genes I/Ve",
+      "razon": "Marchitez vascular (hongos Fusarium / Verticillium)",
+      "cuando": "Cuando la planta está creciendo",
+      "sintoma": "Las hojas se ponen amarillas de a poquito, los tubos por donde sube el agua dentro de la planta se tapan, la planta se cae y no se recupera",
+      "agente_causal": "Hongos que viven en el suelo por muchos años",
+      "mitigacion": "Cada año cambia el tipo de planta que siembras en el mismo terreno (no repitas tomate, papa, berenjena ni pimentón). Aplica Trichoderma al suelo. Usa variedades resistentes con genes I/Ve.",
       "frecuencia": "ocasional"
     }
   ],
   "companions": [
-    { "especie": "Ocimum basilicum (albahaca)", "razon": "Eugenoles y linaloles evaporados desestabilizan señales quimiotácticas de dípteros. Priming sistémico de respuesta a heridas mediado por compuestos volátiles", "evidencia": "Suzuki et al. NIH PMC11263239 — evidencia experimental publicada" },
-    { "especie": "Calendula officinalis + Tagetes patula (caléndulas)", "razon": "Plantas trampa para nemátodos Meloidogyne. Atracción de polinizadores", "evidencia": "literatura experimental" },
-    { "especie": "Daucus carota (zanahoria)", "razon": "Complementariedad radicular", "evidencia": "tradicion" },
-    { "especie": "Allium cepa + sativum (cebolla, ajo)", "razon": "Repelencia de áfidos por compuestos azufrados", "evidencia": "tradicion + literatura" },
-    { "especie": "Borago officinalis (borraja)", "razon": "Repele Manduca quinquemaculata (gusano cachón)", "evidencia": "literatura agronomica" }
+    { "especie": "Albahaca (Ocimum basilicum)", "razon": "Su olor confunde a las moscas y las plagas para que no encuentren el tomate. También avisa a la planta para defenderse cuando es atacada.", "evidencia": "Suzuki et al. NIH PMC11263239 — evidencia experimental publicada" },
+    { "especie": "Caléndulas (Calendula officinalis + Tagetes patula)", "razon": "Atraen a los nematodos (gusanitos del suelo) y los engañan. Atraen abejas y mariposas que polinizan.", "evidencia": "literatura experimental" },
+    { "especie": "Zanahoria (Daucus carota)", "razon": "Sus raíces van más profundo y no pelean con las del tomate", "evidencia": "tradicion" },
+    { "especie": "Cebolla y ajo (Allium cepa + sativum)", "razon": "Su olor a azufre espanta a los pulgones", "evidencia": "tradicion + literatura" },
+    { "especie": "Borraja (Borago officinalis)", "razon": "Espanta al gusano cachón del tomate (Manduca quinquemaculata)", "evidencia": "literatura agronomica" }
   ],
   "antagonistas": [
-    { "especie": "Foeniculum vulgare (hinojo)", "razon": "Alelopatía severa" },
-    { "especie": "Solanum tuberosum (papa)", "razon": "Comparte Phytophthora infestans — corredor epidemiológico crítico" },
-    { "especie": "Solanum melongena (berenjena), Capsicum annuum (pimentón)", "razon": "Solanáceas — comparten Begomovirus + tizón + Fusarium" },
-    { "especie": "Cucumis sativus (pepino)", "razon": "Vectores comunes (mosca blanca, ácaros)" },
-    { "especie": "Juglans (nogal)", "razon": "Juglona alelopática" }
+    { "especie": "Hinojo (Foeniculum vulgare)", "razon": "Suelta sustancias fuertes que no dejan crecer al tomate" },
+    { "especie": "Papa (Solanum tuberosum)", "razon": "Comparten el hongo Phytophthora infestans — se contagian fácilmente" },
+    { "especie": "Berenjena (Solanum melongena), Pimentón (Capsicum annuum)", "razon": "Son de la misma familia que el tomate — comparten virus, tizón y Fusarium" },
+    { "especie": "Pepino (Cucumis sativus)", "razon": "Comparten plagas (mosca blanca, ácaros)" },
+    { "especie": "Nogal (Juglans)", "razon": "Suelta juglona, sustancia que afecta al tomate" }
   ],
   "biopreparados": [
     { "nombre": "M-5 (insecticida orgánico)", "uso": "Decocción anaeróbica de ajo + ají + cebolla + aromáticas + alcohol fermentados 30 días. Asperjar canopia al 5-20% (400 ml a 2 L por bomba 20 L)", "fuente": "manuales agroecologicos colombianos" },


### PR DESCRIPTION
## Summary
Operador reportó al revisar ayuda de fresa:
> "Síntoma: Masa miceliar grisácea — ni yo entendí qué quiere decir eso, y la app debe ser apta para un niño de 11 años. Adicional, varios nombres científicos salen primero que los nombres comunes — arregla esto en toda la ayuda."

Aplico ambos fixes a los 3 cycle-content (fresa, lechuga, tomate_chonto): `public/cycle-content/{fresa,lechuga,tomate_chonto}.json`.

## Cambios

### 1. Nombre común PRIMERO, científico entre paréntesis
| Antes | Ahora |
|---|---|
| `"Botrytis cinerea (moho gris)"` | `"Moho gris (Botrytis cinerea)"` |
| `"Sphaerotheca macularis (oídio)"` | `"Oídio (Sphaerotheca macularis)"` |
| `"Daucus carota (zanahoria)"` | `"Zanahoria (Daucus carota)"` |

Aplicado a `failure_modes[].razon`, `companions[].especie`, `antagonistas[].especie`. ~20 entradas.

### 2. Jargon → lenguaje cotidiano (apto 11 años)
| Antes | Ahora |
|---|---|
| "Masa miceliar grisácea y algodonosa sobre drupas" | "Pelusa gris peluda como algodón sobre los frutos" |
| "meristemo apical" | "centro de la planta donde nacen las hojas" |
| "taponamiento del xilema" | "los tubos por donde sube el agua se tapan" |
| "necrosis marginal" | "bordes quemados, marrones y secos" |
| "clorosis" | "hojas amarillas" |
| "hifas de Fusarium" | "hongos malos Fusarium" |
| "Begomovirus PYMV/TYLCV" | "Virus del enrollado del tomate" |
| ...12 más en commit msg | |

## Verificación
- ✅ 3/3 JSONs `json.load()` parseables
- ✅ 0 instancias de jargon (regex `miceli|necrosis|xilema|clorosis|drupas|edáfico|hifa|saprófitos|fitoseidos|biotrofo|gasterópodos`)
- ✅ Todos los nombres con formato `Común (Científico)` invertido

## Out of scope
- `src/data/dictionary.js` — glosario lookup técnico, no ayuda principal. Si operador confirma que niños lo leen también, audit separado.
- `HelpManual.jsx` + otros componentes — no se detectaron jargons equivalentes, pero pendiente audit completo.

## Test plan
- [ ] CodeQL + Playwright verdes.
- [ ] Operador abre ayuda de fresa → verifica:
  - Sección "Cosas que pueden salir mal" → "Moho gris (Botrytis cinerea)" + "Pelusa gris peluda como algodón..."
  - Sección "Buenos vecinos" → "Borraja (Borago officinalis)..."
  - Niño/a de 11 años entiende cada explicación.
- [ ] Repetir para lechuga + tomate_chonto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)