### PR TITLE
perf(rag): pre-tokenize docs to fix post-voice UI latency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.145",
+  "version": "0.12.146",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v187';
+const CACHE_NAME = 'chagra-v188';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/scripts/bench-rag-retrieve.loader.mjs
+++ b/scripts/bench-rag-retrieve.loader.mjs
@@ -1,0 +1,40 @@
+/**
+ * Loader hook para bench-rag-retrieve.mjs.
+ *
+ * El código de src/ usa imports estilo Vite sin extensión `.js`. Este hook
+ * añade extensiones cuando Node nativo no puede resolver el specifier.
+ *
+ * Uso:
+ *   node --import ./scripts/bench-rag-retrieve.register.mjs scripts/bench-rag-retrieve.mjs
+ */
+import { stat } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const EXT_CANDIDATES = ['.js', '.mjs', '.jsx', '.ts', '.tsx'];
+
+async function fileExists(url) {
+  try {
+    const path = fileURLToPath(url);
+    const s = await stat(path);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    // Solo intentamos rescate si parece un path relativo o absoluto sin ext.
+    if (!specifier.startsWith('.') && !specifier.startsWith('/')) throw err;
+    const base = context.parentURL ?? import.meta.url;
+    for (const ext of EXT_CANDIDATES) {
+      const candidate = new URL(specifier + ext, base);
+      if (await fileExists(candidate)) {
+        return nextResolve(specifier + ext, context);
+      }
+    }
+    throw err;
+  }
+}

--- a/scripts/bench-rag-retrieve.mjs
+++ b/scripts/bench-rag-retrieve.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * bench-rag-retrieve.mjs — benchmark de latencia del retrieve BM25.
+ *
+ * Mide el costo de `retrieve(query, topK)` sobre el corpus real (491+ species
+ * en public/cycle-content/). Útil para verificar el efecto del fix de
+ * pre-tokenize (2026-05-20): antes scoreBM25 re-tokenizaba cada doc por
+ * query (500ms-2s blocking), ahora usa termCounts pre-computados (~ms).
+ *
+ * Uso:
+ *   node scripts/bench-rag-retrieve.mjs
+ *
+ * No usa Vitest. Stubea `fetch` con `fs.readFile` para servir el corpus
+ * desde public/cycle-content/, simulando el flujo de carga del PWA.
+ *
+ * Output: timings cold load + N queries warm + percentiles.
+ */
+import { readFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CORPUS_ROOT = join(__dirname, '..', 'public', 'cycle-content');
+
+// El repo usa imports estilo Vite sin extensión `.js` (ej.
+// `from '../config/taxonomy'`). Node nativo exige extensión, así que
+// registramos un loader local con un customization hook.
+//
+// Implementado como script separado porque `register()` debe correr antes
+// del import. Ver scripts/bench-rag-retrieve.loader.mjs para el hook.
+
+// Stub global.fetch para que ragRetriever.js pueda cargar desde el FS.
+globalThis.fetch = async (url) => {
+  const u = String(url);
+  // Ruta relativa /cycle-content/foo.json → file en disco.
+  const m = u.match(/\/cycle-content\/(.+)$/);
+  if (!m) {
+    return { ok: false, status: 404, headers: { get: () => '' }, json: async () => ({}) };
+  }
+  const file = join(CORPUS_ROOT, m[1]);
+  try {
+    const buf = await readFile(file, 'utf-8');
+    const data = JSON.parse(buf);
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+      json: async () => data,
+    };
+  } catch (_) {
+    return { ok: false, status: 404, headers: { get: () => '' }, json: async () => ({}) };
+  }
+};
+
+const QUERIES = [
+  'fresa cuidados clima frío',
+  'café arábica sombra parcial roya',
+  'lechuga bolting hortaliza',
+  'maíz siembra suelo asociación frijol',
+  'aguacate poda fertilización clima cálido',
+  'banano sigatoka manejo sombra',
+  'plátano hartón cosecha tiempo',
+  'tomate plagas mosca blanca control biológico',
+  'arroz drenaje suelo manejo agua',
+  'yuca propagación esquejes suelos arcillosos',
+];
+
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+async function main() {
+  // Import dinámico para que el stub de fetch ya esté en su lugar.
+  const { retrieve, getCorpusStats } = await import('../src/services/ragRetriever.js');
+
+  // Cold load: la primera query carga manifest + 491 fetches + tokenize.
+  console.log('[bench] Cold load: cargando corpus completo + primera query…');
+  const coldStart = performance.now();
+  const firstHits = await retrieve(QUERIES[0], 5, 'bench');
+  const coldMs = performance.now() - coldStart;
+  const stats = await getCorpusStats();
+  console.log(`[bench] Cold load: ${coldMs.toFixed(1)} ms`);
+  console.log(`[bench] Corpus: ${stats.totalDocs} docs, ${stats.uniqueTerms} terms únicos, avgDocLen=${stats.avgDocLen}`);
+  console.log(`[bench] Primera query devolvió ${firstHits.length} hits (top score=${firstHits[0]?.score?.toFixed(3) ?? 'n/a'})`);
+  console.log('');
+
+  // Warm: cada query a corpus ya cacheado. Esto es lo que mide el hot path.
+  const ITERATIONS = 3;
+  const timings = [];
+  console.log(`[bench] Warm: ${QUERIES.length} queries × ${ITERATIONS} iteraciones…`);
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    for (const q of QUERIES) {
+      const t0 = performance.now();
+      await retrieve(q, 5, 'bench');
+      const t1 = performance.now();
+      timings.push(t1 - t0);
+    }
+  }
+  timings.sort((a, b) => a - b);
+  const total = timings.reduce((s, t) => s + t, 0);
+  console.log(`[bench] Warm: n=${timings.length}`);
+  console.log(`[bench]   min   = ${timings[0].toFixed(2)} ms`);
+  console.log(`[bench]   p50   = ${percentile(timings, 50).toFixed(2)} ms`);
+  console.log(`[bench]   p95   = ${percentile(timings, 95).toFixed(2)} ms`);
+  console.log(`[bench]   max   = ${timings[timings.length - 1].toFixed(2)} ms`);
+  console.log(`[bench]   avg   = ${(total / timings.length).toFixed(2)} ms`);
+
+  // Estimación de memoria extra del pre-tokenize:
+  // Heurística — cada token es un string ~8B (small string), termCounts Map
+  // ~32B por entrada. avgDocLen tokens × totalDocs.
+  const tokensTotal = stats.totalDocs * stats.avgDocLen;
+  const memEstKB = (tokensTotal * 16 + stats.totalDocs * 64) / 1024;
+  console.log(`[bench]   memoria extra estimada del pre-tokenize: ~${(memEstKB / 1024).toFixed(2)} MB`);
+}
+
+main().catch((err) => {
+  console.error('[bench] FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/bench-rag-retrieve.register.mjs
+++ b/scripts/bench-rag-retrieve.register.mjs
@@ -1,0 +1,6 @@
+// Registrador del loader hook para bench-rag-retrieve.mjs.
+// Se invoca vía `node --import ./scripts/bench-rag-retrieve.register.mjs ...`.
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('./bench-rag-retrieve.loader.mjs', pathToFileURL('./scripts/'));

--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -151,3 +151,85 @@ describe('ragRetriever — corpus extendido v2', () => {
     });
   });
 });
