### PR TITLE
feat(agent): UX queueing 2-max + ETA — task #121

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.182",
+  "version": "0.12.183",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v224';
+const CACHE_NAME = 'chagra-v225';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -30,6 +30,7 @@ import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
 import useAgentNotificationStore from '../../store/useAgentNotificationStore';
 import useOllamaWarmStore from '../../store/useOllamaWarmStore';
+import useAgentQueueStore from '../../store/useAgentQueueStore';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 
 // 2026-05-16: migrado a llmRouter (Multi-LLM por tarea). AgentScreen usa
@@ -58,6 +59,12 @@ export default function AgentScreen({ onBack }) {
   // banner — la primera query caerá al cold-start clásico con su propio
   // indicador ("pensando...") que ya cubre la espera percibida.
   const ollamaWarmStatus = useOllamaWarmStore((s) => s.status);
+  // Task #121: queue UX del agente. Permite 2 preguntas max (1 procesando +
+  // 1 pendiente). 3ra rechazada con toast claro. ETA dinámico basado en
+  // EMA de latencia por modelo (llama3.1:8b ~12.9s, granite3.1-dense:8b
+  // ~24.7s — bench nocturno 2026-05-24).
+  const queueProcessing = useAgentQueueStore((s) => s.processing);
+  const queuePending = useAgentQueueStore((s) => s.pending);
   const plants = useAssetStore((s) => s.plants);
   // 062.6: contexto finca activa para system prompt (zona biocultural,
   // altitud, override indoor invernadero).
@@ -80,6 +87,19 @@ export default function AgentScreen({ onBack }) {
   // token, abortamos automáticamente con error visible.
   const [showSlowWarning, setShowSlowWarning] = useState(false);
   const [llmHealthy, setLlmHealthy] = useState(true);
+  // Task #121: countdown ETA. Lo guardamos en state aparte porque
+  // re-renderea cada segundo via setInterval mientras hay processing —
+  // si lo leyéramos directo del store con selector, no se re-evalúa
+  // hasta que el store hace `set()`. Aquí: el store es la fuente del
+  // expectedEtaMs; este state local es solo el snapshot del tick actual.
+  const [remainingMs, setRemainingMs] = useState(null);
+  // Hint "puedes hacer X mientras esperas" dismissible. Si el operador
+  // lo cierra una vez, no se lo volvemos a mostrar en esta sesión —
+  // ya entendió la idea. Se resetea solo al re-mount del componente.
+  const [hintDismissed, setHintDismissed] = useState(false);
+  // Toast de rechazo de la 3ra pregunta. Auto-dismiss a 4s para no
+  // bloquear el input visualmente.
+  const [queueRejectedToast, setQueueRejectedToast] = useState('');
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -186,6 +206,12 @@ export default function AgentScreen({ onBack }) {
     setError('');
     setStreamingContent('');
     setShowFreshSessionBadge(true);
+    // Task #121: reset también el queue. Si el operador pide nueva
+    // conversación, cualquier pregunta pendiente queda huérfana — el
+    // contexto cambió y procesarla en serie respondería con system
+    // prompt distinto al esperado.
+    useAgentQueueStore.getState().reset();
+    setQueueRejectedToast('');
   }, [operatorId]);
 
   // Bug 2026-05-18: warning timer cuando STATE_THINKING dura >20s sin tokens
@@ -200,6 +226,30 @@ export default function AgentScreen({ onBack }) {
     const slowTimer = setTimeout(() => setShowSlowWarning(true), 20000);
     return () => clearTimeout(slowTimer);
   }, [state]);
