### PR TITLE
feat(age): Apache AGE POC — schema + importer + queries

### DIFF
--- a/docs/POC_APACHE_AGE.md
+++ b/docs/POC_APACHE_AGE.md
@@ -1,0 +1,92 @@
+# POC Apache AGE — KG sobre el catálogo Chagra
+
+**Estado**: prueba de concepto documental (worktree `feat/apache-age-poc-2026-05-20`).
+**Branch**: `feat/apache-age-poc-2026-05-20`.
+**NO operacional** — ningún script de este POC ha corrido contra `postgres-farm` ni contra `farmOS` en producción.
+
+---
+
+## TL;DR
+
+El catálogo Chagra (488 species + 19 biopreparados + 66 sources) tiene topología natural de grafo (compañerismo, antagonismo, biopreparados por etapa, sources por species). Las queries multi-hop sobre esta topología son donde **BM25 puro degrada y un grafo brilla**.
+
+Este POC propone:
+
+1. Migrar el container `postgres-farm` de la imagen oficial PG-15 alpine a `apache/age:PG15_latest` (que es PG15 con la extension AGE pre-compilada).
+2. Crear una DB separada `chagra_kg` dentro del mismo cluster — el backend de farmOS sigue intacto en la DB `farmos`.
+3. Cargar el corpus al grafo vía script importer determinista (`scripts/catalog-to-age.mjs`).
+4. Exponer queries pre-compiladas a la PWA vía wrapper REST (`/api/graph/*`) con whitelist (NO Cypher arbitrario).
+
+---
+
+## Archivos del POC
+
+| Archivo | Propósito |
+|---|---|
+| `scripts/catalog-to-age.mjs` | Importer Node ESM. Lee el seed JSON y emite SQL idempotente (`MERGE` Cypher envuelto en `cypher('chagra_kg', $$ ... $$)`). |
+| `scripts/__tests__/catalog-to-age.test.mjs` | 42 assertions vitest. Verifica helpers + comportamiento end-to-end sobre fixture sintético y subset (10 species) del seed real. |
+| `scripts/age-queries-example.sql` | 5 queries Cypher comentadas (single-hop, multi-hop simple, multi-hop complejo, cross-query SQL+Cypher, agregación). |
+| `vitest.config.js` | Patch mínimo: incluye `scripts/__tests__/**/*.test.{js,mjs}` además de las rutas existentes. |
+| `docs/POC_APACHE_AGE.md` | Este archivo. |
+
+### Artefactos fuera del repo (vivos en `/tmp/` del nodo alpha, listos para que el operador los mueva donde quiera)
+
+| Path | Propósito |
+|---|---|
+| `/tmp/postgres-farm-age-migration.nix` | Diff propuesto sobre `guatoc-nixos/modules/agriculture/postgres-farm.nix` para cambiar la imagen a `apache/age:PG15_latest`. Incluye nueva opción `enableAge` + hooks `ExecStartPost` para `CREATE DATABASE chagra_kg` + `CREATE EXTENSION age`. |
+| `/tmp/age-kg-schema-2026-05-20.md` | Diseño detallado de nodos + relaciones del KG con cardinalidades esperadas + decisiones de modelado. |
+| `/tmp/age-rest-wrapper-design-2026-05-20.md` | Diseño del wrapper REST `/api/graph/*` con whitelist de queries, validación de input, caching, rate limiting. Postergada implementación a fase 2. |
+
+---
+
+## Quickstart (en un entorno de prueba aislado, NO en postgres-farm real)
+
+```bash
+# 1. Validar el importer offline (sin tocar postgres).
+node scripts/catalog-to-age.mjs --limit 10 --output /tmp/chagra-kg-test10.sql
+
+# 2. Inspeccionar el SQL generado.
+head -50 /tmp/chagra-kg-test10.sql
+
+# 3. Correr los tests del importer.
+npm run test:unit -- scripts/__tests__/catalog-to-age.test.mjs
+
+# 4. (Solo cuando el operador autorice) — aplicar contra una DB con AGE:
+psql -h localhost -p 5432 -U farmos -d chagra_kg -f /tmp/chagra-kg-test10.sql
+```
+
+---
+
+## Hipótesis de impacto en tokens del LLM
+
+| Tipo de query | BM25 actual (`ragRetriever.js`) | AGE Cypher esperado | Ahorro tokens LLM |
+|---|---|---|---|
+| Single-hop ("especies del templado") | 2.7 ms p95 — bien | ~3-5 ms — parecido | ~0% (BM25 ya gana) |
+| Multi-hop simple ("templado + compatible") | El LLM tiene que razonar sobre top-k chunks de RAG → varios pases CoT | <30 ms — query directa | **~70-85%** |
+| Multi-hop complejo ("triples guild design") | Casi imposible expresar — el LLM termina alucinando o pidiendo más context | <50 ms — pattern match nativo | **~85-95%** |
+| Agregación ("top 10 hubs") | No-go en BM25 puro — el LLM tiene que contar manualmente | <40 ms — COUNT con ORDER BY | **~90%** |
+
+(Cifras son estimaciones order-of-magnitude — fase 2 incluye bench real comparado contra `scripts/bench-rag-retrieve.mjs` existente.)
+
+---
+
+## Riesgos identificados
+
+1. **AGE 1.5.x todavía es young**. El project tiene tracción pero menos que `pgvector`. Antes de promover a producción, validar:
+   - Estabilidad en restarts del container postgres-farm.
+   - Performance de queries que devuelven >1000 nodos (el cast a JSON puede ser pesado).
+   - Compatibilidad de pg_dump con extensiones AGE (sí — pg_dump incluye CREATE EXTENSION).
+2. **Costo de imagen base**: apache/age:PG15_latest es debian, no alpine → ~250MB vs ~80MB. Aceptable, pero notar para el log.
+3. **Sin sops-nix todavía** (issue separado): `POSTGRES_PASSWORD=changeme` sigue en el .nix. NO migrar AGE sin antes resolver eso si va a producción.
+4. **AMB-10 simetría**: el catálogo garantiza `species.companions[]` simétrico por CI. Pero el grafo AGE almacena pares dirigidos. Para preguntas simétricas usar `MATCH (a)-[:COMPATIBLE_WITH]-(b)` (sin flecha).
+
+---
+
+## Decisión pendiente del operador
+
+1. **GO migration**: aplicar `/tmp/postgres-farm-age-migration.nix` → switch postgres-farm a apache/age.
+2. **Backup pre-cutover**: confirmar último dump de `postgres-farm-backup.nix` (cada 4h) + snapshot ZFS explícito.
+3. **Cargar corpus**: ejecutar el importer contra `chagra_kg` (DB nueva, NO `farmos`).
+4. **Bench**: medir p95 de Q2/Q3/Q5 vs BM25 actual.
+
+Hasta que esos pasos sean OK del operador, este POC queda exactamente como está: documentado, testeado offline, sin tocar producción.

