### PR TITLE
fix(ui): ocultar FieldFeedback FAB en agente y voz (operator: tapaba enviar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.133",
+  "version": "0.12.134",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v175';
+const CACHE_NAME = 'chagra-v176';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -442,8 +442,10 @@ export default function App() {
       <Suspense fallback={<LoadingFallback />}>
         {renderView()}
       </Suspense>
-      {/* FAB feedback inline para field testing, siempre visible salvo loading */}
-      {currentView !== 'loading' && currentView !== 'login' && <FieldFeedback />}
+      {/* FAB feedback inline para field testing. Operator bug 2026-05-18:
+          FieldFeedback FAB bottom-right tapaba el botón "enviar" en AgentScreen
+          y el textarea voice en VoiceCapture. Excluido en agente + voz. */}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'agente' && currentView !== 'voz' && <FieldFeedback />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <MicFab onNavigate={navigate} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <AgentFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}


### PR DESCRIPTION
Operator: 'el botón feedback tapa el botón enviar en IA'. Exclude AgentScreen + VoiceCapture del FAB.