### PR TITLE
feat(vision): migrate callers to recognizeSpeciesGrounded + badges UI (#114)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.168",
+  "version": "0.12.169",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v210';
+const CACHE_NAME = 'chagra-v211';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
-import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug } from 'lucide-react';
+import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug, Check, AlertCircle } from 'lucide-react';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { resolveSpeciesDefaults } from '../config/speciesDefaults';
 import { fuzzyFilter } from '../utils/fuzzySearch';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
 import useAssetStore from '../store/useAssetStore';
 import { captureAndCompress } from '../services/photoService';
-import { recognizeSpecies } from '../services/aiService';
+import { recognizeSpeciesGrounded } from '../services/aiService';
 import { getAllSpecies } from '../db/catalogDB';
 
 /**
@@ -166,7 +166,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
           console.warn('[SpeciesSelect] onPhoto callback failed:', err);
         }
       }
-      const result = await recognizeSpecies(blob);
+      const result = await recognizeSpeciesGrounded(blob);
       if (!result) {
         setAiState('error');
         return;
@@ -497,6 +497,28 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
               <p className="text-[10px] uppercase tracking-wider text-emerald-500 font-bold mb-0.5">
                 Especie sugerida ({Math.round((aiResult.confidence || 0) * 100)}% confianza)
               </p>
+              {/* Badge grounded contra catálogo (PR #114 — anti-alucinación).
+                  _grounded === true  → verde "Verificado catálogo".
+                  _grounded === false → amber "No verificado — revisar manualmente".
+                  _grounded === null  → sidecar offline o no aplica, sin badge. */}
+              {aiResult._grounded === true && (
+                <span
+                  data-testid="grounded-badge-verified"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-green-600/20 text-green-300 border border-green-700 mb-1"
+                >
+                  <Check size={14} aria-hidden="true" />
+                  Verificado catálogo
+                </span>
+              )}
+              {aiResult._grounded === false && (
+                <span
+                  data-testid="grounded-badge-unverified"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-amber-600/20 text-amber-300 border border-amber-700 mb-1"
+                >
+                  <AlertCircle size={14} aria-hidden="true" />
+                  No verificado — revisar manualmente
+                </span>
+              )}
               <p className="text-sm text-emerald-200 font-bold">
                 {aiResult.common_name_es || '—'}
               </p>
@@ -506,6 +528,34 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                 </p>
               )}
             </div>
