### PR TITLE
fix(biodiversidad): calcular estratos + gremios desde catálogo, no atributos plant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.129",
+  "version": "0.12.130",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v171';
+const CACHE_NAME = 'chagra-v172';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/BiodiversidadView.jsx
+++ b/src/components/BiodiversidadView.jsx
@@ -5,11 +5,28 @@
  * flora del bosque alto-andino colombiano (oso andino, quetzal, morpho,
  * frailejón, maíz, armadillo, entre otros). Aplicada con gradient overlay
  * para legibilidad de las tarjetas de estadísticas encima.
+ *
+ * Bug operator 2026-05-18: estratos y gremios siempre mostraban 0 aunque
+ * las 37 species reales del operator cubrían 4 estratos y >3 gremios. El
+ * cálculo previo solo parseaba `attributes.notes` ("Estrato: X | Gremio: Y"
+ * — formato AssetsDashboard.formatNotes), pero plants creadas por
+ * VoiceCapture o sincronizadas desde FarmOS no llevan ese inline. El nuevo
+ * cálculo resuelve estrato + gremio vía lookup contra el catálogo SQLite
+ * por nombre normalizado (con fallback al parser legacy de notes para
+ * compatibilidad con plants viejas que SÍ tengan el inline).
+ *
+ * Lógica extraída a `src/utils/biodiversityStats.js` (función pura, tests
+ * en `biodiversityStats.test.js`).
  */
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Leaf } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import useAssetStore from '../store/useAssetStore';
+import { getAllSpecies } from '../db/catalogDB';
+import {
+  buildSpeciesIndex,
+  computeBiodiversityStats,
+} from '../utils/biodiversityStats';
 
 const STRATA = [
   { key: 'emergente', label: 'Emergente', color: 'text-emerald-300' },
@@ -18,48 +35,55 @@ const STRATA = [
   { key: 'bajo',      label: 'Bajo',      color: 'text-orange-300'  },
 ];
 
+// Timeout duro del load del catálogo: igual al de SpeciesSelect. Si SQLite
+// WASM se cuelga (OPFS bloqueado, cold boot offline), seguimos renderizando
+// con índice vacío → los stats caen al parser de notes legacy en vez de
+// quedar en blanco.
+const CATALOG_LOAD_TIMEOUT_MS = 2000;
+
 export default function BiodiversidadView({ onBack }) {
   const plants = useAssetStore((s) => s.plants || []);
+  const [speciesIndex, setSpeciesIndex] = useState(() => new Map());
 
-  const { speciesCount, strataCount, guildsCount, byStratum } = useMemo(() => {
-    const species = new Set();
-    const guilds = new Set();
-    const strata = new Set();
-    const perStratum = Object.fromEntries(STRATA.map((s) => [s.key, 0]));
-
-    // formatNotes() en AssetsDashboard guarda así:
-    //   "Notas usuario | Estrato: Medio (2-10m) | Gremio: Productivo principal"
-    // Delimitador: " | " (NO saltos de línea). El regex debe detenerse en "|".
-    const FIELD_RE = (key) => new RegExp(`${key}:\\s*([^|]+?)\\s*(?:\\||$)`, 'i');
-
-    for (const p of plants) {
-      const attrs = p.attributes || {};
-      // Especie se guarda en attributes.name (no en notes).
-      const name = (attrs.name || '').trim();
-      if (name) species.add(name.toLowerCase());
-
-      const notesValue =
-        (typeof attrs.notes === 'object' ? attrs.notes?.value : attrs.notes) || '';
-
-      const gremio = notesValue.match(FIELD_RE('Gremio'))?.[1]?.trim();
-      if (gremio) guilds.add(gremio.toLowerCase());
-
-      const stratumRaw = notesValue.match(FIELD_RE('Estrato'))?.[1]?.trim().toLowerCase();
-      if (stratumRaw) {
-        strata.add(stratumRaw);
-        // El label guardado es "Medio (2-10m)"; comparamos por prefijo de la palabra clave.
-        const key = STRATA.find((s) => stratumRaw.startsWith(s.key) || stratumRaw.includes(` ${s.key} `))?.key;
-        if (key) perStratum[key] += 1;
+  // Catálogo SQLite (v3.1+ ≈480 species con estrato + gremio curados). Se
+  // pre-carga en App.jsx pero leemos defensivamente: si tarda >2s o falla,
+  // dejamos el índice vacío y el stats calc cae a notes parsing.
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      if (!cancelled) {
+        console.warn('[BiodiversidadView] catalogDB timeout >2s, stats con índice vacío');
       }
-    }
+    }, CATALOG_LOAD_TIMEOUT_MS);
 
-    return {
-      speciesCount: species.size,
-      strataCount: strata.size,
-      guildsCount: guilds.size,
-      byStratum: perStratum,
+    Promise.race([
+      getAllSpecies(),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('catalog_timeout')), CATALOG_LOAD_TIMEOUT_MS)),
+    ])
+      .then((rows) => {
+        if (cancelled) return;
+        if (!Array.isArray(rows) || rows.length === 0) return;
+        setSpeciesIndex(buildSpeciesIndex(rows));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn('[BiodiversidadView] catalogDB load failed:', err?.message || err);
+      })
+      .finally(() => clearTimeout(timer));
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
     };
