### PR TITLE
feat(voice): entityExtractor enriquece con RAG (companions, biopreparados, warnings)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.123",
+  "version": "0.12.124",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v165';
+const CACHE_NAME = 'chagra-v166';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -3,6 +3,7 @@ import { Mic, MicOff, AlertTriangle, Save, RotateCcw, Ear, BrainCircuit } from '
 import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import { transcribe, queueForRetry } from '../services/voiceService';
 import { extractEntities } from '../services/entityExtractor';
+import { enrichEntitiesWithRag } from '../services/voiceRagEnricher';
 import { syncManager } from '../services/syncManager';
 import { savePayload } from '../services/payloadService';
 import { applyRegionalismOverlay, getRegionFromDepartment } from '../services/regionalismsService';
@@ -177,8 +178,22 @@ export default function VoiceCapture({ onSave }) {
         const extracted = await extractEntities(text, {
           onToken: (_chunk, full) => setLiveStream(full),
         });
-        setEntities(extracted);
-        logVoiceEvent('voice:extraction_done', { entityCount: extracted.length });
+        // Enriquecimiento RAG post-extracción (audit 2026-05-18). No bloqueante
+        // a nivel de error: si falla, las entidades quedan sin _ragInsights y
+        // la UI degrada gracefully.
+        const { entities: enriched, summary } = await enrichEntitiesWithRag(extracted)
+          .catch((err) => {
+            console.warn('[VoiceCapture] enrichEntitiesWithRag failed (reprocess):', err);
+            return { entities: extracted, summary: { enriched: 0, total: extracted.length, slugs: [] } };
+          });
+        setEntities(enriched);
+        logVoiceEvent('voice:extraction_done', { entityCount: enriched.length });
+        logVoiceEvent('voice:rag_enriched', {
+          rag_enriched: summary.enriched > 0,
+          enriched: summary.enriched,
+          total: summary.total,
+          slugs: summary.slugs,
+        });
         recordEvent({
           event_type: 'voice_extraction_success',
           flujo: 'voice_capture',
@@ -243,8 +258,22 @@ export default function VoiceCapture({ onSave }) {
       const extracted = await extractEntities(text, {
         onToken: (_chunk, full) => setLiveStream(full),
       });
-      setEntities(extracted);
-      logVoiceEvent('voice:extraction_done', { entityCount: extracted.length });
+      // Enriquecimiento RAG post-extracción (audit 2026-05-18). Tolerante a
+      // fallas: si el corpus no carga o no hay hits, se devuelven entidades
+      // sin _ragInsights y VoiceConfirmation oculta la sección.
+      const { entities: enriched, summary } = await enrichEntitiesWithRag(extracted)
+        .catch((err) => {
+          console.warn('[VoiceCapture] enrichEntitiesWithRag failed:', err);
+          return { entities: extracted, summary: { enriched: 0, total: extracted.length, slugs: [] } };
+        });
+      setEntities(enriched);
+      logVoiceEvent('voice:extraction_done', { entityCount: enriched.length });
+      logVoiceEvent('voice:rag_enriched', {
+        rag_enriched: summary.enriched > 0,
+        enriched: summary.enriched,
+        total: summary.total,
+        slugs: summary.slugs,
+      });
       setView(STATE_REVIEW);
     } catch (err) {
       logVoiceEvent('voice:extraction_failed', { error: err.message }, 'warn');

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Check, X, Trash2, AlertTriangle, Wand2 } from 'lucide-react';
+import { Check, X, Trash2, AlertTriangle, Wand2, Sprout, FlaskConical, Ban } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
 import { CROP_TAXONOMY } from '../config/taxonomy';
@@ -120,6 +120,10 @@ export default function VoiceConfirmation({
         locationType: resolvedLoc?.type || 'asset--land',
         locationMatchedName: resolvedLoc?.matchedName || null,
         locationScore: resolvedLoc?.score || null,
+        // Insights del RAG post-extracción (audit 2026-05-18). Opcional: si
+        // el RAG no encontró hits o el corpus está cold, queda null y la UI
+        // omite la sección. Ver voiceRagEnricher.js.
+        ragInsights: e._ragInsights || null,
       };
     })
   );
@@ -150,6 +154,11 @@ export default function VoiceConfirmation({
         locationType: source.locationType || 'asset--land',
         locationMatchedName: source.locationMatchedName || null,
         locationScore: source.locationScore || null,
+        // Rows agregadas por sugerencia de compañeros no traen pre-fetch
+        // del RAG; la pantalla solo muestra ragInsights para las extraídas
+        // por el LLM. Si en el futuro se requiere, se puede invocar
+        // enrichEntity(name) on-demand aquí.
+        ragInsights: null,
       },
     ]);
   };