+            {/* Si el primario NO está verificado pero el sidecar encontró
+                candidates alternativos válidos en el catálogo, ofrecerlos
+                como sugerencias confiables. */}
+            {aiResult._grounded === false && Array.isArray(aiResult._all_validations) && (() => {
+              const validCandidates = aiResult._all_validations.filter(
+                (v) => v && v.valid === true && v.species_id
+              );
+              if (validCandidates.length === 0) return null;
+              return (
+                <div data-testid="grounded-valid-candidates">
+                  <p className="text-[10px] uppercase tracking-wider text-green-400 font-bold mb-1">
+                    Coincidencias en catálogo
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {validCandidates.slice(0, 4).map((v, i) => (
+                      <button
+                        key={v.species_id || i}
+                        type="button"
+                        onClick={() => handleAiPickAlternative(v.source_label || v.species_id || '')}
+                        className="text-[11px] px-2 py-0.5 rounded bg-green-900/30 hover:bg-green-800/40 text-green-200 border border-green-700"
+                      >
+                        {v.source_label || v.species_id}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })()}
             {Array.isArray(aiResult.alternatives) && aiResult.alternatives.length > 0 && (
               <div>
                 <p className="text-[10px] uppercase tracking-wider text-emerald-500 font-bold mb-1">

--- a/src/components/__tests__/SpeciesSelect.smoke.test.jsx
+++ b/src/components/__tests__/SpeciesSelect.smoke.test.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// Smoke tests para la migración de SpeciesSelect a recognizeSpeciesGrounded
+// (PR #114). Cubre los tres valores observables de `_grounded`:
+//   - true  → badge VERDE "Verificado catálogo".
+//   - false → badge AMBER "No verificado — revisar manualmente" + bloque
+//             "Coincidencias en catálogo" cuando hay alternativas válidas
+//             en `_all_validations`.
+//   - null  → sidecar offline o no aplica → ningún badge se renderiza
+//             (degradación graceful).
+
+// Mock del store: lista vacía para evitar el chip "Recientes" (no toca el badge).
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [] }),
+}));
+
+// Mock catálogo SQLite — vacío para forzar fallback LEGACY_SPECIES (offline-safe).
+vi.mock('../../db/catalogDB', () => ({
+  getAllSpecies: vi.fn().mockResolvedValue([]),
+}));
+
+// Mock photoService.captureAndCompress → blob sintético sin tocar canvas/FileReader.
+vi.mock('../../services/photoService', () => ({
+  captureAndCompress: vi.fn().mockResolvedValue({
+    blob: new Blob(['stub'], { type: 'image/jpeg' }),
+  }),
+}));
+
+// Mock hook usePhotoUrl — sin foto, no relevante para el badge.
+vi.mock('../../hooks/usePhotoUrl', () => ({
+  usePhotoUrl: () => ({ url: null, source: null, loading: false }),
+}));
+
+// Mock aiService.recognizeSpeciesGrounded — se reescribe per-test con el valor
+// de `_grounded` que queremos validar.
+const mockRecognizeSpeciesGrounded = vi.fn();
+vi.mock('../../services/aiService', () => ({
+  recognizeSpeciesGrounded: (...args) => mockRecognizeSpeciesGrounded(...args),
+}));
+
+import SpeciesSelect from '../SpeciesSelect';
+
+const buildResult = (grounded, extra = {}) => ({
+  common_name_es: 'Tomate',
+  scientific_name: 'Solanum lycopersicum',
+  confidence: 0.85,
+  alternatives: [],
+  _grounded: grounded,
+  _validation: extra.validation ?? null,
+  _all_validations: extra.all_validations ?? [],
+});
+
+const triggerCapture = async () => {
+  // El input file vive dentro de la sección "Identificar con foto", oculto
+  // detrás del label "Tomar foto". testing-library no expone hidden inputs
+  // via getByRole — usamos querySelector específico del ref camera.
+  const fileInput = document.querySelector('input[type="file"][capture="environment"]');
+  expect(fileInput).toBeTruthy();
+  const file = new File(['stub'], 'planta.jpg', { type: 'image/jpeg' });
+  await fireEvent.change(fileInput, { target: { files: [file] } });
+};
+
+describe('SpeciesSelect — badges grounded (PR #114)', () => {
+  beforeEach(() => {
+    mockRecognizeSpeciesGrounded.mockReset();
+  });
+
+  it('renderiza badge VERDE "Verificado catálogo" cuando _grounded === true', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult(true, {
+        validation: { valid: true, species_id: 'solanum_lycopersicum', confidence_adjusted: 0.92 },
+      })
+    );
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    await waitFor(() => {
+      const badge = screen.getByTestId('grounded-badge-verified');
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toMatch(/Verificado catálogo/i);
+    });
+    // El badge unverified NO debe estar.
+    expect(screen.queryByTestId('grounded-badge-unverified')).toBeNull();
+  });
+
+  it('renderiza badge AMBER "No verificado" cuando _grounded === false', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult(false, {
+        validation: { valid: false, species_id: 'mangosteenia_colombiana', reason: 'not_in_catalog' },
+        all_validations: [
+          { valid: false, species_id: 'mangosteenia_colombiana', source_label: 'Mangosteenia colombiana' },
+        ],
+      })
+    );
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    await waitFor(() => {
+      const badge = screen.getByTestId('grounded-badge-unverified');
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toMatch(/No verificado/i);
+      expect(badge.textContent).toMatch(/revisar manualmente/i);
+    });
+    expect(screen.queryByTestId('grounded-badge-verified')).toBeNull();
+  });
+
+  it('muestra "Coincidencias en catálogo" si _grounded === false y _all_validations trae candidates válidos', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult(false, {
+        validation: { valid: false, species_id: 'mangosteenia_colombiana' },
+        all_validations: [
+          { valid: false, species_id: 'mangosteenia_colombiana', source_label: 'Mangosteenia colombiana' },
+          { valid: true, species_id: 'garcinia_mangostana', source_label: 'Garcinia mangostana' },
+        ],
+      })
+    );
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    await waitFor(() => {
+      const candidatesBlock = screen.getByTestId('grounded-valid-candidates');
+      expect(candidatesBlock).toBeTruthy();
+      expect(candidatesBlock.textContent).toMatch(/Coincidencias en catálogo/i);
+      expect(candidatesBlock.textContent).toMatch(/Garcinia mangostana/i);
+    });
+  });
+
+  it('NO renderiza badge cuando _grounded === null (degradación graceful)', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(buildResult(null));
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    // Esperamos a que el resultado AI aparezca (Especie sugerida) para
+    // confirmar que llegamos al render del bloque 'done'.
+    await waitFor(() => {
+      expect(screen.getByText(/Especie sugerida/i)).toBeTruthy();
+    });
+    expect(screen.queryByTestId('grounded-badge-verified')).toBeNull();
+    expect(screen.queryByTestId('grounded-badge-unverified')).toBeNull();
+    expect(screen.queryByTestId('grounded-valid-candidates')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Migra `SpeciesSelect` (único caller de `recognizeSpecies` en `src/components/`) al wrapper `recognizeSpeciesGrounded` introducido en PR #1007. La salida del modelo vision ahora se valida contra el catálogo + Apache AGE via tool `validate_visual_match` del sidecar agro-mcp antes de mostrarse al operador.
- Agrega badges UI honestos según `_grounded`: verde **"Verificado catálogo"** (`Check`), amber **"No verificado — revisar manualmente"** (`AlertCircle`), o ningún badge cuando es `null` (degradación graceful por sidecar offline o `scientific_name` no parseable).
- Cuando el primario falla validación (`_grounded === false`) pero el sidecar reportó candidates alternativos con `valid:true` en `_all_validations`, se renderiza un bloque **"Coincidencias en catálogo"** con esos matches válidos para que el operador escoja uno en lugar de aceptar la sugerencia hallucinated.

## Alcance

Audit `grep -rln "recognizeSpecies\b" src/components/` arrojó **un único caller**: `SpeciesSelect.jsx`. `EvidenceCapture.jsx`, `VoiceCapture.jsx` y `AssetsDashboard.jsx` (candidates listados en la spec) NO usan `recognizeSpecies` — verificado caso por caso. `aiService.js`, `llmRouter.js`, `sidecarClient.js` y `llmGuardrails.js` quedaron intocados (constraint del operador).

## Archivos modificados

- `src/components/SpeciesSelect.jsx` — import wrapper, badge JSX, bloque "Coincidencias en catálogo".
- `src/components/__tests__/SpeciesSelect.smoke.test.jsx` — **nuevo**, 4 escenarios (true/false/false+candidates/null).
- `package.json` + `public/sw.js` — bump auto v0.12.168 → v0.12.169 + cache chagra-v210 → v211.

## Cómo se ve el badge en SpeciesSelect

Dentro del bloque "Identificar con foto" (sección BETA), cuando el flow termina y `aiResult` está disponible:

- **Sidecar verifica OK** (`_grounded:true`): junto al label "Especie sugerida (XX% confianza)" aparece una pill verde con check icon: `[✓ Verificado catálogo]`. Tono `bg-green-600/20 text-green-300 border border-green-700`.
- **Sidecar rechaza** (`_grounded:false`): pill amber con alert icon: `[⚠ No verificado — revisar manualmente]`. Tono `bg-amber-600/20 text-amber-300 border border-amber-700`. Si `_all_validations` trae candidates `valid:true`, debajo aparece "Coincidencias en catálogo" con chips verdes clicables que sustituyen la sugerencia del modelo por el match real.
- **Sidecar offline o species_id no derivable** (`_grounded:null`): no se renderiza badge — el flow queda idéntico al pre-PR para no romper offline-first.

Tamaño consistente con la guideline (`text-xs px-2 py-1 rounded-md inline-flex items-center gap-1`, icono 14px).

## Test plan

- [x] `npx vitest run src/components/__tests__/SpeciesSelect.smoke.test.jsx` → 4/4 passed.
- [x] `npx vitest run` (suite completa) → 592/592 passed, 52 archivos.
- [x] `npm run build` → built in 2.38s sin warnings.
- [x] `npm run lint` → cero issues.
- [x] Anti-secret scan → cero hits.
- [x] Anti-voseo argentino (`grep "vos\|querés\|tenés\|elegí"`) → cero hits.
- [ ] Smoke manual con sidecar real activo (`/api/mcp/agro/validate_visual_match`) cuando el operador haga merge.

## Compatibilidad

- Offline-first: si `isSidecarEnabled()=false` o `navigator.onLine=false`, el wrapper degrada a `recognizeSpecies` puro con `_grounded:null` → no badge → UX pre-PR sin cambio.
- Auto-select por confidence ≥0.7 sigue funcionando: el cambio sólo es el render del badge, NO toca la lógica de matching en `allSpecies`.
- Clave de bug-report en localStorage (`feature: 'recognizeSpecies'`) se mantiene para preservar historial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)