### PR TITLE
feat(plant): PlanEditor montado en AssetDetailView (audit 070.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.129",
+  "version": "0.12.130",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v171';
+const CACHE_NAME = 'chagra-v172';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -14,6 +14,8 @@ import { proximityCheck, findNearestLand, checkInvasiveProximity, getCoords } fr
 import { ExternalAiButton } from './common/ExternalAiButton';
 import { buildOpenExternalPrompt } from '../services/externalAiPromptBuilder';
 import { listUserPhotosBySpecies, captureAndCompress, savePhoto } from '../services/photoService';
+import PlanEditor from './PlanEditor';
+import { getAllSpecies } from '../db/catalogDB';
 
 // Derive speciesSlug from asset name.
 function deriveSpeciesSlug(name) {
@@ -122,6 +124,85 @@ function SpeciesPhotoGallery({ speciesSlug, currentAssetId }) {
         </div>
       ))}
     </div>
+  );
+}
+
+// Plan de alimentación section: monta PlanEditor cuando la especie tiene
+// feeding_plan_template en el catálogo. Si la especie existe pero NO tiene
+// template (species pre-pipeline o sin curaduría agronómica), muestra un
+// placeholder pidiendo al equipo Chagra que agregue el plan. Audit finding
+// 070.7 (2026-05-18): PlanEditor estaba orphan — la UI existía pero no se
+// montaba en ninguna parte. Esta sección hace el wiring sin tocar la lógica
+// interna de PlanEditor.
+function PlanSection({ assetId, speciesSlug, plantingDate }) {
+  // 'loading' | 'has_template' | 'no_template' | 'no_species'
+  const [status, setStatus] = useState('loading');
+  const [requested, setRequested] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    if (!speciesSlug) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setStatus('no_species');
+      return () => { alive = false; };
+    }
+    (async () => {
+      try {
+        const species = await getAllSpecies();
+        if (!alive) return;
+        const entry = species.find((s) => s.id === speciesSlug);
+        if (!entry) {
+          setStatus('no_species');
+          return;
+        }
+        const hasTpl = !!(entry.feeding_plan_template && entry.feeding_plan_template.primary_steps?.length);
+        setStatus(hasTpl ? 'has_template' : 'no_template');
+      } catch (err) {
+        console.warn('[PlanSection] No se pudo leer el catálogo:', err);
+        if (alive) setStatus('no_template');
+      }
+    })();
+    return () => { alive = false; };
+  }, [speciesSlug]);
+
+  if (status === 'loading') {
+    return (
+      <section className="rounded-xl border border-slate-700/50 bg-slate-800/40 p-4">
+        <p className="text-xs text-slate-500 italic">Cargando plan de alimentación…</p>
+      </section>
+    );
+  }
+
+  if (status === 'no_species' || status === 'no_template') {
+    return (
+      <section className="rounded-xl border border-slate-700/50 bg-slate-800/40 p-4 space-y-3">
+        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider">Plan de Alimentación</h3>
+        <p className="text-sm text-slate-300">Sin plan disponible para esta especie</p>
+        <button
+          type="button"
+          disabled={requested}
+          onClick={() => setRequested(true)}
+          className="px-3 py-2 rounded-lg bg-amber-700/30 hover:bg-amber-700/50 active:scale-95 text-amber-200 border border-amber-700/40 text-xs font-bold disabled:opacity-60"
+        >
+          {requested ? 'Solicitud anotada' : 'Solicitar al equipo Chagra agregar plan'}
+        </button>
+        {requested && (
+          <p className="text-[11px] text-slate-400 italic">
+            Tu solicitud quedó registrada localmente. Pronto el equipo evaluará agregar el plan al catálogo.
+          </p>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-slate-700/50 bg-slate-800/40 p-1">
+      <PlanEditor
+        assetId={assetId}
+        speciesSlug={speciesSlug}
+        plantingDate={plantingDate}
+      />
+    </section>
   );
 }
 
@@ -258,6 +339,14 @@ export const AssetDetailView = () => {
                 <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-4 px-1">Acciones de Campo</h3>
                 <InputLogForm assetId={asset.id} onComplete={() => { }} />
               </section>
+
+              {deriveSpeciesSlug(name) && (
+                <PlanSection
+                  assetId={asset.id}
+                  speciesSlug={deriveSpeciesSlug(name)}
+                  plantingDate={asset.attributes?.created ? asset.attributes.created * 1000 : asset._createdAt || Date.now()}
+                />
+              )}
 
               <section className="pt-2">
                 <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Historial de la planta</h3>

--- a/src/components/__tests__/AssetDetailView.smoke.test.jsx
+++ b/src/components/__tests__/AssetDetailView.smoke.test.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// El asset que el store devolverá al test. Mutado por test para variar el
+// escenario (planta con/sin speciesSlug en catálogo, no-plant).
+let currentAsset = null;
+
+// Mock del store antes del import del componente. selectedAssetId se
+// deriva del currentAsset para que el AssetDetailView lo encuentre via
+// useMemo([...plants, ...structures, ...].find(a => a.id === selectedId)).
+vi.mock('../../store/useAssetStore', () => {
+  const useAssetStore = (selector) => {
+    return selector({
+      selectedAssetId: currentAsset?.id || null,
+      plants: currentAsset && (currentAsset.asset_type || '').includes('plant') ? [currentAsset] : [],
+      structures: currentAsset && (currentAsset.asset_type || '').includes('structure') ? [currentAsset] : [],
+      equipment: [],
+      materials: [],
+      lands: [],
+      clearSelectedAsset: vi.fn(),
+      updateAsset: vi.fn(),
+    });
+  };
+  return { default: useAssetStore };
+});
+
+// Mock catalogDB.getAllSpecies — controla si la especie tiene
+// feeding_plan_template o no.
+const mockSpecies = [
+  {
+    id: 'tomate',
+    feeding_plan_template: {
+      primary_steps: [{ action: 'apply_biofertilizer', offset_days: 7, biofertilizer_slug: 'biol_tomate', dose_ml: 100 }],
+    },
+  },
+  {
+    id: 'planta_sin_plan',
+    // sin feeding_plan_template
+  },
+];
+
+vi.mock('../../db/catalogDB', () => ({
+  getAllSpecies: vi.fn(async () => mockSpecies),
+}));
+
+// Mock planGeneratorService para PlanEditor: por defecto plan vacío.
+vi.mock('../../services/planGeneratorService', () => ({
+  getPlanForAsset: vi.fn(async () => null),
+  generatePlanForPlant: vi.fn(),
+  updatePlanStep: vi.fn(),
+  markStepExecuted: vi.fn(),
+}));
+
+vi.mock('../../services/operatorIdentityService', () => ({
+  getCurrentOperatorHash: () => 'test-hash',
+}));
+
+// Mocks de sub-componentes pesados para que el smoke test corra rápido.
+vi.mock('../AssetTimeline', () => ({
+  default: () => <div data-testid="asset-timeline">[AssetTimeline]</div>,
+}));
+
+vi.mock('../InputLogForm', () => ({
+  InputLogForm: () => <div data-testid="input-log-form">[InputLogForm]</div>,
+}));
+
+vi.mock('../MapPicker', () => ({
+  default: () => null,
+}));
+
+vi.mock('../PlantCemeteryModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('../SplitFlow', () => ({
+  SplitFlow: () => null,
+}));
+
+vi.mock('../common/ExternalAiButton', () => ({
+  ExternalAiButton: () => <button type="button">Ayuda IA</button>,
+}));
+
+vi.mock('../../hooks/useAssetPerformance', () => ({
+  useAssetPerformance: () => ({ globalRatio: 0, byCategory: {}, totalHarvestWeight: 0, totalInputWeight: 0, hasData: false }),
+}));
+
+vi.mock('../../services/photoService', () => ({
+  listUserPhotosBySpecies: vi.fn(async () => []),
+  captureAndCompress: vi.fn(),
+  savePhoto: vi.fn(),
+}));
+
+vi.mock('../../services/externalAiPromptBuilder', () => ({
+  buildOpenExternalPrompt: vi.fn(),
+}));
+
+import { AssetDetailView } from '../AssetDetailView';
+
+describe('AssetDetailView smoke — PlanSection wiring (audit 070.7)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('monta PlanSection para una planta cuya especie tiene feeding_plan_template', async () => {
+    currentAsset = {
+      id: 'asset-1',
+      asset_type: 'plant',
+      attributes: { name: 'Tomate #1', status: 'active', created: 1700000000 },
+    };
+
+    render(<AssetDetailView />);
+
+    // El PlanSection arranca en loading y luego resuelve a has_template,
+    // que renderiza PlanEditor — su fallback "Sin plan / Generar Plan"
+    // aparece porque getPlanForAsset() devolvió null en el mock.
+    await waitFor(() => {
+      expect(screen.getByText(/Generar Plan/i)).toBeTruthy();
+    });
+  });
+
+  it('muestra placeholder "Solicitar al equipo Chagra" cuando la especie no tiene template', async () => {
+    currentAsset = {
+      id: 'asset-2',
+      asset_type: 'plant',
+      attributes: { name: 'Planta sin plan #1', status: 'active', created: 1700000000 },
+    };
+
+    render(<AssetDetailView />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sin plan disponible para esta especie/i)).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: /Solicitar al equipo Chagra agregar plan/i })).toBeTruthy();
+  });
+
+  it('no monta PlanSection para assets que no son plants', async () => {
+    currentAsset = {
+      id: 'asset-3',
+      asset_type: 'structure',
+      attributes: { name: 'Invernadero', status: 'active', created: 1700000000 },
+    };
+
+    render(<AssetDetailView />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invernadero')).toBeTruthy();
+    });
+
+    // No debe aparecer ni PlanEditor ni el placeholder de solicitud.
+    expect(screen.queryByText(/Generar Plan/i)).toBeNull();
+    expect(screen.queryByText(/Solicitar al equipo Chagra/i)).toBeNull();
+  });
+});

