### PR TITLE
feat(rag): retrieveWithPhotos — combinar passages + fotos del operador (L1.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.138",
+  "version": "0.12.139",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v180';
+const CACHE_NAME = 'chagra-v181';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/ragWithPhotos.test.js
+++ b/src/services/__tests__/ragWithPhotos.test.js
@@ -1,0 +1,203 @@
+/**
+ * ragWithPhotos.test.js — cobertura del service que combina passages del RAG
+ * con fotos del operador (L1.6, pre-Diana 2026-05-19).
+ *
+ * Estrategia:
+ *   - Mockeamos `../ragRetriever` (retrieve) y `../photoService`
+ *     (listUserPhotosBySpecies) para evitar fetch + IndexedDB.
+ *   - Verificamos:
+ *     1. Shape compuesto correcto.
+ *     2. Agrupación por species_slug única (sin duplicar fetch de fotos).
+ *     3. Respeta `photosPerSpecies` (top-N por capturedAt desc).
+ *     4. Species sin fotos → array vacío en el mapa.
+ *     5. `topK` se propaga a retrieve().
+ *     6. Failure path: si retrieve devuelve [], no se llama listUserPhotosBySpecies.
+ *     7. Failure path: si una species rompe listUserPhotosBySpecies, las otras
+ *        siguen devolviendo fotos.
+ *     8. `photosPerSpecies: 0` desactiva el join lateral.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn(),
+}));
+
+vi.mock('../photoService', () => ({
+  listUserPhotosBySpecies: vi.fn(),
+}));
+
+import { retrieve } from '../ragRetriever';
+import { listUserPhotosBySpecies } from '../photoService';
+import { retrieveWithPhotos } from '../ragWithPhotos';
+
+function fakeBlob(label = 'jpg') {
+  // Devolver un objeto opaco — el service no debe inspeccionar el contenido.
+  return { __blob: true, label };
+}
+
+function fakePhoto({ id, speciesSlug, capturedAt, label }) {
+  return {
+    id,
+    blob: fakeBlob(label || `photo-${id}`),
+    speciesSlug,
+    assetId: `asset-${id}`,
+    capturedAt,
+    createdAt: capturedAt,
+    mime: 'image/jpeg',
+    size: 12345,
+  };
+}
+
+describe('ragWithPhotos.retrieveWithPhotos', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('devuelve shape { passages, photosBySpecies } con fotos agrupadas por species_slug', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'valor_pedagogico', text: 'La fresa…', species: 'fragaria_test', score: 3.2 },
+      { key: 'feeding_plan_markdown', text: '### Plan…', species: 'fragaria_test', score: 2.1 },
+      { key: 'valor_pedagogico', text: 'El café…', species: 'coffea_test', score: 1.7 },
+    ]);
+
+    listUserPhotosBySpecies.mockImplementation(async (slug) => {
+      if (slug === 'fragaria_test') {
+        return [
+          fakePhoto({ id: 1, speciesSlug: 'fragaria_test', capturedAt: '2026-05-10T10:00:00Z' }),
+          fakePhoto({ id: 2, speciesSlug: 'fragaria_test', capturedAt: '2026-05-15T10:00:00Z' }),
+          fakePhoto({ id: 3, speciesSlug: 'fragaria_test', capturedAt: '2026-05-18T10:00:00Z' }),
+        ];
+      }
+      if (slug === 'coffea_test') {
+        return [fakePhoto({ id: 4, speciesSlug: 'coffea_test', capturedAt: '2026-05-12T10:00:00Z' })];
+      }
+      return [];
+    });
+
+    const result = await retrieveWithPhotos('fresa café', 5);
+
+    expect(result.passages).toHaveLength(3);
+    expect(Object.keys(result.photosBySpecies).sort()).toEqual(['coffea_test', 'fragaria_test']);
+
+    // Default photosPerSpecies = 2; las más recientes primero.
+    expect(result.photosBySpecies.fragaria_test).toHaveLength(2);
+    expect(result.photosBySpecies.fragaria_test.map((p) => p.id)).toEqual([3, 2]);
+
+    expect(result.photosBySpecies.coffea_test).toHaveLength(1);
+    expect(result.photosBySpecies.coffea_test[0].id).toBe(4);
+
+    // No se hace fetch duplicado de fragaria_test aunque aparezca en 2 passages.
+    expect(listUserPhotosBySpecies).toHaveBeenCalledTimes(2);
+    expect(listUserPhotosBySpecies).toHaveBeenCalledWith('fragaria_test');
+    expect(listUserPhotosBySpecies).toHaveBeenCalledWith('coffea_test');
+  });
+
+  it('respeta el override photosPerSpecies', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'k', text: 't', species: 'fragaria_test', score: 1 },
+    ]);
+    listUserPhotosBySpecies.mockResolvedValueOnce([
+      fakePhoto({ id: 1, speciesSlug: 'fragaria_test', capturedAt: '2026-05-10T10:00:00Z' }),
+      fakePhoto({ id: 2, speciesSlug: 'fragaria_test', capturedAt: '2026-05-15T10:00:00Z' }),
+      fakePhoto({ id: 3, speciesSlug: 'fragaria_test', capturedAt: '2026-05-18T10:00:00Z' }),
+    ]);
+
+    const result = await retrieveWithPhotos('q', 5, { photosPerSpecies: 1 });
+    expect(result.photosBySpecies.fragaria_test).toHaveLength(1);
+    expect(result.photosBySpecies.fragaria_test[0].id).toBe(3);
+  });
+
+  it('species sin fotos quedan con array vacío', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'k', text: 't', species: 'lechuga_test', score: 1 },
+    ]);
+    listUserPhotosBySpecies.mockResolvedValueOnce([]);
+
+    const result = await retrieveWithPhotos('lechuga', 3);
+    expect(result.passages).toHaveLength(1);
+    expect(result.photosBySpecies).toEqual({ lechuga_test: [] });
+  });
+
+  it('propaga topK al llamar retrieve', async () => {
+    retrieve.mockResolvedValueOnce([]);
+    await retrieveWithPhotos('algo', 7);
+    expect(retrieve).toHaveBeenCalledWith('algo', 7);
+  });
+
+  it('topK default = 5 cuando no se pasa', async () => {
+    retrieve.mockResolvedValueOnce([]);
+    await retrieveWithPhotos('algo');
+    expect(retrieve).toHaveBeenCalledWith('algo', 5);
+  });
+
+  it('si retrieve devuelve [], no llama listUserPhotosBySpecies y devuelve mapa vacío', async () => {
+    retrieve.mockResolvedValueOnce([]);
+
+    const result = await retrieveWithPhotos('query sin matches', 5);
+    expect(result.passages).toEqual([]);
+    expect(result.photosBySpecies).toEqual({});
+    expect(listUserPhotosBySpecies).not.toHaveBeenCalled();
+  });
+
+  it('si retrieve devuelve passages sin species_slug, no rompe y mapa queda vacío', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'k', text: 'pasaje suelto sin species' },
+      { key: 'k2', text: 'otro sin species', species: null },
+    ]);
+
+    const result = await retrieveWithPhotos('q', 5);
+    expect(result.passages).toHaveLength(2);
+    expect(result.photosBySpecies).toEqual({});
+    expect(listUserPhotosBySpecies).not.toHaveBeenCalled();
+  });
+
+  it('si una species rompe listUserPhotosBySpecies, las otras siguen', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'k', text: 't', species: 'fragaria_test', score: 2 },
+      { key: 'k', text: 't', species: 'coffea_test', score: 1 },
+    ]);
+    listUserPhotosBySpecies.mockImplementation(async (slug) => {
+      if (slug === 'fragaria_test') throw new Error('IDB exploded for fragaria');
+      if (slug === 'coffea_test') {
+        return [fakePhoto({ id: 9, speciesSlug: 'coffea_test', capturedAt: '2026-05-17T00:00:00Z' })];
+      }
+      return [];
+    });
+
+    const result = await retrieveWithPhotos('q', 5);
+    expect(result.photosBySpecies.fragaria_test).toEqual([]);
+    expect(result.photosBySpecies.coffea_test).toHaveLength(1);
+    expect(result.photosBySpecies.coffea_test[0].id).toBe(9);
+  });
+
+  it('photosPerSpecies: 0 desactiva el join lateral', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'k', text: 't', species: 'fragaria_test', score: 1 },
+    ]);
+    const result = await retrieveWithPhotos('q', 5, { photosPerSpecies: 0 });
+    expect(result.passages).toHaveLength(1);
+    expect(result.photosBySpecies).toEqual({});
+    expect(listUserPhotosBySpecies).not.toHaveBeenCalled();
+  });
+
+  it('si retrieve lanza excepción, devuelve shape vacío sin propagar', async () => {
+    retrieve.mockRejectedValueOnce(new Error('boom'));
+    const result = await retrieveWithPhotos('q', 5);
+    expect(result).toEqual({ passages: [], photosBySpecies: {} });
+    expect(listUserPhotosBySpecies).not.toHaveBeenCalled();
+  });
+
+  it('photos sin capturedAt quedan al final (fallback createdAt)', async () => {
+    retrieve.mockResolvedValueOnce([
+      { key: 'k', text: 't', species: 'fragaria_test', score: 1 },
+    ]);
+    listUserPhotosBySpecies.mockResolvedValueOnce([
+      { id: 1, speciesSlug: 'fragaria_test', blob: fakeBlob(), createdAt: '2026-05-10T10:00:00Z' },
+      { id: 2, speciesSlug: 'fragaria_test', blob: fakeBlob(), capturedAt: '2026-05-15T10:00:00Z' },
+      { id: 3, speciesSlug: 'fragaria_test', blob: fakeBlob() }, // sin fecha
+    ]);
+
+    const result = await retrieveWithPhotos('q', 5, { photosPerSpecies: 3 });
+    expect(result.photosBySpecies.fragaria_test.map((p) => p.id)).toEqual([2, 1, 3]);
+  });
+});

--- a/src/services/ragWithPhotos.js
+++ b/src/services/ragWithPhotos.js
@@ -1,0 +1,130 @@
+/**
+ * ragWithPhotos — combinación no destructiva de RAG de texto + fotos del operador.
+ *
+ * Motivación (L1.6, pre-Diana 2026-05-19):
+ *   El RAG actual (`ragRetriever.retrieve`) devuelve passages de texto del corpus
+ *   `public/cycle-content/*.json`. Pero el operador ya capturó fotos reales de su
+ *   finca atadas a `speciesSlug` en IndexedDB store `media_cache` (ver
+ *   `photoService.listUserPhotosBySpecies`). Cuando un consumidor del RAG busca
+ *   por una species, debería poder mostrar también las fotos que el operador
+ *   tomó — no solo texto del corpus.
+ *
+ * Decisión de diseño — separación de canales:
+ *   - NO mezclamos blobs binarios en el corpus BM25 (sería ruidoso, ineficiente,
+ *     y el índice se recalcularía mal). El corpus de texto sigue intacto.
+ *   - En cambio, hacemos un "join lateral" post-retrieve: para cada species_slug
+ *     que apareció en los hits, traemos top-N fotos por separado y devolvemos
+ *     un shape compuesto `{ passages, photosBySpecies }`.
+ *
+ * Convención del campo `species`:
+ *   - `retrieve()` produce passages con la prop `species` igual al `species_slug`.
+ *   - Documentos sintéticos sin `species_slug` quedan con `species === undefined`
+ *     y se omiten del join (defensivo).
+ *
+ * Caller responsibility:
+ *   - Si las photos contienen Blob, el caller debe gestionar `URL.createObjectURL`
+ *     y su `revoke` cuando ya no las necesite. Este service NO crea ObjectURLs
+ *     (mantiene la separación: dato vs presentación).
+ *
+ * @module ragWithPhotos
+ */
+
+import { retrieve } from './ragRetriever';
+import { listUserPhotosBySpecies } from './photoService';
+
+const DEFAULT_PHOTOS_PER_SPECIES = 2;
+
+/**
+ * Ordena las fotos por `capturedAt` desc, con fallback a `createdAt` desc.
+ * Las fotos sin fecha quedan al final (orden estable).
+ *
+ * @param {Array<Object>} photos
+ * @returns {Array<Object>} nueva lista ordenada (no muta input).
+ */
+function sortPhotosRecentFirst(photos) {
+  return [...photos].sort((a, b) => {
+    const aKey = a?.capturedAt || a?.createdAt || '';
+    const bKey = b?.capturedAt || b?.createdAt || '';
+    // localeCompare maneja ISO-8601 correctamente (orden lexicográfico = cronológico).
+    return bKey.localeCompare(aKey);
+  });
+}
+
+/**
+ * Recupera passages del RAG y los enriquece con fotos del operador agrupadas
+ * por species_slug. NO modifica el shape de los passages individuales — solo
+ * agrega un mapa lateral `photosBySpecies`.
+ *
+ * Manejo de errores:
+ *   - Si `retrieve()` falla, devuelve `{ passages: [], photosBySpecies: {} }`.
+ *   - Si `listUserPhotosBySpecies` falla para una species, esa species queda con
+ *     `[]` (no rompe las otras). photoService ya hace try/catch interno.
+ *
+ * @param {string} query — texto libre del usuario / agente.
+ * @param {number} [topK=5] — top-K passages a recuperar del corpus de texto.
+ * @param {Object} [opts]
+ * @param {number} [opts.photosPerSpecies=2] — máximo de fotos por species
+ *   incluidas en el resultado. Negativo o 0 desactiva el join de fotos.
+ * @returns {Promise<{passages: Array<Object>, photosBySpecies: Object<string, Array<Object>>}>}
+ *   `passages` mantiene el shape original de `ragRetriever.retrieve()`.
+ *   `photosBySpecies` mapea cada species_slug presente en los hits a un array
+ *   de fotos del operador (top-N por `capturedAt` desc). Species sin fotos
+ *   quedan con `[]`.
+ */
+export async function retrieveWithPhotos(query, topK = 5, opts = {}) {
+  const { photosPerSpecies = DEFAULT_PHOTOS_PER_SPECIES } = opts;
+
+  let passages;
+  try {
+    passages = await retrieve(query, topK);
+  } catch (err) {
+    // Defensivo: retrieve() ya tiene su propio try/catch interno, pero protegemos
+    // contra una excepción inesperada (ej. import roto en test).
+    console.error('[ragWithPhotos] retrieve failed:', err);
+    return { passages: [], photosBySpecies: {} };
+  }
+
+  if (!Array.isArray(passages) || passages.length === 0) {
+    return { passages: passages || [], photosBySpecies: {} };
+  }
+
+  // Si el caller desactivó fotos, devolvemos passages tal cual.
+  if (!photosPerSpecies || photosPerSpecies <= 0) {
+    return { passages, photosBySpecies: {} };
+  }
+
+  // Unique species presentes en los hits, en orden de primera aparición.
+  // Preserva el orden estable: si dos passages comparten species, la entrada
+  // del slug se crea al ver el primer hit.
+  const speciesSlugs = [];
+  const seen = new Set();
+  for (const p of passages) {
+    const slug = p?.species;
+    if (typeof slug === 'string' && slug.length > 0 && !seen.has(slug)) {
+      seen.add(slug);
+      speciesSlugs.push(slug);
+    }
+  }
+
+  // Fetch en paralelo — IndexedDB es non-blocking y agrupar reduce latencia
+  // en mobile rural cuando hay 3-5 species en los hits.
+  const photoLists = await Promise.all(
+    speciesSlugs.map(async (slug) => {
+      try {
+        const all = await listUserPhotosBySpecies(slug);
+        const sorted = sortPhotosRecentFirst(all || []);
+        return [slug, sorted.slice(0, photosPerSpecies)];
+      } catch (err) {
+        console.error(`[ragWithPhotos] listUserPhotosBySpecies(${slug}) failed:`, err);
+        return [slug, []];
+      }
+    }),
+  );
+
+  const photosBySpecies = Object.fromEntries(photoLists);
+  return { passages, photosBySpecies };
+}
+
+export const RAG_WITH_PHOTOS_SERVICE = {
+  retrieveWithPhotos,
+};


### PR DESCRIPTION
## Summary

L1.6 — combina los hits BM25 de `ragRetriever.retrieve()` con las fotos que el operador capturó en su finca (IndexedDB `media_cache`), sin contaminar el corpus de texto con blobs binarios.

- Nuevo `src/services/ragWithPhotos.js` con `retrieveWithPhotos(query, topK, { photosPerSpecies = 2 } = {})`.
- Devuelve shape compuesto `{ passages: [...], photosBySpecies: { slug: [photo, ...] } }`.
- Agrupa por `species_slug` única para evitar lookups duplicados en IDB.
- Fotos ordenadas por `capturedAt` desc (fallback `createdAt`).
- Failure-path defensivo: una species rota no bloquea las otras (`photoService.listUserPhotosBySpecies` ya tiene try/catch interno; este service además protege contra errores inesperados).
- NO crea `ObjectURL` (separa dato vs presentación; el caller gestiona el ciclo de vida de los `Blob`).
- NO modifica `retrieve()` ni el corpus; es función separada e idempotente.

Sin wiring a UI todavía — eso queda para PR posterior.

## Test plan

- [x] `npx vitest run src/services/__tests__/ragWithPhotos` — 11 casos verde local.
- [x] `npm run build` — verde local (0 warnings nuevos).
- [ ] CodeQL SAST (CI) verde.
- [ ] Playwright E2E offline-first (CI) verde.
- [ ] Verificación manual en demo Diana: pedir RAG por una species con fotos capturadas y confirmar que el shape llega bien al caller (cuando se wiree en PR posterior).

Cobertura del test:
1. Shape `{ passages, photosBySpecies }` correcto + agrupación por slug único.
2. Respeta `photosPerSpecies` (top-N por `capturedAt` desc).
3. Species sin fotos → array vacío.
4. `topK` se propaga a `retrieve()` (incl. default 5).
5. `retrieve` → `[]` no llama `listUserPhotosBySpecies`.
6. Passages sin `species` no rompen (mapa vacío).
7. Failure path: una species lanza excepción, las otras siguen.
8. `photosPerSpecies: 0` desactiva el join lateral.
9. `retrieve` rechaza → shape vacío sin propagar excepción.
10. Fallback de ordenamiento cuando falta `capturedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)