### PR TITLE
feat(agent): wire 3 MCP tools (ICA/IDEAM/SIPSA) + framing agroecológico defensivo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.181",
+  "version": "0.12.182",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v223';
+const CACHE_NAME = 'chagra-v224';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -17,7 +17,8 @@ import { buildLLMRequest, selectChatRoute } from '../../services/llmRouter';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, resolveEntities } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
+import { FARM_CONFIG } from '../../config/defaults';
 import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
 import ChatHistory from './ChatHistory';
@@ -505,6 +506,27 @@ HEURÍSTICA FINAL CASO C: ¿la query DICE LITERALMENTE "variedades", "clases", "
 
 CAMPOS NULL EN TOOL RESULT: si get_species devuelve found:true PERO companions:[] o un campo X:null, NO defaultes a CASO C. Responde explícitamente "El catálogo confirma [especie] pero el campo [X] aún no está documentado", y usa el resto del data útil (altitud, manejo, valor_pedagogico, etc.).
 
+HERRAMIENTAS NORMATIVA SOLO PARA VALIDACIÓN, NUNCA PRESCRIPCIÓN:
+
+- get_normativa_ica (agroquímicos registrados ICA): úselo SOLO cuando
+  el usuario menciona explícitamente un producto químico/sintético O
+  pregunta si algo está prohibido/registrado/restringido. NUNCA lo
+  use para responder "¿qué le pongo a la plaga X?" — para eso use
+  get_biopreparados + get_pest_controllers primero (agroecológico).
+  Si la respuesta incluye sintéticos, contextualice con biopreparados
+  alternativos y advertencia de impacto agroecológico.
+
+- get_clima_ideam (estaciones IDEAM nacional): úselo para preguntas
+  sobre clima histórico/actual del municipio del usuario. Si el user
+  no ha mencionado municipio, pregúntele antes. No invente datos de
+  lluvia/temperatura — si IDEAM no responde, dígalo plano.
+
+- get_precio_sipsa (precios mayoristas SIPSA): el dataset hoy está
+  publicado como ZIP federated (no consulta directa). El tool devuelve
+  metadata + URL del ZIP DANE. Si el user pregunta precio, oriente al
+  ZIP DANE o sugiera consulta directa en Corabastos. Nunca invente
+  precios.
+
 Responde en español colombiano (tú/usted, sin voseo argentino). Sé específico y útil cuando tengas certeza; humilde y preguntón cuando no.`;
   }, [plants, fincas, activeFincaSlug, indoorZone]);
 
@@ -914,6 +936,48 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
               latencyNlu: Math.round(tNlu1 - tNlu0),
               reason: plan.reason || 'no_tool',
             });
+          }
+
+          // PASO 3 — detección heurística frontend de intent climática
+          // mientras NLU sidecar no se actualiza (TODO en nlu.ts del sidecar).
+          // Si el user pregunta por clima/lluvia/temperatura → llamar
+          // get_clima_ideam('monthly_avg', { municipio, metric, desde }) para
+          // grounding macro. Optimista no-estricto: si falla → seguimos sin
+          // clima inyectado (graceful degrade — el LLM tira de RAG y dice
+          // "no tengo IDEAM" en último caso). Solo se ejecuta si NO hubo
+          // tool ya invocado vía NLU para no inflar contexto.
+          if (!toolEvidence) {
+            const climaKeywords = /clima|lluvia|llueve|llover|temperatura|sequ[íi]a|fr[íi]o|calor|estaci[óo]n\s+meteorol[óo]gica|ideam|precipitaci[óo]n/i;
+            const municipio = FARM_CONFIG?.MUNICIPIO || null;
+            if (climaKeywords.test(text) && municipio) {
+              try {
+                const tClima0 = performance.now();
+                const desdeDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+                  .toISOString()
+                  .slice(0, 10);
+                const climaResult = await getClimaIdeam('monthly_avg', {
+                  municipio,
+                  metric: 'precipitation',
+                  desde: desdeDate,
+                });
+                const tClima1 = performance.now();
+                if (climaResult) {
+                  toolEvidence = {
+                    tool: 'get_clima_ideam',
+                    args: { action: 'monthly_avg', municipio, metric: 'precipitation', desde: desdeDate },
+                    result: climaResult,
+                  };
+                  console.debug('[sidecar] clima_ideam heuristic hit', {
+                    municipio,
+                    latencyMs: Math.round(tClima1 - tClima0),
+                  });
+                } else {
+                  console.debug('[sidecar] clima_ideam heuristic null', { municipio });
+                }
+              } catch (climaErr) {
+                console.debug('[sidecar] clima_ideam fail', climaErr?.message);
+              }
+            }
           }
         } catch (sidecarErr) {
           // Defensa extra: planNlu/callTool/resolveEntities ya son no-throw,

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -295,6 +295,13 @@ describe('sidecarClient — feature flag on', () => {
       expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/tools/get_pest_controllers');
     });
 
+    it('tools nuevos chagra-pro #64/#65/#66 (ICA/IDEAM/SIPSA) están en whitelist', async () => {
+      const { __TEST__ } = await importFresh();
+      expect(__TEST__.ALLOWED_TOOLS.has('get_normativa_ica')).toBe(true);
+      expect(__TEST__.ALLOWED_TOOLS.has('get_clima_ideam')).toBe(true);
+      expect(__TEST__.ALLOWED_TOOLS.has('get_precio_sipsa')).toBe(true);
+    });
+
     it('5xx → null sin throw', async () => {
       fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: 'kg down' }));
       const { callTool } = await importFresh();
@@ -335,6 +342,74 @@ describe('sidecarClient — feature flag on', () => {
       await planNlu('test');
       const headers = fetchMock.mock.calls[0][1].headers;
       expect('X-Chagra-Token' in headers).toBe(false);
+    });
+  });
+
+  describe('wrappers ICA / IDEAM / SIPSA (chagra-pro #64/#65/#66)', () => {
+    it('getNormativaIca rechaza action inválida sin fetch', async () => {
+      const { getNormativaIca } = await importFresh();
+      expect(await getNormativaIca('delete_database', {})).toBeNull();
+      expect(await getNormativaIca('', {})).toBeNull();
+      expect(await getNormativaIca(null, {})).toBeNull();
+      expect(await getNormativaIca(42, {})).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('getNormativaIca con action válida hace POST a /tools/get_normativa_ica con action en body', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { resolutions: [] }));
+      const { getNormativaIca } = await importFresh();
+      const res = await getNormativaIca('latest_active_ingredients', { limit: 10 });
+      expect(res).toEqual({ resolutions: [] });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/tools/get_normativa_ica');
+      expect(JSON.parse(opts.body)).toEqual({ action: 'latest_active_ingredients', limit: 10 });
+    });
+
+    it('getClimaIdeam valida shape de action (rechaza inválidas, acepta válidas)', async () => {
+      const { getClimaIdeam, __TEST__ } = await importFresh();
+      // Inválidas → null sin fetch
+      expect(await getClimaIdeam('drop_table', { municipio: 'Bogotá' })).toBeNull();
+      expect(await getClimaIdeam(undefined, {})).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+      // Set autoritativo de actions
+      expect(__TEST__.CLIMA_IDEAM_ACTIONS.has('monthly_avg')).toBe(true);
+      expect(__TEST__.CLIMA_IDEAM_ACTIONS.has('stations_near')).toBe(true);
+      expect(__TEST__.CLIMA_IDEAM_ACTIONS.has('climate_series')).toBe(true);
+      expect(__TEST__.CLIMA_IDEAM_ACTIONS.has('anomalies')).toBe(true);
+      // Válida → hace fetch
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { avg_precipitation_mm: 142.3 }));
+      const res = await getClimaIdeam('monthly_avg', {
+        municipio: 'Mosquera',
+        metric: 'precipitation',
+        desde: '2026-04-24',
+      });
+      expect(res).toEqual({ avg_precipitation_mm: 142.3 });
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.action).toBe('monthly_avg');
+      expect(body.municipio).toBe('Mosquera');
+    });
+
+    it('getPrecioSipsa devuelve null si flag off (no fetch)', async () => {
+      disableFlag();
+      const { getPrecioSipsa } = await importFresh();
+      const res = await getPrecioSipsa('latest_price', { producto: 'tomate' });
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('getPrecioSipsa happy path con action válida pasa metadata-ZIP del DANE', async () => {
+      const sipsaMeta = {
+        action: 'dataset_metadata',
+        dataset: 'precios-mayoristas-sipsa',
+        zip_url: 'https://www.dane.gov.co/files/.../sipsa.zip',
+        notes: 'federated, ZIP only',
+      };
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, sipsaMeta));
+      const { getPrecioSipsa } = await importFresh();
+      const res = await getPrecioSipsa('dataset_metadata', {});
+      expect(res).toEqual(sipsaMeta);
+      expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/tools/get_precio_sipsa');
     });
   });
 });

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -171,8 +171,14 @@ export async function planNlu(userMessage, context) {
  * el endpoint del sidecar es trusted, pero acotamos el set para que un
  * planner buggy/comprometido no pueda pedir paths arbitrarios.
  *
- * Las últimas 3 son nuevas (PR chagra-pro #48 — wire AGE). NLU planner aún
- * no las routea automáticamente; quedan disponibles para invocación manual.
+ * Las últimas 3 (`get_normativa_ica`, `get_clima_ideam`, `get_precio_sipsa`)
+ * vienen de los merges chagra-pro #64/#65/#66 + hotfix #67 — exponen
+ * normativa ICA defensiva, clima IDEAM nacional y precios SIPSA DANE.
+ *
+ * TODO(NLU): add keywords agroquimico/clima/precio in chagra-pro nlu.ts
+ * (sidecar repo, NO acá) para que el planner las routee automáticamente.
+ * Mientras tanto el frontend hace detection por keywords + invocación
+ * directa de los wrappers (ver AgentScreen handleSubmit).
  */
 const ALLOWED_TOOLS = new Set([
   'get_species',
@@ -182,6 +188,26 @@ const ALLOWED_TOOLS = new Set([
   'get_multihop_companions',
   'validate_visual_match',
   'validate_taxonomy',
+  'get_normativa_ica',
+  'get_clima_ideam',
+  'get_precio_sipsa',
+]);
+
+const NORMATIVA_ICA_ACTIONS = new Set([
+  'latest_active_ingredients',
+  'extract_resolutions',
+  'full_sync',
+]);
+const CLIMA_IDEAM_ACTIONS = new Set([
+  'stations_near',
+  'climate_series',
+  'monthly_avg',
+  'anomalies',
+]);
+const PRECIO_SIPSA_ACTIONS = new Set([
+  'latest_price',
+  'dataset_metadata',
+  'related_resources',
 ]);
 
 /**
@@ -229,6 +255,70 @@ export async function callTool(toolName, args) {
   return postJson(`/tools/${toolName}`, args || {}, TOOL_TIMEOUT_MS);
 }
 
+/**
+ * Wrapper defensivo de `get_normativa_ica`. Validá la action localmente
+ * para que el frontend NO pueda pedir paths arbitrarios al sidecar.
+ *
+ * USO DEFENSIVO ÚNICAMENTE: este tool sirve para validar si un producto
+ * agroquímico está registrado/restringido por el ICA. NUNCA debe usarse
+ * para responder "¿qué le pongo a la plaga X?" — para eso primero
+ * `get_biopreparados` + `get_pest_controllers` (agroecológico). El system
+ * prompt del agente debe explicitar esta restricción.
+ *
+ * @param {string} action — uno de NORMATIVA_ICA_ACTIONS
+ * @param {object} [args] — body adicional pasado al tool
+ * @returns {Promise<null | object>}
+ */
+export async function getNormativaIca(action, args) {
+  if (!action || typeof action !== 'string' || !NORMATIVA_ICA_ACTIONS.has(action)) {
+    console.debug('[sidecar] get_normativa_ica action inválida', action);
+    return null;
+  }
+  return callTool('get_normativa_ica', { action, ...(args || {}) });
+}
+
+/**
+ * Wrapper de `get_clima_ideam`. Estaciones IDEAM nacional para grounding
+ * climático histórico. El sidecar devuelve null si IDEAM no responde
+ * (graceful degrade — caller debe seguir sin clima inyectado).
+ *
+ * @param {string} action — uno de CLIMA_IDEAM_ACTIONS
+ * @param {object} [args] — body adicional (municipio, metric, desde, etc.)
+ * @returns {Promise<null | object>}
+ */
+export async function getClimaIdeam(action, args) {
+  if (!action || typeof action !== 'string' || !CLIMA_IDEAM_ACTIONS.has(action)) {
+    console.debug('[sidecar] get_clima_ideam action inválida', action);
+    return null;
+  }
+  return callTool('get_clima_ideam', { action, ...(args || {}) });
+}
+
+/**
+ * Wrapper de `get_precio_sipsa`. Precios mayoristas SIPSA — hoy el dataset
+ * DANE está publicado como ZIP federated (no consulta directa), así que
+ * el tool devuelve metadata + URL del ZIP en vez de precio puntual. El
+ * agente debe orientar al usuario al ZIP DANE o sugerir Corabastos.
+ *
+ * @param {string} action — uno de PRECIO_SIPSA_ACTIONS
+ * @param {object} [args] — body adicional (producto, fecha, etc.)
+ * @returns {Promise<null | object>}
+ */
+export async function getPrecioSipsa(action, args) {
+  if (!action || typeof action !== 'string' || !PRECIO_SIPSA_ACTIONS.has(action)) {
+    console.debug('[sidecar] get_precio_sipsa action inválida', action);
+    return null;
+  }
+  return callTool('get_precio_sipsa', { action, ...(args || {}) });
+}
+
 // Export interno para testabilidad — los tests pueden assertear el set
 // sin tener que reflectar la closure.
-export const __TEST__ = { ALLOWED_TOOLS, getBaseUrl, getToken };
+export const __TEST__ = {
+  ALLOWED_TOOLS,
+  NORMATIVA_ICA_ACTIONS,
+  CLIMA_IDEAM_ACTIONS,
+  PRECIO_SIPSA_ACTIONS,
+  getBaseUrl,
+  getToken,
+};


### PR DESCRIPTION
## Summary

Cierra el missing link backend↔frontend de la sesión 2026-05-24: sidecar prod expone los 3 tools nuevos (PRs #64/#65/#66 + hotfix #67), pero `ALLOWED_TOOLS` del frontend solo conocía los 6 clásicos.

## Cambios

- **`sidecarClient.js`** — añade `get_normativa_ica/clima_ideam/precio_sipsa` a `ALLOWED_TOOLS` + 3 wrappers `getNormativaIca/getClimaIdeam/getPrecioSipsa` con validación de action + Sets exportados.
- **`AgentScreen.jsx`** — PASO 3 en `handleSubmit`: detección regex de query climática + auto-call `getClimaIdeam(monthly_avg)` cuando hay municipio en `FARM_CONFIG` → inyecta como `toolEvidence` (mismo pipeline DATOS VERIFICADOS). Falla silenciosa.
- **System prompt** — bloque `HERRAMIENTAS NORMATIVA SOLO PARA VALIDACIÓN, NUNCA PRESCRIPCIÓN`:
  - ICA: validación regulatoria defensiva, no recomendación de químicos
  - IDEAM: solo si user menciona municipio
  - SIPSA: orienta a ZIP DANE, no inventa precios
- **Tests**: 27 → 33 (6 nuevos en `sidecarClient.test.js`).

## Test plan

- [x] `npx vitest run` full suite → **714 passed** (era 708)
- [x] `npx eslint . --max-warnings=0` → clean
- [x] `npm run build` → OK, AgentScreen 68.28 KB gzip 25.75 KB
- [ ] (operador) Smoke E2E en producción con queries clima ("¿cuánto llueve en Choachí este mes?")

## TODO próximo PR (sidecar nlu.ts)

Keywords NLU para que el sidecar enrute queries a los nuevos tools automáticamente vive en `chagra-pro/modules/agro-mcp/sidecar/src/nlu.ts` — comentado como TODO en este PR.