### PR TITLE
feat(plant): PlanEditor montado en AssetDetailView (audit 070.7 v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.132",
+  "version": "0.12.133",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v174';
+const CACHE_NAME = 'chagra-v175';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { X, Calendar, Tag, Activity, MapPin, AlertCircle, Images, Skull, Layers } from 'lucide-react';
+import { X, Calendar, Tag, Activity, MapPin, AlertCircle, Images, Skull, Layers, Sprout } from 'lucide-react';
 import { SplitFlow } from './SplitFlow';
 import PlantCemeteryModal from './PlantCemeteryModal';
 import useAssetStore from '../store/useAssetStore';
 import AssetTimeline from './AssetTimeline';
 import { InputLogForm } from './InputLogForm';
 import MapPicker from './MapPicker';
+import PlanEditor from './PlanEditor';
 import { useAssetPerformance } from '../hooks/useAssetPerformance';
 import { MATERIAL_CATEGORIES } from '../config/materials';
 import { FARM_CONFIG } from '../config/defaults';
@@ -15,6 +16,7 @@ import { ExternalAiButton } from './common/ExternalAiButton';
 import { buildOpenExternalPrompt } from '../services/externalAiPromptBuilder';
 import { listUserPhotosBySpecies, captureAndCompress, savePhoto } from '../services/photoService';
 import { ETAPA_FENOLOGICA_LABELS } from '../utils/plantMeta';
+import { getAllSpecies } from '../db/catalogDB';
 
 // Derive speciesSlug from asset name.
 function deriveSpeciesSlug(name) {
@@ -171,6 +173,125 @@ const PlantMetaPanel = ({ asset }) => {
   );
 };
 
+// Audit finding 070.7 (2026-05-18): PlanEditor wrapper. Verifica si la
+// species de la planta tiene `feeding_plan_template` en el catálogo:
+//   - Si sí → monta PlanEditor (que se auto-fetchea de IDB store `plans`).
+//   - Si no → muestra placeholder "Sin plan disponible" con botón mock
+//     "Solicitar al equipo Chagra agregar plan" (sin envío real, queda
+//     como hook UX para una futura iteración de feedback al catálogo).
+// Resolución de speciesSlug:
+//   1. asset.attributes._speciesSlug explícito (camino VoiceCapture / seeding).
+//   2. asset.attributes._chagra_plant_meta.species_slug si existe.
+//   3. deriveSpeciesSlug(name) como fallback.
+// plantingDate viene de attributes._chagra_plant_meta.fecha_germinacion (post
+// PR #918) o Date.now() si la planta aún no tiene metadata sembrada.
+const resolveSpeciesSlug = (asset) => {
+  if (!asset) return null;
+  const explicit = asset.attributes?._speciesSlug || asset._speciesSlug;
+  if (explicit && typeof explicit === 'string') return explicit;
+  const metaSlug = asset.attributes?._chagra_plant_meta?.species_slug;
+  if (metaSlug && typeof metaSlug === 'string') return metaSlug;
+  const name = asset.attributes?.name || asset.name || '';
+  return deriveSpeciesSlug(name);
+};
+
+const resolvePlantingDate = (asset) => {
+  const fecha = asset?.attributes?._chagra_plant_meta?.fecha_germinacion;
+  if (fecha) {
+    const t = new Date(fecha).getTime();
+    if (Number.isFinite(t)) return t;
+  }
+  return Date.now();
+};
+
+const PlanSection = ({ asset }) => {
+  const speciesSlug = useMemo(() => resolveSpeciesSlug(asset), [asset]);
+  const plantingDate = useMemo(() => resolvePlantingDate(asset), [asset]);
+  // status: 'idle' (sin slug, nada que buscar), 'loading', 'present', 'absent', 'error'.
+  // Inicialización lazy (function form) garantiza que React no llame al
+  // initializer en re-renders y respeta la regla react-hooks/set-state-in-effect.
+  const [status, setStatus] = useState(() => (speciesSlug ? 'loading' : 'idle'));
+
+  useEffect(() => {
+    if (!speciesSlug) return undefined;
+    let cancelled = false;
+    getAllSpecies()
+      .then((list) => {
+        if (cancelled) return;
+        const match = (list || []).find(
+          (s) => s?.id === speciesSlug || s?.slug === speciesSlug,
+        );
+        const tpl = match?.feeding_plan_template;
+        const present = !!(tpl && tpl.primary_steps && tpl.primary_steps.length > 0);
+        setStatus(present ? 'present' : 'absent');
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn('[PlanSection] getAllSpecies falló:', err);
+        setStatus('error');
+      });
+    return () => { cancelled = true; };
+  }, [speciesSlug]);
+
+  if (!speciesSlug) {
+    return (
+      <section data-testid="plan-section-no-slug" className="bg-slate-800/40 p-4 rounded-xl border border-slate-700/50">
+        <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-2 flex items-center gap-1">
+          <Sprout size={12} /> Plan de alimentación
+        </h3>
+        <p className="text-sm text-slate-400">
+          Sin especie reconocida; no es posible asociar un plan.
+        </p>
+      </section>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <section data-testid="plan-section-loading" className="bg-slate-800/40 p-4 rounded-xl border border-slate-700/50">
+        <p className="text-sm text-slate-400 italic">Buscando plan en el catálogo…</p>
+      </section>
+    );
+  }
+
+  if (status !== 'present') {
+    return (
+      <section data-testid="plan-section-empty" className="bg-slate-800/40 p-4 rounded-xl border border-slate-700/50 space-y-3">
+        <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider flex items-center gap-1">
+          <Sprout size={12} /> Plan de alimentación
+        </h3>
+        <p className="text-sm text-slate-300">
+          {status === 'error'
+            ? 'No se pudo consultar el catálogo de planes. Inténtalo de nuevo más tarde.'
+            : 'Sin plan disponible para esta especie.'}
+        </p>
+        <button
+          type="button"
+          onClick={() => window.alert(
+            'Tu solicitud quedó anotada localmente. El equipo Chagra revisará agregar un plan para esta especie.',
+          )}
+          className="w-full px-3 py-2 rounded-lg bg-emerald-700 hover:bg-emerald-600 text-white text-xs font-bold"
+        >
+          Solicitar al equipo Chagra agregar plan
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="plan-section-editor" className="space-y-2">
+      <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider px-1 flex items-center gap-1">
+        <Sprout size={12} /> Plan de alimentación
+      </h3>
+      <PlanEditor
+        assetId={asset.id}
+        speciesSlug={speciesSlug}
+        plantingDate={plantingDate}
+      />
+    </section>
+  );
+};
+
 // Bio-efficiency metrics panel.
 const PerformancePanel = ({ assetId }) => {
   const { globalRatio, byCategory, totalHarvestWeight, totalInputWeight, hasData } = useAssetPerformance(assetId);
@@ -305,6 +426,8 @@ export const AssetDetailView = () => {
                 <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-4 px-1">Acciones de Campo</h3>
                 <InputLogForm assetId={asset.id} onComplete={() => { }} />
               </section>
+
+              <PlanSection asset={asset} />
 
               <section className="pt-2">
                 <h3 className="text-xs font-bold text-slate-500 uppercase tracking-wider mb-3">Historial de la planta</h3>

--- a/src/components/__tests__/AssetDetailView.smoke.test.jsx
+++ b/src/components/__tests__/AssetDetailView.smoke.test.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Audit 070.7 smoke tests para el wiring de PlanEditor dentro de
+// AssetDetailView. Cubrimos:
+//   1. Planta cuya species tiene `feeding_plan_template` → monta PlanEditor.
+//   2. Planta cuya species NO tiene template → muestra placeholder
+//      "Sin plan disponible" + botón "Solicitar al equipo Chagra".
+//   3. Asset no-plant (land) → no monta PlanSection.
+
+// Mock del catálogo SQLite (jsdom no carga WASM): inyectamos un getAllSpecies
+// con dos especies, una con template y otra sin. vi.mock se hoistea, por eso
+// definimos el dataset DENTRO de la factory en vez de a top-level (evita el
+// ReferenceError "Cannot access before initialization").
+vi.mock('../../db/catalogDB', () => {
+  const speciesFixtures = [
+    {
+      id: 'solanum_lycopersicum',
+      feeding_plan_template: {
+        primary_steps: [{ offset_days: 7, biofertilizer_slug: 'biol_basico', dose_ml: 50 }],
+      },
+    },
+    {
+      id: 'lactuca_sativa',
+      // sin feeding_plan_template
+    },
+  ];
+  return {
+    getAllSpecies: vi.fn().mockResolvedValue(speciesFixtures),
+  };
+});
+
+// PlanEditor self-fetchea desde IDB — stubeamos para que el smoke no toque
+// el store real ni IndexedDB.
+vi.mock('../../services/planGeneratorService', () => ({
+  getPlanForAsset: vi.fn().mockResolvedValue(null),
+  generatePlanForPlant: vi.fn(),
+  updatePlanStep: vi.fn(),
+  markStepExecuted: vi.fn(),
+}));
+
+vi.mock('../../services/operatorIdentityService', () => ({
+  getCurrentOperatorHash: () => 'hash-test',
+}));
+
+// useAssetPerformance vacío (sin métricas).
+vi.mock('../../hooks/useAssetPerformance', () => ({
+  useAssetPerformance: () => ({
+    globalRatio: 0, byCategory: {}, totalHarvestWeight: 0, totalInputWeight: 0, hasData: false,
+  }),
+}));
+
+// AssetTimeline pesado — render stub.
+vi.mock('../AssetTimeline', () => ({
+  default: () => <div data-testid="timeline-stub" />,
+}));
+
+// InputLogForm pesado (tira asset store + payload) — stub.
+vi.mock('../InputLogForm', () => ({
+  InputLogForm: () => <div data-testid="input-log-form-stub" />,
+}));
+
+// MapPicker, PlantCemeteryModal, SplitFlow lazy-mounted via state flags;
+// stubeamos por si acaso.
+vi.mock('../MapPicker', () => ({ default: () => null }));
+vi.mock('../PlantCemeteryModal', () => ({ default: () => null }));
+vi.mock('../SplitFlow', () => ({ SplitFlow: () => null }));
+
+// photoService listUserPhotosBySpecies → resolve [].
+vi.mock('../../services/photoService', () => ({
+  listUserPhotosBySpecies: vi.fn().mockResolvedValue([]),
+  captureAndCompress: vi.fn(),
+  savePhoto: vi.fn(),
+}));
+
+// externalAiPromptBuilder used by ExternalAiButton import chain.
+vi.mock('../../services/externalAiPromptBuilder', () => ({
+  buildOpenExternalPrompt: () => 'stub-prompt',
+}));
+
+// State mutable del mock store: cada test reasigna selectedAssetId + plants/lands.
+const mockState = {
+  selectedAssetId: null,
+  plants: [],
+  structures: [],
+  equipment: [],
+  materials: [],
+  lands: [],
+  clearSelectedAsset: vi.fn(),
+  updateAsset: vi.fn(),
+};
+
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector(mockState),
+}));
+
+import { AssetDetailView } from '../AssetDetailView';
+
+beforeEach(() => {
+  mockState.selectedAssetId = null;
+  mockState.plants = [];
+  mockState.structures = [];
+  mockState.equipment = [];
+  mockState.materials = [];
+  mockState.lands = [];
+});
+
+describe('AssetDetailView — PlanSection wiring (audit 070.7)', () => {
+  it('monta PlanEditor cuando la planta es una species con feeding_plan_template', async () => {
+    mockState.selectedAssetId = 'plant-tomate';
+    mockState.plants = [{
+      id: 'plant-tomate',
+      asset_type: 'plant',
+      attributes: {
+        name: 'Tomate Cherry #1',
+        _speciesSlug: 'solanum_lycopersicum',
+        _chagra_plant_meta: { fecha_germinacion: '2026-05-01' },
+      },
+    }];
+
+    render(<AssetDetailView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-section-editor')).toBeTruthy();
+    });
+    // PlanEditor renderiza su propio CTA "Generar Plan" cuando getPlanForAsset → null.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Generar Plan/i })).toBeTruthy();
+    });
+  });
+
+  it('muestra placeholder + botón "Solicitar" cuando la species no tiene template', async () => {
+    mockState.selectedAssetId = 'plant-lechuga';
+    mockState.plants = [{
+      id: 'plant-lechuga',
+      asset_type: 'plant',
+      attributes: {
+        name: 'Lechuga #3',
+        _speciesSlug: 'lactuca_sativa',
+      },
+    }];
+
+    render(<AssetDetailView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-section-empty')).toBeTruthy();
+    });
+    expect(screen.getByText(/Sin plan disponible/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Solicitar al equipo Chagra/i })).toBeTruthy();
+  });
+
+  it('no monta PlanSection cuando el asset es land (no-plant)', async () => {
+    mockState.selectedAssetId = 'land-1';
+    mockState.lands = [{
+      id: 'land-1',
+      asset_type: 'land',
+      attributes: { name: 'Era 4' },
+    }];
+
+    render(<AssetDetailView />);
+
+    // El nombre del land sí está; PlanSection no.
+    expect(screen.getByText(/Era 4/i)).toBeTruthy();
+    expect(screen.queryByTestId('plan-section-editor')).toBeNull();
+    expect(screen.queryByTestId('plan-section-empty')).toBeNull();
+    expect(screen.queryByTestId('plan-section-loading')).toBeNull();
+    expect(screen.queryByTestId('plan-section-no-slug')).toBeNull();
+  });
+});

