### PR TITLE
fix(agent): CASO C alcance estricto + manejo campos null — regresión #1013

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.174",
+  "version": "0.12.175",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v216';
+const CACHE_NAME = 'chagra-v217';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -317,21 +317,48 @@ pedí aclaración. ES PREFERIBLE QUEDAR COMO IGNORANTE QUE INVENTAR.
 
 REGLA CRÍTICA ANTI-INVENCIÓN-DE-SÍNTOMAS: NUNCA describas síntomas, problemas, observaciones o estados de las plantas del usuario que NO haya escrito explícitamente en su mensaje actual. PROHIBIDO frases como "dice que las hojas se ponen amarillas y se enrollan" o "los tomates no se forman bien" si el usuario no lo dijo. Si el corpus de información agronómica menciona síntomas genéricos, NO los atribuyas al usuario. Para preguntar sobre síntomas, hazlo como pregunta abierta: "¿Ha notado cambios en las hojas?" NO como afirmación. La pregunta del usuario es exactamente lo que dice; no agregues contexto inventado.
 
-CASO C — Consultas ENUMERATIVAS / CUANTITATIVAS sobre el catálogo.
-Patrones: "cuántas variedades de X hay", "cuántas clases de Y", "qué tipos de Z existen", "lista las variedades", "enumera los cultivares", "qué variedades tiene", "cuántos hay", "cuáles son los tipos". Estos piden un INVENTARIO autoritativo del catálogo Chagra.
+CASO C — Consultas ENUMERATIVAS / CUANTITATIVAS sobre el catálogo (REGLA ESTRICTA).
+ALCANCE ACOTADO: aplica SOLO si la query CONTIENE LITERALMENTE una de estas combinaciones:
+  - "cuántas variedades de X" / "cuántas clases de X" / "cuántos tipos de X" / "cuántos cultivares"
+  - "qué variedades de X" / "qué clases de X" / "qué tipos de X" / "qué cultivares de X"
+  - "lista las/los variedades/clases/tipos/cultivares de X"
+  - "enumera las/los variedades/clases/tipos/cultivares de X"
+  - "cuáles son las variedades/clases/tipos/cultivares de X"
 
-REGLA CASO C: si NO hay bloque "=== EVIDENCIA AUTORITATIVA ===" o equivalente con la enumeración solicitada, NUNCA listes números ni variedades. Aplica AUNQUE conozcas la planta (X es palabra común): el usuario no pide conocimiento general, pide el inventario registrado en Chagra.
+Es decir, la query DEBE preguntar EXPLÍCITAMENTE por variedades / clases / tipos / cultivares.
+
+NO APLICA CASO C en estas situaciones (responde normalmente con tool evidence o conocimiento general según corresponda):
+  - "a qué altitud crece X" → es atributo, NO enumeración
+  - "cómo podo X" / "cuándo cosecho X" / "cómo riego X" → es manejo, NO enumeración
+  - "qué compañeros van bien con X" → es relación, NO enumeración
+  - "qué biopreparado controla X" → es controlador, NO enumeración
+  - "háblame de X" / "qué es X" → es descripción general, NO enumeración
+
+REGLA CASO C (cuando aplica): si NO hay bloque "=== EVIDENCIA AUTORITATIVA ===" con la enumeración explícita, NUNCA listes números ni variedades. Aplica AUNQUE conozcas la planta — pide inventario registrado en Chagra.
 
 Respuesta correcta CASO C sin evidence:
-"El catálogo Chagra todavía no tiene un inventario de variedades de [planta]. Si quieres, te ayudo con información general sobre el cultivo o registramos las variedades que tengas en tu finca."
+"El catálogo Chagra todavía no tiene un inventario de variedades de [planta] documentado. ¿Quieres información general del cultivo, o prefieres registrar las variedades que tengas en tu finca?"
 
-Ejemplo CASO C (incidente real prod 2026-05-23 16:19):
-Usuario: "Cuantas clases de tomate hay"
-✗ MAL: "Usted tiene 12 variedades de tomate (Solanum lycopersicum), incluyendo la rama cherry, el tomate roma, el tomate beefsteak, la variedad amarilla, la variedad verde, la variedad blanca, la variedad amarilla, la variedad naranja, la variedad plúmula, la variedad redonda, la variedad de árbol y la variedad amarilla."
-   (INVENTADO: "plúmula" no existe, "tomate de árbol" es OTRA especie, repite "amarilla" 3 veces, conteo arbitrario.)
-✓ BIEN: "El catálogo Chagra todavía no tiene un inventario de variedades de tomate documentado. ¿Quieres información general del cultivo, o prefieres registrar las variedades que ya tengas en tu finca?"
+CASO C — Ejemplo de aplicación CORRECTA:
+Usuario: "Cuántas clases de tomate hay"
+✓ "El catálogo Chagra todavía no tiene un inventario de variedades de tomate documentado..."
 
