### PR TITLE
fix(app): NN4 pre-warm Ollama al login (no dashboard) — elimina cold start 116s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.177",
+  "version": "0.12.178",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v219';
+const CACHE_NAME = 'chagra-v220';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { initCatalog } from './db/catalogDB';
 import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
 import SyncProgressIndicator from './components/common/SyncProgressIndicator';
+import useOllamaWarmStore from './store/useOllamaWarmStore';
 // FieldFeedback ya no se monta globalmente en App; vive embebido en
 // HelpUsoScreen como sección de Ayuda (decisión 2026-05-21, ver
 // comentario abajo donde se removió el render).
@@ -334,42 +335,25 @@ export default function App() {
     });
   }, []);
 
-  // N5 fix 2026-05-23: pre-warm Ollama gemma3:4b al boot post-dashboard.
-  // Playwright detectó cold-start de 116s en la primera query del agente
-  // porque Ollama carga el modelo en GPU bajo demanda (4.6 GB VRAM). Pre-warm
-  // dispara POST silente con prompt mínimo + keep_alive=30m → modelo queda
-  // hot. Si falla, transparente (degrada al cold-start clásico). Solo
-  // post-dashboard (no login) para no consumir GPU si user no llega a usar
-  // el agente. Una sola vez por sesión de tab (useEffect deps cuidadas).
-  const [ollamaPrewarmed, setOllamaPrewarmed] = useState(false);
+  // NN4 fix 2026-05-23: pre-warm Ollama gemma3:4b se dispara al LOGIN
+  // SUCCESS (LoginScreen → useOllamaWarmStore.startWarmup()), NO al
+  // dashboard. Esto da ~15-30s de margen humano antes que el operador
+  // llegue al agente, eliminando el cold-start 116s observado en
+  // Playwright Q1 curuba 2026-05-23.
+  //
+  // Este useEffect es FALLBACK para el caso de re-mount sin login (ej.
+  // tab refresh con sesión persistida en localStorage que arranca directo
+  // al dashboard). Solo dispara si status==='unknown'. Si LoginScreen ya
+  // disparó el warm-up (caso normal), el store devuelve early y no se
+  // hace request duplicado. Si Ollama falla o tarda, el banner del agente
+  // muestra "Preparando agente IA" hasta que warm-up complete.
   useEffect(() => {
-    if (currentView !== 'dashboard' || ollamaPrewarmed) return;
-    let cancelled = false;
-    const prewarm = async () => {
-      try {
-        await fetch('/api/ollama/api/generate', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            model: 'gemma3:4b',
-            prompt: 'ok',
-            stream: false,
-            keep_alive: '30m',
-            options: { num_predict: 1 },
-          }),
-          signal: AbortSignal.timeout(150000),
-        });
-        if (!cancelled) {
-          console.debug('[App] ollama gemma3:4b pre-warm OK');
-          setOllamaPrewarmed(true);
-        }
-      } catch (err) {
-        if (!cancelled) console.debug('[App] ollama pre-warm degradó (cold-start clásico):', err?.message);
-      }
-    };
-    prewarm();
-    return () => { cancelled = true; };
-  }, [currentView, ollamaPrewarmed]);
+    if (currentView !== 'dashboard') return;
+    const { status, startWarmup } = useOllamaWarmStore.getState();
+    if (status === 'unknown') {
+      startWarmup();
+    }
+  }, [currentView]);
 
   // 2026-05-18 (operator request): la imagen de fondo agroecológica de
   // /biodiversidad-bg.jpg que está en la pestaña Biodiversidad se aplica

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -28,6 +28,7 @@ import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
 import useAgentNotificationStore from '../../store/useAgentNotificationStore';
+import useOllamaWarmStore from '../../store/useOllamaWarmStore';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 
 // 2026-05-16: migrado a llmRouter (Multi-LLM por tarea). AgentScreen usa
