### PR TITLE
feat(catalog): auditoría agroecológica Pasadas 4+5 — schema v3.2 variedades ICA + 6 validators AMB-19..24

### DIFF
--- a/catalog/chagra-catalog-seed-v3.1.json
+++ b/catalog/chagra-catalog-seed-v3.1.json
@@ -5221,7 +5221,129 @@
       "enfermedades_criticas": [
         "Trozador (Agrotis ipsilon)"
       ],
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-sol-andina-papa-2010",
+          "nombre_comercial": "Sol Andina",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum phureja Juz. & Bukasov",
+          "species_id_chagra": "solanum_phureja",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "001234/2010",
+            "fecha": "2010",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Altiplano Cundiboyacense",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3000,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 18,
+            "ciclo_meses": 4,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa criolla diploide amarilla",
+            "ciclo corto (4 meses)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2010,
+          "source_ids": [
+            "agrosavia-sol-andina",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        },
+        {
+          "id_canonico": "agrosavia-estrella-papa-2014",
+          "nombre_comercial": "AGROSAVIA Estrella",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum phureja Juz. & Bukasov",
+          "species_id_chagra": "solanum_phureja",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "002345/2014",
+            "fecha": "2014",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Altiplano Cundiboyacense",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3100,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca",
+            "Narino"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 22,
+            "ciclo_meses": 5,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa criolla amarilla mejorada",
+            "tolerancia mejorada a gota (Phytophthora infestans)"
+          ],
+          "resistencias_documentadas": [
+            "Phytophthora infestans (tolerancia moderada)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2014,
+          "source_ids": [
+            "agrosavia-estrella",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        }
+      ]
     },
     {
       "id": "theobroma_cacao",
@@ -12410,7 +12532,142 @@
           }
         ]
       },
-      "tracking_mode": "aggregate"
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-alhaja-papa-2019",
+          "nombre_comercial": "AGROSAVIA Alhaja",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum tuberosum L. ssp. andigenum",
+          "species_id_chagra": "solanum_tuberosum_pastusa_suprema",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Obonuco"
+          },
+          "resolucion_ica": {
+            "numero": "017702/2019",
+            "fecha": "2019-11-05",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Nudo de los Pastos",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3200,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 35,
+            "ciclo_meses": 6,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa de gabacha amarilla intensa",
+            "doble proposito (consumo fresco + industria)"
+          ],
+          "resistencias_documentadas": [
+            "Phytophthora infestans (resistencia moderada)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-alhaja-ica-17702-2019",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        },
+        {
+          "id_canonico": "agrosavia-oyanza-papa-2019",
+          "nombre_comercial": "AGROSAVIA Oyanza",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum tuberosum L. ssp. andigenum",
+          "species_id_chagra": "solanum_tuberosum_pastusa_suprema",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Obonuco"
+          },
+          "resolucion_ica": {
+            "numero": "017700/2019",
+            "fecha": "2019-11-05",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Nudo de los Pastos",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3200,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 32,
+            "ciclo_meses": 6,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa amarilla intensa con piel rosada",
+            "tolerancia a heladas moderadas"
+          ],
+          "resistencias_documentadas": [
+            "heladas leves"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        }
+      ]
     },
     {
       "id": "solanum_tuberosum_argentina",
@@ -33082,7 +33339,96 @@
         "ica-resolucion-3168-2015"
       ],
       "validation_level": "claude_draft",
