### PR TITLE
fix(agent): restore chat max_tokens 80→512 (intelligence-first)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.160",
+  "version": "0.12.161",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v202';
+const CACHE_NAME = 'chagra-v203';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -53,7 +53,7 @@ export const ROUTES = {
     model: 'gemma3:4b',
     keep_alive_min: 30,
     temperature: 0.3,
-    max_tokens: 80,
+    max_tokens: 512,
     url: '/api/ollama/v1/chat/completions',
     rationale:
       'Bench GPU 2026-05-17: 118 t/s, 4 GB VRAM, load 3s. keep_alive=30m. ' +
@@ -62,11 +62,13 @@ export const ROUTES = {
       'definición con más confianza. La fix real es system prompt agresivo ' +
       '(ver AgentScreen.getSystemPrompt) + temperature baja. Mantener 4b ' +
       'por velocidad y VRAM (vision cabe on-demand). Solución modelo-agnóstica. ' +
-      'max_tokens 512→80 2026-05-20 (Task #45 fix latencia TTS): ' +
-      'kokoro-82m CPU escala lineal con caracteres, 512 tokens ≈ 23s audio. ' +
-      '80 tokens ≈ 30 palabras ≈ 3-4s audio = sustentable para UX rural por voz. ' +
-      'system prompt agroecológico ya tiene REGLA 6 que pide concisión + ' +
-      'pregunta de seguimiento si necesita detalle.',
+      'max_tokens 80→512 2026-05-23 (principio intelligence-first): el cap ' +
+      'de 80 introducido en Task #45 para mitigar latencia kokoro-tts cortaba ' +
+      'respuestas a media oración y disfrazaba un fix de TTS como límite ' +
+      'cognitivo. La solución correcta es TTS chunked streaming (task #69), ' +
+      'no truncar capacidad de razonamiento. system prompt sigue pidiendo ' +
+      'concisión + follow-up; el modelo elige longitud por contenido, no por ' +
+      'hard cap. Si TTS sigue siendo bottleneck, mitigar ahí, no aquí.',
   },
   nlu: {
     model: 'qwen2.5-coder:7b',


### PR DESCRIPTION
## Summary

- Revert: `llmRouter.js` route `chat` `max_tokens: 80` → `max_tokens: 512`.
- Razón: el cap de 80 introducido en Task #45 cortaba respuestas a media oración para mitigar latencia kokoro-tts. La causa raíz era TTS, pero el fix se aplicó al razonamiento. Sacrificio cognitivo silencioso.
- Principio rector reafirmado 2026-05-23: nunca sacrificar inteligencia por velocidad. TTS chunked streaming (task #69) es el fix correcto para respuestas largas vía voz.

## Cambio

```diff
-    max_tokens: 80,
+    max_tokens: 512,
```

Rationale actualizada para documentar el revert y apuntar a task #69 como fix correcto.

## Test plan

- [x] llmRouter.js: max_tokens en route `chat` ahora 512 (parea con `reasoning`/`vision`).
- [x] No hay test que assert max_tokens=80 (telemetry-llm-bounds.spec.js verificado).
- [x] System prompt agroecológico (REGLA 6) sigue pidiendo concisión + follow-up.
- [ ] Post-merge: smoke test en alpha — preguntar al agente algo que requiera respuesta larga (ej. "describí 5 pasos del supermagro") y verificar que no se corta.
- [ ] Task #69 (kokoro chunked streaming) sigue pendiente — sin esto, respuestas largas vía voz seguirán siendo lentas, pero ya no se truncan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)