--- a/scripts/__tests__/.keep
+++ b/scripts/__tests__/.keep
@@ -1,0 +1,4 @@
+Tests del importer `catalog-to-age.mjs` (POC Apache AGE — feat/apache-age-poc-2026-05-20).
+
+El test principal `catalog-to-age.test.mjs` se ejecuta con vitest (incluye
+`scripts/__tests__/**/*.test.{js,mjs}` en `vitest.config.js`).

--- a/scripts/__tests__/catalog-to-age.test.mjs
+++ b/scripts/__tests__/catalog-to-age.test.mjs
@@ -1,0 +1,312 @@
+/**
+ * scripts/__tests__/catalog-to-age.test.mjs
+ *
+ * Cobertura unitaria del importer Catalog → Apache AGE POC. NO toca la red
+ * ni postgres real; verifica únicamente que la función pura `buildSqlScript`
+ * y sus helpers producen SQL Cypher determinista y bien-formado a partir
+ * de fixtures sintéticos + del seed real (parcial).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  cypherLiteral,
+  truncText,
+  normalizeOrigen,
+  normalizePest,
+  emitNode,
+  emitRel,
+  wrapCypher,
+  buildSqlScript,
+} from '../catalog-to-age.mjs';
+
+describe('cypherLiteral', () => {
+  it('mapea null/undefined a literal null', () => {
+    expect(cypherLiteral(null)).toBe('null');
+    expect(cypherLiteral(undefined)).toBe('null');
+  });
+
+  it('mapea booleanos a true/false', () => {
+    expect(cypherLiteral(true)).toBe('true');
+    expect(cypherLiteral(false)).toBe('false');
+  });
+
+  it('mapea números finitos directo', () => {
+    expect(cypherLiteral(0)).toBe('0');
+    expect(cypherLiteral(42)).toBe('42');
+    expect(cypherLiteral(-3.14)).toBe('-3.14');
+  });
+
+  it('mapea NaN/Infinity a null para no romper Cypher', () => {
+    expect(cypherLiteral(NaN)).toBe('null');
+    expect(cypherLiteral(Infinity)).toBe('null');
+  });
+
+  it('escapa comillas simples doblándolas (regla SQL/Cypher)', () => {
+    expect(cypherLiteral("d'agua")).toBe("'d''agua'");
+    expect(cypherLiteral("Restrepo's bocashi")).toBe("'Restrepo''s bocashi'");
+  });
+
+  it('serializa arrays/objetos como string JSON saneado', () => {
+    const out = cypherLiteral([1, 2, 3]);
+    expect(out.startsWith("'") && out.endsWith("'")).toBe(true);
+    expect(out).toContain('1,2,3');
+  });
+});
+
+describe('truncText', () => {
+  it('devuelve null para null/undefined', () => {
+    expect(truncText(null)).toBeNull();
+    expect(truncText(undefined)).toBeNull();
+  });
+
+  it('no toca strings dentro del límite', () => {
+    expect(truncText('hola', 10)).toBe('hola');
+  });
+
+  it('trunca con elipsis textual fuera del límite', () => {
+    const out = truncText('abcdefghij', 6);
+    expect(out).toHaveLength(6);
+    expect(out.endsWith('...')).toBe(true);
+  });
+});
+
+describe('normalizeOrigen', () => {
+  it('devuelve null para empty', () => {
+    expect(normalizeOrigen('')).toBeNull();
+    expect(normalizeOrigen(null)).toBeNull();
+  });
+
+  it('extrae las primeras 4 palabras slug-ified', () => {
+    expect(normalizeOrigen('Sudeste de Australia (Tasmania)')).toBe('sudeste_de_australia_tasmania');
+  });
+
+  it('strip de acentos', () => {
+    // "región andina central" → "region_andina_central"
+    expect(normalizeOrigen('región andina central de Colombia'))
+      .toBe('region_andina_central_de');
+  });
+});
+
+describe('normalizePest', () => {
+  it('slug-ifica nombres científicos', () => {
+    expect(normalizePest('Hypothenemus hampei (broca)')).toBe('hypothenemus_hampei_broca');
+  });
+
+  it('devuelve null para empty', () => {
+    expect(normalizePest('')).toBeNull();
+  });
+});
+
+describe('emitNode', () => {
+  it('genera MERGE con SET cuando hay propiedades', () => {
+    const out = emitNode('Species', { id: 'zea_mays', nombre_comun: 'Maíz' });
+    expect(out).toContain('MERGE (n:Species {id: \'zea_mays\'})');
+    expect(out).toContain("nombre_comun: 'Maíz'");
+  });
+
+  it('omite SET si solo viene id', () => {
+    const out = emitNode('PisoTermico', { id: 'templado' });
+    expect(out).toBe("MERGE (n:PisoTermico {id: 'templado'})");
+  });
+
+  it('descarta null/undefined/empty en SET', () => {
+    const out = emitNode('Species', { id: 'x', a: null, b: undefined, c: '', d: 'ok' });
+    expect(out).toContain('d: \'ok\'');
+    expect(out).not.toContain('a:');
+    expect(out).not.toContain('b:');
+    expect(out).not.toContain('c:');
+  });
+
+  it('explota si falta id', () => {
+    expect(() => emitNode('Species', {})).toThrow(/missing id/);
+  });
+});
+
+describe('emitRel', () => {
+  it('genera MATCH+MATCH+MERGE sin props', () => {
+    const out = emitRel(
+      { label: 'Species', id: 'a' },
+      'COMPATIBLE_WITH',
+      { label: 'Species', id: 'b' },
+    );
+    expect(out).toContain("MATCH (a:Species {id: 'a'})");
+    expect(out).toContain("MATCH (b:Species {id: 'b'})");
+    expect(out).toContain('MERGE (a)-[r:COMPATIBLE_WITH]->(b)');
+  });
+
+  it('inyecta props inline en la arista', () => {
+    const out = emitRel(
+      { label: 'Species', id: 'a' },
+      'USED_AS_BIOPREPARADO',
+      { label: 'Biopreparado', id: 'bocashi' },
+      { source: 'feeding_plan_template', etapa: 'establecimiento' },
+    );
+    expect(out).toContain("source: 'feeding_plan_template'");
+    expect(out).toContain("etapa: 'establecimiento'");
+  });
+});
+
+describe('wrapCypher', () => {
+  it('envuelve en SELECT * FROM cypher(...) con RETURN sintético', () => {
+    const out = wrapCypher('chagra_kg', "MERGE (n:Species {id: 'a'})");
+    expect(out).toMatch(/^SELECT \* FROM cypher\('chagra_kg', \$\$/);
+    expect(out).toContain('RETURN 0');
+    expect(out).toContain('AS (v agtype);');
+  });
+
+  it('no agrega RETURN si el Cypher ya lo trae', () => {
+    const out = wrapCypher('chagra_kg', 'MATCH (n) RETURN n LIMIT 1');
+    // Solo el RETURN explícito del input — no se duplica.
+    const matches = out.match(/return/gi) || [];
+    expect(matches.length).toBe(1);
+  });
+});
+
+describe('buildSqlScript — fixture sintético', () => {
+  const fixture = {
+    species: [
+      {
+        id: 'zea_mays',
+        nombre_comun: 'Maíz',
+        nombre_cientifico: 'Zea mays L.',
+        familia_botanica: 'Poaceae',
+        category: 'cereales',
+        estrato: 'medio',
+        origen: 'Mesoamérica (México central)',
+        roles_in_guild: ['crop', 'nitrogen_fixer'],
+        thermal_zones: ['templado', 'calido'],
+        cultivable: true,
+        altitud_msnm: { optimo_min: 0, optimo_max: 2400 },
+        temperatura_c: { optimo_min: 15, optimo_max: 28 },
+        companions: ['phaseolus_vulgaris', 'cucurbita_pepo'],
+        antagonists: [],
+        source_ids: ['ica-guia-fertilizantes-2019'],
+        plagas_criticas: ['Spodoptera frugiperda'],
+        feeding_plan_template: {
+          primary_steps: [
+            { biofertilizer_slug: 'bocashi' },
+            { biofertilizer_slug: 'biol' },
+            { biofertilizer_slug: 'bocashi' }, // duplicado intencional
+          ],
+        },
+      },
+      {
+        id: 'phaseolus_vulgaris',
+        nombre_comun: 'Frijol',
+        familia_botanica: 'Fabaceae',
+        thermal_zones: ['templado'],
+        roles_in_guild: ['crop', 'nitrogen_fixer'],
+        companions: ['zea_mays'],
+        antagonists: ['foeniculum_vulgare'],
+      },
+    ],
+    biopreparados: [
+      { id: 'bocashi', nombre: 'Bocashi', source_ids: ['restrepo-1996-bocashi'] },
+      { id: 'biol', nombre: 'Biol', source_ids: [] },
+    ],
+    sources: [
+      { id: 'ica-guia-fertilizantes-2019', titulo: 'Guía ICA Fertilizantes 2019', tier: 'A' },
+      { id: 'restrepo-1996-bocashi', titulo: 'Restrepo Bocashi 1996', tier: 'B' },
+    ],
+  };
+
+  const statements = buildSqlScript(fixture);
+
+  it('arranca con LOAD age + SET search_path + create_graph', () => {
+    expect(statements[0]).toContain("LOAD 'age'");
+    expect(statements[1]).toContain('search_path = ag_catalog');
+    expect(statements.some((s) => s.includes("drop_graph('chagra_kg'"))).toBe(true);
+    expect(statements.some((s) => s.includes("create_graph('chagra_kg'"))).toBe(true);
+  });
+
+  it('respeta --no-drop omitiendo drop_graph', () => {
+    const stmts = buildSqlScript(fixture, { includeDrop: false });
+    expect(stmts.some((s) => s.includes('drop_graph'))).toBe(false);
+    expect(stmts.some((s) => s.includes('create_graph'))).toBe(true);
+  });
+
+  it('crea exactamente 1 nodo por taxón único (sin duplicados)', () => {
+    // Filtramos por MERGE (n:Label — eso solo matchea nodos, no las relaciones
+    // que contienen (a:Label) y (b:Label) en el MATCH.
+    const familyNodes = statements.filter((s) => /MERGE \(n:Family /.test(s));
+    // Poaceae + Fabaceae
+    expect(familyNodes).toHaveLength(2);
+    const tzNodes = statements.filter((s) => /MERGE \(n:PisoTermico /.test(s));
+    // templado + calido (templado aparece 2× en species pero solo 1 nodo)
+    expect(tzNodes).toHaveLength(2);
+  });
+
+  it('genera todas las COMPATIBLE_WITH desde companions[]', () => {
+    const compatRels = statements.filter((s) => s.includes('COMPATIBLE_WITH'));
+    // zea_mays → phaseolus_vulgaris, zea_mays → cucurbita_pepo, phaseolus_vulgaris → zea_mays
+    expect(compatRels).toHaveLength(3);
+  });
+
+  it('genera ANTAGONIST_OF solo desde antagonists[]', () => {
+    const antagRels = statements.filter((s) => s.includes('ANTAGONIST_OF'));
+    // phaseolus_vulgaris → foeniculum_vulgare
+    expect(antagRels).toHaveLength(1);
+  });
+
+  it('deduplica USED_AS_BIOPREPARADO por species+biopreparado', () => {
+    const bpRels = statements.filter((s) => s.includes('USED_AS_BIOPREPARADO'));
+    // zea_mays → bocashi (1×, no 2×), zea_mays → biol (1×) = 2 rels
+    expect(bpRels).toHaveLength(2);
+  });
+
+  it('genera REFERENCED_BY tanto desde Species como desde Biopreparado', () => {
+    const refRels = statements.filter((s) => s.includes('REFERENCED_BY'));
+    // zea_mays → ica-guia, bocashi → restrepo-1996 = 2
+    expect(refRels).toHaveLength(2);
+  });
+
+  it('crea nodo Pest normalizado para plagas_criticas', () => {
+    const pestNodes = statements.filter((s) => /MERGE \(n:Pest /.test(s));
+    expect(pestNodes).toHaveLength(1);
+    expect(pestNodes[0]).toContain('spodoptera_frugiperda');
+  });
+
+  it('respeta limit slicing species[]', () => {
+    const limited = buildSqlScript(fixture, { limit: 1 });
+    const speciesNodes = limited.filter((s) => /MERGE \(n:Species /.test(s));
+    expect(speciesNodes).toHaveLength(1);
+  });
+});
+
+describe('buildSqlScript — fixture real (subset del seed v3.1)', () => {
+  const seedPath = resolve('catalog/chagra-catalog-seed-v3.1.json');
+  let seed;
+  try {
+    seed = JSON.parse(readFileSync(seedPath, 'utf-8'));
+  } catch {
+    // En CI sin acceso al seed (poco probable acá), skip suave.
+    seed = null;
+  }
+
+  it.skipIf(!seed)('arroja >0 statements para limit=10', () => {
+    const stmts = buildSqlScript(seed, { limit: 10 });
+    expect(stmts.length).toBeGreaterThan(20); // headers + nodos taxonomicos + species + rels
+  });
+
+  it.skipIf(!seed)('cada statement (excepto LOAD/SET/drop/create) está envuelto en cypher() SELECT', () => {
+    const stmts = buildSqlScript(seed, { limit: 5 });
+    for (const s of stmts) {
+      const isPreamble = s.startsWith('LOAD')
+        || s.startsWith('SET search_path')
+        || s.startsWith('SELECT drop_graph')
+        || s.startsWith('SELECT create_graph');
+      if (!isPreamble) {
+        expect(s).toMatch(/^SELECT \* FROM cypher\('chagra_kg'/);
+        expect(s).toContain('AS (v agtype);');
+      }
+    }
+  });
+
+  it.skipIf(!seed)('SQL output total para limit=10 < 200KB (sanity, no balloon)', () => {
+    const stmts = buildSqlScript(seed, { limit: 10 });
+    const total = stmts.join('\n').length;
+    expect(total).toBeLessThan(200_000);
+  });
+});

--- a/scripts/age-queries-example.sql
+++ b/scripts/age-queries-example.sql
@@ -1,0 +1,147 @@
+-- =============================================================================
+-- scripts/age-queries-example.sql
+--
+-- 5 queries Cypher de ejemplo sobre el grafo `chagra_kg` que demuestran:
+--   1. single-hop trivial (filtro por piso térmico)
+--   2. multi-hop simple (compatibilidad dentro de un piso)
+--   3. multi-hop complejo (triples compatibles entre sí)
+--   4. cross-query SQL + Cypher (corpus × farmOS inventory si la DB se uniera)
+--   5. agregación con ORDER BY (top compañeras del grafo)
+--
+-- Para ejecutar (cuando AGE esté instalado en postgres-farm y `chagra_kg`
+-- haya sido poblado por scripts/catalog-to-age.mjs):
+--
+--     psql -h localhost -p 5432 -U farmos -d chagra_kg -f scripts/age-queries-example.sql
+--
+-- Estado POC: NO ejecutado contra postgres real. Validar primero en una DB
+-- aparte con AGE habilitado.
+-- =============================================================================
+
+LOAD 'age';
+SET search_path = ag_catalog, "$user", public;
+
+-- -----------------------------------------------------------------------------
+-- Q1. SINGLE-HOP — Especies del piso templado
+-- -----------------------------------------------------------------------------
+-- Patrón: filtro plano por un atributo categórico relacionado.
+-- En BM25 actual esto es trivial; en SQL convencional requiere JOIN
+-- `species_thermal_zones`. En Cypher: una sola línea declarativa.
+-- Cost esperado AGE: <5 ms en 488 species (lookup directo por etiqueta + filter).
+-- -----------------------------------------------------------------------------
+
+SELECT * FROM cypher('chagra_kg', $$
+  MATCH (sp:Species)-[:GROWS_IN]->(:PisoTermico {id: 'templado'})
+  RETURN sp.id AS species_id, sp.nombre_comun AS nombre, sp.categoria AS categoria
+  ORDER BY sp.id
+  LIMIT 50
+$$) AS (species_id agtype, nombre agtype, categoria agtype);
+
+-- -----------------------------------------------------------------------------
+-- Q2. MULTI-HOP SIMPLE — Pares de especies del templado compatibles
+-- -----------------------------------------------------------------------------
+-- Patrón: dos especies que comparten piso térmico Y tienen arista de
+-- compatibilidad. En SQL serían 3 JOINs (species × piso × companions);
+-- en Cypher: 3 aristas pattern-matched en una sola query.
+-- En BM25 actual NO se puede expresar — requiere razonamiento manual del LLM
+-- sobre múltiples chunks RAG (consume tokens).
+-- -----------------------------------------------------------------------------
+
+SELECT * FROM cypher('chagra_kg', $$
+  MATCH (a:Species)-[:GROWS_IN]->(:PisoTermico {id: 'templado'}),
+        (b:Species)-[:GROWS_IN]->(:PisoTermico {id: 'templado'}),
+        (a)-[:COMPATIBLE_WITH]->(b)
+  WHERE a.id < b.id  -- dedup pares (a,b) vs (b,a)
+  RETURN a.id AS a, b.id AS b
+  ORDER BY a, b
+  LIMIT 100
+$$) AS (a agtype, b agtype);
+
+-- -----------------------------------------------------------------------------
+-- Q3. MULTI-HOP COMPLEJO — Triples compatibles entre sí del piso templado
+-- -----------------------------------------------------------------------------
+-- Patrón: triángulo de compatibilidad (las 3 especies son mutuamente
+-- compañeras) Y todas comparten piso templado Y todas tienen rol crop.
+-- Este es el caso "guild design" de permacultura: tres cultivos que se
+-- llevan entre sí y caben en el mismo piso. En SQL puro: 6+ JOINs con
+-- self-joins sobre la tabla companion. En Cypher: 6 patterns en 4 líneas.
+-- -----------------------------------------------------------------------------
+
+SELECT * FROM cypher('chagra_kg', $$
+  MATCH (a:Species)-[:GROWS_IN]->(:PisoTermico {id: 'templado'}),
+        (b:Species)-[:GROWS_IN]->(:PisoTermico {id: 'templado'}),
+        (c:Species)-[:GROWS_IN]->(:PisoTermico {id: 'templado'}),
+        (a)-[:COMPATIBLE_WITH]-(b),
+        (b)-[:COMPATIBLE_WITH]-(c),
+        (a)-[:COMPATIBLE_WITH]-(c),
+        (a)-[:HAS_ROLE]->(:RoleInGuild {id: 'crop'}),
+        (b)-[:HAS_ROLE]->(:RoleInGuild {id: 'crop'}),
+        (c)-[:HAS_ROLE]->(:RoleInGuild {id: 'crop'})
+  WHERE a.id < b.id AND b.id < c.id
+  RETURN a.id AS a, b.id AS b, c.id AS c
+  ORDER BY a, b, c
+  LIMIT 25
+$$) AS (a agtype, b agtype, c agtype);
+
+-- -----------------------------------------------------------------------------
+-- Q4. CROSS-QUERY (corpus × farmOS inventory)
+-- -----------------------------------------------------------------------------
+-- Patrón: si la DB `farmos` y `chagra_kg` vivieran en el mismo cluster
+-- postgres-farm (o vía FDW), se puede cruzar el grafo del corpus con el
+-- inventario de assets del operador. Esto es el caso de uso real para el
+-- "agente recomendador": "el operador tiene maíz y cebolla en su finca,
+-- qué companions del corpus le faltan agregar".
+--
+-- Diseño postergado al wrapper REST. Acá demo del shape SQL:
+-- -----------------------------------------------------------------------------
+
+-- ⚠️ Esta query asume que existe un FDW `farmos_fdw` apuntando a la DB
+-- farmos del cluster, o que ambas DBs viven en el mismo postgres y se puede
+-- cross-database query via dblink. AGE NO permite todavía hacer JOIN nativo
+-- entre cypher() y tablas relacionales en la misma query — el patrón
+-- estándar es: ejecutar cypher() → CTE → JOIN contra tablas relacionales.
+
+WITH companions_recomendados AS (
+  SELECT
+    (companion_id::text)::text AS companion_slug,
+    (companion_nombre::text)::text AS companion_nombre
+  FROM cypher('chagra_kg', $$
+    MATCH (mine:Species)-[:COMPATIBLE_WITH]->(comp:Species)
+    WHERE mine.id IN ['zea_mays', 'allium_cepa']   -- inventario del operador
+      AND NOT comp.id IN ['zea_mays', 'allium_cepa']
+    RETURN comp.id AS companion_id, comp.nombre_comun AS companion_nombre
+  $$) AS (companion_id agtype, companion_nombre agtype)
+)
+SELECT companion_slug, companion_nombre
+FROM companions_recomendados
+ORDER BY companion_slug
+LIMIT 25;
+-- En producción: el array `['zea_mays', 'allium_cepa']` vendría de
+-- `SELECT slug FROM farmos.asset__plant WHERE uid = $tenant`.
+
+-- -----------------------------------------------------------------------------
+-- Q5. AGREGACIÓN — Top 10 species con más compañeras documentadas
+-- -----------------------------------------------------------------------------
+-- Patrón: ranking. Útil para detectar "species hub" del grafo (las que
+-- más conexiones tienen suelen ser las mejor documentadas o las que más
+-- aplicaciones tienen en sistemas tradicionales — yuca, maíz, fríjol).
+-- En BM25 imposible expresar; en SQL relacional implica COUNT con JOIN
+-- pesado; en Cypher: COUNT directo sobre pattern.
+-- -----------------------------------------------------------------------------
+
+SELECT * FROM cypher('chagra_kg', $$
+  MATCH (sp:Species)-[:COMPATIBLE_WITH]-(other:Species)
+  RETURN sp.id AS species, sp.nombre_comun AS nombre, COUNT(DISTINCT other) AS companion_count
+  ORDER BY companion_count DESC
+  LIMIT 10
+$$) AS (species agtype, nombre agtype, companion_count agtype);
+
+-- =============================================================================
+-- Notas operacionales
+--   - Todas las queries devuelven `agtype` (tipo nativo AGE). Casts a text/int
+--     se hacen del lado del wrapper REST (ver /tmp/age-rest-wrapper-design-2026-05-20.md).
+--   - Para integrar al cliente Chagra PWA: NO se expone Cypher arbitrario al
+--     navegador. Solo queries pre-compiladas vía /api/graph/* (whitelist).
+--   - Bench plan: medir p50/p95 de cada Q tras importar el catálogo completo;
+--     comparar contra BM25 actual para confirmar la estimación 80-95% ahorro
+--     de tokens en multi-hop.
+-- =============================================================================

--- a/scripts/catalog-to-age.mjs
+++ b/scripts/catalog-to-age.mjs
@@ -1,0 +1,532 @@
+#!/usr/bin/env node
+/**
+ * scripts/catalog-to-age.mjs
+ *
+ * POC importer: lee `catalog/chagra-catalog-seed-v3.1.json` y genera un script
+ * SQL idempotente que puede cargarse contra una instancia de PostgreSQL con
+ * Apache AGE (https://age.apache.org/) instalado, creando un grafo
+ * `chagra_kg` con la estructura del catálogo Chagra.
+ *
+ * Estado: POC documental. NO ejecuta nada contra el postgres-farm real.
+ * Genera un .sql en stdout (o --output FILE) que el operador revisa, ejecuta
+ * en una base apartada (`chagra_kg`) y deja el postgres-farm de farmOS
+ * intacto.
+ *
+ * Diseño:
+ *   - Cada species, biopreparado, source, family, thermal_zone, origen, role,
+ *     habito y pest se representa como un nodo Cypher.
+ *   - Relaciones derivadas:
+ *       (:Species)-[:COMPATIBLE_WITH]->(:Species)        (companions[])
+ *       (:Species)-[:ANTAGONIST_OF]->(:Species)          (antagonists[])
+ *       (:Species)-[:USED_AS_BIOPREPARADO]->(:Biopreparado)
+ *           desde feeding_plan_template.primary_steps[].biofertilizer_slug
+ *           y plan_nutricion_base.biopreparados_por_etapa.*[].biopreparado_id
+ *       (:Species)-[:GROWS_IN]->(:PisoTermico)           (thermal_zones[])
+ *       (:Species)-[:HAS_FAMILY]->(:Family)              (familia_botanica)
+ *       (:Species)-[:HAS_HABIT]->(:Habito)               (estrato)
+ *       (:Species)-[:HAS_ORIGIN]->(:Origen)              (origen, normalizado)
+ *       (:Species)-[:HAS_ROLE]->(:RoleInGuild)           (roles_in_guild[])
+ *       (:Species)-[:REFERENCED_BY]->(:Source)           (source_ids[])
+ *       (:Biopreparado)-[:REFERENCED_BY]->(:Source)      (source_ids[])
+ *       (:Species)-[:TARGETS_PEST]->(:Pest)              (plagas_criticas[])
+ *
+ * Idempotencia:
+ *   - El script abre con `DROP GRAPH IF EXISTS chagra_kg CASCADE`. Cargar
+ *     dos veces no duplica nodos.
+ *   - Usa `MERGE` Cypher en cada nodo y arista — defense in depth si el
+ *     operador elige no dropear y solo aplicar deltas.
+ *
+ * Seguridad:
+ *   - Sanitiza strings con escape de comilla simple (Cypher: doble la comilla).
+ *   - Trunca textos largos (>500 chars) en propiedades de nodo para no
+ *     hinchar el grafo con prosa que vive mejor en Source/RAG documental.
+ *   - NO acepta input externo arbitrario — solo el seed JSON del repo.
+ *
+ * Uso:
+ *   node scripts/catalog-to-age.mjs \
+ *     --input catalog/chagra-catalog-seed-v3.1.json \
+ *     --output /tmp/chagra-kg-import.sql \
+ *     [--limit 10]        # subset de species (default: todas)
+ *     [--no-drop]         # no incluye DROP GRAPH al inicio
+ *     [--graph chagra_kg] # nombre del grafo (default: chagra_kg)
+ *
+ * Pipeline propuesto en postgres real (NO ejecutado por este POC):
+ *   psql -h localhost -p 5432 -U farmos -d chagra_kg -f /tmp/chagra-kg-import.sql
+ *
+ * Limitaciones (documentadas):
+ *   - chagra_kg DB debe existir antes (`CREATE DATABASE chagra_kg`).
+ *   - Extension AGE debe estar habilitada (`CREATE EXTENSION age`).
+ *   - Path debe estar seteado (`SET search_path = ag_catalog, "$user", public`).
+ *   - No se genera índice grafo todavía — fase 2 cuando se midan queries.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// =============================================================================
+// Utilidades públicas (exportadas para tests)
+// =============================================================================
+
+/**
+ * Escapa un valor JS para inlining seguro como literal Cypher dentro del
+ * argumento string de `cypher('graph', $$ ... $$, ...)`.
+ *
+ * Reglas:
+ *   - null / undefined → 'null' (literal Cypher).
+ *   - boolean / number finitos → toString.
+ *   - string → comillas simples + dobla cualquier comilla simple interna.
+ *     (Cypher es como SQL en eso.)
+ *   - cualquier otro tipo (array/object) → JSON.stringify y luego se trata
+ *     como string. Útil si el caller quiere meter un blob en una propiedad.
+ *
+ * @param {unknown} v
+ * @returns {string} literal Cypher seguro
+ */
+export function cypherLiteral(v) {
+  if (v === null || v === undefined) return 'null';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  if (typeof v === 'number') {
+    if (!Number.isFinite(v)) return 'null';
+    return String(v);
+  }
+  if (typeof v === 'string') {
+    return `'${v.replace(/'/g, "''")}'`;
+  }
+  // arrays / objects → string JSON saneado
+  return cypherLiteral(JSON.stringify(v));
+}
+
+/**
+ * Convierte un id de catálogo (`solanum_lycopersicum_san_marzano`) al
+ * formato canónico que se guarda en el nodo. Acá no hay transformación
+ * porque ya viene normalizado, pero la función existe para centralizar
+ * la decisión y poder reescribirla sin tocar callsites.
+ *
+ * @param {string} id
+ */
+export function nodeId(id) {
+  return String(id).trim();
+}
+
+/**
+ * Trunca un campo libre a maxLen para no inflar nodos con prosa larga.
+ * El detalle completo vive en el JSON original (Source/RAG documental).
+ *
+ * @param {string|null|undefined} text
+ * @param {number} maxLen
+ */
+export function truncText(text, maxLen = 500) {
+  if (text === null || text === undefined) return null;
+  const s = String(text);
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Normaliza el campo `origen` de una species a un id corto.
+ * Es prosa libre en el seed (ej. "Sudeste de Australia ..."), así que
+ * extraemos las primeras 4 palabras alfanuméricas y las slug-ificamos.
+ *
+ * @param {string|null|undefined} origenText
+ * @returns {string|null}
+ */
+export function normalizeOrigen(origenText) {
+  if (!origenText) return null;
+  const cleaned = String(origenText)
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip accents
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 4)
+    .join('_');
+  return cleaned || null;
+}
+
+/**
+ * Normaliza un nombre de plaga (string libre) a id slug.
+ *
+ * @param {string} pestName
+ */
+export function normalizePest(pestName) {
+  if (!pestName) return null;
+  return String(pestName)
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80);
+}
+
+/**
+ * Construye un CREATE/MERGE Cypher para un nodo.
+ *
+ * @param {string} label - 'Species', 'Biopreparado', etc.
+ * @param {Record<string, unknown>} props - debe incluir `id`.
+ * @returns {string} fragmento Cypher (`MERGE (n:Label {id: 'x'}) SET n += {...}`)
+ */
+export function emitNode(label, props) {
+  const id = props.id;
+  if (!id) throw new Error(`emitNode(${label}): missing id`);
+  const setProps = Object.entries(props)
+    .filter(([k]) => k !== 'id')
+    .filter(([, v]) => v !== null && v !== undefined && v !== '')
+    .map(([k, v]) => `${k}: ${cypherLiteral(v)}`)
+    .join(', ');
+  const setClause = setProps ? `SET n += {${setProps}}` : '';
+  return `MERGE (n:${label} {id: ${cypherLiteral(id)}}) ${setClause}`.trim();
+}
+
+/**
+ * Construye un MERGE Cypher para una arista entre nodos ya existentes.
+ *
+ * @param {{label:string,id:string}} from
+ * @param {string} relType
+ * @param {{label:string,id:string}} to
+ * @param {Record<string, unknown>} [relProps]
+ */
+export function emitRel(from, relType, to, relProps = {}) {
+  const propEntries = Object.entries(relProps)
+    .filter(([, v]) => v !== null && v !== undefined && v !== '');
+  const propClause = propEntries.length
+    ? ` {${propEntries.map(([k, v]) => `${k}: ${cypherLiteral(v)}`).join(', ')}}`
+    : '';
+  return [
+    `MATCH (a:${from.label} {id: ${cypherLiteral(from.id)}})`,
+    `MATCH (b:${to.label} {id: ${cypherLiteral(to.id)}})`,
+    `MERGE (a)-[r:${relType}${propClause}]->(b)`,
+  ].join(' ');
+}
+
+/**
+ * Genera el bloque SQL completo `SELECT * FROM cypher(...)` que envuelve
+ * uno o más statements Cypher. AGE no soporta múltiples statements por
+ * cypher() call, así que cada statement va en su propio SELECT.
+ *
+ * @param {string} graphName
+ * @param {string} cypher
+ */
+export function wrapCypher(graphName, cypher) {
+  // AGE requiere RETURN explícito; usamos un id sintético cuando no hay nada que retornar.
+  const needsReturn = !/\breturn\b/i.test(cypher);
+  const finalCypher = needsReturn ? `${cypher} RETURN 0` : cypher;
+  return `SELECT * FROM cypher(${cypherLiteral(graphName)}, $$\n  ${finalCypher}\n$$) AS (v agtype);`;
+}
+
+// =============================================================================
+// Construcción del corpus de statements
+// =============================================================================
+
+/**
+ * Punto de entrada principal. Recibe el seed parseado y devuelve un array
+ * de statements SQL en el orden correcto (nodos antes que aristas).
+ *
+ * @param {object} seed
+ * @param {object} [opts]
+ * @param {number} [opts.limit] - subset de species
+ * @param {string} [opts.graph='chagra_kg']
+ * @param {boolean} [opts.includeDrop=true]
+ */
+export function buildSqlScript(seed, opts = {}) {
+  const graph = opts.graph || 'chagra_kg';
+  const includeDrop = opts.includeDrop !== false;
+  const speciesAll = Array.isArray(seed.species) ? seed.species : [];
+  const species = typeof opts.limit === 'number'
+    ? speciesAll.slice(0, opts.limit)
+    : speciesAll;
+  const biopreparados = Array.isArray(seed.biopreparados) ? seed.biopreparados : [];
+  const sources = Array.isArray(seed.sources) ? seed.sources : [];
+
+  const statements = [];
+
+  // 0. Preamble: cargar AGE + setear search_path + opcionalmente recrear grafo.
+  statements.push('LOAD \'age\';');
+  statements.push('SET search_path = ag_catalog, "$user", public;');
+  if (includeDrop) {
+    statements.push(`SELECT drop_graph(${cypherLiteral(graph)}, true);`);
+  }
+  statements.push(`SELECT create_graph(${cypherLiteral(graph)});`);
+
+  // 1. Nodos taxonómicos / ontológicos (sets pequeños, derivados de species).
+  const families = new Set();
+  const habitats = new Set();
+  const origins = new Set();
+  const roles = new Set();
+  const thermalZones = new Set();
+  const pests = new Set();
+
+  for (const sp of species) {
+    if (sp.familia_botanica) families.add(sp.familia_botanica);
+    if (sp.estrato) habitats.add(sp.estrato);
+    const o = normalizeOrigen(sp.origen);
+    if (o) origins.add(o);
+    for (const r of (sp.roles_in_guild || [])) roles.add(r);
+    for (const tz of (sp.thermal_zones || [])) thermalZones.add(tz);
+    for (const pest of (sp.plagas_criticas || [])) {
+      const n = normalizePest(pest);
+      if (n) pests.add(n);
+    }
+  }
+
+  for (const f of families) {
+    statements.push(wrapCypher(graph, emitNode('Family', { id: f, nombre: f })));
+  }
+  for (const h of habitats) {
+    statements.push(wrapCypher(graph, emitNode('Habito', { id: h })));
+  }
+  for (const o of origins) {
+    statements.push(wrapCypher(graph, emitNode('Origen', { id: o })));
+  }
+  for (const r of roles) {
+    statements.push(wrapCypher(graph, emitNode('RoleInGuild', { id: r })));
+  }
+  for (const tz of thermalZones) {
+    statements.push(wrapCypher(graph, emitNode('PisoTermico', { id: tz })));
+  }
+  for (const p of pests) {
+    statements.push(wrapCypher(graph, emitNode('Pest', { id: p })));
+  }
+
+  // 2. Source nodes (todos los sources del catálogo).
+  for (const s of sources) {
+    statements.push(wrapCypher(graph, emitNode('Source', {
+      id: nodeId(s.id),
+      titulo: truncText(s.titulo, 240),
+      autores: truncText(s.autores, 120),
+      ano: s['año'] ?? null, // ñ-aware
+      tier: s.tier ?? null,
+      tipo: s.tipo ?? null,
+      institucion: truncText(s.institucion, 120),
+    })));
+  }
+
+  // 3. Biopreparado nodes.
+  for (const bp of biopreparados) {
+    statements.push(wrapCypher(graph, emitNode('Biopreparado', {
+      id: nodeId(bp.id),
+      nombre: bp.nombre || null,
+      tipo: bp.tipo || null,
+      proposito: Array.isArray(bp.proposito) ? bp.proposito.join('|') : null,
+      tiempo_elaboracion_dias: bp.tiempo_elaboracion_dias ?? null,
+      vida_util_dias: bp.vida_util_dias ?? null,
+      uso: truncText(bp.uso, 300),
+    })));
+    // Bp → Source
+    for (const sid of (bp.source_ids || [])) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Biopreparado', id: bp.id },
+        'REFERENCED_BY',
+        { label: 'Source', id: sid },
+      )));
+    }
+  }
+
+  // 4. Species nodes + relaciones.
+  for (const sp of species) {
+    statements.push(wrapCypher(graph, emitNode('Species', {
+      id: nodeId(sp.id),
+      nombre_comun: sp.nombre_comun || null,
+      nombre_cientifico: sp.nombre_cientifico || null,
+      categoria: sp.category || null,
+      cultivable: sp.cultivable ?? null,
+      conservation_status: sp.conservation_status || null,
+      validation_level: sp.validation_level || null,
+      tracking_mode: sp.tracking_mode || null,
+      // Numéricos planos útiles para queries con WHERE:
+      altitud_min: sp.altitud_msnm?.optimo_min ?? sp.altitud_msnm?.min_absoluto ?? null,
+      altitud_max: sp.altitud_msnm?.optimo_max ?? sp.altitud_msnm?.max_absoluto ?? null,
+      temp_min: sp.temperatura_c?.optimo_min ?? null,
+      temp_max: sp.temperatura_c?.optimo_max ?? null,
+      // valor_pedagogico va a Source/RAG documental; aquí solo un teaser:
+      teaser: truncText(sp.valor_pedagogico, 240),
+    })));
+
+    // Species → Family
+    if (sp.familia_botanica) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'HAS_FAMILY',
+        { label: 'Family', id: sp.familia_botanica },
+      )));
+    }
+    // Species → Habito
+    if (sp.estrato) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'HAS_HABIT',
+        { label: 'Habito', id: sp.estrato },
+      )));
+    }
+    // Species → Origen
+    const origen = normalizeOrigen(sp.origen);
+    if (origen) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'HAS_ORIGIN',
+        { label: 'Origen', id: origen },
+      )));
+    }
+    // Species → PisoTermico
+    for (const tz of (sp.thermal_zones || [])) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'GROWS_IN',
+        { label: 'PisoTermico', id: tz },
+      )));
+    }
+    // Species → RoleInGuild
+    for (const r of (sp.roles_in_guild || [])) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'HAS_ROLE',
+        { label: 'RoleInGuild', id: r },
+      )));
+    }
+    // Species → Species companions (COMPATIBLE_WITH)
+    for (const comp of (sp.companions || [])) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'COMPATIBLE_WITH',
+        { label: 'Species', id: comp },
+      )));
+    }
+    // Species → Species antagonists (ANTAGONIST_OF)
+    for (const ant of (sp.antagonists || [])) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'ANTAGONIST_OF',
+        { label: 'Species', id: ant },
+      )));
+    }
+    // Species → Source
+    for (const sid of (sp.source_ids || [])) {
+      statements.push(wrapCypher(graph, emitRel(
+        { label: 'Species', id: sp.id },
+        'REFERENCED_BY',
+        { label: 'Source', id: sid },
+      )));
+    }
+    // Species → Pest
+    for (const pest of (sp.plagas_criticas || [])) {
+      const pid = normalizePest(pest);
+      if (pid) {
+        statements.push(wrapCypher(graph, emitRel(
+          { label: 'Species', id: sp.id },
+          'TARGETS_PEST',
+          { label: 'Pest', id: pid },
+          { raw_name: pest },
+        )));
+      }
+    }
+    // Species → Biopreparado (vía feeding_plan_template)
+    const seenBp = new Set();
+    const steps = sp.feeding_plan_template?.primary_steps || [];
+    for (const step of steps) {
+      const bp = step.biofertilizer_slug;
+      if (bp && !seenBp.has(bp)) {
+        seenBp.add(bp);
+        statements.push(wrapCypher(graph, emitRel(
+          { label: 'Species', id: sp.id },
+          'USED_AS_BIOPREPARADO',
+          { label: 'Biopreparado', id: bp },
+          { source: 'feeding_plan_template' },
+        )));
+      }
+    }
+    // Species → Biopreparado (vía plan_nutricion_base.biopreparados_por_etapa)
+    const etapas = sp.plan_nutricion_base?.biopreparados_por_etapa || {};
+    for (const etapa of Object.keys(etapas)) {
+      const arr = Array.isArray(etapas[etapa]) ? etapas[etapa] : [];
+      for (const item of arr) {
+        const bp = item?.biopreparado_id;
+        if (bp && !seenBp.has(`${bp}:${etapa}`)) {
+          seenBp.add(`${bp}:${etapa}`);
+          statements.push(wrapCypher(graph, emitRel(
+            { label: 'Species', id: sp.id },
+            'USED_AS_BIOPREPARADO',
+            { label: 'Biopreparado', id: bp },
+            { source: 'plan_nutricion_base', etapa },
+          )));
+        }
+      }
+    }
+  }
+
+  return statements;
+}
+
+/**
+ * CLI entry point.
+ *
+ * @param {string[]} argv - process.argv.slice(2)
+ * @returns {Promise<{outputPath: string|null, statementCount: number, bytes: number}>}
+ */
+export async function main(argv = process.argv.slice(2)) {
+  // Parsing manual (sin deps externas para mantener el script ligero).
+  const opts = {
+    input: 'catalog/chagra-catalog-seed-v3.1.json',
+    output: null,
+    limit: null,
+    graph: 'chagra_kg',
+    includeDrop: true,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--input') opts.input = argv[++i];
+    else if (a === '--output') opts.output = argv[++i];
+    else if (a === '--limit') opts.limit = Number(argv[++i]);
+    else if (a === '--graph') opts.graph = argv[++i];
+    else if (a === '--no-drop') opts.includeDrop = false;
+    else if (a === '--help' || a === '-h') {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Usage: node scripts/catalog-to-age.mjs [--input FILE] [--output FILE] [--limit N] [--graph NAME] [--no-drop]',
+      );
+      return { outputPath: null, statementCount: 0, bytes: 0 };
+    }
+  }
+
+  const seedPath = resolve(opts.input);
+  const seed = JSON.parse(readFileSync(seedPath, 'utf-8'));
+  const statements = buildSqlScript(seed, {
+    limit: opts.limit ?? undefined,
+    graph: opts.graph,
+    includeDrop: opts.includeDrop,
+  });
+
+  const header = [
+    '-- chagra-kg-import.sql',
+    `-- Generated by scripts/catalog-to-age.mjs at ${new Date().toISOString()}`,
+    `-- Source: ${opts.input}`,
+    `-- Graph: ${opts.graph}`,
+    `-- Statements: ${statements.length}`,
+    '--',
+    '-- WARNING: this script DROPs and re-creates the graph by default.',
+    '-- Use --no-drop to apply as a delta MERGE.',
+    '',
+  ].join('\n');
+
+  const body = statements.join('\n') + '\n';
+  const out = header + body;
+
+  if (opts.output) {
+    writeFileSync(opts.output, out, 'utf-8');
+    // eslint-disable-next-line no-console
+    console.error(`Wrote ${statements.length} statements (${out.length} bytes) to ${opts.output}`);
+    return { outputPath: opts.output, statementCount: statements.length, bytes: out.length };
+  }
+  // stdout
+  process.stdout.write(out);
+  return { outputPath: null, statementCount: statements.length, bytes: out.length };
+}
+
+// ESM-friendly entry-point check.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error('catalog-to-age failed:', err);
+    process.exit(1);
+  });
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,7 +20,14 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/unit/setup.js'],
-    include: ['src/**/*.test.{js,jsx}', 'tests/unit/**/*.test.{js,jsx}'],
+    include: [
+      'src/**/*.test.{js,jsx}',
+      'tests/unit/**/*.test.{js,jsx}',
+      // POC Apache AGE (feat/apache-age-poc-2026-05-20): tests del importer
+      // viven junto al script para mantener cohesión local. Incluye .mjs
+      // porque el importer es ESM nativo.
+      'scripts/__tests__/**/*.test.{js,mjs}',
+    ],
     exclude: ['node_modules', 'dist', 'tests/*.spec.js'],
     css: false,
   },