--- a/src/components/__tests__/PlanEditor.smoke.test.jsx
+++ b/src/components/__tests__/PlanEditor.smoke.test.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import PlanEditor from '../PlanEditor';
+
+// Audit 070.7 smoke tests para el PlanEditor. Cubren los tres caminos
+// observables del componente:
+//   1. Plan presente con `steps` no-vacíos → renderiza encabezado + steps.
+//   2. Plan null (IDB sin entrada) → render del CTA "Generar Plan".
+//   3. Plan presente pero con steps=[] → render del CTA "Generar Plan"
+//      (mismo fallback porque el componente trata ambos casos igual).
+
+const mockGetPlanForAsset = vi.fn();
+const mockGeneratePlanForPlant = vi.fn();
+const mockUpdatePlanStep = vi.fn();
+const mockMarkStepExecuted = vi.fn();
+
+vi.mock('../../services/planGeneratorService', () => ({
+  getPlanForAsset: (...args) => mockGetPlanForAsset(...args),
+  generatePlanForPlant: (...args) => mockGeneratePlanForPlant(...args),
+  updatePlanStep: (...args) => mockUpdatePlanStep(...args),
+  markStepExecuted: (...args) => mockMarkStepExecuted(...args),
+}));
+
+vi.mock('../../services/operatorIdentityService', () => ({
+  getCurrentOperatorHash: () => 'hash-test-0000000000000000000000000000000000000000000000000000000000',
+}));
+
+beforeEach(() => {
+  mockGetPlanForAsset.mockReset();
+  mockGeneratePlanForPlant.mockReset();
+  mockUpdatePlanStep.mockReset();
+  mockMarkStepExecuted.mockReset();
+});
+
+describe('PlanEditor smoke', () => {
+  it('renderiza encabezado + steps cuando hay plan con pasos', async () => {
+    mockGetPlanForAsset.mockResolvedValue({
+      id: 'plan-1',
+      asset_id: 'asset-1',
+      species_slug: 'solanum_lycopersicum',
+      generated_at: Date.now(),
+      steps: [
+        {
+          id: 'step-1',
+          scheduled_date: Date.now() + 3 * 86400000,
+          action_type: 'biofertilizer_application',
+          status: 'pending',
+          biofertilizer_slug: 'biol_basico',
+          dose_ml: 50,
+          notes: 'Aplicar diluido 1:10.',
+        },
+      ],
+    });
+    render(<PlanEditor assetId="asset-1" speciesSlug="solanum_lycopersicum" />);
+    await waitFor(() => {
+      expect(screen.getByText(/Plan de Alimentación/i)).toBeTruthy();
+    });
+    expect(screen.getByText(/solanum_lycopersicum/i)).toBeTruthy();
+    expect(screen.getByText(/Regenerar plan/i)).toBeTruthy();
+  });
+
+  it('muestra CTA "Generar Plan" cuando getPlanForAsset retorna null', async () => {
+    mockGetPlanForAsset.mockResolvedValue(null);
+    render(<PlanEditor assetId="asset-2" speciesSlug="zea_mays" />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Generar Plan/i })).toBeTruthy();
+    });
+    expect(screen.getByText(/Sin plan/i)).toBeTruthy();
+  });
+
+  it('muestra CTA "Generar Plan" cuando el plan tiene steps vacíos', async () => {
+    mockGetPlanForAsset.mockResolvedValue({
+      id: 'plan-empty',
+      asset_id: 'asset-3',
+      species_slug: 'phaseolus_vulgaris',
+      generated_at: Date.now(),
+      steps: [],
+    });
+    render(<PlanEditor assetId="asset-3" speciesSlug="phaseolus_vulgaris" />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Generar Plan/i })).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Audit finding 070.7 (P2 quick win)**: `src/components/PlanEditor.jsx` (177 LOC, UI completa para editar/regenerar planes de alimentación) era huérfano — sin route ni vista que lo montara. Este PR lo cablea en `AssetDetailView`.
- **PlanSection wrapper** decide entre montar el editor o un placeholder según el catálogo:
  - Consulta `getAllSpecies()` desde `db/catalogDB` y verifica si la species tiene `feeding_plan_template.primary_steps` no vacío.
  - Si **sí** → monta `<PlanEditor assetId speciesSlug plantingDate />`. PlanEditor se auto-fetchea del IDB store `plans` (schema v8) y renderiza pasos, regeneración, edición por asesor y marca de ejecución (lógica interna intacta — sólo wiring).
  - Si **no** → placeholder "Sin plan disponible para esta especie." + botón mock "Solicitar al equipo Chagra agregar plan" (sin envío real; hook UX para futura iteración de feedback al catálogo).
