### PR TITLE
feat(case-study): voice/text → caso extraction via Ollama local (DR-044 F1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.103",
+  "version": "0.12.104",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v145';
+const CACHE_NAME = 'chagra-v146';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CaseStudyScreen.jsx
+++ b/src/components/CaseStudyScreen.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { FileText, Plus, AlertTriangle, AlertCircle, Activity, CheckCircle, XCircle, ChevronRight } from 'lucide-react';
+import { FileText, Plus, AlertTriangle, AlertCircle, Activity, CheckCircle, XCircle, ChevronRight, Sparkles, Loader2 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { useCaseStudyStore, CASE_SEVERITIES } from '../store/useCaseStudyStore';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
+import { extractCaseFromText } from '../services/caseStudyVoiceExtractor';
 
 /**
  * CaseStudyScreen — vista lista de casos de estudio agronómicos
@@ -98,6 +99,11 @@ const NewCaseForm = ({ onCreate, onCancel, defaultFincaSlug }) => {
     count_total: '',
     count_affected: '',
   });
+  // DR-044 sub-viii feature 1: Voice/text → Caso extraction via Ollama
+  const [showExtractor, setShowExtractor] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const [extracting, setExtracting] = useState(false);
+  const [extractError, setExtractError] = useState(null);
 
   const submit = (e) => {
     e.preventDefault();
@@ -118,8 +124,82 @@ const NewCaseForm = ({ onCreate, onCancel, defaultFincaSlug }) => {
     });
   };
 
+  const handleExtract = async () => {
+    if (!transcript.trim()) return;
+    setExtracting(true);
+    setExtractError(null);
+    try {
+      const extracted = await extractCaseFromText(transcript);
+      if (!extracted) {
+        setExtractError('No se pudo extraer información. Verifica el texto o llena manualmente.');
+        return;
+      }
+      // Pre-fill form fields (preserva ediciones manuales previas si están)
+      setForm((prev) => ({
+        ...prev,
+        title: prev.title || extracted.title || '',
+        problem_name: prev.problem_name || extracted.problem_name || '',
+        zone_freetext: prev.zone_freetext || extracted.subzone || '',
+        severity: extracted.severity || prev.severity,
+        count_total: extracted.count_total != null ? String(extracted.count_total) : prev.count_total,
+        count_affected: extracted.count_affected != null ? String(extracted.count_affected) : prev.count_affected,
+      }));
+      setShowExtractor(false);
+    } catch (e) {
+      setExtractError(e?.message || 'Error en extracción');
+    } finally {
+      setExtracting(false);
+    }
+  };
+
   return (
     <form onSubmit={submit} className="space-y-3 p-4 rounded-xl bg-slate-900/60 border border-slate-700">
+      {/* DR-044 sub-viii Feature 1: extracción asistida por IA local */}
+      {!showExtractor && (
+        <button
+          type="button"
+          onClick={() => setShowExtractor(true)}
+          className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-purple-900/40 border border-purple-700/50 text-purple-200 text-xs font-bold hover:bg-purple-800/40 transition-colors"
+        >
+          <Sparkles className="w-3.5 h-3.5" />
+          Extraer desde transcripción (IA local)
+        </button>
+      )}
+      {showExtractor && (
+        <div className="p-3 rounded-lg bg-purple-950/30 border border-purple-700/50 space-y-2">
+          <p className="text-purple-200 text-[10px] uppercase font-black tracking-wider flex items-center gap-1.5">
+            <Sparkles className="w-3 h-3" /> Pega o dicta lo que observaste
+          </p>
+          <textarea
+            placeholder='Ej: "Esta mañana en el invernadero de los 1000 tomates, encontré 10 plantas cerca de la entrada atacadas por trozador, los tallos cortados."'
+            value={transcript}
+            onChange={(e) => setTranscript(e.target.value)}
+            rows={3}
+            className="w-full px-3 py-2 rounded bg-slate-900 border border-slate-700 text-white text-xs focus:outline-none focus:border-purple-500"
+            disabled={extracting}
+          />
+          {extractError && <p className="text-red-400 text-xs">{extractError}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => { setShowExtractor(false); setTranscript(''); setExtractError(null); }}
+              disabled={extracting}
+              className="flex-1 py-1.5 rounded bg-slate-800 text-slate-300 text-xs"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleExtract}
+              disabled={extracting || !transcript.trim()}
+              className="flex-1 py-1.5 rounded bg-purple-700 text-white text-xs font-bold disabled:opacity-50 flex items-center justify-center gap-1.5"
+            >
+              {extracting ? <><Loader2 className="w-3 h-3 animate-spin" /> Procesando…</> : 'Extraer'}
+            </button>
+          </div>
+        </div>
+      )}
+
       <input
         type="text"
         required

