### PR TITLE
fix(asset-form): pre-pobla parentLandId con currentZoneId al abrir form en zona

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.121",
+  "version": "0.12.122",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v163';
+const CACHE_NAME = 'chagra-v164';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -300,6 +300,22 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState(buildInitialFormState);
 
+  // Bug 2026-05-18 operator: 'agregué 50 plantas dentro de Túnel +100 especies
+  // y siguen sin aparecer ahí'. Causa: si el operador navega DENTRO de una
+  // zona específica (currentZoneId NO __all__/__orphan__/__cemetery__) y
+  // abre el form de agregar planta, formData.parentLandId queda vacío y
+  // cae a DEFAULT_LOCATION_ID — la planta NO va al túnel actual.
+  // Fix: al abrir el form, pre-poblar parentLandId con currentZoneId si es
+  // una zona real (no virtual).
+  useEffect(() => {
+    if (!showForm) return;
+    const isRealZone = currentZoneId && !['__all__', '__orphan__', '__cemetery__'].includes(currentZoneId);
+    if (isRealZone && !formData.parentLandId) {
+      setFormData((prev) => ({ ...prev, parentLandId: currentZoneId }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showForm, currentZoneId]);
+
   // Estado local del formulario de cosecha scoped por asset.id
   const [activeHarvestId, setActiveHarvestId] = useState(null);
   const [harvestData, setHarvestData] = useState({ yield: '', unit: 'kg', notes: '' });


### PR DESCRIPTION
Operator: 50 plantas dentro de Túnel no aparecen. Fix pre-pobla parentLandId con zona actual.