### PR TITLE
fix(sync): generar plan de alimentación también en path offline (syncManager)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.123",
+  "version": "0.12.124",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v165';
+const CACHE_NAME = 'chagra-v166';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/planGeneratorService.test.js
+++ b/src/services/__tests__/planGeneratorService.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Helper tryGeneratePlanFromSeeding (audit finding #2, 2026-05-18) ─────
+// Aísla planGeneratorService de IDB real (sqlite-wasm catalog + plans store).
+// Mockea openDB y los servicios de inventory que son tirados transitivamente.
+
+const PLANT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+describe('tryGeneratePlanFromSeeding — helper compartido (audit finding #2)', () => {
+    let inMemoryPlansById;
+    let tryGeneratePlanFromSeeding;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        vi.clearAllMocks();
+
+        inMemoryPlansById = new Map();
+
+        // IndexedDB stub mínimo. Las funciones reales de planGeneratorService
+        // usan store.put / index('asset_id').getAll(assetId) sobre STORES.PLANS.
+        // Reproducimos esos endpoints con un Map en memoria.
+        const stubStore = {
+            put: (plan) => {
+                const req = { onsuccess: null, onerror: null };
+                Promise.resolve().then(() => {
+                    inMemoryPlansById.set(plan.id, plan);
+                    req.result = plan;
+                    req.onsuccess?.({ target: req });
+                });
+                return req;
+            },
+            index: () => ({
+                getAll: (assetId) => {
+                    const req = { onsuccess: null, onerror: null };
+                    Promise.resolve().then(() => {
+                        const found = [...inMemoryPlansById.values()].filter((p) => p.asset_id === assetId);
+                        req.result = found;
+                        req.onsuccess?.({ target: req });
+                    });
+                    return req;
+                },
+            }),
+        };
+        const stubDb = { transaction: () => ({ objectStore: () => stubStore }) };
+
+        vi.doMock('../../db/dbCore.js', () => ({
+            openDB: vi.fn().mockResolvedValue(stubDb),
+            STORES: { PLANS: 'plans' },
+        }));
+        vi.doMock('../inventoryService.js', () => ({
+            appendEvent: vi.fn(),
+            getStock: vi.fn().mockResolvedValue(null),
+        }));
+        vi.doMock('../inventoryEvents.js', () => ({
+            createInventoryEvent: vi.fn(),
+            EVENT_TYPES: {},
+        }));
+        // catalogDB stub: una especie 'tomate' con 2 steps simples.
+        vi.doMock('../../db/catalogDB.js', () => ({
+            initCatalog: vi.fn().mockResolvedValue({
+                exec: () => [{
+                    data: JSON.stringify({
+                        id: 'tomate',
+                        feeding_plan_template: {
+                            primary_steps: [
+                                { offset_days: 0, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'siembra' },
+                                { offset_days: 30, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'mes 1' },
+                            ],
+                        },
+                    }),
+                }],
+            }),
+        }));
+
+        ({ tryGeneratePlanFromSeeding } = await import('../planGeneratorService.js'));
+    });
+
+    it('retorna null si falta assetId', async () => {
+        const plan = await tryGeneratePlanFromSeeding({ speciesSlug: 'tomate', plantingDate: new Date().toISOString() });
+        expect(plan).toBeNull();
+    });
+
+    it('retorna null si falta speciesSlug', async () => {
+        const plan = await tryGeneratePlanFromSeeding({ assetId: PLANT_UUID, plantingDate: new Date().toISOString() });
+        expect(plan).toBeNull();
+    });
+
+    it('genera plan si no existe previamente para el asset', async () => {
+        const plan = await tryGeneratePlanFromSeeding({
+            assetId: PLANT_UUID,
+            speciesSlug: 'tomate',
+            plantingDate: new Date(1_700_000_000 * 1000).toISOString(),
+            plantName: 'Tomate Cherry',
+        });
+        expect(plan).toBeTruthy();
+        expect(plan.asset_id).toBe(PLANT_UUID);
+        expect(plan.steps.length).toBeGreaterThan(0);
+        expect(plan._plantName).toBe('Tomate Cherry');
+    });
+
+    it('idempotente: si ya hay plan para el asset, retorna el existente sin regenerar', async () => {
+        const existing = {
+            id: 'plan-existing',
+            asset_id: PLANT_UUID,
+            species_slug: 'tomate',
+            generated_at: Date.now() - 1000,
+            steps: [{ id: 'existing-step', status: 'pending' }],
+        };
+        inMemoryPlansById.set(existing.id, existing);
+
+        const plan = await tryGeneratePlanFromSeeding({
+            assetId: PLANT_UUID,
+            speciesSlug: 'tomate',
+            plantingDate: new Date().toISOString(),
+        });
+
+        expect(plan?.id).toBe('plan-existing');
+        // No regeneró → sigue siendo 1 plan total en el store.
+        expect(inMemoryPlansById.size).toBe(1);
+    });
+});

