### PR TITLE
fix(sync): GC paginado borraba plantas legítimas (data-loss)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.135",
+  "version": "0.12.136",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v177';
+const CACHE_NAME = 'chagra-v178';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/db/assetCache.js
+++ b/src/db/assetCache.js
@@ -34,10 +34,24 @@ export const assetCache = {
    * Inserta múltiples activos preservando aquellos que tienen cambios locales pendientes.
    * Regla: si `local._pending === true`, la versión remota se ignora.
    * Los datos del servidor siempre nacen confirmados (`_pending: false`).
+   *
+   * 2026-05-19 — DATA LOSS FIX: el GC NO se ejecuta dentro de bulkPut por
+   * defecto. Antes purgaba assets locales que no estuvieran en `remoteAssets`,
+   * pero como el sync llama bulkPut **por página**, las plantas de páginas
+   * posteriores se borraban tras procesar la primera página → operator
+   * perdió plantas creadas hoy. El GC ahora vive en `purgeAbsent(...)` que
+   * `syncFromServer` invoca UNA vez al final con todos los ids remotos del
+   * tipo. Para no romper callers que dependían del comportamiento anterior,
+   * el flag `allowInlineGC: true` mantiene la semántica vieja.
+   *
    * @param {string} assetType - Tipo de activo (plant, equipment, etc.)
    * @param {Array} remoteAssets - Lista de activos provenientes del servidor
+   * @param {object} [opts]
+   * @param {boolean} [opts.allowInlineGC=false] - Si true, purga locales no
+   *   presentes en `remoteAssets`. ÚSALO solo cuando `remoteAssets` representa
+   *   el universo completo del tipo. NUNCA dentro de un loop paginado.
    */
-  async bulkPut(assetType, remoteAssets) {
+  async bulkPut(assetType, remoteAssets, { allowInlineGC = false } = {}) {
     const db = await openDB();
     const tx = db.transaction(STORES.ASSETS, 'readwrite');
     const store = tx.objectStore(STORES.ASSETS);
@@ -92,12 +106,18 @@ export const assetCache = {
       });
     }
 
-    // 3. Garbage Collection: purgar locales confirmados que el servidor ya no tiene
-    const remoteIds = new Set(remoteAssets.map((r) => r.id));
-    for (const local of localAssets) {
-      if (!remoteIds.has(local.id) && !local._pending) {
-        store.delete(local.id);
-        console.warn(`[Cache] Purgando activo eliminado en servidor: ${local.id}`);
+    // 3. Garbage Collection: solo cuando el caller garantiza que
+    // `remoteAssets` es el universo COMPLETO del tipo (no una página).
+    // Sin este guard, un sync paginado purgaba plantas legítimas que aún
+    // no habían aparecido en una página previa (data loss reportado
+    // 2026-05-19). Para sync paginado, ver `purgeAbsent(...)` al cierre.
+    if (allowInlineGC) {
+      const remoteIds = new Set(remoteAssets.map((r) => r.id));
+      for (const local of localAssets) {
+        if (!remoteIds.has(local.id) && !local._pending) {
+          store.delete(local.id);
+          console.warn(`[Cache] Purgando activo eliminado en servidor: ${local.id}`);
+        }
       }
     }
 
@@ -116,6 +136,47 @@ export const assetCache = {
           );
         }
         resolve();
+      };
+      tx.onabort = () => reject(tx.error);
+      tx.onerror = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Purga assets locales no-pending que NO están en el universo completo
+   * del servidor. Llamar UNA sola vez al final de un sync paginado, con
+   * el Set de TODOS los ids retornados sumando todas las páginas.
+   *
+   * @param {string} assetType
+   * @param {Set<string>} allRemoteIds - universo completo del sync
+   * @returns {Promise<number>} cantidad purgada
+   */
+  async purgeAbsent(assetType, allRemoteIds) {
+    if (!(allRemoteIds instanceof Set)) {
+      throw new Error('purgeAbsent: allRemoteIds debe ser un Set');
+    }
+    const db = await openDB();
+    const tx = db.transaction(STORES.ASSETS, 'readwrite');
+    const store = tx.objectStore(STORES.ASSETS);
+    const index = store.index('asset_type');
+    const localAssets = await new Promise((res, rej) => {
+      const req = index.getAll(IDBKeyRange.only(assetType));
+      req.onsuccess = () => res(req.result || []);
+      req.onerror = () => rej(req.error);
+    });
+    let purged = 0;
+    for (const local of localAssets) {
+      if (!allRemoteIds.has(local.id) && !local._pending) {
+        store.delete(local.id);
+        purged++;
+      }
+    }
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => {
+        if (purged > 0) {
+          console.warn(`[Cache] purgeAbsent(${assetType}): ${purged} purgados (post-sync completo)`);
+        }
+        resolve(purged);
       };
       tx.onabort = () => reject(tx.error);
       tx.onerror = () => reject(tx.error);

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -93,6 +93,15 @@ const useAssetStore = create((set, get) => ({
         let hasMore = true;
         let totalFetched = 0;
         let estimatedTotal = null;
+        // 2026-05-19 — acumula TODOS los ids remotos del tipo a lo largo
+        // de las páginas. La purga de locales (GC) corre UNA vez al final
+        // del sync completo del tipo, no por página, para evitar borrar
+        // assets legítimos que aparecerán en páginas posteriores.
+        const allRemoteIdsForType = new Set();
+        // Si el sync se aborta o falla parcialmente, NO purgar: el universo
+        // remoto no es confiable. `syncCompletedForType` solo se vuelve true
+        // cuando todas las páginas se procesaron sin signal aborted.
+        let syncCompletedForType = false;
 
         while (hasMore && !signal?.aborted) {
           const offset = page * pageLimit;
@@ -101,7 +110,9 @@ const useAssetStore = create((set, get) => ({
           const res = await fetchFn(url, { signal });
           const list = res.data || [];
 
+          // bulkPut SIN allowInlineGC: solo upsert, sin purgar (data-loss fix).
           await assetCache.bulkPut(t, list);
+          for (const r of list) allRemoteIdsForType.add(r.id);
           totalFetched += list.length;
 
           estimatedTotal = res.meta?.count || estimatedTotal;
@@ -123,6 +134,16 @@ const useAssetStore = create((set, get) => ({
         if (signal?.aborted) {
           syncProgress.isCancelled = true;
           break;
+        }
+        // Universo completo del tipo recolectado → ahora sí, GC final.
+        syncCompletedForType = true;
+        if (syncCompletedForType) {
+          try {
+            await assetCache.purgeAbsent(t, allRemoteIdsForType);
+          } catch (purgeErr) {
+            // Si la purga falla, mejor preservar datos: log y continuar.
+            console.warn(`[Sync] purgeAbsent(${t}) falló — preservando local:`, purgeErr);
+          }
         }
       }
 


### PR DESCRIPTION
## 🚨 Causa del data-loss reportado 2026-05-19

\`assetCache.bulkPut\` corría garbage-collection **cada vez que se llamaba**. \`syncFromServer\` la llama **una vez por página**. Resultado: los assets de páginas posteriores que **aún no se habían fetchado** se borraban tras procesar la primera página.

**Caso reportado**: operator perdió plantas creadas hoy + reaparecieron viejas plantas sin zona que había eliminado en sesión anterior cuyo delete-tx aún no llegó al servidor.

## Cambios

- \`bulkPut(assetType, list, { allowInlineGC = false })\` — sólo upsert por default. El flag mantiene la semántica vieja para callers que pasen el universo completo.
- \`purgeAbsent(assetType, Set<ids>)\` — nueva función que purga al final del sync con el universo completo recolectado.
- \`syncFromServer\` acumula ids remotos a lo largo de páginas y llama \`purgeAbsent\` UNA vez al final del tipo, condicionado a que el sync no haya sido abortado. Si la purga falla, prevalece la preservación del local.

## Recovery sugerido para operator

Las plantas perdidas localmente pueden estar aún en FarmOS si llegaron a sincronizarse antes del bug. Fetchear \`/api/asset/plant\` y rehidratar IDB. Si NO se sincronizaron y solo estaban en pending_transactions, revisar IDB \`pending_transactions\` store por txs no procesadas.

## Test plan

- [x] syncManager tests → 10/10 pass
- [x] npm run build → ok
- [ ] Operator: probar crear + borrar plantas, forzar sync, validar que ambas operaciones se preservan

🤖 Generated with [Claude Code](https://claude.com/claude-code)