### PR TITLE
feat(catalog): CHAGRA_TIER detection — OSS→Pro cutover step 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,12 @@ VITE_SIDECAR_URL=/api/mcp/agro
 # Token de auth del sidecar. Inyectado en build-time. NUNCA commitear el
 # valor real — vive solo en GHA secrets / shell del operador.
 VITE_CHAGRA_MCP_TOKEN=
+
+# CHAGRA_TIER detection runtime (#74) — define qué catálogo SQLite carga
+# la PWA al boot. OSS (default) usa /catalog.sqlite bundleado en el build
+# (subset 105 species curado en chagra-catalog-oss-subset-v3.2.json). PRO
+# overrideea con un CDN externo que sirve el corpus full (~496 species,
+# vive en repo privado chagra-pro). Si TIER=PRO pero CATALOG_URL no está
+# set, el loader cae a OSS con warning — no rompe deploy.
+VITE_CHAGRA_TIER=OSS
+VITE_CHAGRA_CATALOG_URL=

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.180",
+  "version": "0.12.181",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v222';
+const CACHE_NAME = 'chagra-v223';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -1,4 +1,5 @@
 import sqlite3InitModule from '@sqlite.org/sqlite-wasm';
+import { loadCatalogBuffer, assertCatalogShape } from '../services/corpusLoader';
 
 let dbInstance = null;
 let initPromise = null;
@@ -10,12 +11,12 @@ async function doInit() {
     });
     console.log('[SQLite WASM] Engine loaded successfully.');
 
-    const response = await fetch('/catalog.sqlite');
-    if (!response.ok) {
-        throw new Error(`Failed to fetch /catalog.sqlite: HTTP ${response.status} ${response.statusText}`);
-    }
-    const arrayBuffer = await response.arrayBuffer();
-    const uint8Array = new Uint8Array(arrayBuffer);
+    // CHAGRA_TIER detection (#74): el blob SQLite puede venir del bundle
+    // OSS (`/catalog.sqlite`) o de un CDN Pro override. corpusLoader
+    // resuelve la URL, fetchea y valida magic header. Si TIER=PRO sin URL
+    // set, hace fallback a OSS (no rompe deploy).
+    const { buffer: uint8Array, source } = await loadCatalogBuffer();
+    console.log(`[SQLite WASM] Catalog loaded from ${source.url} (tier=${source.tier}${source.fallback ? ', fallback' : ''})`);
 
     let db = null;
     if (sqlite3.opfs && typeof navigator !== 'undefined' && navigator.storage && navigator.storage.getDirectory) {
@@ -45,6 +46,10 @@ async function doInit() {
         if (rc !== 0) throw new Error('Deserialize failed with code ' + rc);
         console.log('[SQLite WASM] Opened SQLite DB locally from Memory deserialization');
     }
+
+    // Validar shape mínimo: tabla species con rows. Si el CDN Pro sirvió un
+    // blob malformado, fallamos rápido acá en vez de degradar silencioso.
+    assertCatalogShape(db);
 
     return db;
 }

