### PR TITLE
feat(plant): form con fecha_germinacion + altura + etapa fenológica (audit 070.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.129",
+  "version": "0.12.130",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v171';
+const CACHE_NAME = 'chagra-v172';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -14,6 +14,7 @@ import { proximityCheck, findNearestLand, checkInvasiveProximity, getCoords } fr
 import { ExternalAiButton } from './common/ExternalAiButton';
 import { buildOpenExternalPrompt } from '../services/externalAiPromptBuilder';
 import { listUserPhotosBySpecies, captureAndCompress, savePhoto } from '../services/photoService';
+import { ETAPA_FENOLOGICA_LABELS } from '../utils/plantMeta';
 
 // Derive speciesSlug from asset name.
 function deriveSpeciesSlug(name) {
@@ -124,6 +125,51 @@ function SpeciesPhotoGallery({ speciesSlug, currentAssetId }) {
     </div>
   );
 }
+
+// Audit finding 070.3 (2026-05-18): muestra el estado actual de la planta
+// (fecha de siembra/germinación, altura, etapa fenológica) cuando AssetsDashboard
+// los persistió en attributes._chagra_plant_meta. Renderiza nada si no hay
+// metadata — permite siembras rápidas sin saturar la vista.
+const formatDaysAgo = (isoDate) => {
+  if (!isoDate) return null;
+  const t = new Date(isoDate).getTime();
+  if (!Number.isFinite(t)) return null;
+  const diffMs = Date.now() - t;
+  if (diffMs < 0) return 'Programada a futuro';
+  const days = Math.floor(diffMs / 86400000);
+  if (days === 0) return 'Sembrada hoy';
+  if (days === 1) return 'Sembrada hace 1 día';
+  return `Sembrada hace ${days} días`;
+};
+
+const PlantMetaPanel = ({ asset }) => {
+  const meta = asset?.attributes?._chagra_plant_meta;
+  if (!meta || typeof meta !== 'object') return null;
+
+  const fechaLabel = formatDaysAgo(meta.fecha_germinacion);
+  const alturaLabel =
+    meta.altura_cm != null && Number.isFinite(Number(meta.altura_cm))
+      ? `Altura: ${Number(meta.altura_cm)} cm`
+      : null;
+  const etapaRaw = meta.etapa_fenologica;
+  const etapaLabel = etapaRaw ? `Etapa: ${ETAPA_FENOLOGICA_LABELS[etapaRaw] || etapaRaw}` : null;
+
+  if (!fechaLabel && !alturaLabel && !etapaLabel) return null;
+
+  return (
+    <section
+      data-testid="plant-meta-panel"
+      className="bg-slate-800/40 p-4 rounded-xl border border-slate-700/50 space-y-2"
+    >
+      <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider">Estado actual</h3>
+      <ul className="space-y-1 text-sm text-white">
+        {fechaLabel && <li>{fechaLabel}</li>}
+        {alturaLabel && <li>{alturaLabel}</li>}
+        {etapaLabel && <li>{etapaLabel}</li>}
+      </ul>
+    </section>
+  );
+};
 
 // Bio-efficiency metrics panel.
 const PerformancePanel = ({ assetId }) => {
@@ -253,6 +299,7 @@ export const AssetDetailView = () => {
 
           {isPlantType && (
             <>
+              <PlantMetaPanel asset={asset} />
               <PerformancePanel assetId={asset.id} />
               <section>
                 <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-4 px-1">Acciones de Campo</h3>

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -21,6 +21,7 @@ import { getAccessToken } from '../services/authService';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
 import { savePhoto } from '../services/photoService';
 import { wktToGeoJson } from '../utils/geo';
+import { buildPlantMeta, formatPlantMetaFallbackLine, ETAPA_FENOLOGICA_OPTIONS } from '../utils/plantMeta';
 import MultiFincaModal from './MultiFincaModal';
 
 // Note: fincaNombre constant removed. Now derived from useFincaActiveStore inside the component.
@@ -85,6 +86,11 @@ const GREMIO_OPTIONS = [
   { value: 'productor_biomasa', label: 'Productor de biomasa' },
   { value: 'productivo_principal', label: 'Productivo principal' },
 ];
+
+// Audit finding 070.3 (2026-05-18): los helpers buildPlantMeta /
+// formatPlantMetaFallbackLine y las opciones ETAPA_FENOLOGICA_OPTIONS
+// viven en src/utils/plantMeta.js para mantener este componente liviano
+// y permitir tests unitarios sin cargar todo el árbol de imports JSX.
 
 // Lili #111 #112 #114, clarificar tabs:
 // - 'Zonas' (land): áreas geográficas con polígono, tab mantenida con
@@ -243,6 +249,13 @@ const INITIAL_FORM_STATE = {
   // El blob comprimido viaja en el form state hasta handleSave, donde
   // se persiste en media_cache (IndexedDB) atado al assetId recién creado.
   photoBlob: null,
+  // Audit finding 070.3 (2026-05-18): estado actual de la planta opcional
+  // (sembrada hace tiempo / altura conocida / etapa fenológica). Se persiste
+  // en attributes._chagra_plant_meta (JSON) o, como fallback, dentro de
+  // attributes.notes serializado para no romper el schema FarmOS.
+  fechaGerminacion: '',  // yyyy-mm-dd (input type=date)
+  alturaCm: '',          // string numérica (input type=number)
+  etapaFenologica: '',   // '' | 'semillero' | 'vegetativo' | 'floracion' | ...
 };
 
 const buildInitialFormState = () => ({
@@ -505,6 +518,30 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       baseAttributes.land_type = formData.landType;
     }
 
+    // Audit finding 070.3 (2026-05-18): persistir estado actual de la planta
+    // (fecha siembra/germinación, altura, etapa fenológica) cuando el
+    // operador llena la sección colapsable opcional. Se guarda en
+    // attributes._chagra_plant_meta (objeto JSON) — campo namespaced para
+    // no chocar con el schema oficial FarmOS. Fallback: si _chagra_plant_meta
+    // termina siendo ignorado por el server, también se serializa una línea
+    // legible al final de attributes.notes para no perder la información.
+    const plantMeta = activeTab === 'plant' ? buildPlantMeta(formData) : null;
+    if (plantMeta) {
+      baseAttributes._chagra_plant_meta = plantMeta;
+      // Fallback notes: agrega una línea legible solo si NO está ya
+      // contenida (evita duplicado en re-renders u optimistic UI).
+      const metaLine = formatPlantMetaFallbackLine(plantMeta);
+      if (metaLine) {
+        const existingNotes = baseAttributes.notes;
+        const existingText = existingNotes
+          ? (typeof existingNotes === 'string' ? existingNotes : existingNotes.value || '')
+          : '';
+        if (!existingText.includes(metaLine)) {
+          baseAttributes.notes = existingText ? `${existingText}\n${metaLine}` : metaLine;
+        }
+      }
+    }
+
     // Relaciones compartidas (location + parent + plant_type)
     let baseRels = null;
     if (activeTab !== 'material') {
@@ -623,10 +660,16 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
           })
           .catch((err) => console.warn('[AssetsDashboard] biopreparado suggestion failed:', err));
       } else if (activeTab === 'plant' && formData.speciesId) {
+        // Audit finding 070.3 (2026-05-18): si el operador declaró fecha de
+        // siembra/germinación, anclamos el plan a esa fecha (los offsets se
+        // calculan retro/prospectivamente desde ahí). Caso por defecto: hoy.
+        const plantingDateIso = formData.fechaGerminacion
+          ? new Date(formData.fechaGerminacion).toISOString()
+          : new Date().toISOString();
         generatePlanForPlant({
           assetId: assetUUIDs[0],
           speciesSlug: formData.speciesId,
-          plantingDate: new Date().toISOString(),
+          plantingDate: plantingDateIso,
         }).then((plan) => {
           if (plan?.steps?.length > 0) {
             window.dispatchEvent(new CustomEvent('chagraToast', {
@@ -856,6 +899,96 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
         rows="2"
         className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white text-sm min-h-[56px]"
       />
+
+      {/*
+        Audit finding 070.3 (2026-05-18): sección colapsable opcional para
+        registrar el estado actual de la planta. Aplica tanto a siembras
+        nuevas (default = hoy) como a plantas que el operador inscribe en
+        Chagra después de haberlas sembrado hace tiempo. Persiste en
+        attributes._chagra_plant_meta + fallback en notes (ver handleSave).
+        Default colapsado para no saturar el flujo rápido de siembra.
+      */}
+      <details className="rounded-xl bg-slate-900 border border-slate-700">
+        <summary
+          className="cursor-pointer p-3 flex items-center gap-2 hover:bg-slate-800/60 active:bg-slate-800 rounded-xl min-h-[48px]"
+          data-testid="plant-meta-toggle"
+        >
+          <span className="text-xs uppercase tracking-wider text-slate-400 font-bold flex-1 text-left">
+            Estado actual de la planta (opcional)
+          </span>
+          <span className="text-[10px] text-slate-500">Tóquelo para abrir</span>
+        </summary>
+        <div className="p-3 space-y-3 border-t border-slate-800">
+          {/* Fecha de siembra/germinación */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="plant-fecha-germinacion"
+              className="text-xs font-bold text-slate-400 uppercase tracking-wider"
+            >
+              Fecha de siembra/germinación (opcional)
+            </label>
+            <input
+              id="plant-fecha-germinacion"
+              name="fecha_germinacion"
+              type="date"
+              value={formData.fechaGerminacion}
+              onChange={(e) => setFormData({ ...formData, fechaGerminacion: e.target.value })}
+              className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white min-h-[48px]"
+            />
+            <p className="text-[10px] text-slate-500 leading-snug">
+              Si la planta lleva tiempo en la chagra, ponga la fecha real para que el plan de
+              alimentación calcule los pasos desde esa fecha.
+            </p>
+          </div>
+
+          {/* Altura actual en cm */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="plant-altura-cm"
+              className="text-xs font-bold text-slate-400 uppercase tracking-wider"
+            >
+              Altura actual (cm, opcional)
+            </label>
+            <input
+              id="plant-altura-cm"
+              name="altura_cm"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              max="2000"
+              step="1"
+              value={formData.alturaCm}
+              onChange={(e) => setFormData({ ...formData, alturaCm: e.target.value })}
+              placeholder="Ej: 35"
+              className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white min-h-[48px]"
+            />
+          </div>
+
+          {/* Etapa fenológica */}
+          <div className="space-y-1.5">
+            <label
+              htmlFor="plant-etapa-fenologica"
+              className="text-xs font-bold text-slate-400 uppercase tracking-wider"
+            >
+              Etapa fenológica (opcional)
+            </label>
+            <select
+              id="plant-etapa-fenologica"
+              name="etapa_fenologica"
+              value={formData.etapaFenologica}
+              onChange={(e) => setFormData({ ...formData, etapaFenologica: e.target.value })}
+              className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white min-h-[48px] focus:ring-lime-500 focus:border-lime-500"
+            >
+              <option value="">— Sin definir —</option>
+              {ETAPA_FENOLOGICA_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </details>
 
       {/* Geometría (POINT para frutales dispersos) */}
       {renderGeometryField('point')}

--- a/src/services/__tests__/planGeneratorService.test.js
+++ b/src/services/__tests__/planGeneratorService.test.js
@@ -119,3 +119,129 @@ describe('tryGeneratePlanFromSeeding — helper compartido (audit finding #2)', 
         expect(inMemoryPlansById.size).toBe(1);
     });
 });
+
+// ─── generatePlanForPlant — plantingDate custom (audit finding 070.3, 2026-05-18) ─────
+// Verifica que cuando el form pasa fechaGerminacion (operador inscribió una
+// planta que lleva tiempo sembrada), los offsets del template se calculan
+// desde esa fecha y no desde Date.now(). Backward-compat: si no se pasa
+// plantingDate, debe seguir anclando a Date.now() sin romper.
+describe('generatePlanForPlant — plantingDate custom (audit finding 070.3)', () => {
+    const PLANT_UUID_2 = 'cccccccc-dddd-eeee-ffff-000000000000';
+    let generatePlanForPlant;
+    let inMemoryPlansById;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        vi.clearAllMocks();
+
+        inMemoryPlansById = new Map();
+
+        const stubStore = {
+            put: (plan) => {
+                const req = { onsuccess: null, onerror: null };
+                Promise.resolve().then(() => {
+                    inMemoryPlansById.set(plan.id, plan);
+                    req.result = plan;
+                    req.onsuccess?.({ target: req });
+                });
+                return req;
+            },
+            index: () => ({
+                getAll: () => {
+                    const req = { onsuccess: null, onerror: null };
+                    Promise.resolve().then(() => {
+                        req.result = [];
+                        req.onsuccess?.({ target: req });
+                    });
+                    return req;
+                },
+            }),
+        };
+        const stubDb = { transaction: () => ({ objectStore: () => stubStore }) };
+
+        vi.doMock('../../db/dbCore.js', () => ({
+            openDB: vi.fn().mockResolvedValue(stubDb),
+            STORES: { PLANS: 'plans' },
+        }));
+        vi.doMock('../inventoryService.js', () => ({
+            appendEvent: vi.fn(),
+            getStock: vi.fn().mockResolvedValue(null),
+        }));
+        vi.doMock('../inventoryEvents.js', () => ({
+            createInventoryEvent: vi.fn(),
+            EVENT_TYPES: {},
+        }));
+        vi.doMock('../../db/catalogDB.js', () => ({
+            initCatalog: vi.fn().mockResolvedValue({
+                exec: () => [{
+                    data: JSON.stringify({
+                        id: 'tomate',
+                        feeding_plan_template: {
+                            primary_steps: [
+                                { offset_days: 0, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'siembra' },
+                                { offset_days: 30, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'mes 1' },
+                                { offset_days: 60, action: 'apply_biofertilizer', biofertilizer_slug: 'humus', dose_ml: 100, notes: 'mes 2' },
+                            ],
+                        },
+                    }),
+                }],
+            }),
+        }));
+
+        ({ generatePlanForPlant } = await import('../planGeneratorService.js'));
+    });
+
+    it('plantingDate custom: ancla offsets desde la fecha pasada (NO Date.now())', async () => {
+        // 2024-03-15 00:00 UTC — fecha conocida claramente anterior a Date.now().
+        const plantingIso = '2024-03-15T00:00:00.000Z';
+        const plantingTs = new Date(plantingIso).getTime();
+
+        const plan = await generatePlanForPlant({
+            assetId: PLANT_UUID_2,
+            speciesSlug: 'tomate',
+            plantingDate: plantingIso,
+        });
+
+        expect(plan).toBeTruthy();
+        expect(plan.steps).toHaveLength(3);
+
+        // Step 0: offset_days=0 → scheduled = plantingTs.
+        expect(plan.steps[0].scheduled_date).toBe(plantingTs);
+        // Step 1: offset_days=30 → scheduled = plantingTs + 30d.
+        expect(plan.steps[1].scheduled_date).toBe(plantingTs + 30 * 86400000);
+        // Step 2: offset_days=60 → scheduled = plantingTs + 60d.
+        expect(plan.steps[2].scheduled_date).toBe(plantingTs + 60 * 86400000);
+    });
+
+    it('plantingDate omitido: fallback a Date.now() (backward-compat)', async () => {
+        const before = Date.now();
+        const plan = await generatePlanForPlant({
+            assetId: PLANT_UUID_2,
+            speciesSlug: 'tomate',
+            // plantingDate intencionalmente omitido
+        });
+        const after = Date.now();
+
+        expect(plan).toBeTruthy();
+        // El step 0 (offset_days=0) debe quedar entre before y after — anclado
+        // a Date.now() interno, no a NaN ni a un valor del pasado lejano.
+        expect(plan.steps[0].scheduled_date).toBeGreaterThanOrEqual(before);
+        expect(plan.steps[0].scheduled_date).toBeLessThanOrEqual(after);
+    });
+
+    it('plantingDate inválido (string basura): fallback a Date.now() sin throw', async () => {
+        const before = Date.now();
+        const plan = await generatePlanForPlant({
+            assetId: PLANT_UUID_2,
+            speciesSlug: 'tomate',
+            plantingDate: 'no-es-una-fecha',
+        });
+        const after = Date.now();
+
+        expect(plan).toBeTruthy();
+        // Verifica que no quedó NaN (NaN no es ≥ before).
+        expect(Number.isFinite(plan.steps[0].scheduled_date)).toBe(true);
+        expect(plan.steps[0].scheduled_date).toBeGreaterThanOrEqual(before);
+        expect(plan.steps[0].scheduled_date).toBeLessThanOrEqual(after);
+    });
+});

--- a/src/services/planGeneratorService.js
+++ b/src/services/planGeneratorService.js
@@ -191,7 +191,13 @@ export async function generatePlanForPlant({ assetId, speciesSlug, plantingDate,
 
     const planId = ulid();
     const generatedAt = Date.now();
-    const pDate = new Date(plantingDate).getTime();
+    // Audit finding 070.3 (2026-05-18): aceptar plantingDate opcional.
+    // Backward-compat: si no se pasa o no parsea, anclamos los offsets a
+    // Date.now() (comportamiento previo). Si SÍ se pasa (form llenó
+    // fechaGerminacion), los offsets se calculan desde esa fecha — útil
+    // para inscribir plantas ya sembradas hace tiempo.
+    let pDate = plantingDate ? new Date(plantingDate).getTime() : NaN;
+    if (!Number.isFinite(pDate)) pDate = Date.now();
 
     // Default to 'huerto_casero' or whichever has notes
     let scaleNotes = '';

--- a/src/utils/plantMeta.js
+++ b/src/utils/plantMeta.js
@@ -1,0 +1,90 @@
+/**
+ * plantMeta.js — Helpers puros para el blob `_chagra_plant_meta` que el
+ * form de siembra de AssetsDashboard escribe en `attributes` del asset
+ * (plant) recién creado.
+ *
+ * Audit finding 070.3 (2026-05-18): el operador puede declarar 3 campos
+ * opcionales sobre el estado actual de la planta (fecha de siembra,
+ * altura, etapa fenológica). Se persisten en
+ * `attributes._chagra_plant_meta` para no chocar con el schema oficial
+ * FarmOS, y como fallback se serializa una línea legible al final de
+ * `attributes.notes` para sobrevivir al sync.
+ *
+ * Se extrae a un util independiente para que los tests unitarios no
+ * tengan que cargar todo el árbol de imports de `AssetsDashboard.jsx`
+ * (zustand stores + IDB + lucide-react + react-virtuoso + leaflet, etc.).
+ */
+
+/**
+ * Opciones canónicas de etapa fenológica. UI las usa para el `<select>`
+ * y AssetDetailView las usa para etiquetar legibles.
+ */
+export const ETAPA_FENOLOGICA_OPTIONS = [
+    { value: 'semillero', label: 'Semillero' },
+    { value: 'vegetativo', label: 'Vegetativo' },
+    { value: 'floracion', label: 'Floración' },
+    { value: 'fructificacion', label: 'Fructificación' },
+    { value: 'madurez', label: 'Madurez' },
+    { value: 'senescencia', label: 'Senescencia' },
+];
+
+/**
+ * Construye el blob `_chagra_plant_meta` a partir del state del form.
+ * Retorna `null` si ningún campo opcional fue capturado, para que el
+ * caller no inyecte un objeto vacío en `attributes` (mantiene el payload
+ * limpio cuando el operador omite la sección colapsable).
+ *
+ * @param {object} formData — state del formulario de planta.
+ * @param {string} [formData.fechaGerminacion] — yyyy-mm-dd (input date).
+ * @param {string|number} [formData.alturaCm] — string del input number.
+ * @param {string} [formData.etapaFenologica] — value de ETAPA_FENOLOGICA_OPTIONS.
+ * @returns {object|null} `{ fecha_germinacion, altura_cm, etapa_fenologica }`
+ *   con solo las claves capturadas. `null` si todo está vacío.
+ */
+export const buildPlantMeta = (formData) => {
+    if (!formData || typeof formData !== 'object') return null;
+
+    const meta = {};
+
+    if (formData.fechaGerminacion) {
+        meta.fecha_germinacion = formData.fechaGerminacion;
+    }
+
+    if (formData.alturaCm !== '' && formData.alturaCm != null) {
+        const n = Number(formData.alturaCm);
+        if (Number.isFinite(n) && n >= 0) {
+            meta.altura_cm = Math.round(n);
+        }
+    }
+
+    if (formData.etapaFenologica) {
+        meta.etapa_fenologica = formData.etapaFenologica;
+    }
+
+    return Object.keys(meta).length > 0 ? meta : null;
+};
+
+/**
+ * Formato fallback para `attributes.notes` cuando el server FarmOS no
+ * soporta el campo namespaced `_chagra_plant_meta`. Línea single-string
+ * que sobrevive al round-trip y es legible por humanos.
+ *
+ * @param {object} meta — output de buildPlantMeta (puede ser null).
+ * @returns {string|null}
+ */
+export const formatPlantMetaFallbackLine = (meta) => {
+    if (!meta || typeof meta !== 'object') return null;
+    const parts = [];
+    if (meta.fecha_germinacion) parts.push(`siembra: ${meta.fecha_germinacion}`);
+    if (meta.altura_cm != null) parts.push(`altura: ${meta.altura_cm} cm`);
+    if (meta.etapa_fenologica) parts.push(`etapa: ${meta.etapa_fenologica}`);
+    return parts.length > 0 ? `[estado-planta] ${parts.join(' · ')}` : null;
+};
+
+/**
+ * Labels legibles de etapa fenológica para AssetDetailView. Espejo de
+ * ETAPA_FENOLOGICA_OPTIONS, pero accesible como mapa rápido.
+ */
+export const ETAPA_FENOLOGICA_LABELS = Object.fromEntries(
+    ETAPA_FENOLOGICA_OPTIONS.map((opt) => [opt.value, opt.label]),
+);

--- a/src/utils/plantMeta.test.js
+++ b/src/utils/plantMeta.test.js
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+    buildPlantMeta,
+    formatPlantMetaFallbackLine,
+    ETAPA_FENOLOGICA_LABELS,
+    ETAPA_FENOLOGICA_OPTIONS,
+} from './plantMeta';
+
+// Audit finding 070.3 (2026-05-18): el form de planta en AssetsDashboard
+// expone 3 campos opcionales (fecha_germinacion, altura_cm, etapa_fenologica)
+// que se persisten en attributes._chagra_plant_meta. Estos tests verifican
+// que buildPlantMeta y su fallback line se comportan determinísticamente,
+// sin perder datos ni inyectar objetos vacíos cuando el operador omite la
+// sección colapsable.
+
+describe('buildPlantMeta — persistencia de los 3 campos opcionales', () => {
+    it('retorna null si el form no llenó ningún campo del estado de planta', () => {
+        expect(buildPlantMeta({ name: 'tomate' })).toBeNull();
+        expect(buildPlantMeta({})).toBeNull();
+        // Strings vacíos del form (default) NO se consideran datos.
+        expect(buildPlantMeta({ fechaGerminacion: '', alturaCm: '', etapaFenologica: '' })).toBeNull();
+    });
+
+    it('retorna null para input inválido (no-objeto / null)', () => {
+        expect(buildPlantMeta(null)).toBeNull();
+        expect(buildPlantMeta(undefined)).toBeNull();
+        expect(buildPlantMeta('no-es-objeto')).toBeNull();
+    });
+
+    it('persiste fecha_germinacion cuando el operador la llenó', () => {
+        const meta = buildPlantMeta({ fechaGerminacion: '2025-03-15' });
+        expect(meta).toEqual({ fecha_germinacion: '2025-03-15' });
+    });
+
+    it('persiste altura_cm como int normalizado (Math.round)', () => {
+        expect(buildPlantMeta({ alturaCm: '35' })).toEqual({ altura_cm: 35 });
+        expect(buildPlantMeta({ alturaCm: 35 })).toEqual({ altura_cm: 35 });
+        expect(buildPlantMeta({ alturaCm: '35.7' })).toEqual({ altura_cm: 36 });
+        expect(buildPlantMeta({ alturaCm: '0' })).toEqual({ altura_cm: 0 });
+    });
+
+    it('descarta altura_cm inválida (no numérica o negativa)', () => {
+        expect(buildPlantMeta({ alturaCm: 'abc' })).toBeNull();
+        expect(buildPlantMeta({ alturaCm: '-10' })).toBeNull();
+        expect(buildPlantMeta({ alturaCm: NaN })).toBeNull();
+    });
+
+    it('persiste etapa_fenologica cuando el operador la eligió', () => {
+        expect(buildPlantMeta({ etapaFenologica: 'floracion' })).toEqual({ etapa_fenologica: 'floracion' });
+    });
+
+    it('combina los 3 campos cuando el operador llenó la sección completa', () => {
+        const meta = buildPlantMeta({
+            fechaGerminacion: '2025-01-10',
+            alturaCm: '120',
+            etapaFenologica: 'vegetativo',
+            // campos no relevantes deben ignorarse silenciosamente
+            name: 'aguacate',
+            plantType: 'Hass',
+        });
+        expect(meta).toEqual({
+            fecha_germinacion: '2025-01-10',
+            altura_cm: 120,
+            etapa_fenologica: 'vegetativo',
+        });
+    });
+});
+
+describe('formatPlantMetaFallbackLine — string legible que sobrevive sync', () => {
+    it('retorna null si meta es null/inválida', () => {
+        expect(formatPlantMetaFallbackLine(null)).toBeNull();
+        expect(formatPlantMetaFallbackLine(undefined)).toBeNull();
+        expect(formatPlantMetaFallbackLine({})).toBeNull();
+    });
+
+    it('serializa los 3 campos en una sola línea con separador "·"', () => {
+        const line = formatPlantMetaFallbackLine({
+            fecha_germinacion: '2025-01-10',
+            altura_cm: 120,
+            etapa_fenologica: 'vegetativo',
+        });
+        expect(line).toBe('[estado-planta] siembra: 2025-01-10 · altura: 120 cm · etapa: vegetativo');
+    });
+
+    it('omite campos faltantes sin dejar separadores huérfanos', () => {
+        const line = formatPlantMetaFallbackLine({ altura_cm: 50 });
+        expect(line).toBe('[estado-planta] altura: 50 cm');
+    });
+});
+
+describe('ETAPA_FENOLOGICA_LABELS — labels legibles para AssetDetailView', () => {
+    it('cubre las 6 etapas requeridas por el audit finding 070.3', () => {
+        expect(Object.keys(ETAPA_FENOLOGICA_LABELS).sort()).toEqual([
+            'floracion',
+            'fructificacion',
+            'madurez',
+            'semillero',
+            'senescencia',
+            'vegetativo',
+        ]);
+    });
+
+    it('espejo de ETAPA_FENOLOGICA_OPTIONS — no hay drift entre value/label', () => {
+        for (const opt of ETAPA_FENOLOGICA_OPTIONS) {
+            expect(ETAPA_FENOLOGICA_LABELS[opt.value]).toBe(opt.label);
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Sección colapsable opcional en el form de siembra (`AssetsDashboard.jsx`) con 3 campos: `fecha_germinacion`, `altura_cm`, `etapa_fenologica` (semillero/vegetativo/floracion/fructificacion/madurez/senescencia).
- Persistencia en `attributes._chagra_plant_meta` (JSON namespaced para no chocar con schema FarmOS) + fallback como línea legible en `attributes.notes` para sobrevivir al sync.
- `planGeneratorService.generatePlanForPlant` ahora acepta `plantingDate` opcional: si el operador declara fecha de siembra, los offsets se calculan desde ahí; si no, fallback a `Date.now()` (backward-compat).
- `AssetDetailView` muestra los 3 valores legibles ("Sembrada hace 45 días", "Altura: 35 cm", "Etapa: floración") cuando existen.

## Diseño

- Helpers `buildPlantMeta` + `formatPlantMetaFallbackLine` + `ETAPA_FENOLOGICA_OPTIONS` viven en `src/utils/plantMeta.js` para que los tests unitarios no carguen todo el árbol de imports JSX (zustand stores + IDB + leaflet + lucide-react).
- UI usa el patrón nativo HTML5 `<details>` (mismo pattern que `BitacoraEntryDetail`, `LLMTelemetryScreen`, `GuildSuggestions`), default colapsado para no saturar el flujo rápido de siembra.
- `fecha_germinacion` del form también ancla el `plantingDate` del plan generado post-create, así una planta inscrita después de meses tiene el plan retro/prospectivo correcto.

## Tests

- `src/utils/plantMeta.test.js` (nuevo): 12 assertions sobre los 3 campos + serialización fallback.
- `src/services/__tests__/planGeneratorService.test.js` extendido con 3 casos de `plantingDate` (custom anclado, omitido, inválido).
- Total: 235 unit tests verdes.

## Test plan

- [x] `npm run lint` verde
- [x] `npm run test:unit` verde (235/235)
- [x] `npm run build` verde
- [ ] CodeQL + Playwright E2E (merge-gates §5 del SOP)
- [ ] Verificar manualmente: abrir form de siembra → toggle "Estado actual de la planta" → llenar los 3 campos → guardar → revisar AssetDetailView muestra los valores.
- [ ] Verificar offline-first: con `setOffline(true)`, los 3 campos se persisten en `pending_transactions` (IDB) y se sincronizan al volver la red.

## Bumps

- `package.json`: 0.12.129 → 0.12.130
- `public/sw.js` CACHE_NAME: chagra-v171 → chagra-v172

Lefthook no estaba en PATH del worktree → bump manual sincronizado.