### PR TITLE
fix(photo): quitar capture="environment" para permitir galería + cámara + archivos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.111",
+  "version": "0.12.112",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v153';
+const CACHE_NAME = 'chagra-v154';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/BitacoraEntryDetail.jsx
+++ b/src/components/BitacoraEntryDetail.jsx
@@ -353,7 +353,7 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
                 ref={fileInputRef}
                 type="file"
                 accept="image/*"
-                capture="environment"
+               
                 onChange={handlePhotoCapture}
                 disabled={photoState === 'uploading'}
                 className="hidden"

--- a/src/components/EvidenceCapture.jsx
+++ b/src/components/EvidenceCapture.jsx
@@ -321,7 +321,7 @@ export const EvidenceCapture = ({
         ref={inputRef}
         type="file"
         accept="image/*"
-        capture="environment"
+       
         className="hidden"
         onChange={handleCapture}
       />

--- a/src/components/MaintenanceScreen.jsx
+++ b/src/components/MaintenanceScreen.jsx
@@ -123,7 +123,7 @@ function MaintenanceScreen({ onBack, onSave }) {
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto</span>
-          <input type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          <input type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
           <button onClick={() => document.querySelector('input[type="file"]').click()} className="p-5 rounded-xl text-2xl font-bold flex justify-center items-center gap-3 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700">
             <Camera size={32} />
             <span>{photo ? photo.name.substring(0, 15) + '...' : 'Capturar Foto'}</span>

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -131,7 +131,7 @@ function ObservationScreen({ onBack, onSave }) {
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto</span>
-          <input type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          <input type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
           <button onClick={() => document.querySelector('input[type="file"]').click()} className="p-5 rounded-xl text-2xl font-bold flex justify-center items-center gap-3 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700">
             <Camera size={32} />
             <span>{photo ? photo.name.substring(0, 15) + '...' : 'Capturar Foto'}</span>

--- a/src/components/PhotoCaptureField.jsx
+++ b/src/components/PhotoCaptureField.jsx
@@ -85,7 +85,6 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
             <input
                 type="file"
                 accept="image/*"
-                capture="environment"
                 onChange={handleFileChange}
                 ref={fileInputRef}
                 className="hidden"

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -215,7 +215,7 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
               <Camera size={48} />
               <span className="text-xl font-bold">{photo ? '📸 Cambiar foto' : '📸 Foto de la planta'}</span>
             </div>
-            <input type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+            <input type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
           </label>
         </div>
 

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -355,7 +355,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill }) => {
               ref={aiInputRef}
               type="file"
               accept="image/*"
-              capture="environment"
+             
               onChange={handleAiCapture}
               className="hidden"
             />

--- a/src/services/photoService.js
+++ b/src/services/photoService.js
@@ -36,7 +36,7 @@ const CATALOG_PHOTOS_BASE = '/catalog-photos';
  * Captura desde input file (cámara o galería). Convierte HEIC→JPEG via canvas,
  * redimensiona, comprime, y retorna un Blob JPEG.
  *
- * @param {File} file - input file (de <input type="file" capture="environment">)
+ * @param {File} file - input file de <input type="file" accept="image/*"> (cámara o galería)
  * @returns {Promise<{blob: Blob, width: number, height: number, originalSize: number, compressedSize: number, mime: string}>}
  */
 export async function captureAndCompress(file) {


### PR DESCRIPTION
## Summary

Operator feedback campo 2026-05-18: al agregar foto solo se abría cámara nativa, no se podía elegir imagen de galería (necesario para testear el módulo de fotos con imágenes preexistentes).

## Causa

7 componentes tenían `<input type="file" accept="image/*" capture="environment">`. El atributo HTML5 `capture="environment"` (cámara trasera) hace que el navegador abra **directamente la cámara nativa sin mostrar picker**. Eso bypasea la opción de elegir entre cámara, galería o archivos.

## Fix

Quitar `capture="environment"` en los 7 inputs. Queda `accept="image/*"` que deja al navegador mostrar picker estándar:
- iOS Safari: prompt "Tomar foto / Elegir foto / Examinar"
- Android Chrome: prompt "Cámara / Archivos / Fotos"
- Desktop: file picker normal

## Archivos tocados

| Archivo | Línea | Componente |
|---|---|---|
| `src/components/PhotoCaptureField.jsx` | 88 | FAB reusable de captura |
| `src/components/SpeciesSelect.jsx` | 358 | Reconocimiento especie por foto |
| `src/components/BitacoraEntryDetail.jsx` | 356 | Análisis diagnóstico foliar |
| `src/components/EvidenceCapture.jsx` | 324 | Evidencia worker |
| `src/components/ObservationScreen.jsx` | 134 | Observación con foto |
| `src/components/MaintenanceScreen.jsx` | 126 | Mantenimiento con foto |
| `src/components/SeedingLog.jsx` | 218 | Log siembra con foto |
| `src/services/photoService.js` | 39 | JSDoc actualizado (comentario) |

## Trade-off

- **Antes:** 1-tap → cámara abre. NO galería.
- **Ahora:** 1-tap → picker. 2-taps → cámara abierta, O elegir desde galería.

Operador valora flexibilidad para testear con imágenes existentes > el tap extra para foto fresca.

## Test plan

- [x] `npm run build` pasa
- [ ] iOS: tap "Agregar foto" → prompt nativo con opciones "Tomar foto" + "Elegir foto"
- [ ] Android: tap "Agregar foto" → picker con Cámara + Archivos + Fotos
- [ ] Desktop: file picker normal
- [ ] Flujos afectados: SpeciesSelect (reconocimiento), BitacoraEntryDetail (diagnóstico), EvidenceCapture (worker), ObservationScreen, MaintenanceScreen, SeedingLog

## Mejora opcional (no este PR)

Si querés UX más rica, podemos agregar DOS botones paralelos:
- Botón "Cámara" con `capture="environment"` (1-tap a cámara)
- Botón "Galería" sin capture (picker)

Tradeoff: más botones / más código vs UX más fluida. Decidir si querés en PR seguimiento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)