-  }, [plants]);
+  }, []);
+
+  // useMemo: con 100+ plants el lookup contra el índice (O(N·log N) en
+  // promedio por los prefix matches) es barato pero igual conviene no
+  // re-computarlo en cada render de scroll/resize.
+  const { speciesCount, strataCount, guildsCount, byStratum } = useMemo(
+    () => computeBiodiversityStats(plants, speciesIndex),
+    [plants, speciesIndex]
+  );
 
   // Lili #119: "mejorar la imagen del background". Overlay reducido
   // (de 0.55-0.82 a 0.45-0.78) para que la ilustración curada del bosque

--- a/src/utils/biodiversityStats.js
+++ b/src/utils/biodiversityStats.js
@@ -1,0 +1,187 @@
+/**
+ * biodiversityStats.js — cómputo puro de estadísticas para BiodiversidadView.
+ *
+ * Bug operator 2026-05-18: "37 Especies / 0 Estratos / 0 Gremios". El cálculo
+ * previo solo parseaba `attributes.notes` (formato `"Estrato: X | Gremio: Y"`),
+ * que únicamente queda inline cuando el operario abre el form rich de
+ * AssetsDashboard con `estrato`/`gremio` definidos. Plants creadas por:
+ *   - VoiceCapture (registro por voz)
+ *   - Sync desde FarmOS (notes libre o vacías)
+ *   - Selección directa de especie sin tocar estrato/gremio
+ * NO tenían el inline → estratos/gremios contaban 0 aunque las 37 especies
+ * estuvieran cubriendo 4 estratos y 5 gremios distintos en el catálogo.
+ *
+ * Fix: resolver estrato + gremio por lookup contra el catálogo SQLite
+ * (`speciesIndex`) usando el nombre de la planta normalizado. Si el match
+ * existe, leer los campos curados por agrónomo del catálogo. Solo si no
+ * matchea (entrada libre), caer al parser de notes legacy como red de
+ * seguridad.
+ *
+ * Función pura → testeable sin DOM. Recibe el índice ya construido para
+ * desacoplar del componente y de la inicialización async del SQLite.
+ */
+
+const STRATA_KEYS = ['emergente', 'alto', 'medio', 'bajo'];
+
+// Delimitador histórico de formatNotes() en AssetsDashboard:
+//   "Notas usuario | Estrato: Medio (2-10m) | Gremio: Productivo principal"
+const FIELD_RE = (key) => new RegExp(`${key}:\\s*([^|]+?)\\s*(?:\\||$)`, 'i');
+
+/**
+ * Normaliza un string para matching: lowercase + sin tildes + trim.
+ * Quita además sufijos del tipo "#001" usados en siembras bulk-individual,
+ * porque el catálogo nunca los lleva ("Gulupa #003" → "gulupa").
+ */
+export const normalizeForMatch = (s) => {
+  if (!s || typeof s !== 'string') return '';
+  return s
+    .replace(/\s+#\d+$/, '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+};
+
+/**
+ * Construye un índice O(1) `nombreNormalizado → species` a partir del array
+ * de species del catálogo SQLite (formato `getAllSpecies()` →
+ * `[{ id, nombre_comun, nombre_cientifico, estrato, gremio, ... }]`).
+ *
+ * Indexa por:
+ *   - id (slug exacto)
+ *   - nombre_comun normalizado
+ *   - "nombre_comun (nombre_cientifico)" normalizado — formato display que
+ *     SpeciesSelect deja en attributes.name al elegir desde el fuzzy search.
+ *   - nombre_cientifico normalizado
+ *
+ * Múltiples plants pueden share el mismo display name, pero el índice resuelve
+ * uno a uno gracias a estas variantes redundantes.
+ */
+export const buildSpeciesIndex = (allSpecies) => {
+  const index = new Map();
+  if (!Array.isArray(allSpecies)) return index;
+  for (const sp of allSpecies) {
+    if (!sp || typeof sp !== 'object') continue;
+    const add = (key) => {
+      const norm = normalizeForMatch(key);
+      if (norm && !index.has(norm)) index.set(norm, sp);
+    };
+    if (sp.id) add(sp.id);
+    if (sp.nombre_comun) add(sp.nombre_comun);
+    if (sp.nombre_cientifico) add(sp.nombre_cientifico);
+    if (sp.nombre_comun && sp.nombre_cientifico) {
+      add(`${sp.nombre_comun} (${sp.nombre_cientifico})`);
+    }
+  }
+  return index;
+};
+
+/**
+ * Resuelve la especie del catálogo asociada a una planta, intentando varias
+ * llaves. Retorna `null` si la planta es entrada libre (no matchea).
+ */
+const lookupSpecies = (plant, speciesIndex) => {
+  if (!speciesIndex || speciesIndex.size === 0) return null;
+  const attrs = plant?.attributes || {};
+  // 1. Slug explícito (VoiceCapture y futuros campos): el más confiable.
+  const slug = plant?._speciesSlug || attrs._speciesSlug;
+  if (slug) {
+    const bySlug = speciesIndex.get(normalizeForMatch(slug));
+    if (bySlug) return bySlug;
+  }
+  // 2. Match por display name (camino estándar de SpeciesSelect / VoiceCapture).
+  const name = attrs.name || plant?.name || '';
+  const norm = normalizeForMatch(name);
+  if (!norm) return null;
+  const direct = speciesIndex.get(norm);
+  if (direct) return direct;
+  // 3. Match por prefijo: el operador escribió "gulupa" pero el catálogo
+  // lo tiene como "gulupa (passiflora edulis f. edulis)". Intentamos al
+  // revés también ("gulupa madura" → "gulupa").
+  for (const [key, sp] of speciesIndex) {
+    if (key.startsWith(norm) || norm.startsWith(key)) return sp;
+  }
+  return null;
+};
+
+/**
+ * Extrae estrato + gremio de una planta usando, en orden:
+ *   1. Catálogo SQLite (vía lookup por nombre/slug).
+ *   2. Notes inline (`"Estrato: X | Gremio: Y"`) — legacy AssetsDashboard.
+ *
+ * Devuelve `{ estrato, gremio }` con strings normalizados (lowercase) o
+ * `null` por campo si no se pudo resolver.
+ */
+export const resolvePlantTraits = (plant, speciesIndex) => {
+  const sp = lookupSpecies(plant, speciesIndex);
+  let estrato = sp?.estrato ? String(sp.estrato).toLowerCase() : null;
+  let gremio = sp?.gremio ? String(sp.gremio).toLowerCase() : null;
+
+  if (estrato && gremio) return { estrato, gremio };
+
+  // Fallback notes parsing — solo si falta algún campo. Mantiene el
+  // comportamiento histórico para plants que SÍ tienen el inline (rich form
+  // con estrato/gremio override manual).
+  const attrs = plant?.attributes || {};
+  const notesValue =
+    (typeof attrs.notes === 'object' ? attrs.notes?.value : attrs.notes) || '';
+  if (typeof notesValue === 'string' && notesValue.length > 0) {
+    if (!estrato) {
+      const raw = notesValue.match(FIELD_RE('Estrato'))?.[1]?.trim().toLowerCase();
+      if (raw) estrato = raw;
+    }
+    if (!gremio) {
+      const raw = notesValue.match(FIELD_RE('Gremio'))?.[1]?.trim().toLowerCase();
+      if (raw) gremio = raw;
+    }
+  }
+
+  return { estrato, gremio };
+};
+
+/**
+ * Cómputo principal de stats para BiodiversidadView.
+ *
+ * @param {Array} plants — `useAssetStore.plants`
+ * @param {Map}   speciesIndex — output de `buildSpeciesIndex(allSpecies)`
+ * @returns {{ speciesCount:number, strataCount:number, guildsCount:number,
+ *            byStratum: Record<string, number> }}
+ */
+export const computeBiodiversityStats = (plants, speciesIndex) => {
+  const species = new Set();
+  const strata = new Set();
+  const guilds = new Set();
+  const byStratum = Object.fromEntries(STRATA_KEYS.map((k) => [k, 0]));
+
+  if (!Array.isArray(plants)) {
+    return { speciesCount: 0, strataCount: 0, guildsCount: 0, byStratum };
+  }
+
+  for (const p of plants) {
+    const attrs = p?.attributes || {};
+    const rawName = (attrs.name || p?.name || '').trim();
+    if (rawName) {
+      // Bulk-individual deja "Gulupa #003" — agrupar al nombre base.
+      species.add(normalizeForMatch(rawName) || rawName.toLowerCase());
+    }
+
+    const { estrato, gremio } = resolvePlantTraits(p, speciesIndex);
+    if (estrato) {
+      strata.add(estrato);
+      const key = STRATA_KEYS.find(
+        (k) => estrato === k || estrato.startsWith(k) || estrato.includes(` ${k} `)
+      );
+      if (key) byStratum[key] += 1;
+    }
+    if (gremio) guilds.add(gremio);
+  }
+
+  return {
+    speciesCount: species.size,
+    strataCount: strata.size,
+    guildsCount: guilds.size,
+    byStratum,
+  };
+};
+
+export const __STRATA_KEYS__ = STRATA_KEYS;

--- a/src/utils/biodiversityStats.test.js
+++ b/src/utils/biodiversityStats.test.js
@@ -1,0 +1,298 @@
+/**
+ * biodiversityStats.test.js — tests para el cómputo de stats que alimenta
+ * BiodiversidadView. Verifica el fix del bug "37 Especies / 0 Estratos /
+ * 0 Gremios" reportado por el operador el 2026-05-18.
+ *
+ * Casos cubiertos:
+ *   1. Catálogo presente + plants con name canónico → estratos/gremios
+ *      derivados del catálogo (camino feliz).
+ *   2. Catálogo presente + plants con name "display" estilo SpeciesSelect
+ *      ("Gulupa (Passiflora edulis f. edulis)") → match por display.
+ *   3. Plants con `attributes.notes` inline ("Estrato: X | Gremio: Y") y
+ *      sin match en catálogo → fallback al parser legacy.
+ *   4. Plants free-text sin match ni notes → contadas como especie pero
+ *      sin sumar a estratos/gremios (skip graceful).
+ *   5. Sufijo "#003" de bulk-individual → mismo nombre base se cuenta una
+ *      sola vez como especie.
+ *   6. Mix realista Guatoc (>=4 estratos, >=3 gremios) — el escenario que
+ *      el operador estaba viendo en producción.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildSpeciesIndex,
+  computeBiodiversityStats,
+  normalizeForMatch,
+  resolvePlantTraits,
+} from './biodiversityStats';
+
+const mockCatalog = [
+  {
+    id: 'passiflora_edulis',
+    nombre_comun: 'Gulupa',
+    nombre_cientifico: 'Passiflora edulis f. edulis',
+    estrato: 'medio',
+    gremio: 'productivo_principal',
+  },
+  {
+    id: 'psidium_guajava',
+    nombre_comun: 'Guayaba',
+    nombre_cientifico: 'Psidium guajava',
+    estrato: 'alto',
+    gremio: 'productivo_principal',
+  },
+  {
+    id: 'phaseolus_vulgaris',
+    nombre_comun: 'Frijol',
+    nombre_cientifico: 'Phaseolus vulgaris',
+    estrato: 'bajo',
+    gremio: 'fijador_nitrogeno',
+  },
+  {
+    id: 'calendula_officinalis',
+    nombre_comun: 'Caléndula',
+    nombre_cientifico: 'Calendula officinalis',
+    estrato: 'bajo',
+    gremio: 'atrayente_polinizadores',
+  },
+  {
+    id: 'zea_mays',
+    nombre_comun: 'Maíz',
+    nombre_cientifico: 'Zea mays',
+    estrato: 'medio',
+    gremio: 'productivo_principal',
+  },
+  {
+    // Especie emergente para validar las 4 capas verticales.
+    id: 'cedrela_montana',
+    nombre_comun: 'Cedro andino',
+    nombre_cientifico: 'Cedrela montana',
+    estrato: 'emergente',
+    gremio: 'productor_biomasa',
+  },
+];
+
+const makePlant = (name, extra = {}) => ({
+  id: `plant-${name}`,
+  type: 'asset--plant',
+  attributes: { name, ...(extra.attributes || {}) },
+  ...extra,
+});
+
+describe('normalizeForMatch', () => {
+  it('quita tildes y baja a lowercase', () => {
+    expect(normalizeForMatch('Caléndula')).toBe('calendula');
+    expect(normalizeForMatch('Maíz')).toBe('maiz');
+  });
+
+  it('quita sufijo "#NNN" de siembras bulk-individual', () => {
+    expect(normalizeForMatch('Gulupa #003')).toBe('gulupa');
+    expect(normalizeForMatch('Frijol #12')).toBe('frijol');
+  });
+
+  it('retorna string vacío para input inválido', () => {
+    expect(normalizeForMatch(null)).toBe('');
+    expect(normalizeForMatch(undefined)).toBe('');
+    expect(normalizeForMatch(42)).toBe('');
+  });
+});
+
+describe('buildSpeciesIndex', () => {
+  it('indexa por id, nombre_comun, nombre_cientifico y display "comun (cientifico)"', () => {
+    const idx = buildSpeciesIndex(mockCatalog);
+    expect(idx.get('gulupa')).toEqual(expect.objectContaining({ id: 'passiflora_edulis' }));
+    expect(idx.get('passiflora_edulis')).toEqual(expect.objectContaining({ id: 'passiflora_edulis' }));
+    expect(idx.get('passiflora edulis f. edulis')).toEqual(
+      expect.objectContaining({ id: 'passiflora_edulis' })
+    );
+    expect(idx.get('gulupa (passiflora edulis f. edulis)')).toEqual(
+      expect.objectContaining({ id: 'passiflora_edulis' })
+    );
+  });
+
+  it('tolera input vacío o no-array', () => {
+    expect(buildSpeciesIndex(null).size).toBe(0);
+    expect(buildSpeciesIndex(undefined).size).toBe(0);
+    expect(buildSpeciesIndex([]).size).toBe(0);
+  });
+});
+
+describe('resolvePlantTraits', () => {
+  const idx = buildSpeciesIndex(mockCatalog);
+
+  it('resuelve via catálogo cuando el name matchea nombre_comun', () => {
+    const plant = makePlant('Gulupa');
+    expect(resolvePlantTraits(plant, idx)).toEqual({
+      estrato: 'medio',
+      gremio: 'productivo_principal',
+    });
+  });
+
+  it('resuelve via catálogo con name display SpeciesSelect ("Comun (Cientifico)")', () => {
+    const plant = makePlant('Gulupa (Passiflora edulis f. edulis)');
+    expect(resolvePlantTraits(plant, idx)).toEqual({
+      estrato: 'medio',
+      gremio: 'productivo_principal',
+    });
+  });
+
+  it('resuelve via _speciesSlug si está presente (camino VoiceCapture)', () => {
+    const plant = makePlant('Frijol bola roja', { _speciesSlug: 'phaseolus_vulgaris' });
+    expect(resolvePlantTraits(plant, idx)).toEqual({
+      estrato: 'bajo',
+      gremio: 'fijador_nitrogeno',
+    });
+  });
+
+  it('fallback a notes parsing cuando no hay match en catálogo', () => {
+    const plant = makePlant('Especie inventada', {
+      attributes: {
+        name: 'Especie inventada',
+        notes: { value: 'Notas | Estrato: Alto | Gremio: Productor biomasa' },
+      },
+    });
+    expect(resolvePlantTraits(plant, idx)).toEqual({
+      estrato: 'alto',
+      gremio: 'productor biomasa',
+    });
+  });
+
+  it('retorna null/null cuando no hay match ni notes inline', () => {
+    const plant = makePlant('Planta libre sin contexto');
+    expect(resolvePlantTraits(plant, idx)).toEqual({ estrato: null, gremio: null });
+  });
+
+  it('acepta notes como string plano (sin wrapper {value})', () => {
+    const plant = makePlant('Otra libre', {
+      attributes: { name: 'Otra libre', notes: 'Origen: voz | Estrato: Medio | Gremio: Repelente plagas' },
+    });
+    expect(resolvePlantTraits(plant, idx)).toEqual({
+      estrato: 'medio',
+      gremio: 'repelente plagas',
+    });
+  });
+});
+
+describe('computeBiodiversityStats', () => {
+  const idx = buildSpeciesIndex(mockCatalog);
+
+  it('retorna 0/0/0 con array vacío', () => {
+    expect(computeBiodiversityStats([], idx)).toMatchObject({
+      speciesCount: 0,
+      strataCount: 0,
+      guildsCount: 0,
+    });
+  });
+
+  it('FIX BUG 2026-05-18: estratos y gremios > 0 cuando plants tienen species del catálogo', () => {
+    // Escenario operator: 5 plants distintas, 3 estratos, 3 gremios.
+    const plants = [
+      makePlant('Gulupa'),          // medio / productivo_principal
+      makePlant('Guayaba'),         // alto  / productivo_principal
+      makePlant('Frijol'),          // bajo  / fijador_nitrogeno
+      makePlant('Caléndula'),       // bajo  / atrayente_polinizadores
+      makePlant('Cedro andino'),    // emergente / productor_biomasa
+    ];
+    const stats = computeBiodiversityStats(plants, idx);
+    expect(stats.speciesCount).toBe(5);
+    expect(stats.strataCount).toBe(4); // emergente + alto + medio + bajo
+    // 4 gremios: productivo_principal (gulupa+guayaba) + fijador_nitrogeno +
+    // atrayente_polinizadores + productor_biomasa.
+    expect(stats.guildsCount).toBe(4);
+    expect(stats.byStratum).toEqual({
+      emergente: 1,
+      alto: 1,
+      medio: 1,
+      bajo: 2,
+    });
+  });
+
+  it('agrupa bulk-individual "Gulupa #001 / #002 / #003" como una sola especie', () => {
+    const plants = [
+      makePlant('Gulupa #001'),
+      makePlant('Gulupa #002'),
+      makePlant('Gulupa #003'),
+    ];
+    const stats = computeBiodiversityStats(plants, idx);
+    expect(stats.speciesCount).toBe(1);
+    expect(stats.strataCount).toBe(1);
+    expect(stats.guildsCount).toBe(1);
+    expect(stats.byStratum.medio).toBe(3);
+  });
+
+  it('mix realista Guatoc: 37 plants en 4 estratos + 4 gremios diferentes', () => {
+    // Reproduce la distribución que el operador esperaba ver (no exactamente
+    // sus 37, pero estructuralmente equivalente: muchas plants de mismas
+    // species cubriendo 4 estratos).
+    const plants = [
+      // 10 frijoles (bajo / fijador_n)
+      ...Array.from({ length: 10 }, (_, i) => makePlant(`Frijol #${String(i + 1).padStart(3, '0')}`)),
+      // 8 maíces (medio / productivo)
+      ...Array.from({ length: 8 }, (_, i) => makePlant(`Maíz #${String(i + 1).padStart(3, '0')}`)),
+      // 5 guayabas (alto / productivo)
+      ...Array.from({ length: 5 }, (_, i) => makePlant(`Guayaba #${String(i + 1).padStart(3, '0')}`)),
+      // 3 cedros (emergente / productor biomasa)
+      ...Array.from({ length: 3 }, (_, i) => makePlant(`Cedro andino #${String(i + 1).padStart(3, '0')}`)),
+      // 6 caléndulas (bajo / atrayente_polinizadores)
+      ...Array.from({ length: 6 }, (_, i) => makePlant(`Caléndula #${String(i + 1).padStart(3, '0')}`)),
+      // 5 gulupas (medio / productivo) — comparte gremio con maíz/guayaba
+      ...Array.from({ length: 5 }, (_, i) => makePlant(`Gulupa #${String(i + 1).padStart(3, '0')}`)),
+    ];
+    const stats = computeBiodiversityStats(plants, idx);
+    expect(stats.speciesCount).toBe(6);
+    expect(stats.strataCount).toBe(4);
+    // 4 gremios distintos: productivo_principal (gulupa+guayaba+maíz) +
+    // fijador_nitrogeno (frijol) + atrayente_polinizadores (caléndula) +
+    // productor_biomasa (cedro andino).
+    expect(stats.guildsCount).toBe(4);
+    expect(stats.byStratum.bajo).toBe(16); // 10 frijoles + 6 caléndulas
+    expect(stats.byStratum.medio).toBe(13); // 8 maíces + 5 gulupas
+    expect(stats.byStratum.alto).toBe(5);  // 5 guayabas
+    expect(stats.byStratum.emergente).toBe(3); // 3 cedros
+  });
+
+  it('plants free-text sin match cuentan como especie pero no suman a estratos/gremios', () => {
+    const plants = [
+      makePlant('Gulupa'),             // catálogo: medio/productivo
+      makePlant('Cucayo del abuelo'),  // libre, sin notes
+      makePlant('Mata misteriosa'),    // libre, sin notes
+    ];
+    const stats = computeBiodiversityStats(plants, idx);
+    expect(stats.speciesCount).toBe(3);
+    expect(stats.strataCount).toBe(1);
+    expect(stats.guildsCount).toBe(1);
+  });
+
+  it('combina catálogo + notes legacy: plants con ambas fuentes', () => {
+    const plants = [
+      makePlant('Gulupa'),                                  // catálogo
+      makePlant('Especie X', {
+        attributes: {
+          name: 'Especie X',
+          notes: { value: 'Estrato: Emergente | Gremio: Productor biomasa' },
+        },
+      }),                                                   // notes
+    ];
+    const stats = computeBiodiversityStats(plants, idx);
+    expect(stats.speciesCount).toBe(2);
+    expect(stats.strataCount).toBe(2);  // medio + emergente
+    expect(stats.guildsCount).toBe(2);
+  });
+
+  it('robusto ante speciesIndex vacío (catalog timeout en cold boot offline)', () => {
+    const emptyIdx = new Map();
+    const plants = [
+      makePlant('Gulupa'),
+      makePlant('Frijol', {
+        attributes: {
+          name: 'Frijol',
+          notes: { value: 'Notas | Estrato: Bajo | Gremio: Fijador nitrogeno' },
+        },
+      }),
+    ];
+    // Sin catálogo, solo plants con notes inline cuentan para estratos/gremios.
+    const stats = computeBiodiversityStats(plants, emptyIdx);
+    expect(stats.speciesCount).toBe(2);
+    expect(stats.strataCount).toBe(1);
+    expect(stats.guildsCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Bug operator 2026-05-18

BiodiversidadView mostraba **"37 Especies / 0 Estratos / 0 Gremios"**. Los contadores de estratos y gremios siempre quedaban en 0, aunque las 37 species reales del operator cubrían 4 estratos (emergente/alto/medio/bajo) y al menos 4 gremios funcionales distintos.

## Causa raíz

El cálculo previo (`BiodiversidadView.jsx` lines 22-62 anteriores) solo parseaba `plant.attributes.notes` buscando el inline `Estrato: X | Gremio: Y` que `formatNotes()` de `AssetsDashboard.jsx:180` escribe al guardar siembras con esos campos. Pero plants creadas por:

- `VoiceCapture` (registro por voz, notes = `"Origen: registro por voz..."`)
- Sync desde FarmOS (notes libre o vacías)
- Form rich sin tocar estrato/gremio (los campos quedan vacíos en `formatNotes`)

NO llevan ese inline. Resultado: regex no matchea → Sets vacíos → conteo 0.

## Fix

Extraje la lógica a `src/utils/biodiversityStats.js` como función pura. Resuelve estrato + gremio multinivel:

1. **Catálogo SQLite** (fuente de verdad): lookup por nombre normalizado contra `getAllSpecies()`. Indexa por `id`, `nombre_comun`, `nombre_cientifico` y display `"Comun (Cientifico)"`. Quita tildes y sufijos `#NNN` de siembras bulk-individual.
2. **`_speciesSlug` explícito**: si la planta lo lleva (camino `VoiceCapture`), es la ruta más confiable.
3. **Fallback notes parsing**: si nada anterior matchea, parsea el formato legacy `"Estrato: X | Gremio: Y"`. Mantiene compatibilidad con plants que SÍ tienen el inline (form rich con overrides manuales).

`BiodiversidadView` carga `getAllSpecies()` async con timeout 2s (idéntico a `SpeciesSelect`). Si el catálogo no carga (cold boot offline, OPFS bloqueado), el índice queda vacío y los stats caen al parser de notes legacy — graceful degradation.

## Tests

18 nuevos tests en `src/utils/biodiversityStats.test.js`:

- `normalizeForMatch`: tildes + sufijo `#NNN` + entradas inválidas.
- `buildSpeciesIndex`: indexación por las 4 variantes de nombre.
- `resolvePlantTraits`: catálogo, display, slug, notes fallback, sin match.
- `computeBiodiversityStats`:
  - **Caso bug operator**: 5 plants → 4 estratos + 4 gremios (verifica `> 0`).
  - Agrupación bulk `Gulupa #001/#002/#003` → 1 especie.
  - Mix Guatoc 37 plants → 4 estratos + 4 gremios + distribución correcta.
  - Free-text sin match cuenta como especie pero no infla estratos/gremios.
  - Mix catálogo + notes legacy.
  - Robusto ante speciesIndex vacío (catalog timeout).

## Validación

- `npm run lint` verde.
- `npm run test:unit` verde (238/238, incluye los 18 nuevos).
- `npm run build` verde.
- Conventional commits + escaneo `grep -iE "(token|bearer|password|secret|10\.88|alpha)"` limpio.
- Bump `0.12.129 → 0.12.130` + `chagra-v171 → chagra-v172` aplicado manualmente (lefthook no estaba en `PATH` del entorno; reportado en memoria operator).

## Test plan

- [ ] CodeQL merge-gate verde.
- [ ] Playwright E2E offline-first verde.
- [ ] Tras merge a `main`: `Deploy Chagra PWA` workflow verde, `sha256sum index.html` cambia, `CACHE_NAME` en prod bumpea al sha corto.
- [ ] Operator abre Biodiversidad y ve `37 Especies / 4 Estratos / N Gremios` (N depende del catálogo real Guatoc).