### PR TITLE
fix(types): tsc:check quick wins en src/utils + src/types (Bug 069.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.113",
+  "version": "0.12.114",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v155';
+const CACHE_NAME = 'chagra-v156';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,27 +1,6 @@
 /**
- * @typedef {Object} ChagraAsset
- * @property {string} id - UUID FarmOS
- * @property {'asset--plant' | 'asset--material' | 'asset--land' | 'asset--structure'} type
- * @property {Object} attributes
- * @property {string} attributes.name
- * @property {'active' | 'archived'} attributes.status
- * @property {Object} [attributes.notes]
- * @property {string} [attributes.notes.value]
- * @property {Object} relationships
- * @property {boolean} [_pending] - flag local pre-FarmOS sync
- * @property {'no_network' | 'no_token' | 'sync_error'} [_pendingReason]
- * @property {number} [_createdAt] - timestamp local ms
- */
-
-/**
- * @typedef {Object} ChagraLog
- * @property {string} id
- * @property {'log--seeding' | 'log--input' | 'log--harvest' | 'log--observation'} type
- * @property {Object} attributes
- * @property {string} attributes.name
- * @property {number} attributes.timestamp - unix seconds
- * @property {'pending' | 'done'} attributes.status
- * @property {Object} relationships
+ * ChagraAsset / ChagraLog: definiciones canónicas viven en `./asset.js` y `./log.js`.
+ * Se re-exportan abajo vía `@typedef {import(...)}` para evitar duplicate identifier (TS2300).
  */
 
 /**

--- a/src/utils/dateFormatter.js
+++ b/src/utils/dateFormatter.js
@@ -49,7 +49,7 @@ export function formatRelativeTime(ts, locale = 'es-CO') {
   const d = new Date(ts);
   if (isNaN(d.getTime())) return '';
   const now = new Date();
-  const diffMs = now - d;
+  const diffMs = now.getTime() - d.getTime();
   const diffMin = Math.floor(diffMs / 60000);
 
   if (diffMin < 1) return 'Ahora mismo';

--- a/src/utils/imageProcessor.js
+++ b/src/utils/imageProcessor.js
@@ -65,7 +65,14 @@ export const optimizeImage = (file, maxWidth = 1280, quality = 0.8) => {
 export const blobToDataUrl = (blob) => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result);
+    reader.onloadend = () => {
+      // readAsDataURL siempre produce string; narrow para satisfacer TS.
+      if (typeof reader.result === 'string') {
+        resolve(reader.result);
+      } else {
+        reject(new Error('FileReader devolvió un tipo inesperado (esperaba string).'));
+      }
+    };
     reader.onerror = () => reject(reader.error);
     reader.readAsDataURL(blob);
   });

--- a/src/utils/spatialAnalysis.js
+++ b/src/utils/spatialAnalysis.js
@@ -47,6 +47,7 @@ export const getCoords = (geometry) => {
  * @param {number} threshold — umbral en metros (default 50)
  */
 export const proximityCheck = (gpsPosition, geometry, threshold = 50) => {
+  /** @type {[number, number]} */
   const deviceCoords = [gpsPosition.coords.longitude, gpsPosition.coords.latitude];
   const targetCoords = getCoords(geometry);
   if (!targetCoords) return { distance: Infinity, isClose: false };


### PR DESCRIPTION
## Summary

Bug 069.6 subset: quick wins de `tsc:check` en `src/utils/` + `src/types/`. Reduce 8 errores TS sin tocar `src/components/` (debt grande, otro sprint).

**Errores eliminados (8):**
- `src/types/index.js` — Duplicate identifier `ChagraAsset` / `ChagraLog` (TS2300 x4). Las definiciones canonicas ya vivian en `./asset.js` / `./log.js` y se re-exportaban via `@typedef {import(...)}`; se eliminaron los `@typedef` inline duplicados.
- `src/utils/dateFormatter.js:52` — aritmetica `Date - Date` (TS2362/TS2363). Fix: `.getTime() - .getTime()`.
- `src/utils/imageProcessor.js:68` — `FileReader.result` puede ser `string | ArrayBuffer` (TS2345). Fix: narrow `typeof === 'string'` + reject defensivo. `readAsDataURL` siempre produce string en runtime.
- `src/utils/spatialAnalysis.js:53` — `number[]` no asignable a `[any, any]` (TS2345). Fix: anotacion JSDoc `/** @type {[number, number]} */` sobre `deviceCoords`.

**Conteo:** `tsc:check` pasa de **277 → 269 errors** (-8). Todos los errores en `src/utils/` + `src/types/` resueltos; los 269 restantes viven todos en `src/components/` (no scope de este PR).

## Test plan

- [x] `npm run tsc:check` → 277 → 269 errors (-8, todos los de `src/utils` + `src/types` resueltos)
- [x] `npm run build` → OK sin warnings nuevos
- [x] `npm run test:unit` → 155/155 passing
- [ ] CI: CodeQL `security-extended` + `security-and-quality` verde
- [ ] CI: Playwright `tests/offline.spec.js` verde
- [ ] CI: Deploy workflow verde post-merge

**Sin cambios de runtime:** solo type hints (JSDoc) y refactor de `@typedef` duplicados. Auto-bump pre-commit subio version `0.12.113 → 0.12.114` y `chagra-v155 → chagra-v156` segun SOP §3.2.
