### PR TITLE
fix(infra): mostrar lands + structures en pantalla infraestructura

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.144",
+  "version": "0.12.145",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v186';
+const CACHE_NAME = 'chagra-v187';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List, Warehouse, Square } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { Virtuoso } from 'react-virtuoso';
 import { fetchFromFarmOS } from '../services/apiService';
@@ -372,11 +372,34 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   };
 
   const getAssetsForTab = () => {
-    let list = activeTab === 'plant' ? plants
-      : activeTab === 'land' ? lands
-        : activeTab === 'structure' ? structures
-          : activeTab === 'equipment' ? equipment
-            : materials;
+    let list;
+    if (activeTab === 'plant') {
+      list = plants;
+    } else if (activeTab === 'land') {
+      list = lands;
+    } else if (activeTab === 'structure') {
+      // Bug pre-demo Diana 2026-05-19: el operador percibe "Infraestructura"
+      // como un único concepto físico/espacial (lotes, túneles, invernaderos,
+      // bodegas). Reportó ver solo guatoc + "sin nombre" (lands) y no el
+      // "tunel de la producción" (structure) que SÍ aparecía en el dropdown
+      // de VoiceConfirmation (lands + structures combinados). Fix mínimo:
+      // unificar lands + structures en este tab, dedupe por id priorizando
+      // entradas con name no vacío. Los iconos por item se diferencian en
+      // el render del Virtuoso (Warehouse vs Square).
+      const byId = new Map();
+      const hasName = (a) => Boolean((a.attributes?.name || a.name || '').trim());
+      [...structures, ...lands].forEach((a) => {
+        const existing = byId.get(a.id);
+        if (!existing || (!hasName(existing) && hasName(a))) {
+          byId.set(a.id, a);
+        }
+      });
+      list = Array.from(byId.values());
+    } else if (activeTab === 'equipment') {
+      list = equipment;
+    } else {
+      list = materials;
+    }
 
     // Cementerio (queue/038 + spine educativo): si zona === '__cemetery__'
     // mostramos solo plants status='dead'. Modo dedicado para reflexionar
@@ -1387,11 +1410,22 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
               style={{ height: '100%', width: '100%' }}
               overscan={400}
               itemContent={(index, asset) => {
-                const name = asset.attributes?.name || asset.name || 'Sin nombre';
+                // Bug pre-demo Diana 2026-05-19: en tab 'structure' ahora
+                // conviven lands + structures. Diferenciamos icono y label
+                // fallback según el `type` del asset para que el operador
+                // pueda distinguir un terreno (land) de una construcción
+                // (structure) aun cuando ambos carecen de nombre.
+                const rawName = (asset.attributes?.name || asset.name || '').trim();
+                const isLand = asset.type === 'asset--land';
+                const isStructure = asset.type === 'asset--structure';
+                const typeLabel = isLand ? 'zona' : isStructure ? 'infraestructura' : '';
+                const name = rawName || (typeLabel ? `(sin nombre · ${typeLabel})` : '(sin nombre)');
                 const notes = asset.attributes?.notes;
                 const notesText = typeof notes === 'object' ? notes?.value : notes;
                 const isPending = asset._pending;
-                const TabIcon = tabConfig.icon;
+                const TabIcon = activeTab === 'structure'
+                  ? (isLand ? Square : Warehouse)
+                  : tabConfig.icon;
 
                 return (
                   <div className="pb-2 px-1">


### PR DESCRIPTION
## Summary

Bug pre-demo Diana (martes 2026-05-19 14:00 Bogota). En la pantalla Infraestructura del modulo Activos la operadora solo veia 2 entradas (guatoc y (sin nombre), ambos asset--land) y faltaba el tunel de la produccion (asset--structure) que SI aparecia en el dropdown de ubicacion del flujo por voz (VoiceConfirmation.jsx:33-48, donde se combinan structures + lands).

Causa: getAssetsForTab() en AssetsDashboard.jsx filtraba el tab structure mostrando unicamente el array structures del store. La operadora percibe Infraestructura como un concepto fisico/espacial unico (lotes + tuneles + invernaderos + bodegas), no como dos taxonomias separadas.

## Fix

- getAssetsForTab() para activeTab === 'structure' ahora combina [...structures, ...lands] con dedupe por id priorizando entradas con name no vacio.
- Render de Virtuoso.itemContent diferencia icono por tipo: Warehouse para asset--structure, Square para asset--land.
- Fallback de nombre mejorado: (sin nombre . zona) o (sin nombre . infraestructura) para distinguir assets sin nombre.
- Sin cambios en logica de creacion ni en otros tabs (plant, land, equipment, material).
- Sin cambios en el form ni en payloads JSON:API.
- Version bump 0.12.144 -> 0.12.145 + sw cache v186 -> v187 manual (lefthook no estaba en PATH del worktree).

## Test plan

- [ ] Abrir Activos > tab Infraestructura: aparecen lands Y structures combinados.
- [ ] Iconos diferenciados (cuadrado para zonas, almacen para construcciones).
- [ ] Asset sin nombre muestra (sin nombre . zona) o (sin nombre . infraestructura).
- [ ] Otros tabs (Siembras, Zonas, Insumos) no afectados.
- [ ] Flujo por voz sigue resolviendo ubicaciones correctamente.

## Notas

- Lint: corrio OOM en el host (issue conocido). El cambio es JSX puro, parseado OK por @babel/parser con plugin jsx.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>