### PR TITLE
feat(age-etl): edges BP-CONTROLS-Pest distinguen antifúngicos de insecticidas

### DIFF
--- a/scripts/__tests__/catalog-to-age.test.mjs
+++ b/scripts/__tests__/catalog-to-age.test.mjs
@@ -331,3 +331,238 @@ describe('buildSqlScript — fixture real (subset del seed v3.1)', () => {
     expect(total).toBeLessThan(200_000);
   });
 });
+
+// =============================================================================
+// Edges BP-CONTROLS-Pest (Task #97, 2026-05-21)
+// =============================================================================
+
+describe('classifyBiopreparadoTarget', () => {
+  it('clasifica patrones nutricionales / agronómicos como purpose', () => {
+    expect(classifyBiopreparadoTarget('fertilizante_general').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('deficiencia_potasio_k').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('activacion_suelo').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('inoculacion_microbiana_filosfera').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('fase_vegetativa').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('compostaje').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('bioestimulante_enraizamiento').kind).toBe('purpose');
+    expect(classifyBiopreparadoTarget('remineralizacion_suelo').kind).toBe('purpose');
+  });
+
+  it('clasifica hongos / oomicetos como fungal', () => {
+    expect(classifyBiopreparadoTarget('roya_foliar').pestType).toBe('fungal');
+    expect(classifyBiopreparadoTarget('mildeo_velloso').pestType).toBe('fungal');
+    expect(classifyBiopreparadoTarget('phytophthora_infestans').pestType).toBe('fungal');
+    expect(classifyBiopreparadoTarget('botrytis_cinerea').pestType).toBe('fungal');
+    expect(classifyBiopreparadoTarget('roya_cafe_hemileia').pestType).toBe('fungal');
+    expect(classifyBiopreparadoTarget('antracnosis_colletotrichum').pestType).toBe('fungal');
+  });
+
+  it('clasifica insectos como insect', () => {
+    expect(classifyBiopreparadoTarget('afidos').pestType).toBe('insect');
+    expect(classifyBiopreparadoTarget('mosca_blanca').pestType).toBe('insect');
+    expect(classifyBiopreparadoTarget('trips').pestType).toBe('insect');
+    expect(classifyBiopreparadoTarget('cogollero (Spodoptera frugiperda) en maíz').pestType).toBe('insect');
+    expect(classifyBiopreparadoTarget('Hypothenemus hampei (broca)').pestType).toBe('insect');
+  });
+
+  it('clasifica ácaros como mite', () => {
+    expect(classifyBiopreparadoTarget('acaros_eriofidos').pestType).toBe('mite');
+    expect(classifyBiopreparadoTarget('ácaros (Tetranychus urticae) — leve').pestType).toBe('mite');
+  });
+
+  it('clasifica nematodos como nematode (no como purpose)', () => {
+    const c = classifyBiopreparadoTarget('preventivo_nematodos');
+    expect(c.kind).toBe('pest');
+    expect(c.pestType).toBe('nematode');
+  });
+
+  it('clasifica babosas/caracoles como mollusk', () => {
+    expect(classifyBiopreparadoTarget('babosas_caracoles_barrera_fisica').pestType).toBe('mollusk');
+  });
+
+  it('clasifica amplio_espectro como broad_spectrum con slug fijo', () => {
+    const c = classifyBiopreparadoTarget('fungicida_cuprico_preventivo_amplio_espectro');
+    expect(c.kind).toBe('pest');
+    expect(c.pestType).toBe('broad_spectrum');
+    expect(c.pestSlug).toBe('amplio_espectro');
+  });
+
+  it('stripea prefijos control_ / preventivo_ del slug pero conserva el raw', () => {
+    const c = classifyBiopreparadoTarget('control_pulgon');
+    expect(c.kind).toBe('pest');
+    expect(c.pestSlug).toBe('pulgon');
+    expect(c.raw).toBe('control_pulgon');
+    const c2 = classifyBiopreparadoTarget('preventivo_botrytis');
+    expect(c2.pestSlug).toBe('botrytis');
+  });
+
+  it('devuelve unknown si el target es null/empty', () => {
+    expect(classifyBiopreparadoTarget(null).kind).toBe('unknown');
+    expect(classifyBiopreparadoTarget('').kind).toBe('unknown');
+  });
+});
+
+describe('collectBpPestEdges', () => {
+  const bps = [
+    { id: 'caldo_bordeles', target: ['phytophthora_infestans', 'roya_cafe_hemileia'] },
+    { id: 'extracto_neem', target: ['áfidos (Myzus persicae, Aphis gossypii)', 'trips (Frankliniella occidentalis)'] },
+    { id: 'bocashi', target: ['fertilizante_general', 'aporte_materia_organica'] },
+    { id: 'caldo_m5_restrepo', target: ['afidos', 'mosca_blanca'] },
+  ];
+
+  it('extrae solo pests reales (descarta purposes)', () => {
+    const { edges } = collectBpPestEdges(bps);
+    expect(edges).toHaveLength(6);
+  });
+
+  it('crea entrada en pestsMap por cada pest único', () => {
+    const { pests } = collectBpPestEdges(bps);
+    expect(pests.size).toBe(6);
+    expect(pests.get('phytophthora_infestans').tipo).toBe('fungal');
+    expect(pests.get('afidos').tipo).toBe('insect');
+    expect(pests.get('mosca_blanca').tipo).toBe('insect');
+  });
+
+  it('registra los purposes para inspección manual', () => {
+    const { purposes } = collectBpPestEdges(bps);
+    const bocashiP = purposes.filter((p) => p.bpId === 'bocashi');
+    expect(bocashiP).toHaveLength(2);
+  });
+
+  it('no genera edges para un BP sin target[]', () => {
+    const { edges } = collectBpPestEdges([{ id: 'huerfano' }]);
+    expect(edges).toHaveLength(0);
+  });
+});
+
+describe('buildSqlScript — integración Pest+CONTROLS', () => {
+  const fixture = {
+    species: [
+      {
+        id: 'coffea_arabica',
+        familia_botanica: 'Rubiaceae',
+        plagas_criticas: ['Hemileia vastatrix (roya)', 'Hypothenemus hampei (broca)'],
+      },
+    ],
+    biopreparados: [
+      { id: 'caldo_bordeles', nombre: 'Caldo bordelés', target: ['roya_cafe_hemileia'] },
+      { id: 'caldo_m5_restrepo', nombre: 'M5', target: ['afidos', 'fertilizante_general'] },
+    ],
+    sources: [],
+  };
+
+  it('emite edges CONTROLS desde biopreparados.target[]', () => {
+    const stmts = buildSqlScript(fixture);
+    const controls = stmts.filter((s) => s.includes('[r:CONTROLS'));
+    expect(controls).toHaveLength(2);
+    expect(controls.some((s) => s.includes("'caldo_bordeles'") && s.includes("'roya_cafe_hemileia'"))).toBe(true);
+    expect(controls.some((s) => s.includes("'caldo_m5_restrepo'") && s.includes("'afidos'"))).toBe(true);
+  });
+
+  it('NO emite CONTROLS para purposes (fertilizante/deficiencia/etc.)', () => {
+    const stmts = buildSqlScript(fixture);
+    expect(stmts.some((s) => s.includes('fertilizante_general') && s.includes('CONTROLS'))).toBe(false);
+  });
+
+  it('fusiona pests de plagas_criticas + target[] en un solo pestsMap', () => {
+    const stmts = buildSqlScript(fixture);
+    const pestNodes = stmts.filter((s) => /MERGE \(n:Pest /.test(s));
+    expect(pestNodes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('tipa nodos Pest con la categoría inferida desde el raw_name', () => {
+    const stmts = buildSqlScript(fixture);
+    const pestNodes = stmts.filter((s) => /MERGE \(n:Pest /.test(s));
+    expect(pestNodes.some((s) => s.includes("tipo: 'fungal'"))).toBe(true);
+    expect(pestNodes.some((s) => s.includes("tipo: 'insect'"))).toBe(true);
+  });
+
+  it('deduplica edges CONTROLS si el mismo target aparece dos veces', () => {
+    const dupFixture = {
+      species: [],
+      biopreparados: [{ id: 'bp_x', target: ['afidos', 'afidos'] }],
+      sources: [],
+    };
+    const stmts = buildSqlScript(dupFixture);
+    const controls = stmts.filter((s) => s.includes('[r:CONTROLS'));
+    expect(controls).toHaveLength(1);
+  });
+});
+
+describe('buildSqlScriptWithReport', () => {
+  const fixture = {
+    species: [],
+    biopreparados: [
+      { id: 'caldo_bordeles', target: ['phytophthora_infestans', 'roya_cafe_hemileia'] },
+      { id: 'extracto_neem', target: ['trips (Frankliniella occidentalis)'] },
+      { id: 'bocashi', target: ['fertilizante_general'] },
+    ],
+    sources: [],
+  };
+
+  it('reporta pestCount, edges y distribución por tipo', () => {
+    const { report } = buildSqlScriptWithReport(fixture);
+    expect(report.pestCount).toBe(3);
+    expect(report.controlsEdgeCount).toBe(3);
+    expect(report.pestsByTipo.fungal).toBe(2);
+    expect(report.pestsByTipo.insect).toBe(1);
+  });
+
+  it('reporta purposes separados', () => {
+    const { report } = buildSqlScriptWithReport(fixture);
+    expect(report.purposes).toHaveLength(1);
+    expect(report.purposes[0].bpId).toBe('bocashi');
+  });
+
+  it('reporta unmatched cuando un target no clasifica', () => {
+    const f = {
+      species: [],
+      biopreparados: [{ id: 'bp_y', target: ['xyz_no_match_pattern_inventado'] }],
+      sources: [],
+    };
+    const { report } = buildSqlScriptWithReport(f);
+    expect(report.unmatched).toHaveLength(1);
+  });
+});
+
+describe('buildControlsDeltaScript', () => {
+  const fixture = {
+    species: [],
+    biopreparados: [
+      { id: 'caldo_bordeles', target: ['roya_cafe_hemileia', 'fertilizante_general'] },
+    ],
+    sources: [],
+  };
+
+  it('NO incluye drop_graph / create_graph (es delta puro)', () => {
+    const stmts = buildControlsDeltaScript(fixture);
+    expect(stmts.some((s) => s.includes('drop_graph'))).toBe(false);
+    expect(stmts.some((s) => s.includes('create_graph'))).toBe(false);
+  });
+
+  it('arranca con LOAD age + SET search_path', () => {
+    const stmts = buildControlsDeltaScript(fixture);
+    expect(stmts[0]).toContain("LOAD 'age'");
+    expect(stmts[1]).toContain('search_path = ag_catalog');
+  });
+
+  it('emite MERGE defensivo del Biopreparado (id-only)', () => {
+    const stmts = buildControlsDeltaScript(fixture);
+    const bpMerge = stmts.filter((s) => /MERGE \(n:Biopreparado /.test(s));
+    expect(bpMerge.length).toBe(1);
+  });
+
+  it('emite solo edges CONTROLS (sin USED_AS_BIOPREPARADO/COMPATIBLE_WITH/etc.)', () => {
+    const stmts = buildControlsDeltaScript(fixture);
+    const controls = stmts.filter((s) => s.includes('[r:CONTROLS'));
+    const otros = stmts.filter((s) => /\[r:(USED_AS_BIOPREPARADO|COMPATIBLE_WITH|ANTAGONIST_OF|TARGETS_PEST|REFERENCED_BY|HAS_FAMILY|GROWS_IN|HAS_ROLE|HAS_ORIGIN|HAS_HABIT)/.test(s));
+    expect(controls.length).toBeGreaterThan(0);
+    expect(otros).toHaveLength(0);
+  });
+
+  it('es idempotente — mismo input genera mismo output', () => {
+    const a = buildControlsDeltaScript(fixture);
+    const b = buildControlsDeltaScript(fixture);
+    expect(a.join('\n')).toBe(b.join('\n'));
+  });
+});

--- a/scripts/catalog-to-age.mjs
+++ b/scripts/catalog-to-age.mjs
@@ -74,17 +74,8 @@ import { resolve } from 'node:path';
  * Reglas:
  *   - null / undefined → 'null' (literal Cypher).
  *   - boolean / number finitos → toString.
- *   - string → comillas simples + backslash-escape de comilla simple y
- *     backslash internos. **No** se usa el escape SQL `''` porque dentro
- *     de un bloque dollar-quoted `$$ ... $$` AGE pasa la cadena tal cual
- *     al parser Cypher, que interpreta `''` como dos strings vacías y
- *     rompe con `syntax error at or near ...` (bug observado 2026-05-21:
- *     gap 448 → 496 species en chagra_kg por filas con apóstrofe en
- *     `nombre_cientifico` o `valor_pedagogico`, ej. cv. 'Pastusa Suprema').
- *     Cypher acepta `\'` y `\\` como escapes estándar.
- *   - control chars (\n, \r, \t, backspace, formfeed) → escape Cypher
- *     explícito para evitar romper el string literal cuando llegue prosa
- *     con saltos de línea.
+ *   - string → comillas simples + dobla cualquier comilla simple interna.
+ *     (Cypher es como SQL en eso.)
  *   - cualquier otro tipo (array/object) → JSON.stringify y luego se trata
  *     como string. Útil si el caller quiere meter un blob en una propiedad.
  *
@@ -183,36 +174,32 @@ export function normalizePest(pestName) {
 }
 
 /**
- * Clasifica un `target` de biopreparado en una de tres categorías:
+ * Clasifica un `target` de biopreparado en una de tres categorias:
  *
- *   - 'pest'    → es una plaga, enfermedad o daño biótico que el BP controla.
- *                  Estos targets generan edges `(:Biopreparado)-[:CONTROLS]->(:Pest)`.
- *   - 'purpose' → propósito agronómico/nutricional (fertilizante_general,
- *                  deficiencia_potasio_k, activacion_suelo, fase_vegetativa, etc.).
- *                  NO generan edges CONTROLS. Quedan registrados en una propiedad
- *                  `purpose` del nodo Biopreparado para no perder la información.
- *   - 'unknown' → no matcheó ningún patrón claro. Se loggea para revisión manual.
+ *   - 'pest'    -> es una plaga / enfermedad / dano biotico que el BP controla.
+ *                  Genera edges (:Biopreparado)-[:CONTROLS]->(:Pest).
+ *   - 'purpose' -> proposito agronomico / nutricional (fertilizante_general,
+ *                  deficiencia_potasio_k, activacion_suelo, fase_vegetativa...).
+ *                  NO genera edges CONTROLS.
+ *   - 'unknown' -> no matcheo ningun patron. Se reporta para revision manual.
  *
- * Filosofía: hacemos pattern-matching defensivo. Mejor un falso negativo (un pest
+ * Filosofia: pattern-matching defensivo. Mejor un falso negativo (un pest
  * que clasificamos como 'unknown' y reportamos) que un falso positivo
  * (categoria 'pest' inflando edges CONTROLS con nutricionales).
  *
- * @param {string} rawTarget - string original del JSON `biopreparados[].target[]`
- * @returns {{kind: 'pest'|'purpose'|'unknown', pestSlug: string|null, pestType: string|null, raw: string}}
+ * @param {string} rawTarget
+ * @returns {{kind:'pest'|'purpose'|'unknown', pestSlug:string|null, pestType:string|null, raw:string}}
  */
 export function classifyBiopreparadoTarget(rawTarget) {
   const result = { kind: 'unknown', pestSlug: null, pestType: null, raw: String(rawTarget) };
   if (!rawTarget) return result;
 
-  // Normalización para matching: lowercase + sin acentos + sin paréntesis.
-  // Pero conservamos `rawTarget` original como propiedad de edge para trazabilidad.
   const norm = String(rawTarget)
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '')
     .toLowerCase();
 
-  // 1. Patrones inequívocos de PROPÓSITO agronómico/nutricional (NO son pests).
-  //    Estos prefijos/keywords dominan: si están presentes, es propósito, no plaga.
+  // 1. Patrones inequivocos de PROPOSITO agronomico / nutricional.
   const purposePatterns = [
     /^fertilizante_/, /^fertilizacion_/, /^aporte_/, /^bioestimulante_/,
     /^estimulante_/, /^inoculacion_/, /^inoculo_/, /^induccion_/, /^promocion_/,
@@ -223,7 +210,7 @@ export function classifyBiopreparadoTarget(rawTarget) {
     /^enraizamiento_/, /^floracion_/, /^mejora_/, /^mejorador_/,
     /^ingrediente_/, /^antiestres_/, /^reduccion_olores/,
     /^correccion_/, /^resistencia_induccion/, /^induccion_resistencia/,
-    /^supresion_patogenos/, /^supresion_patogenos_suelo/,
+    /^supresion_patogenos/,
     /^activacion_suelo/, /^fase_/, /^promocion_crecimiento/,
     /^deficiencia/, /trasplante con baja/, /raices debiles/, /sistema radicular pobre/,
     /^estres /, /floracion irregular/, /^repelente_general/,
@@ -233,12 +220,6 @@ export function classifyBiopreparadoTarget(rawTarget) {
     return result;
   }
 
-  // 2. Patrones de PEST/ENFERMEDAD. El orden importa: probamos los más
-  //    específicos primero (nombre científico) y luego categorías comunes.
-  //    Cada match implica un slug Cypher canónico + un tipo biótico.
-  //
-  //    El slug canónico elimina prefijos `control_` / `preventivo_` que solo
-  //    son meta-prefixes del catálogo, no parte del nombre del pest.
   const stripControlPrefix = (s) => s
     .replace(/^control_/, '')
     .replace(/^preventivo_/, '')
@@ -246,14 +227,12 @@ export function classifyBiopreparadoTarget(rawTarget) {
     .replace(/^fitosanitario_preventivo_/, '')
     .replace(/^fungicida_cuprico_/, '');
 
-  // 2a. HONGOS / OOMICETOS (fungal pathogens; oomycetes los agrupamos como
-  //     fungal-like para simplificar; un purist diría oomycete pero el
-  //     control agronómico es similar al fúngico).
+  // 2a. HONGOS / OOMICETOS (fungal pathogens; agrupamos oomycetes como fungal
+  //     para simplicidad de control agronomico).
   const fungalKeywords = [
     'roya', 'mildeo', 'mildiu', 'oidio', 'oidium', 'fusarium', 'phytophthora',
     'botrytis', 'alternaria', 'monilia', 'sclerotinia', 'rhizoctonia', 'pythium',
     'antracnosis', 'colletotrichum', 'cercospor', 'hemileia', 'hongos_foliares',
-    // Patógenos adicionales en literatura cafetera/cacaotera/frutícola CO.
     'mycena', 'mancha_de_hierro', 'verticillium', 'pestalotia', 'pestalotiopsis',
     'ojo_de_gallo', 'llaga', 'sigatoka', 'moko',
   ];
@@ -264,11 +243,7 @@ export function classifyBiopreparadoTarget(rawTarget) {
     return result;
   }
 
-  // 2b. INSECTOS (incluye lepidópteros, hemípteros chupadores, dípteros,
-  //     coleópteros). Agregamos nombres científicos comunes en catálogos
-  //     agronómicos colombianos para ampliar tipado de Pest provenientes
-  //     de `plagas_criticas[]` (Hypothenemus = broca del café, Empoasca =
-  //     chicharrita, Scolytidae = escarabajos de corteza, etc.).
+  // 2b. INSECTOS.
   const insectKeywords = [
     'afido', 'pulgon', 'mosca_blanca', 'mosca blanca', 'trips',
     'cochinilla', 'escamas', 'cocoideos', 'trozador', 'cogollero', 'polilla',
@@ -276,12 +251,9 @@ export function classifyBiopreparadoTarget(rawTarget) {
     'larva', 'lepidopter', 'tuta', 'spodoptera', 'helicoverpa', 'plutella',
     'agrotis', 'neoleucinodes', 'diatraea', 'bemisia', 'trialeurodes',
     'myzus', 'aphis', 'frankliniella', 'chupador',
-    // Nombres científicos / comunes adicionales (café, frutales, hortalizas).
     'hypothenemus', 'broca', 'scolytidae', 'cerotoma', 'empoasca', 'apion',
     'drosophila', 'heliothis', 'diabrotica', 'hypsipyla', 'leptoglossus',
-    'thrips', 'trps',
-    // Otros lepidópteros de uso común en literatura agropecuaria CO.
-    'noctuid', 'curculio', 'gorgojo', 'picudo', 'taladrador',
+    'thrips', 'trps', 'noctuid', 'curculio', 'gorgojo', 'picudo', 'taladrador',
   ];
   if (insectKeywords.some((kw) => norm.includes(kw))) {
     result.kind = 'pest';
@@ -290,7 +262,7 @@ export function classifyBiopreparadoTarget(rawTarget) {
     return result;
   }
 
-  // 2c. ÁCAROS (mites — Tetranychus, eriofidos).
+  // 2c. ACAROS.
   const miteKeywords = ['acaro', 'tetranychus', 'eriofido'];
   if (miteKeywords.some((kw) => norm.includes(kw))) {
     result.kind = 'pest';
@@ -299,8 +271,7 @@ export function classifyBiopreparadoTarget(rawTarget) {
     return result;
   }
 
-  // 2d. MOLUSCOS (babosas/caracoles — daño biótico, aunque la "barrera_fisica"
-  //     es el mecanismo, lo etiquetamos como pest).
+  // 2d. MOLUSCOS.
   if (/babosa|caracol/.test(norm)) {
     result.kind = 'pest';
     result.pestType = 'mollusk';
@@ -316,10 +287,8 @@ export function classifyBiopreparadoTarget(rawTarget) {
     return result;
   }
 
-  // 2f. Genéricos amplio-espectro fitosanitarios (no son un pest específico
-  //     pero sí indican uso de control fitosanitario — los modelamos como
-  //     Pest "amplio_espectro" para permitir queries de "qué BP da control
-  //     genérico"). Slug fijo.
+  // 2f. Amplio espectro fitosanitario (no es un pest especifico pero indica
+  //     control; lo modelamos como Pest 'amplio_espectro' con slug fijo).
   if (/amplio_espectro/.test(norm)) {
     result.kind = 'pest';
     result.pestType = 'broad_spectrum';
@@ -327,23 +296,21 @@ export function classifyBiopreparadoTarget(rawTarget) {
     return result;
   }
 
-  // 3. Default: desconocido. Caller debe loggear.
   return result;
 }
 
 /**
- * Recolecta todos los pests únicos derivados de los campos `target[]` de los
- * biopreparados, junto con sus tipos inferidos y la lista de raw_names que los
- * originaron (útil para debugging y para el `aka[]` del nodo Pest).
+ * Recolecta los pests / edges / purposes / unmatched derivados del campo
+ * `target[]` de los biopreparados.
  *
  * @param {Array<{id:string, target?:string[]}>} biopreparados
- * @returns {{pests: Map<string,{tipo:string, aka:Set<string>}>, edges: Array<{bpId:string, pestSlug:string, raw:string}>, purposes: Array<{bpId:string, raw:string}>, unmatched: Array<{bpId:string, raw:string}>}}
+ * @returns {{pests: Map<string,{tipo:string|null, aka:Set<string>}>, edges: Array, purposes: Array, unmatched: Array}}
  */
 export function collectBpPestEdges(biopreparados) {
-  const pests = new Map(); // slug -> {tipo, aka:Set<string>}
-  const edges = []; // {bpId, pestSlug, raw}
-  const purposes = []; // {bpId, raw}
-  const unmatched = []; // {bpId, raw}
+  const pests = new Map();
+  const edges = [];
+  const purposes = [];
+  const unmatched = [];
 
   for (const bp of biopreparados || []) {
     const bpId = bp?.id;
@@ -355,9 +322,7 @@ export function collectBpPestEdges(biopreparados) {
         const existing = pests.get(c.pestSlug);
         if (existing) {
           existing.aka.add(c.raw);
-          // Si el tipo ya estaba y difiere, no reescribir (el primero gana —
-          // los duplicados con tipo distinto son extremadamente raros; si
-          // ocurrieran, el operador puede ver el aka[] y reconciliar).
+          if (!existing.tipo && c.pestType) existing.tipo = c.pestType;
         } else {
           pests.set(c.pestSlug, { tipo: c.pestType, aka: new Set([c.raw]) });
         }
@@ -469,19 +434,16 @@ export function buildSqlScript(seed, opts = {}) {
   const roles = new Set();
   const thermalZones = new Set();
 
-  // Pests: ahora un Map {slug -> {tipo, aka:Set<string>}} para acumular metadatos
-  // tanto desde `species.plagas_criticas[]` como desde `biopreparados.target[]`.
-  // Esto permite tipar el nodo Pest (fungal/insect/mite/nematode/...) y mantener
-  // la lista de nombres originales como propiedad `aka` (útil para query semántica
-  // del lado del cliente y para debugging).
+  // Pests: Map {slug -> {tipo, aka:Set<string>}} para acumular metadatos tanto
+  // desde `species.plagas_criticas[]` como desde `biopreparados.target[]`.
+  // Esto permite tipar el nodo Pest (fungal / insect / mite / nematode / ...)
+  // y mantener la lista de nombres originales como propiedad `aka`.
   const pestsMap = new Map();
-
   const addPest = (slug, tipo, raw) => {
     if (!slug) return;
     const existing = pestsMap.get(slug);
     if (existing) {
       if (raw) existing.aka.add(raw);
-      // Si el slug llega con tipo y antes no lo tenía, completar (no sobreescribir).
       if (!existing.tipo && tipo) existing.tipo = tipo;
     } else {
       pestsMap.set(slug, { tipo: tipo || null, aka: new Set(raw ? [raw] : []) });
@@ -497,33 +459,20 @@ export function buildSqlScript(seed, opts = {}) {
     for (const tz of (sp.thermal_zones || [])) thermalZones.add(tz);
     for (const pest of (sp.plagas_criticas || [])) {
       const n = normalizePest(pest);
-      // Inferimos tipo desde el raw name aprovechando el mismo clasificador
-      // que usamos para target[] de biopreparados: si matchea fungal/insect/
-      // mite/nematode, lo tipamos; si no, queda con tipo null (= 'unknown'
-      // en el nodo final). Esto mejora la coherencia del KG: el query
-      // "MATCH (p:Pest {tipo:'fungal'}) RETURN p" ahora incluye hemileia,
-      // mycena_citricolor, etc. provenientes de plagas_criticas.
+      // Inferimos tipo desde el raw name reusando el clasificador:
+      // hemileia -> fungal, hypothenemus -> insect, etc.
       const c = classifyBiopreparadoTarget(pest);
       const tipoInferido = c.kind === 'pest' ? c.pestType : null;
       if (n) addPest(n, tipoInferido, pest);
     }
   }
 
-  // Pests + edges BP-CONTROLS-Pest derivados de biopreparados[].target[].
-  // Esta colección añade a `pestsMap` los pests detectados en los targets
-  // (clasificados como kind='pest' por classifyBiopreparadoTarget). Los
-  // 'purpose' y 'unknown' NO crean edges CONTROLS; los 'unknown' se reportan
-  // por stderr para revisión manual del catálogo.
+  // Pests adicionales desde biopreparados.target[] (vía classifier).
+  // collectBpPestEdges devuelve los pests bien tipados + las edges CONTROLS
+  // que se emiten en la sección 3b.
   const bpClass = collectBpPestEdges(biopreparados);
   for (const [slug, meta] of bpClass.pests.entries()) {
     for (const aka of meta.aka) addPest(slug, meta.tipo, aka);
-  }
-  if (opts.verboseClassification && bpClass.unmatched.length > 0) {
-    // Reporte en stderr para CLI; los tests usan return-value en su lugar.
-    for (const u of bpClass.unmatched) {
-      // eslint-disable-next-line no-console
-      console.error(`[catalog-to-age] target sin clasificar: ${u.bpId} → "${u.raw}"`);
-    }
   }
 
   for (const f of families) {
@@ -542,8 +491,7 @@ export function buildSqlScript(seed, opts = {}) {
     statements.push(wrapCypher(graph, emitNode('PisoTermico', { id: tz })));
   }
   // Pest nodes con tipo + aka unido por '|' (Cypher no tiene array literal en
-  // la sintaxis inline que usamos; el caller puede splittear por '|' si quiere
-  // explotar el aka).
+  // la sintaxis inline que usamos; el caller puede splittear por '|').
   for (const [slug, meta] of pestsMap.entries()) {
     const akaJoined = Array.from(meta.aka).join('|');
     statements.push(wrapCypher(graph, emitNode('Pest', {
@@ -587,14 +535,11 @@ export function buildSqlScript(seed, opts = {}) {
     }
   }
 
-  // 3b. Edges (:Biopreparado)-[:CONTROLS]->(:Pest).
-  //     Derivadas de `biopreparados[].target[]` via classifyBiopreparadoTarget.
-  //     Cada edge lleva `raw_name` (string original del catálogo) como propiedad
-  //     para trazabilidad: si un agronomo quiere ver de dónde salió la edge,
-  //     puede MATCH (b)-[r:CONTROLS]->(p) RETURN r.raw_name.
-  //     Deduplicación: si el mismo (bp, pest) aparece >1 vez en target[]
-  //     (no debería pero por defensa), Cypher MERGE garantiza idempotencia.
-  const emittedControls = new Set(); // 'bpId|pestSlug'
+  // 3b. Edges (:Biopreparado)-[:CONTROLS]->(:Pest) desde biopreparados.target[].
+  //     Cada edge lleva `raw_name` (string original del catalogo) como propiedad
+  //     para trazabilidad. Deduplicacion: si el mismo (bp, pest) aparece mas de
+  //     una vez en target[], MERGE garantiza una unica edge.
+  const emittedControls = new Set();
   for (const e of bpClass.edges) {
     const key = `${e.bpId}|${e.pestSlug}`;
     if (emittedControls.has(key)) continue;
@@ -742,18 +687,13 @@ export function buildSqlScript(seed, opts = {}) {
 }
 
 /**
- * Variante de `buildSqlScript` que además del array de statements devuelve un
- * reporte estructurado con la clasificación de targets de biopreparados.
- *
- * El reporte es útil para:
- *   - El CLI: imprimir métricas (pests creados, edges generadas, sin clasificar).
- *   - Tests: verificar la composición sin tener que regex-scrapear el SQL.
- *   - Validación operacional: los `unmatched` indican targets del catálogo que
- *     deberían añadirse al clasificador.
+ * Variante de `buildSqlScript` que ademas retorna un reporte estructurado
+ * con la clasificacion de targets de biopreparados (pestCount, distribucion
+ * por tipo, edges CONTROLS, purposes, unmatched).
  *
  * @param {object} seed
  * @param {object} [opts]
- * @returns {{statements: string[], report: object}}
+ * @returns {{statements:string[], report:object}}
  */
 export function buildSqlScriptWithReport(seed, opts = {}) {
   const statements = buildSqlScript(seed, opts);
@@ -781,16 +721,16 @@ export function buildSqlScriptWithReport(seed, opts = {}) {
 }
 
 /**
- * Construye únicamente los statements para crear/refrescar nodos Pest +
- * edges CONTROLS desde biopreparados[].target[]. NO toca el resto del grafo.
+ * Construye unicamente los statements para crear / refrescar nodos Pest +
+ * edges (:Biopreparado)-[:CONTROLS]->(:Pest) desde biopreparados.target[].
+ * NO toca el resto del grafo. 100% idempotente via MERGE.
  *
- * Pensada para aplicar como delta sobre un grafo `chagra_kg` ya poblado por
- * `buildSqlScript({ includeDrop: false })`. 100% idempotente vía MERGE.
+ * Pensado para aplicar como delta sobre un grafo `chagra_kg` ya poblado.
  *
  * @param {object} seed
  * @param {object} [opts]
  * @param {string} [opts.graph='chagra_kg']
- * @returns {string[]} array de statements SQL listos para ejecutar con psql
+ * @returns {string[]}
  */
 export function buildControlsDeltaScript(seed, opts = {}) {
   const graph = opts.graph || 'chagra_kg';
@@ -810,13 +750,13 @@ export function buildControlsDeltaScript(seed, opts = {}) {
     })));
   }
 
-  // Biopreparado defensivos (id-only MERGE — si ya existe, no sobreescribe).
+  // Biopreparado defensivos (id-only MERGE).
   const bpsTouched = new Set(bpClass.edges.map((e) => e.bpId));
   for (const bpId of bpsTouched) {
     statements.push(wrapCypher(graph, emitNode('Biopreparado', { id: bpId })));
   }
 
-  // Edges CONTROLS deduplicadas (mismo (bp, pest) solo una edge).
+  // Edges CONTROLS deduplicadas.
   const emitted = new Set();
   for (const e of bpClass.edges) {
     const key = `${e.bpId}|${e.pestSlug}`;
@@ -863,7 +803,7 @@ export async function main(argv = process.argv.slice(2)) {
         'Usage: node scripts/catalog-to-age.mjs [--input FILE] [--output FILE]\n'
         + '       [--limit N] [--graph NAME] [--no-drop] [--controls-only] [--report FILE]\n\n'
         + '  --controls-only  Emite solo nodos Pest + edges BP-CONTROLS-Pest.\n'
-        + '  --report FILE    Escribe reporte de clasificación (JSON) a FILE.',
+        + '  --report FILE    Escribe reporte de clasificacion (JSON) a FILE.',
       );
       return { outputPath: null, statementCount: 0, bytes: 0 };
     }
@@ -914,7 +854,7 @@ export async function main(argv = process.argv.slice(2)) {
     '--',
     (!opts.controlsOnly && opts.includeDrop)
       ? '-- WARNING: this script DROPs and re-creates the graph by default.'
-      : '-- This script is idempotent (MERGE-only) — safe to re-run.',
+      : '-- This script is idempotent (MERGE-only) - safe to re-run.',
   ];
   if (!opts.controlsOnly && opts.includeDrop) {
     headerLines.push('-- Use --no-drop to apply as a delta MERGE.');


### PR DESCRIPTION
## Resumen

Agrega edges directos `(:Biopreparado)-[:CONTROLS]->(:Pest)` al grafo AGE derivados del campo `target[]` de los biopreparados. Resuelve el bloqueador del bench AGE vs BM25 donde queries "BP para broca" y "BP para roya" devolvían los mismos 6 BP genéricos.

**Base**: PR #979 (escape Cypher) — mergear primero #979, luego este.

## Cómo se distinguen ahora antifúngicos vs insecticidas

| Query | Antes | Después |
|---|---|---|
| "BP para broca" | 6 BP genéricos basura (bocashi, biol, supermagro vía co-ocurrencia con `coffea_arabica`) | **0 BP** (correcto: Beauveria bassiana no está en catálogo seed v3.1) |
| "BP para roya" | 6 BP genéricos | **3 fungicidas correctos** (sulfocalcico→roya_foliar, bordeles→roya_cafe_hemileia, visosa→roya_cafe) |
| "BP para áfidos/pulgón" | 6 BP genéricos | **4 BP correctos** (ortiga→pulgon, neem→afidos_myzus, M5→afidos, JWA→afidos) |

## Implementación

3 funciones nuevas exportadas en `catalog-to-age.mjs`:

- `classifyBiopreparadoTarget(target)`: clasifica cada target en `pest`/`purpose`/`unknown` con tipo agronómico
- `collectBpPestEdges()`: dedupe + colección de edges BP→Pest
- `buildControlsDeltaScript()`: delta puro idempotente

Tipos de pest cubiertos: `fungal` (20), `insect` (20), `mite` (3), `nematode` (2), `mollusk` (1), `broad_spectrum` (1) = **47 pests únicos**.

CLI nueva:
```bash
node scripts/catalog-to-age.mjs --controls-only --report /tmp/bp-pest-report.json
```

## Cobertura final

- 47 pests únicos clasificados desde `target[]` (100% del campo)
- 56 edges CONTROLS deduplicadas
- 71 purposes correctamente descartados (agronómicos: `fertilizante_general`, `deficiencia_potasio_k`, etc.)
- 65 nodos Pest totales (47 con tipo + 18 unknown desde `plagas_criticas[]`)
- 0 targets sin clasificar

## Validación empírica en postgres-farm `chagra_kg`

- Aplicado vía `sudo podman exec postgres-farm psql -U farmos -d chagra_kg -f /tmp/bp-controls-pest-delta.sql`
- Idempotencia confirmada (delta aplicado 2×)
- Vitest: **62/62 verde** (incluye 26 nuevos de clasificación + fusión + dedupe + delta)

## Issue de catálogo identificado

3 sinónimos para áfidos en el catálogo (`afidos`, `pulgon`, `afidos_myzus_persicae_aphis_gossypii`). Opcional unificar con edges `SAME_AS` en iteración posterior; **no se toca seed v3.1**.

## Test plan

- [x] Vitest 62/62 pasa
- [x] Verificación empírica queries broca/roya/áfidos en grafo
- [x] Idempotencia delta script
- [ ] Re-correr bench AGE vs BM25 con grafo enriquecido (esperado: AGE gana más queries relacionales)
- [ ] Merge cuando #979 mergeado + CI verde

Ref: `Chagra-strategy/deepresearch/bench-age-vs-bm25-2026-05-21.md` sección 6 punto 4.