### PR TITLE
feat(case-study): wire speciesResolver en demoLoader (skip species sin match)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.138",
+  "version": "0.12.139",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v180';
+const CACHE_NAME = 'chagra-v181';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/caseStudyDemoLoader.test.js
+++ b/src/services/__tests__/caseStudyDemoLoader.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../speciesResolver', () => ({
+  resolveSpecies: vi.fn(),
+}));
+
+import { resolveSpecies } from '../speciesResolver';
+import { loadCaseStudyDemos } from '../caseStudyDemoLoader';
+
+function makeFetchMock(manifest, cases) {
+  return vi.fn((url) => {
+    if (url.endsWith('/manifest.json')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(manifest) });
+    }
+    const file = url.split('/').pop();
+    const found = cases.find((c) => `${c.id}.json` === file);
+    if (found) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(found) });
+    }
+    return Promise.resolve({ ok: false });
+  });
+}
+
+function makeStore() {
+  let lastCalled = null;
+  return {
+    getState: () => ({
+      hydrateDemoCases: (cases) => {
+        lastCalled = cases;
+        return cases.length;
+      },
+    }),
+    _lastCalled: () => lastCalled,
+  };
+}
+
+beforeEach(() => {
+  resolveSpecies.mockReset();
+});
+
+describe('loadCaseStudyDemos — wiring speciesResolver', () => {
+  it('preserva species_ids resueltos (exact match)', async () => {
+    resolveSpecies.mockImplementation((id) =>
+      Promise.resolve({ slug: id, match: 'exact', confidence: 1 })
+    );
+    const manifest = { cases: ['case1.json'] };
+    const cases = [
+      { id: 'case1', subject: { species_ids: ['tomate_cherry', 'guanabana'] } },
+    ];
+    const store = makeStore();
+    const r = await loadCaseStudyDemos(store, { fetchImpl: makeFetchMock(manifest, cases) });
+    expect(r.attempted).toBe(1);
+    const persisted = store._lastCalled();
+    expect(persisted[0].subject.species_ids).toEqual(['tomate_cherry', 'guanabana']);
+  });
+
+  it('reemplaza por fuzzy slug cuando confidence ≥ 0.6', async () => {
+    resolveSpecies.mockImplementation((id) => {
+      if (id === 'tomatico_extraño') {
+        return Promise.resolve({ slug: 'solanum_lycopersicum_cherry', match: 'fuzzy', confidence: 0.8 });
+      }
+      return Promise.resolve(null);
+    });
+    const manifest = { cases: ['c.json'] };
+    const cases = [{ id: 'c', subject: { species_ids: ['tomatico_extraño'] } }];
+    const store = makeStore();
+    await loadCaseStudyDemos(store, { fetchImpl: makeFetchMock(manifest, cases) });
+    expect(store._lastCalled()[0].subject.species_ids).toEqual(['solanum_lycopersicum_cherry']);
+  });
+
+  it('dropea species sin match (skip silencioso) sin afectar el caso', async () => {
+    resolveSpecies.mockImplementation((id) => {
+      if (id === 'valid') return Promise.resolve({ slug: 'valid', match: 'exact', confidence: 1 });
+      return Promise.resolve(null);
+    });
+    const manifest = { cases: ['c.json'] };
+    const cases = [{ id: 'c', subject: { species_ids: ['valid', 'inexistente'] } }];
+    const store = makeStore();
+    await loadCaseStudyDemos(store, { fetchImpl: makeFetchMock(manifest, cases) });
+    const persisted = store._lastCalled();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].subject.species_ids).toEqual(['valid']);
+  });
+
+  it('dropea fuzzy con confidence < 0.6', async () => {
+    resolveSpecies.mockImplementation(() =>
+      Promise.resolve({ slug: 'algo', match: 'fuzzy', confidence: 0.4 })
+    );
+    const manifest = { cases: ['c.json'] };
+    const cases = [{ id: 'c', subject: { species_ids: ['rasguñoso'] } }];
+    const store = makeStore();
+    await loadCaseStudyDemos(store, { fetchImpl: makeFetchMock(manifest, cases) });
+    expect(store._lastCalled()[0].subject.species_ids).toEqual([]);
+  });
+
+  it('caso sin subject.species_ids pasa intacto', async () => {
+    const manifest = { cases: ['c.json'] };
+    const cases = [{ id: 'c', subject: {} }];
+    const store = makeStore();
+    const r = await loadCaseStudyDemos(store, { fetchImpl: makeFetchMock(manifest, cases) });
+    expect(r.attempted).toBe(1);
+  });
+
+  it('si resolveSpecies throws, NO falla el caso (defensivo)', async () => {
+    resolveSpecies.mockImplementation(() => Promise.reject(new Error('boom')));
+    const manifest = { cases: ['c.json'] };
+    const cases = [{ id: 'c', subject: { species_ids: ['x'] } }];
+    const store = makeStore();
+    const r = await loadCaseStudyDemos(store, { fetchImpl: makeFetchMock(manifest, cases) });
+    expect(r.attempted).toBe(1);
+  });
+});

