### PR TITLE
fix(home): React #185 Maximum update depth en CaseStudyTopWidget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.111",
+  "version": "0.12.112",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v153';
+const CACHE_NAME = 'chagra-v154';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CaseStudyTopWidget.jsx
+++ b/src/components/CaseStudyTopWidget.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { AlertTriangle, AlertCircle, Activity, ChevronRight, FileText } from 'lucide-react';
 import { useCaseStudyStore } from '../store/useCaseStudyStore';
 
@@ -45,7 +45,33 @@ const formatPct = (a, t) => {
 };
 
 export default function CaseStudyTopWidget({ onNavigate, maxItems = 3 }) {
-  const topActive = useCaseStudyStore((s) => s.getTopActiveProblems(10));
+  // Suscribirse solo a `cases` (estable por referencia entre actions del store) y
+  // derivar el ranking con useMemo. Llamar `getTopActiveProblems(10)` dentro del
+  // selector retornaba un nuevo array + nuevos objetos `{...c, _score}` en cada
+  // render → Zustand re-suscripción infinita → React #185 (Maximum update depth).
+  const cases = useCaseStudyStore((s) => s.cases);
+  // `now` capturado una sola vez al mount (no afecta resultado: el sort solo
+  // necesita orden relativo de edad entre casos, no tiempo absoluto).
+  // eslint-disable-next-line react-hooks/purity
+  const mountedAt = useMemo(() => Date.now(), []);
+  const topActive = useMemo(() => {
+    if (!Array.isArray(cases) || cases.length === 0) return [];
+    const severityWeight = { critical: 4, high: 3, medium: 2, low: 1 };
+    return [...cases]
+      .filter((c) => !['closed_resolved', 'closed_failed'].includes(c.state))
+      .map((c) => {
+        const ageMs = mountedAt - new Date(c.problem.detected_at || c.created_at).getTime();
+        const ageDays = Math.max(1, ageMs / 86400000);
+        const sevW = severityWeight[c.problem.severity] || 1;
+        const affPct = c.subject.count_total
+          ? (c.subject.count_affected || 0) / c.subject.count_total
+          : 0;
+        const score = sevW * (1 + affPct) * Math.log10(1 + ageDays);
+        return { ...c, _score: score };
+      })
+      .sort((a, b) => b._score - a._score)
+      .slice(0, 10);
+  }, [cases, mountedAt]);
   const totalActive = topActive.length;
   if (totalActive === 0) return null;
 


### PR DESCRIPTION
## Bug

Operator reported 2026-05-18: en lugar de inferencia IA en home aparece:

```
Minified React error #185; visit https://react.dev/errors/185
```

React #185 = Maximum update depth exceeded.

## Causa

`useCaseStudyStore((s) => s.getTopActiveProblems(10))` llamaba la action en cada render → retorna nuevo array + nuevos objetos `{...c, _score}` → Zustand detecta referencia distinta → re-render → loop infinito.

## Fix

- Subscribir solo a `cases` (estable entre actions del store)
- useMemo para derivar ranking
- mountedAt capturado al mount (sort solo necesita orden relativo de edad, no tiempo absoluto — eslint react-hooks/purity disable justificado)

## Test plan

- [x] npm run build pasa
- [x] eslint clean
- [ ] Operator abre home → ve widget Top problemas (si hay casos) sin overlay error

🤖 Generated with Claude Code