### PR TITLE
chore(catalog): batch 51 — +10 medicinales páramo + altas montañas (360→370)

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -21905,6 +21905,644 @@
         "sinchi-amazonia-colombiana"
       ],
       "valor_pedagogico": "La malanga morada u ocumo morado (Xanthosoma violaceum Schott, familia Araceae) es la especie hermana pigmentada de la malanga blanca (X. sagittifolium) — una aroidea tuberosa neotropical de cormo central y cormelos hijos múltiples con pulpa morada-violácea intensa por acumulación de antocianinas (principalmente cianidina-3-glucósido y peonidina-3-glucósido, mismos pigmentos antioxidantes responsables del color de la mora andina, el maíz morado peruano y la batata morada), reconocible además por sus peciolos morados-violáceos diagnósticos en campo y por el margen foliar violáceo en hojas tiernas. Es una variedad gastronómica especial neotropical cultivada tradicionalmente en el Caribe (afrocaribe, Puerto Rico-Cuba-República Dominicana-Haití, donde se llama 'yautía morada' o 'blue taro') y en el Pacífico afrocolombiano-amazónico colombiano donde se conserva como cultivo de chagra-finca-azotea tradicional por su valor culinario especial, su color llamativo y su perfil nutricional enriquecido en antioxidantes respecto a la malanga blanca común. En Colombia se cultiva en el Pacífico colombiano (Chocó-Valle litoral-Cauca litoral-Nariño litoral: Buenaventura, Quibdó, Istmina, Tumaco, Guapi, López de Micay), Caribe húmedo (Magdalena, Bolívar, San Andrés y Providencia donde es alimento ancestral afrosanandresano del 'callaloo'), Amazonía (trapecio amazónico Leticia-Puerto Nariño, Putumayo-Caquetá piedemonte) y zonas bajas inundables del Magdalena medio entre 0 y 1.000 msnm en zona térmica cálida húmeda, bajo nombres locales 'ocumo morado' o 'mafafa morada' (Caribe), 'malanga lila' (Pacífico) y 'yautía morada' (San Andrés-Providencia). Lección viva de variabilidad genética intra-género y color-marker antioxidante: el par botánico Xanthosoma sagittifolium (blanco) y X. violaceum (morado) es ejemplo perfecto de cómo la diversidad fenotípica de un cultivo tradicional refleja diversidad bioquímica funcional importante — el color morado de la malanga violácea NO es un capricho ornamental sino un perfil antioxidante real (capacidad antioxidante ORAC 4-8 veces superior a malanga blanca, similar a batata morada y mora andina), lección magistral de cómo el manejo campesino tradicional conserva 'farmacias vivas' en los policultivos de la chagra-finca-azotea. Esta misma lógica de color-marker antioxidante aparece en otros pares de cultivos neotropicales tradicionales: batata blanca vs batata morada (Ipomoea batatas), arracacha blanca vs arracacha morada (Arracacia xanthorrhiza), maíz blanco vs maíz morado (Zea mays), papa criolla amarilla vs papa criolla negra (Solanum phureja). El cormo central (5-12 cm diámetro, 0.5-2 kg) y los cormelos hijos con pulpa morada-violácea son ricos en antocianinas antioxidantes, almidón fino, fibra dietaria, mucílagos prebióticos, vitaminas B1-B6, vitamina C, potasio y proteína vegetal moderada (2-3%), consumidos cocidos en sancocho de mariscos del Pacífico, ajiaco caribeño, sopa de queso del Pacífico, frituras dulces, croquetas, cremas espesas y como ingrediente especial en mesa gourmet por su color llamativo. Las hojas también son comestibles tras cocción prolongada (callaloo morado del Caribe insular). Manejo agroecológico: propagación por cormelos hijos preferentemente del mismo color (selección campesina de mantenimiento de cv.) o por trozos de cormo madre con yemas activas, plantación a 60-80 cm entre plantas en suelo húmedo bien drenado rico en MO con pH 5.5-6.5, ciclo 8-12 meses a cosecha, rendimientos 8-20 t/ha cormos (ligeramente menores que la blanca por menor vigor vegetativo). Asocio idéntico a malanga blanca con plátano hartón, yuca dulce, piña, achiote, caña panelera y árboles frutales en finca pacífica-caribe-amazónica. Cultivo especializado de soberanía alimentaria afrocolombiana e indígena amazónica con potencial gourmet altísimo para gastronomía colombiana moderna. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, FAO EcoCrop, Bernal 2015 Catálogo Plantas Colombia, Pérez-Arbeláez 1947 Plantas Útiles Colombia, SINCHI Amazonía Colombiana."
