### PR TITLE
fix(forms): validation client-side en forms críticos (Bug 069.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.113",
+  "version": "0.12.114",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v155';
+const CACHE_NAME = 'chagra-v156';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CaseStudyScreen.jsx
+++ b/src/components/CaseStudyScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FileText, Plus, AlertTriangle, AlertCircle, Activity, CheckCircle, XCircle, ChevronRight, Sparkles, Loader2, Mic, MicOff } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { useCaseStudyStore, CASE_SEVERITIES } from '../store/useCaseStudyStore';
@@ -107,10 +107,42 @@ const NewCaseForm = ({ onCreate, onCancel, defaultFincaSlug }) => {
   const [extracting, setExtracting] = useState(false);
   const [extractError, setExtractError] = useState(null);
   const [transcribing, setTranscribing] = useState(false);
+  const [touched, setTouched] = useState({});
   const recorder = useVoiceRecorder();
+
+  // Bug 069.10 — validación inline: títulos/problemas mínimos para no crear
+  // casos de estudio basura; counts coherentes (afectados ≤ total).
+  const errors = useMemo(() => {
+    const e = {};
+    if (!form.title.trim()) e.title = 'Indica un título';
+    else if (form.title.trim().length < 3) e.title = 'Mínimo 3 caracteres';
+    if (!form.problem_name.trim()) e.problem_name = 'Describe el problema';
+    else if (form.problem_name.trim().length < 3) e.problem_name = 'Mínimo 3 caracteres';
+    const total = form.count_total === '' ? null : Number(form.count_total);
+    const affected = form.count_affected === '' ? null : Number(form.count_affected);
+    if (total !== null) {
+      if (!Number.isFinite(total) || total < 0) e.count_total = 'Debe ser ≥ 0';
+      else if (!Number.isInteger(total)) e.count_total = 'Sin decimales';
+    }
+    if (affected !== null) {
+      if (!Number.isFinite(affected) || affected < 0) e.count_affected = 'Debe ser ≥ 0';
+      else if (!Number.isInteger(affected)) e.count_affected = 'Sin decimales';
+      else if (total !== null && Number.isFinite(total) && affected > total) {
+        e.count_affected = 'No puede exceder el total';
+      }
+    }
+    return e;
+  }, [form]);
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const markTouched = (field) => setTouched((t) => ({ ...t, [field]: true }));
 
   const submit = (e) => {
     e.preventDefault();
+    if (hasErrors) {
+      setTouched({ title: true, problem_name: true, count_total: true, count_affected: true });
+      return;
+    }
     if (!form.title.trim() || !form.problem_name.trim()) return;
     onCreate({
       title: form.title.trim(),
@@ -259,22 +291,44 @@ const NewCaseForm = ({ onCreate, onCancel, defaultFincaSlug }) => {
         </div>
       )}
 
-      <input
-        type="text"
-        required
-        placeholder="Título del caso (ej. Trozador invernadero David)"
-        value={form.title}
-        onChange={(e) => setForm({ ...form, title: e.target.value })}
-        className="w-full px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white text-sm focus:outline-none focus:border-slate-500"
-      />
-      <input
-        type="text"
-        placeholder="Problema (ej. Trozador — Agrotis ipsilon)"
-        required
-        value={form.problem_name}
-        onChange={(e) => setForm({ ...form, problem_name: e.target.value })}
-        className="w-full px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white text-sm focus:outline-none focus:border-slate-500"
-      />
+      <div>
+        <input
+          type="text"
+          required
+          placeholder="Título del caso (ej. Trozador invernadero David)"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          onBlur={() => markTouched('title')}
+          aria-invalid={touched.title && !!errors.title}
+          className={`w-full px-3 py-2 rounded-lg bg-slate-800 border text-white text-sm focus:outline-none focus:border-slate-500 ${
+            touched.title && errors.title ? 'border-red-700' : 'border-slate-700'
+          }`}
+        />
+        {touched.title && errors.title && (
+          <p className="text-xs text-red-400 mt-1 flex items-center gap-1">
+            <AlertCircle className="w-3 h-3" /> {errors.title}
+          </p>
+        )}
+      </div>
+      <div>
+        <input
+          type="text"
+          placeholder="Problema (ej. Trozador — Agrotis ipsilon)"
+          required
+          value={form.problem_name}
+          onChange={(e) => setForm({ ...form, problem_name: e.target.value })}
+          onBlur={() => markTouched('problem_name')}
+          aria-invalid={touched.problem_name && !!errors.problem_name}
+          className={`w-full px-3 py-2 rounded-lg bg-slate-800 border text-white text-sm focus:outline-none focus:border-slate-500 ${
+            touched.problem_name && errors.problem_name ? 'border-red-700' : 'border-slate-700'
+          }`}
+        />
+        {touched.problem_name && errors.problem_name && (
+          <p className="text-xs text-red-400 mt-1 flex items-center gap-1">
+            <AlertCircle className="w-3 h-3" /> {errors.problem_name}
+          </p>
+        )}
+      </div>
       <div className="grid grid-cols-2 gap-2">
         <input
           type="text"
@@ -296,22 +350,46 @@ const NewCaseForm = ({ onCreate, onCancel, defaultFincaSlug }) => {
         </select>
       </div>
       <div className="grid grid-cols-2 gap-2">
-        <input
-          type="number"
-          min="0"
-          placeholder="Total plantas"
-          value={form.count_total}
-          onChange={(e) => setForm({ ...form, count_total: e.target.value })}
-          className="px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white text-sm focus:outline-none focus:border-slate-500"
-        />
-        <input
-          type="number"
-          min="0"
-          placeholder="Afectadas"
-          value={form.count_affected}
-          onChange={(e) => setForm({ ...form, count_affected: e.target.value })}
-          className="px-3 py-2 rounded-lg bg-slate-800 border border-slate-700 text-white text-sm focus:outline-none focus:border-slate-500"
-        />
+        <div>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            placeholder="Total plantas"
+            value={form.count_total}
+            onChange={(e) => setForm({ ...form, count_total: e.target.value })}
+            onBlur={() => markTouched('count_total')}
+            aria-invalid={touched.count_total && !!errors.count_total}
+            className={`w-full px-3 py-2 rounded-lg bg-slate-800 border text-white text-sm focus:outline-none focus:border-slate-500 ${
+              touched.count_total && errors.count_total ? 'border-red-700' : 'border-slate-700'
+            }`}
+          />
+          {touched.count_total && errors.count_total && (
+            <p className="text-xs text-red-400 mt-1 flex items-center gap-1">
+              <AlertCircle className="w-3 h-3" /> {errors.count_total}
+            </p>
+          )}
+        </div>
+        <div>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            placeholder="Afectadas"
+            value={form.count_affected}
+            onChange={(e) => setForm({ ...form, count_affected: e.target.value })}
+            onBlur={() => markTouched('count_affected')}
+            aria-invalid={touched.count_affected && !!errors.count_affected}
+            className={`w-full px-3 py-2 rounded-lg bg-slate-800 border text-white text-sm focus:outline-none focus:border-slate-500 ${
+              touched.count_affected && errors.count_affected ? 'border-red-700' : 'border-slate-700'
+            }`}
+          />
+          {touched.count_affected && errors.count_affected && (
+            <p className="text-xs text-red-400 mt-1 flex items-center gap-1">
+              <AlertCircle className="w-3 h-3" /> {errors.count_affected}
+            </p>
+          )}
+        </div>
       </div>
       <div className="flex gap-2 pt-1">
         <button
@@ -323,7 +401,10 @@ const NewCaseForm = ({ onCreate, onCancel, defaultFincaSlug }) => {
         </button>
         <button
           type="submit"
-          className="flex-1 px-3 py-2 rounded-lg bg-emerald-600 text-white text-sm font-bold hover:bg-emerald-500 transition-colors"
+          disabled={hasErrors}
+          aria-disabled={hasErrors || undefined}
+          title={hasErrors ? 'Completa los campos correctamente' : undefined}
+          className="flex-1 px-3 py-2 rounded-lg bg-emerald-600 text-white text-sm font-bold hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-emerald-600"
         >
           Crear caso
         </button>

--- a/src/components/HarvestLog.jsx
+++ b/src/components/HarvestLog.jsx
@@ -1,8 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { ArrowLeft, TrendingUp, CheckCircle } from 'lucide-react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { ArrowLeft, AlertCircle, TrendingUp, CheckCircle } from 'lucide-react';
 import DateField from './DateField';
 import { savePayload } from '../services/payloadService';
 import { logCache } from '../db/logCache';
+
+// Bug 069.10 — sanity caps para evitar typos absurdos (ej. "100kg" → 100000)
+// que rompan analítica downstream sin que el operador lo note.
+const MAX_QTY_KG = 50000;     // 50 toneladas en una sola cosecha → ya implausible
+const MAX_QTY_UNITS = 1000000; // 1 millón de unidades / huevos / manojos
+const MIN_PRODUCT_LEN = 2;
 
 // Autopilot #7 (2026-05-03): mediana de cosechas pasadas como sugerencia
 // de cantidad. Reduce friction en cosechas repetitivas (fresa cada semana,
@@ -81,6 +87,30 @@ export default function HarvestLog({ onBack, onSave }) {
   const [medianHint, setMedianHint] = useState(null); // { median, count } | null
   const [syncedOffline, setSyncedOffline] = useState(false);
   const [view, setView] = useState('form'); // 'form' | 'success'
+  const [touched, setTouched] = useState({});
+
+  // Bug 069.10 — validación inline (subArea, product, quantity, date)
+  const errors = useMemo(() => {
+    const e = {};
+    const today = new Date().toISOString().split('T')[0];
+    if (!formData.subArea) e.subArea = 'Selecciona el sub-área';
+    if (!formData.product.trim()) e.product = 'Indica el producto';
+    else if (formData.product.trim().length < MIN_PRODUCT_LEN) e.product = `Mínimo ${MIN_PRODUCT_LEN} caracteres`;
+    const qty = Number(formData.quantity);
+    const cap = formData.unit === 'Gramos' ? MAX_QTY_KG * 1000
+              : formData.unit === 'Kilogramos' ? MAX_QTY_KG
+              : MAX_QTY_UNITS;
+    if (formData.quantity === '' || formData.quantity === null) e.quantity = 'Indica la cantidad';
+    else if (!Number.isFinite(qty)) e.quantity = 'Cantidad inválida';
+    else if (qty <= 0) e.quantity = 'Debe ser mayor que cero';
+    else if (qty > cap) e.quantity = `Máximo ${cap.toLocaleString()} ${formData.unit.toLowerCase()}`;
+    if (!formData.date) e.date = 'Indica la fecha';
+    else if (formData.date > today) e.date = 'La fecha no puede ser futura';
+    return e;
+  }, [formData]);
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const markTouched = (field) => setTouched((t) => ({ ...t, [field]: true }));
 
   const handleInput = (e) => {
     const { name, value } = e.target;
@@ -120,8 +150,10 @@ export default function HarvestLog({ onBack, onSave }) {
 
   const handleSave = async () => {
     if (isSaving) return;
-    if (!formData.subArea || !formData.quantity || !formData.product) {
-      onSave('Completa Sub-área, Producto y Cantidad', true);
+    // Bug 069.10 — re-validar antes de enviar
+    if (hasErrors) {
+      setTouched({ subArea: true, product: true, quantity: true, date: true });
+      onSave('Revisa los campos marcados', true);
       return;
     }
 
@@ -220,9 +252,14 @@ export default function HarvestLog({ onBack, onSave }) {
         <DateField
           label="Fecha"
           value={formData.date}
-          onChange={(val) => setFormData(p => ({ ...p, date: val }))}
+          onChange={(val) => { setFormData(p => ({ ...p, date: val })); markTouched('date'); }}
           required
         />
+        {touched.date && errors.date && (
+          <p className="text-sm text-red-400 -mt-4 flex items-center gap-1.5">
+            <AlertCircle size={14} aria-hidden="true" /> {errors.date}
+          </p>
+        )}
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Área Principal</span>
@@ -235,22 +272,70 @@ export default function HarvestLog({ onBack, onSave }) {
         {formData.mainArea && (
           <label className="flex flex-col gap-2">
             <span className="text-xl font-bold">Segmento / Sub-área</span>
-            <select name="subArea" value={formData.subArea} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none">
+            <select
+              name="subArea"
+              value={formData.subArea}
+              onChange={handleInput}
+              onBlur={() => markTouched('subArea')}
+              aria-invalid={touched.subArea && !!errors.subArea}
+              className={`p-4 rounded-xl bg-slate-900 border text-2xl text-white min-h-[64px] appearance-none ${
+                touched.subArea && errors.subArea ? 'border-red-700' : 'border-slate-700'
+              }`}
+            >
               <option value="">-- Seleccionar --</option>
               {MOCK_SUB_AREAS[formData.mainArea]?.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
             </select>
+            {touched.subArea && errors.subArea && (
+              <p className="text-sm text-red-400 flex items-center gap-1.5">
+                <AlertCircle size={14} aria-hidden="true" /> {errors.subArea}
+              </p>
+            )}
           </label>
         )}
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Producto</span>
-          <input type="text" name="product" value={formData.product} onChange={handleInput} placeholder="Ej: Fresa Monterrey" className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] placeholder-slate-500" />
+          <input
+            type="text"
+            name="product"
+            value={formData.product}
+            onChange={handleInput}
+            onBlur={() => markTouched('product')}
+            aria-invalid={touched.product && !!errors.product}
+            placeholder="Ej: Fresa Monterrey"
+            className={`p-4 rounded-xl bg-slate-900 border text-2xl text-white min-h-[64px] placeholder-slate-500 ${
+              touched.product && errors.product ? 'border-red-700' : 'border-slate-700'
+            }`}
+          />
+          {touched.product && errors.product && (
+            <p className="text-sm text-red-400 flex items-center gap-1.5">
+              <AlertCircle size={14} aria-hidden="true" /> {errors.product}
+            </p>
+          )}
         </label>
 
         <div className="grid grid-cols-2 gap-4">
           <label className="flex flex-col gap-2">
             <span className="text-xl font-bold">Cantidad</span>
-            <input type="number" step="0.01" name="quantity" value={formData.quantity} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]" placeholder="0.00" />
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              name="quantity"
+              value={formData.quantity}
+              onChange={handleInput}
+              onBlur={() => markTouched('quantity')}
+              aria-invalid={touched.quantity && !!errors.quantity}
+              className={`p-4 rounded-xl bg-slate-900 border text-2xl text-white min-h-[64px] ${
+                touched.quantity && errors.quantity ? 'border-red-700' : 'border-slate-700'
+              }`}
+              placeholder="0.00"
+            />
+            {touched.quantity && errors.quantity && (
+              <p className="text-sm text-red-400 flex items-center gap-1.5">
+                <AlertCircle size={14} aria-hidden="true" /> {errors.quantity}
+              </p>
+            )}
             {medianHint && (
               <span className="inline-flex items-center gap-1.5 text-xs text-emerald-400 px-1">
                 <TrendingUp size={12} />
@@ -276,9 +361,11 @@ export default function HarvestLog({ onBack, onSave }) {
 
         <button
           onClick={handleSave}
-          disabled={isSaving}
+          disabled={isSaving || hasErrors}
           aria-busy={isSaving}
-          className="mt-4 p-6 rounded-xl bg-orange-600 active:bg-orange-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-orange-800 disabled:opacity-60 disabled:active:bg-orange-600"
+          aria-disabled={hasErrors || undefined}
+          title={hasErrors ? 'Completa los campos correctamente' : undefined}
+          className="mt-4 p-6 rounded-xl bg-orange-600 active:bg-orange-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-orange-800 disabled:opacity-60 disabled:active:bg-orange-600 disabled:cursor-not-allowed"
         >
           {isSaving ? 'Guardando…' : 'Guardar Cosecha'}
         </button>

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -1,7 +1,12 @@
-import React, { useState } from 'react';
-import { ArrowLeft, Camera } from 'lucide-react';
+import React, { useState, useMemo } from 'react';
+import { ArrowLeft, AlertCircle, Camera } from 'lucide-react';
 import DateField from './DateField';
 import { syncManager } from '../services/syncManager';
+
+// Bug 069.10 — observation requiere descripción mínima útil + ubicación.
+// Mínimo de 5 caracteres descarta entries vacíos tipo "ok" o "test".
+const MIN_DESCRIPTION_LEN = 5;
+const MAX_DESCRIPTION_LEN = 2000;
 
 function ObservationScreen({ onBack, onSave }) {
   const [formData, setFormData] = useState({
@@ -14,6 +19,25 @@ function ObservationScreen({ onBack, onSave }) {
   const [photo, setPhoto] = useState(null);
   const [photoUrl, setPhotoUrl] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [touched, setTouched] = useState({});
+
+  // Bug 069.10 — validación inline para description + date. `locationId` no
+  // tiene input en la UI todavía (queda en el handleSave check legacy) — no se
+  // incluye acá para no deshabilitar el botón de forma permanente.
+  const errors = useMemo(() => {
+    const e = {};
+    const today = new Date().toISOString().split('T')[0];
+    const desc = (formData.description || '').trim();
+    if (!desc) e.description = 'Describe la observación';
+    else if (desc.length < MIN_DESCRIPTION_LEN) e.description = `Mínimo ${MIN_DESCRIPTION_LEN} caracteres`;
+    else if (desc.length > MAX_DESCRIPTION_LEN) e.description = `Máximo ${MAX_DESCRIPTION_LEN} caracteres`;
+    if (!formData.date) e.date = 'Indica la fecha';
+    else if (formData.date > today) e.date = 'La fecha no puede ser futura';
+    return e;
+  }, [formData]);
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const markTouched = (field) => setTouched((t) => ({ ...t, [field]: true }));
 
   const handleInput = (e) => {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
@@ -30,6 +54,12 @@ function ObservationScreen({ onBack, onSave }) {
 
   const handleSave = async () => {
     if (isSaving) return;
+    // Bug 069.10 — validación inline previa
+    if (hasErrors) {
+      setTouched({ description: true, date: true });
+      onSave('Revisa los campos marcados', true);
+      return;
+    }
     if (!formData.description || !formData.locationId) {
       onSave('Completa descripcion y ubicacion', true);
       return;
@@ -104,7 +134,24 @@ function ObservationScreen({ onBack, onSave }) {
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Descripcion</span>
-          <textarea name="description" value={formData.description} onChange={handleInput} rows="4" className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-xl text-white min-h-[80px]" placeholder="Describe la observacion..." />
+          <textarea
+            name="description"
+            value={formData.description}
+            onChange={handleInput}
+            onBlur={() => markTouched('description')}
+            aria-invalid={touched.description && !!errors.description}
+            rows="4"
+            maxLength={MAX_DESCRIPTION_LEN}
+            className={`p-4 rounded-xl bg-slate-900 border text-xl text-white min-h-[80px] ${
+              touched.description && errors.description ? 'border-red-700' : 'border-slate-700'
+            }`}
+            placeholder="Describe la observacion..."
+          />
+          {touched.description && errors.description && (
+            <p className="text-sm text-red-400 flex items-center gap-1.5">
+              <AlertCircle size={14} aria-hidden="true" /> {errors.description}
+            </p>
+          )}
         </label>
 
         <label className="flex flex-col gap-2">
@@ -120,9 +167,14 @@ function ObservationScreen({ onBack, onSave }) {
         <DateField
           label="Fecha"
           value={formData.date}
-          onChange={(val) => setFormData(p => ({ ...p, date: val }))}
+          onChange={(val) => { setFormData(p => ({ ...p, date: val })); markTouched('date'); }}
           required
         />
+        {touched.date && errors.date && (
+          <p className="text-sm text-red-400 -mt-4 flex items-center gap-1.5">
+            <AlertCircle size={14} aria-hidden="true" /> {errors.date}
+          </p>
+        )}
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Notas Adicionales</span>
@@ -140,9 +192,11 @@ function ObservationScreen({ onBack, onSave }) {
 
         <button
           onClick={handleSave}
-          disabled={isSaving}
+          disabled={isSaving || hasErrors}
           aria-busy={isSaving}
-          className="mt-4 p-6 rounded-xl bg-purple-600 active:bg-purple-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-purple-800 disabled:opacity-60 disabled:active:bg-purple-600"
+          aria-disabled={hasErrors || undefined}
+          title={hasErrors ? 'Completa los campos correctamente' : undefined}
+          className="mt-4 p-6 rounded-xl bg-purple-600 active:bg-purple-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-purple-800 disabled:opacity-60 disabled:active:bg-purple-600 disabled:cursor-not-allowed"
         >
           {isSaving ? 'Guardando…' : 'Guardar Observacion'}
         </button>

--- a/src/components/OnboardingPiloto.jsx
+++ b/src/components/OnboardingPiloto.jsx
@@ -159,6 +159,18 @@ function FormPiloto() {
     if (!data.maps_url.trim()) e.maps_url = 'Requerido';
     else if (!/(maps|goo\.gl|google\.com)/i.test(data.maps_url)) e.maps_url = 'Pegá un link de Google Maps';
     if (!data.vocacion) e.vocacion = 'Selecciona vocación';
+    // Bug 069.10 — rangos para campos numéricos opcionales (si están presentes)
+    if (data.altitud_msnm !== '') {
+      const alt = Number(data.altitud_msnm);
+      if (!Number.isFinite(alt)) e.altitud_msnm = 'Número inválido';
+      else if (alt < 0 || alt > 5500) e.altitud_msnm = 'Rango 0–5500 msnm';
+    }
+    if (data.area_m2 !== '') {
+      const area = Number(data.area_m2);
+      if (!Number.isFinite(area)) e.area_m2 = 'Número inválido';
+      else if (area <= 0) e.area_m2 = 'Debe ser mayor que cero';
+      else if (area > 100_000_000) e.area_m2 = 'Máximo 100.000.000 m² (10.000 ha)';
+    }
     return e;
   }, [data]);
 
@@ -336,11 +348,18 @@ ${data.operador_nombre}`;
                 value={data.altitud_msnm}
                 onChange={(e) => setField('altitud_msnm', e.target.value)}
                 placeholder="1730"
-                className={inputClass(false)}
+                aria-invalid={!!errors.altitud_msnm}
+                className={inputClass(!!errors.altitud_msnm)}
               />
-              <p className="text-xs text-slate-500 mt-1">
-                Si no la sabes, déjalo vacío — la calculamos desde el link de Maps.
-              </p>
+              {errors.altitud_msnm ? (
+                <p className="text-xs text-red-400 mt-1 flex items-center gap-1">
+                  <AlertCircle size={12} /> {errors.altitud_msnm}
+                </p>
+              ) : (
+                <p className="text-xs text-slate-500 mt-1">
+                  Si no la sabes, déjalo vacío — la calculamos desde el link de Maps.
+                </p>
+              )}
             </div>
 
             <div>
@@ -352,11 +371,18 @@ ${data.operador_nombre}`;
                 value={data.area_m2}
                 onChange={(e) => setField('area_m2', e.target.value)}
                 placeholder="3500"
-                className={inputClass(false)}
+                aria-invalid={!!errors.area_m2}
+                className={inputClass(!!errors.area_m2)}
               />
-              <p className="text-xs text-slate-500 mt-1">
-                Escritura o levantamiento. Vacío si no lo sabes.
-              </p>
+              {errors.area_m2 ? (
+                <p className="text-xs text-red-400 mt-1 flex items-center gap-1">
+                  <AlertCircle size={12} /> {errors.area_m2}
+                </p>
+              ) : (
+                <p className="text-xs text-slate-500 mt-1">
+                  Escritura o levantamiento. Vacío si no lo sabes.
+                </p>
+              )}
             </div>
           </div>
 

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -1,9 +1,14 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { ArrowLeft, Camera, MapPin, CheckCircle } from 'lucide-react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { ArrowLeft, AlertCircle, Camera, MapPin, CheckCircle } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
 import { captureAndCompress, savePhoto } from '../services/photoService';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
 import DateField from './DateField';
+
+// Bug 069.10 — validación client-side: límites razonables para evitar
+// payloads inválidos sincronizándose con FarmOS.
+const MAX_QUANTITY = 100000; // sanity cap: 100k plántulas en una siembra es ya raro
+const MIN_CROP_LEN = 2;
 
 export default function SeedingLog({ onBack, onSave, initialData = {} }) {
   const [formData, setFormData] = useState({
@@ -21,7 +26,28 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
   const [isSaving, setIsSaving] = useState(false);
   const [syncedOffline, setSyncedOffline] = useState(false);
   const [view, setView] = useState('form');
+  const [touched, setTouched] = useState({});
   const watchIdRef = useRef(null);
+
+  // Bug 069.10 — validación inline (no bloquea submit existente, pero deshabilita el botón
+  // y muestra errores para que el operador corrija antes de guardar).
+  const errors = useMemo(() => {
+    const e = {};
+    const today = new Date().toISOString().split('T')[0];
+    if (!formData.crop.trim()) e.crop = 'Indica el cultivo';
+    else if (formData.crop.trim().length < MIN_CROP_LEN) e.crop = `Mínimo ${MIN_CROP_LEN} caracteres`;
+    const qty = Number(formData.quantity);
+    if (formData.quantity === '' || formData.quantity === null) e.quantity = 'Indica la cantidad';
+    else if (!Number.isFinite(qty)) e.quantity = 'Cantidad inválida';
+    else if (qty <= 0) e.quantity = 'Debe ser mayor que cero';
+    else if (qty > MAX_QUANTITY) e.quantity = `Máximo ${MAX_QUANTITY.toLocaleString()} plántulas`;
+    if (!formData.date) e.date = 'Indica la fecha';
+    else if (formData.date > today) e.date = 'La fecha no puede ser futura';
+    return e;
+  }, [formData]);
+
+  const hasErrors = Object.keys(errors).length > 0;
+  const markTouched = (field) => setTouched((t) => ({ ...t, [field]: true }));
 
   useEffect(() => {
     return () => {
@@ -80,8 +106,11 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
 
   const handleSave = async () => {
     if (isSaving) return;
-    if (!formData.crop || !formData.quantity) {
-      onSave('Completa Cultivo y Cantidad', true);
+    // Bug 069.10 — re-validar antes de enviar; marca todos los campos como touched
+    // para que los errores se vean si el operador llegó acá con el botón deshabilitado vencido.
+    if (hasErrors) {
+      setTouched({ crop: true, quantity: true, date: true });
+      onSave('Revisa los campos marcados', true);
       return;
     }
 
@@ -222,13 +251,34 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
         <DateField
           label="Fecha"
           value={formData.date}
-          onChange={(val) => setFormData(p => ({ ...p, date: val }))}
+          onChange={(val) => { setFormData(p => ({ ...p, date: val })); markTouched('date'); }}
           required
         />
+        {touched.date && errors.date && (
+          <p className="text-sm text-red-400 -mt-4 flex items-center gap-1.5">
+            <AlertCircle size={14} aria-hidden="true" /> {errors.date}
+          </p>
+        )}
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Cultivo</span>
-          <input type="text" name="crop" placeholder="Ej: Fresa" value={formData.crop} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white placeholder-slate-500 min-h-[64px]" />
+          <input
+            type="text"
+            name="crop"
+            placeholder="Ej: Fresa"
+            value={formData.crop}
+            onChange={handleInput}
+            onBlur={() => markTouched('crop')}
+            aria-invalid={touched.crop && !!errors.crop}
+            className={`p-4 rounded-xl bg-slate-900 border text-2xl text-white placeholder-slate-500 min-h-[64px] ${
+              touched.crop && errors.crop ? 'border-red-700' : 'border-slate-700'
+            }`}
+          />
+          {touched.crop && errors.crop && (
+            <p className="text-sm text-red-400 flex items-center gap-1.5">
+              <AlertCircle size={14} aria-hidden="true" /> {errors.crop}
+            </p>
+          )}
         </label>
 
         <label className="flex flex-col gap-2">
@@ -243,7 +293,25 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Cantidad de Plántulas</span>
-          <input type="number" name="quantity" min="1" value={formData.quantity} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]" />
+          <input
+            type="number"
+            name="quantity"
+            min="1"
+            max={MAX_QUANTITY}
+            step="1"
+            value={formData.quantity}
+            onChange={handleInput}
+            onBlur={() => markTouched('quantity')}
+            aria-invalid={touched.quantity && !!errors.quantity}
+            className={`p-4 rounded-xl bg-slate-900 border text-2xl text-white min-h-[64px] ${
+              touched.quantity && errors.quantity ? 'border-red-700' : 'border-slate-700'
+            }`}
+          />
+          {touched.quantity && errors.quantity && (
+            <p className="text-sm text-red-400 flex items-center gap-1.5">
+              <AlertCircle size={14} aria-hidden="true" /> {errors.quantity}
+            </p>
+          )}
         </label>
 
         <div className="flex flex-col gap-2">
@@ -257,9 +325,11 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
 
         <button
           onClick={handleSave}
-          disabled={isSaving}
+          disabled={isSaving || hasErrors}
           aria-busy={isSaving}
-          className="mt-4 p-6 rounded-xl bg-green-600 active:bg-green-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-green-800 disabled:opacity-60 disabled:active:bg-green-600"
+          aria-disabled={hasErrors || undefined}
+          title={hasErrors ? 'Completa los campos correctamente' : undefined}
+          className="mt-4 p-6 rounded-xl bg-green-600 active:bg-green-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-green-800 disabled:opacity-60 disabled:active:bg-green-600 disabled:cursor-not-allowed"
         >
           {isSaving ? 'Guardando…' : 'Guardar Registro'}
         </button>


### PR DESCRIPTION
## Summary

Bug 069.10 — Agrega validación client-side inline a 5 forms críticos del path demo Diana para evitar que payloads inválidos (números negativos, strings vacíos, fechas futuras, counts incoherentes) se sincronicen con FarmOS.

## Forms modificados

| Form | Validaciones agregadas |
|---|---|
| `SeedingLog` | crop (min 2 chars), quantity (>0, ≤100k), date (no futura) |
| `HarvestLog` | subArea required, product (min 2), quantity (>0 con cap por unidad: 50t kg / 50Mt g / 1M unidades), date (no futura) |
| `ObservationScreen` | description (5–2000 chars), date (no futura) |
| `CaseStudyScreen.NewCaseForm` | title/problem_name (min 3), count_total/affected (>=0, enteros, afectadas ≤ total) |
| `OnboardingPiloto` | altitud (0–5500 msnm), area_m2 (>0, ≤10k ha) |

## Pattern (reusado del LoginScreen/OnboardingPiloto existentes)

- Errores derivados con `useMemo` (sin estado redundante).
- `touched` state: el error solo se muestra después de blur, no mientras el usuario está escribiendo.
- Display inline con `<AlertCircle>` — sin alerts disruptivos.
- Submit button `disabled` cuando `hasErrors`; `aria-disabled` y `title` para a11y.
- Re-validación pre-`handleSave` que marca todos los campos como `touched` si el usuario llegó hasta ahí (defensa en profundidad).
- Lógica de submit existente intacta — solo se añade un gate de validación previo.

## Reglas duras respetadas

- No cambia lógica de submit existente (savePayload, syncManager, etc.).
- No toca tests.
- 155 unit tests passing.
- ESLint 0 issues.
- `npm run build` OK.
- Auto-bump 0.12.113 → 0.12.114.

## Test plan

- [ ] CodeQL pasa.
- [ ] Playwright E2E (offline.spec.js) pasa — el flow de siembra offline no cambia.
- [ ] Manual: abrir SeedingLog, intentar guardar con quantity=0 → botón disabled, error inline visible.
- [ ] Manual: HarvestLog, escribir quantity=99999 con unidad Kilogramos → error "Máximo 50.000 kilogramos".
- [ ] Manual: NewCaseForm, count_affected > count_total → error "No puede exceder el total".
- [ ] Manual: OnboardingPiloto, altitud=6000 → error "Rango 0–5500 msnm".

Generated with Claude Code