--- a/src/services/__tests__/corpusLoader.test.js
+++ b/src/services/__tests__/corpusLoader.test.js
@@ -1,0 +1,244 @@
+/**
+ * corpusLoader.test.js — unit tests para TIER detection runtime (#74).
+ *
+ * Cobertura:
+ * - getTier(): default OSS, lectura case-insensitive de PRO, otros valores → OSS.
+ * - resolveCatalogUrl(): OSS → /catalog.sqlite. PRO + URL set → URL override.
+ *   PRO sin URL → fallback OSS + warning.
+ * - loadCatalogBuffer(): fetch happy path con magic header válido. Magic
+ *   header inválido → throw. HTTP non-OK → throw.
+ * - assertCatalogShape(): tabla con rows OK. Tabla vacía → throw. Tabla no
+ *   consultable → throw.
+ *
+ * Aislamiento: vitest stubEnv + mock fetch global. resetModules entre tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const ENV_TIER = 'VITE_CHAGRA_TIER';
+const ENV_URL = 'VITE_CHAGRA_CATALOG_URL';
+
+const SQLITE_MAGIC = 'SQLite format 3\0';
+
+const importFresh = async () => {
+    vi.resetModules();
+    return import('../corpusLoader.js');
+};
+
+/**
+ * Construye un Uint8Array que empieza con el magic header SQLite válido,
+ * seguido de bytes arbitrarios para llegar a `byteLength` total.
+ */
+const makeSqliteBlob = (byteLength = 4096) => {
+    const buf = new Uint8Array(byteLength);
+    for (let i = 0; i < SQLITE_MAGIC.length; i++) {
+        buf[i] = SQLITE_MAGIC.charCodeAt(i);
+    }
+    return buf;
+};
+
+let fetchMock;
+let warnSpy;
+
+beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { });
+});
+
+afterEach(() => {
+    vi.unstubAllEnvs();
+    warnSpy.mockRestore();
+});
+
+describe('corpusLoader — getTier', () => {
+    it('default OSS cuando VITE_CHAGRA_TIER no está set', async () => {
+        vi.unstubAllEnvs();
+        const { getTier } = await importFresh();
+        expect(getTier()).toBe('OSS');
+    });
+
+    it('OSS cuando VITE_CHAGRA_TIER="OSS"', async () => {
+        vi.stubEnv(ENV_TIER, 'OSS');
+        const { getTier } = await importFresh();
+        expect(getTier()).toBe('OSS');
+    });
+
+    it('PRO cuando VITE_CHAGRA_TIER="PRO" (case-insensitive)', async () => {
+        vi.stubEnv(ENV_TIER, 'pro');
+        const { getTier } = await importFresh();
+        expect(getTier()).toBe('PRO');
+    });
+
+    it('OSS para valores desconocidos (defensive)', async () => {
+        vi.stubEnv(ENV_TIER, 'enterprise');
+        const { getTier } = await importFresh();
+        expect(getTier()).toBe('OSS');
+    });
+});
+
+describe('corpusLoader — resolveCatalogUrl', () => {
+    it('OSS default → /catalog.sqlite, sin fallback', async () => {
+        vi.unstubAllEnvs();
+        const { resolveCatalogUrl } = await importFresh();
+        const r = resolveCatalogUrl();
+        expect(r).toEqual({ url: '/catalog.sqlite', tier: 'OSS', fallback: false });
+    });
+
+    it('PRO + URL set → override URL', async () => {
+        vi.stubEnv(ENV_TIER, 'PRO');
+        vi.stubEnv(ENV_URL, 'https://cdn.example.com/catalog/full-v3.2.sqlite');
+        const { resolveCatalogUrl } = await importFresh();
+        const r = resolveCatalogUrl();
+        expect(r).toEqual({
+            url: 'https://cdn.example.com/catalog/full-v3.2.sqlite',
+            tier: 'PRO',
+            fallback: false,
+        });
+    });
+
+    it('PRO sin VITE_CHAGRA_CATALOG_URL → fallback OSS + warning (no rompe deploy)', async () => {
+        vi.stubEnv(ENV_TIER, 'PRO');
+        // VITE_CHAGRA_CATALOG_URL no set
+        const { resolveCatalogUrl } = await importFresh();
+        const r = resolveCatalogUrl();
+        expect(r).toEqual({ url: '/catalog.sqlite', tier: 'OSS', fallback: true });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain('VITE_CHAGRA_CATALOG_URL');
+    });
+
+    it('PRO con VITE_CHAGRA_CATALOG_URL="" (vacío) → fallback OSS', async () => {
+        vi.stubEnv(ENV_TIER, 'PRO');
+        vi.stubEnv(ENV_URL, '   ');
+        const { resolveCatalogUrl } = await importFresh();
+        const r = resolveCatalogUrl();
+        expect(r.tier).toBe('OSS');
+        expect(r.fallback).toBe(true);
+        expect(r.url).toBe('/catalog.sqlite');
+    });
+});
+
+describe('corpusLoader — loadCatalogBuffer', () => {
+    it('OSS happy path: fetchea /catalog.sqlite con magic válido', async () => {
+        vi.unstubAllEnvs();
+        const blob = makeSqliteBlob(8192);
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            arrayBuffer: async () => blob.buffer,
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        const { buffer, source } = await loadCatalogBuffer();
+        expect(fetchMock).toHaveBeenCalledWith('/catalog.sqlite');
+        expect(buffer.byteLength).toBe(8192);
+        expect(source).toEqual({ url: '/catalog.sqlite', tier: 'OSS', fallback: false });
+    });
+
+    it('PRO + URL set: fetchea la URL override', async () => {
+        vi.stubEnv(ENV_TIER, 'PRO');
+        vi.stubEnv(ENV_URL, 'https://cdn.example.com/full.sqlite');
+        const blob = makeSqliteBlob(4096);
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            arrayBuffer: async () => blob.buffer,
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        const { source } = await loadCatalogBuffer();
+        expect(fetchMock).toHaveBeenCalledWith('https://cdn.example.com/full.sqlite');
+        expect(source.tier).toBe('PRO');
+        expect(source.fallback).toBe(false);
+    });
+
+    it('HTTP 404 → throw con info de la URL', async () => {
+        vi.unstubAllEnvs();
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            arrayBuffer: async () => new ArrayBuffer(0),
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        await expect(loadCatalogBuffer()).rejects.toThrow(/HTTP 404/);
+    });
+
+    it('Magic header inválido (HTML de error) → throw', async () => {
+        vi.unstubAllEnvs();
+        // Simula que el CDN devolvió HTML "404 Not Found" en vez de SQLite.
+        const html = '<!DOCTYPE html><html><body>404</body></html>';
+        const buf = new Uint8Array(html.length);
+        for (let i = 0; i < html.length; i++) buf[i] = html.charCodeAt(i);
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            arrayBuffer: async () => buf.buffer,
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        await expect(loadCatalogBuffer()).rejects.toThrow(/SQLite magic header/);
+    });
+
+    it('Blob muy chico (<16 bytes) → throw', async () => {
+        vi.unstubAllEnvs();
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            arrayBuffer: async () => new ArrayBuffer(8),
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        await expect(loadCatalogBuffer()).rejects.toThrow(/too small/);
+    });
+
+    it('PRO sin URL set → fetchea /catalog.sqlite (fallback path)', async () => {
+        vi.stubEnv(ENV_TIER, 'PRO');
+        const blob = makeSqliteBlob(2048);
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            arrayBuffer: async () => blob.buffer,
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        const { source } = await loadCatalogBuffer();
+        expect(fetchMock).toHaveBeenCalledWith('/catalog.sqlite');
+        expect(source.fallback).toBe(true);
+        expect(source.tier).toBe('OSS');
+    });
+});
+
+describe('corpusLoader — assertCatalogShape', () => {
+    it('tabla species con rows → devuelve speciesCount', async () => {
+        const { assertCatalogShape } = await importFresh();
+        const fakeDb = {
+            exec: ({ sql }) => {
+                if (sql.includes('species')) return [{ n: 105 }];
+                return [];
+            },
+        };
+        expect(assertCatalogShape(fakeDb)).toEqual({ speciesCount: 105 });
+    });
+
+    it('tabla species vacía → throw', async () => {
+        const { assertCatalogShape } = await importFresh();
+        const fakeDb = { exec: () => [{ n: 0 }] };
+        expect(() => assertCatalogShape(fakeDb)).toThrow(/vacía o count inválido/);
+    });
+
+    it('handle inválido → throw', async () => {
+        const { assertCatalogShape } = await importFresh();
+        expect(() => assertCatalogShape(null)).toThrow(/handle SQLite inválido/);
+        expect(() => assertCatalogShape({})).toThrow(/handle SQLite inválido/);
+    });
+
+    it('exec throws (tabla species inexistente) → throw envuelve mensaje', async () => {
+        const { assertCatalogShape } = await importFresh();
+        const fakeDb = {
+            exec: () => {
+                throw new Error('no such table: species');
+            },
+        };
+        expect(() => assertCatalogShape(fakeDb)).toThrow(/tabla species no consultable/);
+    });
+});