--- a/src/services/__tests__/caseStudyVoiceExtractor.test.js
+++ b/src/services/__tests__/caseStudyVoiceExtractor.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { __TEST__ } from '../caseStudyVoiceExtractor';
+
+// Test del parseLLMJson tolerante (sin call real a Ollama).
+// La función estructurada extractCaseFromText requiere Ollama runtime,
+// se cubre por integration test separado.
+
+describe('caseStudyVoiceExtractor — parseLLMJson', () => {
+  const { parseLLMJson } = __TEST__;
+
+  it('parsea JSON limpio', () => {
+    const r = parseLLMJson('{"a":1}');
+    expect(r).toEqual({ a: 1 });
+  });
+
+  it('quita markdown fences ```json', () => {
+    const r = parseLLMJson('```json\n{"problem_name":"Trozador","severity":"high"}\n```');
+    expect(r.problem_name).toBe('Trozador');
+    expect(r.severity).toBe('high');
+  });
+
+  it('quita ``` sin lang tag', () => {
+    const r = parseLLMJson('```\n{"x":2}\n```');
+    expect(r).toEqual({ x: 2 });
+  });
+
+  it('encuentra JSON dentro de texto con prefix', () => {
+    const r = parseLLMJson('Aqui está la respuesta: {"count_affected":10,"count_total":1000} fin.');
+    expect(r.count_affected).toBe(10);
+    expect(r.count_total).toBe(1000);
+  });
+
+  it('retorna null si no hay JSON válido', () => {
+    expect(parseLLMJson('no hay json')).toBeNull();
+    expect(parseLLMJson('')).toBeNull();
+    expect(parseLLMJson(null)).toBeNull();
+  });
+
+  it('retorna null si JSON no parsea', () => {
+    expect(parseLLMJson('{ broken json with trailing , }')).toBeNull();
+  });
+
+  it('maneja JSON multilinea', () => {
+    const text = `Algo de texto.
+{
+  "title": "Trozador invernadero",
+  "severity": "high",
+  "count_affected": 10
+}
+Fin del mensaje.`;
+    const r = parseLLMJson(text);
+    expect(r.title).toBe('Trozador invernadero');
+    expect(r.count_affected).toBe(10);
+  });
+
+  it('captura solo el primer JSON si hay múltiples', () => {
+    const r = parseLLMJson('{"a":1} luego {"b":2}');
+    expect(r).toEqual({ a: 1 });
+  });
+});
+
+describe('caseStudyVoiceExtractor — exports', () => {
+  it('SEVERITY_VOCAB tiene 4 niveles canónicos', () => {
+    const sevs = Object.keys(__TEST__.SEVERITY_VOCAB);
+    expect(sevs).toEqual(['critical', 'high', 'medium', 'low']);
+  });
+
+  it('PROMPT_VERSION y MODEL están definidos', () => {
+    expect(__TEST__.PROMPT_VERSION).toMatch(/^v\d/);
+    expect(__TEST__.MODEL).toBeTruthy();
+    expect(__TEST__.MODEL).toMatch(/qwen|gemma|llama|mistral/i);
+  });
+});

