### PR TITLE
feat(sprint-lili-2): FieldFeedback inline en Ayuda + iOS GPS doc + workflow soft-fail

### DIFF
--- a/.github/workflows/llm-local-review.yml
+++ b/.github/workflows/llm-local-review.yml
@@ -166,11 +166,25 @@ jobs:
           fi
 
       - name: Upsert PR comment
+        # Soft-fail por contrato (ver docs/ai-review-gates.md): si Ollama
+        # caído, timeout, o el step de inferencia no generó /tmp/review.md,
+        # NO bloqueamos el merge — el job termina success silencioso.
+        # Bug 2026-05-20 (PR #965+966): este step hacía `cat /tmp/review.md`
+        # sin guard y exit 1 cuando el archivo no existía, contradiciendo
+        # el contrato de soft-fail. Fix: skip el step si el archivo no
+        # existe + continue-on-error para defensa en profundidad.
         if: steps.ollama.outputs.skip != '1'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
+          # Guard de existencia: si Ollama no produjo el archivo de review,
+          # salimos con success y log al stderr (no spam GH UI con error).
+          if [ ! -s /tmp/review.md ]; then
+            echo "::warning::/tmp/review.md no existe o está vacío — soft-fail (Ollama down, timeout o sin diff útil)."
+            exit 0
+          fi
           MARKER='<!-- llm-review-bot -->'
           {
             echo "$MARKER"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.154",
+  "version": "0.12.155",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-21T03:30:47.313Z",
+  "generated_at": "2026-05-21T03:44:23.881Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v196';
+const CACHE_NAME = 'chagra-v197';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,10 @@ import { initCatalog } from './db/catalogDB';
 import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
 import SyncProgressIndicator from './components/common/SyncProgressIndicator';
-import FieldFeedback from './components/FieldFeedback';
+// FieldFeedback ya no se monta globalmente en App; vive embebido en
+// HelpUsoScreen como sección de Ayuda (decisión 2026-05-21, ver
+// comentario abajo donde se removió el render).
+// import FieldFeedback from './components/FieldFeedback';
 import MicFab from './components/MicFab';
 import AgentFab from './components/AgentFab';
 import { ScreenShell } from './components/common/ScreenShell';
@@ -479,10 +482,12 @@ export default function App() {
       <Suspense fallback={<LoadingFallback />}>
         {renderView()}
       </Suspense>
-      {/* FAB feedback inline para field testing. Operator bug 2026-05-18:
-          FieldFeedback FAB bottom-right tapaba el botón "enviar" en AgentScreen
-          y el textarea voice en VoiceCapture. Excluido en agente + voz. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'agente' && currentView !== 'voz' && <FieldFeedback />}
+      {/* FAB feedback flotante REMOVIDO 2026-05-21: el reporte de errores
+          ahora vive embebido dentro de HelpUsoScreen (sección "Reportar
+          problema con Chagra") en lugar de un FAB global. Decisión user
+          tras Lili UX feedback: FAB tapaba contenido + no era discoverable.
+          El form sigue siendo el mismo componente, instanciado con prop
+          `embedded` desde HelpUsoScreen. */}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <MicFab onNavigate={navigate} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <AgentFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}

--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -36,14 +36,23 @@ const formatDuration = (ms) => {
   return `${s}s`;
 };
 
-export default function FieldFeedback() {
-  const [open, setOpen] = useState(false);
+/**
+ * Props:
+ *   embedded?: boolean   — si true, renderea solo el form (sin FAB ni modal).
+ *                          Usado en HelpUsoScreen donde el feedback vive
+ *                          dentro de la sección "Reportar problema" en lugar
+ *                          de ser un FAB global. Decisión 2026-05-21 tras
+ *                          feedback Lili #5 (FABs tapaban contenido).
+ */
+export default function FieldFeedback({ embedded = false } = {}) {
+  // En modo embedded el form siempre está "abierto" (no hay FAB que abrir).
+  const [open, setOpen] = useState(embedded);
   const [text, setText] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   // Auto-hide tras 2s sin interacción (feedback usuario externo 2026-05-06,
   // bug #2: FAB tapaba widgets en home). El modal abierto NO se ve afectado
-  // — solo el FAB fab-button colapsado es lo que se oculta.
+  // — solo el FAB fab-button colapsado es lo que se oculta. No aplica en embedded.
   const isFabVisible = useIdleVisibility(2000);
   const [errorMsg, setErrorMsg] = useState('');
 
@@ -98,7 +107,9 @@ export default function FieldFeedback() {
   const handleClose = () => {
     if (isRecording) stop();
     handleDiscardAudio();
-    setOpen(false);
+    // En modo embedded el form NO se "cierra", solo se limpia (no hay modal
+    // que ocultar — vive permanente dentro de Ayuda).
+    if (!embedded) setOpen(false);
     setText('');
     setSubmitted(false);
     setErrorMsg('');
@@ -213,44 +224,52 @@ export default function FieldFeedback() {
 
   return (
     <>
-      {/* FAB button (auto-hide 2s idle) */}
-      <button
-        type="button"
-        aria-label="Reportar feedback"
-        title="Reportar feedback de campo"
-        onClick={() => setOpen(true)}
-        style={{
-          position: 'fixed',
-          bottom: 18,
-          right: 18,
-          width: FAB_SIZE,
-          height: FAB_SIZE,
-          borderRadius: '50%',
-          border: `2px solid ${COLOR_ACCENT}`,
-          background: `linear-gradient(135deg, ${COLOR_PRIMARY} 0%, #075f6e 100%)`,
-          color: '#fff',
-          fontSize: 22,
-          cursor: 'pointer',
-          boxShadow: `0 4px 16px rgba(0,0,0,0.4), 0 0 14px ${COLOR_ACCENT}55`,
-          zIndex: 9000,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: 0,
-          opacity: isFabVisible ? 1 : 0,
-          pointerEvents: isFabVisible ? 'auto' : 'none',
-          transition: 'opacity 250ms ease',
-        }}
-      >
-        💬
-      </button>
-
-      {open && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          onClick={(e) => e.target === e.currentTarget && handleClose()}
+      {/* FAB button (auto-hide 2s idle). Solo en modo NO embedded — en
+          embedded el form vive dentro de HelpUsoScreen y no necesita FAB. */}
+      {!embedded && (
+        <button
+          type="button"
+          aria-label="Reportar feedback"
+          title="Reportar feedback de campo"
+          onClick={() => setOpen(true)}
           style={{
+            position: 'fixed',
+            bottom: 18,
+            right: 18,
+            width: FAB_SIZE,
+            height: FAB_SIZE,
+            borderRadius: '50%',
+            border: `2px solid ${COLOR_ACCENT}`,
+            background: `linear-gradient(135deg, ${COLOR_PRIMARY} 0%, #075f6e 100%)`,
+            color: '#fff',
+            fontSize: 22,
+            cursor: 'pointer',
+            boxShadow: `0 4px 16px rgba(0,0,0,0.4), 0 0 14px ${COLOR_ACCENT}55`,
+            zIndex: 9000,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: 0,
+            opacity: isFabVisible ? 1 : 0,
+            pointerEvents: isFabVisible ? 'auto' : 'none',
+            transition: 'opacity 250ms ease',
+          }}
+        >
+          💬
+        </button>
+      )}
+
+      {/* En modo NO embedded: dialog modal fixed con overlay. En modo
+          embedded: el form vive en flujo normal del documento (sin
+          overlay/fixed/zIndex), porque está adentro de Ayuda. */}
+      {(open || embedded) && (
+        <div
+          {...(!embedded && { role: 'dialog', 'aria-modal': 'true' })}
+          onClick={!embedded ? (e) => e.target === e.currentTarget && handleClose() : undefined}
+          style={embedded ? {
+            display: 'flex',
+            justifyContent: 'center',
+          } : {
             position: 'fixed',
             inset: 0,
             background: 'rgba(0,0,0,0.65)',
@@ -265,12 +284,13 @@ export default function FieldFeedback() {
           <form
             onSubmit={handleSubmit}
             style={{
-              width: 'min(420px, 92vw)',
-              background: '#0a0e14',
-              border: `1px solid ${COLOR_ACCENT}55`,
-              borderRadius: 8,
-              padding: '1.2rem',
-              boxShadow: `0 12px 40px rgba(0,0,0,0.6), 0 0 24px ${COLOR_ACCENT}33`,
+              width: embedded ? '100%' : 'min(420px, 92vw)',
+              maxWidth: embedded ? '100%' : 'min(420px, 92vw)',
+              background: embedded ? 'transparent' : '#0a0e14',
+              border: embedded ? 'none' : `1px solid ${COLOR_ACCENT}55`,
+              borderRadius: embedded ? 0 : 8,
+              padding: embedded ? 0 : '1.2rem',
+              boxShadow: embedded ? 'none' : `0 12px 40px rgba(0,0,0,0.6), 0 0 24px ${COLOR_ACCENT}33`,
               display: 'flex',
               flexDirection: 'column',
               gap: '0.8rem',
@@ -278,18 +298,39 @@ export default function FieldFeedback() {
               color: '#e6edf3',
             }}
           >
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-              <div style={{ fontSize: '0.7rem', letterSpacing: '0.22em', color: COLOR_ACCENT, textTransform: 'uppercase', fontWeight: 700 }}>
-                Field feedback
+            {/* Header con título + close button. Solo en modo modal —
+                en embedded el título lo da la sección de Ayuda. */}
+            {!embedded && (
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ fontSize: '0.7rem', letterSpacing: '0.22em', color: COLOR_ACCENT, textTransform: 'uppercase', fontWeight: 700 }}>
+                  Field feedback
+                </div>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  style={{ background: 'transparent', border: 'none', color: '#8b9cab', fontSize: 18, cursor: 'pointer' }}
+                >
+                  ×
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={handleClose}
-                style={{ background: 'transparent', border: 'none', color: '#8b9cab', fontSize: 18, cursor: 'pointer' }}
-              >
-                ×
-              </button>
-            </div>
+            )}
+            {/* Copy amigable solo en embedded. Decisión 2026-05-21: en
+                lugar de "Field feedback" técnico, contar al operador qué
+                tipo de feedback nos sirve y por qué. */}
+            {embedded && (
+              <div className="text-sm text-slate-300 leading-relaxed mb-1 space-y-2">
+                <p>
+                  ¿Algo del agente te respondió raro, viste información errónea
+                  o algo no se comporta como esperás?
+                </p>
+                <p>
+                  <strong>Grabá un audio</strong> contando qué hiciste y qué fue lo
+                  raro (es más rápido que tipear en el campo). Si querés adjuntar
+                  el contexto en texto también, mejor todavía. Cada reporte ayuda
+                  a hacer Chagra más poderoso.
+                </p>
+              </div>
+            )}
 
             <div style={{ fontSize: '0.7rem', color: '#8b9cab', letterSpacing: '0.05em', lineHeight: 1.4 }}>
               Pantalla: <span style={{ color: COLOR_ACCENT }}>{window.location.pathname || '/'}</span>

--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -3,6 +3,7 @@ import {
   ArrowLeft, ChevronDown, ChevronRight, Sprout, Camera, MapPin, Bug, Apple,
   MessageCircle, Wrench,
 } from 'lucide-react';
+import FieldFeedback from './FieldFeedback';
 
 /**
  * Sub-vista del Manual: cómo usar Chagra (FAQs reorganizadas).
@@ -183,18 +184,19 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
           </div>
         </Section>
 
-        {/* 5. Reportar bug / sugerir mejora — incluido aquí (no cuarto botón) */}
-        <Section icon={MessageCircle} title="💬 Reportar bug o sugerir mejora">
-          <p>Botón flotante 💬 abajo a la <strong>derecha</strong>, siempre visible. Puedes:</p>
-          <ul className="list-disc pl-5 space-y-1">
-            <li>Escribir texto explicando qué pasó</li>
-            <li>Grabar audio (botón 🎤 dentro del modal): &ldquo;hice click acá y pasó X&rdquo;, sin tener que escribir en la pantalla</li>
-            <li>Ambos: texto + audio</li>
-          </ul>
-          <p>Tu feedback queda guardado localmente y se sincroniza después.</p>
-          <p className="text-xs text-slate-500 italic mt-2">
-            Cada reporte importa: la app aprende contigo. Si algo es confuso, decirlo es la forma más rápida de arreglarlo.
-          </p>
+        {/* 5. Reportar problema / sugerir mejora — embed del FieldFeedback
+            form. Antes vivía como FAB flotante 💬 global; movido acá
+            2026-05-21 por feedback usuario (más discoverable + no tapa
+            contenido). isNew=true para resaltar la nueva ubicación. */}
+        <Section
+          icon={MessageCircle}
+          title="💬 Reportar problema con Chagra"
+          isNew
+          defaultOpen
+        >
+          <div className="bg-slate-950/50 border border-cyan-800/40 rounded-lg p-4">
+            <FieldFeedback embedded />
+          </div>
         </Section>
 
         {/* 6. Problemas comunes */}
@@ -202,7 +204,65 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
           <div className="space-y-3">
             <div>
               <p className="font-bold text-amber-300">📍 GPS no encuentra mi ubicación</p>
-              <p className="text-xs text-slate-400 leading-relaxed">El mapa centra automático al abrir el modal. Si tarda más de 15s o cae en error, toca &ldquo;Reintentar&rdquo;. En Brave: revisa que la opción de bloqueo de huellas digitales esté desactivada.</p>
+              <p className="text-xs text-slate-400 leading-relaxed mb-2">
+                El mapa centra automático al abrir el modal. Si tarda más
+                de 15s o cae en error, toca &ldquo;Reintentar&rdquo;.
+              </p>
+              <details className="text-xs text-slate-400 leading-relaxed">
+                <summary className="cursor-pointer text-cyan-400 hover:text-cyan-300 font-bold mb-1">
+                  📱 En iPhone (iOS Safari)
+                </summary>
+                <ol className="list-decimal pl-5 space-y-1 mt-1">
+                  <li>
+                    Ajustes (la app del engranaje gris) → busca &ldquo;Safari&rdquo;
+                    en la lista de apps → entrá ahí.
+                  </li>
+                  <li>
+                    Bajá hasta encontrar <strong>&ldquo;Ubicación&rdquo;</strong> y
+                    tocá. Si dice &ldquo;Denegar&rdquo;, cambialo a
+                    &ldquo;Preguntar&rdquo; o &ldquo;Permitir&rdquo;.
+                  </li>
+                  <li>
+                    Volvé a Ajustes → &ldquo;Privacidad y seguridad&rdquo; →
+                    &ldquo;Localización&rdquo; → confirmá que la
+                    <strong> localización general esté activada</strong> (al
+                    principio de la pantalla).
+                  </li>
+                  <li>
+                    Volvé a Chagra, recargá la página (cerrá la pestaña en
+                    Safari y volvé a entrar), y aceptá el popup de permiso
+                    cuando aparezca.
+                  </li>
+                </ol>
+                <p className="mt-2 text-slate-500 italic">
+                  Si instalaste Chagra como app desde &ldquo;Añadir a pantalla
+                  de inicio&rdquo;, la primera vez te va a preguntar de nuevo
+                  el permiso — es esperado, aceptá.
+                </p>
+              </details>
+              <details className="text-xs text-slate-400 leading-relaxed mt-2">
+                <summary className="cursor-pointer text-cyan-400 hover:text-cyan-300 font-bold mb-1">
+                  🤖 En Android (Chrome o Brave)
+                </summary>
+                <ol className="list-decimal pl-5 space-y-1 mt-1">
+                  <li>
+                    En Chrome: barra de URL → ícono del candado o tres
+                    puntos → &ldquo;Configuración del sitio&rdquo; o
+                    &ldquo;Permisos&rdquo; → &ldquo;Ubicación&rdquo; → permitir
+                    para chagra.guatoc.co.
+                  </li>
+                  <li>
+                    En Brave: lo mismo + revisar que la opción de
+                    <strong> bloqueo de huellas digitales esté desactivada</strong>
+                    {' '}solo para este sitio (Brave bloquea geolocation por defecto).
+                  </li>
+                  <li>
+                    A nivel sistema: Ajustes Android → Ubicación → activada
+                    + el navegador con permiso en &ldquo;Permitir todo el
+                    tiempo&rdquo; o &ldquo;Solo mientras se usa&rdquo;.
+                  </li>
+                </ol>
+              </details>
             </div>
             <div>
               <p className="font-bold text-amber-300">🎤 Voz no transcribe</p>


### PR DESCRIPTION
## Summary

Tres fixes paralelos del sprint post-demo (bajo esfuerzo, alta visibilidad).

### 1. 💬 FieldFeedback → Ayuda (T#78)

Antes: FAB flotante 💬 abajo a la derecha (tapaba contenido + no era discoverable).
Después: vive como sección en HelpUsoScreen — "Reportar problema con Chagra", defaultOpen + isNew badge.

Copy nuevo:
> ¿Algo del agente te respondió raro, viste información errónea o algo no se comporta como esperás?
> Grabá un audio contando qué hiciste y qué fue lo raro (es más rápido que tipear en el campo). Si querés adjuntar el contexto en texto también, mejor todavía. Cada reporte ayuda a hacer Chagra más poderoso.

Implementación: prop `embedded` en `FieldFeedback` que skip el FAB + modal y renderea el form en flow normal. Reusa todo el form existente (textarea + audio + watchdog). `App.jsx` ya no monta `<FieldFeedback />` global.

### 2. 📱 iOS GPS doc (Lili UX F)

Sección "Problemas comunes" en HelpUsoScreen ahora tiene 2 `<details>` collapsibles:
- **En iPhone (iOS Safari)** — 4 pasos: Ajustes → Safari → Ubicación → Preguntar/Permitir → confirmar localización general → recargar
- **En Android (Chrome o Brave)** — notas Brave-specific (huellas digitales bloquea geolocation)

Crítico para Lili (usa iOS).

### 3. 🤖 Workflow llm-local-review soft-fail real (T#76)

El step "Upsert PR comment" hacía `cat /tmp/review.md` sin guard → hard-fail cuando Ollama no producía el archivo. **Contradecía la doc que prometía soft-fail**. Causó UNSTABLE en PRs #965, #966, #967, #968, #969.

Fix:
```yaml
- name: Upsert PR comment
  continue-on-error: true   # defensa en profundidad
  run: |
    if [ ! -s /tmp/review.md ]; then
      echo "::warning::soft-fail"
      exit 0
    fi
    # ... existing logic
```

## Test plan

- [x] `npm run build` clean
- [x] `eslint` clean
- [ ] **iOS Safari** — confirmar Section "Reportar problema" visible + audio capture funciona
- [ ] iOS GPS doc se ve bien con `<details>` collapse
- [ ] Próximos PRs (este + futuros) deberían tener review check `success` aunque Ollama esté caído

🤖 Generated with [Claude Code](https://claude.com/claude-code)