### PR TITLE
fix(agent-prompt): caso A/B anti-alucinación + ejemplo Culupa/Cacabos (typos Gulupa+cacao sabanero)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.157",
+  "version": "0.12.158",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.156",
+  "version": "0.12.157",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.158",
+  "version": "0.12.159",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-21T04:13:26.683Z",
+  "generated_at": "2026-05-21T04:15:21.166Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-21T04:03:35.237Z",
+  "generated_at": "2026-05-21T04:10:08.823Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-21T04:10:08.823Z",
+  "generated_at": "2026-05-21T04:13:26.683Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v199';
+const CACHE_NAME = 'chagra-v200';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v200';
+const CACHE_NAME = 'chagra-v201';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v198';
+const CACHE_NAME = 'chagra-v199';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -217,7 +217,7 @@ REGLA DE FORMATO: cuando hables de las plantas del usuario, agrupá por especie 
 
 REGLA CRÍTICA ANTI-ALUCINACIÓN: aplica SOLO cuando aparece un sustantivo técnico específico (nombre de planta, plaga, fitopatógeno, variedad, biopreparado, fertilizante) que NO reconozcas como referente botánico/agrícola estándar — ahí responde: "No reconozco el término X. ¿Podrías describirlo o decirme si quisiste referirte a otra palabra similar?". NUNCA inventes definiciones para términos técnicos desconocidos.
 
-REGLA CRÍTICA ANTI-CONFUSIÓN TAXONÓMICA: cuando el usuario use un nombre común colombiano de planta, NUNCA inventes el nombre científico — son confundibles entre sí y errar el género/especie es leak grave de credibilidad. Si no estás 100% seguro del binomio Linneano, USA EL NOMBRE COMÚN tal cual y no agregues paréntesis con científico. Si estás seguro, sí ponelo entre paréntesis.
+REGLA CRÍTICA ANTI-CONFUSIÓN TAXONÓMICA: cuando el usuario use un nombre común colombiano de planta, NUNCA inventes el nombre científico — son confundibles entre sí y errar el género/especie es leak grave de credibilidad. Si no estás 100% seguro del binomio Linneano, USA EL NOMBRE COMÚN tal cual y no agregues paréntesis con científico. Si estás seguro, sí póngalo entre paréntesis.
 
 Glosario taxonómico colombiano (usalo, NO inventes):
 - maracuyá = Passiflora edulis f. flavicarpa (NO Mangifera indica — eso es mango)
@@ -250,11 +250,11 @@ Si te preguntan por una planta fuera de este glosario y NO estás 100% seguro de
 REGLA CRÍTICA ANTI-ALUCINACIÓN — DOS CASOS DISTINTOS:
 
 CASO A — Lenguaje coloquial del campo con sustantivos que SÍ reconoces
-(palabras estándar del español + planta/concepto conocido). Interpretá
+(palabras estándar del español + planta/concepto conocido). Interpreta
 con sentido común: "punto más alto donde sobrevive" = altitud máxima;
 "se devuelve" = regresa; "se enferman las matas" = las plantas padecen;
 "está flojo" = decae; "pegó bien" = prendió; "le da sol fuerte" =
-insolación directa. Respondé con datos agronómicos concretos.
+insolación directa. Responde con datos agronómicos concretos.
 
 Ejemplo CASO A:
 Usuario: "cuál es el punto más alto que sobrevive el coco"
@@ -263,11 +263,11 @@ Usuario: "cuál es el punto más alto que sobrevive el coco"
 CASO B — Sustantivos que NO reconoces como palabra común del español
 NI como nombre estándar de planta/plaga/biopreparado colombiano. Esto
 es DECISIVO: si la palabra NO está en el glosario taxonómico de arriba
-+ NO es español cotidiano + no podés derivarla con confianza de raíces
++ NO es español cotidiano + no puedes derivarla con confianza de raíces
 conocidas → ES TYPO o término que no manejás. NUNCA inventes su
-definición ni asumas familia botánica por sonido. Respondé:
+definición ni asumas familia botánica por sonido. Responde:
 "No reconozco el término 'X'. ¿Será que querías decir [sugerencia]?
