### PR TITLE
fix(catalog): 5 species batch 23 vp ≥200 chars + Tier A (manual refine)

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -8279,9 +8279,10 @@
       "source_ids": [
         "powo-kew",
         "gbif-taxonomic-backbone",
-        "ica-resolucion-3168-2015"
+        "ica-resolucion-3168-2015",
+        "fao-ecocrop"
       ],
-      "valor_pedagogico": "Variedad de raiz roja clasica: su color intenso indica presencia de antocianinas. Ciclo mas corto del huerto, ideal para ensenar germinacion y cosecha a ninos."
+      "valor_pedagogico": "Variedad de rabano de raiz roja (Raphanus sativus var. sativus, Brassicaceae) con el ciclo mas corto del huerto: 25-35 dias de semilla a cosecha. Su color rojo intenso indica antocianinas y su sabor picante viene de glucosinolatos que ahuyentan insectos del suelo. Ideal para enseñar a niños germinacion, crecimiento y cosecha en menos de un mes escolar, y para siembras escalonadas cada 10-15 dias que dan cosecha continua. Cultivo puente en rotaciones que rompe ciclos de plagas en parcelas hortelanas andinas."
     },
     {
       "id": "beta_vulgaris_altissima",
@@ -8913,10 +8914,12 @@
       "source_ids": [
         "perez-arbelaez-1947-plantas-utiles",
         "humboldt-flora-alto-andina",
-        "gbif-taxonomic-backbone"
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "jbb-plantas-medicinales"
       ],
       "rol_ecologico": "Atractora de polinizadores (mariposas, colibries, abejas). Especie pionera en bordes de bosque. Medicina tradicional cicatrizante. Cerca viva de alta montana.",
-      "valor_pedagogico": "El jardin de mariposas: sus flores aromaticas atraen polinizadores de toda la finca. Ensenia la interaccion planta-polinizador en ecosistemas de alta montana.",
+      "valor_pedagogico": "Arbusto o arbolito nativo de los Andes neotropicales (Buddleja americana, Scrophulariaceae) llamado salvion o matico por el campesinado andino. Sus flores lilas aromaticas en paniculos atraen mariposas, colibries y abejas nativas durante toda la floracion, sosteniendo la polinizacion de la chagra entera. Sus hojas se usan en infusion tradicional como antiinflamatorio y cicatrizante de heridas. Enseña la doble funcion de una cerca viva nativa: refugio de polinizadores y botiquin campesino de alta montaña.",
       "validation_level": "claude_draft"
     },
     {
@@ -9068,9 +9071,11 @@
       "source_ids": [
         "perez-arbelaez-1947-plantas-utiles",
         "bernal-2015-plantas-liquenes-colombia",
-        "gbif-taxonomic-backbone"
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "jbb-plantas-medicinales"
       ],
-      "valor_pedagogico": "Endémica de los Andes colombianos: un tesoro etnobotánico del páramo que enseña la relación entre altitud, compuestos activos y saber tradicional campesino.",
+      "valor_pedagogico": "Valeriana criolla endémica de los Andes colombianos (Valeriana pavonii, Caprifoliaceae) que habita páramos y bosques altoandinos entre 2.800 y 3.500 msnm. Sus raíces contienen valepotriatos sedantes usados en infusión tradicional para calmar nervios y mejorar el sueño, conocimiento conservado por campesinos de Cundinamarca, Boyacá y Santander. Enseña la relación entre altitud, compuestos activos y saber etnobotánico, y por qué conservar el páramo equivale a conservar una farmacopea viva.",
       "validation_level": "claude_draft"
     },
     {


### PR DESCRIPTION
## Refina species del catálogo Chagra v3.1 — batch 23 pre-demo 2026-05-19

### 3 species refinadas en este PR

| Slug | vp chars | sources | Tier A nuevas |
|---|---|---|---|
| `raphanus_sativus_sativus` | 159 → 512 | 3 → 4 | FAO EcoCrop |
| `buddleja_americana` | 158 → 509 | 3 → 5 | POWO Kew + JBB plantas medicinales |
| `valeriana_pavonii` | 156 → 492 | 3 → 5 | POWO Kew + JBB plantas medicinales |

### Desfase del slice

Las otras 2 species del batch original (`eryngium_foetidum`, `aiphanes_aculeata`) **ya habían sido refinadas en batches previos** (#812–#817) con vp 1699–1977 chars y 6 sources cada una — no se tocan para mantener diff mínimo.

### Sources

Todas las refs agregadas ya existían en `sources[]` del catálogo. **No se agregan nuevas entradas a sources[]** ni a `biopreparados[]`. Edits limitadas estrictamente a 3 species dentro de `species[]`.

### Validator

```
node scripts/validate-catalog.mjs --lenient-schema --seed-mode
```

→ `✓ Catálogo válido` (rc=0). AMB-16 warnings 34→31 (-3), una mejora directa por species refinada. AMB-17 Tier A coverage PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)