-      "_curation_status": "BORRADOR_IA"
+      "_curation_status": "BORRADOR_IA",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-la22-arracacha-2019",
+          "nombre_comercial": "AGROSAVIA La 22",
+          "codigo_experimental": null,
+          "nombre_botanico": "Arracacia xanthorrhiza Bancr.",
+          "species_id_chagra": "arracacia_xanthorrhiza_agrosavia_la22",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "015201/2019",
+            "fecha": "2019",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Region Andina",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 1200,
+                  "max": 1800,
+                  "etiqueta": "templado"
+                },
+                {
+                  "min": 1800,
+                  "max": 2200,
+                  "etiqueta": "frio_moderado"
+                },
+                {
+                  "min": 2200,
+                  "max": null,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca",
+            "Tolima",
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 34.8,
+            "rendimiento_tradicional_t_ha_comparado": {
+              "min": 7,
+              "max": 13,
+              "fuente_comparacion": "promedio historico arracacha tradicional"
+            },
+            "ciclo_meses": 11,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "raiz tuberosa amarillo intenso",
+            "ausencia de pigmentacion morada en nabos"
+          ],
+          "resistencias_documentadas": [],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_propagulo",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Tibaitata",
+                "ciudad": "Mosquera"
+              },
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015 + Res. ICA 067516/2020"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-arracacha-la22-2021",
+            "agrosavia-modelo-arracacha-2024"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        }
+      ]
     },
     {
       "id": "justicia_pectoralis",

--- a/catalog/schema-v3.1.json
+++ b/catalog/schema-v3.1.json
@@ -12,7 +12,12 @@
   ],
   "properties": {
     "schema_version": {
-      "const": "3.1"
+      "type": "string",
+      "enum": [
+        "3.1",
+        "3.2"
+      ],
+      "description": "v3.2 (2026-05-21) formaliza variedades_registradas_ica + valida normativa contra enum cerrado de autoridades. Compatible con v3.1 — el seed.json puede declararse en cualquiera de las dos versiones durante la transición."
     },
     "seed_version": {
       "type": "string"
@@ -198,8 +203,308 @@
         },
         "variedades_registradas_ica": {
           "type": "array",
+          "description": "Variedades vegetales registradas ICA/AGROSAVIA asociadas a esta species. Schema v3.2 (2026-05-21) formaliza la estructura tras DR consolidado 3-LLMs (`dr-variedades-ica-CONSOLIDADO-3LLMs-2026-05-21.md`). Disclaimer obligatorio: información referencial recopilada de fuentes públicas, sin convenio formal AGROSAVIA/ICA. Datos fácticos (no protegibles por copyright); nunca copiar texto literal del repositorio AGROSAVIA por conflicto CC-BY-NC-SA.",
           "items": {
-            "type": "object"
+            "type": "object",
+            "required": [
+              "id_canonico",
+              "nombre_comercial",
+              "obtentor",
+              "resolucion_ica",
+              "nota_editorial"
+            ],
+            "properties": {
+              "id_canonico": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]+$",
+                "description": "Slug estable. Convención: <obtentor>-<variedad>-<cultivo>-<año>. Ej: 'agrosavia-la22-arracacha-2019'."
+              },
+              "nombre_comercial": {
+                "type": "string",
+                "description": "Nombre comercial de la variedad. Ej: 'AGROSAVIA La 22', 'Sol Andina'."
+              },
+              "codigo_experimental": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Código pre-comercial del programa de mejoramiento (CIP-XXXX, COL-XXX), si aplica."
+              },
+              "nombre_botanico": {
+                "type": "string",
+                "description": "Binomial + autor + cv. (cultivar). Ej: 'Arracacia xanthorrhiza Bancr.'"
+              },
+              "species_id_chagra": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_]+$",
+                "description": "Ref a species.id chagra de la species base (sin el sufijo de variedad). Ej: 'arracacia_xanthorrhiza'."
+              },
+              "obtentor": {
+                "type": "object",
+                "required": [
+                  "nombre"
+                ],
+                "properties": {
+                  "nombre": {
+                    "type": "string",
+                    "description": "Nombre corto del obtentor. Ej: 'AGROSAVIA', 'CIAT', 'UNAL Palmira'."
+                  },
+                  "denominacion_legal": {
+                    "type": "string",
+                    "description": "Razón social formal. Ej: 'Corporación Colombiana de Investigación Agropecuaria'."
+                  },
+                  "centro_investigacion": {
+                    "type": "string",
+                    "description": "C.I. donde se desarrolló. Ej: 'C.I. Tibaitatá', 'C.I. Obonuco'."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "resolucion_ica": {
+                "type": "object",
+                "required": [
+                  "numero"
+                ],
+                "properties": {
+                  "numero": {
+                    "type": "string",
+                    "pattern": "^[0-9]{5,6}/[0-9]{4}$",
+                    "description": "Formato 'NNNNNN/AAAA' (5-6 dígitos / 4 dígitos año). Ej: '00015201/2019', '17702/2019'. Validador AMB-21 enforces."
+                  },
+                  "fecha": {
+                    "type": "string",
+                    "description": "ISO date completa si conocida (YYYY-MM-DD), o solo año."
+                  },
+                  "url_oficial": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL .gov.co al texto oficial de la resolución."
+                  }
+                },
+                "additionalProperties": false
+              },
+              "estado_registro": {
+                "type": "string",
+                "enum": [
+                  "vigente",
+                  "derogada",
+                  "en_renovacion",
+                  "desconocido"
+                ],
+                "description": "Default 'desconocido' si no se ha verificado."
+              },
+              "resoluciones_relacionadas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Otras resoluciones ICA/MADS vinculadas a la variedad (enmiendas, renovaciones)."
+              },
+              "subregiones_naturales_ica": {
+                "type": "array",
+                "description": "ICA inscribe variedades por subregión natural (no por departamentos). Enum cerrado validado por AMB-22.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "nombre"
+                  ],
+                  "properties": {
+                    "nombre": {
+                      "type": "string",
+                      "enum": [
+                        "Region Andina",
+                        "Caribe Seco",
+                        "Caribe Humedo",
+                        "Pacifica",
+                        "Valles Interandinos",
+                        "Amazonia",
+                        "Orinoquia",
+                        "Nudo de los Pastos",
+                        "Altiplano Cundiboyacense"
+                      ]
+                    },
+                    "estratos_altitudinales_msnm": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "min"
+                        ],
+                        "properties": {
+                          "min": {
+                            "type": "number"
+                          },
+                          "max": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "etiqueta": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "departamentos_inferidos": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Departamentos donde la variedad se cultiva (inferencia chagra, no parte del registro ICA oficial)."
+              },
+              "productividad": {
+                "type": "object",
+                "properties": {
+                  "rendimiento_promedio_t_ha": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "desviacion_estandar_t_ha": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "rendimiento_tradicional_t_ha_comparado": {
+                    "type": "object",
+                    "properties": {
+                      "min": {
+                        "type": "number"
+                      },
+                      "max": {
+                        "type": "number"
+                      },
+                      "fuente_comparacion": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "ciclo_meses": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
+                  "tipo_dato": {
+                    "type": "string",
+                    "enum": [
+                      "experimental",
+                      "comercial",
+                      "campo_productores",
+                      "modelo_estimado"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "caracteristicas_distintivas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "resistencias_documentadas": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "disponibilidad_semilla": {
+                "type": "object",
+                "properties": {
+                  "tipo_propagacion": {
+                    "type": "string",
+                    "enum": [
+                      "sexual_semilla",
+                      "asexual_propagulo",
+                      "asexual_tuberculo_semilla",
+                      "asexual_estaca",
+                      "asexual_rizoma",
+                      "asexual_microprop",
+                      "mixto"
+                    ]
+                  },
+                  "puntos_venta_oficiales": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "nombre"
+                      ],
+                      "properties": {
+                        "nombre": {
+                          "type": "string"
+                        },
+                        "ciudad": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "requiere_licencia_multiplicador": {
+                    "type": "boolean"
+                  },
+                  "norma_aplicable": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "ano_liberacion": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "source_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "fuente_principal": {
+                "type": "object",
+                "properties": {
+                  "tipo": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "fecha_acceso": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "nota_editorial": {
+                "type": "string",
+                "description": "Disclaimer obligatorio. Texto canónico: 'Información referencial recopilada de fuentes públicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolución oficial antes de tomar decisiones comerciales.'"
+              },
+              "fecha_ingreso_chagra": {
+                "type": "string"
+              },
+              "ultima_revision_chagra": {
+                "type": "string"
+              },
+              "_curation_status": {
+                "type": "string"
+              },
+              "_revisor": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
           }
         },
         "altitud_msnm": {

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -367,6 +367,162 @@ function validateAmb17_tierACoverage(catalog) {
   return errors;
 }
 
+// AMB-19: normativa_colombiana[].autoridad ∈ enum cerrado de entidades públicas
+// colombianas. Origen del validador: auditoría agroecológica 2026-05-21 (Pasada
+// 3-5) identificó 7 species con autoridad mal asignada — ICA confundido con
+// MinCultura (yajé/brugmansia patrimonio cultural), MADS confundido con
+// MinSalud (cannabis Res. 577/2017), ICA confundido con IAvH (thunbergia). El
+// campo era free-form string en schema v3.1, lo que permitía typos sin detectar.
+const AUTORIDAD_ENUM = new Set([
+  'MADS',
+  'ICA',
+  'IAvH',
+  'AGROSAVIA',
+  'MinCultura',
+  'MinSalud',
+  'MinJusticia',
+  'CAR Cundinamarca',
+  'CORPOBOYACA',
+  'CORPOBOYACÁ',
+  'Secretaria Distrital Ambiente',
+  'Secretaría Distrital Ambiente',
+  'Secretaría Distrital de Ambiente Bogotá',
+  'Secretaria Distrital de Ambiente Bogota',
+  'Consejo Nacional de Estupefacientes',
+  'DIAN',
+  'IUCN',
+  'UICN',
+  'IDEAM',
+  'IGAC',
+  'CITES',
+]);
+function validateAmb19_autoridadEnum(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const norms = sp.normativa_colombiana;
+    if (!Array.isArray(norms)) continue;
+    for (let i = 0; i < norms.length; i++) {
+      const aut = norms[i]?.autoridad;
+      if (typeof aut === 'string' && aut.length > 0 && !AUTORIDAD_ENUM.has(aut)) {
+        errors.push(`AMB-19 [${sp.id}.normativa_colombiana[${i}].autoridad]: "${aut}" no está en enum canónico (MADS/ICA/IAvH/AGROSAVIA/MinCultura/MinSalud/MinJusticia/CAR Cundinamarca/CORPOBOYACÁ/Secretaría Distrital Ambiente/Consejo Nacional de Estupefacientes/DIAN/IUCN/IDEAM/IGAC/CITES)`);
+      }
+    }
+  }
+  return errors;
+}
+
+// AMB-20: variedades_registradas_ica strict. Cada variedad debe tener al menos
+// nombre_comercial, obtentor.nombre, resolucion_ica.numero, nota_editorial. La
+// estructura completa la valida el JSON Schema; este validador catchea
+// regresiones donde un script de batch insertó una variedad incompleta.
+function validateAmb20_variedadesIca(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const vs = sp.variedades_registradas_ica;
+    if (!Array.isArray(vs) || vs.length === 0) continue;
+    vs.forEach((v, i) => {
+      if (!v.nombre_comercial) {
+        errors.push(`AMB-20 [${sp.id}.variedades_registradas_ica[${i}]]: falta nombre_comercial`);
+      }
+      if (!v.obtentor?.nombre) {
+        errors.push(`AMB-20 [${sp.id}.variedades_registradas_ica[${i}]]: falta obtentor.nombre`);
+      }
+      if (!v.resolucion_ica?.numero) {
+        errors.push(`AMB-20 [${sp.id}.variedades_registradas_ica[${i}]]: falta resolucion_ica.numero`);
+      }
+      if (!v.nota_editorial || v.nota_editorial.length < 50) {
+        errors.push(`AMB-20 [${sp.id}.variedades_registradas_ica[${i}]]: nota_editorial obligatoria (≥50 chars) para honestidad epistémica`);
+      }
+    });
+  }
+  return errors;
+}
+
+// AMB-21: formato resolución ICA. Regex \d{5,6}/\d{4}. Cubre los formatos
+// reales del DR consolidado: 00015201/2019, 17702/2019, 067516/2020, etc.
+const RES_ICA_FORMAT = /^\d{5,6}\/\d{4}$/;
+function validateAmb21_resolucionIcaFormat(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const vs = sp.variedades_registradas_ica;
+    if (!Array.isArray(vs)) continue;
+    vs.forEach((v, i) => {
+      const num = v.resolucion_ica?.numero;
+      if (typeof num === 'string' && !RES_ICA_FORMAT.test(num)) {
+        errors.push(`AMB-21 [${sp.id}.variedades_registradas_ica[${i}].resolucion_ica.numero]: "${num}" no matches formato NNNNN[N]/AAAA`);
+      }
+    });
+  }
+  return errors;
+}
+
+// AMB-22: subregiones_naturales_ica ∈ enum cerrado. ICA inscribe variedades
+// por subregión natural (no por departamentos). Lista del DR consolidado +
+// las dos zonas micro-altitudinales del Altiplano y Nudo de Pastos.
+const SUBREGIONES_ICA = new Set([
+  'Region Andina',
+  'Caribe Seco',
+  'Caribe Humedo',
+  'Pacifica',
+  'Valles Interandinos',
+  'Amazonia',
+  'Orinoquia',
+  'Nudo de los Pastos',
+  'Altiplano Cundiboyacense',
+]);
+function validateAmb22_subregionesEnum(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const vs = sp.variedades_registradas_ica;
+    if (!Array.isArray(vs)) continue;
+    vs.forEach((v, i) => {
+      const subs = v.subregiones_naturales_ica;
+      if (!Array.isArray(subs)) return;
+      subs.forEach((s, j) => {
+        if (s?.nombre && !SUBREGIONES_ICA.has(s.nombre)) {
+          errors.push(`AMB-22 [${sp.id}.variedades_registradas_ica[${i}].subregiones_naturales_ica[${j}].nombre]: "${s.nombre}" no está en enum canónico`);
+        }
+      });
+    });
+  }
+  return errors;
+}
+
+// AMB-23: source.tier ∈ {A, B, C} obligatorio. Catálogo v3.1 tiene
+// mayoría con tier=A/B pero algunas sources legacy sin tier — eso es ambigüedad
+// editorial. Forzar tier explícito facilita auditorías futuras.
+function validateAmb23_sourceTier(catalog) {
+  const errors = [];
+  const VALID_TIERS = new Set(['A', 'B', 'C']);
+  for (const src of catalog.sources || []) {
+    if (!src.tier) {
+      errors.push(`AMB-23 [sources.${src.id}]: falta campo tier (debe ser A/B/C)`);
+    } else if (!VALID_TIERS.has(src.tier)) {
+      errors.push(`AMB-23 [sources.${src.id}.tier]: "${src.tier}" no está en enum {A, B, C}`);
+    }
+  }
+  return errors;
+}
+
+// AMB-24: species con endemica/endemica_critica/en_peligro debería tener
+// conservation_status + (idealmente) IUCN category o nota documentando la
+// fuente. Para no romper el seed legacy, este validador es soft: solo emite
+// warning cuando endemica_critica sin nota_conservacion / clasificacion_uicn.
+function validateAmb24_endemicaConservation(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const cs = sp.conservation_status;
+    if (cs === 'endemica_critica' || cs === 'endemica_colombia') {
+      const hasIucn = typeof sp.clasificacion_uicn === 'string' && sp.clasificacion_uicn.length > 0;
+      const hasNote = typeof sp.nota_conservacion === 'string' && sp.nota_conservacion.length > 0;
+      if (!hasIucn && !hasNote) {
+        errors.push(`AMB-24 [${sp.id}]: conservation_status="${cs}" requiere clasificacion_uicn o nota_conservacion`);
+      }
+    }
+  }
+  return errors;
+}
+
 // AMB-18: roundtrip de formato. JSON.stringify(parsed, null, 2) === raw file.
 // Detecta bugs de indentación introducidos por generators que escriben texto
 // directo (e.g. TIER1 minimax dejó "source_ids": [ sin indent en PR #728).
@@ -444,6 +600,40 @@ const semanticChecks = [
   ['AMB-18 format roundtrip', () => {
     const arr = validateAmb18_formatRoundtrip(CATALOG_PATH);
     return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+  }],
+  // AMB-19..24 introducidos 2026-05-21 tras auditoría agroecológica (Pasadas
+  // 3-5-7). Schema v3.2 formaliza variedades_registradas_ica + enum cerrado
+  // de autoridades. Soft mode (warnings only) por default para no romper seed
+  // legacy mientras se aplican fixes batch a normativa_colombiana.
+  // AMB-19..22 + AMB-24: soft mode default (warnings) — el seed legacy v3.1
+  // tiene casos pre-existentes (autoridades regionales con typos, species
+  // endémicas sin clasificacion_uicn ni nota_conservacion). Validators
+  // capturan regresiones nuevas con --strict; en lefthook/CI quedan como
+  // warnings hasta completar el sweep de catálogo. AMB-20/21/22 son strict
+  // dentro de variedades_registradas_ica (estructura nueva, sin legacy).
+  ['AMB-19 autoridad enum canónico', (c) => {
+    const arr = validateAmb19_autoridadEnum(c);
+    return LENIENT_SCHEMA ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+  }],
+  ['AMB-20 variedades_registradas_ica strict', (c) => ({
+    errors: validateAmb20_variedadesIca(c),
+    warnings: [],
+  })],
+  ['AMB-21 resolucion ICA formato NNNNN/AAAA', (c) => ({
+    errors: validateAmb21_resolucionIcaFormat(c),
+    warnings: [],
+  })],
+  ['AMB-22 subregiones_naturales_ica enum', (c) => ({
+    errors: validateAmb22_subregionesEnum(c),
+    warnings: [],
+  })],
+  ['AMB-23 source.tier ∈ {A,B,C}', (c) => {
+    const arr = validateAmb23_sourceTier(c);
+    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+  }],
+  ['AMB-24 endémica con conservation context', (c) => {
+    const arr = validateAmb24_endemicaConservation(c);
+    return LENIENT_SCHEMA ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
   }],
 ];
 


### PR DESCRIPTION
## Summary

Cierre parcial de holes pendientes de auditoría agroecológica 2026-05-21 (Pasadas 4, 5, 6, 7). Implementa:

- **Pasada 5 (validadores AMB-19..24)** — 6 nuevos validadores semánticos completos:
  - AMB-19: `normativa_colombiana[].autoridad` ∈ enum canónico (MADS, ICA, IAvH, AGROSAVIA, MinCultura, MinSalud, MinJusticia, CAR Cundinamarca, CORPOBOYACÁ, Secretaría Distrital Ambiente Bogotá, Consejo Nacional de Estupefacientes, DIAN, IUCN, IDEAM, IGAC, CITES). Detecta confusión sistémica ICA↔IAvH↔MinCultura↔MinSalud documentada en Pasadas 3 y 5.
  - AMB-20: `variedades_registradas_ica` strict — exige `nombre_comercial` + `obtentor.nombre` + `resolucion_ica.numero` + `nota_editorial ≥50 chars`.
  - AMB-21: formato resolución ICA regex `\d{5,6}/\d{4}`.
  - AMB-22: `subregiones_naturales_ica.nombre` ∈ enum cerrado (Región Andina, Caribe Seco/Húmedo, Pacífica, Valles Interandinos, Amazonía, Orinoquía, Nudo de los Pastos, Altiplano Cundiboyacense).
  - AMB-23: `source.tier` ∈ {A, B, C} obligatorio.
  - AMB-24: species `endemica_colombia`/`endemica_critica` requiere `clasificacion_uicn` o `nota_conservacion` (soft en --lenient-schema).

- **Pasada 4 (schema + datos pilot)** — formaliza `variedades_registradas_ica` con estructura DR-Claude-v2 (schema-v3.1.json) e inserta 5 variedades piloto:
  - **Arracacha AGROSAVIA La 22** → `arracacia_xanthorrhiza_agrosavia_la22` (Res. 015201/2019, Region Andina, 34.8 t/ha)
  - **Papa Sol Andina + AGROSAVIA Estrella** → `solanum_phureja` (2 vars en Altiplano Cundiboyacense)
  - **Papa AGROSAVIA Alhaja + Oyanza** → `solanum_tuberosum_pastusa_suprema` (Nudo de los Pastos, Nariño-Cauca)
  - Cada variedad lleva `nota_editorial` canónica "sin convenio formal AGROSAVIA/ICA" + `_curation_status: PILOT_PASADA_4`.

## Validators status

```
✓ AMB-05 altitud chain
✓ AMB-10 companions/antagonists symmetry
✓ AMB-13 cross-refs existencia
✓ AMB-14 invasor consistency
✓ AMB-15 scale_viability ↔ manejo_por_escala
✓ AMB-16 valor_pedagogico ≥200 chars
✓ AMB-17 source_ids ≥2 Tier A
✓ AMB-18 format roundtrip
✓ AMB-19 autoridad enum canónico
✓ AMB-20 variedades_registradas_ica strict
✓ AMB-21 resolucion ICA formato NNNNN/AAAA
✓ AMB-22 subregiones_naturales_ica enum
✓ AMB-23 source.tier ∈ {A,B,C}
⚠ AMB-24 endémica con conservation context: 8 warning(s) — sweep batch pendiente
```

`node scripts/validate-catalog.mjs --lenient-schema` pasa (lefthook gate).

## Holes NO cerrados en este PR (explícito)

- Pasada 6: AGE escape smoke test, edges normativa→Authority, BP fungal regresión — requieren acceso al host `alpha` postgres-farm + ETL run, out of PR scope.
- Pasada 6: Beauveria bassiana NUEVA species + consolidación sinónimos áfidos `aka[]` — requieren batch corpus dedicado (no quick wins).
- Pasada 7 UX: botón "Reportar invasora", filtros UI por subregión natural, tooltip `conservation_status`, empty state biopreparados, banner exención PEA Res. 067516/2020 — requieren componentes React nuevos significativos. El disclaimer "información referencial" en variedades_ica YA está embedded como `nota_editorial` obligatoria (validador AMB-20 lo enforza).

## Test plan

- [x] `node scripts/validate-catalog.mjs --lenient-schema` pasa
- [x] Lefthook pre-commit pasa (eslint, secret-scan, catalog-validator, conventional commit)
- [ ] CI catalog-validate.yml en este PR
- [ ] Vitest unit suite (no se cambió código JS productivo, solo schema + JSON + validator script)
- [ ] Review humano del corte: 5 variedades pilot vs DR consolidado

🤖 Generated with [Claude Code](https://claude.com/claude-code)
