### PR TITLE
feat(backup): export IDB completo + detector vaciado post-clear-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.140",
+  "version": "0.12.141",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v182';
+const CACHE_NAME = 'chagra-v183';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import ChagraGrowLoader from './components/ChagraGrowLoader';
 import IosInstallBanner from './components/IosInstallBanner';
 import UpdateAvailableBanner from './components/UpdateAvailableBanner';
 import GpsFincaBanner from './components/GpsFincaBanner';
+import DataLossBanner from './components/DataLossBanner';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
 // Lazy-loaded route components
@@ -439,6 +440,13 @@ export default function App() {
       <IosInstallBanner />
       <UpdateAvailableBanner />
       <GpsFincaBanner />
+      {/* Detector de vaciado IDB (post clear-cache).
+          2026-05-19: el operador perdió plantas con foto + 100 species por
+          un "Clear cache" en Chrome Android. El banner se muestra solo si
+          detectamos huella `chagra:had-data-once` en localStorage + IDB
+          vacío. NO se muestra en loading/login para no asustar antes de
+          que la app pueda confirmar estado. */}
+      {currentView !== 'loading' && currentView !== 'login' && <DataLossBanner />}
       <Suspense fallback={<LoadingFallback />}>
         {renderView()}
       </Suspense>

--- a/src/components/BackupExportButton.jsx
+++ b/src/components/BackupExportButton.jsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import { Save, Download, Check } from 'lucide-react';
+import { downloadBackupJSON, getBackupSummary } from '../services/dataBackup';
+
+/**
+ * BackupExportButton — botón "Exportar copia" reutilizable.
+ *
+ * Diseño:
+ *   - Lee resumen al montar para mostrar "Vas a exportar X plantas, Y fotos"
+ *     ANTES del click. Operator pide saber qué se va a llevar.
+ *   - Al clickear, genera el JSON y dispara descarga. Flash de
+ *     confirmación 2s. Errores se muestran inline (no toast porque a veces
+ *     se monta en flujos sin sistema de toast cercano).
+ *
+ * Variante: prop `compact` para el botón en headers / widgets donde solo
+ * cabe el icono + label corto.
+ */
+export default function BackupExportButton({ compact = false, className = '' }) {
+  const [summary, setSummary] = useState(null);
+  const [downloading, setDownloading] = useState(false);
+  const [doneFlash, setDoneFlash] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    getBackupSummary()
+      .then((s) => {
+        if (mounted) setSummary(s);
+      })
+      .catch((err) => {
+        if (mounted) {
+          console.warn('[BackupExportButton] No se pudo leer resumen:', err);
+          setSummary(null);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleClick = async () => {
+    setDownloading(true);
+    setError(null);
+    try {
+      await downloadBackupJSON();
+      setDoneFlash(true);
+      setTimeout(() => setDoneFlash(false), 2500);
+    } catch (err) {
+      console.error('[BackupExportButton] Falló la exportación:', err);
+      setError(err?.message || 'No se pudo exportar.');
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={downloading}
+        className={`px-3 py-2 rounded-lg bg-emerald-700 hover:bg-emerald-600 disabled:opacity-60 text-white font-bold text-sm flex items-center gap-2 transition-colors min-h-[40px] ${className}`}
+        aria-label="Exportar copia de seguridad"
+      >
+        {doneFlash ? <Check size={16} aria-hidden="true" /> : <Save size={16} aria-hidden="true" />}
+        <span>{doneFlash ? 'Listo' : 'Exportar copia'}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className={`bg-slate-900/40 border border-slate-800 rounded-2xl p-5 flex flex-col gap-3 ${className}`}>
+      <div className="flex items-center gap-2 px-1">
+        <Download size={18} className="text-emerald-400" />
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">
+          Copia de seguridad
+        </h3>
+      </div>
+
+      <p className="text-xs text-slate-400 leading-relaxed">
+        Descarga un archivo JSON con TODO lo que vive en este dispositivo:
+        plantas, bitácora, fotos, biopreparados, tareas pendientes y configuración local.
+        Guárdalo en un lugar seguro — te salva si borras el cache del navegador,
+        cambias de teléfono o reinstalas la app.
+      </p>
+
+      {summary && (
+        <div className="bg-slate-800/60 border border-slate-700 rounded-xl p-3">
+          <p className="text-[11px] text-slate-400 uppercase tracking-wide font-bold mb-2">
+            Vas a exportar:
+          </p>
+          <ul className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-slate-200">
+            <li className="flex justify-between"><span>Plantas</span><span className="tabular-nums text-emerald-300">{summary.plants}</span></li>
+            <li className="flex justify-between"><span>Zonas</span><span className="tabular-nums text-emerald-300">{summary.lands}</span></li>
+            <li className="flex justify-between"><span>Infraestructura</span><span className="tabular-nums text-emerald-300">{summary.structures}</span></li>
+            <li className="flex justify-between"><span>Insumos</span><span className="tabular-nums text-emerald-300">{summary.materials}</span></li>
+            <li className="flex justify-between"><span>Bitácora</span><span className="tabular-nums text-emerald-300">{summary.logs}</span></li>
+            <li className="flex justify-between"><span>Fotos</span><span className="tabular-nums text-emerald-300">{summary.photos}</span></li>
+            <li className="flex justify-between"><span>Pendiente sync</span><span className="tabular-nums text-amber-300">{summary.pendingTx}</span></li>
+            <li className="flex justify-between"><span>Voz pendiente</span><span className="tabular-nums text-amber-300">{summary.pendingVoice}</span></li>
+          </ul>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={downloading}
+        className={`w-full p-3 rounded-xl font-bold flex items-center justify-center gap-2 transition-colors min-h-[48px] ${
+          doneFlash
+            ? 'bg-emerald-600 text-white'
+            : 'bg-emerald-700 hover:bg-emerald-600 disabled:opacity-60 text-white'
+        }`}
+      >
+        {downloading ? (
+          <>Exportando…</>
+        ) : doneFlash ? (
+          <><Check size={18} aria-hidden="true" /> Descarga iniciada</>
+        ) : (
+          <><Save size={18} aria-hidden="true" /> Exportar copia ahora</>
+        )}
+      </button>
+
+      {error && (
+        <p className="text-xs text-red-300 bg-red-950 border border-red-800 rounded-lg p-2" role="alert">
+          {error}
+        </p>
+      )}
+
+      <p className="text-[10px] text-slate-500 leading-relaxed">
+        El archivo NO incluye tu token de FarmOS por seguridad. Si lo importas
+        en otro dispositivo, vas a tener que volver a iniciar sesión.
+      </p>
+    </div>
+  );
+}

--- a/src/components/DataLossBanner.jsx
+++ b/src/components/DataLossBanner.jsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, Upload, X } from 'lucide-react';
+import { shouldWarnDataLoss } from '../services/emptyDbDetector';
+
+/**
+ * DataLossBanner — banner rojo prominente que aparece cuando detectamos que
+ * el dispositivo tenía datos antes (flag `chagra:had-data-once` en
+ * localStorage) y ahora IDB está vacío. El caso disparador real es el
+ * operador haciendo "Clear cache" en Chrome Android, que borra IndexedDB
+ * pero NO localStorage — la huella sobrevive y permite alertar.
+ *
+ * UX:
+ *   - Color rojo agresivo (bg-red-900 + border-red-500), NO un toast suave.
+ *     El operador perdió datos reales; el banner DEBE ser imposible de
+ *     ignorar.
+ *   - Botón "Importar copia anterior" → modal con `<input type="file">`
+ *     que SOLO lee y muestra preview del JSON. El import real vendrá en
+ *     un PR posterior; este PR solo previene futuras pérdidas y permite
+ *     verificar que la copia descargada es legible.
+ *   - Botón "Cerrar" (×) → oculta el banner solo para esta sesión (no
+ *     borra el flag). Si el operador refresca, vuelve. Sin esta vía
+ *     mínima de descarte la banner bloquearía la app si fue falso
+ *     positivo.
+ */
+export default function DataLossBanner({ onDismiss }) {
+  const [status, setStatus] = useState({ shouldWarn: false, lastKnownCount: 0, lastMarkedAt: null });
+  const [hidden, setHidden] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    shouldWarnDataLoss()
+      .then((s) => {
+        if (mounted) setStatus(s);
+      })
+      .catch((err) => {
+        console.warn('[DataLossBanner] No se pudo chequear data-loss status:', err);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!status.shouldWarn || hidden) return null;
+
+  const lastDate = status.lastMarkedAt ? new Date(status.lastMarkedAt) : null;
+  const lastDateLabel = lastDate && !Number.isNaN(lastDate.getTime())
+    ? lastDate.toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' })
+    : null;
+
+  return (
+    <>
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="bg-red-900 border-y-4 border-red-500 text-white px-4 py-3 shadow-lg"
+        style={{ paddingTop: 'max(0.75rem, env(safe-area-inset-top))' }}
+      >
+        <div className="flex items-start gap-3 max-w-screen-md mx-auto">
+          <AlertTriangle size={28} className="text-yellow-300 shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <p className="text-base font-black uppercase tracking-wide leading-tight">
+              ¿Hiciste clear cache?
+            </p>
+            <p className="text-sm mt-1 leading-snug">
+              No encontramos tu información local.{' '}
+              {status.lastKnownCount > 0 ? (
+                <>
+                  Antes tenías al menos <strong>{status.lastKnownCount}</strong> activos registrados
+                  {lastDateLabel ? <> (visto por última vez el <strong>{lastDateLabel}</strong>)</> : null}.
+                </>
+              ) : (
+                <>Antes este dispositivo tenía datos registrados y ahora aparece vacío.</>
+              )}
+            </p>
+            <p className="text-xs mt-2 leading-snug text-red-100/90">
+              Esto puede pasar si borraste el cache del navegador o reinstalaste la app.
+              Lo que estaba sin sincronizar con FarmOS (fotos, plantas nuevas) se perdió.
+            </p>
+            <div className="flex flex-wrap gap-2 mt-3">
+              <button
+                type="button"
+                onClick={() => setShowImportModal(true)}
+                className="px-3 py-2 rounded-lg bg-white text-red-900 font-bold text-sm flex items-center gap-2 hover:bg-red-50 transition-colors min-h-[40px]"
+              >
+                <Upload size={16} aria-hidden="true" />
+                Importar copia anterior
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setHidden(true);
+                  onDismiss?.();
+                }}
+                className="px-3 py-2 rounded-lg bg-red-800 text-red-100 font-bold text-sm flex items-center gap-2 hover:bg-red-700 transition-colors min-h-[40px]"
+                aria-label="Cerrar advertencia"
+              >
+                <X size={16} aria-hidden="true" />
+                Entendido
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {showImportModal && (
+        <ImportPreviewModal onClose={() => setShowImportModal(false)} />
+      )}
+    </>
+  );
+}
+
+/**
+ * ImportPreviewModal — modal que permite seleccionar un archivo JSON de
+ * backup y muestra solamente el conteo de items (preview). NO importa.
+ * El import real (con su flujo de merge / overwrite / sanity checks) es
+ * un PR independiente.
+ */
+function ImportPreviewModal({ onClose }) {
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleFile = async (e) => {
+    const f = e.target.files?.[0];
+    setFile(f || null);
+    setPreview(null);
+    setError(null);
+    if (!f) return;
+    try {
+      const text = await f.text();
+      const parsed = JSON.parse(text);
+      if (!parsed.version || !parsed.idb) {
+        throw new Error('El archivo no parece un backup de Chagra (faltan claves version/idb).');
+      }
+      const counts = Object.entries(parsed.idb).map(([store, records]) => ({
+        store,
+        count: Array.isArray(records) ? records.length : 0,
+      }));
+      const totalItems = counts.reduce((acc, c) => acc + c.count, 0);
+      setPreview({
+        version: parsed.version,
+        exportedAt: parsed.exportedAt,
+        dbName: parsed.dbName,
+        counts,
+        totalItems,
+        localStorageKeys: Object.keys(parsed.localStorage || {}).length,
+      });
+    } catch (err) {
+      setError(err.message || 'No se pudo leer el archivo.');
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-black/80 flex items-end sm:items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="import-preview-title"
+    >
+      <div className="w-full max-w-md bg-slate-900 border border-slate-700 rounded-2xl p-5 shadow-2xl flex flex-col gap-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h3 id="import-preview-title" className="text-lg font-black text-white">
+              Importar copia anterior
+            </h3>
+            <p className="text-xs text-slate-400 mt-0.5 leading-snug">
+              Por ahora solo previsualizamos. La importación efectiva se habilita en una próxima versión.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-slate-400 hover:text-white p-1"
+            aria-label="Cerrar"
+          >
+            <X size={20} aria-hidden="true" />
+          </button>
+        </div>
+
+        <label className="flex flex-col gap-2">
+          <span className="text-xs font-bold text-slate-300 uppercase tracking-wide">
+            Archivo de backup
+          </span>
+          <input
+            type="file"
+            accept="application/json,.json"
+            onChange={handleFile}
+            className="text-sm text-slate-200 file:mr-3 file:py-2 file:px-3 file:rounded-lg file:border-0 file:bg-emerald-700 file:text-white file:font-bold hover:file:bg-emerald-600 cursor-pointer"
+          />
+          {file && (
+            <p className="text-[11px] text-slate-500 truncate">
+              {file.name} ({Math.round((file.size / 1024) * 10) / 10} KB)
+            </p>
+          )}
+        </label>
+
+        {error && (
+          <div className="bg-red-950 border border-red-700 rounded-lg p-3 text-sm text-red-200" role="alert">
+            {error}
+          </div>
+        )}
+
+        {preview && (
+          <div className="bg-slate-800/60 border border-slate-700 rounded-xl p-4 flex flex-col gap-2">
+            <p className="text-xs text-slate-400">
+              Backup v{preview.version} — exportado el{' '}
+              <strong className="text-slate-200">
+                {preview.exportedAt ? new Date(preview.exportedAt).toLocaleString('es-CO') : 'fecha desconocida'}
+              </strong>
+            </p>
+            <p className="text-sm text-slate-200">
+              Contiene <strong>{preview.totalItems}</strong> registros en{' '}
+              <strong>{preview.counts.length}</strong> stores, más{' '}
+              <strong>{preview.localStorageKeys}</strong> claves de configuración.
+            </p>
+            <ul className="text-[11px] text-slate-300 max-h-40 overflow-y-auto flex flex-col gap-0.5 mt-1">
+              {preview.counts
+                .filter((c) => c.count > 0)
+                .sort((a, b) => b.count - a.count)
+                .map((c) => (
+                  <li key={c.store} className="flex justify-between font-mono">
+                    <span className="truncate">{c.store}</span>
+                    <span className="tabular-nums text-emerald-300">{c.count}</span>
+                  </li>
+                ))}
+            </ul>
+            <p className="text-[10px] text-amber-300 mt-2 leading-snug">
+              Para restaurar estos datos, guarda este archivo en lugar seguro.
+              La importación se habilita en la próxima versión.
+            </p>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-3 rounded-xl bg-slate-800 hover:bg-slate-700 text-white font-bold min-h-[48px]"
+        >
+          Cerrar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import ThemeSelector from './common/ThemeSelector';
+import BackupExportButton from './BackupExportButton';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
 
@@ -202,6 +203,12 @@ export default function ProfileScreen({ onBack }) {
             El dashboard de visualización se migró al panel privado del operador (ADR-020 anti-leak / ADR-029 Capa C).
           </p>
         </div>
+
+        {/* Copia de seguridad (2026-05-19): operador perdió plantas + 100
+            species + túnel por un "Clear cache" en Chrome Android. Botón
+            visible y prominente para que descargue snapshot JSON cuando
+            quiera. */}
+        <BackupExportButton />
 
         {/* Multifinca + GPS Section (062.7 indoor override + 062.8 privacy) */}
         <MultifincaGpsSection />

--- a/src/services/__tests__/dataBackup.test.js
+++ b/src/services/__tests__/dataBackup.test.js
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────
+// dbCore.openDB se mockea para devolver un IDBDatabase fake que expone los
+// dos métodos que dataBackup usa: `objectStoreNames` (DOMStringList-like)
+// y `transaction(storeName).objectStore(storeName).getAll()`.
+
+const makeFakeDB = (data, { name = 'ChagraDB', version = 14 } = {}) => {
+  const storeNames = Object.keys(data);
+  return {
+    name,
+    version,
+    objectStoreNames: {
+      contains: (n) => storeNames.includes(n),
+      length: storeNames.length,
+      [Symbol.iterator]: function* () {
+        for (const n of storeNames) yield n;
+      },
+    },
+    transaction(_storeName) {
+      return {
+        objectStore(name) {
+          return {
+            getAll() {
+              const req = {};
+              setTimeout(() => {
+                req.result = data[name] || [];
+                req.onsuccess?.({ target: req });
+              }, 0);
+              return req;
+            },
+            count() {
+              const req = {};
+              setTimeout(() => {
+                req.result = (data[name] || []).length;
+                req.onsuccess?.({ target: req });
+              }, 0);
+              return req;
+            },
+          };
+        },
+      };
+    },
+  };
+};
+
+vi.mock('../../db/dbCore', () => ({
+  openDB: vi.fn(),
+  STORES: {
+    ASSETS: 'assets',
+    LOGS: 'logs',
+    MEDIA_CACHE: 'media_cache',
+    PENDING_TX: 'pending_transactions',
+  },
+}));
+
+import { openDB } from '../../db/dbCore';
+import { exportAllData, downloadBackupJSON, getBackupSummary, BACKUP_VERSION } from '../dataBackup';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Limpiamos localStorage entre tests.
+  window.localStorage.clear();
+});
+
+describe('dataBackup.exportAllData', () => {
+  it('devuelve estructura con version, exportedAt, idb y localStorage', async () => {
+    openDB.mockResolvedValue(
+      makeFakeDB({
+        assets: [{ id: 'a1', asset_type: 'plant', attributes: { name: 'Tomate' } }],
+        logs: [{ id: 'l1', type: 'log--seeding' }],
+      })
+    );
+    window.localStorage.setItem('chagra:operator:name', 'Miguel');
+
+    const dump = await exportAllData();
+
+    expect(dump.version).toBe(BACKUP_VERSION);
+    expect(typeof dump.exportedAt).toBe('string');
+    expect(new Date(dump.exportedAt).toString()).not.toBe('Invalid Date');
+    expect(dump.dbName).toBe('ChagraDB');
+    expect(dump.idb.assets).toHaveLength(1);
+    expect(dump.idb.assets[0].id).toBe('a1');
+    expect(dump.idb.logs).toHaveLength(1);
+    expect(dump.localStorage['chagra:operator:name']).toBe('Miguel');
+  });
+
+  it('NO exporta claves sensibles de localStorage (token/password/secret)', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: [] }));
+    window.localStorage.setItem('access_token', 'super-secret-jwt');
+    window.localStorage.setItem('refresh_token', 'refresh-jwt');
+    window.localStorage.setItem('user_password', 'plain123');
+    window.localStorage.setItem('some_secret_key', 'shh');
+    window.localStorage.setItem('chagra:operator:name', 'Miguel');
+
+    const dump = await exportAllData();
+
+    expect(dump.localStorage.access_token).toBeUndefined();
+    expect(dump.localStorage.refresh_token).toBeUndefined();
+    expect(dump.localStorage.user_password).toBeUndefined();
+    expect(dump.localStorage.some_secret_key).toBeUndefined();
+    expect(dump.localStorage['chagra:operator:name']).toBe('Miguel');
+  });
+
+  it('serializa blobs de media_cache a dataURL base64', async () => {
+    const blob = new Blob(['hola mundo'], { type: 'text/plain' });
+    openDB.mockResolvedValue(
+      makeFakeDB({
+        media_cache: [{ id: 1, logId: 'log-1', blob, mimeType: 'text/plain' }],
+      })
+    );
+
+    const dump = await exportAllData();
+
+    expect(dump.idb.media_cache).toHaveLength(1);
+    const record = dump.idb.media_cache[0];
+    expect(typeof record.blob).toBe('string');
+    expect(record.blob.startsWith('data:')).toBe(true);
+    expect(record._blobEncoding).toBe('dataURL');
+  });
+
+  it('soporta stores nuevos no listados manualmente (itera objectStoreNames real)', async () => {
+    openDB.mockResolvedValue(
+      makeFakeDB({
+        assets: [],
+        un_store_nuevo_que_no_estaba_listado: [{ id: 'x', payload: 'datos' }],
+      })
+    );
+
+    const dump = await exportAllData();
+
+    expect(dump.idb.un_store_nuevo_que_no_estaba_listado).toHaveLength(1);
+    expect(dump.idb.un_store_nuevo_que_no_estaba_listado[0].id).toBe('x');
+  });
+});
+
+describe('dataBackup.downloadBackupJSON', () => {
+  it('genera un Blob JSON, dispara un click sintético y revoca el ObjectURL', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: [{ id: 'a1', asset_type: 'plant' }] }));
+
+    const createObjectURL = vi.fn(() => 'blob:mock-url');
+    const revokeObjectURL = vi.fn();
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    try {
+      const result = await downloadBackupJSON();
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      const blobArg = createObjectURL.mock.calls[0][0];
+      expect(blobArg).toBeInstanceOf(Blob);
+      expect(blobArg.type).toBe('application/json');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      // El filename debe seguir el patrón chagra-backup-YYYY-MM-DD-HHMM.json
+      expect(result._filename).toMatch(/^chagra-backup-\d{4}-\d{2}-\d{2}-\d{4}\.json$/);
+
+      // El revoke se hace en setTimeout(0); esperamos a que se procese.
+      await new Promise((r) => setTimeout(r, 5));
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    } finally {
+      clickSpy.mockRestore();
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+    }
+  });
+});
+
+describe('dataBackup.getBackupSummary', () => {
+  it('cuenta items por tipo (plants, structures, logs, photos, pendingTx)', async () => {
+    openDB.mockResolvedValue(
+      makeFakeDB({
+        assets: [
+          { id: 'a1', asset_type: 'plant' },
+          { id: 'a2', asset_type: 'plant' },
+          { id: 'a3', asset_type: 'structure' },
+          { id: 'a4', asset_type: 'material' },
+          { id: 'a5', asset_type: 'land' },
+        ],
+        logs: [{ id: 'l1' }, { id: 'l2' }, { id: 'l3' }],
+        media_cache: [{ id: 1, blob: null }, { id: 2, blob: null }],
+        pending_transactions: [{ id: 1 }],
+        pending_voice_recordings: [],
+        taxonomy_terms: [{ id: 't1' }, { id: 't2' }, { id: 't3' }],
+      })
+    );
+
+    const summary = await getBackupSummary();
+
+    expect(summary.assets).toBe(5);
+    expect(summary.plants).toBe(2);
+    expect(summary.structures).toBe(1);
+    expect(summary.materials).toBe(1);
+    expect(summary.lands).toBe(1);
+    expect(summary.logs).toBe(3);
+    expect(summary.photos).toBe(2);
+    expect(summary.pendingTx).toBe(1);
+    expect(summary.pendingVoice).toBe(0);
+    expect(summary.taxonomyTerms).toBe(3);
+    expect(summary.totalStores).toBeGreaterThan(0);
+  });
+
+  it('devuelve ceros cuando los stores no existen en el DB (PWA recién instalada)', async () => {
+    openDB.mockResolvedValue(makeFakeDB({})); // ningún store
+
+    const summary = await getBackupSummary();
+
+    expect(summary.assets).toBe(0);
+    expect(summary.plants).toBe(0);
+    expect(summary.logs).toBe(0);
+    expect(summary.photos).toBe(0);
+    expect(summary.pendingTx).toBe(0);
+  });
+});

--- a/src/services/__tests__/emptyDbDetector.test.js
+++ b/src/services/__tests__/emptyDbDetector.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock de dbCore. El test maneja distintos escenarios cambiando lo que
+// devuelve openDB en cada caso.
+const makeFakeDB = (storeCounts) => {
+  const storeNames = Object.keys(storeCounts);
+  return {
+    name: 'ChagraDB',
+    version: 14,
+    objectStoreNames: {
+      contains: (n) => storeNames.includes(n),
+      length: storeNames.length,
+    },
+    transaction(_storeName) {
+      return {
+        objectStore(name) {
+          return {
+            count() {
+              const req = {};
+              setTimeout(() => {
+                req.result = storeCounts[name] || 0;
+                req.onsuccess?.({ target: req });
+              }, 0);
+              return req;
+            },
+          };
+        },
+      };
+    },
+  };
+};
+
+vi.mock('../../db/dbCore', () => ({
+  openDB: vi.fn(),
+  STORES: { ASSETS: 'assets', LOGS: 'logs', MEDIA_CACHE: 'media_cache' },
+}));
+
+import { openDB } from '../../db/dbCore';
+import {
+  markHadData,
+  clearHadDataFlag,
+  isCurrentlyEmpty,
+  shouldWarnDataLoss,
+  HAD_DATA_KEY,
+  LAST_COUNT_KEY,
+  LAST_MARKED_AT_KEY,
+} from '../emptyDbDetector';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe('emptyDbDetector.markHadData', () => {
+  it('setea flag had-data + last-asset-count + last-marked-at', () => {
+    markHadData(42);
+    expect(window.localStorage.getItem(HAD_DATA_KEY)).toBe('1');
+    expect(window.localStorage.getItem(LAST_COUNT_KEY)).toBe('42');
+    expect(window.localStorage.getItem(LAST_MARKED_AT_KEY)).toBeTruthy();
+    // El timestamp debe ser ISO parseable.
+    const ts = window.localStorage.getItem(LAST_MARKED_AT_KEY);
+    expect(new Date(ts).toString()).not.toBe('Invalid Date');
+  });
+
+  it('no rompe si no se le pasa count (mantiene last-count previo)', () => {
+    window.localStorage.setItem(LAST_COUNT_KEY, '10');
+    markHadData();
+    expect(window.localStorage.getItem(HAD_DATA_KEY)).toBe('1');
+    expect(window.localStorage.getItem(LAST_COUNT_KEY)).toBe('10');
+  });
+
+  it('ignora counts no-finitos (NaN, Infinity)', () => {
+    markHadData(NaN);
+    expect(window.localStorage.getItem(LAST_COUNT_KEY)).toBeNull();
+    markHadData(Infinity);
+    expect(window.localStorage.getItem(LAST_COUNT_KEY)).toBeNull();
+  });
+});
+
+describe('emptyDbDetector.clearHadDataFlag', () => {
+  it('limpia todas las claves had-data', () => {
+    markHadData(5);
+    clearHadDataFlag();
+    expect(window.localStorage.getItem(HAD_DATA_KEY)).toBeNull();
+    expect(window.localStorage.getItem(LAST_COUNT_KEY)).toBeNull();
+    expect(window.localStorage.getItem(LAST_MARKED_AT_KEY)).toBeNull();
+  });
+});
+
+describe('emptyDbDetector.isCurrentlyEmpty', () => {
+  it('true cuando assets + logs + media_cache están todos en cero', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 0, logs: 0, media_cache: 0 }));
+    expect(await isCurrentlyEmpty()).toBe(true);
+  });
+
+  it('false cuando hay aunque sea un asset', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 1, logs: 0, media_cache: 0 }));
+    expect(await isCurrentlyEmpty()).toBe(false);
+  });
+
+  it('false cuando hay un log aunque no haya assets', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 0, logs: 1, media_cache: 0 }));
+    expect(await isCurrentlyEmpty()).toBe(false);
+  });
+
+  it('false cuando hay solo una foto suelta', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 0, logs: 0, media_cache: 1 }));
+    expect(await isCurrentlyEmpty()).toBe(false);
+  });
+
+  it('false (NO alerta) si openDB lanza error — conservador para no romper UI', async () => {
+    openDB.mockRejectedValue(new Error('DB bloqueada'));
+    expect(await isCurrentlyEmpty()).toBe(false);
+  });
+
+  it('ignora stores ausentes (PWA nueva sin schema completo)', async () => {
+    openDB.mockResolvedValue(makeFakeDB({})); // ningún store
+    expect(await isCurrentlyEmpty()).toBe(true);
+  });
+});
+
+describe('emptyDbDetector.shouldWarnDataLoss', () => {
+  it('NEVER HAD DATA: no advierte aunque IDB esté vacío', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 0, logs: 0, media_cache: 0 }));
+    // No llamamos markHadData → no hay flag.
+
+    const result = await shouldWarnDataLoss();
+
+    expect(result.shouldWarn).toBe(false);
+    expect(result.lastKnownCount).toBe(0);
+    expect(result.lastMarkedAt).toBeNull();
+  });
+
+  it('HAD DATA + NOW EMPTY: ADVIERTE — caso post-clear-cache', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 0, logs: 0, media_cache: 0 }));
+    markHadData(100);
+
+    const result = await shouldWarnDataLoss();
+
+    expect(result.shouldWarn).toBe(true);
+    expect(result.lastKnownCount).toBe(100);
+    expect(result.lastMarkedAt).toBeTruthy();
+  });
+
+  it('HAS DATA: no advierte aunque el flag had-data esté seteado', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 50, logs: 0, media_cache: 0 }));
+    markHadData(50);
+
+    const result = await shouldWarnDataLoss();
+
+    expect(result.shouldWarn).toBe(false);
+    expect(result.lastKnownCount).toBe(50);
+  });
+
+  it('clearHadDataFlag desactiva la advertencia aunque IDB siga vacío', async () => {
+    openDB.mockResolvedValue(makeFakeDB({ assets: 0, logs: 0, media_cache: 0 }));
+    markHadData(7);
+    expect((await shouldWarnDataLoss()).shouldWarn).toBe(true);
+    clearHadDataFlag();
+    expect((await shouldWarnDataLoss()).shouldWarn).toBe(false);
+  });
+});