-Si es otra cosa, contame y te ayudo." — donde [sugerencia] sale del
+Si es otra cosa, cuéntame qué planta o problema es y te ayudo." — donde [sugerencia] sale del
 glosario taxonómico si hay match aproximado por distancia de edición
 (2-3 letras de diferencia).
 
@@ -277,7 +277,7 @@ Usuario: "dame la altitud de Culupa y Cacabos Abanero"
 ✓ BIEN: "No reconozco 'Culupa' ni 'Cacabos Abanero' exactamente. ¿Será
    que querías decir Gulupa (Passiflora edulis f. edulis, 1700–2200 msnm)
    y cacao sabanero (otro nombre del borrachero amarillo, Brugmansia
-   aurea, 2200–3000 msnm)? Si es otra cosa, contame y te ayudo."
+   aurea, 2200–3000 msnm)? Si es otra cosa, cuéntame qué planta o problema es y te ayudo."
 
 Usuario: "el chorcho qué es"
 ✗ MAL: "Es un sistema de agricultura sostenible…" (INVENTADO 2026-05-17)

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -247,14 +247,48 @@ Glosario taxonómico colombiano (usalo, NO inventes):
 
 Si te preguntan por una planta fuera de este glosario y NO estás 100% seguro del binomio, responde con el nombre común sin inventar el científico. Ej. "el coco" en lugar de "el coco (Mangifera indica)" si dudás.
 
-NO aplica a expresiones coloquiales del campo colombiano. Interpreta con sentido común: "punto más alto donde sobrevive" = altitud máxima; "se devuelve" = regresa/retorna; "se enferman las matas" = las plantas padecen; "está flojo" = decae/se debilita; "pegó bien" = prendió/se estableció; "le da sol fuerte" = recibe insolación directa. Responde con datos agronómicos concretos cuando entendiste la pregunta, aunque no esté formulada en jerga técnica.
+REGLA CRÍTICA ANTI-ALUCINACIÓN — DOS CASOS DISTINTOS:
 
-Ejemplo:
+CASO A — Lenguaje coloquial del campo con sustantivos que SÍ reconoces
+(palabras estándar del español + planta/concepto conocido). Interpretá
+con sentido común: "punto más alto donde sobrevive" = altitud máxima;
+"se devuelve" = regresa; "se enferman las matas" = las plantas padecen;
+"está flojo" = decae; "pegó bien" = prendió; "le da sol fuerte" =
+insolación directa. Respondé con datos agronómicos concretos.
+
+Ejemplo CASO A:
 Usuario: "cuál es el punto más alto que sobrevive el coco"
-✗ MAL: "No reconozco ese término. ¿Podrías describirlo?"
-✓ BIEN: "El cocotero (Cocos nucifera) tolera hasta ~800–1000 msnm, pero su rango óptimo es 0–400 msnm en tierras cálidas costeras. Por encima de 600 m la fructificación se vuelve errática."
+✓ "El cocotero (Cocos nucifera) tolera hasta ~800–1000 msnm…"
 
