### PR TITLE
fix(agent): bloquear mapeo creativo cuando tool devuelve found:false (Test #4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.162",
+  "version": "0.12.163",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v204';
+const CACHE_NAME = 'chagra-v205';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -350,9 +350,48 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
 
   const formatToolEvidence = (toolEvidence) => {
     if (!toolEvidence || !toolEvidence.tool || !toolEvidence.result) return '';
+
+    // 2026-05-23 incidente test #4: usuario preguntó por "mareñongoño del
+    // Tolima" (especie NO en catálogo). El tool devolvió {found:false,
+    // hint:"..."} pero gemma3:4b IGNORÓ el flag found:false y mapeó
+    // creativamente "mareñongoño" → "Ullucus tuberosus" inventando una
+    // equivalencia, luego listó companions reales de Ullucus pretendiendo
+    // que eran de mareñongoño. Alucinación creativa grave.
+    //
+    // Fix: detectar found:false en el frontend ANTES del LLM call y
+    // formatear un bloque hyper-explícito que prohíbe el mapeo creativo.
+    const result = toolEvidence.result;
+    const isNotFound =
+      result &&
+      typeof result === 'object' &&
+      (result.found === false ||
+        result.available === false ||
+        (result.matches_count !== undefined && result.matches_count === 0));
+
+    if (isNotFound) {
+      const hint = (result && (result.hint || result.reason)) || '';
+      const queryStr = JSON.stringify(toolEvidence.args || {});
+      return `
+
+=== ESPECIE / RELACIÓN NO ENCONTRADA EN CATÁLOGO ===
+El usuario preguntó por algo que NO existe en el catálogo Chagra. El tool ${toolEvidence.tool} fue invocado con args ${queryStr} y devolvió found:false.
+
+INSTRUCCIÓN OBLIGATORIA — anti-alucinación creativa:
+
+1. NO mapees el nombre que preguntó el usuario a otra especie "parecida" que sí exista en el catálogo (eso es ALUCINACIÓN CREATIVA grave).
+2. NO listes companions/biopreparados/relaciones de OTRA especie pretendiendo que son de la que preguntó.
+3. NO inventes nombres científicos como sinónimos del término del usuario.
+4. RESPONDE textualmente algo como: "El catálogo Chagra no tiene esa especie/relación documentada todavía. ¿Podrías describir la planta o decir su nombre científico? Si te referís a una especie conocida con otro nombre, decímelo y la busco."
+5. Si querés sugerir, SOLO podés decir: "Si te referís a [especie real del catálogo], avísame y consulto sus compañeros". Pero NUNCA afirmar la equivalencia.
+
+Hint del tool: ${hint}
+=== FIN ===
+`;
+    }
+
     let payload;
     try {
-      payload = JSON.stringify(toolEvidence.result);
+      payload = JSON.stringify(result);
     } catch (_) {
       return '';
     }
@@ -361,12 +400,9 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
       payload = payload.slice(0, TOOL_EVIDENCE_MAX_CHARS);
       truncated = true;
     }
-    // 2026-05-23 incident: gemma3:4b en producción IGNORÓ la evidence y
-    // respondió de memoria con fresa/maracuyá/uchuva cuando el catálogo
-    // verificado tenía Aliso/Chachafruto/Guamo/Cedro real para café arábica.
-    // Wording previo ("citalos si responden la pregunta") era opcional —
-    // el modelo lo trataba como sugerencia, no como override autoritativo.
-    // Fix: hacer la evidencia CRÍTICA con jerarquía explícita de fuentes.
+    // Caso "found:true" — wording autoritativo de PR #998. El bloque
+    // "DATOS VERIFICADOS" reemplaza la memoria del modelo cuando se cita
+    // companions / biopreparados / pest controllers / multihop / visual.
     return `
 
 === INSTRUCCIÓN CRÍTICA — PRIORIDAD DE FUENTES ===


### PR DESCRIPTION
## Test #4 FAIL en sesión 2026-05-23

Operador probó: `qué compañeros van bien con la planta mareñongoño del Tolima` (especie inventada para test anti-hallucination).

Esperado: "El catálogo Chagra no tiene 'mareñongoño' documentado."

Real:
> "Entiendo que se refiere a *Ullucus tuberosus*, también conocida como mareñongoño..."
> [lista yacón/arracacha/mashua/oca]

El LLM MAPEÓ arbitrariamente a Ullucus (que sí existe). Cero base para esa equivalencia.

## Fix

Detección en frontend de `found:false` (o `available:false`, o `matches_count===0`) ANTES del LLM call. Cuando el tool devuelve negativo, formatToolEvidence inyecta un bloque hyper-explícito que prohíbe:

- Mapear el nombre del usuario a especie 'parecida' del catálogo
- Listar companions de OTRA especie pretendiendo que son de la que preguntó
- Inventar nombres científicos como sinónimos del término del usuario

## Test plan post-deploy

- [ ] Repetir Test #4 ("mareñongoño del Tolima") → debe rechazar honestamente
- [ ] Probar variantes: "amotaqui", "marrunchera", "guaspirio" — todos inventados — debe rechazar igual
- [ ] Verificar que Tests 1, 3, 5 siguen PASS (no regresión)

Test #2 (broca del café) sigue pendiente — el operador lo skipó.

## Si esto NO funciona con gemma3:4b

Escalar a gemma3:12b local o Claude/Gemini cloud fallback. Bajo intelligence-first NO bajamos modelo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)