### PR TITLE
feat(case-study): photo gallery + lessons summarization IA (DR-044 F2+F5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.104",
+  "version": "0.12.105",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v146';
+const CACHE_NAME = 'chagra-v147';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CaseStudyDetail.jsx
+++ b/src/components/CaseStudyDetail.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react';
-import { FileText, AlertTriangle, AlertCircle, Activity, CheckCircle, XCircle, Beaker, Clock, MapPin } from 'lucide-react';
+import { FileText, AlertTriangle, AlertCircle, Activity, CheckCircle, XCircle, Beaker, Clock, MapPin, Camera, Sparkles, Loader2, Image as ImageIcon, Trash2 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { useCaseStudyStore } from '../store/useCaseStudyStore';
+import PhotoCaptureField from './PhotoCaptureField';
+import { summarizeLessons } from '../services/caseStudyLessonsSummarizer';
 
 /**
  * CaseStudyDetail — vista detalle + edición de un caso de estudio
@@ -106,10 +108,31 @@ const TreatmentForm = ({ onSubmit, onCancel }) => {
   );
 };
 
-const CloseCaseForm = ({ onSubmit, onCancel, currentAffected }) => {
+const CloseCaseForm = ({ onSubmit, onCancel, currentAffected, caseObj }) => {
   const [resolved, setResolved] = useState(true);
   const [finalAffected, setFinalAffected] = useState(currentAffected || '');
   const [lessons, setLessons] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [genError, setGenError] = useState(null);
+
+  // DR-044 sub-viii Feature 5: lessons_learned summarization via Ollama
+  const handleGenerate = async () => {
+    setGenerating(true);
+    setGenError(null);
+    try {
+      const result = await summarizeLessons(caseObj);
+      if (!result || !result.text) {
+        setGenError('IA no disponible. Llena manualmente.');
+        return;
+      }
+      setLessons(result.text);
+    } catch (e) {
+      setGenError(e?.message || 'Error generando resumen');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
   return (
     <form
       onSubmit={(e) => {
@@ -146,13 +169,29 @@ const CloseCaseForm = ({ onSubmit, onCancel, currentAffected }) => {
         onChange={(e) => setFinalAffected(e.target.value)}
         className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-white text-sm"
       />
-      <textarea
-        placeholder="Lecciones aprendidas (qué funcionó, qué no, qué repetir/evitar)"
-        value={lessons}
-        onChange={(e) => setLessons(e.target.value)}
-        rows={3}
-        className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-white text-sm"
-      />
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <label className="text-[10px] uppercase font-bold tracking-wider text-slate-500">Lecciones aprendidas</label>
+          <button
+            type="button"
+            onClick={handleGenerate}
+            disabled={generating}
+            title="Generar borrador con IA local (Ollama)"
+            className="text-[10px] px-2 py-1 rounded bg-purple-900/50 text-purple-200 hover:bg-purple-800/50 disabled:opacity-50 flex items-center gap-1"
+          >
+            {generating ? <Loader2 className="w-3 h-3 animate-spin" /> : <Sparkles className="w-3 h-3" />}
+            {generating ? 'Generando…' : 'Sugerir con IA'}
+          </button>
+        </div>
+        <textarea
+          placeholder="Qué funcionó, qué no, qué repetir/evitar"
+          value={lessons}
+          onChange={(e) => setLessons(e.target.value)}
+          rows={4}
+          className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-white text-sm"
+        />
+        {genError && <p className="text-red-400 text-[10px]">{genError}</p>}
+      </div>
       <div className="flex gap-2">
         <button type="button" onClick={onCancel} className="flex-1 py-2 rounded bg-slate-800 text-slate-300 text-sm">
           Cancelar
@@ -165,6 +204,92 @@ const CloseCaseForm = ({ onSubmit, onCancel, currentAffected }) => {
   );
 };
 
+/**
+ * PhotoGallery — visualiza fotos linkadas al caso (DR-044 sub-viii F2 partial).
+ * MVP: photos guardadas como data URLs en photo_asset_ids[].
+ * Post-DR-044 sub-i: migración a FarmOS media asset IDs reales.
+ */
+const PhotoGallery = ({ photos, onAdd, onRemove }) => {
+  const [showCapture, setShowCapture] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const handlePhoto = async (blob) => {
+    if (!blob) return;
+    setBusy(true);
+    try {
+      // KISS: convertir blob a data URL para storage local en case.photo_asset_ids[]
+      // Migración a FarmOS media post-DR-044 sub-i.
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        onAdd(reader.result); // data:image/jpeg;base64,...
+        setShowCapture(false);
+        setBusy(false);
+      };
+      reader.onerror = () => setBusy(false);
+      reader.readAsDataURL(blob);
+    } catch {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section>
+      <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500 mb-2 flex items-center gap-2">
+        <ImageIcon className="w-3 h-3" /> Fotos ({photos.length})
+        {!showCapture && (
+          <button
+            type="button"
+            onClick={() => setShowCapture(true)}
+            className="ml-auto text-[10px] px-2 py-1 rounded bg-slate-800 text-slate-300 hover:bg-slate-700 flex items-center gap-1"
+          >
+            <Camera className="w-3 h-3" /> Capturar
+          </button>
+        )}
+      </h3>
+      {showCapture && (
+        <div className="mb-3 p-3 rounded-lg bg-slate-900 border border-slate-700">
+          <PhotoCaptureField onPhoto={handlePhoto} onRemove={() => setShowCapture(false)} label="Tomar foto del problema" />
+          {busy && <p className="text-slate-400 text-xs mt-2">Procesando…</p>}
+          <button
+            type="button"
+            onClick={() => setShowCapture(false)}
+            disabled={busy}
+            className="mt-2 w-full py-1.5 rounded bg-slate-800 text-slate-400 text-xs"
+          >
+            Cancelar
+          </button>
+        </div>
+      )}
+      {photos.length === 0 && !showCapture && (
+        <p className="text-slate-600 text-xs italic">Sin fotos aún. Captura para documentar.</p>
+      )}
+      {photos.length > 0 && (
+        <div className="grid grid-cols-3 gap-2">
+          {photos.map((url, idx) => (
+            <div key={idx} className="relative group">
+              <img
+                src={url}
+                alt={`Foto ${idx + 1}`}
+                className="w-full h-24 object-cover rounded-lg border border-slate-800"
+              />
+              {onRemove && (
+                <button
+                  type="button"
+                  onClick={() => onRemove(url)}
+                  className="absolute top-1 right-1 p-1 rounded bg-red-900/80 text-red-200 opacity-0 group-hover:opacity-100 transition-opacity"
+                  aria-label="Eliminar foto"
+                >
+                  <Trash2 className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
 export default function CaseStudyDetail({ caseId, onBack }) {
   const c = useCaseStudyStore((s) => s.getById(caseId));
   const addTreatment = useCaseStudyStore((s) => s.addTreatment);
@@ -173,6 +298,20 @@ export default function CaseStudyDetail({ caseId, onBack }) {
 
   const [showTreatment, setShowTreatment] = useState(false);
   const [showClose, setShowClose] = useState(false);
+  const linkPhoto = useCaseStudyStore((s) => s.linkPhoto);
+  // KISS: mutator local para remove (sin agregar action al store; raro en MVP).
+  const removePhoto = (url) => {
+    const store = useCaseStudyStore.getState();
+    const target = store.cases.find((cc) => cc.id === caseId);
+    if (!target) return;
+    useCaseStudyStore.setState({
+      cases: store.cases.map((cc) =>
+        cc.id === caseId
+          ? { ...cc, photo_asset_ids: cc.photo_asset_ids.filter((u) => u !== url), updated_at: new Date().toISOString() }
+          : cc
+      ),
+    });
+  };
 
   if (!c) {
     return (
@@ -266,6 +405,7 @@ export default function CaseStudyDetail({ caseId, onBack }) {
           <section>
             <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-500 mb-2">Cierre del caso</h3>
             <CloseCaseForm
+              caseObj={c}
               currentAffected={c.subject.count_affected}
               onSubmit={(payload) => {
                 closeCase(c.id, payload);
@@ -275,6 +415,13 @@ export default function CaseStudyDetail({ caseId, onBack }) {
             />
           </section>
         )}
+
+        {/* Photo gallery (DR-044 sub-viii F2 partial) */}
+        <PhotoGallery
+          photos={c.photo_asset_ids}
+          onAdd={(dataUrl) => linkPhoto(c.id, dataUrl)}
+          onRemove={removePhoto}
+        />
 
         {/* Treatments applied */}
         {c.treatments_applied.length > 0 && (

--- a/src/services/__tests__/caseStudyLessonsSummarizer.test.js
+++ b/src/services/__tests__/caseStudyLessonsSummarizer.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { __TEST__ } from '../caseStudyLessonsSummarizer';
+
+const { buildCaseSummaryInput, SYSTEM_PROMPT, PROMPT_VERSION } = __TEST__;
+
+describe('caseStudyLessonsSummarizer — buildCaseSummaryInput', () => {
+  it('estructura un caso completo con tratamientos + outcome', () => {
+    const c = {
+      problem: { name_freetext: 'Trozador (Agrotis ipsilon)', severity: 'high' },
+      subject: { count_total: 1000, count_affected: 10 },
+      zone_freetext: 'invernadero-david',
+      state_history: [
+        { at: '2026-05-17T08:00:00Z', state: 'open', notes: 'Caso creado' },
+        { at: '2026-05-17T10:00:00Z', state: 'in_treatment', notes: 'BT aplicado' },
+        { at: '2026-05-24T08:00:00Z', state: 'monitoring', notes: 'Sin nuevas pérdidas en 7d' },
+      ],
+      treatments_applied: [
+        { applied_at: '2026-05-17T10:00:00Z', biopreparado_id: 'bacillus_thuringiensis', dose: '1g/L', notes: 'foliar atardecer' },
+      ],
+      outcome: { closed_at: '2026-05-30T00:00:00Z', final_count_affected: 0 },
+    };
+    const input = buildCaseSummaryInput(c);
+    expect(input).toContain('Trozador');
+    expect(input).toContain('high');
+    expect(input).toContain('10/1000');
+    expect(input).toContain('invernadero-david');
+    expect(input).toContain('bacillus_thuringiensis');
+    expect(input).toContain('1g/L');
+    expect(input).toContain('Afectadas finales: 0');
+  });
+
+  it('maneja caso sin tratamientos', () => {
+    const c = {
+      problem: { name_freetext: 'Manchas hojas', severity: 'low' },
+      subject: {},
+      state_history: [{ at: '2026-05-01', state: 'open', notes: '' }],
+      treatments_applied: [],
+    };
+    const input = buildCaseSummaryInput(c);
+    expect(input).toContain('Sin tratamientos registrados');
+  });
+
+  it('retorna null si caso es null/undefined', () => {
+    expect(buildCaseSummaryInput(null)).toBeNull();
+    expect(buildCaseSummaryInput(undefined)).toBeNull();
+  });
+
+  it('omite zone si está vacía', () => {
+    const c = {
+      problem: { name_freetext: 'x' },
+      subject: {},
+      zone_freetext: '',
+      state_history: [{ at: '2026-05-01', state: 'open' }],
+      treatments_applied: [],
+    };
+    const input = buildCaseSummaryInput(c);
+    expect(input).not.toMatch(/^Zona:/m);
+  });
+
+  it('SYSTEM_PROMPT incluye reglas privacy ADR-020', () => {
+    expect(SYSTEM_PROMPT).toMatch(/ADR-020|Ley 1581|privacy|personas/i);
+  });
+
+  it('PROMPT_VERSION está versionado', () => {
+    expect(PROMPT_VERSION).toMatch(/^v\d/);
+  });
+});

--- a/src/services/caseStudyLessonsSummarizer.js
+++ b/src/services/caseStudyLessonsSummarizer.js
@@ -1,0 +1,137 @@
+/**
+ * caseStudyLessonsSummarizer.js — LLM resume al cerrar caso (DR-044 sub-viii F5)
+ * ================================================================
+ * Toma el state_history + treatments_applied + outcome de un caso y
+ * propone un borrador de `lessons_learned` (3-5 frases, español Colombia).
+ *
+ * Privacy: NUNCA sale del host alpha. Si Ollama down → null (UI cae a
+ * input manual).
+ *
+ * Audit trail: cada respuesta retorna `_audit` para vincular a
+ * case.event_log_ids.
+ */
+
+import { streamOllama } from './ollamaStream';
+
+const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
+const MODEL = 'qwen2.5:7b';
+const TIMEOUT_MS = 60000;
+const PROMPT_VERSION = 'v1.0-2026-05-17';
+
+const SYSTEM_PROMPT = `Eres un curador agronómico que resume lecciones de un caso de estudio. Recibes el historial de un caso (estados, tratamientos, outcome) y devuelves un párrafo claro y útil para el operador campesino.
+
+OUTPUT: texto plano (NO JSON, NO markdown), 3-5 frases máximo, español Colombia register agroecológico.
+
+Estructura sugerida:
+1. Qué funcionó (tratamiento + dosis + frecuencia que dio resultado).
+2. Qué NO funcionó o tiempo perdido.
+3. Recomendación para próxima vez (preventivo, momento ideal, sinergia).
+
+Reglas:
+- NO inventes datos no presentes en el historial.
+- NO incluyas nombres de personas (privacy ADR-020 Ley 1581).
+- NO incluyas coordenadas exactas si la finca/zona aparece.
+- Foco en aprendizaje accionable: "Próxima vez aplicar BT 1g/L al primer signo".
+- Si el caso falló (closed_failed), explicita por qué probablemente.
+- Si el caso fue muy corto o sin tratamientos, sé honesto: "Caso cerrado sin intervención registrada, observación inicial fue exagerada."
+`;
+
+/**
+ * Construye payload narrativo desde la estructura del caso.
+ */
+export function buildCaseSummaryInput(caseObj) {
+  if (!caseObj) return null;
+  const parts = [];
+  parts.push(`Problema: ${caseObj.problem?.name_freetext || 'sin nombre'}`);
+  if (caseObj.problem?.severity) parts.push(`Severidad inicial: ${caseObj.problem.severity}`);
+  if (caseObj.subject?.count_total) {
+    parts.push(`Cohort: ${caseObj.subject.count_affected ?? '?'}/${caseObj.subject.count_total} afectadas`);
+  }
+  if (caseObj.zone_freetext) parts.push(`Zona: ${caseObj.zone_freetext}`);
+
+  parts.push('\nHistorial de estados (cronológico):');
+  for (const h of caseObj.state_history || []) {
+    parts.push(`- [${h.at}] → ${h.state}${h.notes ? ` (${h.notes})` : ''}`);
+  }
+
+  if ((caseObj.treatments_applied || []).length > 0) {
+    parts.push('\nTratamientos aplicados:');
+    for (const t of caseObj.treatments_applied) {
+      parts.push(`- [${t.applied_at}] ${t.biopreparado_id}${t.dose ? ' · ' + t.dose : ''}${t.notes ? ' · ' + t.notes : ''}`);
+    }
+  } else {
+    parts.push('\nSin tratamientos registrados.');
+  }
+
+  if (caseObj.outcome) {
+    parts.push(`\nOutcome:`);
+    if (caseObj.outcome.final_count_affected != null) {
+      parts.push(`- Afectadas finales: ${caseObj.outcome.final_count_affected}`);
+    }
+    if (caseObj.outcome.closed_at) parts.push(`- Cerrado: ${caseObj.outcome.closed_at}`);
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Llama Ollama para generar lessons_learned. Devuelve {text, _audit} o null.
+ */
+export async function summarizeLessons(caseObj, opts = {}) {
+  const input = buildCaseSummaryInput(caseObj);
+  if (!input) return null;
+
+  const body = {
+    model: MODEL,
+    stream: true,
+    keep_alive: '5m',
+    options: { temperature: 0.3, num_ctx: 4096 },
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: input },
+    ],
+  };
+
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  const signal = opts.signal
+    ? mergeSignals(opts.signal, ctrl.signal)
+    : ctrl.signal;
+
+  try {
+    const fullText = await streamOllama(OLLAMA_CHAT_URL, body, opts.onToken, { signal });
+    clearTimeout(t);
+    if (!fullText || fullText.trim().length < 30) return null;
+
+    return {
+      text: fullText.trim(),
+      _audit: {
+        model: MODEL,
+        prompt_version: PROMPT_VERSION,
+        generated_at: new Date().toISOString(),
+      },
+    };
+  } catch (e) {
+    clearTimeout(t);
+    if (e?.name === 'AbortError') {
+      console.warn('[caseStudyLessonsSummarizer] timeout/abort');
+    } else {
+      console.warn('[caseStudyLessonsSummarizer] error:', e?.message || e);
+    }
+    return null;
+  }
+}
+
+function mergeSignals(a, b) {
+  const ctrl = new AbortController();
+  if (a.aborted || b.aborted) ctrl.abort();
+  else {
+    a.addEventListener('abort', () => ctrl.abort(), { once: true });
+    b.addEventListener('abort', () => ctrl.abort(), { once: true });
+  }
+  return ctrl.signal;
+}
+
+export const __TEST__ = { buildCaseSummaryInput, SYSTEM_PROMPT, PROMPT_VERSION };
+
+export default summarizeLessons;


### PR DESCRIPTION
## Resumen

Continúa integración IA del módulo Casos de Estudio. Cumple DR-044 Sub-viii features 2 (Photo gallery) y 5 (Lessons summarization).

## Feature 2 — Photo gallery

- Componente `PhotoGallery` dentro de `CaseStudyDetail`.
- Reusa `PhotoCaptureField` existente (Issue #86/#87): captura + compresión + previsualización ya implementadas.
- Storage KISS: blob → FileReader → data URL → linkPhoto. Offline-first compatible.
- Grid 3 columnas + delete on hover.
- Migración a FarmOS media asset IDs viene post-DR-044 sub-i.

## Feature 5 — Lessons learned summarization

- `src/services/caseStudyLessonsSummarizer.js`: `summarizeLessons(caseObj)` → Ollama qwen2.5:7b con prompt focused en aprendizaje agronómico accionable.
- Audit trail metadata para vincular a `case.event_log_ids`.
- Privacy: NUNCA sale del host. Si Ollama down → null (UI cae a input manual).
- `buildCaseSummaryInput()` estructura el case en formato narrativo.

UI: botón "✨ Sugerir con IA" al lado del textarea lessons_learned en CloseCaseForm. Loading state + error friendly.

## Tests

```
Test Files  18 passed (18)
Tests       135 passed (135)
```

6 nuevos tests cubren input building + null-safety + privacy keywords + versioning.

## Test plan

- [ ] CodeQL SAST verde
- [ ] Playwright E2E verde
- [ ] (auto) 135/135 tests passing
- [ ] (manual post-merge) capturar foto → linkPhoto → ver en gallery
- [ ] (manual post-merge, post-GPU sm_52) generar lessons con caso David trozador

🤖 Generated with [Claude Code](https://claude.com/claude-code)