### PR TITLE
fix(catalog): 6 species batch 28 vp ≥200 chars manual reapply (cierre Sprint 1)

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -8562,7 +8562,7 @@
         "bernal-2015-plantas-liquenes-colombia",
         "powo-kew"
       ],
-      "valor_pedagogico": "Palma frutal de la region Pacifica colombiana; sus frutos son aprovechados por comunidades locales. Su presencia en el catalogo resalta la importancia de documentar especies con vacios taxonomicos."
+      "valor_pedagogico": "El asaí o naidí del Pacífico colombiano (Euterpe oleracea/enbacca según taxonomía en revisión, Arecaceae) es una palma multicaule (8-15 m altura, troncos delgados 7-12 cm diámetro) nativa de bosques húmedos del litoral Pacífico colombiano (Chocó, Valle del Cauca, Cauca, Nariño), Amazonía occidental y áreas inundables del Caribe sur. Lección viva de la importancia de documentar especies con vacíos taxonómicos: hasta hace décadas el naidí del Pacífico se confundía con el asaí brasileño en literatura científica, invisibilizando el aprovechamiento ancestral por comunidades afrocolombianas e indígenas Embera, Wounaan y Awá. Sus frutos pequeños (1-2 cm) violeta-negros producen pulpa rica en antocianinas, grasas saludables omega-9, fibra y minerales, base del jugo de naidí tradicional del Pacífico. La palma aporta palmito (cogollo central comestible) y madera para construcción artesanal. Manejo agroecológico: requiere suelos húmedos permanentemente saturados o cerca de cauces, sombra parcial primer año, propagación por semilla fresca (germinación 2-3 semanas, pierde viabilidad si se seca). Cosecha sostenible: cortar solo frutos maduros 4-6 racimos por palma, dejar al menos 2 racimos para regeneración natural."
     },
     {
       "id": "dioscorea_alata",
@@ -9008,7 +9008,7 @@
         "gbif-taxonomic-backbone",
         "ica-resolucion-3168-2015"
       ],
-      "valor_pedagogico": "Leccion de mejoramiento genetico: la betarraga azucarera fue seleccionada durante siglos para concentrar sacarosa, demostrando el poder de la seleccion artificial en la agricultura."
+      "valor_pedagogico": "La acelga forrajera o betarraga azucarera (Beta vulgaris L. ssp. vulgaris var. altissima, Amaranthaceae) es una variedad seleccionada del mismo complejo botánico de la acelga de hoja y la remolacha de mesa, cultivada en zonas templadas-frías colombianas (1800-3000 msnm: Sabana de Bogotá, Boyacá altiplano, Nariño) como forraje para vacas lecheras y conejos. Lección viva de mejoramiento genético histórico: las primeras betarragas eran raíces fibrosas similares a zanahorias delgadas; agricultores europeos del siglo XVIII y XIX seleccionaron año tras año plantas con raíces más gruesas y dulces hasta lograr la remolacha azucarera moderna (15-20% sacarosa) y la forrajera (más biomasa foliar y radical, menor azúcar pero más volumen). Aporta forraje fresco rico en proteína cruda (10-14% en hojas), calcio, potasio y betacarotenos. Manejo agroecológico: siembra directa a chorro continuo en surcos a 50 cm, ralear a 30 cm entre plantas, suelo profundo bien drenado pH 6.5-7.5, encalado SOLO si pH<5.5 con análisis previo, fertilización con compost maduro y bocashi, cosecha escalonada de hojas externas dejando el corazón crecer. Asocio: trébol blanco, alfalfa, raygrass."
     },
     {
       "id": "pastinaca_sativa",
@@ -9181,7 +9181,7 @@
         "gbif-taxonomic-backbone",
         "sib-colombia"
       ],
-      "valor_pedagogico": "Cucurbitacea nativa de los Andes subestimada. Ensenia el valor de las especies tradicionales subutilizadas en la seguridad alimentaria y la importancia de conservar germoplasma andino."
+      "valor_pedagogico": "La cidrayota, achocha, caigua o pepino de carcel (Cyclanthera pedata, Cucurbitaceae) es una trepadora cucurbitácea nativa de los Andes (Perú, Bolivia, Ecuador, Colombia), cultivada en huertas familiares entre 500 y 2600 msnm con clima templado-frío fresco (Antioquia, Cundinamarca, Boyacá, Nariño, Cauca, Putumayo). Lección viva de especies tradicionales subutilizadas (NUS — Neglected and Underutilized Species), enseña la importancia de conservar germoplasma andino frente al monocultivo de pepino europeo y la pérdida de soberanía alimentaria. Su fruto verde claro ovoide-curvo con espinas blandas y semillas oscuras planas en cámara hueca interna se consume crudo en ensaladas (sabor fresco, menos amargo que pepino) o cocido relleno como ají de gallina peruano. Aporta fibra, minerales y propiedades hipoglucemiantes (cucurbitacinas). Manejo agroecológico: siembra directa o trasplante post-heladas, requiere tutor porque crece 3-5 m por temporada, suelo rico en materia orgánica bien drenado, riego moderado, asocio clásico con maíz (sistema milpa andina) usando el tallo como tutor vivo. Cosecha continua 90-110 días. Una planta produce 30-60 frutos por ciclo."
     },
     {
       "id": "gliricidia_sepium",
@@ -9723,7 +9723,7 @@
         "gbif-taxonomic-backbone",
         "bernal-2015-plantas-liquenes-colombia"
       ],
