### PR TITLE
feat(observation): auto-sugerir tratamientos via RAG en severity medium/high (L1.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.138",
+  "version": "0.12.139",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v180';
+const CACHE_NAME = 'chagra-v181';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useMemo } from 'react';
-import { ArrowLeft, AlertCircle, Camera } from 'lucide-react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
+import { ArrowLeft, AlertCircle, Camera, Sparkles } from 'lucide-react';
 import DateField from './DateField';
 import CaseLinkModal from './CaseLinkModal';
 import { syncManager } from '../services/syncManager';
 import useAssetStore from '../store/useAssetStore';
 import { getParentLandIdFromAsset } from '../utils/assetRelationships';
+import { retrieve as ragRetrieve } from '../services/ragRetriever';
 
 // Bug 069.10 — observation requiere descripción mínima útil + ubicación.
 // Mínimo de 5 caracteres descarta entries vacíos tipo "ok" o "test".
@@ -20,6 +21,17 @@ const MAX_DESCRIPTION_LEN = 2000;
 // resultante para que el operador linke a caso existente o cree uno nuevo
 // (pre-fill species_slug + timeline[0]).
 const SEVERITY_TRIGGER_CASE_BRIDGE = new Set(['high', 'critical']);
+
+// L1.5 — sugerencia proactiva de tratamientos vía RAG.
+// Cuando el operador describe una observación con severity media-alta,
+// disparamos `retrieve(description + species_name, 5)` tras 3s de inactividad
+// (debounce) y mostramos top 2-3 passages en sección colapsada NO bloqueante.
+// La sugerencia es informativa: el operador puede ignorarla y guardar igual.
+const SEVERITY_TRIGGER_RAG_SUGGEST = new Set(['medium', 'high', 'critical']);
+const RAG_SUGGEST_DEBOUNCE_MS = 3000;
+const RAG_SUGGEST_TOP_K = 5;
+const RAG_SUGGEST_SHOW_LIMIT = 3;
+const RAG_PASSAGE_EXCERPT_LEN = 220;
 
 function ObservationScreen({ onBack, onSave }) {
   const [formData, setFormData] = useState({
@@ -65,6 +77,64 @@ function ObservationScreen({ onBack, onSave }) {
 
   const hasErrors = Object.keys(errors).length > 0;
   const markTouched = (field) => setTouched((t) => ({ ...t, [field]: true }));
+
+  // L1.5 — sugerencias proactivas RAG (debounced, no bloqueante).
+  const [ragSuggestions, setRagSuggestions] = useState([]);
+  const [ragLoading, setRagLoading] = useState(false);
+  const ragRequestIdRef = useRef(0);
+
+  // Nombre de la especie seleccionada (si hay plant). Usado para enriquecer
+  // la query RAG con contexto botánico. Cae a '' cuando no hay match.
+  const selectedSpeciesName = useMemo(() => {
+    if (!formData.plantId) return '';
+    const plant = (plants || []).find((p) => p.id === formData.plantId);
+    return (
+      plant?.attributes?.species_slug
+      || plant?.attributes?.species?.name
+      || plant?.attributes?.name
+      || ''
+    );
+  }, [formData.plantId, plants]);
+
+  useEffect(() => {
+    const desc = (formData.description || '').trim();
+    const triggers = SEVERITY_TRIGGER_RAG_SUGGEST.has(formData.severity);
+
+    // Reset si no se cumplen condiciones (mantiene UI limpia entre cambios
+    // de severity o descripción vaciada).
+    if (!triggers || desc.length < MIN_DESCRIPTION_LEN) {
+      setRagSuggestions([]);
+      setRagLoading(false);
+      return undefined;
+    }
+
+    const requestId = ++ragRequestIdRef.current;
+    setRagLoading(true);
+
+    const timerId = setTimeout(async () => {
+      try {
+        const query = selectedSpeciesName
+          ? `${desc} ${selectedSpeciesName}`
+          : desc;
+        const results = await ragRetrieve(query, RAG_SUGGEST_TOP_K);
+        // Race-guard: si entre el debounce y el resolve otro cambio disparó
+        // un nuevo request, descartamos este resultado.
+        if (requestId !== ragRequestIdRef.current) return;
+        const filtered = Array.isArray(results)
+          ? results.filter((r) => r && typeof r.score === 'number' && r.score > 0)
+          : [];
+        setRagSuggestions(filtered.slice(0, RAG_SUGGEST_SHOW_LIMIT));
+      } catch (err) {
+        // Graceful: RAG falla → sección NO se renderiza, sin error UI.
+        console.warn('[ObservationScreen] RAG retrieve failed:', err);
+        if (requestId === ragRequestIdRef.current) setRagSuggestions([]);
+      } finally {
+        if (requestId === ragRequestIdRef.current) setRagLoading(false);
+      }
+    }, RAG_SUGGEST_DEBOUNCE_MS);
+
+    return () => clearTimeout(timerId);
+  }, [formData.description, formData.severity, selectedSpeciesName]);
 
   const handleInput = (e) => {
     setFormData(prev => {
@@ -257,6 +327,49 @@ function ObservationScreen({ onBack, onSave }) {
             <option value="critical">Critica</option>
           </select>
         </label>
+
+        {/* L1.5 — sugerencias RAG no bloqueantes. Solo renderiza si hay
+            resultados con score>0. Colapsada por defecto para no robar foco
+            del flujo de guardado. Operador puede ignorarla. */}
+        {ragSuggestions.length > 0 && (
+          <details
+            data-testid="rag-treatment-suggestions"
+            className="rounded-xl bg-slate-900 border border-purple-700/40 overflow-hidden"
+          >
+            <summary className="p-4 cursor-pointer flex items-center gap-2 text-lg font-bold text-purple-200">
+              <Sparkles size={20} aria-hidden="true" className="text-purple-300" />
+              Tratamientos sugeridos por la red Chagra
+              <span className="text-sm font-normal text-slate-400 ml-1">
+                ({ragSuggestions.length})
+              </span>
+            </summary>
+            <ul className="px-4 pb-4 flex flex-col gap-3" role="list">
+              {ragSuggestions.map((suggestion, idx) => {
+                const excerpt = (suggestion.text || '').slice(0, RAG_PASSAGE_EXCERPT_LEN);
+                const truncated = (suggestion.text || '').length > RAG_PASSAGE_EXCERPT_LEN;
+                return (
+                  <li
+                    key={`${suggestion.species || 'unknown'}-${suggestion.key || idx}`}
+                    data-testid="rag-suggestion-item"
+                    className="rounded-lg bg-slate-950/60 border border-slate-800 p-3 text-base"
+                  >
+                    {suggestion.species && (
+                      <p className="text-purple-300 text-sm font-semibold italic mb-1">
+                        {suggestion.species}
+                      </p>
+                    )}
+                    <p className="text-slate-200 leading-relaxed">
+                      {excerpt}{truncated ? '…' : ''}
+                    </p>
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="px-4 pb-3 text-xs text-slate-500">
+              Sugerencia informativa. Puedes ignorarla y guardar la observación.
+            </p>
+          </details>
+        )}
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Zona (Land)</span>

--- a/src/components/__tests__/ObservationScreen.test.jsx
+++ b/src/components/__tests__/ObservationScreen.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Audit 070.5 + 070.6 — tests del selector plant opcional y el bridge
 // case_study en severidad high/critical.
@@ -45,6 +45,13 @@ if (typeof globalThis.crypto?.randomUUID !== 'function') {
     randomUUID: () => 'uuid-test-stub',
   };
 }
+
+// L1.5 — mock ragRetriever.retrieve para no tocar el corpus real durante los
+// tests unitarios. Default empty; se sobrescribe per-test cuando hace falta.
+const ragRetrieveMock = vi.fn().mockResolvedValue([]);
+vi.mock('../../services/ragRetriever', () => ({
+  retrieve: (...args) => ragRetrieveMock(...args),
+}));
 
 import ObservationScreen from '../ObservationScreen';
 import { getParentLandIdFromAsset } from '../../utils/assetRelationships';
@@ -251,5 +258,166 @@ describe('ObservationScreen — audit 070.6 bridge case_study', () => {
     const rels = callArg.payload.data.relationships;
     expect(rels.location.data[0]).toEqual({ type: 'asset--land', id: 'land-2' });
     expect(rels.asset).toBeUndefined();
+  });
+});
+
+// L1.5 — sugerencias RAG de tratamientos. Verifica:
+//   1. Debounce ≥3s antes de invocar retrieve().
+//   2. Severity info/low NO disparan retrieve.
+//   3. Render condicional: solo si hay resultados con score>0.
+//   4. Falla graceful: retrieve throws → sección no se renderiza.
+describe('ObservationScreen — L1.5 sugerencias RAG de tratamientos', () => {
+  beforeEach(() => {
+    saveTransactionMock.mockClear();
+    ragRetrieveMock.mockClear();
+    ragRetrieveMock.mockResolvedValue([]);
+    resetCaseStore();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    // Limpiar fake timers para no contaminar otros describes que asumen
+    // timers reales (caso bridge usa setTimeout legítimo).
+    vi.useRealTimers();
+  });
+
+  // Usamos act+advanceTimersByTimeAsync para el debounce de 3s.
+
+  const seedDescriptionAndSeverity = (description, severity) => {
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: description },
+    });
+    const severitySelect = screen.getAllByRole('combobox').find((s) => s.name === 'severity');
+    fireEvent.change(severitySelect, { target: { value: severity } });
+  };
+
+  it('NO llama retrieve antes de los 3s de debounce', async () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Hojas con manchas oscuras tipo antracnosis', 'medium');
+
+    // Antes del debounce: NO se invocó retrieve aún.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(ragRetrieveMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('rag-treatment-suggestions')).toBeNull();
+  });
+
+  it('llama retrieve después de 3s con severity=medium y descripción válida', async () => {
+    ragRetrieveMock.mockResolvedValue([
+      { species: 'phaseolus_vulgaris', key: 'pest', text: 'Antracnosis foliar — aplicar caldo bordelés cada 7 días en follaje seco.', score: 4.2 },
+      { species: 'lycopersicon_esculentum', key: 'biocontrol', text: 'Bacillus subtilis foliar previene establecimiento de Colletotrichum y otros hongos.', score: 3.1 },
+    ]);
+
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Hojas con manchas oscuras tipo antracnosis', 'medium');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3100);
+    });
+
+    await waitFor(() => expect(ragRetrieveMock).toHaveBeenCalledTimes(1));
+    expect(ragRetrieveMock.mock.calls[0][0]).toMatch(/antracnosis/i);
+    expect(ragRetrieveMock.mock.calls[0][1]).toBe(5);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rag-treatment-suggestions')).toBeTruthy()
+    );
+    const items = screen.getAllByTestId('rag-suggestion-item');
+    expect(items.length).toBe(2);
+    expect(screen.getByText(/caldo bordelés/i)).toBeTruthy();
+  });
+
+  it('severity=info NO dispara retrieve aunque pasen 3s', async () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Observación rutinaria sin anomalías', 'info');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(ragRetrieveMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('rag-treatment-suggestions')).toBeNull();
+  });
+
+  it('descripción demasiado corta NO dispara retrieve aunque severity sea high', async () => {
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('ok', 'high');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(ragRetrieveMock).not.toHaveBeenCalled();
+  });
+
+  it('retrieve devuelve [] → sección NO se renderiza (graceful empty)', async () => {
+    ragRetrieveMock.mockResolvedValue([]);
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Marchitez súbita en plántulas jóvenes', 'high');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3100);
+    });
+
+    await waitFor(() => expect(ragRetrieveMock).toHaveBeenCalled());
+    expect(screen.queryByTestId('rag-treatment-suggestions')).toBeNull();
+  });
+
+  it('retrieve lanza error → sección NO se renderiza (graceful failure)', async () => {
+    ragRetrieveMock.mockRejectedValue(new Error('corpus offline'));
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Defoliación severa en cultivo de tomate', 'critical');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3100);
+    });
+
+    await waitFor(() => expect(ragRetrieveMock).toHaveBeenCalled());
+    expect(screen.queryByTestId('rag-treatment-suggestions')).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('cambios rápidos en descripción cancelan retrieve previo (debounce reset)', async () => {
+    ragRetrieveMock.mockResolvedValue([
+      { species: 'capsicum_annuum', key: 'pest', text: 'Pulgones en brotes tiernos — control con extracto de neem y jabón potásico.', score: 5.1 },
+    ]);
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Manchas en hojas', 'medium');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    // Reescribimos antes de cumplirse el debounce; debe reiniciar el timer.
+    fireEvent.change(screen.getByPlaceholderText(/Describe la observacion/i), {
+      target: { value: 'Pulgones cubriendo brotes nuevos' },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    // Aún no debió pasar el debounce completo desde el cambio.
+    expect(ragRetrieveMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    await waitFor(() => expect(ragRetrieveMock).toHaveBeenCalledTimes(1));
+    expect(ragRetrieveMock.mock.calls[0][0]).toMatch(/pulgones/i);
+  });
+
+  it('passage muy largo se trunca con elipsis en el render', async () => {
+    const longText = 'Lorem ipsum dolor sit amet '.repeat(40); // > 220 chars
+    ragRetrieveMock.mockResolvedValue([
+      { species: 'zea_mays', key: 'long_passage', text: longText, score: 2.5 },
+    ]);
+    render(<ObservationScreen onBack={vi.fn()} onSave={vi.fn()} />);
+    seedDescriptionAndSeverity('Plagas múltiples en maíz', 'high');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3100);
+    });
+    await waitFor(() => expect(screen.getByTestId('rag-treatment-suggestions')).toBeTruthy());
+    const items = screen.getAllByTestId('rag-suggestion-item');
+    expect(items[0].textContent).toMatch(/…$/);
   });
 });