### PR DESCRIPTION
## Summary

POC documental de Apache AGE (PostgreSQL graph extension) sobre el catálogo Chagra (488 species + 19 biopreparados + 66 sources). Diseña migración postgres-farm → apache/age:PG15_latest, schema de KG, importer determinista, 5 queries Cypher de ejemplo, y wrapper REST. **No operacional** — ningún script ha corrido contra postgres-farm en producción.

## Cambios

- `scripts/catalog-to-age.mjs` (importer ESM, 532 líneas): lee `catalog/chagra-catalog-seed-v3.1.json` y genera SQL idempotente que puebla un grafo `chagra_kg`. Sanitiza strings escapando comilla simple. Trunca textos largos. Idempotente con `DROP GRAPH IF EXISTS` + `MERGE`.
- `scripts/age-queries-example.sql` (147 líneas): 5 queries documentadas — single-hop, multi-hop simple, multi-hop complejo (guild design triple), cross-query SQL+Cypher (corpus × farmOS inventory), agregación (top hubs).
- `scripts/__tests__/catalog-to-age.test.mjs` (42 assertions): cobertura unitaria de helpers + fixture sintético + subset (10 species) del seed real. `vitest.config.js` incluye `scripts/__tests__/**/*.test.{js,mjs}`.
- `docs/POC_APACHE_AGE.md`: índice del POC con quickstart + tabla de impacto en tokens del LLM + riesgos.