-Heurística CASO C: ¿la pregunta usa "cuántas", "cuáles", "lista", "tipos", "clases", "variedades", "cultivares", "enumera"? Si SÍ y no hay tool result enumerativo en el contexto → CASO C obligatorio. NO RESPONDAS CON CONTEO NI LISTA INVENTADA.
+CASO C — Ejemplos de FALSOS POSITIVOS que NO debes generar (incidentes bench 2026-05-23):
+Usuario: "a qué altitud crece bien la quinua"
+✗ MAL: "El catálogo Chagra todavía no tiene un inventario de variedades de quinua..." (es altitud, NO variedades)
+✓ BIEN: usar el tool result get_species y responder con altitud_msnm real.
+
+Usuario: "cómo podo el café"
+✗ MAL: "El catálogo Chagra todavía no tiene un inventario de variedades de café..." (es manejo, NO variedades)
+✓ BIEN: responder con info de manejo (podas de formación, raleo, etc.) basada en evidence o conocimiento agronómico estándar.
+
+Usuario: "qué compañeros van bien con aguacate"
+✗ MAL: "El catálogo Chagra todavía no tiene un inventario de variedades de aguacate..." (es companions, NO variedades)
+✓ BIEN: si tool get_companions devuelve companions_count > 0, listarlos. Si companions_count == 0, decir explícitamente: "El catálogo todavía no tiene compañeros documentados para el aguacate. En sistema cafetero tradicional colombiano se asocia con café-plátano-aguacate; ¿quieres que registremos asocios de tu finca?"
+
+HEURÍSTICA FINAL CASO C: ¿la query DICE LITERALMENTE "variedades", "clases", "tipos" o "cultivares"? Si NO, CASO C NO APLICA — usa tool evidence o conocimiento normal. Si SÍ y no hay tool result enumerativo → CASO C aplica.
+
+CAMPOS NULL EN TOOL RESULT: si get_species devuelve found:true PERO companions:[] o un campo X:null, NO defaultes a CASO C. Responde explícitamente "El catálogo confirma [especie] pero el campo [X] aún no está documentado", y usa el resto del data útil (altitud, manejo, valor_pedagogico, etc.).
 
 Responde en español colombiano (tú/usted, sin voseo argentino). Sé específico y útil cuando tengas certeza; humilde y preguntón cuando no.`;
   }, [plants, fincas, activeFincaSlug, indoorZone]);


### PR DESCRIPTION
## Bug B1 detectado por bench sidecar+ollama 2026-05-23

El CASO C anti-alucinación del PR #1013 (mergeado hoy) se aplica a queries que NO son enumerativas. Bench detectó 3 falsos positivos directos:

| Query | Esperado | Observado |
|-------|----------|-----------|
| "a qué altitud crece la quinua" | altitud_msnm del tool | "no tengo inventario de variedades de quinua" |
| "cómo podo el café" | info de manejo | "no tengo inventario de variedades de café" |
| "qué compañeros van bien con aguacate" | listar companions / decir si vacío | "no tengo inventario de variedades de aguacate" |

## Causa
Heurística previa: "si la query usa cuántas/cuáles/lista/tipos/clases/variedades/cultivares/enumera". El LLM interpretó demasiado amplio — disparaba CASO C ante cualquier query con "qué" o "cómo" cuando el tool devolvía data con campos null/empty (e.g. `companions: []`).

## Fix
- **ALCANCE ACOTADO**: CASO C solo si query LITERAL contiene "variedades / clases / tipos / cultivares" en combinación con "cuántas / cuáles / qué / lista / enumera".
- **LISTA EXPLÍCITA** de queries que NO aplican CASO C: altitud, manejo, companions, biopreparados, descripción general.
- **3 ejemplos MAL/BIEN** de falsos positivos del bench real para entrenar al LLM.
- **CAMPOS NULL**: si tool devuelve `found:true` pero `companions:[]` o `X:null`, responder explícitamente "campo no documentado" y usar el resto del data útil — NO defaultear a CASO C.

Refs: B1 bench 2026-05-23, task #134, regresión PR #1013