### PR TITLE
feat(agent): wire sidecar agro-mcp NLU+tools to AgentScreen (ADR-045 Step B/C)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,16 @@ VITE_HA_ACCESS_TOKEN=tu_token_home_assistant_aqui
 # Se muestran en el header del menu de voz.
 VITE_STT_MODEL=base
 VITE_NLU_MODEL=qwen3.5:4b
+
+# Sidecar chagra-agro-mcp — ADR-045 Fase 2 (NLU planner + MCP tools).
+# Master switch. Mientras no esté desplegado el sidecar en el nodo
+# productor, dejar en `false` y el AgentScreen sigue con RAG-only.
+# Cuando el sidecar esté live, setear a `true` en el build-time env.
+VITE_USE_SIDECAR_AGRO_MCP=false
+# Base URL del sidecar. Default `/api/mcp/agro` (nginx proxia a :7880 en
+# el nodo productor). Para dev local con sidecar en otro host, override
+# con la URL absoluta — el header X-Chagra-Token igual se manda.
+VITE_SIDECAR_URL=/api/mcp/agro
+# Token de auth del sidecar. Inyectado en build-time. NUNCA commitear el
+# valor real — vive solo en GHA secrets / shell del operador.
+VITE_CHAGRA_MCP_TOKEN=

--- a/ARCHITECTURE_STATE.md
+++ b/ARCHITECTURE_STATE.md
@@ -134,3 +134,59 @@ VITE_HA_ACCESS_TOKEN=             # Long-lived token de Home Assistant
 VITE_DEFAULT_LOCATION_ID=         # UUID de la ubicación principal
 VITE_DEFAULT_FARM_NAME=           # Nombre visible de la finca
 ```
+
+---
+
+## 8. Sidecar agro-mcp (ADR-045 Fase 2 — wiring del AgentScreen)
+
+El AgentScreen consume opcionalmente un sidecar HTTP (`chagra-agro-mcp`) que
+expone un planner NLU + un set de MCP tools sobre el knowledge graph de
+especies (catálogo Chagra). El wiring vive en `src/services/sidecarClient.js`
++ una integración corta en `src/components/AgentScreen/AgentScreen.jsx`,
+detrás de un feature flag para que el deploy del sidecar y la activación en
+cliente sean independientes.
+
+**Pipeline cuando flag=true + online:**
+
+```
+userMessage → planNlu(message, contextMemory)
+              → { useTool, tool, args, ... }
+              ↓ (si useTool)
+              callTool(tool, args) → result (ficha species, companions, etc.)
+              ↓
+   AgentScreen inyecta el JSON del result como bloque delimitado en el
+   system prompt ("=== DATOS VERIFICADOS (chagra-agro-mcp tool: X) ===")
+   antes del chat LLM, dándole grounding citable. Truncado a 1500 chars
+   para no reventar la ventana 4096 tokens.
+```
+
+Si el sidecar falla (timeout, 5xx, 401), si `navigator.onLine=false` o si
+la flag está apagada → `planNlu`/`callTool` devuelven `null` y el chat
+sigue con el flujo RAG-only previo. El cliente nunca arroja: contract
+`T | null` para el caller.
+
+**Tools disponibles en el sidecar:** `get_species`, `get_companions`,
+`get_biopreparados`, `get_pest_controllers`, `get_multihop_companions`,
+`validate_visual_match` (las últimas 3 vía AGE 2nd-degree; NLU planner aún
+no las routea automáticamente, pero quedan invocables por nombre).
+
+**Variables de entorno (todas opcionales — default seguro = sidecar off):**
+
+| Var | Default | Notas |
+|---|---|---|
+| `VITE_USE_SIDECAR_AGRO_MCP` | `false` | Master switch. `"true"` o `"1"` lo habilitan. |
+| `VITE_SIDECAR_URL` | `/api/mcp/agro` | Relativo → nginx proxia a :7880 en el nodo productor. |
+| `VITE_CHAGRA_MCP_TOKEN` | (vacío) | Build-time only. NUNCA commitear el valor real. |
+
+**Activación post-deploy del sidecar:**
+
+1. Mergear el PR de despliegue del sidecar en el repo de infra del nodo
+   productor (NixOS gestiona el systemd unit + el route nginx).
+2. Setear `VITE_USE_SIDECAR_AGRO_MCP=true` y `VITE_CHAGRA_MCP_TOKEN=<token>`
+   en el entorno del runner de GHA (secret) y rebuild.
+3. Observar `console.debug('[sidecar]', { tool, latencyNlu, latencyTool,
+   toolEvidenceBytes })` en DevTools de Chrome para medir adopción y p95.
+
+Con flag off (estado por defecto del repo público), el comportamiento del
+AgentScreen es idéntico al pipeline RAG-only — no hay cambio para usuarios
+hasta que el operador active explícitamente.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.160",
+  "version": "0.12.161",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v202';
+const CACHE_NAME = 'chagra-v203';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -7,6 +7,10 @@ import { retrieve } from '../../services/ragRetriever';
 import { parseIntent, formatIntentDescription } from '../../services/agentIntentParser';
 import { streamOpenAI } from '../../services/openaiStream';
 import { buildLLMRequest } from '../../services/llmRouter';
+// Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
+// `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
+// y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
+import { isSidecarEnabled, planNlu, callTool } from '../../services/sidecarClient';
 import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
 import ChatHistory from './ChatHistory';
