### PR TITLE
feat(vision): analyzeFoliage usa RAG para diagnóstico contextualizado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.123",
+  "version": "0.12.124",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v165';
+const CACHE_NAME = 'chagra-v166';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/BitacoraEntryDetail.jsx
+++ b/src/components/BitacoraEntryDetail.jsx
@@ -91,11 +91,46 @@ function isEditableTask(entry) {
   return status === 'pending' || status === 'in_progress' || entry?._pending === true;
 }
 
+// Audit 2026-05-18 #4: extrae el asset_id (UUID asset--plant) de la entry
+// para luego derivar `speciesSlug` y enriquecer el RAG en `analyzeFoliage`.
+// Soporta los múltiples shapes que llegan a esta vista (payload pending,
+// log persistido, attributes JSON:API, etc).
+function getEntryAssetId(entry) {
+  if (!entry) return null;
+  const rels = entry.relationships
+    || entry.attributes?.relationships
+    || entry.payload?.data?.relationships;
+  const assetData = rels?.asset?.data;
+  if (Array.isArray(assetData) && assetData[0]?.id) return assetData[0].id;
+  if (assetData?.id) return assetData.id;
+  return entry.asset_id || entry.attributes?.asset_id || null;
+}
+
+// Patrón compartido con AssetDetailView/WorkerDashboard: slug-ify el name.
+function deriveSpeciesSlug(name) {
+  if (!name || typeof name !== 'string') return null;
+  return name.replace(/\s+#\d+$/, '').toLowerCase().replace(/\s+/g, '_').trim() || null;
+}
+
 export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
   const attachPhotoToLog = useAssetStore((s) => s.attachPhotoToLog);
+  const plants = useAssetStore((s) => s.plants);
   const [photoState, setPhotoState] = useState('idle'); // idle | uploading | success | error
   const [photoMsg, setPhotoMsg] = useState('');
   const fileInputRef = useRef(null);
+
+  // Audit 2026-05-18 #4: derivar speciesSlug del asset relacionado al log
+  // para que `analyzeFoliage` consulte RAG con contexto específico de la
+  // especie. Si la entry no tiene asset linkado (logs huérfanos) o el plant
+  // no está en store (eventual consistency), `analyzeFoliage` cae a fallback
+  // genérico — no rompe.
+  const entrySpeciesSlug = (() => {
+    const assetId = getEntryAssetId(entry);
+    if (!assetId) return null;
+    const plant = (plants || []).find((p) => p.id === assetId);
+    if (!plant) return null;
+    return plant.speciesSlug || deriveSpeciesSlug(plant.attributes?.name || plant.name);
+  })();
 
   // High-impact #3 (2026-05-03): analyzeFoliage post-attach experimental.
   // Mantenemos el blob en state tras attach exitoso para permitir analizar
@@ -174,6 +209,8 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
     try {
       const result = await analyzeFoliage(lastBlob, {
         onToken: (_chunk, fullText) => setAiStream(fullText),
+        speciesSlug: entrySpeciesSlug,
+        assetId: getEntryAssetId(entry),
       });
       if (result) {
         setAiResult(result);

--- a/src/components/EvidenceCapture.jsx
+++ b/src/components/EvidenceCapture.jsx
@@ -13,10 +13,16 @@ import { useGeolocation } from '../hooks/useGeolocation';
 /**
  * EvidenceCapture, Captura con diagnóstico IA y evolución histórica (Fase 20.2b).
  *
+ * Audit 2026-05-18 #4: cuando el caller conoce `speciesSlug`, lo propaga a
+ * `analyzeFoliage` para que el RAG inyecte passages específicos de esa
+ * especie al prompt vision (vs. diagnóstico genérico sin catálogo).
+ *
  * Props:
  *   - logId:          UUID del log
  *   - assetId:        UUID del activo relacionado (para historial)
  *   - assetGeometry:  WKT o GeoJSON de la ubicación del activo
+ *   - speciesSlug:    slug catálogo (ej. `fragaria_ananassa_monterrey`).
+ *                     Opcional — sin él, el RAG usa fallback genérico.
  *   - onCountChange:  callback(count)
  *   - onDiagnosis:    callback(diagnosis), para toast externo
  *   - disabled:       boolean
@@ -25,6 +31,7 @@ export const EvidenceCapture = ({
   logId,
   assetId = null,
   assetGeometry = null,
+  speciesSlug = null,
   onCountChange,
   onDiagnosis,
   disabled = false,
@@ -131,6 +138,8 @@ export const EvidenceCapture = ({
         try {
           const result = await analyzeFoliage(optimized, {
             onToken: (_chunk, full) => setLiveDiagnosis(full),
+            speciesSlug,
+            assetId,
           });
           if (result) {
             setDiagnosis(result);

--- a/src/components/LLMTelemetryScreen.jsx
+++ b/src/components/LLMTelemetryScreen.jsx
@@ -305,6 +305,7 @@ export default function LLMTelemetryScreen({ onBack }) {
                       <th className="text-right px-3 py-2">Total</th>
                       <th className="text-right px-3 py-2">Tokens</th>
                       <th className="text-right px-3 py-2">t/s</th>
+                      <th className="text-center px-3 py-2" title="Passages RAG inyectados al prompt">RAG</th>
                       <th className="text-center px-3 py-2">GPU</th>
                       <th className="text-center px-3 py-2">Estado</th>
                     </tr>
@@ -321,6 +322,9 @@ export default function LLMTelemetryScreen({ onBack }) {
                           <td className="px-3 py-1.5 text-right text-slate-300">{formatMs(e.total_ms)}</td>
                           <td className="px-3 py-1.5 text-right text-slate-500">{e.eval_count ?? '-'}</td>
                           <td className="px-3 py-1.5 text-right text-amber-400">{formatRate(e.eval_rate)}</td>
+                          <td className="px-3 py-1.5 text-center text-emerald-400 font-mono">
+                            {typeof e.rag_passages_used === 'number' ? e.rag_passages_used : '—'}
+                          </td>
                           <td className="px-3 py-1.5 text-center">
                             <span className={`text-[9px] px-1.5 py-0.5 rounded-full border font-mono ${proc.color}`}>{proc.label}</span>
                           </td>

--- a/src/components/WorkerDashboard.jsx
+++ b/src/components/WorkerDashboard.jsx
@@ -36,6 +36,14 @@ const formatDistance = (m) => {
   return `${(m / 1000).toFixed(1)}km`;
 };
 
+// Audit 2026-05-18 #4: deriva slug del catálogo desde el `name` del asset
+// para que `EvidenceCapture` lo propague a `analyzeFoliage` y el RAG inyecte
+// passages específicos. Patrón ya usado en `AssetDetailView.deriveSpeciesSlug`.
+const deriveSpeciesSlug = (name) => {
+  if (!name || typeof name !== 'string') return null;
+  return name.replace(/\s+#\d+$/, '').toLowerCase().replace(/\s+/g, '_').trim() || null;
+};
+
 export const WorkerDashboard = () => {
   const plants = useAssetStore((s) => s.plants);
   const lands = useAssetStore((s) => s.lands);
@@ -226,6 +234,14 @@ export const WorkerDashboard = () => {
                   logId={task.id}
                   assetId={task.asset_id || task.attributes?.asset_id}
                   assetGeometry={task.attributes?.intrinsic_geometry}
+                  speciesSlug={(() => {
+                    const aId = task.asset_id || task.attributes?.asset_id;
+                    if (!aId) return null;
+                    const plant = plants.find((p) => p.id === aId);
+                    return plant
+                      ? (plant.speciesSlug || deriveSpeciesSlug(plant.attributes?.name || plant.name))
+                      : null;
+                  })()}
                   disabled={isCompleting}
                   onCountChange={(count) => {
                     setEvidenceCounts((prev) => ({ ...prev, [task.id]: count }));

--- a/src/services/__tests__/aiService.test.js
+++ b/src/services/__tests__/aiService.test.js
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks DEBEN declararse antes del import del módulo bajo test.
+// Audit 2026-05-18 #4: integramos RAG en analyzeFoliage; estos tests
+// aíslan el flujo de retrieval + prompt building + propagación de
+// rag_passages_used a la telemetría.
+
+const streamOllamaMock = vi.fn();
+const retrieveMock = vi.fn();
+
+vi.mock('../ollamaStream', () => ({
+  streamOllama: (...args) => streamOllamaMock(...args),
+}));
+
+vi.mock('../ragRetriever', () => ({
+  retrieve: (...args) => retrieveMock(...args),
+}));
+
+// blobToBase64 internamente usa FileReader.readAsDataURL. JSDOM lo soporta,
+// pero el resultado depende del shape del Blob. Polyfill defensivo: si
+// global no provee FileReader compatible, simulamos suficiente.
+if (typeof globalThis.FileReader === 'undefined') {
+  globalThis.FileReader = class {
+    constructor() { this.onloadend = null; this.onerror = null; this.result = null; }
+    readAsDataURL(_blob) {
+      this.result = 'data:image/webp;base64,FAKE_BASE64';
+      queueMicrotask(() => this.onloadend && this.onloadend());
+    }
+  };
+}
+
+const { analyzeFoliage, __TEST__, __retrieveRagContextForFoliage } = await import('../aiService');
+
+const makeBlob = () => new Blob(['fake image bytes'], { type: 'image/webp' });
+
+const happyDiagnosisJson = JSON.stringify({
+  score: 78,
+  issues: ['mancha foliar incipiente'],
+  treatment: 'aplicar caldo bordelés (Fuente 1)',
+});
+
+beforeEach(() => {
+  streamOllamaMock.mockReset();
+  retrieveMock.mockReset();
+});
+
+describe('aiService — buildRagQuery (helper)', () => {
+  it('con speciesSlug → query especifica + tokens fitosanitarios', () => {
+    const q = __TEST__.buildRagQuery('fragaria_ananassa_monterrey');
+    expect(q).toContain('fragaria ananassa monterrey');
+    expect(q).toMatch(/plagas|enfermedades|manejo/i);
+  });
+
+  it('sin speciesSlug → fallback genérico agroecológico', () => {
+    expect(__TEST__.buildRagQuery(null)).toBe(__TEST__.RAG_FALLBACK_QUERY);
+    expect(__TEST__.buildRagQuery(undefined)).toBe(__TEST__.RAG_FALLBACK_QUERY);
+    expect(__TEST__.buildRagQuery('')).toBe(__TEST__.RAG_FALLBACK_QUERY);
+    expect(__TEST__.buildRagQuery('   ')).toBe(__TEST__.RAG_FALLBACK_QUERY);
+  });
+
+  it('normaliza underscores a espacios para que BM25 tokenice', () => {
+    const q = __TEST__.buildRagQuery('coffea_arabica');
+    expect(q).toContain('coffea arabica');
+    expect(q).not.toContain('coffea_arabica');
+  });
+});
+
+describe('aiService — formatRagContext (helper)', () => {
+  it('passages vacíos → string vacío (caller usa prompt base)', () => {
+    expect(__TEST__.formatRagContext([])).toBe('');
+    expect(__TEST__.formatRagContext(null)).toBe('');
+    expect(__TEST__.formatRagContext(undefined)).toBe('');
+  });
+
+  it('formatea bloque CONTEXTO_CIENTÍFICO con fuentes numeradas', () => {
+    const passages = [
+      { text: 'La fresa Monterrey es sensible a Botrytis cinerea en clima frío y húmedo.', species: 'fragaria_ananassa_monterrey', key: 'valor_pedagogico' },
+      { text: 'Caldo bordelés a 1% es el manejo agroecológico estándar AGROSAVIA.', species: 'fragaria_ananassa_monterrey', key: 'manejo' },
+    ];
+    const ctx = __TEST__.formatRagContext(passages);
+    expect(ctx).toContain('<CONTEXTO_CIENTÍFICO>');
+    expect(ctx).toContain('</CONTEXTO_CIENTÍFICO>');
+    expect(ctx).toContain('[Fuente 1 — fragaria_ananassa_monterrey :: valor_pedagogico]');
+    expect(ctx).toContain('[Fuente 2 — fragaria_ananassa_monterrey :: manejo]');
+    expect(ctx).toContain('Botrytis');
+    expect(ctx).toContain('AGROSAVIA');
+  });
+
+  it('trunca passages largos al cap defensivo', () => {
+    const longText = 'x'.repeat(__TEST__.PASSAGE_CHAR_CAP + 500);
+    const ctx = __TEST__.formatRagContext([{ text: longText, species: 'tomate', key: 'k' }]);
+    // El bloque incluye solo PASSAGE_CHAR_CAP 'x' (sin contar headers/fences).
+    const xs = (ctx.match(/x/g) || []).length;
+    expect(xs).toBe(__TEST__.PASSAGE_CHAR_CAP);
+  });
+
+  it('passages con text vacío se filtran (no bloques fantasma)', () => {
+    const ctx = __TEST__.formatRagContext([
+      { text: '   ', species: 'a', key: 'b' },
+      { text: 'contenido real útil para diagnóstico', species: 'c', key: 'd' },
+    ]);
+    expect(ctx).toContain('[Fuente 1 — c :: d]');
+    expect(ctx).not.toContain('[Fuente 2');
+  });
+});
+
+describe('aiService — buildDiagnosisPrompt (helper)', () => {
+  it('sin contexto → usa DIAGNOSIS_BASE_PROMPT crudo (degrade graceful)', () => {
+    expect(__TEST__.buildDiagnosisPrompt('')).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
+    expect(__TEST__.buildDiagnosisPrompt(null)).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
+  });
+
+  it('con contexto → instruye citar fuente + mantiene JSON output spec', () => {
+    const ctx = '<CONTEXTO_CIENTÍFICO>\nFuente 1\n</CONTEXTO_CIENTÍFICO>\n\n';
+    const prompt = __TEST__.buildDiagnosisPrompt(ctx);
+    expect(prompt).toContain('<CONTEXTO_CIENTÍFICO>');
+    expect(prompt).toContain('agroecológico');
+    expect(prompt).toMatch(/cit.*fuente/i);
+    expect(prompt).toContain('{"score": 0-100');
+  });
+});
+
+describe('aiService — __retrieveRagContextForFoliage (graceful degrade)', () => {
+  it('retrieve falla → retorna [] sin propagar la excepción', async () => {
+    retrieveMock.mockRejectedValueOnce(new Error('corpus boom'));
+    const result = await __retrieveRagContextForFoliage('cualquier');
+    expect(result).toEqual([]);
+  });
+
+  it('retrieve retorna non-array → normaliza a []', async () => {
+    retrieveMock.mockResolvedValueOnce(null);
+    const result = await __retrieveRagContextForFoliage('x');
+    expect(result).toEqual([]);
+  });
+
+  it('retrieve retorna passages → pasa-through', async () => {
+    const passages = [{ text: 'algo', species: 's', key: 'k' }];
+    retrieveMock.mockResolvedValueOnce(passages);
+    const result = await __retrieveRagContextForFoliage('s');
+    expect(result).toBe(passages);
+  });
+});
+
+describe('aiService — analyzeFoliage integración RAG', () => {
+  it('con speciesSlug → retrieve query incluye el slug + 3 passages al prompt', async () => {
+    retrieveMock.mockResolvedValueOnce([
+      { text: 'Mancha foliar en fresa por Mycosphaerella fragariae.', species: 'fragaria_ananassa_monterrey', key: 'valor_pedagogico' },
+      { text: 'Manejo: caldo bordelés 1%, podar foliolos enfermos.', species: 'fragaria_ananassa_monterrey', key: 'manejo_agroecologico' },
+      { text: 'AGROSAVIA recomienda inspección semanal en clima frío húmedo.', species: 'fragaria_ananassa_monterrey', key: 'monitoreo' },
+    ]);
+    streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
+
+    const result = await analyzeFoliage(makeBlob(), { speciesSlug: 'fragaria_ananassa_monterrey' });
+
+    expect(retrieveMock).toHaveBeenCalledTimes(1);
+    const [retrieveQuery, retrieveK] = retrieveMock.mock.calls[0];
+    expect(retrieveQuery).toContain('fragaria ananassa monterrey');
+    expect(retrieveK).toBe(3);
+
+    expect(streamOllamaMock).toHaveBeenCalledTimes(1);
+    const [, body, , options] = streamOllamaMock.mock.calls[0];
+    expect(body.model).toBe('gemma3:4b');
+    expect(body.prompt).toContain('<CONTEXTO_CIENTÍFICO>');
+    expect(body.prompt).toContain('Mycosphaerella fragariae');
+    expect(body.prompt).toContain('caldo bordelés');
+    expect(body.prompt).toMatch(/cit.*fuente/i);
+    expect(options.meta).toEqual({ rag_passages_used: 3 });
+
+    expect(result).toEqual({
+      score: 78,
+      issues: ['mancha foliar incipiente'],
+      treatment: 'aplicar caldo bordelés (Fuente 1)',
+      treatment_suggestion: 'aplicar caldo bordelés (Fuente 1)',
+    });
+  });
+
+  it('sin speciesSlug → fallback query genérica + prompt aún incluye contexto si RAG matchea', async () => {
+    retrieveMock.mockResolvedValueOnce([
+      { text: 'Pautas generales de manejo agroecológico colombiano.', species: 'general', key: 'guía' },
+    ]);
+    streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
+
+    await analyzeFoliage(makeBlob(), {});
+
+    const [retrieveQuery] = retrieveMock.mock.calls[0];
+    expect(retrieveQuery).toBe(__TEST__.RAG_FALLBACK_QUERY);
+
+    const [, body, , options] = streamOllamaMock.mock.calls[0];
+    expect(body.prompt).toContain('<CONTEXTO_CIENTÍFICO>');
+    expect(options.meta).toEqual({ rag_passages_used: 1 });
+  });
+
+  it('RAG retorna [] (cold-start / sin matches) → usa DIAGNOSIS_BASE_PROMPT crudo', async () => {
+    retrieveMock.mockResolvedValueOnce([]);
+    streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
+
+    await analyzeFoliage(makeBlob(), { speciesSlug: 'planta_inexistente' });
+
+    const [, body, , options] = streamOllamaMock.mock.calls[0];
+    expect(body.prompt).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
+    expect(body.prompt).not.toContain('<CONTEXTO_CIENTÍFICO>');
+    expect(options.meta).toEqual({ rag_passages_used: 0 });
+  });
+
+  it('RAG lanza excepción → degrade graceful al prompt base sin romper analyzeFoliage', async () => {
+    retrieveMock.mockRejectedValueOnce(new Error('boom corpus'));
+    streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
+
+    const result = await analyzeFoliage(makeBlob(), { speciesSlug: 'cualquier' });
+
+    expect(result).not.toBeNull();
+    expect(result.score).toBe(78);
+
+    const [, body, , options] = streamOllamaMock.mock.calls[0];
+    expect(body.prompt).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
+    expect(options.meta).toEqual({ rag_passages_used: 0 });
+  });
+
+  it('streamOllama falla → retorna null sin romper (contrato legacy preservado)', async () => {
+    retrieveMock.mockResolvedValueOnce([]);
+    streamOllamaMock.mockRejectedValueOnce(new Error('ollama down'));
+
+    const result = await analyzeFoliage(makeBlob(), {});
+    expect(result).toBeNull();
+  });
+
+  it('response con markdown fences → JSON.parse robusto', async () => {
+    retrieveMock.mockResolvedValueOnce([]);
+    streamOllamaMock.mockResolvedValueOnce('```json\n' + happyDiagnosisJson + '\n```');
+
+    const result = await analyzeFoliage(makeBlob(), {});
+    expect(result.score).toBe(78);
+    expect(result.treatment_suggestion).toContain('caldo bordelés');
+  });
+
+  it('legacy: respuesta sin field treatment → treatment_suggestion vacío', async () => {
+    retrieveMock.mockResolvedValueOnce([]);
+    streamOllamaMock.mockResolvedValueOnce(JSON.stringify({ score: 95, issues: [] }));
+    const result = await analyzeFoliage(makeBlob(), {});
+    expect(result.treatment_suggestion).toBe('');
+  });
+});

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -6,6 +6,12 @@
  * respuesta en streaming NDJSON via `streamOllama`, permitiendo a la UI
  * mostrar el diagnóstico token-por-token con efecto typewriter.
  *
+ * Audit 2026-05-18 finding #4 (P2): `analyzeFoliage` ahora consume RAG
+ * (`ragRetriever.retrieve`) para pre-pendear top-3 passages del corpus
+ * `cycle-content/*.json` al prompt. Resultado: diagnóstico contextualizado
+ * con `valor_pedagogico`, manejo agroecológico y fuentes del catálogo
+ * (AGROSAVIA / IDEAM / POWO) en lugar de respuesta genérica.
+ *
  * @typedef {import('../types').ChagraAsset} ChagraAsset
  * @typedef {import('../types').ChagraLog} ChagraLog
  * @typedef {import('../types').ChagraSpecies} ChagraSpecies
@@ -13,6 +19,7 @@
  */
 
 import { streamOllama } from './ollamaStream';
+import { retrieve } from './ragRetriever';
 
 // Ruta relativa: Nginx proxea /api/ollama/ → http://localhost:11434/
 // Ruta final: /api/ollama/api/generate → http://localhost:11434/api/generate
@@ -29,7 +36,76 @@ const DIAGNOSIS_MODEL = 'gemma3:4b';
 const VISION_SPECIES_MODEL = 'qwen2.5vl:7b';
 const VISION_SPECIES_FALLBACK_MODEL = 'gemma3:4b';
 
-const DIAGNOSIS_PROMPT = 'detect disease, nutrient deficiency, and overall plant health. Output JSON: {"score": 0-100, "issues": [], "treatment": ""}';
+// Prompt base sin contexto RAG. Fallback usado cuando el corpus no cargó
+// o el retrieve no devolvió passages relevantes.
+const DIAGNOSIS_BASE_PROMPT = 'detect disease, nutrient deficiency, and overall plant health. Output JSON: {"score": 0-100, "issues": [], "treatment": ""}';
+
+// Query genérica para fallback cuando no conocemos la especie. Apunta a
+// passages del corpus que hablen de manejo agroecológico colombiano —
+// catálogo v3.1 tiene `valor_pedagogico` con esa orientación.
+const RAG_FALLBACK_QUERY = 'diagnóstico foliar agroecológico colombiano plagas enfermedades manejo';
+
+// Cap defensivo por passage: el corpus contiene `valor_pedagogico` largos
+// (>1KB) que inflan el prompt y degradan eval_rate del modelo vision.
+// 600 chars por passage × 3 passages ≈ 1.8 KB extra al prompt, manejable.
+const PASSAGE_CHAR_CAP = 600;
+
+/**
+ * Construye query RAG para `analyzeFoliage` priorizando contexto fitosanitario.
+ * Si recibe slug específico (ej. `fragaria_ananassa_monterrey`) tokeniza para
+ * que BM25 lo matchee aún con underscores. Si no, usa fallback genérico.
+ */
+const buildRagQuery = (speciesSlug) => {
+  if (typeof speciesSlug === 'string' && speciesSlug.trim().length > 0) {
+    // BM25 tokenize separa por \s — convertir underscores a espacios
+    // para que `fragaria_ananassa` matchee `fragaria` y `ananassa` por separado.
+    const normalized = speciesSlug.trim().toLowerCase().replace(/_/g, ' ');
+    return `${normalized} diagnóstico foliar plagas enfermedades manejo agroecológico`;
+  }
+  return RAG_FALLBACK_QUERY;
+};
+
+/**
+ * Compone el bloque `<CONTEXTO_CIENTÍFICO>` con los top-K passages del RAG.
+ * Cada passage se trunca a `PASSAGE_CHAR_CAP` y se etiqueta con su origen
+ * (species slug + key del campo, ej. `fragaria_ananassa_monterrey :: valor_pedagogico`).
+ * Si no hay passages, retorna string vacío (caller usa DIAGNOSIS_BASE_PROMPT crudo).
+ */
+const formatRagContext = (passages) => {
+  if (!Array.isArray(passages) || passages.length === 0) return '';
+  // Filtramos ANTES de numerar: si un passage viene vacío (caso raro pero
+  // posible si el corpus tiene fields whitespace-only), no queremos un hueco
+  // "[Fuente 2]" sin "Fuente 1" — la numeración debe ser contigua para que
+  // el modelo cite correctamente.
+  const valid = passages
+    .map((p) => {
+      const text = String(p?.text || '').slice(0, PASSAGE_CHAR_CAP).trim();
+      if (!text) return null;
+      const source = p.species ? `${p.species} :: ${p.key || 'corpus'}` : (p.key || 'corpus');
+      return { source, text };
+    })
+    .filter(Boolean);
+  if (valid.length === 0) return '';
+  const blocks = valid.map((p, i) => `[Fuente ${i + 1} — ${p.source}]\n${p.text}`);
+  return `<CONTEXTO_CIENTÍFICO>\n${blocks.join('\n\n')}\n</CONTEXTO_CIENTÍFICO>\n\n`;
+};
+
+/**
+ * Combina contexto RAG + instrucción al modelo vision. Cuando hay contexto
+ * pide explícitamente que cite la fuente para que el operador pueda auditar
+ * de dónde salió la recomendación (vs. alucinación pura).
+ */
+const buildDiagnosisPrompt = (ragContext) => {
+  if (!ragContext) return DIAGNOSIS_BASE_PROMPT;
+  return (
+    `${ragContext}` +
+    'Eres un agrónomo agroecológico colombiano. Usa el CONTEXTO_CIENTÍFICO ' +
+    'arriba + lo que observas en la imagen para diagnosticar. Cita la fuente ' +
+    'numérica (ej. "Fuente 1") cuando aplique. Si el contexto no aplica a lo ' +
+    'que ves, ignóralo y diagnostica solo por la imagen. ' +
+    'Output JSON: {"score": 0-100, "issues": [], "treatment": ""}'
+  );
+};
 
 // Species recognition (EXPERIMENTAL — feature flag operador 2026-05-03 Miguel).
 // Mismo modelo gemma3:4b multimodal pero distinto prompt. Output JSON
@@ -66,34 +142,73 @@ const blobToBase64 = (blob) =>
   });
 
 /**
+ * Recupera contexto RAG para `analyzeFoliage` con tolerancia total a fallos.
+ * Cualquier excepción (corpus no cargado, fetch failure, BM25 vacío) retorna
+ * `[]` para que el caller use el prompt base sin contexto. Audit finding #4
+ * exige degrade graceful: vision diagnóstico nunca debe romperse por RAG.
+ *
+ * @internal exportado solo para tests.
+ */
+export const __retrieveRagContextForFoliage = async (speciesSlug) => {
+  try {
+    const query = buildRagQuery(speciesSlug);
+    const passages = await retrieve(query, 3);
+    return Array.isArray(passages) ? passages : [];
+  } catch (err) {
+    console.warn('[aiService] RAG retrieve failed, falling back to base prompt:', err?.message);
+    return [];
+  }
+};
+
+/**
  * Analiza una imagen de follaje via Ollama (modelo multimodal) en streaming.
+ *
+ * Desde audit 2026-05-18 #4: pre-pende top-3 passages del RAG (`ragRetriever`)
+ * al `DIAGNOSIS_BASE_PROMPT` para que el modelo cite catálogo agroecológico
+ * (`valor_pedagogico`, manejo plagas, etc.) en lugar de alucinar treatments.
+ * Si `speciesSlug` está disponible, el RAG query es específico; si no, usa
+ * fallback genérico. Cold-start o fallo RAG → degrade transparente al prompt
+ * estático original.
  *
  * @param {Blob} imageBlob - imagen optimizada (WebP)
  * @param {Object} [options]
  * @param {Function} [options.onToken] - callback (chunk, fullText) invocado
  *        por cada token emitido por el modelo. La UI lo usa para mostrar el
- *        diagnostico apareciendo caracter-a-caracter.
- * @param {AbortSignal} [options.signal] - cancelacion externa.
+ *        diagnóstico apareciendo caracter-a-caracter.
+ * @param {AbortSignal} [options.signal] - cancelación externa.
+ * @param {string} [options.speciesSlug] - slug del catálogo (ej.
+ *        `fragaria_ananassa_monterrey`). Cuando se conoce, el retrieve apunta
+ *        al passage de esa especie. Si es null/undefined, fallback genérico.
+ * @param {string} [options.assetId] - solo telemetría, opcional. No se
+ *        persiste (privacy-safe).
  * @returns {Promise<{score: number, issues: string[], treatment_suggestion: string} | null>}
  *          null si el modelo no responde o no es multimodal.
  * @example
  * const result = await analyzeFoliage(imageBlob, {
+ *   speciesSlug: 'fragaria_ananassa_monterrey',
  *   onToken: (chunk, text) => setDiagnosis(text),
  * });
- * // result => { score: 85, issues: ["mancha foliar"], treatment_suggestion: "aplicar caldo bordeles" }
+ * // result => { score: 85, issues: ["mancha foliar"], treatment_suggestion: "aplicar caldo bordelés (Fuente 1)" }
  */
-export const analyzeFoliage = async (imageBlob, { onToken, signal } = {}) => {
+// eslint-disable-next-line no-unused-vars
+export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, assetId } = {}) => {
   try {
     const base64 = await blobToBase64(imageBlob);
 
+    // 1) RAG context (graceful degrade — nunca rompe el call si falla)
+    const passages = await __retrieveRagContextForFoliage(speciesSlug);
+    const ragContext = formatRagContext(passages);
+    const prompt = buildDiagnosisPrompt(ragContext);
+
+    // 2) Vision call con telemetría enriquecida (`rag_passages_used`).
     // streamOllama hace fetch con stream:true y procesa el NDJSON del body.
     // No usa fetchFromFarmOS para evitar inyección de headers OAuth — Ollama
     // local no requiere autenticación.
     const text = (await streamOllama(
       OLLAMA_URL,
-      { model: DIAGNOSIS_MODEL, prompt: DIAGNOSIS_PROMPT, images: [base64] },
+      { model: DIAGNOSIS_MODEL, prompt, images: [base64] },
       onToken,
-      { signal },
+      { signal, meta: { rag_passages_used: passages.length } },
     )).trim();
 
     // Parsear JSON (Gemma puede envolver en markdown fences)
@@ -173,3 +288,13 @@ export const recognizeSpecies = async (imageBlob, { onToken, signal } = {}) => {
 };
 
 export default analyzeFoliage;
+
+// Test-only exports: helpers internos del flujo RAG. NO usar fuera de tests.
+export const __TEST__ = {
+  buildRagQuery,
+  formatRagContext,
+  buildDiagnosisPrompt,
+  DIAGNOSIS_BASE_PROMPT,
+  RAG_FALLBACK_QUERY,
+  PASSAGE_CHAR_CAP,
+};

--- a/src/services/llmTelemetryService.js
+++ b/src/services/llmTelemetryService.js
@@ -23,6 +23,10 @@
  *     eval_rate: 118.18,          // tokens/s calculado (eval_count / eval_ms*1000)
  *     processor: 'gpu' | 'cpu' | 'unknown',
  *     error_kind: null | 'timeout' | 'http_4xx' | 'http_5xx' | 'abort' | 'network' | 'parse',
+ *     rag_passages_used: 3,       // # passages prepended by RAG (0 = no context).
+ *                                 // Audit 2026-05-18 #4: tracking hit-rate del
+ *                                 // RAG en `analyzeFoliage` y futuros consumers.
+ *                                 // null cuando el call no consultó RAG.
  *     created_at: ISO,
  *     synced: false,
  *   }
@@ -69,6 +73,9 @@ export const recordLLMEvent = async (event) => {
     eval_rate: typeof event.eval_rate === 'number' ? event.eval_rate : null,
     processor: event.processor || 'unknown',
     error_kind: event.error_kind || null,
+    // Audit 2026-05-18 #4: # passages que el RAG inyectó al prompt.
+    // 0 = consultó RAG pero no encontró matches. null = call no usó RAG.
+    rag_passages_used: typeof event.rag_passages_used === 'number' ? event.rag_passages_used : null,
     created_at: new Date().toISOString(),
     synced: false,
   };
@@ -246,7 +253,8 @@ export const exportLLMTelemetry = async (format = 'json') => {
   if (format === 'csv') {
     const headers = ['id', 'created_at', 'model', 'endpoint', 'flujo', 'status',
                      'processor', 'total_ms', 'load_ms', 'eval_count',
-                     'prompt_eval_count', 'eval_rate', 'error_kind'];
+                     'prompt_eval_count', 'eval_rate', 'error_kind',
+                     'rag_passages_used'];
     const rows = events.map((e) => headers.map((h) => e[h] ?? '').join(','));
     return [headers.join(','), ...rows].join('\n');
   }

--- a/src/services/ollamaStream.js
+++ b/src/services/ollamaStream.js
@@ -82,13 +82,17 @@ const extractChunk = (parsed) => {
  * @param {Function}    [options.onDone] callback invocado con el ultimo objeto
  *        del stream (done:true). Expone metadata de Ollama: model,
  *        total_duration, eval_count, prompt_eval_count, etc.
+ * @param {Object}      [options.meta]   campos extra propagados al
+ *        `recordLLMEvent` final (solo en `success`). Ej.
+ *        `{ rag_passages_used: 3 }` para análisis hit-rate RAG en
+ *        `LLMTelemetryScreen`. Privacy-safe: no debe contener prompt/respuesta.
  * @returns {Promise<string>} texto completo concatenado al terminar.
  * @throws {Error} si el fetch falla, el servidor responde no-2xx o el body no es streameable.
  * @example
  * const full = await streamOllama('/api/ollama/api/generate', { model: 'gemma3:4b', prompt: 'hola' }, tok => setText(tok));
  * // full => "Hola, en que puedo ayudarte?"
  */
-export async function streamOllama(url, body, onToken, { signal, onDone } = {}) {
+export async function streamOllama(url, body, onToken, { signal, onDone, meta } = {}) {
   const t0 = Date.now();
   const modelHint = body?.model || 'unknown';
   const flujoHint = inferFlujo(url, body);
@@ -224,6 +228,10 @@ export async function streamOllama(url, body, onToken, { signal, onDone } = {}) 
       eval_count,
       eval_rate,
       processor,
+      // Meta extra del caller (ej. rag_passages_used para audit hit-rate RAG).
+      // `recordLLMEvent` filtra a campos whitelisted del schema; cualquier
+      // otra prop se descarta. Privacy-safe enforced en service layer.
+      ...(meta && typeof meta === 'object' ? meta : {}),
     });
   });
 


