### PR TITLE
chore(multifinca): quitar Los Sitios placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.99",
+  "version": "0.12.100",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -12,19 +12,5 @@
     "estado": "activo",
     "descripcion_corta": "Laboratorio de conservación + restauración de páramo en Choachí.",
     "farmos_endpoint": "https://farmos.guatoc.co"
-  },
-  {
-    "slug": "los-sitios",
-    "nombre": "Los Sitios",
-    "operador": "Placeholder",
-    "coords": [
-      4.5500,
-      -73.9000
-    ],
-    "altitud": 2200,
-    "biocultural_zone": "andino_medio",
-    "estado": "demo",
-    "descripcion_corta": "Finca demo (coords aproximadas, sustituir con datos reales antes de field test).",
-    "farmos_endpoint": "https://farmos.guatoc.co"
   }
 ]

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v141';
+const CACHE_NAME = 'chagra-v142';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
Reverte placeholder agregado en #776 — multifinca opera con Guatoc únicamente hasta que haya datos reales de 2da finca.