--- a/src/services/corpusLoader.js
+++ b/src/services/corpusLoader.js
@@ -1,0 +1,164 @@
+/**
+ * corpusLoader.js — TIER detection runtime para el catálogo SQLite (#74).
+ *
+ * Step 3 del cutover OSS→Pro (ADR-002, oss-pro/README.md). La PWA se
+ * compila a un único bundle público; el seed del catálogo SQLite que se
+ * embebe en `public/catalog.sqlite` lo elige el build script según
+ * `CHAGRA_SEED` (subset OSS v3.2 por default; corpus full en build Pro).
+ * Este módulo decide en RUNTIME desde dónde fetchea el blob según
+ * `VITE_CHAGRA_TIER`, para que un único deploy pueda servir el catálogo
+ * full cuando vive en CDN separado (chagra-pro).
+ *
+ * Reglas operativas:
+ * - OSS (default): fetchea `/catalog.sqlite` bundleado (subset 105 species).
+ * - PRO: fetchea `VITE_CHAGRA_CATALOG_URL`. Si la URL no está set, se
+ *   loguea warning y se cae a OSS para no romper el deploy.
+ * - El loader valida que la respuesta tenga magic header SQLite y devuelve
+ *   el Uint8Array. La validación del shape (tabla `species` con rows) la
+ *   hace el caller (catalogDB.js) cuando deserializa, vía
+ *   `assertCatalogShape(db)`.
+ * - Backwards-compatible: sin las nuevas vars, sigue cargando `/catalog.sqlite`.
+ *
+ * Env vars (build-time, opcionales):
+ * - VITE_CHAGRA_TIER=OSS|PRO            — default OSS
+ * - VITE_CHAGRA_CATALOG_URL=<absURL>    — solo aplica si TIER=PRO
+ *
+ * NOTA: este módulo NO importa nada del bundle Pro (ADR-002). El catálogo
+ * Pro vive en un CDN externo; este código sólo conoce su URL como string.
+ */
+
+const SQLITE_MAGIC = 'SQLite format 3\0';
+const TIER_OSS = 'OSS';
+const TIER_PRO = 'PRO';
+const DEFAULT_CATALOG_URL = '/catalog.sqlite';
+
+/**
+ * Lee `VITE_CHAGRA_TIER`. Acepta 'PRO'/'pro' como Pro; cualquier otro valor
+ * (incluido undefined, vacío o cualquier string) → OSS.
+ *
+ * @returns {'OSS'|'PRO'}
+ */
+export function getTier() {
+    try {
+        const raw = import.meta.env?.VITE_CHAGRA_TIER;
+        if (typeof raw === 'string' && raw.trim().toUpperCase() === TIER_PRO) {
+            return TIER_PRO;
+        }
+    } catch (_) {
+        // ignore — fallback OSS
+    }
+    return TIER_OSS;
+}
+
+/**
+ * Resuelve la URL del catálogo SQLite a fetchear.
+ *
+ * Contrato:
+ *   - tier=OSS → `/catalog.sqlite` (bundle estático en public/).
+ *   - tier=PRO + URL set → la URL override (CDN externo Pro).
+ *   - tier=PRO + URL ausente → warning + fallback a OSS (no rompe deploy).
+ *
+ * @returns {{ url: string, tier: 'OSS'|'PRO', fallback: boolean }}
+ */
+export function resolveCatalogUrl() {
+    const tier = getTier();
+    if (tier === TIER_OSS) {
+        return { url: DEFAULT_CATALOG_URL, tier, fallback: false };
+    }
+
+    let overrideUrl = null;
+    try {
+        const raw = import.meta.env?.VITE_CHAGRA_CATALOG_URL;
+        if (typeof raw === 'string' && raw.trim()) {
+            overrideUrl = raw.trim();
+        }
+    } catch (_) {
+        // ignore
+    }
+
+    if (!overrideUrl) {
+        console.warn(
+            '[corpusLoader] VITE_CHAGRA_TIER=PRO pero VITE_CHAGRA_CATALOG_URL no está set; ' +
+            'fallback a catálogo OSS bundleado para no romper deploy.'
+        );
+        return { url: DEFAULT_CATALOG_URL, tier: TIER_OSS, fallback: true };
+    }
+
+    return { url: overrideUrl, tier: TIER_PRO, fallback: false };
+}
+
+/**
+ * Fetchea el catálogo SQLite y devuelve un Uint8Array. Valida magic header
+ * SQLite ("SQLite format 3\0") antes de devolver, para fallar rápido si el
+ * CDN devuelve HTML de error o el archivo está corrupto.
+ *
+ * Throws si:
+ *   - fetch no responde 2xx.
+ *   - el blob es muy chico (<16 bytes) o no empieza con magic SQLite.
+ *
+ * @returns {Promise<{ buffer: Uint8Array, source: { url: string, tier: 'OSS'|'PRO', fallback: boolean } }>}
+ */
+export async function loadCatalogBuffer() {
+    const source = resolveCatalogUrl();
+    const response = await fetch(source.url);
+    if (!response.ok) {
+        throw new Error(
+            `[corpusLoader] Failed to fetch ${source.url}: HTTP ${response.status} ${response.statusText}`
+        );
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = new Uint8Array(arrayBuffer);
+
+    if (buffer.byteLength < SQLITE_MAGIC.length) {
+        throw new Error(
+            `[corpusLoader] Catalog payload too small (${buffer.byteLength} bytes) — not a valid SQLite file.`
+        );
+    }
+    // Validar magic header SQLite.
+    for (let i = 0; i < SQLITE_MAGIC.length; i++) {
+        if (buffer[i] !== SQLITE_MAGIC.charCodeAt(i)) {
+            throw new Error(
+                `[corpusLoader] Invalid catalog payload — missing SQLite magic header. ` +
+                `Source=${source.url} tier=${source.tier}`
+            );
+        }
+    }
+
+    return { buffer, source };
+}
+
+/**
+ * Valida que un handle SQLite ya inicializado contiene un catálogo bien
+ * formado (tabla `species` con al menos una row). Llamado por catalogDB.js
+ * después de deserializar.
+ *
+ * Lanza Error si la tabla no existe o está vacía. El motivo: un blob SQLite
+ * válido pero vacío (ej. CDN devolvió placeholder) pasaría la validación de
+ * magic header pero rompería todo el agente downstream.
+ *
+ * @param {object} db — handle sqlite-wasm con .exec().
+ * @returns {{ speciesCount: number }}
+ */
+export function assertCatalogShape(db) {
+    if (!db || typeof db.exec !== 'function') {
+        throw new Error('[corpusLoader] assertCatalogShape: handle SQLite inválido.');
+    }
+    let rows;
+    try {
+        rows = db.exec({
+            sql: 'SELECT COUNT(*) as n FROM species',
+            rowMode: 'object',
+        });
+    } catch (e) {
+        throw new Error(
+            `[corpusLoader] assertCatalogShape: tabla species no consultable (${e.message}).`
+        );
+    }
+    const count = Number(rows?.[0]?.n ?? 0);
+    if (!Number.isFinite(count) || count <= 0) {
+        throw new Error(
+            `[corpusLoader] assertCatalogShape: tabla species vacía o count inválido (${count}).`
+        );
+    }
+    return { speciesCount: count };
+}


### PR DESCRIPTION
## Summary

OSS→Pro cutover step 3 (task #74). Step 2 (subset v3.2 = 105 species) ya en main. Step 4 (release v0.13.0 + E2E) sigue.

- Nuevo `src/services/corpusLoader.js`: resuelve URL del catálogo SQLite según `VITE_CHAGRA_TIER` (default OSS → `/catalog.sqlite` bundleado; PRO → `VITE_CHAGRA_CATALOG_URL` override).
- PRO sin URL set → fallback OSS + warning (no rompe deploy).
- Valida magic header SQLite al fetchear + shape mínimo (tabla `species` con rows). Falla rápido si CDN Pro sirve HTML/blob malformado.
- `catalogDB.js` usa el loader; backwards-compatible (sin vars nuevas = comportamiento idéntico OSS).
- `.env.example` documenta las dos vars con su semántica.

## Test plan

- [x] `npx vitest run src/services/__tests__/corpusLoader.test.js` → **18/18 pass**
- [x] `npx vitest run` full suite → **708/708 pass** (sin regresión)
- [x] `npm run build` → OK
- [x] `npx eslint . --max-warnings=0` → clean
- [ ] (operador) E2E manual con `VITE_CHAGRA_TIER=PRO` + URL CDN real
- [ ] (operador) decisión URL CDN Pro definitiva (placeholder vacío en .env.example)