### PR TITLE
fix(ux): MicFab tapa AgentScreen + SyncProgressIndicator detrás del bug-report FAB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.108",
+  "version": "0.12.109",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v150';
+const CACHE_NAME = 'chagra-v151';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -423,7 +423,7 @@ export default function App() {
       </Suspense>
       {/* FAB feedback inline para field testing, siempre visible salvo loading */}
       {currentView !== 'loading' && currentView !== 'login' && <FieldFeedback />}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && <MicFab onNavigate={navigate} />}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <MicFab onNavigate={navigate} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <AgentFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
       {currentView !== 'loading' && currentView !== 'login' && <SyncProgressIndicator />}

--- a/src/components/common/SyncProgressIndicator.jsx
+++ b/src/components/common/SyncProgressIndicator.jsx
@@ -30,7 +30,7 @@ export default function SyncProgressIndicator() {
   if (!shouldShow && !syncProgress) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 animate-slide-up">
+    <div className="fixed bottom-4 right-4 z-[9100] animate-slide-up">
       <div className="bg-slate-800 border border-slate-700 rounded-lg shadow-xl p-4 min-w-[300px]">
         {syncProgress?.isComplete ? (
           <div className="flex items-center gap-3 text-emerald-400">


### PR DESCRIPTION
## Summary

Dos bugs UX reportados en sesión 2026-05-17 (operador en finca):

### Bug 1 — Laptop: MicFab tapa botón mic del AgentScreen
- `App.jsx:426` excluía `MicFab` solo de `loading`/`login`/`voz`. NO de `agente`.
- El FAB verde "Voz" (56px alto, bottom-left, z=9000) se renderizaba sobre AgentScreen → tapaba el botón mic interno del chat IA → operador no podía grabar voz en el chat.
- Fix: alinear con la exclusión que `AgentFab` (línea 427) ya tenía para `agente`.

### Bug 2 — Mobile: SyncProgressIndicator debajo del FieldFeedback FAB
- `SyncProgressIndicator` en `bottom-4 right-4 z-50` (toast "Sincronización completa").
- `FieldFeedback` 💬 en `bottom:18 right:18 z=9000` (botón bug report).
- Ambos en esquina derecha-inferior → el FAB tapaba el botón `X` de cerrar del toast → diálogo inalcanzable hasta que auto-hide (2s idle) bajaba el FAB.
- Fix: subir z-index del indicador a `z-[9100]` (encima del FAB).

## Test plan

- [x] `npm run build` pasa
- [ ] Laptop: abrir AgentScreen → confirmar que el botón "Voz" verde ya NO aparece bottom-left
- [ ] Mobile: disparar sync → toast "Sincronización completa" → tap `X` → debe cerrar (antes el 💬 lo tapaba)
- [ ] Regresión: en otras vistas (dashboard, bitácora, voz) el MicFab y SyncProgressIndicator siguen funcionando

## Notas operativas pendientes (no en este PR)

- Idea operador: extender el MicFab para acciones de campo rápidas (foto, log, observación). Aterrizar después en un DR-UX/QW dedicado. Field test Lili 2026-04-30 ya documenta los flows que ese FAB cubriría (siembra-en-1-tap, cosecha por voz, foto diagnóstico).
- Pendiente sin PR: fix React #185 (`CaseStudyTopWidget` re-suscripción Zustand → `Maximum update depth exceeded`) detectado en working tree, branch `fix/react-185-casestudy-render-loop-v2` obsoleta vs main. Stasheado para no mezclarlo aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)