@@ -49,6 +50,13 @@ export default function AgentScreen({ onBack }) {
   const setResponseReady = useAgentNotificationStore((s) => s.setResponseReady);
   const setLastNotificationMessage = useAgentNotificationStore((s) => s.setLastMessage);
   const markRead = useAgentNotificationStore((s) => s.markRead);
+  // NN4 fix 2026-05-23: subscripción al store warm-up. Si el modelo todavía
+  // no está caliente cuando el operador llega al agente, mostramos banner
+  // pequeño "Preparando agente IA". El banner desaparece automáticamente
+  // cuando status pasa a 'warm'. En status 'failed' tampoco mostramos el
+  // banner — la primera query caerá al cold-start clásico con su propio
+  // indicador ("pensando...") que ya cubre la espera percibida.
+  const ollamaWarmStatus = useOllamaWarmStore((s) => s.status);
   const plants = useAssetStore((s) => s.plants);
   // 062.6: contexto finca activa para system prompt (zona biocultural,
   // altitud, override indoor invernadero).
@@ -993,6 +1001,29 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           <p className="text-xs text-slate-300" data-testid="fresh-session-badge">
             Nueva conversación. El historial anterior queda guardado pero no se
             incluye en el contexto.
+          </p>
+        </div>
+      )}
+
+      {/* NN4 fix 2026-05-23: banner pequeño cuando el modelo Ollama todavía
+          se está calentando (warm-up disparado en login pero aún no completó).
+          Aparece solo en status 'unknown' o 'warming' — en 'warm' o 'failed'
+          queda oculto. Se mostraría típicamente si el operador navega al
+          agente MUY rápido tras login antes que termine el warm-up (~25-40s
+          en GPU M6000). Spinner CSS con animación spin de Tailwind. */}
+      {(ollamaWarmStatus === 'warming' || ollamaWarmStatus === 'unknown') && (
+        <div
+          className="px-4 py-2 mx-4 mt-2 rounded-lg bg-amber-900/30 border border-amber-800/50 flex items-center gap-2"
+          data-testid="ollama-warming-banner"
+          role="status"
+          aria-live="polite"
+        >
+          <span
+            className="w-3 h-3 rounded-full border-2 border-amber-400 border-t-transparent animate-spin shrink-0"
+            aria-hidden="true"
+          />
+          <p className="text-xs text-amber-300">
+            Preparando agente IA (~20s)…
           </p>
         </div>
       )}

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -7,6 +7,7 @@ import { version as APP_VERSION } from '../../package.json';
 import ChagraGrowLoader from './ChagraGrowLoader';
 import LegalLinks from './LegalLinks';
 import WelcomeStatsHero from './WelcomeStatsHero';
+import useOllamaWarmStore from '../store/useOllamaWarmStore';
 
 export default function LoginScreen({ onLoginSuccess, onSave }) {
   const [creds, setCreds] = useState({ username: '', password: '' });
@@ -58,6 +59,21 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
         setActiveTenantId(creds.username);
       } catch (err) {
         console.warn('[LoginScreen] setActiveTenantId failed:', err);
+      }
+      // NN4 fix 2026-05-23: disparar pre-warm Ollama gemma3:4b ANTES de
+      // navegar al dashboard. Esto da ~15-30s de margen humano (el operador
+      // mira el dashboard, escoge una tile, abre el agente) durante los
+      // cuales el modelo se carga en GPU en background. Sin esto, la
+      // primera query al agente caía al cold-start 116s. Fire-and-forget:
+      // el store maneja el estado, AgentScreen lo lee y muestra banner si
+      // todavía está warming cuando el operador llega al agente.
+      // Idempotente: si por alguna razón se llama 2 veces, el store
+      // dedupea internamente.
+      try {
+        useOllamaWarmStore.getState().startWarmup();
+      } catch (err) {
+        // No bloquear login si falla (ej. tests sin fetch global).
+        console.warn('[LoginScreen] ollama warm-up dispatch failed:', err);
       }
       setLoading(false);
       onLoginSuccess();

