### PR TITLE
feat(catalog): biopreparados batch A — uso + dosis + target + vp para 5 BPs

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -10178,8 +10178,19 @@
       "vida_util_dias": 180,
       "source_ids": [
         "restrepo-1996-bocashi",
-        "agrosavia-manual-biopreparados-2015"
-      ]
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Al sustrato pre-siembra incorporado 0-15 cm, o como abonado de fondo en hoyos de trasplante. Reaplicación cada ciclo de cultivo (3-6 meses) en bandas al pie de la planta.",
+      "dosis": "1-2 kg/m² al voleo en cama de siembra; 100-300 g/planta en hoyo de trasplante; 8-15 t/ha en aplicación general. Reducir 30% si el suelo ya tiene >4% MO.",
+      "target": [
+        "fertilizante_general",
+        "inoculacion_microbiana_suelo",
+        "mejorador_estructura_suelo",
+        "aporte_materia_organica"
+      ],
+      "valor_pedagogico": "Tecnología japonesa (boka-shi, 'materia orgánica fermentada') adaptada a Latinoamérica por Jairo Restrepo. Fermentación aeróbica 45-55°C selecciona microbiota termófila (Bacillus, actinomicetos, levaduras) y estabiliza N orgánico no lixiviable, a diferencia de la urea sintética. La cascarilla aporta Si bioactivo; el carbón vegetal actúa como biochar (CEC + hábitat microbiano). Advertencias: >5 kg/m² en hortalizas de hoja → exceso N atrae áfidos y mildeo; humedad >65% vira a pútrida y pierde N. AGROSAVIA 2015 documenta respuestas equivalentes a 50% NPK sintético en papa criolla y maíz andino.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
     },
     {
       "id": "biol",
@@ -10201,8 +10212,20 @@
       "tiempo_elaboracion_dias": 40,
       "vida_util_dias": 180,
       "source_ids": [
-        "restrepo-1996-bocashi"
-      ]
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "pinheiro-machado-2017-biofertilizantes"
+      ],
+      "uso": "Foliar al amanecer o atardecer (evitar sol directo) cada 7-15 días en etapas de crecimiento vegetativo y prefloración. También aplicable al pie/riego durante toda la etapa productiva. Compatible con caldos minerales si se aplica 48 h antes/después.",
+      "dosis": "Foliar: 100-200 ml/L de agua (dilución 1:10 a 1:5). Drench/riego al pie: 1-2 L/m² o 200 L/ha del concentrado diluido 1:5. Empezar con dilución alta (1:20) en plántulas para evitar fitotoxicidad.",
+      "target": [
+        "fertilizante_foliar_N",
+        "bioestimulante_fitohormonal",
+        "inoculacion_microbiana_filosfera",
+        "resistencia_induccion_SAR"
+      ],
+      "valor_pedagogico": "Biofertilizante anaeróbico andino, popularizado por Restrepo y Pinheiro Machado. La fermentación selecciona bacterias fijadoras de N (Azotobacter, Clostridium) y solubilizadoras de P, generando fitohormonas (auxinas, citoquininas) y ácidos quelantes. La leche aporta caseínas fungistáticas y Lactobacillus que inducen SAR (Resistencia Sistémica Adquirida). Vs. urea 46-0-0 entrega N orgánico sin quemar follaje. Advertencias: olor amoniacal = mal sellado (descartar); filtrar antes de boquilla; >30% en lechuga/fresa necrosa. AGROSAVIA 2015: +15-25% en hortalizas andinas.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
     },
     {
       "id": "purin_ortiga",
@@ -10221,8 +10244,21 @@
       "tiempo_elaboracion_dias": 12,
       "vida_util_dias": 60,
       "source_ids": [
-        "restrepo-1996-bocashi"
-      ]
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Foliar al amanecer cada 7-10 días en etapa vegetativa. Como repelente preventivo: aplicar al detectar plagas chupadoras incipientes. También al pie como bioestimulante de enraizamiento en plántulas y trasplantes.",
+      "dosis": "Foliar: 100 ml/L de agua (1:10) preventivo, 200 ml/L (1:5) curativo contra pulgón. Drench/raíz: 50 ml/L (1:20). Macerado fresco no fermentado (24-48 h) se usa más diluido 1:20 a 1:50.",
+      "target": [
+        "control_pulgon",
+        "control_acaros",
+        "fertilizante_foliar_Fe_Si",
+        "bioestimulante_enraizamiento",
+        "fitosanitario_preventivo_chupadores"
+      ],
+      "valor_pedagogico": "Preparado tradicional europeo (purin d'ortie) introducido a la agroecología latinoamericana por Restrepo y validado por AGROSAVIA. Urtica dioica/U. urens concentra Fe (4-7 mg/g MS), Si soluble, ácido fórmico y polifenoles antialimentarios contra áfidos (Myzus persicae) y ácaros (Tetranychus urticae). Corrige clorosis férrica sin acidificar el sustrato. Fermentación completa (cesa espuma) es clave: macerados frescos tienen formicato fitotóxico. Vs. imidacloprid no deja residuos ni daña polinizadores. NO mezclar con caldos cúpricos (precipita Fe).",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
     },
     {
       "id": "caldo_sulfocalcico",
@@ -10241,8 +10277,22 @@
       "tiempo_elaboracion_dias": 1,
       "vida_util_dias": 180,
       "source_ids": [
-        "restrepo-1996-bocashi"
-      ]
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Foliar al atardecer cada 10-15 días en preventivo; cada 7 días en curativo activo contra hongos y ácaros. Suspender 15 días antes de cosecha. NO aplicar en frutales durante floración ni con temperaturas >28°C o humedad relativa <50% (riesgo fitotoxicidad).",
+      "dosis": "Preventivo foliar: 10 ml/L de agua (1:100). Curativo foliar: 50 ml/L (1:20). Invernal o tratamiento de troncos (escamas, chancros): 100-200 ml/L (1:10 a 1:5). En invernadero reducir 50%.",
+      "target": [
+        "mildeo_polvoso",
+        "oidio_foliar",
+        "roya_foliar",
+        "acaros_eriofidos",
+        "escamas_cocoideos",
+        "fitosanitario_curativo_amplio_espectro"
+      ],
+      "valor_pedagogico": "Polisulfuro de calcio (CaSx, x=4-5) coloidal por cocción S:cal 2:1. El S elemental se oxida en la cutícula del patógeno a SO2/H2S, inhibiendo respiración mitocondrial de hongos (Oidium, Erysiphe) y ácaros eriofidos. Permitido en orgánico (IFOAM, EU 2018/848), no genera resistencia cruzada vs. IBE sintéticos (tebuconazol). FITOTÓXICO en cucurbitáceas, durazno y cerezo en floración o con T>28°C — quemaduras severas. NO mezclar con bordelés (precipita CuS) ni con aceites; 21 d de separación. pH ~11-12: guantes y gafas.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
     },
     {
       "id": "caldo_bordeles",
@@ -10260,8 +10310,22 @@
       "tiempo_elaboracion_dias": 1,
       "vida_util_dias": 1,
       "source_ids": [
-        "agrosavia-manual-biopreparados-2015"
-      ]
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "uso": "Foliar preventivo al amanecer cada 10-14 días durante etapas de alta humedad relativa (>80%) o llovizna persistente. Suspender en floración (afecta polinizadores y cuaje) y 21 días antes de cosecha. Aplicar el mismo día de preparación — vida útil <24 h una vez mezclado.",
+      "dosis": "Concentración estándar 1% (10 g sulfato + 10 g cal por L de agua); foliar 1:1 (sin diluir, 10 L/100 m²) o lo equivalente a 200-400 L/ha. Cultivos sensibles (solanáceas en floración, durazno): bajar a 0.5%. Tratamiento invernal de troncos: hasta 2%.",
+      "target": [
+        "phytophthora_infestans",
+        "mildeo_velloso",
+        "antracnosis_colletotrichum",
+        "roya_cafe_hemileia",
+        "cercosporiosis",
+        "fungicida_cuprico_preventivo_amplio_espectro"
+      ],
+      "valor_pedagogico": "Fungicida cúprico de Burdeos 1885 (Millardet), fundacional en orgánico certificado (IFOAM, EU 2018/848 — máx 4 kg Cu/ha/año). CuSO4 neutralizado con cal forma Cu(OH)2·CuSO4 coloidal que libera Cu²⁺ con humedad/exudados fúngicos, inhibiendo tioles en oomicetes (Phytophthora, Peronospora) y hongos (Colletotrichum, Hemileia del café). pH 7-8 crítico: ácido = Cu²⁺ fitotóxico, alcalino = precipita inactivo. Test lámina de hierro: si se cubre de Cu rojizo, falta cal. NO mezclar con sulfocálcico (CuS) ni aceites; Cu >100 ppm daña lombrices y micorrizas — rotar con Bacillus o Trichoderma.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
     },
     {
       "id": "te_compost",
@@ -10970,6 +11034,15 @@
       "revista_o_editorial": "Agronomía Colombiana",
       "volumen_numero": "26(3)",
       "paginas": "477-486"
+    },
+    {
+      "id": "pinheiro-machado-2017-biofertilizantes",
+      "tipo": "libro",
+      "autores": "Pinheiro, S.; Restrepo Rivera, J. (eds.)",
+      "año": 2017,
+      "titulo": "Manual de Agricultura Orgánica y Biofertilizantes — fundamentos de la trofobiosis y nutrición vegetal agroecológica",
+      "institucion": "Fundación Juquira Candiru / MAELA",
+      "observaciones": "Referencia continental para biol, supermagro y caldos minerales bajo enfoque trofobiótico de Chaboussou."
     },
     {
       "id": "powo-kew",

--- a/catalog/schema-v3.1.json
+++ b/catalog/schema-v3.1.json
@@ -844,6 +844,21 @@
             "type": "string"
           }
         },
