### PR TITLE
fix(tts): strip markdown antes de enviar a Kokoro/SpeechSynthesis (#125)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.165",
+  "version": "0.12.166",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v207';
+const CACHE_NAME = 'chagra-v208';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/ttsService.sanitize.test.js
+++ b/src/services/__tests__/ttsService.sanitize.test.js
@@ -1,0 +1,134 @@
+/**
+ * Tests para `sanitizeForTTS` — strip markdown antes de enviar a Kokoro
+ * o Web SpeechSynthesis para evitar que el TTS lea literal "asterisco
+ * asterisco" cuando el LLM emite **negrita**.
+ *
+ * Bug reportado por operador 2026-05-23 (task #125).
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizeForTTS } from '../ttsService.js';
+
+describe('sanitizeForTTS', () => {
+  it('elimina ** de negrita pero mantiene el texto', () => {
+    expect(sanitizeForTTS('Esto es **importante** para el café'))
+      .toBe('Esto es importante para el café');
+  });
+
+  it('elimina __ de negrita estilo underscore', () => {
+    expect(sanitizeForTTS('Café __arábica__ y robusta'))
+      .toBe('Café arábica y robusta');
+  });
+
+  it('elimina * de cursiva', () => {
+    expect(sanitizeForTTS('La *Coffea arabica* es nativa de Etiopía'))
+      .toBe('La Coffea arabica es nativa de Etiopía');
+  });
+
+  it('elimina _ de cursiva estilo underscore', () => {
+    expect(sanitizeForTTS('El _aguacate_ requiere drenaje'))
+      .toBe('El aguacate requiere drenaje');
+  });
+
+  it('NO toca underscores en medio de palabras (snake_case)', () => {
+    // Common case: species_id, coffea_arabica. NO debe eliminarlos.
+    expect(sanitizeForTTS('El id es coffea_arabica con datos verificados'))
+      .toBe('El id es coffea_arabica con datos verificados');
+  });
+
+  it('elimina viñetas - * + al inicio de línea', () => {
+    const input = '- Aliso andino\n* Guamo\n+ Chachafruto';
+    const output = sanitizeForTTS(input);
+    expect(output).toContain('Aliso andino');
+    expect(output).toContain('Guamo');
+    expect(output).toContain('Chachafruto');
+    expect(output).not.toContain('-');
+    expect(output).not.toContain('+');
+  });
+
+  it('elimina numeración 1. 2. al inicio de línea', () => {
+    const input = '1. Sembrar\n2. Regar\n3. Cosechar';
+    const output = sanitizeForTTS(input);
+    expect(output).toContain('Sembrar');
+    expect(output).toContain('Regar');
+    expect(output).toContain('Cosechar');
+    expect(output).not.toMatch(/^\d/);
+  });
+
+  it('elimina encabezados # ## ### al inicio de línea', () => {
+    expect(sanitizeForTTS('# Companions del café')).toBe('Companions del café');
+    expect(sanitizeForTTS('## Subtitle')).toBe('Subtitle');
+    expect(sanitizeForTTS('### H3')).toBe('H3');
+  });
+
+  it('elimina inline code `texto`', () => {
+    expect(sanitizeForTTS('Usá `npm run build` antes')).toBe('Usá npm run build antes');
+  });
+
+  it('elimina links manteniendo solo el texto visible', () => {
+    expect(sanitizeForTTS('Ver [el catálogo](https://chagra.bio/catalog)'))
+      .toBe('Ver el catálogo');
+  });
+
+  it('elimina blockquote > al inicio de línea', () => {
+    expect(sanitizeForTTS('> Cita importante'))
+      .toBe('Cita importante');
+  });
+
+  it('elimina separadores horizontales', () => {
+    expect(sanitizeForTTS('Antes\n---\nDespués'))
+      .toContain('Antes');
+    expect(sanitizeForTTS('Antes\n---\nDespués'))
+      .toContain('Después');
+    expect(sanitizeForTTS('Antes\n---\nDespués'))
+      .not.toContain('---');
+  });
+
+  it('elimina pipes de tablas', () => {
+    expect(sanitizeForTTS('| Especie | Altitud |'))
+      .toBe('Especie Altitud');
+  });
+
+  it('mezcla compleja: respuesta típica del agente', () => {
+    const input = `**Compañeros del café arábica**
+
+Según el catálogo Chagra:
+
+- Aliso andino (Alnus acuminata)
+- Chachafruto (*Erythrina edulis*)
+- Guamo (Inga edulis)
+
+Ver [ficha completa](https://chagra.bio/especies/coffea_arabica) para más.`;
+    const output = sanitizeForTTS(input);
+    expect(output).toContain('Compañeros del café arábica');
+    expect(output).toContain('Aliso andino');
+    expect(output).toContain('Chachafruto');
+    expect(output).toContain('Erythrina edulis');
+    expect(output).toContain('ficha completa');
+    expect(output).not.toContain('*');
+    expect(output).not.toContain('https://');
+    expect(output).not.toContain('[');
+    expect(output).not.toContain(']');
+    expect(output).not.toMatch(/^- /m);
+  });
+
+  it('texto sin markdown pasa idempotente', () => {
+    const plain = 'El café arábica crece entre 1200 y 1800 msnm';
+    expect(sanitizeForTTS(plain)).toBe(plain);
+  });
+
+  it('texto vacío o no-string devuelve sin cambios', () => {
+    expect(sanitizeForTTS('')).toBe('');
+    expect(sanitizeForTTS(null)).toBe(null);
+    expect(sanitizeForTTS(undefined)).toBe(undefined);
+    expect(sanitizeForTTS(123)).toBe(123);
+  });
+
+  it('colapsa espacios múltiples', () => {
+    expect(sanitizeForTTS('Café    arábica     andino'))
+      .toBe('Café arábica andino');
+  });
+
+  it('colapsa líneas vacías múltiples', () => {
+    expect(sanitizeForTTS('Antes\n\n\n\nDespués')).toBe('Antes\n\nDespués');
+  });
+});

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -5,6 +5,58 @@
  * Si Kokoro no está disponible, fallback transparente a window.speechSynthesis.
  */
 
+/**
+ * Limpia markdown del texto antes de mandarlo al TTS. Sin esto, kokoro y
+ * SpeechSynthesis leen literal los caracteres de formato:
+ *   "asterisco asterisco bold asterisco asterisco" en lugar de "bold",
+ *   "guion espacio item" en lugar de "item".
+ *
+ * Bug reportado por operador 2026-05-23 (task #125): el agente Chagra
+ * emite respuestas en markdown con listas (`*`), negrita (`**`),
+ * encabezados (`#`), inline code (`` ` ``), y links `[txt](url)`. El TTS
+ * los leía literal, generando UX muy fea ("peye" según operador).
+ *
+ * Mantenemos las transformaciones simples + idempotentes. Si el texto NO
+ * tiene markdown, devuelve el texto sin cambios.
+ */
+export function sanitizeForTTS(text) {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  return text
+    // Negrita ** o __ (procesar antes que cursiva para evitar romper la pareja)
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    // Cursiva * o _
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/(?<![A-Za-z0-9])_([^_\n]+)_(?![A-Za-z0-9])/g, '$1')
+    // Inline code `texto`
+    .replace(/`([^`\n]+)`/g, '$1')
+    // Code fences ```lang\n...\n```
+    .replace(/```[a-z]*\n?([\s\S]*?)```/gi, '$1')
+    // Encabezados markdown # ## ### al inicio de línea
+    .replace(/^#{1,6}\s+/gm, '')
+    // Viñetas - * + al inicio de línea
+    .replace(/^[\s]*[-*+]\s+/gm, '')
+    // Numeración 1. 2. etc al inicio de línea
+    .replace(/^[\s]*\d+[.)]\s+/gm, '')
+    // Links [texto](url) → solo el texto visible
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    // Citas blockquote > al inicio de línea
+    .replace(/^[\s]*>\s+/gm, '')
+    // Separadores horizontales ---, ===, ***
+    .replace(/^[\s]*[-=*]{3,}[\s]*$/gm, '')
+    // Tablas (filas con |) — borrar carácter pipe
+    .replace(/\|/g, ' ')
+    // Caracteres residuales * y ` (NO _ — esos forman parte de snake_case ids
+    // como coffea_arabica que el agente cita literalmente). Si el LLM emite
+    // __ o * sueltos, los limpio; pero un _ entre dos letras de un id NO.
+    .replace(/[*`]/g, '')
+    // Espacios múltiples consecutivos → 1
+    .replace(/[ \t]+/g, ' ')
+    // Líneas en blanco múltiples → 1
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 let voices = [];
 let voicesLoaded = false;
 let kokoroAvailable = null;
@@ -72,7 +124,10 @@ export function speak(text, options = {}) {
 
   stop();
 
-  const utterance = new SpeechSynthesisUtterance(text);
+  // Strip markdown antes de sintetizar. Sin esto, SpeechSynthesis lee
+  // literal "asterisco asterisco" cuando el texto trae **negrita**.
+  const cleanText = sanitizeForTTS(text);
+  const utterance = new SpeechSynthesisUtterance(cleanText);
 
   const {
     rate = 0.9,
@@ -153,11 +208,17 @@ export async function speakKokoro(text, options = {}) {
 
   stop();
 
+  // Strip markdown antes de mandar al server Kokoro. Sin esto, el TTS
+  // neuronal lee literal "asterisco asterisco" cuando el texto trae
+  // **negrita**, "guion item" para viñetas, etc. (operador 2026-05-23,
+  // task #125: "como peye no?").
+  const cleanText = sanitizeForTTS(text);
+
   try {
     const res = await fetch('/api/kokoro/tts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, voice, format, lang }),
+      body: JSON.stringify({ text: cleanText, voice, format, lang }),
     });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);


### PR DESCRIPTION
## Bug

Operador 2026-05-23: el TTS lee literal '**asterisco asterisco** importante **asterisco asterisco**' cuando el agente emite `**negrita**`. Idem viñetas, encabezados, links. *'Como peye no?'*

## Fix

Nueva función pura `sanitizeForTTS(text)` que normaliza markdown antes de `speak()` y `speakKokoro()`.

Preserva snake_case ids como `coffea_arabica` que el agente cita literalmente (caso especial verificado con test).

## Tests

18 vitest pasan, incluye mezcla típica de respuesta del agente con bullets + bold + scientific name + link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)