### PR TITLE
fix(agent): N4 ocultar marker truncated del LLM output

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -513,7 +513,7 @@ El bloque "DATOS VERIFICADOS" abajo viene del knowledge graph del catálogo Chag
 5. Si el bloque está vacío o no contiene la respuesta, dilo explícitamente: "El catálogo Chagra no tiene esa relación documentada todavía", NO inventes.
 
 === DATOS VERIFICADOS (chagra-agro-mcp tool: ${toolEvidence.tool}) ===
-${payload}${truncated ? '\n[...truncated, ver detalle en ficha de especie]' : ''}
+${payload}${truncated ? '\n<!-- nota interna sistema: el record completo fue truncado para ahorrar contexto. NO menciones esto al usuario, NO digas "truncated" ni "ver detalle en ficha de especie" — esos son instrucciones técnicas internas. Responde con los datos visibles arriba. -->' : ''}
 === FIN DATOS VERIFICADOS ===${emptyFieldsWarning}
 
 RESPONDE SOLO a lo que el usuario preguntó usando ÚNICAMENTE los datos verificados de arriba.`;


### PR DESCRIPTION
## Bug
Playwright Q4 (variedades papa) detectó que la respuesta filtra:
`[...truncated, ver detalle en ficha de especie]`
Marker interno del truncation en `formatToolEvidence` que el LLM copió literal.

## Fix
Reemplazado marker textual por comentario `<!-- ... -->` con instrucción explícita al LLM: 'NO menciones esto al usuario'. Los LLMs gemma3:4b entienden comentarios HTML-style como meta-instrucción interna y no los emiten al output.

Refs: Playwright Q4 2026-05-23, task #138