### PR TITLE
feat(agent): colibrí grande en empty state + 'Pensando…' bubble pre-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.152",
+  "version": "0.12.153",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-19T00:44:50.940Z",
+  "generated_at": "2026-05-21T03:09:39.077Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v194';
+const CACHE_NAME = 'chagra-v195';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -1,19 +1,24 @@
 import React, { useEffect, useRef } from 'react';
 import ChatBubble from './ChatBubble';
+import ChagraAgentAvatar from '../ChagraAgentAvatar';
 
 export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false }) {
   const bottomRef = useRef(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, streamingContent]);
+  }, [messages, streamingContent, isStreaming]);
 
+  // Empty state: aprovechamos el espacio vacío para mostrar el colibrí
+  // libando en su tamaño más grande de toda la app (size=200). El header
+  // ya tiene una versión chiquita (size=40) — acá vive en grande, como
+  // primera impresión del agente.
   if (messages.length === 0 && !isStreaming) {
     return (
-      <div className="flex-1 flex items-center justify-center p-8">
+      <div className="flex-1 flex items-center justify-center p-6">
         <div className="text-center">
-          <div className="text-5xl mb-4">🤖</div>
-          <p className="text-slate-400 text-sm mb-2">¡Hola! Soy tu asistente agroecológico.</p>
+          <ChagraAgentAvatar state="idle" size={200} className="mx-auto mb-4" />
+          <p className="text-slate-200 text-base mb-2 font-medium">¡Hola! Soy tu asistente agroecológico.</p>
           <p className="text-slate-500 text-xs">Puedes hablarme o escribirme sobre tus plantas.</p>
         </div>
       </div>
@@ -29,6 +34,28 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
           isStreaming={false}
         />
       ))}
+
+      {/* Placeholder visible mientras llega el primer token (pre-stream).
+          Sin esto el chat se ve "muerto" entre el envío del usuario y la
+          aparición del primer token — el indicador del header pasa
+          desapercibido porque el ojo del operador está en la ventana de
+          diálogo. Acá el colibrí late en thinking + texto "Pensando…". */}
+      {isStreaming && !streamingContent && (
+        <div className="flex items-end gap-3 mb-4 animate-fadeIn">
+          <ChagraAgentAvatar
+            state="thinking"
+            size={96}
+            className="shrink-0 mb-1"
+            ariaLabel="Chagra IA está pensando"
+          />
+          <div className="rounded-2xl rounded-bl-sm bg-slate-800/80 border border-slate-700/60 px-4 py-3 text-slate-300 text-sm italic shadow-lg">
+            Pensando
+            <span className="inline-block ml-1 animate-thinkingDot">·</span>
+            <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:200ms]">·</span>
+            <span className="inline-block ml-0.5 animate-thinkingDot [animation-delay:400ms]">·</span>
+          </div>
+        </div>
+      )}
 
       {isStreaming && streamingContent && (
         <ChatBubble

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -111,6 +111,19 @@ export default {
                     '0%': { strokeDashoffset: '0' },
                     '100%': { strokeDashoffset: '-1' },
                 },
+                // Fade-in suave para placeholders del chat al aparecer
+                // (Pensando, sugerencias post-stream). 200ms ease-out.
+                fadeIn: {
+                    '0%': { opacity: '0', transform: 'translateY(4px)' },
+                    '100%': { opacity: '1', transform: 'translateY(0)' },
+                },
+                // Pulso de los puntos suspensivos del estado "Pensando…"
+                // del agente. Cada punto usa el mismo keyframe pero con
+                // delay distinto (0ms / 200ms / 400ms) → onda secuencial.
+                thinkingDot: {
+                    '0%, 100%': { opacity: '0.3', transform: 'scale(0.85)' },
+                    '50%': { opacity: '1', transform: 'scale(1.05)' },
+                },
             },
             animation: {
                 'scanline': 'scanline 2.4s linear infinite',
@@ -127,6 +140,12 @@ export default {
                 // Destello que recorre el borde del panel, sincronizado con
                 // negative-breath: 30s linear infinite.
                 'border-march': 'borderMarch 30s linear infinite',
+                // Aparición suave del placeholder "Pensando…" del agente.
+                'fadeIn': 'fadeIn 200ms ease-out forwards',
+                // Puntos suspensivos del estado "Pensando…". Cada punto
+                // hereda esta animación + delay distinto via arbitrary
+                // values (animation-delay:200ms / 400ms).
+                'thinkingDot': 'thinkingDot 1.4s ease-in-out infinite',
             },
         },
     },


### PR DESCRIPTION
## Summary

Dos mejoras a la UX del chat del agente (feedback usuario 2026-05-20).

### 1. Empty state con colibrí GRANDE
Antes: `<div className="text-5xl">🤖</div>` (emoji plano).
Después: \`ChagraAgentAvatar size={200}\` (colibrí libando del abutilón, su tamaño más grande de toda la app).

### 2. Bubble 'Pensando…' pre-stream
**Bug reportado**: cuando el usuario manda un mensaje, no veía nada en el chat hasta que llegaba el primer token del LLM. El indicador 'pensando…' del header pasaba desapercibido porque el ojo del operador está en la ventana de diálogo.

**Fix**: cuando \`isStreaming && !streamingContent\` (LLM activo pero sin tokens todavía), renderizamos un bubble con:
- Colibrí \`state=thinking\` size=96 a la izquierda
- Texto "Pensando" + 3 puntos suspensivos animados (delays 0/200/400ms)

Cuando llega el primer token, este bubble se reemplaza por el streaming bubble normal.

## Tailwind nuevo

Agregadas dos custom animations en \`tailwind.config.js\`:
- \`fadeIn\` (200ms ease-out forwards) — aparición del placeholder
- \`thinkingDot\` (1.4s ease-in-out infinite) — pulse de cada punto suspensivo

Sin afectar el resto del proyecto.

## Test plan

- [x] \`npm run build\` clean
- [x] AgentScreen chunk incluye \`Pensando\` + \`animate-fadeIn\` + \`animate-thinkingDot\`
- [x] CSS bundle incluye los keyframes
- [x] eslint clean
- [ ] CI: deploy a prod
- [ ] User confirma colibrí grande + 'Pensando…' visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)