### PR TITLE
feat(sparkline): pulsing 'live' indicator on last datapoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.150",
+  "version": "0.12.151",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v192';
+const CACHE_NAME = 'chagra-v193';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/common/Sparkline.jsx
+++ b/src/components/common/Sparkline.jsx
@@ -152,9 +152,33 @@ export default function Sparkline({
         opacity="0.98"
       />
 
-      {/* Ultimo punto con glow */}
-      <circle cx={lastX} cy={lastY} r="3.2" fill={color} opacity="0.25" />
-      <circle cx={lastX} cy={lastY} r="2.2" fill={color} />
+      {/* Ultimo punto con glow latente — pulso 2s sugiere "datos vivos en
+          tiempo real". El outer glow late en radio + opacity, el inner se
+          mantiene visible con leve fade. Pausable via prefers-reduced-motion:
+          si el usuario activó "reducir movimiento" en el OS, el navegador
+          ignora los <animate> SVG según spec, dejando la sparkline estática. */}
+      <circle cx={lastX} cy={lastY} r="3.2" fill={color} opacity="0.25">
+        <animate
+          attributeName="r"
+          values="3.2;6.8;3.2"
+          dur="2s"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="opacity"
+          values="0.28;0.05;0.28"
+          dur="2s"
+          repeatCount="indefinite"
+        />
+      </circle>
+      <circle cx={lastX} cy={lastY} r="2.2" fill={color}>
+        <animate
+          attributeName="opacity"
+          values="1;0.55;1"
+          dur="2s"
+          repeatCount="indefinite"
+        />
+      </circle>
 
       {/* Chip del valor actual (recuadro contrastado arriba-derecha) */}
       {showLastValue && (


### PR DESCRIPTION
## Summary

Agrega un pulso SVG (2s) en el último punto de las sparklines IoT — pista visual barata de que la gráfica es tiempo real, no screenshot estático.

## Antes

Sparkline con un punto fijo en el último valor (radio 3.2 + 2.2, opacity 0.25 + 1.0). No hay diferencia visual entre "datos vivos" vs "datos congelados".

## Después

- Outer glow late en radio (3.2 → 6.8 → 3.2) y opacity (0.28 → 0.05 → 0.28).
- Inner dot late en opacity (1 → 0.55 → 1), radio fijo.
- Ciclo 2s, `repeatCount="indefinite"`.

## Por qué SVG `<animate>` declarativo y no React state

- **0 JS overhead**: SVG nativo, sin re-renders.
- **Accessibility**: navegadores que respetan `prefers-reduced-motion` ignoran `<animate>` SVG según spec → fallback estático automático para usuarios con sensibilidad a movimiento.
- **No depende de raf**: no hay riesgo de leak de listener si el componente unmount durante el ciclo.

## Donde se ve

Cualquier sparkline en la app — actualmente `IoTSensorCard` (humedad/temperatura sensores) y `TelemetryAlerts` consumen este componente.

## Test plan

- [ ] Abrir Telemetría con HA conectado → ver pulso en última muestra.
- [ ] Verificar en mobile con `prefers-reduced-motion: reduce` → pulso desaparece, dot estático.
- [ ] CI: lint pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)