### PR TITLE
feat(agent): badge fuente en mensajes chat (verificado vs generativo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.169",
+  "version": "0.12.170",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v211';
+const CACHE_NAME = 'chagra-v212';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe } from '../../services/voiceService';
-import { addTurn, getFullHistory, getContextString } from '../../services/conversationMemory';
+import { addTurn, getFullHistory, getContextString, computeSourceMetadata } from '../../services/conversationMemory';
 import { retrieve } from '../../services/ragRetriever';
 import { parseIntent, formatIntentDescription } from '../../services/agentIntentParser';
 import { streamOpenAI } from '../../services/openaiStream';
@@ -607,13 +607,24 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
       const { intent } = parseIntent(text);
 
+      // 2026-05-23: badge de "fuente" — persistimos en metadata si el turno
+      // del assistant fue grounded contra el catálogo (tool MCP devolvió
+      // match) o fue solo generativo del LLM. ChatBubble lee este metadata
+      // para renderizar el badge verde/amber/gris (ver computeSourceMetadata).
+      const sourceMetadata = computeSourceMetadata(toolEvidence);
+
       const assistantMessage = {
         role: 'assistant',
         content: response,
         timestamp: Date.now(),
+        metadata: sourceMetadata,
       };
 
-      await addTurn(operatorId, { role: 'assistant', content: response });
+      await addTurn(operatorId, {
+        role: 'assistant',
+        content: response,
+        metadata: sourceMetadata,
+      });
       setMessages((prev) => [...prev, assistantMessage]);
 
       // Task #122: cachear el último mensaje del agente en el store global

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { User } from 'lucide-react';
+import { User, BadgeCheck, Info, Sparkles } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../services/ttsService';
 import { agentSounds } from '../../services/agentSoundService';