--- a/src/components/__tests__/PlanEditor.smoke.test.jsx
+++ b/src/components/__tests__/PlanEditor.smoke.test.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import PlanEditor from '../PlanEditor';
+
+// Mock del service planGeneratorService — el comportamiento por test se
+// configura sobreescribiendo mockResolvedValueOnce de getPlanForAsset en
+// cada `it()`. Audit finding 070.7: validar render con plan + fallback sin
+// plan después de montar PlanEditor en AssetDetailView.
+vi.mock('../../services/planGeneratorService', () => ({
+  getPlanForAsset: vi.fn(),
+  generatePlanForPlant: vi.fn(),
+  updatePlanStep: vi.fn(),
+  markStepExecuted: vi.fn(),
+}));
+
+vi.mock('../../services/operatorIdentityService', () => ({
+  getCurrentOperatorHash: () => 'test-hash',
+}));
+
+import {
+  getPlanForAsset,
+  generatePlanForPlant,
+} from '../../services/planGeneratorService';
+
+const samplePlan = {
+  id: 'plan-1',
+  asset_id: 'asset-1',
+  species_slug: 'tomate',
+  generated_at: Date.now(),
+  scale_notes: 'Sugerencia para huerto casero',
+  companions: ['albahaca'],
+  antagonists: ['hinojo'],
+  steps: [
+    {
+      id: 'step-1',
+      scheduled_date: Date.now() + 7 * 86400000,
+      action_type: 'apply_biofertilizer',
+      biofertilizer_slug: 'biol_tomate',
+      dose_ml: 100,
+      status: 'pending',
+      stock_unavailable: false,
+      notes: 'Aplicar al pie de la planta',
+    },
+  ],
+};
+
+describe('PlanEditor smoke', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renderiza el plan cuando getPlanForAsset devuelve un plan con steps', async () => {
+    getPlanForAsset.mockResolvedValueOnce(samplePlan);
+
+    render(<PlanEditor assetId="asset-1" speciesSlug="tomate" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Plan de Alimentación/i)).toBeTruthy();
+    });
+
+    // El plan trae scale_notes — debe mostrarlas como sugerencia agronómica.
+    expect(screen.getByText(/Sugerencia para huerto casero/i)).toBeTruthy();
+    // Y al menos un step con su biofertilizer_slug visible (input editable
+    // del asesor o span sólo-lectura del operador básico).
+    expect(screen.getAllByDisplayValue('biol_tomate').length).toBeGreaterThan(0);
+    // Botón regenerar plan visible.
+    expect(screen.getByText(/Regenerar plan/i)).toBeTruthy();
+  });
+
+  it('muestra fallback "Generar Plan" cuando getPlanForAsset devuelve null', async () => {
+    getPlanForAsset.mockResolvedValueOnce(null);
+
+    render(<PlanEditor assetId="asset-2" speciesSlug="aji_dulce" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sin plan/i)).toBeTruthy();
+    });
+
+    expect(screen.getByRole('button', { name: /Generar Plan/i })).toBeTruthy();
+    // generatePlanForPlant aún no fue invocado (solo al click).
+    expect(generatePlanForPlant).not.toHaveBeenCalled();
+  });
+
+  it('muestra fallback cuando el plan existe pero tiene steps vacíos', async () => {
+    getPlanForAsset.mockResolvedValueOnce({
+      ...samplePlan,
+      steps: [],
+    });
+
+    render(<PlanEditor assetId="asset-3" speciesSlug="quinoa" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sin plan/i)).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: /Generar Plan/i })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Audit deep finding **070.7**: `PlanEditor.jsx` (177 LOC) tenía UI completa para editar/regenerar planes pero estaba orphan. Este PR lo monta en `AssetDetailView` sin tocar la lógica interna del componente (regla: solo wiring).
- Nuevo wrapper `PlanSection` en `AssetDetailView` consulta el catálogo y decide entre montar `<PlanEditor>` (especie con `feeding_plan_template`) o renderizar placeholder *"Sin plan disponible para esta especie"* + botón *"Solicitar al equipo Chagra agregar plan"* (placeholder UI sin envío real, marca solicitud local únicamente).
- Posición de montaje: dentro de la rama `isPlantType`, después de `InputLogForm` (Acciones de Campo) y antes del historial de la planta. Solo se monta si `deriveSpeciesSlug(name)` resuelve a un slug válido.
- Bump `0.12.129 → 0.12.130` + `chagra-v171 → chagra-v172` sincronizado manualmente (lefthook no estaba en PATH al committear; sigue SOP §3.2: el bump viaja dentro del commit funcional).

