### PR TITLE
feat(asset-detail): AddPhotoSection para todos asset types (cubio, túnel, zona)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.122",
+  "version": "0.12.123",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v164';
+const CACHE_NAME = 'chagra-v165';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -240,13 +240,14 @@ export const AssetDetailView = () => {
           {/* Bug 2026-05-18 operator: 'no es posible agregar foto a una planta
               ya creada' (cubio recién agregado). Botones para subir foto
               post-creación con dual options cámara/galería + captureAndCompress
-              + savePhoto. Refresh la galería al guardar. */}
-          {isPlantType && (
-            <AddPhotoSection
-              assetId={asset.id}
-              speciesSlug={deriveSpeciesSlug(name)}
-            />
-          )}
+              + savePhoto. Refresh la galería al guardar.
+              Update 2026-05-18: extendido a TODOS los tipos de asset (plant,
+              land/zona/propiedad, structure/túnel/invernadero, equipment),
+              no solo plants. Operator agregó zona y no podía ver fecha ni foto. */}
+          <AddPhotoSection
+            assetId={asset.id}
+            speciesSlug={isPlantType ? deriveSpeciesSlug(name) : null}
+          />
 
           <GeometrySection asset={asset} parentZoneName={parentZoneName} onEdit={() => setShowGeoPicker(true)} saving={geoSaving} />
 


### PR DESCRIPTION
Operator reports: cubio sin foto, túnel sin foto, zona sin foto. AddPhotoSection ahora aplica a TODOS los asset types, no solo plants. Plant path sin breaking changes.