### PR DESCRIPTION
## Summary

Audit `2026-05-18-conexiones-rotas-deep.md` finding #4 (P2): el análisis vision de follaje (`analyzeFoliage`) usaba un prompt estático sin contexto del catálogo agroecológico. Resultado: treatments genéricos que no citaban AGROSAVIA/IDEAM/POWO ni el `valor_pedagogico` de la especie en cuestión.

Ahora **`analyzeFoliage(blob, { speciesSlug, assetId })` consulta el RAG** (`ragRetriever.retrieve`), pre-pende top-3 passages como bloque `<CONTEXTO_CIENTÍFICO>` con fuentes numeradas, y pide al modelo citar fuente. **Degrade graceful** garantizado: si RAG falla o devuelve 0 matches, cae al prompt base original sin romper.

## Antes / Después del prompt

**Antes (estático):**
```
detect disease, nutrient deficiency, and overall plant health.
Output JSON: {"score": 0-100, "issues": [], "treatment": ""}
```

**Después (con speciesSlug=`fragaria_ananassa_monterrey`):**
```
<CONTEXTO_CIENTÍFICO>
[Fuente 1 — fragaria_ananassa_monterrey :: valor_pedagogico]
Mancha foliar por Mycosphaerella fragariae es la principal limitante…

[Fuente 2 — fragaria_ananassa_monterrey :: manejo_agroecologico]
Caldo bordelés 1% + poda foliolos enfermos…

[Fuente 3 — fragaria_ananassa_monterrey :: monitoreo]
AGROSAVIA recomienda inspección semanal en clima frío húmedo…
</CONTEXTO_CIENTÍFICO>

Eres un agrónomo agroecológico colombiano. Usa el CONTEXTO_CIENTÍFICO
arriba + lo que observas en la imagen para diagnosticar. Cita la fuente
numérica (ej. "Fuente 1") cuando aplique. Si el contexto no aplica a lo
que ves, ignóralo y diagnostica solo por la imagen.
Output JSON: {"score": 0-100, "issues": [], "treatment": ""}
```