--- a/src/services/caseStudyVoiceExtractor.js
+++ b/src/services/caseStudyVoiceExtractor.js
@@ -1,0 +1,223 @@
+/**
+ * caseStudyVoiceExtractor.js — Voice → Case Study extraction
+ * ================================================================
+ * Toma una transcripción en español (Whisper output) y devuelve campos
+ * estructurados para pre-fill del CaseStudyScreen NewCaseForm.
+ *
+ * Pipeline (referenced en DR-044 sub-viii Feature 1):
+ *   1. Operator dicta caso → Whisper transcribe.
+ *   2. extractCaseFromText(transcript) → Ollama qwen2.5:7b structured JSON.
+ *   3. UI pre-fill form, operator confirma.
+ *
+ * Patrón espejado de `entityExtractor.js` (gemma3:4b para extracción simple).
+ * Para casos de estudio elegimos `qwen2.5:7b` por mejor razonamiento con
+ * campos múltiples + reasoning sobre pest taxonomy + count parsing.
+ *
+ * Privacy: el prompt + transcripción NUNCA salen del host alpha. Si
+ * Ollama no responde (down, timeout), retorna `null` y la UI cae a modo
+ * manual (offline-first compliant DR-044 restricciones).
+ *
+ * Audit trail: cada call retorna también { model, prompt_hash, timestamp }
+ * para que CaseStudy log en event_log_ids referenciado.
+ */
+
+import { streamOllama } from './ollamaStream';
+
+const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
+// qwen2.5:7b: mejor estructura JSON sobre campos múltiples vs gemma3:4b.
+// Bench 2026-05-15 (CPU): ~25-35s. Post-GPU sm_52 target ~5-10s.
+// Fallback: gemma3:4b si qwen2.5:7b no responde (ver llmRouter pattern).
+const MODEL = 'qwen2.5:7b';
+const TIMEOUT_MS = 90000; // 90s CPU; ajustar post-GPU
+const PROMPT_VERSION = 'v1.0-2026-05-17';
+
+const SEVERITY_VOCAB = {
+  critical: ['crítico', 'crítica', 'gravísim', 'urgente', 'emergencia', 'catástrofe'],
+  high: ['alto', 'alta', 'grave', 'serio', 'preocupante'],
+  medium: ['medio', 'media', 'moderado', 'algo'],
+  low: ['bajo', 'baja', 'leve', 'pequeño', 'poco'],
+};
+
+// Sistema prompt focado en case study domain (no general entity).
+const SYSTEM_PROMPT = `Eres un extractor estructurado de casos de estudio agronómicos chagra colombianos. Recibes la transcripción de un operador describiendo un PROBLEMA en su finca (plaga, enfermedad, déficit, anomalía).
+
+Devuelves EXCLUSIVAMENTE un objeto JSON válido sin texto adicional, sin markdown, sin backticks.
+
+Schema:
+{
+  "title": "<resumen breve, máx 60 chars, formato 'Pest en zona — fecha o lugar'>",
+  "problem_name": "<nombre del problema en lenguaje del operador>",
+  "pest_scientific_candidate": "<binomio latín si reconocible, ej. 'Agrotis ipsilon'; null si no aplica>",
+  "severity": "low|medium|high|critical",
+  "count_total": <entero o null>,
+  "count_affected": <entero o null>,
+  "subzone": "<lugar dentro de la finca tal como lo dice el operador, o cadena vacía>",
+  "species_candidates": ["<id_species_si_se_menciona>"],
+  "symptoms": ["<lista de signos clínicos observados, cada uno frase corta>"]
+}
+
+Reglas estrictas:
+
+1. NUMERAL → entero: "diez"=10, "cien"=100, "mil"=1000, "1000"=1000, "doce"=12.
+2. CONTEO afectado vs total: "10 de 1000 plantas atacadas" → {count_affected:10, count_total:1000}. Si solo dice "10 plantas atacadas" → {count_affected:10, count_total:null}.
+3. SEVERIDAD por palabras clave (caso prevalece sobre keyword):
+   - "crítico"/"crítica"/"gravísimo"/"urgente"/"catástrofe"/"emergencia" → critical
+   - "grave"/"serio"/"preocupante"/"alto"/"alta" → high
+   - "moderado"/"medio"/"algo" → medium
+   - "leve"/"poco"/"bajo"/"pequeño" → low
+   - Sin keyword: usa "medium" default.
+4. PESTS comunes Colombia (mapeo a binomio):
+   - trozador, gusano cortador → Agrotis ipsilon
+   - cogollero → Spodoptera frugiperda
+   - mosca blanca → Bemisia tabaci o Trialeurodes vaporariorum
+   - polilla del tomate, palomilla tomate → Tuta absoluta
+   - áfidos, pulgones → Aphis spp. o Myzus persicae
+   - ácaros, arañita roja → Tetranychus urticae
+   - tizón tardío → Phytophthora infestans
+   - antracnosis → Colletotrichum spp.
+   - oídio, blanco → Erysiphales
+5. SPECIES candidatas (Colombian crops, mapeo a chagra catalog ids cuando reconocible):
+   - tomate, tomatera → solanum_lycopersicum_cerasiforme
+   - tomate cherry → solanum_lycopersicum_cerasiforme
+   - tomate san marzano → solanum_lycopersicum_san_marzano
+   - papa, papa criolla → solanum_phureja o solanum_tuberosum
+   - ají, chile, capsicum → capsicum_annuum
+   - café, cafeto → coffea_arabica
+   - lechuga → lactuca_sativa_*
+   - cebolla larga → allium_fistulosum
+   - ajo → allium_sativum
+   - frijol → phaseolus_vulgaris
+6. SUBZONE: extraer descripción literal ("entrada del invernadero", "cama 3 del cuadrante norte", "esquina sureste"). Si no se menciona, "".
+7. SYMPTOMS: cada signo como frase corta separada. Ej: "tallo cortado a nivel del cuello", "manchas amarillas hojas viejas", "polvo blanco hojas".
+8. TITLE: generar conciso. Ej "Trozador invernadero entrada — 10 plantas". Máx 60 chars.
+
+Si el operador NO está reportando un problema sino otro tipo de log (siembra, cosecha, mantenimiento), retorna {"_not_case": true}.
+`;
+
+const truncate = (s, n) => (s && s.length > n ? s.slice(0, n - 1) + '…' : s || '');
+
+/**
+ * Extrae campos de caso desde transcripción. Devuelve null si Ollama falla
+ * (operator-friendly UX: cae a modo manual).
+ *
+ * @param {string} transcript - Texto en español.
+ * @param {Object} opts
+ * @param {AbortSignal} [opts.signal]
+ * @param {(chunk, fullText) => void} [opts.onToken] - Para typewriter UI.
+ * @returns {Promise<Object|null>} estructura caso o null si falla.
+ */
+export async function extractCaseFromText(transcript, opts = {}) {
+  if (!transcript || transcript.trim().length < 5) {
+    return null;
+  }
+
+  const userMsg = `Transcripción del operador:\n${transcript.trim()}`;
+  const body = {
+    model: MODEL,
+    stream: true,
+    format: 'json',
+    keep_alive: '5m',
+    options: { temperature: 0.1, num_ctx: 4096 },
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: userMsg },
+    ],
+  };
+
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  const signal = opts.signal
+    ? mergeSignals(opts.signal, ctrl.signal)
+    : ctrl.signal;
+
+  try {
+    const fullText = await streamOllama(OLLAMA_CHAT_URL, body, opts.onToken, { signal });
+    clearTimeout(t);
+    if (!fullText) return null;
+
+    const parsed = parseLLMJson(fullText);
+    if (!parsed || parsed._not_case) return null;
+
+    // Sanitize: ensure severity in vocab, counts are integers.
+    const sev = String(parsed.severity || '').toLowerCase();
+    const finalSev = ['low', 'medium', 'high', 'critical'].includes(sev) ? sev : 'medium';
+
+    const toInt = (v) => {
+      if (typeof v === 'number' && Number.isFinite(v)) return Math.round(v);
+      const n = parseInt(v, 10);
+      return Number.isFinite(n) ? n : null;
+    };
+
+    return {
+      title: truncate(parsed.title, 80),
+      problem_name: parsed.problem_name || '',
+      pest_scientific_candidate: parsed.pest_scientific_candidate || null,
+      severity: finalSev,
+      count_total: toInt(parsed.count_total),
+      count_affected: toInt(parsed.count_affected),
+      subzone: parsed.subzone || '',
+      species_candidates: Array.isArray(parsed.species_candidates) ? parsed.species_candidates : [],
+      symptoms: Array.isArray(parsed.symptoms) ? parsed.symptoms : [],
+      // Audit trail metadata
+      _audit: {
+        model: MODEL,
+        prompt_version: PROMPT_VERSION,
+        extracted_at: new Date().toISOString(),
+        transcript_length: transcript.length,
+      },
+    };
+  } catch (e) {
+    clearTimeout(t);
+    if (e?.name === 'AbortError') {
+      console.warn('[caseStudyVoiceExtractor] timeout/abort tras', TIMEOUT_MS, 'ms');
+    } else {
+      console.warn('[caseStudyVoiceExtractor] error:', e?.message || e);
+    }
+    return null;
+  }
+}
+
+/**
+ * Parse JSON tolerante: LLM puede envolver en markdown o trailing junk.
+ */
+function parseLLMJson(text) {
+  if (!text) return null;
+  // Strip markdown fences si LLM los agregó
+  let cleaned = text.replace(/^```(?:json)?\s*\n?/i, '').replace(/\n?```\s*$/i, '').trim();
+  // Find first { ... matching }
+  const start = cleaned.indexOf('{');
+  if (start === -1) return null;
+  // Match braces simple (asume LLM no anida deep + queries simples)
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < cleaned.length; i++) {
+    const ch = cleaned[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+  if (end === -1) return null;
+  try {
+    return JSON.parse(cleaned.slice(start, end + 1));
+  } catch (_) {
+    return null;
+  }
+}
+
+function mergeSignals(a, b) {
+  // Combine AbortSignal: any abort propagates.
+  const ctrl = new AbortController();
+  if (a.aborted || b.aborted) ctrl.abort();
+  else {
+    a.addEventListener('abort', () => ctrl.abort(), { once: true });
+    b.addEventListener('abort', () => ctrl.abort(), { once: true });
+  }
+  return ctrl.signal;
+}
+
+// Exports adicionales para tests
+export const __TEST__ = { parseLLMJson, SEVERITY_VOCAB, PROMPT_VERSION, MODEL };
+
+export default extractCaseFromText;


### PR DESCRIPTION
## Resumen

**Primera integración IA** del módulo Casos de Estudio (PR #788 mergeado). Implementa DR-044 Sub-viii Feature 1: extraction de campos estructurados desde transcripción libre, via Ollama qwen2.5:7b local.

## Pipeline

```
operator pega/dicta texto libre
        │
        ▼
extractCaseFromText(transcript)
        │
        ▼
POST /api/ollama/api/chat  (qwen2.5:7b, format:json, keep_alive=5m)
        │
        ▼  structured JSON
        │
{
  title, problem_name, pest_scientific_candidate,
  severity, count_total, count_affected, subzone,
  species_candidates, symptoms, _audit
}
        │
        ▼
NewCaseForm pre-filled (preserva ediciones manuales)
```

## System prompt highlights

- Mapeo pest común → binomio latín (trozador → Agrotis ipsilon; cogollero → Spodoptera frugiperda; etc.).
- Mapeo species nombre común → catalog id (tomate → solanum_lycopersicum_cerasiforme).
- Severity classification por keywords (crítico/grave/moderado/leve).
- Count parsing (numerales palabra → entero).
- Symptoms extraction frase-corta.
- `_not_case: true` si no es un problema agronómico (operator confirma manualmente).

## Privacy / Offline-first

- Transcripción NUNCA sale del host alpha. Ollama local en `:11434`.
- Si Ollama down → `extractCaseFromText` retorna `null` → UI muestra error user-friendly → operator llena manualmente.
- AbortController 90s timeout (post-GPU sm_52 será mucho menor).
- Audit trail metadata (`_audit: { model, prompt_version, extracted_at }`) listo para vincular a `case.event_log_ids` formal cuando DR-044 sub-i cierre.

## UX

Botón collapsible "✨ Extraer desde transcripción (IA local)" en NewCaseForm. Textarea + extract button. Pre-fill **preserva ediciones manuales previas** (no sobre-escribe campos no vacíos).

## Tests

```
Test Files  17 passed (17)
Tests       129 passed (129)
```

10 nuevos tests cubren `parseLLMJson` tolerante (markdown fences, JSON-in-text, multi-JSON, malformed).

## Pipeline futuro (post-GPU sm_52 + acoplado DR-044 features 2-6)

- Feature 2: Vision diagnostic foto pest (qwen2.5vl:7b)
- Feature 3: Similar cases RAG (nomic-embed-text + sqlite-vss)
- Feature 4: Treatment recommendation desde catalog biopreparados
- Feature 5: Lessons learned summarization (LLM closer)
- Feature 6: Predictive alerts seasonality

## Test plan

- [ ] CodeQL SAST verde
- [ ] Playwright E2E verde
- [ ] Catalog Validate verde (no toca catalog)
- [ ] (auto) 10 nuevos tests passing
- [ ] (manual post-merge) probar extraction con caso David trozador real:
      transcripción: *"Esta mañana en el invernadero de los 1000 tomates, encontré 10 plantas cerca de la entrada atacadas por trozador, los tallos cortados a nivel del cuello."*
      Expected: `{title: "Trozador invernadero entrada — 10 plantas", problem_name: "Trozador", pest_scientific_candidate: "Agrotis ipsilon", severity: "high", count_total: 1000, count_affected: 10, subzone: "entrada del invernadero", species_candidates: ["solanum_lycopersicum_cerasiforme"]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)