--- a/src/store/__tests__/useOllamaWarmStore.test.js
+++ b/src/store/__tests__/useOllamaWarmStore.test.js
@@ -1,0 +1,152 @@
+/**
+ * useOllamaWarmStore — NN4 fix 2026-05-23.
+ *
+ * Cubre el bus global de warm-up del modelo Ollama gemma3:4b:
+ *   - estado inicial 'unknown'
+ *   - startWarmup dispara fetch con payload correcto y transiciona
+ *     'unknown' → 'warming' → 'warm' al recibir 200 OK
+ *   - error de fetch transiciona 'warming' → 'failed'
+ *   - idempotencia: llamar startWarmup mientras está 'warming' o 'warm' NO
+ *     dispara segunda request
+ *   - resetWarmup vuelve al estado inicial limpio
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import useOllamaWarmStore from '../useOllamaWarmStore';
+
+describe('useOllamaWarmStore — NN4 pre-warm Ollama al login', () => {
+  beforeEach(() => {
+    // Reset siempre antes de cada test: el store es singleton entre tests.
+    useOllamaWarmStore.getState().resetWarmup();
+    // Spy sobre fetch global. Cada test lo configura con su mock específico.
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('estado inicial: status="unknown", startedAt=null, completedAt=null', () => {
+    const s = useOllamaWarmStore.getState();
+    expect(s.status).toBe('unknown');
+    expect(s.startedAt).toBeNull();
+    expect(s.completedAt).toBeNull();
+  });
+
+  it('startWarmup dispara fetch al endpoint Ollama con payload correcto', () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    useOllamaWarmStore.getState().startWarmup();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe('/api/ollama/api/generate');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    const body = JSON.parse(opts.body);
+    expect(body).toMatchObject({
+      model: 'gemma3:4b',
+      prompt: 'ok',
+      stream: false,
+      keep_alive: '30m',
+      options: { num_predict: 1 },
+    });
+  });
+
+  it('transiciona unknown → warming → warm cuando fetch responde 200', async () => {
+    let resolveFetch;
+    fetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = () => resolve({ ok: true, status: 200 });
+        }),
+    );
+
+    useOllamaWarmStore.getState().startWarmup();
+    // Inmediatamente post-dispatch, status debe ser 'warming' con startedAt.
+    let s = useOllamaWarmStore.getState();
+    expect(s.status).toBe('warming');
+    expect(s.startedAt).toBeTypeOf('number');
+    expect(s.completedAt).toBeNull();
+
+    // Resolvemos el fetch y flusheamos el microtask queue.
+    resolveFetch();
+    await new Promise((r) => setTimeout(r, 0));
+
+    s = useOllamaWarmStore.getState();
+    expect(s.status).toBe('warm');
+    expect(s.completedAt).toBeTypeOf('number');
+    expect(s.completedAt).toBeGreaterThanOrEqual(s.startedAt);
+  });
+
+  it('transiciona warming → failed cuando fetch rechaza con error de red', async () => {
+    fetch.mockRejectedValueOnce(new Error('Network down'));
+
+    useOllamaWarmStore.getState().startWarmup();
+    expect(useOllamaWarmStore.getState().status).toBe('warming');
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const s = useOllamaWarmStore.getState();
+    expect(s.status).toBe('failed');
+    expect(s.completedAt).toBeTypeOf('number');
+  });
+
+  it('transiciona warming → failed cuando fetch responde HTTP no-OK', async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    useOllamaWarmStore.getState().startWarmup();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(useOllamaWarmStore.getState().status).toBe('failed');
+  });
+
+  it('idempotencia: llamar startWarmup en estado warming NO dispara segundo fetch', () => {
+    fetch.mockImplementation(() => new Promise(() => {})); // pending forever
+    useOllamaWarmStore.getState().startWarmup();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(useOllamaWarmStore.getState().status).toBe('warming');
+
+    useOllamaWarmStore.getState().startWarmup();
+    useOllamaWarmStore.getState().startWarmup();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('idempotencia: llamar startWarmup en estado warm NO dispara segundo fetch', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    useOllamaWarmStore.getState().startWarmup();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useOllamaWarmStore.getState().status).toBe('warm');
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    useOllamaWarmStore.getState().startWarmup();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('desde estado failed sí permite re-intentar startWarmup', async () => {
+    fetch.mockRejectedValueOnce(new Error('first fail'));
+    useOllamaWarmStore.getState().startWarmup();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useOllamaWarmStore.getState().status).toBe('failed');
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    // Segundo intento desde 'failed' debe disparar un nuevo fetch.
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    useOllamaWarmStore.getState().startWarmup();
+    expect(fetch).toHaveBeenCalledTimes(2);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useOllamaWarmStore.getState().status).toBe('warm');
+  });
+
+  it('resetWarmup vuelve al estado inicial limpio', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    useOllamaWarmStore.getState().startWarmup();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(useOllamaWarmStore.getState().status).toBe('warm');
+
+    useOllamaWarmStore.getState().resetWarmup();
+    const s = useOllamaWarmStore.getState();
+    expect(s.status).toBe('unknown');
+    expect(s.startedAt).toBeNull();
+    expect(s.completedAt).toBeNull();
+  });
+});

--- a/src/store/useOllamaWarmStore.js
+++ b/src/store/useOllamaWarmStore.js
@@ -1,0 +1,113 @@
+import { create } from 'zustand';
+
+/**
+ * useOllamaWarmStore — bus global de estado warm-up del modelo Ollama
+ * (gemma3:4b) que usa el agente Chagra IA.
+ *
+ * Problema (NN4, Playwright 2026-05-23 Q1 curuba): la primera query al
+ * agente tras una sesión fresca tardaba 116s porque Ollama carga el modelo
+ * en GPU bajo demanda (~4.6 GB VRAM). PR #1020 introdujo pre-warm al entrar
+ * al dashboard, pero el `keep_alive=30m` se mide desde el último request:
+ * si entre sesiones de Playwright el modelo se descargó del VRAM, el
+ * pre-warm al dashboard llegaba tarde si el operador iba directo al agente.
+ *
+ * Solución (este PR): disparar el pre-warm al login success ANTES de
+ * navegar al dashboard. Esto da ~15-30s de margen extra entre login y la
+ * primera interacción con el agente (el operador tiene que mirar el
+ * dashboard, escoger una tile, abrir el agente — tiempo humano natural).
+ *
+ * El store es la fuente de verdad sobre si el modelo está caliente o no.
+ * AgentScreen suscribe a `status` y muestra un banner pequeño "preparando
+ * agente IA" si status !== 'warm'. El banner desaparece automáticamente
+ * cuando el pre-warm completa.
+ *
+ * Estados:
+ *   - 'unknown'  : no se ha intentado pre-warm en esta sesión (post-reload).
+ *   - 'warming'  : pre-warm en vuelo. Banner visible si user entra al agente.
+ *   - 'warm'     : pre-warm OK. Banner oculto. Modelo cargado por ~30 min.
+ *   - 'failed'   : pre-warm falló (red, timeout, Ollama down). Banner
+ *                  igualmente oculto — el primer request del agente caerá
+ *                  al cold-start clásico y mostrará su propio progreso.
+ *
+ * Reglas de transición:
+ *   - startWarmup() es idempotente: si status === 'warming' o 'warm', NO
+ *     dispara una segunda request. Evita pre-warm duplicados si el login
+ *     se llama dos veces (re-mount) o si el fallback del dashboard se
+ *     superpone.
+ *   - resetWarmup() existe para tests; no debe usarse en runtime.
+ *
+ * NO persistimos en localStorage: el status del modelo es efímero (vive
+ * solo mientras el proceso ollama lo tenga cargado). Post-reload del
+ * navegador, el modelo podría seguir cargado o no — un nuevo startWarmup
+ * resuelve el estado real al primer intento.
+ */
+
+// Timeout total del pre-warm. La primera carga gemma3:4b en GPU M6000
+// tarda ~25-40s. 180s es defensivo para casos de Ollama recuperándose
+// de un crash de runner o swap en disco.
+const WARMUP_TIMEOUT_MS = 180000;
+
+const useOllamaWarmStore = create((set, get) => ({
+  status: 'unknown',
+  startedAt: null,
+  completedAt: null,
+
+  /**
+   * Dispara el pre-warm POST a `/api/ollama/api/generate` con prompt
+   * mínimo + keep_alive=30m. Fire-and-forget desde el caller (no await).
+   * El store maneja transiciones de status internamente.
+   *
+   * Idempotente: si ya estamos en 'warming' o 'warm', retorna sin
+   * disparar nada. Solo re-dispara desde 'unknown' o 'failed'.
+   */
+  startWarmup: () => {
+    const { status } = get();
+    if (status === 'warming' || status === 'warm') return;
+
+    set({ status: 'warming', startedAt: Date.now(), completedAt: null });
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), WARMUP_TIMEOUT_MS);
+
+    fetch('/api/ollama/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'gemma3:4b',
+        prompt: 'ok',
+        stream: false,
+        keep_alive: '30m',
+        options: { num_predict: 1 },
+      }),
+      signal: controller.signal,
+    })
+      .then((res) => {
+        clearTimeout(timer);
+        if (res.ok) {
+          set({ status: 'warm', completedAt: Date.now() });
+          console.debug('[useOllamaWarmStore] gemma3:4b warm-up OK');
+        } else {
+          set({ status: 'failed', completedAt: Date.now() });
+          console.debug('[useOllamaWarmStore] warm-up falló: HTTP', res.status);
+        }
+      })
+      .catch((err) => {
+        clearTimeout(timer);
+        set({ status: 'failed', completedAt: Date.now() });
+        console.debug(
+          '[useOllamaWarmStore] warm-up degradó (cold-start clásico):',
+          err?.message,
+        );
+      });
+  },
+
+  /**
+   * Reset explícito del store. Solo para tests — en runtime el ciclo
+   * natural cubre los casos esperados (unknown → warming → warm/failed).
+   */
+  resetWarmup: () => {
+    set({ status: 'unknown', startedAt: null, completedAt: null });
+  },
+}));
+
+export default useOllamaWarmStore;