+
+/**
+ * Cobertura del fix de pre-tokenize (perf BM25, 2026-05-20).
+ *
+ * El refactor mueve `tokenize(doc.text)` desde scoreBM25 (hot path, una vez
+ * por query × por doc) a loadCorpus (cold path, una vez por boot). Estos
+ * tests verifican:
+ *   - retrieve sigue devolviendo docs con shape público esperado.
+ *   - score > 0 cuando hay match.
+ *   - El shape devuelto NO incluye las estructuras internas de scoring
+ *     (`tokenized`, `termCounts`, `docLen`) — solo species/text/key/score.
+ *   - retrieve es determinístico (mismo input → mismo output).
+ */
+describe('ragRetriever — pre-tokenize perf fix', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setupFetchMock();
+  });
+
+  afterEach(() => {
+    delete globalThis.fetch;
+    vi.clearAllMocks();
+  });
+
+  it('retrieve("fresa") devuelve docs con score>0 y shape público {species, text, key, score}', async () => {
+    const { retrieve } = await import('../ragRetriever.js');
+    const hits = await retrieve('fresa rosácea perenne estolones', 5, 'voice');
+    expect(hits.length).toBeGreaterThan(0);
+    hits.forEach((h) => {
+      expect(h.score).toBeGreaterThan(0);
+      expect(typeof h.species).toBe('string');
+      expect(typeof h.text).toBe('string');
+      expect(typeof h.key).toBe('string');
+      // El refactor cambió `{...doc, score}` por proyección explícita.
+      // No deben filtrarse estructuras internas de scoring.
+      expect(h).not.toHaveProperty('tokenized');
+      expect(h).not.toHaveProperty('termCounts');
+      expect(h).not.toHaveProperty('docLen');
+    });
+  });
+
+  it('retrieve es determinístico — dos llamadas con el mismo query devuelven mismos hits y mismo orden', async () => {
+    const { retrieve } = await import('../ragRetriever.js');
+    const q = 'café arábica sombra parcial altitud roya';
+    const a = await retrieve(q, 5);
+    const b = await retrieve(q, 5);
+    expect(a.length).toBe(b.length);
+    a.forEach((hit, i) => {
+      expect(b[i].species).toBe(hit.species);
+      expect(b[i].key).toBe(hit.key);
+      expect(b[i].score).toBe(hit.score);
+    });
+  });
+
+  it('retrieve respeta topK y ordena por score descendente', async () => {
+    const { retrieve } = await import('../ragRetriever.js');
+    const hits = await retrieve('fresa café lechuga clima frío hortaliza', 3);
+    expect(hits.length).toBeLessThanOrEqual(3);
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i - 1].score).toBeGreaterThanOrEqual(hits[i].score);
+    }
+  });
+
+  it('retrieve con query vacío o solo stopwords devuelve []', async () => {
+    const { retrieve } = await import('../ragRetriever.js');
+    const empty = await retrieve('', 5);
+    expect(empty).toEqual([]);
+    // tokens <=2 chars son filtrados por tokenize.
+    const tiny = await retrieve('a b c', 5);
+    expect(tiny).toEqual([]);
+  });
+
+  it('getCorpusStats refleja avgDocLen pre-computado', async () => {
+    const { retrieve, getCorpusStats } = await import('../ragRetriever.js');
+    // Forzar carga de corpus.
+    await retrieve('fresa', 1);
+    const stats = await getCorpusStats();
+    expect(stats.totalDocs).toBeGreaterThan(0);
+    expect(stats.uniqueTerms).toBeGreaterThan(0);
+    expect(stats.avgDocLen).toBeGreaterThan(0);
+  });
+});

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -25,7 +25,10 @@ function tokenize(text) {
 function buildInvertedIndex(docs) {
   const df = new Map();
   docs.forEach((doc) => {
-    const terms = new Set(tokenize(doc.text));
+    // Cada doc trae `tokenized` ya pre-computado en loadCorpus.
+    // Usamos Set para contar document frequency (DF) — un término que
+    // aparece N veces en el mismo doc cuenta como 1 para DF.
+    const terms = new Set(doc.tokenized);
     terms.forEach((term) => {
       df.set(term, (df.get(term) || 0) + 1);
     });
@@ -41,13 +44,19 @@ function computeIDF(df, N) {
   return idf;
 }
 
+/**
+ * Calcula score BM25 contra un doc.
+ *
+ * Requiere que `doc` traiga pre-computados `termCounts: Map<term, count>` y
+ * `docLen: number` (lo hace `loadCorpus` una sola vez en carga del corpus).
+ * Antes esta función re-tokenizaba el texto del doc en cada query × cada doc,
+ * generando 500ms–2s de bloqueo del main thread con 5K–15K passages y query
+ * de 4 términos. El pre-tokenize bajó el costo a O(|queryTerms|) por doc.
+ */
 function scoreBM25(doc, queryTerms, idf, avgLen) {
-  const docTerms = tokenize(doc.text);
-  const docLen = docTerms.length;
-  const termCounts = new Map();
-  docTerms.forEach((t) => termCounts.set(t, (termCounts.get(t) || 0) + 1));
-
   let score = 0;
+  const docLen = doc.docLen;
+  const termCounts = doc.termCounts;
   queryTerms.forEach((term) => {
     const tf = termCounts.get(term) || 0;
     if (tf > 0) {
@@ -126,6 +135,17 @@ async function loadCorpus() {
       const data = await res.json();
       const passages = flattenDoc(data);
       passages.forEach((p) => {
+        // Pre-tokenize cada passage una sola vez en carga del corpus.
+        // Trade-off de memoria: ~2-5MB extra para 10K docs con ~50 tokens promedio
+        // (tokenized[] + termCounts Map). Aceptable a cambio de evitar re-tokenizar
+        // 5K-15K docs × cada query (que bloqueaba el main thread 500ms-2s y
+        // generaba la latencia post-voz que motivó este fix).
+        const tokenized = tokenize(p.text);
+        const termCounts = new Map();
+        tokenized.forEach((t) => termCounts.set(t, (termCounts.get(t) || 0) + 1));
+        p.tokenized = tokenized;
+        p.termCounts = termCounts;
+        p.docLen = tokenized.length;
         docs.push(p);
       });
     } catch (e) {
@@ -133,7 +153,7 @@ async function loadCorpus() {
     }
   }
 
-  const totalLen = docs.reduce((sum, d) => sum + tokenize(d.text).length, 0);
+  const totalLen = docs.reduce((sum, d) => sum + d.docLen, 0);
   avgDocLen = docs.length > 0 ? totalLen / docs.length : 1;
 
   const df = buildInvertedIndex(docs);
@@ -153,8 +173,13 @@ async function retrieveInternal(query, topK) {
 
   if (queryTerms.length === 0) return [];
 
+  // Project explícito: NO spreedeamos `...doc` porque ahora trae `tokenized`,
+  // `termCounts` y `docLen` (estructuras de scoring interno). Devolvemos solo
+  // los campos públicos que los callers consumen (species, text, key, score).
   const scored = docs.map((doc) => ({
-    ...doc,
+    species: doc.species,
+    text: doc.text,
+    key: doc.key,
     score: scoreBM25(doc, queryTerms, idf, avgDocLen),
   }));
 


### PR DESCRIPTION
## Summary

- **Sintoma:** post-voz el texto del LLM aparece (typewriter) pero la UI con companions/antagonists/biopreparados tarda 1-4s mas en pintar.
- **Causa raiz:** `scoreBM25` en `src/services/ragRetriever.js` re-tokenizaba `doc.text` en cada query x cada doc. Con 491 species - 8452 passages, una query de 4 terminos bloqueaba el main thread ~75ms por retrieve. `voiceRagEnricher` hace `Promise.all` sobre N entities, el bloqueo se multiplica.
- **Fix #1 del diagnostico:** mover el `tokenize(doc.text)` desde el hot path (scoreBM25) al cold path (loadCorpus). Cada passage trae ahora `termCounts`, `docLen` y `tokenized` pre-computados. `scoreBM25` queda O(|queryTerms|) por doc.

## Bench (corpus real, 491 species, 8452 docs)

| Metric  | Antes    | Despues | Speedup |
|---------|----------|---------|---------|
| min     | 75.2 ms  | 2.1 ms  | 36x     |
| p50     | 76.9 ms  | 2.6 ms  | 30x     |
| p95     | 81.9 ms  | 4.0 ms  | 20x     |
| avg     | 77.5 ms  | 2.7 ms  | 28x     |

Cold load: 231 ms (manifest + 491 fetches + tokenize de 8452 passages, idempotente solo en boot).

Memoria extra estimada: **~3.4 MB** (tokenized array + termCounts Map). Aceptable.

## Cambios

- `src/services/ragRetriever.js`:
  - `loadCorpus`: pre-computa `tokenized`, `termCounts`, `docLen` por passage.
  - `scoreBM25`: simplificado, lee directo de `doc.termCounts` y `doc.docLen`.
  - `buildInvertedIndex`: usa `doc.tokenized` en vez de re-tokenizar.
  - `retrieveInternal`: proyeccion explicita `{species, text, key, score}` para no filtrar estructuras internas al API publico.
- `src/services/__tests__/ragRetriever.test.js`: +5 tests (shape, determinismo, topK, query vacio, getCorpusStats). Los 4 tests preexistentes siguen pasando.
- `scripts/bench-rag-retrieve.*`: script Node puro para medir latencia retrieve sobre corpus real.

## Test plan

- [x] `npx vitest run src/services/__tests__/ragRetriever.test.js` - 9 passed
- [x] Tests RAG-related adicionales (voiceRagEnricher, ragTelemetry, ragWithPhotos, guildServiceRag, aiService, caseStudyLessonsSummarizer, speciesResolver) - all green
- [x] `npm run build` - green
- [x] `npx eslint` sobre archivos tocados - clean
- [ ] Verificacion manual en demo: grabar audio voz mencionando 2-3 species, verificar que la UI de companions aparece <300ms post-typewriter.

## Riesgos

- API publica de `retrieve()` cambio sutilmente: antes spreedeaba `...doc` (`{species, text, key, score, ...}`), ahora proyecta solo `{species, text, key, score}`. Los 8 callers internos solo usan esos campos, validado por grep. Si algun consumer externo dependia de campos adicionales (no encontrados), romperia.
- Memoria del `corpusCache` crece ~3.4 MB. En mobile rural offline-first esto es aceptable pero hay que monitorear si aparece presion de memoria en devices muy limitados.

Generated with Claude Code