+
+  // Task #121: countdown ETA. Tick cada 1s mientras haya processing.
+  // Se desmonta automáticamente cuando processing pasa a null o el
+  // componente se desmonta.
+  useEffect(() => {
+    if (!queueProcessing) {
+      setRemainingMs(null);
+      return undefined;
+    }
+    const tick = () => {
+      const r = useAgentQueueStore.getState().getRemainingMs();
+      setRemainingMs(r);
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [queueProcessing]);
+
+  // Task #121: auto-dismiss del toast de rechazo a 4s.
+  useEffect(() => {
+    if (!queueRejectedToast) return undefined;
+    const t = setTimeout(() => setQueueRejectedToast(''), 4000);
+    return () => clearTimeout(t);
+  }, [queueRejectedToast]);
 
   // Bug 2026-05-18: health check del LLM al mount. Si /api/ollama/api/tags
   // no responde en 5s, marcamos llmHealthy=false y avisamos al operador
@@ -223,6 +273,11 @@ export default function AgentScreen({ onBack }) {
     setState(STATE_IDLE);
     setStreamingContent('');
     setError('Cancelado. Toca de nuevo si quieres reintentar.');
+    // Task #121: al cancelar manualmente, descartamos también la pregunta
+    // pendiente (si la hubiera) — el operador puede re-encolarla, pero
+    // si presionó Cancelar es porque quiere cortar la cadena, no que
+    // sigamos con la siguiente automáticamente.
+    useAgentQueueStore.getState().reset();
   };
 
   useEffect(() => {
@@ -259,6 +314,11 @@ export default function AgentScreen({ onBack }) {
       // Limpiar callback al desmontar para evitar referencias stale
       setActionGateCallback(null);
       actionGateResolverRef.current = null;
+      // Task #121: el queue es efímero por mount del AgentScreen. Si el
+      // operador sale a otra pantalla, las preguntas pendientes se
+      // descartan — pretender que las respondemos minutos después con
+      // contexto distinto sería peor UX que pedir reformular.
+      useAgentQueueStore.getState().reset();
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
@@ -574,6 +634,12 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
   // modelos no hagan cold-load entre conversaciones.
   const LLM_TIMEOUT_MS = 60000;
 
+  // Task #121: safety cap del while loop que drena el queue. Con QUEUE_MAX=2
+  // (1 processing + 1 pending) jamás debería haber más de 2 iteraciones,
+  // pero ponemos 10 como guard defensivo contra cualquier bug futuro que
+  // permita encolar más sin detectar (evita loops infinitos en producción).
+  const QUEUE_DRAIN_MAX = 10;
+
   // Cap defensivo para inyectar evidencia del sidecar como context turn
   // sin reventar la ventana 4096 tokens. ~1500 chars ≈ 400-500 tokens —
   // deja sitio cómodo para system prompt + corpus RAG + historial + query.
@@ -842,16 +908,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     }
   };
 
-  const handleSubmit = async (text, { fromVoice = false } = {}) => {
-    if (!text.trim()) return;
-    // Re-entry guard: rechaza submits concurrentes. Permitimos `fromVoice`
-    // como excepción porque `handleVoiceRecord` ya seteó STATE_THINKING
-    // antes de await transcribe(blob), por lo que cuando llega acá `state`
-    // NO es IDLE (closure capturó STATE_RECORDING). Bug previo: el guard
-    // `state !== STATE_IDLE` rechazaba la llamada → UI quedaba en pensando
-    // sin disparar el LLM (race de closure + async state).
-    if (!fromVoice && state !== STATE_IDLE) return;
-
+  // Task #121: pipeline LLM extraído de handleSubmit. Ejecuta el flow
+  // completo (RAG, sidecar, LLM, TTS, action gate) para UN solo texto.
+  // No toca el queue store — eso lo hace handleSubmit antes/después.
+  // Tampoco hace re-entry guard porque el queue ya garantiza serialización.
+  const runAgentPipeline = async (text) => {
     const userMessage = {
       role: 'user',
       content: text.trim(),
@@ -1069,6 +1130,82 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     } finally {
       setState(STATE_IDLE);
       setStreamingContent('');
+    }
+  };
+
+  // Task #121: puerta de entrada al pipeline. Gestiona queueing (max 2),
+  // ETA, hint paralelo, rechazo de 3ras. Si la pregunta entra como
+  // processing, ejecuta runAgentPipeline + al terminar promueve cualquier
+  // pending. Si entra como queued, solo agrega visualmente el mensaje al
+  // chat (lo procesará la promoción cuando termine el actual). Si entra
+  // rejected, muestra toast.
+  const handleSubmit = async (text, { fromVoice = false } = {}) => {
+    if (!text || !text.trim()) return;
+    const trimmed = text.trim();
+
+    // El queue ya serializa. NO replicamos el guard `state !== STATE_IDLE`
+    // del flow previo — eso hacía que la 2da pregunta se perdiera sin
+    // feedback. El parámetro `fromVoice` queda como hint semántico para
+    // futuras políticas (e.g. voice → priority? hoy no se usa).
+    void fromVoice;
+
+    const route = selectChatRoute(trimmed);
+    const result = useAgentQueueStore.getState().enqueue(trimmed, route);
+
+    if (result.status === 'rejected') {
+      if (result.reason === 'queue_full') {
+        setQueueRejectedToast(result.message);
+        agentSounds.cancel();
+      }
+      return;
+    }
+
+    if (result.status === 'queued') {
+      // El operador ya escribió la pregunta — mostrarla en el chat como
+      // burbuja "pending" para que sienta que el sistema la escuchó. El
+      // procesamiento real arrancará cuando termine la actual via
+      // promoción en el finally del pipeline.
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'user',
+          content: trimmed,
+          timestamp: Date.now(),
+          _queued: true,
+        },
+      ]);
+      return;
+    }
+
+    // status === 'started' → arrancar pipeline para este texto y luego
+    // drenar el pending (si hay) en serie.
+    let currentText = trimmed;
+    let safety = 0;
+    while (currentText && safety < QUEUE_DRAIN_MAX) {
+      safety += 1;
+      let pipelineFailed = false;
+      try {
+        await runAgentPipeline(currentText);
+      } catch (pipelineErr) {
+        // runAgentPipeline ya captura todo internamente; este catch es
+        // defensivo (e.g. error fuera del try interno). Marcamos failed
+        // explícito para no contaminar EMA con latencias de muestras
+        // que no representan inferencia exitosa.
+        pipelineFailed = true;
+        console.warn('[Agent] pipeline outer catch (defensive):', pipelineErr?.message);
+      }
+      const promoted = useAgentQueueStore.getState().completeProcessing({
+        failed: pipelineFailed,
+      });
+      if (!promoted) {
+        currentText = null;
+        break;
+      }
+      // Corregir el route del promoted con su query real (al promover
+      // lo pusimos como 'chat' por default).
+      const promotedRoute = selectChatRoute(promoted.prompt);
+      useAgentQueueStore.getState().updateProcessingRoute(promoted.id, promotedRoute);
+      currentText = promoted.prompt;
     }
   };
 
@@ -1293,14 +1430,26 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
             type="text"
             value={inputText}
             onChange={(e) => setInputText(e.target.value)}
-            placeholder="Escribe tu pregunta..."
-            disabled={state !== STATE_IDLE}
+            placeholder={
+              queuePending.length >= 1
+                ? 'Espera — ya hay una en cola'
+                : queueProcessing
+                  ? 'Adelanta otra pregunta (cola: 1 más)'
+                  : 'Escribe tu pregunta...'
+            }
+            disabled={state === STATE_RECORDING || queuePending.length >= 1}
+            data-testid="agent-input"
             className="flex-1 px-4 py-3 rounded-full bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-violet-500/50 disabled:opacity-50"
           />
 
           <button
             type="submit"
-            disabled={!inputText.trim() || state !== STATE_IDLE}
+            disabled={
+              !inputText.trim() ||
+              state === STATE_RECORDING ||
+              queuePending.length >= 1
+            }
+            data-testid="agent-submit"
             className="shrink-0 w-12 h-12 rounded-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
           >
             <Send size={18} className="text-white" />
@@ -1315,15 +1464,90 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
         {state === STATE_THINKING && (
           <div className="flex flex-col items-center gap-2 mt-2">
-            <p className={`text-center text-xs ${showSlowWarning ? 'text-amber-400' : 'text-violet-400'}`}>
-              {showSlowWarning ? 'Chagra IA sigue pensando — toca Cancelar si quieres reintentar' : 'Chagra IA está pensando…'}
+            <p
+              className={`text-center text-xs ${showSlowWarning ? 'text-amber-400' : 'text-violet-400'}`}
+              data-testid="eta-label"
+            >
+              {(() => {
+                if (showSlowWarning) {
+                  return 'Chagra IA sigue pensando — toca Cancelar si quieres reintentar';
+                }
+                // ETA visible. Si remainingMs es null o el item recién arrancó
+                // sin haber medido aún, caemos a "Procesando tu pregunta…".
+                if (remainingMs !== null && queueProcessing) {
+                  const expected = queueProcessing.expectedEtaMs;
+                  const elapsed = expected - remainingMs;
+                  const overshoot = elapsed > expected * 1.5;
+                  const stretching = elapsed > expected;
+                  // Verde si < ema, ámbar si entre 1x-1.5x ema, rojo si > 1.5x.
+                  // El color lo aplicamos a un span aparte para mantener el
+                  // texto general en violeta.
+                  const secsLeft = Math.max(0, Math.ceil(remainingMs / 1000));
+                  if (overshoot) {
+                    return `Tardando más de lo normal (${Math.floor(elapsed / 1000)}s ya)`;
+                  }
+                  if (stretching) {
+                    return `Casi listo… (${Math.floor(elapsed / 1000)}s)`;
+                  }
+                  return `Procesando tu pregunta… ~${secsLeft}s`;
+                }
+                return 'Chagra IA está pensando…';
+              })()}
             </p>
+            {queuePending.length >= 1 && (
+              <p
+                className="text-center text-[10px] text-violet-300"
+                data-testid="queue-pending-badge"
+              >
+                Tienes 1 pregunta en cola — te respondo después de la actual.
+              </p>
+            )}
+            {!hintDismissed && (
+              <div
+                className="mt-1 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/60 flex items-start gap-2 max-w-sm"
+                data-testid="parallel-hint"
+              >
+                <Sparkles size={14} className="text-violet-400 shrink-0 mt-0.5" />
+                <p className="text-[11px] text-slate-300 leading-snug flex-1">
+                  Mientras espero, puedes registrar una planta, revisar tu
+                  historial o tomar una foto IoT — sigues sin perder esta
+                  respuesta.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setHintDismissed(true)}
+                  aria-label="Cerrar sugerencia"
+                  className="text-[10px] text-slate-500 hover:text-slate-300 shrink-0 leading-none"
+                >
+                  ×
+                </button>
+              </div>
+            )}
             <button
               type="button"
               onClick={handleCancelLLM}
               className="text-[10px] px-3 py-1 rounded-full bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700 active:scale-95 transition-all"
             >
               Cancelar
+            </button>
+          </div>
+        )}
+
+        {queueRejectedToast && (
+          <div
+            className="mt-2 px-3 py-2 rounded-lg bg-amber-900/40 border border-amber-700/60 flex items-center gap-2"
+            data-testid="queue-rejected-toast"
+            role="status"
+            aria-live="polite"
+          >
+            <p className="text-xs text-amber-300 flex-1">{queueRejectedToast}</p>
+            <button
+              type="button"
+              onClick={() => setQueueRejectedToast('')}
+              aria-label="Cerrar aviso"
+              className="text-amber-400 hover:text-amber-200 text-sm leading-none"
+            >
+              ×
             </button>
           </div>
         )}