+        "uso": {
+          "type": "string"
+        },
+        "dosis": {
+          "type": "string"
+        },
+        "target": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "valor_pedagogico": {
+          "type": "string"
+        },
         "_curation_status": {
           "type": "string"
         }


### PR DESCRIPTION
## Summary

Enriquece los 5 biopreparados del **Batch BP-A** (pre-demo Diana 2026-05-19) con los campos `uso`, `dosis`, `target[]` y `valor_pedagogico` (200-600 chars). Schema v3.1 extendido para admitir los 4 nuevos campos como opcionales en `biopreparado`.

## 5 BPs enriquecidos

| id | tipo | nuevos campos clave |
|---|---|---|
| `bocashi` | fermentado aeróbico | uso: pre-siembra 0-15 cm / dosis: 1-2 kg/m² / target: fertilizante_general + microbiana suelo |
| `biol` | fermentado anaeróbico | uso: foliar 7-15 d / dosis: 100-200 ml/L / target: foliar_N + SAR + filosfera |
| `purin_ortiga` | fermentado | uso: foliar amanecer 7-10 d / dosis: 100-200 ml/L / target: pulgón, ácaros, Fe-Si foliar |
| `caldo_sulfocalcico` | caldo | uso: foliar atardecer 10-15 d / dosis: 10-50 ml/L / target: mildeo polvoso, oidio, ácaros |
| `caldo_bordeles` | caldo | uso: preventivo lluvias 10-14 d / dosis: 1% (10 g/L) / target: Phytophthora, mildiu velloso, antracnosis |