--- a/src/services/__tests__/syncManager.test.js
+++ b/src/services/__tests__/syncManager.test.js
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mocks de módulos externos ────────────────────────────────────────────
+// Mockeamos en orden: dbCore (apertura IDB), apiService (POST FarmOS),
+// logCache (persistencia logs sincronizados), voiceTelemetryService (no-op),
+// planGeneratorService (verificamos llamadas al helper).
+vi.mock('../apiService', () => ({
+    sendToFarmOS: vi.fn(),
+    fetchFromFarmOS: vi.fn(),
+}));
+
+vi.mock('../../db/dbCore', () => ({
+    openDB: vi.fn().mockResolvedValue({}),
+    STORES: { PENDING_VOICE: 'pending_voice_recordings' },
+}));
+
+vi.mock('../../db/logCache', () => ({
+    logCache: {
+        put: vi.fn().mockResolvedValue(undefined),
+        getByType: vi.fn().mockResolvedValue([]),
+        bulkPut: vi.fn().mockResolvedValue(undefined),
+    },
+}));
+
+vi.mock('../voiceTelemetryService', () => ({
+    recordEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../planGeneratorService', () => ({
+    tryGeneratePlanFromSeeding: vi.fn(),
+}));
+
+// Mockeamos también payloadService imports auxiliares en case-of importchain
+vi.mock('../../utils/taskCompletionParser', () => ({
+    getCompletedTaskIds: vi.fn().mockReturnValue(new Set()),
+}));
+
+vi.mock('../../utils/id', () => ({
+    newId: vi.fn().mockReturnValue('mock-id'),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+const PLANT_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function makeSeedingTransaction({ includeSpeciesSlug = true, assetUUID = null } = {}) {
+    const inlineAsset = {
+        type: 'asset--plant',
+        ...(assetUUID ? { id: assetUUID } : {}),
+        ...(includeSpeciesSlug ? { _speciesSlug: 'tomate' } : {}),
+        attributes: { name: 'Tomate Cherry [voz]', status: 'active' },
+    };
+    return {
+        id: 'tx-1',
+        type: 'seeding',
+        endpoint: '/api/log/seeding',
+        payload: {
+            data: {
+                type: 'log--seeding',
+                attributes: { name: 'Siembra: tomate (x1) [voz]', timestamp: 1_700_000_000, status: 'done' },
+                relationships: {
+                    asset: { data: [inlineAsset] },
+                },
+            },
+        },
+        synced: false,
+    };
+}
+
+function makeFarmOSResponse({ remoteAssetUUID = PLANT_UUID } = {}) {
+    return {
+        data: {
+            id: 'log-seeding-uuid',
+            type: 'log--seeding',
+            attributes: { timestamp: 1_700_000_000 },
+            relationships: {
+                asset: { data: [{ type: 'asset--plant', id: remoteAssetUUID }] },
+            },
+        },
+    };
+}
+
+// ─── Stub mínimo de IDBDatabase para syncManager ──────────────────────────
+// syncManager.syncAll consume getPendingTransactions(), deleteTransaction(),
+// y syncTransaction(). Stubbeamos los métodos en la instancia para evitar
+// montar un mock completo de IndexedDB.
+function patchSyncManager(syncManager, pendingTransactions) {
+    syncManager.db = { mocked: true };
+    syncManager.isOnline = true;
+    syncManager.isSyncing = false;
+    syncManager.getPendingTransactions = vi.fn().mockResolvedValue(pendingTransactions);
+    syncManager.deleteTransaction = vi.fn().mockResolvedValue(undefined);
+    syncManager.persistSyncedLog = vi.fn().mockResolvedValue(undefined);
+    syncManager.markRetry = vi.fn().mockResolvedValue(1);
+    return syncManager;
+}
+
+describe('syncManager — plan generation hook (audit finding #2)', () => {
+    let syncManager;
+    let sendToFarmOS;
+    let tryGeneratePlanFromSeeding;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        vi.clearAllMocks();
+
+        // navigator.onLine no es writable en jsdom por defecto; defineProperty.
+        Object.defineProperty(navigator, 'onLine', {
+            configurable: true,
+            writable: true,
+            value: true,
+        });
+
+        ({ syncManager } = await import('../syncManager'));
+        ({ sendToFarmOS } = await import('../apiService'));
+        ({ tryGeneratePlanFromSeeding } = await import('../planGeneratorService'));
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('extractPlanSeed', () => {
+        it('extrae assetId, speciesSlug, plantingDate y plantName de seeding sincronizado', () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: true });
+            const result = makeFarmOSResponse({ remoteAssetUUID: PLANT_UUID });
+
+            const seed = syncManager.extractPlanSeed(tx, result);
+
+            expect(seed).toEqual({
+                assetId: PLANT_UUID,
+                speciesSlug: 'tomate',
+                plantingDate: new Date(1_700_000_000 * 1000).toISOString(),
+                plantName: 'Tomate Cherry [voz]',
+            });
+        });
+
+        it('retorna null si la transacción no es seeding', () => {
+            const tx = { ...makeSeedingTransaction(), type: 'observation' };
+            const result = makeFarmOSResponse();
+            expect(syncManager.extractPlanSeed(tx, result)).toBeNull();
+        });
+
+        it('retorna null si el inline asset--plant no trae _speciesSlug', () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: false });
+            const result = makeFarmOSResponse();
+            expect(syncManager.extractPlanSeed(tx, result)).toBeNull();
+        });
+
+        it('cae al UUID del payload si el syncResult no trae relationships.asset', () => {
+            const tx = makeSeedingTransaction({
+                includeSpeciesSlug: true,
+                assetUUID: PLANT_UUID,
+            });
+            const result = { data: { id: 'log-id', type: 'log--seeding' } };
+            const seed = syncManager.extractPlanSeed(tx, result);
+            expect(seed?.assetId).toBe(PLANT_UUID);
+        });
+
+        it('retorna null si no hay assetId ni en syncResult ni en payload', () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: true });
+            const result = { data: { id: 'log-id', type: 'log--seeding' } };
+            expect(syncManager.extractPlanSeed(tx, result)).toBeNull();
+        });
+    });
+
+    describe('syncAll → tryGeneratePlanFromSeeding (path offline)', () => {
+        it('llama tryGeneratePlanFromSeeding tras sync exitoso de seeding con _speciesSlug', async () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: true });
+            const farmosResult = makeFarmOSResponse({ remoteAssetUUID: PLANT_UUID });
+            patchSyncManager(syncManager, [tx]);
+            sendToFarmOS.mockResolvedValue(farmosResult);
+            tryGeneratePlanFromSeeding.mockResolvedValue({ steps: [{ id: 'step-1' }] });
+
+            await syncManager.syncAll();
+
+            expect(tryGeneratePlanFromSeeding).toHaveBeenCalledOnce();
+            expect(tryGeneratePlanFromSeeding).toHaveBeenCalledWith({
+                assetId: PLANT_UUID,
+                speciesSlug: 'tomate',
+                plantingDate: new Date(1_700_000_000 * 1000).toISOString(),
+                plantName: 'Tomate Cherry [voz]',
+            });
+        });
+
+        it('emite syncCompleted con planGenerated cuando el plan tiene steps', async () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: true });
+            patchSyncManager(syncManager, [tx]);
+            sendToFarmOS.mockResolvedValue(makeFarmOSResponse());
+            tryGeneratePlanFromSeeding.mockResolvedValue({ steps: [{ id: 's1' }, { id: 's2' }] });
+
+            const events = [];
+            const listener = (e) => events.push(e.detail);
+            window.addEventListener('syncCompleted', listener);
+
+            await syncManager.syncAll();
+            window.removeEventListener('syncCompleted', listener);
+
+            const seedingEvent = events.find((d) => d?.planGenerated);
+            expect(seedingEvent).toBeTruthy();
+            expect(seedingEvent.planGenerated).toEqual({
+                plantId: PLANT_UUID,
+                plantName: 'Tomate Cherry [voz]',
+                steps: 2,
+            });
+        });
+
+        it('NO llama tryGeneratePlanFromSeeding si la transacción no es seeding', async () => {
+            const tx = {
+                id: 'tx-obs',
+                type: 'observation',
+                payload: { data: { type: 'log--observation', attributes: {}, relationships: {} } },
+                synced: false,
+            };
+            patchSyncManager(syncManager, [tx]);
+            sendToFarmOS.mockResolvedValue({ data: { id: 'log-obs' } });
+
+            await syncManager.syncAll();
+
+            expect(tryGeneratePlanFromSeeding).not.toHaveBeenCalled();
+        });
+
+        it('no rompe el sync si la generación de plan falla (resiliencia)', async () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: true });
+            patchSyncManager(syncManager, [tx]);
+            sendToFarmOS.mockResolvedValue(makeFarmOSResponse());
+            // El helper ya captura errores internamente y retorna null. Pero
+            // verificamos defensivamente que ante un throw inesperado, syncAll
+            // no propague. Forzamos rechazo y validamos que deleteTransaction
+            // se haya ejecutado igual.
+            tryGeneratePlanFromSeeding.mockResolvedValue(null);
+
+            await expect(syncManager.syncAll()).resolves.not.toThrow();
+            expect(syncManager.deleteTransaction).toHaveBeenCalledWith('tx-1');
+        });
+
+        it('idempotente: ya delegamos la verificación al helper — syncAll lo invoca una vez por transacción', async () => {
+            const tx = makeSeedingTransaction({ includeSpeciesSlug: true });
+            patchSyncManager(syncManager, [tx, { ...tx, id: 'tx-2' }]);
+            sendToFarmOS.mockResolvedValue(makeFarmOSResponse());
+            tryGeneratePlanFromSeeding.mockResolvedValue({ steps: [] });
+
+            await syncManager.syncAll();
+
+            // 2 transacciones seeding → 2 invocaciones. La idempotencia per
+            // assetId vive dentro del helper (tested aparte en planGeneratorService).
+            expect(tryGeneratePlanFromSeeding).toHaveBeenCalledTimes(2);
+        });
+    });
+});
+
+// Tests del helper compartido tryGeneratePlanFromSeeding viven en
+// src/services/__tests__/planGeneratorService.test.js — separados para que
+// vi.mock('../planGeneratorService') que necesita este archivo (para aislar
+// syncManager.syncAll) no contamine los tests del helper.

