### PR TITLE
fix(agent): strict mode cuando catalog tiene campos críticos en null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.164",
+  "version": "0.12.165",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v206';
+const CACHE_NAME = 'chagra-v207';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -400,9 +400,43 @@ Hint del tool: ${hint}
       payload = payload.slice(0, TOOL_EVIDENCE_MAX_CHARS);
       truncated = true;
     }
-    // Caso "found:true" — wording autoritativo de PR #998. El bloque
-    // "DATOS VERIFICADOS" reemplaza la memoria del modelo cuando se cita
-    // companions / biopreparados / pest controllers / multihop / visual.
+    // 2026-05-23 incidente Test B (tomate de árbol temp/altitud) + Test A
+    // (aguacate Hass companions): el tool devolvió found:true pero con
+    // CAMPOS NULL (temp_min:null, altitud_min:null, companions:null). El
+    // LLM ignoró los null y RELLENÓ DE MEMORIA con valores inventados
+    // (tomate árbol "0-1200 msnm" cuando es 1500-2800 msnm).
+    //
+    // Detección de campos críticos vacíos. Si el record viene con null
+    // en data que el usuario claramente pidió, agregar warning explícito
+    // al system prompt para que el LLM NO invente esos valores.
+    const criticalEmptyFields = [];
+    if (result && typeof result === 'object') {
+      const sp = result.species || result;
+      if (sp && typeof sp === 'object') {
+        if (sp.temp_min === null && sp.temp_max === null) {
+          criticalEmptyFields.push('temperatura (temp_min y temp_max son null)');
+        }
+        if (sp.altitud_min === null && sp.altitud_max === null) {
+          criticalEmptyFields.push('altitud (altitud_min y altitud_max son null)');
+        }
+        if (sp.companions === null || (Array.isArray(sp.companions) && sp.companions.length === 0)) {
+          criticalEmptyFields.push('companions (vacío o null)');
+        }
+        if (sp.antagonists === null || (Array.isArray(sp.antagonists) && sp.antagonists.length === 0)) {
+          criticalEmptyFields.push('antagonists (vacío o null)');
+        }
+      }
+    }
+    const emptyFieldsWarning =
+      criticalEmptyFields.length > 0
+        ? `
+
+⚠️ CAMPOS CRÍTICOS VACÍOS EN ESTOS DATOS: ${criticalEmptyFields.join(', ')}.
+NO INVENTES valores numéricos (temperatura, altitud) ni listas (companions, antagonists) cuando el campo viene null o vacío. Responde literal: "El catálogo Chagra todavía no tiene documentados los valores de [campo] para [especie]. Tu consulta queda como pendiente de curaduría editorial."`
+        : '';
+
+    // Caso "found:true" — wording autoritativo de PR #998 + warning campos
+    // críticos vacíos (PR del 2026-05-23 tras tests A-E).
     return `
 
 === INSTRUCCIÓN CRÍTICA — PRIORIDAD DE FUENTES ===
@@ -416,7 +450,7 @@ El bloque "DATOS VERIFICADOS" abajo viene del knowledge graph del catálogo Chag
 
 === DATOS VERIFICADOS (chagra-agro-mcp tool: ${toolEvidence.tool}) ===
 ${payload}${truncated ? '\n[...truncated, ver detalle en ficha de especie]' : ''}
-=== FIN DATOS VERIFICADOS ===
+=== FIN DATOS VERIFICADOS ===${emptyFieldsWarning}
 
 RESPONDE SOLO a lo que el usuario preguntó usando ÚNICAMENTE los datos verificados de arriba.`;
   };


### PR DESCRIPTION
## Tests A, B del operador 2026-05-23 expusieron alucinación con tool found:true + null fields

- **Test A aguacate Hass**: persea_americana en catálogo tiene `companions:null`. LLM ignoró null + rellenó con companions del café (alucinación contextual).
- **Test B tomate árbol temp/altitud**: solanum_betaceum tiene temp y altitud TODOS null. LLM respondió '0-1200 msnm, 18-27°C' (real: 1500-2800 msnm, 13-20°C — planta andina).

## Fix

Detección en frontend de campos críticos vacíos (temp_min/max, altitud_min/max, companions, antagonists). Si alguno viene null, inyecta warning al system prompt forzando "NO INVENTES valores cuando viene null".

## Combina con

- PR #50 chagra-pro: heurística NLU extendida (252 keywords) para que MÁS queries disparen tool
- PR #999 (mergeado): anti-mapeo creativo cuando found:false
- PR #998 (mergeado): evidence autoritativa cuando found:true con datos

Este PR cierra el último gap (found:true + nulls).

## Solución de fondo

Enriquecer catálogo (task #113 corpus colombiano Fase 1 A1-A9). Este PR es parche prompt hasta que llegue corpus real.

## Test plan post-deploy

- [ ] Re-correr Test B: "qué temperatura y altitud necesita el tomate de árbol" → debe responder "el catálogo no tiene esos datos documentados todavía", no inventar
- [ ] Re-correr Test A: "qué plantas se asocian bien con el aguacate hass" → debe rechazar honesto sobre companions null
- [ ] Si responde correcto y dice no inventa → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)