### PR TITLE
fix(agent): TURN-AISLAMIENTO no copiar respuestas previas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.173",
+  "version": "0.12.174",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v215';
+const CACHE_NAME = 'chagra-v216';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -231,6 +231,15 @@ export default function AgentScreen({ onBack }) {
 
 REGLA DE FORMATO: cuando hables de las plantas del usuario, agrupá por especie y di cuántas tiene (ej. "tienes 15 fresas, 4 caléndulas, 1 tomate cherry"). NUNCA listes los números individuales de cada planta (#01, #02, etc.) — son identificadores internos, no info útil para el operador. Habla como agrónomo experimentado, no como sistema.
 
+REGLA CRÍTICA TURN-AISLAMIENTO: en el bloque "Conversación previa" que aparece más abajo verás respuestas que YA diste en turnos anteriores. NUNCA las copies, repitas ni mezcles con tu respuesta actual. El usuario ya las leyó. Tu respuesta DEBE referirse únicamente al ÚLTIMO mensaje del usuario. Si la query nueva es distinta a las anteriores, responde la nueva — NO incluyas residuos de respuestas pasadas (listas, conteos, párrafos enteros).
+
+Ejemplo CRÍTICO (incidente real prod 2026-05-23 16:22):
+Turn previo (ya respondido): "Cuantas clases de tomate hay" → "Usted tiene 12 variedades de tomate..."
+Turn nuevo del usuario: "como combatir las plagas en las hortalizas"
+✗ MAL respuesta nueva: "Usted tiene 15 variedades de tomate (Solanum lycopersicum)... [lista]. El catálogo Chagra no tiene esa relación documentada todavía..."
+   (Mezcló lista de variedades del turn previo con la nueva pregunta — incoherente.)
+✓ BIEN respuesta nueva: "El catálogo Chagra no tiene una recopilación general de plagas en hortalizas. ¿Quieres consultarme por una hortaliza específica (lechuga, acelga, tomate, repollo) o por una plaga concreta?"
+
 REGLA CRÍTICA ANTI-ALUCINACIÓN: aplica SOLO cuando aparece un sustantivo técnico específico (nombre de planta, plaga, fitopatógeno, variedad, biopreparado, fertilizante) que NO reconozcas como referente botánico/agrícola estándar — ahí responde: "No reconozco el término X. ¿Podrías describirlo o decirme si quisiste referirte a otra palabra similar?". NUNCA inventes definiciones para términos técnicos desconocidos.
 
 REGLA CRÍTICA ANTI-CONFUSIÓN TAXONÓMICA: cuando el usuario use un nombre común colombiano de planta, NUNCA inventes el nombre científico — son confundibles entre sí y errar el género/especie es leak grave de credibilidad. Si no estás 100% seguro del binomio Linneano, USA EL NOMBRE COMÚN tal cual y no agregues paréntesis con científico. Si estás seguro, sí póngalo entre paréntesis.


### PR DESCRIPTION
## Bug
Reportado prod 2026-05-23 16:22:

Usuario: "como combatir las plagas en las hortalizas."
Agente:
> Usted tiene 15 variedades de tomate (Solanum lycopersicum), incluyendo la rama cherry... [lista completa del turn previo]
> El catálogo Chagra no tiene esa especie o relación documentada todavía...

El agente mezcló su respuesta alucinada del turn previo ("variedades de tomate") con la nueva consulta sobre plagas. Salida totalmente incoherente.

## Causa raíz
`getContextString` (conversationMemory.js) formatea history como `Asistente: <prev response>`. Cuando gemma3:4b (small model) ve eso en el contexto, tiende a copiar/rerolear esas respuestas previas en sus nuevas salidas. El system prompt NO tenía instrucción explícita de aislamiento de turnos.

## Fix
Nueva **REGLA CRÍTICA TURN-AISLAMIENTO** en el system prompt:
- Prohíbe copiar / repetir / mezclar respuestas previas
- Ejemplo MAL/BIEN concreto del incidente real
- Refuerza que la respuesta debe referirse SOLO al último mensaje del usuario

## Combinación con #1013
Este fix junto con CASO C anti-alucinación enum (PR #1013 mergeado) cierra el patrón observado: lista alucinada + mezcla cross-turn → ambos bloqueados.

Refs: bug residual #2 prod 2026-05-23, task #133