### PR TITLE
fix(catalog): allow 'tier' field en schema-v3.1 sources

### DIFF
--- a/catalog/schema-v3.1.json
+++ b/catalog/schema-v3.1.json
@@ -929,6 +929,15 @@
         },
         "observaciones": {
           "type": "string"
+        },
+        "tier": {
+          "type": "string",
+          "enum": [
+            "A",
+            "B",
+            "C"
+          ],
+          "description": "Calidad de la fuente: A=papers/institucionales, B=manuales divulgativos, C=web/blog"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Schema fix tras #875 poblar tier. Schema strict 66 errors → 0.