+import usePrefsStore from '../../store/usePrefsStore';
 
 function formatTime(timestamp) {
   if (!timestamp) return '';
@@ -10,8 +11,92 @@ function formatTime(timestamp) {
   return d.toLocaleTimeString('es-CO', { hour: '2-digit', minute: '2-digit' });
 }
 
+/**
+ * Mapa de nombres "humanizados" de tools del sidecar agro-mcp. Cuando un
+ * tool no está mapeado, mostramos el nombre técnico tal cual (e.g.
+ * "get_pest_controllers" si no lo tradujimos todavía). Wording cero hype:
+ * "compañeras", "biopreparados", no "perfectos", "garantizados".
+ */
+const TOOL_LABELS = {
+  get_species: 'especie',
+  get_companions: 'compañeras',
+  get_biopreparados: 'biopreparados',
+  get_pest_controllers: 'controladores de plagas',
+  get_multihop_companions: 'compañeras multi-salto',
+  validate_visual_match: 'visión',
+};
+
+function toolLabel(toolName) {
+  if (!toolName) return '';
+  return TOOL_LABELS[toolName] || toolName;
+}
+
+/**
+ * Renderiza el badge de "fuente" según el metadata del turno del assistant:
+ *   - grounded === true             → verde "Catálogo verificado · <tool>"
+ *   - tool_used && !grounded        → amber "Tool sin match · <tool>"
+ *   - !tool_used (LLM only)         → gris "Respuesta generativa"
+ *
+ * Wording deliberadamente sobrio (cero hype). Sin "garantizado", "100%",
+ * "perfecto" — el catálogo Chagra está en construcción, el badge solo dice
+ * "esta respuesta viene del catálogo verificado vs solo del modelo".
+ */
+function SourceBadge({ metadata }) {
+  const md = metadata || {};
+  const toolUsed = md.tool_used || null;
+  const grounded = md.grounded === true;
+
+  if (toolUsed && grounded) {
+    return (
+      <span
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-green-600/20 text-green-300 border border-green-700"
+        data-testid="source-badge"
+        data-source="catalog"
+      >
+        <BadgeCheck size={12} aria-hidden="true" />
+        <span>Catálogo verificado · {toolLabel(toolUsed)}</span>
+      </span>
+    );
+  }
+
+  if (toolUsed && !grounded) {
+    return (
+      <span
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-amber-600/20 text-amber-300 border border-amber-700"
+        data-testid="source-badge"
+        data-source="tool-no-match"
+      >
+        <Info size={12} aria-hidden="true" />
+        <span>Tool sin match · {toolLabel(toolUsed)}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-slate-700/40 text-slate-400 border border-slate-600"
+      data-testid="source-badge"
+      data-source="generative"
+    >
+      <Sparkles size={12} aria-hidden="true" />
+      <span>Respuesta generativa</span>
+    </span>
+  );
+}
+
 export default function ChatBubble({ message, isStreaming = false }) {
   const isUser = message.role === 'user';
+  const showSourceBadges = usePrefsStore((s) => s.showSourceBadges);
+  // Badge "fuente" solo aplica a respuestas del agente, no del usuario, y
+  // no durante streaming (se muestra cuando el turn está estabilizado).
+  // Mensajes _orphan_recovery (recuperación de pregunta sin respuesta) no
+  // llevan badge — no son una respuesta real del agente. Backward compat:
+  // mensajes assistant viejos sin metadata se renderizan como "generativa".
+  const shouldShowBadge =
+    !isUser &&
+    !isStreaming &&
+    showSourceBadges &&
+    !message._orphan_recovery;
   // 2026-05-19 operator: el avatar del agente en el chat debe verse SIEMPRE
   // vivo, no inerte. Aunque la respuesta ya este completa, el colibri sigue
   // libando suavemente — comunica que el agente esta "presente" y listo para
@@ -73,6 +158,11 @@ export default function ChatBubble({ message, isStreaming = false }) {
           title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
         >
           <p className="text-sm leading-relaxed whitespace-pre-wrap">{message.content}</p>
+          {shouldShowBadge && (
+            <div className="mt-1">
+              <SourceBadge metadata={message.metadata} />
+            </div>
+          )}
           {message.timestamp && (
             <p className={`text-[10px] mt-1 ${isUser ? 'text-emerald-300/60' : 'text-slate-500'}`}>
               {formatTime(message.timestamp)}

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatBubble from '../AgentScreen/ChatBubble';
+import usePrefsStore from '../../store/usePrefsStore';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Mocks de servicios pesados (TTS, audio) que ChatBubble importa para el
+// handler de doble-click. No los ejercitamos en estos tests — el foco está
+// en el badge de "fuente". Evitamos que jsdom intente speechSynthesis.
+vi.mock('../../services/ttsService', () => ({
+  speak: vi.fn(),
+  speakKokoro: vi.fn(),
+  stop: vi.fn(),
+  isSpeaking: vi.fn(() => false),
+  isKokoroAvailable: vi.fn(async () => false),
+}));
+
+vi.mock('../../services/agentSoundService', () => ({
+  agentSounds: {
+    chime: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+// El avatar usa SVG complejo, mockeamos a un placeholder.
+vi.mock('../ChagraAgentAvatar', () => ({
+  __esModule: true,
+  default: () => <div data-testid="avatar-mock" />,
+}));
+
+vi.mock('../../store/usePrefsStore');
+
+describe('ChatBubble — badge de fuente (verificado vs generativo)', () => {
+  let storeState;
+
+  beforeEach(() => {
+    storeState = {
+      showSourceBadges: true,
+    };
+    usePrefsStore.mockImplementation((selector) => selector(storeState));
+  });
+
+  test('Renderiza badge verde cuando metadata.grounded === true', () => {
+    const message = {
+      role: 'assistant',
+      content: 'El aguacate Hass tiene como compañeras...',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_companions', grounded: true },
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('source-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-source', 'catalog');
+    expect(badge).toHaveTextContent(/Catálogo verificado/i);
+    expect(badge).toHaveTextContent(/compañeras/i);
+    // Wording cero hype: NO debe aparecer "garantizado", "perfecto", "100%".
+    expect(badge.textContent).not.toMatch(/garantizado/i);
+    expect(badge.textContent).not.toMatch(/perfecto/i);
+    expect(badge.textContent).not.toMatch(/100%/i);
+  });
+
+  test('Renderiza badge amber cuando metadata.grounded === false (tool sin match)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'El catálogo Chagra no tiene esa especie documentada.',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_species', grounded: false },
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('source-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-source', 'tool-no-match');
+    expect(badge).toHaveTextContent(/Tool sin match/i);
+    expect(badge).toHaveTextContent(/especie/i);
+  });
+
+  test('Renderiza badge gris cuando assistant sin tool_used (generativo)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Buenos días, ¿en qué te puedo ayudar?',
+      timestamp: Date.now(),
+      metadata: { tool_used: null, grounded: false },
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('source-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-source', 'generative');
+    expect(badge).toHaveTextContent(/Respuesta generativa/i);
+  });
+
+  test('NO renderiza badge si showSourceBadges está OFF', () => {
+    storeState.showSourceBadges = false;
+    const message = {
+      role: 'assistant',
+      content: 'Datos del aguacate.',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_species', grounded: true },
+    };
+    render(<ChatBubble message={message} />);
+    expect(screen.queryByTestId('source-badge')).not.toBeInTheDocument();
+  });
+
+  test('NO renderiza badge en mensajes del usuario', () => {
+    const message = {
+      role: 'user',
+      content: '¿Qué compañeras tiene el aguacate?',
+      timestamp: Date.now(),
+    };
+    render(<ChatBubble message={message} />);
+    expect(screen.queryByTestId('source-badge')).not.toBeInTheDocument();
+  });
+
+  test('NO renderiza badge mientras isStreaming=true (estado transitorio)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Generando...',
+      metadata: { tool_used: 'get_species', grounded: true },
+    };
+    render(<ChatBubble message={message} isStreaming />);
+    expect(screen.queryByTestId('source-badge')).not.toBeInTheDocument();
+  });
+
+  test('NO renderiza badge en mensajes _orphan_recovery (no es respuesta real)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Tu pregunta anterior no recibió respuesta.',
+      timestamp: Date.now(),
+      _orphan_recovery: true,
+    };
+    render(<ChatBubble message={message} />);
+    expect(screen.queryByTestId('source-badge')).not.toBeInTheDocument();
+  });
+
+  test('Backward compat: mensajes assistant viejos sin metadata renderizan como generativos sin crashear', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Mensaje antiguo persistido antes de la feature de badges.',
+      timestamp: Date.now(),
+      // sin metadata
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('source-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-source', 'generative');
+    expect(badge).toHaveTextContent(/Respuesta generativa/i);
+  });
+
+  test('Backward compat: metadata=null no rompe el render', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Otro mensaje legacy.',
+      timestamp: Date.now(),
+      metadata: null,
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('source-badge');
+    expect(badge).toHaveAttribute('data-source', 'generative');
+  });
+
+  test('Tool sin label en el mapa muestra el nombre técnico (no crashea)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Resultado de un tool nuevo.',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_brand_new_tool', grounded: true },
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('source-badge');
+    expect(badge).toHaveTextContent(/get_brand_new_tool/);
+  });
+});

--- a/src/services/__tests__/conversationMemory.sourceMetadata.test.js
+++ b/src/services/__tests__/conversationMemory.sourceMetadata.test.js
@@ -1,0 +1,108 @@
+/**
+ * conversationMemory.sourceMetadata.test.js
+ *
+ * Tests del helper puro `computeSourceMetadata`, que determina si un
+ * turno del assistant debe quedar persistido como:
+ *   - tool_used + grounded=true  (catálogo verificado)
+ *   - tool_used + grounded=false (tool corrió pero no hubo match)
+ *   - tool_used=null             (LLM puro, sin tool MCP)
+ *
+ * El ChatBubble renderiza el badge a partir de este metadata.
+ */
+import { describe, test, expect } from 'vitest';
+import { computeSourceMetadata } from '../conversationMemory';
+
+describe('computeSourceMetadata', () => {
+  test('null / undefined toolEvidence → no tool, no grounded', () => {
+    expect(computeSourceMetadata(null)).toEqual({ tool_used: null, grounded: false });
+    expect(computeSourceMetadata(undefined)).toEqual({ tool_used: null, grounded: false });
+  });
+
+  test('toolEvidence sin tool field → no tool, no grounded', () => {
+    expect(computeSourceMetadata({ tool: null, args: {}, result: {} })).toEqual({
+      tool_used: null,
+      grounded: false,
+    });
+  });
+
+  test('found:true → grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_species',
+      args: { name: 'aguacate' },
+      result: { found: true, species: { name: 'Persea americana' } },
+    });
+    expect(md).toEqual({ tool_used: 'get_species', grounded: true });
+  });
+
+  test('found:false → tool_used pero no grounded (catálogo no tiene la especie)', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_species',
+      args: { name: 'mareñongoño' },
+      result: { found: false, hint: 'no en catálogo' },
+    });
+    expect(md).toEqual({ tool_used: 'get_species', grounded: false });
+  });
+
+  test('available:true → grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_biopreparados',
+      args: { species: 'tomate' },
+      result: { available: true, biopreparados: [{ name: 'caldo bordelés' }] },
+    });
+    expect(md.grounded).toBe(true);
+  });
+
+  test('available:false → no grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_biopreparados',
+      args: { species: 'X inexistente' },
+      result: { available: false },
+    });
+    expect(md.grounded).toBe(false);
+  });
+
+  test('matches_count > 0 → grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_multihop_companions',
+      args: { species: 'maíz' },
+      result: { matches_count: 5, matches: [{ name: 'frijol' }] },
+    });
+    expect(md.grounded).toBe(true);
+  });
+
+  test('matches_count === 0 → no grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_multihop_companions',
+      args: { species: 'X' },
+      result: { matches_count: 0, matches: [] },
+    });
+    expect(md.grounded).toBe(false);
+  });
+
+  test('result con array no vacío y sin flags explícitos → grounded (heurística)', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_companions',
+      args: { species: 'maíz' },
+      result: { companions: [{ name: 'frijol' }, { name: 'auyama' }] },
+    });
+    expect(md).toEqual({ tool_used: 'get_companions', grounded: true });
+  });
+
+  test('result no-object (string) → tool_used pero no grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_species',
+      args: {},
+      result: 'string raro',
+    });
+    expect(md).toEqual({ tool_used: 'get_species', grounded: false });
+  });
+
+  test('result null → tool_used pero no grounded', () => {
+    const md = computeSourceMetadata({
+      tool: 'get_species',
+      args: {},
+      result: null,
+    });
+    expect(md).toEqual({ tool_used: 'get_species', grounded: false });
+  });
+});

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -185,10 +185,73 @@ export async function clearMemory(operatorId) {
   }
 }
 
