### PR TITLE
feat(species): resolveSpecies con RAG + skip silencioso

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.137",
+  "version": "0.12.138",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v179';
+const CACHE_NAME = 'chagra-v180';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/speciesResolver.test.js
+++ b/src/services/__tests__/speciesResolver.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db/catalogDB', () => ({
+  getAllSpecies: vi.fn(),
+}));
+
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn(),
+}));
+
+import { getAllSpecies } from '../../db/catalogDB';
+import { retrieve } from '../ragRetriever';
+import {
+  resolveSpecies,
+  resolveSpeciesBatch,
+  __resetSpeciesResolverCache,
+} from '../speciesResolver';
+
+const SPECIES_FIXTURE = [
+  {
+    slug: 'solanum_lycopersicum_cherry',
+    name_es: 'Tomate Cherry',
+    name_la: 'Solanum lycopersicum var. cerasiforme',
+    nombres_comunes: ['tomatico', 'cherry'],
+  },
+  {
+    slug: 'fragaria_ananassa_monterrey',
+    name_es: 'Fresa Monterrey',
+    name_la: 'Fragaria × ananassa cv. Monterrey',
+  },
+  {
+    slug: 'annona_muricata',
+    name_es: 'Guanábana',
+    name_la: 'Annona muricata',
+  },
+];
+
+beforeEach(() => {
+  __resetSpeciesResolverCache();
+  getAllSpecies.mockResolvedValue(SPECIES_FIXTURE);
+  retrieve.mockResolvedValue([]);
+});
+
+describe('resolveSpecies', () => {
+  it('matchea exact por slug', async () => {
+    const r = await resolveSpecies('solanum_lycopersicum_cherry');
+    expect(r?.match).toBe('exact');
+    expect(r?.slug).toBe('solanum_lycopersicum_cherry');
+    expect(r?.confidence).toBe(1);
+  });
+
+  it('matchea exact por name_es (case-insensitive)', async () => {
+    const r = await resolveSpecies('Tomate Cherry');
+    expect(r?.match).toBe('exact');
+    expect(r?.slug).toBe('solanum_lycopersicum_cherry');
+  });
+
+  it('matchea exact por name_la', async () => {
+    const r = await resolveSpecies('Annona muricata');
+    expect(r?.match).toBe('exact');
+    expect(r?.slug).toBe('annona_muricata');
+  });
+
+  it('matchea por nombre regional', async () => {
+    const r = await resolveSpecies('tomatico');
+    expect(r?.match).toBe('exact');
+    expect(r?.slug).toBe('solanum_lycopersicum_cherry');
+  });
+
+  it('folds acentos y normaliza', async () => {
+    const r = await resolveSpecies('GUANÁBANA');
+    expect(r?.match).toBe('exact');
+    expect(r?.slug).toBe('annona_muricata');
+  });
+
+  it('skip (null) cuando catálogo y RAG no tienen match', async () => {
+    retrieve.mockResolvedValue([]);
+    const r = await resolveSpecies('chorcho');
+    expect(r).toBeNull();
+  });
+
+  it('RAG fuzzy match cuando supera threshold', async () => {
+    retrieve.mockResolvedValue([
+      { species: 'fragaria_ananassa_monterrey', text: '...', score: 3.5 },
+      { species: 'fragaria_ananassa_monterrey', text: '...', score: 1.2 },
+      { species: 'solanum_lycopersicum_cherry', text: '...', score: 0.4 },
+    ]);
+    const r = await resolveSpecies('fresita');
+    expect(r?.match).toBe('fuzzy');
+    expect(r?.slug).toBe('fragaria_ananassa_monterrey');
+    expect(r?.confidence).toBeGreaterThan(0.4);
+    expect(r?.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it('skip (null) si RAG retorna scores bajo threshold', async () => {
+    retrieve.mockResolvedValue([
+      { species: 'fragaria_ananassa_monterrey', text: '...', score: 0.5 },
+      { species: 'solanum_lycopersicum_cherry', text: '...', score: 0.3 },
+    ]);
+    const r = await resolveSpecies('cosa-rara');
+    expect(r).toBeNull();
+  });
+
+  it('string vacío → null', async () => {
+    expect(await resolveSpecies('')).toBeNull();
+    expect(await resolveSpecies(null)).toBeNull();
+  });
+
+  it('NO falla si catalogDB throws — RAG-only fallback', async () => {
+    getAllSpecies.mockRejectedValue(new Error('catalog not ready'));
+    retrieve.mockResolvedValue([
+      { species: 'annona_muricata', text: '...', score: 5.0 },
+    ]);
+    const r = await resolveSpecies('guanabana sabrosa');
+    expect(r?.match).toBe('fuzzy');
+    expect(r?.slug).toBe('annona_muricata');
+  });
+});
+
+describe('resolveSpeciesBatch', () => {
+  it('preserva resueltos y reporta skippeados', async () => {
+    retrieve.mockResolvedValue([]);
+    const { resolved, skipped } = await resolveSpeciesBatch([
+      'Tomate Cherry',
+      'cosa-inexistente',
+      'Guanábana',
+    ]);
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0].slug).toBe('solanum_lycopersicum_cherry');
+    expect(resolved[1].slug).toBe('annona_muricata');
+    expect(skipped).toEqual(['cosa-inexistente']);
+  });
+
+  it('batch vacío → {resolved:[], skipped:[]}', async () => {
+    const r = await resolveSpeciesBatch([]);
+    expect(r).toEqual({ resolved: [], skipped: [] });
+  });
+
+  it('no-array → {resolved:[], skipped:[]}', async () => {
+    const r = await resolveSpeciesBatch(null);
+    expect(r).toEqual({ resolved: [], skipped: [] });
+  });
+});

--- a/src/services/speciesResolver.js
+++ b/src/services/speciesResolver.js
@@ -1,0 +1,191 @@
+/**
+ * speciesResolver — Resolver de nombres libres a species del catálogo.
+ *
+ * Regla operativa (operator 2026-05-19):
+ *   "Cuando una species no se pueda matchear con lo registrado en el
+ *    catálogo se skipea esa especie sin afectar otros registros. Se
+ *    debe sugerir la que mejor matchea con lo existente siempre; pero
+ *    si no la encuentra, skippea."
+ *
+ * Estrategia en cascada:
+ *   1. Exact match: contra slug, name_es, name_la (case-insensitive,
+ *      acentos-folded). Confianza 1.0.
+ *   2. RAG match: query BM25 sobre cycle-content (passages indexados
+ *      por species_slug). Agrupa scores por species, toma el top. Si
+ *      score normalizado > RAG_THRESHOLD → match 'fuzzy'.
+ *   3. Sin match → return null (caller debe skip silencioso).
+ *
+ * NO bloquea: si el catálogo no está listo o el RAG falla, retorna null
+ * (skip) sin throw. El caller decide qué hacer con los skippeados (log,
+ * UI badge, etc.).
+ *
+ * @example
+ *   const result = await resolveSpecies('tomate cherry');
+ *   if (result?.match === 'exact') {
+ *     usar result.species;
+ *   } else if (result?.match === 'fuzzy') {
+ *     sugerir result.species + 'confianza: ' + result.confidence;
+ *   } else {
+ *     skip silencioso, log para audit
+ *   }
+ */
+
+import { getAllSpecies } from '../db/catalogDB';
+import { retrieve } from './ragRetriever';
+
+// Threshold conservador: BM25 retorna scores absolutos variables; basta
+// que el species ganador tenga > 2.0 acumulado en el top-10 para considerarlo
+// candidato. Ajustar empíricamente si genera falsos positivos.
+const RAG_THRESHOLD = 2.0;
+
+const fold = (s) =>
+  (s || '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+
+/**
+ * Cache del índice de species por slug/name. Se invalida si el catálogo
+ * cambia (rara vez en runtime). KISS: TTL por sesión.
+ */
+let speciesIndexCache = null;
+
+async function buildSpeciesIndex() {
+  if (speciesIndexCache) return speciesIndexCache;
+  try {
+    const all = await getAllSpecies();
+    const bySlug = new Map();
+    const byName = new Map();
+    for (const sp of all) {
+      if (!sp || !sp.slug) continue;
+      bySlug.set(fold(sp.slug), sp);
+      if (sp.name_es) byName.set(fold(sp.name_es), sp);
+      if (sp.name_la) byName.set(fold(sp.name_la), sp);
+      // Nombres regionales también indexados (opcional, depende del schema).
+      if (Array.isArray(sp.nombres_comunes)) {
+        for (const n of sp.nombres_comunes) {
+          if (typeof n === 'string') byName.set(fold(n), sp);
+        }
+      }
+    }
+    speciesIndexCache = { bySlug, byName };
+    return speciesIndexCache;
+  } catch (e) {
+    // catalogDB no listo o vacío — devolver índices vacíos, el caller
+    // recibirá null y skippeará silenciosamente.
+    console.warn('[speciesResolver] catálogo no disponible, RAG-only:', e?.message || e);
+    return { bySlug: new Map(), byName: new Map() };
+  }
+}
+
+/**
+ * Intenta resolver `name` a una species del catálogo.
+ *
+ * @param {string} name - texto libre (slug, nombre español, nombre latín,
+ *   nombre regional).
+ * @param {object} [opts]
+ * @param {number} [opts.ragTopK=10] - cuántos passages mirar para agrupar.
+ * @param {number} [opts.ragThreshold=RAG_THRESHOLD] - score mínimo del top.
+ * @returns {Promise<{species: object, slug: string, match: 'exact'|'fuzzy', confidence: number}|null>}
+ *   null si no hay match razonable (caller debe skip).
+ */
+export async function resolveSpecies(name, opts = {}) {
+  const { ragTopK = 10, ragThreshold = RAG_THRESHOLD } = opts;
+  const q = fold(name);
+  if (!q) return null;
+
+  const { bySlug, byName } = await buildSpeciesIndex();
+
+  // 1. Exact slug
+  if (bySlug.has(q)) {
+    const sp = bySlug.get(q);
+    return { species: sp, slug: sp.slug, match: 'exact', confidence: 1.0 };
+  }
+  // 2. Exact name (español/latín/regional)
+  if (byName.has(q)) {
+    const sp = byName.get(q);
+    return { species: sp, slug: sp.slug, match: 'exact', confidence: 1.0 };
+  }
+
+  // 3. RAG fallback — usar BM25 sobre cycle-content para encontrar species
+  //    con mayor evidencia textual relacionada al query. Agrupar scores por
+  //    species_slug (cada passage trae su slug).
+  let scoredPassages;
+  try {
+    scoredPassages = await retrieve(name, ragTopK);
+  } catch (e) {
+    console.warn('[speciesResolver] RAG falló:', e?.message || e);
+    return null;
+  }
+  if (!Array.isArray(scoredPassages) || scoredPassages.length === 0) {
+    return null;
+  }
+
+  const speciesScores = new Map();
+  for (const p of scoredPassages) {
+    if (!p || !p.species) continue;
+    speciesScores.set(p.species, (speciesScores.get(p.species) || 0) + (p.score || 0));
+  }
+  if (speciesScores.size === 0) return null;
+
+  let topSlug = null;
+  let topScore = -Infinity;
+  for (const [slug, score] of speciesScores) {
+    if (score > topScore) {
+      topScore = score;
+      topSlug = slug;
+    }
+  }
+  if (!topSlug || topScore < ragThreshold) {
+    return null; // sin candidato confiable → skip
+  }
+
+  // Recuperar species del índice si lo tenemos; si no, devolver shape
+  // mínimo (slug solo). El caller puede enriquecer después con
+  // getSpeciesById.
+  const sp = bySlug.get(fold(topSlug));
+  // Normaliza confidence a [0, 1] usando el score acumulado.
+  // Heurística: 2 → 0.5, 4 → 0.75, 8+ → ~0.9. logística simple.
+  const confidence = Math.min(1, topScore / (topScore + ragThreshold * 2));
+  return {
+    species: sp || { slug: topSlug },
+    slug: topSlug,
+    match: 'fuzzy',
+    confidence,
+  };
+}
+
+/**
+ * Resuelve un array de nombres aplicando la regla skip-on-no-match.
+ * Retorna `{ resolved: [{name, species, match}], skipped: [name] }`.
+ * Útil para importers / batch loaders que no deben fallar por 1 species.
+ *
+ * @param {string[]} names
+ * @param {object} [opts] - mismas opciones que resolveSpecies
+ */
+export async function resolveSpeciesBatch(names, opts = {}) {
+  if (!Array.isArray(names)) return { resolved: [], skipped: [] };
+  const resolved = [];
+  const skipped = [];
+  for (const name of names) {
+    const result = await resolveSpecies(name, opts);
+    if (result) {
+      resolved.push({ name, ...result });
+    } else {
+      skipped.push(name);
+    }
+  }
+  if (skipped.length > 0) {
+    console.warn(`[speciesResolver] skip ${skipped.length} sin match:`, skipped);
+  }
+  return { resolved, skipped };
+}
+
+/** Invalida cache — útil tras cambios en catálogo (tests, migraciones). */
+export function __resetSpeciesResolverCache() {
+  speciesIndexCache = null;
+}


### PR DESCRIPTION
## Regla operativa

Operator dictó 2026-05-19: *\"cuando una species no se pueda matchear con el catálogo, se skipea sin afectar otros registros. Sugerir best match si lo hay; si no, skippea.\"*

## Implementación

\`src/services/speciesResolver.js\` con cascada:

1. **Exact** match contra \`slug\` / \`name_es\` / \`name_la\` / \`nombres_comunes\` (case-insensitive, acentos folded). Confianza 1.0.
2. **RAG fuzzy**: BM25 sobre \`cycle-content\` (passages ya indexados por \`species_slug\`). Agrupa scores por species, devuelve top si score >= 2.0. Confianza normalizada en [0,1].
3. **Skip**: \`null\` — caller decide qué hacer (typical: log + continue).

\`resolveSpeciesBatch(names)\` aplica la regla a un array, retornando \`{ resolved, skipped }\`.

## Resiliencia

- Si \`catalogDB\` no está listo → fallback RAG-only.
- Si RAG falla → null silencioso (no throw).
- Caller nunca recibe excepción — preservación del flow.

## Test plan

- [x] vitest 13/13 pass (exact, fuzzy, threshold, batch, edge cases)
- [x] npm run build → ok
- [ ] Post-merge: aplicar en importers + asset cards + catalog-validator

## No-aplica-aún

El servicio queda disponible pero no wired a ningún caller en este PR. Wiring incremental en PRs subsiguientes (importers, validator, UI fallback en \`deriveSpeciesSlug\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)