### PR TITLE
feat(oracle): telemetría LLM/GPU privacy-safe en Eco-Oracle (ADR-023)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.107",
+  "version": "0.12.108",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v149';
+const CACHE_NAME = 'chagra-v150';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,7 @@ const OnboardingPiloto = lazy(() => import('./components/OnboardingPiloto'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const VoiceTelemetryScreen = lazy(() => import('./components/VoiceTelemetryScreen'));
+const LLMTelemetryScreen = lazy(() => import('./components/LLMTelemetryScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
 const CaseStudyTopWidget = lazy(() => import('./components/CaseStudyTopWidget'));
@@ -382,6 +383,8 @@ export default function App() {
         return <ProfileScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />;
       case 'voice_telemetry':
         return <VoiceTelemetryScreen onBack={() => navigate('perfil')} />;
+      case 'llm_telemetry':
+        return <LLMTelemetryScreen onBack={() => navigate('perfil')} />;
       case 'casos':
         return (
           <CaseStudyScreen

--- a/src/components/LLMTelemetryScreen.jsx
+++ b/src/components/LLMTelemetryScreen.jsx
@@ -1,0 +1,376 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Cpu, Zap, Activity, RefreshCw, Download, Trash2, AlertTriangle, CheckCircle2, XCircle, ChevronLeft } from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import {
+  getLLMEvents,
+  aggregateLLMMetrics,
+  clearLLMTelemetry,
+  exportLLMTelemetry,
+  isLLMTelemetryEnabled,
+  setLLMTelemetryEnabled,
+} from '../services/llmTelemetryService';
+import { getGpuSnapshot, listAvailableModels } from '../services/gpuTelemetryService';
+
+const FLUJO_LABELS = {
+  chat: 'Chat',
+  extract: 'Extracción NLU',
+  vision: 'Visión foliar',
+  summarize: 'Resumen',
+  recommend: 'Recomendación',
+  help: 'Ayuda Q&A',
+  other: 'Otro',
+};
+
+const STATUS_STYLES = {
+  success: { dot: 'bg-emerald-500', label: 'OK', icon: CheckCircle2, color: 'text-emerald-400' },
+  error: { dot: 'bg-red-500', label: 'Error', icon: XCircle, color: 'text-red-400' },
+  abort: { dot: 'bg-amber-500', label: 'Abort', icon: AlertTriangle, color: 'text-amber-400' },
+};
+
+const PROCESSOR_STYLES = {
+  gpu: { label: 'GPU', color: 'bg-emerald-900/40 text-emerald-300 border-emerald-700/50' },
+  partial: { label: 'Parcial', color: 'bg-amber-900/40 text-amber-300 border-amber-700/50' },
+  cpu: { label: 'CPU', color: 'bg-slate-700/40 text-slate-300 border-slate-600/50' },
+  unknown: { label: '?', color: 'bg-slate-800/40 text-slate-500 border-slate-700/50' },
+};
+
+const formatTs = (iso) => {
+  if (!iso) return '-';
+  const d = new Date(iso);
+  return d.toLocaleString('es-CO', {
+    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit',
+  });
+};
+
+const formatMs = (ms) => {
+  if (ms == null) return '-';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+};
+
+const formatVram = (mb) => {
+  if (!mb) return '-';
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`;
+  return `${mb} MB`;
+};
+
+const formatRate = (rate) => (rate == null ? '-' : `${rate.toFixed(1)} t/s`);
+
+const formatPct = (frac) => `${Math.round((frac || 0) * 100)}%`;
+
+const StatCard = ({ icon: Icon, label, value, sublabel, color = 'text-slate-300' }) => (
+  <div className="rounded-xl bg-slate-900/40 border border-slate-800 p-3 flex flex-col gap-1">
+    <div className="flex items-center gap-1.5 text-[10px] uppercase tracking-wider text-slate-500">
+      {Icon && <Icon size={12} />}
+      {label}
+    </div>
+    <div className={`text-xl font-bold ${color}`}>{value}</div>
+    {sublabel && <div className="text-[10px] text-slate-500">{sublabel}</div>}
+  </div>
+);
+
+export default function LLMTelemetryScreen({ onBack }) {
+  const [events, setEvents] = useState([]);
+  const [aggregates, setAggregates] = useState({ totals: {}, byModel: {}, byFlujo: {} });
+  const [gpuSnapshot, setGpuSnapshot] = useState(null);
+  const [availableModels, setAvailableModels] = useState({ available: false, models: [] });
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabledState] = useState(isLLMTelemetryEnabled());
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [list, snap, tags] = await Promise.all([
+        getLLMEvents(200),
+        getGpuSnapshot({ force: true }),
+        listAvailableModels(),
+      ]);
+      setEvents(list);
+      setAggregates(aggregateLLMMetrics(list));
+      setGpuSnapshot(snap);
+      setAvailableModels(tags);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const onToggleEnabled = () => {
+    const next = !enabled;
+    setLLMTelemetryEnabled(next);
+    setEnabledState(next);
+  };
+
+  const onClear = async () => {
+    if (!window.confirm('¿Borrar todos los eventos de telemetría LLM? (no afecta el catálogo ni la chagra)')) return;
+    await clearLLMTelemetry();
+    refresh();
+  };
+
+  const onExport = async (format) => {
+    const data = await exportLLMTelemetry(format);
+    const blob = new Blob([data], { type: format === 'csv' ? 'text/csv' : 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `chagra-llm-telemetry-${new Date().toISOString().slice(0, 10)}.${format}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const totals = aggregates.totals || {};
+  const byModel = aggregates.byModel || {};
+  const byFlujo = aggregates.byFlujo || {};
+
+  return (
+    <ScreenShell>
+      <div className="max-w-5xl mx-auto p-4 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-2 text-sm text-slate-400 hover:text-white"
+          >
+            <ChevronLeft size={18} /> Volver
+          </button>
+          <h1 className="text-lg font-bold text-white flex items-center gap-2">
+            <Cpu size={20} className="text-emerald-400" /> Oracle LLM / GPU
+          </h1>
+          <button
+            onClick={refresh}
+            disabled={loading}
+            className="p-2 rounded-lg bg-slate-800 hover:bg-slate-700 disabled:opacity-50"
+            aria-label="Refrescar"
+          >
+            <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+          </button>
+        </div>
+
+        {/* GPU Snapshot */}
+        <section className="space-y-2">
+          <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-2">
+            <Zap size={14} className="text-amber-400" /> GPU — Modelos cargados
+          </h2>
+          <div className="rounded-2xl bg-slate-900/40 border border-slate-800 p-4">
+            {!gpuSnapshot && (
+              <div className="text-sm text-slate-500">Cargando snapshot…</div>
+            )}
+            {gpuSnapshot && !gpuSnapshot.available && (
+              <div className="text-sm text-amber-300 flex items-center gap-2">
+                <AlertTriangle size={14} /> Ollama no responde — {gpuSnapshot.error}
+              </div>
+            )}
+            {gpuSnapshot?.available && gpuSnapshot.models.length === 0 && (
+              <div className="text-sm text-slate-500">Ningún modelo cargado en RAM/VRAM ahora mismo. Se cargan al primer call.</div>
+            )}
+            {gpuSnapshot?.available && gpuSnapshot.models.length > 0 && (
+              <div className="space-y-2">
+                <div className="text-[11px] text-slate-500">
+                  VRAM total ocupada: <span className="text-emerald-400 font-mono">{formatVram(gpuSnapshot.totalVramMB)}</span>
+                  {' · '}snapshot: {formatTs(gpuSnapshot.ts)}
+                </div>
+                {gpuSnapshot.models.map((m) => {
+                  const procStyle = PROCESSOR_STYLES[m.processor] || PROCESSOR_STYLES.unknown;
+                  return (
+                    <div key={m.name} className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/40 border border-slate-800">
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-bold text-white truncate">{m.name}</div>
+                        <div className="text-[10px] text-slate-500">
+                          {m.details.parameterSize || '?'} · {m.details.quantization || '?'} · {m.details.family || '?'}
+                        </div>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className="text-xs font-mono text-emerald-400">{formatVram(m.vramMB)}</div>
+                        <div className="text-[9px] text-slate-500">VRAM / {formatVram(m.sizeMB)}</div>
+                      </div>
+                      <span className={`text-[10px] px-2 py-1 rounded-full border font-mono ${procStyle.color}`}>
+                        {procStyle.label} {m.gpuShare ? `${Math.round(m.gpuShare * 100)}%` : ''}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          {availableModels.available && availableModels.models.length > 0 && (
+            <details className="rounded-xl bg-slate-900/30 border border-slate-800 p-3">
+              <summary className="text-xs text-slate-400 cursor-pointer">
+                Catálogo de modelos disponibles ({availableModels.models.length})
+              </summary>
+              <div className="mt-2 grid grid-cols-2 gap-1 text-[11px] font-mono">
+                {availableModels.models.map((m) => (
+                  <div key={m.name} className="flex justify-between gap-2 text-slate-400">
+                    <span className="truncate">{m.name}</span>
+                    <span className="text-slate-600 shrink-0">{m.parameterSize || ''}</span>
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
+        </section>
+
+        {/* Totals */}
+        <section className="space-y-2">
+          <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-2">
+            <Activity size={14} className="text-emerald-400" /> Telemetría LLM — agregados
+          </h2>
+          {totals.total === 0 ? (
+            <div className="rounded-2xl bg-slate-900/40 border border-slate-800 p-6 text-center">
+              <p className="text-sm text-slate-400">
+                {enabled
+                  ? 'Aún no hay eventos. Hacé una pregunta a la IA y volvé acá.'
+                  : 'Telemetría LLM deshabilitada. Activá el switch para empezar a registrar.'}
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              <StatCard label="Calls total" value={totals.total} sublabel={`${totals.success || 0} OK · ${totals.error || 0} err`} />
+              <StatCard label="GPU / CPU" value={`${totals.gpuCalls || 0} / ${totals.cpuCalls || 0}`} sublabel={`${formatPct((totals.gpuCalls || 0) / (totals.total || 1))} GPU`} color="text-emerald-400" />
+              <StatCard label="Latencia media" value={formatMs(totals.avgTotalMs)} sublabel={`p95: ${formatMs(totals.p95TotalMs)}`} />
+              <StatCard label="Eval rate medio" value={formatRate(totals.avgEvalRate)} sublabel={`${formatPct(totals.successRate)} success`} color="text-amber-400" />
+            </div>
+          )}
+        </section>
+
+        {/* Por modelo */}
+        {Object.keys(byModel).length > 0 && (
+          <section className="space-y-2">
+            <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider">Por modelo</h2>
+            <div className="rounded-2xl bg-slate-900/40 border border-slate-800 overflow-hidden">
+              <table className="w-full text-xs">
+                <thead className="bg-slate-800/60 text-slate-400">
+                  <tr>
+                    <th className="text-left px-3 py-2">Modelo</th>
+                    <th className="text-right px-3 py-2">Calls</th>
+                    <th className="text-right px-3 py-2">Lat. media</th>
+                    <th className="text-right px-3 py-2">p95</th>
+                    <th className="text-right px-3 py-2">t/s</th>
+                    <th className="text-right px-3 py-2">GPU%</th>
+                    <th className="text-right px-3 py-2">Err%</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(byModel).map(([model, s]) => (
+                    <tr key={model} className="border-t border-slate-800 hover:bg-slate-800/30">
+                      <td className="px-3 py-2 font-mono text-white truncate max-w-[180px]">{model}</td>
+                      <td className="px-3 py-2 text-right text-slate-300">{s.count}</td>
+                      <td className="px-3 py-2 text-right text-slate-300">{formatMs(s.avgTotalMs)}</td>
+                      <td className="px-3 py-2 text-right text-slate-400">{formatMs(s.p95TotalMs)}</td>
+                      <td className="px-3 py-2 text-right text-amber-400">{formatRate(s.avgEvalRate)}</td>
+                      <td className={`px-3 py-2 text-right ${s.gpuShare > 0.5 ? 'text-emerald-400' : 'text-slate-500'}`}>{formatPct(s.gpuShare)}</td>
+                      <td className={`px-3 py-2 text-right ${s.errorRate > 0.1 ? 'text-red-400' : 'text-slate-500'}`}>{formatPct(s.errorRate)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Por flujo */}
+        {Object.keys(byFlujo).length > 0 && (
+          <section className="space-y-2">
+            <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider">Por flujo</h2>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {Object.entries(byFlujo).map(([flujo, s]) => (
+                <div key={flujo} className="rounded-xl bg-slate-900/40 border border-slate-800 p-3">
+                  <div className="text-[10px] uppercase tracking-wider text-slate-500">{FLUJO_LABELS[flujo] || flujo}</div>
+                  <div className="text-lg font-bold text-white">{s.count}</div>
+                  <div className="text-[10px] text-slate-500">
+                    {formatMs(s.avgTotalMs)} medio · {formatPct(s.errorRate)} err
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Eventos recientes */}
+        {events.length > 0 && (
+          <section className="space-y-2">
+            <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider">
+              Eventos recientes ({events.length})
+            </h2>
+            <div className="rounded-2xl bg-slate-900/40 border border-slate-800 overflow-hidden">
+              <div className="max-h-96 overflow-y-auto">
+                <table className="w-full text-[11px]">
+                  <thead className="bg-slate-800/60 text-slate-400 sticky top-0">
+                    <tr>
+                      <th className="text-left px-3 py-2">Fecha</th>
+                      <th className="text-left px-3 py-2">Modelo</th>
+                      <th className="text-left px-3 py-2">Flujo</th>
+                      <th className="text-right px-3 py-2">Total</th>
+                      <th className="text-right px-3 py-2">Tokens</th>
+                      <th className="text-right px-3 py-2">t/s</th>
+                      <th className="text-center px-3 py-2">GPU</th>
+                      <th className="text-center px-3 py-2">Estado</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {events.map((e) => {
+                      const status = STATUS_STYLES[e.status] || STATUS_STYLES.success;
+                      const proc = PROCESSOR_STYLES[e.processor] || PROCESSOR_STYLES.unknown;
+                      return (
+                        <tr key={e.id} className="border-t border-slate-800/60 hover:bg-slate-800/30">
+                          <td className="px-3 py-1.5 text-slate-400 font-mono whitespace-nowrap">{formatTs(e.created_at)}</td>
+                          <td className="px-3 py-1.5 text-slate-300 font-mono truncate max-w-[140px]">{e.model}</td>
+                          <td className="px-3 py-1.5 text-slate-500">{FLUJO_LABELS[e.flujo] || e.flujo}</td>
+                          <td className="px-3 py-1.5 text-right text-slate-300">{formatMs(e.total_ms)}</td>
+                          <td className="px-3 py-1.5 text-right text-slate-500">{e.eval_count ?? '-'}</td>
+                          <td className="px-3 py-1.5 text-right text-amber-400">{formatRate(e.eval_rate)}</td>
+                          <td className="px-3 py-1.5 text-center">
+                            <span className={`text-[9px] px-1.5 py-0.5 rounded-full border font-mono ${proc.color}`}>{proc.label}</span>
+                          </td>
+                          <td className={`px-3 py-1.5 text-center ${status.color}`}>
+                            <span className="inline-flex items-center gap-1">
+                              <span className={`w-2 h-2 rounded-full ${status.dot}`} />
+                              {e.error_kind || status.label}
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {/* Controles */}
+        <section className="space-y-3 rounded-2xl bg-slate-900/40 border border-slate-800 p-4">
+          <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-bold text-slate-200">Habilitar telemetría LLM</span>
+              <span className="text-[10px] text-slate-500">Registra metadata privacy-safe — NUNCA prompt ni respuesta</span>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              onClick={onToggleEnabled}
+              className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${enabled ? 'bg-emerald-600' : 'bg-slate-700'}`}
+            >
+              <span className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform ${enabled ? 'translate-x-5' : 'translate-x-0'}`} />
+            </button>
+          </label>
+
+          <div className="grid grid-cols-3 gap-2">
+            <button onClick={() => onExport('json')} className="p-3 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-700 text-sm text-slate-200 flex items-center justify-center gap-2 min-h-[44px]">
+              <Download size={14} /> JSON
+            </button>
+            <button onClick={() => onExport('csv')} className="p-3 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-700 text-sm text-slate-200 flex items-center justify-center gap-2 min-h-[44px]">
+              <Download size={14} /> CSV
+            </button>
+            <button onClick={onClear} className="p-3 rounded-xl bg-red-900/30 hover:bg-red-900/50 border border-red-800/50 text-sm text-red-300 flex items-center justify-center gap-2 min-h-[44px]">
+              <Trash2 size={14} /> Borrar
+            </button>
+          </div>
+        </section>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User, Palette, Briefcase, Save, Check, Mic, Eye, MapPin, Home } from 'lucide-react';
+import { User, Palette, Briefcase, Save, Check, Mic, Eye, MapPin, Home, Cpu } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import ThemeSelector from './common/ThemeSelector';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
@@ -203,6 +203,24 @@ export default function ProfileScreen({ onBack, onNavigate }) {
             className="w-full p-3 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-700 font-bold text-sm text-slate-200 flex items-center justify-center gap-2 min-h-[48px] transition-colors"
           >
             <Eye size={16} /> Ver telemetría
+          </button>
+        </div>
+
+        {/* Oracle LLM/GPU Section (v13 2026-05-17 — ADR-023 Eco-Oracle) */}
+        <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+          <div className="flex items-center gap-2 px-1">
+            <Cpu size={18} className="text-emerald-400" />
+            <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Oracle LLM / GPU</h3>
+          </div>
+          <p className="text-[11px] text-slate-500 px-1">
+            Estado del modelo de IA, uso de GPU/CPU, latencias y errores. Privacy-safe: NUNCA guarda prompt ni respuesta.
+          </p>
+          <button
+            type="button"
+            onClick={() => onNavigate && onNavigate('llm_telemetry')}
+            className="w-full p-3 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-700 font-bold text-sm text-slate-200 flex items-center justify-center gap-2 min-h-[48px] transition-colors"
+          >
+            <Cpu size={16} /> Abrir Oracle LLM/GPU
           </button>
         </div>
 

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -24,10 +24,15 @@
  *   - voice_telemetry      (v10 ADR-030 Regla 8: IDB para telemetría voz)
  *   - conversation_memory (v12 057.3: IDB para memoria conversacional persistente)
  *                           keyPath: id; indexes: operator_id, timestamp)
+ *   - llm_telemetry        (v13 2026-05-17: telemetría privacy-safe de calls LLM
+ *                           para Eco-Oracle Dashboard ADR-023. Captura solo
+ *                           metadata — modelo, latencia, tokens, processor
+ *                           gpu/cpu — NUNCA prompt ni respuesta. keyPath: id;
+ *                           indexes: model, flujo, created_at, status, synced)
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 12;
+export const DB_VERSION = 13;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -43,6 +48,7 @@ export const STORES = {
   PLANS: 'plans',
   VOICE_TELEMETRY: 'voice_telemetry',
   CONVERSATION_MEMORY: 'conversation_memory',
+  LLM_TELEMETRY: 'llm_telemetry',
 };
 
 let dbInstance = null;
@@ -177,6 +183,21 @@ export const openDB = async () => {
           const store = db.createObjectStore(STORES.CONVERSATION_MEMORY, { keyPath: 'id' });
           store.createIndex('operator_id', 'operator_id', { unique: false });
           store.createIndex('timestamp', 'timestamp', { unique: false });
+        }
+      }
+
+      // v13: llm_telemetry — metadata privacy-safe de cada call LLM
+      // (ollamaStream + openaiStream). Captura solo modelo, latencia, tokens,
+      // processor gpu/cpu — NUNCA prompt ni respuesta. Alimenta Eco-Oracle
+      // Dashboard (ADR-023) sección LLM + GPU.
+      if (event.oldVersion < 13) {
+        if (!db.objectStoreNames.contains(STORES.LLM_TELEMETRY)) {
+          const store = db.createObjectStore(STORES.LLM_TELEMETRY, { keyPath: 'id' });
+          store.createIndex('model', 'model', { unique: false });
+          store.createIndex('flujo', 'flujo', { unique: false });
+          store.createIndex('created_at', 'created_at', { unique: false });
+          store.createIndex('status', 'status', { unique: false });
+          store.createIndex('synced', 'synced', { unique: false });
         }
       }
     };

--- a/src/services/gpuTelemetryService.js
+++ b/src/services/gpuTelemetryService.js
@@ -1,0 +1,138 @@
+/**
+ * gpuTelemetryService.js — Snapshot de GPU/Ollama process state (v13 2026-05-17).
+ *
+ * Consulta `/api/ollama/api/ps` (proxy → http://localhost:11434/api/ps) para
+ * obtener modelos cargados, tamaño en VRAM y processor (gpu/cpu) usado por
+ * cada uno. Alimenta el Eco-Oracle Dashboard sección GPU.
+ *
+ * Cache: 5s — un solo poll alimenta a múltiples consumidores en la misma
+ * ventana de render. Sin polling automático: el screen llama al refresh
+ * explícito por botón o tras un call LLM.
+ *
+ * Privacy: solo modelo y bytes VRAM. NO digests, NO usuarios, NO prompts.
+ *
+ * Response shape Ollama `/api/ps`:
+ *   { models: [{ name, model, size, size_vram, expires_at, details: {...} }] }
+ *
+ * `size_vram > 0` con `size_vram == size` => 100% GPU offload.
+ * `size_vram == 0` => CPU only.
+ * `0 < size_vram < size` => parcial (warning para nuestro caso M6000 12GB).
+ */
+
+const OLLAMA_PS_URL = '/api/ollama/api/ps';
+const CACHE_TTL_MS = 5000;
+const FETCH_TIMEOUT_MS = 3000;
+
+let cache = null; // { ts, snapshot }
+
+const fetchWithTimeout = async (url, options = {}, timeoutMs = FETCH_TIMEOUT_MS) => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Convierte un model entry Ollama a una fila legible.
+ */
+const normalizeModel = (m) => {
+  const size = Number(m?.size) || 0;
+  const sizeVram = Number(m?.size_vram) || 0;
+  let processor = 'cpu';
+  let gpuShare = 0;
+  if (sizeVram > 0 && size > 0) {
+    gpuShare = sizeVram / size;
+    processor = gpuShare >= 0.99 ? 'gpu' : (gpuShare > 0 ? 'partial' : 'cpu');
+  }
+  return {
+    name: m?.name || m?.model || 'unknown',
+    sizeMB: Math.round(size / (1024 * 1024)),
+    vramMB: Math.round(sizeVram / (1024 * 1024)),
+    processor,
+    gpuShare: Math.round(gpuShare * 100) / 100,
+    expiresAt: m?.expires_at || null,
+    details: {
+      family: m?.details?.family || null,
+      parameterSize: m?.details?.parameter_size || null,
+      quantization: m?.details?.quantization_level || null,
+    },
+  };
+};
+
+/**
+ * Devuelve snapshot {ts, available, models[]}. Si Ollama está down,
+ * retorna {ts, available:false, error}. NUNCA throw.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.force] - ignora cache 5s
+ */
+export const getGpuSnapshot = async (opts = {}) => {
+  const now = Date.now();
+  if (!opts.force && cache && (now - cache.ts) < CACHE_TTL_MS) {
+    return cache.snapshot;
+  }
+
+  try {
+    const response = await fetchWithTimeout(OLLAMA_PS_URL, { method: 'GET' });
+    if (!response.ok) {
+      const snapshot = {
+        ts: new Date().toISOString(),
+        available: false,
+        error: `HTTP ${response.status} ${response.statusText}`,
+        models: [],
+        totalVramMB: 0,
+      };
+      cache = { ts: now, snapshot };
+      return snapshot;
+    }
+    const data = await response.json();
+    const models = Array.isArray(data?.models) ? data.models.map(normalizeModel) : [];
+    const totalVramMB = models.reduce((sum, m) => sum + (m.vramMB || 0), 0);
+    const snapshot = {
+      ts: new Date().toISOString(),
+      available: true,
+      models,
+      totalVramMB,
+      hasGpu: models.some((m) => m.processor === 'gpu' || m.processor === 'partial'),
+    };
+    cache = { ts: now, snapshot };
+    return snapshot;
+  } catch (err) {
+    const snapshot = {
+      ts: new Date().toISOString(),
+      available: false,
+      error: err?.name === 'AbortError' ? 'timeout' : (err?.message || 'network'),
+      models: [],
+      totalVramMB: 0,
+    };
+    cache = { ts: now, snapshot };
+    return snapshot;
+  }
+};
+
+/**
+ * Lista de modelos disponibles (no necesariamente cargados) via `/api/tags`.
+ * Útil para mostrar catálogo en Oracle.
+ */
+export const listAvailableModels = async () => {
+  try {
+    const response = await fetchWithTimeout('/api/ollama/api/tags', { method: 'GET' });
+    if (!response.ok) return { available: false, models: [] };
+    const data = await response.json();
+    const models = Array.isArray(data?.models) ? data.models.map((m) => ({
+      name: m?.name,
+      sizeMB: Math.round((m?.size || 0) / (1024 * 1024)),
+      family: m?.details?.family || null,
+      parameterSize: m?.details?.parameter_size || null,
+      quantization: m?.details?.quantization_level || null,
+    })) : [];
+    return { available: true, models };
+  } catch (_) {
+    return { available: false, models: [] };
+  }
+};
+
+export const clearGpuCache = () => { cache = null; };

--- a/src/services/llmTelemetryService.js
+++ b/src/services/llmTelemetryService.js
@@ -1,0 +1,265 @@
+/**
+ * llmTelemetryService.js — Telemetría privacy-safe de calls LLM (v13 2026-05-17).
+ *
+ * Alimenta el Eco-Oracle Dashboard (ADR-023) sección LLM + GPU. Espejo del
+ * patrón `voiceTelemetryService.js` para coherencia operativa.
+ *
+ * Privacy (ADR-030 Regla 9 extendida a LLM):
+ * - NUNCA persiste prompt ni respuesta del modelo (solo longitudes/conteos).
+ * - NO operator_id, NO coords, NO transcripciones.
+ * - Aggregates solo: modelo, latencias, tokens, processor (gpu/cpu), error_kind.
+ *
+ * Schema del evento:
+ *   {
+ *     id: 'lm_<ts36><rand36>',
+ *     model: 'gemma3:4b',
+ *     endpoint: '/api/ollama/api/chat',
+ *     flujo: 'chat' | 'extract' | 'vision' | 'summarize' | 'recommend' | 'help' | 'other',
+ *     status: 'success' | 'error' | 'abort',
+ *     total_ms: 5432,             // wall-clock cliente
+ *     load_ms: 3020,              // ollama: load_duration / 1e6 (null si no aplica)
+ *     prompt_eval_count: 12,      // tokens prompt
+ *     eval_count: 89,             // tokens generación
+ *     eval_rate: 118.18,          // tokens/s calculado (eval_count / eval_ms*1000)
+ *     processor: 'gpu' | 'cpu' | 'unknown',
+ *     error_kind: null | 'timeout' | 'http_4xx' | 'http_5xx' | 'abort' | 'network' | 'parse',
+ *     created_at: ISO,
+ *     synced: false,
+ *   }
+ *
+ * Backend: IndexedDB store `llm_telemetry` (dbCore v13).
+ */
+
+import { openDB, STORES } from '../db/dbCore.js';
+
+const RETAIN_MAX = 1000; // cap defensivo — al sobrepasar se purga el oldest
+
+const generateId = () => {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 10);
+  return `lm_${timestamp}${random}`;
+};
+
+const isEnabled = () => {
+  try {
+    return localStorage.getItem('chagra:llm-telemetry-enabled') !== 'false';
+  } catch (_) {
+    return true;
+  }
+};
+
+/**
+ * Registra un evento LLM. Llamado por ollamaStream/openaiStream al cerrar.
+ * No-op si la telemetría está deshabilitada por el usuario.
+ */
+export const recordLLMEvent = async (event) => {
+  if (!isEnabled()) return null;
+  if (!event || typeof event !== 'object') return null;
+
+  const record = {
+    id: generateId(),
+    model: event.model || 'unknown',
+    endpoint: event.endpoint || 'unknown',
+    flujo: event.flujo || 'other',
+    status: event.status || 'success',
+    total_ms: typeof event.total_ms === 'number' ? event.total_ms : null,
+    load_ms: typeof event.load_ms === 'number' ? event.load_ms : null,
+    prompt_eval_count: typeof event.prompt_eval_count === 'number' ? event.prompt_eval_count : null,
+    eval_count: typeof event.eval_count === 'number' ? event.eval_count : null,
+    eval_rate: typeof event.eval_rate === 'number' ? event.eval_rate : null,
+    processor: event.processor || 'unknown',
+    error_kind: event.error_kind || null,
+    created_at: new Date().toISOString(),
+    synced: false,
+  };
+
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.LLM_TELEMETRY, 'readwrite');
+    tx.objectStore(STORES.LLM_TELEMETRY).add(record);
+    await new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+    return record;
+  } catch (_err) {
+    // Telemetría NUNCA debe romper la UX. Falla silente.
+    return null;
+  }
+};
+
+/**
+ * Devuelve los eventos LLM más recientes, orden descendente por created_at.
+ */
+export const getLLMEvents = async (limit = 200) => {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.LLM_TELEMETRY, 'readonly');
+    const store = tx.objectStore(STORES.LLM_TELEMETRY);
+    const index = store.index('created_at');
+    const events = [];
+    return new Promise((resolve, reject) => {
+      const req = index.openCursor(null, 'prev');
+      req.onsuccess = (e) => {
+        const cursor = e.target.result;
+        if (cursor && events.length < limit) {
+          events.push(cursor.value);
+          cursor.continue();
+        } else {
+          resolve(events);
+        }
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch (_) {
+    return [];
+  }
+};
+
+/**
+ * Borra todos los eventos LLM (action de usuario en pantalla Telemetría).
+ */
+export const clearLLMTelemetry = async () => {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.LLM_TELEMETRY, 'readwrite');
+    tx.objectStore(STORES.LLM_TELEMETRY).clear();
+    await new Promise((resolve) => { tx.oncomplete = resolve; });
+    return true;
+  } catch (_) {
+    return false;
+  }
+};
+
+/**
+ * Mantiene el store por debajo de RETAIN_MAX (LRU por created_at). Idempotente
+ * y barato — corre opcionalmente al cerrar cada evento. Falla silente.
+ */
+export const pruneLLMTelemetry = async () => {
+  try {
+    const db = await openDB();
+    const countTx = db.transaction(STORES.LLM_TELEMETRY, 'readonly');
+    const count = await new Promise((resolve, reject) => {
+      const req = countTx.objectStore(STORES.LLM_TELEMETRY).count();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+    if (count <= RETAIN_MAX) return 0;
+
+    const excess = count - RETAIN_MAX;
+    const delTx = db.transaction(STORES.LLM_TELEMETRY, 'readwrite');
+    const index = delTx.objectStore(STORES.LLM_TELEMETRY).index('created_at');
+    let removed = 0;
+    return new Promise((resolve, reject) => {
+      const req = index.openCursor(null, 'next');
+      req.onsuccess = (e) => {
+        const cursor = e.target.result;
+        if (cursor && removed < excess) {
+          cursor.delete();
+          removed += 1;
+          cursor.continue();
+        } else {
+          resolve(removed);
+        }
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch (_) {
+    return 0;
+  }
+};
+
+/**
+ * Calcula agregaciones por modelo + flujo para el dashboard.
+ *
+ * @param {Array} events - eventos del store (precargados con getLLMEvents)
+ * @returns {{ totals, byModel, byFlujo }}
+ */
+export const aggregateLLMMetrics = (events) => {
+  const list = Array.isArray(events) ? events : [];
+
+  const success = list.filter((e) => e.status === 'success');
+  const failed = list.filter((e) => e.status === 'error');
+  const aborted = list.filter((e) => e.status === 'abort');
+
+  const totals = {
+    total: list.length,
+    success: success.length,
+    error: failed.length,
+    abort: aborted.length,
+    successRate: list.length ? (success.length / list.length) : 0,
+    gpuCalls: list.filter((e) => e.processor === 'gpu').length,
+    cpuCalls: list.filter((e) => e.processor === 'cpu').length,
+    avgTotalMs: avg(list.map((e) => e.total_ms).filter(isNum)),
+    p95TotalMs: p95(list.map((e) => e.total_ms).filter(isNum)),
+    avgEvalRate: avg(list.map((e) => e.eval_rate).filter(isNum)),
+  };
+
+  const byModel = groupReduce(list, (e) => e.model || 'unknown', (group) => ({
+    count: group.length,
+    success: group.filter((e) => e.status === 'success').length,
+    errorRate: group.length ? group.filter((e) => e.status === 'error').length / group.length : 0,
+    avgTotalMs: avg(group.map((e) => e.total_ms).filter(isNum)),
+    p95TotalMs: p95(group.map((e) => e.total_ms).filter(isNum)),
+    avgEvalRate: avg(group.map((e) => e.eval_rate).filter(isNum)),
+    avgEvalCount: avg(group.map((e) => e.eval_count).filter(isNum)),
+    gpuShare: group.length ? group.filter((e) => e.processor === 'gpu').length / group.length : 0,
+  }));
+
+  const byFlujo = groupReduce(list, (e) => e.flujo || 'other', (group) => ({
+    count: group.length,
+    avgTotalMs: avg(group.map((e) => e.total_ms).filter(isNum)),
+    errorRate: group.length ? group.filter((e) => e.status === 'error').length / group.length : 0,
+  }));
+
+  return { totals, byModel, byFlujo };
+};
+
+const isNum = (n) => typeof n === 'number' && Number.isFinite(n);
+const avg = (arr) => arr.length ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+const p95 = (arr) => {
+  if (!arr.length) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.floor(sorted.length * 0.95);
+  return Math.round(sorted[Math.min(idx, sorted.length - 1)]);
+};
+const groupReduce = (arr, keyFn, reduceFn) => {
+  const groups = {};
+  for (const item of arr) {
+    const key = keyFn(item);
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(item);
+  }
+  const out = {};
+  for (const [key, group] of Object.entries(groups)) {
+    out[key] = reduceFn(group);
+  }
+  return out;
+};
+
+/**
+ * Exporta los eventos a CSV o JSON para auditoría (no incluye prompts/respuestas).
+ */
+export const exportLLMTelemetry = async (format = 'json') => {
+  const events = await getLLMEvents(RETAIN_MAX);
+  if (format === 'csv') {
+    const headers = ['id', 'created_at', 'model', 'endpoint', 'flujo', 'status',
+                     'processor', 'total_ms', 'load_ms', 'eval_count',
+                     'prompt_eval_count', 'eval_rate', 'error_kind'];
+    const rows = events.map((e) => headers.map((h) => e[h] ?? '').join(','));
+    return [headers.join(','), ...rows].join('\n');
+  }
+  return JSON.stringify(events, null, 2);
+};
+
+/**
+ * Toggle telemetría LLM (persistente en localStorage para coherencia con voice).
+ */
+export const setLLMTelemetryEnabled = (enabled) => {
+  try {
+    localStorage.setItem('chagra:llm-telemetry-enabled', enabled ? 'true' : 'false');
+  } catch (_) { /* noop */ }
+};
+
+export const isLLMTelemetryEnabled = isEnabled;

--- a/src/services/ollamaStream.js
+++ b/src/services/ollamaStream.js
@@ -15,7 +15,45 @@
  *   proxy_http_version 1.1;
  * Sin esa configuracion, los chunks llegan en un unico lote al cliente y el
  * efecto de typewriter se pierde (la request sigue funcionando igual).
+ *
+ * Telemetría (v13 2026-05-17): cada call registra un evento privacy-safe en
+ * IDB store `llm_telemetry` con modelo, latencia, tokens y processor
+ * (gpu/cpu detectado vía /api/ps cache 5s). NUNCA persiste prompt ni respuesta.
+ * Falla silente — telemetría jamás rompe la UX.
  */
+
+import { recordLLMEvent } from './llmTelemetryService';
+import { getGpuSnapshot } from './gpuTelemetryService';
+
+const detectProcessorFor = async (model) => {
+  try {
+    const snapshot = await getGpuSnapshot();
+    if (!snapshot?.available) return 'unknown';
+    const entry = snapshot.models.find((m) => m.name === model || m.name?.startsWith(`${model}:`) || model?.startsWith(`${m.name}`));
+    if (!entry) return 'unknown';
+    return entry.processor === 'partial' ? 'partial' : entry.processor;
+  } catch (_) {
+    return 'unknown';
+  }
+};
+
+const inferFlujo = (url, body) => {
+  if (body?.flujo) return body.flujo;
+  if (typeof url !== 'string') return 'other';
+  if (url.includes('/api/chat')) return 'chat';
+  if (url.includes('/api/generate')) return 'vision'; // generate se usa para vision foliage analysis
+  if (url.includes('/v1/chat/completions')) return 'chat';
+  return 'other';
+};
+
+const classifyError = (err, status) => {
+  if (err?.name === 'AbortError') return 'abort';
+  if (status >= 500) return 'http_5xx';
+  if (status >= 400) return 'http_4xx';
+  if (err?.message?.toLowerCase().includes('network')) return 'network';
+  if (err?.message?.toLowerCase().includes('timeout')) return 'timeout';
+  return 'network';
+};
 
 const parseLine = (line) => {
   if (!line) return null;
@@ -51,12 +89,30 @@ const extractChunk = (parsed) => {
  * // full => "Hola, en que puedo ayudarte?"
  */
 export async function streamOllama(url, body, onToken, { signal, onDone } = {}) {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ ...body, stream: true }),
-    signal,
-  });
+  const t0 = Date.now();
+  const modelHint = body?.model || 'unknown';
+  const flujoHint = inferFlujo(url, body);
+  let lastDoneObj = null;
+  let response;
+
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...body, stream: true }),
+      signal,
+    });
+  } catch (err) {
+    recordLLMEvent({
+      model: modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: err?.name === 'AbortError' ? 'abort' : 'error',
+      total_ms: Date.now() - t0,
+      error_kind: classifyError(err, 0),
+    });
+    throw err;
+  }
 
   if (!response.ok) {
     let detail = '';
@@ -65,9 +121,25 @@ export async function streamOllama(url, body, onToken, { signal, onDone } = {}) 
     // HTML completo que el slice(200) leakea al UI (bug HelpVoiceQuestion 2026-05-08).
     const { buildCleanErrorMessage } = await import('./sanitizeError.js');
     const ctype = response.headers?.get?.('content-type') || '';
+    recordLLMEvent({
+      model: modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: 'error',
+      total_ms: Date.now() - t0,
+      error_kind: classifyError(null, response.status),
+    });
     throw new Error(buildCleanErrorMessage('Ollama', response.status, response.statusText, detail, ctype));
   }
   if (!response.body) {
+    recordLLMEvent({
+      model: modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: 'error',
+      total_ms: Date.now() - t0,
+      error_kind: 'parse',
+    });
     throw new Error('Respuesta sin body streameable (¿buffering del proxy?)');
   }
 
@@ -96,6 +168,7 @@ export async function streamOllama(url, body, onToken, { signal, onDone } = {}) 
           if (onToken) onToken(chunk, fullText);
         }
         if (parsed.done) {
+          lastDoneObj = parsed;
           if (onDone) {
             try { onDone(parsed); } catch (_) { /* noop */ }
           }
@@ -104,6 +177,16 @@ export async function streamOllama(url, body, onToken, { signal, onDone } = {}) 
         }
       }
     }
+  } catch (err) {
+    recordLLMEvent({
+      model: lastDoneObj?.model || modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: err?.name === 'AbortError' ? 'abort' : 'error',
+      total_ms: Date.now() - t0,
+      error_kind: classifyError(err, 0),
+    });
+    throw err;
   } finally {
     try { reader.releaseLock(); } catch (_) { /* noop */ }
   }
@@ -117,7 +200,32 @@ export async function streamOllama(url, body, onToken, { signal, onDone } = {}) 
       fullText += chunk;
       if (onToken) onToken(chunk, fullText);
     }
+    if (parsed?.done) lastDoneObj = parsed;
   }
+
+  // Telemetría privacy-safe (NUNCA prompt ni respuesta, solo metadata).
+  const total_ms = Date.now() - t0;
+  const load_ms = lastDoneObj?.load_duration ? Math.round(lastDoneObj.load_duration / 1e6) : null;
+  const eval_count = lastDoneObj?.eval_count ?? null;
+  const eval_duration_ns = lastDoneObj?.eval_duration || 0;
+  const eval_rate = (eval_count && eval_duration_ns)
+    ? Math.round((eval_count / (eval_duration_ns / 1e9)) * 100) / 100
+    : null;
+  // Detección processor non-blocking (no esperamos, schedule en background)
+  detectProcessorFor(lastDoneObj?.model || modelHint).then((processor) => {
+    recordLLMEvent({
+      model: lastDoneObj?.model || modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: 'success',
+      total_ms,
+      load_ms,
+      prompt_eval_count: lastDoneObj?.prompt_eval_count ?? null,
+      eval_count,
+      eval_rate,
+      processor,
+    });
+  });
 
   return fullText;
 }

--- a/src/services/openaiStream.js
+++ b/src/services/openaiStream.js
@@ -23,7 +23,42 @@
  *   proxy_cache off;
  *   chunked_transfer_encoding on;
  * (configurado en hosts/alpha/default.nix, mismo patrón que /api/ollama/).
+ *
+ * Telemetría (v13 2026-05-17): cada call registra evento privacy-safe en
+ * IDB `llm_telemetry` con modelo, latencia, tokens, processor (gpu/cpu).
+ * NUNCA persiste prompt ni respuesta. Falla silente.
  */
+
+import { recordLLMEvent } from './llmTelemetryService';
+import { getGpuSnapshot } from './gpuTelemetryService';
+
+const detectProcessorFor = async (model) => {
+  try {
+    const snapshot = await getGpuSnapshot();
+    if (!snapshot?.available) return 'unknown';
+    const entry = snapshot.models.find((m) => m.name === model || m.name?.startsWith(`${model}:`) || model?.startsWith(`${m.name}`));
+    if (!entry) return 'unknown';
+    return entry.processor === 'partial' ? 'partial' : entry.processor;
+  } catch (_) {
+    return 'unknown';
+  }
+};
+
+const classifyError = (err, status) => {
+  if (err?.name === 'AbortError') return 'abort';
+  if (status >= 500) return 'http_5xx';
+  if (status >= 400) return 'http_4xx';
+  if (err?.message?.toLowerCase().includes('network')) return 'network';
+  if (err?.message?.toLowerCase().includes('timeout')) return 'timeout';
+  return 'network';
+};
+
+const inferFlujo = (url, body) => {
+  if (body?.flujo) return body.flujo;
+  if (typeof url !== 'string') return 'other';
+  if (url.includes('/v1/chat/completions')) return 'chat';
+  return 'other';
+};
 
 const SSE_DATA_PREFIX = 'data: ';
 
@@ -67,24 +102,57 @@ const isDoneChunk = (parsed) =>
  * @throws {Error} si fetch falla, no-2xx, o body no streameable.
  */
 export async function streamOpenAI(url, body, onToken, { signal, onDone } = {}) {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'text/event-stream',
-    },
-    body: JSON.stringify({ ...body, stream: true }),
-    signal,
-  });
+  const t0 = Date.now();
+  const modelHint = body?.model || 'unknown';
+  const flujoHint = inferFlujo(url, body);
+  let response;
+
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+      },
+      body: JSON.stringify({ ...body, stream: true }),
+      signal,
+    });
+  } catch (err) {
+    recordLLMEvent({
+      model: modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: err?.name === 'AbortError' ? 'abort' : 'error',
+      total_ms: Date.now() - t0,
+      error_kind: classifyError(err, 0),
+    });
+    throw err;
+  }
 
   if (!response.ok) {
     let detail = '';
     try { detail = await response.text(); } catch (_) { /* noop */ }
     const { buildCleanErrorMessage } = await import('./sanitizeError.js');
     const ctype = response.headers?.get?.('content-type') || '';
+    recordLLMEvent({
+      model: modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: 'error',
+      total_ms: Date.now() - t0,
+      error_kind: classifyError(null, response.status),
+    });
     throw new Error(buildCleanErrorMessage('LLM', response.status, response.statusText, detail, ctype));
   }
   if (!response.body) {
+    recordLLMEvent({
+      model: modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: 'error',
+      total_ms: Date.now() - t0,
+      error_kind: 'parse',
+    });
     throw new Error('Respuesta sin body streameable (¿buffering del proxy?)');
   }
 
@@ -132,6 +200,16 @@ export async function streamOpenAI(url, body, onToken, { signal, onDone } = {}) 
         if (done) break;
       }
     }
+  } catch (err) {
+    recordLLMEvent({
+      model: lastParsed?.model || modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: err?.name === 'AbortError' ? 'abort' : 'error',
+      total_ms: Date.now() - t0,
+      error_kind: classifyError(err, 0),
+    });
+    throw err;
   } finally {
     try { reader.releaseLock(); } catch (_) { /* noop */ }
   }
@@ -139,6 +217,30 @@ export async function streamOpenAI(url, body, onToken, { signal, onDone } = {}) 
   if (onDone && lastParsed) {
     try { onDone(lastParsed); } catch (_) { /* noop */ }
   }
+
+  // Telemetría privacy-safe.
+  const total_ms = Date.now() - t0;
+  const usage = lastParsed?.usage || null;
+  const eval_count = usage?.completion_tokens ?? null;
+  const prompt_eval_count = usage?.prompt_tokens ?? null;
+  // OpenAI-compatible no expone eval_duration. Estimación tokens/s sobre wall-clock.
+  const eval_rate = (eval_count && total_ms)
+    ? Math.round((eval_count / (total_ms / 1000)) * 100) / 100
+    : null;
+  detectProcessorFor(lastParsed?.model || modelHint).then((processor) => {
+    recordLLMEvent({
+      model: lastParsed?.model || modelHint,
+      endpoint: url,
+      flujo: flujoHint,
+      status: 'success',
+      total_ms,
+      load_ms: null,
+      prompt_eval_count,
+      eval_count,
+      eval_rate,
+      processor,
+    });
+  });
 
   return fullText;
 }


### PR DESCRIPTION
## Summary
- Integra estadísticas GPU y LLM en el **Eco-Oracle Dashboard** del operador (ADR-023). Acceso: Perfil → \"Oracle LLM/GPU\".
- **Privacy:** NUNCA persiste prompt ni respuesta — solo metadata (modelo, latencia, tokens, processor gpu/cpu, error_kind). Toggle persistente.
- Aprovecha la GPU Quadro M6000 sm_52 (gemma3:4b 118 t/s GPU vs 13.5 t/s CPU +8.7×) ya activa en alpha.

## Cambios
- **dbCore v12 → v13:** nuevo store \`llm_telemetry\` + 5 indexes. Migración transparente.
- **llmTelemetryService.js:** record/get/aggregate/clear/export + cap 1000 eventos.
- **gpuTelemetryService.js:** snapshot \`/api/ollama/api/ps\` (cache 5s) + lista \`/api/tags\`.
- **ollamaStream.js + openaiStream.js:** instrumentación interna que captura model/lat/tokens/processor + clasifica error/abort/network/4xx/5xx. Falla silente.
- **LLMTelemetryScreen.jsx:** GPU snapshot (modelos cargados + VRAM + badge processor), agregados totales (success rate, GPU%, p95), tabla por modelo, tabla por flujo (chat/extract/vision/summarize/recommend/help), lista 200 eventos recientes, export JSON/CSV, toggle, clear.
- **ProfileScreen.jsx + App.jsx:** wiring de pantalla y botón.

## Test plan
- [x] \`npm run test:unit\` — 155/155 pass
- [x] \`npm run lint\` — clean
- [x] \`npm run build\` — 2.03s OK
- [ ] CI: CodeQL + Playwright E2E
- [ ] Smoke manual: abrir Perfil → Oracle LLM/GPU → hacer una pregunta IA en otra pantalla → volver y ver evento registrado con processor=GPU
- [ ] Verificar que ningún prompt/respuesta queda en \`llm_telemetry\` (dev tools → IndexedDB → ChagraDB)

## Demo readiness 2026-05-19
Track adicional listo para martes: Diana puede ver en tiempo real cuánto está usando GPU vs CPU, latencia por modelo, errores recientes — sin exponer queries de los operadores.

Refs: ADR-023 Eco-Oracle Dashboard, ADR-030 Regla 9 privacy, \`bench-results/2026-05-17-gpu-m6000-sm52-summary.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)