+/**
+ * Computar metadata de "fuente" del mensaje del assistant a partir del
+ * toolEvidence que devolvió el sidecar NLU + chagra-agro-mcp.
+ *
+ * Promesa visual del Manual (HelpAgentSection): "respuestas con fondo
+ * verde son del catálogo verificado". Esa promesa requiere persistir
+ * en cada turn del assistant si se invocó un tool MCP y si el tool
+ * devolvió un match real del catálogo (grounded=true) o un miss
+ * (grounded=false). Mensajes sin tool_used quedan como "respuesta
+ * generativa" (solo LLM, sin verificación catálogo).
+ *
+ * Reglas de grounded (alineadas con `formatToolEvidence` en AgentScreen):
+ *   - found === true                  → grounded
+ *   - available === true              → grounded
+ *   - matches_count > 0               → grounded
+ *   - found:false / available:false   → no grounded (tool corrió pero
+ *     no hay datos en catálogo)
+ *   - matches_count === 0             → no grounded
+ *   - otros casos (result presente sin estos flags, e.g. lista no
+ *     vacía como get_companions devolviendo array)  → grounded
+ *     (asumimos que devolver payload con datos es match útil)
+ *
+ * @param {{tool: string, args: object, result: any} | null | undefined} toolEvidence
+ * @returns {{tool_used: string|null, grounded: boolean}}
+ */
+export function computeSourceMetadata(toolEvidence) {
+  if (!toolEvidence || !toolEvidence.tool) {
+    return { tool_used: null, grounded: false };
+  }
+  const result = toolEvidence.result;
+  if (!result || typeof result !== 'object') {
+    return { tool_used: toolEvidence.tool, grounded: false };
+  }
+
+  // Miss explícito: el tool indicó que no hay match en catálogo.
+  if (result.found === false || result.available === false) {
+    return { tool_used: toolEvidence.tool, grounded: false };
+  }
+  if (typeof result.matches_count === 'number' && result.matches_count === 0) {
+    return { tool_used: toolEvidence.tool, grounded: false };
+  }
+
+  // Match explícito.
+  if (result.found === true || result.available === true) {
+    return { tool_used: toolEvidence.tool, grounded: true };
+  }
+  if (typeof result.matches_count === 'number' && result.matches_count > 0) {
+    return { tool_used: toolEvidence.tool, grounded: true };
+  }
+
+  // Sin flags explícitos: si el tool devolvió un payload no vacío
+  // (e.g. get_companions con array), lo consideramos grounded.
+  const hasArrayPayload = Object.values(result).some(
+    (v) => Array.isArray(v) && v.length > 0
+  );
+  if (hasArrayPayload) {
+    return { tool_used: toolEvidence.tool, grounded: true };
+  }
+  // Fallback: tool corrió, result presente pero sin señal clara.
+  return { tool_used: toolEvidence.tool, grounded: true };
+}
+
 export default {
   addTurn,
   getRecentContext,
   getContextString,
   getFullHistory,
   clearMemory,
+  computeSourceMetadata,
 };