- **speciesSlug resolution** (precedencia): `attributes._speciesSlug` (camino VoiceCapture / seeding) → `attributes._chagra_plant_meta.species_slug` → `deriveSpeciesSlug(name)` → null (placeholder no-slug).
- **plantingDate**: se toma de `attributes._chagra_plant_meta.fecha_germinacion` (post #918), con fallback a `Date.now()` para plantas sin metadata sembrada.
- **Mount point**: dentro del bloque `isPlantType`, entre la sección "Acciones de Campo" (`InputLogForm`) y "Historial de la planta", para que el plan quede contiguo a las acciones de campo que lo van a ejecutar.

## Referencias

- PR #918 (plant form fecha_germinacion + altura + etapa fenológica) es upstream para `plantingDate`.
- Reemplaza al PR #921 cerrado por conflicts; rebuilt desde `main` fresco post-#918/#919/#920/#922/#923/#924.

## Tests (+6 sobre baseline)

- `src/components/__tests__/PlanEditor.smoke.test.jsx`: 3 tests
  - Plan con steps no vacíos → renderiza encabezado + botón regenerar.
  - Plan null → CTA "Generar Plan".
  - Plan con `steps: []` → CTA "Generar Plan" (mismo fallback).
- `src/components/__tests__/AssetDetailView.smoke.test.jsx`: 3 tests
  - Planta con species que tiene template → monta `plan-section-editor` + CTA PlanEditor.
  - Planta sin template → muestra `plan-section-empty` + botón "Solicitar al equipo Chagra".
  - Asset land (no-plant) → no monta PlanSection.

Total: 277 tests (baseline 271 + 6 nuevos).

## Test plan

- [x] `npm run lint` verde
- [x] `npm run test:unit` verde (30 archivos, 277 tests)
- [x] `npm run build` verde
- [ ] Smoke manual: abrir detalle de planta con species que tiene `feeding_plan_template` (tomate/aji) → ver PlanEditor.
- [ ] Smoke manual: abrir detalle de planta con species sin template → ver placeholder.
- [ ] Smoke manual: abrir detalle de un land → confirmar que PlanSection no aparece.