**Después (sin speciesSlug → fallback genérico):** mismo formato pero la query RAG es `'diagnóstico foliar agroecológico colombiano plagas enfermedades manejo'`.

**Después (RAG cold-start / 0 matches / excepción):** cae al prompt estático original. Zero regresión.

## Consumidores actualizados (2)

- `EvidenceCapture` — acepta nueva prop `speciesSlug` y la propaga.
- `WorkerDashboard` — lookupea el plant por `task.asset_id` en el store y deriva `speciesSlug` del nombre (`deriveSpeciesSlug` shared pattern con `AssetDetailView`).
- `BitacoraEntryDetail` — extrae `assetId` del `relationships` JSON:API de la entry, lookupea el plant en el store y deriva slug igual.

Cuando el consumidor no logra resolver `speciesSlug` (logs huérfanos, eventual consistency del store), `analyzeFoliage` cae al fallback genérico — el flujo NO se rompe.

## Telemetría privacy-safe

- `recordLLMEvent` schema añade `rag_passages_used: number | null`.
- `streamOllama` acepta `options.meta` para que callers propaguen campos whitelisted al event final (retro-compatible, los call sites existentes no cambian).
- `LLMTelemetryScreen` muestra columna **RAG** (count) y el CSV export incluye el campo. Permite medir hit-rate del RAG en producción.

