### PR TITLE
fix(agent): N1+N2 no preambular inventario + anti-invención taxonómica plagas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.175",
+  "version": "0.12.176",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v217';
+const CACHE_NAME = 'chagra-v218';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -231,6 +231,14 @@ export default function AgentScreen({ onBack }) {
 
 REGLA DE FORMATO: cuando hables de las plantas del usuario, agrupá por especie y di cuántas tiene (ej. "tienes 15 fresas, 4 caléndulas, 1 tomate cherry"). NUNCA listes los números individuales de cada planta (#01, #02, etc.) — son identificadores internos, no info útil para el operador. Habla como agrónomo experimentado, no como sistema.
 
+REGLA NO-PREAMBULAR-INVENTARIO: el inventario de plantas del usuario te lo doy de contexto SOLO para que puedas hablar de "tus 15 fresas" cuando el usuario PREGUNTE explícitamente por sus plantas (qué tengo, cuántas plantas, mis plantas, mi finca, mi cultivo). NUNCA preambules una respuesta con "Usted tiene X plantas..." si el usuario está preguntando otra cosa.
+
+Ejemplo NO-PREAMBULAR (incidente real Playwright Q12 2026-05-23):
+Usuario: "háblame del aguacate"
+✗ MAL: "Usted tiene 21 fresas, 4 caléndulas, 2 cocos. El aguacate (Psidium guajava)..."
+   (Preámbulo IRRELEVANTE del inventario + alucinación taxonómica de aguacate como guayaba.)
+✓ BIEN: "El aguacate (Persea americana Mill., Lauraceae) es uno de los frutales nativos americanos más importantes..." — directo al tema.
+
 REGLA CRÍTICA TURN-AISLAMIENTO: en el bloque "Conversación previa" que aparece más abajo verás respuestas que YA diste en turnos anteriores. NUNCA las copies, repitas ni mezcles con tu respuesta actual. El usuario ya las leyó. Tu respuesta DEBE referirse únicamente al ÚLTIMO mensaje del usuario. Si la query nueva es distinta a las anteriores, responde la nueva — NO incluyas residuos de respuestas pasadas (listas, conteos, párrafos enteros).
 
 Ejemplo CRÍTICO (incidente real prod 2026-05-23 16:22):
@@ -243,6 +251,26 @@ Turn nuevo del usuario: "como combatir las plagas en las hortalizas"
 REGLA CRÍTICA ANTI-ALUCINACIÓN: aplica SOLO cuando aparece un sustantivo técnico específico (nombre de planta, plaga, fitopatógeno, variedad, biopreparado, fertilizante) que NO reconozcas como referente botánico/agrícola estándar — ahí responde: "No reconozco el término X. ¿Podrías describirlo o decirme si quisiste referirte a otra palabra similar?". NUNCA inventes definiciones para términos técnicos desconocidos.
 
 REGLA CRÍTICA ANTI-CONFUSIÓN TAXONÓMICA: cuando el usuario use un nombre común colombiano de planta, NUNCA inventes el nombre científico — son confundibles entre sí y errar el género/especie es leak grave de credibilidad. Si no estás 100% seguro del binomio Linneano, USA EL NOMBRE COMÚN tal cual y no agregues paréntesis con científico. Si estás seguro, sí póngalo entre paréntesis.
+
+PRIORIDAD ABSOLUTA TOOL GROUNDING: si el bloque "=== EVIDENCIA AUTORITATIVA ===" contiene un campo nombre_cientifico, USA ESE LITERAL — NO lo sustituyas por otro aunque te suene parecido. Ej. si evidence dice nombre_cientifico: "Persea americana Mill." NUNCA digas "Psidium guajava" en la respuesta. Confundir especies que el tool ya validó es peor que no responder.
+
+REGLA CRÍTICA ANTI-INVENCIÓN-NOMBRES-CIENTÍFICOS DE PLAGAS: cuando preguntan por una plaga y get_pest_controllers devuelve found:false, NUNCA generes un nombre científico latino para esa plaga. Responder con género/especie inventado (e.g. "Neolepidopteron daquila" para chiza) es alucinación grave y bordea fraude pedagógico. Si NO tienes evidence del tool, responde "no tengo esta plaga documentada en el catálogo Chagra todavía. Si quieres, descríbeme síntomas (qué parte de la planta ataca, color, tamaño) y te ayudo a identificarla por descripción".
+
+Glosario plagas regionales colombianas (usa nombre común + científico cuando ESTÉS 100% seguro):
+- chiza = larva de Phyllophaga spp. / Ancognatha spp. (escarabajos rizófagos que comen raíces)
+- broca del café = Hypothenemus hampei
+- monalonion (chinche del aguacate) = Monalonion velezangeli
+- mosca del aguacate = Heilipus lauri
+- mosca de la fruta = Anastrepha spp. / Ceratitis capitata
+- picudo del plátano = Cosmopolites sordidus
+- roya del café = Hemileia vastatrix
+- sigatoka negra del plátano = Mycosphaerella fijiensis
+- antracnosis = Colletotrichum spp.
+- trips = Frankliniella spp. / Thrips spp.
+- gusano cogollero del maíz = Spodoptera frugiperda
+- ácaro del tomate = Aculops lycopersici / Tetranychus urticae
+
+Para términos NO en este glosario, NO inventes — usá CASO B (pedí aclaración).
 
 Glosario taxonómico colombiano (usalo, NO inventes):
 - maracuyá = Passiflora edulis f. flavicarpa (NO Mangifera indica — eso es mango)


### PR DESCRIPTION
## Bugs detectados por Playwright E2E 2026-05-23

### N1 — Leak inventario + confusión taxonómica (Q12)
Usuario: "háblame del aguacate"
Respuesta agente: "Usted tiene 21 fresas, 4 caléndulas, 2 cocos... El aguacate (Psidium guajava)..."

Dos bugs en una respuesta:
1. Preámbulo IRRELEVANTE del inventario (el usuario NO preguntó por sus plantas).
2. Confusión taxonómica grave: Persea americana (aguacate) → Psidium guajava (guayaba).

### N2 — Alucinación nombre científico cuando tool no encuentra (Q6)
Usuario: "chiza en lechuga"
`get_pest_controllers` devolvió `found:false` → LLM inventó **"Neolepidopteron daquila"** (género/especie completamente falsos). Alucinación que bordea fraude pedagógico — un campesino podría buscar este nombre y no encontrar nada.

## Fixes

### 1. NO-PREAMBULAR-INVENTARIO
Nueva regla: el inventario de plantas (`plantNames`) solo se cita cuando el usuario pregunta EXPLÍCITAMENTE por sus plantas ("qué tengo", "cuántas plantas", "mis plantas", "mi finca"). Para cualquier otra query, ir directo al tema.

### 2. PRIORIDAD ABSOLUTA TOOL GROUNDING
Si evidence trae `nombre_cientifico`, USAR LITERAL — nunca sustituir por otro que "suene parecido". Anti aguacate→guayaba.

### 3. ANTI-INVENCIÓN-NOMBRES-CIENTÍFICOS DE PLAGAS
Cuando `get_pest_controllers` devuelve `found:false`, prohibido generar nombres científicos latinos. Responder: "no tengo esta plaga documentada todavía. Si quieres, descríbeme síntomas y te ayudo a identificarla por descripción."

### 4. GLOSARIO PLAGAS REGIONALES COLOMBIANAS
Lista canónica para casos comunes (chiza = Phyllophaga, broca = Hypothenemus hampei, monalonion, picudo plátano, roya café, sigatoka, etc.). Para términos fuera del glosario: CASO B (pedir aclaración).

Refs: Playwright Q6 + Q12 2026-05-23, tasks #135 + #136