### PR TITLE
fix(species-select): warning cuando se usa nombre libre sin id catálogo (audit 070.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.121",
+  "version": "0.12.122",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v163';
+const CACHE_NAME = 'chagra-v164';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -386,6 +386,13 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
               >
                 Usar "{query}" como nombre libre
               </button>
+              {/* Audit 2026-05-18 #070.10: avisar que sin id de catálogo no
+                  habrá plan de alimentación auto-generado. Operador reporta
+                  bug "fresa sin plan" cuando entra por entrada libre. */}
+              <p className="text-[10px] text-amber-400 mt-2 px-2 leading-snug">
+                Sin coincidencia en catálogo: el plan de alimentación automático no se generará.
+                Probá variantes (ej. &quot;fresa monterrey&quot; o nombre científico).
+              </p>
             </div>
           ) : (
             filtered.map((sp) => (


### PR DESCRIPTION
## Summary

Quick win del audit deep `Chagra-strategy/audit/2026-05-18-conexiones-rotas-deep.md` (item #070.10).

Operador reportó: "creo planta fresa → no se genera plan de alimentación".

La auditoría confirmó que es un problema sistémico (catálogo v3.1 sin `feeding_plan_template` en 479/480 species). UNO de los varios síntomas es que `SpeciesSelect` permite "entrada libre" sin avisar que perdiste el `speciesId` y por tanto el plan automático no se generará.

Este PR agrega un warning audible (4 líneas JSX) bajo el botón "Usar X como nombre libre" indicando consecuencia + sugiriendo variantes.

## Test plan

- [x] `npm run lint` ✅ verde
- [x] `npm run test:unit` ✅ 155/155
- [x] `npm run build` ✅
- [ ] Manual: abrir SpeciesSelect → escribir "fresita" → verificar warning aparece bajo botón
- [ ] Manual: escribir "fresa monterrey" → verificar fuzzy filter encuentra match (warning no aparece)

## Audit completo

- Reporte: `Chagra-strategy/audit/2026-05-18-conexiones-rotas-deep.md` (10 findings, 8 secciones)
- Queue: `Chagra-strategy/queue/070-conexiones-rotas-audit-2026-05-18.md` (P1-P3 priorizados)

P1 items (catálogo sin templates, offline path sin plan, plant form sin edad/altura/fenología) van a sprint post-demo.

🪚 Audit nocturno, autopilot extremo.