### PR TITLE
fix(ci): regex de quota más estricta — exige error estructural + keyword

### DIFF
--- a/.github/workflows/claude-code-generate.yml
+++ b/.github/workflows/claude-code-generate.yml
@@ -197,11 +197,18 @@ jobs:
             tail -c 2000 "$out_file" || true
             echo "::endgroup::"
 
-            # Detectar fin de tokens / quota / rate-limit explícito en output
-            # antes de chequear edits. Heurística amplia para cubrir formatos
-            # variados de error de providers free.
-            if grep -qiE 'quota|rate.?limit|insufficient.?(credit|balance|token)|429|payment.?required|free.?tier.?expired|out of (credits|tokens)|usage limit' "$out_file"; then
-              echo "WARN tier $label: señal de quota exhausted detectada en output." >&2
+            # Detectar fin de tokens / quota / rate-limit explícito en output.
+            # Doble pasada para evitar falsos positivos (incidente 2026-05-16:
+            # `429` matcheaba substring dentro de sessionIDs hex tipo `e329d…`
+            # o números de output_tokens, marcando como quota runs que en
+            # realidad solo tenían bash tool-call fallido por shell nologin).
+            # Pasada 1: el output debe contener al menos UN indicador de error
+            # estructural (campo "error", status code 4xx/5xx, HTTP error
+            # line). Pasada 2: alguna palabra de quota debe aparecer.
+            # Ambas deben pasar para clasificar como quota exhausted.
+            if grep -qiE '"error"\s*:\s*"[^"]+"|"status"\s*:\s*"(error|failed|exhausted|quota[a-z_-]*|payment[a-z_-]*|rate[a-z_-]*|insufficient[a-z_-]*)"|"(status_code|code)"\s*:\s*[45][0-9]{2}|HTTP/[12]\.[01]\s+[45][0-9]{2}|"finish_reason"\s*:\s*"(length|content_filter)"' "$out_file" \
+               && grep -qiE '\b(quota|rate[._-]?limit|insufficient[._ -]?(credit|balance|token)s?|payment[._ -]?required|free[._ -]?tier[._ -]?expired|out of (credits|tokens)|usage[._ -]?limit|too many requests|model not available)\b' "$out_file"; then
+              echo "WARN tier $label: señal de quota exhausted detectada (error + keyword en output)." >&2
               return 10  # código reservado: quota
             fi
 


### PR DESCRIPTION
## Summary

- Refina la regex de detección de quota exhausted en `Claude Code Generate` para que **no produzca falsos positivos** contra IDs hex o keys JSON estructurales.
- Doble pasada obligatoria: (1) indicador de error estructural + (2) keyword de quota. Ambas deben matchear para clasificar como quota.

## Causa raíz

El piloto `zea_mays #717` lanzado hoy 2026-05-16 fue clasificado como \`chain_exhausted\` cuando en realidad el modelo respondió bien — falló por otro bug (shell nologin del runner, que se arregla en PR paralelo de guatoc-nixos).

La regex original \`429\` matcheaba dentro de strings como \`sessionID:"ses_1cd28b003ffe...429..."\` o números \`output_tokens:429\`, marcando como quota cualquier output que contuviera ese substring.

## Test plan

- [ ] CodeQL pasa (no toca src).
- [ ] Playwright pasa (no toca src).
- [ ] Verificación manual: la nueva regex aplicada contra el output del run 25974259940 (piloto fallido) NO matchea — confirmado localmente.
- [ ] Tras merge + re-pilotar #717 con el shell del runner arreglado: el comentario del PR debe mostrar \`tier=tier1-minimax-m2.5-free\` o \`tier=tier0-glm-4.6-via-litellm\`, no quota_exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)