### PR TITLE
feat(agent): colibrí global notification + double-click tts controls (#122)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.166",
+  "version": "0.12.167",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v208';
+const CACHE_NAME = 'chagra-v209';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentFab.jsx
+++ b/src/components/AgentFab.jsx
@@ -1,5 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import ChagraAgentAvatar from './ChagraAgentAvatar';
+import useAgentNotificationStore from '../store/useAgentNotificationStore';
+import usePrefsStore from '../store/usePrefsStore';
+import { isSpeaking, stop, replayLast, isKokoroAvailable } from '../services/ttsService';
+import { agentSounds } from '../services/agentSoundService';
 
 /**
  * AgentFab — Floating Action Button para abrir el agente Chagra IA.
@@ -10,12 +14,27 @@ import ChagraAgentAvatar from './ChagraAgentAvatar';
  *   - mouse down / pulsacion → estado `speaking` mas breve para sentir el feedback.
  *   - touch (mobile) → estado `thinking` mientras se mantiene el toque.
  *
+ * Task #122 (2026-05-23): el FAB ahora es el avatar global. Lee de
+ * `useAgentNotificationStore`:
+ *   - `responseReady` → glow drop-shadow amber para anunciar "respuesta lista"
+ *     mientras el operador está en otra pantalla.
+ * Double-click handler:
+ *   - Si TTS está reproduciendo → stop() inmediato + ttsEnabled=false.
+ *   - Si TTS OFF y hay último mensaje → replayLast() + ttsEnabled=true.
+ *   - Si no hay nada que reproducir, no-op (sin error visible).
+ * Single click → abrir AgentScreen (comportamiento previo).
+ *
  * El FAB tambien escala 1.06x al hover/active para feedback claro de boton
  * sin perder el sello visual del colibri.
  */
 export default function AgentFab({ onNavigate }) {
   const [hover, setHover] = useState(false);
   const [pressed, setPressed] = useState(false);
+
+  const responseReady = useAgentNotificationStore((s) => s.responseReady);
+  const lastAssistantMessage = useAgentNotificationStore((s) => s.lastAssistantMessage);
+  const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
+  const setTtsEnabled = usePrefsStore((s) => s.setTtsEnabled);
 
   // Estado del avatar:
   // - pressed -> 'speaking' (cuerpo bob, plumaje pulsa) durante el tap
@@ -28,12 +47,48 @@ export default function AgentFab({ onNavigate }) {
   const handleDown = () => setPressed(true);
   const handleUp = () => setPressed(false);
 
+  const handleClick = () => {
+    onNavigate('agente');
+  };
+
+  // Task #122: double-click toggle silencia/reactiva audio global.
+  // - Si está hablando (Kokoro o Web Speech) → stop() + ttsEnabled OFF.
+  // - Si silenciado y hay last message → replayLast() + ttsEnabled ON.
+  // - Sin último mensaje: feedback sutil (cancel sound) y no-op de TTS.
+  const handleDoubleClick = useCallback(async (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+    if (isSpeaking() || ttsEnabled) {
+      // Cualquier playback activo OR estado "enabled" lo apagamos
+      stop();
+      setTtsEnabled(false);
+      agentSounds.cancel();
+      return;
+    }
+    // TTS OFF: reactivar + replay si hay algo cacheado
+    if (lastAssistantMessage) {
+      setTtsEnabled(true);
+      const kokoroReady = await isKokoroAvailable();
+      await replayLast({ useKokoro: kokoroReady });
+      agentSounds.chime();
+    } else {
+      // No hay nada que reproducir. Reactivamos el toggle igual para que
+      // futuras respuestas suenen, pero sin chime engañoso.
+      setTtsEnabled(true);
+    }
+  }, [ttsEnabled, lastAssistantMessage, setTtsEnabled]);
+
   return (
     <button
       type="button"
-      aria-label="Asistente Chagra IA"
-      title="Hablar con Chagra IA"
-      onClick={() => onNavigate('agente')}
+      aria-label={responseReady ? 'Chagra IA tiene respuesta nueva' : 'Asistente Chagra IA'}
+      title={
+        responseReady
+          ? 'Chagra IA tiene respuesta nueva. Doble click silencia o reactiva la voz'
+          : 'Hablar con Chagra IA. Doble click silencia o reactiva la voz'
+      }
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
       onMouseEnter={handleEnter}
       onMouseLeave={handleLeave}
       onMouseDown={handleDown}
@@ -49,7 +104,9 @@ export default function AgentFab({ onNavigate }) {
         width: 56,
         height: 56,
         borderRadius: '50%',
-        border: '2px solid rgba(16,185,129,.55)',
+        border: responseReady
+          ? '2px solid rgba(255,183,0,.7)'
+          : '2px solid rgba(16,185,129,.55)',
         background: hover
           ? 'radial-gradient(circle at 30% 25%, #1e3a2f 0%, #0a1320 70%)'
           : 'radial-gradient(circle at 30% 25%, #1e293b 0%, #0f172a 70%)',
@@ -65,10 +122,10 @@ export default function AgentFab({ onNavigate }) {
         padding: 0,
         overflow: 'hidden',
         transform: pressed ? 'scale(0.95)' : hover ? 'scale(1.06)' : 'scale(1)',
-        transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), box-shadow .25s ease, background .25s ease',
+        transition: 'transform .18s cubic-bezier(.34,1.56,.64,1), box-shadow .25s ease, background .25s ease, border-color .25s ease',
       }}
     >
-      <ChagraAgentAvatar state={state} size={48} ariaLabel="Chagra IA" />
+      <ChagraAgentAvatar state={state} size={48} ariaLabel="Chagra IA" glow={responseReady} />
     </button>
   );
 }

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -11,7 +11,7 @@ import { buildLLMRequest } from '../../services/llmRouter';
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool } from '../../services/sidecarClient';
-import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable } from '../../services/ttsService';
+import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
 import ChatHistory from './ChatHistory';
 import SuggestedActions from './SuggestedActions';
