### PR TITLE
fix(agent): system prompt anti-alucinación + temperature 0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.108",
+  "version": "0.12.109",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v150';
+const CACHE_NAME = 'chagra-v151';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -113,7 +113,20 @@ export default function AgentScreen({ onBack }) {
     const indoorContext = indoorZone
       ? `El operador está bajo techo en: ${indoorZone}. Considera condiciones de invernadero al recomendar. `
       : '';
-    return `Eres un asistente agroecológico en Colombia. ${fincaContext}${indoorContext}El usuario tiene estas plantas: ${plantNames}. Responde en español, sé helpful y específico. Si no sabes algo, dilo honestamente.`;
+    // REGLA ANTI-ALUCINACIÓN: "Si no sabes algo, dilo honestamente" (versión
+    // previa) era demasiado débil — el modelo lo ignoraba y rellenaba con
+    // confianza. Incidente 2026-05-17: operador escribió "chorcho" (typo de
+    // chocho/Lupinus mutabilis) y gemma3:4b inventó "sistema de agricultura
+    // de bajo impacto". Probado en bench: 12b inventó OTRA cosa distinta
+    // (Alternaria solani). Subir parámetros no ayuda. Solución: prompt
+    // agresivo con respuesta literal exigida + ejemplo + bajar temperature
+    // a 0.3. Bench 2026-05-17 con esta versión devolvió la respuesta
+    // EXACTA esperada (no reconozco el término) en 27 tokens / 8s.
+    return `Eres un asistente agroecológico en Colombia. ${fincaContext}${indoorContext}El usuario tiene estas plantas: ${plantNames}.
+
+REGLA CRÍTICA ANTI-ALUCINACIÓN: si un término te suena raro, no es estándar agroecológico colombiano, o no estás 100% seguro de lo que significa, responde EXACTAMENTE: "No reconozco ese término. ¿Podrías describirlo o decirme si quisiste referirte a otra palabra similar?" NUNCA inventes definiciones de términos que no reconozcas. Es PREFERIBLE pedir aclaración que dar información incorrecta. Si sospechas que el operador escribió mal una palabra (typo), sugiere la palabra correcta como PREGUNTA, no como afirmación.
+
+Responde en español colombiano (tú/usted, sin voseo argentino). Sé específico y útil cuando tengas certeza; humilde y preguntón cuando no.`;
   }, [plants, fincas, activeFincaSlug, indoorZone]);
 
   // 057.4 integration: los handlers ya NO ejecutan addLog directo. Solo

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -54,13 +54,16 @@ export const ROUTES = {
   chat: {
     model: 'gemma3:4b',
     keep_alive_min: 30,
-    temperature: 0.7,
+    temperature: 0.3,
     max_tokens: 512,
     url: '/api/ollama/v1/chat/completions',
     rationale:
-      'Bench GPU: 118 t/s, 4 GB VRAM, load 3s. CPU baseline 13.5 t/s. ' +
-      'keep_alive=30m viable porque load es barato post-GPU y VRAM 4 GB ' +
-      'cabe holgado con cualquier 7B on-demand. UX fluida en campo.',
+      'Bench GPU 2026-05-17: 118 t/s, 4 GB VRAM, load 3s. keep_alive=30m. ' +
+      'temperature 0.7→0.3 tras incidente alucinación "chorcho" 2026-05-17: ' +
+      'gemma3:12b (probado en PR #809, cerrado) NO resolvió — inventó OTRA ' +
+      'definición con más confianza. La fix real es system prompt agresivo ' +
+      '(ver AgentScreen.getSystemPrompt) + temperature baja. Mantener 4b ' +
+      'por velocidad y VRAM (vision cabe on-demand). Solución modelo-agnóstica.',
   },
   nlu: {
     model: 'qwen2.5-coder:7b',


### PR DESCRIPTION
## Contexto

Operador reportó 2026-05-17: AgentScreen con gemma3:4b inventó una definición agroecológica para \`chorcho\` (término inexistente, probable typo de \`chocho\`/Lupinus mutabilis).

Hipótesis inicial: el modelo 4B es muy chico, subir a 12B reduce alucinación. **Hipótesis incorrecta**.

## Bench 2026-05-17 (Quadro M6000 + ollama-cuda sm_52)

| Modelo | Respuesta a "qué es chorcho?" |
|---|---|
| gemma3:4b | "sistema de agricultura de bajo impacto, rotación..." (fábula 1) |
| gemma3:12b | "hongo *Alternaria solani*, manchas necróticas..." (fábula 2, más confiada) |
| **gemma3:4b + prompt agresivo + temp 0.3** | "No reconozco ese término. ¿Podrías describirlo...?" ✅ |

Subir parámetros del modelo NO resuelve alucinación — sólo cambia la fábula. La solución es prompt + temperature.

## Cambio

1. \`AgentScreen.getSystemPrompt\`: regla literal exigida (responde EXACTAMENTE: "No reconozco ese término..."), ejemplo positivo (typo → sugerir como pregunta), tono explícito.
2. \`llmRouter.js\` ROUTES.chat: temperature 0.7 → 0.3.
3. Mantiene gemma3:4b por velocidad y VRAM (vision cabe on-demand).

## Test plan

- [ ] AgentScreen → "qué es chorcho?" → "No reconozco ese término..."
- [ ] AgentScreen → "qué es tomate?" → respuesta normal con detalle
- [ ] AgentScreen → typo "frrutal" → "¿Quisiste decir frutal?"
- [ ] Bench warm: <10s respuesta a pregunta corta

## Referencias

- PR #809 cerrado: bench demostró que 12b no resuelve
- Incidente: operador con respuesta "chorcho" inventada en chat (sesión 2026-05-17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)