### PR TITLE
fix(deploy): unblock CI lint — rename unused ragLoading + drop dead eslint-disables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.151",
+  "version": "0.12.152",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v193';
+const CACHE_NAME = 'chagra-v194';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/scripts/catalog-to-age.mjs
+++ b/scripts/catalog-to-age.mjs
@@ -480,7 +480,6 @@ export async function main(argv = process.argv.slice(2)) {
     else if (a === '--graph') opts.graph = argv[++i];
     else if (a === '--no-drop') opts.includeDrop = false;
     else if (a === '--help' || a === '-h') {
-      // eslint-disable-next-line no-console
       console.error(
         'Usage: node scripts/catalog-to-age.mjs [--input FILE] [--output FILE] [--limit N] [--graph NAME] [--no-drop]',
       );
@@ -513,7 +512,6 @@ export async function main(argv = process.argv.slice(2)) {
 
   if (opts.output) {
     writeFileSync(opts.output, out, 'utf-8');
-    // eslint-disable-next-line no-console
     console.error(`Wrote ${statements.length} statements (${out.length} bytes) to ${opts.output}`);
     return { outputPath: opts.output, statementCount: statements.length, bytes: out.length };
   }
@@ -525,7 +523,6 @@ export async function main(argv = process.argv.slice(2)) {
 // ESM-friendly entry-point check.
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((err) => {
-    // eslint-disable-next-line no-console
     console.error('catalog-to-age failed:', err);
     process.exit(1);
   });

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -80,7 +80,10 @@ function ObservationScreen({ onBack, onSave }) {
 
   // L1.5 — sugerencias proactivas RAG (debounced, no bloqueante).
   const [ragSuggestions, setRagSuggestions] = useState([]);
-  const [ragLoading, setRagLoading] = useState(false);
+  // _ragLoading: prefijo `_` para satisfacer eslint (state actualizado pero
+  // no leído en este componente — el UI loading lo refleja vía ragSuggestions
+  // length + skeleton fallback. Mantener el setter para futuro indicator).
+  const [_ragLoading, setRagLoading] = useState(false);
   const ragRequestIdRef = useRef(0);
 
   // Nombre de la especie seleccionada (si hay plant). Usado para enriquecer


### PR DESCRIPTION
## 🚨 Hot-fix — deploy a prod bloqueado desde 0.12.140

Producción está stuck en **0.12.139** desde el merge de PR #934 (auto-suggest treatments via RAG, 2026-05-20). 12+ bumps subsecuentes han fallado en el step \`Lint\` del workflow \`deploy.yml\` y por eso el sitio chagra.guatoc.co no muestra:
- Apache AGE POC (#963)
- AMB-10 fix (#949)
- RAG pre-tokenize voice latency (#947)
- Anti-leak sweep (#965)
- Sparkline pulsing (#966)
- Animación colibrí en home + agent loader (task #66)

## Root cause

```
src/components/ObservationScreen.jsx
  83:10  error  'ragLoading' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u  no-unused-vars
```

\`ragLoading\` venía del PR #934 — está set vía \`setRagLoading()\` pero nunca leído (el loading state se refleja vía \`ragSuggestions.length + skeleton\`). El lint regla aplicable permite unused destructuring con prefijo \`_\`.

## Fix

1. \`ObservationScreen.jsx:83\` — \`ragLoading\` → \`_ragLoading\`. Setter \`setRagLoading\` sin cambios (sigue updateando state).
2. \`scripts/catalog-to-age.mjs\` — drop 3x \`// eslint-disable-next-line no-console\` que el lint marca como "unused directive".

## Test plan

- [x] \`npx eslint src/components/ObservationScreen.jsx scripts/catalog-to-age.mjs\` → exit 0
- [ ] CI lint pasa
- [ ] Deploy actualiza chagra.guatoc.co a 0.12.151+

## Post-merge

Una vez mergeado, el deploy debe pickup todas las features acumuladas. El usuario va a ver:
- Colibrí flotando en home + en thinking state del agente
- Pulso 'live' en sparklines IoT
- Sugerencias RAG en ObservationScreen severity medium/high
- Análisis caso David (Apache AGE POC)
- Companions symmetrizados

🤖 Generated with [Claude Code](https://claude.com/claude-code)