### PR DESCRIPTION
## Summary

- **Bug NN4** (Playwright 2026-05-23 Q1 curuba): primera query al agente Chagra IA tardaba 116s porque el pre-warm de PR #1020 disparaba al \`currentView === 'dashboard'\`, pero el \`keep_alive=30m\` de Ollama se cuenta desde el último request al modelo. Si el operador iba directo al agente antes que el warm-up terminara (race), o entre sesiones Playwright fresh el modelo se descargaba de VRAM, el banner "pensando..." se quedaba 100+ segundos.
- **Fix**: disparar el pre-warm al **login success** (fire-and-forget) en lugar de al dashboard. Esto da ~15-30s de margen humano (operador mira dashboard, escoge tile, abre agente) durante los cuales \`gemma3:4b\` se carga en GPU en background.
- **Nuevo store** \`useOllamaWarmStore\` (zustand) con status \`unknown/warming/warm/failed\` + \`startedAt/completedAt\` timestamps. \`startWarmup()\` es idempotente: dedupea si ya está \`warming\` o \`warm\`. Solo re-dispara desde \`unknown\` o \`failed\`.
- **Banner UX** en AgentScreen: si el operador llega al agente cuando status !== 'warm', se muestra banner amber pequeño "Preparando agente IA (~20s)..." con spinner. Desaparece automáticamente al transicionar a 'warm'. En 'failed' queda oculto (la query caerá al cold-start clásico con su propio indicador "pensando...").
- **App.jsx pre-warm** pasa a fallback: solo dispara si \`status === 'unknown'\` al entrar al dashboard. Cubre el caso de re-mount sin login (tab refresh con sesión persistida en localStorage que arranca directo al dashboard).

## Archivos

- \`src/store/useOllamaWarmStore.js\` (nuevo) — store zustand + lógica de warm-up.
- \`src/store/__tests__/useOllamaWarmStore.test.js\` (nuevo) — 9 tests cubren transiciones, payload, idempotencia, re-intento, reset.
- \`src/components/LoginScreen.jsx\` — dispara \`useOllamaWarmStore.getState().startWarmup()\` tras \`setActiveTenantId\` y antes de \`onLoginSuccess()\`.
- \`src/App.jsx\` — reemplaza useEffect cold-start propio por subscripción al store (fallback dashboard).
- \`src/components/AgentScreen/AgentScreen.jsx\` — suscribe a \`ollamaWarmStatus\`, renderiza banner condicional con \`data-testid="ollama-warming-banner"\`.

## Test plan

- [x] \`npx vitest run src/store/__tests__/useOllamaWarmStore.test.js\` → 9/9 passing local.
- [x] \`npx eslint ... --max-warnings=0\` clean en los 5 archivos del PR.
- [x] \`npm run build\` ✓ built in 2.38s sin warnings nuevos.
- [ ] CodeQL + Playwright merge-gates pasan en CI.
- [ ] Post-merge, verificar en producción que primera query al agente tras login fresh tarda <10s en lugar de 116s.
- [ ] Smoke manual: login → dashboard → agente → escribir pregunta corta ("hola") → respuesta en <10s.

## Notas

- El banner solo se muestra si el operador es MUY rápido (warm-up gemma3:4b en GPU M6000 toma ~25-40s; tiempo humano login→agente típicamente >40s).
- \`keep_alive=30m\` reinicia con cada request, así que el warm-up cubre toda la sesión activa del operador sin re-cargas.
- En tests Playwright que arrancan directo al agente sin login flow, el fallback del dashboard NO se dispara (no hay vista dashboard intermedia); ahí cae al cold-start clásico. Para Playwright cubrir el path de login también, el test debe loguearse primero.