### PR TITLE
fix(deploy): unblock CI lint — usar showThinkingAvatar declarada + visibility annotations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,40 @@ jobs:
         name: Lint
         # max-warnings 20 ya es el cap; si excede, debe BLOQUEAR el deploy.
         # Removido continue-on-error: true que silenciaba errores fatales.
-        run: npm run lint -- --max-warnings 20
+        #
+        # Visibilidad (2026-05-21 — Task #77): el lint step NO es required
+        # check del PR (corre solo `on: push` a main), así que un PR puede
+        # mergearse verde y romper deploy aquí sin warning visible en la UI
+        # del PR — prod queda atrás N versiones hasta que alguien revise
+        # `gh run list --workflow=deploy.yml`. Para mitigar el silent-block:
+        #   1) Capturamos stdout+stderr a un archivo.
+        #   2) En fail, lo volcamos al $GITHUB_STEP_SUMMARY así aparece en
+        #      la home del run como banner rojo legible (no enterrado en logs).
+        #   3) Re-emitimos como ::error:: para que GitHub muestre annotations
+        #      inline en el commit y mande email con detalle (no solo
+        #      "Deploy failed" genérico).
+        run: |
+          set -o pipefail
+          if ! npm run lint -- --max-warnings 20 2>&1 | tee /tmp/lint.log; then
+            {
+              echo "## Deploy bloqueado: lint failed"
+              echo ""
+              echo "Prod chagra.guatoc.co queda atrasado hasta que el lint pase."
+              echo "Fix recomendado: rama \`fix/lint-deploy-<fecha>\` con el PR pequeño que corrige los warnings."
+              echo ""
+              echo "<details><summary>Output completo del lint</summary>"
+              echo ""
+              echo '```'
+              cat /tmp/lint.log
+              echo '```'
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
+            # Annotations inline por cada error de eslint (aparecen en commit + email).
+            grep -E "^\s+[0-9]+:[0-9]+\s+error" /tmp/lint.log | head -20 | while read -r line; do
+              echo "::error::deploy lint: $line"
+            done
+            exit 1
+          fi
 
       - if: env.SKIP_DEPLOY != '1'
         name: Verify secrets

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.159",
+  "version": "0.12.160",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v201';
+const CACHE_NAME = 'chagra-v202';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -46,7 +46,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
           aparición del primer token — el indicador del header pasa
           desapercibido porque el ojo del operador está en la ventana de
           diálogo. Acá el colibrí late en thinking + texto "Pensando…". */}
-      {isStreaming && !streamingContent && (
+      {showThinkingAvatar && (
         <div className="flex items-end gap-3 mb-4 animate-fadeIn">
           <ChagraAgentAvatar
             state="thinking"


### PR DESCRIPTION
## Summary
- **ChatHistory.jsx**: el const `showThinkingAvatar` ya estaba declarado pero el JSX seguía referenciando la expresión inline → eslint flag `no-unused-vars` → deploy bloqueado por 12 versiones sin warning en la UI de PRs (lint NO es required check de PR).
- **deploy.yml**: cuando vuelva a fallar (lo hará), el output ahora se vuelca a `$GITHUB_STEP_SUMMARY` + `::error::` annotations inline + email con detalle, no solo "Deploy failed" genérico.

## Test plan
- [x] `npm run lint -- --max-warnings 20` pasa local (exit 0)
- [x] lefthook eslint hook pasa (1.03s)
- [ ] deploy.yml run pasa en main post-merge
- [ ] `https://chagra.guatoc.co/` muestra versión `0.12.160` (chagra-v202) post-deploy

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)