--- a/src/components/AgentScreen/__tests__/AgentScreen.queue.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentScreen.queue.test.jsx
@@ -1,0 +1,198 @@
+/**
+ * Tests del UX de queueing del AgentScreen (task #121, 2026-05-24).
+ *
+ * Cubrimos la máquina de estados `useAgentQueueStore` que orquesta el
+ * queue de preguntas al agente con capacidad max 2, ETA visible y
+ * EMA de latencia por modelo.
+ *
+ * Foco unit-puro sobre el store (sin renderear el AgentScreen completo
+ * — eso requeriría stubbing de ~25 servicios y traería tests frágiles).
+ * El store es la lógica testable, AgentScreen.jsx es orquestación de UI
+ * alrededor del store.
+ *
+ * Archivo ubicado en src/components/AgentScreen/__tests__/ por cohesión
+ * semántica (es el UX queueing del AgentScreen) y por el path pedido
+ * explícitamente en el task brief.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import useAgentQueueStore, {
+  DEFAULT_EMA_MS,
+  QUEUE_MAX,
+} from '../../../store/useAgentQueueStore';
+
+describe('useAgentQueueStore — queue UX agente (task #121)', () => {
+  beforeEach(() => {
+    useAgentQueueStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('Caso 1: 1 pregunta → goes to processing, pending vacío', () => {
+    const result = useAgentQueueStore.getState().enqueue('cómo combato la broca', 'chat');
+    expect(result.status).toBe('started');
+    expect(result.item.prompt).toBe('cómo combato la broca');
+    expect(result.item.model).toBe('chat');
+    expect(result.item.startedAt).toBeTypeOf('number');
+    expect(result.item.expectedEtaMs).toBe(DEFAULT_EMA_MS.chat);
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing).not.toBeNull();
+    expect(s.processing.id).toBe(result.item.id);
+    expect(s.pending).toEqual([]);
+    expect(s.rejectedCount).toBe(0);
+  });
+
+  it('Caso 2: 2 preguntas rápidas → primera processing, segunda pending', () => {
+    const r1 = useAgentQueueStore.getState().enqueue('pregunta uno', 'chat');
+    const r2 = useAgentQueueStore.getState().enqueue('pregunta dos', 'chat');
+
+    expect(r1.status).toBe('started');
+    expect(r2.status).toBe('queued');
+    expect(r2.item.prompt).toBe('pregunta dos');
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing.prompt).toBe('pregunta uno');
+    expect(s.pending).toHaveLength(1);
+    expect(s.pending[0].prompt).toBe('pregunta dos');
+    expect(s.rejectedCount).toBe(0);
+  });
+
+  it('Caso 3: 3ra pregunta rechazada con mensaje "espera"', () => {
+    useAgentQueueStore.getState().enqueue('uno', 'chat');
+    useAgentQueueStore.getState().enqueue('dos', 'chat');
+    const r3 = useAgentQueueStore.getState().enqueue('tres', 'chat');
+
+    expect(r3.status).toBe('rejected');
+    expect(r3.reason).toBe('queue_full');
+    expect(r3.message).toMatch(/espera/i);
+    expect(r3.message).toMatch(/dos|2/);
+    // No voseo argentino (regla CLAUDE.md): no debe aparecer "tenés", "esperá", "querés".
+    expect(r3.message).not.toMatch(/tenés|esperá|querés|elegí/i);
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing.prompt).toBe('uno');
+    expect(s.pending).toHaveLength(1);
+    expect(s.pending[0].prompt).toBe('dos');
+    expect(s.rejectedCount).toBe(1);
+  });
+
+  it('Caso 4: completeProcessing promueve pending → processing y actualiza EMA', () => {
+    // Fake clock para controlar `elapsed` exacto.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T10:00:00Z'));
+
+    const r1 = useAgentQueueStore.getState().enqueue('primera', 'chat');
+    expect(r1.status).toBe('started');
+    useAgentQueueStore.getState().enqueue('segunda', 'chat');
+
+    // Avanzar 10s (elapsed=10000ms para la primera).
+    vi.advanceTimersByTime(10000);
+
+    const promoted = useAgentQueueStore.getState().completeProcessing();
+
+    expect(promoted).not.toBeNull();
+    expect(promoted.prompt).toBe('segunda');
+    expect(promoted.startedAt).toBeTypeOf('number');
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing.prompt).toBe('segunda');
+    expect(s.pending).toEqual([]);
+
+    // EMA actualizado: oldEma=12900, elapsed=10000, alpha=0.3
+    // newEma = round(12900*0.7 + 10000*0.3) = round(9030 + 3000) = 12030
+    expect(s.latencyEma.chat).toBe(12030);
+  });
+
+  it('Caso 5: completeProcessing(failed=true) NO contamina el EMA', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T10:00:00Z'));
+
+    useAgentQueueStore.getState().enqueue('primera', 'chat');
+    // Latencia absurda 60s simulando un timeout / cold-start fallido.
+    vi.advanceTimersByTime(60000);
+
+    useAgentQueueStore.getState().completeProcessing({ failed: true });
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing).toBeNull();
+    // EMA preservado en el default original.
+    expect(s.latencyEma.chat).toBe(DEFAULT_EMA_MS.chat);
+  });
+
+  it('Caso 6: getRemainingMs decrementa con el tiempo (ETA countdown)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T10:00:00Z'));
+
+    useAgentQueueStore.getState().enqueue('test', 'chat');
+
+    const r0 = useAgentQueueStore.getState().getRemainingMs();
+    expect(r0).toBe(DEFAULT_EMA_MS.chat);
+
+    vi.advanceTimersByTime(5000);
+    const r1 = useAgentQueueStore.getState().getRemainingMs();
+    expect(r1).toBe(DEFAULT_EMA_MS.chat - 5000);
+
+    vi.advanceTimersByTime(10000);
+    const r2 = useAgentQueueStore.getState().getRemainingMs();
+    expect(r2).toBe(DEFAULT_EMA_MS.chat - 15000);
+  });
+
+  it('Caso 7: updateProcessingRoute recalcula expectedEtaMs cuando el router decide chat_complex', () => {
+    const r = useAgentQueueStore.getState().enqueue('plan multi-aspecto para asocios de aguacate', 'chat');
+    expect(r.item.expectedEtaMs).toBe(DEFAULT_EMA_MS.chat);
+
+    useAgentQueueStore.getState().updateProcessingRoute(r.item.id, 'chat_complex');
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing.model).toBe('chat_complex');
+    expect(s.processing.expectedEtaMs).toBe(DEFAULT_EMA_MS.chat_complex);
+  });
+
+  it('Caso 8: enqueue("") devuelve rejected reason="empty"', () => {
+    const r = useAgentQueueStore.getState().enqueue('   ', 'chat');
+    expect(r.status).toBe('rejected');
+    expect(r.reason).toBe('empty');
+    expect(useAgentQueueStore.getState().processing).toBeNull();
+  });
+
+  it('Caso 9: completeProcessing sin pending deja processing=null', () => {
+    useAgentQueueStore.getState().enqueue('única', 'chat');
+    const promoted = useAgentQueueStore.getState().completeProcessing();
+    expect(promoted).toBeNull();
+    const s = useAgentQueueStore.getState();
+    expect(s.processing).toBeNull();
+    expect(s.pending).toEqual([]);
+  });
+
+  it('Caso 10: latencia anómala (>120s) NO actualiza el EMA (clamp defensivo)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-24T10:00:00Z'));
+
+    useAgentQueueStore.getState().enqueue('q', 'chat');
+    // 130s simula un cuelgue raro que no debería envenenar la EMA.
+    vi.advanceTimersByTime(130000);
+    useAgentQueueStore.getState().completeProcessing();
+
+    expect(useAgentQueueStore.getState().latencyEma.chat).toBe(DEFAULT_EMA_MS.chat);
+  });
+
+  it('Caso 11: capacidad QUEUE_MAX exportada como 2 (acoplada al brief)', () => {
+    expect(QUEUE_MAX).toBe(2);
+  });
+
+  it('Caso 12: reset() restaura defaults incluyendo latencyEma', () => {
+    useAgentQueueStore.getState().enqueue('uno', 'chat');
+    useAgentQueueStore.getState().enqueue('dos', 'chat');
+    useAgentQueueStore.getState().enqueue('tres', 'chat'); // rejected → rejectedCount=1
+    useAgentQueueStore.getState().reset();
+
+    const s = useAgentQueueStore.getState();
+    expect(s.processing).toBeNull();
+    expect(s.pending).toEqual([]);
+    expect(s.rejectedCount).toBe(0);
+    expect(s.latencyEma).toEqual(DEFAULT_EMA_MS);
+  });
+});

--- a/src/store/useAgentQueueStore.js
+++ b/src/store/useAgentQueueStore.js
@@ -1,0 +1,253 @@
+import { create } from 'zustand';
+
+/**
+ * useAgentQueueStore — máquina de estados del queue del agente Chagra IA
+ * (task #121, 2026-05-24).
+ *
+ * Problema (UX 2026-05-23 testing manual con operadora real):
+ * Cuando una pregunta al agente tarda 12-25s en responder (router dual
+ * model: llama3.1:8b ~12.9s simple, granite3.1-dense:8b ~24.7s complex),
+ * el operador no espera quieto: dispara 2-3 preguntas seguidas. Con el
+ * guard `state !== STATE_IDLE` actual en `handleSubmit`, las preguntas
+ * 2 y 3 se ignoraban silenciosamente (`return` mudo). El operador veía
+ * el input quedarse quieto sin feedback y asumía que la app estaba rota.
+ *
+ * Solución: queue explícito con capacidad MÁXIMA 2 (1 procesándose + 1
+ * pendiente). La tercera se rechaza con mensaje claro "espera, ya hay
+ * 2 en cola". Mientras espera ve ETA dinámico basado en latencia
+ * histórica del modelo elegido por el router.
+ *
+ * Capa pura (no toca DOM, fetch, ni servicios): testeable al 100% con
+ * vitest sin renderear nada. AgentScreen orquesta UI alrededor del
+ * store via subscripciones + comandos `enqueue` / `markStarted` /
+ * `completeProcessing`.
+ *
+ * Estado:
+ *   - processing:   { id, prompt, model, startedAt, expectedEtaMs } | null
+ *   - pending:      Array de { id, prompt, enqueuedAt }; max 1 elemento
+ *                   (allow 2 total = 1 processing + 1 pending).
+ *   - latencyEma:   Object { [model]: emaMs }. Init defaults por modelo
+ *                   del bench nocturno 2026-05-24. Se actualiza con
+ *                   alpha 0.3 cada `completeProcessing`.
+ *   - rejectedCount: contador defensivo para telemetría (cuántas veces
+ *                   el operador trató de mandar una 3ra mientras había 2).
+ *
+ * NO persistimos: el queue es efímero por sesión de chat. Si el operador
+ * cierra el navegador, la pregunta pendiente se pierde — y eso es
+ * deliberado: el operador escribió pero no le respondimos, no podemos
+ * fingir que respondimos tarde sin contexto fresco.
+ */
+
+/**
+ * Defaults de latencia inicial por route del router (selectChatRoute).
+ * Bench nocturno 2026-05-24 (DR bench-modelos-nocturno-2026-05-24.md):
+ *   - 'chat' (llama3.1:8b)             ≈ 12.9s avg
+ *   - 'chat_complex' (granite3.1-dense:8b) ≈ 24.7s avg
+ *   - 'unknown' (fallback defensivo)   ≈ 15.0s
+ * Si en el futuro se agrega otro route al router, se cae al fallback
+ * limpio en lugar de explotar.
+ */
+export const DEFAULT_EMA_MS = {
+  chat: 12900,
+  chat_complex: 24700,
+  unknown: 15000,
+};
+
+/**
+ * Alpha del Exponential Moving Average. 0.3 da peso suave al sample
+ * nuevo (30%) preservando inercia histórica (70%). Equilibrio entre
+ * reaccionar a degradaciones reales del modelo (cold-start tras swap
+ * de VRAM) y no oscilar ante un single outlier.
+ */
+const EMA_ALPHA = 0.3;
+
+/**
+ * Capacidad total del queue (processing + pending). 2 es el valor del
+ * task #121: permite que el operador adelante una pregunta siguiente
+ * mientras la actual procesa, sin abrir la puerta a colas infinitas que
+ * acumulen contexto stale (a los 60s ya no recuerda qué preguntó).
+ */
+export const QUEUE_MAX = 2;
+
+/**
+ * Genera un id estable para cada item del queue. ULID-like pero sin
+ * importar dependencia: timestamp + counter local. Suficiente para
+ * tracking dentro de una sesión.
+ */
+let _itemSeq = 0;
+function nextItemId() {
+  _itemSeq += 1;
+  return `q-${Date.now()}-${_itemSeq}`;
+}
+
+const useAgentQueueStore = create((set, get) => ({
+  processing: null,
+  pending: [],
+  latencyEma: { ...DEFAULT_EMA_MS },
+  rejectedCount: 0,
+
+  /**
+   * Intenta encolar una pregunta nueva. Retorna un objeto descriptivo
+   * para que el caller (AgentScreen.handleSubmit) decida qué hacer:
+   *   - { status: 'started', item }       → empezar el pipeline LLM ya
+   *   - { status: 'queued',  item }       → mensaje "tu pregunta queda en cola"
+   *   - { status: 'rejected', reason }    → toast "ya hay 2 en cola, espera"
+   *
+   * El caller dispara el LLM solo cuando status === 'started'. Cuando
+   * `completeProcessing` corre, el store mueve el `pending` a `processing`
+   * y retorna el item promovido para que el caller lo dispare a su vez.
+   */
+  enqueue: (prompt, route = 'chat') => {
+    const trimmed = (prompt || '').trim();
+    if (!trimmed) return { status: 'rejected', reason: 'empty' };
+
+    const { processing, pending, latencyEma, rejectedCount } = get();
+
+    // CAPACIDAD: 1 processing + 1 pending = 2 total. Tercera rechaza.
+    const totalInFlight = (processing ? 1 : 0) + pending.length;
+    if (totalInFlight >= QUEUE_MAX) {
+      set({ rejectedCount: rejectedCount + 1 });
+      return {
+        status: 'rejected',
+        reason: 'queue_full',
+        message: 'Espera un momento. Ya tengo dos preguntas en cola; te respondo en orden.',
+      };
+    }
+
+    const item = { id: nextItemId(), prompt: trimmed, enqueuedAt: Date.now() };
+
+    if (!processing) {
+      // No hay nada procesando — arranca de una.
+      const eta = latencyEma[route] ?? latencyEma.unknown ?? DEFAULT_EMA_MS.unknown;
+      const processingItem = {
+        ...item,
+        model: route,
+        startedAt: Date.now(),
+        expectedEtaMs: eta,
+      };
+      set({ processing: processingItem });
+      return { status: 'started', item: processingItem };
+    }
+
+    // Hay algo procesando — encola.
+    set({ pending: [...pending, item] });
+    return { status: 'queued', item };
+  },
+
+  /**
+   * Marca el item processing como terminado y actualiza el EMA del
+   * modelo usado. Retorna el siguiente item promovido a processing (o
+   * null si no había pending). El caller debe disparar el LLM con el
+   * item retornado.
+   *
+   * `failed`: si la inferencia falló (timeout, abort), NO actualizamos
+   * el EMA — el sample es ruido (cold-start fallido, red caída) y
+   * contaminaría las estimaciones futuras.
+   */
+  completeProcessing: ({ failed = false } = {}) => {
+    const { processing, pending, latencyEma } = get();
+    if (!processing) {
+      // Defensa: completeProcessing sin processing activo es un bug
+      // pero NO debe explotar. Loggea y promueve pending si lo hay
+      // (estado limpio).
+      console.debug('[useAgentQueueStore] completeProcessing sin processing activo');
+    }
+
+    // Actualizar EMA del modelo usado (solo si éxito real).
+    let nextEma = latencyEma;
+    if (processing && !failed) {
+      const elapsed = Date.now() - processing.startedAt;
+      // Clamp defensivo: muestras absurdas (< 500ms o > 120s) las
+      // descartamos para no envenenar el EMA con anomalías.
+      if (elapsed >= 500 && elapsed <= 120000) {
+        const key = processing.model || 'unknown';
+        const oldEma = latencyEma[key] ?? DEFAULT_EMA_MS.unknown;
+        const newEma = Math.round(oldEma * (1 - EMA_ALPHA) + elapsed * EMA_ALPHA);
+        nextEma = { ...latencyEma, [key]: newEma };
+      }
+    }
+
+    // Promover pending si lo hay.
+    if (pending.length > 0) {
+      const [nextItem, ...rest] = pending;
+      // Para el item promovido NO conocemos aún el route definitivo
+      // (lo decide el caller con selectChatRoute(prompt)). Pasamos el
+      // route como 'chat' por default y `startProcessing` lo corrige.
+      const route = 'chat';
+      const eta = nextEma[route] ?? nextEma.unknown ?? DEFAULT_EMA_MS.unknown;
+      const promotedItem = {
+        ...nextItem,
+        model: route,
+        startedAt: Date.now(),
+        expectedEtaMs: eta,
+      };
+      set({
+        processing: promotedItem,
+        pending: rest,
+        latencyEma: nextEma,
+      });
+      return promotedItem;
+    }
+
+    set({
+      processing: null,
+      latencyEma: nextEma,
+    });
+    return null;
+  },
+
+  /**
+   * Ajusta el route del processing actual. Lo llamamos justo después
+   * de `enqueue` o tras promoción cuando el caller ya invocó
+   * `selectChatRoute(prompt)` y conoce el modelo real. Recalcula el
+   * `expectedEtaMs` con el EMA del nuevo route.
+   *
+   * Patrón de uso (AgentScreen):
+   *   const r = enqueue(prompt);
+   *   if (r.status === 'started') {
+   *     const route = selectChatRoute(prompt);
+   *     updateProcessingRoute(r.item.id, route);
+   *     // ...llamar LLM...
+   *   }
+   */
+  updateProcessingRoute: (id, route) => {
+    const { processing, latencyEma } = get();
+    if (!processing || processing.id !== id) return;
+    const eta = latencyEma[route] ?? latencyEma.unknown ?? DEFAULT_EMA_MS.unknown;
+    set({
+      processing: { ...processing, model: route, expectedEtaMs: eta },
+    });
+  },
+
+  /**
+   * Calcula tiempo restante estimado del item processing actual.
+   * Retorna milisegundos restantes (puede ser negativo si pasamos el
+   * ETA — la UI lo trata como "ya casi"). Retorna null si no hay
+   * processing.
+   *
+   * NOTA: este getter es pure. AgentScreen llama esto cada segundo
+   * vía setInterval para renderear el countdown.
+   */
+  getRemainingMs: () => {
+    const { processing } = get();
+    if (!processing) return null;
+    const elapsed = Date.now() - processing.startedAt;
+    return processing.expectedEtaMs - elapsed;
+  },
+
+  /**
+   * Reset explícito del store. Para tests y para el botón "Nueva
+   * conversación" del header (un reset de conversación debe abortar
+   * también cualquier pregunta pendiente — el contexto cambió).
+   */
+  reset: () => {
+    set({
+      processing: null,
+      pending: [],
+      latencyEma: { ...DEFAULT_EMA_MS },
+      rejectedCount: 0,
+    });
+  },
+}));
+
+export default useAgentQueueStore;


### PR DESCRIPTION
## Summary
- Queue max 2 preguntas (1 processing + 1 pending). 3ra rechazada con toast 4s "Espera un momento. Ya tengo dos preguntas en cola".
- ETA visible dinámico countdown 1Hz basado en EMA por modelo del router dual (chat 12.9s init, chat_complex 24.7s init, alpha 0.3).
- Hint dismissible "puedes registrar planta / revisar historial / foto IoT" mientras espera.
- Store zustand `useAgentQueueStore` puro (testeable sin DOM) + 12 tests verde.
- No toca llmRouter ni pipeline NLU — solo capa UI de queueing.

## Test plan
- [x] `npx vitest run` → 726/726 (era 714)
- [x] `npx eslint . --max-warnings=0` → clean
- [x] `npm run build` → OK (AgentScreen 72.67 KB)
- [ ] manual: 2 preguntas rápidas → 2da visual en cola
- [ ] manual: 3 preguntas rápidas → toast ámbar
- [ ] manual: countdown ETA decrementa
- [ ] manual: tras 1.5x EMA, label rojo "Tardando más de lo normal"