## Props que espera `PlanEditor` (documentadas mientras se hacía el wiring)

| Prop            | Tipo                  | Default       | Uso |
|-----------------|-----------------------|---------------|---|
| `assetId`       | `string` (requerido)  | —             | usado por `getPlanForAsset(assetId)` para hidratar plan desde IDB store `plans` |
| `speciesSlug`   | `string` (requerido)  | —             | usado por `generatePlanForPlant({speciesSlug,...})` para localizar la entry del catálogo |
| `plantingDate`  | `number|Date|string`  | `Date.now()`  | timestamp base para calcular `scheduled_date` de cada step (modulado por climateZone + lunarPhase) |
| `climateZone`   | `string`              | `'frio'`      | modula offsets ±20% |
| `lunarPhase`    | `string`              | `'creciente'` | modula offsets ±1 día |

> **Nota**: la tarea sugería `currentPlan` como prop probable. No existe — `PlanEditor` self-fetchea con `getPlanForAsset(assetId)` y persiste en IDB (`STORES.PLANS` v8 schema, ver `db/dbCore.js:142-144`).

## Test plan

- [x] `npm run lint` verde (ESLint clean en archivos tocados + global).
- [x] `npm run test:unit` verde (226/226 tests, incluye los 6 nuevos: 3 PlanEditor + 3 AssetDetailView).
- [x] `npm run build` verde (vite build sin warnings nuevos).
- [ ] Validar manual en dev: abrir detalle de una planta cuya especie tenga `feeding_plan_template` (ej. tomate, papa) → debe aparecer `PlanEditor` con steps o botón "Generar Plan".
- [ ] Validar manual en dev: abrir detalle de una planta cuya especie NO tenga template (ej. árbol pre-pipeline) → debe aparecer placeholder con botón "Solicitar al equipo Chagra agregar plan".
- [ ] Validar manual: abrir detalle de un asset que no sea planta (zona, estructura, equipo) → no debe aparecer `PlanSection`.

## Audit context

Finding 070.7 — orphan UI components. Este es el primer remediation; quedan otros componentes orphan en el audit (no parte de este PR).