-      "valor_pedagogico": "Planta maestra de la medicina popular andina: sus hojas azulverdosas y su olor intenso enseñan el poder de los aceites esenciales como repelentes naturales de insectos en la chagra.",
+      "valor_pedagogico": "La ruda (Ruta graveolens L., Rutaceae) es planta maestra de la medicina popular andina, en huertas tradicionales colombianas desde zonas cálidas hasta altiplano frío (500-2800 msnm). Sus hojas azul-verdosas y olor intenso enseñan el poder de los aceites esenciales como repelentes naturales: contiene rutina (flavonoide), undecanona, nonanona y furanocumarinas (psoralenos como bergapteno) que repelen pulgones, moscas blancas, mosca de fruta y hormigas cortadoras cuando se planta como barrera viva o se aplica en infusión foliar al 5%. ⚠️ ADVERTENCIA DE SEGURIDAD CRÍTICA: La ruda es ABORTIFACIENTE, contiene compuestos uteroactivos que pueden causar aborto espontáneo. PROHIBIDA en mujeres embarazadas o que sospechen embarazo. Las furanocumarinas también producen FOTOTOXICIDAD: el contacto directo con la savia bajo sol genera quemaduras dermatológicas (fitofotodermatitis). Manipular con guantes y en sombra. Uso interno tradicional para regular ciclos menstruales y dolores reumáticos, pero la dosis terapéutica está muy cerca de la tóxica. Manejo agroecológico: propagación por esquejes leñosos, suelo bien drenado, pleno sol, planta perenne 60-100 cm. Asocio repelente con tomate, lechuga, rosales. NUNCA cerca de albahaca.",
       "validation_level": "claude_draft"
     },
     {
@@ -10075,7 +10075,7 @@
         "gbif-taxonomic-backbone",
         "powo-kew"
       ],
-      "valor_pedagogico": "Cubresuelos aromático que protege el suelo vivo: sus tallos rastreros enseñan cobertura vegetal permanente y su aceite esencial (timol) demuestra repelencia natural de plagas en la base de la chagra.",
+      "valor_pedagogico": "El tomillo silvestre o serpol (Thymus serpyllum L., Lamiaceae) es una aromática mediterránea perenne rastrera (5-15 cm altura, tallos extendidos 30-60 cm) distinta del tomillo común Thymus vulgaris (porte erecto). Adaptada a zonas templadas-frías colombianas (1500-2800 msnm: Cundinamarca, Boyacá, Nariño, Antioquia frío). Lección viva de cobertura vegetal permanente que enseña cómo proteger el suelo vivo: sus tallos rastreros forman alfombras densas que reducen evaporación de humedad superficial 30-50%, suprimen malezas competitivas por sombra y alelopatía suave, refugian arañas predadoras (Lycosidae) y carábidos que controlan biológicamente larvas de lepidópteros. Su aceite esencial concentra timol (35-50%) y carvacrol (10-15%), terpenos volátiles con actividad antifúngica y antibacterial demostrada contra Botrytis cinerea, Fusarium oxysporum y Erwinia amylovora. Floración rosa-púrpura atrae abejas, abejorros nativos (Bombus atratus) y mariposas. Manejo agroecológico: propagación por división de mata o esquejes, suelo pobre bien drenado pleno sol (NO tolera encharcamiento ni sombra densa), riego moderado, poda anual post-floración. Asocio: lechuga, fresa, repollo, rosas.",
       "validation_level": "claude_draft"
     },
     {
@@ -10717,7 +10717,7 @@
         "gbif-taxonomic-backbone",
         "powo-kew"
       ],
-      "valor_pedagogico": "Árbol/arbusto nativo andino utilizado tradicionalmente para cercas vivas y como sustituta nativa frente al retamo espinoso (Ulex europaeus) invasor. Floración blanca atractiva para polinizadores."
+      "valor_pedagogico": "El sauco peruano o tilo andino (Sambucus peruviana Kunth, Adoxaceae) es un árbol/arbusto nativo andino (3-8 m) endémico del norte de Sudamérica (Colombia, Ecuador, Perú, Bolivia) entre 1800 y 3400 msnm, distinto del Sambucus nigra europeo. Crece en bosque alto andino y subpáramo, frecuente en cercas vivas tradicionales del altiplano cundiboyacense y Nariño. Lección viva de sustitución nativa frente al retamo espinoso invasor (Ulex europaeus): cumple las MISMAS funciones de cerca viva (espinosidad moderada, denso, perenne) sin los problemas de banco de semillas longevo, alelopatía severa ni alteración del régimen de fuego. Floración blanca en panículas atrae abejas nativas (Bombus atratus, abejas sin aguijón Meliponini), polinizadores cruciales para tomate, papa criolla, mora y curuba. Frutos pequeños negro-purpúreos comestibles cocidos (NO crudos, contienen glicósidos cianogénicos que se neutralizan con cocción) usados en jaleas y vinos artesanales. Hojas medicinales en infusión para diaforesis en resfriados (uso en farmacopea Muisca y Chibcha). Manejo agroecológico: propagación por estaca de 30-40 cm directa al sitio, primer año riego, después tolera sequía moderada. Excelente para programas de restauración Cruz Verde-Sumapaz."
     },
     {
       "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",


### PR DESCRIPTION
Rescate de las 6 species que el agent batch 28 dejó sin commit por sandbox issue. Aplicado manual sobre rama efímera. Cierra Sprint 1: 190/190 species con vp ≥200.