### PR TITLE
feat(observation): selector plant + bridge case_study severity high/critical (audit 070.5+6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.129",
+  "version": "0.12.130",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v171';
+const CACHE_NAME = 'chagra-v172';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CaseLinkModal.jsx
+++ b/src/components/CaseLinkModal.jsx
@@ -1,0 +1,258 @@
+import React, { useMemo, useState } from 'react';
+import { X, FileText, Sparkles, AlertCircle, AlertTriangle } from 'lucide-react';
+import { useCaseStudyStore } from '../store/useCaseStudyStore';
+import { useFincaActiveStore } from '../services/fincaActiveStore';
+
+/**
+ * CaseLinkModal — bridge severity → case_study (audit deep 070.6)
+ * ================================================================
+ * Trigger: tras guardar una observación con severity `high` o `critical`,
+ * ObservationScreen abre este modal para que el operador decida si vincula
+ * el log a un caso de estudio existente o crea uno nuevo.
+ *
+ * Filtrado:
+ *   - Solo casos activos (state ∉ closed_*).
+ *   - Si la observación está vinculada a un asset--plant con `species_slug`
+ *     conocido, prioriza los casos cuyo `subject.species_ids` contiene ese
+ *     slug. Cuando no hay matches se muestra la lista completa de activos.
+ *
+ * Acciones:
+ *   - Tap en caso card → linkLog(caseId, logId) → cierra modal.
+ *   - "Crear nuevo caso de estudio" → createCase con pre-fill
+ *     (species_slug, severity, created_at, timeline[0] = evento observación,
+ *     visibility='private', validation.status='pending') + linkLog.
+ *   - "Más tarde" → solo cierra el modal (no destructivo).
+ *
+ * Si no hay casos activos, el modal expone únicamente la CTA "Crear nuevo
+ * caso" como camino feliz.
+ *
+ * Props:
+ *   - logId: string — id del log--observation que dispara el bridge.
+ *   - severity: 'high' | 'critical' — severidad del evento detonante.
+ *   - description: string — texto libre de la observación (alimenta timeline[0]).
+ *   - speciesSlug: string | null — slug de la planta asociada (cuando aplica).
+ *   - plantId: string | null — id del asset--plant (para metadata).
+ *   - landId: string | null — id del asset--land donde ocurrió.
+ *   - onClose: () => void — cierre del modal (link, create o "más tarde").
+ */
+
+const SEVERITY_META = {
+  critical: { icon: AlertTriangle, color: 'text-red-400', label: 'crítica' },
+  high: { icon: AlertCircle, color: 'text-orange-400', label: 'alta' },
+};
+
+const formatRelativeTime = (iso) => {
+  if (!iso) return '';
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days <= 0) return 'hoy';
+  if (days === 1) return 'ayer';
+  if (days < 30) return `hace ${days}d`;
+  if (days < 365) return `hace ${Math.floor(days / 30)}m`;
+  return `hace ${Math.floor(days / 365)}a`;
+};
+
+export default function CaseLinkModal({
+  logId,
+  severity = 'high',
+  description = '',
+  speciesSlug = null,
+  plantId = null,
+  landId = null,
+  onClose,
+}) {
+  const getActive = useCaseStudyStore((s) => s.getActive);
+  const linkLog = useCaseStudyStore((s) => s.linkLog);
+  const createCase = useCaseStudyStore((s) => s.createCase);
+  const linkTimelineEvent = useCaseStudyStore((s) => s.linkTimelineEvent);
+  const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Lista filtrada de casos activos. Si hay species_slug, prioriza matches;
+  // si no hay matches o no hay slug, muestra todos los activos.
+  const { cases, filteredBySpecies } = useMemo(() => {
+    const all = (typeof getActive === 'function' ? getActive() : []) || [];
+    if (!speciesSlug) return { cases: all, filteredBySpecies: false };
+    const matches = all.filter((c) =>
+      Array.isArray(c.subject?.species_ids) && c.subject.species_ids.includes(speciesSlug)
+    );
+    if (matches.length > 0) return { cases: matches, filteredBySpecies: true };
+    return { cases: all, filteredBySpecies: false };
+  }, [getActive, speciesSlug]);
+
+  const sevMeta = SEVERITY_META[severity] || SEVERITY_META.high;
+  const SevIcon = sevMeta.icon;
+
+  const handleLink = (caseId) => {
+    if (busy || !logId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      linkLog(caseId, logId);
+      onClose?.();
+    } catch (err) {
+      console.error('[CaseLinkModal] Error linking log:', err);
+      setError('No se pudo vincular el registro. Inténtalo de nuevo.');
+      setBusy(false);
+    }
+  };
+
+  const handleCreateAndLink = () => {
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const desc = (description || '').trim();
+      const title = desc
+        ? `Observación ${sevMeta.label} — ${desc.slice(0, 60)}${desc.length > 60 ? '…' : ''}`
+        : `Observación ${sevMeta.label} ${new Date().toLocaleDateString('es-CO')}`;
+      const now = new Date().toISOString();
+      const newCaseId = createCase({
+        title,
+        finca_slug: activeFincaSlug || 'guatoc',
+        zone_freetext: '',
+        subject: {
+          species_ids: speciesSlug ? [speciesSlug] : [],
+          count_total: null,
+          count_affected: null,
+        },
+        problem: {
+          name_freetext: desc || `Observación severidad ${sevMeta.label}`,
+          severity,
+          detected_at: now,
+        },
+        visibility: 'private',
+      });
+
+      // Pre-fill timeline[0] con el evento de observación que detonó el caso.
+      try {
+        linkTimelineEvent(newCaseId, {
+          event_type: 'observation',
+          date: now,
+          description: desc || `Observación severidad ${sevMeta.label} registrada`,
+        });
+      } catch (timelineErr) {
+        console.warn('[CaseLinkModal] No se pudo pre-fill timeline[0]:', timelineErr);
+      }
+
+      if (logId) linkLog(newCaseId, logId);
+      onClose?.();
+    } catch (err) {
+      console.error('[CaseLinkModal] Error creando caso:', err);
+      setError('No se pudo crear el caso de estudio. Inténtalo de nuevo.');
+      setBusy(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    if (busy) return;
+    onClose?.();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="case-link-modal-title"
+      onClick={(e) => e.target === e.currentTarget && handleDismiss()}
+      className="fixed inset-0 z-[100] bg-black/70 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4"
+    >
+      <div className="w-full max-w-lg bg-slate-950 border border-orange-800/50 rounded-t-2xl sm:rounded-2xl flex flex-col max-h-[85vh] overflow-hidden">
+        <header className="p-4 bg-gradient-to-r from-orange-900/40 to-orange-950/40 border-b border-orange-800/40 flex items-start gap-3 shrink-0">
+          <SevIcon size={22} className={`${sevMeta.color} mt-0.5 shrink-0`} aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <h3 id="case-link-modal-title" className="text-sm font-bold text-orange-200">
+              Severidad {sevMeta.label}: ¿vinculas a un caso?
+            </h3>
+            <p className="text-xs text-slate-400 mt-0.5">
+              Las observaciones serias suelen ser parte de un problema mayor. Vincula este registro a un caso de estudio para llevar el hilo.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Cerrar"
+            disabled={busy}
+            className="p-2 hover:bg-slate-800 rounded text-slate-400 shrink-0 disabled:opacity-50"
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-3 space-y-2">
+          {error && (
+            <div role="alert" className="p-2 rounded bg-red-950/40 border border-red-800 text-xs text-red-300">
+              {error}
+            </div>
+          )}
+
+          {cases.length === 0 && (
+            <div className="p-3 rounded-xl bg-slate-900 border border-slate-800 text-xs text-slate-400">
+              No hay casos de estudio activos para esta finca. Crea uno nuevo para empezar a seguir este problema.
+            </div>
+          )}
+
+          {cases.length > 0 && (
+            <>
+              <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold px-1">
+                {filteredBySpecies
+                  ? `Casos activos para esta especie (${cases.length})`
+                  : `Casos activos (${cases.length})`}
+              </p>
+              {cases.map((c) => {
+                const cSev = SEVERITY_META[c.problem?.severity];
+                return (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => handleLink(c.id)}
+                    disabled={busy}
+                    className="w-full text-left p-3 rounded-xl border border-slate-800 bg-slate-900 hover:border-slate-600 active:bg-slate-800 transition-all flex items-start gap-3 min-h-[64px] disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <FileText size={18} className="shrink-0 text-slate-400 mt-0.5" aria-hidden="true" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-bold text-white truncate">{c.title}</p>
+                      <p className="text-[11px] text-slate-500 mt-0.5">
+                        {c.problem?.name_freetext || 'Problema sin descripción'}
+                        {cSev && <> · <span className={cSev.color}>severidad {cSev.label}</span></>}
+                        {c.created_at && <> · {formatRelativeTime(c.created_at)}</>}
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
+            </>
+          )}
+        </div>
+
+        <footer className="p-3 border-t border-slate-800 shrink-0 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={handleCreateAndLink}
+            disabled={busy}
+            className="w-full p-3 rounded-xl bg-emerald-700 hover:bg-emerald-600 active:bg-emerald-500 text-white font-bold text-sm flex items-center justify-center gap-2 min-h-[48px] disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            <Sparkles size={16} aria-hidden="true" />
+            <span>Crear nuevo caso de estudio</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            disabled={busy}
+            className="w-full p-3 rounded-xl bg-slate-800 hover:bg-slate-700 active:bg-slate-600 text-slate-300 text-sm min-h-[44px] disabled:opacity-50"
+          >
+            Más tarde
+          </button>
+          {plantId && (
+            <p className="text-[10px] text-slate-600 italic text-center" data-testid="case-link-modal-plant-id">
+              Planta asociada: {plantId}
+              {landId ? ` · zona: ${landId}` : ''}
+            </p>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -1,12 +1,25 @@
 import React, { useState, useMemo } from 'react';
 import { ArrowLeft, AlertCircle, Camera } from 'lucide-react';
 import DateField from './DateField';
+import CaseLinkModal from './CaseLinkModal';
 import { syncManager } from '../services/syncManager';
+import useAssetStore from '../store/useAssetStore';
+import { getParentLandIdFromAsset } from '../utils/assetRelationships';
 
 // Bug 069.10 — observation requiere descripción mínima útil + ubicación.
 // Mínimo de 5 caracteres descarta entries vacíos tipo "ok" o "test".
 const MIN_DESCRIPTION_LEN = 5;
 const MAX_DESCRIPTION_LEN = 2000;
+
+// Audit deep 070.5 — selector plant opcional. Cuando el land seleccionado
+// tiene plants asociadas (parent.data o location.data apuntan al landId),
+// mostramos un dropdown para vincular la observación a una planta puntual.
+//
+// Audit deep 070.6 — bridge severity → case_study. Si severity ∈ {high,
+// critical} y savePayload resuelve OK, abrimos CaseLinkModal con el logId
+// resultante para que el operador linke a caso existente o cree uno nuevo
+// (pre-fill species_slug + timeline[0]).
+const SEVERITY_TRIGGER_CASE_BRIDGE = new Set(['high', 'critical']);
 
 function ObservationScreen({ onBack, onSave }) {
   const [formData, setFormData] = useState({
@@ -14,12 +27,26 @@ function ObservationScreen({ onBack, onSave }) {
     observationType: 'general',
     description: '',
     locationId: '',
+    plantId: '',
     severity: 'info'
   });
   const [photo, setPhoto] = useState(null);
   const [photoUrl, setPhotoUrl] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
   const [touched, setTouched] = useState({});
+  // Audit 070.6 — modal payload tras éxito en severity high/critical.
+  // Shape: { logId, severity, description, speciesSlug, plantId, landId }.
+  const [caseBridgePayload, setCaseBridgePayload] = useState(null);
+
+  const lands = useAssetStore((s) => s.lands);
+  const plants = useAssetStore((s) => s.plants);
+
+  // Audit 070.5 — plants filtradas por land seleccionado. Cuando no hay
+  // locationId aún (o el land no tiene plants), el selector se oculta.
+  const plantsForSelectedLand = useMemo(() => {
+    if (!formData.locationId || !Array.isArray(plants) || plants.length === 0) return [];
+    return plants.filter((p) => getParentLandIdFromAsset(p) === formData.locationId);
+  }, [formData.locationId, plants]);
 
   // Bug 069.10 — validación inline para description + date. `locationId` no
   // tiene input en la UI todavía (queda en el handleSave check legacy) — no se
@@ -40,7 +67,13 @@ function ObservationScreen({ onBack, onSave }) {
   const markTouched = (field) => setTouched((t) => ({ ...t, [field]: true }));
 
   const handleInput = (e) => {
-    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+    setFormData(prev => {
+      const next = { ...prev, [e.target.name]: e.target.value };
+      // Si cambia el land, reseteamos plantId para no arrastrar referencia
+      // huérfana de la zona anterior.
+      if (e.target.name === 'locationId') next.plantId = '';
+      return next;
+    });
   };
 
   const handlePhotoCapture = (e) => {
@@ -67,22 +100,39 @@ function ObservationScreen({ onBack, onSave }) {
 
     setIsSaving(true);
     try {
+      // Audit 070.5 — id pre-asignado para que el bridge 070.6 tenga un
+      // logId estable que pasar al modal aún en flujo offline.
+      const logId = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+        ? crypto.randomUUID()
+        : `obs-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+      // Audit 070.5 — relationships dual:
+      //   - location: SIEMPRE asset--land (compat flujo legacy).
+      //   - asset: SOLO si el operador eligió una planta puntual.
+      const relationships = {
+        location: {
+          data: [{ type: 'asset--land', id: formData.locationId }],
+        },
+      };
+      if (formData.plantId) {
+        relationships.asset = {
+          data: [{ type: 'asset--plant', id: formData.plantId }],
+        };
+      }
+
       const payload = {
         data: {
-          type: "log--observation",
+          type: 'log--observation',
+          id: logId,
           attributes: {
             name: formData.description,
             timestamp: new Date(formData.date).toISOString().split('.')[0] + '+00:00',
-            status: "done",
-            notes: formData.notes || "",
-            severity: formData.severity
+            status: 'done',
+            notes: formData.notes || '',
+            severity: formData.severity,
           },
-          relationships: {
-            location: {
-              data: [{ type: "asset--land", id: formData.locationId }]
-            }
-          }
-        }
+          relationships,
+        },
       };
 
       // Guardar en IndexedDB usando syncManager
@@ -93,12 +143,48 @@ function ObservationScreen({ onBack, onSave }) {
 
       onSave('Registro guardado localmente (Pendiente de sincronización)', false);
 
-      // Reset partial state and navigate back
+      // Audit 070.6 — bridge severity → case_study. Si severity es high/critical
+      // abrimos el modal ANTES de navegar atrás para que el operador pueda
+      // linkar o crear caso. La planta seleccionada (si la hay) alimenta el
+      // pre-fill de species_slug.
+      const triggersCaseBridge = SEVERITY_TRIGGER_CASE_BRIDGE.has(formData.severity);
+      if (triggersCaseBridge) {
+        const selectedPlant = formData.plantId
+          ? (plants || []).find((p) => p.id === formData.plantId)
+          : null;
+        const speciesSlug = selectedPlant?.attributes?.species_slug
+          || selectedPlant?.attributes?.species?.name
+          || null;
+        setCaseBridgePayload({
+          logId,
+          severity: formData.severity,
+          description: formData.description,
+          speciesSlug,
+          plantId: formData.plantId || null,
+          landId: formData.locationId,
+        });
+        // Reset parcial: NO navegamos atrás hasta que el modal cierre.
+        setFormData({
+          date: new Date().toISOString().split('T')[0],
+          observationType: 'general',
+          description: '',
+          locationId: '',
+          plantId: '',
+          severity: 'info',
+        });
+        setPhoto(null);
+        if (photoUrl) URL.revokeObjectURL(photoUrl);
+        setPhotoUrl(null);
+        return;
+      }
+
+      // Reset partial state and navigate back (flujo sin bridge)
       setFormData({
         date: new Date().toISOString().split('T')[0],
         observationType: 'general',
         description: '',
         locationId: '',
+        plantId: '',
         severity: 'info'
       });
       setPhoto(null);
@@ -110,6 +196,12 @@ function ObservationScreen({ onBack, onSave }) {
     } finally {
       setIsSaving(false);
     }
+  };
+
+  const handleCaseBridgeClose = () => {
+    setCaseBridgePayload(null);
+    // Cerrar la pantalla tras dismiss del modal (link, create o "más tarde").
+    setTimeout(() => onBack(), 200);
   };
 
   return (
@@ -159,10 +251,55 @@ function ObservationScreen({ onBack, onSave }) {
           <select name="severity" value={formData.severity} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none">
             <option value="info">Informacion</option>
             <option value="warning">Advertencia</option>
-            <option value="error">Error</option>
-            <option value="critical">Critico</option>
+            <option value="low">Baja</option>
+            <option value="medium">Media</option>
+            <option value="high">Alta</option>
+            <option value="critical">Critica</option>
           </select>
         </label>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xl font-bold">Zona (Land)</span>
+          <select
+            name="locationId"
+            value={formData.locationId}
+            onChange={handleInput}
+            className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none"
+          >
+            <option value="">— Selecciona una zona —</option>
+            {(lands || []).map((l) => (
+              <option key={l.id} value={l.id}>
+                {l.attributes?.name || l.name || l.id}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        {/* Audit 070.5 — selector plant opcional. Solo aparece si hay land
+            seleccionado Y ese land tiene plants asociadas. Sin selección, la
+            observación queda vinculada solo al land (compat legacy). */}
+        {plantsForSelectedLand.length > 0 && (
+          <label className="flex flex-col gap-2" data-testid="plant-selector-wrapper">
+            <span className="text-xl font-bold">Planta (opcional)</span>
+            <select
+              name="plantId"
+              value={formData.plantId}
+              onChange={handleInput}
+              data-testid="plant-selector"
+              className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px] appearance-none"
+            >
+              <option value="">— Sin planta puntual —</option>
+              {plantsForSelectedLand.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.attributes?.name || p.name || p.id}
+                </option>
+              ))}
+            </select>
+            <span className="text-xs text-slate-500">
+              Si eliges una planta, la observación se vincula a la planta además del land.
+            </span>
+          </label>
+        )}
 
         <DateField
           label="Fecha"
@@ -201,6 +338,18 @@ function ObservationScreen({ onBack, onSave }) {
           {isSaving ? 'Guardando…' : 'Guardar Observacion'}
         </button>
       </div>
+
+      {caseBridgePayload && (
+        <CaseLinkModal
+          logId={caseBridgePayload.logId}
+          severity={caseBridgePayload.severity}
+          description={caseBridgePayload.description}
+          speciesSlug={caseBridgePayload.speciesSlug}
+          plantId={caseBridgePayload.plantId}
+          landId={caseBridgePayload.landId}
+          onClose={handleCaseBridgeClose}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/__tests__/CaseLinkModal.test.jsx
+++ b/src/components/__tests__/CaseLinkModal.test.jsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import CaseLinkModal from '../CaseLinkModal';
+import { useCaseStudyStore } from '../../store/useCaseStudyStore';
+
+// Audit 070.6 — tests del bridge severity → case_study.
+//
+// Cubren:
+//   1. Modal lista correctos (solo casos activos, filtra closed_*).
+//   2. Filtrado por species_slug cuando la observación trae planta.
+//   3. Caso nuevo pre-fill (species_slug, severity, created_at, timeline[0]).
+//   4. CTA "Crear nuevo caso" como único path cuando no hay activos.
+//   5. "Más tarde" solo cierra (no destructivo, no crea caso).
+
+const resetStore = () => {
+  useCaseStudyStore.setState({ cases: [] });
+  if (typeof localStorage !== 'undefined') localStorage.removeItem('chagra:case-study');
+};
+
+describe('CaseLinkModal', () => {
+  beforeEach(resetStore);
+
+  it('lista solo casos activos (excluye closed_*)', () => {
+    const store = useCaseStudyStore.getState();
+    const activeId = store.createCase({
+      title: 'Caso activo trozador',
+      finca_slug: 'guatoc',
+      problem: { name_freetext: 'Trozador en tomate' },
+    });
+    const closedId = store.createCase({
+      title: 'Caso cerrado mildiú',
+      finca_slug: 'guatoc',
+      problem: { name_freetext: 'Mildiú resuelto' },
+    });
+    store.closeCase(closedId, { resolved: true });
+
+    const onClose = vi.fn();
+    render(
+      <CaseLinkModal
+        logId="log-test-1"
+        severity="high"
+        description="Daño en plántulas"
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText(/Caso activo trozador/i)).toBeTruthy();
+    expect(screen.queryByText(/Caso cerrado mildiú/i)).toBeNull();
+    // Sin species_slug → muestra todos activos, no el filtrado.
+    expect(screen.getByText(/Casos activos \(1\)/i)).toBeTruthy();
+    expect(activeId).toBeTruthy();
+  });
+
+  it('filtra por species_slug cuando la observación trae planta', () => {
+    const store = useCaseStudyStore.getState();
+    store.createCase({
+      title: 'Caso tomate',
+      finca_slug: 'guatoc',
+      subject: { species_ids: ['solanum_lycopersicum'] },
+      problem: { name_freetext: 'Trozador en tomate' },
+    });
+    store.createCase({
+      title: 'Caso lechuga',
+      finca_slug: 'guatoc',
+      subject: { species_ids: ['lactuca_sativa'] },
+      problem: { name_freetext: 'Pulgón en lechuga' },
+    });
+
+    const onClose = vi.fn();
+    render(
+      <CaseLinkModal
+        logId="log-test-2"
+        severity="critical"
+        description="Plántulas cortadas en la noche"
+        speciesSlug="solanum_lycopersicum"
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText(/Casos activos para esta especie \(1\)/i)).toBeTruthy();
+    expect(screen.getByText(/Caso tomate/i)).toBeTruthy();
+    expect(screen.queryByText(/Caso lechuga/i)).toBeNull();
+  });
+
+  it('si no hay matches por species, muestra lista completa de activos como fallback', () => {
+    const store = useCaseStudyStore.getState();
+    store.createCase({
+      title: 'Caso tomate',
+      finca_slug: 'guatoc',
+      subject: { species_ids: ['solanum_lycopersicum'] },
+      problem: { name_freetext: 'Trozador' },
+    });
+
+    render(
+      <CaseLinkModal
+        logId="log-test-fallback"
+        severity="high"
+        description="Algo raro en la fresa"
+        speciesSlug="fragaria_ananassa"
+        onClose={vi.fn()}
+      />
+    );
+
+    // No hay caso para fragaria → fallback lista todos activos sin tag de especie.
+    expect(screen.getByText(/Casos activos \(1\)/i)).toBeTruthy();
+    expect(screen.getByText(/Caso tomate/i)).toBeTruthy();
+  });
+
+  it('linka el log al caso al hacer click en su card', () => {
+    const store = useCaseStudyStore.getState();
+    const caseId = store.createCase({
+      title: 'Caso linkable',
+      finca_slug: 'guatoc',
+      problem: { name_freetext: 'Trozador' },
+    });
+    const onClose = vi.fn();
+
+    render(
+      <CaseLinkModal
+        logId="log-link-1"
+        severity="high"
+        description="Daño severo"
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByText(/Caso linkable/i));
+
+    const updated = useCaseStudyStore.getState().getById(caseId);
+    expect(updated.event_log_ids).toContain('log-link-1');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('caso nuevo pre-fill: species_slug, severity, created_at, timeline[0] = observación', () => {
+    const onClose = vi.fn();
+    render(
+      <CaseLinkModal
+        logId="log-newcase-1"
+        severity="critical"
+        description="Plántulas cortadas, daño masivo overnight"
+        speciesSlug="solanum_lycopersicum"
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Crear nuevo caso de estudio/i }));
+
+    const cases = useCaseStudyStore.getState().cases;
+    expect(cases).toHaveLength(1);
+    const c = cases[0];
+    expect(c.subject.species_ids).toEqual(['solanum_lycopersicum']);
+    expect(c.problem.severity).toBe('critical');
+    expect(c.problem.name_freetext).toMatch(/Plántulas cortadas/);
+    expect(c.created_at).toBeTruthy();
+    expect(c.visibility).toBe('private');
+    expect(c.validation.status).toBe('pending');
+    // timeline[0] = evento observación
+    expect(c.timeline).toHaveLength(1);
+    expect(c.timeline[0].event_type).toBe('observation');
+    expect(c.timeline[0].description).toMatch(/Plántulas cortadas/);
+    // log queda linkado al caso recién creado
+    expect(c.event_log_ids).toContain('log-newcase-1');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('cuando no hay casos activos, expone solo el CTA "Crear nuevo caso"', () => {
+    const onClose = vi.fn();
+    render(
+      <CaseLinkModal
+        logId="log-empty-1"
+        severity="high"
+        description="Primer caso de la finca"
+        onClose={onClose}
+      />
+    );
+
+    // No hay lista (cuenta cero casos activos)
+    expect(screen.queryByText(/Casos activos \(/i)).toBeNull();
+    // Mensaje de empty state
+    expect(screen.getByText(/No hay casos de estudio activos/i)).toBeTruthy();
+    // CTA principal visible
+    expect(screen.getByRole('button', { name: /Crear nuevo caso de estudio/i })).toBeTruthy();
+  });
+
+  it('"Más tarde" solo cierra y no crea caso ni linka log', () => {
+    const onClose = vi.fn();
+    render(
+      <CaseLinkModal
+        logId="log-dismiss-1"
+        severity="high"
+        description="No quiero crear caso aún"
+        onClose={onClose}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Más tarde/i }));
+
+    expect(useCaseStudyStore.getState().cases).toHaveLength(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/ObservationScreen.test.jsx
+++ b/src/components/__tests__/ObservationScreen.test.jsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Audit 070.5 + 070.6 — tests del selector plant opcional y el bridge
+// case_study en severidad high/critical.
+
+// Mock del store de assets — los lands/plants vienen del Zustand store.
+// Inyectamos shape mínimo: 2 lands, 2 plants (una bajo el land seleccionado).
+const mockState = {
+  lands: [
+    { id: 'land-1', attributes: { name: 'Invernadero David' } },
+    { id: 'land-2', attributes: { name: 'Era 4' } },
+  ],
+  plants: [
+    {
+      id: 'plant-1',
+      attributes: { name: 'Tomate Cherry #1', species_slug: 'solanum_lycopersicum_cerasiforme' },
+      relationships: { parent: { data: [{ type: 'asset--land', id: 'land-1' }] } },
+    },
+    {
+      id: 'plant-2',
+      attributes: { name: 'Lechuga Era 4', species_slug: 'lactuca_sativa' },
+      relationships: { location: { data: [{ type: 'asset--land', id: 'land-2' }] } },
+    },
+  ],
+};
+
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector(mockState),
+}));
+
+// Mock syncManager.saveTransaction → resolve sin tocar IDB real.
+const saveTransactionMock = vi.fn().mockResolvedValue({ id: 'tx-stub' });
+vi.mock('../../services/syncManager', () => ({
+  syncManager: {
+    saveTransaction: (...args) => saveTransactionMock(...args),
+  },
+}));
+
+// Mock crypto.randomUUID si jsdom no lo trae estable. Solo override mínimo.
+if (typeof globalThis.crypto?.randomUUID !== 'function') {
+  globalThis.crypto = {
+    ...(globalThis.crypto || {}),
+    randomUUID: () => 'uuid-test-stub',
+  };
+}
+
+import ObservationScreen from '../ObservationScreen';
+import { getParentLandIdFromAsset } from '../../utils/assetRelationships';
+import { useCaseStudyStore } from '../../store/useCaseStudyStore';
+
+const resetCaseStore = () => {
+  useCaseStudyStore.setState({ cases: [] });
+  if (typeof localStorage !== 'undefined') localStorage.removeItem('chagra:case-study');
+};
+
+describe('getParentLandIdFromAsset (helper exportado)', () => {
+  it('resuelve parent.data como array', () => {
+    expect(
+      getParentLandIdFromAsset({
+        relationships: { parent: { data: [{ type: 'asset--land', id: 'land-1' }] } },
+      })
+    ).toBe('land-1');
+  });
+
+  it('cae a location.data cuando no hay parent', () => {
+    expect(
+      getParentLandIdFromAsset({
+        relationships: { location: { data: { type: 'asset--land', id: 'land-9' } } },
+      })
+    ).toBe('land-9');
+  });
+
+  it('retorna null si no hay relaciones', () => {
+    expect(getParentLandIdFromAsset({})).toBeNull();
+    expect(getParentLandIdFromAsset(null)).toBeNull();
+  });
+});
+
+describe('ObservationScreen — audit 070.5 selector plant', () => {
+  beforeEach(() => {
+    saveTransactionMock.mockClear();
+    resetCaseStore();
+  });
+
+  it('selector plant NO aparece si no hay land seleccionado (estado inicial)', () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    // Estado inicial: locationId === '' → plantsForSelectedLand === [] → selector oculto.
+    expect(screen.queryByTestId('plant-selector')).toBeNull();
+  });
+
+  it('selector plant aparece si el land seleccionado tiene plants asociadas', () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-1' },
+    });
+    expect(screen.getByTestId('plant-selector')).toBeTruthy();
+    expect(screen.getByText(/Tomate Cherry #1/)).toBeTruthy();
+    // Lechuga (otro land) no debe aparecer en este dropdown.
+    expect(screen.queryByText(/Lechuga Era 4/)).toBeNull();
+  });
+
+  it('cambiar de land resetea el plantId seleccionado', () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-1' },
+    });
+    const plantSel = screen.getByTestId('plant-selector');
+    fireEvent.change(plantSel, { target: { value: 'plant-1' } });
+    expect(plantSel.value).toBe('plant-1');
+
+    // Cambio a land-2 → selector apunta a plant-2 dropdown, plantId resetea.
+    fireEvent.change(screen.getAllByRole('combobox').find((s) => s.name === 'locationId'), {
+      target: { value: 'land-2' },
+    });
+    const plantSel2 = screen.getByTestId('plant-selector');
+    expect(plantSel2.value).toBe('');
+  });
+});
+
+describe('ObservationScreen — audit 070.6 bridge case_study', () => {
+  beforeEach(() => {
+    saveTransactionMock.mockClear();
+    resetCaseStore();
+  });
+
+  it('severity low NO dispara CaseLinkModal post-save', async () => {
+    const onBack = vi.fn();
+    const onSave = vi.fn();
+    render(<ObservationScreen onBack={onBack} onSave={onSave} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: 'Hojas amarillas leves en una rama' },
+    });
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-1' },
+    });
+    // Severity por defecto es 'info' — explícitamente verificamos low también.
+    const severitySelect = screen.getAllByRole('combobox').find((s) => s.name === 'severity');
+    fireEvent.change(severitySelect, { target: { value: 'low' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Guardar Observacion/i }));
+    });
+
+    await waitFor(() => expect(saveTransactionMock).toHaveBeenCalled());
+    // Modal NO debe aparecer
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('severity high SÍ dispara CaseLinkModal con logId del payload', async () => {
+    const onBack = vi.fn();
+    const onSave = vi.fn();
+    render(<ObservationScreen onBack={onBack} onSave={onSave} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: 'Daño masivo en plántulas overnight' },
+    });
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-1' },
+    });
+    const severitySelect = screen.getAllByRole('combobox').find((s) => s.name === 'severity');
+    fireEvent.change(severitySelect, { target: { value: 'high' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Guardar Observacion/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('dialog')).toBeTruthy()
+    );
+    // Header del modal muestra severidad alta
+    expect(screen.getByText(/Severidad alta/i)).toBeTruthy();
+  });
+
+  it('severity critical + plant seleccionada pasa speciesSlug al modal para pre-fill', async () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: 'Trozador cortó 50 plántulas en una noche' },
+    });
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-1' },
+    });
+    const plantSel = screen.getByTestId('plant-selector');
+    fireEvent.change(plantSel, { target: { value: 'plant-1' } });
+
+    const severitySelect = screen.getAllByRole('combobox').find((s) => s.name === 'severity');
+    fireEvent.change(severitySelect, { target: { value: 'critical' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Guardar Observacion/i }));
+    });
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
+
+    // Crear nuevo caso → debe pre-fillear species_slug=solanum_lycopersicum_cerasiforme
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Crear nuevo caso de estudio/i }));
+    });
+
+    const cases = useCaseStudyStore.getState().cases;
+    expect(cases).toHaveLength(1);
+    expect(cases[0].subject.species_ids).toEqual(['solanum_lycopersicum_cerasiforme']);
+    expect(cases[0].problem.severity).toBe('critical');
+    expect(cases[0].timeline[0].event_type).toBe('observation');
+  });
+
+  it('payload incluye relationships.asset cuando plant está seleccionada', async () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: 'Hojas con manchas en planta puntual' },
+    });
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-1' },
+    });
+    fireEvent.change(screen.getByTestId('plant-selector'), {
+      target: { value: 'plant-1' },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Guardar Observacion/i }));
+    });
+
+    await waitFor(() => expect(saveTransactionMock).toHaveBeenCalled());
+    const callArg = saveTransactionMock.mock.calls[0][0];
+    const rels = callArg.payload.data.relationships;
+    expect(rels.location.data[0]).toEqual({ type: 'asset--land', id: 'land-1' });
+    expect(rels.asset.data[0]).toEqual({ type: 'asset--plant', id: 'plant-1' });
+  });
+
+  it('payload NO incluye relationships.asset cuando no hay plant seleccionada (compat legacy)', async () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: 'Observación general del lote' },
+    });
+    fireEvent.change(screen.getByDisplayValue(/Selecciona una zona/i), {
+      target: { value: 'land-2' },
+    });
+    // No seleccionamos plant (queda en '')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Guardar Observacion/i }));
+    });
+
+    await waitFor(() => expect(saveTransactionMock).toHaveBeenCalled());
+    const callArg = saveTransactionMock.mock.calls[0][0];
+    const rels = callArg.payload.data.relationships;
+    expect(rels.location.data[0]).toEqual({ type: 'asset--land', id: 'land-2' });
+    expect(rels.asset).toBeUndefined();
+  });
+});

--- a/src/utils/assetRelationships.js
+++ b/src/utils/assetRelationships.js
@@ -1,0 +1,21 @@
+/**
+ * assetRelationships.js — helpers para resolver refs JSON:API en assets.
+ *
+ * Justificación: el shape `relationships.parent.data` ↔ `relationships.location.data`
+ * se repite en AssetsDashboard, FarmMap, AssetDetailView y ObservationScreen.
+ * Centralizamos el fallback para evitar drift entre vistas.
+ */
+
+/**
+ * Resuelve el id del parent land asociado a un asset (planta, normalmente).
+ * Acepta el shape JSON:API tanto en array como objeto único y cae a
+ * `location.data` cuando no hay `parent.data` (compat FarmOS v2 + legacy).
+ *
+ * @param {object|null} asset
+ * @returns {string|null}
+ */
+export const getParentLandIdFromAsset = (asset) => {
+  const rel = asset?.relationships?.parent?.data || asset?.relationships?.location?.data;
+  if (Array.isArray(rel)) return rel[0]?.id || null;
+  return rel?.id || null;
+};


### PR DESCRIPTION
## Summary

Implementa findings 070.5 y 070.6 del audit deep:

- **070.5** — `ObservationScreen` ahora muestra un selector de planta opcional cuando el `asset--land` seleccionado tiene plants asociadas (`parent.data` o `location.data` apuntan al landId). Si el operador elige una planta, el payload incluye `relationships.asset` (`asset--plant`) además de `relationships.location` (`asset--land`). Sin selección, el flujo legacy queda intacto.
- **070.6** — Tras `savePayload` exitoso con `severity ∈ {high, critical}`, abre `CaseLinkModal` con el `logId` resultante. El modal lista solo casos activos (excluye `closed_*`), filtra por `species_slug` cuando la observación vincula a una planta puntual, y ofrece CTA "Crear nuevo caso" con pre-fill (`species_slug`, `severity`, `created_at`, `timeline[0]=observación`, `visibility='private'`, `validation.status='pending'`). El botón "Más tarde" cierra sin efectos secundarios.
- Helper `getParentLandIdFromAsset` movido a `src/utils/assetRelationships.js` para evitar drift entre vistas (AssetsDashboard, FarmMap, AssetDetailView usan el mismo shape) y satisfacer `react-refresh`.

## Componentes

- **Nuevo** `src/components/CaseLinkModal.jsx` — modal con lista de casos activos, filtro por especie, CTA crear/linkar, dismiss "más tarde".
- **Modificado** `src/components/ObservationScreen.jsx` — selector zona (land) explícito, selector planta condicional, payload dual asset+land, trigger del bridge case_study.
- **Nuevo** `src/utils/assetRelationships.js` — helper compartido `getParentLandIdFromAsset`.

## Test plan

- [x] `npm run lint` verde (0 warnings/errores).
- [x] `npm run test:unit` verde (238 tests, 18 nuevos pasando).
- [x] `npm run build` verde (sin warnings nuevos).
- [ ] CodeQL en verde (CI).
- [ ] Playwright E2E offline-first en verde (CI).
- [ ] Verificar manualmente: severity=low no dispara modal; severity=high con planta seleccionada abre modal con species_slug correcto; "Más tarde" cierra sin crear caso ni linkar log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)