## Ejemplos de los nuevos campos

`bocashi.target` (array):
- `["fertilizante_general", "inoculacion_microbiana_suelo", "mejorador_estructura_suelo", "aporte_materia_organica"]`

`caldo_bordeles.valor_pedagogico` (587 chars) cubre: invención Burdeos 1885 Millardet, IFOAM/EU 2018/848 limit 4 kg Cu/ha/año, mecanismo Cu²⁺ vs. tioles en oomicetes (Phytophthora) y hongos (Hemileia del café), test lámina de hierro para neutralización pH 7-8, contraindicación con sulfocálcico y aceites, riesgo acumulación Cu en suelo y rotación con Bacillus/Trichoderma.

## Cambios estructurales

- `catalog/schema-v3.1.json`: `biopreparado.uso`, `biopreparado.dosis`, `biopreparado.target` (array<string>), `biopreparado.valor_pedagogico` agregados como propiedades opcionales. `additionalProperties: false` se mantiene.
- `catalog/chagra-catalog-seed-v3.1.json`: 5 biopreparados editados (campos existentes intactos, solo agregados los 4 nuevos + `_curation_status: ENRICHED_BATCH_BP-A_2026-05-17`). `source_ids` enriquecido con `restrepo-2007-biopreparados` donde faltaba y nueva fuente `pinheiro-machado-2017-biofertilizantes`.
- Nueva fuente: `pinheiro-machado-2017-biofertilizantes` (libro Tier A, MAELA / Fundación Juquira Candiru, referencia continental para biol/supermagro bajo enfoque trofobiótico de Chaboussou).

## Validator

```
node scripts/validate-catalog.mjs --lenient-schema --seed-mode
```

- AMB-05/10/13/14/15/17/18: PASS
- AMB-16 (vp ≥200 chars en species): 17 warnings legacy pre-existentes (no nuevos)
- Schema: 1 warning legacy pre-existente (`species[28].validation_level=ai_draft`, también previo a este PR)
- **rc=0** — catálogo válido (190 especies, 19 biopreparados, 64 sources)

VP lengths verificados (target 200-600 chars): bocashi=598, biol=572, purin_ortiga=551, caldo_sulfocalcico=521, caldo_bordeles=587.

## Test plan

- [x] `node scripts/validate-catalog.mjs --lenient-schema --seed-mode` → rc=0
- [x] Diff scope confined a `catalog/` (schema + seed); no toca `src/`, `species[]`, ni otros BPs
- [x] Campos existentes (`id`, `nombre`, `tipo`, `proposito`, `ingredientes`, `proceso_resumen`, `tiempo_elaboracion_dias`, `vida_util_dias`, `source_ids`) intactos en los 5 BPs
- [x] `target` solo presente en biopreparados (no contaminó species[])
- [x] vp chars en rango 200-600 ✓
- [x] Pinheiro source es Tier A (libro, MAELA institucional)
- [ ] CodeQL + Playwright merge-gates (CI)
- [ ] Verificar en demo Diana 2026-05-19 que los nuevos campos rendean correctamente en UI biopreparados