@@ -339,7 +343,36 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
   // modelos no hagan cold-load entre conversaciones.
   const LLM_TIMEOUT_MS = 60000;
 
-  const callLLM = async (query, contextMemory, contextCorpus) => {
+  // Cap defensivo para inyectar evidencia del sidecar como context turn
+  // sin reventar la ventana 4096 tokens. ~1500 chars ≈ 400-500 tokens —
+  // deja sitio cómodo para system prompt + corpus RAG + historial + query.
+  const TOOL_EVIDENCE_MAX_CHARS = 1500;
+
+  const formatToolEvidence = (toolEvidence) => {
+    if (!toolEvidence || !toolEvidence.tool || !toolEvidence.result) return '';
+    let payload;
+    try {
+      payload = JSON.stringify(toolEvidence.result);
+    } catch (_) {
+      return '';
+    }
+    let truncated = false;
+    if (payload.length > TOOL_EVIDENCE_MAX_CHARS) {
+      payload = payload.slice(0, TOOL_EVIDENCE_MAX_CHARS);
+      truncated = true;
+    }
+    // Bloque delimitado y citable. Mismo patrón que el corpus RAG: el LLM
+    // sabe que NO viene del usuario y puede atribuirlo a la fuente.
+    return `
+
+=== DATOS VERIFICADOS (chagra-agro-mcp tool: ${toolEvidence.tool}) ===
+${payload}${truncated ? '\n[...truncated, ver detalle en ficha de especie]' : ''}
+=== FIN DATOS VERIFICADOS ===
+
+Estos datos vienen del knowledge graph del catálogo Chagra (verificado). Citalos si responden la pregunta, pero RESPONDE SOLO a lo que el usuario te preguntó.`;
+  };
+
+  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence) => {
     const systemPrompt = getSystemPrompt();
     // 2026-05-19: incidente alucinación tomate — gemma3:4b confundía el
     // corpus RAG con lo que el usuario dijo (atribuía síntomas "hojas
@@ -356,8 +389,10 @@ ${contextCorpus.map((c) => c.text).join('\n\n---\n\n')}
 Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el usuario te preguntó. NO menciones síntomas ni observaciones que no estén explícitamente en el mensaje del usuario.`
       : '';
 
+    const evidenceContext = formatToolEvidence(toolEvidence);
+
     const messages = [
-      { role: 'system', content: systemPrompt + corpusContext },
+      { role: 'system', content: systemPrompt + corpusContext + evidenceContext },
       ...(contextMemory ? [{ role: 'user', content: contextMemory }] : []),
       { role: 'user', content: query },
     ];
@@ -430,7 +465,49 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       const contextMemory = await getContextString(operatorId, 10);
       const contextCorpus = await retrieve(text, 3, 'agente');
 
-      const response = await callLLM(text, contextMemory, contextCorpus);
+      // ADR-045 Fase 2 Step B/C — sidecar NLU + MCP tool grounding.
+      // Solo si flag VITE_USE_SIDECAR_AGRO_MCP=true Y estamos online.
+      // Si sidecar falla / no aplica, sigue al chat con RAG-only (no
+      // degrada UX). El planNlu/callTool wrappers son no-throw: devuelven
+      // null en error/timeout. La evidencia se inyecta como bloque
+      // delimitado en el system prompt para grounding citable.
+      let toolEvidence = null;
+      if (isOnline && isSidecarEnabled()) {
+        try {
+          const tNlu0 = performance.now();
+          const plan = await planNlu(text, contextMemory);
+          const tNlu1 = performance.now();
+          if (plan?.useTool && plan.tool && plan.args) {
+            const tTool0 = performance.now();
+            const result = await callTool(plan.tool, plan.args);
+            const tTool1 = performance.now();
+            if (result) {
+              toolEvidence = { tool: plan.tool, args: plan.args, result };
+              const evidenceBytes = (() => {
+                try { return JSON.stringify(result).length; } catch (_) { return 0; }
+              })();
+              console.debug('[sidecar]', {
+                tool: plan.tool,
+                latencyNlu: Math.round(tNlu1 - tNlu0),
+                latencyTool: Math.round(tTool1 - tTool0),
+                toolEvidenceBytes: evidenceBytes,
+              });
+            }
+          } else if (plan) {
+            console.debug('[sidecar]', {
+              tool: null,
+              latencyNlu: Math.round(tNlu1 - tNlu0),
+              reason: plan.reason || 'no_tool',
+            });
+          }
+        } catch (sidecarErr) {
+          // Defensa extra: planNlu/callTool ya son no-throw, pero si algo
+          // raro pasa NO bloqueamos el chat.
+          console.debug('[sidecar] inesperado, sigo con RAG-only:', sidecarErr?.message);
+        }
+      }
+
+      const response = await callLLM(text, contextMemory, contextCorpus, toolEvidence);
       agentSounds.chime();
 
       const { intent } = parseIntent(text);

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -1,0 +1,340 @@
+/**
+ * sidecarClient.test.js — unit tests para el cliente HTTP del sidecar
+ * chagra-agro-mcp (ADR-045 Fase 2 Step B/C).
+ *
+ * Cobertura:
+ * - Feature flag off → todas las funciones devuelven null sin fetch.
+ * - navigator.onLine=false → null sin fetch (offline-first).
+ * - NLU 200 happy path → parsea snake_case → camelCase.
+ * - NLU timeout → null sin throw (caller espera contract T | null).
+ * - NLU 5xx / 401 → null sin throw.
+ * - callTool con tool no permitido → null sin fetch (whitelist defense).
+ * - callTool happy path → pasa-through el JSON del sidecar tal cual.
+ *
+ * Aislamiento: vitest `vi.stubEnv` para `import.meta.env.VITE_*`, `vi.fn()`
+ * sobre el global `fetch`. No requiere red real. Usa `vi.resetModules()`
+ * para que cada test re-importe `sidecarClient.js` con el env actualizado
+ * (algunos paths evalúan env en module-load... aunque acá leemos siempre
+ * just-in-time, dejamos resetModules como defensa por si refactoreamos).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const ENV_FLAG = 'VITE_USE_SIDECAR_AGRO_MCP';
+const ENV_URL = 'VITE_SIDECAR_URL';
+const ENV_TOKEN = 'VITE_CHAGRA_MCP_TOKEN';
+
+let fetchMock;
+let originalOnLine;
+
+const enableFlag = () => {
+  vi.stubEnv(ENV_FLAG, 'true');
+  vi.stubEnv(ENV_URL, '/api/mcp/agro');
+  vi.stubEnv(ENV_TOKEN, 'test-token-123');
+};
+
+const disableFlag = () => {
+  vi.stubEnv(ENV_FLAG, 'false');
+};
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import('../sidecarClient.js');
+};
+
+const jsonResponse = (status, body) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  globalThis.fetch = fetchMock;
+  originalOnLine = navigator.onLine;
+  // Por default jsdom marca navigator.onLine=true. Sobreescribimos por
+  // test cuando hace falta simular offline.
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  Object.defineProperty(navigator, 'onLine', { configurable: true, value: originalOnLine });
+});
+
+describe('sidecarClient — feature flag off', () => {
+  it('isSidecarEnabled() devuelve false si la env var no está set', async () => {
+    vi.unstubAllEnvs();
+    const { isSidecarEnabled } = await importFresh();
+    expect(isSidecarEnabled()).toBe(false);
+  });
+
+  it('isSidecarEnabled() devuelve false con "false" explícito', async () => {
+    disableFlag();
+    const { isSidecarEnabled } = await importFresh();
+    expect(isSidecarEnabled()).toBe(false);
+  });
+
+  it('planNlu() devuelve null sin hacer fetch cuando flag off', async () => {
+    disableFlag();
+    const { planNlu } = await importFresh();
+    const res = await planNlu('hola');
+    expect(res).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('callTool() devuelve null sin hacer fetch cuando flag off', async () => {
+    disableFlag();
+    const { callTool } = await importFresh();
+    const res = await callTool('get_species', { id_or_name: 'maracuya' });
+    expect(res).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('sidecarClient — feature flag on', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  it('isSidecarEnabled() devuelve true con "true"', async () => {
+    const { isSidecarEnabled } = await importFresh();
+    expect(isSidecarEnabled()).toBe(true);
+  });
+
+  it('isSidecarEnabled() acepta "1" como truthy (compat con docker env)', async () => {
+    vi.stubEnv(ENV_FLAG, '1');
+    const { isSidecarEnabled } = await importFresh();
+    expect(isSidecarEnabled()).toBe(true);
+  });
+
+  describe('offline behavior', () => {
+    it('planNlu() devuelve null sin fetch cuando navigator.onLine=false', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { planNlu } = await importFresh();
+      const res = await planNlu('hola');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('callTool() devuelve null sin fetch cuando navigator.onLine=false', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { callTool } = await importFresh();
+      const res = await callTool('get_species', { id_or_name: 'mora' });
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('planNlu — happy path + parsing', () => {
+    it('200 con body válido → normaliza snake_case → camelCase', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        use_tool: true,
+        tool: 'get_species',
+        args: { id_or_name: 'maracuya' },
+        latency_ms: 187,
+        model_used: 'gemma3:4b',
+        heuristic_skipped: false,
+        reason: null,
+        error: null,
+      }));
+      const { planNlu } = await importFresh();
+      const res = await planNlu('contame de la maracuyá', 'historial reciente');
+      expect(res).toEqual({
+        useTool: true,
+        tool: 'get_species',
+        args: { id_or_name: 'maracuya' },
+        latencyMs: 187,
+        modelUsed: 'gemma3:4b',
+        heuristicSkipped: false,
+        reason: null,
+        error: null,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/nlu');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token-123');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+      const body = JSON.parse(opts.body);
+      expect(body).toEqual({ user_message: 'contame de la maracuyá', context: 'historial reciente' });
+    });
+
+    it('200 sin context (caller no lo pasa) → body no incluye la key', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { use_tool: false }));
+      const { planNlu } = await importFresh();
+      await planNlu('hola');
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body).toEqual({ user_message: 'hola' });
+      expect('context' in body).toBe(false);
+    });
+
+    it('200 con use_tool=false → useTool false + tool/args null', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        use_tool: false,
+        tool: null,
+        args: null,
+        reason: 'low_confidence',
+      }));
+      const { planNlu } = await importFresh();
+      const res = await planNlu('contame un chiste');
+      expect(res.useTool).toBe(false);
+      expect(res.tool).toBeNull();
+      expect(res.args).toBeNull();
+      expect(res.reason).toBe('low_confidence');
+    });
+
+    it('userMessage vacío → null sin fetch', async () => {
+      const { planNlu } = await importFresh();
+      expect(await planNlu('')).toBeNull();
+      expect(await planNlu(null)).toBeNull();
+      expect(await planNlu(undefined)).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('planNlu — failure modes', () => {
+    it('5xx → null sin throw', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'sidecar down' }));
+      const { planNlu } = await importFresh();
+      const res = await planNlu('test');
+      expect(res).toBeNull();
+    });
+
+    it('401 unauth → null sin throw', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(401, { error: 'invalid token' }));
+      const { planNlu } = await importFresh();
+      const res = await planNlu('test');
+      expect(res).toBeNull();
+    });
+
+    it('fetch throws (network failure) → null sin throw', async () => {
+      fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const { planNlu } = await importFresh();
+      const res = await planNlu('test');
+      expect(res).toBeNull();
+    });
+
+    it('AbortError (timeout) → null sin throw', async () => {
+      fetchMock.mockImplementationOnce((_url, opts) => {
+        // Simula timeout: rechaza con AbortError si el signal aborta antes
+        // de que respondamos. Para garantizar el path, abortamos el signal
+        // sincrónicamente y rechazamos con el error correspondiente.
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        if (opts?.signal) {
+          // No esperamos al timer real (10s es demasiado para vitest); simulamos
+          // el abort directo.
+        }
+        return Promise.reject(err);
+      });
+      const { planNlu } = await importFresh();
+      const res = await planNlu('test');
+      expect(res).toBeNull();
+    });
+
+    it('200 pero JSON inválido (json() throws) → null sin throw', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => { throw new SyntaxError('bad json'); },
+      });
+      const { planNlu } = await importFresh();
+      const res = await planNlu('test');
+      expect(res).toBeNull();
+    });
+  });
+
+  describe('callTool — happy path + whitelist', () => {
+    it('200 con ficha species → devuelve el body tal cual', async () => {
+      const ficha = {
+        species_id: 'passiflora_edulis_flavicarpa',
+        nombre_comun: ['maracuyá', 'maracuya amarillo'],
+        nombre_cientifico: 'Passiflora edulis f. flavicarpa',
+        altitud_msnm: [0, 1600],
+      };
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, ficha));
+      const { callTool } = await importFresh();
+      const res = await callTool('get_species', { id_or_name: 'maracuya' });
+      expect(res).toEqual(ficha);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/tools/get_species');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token-123');
+      expect(JSON.parse(opts.body)).toEqual({ id_or_name: 'maracuya' });
+    });
+
+    it('200 con found=false → pasa-through (no se intercepta)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { found: false }));
+      const { callTool } = await importFresh();
+      const res = await callTool('get_species', { id_or_name: 'planta_inexistente' });
+      expect(res).toEqual({ found: false });
+    });
+
+    it('tool name no permitido → null sin fetch (whitelist defense)', async () => {
+      const { callTool } = await importFresh();
+      const res = await callTool('delete_everything', {});
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('toolName vacío/no-string → null sin fetch', async () => {
+      const { callTool } = await importFresh();
+      expect(await callTool('', {})).toBeNull();
+      expect(await callTool(null, {})).toBeNull();
+      expect(await callTool(42, {})).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('tools nuevos del PR chagra-pro #48 están en whitelist', async () => {
+      const { callTool, __TEST__ } = await importFresh();
+      expect(__TEST__.ALLOWED_TOOLS.has('get_pest_controllers')).toBe(true);
+      expect(__TEST__.ALLOWED_TOOLS.has('get_multihop_companions')).toBe(true);
+      expect(__TEST__.ALLOWED_TOOLS.has('validate_visual_match')).toBe(true);
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: 1 }));
+      await callTool('get_pest_controllers', { pest_id_or_name: 'fusarium', limit: 5 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/tools/get_pest_controllers');
+    });
+
+    it('5xx → null sin throw', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: 'kg down' }));
+      const { callTool } = await importFresh();
+      const res = await callTool('get_companions', { species_id: 'maiz' });
+      expect(res).toBeNull();
+    });
+  });
+
+  describe('configuración / base URL', () => {
+    it('default base URL es /api/mcp/agro si VITE_SIDECAR_URL no está set', async () => {
+      vi.stubEnv(ENV_URL, '');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
+      const { planNlu } = await importFresh();
+      await planNlu('test');
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/nlu');
+    });
+
+    it('respeta VITE_SIDECAR_URL custom (sin trailing slash)', async () => {
+      vi.stubEnv(ENV_URL, 'https://sidecar.example.test/v1');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
+      const { planNlu } = await importFresh();
+      await planNlu('test');
+      expect(fetchMock.mock.calls[0][0]).toBe('https://sidecar.example.test/v1/nlu');
+    });
+
+    it('strip trailing slash de VITE_SIDECAR_URL para no duplicar /', async () => {
+      vi.stubEnv(ENV_URL, '/api/mcp/agro/');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
+      const { planNlu } = await importFresh();
+      await planNlu('test');
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/nlu');
+    });
+
+    it('sin token → no agrega header X-Chagra-Token (no header vacío)', async () => {
+      vi.stubEnv(ENV_TOKEN, '');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
+      const { planNlu } = await importFresh();
+      await planNlu('test');
+      const headers = fetchMock.mock.calls[0][1].headers;
+      expect('X-Chagra-Token' in headers).toBe(false);
+    });
+  });
+});

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -1,0 +1,205 @@
+/**
+ * sidecarClient.js — Cliente HTTP del sidecar chagra-agro-mcp (ADR-045 Fase 2).
+ *
+ * Wirea el AgentScreen del PWA con el endpoint `/api/mcp/agro/` (nginx
+ * proxia a sidecar :7880 en alpha). Detrás de un feature flag — mientras
+ * el deploy del sidecar (PR #103 guatoc-nixos) no esté merged, la flag
+ * queda en false y el comportamiento del cliente es idéntico al anterior
+ * (todas las funciones devuelven null sin hacer fetch).
+ *
+ * Pipeline esperado (cuando flag=true + sidecar live):
+ *   userMessage → planNlu() → { use_tool, tool, args, ... }
+ *                ↓ (si use_tool)
+ *                callTool(tool, args) → result (ficha species/companions/etc.)
+ *                ↓
+ *   El AgentScreen inyecta `result` como context turn antes del chat LLM,
+ *   dándole grounding citable. Si NLU/tool fallan o devuelven null, el
+ *   chat sigue con el flujo RAG actual sin degradar UX.
+ *
+ * Reglas operativas:
+ * - Offline-first: si `!navigator.onLine` → null inmediato, no fetch.
+ * - Timeout corto: NLU 10s, tools 5s (cap defensivo p99 sidecar).
+ * - Falla silenciosa: en error/non-200/abort → null + console.debug.
+ *   NUNCA throw — el caller espera contract `T | null`.
+ * - Auth: header `X-Chagra-Token: ${VITE_CHAGRA_MCP_TOKEN}` siempre.
+ * - Sin dependencias: fetch puro + AbortController. Testeable sin red real.
+ *
+ * Env vars (todas opcionales, default seguro para offline-only):
+ * - VITE_USE_SIDECAR_AGRO_MCP=true|false  — master switch (default false)
+ * - VITE_SIDECAR_URL=/api/mcp/agro        — base relativa, nginx-proxied
+ * - VITE_CHAGRA_MCP_TOKEN=<token>         — build-time, NUNCA en .env commiteado
+ *
+ * Telemetry: `console.debug('[sidecar]', ...)` con latencias para que el
+ * operador mida adopción cuando active la flag (no hay backend de
+ * telemetría aún — esto se sumará a una task futura si hace falta).
+ */
+
+const NLU_TIMEOUT_MS = 10000;
+const TOOL_TIMEOUT_MS = 5000;
+
+/**
+ * Lee la flag `VITE_USE_SIDECAR_AGRO_MCP`. Acepta los strings 'true'/'1'
+ * como habilitado. Cualquier otro valor (incluido undefined) → false.
+ *
+ * Exportado para que el caller pueda short-circuitear UI/telemetría sin
+ * llamar las funciones (ej. tooltip "sidecar inactivo").
+ */
+export function isSidecarEnabled() {
+  try {
+    const raw = import.meta.env?.VITE_USE_SIDECAR_AGRO_MCP;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+function getBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) {
+      // Strip trailing slash para joinear sin duplicar
+      return raw.trim().replace(/\/+$/, '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '/api/mcp/agro';
+}
+
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+/**
+ * Wrapper interno: POST con timeout + headers + degrade-to-null.
+ * No exportado — el contrato público son planNlu y callTool.
+ */
+async function postJson(path, body, timeoutMs) {
+  if (!isSidecarEnabled()) return null;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    console.debug('[sidecar] offline — skip', path);
+    return null;
+  }
+
+  const base = getBaseUrl();
+  const url = `${base}${path}`;
+  const token = getToken();
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+
+  const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body || {}),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.debug('[sidecar] non-2xx', { path, status: res.status });
+      return null;
+    }
+    const json = await res.json();
+    const latency = Math.round(((typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now()) - t0);
+    console.debug('[sidecar] ok', { path, latency_ms: latency });
+    return json;
+  } catch (err) {
+    const reason = err?.name === 'AbortError' ? 'timeout' : (err?.message || 'unknown');
+    console.debug('[sidecar] fail', { path, reason });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Llama `POST ${BASE}/nlu` para que el planner decida si el mensaje del
+ * usuario debe routearse a un MCP tool.
+ *
+ * @param {string} userMessage — texto del operador
+ * @param {string} [context] — context turn opcional (ej. historial reciente)
+ * @returns {Promise<null | {
+ *   useTool: boolean,
+ *   tool: string | null,
+ *   args: object | null,
+ *   latencyMs: number | null,
+ *   modelUsed: string | null,
+ *   heuristicSkipped: boolean,
+ *   reason: string | null,
+ *   error: string | null,
+ * }>}
+ *
+ * Normaliza el snake_case del API a camelCase JS-idiomatic. Devuelve null
+ * si: flag off, offline, timeout, non-2xx, body inválido.
+ */
+export async function planNlu(userMessage, context) {
+  if (!userMessage || typeof userMessage !== 'string') return null;
+  const body = { user_message: userMessage };
+  if (context && typeof context === 'string') body.context = context;
+
+  const raw = await postJson('/nlu', body, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+
+  return {
+    useTool: Boolean(raw.use_tool),
+    tool: typeof raw.tool === 'string' ? raw.tool : null,
+    args: (raw.args && typeof raw.args === 'object') ? raw.args : null,
+    latencyMs: Number.isFinite(raw.latency_ms) ? raw.latency_ms : null,
+    modelUsed: typeof raw.model_used === 'string' ? raw.model_used : null,
+    heuristicSkipped: Boolean(raw.heuristic_skipped),
+    reason: typeof raw.reason === 'string' ? raw.reason : null,
+    error: typeof raw.error === 'string' ? raw.error : null,
+  };
+}
+
+/**
+ * Whitelist de tools que el cliente puede invocar. Defensa en profundidad:
+ * el endpoint del sidecar es trusted, pero acotamos el set para que un
+ * planner buggy/comprometido no pueda pedir paths arbitrarios.
+ *
+ * Las últimas 3 son nuevas (PR chagra-pro #48 — wire AGE). NLU planner aún
+ * no las routea automáticamente; quedan disponibles para invocación manual.
+ */
+const ALLOWED_TOOLS = new Set([
+  'get_species',
+  'get_companions',
+  'get_biopreparados',
+  'get_pest_controllers',
+  'get_multihop_companions',
+  'validate_visual_match',
+]);
+
+/**
+ * Llama `POST ${BASE}/tools/<toolName>` con los args dados.
+ *
+ * @param {string} toolName — uno de ALLOWED_TOOLS
+ * @param {object} args — body raw (forma específica por tool)
+ * @returns {Promise<null | object>} respuesta del sidecar tal cual, o null
+ *   si flag off / offline / tool no permitido / fetch falla.
+ */
+export async function callTool(toolName, args) {
+  if (!toolName || typeof toolName !== 'string') return null;
+  if (!ALLOWED_TOOLS.has(toolName)) {
+    console.debug('[sidecar] tool no permitido', toolName);
+    return null;
+  }
+  return postJson(`/tools/${toolName}`, args || {}, TOOL_TIMEOUT_MS);
+}
+
+// Export interno para testabilidad — los tests pueden assertear el set
+// sin tener que reflectar la closure.
+export const __TEST__ = { ALLOWED_TOOLS, getBaseUrl, getToken };


### PR DESCRIPTION
## Summary

Wirea el `AgentScreen` del PWA con el sidecar `chagra-agro-mcp` para que las preguntas del operador atraviesen un planner NLU y, si aplica, un MCP tool del knowledge graph del catálogo, devolviendo evidencia citable que se inyecta como contexto antes del chat LLM. Implementa **Step B + Step C** de la task #79 (Fase 2 MCP — ADR-045).

Detrás de un feature flag `VITE_USE_SIDECAR_AGRO_MCP` (default `false`). Mientras el deploy del sidecar (PR #103 guatoc-nixos) no esté merged, este wiring no cambia nada en runtime — el AgentScreen sigue con el flujo RAG-only previo.

## Pipeline

```
userMessage
  → planNlu(message, contextMemory)
    → { useTool, tool, args, ... }
  ↓ (si useTool && plan completo)
  callTool(tool, args) → result (ficha species, companions, biopreparados, etc.)
  ↓
  AgentScreen inyecta JSON.stringify(result) como bloque delimitado en el
  system prompt: "=== DATOS VERIFICADOS (chagra-agro-mcp tool: X) ===".
  Cap defensivo 1500 chars (~400-500 tokens) para no reventar ventana 4096.
```

Si `planNlu`/`callTool` fallan (timeout, 5xx, 401, JSON inválido), si `navigator.onLine=false`, o si la flag está apagada → ambos devuelven `null` y `callLLM` corre sin `toolEvidence` (degrade graceful al pipeline RAG-only).

## Archivos cambiados

| Archivo | Cambio |
|---|---|
| `src/services/sidecarClient.js` | **NEW**. Fetch puro sin dependencias. `isSidecarEnabled()`, `planNlu()`, `callTool()`. Contract `T \| null` (no-throw). Timeouts 10s/5s. Header `X-Chagra-Token`. Whitelist de 6 tools permitidos. |
| `src/components/AgentScreen/AgentScreen.jsx` | Import del sidecarClient + bloque NLU+tool antes de `callLLM` + nuevo param `toolEvidence` en `callLLM` + helper `formatToolEvidence` + `console.debug` con latencias. |
| `src/services/__tests__/sidecarClient.test.js` | **NEW**. 27 tests con `fetch` mockeado y `vi.stubEnv`. Cubre flag off, offline, NLU happy/parsing, NLU failure modes, callTool happy/whitelist, base URL/token config. |
| `.env.example` | Agregadas `VITE_USE_SIDECAR_AGRO_MCP`, `VITE_SIDECAR_URL`, `VITE_CHAGRA_MCP_TOKEN`. |
| `ARCHITECTURE_STATE.md` | Nueva §8 con diagrama + tabla de env vars + procedimiento de activación. |
| `package.json` + `public/sw.js` | Bump rutinario 0.12.160 → 0.12.161 + cache v202 → v203 (lefthook hook no estaba en PATH del worktree, bumpeo manual). |

## Feature flag y env vars

| Var | Default | Notas |
|---|---|---|
| `VITE_USE_SIDECAR_AGRO_MCP` | `false` | Master switch. `"true"` o `"1"` lo habilitan. |
| `VITE_SIDECAR_URL` | `/api/mcp/agro` | Relativo → nginx proxia al sidecar. Override absoluto para dev local. |
| `VITE_CHAGRA_MCP_TOKEN` | (vacío) | Build-time only. NUNCA commitear el valor real — vive en GHA secrets o shell del operador. |

## Cómo activar (post-merge de PR #103 guatoc-nixos)

1. Mergear este PR a `main`.
2. Setear `VITE_USE_SIDECAR_AGRO_MCP=true` y `VITE_CHAGRA_MCP_TOKEN=<token>` como GHA secrets del repo.
3. Re-run del workflow `deploy.yml` (o cualquier commit a `main` que lo dispare).
4. Observar `console.debug('[sidecar]', { tool, latencyNlu, latencyTool, toolEvidenceBytes })` en DevTools para medir adopción.

Con flag off (estado por defecto), comportamiento idéntico al RAG-only previo.

## Qué pasa si el sidecar está caído (con flag on)

- Timeout 10s en NLU, 5s en tools (`AbortController`).
- En timeout/5xx/401/JSON inválido → `planNlu`/`callTool` devuelven `null`, se loguea `console.debug('[sidecar] fail', { path, reason })`.
- `handleSubmit` sigue al `callLLM` sin `toolEvidence` — el operador recibe respuesta RAG-only, no nota la falla.

## Constraints respetados

- NO se modificaron `llmRouter.js`, `openaiStream.js`, `ttsService.js`, `voiceService.js`.
- NO se rompe offline-first: con flag off o `navigator.onLine=false`, behavior idéntico al previo.
- NO secrets en `.env.example` (token vacío + comentario explícito).
- Conventional Commits + branch base `main`.
- NO `--no-verify`, NO force-push.

## Test plan

- [x] `npm run test:unit` → 545/545 verde (incluye los 27 nuevos del sidecarClient).
- [x] `npx eslint` sobre los 3 archivos tocados → clean, `--max-warnings=0` OK.
- [x] `npm run build` → verde, sin warnings, AgentScreen chunk 46.84 kB (no regresión apreciable).
- [ ] Playwright E2E offline-first — depende del runner self-hosted; el wiring está detrás de flag off, no debería afectar el spec `tests/offline.spec.js`.
- [ ] **E2E live con sidecar real** — pendiente para sesión post-merge de PR #103. El test ideal sería: setear flag=true, mockear `/api/mcp/agro/nlu` con un servidor de fixtures, verificar que el chat LLM recibe el bloque `=== DATOS VERIFICADOS ===` en el system prompt. Documentado como TODO acá para no bloquear este PR.

## Decisiones de diseño no triviales

1. **Contract `T \| null` en lugar de throw**: el caller (AgentScreen) ya tiene un `try/catch` para `callLLM`, pero NO queremos que un sidecar caído rompa el chat. Devolver `null` mantiene el flujo limpio y predecible.

2. **Whitelist explícita de tools**: defensa en profundidad. Aunque el sidecar es trusted, acotamos el set a 6 tools concretos (`get_species`, `get_companions`, `get_biopreparados`, `get_pest_controllers`, `get_multihop_companions`, `validate_visual_match`). Un planner buggy/comprometido no puede pedir paths arbitrarios.

3. **Inyección en system prompt vs. user turn separado**: opté por concatenar al `system` content (mismo patrón que el bloque RAG corpus existente) en lugar de inyectar un `user`/`assistant` turn falso. Razón: gemma3:4b respeta mejor el delimitador `=== ... ===` dentro del system que un turn artificial, y mantengo la trazabilidad del historial conversacional limpia.

4. **Truncado a 1500 chars**: cap defensivo para no reventar la ventana 4096 (gemma3:4b). Las fichas de species del catálogo son típicamente <800 chars JSON-serializadas; companions/biopreparados pueden ser más, pero 1500 cubre el p95.

5. **`console.debug` en vez de telemetría persistente**: por ahora telemetría liviana (visible en DevTools) hasta que el operador active la flag y medir el patrón real. Si hace falta, una task futura puede sumarlo a `llmTelemetryService` o `ragTelemetry`.

## Blockers en CI

Ninguno conocido. CodeQL + Playwright deberían pasar — el lint está clean, los 545 tests pasan, build verde, y el feature flag off mantiene paridad con el comportamiento previo. Si Playwright se pone difícil, está documentado arriba como TODO post-merge.

## NO mergear este PR

Per instrucciones explícitas: el PR queda abierto. El operador lo activa post #103 switch.