### PR TITLE
feat(schema): Batch 7A — enums cerrados Pasada 7 (autoridad, validation_level, advertencia_toxicologica)

### DIFF
--- a/catalog/schema-v3.1.json
+++ b/catalog/schema-v3.1.json
@@ -936,7 +936,21 @@
                   },
                   "autoridad": {
                     "type": "string",
-                    "description": "Entidad emisora de la norma. Ej: 'MADS', 'ICA', 'Consejo Nacional de Estupefacientes', 'IAvH', 'CAR Cundinamarca'."
+                    "enum": [
+                      "MADS",
+                      "ICA",
+                      "IAvH",
+                      "AGROSAVIA",
+                      "MinCultura",
+                      "MinSalud",
+                      "MinJusticia",
+                      "CAR",
+                      "CORPOBOYACA",
+                      "SDA-Bogota",
+                      "UICN",
+                      "IDEAM"
+                    ],
+                    "description": "Entidad emisora de la norma. Enum cerrado (Batch 7A Pasada 7) — 12 valores canónicos. Variantes regionales colapsadas: 'CAR Cundinamarca' → 'CAR', 'Secretaría Distrital de Ambiente Bogotá' → 'SDA-Bogota', 'IUCN' → 'UICN'. Sweep de datos legacy queda para Batch 3A. Validador AMB-25 enforces strict."
                   },
                   "fecha_vigor": {
                     "type": "string",
@@ -979,15 +993,20 @@
         "protocolo_post_remocion": {
           "type": "string"
         },
+        "advertencia_toxicologica": {
+          "type": "string",
+          "description": "Campo opcional añadido en Batch 7A (Pasada 7). Recomendado para species cuyo valor_pedagogico menciona toxicidad (alcaloides letales, fotosensibilidad, abortifacientes, neurotóxicos). El validador AMB-27 emite warning (no error) para sugerir documentación explícita del riesgo — el sweep de poblamiento se hace en Batch 3A. Texto sugerido: contraindicación principal + dosis crítica si conocida + via de exposición + audiencia en riesgo (niños, gestantes, animales)."
+        },
         "validation_level": {
           "type": "string",
           "enum": [
             "claude_draft",
-            "operator_reviewed",
-            "agronomist_validated",
-            "community_attested"
+            "powo_validated",
+            "agrosavia_verified",
+            "expert_reviewed",
+            "published"
           ],
-          "description": "Nivel de validación. Default 'claude_draft' para entradas generadas por LLM sin revisión humana. Sube cuando el operador revisa, cuando un agrónomo con identidad registrada valida, o cuando la comunidad custodio atestigua el saber ancestral. Consumido por el módulo Pro de curación (ver ADR-016)."
+          "description": "Nivel de validación (Batch 7A Pasada 7 — enum canónico ampliado). Escala ascendente de rigor: 'claude_draft' (LLM sin revisión) → 'powo_validated' (taxonomía cruzada contra POWO/Kew) → 'agrosavia_verified' (validada contra fichas AGROSAVIA / variedades ICA) → 'expert_reviewed' (revisada por agrónomo con identidad registrada) → 'published' (apto para distribución pública del catálogo). Valores legacy 'operator_reviewed', 'agronomist_validated', 'community_attested' quedan fuera del enum nuevo — sweep migración en Batch 3A/5A. Validador AMB-26 enforces strict. Consumido por el módulo Pro de curación (ver ADR-016)."
         },
         "validated_by": {
           "type": "array",

--- a/scripts/__tests__/validate-catalog.test.mjs
+++ b/scripts/__tests__/validate-catalog.test.mjs
@@ -1,0 +1,198 @@
+/**
+ * scripts/__tests__/validate-catalog.test.mjs
+ *
+ * Cobertura unitaria de los validadores semánticos AMB-25/26/27 introducidos
+ * en Batch 7A (Pasada 7 — auditoría agroecológica 2026-05-22). El módulo
+ * principal `validate-catalog.mjs` mantiene un guard `import.meta.url`
+ * alrededor del CLI para permitir que este test importe las funciones sin
+ * disparar `process.exit()`.
+ *
+ * Convenciones de catálogo sintético:
+ * - Cada catalog de test incluye solo los campos mínimos requeridos por el
+ *   validador bajo prueba; no se valida JSON Schema completo.
+ * - Los species fixture usan id snake_case + nombre real para que un fallo
+ *   se lea de forma humana sin tener que crossref vs el seed.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  AUTORIDAD_ENUM_CANONICA_ESTRICTA,
+  VALIDATION_LEVEL_ENUM,
+  TOXICO_KEYWORDS,
+  validateAmb25_autoridadCanonicaEstricta,
+  validateAmb26_validationLevelCanonico,
+  validateAmb27_toxicoSinAdvertencia,
+} from '../validate-catalog.mjs';
+
+describe('AMB-25 — autoridad canónica estricta', () => {
+  it('expone los 12 valores canónicos exactos', () => {
+    expect(AUTORIDAD_ENUM_CANONICA_ESTRICTA.size).toBe(12);
+    for (const v of ['MADS', 'ICA', 'IAvH', 'AGROSAVIA', 'MinCultura', 'MinSalud', 'MinJusticia', 'CAR', 'CORPOBOYACA', 'SDA-Bogota', 'UICN', 'IDEAM']) {
+      expect(AUTORIDAD_ENUM_CANONICA_ESTRICTA.has(v)).toBe(true);
+    }
+  });
+
+  it('acepta autoridades en el enum sin error', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'eucalyptus_globulus',
+          normativa_colombiana: [
+            { tipo: 'regulatoria', autoridad: 'MADS', alcance: 'control invasoras' },
+            { tipo: 'regulatoria', autoridad: 'ICA', alcance: 'cuarentena' },
+          ],
+        },
+      ],
+    };
+    expect(validateAmb25_autoridadCanonicaEstricta(catalog)).toEqual([]);
+  });
+
+  it('reporta autoridades legacy fuera del enum (CAR Cundinamarca, IUCN, SDA Bogotá larga)', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'acacia_melanoxylon',
+          normativa_colombiana: [
+            { tipo: 'regulatoria', autoridad: 'CAR Cundinamarca', alcance: 'control regional' },
+            { tipo: 'estatus_conservacion', autoridad: 'IUCN', alcance: 'LC' },
+            { tipo: 'regulatoria', autoridad: 'Secretaría Distrital de Ambiente Bogotá', alcance: 'invasora distrital' },
+          ],
+        },
+      ],
+    };
+    const errors = validateAmb25_autoridadCanonicaEstricta(catalog);
+    expect(errors).toHaveLength(3);
+    expect(errors[0]).toContain('"CAR Cundinamarca"');
+    expect(errors[1]).toContain('"IUCN"');
+    expect(errors[2]).toContain('"Secretaría Distrital de Ambiente Bogotá"');
+    // Mensaje incluye sugerencia de batch responsable del sweep
+    expect(errors[0]).toContain('Batch 3A');
+  });
+
+  it('ignora species sin normativa_colombiana o normativa string legacy', () => {
+    const catalog = {
+      species: [
+        { id: 'no_norm' },
+        { id: 'legacy_string', normativa_colombiana: 'string libre legacy' },
+      ],
+    };
+    expect(validateAmb25_autoridadCanonicaEstricta(catalog)).toEqual([]);
+  });
+
+  it('ignora normativa_colombiana[i] sin autoridad', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'sin_aut',
+          normativa_colombiana: [
+            { tipo: 'contexto_etnocultural', alcance: 'patrimonio cultural' },
+          ],
+        },
+      ],
+    };
+    expect(validateAmb25_autoridadCanonicaEstricta(catalog)).toEqual([]);
+  });
+});
+
+describe('AMB-26 — validation_level canónico', () => {
+  it('expone los 5 valores canónicos exactos', () => {
+    expect(VALIDATION_LEVEL_ENUM.size).toBe(5);
+    for (const v of ['claude_draft', 'powo_validated', 'agrosavia_verified', 'expert_reviewed', 'published']) {
+      expect(VALIDATION_LEVEL_ENUM.has(v)).toBe(true);
+    }
+  });
+
+  it('acepta valores en el enum sin error', () => {
+    const catalog = {
+      species: [
+        { id: 'a', validation_level: 'claude_draft' },
+        { id: 'b', validation_level: 'powo_validated' },
+        { id: 'c', validation_level: 'agrosavia_verified' },
+        { id: 'd', validation_level: 'expert_reviewed' },
+        { id: 'e', validation_level: 'published' },
+      ],
+    };
+    expect(validateAmb26_validationLevelCanonico(catalog)).toEqual([]);
+  });
+
+  it('reporta valor legacy operator_reviewed', () => {
+    const catalog = {
+      species: [
+        { id: 'acacia_melanoxylon', validation_level: 'operator_reviewed' },
+      ],
+    };
+    const errors = validateAmb26_validationLevelCanonico(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('"operator_reviewed"');
+    expect(errors[0]).toContain('Batch 3A/5A');
+  });
+
+  it('ignora species sin validation_level', () => {
+    const catalog = { species: [{ id: 'a' }, { id: 'b', validation_level: '' }] };
+    expect(validateAmb26_validationLevelCanonico(catalog)).toEqual([]);
+  });
+});
+
+describe('AMB-27 — toxico_sin_advertencia (WARN-only)', () => {
+  it('expone keywords con tildes opcionales', () => {
+    expect(TOXICO_KEYWORDS.length).toBeGreaterThanOrEqual(5);
+    // 'tóxico' con tilde y 'toxico' sin tilde ambos matchean
+    const rx = TOXICO_KEYWORDS.find((r) => r.test('contiene compuestos tóxicos'));
+    expect(rx).toBeTruthy();
+    const rx2 = TOXICO_KEYWORDS.find((r) => r.test('contiene compuestos toxicos'));
+    expect(rx2).toBeTruthy();
+  });
+
+  it('emite warning cuando vp menciona toxicidad y falta advertencia_toxicologica', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'ruta_graveolens',
+          valor_pedagogico: 'La ruda es abortifaciente y puede causar fotosensibilidad en piel expuesta.',
+        },
+      ],
+    };
+    const warnings = validateAmb27_toxicoSinAdvertencia(catalog);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('ruta_graveolens');
+    expect(warnings[0]).toContain('advertencia_toxicologica');
+  });
+
+  it('NO emite warning si advertencia_toxicologica está presente', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'ruta_graveolens',
+          valor_pedagogico: 'La ruda es abortifaciente.',
+          advertencia_toxicologica: 'Contraindicada en gestación; ruta cutánea provoca fotodermatitis.',
+        },
+      ],
+    };
+    expect(validateAmb27_toxicoSinAdvertencia(catalog)).toEqual([]);
+  });
+
+  it('NO emite warning si vp no menciona toxicidad', () => {
+    const catalog = {
+      species: [
+        { id: 'allium_cepa', valor_pedagogico: 'La cebolla aporta vitamina C y sabor base a la sopa.' },
+      ],
+    };
+    expect(validateAmb27_toxicoSinAdvertencia(catalog)).toEqual([]);
+  });
+
+  it('matchea alcaloides letales como frase compuesta', () => {
+    const catalog = {
+      species: [
+        { id: 'datura_stramonium', valor_pedagogico: 'Contiene alcaloides letales (escopolamina, atropina) — uso ritual restringido.' },
+      ],
+    };
+    const warnings = validateAmb27_toxicoSinAdvertencia(catalog);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('alcaloide');
+  });
+
+  it('ignora species sin valor_pedagogico', () => {
+    const catalog = { species: [{ id: 'sin_vp' }] };
+    expect(validateAmb27_toxicoSinAdvertencia(catalog)).toEqual([]);
+  });
+});

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -546,118 +546,242 @@ function validateAmb18_formatRoundtrip(catalogPath) {
   return [`AMB-18: formato no normalizado (length diff: raw=${rawLines.length} líneas vs fmt=${fmtLines.length})`];
 }
 
-// ----------------------------------------------------------------
-// Main
-// ----------------------------------------------------------------
-
-console.log('Chagra Catalog Validator v3.1');
-console.log(`  catalog: ${CATALOG_PATH}`);
-console.log(`  schema:  ${SCHEMA_PATH}`);
-console.log('');
-
-const schema = loadJSON(SCHEMA_PATH);
-const catalog = loadJSON(CATALOG_PATH);
-
-// 1. JSON Schema
-const schemaErrors = [];
-validate(catalog, schema, schema, '$', schemaErrors);
-if (schemaErrors.length) {
-  if (LENIENT_SCHEMA) {
-    warn(`JSON Schema v3.1: ${schemaErrors.length} warning(s) (lenient)`);
-    for (const e of schemaErrors.slice(0, 10)) console.warn(`    ${e}`);
-    if (schemaErrors.length > 10) console.warn(`    ... +${schemaErrors.length - 10} más`);
-  } else {
-    for (const e of schemaErrors) console.error(`  ✗ schema: ${e}`);
-    die(1, `${schemaErrors.length} errores de JSON Schema (usa --lenient-schema para downgrade a warnings)`);
+// AMB-25: autoridad ∈ enum canónico ESTRICTO (Batch 7A Pasada 7). Distinto de
+// AMB-19 (legacy laxo con variantes regionales: 'CAR Cundinamarca',
+// 'Secretaría Distrital de Ambiente Bogotá', 'IUCN'). Schema v3.1 cierra el
+// enum a 12 valores canónicos:
+//   MADS, ICA, IAvH, AGROSAVIA, MinCultura, MinSalud, MinJusticia,
+//   CAR, CORPOBOYACA, SDA-Bogota, UICN, IDEAM
+// Variantes legacy quedan fuera — el sweep de datos lo hace Batch 3A. Este
+// validador SOLO reporta hallazgos (no rompe build); en CI/lefthook corre
+// dentro de --lenient-schema para emitir warnings hasta completar el sweep.
+export const AUTORIDAD_ENUM_CANONICA_ESTRICTA = new Set([
+  'MADS',
+  'ICA',
+  'IAvH',
+  'AGROSAVIA',
+  'MinCultura',
+  'MinSalud',
+  'MinJusticia',
+  'CAR',
+  'CORPOBOYACA',
+  'SDA-Bogota',
+  'UICN',
+  'IDEAM',
+]);
+export function validateAmb25_autoridadCanonicaEstricta(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const norms = sp.normativa_colombiana;
+    if (!Array.isArray(norms)) continue;
+    for (let i = 0; i < norms.length; i++) {
+      const aut = norms[i]?.autoridad;
+      if (typeof aut === 'string' && aut.length > 0 && !AUTORIDAD_ENUM_CANONICA_ESTRICTA.has(aut)) {
+        errors.push(`AMB-25 [${sp.id}.normativa_colombiana[${i}].autoridad]: "${aut}" no está en enum canónico estricto (MADS/ICA/IAvH/AGROSAVIA/MinCultura/MinSalud/MinJusticia/CAR/CORPOBOYACA/SDA-Bogota/UICN/IDEAM). Sweep migración: Batch 3A.`);
+      }
+    }
   }
-} else {
-  ok('JSON Schema v3.1 — PASS');
+  return errors;
 }
 
-// 2. Validadores semánticos
-// Nota: AMB-16/17/18 introducidos 2026-05-16 tras detectar bugs en species PRs
-// auto-generados (vp corto, source_ids sin Tier A, formato sin roundtrip).
-// SEED_MODE relaja AMB-16/17 a warnings: el catálogo seed legacy aún tiene
-// entradas pre-pipeline con vp/sources incompletos que se completan progresivo
-// vía batches. main no debe REGRESAR — el guard es para PRs nuevos, no existing.
-const semanticChecks = [
-  ['AMB-05 altitud chain', (c) => ({ errors: validateAmb05_altitudChain(c), warnings: [] })],
-  ['AMB-10 companions/antagonists symmetry', (c) => {
-    const arr = validateAmb10_companionsSymmetry(c);
-    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
-  ['AMB-13 cross-refs existencia', (c) => validateAmb13_crossRefs(c, SEED_MODE)],
-  ['AMB-14 invasor consistency', (c) => ({ errors: validateAmb14_invasorConsistency(c), warnings: [] })],
-  ['AMB-15 scale_viability ↔ manejo_por_escala', (c) => ({ errors: validateAmb15_scaleCoherence(c), warnings: [] })],
-  ['AMB-16 valor_pedagogico ≥200 chars', (c) => {
-    const arr = validateAmb16_vpLength(c);
-    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
-  ['AMB-17 source_ids ≥2 Tier A', (c) => {
-    const arr = validateAmb17_tierACoverage(c);
-    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
-  ['AMB-18 format roundtrip', () => {
-    const arr = validateAmb18_formatRoundtrip(CATALOG_PATH);
-    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
-  // AMB-19..24 introducidos 2026-05-21 tras auditoría agroecológica (Pasadas
-  // 3-5-7). Schema v3.2 formaliza variedades_registradas_ica + enum cerrado
-  // de autoridades. Soft mode (warnings only) por default para no romper seed
-  // legacy mientras se aplican fixes batch a normativa_colombiana.
-  // AMB-19..22 + AMB-24: soft mode default (warnings) — el seed legacy v3.1
-  // tiene casos pre-existentes (autoridades regionales con typos, species
-  // endémicas sin clasificacion_uicn ni nota_conservacion). Validators
-  // capturan regresiones nuevas con --strict; en lefthook/CI quedan como
-  // warnings hasta completar el sweep de catálogo. AMB-20/21/22 son strict
-  // dentro de variedades_registradas_ica (estructura nueva, sin legacy).
-  ['AMB-19 autoridad enum canónico', (c) => {
-    const arr = validateAmb19_autoridadEnum(c);
-    return LENIENT_SCHEMA ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
-  ['AMB-20 variedades_registradas_ica strict', (c) => ({
-    errors: validateAmb20_variedadesIca(c),
-    warnings: [],
-  })],
-  ['AMB-21 resolucion ICA formato NNNNN/AAAA', (c) => ({
-    errors: validateAmb21_resolucionIcaFormat(c),
-    warnings: [],
-  })],
-  ['AMB-22 subregiones_naturales_ica enum', (c) => ({
-    errors: validateAmb22_subregionesEnum(c),
-    warnings: [],
-  })],
-  ['AMB-23 source.tier ∈ {A,B,C}', (c) => {
-    const arr = validateAmb23_sourceTier(c);
-    return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
-  ['AMB-24 endémica con conservation context', (c) => {
-    const arr = validateAmb24_endemicaConservation(c);
-    return LENIENT_SCHEMA ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
-  }],
+// AMB-26: validation_level ∈ enum canónico ampliado (Batch 7A Pasada 7).
+// Reemplaza el legacy {claude_draft, operator_reviewed, agronomist_validated,
+// community_attested} por la escala nueva alineada al pipeline POWO/AGROSAVIA:
+//   claude_draft, powo_validated, agrosavia_verified, expert_reviewed, published
+// Solo verifica cuando el campo está presente (es opcional en species).
+export const VALIDATION_LEVEL_ENUM = new Set([
+  'claude_draft',
+  'powo_validated',
+  'agrosavia_verified',
+  'expert_reviewed',
+  'published',
+]);
+export function validateAmb26_validationLevelCanonico(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const vl = sp.validation_level;
+    if (typeof vl === 'string' && vl.length > 0 && !VALIDATION_LEVEL_ENUM.has(vl)) {
+      errors.push(`AMB-26 [${sp.id}.validation_level]: "${vl}" no está en enum canónico (claude_draft/powo_validated/agrosavia_verified/expert_reviewed/published). Sweep migración: Batch 3A/5A.`);
+    }
+  }
+  return errors;
+}
+
+// AMB-27 (WARN): species con menciones de toxicidad en valor_pedagogico pero
+// SIN advertencia_toxicologica explícita. Guía Batch 3A para poblar el campo
+// nuevo (advertencia_toxicologica) de forma sistemática. Match case-insensitive
+// por keywords agroecológicas reales: "tóxico", "abortifaciente",
+// "fotosensibilidad", "neurotoxic" (cubre neurotóxico/neurotoxic), "alcaloide
+// letal". Tildes opcionales (regex con tolerancia). Soft mode siempre — este
+// validador NUNCA emite errors, solo warnings.
+export const TOXICO_KEYWORDS = [
+  /t[oó]xic[oa]s?/i,
+  /abortifacient[eo]s?/i,
+  /fotosensibilidad/i,
+  /neurot[oó]xic[oa]s?/i,
+  /neurotoxic/i,
+  /alcaloide[s]?\s+letal[es]?/i,
 ];
-
-if (SEED_MODE) console.log('  mode:    SEED (refs a species ausentes = warnings)\n');
-
-const allSemanticErrors = [];
-for (const [label, fn] of semanticChecks) {
-  const { errors, warnings } = fn(catalog);
-  if (errors.length) {
-    console.error(`  ✗ ${label}: ${errors.length} error(es)`);
-    for (const e of errors) console.error(`    ${e}`);
-    allSemanticErrors.push(...errors);
-  } else if (warnings.length) {
-    warn(`${label}: ${warnings.length} warning(s) — refs a species aún no migradas`);
-    for (const w of warnings.slice(0, 5)) console.warn(`    ${w}`);
-    if (warnings.length > 5) console.warn(`    ... +${warnings.length - 5} más`);
-  } else {
-    ok(label);
+export function validateAmb27_toxicoSinAdvertencia(catalog) {
+  const warnings = [];
+  for (const sp of catalog.species || []) {
+    const vp = typeof sp.valor_pedagogico === 'string' ? sp.valor_pedagogico : '';
+    if (!vp) continue;
+    const hits = TOXICO_KEYWORDS.filter((rx) => rx.test(vp)).map((rx) => rx.source);
+    if (hits.length === 0) continue;
+    const hasAdvertencia = typeof sp.advertencia_toxicologica === 'string' && sp.advertencia_toxicologica.trim().length > 0;
+    if (!hasAdvertencia) {
+      warnings.push(`AMB-27 [${sp.id}]: valor_pedagogico menciona toxicidad [${hits.join(', ')}] pero falta advertencia_toxicologica. Sweep poblamiento: Batch 3A.`);
+    }
   }
+  return warnings;
 }
 
-if (allSemanticErrors.length) die(2, `${allSemanticErrors.length} errores semánticos`);
+// ----------------------------------------------------------------
+// Main (CLI). Gated por `import.meta.url === file://${process.argv[1]}` para
+// permitir importar las funciones validador desde tests (scripts/__tests__/
+// validate-catalog.test.mjs) sin que se dispare process.exit(). Patrón usado
+// también en scripts/catalog-to-age.mjs.
+// ----------------------------------------------------------------
 
-console.log('');
-console.log('\x1b[32m✓ Catálogo válido\x1b[0m');
-console.log(`  ${(catalog.species || []).length} especies, ${(catalog.biopreparados || []).length} biopreparados, ${(catalog.sources || []).length} sources`);
-process.exit(0);
+const IS_CLI = import.meta.url === `file://${process.argv[1]}`;
+
+if (IS_CLI) {
+  runCli();
+}
+
+function runCli() {
+  console.log('Chagra Catalog Validator v3.1');
+  console.log(`  catalog: ${CATALOG_PATH}`);
+  console.log(`  schema:  ${SCHEMA_PATH}`);
+  console.log('');
+
+  const schema = loadJSON(SCHEMA_PATH);
+  const catalog = loadJSON(CATALOG_PATH);
+
+  // 1. JSON Schema
+  const schemaErrors = [];
+  validate(catalog, schema, schema, '$', schemaErrors);
+  if (schemaErrors.length) {
+    if (LENIENT_SCHEMA) {
+      warn(`JSON Schema v3.1: ${schemaErrors.length} warning(s) (lenient)`);
+      for (const e of schemaErrors.slice(0, 10)) console.warn(`    ${e}`);
+      if (schemaErrors.length > 10) console.warn(`    ... +${schemaErrors.length - 10} más`);
+    } else {
+      for (const e of schemaErrors) console.error(`  ✗ schema: ${e}`);
+      die(1, `${schemaErrors.length} errores de JSON Schema (usa --lenient-schema para downgrade a warnings)`);
+    }
+  } else {
+    ok('JSON Schema v3.1 — PASS');
+  }
+
+  // 2. Validadores semánticos
+  // Nota: AMB-16/17/18 introducidos 2026-05-16 tras detectar bugs en species PRs
+  // auto-generados (vp corto, source_ids sin Tier A, formato sin roundtrip).
+  // SEED_MODE relaja AMB-16/17 a warnings: el catálogo seed legacy aún tiene
+  // entradas pre-pipeline con vp/sources incompletos que se completan progresivo
+  // vía batches. main no debe REGRESAR — el guard es para PRs nuevos, no existing.
+  const semanticChecks = [
+    ['AMB-05 altitud chain', (c) => ({ errors: validateAmb05_altitudChain(c), warnings: [] })],
+    ['AMB-10 companions/antagonists symmetry', (c) => {
+      const arr = validateAmb10_companionsSymmetry(c);
+      return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    ['AMB-13 cross-refs existencia', (c) => validateAmb13_crossRefs(c, SEED_MODE)],
+    ['AMB-14 invasor consistency', (c) => ({ errors: validateAmb14_invasorConsistency(c), warnings: [] })],
+    ['AMB-15 scale_viability ↔ manejo_por_escala', (c) => ({ errors: validateAmb15_scaleCoherence(c), warnings: [] })],
+    ['AMB-16 valor_pedagogico ≥200 chars', (c) => {
+      const arr = validateAmb16_vpLength(c);
+      return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    ['AMB-17 source_ids ≥2 Tier A', (c) => {
+      const arr = validateAmb17_tierACoverage(c);
+      return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    ['AMB-18 format roundtrip', () => {
+      const arr = validateAmb18_formatRoundtrip(CATALOG_PATH);
+      return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    // AMB-19..24 introducidos 2026-05-21 tras auditoría agroecológica (Pasadas
+    // 3-5-7). Schema v3.2 formaliza variedades_registradas_ica + enum cerrado
+    // de autoridades. Soft mode (warnings only) por default para no romper seed
+    // legacy mientras se aplican fixes batch a normativa_colombiana.
+    // AMB-19..22 + AMB-24: soft mode default (warnings) — el seed legacy v3.1
+    // tiene casos pre-existentes (autoridades regionales con typos, species
+    // endémicas sin clasificacion_uicn ni nota_conservacion). Validators
+    // capturan regresiones nuevas con --strict; en lefthook/CI quedan como
+    // warnings hasta completar el sweep de catálogo. AMB-20/21/22 son strict
+    // dentro de variedades_registradas_ica (estructura nueva, sin legacy).
+    ['AMB-19 autoridad enum canónico', (c) => {
+      const arr = validateAmb19_autoridadEnum(c);
+      return LENIENT_SCHEMA ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    ['AMB-20 variedades_registradas_ica strict', (c) => ({
+      errors: validateAmb20_variedadesIca(c),
+      warnings: [],
+    })],
+    ['AMB-21 resolucion ICA formato NNNNN/AAAA', (c) => ({
+      errors: validateAmb21_resolucionIcaFormat(c),
+      warnings: [],
+    })],
+    ['AMB-22 subregiones_naturales_ica enum', (c) => ({
+      errors: validateAmb22_subregionesEnum(c),
+      warnings: [],
+    })],
+    ['AMB-23 source.tier ∈ {A,B,C}', (c) => {
+      const arr = validateAmb23_sourceTier(c);
+      return SEED_MODE ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    ['AMB-24 endémica con conservation context', (c) => {
+      const arr = validateAmb24_endemicaConservation(c);
+      return LENIENT_SCHEMA ? { errors: [], warnings: arr } : { errors: arr, warnings: [] };
+    }],
+    // AMB-25/26/27 introducidos 2026-05-22 (Batch 7A Pasada 7 — auditoría
+    // agroecológica). Soft mode default: AMB-25/26 reportan como warnings hasta
+    // que Batch 3A/5A complete el sweep de datos legacy (CAR Cundinamarca →
+    // CAR, IUCN → UICN, operator_reviewed → expert_reviewed, etc.). AMB-27
+    // siempre es warning-only (guía de poblamiento del campo nuevo
+    // advertencia_toxicologica).
+    ['AMB-25 autoridad canónica estricta', (c) => {
+      const arr = validateAmb25_autoridadCanonicaEstricta(c);
+      return LENIENT_SCHEMA || SEED_MODE
+        ? { errors: [], warnings: arr }
+        : { errors: arr, warnings: [] };
+    }],
+    ['AMB-26 validation_level canónico', (c) => {
+      const arr = validateAmb26_validationLevelCanonico(c);
+      return LENIENT_SCHEMA || SEED_MODE
+        ? { errors: [], warnings: arr }
+        : { errors: arr, warnings: [] };
+    }],
+    ['AMB-27 toxico_sin_advertencia (WARN)', (c) => ({
+      errors: [],
+      warnings: validateAmb27_toxicoSinAdvertencia(c),
+    })],
+  ];
+
+  if (SEED_MODE) console.log('  mode:    SEED (refs a species ausentes = warnings)\n');
+
+  const allSemanticErrors = [];
+  for (const [label, fn] of semanticChecks) {
+    const { errors, warnings } = fn(catalog);
+    if (errors.length) {
+      console.error(`  ✗ ${label}: ${errors.length} error(es)`);
+      for (const e of errors) console.error(`    ${e}`);
+      allSemanticErrors.push(...errors);
+    } else if (warnings.length) {
+      warn(`${label}: ${warnings.length} warning(s) — refs a species aún no migradas`);
+      for (const w of warnings.slice(0, 5)) console.warn(`    ${w}`);
+      if (warnings.length > 5) console.warn(`    ... +${warnings.length - 5} más`);
+    } else {
+      ok(label);
+    }
+  }
+
+  if (allSemanticErrors.length) die(2, `${allSemanticErrors.length} errores semánticos`);
+
+  console.log('');
+  console.log('\x1b[32m✓ Catálogo válido\x1b[0m');
+  console.log(`  ${(catalog.species || []).length} especies, ${(catalog.biopreparados || []).length} biopreparados, ${(catalog.sources || []).length} sources`);
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Batch 7A — Pasada 7 (auditoría agroecológica Chagra). **Blocker** que habilita Batches 2A/3A/5A.

Cierra enums clave del schema + añade 3 validators (AMB-25/26/27) que reportan datos legacy fuera de canon — sin modificar species. El sweep de datos queda para Batch 3A/5A.

## Cambios

### Schema (`catalog/schema-v3.1.json`)

- **`normativa_colombiana[].autoridad`** → enum cerrado de **12 valores canónicos**:
  ```
  MADS, ICA, IAvH, AGROSAVIA, MinCultura, MinSalud, MinJusticia,
  CAR, CORPOBOYACA, SDA-Bogota, UICN, IDEAM
  ```
  Variantes regionales colapsadas: `CAR Cundinamarca` → `CAR`, `Secretaría Distrital de Ambiente Bogotá` → `SDA-Bogota`, `IUCN` → `UICN`.

- **`validation_level`** → enum nuevo alineado al pipeline POWO/AGROSAVIA:
  ```
  claude_draft, powo_validated, agrosavia_verified, expert_reviewed, published
  ```
  Legacy fuera: `operator_reviewed`, `agronomist_validated`, `community_attested`.

- **`advertencia_toxicologica`** — campo opcional nuevo (string). Recomendado para species cuyo `valor_pedagogico` mencione compuestos tóxicos.

### Validators (`scripts/validate-catalog.mjs`)

| Validator | Modo | Descripción |
|---|---|---|
| **AMB-25** `autoridad_canónica_estricta` | soft (warning en lefthook/CI con `--lenient-schema` o `--seed-mode`) | Verifica `normativa_colombiana[].autoridad ∈ enum`. Más estricto que AMB-19 (que aún tolera variantes regionales). |
| **AMB-26** `validation_level_canónico` | soft (warning en lefthook/CI) | Verifica `validation_level ∈ enum` cuando el campo está presente. |
| **AMB-27** `toxico_sin_advertencia` | WARN-only siempre | Match case-insensitive por keywords (`tóxico`, `abortifaciente`, `fotosensibilidad`, `neurotóxico`, `alcaloide letal`) en `valor_pedagogico`. Warn si falta `advertencia_toxicologica`. |

Refactor mínimo: el CLI principal ahora vive en `runCli()` gated por `import.meta.url === \`file://${process.argv[1]}\``, permitiendo importar las funciones validador desde tests sin disparar `process.exit()`. Patrón ya usado en `scripts/catalog-to-age.mjs`.

### Tests (`scripts/__tests__/validate-catalog.test.mjs`)

15 cases / 4 grupos cubriendo:
- enum size exacto + miembros
- acepta valores canónicos
- reporta valores legacy con sugerencia de batch responsable del sweep
- ignora species sin el campo / con string libre legacy
- AMB-27 case-insensitive + tildes opcionales + frase compuesta (`alcaloide letal`)

```
✓ scripts/__tests__/validate-catalog.test.mjs (15 tests)
  Tests  77 passed (77 total con catalog-to-age)
```

## Findings actuales (input para Batch 3A/5A)

Ejecutado `node scripts/validate-catalog.mjs --lenient-schema` sobre `catalog/chagra-catalog-seed-v3.1.json`:

| Validator | Hallazgos | Tipo |
|---|---|---|
| **AMB-25** | **11 autoridades fuera de enum** | 8× `CAR Cundinamarca`, 2× `Secretaría Distrital de Ambiente Bogotá`, 1× `IUCN`. Distribuidas en `acacia_melanoxylon`, `cytisus_monspessulanus`, `eucalyptus_globulus`, `pinus_patula`, `pteridium_aquilinum`, `rubus_alceifolius`, `thunbergia_alata`, `ulex_europaeus`. |
| **AMB-26** | **22 species con `operator_reviewed`** | Todas migrarán a `expert_reviewed` o `agrosavia_verified` en Batch 3A/5A según rigor real. |
| **AMB-27** | **33 species con menciones de toxicidad sin advertencia_toxicologica** | Ej: `artemisia_absinthium`, `pachyrhizus_erosus`, `codiaeum_variegatum`, `ruta_graveolens`, `illicium_verum`. |

El script termina con **exit 0** (no crashea) en modo lenient — los hallazgos quedan como warnings hasta que Batch 3A/5A complete el sweep.

## Desbloquea

- **Batch 2A** — sweep crítico de validaciones agroecológicas que requería el enum cerrado de `validation_level` para clasificar progreso.
- **Batch 3A** — sweep de `normativa_colombiana` (renombrar `CAR Cundinamarca` → `CAR`, etc.) + poblamiento de `advertencia_toxicologica` en las 33 species detectadas por AMB-27.
- **Batch 5A** — migración masiva de `validation_level: operator_reviewed` → valor canónico apropiado.

## Out-of-scope (por diseño)

- **NO** se modifica species data (`catalog/chagra-catalog-seed-v3.1.json`). El sweep es trabajo de Batch 3A/5A.
- **NO** se fixea AMB-25/26 hallazgos — el validator queda reportando hasta que la migración esté lista.
- **NO** se mergea — espera revisión.

## Test plan

- [x] `npx vitest run scripts/__tests__/validate-catalog.test.mjs` → 15/15 pass
- [x] `npx vitest run scripts/__tests__/` → 77/77 pass (no regresión en `catalog-to-age.test.mjs`)
- [x] `node scripts/validate-catalog.mjs --lenient-schema` → exit 0, reporta 11/22/33 hallazgos como warnings
- [x] `npx eslint scripts/validate-catalog.mjs scripts/__tests__/validate-catalog.test.mjs` → clean
- [ ] CI green (CodeQL + Playwright + lefthook catalog-validator)
- [ ] Revisión humana del enum de autoridades (¿faltan entidades?)

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)