### PR TITLE
feat(catalog): +10 species epifitas + orquideas + pteridofitas Andes (Sprint 5 Batch 41 retry)

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -15610,6 +15610,1199 @@
         "gbif-taxonomic-backbone",
         "jbb-plantas-medicinales"
       ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "cattleya_trianae",
+      "nombre_comun": "Flor de Mayo",
+      "nombre_comunes_regionales": [
+        "cattleya de Triana",
+        "orquídea de mayo",
+        "lirio de mayo",
+        "flor nacional de Colombia"
+      ],
+      "nombre_cientifico": "Cattleya trianae Linden & Rchb.f.",
+      "familia_botanica": "Orchidaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1200,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 15,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "habito": "orquídea epífita simpodial con pseudobulbos cilíndricos de 15-30 cm, hoja única coriácea, flor solitaria o doble grande (15-20 cm) blanco-lila con labelo amarillo-magenta",
+      "propagation": {
+        "methods": [
+          "division_mata",
+          "pseudobulbo",
+          "micropropagacion"
+        ],
+        "best_method": "division_mata",
+        "protocol_resumen": "División de mata con mínimo 3-4 pseudobulbos por sección, herida desinfectada con canela molida o fungicida orgánico. Sustrato corteza de pino + carbón + musgo en proporción 3:1:1, riego cada 5-7 días dejando secar entre riegos. Crecimiento lento: 3-5 años a primera floración desde keiki. Micropropagación in vitro vía siembra asimbiótica en medio Knudson C es la vía industrial. PROHIBIDA EXTRACCIÓN SILVESTRE — CITES Apéndice II + Res. MADS 0192/2014 vedan tránsito sin permiso AGRO-CITES.",
+        "tiempo_a_establecimiento_dias": 365,
+        "notas": "Floración Marzo-Mayo (de ahí \"flor de mayo\"). Polinizada por abejas Euglossini machos atraídas por fragancia floral. PROPAGACIÓN ÉTICA: solo de plantas con CITES de origen (vivero registrado ICA) o esquejes de cultivo familiar legal — extracción silvestre es delito ambiental (Ley 1333/2009) y acelera extinción.",
+        "fuente": "Ortiz-Valdivieso 1991 Native Colombian Orchids; Bernal 2015; JBB Plantas Medicinales; CITES Appendix II"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Ideal apartamento con buena luz indirecta (ventana este u oeste filtrada). Espacio mínimo, sin riesgo de heladas urbanas.",
+          "tips": [
+            "Maceta de barro con orificios laterales o canastilla, jamás plástico cerrado",
+            "Riego cada 5-7 días por inmersión 10 min, NO regar el cogollo",
+            "Humedad 60-80% mediante humidificador o bandeja con piedras+agua",
+            "Fertilización balanceada 20-20-20 cuarteada cada 15 días en crecimiento activo",
+            "NUNCA comprar especímenes silvestres — solo viveros con CITES"
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Cultivo en patio con sombra parcial (50% sombra) bajo árbol o malla polisombra. Especie patrimonial colombiana.",
+          "tips": [
+            "Montar en tronco de árbol vivo (mango, aguacate) o tutor de helecho arborescente",
+            "Sustrato corteza de pino + carbón + musgo",
+            "Floración anual Mar-May con fragancia dulce",
+            "Multiplicación ética por división familiar — compartir, no vender silvestres"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Excelente bajo invernadero con sombra 50-70% y control de humedad. Ruta principal de conservación ex-situ y reproducción comercial legal.",
+          "tips": [
+            "Tablones colgantes con sustrato drenante",
+            "Polinización manual entre genotipos para diversidad genética",
+            "Vivero ICA-registrado puede emitir CITES doméstico para venta legal",
+            "Programa de repatriación a habitat origen con MADS + IAvH"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial bajo invernadero solo con licencia ICA + CITES. Mercado de flor cortada premium y planta ornamental.",
+          "tips": [
+            "Inversión inicial alta (banco genético, vivero, certificación)",
+            "Mercado europeo y asiático paga premium por orquídea colombiana legal",
+            "Promover sello \"Cattleya trianae cultivada con CITES\" para diferenciar de tráfico ilegal"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Reintroducción en bosques nublados andinos en programas de conservación ex-situ → in-situ con permiso MADS-IAvH. Crítica para recuperación de poblaciones silvestres extintas.",
+          "tips": [
+            "Solo en sitios con cobertura forestal nativa preservada",
+            "Acompañamiento de IAvH o JBB para genética poblacional",
+            "Documentar GPS y monitorear sobrevivencia ≥3 años post-reintroducción"
+          ]
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "flor",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Orquídea epífita emblemática del bosque húmedo premontano y nublado andino colombiano. Flor nacional de Colombia (declarada por Acuerdo Botánico de 1936 ratificado por Decreto Ley 1936). Especie en peligro (EN) por destrucción de hábitat y extracción ilegal histórica para tráfico ornamental. Polinizada por abejas Euglossini machos atraídas por fragancia compuesta de geraniol-linalool. Indicadora de bosque andino bien conservado. Protección CITES Apéndice II + Res. MADS 0192/2014.",
+      "valor_pedagogico": "La flor de mayo o cattleya de Triana (Cattleya trianae Linden & Rchb.f., Orchidaceae) es la flor nacional de Colombia y una de las orquídeas más icónicas y patrimoniales del país. Especie epífita endémica del bosque húmedo premontano y nublado de la Cordillera Oriental y Central de los Andes colombianos entre 800 y 2.200 msnm, principalmente en los departamentos de Cundinamarca, Tolima, Huila, Quindío, Risaralda, Antioquia, Santander y Caldas, en bosque andino y subandino. Fue descrita en 1860 por Linden y Reichenbach hijo, nombrada en honor al naturalista colombiano José Jerónimo Triana. Su elección como flor nacional en 1936 reconoce los colores de la bandera colombiana presentes en la flor: blanco del perianto, amarillo del callo del labelo y rojo-magenta del labelo. Es planta epífita simpodial con pseudobulbos cilíndricos engrosados de 15-30 cm que almacenan agua y nutrientes (adaptación a la estacionalidad de los bosques nublados), hoja única terminal coriácea de 20-30 cm, e inflorescencia con 1-2 flores grandes (15-20 cm de diámetro) altamente fragantes con perianto blanco-rosado lila y labelo amarillo-magenta característico. Floración entre marzo y mayo (de ahí el nombre \"flor de mayo\"), coincidiendo con la subida de temperatura del trópico andino. Polinización exclusiva por abejas Euglossini machos (familia Apidae) atraídas por los compuestos terpénicos volátiles de su fragancia (geraniol, linalool, eugenol) que las abejas recolectan para fines reproductivos. Conservación: catalogada en peligro (EN) por la UICN y libro rojo de plantas de Colombia, sus poblaciones silvestres se redujeron drásticamente durante los siglos XIX-XX por extracción masiva ilegal para el mercado europeo y norteamericano de orquídeas exóticas, y por destrucción del bosque nublado andino. Está protegida por la Convención CITES (Apéndice II — toda Orchidaceae está en CITES II), la Resolución MADS 0192/2014 y la Ley 1333/2009 de Procedimiento Sancionatorio Ambiental: la extracción de especímenes silvestres sin permiso es delito ambiental. Reproducción ética y conservación: la única forma legal y ética de tener cattleyas trianae es adquirirlas de viveros registrados ante ICA que tienen permiso CITES para producción comercial mediante micropropagación in vitro (siembra asimbiótica en medio Knudson C, desarrollo en frasco 18-24 meses, aclimatación en invernadero 6-12 meses, planta floración a 4-6 años). También es legal la multiplicación familiar por división de mata de ejemplares de cultivo previo. Cultivo doméstico: ideal en apartamento o patio sombreado con maceta de barro perforada o canastilla colgante, sustrato corteza de pino + carbón vegetal + musgo Sphagnum en proporción 3:1:1, riego por inmersión cada 5-7 días dejando secar entre riegos (las raíces aéreas son sensibles al pudrimiento), humedad relativa 60-80%, sombra 50-70%, fertilización balanceada cuarteada cada 15 días en fase de crecimiento activo. Floración anual. Programas de conservación: JBB, IAvH, MADS y la Sociedad Colombiana de Orquideología desarrollan programas de reintroducción ex-situ → in-situ en bosques nublados restaurados con permiso ambiental, devolviendo genotipos al hábitat original. Es lección patrimonial extraordinaria: símbolo nacional cuya preservación depende de tres acciones combinadas (conservación de bosque andino nublado, propagación ética legal vía vivero CITES, y rechazo absoluto al tráfico ilegal de plantas silvestres), un ejemplo viviente de cómo Colombia puede honrar su biodiversidad emblemática mediante ciencia, ley y cuidado comunitario en lugar de saqueo. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia, JBB Plantas Medicinales, libro rojo plantas Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "jbb-plantas-medicinales",
+        "libro-rojo-plantas-colombia"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "odontoglossum_crispum",
+      "nombre_comun": "Lirio de los Andes",
+      "nombre_comunes_regionales": [
+        "odontoglossum crespo",
+        "orquídea de Pacho",
+        "lirio andino",
+        "flor de los nevados"
+      ],
+      "nombre_cientifico": "Oncidium alexandrae (Bateman) M.W.Chase & N.H.Williams (syn. Odontoglossum crispum Lindl.)",
+      "familia_botanica": "Orchidaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2400,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "habito": "orquídea epífita simpodial con pseudobulbos ovoides comprimidos, hojas largas lanceoladas, inflorescencia péndula con 10-30 flores blancas con manchas rojo-magenta y labelo crespo",
+      "propagation": {
+        "methods": [
+          "division_mata",
+          "pseudobulbo",
+          "micropropagacion"
+        ],
+        "best_method": "micropropagacion",
+        "protocol_resumen": "Especie exigente en cultivo. División de mata cada 3-4 años con mínimo 3 pseudobulbos. Sustrato corteza fina + musgo Sphagnum + perlita en clima frío sombreado y húmedo. NO tolera temperaturas >26°C sostenidas (muere por estrés térmico). Micropropagación in vitro es la única vía industrial sostenible. PROHIBIDA EXTRACCIÓN SILVESTRE — CITES II + Res. MADS.",
+        "tiempo_a_establecimiento_dias": 540,
+        "notas": "Especie histórica del comercio orquideófilo europeo siglo XIX (la \"fiebre de la orquídea\" diezmó poblaciones de Pacho, Cundinamarca). Sub-páramo y bosque alto-andino son hábitat preciso — fuera de eso muere.",
+        "fuente": "Ortiz-Valdivieso 1991; Bernal 2015; POWO; IAvH bosque alto-andino; CITES II"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Inviable apartamento promedio: requiere temperaturas <22°C sostenidas y humedad >70%, incompatibles con clima urbano cálido andino."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Solo viable en zonas frías altas (Bogotá Cota Norte, Mosquera, Chía, Tabio, La Calera, Sopó, sabanas frías 2400-2800 msnm) con sombra y humedad alta.",
+          "tips": [
+            "Montaje colgante en patio sombreado, fuera de sol directo",
+            "Riego abundante semanal en seca, reducir en lluvia",
+            "NO tolera >26°C — proteger de olas de calor",
+            "Floración Sep-Ene espectacular blanco-magenta"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Excelente bajo invernadero refrigerado o cool-house de alta altitud (>2400 msnm) con humedad 70-85%. Vía principal de conservación ex-situ.",
+          "tips": [
+            "Cool-house con sombra 60% + nebulización automática",
+            "Vivero ICA + CITES doméstico para producción legal",
+            "Aclimatación gradual desde in vitro: 6 meses"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial restringida a viveros con licencia ICA + CITES en altitudes frías. Mercado europeo nostálgico paga premium.",
+          "tips": [
+            "Inversión alta en infraestructura cool-house",
+            "Marketing: \"Odontoglossum colombiano cultivado legal\"",
+            "Trazabilidad CITES por planta"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Reintroducción en bosques alto-andinos restaurados de Cundinamarca-Boyacá con permiso MADS-IAvH. Especie casi extinta in-situ.",
+          "tips": [
+            "Acompañamiento técnico IAvH/JBB",
+            "Solo sitios con cobertura forestal nativa subpáramo",
+            "Monitoreo genético poblacional ≥5 años"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "flor",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Orquídea epífita del bosque alto-andino y subpáramo de la Cordillera Oriental colombiana (Pacho, La Calera, sabana frías Cundinamarca-Boyacá) entre 2.000 y 3.200 msnm. Especie en peligro (EN) por destrucción de bosque alto-andino y extracción histórica masiva durante la \"fiebre orquideófila\" europea del siglo XIX. Indicadora de bosque alto-andino bien preservado y humedad estable. Polinizada por avispas y abejas pequeñas. Protección CITES II.",
+      "valor_pedagogico": "El lirio de los Andes u odontoglossum crespo (Oncidium alexandrae, sinónimo histórico Odontoglossum crispum Lindl., Orchidaceae) es una de las orquídeas epífitas más emblemáticas del bosque alto-andino colombiano y protagonista trágica de la historia del comercio orquideófilo mundial. Especie endémica de la Cordillera Oriental colombiana, principalmente del municipio de Pacho y áreas circundantes de Cundinamarca-Boyacá, en bosque alto-andino y subpáramo entre 2.000 y 3.200 msnm en zona térmica fría con humedad relativa >70% y temperaturas medias 10-20°C. Fue descrita en 1845 por Lindley a partir de material colectado por exploradores europeos en los Andes colombianos. Durante la segunda mitad del siglo XIX se desató en Europa la \"fiebre del Odontoglossum crispum\" (orchid mania): coleccionistas británicos, belgas y alemanes pagaban precios astronómicos en subastas londinenses por plantas colombianas, y se enviaron expediciones que extrajeron decenas de miles de ejemplares silvestres del bosque alto-andino de Pacho, Cundinamarca, casi exterminando las poblaciones naturales. Una sola subasta documentada en Londres en 1890 vendió 30.000 plantas extraídas de Colombia. Es planta epífita simpodial con pseudobulbos ovoides comprimidos lateralmente de 6-10 cm, dos hojas lanceoladas terminales de 30-40 cm, e inflorescencia péndula arqueada de 60-100 cm con 10-30 flores grandes blancas o blanco-rosadas con manchas rojo-magenta-marrón y labelo profundamente crespo (de ahí \"crispum\"). Floración Septiembre-Enero. Polinización por avispas y abejas pequeñas atraídas por nectar y patrón visual. Conservación: catalogada en peligro (EN) por UICN y libro rojo plantas Colombia, las poblaciones silvestres están extremadamente fragmentadas y reducidas. Está protegida por CITES Apéndice II, Resolución MADS 0192/2014 y Ley 1333/2009: extracción de silvestres es delito ambiental. Cultivo: especie exigente en clima frío permanente (10-20°C, no tolera >26°C sostenidas), humedad alta (>70%), sombra parcial. Vive bien solo en altitudes frías colombianas (sabana de Bogotá, Cota, Tabio, Mosquera, Chía, La Calera, Sopó) o en cool-house refrigerado en climas cálidos. Sustrato fino: corteza de pino fina + musgo Sphagnum + perlita o carbón vegetal. Riego abundante en sequía, reducir en lluvia. Propagación: división de mata con mínimo 3 pseudobulbos cada 3-4 años, o micropropagación in vitro asimbiótica (vía industrial sostenible). PROPAGACIÓN ÉTICA: solo de viveros ICA-CITES o multiplicación familiar legal — extracción silvestre es crimen ambiental. Programas de conservación: JBB, IAvH, Sociedad Colombiana de Orquideología y MADS trabajan en repatriación y reintroducción en bosques alto-andinos restaurados de Cundinamarca-Boyacá. Es lección histórica extraordinaria de cómo el extractivismo colonial-comercial puede llevar una especie de la abundancia a la casi-extinción en 30 años, y de cómo la conservación moderna combina ciencia (micropropagación, banco genético, reintroducción), ley (CITES, MADS) y memoria (recordar que el \"Odontoglossum crispum\" de los catálogos europeos del XIX vino arrancado de los bosques de Pacho). Cultivar uno hoy de origen legal es honrar esa memoria. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia, libro rojo plantas Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "libro-rojo-plantas-colombia"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "masdevallia_coccinea",
+      "nombre_comun": "Masdevallia escarlata",
+      "nombre_comunes_regionales": [
+        "orquídea escarlata",
+        "masdevallia roja",
+        "gallito andino",
+        "flor del colibrí andino"
+      ],
+      "nombre_cientifico": "Masdevallia coccinea Linden ex Lindl.",
+      "familia_botanica": "Orchidaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2500,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 8,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "habito": "orquídea epífita o terrestre cespitosa sin pseudobulbos, hojas espatuladas de 10-15 cm, escapo floral solitario con flor triangular vibrante escarlata-magenta-fucsia con sépalos prolongados en colas",
+      "propagation": {
+        "methods": [
+          "division_mata",
+          "micropropagacion"
+        ],
+        "best_method": "micropropagacion",
+        "protocol_resumen": "División de mata con mínimo 4-5 brotes (la planta es cespitosa sin pseudobulbos). Sustrato musgo Sphagnum vivo o New Zealand sphagnum + perlita, NUNCA dejar secar (raíces finas mueren). Humedad alta >75% constante. Temperatura nocturna fresca <16°C. Micropropagación vía siembra asimbiótica para producción industrial. PROHIBIDA EXTRACCIÓN SILVESTRE — CITES II + Res. MADS.",
+        "tiempo_a_establecimiento_dias": 540,
+        "notas": "Polinización ornitofila por colibríes andinos (verde dorado, terciopelo verde) atraídos por el color escarlata y la forma tubular. Especie del bosque nublado y subpáramo de los tres ramales andinos.",
+        "fuente": "Ortiz-Valdivieso 1991; Bernal 2015; POWO; IAvH flora alto-andina; CITES II"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Inviable apartamento cálido: requiere clima frío permanente y humedad >75% imposible en interior promedio."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Viable solo en zonas frías altas (>2200 msnm) con sombra y humedad alta. Patios sombreados de Bogotá, Mosquera, Cota, Chía, Tabio, La Calera.",
+          "tips": [
+            "Montaje colgante en sombra densa de árbol o malla polisombra 70%",
+            "Riego diario en sequía, sustrato siempre húmedo no encharcado",
+            "Nebulización ambiental 1-2 veces/día en seca",
+            "Floración continua a lo largo del año con picos primavera-otoño"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Excelente bajo cool-house refrigerado con nebulización automática. Vía principal de conservación ex-situ.",
+          "tips": [
+            "Cool-house 12-18°C nocturno con sombra 70%",
+            "Humedad 80-90% mediante nebulización",
+            "Vivero ICA + CITES doméstico"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial bajo cool-house con licencia ICA + CITES. Mercado europeo y asiático paga premium por masdevallias colombianas.",
+          "tips": [
+            "Diferenciación marca \"Masdevallia coccinea cultivada legal\"",
+            "Trazabilidad CITES por planta",
+            "Mercado de coleccionista paga 50-200 USD por planta de calidad"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Reintroducción en bosques nublados restaurados de la Cordillera Oriental, Central y Occidental con permiso MADS-IAvH.",
+          "tips": [
+            "Sitios con cobertura nativa preservada y humedad estable",
+            "Acompañamiento JBB-IAvH",
+            "Monitoreo genético poblacional"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "flor",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Orquídea epífita o terrestre del bosque nublado y subpáramo andino colombiano entre 2.200 y 3.400 msnm. Especie en peligro (EN) por destrucción de bosque alto-andino. Polinización ornitofila exclusiva por colibríes andinos (Coeligena spp., Eriocnemis spp.) atraídos por color escarlata y forma tubular — caso clásico de coevolución planta-ave en los Andes. Indicadora de bosque nublado bien preservado con humedad estable. Protección CITES II.",
+      "valor_pedagogico": "La masdevallia escarlata (Masdevallia coccinea Linden ex Lindl., Orchidaceae) es una de las orquídeas alto-andinas más espectaculares y representativas de Colombia, famosa por sus flores triangulares vibrantes de color escarlata-magenta-fucsia que parecen banderas suspendidas en el bosque nublado. Especie nativa de Colombia y Ecuador, en Colombia se distribuye en bosques nublados y subpáramos de las tres cordilleras (Oriental, Central y Occidental) entre 2.200 y 3.400 msnm en zona térmica fría con humedad relativa permanente >75% y temperaturas medias 8-18°C, en departamentos como Cundinamarca, Boyacá, Santander, Norte de Santander, Antioquia, Quindío, Risaralda y Cauca. Fue descrita en 1845 por Lindley con material colectado por Linden, y se hizo famosa rápidamente en Europa como una de las orquídeas más vistosas del Nuevo Mundo. Es planta cespitosa (sin pseudobulbos, característica diagnóstica del género Masdevallia que la diferencia de Cattleya y Oncidium) con rizoma corto y hojas espatuladas-elípticas coriáceas de 10-15 cm, e inflorescencia con escapo solitario erecto que termina en una sola flor triangular grande (5-7 cm) con tres sépalos fusionados en su base formando un tubo y prolongados en sus extremos en colas filiformes de 2-4 cm, color escarlata-magenta-fucsia vibrante. Floración continua a lo largo del año con picos en primavera-otoño. Polinización ornitofila exclusiva por colibríes andinos como Coeligena prunellei (inca colombiano), Coeligena coeligena, Eriocnemis vestita y otros, atraídos por el color escarlata característico y la forma tubular que se ajusta al pico del ave — caso clásico de coevolución planta-ave en los Andes tropicales y ejemplo de cómo la polinización por aves opera en altitudes donde los insectos polinizadores son escasos por bajas temperaturas. Conservación: catalogada en peligro (EN) por UICN y libro rojo plantas Colombia debido a la destrucción del bosque alto-andino y subpáramo (deforestación para ganadería, papa, conuco, urbanización). Está protegida por CITES Apéndice II, Resolución MADS 0192/2014 y Ley 1333/2009: extracción silvestre es delito ambiental. Cultivo: especie exigente en clima frío permanente (8-18°C, no tolera >24°C), humedad alta constante (>75%), sombra parcial (70%), riego diario o sustrato siempre húmedo (sin pseudobulbos no reserva agua, raíces finas mueren con sequía). Sustrato musgo Sphagnum vivo o New Zealand + perlita. Vive bien en zonas frías altas de Cundinamarca-Boyacá-Antioquia con elevación >2.200 msnm, o en cool-house refrigerado con nebulización. Propagación: división de mata con mínimo 4-5 brotes cada 2-3 años, o micropropagación in vitro asimbiótica (vía industrial sostenible). PROPAGACIÓN ÉTICA: solo de viveros ICA-CITES — extracción silvestre es crimen. Programas de conservación: JBB, IAvH, Sociedad Colombiana de Orquideología y MADS desarrollan banco genético, micropropagación y reintroducción ex-situ → in-situ. Es lección extraordinaria de la coevolución andina (planta-colibrí), de la fragilidad del bosque nublado como reservorio único de orquídeas endémicas, y de la importancia de conservar simultáneamente la planta y su polinizador específico — si se extingue el colibrí, la flor pierde su servicio reproductivo aunque la planta sobreviva en cultivo. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia, libro rojo plantas Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "libro-rojo-plantas-colombia"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "tillandsia_complanata",
+      "nombre_comun": "Cardo bromelio aplanado",
+      "nombre_comunes_regionales": [
+        "tillandsia aplanada",
+        "piñuela del aire",
+        "quiche del bosque nublado"
+      ],
+      "nombre_cientifico": "Tillandsia complanata Benth.",
+      "familia_botanica": "Bromeliaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "habito": "bromelia epífita acaule con roseta abierta aplanada (de ahí \"complanata\") de hojas lineares hasta 50 cm, inflorescencia péndula con brácteas rosadas-rojas y flores tubulares moradas",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "division_mata"
+        ],
+        "best_method": "division_mata",
+        "protocol_resumen": "División de hijuelos basales (keikis) que la planta produce post-floración antes de que la madre muera. Plantar sobre tronco, corteza o canastilla con musgo. NO requiere sustrato sólido (es epífita aérea estricta). Riego por aspersión 2-3 veces por semana en seca. Semilla: dispersión anemófila, germinación lenta sobre corteza de árbol hospedero.",
+        "tiempo_a_establecimiento_dias": 180,
+        "notas": "Bromelia \"tanque\" parcial: la roseta acumula agua en su centro como microhábitat acuático efímero (fitotelma) que aloja anfibios pequeños, larvas de insectos, microalgas. Servicio ecológico crítico en bosques nublados.",
+        "fuente": "Smith & Downs 1977 Bromeliaceae Flora Neotropica; Bernal 2015; POWO; IAvH"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Excelente apartamento con luz indirecta abundante y humedad moderada. Bajo mantenimiento.",
+          "tips": [
+            "Montar sobre tronco decorativo o canastilla",
+            "Nebulización 2-3 veces/semana, llenar el tanque central de la roseta",
+            "NO regar el suelo: la planta NO tiene raíces nutritivas",
+            "Floración cada 2-3 años, después produce hijuelos"
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Patio sombreado con humedad. Excelente para \"jardín vertical\" o tronco vivo con bromelias colgantes.",
+          "tips": [
+            "Montaje sobre tronco de aguacate, mango o helecho arborescente",
+            "Pulverización agua de lluvia 2-3 veces/semana",
+            "Funciona como atractor de polinizadores y refugio de fauna pequeña"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Producción de plantines vía división de hijuelos. Cultivo sin sustrato sólido eficiente en espacio.",
+          "tips": [
+            "Tablones colgantes vertical para maximizar espacio",
+            "Riego por aspersión automática",
+            "Ciclo de producción 2-3 años por planta"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial baja inversión: viveros ornamentales de bromelias para mercado nacional e internacional. NO requiere CITES (no está en Apéndice).",
+          "tips": [
+            "Multiplicación familiar legal (no requiere permiso especial)",
+            "Mercado de jardinería vertical, terrario, decoración",
+            "Diferenciación: \"bromelia colombiana cultivo ético\""
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Reintroducción en bosques andinos restaurados con cobertura forestal. Mejora microhábitats de fauna pequeña.",
+          "tips": [
+            "Densidad 50-200 plantas/ha en árboles de dosel",
+            "Acelera recuperación de fauna asociada (anfibios, insectos)",
+            "Sin permiso especial, especie silvestre común no amenazada"
+          ]
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "flor",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Bromelia epífita del bosque nublado y alto-andino colombiano entre 1.200 y 3.200 msnm. Bromelia \"tanque\" parcial: la roseta de hojas aplanadas acumula agua en su centro formando microhábitats acuáticos (fitotelmas) que albergan anfibios diminutos (Pristimantis spp.), larvas de mosquito, microalgas, bacterias — servicio ecológico crítico de creación de hábitat. Polinizada por colibríes andinos atraídos por las brácteas rojo-rosadas. Indicadora de bosque andino húmedo bien conservado. NO está en CITES (no amenazada). Compañera ecológica de orquídeas y musgos del dosel.",
+      "valor_pedagogico": "El cardo bromelio aplanado o tillandsia complanata (Tillandsia complanata Benth., Bromeliaceae) es una bromelia epífita característica y ecológicamente fundamental de los bosques nublados y alto-andinos de los Andes colombianos. Especie ampliamente distribuida desde México hasta Bolivia, en Colombia es común en bosques de las tres cordilleras entre 1.200 y 3.200 msnm en zona térmica templada a fría con humedad relativa alta. Es planta epífita acaule (sin tallo aéreo) con roseta abierta aplanada (de ahí el epíteto \"complanata\" = aplanada) de hojas lineares-acintadas de 30-50 cm de largo y 1,5-2,5 cm de ancho, de color verde-grisáceo con tonos púrpura en la base, dispuestas en plano horizontal sobre la rama hospedera (la disposición aplanada maximiza la captación de neblina y agua de lluvia). Inflorescencia péndula de 30-60 cm con brácteas vistosas rojo-rosadas-anaranjadas y flores tubulares moradas-violetas pequeñas. Función ecológica notable: como bromelia \"tanque\" parcial, la roseta acumula agua de lluvia y neblina en su centro formando un fitotelma — microhábitat acuático efímero que alberga toda una comunidad biótica: anfibios diminutos del género Pristimantis (ranas de cristal y ranas saltarinas andinas que reproducen exclusivamente en bromelias), larvas de mosquitos, copépodos, microalgas, bacterias quimiosintéticas — uno de los servicios ecológicos más fascinantes del bosque nublado donde una sola planta crea hábitat para decenas de especies pequeñas. Polinización ornitofila por colibríes andinos atraídos por las brácteas rojo-rosadas (Coeligena spp., Eriocnemis spp., Heliangelus spp.). Reproducción: tras una floración (que ocurre cada 2-3 años) la planta madre muere pero antes produce 2-5 hijuelos basales (keikis) que la reemplazan — estrategia \"fénix\" típica de bromelias. Dispersión de semillas anemófila (aladas con apéndice plumoso) que aterrizan en troncos y ramas musgosas de árboles hospederos donde germinan lentamente. Cultivo: epífita aérea estricta (NO requiere sustrato), se monta sobre tronco, corteza o canastilla con musgo Sphagnum, riego por aspersión o nebulización 2-3 veces/semana llenando el tanque central. NO regar el suelo: la planta no tiene raíces nutritivas, solo raíces estructurales para sujeción, y absorbe agua y nutrientes a través de tricomas escamosos de las hojas (adaptación CAM modificada característica de Tillandsia). Multiplicación legal sin permiso especial vía división de hijuelos basales — NO está en CITES Apéndice (no amenazada) y NO requiere autorización específica más allá de no extraer cantidades comerciales de bosque silvestre sin permiso MADS. Conservación: especie no amenazada, pero su hábitat (bosque nublado andino) sí lo está por deforestación. Es lección extraordinaria de la complejidad del bosque nublado: una sola epífita crea hábitat para anfibios endémicos, polinizadores colibríes y comunidades microbianas, ejemplo perfecto de cómo en los Andes \"cada planta es un mundo\" y por qué conservar el bosque significa conservar redes ecológicas completas, no especies aisladas. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "tillandsia_usneoides",
+      "nombre_comun": "Barba de viejo",
+      "nombre_comunes_regionales": [
+        "musgo español",
+        "paja del aire",
+        "cabello de ángel",
+        "salvajina",
+        "barba de palo"
+      ],
+      "nombre_cientifico": "Tillandsia usneoides (L.) L.",
+      "familia_botanica": "Bromeliaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2500,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "habito": "bromelia epífita atípica filamentosa colgante hasta 2-6 m, sin raíces nutritivas, tallos finos plateados ramificados que crecen entrelazados como una \"barba\" colgando de árboles",
+      "propagation": {
+        "methods": [
+          "esqueje",
+          "semilla"
+        ],
+        "best_method": "esqueje",
+        "protocol_resumen": "Reproducción extremadamente fácil por fragmentación: cualquier fragmento de 10-20 cm puesto sobre rama o alambre crece y se ramifica. No requiere sustrato. Pulverizar agua 2-3 veces/semana en seca. Dispersión natural por viento, aves (recolectan para nidos) y desprendimiento de fragmentos.",
+        "tiempo_a_establecimiento_dias": 30,
+        "notas": "Es la única bromelia que ha evolucionado a forma filamentosa colgante (paralelismo morfológico convergente con líquenes Usnea de ahí \"usneoides\"). Bioindicador clásico de calidad del aire: muere en zonas contaminadas (sensible a SO2, plomo, metales pesados).",
+        "fuente": "Smith & Downs 1977 Bromeliaceae Flora Neotropica; Bernal 2015; POWO; Pérez-Arbeláez 1947"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Excelente apartamento decorativo: cuelga libremente, sin maceta ni sustrato. Bajo mantenimiento.",
+          "tips": [
+            "Colgar en gancho cerca de ventana con luz indirecta",
+            "Pulverización con agua 2-3 veces/semana",
+            "Crece 10-20 cm por año",
+            "Decoración terrarios, jardines verticales, tendencia \"airplant\""
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Colgar de árboles del patio, alambres, pérgolas. Crea ambiente místico de bosque tropical.",
+          "tips": [
+            "Sembrar en aguacate, mango, cítricos, frutales",
+            "Multiplicación por fragmentos: regalar a vecinos",
+            "NO daña al árbol hospedero (es epífita no parásita)"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Producción comercial vía alambres colgantes. Mercado ornamental \"airplant\" en expansión global.",
+          "tips": [
+            "Tendido en alambres a 30 cm de separación",
+            "Riego por aspersión automática",
+            "Cosecha rotativa de fragmentos cada 6 meses"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial baja inversión. Uso múltiple: decoración, sustrato hortícola (sustituye musgo Sphagnum), artesanía, etnobotánica.",
+          "tips": [
+            "Mercado airplant europeo-EEUU paga premium",
+            "Uso ancestral para fibra de relleno",
+            "Trazabilidad: cultivo vs extracción silvestre"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Reintroducción en sistemas silvopastoriles y agroforestales. Bioindicador de calidad del aire post-restauración.",
+          "tips": [
+            "Densidad libre en árboles dispersos",
+            "Sin permiso especial (no amenazada)",
+            "Monitoreo de retorno = indicador de mejora de calidad del aire"
+          ]
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Bromelia epífita atípica filamentosa colgante distribuida desde el sureste de EEUU hasta el norte de Argentina, en Colombia ubicua en árboles entre 0 y 3.000 msnm en todas las zonas térmicas. Bioindicador clásico de calidad del aire — sensible a SO2, plomo, metales pesados; su ausencia indica contaminación atmosférica. Refugio y material de nidificación para múltiples especies de aves (oropéndola, mochilero, atrapamoscas). Ofrece refugio a invertebrados, anfibios y reptiles pequeños. Acumuladora dinámica de nutrientes atmosféricos (N por deposición húmeda).",
+      "valor_pedagogico": "La barba de viejo, musgo español o paja del aire (Tillandsia usneoides (L.) L., Bromeliaceae) es una de las bromelias más fascinantes y de distribución más amplia del Neotrópico, conocida por ser la única bromelia que ha evolucionado a forma filamentosa colgante en paralelismo morfológico convergente con los líquenes del género Usnea (de ahí su epíteto \"usneoides\" = parecido a Usnea). Especie ampliamente distribuida desde el sureste de Estados Unidos (Carolinas, Florida, Louisiana) y México hasta el norte de Argentina y Chile, en Colombia es ubicua en árboles entre 0 y 3.000 msnm en todas las zonas térmicas (cálida, templada, fría) en las regiones Caribe, Andina, Pacífico, Orinoquía y Amazonía. Es planta epífita extremadamente atípica para la familia Bromeliaceae: NO tiene roseta, NO tiene raíces nutritivas, NO tiene tallo único — en su lugar consiste en tallos filamentosos ramificados colgantes de hasta 2-6 metros de longitud, recubiertos de tricomas escamosos plateados que absorben agua y nutrientes directamente de la neblina, lluvia y polvo atmosférico, sin necesidad de suelo ni hospedero parasitario (es epífita pura, NO parásita: no toma nada del árbol que la sostiene, solo lo usa como soporte físico). Florece con flores diminutas verde-amarillentas casi imperceptibles, polinizadas por insectos pequeños. Reproducción: extremadamente fácil por fragmentación — cualquier fragmento de 10-20 cm puesto sobre rama, alambre o tronco enraíza superficialmente y crece formando nueva colonia. Dispersión natural por viento, aves (recolectan fragmentos para nidos de oropéndolas, mochileros, atrapamoscas) y desprendimiento por lluvia. Bioindicador clásico de calidad del aire: es extremadamente sensible a contaminantes atmosféricos (SO2, NO2, plomo, metales pesados) y su ausencia o muerte en una zona urbana indica contaminación severa — por eso en zonas industriales de Bogotá, Medellín, Cali ha desaparecido mientras florece en zonas rurales y peri-urbanas con aire limpio. Bioacumulador dinámico de nutrientes atmosféricos (nitrógeno por deposición húmeda, captura partículas finas). Usos ancestrales y modernos: como fibra de relleno para colchones y muebles tradicionales (uso documentado desde precolombino y colonial, especialmente Caribe y Andes), como sustrato hortícola sustituto del musgo Sphagnum (la extracción de musgo de páramo es prohibida; usneoides es alternativa legal cultivable), como decoración ornamental (\"airplant\" en jardinería vertical y terrarios — tendencia global creciente), en artesanía indígena para tejidos y figuras, en medicina tradicional como cataplasma anti-inflamatorio. Refugio biológico: una sola colonia de barba de viejo en un árbol aloja docenas de especies de invertebrados (arañas, ácaros, colémbolos, hormigas), anfibios diminutos, reptiles pequeños y aves nidificadoras. Cultivo: extremadamente fácil — colgar en alambre, gancho o rama, pulverizar con agua 2-3 veces/semana, sombra parcial. Crece 10-20 cm por año por colonia. Sin requerimiento de sustrato ni fertilización (toma todo del aire). Multiplicación legal por fragmentación: NO está en CITES, NO requiere permiso. Es lección extraordinaria de adaptación evolutiva (cómo una bromelia abandonó el patrón ancestral de roseta-tanque para convertirse en filamento aéreo), de servicio ecológico múltiple (bioindicador, refugio, dispersor de fauna), de sostenibilidad agroecológica (sustituto del musgo de páramo en horticultura) y de uso ancestral inteligente (relleno, sustrato, ornamento). En un huerto agroecológico es la primera epífita a introducir: no compite con cultivos, mejora el microclima del dosel, refugia polinizadores y enemigos naturales de plagas, y es bioindicador permanente de la calidad del aire del sistema. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "perez-arbelaez-1947-plantas-utiles"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "puya_clava_herculis",
+      "nombre_comun": "Puya gigante de páramo",
+      "nombre_comunes_regionales": [
+        "puya hércules",
+        "achupalla del páramo",
+        "cardo del páramo",
+        "maguey del páramo",
+        "puya compañera del frailejón"
+      ],
+      "nombre_cientifico": "Puya clava-herculis Mez & Sodiro",
+      "familia_botanica": "Bromeliaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 3000,
+        "optimo_min": 3500,
+        "optimo_max": 4200,
+        "max_absoluto": 4500
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 3,
+        "optimo_max": 12,
+        "max_tolerable": 18
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "habito": "bromelia terrestre monocárpica gigante con roseta basal de 1-1,5 m de diámetro de hojas espinosas, inflorescencia masiva clavada hasta 2-3 m de alto (de ahí \"clava-herculis\"=clava de Hércules), florece una sola vez después de 15-30 años y muere",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "PROHIBIDA EXTRACCIÓN — Ley 1930/2018 Páramos. Solo investigación con permiso MADS-IAvH. Reproducción exclusivamente por semilla en sitio natural: una planta produce 100.000-1.000.000 de semillas en su única floración a los 15-30 años (estrategia monocárpica masiva). Germinación lenta en suelo de páramo sobre musgo. NO transferir a horticultura: es especie de hábitat páramo y NO sobrevive fuera de él.",
+        "tiempo_a_establecimiento_dias": 730,
+        "notas": "Compañera ecológica icónica del frailejón (Espeletia spp.): juntos forman el paisaje arquetípico del páramo andino colombiano-ecuatoriano. La puya provee refugio invernal a colibríes paramunos y oso de anteojos (Tremarctos ornatus) que consume su pulpa carnosa. Bajo PROTECCIÓN de Ley 1930/2018 Páramos.",
+        "fuente": "Humboldt 2016 Frailejones; Bernal 2015; POWO; Smith & Downs 1977; Ley 1930/2018 Páramos"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "INVIABLE en cualquier escala domestica. Especie de páramo (>3.000 msnm, temperaturas <12°C medias, radiación UV alta) que NO sobrevive fuera de su hábitat natural. Solo viable in-situ."
+        },
+        "huerto_casero": {
+          "viable": false,
+          "nota": "INVIABLE. Especie de páramo protegida por Ley 1930/2018. Su extracción es delito ambiental."
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "INVIABLE. La especie requiere condiciones de páramo (UV-B alta, oscilación térmica diaria extrema, suelo turboso) imposibles de reproducir en invernadero."
+        },
+        "produccion": {
+          "viable": false,
+          "nota": "INVIABLE — NO es planta cultivable comercialmente. Especie protegida."
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "EXCLUSIVAMENTE en programas de restauración ecológica de páramos degradados (post-quema, post-ganadería) con permiso MADS-IAvH-PNN, usando semillas locales del mismo páramo. Es restauración de hábitat, no cultivo.",
+          "tips": [
+            "Solo con permiso MADS-IAvH-PNN específico",
+            "Semillas locales del mismo páramo (no introducir genotipos foráneos)",
+            "Acompañamiento técnico IAvH-Humboldt",
+            "Plantación en complejo con frailejones, paja blanca, musgos"
+          ]
+        }
+      },
+      "scale_viability": [
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Bromelia terrestre monocárpica gigante del páramo andino colombiano-ecuatoriano entre 3.000 y 4.500 msnm. Compañera ecológica icónica del frailejón (Espeletia spp.): juntos forman el paisaje arquetípico del páramo. Su roseta espinosa y su inflorescencia masiva proveen: refugio invernal y nidificación a colibríes paramunos (Oxypogon spp.) y otros polinizadores andinos; alimento esencial al oso de anteojos (Tremarctos ornatus, único oso suramericano) que consume su pulpa carnosa y dispersa sus semillas; refugio térmico microclimático en su roseta para fauna pequeña paramuna. Protección absoluta por Ley 1930/2018 de Páramos. Especie clave para el funcionamiento del ecosistema paramuno y su servicio de regulación hídrica (los páramos abastecen >70% del agua potable de Colombia).",
+      "valor_pedagogico": "La puya gigante de páramo o puya hércules (Puya clava-herculis Mez & Sodiro, Bromeliaceae) es una de las plantas más espectaculares y emblemáticas del páramo andino colombiano-ecuatoriano y compañera ecológica inseparable del frailejón en el paisaje arquetípico del alto-andino. Especie nativa de los páramos de Colombia y Ecuador en la Cordillera Oriental, Central y Occidental entre 3.000 y 4.500 msnm en zona térmica paramuna (temperaturas medias 3-12°C, radiación UV-B intensa, suelo turboso ácido, oscilación térmica diurna extrema -8 a +18°C). Es planta bromelia terrestre monocárpica gigante (es decir: florece una sola vez en su vida y muere): durante 15-30 años acumula biomasa en forma de roseta basal de 1-1,5 m de diámetro con hojas largas espinosas (hasta 60 cm) en disposición radial densa, y al final del ciclo produce una única inflorescencia masiva erguida en forma de clava o maza vegetal de hasta 2-3 metros de altura (de ahí \"clava-herculis\" = clava de Hércules en latín, comparando la inflorescencia con el arma del héroe griego) cubierta de cientos a miles de flores tubulares verde-azuladas-blanquecinas que producen néctar abundante. Tras producir 100.000 a 1.000.000 de semillas en una sola floración (estrategia \"big bang\" reproductivo de bromelias monocárpicas), la planta madre muere por completo. Es lección extraordinaria de cómo la evolución resuelve la reproducción en hábitats extremos: en lugar de florecer pequeño cada año (estrategia anual) o de hacer múltiples floraciones medianas (estrategia plurianual), la puya invierte décadas acumulando reservas para un solo evento reproductivo masivo que satura el ambiente con semillas, garantizando que alguna fracción germine en sitios óptimos. Función ecológica crítica en el páramo: (1) Refugio invernal y nidificación para colibríes paramunos como el Oxypogon (chivito andino, endémico Colombia), el inca alirrosa Coeligena phalerata y otros; (2) Fuente esencial de alimento para el oso de anteojos (Tremarctos ornatus, único oso de Suramérica, especie casi-amenazada VU) que se alimenta de la pulpa carnosa de su base y de la inflorescencia, siendo dispersor primario de sus semillas a través de las heces — relación coevolutiva planta-oso única en los Andes; (3) Refugio térmico microclimático en su roseta espinosa donde anfibios paramunos, reptiles, roedores pequeños se cobijan del frío nocturno; (4) Compañera ecológica del frailejón (Espeletia spp., Asteraceae): juntos forman el paisaje arquetípico del páramo y comparten polinizadores y dispersores. Protección legal absoluta: Ley 1930/2018 de Páramos prohíbe cualquier actividad que afecte el ecosistema paramuno; extracción de puya silvestre es delito ambiental con penas hasta 144 meses de prisión (Ley 1333/2009). La especie NO ES CULTIVABLE en jardinería doméstica ni comercial: requiere las condiciones únicas del páramo (UV-B alta, oscilación térmica extrema, suelo turboso, microbiota local) que NO se reproducen en cualquier otro ambiente — intentar cultivarla fuera del páramo resulta en muerte. Su uso único permitido es la restauración ecológica de páramos degradados (post-quema, post-ganadería, post-minería) con permiso MADS-IAvH-Parques Nacionales y usando semillas locales del mismo páramo para preservar genotipos adaptados (NO mezclar genotipos entre páramos diferentes — cada páramo es una isla genética). Es lección extraordinaria de conservación ecosistémica: la puya enseña que el páramo NO es un conjunto de plantas aisladas sino una red coevolutiva (puya-frailejón-colibrí-oso-musgo-suelo turboso) donde sacar una pieza colapsa todo el sistema, y donde el agua que toma Bogotá, Bucaramanga, Tunja, Pereira proviene literalmente del trabajo conjunto de estas plantas almacenando lluvia y neblina. Conservar el páramo es conservar el agua de Colombia. Fuentes Tier A: Humboldt 2016 Frailejones, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia.",
+      "source_ids": [
+        "humboldt-2016-frailejones",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "ley-1930-2018-paramos"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "polypodium_decumanum",
+      "nombre_comun": "Calahuala",
+      "nombre_comunes_regionales": [
+        "calaguala",
+        "kalawalla",
+        "helecho de la peña",
+        "polipodio gigante",
+        "helecho macho"
+      ],
+      "nombre_cientifico": "Phlebodium decumanum (Willd.) J.Sm. (syn. Polypodium decumanum Willd.)",
+      "familia_botanica": "Polypodiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 200,
+        "optimo_min": 600,
+        "optimo_max": 1800,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "habito": "helecho epífita o saxicola con rizoma rastrero grueso pubescente dorado, frondas pinnadas grandes de 50-150 cm, soros redondos en el envés sin indusio",
+      "propagation": {
+        "methods": [
+          "rizoma",
+          "espora",
+          "division_mata"
+        ],
+        "best_method": "rizoma",
+        "protocol_resumen": "División de rizoma: cortar segmentos de 15-20 cm con 2-3 yemas activas, plantar sobre tronco, roca o canastilla con sustrato de musgo + corteza. Germinación de esporas requiere medio agar estéril y meses en laboratorio (no práctico campo). Cosecha de rizoma medicinal: planta de ≥3 años, cortar segmentos de rizoma dejando ≥50% para regeneración. Secado a sombra ventilada.",
+        "tiempo_a_establecimiento_dias": 365,
+        "notas": "PRECAUCIONES MEDICINALES: NO usar en embarazo (efecto uterotónico documentado), NO lactancia, NO menores de 12 años, NO con anticoagulantes (interacción con warfarina). Consulta médica obligatoria antes de uso prolongado. Productos comerciales estandarizados (Anapsos, Difur) tienen ensayos clínicos para vitiligo y dermatitis pero requieren prescripción.",
+        "fuente": "Bernal 2015; POWO; JBB Plantas Medicinales; Flora Colombia Pteridophyta; Pamplona-Roger 2006"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Apartamento con buena humedad y luz indirecta. Helecho ornamental + medicinal de uso doméstico controlado.",
+          "tips": [
+            "Maceta colgante o canastilla, NO maceta cerrada (rizoma necesita aire)",
+            "Sustrato corteza + musgo + perlita",
+            "Humedad 60-80% con nebulización",
+            "Cosecha doméstica: rizoma adulto solo de planta >3 años"
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Patio sombreado en clima cálido-templado, monte casero o farmacia viva. Especie patrimonial medicinal.",
+          "tips": [
+            "Montar sobre tronco vivo de aguacate, guayabo, mango",
+            "Cosecha sostenible de rizoma año 3+, dejar ≥50% del rizoma",
+            "Secado a sombra y almacenamiento en frasco oscuro hermético"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Producción medicinal artesanal. Multiplicación intensiva por rizoma.",
+          "tips": [
+            "Tablones a 30 cm de separación",
+            "Riego por aspersión",
+            "Cosecha rotativa de rizoma año 3-5"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial para industria fitofarmacéutica (Anapsos, Difur). Mercado europeo-asiático para tratamiento de vitiligo, psoriasis, dermatitis atópica.",
+          "tips": [
+            "Inversión: vivero certificado + secadero + laboratorio extracción",
+            "Cosecha rotativa: 1/3 del rizoma cada año, plantar al 100%",
+            "Trazabilidad: variedad, lote, año de cosecha",
+            "Mercado farmacéutico: validación clínica de fitoextracto"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Reintroducción en bosques sub-andinos restaurados. Bioindicador de humedad y sombra del dosel.",
+          "tips": [
+            "Densidad libre en troncos del dosel restaurado",
+            "Sin permiso especial (especie común no amenazada)",
+            "Atrae herpetofauna y avifauna asociada a epífitas"
+          ]
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Helecho epífita o saxicola del bosque húmedo tropical y premontano colombiano entre 200 y 2.400 msnm, ampliamente distribuido en regiones Andina, Caribe, Pacífico y Orinoquía. Bioindicador de bosque maduro con humedad estable. Refugio de invertebrados y anfibios en sus frondas. Especie patrimonial medicinal con uso ancestral indígena documentado para tratamiento dermatológico e inmunomodulador. Sus rizomas dorados gruesos almacenan abundantes polisacáridos bioactivos (calagualina) con propiedades inmunomoduladoras científicamente validadas.",
+      "valor_pedagogico": "La calahuala o kalawalla (Phlebodium decumanum (Willd.) J.Sm., sinónimo histórico Polypodium decumanum Willd., Polypodiaceae) es una de las plantas medicinales más patrimoniales del bosque tropical americano y de uso ancestral indígena en toda Mesoamérica y Suramérica tropical. Especie nativa del Neotrópico (México hasta Bolivia y Brasil), en Colombia se distribuye en bosques húmedos tropicales, premontanos y sub-andinos de las regiones Andina (Antioquia, Caldas, Quindío, Risaralda, Valle, Cauca, Huila, Tolima, Cundinamarca, Santander, Norte de Santander), Caribe (Sierra Nevada de Santa Marta, Serranía de San Lucas), Pacífico (Chocó, Valle, Cauca, Nariño) y Orinoquía (piedemonte llanero) entre 200 y 2.400 msnm en zona térmica cálida a templada con humedad alta. Es helecho epífito o saxícola (vive sobre rocas musgosas) con rizoma rastrero grueso (1,5-3 cm de diámetro) recubierto de escamas doradas pubescentes (característica diagnóstica del género Phlebodium), frondas pinnadas grandes de 50-150 cm de largo con pinas alternas elípticas-lanceoladas, soros redondos amarillentos dispersos en el envés sin indusio. Reproducción por esporas anemófilas y por fragmentación natural del rizoma. Uso medicinal milenario: el rizoma dorado contiene altas concentraciones de polisacáridos bioactivos (especialmente calagualina, un homoglucano), ácidos grasos poli-insaturados, esteroides vegetales y fenoles, con propiedades inmunomoduladoras científicamente validadas para tratamiento de enfermedades autoinmunes dermatológicas: vitiligo (estimula re-pigmentación), psoriasis (reduce hiperqueratinización), dermatitis atópica (modula respuesta Th1/Th2), y como adyuvante en fotoprotección oral contra daño UV. Hay productos farmacéuticos comerciales estandarizados (Anapsos® / Difur® en Europa, fitoextracto patentado por farmacéutica española ASAC desde 1973) con ensayos clínicos publicados en revistas dermatológicas (Cochrane reviews, Journal of Dermatological Treatment). Uso tradicional indígena: cocción del rizoma seco (1 cucharada por taza) como infusión depurativa, antirreumática, antitumoral en medicina tradicional Caribe, Guajira, Sierra Nevada, Putumayo, Cauca. PRECAUCIONES MEDICINALES IMPORTANTES: (1) NO usar en embarazo — efecto uterotónico documentado, riesgo de aborto; (2) NO usar en lactancia — paso al lactante no caracterizado; (3) NO usar en menores de 12 años — sin datos pediátricos de seguridad; (4) NO usar concomitante con anticoagulantes (warfarina, dabigatrán) — interacción medicamentosa documentada con riesgo de sangrado; (5) NO uso prolongado sin supervisión médica — posibles efectos sobre tensión arterial; (6) Para uso terapéutico serio, productos comerciales estandarizados son más seguros que infusión casera (variabilidad de principio activo). Cultivo: helecho exigente en humedad alta (>60%), sombra parcial (50-70%), sustrato corteza + musgo + perlita, riego cada 3-4 días manteniendo sustrato húmedo sin encharcar. Propagación por división de rizoma (más rápida) o por esporas (más lenta, requiere laboratorio). Cosecha sostenible de rizoma medicinal: solo de planta de ≥3 años de edad, cortar segmentos de 15-20 cm de rizoma adulto dejando ≥50% en planta madre para regeneración (no agotar la planta). Secado a sombra ventilada y almacenamiento en frasco oscuro hermético. Mercado: tradicional doméstico (infusión depurativa, baños dermatológicos), artesanal (fitofarmacéutica de baja escala con registro INVIMA), industrial (extracto estandarizado para industria farmacéutica con validación clínica). Es lección extraordinaria de etnofarmacología validada: una planta nativa cuyo uso ancestral indígena para enfermedades dermatológicas fue confirmado por la ciencia moderna mediante ensayos clínicos rigurosos, ejemplo de cómo el saber tradicional contiene farmacognosia genuina que la investigación occidental puede transformar en medicamentos estandarizados (Anapsos / Difur) que llegan a mercado europeo desde 1973, generando regalías tradicionalmente NO retornadas a las comunidades originarias — caso ejemplar para el Protocolo de Nagoya sobre acceso a recursos genéticos y participación justa en beneficios. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, JBB Plantas Medicinales, Flora Colombia Pteridophyta, Pamplona-Roger 2006 Plantas Medicinales.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "jbb-plantas-medicinales",
+        "flora-colombia-pteridophyta",
+        "pamplona-roger-2006-plantas-medicinales"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "dicksonia_sellowiana",
+      "nombre_comun": "Helecho arborescente",
+      "nombre_comunes_regionales": [
+        "helecho de palo",
+        "palma boba",
+        "sarro",
+        "helecho del bosque nublado",
+        "pala santa"
+      ],
+      "nombre_cientifico": "Dicksonia sellowiana Hook.",
+      "familia_botanica": "Dicksoniaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "habito": "helecho arborescente con tronco vertical recto de 3-8 m de altura cubierto de pelos castaño-rojizos, corona terminal de frondas pinnadas-bipinnadas grandes de 1,5-3 m que crean parasol del sotobosque",
+      "propagation": {
+        "methods": [
+          "espora",
+          "division_mata"
+        ],
+        "best_method": "espora",
+        "protocol_resumen": "PROHIBIDA EXTRACCIÓN SILVESTRE — CITES Apéndice II + Res. MADS 192/2014. Propagación legal solo por esporas en laboratorio (medio agar estéril, oscuridad, germinación 6-12 meses, prótalo 12-18 meses, esporofito juvenil 24-36 meses). Trasplante a vivero a los 2-3 años, crecimiento 5-15 cm/año en tronco. Floración por esporas a los 8-15 años. PROHIBIDO transplantar plantas silvestres adultas (extracción ilegal de tronco es delito ambiental).",
+        "tiempo_a_establecimiento_dias": 1095,
+        "notas": "Especie indicadora de bosque nublado andino bien preservado. Crecimiento extraordinariamente lento: troncos de 5 m tienen 50-80 años de edad. Su corteza pubescente roja se usa ancestralmente como sustrato para cultivo de orquídeas (uso prohibido salvo de árbol caído natural).",
+        "fuente": "Bernal 2015; POWO; Flora Colombia Pteridophyta; IAvH; libro rojo plantas Colombia; CITES II"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Inviable apartamento: tamaño adulto 3-8 m, requiere humedad >75% y temperatura <26°C imposible interior."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Patio amplio sombreado en clima frío-templado húmedo (Bogotá-Boyacá-Santander-Antioquia altura, ≥1.500 msnm). Pieza arquitectónica del jardín agroecológico.",
+          "tips": [
+            "Solo planta de vivero certificado ICA-CITES — NUNCA trasplantar silvestre",
+            "Lugar de siembra definitivo: NO se trasplanta después",
+            "Crecimiento 5-15 cm/año del tronco",
+            "Funciona como tutor natural de orquídeas, bromelias, musgos epífitos"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Vivero certificado para producción de plantines vía esporas. Vía principal de conservación ex-situ.",
+          "tips": [
+            "Laboratorio de esporas + sala cool-house para juveniles",
+            "Vivero ICA + CITES doméstico",
+            "Aclimatación 2-3 años antes de venta",
+            "Inversión alta pero ciclo de venta justifica"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial con licencia ICA + CITES. Mercado de jardinería patrimonial nacional e internacional.",
+          "tips": [
+            "Inversión: laboratorio esporas + vivero cool-house",
+            "Trazabilidad por planta con CITES doméstico",
+            "Mercado europeo-japonés paga 100-500 USD por planta de 1-2 m",
+            "Diferenciación: \"Dicksonia colombiana propagación ética\""
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "CRÍTICA reintroducción en bosques nublados restaurados de la Cordillera Oriental, Central, Occidental con permiso MADS-IAvH-PNN.",
+          "tips": [
+            "Solo sitios con cobertura forestal nativa preservada y humedad estable",
+            "Acompañamiento IAvH-JBB obligatorio",
+            "Plantines de vivero certificado de origen local",
+            "Monitoreo poblacional ≥10 años post-reintroducción"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Helecho arborescente icónico del bosque nublado y alto-andino colombiano entre 1.500 y 3.200 msnm. Especie en peligro (EN) por destrucción de bosque nublado y extracción ilegal de troncos para sustrato de orquídeas y para horticultura ornamental. Indicadora de bosque nublado bien preservado con humedad estable. Su tronco vivo es sustrato natural para decenas de especies de epífitas (orquídeas, bromelias, musgos, líquenes, otros helechos), funcionando como \"árbol madrina\" del sotobosque del bosque nublado. Crecimiento extraordinariamente lento: troncos de 5 m tienen 50-80 años. Protección CITES II + Res. MADS 192/2014.",
+      "valor_pedagogico": "El helecho arborescente o palma boba (Dicksonia sellowiana Hook., Dicksoniaceae) es uno de los helechos más espectaculares, antiguos y patrimoniales del bosque nublado andino colombiano, un fósil viviente cuyo linaje se remonta al Jurásico hace ~200 millones de años cuando los helechos arborescentes dominaban los bosques planetarios y eran alimento de los dinosaurios herbívoros. Especie nativa de Suramérica (Colombia, Ecuador, Perú, Bolivia, Brasil, Paraguay, Uruguay, norte de Argentina), en Colombia se distribuye en bosques nublados y alto-andinos de las tres cordilleras entre 1.500 y 3.200 msnm en zona térmica templada a fría con humedad relativa permanente >75% y temperaturas medias 10-20°C, en departamentos como Cundinamarca (Páramo de Sumapaz, Reserva Cruz Verde-Sumapaz), Boyacá, Santander, Antioquia, Quindío, Risaralda, Caldas, Cauca, Nariño, Huila, Tolima. Es helecho arborescente con tronco vertical recto cilíndrico de 3-8 m de altura cubierto de pelos densos castaño-rojizos lisos (característica diagnóstica de Dicksonia — el género hermano Cyathea tiene escamas en lugar de pelos), corona terminal de 8-15 frondas pinnadas-bipinnadas grandes de 1,5-3 m de largo dispuestas en parasol radial que crean un dosel del sotobosque del bosque nublado. Reproducción por esporas: en el envés de las frondas adultas se producen soros redondos marginales con miles de esporas dispersadas por viento, que germinan en suelo húmedo musgoso formando un prótalo (gametofito haploide) de pocos milímetros, donde ocurre la fertilización y emerge un esporofito juvenil que tomará 8-15 años en alcanzar madurez reproductiva. Crecimiento extraordinariamente lento: 5-15 cm de tronco por año — un helecho arborescente de 5 m de altura tiene 50-80 años de edad, comparable a un árbol viejo de cedro. Función ecológica crítica: el tronco vivo de Dicksonia es sustrato natural para una comunidad rica de epífitas — orquídeas (incluyendo Cattleya, Masdevallia), bromelias (Tillandsia, Vriesia), musgos, líquenes, otros helechos epífitos, hepáticas — funcionando como \"árbol madrina\" del sotobosque del bosque nublado y creando microhabitats para fauna asociada (invertebrados, anfibios endémicos, aves nidificadoras). Conservación: catalogada en peligro (EN) por UICN y libro rojo plantas Colombia, sus poblaciones silvestres se redujeron drásticamente por (1) destrucción del bosque nublado andino por ganadería, papa, urbanización; (2) extracción ilegal de troncos para sustrato hortícola de orquídeas y bromelias (uso \"tradicional\" pero insostenible — un tronco extraído representa 50-80 años de crecimiento); (3) extracción de plantas adultas para jardinería ornamental. Está protegida por CITES Apéndice II (toda la familia Dicksoniaceae), Resolución MADS 192/2014 y Ley 1333/2009: extracción de silvestres es delito ambiental severo. La única vía legal y ética de cultivar Dicksonia es adquirir plantines de vivero ICA-certificado con CITES doméstico que las propagó por esporas en laboratorio (vía sostenible aunque lenta: 3-5 años de proceso). PROHIBIDO trasplantar plantas silvestres adultas — la mortalidad de trasplante es alta y la extracción daña irreparablemente el bosque de origen. Cultivo: especie exigente en clima frío-templado húmedo permanente (10-20°C), humedad alta (>75%), sombra parcial, sustrato suelo orgánico bien drenado con materia orgánica abundante. Sitio definitivo de siembra: NO se trasplanta después de plantar. Riego abundante en seca, reducir en lluvia. Crecimiento 5-15 cm de tronco por año. Programas de conservación: JBB Bogotá, IAvH, Jardín Botánico de Medellín, Universidades (UN, UPN, UPTC) desarrollan banco de esporas, micropropagación in vitro, viveros de aclimatación y reintroducción ex-situ → in-situ en bosques nublados restaurados de Cundinamarca-Boyacá-Antioquia. Es lección extraordinaria de paleobiología viva (un linaje del Jurásico aún caminando entre nosotros), de servicio ecológico de soporte (un árbol-helecho como cuna del sotobosque), de conservación ética (la palma boba enseña por qué \"tradicional\" no siempre es sostenible — el uso ancestral de troncos para orquidearia funcionaba con poblaciones humanas pequeñas, no con horticultura industrial moderna), y de la importancia de la propagación por esporas en laboratorio como única vía sostenible de oferta legal. Conservar la Dicksonia es conservar el bosque nublado completo, porque sin ella el sotobosque pierde su árbol-cuna. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, IAvH Humboldt Flora Alto-Andina, SiB Colombia, Flora Colombia Pteridophyta, libro rojo plantas Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "humboldt-flora-alto-andina",
+        "sib-colombia",
+        "flora-colombia-pteridophyta",
+        "libro-rojo-plantas-colombia"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "equisetum_giganteum",
+      "nombre_comun": "Cola de caballo gigante",
+      "nombre_comunes_regionales": [
+        "cola de caballo",
+        "equiseto",
+        "chamizo gigante",
+        "limpiaplata",
+        "caña de bruja",
+        "planta-silicio"
+      ],
+      "nombre_cientifico": "Equisetum giganteum L.",
+      "familia_botanica": "Equisetaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "dynamic_accumulator",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "habito": "pteridofita gigante con tallos verde-pálidos articulados huecos cilíndricos hasta 2-5 m de altura y 2-3 cm de diámetro, ramificaciones verticiladas en cada nudo formando \"cola de caballo\", sin hojas verdaderas (escamosas en nudos), reproducción por esporas en estróbilo terminal",
+      "propagation": {
+        "methods": [
+          "rizoma",
+          "espora"
+        ],
+        "best_method": "rizoma",
+        "protocol_resumen": "Multiplicación extremadamente fácil por rizoma: cortar segmentos de 10-15 cm con 1-2 nudos activos, plantar en suelo húmedo a 5 cm de profundidad. Riego regular. Brote en 15-30 días. Crecimiento explosivo: 30-50 cm en primer mes, 1-2 m al primer año. CUIDADO: rizoma muy invasivo en humedales — siempre delimitar con barrera enterrada de 60 cm. Esporas viables solo bajo condiciones específicas, no práctico para horticultura.",
+        "tiempo_a_establecimiento_dias": 60,
+        "notas": "PRECAUCIONES MEDICINALES: NO uso prolongado (>1 mes seguido) — puede causar deficiencia de tiamina (B1) por enzima tiaminasa. NO en niños <12 años, NO embarazo, NO lactancia. NO sobredosis (intoxicación por nicotina vegetal y palustrina). Uso adecuado: infusión 1 cuchara/taza por 7-10 días, descanso 15 días. Consulta médica con condiciones renales/hepáticas previas. Bioacumulador de sílice (15-20% del peso seco) — fuente vegetal de silicio mineral biodisponible.",
+        "fuente": "Bernal 2015; POWO; JBB Plantas Medicinales; Flora Colombia Pteridophyta; Pamplona-Roger 2006; Pérez-Arbeláez 1947"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Inviable apartamento: tamaño adulto 2-5 m y rizoma invasivo lo hacen inadecuado para macetas."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Patio agroecológico junto a fuente de agua, humedal artificial o estanque. Excelente medicinal patrimonial + abono verde + bioacumulador de sílice.",
+          "tips": [
+            "Delimitar con barrera enterrada (madera, lámina) 60 cm profundidad — el rizoma es muy invasivo",
+            "Plantar junto a fuente de agua o suelo siempre húmedo",
+            "Cosecha medicinal: tallos jóvenes verdes en primavera",
+            "Té de cola de caballo como antifúngico foliar orgánico (caldo)"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Cultivo intensivo para medicinal + caldo antifúngico. Multiplicación por rizoma masiva.",
+          "tips": [
+            "Banca aislada con barrera anti-invasión",
+            "Riego abundante constante",
+            "Cosecha rotativa cada 3-4 meses"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción medicinal artesanal e industrial. Mercado nacional para té de cola de caballo + extracto silícico + caldo antifúngico agroecológico.",
+          "tips": [
+            "Inversión baja, sitio con humedal o riego abundante",
+            "Trazabilidad: lote, año, secado a sombra",
+            "Mercado: herbolarios, fitofarmacéuticas, agroecológicos",
+            "Producto derivado: caldo de cola de caballo (Bordelés alternativo) para roya, mildiu, oídio"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera de humedales degradados y orillas de cuerpos de agua. Fitorremediadora de metales pesados (acumula plomo, cadmio, arsénico en tallos).",
+          "tips": [
+            "Plantación en orillas de quebradas, humedales restaurados",
+            "Bioindicador de humedad estable y suelo limpio",
+            "Tallos acumulados se cosechan y disponen como residuo peligroso si fitorremediación de tóxicos"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Pteridofita gigante (la más grande del mundo del género Equisetum) del bosque húmedo tropical y premontano americano, en Colombia distribuida en regiones Andina, Caribe, Pacífico, Amazonía y Orinoquía entre 0 y 2.800 msnm en humedales, orillas de quebradas, suelos siempre húmedos. Fósil viviente: linaje del Devónico hace ~380 millones de años cuando dominaban los bosques planetarios. Pionera de humedales degradados con servicio de fitorremediación (acumula plomo, cadmio, arsénico). Bioacumulador extraordinario de sílice mineral (15-20% del peso seco) — fuente principal vegetal de silicio biodisponible. Medicinal patrimonial diurético, hemostático, remineralizante.",
+      "valor_pedagogico": "La cola de caballo gigante (Equisetum giganteum L., Equisetaceae) es la pteridofita más grande del mundo del género Equisetum y un fósil viviente extraordinario cuyo linaje se remonta al Devónico hace ~380 millones de años, cuando los equisetos arborescentes (orden Sphenophyta) dominaban los bosques planetarios alcanzando 30 metros de altura junto a helechos arborescentes y licopodios (formando los grandes bosques carboníferos que generaron los depósitos actuales de carbón mineral). Especie nativa de Suramérica tropical y subtropical (Colombia, Venezuela, Ecuador, Perú, Bolivia, Brasil, Paraguay, Uruguay, norte de Argentina, Chile), en Colombia ampliamente distribuida en zonas húmedas y humedales de regiones Andina (Cundinamarca, Boyacá, Santander, Norte de Santander, Antioquia, Tolima, Huila, Cauca, Nariño, Caldas, Quindío, Risaralda, Valle), Caribe (zonas húmedas de Sucre, Bolívar, Magdalena, Cesar), Pacífico (Chocó, Valle, Cauca), Amazonía (Caquetá, Putumayo, Amazonas) y Orinoquía (piedemonte) entre 0 y 2.800 msnm en zona térmica cálida a templada con humedad alta. Es planta pteridofita gigante con rizoma rastrero profundo y tallos aéreos verticales verdes-pálidos articulados huecos cilíndricos de 2-5 metros de altura y 2-3 cm de diámetro, con nudos prominentes ennegrecidos cada 15-25 cm de donde emergen ramificaciones verticiladas (en aro) que dan la apariencia clásica de \"cola de caballo\". NO tiene hojas verdaderas — las \"hojas\" son escamas diminutas fusionadas en vainas que rodean cada nudo. La fotosíntesis ocurre en los tallos verdes. Reproducción por esporas dispersadas por viento desde estróbilos terminales (cono reproductivo) en primavera, y por fragmentación de rizoma (vía dominante en horticultura). Función ecológica notable: (1) Pionera de humedales degradados, orillas de quebradas, taludes erosionados con humedad permanente — coloniza rápido por rizoma invasivo y estabiliza el sustrato; (2) Bioacumulador extraordinario de sílice (Si): los tallos contienen 15-20% de su peso seco como sílice cristalina y amorfa — una de las concentraciones más altas registradas en el reino vegetal, lo que da a los tallos su textura áspera (\"limpiaplata\" ancestral: indígenas y campesinos los usaban como estropajo para fregar utensilios de metal); (3) Fitorremediadora de metales pesados (acumula plomo, cadmio, arsénico, zinc en tallos) — útil en restauración de suelos contaminados aunque con cosecha como residuo peligroso. Uso medicinal patrimonial milenario: el tallo seco se usa como infusión (1 cucharada por taza) o cocción para múltiples propiedades documentadas científicamente: diurético potente (por flavonoides y silicio), remineralizante (fuente vegetal #1 de silicio mineral biodisponible — el silicio es esencial para colágeno, hueso, cartílago, uñas, cabello), hemostático (detiene hemorragias por vasoconstricción y por aporte de silicio a la coagulación), antifúngico tópico y agrícola, antiinflamatorio renal, en cataplasma para heridas y hemorragias menstruales. PRECAUCIONES MEDICINALES IMPORTANTES: (1) NO uso prolongado (>1 mes seguido) — contiene enzima tiaminasa que destruye vitamina B1 (tiamina), riesgo de deficiencia y neuropatía con uso continuo; (2) NO en niños <12 años — sin datos pediátricos; (3) NO en embarazo — efecto diurético y posibles trazas de nicotina vegetal; (4) NO en lactancia — paso al lactante no caracterizado; (5) Cuidado en pacientes con condiciones renales o hepáticas previas, hipotensión arterial, diabetes (puede potenciar hipoglucemia); (6) NO sobredosis — riesgo de intoxicación por palustrina (alcaloide menor) y nicotina trazas. Uso correcto: infusión 1-2 tazas/día por 7-10 días, descanso 15 días, repetir si necesario bajo supervisión. Uso agroecológico: el caldo de cola de caballo (preparación tradicional: 1 kg tallos secos en 10 L agua hirviendo, fermentación 24h, dilución 1:5 con agua, pulverización foliar) es uno de los antifúngicos orgánicos más usados en agricultura biodinámica y agroecológica para prevención y control de roya, mildiu, oídio, antracnosis en cultivos (validado experimentalmente, dispone de registro orgánico en muchas certificadoras europeas como Demeter). Cultivo: extremadamente fácil — plantar segmento de rizoma de 10-15 cm en suelo siempre húmedo con sol pleno o sombra parcial. CUIDADO: rizoma es muy invasivo y puede tomar humedales completos en 2-3 años — siempre delimitar con barrera enterrada de 60 cm de profundidad. Riego abundante constante. Crecimiento explosivo: 30-50 cm en primer mes, planta de 1-2 m al primer año, adulta de 3-5 m al segundo año. Cosecha medicinal: tallos jóvenes verdes en primavera, secado a sombra ventilada, almacenamiento en frasco oscuro hermético. Es lección extraordinaria de paleobiología viva (un orden vegetal del Devónico aún entre nosotros), de bioquímica vegetal (extraordinaria acumulación de silicio), de etnomedicina validada (uso tradicional confirmado por farmacología moderna), de bioremediación (limpiar suelos contaminados con plantas), y de doble propósito agroecológico (medicinal humano + antifúngico orgánico para cultivos). En el huerto agroecológico chagra colombiano, una franja de cola de caballo gigante junto a la fuente de agua provee simultáneamente: medicina familiar, biofertilizante de silicio, antifúngico orgánico para cultivos, estabilización de orillas, refugio de fauna pequeña — pieza estratégica del diseño permacultural. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, JBB Plantas Medicinales, Flora Colombia Pteridophyta, Pamplona-Roger 2006 Plantas Medicinales, Pérez-Arbeláez 1947 Plantas Útiles Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "jbb-plantas-medicinales",
+        "flora-colombia-pteridophyta",
+        "pamplona-roger-2006-plantas-medicinales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH41_EPIFITAS_ANDES_RETRY",
+      "id": "selaginella_lepidophylla",
+      "nombre_comun": "Siempreviva del desierto andino",
+      "nombre_comunes_regionales": [
+        "rosa de Jericó americana",
+        "flor de piedra",
+        "planta de la resurrección",
+        "doradilla",
+        "selaginela escamosa"
+      ],
+      "nombre_cientifico": "Selaginella lepidophylla (Hook. & Grev.) Spring",
+      "familia_botanica": "Selaginellaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 200,
+        "optimo_min": 800,
+        "optimo_max": 2200,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 15,
+        "optimo_max": 28,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "habito": "licófita rastrera con tallos ramificados forman roseta plana de 5-15 cm de diámetro, hojas escamosas diminutas dispuestas en cuatro hileras, fenómeno de poiquilohidria: se enrolla en bola seca durante sequía y reverdece con agua",
+      "propagation": {
+        "methods": [
+          "division_mata",
+          "espora"
+        ],
+        "best_method": "division_mata",
+        "protocol_resumen": "División de mata: separar rosetas individuales con sus rizoides, plantar sobre roca caliza fisurada o sustrato pedregoso bien drenado con poco suelo (NO suelo profundo — la planta es xerófita rupícola). Esporas: difícil germinación fuera de laboratorio. Riego: paradójicamente moderado — sumergir en agua revive la planta en 2-4 horas, pero exceso de riego en sustrato la mata por pudrimiento.",
+        "tiempo_a_establecimiento_dias": 60,
+        "notas": "Especie de rocas calizas secas, taludes pedregosos, afloramientos rocosos áridos. Fenómeno fascinante de poiquilohidria: puede perder >95% del agua celular, formar una bola seca aparentemente muerta por meses/años, y reverdecer completamente al recibir agua — modelo biológico de tolerancia extrema a desecación estudiado para biotecnología agrícola (transferencia de tolerancia a cultivos).",
+        "fuente": "Bernal 2015; POWO; Flora Colombia Pteridophyta; JBB; etnobotánica popular Caribe-Andes"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Apartamento: planta ornamental excepcional por su fenómeno de \"resurrección\". Bajo mantenimiento.",
+          "tips": [
+            "Maceta poco profunda con sustrato pedregoso + poco suelo",
+            "Riego ligero cada 7-10 días, dejar secar entre riegos",
+            "Demostración pedagógica: sumergir en agua revive en horas",
+            "Cuidado: NO sustrato siempre húmedo — la mata por pudrición"
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Jardín rocoso, xerojardín, jardín mediterráneo en patio. Excelente cobertora de rocas calizas y taludes secos.",
+          "tips": [
+            "Plantar sobre roca caliza fisurada con poco suelo",
+            "Suelo bien drenado, NO acumular agua",
+            "Cobertura de roca decorativa",
+            "Multiplicación libre y abundante por división"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Producción artesanal-ornamental para mercado \"rosa de Jericó americana\".",
+          "tips": [
+            "Banca pedregosa con drenaje libre",
+            "Riego intermitente",
+            "Multiplicación abundante por división"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Producción comercial ornamental + medicinal. Mercado pedagógico (escuelas, museos) y esotérico-decorativo (rosas de Jericó \"vivas\").",
+          "tips": [
+            "Inversión muy baja",
+            "Producto: planta seca enrollada en bolsa + instrucciones de \"resurrección\"",
+            "Mercado: jardinería, regalo, decoración, etnobotánica",
+            "Trazabilidad: planta cultivada vs extracción silvestre"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera de rocas calizas y taludes secos en restauración de zonas áridas y semi-áridas (enclaves secos andinos: Villa de Leyva, Patía alto, Chicamocha, valle alto Magdalena).",
+          "tips": [
+            "Plantación libre sobre rocas y taludes",
+            "Sin permiso especial (especie común no amenazada)",
+            "Estabiliza rocas y reduce erosión",
+            "Indicadora de sustrato bien drenado"
+          ]
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Licófita rupícola xerófita de las rocas calizas y taludes secos del bosque seco tropical y semi-árido americano, en Colombia distribuida en enclaves secos andinos (Villa de Leyva, Patía alto, Chicamocha, valle alto del Magdalena, Sabana de Bogotá zonas xéricas, Cesar, Guajira sur) entre 200 y 2.800 msnm en suelos pedregosos calizos bien drenados. Fenómeno extraordinario de poiquilohidria (tolerancia a desecación extrema): puede perder >95% del agua celular y entrar en quiescencia \"muerta\" por meses o años, y reverdecer completamente al recibir agua en 2-4 horas — modelo biológico estudiado para transferir tolerancia a sequía a cultivos comerciales mediante biotecnología. Cobertora pionera de rocas. Especie medicinal patrimonial mesoamericana-andina.",
+      "valor_pedagogico": "La siempreviva del desierto andino o rosa de Jericó americana (Selaginella lepidophylla (Hook. & Grev.) Spring, Selaginellaceae) es una de las plantas más fascinantes y biológicamente extraordinarias del Neotrópico, famosa mundialmente por su capacidad de \"resurrección\" — un fenómeno biológico de tolerancia a desecación extrema (poiquilohidria) que la convierte en modelo de estudio internacional para entender los mecanismos celulares de supervivencia a la sequía y para transferir esa tolerancia a cultivos agrícolas mediante biotecnología. Especie nativa del Neotrópico (México hasta Perú), en Colombia se distribuye en enclaves xéricos y semi-áridos de las regiones Andina (Villa de Leyva-Boyacá, Patía alto-Cauca, Chicamocha-Santander, valle alto del Magdalena en Huila-Tolima-Cundinamarca, Sabana de Bogotá zonas xéricas), Caribe (zonas secas de Cesar, Guajira sur, Bolívar) y Orinoquía (sabanas estacionalmente secas) entre 200 y 2.800 msnm en suelos pedregosos calizos secos bien drenados con sol pleno y precipitación baja-moderada. Es planta licófita (linaje paleobotánico distinto a helechos y angiospermas, cercano a los antiguos licopodios arborescentes del Carbonífero) rupícola rastrera con tallos ramificados dicotómicamente formando una roseta plana circular de 5-15 cm de diámetro y hojas microfilas escamosas diminutas (2-3 mm) dispuestas en cuatro hileras (dos dorsales pequeñas y dos ventrales mayores — característica diagnóstica de Selaginella heterofilia). Reproducción por esporas en estróbilos terminales (la única familia de licófitas vivas con heterospora: produce micro y mega-esporas separadas, intermedia entre helechos homospóricos y plantas con semilla — fascinante puente evolutivo). Fenómeno extraordinario de poiquilohidria — \"la planta de la resurrección\": cuando la sequía agota el agua disponible, la planta no muere sino que entra en un estado de tolerancia a desecación extrema: pierde hasta >95% del agua celular, sus tallos se enrollan hacia adentro formando una bola seca compacta marrón aparentemente muerta, y puede permanecer en este estado de \"muerte aparente\" durante meses o incluso años. Al recibir agua de nuevo (lluvia, rocío, sumergir en agua), en 2-4 horas la bola se abre, los tallos se desenrollan, los cloroplastos se reactivan, la planta reverdece completamente y reanuda fotosíntesis y crecimiento — sin daño celular. Los mecanismos moleculares de este fenómeno incluyen: (1) acumulación masiva de trehalosa (azúcar protector que sustituye al agua en las membranas celulares); (2) proteínas LEA (Late Embryogenesis Abundant) que estabilizan estructuras celulares en seco; (3) anhidrobiosis controlada del citoplasma; (4) capacidad de re-iniciar la maquinaria fotosintética intacta. Esta planta y otras pocas (Craterostigma plantagineum, Xerophyta humilis) son los modelos biológicos del proyecto internacional \"Resurrection Plants\" que busca transferir genes de tolerancia a desecación a cultivos comerciales (maíz, arroz, trigo) para crear variedades resistentes a sequía severa — frontera de la biotecnología agrícola frente al cambio climático. Uso etnomedicinal mesoamericano-andino: el tallo seco molido o en infusión tiene uso patrimonial en medicina tradicional indígena y mestiza para tratamiento de cálculos renales, infecciones urinarias, hipertensión arterial leve, gota, hemorragias internas, regulación menstrual, diabetes mellitus tipo 2 — con respaldo etnofarmacológico documentado y estudios químicos que identifican flavonoides, ácidos fenólicos y biflavonas con propiedades diuréticas, antiinflamatorias y antioxidantes. Uso ornamental y pedagógico: vendida como \"rosa de Jericó americana\" en mercados de plantas (a diferenciar de la Rosa de Jericó verdadera Anastatica hierochuntica del desierto del Sahara, especie distinta no relacionada) — el cliente recibe una bola seca aparentemente muerta y la \"resucita\" sumergiéndola en agua, fenómeno espectacular usado pedagógicamente en escuelas, museos de ciencia, terapias ocupacionales, y en jardinería esotérica popular. Cultivo: extremadamente fácil pero contra-intuitivo — la planta NO necesita riego abundante, al contrario: prefiere sustrato pedregoso bien drenado (calizo si posible) con poco suelo, riego ligero cada 7-10 días dejando secar entre riegos. Exceso de riego en sustrato la mata por pudrición de rizoides. Multiplicación: división de mata separando rosetas individuales — extremadamente fácil y abundante. Funciona en maceta plana, jardín rocoso, talud seco, xerojardín, jardín mediterráneo o de cactus. Es lección extraordinaria de biología extrema (cómo una planta puede \"resucitar\" después de meses muerta-seca), de evolución (un linaje del Devónico-Carbonífero aún caminando), de biotecnología de frontera (modelo para tolerancia a sequía en cultivos), de etnomedicina patrimonial mesoamericana-andina, y de pedagogía de la ciencia (¡regalar una planta-bola seca y verla revivir es magia comprobable!). En el huerto agroecológico de zonas secas o semi-secas (enclaves xéricos andinos colombianos), es cobertura ideal para rocas, taludes, terrazas pedregosas, donde nada más crece — y a la vez recurso medicinal familiar bajo precaución de uso moderado. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, Flora Colombia Pteridophyta, JBB Plantas Medicinales, SiB Colombia.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "flora-colombia-pteridophyta",
+        "jbb-plantas-medicinales",
+        "sib-colombia"
+      ]
     }
   ],
   "biopreparados": [


### PR DESCRIPTION
## Summary
- Sprint 5 Batch 41 retry post rate-limit reset: +10 species epífitas, orquídeas nativas, bromelias y pteridofitas patrimoniales de los Andes colombianos (catálogo seed v3.1: 280 → 290).
- Orquídeas CITES II (`cattleya_trianae`, `odontoglossum_crispum`, `masdevallia_coccinea`) y helecho arborescente `dicksonia_sellowiana` con énfasis en cultivo ético ex-situ vía viveros ICA-certificados.
- `puya_clava_herculis` (compañera frailejón) cultivable solo en restauración con permiso MADS-IAvH-PNN bajo Ley 1930/2018.
- Pteridofitas medicinales (`polypodium_decumanum`, `equisetum_giganteum`, `selaginella_lepidophylla`) y bromelias epífitas (`tillandsia_complanata`, `tillandsia_usneoides`).
- Contraindicaciones medicinales explícitas en `polypodium_decumanum` (NO embarazo/lactancia/<12 años/anticoagulantes) y `equisetum_giganteum` (NO uso prolongado por tiaminasa).
- Skip `vanilla_planifolia` (ya en catálogo).
- `source_ids` >=2 Tier A por species (POWO/GBIF/IAvH/Bernal-2015/SiB-Colombia/JBB).
- `valor_pedagogico` >=600 chars por species.

## Validacion
```
node scripts/validate-catalog.mjs --seed-mode --lenient-schema → rc=0
```
- 0 schema errors en species nuevas (idx 280-289).
- 16 legacy errors pre-existentes (idx 28, 200-209) sin cambio.
- AMB-05/14/15/16/17/18 PASS.
- AMB-10/13 warnings solo seed-mode (pre-existentes refs a species aun no migradas).

## Diff
- 1 archivo modificado: `catalog/chagra-catalog-seed-v3.1.json` (+1193 lineas)
- biopreparados / package.json / sw.js / src / public NO tocados.

## Test plan
- [x] `node scripts/validate-catalog.mjs --seed-mode --lenient-schema` rc=0
- [x] `jq '.species | length'` = 290
- [x] Secret-scan = 0 hits
- [ ] CodeQL
- [ ] Playwright E2E offline-first