+    },
+    {
+      "id": "espeletia_uribei",
+      "nombre_comun": "Frailejón de Uribe",
+      "nombre_comunes_regionales": [
+        "frailejón de Sumapaz",
+        "frailejón de Uribe",
+        "espeletia uribei"
+      ],
+      "nombre_cientifico": "Espeletia uribei Cuatrec.",
+      "familia_botanica": "Asteraceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 3200,
+        "optimo_min": 3500,
+        "optimo_max": 3900,
+        "max_absoluto": 4200
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 2,
+        "optimo_max": 9,
+        "max_tolerable": 17
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 90,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Frailejón endémico del Páramo de Sumapaz (Cundinamarca-Meta-Huila), nombrado en honor al botánico Lorenzo Uribe-Uribe S.J. Roseta caulescente con tallo subterráneo corto y hojas lanceoladas plateadas densamente pubescentes (tricomas blanco-grisáceos). Inflorescencia en racimo terminal con capítulos amarillos grandes. Germinación lenta 30-90 días, crecimiento ~0.8 cm/año, individuos de 1.5 m tardan ~180 años. Protegido absolutamente por Ley 1930/2018 (páramos colombianos) y Resolución 383/2010 MADS. Extracción, tránsito y aprovechamiento PROHIBIDOS sin permiso de autoridad ambiental (CAR Cundinamarca, CORPORINOQUIA). Solo manipulación bajo proyecto de restauración ecológica autorizado."
+      },
+      "source_ids": [
+        "humboldt-2016-frailejones",
+        "diazgranados-2012-espeletiinae",
+        "ley-1930-2018-paramos",
+        "mads-res-383-2010",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "pnn-sumapaz-plan-manejo"
+      ],
+      "valor_pedagogico": "El frailejón de Uribe (Espeletia uribei Cuatrec., familia Asteraceae) es un frailejón endémico del Páramo de Sumapaz — el complejo paramuno más extenso del mundo (333.420 hectáreas entre Cundinamarca, Meta y Huila), corazón hídrico de Bogotá y la región andina central colombiana. Nombrado en honor al sacerdote-botánico Lorenzo Uribe-Uribe S.J. (1900-1980), pionero del estudio florístico colombiano y autor de la 'Flora de Colombia'. Es una roseta caulescente típica del subgénero Espeletia s.s., con tallo corto subterráneo o emergente bajo, hojas lanceoladas plateadas (15-30 cm largo) densamente cubiertas por tricomas blanco-grisáceos que cumplen función termorreguladora (reducen pérdida de calor nocturna y captan agua de niebla matinal por condensación capilar), e inflorescencia en racimo terminal con capítulos amarillos grandes característicos de la subtribu Espeletiinae. En Colombia se distribuye exclusivamente en el complejo paramuno Sumapaz-Cruz Verde-Chingaza-Guerrero-Guacheneque en zona térmica de páramo entre 3.200 y 4.200 msnm, con óptimo en 3.500-3.900 msnm en pajonales-frailejonales del subpáramo-páramo medio dominados por Calamagrostis effusa, Calamagrostis bogotensis y otras especies de Espeletia (E. grandiflora, E. argentea, E. killipii, E. uribei, E. summapacis). Lección viva de endemismo paramuno colombiano y biogeografía de altísima montaña tropical: el género Espeletia, con ~140 especies descritas (Diazgranados-2012), es uno de los radiados evolutivos más espectaculares de la flora andina, con cada complejo paramuno (Sumapaz, Chingaza, Iguaque, Pisba, Cocuy, Santurbán, Belmira, Tatamá, Frontino-Urrao, Las Hermosas) albergando especies endémicas exclusivas — patrón biogeográfico de 'islas en el cielo' (sky islands) donde el aislamiento geográfico entre páramos separados por valles interandinos cálidos ha promovido especiación alopátrica. E. uribei es uno de los frailejones diagnósticos del páramo de Sumapaz junto con E. grandiflora y E. killipii (este último más típico de Chingaza). El crecimiento extremadamente lento (~0.8 cm/año, individuos de 1.5 m con ~180 años de edad) y la baja tasa de germinación natural (5-15%) hacen que la regeneración poblacional sea extraordinariamente vulnerable a cualquier disturbio: quemas para ampliar potreros, pisoteo ganadero, minería ilegal, expansión de frontera papera, cambio climático y deshielo glaciar son amenazas reales y críticas. Protección legal: Ley 1930 de 2018 (Gestión Integral de Páramos) prohíbe TODA actividad agropecuaria, minera, de hidrocarburos y de infraestructura nueva en ecosistemas de páramo delimitados por el Ministerio de Ambiente y el Instituto Humboldt. Resolución 383/2010 MADS declara TODOS los frailejones (todas las especies del género Espeletia y géneros relacionados de Espeletiinae) como especies amenazadas con prohibición absoluta de aprovechamiento, tránsito, comercialización y movilización sin permiso CAR. Sentencia T-361/2017 Corte Constitucional ordena la delimitación participativa del Páramo de Santurbán y por extensión sienta precedente para todos los páramos colombianos. La manipulación legal del frailejón se restringe EXCLUSIVAMENTE a proyectos de restauración ecológica autorizados por la autoridad ambiental competente (CAR Cundinamarca, CORPORINOQUIA, CORPOAMAZONIA según jurisdicción) bajo protocolos validados (Rojas-Zamora 2013, Vargas-Ríos 2007, PNN Sumapaz). Manejo agroecológico (solo restauración): recolección de aquenios maduros (diciembre-febrero, temporada seca cordillera oriental) con autorización CAR, siembra en sustrato turba de páramo + tierra subpáramo 50% + arena gruesa 30% + MO 20%, germinación en invernadero de alta montaña 30-90 días, trasplante a bolsa 4-6 meses, plantación definitiva >12 meses a 15-20 cm en sitios degradados con exclusión ganadera obligatoria mínimo 3 años, densidad 100-400 individuos/ha según grado de degradación, monitoreo anual de supervivencia, asocio con Calamagrostis effusa, Hypericum juniperinum, Senecio formosus y otras especies nativas del cortejo florístico paramuno. La regulación hídrica del frailejón es servicio ecosistémico estratégico: la pubescencia foliar captura agua de niebla y rocío matutino, escurrimiento foliar dirige el agua al cuello de la roseta y al suelo orgánico turboso de páramo (almacenamiento prolongado), regulando caudales base de las cuencas que abastecen >70% del agua potable de las ciudades andinas colombianas (Bogotá, Cundinamarca, Boyacá, Meta). Fuentes Tier A: Humboldt 2016 Frailejones de Colombia, Diazgranados 2012 Revisión Espeletiinae, Ley 1930/2018, Resolución 383/2010 MADS, Libro Rojo de Plantas de Colombia, Bernal 2015 Catálogo Plantas Colombia, Plan de Manejo PNN Sumapaz."
+    },
+    {
+      "id": "espeletia_killipii",
+      "nombre_comun": "Frailejón Killip",
+      "nombre_comunes_regionales": [
+        "frailejón de Chingaza",
+        "frailejón Killip",
+        "espeletia killipii"
+      ],
+      "nombre_cientifico": "Espeletia killipii Cuatrec.",
+      "familia_botanica": "Asteraceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 3000,
+        "optimo_min": 3300,
+        "optimo_max": 3800,
+        "max_absoluto": 4100
+      },
+      "temperatura_c": {
+        "helada_letal": -14,
+        "optimo_min": 2,
+        "optimo_max": 10,
+        "max_tolerable": 17
+      },
+      "humedad_relativa_pct": {
+        "min": 75,
+        "optimo": 92,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Frailejón típico del Páramo de Chingaza (Cundinamarca-Meta), nombrado en honor al botánico estadounidense Ellsworth Paine Killip (1890-1968) colector clave de la flora colombiana en el siglo XX. Roseta caulescente de tallo erecto que alcanza 1-3 m, con hojas oblongo-lanceoladas plateadas pubescentes en roseta apical compacta. Inflorescencia en panícula amarilla terminal. Germinación 30-90 días, crecimiento ~1 cm/año, individuos de 2 m con ~200 años. Protegido por Ley 1930/2018 (páramos) y Resolución 383/2010 MADS. Restauración ecológica autorizada únicamente por CAR Cundinamarca o CORPORINOQUIA según jurisdicción."
+      },
+      "source_ids": [
+        "humboldt-2016-frailejones",
+        "diazgranados-2012-espeletiinae",
+        "ley-1930-2018-paramos",
+        "mads-res-383-2010",
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "pnn-chingaza-plan-manejo"
+      ],
+      "valor_pedagogico": "El frailejón Killip (Espeletia killipii Cuatrec., familia Asteraceae) es uno de los frailejones diagnósticos del Páramo de Chingaza — el complejo paramuno que abastece >80% del agua potable de Bogotá a través del sistema de embalses Chuza-San Rafael-Chingaza operado por la EAAB (Empresa de Acueducto y Alcantarillado de Bogotá). Nombrado en honor al botánico estadounidense Ellsworth Paine Killip (1890-1968), curador del U.S. National Herbarium (Smithsonian) y colector pionero de la flora colombiana junto con Pennell, Cuatrecasas, García-Barriga y Schultes en las expediciones botánicas de las primeras décadas del siglo XX que documentaron la riqueza florística andino-amazónica colombiana. Es una roseta caulescente del subgénero Espeletia s.s. con tallo erecto que alcanza 1-3 m de altura (uno de los frailejones de talla mediana-alta), hojas oblongo-lanceoladas plateadas densamente pubescentes (15-25 cm largo) dispuestas en roseta apical compacta, e inflorescencia en panícula amarilla terminal con capítulos típicos de la subtribu Espeletiinae. En Colombia se distribuye principalmente en el complejo paramuno Chingaza-Cruz Verde-Sumapaz-Guerrero-Guasca-Guatavita-Guacheneque entre 3.000 y 4.100 msnm, con óptimo en 3.300-3.800 msnm en frailejonales-pajonales del subpáramo-páramo medio dominados por Calamagrostis effusa, Calamagrostis bogotensis, Espeletia grandiflora, E. killipii, E. uribei (en Sumapaz) y otras especies del cortejo florístico paramuno. Lección viva de servicio ecosistémico hídrico estratégico nacional: el complejo Chingaza protege ~76.600 ha de páramos, bosques altoandinos y subpáramos, regula la oferta hídrica de la cuenca del río Bogotá y la cuenca del río Guavio, y abastece el sistema Chingaza que entrega 14 m³/s de agua potable a Bogotá (>80% del consumo metropolitano). La densidad de frailejones de Chingaza (estimada en 4.000-8.000 individuos/ha en frailejonal puro) es indicador de salud ecosistémica y de capacidad de captura-regulación hídrica del páramo. E. killipii es uno de los frailejones más estudiados en proyectos de restauración liderados por la EAAB, CAR Cundinamarca, CORPORINOQUIA, PNN Chingaza, Universidad Nacional de Colombia (grupo Restauración Ecológica), Instituto Humboldt y Fundación Conservación Internacional Colombia. El crecimiento lento (~1 cm/año) y la regeneración natural extremadamente baja (5-15% de germinación, alta mortalidad de plántulas) hacen que la conservación dependa esencialmente de la protección activa del hábitat: exclusión ganadera, prevención de quemas, control de minería ilegal, vigilancia comunitaria y restauración asistida en sitios degradados. Protección legal: Ley 1930/2018 (Gestión Integral de Páramos) prohíbe agricultura, ganadería extensiva, minería, hidrocarburos e infraestructura nueva en páramos delimitados; Resolución 383/2010 MADS declara TODOS los frailejones especies amenazadas con prohibición absoluta de aprovechamiento sin permiso CAR; Sentencia C-035/2016 Corte Constitucional confirma constitucionalidad de la prohibición de minería en páramos. Manejo legal restringido EXCLUSIVAMENTE a proyectos de restauración autorizados: recolección de aquenios maduros (octubre-febrero según altitud) con permiso CAR, siembra en sustrato de turba de páramo + tierra de subpáramo + arena + MO, germinación 30-90 días en invernadero alta montaña, trasplante a bolsa 4-6 meses, plantación definitiva >12 meses, densidad 100-400 ind/ha según degradación, asocio con Calamagrostis, Hypericum, Senecio, Bartsia, Disterigma, Pernettya y otras especies nativas paramunas. La protección de E. killipii es indisociable de la protección del recurso hídrico estratégico nacional y de la viabilidad del sistema de acueducto de Bogotá D.C. Fuentes Tier A: Humboldt 2016 Frailejones de Colombia, Diazgranados 2012 Revisión Espeletiinae, Ley 1930/2018, Resolución 383/2010 MADS, Libro Rojo de Plantas de Colombia, Bernal 2015 Catálogo Plantas Colombia, Plan de Manejo PNN Chingaza."
+    },
+    {
+      "id": "senecio_formosus",
+      "nombre_comun": "Árnica de páramo",
+      "nombre_comunes_regionales": [
+        "árnica paramuna",
+        "árnica andina",
+        "senecio formosus",
+        "árnica de los andes"
+      ],
+      "nombre_cientifico": "Senecio formosus Kunth",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "paramo",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "dynamic_accumulator",
+        "pollinator_attractor"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2500,
+        "optimo_min": 3000,
+        "optimo_max": 3800,
+        "max_absoluto": 4200
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 3,
+        "optimo_max": 12,
+        "max_tolerable": 18
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 88,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 6,
+        "max": 6.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Hierba perenne paramuna de la familia Asteraceae con capítulos amarillos vistosos, conocida tradicionalmente como 'árnica de páramo' por su uso etnobotánico ancestral análogo al de la árnica europea (Arnica montana). Roseta basal de hojas oblanceoladas pubescentes y tallos florales erectos de 30-80 cm. Floración abundante temporada seca cordillera oriental. Recolección silvestre permitida con responsabilidad — NO incluida en lista de especies con prohibición absoluta de aprovechamiento del MADS, pero protegida indirectamente por Ley 1930/2018 cuando crece dentro de páramos delimitados. Propagación por semilla en invernadero alta montaña."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "garcia-barriga-flora-medicinal-colombia",
+        "jbb-jardin-botanico-bogota",
+        "humboldt-flora-paramos"
+      ],
+      "valor_pedagogico": "La árnica de páramo (Senecio formosus Kunth, familia Asteraceae) es una hierba perenne paramuna emblemática de la medicina tradicional andina colombiana, conocida como 'árnica andina' o 'árnica paramuna' por su uso etnobotánico ancestral análogo al de la árnica europea (Arnica montana) — aunque taxonómicamente distinta (la verdadera Arnica es género hermano restringido al hemisferio norte). Es una roseta basal con hojas oblanceoladas pubescentes (10-20 cm largo) y tallos florales erectos de 30-80 cm que portan capítulos amarillos vistosos típicos de la familia Asteraceae con flores liguladas y flósculos centrales tubulares. La floración abundante (octubre-febrero, temporada seca de la cordillera oriental colombiana) atrae himenópteros, dípteros y aves nectarívoras paramunas (colibríes de altura como Eriocnemis vestita, Aglaeactis cupripennis, Pterophanes cyanopterus). En Colombia se distribuye ampliamente en los páramos y subpáramos de las tres cordilleras (Oriental: Sumapaz, Chingaza, Cocuy, Pisba, Santurbán; Central: Los Nevados, Las Hermosas; Occidental: Tatamá, Frontino, Paramillo) entre 2.500 y 4.200 msnm, con óptimo en 3.000-3.800 msnm en pajonales-frailejonales-matorrales paramunos. Lección viva de medicina tradicional andina y sustitución funcional intergenérica: la árnica de páramo es un ejemplo magistral de cómo el conocimiento etnobotánico campesino-indígena colombiano identificó una planta nativa con propiedades farmacológicas similares a la árnica europea de farmacopea oficial — los campesinos paramunos y muiscas-uwa-pijao-yanacona del altiplano cundiboyacense, Sumapaz, Cocuy, Tolima alto y Cauca alto usan tradicionalmente la infusión y maceración alcohólica de S. formosus para los mismos fines que la árnica europea: tratamiento tópico de golpes, contusiones, hematomas, dolores musculares, esguinces, inflamación articular y dolor reumático. La fitoquímica moderna ha confirmado parcialmente este uso al detectar en el género Senecio compuestos sesquiterpénicos (lactonas sesquiterpénicas, principalmente del tipo eremofilano), flavonoides (quercetina, kempferol), alcaloides pirrolizidínicos (PRECAUCIÓN: estos últimos son hepatotóxicos si se administran por vía oral en dosis altas o sostenidas, razón por la cual la árnica de páramo se usa EXCLUSIVAMENTE por vía tópica nunca interna), y aceites esenciales con actividad antiinflamatoria y antimicrobiana. ADVERTENCIA TOXICOLÓGICA: los alcaloides pirrolizidínicos del género Senecio son hepatotóxicos por vía oral; el uso tradicional correcto es EXCLUSIVAMENTE TÓPICO mediante maceración alcohólica para frotaciones externas, NUNCA infusión oral. Uso etnobotánico documentado (García-Barriga 1974 Flora Medicinal de Colombia, Bernal 2015): maceración alcohólica de capítulos florales en alcohol de 70-90° por 21 días, filtrado y aplicación tópica directa sobre el área afectada 3-4 veces/día. Uso prudencial: máximo 7-10 días continuos, evitar aplicación sobre heridas abiertas o piel lesionada, contraindicado embarazo y lactancia. Recolección silvestre paramuna con responsabilidad: solo capítulos florales en plena floración (octubre-febrero), nunca arrancar la planta completa, dejar mínimo 70% de los individuos del rodal sin recolectar para garantizar regeneración natural, NO recolectar dentro de Parques Nacionales Naturales ni Áreas Protegidas Regionales sin permiso de la autoridad ambiental competente. Protección indirecta: la Ley 1930/2018 protege los ecosistemas de páramo donde S. formosus habita, por lo que aunque la especie no está en la lista de especies amenazadas del MADS, su hábitat sí está jurídicamente protegido. Manejo agroecológico (cultivo restringido a finca de alta montaña fría >2.500 msnm): propagación por semilla recolectada de aquenios maduros, siembra en sustrato de turba de páramo + tierra de subpáramo + arena + MO en invernadero frío, germinación 20-45 días, trasplante a bolsa 3-4 meses, plantación definitiva 6-8 meses, asocio con otras medicinales paramunas (Hypericum juniperinum, Disterigma, Bartsia, Pernettya), uso doméstico exclusivo NO COMERCIAL. La árnica de páramo es ejemplo paradigmático de la riqueza farmacológica de la flora paramuna colombiana y de la necesidad de preservar conocimiento etnobotánico tradicional con responsabilidad toxicológica moderna. Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, García-Barriga 1974 Flora Medicinal de Colombia, JBB Jardín Botánico de Bogotá, Humboldt Flora de Páramos."
+    },
+    {
+      "id": "pernettya_prostrata",
+      "nombre_comun": "Pernettya / Mortiño rastrero",
+      "nombre_comunes_regionales": [
+        "pernettya",
+        "mortiño rastrero",
+        "uvilla de páramo",
+        "uvito paramuno",
+        "macha-macha"
+      ],
+      "nombre_cientifico": "Pernettya prostrata (Cav.) DC.",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "paramo",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2800,
+        "optimo_max": 3800,
+        "max_absoluto": 4300
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 3,
+        "optimo_max": 12,
+        "max_tolerable": 18
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 88,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 3.8,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Arbusto rastrero ericáceo de páramo y bosque altoandino con hojas pequeñas coriáceas y bayas esféricas blancas-rosadas-rojas-moradas vistosas. ADVERTENCIA: los frutos de Pernettya contienen glucósidos diterpénicos tóxicos (andromedotoxinas similares a Rhododendron) y aunque hay reporte de consumo tradicional en pequeñas cantidades, su ingesta es POTENCIALMENTE TÓXICA en cantidades moderadas-altas (mareo, convulsiones). NO recomendado para consumo humano libre. Valor ecológico como atractor de aves frugívoras paramunas. Protección indirecta vía Ley 1930/2018 cuando crece dentro de páramos delimitados."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-paramos",
+        "jbb-jardin-botanico-bogota",
+        "luteyn-ericaceae-neotropics"
+      ],
+      "valor_pedagogico": "La pernettya o mortiño rastrero (Pernettya prostrata (Cav.) DC., familia Ericaceae, sinónimo taxonómico moderno Gaultheria myrsinoides Kunth según POWO/Kew aunque tradicionalmente tratada como Pernettya en flora paramuna colombiana) es un arbusto rastrero-postrado típico del páramo, subpáramo y bosque altoandino colombiano, reconocible por sus hojas pequeñas coriáceas verde oscuro brillante con margen aserrado y especialmente por sus bayas esféricas blancas-rosadas-rojas-moradas (4-8 mm diámetro) que cubren la planta en temporada de fructificación (febrero-mayo) dando aspecto de tapete moteado de colores. Es una de las plantas más vistosas y fotografiadas del paisaje paramuno colombiano. En Colombia se distribuye ampliamente en páramos, subpáramos y bosques altoandinos de las tres cordilleras y la Sierra Nevada de Santa Marta entre 2.400 y 4.300 msnm, con óptimo en 2.800-3.800 msnm en pajonales-frailejonales, matorrales paramunos, bordes de bosque altoandino y áreas abiertas postglaciares. Es planta acidófila estricta (pH suelo 4-5.5) típica de suelos turbosos paramunos. Lección viva de ericáceas paramunas y advertencia toxicológica etnobotánica: la familia Ericaceae es una de las familias dominantes de páramo y bosque altoandino con géneros emblemáticos (Pernettya, Gaultheria, Disterigma, Vaccinium, Cavendishia, Macleania, Themistoclesia, Satyria, Bejaria, Befaria) que comparten frutos en baya carnosa atractivos para aves frugívoras (mirlos, tángaras, frugívoros de altura como Diglossa) y muchos también consumidos tradicionalmente por humanos. SIN EMBARGO, el género Pernettya es CASO ESPECIAL de TOXICIDAD: a diferencia de Vaccinium (mortiño negro comestible, Vaccinium meridionale) y de algunos Disterigma comestibles, los frutos de Pernettya prostrata contienen glucósidos diterpénicos del grupo de las andromedotoxinas (también llamadas grayanotoxinas) — los mismos compuestos tóxicos presentes en Rhododendron, Kalmia, Pieris y otras ericáceas ornamentales — que actúan como neurotoxinas y cardiotoxinas en mamíferos al unirse a canales de sodio dependientes de voltaje en membranas neuronales y musculares. La intoxicación por Pernettya en cantidades moderadas-altas produce mareo, vómito, salivación profusa, bradicardia, hipotensión, convulsiones y en casos graves coma o muerte. EXISTE reporte etnobotánico de consumo tradicional en cantidades pequeñas (1-3 bayas) en algunas comunidades andinas (especialmente en Perú-Bolivia donde la planta es llamada 'macha-macha' que significa precisamente 'borrachera-borrachera' por sus efectos psicoactivos en dosis bajas) pero ESTA PRÁCTICA NO ES RECOMENDABLE NI SEGURA para consumo libre por desconocimiento de dosis-respuesta individual. En el contexto pedagógico de la chagra colombiana, P. prostrata se reconoce como planta ornamental nativa paramuna y atractor de fauna frugívora, NO como cultivo comestible. Su valor ecológico es alto: cobertura de suelo en páramo (control de erosión postglaciar), atractor de avifauna frugívora paramuna, planta nodriza para regeneración de ericáceas mayores (Bejaria, Cavendishia), e indicador biogeográfico de suelos turbosos ácidos paramunos. Manejo (no cultivo doméstico recomendado): observación in-situ en páramo, fotografía, valor ornamental in-situ. NO recolectar en Parques Nacionales Naturales sin permiso. Si se requiere propagación para restauración ecológica de páramo degradado, semilla de baya madura recolectada con permiso CAR, siembra en sustrato turba ericáceo (pH 4-5) con arena, germinación 30-60 días, trasplante 4-6 meses, plantación definitiva 8-10 meses. Asocio con Calamagrostis, Hypericum juniperinum, Disterigma empetrifolium, Bartsia santolinifolia, otras ericáceas paramunas. Pernettya es lección sobre cómo la biodiversidad paramuna combina belleza visual, valor ecológico, riqueza etnobotánica y advertencias toxicológicas importantes que el conocimiento tradicional y la fitoquímica moderna deben integrar con responsabilidad. Fuentes Tier A: POWO Kew (sinonimia Gaultheria myrsinoides), GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Humboldt Flora de Páramos, JBB Jardín Botánico de Bogotá, Luteyn Ericaceae of the Neotropics."
+    },
+    {
+      "id": "hypericum_juniperinum",
+      "nombre_comun": "Hipérico de páramo",
+      "nombre_comunes_regionales": [
+        "hipérico paramuno",
+        "chite",
+        "chite de páramo",
+        "hypericum juniperinum"
+      ],
+      "nombre_cientifico": "Hypericum juniperinum Kunth",
+      "familia_botanica": "Hypericaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "paramo",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "dynamic_accumulator",
+        "pollinator_attractor"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2700,
+        "optimo_min": 3000,
+        "optimo_max": 3800,
+        "max_absoluto": 4200
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 2,
+        "optimo_max": 11,
+        "max_tolerable": 18
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 88,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Arbusto bajo paramuno endémico de Andes colombianos-venezolano-ecuatorianos con hojas pequeñas escamiformes tipo junípero (de ahí el epíteto) y flores amarillas vistosas con muchos estambres prominentes característicos de Hypericum. Pariente neotropical del hipérico europeo (Hypericum perforatum) usado como antidepresivo natural. Contiene hipericina, hiperforina y flavonoides con actividad antidepresiva-ansiolítica-antiinflamatoria-antibacteriana. Protección indirecta por Ley 1930/2018 dentro de páramos delimitados."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "garcia-barriga-flora-medicinal-colombia",
+        "humboldt-flora-paramos",
+        "robson-hypericum-monograph"
+      ],
+      "valor_pedagogico": "El hipérico de páramo o chite (Hypericum juniperinum Kunth, familia Hypericaceae) es un arbusto bajo paramuno endémico de los Andes colombianos-venezolano-ecuatorianos, pariente neotropical del célebre hipérico europeo o hierba de San Juan (Hypericum perforatum L.) usado en farmacopea fitoterapéutica europea como antidepresivo natural validado por meta-análisis clínicos. Es una de las plantas más distintivas del paisaje paramuno colombiano por su porte denso ramoso (30-80 cm altura), sus hojas pequeñas escamiformes verde-oscuras tipo junípero (de ahí el epíteto específico 'juniperinum' = parecido a Juniperus, el género del enebro europeo) que cubren los tallos en disposición decussada apretada, y especialmente por sus flores amarillas vistosas (1.5-2.5 cm diámetro) con cinco pétalos amarillo-dorados y un denso penacho central de numerosos estambres amarillos prominentes — patrón floral diagnóstico del género Hypericum a nivel mundial. En Colombia se distribuye en páramos y subpáramos de las tres cordilleras (Oriental: Sumapaz, Chingaza, Cocuy, Pisba, Santurbán, Almorzadero; Central: Los Nevados, Las Hermosas, Puracé; Occidental: Tatamá, Frontino-Urrao, Paramillo) entre 2.700 y 4.200 msnm, con óptimo en 3.000-3.800 msnm en frailejonales-pajonales-matorrales paramunos asociado a Espeletia, Calamagrostis, Disterigma, Pernettya, Bartsia, Diplostephium, Pentacalia y otras especies del cortejo florístico paramuno. Lección viva de farmacognosia comparada neotrópico-paleártico y de medicina tradicional andina: el género Hypericum incluye ~500 especies de distribución cosmopolita con un perfil fitoquímico característico globalmente conservado — naftodiantronas (hipericina, pseudohipericina), floroglucinoles (hiperforina, adhiperforina), flavonoides (quercetina, rutina, hiperósido, quercitrina, isoquercitrina), xantonas, taninos catequínicos y aceite esencial — que confieren al género propiedades farmacológicas validadas: actividad antidepresiva-ansiolítica (por inhibición de recaptación de serotonina, dopamina, noradrenalina y GABA por la hiperforina), antiinflamatoria, cicatrizante tópica, antibacteriana, antiviral (incluyendo actividad contra herpes virus por la hipericina foto-activada) y diurética suave. En Colombia el chite de páramo H. juniperinum (junto con su pariente cercano H. mexicanum) es la sustitución funcional nativa del H. perforatum europeo en la medicina tradicional muisca-uwa-pijao y campesina andina del altiplano cundiboyacense y Cocuy. García-Barriga (1974 Flora Medicinal de Colombia) documenta uso etnobotánico ancestral del chite paramuno en infusión y maceración alcohólica para: tratamiento de melancolía-tristeza-decaimiento (uso 'antidepresivo' tradicional), heridas-quemaduras-úlceras (uso cicatrizante tópico), inflamación urinaria (uso diurético-antiséptico genitourinario), dolor reumático y articular (uso antiinflamatorio tópico) y trastornos del sueño-ansiedad nocturna (uso ansiolítico-hipnótico suave). Uso etnobotánico tradicional (precaución farmacológica importante): infusión 1-2 g de sumidades floridas en 200 ml agua hirviendo 10 min, 1-2 tazas/día, máximo 4-6 semanas continuas. PRECAUCIÓN FARMACOLÓGICA: el género Hypericum (incluido H. juniperinum por analogía fitoquímica) es FOTOSENSIBILIZANTE — la hipericina activada por luz UV solar provoca dermatitis fotosensible en piel expuesta, especialmente en personas de piel clara, ganado bovino-ovino-caprino que pasta H. perforatum en regiones templadas. Más crítico aún, Hypericum es INDUCTOR POTENTE del citocromo P450 (especialmente CYP3A4 y CYP2C9) y de la glicoproteína P, lo que produce INTERACCIONES FARMACOLÓGICAS PELIGROSAS con: anticonceptivos orales (reducción de eficacia, riesgo de embarazo no deseado), warfarina y anticoagulantes (reducción de efecto anticoagulante con riesgo trombótico), ciclosporina y tacrolimus (riesgo de rechazo de injerto en trasplantados), antirretrovirales (especialmente indinavir y otros inhibidores de proteasa con reducción de niveles plasmáticos), digoxina, teofilina, antidepresivos ISRS (riesgo de síndrome serotoninérgico por suma de mecanismo). El uso del chite paramuno requiere supervisión médica calificada si la persona toma alguna de estas medicaciones. Recolección silvestre con responsabilidad: solo sumidades floridas en floración (octubre-febrero), nunca arrancar la planta completa, dejar >70% del rodal sin recolectar para regeneración, NO recolectar dentro de Parques Nacionales Naturales sin permiso. Manejo agroecológico (cultivo restringido a finca alta montaña fría >2.500 msnm): propagación por semilla en sustrato turba paramuna + arena + MO en invernadero frío, germinación 30-60 días, trasplante a bolsa 4-6 meses, plantación definitiva 8-10 meses, asocio con otras medicinales paramunas (Senecio formosus, Bartsia, Disterigma) en huertos pedagógicos de alta montaña. Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, García-Barriga 1974 Flora Medicinal de Colombia, Humboldt Flora de Páramos, Robson Hypericum Monograph (Kew)."
+    },
+    {
+      "id": "bartsia_santolinifolia",
+      "nombre_comun": "Santolina paramuna",
+      "nombre_comunes_regionales": [
+        "santolina de páramo",
+        "bartsia santolinifolia",
+        "santolina paramuna",
+        "trompetilla paramuna"
+      ],
+      "nombre_cientifico": "Bartsia santolinifolia (Kunth) Benth.",
+      "familia_botanica": "Orobanchaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2800,
+        "optimo_min": 3200,
+        "optimo_max": 3900,
+        "max_absoluto": 4300
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 2,
+        "optimo_max": 10,
+        "max_tolerable": 17
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 90,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 5.8,
+        "max": 6.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Hierba perenne paramuna hemiparásita facultativa de raíces de otras especies (Orobanchaceae es familia de plantas parásitas y hemiparásitas), con hojas pequeñas finamente divididas (parecidas a las de santolina mediterránea, de ahí el epíteto), tallos erectos y flores tubulares moradas-violáceas vistosas atractivas para colibríes de altura. Ecológicamente compleja: requiere asocio radicular con planta hospedera (pajonal de Calamagrostis o frailejón). NO cultivable en condiciones convencionales por dependencia obligada de hospedera. Valor in-situ paramuno."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-paramos",
+        "molau-bartsia-monograph",
+        "jbb-jardin-botanico-bogota"
+      ],
+      "valor_pedagogico": "La santolina paramuna o trompetilla de páramo (Bartsia santolinifolia (Kunth) Benth., familia Orobanchaceae, anteriormente clasificada en Scrophulariaceae sensu lato antes de la reorganización filogenética de las Lamiales) es una hierba perenne paramuna emblemática de los frailejonales-pajonales colombianos, reconocible por sus hojas pequeñas finamente divididas (lobulado-pinnadas, 1-3 cm largo) muy similares en aspecto a las de la santolina mediterránea (Santolina chamaecyparissus) — de ahí el epíteto específico 'santolinifolia' = con hojas de santolina —, sus tallos erectos cespitosos de 10-40 cm altura, y especialmente por sus flores tubulares vistosas (2-3 cm largo) de corola morada-violácea intensa con dos labios bilabiados (labio superior estrecho-galeado, labio inferior trilobado) que la hacen una de las plantas más atractivas visualmente del paisaje paramuno colombiano y un importante recurso nectarífero para colibríes de altura. En Colombia se distribuye en páramos y subpáramos de las tres cordilleras (Oriental: Sumapaz, Chingaza, Cocuy, Pisba, Santurbán; Central: Los Nevados, Las Hermosas, Puracé, Doña Juana; Occidental: Frontino-Urrao, Paramillo, Tatamá) entre 2.800 y 4.300 msnm, con óptimo en 3.200-3.900 msnm en pajonales de Calamagrostis, frailejonales de Espeletia y matorrales paramunos de Diplostephium-Pentacalia-Hypericum. Lección viva de parasitismo radicular vegetal en ecosistemas paramunos y de evolución de Orobanchaceae: la familia Orobanchaceae es una familia botánicamente fascinante porque incluye un gradiente evolutivo completo desde plantas autótrofas no parásitas (Lindenbergia) hasta hemiparásitas facultativas (Bartsia, Pedicularis, Castilleja, Euphrasia, Rhinanthus, Odontites — que tienen clorofila y fotosintetizan pero también extraen agua y nutrientes minerales de raíces de plantas hospederas a través de órganos especializados llamados haustorios) hasta holoparásitas obligadas (Orobanche, Cistanche, Phelipanche, Striga, Conopholis, Aphyllon — que carecen de clorofila completa y dependen 100% del flujo de fotosintatos del hospedero). Bartsia santolinifolia es HEMIPARÁSITA FACULTATIVA: contiene clorofila y fotosintetiza pero también desarrolla haustorios radiculares que penetran en las raíces de plantas hospederas (típicamente gramíneas paramunas como Calamagrostis effusa, Calamagrostis bogotensis, Festuca dolichophylla, Agrostis perennans y en menor grado frailejones de Espeletia y otras dicotiledóneas paramunas) de las cuales extrae agua, nitrógeno mineral, fósforo, potasio y otros nutrientes minerales que complementan su nutrición autotrófica. Esta estrategia mixta hemiparásita le da ventaja competitiva en suelos paramunos pobres en nutrientes y secos por exposición a viento-radiación-helada. La consecuencia ecológica práctica es enorme: B. santolinifolia (y todas las Bartsia/Pedicularis/Castilleja paramunas) son ECOLÓGICAMENTE NO-AISLABLES de sus hospederas. Cualquier intento de cultivo ex-situ en jardín-vivero requiere presencia obligada de Calamagrostis u otra hospedera apropiada en el mismo macetón-cantero; el cultivo en monocultivo aislado fracasa por carencia de fuente haustorial. Esta dependencia obligada con el cortejo florístico paramuno hace que B. santolinifolia sea una especie indicadora robusta de integridad ecosistémica paramuna: solo persiste en páramos con cobertura de pajonal-frailejonal funcional, declina rápidamente con degradación por quema-pastoreo-minería. Servicio ecosistémico: recurso nectarífero estratégico para avifauna nectarívora paramuna especializada — colibríes de altura como Eriocnemis cupreoventris (zamarrito cobrizo), Eriocnemis vestita (calzadito gorgiazul), Aglaeactis cupripennis (rayito brillante), Pterophanes cyanopterus (alas grandes alizafiro), Lesbia victoriae (cola larga azul), Oxypogon guerinii (chivito), Aglaiocercus kingii (cola larga verdiazul), Coeligena lutetiae (incaco coliplomo). La flor tubular morada de B. santolinifolia es coevolutivamente apropiada al pico-recto-largo de estos colibríes. Manejo (NO cultivo doméstico recomendado por dependencia obligada de hospedera y por pertenencia a ecosistema paramuno protegido por Ley 1930/2018): observación in-situ en páramo, fotografía, estudio ecológico. NO recolectar en Parques Nacionales Naturales sin permiso CAR. Si se requiere para restauración ecológica de páramo degradado, propagación por semilla en asocio obligado con Calamagrostis (siembra simultánea de pajonal + Bartsia), germinación 30-60 días, plantación definitiva 8-10 meses asociada a pajonal establecido, asocio con otras especies paramunas (Espeletia, Hypericum, Disterigma, Pernettya, Senecio). Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Humboldt Flora de Páramos, Molau Bartsia Monograph, JBB Jardín Botánico de Bogotá."
+    },
+    {
+      "id": "lupinus_alopecuroides",
+      "nombre_comun": "Chocho de páramo",
+      "nombre_comunes_regionales": [
+        "chocho paramuno",
+        "lupino de páramo",
+        "lupinus alopecuroides",
+        "tarwi de páramo",
+        "altramuz andino"
+      ],
+      "nombre_cientifico": "Lupinus alopecuroides Desr.",
+      "familia_botanica": "Fabaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "pollinator_attractor"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 3200,
+        "optimo_min": 3500,
+        "optimo_max": 4200,
+        "max_absoluto": 4500
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 1,
+        "optimo_max": 9,
+        "max_tolerable": 16
+      },
+      "humedad_relativa_pct": {
+        "min": 65,
+        "optimo": 85,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 6,
+        "max": 6.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Lupino de páramo nativo de Andes ecuatorianos-colombianos a alta montaña fría (3.500-4.500 msnm). Distinto del lupinus_mutabilis (tarwi-chocho andino cultivado en zona fría 2.500-3.500 msnm). Roseta basal densa con tallo floral robusto (50-150 cm) cubierto de inflorescencias densas blanco-azuladas-violáceas. Fija nitrógeno por nodulación rhizobiana en suelos paramunos pobres. NO COMESTIBLE: alcaloides quinolizidínicos amargos y tóxicos sin desamargado. Valor ecológico como fijador de N en paramos degradados y atractor nectarífero. Protección indirecta por Ley 1930/2018 dentro de páramos delimitados."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-paramos",
+        "eastwood-lupinus-monograph",
+        "jbb-jardin-botanico-bogota"
+      ],
+      "valor_pedagogico": "El chocho de páramo (Lupinus alopecuroides Desr., familia Fabaceae) es un lupino paramuno endémico de los Andes ecuatorianos-colombianos, especie distinta y CON CARACTERÍSTICAS BIOLÓGICAS DIFERENTES al célebre lupinus_mutabilis Sweet (tarwi-chocho andino, cultivo comestible domesticado de la cordillera andina entre 2.500-3.500 msnm en zona fría) — esta distinción es importante pedagógicamente para evitar confusión entre las dos especies del mismo género en el catálogo de Chagra. L. alopecuroides es planta silvestre paramuna no domesticada, propia de páramo medio-superior y superpáramo entre 3.200 y 4.500 msnm (zona térmica de páramo fría-extrema), mientras que L. mutabilis es cultivo domesticado de zona fría templada (2.500-3.500 msnm) tradicionalmente desamargado y consumido por culturas andinas. Es una herbácea perenne robusta con roseta basal densa de hojas digitado-palmadas (7-11 folíolos oblanceolados) verdoso-plateadas pubescentes, tallo floral erecto vigoroso de 50-150 cm cubierto en su porción apical por una inflorescencia espigada densa larga (20-50 cm) con numerosas flores papilionadas (típicas de Fabaceae) blanco-azuladas a violáceo-azuladas intensas, similar en aspecto general al lupino europeo ornamental (Lupinus polyphyllus) pero adaptada a condiciones paramunas extremas: viento permanente, helada nocturna recurrente, radiación UV-B intensa de altura, suelo turboso ácido pobre en N. Es una de las plantas más vistosas del superpáramo colombiano y una de las pocas leguminosas paramunas presentes en el cortejo florístico del frailejonal-pajonal. En Colombia se distribuye principalmente en páramos altos y superpáramos de la cordillera Central (Los Nevados, Las Hermosas, Doña Juana) y Oriental (Sumapaz, Cocuy, Pisba, Santurbán) entre 3.200 y 4.500 msnm con óptimo en 3.500-4.200 msnm en superpáramo de tipo zonal-azonal y pajonal-frailejonal con presencia de afloramientos rocosos. Lección viva de fijación biológica de nitrógeno (BNF) en ecosistemas paramunos y de quimio-defensa por alcaloides quinolizidínicos: como toda Fabaceae, L. alopecuroides tiene nódulos radiculares simbióticos con bacterias del género Bradyrhizobium (Rhizobiaceae sensu lato) que fijan nitrógeno atmosférico (N₂) convirtiéndolo en amonio (NH₄⁺) asimilable por la planta. Esta capacidad es ESTRATÉGICA en páramos donde el N disponible es extremadamente limitante por: (1) bajas temperaturas que ralentizan la mineralización de la MO turbosa, (2) alta acidez del suelo (pH 4-5.5) que inhibe la nitrificación bacteriana, (3) lixiviación intensa por alta precipitación, y (4) volatilización por viento permanente. L. alopecuroides es por lo tanto un FERTILIZADOR BIOLÓGICO NATURAL del páramo, aumentando la disponibilidad de N para otras especies del cortejo florístico (Calamagrostis, Espeletia, Hypericum) y constituyendo nodo clave del ciclo biogeoquímico del nitrógeno paramuno. Por otra parte, L. alopecuroides (como casi todos los lupinos silvestres no domesticados) contiene altas concentraciones de alcaloides quinolizidínicos amargos y tóxicos: lupinina, lupanina, esparteína, isolupanina, anagirina, y otros (perfil fitoquímico que da nombre al grupo de 'lupinos amargos' versus 'lupinos dulces' de bajo contenido alcaloídico que es donde se ubica el cultivo domesticado L. mutabilis tras siglos de selección campesina andina). Estos alcaloides son neurotóxicos en mamíferos (bloqueo de receptores nicotínicos de acetilcolina, depresión del SNC, convulsiones, parálisis respiratoria en dosis altas) y tienen además función ecológica defensiva contra herbivoría (rumiantes, roedores, insectos). Por esta razón el chocho de páramo NO ES COMESTIBLE en su estado natural — no debe consumirse las semillas ni las hojas. Su pariente cultivado L. mutabilis sí es comestible PERO solo después del proceso ancestral andino de desamargado por lavado prolongado (>4-7 días en agua corriente) que lixivia los alcaloides solubles en agua, técnica desarrollada por las culturas pre-incaicas y conservada por campesinos andinos en Boyacá, Cundinamarca, Nariño, Ecuador, Perú y Bolivia. Servicio ecosistémico de L. alopecuroides: fijación de N en suelos paramunos pobres (40-100 kg N/ha/año en condiciones favorables), atractor nectarífero importante para abejorros andinos (Bombus rohweri, Bombus funebris) y otros himenópteros paramunos, polinización por vibración (buzz pollination), planta nodriza para regeneración de especies pioneras post-disturbio, indicador de páramo en condiciones bien conservadas. Manejo (no cultivo comestible recomendado por su toxicidad alcaloídica y por su carácter silvestre paramuno protegido por Ley 1930/2018): observación in-situ, valor ornamental in-situ, valor ecológico como fijador de N en proyectos de restauración paramuna autorizados. Propagación para restauración (con permiso CAR): semilla escarificada (testa muy dura, escarificación mecánica o térmica con agua caliente 50°C por 30 min seguido de remojo 24h en agua fría), siembra en sustrato turba paramuna + arena, germinación 30-90 días, plantación definitiva 8-12 meses, asocio con pajonal-frailejonal, exclusión ganadera. Distinción pedagógica: si quieres tarwi-chocho comestible cultivable en chagra fría, busca lupinus_mutabilis (especie distinta ya incluida en catálogo Chagra). Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Humboldt Flora de Páramos, Eastwood Lupinus Monograph, JBB Jardín Botánico de Bogotá."
+    },
+    {
+      "id": "loricaria_complanata",
+      "nombre_comun": "Escobilla paramuna",
+      "nombre_comunes_regionales": [
+        "escobilla de páramo",
+        "loricaria",
+        "loricaria complanata",
+        "ciprés paramuno"
+      ],
+      "nombre_cientifico": "Loricaria complanata (Sch.Bip.) Wedd.",
+      "familia_botanica": "Asteraceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 3000,
+        "optimo_min": 3400,
+        "optimo_max": 4100,
+        "max_absoluto": 4400
+      },
+      "temperatura_c": {
+        "helada_letal": -14,
+        "optimo_min": 2,
+        "optimo_max": 10,
+        "max_tolerable": 17
+      },
+      "humedad_relativa_pct": {
+        "min": 65,
+        "optimo": 85,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 5.8,
+        "max": 6.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Arbusto paramuno típico de superpáramo de las cordilleras colombianas con hojas escamiformes diminutas imbricadas que dan apariencia de junípero o ciprés enano (de ahí el nombre vernáculo 'ciprés paramuno'), porte denso con ramas aplanadas, hojas pequeñas verde-grisáceas, e inflorescencias pequeñas con capítulos amarillos en panículas terminales. Crecimiento muy lento. Indicador de superpáramo bien conservado. Protección indirecta por Ley 1930/2018 dentro de páramos delimitados."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-paramos",
+        "cuatrecasas-loricaria-revision",
+        "jbb-jardin-botanico-bogota"
+      ],
+      "valor_pedagogico": "La escobilla paramuna o ciprés de páramo (Loricaria complanata (Sch.Bip.) Wedd., familia Asteraceae) es un arbusto característico del superpáramo colombiano y de la línea altitudinal alta del páramo medio, una de las plantas más distintivas y morfológicamente curiosas del paisaje paramuno andino por su aspecto ericoide-cupresoide que la hace parecer un junípero o ciprés enano más que una Asteraceae típica. Es un arbusto perenne erecto-ramoso de 30-150 cm altura con tallos densamente ramificados, ramas aplanadas (de ahí el epíteto específico 'complanata' = aplanada), hojas escamiformes diminutas (1-3 mm largo) imbricadas en disposición decussada apretada cubriendo completamente los tallos verde-grisáceos plateados, e inflorescencias pequeñas con capítulos amarillos discretos agrupados en panículas terminales típicas de Asteraceae. La morfología foliar escamiforme imbricada — muy distinta de la morfología foliar típica de Asteraceae herbáceas — es un excelente ejemplo de CONVERGENCIA EVOLUTIVA con coníferas (Cupressaceae como Juniperus, Cupressus, Chamaecyparis) y con ericáceas reducidas (Erica, Calluna, Empetrum, Disterigma, Pernettya): adaptación morfológica al estrés climático de alta montaña (xericidad fisiológica por viento permanente, radiación UV-B intensa, helada nocturna, baja presión parcial de CO₂ por altitud) que se manifiesta repetidamente en linajes filogenéticamente distintos como solución estructural similar (hojas pequeñas escamiformes que minimizan superficie de transpiración y maximizan resistencia mecánica al viento). En Colombia se distribuye principalmente en superpáramo y páramo alto de la cordillera Central (Los Nevados, Las Hermosas, Doña Juana, Puracé) y Oriental (Sumapaz, Cocuy, Pisba, Santurbán) entre 3.000 y 4.400 msnm, con óptimo en 3.400-4.100 msnm en superpáramo zonal-azonal de tipo rocoso o turboso, en pajonal-frailejonal de transición a superpáramo, y en afloramientos rocosos de páramo alto. Es indicador robusto de superpáramo bien conservado: solo persiste en sitios con cobertura paramuna funcional poco perturbada por ganadería-quema-minería. Lección viva de convergencia evolutiva morfológica en alta montaña y de diversidad de Asteraceae paramunas colombianas: el género Loricaria (con ~20 especies neotropicales andinas y centroamericanas) es uno de los géneros más fascinantes de Asteraceae andinas por su morfología engañosa que ha confundido a botánicos por más de un siglo — el primer autor que describió el género fue Weddell en 1856 en su 'Chloris Andina'. La revisión taxonómica moderna del género por Cuatrecasas confirmó su pertenencia a Asteraceae tribu Gnaphalieae (subtribu Loricariinae) — el mismo grupo de las inmortales (Helichrysum, Anaphalis) y de las cespitosas paramunas (Antennaria, Belloa, Lucilia, Mniodes). El cortejo florístico paramuno colombiano incluye múltiples Asteraceae con morfologías especializadas a alta montaña: Espeletia (frailejones, roseta caulescente), Diplostephium (arbustos ericoides), Pentacalia (arbustos pubescentes), Senecio (rosetas herbáceas), Baccharis (chilcas), Aphanactis (postradas), Werneria (rosetas acolchonadas), Belloa-Lucilia (cespitosas plateadas) y Loricaria (escamiformes ericoides) — una diversificación adaptativa espectacular dentro de la familia Asteraceae en el ecosistema paramuno. El crecimiento extremadamente lento de Loricaria (estimado en 0.3-0.6 cm/año, individuos de 1 m con ~200 años de edad) y su distribución restringida al superpáramo bien conservado hacen que sea especie sensible a degradación: declina rápidamente con quema, pisoteo ganadero excesivo, minería ilegal de superpáramo, y especialmente con cambio climático que está moviendo el ecotono páramo-glaciar hacia arriba en respuesta al deshielo glaciar acelerado de los nevados colombianos (Pan de Azúcar-Cocuy, Ruiz-Tolima, Huila, Santa Isabel, Cisne, Quindío, Puracé, Chiles). Servicio ecosistémico: regulación hídrica en superpáramo (captura niebla por superficie foliar imbricada), planta nodriza para regeneración de otras especies superparamunas en sitios degradados, indicador biogeográfico de integridad ecosistémica paramuna alta. Manejo (no cultivo doméstico recomendado por carácter silvestre paramuno protegido por Ley 1930/2018, crecimiento extremadamente lento y dependencia de condiciones de superpáramo): observación in-situ, valor ornamental in-situ, valor ecológico en proyectos de restauración paramuna autorizados por CAR. Si se requiere propagación para restauración (con permiso CAR-CORPORINOQUIA-CORPOAMAZONIA), semilla recolectada de inflorescencias maduras (febrero-mayo), siembra en sustrato turba superparamuna + arena gruesa, germinación 30-90 días en invernadero alta montaña, plantación definitiva >12 meses a 30-50 cm, asocio con Espeletia, Calamagrostis, Hypericum, Disterigma, Pernettya, otras especies superparamunas. Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Humboldt Flora de Páramos, Cuatrecasas Loricaria Revision, JBB Jardín Botánico de Bogotá."
+    },
+    {
+      "id": "disterigma_empetrifolium",
+      "nombre_comun": "Mortiño rastrero ericáceo",
+      "nombre_comunes_regionales": [
+        "disterigma",
+        "uvillito de páramo",
+        "mortiño rastrero",
+        "uvito ericáceo"
+      ],
+      "nombre_cientifico": "Disterigma empetrifolium (Kunth) Drude",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "paramo",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2500,
+        "optimo_min": 2900,
+        "optimo_max": 3700,
+        "max_absoluto": 4200
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 3,
+        "optimo_max": 12,
+        "max_tolerable": 18
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 90,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 3.8,
+        "optimo_min": 4.3,
+        "optimo_max": 5.3,
+        "max": 5.8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Arbusto rastrero ericáceo de páramo y bosque altoandino, con hojas pequeñas coriáceas similares a las de Empetrum (de ahí el epíteto 'empetrifolium' = con hojas de Empetrum), flores tubulares blanco-rosadas pequeñas y bayas esféricas blanco-traslúcidas, blanco-rosadas o moradas (4-7 mm diámetro) DULCES y COMESTIBLES en pequeñas cantidades — a diferencia de Pernettya que es tóxica, Disterigma es generalmente comestible aunque no consumida extensivamente. Atractor de fauna paramuna frugívora. Protección indirecta por Ley 1930/2018."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "luteyn-ericaceae-neotropics",
+        "humboldt-flora-paramos",
+        "jbb-jardin-botanico-bogota"
+      ],
+      "valor_pedagogico": "El disterigma o mortiño rastrero ericáceo (Disterigma empetrifolium (Kunth) Drude, familia Ericaceae) es un arbusto rastrero-postrado típico de páramo y bosque altoandino colombiano, una de las ericáceas más abundantes del cortejo florístico paramuno y un excelente ejemplo de la diversidad ericácea andina. Es un arbusto enano postrado-rastrero de 5-30 cm altura con tallos largos extendidos sobre el suelo turboso, hojas pequeñas coriáceas verde-oscuro brillantes (3-8 mm largo) con margen entero revoluto similar en aspecto a las hojas del crowberry europeo Empetrum nigrum (de ahí el epíteto específico 'empetrifolium' = con hojas de Empetrum), flores tubulares-urceoladas blanco-rosadas pequeñas (3-5 mm largo) en grupos axilares, y especialmente sus bayas esféricas (4-7 mm diámetro) blanco-traslúcidas, blanco-rosadas o moradas-oscuras que cubren la planta en temporada de fructificación (marzo-junio). Las bayas de Disterigma son comestibles en pequeñas cantidades — a DIFERENCIA del género hermano Pernettya (también ericáceo paramuno) que contiene andromedotoxinas tóxicas (ver pernettya_prostrata) — y han sido consumidas tradicionalmente por campesinos paramunos, niños pastores y caminantes de páramo en bocados oportunistas. Sin embargo, su consumo no es extensivo por el tamaño pequeño de las bayas, la dispersión espacial del recurso y el bajo rendimiento por unidad de área en comparación con el mortiño negro mayor (Vaccinium meridionale) que sí es cultivado-aprovechado comercialmente en Colombia. En Colombia se distribuye ampliamente en páramos, subpáramos y bosques altoandinos de las tres cordilleras y la Sierra Nevada de Santa Marta entre 2.500 y 4.200 msnm, con óptimo en 2.900-3.700 msnm en pajonales-frailejonales, matorrales paramunos, bordes de bosque altoandino y turberas paramunas. Es planta acidófila estricta (pH suelo 3.8-5.3) típica de suelos turbosos paramunos con micorrizas ericoides obligadas (ver más abajo). Lección viva de simbiosis micorrízica ericoide y de adaptación ericácea a suelos paramunos extremos: como TODAS las Ericaceae (familia que incluye además de Disterigma a Pernettya, Vaccinium, Gaultheria, Cavendishia, Macleania, Themistoclesia, Satyria, Bejaria, Befaria, y a nivel global Rhododendron, Erica, Calluna, Vaccinium-arándano, blueberry, cranberry, manzanita), Disterigma empetrifolium tiene una asociación micorrízica OBLIGADA muy especializada llamada MICORRIZA ERICOIDE (ErM), formada con hongos ascomicetos del género Rhizoscyphus (anteriormente Hymenoscyphus ericae) y otros taxones ericoides. Esta simbiosis es estratégica en suelos paramunos por: (1) el suelo turboso de páramo es extremadamente ácido (pH 3.5-5.5) y rico en MO refractaria pero pobre en N-P disponibles por inhibición microbiana de descomposición, (2) los hongos ericoides poseen enzimas extracelulares (proteasas, quitinasas, fosfatasas) capaces de hidrolizar MO compleja y liberar N-P para la planta hospedera, (3) tolerancia compartida a aluminio y metales pesados acumulados en turberas paramunas, (4) provisión hídrica complementaria en períodos secos. Esta dependencia obligada con hongos ericoides es la razón por la cual la propagación ex-situ de Disterigma (y de la mayoría de ericáceas paramunas) es extraordinariamente difícil: cualquier intento de cultivo en sustrato esterilizado o sin inóculo ericoide apropiado fracasa por falta de simbiosis funcional. La estrategia exitosa es trasplante con cepellón completo de turba paramuna que contenga propágulos fúngicos endógenos. Servicio ecosistémico paramuno: cobertura de suelo en páramo (control de erosión post-glaciar, retención de turba), atractor de avifauna frugívora paramuna (mirlos paramunos Turdus fuscater quindio, tángaras de altura, Diglossa de páramo), planta nodriza para regeneración de ericáceas mayores (Bejaria, Cavendishia, Macleania, Vaccinium), e indicador biogeográfico de suelos turbosos ácidos paramunos. Manejo agroecológico (cultivo restringido a finca alta montaña fría >2.500 msnm con presencia de sustrato turboso paramuno): propagación por semilla de baya madura en sustrato turba ericáceo paramuno con micorrizas ericoides obligadas (NO sustrato esterilizado), germinación 30-90 días, trasplante a bolsa 6-8 meses, plantación definitiva 10-14 meses, exclusión ganadera, asocio con Calamagrostis, Hypericum, Bartsia, Pernettya, otras ericáceas paramunas. Diferenciación pedagógica importante con Pernettya: aunque ambas son ericáceas paramunas de morfología similar con bayas vistosas, Disterigma empetrifolium es COMESTIBLE en pequeñas cantidades mientras Pernettya prostrata es POTENCIALMENTE TÓXICA por andromedotoxinas (ver pernettya_prostrata). En campo se distinguen por: (1) tamaño de baya (Disterigma 4-7 mm, Pernettya 4-8 mm — similar), (2) color de baya (Disterigma blanco-rosado-morado-traslúcido, Pernettya blanco-rosado-rojo-morado con tonalidades más intensas), (3) sabor (Disterigma dulce-insípido, Pernettya amargo-acre con ardor en mucosa oral), (4) presentación floral (Disterigma flores agrupadas en grupos axilares de 2-5, Pernettya flores solitarias o pareadas), (5) reacción al masticar (Pernettya provoca rápidamente sensación de ardor-anestesia en labios-lengua característica). En caso de duda en campo, NUNCA consumir baya ericácea paramuna sin identificación experta. Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Luteyn Ericaceae of the Neotropics, Humboldt Flora de Páramos, JBB Jardín Botánico de Bogotá."
+    },
+    {
+      "id": "paepalanthus_columbiensis",
+      "nombre_comun": "Paja paramuna",
+      "nombre_comunes_regionales": [
+        "paepalanthus",
+        "paja de páramo",
+        "paepalanthus columbiensis",
+        "estrellita paramuna",
+        "botoncillo de páramo"
+      ],
+      "nombre_cientifico": "Paepalanthus columbiensis Ruhland",
+      "familia_botanica": "Eriocaulaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2900,
+        "optimo_min": 3200,
+        "optimo_max": 3900,
+        "max_absoluto": 4200
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 2,
+        "optimo_max": 10,
+        "max_tolerable": 17
+      },
+      "humedad_relativa_pct": {
+        "min": 75,
+        "optimo": 92,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "moderado",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Hierba paramuna cespitosa de la familia Eriocaulaceae (familia monocotiledónea pequeña de plantas paludícolas-paramunas neotropicales-paleotropicales), con roseta basal de hojas lineares-ensiformes y escapos florales delgados (5-30 cm) que terminan en capítulos esféricos blanco-grisáceos de aspecto de botón (de ahí el nombre 'botoncillo de páramo' o 'estrellita paramuna'). Indicador de turberas paramunas húmedas. Endémico de páramos colombianos según epíteto específico. Protección indirecta por Ley 1930/2018."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "humboldt-flora-paramos",
+        "giulietti-eriocaulaceae-monograph",
+        "jbb-jardin-botanico-bogota"
+      ],
+      "valor_pedagogico": "La paja paramuna o botoncillo de páramo (Paepalanthus columbiensis Ruhland, familia Eriocaulaceae) es una hierba paramuna cespitosa endémica de los páramos colombianos (el epíteto específico 'columbiensis' indica precisamente su tipificación en territorio colombiano), una de las plantas más distintivas y delicadas del paisaje paramuno por su morfología característica de roseta basal compacta de hojas lineares-ensiformes verde-grisáceas (5-15 cm largo, 2-5 mm ancho) y especialmente por sus escapos florales delgados erectos (5-30 cm altura) que terminan en capítulos esféricos blanco-grisáceos a blanco-amarillentos (5-10 mm diámetro) de aspecto curioso de botón o estrellita — patrón floral típico del género Paepalanthus que da nombre a los nombres vernáculos populares 'botoncillo de páramo' o 'estrellita paramuna'. En Colombia se distribuye en páramos y subpáramos de las tres cordilleras (Oriental: Sumapaz, Chingaza, Cocuy, Pisba, Santurbán; Central: Los Nevados, Las Hermosas, Puracé; Occidental: Tatamá, Frontino-Urrao, Paramillo) entre 2.900 y 4.200 msnm, con óptimo en 3.200-3.900 msnm en turberas paramunas, bordes de pantanos paramunos, manantiales paramunos y suelos turbosos húmedos del subpáramo-páramo medio. Es planta indicadora robusta de TURBERAS PARAMUNAS HÚMEDAS — los ecosistemas más vulnerables y biogeoquímicamente importantes del páramo por su función de almacenamiento masivo de carbono orgánico y de regulación hídrica de cuencas altas. Lección viva de Eriocaulaceae neotropicales y de biogeoquímica de turberas paramunas: la familia Eriocaulaceae es una familia botánicamente fascinante de monocotiledóneas paludícolas-paramunas-rupícolas distribuida principalmente en los neotrópicos y en menor medida en el paleotrópico (África-Asia tropical-Australia), con ~1.200 especies en ~10 géneros (Eriocaulon, Paepalanthus, Syngonanthus, Leiothrix, Lachnocaulon, Tonina, etc.). El género Paepalanthus es el segundo en diversidad después de Eriocaulon con ~400 especies neotropicales, con epicentro de diversidad en los campos rupestres del Brasil (Cadena do Espinhaço) y los páramos andinos colombianos-venezolanos-ecuatorianos. Filogenéticamente, Eriocaulaceae es miembro del orden Poales (junto con Poaceae, Cyperaceae, Bromeliaceae, Juncaceae) y comparte con estas familias el síndrome de adaptación a ambientes con estrés hídrico-edáfico (capacidad de tolerar suelos saturados-anegados o suelos secos-pobres, fotosíntesis C3-C4 según linaje, propagación por semilla pequeña con dispersión por viento-agua-fauna). Las Eriocaulaceae son consideradas BIOINDICADORES sensibles de turbera funcional: solo persisten en turberas paramunas con cobertura vegetal funcional, freático superficial estable, baja perturbación por ganadería-quema-drenaje. La turbera paramuna es el ecosistema con mayor concentración de carbono orgánico edáfico del territorio colombiano: 30-50% de C-orgánico en suelo turboso vs 2-5% en suelo agrícola normal, con espesores turbosos de 1-5 m equivalentes a 1.000-15.000 años de acumulación post-glaciar. Las turberas paramunas colombianas almacenan estimadamente 1-3 gigatoneladas de C-orgánico — equivalentes a varias décadas de emisiones de CO₂ del país. La perturbación de turbera (drenaje, quema, sobrepastoreo, minería, papicultivo de páramo) provoca emisión masiva de C-CO₂ por mineralización aeróbica acelerada de la turba expuesta, además de pérdida de regulación hídrica y de biodiversidad turberícola. Por esta razón la Ley 1930/2018 protege con énfasis especial los humedales y turberas dentro de páramos delimitados. Paepalanthus columbiensis es uno de los marcadores florísticos de turbera paramuna funcional bien conservada: si está presente en una turbera, indica que la turbera está estructuralmente íntegra. Su declive en una turbera indica perturbación incipiente y riesgo de pérdida de servicio ecosistémico. Servicio ecosistémico: indicador de turbera paramuna funcional, recurso nectarífero secundario para himenópteros y dípteros paramunos, alimento de fauna granívora paramuna (paseriformes pequeños como semilleros de altura). Manejo (NO cultivo doméstico recomendado por carácter silvestre paramuno protegido por Ley 1930/2018, por dependencia obligada de hidrología turbosa, y por carácter indicador-conservación): observación in-situ, fotografía, estudio bioindicación de turbera. NO recolectar dentro de Parques Nacionales Naturales ni de complejos paramunos delimitados sin permiso CAR-CORPORINOQUIA-CORPOAMAZONIA. Si se requiere propagación para restauración de turbera paramuna autorizada (con permiso CAR), semilla diminuta recolectada de capítulos maduros (febrero-mayo), siembra superficial sobre sustrato turbera-paramuna húmedo + arena fina, germinación 20-60 días con humedad constante, plantación definitiva 6-10 meses en turbera receptora con freático superficial estable, exclusión ganadera, asocio con otras turberícolas paramunas (Cortaderia, Sphagnum, Calamagrostis, Carex de páramo, juncos paramunos). Fuentes Tier A: POWO Kew, GBIF Taxonomic Backbone, GBIF Colombia, Bernal 2015 Catálogo Plantas Colombia, Humboldt Flora de Páramos, Giulietti Eriocaulaceae Monograph, JBB Jardín Botánico de Bogotá."
     }
   ],
   "biopreparados": [


### PR DESCRIPTION
## Summary

Sprint 9 Batch 51 nocturno: agrega **10 species medicinales y emblemáticas de páramo + altas montañas colombianas** al catálogo (360→370 species).

### Species agregadas
1. `espeletia_uribei` — frailejón de Uribe (endémico Sumapaz)
2. `espeletia_killipii` — frailejón Killip (Chingaza)
3. `senecio_formosus` — árnica de páramo (Asteraceae)
4. `pernettya_prostrata` — pernettya / mortiño rastrero (Ericaceae)
5. `hypericum_juniperinum` — hipérico de páramo (antidepresivo natural)
6. `bartsia_santolinifolia` — santolina paramuna (Orobanchaceae hemiparásita)
7. `lupinus_alopecuroides` — chocho de páramo (distinto a L. mutabilis)
8. `loricaria_complanata` — escobilla paramuna (Asteraceae ericoide)
9. `disterigma_empetrifolium` — mortiño rastrero ericáceo comestible
10. `paepalanthus_columbiensis` — paja paramuna (Eriocaulaceae)

### Validación / Reglas duras
- `jq empty` rc=0 — JSON estructural válido.
- `node scripts/validate-catalog.mjs` rc=0 — los 16 errores residuales son **pre-existentes en main** (species[28]=ai_draft + species[200-209]=variedad_tradicional/cereales_pseudocereales/verduras_legumbres). Las 10 species nuevas (índices 360-369) pasan schema-v3.1 sin errores.
- `valor_pedagogico` longitudes 3.976–5.521 chars (target ≥200, rango 600-1500+ superado).
- `source_ids` ≥2 Tier A por species (POWO/GBIF/IAvH-Humboldt/JBB/Bernal-2015/Diazgranados-2012/García-Barriga/Luteyn/Robson/Molau/Cuatrecasas/Giulietti + Ley-1930-2018/MADS-Res-383-2010).
- NO toca `biopreparados`, `package.json` ni `sw.js`.
- AGREGA al final del array (`.species[360..369]`). NO modifica species existentes.
- Sin duplicados con catálogo existente.
- Frailejones (E. uribei, E. killipii) declarados con protección Ley 1930/2018 + Resolución 383/2010 MADS.

### Notas toxicológicas/farmacológicas integradas en valor_pedagogico
- **Pernettya prostrata**: andromedotoxinas — NO consumir libremente, distinción cuidadosa de Disterigma comestible.
- **Hypericum juniperinum**: inductor CYP450/glicoproteína-P — interacciones con anticonceptivos, warfarina, antirretrovirales, ciclosporina, ISRS.
- **Senecio formosus**: alcaloides pirrolizidínicos hepatotóxicos — uso EXCLUSIVAMENTE tópico, nunca oral.
- **Lupinus alopecuroides**: alcaloides quinolizidínicos — NO comestible en estado natural (distinto a L. mutabilis cultivado).

## Test plan
- [ ] CodeQL SAST verde
- [ ] Playwright E2E offline-first verde
- [ ] Conteo final 370 species en `catalog/chagra-catalog-seed-v3.1.json`
