### PR TITLE
feat(vision): recognizeSpeciesGrounded — anti-alucinación vía validate_visual_match

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.167",
+  "version": "0.12.168",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v209';
+const CACHE_NAME = 'chagra-v210';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/aiService.grounded.test.js
+++ b/src/services/__tests__/aiService.grounded.test.js
@@ -1,0 +1,213 @@
+/**
+ * Tests para `recognizeSpeciesGrounded` y `scientificToSpeciesId` —
+ * wiring de validate_visual_match al pipeline de foto. Anti-hallucination
+ * visión (PR chagra-pro #48 expuso la tool, este PR la consume).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock del sidecarClient ANTES de importar aiService.
+vi.mock('../sidecarClient.js', () => ({
+  isSidecarEnabled: vi.fn(() => true),
+  callTool: vi.fn(),
+  planNlu: vi.fn(),
+}));
+
+// Mock de recognizeSpecies para no llamar a Ollama. recognizeSpeciesGrounded
+// es wrapper sobre recognizeSpecies — verificamos el wiring sin pegar al modelo.
+vi.mock('../ollamaStream', () => ({
+  streamOllama: vi.fn(),
+}));
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn().mockResolvedValue([]),
+}));
+
+import { recognizeSpeciesGrounded } from '../aiService.js';
+import * as sidecarClient from '../sidecarClient.js';
+import * as ollamaStream from '../ollamaStream.js';
+
+function mockVisionResponse(json) {
+  ollamaStream.streamOllama.mockResolvedValueOnce(JSON.stringify(json));
+}
+
+describe('recognizeSpeciesGrounded', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sidecarClient.isSidecarEnabled.mockReturnValue(true);
+    // Browser online por default.
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { onLine: true },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cuando el vision identifica species válida del catálogo, marca _grounded:true', async () => {
+    mockVisionResponse({
+      common_name_es: 'café',
+      scientific_name: 'Coffea arabica L.',
+      confidence: 0.92,
+      alternatives: [],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce({
+      available: true,
+      results: [
+        {
+          species_id: 'coffea_arabica',
+          valid: true,
+          confidence_input: 0.92,
+          confidence_adjusted: 0.92,
+          nombre_comun: 'Café',
+          nombre_cientifico: 'Coffea arabica L.',
+        },
+      ],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result).toBeTruthy();
+    expect(result._grounded).toBe(true);
+    expect(result._validation.valid).toBe(true);
+    expect(sidecarClient.callTool).toHaveBeenCalledWith(
+      'validate_visual_match',
+      expect.objectContaining({
+        candidates: expect.arrayContaining([
+          expect.objectContaining({ species_id: 'coffea_arabica', confidence: 0.92 }),
+        ]),
+      }),
+    );
+  });
+
+  it('cuando el vision alucina una especie inexistente, marca _grounded:false', async () => {
+    mockVisionResponse({
+      common_name_es: 'planta inventada',
+      scientific_name: 'Mangosteenia colombiana',
+      confidence: 0.78,
+      alternatives: [],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce({
+      available: true,
+      results: [
+        {
+          species_id: 'mangosteenia_colombiana',
+          valid: false,
+          confidence_input: 0.78,
+          confidence_adjusted: 0,
+          reason: 'not_in_catalog',
+        },
+      ],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded).toBe(false);
+    expect(result._validation.valid).toBe(false);
+    expect(result._validation.confidence_adjusted).toBe(0);
+  });
+
+  it('si el sidecar está disabled, degrada a recognizeSpecies sin validar', async () => {
+    sidecarClient.isSidecarEnabled.mockReturnValue(false);
+    mockVisionResponse({
+      common_name_es: 'tomate',
+      scientific_name: 'Solanum lycopersicum',
+      confidence: 0.85,
+      alternatives: [],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded).toBeNull();
+    expect(sidecarClient.callTool).not.toHaveBeenCalled();
+  });
+
+  it('si offline, degrada sin validar', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { onLine: false },
+      configurable: true,
+    });
+    mockVisionResponse({
+      common_name_es: 'lechuga',
+      scientific_name: 'Lactuca sativa',
+      confidence: 0.88,
+      alternatives: [],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded).toBeNull();
+    expect(sidecarClient.callTool).not.toHaveBeenCalled();
+  });
+
+  it('si scientific_name está vacío o malformado, no llama al sidecar', async () => {
+    mockVisionResponse({
+      common_name_es: 'desconocido',
+      scientific_name: '', // vacío
+      confidence: 0.4,
+      alternatives: [],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded).toBeNull();
+    expect(sidecarClient.callTool).not.toHaveBeenCalled();
+  });
+
+  it('incluye alternativas en candidates cuando el vision las devuelve', async () => {
+    mockVisionResponse({
+      common_name_es: 'café',
+      scientific_name: 'Coffea arabica',
+      confidence: 0.6,
+      alternatives: [
+        { scientific_name: 'Coffea canephora', confidence: 0.3 },
+        { scientific_name: 'Coffea liberica', confidence: 0.15 },
+      ],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce({
+      available: true,
+      results: [
+        { species_id: 'coffea_arabica', valid: true, confidence_adjusted: 0.6 },
+        { species_id: 'coffea_canephora', valid: false, confidence_adjusted: 0 },
+        { species_id: 'coffea_liberica', valid: false, confidence_adjusted: 0 },
+      ],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded).toBe(true);
+    expect(result._all_validations).toHaveLength(3);
+    expect(sidecarClient.callTool).toHaveBeenCalledWith(
+      'validate_visual_match',
+      expect.objectContaining({
+        candidates: expect.arrayContaining([
+          expect.objectContaining({ species_id: 'coffea_arabica' }),
+          expect.objectContaining({ species_id: 'coffea_canephora' }),
+          expect.objectContaining({ species_id: 'coffea_liberica' }),
+        ]),
+      }),
+    );
+  });
+
+  it('si el sidecar tool falla (devuelve null), degrada', async () => {
+    mockVisionResponse({
+      common_name_es: 'aguacate',
+      scientific_name: 'Persea americana',
+      confidence: 0.95,
+      alternatives: [],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce(null);
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded).toBeNull();
+    expect(result.scientific_name).toBe('Persea americana');
+  });
+});

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -20,6 +20,7 @@
 
 import { streamOllama } from './ollamaStream';
 import { retrieve } from './ragRetriever';
+import { callTool, isSidecarEnabled } from './sidecarClient';
 
 // Ruta relativa: Nginx proxea /api/ollama/ → http://localhost:11434/
 // Ruta final: /api/ollama/api/generate → http://localhost:11434/api/generate
@@ -259,6 +260,108 @@ const runSpeciesRecognition = async (model, base64, { onToken, signal }) => {
     confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
     alternatives: Array.isArray(parsed.alternatives) ? parsed.alternatives : [],
     _model: model,
+  };
+};
+
+/**
+ * Convierte un nombre científico binomial ("Coffea arabica L.") a un
+ * `species_id` snake_case canónico ("coffea_arabica") compatible con el
+ * catálogo Chagra. Quita autoría taxonómica (L., Mart., Kunth, etc.) y
+ * cualquier sufijo descriptivo después del epíteto específico.
+ *
+ * Ejemplos:
+ *   "Coffea arabica L."                       → "coffea_arabica"
+ *   "Solanum betaceum"                        → "solanum_betaceum"
+ *   "Erythrina edulis Triana ex Micheli"      → "erythrina_edulis"
+ *   "Solanum tuberosum Grupo Phureja"         → "solanum_tuberosum"  (sin Grupo)
+ *
+ * Esto es heurística, no taxonomía perfecta. La validación final la hace
+ * el catálogo: si el id derivado no existe, validate_visual_match lo
+ * rechaza con `valid:false`.
+ */
+function scientificToSpeciesId(scientific) {
+  if (typeof scientific !== 'string' || scientific.trim().length === 0) return null;
+  // Tomar primeras 2 palabras (género + epíteto). Resto es autoría/notas.
+  const parts = scientific.trim().split(/\s+/);
+  if (parts.length < 2) return null;
+  const genus = parts[0];
+  const species = parts[1];
+  // Solo aceptar palabras con letras + (opcional) guión. Rechazar autoría
+  // que tipicamente empieza con mayúsculas pero no es epíteto científico.
+  if (!/^[A-Za-z-]+$/.test(genus) || !/^[a-z-]+$/.test(species)) return null;
+  return `${genus}_${species}`.toLowerCase();
+}
+
+/**
+ * Versión grounded de recognizeSpecies. Llama al modelo de visión Y
+ * después valida el resultado contra el catálogo Chagra usando el tool
+ * `validate_visual_match` del sidecar agro-mcp.
+ *
+ * Anti-alucinación: si el modelo vision devuelve "Mangosteenia colombiana"
+ * (especie inexistente), el catálogo lo rechaza con `valid:false`. El
+ * caller puede usar el campo `_grounded` para decidir:
+ *   - _grounded === true  → mostrar al usuario con confianza alta
+ *   - _grounded === false → mostrar advertencia "no verificado en catálogo"
+ *
+ * Si el sidecar no está disponible (feature flag off o offline),
+ * recognizeSpeciesGrounded degrada al comportamiento de recognizeSpecies
+ * (sin validación). Caller obtiene _grounded:null para distinguir.
+ *
+ * @param {Blob} imageBlob — foto del usuario.
+ * @param {Object} options — { onToken, signal } pasados al modelo vision.
+ * @returns {Promise<Object|null>} estructura igual a recognizeSpecies +
+ *   `_grounded: boolean|null`,
+ *   `_validation: { valid, confidence_adjusted, ... }` cuando aplique.
+ */
+export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
+  const visionResult = await recognizeSpecies(imageBlob, options);
+  if (!visionResult) return null;
+
+  // Si sidecar disabled / offline, devolver lo del vision sin validar.
+  if (!isSidecarEnabled() || !navigator.onLine) {
+    return { ...visionResult, _grounded: null };
+  }
+
+  // Derive species_id from scientific_name. Si no podemos derivar (binomial
+  // ausente o malformado), tampoco podemos validar — degradamos.
+  const speciesId = scientificToSpeciesId(visionResult.scientific_name);
+  if (!speciesId) {
+    return { ...visionResult, _grounded: null };
+  }
+
+  // Construir lista de candidates: el principal + alternatives si vienen.
+  const candidates = [
+    {
+      species_id: speciesId,
+      confidence: visionResult.confidence,
+      source_label: visionResult.scientific_name,
+    },
+  ];
+  for (const alt of (visionResult.alternatives || []).slice(0, 4)) {
+    const altSci = alt.scientific_name || alt;
+    const altId = scientificToSpeciesId(altSci);
+    if (altId && altId !== speciesId) {
+      candidates.push({
+        species_id: altId,
+        confidence: typeof alt.confidence === 'number' ? alt.confidence : 0.3,
+        source_label: altSci,
+      });
+    }
+  }
+
+  const result = await callTool('validate_visual_match', { candidates });
+  if (!result) {
+    // Sidecar timeout / 5xx — fallback al resultado vision sin validar.
+    return { ...visionResult, _grounded: null };
+  }
+
+  // Buscar el match del candidato primario en results.
+  const primary = (result.results || []).find((r) => r.species_id === speciesId);
+  return {
+    ...visionResult,
+    _grounded: primary?.valid === true,
+    _validation: primary || null,
+    _all_validations: result.results || [],
   };
 };
 


### PR DESCRIPTION
Cierra ciclo anti-alucinación foto. Nuevo wrapper grounded llama a vision + valida species_id contra catálogo+AGE via sidecar tool.

- `_grounded: true` → validado catálogo
- `_grounded: false` → alucinación atrapada
- `_grounded: null` → sidecar offline/disabled (sin break)

Tests 7/7. Build verde. Backward compat preservada (recognizeSpecies sin cambios).

Próximo PR: migrar callers existentes (EvidenceCapture, SpeciesSelect, AssetsDashboard) a usar wrapper grounded + UI badges.