--- a/src/services/caseStudyDemoLoader.js
+++ b/src/services/caseStudyDemoLoader.js
@@ -18,8 +18,36 @@
  * del operador. Esto NO bloquea la UX bajo ningún escenario.
  */
 
+import { resolveSpecies } from './speciesResolver';
+
 const MANIFEST_URL = '/case-studies-demo/manifest.json';
 const DEMO_BASE = '/case-studies-demo';
+
+/**
+ * Aplica la regla operator 2026-05-19: si un species_id en
+ * `subject.species_ids` no matchea el catálogo, intenta resolver con RAG
+ * y reemplaza por el slug real; si no hay candidato, lo dropea
+ * silenciosamente. NUNCA falla el caso completo por species inválida.
+ *
+ * @param {object} caseObj
+ * @returns {Promise<object>} mismo case con species_ids normalizado
+ */
+async function normalizeSpeciesIds(caseObj) {
+  const ids = caseObj?.subject?.species_ids;
+  if (!Array.isArray(ids) || ids.length === 0) return caseObj;
+  const resolved = [];
+  for (const id of ids) {
+    const r = await resolveSpecies(id);
+    if (r && (r.match === 'exact' || (r.match === 'fuzzy' && r.confidence >= 0.6))) {
+      resolved.push(r.slug);
+    }
+    // sin match → skip silencioso (regla operator)
+  }
+  return {
+    ...caseObj,
+    subject: { ...caseObj.subject, species_ids: resolved },
+  };
+}
 
 /**
  * Carga el manifest + cada case JSON listado.
@@ -54,7 +82,12 @@ export async function loadCaseStudyDemos(store, { fetchImpl = fetch } = {}) {
       const r = await fetchImpl(`${DEMO_BASE}/${file}`, { cache: 'no-cache' });
       if (!r.ok) continue;
       const c = await r.json();
-      if (c && c.id) fetched.push(c);
+      if (!c || !c.id) continue;
+      // 2026-05-19: aplicar regla skip-species-no-match a species_ids del caso.
+      // Cualquier species_id inválido se dropea silenciosamente (resolver con
+      // RAG si hay candidato fuzzy). El caso NUNCA falla por species.
+      const normalized = await normalizeSpeciesIds(c).catch(() => c);
+      fetched.push(normalized);
     } catch {
       // skip silently — el demo es nice-to-have, no bloquea
     }


### PR DESCRIPTION
## Primer wiring real del speciesResolver

Aplica la regla operator 2026-05-19 (\"skip species sin match en catálogo\") al loader de demos de casos de estudio.

## Comportamiento

Cuando un case demo incluye \`subject.species_ids\` con slugs no en catálogo:

| Caso | Acción |
|---|---|
| Exact match | preservar |
| Fuzzy match, confidence ≥ 0.6 | reemplazar por slug catálogo |
| Fuzzy match, confidence < 0.6 | dropear silenciosamente |
| Sin match | dropear silenciosamente |
| resolveSpecies throws | caso pasa intacto (defensivo) |

El **caso completo** nunca falla por una species inválida.

## Test plan

- [x] vitest 6/6 nuevos pass
- [x] 19/19 combinado con speciesResolver
- [x] npm run build ok

## Próximos wirings (no este PR)

- importers \`scripts/import-*.mjs\`
- catalog-validator (warning vs fail)
- asset cards \`deriveSpeciesSlug\` con resolver async (refactor UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)