### PR DESCRIPTION
## Summary

L1.5 — Cuando el operador registra una observación con severidad **medium/high/critical** en `ObservationScreen`, la PWA le sugiere tratamientos relevantes desde el corpus RAG (`ragRetriever.retrieve`) **sin bloquear el flujo de guardado**.

- Trigger: `severity ∈ {medium, high, critical}` + `description ≥ 5 chars`.
- Debounce: **3s** de inactividad antes de invocar `retrieve`. Cancela request previo si el operador sigue escribiendo.
- Race-guard: `requestId` monotónico descarta resultados stale.
- Query enriquecida con `species_slug` de la planta seleccionada (si la hay).
- Render: `<details>` colapsado con top-3 passages (species + extracto truncado a 220 chars).
- Graceful: `retrieve` falla / corpus vacío → la sección **no se renderiza**, sin error UI. **Nunca** bloquea `handleSave`.

## Archivos tocados

- `src/components/ObservationScreen.jsx` — hook debounced `useEffect` + sección `<details>` colapsada.
- `src/components/__tests__/ObservationScreen.test.jsx` — 8 tests nuevos del comportamiento RAG.

## Separación de responsabilidades

- **NO** toca `treatmentRecommender.js` ni `lessonsSummarizer.js` (esos viven en `feat/L1.3-L1.4-casestudy-rag`).
- Usa `retrieve()` directo de `ragRetriever.js` como acordado.

## Test plan

- [x] `npx vitest run src/components/__tests__/ObservationScreen.test.jsx` → **19/19 passing** (11 existentes + 8 nuevos)
- [x] `npm run build` verde, sin warnings nuevos
- [ ] CodeQL / Analyze (merge-gate §5.1)
- [ ] Playwright E2E / Offline-first (merge-gate §5.2)
- [ ] Smoke manual en demo Diana (14:00 Bogotá): describir observación con severity=high, esperar 3s, verificar que aparece sección colapsada
- [ ] Smoke offline: con corpus vacío / sin manifest, verificar que la sección NO aparece y el guardado sigue funcionando

## Notas

- Bump `0.12.138 → 0.12.139` + `chagra-v180 → chagra-v181` incluido en el commit funcional (lefthook no estaba en PATH del entorno del agente; el bump replica `auto-bump-version.mjs`).
- AGPL-3.0 respect: sin nuevas dependencias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)