### PR TITLE
feat(multifinca): tenant scoping MVP — assets + logs + case studies

### DIFF
--- a/catalog/chagra-catalog-oss-subset-v3.1.json
+++ b/catalog/chagra-catalog-oss-subset-v3.1.json
@@ -1,0 +1,4267 @@
+{
+  "_meta": {
+    "fuente_migracion": "chagra-catalog-seed-v3.0.json",
+    "ambiguedades_resueltas": [
+      "AMB-01: gremio eliminado, roles_in_guild único campo",
+      "AMB-02: thermal_zones plural array (ya era en v3.0)",
+      "AMB-03: español en todos los campos (ya era en v3.0)",
+      "AMB-05: altitud_msnm chain validada por validate-catalog.mjs",
+      "AMB-06: heladas_tolerancia como objeto (ya era en v3.0)",
+      "AMB-07: production (string) → harvest_type (enum)",
+      "AMB-08: NPK como objeto {min,max,unidad} (ya era en v3.0)",
+      "AMB-09: biopreparados_seed.json catálogo auxiliar con 15 ids",
+      "AMB-10: simetría companions/antagonists validada por CI",
+      "AMB-11/16: sources_seed.json catálogo auxiliar con ~30 fuentes",
+      "AMB-12: prompts_ia_externa objeto con 5 slots estándar",
+      "AMB-13: cross-refs validadas por CI (seed-mode downgrade a warning)",
+      "AMB-14: consistencia invasor aplicada en migración",
+      "AMB-15: scale_viability + manejo_por_escala con CI de coherencia"
+    ],
+    "alcance_seed": "7 especies migradas desde v3.0. Las DRs por piso térmico poblarán hasta ~400 especies totales (100 × 4 pisos).",
+    "advertencia": "Validar con: node scripts/validate-catalog.mjs --seed-mode. Refs a species aún no migradas aparecen como warnings."
+  },
+  "schema_version": "3.1",
+  "seed_version": "0.2.0-oss-subset",
+  "generated_at": "2026-05-21T00:31:06.539Z",
+  "generated_by": "scripts/extract-oss-subset.mjs",
+  "_subset_meta": {
+    "subset_name": "oss-subset-50",
+    "source_file": "chagra-catalog-seed-v3.1.json",
+    "species_count": 50,
+    "sources_count": 32,
+    "license": "CC-BY-NC-SA 4.0",
+    "rationale": "Subset representativo multi-piso (12 cálidas + 13 templadas + 13 frías + 12 páramo/altoandinas) para uso OSS público bajo CC-BY-NC-SA. Catálogo full queda reserved para chagra-pro post-cutover. Plan detallado: Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md."
+  },
+  "species": [
+    {
+      "id": "allium_cepa",
+      "nombre_comun": "Cebolla cabezona",
+      "nombre_cientifico": "Allium cepa L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 13,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "En la chagra chiguana se prefiere la siembra por bulbitos (cebollín de siembra) para acelerar el ciclo."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La cebolla cabezona (Allium cepa L.) se cultiva en diversos departamentos de Colombia, incluyendo Cundinamarca, Boyacá, Nariño y Antioquia, entre 0 y 3500 msnm, con óptimo entre 1500 y 2800 msnm en zonas térmicas frías y templadas. Su manejo agronómico incluye propagación por semilla o bulbitos (cebollín de siembra) para acelerar el ciclo, con un ciclo vegetativo de 90-120 días, asociaciones beneficiosas con zanahoria y lechuga que mejoran la salud del huerto, y requiere manejo de plagas como trips, minadores de hojas y áfidos mediante monitoreo frecuente y biopreparados andinos. En el contexto campesino andino, esta hortaliza ha sido tradicionalmente utilizada en guisos, sopros y ensaladas como ingrediente esencial, preservando sabores prehispánicos en las cocinas rurales. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Allium cepa L.",
+      "feeding_plan_template": {
+        "source": "ICA Guía fertilizantes (2019) + Restrepo (1996). Cebolla cabezona clima frío altiplano cundiboyacense, ciclo 5-6 meses.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Incorporar bocashi + ceniza al surco",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 100,
+            "notes": "Surco preparado 0-15 cm. Complementar con 50 g/m² de ceniza_madera para aporte K y prevención de mildiú."
+          },
+          {
+            "offset_days": 20,
+            "action": "Foliar con biol fase macollamiento",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Estimula desarrollo foliar antes de inicio de bulbificación."
+          },
+          {
+            "offset_days": 45,
+            "action": "Foliar con purín de ortiga preventivo",
+            "biofertilizer_slug": "purin_ortiga",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Repelente preventivo de trips (Thrips tabaci) — vector de virus IYSV en cebolla."
+          },
+          {
+            "offset_days": 75,
+            "action": "Drench con humus líquido inicio bulbificación",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Aporte de aminoácidos para llenado de bulbo."
+          },
+          {
+            "offset_days": 105,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 0.5%. Preventivo Peronospora destructor (mildiú velloso) en época lluviosa."
+          },
+          {
+            "offset_days": 135,
+            "action": "Suspender riego para curado de bulbo",
+            "notes": "Reducir riego 70% en últimas 3 semanas antes de cosecha. Curado in situ mejora conservación post-cosecha."
+          }
+        ]
+      },
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "allium_fistulosum",
+      "nombre_comun": "Cebollín / Cebolla larga",
+      "nombre_cientifico": "Allium fistulosum L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Se dividen los macollos (hijuelos) para una propagación rápida y perenne."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "Allium fistulosum, conocida como cebolla larga o cebollín, es una aliácea hortícola perenne ampliamente cultivada en el cinturón agrícola de Cundinamarca, particularmente en las zonas de Aquitania y Sumapaz, donde abastece los mercados de Bogotá entre 1800 y 2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación mediante división de bulbillos (hijuelos) cada 4 meses para cosecha permanente, asociaciones beneficiosas con zanahoria y lechuga que mejora la salud del huerto, y requiere manejo de plagas como trips y manchas foliares mediante monitoreo frecuente y biopreparados andinos. En el contexto campesino andino, esta cebolla ha sido tradicionalmente utilizada en sofritos y guisos como base aromática esencial, preservando sabores prehispánicos en las cocinas rurales de Cundinamarca y Boyacá. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Allium fistulosum L.",
+      "antagonists": [
+        "phaseolus_vulgaris"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "allium_sativum",
+      "nombre_comun": "Ajo",
+      "nombre_cientifico": "Allium sativum L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "clavo_bulbo",
+        "notas": "Se siembran los 'dientes' o clavos individuales con el ápice hacia arriba."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El ajo (Allium sativum L.) se cultiva en diversos departamentos de Colombia incluyendo Cundinamarca, Boyacá, Nariño y Antioquia entre 0 y 3400 msnm en zonas térmicas frías y templadas. Su manejo agronómico incluye propagación por clavos bulbillos (dientes) sembrados con el ápice hacia arriba, ciclo vegetativo de 90-120 días, asociaciones beneficiosas con zanahoria, lechuga y fresas que repelen plagas como áfidos y ácaros, y requiere monitoreo de plagas como el nemátodo del tallo y enfermedades como la pudrición blanca. En el contexto cultural muisca y andino, este bulbo ha sido tradicionalmente utilizado tanto en preparaciones culinarias como en remedios medicinales por sus propiedades antibacterianas y antifúngicas, formando parte esencial de la dieta y la medicina tradicional andina. Según fuentes taxonómicas verificadas de GBIF Backbone Taxonomy, Plants of the World Online (POWO), AGROSAVIA Sol Andina y la ICA Resolución 3168/2015, su nombre científico válido es Allium sativum L.",
+      "feeding_plan_template": {
+        "source": "Pinheiro-Machado (2017) Biofertilizantes + Restrepo (2007) Biopreparados. Ajo clima frío altiplano, ciclo 6-7 meses.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + ceniza al surco",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 150,
+            "notes": "Surco 0-15 cm. Sembrar dientes con punta hacia arriba. Ajo requiere suelo bien drenado y rico en MO."
+          },
+          {
+            "offset_days": 25,
+            "action": "Foliar con biol fase de brotación",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Estimula desarrollo foliar inicial post-emergencia."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con humus líquido",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 200,
+            "notes": "Dilución 1:5. Aporte de aminoácidos antes de inicio de bulbificación."
+          },
+          {
+            "offset_days": 100,
+            "action": "Foliar con supermagro inicio bulbificación",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 50,
+            "notes": "Dilución 1:20. Corrección micronutrientes — S y Zn críticos para llenado de bulbo."
+          },
+          {
+            "offset_days": 130,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 80,
+            "notes": "Concentración 0.5%. Preventivo roya (Puccinia allii) en épocas húmedas."
+          },
+          {
+            "offset_days": 165,
+            "action": "Suspender riego para maduración",
+            "notes": "Reducir riego 70% últimas 3 semanas. Tumbado de follaje = señal de cosecha próxima (180-210 días)."
+          }
+        ]
+      },
+      "antagonists": [
+        "vicia_sativa"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "alnus_acuminata",
+      "_curation_status": "VALIDADO con fuentes CIAT/AGROSAVIA",
+      "nombre_comun": "Aliso andino",
+      "nombre_comunes_regionales": [
+        "aliso",
+        "cerezo (cordillera oriental)",
+        "jaul (algunas zonas)"
+      ],
+      "nombre_cientifico": "Alnus acuminata Kunth",
+      "familia_botanica": "Betulaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "living_fence",
+        "windbreak",
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "cycleMonths": null,
+      "habito": "arbol deciduo semicaducifolio, 15-25m altura",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 8,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "humedad_relativa_pct": {
+        "min": 60,
+        "optimo": 80,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.5,
+        "optimo_max": 6.8,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "companions": [
+        "cenchrus_clandestinus_manejado",
+        "coffea_arabica",
+        "erythrina_edulis",
+        "lupinus_mutabilis",
+        "passiflora_tripartita_mollissima",
+        "quercus_humboldtii",
+        "solanum_phureja",
+        "trifolium_repens",
+        "vicia_faba",
+        "weinmannia_tomentosa"
+      ],
+      "antagonists": [],
+      "recommended_covers": [
+        "trifolium_repens",
+        "vicia_sativa"
+      ],
+      "recommended_fences": [
+        "sambucus_peruviana",
+        "dodonaea_viscosa"
+      ],
+      "fence_function": [
+        "rompevientos",
+        "delimitacion",
+        "sombra",
+        "refugio_fauna"
+      ],
+      "densidad_siembra_fence_m": 2.5,
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla recolectada de amentos maduros (marzo-mayo en cordillera oriental). Estratificación fría opcional 30 días. Germinación en bandejas con sustrato: 60% tierra negra + 30% arena + 10% compost maduro. Trasplante a bolsa negra 1.5kg a las 6 semanas. Plantación definitiva a los 4-6 meses (altura 30-40cm).",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Actinorrícica: forma nódulos fijadores de N con Frankia alni. Inoculación con suelo de aliso adulto acelera establecimiento.",
+        "fuente": "CIAT 1995 'El aliso (Alnus acuminata) en sistemas silvopastoriles'; Corpoica (AGROSAVIA) varios"
+      },
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol de 15-25m no apto para apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Como cerca viva o sombra puntual. Un solo árbol por huerto pequeño.",
+          "tips": [
+            "Plantar en esquina noroeste para sombra de tarde sin bloqueo solar mañanero",
+            "Podas anuales para mantener forma"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta por tamaño."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Ideal para sistemas silvopastoriles (20-40 árboles/ha) o como linderos entre lotes. Fija 150-300 kg N/ha/año según densidad y edad.",
+          "tips": [
+            "Densidad 10x10m o lindero a 2.5m",
+            "Podas de formación años 2-3 y posteriores cada 3 años"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "ESPECIE CLAVE para restauración de bosque alto andino y bordes de páramo. Nurse plant para especies de sotobosque. Recuperación de taludes degradados.",
+          "tips": [
+            "Plantación asociada a Weinmannia tomentosa y Escallonia paniculata",
+            "Densidad restauración: 1100 individuos/ha (3x3m)",
+            "Protección contra ganado primeros 3 años"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plan_nutricion_base": null,
+      "_nota_nutricion": "Como árbol fijador de N, no requiere plan de fertilización estándar. Aporta N al sistema. Solo monitoreo de P y K en suelos muy pobres durante establecimiento.",
+      "tests_suelo_recomendados": [
+        {
+          "tipo": "ph_casero",
+          "rango_objetivo": "5.5-6.8",
+          "frecuencia": "pre-siembra"
+        },
+        {
+          "tipo": "conteo_nodulos",
+          "frecuencia": "año 1 post-establecimiento",
+          "objetivo": "verificar nodulación por Frankia alni; objetivo >20 nódulos en raíz principal a 30cm profundidad"
+        }
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_restauracion": "Actúa como ecólogo de restauración de bosque alto andino colombiano.\nÁrea: {AREA_HA} ha a {ALTITUD} msnm en {MUNICIPIO}, pendiente {PENDIENTE}%, suelo degradado por {HISTORIAL_USO}. Quiero restaurar con Alnus acuminata como especie nodriza asociada a {ESPECIES_OBJETIVO}.\n\nDiseña: (a) marco de plantación y espaciamiento, (b) secuencia de establecimiento por fases (pioneras 1-3 años, secundarias 3-8 años, climácicas 8+ años), (c) protocolo de protección contra ganado, (d) indicadores de éxito de restauración a 1, 3, 5 años."
+      },
+      "rol_ecologico": "Especie nodriza clave en restauración de bosque alto andino. Fija nitrógeno simbiótico con actinomiceto Frankia alni. Hojas ricas en N mejoran el mantillo. Madera usada tradicionalmente para herramientas, construcciones rurales y leña. Corteza con taninos para curtiembre.",
+      "valor_pedagogico": "El aliso andino (Alnus acuminata Kunth) es una betulácea árbol nativo de los Andes ampliamente usada en sistemas agroforestales colombianos por su capacidad fijadora de nitrógeno (~150-200 kg N/ha/año mediante simbiosis con Frankia, actinorrhizas). Se distribuye naturalmente en Cundinamarca, Boyacá (cordillera Oriental), Antioquia, Cauca, Nariño y Tolima entre 1.500 y 3.200 msnm en zona térmica fría. Árbol caducifolio puede alcanzar 20-25 m, copa rala que permite paso de luz a cultivos asociados. Vida productiva 30-50 años. Manejo agroecológico: asocio café (sombra + N), sistemas silvopastoriles con pasturas naturalizadas, riberas microcuencas (estabilización suelo + sombra agua), barreras rompevientos en franjas anchas, restauración bosque altoandino. Madera blanda para artesanías locales. Fuentes Tier A: AGROSAVIA, Catálogo Plantas y Líquenes Colombia (Bernal et al.), POWO Kew, GBIF Backbone Taxonomy.",
+      "saber_origen": {
+        "pueblo": "Pueblos andinos (uso generalizado Muisca, Pasto, Inga)",
+        "region": "Andes colombianos 1800-3600 msnm",
+        "practica_original": "Uso en linderos tradicionales de aynokas, sombra para ganado, leña, reparación de taludes ribereños. Asociación con cultivos de frío (papa, maíz de altura, haba).",
+        "validacion_cientifica_source_ids": [
+          "ciat-1995-alnus",
+          "agrosavia-silvopastoriles"
+        ]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "Especie nativa andina ampliamente documentada. Datos consolidados.",
+      "harvest_type": "biomasa",
+      "validation_level": "operator_reviewed",
+      "source_ids": [
+        "ciat-1995-alnus",
+        "agrosavia-silvopastoriles",
+        "humboldt-flora-alto-andina"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "beta_vulgaris_conditiva",
+      "nombre_comun": "Remolacha",
+      "nombre_cientifico": "Beta vulgaris L. subsp. vulgaris Conditiva Group",
+      "familia_botanica": "Amaranthaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Los glomérulos contienen varias semillas; el trasplante debe ser muy cuidadoso para no dañar la raíz incipiente."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "restrepo-1996-abc-agricultura-organica",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La remolacha o betarraga (Beta vulgaris L. subsp. vulgaris Conditiva Group) es una quenopodiácea bienal cultivada como anual por su raíz hipocotila engrosada rica en azúcares, betalaínas (pigmentos antioxidantes) y nitratos vegetales. Hortaliza tradicional de huertas andinas colombianas. Se cultiva en Sabana de Bogotá (Mosquera, Madrid, Funza), Boyacá altiplano (Tunja, Duitama), Nariño y Antioquia entre 1.800 y 2.900 msnm en zona térmica fría. Ciclo 90-120 días desde siembra directa hasta raíz comercial (5-10 cm diámetro). Rendimientos 25-40 t/ha. Lección viva: muestra cómo la planta acumula reservas en raíz hipocotila para sobrevivir período seco o frío. Manejo agroecológico: siembra directa a chorrillo, aclareo a 10-15 cm planta, suelos francos profundos pH 6.5-7.5, fertilización con compost + bocashi al fondo, asocio con lechugas y zanahorias en cama mixta, control de minador hoja (Pegomya betae) con purín de ortiga + caldo sulfocálcico. Fuentes Tier A: ICA Resolución 3168/2015, Restrepo 1996 ABC Agricultura Orgánica, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "brassica_oleracea_acephala_curly",
+      "nombre_comun": "Kale rizado verde",
+      "nombre_cientifico": "Brassica oleracea var. acephala 'Curly'",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -12,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se recomienda sembrar escalonadamente; extremadamente resistente a la manipulación."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "valor_pedagogico": "El kale rizado (Brassica oleracea var. acephala DC 'Curly') es una Brassicaceae de hoja rizada de origen europeo introducida a los Andes colombianos durante la Colonia. En Colombia se cultiva principalmente en departamentos de clima frío y templado como Cundinamarca (valle de Ubaqué-Choachí), Boyacá, Nariño, Putumayo y el altiplano cundiboyacense, en altitudes entre 1800 y 2800 msnm (rango efectivo 1000-3500 msnm), en zonas térmicas frío y templado con temperaturas óptimas entre 10°C y 18°C. Su manejo agronómico incluye propagación por semilla en semillero, ciclo de vegetativo de 60-90 días hasta primera cosecha, y se asocia tradicionalmente con otras brassicáceas como el repollo y la coliflor, así como en sistemas de policultivo con especies de ciclo corto como radícheta y espinaca. Las principales plagas incluyen pulgones (Brevicoryne brassicae), mosca minadora (Liriomyza spp.) y oruga de la col (Pieris rapae), mientras que las enfermedades críticas son la hernia de la col (Plasmodiophora brassicae) y mildiu velloso (Peronospora parasitica). Culturalmente, esta especie se ha integrado en la dieta campesina andina desde el siglo XVI, utilizándose en preparaciones como hervidos, jugos verdes, sautés y como ingrediente nutricional por su alto contenido en vitaminas A, C, K y antioxidantes. Fuente: nrc-1989-cultivos-andinos.",
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "brassica_oleracea_capitata_alba",
+      "nombre_comun": "Repollo blanco",
+      "nombre_cientifico": "Brassica oleracea var. capitata L.",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere semillero. El trasplante debe ser profundo para asegurar estabilidad."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El repollo blanco (Brassica oleracea var. capitata L.) se cultiva ampliamente en los departamentos andinos de Colombia como Cundinamarca, Boyacá, Nariño y Antioquia entre 800 y 3000 msnm en zonas térmicas fría y templada. Su manejo agronómico incluye propagación por semilla en semillero seguido de trasplante profundo para asegurar estabilidad, con un ciclo de cultivo de 90-120 días, se asocia beneficiosamente con zanahoria y cebolla para reducir plagas como áfidos y lepidópteros, y requiere monitoreo de plagas como mosca blanca y gusanos del repollo. En el contexto campesino andino, esta crucífera ha sido tradicionalmente utilizada en soplos, ensaladas y preparaciones fermentadas como base alimenticia esencial, preservando sabores prehispánicos en las cocinas rurales de los Andes colombianos. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Brassica oleracea var. capitata L.",
+      "antagonists": [
+        "solanum_lycopersicum_san_marzano",
+        "vaccinium_corymbosum_biloxi"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "calendula_officinalis",
+      "nombre_comun": "Caléndula",
+      "nombre_cientifico": "Calendula officinalis L.",
+      "nombre_comunes_regionales": [
+        "Margarita dorada"
+      ],
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1200,
+        "optimo_max": 2500,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se resiembra sola con facilidad; sus raíces secretan sustancias que controlan nematodos en el suelo."
+      },
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "antagonists": [],
+      "valor_pedagogico": "La Caléndula (Calendula officinalis L.) es una especie ornamental-medicinal originaria del Mediterráneo, ampliamente cultivada en jardines campesinos de Cundinamarca entre 0-2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con ciclo de floración de 75-90 días, asociándose beneficiosamente con cultivos como el tomate (Solanum lycopersicum) mientras actúa como repelente natural de trips y nemátodos mediante secreciones radiculares. En el contexto cultural andino-campesino, sus flores se utilizan tradicionalmente en preparaciones de crema cicatrizante por sus propiedades flavonoides, saponinas y aceites esenciales. Según GBIF Backbone Taxonomy y Plants of the World Online (POWO), esta especie destaca por su valor ecológico en atracción de polinizadores y manejo integrado de plagas en sistemas agroecológicos de montaña.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "jbb-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft",
+      "estrato": "medio",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "chenopodium_quinoa",
+      "nombre_comun": "Quinua",
+      "nombre_cientifico": "Chenopodium quinoa Willd.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Cosechar cuando el tallo cambie de color y el grano esté duro (no se deje rayar con la uña)."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-leguminosas-andinas",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "valor_pedagogico": "La quinua (Chenopodium quinoa Willd.) es un pseudocereal andino tradicional con alto valor proteico (~14-18%) y aminoácidos esenciales, redescubierta como cultivo estratégico de seguridad alimentaria. En Colombia se cultiva en Boyacá, Nariño, Cundinamarca y Cauca entre 2.500 y 3.500 msnm en zona térmica fría a páramo bajo. Las variedades AGROSAVIA Aurora, Tunkahuán y Blanca de Jericó están adaptadas al altiplano cundiboyacense con ciclo 5-6 meses. Tolera salinidad moderada, sequía y heladas leves (-2°C en estados vegetativos). Manejo agroecológico: rotación con leguminosas, fertilización orgánica con bocashi y biol, control mecánico de mildiú (Peronospora variabilis) por densidad de siembra adecuada (60-80 cm entre surcos). Fuentes Tier A: AGROSAVIA fichas técnicas, FAO Quinoa Sourcebook 2013, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "companions": [
+        "vicia_sativa",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "coffea_arabica",
+      "nombre_comun": "Café caturra / Castillo / Cenicafé 1",
+      "nombre_cientifico": "Coffea arabica L.",
+      "nombre_comunes_regionales": [
+        "Café Supremo (categoría comercial)",
+        "Café Arábigo"
+      ],
+      "familia_botanica": "Rubiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 180,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 2000,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 6,
+        "max": 6.5
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 2,
+        "horas_acumuladas_max": 0,
+        "notes": "Altamente sensible a heladas; las bajas temperaturas afectan la calidad del grano."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "erythrina_edulis"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere germinador en arena y posterior embolsado."
+      },
+      "valor_pedagogico": "El café arábica (Coffea arabica L.) es el cultivo agroindustrial emblemático de Colombia y la principal fuente de ingresos de la economía campesina cafetera, con cerca de 850.000 hectáreas distribuidas en Caldas, Quindío, Risaralda, Antioquia, Tolima, Huila, Cundinamarca y Santander entre 1.200 y 2.000 msnm en zona térmica templada. Las variedades Caturra, Castillo y Cenicafé 1 son las más adoptadas en Colombia por su resistencia a roya (Hemileia vastatrix) y broca (Hypothenemus hampei) según Cenicafé. Requiere sombra parcial 35-50%, suelos francos con pH 5.0-5.5, y precipitación 1.800-2.800 mm anuales. Sistemas agroecológicos asocian café con plátano (Musa spp.), guandul (Cajanus cajan) y nogal cafetero (Cordia alliodora) para sombra estratificada. Fuentes Tier A: Cenicafé Manual del Cafetero 2013, AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "feeding_plan_template": {
+        "source": "Cenicafé — Manual del Cafetero Colombiano (2013) + Cenicafé — Trichoderma spp. en manejo integrado (2010). Programa nutricional café tradicional Caturra/Castillo zona cafetera.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 500,
+            "notes": "Hoyo 40x40x40 cm. Cenicafé recomienda fertilización inicial al establecimiento. Mezclar con suelo del hoyo."
+          },
+          {
+            "offset_days": 30,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 20,
+            "notes": "Preventivo contra Fusarium oxysporum f.sp. coffeae (llaga macana) y Rhizoctonia. Cenicafé 2010."
+          },
+          {
+            "offset_days": 90,
+            "action": "Drench con biol fase vegetativa",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 1000,
+            "notes": "Dilución 1:5, 1 L por planta al pie. Refuerzo N orgánico fase de crecimiento foliar activo."
+          },
+          {
+            "offset_days": 180,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo roya (Hemileia vastatrix) en época de lluvias antes de iniciar floración."
+          },
+          {
+            "offset_days": 365,
+            "action": "Refuerzo anual con bocashi en banda",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 1500,
+            "notes": "Año 1 establecimiento completo. Aplicar en corona radicular antes de inicio de lluvias."
+          },
+          {
+            "offset_days": 540,
+            "action": "Foliar con supermagro pre-floración",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 80,
+            "notes": "Dilución 1:12. Corrige B y Zn críticos para cuajado de chereza. Aplicar 30 días antes de floración esperada."
+          },
+          {
+            "offset_days": 720,
+            "action": "Aplicar Bacillus subtilis foliar en cosecha",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 25,
+            "notes": "Año 2 primera cosecha. Control biológico de Cercospora coffeicola y Mycena citricolor (gotera)."
+          }
+        ]
+      },
+      "plagas_criticas": [
+        "Hypothenemus hampei (broca)",
+        "Hemileia vastatrix (roya)",
+        "Mycena citricolor"
+      ],
+      "enfermedades_criticas": [
+        "Cercospora coffeicola"
+      ],
+      "source_ids": [
+        "cenicafe-manual-cafetero-2013",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "coriandrum_sativum",
+      "nombre_comun": "Cilantro",
+      "nombre_cientifico": "Coriandrum sativum L.",
+      "familia_botanica": "Apiaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa escalonada cada 15 días para cosecha continua en la chagra."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El cilantro (Coriandrum sativum L.) es una aromática mediterránea naturalizada en Colombia, cultivada permanentemente en Cundinamarca entre 1000-2400 msnm en zonas térmicas templadas y frías. Su ciclo corto de 40-60 días permite cosechas escalonadas de hojas y semillas utilizadas en preparaciones culinarias tradicionales. Se propaga por siembra directa cada 15 días, prefiriendo medio-sombra en épocas cálidas, y se asocia beneficiosamente con repollo y zanahoria para reducir plagas como áfidos y trips. En el contexto andino campesino, su uso culinario se remonta a tiempos coloniales integrado en sofritos y guayos, mientras su cultivo sostenible evita sintéticos mediante manejo agroecológico. Fuentes: GBIF Taxonomic Backbone, POWO Kew, ICA Resolución 3168/2015.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "cymbopogon_citratus",
+      "nombre_comun": "Limonaria",
+      "nombre_cientifico": "Cymbopogon citratus (DC.) Stapf",
+      "familia_botanica": "Poaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent",
+        "biomass_producer",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 18,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "division_rizoma",
+        "notas": "Se propaga mediante el trasplante de 'hijos' (macollos) de la corona."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "Gramínea aromática tropical presente en departamentos cálidos y templados de Colombia como Cundinamarca (0-2400 msnm, zonas térmicas cálido, templado y frío). Se propaga fácilmente por división de matas o rizomas, formando densos tocuyos que requieren poda periódica para renovar tallos y maximizar producción de aceite esencial rico en citral (75-85%, compuesto por citronelal y geraniol). En contextos campesinos andinos, su infusión se usa tradicionalmente como antiespasmódico y digestivo, mientras su aroma cítrico actúa como repelente natural de mosquitos y otros insectos. Cultivada en asociación con hortalizas y como barrera antiviento en huertos familiares, contribuye al manejo ecológico de plagas sin insumos químicos. Fuente: GBIF Backbone Taxonomy y Plants of the World Online confirman su distribución neotropical y sinonimia taxonómica aceptada.",
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "erythrina_edulis",
+      "nombre_comun": "Chachafruto / Balú",
+      "nombre_cientifico": "Erythrina edulis Triana ex Micheli",
+      "nombre_comunes_regionales": [
+        "Poroto andino",
+        "Fríjol de árbol",
+        "Pajuro"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "alto",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1600,
+        "optimo_max": 2400,
+        "max_absoluto": 2700
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5,
+        "optimo_min": 5.5,
+        "optimo_max": 7,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 4,
+        "notas": "Tolerancia moderada; los brotes jóvenes pueden verse afectados por heladas nocturnas."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "coffea_arabica"
+      ],
+      "antagonists": [
+        "ulex_europaeus"
+      ],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germina rápidamente; el esqueje se usa principalmente para cercas vivas."
+      },
+      "valor_pedagogico": "El chachafruto (Erythrina edulis) se distribuye en los departamentos andinos de Colombia como Cundinamarca, Boyacá, Antioquia y Nariño entre 1200 y 2700 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con germinación rápida y uso de esquejes para cercas vivas, ciclo productivo de 8-12 meses, asociaciones beneficiosas con café y aliso que mejoran la fertilidad del suelo mediante fijación de nitrógeno, y requiere monitoreo de plagas como brotes de Scolytidae y Cerotoma spp. mediante biopreparados andinos. En el contexto campesino andino, sus semillas se utilizan tradicionalmente en preparaciones culinarias como source de proteína vegetal, aprovechando su alto contenido de lisina y triptófano, tal como documenta el Instituto Colombiano Agropecuario (ICA) en la Resolución 3168/2015 que establece normas para la producción y comercialización de especies forrajeras y alimenticias.",
+      "plagas_criticas": [
+        "Scolytidae",
+        "Cerotoma spp."
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis foliar"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-chachafruto-2015",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "foeniculum_vulgare",
+      "nombre_comun": "Hinojo",
+      "nombre_cientifico": "Foeniculum vulgare Mill.",
+      "familia_botanica": "Apiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa recomendada; el trasplante puede dañar su raíz pivotante profunda."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales",
+        "restrepo-2007-biopreparados",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El hinojo (Foeniculum vulgare Mill., familia Apiaceae) es una umbelífera perenne aromática originaria del Mediterráneo, naturalizada y cultivada en huertas familiares colombianas para uso culinario (bulbo, semilla, hoja), medicinal (digestivo, carminativo) e industrial (aceite esencial rico en anetol). Se cultiva en zonas templadas a frías: Cundinamarca (Sabana Bogotá), Boyacá, Antioquia, Quindío y Nariño entre 1.500 y 2.800 msnm en zona térmica templada a fría. Ciclo 4-6 meses a primera cosecha, perennización opcional 2-3 años. Caso de estudio principal en alelopatía: sus exudados radicales (compuestos cumarínicos) inhiben la germinación y crecimiento de la mayoría de vecinos, especialmente tomate, frijol, cilantro y eneldo. Manejo agroecológico: aislamiento mínimo 2-3 m de otras hortalizas O confinamiento en bordura/macetón, asocio compatible solo con hisopo y romero, fertilización moderada con compost al fondo, atrayente de polinizadores beneficiosos (Syrphidae, Braconidae) en floración. Lección viva: enseña la necesidad de planificar diseño espacial del huerto considerando interacciones químicas. Fuentes Tier A: ICA Resolución 3168/2015, Pamplona Roger 2006 Plantas Medicinales, Restrepo 2007 Biopreparados, POWO Kew, GBIF Backbone Taxonomy.",
+      "antagonists": [
+        "coffea_arabica",
+        "phaseolus_vulgaris",
+        "solanum_lycopersicum_san_marzano",
+        "zea_mays"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "fragaria_ananassa_monterrey",
+      "nombre_comun": "Fresa Monterrey",
+      "nombre_cientifico": "Fragaria × ananassa 'Monterrey'",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "estolon",
+        "notas": "Variedad de día neutro; requiere acolchado (mulch) de paja o plástico para evitar que el fruto toque el suelo y se pudra."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "valor_pedagogico": "La fresa Monterrey (Fragaria × ananassa Duchesne ex Rozier cv. Monterrey) es una rosácea perenne híbrida productiva (day-neutral) muy adoptada en cultivos comerciales colombianos por su precocidad, fruto grande y firme, y producción extendida primavera-otoño. Se cultiva en Cundinamarca (Sabana Bogotá, Sopó, Choachí, Sibaté), Boyacá (Sotaquirá, Toca), Nariño y Antioquia entre 1.800 y 2.800 msnm en zona térmica fría. Ciclo a primera cosecha 60-90 días desde trasplante, productividad sostenida 8-12 meses con manejo adecuado. Rendimientos 25-45 t/ha en sistema agroecológico mulching. Manejo: cama elevada con MO abundante, mulch plástico o paja, fertilización con biol foliar y bocashi al fondo, control de Botrytis cinerea con caldo bordelés + bacillus_subtilis, manejo de ácaros con caldo sulfocálcico. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual de biopreparados (2015) + ICA Guía de fertilización (2019). Ciclo fresa Monterrey clima frío altiplano cundiboyacense.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de trasplante",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 200,
+            "notes": "Incorporar 200 g/planta en hoyo + mezclar con suelo nativo. Establece microbiota inicial."
+          },
+          {
+            "offset_days": 15,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 250,
+            "notes": "Dilución 1:5. Mitiga estrés post-trasplante y enraizamiento activo."
+          },
+          {
+            "offset_days": 30,
+            "action": "Aplicar Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 10,
+            "notes": "Preventivo contra Phytophthora cactorum y Verticillium en raíces — patógenos crónicos en fresa altiplano."
+          },
+          {
+            "offset_days": 45,
+            "action": "Foliar con biol pre-floración",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Estimula formación de yemas florales antes de inicio reproductivo."
+          },
+          {
+            "offset_days": 60,
+            "action": "Foliar con supermagro inicio fructificación",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 50,
+            "notes": "Dilución 1:20. Corrige micronutrientes (Cu, Zn, B) críticos para cuajado de frutos."
+          },
+          {
+            "offset_days": 90,
+            "action": "Aplicar lixiviado de frutas durante cosecha",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 50,
+            "notes": "Dilución 1:20 foliar. Mantiene producción durante cosecha sostenida 2-4 meses."
+          },
+          {
+            "offset_days": 120,
+            "action": "Refuerzo con bocashi en banda",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 100,
+            "notes": "Banda lateral 10 cm de la planta. Cultivo en plena producción."
+          }
+        ]
+      },
+      "estrato": "rastrero",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "ipomoea_batatas",
+      "nombre_comun": "Batata / Camote",
+      "nombre_cientifico": "Ipomoea batatas (L.) Lam.",
+      "familia_botanica": "Convolvulaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1200,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje (bejuco)",
+        "notas": "Planta trepadora o rastrera de rápido crecimiento; requiere climas templados para desarrollar dulzor."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La batata o camote (Ipomoea batatas (L.) Lam., familia Convolvulaceae) es una convolvulácea perenne rastrera cultivada como anual por sus raíces tuberosas dulces ricas en betacarotenos (precursores vitamina A) y carbohidratos complejos. Cultivo tradicional precolombino de los campesinos colombianos para seguridad alimentaria. Se cultiva en Cundinamarca (Tena, Tocaima, La Mesa, La Vega), Tolima, Huila, Valle del Cauca, Antioquia, Magdalena y Llanos Orientales entre 0 y 2.400 msnm en zona térmica cálida a templada. Lección viva de raíces reservantes: enseña cómo una planta rastrera puede concentrar la energía solar capturada por su follaje en forma de carbohidratos dulces almacenados bajo la tierra. Propagación por esquejes tallo (15-30 cm) plantados en caballón, ciclo 4-6 meses, rendimientos 15-30 t/ha. Manejo agroecológico: cama o caballón elevado para mejor desarrollo tubérculo, suelos francoarenosos drenados, asocio con maíz y frijol (chacra muisca), fertilización con compost al fondo + ceniza madera, rotación trienal anti-gorgojo (Cylas spp.) con trampas feromonales. Fuentes Tier A: ICA Resolución 3168/2015, AGROSAVIA Tubérculos Tropicales, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "inga_edulis",
+      "nombre_comun": "Guamo",
+      "nombre_cientifico": "Inga edulis Mart.",
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 1500,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante; sembrar inmediatamente post-recolección. Rápida emergencia (7-14 días). También puede propagarse por estacas de ramas jóvenes."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El guamo (Inga edulis) se cultiva en departamentos colombianos como Valle del Cauca, Antioquia, Caldas, Quindío, Tolima y Huila entre 0 y 2000 msnm en zonas térmicas cálidas y templadas. Su manejo agronómico incluye propagación por semilla recalcitrante (sembrar inmediatamente post-recolección) con emergencia rápida de 7-14 días, ciclo productivo de 3-5 años hasta primera cosecha significativa, asociaciones tradicionales con cacao y café como especie sombreadora que fija nitrógeno atmosférico mediante simbiosis con rizobios, y requiere manejo de plagas como barrenadores de tallos y mosca de la fruta mediante monitoreo y poda fitosanitaria. En el contexto cultural campesino andino, esta leguminosa ha sido tradicionalmente utilizada como sombra de cacao y café, sus vainas contienen pulpa dulce comestible rica en azúcares naturales, y forma parte de sistemas agroforestales tradicionales que combinan producción con conservación de suelo. Según las fuentes taxonómicas verificadas de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Inga edulis Mart.",
+      "estrato": "alto",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "lactuca_sativa_capitata",
+      "nombre_comun": "Lechuga cogollo morada",
+      "nombre_cientifico": "Lactuca sativa var. capitata L.",
+      "familia_botanica": "Asteraceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 14,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere sustrato fino y riego por nebulización en etapas tempranas; trasplante a los 25-30 días."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "valor_pedagogico": "La lechuga cogollo morada (Lactuca sativa var. capitata) es una hortaliza de hoja ampliamente cultivada en Colombia, especialmente en departamentos como Cundinamarca (cinturón productivo Choachí-Fómeque), Boyacá, Nariño y Santander, entre 800-3200 msnm en zonas térmicas fría y templada. Su manejo agronómico incluye propagación por semilla en semillero con sustrato fino, riego por nebulización en etapas tempranas, trasplante a los 25-30 días, ciclo de 60-90 días hasta cosecha, y asociaciones beneficiosas con Brassicaceae y Allium para repelencia de pulguilla. Plagas principales: pulgones (Myzus persicae), babosas (Deroceras reticulatum) y minadores (Liriomyza spp.). Culturalmente, aunque no es originaria del contexto muisca, se ha integrado en la agricultura andina contemporánea como cultivo de ciclo corto para seguridad alimentaria. Los cogollos morados deben su pigmentación a las antocianinas, pigmentos que actúan como protección natural contra radiación UV y estrés térmico. Fuente: nrc-1989-cultivos-andinos.",
+      "companions": [
+        "phaseolus_vulgaris",
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "lupinus_mutabilis",
+      "nombre_comun": "Chocho / Tarwi",
+      "nombre_cientifico": "Lupinus mutabilis Sweet",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2400,
+        "optimo_max": 3000,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Sus raíces son fijadoras masivas de nitrógeno; excelente abono verde si se incorpora antes de florecer."
+      },
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "cip-2006-ghislain",
+        "gbif-taxonomic-backbone",
+        "agrosavia-leguminosas-andinas"
+      ],
+      "valor_pedagogico": "El tarwi o chocho andino (Lupinus mutabilis Sweet) es una leguminosa nativa de los Andes con alto contenido proteico en grano (35-50%), tradicionalmente cultivada en sistemas campesinos altoandinos colombianos para autoconsumo (cosecha desamargada). Se cultiva en Boyacá (Tunja, Soatá, Ventaquemada), Cundinamarca (Sumapaz, Choachí), Nariño y Cauca entre 2.500 y 3.500 msnm en zona térmica fría a páramo bajo. Ciclo 6-8 meses, fijación N biológica ~100-160 kg N/ha. Granos con alcaloides amargos (quinolizidínicos) requieren desamargado tradicional (remojo + enjuagues). Manejo agroecológico: siembra al voleo en pre-cultivo (8-12 kg/ha), incorporación como abono verde o cosecha grano + restos al suelo, rotación con tubérculos andinos. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989 Cultivos Andinos, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "alnus_acuminata",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "melissa_officinalis",
+      "nombre_comun": "Toronjil",
+      "nombre_cientifico": "Melissa officinalis L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 27
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Fácil propagación vegetativa mediante la separación de macollos estacionales."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "Melissa officinalis, conocida como toronjil o melisa, se cultiva en Colombia en departamentos como Bogotá DC, Boyacá, Cauca, Cundinamarca, Huila, Santander y Valle del Cauca, entre 1200 y 2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación vegetativa mediante división de macollos estacionales, ciclo perenne de 2-3 años con podas de renovación, asociaciones beneficiosas con tomate y coles para confundir plagas mediante su aroma cítrico, y manejo de áfidos y trips mediante monitoreo y biopreparados andinos. En el contexto campesino andino, sus hojas se utilizan tradicionalmente en infusiones digestivas y calmantes, siendo parte del botiquín casero desde la época colonial para aliviar nerviosismo y trastornos del sueño. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Melissa officinalis L.",
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "mentha_spicata",
+      "nombre_comun": "Yerbabuena / Menta",
+      "nombre_cientifico": "Mentha spicata L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "propagation": {
+        "metodo_principal": "estolon",
+        "notas": "Muy invasiva; se recomienda controlar su crecimiento mediante barreras físicas o macetas."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Mentha spicata (Labiada aromática) se cultiva perenne en huertas de Cundinamarca entre 500-2600 msnm en zonas térmicas cálidas, templadas y frías. Su propagación se realiza mediante esquejes y estolones, requiere control de invasividad mediante barreras físicas y se asocia beneficiosamente con tomate y repollo al repeler pulgón. En contexto campesino andino, su infusión digestiva (té de menta) se usa tradicionalmente para aliviar molestias gastrointestinales, aprovechando su aceite esencial rico en carvona y limoneno. Fuente taxonómica validada por GBIF Backbone Taxonomy y Plants of the World Online (POWO).",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "origanum_vulgare",
+      "nombre_comun": "Orégano",
+      "nombre_cientifico": "Origanum vulgare L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1200,
+        "optimo_max": 2200,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Propagación fácil por estacas de tallo o división de mata en época de lluvias."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El orégano común (Origanum vulgare L.) es una labiada perenne aromática originaria del Mediterráneo, ampliamente cultivada en huertas familiares y campesinas colombianas para uso culinario, medicinal y como repelente natural. Se cultiva en zonas frías y templadas: Sabana de Bogotá, Boyacá, Antioquia, Quindío, Caldas y Risaralda entre 1.200 y 2.800 msnm en zona térmica fría a templada. Propagación por estaca leñosa (60-80% prendimiento) o división de mata establecida. Ciclo perenne con vida productiva 4-6 años. Cortes graduales mensuales mantienen el porte compacto. Manejo agroecológico: cama elevada con drenaje excelente, suelos calcáreos pH 6.5-7.5, riego moderado (NO encharcamiento), asocio con tomate y pimentón (efecto repelente). Aceite esencial con carvacrol y timol confiere propiedades antibacterianas y antifúngicas. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "oxalis_tuberosa",
+      "nombre_comun": "Oca / Hibia",
+      "nombre_cientifico": "Oxalis tuberosa Molina",
+      "familia_botanica": "Oxalidaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2400,
+        "optimo_max": 2800,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo",
+        "notas": "Asoliar los tubérculos antes de consumirlos para reducir el contenido de ácido oxálico y aumentar el dulzor."
+      },
+      "source_ids": [
+        "nrc-1989-cultivos-andinos",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "La oca (Oxalis tuberosa) se cultiva en Colombia principalmente en los departamentos de Cundinamarca, Boyacá, Nariño y Cauca, entre 2400-3400 msnm en zona térmica fría, con propagación por tubérculos semilla y un ciclo de crecimiento de 8-9 meses, asociándose frecuentemente con papa y maíz en sistemas de policultivo andino, mientras enfrenta desafíos por plagas como el gusano blanco y la mosca de la oca; su cultivo tiene profundas raíces culturales en la tradición muisca y campesina andina, donde se reconocen variedades de tubérculo blanco, rosado, morado y amarillo, utilizándose tradicionalmente cocido en sopas y aplicándose la técnica ancestral de 'qollotear' (exposición al sol post-cosecha) para reducir el contenido de ácido oxálico y aumentar el dulzor, tal como documenta el National Research Council en su obra de 1989 'Lost Crops of the Incas' que identifica a la oca como uno de los tubérculos andinos subutilizados con gran potencial para cultivo mundial.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "passiflora_edulis_flavicarpa",
+      "nombre_comun": "Maracuyá",
+      "nombre_cientifico": "Passiflora edulis f. flavicarpa Deg.",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1300,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 24,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Polinización manual a menudo necesaria para alta producción; muy sensible al frío."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La Passiflora edulis f. flavicarpa, conocida como maracuyá amarilla, se cultiva en departamentos colombianos como Antioquia, Cundinamarca, Santander y el Valle del Cauca entre 0 y 1800 msnm en zonas térmicas cálidas y templadas. Su manejo agronómico incluye propagación por semilla o injerto, ciclo productivo de 18-24 meses, asociaciones beneficiosas con cultivos de sombra como plátano y caucho para reducir estrés hídrico, y requiere manejo de plagas como la mosca de la fruta (Ceratitis capitata) y ácaros mediante monitoreo y biopreparados. En el contexto andino-colombiano, aunque originaria de Brasil, su cultivo se ha integrado en sistemas agrofrutícolas de mediana altura, contribuyendo a la diversificación económica de pequeños productores. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Passiflora edulis f. flavicarpa Deg.",
+      "estrato": "alto",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "passiflora_edulis_morada",
+      "nombre_comun": "Gulupa",
+      "nombre_cientifico": "Passiflora edulis f. edulis Sims",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1600,
+        "optimo_min": 1800,
+        "optimo_max": 2300,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se recomienda el uso de micorrizas en el trasplante; evitar cercanía con maracuyá."
+      },
+      "source_ids": [
+        "powo-kew",
+        "sib-colombia",
+        "gbif-taxonomic-backbone",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "La gulupa (Passiflora edulis f. edulis) se cultiva en Colombia principalmente en los departamentos de Cundinamarca, Boyacá y Antioquia entre 1600 y 2600 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con uso de micorrizas en el trasplante, ciclo productivo de 12-18 meses, associations beneficiosas con cultivos de sombra como plátano y requerimiento de control de plagas como áfidos, trips y enfermedades foliares mediante monitoreo integrado. En el contexto andino campesino, se valora por su sabor aromático y se consume tradicionalmente en jugos y postres, contribuyendo a la diversificación de ingresos familiares en zonas de mediana altitud. Según fuentes técnicas validadas por AGROSAVIA y taxónomicamente confirmada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Passiflora edulis f. edulis Sims.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual de Gulupa (preserva citación original) + Agrosavia Manual frutales tropicales. Gulupa clima frío-templado 1800-2200 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 500,
+            "notes": "Hoyo 40x40x40 cm. Mezclar con suelo nativo. Gulupa requiere tutorado en espaldera desde el establecimiento."
+          },
+          {
+            "offset_days": 30,
+            "action": "Inocular Trichoderma harzianum",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 20,
+            "notes": "Preventivo Fusarium oxysporum f.sp. passiflorae (marchitez vascular) — principal enfermedad de la pasifloráceas."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con humus líquido fase vegetativa",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 500,
+            "notes": "Dilución 1:4. Crecimiento foliar activo de bejucos. Aporte de aminoácidos."
+          },
+          {
+            "offset_days": 120,
+            "action": "Foliar con biol pre-floración",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 200,
+            "notes": "Dilución 1:5. Promueve formación de yemas florales y polinización efectiva."
+          },
+          {
+            "offset_days": 180,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo antracnosis (Colletotrichum gloeosporioides) y roña (Cladosporium herbarum) en frutos."
+          },
+          {
+            "offset_days": 240,
+            "action": "Drench con lixiviado de frutas durante cuajado",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 200,
+            "notes": "Dilución 1:10. Llenado y maduración de frutos. Cosecha esperada 270-300 días post-siembra."
+          },
+          {
+            "offset_days": 300,
+            "action": "Foliar con supermagro durante cosecha",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 80,
+            "notes": "Dilución 1:12. Cosecha sostenida — mantiene calidad de frutos en producción continua."
+          }
+        ]
+      },
+      "estrato": "alto",
+      "companions": [
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "phaseolus_vulgaris",
+      "nombre_comun": "Frijol arbustivo / voluble",
+      "nombre_cientifico": "Phaseolus vulgaris L.",
+      "nombre_comunes_regionales": [
+        "Frijol cargamanto",
+        "Bola roja",
+        "Frijol recal"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 4,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6,
+        "optimo_max": 7,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Altamente sensible a heladas; requiere protección o siembra en épocas seguras."
+      },
+      "companions": [
+        "lactuca_sativa_capitata",
+        "zea_mays"
+      ],
+      "antagonists": [
+        "allium_ampeloprasum",
+        "allium_fistulosum",
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Inocular con Rhizobium para optimizar la fijación de nitrógeno."
+      },
+      "valor_pedagogico": "El frijol común (Phaseolus vulgaris L.) es un fijador de nitrógeno esencial en sistemas agrícolas andinos, contribuyendo con 50-80 kg N/ha mediante simbiosis con Rhizobium leguminosarum. En Colombia se cultiva ampliamente en departamentos como Cundinamarca (cinturón productivo Fómeque-Choachí), Boyacá y Nariño, entre 800-2800 msnm en zonas térmicas fría, templada y cálida. Varietales destacados incluyen Cargamanto, Bola Roja y Radical. Su manejo agronómico incluye propagación por semilla, ciclo de 3-4 meses, asociación tradicional en el sistema '3 hermanas' con maíz y ahuyama, y requiere monitoreo de plagas como Empoasca kraemeri y Bemisia tabaci. Culturalmente, ha sido parte fundamental de la dieta muisca y campesina andina desde época precolombina, utilizado en preparaciones como sopas, guisos y harinas. Fuente: nrc-1989-cultivos-andinos.",
+      "plagas_criticas": [
+        "Empoasca kraemeri",
+        "Apion godmani",
+        "Bemisia tabaci"
+      ],
+      "enfermedades_criticas": [
+        "Colletotrichum lindemuthianum (antracnosis)",
+        "Uromyces appendiculatus"
+      ],
+      "source_ids": [
+        "nrc-1989-cultivos-andinos",
+        "agrosavia-leguminosas-andinas",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "physalis_peruviana",
+      "nombre_comun": "Uchuva",
+      "nombre_cientifico": "Physalis peruviana L.",
+      "familia_botanica": "Solanaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Planta perenne de corta vida (2-3 años productivos); requiere tutorado para facilitar la cosecha y evitar hongos por humedad."
+      },
+      "source_ids": [
+        "agrosavia-manual-uchuva-2015",
+        "powo-kew",
+        "agrosavia-leguminosas-andinas"
+      ],
+      "valor_pedagogico": "La uchuva (Physalis peruviana L.) es una solanácea perenne nativa de los Andes ahora cultivada comercialmente para exportación. Colombia es el principal exportador mundial con cerca de 1.000 hectáreas en Cundinamarca (Granada, Silvania, Pasca), Boyacá (Ventaquemada), Antioquia (Sonsón) y Nariño entre 1.800 y 2.800 msnm en zona térmica fría a templada. La variedad AGROSAVIA Andina es la más adoptada, con ciclo productivo 8-10 meses y rendimientos 18-25 t/ha. Crece como arbusto perenne con cáliz papiráceo que envuelve la baya naranja madura. Manejo agroecológico: tutorado vertical, poda de formación, manejo integrado de Tuta absoluta (polilla) y Liriomyza huidobrensis (minador hoja) con biopreparados como BT y purín de ortiga, fertilización con bocashi + biol. Fuentes Tier A: AGROSAVIA Manual Uchuva, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "estrato": "bajo",
+      "antagonists": [
+        "vaccinium_corymbosum_biloxi"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "psidium_guajava_manzana",
+      "nombre_comun": "Guayaba manzana",
+      "nombre_cientifico": "Psidium guajava 'Manzana'",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1200,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 25,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "injerto",
+        "notas": "Variedad seleccionada por su menor contenido de semillas y mayor tamaño; muy rústica pero sensible a las heladas directas del páramo."
+      },
+      "source_ids": [
+        "fao-ecocrop",
+        "gbif-taxonomic-backbone",
+        "restrepo-1996-abc-agricultura-organica",
+        "powo-kew",
+        "agrosavia-manual-frutales-tropicales"
+      ],
+      "valor_pedagogico": "La guayaba manzana (Psidium guajava L. variedad manzana) es una mirtácea perenne nativa de los Andes y muy adaptada a sistemas agroecológicos colombianos en transición de zona templada a frío bajo. Se cultiva en Santander, Boyacá, Cundinamarca, Tolima y Huila entre 1.000 y 2.000 msnm en zona térmica templada. La variedad manzana se caracteriza por fruto blanco crocante con menor número de semillas, ciclo a primera cosecha de 2-3 años, vida productiva 15-25 años y rendimientos 25-40 t/ha. Soporta períodos de sequía moderados y tolera suelos francos a francoarcillosos con pH 4.5-7.0. Manejo agroecológico: poda formación copa baja, fertilización orgánica compost + roca fosfórica, control de mosca de la fruta (Anastrepha spp.) con trampas McPhail y biopreparados. Fuentes Tier A: AGROSAVIA Manual Frutales Tropicales, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone, Bernal et al. Catálogo Plantas y Líquenes de Colombia.",
+      "estrato": "alto",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "theobroma_cacao",
+      "nombre_comun": "Cacao",
+      "nombre_cientifico": "Theobroma cacao L.",
+      "familia_botanica": "Malvaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "shade_lover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 900,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 32
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se propaga por semilla recién extraída del fruto (recalcitrante: pierde viabilidad en 1-2 semanas si se seca) o por injerto de yema/púa de clones élite ICA/FEDECACAO sobre patrón franco. El injerto es estándar comercial: garantiza productividad, tolerancia a monilia y uniformidad."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "agrosavia-tibaitata",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El cacao (Theobroma cacao L.) es un árbol perenne de la familia Malvaceae nativo de la cuenca amazónica, cultivado en Colombia entre 0 y 1.200 msnm en zona térmica cálida húmeda. Se siembra en Santander (San Vicente de Chucurí, Rionegro, Landázuri — primer productor nacional), Antioquia (Magdalena Medio), Huila, Tolima, Arauca, Meta y la región Pacífica (Tumaco, Buenaventura) bajo sombra parcial de plátano, cítricos o maderables nativos (Cordia alliodora, Cedrela odorata, Erythrina poeppigiana). Árbol cauliflor (flores y frutos en el tronco), 4-8 m, ciclo a primera cosecha 3-5 años por injerto. Manejo agroecológico: poda sanitaria + de mantenimiento dos veces al año, recolección semanal de mazorcas enfermas (monilia, escoba de bruja, mazorca negra) y entierro o composteo lejos del cultivo, fertilización con compost + pulpa fermentada del propio cacao + ceniza. Asociar con leguminosas arbóreas (Inga edulis, Erythrina poeppigiana) para sombra + fijación de N, y plátano (Musa AAB) como sombra provisional los primeros 3 años. Fermentación post-cosecha 5-7 días en cajones de madera (no plástico) define el perfil de sabor exportable. Colombia es origen de cacaos finos de aroma reconocidos por ICCO. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, AGROSAVIA Tibaitatá, ICA Resolución 3168/2015.",
+      "validation_level": "claude_draft",
+      "estrato": "alto"
+    },
+    {
+      "id": "tropaeolum_tuberosum",
+      "nombre_comun": "Mashua / Cubio",
+      "nombre_cientifico": "Tropaeolum tuberosum Ruiz & Pav.",
+      "familia_botanica": "Tropaeolaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 10,
+        "optimo_max": 16,
+        "max_tolerable": 20
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo",
+        "notas": "Posee propiedades nematicidas naturales; excelente para rotar terrenos tras la siembra de papa."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La mashua (Tropaeolum tuberosum) se cultiva en los departamentos andinos de Colombia como Boyacá, Cundinamarca, Nariño y Cauca entre 2000 y 3600 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación por tubérculos semilla, ciclo de cultivo de 8-9 meses, asociaciones beneficiosas con papa y maíz que reducen nemátodos y plagas del suelo, y requiere monitoreo de plagas como trips y áfidos mediante biopreparados andinos. En el contexto cultural muisca y andino, este tubérculo ha sido tradicionalmente utilizado en sopros y guisos como alimento esencial, preservando sabores prehispánicos en las cocinas rurales de los Andes colombianos. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Tropaeolum tuberosum Ruiz & Pav.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "ullucus_tuberosus",
+      "nombre_comun": "Ulluco / Chugua",
+      "nombre_cientifico": "Ullucus tuberosus Caldas",
+      "familia_botanica": "Basellaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo",
+        "notas": "Variedades de colores vibrantes; requiere suelos con alto contenido de materia orgánica para un desarrollo óptimo."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El ulluco (Ullucus tuberosus Caldas) es un tubérculo andino cultivado en Colombia principalmente en los departamentos de Cundinamarca, Boyacá y Nariño entre 1800 y 3400 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación mediante tubérculos semilla con un ciclo de cultivo de 6-8 meses, requiere suelos con alto contenido de materia orgánica para un desarrollo óptimo, se asocia beneficiosamente con maíz y haba en sistemas de cultivo mixto, y requiere manejo de plagas como el gorgojo del ulluco y enfermedades como el mildiu mediante rotación de cultivos y uso de biopreparados andinos. En el contexto cultural andino, especialmente muisca, el ulluco ha sido cultivado desde tiempos prehispánicos como alimento esencial en la dieta campesino, utilizado tanto en su forma fresca en guisos y sopas como en forma seca para conservación, formando parte de la chagra tradicional como uno de los tubérculos originarios de los Andes. Según la taxonomía verificada por GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Ullucus tuberosus Caldas.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "zea_mays",
+      "nombre_comun": "Maíz criollo",
+      "nombre_cientifico": "Zea mays L.",
+      "nombre_comunes_regionales": [
+        "Maíz capio",
+        "Maíz pira",
+        "Maíz de montaña"
+      ],
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 6,
+      "estrato": "alto",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6,
+        "optimo_max": 7,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 2,
+        "notas": "Sensible en etapas tempranas; variedades altoandinas como 'Capio' tienen mejor comportamiento ante el frío."
+      },
+      "companions": [
+        "chenopodium_quinoa",
+        "lupinus_mutabilis",
+        "mucuna_pruriens",
+        "phaseolus_vulgaris",
+        "solanum_phureja",
+        "trifolium_repens",
+        "vicia_sativa"
+      ],
+      "antagonists": [
+        "foeniculum_vulgare"
+      ],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Siembra directa en sitio definitivo."
+      },
+      "notas_taxonomicas": "Las razas locales colombianas como 'Capio' (blanco harinoso), 'Cusco' (morado) y 'Pira' son fundamentales para la soberanía alimentaria de la zona altoandina. El sistema Milpa integra maíz con frijol y calabaza.",
+      "valor_pedagogico": "Lección de Milpa: el maíz criollo andino (Zea mays L.) se cultiva en el altiplano cundiboyacense y Nariño entre 1800-2800 msnm en zonas frío-templadas. Las variedades 'Capio', 'Pira' y 'Cusco' son patrimonios genéticos muiscas. Ciclo de 6 meses, propagación por semilla directa. En asociación tradicional milpa (frijol+calabaza) se emplea manejo integrado de Spodoptera frugiperda y Puccinia sorghi. Fuente: NRC (1989) Cultivos Andinos, AGROSAVIA, ICA Res. 3168/2015.",
+      "plagas_criticas": [
+        "Spodoptera frugiperda (cogollero)",
+        "Helicoverpa zea",
+        "Diabrotica balteata"
+      ],
+      "enfermedades_criticas": [
+        "Puccinia sorghi (roya)",
+        "Fusarium spp."
+      ],
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "amaranthus_caudatus",
+      "nombre_comun": "Amaranto",
+      "nombre_comunes_regionales": [
+        "Kiwicha",
+        "Achis"
+      ],
+      "nombre_cientifico": "Amaranthus caudatus L.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla muy pequeña; sembrar superficialmente en semillero y trasplantar a los 30-45 dias. Tradicionalmente se asocia con maiz y frijol en la milpa andina."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-2013-quinua",
+        "nrc-1989-cultivos-andinos",
+        "perez-arbelaez-1947-plantas-utiles",
+        "mujica-1992-quinua"
+      ],
+      "valor_pedagogico": "El amaranto caudado o kiwicha (Amaranthus caudatus L., familia Amaranthaceae) es una amarantácea anual andina considerada pseudocereal de alta montaña por su grano con proteína completa (15-18%) rica en lisina, aminoácido limitante en cereales convencionales (maíz, trigo). Cultivo tradicional precolombino de comunidades campesinas andinas colombianas. Se cultiva en Boyacá (Tunja, Soracá, Ventaquemada), Cundinamarca (Sumapaz, Choachí), Nariño (Pasto, Yacuanquer) y Cauca entre 1.500 y 3.600 msnm en zona térmica fría a páramo bajo. Ciclo 5-6 meses, productividad 1.5-3 t/ha grano. Sus inflorescencias colgantes color rojo intenso a violáceo contienen miles de semillas pequeñas brillantes. Lección viva: enseña la resiliencia a sequía, heladas moderadas y suelos pobres, demostrando cómo cultivos nativos andinos resuelven seguridad alimentaria en zonas marginales. Manejo agroecológico: siembra al voleo en pre-cultivo o trasplante a doble fila, asocio con maíz y frijol (chacra andina), cosecha cuando inflorescencias se inclinan + secado al sol 7 días, trilla manual con vara. Fuentes Tier A: FAO 2013 Quinua y Cultivos Andinos, NRC 1989 Cultivos Andinos, AGROSAVIA Granos Andinos, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "solanum_tuberosum_sabanera",
+      "nombre_comun": "Papa Sabanera",
+      "nombre_comunes_regionales": [
+        "papa de la sabana",
+        "papa sabanera blanca",
+        "papa sabanera amarilla"
+      ],
+      "nombre_cientifico": "Solanum tuberosum L. subsp. andigenum var. Sabanera",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2400,
+        "optimo_max": 3000,
+        "max_absoluto": 3400
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 10,
+        "optimo_max": 17,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo (semilla asexual)",
+        "notas": "Variedad tradicional del altiplano cundiboyacense. Ciclo largo (5-7 meses). Requiere periodos de dormancia antes de resiembra."
+      },
+      "source_ids": [
+        "perez-rodriguez-gomez-2008",
+        "nustez-rodriguez-2024-unal",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La papa Sabanera (Solanum tuberosum L. variedad Sabanera) es una variedad colombiana de papa de gran adaptación al altiplano cundiboyacense, desarrollada y registrada por ICA y AGROSAVIA. Se cultiva en Cundinamarca (Mosquera, Bojacá, Soacha), Boyacá (Tunja, Ventaquemada, Toca) y Nariño entre 2.500 y 3.200 msnm en zona térmica fría. Ciclo vegetativo 5-6 meses, rendimientos comerciales 25-35 t/ha. Tubérculo grande oblongo con piel crema y carne amarilla suave. Susceptible a Phytophthora infestans (tizón tardío); manejo agroecológico incluye rotación trienal con leguminosas (haba, arveja andina), siembra escalonada, manejo de inóculo de papa-volunta, biopreparados como caldo bordelés y trichoderma. Fuentes Tier A: AGROSAVIA fichas papa, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy, Bernal et al. Catálogo Plantas y Líquenes Colombia.",
+      "enfermedades_criticas": [
+        "Trozador (Agrotis ipsilon)"
+      ],
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "fragaria_vesca",
+      "nombre_comun": "Fresa silvestre andina",
+      "nombre_cientifico": "Fragaria vesca L.",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2500,
+        "optimo_max": 3300,
+        "max_absoluto": 3700
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 8,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "estolon",
+        "notas": "Se reproduce vegetativamente por estolones; tambien por semilla pero con menor tasa de exito. Variantes andinas adaptadas a mayor altitud que la europea."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-colombia",
+        "humboldt-flora-alto-andina"
+      ],
+      "valor_pedagogico": "El fruto escondido: la fresa silvestre crece a ras del suelo en los bordes del bosque andino, ensenando que los mejores alimentos a veces estan donde menos se espera. Su estolon es leccion de reproduccion asexual.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "rubus_glaucus",
+      "nombre_comun": "Mora andina / Mora de Castilla",
+      "nombre_cientifico": "Rubus glaucus Benth.",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "acodo",
+        "notas": "Propagacion por acodo de punta o esqueje. La forma silvestre presenta espinas; requiere tutorado en espaldera. Produce frutos a partir del segundo ano."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "La espina que protege: la mora silvestre ensena que las defensas naturales de las plantas tienen un proposito. Su cultivo en espaldera muestra como la agricultura domestica sin eliminar la esencia silvestre.",
+      "feeding_plan_template": {
+        "source": "Agrosavia Tibaitatá — fichas frutales andinos + Pinheiro-Machado (2017) Biofertilizantes. Manejo mora castilla clima frío 1800-2600 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + roca fosfórica al hoyo",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 400,
+            "notes": "Hoyo 40x40 cm. Mora requiere P alto al establecimiento — combinar con roca_fosforica si suelo deficiente."
+          },
+          {
+            "offset_days": 30,
+            "action": "Foliar con biol fase de brotación",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Estimula brotación lateral de cañas productivas."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 300,
+            "notes": "Dilución 1:4. Aporta micro flora y aminoácidos antes de cuajado."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo Botrytis cinerea y Peronospora — críticos en mora altiplano lluvioso."
+          },
+          {
+            "offset_days": 120,
+            "action": "Aplicar lixiviado de frutas en fructificación",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10 drench. Mora produce cosecha sostenida — refuerza llenado de fruto."
+          },
+          {
+            "offset_days": 180,
+            "action": "Refuerzo con bocashi post-poda",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 200,
+            "notes": "Después de poda sanitaria. Renueva tejido productivo para próximo flush."
+          }
+        ]
+      },
+      "validation_level": "claude_draft",
+      "companions": [
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "solanum_quitoense",
+      "nombre_comun": "Lulo / Naranjilla / Chuva",
+      "nombre_cientifico": "Solanum quitoense Lam.",
+      "familia_botanica": "Solanaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1600,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 16,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere sombra en etapas tempranas; sensible a nematodos del genero Meloidogyne. Se asocia bien con platano o maiz como sombra temporal."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-colombia",
+        "gbif-taxonomic-backbone",
+        "agrosavia-tibaitata",
+        "agrosavia-manual-frutales-tropicales",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El lulo o naranjilla (Solanum quitoense Lam., familia Solanaceae) es una solanácea subarbustiva perenne nativa de la región andina norte (Colombia, Ecuador, Perú), cultivada tradicionalmente en sistemas agroforestales campesinos colombianos por sus frutos esféricos anaranjados de pulpa verde ácida (pH 2.8-3.4), ricos en vitamina C, ácido cítrico y carotenoides, considerada el cítrico andino por excelencia. Se cultiva en Cundinamarca (Fómeque, Quetame, Une), Boyacá (Miraflores, Garagoa), Huila (San Agustín, Pitalito), Caquetá (Florencia) y Cauca (Silvia, Inzá) entre 1.600 y 2.400 msnm en zona térmica templada a fría. Ciclo perenne con primera cosecha a los 9-12 meses, producción sostenida 3-4 años. Rendimientos 12-20 t/ha fruto fresco. Lección viva: enseña la importancia de la acidez (ácido cítrico y málico) como mecanismo de defensa natural anti-herbívoros y anti-microbiano, su valor en la gastronomía tradicional (jugo, sorbete, mermelada, lulada vallecaucana) y la sensibilidad a nematodos del nudo radical Meloidogyne incognita como bioindicador de salud del suelo. Manejo agroecológico: siembra con sombra parcial (40-60%) en sistemas con plátano o guamo (Inga edulis) como sombra temporal, asocio con maíz para protección contra viento, podas sanitarias de hojas viejas, control biológico de Neoleucinodes elegantalis (perforador) con Trichogramma pretiosum, no requiere agroquímicos. Fuentes Tier A: AGROSAVIA Manual Frutales Tropicales, POWO Kew, GBIF Backbone Taxonomy, SIB Colombia, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "cucurbita_maxima",
+      "nombre_comun": "Calabaza / Auyama",
+      "nombre_comunes_regionales": [
+        "Zapallo",
+        "Calabazo",
+        "Auyama"
+      ],
+      "nombre_cientifico": "Cucurbita maxima Duchesne",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "flor",
+      "estrato": "rastrero",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en sitio definitivo. Necesita buen espacio para sus guias rastreras. Las flores masculinas se cosechan temprano en la manana para consumo."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "fao-ecocrop",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "La calabaza o auyama (Cucurbita maxima Duchesne, familia Cucurbitaceae) es una cucurbitácea anual herbácea rastrera-trepadora originaria de los Andes sudamericanos (Bolivia, Perú, Argentina), domesticada hace más de 8.000 años y dispersada precolombinamente por toda América, cultivada tradicionalmente en sistemas campesinos colombianos como uno de los tres pilares del sistema mesoamericano-andino de las tres hermanas (maíz-fríjol-calabaza). Produce frutos grandes (3-15 kg, hasta 50 kg en variedades gigantes) de pulpa amarillo-anaranjada rica en betacaroteno, vitamina A y fibra. Se cultiva en Cundinamarca (Pacho, Subachoque, sabana de Bogotá), Boyacá (Tunja, Villa de Leyva), Nariño (Pasto, Ipiales), Cauca, Antioquia (oriente, Suroeste) y Eje cafetero entre 1.000 y 2.600 msnm en zona térmica cálida a fría. Ciclo anual de 4-6 meses. Rendimientos 15-30 t/ha fruto. Lección viva: en la milpa andina-mesoamericana enseña el sistema de las tres hermanas — el maíz aporta soporte estructural a la guía rastrera, el fríjol fija nitrógeno biológico (Rhizobium spp.) y la calabaza cubre el suelo con sus hojas amplias reduciendo evapotranspiración y suprimiendo arvenses. Las flores masculinas rellenas de queso y huevo son patrimonio culinario de Cundinamarca y Boyacá. Manejo agroecológico: siembra directa en sitio definitivo a 1.5-2 m entre golpes, asocio obligatorio en milpa, polinización por abejas nativas (Peponapis pruinosa, Apis mellifera), cosecha post-marchitamiento de guía, almacenamiento en bodega ventilada hasta 6 meses, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA, FAO Ecocrop, Bernal 2015 Catálogo Plantas Colombia.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "cocos_nucifera",
+      "nombre_comun": "Coco",
+      "nombre_comunes_regionales": [
+        "Cocotero",
+        "Palma de coco"
+      ],
+      "nombre_cientifico": "Cocos nucifera L.",
+      "familia_botanica": "Arecaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 300,
+        "max_absoluto": 500
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 24,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "humedad_relativa_pct": {
+        "min": 60,
+        "optimo": 80,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 5,
+        "optimo_min": 5.5,
+        "optimo_max": 7,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinacion en vivero de 6-12 meses; requiere transplante a sitio definitivo con suelo profundo y bien drenado. Palma emblematica de la Costa Caribe y Pacifica colombiana."
+      },
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El arbol de la vida tropical: ensenia aprovechamiento integral (agua, alimento, fibra, aceite, vivienda) en sistemas agroforestales de la costa colombiana. Caso de estudio en resiliencia costera y seguridad alimentaria.",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "euterpe_oleracea",
+      "nombre_comun": "Asai",
+      "nombre_comunes_regionales": [
+        "Azai",
+        "Manaca",
+        "Palma de asai"
+      ],
+      "nombre_cientifico": "Euterpe oleracea Mart.",
+      "familia_botanica": "Arecaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 12,
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 200,
+        "max_absoluto": 500
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 24,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "humedad_relativa_pct": {
+        "min": 70,
+        "optimo": 85,
+        "max": 100
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 6,
+        "max": 6.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "moderado",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Palma nativa de la Amazonia colombiana; crece en rebrotes multiples desde la base (multitallo). Sus frutos son la base del 'asai' de la canasta amazonica."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia",
+        "sinchi-amazonia-colombiana"
+      ],
+      "valor_pedagogico": "El açaí o asaí (Euterpe oleracea Mart., familia Arecaceae, subfamilia Arecoideae) es una arecácea palmiforme cespitosa multitallo nativa silvestre de la cuenca amazónica y zonas estuarinas del bajo Amazonas y el Pacífico colombiano, considerada producto forestal no maderable (PFNM) emblemático del Chocó biogeográfico y la Amazonia colombiana. Forma touceiras o macollas de 4-10 estipes (tallos) desde una misma base por rebrote basal, alcanzando 15-25 m de altura, con hojas pinnadas verde-oscuras, inflorescencias en panícula entre las hojas y frutos pequeños globosos negro-morados (1-2 cm) con un único pirene grande y mesocarpo carnoso delgado rico en antocianinas (cianidina-3-glucósido, cianidina-3-rutinósido), ácidos grasos monoinsaturados (oleico 60%), polifenoles antioxidantes y minerales. Se distribuye en Chocó (Quibdó, Atrato medio, Bajo Baudó, Bahía Solano, Nuquí), Valle del Cauca (Buenaventura, Bajo Calima), Cauca (Guapi, Timbiquí, López), Nariño (Tumaco, Mosquera, Olaya Herrera), Amazonas (Leticia, Puerto Nariño, Trapecio amazónico) y Vaupés (Mitú) entre 0 y 200 msnm en zona térmica cálida húmeda con altísima pluviosidad (3.000-9.000 mm/año). Ciclo perenne, primera fructificación a los 4-5 años, productividad sostenida 30-50 años. Rendimientos 6-12 kg fruto/estipe/año, 30-60 kg/touceira/año. Lección viva: el açaí enseña el aprovechamiento sostenible de productos forestales no maderables del Pacífico y la Amazonia colombiana por comunidades afrocolombianas e indígenas (Embera, Wounaan, Tikuna, Yagua), su rol en la canasta amazónica como superalimento (concentra antioxidantes y energía), y la importancia de los manglares ribereños y bosques de várzea estuarina como ecosistemas de provisión. Manejo agroecológico: aprovechamiento por extractivismo regulado certificado con comunidades locales, propagación por semilla en germinador con sombra (90-180 días germinación), siembra a 4-6 m entre touceiras en sistemas agroforestales con plátano, cacao y maderables nativos, cosecha manual de racimos por trepador, no requiere agroquímicos. Fuentes Tier A: SINCHI Amazonia Colombiana, POWO Kew, GBIF Backbone Taxonomy, Bernal 2015 Catálogo Plantas Colombia, SIB Colombia.",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "gliricidia_sepium",
+      "nombre_comun": "Matarratón",
+      "nombre_comunes_regionales": [
+        "Madre cacao",
+        "Cocoite",
+        "Mata ratón"
+      ],
+      "nombre_cientifico": "Gliricidia sepium (Jacq.) Kunth ex Walp.",
+      "familia_botanica": "Fabaceae",
+      "category": "cercas_vivas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "living_fence",
+        "nitrogen_fixer",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1600
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "fence_function": [
+        "delimitacion",
+        "rompevientos",
+        "sombra_parcial"
+      ],
+      "densidad_siembra_fence_m": 1,
+      "propagation": {
+        "methods": [
+          "esqueje",
+          "semilla"
+        ],
+        "best_method": "esqueje",
+        "protocol_resumen": "Estacas de 1.5-2m de largo y 5-10cm de diametro, plantadas directamente a 30cm de profundidad en epoca lluviosa. Sin hojas en la porcion enterrada. Prendimiento superior al 90%.",
+        "notas": "Clasica cerca viva colombiana. Estaca enraiza sin hormonas. Fija N atmosferico. Follaje forrajero rico en proteinas para rumiantes.",
+        "fuente": "Perez Arbelaez 1947; AGROSAVIA sistemas silvopastoriles"
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "agrosavia-silvopastoriles"
+      ],
+      "rol_ecologico": "Fijador de nitrogeno simbiotico con Rhizobium. Forrajera de alto valor proteico. Sombra ligera para cafe y cacao. Madera para leña y construcciones rurales.",
+      "valor_pedagogico": "El matarratón (Gliricidia sepium (Jacq.) Walp.) es una leguminosa arbórea nativa de Mesoamérica naturalizada y ampliamente usada en sistemas agroforestales colombianos. Fija nitrógeno biológico (~100-200 kg N/ha/año) por simbiosis con Rhizobium, sirviendo como cerca viva, sombra ganadera, banco proteico forrajero y especie pionera en restauración. Se cultiva en zonas templadas y cálidas: Tolima, Huila, Valle del Cauca, Antioquia, Cauca, Magdalena y Llanos Orientales entre 0 y 1.700 msnm en zona térmica cálida a templada. Propagación por estaca leñosa (60-80% prendimiento), crecimiento rápido alcanza 3-4 m primer año. Manejo agroecológico: poda anual a 1.5 m altura, biomasa cortada se usa como mulch verde o forraje (proteína 20-25%). Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "solanum_tuberosum_pastusa_suprema",
+      "nombre_comun": "Papa Pastusa Suprema",
+      "nombre_comunes_regionales": [
+        "pastusa suprema",
+        "papa suprema",
+        "ICA-Pastusa Suprema"
+      ],
+      "nombre_cientifico": "Solanum tuberosum L. subsp. tuberosum cv. 'Pastusa Suprema'",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2500,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 10,
+        "optimo_max": 17,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo (semilla asexual)",
+        "notas": "Variedad industrial moderna liberada por ICA-CORPOICA en 1996. Ciclo 5-6 meses. Alta productividad pero alta dependencia de insumos sintéticos y muy susceptible a Phytophthora infestans. Requiere semilla certificada cada 2-3 ciclos para mantener vigor. Resiembra con tubérculo entero o cortado con yemas, distancia 30 cm x 90 cm."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "nustez-rodriguez-2024-unal",
+        "perez-rodriguez-gomez-2008",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La papa Pastusa Suprema (Solanum tuberosum L. subsp. tuberosum cv. 'Pastusa Suprema') es la variedad comercial dominante en Colombia desde su liberación oficial por ICA-CORPOICA en 1996, surgida de un cruzamiento dirigido para combinar la calidad culinaria de la pastusa tradicional con mayor rendimiento agronómico. Se cultiva intensivamente en Nariño (Túquerres, Pupiales, Guachucal, Ipiales), Cundinamarca (Subachoque, Zipaquirá, Carmen de Carupa, Une), Boyacá (Ventaquemada, Toca, Soracá) y zona norte de Antioquia (La Unión, Sonsón) entre 2.500 y 3.000 msnm. Rendimientos comerciales 30-45 t/ha bajo manejo convencional, tubérculos grandes (150-250 g) oblongos de piel rosa-crema y carne crema con bajo contenido de azúcares reductores: ideal para fritura industrial (papas a la francesa) y mercados de plaza. Es una lección crítica sobre el modelo agroindustrial: aunque productiva, la pastusa suprema es extremadamente susceptible a Phytophthora infestans (tizón tardío) y polilla guatemalteca (Tecia solanivora), lo que ata su cultivo a 8-14 aplicaciones de fungicida/insecticida sintético por ciclo, costo que estrangula al pequeño productor y deja residuos en suelo, agua y tubérculo. En contraste con las nativas Andigenum (carrera negra, criolla, sabanera), depende totalmente de semilla certificada renovada cada 2-3 ciclos por degeneración viral (PVY, PLRV). Manejo agroecológico de transición: rotación obligatoria con haba o arveja para fijar nitrógeno, aplicación de compost o bocashi al surco, biopreparados como caldo bordelés preventivo (no curativo) y trichoderma, monitoreo semanal de adultos de polilla con feromonas, asociación con tagetes para repelencia. La pastusa suprema enseña por contraste el costo real de la dependencia a paquetes tecnológicos y por qué la conservación in situ de variedades nativas es seguro alimentario. Fuentes Tier A: AGROSAVIA Manual Tubérculos Andinos 2017, Núñez-Rodríguez 2024 UNAL, Pérez-Rodríguez-Gómez 2008, ICA Resolución 3168/2015, GBIF Backbone, POWO Kew.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual tubérculos andinos (2017) + Pérez-Rodríguez-Gómez (2008) Plan fertilización papa criolla altiplano. Papa pastusa ciclo 5-6 meses clima frío 2000-3000 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al surco",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 250,
+            "notes": "Surco preparado 0-20 cm. Tubérculos-semilla pre-brotados con yemas activas. Suelo bien drenado."
+          },
+          {
+            "offset_days": 25,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 15,
+            "notes": "Preventivo Rhizoctonia solani y Spongospora subterranea — patógenos críticos en papa altiplano."
+          },
+          {
+            "offset_days": 45,
+            "action": "Aporque + drench con humus líquido",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 200,
+            "notes": "Dilución 1:5. Aporque obligatorio para tuberización. Aporte de NPK orgánico antes de bulbificación."
+          },
+          {
+            "offset_days": 60,
+            "action": "Foliar con biol fase pre-tuberización",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Etapa crítica — papa define número de tubérculos en los 10-20 días pre-tuberización."
+          },
+          {
+            "offset_days": 80,
+            "action": "Foliar con caldo bordelés preventivo gota",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo Phytophthora infestans (gota o tizón) — enemigo principal de la papa. Cada 14 días en lluvia activa."
+          },
+          {
+            "offset_days": 100,
+            "action": "Foliar con supermagro durante llenado",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. K crítico para llenado de tubérculo y materia seca final."
+          },
+          {
+            "offset_days": 130,
+            "action": "Suspender riego para maduración piel",
+            "notes": "Reducir riego 80% últimas 3 semanas. Maduración piel = mejor conservación post-cosecha. Cosecha 150-180 días."
+          }
+        ]
+      },
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "cucurbita_moschata",
+      "nombre_comun": "Ahuyama Amarilla",
+      "nombre_comunes_regionales": [
+        "zapallo cuello",
+        "zapallo de cuello",
+        "calabaza moscada",
+        "auyama",
+        "ahuyama común"
+      ],
+      "nombre_cientifico": "Cucurbita moschata Duchesne",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Especie distinta de Cucurbita maxima (zapallo de cabello/loche andino): C. moschata es la ahuyama tropical-templada de cuello largo o calabaza moscada de tierra caliente y media. Siembra directa al inicio de lluvias, 2-3 semillas por hoyo a 2-3 cm de profundidad, distancia 2-3 m entre matas por su porte rastrero expansivo. Ciclo 4-5 meses."
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "agrosavia-leguminosas-andinas",
+        "nrc-1989-cultivos-andinos",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop"
+      ],
+      "valor_pedagogico": "La ahuyama amarilla o zapallo cuello (Cucurbita moschata Duchesne, Cucurbitaceae) es una de las tres cucurbitas domesticadas en Mesoamérica y Sudamérica (junto con Cucurbita maxima y Cucurbita pepo), distintiva por su fruto de cuello largo o piriforme, piel verde-ocre que vira a amarillo-crema al madurar, y carne anaranjada intensa rica en betacaroteno (precursor de vitamina A). En Colombia se cultiva ampliamente en clima cálido y templado de Caribe (Córdoba, Sucre, Bolívar), valles interandinos (Tolima, Huila, Valle), Llanos (Casanare, Meta) y zona andina hasta los 1.800-2.000 msnm. Es lección viva de las 'tres hermanas' mesoamericanas adaptadas al trópico colombiano: la ahuyama se asocia históricamente con maíz y fríjol en policultivo donde el maíz da soporte, el fríjol fija nitrógeno y la ahuyama cubre el suelo con su porte rastrero, suprime arvenses, conserva humedad y reduce evaporación. A diferencia de Cucurbita maxima (zapallo de cabello, loche, criollo andino) que prefiere clima frío de altura, la C. moschata es la calabaza de tierra caliente, más resistente a calor, humedad alta y a la mosca blanca. Fruto multifuncional: pulpa para sopas (sancocho, mute santandereano), dulces (dulce de ahuyama, conserva), purés y compotas; semillas tostadas como botana o como antiparasitario tradicional (cucurbitina); flores comestibles en frituras; hojas tiernas en cocidos. Manejo agroecológico: siembra directa al inicio de lluvias, distancia 2-3 m entre matas; asociación clásica con maíz (Zea mays) y fríjol voluble (Phaseolus vulgaris); abono orgánico al hoyo (compost o bocashi); biopreparados caldo de ceniza o caldo sulfocalcio contra oídio (Erysiphe cichoracearum). Conservación de semilla local fácil porque la planta es monoica y fácil de polinizar a mano, lo cual permite mantener variedades familiares por generaciones. Fuentes Tier A: Pérez Arbeláez 1947 Plantas Útiles, AGROSAVIA Leguminosas Andinas (manejo policultivo), NRC 1989 Cultivos Andinos, GBIF Backbone, POWO Kew, FAO EcoCrop.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "manihot_esculenta",
+      "nombre_comun": "Yuca brava amazónica",
+      "nombre_comunes_regionales": [
+        "yuca amarga",
+        "mandioca brava",
+        "casabe",
+        "fariña",
+        "yuca venenosa",
+        "tapioca"
+      ],
+      "nombre_cientifico": "Manihot esculenta Crantz",
+      "familia_botanica": "Euphorbiaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "estaca",
+        "notas": "Estacas de 20-25 cm de tallo maduro (1 año), sembradas en horizontal o inclinadas a 5-10 cm de profundidad. Cosecha de raíces tuberosas a 8-18 meses según ecotipo (yuca brava amazónica suele ser de ciclo largo 12-18 meses). La yuca amarga (alto contenido cianogénico, >100 mg HCN/kg fresco) requiere procesamiento obligatorio: rallado, prensado del manipueira (líquido amarillo tóxico) y tostado para fabricar casabe o fariña, lección milenaria de seguridad alimentaria indígena."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "sinchi-amazonia-colombiana",
+        "bernal-2015-plantas-liquenes-colombia",
+        "fao-ecocrop",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "La yuca brava amazónica o mandioca amarga (Manihot esculenta Crantz, familia Euphorbiaceae) es un arbusto leñoso (2-4 m altura) nativo de las tierras bajas de Sudamérica tropical, domesticada hace 8.000-10.000 años en el sudoeste de la cuenca amazónica (frontera Brasil-Bolivia, área de Rondônia) según evidencia arqueobotánica y genética (Olsen & Schaal 1999), considerada la cuarta fuente de carbohidratos para la humanidad después del arroz, el trigo y el maíz, y la base alimentaria milenaria de los pueblos amazónicos colombianos (tikuna, huitoto, bora, miraña, muinane, andoke, ocaina, yagua, kichwa, siona, kofán, secoya, inga, kamëntsá, makuna, yukpa, sikuani, piaroa). Existen dos grupos varietales tradicionales bien diferenciados: yuca dulce (mansa, bajo contenido de glucósidos cianogénicos <50 mg HCN/kg, consumo directo cocida) y yuca brava o amarga (alto contenido cianogénico 100-500 mg HCN/kg, requiere procesamiento elaborado para eliminar el ácido cianhídrico y transformarse en casabe, fariña o manicuera fermentada). El proceso tradicional indígena para procesar la yuca brava — rallado en tabla de aserrín de palma o concha, prensado en sebucán (cilindro tejido de palma con torsión gravitacional) para extraer el manipueira o yare (líquido amarillo cianhídrico tóxico), tamizado de la masa, tostado en budare o tiesto cerámico para hacer casabe (torta delgada) o fariña (granulado seco) — es uno de los logros etnoquímicos más sofisticados de la humanidad precolombina, comparable al procesamiento del maíz por nixtamalización mesoamericana. Lección viva: planta-pilar de la chagra amazónica colombiana que enseña cinco conceptos críticos: (1) la domesticación temprana de plantas tóxicas (yuca amarga) por pueblos amazónicos como ejemplo magistral de coevolución cultura-naturaleza, donde un cultivo venenoso se vuelve alimento básico mediante una tecnología procesual milenaria; (2) la diferencia entre yuca dulce y yuca brava como caso de selección artificial divergente — la yuca brava conserva su defensa cianogénica natural contra herbívoros y la cultura humana la procesa, mientras la yuca dulce ha perdido esa defensa por selección y se cultiva en zonas con menor presión de saqueo (ej. periurbano colombiano); (3) la chagra amazónica de yuca como sistema rotatorio milenario sostenible: tumba-pudre o slash-and-mulch, ciclo de 1-3 años de cultivo seguido de barbecho de 8-15 años, lección magistral de agricultura itinerante de bosque tropical sin uso de fuego en muchas variantes; (4) la soberanía alimentaria amazónica — el casabe y la fariña son alimentos vivos de la identidad cultural de pueblos como los huitoto, tikuna y bora, y la pérdida del manejo tradicional implica erosión cultural y genética simultánea (>200 variedades locales documentadas en chagras del trapecio amazónico colombiano por SINCHI); (5) la bioquímica defensiva vegetal: los glucósidos cianogénicos (linamarina, lotaustralina) liberan HCN al ser hidrolizados por la enzima linamarasa, lección de bioquímica de defensa estructural disociada espacialmente (los glucósidos en vacuola, la enzima en citoplasma, contacto solo al daño mecánico). Manejo agroecológico: siembra en chagras nuevas (tumba-pudre tradicional), asocio con plátano, piña, copoazú, ají, achiote, cocona; cosecha escalonada manual; cero agroquímicos; control biológico de Phenacoccus manihoti (cochinilla de la yuca) con Anagyrus lopezi (avispita brasileña). Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, AGROSAVIA Manual Frutales Tropicales, Bernal 2015 Catálogo Plantas Colombia, SINCHI Amazonía, FAO EcoCrop, Pérez-Arbeláez 1947.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "cordia_alliodora",
+      "nombre_comun": "Nogal cafetero",
+      "nombre_comunes_regionales": [
+        "nogal",
+        "moho",
+        "salmwood",
+        "vara de humo",
+        "canalete"
+      ],
+      "nombre_cientifico": "Cordia alliodora (Ruiz & Pav.) Oken",
+      "familia_botanica": "Boraginaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol semicaducifolio, 15-25 m de altura, copa rala estratificada",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Recolección de núcula seca en panículas persistentes (cáliz acrescente actúa como ala anemócora). Sin tratamiento pre-germinativo. Germinación 60-80% a 10-20 días. Plántula vigorosa, trasplante directo o a bolsa 1 kg. Definitiva a 3-4 meses (25-35 cm).",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Regeneración natural espontánea en cafetales y potreros (anemócora). Asocio nodal con Coffea arabica en Eje Cafetero colombiano: dosel ralo permite paso de luz tamizada óptima para café.",
+        "fuente": "Cenicafé manuales sombrío cafetero; CATIE 1997 'Cordia alliodora en sistemas agroforestales'; Trees of Antioquia"
+      },
+      "companions": [
+        "cedrela_odorata",
+        "coffea_arabica",
+        "erythrina_edulis",
+        "inga_edulis"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 15-25 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Sombrío puntual o lindero. Regenera espontáneamente desde semilla anemócora dispersada del vecindario.",
+          "tips": [
+            "Aprovechar regeneración natural en lugar de plantar",
+            "Selección de fustes rectos para uso maderable"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío clásico cafetero zona templada 100-250 árb/ha. Sistemas cacaoteros 80-150 árb/ha. Plantación maderable pura 400-600 árb/ha, turno 15-20 años.",
+          "tips": [
+            "Manejo de regeneración natural en cafetales (raleos selectivos)",
+            "Poda apical año 2-3 para corregir bifurcaciones",
+            "Madera con valor comercial: ebanistería, postes, instrumentos"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera de bosque secundario tropical. Colonización rápida de potreros abandonados.",
+          "tips": [
+            "Densidad 600-800 ind/ha asociado a Ochroma pyramidale",
+            "Tolera suelos pobres y compactados"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Sombrío cafetero clásico del Eje Cafetero colombiano. Copa rala estratificada permite paso de luz tamizada óptima para café. Hojas pequeñas aromáticas (olor a ajo al estrujarlas, de ahí 'alliodora') con descomposición rápida y aporte de N. Flores blancas pequeñas en panículas terminales, melíferas, atraen abejas y polinizadores. Núcula dispersada por viento permite regeneración natural espontánea. Madera marrón clara apreciada en ebanistería, postes, instrumentos musicales, canoas.",
+      "valor_pedagogico": "El nogal cafetero (Cordia alliodora (Ruiz & Pav.) Oken, Boraginaceae) es el árbol de sombrío más emblemático del paisaje cultural cafetero colombiano. Nativo del Neotrópico, en Colombia se distribuye en bosques húmedos a subhúmedos premontanos de toda la región Andina (Eje Cafetero: Quindío, Risaralda, Caldas; Antioquia, Cundinamarca, Tolima, Huila, Santander, Norte de Santander, Valle, Cauca, Nariño), Caribe (estribaciones Sierra Nevada, Serranía Perijá, Montes de María) y Pacífico entre 400 y 1.600 msnm en zona térmica cálida a templada. Árbol semicaducifolio de 15-25 m con fuste recto y copa rala estratificada en pisos horizontales característicos (de ahí 'estratificada'), hojas pequeñas alternas elíptico-lanceoladas que despiden olor a ajo al estrujarlas (epíteto 'alliodora' del griego 'allion' = ajo), flores blancas pequeñas en grandes panículas terminales muy melíferas que atraen abejas nativas y Apis mellifera, frutos pequeños tipo núcula con cáliz persistente acrescente que actúa como ala anemócora permitiendo dispersión por viento a decenas de metros (de ahí su regeneración espontánea masiva en potreros y cafetales del Eje). Es la lección viva del agroforestería cafetera colombiana: a diferencia del sombrío con especies exóticas (Grevillea robusta australiana, Inga densiflora introducida o Eucalyptus invasor), el nogal cafetero es nativo, no demanda manejo intensivo porque se regenera solo desde semilla anemócora del vecindario, tiene copa rala que deja pasar 30-50% de luz tamizada (ideal para café arábica de mediana sombra), descompone hojarasca rápido aportando N al suelo cafetero, produce madera de valor (ebanistería, postes, mangos de herramienta, canoas) que el caficultor puede aprovechar como reserva al final de la vida útil del cafetal, y atrae polinizadores que benefician al café y otros cultivos asociados. Cenicafé ha documentado densidades óptimas de 100-250 árboles/ha en cafetales tradicionales del Quindío y Risaralda. Es también pionera valiosa en restauración de bosque secundario: coloniza rápidamente potreros abandonados, tolera suelos pobres y prepara sitios para especies climácicas. Manejo agroecológico: aprovechar regeneración natural antes que plantar, raleos selectivos cada 5-7 años, podas apicales tempranas para corregir bifurcaciones, cosecha de madera a 15-20 años para diámetros >30 cm. Fuentes Tier A: Cenicafé manuales cafeteros, CATIE 1997 manual Cordia alliodora sistemas agroforestales, Trees of Antioquia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF.",
+      "source_ids": [
+        "cenicafe-manual-cafetero-2013",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "tabebuia_rosea",
+      "nombre_comun": "Guayacán rosado",
+      "nombre_comunes_regionales": [
+        "ocobo",
+        "roble morado",
+        "flor morado",
+        "macuelizo",
+        "Handroanthus rosea"
+      ],
+      "nombre_cientifico": "Tabebuia rosea (Bertol.) DC.",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol caducifolio, 15-25 m de altura, floración rosada espectacular",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca (enero-marzo en Caribe). Sin tratamiento pre-germinativo. Germinación 80-95% a 8-15 días, una de las germinaciones más rápidas de los maderables tropicales. Vivero a sol parcial, trasplante definitivo a 30-40 cm.",
+        "tiempo_a_establecimiento_dias": 50,
+        "notas": "Floración masiva sincrónica en estación seca (febrero-marzo Andes/Caribe) tras estrés hídrico: árbol totalmente desnudo de hojas se cubre de flores rosado-violáceas que tapizan el suelo al caer. Espectáculo paisajístico icónico del paisaje cafetero y de pueblos del Caribe.",
+        "fuente": "Bernal 2015; Cárdenas-Salinas 2007; Trees of Antioquia; arbolado urbano municipios Andes-Caribe"
+      },
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "erythrina_edulis",
+        "inga_edulis"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 15-25 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Árbol ornamental-maderable patrimonial. Floración espectacular paisajística.",
+          "tips": [
+            "Plantar en zona visible (jardín frontal, andén)",
+            "Tolera podas urbanas anuales para formación"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío cafetalero compatible 80-150 árb/ha. Maderable secundario en plantaciones mixtas. Arbolado urbano patrimonial municipal.",
+          "tips": [
+            "Madera dura amarillo-marrón apreciada para construcción rural",
+            "Polen y néctar para apicultura nativa",
+            "Tolera contaminación urbana mejor que Quercus"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera bosque seco tropical en restauración Caribe y valles interandinos.",
+          "tips": [
+            "Tolera suelos pedregosos y pendientes fuertes",
+            "Asocio con Bombacopsis quinata en bosque seco"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Árbol ornamental-maderable patrimonial neotropical. Floración masiva sincrónica rosado-violácea en estación seca tras estrés hídrico, espectáculo paisajístico icónico de cafetales y pueblos del Caribe colombiano. Madera amarillo-marrón dura apreciada para construcción rural, vigas, postes, ebanistería. Flores grandes tubulares atraen abejas y colibríes. Importante en arbolado urbano municipal de ciudades cálidas y templadas.",
+      "valor_pedagogico": "El guayacán rosado u ocobo (Tabebuia rosea (Bertol.) DC., sinónimo válido Handroanthus roseus, Bignoniaceae) es uno de los árboles más patrimoniales del paisaje colombiano. Nativo desde el sur de México hasta Ecuador, en Colombia se distribuye prácticamente en todas las regiones bajas y medias: Caribe (Sucre, Córdoba, Bolívar, Magdalena, La Guajira), Andina (valles del Magdalena, Cauca y Patía, piedemonte llanero en Cundinamarca, Tolima, Huila, Antioquia, Santander, Norte de Santander, Caldas, Risaralda, Quindío, Valle), Pacífico (Chocó, Valle), Orinoquía (Casanare, Meta) entre 0 y 1.600 msnm en zona térmica cálida a templada. Árbol caducifolio de 15-25 m de altura con fuste recto y copa abierta hemisférica, hojas opuestas palmaticompuestas con 5 folíolos elípticos, su característica más espectacular es la floración masiva sincrónica en estación seca (febrero-marzo en Andes, enero-marzo en Caribe): tras estrés hídrico el árbol pierde totalmente las hojas y se cubre de grandes flores tubulares rosado-violáceas (5-8 cm) en panículas terminales que tapizan el suelo al caer convirtiendo calles y veredas en alfombras rosadas. Este fenómeno paisajístico es ícono cultural de pueblos cafeteros (Pueblo Tapao, Filandia, Salento), municipios del Caribe (Sincelejo, Valledupar), Ibagué, Bogotá (avenidas), y aparece en pinturas, poesía y postales turísticas. Su madera amarillo-marrón dura y resistente a la pudrición es apreciada para construcción rural (vigas, postes, durmientes), ebanistería e instrumentos musicales artesanales. Es importante en arbolado urbano municipal porque tolera mejor que el roble (Quercus) la contaminación urbana, los suelos compactados y las podas eléctricas, además provee néctar y polen para abejas y colibríes urbanos durante semanas de floración masiva. En sistemas agroforestales cafetales templados acepta densidades 80-150 árb/ha como sombrío estético-productivo. En restauración de bosque seco tropical (Caribe, valle del Magdalena) es pionera valiosa por tolerancia a suelos pedregosos y pendientes. La floración masiva sincrónica es tema clásico de fenología tropical: dispara la dehiscencia de cápsulas y la dispersión de semillas aladas justo al inicio de lluvias, maximizando germinación. Manejo agroecológico: propagación por semilla recién recolectada con germinación rápida (8-15 días), vivero al sol parcial, plantación definitiva a 30-40 cm, podas de formación años 1-3, tolera podas urbanas anuales. Es lección de soberanía paisajística: en lugar de plantar jacaranda exótica de Argentina-Brasil o cerezos japoneses ornamentales, el ocobo nativo provee la misma magia floral en su versión rosada colombiana, con valor maderable adicional. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Cárdenas & Salinas 2007, Trees of Antioquia, POWO Kew, GBIF Backbone Taxonomy.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "libro-rojo-plantas-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH40_BOSQUE_SECO",
+      "id": "enterolobium_cyclocarpum",
+      "nombre_comun": "Orejero",
+      "nombre_comunes_regionales": [
+        "carito",
+        "piñón de oreja",
+        "oreja de negro",
+        "guanacaste",
+        "conacaste"
+      ],
+      "nombre_cientifico": "Enterolobium cyclocarpum (Jacq.) Griseb.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "nitrogen_fixer",
+        "windbreak",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1300
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 24,
+        "optimo_max": 32,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "habito": "árbol caducifolio gigante 25-40 m, copa hemisférica muy amplia hasta 50 m de diámetro, fruto característico en forma de oreja",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla muy dura requiere escarificación: lima, ácido sulfúrico 30 min o agua hirviendo + remojo 24 h. Germinación 80-95% a 7-14 días. Vivero 4-5 meses. Plantación definitiva a 30 cm. Crecimiento rápido.",
+        "tiempo_a_establecimiento_dias": 50,
+        "notas": "Árbol más grande del bosque seco tropical americano. Fruto característico vaina circular curvada en forma de oreja humana (origen del nombre). Forraje suplementario crítico ganadería seca: vainas dulces alto contenido proteína.",
+        "fuente": "Bernal 2015; POWO; FAO Ecocrop; Agrosavia silvopastoriles; CIAT manuales bosque seco"
+      },
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "pseudosamanea_guachapele",
+        "samanea_saman"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol gigante 25-40 m copa 50 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": false,
+          "nota": "Inviable en huerto casero por tamaño extraordinario. Requiere mínimo 50 m de radio."
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío silvopastoril extensivo 25-40 árb/ha. Vainas forraje suplementario alto proteína. Patrimonial Caribe-Valle.",
+          "tips": [
+            "Vainas cosechables sept-nov: 50-80 kg/árb/año",
+            "Forraje complementario seca: bovinos, equinos, porcinos",
+            "Madera blanca-cremosa apreciada tornería embarcaciones"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Especie patrimonial y emblemática bs-T colombiano. Densidad baja por tamaño extraordinario (15-30 ind/ha).",
+          "tips": [
+            "Atrae avifauna y mamíferos dispersores (sahínos, dantas)",
+            "Sombra crítica fauna seca",
+            "Resistente sequías extremas 6 meses"
+          ]
+        }
+      },
+      "scale_viability": [
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Árbol gigante caducifolio leguminosa fijadora de N del bosque seco tropical americano. Copa hemisférica hasta 50 m de diámetro provee sombrío extremo a ganadería extensiva. Vainas en forma de oreja humana (origen del nombre) cosechables como forraje suplementario alto en proteína (16-20% MS) crítico en estación seca prolongada. Atractor mamíferos y avifauna dispersora del bs-T. Patrimonial Caribe, Valle del Cauca, Tolima, Huila.",
+      "valor_pedagogico": "El orejero, carito o piñón de oreja (Enterolobium cyclocarpum (Jacq.) Griseb., Fabaceae subfamilia Mimosoideae) es el árbol más grande y emblemático del bosque seco tropical (bs-T) americano, conocido como \"guanacaste\" en Centroamérica (árbol nacional de Costa Rica), \"conacaste\" en El Salvador, y \"orejero\" o \"carito\" en Colombia. Su nombre español proviene del fruto característico: una vaina circular curvada y aplanada en forma de oreja humana, marrón-negra brillante a la madurez, contiene 6-15 semillas duras inmersas en pulpa dulce y aromática. Nativo del Neotrópico desde México hasta Brasil-Perú, en Colombia se distribuye en el bosque seco tropical de los valles interandinos del Magdalena (Tolima, Huila, Cundinamarca, Boyacá, Santander), Cauca (Valle, Cauca), Patía, Sinú-San Jorge (Córdoba, Sucre, Bolívar), Caribe seco (La Guajira, Cesar, Magdalena, Atlántico) y piedemonte llanero (Casanare, Arauca) entre 0-1.000 msnm en zona térmica exclusivamente cálida (>24°C promedio anual). Árbol caducifolio de 25-40 m de altura con copa hemisférica muy amplia hasta 50 m de diámetro (la copa más extensa del bs-T), fuste recto cilíndrico hasta 3-4 m DAP, corteza grisácea con lenticelas, hojas bipinnadas con folíolos pequeños caducas en estación seca, flores blanco-verdosas en cabezuelas globulosas, frutos vaina circular curvada característica. Su rol ecológico es triple: (1) sombrío extremo para ganadería extensiva — un solo árbol provee sombra a 50-100 cabezas de ganado bovino reduciendo estrés térmico crítico en climas 35-38°C; (2) forraje suplementario en estación seca: las vainas dulces caen desde septiembre-noviembre, son apetentes para bovinos, equinos y porcinos, contienen 16-20% proteína MS y 65% TND, sustituyendo concentrado comercial en finca; (3) fijación biológica de N como Mimosoideae mediante rizobios, aporte crítico en suelos pobres compactados del bs-T. Como leguminosa pionera de gran porte y crecimiento rápido (10-15 m en 8-10 años) es especie clave en restauración de bs-T y atractor crítico para mamíferos dispersores nativos como sahínos (Tayassu pecari, T. tajacu), dantas (Tapirus bairdii), ñeques (Dasyprocta), micos aulladores (Alouatta seniculus) y avifauna granívora (Aratinga, Brotogeris, Forpus). Su madera blanco-cremosa medianamente densa es apreciada en tornería, ebanistería, embarcaciones tradicionales (canoas dugout precolombinas), construcción rural ligera. Manejo agroecológico: propagación por semilla con escarificación crítica (semilla muy dura: lima mecánica, ácido sulfúrico 30 min, o agua hirviendo + remojo 24 h, germinación 80-95% a 7-14 días), vivero 4-5 meses a sol pleno, plantación definitiva a 30 cm, distancia 25-40 árb/ha en silvopastoril extensivo (densidad baja por tamaño extraordinario), cosecha de vainas septiembre-noviembre 50-80 kg/árb/año. Es lección extraordinaria de cómo un árbol nativo gigante puede transformar la ganadería extensiva del bs-T en sistema silvopastoril sostenible: reduce estrés calórico bovino, provee forraje suplementario gratuito que ahorra concentrado importado, fija N al suelo, atrae fauna dispersora restauradora, y produce madera de calidad — todo en un solo árbol patrimonial. Es además testimonio vivo de los bosques secos pre-coloniales, donde estos gigantes eran abundantes y dispersaban sus vainas a través de la megafauna pleistocénica extinta (gomphoteres, gliptodontes): hoy el ganado bovino doméstico cumple el rol dispersor co-evolutivo, manteniendo el árbol vivo en el paisaje. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, Agrosavia silvopastoriles bs-T.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "fao-ecocrop",
+        "agrosavia-silvopastoriles"
+      ],
+      "tracking_mode": "individual"
+    },
+    {
+      "id": "capsicum_chinense_aji_panca",
+      "nombre_comun": "Ají panca",
+      "nombre_comunes_regionales": [
+        "ají panca colombiano",
+        "ají rojo seco",
+        "ají dulce-picante",
+        "panca"
+      ],
+      "nombre_cientifico": "Capsicum chinense Jacq. cv. 'Panca'",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación 8-15 días a 22-28°C. Trasplante a las 6-8 semanas con 4-6 hojas verdaderas. Distancia 50-60 cm. Ciclo 4-6 meses a primera cosecha."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El ají panca (Capsicum chinense Jacq. cv. 'Panca', Solanaceae) es un cultivar de ají de fruto rojo intenso y picor moderado (10.000-30.000 SHU en escala Scoville, equivalente a ají cayena suave) tradicional de la región andina noroccidental de Suramérica con presencia ancestral en Colombia bajo el nombre 'ají panca colombiano' o 'ají rojo seco', particularmente en las regiones Andina (Cundinamarca, Boyacá clima medio, Santander, Norte de Santander, Tolima, Huila, Antioquia, Valle del Cauca, Cauca, Nariño) y Caribe (Magdalena, Bolívar, Sucre, Córdoba) entre 0 y 1.800 msnm en zonas térmicas cálidas y templadas. Pertenece a la familia Solanaceae (igual que tomate, papa, pimentón, lulo, tomate de árbol, uchuva, ají dulce, rocoto, ulluco) y al género Capsicum del que existen cinco especies domesticadas: C. annuum (pimentón, jalapeño, cayena), C. chinense (habanero, panca, ají charapita, ají amarillo de mar), C. baccatum (ají amarillo andino), C. pubescens (rocoto), C. frutescens (tabasco, chiltepín). El cultivar 'panca' se distingue por frutos alargados (8-12 cm) de color rojo oscuro a casi negro cuando maduros, secados al sol para uso culinario en pastas y aderezos, picor moderado equilibrado por dulzor afrutado, y aceites esenciales ricos en capsaicina (alcaloide responsable del picor con propiedades vasodilatadoras, analgésicas tópicas y antimicrobianas) y carotenoides (capsantina, capsorubina, beta-caroteno provitamina A). Es lección viva de domesticación precolombina y biodiversidad cultivada que enseña a niñas y niños cómo los pueblos andinos seleccionaron durante miles de años decenas de cultivares de ají con diferentes niveles de picor, color, sabor y uso culinario — patrimonio agrobiocultural irreemplazable. Manejo agroecológico: propagación por semilla (germinación 8-15 días a 22-28°C, no tolera heladas), trasplante a las 6-8 semanas con 4-6 hojas verdaderas, distancia 50-60 cm entre plantas y 80 cm entre surcos, riego regular pero sin encharcamiento (sensible a Phytophthora capsici), tutorado opcional para variedades altas, cosecha escalonada de frutos maduros rojos durante 2-4 meses, secado al sol para conservación de pasta picante. Companion plants ideales: albahaca (repele plagas), cebollín y cebolla larga (repele áfidos), zanahoria. Antagonistas: hinojo (alelopatía), brassicas en proximidad cercana. Función en chagra como hortaliza-condimento de alto valor culinario y atractora de polinizadores. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015 Catálogo Plantas y Líquenes Colombia, AGROSAVIA Manual Frutales Tropicales, Pérez-Arbeláez 1947 Plantas Útiles Colombia.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "id": "capsicum_annuum_aji_dulce_caribe",
+      "nombre_comun": "Ají dulce caribe",
+      "nombre_comunes_regionales": [
+        "ají dulce",
+        "ají de olor",
+        "ají gustoso",
+        "ajicito dulce"
+      ],
+      "nombre_cientifico": "Capsicum annuum L. cv. 'Dulce'",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1500,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 20,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germinación 7-12 días a 25-28°C. Trasplante a las 5-6 semanas. Distancia 40-50 cm. Ciclo 3-5 meses a primera cosecha. Sin picor por mutación recesiva del gen Pun1 — frutos aromáticos pero sin capsaicina."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "bernal-2015-plantas-liquenes-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "El ají dulce caribe (Capsicum annuum L. cv. 'Dulce', Solanaceae) es un cultivar emblemático de la cocina caribeña colombiana, venezolana y antillana caracterizado por la ausencia total de picor (0 SHU, mutación recesiva del gen Pun1 que desactiva la biosíntesis de capsaicina) pero con un aroma frutal-floral intenso y único que lo convierte en el condimento aromático base del sofrito caribeño, hogao y guisos costeños — patrimonio agroalimentario afro-caribeño irreemplazable. Se cultiva en toda la región Caribe colombiana (Atlántico, Magdalena, Bolívar, Cesar, Córdoba, Sucre, La Guajira, Arauca, Casanare en piedemonte llanero), Pacífico (Chocó, Valle), Andina baja (valles cálidos interandinos de Antioquia, Santander, Norte de Santander, Tolima, Huila, Valle del Cauca) y Orinoquía (Meta, Vichada) entre 0 y 1.500 msnm en zonas térmicas cálidas y templadas. Pertenece a la familia Solanaceae y al género Capsicum, especie C. annuum (la más cultivada globalmente, que incluye pimentón, jalapeño, cayena, paprika), cultivar 'Dulce' diferenciado del pimentón por su tamaño pequeño (3-6 cm), forma campanulada irregular o piriforme, colores variados al madurar (rojo, amarillo, naranja, verde-amarillento), pulpa delgada aromática y aroma intenso frutal-floral con notas a manzana-piña-floral distinto del aroma vegetal del pimentón. La mutación que elimina el picor mantiene íntegros los carotenoides (capsantina, capsorubina, beta-caroteno), flavonoides (quercetina, luteolina), vitamina C abundante y aceites esenciales aromáticos — convirtiéndolo en condimento de alta densidad nutricional sin la barrera sensorial del picante para niños y mayores. Es lección viva de domesticación selectiva por sabor y de cómo los pueblos afro-caribeños seleccionaron a través de generaciones una variante sin picor pero con aroma maximizado para construir una identidad culinaria distintiva: el sofrito caribeño con ají dulce, cebolla larga, ajo, cilantro y tomate es la base aromática de la cocina costeña colombiana, venezolana, cubana, dominicana y boricua. Manejo agroecológico: propagación por semilla (germinación 7-12 días a 25-28°C), trasplante a las 5-6 semanas, distancia 40-50 cm entre plantas, riego regular, sin tutorado en variedades compactas, cosecha escalonada 3-5 meses, primera cosecha temprana (más rápido que ajíes picantes). Companion plants ideales: albahaca, cilantro cimarrón, cebollín, tomate, plátano (estrato superior). Función en chagra costeña como hortaliza-condimento aromática insustituible. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, Bernal 2015 Catálogo Plantas y Líquenes Colombia, AGROSAVIA Manual Frutales Tropicales, Pérez-Arbeláez 1947 Plantas Útiles Colombia.",
+      "tracking_mode": "aggregate"
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_ARBOLES_TEMPLADO_RETRY",
+      "id": "cedrela_montana",
+      "nombre_comun": "Cedro de montaña",
+      "nombre_comunes_regionales": [
+        "cedro andino",
+        "cedro de tierra fría",
+        "cedro rosado"
+      ],
+      "nombre_cientifico": "Cedrela montana Moritz ex Turcz.",
+      "familia_botanica": "Meliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "árbol caducifolio de montaña, 20-30 m altura, fuste recto, copa amplia globosa, corteza pardo-grisácea profundamente fisurada",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca (julio-agosto en Andes colombianos). Sin tratamiento pregerminativo. Germinación 60-80% a 20-40 días en bandejas con sustrato orgánico. Vivero a media sombra 50%. Plantación definitiva a los 5-8 meses (30-50 cm altura) a inicio de lluvias.",
+        "tiempo_a_establecimiento_dias": 90,
+        "notas": "Análogo andino de Cedrela odorata adaptado a clima frío templado. Menos atacado por Hypsipyla grandella que C. odorata. Madera rosada apreciada en mueblería andina. Recomendado restauración Andes 1500-2800 msnm.",
+        "fuente": "Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia; Bernal et al. 2015; CIAT/AGROSAVIA manuales restauración andina"
+      },
+      "companions": [
+        "alnus_acuminata",
+        "coffea_arabica",
+        "inga_densiflora",
+        "juglans_neotropica"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 20-30 m, inviable."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Ejemplar patrimonial en huerto andino >800 m² como sombra y reserva maderable familiar.",
+          "tips": [
+            "Plantación a >8 m de construcciones",
+            "Podas de formación años 2-4 para fuste recto"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Plantaciones maderables andinas templado-frío 400-625 árb/ha (4x4 a 5x5 m) o sombrío café-altura 80-150 árb/ha. Turno comercial 30-40 años para diámetros >40 cm.",
+          "tips": [
+            "Asocio con Alnus o Inga densiflora",
+            "Raleos progresivos años 10-18-25",
+            "Menor presión Hypsipyla que C. odorata"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Especie clave restauración bosque andino premontano y montano bajo Andes colombianos.",
+          "tips": [
+            "Densidad 600-800 ind/ha",
+            "Asociar con Alnus acuminata como N-fijadora pionera",
+            "Protección de ganado primeros 5 años"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [
+        "Hypsipyla grandella — barrenador del cedro, menor presión que C. odorata pero presente en plantaciones puras"
+      ],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Maderable nativo del bosque andino montano colombiano. Caducifolio que aporta hojarasca estacional rica en N al suelo, atractor de polinizadores nativos (panículas florales melíferas), hospedero de avifauna andina, especie clave para restauración entre 1500-2800 msnm. Madera rosada-rojiza apreciada en ebanistería tradicional andina.",
+      "valor_pedagogico": "El cedro de montaña (Cedrela montana, Meliaceae) es el análogo andino del cedro real (Cedrela odorata) adaptado al clima templado-frío de los bosques montanos colombianos entre 1.500 y 2.800 msnm. Distribuido en la región Andina especialmente en Antioquia, Boyacá, Cundinamarca, Caldas, Quindío, Risaralda, Tolima, Huila, Valle del Cauca, Cauca, Nariño y Santanderes. Árbol caducifolio de montaña de 20-30 metros de altura con fuste cilíndrico recto, copa amplia globosa y corteza pardo-grisácea profundamente fisurada longitudinalmente; hojas pinnadas grandes con folíolos lanceolados-elípticos verde oscuro que despiden olor característico a cedro al frotarlas (igual que C. odorata), flores pequeñas blanco-verdosas en panículas terminales melíferas atractoras de abejas y mariposas nativas, cápsulas leñosas dehiscentes con semillas aladas dispersadas por viento de montaña en estación seca. Su madera —de color rosado-rojizo, aromática, de densidad media— ha sido históricamente apreciada en la ebanistería tradicional andina colombiana para mueblería rural, puertas, ventanas, vigas y construcción patrimonial campesina del altiplano cundiboyacense y la zona cafetera de altura. A diferencia del cedro real (C. odorata) de tierras bajas calientes, el cedro de montaña se desarrolla en climas templados-fríos con temperaturas medias 12-20°C y aguanta heladas suaves hasta -2°C, lo que lo hace ideal para reforestación de tierras altas y de cordillera Andina colombiana. Su mayor virtud agroecológica es que sufre menor presión del barrenador Hypsipyla grandella que su congénere de tierra caliente, lo que permite plantaciones más puras y de mayor productividad maderable sin requerir tanto sombrío protector. Es especie clave en programas de restauración de bosque andino montano y premontano, asociado a Alnus acuminata (aliso N-fijador pionero) que actúa como nodriza inicial mientras el cedro alcanza el dosel intermedio. Su asocio agroecológico tradicional incluye los cafetales de altura (1.500-2.000 msnm) en Caldas, Quindío, Antioquia y Santander, donde aporta sombrío parcial, biomasa hojarasca rica, atractor de polinizadores y madera patrimonial familiar de turno largo (30-40 años). Es lección de soberanía maderera andina: en lugar de pino patula o pino radiata exóticos plantados masivamente en los Andes durante el siglo XX (con altos costos ecológicos: acidificación, erosión, desertificación de suelos), el cedro de montaña nativo ofrece servicios maderables equivalentes con servicios ecosistémicos completos (biodiversidad, polinización, fauna). Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, CIAT/AGROSAVIA manuales restauración andina.",
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "ciat-1995-alnus"
+      ],
+      "tracking_mode": "individual"
+    }
+  ],
+  "sources": [
+    {
+      "id": "agrosavia-leguminosas-andinas",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "AGROSAVIA",
+      "año": null,
+      "titulo": "Fichas técnicas de leguminosas andinas (haba, arveja, lenteja, frijol)",
+      "institucion": "Corporación Colombiana de Investigación Agropecuaria (AGROSAVIA)",
+      "observaciones": "Compilación de fichas técnicas de AGROSAVIA para leguminosas de clima frío. Año y volumen pendientes de consolidación.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-biopreparados-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual de biopreparados para la agricultura colombiana",
+      "institucion": "AGROSAVIA",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-chachafruto-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual técnico para el cultivo de chachafruto (Erythrina edulis) en sistemas agroforestales andinos",
+      "institucion": "AGROSAVIA",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-frutales-tropicales",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA — Corporación Colombiana de Investigación Agropecuaria",
+      "año": 2017,
+      "titulo": "Manual técnico para el cultivo de frutales tropicales en Colombia",
+      "institucion": "AGROSAVIA",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-tuberculos-andinos-2017",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2017,
+      "titulo": "Manual técnico para el cultivo de tubérculos andinos (oca, ulluco, mashua) en Colombia",
+      "institucion": "AGROSAVIA",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-uchuva-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual técnico para el cultivo de uchuva (Physalis peruviana) bajo condiciones colombianas",
+      "institucion": "AGROSAVIA",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-silvopastoriles",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": null,
+      "titulo": "Sistemas silvopastoriles en el altoandino colombiano",
+      "institucion": "AGROSAVIA",
+      "observaciones": "STUB migrado de v3.0. Año y publicación específica pendientes.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-sol-andina",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "AGROSAVIA",
+      "año": 2016,
+      "titulo": "Ficha técnica Sol Andina — papa criolla Grupo Phureja",
+      "institucion": "Corporación Colombiana de Investigación Agropecuaria (AGROSAVIA)",
+      "url": "https://www.agrosavia.co",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-tibaitata",
+      "tipo": "base_datos",
+      "autores": "AGROSAVIA",
+      "año": null,
+      "titulo": "Centro de Investigación Tibaitatá — publicaciones sobre cultivos andinos y altoandinos",
+      "institucion": "AGROSAVIA",
+      "url": "https://www.agrosavia.co/investigacion/centros-de-investigacion/tibaitat%C3%A1",
+      "tier": "A"
+    },
+    {
+      "id": "bernal-2015-plantas-liquenes-colombia",
+      "tipo": "base_datos",
+      "autores": "Bernal, R.; Gradstein, S.R.; Celis, M. (eds.)",
+      "año": 2015,
+      "titulo": "Catálogo de Plantas y Líquenes de Colombia",
+      "institucion": "Instituto de Ciencias Naturales, Universidad Nacional de Colombia",
+      "url": "http://catalogoplantasdecolombia.unal.edu.co",
+      "tier": "A"
+    },
+    {
+      "id": "cenicafe-manual-cafetero-2013",
+      "tipo": "manual_tecnico",
+      "autores": "Cenicafé",
+      "año": 2013,
+      "titulo": "Manual del Cafetero Colombiano — Investigación y tecnología para la sostenibilidad de la caficultura",
+      "institucion": "Centro Nacional de Investigaciones de Café (Cenicafé)",
+      "url": "https://www.cenicafe.org/es/index.php/nuestras_publicaciones",
+      "tier": "A"
+    },
+    {
+      "id": "ciat-1995-alnus",
+      "tipo": "manual_tecnico",
+      "autores": "CIAT — Centro Internacional de Agricultura Tropical",
+      "año": 1995,
+      "titulo": "Alnus acuminata en sistemas agroforestales andinos",
+      "institucion": "CIAT Palmira",
+      "observaciones": "STUB migrado de v3.0 — título y paginación pendientes de confirmación.",
+      "tier": "A"
+    },
+    {
+      "id": "cip-2006-ghislain",
+      "tipo": "articulo_revista",
+      "autores": "Ghislain, M.; Andrade, D.; Rodríguez, F.; Hijmans, R.J.; Spooner, D.M.",
+      "año": 2006,
+      "titulo": "Genetic analysis of the cultivated potato Solanum tuberosum L. Phureja Group using RAPDs",
+      "institucion": "CIP — International Potato Center",
+      "tier": "A"
+    },
+    {
+      "id": "fao-2013-quinua",
+      "tipo": "libro",
+      "autores": "FAO — Organización de las Naciones Unidas para la Alimentación y la Agricultura",
+      "año": 2013,
+      "titulo": "Quinua: Año Internacional de la Quinua 2013 — Documentos técnicos y estado del arte",
+      "institucion": "FAO",
+      "url": "https://www.fao.org/quinoa-2013",
+      "tier": "A"
+    },
+    {
+      "id": "fao-ecocrop",
+      "tipo": "base_datos",
+      "autores": "FAO",
+      "año": null,
+      "titulo": "EcoCrop — Crop Environmental Requirements Database",
+      "url": "https://gaez.fao.org/pages/ecocrop",
+      "tier": "A"
+    },
+    {
+      "id": "gbif-colombia",
+      "tipo": "base_datos",
+      "autores": "GBIF Secretariat / SiB Colombia",
+      "año": null,
+      "titulo": "GBIF — Global Biodiversity Information Facility (datos de ocurrencia en Colombia)",
+      "url": "https://www.gbif.org/country/CO",
+      "tier": "A"
+    },
+    {
+      "id": "gbif-taxonomic-backbone",
+      "tipo": "base_datos",
+      "autores": "GBIF Secretariat",
+      "año": 2024,
+      "titulo": "GBIF Backbone Taxonomy",
+      "institucion": "Global Biodiversity Information Facility",
+      "url": "https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c",
+      "tier": "A"
+    },
+    {
+      "id": "humboldt-flora-alto-andina",
+      "tipo": "libro",
+      "autores": "Instituto Alexander von Humboldt",
+      "año": null,
+      "titulo": "Flora del bosque alto andino colombiano",
+      "institucion": "Instituto Humboldt",
+      "observaciones": "STUB migrado de v3.0.",
+      "tier": "A"
+    },
+    {
+      "id": "ica-resolucion-3168-2015",
+      "tipo": "resolucion_oficial",
+      "autores": "ICA",
+      "año": 2015,
+      "titulo": "Resolución 3168 de 2015 — Reglamenta la producción, importación y exportación de semillas",
+      "institucion": "Instituto Colombiano Agropecuario (ICA)",
+      "tier": "A"
+    },
+    {
+      "id": "jbb-plantas-medicinales",
+      "tipo": "libro",
+      "autores": "Jardín Botánico José Celestino Mutis — Bogotá",
+      "año": 2010,
+      "titulo": "Plantas medicinales de Cundinamarca y Boyacá",
+      "institucion": "Jardín Botánico de Bogotá José Celestino Mutis",
+      "tier": "A"
+    },
+    {
+      "id": "libro-rojo-plantas-colombia",
+      "tipo": "libro",
+      "autores": "Cárdenas-López, D.; Salinas, N.R. (eds.)",
+      "año": 2006,
+      "titulo": "Libro Rojo de Plantas de Colombia. Volumen 4 — Especies maderables amenazadas (y volúmenes sucesivos)",
+      "institucion": "Instituto Amazónico de Investigaciones Científicas SINCHI / Instituto Humboldt / MADS",
+      "tier": "A"
+    },
+    {
+      "id": "mujica-1992-quinua",
+      "tipo": "articulo_revista",
+      "autores": "Mujica, A.",
+      "año": 1992,
+      "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
+      "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales.",
+      "tier": "B"
+    },
+    {
+      "id": "nrc-1989-cultivos-andinos",
+      "tipo": "libro",
+      "autores": "National Research Council (NRC)",
+      "año": 1989,
+      "titulo": "Lost Crops of the Incas: Little-Known Plants of the Andes with Promise for Worldwide Cultivation",
+      "revista_o_editorial": "National Academy Press",
+      "isbn": "9780309042642",
+      "tier": "A"
+    },
+    {
+      "id": "nustez-rodriguez-2024-unal",
+      "tipo": "libro",
+      "autores": "Ñústez, C.E.; Rodríguez, L.E.",
+      "año": 2024,
+      "titulo": "Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca",
+      "revista_o_editorial": "Editorial Universidad Nacional de Colombia",
+      "isbn": "9789585054929",
+      "tier": "B"
+    },
+    {
+      "id": "pamplona-roger-2006-plantas-medicinales",
+      "tipo": "libro",
+      "autores": "Pamplona-Roger, J.D.",
+      "año": 2006,
+      "titulo": "Enciclopedia de las plantas medicinales",
+      "revista_o_editorial": "Safeliz",
+      "observaciones": "STUB migrado de v3.0 — confirmar ISBN.",
+      "tier": "B"
+    },
+    {
+      "id": "perez-arbelaez-1947-plantas-utiles",
+      "tipo": "libro",
+      "autores": "Pérez Arbeláez, E.",
+      "año": 1947,
+      "titulo": "Plantas Útiles de Colombia",
+      "revista_o_editorial": "Librería Colombiana / Camacho Roldán",
+      "observaciones": "Obra clásica de la botánica económica colombiana; múltiples reediciones posteriores.",
+      "tier": "A"
+    },
+    {
+      "id": "perez-rodriguez-gomez-2008",
+      "tipo": "articulo_revista",
+      "autores": "Pérez, L.; Rodríguez, L.E.; Gómez, M.I.",
+      "año": 2008,
+      "titulo": "Plan de fertilización de la papa criolla en el altiplano cundiboyacense",
+      "revista_o_editorial": "Agronomía Colombiana",
+      "volumen_numero": "26(3)",
+      "paginas": "477-486",
+      "tier": "B"
+    },
+    {
+      "id": "powo-kew",
+      "tipo": "base_datos",
+      "autores": "Royal Botanic Gardens, Kew",
+      "año": null,
+      "titulo": "Plants of the World Online (POWO)",
+      "url": "https://powo.science.kew.org",
+      "tier": "A"
+    },
+    {
+      "id": "restrepo-1996-abc-agricultura-organica",
+      "tipo": "libro",
+      "autores": "Restrepo, J.",
+      "año": 1996,
+      "titulo": "ABC de la agricultura orgánica (variante de cita usada en v3.0)",
+      "observaciones": "STUB — posiblemente misma obra que restrepo-1996-bocashi. Verificar y dedupear.",
+      "tier": "B"
+    },
+    {
+      "id": "restrepo-2007-biopreparados",
+      "tipo": "manual_tecnico",
+      "autores": "Jairo Restrepo Rivera",
+      "año": 2007,
+      "titulo": "Manual práctico de biopreparados aplicados a la agricultura orgánica",
+      "institucion": "Fundación Juquira Candiru",
+      "tier": "B"
+    },
+    {
+      "id": "sib-colombia",
+      "tipo": "base_datos",
+      "autores": "Sistema de Información sobre Biodiversidad de Colombia",
+      "año": null,
+      "titulo": "SiB Colombia — Catálogo de la biodiversidad de Colombia",
+      "url": "https://sibcolombia.net",
+      "tier": "A"
+    },
+    {
+      "id": "sinchi-amazonia-colombiana",
+      "tipo": "base_datos",
+      "autores": "Instituto SINCHI",
+      "año": null,
+      "titulo": "Publicaciones científicas sobre especies de la Amazonía colombiana",
+      "institucion": "Instituto Amazónico de Investigaciones Científicas SINCHI",
+      "tier": "A"
+    }
+  ],
+  "biopreparados": [
+    {
+      "id": "bocashi",
+      "nombre": "Bocashi",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "gallinaza",
+        "cascarilla de arroz",
+        "tierra de capote",
+        "carbón vegetal triturado",
+        "afrecho",
+        "melaza",
+        "levadura",
+        "agua"
+      ],
+      "proceso_resumen": "Fermentación aeróbica 15-21 días con volteo diario hasta bajar temperatura a <40°C. Humedad 'prueba de puño': al apretar un puñado, el agua no gotea pero la mano queda húmeda.",
+      "tiempo_elaboracion_dias": 18,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Al sustrato pre-siembra incorporado 0-15 cm, o como abonado de fondo en hoyos de trasplante. Reaplicación cada ciclo de cultivo (3-6 meses) en bandas al pie de la planta.",
+      "dosis": "1-2 kg/m² al voleo en cama de siembra; 100-300 g/planta en hoyo de trasplante; 8-15 t/ha en aplicación general. Reducir 30% si el suelo ya tiene >4% MO.",
+      "target": [
+        "fertilizante_general",
+        "inoculacion_microbiana_suelo",
+        "mejorador_estructura_suelo",
+        "aporte_materia_organica"
+      ],
+      "valor_pedagogico": "Tecnología japonesa (boka-shi, 'materia orgánica fermentada') adaptada a Latinoamérica por Jairo Restrepo. Fermentación aeróbica 45-55°C selecciona microbiota termófila (Bacillus, actinomicetos, levaduras) y estabiliza N orgánico no lixiviable, a diferencia de la urea sintética. La cascarilla aporta Si bioactivo; el carbón vegetal actúa como biochar (CEC + hábitat microbiano). Advertencias: >5 kg/m² en hortalizas de hoja → exceso N atrae áfidos y mildeo; humedad >65% vira a pútrida y pierde N. AGROSAVIA 2015 documenta respuestas equivalentes a 50% NPK sintético en papa criolla y maíz andino.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "biol",
+      "nombre": "Biol",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "estiércol fresco (vaca/cabra)",
+        "leche o suero",
+        "melaza",
+        "ceniza",
+        "agua",
+        "roca fosfórica (opcional)"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica 30-45 días en biodigestor o caneca sellada con válvula de gases. Aplicación foliar diluido 1:10.",
+      "tiempo_elaboracion_dias": 40,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "pinheiro-machado-2017-biofertilizantes"
+      ],
+      "uso": "Foliar al amanecer o atardecer (evitar sol directo) cada 7-15 días en etapas de crecimiento vegetativo y prefloración. También aplicable al pie/riego durante toda la etapa productiva. Compatible con caldos minerales si se aplica 48 h antes/después.",
+      "dosis": "Foliar: 100-200 ml/L de agua (dilución 1:10 a 1:5). Drench/riego al pie: 1-2 L/m² o 200 L/ha del concentrado diluido 1:5. Empezar con dilución alta (1:20) en plántulas para evitar fitotoxicidad.",
+      "target": [
+        "fertilizante_foliar_N",
+        "bioestimulante_fitohormonal",
+        "inoculacion_microbiana_filosfera",
+        "resistencia_induccion_SAR"
+      ],
+      "valor_pedagogico": "Biofertilizante anaeróbico andino, popularizado por Restrepo y Pinheiro Machado. La fermentación selecciona bacterias fijadoras de N (Azotobacter, Clostridium) y solubilizadoras de P, generando fitohormonas (auxinas, citoquininas) y ácidos quelantes. La leche aporta caseínas fungistáticas y Lactobacillus que inducen SAR (Resistencia Sistémica Adquirida). Vs. urea 46-0-0 entrega N orgánico sin quemar follaje. Advertencias: olor amoniacal = mal sellado (descartar); filtrar antes de boquilla; >30% en lechuga/fresa necrosa. AGROSAVIA 2015: +15-25% en hortalizas andinas.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "purin_ortiga",
+      "nombre": "Purín de ortiga",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "repelente_insectos",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "ortiga fresca 1kg",
+        "agua 10L"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica 10-14 días (cuando deja de espumar, está listo). Rico en Fe, Si, N. Aplicación foliar 1:10.",
+      "tiempo_elaboracion_dias": 12,
+      "vida_util_dias": 60,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Foliar al amanecer cada 7-10 días en etapa vegetativa. Como repelente preventivo: aplicar al detectar plagas chupadoras incipientes. También al pie como bioestimulante de enraizamiento en plántulas y trasplantes.",
+      "dosis": "Foliar: 100 ml/L de agua (1:10) preventivo, 200 ml/L (1:5) curativo contra pulgón. Drench/raíz: 50 ml/L (1:20). Macerado fresco no fermentado (24-48 h) se usa más diluido 1:20 a 1:50.",
+      "target": [
+        "control_pulgon",
+        "control_acaros",
+        "fertilizante_foliar_Fe_Si",
+        "bioestimulante_enraizamiento",
+        "fitosanitario_preventivo_chupadores"
+      ],
+      "valor_pedagogico": "Preparado tradicional europeo (purin d'ortie) introducido a la agroecología latinoamericana por Restrepo y validado por AGROSAVIA. Urtica dioica/U. urens concentra Fe (4-7 mg/g MS), Si soluble, ácido fórmico y polifenoles antialimentarios contra áfidos (Myzus persicae) y ácaros (Tetranychus urticae). Corrige clorosis férrica sin acidificar el sustrato. Fermentación completa (cesa espuma) es clave: macerados frescos tienen formicato fitotóxico. Vs. imidacloprid no deja residuos ni daña polinizadores. NO mezclar con caldos cúpricos (precipita Fe).",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "caldo_sulfocalcico",
+      "nombre": "Caldo sulfocálcico",
+      "tipo": "caldo",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "azufre elemental",
+        "cal viva o hidratada",
+        "agua"
+      ],
+      "proceso_resumen": "Cocción de azufre + cal 2:1 en 10L agua por 45-60 min hasta color ámbar. Aplicación foliar 1:100 preventivo, 1:20 curativo. Evitar en frutales durante floración.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Foliar al atardecer cada 10-15 días en preventivo; cada 7 días en curativo activo contra hongos y ácaros. Suspender 15 días antes de cosecha. NO aplicar en frutales durante floración ni con temperaturas >28°C o humedad relativa <50% (riesgo fitotoxicidad).",
+      "dosis": "Preventivo foliar: 10 ml/L de agua (1:100). Curativo foliar: 50 ml/L (1:20). Invernal o tratamiento de troncos (escamas, chancros): 100-200 ml/L (1:10 a 1:5). En invernadero reducir 50%.",
+      "target": [
+        "mildeo_polvoso",
+        "oidio_foliar",
+        "roya_foliar",
+        "acaros_eriofidos",
+        "escamas_cocoideos",
+        "fitosanitario_curativo_amplio_espectro"
+      ],
+      "valor_pedagogico": "Polisulfuro de calcio (CaSx, x=4-5) coloidal por cocción S:cal 2:1. El S elemental se oxida en la cutícula del patógeno a SO2/H2S, inhibiendo respiración mitocondrial de hongos (Oidium, Erysiphe) y ácaros eriofidos. Permitido en orgánico (IFOAM, EU 2018/848), no genera resistencia cruzada vs. IBE sintéticos (tebuconazol). FITOTÓXICO en cucurbitáceas, durazno y cerezo en floración o con T>28°C — quemaduras severas. NO mezclar con bordelés (precipita CuS) ni con aceites; 21 d de separación. pH ~11-12: guantes y gafas.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "caldo_bordeles",
+      "nombre": "Caldo bordelés",
+      "tipo": "caldo",
+      "proposito": [
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "sulfato de cobre",
+        "cal hidratada",
+        "agua"
+      ],
+      "proceso_resumen": "100g sulfato + 100g cal en 10L agua, pH neutralizado (lámina de hierro no oxida). Aplicación foliar preventiva contra hongos (Phytophthora, mildius). No mezclar con otros.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 1,
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "uso": "Foliar preventivo al amanecer cada 10-14 días durante etapas de alta humedad relativa (>80%) o llovizna persistente. Suspender en floración (afecta polinizadores y cuaje) y 21 días antes de cosecha. Aplicar el mismo día de preparación — vida útil <24 h una vez mezclado.",
+      "dosis": "Concentración estándar 1% (10 g sulfato + 10 g cal por L de agua); foliar 1:1 (sin diluir, 10 L/100 m²) o lo equivalente a 200-400 L/ha. Cultivos sensibles (solanáceas en floración, durazno): bajar a 0.5%. Tratamiento invernal de troncos: hasta 2%.",
+      "target": [
+        "phytophthora_infestans",
+        "mildeo_velloso",
+        "antracnosis_colletotrichum",
+        "roya_cafe_hemileia",
+        "cercosporiosis",
+        "fungicida_cuprico_preventivo_amplio_espectro"
+      ],
+      "valor_pedagogico": "Fungicida cúprico de Burdeos 1885 (Millardet), fundacional en orgánico certificado (IFOAM, EU 2018/848 — máx 4 kg Cu/ha/año). CuSO4 neutralizado con cal forma Cu(OH)2·CuSO4 coloidal que libera Cu²⁺ con humedad/exudados fúngicos, inhibiendo tioles en oomicetes (Phytophthora, Peronospora) y hongos (Colletotrichum, Hemileia del café). pH 7-8 crítico: ácido = Cu²⁺ fitotóxico, alcalino = precipita inactivo. Test lámina de hierro: si se cubre de Cu rojizo, falta cal. NO mezclar con sulfocálcico (CuS) ni aceites; Cu >100 ppm daña lombrices y micorrizas — rotar con Bacillus o Trichoderma.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "te_compost",
+      "nombre": "Té de compost",
+      "tipo": "extracto",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "compost maduro 1kg",
+        "agua declorada 10L",
+        "melaza 2 cucharadas"
+      ],
+      "proceso_resumen": "Aeración con bomba de pecera 24-36h. Uso dentro de 4h post-preparación. Aplicación foliar 1:5 o riego al pie 1:10.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 1,
+      "uso": "Foliar al amanecer o atardecer cada 10-15 días en fase vegetativa, o como empapado al sustrato pre-trasplante; aplicar dentro de las 4 h posteriores a cortar la aireación para no perder la microbiota activa.",
+      "dosis": "Foliar: dilución 1:5 con agua declorada (≈200 ml de té por L de agua, 200-300 L/ha). Drench al pie: 1:10 (≈1 L por planta hortícola, 5 L por árbol joven).",
+      "target": [
+        "fertilizante_general",
+        "estimulante_microbiano_suelo",
+        "preventivo_mildeo_polvoso",
+        "preventivo_botrytis"
+      ],
+      "valor_pedagogico": "Inóculo microbiano vivo (10^8-10^9 UFC/ml de bacterias aerobias y esporas de hongos saprófitos) extraído del compost por aireación forzada con melaza como carbono lábil. Coloniza filoplano y rizosfera por exclusión competitiva contra patógenos (Ingham; Restrepo, ABC orgánico). Advertencias: si la aireación se detiene >2 h vira anaeróbico y produce ácidos fitotóxicos; no aplicar bajo sol del mediodía (UV mata 90% del inóculo en 30 min); no mezclar con caldo bordelés o sulfocálcico — el cobre/azufre esterilizan la microbiota.",
+      "source_ids": [
+        "ingham-2000-compost-tea",
+        "restrepo-1996-abc-agricultura-organica",
+        "agrosavia-manual-biopreparados-2015"
+      ]
+    },
+    {
+      "id": "humus_liquido",
+      "nombre": "Humus líquido (lixiviado de lombriz)",
+      "tipo": "extracto",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "humus de lombriz",
+        "agua"
+      ],
+      "proceso_resumen": "Lixiviado por percolación 1kg humus/5L agua durante 24h. Aplicación foliar 1:10 o riego 1:5.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 15,
+      "uso": "Foliar cada 7-15 días en fase vegetativa y vegetativa-reproductiva, preferentemente al amanecer; también drench al pie de plántulas recién trasplantadas para mitigar estrés de transplante.",
+      "dosis": "Foliar: 1:10 con agua (≈100 ml de lixiviado por L, ≈300 L de mezcla/ha). Drench: 1:5 (≈250 ml por planta hortícola, 1-2 L por árbol joven).",
+      "target": [
+        "fertilizante_general",
+        "bioestimulante_acidos_humicos",
+        "antiestres_transplante",
+        "preventivo_nematodos"
+      ],
+      "valor_pedagogico": "Lixiviado rico en ácidos húmicos y fúlvicos (3-8 g/L), reguladores tipo auxinas/citoquininas y microbiota aeróbica del tracto de Eisenia foetida (Pseudomonas, Bacillus, Actinomycetes). Los fúlvicos quelatan micronutrientes (Fe, Zn, Mn) facilitando absorción foliar — análogo orgánico a quelatos EDTA, biodegradable y de bajo costo (AGROSAVIA, Restrepo). Advertencias: dosis foliares >1:5 queman hojas tiernas por sales; olor a podredumbre indica anaerobiosis y descarte; conservar tapado en oscuridad <25°C — vida útil cae a 7 días si supera 30°C.",
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-1996-abc-agricultura-organica",
+        "restrepo-2007-biopreparados"
+      ]
+    },
+    {
+      "id": "lixiviado_frutas",
+      "nombre": "Lixiviado de frutas",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion"
+      ],
+      "ingredientes": [
+        "cáscaras y pulpas de frutas maduras",
+        "melaza",
+        "agua"
+      ],
+      "proceso_resumen": "Fermentación aeróbica 20-30 días con revolver semanal. Rica en K y micronutrientes. Aplicación foliar 1:20 en fase reproductiva.",
+      "tiempo_elaboracion_dias": 25,
+      "vida_util_dias": 120,
+      "uso": "Foliar cada 10-15 días desde inicio de floración hasta llenado de fruto; especialmente útil en cucurbitáceas, solanáceas, frutales en cuaja y leguminosas en envainado.",
+      "dosis": "Foliar: 1:20 con agua (≈50 ml de lixiviado por L, 200-300 L/ha). Drench reproductivo: 1:10 al pie semanal en pleno cuajado.",
+      "target": [
+        "fertilizante_floracion_fructificacion",
+        "aporte_potasio",
+        "micronutrientes_B_Zn_Mn",
+        "mejora_brix_calidad_fruto"
+      ],
+      "valor_pedagogico": "Fermentación láctica-alcohólica: levaduras (Saccharomyces, Hanseniaspora) y lácticas (Lactobacillus) degradan azúcares liberando K soluble (4-12 g/L K2O), B, Zn, Mn y ácidos orgánicos que liberan cationes en suelos calcáreos. Restrepo y Pinheiro lo usan como análogo orgánico al KNO3 en floración, sin salinización. Advertencias: moho blanco (Geotrichum) es seguro; negro/verde (Aspergillus) obliga descarte por micotoxinas. pH final 3.5-4.0; >4.5 indica putrefacción. No aplicar en vegetativa temprana — K antagoniza N.",
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ]
+    },
+    {
+      "id": "supermagro",
+      "nombre": "Supermagro",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "estiércol vaca",
+        "leche",
+        "melaza",
+        "sulfatos minerales (Mg, Zn, Mn, Cu, Fe, B, Co)",
+        "agua"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica 90 días con adición escalonada de sulfatos minerales cada 7 días. Corrige micronutrientes. Aplicación foliar 1:20.",
+      "tiempo_elaboracion_dias": 90,
+      "vida_util_dias": 365,
+      "uso": "Foliar correctivo de micronutrientes cada 15-21 días durante todo el ciclo, intensificando frecuencia en cultivos con síntomas visibles de deficiencia (clorosis intervenal, brotes deformes, frutos pequeños) o en suelos pobres/calcáreos del altiplano cundiboyacense.",
+      "dosis": "Foliar: 1:20 con agua (≈50 ml/L, 200-400 L/ha). Preventivo: 1:50 cada 30 días. Nunca superar 100 ml/L — riesgo de fitotoxicidad por exceso de Cu/Zn.",
+      "target": [
+        "correccion_micronutrientes",
+        "deficiencia_boro_zinc_manganeso",
+        "estimulante_microbiano_filoplano",
+        "fertilizacion_complemento_NPK"
+      ],
+      "valor_pedagogico": "Receta de Restrepo (1996) y Pinheiro: fermentación anaeróbica láctica de estiércol + leche + melaza donde Lactobacillus y levaduras solubilizan sulfatos añadidos en 5-7 etapas semanales, quelándolos con ácidos orgánicos y aminoácidos biodisponibles. Análogo orgánico a quelatos EDTA/EDDHA, biodegradable y a 1/10 del costo. Cubre 7 deficiencias típicas en suelos andinos ácidos (Mg, Zn, Mn, Cu, Fe, B, Co). Advertencias: sulfatos de Cu/Zn >2% esterilizan el barril; fermentación <60 días deja sulfatos sin quelatar y quema follaje; pH 3.5-4.2; contraindicado en floración plena.",
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2005-agroecologia",
+        "restrepo-2007-biopreparados"
+      ]
+    },
+    {
+      "id": "trichoderma_harzianum_suelo",
+      "nombre": "Trichoderma harzianum (aplicación al suelo)",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "cepa T. harzianum propagada en sustrato sólido (arroz/afrecho)"
+      ],
+      "proceso_resumen": "Aplicación 1kg/ha mezclado con compost maduro, incorporado en los primeros 10cm del suelo. Control biológico de Rhizoctonia, Fusarium, Sclerotinia.",
+      "tiempo_elaboracion_dias": 21,
+      "vida_util_dias": 90,
+      "uso": "Al sustrato pre-siembra o pre-trasplante, incorporado a 0-15 cm de profundidad mezclado con compost maduro como vehículo; también en hoyos de plantación de frutales y forestales, y como drench preventivo cada 30-45 días en cultivos con historial de pudriciones radiculares.",
+      "dosis": "Sustrato/campo: 1-2 kg/ha de sustrato sólido (10^8 UFC/g). Hoyo de plantación: 5-10 g por hoyo. Drench preventivo: 50 g/100 L de agua, 1-2 L por planta. Repetir a los 30-45 días en cultivos susceptibles.",
+      "target": [
+        "control_rhizoctonia_solani",
+        "control_fusarium_oxysporum",
+        "control_sclerotinia_sclerotiorum",
+        "control_pythium",
+        "induccion_resistencia_sistemica",
+        "promocion_crecimiento_radicular"
+      ],
+      "valor_pedagogico": "Hongo antagonista saprófito que coloniza la rizosfera y controla patógenos vía: (1) micoparasitismo sobre Rhizoctonia, Fusarium, Sclerotinia y Pythium degradándolas con quitinasas/β-1,3-glucanasas; (2) competencia por exudados radiculares; (3) antibióticos volátiles (6-pentil-pirona, gliotoxina); (4) inducción de resistencia sistémica vía jasmonato/etileno. AGROSAVIA y Cenicafé validaron cepas locales ICA-registradas, análogo al carbendazim sin residuos. Advertencias: no aplicar a suelo seco (<30% humedad); incompatible con cúpricos y mancozeb; evitar pleno sol; pH >8.0 contraindicado.",
+      "source_ids": [
+        "cenicafe-trichoderma-2010",
+        "agrosavia-manual-biopreparados-2015",
+        "agrosavia-bacillus-2018",
+        "ica-resolucion-3168-2015"
+      ]
+    },
+    {
+      "id": "bacillus_subtilis_foliar",
+      "nombre": "Bacillus subtilis (aplicación foliar)",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "cepa B. subtilis en suspensión 10^9 UFC/ml"
+      ],
+      "proceso_resumen": "Aplicación foliar 1L/ha cada 7-10 días. Control de Botrytis, Alternaria, Monilia. Compatible con caldos minerales.",
+      "tiempo_elaboracion_dias": 14,
+      "vida_util_dias": 30,
+      "source_ids": [
+        "agrosavia-bacillus-2018",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Prevención y control biológico de hongos foliares (Botrytis cinerea, Alternaria spp., Monilia spp., Sclerotinia) en hortalizas, frutales y aromáticas; aplicar al atardecer con cielo cubierto.",
+      "dosis": "Foliar: 2-5 ml/L de agua (suspensión 10^9 UFC/ml) cada 7-10 días en presión preventiva; 5-10 ml/L cada 5-7 días en presión curativa. Equivalente 1-2 L/ha. Volumen 200-400 L/ha según follaje.",
+      "target": [
+        "botrytis_cinerea",
+        "alternaria_spp",
+        "monilia_spp",
+        "sclerotinia_sclerotiorum",
+        "mildiu_velloso",
+        "oidio_temprano"
+      ],
+      "valor_pedagogico": "Bacteria Gram+ esporulada que coloniza la filosfera por exclusión competitiva y secreta lipopéptidos cíclicos (iturina, fengicina, surfactina) que perforan membranas fúngicas y disparan resistencia sistémica inducida (ISR) vía jasmonato/etileno. AGROSAVIA 2018 reporta cepas nativas con 60-80% de eficacia contra Botrytis en fresa/mora —equiparable a azoxistrobina, sin resistencia cruzada ni residuos. Restrepo lo combina con bocashi: éste siembra microbiota en suelo, B. subtilis la extiende al follaje. ADVERTENCIA: esporas fotosensibles (UV degrada en 2-4 h) → aplicar SIEMPRE al atardecer con adherente; incompatible con cobre y caldo sulfocálcico (alternar 48 h)."
+    },
+    {
+      "id": "cal_dolomita",
+      "nombre": "Cal dolomítica",
+      "tipo": "mineral",
+      "proposito": [
+        "enmienda_ph",
+        "enmienda_ca"
+      ],
+      "ingredientes": [
+        "CaMg(CO3)2 molido"
+      ],
+      "proceso_resumen": "Aplicación directa al suelo antes de siembra, dosis según análisis (típicamente 500-2000 kg/ha para subir pH 0.5 puntos).",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 730,
+      "source_ids": [
+        "ica-fertilizantes-2019",
+        "cochrane-1980-aluminio-saturacion",
+        "pinheiro-2003-cartilha-cal",
+        "restrepo-2005-agroecologia",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Enmienda correctiva para suelos ácidos con saturación de aluminio tóxica, SOLO con análisis de suelo en mano (pH < 5.5 y saturación Al > 30%); aplicar 2-3 meses antes de la siembra e incorporar a 10-15 cm.",
+      "dosis": "Fórmula Cochrane (1980): t/ha = 1.5-2 × cmol Al intercambiable/kg (suelos andinos tipo Andisol). Rango operativo 500-2000 kg/ha para subir pH 0.5 unidades. Particionar 50% pre-arado + 50% post-arado mejora homogeneidad. NUNCA exceder 3 t/ha por aplicación.",
+      "target": [
+        "acidez_suelo_ph_menor_5_5",
+        "toxicidad_aluminio_intercambiable",
+        "deficiencia_calcio",
+        "deficiencia_magnesio",
+        "saturacion_bases_baja"
+      ],
+      "valor_pedagogico": "CaMg(CO3)2 neutraliza H+/Al3+ del complejo de intercambio: CaMg(CO3)2 + 2Al3+ → Ca2+ + Mg2+ + 2Al(OH)3↓ + 2CO2. La cal NO es fertilizante de Ca: es corrector de toxicidad de aluminio (Cochrane 1980). Usarla 'a ojo' alcaliniza el complejo, precipita P como Ca-fosfatos insolubles, calcina la microbiota y emite ~440 kg CO2/t. REGLA DURA AGROECOLÓGICA: aplicar SOLO con análisis de suelo que muestre pH<5.5 Y saturación Al>30% —sin esos dos criterios es daño neto. NUNCA cal viva (CaO) ni hidratada (Ca(OH)2) en orgánico: Pinheiro y Restrepo lo prohíben (queman raíces y microbiota). Alternativas: bocashi, biocarbón, compost maduro o yeso (CaSO4·2H2O) si solo se requiere Ca sin subir pH."
+    },
+    {
+      "id": "roca_fosforica",
+      "nombre": "Roca fosfórica",
+      "tipo": "mineral",
+      "proposito": [
+        "enmienda_p",
+        "fertilizacion"
+      ],
+      "ingredientes": [
+        "apatita (Ca5(PO4)3(F,Cl,OH)) molida"
+      ],
+      "proceso_resumen": "Aplicación pre-siembra, dosis 500-1000 kg/ha. Liberación lenta de P, requiere suelos ácidos (pH<5.5) para solubilizar, o compostaje previo con ácidos orgánicos.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 730,
+      "source_ids": [
+        "ica-fertilizantes-2019",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Corrección de deficiencia crónica de fósforo en suelos ácidos (pH < 5.5) con baja fertilidad nativa; ideal pre-siembra de cultivos perennes, frutales, café, plátano y como acelerador de bocashi/compost.",
+      "dosis": "Aplicación directa al suelo: 500-1000 kg/ha incorporados pre-arado. Hoyo de siembra frutales: 200-500 g por hoyo mezclados con compost. Co-compostaje: 5-10% peso/peso de la pila de bocashi o compost (acelera mineralización vía ácidos orgánicos).",
+      "target": [
+        "deficiencia_fosforo_p_olsen_bajo",
+        "suelos_acidos_alta_fijacion_p",
+        "establecimiento_perennes",
+        "enraizamiento_inicial",
+        "floracion_fructificacion"
+      ],
+      "valor_pedagogico": "Apatita Ca5(PO4)3(F,Cl,OH) de yacimientos colombianos (Pesca-Boyacá, Norte de Santander) molida a malla 200. Libera P-PO4 lentamente sólo en suelo ácido: H+ del rizoplano y ácidos orgánicos (cítrico, oxálico) de micorrizas Glomus protonan el fluorapatito y solubilizan P por 6-24 meses. A pH>6.5 es inerte —aplicarla sobre suelo encalado es desperdicio. AGROSAVIA 2015 y Restrepo 2007 la co-compostan con bocashi: los ácidos del fermento aceleran solubilización 3-5× y Pseudomonas/Bacillus solubilizadores la liberan como P disponible. Vs. DAP/MAP químicos: entrega P sostenida sin acidificar ni salinizar, conserva micorrizas, compatible con IFOAM. Aporta Ca pero no Mg. Usar mascarilla: contiene flúor."
+    },
+    {
+      "id": "ceniza_madera",
+      "nombre": "Ceniza de madera",
+      "tipo": "mineral",
+      "proposito": [
+        "fertilizacion",
+        "enmienda_ph"
+      ],
+      "ingredientes": [
+        "ceniza de madera dura no tratada"
+      ],
+      "proceso_resumen": "Aplicación al pie o incorporada 100-200 g/planta. Rica en K, Ca. Alcalinizante; no usar en suelos con pH>6.5 ni en cultivos acidófilos (arándano, té).",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 730,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Aporte de potasio y calcio + corrección suave de acidez en suelos ácidos (pH 5.0-6.0); también ingrediente clave del bocashi (5-10%) y repelente físico de babosas en bordes de era.",
+      "dosis": "Riego al pie: 100-200 g por planta/año en frutales jóvenes; 50-80 g/planta en hortalizas de fruto (tomate, pimentón). Suelo: 1-3 t/ha incorporadas pre-siembra. Bocashi: 5-10% del peso total. Barrera anti-babosa: cordón de 2-3 cm alrededor del cultivo (re-aplicar tras lluvia).",
+      "target": [
+        "deficiencia_potasio_k",
+        "deficiencia_calcio_suave",
+        "acidez_suelo_moderada_ph_5_a_6",
+        "babosas_caracoles_barrera_fisica",
+        "ingrediente_bocashi"
+      ],
+      "valor_pedagogico": "Residuo de combustión completa de madera dura no tratada: K2CO3 (5-10%), CaO+CaCO3 (20-35%), MgO, P2O5 y micros (B, Zn, Mn, Cu). Restrepo 1996 la incorpora al bocashi como aporte mineral y modulador de pH. ADVERTENCIAS: (1) NUNCA ceniza tratada/pintada/contrachapado/carbón mineral —Cr-Cu-As (CCA), dioxinas, metales pesados; (2) alcalinizante fuerte (~30-50% eq. CaCO3): prohibida con pH>6.5 y en acidófilos (arándano, té); (3) lixivia K rápido —no almacenar a la intemperie; (4) volatiliza NH3 con fertilizante amoniacal. Vs. KCl químico: aporta K+Ca+micros sin salinización por Cl-. AGROSAVIA 2015 la valida como fuente económica de K en finca con leña disponible."
+    },
+    {
+      "id": "compost_maduro",
+      "nombre": "Compost maduro",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "residuos vegetales",
+        "estiércol maduro",
+        "ceniza",
+        "tierra de bosque"
+      ],
+      "proceso_resumen": "Compostaje aeróbico por pila con volteos cada 7 días durante 90-120 días. Maduro cuando baja a temperatura ambiente, color oscuro, olor a tierra fresca.",
+      "tiempo_elaboracion_dias": 100,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados",
+        "restrepo-2005-agroecologia"
+      ],
+      "uso": "Enmienda orgánica base para preparación de eras, hoyos de siembra y mantenimiento anual del suelo; restaura materia orgánica, estructura, capacidad de intercambio catiónico (CIC) y microbiota tras décadas de manejo extractivista.",
+      "dosis": "Pre-siembra hortalizas: 2-5 kg/m² (20-50 t/ha) incorporados a 15 cm. Hoyo de siembra frutales: 5-10 kg por hoyo mezclado con tierra. Mantenimiento perennes: 3-5 kg/planta/año en corona, sin tocar el tallo. Sustrato semillero: 30-40% del volumen mezclado con tierra negra y cascarilla de arroz.",
+      "target": [
+        "baja_materia_organica_suelo",
+        "estructura_suelo_compactada",
+        "baja_capacidad_intercambio_cationico",
+        "deficiencia_n_p_k_balanceada",
+        "microbiota_suelo_empobrecida",
+        "retencion_agua_suelo"
+      ],
+      "valor_pedagogico": "Compostaje aeróbico mesofílico-termofílico: sucesión de bacterias (Bacillus, Pseudomonas), actinomicetos (Streptomyces, olor a tierra) y hongos saprófitos que degradan C:N 30:1 hasta húmicos estables (C:N ~12:1). Fase termofílica 55-70°C esteriliza patógenos y semillas de arvenses. Restrepo 1996 y AGROSAVIA 2015 lo posicionan como pilar agroecológico: vs. bocashi (microbioma fresco), aporta materia orgánica HUMIFICADA estable que mejora CIC y retención hídrica (1 g humus = 4-6 g H2O). Vs. NPK químico: no saliniza, secuestra C y reinocula microbiota. CONTROL: C:N 10-15, germinación rábano >80%, sin olor amoniacal. NO usar inmaduro ni de origen desconocido (clopiralida residual mata leguminosas)."
+    },
+    {
+      "id": "biofertilizante_algas",
+      "nombre": "Biofertilizante de algas marinas",
+      "tipo": "extracto",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "algas marinas secas (Ascophyllum/Sargassum/Ecklonia)"
+      ],
+      "proceso_resumen": "Extracto hidrolizado alcalino o ácido. Aplicación foliar 1:500. Fuente de citoquininas, auxinas, oligoelementos. Estimulante de enraizamiento.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 365,
+      "uso": "Bioestimulante foliar en trasplante, prefloración y post-estrés (sequía, granizo, helada leve); también en remojo de semillas/esquejes para enraizamiento.",
+      "dosis": "Foliar 2-3 mL/L (1:500) cada 10-15 días; remojo de semillas 5 mL/L por 12h; drench 3-5 mL/L en trasplante. No exceder 4 aplicaciones por ciclo para evitar desbalance hormonal.",
+      "target": [
+        "estrés hídrico y térmico",
+        "trasplante con baja sobrevivencia",
+        "deficiencias de micronutrientes (B, Zn, Mo)",
+        "raíces débiles o sistema radicular pobre",
+        "floración irregular o aborto floral"
+      ],
+      "valor_pedagogico": "El extracto de algas pardas concentra citoquininas (zeatina) y auxinas (IAA) que estimulan división celular y enraizamiento; aporta manitol osmoprotector y oligoelementos quelados (B, Zn, Mn) biodisponibles vía cutícula foliar. Alginatos y laminarinas activan defensa SAR como elicitores PAMP. En Colombia se usan importados (Ascophyllum nodosum) y lixiviados de Sargassum del Caribe. Advertencia: NO mezclar con caldo bordelés ni sulfocálcico (oxidan los reguladores); aplicar al atardecer (UV degrada citoquininas).",
+      "source_ids": [
+        "khan-2009-seaweed-extracts",
+        "agrosavia-manual-biopreparados-2015"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
+      "id": "bacillus_thuringiensis",
+      "nombre": "Bacillus thuringiensis (BT) — bioinsecticida lepidópteros",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "esporas y cristales proteicos comerciales Bacillus thuringiensis var. kurstaki (BTk) o aizawai (BTa)",
+        "agua sin cloro",
+        "adherente foliar (jabón potásico opcional, 0.5%)"
+      ],
+      "proceso_resumen": "Producto comercial registrado ante ICA (no preparación finca). Dilución típica 1-2 g/L de agua. Aplicación foliar al ATARDECER (luz UV degrada cristales delta-endotoxina). Efectivo contra larvas Lepidoptera incluyendo Agrotis ipsilon (trozador), Spodoptera frugiperda (cogollero), Tuta absoluta (polilla tomate), Plutella xylostella (palomilla crucíferas). NO afecta abejas ni vertebrados. Repetir cada 7-10 días si presión alta. Eficacia tras ingesta de la larva — esperar 24-72h mortalidad.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 730,
+      "uso": "Aplicar al detectar larvas pequeñas (instares 1-3) de lepidópteros — antes son más sensibles a las endotoxinas Cry. Monitoreo con trampas de feromona o conteo de hojas con daño fresco para definir umbral.",
+      "dosis": "BTk en polvo mojable: 1-2 g/L de agua (500-1000 g/ha) con adherente foliar 0.5%. Aplicar al atardecer cada 7-10 días mientras dure la presión. En tomate y maíz, dirigir aspersión a cogollos y envés de hojas.",
+      "target": [
+        "trozador (Agrotis ipsilon, A. segetum) en almácigos",
+        "cogollero (Spodoptera frugiperda) en maíz",
+        "polilla del tomate (Tuta absoluta)",
+        "palomilla de las crucíferas (Plutella xylostella)",
+        "gusano de la mazorca (Helicoverpa zea)",
+        "minador del fruto (Neoleucinodes elegantalis)"
+      ],
+      "valor_pedagogico": "Bt produce cristales Cry (delta-endotoxinas) que el pH alcalino (>9.5) del mesenterón larval solubiliza y proteasas activan; las toxinas se unen a receptores cadherina/aminopeptidasa, forman poros y causan parálisis, sepsis y muerte en 24-72h. BTk (var. kurstaki) es la cepa más usada en Colombia orgánico contra Lepidoptera; BTi controla dípteros; BTt coleópteros. AGROSAVIA registra formulaciones nativas. Advertencia: UV inactiva cristales en 4-8h — aplicar al atardecer; pH agua >8 degrada; resistencia en P. xylostella exige rotar con neem o spinosad.",
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
+      "id": "trichogramma_spp",
+      "nombre": "Trichogramma spp. — parasitoide de huevos de lepidópteros",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "cartulinas con huevos parasitados (pulgas pre-emergencia) Trichogramma exiguum o T. pretiosum",
+        "soporte de papel para liberación"
+      ],
+      "proceso_resumen": "Control biológico CLÁSICO preventivo: avispas microscópicas parasitan huevos de Lepidoptera antes de eclosionar. Liberación 50.000-100.000 individuos/hectárea cuando se detectan adultos (trampas de luz o monitoreo). Sinergia con BT (Trichogramma actúa sobre huevos, BT sobre larvas eclosionadas). AGROSAVIA y empresas como Bioglobal producen comercialmente en Colombia. Distribuir en campo cada 7-10 días por 3-4 ciclos.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 7,
+      "uso": "Liberar PREVENTIVAMENTE al detectar primeros adultos del lepidóptero plaga (trampas de luz, feromona) o antes de oviposición esperada. Es control preventivo, NO curativo: no funciona si ya hay larvas eclosionadas.",
+      "dosis": "50.000-100.000 individuos/hectárea por liberación, distribuidos en 25-50 puntos. Repetir cada 7-10 días por 3-4 ciclos consecutivos cubriendo el periodo de oviposición. En huertos familiares: 1 pulguilla (~2.000 individuos) cada 100 m².",
+      "target": [
+        "trozador (Agrotis ipsilon) — control preventivo de huevos",
+        "cogollero (Spodoptera frugiperda) en maíz",
+        "polilla del tomate (Tuta absoluta)",
+        "gusano de la mazorca (Helicoverpa zea)",
+        "perforador del fruto (Neoleucinodes elegantalis)",
+        "barrenador de la caña (Diatraea saccharalis)"
+      ],
+      "valor_pedagogico": "Trichogramma spp. son microhimenópteros (Trichogrammatidae) de 0.3-0.5 mm — MACROORGANISMOS parasitoides, NO microbios. La hembra deposita un huevo dentro del huevo del lepidóptero; la larva consume el embrión y emerge en 8-10d a 25°C, cortando el ciclo ANTES de la larva fitófaga. AGROSAVIA y Bioglobal producen T. exiguum y T. pretiosum sobre Sitotroga cerealella. Sinergia con Bt: Trichogramma sobre huevos, Bt sobre larvas. Advertencia: incompatible con insecticidas amplio espectro 15d antes/después; vida útil 5-7d refrigerado. Pilar del MIP campesino del ICA/CIAT desde los 80s.",
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "gbif-taxonomic-backbone"
+      ]
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
+      "id": "extracto_neem",
+      "nombre": "Extracto de neem (Azadirachta indica)",
+      "tipo": "extracto",
+      "proposito": [
+        "fitosanitario_curativo",
+        "repelente_insectos"
+      ],
+      "ingredientes": [
+        "semillas o frutos secos Azadirachta indica (neem)",
+        "agua o aceite vegetal portador",
+        "alcohol etílico 70% (opcional, para extracto alcohólico)",
+        "jabón potásico (emulsionante)"
+      ],
+      "proceso_resumen": "Macerar semillas molidas 24-48h en agua tibia (50g/L) o usar aceite de neem comercial. La azadiractina actúa como antialimentario (inhibe ecdisis) en larvas Lepidoptera + áfidos + ácaros. NO sistémico foliar pero translaminar leve. Compatible con BT y Trichogramma. Aplicar al atardecer cada 7d. Cuidado: tóxico para peces; no aplicar cerca de fuentes hídricas. En Colombia hay cultivos comerciales en valle del Magdalena.",
+      "tiempo_elaboracion_dias": 2,
+      "vida_util_dias": 14,
+      "uso": "Aplicar al detectar primeros instares larvales o colonias incipientes de chupadores; útil en MIP rotando con Bt y caldos minerales para evitar resistencia. Repelente y antialimentario, no derribante: efecto progresivo en 3-7 días.",
+      "dosis": "Extracto acuoso de semilla: 50 g/L de macerado o 3-5 mL/L de aceite de neem comercial (1500 ppm azadiractina) + jabón potásico 0.5% como emulsionante. Foliar al atardecer cada 7 días. NO superar 4 aplicaciones consecutivas — rotar con otro modo de acción.",
+      "target": [
+        "larvas de lepidópteros (trozador, cogollero, Tuta)",
+        "áfidos (Myzus persicae, Aphis gossypii)",
+        "mosca blanca (Bemisia tabaci, Trialeurodes vaporariorum)",
+        "ácaros (Tetranychus urticae) — leve",
+        "trips (Frankliniella occidentalis)",
+        "nematodos fitoparásitos (aplicación al suelo)"
+      ],
+      "valor_pedagogico": "La azadiractina (limonoide de A. indica) actúa como análogo de ecdisona: bloquea PTTH e interrumpe la muda, inhibe alimentación vía quimiorreceptores gustativos y reduce oviposición. Translaminar leve pero NO sistémica vía xilema — requiere cobertura del envés foliar. Compatible con Bt, Trichogramma y entomopatógenos (Beauveria, Metarhizium): pilar del MIP orgánico. En Colombia se cultiva en valle medio del Magdalena; difundido en los 90s vía Cenicaña y CIPAV. Advertencias: TÓXICO para peces — no aplicar a <30 m de hídricos; UV degrada en 3-5d; macerado pierde azadiractina si se almacena >14d.",
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ]
+    }
+  ]
+}

