### PR TITLE
fix(sw): persist nueva-versión ack — Antigravity QA #18

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -219,4 +219,22 @@ self.addEventListener('message', (event) => {
       self.registration.sync.register('voice-telemetry-flush');
     }
   }
+
+  // SKIP_WAITING: el cliente (UpdateAvailableBanner) lo manda cuando el
+  // usuario click "Actualizar". Activa el SW en waiting → dispara
+  // controllerchange → el cliente recarga (window.location.reload()).
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+
+  // GET_VERSION: el cliente pregunta la version del SW activo para
+  // comparar con `sw:last-acked-version` en localStorage y decidir si
+  // mostrar el banner "nueva version disponible". Respondemos por
+  // MessageChannel (event.ports[0]) para evitar broadcast a otros clients.
+  // Fix Antigravity QA #18.
+  if (event.data && event.data.type === 'GET_VERSION') {
+    if (event.ports && event.ports[0]) {
+      event.ports[0].postMessage({ type: 'VERSION', version: CACHE_NAME });
+    }
+  }
 });

--- a/src/__tests__/swUpdateAck.test.js
+++ b/src/__tests__/swUpdateAck.test.js
@@ -1,0 +1,118 @@
+/**
+ * swUpdateAck.test.js — cobertura del fix Antigravity QA #18.
+ *
+ * Bug: el banner "nueva versión disponible" se mostraba cada reload aunque
+ * el usuario ya hubiera clickeado "Actualizar". Persistimos el ack en
+ * localStorage clave `sw:last-acked-version` y suprimimos el banner si la
+ * versión actual del SW coincide con la ya aceptada.
+ *
+ * Casos cubiertos (3 mínimos pedidos en el ticket #128):
+ *   1. First install (no ack previo) → NO mostrar banner.
+ *   2. Ack persistido y misma versión → NO mostrar banner.
+ *   3. Versión cambió (incluido rollback) → SÍ mostrar banner.
+ *
+ * Refs: Antigravity QA #18, task #128.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  shouldShowUpdateBanner,
+  readAckedVersion,
+  writeAckedVersion,
+  seedFirstInstallAck,
+  ACK_STORAGE_KEY,
+} from '../services/swUpdateAck';
+
+beforeEach(() => {
+  // jsdom expone localStorage real — limpiar entre tests para no leak ack.
+  globalThis.localStorage.clear();
+});
+
+describe('shouldShowUpdateBanner', () => {
+  it('NO muestra banner en first install (lastAcked null)', () => {
+    expect(shouldShowUpdateBanner('chagra-v210', null)).toBe(false);
+  });
+
+  it('NO muestra banner cuando lastAcked === currentVersion (ack persistido)', () => {
+    expect(shouldShowUpdateBanner('chagra-v210', 'chagra-v210')).toBe(false);
+  });
+
+  it('SÍ muestra banner cuando la versión cambió (upgrade)', () => {
+    expect(shouldShowUpdateBanner('chagra-v211', 'chagra-v210')).toBe(true);
+  });
+
+  it('SÍ muestra banner en rollback (currentVersion distinta aunque numericamente menor)', () => {
+    // Rollback: prod hizo revert y el CACHE_NAME bajó. Es una version nueva
+    // legitima desde la perspectiva del usuario aunque el número sea menor.
+    expect(shouldShowUpdateBanner('chagra-v209', 'chagra-v210')).toBe(true);
+  });
+
+  it('NO muestra banner si currentVersion es falsy (SW aún no respondió)', () => {
+    expect(shouldShowUpdateBanner(null, 'chagra-v210')).toBe(false);
+    expect(shouldShowUpdateBanner('', 'chagra-v210')).toBe(false);
+    expect(shouldShowUpdateBanner(undefined, 'chagra-v210')).toBe(false);
+  });
+
+  it('trata empty-string lastAcked como first install', () => {
+    expect(shouldShowUpdateBanner('chagra-v210', '')).toBe(false);
+  });
+});
+
+describe('localStorage helpers (read/write/seed)', () => {
+  it('readAckedVersion devuelve null cuando no hay ack', () => {
+    expect(readAckedVersion()).toBeNull();
+  });
+
+  it('writeAckedVersion persiste y readAckedVersion lo recupera', () => {
+    writeAckedVersion('chagra-v210');
+    expect(readAckedVersion()).toBe('chagra-v210');
+    expect(globalThis.localStorage.getItem(ACK_STORAGE_KEY)).toBe('chagra-v210');
+  });
+
+  it('writeAckedVersion no escribe si version es falsy', () => {
+    writeAckedVersion('');
+    expect(readAckedVersion()).toBeNull();
+    writeAckedVersion(null);
+    expect(readAckedVersion()).toBeNull();
+  });
+
+  it('seedFirstInstallAck escribe cuando no hay ack previo', () => {
+    expect(seedFirstInstallAck('chagra-v210')).toBe(true);
+    expect(readAckedVersion()).toBe('chagra-v210');
+  });
+
+  it('seedFirstInstallAck NO sobrescribe ack existente', () => {
+    writeAckedVersion('chagra-v210');
+    expect(seedFirstInstallAck('chagra-v211')).toBe(false);
+    expect(readAckedVersion()).toBe('chagra-v210');
+  });
+});
+
+describe('flujo end-to-end del ack (3 casos del ticket #128)', () => {
+  it('caso 1 (first install): suprime banner + seed ack', () => {
+    const currentVersion = 'chagra-v210';
+    const lastAcked = readAckedVersion();
+    expect(lastAcked).toBeNull();
+    // Lógica del main.jsx: first install → seed + suprimir.
+    expect(shouldShowUpdateBanner(currentVersion, lastAcked)).toBe(false);
+    seedFirstInstallAck(currentVersion);
+    expect(readAckedVersion()).toBe(currentVersion);
+  });
+
+  it('caso 2 (ack persistido, misma version): suprime banner', () => {
+    writeAckedVersion('chagra-v210');
+    const currentVersion = 'chagra-v210';
+    const lastAcked = readAckedVersion();
+    expect(shouldShowUpdateBanner(currentVersion, lastAcked)).toBe(false);
+  });
+
+  it('caso 3 (version cambió): muestra banner; ack persiste tras click', () => {
+    writeAckedVersion('chagra-v210');
+    const currentVersion = 'chagra-v211';
+    const lastAcked = readAckedVersion();
+    expect(shouldShowUpdateBanner(currentVersion, lastAcked)).toBe(true);
+    // Simular click "Actualizar": persistir ack ANTES del reload.
+    writeAckedVersion(currentVersion);
+    // Tras reload, el toast no debería volver a aparecer:
+    expect(shouldShowUpdateBanner(currentVersion, readAckedVersion())).toBe(false);
+  });
+});

--- a/src/components/UpdateAvailableBanner.jsx
+++ b/src/components/UpdateAvailableBanner.jsx
@@ -1,16 +1,30 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { RefreshCw } from 'lucide-react';
+import { writeAckedVersion } from '../services/swUpdateAck';
 
 export default function UpdateAvailableBanner() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
+  // Capturamos la version reportada por el SW (via event.detail) para
+  // persistir el ack en click "Actualizar". Fix Antigravity QA #18.
+  const announcedVersionRef = useRef(null);
 
   useEffect(() => {
-    const handler = () => setUpdateAvailable(true);
+    const handler = (event) => {
+      const version = event?.detail?.version ?? null;
+      if (version) announcedVersionRef.current = version;
+      setUpdateAvailable(true);
+    };
     window.addEventListener('chagra:update-available', handler);
     return () => window.removeEventListener('chagra:update-available', handler);
   }, []);
 
   const handleUpdate = async () => {
+    // Persistimos el ack ANTES del reload: si el reload falla o el usuario
+    // cierra la pestaña, no queremos repetir el toast en la proxima sesion
+    // para una version que ya acepto.
+    if (announcedVersionRef.current) {
+      writeAckedVersion(announcedVersionRef.current);
+    }
     try {
       const reg = await navigator.serviceWorker.ready;
       if (reg.waiting) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,6 +11,11 @@ import { fetchFromFarmOS } from './services/apiService'
 import { PRIMARY_WORKER_NAME } from './config/workerConfig'
 import { renameWorker } from './services/assetService'
 import { getAccessToken } from './services/authService'
+import {
+  shouldShowUpdateBanner,
+  readAckedVersion,
+  seedFirstInstallAck,
+} from './services/swUpdateAck'
 
 import { loadDemoSeedData } from '../scripts/seed-demo';
 import { bootstrapOssModules } from './core/bootstrap-oss';
@@ -87,21 +92,91 @@ if ('serviceWorker' in navigator) {
   // Banner "nueva version disponible" cuando SW cambia (controllerchange) o
   // cuando un nuevo SW esta en waiting (updatefound). Reemplaza auto-reload:
   // el operador decide cuando actualizar via UpdateAvailableBanner.
+  //
+  // Fix Antigravity QA #18: persistimos el ack en localStorage
+  // (`sw:last-acked-version`) para no repetir el toast cada reload. Antes
+  // de disparar `chagra:update-available` preguntamos al SW su CACHE_NAME
+  // via MessageChannel y comparamos con el acked. Si coincide → suprimir.
+  // First install (no ack previo) → suprimir tambien y sembrar el ack para
+  // que la primera notif real (al actualizar) si dispare.
+  const maybeDispatchUpdateAvailable = async (sw) => {
+    if (!sw) return;
+    try {
+      const version = await getSwVersion(sw);
+      if (!version) return;
+      const lastAcked = readAckedVersion();
+      // Seed first-install: nunca hubo ack previo → guardamos current y
+      // suprimimos el toast. Asi en la proxima version real (CACHE_NAME
+      // distinto) el banner si dispara.
+      if (lastAcked === null) {
+        seedFirstInstallAck(version);
+        return;
+      }
+      if (shouldShowUpdateBanner(version, lastAcked)) {
+        window.dispatchEvent(
+          new CustomEvent('chagra:update-available', { detail: { version } })
+        );
+      }
+    } catch (_) {
+      // SW no responde / MessageChannel timeout → no spammear toast.
+    }
+  };
+
   navigator.serviceWorker.addEventListener('controllerchange', () => {
-    window.dispatchEvent(new CustomEvent('chagra:update-available'));
+    maybeDispatchUpdateAvailable(navigator.serviceWorker.controller);
   });
 
   // Tambien detectar SW en waiting por si el controllerchange no se dispara
   // (ej. si el SW no hace skipWaiting automaticamente en el futuro).
   navigator.serviceWorker.ready.then((registration) => {
+    // Estado inicial: si ya hay un SW controlador, sembrar ack para suprimir
+    // toast en cargas siguientes.
+    if (navigator.serviceWorker.controller) {
+      maybeDispatchUpdateAvailable(navigator.serviceWorker.controller);
+    }
     if (registration.waiting) {
-      window.dispatchEvent(new CustomEvent('chagra:update-available'));
+      maybeDispatchUpdateAvailable(registration.waiting);
     }
     registration.addEventListener('updatefound', () => {
-      if (registration.waiting) {
-        window.dispatchEvent(new CustomEvent('chagra:update-available'));
+      const installing = registration.installing;
+      if (installing) {
+        installing.addEventListener('statechange', () => {
+          if (installing.state === 'installed' && registration.waiting) {
+            maybeDispatchUpdateAvailable(registration.waiting);
+          }
+        });
+      } else if (registration.waiting) {
+        maybeDispatchUpdateAvailable(registration.waiting);
       }
     });
+  });
+}
+
+// Pregunta CACHE_NAME al SW via MessageChannel con timeout corto. Devuelve
+// null si no responde (no bloquear UI ni spammear toast).
+function getSwVersion(sw, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    if (!sw || typeof MessageChannel === 'undefined') {
+      resolve(null);
+      return;
+    }
+    const channel = new MessageChannel();
+    const timer = setTimeout(() => {
+      channel.port1.close();
+      resolve(null);
+    }, timeoutMs);
+    channel.port1.onmessage = (event) => {
+      clearTimeout(timer);
+      channel.port1.close();
+      resolve(event.data?.version ?? null);
+    };
+    try {
+      sw.postMessage({ type: 'GET_VERSION' }, [channel.port2]);
+    } catch (_) {
+      clearTimeout(timer);
+      channel.port1.close();
+      resolve(null);
+    }
   });
 }
 

--- a/src/services/swUpdateAck.js
+++ b/src/services/swUpdateAck.js
@@ -1,0 +1,105 @@
+/**
+ * swUpdateAck.js — persistencia del "ack de versión" del Service Worker.
+ *
+ * Bug Antigravity QA #18: la notificación "nueva versión disponible" se
+ * mostraba cada reload aunque el usuario ya hubiera clickeado "Actualizar".
+ * El SW dispara `controllerchange`/`updatefound` con cada activación nueva
+ * y el cliente no recordaba que el usuario ya había aceptado esa versión.
+ *
+ * Estrategia:
+ *  - Cuando el usuario click "Actualizar" → guardamos `currentVersion` en
+ *    localStorage clave `sw:last-acked-version`.
+ *  - Al boot (o al recibir notif del SW) preguntamos si debemos mostrar el
+ *    banner: solo si `currentVersion !== lastAcked` y no es first-install.
+ *  - First install (`lastAcked === null`) → NO mostramos toast; es la primera
+ *    vez que el usuario abre la app, no es "actualización".
+ *  - Cambio de versión (incluido rollback con SHA distinto) → SÍ mostramos.
+ *
+ * Este módulo expone funciones puras + helpers de localStorage para que
+ * `swUpdateAck.test.js` pueda cubrir los 3 casos sin mockear navigator.
+ *
+ * Refs: Antigravity QA #18, task #128.
+ */
+
+export const ACK_STORAGE_KEY = 'sw:last-acked-version';
+
+/**
+ * Decide si mostrar el banner "nueva versión disponible".
+ *
+ * @param {string|null|undefined} currentVersion — versión reportada por el SW
+ *   activo (ej. `CACHE_NAME` `chagra-v210` o `chagra-<sha>`).
+ * @param {string|null|undefined} lastAcked — última versión que el usuario
+ *   aceptó (de localStorage).
+ * @returns {boolean} true si se debe mostrar el banner.
+ */
+export function shouldShowUpdateBanner(currentVersion, lastAcked) {
+  // Sin versión actual conocida (SW aún no respondió o sin SW) → no mostrar.
+  if (!currentVersion) return false;
+  // First install: el usuario nunca aceptó ninguna versión. NO es "update",
+  // es la primera vez que abre la app. Persistimos el current como acked
+  // para que la primera notif real (cuando haya un update) sí dispare.
+  if (lastAcked === null || lastAcked === undefined || lastAcked === '') {
+    return false;
+  }
+  // Misma versión ya aceptada → no repetir el toast aunque el SW redispare
+  // controllerchange/updatefound al refresh.
+  if (currentVersion === lastAcked) return false;
+  // Cualquier otro caso (upgrade, downgrade/rollback, cache name distinto)
+  // → mostrar banner. El operador decide reload.
+  return true;
+}
+
+/**
+ * Lee el ack persistido. Devuelve null si no hay o si localStorage no está
+ * disponible (e.g. modo privado con restricciones).
+ *
+ * @param {Storage} [storage=globalThis.localStorage]
+ * @returns {string|null}
+ */
+export function readAckedVersion(storage = safeLocalStorage()) {
+  if (!storage) return null;
+  try {
+    return storage.getItem(ACK_STORAGE_KEY);
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Persiste el ack. Idempotente, swallow errors (quota / Safari private).
+ *
+ * @param {string} version
+ * @param {Storage} [storage=globalThis.localStorage]
+ */
+export function writeAckedVersion(version, storage = safeLocalStorage()) {
+  if (!storage || !version) return;
+  try {
+    storage.setItem(ACK_STORAGE_KEY, version);
+  } catch (_) {
+    /* quota / private mode — silent */
+  }
+}
+
+/**
+ * Persiste el ack al boot para suprimir el toast "first install" en sesiones
+ * futuras. Solo escribe si no hay ack previo (lastAcked === null).
+ *
+ * @param {string} currentVersion
+ * @param {Storage} [storage=globalThis.localStorage]
+ * @returns {boolean} true si seedió, false si ya existía un ack.
+ */
+export function seedFirstInstallAck(currentVersion, storage = safeLocalStorage()) {
+  if (!currentVersion) return false;
+  const existing = readAckedVersion(storage);
+  if (existing !== null && existing !== undefined && existing !== '') return false;
+  writeAckedVersion(currentVersion, storage);
+  return true;
+}
+
+function safeLocalStorage() {
+  try {
+    return typeof globalThis !== 'undefined' ? globalThis.localStorage : null;
+  } catch (_) {
+    return null;
+  }
+}


### PR DESCRIPTION
## Bug
El banner "nueva versión disponible" se mostraba en cada reload aunque el usuario ya hubiera clickeado "Actualizar".

## Cambios
- Nuevo `src/services/swUpdateAck.js` con helpers `shouldShowUpdateBanner` + `read/writeAckedVersion` + `seedFirstInstallAck` usando `localStorage` key `sw:last-acked-version`.
- `src/main.jsx`: gate del `chagra:update-available` dispatch — pregunta al SW su `CACHE_NAME` vía `MessageChannel`, compara con ack, suprime toast si coincide. First install seedea ack sin mostrar banner. Listener `updatefound` ahora espera `statechange === 'installed'` (el original leía `registration.waiting` síncronamente, siempre null en ese momento).
- `src/components/UpdateAvailableBanner.jsx`: captura version del `event.detail` y persiste ack ANTES del reload.
- `public/sw.js`: añade handler `SKIP_WAITING` (estaba faltando — el banner lo posteaba pero el SW lo ignoraba) y `GET_VERSION` reply via MessageChannel.

## Sorpresa empírica
El `public/sw.js` original NO manejaba `SKIP_WAITING`. El botón Actualizar confiaba en `window.location.reload()` pero sin `skipWaiting()` el SW nuevo quedaba en `waiting` cross-reload. Eso por sí solo contribuía al toast repetido (el `controllerchange` disparaba cuando el browser eventualmente activaba el waiting, sin persistencia → toast otra vez).

## Tests
`src/__tests__/swUpdateAck.test.js` — 14 casos (3 del ticket + edges: rollback, falsy version, idempotency, first-install seed, etc.).

Refs: Antigravity QA bug #18, task #128