### PR TITLE
fix(voice): form review race-condition + colibri en FAB y chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.141",
+  "version": "0.12.142",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v183';
+const CACHE_NAME = 'chagra-v184';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,12 +1,22 @@
 import React from 'react';
-import { Sparkles } from 'lucide-react';
+import ChagraAgentAvatar from './ChagraAgentAvatar';
 
+/**
+ * AgentFab — Floating Action Button para abrir el agente Chagra IA.
+ *
+ * 2026-05-19 operator: integrar ChagraAgentAvatar (colibri libando del
+ * abutilon) en lugar del icono Sparkles generico. Estado idle = vuelo
+ * estacionario + alas batiendo, da vida al CTA flotante sin distraer.
+ *
+ * El FAB sigue siendo circular 56x56, con el avatar inscrito (svg 200x200
+ * escalado). Bordes y glow se mantienen para mantener affordance de boton.
+ */
 export default function AgentFab({ onNavigate }) {
   return (
     <button
       type="button"
-      aria-label="Asistente IA"
-      title="Hablar con el asistente IA"
+      aria-label="Asistente Chagra IA"
+      title="Hablar con Chagra IA"
       onClick={() => onNavigate('agente')}
       style={{
         position: 'fixed',
@@ -15,18 +25,20 @@ export default function AgentFab({ onNavigate }) {
         width: 56,
         height: 56,
         borderRadius: '50%',
-        border: '2px solid #a78bfa',
-        background: 'linear-gradient(135deg, #7c3aed 0%, #4c1d95 100%)',
+        border: '2px solid rgba(16,185,129,.55)',
+        background: 'radial-gradient(circle at 30% 25%, #1e293b 0%, #0f172a 70%)',
         color: 'white',
         cursor: 'pointer',
-        boxShadow: '0 4px 16px rgba(0,0,0,0.4), 0 0 14px #a78bfa55',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.4), 0 0 14px rgba(16,185,129,.35)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         zIndex: 40,
+        padding: 0,
+        overflow: 'hidden',
       }}
     >
-      <Sparkles size={24} />
+      <ChagraAgentAvatar state="idle" size={48} ariaLabel="Chagra IA" />
     </button>
   );
 }

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { User, Bot } from 'lucide-react';
+import { User } from 'lucide-react';
+import ChagraAgentAvatar from '../ChagraAgentAvatar';
 
 function formatTime(timestamp) {
   if (!timestamp) return '';
@@ -9,15 +10,23 @@ function formatTime(timestamp) {
 
 export default function ChatBubble({ message, isStreaming = false }) {
   const isUser = message.role === 'user';
+  // 2026-05-19 operator: reemplazar icono Bot generico por ChagraAgentAvatar
+  // (colibri). En burbujas del agente, el avatar entra en estado 'thinking'
+  // mientras el mensaje esta streaming → coherencia visual con el header.
+  const agentState = isStreaming ? 'thinking' : 'idle';
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
       <div className={`flex gap-2 max-w-[85%] ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
-        <div className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
-          isUser ? 'bg-emerald-600' : 'bg-violet-700'
-        }`}>
-          {isUser ? <User size={16} className="text-white" /> : <Bot size={16} className="text-white" />}
-        </div>
+        {isUser ? (
+          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600">
+            <User size={16} className="text-white" />
+          </div>
+        ) : (
+          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-slate-900 border border-emerald-700/40 overflow-hidden">
+            <ChagraAgentAvatar state={agentState} size={28} ariaLabel="Chagra IA" />
+          </div>
+        )}
 
         <div className={`rounded-2xl px-4 py-2.5 ${
           isUser

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, X, Trash2, AlertTriangle, Wand2, Sprout, FlaskConical, Ban } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
@@ -102,34 +102,66 @@ export default function VoiceConfirmation({
     };
   };
 
-  const [rows, setRows] = useState(() =>
-    (initialEntities || []).map((e) => {
-      const resolvedLoc = resolveLocation(e.location);
-      const resolvedCrop = resolveCrop(e.crop || '');
-      return {
-        crop: resolvedCrop.crop,
-        cropOriginal: e.crop || '',
-        cropCanonical: resolvedCrop.canonical,
-        cropSlug: resolvedCrop.cropSlug,
-        farmosTermId: resolvedCrop.farmosTermId,
-        cropScore: resolvedCrop.score,
-        cropGroup: resolvedCrop.group,
-        quantity: e.quantity || 1,
-        rawLocation: e.location || '',
-        locationId: resolvedLoc?.id || '',
-        locationType: resolvedLoc?.type || 'asset--land',
-        locationMatchedName: resolvedLoc?.matchedName || null,
-        locationScore: resolvedLoc?.score || null,
-        // Insights del RAG post-extracción (audit 2026-05-18). Opcional: si
-        // el RAG no encontró hits o el corpus está cold, queda null y la UI
-        // omite la sección. Ver voiceRagEnricher.js.
-        ragInsights: e._ragInsights || null,
-      };
-    })
-  );
+  // Build inicial de rows: resuelve cultivo + ubicacion contra catalogos.
+  // 2026-05-19 bug operador: si useAssetStore aun estaba hidratando IndexedDB
+  // cuando este componente monta, locationOptions=[] y resolveLocation()
+  // siempre devolvia null -> locationId='' -> allValid=false -> boton Guardar
+  // disabled -> operador percibe "form vacio sin info". Fix: useEffect que
+  // recompute rows cuando los stores cargan, preservando ediciones del usuario.
+  const buildRows = (entities) => (entities || []).map((e) => {
+    const resolvedLoc = resolveLocation(e.location);
+    const resolvedCrop = resolveCrop(e.crop || '');
+    return {
+      crop: resolvedCrop.crop,
+      cropOriginal: e.crop || '',
+      cropCanonical: resolvedCrop.canonical,
+      cropSlug: resolvedCrop.cropSlug,
+      farmosTermId: resolvedCrop.farmosTermId,
+      cropScore: resolvedCrop.score,
+      cropGroup: resolvedCrop.group,
+      quantity: e.quantity || 1,
+      rawLocation: e.location || '',
+      locationId: resolvedLoc?.id || '',
+      locationType: resolvedLoc?.type || 'asset--land',
+      locationMatchedName: resolvedLoc?.matchedName || null,
+      locationScore: resolvedLoc?.score || null,
+      ragInsights: e._ragInsights || null,
+    };
+  });
 
-  const updateRow = (i, patch) => setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
-  const removeRow = (i) => setRows((prev) => prev.filter((_, idx) => idx !== i));
+  const [rows, setRows] = useState(() => buildRows(initialEntities));
+
+  // Flag de "el usuario empezo a editar" para no pisar ediciones cuando los
+  // stores async terminan de hidratar. Si dirty=true, mantenemos las rows
+  // actuales aunque locationOptions cambie. Si dirty=false (acaba de
+  // entrar a STATE_REVIEW), recomputamos en caso de stores recien hidratados.
+  const dirtyRef = useRef(false);
+  const storesReady = locationOptions.length > 0 && allCropSpecies.length > 0;
+  const lastEntitiesRef = useRef(initialEntities);
+  useEffect(() => {
+    // Cambio de initialEntities (nueva extraccion) -> reset dirty + rebuild.
+    if (initialEntities !== lastEntitiesRef.current) {
+      lastEntitiesRef.current = initialEntities;
+      dirtyRef.current = false;
+      setRows(buildRows(initialEntities));
+      return;
+    }
+    // Mismo initialEntities pero stores acaban de cargar -> re-resolver
+    // ubicacion y cultivo si el usuario aun no edito.
+    if (!dirtyRef.current && storesReady) {
+      setRows(buildRows(initialEntities));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialEntities, storesReady]);
+
+  const updateRow = (i, patch) => {
+    dirtyRef.current = true;
+    setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+  };
+  const removeRow = (i) => {
+    dirtyRef.current = true;
+    setRows((prev) => prev.filter((_, idx) => idx !== i));
+  };
 
   // Agrega una nueva fila a partir de un "compañero sugerido" (capas de
   // GuildSuggestions). Resuelve la especie contra CROP_TAXONOMY para


### PR DESCRIPTION
## Summary
- Fix race-condition en `VoiceConfirmation`: el form de revisión de entidades extraídas por voz se renderizaba con `locationId=''` cuando `useAssetStore` aún hidratando IDB → operador veía "form vacío sin info" y botón Guardar deshabilitado.
- Integrar `ChagraAgentAvatar` (colibrí) en `AgentFab` (FAB flotante) y `ChatBubble` (cada mensaje del agente).

## Cambios
- `src/components/VoiceConfirmation.jsx`: useState→useEffect que recomputa rows cuando stores hidratan; `dirtyRef` para preservar ediciones del usuario.
- `src/components/AgentFab.jsx`: Sparkles→ChagraAgentAvatar idle.
- `src/components/AgentScreen/ChatBubble.jsx`: Bot icon→ChagraAgentAvatar mini (28px), state thinking durante streaming.

## Test plan
- [x] `npm run test:unit` → 396/396 pass
- [x] `npm run lint` → clean
- [ ] Visual: registrar siembra por voz → confirmar form muestra cultivo+cantidad+ubicacion con stores recien hidratados
- [ ] Visual: abrir agente → FAB y burbujas muestran colibri animado

🤖 Generated with [Claude Code](https://claude.com/claude-code)