@@ -20,6 +20,7 @@ import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
+import useAgentNotificationStore from '../../store/useAgentNotificationStore';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 
 // 2026-05-16: migrado a llmRouter (Multi-LLM por tarea). AgentScreen usa
@@ -33,6 +34,14 @@ const STATE_THINKING = 'thinking';
 
 export default function AgentScreen({ onBack }) {
   const operatorId = usePrefsStore((s) => s.operatorId) || 'default-operator';
+  // Task #122 (2026-05-23): ttsEnabled global persistido en usePrefsStore.
+  // Antes era useState local — al cambiarlo en otra pantalla (header
+  // colibrí dblclick) AgentScreen no se enteraba.
+  const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
+  const setTtsEnabled = usePrefsStore((s) => s.setTtsEnabled);
+  const setResponseReady = useAgentNotificationStore((s) => s.setResponseReady);
+  const setLastNotificationMessage = useAgentNotificationStore((s) => s.setLastMessage);
+  const markRead = useAgentNotificationStore((s) => s.markRead);
   const plants = useAssetStore((s) => s.plants);
   // 062.6: contexto finca activa para system prompt (zona biocultural,
   // altitud, override indoor invernadero).
@@ -47,7 +56,6 @@ export default function AgentScreen({ onBack }) {
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [error, setError] = useState('');
   const [actionModal, setActionModal] = useState({ isOpen: false, intent: null, llmResponse: '' });
-  const [ttsEnabled, setTtsEnabled] = useState(true);
   const ttsSupported = isSupported();
   const [kokoroReady, setKokoroReady] = useState(false);
   // Bug 2026-05-18 (Karen reportó stuck-pensando): tras 20s sin token visible,
@@ -149,6 +157,10 @@ export default function AgentScreen({ onBack }) {
     initTTS();
     isKokoroAvailable().then(setKokoroReady);
     loadHistory();
+    // Task #122: al entrar a AgentScreen, apaga el glow del avatar global.
+    // El operador ya está mirando la conversación, no necesita el "reluce"
+    // de "respuesta nueva".
+    markRead();
     // 057.4 integration: registrar el callback del actionExecutor. Cuando el
     // LLM proponga una tool con requiresGate=true, actionExecutor llamará
     // este callback que abre el ActionConfirmModal y retorna un Promise.
@@ -178,7 +190,7 @@ export default function AgentScreen({ onBack }) {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, [loadHistory]);
+  }, [loadHistory, markRead]);
 
   const getSystemPrompt = useCallback(() => {
     // Operator bug 2026-05-18: agente listaba "Fresa #02, Fresa #08, Fresa #02..."
@@ -604,6 +616,18 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       await addTurn(operatorId, { role: 'assistant', content: response });
       setMessages((prev) => [...prev, assistantMessage]);
 
+      // Task #122: cachear el último mensaje del agente en el store global
+      // para que el doble-click del avatar (cualquier pantalla) pueda re-
+      // reproducirlo via replayLast(). responseReady NO se setea acá porque
+      // el usuario ESTÁ en AgentScreen — el glow se activa cuando alguien
+      // sale a otra pantalla mid-stream y vuelve a recibir respuesta tarde.
+      // Para cubrir ese caso, también lo seteamos pero igualmente markRead
+      // se dispara al ver el componente activo (efecto cancelado al volver).
+      if (response) {
+        setLastNotificationMessage(response);
+        setResponseReady(true);
+      }
+
       if (ttsEnabled && response) {
         stop();
         if (kokoroReady) {
@@ -722,6 +746,22 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         <ChagraAgentAvatar
           state={state === STATE_RECORDING ? 'listening' : state === STATE_THINKING ? 'thinking' : 'idle'}
           size={40}
+          onDoubleClick={async () => {
+            // Task #122: doble-click avatar header silencia/reactiva audio.
+            // Espejo del comportamiento del AgentFab global, pero acá ya
+            // estamos en AgentScreen así que solo tocamos TTS.
+            if (isSpeaking() || ttsEnabled) {
+              stop();
+              setTtsEnabled(false);
+              agentSounds.cancel();
+              return;
+            }
+            // Reactivar + replay último mensaje
+            setTtsEnabled(true);
+            const ok = await replayLast({ useKokoro: kokoroReady });
+            if (ok) agentSounds.chime();
+          }}
+          ariaLabel="Avatar Chagra IA, doble click para silenciar o reactivar la voz"
         />
         <div className="flex-1 min-w-0">
           <h1 className="text-base font-bold text-white leading-tight">Chagra IA</h1>

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { User } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../services/ttsService';
+import { agentSounds } from '../../services/agentSoundService';
 
 function formatTime(timestamp) {
   if (!timestamp) return '';
@@ -16,6 +18,33 @@ export default function ChatBubble({ message, isStreaming = false }) {
   // la proxima pregunta. Si esta streaming, intensifica a thinking (sip mas
   // rapido + alas en blur). Si no, idle suave igual queda en movimiento.
   const agentState = isStreaming ? 'thinking' : 'thinking';
+
+  // Task #122 (2026-05-23): doble-click en burbuja del agente activa/silencia
+  // SOLO ese mensaje. Si TTS está sonando → stop. Si está silenciado →
+  // reproducir SOLO esa respuesta puntual (no cambia el toggle global de
+  // ttsEnabled). Permite al operador "leer en voz alta este párrafo" sin
+  // reactivar toda la voz del agente.
+  const handleBubbleDoubleClick = async (e) => {
+    if (isUser || isStreaming) return;
+    if (typeof message.content !== 'string' || message.content.trim().length === 0) return;
+    e.stopPropagation();
+    if (isSpeaking()) {
+      stop();
+      agentSounds.cancel();
+      return;
+    }
+    try {
+      const kokoroReady = await isKokoroAvailable();
+      if (kokoroReady) {
+        await speakKokoro(message.content, { rate: 0.9, pitch: 1.0 });
+      } else {
+        speak(message.content, { rate: 0.9, pitch: 1.0 });
+      }
+      agentSounds.chime();
+    } catch (_) {
+      // No reportar al UI — el TTS es secundario, no debe interrumpir lectura.
+    }
+  };
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} mb-3`}>
@@ -34,11 +63,15 @@ export default function ChatBubble({ message, isStreaming = false }) {
           </div>
         )}
 
-        <div className={`rounded-2xl px-4 py-2.5 ${
-          isUser
-            ? 'bg-emerald-700/60 text-white rounded-tr-sm'
-            : 'bg-slate-800/80 text-slate-100 rounded-tl-sm'
-        }`}>
+        <div
+          className={`rounded-2xl px-4 py-2.5 ${
+            isUser
+              ? 'bg-emerald-700/60 text-white rounded-tr-sm'
+              : 'bg-slate-800/80 text-slate-100 rounded-tl-sm cursor-pointer'
+          }`}
+          onDoubleClick={handleBubbleDoubleClick}
+          title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
+        >
           <p className="text-sm leading-relaxed whitespace-pre-wrap">{message.content}</p>
           {message.timestamp && (
             <p className={`text-[10px] mt-1 ${isUser ? 'text-emerald-300/60' : 'text-slate-500'}`}>

--- a/src/components/ChagraAgentAvatar.jsx
+++ b/src/components/ChagraAgentAvatar.jsx
@@ -30,6 +30,12 @@ import React from 'react';
  *   - `size`: number en px (default 56). Mínimo recomendado 40px.
  *   - `withLabel`: muestra "Chagra IA" + sub-estado bajo el avatar
  *   - `onClick`: opcional, hace clickable
+ *   - `onDoubleClick`: opcional, double-click handler (task #122). Si está
+ *     presente, el wrapper button maneja también `onDoubleClick`. Operator
+ *     usa para silenciar/re-reproducir TTS sin abrir AgentScreen.
+ *   - `glow`: boolean (default false). Si true, el avatar pulsa con
+ *     drop-shadow amber (#FFB700) anunciando "respuesta lista". Tono
+ *     honesto, sin confetti.
  *   - `className`, `ariaLabel`: passthrough
  */
 
@@ -52,12 +58,14 @@ export default function ChagraAgentAvatar({
   size = 56,
   withLabel = false,
   onClick,
+  onDoubleClick,
+  glow = false,
   className = '',
   ariaLabel,
 }) {
   const tone = STATE_TONE_TEXT[state] || STATE_TONE_TEXT.idle;
   const label = STATE_LABEL[state] || STATE_LABEL.idle;
-  const interactive = typeof onClick === 'function';
+  const interactive = typeof onClick === 'function' || typeof onDoubleClick === 'function';
   // ID único por instancia para que múltiples avatares no colisionen en gradients
   const uid = React.useId();
 
@@ -67,7 +75,7 @@ export default function ChagraAgentAvatar({
         viewBox="0 0 200 200"
         width={size}
         height={size}
-        className={`chagra-agent-avatar chagra-state-${state}`}
+        className={`chagra-agent-avatar chagra-state-${state}${glow ? ' chagra-glow' : ''}`}
         role="img"
         aria-label={ariaLabel || label}
       >
@@ -427,10 +435,32 @@ export default function ChagraAgentAvatar({
             100% { opacity: 0; transform: scale(1.3); }
           }
 
+          /* ===== GLOW (task #122): respuesta lista, brilla pulsando ====
+             drop-shadow amber #FFB700 1.5s ease-in-out infinite. NO confetti,
+             NO bouncing — tono honesto del avatar. Activo en TODA la app
+             cuando responseReady=true en useAgentNotificationStore. */
+          .chagra-agent-avatar.chagra-glow {
+            animation: chagra-glow-pulse 1.5s ease-in-out infinite;
+          }
+          @keyframes chagra-glow-pulse {
+            0%, 100% {
+              filter: drop-shadow(0 0 2px rgba(255, 183, 0, .35))
+                      drop-shadow(0 0 6px rgba(255, 183, 0, .25));
+            }
+            50% {
+              filter: drop-shadow(0 0 6px rgba(255, 183, 0, .9))
+                      drop-shadow(0 0 14px rgba(255, 183, 0, .55));
+            }
+          }
+
           /* ===== Reduced motion ===== */
           @media (prefers-reduced-motion: reduce) {
             .chagra-agent-avatar * {
               animation: none !important;
+            }
+            .chagra-agent-avatar.chagra-glow {
+              animation: none !important;
+              filter: drop-shadow(0 0 4px rgba(255, 183, 0, .6));
             }
           }
         `}</style>
@@ -450,8 +480,10 @@ export default function ChagraAgentAvatar({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-400/50 transition-all hover:scale-105"
+      onDoubleClick={onDoubleClick}
+      className="rounded-full focus:outline-none focus:ring-2 focus:ring-emerald-400/50 transition-all hover:scale-105 active:scale-95"
       aria-label={ariaLabel || `Abrir ${label}`}
+      title={onDoubleClick ? 'Doble click silencia o reactiva la voz' : undefined}
     >
       {content}
     </button>

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home } from 'lucide-react';
+import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import ThemeSelector from './common/ThemeSelector';
 import BackupExportButton from './BackupExportButton';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
+import usePrefsStore from '../store/usePrefsStore';
+import { stop as stopTTS } from '../services/ttsService';
 
 const TTL_OPTIONS = [
   { id: '1d', label: '1 día' },
@@ -156,6 +158,12 @@ export default function ProfileScreen({ onBack, onHome }) {
           <ThemeSelector />
         </div>
 
+        {/* Task #122 (2026-05-23): toggle global TTS del agente Chagra.
+            Persiste en usePrefsStore (localStorage `chagra:prefs:tts-enabled`).
+            Default ON. Operador puede silenciar también con doble-click en
+            el avatar colibrí (header AgentScreen o FAB global). */}
+        <AgentVoiceSection />
+
         {/* Telemetry Section */}
         <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
           <div className="flex items-center gap-2 px-1">
@@ -224,6 +232,66 @@ export default function ProfileScreen({ onBack, onHome }) {
         </div>
       </div>
     </ScreenShell>
+  );
+}
+
+/**
+ * AgentVoiceSection — Task #122 (2026-05-23).
+ *
+ * Toggle "Voz del agente activa" persistido en usePrefsStore (key
+ * `chagra:prefs:tts-enabled`). Cuando se desactiva, se llama stop()
+ * inmediato del ttsService para silenciar cualquier playback en curso.
+ *
+ * Equivalente al doble-click del avatar colibrí, pero accesible desde
+ * Perfil para operadores que prefieran control explícito UI.
+ */
+function AgentVoiceSection() {
+  const ttsEnabled = usePrefsStore((s) => s.ttsEnabled);
+  const setTtsEnabled = usePrefsStore((s) => s.setTtsEnabled);
+
+  const handleToggle = () => {
+    const next = !ttsEnabled;
+    if (!next) {
+      // Si desactivamos, cortamos cualquier audio actual de inmediato
+      stopTTS();
+    }
+    setTtsEnabled(next);
+  };
+
+  return (
+    <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+      <div className="flex items-center gap-2 px-1">
+        <Volume2 size={18} className="text-violet-400" />
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Voz del agente</h3>
+      </div>
+
+      <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
+        <div className="flex flex-col gap-0.5 flex-1">
+          <span className="text-sm font-bold text-slate-200">Voz del agente activa</span>
+          <span className="text-[10px] text-slate-500 leading-snug">
+            Cuando está activa, Chagra IA lee en voz alta sus respuestas (Kokoro TTS,
+            con respaldo al sintetizador del navegador). Doble click en el avatar
+            colibrí silencia o reactiva sin abrir esta pantalla.
+          </span>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={ttsEnabled}
+          aria-label="Activar o silenciar la voz del agente"
+          onClick={handleToggle}
+          className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+            ttsEnabled ? 'bg-violet-600' : 'bg-slate-700'
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform ${
+              ttsEnabled ? 'translate-x-5' : 'translate-x-0'
+            }`}
+          />
+        </button>
+      </label>
+    </div>
   );
 }
 

--- a/src/components/__tests__/ChagraAgentAvatar.test.jsx
+++ b/src/components/__tests__/ChagraAgentAvatar.test.jsx
@@ -1,0 +1,93 @@
+/**
+ * ChagraAgentAvatar — task #122.
+ *
+ * Cubre las extensiones añadidas para el sistema global de notificaciones:
+ *   - `glow` prop agrega la clase `chagra-glow` al SVG raíz.
+ *   - `onDoubleClick` se invoca al doble-click del wrapper button.
+ *   - a11y: aria-label custom + role="img" + tooltip title presente cuando
+ *     hay onDoubleClick.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import ChagraAgentAvatar from '../ChagraAgentAvatar';
+
+describe('ChagraAgentAvatar — task #122 glow + double-click', () => {
+  test('por defecto NO incluye clase chagra-glow', () => {
+    const { container } = render(<ChagraAgentAvatar state="idle" />);
+    const svg = container.querySelector('svg.chagra-agent-avatar');
+    expect(svg).toBeInTheDocument();
+    expect(svg.classList.contains('chagra-glow')).toBe(false);
+  });
+
+  test('con prop glow={true} agrega clase chagra-glow al SVG', () => {
+    const { container } = render(<ChagraAgentAvatar state="idle" glow />);
+    const svg = container.querySelector('svg.chagra-agent-avatar');
+    expect(svg).toBeInTheDocument();
+    expect(svg.classList.contains('chagra-glow')).toBe(true);
+  });
+
+  test('sin onClick ni onDoubleClick renderiza solo el SVG (no button)', () => {
+    const { container } = render(<ChagraAgentAvatar state="idle" />);
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  test('con onDoubleClick envuelve en button y dispara el handler', () => {
+    const onDoubleClick = vi.fn();
+    render(<ChagraAgentAvatar state="idle" onDoubleClick={onDoubleClick} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeInTheDocument();
+    fireEvent.doubleClick(btn);
+    expect(onDoubleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('con onClick y onDoubleClick juntos cada uno dispara independiente', () => {
+    const onClick = vi.fn();
+    const onDoubleClick = vi.fn();
+    render(<ChagraAgentAvatar state="idle" onClick={onClick} onDoubleClick={onDoubleClick} />);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    fireEvent.doubleClick(btn);
+    expect(onClick).toHaveBeenCalled();
+    expect(onDoubleClick).toHaveBeenCalled();
+  });
+
+  test('a11y: aria-label custom se respeta', () => {
+    render(
+      <ChagraAgentAvatar
+        state="idle"
+        onDoubleClick={() => {}}
+        ariaLabel="Avatar Chagra IA, doble click para silenciar la voz"
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /silenciar la voz/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('a11y: tooltip title aparece cuando hay onDoubleClick', () => {
+    render(<ChagraAgentAvatar state="idle" onDoubleClick={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('title', expect.stringMatching(/doble click/i));
+  });
+
+  test('SVG aplica la clase de estado correspondiente', () => {
+    const { container, rerender } = render(<ChagraAgentAvatar state="thinking" />);
+    expect(
+      container.querySelector('svg.chagra-state-thinking'),
+    ).toBeInTheDocument();
+    rerender(<ChagraAgentAvatar state="listening" />);
+    expect(
+      container.querySelector('svg.chagra-state-listening'),
+    ).toBeInTheDocument();
+  });
+
+  test('glow + state coexisten sin conflicto', () => {
+    const { container } = render(<ChagraAgentAvatar state="speaking" glow />);
+    const svg = container.querySelector('svg.chagra-agent-avatar');
+    expect(svg.classList.contains('chagra-state-speaking')).toBe(true);
+    expect(svg.classList.contains('chagra-glow')).toBe(true);
+  });
+});

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -62,6 +62,14 @@ let voicesLoaded = false;
 let kokoroAvailable = null;
 let currentKokoroAudio = null;
 let currentKokoroUrl = null;
+// Task #122 (2026-05-23): cache del último texto que se mandó a hablar
+// (Kokoro o Web Speech). Permite el "double-click avatar global → re-
+// reproducir último mensaje del agente" cuando TTS está habilitado.
+// El cache se llena cada vez que speakKokoro/speak corre con texto
+// no vacío. Se preserva entre stop()s para que el operador silencie y
+// luego pueda re-escuchar lo mismo.
+let lastSpoken = null;
+let lastSpokenOptions = null;
 
 function loadVoices() {
   return new Promise((resolve) => {
@@ -151,6 +159,13 @@ export function speak(text, options = {}) {
 
   utterance.lang = 'es-CO';
 
+  // Task #122: guardar para replayLast(). Texto vacío no se cachea para
+  // evitar replayLast() repitiendo nada cuando el operador hizo speak('').
+  if (typeof text === 'string' && text.trim().length > 0) {
+    lastSpoken = text;
+    lastSpokenOptions = { ...options };
+  }
+
   window.speechSynthesis.speak(utterance);
 
   return utterance;
@@ -214,6 +229,13 @@ export async function speakKokoro(text, options = {}) {
   // task #125: "como peye no?").
   const cleanText = sanitizeForTTS(text);
 
+  // Task #122: guardar el texto original (no sanitizado) para replayLast()
+  // — replayLast vuelve a llamar speakKokoro que re-sanitiza idempotente.
+  if (typeof text === 'string' && text.trim().length > 0) {
+    lastSpoken = text;
+    lastSpokenOptions = { ...options };
+  }
+
   try {
     const res = await fetch('/api/kokoro/tts', {
       method: 'POST',
@@ -255,6 +277,45 @@ export function isPaused() {
   return window.speechSynthesis?.paused || false;
 }
 
+/**
+ * Task #122 (2026-05-23): re-reproduce el último texto sintetizado.
+ *
+ * Usado por el doble-click del avatar global colibrí cuando TTS está
+ * silenciado y el operador quiere volver a escuchar el último mensaje
+ * del agente. Si nunca se habló, no-op silencioso (no throw, devuelve
+ * false para que el caller decida feedback).
+ *
+ * Estrategia: si Kokoro estaba ready (sabemos porque lastSpokenOptions
+ * existe), re-feed por Kokoro. Sino, Web Speech. Acepta override de
+ * `useKokoro` para casos donde el caller ya sabe el estado del backend.
+ */
+export async function replayLast({ useKokoro = null } = {}) {
+  if (!lastSpoken) return false;
+  const opts = lastSpokenOptions || {};
+  // Decisión por defecto: probar Kokoro si la última vez fue Kokoro
+  // (heurística: opts trae `voice` ef_*). Sino Web Speech.
+  const shouldUseKokoro =
+    useKokoro !== null
+      ? useKokoro
+      : typeof opts.voice === 'string' && opts.voice.startsWith('ef_');
+  try {
+    if (shouldUseKokoro) {
+      await speakKokoro(lastSpoken, opts);
+    } else {
+      speak(lastSpoken, opts);
+    }
+    return true;
+  } catch (_) {
+    // speakKokoro ya hace fallback interno a speak() en error, así que si
+    // tira hasta acá es algo raro. No bloquear el caller.
+    return false;
+  }
+}
+
+export function getLastSpoken() {
+  return lastSpoken;
+}
+
 export function init() {
   loadVoices();
 }
@@ -271,5 +332,7 @@ export default {
   isKokoroAvailable,
   getVoices,
   getSpanishVoice,
+  replayLast,
+  getLastSpoken,
   init,
 };

--- a/src/store/__tests__/useAgentNotificationStore.test.js
+++ b/src/store/__tests__/useAgentNotificationStore.test.js
@@ -1,0 +1,74 @@
+/**
+ * useAgentNotificationStore — task #122.
+ *
+ * Cubre el bus global de notificaciones del avatar colibrí:
+ *   - setResponseReady toggle correctamente
+ *   - setLastMessage acepta strings no vacíos, descarta tipos inválidos
+ *   - markRead apaga responseReady sin tocar lastAssistantMessage
+ *     (porque queremos retener el texto para replayLast aún tras "leer")
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import useAgentNotificationStore from '../useAgentNotificationStore';
+
+const resetStore = () => {
+  useAgentNotificationStore.setState({
+    responseReady: false,
+    lastAssistantMessage: null,
+  });
+};
+
+describe('useAgentNotificationStore', () => {
+  beforeEach(resetStore);
+
+  it('arranca con responseReady=false y lastAssistantMessage=null', () => {
+    const s = useAgentNotificationStore.getState();
+    expect(s.responseReady).toBe(false);
+    expect(s.lastAssistantMessage).toBeNull();
+  });
+
+  it('setResponseReady acepta truthy/falsy y normaliza a Boolean', () => {
+    const { setResponseReady } = useAgentNotificationStore.getState();
+    setResponseReady(true);
+    expect(useAgentNotificationStore.getState().responseReady).toBe(true);
+    setResponseReady(false);
+    expect(useAgentNotificationStore.getState().responseReady).toBe(false);
+    setResponseReady('yes');
+    expect(useAgentNotificationStore.getState().responseReady).toBe(true);
+    setResponseReady(0);
+    expect(useAgentNotificationStore.getState().responseReady).toBe(false);
+  });
+
+  it('setLastMessage guarda strings no vacíos', () => {
+    const { setLastMessage } = useAgentNotificationStore.getState();
+    setLastMessage('respuesta del agente');
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBe('respuesta del agente');
+  });
+
+  it('setLastMessage descarta strings vacíos y tipos no-string', () => {
+    const { setLastMessage } = useAgentNotificationStore.getState();
+    setLastMessage('hola');
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBe('hola');
+    setLastMessage('');
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBeNull();
+    setLastMessage(123);
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBeNull();
+    setLastMessage({ x: 1 });
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBeNull();
+  });
+
+  it('markRead apaga responseReady pero retiene lastAssistantMessage', () => {
+    const { setResponseReady, setLastMessage, markRead } =
+      useAgentNotificationStore.getState();
+    setResponseReady(true);
+    setLastMessage('respuesta cacheada');
+    expect(useAgentNotificationStore.getState().responseReady).toBe(true);
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBe('respuesta cacheada');
+
+    markRead();
+
+    expect(useAgentNotificationStore.getState().responseReady).toBe(false);
+    // El mensaje se conserva — el replayLast debe poder seguir funcionando
+    // aún después de que el operador "lea" la respuesta visualmente.
+    expect(useAgentNotificationStore.getState().lastAssistantMessage).toBe('respuesta cacheada');
+  });
+});

--- a/src/store/useAgentNotificationStore.js
+++ b/src/store/useAgentNotificationStore.js
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+/**
+ * useAgentNotificationStore — bus global de notificaciones del agente.
+ *
+ * Operator decisión 2026-05-23 (task #122): el colibrí Chagra es el avatar
+ * del agente y vive global (AgentFab) en TODA la app. Cuando AgentScreen
+ * termina un stream LLM, marcamos `responseReady=true` y el AgentFab
+ * arranca a brillar (glow drop-shadow amber) en cualquier pantalla. Al
+ * volver a AgentScreen → `markRead()` apaga el brillo.
+ *
+ * `lastAssistantMessage` se usa para el doble-click del avatar global:
+ * si TTS está silenciado, re-reproducir el último mensaje del agente.
+ *
+ * Tono: honesto, sin confetti ni bouncing. El glow es señal sutil de
+ * "hay algo nuevo para ti sin gritarlo".
+ *
+ * No persistimos en localStorage: la noción de "respuesta lista no leída"
+ * tiene sentido SOLO dentro de la sesión activa (post-reload nada nuevo
+ * te espera, salvo que el agente esté streameando).
+ */
+const useAgentNotificationStore = create((set) => ({
+  responseReady: false,
+  lastAssistantMessage: null,
+
+  setResponseReady: (flag) => set({ responseReady: Boolean(flag) }),
+  setLastMessage: (text) =>
+    set({ lastAssistantMessage: typeof text === 'string' && text.length > 0 ? text : null }),
+  markRead: () => set({ responseReady: false }),
+}));
+
+export default useAgentNotificationStore;

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -2,6 +2,10 @@ import { create } from 'zustand';
 
 const STORAGE_KEY_VOICE_REGION = 'chagra:prefs:voice-region';
 const STORAGE_KEY_VOICE_INTENSITY = 'chagra:prefs:voice-intensity';
+// Task #122 (2026-05-23): toggle global TTS persistido. Default ON porque
+// el avatar colibrí es voz primaria del agente; el operador puede
+// silenciarlo via doble-click en el avatar header o en Perfil/Settings.
+const STORAGE_KEY_TTS_ENABLED = 'chagra:prefs:tts-enabled';
 
 function load(key, fallback) {
   try {
@@ -19,6 +23,7 @@ function save(key, val) {
 const usePrefsStore = create((set, _get) => ({
   voiceRegion: load(STORAGE_KEY_VOICE_REGION, 'auto'),
   voiceRegionIntensity: load(STORAGE_KEY_VOICE_INTENSITY, 1),
+  ttsEnabled: load(STORAGE_KEY_TTS_ENABLED, true),
 
   setVoiceRegion: (region) => {
     save(STORAGE_KEY_VOICE_REGION, region);
@@ -28,6 +33,12 @@ const usePrefsStore = create((set, _get) => ({
   setVoiceRegionIntensity: (intensity) => {
     save(STORAGE_KEY_VOICE_INTENSITY, intensity);
     set({ voiceRegionIntensity: intensity });
+  },
+
+  setTtsEnabled: (flag) => {
+    const bool = Boolean(flag);
+    save(STORAGE_KEY_TTS_ENABLED, bool);
+    set({ ttsEnabled: bool });
   },
 }));
 


### PR DESCRIPTION
## Resumen

Task #122 — el avatar colibrí Chagra se convierte en sistema global de notificaciones del agente.

- **Glow global**: cuando AgentScreen termina un stream, el colibrí del FAB pulsa con drop-shadow amber (`#FFB700`, 1.5s ease-in-out) en cualquier pantalla. Volver a AgentScreen apaga el glow via `markRead()`.
- **Doble-click avatar (FAB global / header AgentScreen)**: si TTS está sonando, lo silencia y desactiva el toggle global. Si TTS está OFF, reactiva el toggle y re-reproduce el último mensaje del agente via `ttsService.replayLast()`.
- **Doble-click en burbuja del agente**: reproduce SOLO ese mensaje puntual sin tocar el toggle global.
- **Toggle persistido**: `usePrefsStore.ttsEnabled` default ON, configurable también desde Perfil → "Voz del agente activa".

## Archivos clave

| Archivo | Cambio |
|---|---|
| `src/store/useAgentNotificationStore.js` | Store nuevo (Zustand): `responseReady`, `lastAssistantMessage`, `setResponseReady`/`setLastMessage`/`markRead`. |
| `src/store/usePrefsStore.js` | Agrega `ttsEnabled` persistido en localStorage. |
| `src/services/ttsService.js` | Cache módulo-level `lastSpoken` + `replayLast({ useKokoro })`. |
| `src/components/ChagraAgentAvatar.jsx` | Prop `glow` (pulse drop-shadow amber) + prop `onDoubleClick` + a11y title + reduced-motion fallback. |
| `src/components/AgentFab.jsx` | Lee `responseReady` → glow + border amber. Maneja dblclick global. |
| `src/components/AgentScreen/AgentScreen.jsx` | `markRead()` al mount, `setResponseReady+setLastMessage` al terminar stream, dblclick en avatar header. `ttsEnabled` migrado de useState local a usePrefsStore. |
| `src/components/AgentScreen/ChatBubble.jsx` | Dblclick por burbuja del agente. |
| `src/components/ProfileScreen.jsx` | `AgentVoiceSection` toggle. |

## Tests

- `src/store/__tests__/useAgentNotificationStore.test.js` — 5 specs (init, setResponseReady normaliza Boolean, setLastMessage descarta tipos inválidos, markRead retiene `lastAssistantMessage`).
- `src/components/__tests__/ChagraAgentAvatar.test.jsx` — 8 specs (glow class, dblclick handler, a11y aria-label/title, state classes, glow+state coexisten).

```
Test Files  50 passed (50)
Tests       581 passed (581)
```

## Verify pre-PR

- `npm run build` verde (2.47s)
- `npx vitest run` verde (581/581)
- `npm run lint` verde (0 warnings)
- Sin voseo argentino en archivos modificados (`grep -E "\bquerés|tenés|decímelo|abrís"` → 0 hits)

## Constraints respetadas

- No se tocó `llmRouter.js` ni `sidecarClient.js`.
- Offline-first intacto (toggle TTS y store viven en cliente, persisten en localStorage).
- Tono honesto: glow drop-shadow amber 1.5s, sin confetti ni bouncing.
- Reduced-motion: animación deshabilitada con filter estático como fallback.
- Auto-bump: `0.12.166 → 0.12.167` + `chagra-v208 → chagra-v209`.

## Test plan

- [ ] Demo manual: hacer una pregunta al agente, salir a Dashboard mid-stream, ver el colibrí del FAB pulsar al llegar la respuesta.
- [ ] Volver a AgentScreen, verificar que el glow se apaga.
- [ ] Doble-click en FAB con TTS sonando → audio para inmediato + toggle queda OFF.
- [ ] Doble-click en FAB con TTS OFF + última respuesta cacheada → re-reproduce + toggle ON.
- [ ] Doble-click en burbuja del agente → reproduce solo esa respuesta.
- [ ] Perfil → toggle "Voz del agente activa" silencia/reactiva global.