### PR TITLE
feat(case-study): enriquecer treatment + lessons con RAG (L1.3+L1.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.138",
+  "version": "0.12.139",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v180';
+const CACHE_NAME = 'chagra-v181';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/caseStudyLessonsSummarizer.test.js
+++ b/src/services/__tests__/caseStudyLessonsSummarizer.test.js
@@ -1,7 +1,29 @@
-import { describe, it, expect } from 'vitest';
-import { __TEST__ } from '../caseStudyLessonsSummarizer';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { buildCaseSummaryInput, SYSTEM_PROMPT, PROMPT_VERSION } = __TEST__;
+// Mocks de dependencias antes del import del módulo bajo test.
+vi.mock('../ollamaStream', () => ({
+  streamOllama: vi.fn(),
+}));
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn(),
+}));
+
+import { streamOllama } from '../ollamaStream';
+import { retrieve } from '../ragRetriever';
+import { summarizeLessons, buildRagQuery, __TEST__ } from '../caseStudyLessonsSummarizer';
+
+const {
+  buildCaseSummaryInput,
+  buildRagBlock,
+  SYSTEM_PROMPT,
+  PROMPT_VERSION,
+  RAG_CONTEXT_HEADER,
+} = __TEST__;
+
+beforeEach(() => {
+  streamOllama.mockReset();
+  retrieve.mockReset();
+});
 
 describe('caseStudyLessonsSummarizer — buildCaseSummaryInput', () => {
   it('estructura un caso completo con tratamientos + outcome', () => {
@@ -63,5 +85,144 @@ describe('caseStudyLessonsSummarizer — buildCaseSummaryInput', () => {
 
   it('PROMPT_VERSION está versionado', () => {
     expect(PROMPT_VERSION).toMatch(/^v\d/);
+  });
+});
+
+describe('caseStudyLessonsSummarizer — buildRagQuery', () => {
+  it('combina problema + treatments + species_id en una query', () => {
+    const q = buildRagQuery({
+      problem: { name_freetext: 'Trozador', pest_scientific_candidate: 'Agrotis ipsilon' },
+      subject: { species_id: 'solanum_lycopersicum_cherry' },
+      treatments_applied: [
+        { biopreparado_id: 'bacillus_thuringiensis' },
+        { biopreparado_id: 'extracto_neem' },
+      ],
+    });
+    expect(q).toContain('Trozador');
+    expect(q).toContain('Agrotis ipsilon');
+    expect(q).toContain('solanum lycopersicum cherry');
+    expect(q).toContain('bacillus thuringiensis');
+    expect(q).toContain('extracto neem');
+  });
+
+  it('caso null → string vacío', () => {
+    expect(buildRagQuery(null)).toBe('');
+    expect(buildRagQuery(undefined)).toBe('');
+  });
+
+  it('omite partes faltantes sin romper', () => {
+    const q = buildRagQuery({ problem: { name_freetext: 'oídio' } });
+    expect(q).toBe('oídio');
+  });
+});
+
+describe('caseStudyLessonsSummarizer — buildRagBlock', () => {
+  it('passages vacíos → string vacío', () => {
+    expect(buildRagBlock([])).toBe('');
+    expect(buildRagBlock(null)).toBe('');
+  });
+
+  it('inserta header y datos del passage', () => {
+    const out = buildRagBlock([
+      { species: 'fragaria_ananassa', text: 'BT específico Lepidoptera.', score: 1.2 },
+    ]);
+    expect(out).toContain(RAG_CONTEXT_HEADER);
+    expect(out).toContain('NO viene del usuario');
+    expect(out).toContain('fragaria_ananassa');
+    expect(out).toContain('BT específico Lepidoptera.');
+  });
+});
+
+describe('caseStudyLessonsSummarizer — summarizeLessons integración RAG', () => {
+  const caseObj = {
+    problem: { name_freetext: 'Trozador (Agrotis ipsilon)', severity: 'high', pest_scientific_candidate: 'Agrotis ipsilon' },
+    subject: { count_total: 100, count_affected: 5, species_id: 'solanum_lycopersicum_cherry' },
+    state_history: [
+      { at: '2026-05-17T08:00:00Z', state: 'open' },
+      { at: '2026-05-17T10:00:00Z', state: 'in_treatment', notes: 'BT aplicado' },
+    ],
+    treatments_applied: [
+      { applied_at: '2026-05-17T10:00:00Z', biopreparado_id: 'bacillus_thuringiensis', dose: '1g/L' },
+    ],
+    outcome: { closed_at: '2026-05-30T00:00:00Z', final_count_affected: 0 },
+  };
+
+  it('hace retrieve con query construida desde el caso y prepende bloque RAG', async () => {
+    retrieve.mockResolvedValue([
+      { species: 'solanum_lycopersicum_cherry', text: 'Bacillus thuringiensis es bioinsecticida específico para Lepidoptera.', score: 1.4, key: 'biopreparados[0].nombre' },
+    ]);
+    streamOllama.mockResolvedValue('Funcionó BT 1g/L al primer signo. Próxima vez aplicar preventivo cada 7 días en cohorte joven.');
+
+    const result = await summarizeLessons(caseObj);
+
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    const [calledQuery] = retrieve.mock.calls[0];
+    expect(calledQuery).toContain('Trozador');
+    expect(calledQuery).toContain('bacillus thuringiensis');
+
+    // streamOllama recibió user content con el bloque RAG prependeado
+    const body = streamOllama.mock.calls[0][1];
+    const userMsg = body.messages.find((m) => m.role === 'user').content;
+    expect(userMsg).toContain(RAG_CONTEXT_HEADER);
+    expect(userMsg).toContain('Bacillus thuringiensis es bioinsecticida');
+    expect(userMsg).toContain('--- HISTORIAL DEL CASO ---');
+    expect(userMsg).toContain('Trozador');
+
+    expect(result).not.toBeNull();
+    expect(result.text).toMatch(/BT|Bacillus|preventivo/i);
+    expect(result._audit.rag_used).toBe(true);
+    expect(result._audit.rag_passages).toHaveLength(1);
+    expect(result._audit.rag_passages[0].species).toBe('solanum_lycopersicum_cherry');
+    expect(result._audit.prompt_version).toBe(PROMPT_VERSION);
+  });
+
+  it('si retrieve falla → degrade gracefully, sigue llamando streamOllama sin bloque RAG', async () => {
+    retrieve.mockRejectedValue(new Error('corpus down'));
+    streamOllama.mockResolvedValue('Resumen sin contexto RAG pero suficientemente largo para no ser descartado.');
+
+    const result = await summarizeLessons(caseObj);
+
+    const body = streamOllama.mock.calls[0][1];
+    const userMsg = body.messages.find((m) => m.role === 'user').content;
+    expect(userMsg).not.toContain(RAG_CONTEXT_HEADER);
+    expect(userMsg).toContain('Trozador');
+
+    expect(result).not.toBeNull();
+    expect(result._audit.rag_used).toBe(false);
+    expect(result._audit.rag_passages).toEqual([]);
+  });
+
+  it('si retrieve devuelve [] → no agrega bloque RAG pero llama Ollama', async () => {
+    retrieve.mockResolvedValue([]);
+    streamOllama.mockResolvedValue('Resumen plano sin contexto agronómico de referencia adicional.');
+
+    const result = await summarizeLessons(caseObj);
+
+    const body = streamOllama.mock.calls[0][1];
+    const userMsg = body.messages.find((m) => m.role === 'user').content;
+    expect(userMsg).not.toContain(RAG_CONTEXT_HEADER);
+
+    expect(result._audit.rag_used).toBe(false);
+  });
+
+  it('caseObj null → devuelve null y no llama nada', async () => {
+    const result = await summarizeLessons(null);
+    expect(result).toBeNull();
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(streamOllama).not.toHaveBeenCalled();
+  });
+
+  it('streamOllama devuelve texto muy corto → null', async () => {
+    retrieve.mockResolvedValue([]);
+    streamOllama.mockResolvedValue('corto');
+    const result = await summarizeLessons(caseObj);
+    expect(result).toBeNull();
+  });
+
+  it('streamOllama throw → null y graceful', async () => {
+    retrieve.mockResolvedValue([]);
+    streamOllama.mockRejectedValue(new Error('ollama down'));
+    const result = await summarizeLessons(caseObj);
+    expect(result).toBeNull();
   });
 });

--- a/src/services/__tests__/caseStudyTreatmentRecommender.test.js
+++ b/src/services/__tests__/caseStudyTreatmentRecommender.test.js
@@ -1,5 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { recommendTreatments, listAllBiopreparados, __TEST__ } from '../caseStudyTreatmentRecommender';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock del RAG retriever — los tests sincrónicos de recommendTreatments
+// NO lo usan, pero los tests async de recommendTreatmentsWithRag sí.
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn(),
+}));
+
+import { retrieve } from '../ragRetriever';
+import {
+  recommendTreatments,
+  recommendTreatmentsWithRag,
+  buildRagContextBlock,
+  listAllBiopreparados,
+  RAG_CONTEXT_HEADER,
+  __TEST__,
+} from '../caseStudyTreatmentRecommender';
+
+beforeEach(() => {
+  retrieve.mockReset();
+});
 
 describe('caseStudyTreatmentRecommender — recommendTreatments', () => {
   it('trozador (Agrotis) → BT + Trichogramma + neem', () => {
@@ -138,5 +157,120 @@ describe('caseStudyTreatmentRecommender — PEST_RULES integrity', () => {
         expect(validPriorities).toContain(rec.priority);
       }
     }
+  });
+});
+
+describe('caseStudyTreatmentRecommender — buildRagContextBlock', () => {
+  it('passages vacíos → string vacío', () => {
+    expect(buildRagContextBlock([])).toBe('');
+    expect(buildRagContextBlock(null)).toBe('');
+    expect(buildRagContextBlock(undefined)).toBe('');
+  });
+
+  it('inserta header + footer + warning anti-alucinación', () => {
+    const out = buildRagContextBlock([
+      { species: 'solanum_lycopersicum_cherry', text: 'BT 1g/L foliar al atardecer.', score: 1.2 },
+    ]);
+    expect(out).toContain(RAG_CONTEXT_HEADER);
+    expect(out).toContain('NO viene del usuario');
+    expect(out).toContain('solanum_lycopersicum_cherry');
+    expect(out).toContain('BT 1g/L foliar al atardecer.');
+    expect(out).toContain('=== FIN INFORMACIÓN AGRONÓMICA DE REFERENCIA ===');
+  });
+
+  it('numera los passages y mantiene orden', () => {
+    const out = buildRagContextBlock([
+      { species: 'a', text: 'primero' },
+      { species: 'b', text: 'segundo' },
+    ]);
+    expect(out).toMatch(/\[1\] \(a\) primero/);
+    expect(out).toMatch(/\[2\] \(b\) segundo/);
+  });
+
+  it('omite passages sin texto', () => {
+    const out = buildRagContextBlock([
+      { species: 'a', text: '   ' },
+      { species: 'b', text: 'útil' },
+    ]);
+    expect(out).not.toMatch(/\(a\)/);
+    expect(out).toMatch(/\(b\) útil/);
+  });
+});
+
+describe('caseStudyTreatmentRecommender — recommendTreatmentsWithRag', () => {
+  it('combina recomendaciones deterministas + passages RAG', async () => {
+    retrieve.mockResolvedValue([
+      { species: 'solanum_lycopersicum_cherry', text: 'Bacillus thuringiensis es bioinsecticida específico para Lepidoptera.', score: 1.5, key: 'biopreparados[0].nombre' },
+      { species: 'solanum_lycopersicum_cherry', text: 'Aplicar BT al atardecer cuando las larvas salen a alimentarse.', score: 1.1, key: 'biopreparados[0].uso' },
+    ]);
+    const result = await recommendTreatmentsWithRag('Trozador (Agrotis ipsilon)', {
+      speciesNames: ['tomate cherry'],
+    });
+
+    // Determinista intacto
+    expect(result.recommendations.map((x) => x.id)).toContain('bacillus_thuringiensis');
+
+    // RAG context populado
+    expect(result.ragPassages).toHaveLength(2);
+    expect(result.ragContext).toContain(RAG_CONTEXT_HEADER);
+    expect(result.ragContext).toContain('Bacillus thuringiensis');
+
+    // retrieve fue llamado con pest + species en la query
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    const [calledQuery, calledTopK] = retrieve.mock.calls[0];
+    expect(calledQuery.toLowerCase()).toContain('trozador');
+    expect(calledQuery.toLowerCase()).toContain('tomate cherry');
+    expect(calledTopK).toBe(5);
+  });
+
+  it('respeta opts.topK', async () => {
+    retrieve.mockResolvedValue([]);
+    await recommendTreatmentsWithRag('oídio', { topK: 3 });
+    expect(retrieve.mock.calls[0][1]).toBe(3);
+  });
+
+  it('topK inválido → default 5', async () => {
+    retrieve.mockResolvedValue([]);
+    await recommendTreatmentsWithRag('oídio', { topK: 0 });
+    expect(retrieve.mock.calls[0][1]).toBe(5);
+  });
+
+  it('si retrieve falla → degrade gracefully, sin contexto pero con recomendaciones', async () => {
+    retrieve.mockRejectedValue(new Error('corpus down'));
+    const result = await recommendTreatmentsWithRag('mildiu');
+    expect(result.recommendations.map((x) => x.id)).toContain('caldo_bordeles');
+    expect(result.ragPassages).toEqual([]);
+    expect(result.ragContext).toBe('');
+  });
+
+  it('si retrieve devuelve [] → ragContext vacío pero objeto bien formado', async () => {
+    retrieve.mockResolvedValue([]);
+    const result = await recommendTreatmentsWithRag('cogollero');
+    expect(result.recommendations.map((x) => x.id)).toContain('bacillus_thuringiensis');
+    expect(result.ragPassages).toEqual([]);
+    expect(result.ragContext).toBe('');
+  });
+
+  it('si retrieve devuelve no-array (defensa) → ragPassages=[]', async () => {
+    retrieve.mockResolvedValue(null);
+    const result = await recommendTreatmentsWithRag('cogollero');
+    expect(result.ragPassages).toEqual([]);
+    expect(result.ragContext).toBe('');
+  });
+
+  it('pestName vacío + sin speciesNames → no llama retrieve y devuelve recs vacías', async () => {
+    const result = await recommendTreatmentsWithRag('');
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(result.recommendations).toEqual([]);
+    expect(result.ragPassages).toEqual([]);
+    expect(result.ragContext).toBe('');
+  });
+
+  it('pestName vacío pero con speciesNames → sí consulta RAG (uso preventivo)', async () => {
+    retrieve.mockResolvedValue([{ species: 'lechuga', text: 'companions con caléndula', score: 0.8 }]);
+    const result = await recommendTreatmentsWithRag('', { speciesNames: ['lechuga'] });
+    expect(retrieve).toHaveBeenCalledTimes(1);
+    expect(retrieve.mock.calls[0][0]).toContain('lechuga');
+    expect(result.ragPassages).toHaveLength(1);
   });
 });

--- a/src/services/caseStudyLessonsSummarizer.js
+++ b/src/services/caseStudyLessonsSummarizer.js
@@ -12,11 +12,16 @@
  */
 
 import { streamOllama } from './ollamaStream';
+import { retrieve } from './ragRetriever';
 
 const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
 const MODEL = 'qwen2.5:7b';
 const TIMEOUT_MS = 60000;
-const PROMPT_VERSION = 'v1.0-2026-05-17';
+const PROMPT_VERSION = 'v1.1-2026-05-19-rag';
+
+const RAG_TOP_K = 5;
+const RAG_CONTEXT_HEADER = '=== INFORMACIÓN AGRONÓMICA DE REFERENCIA ===';
+const RAG_CONTEXT_FOOTER = '=== FIN INFORMACIÓN AGRONÓMICA DE REFERENCIA ===';
 
 const SYSTEM_PROMPT = `Eres un curador agronómico que resume lecciones de un caso de estudio. Recibes el historial de un caso (estados, tratamientos, outcome) y devuelves un párrafo claro y útil para el operador campesino.
 
@@ -34,7 +39,47 @@ Reglas:
 - Foco en aprendizaje accionable: "Próxima vez aplicar BT 1g/L al primer signo".
 - Si el caso falló (closed_failed), explicita por qué probablemente.
 - Si el caso fue muy corto o sin tratamientos, sé honesto: "Caso cerrado sin intervención registrada, observación inicial fue exagerada."
+- Si recibes un bloque "=== INFORMACIÓN AGRONÓMICA DE REFERENCIA ===", úsalo SOLO como apoyo agronómico (dosis típicas, sinergias, manejo). NO lo cites como si el operador te lo hubiera dicho. NO inventes nada que NO esté ni en el historial ni en ese bloque.
 `;
+
+/**
+ * Construye el bloque RAG con passages del corpus. Devuelve string vacío
+ * si no hay nada útil. Mismo formato que `caseStudyTreatmentRecommender`
+ * para consistencia entre prompts.
+ */
+function buildRagBlock(passages) {
+  if (!Array.isArray(passages) || passages.length === 0) return '';
+  const lines = [RAG_CONTEXT_HEADER];
+  lines.push('(NO viene del usuario, NO citarla como si el operador te lo hubiera contado)');
+  passages.forEach((p, i) => {
+    const slug = p?.species || 'unknown';
+    const text = typeof p?.text === 'string' ? p.text.trim() : '';
+    if (!text) return;
+    lines.push(`[${i + 1}] (${slug}) ${text}`);
+  });
+  lines.push(RAG_CONTEXT_FOOTER);
+  return lines.join('\n');
+}
+
+/**
+ * Construye la query RAG a partir del caso: problema + biopreparados
+ * aplicados + (opcional) species_id. Esto le da al BM25 los términos más
+ * distintivos del corpus para recuperar pasajes relevantes.
+ */
+export function buildRagQuery(caseObj) {
+  if (!caseObj) return '';
+  const parts = [];
+  const prob = caseObj.problem?.name_freetext;
+  if (typeof prob === 'string' && prob.trim()) parts.push(prob.trim());
+  const sci = caseObj.problem?.pest_scientific_candidate;
+  if (typeof sci === 'string' && sci.trim()) parts.push(sci.trim());
+  const sp = caseObj.subject?.species_id || caseObj.species_id;
+  if (typeof sp === 'string' && sp.trim()) parts.push(sp.trim().replace(/_/g, ' '));
+  (caseObj.treatments_applied || []).forEach((t) => {
+    if (t?.biopreparado_id) parts.push(String(t.biopreparado_id).replace(/_/g, ' '));
+  });
+  return parts.join(' ').trim();
+}
 
 /**
  * Construye payload narrativo desde la estructura del caso.
@@ -76,10 +121,38 @@ export function buildCaseSummaryInput(caseObj) {
 
 /**
  * Llama Ollama para generar lessons_learned. Devuelve {text, _audit} o null.
+ *
+ * Pipeline:
+ *   1. Construye narrativa del caso (`buildCaseSummaryInput`).
+ *   2. Hace `retrieve(query, RAG_TOP_K)` con problema + treatments + species.
+ *      Si falla o no hay hits, sigue sin contexto (degrade gracefully).
+ *   3. Prepende el bloque RAG al user message, delimitado para evitar
+ *      alucinación (lección incidente tomates 2026-05-19).
+ *   4. Llama streamOllama con messages [system, user].
+ *
+ * El `_audit` incluye `rag_passages` (slugs + score) para trazabilidad.
  */
 export async function summarizeLessons(caseObj, opts = {}) {
   const input = buildCaseSummaryInput(caseObj);
   if (!input) return null;
+
+  // RAG retrieval — best effort, nunca lanza.
+  let ragPassages = [];
+  const ragQuery = buildRagQuery(caseObj);
+  if (ragQuery) {
+    try {
+      const hits = await retrieve(ragQuery, RAG_TOP_K);
+      if (Array.isArray(hits)) ragPassages = hits;
+    } catch (err) {
+      console.warn('[caseStudyLessonsSummarizer] retrieve failed, sin contexto RAG:', err?.message || err);
+      ragPassages = [];
+    }
+  }
+
+  const ragBlock = buildRagBlock(ragPassages);
+  const userContent = ragBlock
+    ? `${ragBlock}\n\n--- HISTORIAL DEL CASO ---\n${input}`
+    : input;
 
   const body = {
     model: MODEL,
@@ -88,7 +161,7 @@ export async function summarizeLessons(caseObj, opts = {}) {
     options: { temperature: 0.3, num_ctx: 4096 },
     messages: [
       { role: 'system', content: SYSTEM_PROMPT },
-      { role: 'user', content: input },
+      { role: 'user', content: userContent },
     ],
   };
 
@@ -109,6 +182,12 @@ export async function summarizeLessons(caseObj, opts = {}) {
         model: MODEL,
         prompt_version: PROMPT_VERSION,
         generated_at: new Date().toISOString(),
+        rag_passages: ragPassages.map((p) => ({
+          species: p?.species || null,
+          key: p?.key || null,
+          score: typeof p?.score === 'number' ? p.score : null,
+        })),
+        rag_used: ragPassages.length > 0,
       },
     };
   } catch (e) {
@@ -132,6 +211,13 @@ function mergeSignals(a, b) {
   return ctrl.signal;
 }
 
-export const __TEST__ = { buildCaseSummaryInput, SYSTEM_PROMPT, PROMPT_VERSION };
+export const __TEST__ = {
+  buildCaseSummaryInput,
+  buildRagBlock,
+  buildRagQuery,
+  SYSTEM_PROMPT,
+  PROMPT_VERSION,
+  RAG_CONTEXT_HEADER,
+};
 
 export default summarizeLessons;

--- a/src/services/caseStudyTreatmentRecommender.js
+++ b/src/services/caseStudyTreatmentRecommender.js
@@ -6,8 +6,11 @@
  *
  * Pipeline KISS:
  *   1. Keyword matcher (offline-first, deterministic, instantáneo).
- *   2. Si Ollama GPU disponible → opcional refinamiento con LLM
- *      (post-DR-044 sub-iv RAG embeddings con nomic-embed-text).
+ *   2. Opcional: `recommendTreatmentsWithRag(...)` enriquece el resultado
+ *      con passages del corpus `public/cycle-content/*.json` vía BM25
+ *      (`ragRetriever.retrieve`). Esto da al caller (LLM o UI) contexto
+ *      agronómico verificable para reducir alucinación — lección del
+ *      incidente 2026-05-19 con tomates donde el LLM inventaba dosis.
  *
  * MVP usa solo keyword matcher porque cubre 80% de casos en agroecología
  * tradicional y NO depende de network/GPU. Operador puede confiar que
@@ -20,6 +23,20 @@
  * roca_fosforica, ceniza_madera, compost_maduro, biofertilizante_algas,
  * bacillus_thuringiensis, trichogramma_spp, extracto_neem.
  */
+
+import { retrieve } from './ragRetriever';
+
+/**
+ * Delimitador del bloque de contexto RAG en prompts. Idéntico al patrón
+ * usado en otros consumidores (ver AgentScreen.jsx) para que un LLM
+ * downstream lo reconozca consistentemente.
+ *
+ * REGLA: el bloque dice explícitamente "NO viene del usuario, NO citarla
+ * como si el usuario te lo hubiera contado" para evitar alucinaciones por
+ * confusión de fuente — lección incidente 2026-05-19.
+ */
+export const RAG_CONTEXT_HEADER = '=== INFORMACIÓN AGRONÓMICA DE REFERENCIA ===';
+export const RAG_CONTEXT_FOOTER = '=== FIN INFORMACIÓN AGRONÓMICA DE REFERENCIA ===';
 
 /**
  * Mapping pest keyword → biopreparados recomendados.
@@ -148,5 +165,91 @@ export function listAllBiopreparados() {
   ];
 }
 
-export const __TEST__ = { PEST_RULES };
+/**
+ * Construye el bloque de contexto RAG con passages BM25 del corpus
+ * `public/cycle-content/*.json`. Devuelve string vacío si no hay passages.
+ *
+ * El caller (UI o LLM downstream) puede:
+ *   - mostrar los passages al operador como evidencia agronómica, o
+ *   - prependerlos a un prompt LLM para grounding offline-first.
+ *
+ * @param {Array<{key:string, text:string, species:string, score:number}>} passages
+ * @returns {string}
+ */
+export function buildRagContextBlock(passages) {
+  if (!Array.isArray(passages) || passages.length === 0) return '';
+  const lines = [RAG_CONTEXT_HEADER];
+  lines.push('(NO viene del usuario, NO citarla como si el usuario te lo hubiera contado)');
+  passages.forEach((p, i) => {
+    const slug = p?.species || 'unknown';
+    const text = typeof p?.text === 'string' ? p.text.trim() : '';
+    if (!text) return;
+    lines.push(`[${i + 1}] (${slug}) ${text}`);
+  });
+  lines.push(RAG_CONTEXT_FOOTER);
+  return lines.join('\n');
+}
+
+/**
+ * Variante asíncrona enriquecida con RAG. Combina el keyword matcher
+ * determinista con un retrieval BM25 contra el corpus para devolver
+ * passages relevantes como contexto adicional.
+ *
+ * Diseño:
+ *   - Llama primero `recommendTreatments(pestName)` (sincrónico, offline,
+ *     siempre rápido). Si no hay match, igual intenta RAG para tener un
+ *     mínimo de contexto antes de pasar al LLM downstream.
+ *   - Hace `retrieve(query, topK)` donde `query = pestName + " " +
+ *     species_names`. species_names es opcional (puede venir vacío).
+ *   - Si `retrieve` falla o devuelve vacío, degrada al comportamiento
+ *     anterior sin contexto (`ragContext: '', ragPassages: []`). Nunca
+ *     lanza.
+ *
+ * @param {string} pestName - texto libre del problema
+ * @param {Object} [opts]
+ * @param {string[]} [opts.speciesNames] - nombres comunes de especies
+ *   afectadas (ej. ['tomate cherry', 'lechuga']). Se concatenan al query.
+ * @param {number} [opts.topK=5] - número de passages a recuperar.
+ * @returns {Promise<{
+ *   recommendations: Array,
+ *   ragPassages: Array,
+ *   ragContext: string,
+ * }>}
+ */
+export async function recommendTreatmentsWithRag(pestName, opts = {}) {
+  const recommendations = recommendTreatments(pestName, opts);
+
+  const speciesNames = Array.isArray(opts.speciesNames) ? opts.speciesNames : [];
+  const topK = Number.isInteger(opts.topK) && opts.topK > 0 ? opts.topK : 5;
+
+  // Query: problema + nombres de especies. Si pestName es vacío, igual
+  // intentamos con species_names — útil para sugerencias preventivas.
+  const queryParts = [];
+  if (typeof pestName === 'string' && pestName.trim().length > 0) {
+    queryParts.push(pestName.trim());
+  }
+  speciesNames.forEach((n) => {
+    if (typeof n === 'string' && n.trim().length > 0) queryParts.push(n.trim());
+  });
+  const query = queryParts.join(' ').trim();
+
+  if (!query) {
+    return { recommendations, ragPassages: [], ragContext: '' };
+  }
+
+  let passages = [];
+  try {
+    const hits = await retrieve(query, topK);
+    if (Array.isArray(hits)) passages = hits;
+  } catch (err) {
+    // Graceful degradation: corpus vacío, fetch falla, etc.
+    console.warn('[caseStudyTreatmentRecommender] retrieve failed, sin contexto RAG:', err?.message || err);
+    passages = [];
+  }
+
+  const ragContext = buildRagContextBlock(passages);
+  return { recommendations, ragPassages: passages, ragContext };
+}
+
+export const __TEST__ = { PEST_RULES, buildRagContextBlock, RAG_CONTEXT_HEADER };
 export default recommendTreatments;


### PR DESCRIPTION
## Resumen

Integra el corpus RAG existente (`ragRetriever.retrieve` sobre `public/cycle-content/*.json`) en los dos servicios del caso de estudio para reducir alucinación del LLM downstream — lección incidente 2026-05-19 con tomates donde el modelo inventaba dosis.

## Cambios

### L1.3 — `caseStudyTreatmentRecommender.js`
- Nueva función async `recommendTreatmentsWithRag(pestName, opts)` que combina el keyword matcher determinista (intacto, sincrónico) con un retrieve BM25 contra el corpus.
- Devuelve `{ recommendations, ragPassages, ragContext }`.
- Query: `pestName + opts.speciesNames` concatenados. `topK` configurable (default 5).
- Bloque RAG delimitado con `=== INFORMACIÓN AGRONÓMICA DE REFERENCIA ===` + warning "NO viene del usuario" para evitar que el LLM downstream lo cite como input del operador.
- API previa (`recommendTreatments` sincrónico) sin cambios → consumidores en JSX (CaseStudyDetail) siguen funcionando idénticos.

### L1.4 — `caseStudyLessonsSummarizer.js`
- `summarizeLessons` ahora hace `retrieve(query, 5)` con `problema + pest_scientific + species_id + biopreparados aplicados` antes de llamar a `streamOllama`.
- Prepende bloque RAG al user message con el mismo delimitador y warning anti-alucinación.
- `SYSTEM_PROMPT` actualizado: el LLM trata el bloque como apoyo agronómico, NO como input del operador.
- `_audit` ahora incluye `rag_passages` (slug/key/score) + `rag_used` para trazabilidad ADR-020.
- `PROMPT_VERSION` bump `v1.0` → `v1.1-2026-05-19-rag`.

### Graceful degradation
Si `retrieve` falla / corpus vacío / query vacía → ambos servicios siguen con el comportamiento previo SIN contexto, nunca lanzan al caller. Logueado con `console.warn`.

## Test plan

- [x] `npx vitest run src/services/__tests__/caseStudy*` → 59/59 passing
- [x] `npm run build` verde
- [x] `git diff --staged | grep -iE "(token|bearer|password|secret|10\.88|alpha)"` sin hits
- [x] Auto-bump del hook: `0.12.138 → 0.12.139` + `chagra-v180 → chagra-v181`
- [ ] CodeQL verde (CI lo decide)
- [ ] Playwright offline-first verde (CI lo decide)
- [ ] Smoke check post-merge en demo Diana 14:00 Bogotá

## Archivos tocados

- `src/services/caseStudyTreatmentRecommender.js` (+109 / -2)
- `src/services/caseStudyLessonsSummarizer.js` (+92 / -11)
- `src/services/__tests__/caseStudyTreatmentRecommender.test.js` (+138 / -1)
- `src/services/__tests__/caseStudyLessonsSummarizer.test.js` (+167 / -1)
- `package.json`, `public/sw.js` (auto-bump del hook)

## Notas

- NO toca agentes RAG paused (L1.5-L1.10).
- NO breaking change para `CaseStudyDetail.jsx` (sigue importando `recommendTreatments` sincrónico).
- El `recommendTreatmentsWithRag` queda disponible para cuando el UI quiera mostrar passages como evidencia agronómica al operador (no scoped en este PR).