@@ -311,6 +320,75 @@ export default function VoiceConfirmation({
               </div>
             );
           })()}
+
+          {/* Insights RAG post-extracción (audit 2026-05-18). Renderiza
+              companions/antagonists/biopreparados/warnings extraídos del
+              corpus en public/cycle-content/ vía voiceRagEnricher. Si
+              ragInsights es null (RAG cold, sin hits, o sección sin datos),
+              esta sección no se muestra — degrade gracefully. */}
+          {row.ragInsights && (
+            <div className="mt-2 pt-3 border-t border-slate-800 flex flex-col gap-2">
+              <p className="text-2xs uppercase font-bold text-slate-500 flex items-center gap-1">
+                <Sprout size={11} className="text-emerald-400" />
+                Catálogo dice
+                {row.ragInsights.sourceSlug && (
+                  <span className="normal-case font-mono text-slate-600 text-2xs">
+                    · {row.ragInsights.sourceSlug}
+                  </span>
+                )}
+              </p>
+
+              {row.ragInsights.invasive && (
+                <div className="bg-red-900/30 border border-red-800/60 rounded-lg p-2 text-xs text-red-200 flex items-start gap-2">
+                  <AlertTriangle size={14} className="text-red-400 shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <p className="font-bold">Especie marcada invasora</p>
+                    {row.ragInsights.warnings.map((w, wi) => (
+                      <p key={wi} className="text-2xs mt-0.5 text-red-300/90">{w}</p>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {row.ragInsights.companions.length > 0 && (
+                <div className="text-xs text-emerald-200/90">
+                  <span className="font-bold inline-flex items-center gap-1">
+                    <Sprout size={12} className="text-emerald-400" /> Va bien con:
+                  </span>{' '}
+                  <span className="text-slate-300">
+                    {row.ragInsights.companions.slice(0, 4).map((c) => c.especie).join(', ')}
+                  </span>
+                </div>
+              )}
+
+              {row.ragInsights.antagonists.length > 0 && (
+                <div className="text-xs text-amber-200/90">
+                  <span className="font-bold inline-flex items-center gap-1">
+                    <Ban size={12} className="text-amber-400" /> Evitar junto a:
+                  </span>{' '}
+                  <span className="text-slate-300">
+                    {row.ragInsights.antagonists.slice(0, 4).map((a) => a.especie).join(', ')}
+                  </span>
+                </div>
+              )}
+
+              {row.ragInsights.biopreparados.length > 0 && (
+                <div className="text-xs text-sky-200/90">
+                  <span className="font-bold inline-flex items-center gap-1">
+                    <FlaskConical size={12} className="text-sky-400" /> Plan típico:
+                  </span>
+                  <ul className="mt-1 ml-4 list-disc text-2xs text-slate-300 space-y-0.5">
+                    {row.ragInsights.biopreparados.slice(0, 4).map((b, bi) => (
+                      <li key={bi}>
+                        <span className="text-slate-200">{b.nombre}</span>
+                        {b.uso && <span className="text-slate-400"> — {b.uso}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Compañeros sugeridos (motor de gremios). Solo aparece cuando
               la especie matcheo contra CROP_TAXONOMY (cropSlug presente),

--- a/src/services/__tests__/voiceRagEnricher.test.js
+++ b/src/services/__tests__/voiceRagEnricher.test.js
@@ -1,0 +1,286 @@
+/**
+ * voiceRagEnricher.test.js — cobertura unitaria del módulo de enriquecimiento
+ * RAG post-extracción de entidades de voz (audit 2026-05-18).
+ *
+ * Estrategia:
+ *   - Mock de `ragRetriever.retrieve` para simular hits BM25 (vía vi.mock).
+ *   - Mock de `fetch` global para servir docs species en
+ *     /cycle-content/<slug>.json sin tocar disco.
+ *   - Casos cubiertos:
+ *       1. Species válida con companions+antagonists+biopreparados → enriched.
+ *       2. Species invasora → warnings + flag invasive.
+ *       3. Species sin cobertura en RAG (retrieve devuelve []) → null.
+ *       4. Fetch de doc falla → null.
+ *       5. Pure helpers (detectInvasive, normalize*).
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn(),
+}));
+
+import { retrieve } from '../ragRetriever';
+import { enrichEntity, enrichEntitiesWithRag, __TEST__ } from '../voiceRagEnricher';
+
+const FRESA_DOC = {
+  species_slug: 'fresa',
+  scientific_name: 'Fragaria × ananassa Duch.',
+  category: 'frutales_perennes',
+  conservation_status: 'cultivo_comun',
+  companions: [
+    { especie: 'Caléndula francesa (Tagetes patula)', razon: 'Mata nematodos' },
+    { especie: 'Ajo (Allium sativum)', razon: 'Espanta ácaros y pulgones' },
+  ],
+  antagonistas: [
+    { especie: 'Tomate (Solanum lycopersicum)', razon: 'Comparten Verticillium' },
+    { especie: 'Repollo y brócoli (Brassica oleracea)', razon: 'Compiten por nitrógeno' },
+  ],
+  biopreparados: [
+    { nombre: 'Bocashi', uso: '200 g/planta al trasplante' },
+    { nombre: 'Caldo bordelés', uso: '0.5% aspersión, EVITAR en floración' },
+  ],
+};
+
+const RETAMO_DOC = {
+  species_slug: 'ulex_europaeus',
+  scientific_name: 'Ulex europaeus L.',
+  category: 'especies_invasoras',
+  conservation_status: 'invasor',
+  roles_in_guild: ['invasive'],
+  antagonists: [],
+  companions: [],
+  biopreparados: [],
+  especies_nativas_sustitutas: ['alnus_acuminata', 'escallonia_paniculata', 'weinmannia_tomentosa'],
+};
+
+// Mock de fetch para servir docs species. Las llamadas a retrieve están
+// mockeadas independientemente; aquí solo manejamos /cycle-content/<slug>.json.
+function setupFetchMock(map) {
+  globalThis.fetch = vi.fn((url) => {
+    const match = String(url).match(/\/cycle-content\/([^.]+)\.json/);
+    if (!match) {
+      return Promise.resolve({ ok: false, status: 404, headers: { get: () => '' } });
+    }
+    const slug = match[1];
+    const doc = map[slug];
+    if (!doc) {
+      return Promise.resolve({ ok: false, status: 404, headers: { get: () => 'text/html' } });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+      json: () => Promise.resolve(doc),
+    });
+  });
+}
+
+describe('voiceRagEnricher', () => {
+  beforeEach(() => {
+    __TEST__._resetDocCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete globalThis.fetch;
+  });
+
+  describe('helpers puros', () => {
+    it('detectInvasive cubre los tres campos del esquema', () => {
+      expect(__TEST__.detectInvasive({ category: 'especies_invasoras' })).toBe(true);
+      expect(__TEST__.detectInvasive({ conservation_status: 'invasor' })).toBe(true);
+      expect(__TEST__.detectInvasive({ roles_in_guild: ['invasive'] })).toBe(true);
+      expect(__TEST__.detectInvasive({ category: 'frutales_perennes' })).toBe(false);
+      expect(__TEST__.detectInvasive(null)).toBe(false);
+      expect(__TEST__.detectInvasive({})).toBe(false);
+    });
+
+    it('normalizeCompanions soporta strings y objetos mixtos', () => {
+      const out = __TEST__.normalizeCompanions([
+        'Caléndula',
+        { especie: 'Ajo', razon: 'Repelente' },
+        { species: 'Menta', reason: 'Confunde plagas' },
+        null,
+        { razon: 'sin especie' },
+      ]);
+      expect(out).toHaveLength(3);
+      expect(out[0]).toEqual({ especie: 'Caléndula', razon: '' });
+      expect(out[1]).toEqual({ especie: 'Ajo', razon: 'Repelente' });
+      expect(out[2]).toEqual({ especie: 'Menta', razon: 'Confunde plagas' });
+    });
+
+    it('normalizeBiopreparados soporta strings y objetos', () => {
+      const out = __TEST__.normalizeBiopreparados([
+        'Bocashi',
+        { nombre: 'Biol', uso: 'Foliar 5%' },
+        { name: 'Caldo bordelés', usage: 'Preventivo' },
+        null,
+      ]);
+      expect(out).toHaveLength(3);
+      expect(out[0]).toEqual({ nombre: 'Bocashi', uso: '' });
+      expect(out[1]).toEqual({ nombre: 'Biol', uso: 'Foliar 5%' });
+      expect(out[2]).toEqual({ nombre: 'Caldo bordelés', uso: 'Preventivo' });
+    });
+
+    it('pickWinningSlug elige por topScore, desempate por totalScore', () => {
+      const hits = [
+        { species: 'fresa', score: 5.2 },
+        { species: 'fresa', score: 3.1 },
+        { species: 'tomate', score: 4.8 },
+        { species: 'tomate', score: 4.5 },
+        { species: 'tomate', score: 0 },
+      ];
+      expect(__TEST__.pickWinningSlug(hits)).toBe('fresa');
+    });
+
+    it('pickWinningSlug devuelve null si no hay hits con score>0', () => {
+      expect(__TEST__.pickWinningSlug([])).toBe(null);
+      expect(__TEST__.pickWinningSlug([{ species: 'x', score: 0 }])).toBe(null);
+      expect(__TEST__.pickWinningSlug(null)).toBe(null);
+    });
+  });
+
+  describe('enrichEntity', () => {
+    it('species válida → enriched con companions, antagonists, biopreparados', async () => {
+      retrieve.mockResolvedValueOnce([
+        { species: 'fresa', score: 8.2, text: 'companions caléndula ajo' },
+        { species: 'fresa', score: 6.1, text: 'biopreparados bocashi caldo bordelés' },
+      ]);
+      setupFetchMock({ fresa: FRESA_DOC });
+
+      const result = await enrichEntity({ crop: 'fresa', quantity: 50, location: 'tunel' });
+
+      expect(result).not.toBeNull();
+      expect(result.sourceSlug).toBe('fresa');
+      expect(result.invasive).toBe(false);
+      expect(result.warnings).toEqual([]);
+      expect(result.companions).toHaveLength(2);
+      expect(result.companions[0].especie).toContain('Caléndula');
+      expect(result.antagonists).toHaveLength(2);
+      expect(result.antagonists.map((a) => a.especie).some((s) => s.includes('Repollo'))).toBe(true);
+      expect(result.biopreparados).toHaveLength(2);
+      expect(result.biopreparados[0].nombre).toBe('Bocashi');
+      expect(result.hitCount).toBe(2);
+    });
+
+    it('species invasora → flag + warnings con sustitutas nativas', async () => {
+      retrieve.mockResolvedValueOnce([
+        { species: 'ulex_europaeus', score: 7.5, text: 'retamo espinoso invasor' },
+      ]);
+      setupFetchMock({ ulex_europaeus: RETAMO_DOC });
+
+      const result = await enrichEntity({ crop: 'retamo', quantity: 10, location: '' });
+
+      expect(result).not.toBeNull();
+      expect(result.invasive).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('invasora');
+      expect(result.warnings[0]).toContain('alnus_acuminata');
+      expect(result.sourceSlug).toBe('ulex_europaeus');
+    });
+
+    it('sin hits del RAG → null (degrade)', async () => {
+      retrieve.mockResolvedValueOnce([]);
+      setupFetchMock({});
+
+      const result = await enrichEntity({ crop: 'unobtanium', quantity: 1, location: '' });
+      expect(result).toBeNull();
+    });
+
+    it('fetch del doc falla (404) → null', async () => {
+      retrieve.mockResolvedValueOnce([
+        { species: 'fake_slug', score: 3.0, text: 'something' },
+      ]);
+      setupFetchMock({});  // map vacío → 404 para cualquier slug
+
+      const result = await enrichEntity({ crop: 'fake', quantity: 1, location: '' });
+      expect(result).toBeNull();
+    });
+
+    it('doc sin companions/biopreparados/warnings útiles → null', async () => {
+      retrieve.mockResolvedValueOnce([
+        { species: 'minimal', score: 2.0, text: 'x' },
+      ]);
+      setupFetchMock({
+        minimal: {
+          species_slug: 'minimal',
+          companions: [],
+          antagonistas: [],
+          biopreparados: [],
+        },
+      });
+
+      const result = await enrichEntity({ crop: 'minimal', quantity: 1, location: '' });
+      expect(result).toBeNull();
+    });
+
+    it('retrieve lanza error → null (no propaga)', async () => {
+      retrieve.mockRejectedValueOnce(new Error('corpus cold'));
+
+      const result = await enrichEntity({ crop: 'fresa', quantity: 1, location: '' });
+      expect(result).toBeNull();
+    });
+
+    it('entity inválida o crop vacío → null sin tocar retrieve', async () => {
+      expect(await enrichEntity(null)).toBeNull();
+      expect(await enrichEntity({})).toBeNull();
+      expect(await enrichEntity({ crop: '   ', quantity: 1 })).toBeNull();
+      expect(retrieve).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enrichEntitiesWithRag', () => {
+    it('procesa array completo y devuelve summary correcto', async () => {
+      retrieve
+        .mockResolvedValueOnce([{ species: 'fresa', score: 8.0 }])
+        .mockResolvedValueOnce([{ species: 'ulex_europaeus', score: 5.0 }])
+        .mockResolvedValueOnce([]);  // tercera entidad sin hit
+      setupFetchMock({ fresa: FRESA_DOC, ulex_europaeus: RETAMO_DOC });
+
+      const input = [
+        { crop: 'fresa', quantity: 50, location: 'tunel' },
+        { crop: 'retamo', quantity: 5, location: '' },
+        { crop: 'desconocida', quantity: 2, location: '' },
+      ];
+      const { entities, summary } = await enrichEntitiesWithRag(input);
+
+      expect(entities).toHaveLength(3);
+      expect(entities[0]._ragInsights).not.toBeNull();
+      expect(entities[0]._ragInsights.sourceSlug).toBe('fresa');
+      expect(entities[1]._ragInsights.invasive).toBe(true);
+      expect(entities[2]._ragInsights).toBeUndefined();  // no enriched
+
+      expect(summary.enriched).toBe(2);
+      expect(summary.total).toBe(3);
+      expect(summary.slugs).toEqual(expect.arrayContaining(['fresa', 'ulex_europaeus']));
+    });
+
+    it('array vacío → summary zero, sin llamadas a retrieve', async () => {
+      const { entities, summary } = await enrichEntitiesWithRag([]);
+      expect(entities).toEqual([]);
+      expect(summary).toEqual({ enriched: 0, total: 0, slugs: [] });
+      expect(retrieve).not.toHaveBeenCalled();
+    });
+
+    it('input no-array → tratado como vacío', async () => {
+      const { entities, summary } = await enrichEntitiesWithRag(null);
+      expect(entities).toEqual([]);
+      expect(summary.total).toBe(0);
+    });
+
+    it('preserva campos originales de cada entidad', async () => {
+      retrieve.mockResolvedValueOnce([{ species: 'fresa', score: 8.0 }]);
+      setupFetchMock({ fresa: FRESA_DOC });
+
+      const input = [{ crop: 'fresa', quantity: 50, location: 'tunel' }];
+      const { entities } = await enrichEntitiesWithRag(input);
+
+      expect(entities[0]).toMatchObject({
+        crop: 'fresa',
+        quantity: 50,
+        location: 'tunel',
+      });
+      expect(entities[0]._ragInsights).toBeTruthy();
+    });
+  });
+});

--- a/src/services/voiceRagEnricher.js
+++ b/src/services/voiceRagEnricher.js
@@ -1,0 +1,270 @@
+/**
+ * voiceRagEnricher.js — Conecta la salida del entityExtractor (voz / Whisper +
+ * gemma3:4b) con el corpus RAG en `public/cycle-content/` para enriquecer
+ * cada entidad reconocida con contexto agronómico del catálogo.
+ *
+ * Motivación (audit deep finding 2026-05-18):
+ *   El entityExtractor extrae `{crop, quantity, location}` pero NO consulta el
+ *   RAG, así que VoiceConfirmation no muestra:
+ *     - companions favorables (ej. "fresa va bien con caléndula y ajo"),
+ *     - antagonistas (ej. "evitar junto a repollo"),
+ *     - biopreparados típicos (ej. "bocashi al trasplante, caldo bordelés"),
+ *     - advertencia si la especie está marcada como invasora.
+ *
+ * Diseño:
+ *   1. `retrieve(query, k)` ya implementa BM25 sobre los pasajes del corpus.
+ *      Lo usamos como índice para identificar el `species_slug` que mejor
+ *      cubre la consulta `{nombre del cultivo} biopreparados companions
+ *      manejo`.
+ *   2. Una vez identificado el slug ganador (>= 1 hit con score>0), se
+ *      hace fetch directo del JSON del species en `/cycle-content/<slug>.json`
+ *      para extraer campos estructurados:
+ *        - `companions[].especie` + `razon`,
+ *        - `antagonistas[].especie` + `razon`,
+ *        - `biopreparados[].nombre` + `uso`,
+ *        - flags de invasora (category=="especies_invasoras" o
+ *          conservation_status=="invasor").
+ *      Esto evita el ruido del re-ranking por pasaje y nos da datos
+ *      directamente renderizables.
+ *   3. Degrade gracefully: si el RAG está cold (corpusCache=null y la primera
+ *      carga falla) o no hay hits, devuelve `ragInsights: null` y la UI
+ *      simplemente omite la sección.
+ *
+ * Contrato:
+ *   `enrichEntitiesWithRag(entities)` → mismo array de entidades, cada una
+ *   con `_ragInsights` opcional. Nunca lanza: errores se loguean con
+ *   `console.warn` y la entidad queda sin enriquecer.
+ *
+ * NO toca el LLM prompt de gemma3:4b ni la integración Whisper. Es estrictamente
+ * post-procesamiento sobre el array de entidades ya extraído.
+ */
+
+import { retrieve } from './ragRetriever';
+
+const CORPUS_PATH = '/cycle-content/';
+
+// Cache en memoria de documentos species ya fetcheados para evitar re-fetch
+// dentro de una misma sesión (común cuando el operador registra el mismo
+// cultivo varias veces).
+const docCache = new Map();
+
+/**
+ * Carga el JSON completo de un species desde `public/cycle-content/<slug>.json`.
+ * Cachea el resultado en memoria. Devuelve null si la carga falla.
+ */
+async function loadSpeciesDoc(slug) {
+  if (!slug) return null;
+  if (docCache.has(slug)) return docCache.get(slug);
+
+  try {
+    const res = await fetch(`${CORPUS_PATH}${slug}.json`);
+    if (!res.ok) {
+      docCache.set(slug, null);
+      return null;
+    }
+    const ct = res.headers.get('content-type') || '';
+    if (!ct.includes('json')) {
+      docCache.set(slug, null);
+      return null;
+    }
+    const data = await res.json();
+    docCache.set(slug, data);
+    return data;
+  } catch (err) {
+    console.warn(`[voiceRagEnricher] Failed to load species doc ${slug}:`, err);
+    docCache.set(slug, null);
+    return null;
+  }
+}
+
+/**
+ * Detección de especies invasoras. El corpus marca con dos campos posibles
+ * según la generación del JSON (esquema mixto pre/post 2026-05):
+ *   - `category: "especies_invasoras"`
+ *   - `conservation_status: "invasor"`
+ *   - `roles_in_guild` incluye `"invasive"`
+ *   - `cultivable: false`
+ */
+function detectInvasive(doc) {
+  if (!doc) return false;
+  if (doc.category === 'especies_invasoras') return true;
+  if (doc.conservation_status === 'invasor') return true;
+  if (Array.isArray(doc.roles_in_guild) && doc.roles_in_guild.includes('invasive')) return true;
+  return false;
+}
+
+/**
+ * Mapea companions del corpus al shape que renderiza VoiceConfirmation.
+ * Algunas variantes del corpus traen strings, otras objetos {especie, razon}.
+ */
+function normalizeCompanions(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((c) => {
+      if (typeof c === 'string') return { especie: c, razon: '' };
+      if (c && typeof c === 'object') {
+        const especie = c.especie || c.species || c.name || '';
+        const razon = c.razon || c.reason || '';
+        if (!especie) return null;
+        return { especie: String(especie).trim(), razon: String(razon).trim() };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function normalizeBiopreparados(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((b) => {
+      if (typeof b === 'string') return { nombre: b, uso: '' };
+      if (b && typeof b === 'object') {
+        const nombre = b.nombre || b.name || '';
+        const uso = b.uso || b.usage || '';
+        if (!nombre) return null;
+        return { nombre: String(nombre).trim(), uso: String(uso).trim() };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Extrae el species_slug que el BM25 considera más relevante para el cultivo.
+ * Reglas:
+ *   - Si todos los hits coinciden en un mismo species, ese es el winner.
+ *   - Si hay disparidad, escoge el species cuyo top-hit tiene mayor score
+ *     (suma de scores como tiebreaker).
+ *   - Devuelve null si no hay hits con score > 0.
+ */
+function pickWinningSlug(hits) {
+  if (!Array.isArray(hits) || hits.length === 0) return null;
+  const tally = new Map();
+  hits.forEach((h, i) => {
+    if (!h?.species || !(h.score > 0)) return;
+    const cur = tally.get(h.species) || { totalScore: 0, topScore: 0, firstRank: i };
+    cur.totalScore += h.score;
+    if (h.score > cur.topScore) cur.topScore = h.score;
+    tally.set(h.species, cur);
+  });
+  if (tally.size === 0) return null;
+  // Mejor topScore primero; desempate por totalScore (más cobertura del doc).
+  let bestSlug = null;
+  let bestKey = [-Infinity, -Infinity];
+  for (const [slug, info] of tally.entries()) {
+    const key = [info.topScore, info.totalScore];
+    if (key[0] > bestKey[0] || (key[0] === bestKey[0] && key[1] > bestKey[1])) {
+      bestKey = key;
+      bestSlug = slug;
+    }
+  }
+  return bestSlug;
+}
+
+/**
+ * Enriquece una única entidad reconocida por voz con insights del RAG.
+ *
+ * @param {{crop:string, quantity:number, location:string}} entity
+ * @returns {Promise<{
+ *   sourceSlug: string|null,
+ *   companions: Array<{especie:string, razon:string}>,
+ *   antagonists: Array<{especie:string, razon:string}>,
+ *   biopreparados: Array<{nombre:string, uso:string}>,
+ *   invasive: boolean,
+ *   warnings: string[],
+ *   hitCount: number
+ * }|null>} insights o null si el RAG no tiene cobertura.
+ */
+export async function enrichEntity(entity) {
+  if (!entity || typeof entity.crop !== 'string' || !entity.crop.trim()) return null;
+
+  const cropName = entity.crop.trim();
+  // Query construida para maximizar coverage del doc species: incluye términos
+  // clave del esquema (companions, biopreparados) y palabras de manejo. BM25
+  // los recogerá del passage flat-key + text.
+  const query = `${cropName} companions biopreparados manejo asociaciones`;
+
+  let hits = [];
+  try {
+    hits = await retrieve(query, 6);
+  } catch (err) {
+    console.warn('[voiceRagEnricher] retrieve failed:', err);
+    return null;
+  }
+
+  const slug = pickWinningSlug(hits);
+  if (!slug) return null;
+
+  const doc = await loadSpeciesDoc(slug);
+  if (!doc) return null;
+
+  const companions = normalizeCompanions(doc.companions);
+  const antagonists = normalizeCompanions(doc.antagonistas || doc.antagonists);
+  const biopreparados = normalizeBiopreparados(doc.biopreparados);
+  const invasive = detectInvasive(doc);
+
+  const warnings = [];
+  if (invasive) {
+    const sub = Array.isArray(doc.especies_nativas_sustitutas) && doc.especies_nativas_sustitutas.length > 0
+      ? ` Considera sustitutas nativas: ${doc.especies_nativas_sustitutas.slice(0, 3).join(', ')}.`
+      : '';
+    warnings.push(`Especie marcada como invasora en el catálogo.${sub}`);
+  }
+
+  // Si no hay nada útil que mostrar, devolvemos null para que la UI omita
+  // la sección por completo (degrade gracefully).
+  const hasSomething =
+    companions.length > 0 ||
+    antagonists.length > 0 ||
+    biopreparados.length > 0 ||
+    warnings.length > 0;
+  if (!hasSomething) return null;
+
+  return {
+    sourceSlug: slug,
+    companions,
+    antagonists,
+    biopreparados,
+    invasive,
+    warnings,
+    hitCount: hits.filter((h) => h.score > 0).length,
+  };
+}
+
+/**
+ * Enriquece un array de entidades en paralelo. Devuelve un nuevo array donde
+ * cada entidad puede traer `_ragInsights` (campo opcional). No muta el input.
+ *
+ * Telemetría: devuelve también un summary `{enriched, total}` que el caller
+ * puede registrar con voiceTelemetry.
+ *
+ * @param {Array} entities
+ * @returns {Promise<{entities: Array, summary: {enriched:number, total:number, slugs:string[]}}>}
+ */
+export async function enrichEntitiesWithRag(entities) {
+  const list = Array.isArray(entities) ? entities : [];
+  if (list.length === 0) return { entities: list, summary: { enriched: 0, total: 0, slugs: [] } };
+
+  const results = await Promise.all(list.map((e) => enrichEntity(e).catch(() => null)));
+  const enrichedEntities = list.map((e, i) => {
+    const insights = results[i];
+    if (!insights) return e;
+    return { ...e, _ragInsights: insights };
+  });
+
+  const slugs = results.filter(Boolean).map((r) => r.sourceSlug).filter(Boolean);
+  const summary = {
+    enriched: results.filter(Boolean).length,
+    total: list.length,
+    slugs,
+  };
+  return { entities: enrichedEntities, summary };
+}
+
+export const __TEST__ = {
+  detectInvasive,
+  normalizeCompanions,
+  normalizeBiopreparados,
+  pickWinningSlug,
+  _resetDocCache: () => docCache.clear(),
+};


### PR DESCRIPTION
## Summary

- **voiceRagEnricher.js (nuevo)**: tras `extractEntities` (gemma3:4b), consulta `ragRetriever.retrieve` para resolver el `species_slug` ganador por BM25 sobre el corpus `public/cycle-content/`, fetchea el doc del species y extrae companions, antagonistas, biopreparados y flags de invasora (`category`, `conservation_status`, `roles_in_guild`).
- **VoiceConfirmation**: renderiza una sección "Catálogo dice" con favorables / evitar / plan típico (biopreparados con uso/dosis) y warning rojo si la especie es invasora, incluyendo sustitutas nativas del catálogo.
- **VoiceCapture**: invoca `enrichEntitiesWithRag` después de `extractEntities` en ambos paths (live + reproceso). Tolerante a fallos del RAG: si retrieve revienta o el corpus está cold, las entidades quedan sin `_ragInsights` y la UI omite la sección — degrade gracefully.
- **Telemetría**: nuevo evento `voice:rag_enriched` con `{rag_enriched, enriched, total, slugs}` para medir hit rate en `VoiceTelemetryScreen`.
- **No se toca** el system prompt de gemma3:4b ni la integración Whisper — solo post-processing del array de entidades extraído.

## Ejemplo antes/después

**Operador dice:** _"voy a plantar 50 fresas en la zona del túnel"_

### Antes
Entities:
```json
[{ "crop": "fresa", "quantity": 50, "location": "tunel" }]
```
VoiceConfirmation muestra crop + cantidad + ubicación + Guild Suggestions (de speciesDefaults).

### Después
Entities tras enrichment:
```json
[{
  "crop": "fresa", "quantity": 50, "location": "tunel",
  "_ragInsights": {
    "sourceSlug": "fresa",
    "companions": [
      { "especie": "Borraja (Borago officinalis)", "razon": "Atrae abejas..." },
      { "especie": "Caléndula francesa (Tagetes patula)", "razon": "Mata nematodos" },
      { "especie": "Ajo (Allium sativum)", "razon": "Espanta ácaros y pulgones" }
    ],
    "antagonists": [
      { "especie": "Tomate (Solanum lycopersicum)", "razon": "Comparten Verticillium" },
      { "especie": "Repollo y brócoli (Brassica oleracea)", "razon": "Compiten por nitrógeno" }
    ],
    "biopreparados": [
      { "nombre": "Bocashi", "uso": "200 g/planta al trasplante; 50 g/planta..." },
      { "nombre": "Caldo bordelés", "uso": "0.5% aspersiones espaciadas. EVITAR en floración" }
    ],
    "invasive": false,
    "warnings": [],
    "hitCount": 6
  }
}]
```
VoiceConfirmation añade sección **Catálogo dice** con tres líneas (Va bien con / Evitar junto a / Plan típico) más warning rojo si invasora.

## Cambios UI VoiceConfirmation

- Nueva sección entre la preview de tracking_mode y GuildSuggestions.
- Iconos `Sprout` (companions), `Ban` (antagonists), `FlaskConical` (biopreparados), `AlertTriangle` (warnings).
- Header `Catálogo dice · <species_slug>` con el slug fuente del enriquecimiento.
- Warning rojo prominente para invasoras con lista de sustitutas nativas si están en el doc.

## Test plan

- [x] `npm run lint` verde
- [x] `npm run test:unit` 171/171 verde (16 casos nuevos en `voiceRagEnricher.test.js`)
- [x] `npm run build` verde
- [ ] CodeQL SAST verde
- [ ] Playwright E2E offline verde
- [ ] Manual smoke: grabar "sembré 5 fresas en invernadero" → verificar sección "Catálogo dice" aparece con companions/antagonists/biopreparados de `fresa.json`
- [ ] Manual smoke: grabar "sembré 10 retamo" → verificar warning rojo invasora
- [ ] Manual smoke: especie fuera de catálogo (ej. "kiwi") → verificar que la sección NO aparece y el resto del flujo sigue normal

## Referencias

- Audit deep finding 2026-05-18: "entityExtractor no consulta RAG post-extracción".
- Arquitectura voz: `ARCHITECTURE_VOICE_0.5.0.md`
- RAG retriever existente: `src/services/ragRetriever.js` (BM25 sobre `public/cycle-content/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)