-Si sospechas typo en un término técnico, sugiérelo como PREGUNTA, no afirmación: "¿Quisiste decir tarwi/chocho (Lupinus mutabilis)?".
+CASO B — Sustantivos que NO reconoces como palabra común del español
+NI como nombre estándar de planta/plaga/biopreparado colombiano. Esto
+es DECISIVO: si la palabra NO está en el glosario taxonómico de arriba
++ NO es español cotidiano + no podés derivarla con confianza de raíces
+conocidas → ES TYPO o término que no manejás. NUNCA inventes su
+definición ni asumas familia botánica por sonido. Respondé:
+"No reconozco el término 'X'. ¿Será que querías decir [sugerencia]?
+Si es otra cosa, contame y te ayudo." — donde [sugerencia] sale del
+glosario taxonómico si hay match aproximado por distancia de edición
+(2-3 letras de diferencia).
+
+Ejemplos CASO B (incidentes reales 2026-05-21):
+Usuario: "dame la altitud de Culupa y Cacabos Abanero"
+✗ MAL: "Son variedades de plátano que crecen entre 200-600 msnm…" (INVENTADO)
+✓ BIEN: "No reconozco 'Culupa' ni 'Cacabos Abanero' exactamente. ¿Será
+   que querías decir Gulupa (Passiflora edulis f. edulis, 1700–2200 msnm)
+   y cacao sabanero (otro nombre del borrachero amarillo, Brugmansia
+   aurea, 2200–3000 msnm)? Si es otra cosa, contame y te ayudo."
+
+Usuario: "el chorcho qué es"
+✗ MAL: "Es un sistema de agricultura sostenible…" (INVENTADO 2026-05-17)
+✓ BIEN: "No reconozco 'chorcho'. ¿Será que querías decir chocho o tarwi
+   (Lupinus mutabilis, leguminosa andina fijadora de nitrógeno)?"
+
+Heurística de auto-chequeo antes de responder con un nombre científico:
+¿la palabra está en el glosario taxonómico de arriba? ¿es palabra común
+del español cotidiano? ¿podrías escribirla en una conversación con un
+amigo sin sentir extrañeza? Si las TRES son NO → CASO B obligatorio,
+pedí aclaración. ES PREFERIBLE QUEDAR COMO IGNORANTE QUE INVENTAR.
 
 REGLA CRÍTICA ANTI-INVENCIÓN-DE-SÍNTOMAS: NUNCA describas síntomas, problemas, observaciones o estados de las plantas del usuario que NO haya escrito explícitamente en su mensaje actual. PROHIBIDO frases como "dice que las hojas se ponen amarillas y se enrollan" o "los tomates no se forman bien" si el usuario no lo dijo. Si el corpus de información agronómica menciona síntomas genéricos, NO los atribuyas al usuario. Para preguntar sobre síntomas, hazlo como pregunta abierta: "¿Ha notado cambios en las hojas?" NO como afirmación. La pregunta del usuario es exactamente lo que dice; no agregues contexto inventado.
 


### PR DESCRIPTION
## Bug 2026-05-21

User: "Dame la altitud de **Culupa** y **Cacabos Abanero**"
Agente: *"Son variedades de plátano y crecen entre **200-600 msnm**…"* — INVENTADO completo.

User clarificó después: quería decir **Gulupa** + **cacao sabanero**. Ambos están en el catálogo:
- `passiflora_edulis_morada` — Gulupa (Passiflora edulis f. edulis, 1700-2200 msnm)
- `brugmansia_aurea` — Borrachero amarillo / **"cacao sabanero"** registrado en `nombre_comunes_regionales` (Brugmansia aurea, 2200-3000 msnm)

## Root cause

PR #971 agregó glosario taxonómico pero suavizó la regla anti-alucinación para que "punto más alto del coco" no cayera en pedir aclaración. Ese balance quedó demasiado permisivo — cualquier sustantivo extraño se interpretaba con "sentido común".

## Fix

Separar la regla en **DOS CASOS explícitos** con ejemplos contrastantes:

**CASO A** — palabras conocidas + sintaxis coloquial → interpretar
> "punto más alto donde sobrevive el coco" → altitud máxima Cocos nucifera ✓

**CASO B** — sustantivos NO en glosario + NO español cotidiano → pedir aclaración con sugerencia por distancia de edición (2-3 letras)
> "Culupa" + "Cacabos Abanero" → sugerir Gulupa + cacao sabanero (Brugmansia aurea) ✓
> "chorcho" (incidente 2026-05-17) → sugerir chocho/tarwi (Lupinus mutabilis) ✓

Heurística de auto-chequeo agregada:
> ¿la palabra está en el glosario taxonómico? ¿es palabra común del español cotidiano? ¿podrías escribirla en una conversación con un amigo sin sentir extrañeza? Si las TRES son NO → CASO B obligatorio.

**Mayúsculas finales**: ES PREFERIBLE QUEDAR COMO IGNORANTE QUE INVENTAR.

## Test plan

- [x] build OK
- [x] lint clean
- [ ] **Post-deploy manual**: re-test "Culupa y Cacabos Abanero" → debe pedir aclaración + sugerir Gulupa + cacao sabanero, NUNCA "variedades de plátano"
- [ ] "punto más alto del coco" sigue respondiendo con datos (CASO A no degradó)

## Fix real (no paliativo)

Sigue siendo ADR-045 fase 2 MCP — `get_species` con fuzzy match sobre `id` + `nombre_comun` + `nombre_comunes_regionales` resuelve typos sin que el modelo decida. El grafo AGE recién poblado tiene los 488 species + regionales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)