--- a/src/store/usePrefsStore.js
+++ b/src/store/usePrefsStore.js
@@ -6,6 +6,12 @@ const STORAGE_KEY_VOICE_INTENSITY = 'chagra:prefs:voice-intensity';
 // el avatar colibrí es voz primaria del agente; el operador puede
 // silenciarlo via doble-click en el avatar header o en Perfil/Settings.
 const STORAGE_KEY_TTS_ENABLED = 'chagra:prefs:tts-enabled';
+// 2026-05-23: badge de "fuente" en cada respuesta del agente (verificado
+// catálogo vs generativo). Default ON cumple la promesa visual del Manual
+// (HelpAgentSection): "respuestas con fondo verde son del catálogo
+// verificado". Operadores en modo "expert" pueden ocultarlos para reducir
+// ruido visual sin perder la información (queda en metadata del turn).
+const STORAGE_KEY_SOURCE_BADGES = 'chagra:prefs:show-source-badges';
 
 function load(key, fallback) {
   try {
@@ -24,6 +30,7 @@ const usePrefsStore = create((set, _get) => ({
   voiceRegion: load(STORAGE_KEY_VOICE_REGION, 'auto'),
   voiceRegionIntensity: load(STORAGE_KEY_VOICE_INTENSITY, 1),
   ttsEnabled: load(STORAGE_KEY_TTS_ENABLED, true),
+  showSourceBadges: load(STORAGE_KEY_SOURCE_BADGES, true),
 
   setVoiceRegion: (region) => {
     save(STORAGE_KEY_VOICE_REGION, region);
@@ -39,6 +46,12 @@ const usePrefsStore = create((set, _get) => ({
     const bool = Boolean(flag);
     save(STORAGE_KEY_TTS_ENABLED, bool);
     set({ ttsEnabled: bool });
+  },
+
+  setShowSourceBadges: (flag) => {
+    const bool = Boolean(flag);
+    save(STORAGE_KEY_SOURCE_BADGES, bool);
+    set({ showSourceBadges: bool });
   },
 }));
 


### PR DESCRIPTION
## Summary

Badge visual en cada respuesta del agente Chagra indicando su fuente. Cumple la promesa visual documentada en el Manual (HelpAgentSection, PR #1004): *"respuestas con fondo verde son del catálogo verificado"*.

Tres estados:

- **Verde** "Catálogo verificado · <tool>" — el sidecar disparó un tool MCP y devolvió match en catálogo (`found:true` / `available:true` / `matches_count>0` / payload con array no vacío).
- **Amber** "Tool sin match · <tool>" — el sidecar disparó tool pero NO hay match (`found:false` / `available:false` / `matches_count===0`). Útil para que el operador sepa que el agente consultó y no encontró, distinto de no haber consultado.
- **Gris** "Respuesta generativa" — el LLM respondió sin tool MCP (chitchat, contexto general, RAG-only).

## Implementación

- `conversationMemory.js` exporta `computeSourceMetadata(toolEvidence) → {tool_used, grounded}`. Heurística alineada con `formatToolEvidence` de AgentScreen.
- `AgentScreen.jsx` persiste `metadata: {tool_used, grounded}` en el turn del assistant (memoria persistente IndexedDB) Y en el mensaje en-RAM. El metadata viaja con el turn y se recupera al recargar.
- `ChatBubble.jsx` renderiza `<SourceBadge metadata={message.metadata} />` debajo del contenido, antes del timestamp. Mapa de labels humanizados para los 6 tools del sidecar (`get_species`, `get_companions`, `get_biopreparados`, `get_pest_controllers`, `get_multihop_companions`, `validate_visual_match`).
- `usePrefsStore.js` agrega `showSourceBadges` (default `true`, persiste en `localStorage` clave `chagra:prefs:show-source-badges`). Modo "expert" puede ocultar TODOS los badges sin perder la información (queda en metadata).

## Backward compat

- Mensajes assistant viejos sin `metadata` o `metadata: null` → renderizan como "Respuesta generativa" (badge gris) sin crashear.
- Mensajes `_orphan_recovery` (recuperación pregunta huérfana) → NO renderizan badge.
- Mensajes durante `isStreaming=true` → NO renderizan badge (evita parpadeo del estado transitorio).

## Wording — cero hype

"Catálogo verificado" / "Tool sin match" / "Respuesta generativa". **NO** se usa "garantizado", "perfecto", "100% preciso". El catálogo Chagra está en construcción y el badge solo distingue "viene del catálogo" vs "viene del modelo", sin promesa de exactitud.

## Constraints respetados

- NO se tocaron `llmRouter.js`, `sidecarClient.js`, `aiService.js`.
- Offline-first intacto: `computeSourceMetadata` es pura y funciona sin red.
- Conventional Commit format.
- Auto-bump 0.12.169 → 0.12.170 + `chagra-v211` → `chagra-v212` (lefthook no estaba en PATH del worktree, bump manual idempotente con el script).
- Voseo argentino: 0 hits en archivos modificados.

## Test plan

- [x] `npx vitest run` → 613 tests passed (54 files), incluye 10 nuevos casos en ChatBubble + 11 en computeSourceMetadata.
- [x] `npm run lint` → clean.
- [x] `npm run build` → built in 2.32s, AgentScreen chunk 47.74 kB (gzip 17.64 kB).
- [ ] Verificación manual en alpha: preguntar al agente algo del catálogo (badge verde), algo inexistente (badge amber), un saludo (badge gris).
- [ ] Verificación manual: toggle `showSourceBadges` desde DevTools (`usePrefsStore.setState({showSourceBadges: false})`) oculta los 3 estados.
- [ ] Verificación manual: recargar AgentScreen → historial restaurado debe mostrar badges correctos para turns persistidos con `metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)