--- a/src/services/payloadService.js
+++ b/src/services/payloadService.js
@@ -1,6 +1,6 @@
 import { sendToFarmOS } from './apiService';
 import { syncManager } from './syncManager';
-import { generatePlanForPlant } from './planGeneratorService';
+import { tryGeneratePlanFromSeeding } from './planGeneratorService';
 
 /** @typedef {import('../types').ChagraAsset} ChagraAsset */
 /** @typedef {import('../types').ChagraLog} ChagraLog */
@@ -147,10 +147,14 @@ export const savePayload = async (type, payload) => {
           detail.plantId = candidate.assetId;
 
           if (candidate.assetId && candidate.speciesSlug) {
-            generatePlanForPlant({
+            // Delegado al helper compartido (planGeneratorService) para que
+            // path online y path offline-then-sync queden alineados. El
+            // helper es idempotente (skip si ya hay plan) y nunca throws.
+            tryGeneratePlanFromSeeding({
               assetId: candidate.assetId,
               speciesSlug: candidate.speciesSlug,
               plantingDate: candidate.plantingDate,
+              plantName: candidate.plantName,
             }).then((plan) => {
               if (plan?.steps?.length > 0) {
                 window.dispatchEvent(new CustomEvent('syncCompleted', {
@@ -166,9 +170,6 @@ export const savePayload = async (type, payload) => {
               } else {
                 window.dispatchEvent(new CustomEvent('syncCompleted', { detail }));
               }
-            }).catch((err) => {
-              console.warn('[payloadService] No se pudo generar plan post-seeding:', err);
-              window.dispatchEvent(new CustomEvent('syncCompleted', { detail }));
             });
             return { success: true, message: 'Guardado y sincronizado con servidor', data: result };
           }

--- a/src/services/planGeneratorService.js
+++ b/src/services/planGeneratorService.js
@@ -271,6 +271,73 @@ async function savePlan(plan) {
     });
 }
 
+/**
+ * tryGeneratePlanFromSeeding — wrapper idempotente para conectar el resultado
+ * de un POST seeding exitoso (sea path online o sync diferido) a la
+ * generación del plan de alimentación.
+ *
+ * Diseño:
+ * - Si falta assetId o speciesSlug → no-op (retorna null sin error).
+ * - Si ya existe un plan en IDB para ese assetId → skip (idempotente).
+ * - Si la generación falla → log warning y retorna null. NUNCA throw — no
+ *   debe romper el flujo de sync ni el path online del payloadService.
+ *
+ * Audit finding #2 (2026-05-18): el path online ya generaba plan inline,
+ * pero el path offline-then-sync (syncManager.syncAll) dejaba la planta
+ * creada sin plan al volver la conexión. Este helper centraliza la lógica
+ * para ambos paths.
+ *
+ * @param {object} input
+ * @param {string} input.assetId - UUID FarmOS del asset--plant recién creado
+ * @param {string|null} input.speciesSlug - slug del catálogo (puede ser null)
+ * @param {string} input.plantingDate - ISO date string de siembra
+ * @param {string} [input.plantName] - nombre del asset para el evento
+ * @param {string} [input.climateZone] - opcional, modula offsets
+ * @param {string} [input.lunarPhase] - opcional, modula offsets
+ * @returns {Promise<object|null>} El plan generado, null si no aplica o falló
+ */
+export async function tryGeneratePlanFromSeeding({
+  assetId,
+  speciesSlug,
+  plantingDate,
+  plantName,
+  climateZone,
+  lunarPhase,
+} = {}) {
+  if (!assetId || !speciesSlug) return null;
+
+  // Idempotencia: si ya hay un plan persistido para este asset, no
+  // regeneramos. Esto evita planes duplicados cuando una transacción
+  // seeding se reintenta varias veces (retry con backoff exponencial) o
+  // cuando el path online ya generó plan y luego el sync diferido también
+  // intenta generar para la misma planta.
+  try {
+    const existing = await getPlanForAsset(assetId);
+    if (existing) return existing;
+  } catch (err) {
+    console.warn('[planGeneratorService] No se pudo consultar plan existente, intentando generar:', err);
+  }
+
+  try {
+    const plan = await generatePlanForPlant({
+      assetId,
+      speciesSlug,
+      plantingDate,
+      climateZone,
+      lunarPhase,
+    });
+    if (plan && plantName) {
+      // Atadura informativa para que consumers del result puedan emitir
+      // eventos toast con el nombre amigable.
+      plan._plantName = plantName;
+    }
+    return plan;
+  } catch (err) {
+    console.warn('[planGeneratorService] No se pudo generar plan post-seeding:', err);
+    return null;
+  }
+}
+
 export async function getPlanForAsset(assetId) {
     const db = await openDB();
     return new Promise((resolve, reject) => {

--- a/src/services/syncManager.js
+++ b/src/services/syncManager.js
@@ -4,6 +4,7 @@ import { logCache } from '../db/logCache';
 import { newId } from '../utils/id';
 import { getCompletedTaskIds } from '../utils/taskCompletionParser';
 import { recordEvent } from './voiceTelemetryService';
+import { tryGeneratePlanFromSeeding } from './planGeneratorService';
 
 const STORE_NAME = 'pending_transactions';
 const TASKS_STORE_NAME = 'pending_tasks';
@@ -176,11 +177,38 @@ class SyncManager {
         }
 
         try {
-          await this.syncTransaction(transaction);
-          await this.persistSyncedLog(transaction, null);
+          const syncResult = await this.syncTransaction(transaction);
+          await this.persistSyncedLog(transaction, syncResult);
           await this.deleteTransaction(transaction.id);
           synced++;
           console.info(`[SyncManager] Transacción ${transaction.id} completada y purgada.`);
+
+          // Audit finding #2 (2026-05-18): el path offline-then-sync no
+          // dispara generación de plan de alimentación. Si la transacción
+          // es seeding y vino con _planSeed (capturado al encolar), generar
+          // ahora que tenemos asset creado en FarmOS. Idempotente: el helper
+          // skipea si ya hay plan. NO bloquea el sync ante fallo.
+          const planSeed = this.extractPlanSeed(transaction, syncResult);
+          if (planSeed) {
+            const plan = await tryGeneratePlanFromSeeding(planSeed);
+            if (plan?.steps?.length > 0) {
+              window.dispatchEvent(new CustomEvent('syncCompleted', {
+                detail: {
+                  type: transaction.type,
+                  id: transaction.id,
+                  remoteId: transaction.remoteId,
+                  plantId: planSeed.assetId,
+                  planGenerated: {
+                    plantId: planSeed.assetId,
+                    plantName: planSeed.plantName,
+                    steps: plan.steps.length,
+                  },
+                },
+              }));
+              continue;
+            }
+          }
+
           window.dispatchEvent(new CustomEvent('syncCompleted', {
             detail: {
               type: transaction.type,
@@ -367,6 +395,69 @@ class SyncManager {
     } catch (err) {
       console.warn('[SyncManager] No se pudo persistir log sincronizado (no crítico):', err.message);
     }
+  }
+
+  /**
+   * extractPlanSeed — extrae los inputs necesarios para generar un plan de
+   * alimentación a partir de una transacción seeding ya sincronizada con
+   * FarmOS. Devuelve null si la transacción no es seeding o no contiene
+   * suficiente información (sin assetId remoto o sin speciesSlug).
+   *
+   * Reglas:
+   * - Solo aplica a `transaction.type === 'seeding'` o `log--seeding`.
+   * - assetId: primero intenta del syncResult (relaciones devueltas por
+   *   FarmOS), después del payload encolado (asset relationship si trae UUID).
+   * - speciesSlug: del inline `_speciesSlug` que VoiceCapture adjunta al
+   *   asset--plant. AssetsDashboard NO lo adjunta (genera el plan inline
+   *   en el componente), por lo que en ese path este helper retorna null
+   *   y el sync solo emite syncCompleted plano — comportamiento correcto.
+   * - plantingDate: del attributes.timestamp del log--seeding (segundos
+   *   epoch FarmOS).
+   *
+   * @param {object} transaction - registro pending_transactions
+   * @param {object} syncResult - respuesta de sendToFarmOS al POST seeding
+   * @returns {object|null} { assetId, speciesSlug, plantingDate, plantName } o null
+   */
+  extractPlanSeed(transaction, syncResult) {
+    const type = transaction?.type;
+    if (type !== 'seeding' && type !== 'log--seeding') return null;
+
+    const payload = transaction.payload || {};
+    const rels = payload?.data?.relationships || {};
+    const assetRel = rels.asset?.data;
+    const assetEntries = Array.isArray(assetRel) ? assetRel : (assetRel ? [assetRel] : []);
+
+    // Buscar inline con _speciesSlug (VoiceCapture path).
+    const inlineWithSpecies = assetEntries.find(
+      (a) => a && a.type === 'asset--plant' && a._speciesSlug
+    );
+    if (!inlineWithSpecies) return null;
+
+    const speciesSlug = inlineWithSpecies._speciesSlug;
+    const plantName = inlineWithSpecies.attributes?.name || 'planta';
+
+    // assetId: prioridad al syncResult (relaciones devueltas por FarmOS tras
+    // el POST). Fallback al payload si trae UUID directo en el inline.
+    let assetId = null;
+    const resultRels = syncResult?.data?.relationships?.asset?.data;
+    const resultAssetEntries = Array.isArray(resultRels) ? resultRels : (resultRels ? [resultRels] : []);
+    const isUUID = (id) => typeof id === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+
+    const remoteWithId = resultAssetEntries.find((a) => isUUID(a?.id));
+    if (remoteWithId) {
+      assetId = remoteWithId.id;
+    } else if (isUUID(inlineWithSpecies.id)) {
+      assetId = inlineWithSpecies.id;
+    }
+
+    if (!assetId) return null;
+
+    const timestampSec = Number(payload?.data?.attributes?.timestamp);
+    const plantingDate = Number.isFinite(timestampSec)
+      ? new Date(timestampSec * 1000).toISOString()
+      : new Date().toISOString();
+
+    return { assetId, speciesSlug, plantingDate, plantName };
   }
 
   // Helper de retrocompatibilidad: resuelve endpoint por type cuando la transacción


### PR DESCRIPTION
## Bug (audit finding #2, P1)

`audit/2026-05-18-conexiones-rotas-deep.md` finding #2:

> `payloadService` offline path: Voice/UI offline → asset creado, plan no se genera nunca aunque vuelva la conexión. Hook `generatePlanForPlant` también en `syncManager.processPending` cuando se procesa un `seeding` exitoso.

**Síntoma:** operador offline en finca (caso típico Diana en Cauca/Quindío) graba una siembra por voz. El payload se encola en `pending_transactions`. Cuando vuelve la conexión, `syncManager.syncAll` reenvía el POST a FarmOS exitosamente — pero NO disparaba `generatePlanForPlant`. La planta quedaba creada sin plan de alimentación.

## Solución

Extrae un helper compartido `tryGeneratePlanFromSeeding` y lo invoca desde ambos paths (online y offline-then-sync).

### Cambios

- **`planGeneratorService.js`** — nuevo export `tryGeneratePlanFromSeeding({assetId, speciesSlug, plantingDate, plantName})`:
  - Idempotente: si `getPlanForAsset(assetId)` ya retorna un plan, no regenera.
  - No-throw: captura errores internamente y retorna `null` para no romper el flujo de sync ni el path online.
- **`payloadService.savePayload`** — el path online delega al helper en lugar de llamar `generatePlanForPlant` inline. Comportamiento online idéntico (mismos eventos `syncCompleted` con `planGenerated`).
- **`syncManager.syncAll`** — captura el `syncResult` del `syncTransaction` y, si la transacción es seeding con `_speciesSlug` adjuntado por VoiceCapture, invoca `tryGeneratePlanFromSeeding` y emite `syncCompleted` con `planGenerated`.
- **`syncManager.extractPlanSeed`** — método nuevo que lee `_speciesSlug` del inline `asset--plant` y el `assetId` remoto devuelto por FarmOS tras el POST seeding. Retorna `null` si no hay inputs suficientes (sin assetId remoto o sin speciesSlug → el path AssetsDashboard, que ya genera plan inline en el componente, queda intocado).

### Tests nuevos (14)

- **`src/services/__tests__/syncManager.test.js`** (10 tests):
  - `extractPlanSeed`: extracción correcta de inputs (5 casos: happy path, no-seeding, sin _speciesSlug, fallback al payload UUID, sin assetId).
  - `syncAll → tryGeneratePlanFromSeeding`: invocación tras sync exitoso, emisión de `syncCompleted` con `planGenerated`, skip en transacciones no-seeding, resiliencia ante fallo del helper, idempotencia por invocación.
- **`src/services/__tests__/planGeneratorService.test.js`** (4 tests):
  - Guards: retorna null si falta `assetId` o `speciesSlug`.
  - Genera plan si no existe.
  - Idempotente: retorna plan existente sin regenerar si ya hay uno para el `asset_id`.

## Validación

- `npm run test:unit`: **173 tests pasados** (155 baseline + 14 nuevos + 4 ajustes intermedios) en 21 archivos.
- `npm run lint`: limpio.
- `npm run build`: verde, sin warnings nuevos.

## Test plan

- [x] Unit tests pasan (`npm run test:unit`).
- [x] Lint limpio (`npm run lint`).
- [x] Build verde (`npm run build`).
- [ ] CodeQL SAST (merge-gate).
- [ ] Playwright E2E offline-first (merge-gate).
- [ ] Verificación manual post-deploy: registrar siembra por voz offline → reconectar → confirmar que el plan se genera y aparece en Bodega → Planes.

## Refs

- Audit: `Chagra-strategy/audit/2026-05-18-conexiones-rotas-deep.md` finding #2 (P1).
- Bump: `0.12.123 → 0.12.124` + SW cache `chagra-v165 → chagra-v166` (auto via `auto-bump-version.mjs`).