### PR TITLE
fix(ux): castellanizar UI — quitar Splitear/Trazabilidad de pantallas visibles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.100",
+  "version": "0.12.101",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v142';
+const CACHE_NAME = 'chagra-v143';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,10 +73,10 @@ const NAV_TILES = [
   { id: 'javier', label: 'Hoy en finca', icon: Eye, accent: 'green', desc: `Tareas por proximidad (${PRIMARY_WORKER_NAME})` },
   { id: 'bodega', label: 'Insumos', icon: Package, accent: 'sky', desc: 'Stock de biopreparados' },
   { id: 'task_log', label: 'Tareas', icon: Clock, accent: 'rose', desc: 'Cola de pendientes' },
-  { id: 'historial', label: 'Bitácora', icon: NotebookPen, accent: 'indigo', desc: 'Trazabilidad de operaciones' },
+  { id: 'historial', label: 'Bitácora', icon: NotebookPen, accent: 'indigo', desc: 'Historial de actividades' },
   { id: 'biodiversidad', label: 'Flora y fauna', icon: Leaf, accent: 'emerald', desc: 'Ecosistema, estratos y gremios' },
   { id: 'reportar_invasora', label: 'Plagas', icon: AlertCircle, accent: 'amber', desc: 'Reporte de plagas y malezas' },
-  { id: 'informes', label: 'Informes', icon: FileText, accent: 'lime', desc: 'Reportes CSV de trazabilidad y descargas' },
+  { id: 'informes', label: 'Informes', icon: FileText, accent: 'lime', desc: 'Descargas de reportes en CSV' },
   { id: 'perfil', label: 'Perfil', icon: Palette, accent: 'indigo', desc: 'Temas y configuración' },
 ];
 

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -182,7 +182,7 @@ export const AssetDetailView = () => {
               </section>
 
               <section className="pt-2">
-                <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Gestión de Trazabilidad</h3>
+                <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Historial de la planta</h3>
                 <div className="flex flex-wrap gap-2">
                   {status !== 'dead' && (
                     <>
@@ -190,7 +190,7 @@ export const AssetDetailView = () => {
                         <Skull size={14} /> Marcar muerte
                       </button>
                       <button onClick={() => setShowSplitFlow(true)} className="px-3 py-2 rounded-lg bg-emerald-900/20 text-emerald-400 border border-emerald-700/30 text-xs flex items-center gap-2">
-                        <Layers size={14} /> Splitear / Unificar
+                        <Layers size={14} /> Dividir / Juntar
                       </button>
                     </>
                   )}

--- a/src/components/InformesScreen.jsx
+++ b/src/components/InformesScreen.jsx
@@ -104,7 +104,7 @@ export default function InformesScreen({ onBack }) {
 
         <ReportCard
           icon={FileText}
-          title="Trazabilidad CSV"
+          title="Historial completo (CSV)"
           description="Cosechas, aplicaciones de biopreparados, observaciones y siembras por activo."
           helpText="Formato CSV abierto, compatible con Excel, Google Sheets, R, Python pandas. Se descarga en tu dispositivo."
           onExport={exportTraceabilityCsv}

--- a/src/components/SplitFlow.jsx
+++ b/src/components/SplitFlow.jsx
@@ -48,7 +48,7 @@ export const SplitFlow = ({ asset, onClose }) => {
             <div className="flex justify-between items-center mb-8">
                 <h2 className="text-xl font-bold text-white flex items-center gap-2">
                     <Layers className="text-emerald-400" />
-                    Splitear {trackingMode === 'individual' ? 'a Agregado' : 'a Individual'}
+                    {trackingMode === 'individual' ? 'Juntar en grupo' : 'Dividir en plantas individuales'}
                 </h2>
                 <button onClick={onClose} className="p-2 text-slate-400 hover:text-white transition-colors">
                     <X size={24} />
@@ -104,7 +104,7 @@ export const SplitFlow = ({ asset, onClose }) => {
                             onClick={() => setStep(2)}
                             className="w-full py-4 bg-emerald-600 text-white rounded-2xl font-black shadow-lg shadow-emerald-900/20 active:scale-95 transition-transform"
                         >
-                            Continuar a Preview
+                            Continuar a Vista previa
                         </button>
                     </div>
                 )}


### PR DESCRIPTION
## Summary

Bug reportado por operador: al abrir cualquier planta se ve **\"Gestión de Trazabilidad\"** como header y un botón **\"Splitear / Unificar\"** (spanglish). La app debe poder usarse por campesinos y niños desde 11 años, sin términos técnicos en inglés ni jerga innecesaria.

## Cambios visibles en UI

| Archivo | Antes | Después |
|---|---|---|
| AssetDetailView | Gestión de Trazabilidad | Historial de la planta |
| AssetDetailView | Splitear / Unificar | Dividir / Juntar |
| SplitFlow | Splitear a Agregado | Juntar en grupo |
| SplitFlow | Splitear a Individual | Dividir en plantas individuales |
| SplitFlow | Continuar a Preview | Continuar a Vista previa |
| App.jsx (Bitácora) | Trazabilidad de operaciones | Historial de actividades |
| App.jsx (Informes) | Reportes CSV de trazabilidad y descargas | Descargas de reportes en CSV |
| InformesScreen | Trazabilidad CSV | Historial completo (CSV) |

## Lo que NO cambió

- El nombre del archivo CSV exportado (\`chagra_trazabilidad_<fecha>.csv\`).
- Comentarios de código internos.
- Documentación legal (LegalLinks, dictionary, ADRs).

\"Trazabilidad\" sigue siendo el término correcto para certificación orgánica (ICA, etc.), pero NO va a la capa visible del usuario final.

## Próxima pasada propuesta (no incluida en este PR)

Otros términos técnicos visibles que podrían simplificarse: **\"Asset\"**, **\"Log\"**, **\"Tracking individual/agregado\"**, **\"Append-only\"**. Si querés los castellanizo en un PR aparte después del demo.

## Test plan

- [ ] CodeQL pasa.
- [ ] Playwright pasa (no cambia comportamiento, solo strings).
- [ ] Validación visual manual del operador en stg antes del demo del martes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)