--- a/public/fincas-publicas.json
+++ b/public/fincas-publicas.json
@@ -2,7 +2,7 @@
   {
     "slug": "guatoc",
     "nombre": "Guatoc",
-    "operador": "Miguel Guerrero",
+    "operador": "Guatoc Ecohub",
     "coords": [
       4.5167,
       -73.9333

--- a/scripts/extract-oss-subset.mjs
+++ b/scripts/extract-oss-subset.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * extract-oss-subset.mjs — Extrae subset 50 species OSS del catálogo full.
+ *
+ * Lee:  catalog/chagra-catalog-seed-v3.1.json  (488 species full)
+ * Escribe: catalog/chagra-catalog-oss-subset-v3.1.json  (50 species curadas)
+ *
+ * Filtra:
+ * - 50 IDs hardcoded (cobertura multi-piso + cultivos canónicos colombianos)
+ * - sources[] solo los referenciados por las 50 species
+ * - biopreparados[] mantiene los presentes en catálogo full (sin filtrado)
+ *
+ * Estrategia boundary: subset = OSS público bajo CC-BY-NC-SA;
+ * catálogo full queda para chagra-pro post-cutover (decisión separada,
+ * ver Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const INPUT = resolve(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+const OUTPUT = resolve(ROOT, 'catalog/chagra-catalog-oss-subset-v3.1.json');
+
+const OSS_SUBSET_IDS = new Set([
+  // Cálidas 0-1000m (12)
+  'cocos_nucifera', 'euterpe_oleracea', 'passiflora_edulis_flavicarpa',
+  'manihot_esculenta', 'theobroma_cacao', 'capsicum_annuum_aji_dulce_caribe',
+  'enterolobium_cyclocarpum', 'inga_edulis', 'tabebuia_rosea',
+  'cymbopogon_citratus', 'ipomoea_batatas', 'gliricidia_sepium',
+  // Templadas 1000-2000m (13)
+  'coffea_arabica', 'psidium_guajava_manzana', 'solanum_quitoense',
+  'physalis_peruviana', 'coriandrum_sativum', 'phaseolus_vulgaris',
+  'zea_mays', 'cucurbita_moschata', 'cucurbita_maxima',
+  'passiflora_edulis_morada', 'cedrela_montana', 'cordia_alliodora',
+  'capsicum_chinense_aji_panca',
+  // Frías 2000-3000m (13)
+  'solanum_tuberosum_pastusa_suprema', 'solanum_tuberosum_sabanera',
+  'fragaria_ananassa_monterrey', 'fragaria_vesca', 'rubus_glaucus',
+  'alnus_acuminata', 'erythrina_edulis', 'lactuca_sativa_capitata',
+  'brassica_oleracea_acephala_curly', 'brassica_oleracea_capitata_alba',
+  'allium_cepa', 'allium_sativum', 'beta_vulgaris_conditiva',
+  // Páramo y altoandinas 2400m+ (12)
+  'lupinus_mutabilis', 'oxalis_tuberosa', 'tropaeolum_tuberosum',
+  'ullucus_tuberosus', 'chenopodium_quinoa', 'amaranthus_caudatus',
+  'melissa_officinalis', 'origanum_vulgare', 'foeniculum_vulgare',
+  'calendula_officinalis', 'mentha_spicata', 'allium_fistulosum',
+]);
+
+if (OSS_SUBSET_IDS.size !== 50) {
+  console.error(`FATAL: OSS_SUBSET_IDS tiene ${OSS_SUBSET_IDS.size}, esperaba 50`);
+  process.exit(2);
+}
+
+const full = JSON.parse(readFileSync(INPUT, 'utf8'));
+
+const species = full.species.filter((s) => OSS_SUBSET_IDS.has(s.id));
+
+if (species.length !== 50) {
+  console.error(`FATAL: encontré ${species.length} matches, esperaba 50`);
+  const found = new Set(species.map((s) => s.id));
+  const missing = [...OSS_SUBSET_IDS].filter((id) => !found.has(id));
+  console.error('IDs faltantes:', missing);
+  process.exit(3);
+}
+
+// Filtra sources referenciados por las 50 species
+const referencedSourceIds = new Set();
+for (const s of species) {
+  for (const sid of s.source_ids || []) referencedSourceIds.add(sid);
+}
+const sources = (full.sources || []).filter((src) => referencedSourceIds.has(src.id));
+
+// biopreparados: mantener tal cual (catalogo separado, no filtra por species)
+const subset = {
+  ...(full._meta && { _meta: full._meta }),
+  schema_version: full.schema_version,
+  seed_version: (full.seed_version || 'v3.1') + '-oss-subset',
+  generated_at: new Date().toISOString(),
+  generated_by: 'scripts/extract-oss-subset.mjs',
+  _subset_meta: {
+    subset_name: 'oss-subset-50',
+    source_file: 'chagra-catalog-seed-v3.1.json',
+    species_count: species.length,
+    sources_count: sources.length,
+    license: 'CC-BY-NC-SA 4.0',
+    rationale: 'Subset representativo multi-piso (12 cálidas + 13 templadas + 13 frías + 12 páramo/altoandinas) para uso OSS público bajo CC-BY-NC-SA. Catálogo full queda reserved para chagra-pro post-cutover. Plan detallado: Chagra-strategy/legal/oss-pro-corpus-split-plan-2026-05-20.md.',
+  },
+  species,
+  sources,
+  biopreparados: full.biopreparados || [],
+};
+
+writeFileSync(OUTPUT, JSON.stringify(subset, null, 2) + '\n');
+console.log(`✓ Escrito ${OUTPUT}`);
+console.log(`  species: ${species.length}, sources: ${sources.length}, biopreparados: ${(full.biopreparados || []).length}`);

--- a/scripts/run-bench-prompts.mjs
+++ b/scripts/run-bench-prompts.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// run-bench-prompts.mjs
+// ---------------------
+// Corre los 20 prompts benchmark de
+// Chagra-strategy/benchmarks/prompts-grafos-2026-05-20.md contra el endpoint
+// chat agroecológico actual (BM25 + ollama gemma3:4b) y emite JSON con
+// latency + respuesta para review manual + scoring vs ground truth.
+//
+// Uso:
+//   node scripts/run-bench-prompts.mjs           # corre los 20, output JSON
+//   node scripts/run-bench-prompts.mjs --quick   # solo los 6 multi-hop simples
+//
+// Pre-requisitos:
+//   - ollama corriendo en localhost:11434 con gemma3:4b cargado (warm)
+//   - este script lee los prompts del archivo benchmark — no se hardcodean
+//
+// Output: /tmp/bench-prompts-YYYY-MM-DD-HHMMSS.json
+//
+// Para correr el bench con un sistema alternativo (Apache AGE futuro):
+//   cambiar OLLAMA_URL + SYSTEM_PROMPT, mantener el resto.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PROMPTS_FILE = '/home/kortux/Workspace/Chagra-strategy/benchmarks/prompts-grafos-2026-05-20.md';
+const OLLAMA_URL = 'http://localhost:11434/api/generate';
+const MODEL = 'gemma3:4b';
+const TIMEOUT_MS = 60_000;
+const QUICK_MODE = process.argv.includes('--quick');
+
+// System prompt mínimo para el bench — emula el chat agroecológico básico.
+// NO incluye RAG (el bench prueba la baseline del LLM solo sobre el corpus
+// inyectado en el prompt manualmente). Esto da floor: si el LLM no responde
+// bien con contexto generoso, no va a responder bien con RAG escaso.
+const SYSTEM_PROMPT = `Eres un asistente agroecológico para chagras colombianas. Tu conocimiento incluye 488 species curadas con fichas referenciadas a Agrosavia, Humboldt, UNAL, Bernal 2015, Pérez-Arbeláez 1947.
+
+Reglas:
+- Responde basado únicamente en información agroecológica verificable.
+- Si no tienes información específica sobre una especie, dilo explícitamente — NO inventes nombres, propiedades ni biopreparados.
+- Cuando recomiendes compañeros simbióticos, biopreparados o incompatibilidades, basate en literatura agroecológica colombiana documentada.
+- Respuestas concisas: 2-4 oraciones máximo.
+- Usa nombres científicos correctos. Para Annona muricata es "guanábana", NO "higuera jabón".`;
+
+function extractPromptsFromMarkdown(content) {
+  // Los prompts están en tablas markdown bajo "### Cat. X — ..." sections.
+  // Cada fila tiene formato:
+  //   | N | "Query..." | Capacidad evaluada | Cómo verificar |
+  // Capturamos el N y la query (segunda columna).
+  const lines = content.split('\n');
+  const prompts = [];
+  let currentCategory = null;
+
+  for (const line of lines) {
+    // Detectar categoría
+    const catMatch = line.match(/^##\s+Categor[ií]a\s+(\d+)\s+[—-]\s+(.+?)$/);
+    if (catMatch) {
+      currentCategory = { num: parseInt(catMatch[1]), name: catMatch[2].trim() };
+      continue;
+    }
+    // Detectar fila de tabla con prompt: | N | "..." | ... | ... |
+    const rowMatch = line.match(/^\|\s*(\d+)\s*\|\s*"(.+?)"\s*\|\s*(.+?)\s*\|/);
+    if (rowMatch) {
+      prompts.push({
+        id: parseInt(rowMatch[1]),
+        category: currentCategory ? currentCategory.num : null,
+        category_name: currentCategory ? currentCategory.name : null,
+        query: rowMatch[2],
+        capability: rowMatch[3].trim(),
+      });
+    }
+  }
+
+  return prompts;
+}
+
+async function callOllama(query, signal) {
+  const start = performance.now();
+  const res = await fetch(OLLAMA_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: MODEL,
+      system: SYSTEM_PROMPT,
+      prompt: query,
+      stream: false,
+      options: {
+        temperature: 0.3,
+        num_predict: 300,
+      },
+      keep_alive: '30m',
+    }),
+    signal,
+  });
+  const elapsed = performance.now() - start;
+  if (!res.ok) {
+    return { error: `HTTP ${res.status}`, latency_ms: elapsed };
+  }
+  const data = await res.json();
+  return {
+    response: data.response,
+    latency_ms: elapsed,
+    eval_count: data.eval_count,
+    eval_duration_ms: data.eval_duration ? data.eval_duration / 1e6 : null,
+    prompt_eval_count: data.prompt_eval_count,
+  };
+}
+
+async function main() {
+  console.log(`[bench] Reading prompts from ${PROMPTS_FILE}`);
+  const content = readFileSync(PROMPTS_FILE, 'utf8');
+  const prompts = extractPromptsFromMarkdown(content);
+
+  let selected = prompts;
+  if (QUICK_MODE) {
+    selected = prompts.filter((p) => p.category === 2);
+    console.log(`[bench] --quick mode: ${selected.length} prompts (Categoría 2 multi-hop simple)`);
+  } else {
+    console.log(`[bench] Full mode: ${selected.length} prompts`);
+  }
+
+  if (selected.length === 0) {
+    console.error('[bench] ERROR: 0 prompts extraídos. Verificá formato markdown del archivo benchmark.');
+    process.exit(1);
+  }
+
+  const results = [];
+  for (const p of selected) {
+    console.log(`[bench] Running prompt #${p.id} (cat ${p.category}): ${p.query.slice(0, 70)}...`);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    try {
+      const result = await callOllama(p.query, controller.signal);
+      results.push({ ...p, ...result });
+      console.log(`  → ${result.latency_ms.toFixed(0)}ms · ${(result.response || '').slice(0, 80).replace(/\n/g, ' ')}...`);
+    } catch (err) {
+      console.error(`  → ERROR: ${err.message}`);
+      results.push({ ...p, error: err.message });
+    } finally {
+      clearTimeout(timer);
+    }
+    // Pausa corta para no saturar ollama
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outFile = `/tmp/bench-prompts-${stamp}.json`;
+  const summary = {
+    timestamp: new Date().toISOString(),
+    model: MODEL,
+    total: results.length,
+    successful: results.filter((r) => !r.error).length,
+    failed: results.filter((r) => r.error).length,
+    avg_latency_ms: results
+      .filter((r) => !r.error)
+      .reduce((sum, r) => sum + r.latency_ms, 0) / results.filter((r) => !r.error).length,
+    by_category: {},
+  };
+  for (const cat of [1, 2, 3, 4, 5, 6]) {
+    const catResults = results.filter((r) => r.category === cat && !r.error);
+    if (catResults.length > 0) {
+      summary.by_category[`cat${cat}`] = {
+        count: catResults.length,
+        avg_latency_ms:
+          catResults.reduce((sum, r) => sum + r.latency_ms, 0) / catResults.length,
+      };
+    }
+  }
+
+  writeFileSync(outFile, JSON.stringify({ summary, results }, null, 2));
+  console.log(`\n[bench] Done. Results: ${outFile}`);
+  console.log(`[bench] Summary:`);
+  console.log(`  Total: ${summary.total}`);
+  console.log(`  Successful: ${summary.successful}`);
+  console.log(`  Failed: ${summary.failed}`);
+  console.log(`  Avg latency: ${summary.avg_latency_ms?.toFixed(0)}ms`);
+  console.log(`  Por categoría:`);
+  for (const [k, v] of Object.entries(summary.by_category)) {
+    console.log(`    ${k}: ${v.count} prompts · ${v.avg_latency_ms.toFixed(0)}ms avg`);
+  }
+  console.log(`\n[bench] Próximo paso: revisar respuestas en ${outFile} y scoring manual vs ground truth.`);
+}
+
+main().catch((err) => {
+  console.error('[bench] FATAL:', err);
+  process.exit(1);
+});

--- a/scripts/run-bench-prompts.mjs
+++ b/scripts/run-bench-prompts.mjs
@@ -19,8 +19,9 @@
 // Para correr el bench con un sistema alternativo (Apache AGE futuro):
 //   cambiar OLLAMA_URL + SYSTEM_PROMPT, mantener el resto.
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const PROMPTS_FILE = '/home/kortux/Workspace/Chagra-strategy/benchmarks/prompts-grafos-2026-05-20.md';
 const OLLAMA_URL = 'http://localhost:11434/api/generate';
@@ -142,8 +143,9 @@ async function main() {
     await new Promise((r) => setTimeout(r, 500));
   }
 
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const outFile = `/tmp/bench-prompts-${stamp}.json`;
+  // mkdtempSync evita CodeQL js/insecure-temporary-file (path predecible en /tmp).
+  const outDir = mkdtempSync(join(tmpdir(), 'bench-prompts-'));
+  const outFile = join(outDir, 'results.json');
   const summary = {
     timestamp: new Date().toISOString(),
     model: MODEL,

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -25,6 +25,12 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
     );
   }
 
+  // Loading state mientras el LLM genera el primer token: colibrí libando del
+  // abutilón en estado `thinking` (alas en blur rápido + sip motion hacia la
+  // flor + corola vibra). Reemplaza el "loading plano" para que la espera
+  // se sienta viva.
+  const showThinkingAvatar = isStreaming && !streamingContent;
+
   return (
     <div className="flex-1 overflow-y-auto p-4 pb-2">
       {messages.map((msg, idx) => (

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Sprout } from 'lucide-react';
 import { authenticateUser } from '../services/authService';
 import { setCurrentOperator } from '../services/operatorIdentityService';
+import { setActiveTenantId } from '../services/tenantContext';
 import { version as APP_VERSION } from '../../package.json';
 import ChagraGrowLoader from './ChagraGrowLoader';
 import LegalLinks from './LegalLinks';
@@ -32,6 +33,15 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
         // No bloquear login si falla crypto (browser sin Web Crypto API).
         // Componentes hacen fallback a default-hash. Tracking warning silenciosa.
         console.warn('[LoginScreen] setCurrentOperator failed:', err);
+      }
+      // ADR-036 MVP multi-finca: persistir el username como tenantId activo.
+      // Lo consumen apiService (filter[uid.name]) y useAssetStore (scope IDB).
+      // Si el tenantId cambia respecto al previo (re-login con otro usuario),
+      // setActiveTenantId emite `tenantChanged` y los stores limpian su caché.
+      try {
+        setActiveTenantId(creds.username);
+      } catch (err) {
+        console.warn('[LoginScreen] setActiveTenantId failed:', err);
       }
       setLoading(false);
       onLoginSuccess();

--- a/src/db/__tests__/assetCache.tenant.test.js
+++ b/src/db/__tests__/assetCache.tenant.test.js
@@ -1,0 +1,166 @@
+/**
+ * assetCache.tenant.test.js — ADR-036 MVP multi-finca scoping en IDB.
+ *
+ * Mock pequeño de IDB usando un Map en memoria para verificar:
+ *   - put/bulkPut stampan `_tenant_id` del tenant activo.
+ *   - getByType filtra por tenant activo.
+ *   - purgeAbsent solo barre assets del tenant activo.
+ *
+ * No usa fake-indexeddb — replica el mínimo subset que assetCache toca.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { _resetForTests, setActiveTenantId, clearActiveTenantId } from '../../services/tenantContext';
+
+// In-memory IDB substitute. Keyed by asset id.
+let store;
+
+const makeIndexGetAll = (assetType) => {
+  const req = { onsuccess: null, onerror: null };
+  Promise.resolve().then(() => {
+    req.result = [...store.values()].filter((a) => a.asset_type === assetType);
+    req.onsuccess?.({ target: req });
+  });
+  return req;
+};
+
+const fakeStore = {
+  put(asset) {
+    store.set(asset.id, asset);
+  },
+  delete(id) {
+    store.delete(id);
+  },
+  index(_name) {
+    return {
+      getAll(range) {
+        // range = IDBKeyRange.only(assetType)
+        const assetType = range?.lower ?? range?.upper ?? range;
+        return makeIndexGetAll(assetType);
+      },
+    };
+  },
+};
+
+const fakeTx = {
+  objectStore(_name) {
+    return fakeStore;
+  },
+  oncomplete: null,
+  onabort: null,
+  onerror: null,
+};
+
+const fakeDB = {
+  transaction(_storeNames, _mode) {
+    const tx = { ...fakeTx, oncomplete: null, onabort: null, onerror: null };
+    // Simulate async oncomplete tick. Encolar con varios microtasks de delay
+    // para que cualquier `req.onsuccess` adentro alcance a correr primero
+    // (assetCache.purgeAbsent espera por getAll y LUEGO marca deletes; el
+    // tx.oncomplete debe llegar al final).
+    Promise.resolve()
+      .then(() => Promise.resolve())
+      .then(() => Promise.resolve())
+      .then(() => {
+        tx.oncomplete?.();
+      });
+    return tx;
+  },
+};
+
+vi.mock('../../db/dbCore', () => ({
+  openDB: vi.fn(async () => fakeDB),
+  STORES: {
+    ASSETS: 'assets',
+    PENDING_TX: 'pending_transactions',
+  },
+}));
+
+// jsdom no expone IDBKeyRange por defecto; este shim alcanza para el test.
+beforeEach(() => {
+  globalThis.IDBKeyRange = {
+    only: (val) => ({ lower: val, upper: val }),
+  };
+  store = new Map();
+  _resetForTests();
+});
+
+const { assetCache } = await import('../assetCache');
+
+describe('assetCache tenant scoping (ADR-036 MVP)', () => {
+  it('put stamps _tenant_id from the active tenant', async () => {
+    setActiveTenantId('alice');
+    await assetCache.put('plant', {
+      id: 'p1',
+      type: 'asset--plant',
+      attributes: { name: 'Tomate' },
+    });
+    expect(store.get('p1')._tenant_id).toBe('alice');
+  });
+
+  it('put preserves _tenant_id already present on the asset', async () => {
+    setActiveTenantId('alice');
+    await assetCache.put('plant', {
+      id: 'p2',
+      type: 'asset--plant',
+      attributes: {},
+      _tenant_id: 'bob', // ya viene marcado
+    });
+    expect(store.get('p2')._tenant_id).toBe('bob');
+  });
+
+  it('getByType returns only assets of the active tenant', async () => {
+    setActiveTenantId('alice');
+    await assetCache.put('plant', { id: 'p1', attributes: {} });
+    setActiveTenantId('bob');
+    await assetCache.put('plant', { id: 'p2', attributes: {} });
+
+    setActiveTenantId('alice');
+    const aliceList = await assetCache.getByType('plant');
+    expect(aliceList.map((a) => a.id)).toEqual(['p1']);
+
+    setActiveTenantId('bob');
+    const bobList = await assetCache.getByType('plant');
+    expect(bobList.map((a) => a.id)).toEqual(['p2']);
+  });
+
+  it('getByType treats legacy assets (no _tenant_id) as visible to active tenant', async () => {
+    // Insertar a mano un asset legacy sin _tenant_id.
+    store.set('legacy', {
+      id: 'legacy',
+      asset_type: 'plant',
+      attributes: {},
+      _tenant_id: null,
+    });
+
+    setActiveTenantId('alice');
+    const list = await assetCache.getByType('plant');
+    expect(list.map((a) => a.id)).toContain('legacy');
+  });
+
+  it('getByType returns all assets when no tenant is active (single-tenant fallback)', async () => {
+    setActiveTenantId('alice');
+    await assetCache.put('plant', { id: 'p1', attributes: {} });
+    setActiveTenantId('bob');
+    await assetCache.put('plant', { id: 'p2', attributes: {} });
+
+    clearActiveTenantId();
+    const list = await assetCache.getByType('plant');
+    expect(list.map((a) => a.id).sort()).toEqual(['p1', 'p2']);
+  });
+
+  it('purgeAbsent only sweeps within the active tenant', async () => {
+    setActiveTenantId('alice');
+    await assetCache.put('plant', { id: 'p-alice-1', attributes: {} });
+    await assetCache.put('plant', { id: 'p-alice-2', attributes: {} });
+    setActiveTenantId('bob');
+    await assetCache.put('plant', { id: 'p-bob-1', attributes: {} });
+
+    // Alice sincroniza con su backend; el universo remoto solo contiene p-alice-1.
+    setActiveTenantId('alice');
+    const remote = new Set(['p-alice-1']);
+    const purged = await assetCache.purgeAbsent('plant', remote);
+    expect(purged).toBe(1); // p-alice-2 desaparece, p-bob-1 sobrevive.
+    expect(store.has('p-bob-1')).toBe(true);
+    expect(store.has('p-alice-2')).toBe(false);
+  });
+});

--- a/src/db/__tests__/logCache.tenant.test.js
+++ b/src/db/__tests__/logCache.tenant.test.js
@@ -1,0 +1,277 @@
+/**
+ * logCache.tenant.test.js — ADR-036 MVP multi-finca scoping del log cache.
+ *
+ * Replica el patrón de assetCache.tenant.test.js: mock pequeño de IDB con
+ * un Map en memoria que verifica:
+ *   - put/bulkPut stampan `_tenant_id` del tenant activo.
+ *   - get* filtra por tenant activo.
+ *   - bulkPut GC respeta el tenant boundary.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  _resetForTests,
+  setActiveTenantId,
+  clearActiveTenantId,
+} from '../../services/tenantContext';
+
+// In-memory IDB substitute. Keyed por id de log.
+let store;
+
+const makeIndexGetAll = (predicate) => {
+  const req = { onsuccess: null, onerror: null };
+  Promise.resolve().then(() => {
+    req.result = [...store.values()].filter(predicate);
+    req.onsuccess?.({ target: req });
+  });
+  return req;
+};
+
+const fakeStore = {
+  indexNames: { contains: () => false }, // forzar fallback sin asset_id_timestamp
+  put(log) {
+    store.set(log.id, log);
+  },
+  get(id) {
+    const req = { onsuccess: null, onerror: null };
+    Promise.resolve().then(() => {
+      req.result = store.get(id) || null;
+      req.onsuccess?.({ target: req });
+    });
+    return req;
+  },
+  getAll() {
+    const req = { onsuccess: null, onerror: null };
+    Promise.resolve().then(() => {
+      req.result = [...store.values()];
+      req.onsuccess?.({ target: req });
+    });
+    return req;
+  },
+  delete(id) {
+    store.delete(id);
+  },
+  index(name) {
+    return {
+      getAll(range) {
+        // range = IDBKeyRange.only(val)
+        const target = range?.lower ?? range?.upper ?? range;
+        const predicate = name === 'type'
+          ? (l) => l.type === target
+          : name === 'asset_id'
+            ? (l) => l.asset_id === target
+            : () => false;
+        return makeIndexGetAll(predicate);
+      },
+    };
+  },
+};
+
+const fakeTx = {
+  objectStore(_name) {
+    return fakeStore;
+  },
+  oncomplete: null,
+  onabort: null,
+  onerror: null,
+};
+
+const fakeDB = {
+  transaction(_storeNames, _mode) {
+    const tx = { ...fakeTx, oncomplete: null, onabort: null, onerror: null };
+    // Demorar oncomplete varios microtasks para que cualquier `req.onsuccess`
+    // adentro alcance a correr primero (mismo patrón que assetCache test).
+    Promise.resolve()
+      .then(() => Promise.resolve())
+      .then(() => Promise.resolve())
+      .then(() => {
+        tx.oncomplete?.();
+      });
+    return tx;
+  },
+};
+
+vi.mock('../../db/dbCore', () => ({
+  openDB: vi.fn(async () => fakeDB),
+  STORES: {
+    LOGS: 'logs',
+  },
+}));
+
+beforeEach(() => {
+  globalThis.IDBKeyRange = {
+    only: (val) => ({ lower: val, upper: val }),
+    bound: (lower, upper) => ({ lower, upper }),
+  };
+  store = new Map();
+  _resetForTests();
+});
+
+const { logCache } = await import('../logCache');
+
+describe('logCache tenant scoping (ADR-036 MVP)', () => {
+  it('put stamps _tenant_id from the active tenant', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({
+      id: 'log-1',
+      type: 'log--harvest',
+      asset_id: 'p1',
+      timestamp: 1000,
+      name: 'Cosecha tomate',
+      _pending: false,
+    });
+    expect(store.get('log-1')._tenant_id).toBe('alice');
+  });
+
+  it('put preserves _tenant_id already present on the log', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({
+      id: 'log-2',
+      type: 'log--harvest',
+      asset_id: 'p2',
+      _tenant_id: 'bob',
+    });
+    expect(store.get('log-2')._tenant_id).toBe('bob');
+  });
+
+  it('getLog returns null if the log belongs to another tenant', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({ id: 'log-a', type: 'log--harvest', asset_id: 'p1' });
+    setActiveTenantId('bob');
+    await logCache.put({ id: 'log-b', type: 'log--harvest', asset_id: 'p2' });
+
+    setActiveTenantId('alice');
+    const ownLog = await logCache.getLog('log-a');
+    expect(ownLog).not.toBeNull();
+    expect(ownLog.id).toBe('log-a');
+
+    const foreignLog = await logCache.getLog('log-b');
+    expect(foreignLog).toBeNull();
+  });
+
+  it('getLog returns legacy logs (no _tenant_id) to the active tenant', async () => {
+    store.set('legacy', {
+      id: 'legacy',
+      type: 'log--harvest',
+      asset_id: 'p1',
+      _tenant_id: null,
+    });
+    setActiveTenantId('alice');
+    const legacy = await logCache.getLog('legacy');
+    expect(legacy).not.toBeNull();
+    expect(legacy.id).toBe('legacy');
+  });
+
+  it('getByType returns only logs of the active tenant', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({ id: 'log-a', type: 'log--harvest', asset_id: 'p1' });
+    setActiveTenantId('bob');
+    await logCache.put({ id: 'log-b', type: 'log--harvest', asset_id: 'p2' });
+
+    setActiveTenantId('alice');
+    const aliceLogs = await logCache.getByType('log--harvest');
+    expect(aliceLogs.map((l) => l.id)).toEqual(['log-a']);
+
+    setActiveTenantId('bob');
+    const bobLogs = await logCache.getByType('log--harvest');
+    expect(bobLogs.map((l) => l.id)).toEqual(['log-b']);
+  });
+
+  it('getLogsByAsset filters by active tenant', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({ id: 'log-a', type: 'log--harvest', asset_id: 'shared-p', timestamp: 100 });
+    setActiveTenantId('bob');
+    await logCache.put({ id: 'log-b', type: 'log--harvest', asset_id: 'shared-p', timestamp: 200 });
+
+    // Aún si el asset_id colisiona (asset compartido por error en device
+    // multi-usuario), cada tenant solo ve su log.
+    setActiveTenantId('alice');
+    const aliceForP = await logCache.getLogsByAsset('shared-p');
+    expect(aliceForP.map((l) => l.id)).toEqual(['log-a']);
+
+    setActiveTenantId('bob');
+    const bobForP = await logCache.getLogsByAsset('shared-p');
+    expect(bobForP.map((l) => l.id)).toEqual(['log-b']);
+  });
+
+  it('getAll / getRecent24h apply tenant filter', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({
+      id: 'log-a',
+      type: 'log--harvest',
+      asset_id: 'p1',
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    setActiveTenantId('bob');
+    await logCache.put({
+      id: 'log-b',
+      type: 'log--harvest',
+      asset_id: 'p2',
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+
+    setActiveTenantId('alice');
+    const all = await logCache.getAll();
+    expect(all.map((l) => l.id)).toEqual(['log-a']);
+
+    const recent = await logCache.getRecent24h();
+    expect(recent.map((l) => l.id)).toEqual(['log-a']);
+  });
+
+  it('without an active tenant, all logs are visible (single-tenant fallback)', async () => {
+    setActiveTenantId('alice');
+    await logCache.put({ id: 'log-a', type: 'log--harvest', asset_id: 'p1' });
+    setActiveTenantId('bob');
+    await logCache.put({ id: 'log-b', type: 'log--harvest', asset_id: 'p2' });
+
+    clearActiveTenantId();
+    const list = await logCache.getByType('log--harvest');
+    expect(list.map((l) => l.id).sort()).toEqual(['log-a', 'log-b']);
+  });
+
+  it('bulkPut GC only sweeps logs belonging to the active tenant', async () => {
+    // Seedeo manual (sin pasar por put) para tener control fino del _tenant_id.
+    store.set('log-a-1', {
+      id: 'log-a-1',
+      type: 'log--harvest',
+      asset_id: 'p1',
+      _tenant_id: 'alice',
+      _pending: false,
+    });
+    store.set('log-a-2', {
+      id: 'log-a-2',
+      type: 'log--harvest',
+      asset_id: 'p2',
+      _tenant_id: 'alice',
+      _pending: false,
+    });
+    store.set('log-b-1', {
+      id: 'log-b-1',
+      type: 'log--harvest',
+      asset_id: 'p3',
+      _tenant_id: 'bob',
+      _pending: false,
+    });
+
+    // Alice sincroniza con su backend, universo remoto solo contiene log-a-1.
+    setActiveTenantId('alice');
+    await logCache.bulkPut(
+      'log--harvest',
+      [
+        {
+          id: 'log-a-1',
+          type: 'log--harvest',
+          attributes: { name: 'Cosecha 1', timestamp: 1000, status: 'done' },
+          relationships: { asset: { data: [{ id: 'p1' }] } },
+        },
+      ],
+      []
+    );
+
+    // log-a-2 (alice, no en remoto) → purgado.
+    expect(store.has('log-a-2')).toBe(false);
+    // log-b-1 (bob) → sobrevive aunque alice no lo tenga en remoto.
+    expect(store.has('log-b-1')).toBe(true);
+    // log-a-1 (alice, en remoto) → preservado.
+    expect(store.has('log-a-1')).toBe(true);
+  });
+});

--- a/src/db/assetCache.js
+++ b/src/db/assetCache.js
@@ -11,8 +11,25 @@
 // assetCache re-exporta openDB/STORES para preservar la API consumida por
 // el resto de los módulos (useAssetStore, logCache).
 import { openDB, STORES } from './dbCore';
+import { getActiveTenantId } from '../services/tenantContext';
 
 export { openDB, STORES };
+
+// ADR-036 MVP multi-finca: filtra una lista de assets ya leídos de IDB para
+// dejar pasar solo los del tenant activo (o los legacy sin _tenant_id, que
+// se consideran heredados pre-multifinca y se le asignan al tenant que los
+// hidrate primero — comportamiento conservador para no esconder datos del
+// operador single-tenant histórico).
+//
+// Mantener este filtro en el read-path (no en un IDB index) tiene un costo
+// O(n) por query pero evita una migración de schema v14→v15 forzada hoy.
+// Si la base supera ~5k assets por tenant, considerar índice compuesto
+// [asset_type, _tenant_id] en una versión futura.
+const filterByActiveTenant = (assets) => {
+  const tenantId = getActiveTenantId();
+  if (!tenantId) return assets; // sin login: comportamiento single-tenant.
+  return assets.filter((a) => !a._tenant_id || a._tenant_id === tenantId);
+};
 
 export const assetCache = {
   /**
@@ -21,10 +38,14 @@ export const assetCache = {
    */
   async put(assetType, asset) {
     const db = await openDB();
+    // ADR-036 MVP multi-finca: stamp del tenant activo. Si el asset ya trae
+    // un `_tenant_id` (rehidratación desde syncFromServer con asset remoto),
+    // preservarlo — el caller sabe a qué tenant pertenece.
+    const tenantId = asset._tenant_id || getActiveTenantId() || null;
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORES.ASSETS, 'readwrite');
       const store = tx.objectStore(STORES.ASSETS);
-      store.put({ ...asset, asset_type: assetType, cached_at: Date.now() });
+      store.put({ ...asset, asset_type: assetType, _tenant_id: tenantId, cached_at: Date.now() });
       tx.oncomplete = () => resolve();
       tx.onerror = () => reject(tx.error);
     });
@@ -101,6 +122,10 @@ export const assetCache = {
       store.put({
         ...remote,
         asset_type: assetType,
+        // ADR-036 MVP: assets recién recibidos pertenecen al tenant que los
+        // descargó. Si no hay tenant activo (dev sin login), queda null y se
+        // trata como legacy pre-multifinca.
+        _tenant_id: getActiveTenantId() || null,
         cached_at: Date.now(),
         _pending: false,
       });
@@ -164,8 +189,16 @@ export const assetCache = {
       req.onsuccess = () => res(req.result || []);
       req.onerror = () => rej(req.error);
     });
+    // ADR-036 MVP multi-finca: el GC opera solo dentro del tenant activo.
+    // Si un usuario A sincroniza, NO debe purgar assets que pertenezcan al
+    // tenant B en el mismo device — el universo `allRemoteIds` solo cubre A.
+    // Assets legacy sin _tenant_id también se purgan (mismo criterio que
+    // filterByActiveTenant: se asumen del tenant activo).
+    const activeTenant = getActiveTenantId();
     let purged = 0;
     for (const local of localAssets) {
+      const belongsToActive = !local._tenant_id || !activeTenant || local._tenant_id === activeTenant;
+      if (!belongsToActive) continue;
       if (!allRemoteIds.has(local.id) && !local._pending) {
         store.delete(local.id);
         purged++;
@@ -206,7 +239,8 @@ export const assetCache = {
       const store = tx.objectStore(STORES.ASSETS);
       const index = store.index('asset_type');
       const request = index.getAll(IDBKeyRange.only(assetType));
-      request.onsuccess = () => resolve(request.result || []);
+      // ADR-036 MVP multi-finca: scope por tenant activo en read-path.
+      request.onsuccess = () => resolve(filterByActiveTenant(request.result || []));
       request.onerror = () => reject(request.error);
     });
   },
@@ -345,8 +379,17 @@ export const assetCache = {
 
       if (assetUpdates.length > 0) {
         const assetStore = tx.objectStore(STORES.ASSETS);
+        const activeTenant = getActiveTenantId() || null;
         assetUpdates.forEach(({ assetType, asset }) => {
-          assetStore.put({ ...asset, asset_type: assetType, cached_at: Date.now() });
+          // ADR-036 MVP: stamp `_tenant_id` para que las queries scoped puedan
+          // filtrarlo. Preserva el del asset si ya viene marcado (refill,
+          // updates desde otro tenant en device compartido, etc).
+          assetStore.put({
+            ...asset,
+            asset_type: assetType,
+            _tenant_id: asset._tenant_id || activeTenant,
+            cached_at: Date.now(),
+          });
         });
       }
 

--- a/src/db/logCache.js
+++ b/src/db/logCache.js
@@ -17,12 +17,25 @@
  */
 
 import { openDB, STORES } from './dbCore';
+import { getActiveTenantId } from '../services/tenantContext';
 
 // Extrae asset_id desde la relación JSON:API (soporta to-one y to-many)
 const extractAssetId = (log) => {
   const rel = log.relationships?.asset?.data;
   if (Array.isArray(rel)) return rel[0]?.id || null;
   return rel?.id || null;
+};
+
+// ADR-036 MVP multi-finca: filtra una lista de logs ya leídos de IDB para
+// dejar pasar solo los del tenant activo (o los legacy sin _tenant_id, que
+// se consideran heredados pre-multifinca, mismo criterio que assetCache).
+// Read-path O(n) por query — barato porque los logs ya pasan por el filtro
+// server-side de `filter[uid.name]` en apiService; el filtrado en IDB es
+// defense-in-depth para el caso de re-login en device compartido.
+const filterLogsByActiveTenant = (logs) => {
+  const tenantId = getActiveTenantId();
+  if (!tenantId) return logs; // sin login: comportamiento single-tenant.
+  return logs.filter((l) => !l._tenant_id || l._tenant_id === tenantId);
 };
 
 // Resuelve la cantidad (quantity--standard) desde el array `included` del JSON:API.
@@ -75,6 +88,10 @@ const normalizeRemoteLog = (remote, fallbackType, included = null) => {
       quantity: resolvedQuantity,
     },
     relationships: remote.relationships || {},
+    // ADR-036 MVP: logs descargados pertenecen al tenant activo en el
+    // momento del pull. Si no hay tenant activo (dev sin login), queda
+    // null y se trata como legacy pre-multifinca.
+    _tenant_id: getActiveTenantId() || null,
     cached_at: Date.now(),
     _pending: false,
   };
@@ -83,25 +100,40 @@ const normalizeRemoteLog = (remote, fallbackType, included = null) => {
 export const logCache = {
   /**
    * Obtener un log individual por id.
+   * ADR-036 MVP: si el log pertenece a OTRO tenant, devolvemos null (oculto).
+   * Legacy (sin `_tenant_id`) sigue visible para el tenant activo — mismo
+   * criterio que assetCache.
    */
   async getLog(id) {
     const db = await openDB();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORES.LOGS, 'readonly');
       const request = tx.objectStore(STORES.LOGS).get(id);
-      request.onsuccess = () => resolve(request.result || null);
+      request.onsuccess = () => {
+        const log = request.result || null;
+        if (!log) return resolve(null);
+        const tenantId = getActiveTenantId();
+        if (tenantId && log._tenant_id && log._tenant_id !== tenantId) {
+          return resolve(null);
+        }
+        resolve(log);
+      };
       request.onerror = () => reject(request.error);
     });
   },
 
   /**
    * Insertar/actualizar un log individual (usado por mutaciones locales con _pending).
+   * ADR-036 MVP: stamp `_tenant_id` con el tenant activo, salvo que el log ya
+   * traiga uno (preserva la propiedad cuando se vuelve a normalizar desde el
+   * pull remoto o cuando otro flujo lo marca explícitamente).
    */
   async put(log) {
     const db = await openDB();
+    const tenantId = log._tenant_id || getActiveTenantId() || null;
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORES.LOGS, 'readwrite');
-      tx.objectStore(STORES.LOGS).put({ ...log, cached_at: Date.now() });
+      tx.objectStore(STORES.LOGS).put({ ...log, _tenant_id: tenantId, cached_at: Date.now() });
       tx.oncomplete = () => resolve();
       tx.onabort = () => reject(tx.error);
       tx.onerror = () => reject(tx.error);
@@ -113,6 +145,8 @@ export const logCache = {
    * Usa índice compuesto asset_id_timestamp (v9) para evitar sort en memoria.
    * Fallback a índice asset_id + sort JS si el compuesto no existe
    * (e.g. durante migración parcial).
+   *
+   * ADR-036 MVP: filtra por tenant activo post-query (read-path scoping).
    */
   async getLogsByAsset(assetId) {
     const db = await openDB();
@@ -125,7 +159,7 @@ export const logCache = {
         const req = index.getAll(range);
         req.onsuccess = () => {
           const results = req.result || [];
-          resolve(results.reverse());
+          resolve(filterLogsByActiveTenant(results.reverse()));
         };
         req.onerror = () => reject(req.error);
       } else {
@@ -133,7 +167,7 @@ export const logCache = {
         const req = index.getAll(IDBKeyRange.only(assetId));
         req.onsuccess = () => {
           const sorted = (req.result || []).sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
-          resolve(sorted);
+          resolve(filterLogsByActiveTenant(sorted));
         };
         req.onerror = () => reject(req.error);
       }
@@ -141,20 +175,20 @@ export const logCache = {
   },
 
   /**
-   * Obtener todos los logs del store, sin filtro.
+   * Obtener todos los logs del store. ADR-036: scope al tenant activo.
    */
   async getAll() {
     const db = await openDB();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(STORES.LOGS, 'readonly');
       const req = tx.objectStore(STORES.LOGS).getAll();
-      req.onsuccess = () => resolve(req.result || []);
+      req.onsuccess = () => resolve(filterLogsByActiveTenant(req.result || []));
       req.onerror = () => reject(req.error);
     });
   },
 
   /**
-   * Obtener todos los logs de un tipo (p.ej. log--harvest).
+   * Obtener todos los logs de un tipo (p.ej. log--harvest). ADR-036: scope.
    */
   async getByType(type) {
     const db = await openDB();
@@ -162,7 +196,7 @@ export const logCache = {
       const tx = db.transaction(STORES.LOGS, 'readonly');
       const index = tx.objectStore(STORES.LOGS).index('type');
       const req = index.getAll(IDBKeyRange.only(type));
-      req.onsuccess = () => resolve(req.result || []);
+      req.onsuccess = () => resolve(filterLogsByActiveTenant(req.result || []));
       req.onerror = () => reject(req.error);
     });
   },
@@ -196,8 +230,16 @@ export const logCache = {
     }
 
     // GC: purgar logs confirmados de este type que el servidor ya no devuelve.
+    // ADR-036 MVP multi-finca: el GC opera solo dentro del tenant activo —
+    // si user A sincroniza, NO debe purgar logs de user B en el mismo device.
+    // Logs legacy (sin _tenant_id) se barren con el activo, mismo criterio
+    // que filterLogsByActiveTenant. El universo `remoteLogs` está scoped por
+    // server-side filter[uid.name] (apiService) así que solo cubre al activo.
     const remoteIds = new Set(remoteLogs.map((r) => r.id));
+    const activeTenant = getActiveTenantId();
     for (const local of localLogs) {
+      const belongsToActive = !local._tenant_id || !activeTenant || local._tenant_id === activeTenant;
+      if (!belongsToActive) continue;
       if (!remoteIds.has(local.id) && !local._pending) {
         store.delete(local.id);
       }
@@ -213,6 +255,7 @@ export const logCache = {
   /**
    * Obtener logs sincronizados de las últimas 24h, ordenados por timestamp desc.
    * Para WorkerHistory "Recientes" (bitácora Parte C).
+   * ADR-036 MVP: scope al tenant activo en read-path.
    */
   async getRecent24h() {
     const db = await openDB();
@@ -221,7 +264,7 @@ export const logCache = {
       const tx = db.transaction(STORES.LOGS, 'readonly');
       const req = tx.objectStore(STORES.LOGS).getAll();
       req.onsuccess = () => {
-        const recent = (req.result || [])
+        const recent = filterLogsByActiveTenant(req.result || [])
           .filter((log) => !log._pending && log.timestamp && log.timestamp * 1000 >= cutoff)
           .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
         resolve(recent);

--- a/src/services/__tests__/tenantContext.test.js
+++ b/src/services/__tests__/tenantContext.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  setActiveTenantId,
+  getActiveTenantId,
+  clearActiveTenantId,
+  hasActiveTenant,
+  _resetForTests,
+} from '../tenantContext';
+
+describe('tenantContext (ADR-036 MVP multi-finca)', () => {
+  beforeEach(() => {
+    _resetForTests();
+    // jsdom localStorage no emite eventos custom solo; los disparamos manual.
+  });
+
+  it('persists tenantId in localStorage and reads it back', () => {
+    setActiveTenantId('alice');
+    expect(getActiveTenantId()).toBe('alice');
+    expect(hasActiveTenant()).toBe(true);
+  });
+
+  it('returns null before any login', () => {
+    expect(getActiveTenantId()).toBeNull();
+    expect(hasActiveTenant()).toBe(false);
+  });
+
+  it('clearActiveTenantId removes the entry', () => {
+    setActiveTenantId('bob');
+    clearActiveTenantId();
+    expect(getActiveTenantId()).toBeNull();
+  });
+
+  it('rejects empty / non-string tenantId', () => {
+    expect(() => setActiveTenantId('')).toThrow();
+    expect(() => setActiveTenantId('   ')).toThrow();
+    expect(() => setActiveTenantId(null)).toThrow();
+    expect(() => setActiveTenantId(123)).toThrow();
+  });
+
+  it('trims whitespace from incoming tenantId', () => {
+    setActiveTenantId('  alice  ');
+    expect(getActiveTenantId()).toBe('alice');
+  });
+
+  it('emits tenantChanged when switching between distinct tenants', () => {
+    setActiveTenantId('alice');
+    const listener = vi.fn();
+    window.addEventListener('tenantChanged', listener);
+    setActiveTenantId('bob');
+    expect(listener).toHaveBeenCalledTimes(1);
+    const evt = listener.mock.calls[0][0];
+    expect(evt.detail).toEqual({ previous: 'alice', current: 'bob' });
+    window.removeEventListener('tenantChanged', listener);
+  });
+
+  it('does NOT emit tenantChanged on first login or on same-tenant re-set', () => {
+    const listener = vi.fn();
+    window.addEventListener('tenantChanged', listener);
+    setActiveTenantId('alice'); // primer login, no hay previo
+    setActiveTenantId('alice'); // mismo tenant, no debería emitir
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener('tenantChanged', listener);
+  });
+});

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -7,6 +7,7 @@
  */
 
 import { getAccessToken } from './authService';
+import { getActiveTenantId } from './tenantContext';
 
 /**
  * @typedef {Object} FetchOptions
@@ -98,6 +99,51 @@ const remapLegacyBundleUrl = (endpoint) => {
   return endpoint;
 };
 
+/**
+ * ADR-036 MVP multi-finca — inyecta `filter[uid.name]=<tenantId>` en GET a
+ * /api/asset/* y /api/log/* cuando hay un tenant activo y la URL aún no trae
+ * un filtro de owner. Defense-in-depth cliente-side: si el backend ya restringe
+ * por OAuth scope esto es redundante; si NO, evita IDOR latente cuando dos
+ * pilotos comparten backend.
+ *
+ * Reglas:
+ *  - Solo aplica a /api/asset/* (sin sub-id, ej /api/asset/plant) y /api/log/*.
+ *    Para GET por id (/api/asset/plant/<uuid>) NO inyectamos — farmOS valida
+ *    por id directo y romper acceso a un id propio sería peor que dejar pasar.
+ *  - Solo en URLs sin filter[uid|owner] ya presente — respetar callers que
+ *    fijan filtros explícitos (assetService.findPersonByName usa filter[name]).
+ *  - Si no hay tenant activo (pre-login, dev sin login), no se toca la URL —
+ *    preserva el comportamiento single-tenant histórico.
+ *
+ * Limitación conocida: farmOS expone `uid` (autor del asset) en asset--*; si
+ * el operador hereda assets creados por otro usuario, este filtro los
+ * ocultaría. Aceptable en MVP — los pilotos arrancan con bases vacías.
+ *
+ * TODO(multifinca-backend): cuando did:key + UCAN estén en farmOS (ADR-036
+ * sub-i + sub-iv), sustituir `filter[uid.name]` por validación UCAN cap +
+ * `filter[finca_did]` en assets y dejar este shim como deprecated.
+ */
+const injectTenantFilter = (endpoint, method) => {
+  if (method && method !== 'GET') return endpoint;
+  const tenantId = getActiveTenantId();
+  if (!tenantId) return endpoint;
+
+  // Solo bundles de asset/log de lista (no por id concreto).
+  const listLikeMatch = endpoint.match(/^\/api\/(asset|log)\/[a-z_]+(?:\?|$)/);
+  if (!listLikeMatch) return endpoint;
+  // Excluir GET por id: /api/asset/plant/<uuid>
+  const afterBundle = endpoint.slice(listLikeMatch[0].length - (listLikeMatch[0].endsWith('?') ? 1 : 0));
+  if (afterBundle && afterBundle.startsWith('/')) return endpoint;
+
+  // No pisar filtros pre-existentes de owner/uid (ej. callers que ya saben).
+  if (/[?&]filter\[(uid|owner)/.test(endpoint)) return endpoint;
+
+  const sep = endpoint.includes('?') ? '&' : '?';
+  // farmOS JSON:API: filter[uid.name]=<username> matchea el autor del asset.
+  // Encode para usernames con caracteres no-ASCII.
+  return `${endpoint}${sep}filter[uid.name]=${encodeURIComponent(tenantId)}`;
+};
+
 // Endpoints que NO existen en FarmOS 4.x — devolver respuesta vacía graceful
 // en lugar de 404 que confunde al operador con error rojo en consola.
 const FARMOS_BUNDLE_GONE = [
@@ -121,6 +167,8 @@ export const fetchFromFarmOS = async (endpoint, options = {}) => {
 
   // Mapping de bundles renombrados FarmOS 3.x → 4.x.
   const mappedEndpoint = remapLegacyBundleUrl(endpoint);
+  // ADR-036 MVP multi-finca: scoping cliente-side por owner (uid.name).
+  const scopedEndpoint = injectTenantFilter(mappedEndpoint, options.method || 'GET');
 
   const token = await getAccessToken();
   if (!token) {
@@ -160,7 +208,7 @@ export const fetchFromFarmOS = async (endpoint, options = {}) => {
   try {
     const { useFincaActiveStore } = await import('./fincaActiveStore.js');
     const baseUrl = useFincaActiveStore.getState().getActiveEndpoint();
-    const response = await fetchWithTimeout(`${baseUrl}${mappedEndpoint}`, {
+    const response = await fetchWithTimeout(`${baseUrl}${scopedEndpoint}`, {
       ...options,
       method: options.method || 'GET',
       body: outgoingBody,

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -6,6 +6,7 @@
  */
 
 import localforage from 'localforage';
+import { clearActiveTenantId } from './tenantContext';
 
 const FARMOS_URL = import.meta.env.VITE_FARMOS_URL;
 const CLIENT_ID = import.meta.env.VITE_FARMOS_CLIENT_ID;
@@ -89,6 +90,14 @@ export const logoutUser = async () => {
         await localforage.removeItem('farmos_token_expiry');
     } catch (err) {
         console.error('[Auth] logoutUser failed (tokens may persist):', err);
+    }
+    // ADR-036 MVP multi-finca: limpiar tenantId asegura que un re-login con
+    // otro usuario no herede el scope del anterior. NO purgamos IDB acá —
+    // useAssetStore decide qué hacer al detectar el cambio de tenantId.
+    try {
+        clearActiveTenantId();
+    } catch (err) {
+        console.warn('[Auth] clearActiveTenantId failed:', err);
     }
 };
 

--- a/src/services/llmGuardrails.js
+++ b/src/services/llmGuardrails.js
@@ -37,7 +37,14 @@ REGLAS DURAS:
 3. Especie en catálogo pero pregunta específica fuera del corpus curado →
    "Esto no está en mi información curada. Prueba el botón 'Consultar IA externa'."
 4. NUNCA inventar datos. Mejor 'no sé' que un dato falso.
-5. Tono "tú" cercano colombiano en todas las respuestas.`;
+5. Tono "tú" cercano colombiano en todas las respuestas.
+6. CONCISIÓN OBLIGATORIA: responde en MÁXIMO 30 palabras o 2 oraciones.
+   La voz de Chagra es agronómica directa, no académica. Si necesitas
+   detalle adicional, terminá con "¿Querés que profundice en X?" para que
+   el operador pida más, en vez de soltar toda la información de una.
+   (Razón técnica: TTS local es CPU, latencia escala lineal con caracteres
+   de salida — 30 palabras ≈ 3s, 150 palabras ≈ 23s; experiencia del
+   usuario rural en voz se rompe sobre 5s. Cap operativo, no estilístico.)`;
 
 /**
  * Respuestas de rechazo pre-armadas. Usar lenguaje natural, sin jerga técnica.

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -53,7 +53,7 @@ export const ROUTES = {
     model: 'gemma3:4b',
     keep_alive_min: 30,
     temperature: 0.3,
-    max_tokens: 512,
+    max_tokens: 80,
     url: '/api/ollama/v1/chat/completions',
     rationale:
       'Bench GPU 2026-05-17: 118 t/s, 4 GB VRAM, load 3s. keep_alive=30m. ' +
@@ -61,7 +61,12 @@ export const ROUTES = {
       'gemma3:12b (probado en PR #809, cerrado) NO resolvió — inventó OTRA ' +
       'definición con más confianza. La fix real es system prompt agresivo ' +
       '(ver AgentScreen.getSystemPrompt) + temperature baja. Mantener 4b ' +
-      'por velocidad y VRAM (vision cabe on-demand). Solución modelo-agnóstica.',
+      'por velocidad y VRAM (vision cabe on-demand). Solución modelo-agnóstica. ' +
+      'max_tokens 512→80 2026-05-20 (Task #45 fix latencia TTS): ' +
+      'kokoro-82m CPU escala lineal con caracteres, 512 tokens ≈ 23s audio. ' +
+      '80 tokens ≈ 30 palabras ≈ 3-4s audio = sustentable para UX rural por voz. ' +
+      'system prompt agroecológico ya tiene REGLA 6 que pide concisión + ' +
+      'pregunta de seguimiento si necesita detalle.',
   },
   nlu: {
     model: 'qwen2.5-coder:7b',

--- a/src/services/tenantContext.js
+++ b/src/services/tenantContext.js
@@ -1,0 +1,94 @@
+/**
+ * tenantContext — Identidad del "tenant" activo en la sesión PWA.
+ *
+ * Esto es el camino MVP del ADR-036 multi-finca: la versión completa propone
+ * `did:key` Ed25519 + UCAN delegations + DB-per-finca en OPFS, pero para
+ * habilitar HOY entregar la PWA a 3-5 usuarios reales compartiendo un único
+ * backend farmOS sin que vean assets ajenos, alcanza con scoping cliente-side
+ * derivado del username del login OAuth2.
+ *
+ * Diferencias con módulos vecinos:
+ *  - `operatorIdentityService` calcula `operator_id_hash` (HMAC-SHA256) para
+ *    pseudonimización Ley 1581 — opaco, no útil como filtro de servidor.
+ *  - `fincaActiveStore` resuelve la finca ACTIVA dentro del catálogo público
+ *    `fincas-publicas.json` (un usuario puede tener acceso a varias fincas);
+ *    no resuelve "quién soy yo" de cara al backend.
+ *
+ * `tenantContext` provee el `tenantId` plaintext (username farmOS), que es
+ * lo que farmOS JSON:API entiende como `filter[uid.name]` / `filter[owner.id]`.
+ *
+ * TODO(multifinca-backend): cuando ADR-036 Fase 1 active did:key + UCAN,
+ * sustituir `tenantId = username` por `tenantId = did:key:zABC...` y delegar
+ * a `farm_did_auth` (módulo Drupal a desarrollar) la verificación server-side.
+ * Hasta entonces, este scoping es DEFENSE-IN-DEPTH cliente-side: defensa real
+ * server-side requiere que farmOS aplique el `filter[uid.name]` y, idealmente,
+ * que el token OAuth2 ya esté ligado a un user que solo ve sus propios assets.
+ */
+
+const TENANT_ID_KEY = 'chagra:active_tenant_id';
+
+/**
+ * Setea el tenantId activo. Llamar tras login exitoso con el username farmOS.
+ * Si cambia respecto al anterior, dispara evento `tenantChanged` para que
+ * stores invaliden cachés (ver useAssetStore.invalidateForTenantChange).
+ *
+ * @param {string} tenantId — username plaintext del operador (ej. 'alice', 'bob')
+ */
+export function setActiveTenantId(tenantId) {
+  if (typeof tenantId !== 'string' || tenantId.trim().length === 0) {
+    throw new Error('tenantId must be non-empty string');
+  }
+  const normalized = tenantId.trim();
+  const previous = getActiveTenantId();
+  try {
+    localStorage.setItem(TENANT_ID_KEY, normalized);
+  } catch (err) {
+    console.warn('[tenantContext] localStorage write failed:', err);
+  }
+  if (previous && previous !== normalized && typeof window !== 'undefined') {
+    window.dispatchEvent(
+      new CustomEvent('tenantChanged', { detail: { previous, current: normalized } })
+    );
+  }
+  return normalized;
+}
+
+/**
+ * @returns {string|null} tenantId activo o null si no hay login en este device.
+ */
+export function getActiveTenantId() {
+  try {
+    return localStorage.getItem(TENANT_ID_KEY);
+  } catch (err) {
+    console.warn('[tenantContext] localStorage read failed:', err);
+    return null;
+  }
+}
+
+/**
+ * Limpia el tenantId activo. Llamar en logout.
+ */
+export function clearActiveTenantId() {
+  try {
+    localStorage.removeItem(TENANT_ID_KEY);
+  } catch (err) {
+    console.warn('[tenantContext] localStorage remove failed:', err);
+  }
+}
+
+/**
+ * @returns {boolean} true si hay un tenant activo (proxy de "estamos logueados
+ * con un usuario identificado").
+ */
+export function hasActiveTenant() {
+  return !!getActiveTenantId();
+}
+
+/**
+ * Para tests.
+ */
+export function _resetForTests() {
+  try {
+    localStorage.removeItem(TENANT_ID_KEY);
+  } catch (_) { /* no-op en entornos sin localStorage */ }
+}

--- a/src/store/__tests__/useCaseStudyStore.tenant.test.js
+++ b/src/store/__tests__/useCaseStudyStore.tenant.test.js
@@ -1,0 +1,216 @@
+/**
+ * useCaseStudyStore.tenant.test.js — ADR-036 MVP multi-finca scoping de
+ * Casos de Estudio.
+ *
+ * Verifica que createCase stampe `_tenant_id` y que todos los selectors
+ * filtren cases de otros tenants, dejando los legacy (sin _tenant_id)
+ * visibles al activo. Aísla cada test con reset del store y de
+ * localStorage para que el zustand persist no contamine las assertions.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  setActiveTenantId,
+  clearActiveTenantId,
+  _resetForTests,
+} from '../../services/tenantContext';
+import { useCaseStudyStore } from '../useCaseStudyStore';
+
+const resetStore = () => {
+  useCaseStudyStore.setState({ cases: [] });
+  if (typeof localStorage !== 'undefined') localStorage.removeItem('chagra:case-study');
+  _resetForTests();
+};
+
+const makeCase = (title, opts = {}) =>
+  useCaseStudyStore.getState().createCase({
+    title,
+    finca_slug: opts.finca_slug || 'guatoc',
+    problem: { name_freetext: opts.problem || 'Trozador', severity: opts.severity || 'medium' },
+    subject: opts.subject,
+  });
+
+describe('useCaseStudyStore tenant scoping (ADR-036 MVP)', () => {
+  beforeEach(resetStore);
+
+  it('createCase stamps _tenant_id from the active tenant', () => {
+    setActiveTenantId('alice');
+    const id = makeCase('Caso alice');
+    const raw = useCaseStudyStore.getState().cases.find((c) => c.id === id);
+    expect(raw._tenant_id).toBe('alice');
+  });
+
+  it('createCase leaves _tenant_id null when no tenant is active', () => {
+    clearActiveTenantId();
+    const id = makeCase('Caso sin login');
+    const raw = useCaseStudyStore.getState().cases.find((c) => c.id === id);
+    expect(raw._tenant_id).toBeNull();
+  });
+
+  it('getById returns only cases of the active tenant', () => {
+    setActiveTenantId('alice');
+    const aliceId = makeCase('Caso alice');
+    setActiveTenantId('bob');
+    const bobId = makeCase('Caso bob');
+
+    setActiveTenantId('alice');
+    expect(useCaseStudyStore.getState().getById(aliceId)?.title).toBe('Caso alice');
+    expect(useCaseStudyStore.getState().getById(bobId)).toBeUndefined();
+
+    setActiveTenantId('bob');
+    expect(useCaseStudyStore.getState().getById(bobId)?.title).toBe('Caso bob');
+    expect(useCaseStudyStore.getState().getById(aliceId)).toBeUndefined();
+  });
+
+  it('getActive / getByFinca / getByVisibility filter out cross-tenant cases', () => {
+    setActiveTenantId('alice');
+    makeCase('Caso alice 1');
+    makeCase('Caso alice 2');
+    setActiveTenantId('bob');
+    makeCase('Caso bob 1', { finca_slug: 'restrepo' });
+
+    setActiveTenantId('alice');
+    const active = useCaseStudyStore.getState().getActive();
+    expect(active.map((c) => c.title).sort()).toEqual(['Caso alice 1', 'Caso alice 2']);
+
+    const aliceFinca = useCaseStudyStore.getState().getByFinca('guatoc');
+    expect(aliceFinca.map((c) => c.title).sort()).toEqual(['Caso alice 1', 'Caso alice 2']);
+
+    const aliceRestrepo = useCaseStudyStore.getState().getByFinca('restrepo');
+    expect(aliceRestrepo).toEqual([]);
+
+    // Visibility default es 'private' — alice solo ve los suyos.
+    const alicePrivate = useCaseStudyStore.getState().getByVisibility('private');
+    expect(alicePrivate.map((c) => c.title).sort()).toEqual(['Caso alice 1', 'Caso alice 2']);
+  });
+
+  it('getPendingValidation respects tenant boundary', () => {
+    setActiveTenantId('alice');
+    makeCase('alice 1');
+    setActiveTenantId('bob');
+    makeCase('bob 1');
+
+    // Ambos arrancan con validation.status === 'pending' por defecto.
+    setActiveTenantId('alice');
+    const alicePending = useCaseStudyStore.getState().getPendingValidation();
+    expect(alicePending.map((c) => c.title)).toEqual(['alice 1']);
+
+    setActiveTenantId('bob');
+    const bobPending = useCaseStudyStore.getState().getPendingValidation();
+    expect(bobPending.map((c) => c.title)).toEqual(['bob 1']);
+  });
+
+  it('getTopActiveProblems excludes cases from other tenants', () => {
+    setActiveTenantId('alice');
+    makeCase('alice trozador', { severity: 'critical' });
+    setActiveTenantId('bob');
+    makeCase('bob mildiu', { severity: 'critical' });
+    makeCase('bob roya', { severity: 'high' });
+
+    setActiveTenantId('alice');
+    const aliceTop = useCaseStudyStore.getState().getTopActiveProblems(10);
+    expect(aliceTop.map((c) => c.title)).toEqual(['alice trozador']);
+
+    setActiveTenantId('bob');
+    const bobTop = useCaseStudyStore.getState().getTopActiveProblems(10);
+    expect(bobTop.map((c) => c.title).sort()).toEqual(['bob mildiu', 'bob roya']);
+  });
+
+  it('legacy cases without _tenant_id stay visible to the active tenant', () => {
+    // Inject a legacy case directly into the store (simulando localStorage
+    // de antes del MVP multifinca).
+    useCaseStudyStore.setState({
+      cases: [
+        {
+          id: 'LEGACY',
+          title: 'caso legacy',
+          finca_slug: 'guatoc',
+          subject: { species_ids: [], count_total: null, count_affected: null },
+          problem: { name_freetext: 'x', severity: 'low', detected_at: new Date().toISOString() },
+          treatments_applied: [],
+          event_log_ids: [],
+          photo_asset_ids: [],
+          state: 'open',
+          state_history: [],
+          outcome: { closed_at: null, final_count_affected: null, lessons_learned: '' },
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          // SIN _tenant_id intencionalmente.
+        },
+      ],
+    });
+
+    setActiveTenantId('alice');
+    expect(useCaseStudyStore.getState().getById('LEGACY')?.title).toBe('caso legacy');
+
+    setActiveTenantId('bob');
+    // Mismo case legacy: también visible para bob — legacy se hereda al activo.
+    expect(useCaseStudyStore.getState().getById('LEGACY')?.title).toBe('caso legacy');
+  });
+
+  it('without active tenant, all cases are visible (single-tenant fallback)', () => {
+    setActiveTenantId('alice');
+    makeCase('alice 1');
+    setActiveTenantId('bob');
+    makeCase('bob 1');
+
+    clearActiveTenantId();
+    const all = useCaseStudyStore.getState().getActive();
+    expect(all.map((c) => c.title).sort()).toEqual(['alice 1', 'bob 1']);
+  });
+
+  it('hydrateDemoCases stamps _tenant_id when no seed owner is provided', () => {
+    setActiveTenantId('alice');
+    const added = useCaseStudyStore.getState().hydrateDemoCases([
+      {
+        id: 'DEMO-1',
+        title: 'demo case',
+        finca_slug: 'guatoc',
+        problem: { name_freetext: 'demo', severity: 'low' },
+      },
+    ]);
+    expect(added).toBe(1);
+    const raw = useCaseStudyStore.getState().cases.find((c) => c.id === 'DEMO-1');
+    expect(raw._tenant_id).toBe('alice');
+
+    // Bob no ve el demo case sembrado por alice.
+    setActiveTenantId('bob');
+    expect(useCaseStudyStore.getState().getById('DEMO-1')).toBeUndefined();
+  });
+
+  it('hydrateDemoCases preserves _tenant_id from the seed if present', () => {
+    setActiveTenantId('alice');
+    useCaseStudyStore.getState().hydrateDemoCases([
+      {
+        id: 'DEMO-2',
+        title: 'demo case con owner',
+        finca_slug: 'guatoc',
+        problem: { name_freetext: 'demo', severity: 'low' },
+        _tenant_id: 'bob',
+      },
+    ]);
+    const raw = useCaseStudyStore.getState().cases.find((c) => c.id === 'DEMO-2');
+    expect(raw._tenant_id).toBe('bob');
+    // Alice no debe verlo aunque ella hizo el hydrate.
+    expect(useCaseStudyStore.getState().getById('DEMO-2')).toBeUndefined();
+  });
+
+  it('tenantChanged listener notifies subscribers without purging data', () => {
+    setActiveTenantId('alice');
+    const aliceId = makeCase('alice 1');
+    setActiveTenantId('bob');
+    const bobId = makeCase('bob 1');
+
+    // Disparar el evento simula el switch de login → tenantContext.setActive*.
+    setActiveTenantId('alice');
+    window.dispatchEvent(
+      new CustomEvent('tenantChanged', { detail: { previous: 'bob', current: 'alice' } })
+    );
+
+    // Ambos casos siguen en cases[] (no se borra nada en localStorage).
+    const raw = useCaseStudyStore.getState().cases.map((c) => c.id).sort();
+    expect(raw).toEqual([aliceId, bobId].sort());
+
+    // Pero el selector solo retorna alice.
+    expect(useCaseStudyStore.getState().getActive().map((c) => c.title)).toEqual(['alice 1']);
+  });
+});

--- a/src/store/__tests__/useLogStore.tenant.test.js
+++ b/src/store/__tests__/useLogStore.tenant.test.js
@@ -1,0 +1,59 @@
+/**
+ * useLogStore.tenant.test.js — ADR-036 MVP multi-finca scoping del log store.
+ *
+ * Verifica el listener `tenantChanged` que flushea el state in-memory de
+ * useLogStore para no exponer logs del tenant anterior tras un re-login.
+ *
+ * El scoping a nivel IDB se prueba en src/db/__tests__/logCache.tenant.test.js;
+ * acá solo el comportamiento del store reactivo.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Stub logCache antes del import del store — el listener `syncCompleted` lo
+// importa pero no lo dispara en estos tests; igual evitamos `openDB` real.
+vi.mock('../../db/logCache', () => ({
+  logCache: {
+    getLogsByAsset: vi.fn(async () => []),
+    bulkPut: vi.fn(async () => {}),
+    getByType: vi.fn(async () => []),
+    getLog: vi.fn(async () => null),
+    put: vi.fn(async () => {}),
+  },
+}));
+
+const { useLogStore } = await import('../useLogStore');
+
+const seedStateWithStaleLogs = () => {
+  useLogStore.setState({
+    logsByAsset: {
+      'plant-a': [{ id: 'log-1', type: 'log--harvest' }],
+      'plant-b': [{ id: 'log-2', type: 'log--input' }],
+    },
+    isSyncing: true,
+    lastPullAt: Date.now(),
+  });
+};
+
+describe('useLogStore tenant scoping (ADR-036 MVP)', () => {
+  beforeEach(() => {
+    useLogStore.setState({ logsByAsset: {}, isSyncing: false, lastPullAt: null });
+  });
+
+  it('tenantChanged listener clears in-memory state', () => {
+    seedStateWithStaleLogs();
+    window.dispatchEvent(
+      new CustomEvent('tenantChanged', { detail: { previous: 'alice', current: 'bob' } })
+    );
+    const s = useLogStore.getState();
+    expect(s.logsByAsset).toEqual({});
+    expect(s.isSyncing).toBe(false);
+    expect(s.lastPullAt).toBeNull();
+  });
+
+  it('tenantChanged is idempotent (multiple events do not error)', () => {
+    seedStateWithStaleLogs();
+    window.dispatchEvent(new CustomEvent('tenantChanged', { detail: {} }));
+    window.dispatchEvent(new CustomEvent('tenantChanged', { detail: {} }));
+    expect(useLogStore.getState().logsByAsset).toEqual({});
+  });
+});

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -908,6 +908,31 @@ const useAssetStore = create((set, get) => ({
   },
 }));
 
+// ADR-036 MVP multi-finca: al cambiar el tenantId activo (re-login con otro
+// usuario sobre el mismo device), limpiar el state in-memory para no exponer
+// assets del tenant anterior. La IDB no se borra — sigue scoped por
+// `_tenant_id` y un re-hydrate la repuebla con los del nuevo tenant.
+if (typeof window !== 'undefined') {
+  window.addEventListener('tenantChanged', () => {
+    useAssetStore.setState({
+      plants: [],
+      structures: [],
+      equipment: [],
+      materials: [],
+      lands: [],
+      taxonomyTerms: [],
+      lastSync: null,
+      selectedAssetId: null,
+      syncProgress: null,
+      error: null,
+    });
+    // Re-hidratar desde IDB ya scoped al nuevo tenant.
+    useAssetStore.getState().hydrate().catch((err) => {
+      console.error('[Store] Falló hydrate post-tenantChanged:', err);
+    });
+  });
+}
+
 // Listener global: al recibir confirmación de sincronización exitosa,
 // liberar el flag _pending del asset y disparar un pull dirigido que lo
 // sobrescriba con el objeto oficial del servidor (Hotfix 10.3 — Opción C).

--- a/src/store/useCaseStudyStore.js
+++ b/src/store/useCaseStudyStore.js
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { getActiveTenantId } from '../services/tenantContext';
 
 /**
  * useCaseStudyStore — Módulo "Casos de Estudio"
@@ -147,6 +148,17 @@ export const withExtendedDefaults = (c) => {
   };
 };
 
+// ADR-036 MVP multi-finca: predicate de visibilidad por tenant. Mismo
+// criterio que assetCache/logCache: cases sin `_tenant_id` (creados antes
+// de 2026-05-20 o sin login) son tratados como legacy single-tenant y
+// quedan visibles al tenant activo. Cuando NO hay tenant activo (dev sin
+// login), todos los cases son visibles — preserva flujos de demo previos.
+const belongsToActiveTenant = (c) => {
+  const tenantId = getActiveTenantId();
+  if (!tenantId) return true;
+  return !c._tenant_id || c._tenant_id === tenantId;
+};
+
 // ULID-lite (timestamp-sortable) sin dependency externa
 const makeId = () => {
   const ts = Date.now().toString(36).toUpperCase().padStart(10, '0');
@@ -166,15 +178,30 @@ export const useCaseStudyStore = create(
       // ─── Selectors (computed, no setters) ───
       // Selectors normalizan defaults extendidos (foro/validación/timeline)
       // para cases legacy almacenados antes de 2026-05-18.
-      getById: (id) => withExtendedDefaults(get().cases.find((c) => c.id === id)),
+      //
+      // ADR-036 MVP multi-finca: TODO selector aplica `belongsToActiveTenant`
+      // ANTES del normalize/map para que el operador solo vea sus propios
+      // cases. Los cases de otros tenants quedan en localStorage pero
+      // ocultos del read-path — comparable al filtrado en read de
+      // assetCache. Cuando did:key + UCAN cierre ADR-036, este filtro
+      // pasará a ser redundante con la cap-based access.
+      getById: (id) => {
+        const c = get().cases.find((x) => x.id === id);
+        if (!c || !belongsToActiveTenant(c)) return undefined;
+        return withExtendedDefaults(c);
+      },
 
       getByFinca: (slug) =>
-        get().cases.filter((c) => c.finca_slug === slug).map(withExtendedDefaults),
+        get()
+          .cases.filter((c) => c.finca_slug === slug && belongsToActiveTenant(c))
+          .map(withExtendedDefaults),
 
       getActive: () =>
         get()
           .cases.filter(
-            (c) => !['closed_resolved', 'closed_failed'].includes(c.state)
+            (c) =>
+              !['closed_resolved', 'closed_failed'].includes(c.state) &&
+              belongsToActiveTenant(c)
           )
           .map(withExtendedDefaults),
 
@@ -182,7 +209,10 @@ export const useCaseStudyStore = create(
       // "Compartidos en red".
       getByVisibility: (visibility) =>
         get()
-          .cases.filter((c) => (c.visibility || 'private') === visibility)
+          .cases.filter(
+            (c) =>
+              (c.visibility || 'private') === visibility && belongsToActiveTenant(c)
+          )
           .map(withExtendedDefaults),
 
       // Casos cuya recomendación o validation_status reclama un agrónomo.
@@ -190,6 +220,7 @@ export const useCaseStudyStore = create(
       getPendingValidation: () =>
         get()
           .cases.filter((c) => {
+            if (!belongsToActiveTenant(c)) return false;
             const v = c.validation?.status || 'pending';
             if (v === 'pending' || v === 'self-reported') return true;
             const recs = c.recommendations || [];
@@ -203,7 +234,11 @@ export const useCaseStudyStore = create(
         const severityWeight = { critical: 4, high: 3, medium: 2, low: 1 };
         const now = Date.now();
         return [...get().cases]
-          .filter((c) => !['closed_resolved', 'closed_failed'].includes(c.state))
+          .filter(
+            (c) =>
+              !['closed_resolved', 'closed_failed'].includes(c.state) &&
+              belongsToActiveTenant(c)
+          )
           .map((c) => {
             const ageMs = now - new Date(c.problem.detected_at || c.created_at).getTime();
             const ageDays = Math.max(1, ageMs / 86400000);
@@ -264,6 +299,9 @@ export const useCaseStudyStore = create(
           recommendations: [],
           created_at: ts,
           created_by_did: null, // ADR-036 lo llenará en multi-finca real
+          // ADR-036 MVP multi-finca: stamp el tenant activo al crear. Si no
+          // hay login (dev sin tenant), queda null y se trata como legacy.
+          _tenant_id: getActiveTenantId() || null,
           updated_at: ts,
         };
         set((s) => ({ cases: [...s.cases, newCase] }));
@@ -534,8 +572,14 @@ export const useCaseStudyStore = create(
 
       // Hidrata casos demo desde un payload externo (público demo seed).
       // Idempotente: solo agrega cases cuyo id NO existe ya.
+      //
+      // ADR-036 MVP multi-finca: los demo cases se stampean con el tenant
+      // activo si lo hay. Si el seed JSON ya trae `_tenant_id` se preserva
+      // (permite seeds compartidos públicos sin owner). Si no hay login,
+      // queda null → legacy (visible a todos hasta que alguien lo "adopte").
       hydrateDemoCases: (demoCases = []) => {
         if (!Array.isArray(demoCases) || demoCases.length === 0) return 0;
+        const activeTenant = getActiveTenantId() || null;
         let added = 0;
         set((s) => {
           const existing = new Set(s.cases.map((c) => c.id));
@@ -549,6 +593,7 @@ export const useCaseStudyStore = create(
               treatments_applied: [],
               outcome: { closed_at: null, final_count_affected: null, lessons_learned: '' },
               created_by_did: null,
+              _tenant_id: activeTenant,
               ...d,
             }));
           added = toAdd.length;
@@ -573,5 +618,17 @@ export const CASE_SEVERITIES = SEVERITY_VALID;
 export const CASE_VISIBILITIES = VISIBILITY_VALID;
 export const CASE_VALIDATION_STATUSES = VALIDATION_STATUS_VALID;
 export const CASE_TIMELINE_EVENT_TYPES = TIMELINE_EVENT_TYPES;
+
+// ADR-036 MVP multi-finca: al cambiar el tenant activo (re-login con otro
+// usuario sobre el mismo device), forzar re-evaluación de los selectors
+// que filtran por tenant. No purga el array `cases` (los datos del tenant
+// anterior siguen en localStorage para que vuelvan a aparecer cuando ese
+// usuario re-loguee), solo reasigna la referencia para que zustand emita
+// notificación a los subscribers de la UI.
+if (typeof window !== 'undefined') {
+  window.addEventListener('tenantChanged', () => {
+    useCaseStudyStore.setState((s) => ({ cases: [...s.cases] }));
+  });
+}
 
 export default useCaseStudyStore;

--- a/src/store/useLogStore.js
+++ b/src/store/useLogStore.js
@@ -89,6 +89,20 @@ export const useLogStore = create((set, get) => ({
   }
 }));
 
+// ADR-036 MVP multi-finca: al cambiar el tenantId activo (re-login con otro
+// usuario sobre el mismo device), limpiar el state in-memory para no exponer
+// logs del tenant anterior. La IDB no se borra — logCache filtra por
+// `_tenant_id` en read-path y el próximo pullRecentLogs los repuebla scoped.
+if (typeof window !== 'undefined') {
+  window.addEventListener('tenantChanged', () => {
+    useLogStore.setState({
+      logsByAsset: {},
+      isSyncing: false,
+      lastPullAt: null,
+    });
+  });
+}
+
 // Listener global: libera el flag _pending de logs confirmados por el servidor
 // y rehidrata el estado scoped por asset (Hotfix 11.5 — análogo a Fase 10.3).
 if (typeof window !== 'undefined') {

--- a/tests/multifinca.spec.js
+++ b/tests/multifinca.spec.js
@@ -142,15 +142,18 @@ test.describe('multifinca client-side scoping (ADR-036 MVP)', () => {
     });
 
     await page.evaluate(async () => {
-      // Setear tenant + token persistido antes de importar apiService.
+      // Login real vía authService (OAuth mockeado en beforeEach con
+      // context.route('**/oauth/token')). authenticateUser persiste el token
+      // en localforage internamente, evitando que el test tenga que importar
+      // 'localforage' como bare specifier (no resuelve en page.evaluate sin
+      // bundler context).
+      const authMod = await import('/src/services/authService.js');
+      const result = await authMod.authenticateUser('alice', 'e2e-pwd');
+      if (!result.success) {
+        throw new Error('OAuth mock no respondió OK: ' + result.error);
+      }
       const tenantMod = await import('/src/services/tenantContext.js');
       tenantMod.setActiveTenantId('alice');
-      const { default: localforage } = await import('localforage');
-      await localforage.setItem('farmos_access_token', 'e2e-multifinca-token');
-      await localforage.setItem(
-        'farmos_token_expiry',
-        Date.now() + 60 * 60 * 1000
-      );
       const apiMod = await import('/src/services/apiService.js');
       window.__apiE2E = apiMod;
     });

--- a/tests/multifinca.spec.js
+++ b/tests/multifinca.spec.js
@@ -174,13 +174,15 @@ test.describe('multifinca client-side scoping (ADR-036 MVP)', () => {
       u.includes('/api/asset/plant?sort=-created')
     );
     expect(listUrl).toBeDefined();
-    expect(listUrl).toContain('filter%5Buid.name%5D=alice');
-    // [..uid.name..]=alice URL-encoded como filter%5Buid.name%5D=alice
+    // apiService.injectTenantFilter concatena literal `filter[uid.name]=<id>`
+    // (sin URL-encode de los corchetes). Playwright reporta la URL tal cual el
+    // browser la envía — en Chromium los corchetes sobreviven sin escapar.
+    expect(listUrl).toContain('filter[uid.name]=alice');
 
     const byIdUrl = seenUrls.find((u) =>
       u.includes('/api/asset/plant/some-uuid')
     );
     expect(byIdUrl).toBeDefined();
-    expect(byIdUrl).not.toContain('filter%5Buid');
+    expect(byIdUrl).not.toContain('filter[uid');
   });
 });

--- a/tests/multifinca.spec.js
+++ b/tests/multifinca.spec.js
@@ -1,0 +1,183 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * multifinca.spec.js — ADR-036 MVP multi-finca client-side scoping.
+ *
+ * Verifica el contrato mínimo de aislación entre dos tenants compartiendo
+ * el mismo backend farmOS + mismo device (peor caso pre-DB-per-finca):
+ *
+ *   1. Tenant A activo → assetCache.put('plant', alicePlant)
+ *      assetCache.getByType('plant') incluye alicePlant.
+ *   2. Cambiar a tenant B → tenantChanged se emite.
+ *   3. Con B activo, getByType('plant') NO devuelve alicePlant.
+ *   4. B inserta su propio bobPlant; queda visible para B.
+ *   5. Volver a A → A ve alicePlant pero NO bobPlant.
+ *
+ * Bonus: apiService.fetchFromFarmOS inyecta filter[uid.name]=<tenant> en GET
+ * a /api/asset/<bundle>. Validado via context.route interceptando la URL.
+ *
+ * Estrategia: ataca el contrato a nivel de módulo (no UI), igual que
+ * offline.spec.js. Carga la app, importa dinámicamente los módulos
+ * relevantes y opera localStorage + IDB directamente.
+ */
+
+test.describe('multifinca client-side scoping (ADR-036 MVP)', () => {
+  test.beforeEach(async ({ context, page }) => {
+    // Fake token OAuth (mismo patrón offline.spec.js).
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-multifinca-token',
+          refresh_token: 'e2e-multifinca-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+    );
+
+    await page.goto('/');
+    // Esperar a que Vite resuelva los módulos. La página real no necesita
+    // hidratarse para que `import()` funcione; basta con tener el SW server up.
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('IDB asset cache is partitioned by active tenantId', async ({ page }) => {
+    // Preload de los módulos que vamos a tocar — mismo truco que offline.spec.
+    await page.evaluate(async () => {
+      const tenantMod = await import('/src/services/tenantContext.js');
+      const cacheMod = await import('/src/db/assetCache.js');
+      window.__multifincaE2E = {
+        tenant: tenantMod,
+        cache: cacheMod,
+      };
+    });
+
+    // 1. Tenant A inserta su asset.
+    await page.evaluate(async () => {
+      const { tenant, cache } = window.__multifincaE2E;
+      tenant.setActiveTenantId('alice');
+      await cache.assetCache.put('plant', {
+        id: 'alice-plant-uuid',
+        type: 'asset--plant',
+        attributes: { name: 'Tomate de Alice' },
+      });
+    });
+
+    const aliceSeesAlice = await page.evaluate(async () => {
+      const { cache } = window.__multifincaE2E;
+      const list = await cache.assetCache.getByType('plant');
+      return list.map((a) => a.id);
+    });
+    expect(aliceSeesAlice).toContain('alice-plant-uuid');
+
+    // 2. Cambiar al tenant B.
+    const tenantChangedFired = await page.evaluate(
+      () =>
+        new Promise((resolve) => {
+          const handler = () => {
+            window.removeEventListener('tenantChanged', handler);
+            resolve(true);
+          };
+          window.addEventListener('tenantChanged', handler);
+          window.__multifincaE2E.tenant.setActiveTenantId('bob');
+          // safety net: si nunca se emite, resolver false a los 200ms.
+          setTimeout(() => resolve(false), 200);
+        })
+    );
+    expect(tenantChangedFired).toBe(true);
+
+    // 3. Bob NO ve la planta de Alice.
+    const bobSeesAlice = await page.evaluate(async () => {
+      const { cache } = window.__multifincaE2E;
+      const list = await cache.assetCache.getByType('plant');
+      return list.map((a) => a.id);
+    });
+    expect(bobSeesAlice).not.toContain('alice-plant-uuid');
+
+    // 4. Bob inserta su propia planta.
+    await page.evaluate(async () => {
+      const { cache } = window.__multifincaE2E;
+      await cache.assetCache.put('plant', {
+        id: 'bob-plant-uuid',
+        type: 'asset--plant',
+        attributes: { name: 'Mora de Bob' },
+      });
+    });
+
+    const bobSeesBob = await page.evaluate(async () => {
+      const { cache } = window.__multifincaE2E;
+      const list = await cache.assetCache.getByType('plant');
+      return list.map((a) => a.id);
+    });
+    expect(bobSeesBob).toContain('bob-plant-uuid');
+    expect(bobSeesBob).not.toContain('alice-plant-uuid');
+
+    // 5. Volver a Alice: ve la suya, no la de Bob.
+    await page.evaluate(() => {
+      window.__multifincaE2E.tenant.setActiveTenantId('alice');
+    });
+
+    const aliceSeesOnlyAlice = await page.evaluate(async () => {
+      const { cache } = window.__multifincaE2E;
+      const list = await cache.assetCache.getByType('plant');
+      return list.map((a) => a.id);
+    });
+    expect(aliceSeesOnlyAlice).toContain('alice-plant-uuid');
+    expect(aliceSeesOnlyAlice).not.toContain('bob-plant-uuid');
+  });
+
+  test('apiService.fetchFromFarmOS appends filter[uid.name] to /api/asset GETs', async ({ page, context }) => {
+    // Interceptar TODA llamada al backend farmOS y capturar las URLs que
+    // tocan /api/asset/ — esperamos ver el filtro.
+    const seenUrls = [];
+    await context.route('**/api/asset/**', (route) => {
+      seenUrls.push(route.request().url());
+      route.fulfill({
+        status: 200,
+        contentType: 'application/vnd.api+json',
+        body: JSON.stringify({ data: [], jsonapi: { version: '1.0' } }),
+      });
+    });
+
+    await page.evaluate(async () => {
+      // Setear tenant + token persistido antes de importar apiService.
+      const tenantMod = await import('/src/services/tenantContext.js');
+      tenantMod.setActiveTenantId('alice');
+      const { default: localforage } = await import('localforage');
+      await localforage.setItem('farmos_access_token', 'e2e-multifinca-token');
+      await localforage.setItem(
+        'farmos_token_expiry',
+        Date.now() + 60 * 60 * 1000
+      );
+      const apiMod = await import('/src/services/apiService.js');
+      window.__apiE2E = apiMod;
+    });
+
+    await page.evaluate(async () => {
+      // GET de lista (debe inyectar filter)
+      await window.__apiE2E
+        .fetchFromFarmOS('/api/asset/plant?sort=-created&page[limit]=10')
+        .catch(() => {}); // 200 con [] no debe lanzar, pero igual atajamos.
+      // GET por id (NO debe inyectar filter)
+      await window.__apiE2E
+        .fetchFromFarmOS('/api/asset/plant/some-uuid')
+        .catch(() => {});
+    });
+
+    expect(seenUrls.length).toBeGreaterThanOrEqual(2);
+    const listUrl = seenUrls.find((u) =>
+      u.includes('/api/asset/plant?sort=-created')
+    );
+    expect(listUrl).toBeDefined();
+    expect(listUrl).toContain('filter%5Buid.name%5D=alice');
+    // [..uid.name..]=alice URL-encoded como filter%5Buid.name%5D=alice
+
+    const byIdUrl = seenUrls.find((u) =>
+      u.includes('/api/asset/plant/some-uuid')
+    );
+    expect(byIdUrl).toBeDefined();
+    expect(byIdUrl).not.toContain('filter%5Buid');
+  });
+});


### PR DESCRIPTION
## Summary

MVP path of ADR-036 multi-finca: client-side per-tenant scoping so two or
more pilot users sharing the same farmOS backend cannot see each other's
assets. Not the full ADR-036 stack (did:key + UCAN + OPFS + Automerge,
~USD 16-24k of work); this is the smallest defensible cut that closes the
IDOR vector identified in the multifinca audit and unblocks handing the
PWA to 3-5 friends today.

## Changes

- New `src/services/tenantContext.js` — thin wrapper around `localStorage`
  exposing `setActiveTenantId / getActiveTenantId / clearActiveTenantId`.
  Emits `tenantChanged` custom event on actual switches.
- `LoginScreen.jsx` calls `setActiveTenantId(username)` right after the
  existing `setCurrentOperator` Capa 1 HMAC step.
- `authService.logoutUser` clears the tenantId alongside the tokens.
- `apiService.fetchFromFarmOS` appends `filter[uid.name]=<tenantId>` to
  list GETs against `/api/asset/*` and `/api/log/*` when a tenant is
  active. GET-by-id requests and endpoints that already pin
  `filter[uid|owner]` are left untouched.
- `db/assetCache.js` stamps every `put`, `bulkPut`, and
  `commitOptimisticUpdate` write with `_tenant_id`; `getByType` filters
  on it; `purgeAbsent` only sweeps within the active tenant so user A's
  sync cannot delete user B's locally-cached assets on a shared device.
- `useAssetStore` listens for `tenantChanged`, clears its in-memory
  slices, and re-hydrates from IDB (now scoped).
- Backwards-compat: assets without `_tenant_id` (legacy single-tenant
  data) remain visible to whichever tenant queries first — no migration
  required.

## Follow-up cerrado en este PR (2026-05-20 segunda pasada)

El cierre del MVP original (commits d1c80b6..220c944) dejó dos stores
globales sin scoping. Esta segunda tanda cierra ese gap antes de
entregar pilotos para que cross-tenant leaks en `logs` y
`case_studies` queden cerrados a la par de `assets`:

- `db/logCache.js` ahora replica el patrón de `assetCache`: `put` /
  `bulkPut` stampan `_tenant_id`, y todo el read-path (`getLog`,
  `getLogsByAsset`, `getAll`, `getByType`, `getRecent24h`) filtra por
  tenant activo. El GC dentro de `bulkPut` solo barre logs del tenant
  activo, evitando que el pull de user A purgue logs de user B en un
  device compartido. Universos remotos ya vienen scoped por el
  `filter[uid.name]` server-side de `apiService.fetchFromFarmOS`
  (commit 3c31d25), así que el filtro IDB es defense-in-depth.
- `useLogStore` escucha `tenantChanged` y limpia su `logsByAsset` +
  `isSyncing` + `lastPullAt` para no exponer logs del tenant anterior
  tras re-login en el mismo device. Re-hidratación ocurre lazy via
  `loadLogsForAsset` / `pullRecentLogs` y lee scoped desde IDB.
- `useCaseStudyStore` stampa `_tenant_id` en `createCase` y
  `hydrateDemoCases`. Cada selector (`getById`, `getByFinca`,
  `getActive`, `getByVisibility`, `getPendingValidation`,
  `getTopActiveProblems`) filtra cases que pertenezcan a otros
  tenants. Listener `tenantChanged` reasigna `cases` a una nueva
  referencia para que zustand notifique a los subscribers (no purga el
  array — el localStorage persistido sigue intacto y los cases del
  tenant anterior reaparecen cuando ese user re-loguee).
- Misma regla de fallback que `assetCache`: registros sin
  `_tenant_id` (datos legacy single-tenant + seeds demo sin owner) se
  consideran heredados al tenant activo. Sin migración requerida.

## Out of scope (ADR-036 follow-up)

- did:key Ed25519 identity, BIP-39 onboarding (sub-i)
- UCAN delegations for read-only advisors (sub-iv)
- Automerge-repo + WebRTC P2P sync (sub-ii)
- DB-per-finca in OPFS namespaced by did:key (sub-v)
- Backblaze B2 cifrado backup (sub-vii)
- Crypto-shred DEK per subject (sub-viii)
- Schema log v1 → v2 expand-contract (sub-ix)
- farmOS server-side enforcement of the same scoping (current change is
  defense-in-depth client-side only)

These are tracked in ADR-036 phases 1-3 and tagged as
`TODO(multifinca-backend)` in the new module's comments where they
would replace the MVP plumbing.

## Test plan

- [x] `npx vitest run src/services/__tests__/tenantContext.test.js` → 7/7
- [x] `npx vitest run src/db/__tests__/assetCache.tenant.test.js` → 6/6
- [x] `npx vitest run src/db/__tests__/logCache.tenant.test.js` → 9/9
- [x] `npx vitest run src/store/__tests__/useLogStore.tenant.test.js` → 2/2
- [x] `npx vitest run src/store/__tests__/useCaseStudyStore.tenant.test.js`
      → 11/11
- [x] `npx vitest run src/store/__tests__/useCaseStudyStore.test.js`
      → 23/23 (no regresiones en la suite existente del store)
- [x] Suma scoping multifinca: 58/58 unit tests verdes con
      `--pool=forks --no-file-parallelism` (paralelo OOM-ea por la
      cantidad de worktrees activos en alpha, no por los tests).
- [x] `npx vitest run` on adjacent suites (fincaActiveStore, syncManager,
      AssetDetailView, ObservationScreen) → 51/51, no regressions
- [x] `npm run lint` → clean
- [ ] `npm run build` — **NO ejecutable localmente esta tarde**: vite v8
      con rolldown/oxc cae OOM en alpha por presión de memoria de
      worktrees paralelos. Confirmado que el OOM ocurre EN EL MISMO
      estado base (sin estos cambios) cuando se intenta el build, así
      que es ortogonal a esta PR. CI ubuntu-latest tiene memoria
      suficiente y debería compilar limpio.
- [ ] `npx playwright test tests/multifinca.spec.js` — **NOT executed
      locally**: the playwright-bundled chrome-headless-shell fails on
      NixOS alpha with `libglib-2.0.so.0: cannot open shared object
      file`. ubuntu-latest CI should run both cases without changes.
- [ ] Manual smoke: log in as user A, create a plant + a log + un case
      study; log out; log in as user B; confirm A's plant/log/case is
      not in any view; insert one as B; log back in as A and confirm
      symmetry across the three resources.

## Risks

- farmOS `filter[uid.name]` assumes assets carry a `uid` relationship
  populated with the authoring user. If the legacy chagra dataset has
  null `uid` on some entries, they will silently disappear from the
  scoped GET. Mitigation: pilot users start fresh; if needed,
  one-time backend backfill of `uid` for legacy rows.
- Single device shared by multiple operators sees an in-memory wipe on
  re-login but IDB is preserved — pending writes survive. If a logout
  happens mid-sync the in-memory progress indicator goes stale.
  Acceptable for MVP.
- `useCaseStudyStore` mantiene los cases del tenant anterior en
  localStorage (no purga). Si un atacante con acceso físico al device
  inspecciona DevTools → Application → Local Storage, puede leer
  `chagra:case-study` y ver títulos/descripciones de cases ajenos. Es
  el mismo modelo de amenaza que IDB para assets/logs — defense
  client-side, no encripción at-rest. Cierre real con OPFS + DEK
  per-finca llega con ADR-036 sub-v/sub-viii.

## Commits

```
9b3bd2c test(multifinca): tenant scoping for logs + case studies
7d75027 feat(multifinca): scope useCaseStudyStore by tenant
48378a2 feat(multifinca): scope useLogStore + logCache by tenant
220c944 test(multifinca): unit + e2e coverage for tenant scoping
4fa8599 feat(multifinca): partition IndexedDB asset cache and Zustand store by tenant
3c31d25 feat(multifinca): inject filter[uid.name] in /api/asset and /api/log GETs
c77b0ca feat(multifinca): wire tenantId set/clear into login and logout flows
d1c80b6 feat(multifinca): add tenantContext service for MVP per-user scoping
```
