### PR TITLE
fix(agent): CASO C anti-alucinación queries enumerativas sin tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.172",
+  "version": "0.12.173",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v214';
+const CACHE_NAME = 'chagra-v215';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -308,6 +308,22 @@ pedí aclaración. ES PREFERIBLE QUEDAR COMO IGNORANTE QUE INVENTAR.
 
 REGLA CRÍTICA ANTI-INVENCIÓN-DE-SÍNTOMAS: NUNCA describas síntomas, problemas, observaciones o estados de las plantas del usuario que NO haya escrito explícitamente en su mensaje actual. PROHIBIDO frases como "dice que las hojas se ponen amarillas y se enrollan" o "los tomates no se forman bien" si el usuario no lo dijo. Si el corpus de información agronómica menciona síntomas genéricos, NO los atribuyas al usuario. Para preguntar sobre síntomas, hazlo como pregunta abierta: "¿Ha notado cambios en las hojas?" NO como afirmación. La pregunta del usuario es exactamente lo que dice; no agregues contexto inventado.
 
+CASO C — Consultas ENUMERATIVAS / CUANTITATIVAS sobre el catálogo.
+Patrones: "cuántas variedades de X hay", "cuántas clases de Y", "qué tipos de Z existen", "lista las variedades", "enumera los cultivares", "qué variedades tiene", "cuántos hay", "cuáles son los tipos". Estos piden un INVENTARIO autoritativo del catálogo Chagra.
+
+REGLA CASO C: si NO hay bloque "=== EVIDENCIA AUTORITATIVA ===" o equivalente con la enumeración solicitada, NUNCA listes números ni variedades. Aplica AUNQUE conozcas la planta (X es palabra común): el usuario no pide conocimiento general, pide el inventario registrado en Chagra.
+
+Respuesta correcta CASO C sin evidence:
+"El catálogo Chagra todavía no tiene un inventario de variedades de [planta]. Si quieres, te ayudo con información general sobre el cultivo o registramos las variedades que tengas en tu finca."
+
+Ejemplo CASO C (incidente real prod 2026-05-23 16:19):
+Usuario: "Cuantas clases de tomate hay"
+✗ MAL: "Usted tiene 12 variedades de tomate (Solanum lycopersicum), incluyendo la rama cherry, el tomate roma, el tomate beefsteak, la variedad amarilla, la variedad verde, la variedad blanca, la variedad amarilla, la variedad naranja, la variedad plúmula, la variedad redonda, la variedad de árbol y la variedad amarilla."
+   (INVENTADO: "plúmula" no existe, "tomate de árbol" es OTRA especie, repite "amarilla" 3 veces, conteo arbitrario.)
+✓ BIEN: "El catálogo Chagra todavía no tiene un inventario de variedades de tomate documentado. ¿Quieres información general del cultivo, o prefieres registrar las variedades que ya tengas en tu finca?"
+
+Heurística CASO C: ¿la pregunta usa "cuántas", "cuáles", "lista", "tipos", "clases", "variedades", "cultivares", "enumera"? Si SÍ y no hay tool result enumerativo en el contexto → CASO C obligatorio. NO RESPONDAS CON CONTEO NI LISTA INVENTADA.
+
 Responde en español colombiano (tú/usted, sin voseo argentino). Sé específico y útil cuando tengas certeza; humilde y preguntón cuando no.`;
   }, [plants, fincas, activeFincaSlug, indoorZone]);
 


### PR DESCRIPTION
## Bug
Reportado prod 2026-05-23 16:19: usuario preguntó "Cuantas clases de tomate hay" y el LLM (gemma3:4b) inventó:

> Usted tiene 12 variedades de tomate (Solanum lycopersicum), incluyendo la rama cherry, el tomate roma, el tomate beefsteak, la variedad amarilla, la variedad verde, la variedad blanca, la variedad amarilla, la variedad naranja, la variedad plúmula, la variedad redonda, la variedad de árbol y la variedad amarilla.

Problemas: "plúmula" no existe, "tomate de árbol" es OTRA especie (`Solanum betaceum`), "amarilla" repetida 3 veces, conteo arbitrario.

## Causa raíz
El system prompt tenía CASO A (lenguaje coloquial reconocible) y CASO B (sustantivos NO reconocidos / typos) + anti-invención de síntomas. **No cubría queries ENUMERATIVAS / CUANTITATIVAS sobre el catálogo**. CASO A se aplicó porque "tomate" es planta reconocida → LLM respondió con "sentido común" = alucinación.

## Fix — CASO C nuevo
Cualquier query con patrones "cuántas / cuáles / lista / tipos / clases / variedades / cultivares / enumera" REQUIERE tool result enumerativo. Sin él, respuesta obligatoria:

> El catálogo Chagra todavía no tiene un inventario de variedades de [X] documentado. ¿Quieres información general del cultivo, o prefieres registrar las variedades que ya tengas en tu finca?

Aplica AUNQUE X sea planta conocida — el usuario pide inventario Chagra, no conocimiento general.

## Heurística incluida
Para que el LLM aplique CASO C automáticamente: 4 preguntas explícitas en el prompt + ejemplo MAL/BIEN concreto del incidente real prod.

Refs: bug residual prod 2026-05-23, task #132