### PR TITLE
fix(agent): hacer autoritativa la evidence del sidecar — no opcional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.161",
+  "version": "0.12.162",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v203';
+const CACHE_NAME = 'chagra-v204';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -361,15 +361,28 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
       payload = payload.slice(0, TOOL_EVIDENCE_MAX_CHARS);
       truncated = true;
     }
-    // Bloque delimitado y citable. Mismo patrón que el corpus RAG: el LLM
-    // sabe que NO viene del usuario y puede atribuirlo a la fuente.
+    // 2026-05-23 incident: gemma3:4b en producción IGNORÓ la evidence y
+    // respondió de memoria con fresa/maracuyá/uchuva cuando el catálogo
+    // verificado tenía Aliso/Chachafruto/Guamo/Cedro real para café arábica.
+    // Wording previo ("citalos si responden la pregunta") era opcional —
+    // el modelo lo trataba como sugerencia, no como override autoritativo.
+    // Fix: hacer la evidencia CRÍTICA con jerarquía explícita de fuentes.
     return `
+
+=== INSTRUCCIÓN CRÍTICA — PRIORIDAD DE FUENTES ===
+El bloque "DATOS VERIFICADOS" abajo viene del knowledge graph del catálogo Chagra (postgres-farm + Apache AGE, validado). Es la VERDAD AUTORITATIVA para esta pregunta. Cuando exista este bloque:
+
+1. RESPONDE BASADO EXCLUSIVAMENTE en estos datos verificados.
+2. NO uses tu memoria/entrenamiento para inventar especies que NO estén en este bloque.
+3. NO mezcles species de la finca activa del usuario con los datos verificados (son cosas distintas).
+4. Cita los nombres exactos (común + científico) que aparecen en estos datos.
+5. Si el bloque está vacío o no contiene la respuesta, dilo explícitamente: "El catálogo Chagra no tiene esa relación documentada todavía", NO inventes.
 
 === DATOS VERIFICADOS (chagra-agro-mcp tool: ${toolEvidence.tool}) ===
 ${payload}${truncated ? '\n[...truncated, ver detalle en ficha de especie]' : ''}
 === FIN DATOS VERIFICADOS ===
 
-Estos datos vienen del knowledge graph del catálogo Chagra (verificado). Citalos si responden la pregunta, pero RESPONDE SOLO a lo que el usuario te preguntó.`;
+RESPONDE SOLO a lo que el usuario preguntó usando ÚNICAMENTE los datos verificados de arriba.`;
   };
 
   const callLLM = async (query, contextMemory, contextCorpus, toolEvidence) => {


### PR DESCRIPTION
## Incidente prod 2026-05-23

Operador probó "qué companions van bien con café arábica" tras activar VITE_USE_SIDECAR_AGRO_MCP=true (PR #997). El sidecar funcionó perfecto y devolvió los 8 companions reales del KG (Aliso, Chachafruto, Guamo, Cedro real, etc.).

Pero el LLM **IGNORÓ la evidence** y respondió con fresa/maracuyá/uchuva (alucinación, no relacionado con café). Repitió el error en el 2do turn. Solo el 3er turn ("no pensaba en mi cultivo") finalmente respetó los datos.

## Root cause

Wording previo: "citalos si responden la pregunta" → tratado como sugerencia opcional por gemma3:4b. El modelo prefería su memoria + bias hacia la finca activa del operador.

## Fix

Bloque **INSTRUCCIÓN CRÍTICA — PRIORIDAD DE FUENTES** con 5 reglas numeradas autoritativas ANTES de la evidence:

1. RESPONDE EXCLUSIVAMENTE en estos datos verificados
2. NO uses memoria/entrenamiento para inventar
3. NO mezcles species de la finca con datos verificados
4. Cita nombres exactos (común + científico)
5. Si vacío: "no tiene esa relación documentada" — NO inventes

## Test plan

Post-merge + deploy:
- [ ] Pregunta "qué companions van bien con café arábica" → debe responder con Aliso/Chachafruto/Guamo/etc, NO con fresa/maracuyá
- [ ] Pregunta "qué controla la broca del café" → tool get_pest_controllers fired, respuesta con biopreparados + species reales
- [ ] Pregunta saludo simple "hola" → heuristic skip 13ms, chat directo sin tool (sin regresión)
- [ ] Pregunta de algo NO en catálogo (planta inventada) → "no tiene esa relación documentada", NO inventa

🤖 Generated with [Claude Code](https://claude.com/claude-code)