### PR TITLE
fix(case-study): cierra loop infinito React #185 en CaseStudyDetail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.134",
+  "version": "0.12.135",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v176';
+const CACHE_NAME = 'chagra-v177';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/CaseStudyDetail.jsx
+++ b/src/components/CaseStudyDetail.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { FileText, AlertTriangle, AlertCircle, Activity, CheckCircle, XCircle, Beaker, Clock, MapPin, Camera, Sparkles, Loader2, Image as ImageIcon, Trash2, ShieldCheck, ShieldAlert, Globe, Lock, Users, Lightbulb, Plus, CalendarClock, Stethoscope } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import {
   useCaseStudyStore,
   CASE_VISIBILITIES,
   CASE_TIMELINE_EVENT_TYPES,
+  withExtendedDefaults,
 } from '../store/useCaseStudyStore';
 import PhotoCaptureField from './PhotoCaptureField';
 import { summarizeLessons } from '../services/caseStudyLessonsSummarizer';
@@ -900,7 +901,12 @@ const PhotoGallery = ({ photos, onAdd, onRemove }) => {
 };
 
 export default function CaseStudyDetail({ caseId, onBack }) {
-  const c = useCaseStudyStore((s) => s.getById(caseId));
+  // 2026-05-18: NO usar `s.getById(caseId)` en selector — devuelve nuevo
+  // objeto cada render (withExtendedDefaults hace spread) → React #185
+  // (Maximum update depth). Seleccionar el raw case desde `cases` (ref
+  // estable de zustand) y normalizar fuera del selector con useMemo.
+  const rawCase = useCaseStudyStore((s) => s.cases.find((cc) => cc.id === caseId));
+  const c = useMemo(() => (rawCase ? withExtendedDefaults(rawCase) : null), [rawCase]);
   const addTreatment = useCaseStudyStore((s) => s.addTreatment);
   const transitionState = useCaseStudyStore((s) => s.transitionState);
   const closeCase = useCaseStudyStore((s) => s.closeCase);

--- a/src/store/useCaseStudyStore.js
+++ b/src/store/useCaseStudyStore.js
@@ -129,7 +129,12 @@ const DEFAULT_VALIDATION = Object.freeze({
 // Normaliza un case legacy (sin campos extendidos) para garantizar
 // que UI siempre lee shape estable. Idempotente: si ya tiene los
 // campos, no los pisa.
-const withExtendedDefaults = (c) => {
+//
+// Exportado en línea 572. NO debe llamarse dentro de un selector zustand
+// (siempre devuelve nuevo objeto → re-render loop / React #185). Usar
+// `cases.find` en el selector + `useMemo(() => withExtendedDefaults(c), [c])`
+// en el componente.
+export const withExtendedDefaults = (c) => {
   if (!c) return c;
   return {
     ...c,


### PR DESCRIPTION
`getById` wrappea con `withExtendedDefaults` que crea nuevo objeto cada render (spread). Llamado dentro del selector zustand → comparación === nunca match → re-render infinito → React #185 (Maximum update depth) al abrir cualquier caso de estudio.

Fix: seleccionar `cases.find` (referencia estable) y normalizar fuera del selector con `useMemo`. Export `withExtendedDefaults` desde el store para permitir la normalización en el componente.

Validado:
- npx vitest run useCaseStudyStore.test.js → 23/23 pass
- npm run build → ok
- eslint → clean

Driver: operator reportó "Fallo en el módulo - Minified React error #185" al entrar a casos de estudio. Bloquea demo Diana 2026-05-19.