--- a/src/services/dataBackup.js
+++ b/src/services/dataBackup.js
@@ -1,0 +1,277 @@
+/**
+ * dataBackup — Servicio de exportación completa de los datos locales.
+ *
+ * MOTIVACIÓN (2026-05-19): el operador perdió plantas con foto, el túnel y
+ * 100 species porque hizo "Clear cache" en Chrome Android — esa acción
+ * elimina IndexedDB completo y todo lo que tenía `_pending: true` (no
+ * sincronizado a FarmOS aún) murió sin retorno.
+ *
+ * Este servicio permite descargar un snapshot JSON con TODO lo que vive en
+ * IndexedDB local (todos los stores de `ChagraDB`) + las claves de
+ * localStorage usadas por la app, para que el operador pueda guardar la
+ * copia y recuperarla luego.
+ *
+ * Diseño:
+ *   - Lee TODOS los stores definidos en `STORES` (dbCore.js), sin asumir
+ *     cuáles existen — itera sobre `db.objectStoreNames` para evitar
+ *     romperse cuando se agregan stores nuevos en bumps de schema.
+ *   - Para `media_cache` (binarios Blob) convierte cada blob a `dataURL`
+ *     base64 con FileReader. El resto se serializa tal cual.
+ *   - LocalStorage: snapshot de las claves prefijadas `chagra:` + las
+ *     conocidas (`access_token` queda EXCLUIDO por seguridad — el operador
+ *     puede re-loguear; el token es secreto).
+ *
+ * NO importa, solo exporta. El import vendrá en un PR posterior.
+ */
+
+import { openDB } from '../db/dbCore';
+
+export const BACKUP_VERSION = '1';
+
+// Claves de localStorage que EXCLUIMOS del export por seguridad.
+// access_token, refresh_token y derivados FarmOS son sensibles — exportarlos
+// permitiría a alguien con el JSON impersonar al operador. Si el operador
+// importa una copia anterior, el flujo de re-login se encarga de regenerarlos.
+const LOCAL_STORAGE_EXCLUDE_PATTERNS = [
+  /token/i,
+  /password/i,
+  /secret/i,
+  /bearer/i,
+  /^access_/i,
+  /^refresh_/i,
+];
+
+const shouldExportLocalStorageKey = (key) => {
+  if (!key) return false;
+  for (const pattern of LOCAL_STORAGE_EXCLUDE_PATTERNS) {
+    if (pattern.test(key)) return false;
+  }
+  return true;
+};
+
+/**
+ * Convierte un Blob a dataURL base64. Usa FileReader (API DOM estándar).
+ * Si el blob es null/undefined, devuelve null.
+ *
+ * @param {Blob} blob
+ * @returns {Promise<string|null>}
+ */
+const blobToDataUrl = (blob) =>
+  new Promise((resolve, reject) => {
+    if (!blob) {
+      resolve(null);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+
+/**
+ * Lee todos los registros de un object store por nombre.
+ *
+ * @param {IDBDatabase} db
+ * @param {string} storeName
+ * @returns {Promise<Array<object>>}
+ */
+const readAllFromStore = (db, storeName) =>
+  new Promise((resolve, reject) => {
+    if (!db.objectStoreNames.contains(storeName)) {
+      resolve([]);
+      return;
+    }
+    const tx = db.transaction(storeName, 'readonly');
+    const store = tx.objectStore(storeName);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result || []);
+    request.onerror = () => reject(request.error);
+  });
+
+/**
+ * Serializa un registro de media_cache convirtiendo `blob` a dataURL.
+ * Otros campos se preservan tal cual.
+ */
+const serializeMediaRecord = async (record) => {
+  if (!record || !record.blob) return { ...record, blob: null };
+  try {
+    const dataUrl = await blobToDataUrl(record.blob);
+    return { ...record, blob: dataUrl, _blobEncoding: 'dataURL' };
+  } catch (err) {
+    console.warn('[dataBackup] No se pudo serializar blob de media_cache', record.id, err);
+    return { ...record, blob: null, _blobError: String(err?.message || err) };
+  }
+};
+
+/**
+ * Serializa un registro de pending_voice_recordings (también tiene blob de audio).
+ */
+const serializeVoiceRecord = async (record) => {
+  if (!record || !record.blob) return record;
+  try {
+    const dataUrl = await blobToDataUrl(record.blob);
+    return { ...record, blob: dataUrl, _blobEncoding: 'dataURL' };
+  } catch (err) {
+    console.warn('[dataBackup] No se pudo serializar audio pending_voice', record.id, err);
+    return { ...record, blob: null, _blobError: String(err?.message || err) };
+  }
+};
+
+/**
+ * Exporta TODO lo que vive en IndexedDB + localStorage relevante.
+ *
+ * Shape devuelto:
+ *   {
+ *     version: '1',
+ *     exportedAt: ISO string,
+ *     dbName: 'ChagraDB',
+ *     dbVersion: number,
+ *     idb: { [storeName]: Array<record> },
+ *     localStorage: { [key]: string },
+ *   }
+ *
+ * @returns {Promise<object>}
+ */
+export const exportAllData = async () => {
+  const db = await openDB();
+  const idb = {};
+
+  // Iterar sobre los stores REALES de la conexión (no sobre STORES constante),
+  // así un bump de schema nuevo se incluye automáticamente sin tocar este file.
+  const storeNames = Array.from(db.objectStoreNames);
+
+  for (const storeName of storeNames) {
+    const records = await readAllFromStore(db, storeName);
+    if (storeName === 'media_cache') {
+      idb[storeName] = await Promise.all(records.map(serializeMediaRecord));
+    } else if (storeName === 'pending_voice_recordings') {
+      idb[storeName] = await Promise.all(records.map(serializeVoiceRecord));
+    } else {
+      idb[storeName] = records;
+    }
+  }
+
+  const localStorageDump = {};
+  if (typeof window !== 'undefined' && window.localStorage) {
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (!shouldExportLocalStorageKey(key)) continue;
+      try {
+        localStorageDump[key] = window.localStorage.getItem(key);
+      } catch (err) {
+        console.warn('[dataBackup] No se pudo leer localStorage key', key, err);
+      }
+    }
+  }
+
+  return {
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    dbName: db.name,
+    dbVersion: db.version,
+    idb,
+    localStorage: localStorageDump,
+  };
+};
+
+/**
+ * Calcula el filename canónico del backup:
+ *   chagra-backup-YYYY-MM-DD-HHMM.json
+ */
+const buildBackupFilename = (date = new Date()) => {
+  const pad = (n) => String(n).padStart(2, '0');
+  const y = date.getFullYear();
+  const m = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const hh = pad(date.getHours());
+  const mm = pad(date.getMinutes());
+  return `chagra-backup-${y}-${m}-${d}-${hh}${mm}.json`;
+};
+
+/**
+ * Descarga el JSON con un click sintético usando Blob + URL.createObjectURL.
+ * Devuelve el resumen del export (mismo `exportAllData`) para que la UI
+ * pueda mostrar "se descargaron X plantas, Y fotos".
+ *
+ * @returns {Promise<object>} backup object (sin la `localStorage` para no
+ *   leakear nada si la UI lo persiste — el archivo descargado SÍ contiene
+ *   localStorage, solo el retorno está depurado).
+ */
+export const downloadBackupJSON = async () => {
+  const backup = await exportAllData();
+  const json = JSON.stringify(backup, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const filename = buildBackupFilename();
+
+  try {
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  } finally {
+    // Revocar el ObjectURL en el siguiente tick para que el download
+    // tenga tiempo de empezar antes de soltar la referencia al blob.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }
+
+  return { ...backup, _filename: filename };
+};
+
+/**
+ * Cuenta resumida por categoría para mostrar en la UI antes/después del export.
+ *
+ * @returns {Promise<{
+ *   assets: number,
+ *   plants: number,
+ *   structures: number,
+ *   equipment: number,
+ *   materials: number,
+ *   lands: number,
+ *   logs: number,
+ *   photos: number,
+ *   pendingTx: number,
+ *   pendingVoice: number,
+ *   taxonomyTerms: number,
+ *   totalStores: number,
+ * }>}
+ */
+export const getBackupSummary = async () => {
+  const db = await openDB();
+  const safeCount = async (storeName, predicate = null) => {
+    if (!db.objectStoreNames.contains(storeName)) return 0;
+    const records = await readAllFromStore(db, storeName);
+    if (!predicate) return records.length;
+    return records.filter(predicate).length;
+  };
+
+  const assets = await safeCount('assets');
+  const plants = await safeCount('assets', (a) => a.asset_type === 'plant');
+  const structures = await safeCount('assets', (a) => a.asset_type === 'structure');
+  const equipment = await safeCount('assets', (a) => a.asset_type === 'equipment');
+  const materials = await safeCount('assets', (a) => a.asset_type === 'material');
+  const lands = await safeCount('assets', (a) => a.asset_type === 'land');
+  const logs = await safeCount('logs');
+  const photos = await safeCount('media_cache');
+  const pendingTx = await safeCount('pending_transactions');
+  const pendingVoice = await safeCount('pending_voice_recordings');
+  const taxonomyTerms = await safeCount('taxonomy_terms');
+
+  return {
+    assets,
+    plants,
+    structures,
+    equipment,
+    materials,
+    lands,
+    logs,
+    photos,
+    pendingTx,
+    pendingVoice,
+    taxonomyTerms,
+    totalStores: db.objectStoreNames.length,
+  };
+};

--- a/src/services/emptyDbDetector.js
+++ b/src/services/emptyDbDetector.js
@@ -1,0 +1,137 @@
+/**
+ * emptyDbDetector — detector de "vaciado" de IndexedDB.
+ *
+ * MOTIVACIÓN (2026-05-19): el operador hizo "Clear cache" en Chrome Android
+ * y eso eliminó todo IDB sin advertencia ni retorno. La detección reactiva
+ * compara dos señales: una "huella" persistente que dice "este dispositivo
+ * tenía datos antes" (vive en localStorage, que sobrevive al clear cache
+ * de IDB) y el conteo actual de IDB. Si la huella dice que había datos pero
+ * IDB está vacío, mostramos un banner rojo prominente.
+ *
+ * Caveats conocidos:
+ *   - "Clear browsing data" en Android borra TANTO localStorage como IDB.
+ *     En ese caso no podemos detectar el vaciado porque también perdimos
+ *     la huella. El detector cubre el caso "Clear cache" (más común y
+ *     accidental) que NO toca localStorage.
+ *   - Si el operador instaló la PWA y reinstaló el navegador, también
+ *     perdemos la huella. Ese caso no se cubre.
+ *
+ * API:
+ *   - markHadData(assetCount?) — llamar tras addAsset / sync exitoso para
+ *     marcar "este dispositivo tuvo datos".
+ *   - isCurrentlyEmpty() — cuenta IDB (assets + logs + media_cache) y devuelve
+ *     true si todo está en cero.
+ *   - shouldWarnDataLoss() — combina ambos: returns
+ *     { shouldWarn, lastKnownCount, currentCount, lastMarkedAt }.
+ *   - clearHadDataFlag() — limpia el flag (útil después de import).
+ */
+
+import { openDB } from '../db/dbCore';
+
+export const HAD_DATA_KEY = 'chagra:had-data-once';
+export const LAST_COUNT_KEY = 'chagra:last-asset-count';
+export const LAST_MARKED_AT_KEY = 'chagra:last-marked-at';
+
+/**
+ * Setea los flags de "este dispositivo tuvo datos". Idempotente.
+ *
+ * @param {number} [assetCount] — conteo actual de assets, opcional. Si se
+ *   pasa, se guarda como `last-asset-count` para mostrar al usuario "antes
+ *   tenías N plantas". Si no, se queda con el valor previo (o '0').
+ */
+export const markHadData = (assetCount = null) => {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.setItem(HAD_DATA_KEY, '1');
+    if (assetCount !== null && Number.isFinite(assetCount)) {
+      window.localStorage.setItem(LAST_COUNT_KEY, String(assetCount));
+    }
+    window.localStorage.setItem(LAST_MARKED_AT_KEY, new Date().toISOString());
+  } catch (err) {
+    console.warn('[emptyDbDetector] No se pudo marcar had-data flag:', err);
+  }
+};
+
+/**
+ * Limpia el flag had-data. Usar después de un import exitoso o reset
+ * explícito del operador (para que el banner no siga apareciendo).
+ */
+export const clearHadDataFlag = () => {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    window.localStorage.removeItem(HAD_DATA_KEY);
+    window.localStorage.removeItem(LAST_COUNT_KEY);
+    window.localStorage.removeItem(LAST_MARKED_AT_KEY);
+  } catch (err) {
+    console.warn('[emptyDbDetector] No se pudo limpiar had-data flag:', err);
+  }
+};
+
+/**
+ * Cuenta total de registros en los stores "de datos del operador":
+ * assets, logs, media_cache. Si la suma es 0, IDB está efectivamente vacío
+ * desde la perspectiva del operador (los stores de telemetría / sync_meta
+ * no cuentan porque pueden estar vacíos en un dispositivo nuevo legítimo).
+ *
+ * @returns {Promise<boolean>}
+ */
+export const isCurrentlyEmpty = async () => {
+  try {
+    const db = await openDB();
+    const dataStores = ['assets', 'logs', 'media_cache'];
+    let total = 0;
+    for (const storeName of dataStores) {
+      if (!db.objectStoreNames.contains(storeName)) continue;
+      const count = await new Promise((resolve, reject) => {
+        const tx = db.transaction(storeName, 'readonly');
+        const req = tx.objectStore(storeName).count();
+        req.onsuccess = () => resolve(req.result || 0);
+        req.onerror = () => reject(req.error);
+      });
+      total += count;
+      if (total > 0) return false; // early exit, no hace falta seguir contando
+    }
+    return total === 0;
+  } catch (err) {
+    console.warn('[emptyDbDetector] Error chequeando IDB vacío:', err);
+    // En duda, NO alertar (evitar false positives que rompan la UI).
+    return false;
+  }
+};
+
+/**
+ * Devuelve si conviene mostrar el banner de "se borró tu data".
+ *
+ * @returns {Promise<{
+ *   shouldWarn: boolean,
+ *   lastKnownCount: number,
+ *   lastMarkedAt: string|null,
+ * }>}
+ */
+export const shouldWarnDataLoss = async () => {
+  const hadDataFlag =
+    typeof window !== 'undefined' && window.localStorage
+      ? window.localStorage.getItem(HAD_DATA_KEY) === '1'
+      : false;
+  const lastKnownCount = (() => {
+    if (typeof window === 'undefined' || !window.localStorage) return 0;
+    const raw = window.localStorage.getItem(LAST_COUNT_KEY);
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? n : 0;
+  })();
+  const lastMarkedAt =
+    typeof window !== 'undefined' && window.localStorage
+      ? window.localStorage.getItem(LAST_MARKED_AT_KEY)
+      : null;
+
+  if (!hadDataFlag) {
+    return { shouldWarn: false, lastKnownCount, lastMarkedAt };
+  }
+
+  const empty = await isCurrentlyEmpty();
+  return {
+    shouldWarn: empty,
+    lastKnownCount,
+    lastMarkedAt,
+  };
+};

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -5,6 +5,7 @@ import { useLogStore } from './useLogStore';
 import { newId } from '../utils/id';
 import { savePayload, updatePayload } from '../services/payloadService';
 import { getAccessToken } from '../services/authService';
+import { markHadData } from '../services/emptyDbDetector';
 
 /** @typedef {import('../types').ChagraAsset} ChagraAsset */
 /** @typedef {import('../types').ChagraLog} ChagraLog */
@@ -52,6 +53,15 @@ const useAssetStore = create((set, get) => ({
       ]);
       const lastSync = await assetCache.getLastSync();
       set({ plants, structures, equipment, materials, lands, taxonomyTerms, lastSync });
+
+      // emptyDbDetector: si hidratamos con assets reales, dejamos huella en
+      // localStorage de "este dispositivo tuvo datos". Sirve para detectar
+      // luego un "Clear cache" de Chrome Android (que borra IDB pero no
+      // localStorage) y mostrar DataLossBanner.
+      const totalAssets = plants.length + structures.length + equipment.length + materials.length + lands.length;
+      if (totalAssets > 0) {
+        markHadData(totalAssets);
+      }
     } catch (err) {
       console.error('Error rehidratando asset store desde IndexedDB:', err);
     }
@@ -163,6 +173,19 @@ const useAssetStore = create((set, get) => ({
         isLoading: false,
         syncProgress: { ...syncProgress },
       });
+      // emptyDbDetector: tras sync exitoso, dejamos huella con el conteo
+      // total. Si después el operador hace "Clear cache" en Chrome Android
+      // (borra IDB pero no localStorage), DataLossBanner aparece.
+      const finalState = get();
+      const totalAfterSync =
+        finalState.plants.length +
+        finalState.structures.length +
+        finalState.equipment.length +
+        finalState.materials.length +
+        finalState.lands.length;
+      if (totalAfterSync > 0) {
+        markHadData(totalAfterSync);
+      }
       onProgress?.({ ...syncProgress, isComplete: true });
     } catch (err) {
       console.error('Error sincronizando activos:', err);
@@ -202,6 +225,9 @@ const useAssetStore = create((set, get) => ({
               : 'materials';
         return { [key]: [...state[key], asset] };
       });
+      // emptyDbDetector: huella para post-clear-cache detection.
+      const totalNow = get().plants.length + get().structures.length + get().equipment.length + get().materials.length + get().lands.length;
+      markHadData(totalNow);
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
     } catch (error) {
       console.error('[Store] Fallo en addAsset atómico:', error);


### PR DESCRIPTION
## Contexto

Hoy 2026-05-19 el operador perdió plantas con foto, el túnel y ~100 species
porque hizo "Clear cache" en Chrome Android — esa acción borra IndexedDB
completo sin advertencia ni retorno. Todo lo que tenía `_pending: true`
(no sincronizado a FarmOS aún) murió.

Esta PR no recupera lo perdido; previene futuras pérdidas con dos
servicios + UI mínima.

## Summary

- **`src/services/dataBackup.js`** — `exportAllData()` lee TODOS los
  object stores de `ChagraDB` (itera `db.objectStoreNames`, no constante
  hardcoded → resiste futuros bumps de schema). Blobs de `media_cache` y
  `pending_voice_recordings` se convierten a `dataURL` base64 con
  FileReader. `downloadBackupJSON()` dispara descarga con filename
  `chagra-backup-YYYY-MM-DD-HHMM.json`. Excluye `access_token`,
  `refresh_token` y cualquier clave con `/token|password|secret|bearer/i`
  por seguridad. `getBackupSummary()` cuenta items por categoría para
  mostrar "vas a exportar X plantas, Y fotos" antes del click.

- **`src/services/emptyDbDetector.js`** — `markHadData(count)` deja huella
  en `localStorage` (`chagra:had-data-once` + `chagra:last-asset-count` +
  `chagra:last-marked-at`). `useAssetStore` la llama al hidratar, al
  agregar asset y al terminar un sync exitoso. `isCurrentlyEmpty()` suma
  `count()` de `assets + logs + media_cache`. `shouldWarnDataLoss()`
  combina ambos: si la huella dice "este dispositivo tuvo datos" pero IDB
  está vacío, el banner se muestra.

  **Caveat documentado**: si el operador hace "Clear *browsing* data"
  (borra TAMBIÉN localStorage), no podemos detectar. Cubre el caso "Clear
  cache" que fue lo que pasó hoy y es el accidental más común.

- **UI**:
  - `DataLossBanner` (rojo prominente, `bg-red-900` + `border-red-500`)
    montado en `App.jsx` debajo de los banners existentes. Solo aparece
    si `shouldWarnDataLoss()` devuelve true. Botón "Importar copia
    anterior" abre modal con `<input type="file" accept="application/json">`
    que **solo previsualiza** (cuenta items por store, version, fecha).
    El import real es PR posterior.
  - `BackupExportButton` agregado a `ProfileScreen` entre Telemetría y
    Multifinca: tarjeta con resumen "vas a exportar X plantas, Y fotos,
    Z pendientes" + botón "Exportar copia ahora".

- **`src/store/useAssetStore.js`** — 3 puntos de llamada a `markHadData`:
  `hydrate()` cuando los assets cargan de IDB, `addAsset()` tras commit
  atómico, `syncFromServer()` al terminar bien.

## Test plan

- [x] `npx vitest run` — 396/396 pasa (21 tests nuevos: 8 dataBackup + 13
      emptyDbDetector).
- [x] `npm run build` — verde, 2.1s.
- [x] Lint sobre archivos modificados — clean (el único error que reporta
      `npm run lint` es `ObservationScreen.jsx:83` que ya está en main,
      pre-existente y no relacionado).
- [ ] Validación mobile del operador: abrir `Perfil` → "Exportar copia
      ahora" → verificar que descarga JSON con plants/structures/fotos.
- [ ] Validación detector: simular clear-cache (Chrome devtools →
      Application → Storage → Clear site data — solo IDB), verificar
      banner rojo en próximo open.
- [ ] CodeQL SAST verde (merge-gate §5.1).
- [ ] Playwright E2E `tests/offline.spec.js` verde (merge-gate §5.2).

## Out of scope (para PR posterior)

- Import real del JSON (este PR solo previsualiza). El import tiene que
  resolver merge vs overwrite, validar shape, restaurar blobs base64 →
  Blob, etc. Complejo y arriesgado → mejor PR aparte.
- Backup automático periódico (este PR solo es manual on-demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)