### PR TITLE
fix(agent-prompt): anti-confusión taxonómica + glosario colombiano (24 nombres comunes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.155",
+  "version": "0.12.156",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-21T03:44:23.881Z",
+  "generated_at": "2026-05-21T04:03:35.237Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v197';
+const CACHE_NAME = 'chagra-v198';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -217,6 +217,36 @@ REGLA DE FORMATO: cuando hables de las plantas del usuario, agrupá por especie 
 
 REGLA CRÍTICA ANTI-ALUCINACIÓN: aplica SOLO cuando aparece un sustantivo técnico específico (nombre de planta, plaga, fitopatógeno, variedad, biopreparado, fertilizante) que NO reconozcas como referente botánico/agrícola estándar — ahí responde: "No reconozco el término X. ¿Podrías describirlo o decirme si quisiste referirte a otra palabra similar?". NUNCA inventes definiciones para términos técnicos desconocidos.
 
+REGLA CRÍTICA ANTI-CONFUSIÓN TAXONÓMICA: cuando el usuario use un nombre común colombiano de planta, NUNCA inventes el nombre científico — son confundibles entre sí y errar el género/especie es leak grave de credibilidad. Si no estás 100% seguro del binomio Linneano, USA EL NOMBRE COMÚN tal cual y no agregues paréntesis con científico. Si estás seguro, sí ponelo entre paréntesis.
+
+Glosario taxonómico colombiano (usalo, NO inventes):
+- maracuyá = Passiflora edulis f. flavicarpa (NO Mangifera indica — eso es mango)
+- gulupa = Passiflora edulis f. edulis (morada)
+- granadilla = Passiflora ligularis
+- mango = Mangifera indica
+- mora andina = Rubus glaucus (NO Morus nigra — eso es mora de árbol)
+- lulo = Solanum quitoense (NO Solanum lycopersicum — eso es tomate)
+- uchuva = Physalis peruviana
+- tomate de árbol = Solanum betaceum
+- guayaba = Psidium guajava
+- chachafruto = Erythrina edulis (NO Theobroma cacao — eso es cacao)
+- cubio = Tropaeolum tuberosum (NO Lupinus — eso es chocho/tarwi)
+- chocho/tarwi = Lupinus mutabilis
+- oca = Oxalis tuberosa
+- mashua = Tropaeolum tuberosum (sinónimo de cubio)
+- ulluco = Ullucus tuberosus
+- yacón = Smallanthus sonchifolius
+- arracacha = Arracacia xanthorrhiza
+- ñame = Dioscorea spp.
+- chontaduro = Bactris gasipaes
+- borojó = Borojoa patinoi
+- arazá = Eugenia stipitata
+- copoazú = Theobroma grandiflorum
+- camu camu = Myrciaria dubia
+- cocotero/coco = Cocos nucifera
+
+Si te preguntan por una planta fuera de este glosario y NO estás 100% seguro del binomio, responde con el nombre común sin inventar el científico. Ej. "el coco" en lugar de "el coco (Mangifera indica)" si dudás.
+
 NO aplica a expresiones coloquiales del campo colombiano. Interpreta con sentido común: "punto más alto donde sobrevive" = altitud máxima; "se devuelve" = regresa/retorna; "se enferman las matas" = las plantas padecen; "está flojo" = decae/se debilita; "pegó bien" = prendió/se estableció; "le da sol fuerte" = recibe insolación directa. Responde con datos agronómicos concretos cuando entendiste la pregunta, aunque no esté formulada en jerga técnica.
 
 Ejemplo:


### PR DESCRIPTION
## 🚨 Bug reportado por operator 2026-05-21

Test: "Eche que es lo más bajito que puedo echar una maracuya"
Respuesta del agente:
> "La variedad de **maracuya (Mangifera indica)** es una subespecie silvestre..."

**Mangifera indica = mango**, NO maracuyá. Maracuyá real = Passiflora edulis f. flavicarpa.

El agente confundió el binomio Linneano con confianza, mismo patrón que el incidente "chorcho" de 2026-05-17 pero con una planta canónica del catálogo. **Leak grave de credibilidad agronómica.**

## Fix paliativo

Hasta que la fase 2 MCP esté integrada (ADR-045 ya draftado), agregamos dos reglas al SYSTEM_PROMPT del agente:

### 1. Regla anti-confusión taxonómica
- NUNCA inventes el nombre científico de un nombre común
- Si no estás 100% seguro del binomio, USA EL NOMBRE COMÚN sin paréntesis
- Solo agregá científico cuando estés seguro

### 2. Mini-glosario de 24 nombres comunes colombianos confundibles
Inyectado directo en el prompt como referencia anclada:
- maracuyá = Passiflora edulis (NO Mangifera indica)
- lulo = Solanum quitoense (NO Solanum lycopersicum = tomate)
- mora andina = Rubus glaucus (NO Morus nigra = mora de árbol)
- chachafruto = Erythrina edulis (NO Theobroma cacao = cacao)
- cubio/mashua = Tropaeolum tuberosum (NO Lupinus = chocho)
- chocho/tarwi = Lupinus mutabilis
- oca, ulluco, yacón, arracacha, ñame, chontaduro, borojó, arazá, copoazú, camu camu...

## Fix real (no paliativo)

Cuando el chat tenga acceso a `get_species` del `chagra-agro-mcp` vía el sidecar bridge (ADR-045 fase 2), el agente puede consultar el catálogo canónico (488 species) en lugar de confiar en su memoria del modelo. Para "maracuyá" devolvería:

```json
{
  "id": "passiflora_edulis_flavicarpa",
  "nombre_comun": "Maracuyá",
  "nombre_cientifico": "Passiflora edulis f. flavicarpa Deg."
}
```

Ya verificado en el grafo AGE recién poblado (488 species).

## Test plan

- [x] `npm run build` OK
- [x] `eslint` clean
- [ ] **Manual test post-deploy**: preguntar "¿hasta dónde sobrevive la maracuyá?" → debe responder con Passiflora edulis (o sin binomio), NUNCA Mangifera indica

🤖 Generated with [Claude Code](https://claude.com/claude-code)