## Schema KG (resumen)

Nodos: Species, Biopreparado, Source, Family, Habito, Origen, RoleInGuild, PisoTermico, Pest.

Relaciones: COMPATIBLE_WITH, ANTAGONIST_OF, USED_AS_BIOPREPARADO, GROWS_IN, HAS_FAMILY, HAS_HABIT, HAS_ORIGIN, HAS_ROLE, REFERENCED_BY, TARGETS_PEST.

Detalle completo en `docs/POC_APACHE_AGE.md` + el archivo `/tmp/age-kg-schema-2026-05-20.md` del nodo alpha.

## Impacto esperado en tokens del LLM

| Query type | BM25 actual | AGE esperado | Ahorro tokens |
|---|---|---|---|
| Single-hop | 2.7 ms p95 OK | ~3-5 ms similar | ~0% (BM25 gana) |
| Multi-hop simple | LLM razona sobre RAG → varios CoT pases | <30 ms query directa | 70-85% |
| Multi-hop complejo | Casi imposible — el LLM alucina o pide más context | <50 ms pattern match | 85-95% |
| Agregación | No-go en BM25 puro | <40 ms COUNT + ORDER | ~90% |

Cifras order-of-magnitude. Bench real pendiente fase 2.

## Lo que NO se hizo (postergado al operador)

- NO se ejecutó el switch postgres-farm a apache/age — diff propuesto en `/tmp/postgres-farm-age-migration.nix`.
- NO se ejecutó el importer contra el postgres real.
- NO se implementó el wrapper REST — diseño en `/tmp/age-rest-wrapper-design-2026-05-20.md`.
- NO se aplicaron índices grafo — fase 2 cuando se midan queries reales.

## Test plan

- [ ] `node scripts/catalog-to-age.mjs --limit 10 --output /tmp/chagra-kg-test10.sql` — verificar SQL bien-formado.
- [ ] `npm run test:unit -- scripts/__tests__/catalog-to-age.test.mjs` — 42 assertions pasan.
- [ ] Revisar `docs/POC_APACHE_AGE.md` para entender el plan.
- [ ] Revisar `/tmp/postgres-farm-age-migration.nix` del nodo alpha antes de promover a `guatoc-nixos`.
- [ ] Antes de cualquier cutover: pg_dumpall del postgres-farm + snapshot ZFS de `/mnt/fast/appdata`.