## Tests añadidos

`src/services/__tests__/aiService.test.js` — 19 tests, mocks de `ragRetriever` + `ollamaStream`:

- `buildRagQuery`: con/sin slug, normalización underscores → espacios para BM25.
- `formatRagContext`: passages vacíos, truncado al cap defensivo (600 chars), filtro+renumber para que `[Fuente N]` sea contigua.
- `buildDiagnosisPrompt`: base vs contextualizado.
- `__retrieveRagContextForFoliage`: graceful degrade ante excepciones, non-array, pass-through.
- `analyzeFoliage` integración: con/sin slug, cold-start (0 passages), RAG falla, stream falla, markdown fences, legacy `treatment` field.

## Test plan

- [x] `npm run lint` verde
- [x] `npm run test:unit` 174/174 verdes (155 previos + 19 nuevos)
- [x] `npm run build` verde (1.99s, sin warnings nuevos)
- [ ] CodeQL SAST verde (CI)
- [ ] Playwright E2E offline-first verde (CI)
- [ ] Smoke manual: capturar foto en `WorkerDashboard` con plant del catálogo → diagnóstico cita fuente
- [ ] Smoke manual: capturar foto sin asset linkado → fallback funciona
- [ ] `LLMTelemetryScreen` muestra columna RAG con counts > 0

## Referencias

- Audit: `Chagra-strategy/audit/2026-05-18-conexiones-rotas-deep.md` finding #4 (P2)
- ADR-019 Phase 3 (AI inference logs): se mantiene intacto.
- ADR-030 Regla 9 (privacy telemetría): respetada — `rag_passages_used` es un counter aggregate, no contenido.