### PR TITLE
feat(tts): selector voz Kokoro con preferencias persistidas — task #124

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.183",
+  "version": "0.12.184",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v225';
+const CACHE_NAME = 'chagra-v226';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -3,6 +3,7 @@ import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2 } fro
 import { ScreenShell } from './common/ScreenShell';
 import ThemeSelector from './common/ThemeSelector';
 import BackupExportButton from './BackupExportButton';
+import VoiceSelector from './Settings/VoiceSelector';
 import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import usePrefsStore from '../store/usePrefsStore';
@@ -163,6 +164,12 @@ export default function ProfileScreen({ onBack, onHome }) {
             Default ON. Operador puede silenciar también con doble-click en
             el avatar colibrí (header AgentScreen o FAB global). */}
         <AgentVoiceSection />
+
+        {/* Task #124 (2026-05-24): selector de voz Kokoro + velocidad. Solo
+            tiene sentido si TTS está activo, pero lo renderizamos siempre
+            (no oculto) para que el operador pueda elegir voz antes de
+            activar TTS — UX más predictible que esconder/mostrar. */}
+        <VoiceSelector />
 
         {/* Telemetry Section */}
         <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">

--- a/src/components/Settings/VoiceSelector.jsx
+++ b/src/components/Settings/VoiceSelector.jsx
@@ -1,0 +1,221 @@
+/**
+ * VoiceSelector — Task #124 (2026-05-24).
+ *
+ * Componente de Settings para elegir la voz Kokoro del asistente Chagra
+ * y la velocidad de reproducción. Persiste preferencias en localStorage
+ * vía `ttsService.setPreferredVoice` / `setPreferredRate`.
+ *
+ * Diseñado para integrarse dentro de ProfileScreen (sección "Voz del
+ * asistente") o cualquier futura pantalla de Ajustes. Mobile-first:
+ * botones grandes (min-h 48px), sin scroll horizontal, dropdown nativo
+ * que respeta el selector OS en mobile.
+ *
+ * Contrato UX:
+ *   - Dropdown con voces curadas (`KOKORO_VOICES` desde ttsService).
+ *   - Botón "Probar" por voz → llama speakKokoro con frase fija.
+ *   - Botón "Guardar" persiste voice + rate y flash de confirmación.
+ *   - El estado del dropdown es local hasta apretar "Guardar".
+ *   - Si Kokoro no está disponible, "Probar" cae al fallback speak()
+ *     transparente (lo maneja speakKokoro internamente).
+ */
+import React, { useState, useRef } from 'react';
+import { Volume2, Play, Save, Check } from 'lucide-react';
+import {
+  speakKokoro,
+  stop as stopTTS,
+  getPreferredVoice,
+  setPreferredVoice,
+  getPreferredRate,
+  setPreferredRate,
+  KOKORO_VOICES,
+  DEFAULT_KOKORO_VOICE,
+  KOKORO_RATE_MIN,
+  KOKORO_RATE_MAX,
+} from '../../services/ttsService';
+
+const SAMPLE_TEXT =
+  'Hola, soy el asistente Chagra. Probemos cómo suena mi voz en su finca.';
+
+export default function VoiceSelector() {
+  const [selectedVoice, setSelectedVoice] = useState(() => getPreferredVoice());
+  const [rate, setRate] = useState(() => getPreferredRate());
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [previewingVoice, setPreviewingVoice] = useState(null);
+  const flashTimerRef = useRef(null);
+
+  const handlePreview = async (voiceId) => {
+    // Cortar cualquier audio previo (preview, agente, lo que sea) antes
+    // de mandar el nuevo sample. Sin esto el operador escucha samples
+    // encimados si presiona "Probar" varias veces seguidas.
+    stopTTS();
+    setPreviewingVoice(voiceId);
+    try {
+      await speakKokoro(SAMPLE_TEXT, { voice: voiceId, rate });
+    } catch (_) {
+      // speakKokoro ya cae a Web Speech internamente. Si falla hasta acá
+      // es algo más raro; no romper la UI por un preview.
+    } finally {
+      setPreviewingVoice(null);
+    }
+  };
+
+  const handleSave = () => {
+    setPreferredVoice(selectedVoice);
+    setPreferredRate(rate);
+    setSavedFlash(true);
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    flashTimerRef.current = setTimeout(() => setSavedFlash(false), 1500);
+  };
+
+  const selectedVoiceMeta =
+    KOKORO_VOICES.find((v) => v.id === selectedVoice) ||
+    KOKORO_VOICES.find((v) => v.id === DEFAULT_KOKORO_VOICE);
+
+  return (
+    <div
+      className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5"
+      data-testid="voice-selector"
+    >
+      <div className="flex items-center gap-2 px-1">
+        <Volume2 size={18} className="text-violet-400" />
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">
+          Voz del asistente
+        </h3>
+      </div>
+
+      <p className="text-[11px] text-slate-500 leading-relaxed px-1">
+        Elija la voz con la que Chagra IA leerá sus respuestas. Pruebe cada
+        opción y guarde la que mejor le suene en su finca. Se usa Kokoro
+        TTS local; el catálogo upstream tiene varias voces probadas para
+        acento más neutro hispano.
+      </p>
+
+      <label className="flex flex-col gap-2">
+        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">
+          Voz
+        </span>
+        <select
+          value={selectedVoice}
+          onChange={(e) => setSelectedVoice(e.target.value)}
+          className="p-3 rounded-xl bg-slate-800 border border-slate-700 focus:border-violet-500 outline-none text-white text-base min-h-[48px] appearance-none"
+          aria-label="Seleccionar voz del asistente"
+          data-testid="voice-dropdown"
+        >
+          {KOKORO_VOICES.map((voice) => (
+            <option key={voice.id} value={voice.id}>
+              {voice.label}
+            </option>
+          ))}
+        </select>
+        {selectedVoiceMeta && (
+          <span className="text-[10px] text-slate-500 leading-snug px-1">
+            {selectedVoiceMeta.description}
+          </span>
+        )}
+      </label>
+
+      {/* Botón Probar para la voz seleccionada en el dropdown */}
+      <button
+        type="button"
+        onClick={() => handlePreview(selectedVoice)}
+        disabled={previewingVoice !== null}
+        className="w-full p-3 rounded-xl font-bold flex items-center justify-center gap-2 bg-slate-800 hover:bg-slate-700 text-violet-400 transition-colors min-h-[48px] disabled:opacity-50"
+        data-testid="voice-preview-button"
+      >
+        <Play size={18} />
+        {previewingVoice === selectedVoice
+          ? 'Reproduciendo...'
+          : 'Probar esta voz'}
+      </button>
+
+      {/* Lista de previews rápidos por voz — útil para comparar A/B */}
+      <div className="space-y-2">
+        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide px-1">
+          Comparar voces
+        </span>
+        <div className="grid grid-cols-1 gap-2">
+          {KOKORO_VOICES.map((voice) => (
+            <button
+              key={voice.id}
+              type="button"
+              onClick={() => handlePreview(voice.id)}
+              disabled={previewingVoice !== null}
+              className={`p-3 rounded-xl flex items-center justify-between gap-2 transition-colors min-h-[48px] disabled:opacity-50 ${
+                voice.id === selectedVoice
+                  ? 'bg-violet-900/30 border border-violet-700/50'
+                  : 'bg-slate-800/50 border border-slate-700/50 hover:bg-slate-800'
+              }`}
+              data-testid={`voice-row-${voice.id}`}
+            >
+              <span className="flex flex-col items-start text-left flex-1 min-w-0">
+                <span className="text-sm font-bold text-slate-200 truncate w-full">
+                  {voice.label}
+                </span>
+                <span className="text-[10px] text-slate-500 truncate w-full">
+                  {voice.gender}
+                </span>
+              </span>
+              <Play
+                size={16}
+                className={
+                  previewingVoice === voice.id
+                    ? 'text-violet-400 animate-pulse'
+                    : 'text-slate-400'
+                }
+              />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Slider de velocidad */}
+      <label className="flex flex-col gap-2">
+        <span className="text-xs font-bold text-slate-400 uppercase tracking-wide">
+          Velocidad ({rate.toFixed(2)}x)
+        </span>
+        <input
+          type="range"
+          min={KOKORO_RATE_MIN}
+          max={KOKORO_RATE_MAX}
+          step="0.05"
+          value={rate}
+          onChange={(e) => setRate(Number.parseFloat(e.target.value))}
+          className="w-full accent-violet-500 min-h-[24px]"
+          aria-label="Velocidad de reproducción de la voz"
+          data-testid="voice-rate-slider"
+        />
+        <div className="flex justify-between text-[10px] text-slate-500 px-1">
+          <span>Más lenta ({KOKORO_RATE_MIN}x)</span>
+          <span>Más rápida ({KOKORO_RATE_MAX}x)</span>
+        </div>
+      </label>
+
+      <button
+        type="button"
+        onClick={handleSave}
+        className={`w-full p-3 rounded-xl font-bold flex items-center justify-center gap-2 transition-all min-h-[48px] ${
+          savedFlash
+            ? 'bg-violet-600 text-white'
+            : 'bg-slate-800 hover:bg-slate-700 text-violet-400'
+        }`}
+        data-testid="voice-save-button"
+      >
+        {savedFlash ? (
+          <>
+            <Check size={18} /> Guardado
+          </>
+        ) : (
+          <>
+            <Save size={18} /> Guardar preferencias
+          </>
+        )}
+      </button>
+
+      <p className="text-[10px] text-slate-500 text-center leading-relaxed">
+        Las preferencias se guardan localmente en su dispositivo. La voz
+        por defecto es <strong className="text-slate-400">Dora</strong>
+        {' '}para no romper a operadores ya acostumbrados.
+      </p>
+    </div>
+  );
+}

--- a/src/components/Settings/__tests__/VoiceSelector.test.jsx
+++ b/src/components/Settings/__tests__/VoiceSelector.test.jsx
@@ -1,0 +1,132 @@
+/**
+ * Tests para VoiceSelector — task #124 (2026-05-24).
+ *
+ * Cubre:
+ *   - Renderiza dropdown con las voces curadas (KOKORO_VOICES)
+ *   - "Probar" dispara speakKokoro con la voz seleccionada
+ *   - "Guardar" persiste voice + rate en localStorage
+ *   - Cambiar dropdown actualiza el state local (no persiste hasta Save)
+ *   - Cada fila de "comparar voces" tiene su propio botón preview
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Mock del ttsService — solo necesitamos verificar que speakKokoro se llame
+// con los args esperados; el detalle interno (fetch, audio) lo cubren los
+// tests del service.
+vi.mock('../../../services/ttsService', async () => {
+  const actual = await vi.importActual('../../../services/ttsService');
+  return {
+    ...actual,
+    speakKokoro: vi.fn().mockResolvedValue(null),
+    stop: vi.fn(),
+  };
+});
+
+import VoiceSelector from '../VoiceSelector';
+import {
+  speakKokoro,
+  stop as stopTTS,
+  KOKORO_VOICES,
+  DEFAULT_KOKORO_VOICE,
+} from '../../../services/ttsService';
+
+describe('VoiceSelector — task #124', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    speakKokoro.mockClear();
+    stopTTS.mockClear();
+  });
+
+  test('renderiza dropdown con todas las voces curadas', () => {
+    render(<VoiceSelector />);
+    const dropdown = screen.getByTestId('voice-dropdown');
+    expect(dropdown).toBeInTheDocument();
+    // El select debe tener una option por voz.
+    const options = dropdown.querySelectorAll('option');
+    expect(options.length).toBe(KOKORO_VOICES.length);
+    for (const voice of KOKORO_VOICES) {
+      expect(dropdown.textContent).toContain(voice.label);
+    }
+  });
+
+  test('selección inicial es la voz preferida del storage (o default)', () => {
+    localStorage.setItem('chagra:tts:voice', 'ef_aoede');
+    render(<VoiceSelector />);
+    const dropdown = screen.getByTestId('voice-dropdown');
+    expect(dropdown.value).toBe('ef_aoede');
+  });
+
+  test('selección inicial cae a default si storage vacío', () => {
+    render(<VoiceSelector />);
+    const dropdown = screen.getByTestId('voice-dropdown');
+    expect(dropdown.value).toBe(DEFAULT_KOKORO_VOICE);
+  });
+
+  test('click "Probar esta voz" llama speakKokoro con la voz seleccionada', async () => {
+    render(<VoiceSelector />);
+    const dropdown = screen.getByTestId('voice-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'ef_kore' } });
+    const previewBtn = screen.getByTestId('voice-preview-button');
+    fireEvent.click(previewBtn);
+    await waitFor(() => {
+      expect(speakKokoro).toHaveBeenCalledTimes(1);
+    });
+    const [text, opts] = speakKokoro.mock.calls[0];
+    expect(text).toMatch(/asistente Chagra/i);
+    expect(opts).toMatchObject({ voice: 'ef_kore' });
+  });
+
+  test('click "Guardar" persiste voice + rate en localStorage', async () => {
+    render(<VoiceSelector />);
+    const dropdown = screen.getByTestId('voice-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'em_alex' } });
+    const slider = screen.getByTestId('voice-rate-slider');
+    fireEvent.change(slider, { target: { value: '1.05' } });
+    const saveBtn = screen.getByTestId('voice-save-button');
+    fireEvent.click(saveBtn);
+    await waitFor(() => {
+      expect(localStorage.getItem('chagra:tts:voice')).toBe('em_alex');
+    });
+    expect(Number.parseFloat(localStorage.getItem('chagra:tts:rate'))).toBeCloseTo(1.05);
+    // Flash de "Guardado" debe aparecer.
+    expect(saveBtn).toHaveTextContent(/Guardado/i);
+  });
+
+  test('cada fila de "comparar voces" tiene su propio botón preview', async () => {
+    render(<VoiceSelector />);
+    for (const voice of KOKORO_VOICES) {
+      const row = screen.getByTestId(`voice-row-${voice.id}`);
+      expect(row).toBeInTheDocument();
+      expect(row.textContent).toContain(voice.label);
+    }
+    // Click en una fila específica dispara preview de esa voz.
+    const aoedeRow = screen.getByTestId('voice-row-ef_aoede');
+    fireEvent.click(aoedeRow);
+    await waitFor(() => {
+      expect(speakKokoro).toHaveBeenCalledTimes(1);
+    });
+    const [, opts] = speakKokoro.mock.calls[0];
+    expect(opts.voice).toBe('ef_aoede');
+  });
+
+  test('cambiar dropdown NO persiste hasta apretar Guardar (state local)', () => {
+    render(<VoiceSelector />);
+    const dropdown = screen.getByTestId('voice-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'ef_kore' } });
+    // No tocamos Guardar — localStorage debe seguir sin la nueva voz.
+    expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
+  });
+
+  test('preview corta cualquier audio previo antes de reproducir (evita overlap)', async () => {
+    render(<VoiceSelector />);
+    const previewBtn = screen.getByTestId('voice-preview-button');
+    fireEvent.click(previewBtn);
+    await waitFor(() => {
+      expect(stopTTS).toHaveBeenCalled();
+      expect(speakKokoro).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/__tests__/ttsService.voice.test.js
+++ b/src/services/__tests__/ttsService.voice.test.js
@@ -1,0 +1,174 @@
+/**
+ * Tests para las preferencias persistidas de voz Kokoro (task #124).
+ *
+ * Cubre:
+ *   - getPreferredVoice fallback + override
+ *   - setPreferredVoice valida contra KOKORO_VOICES
+ *   - getPreferredRate clamp + fallback
+ *   - setPreferredRate clamp
+ *   - speakKokoro respeta preferido cuando no se pasa voice explícito
+ *   - speakKokoro respeta override explícito por sobre preferido
+ *   - speakKokoro lleva el rate preferido cuando no se pasa explícito (a
+ *     través del options.voice resolution; verificamos el body POSTed)
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  getPreferredVoice,
+  setPreferredVoice,
+  getPreferredRate,
+  setPreferredRate,
+  speakKokoro,
+  DEFAULT_KOKORO_VOICE,
+  DEFAULT_KOKORO_RATE,
+  KOKORO_RATE_MIN,
+  KOKORO_RATE_MAX,
+  KOKORO_VOICES,
+} from '../ttsService.js';
+
+// Mock Audio (jsdom no implementa play() de forma usable).
+class MockAudio {
+  constructor() {
+    this.paused = true;
+    this.onended = null;
+  }
+  play() {
+    this.paused = false;
+    return Promise.resolve();
+  }
+  pause() {
+    this.paused = true;
+  }
+}
+
+describe('ttsService — preferencias de voz Kokoro (task #124)', () => {
+  let fetchMock;
+  let originalAudio;
+  let originalCreateObjectURL;
+  let originalRevokeObjectURL;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['fake-audio'], { type: 'audio/opus' }),
+    });
+    globalThis.fetch = fetchMock;
+    originalAudio = globalThis.Audio;
+    globalThis.Audio = MockAudio;
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn(() => 'blob:fake-url');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    vi.restoreAllMocks();
+  });
+
+  describe('getPreferredVoice', () => {
+    it('devuelve default ef_dora si localStorage está vacío', () => {
+      expect(getPreferredVoice()).toBe(DEFAULT_KOKORO_VOICE);
+      expect(getPreferredVoice()).toBe('ef_dora');
+    });
+
+    it('devuelve la voz persistida si está en KOKORO_VOICES', () => {
+      localStorage.setItem('chagra:tts:voice', 'ef_aoede');
+      expect(getPreferredVoice()).toBe('ef_aoede');
+    });
+
+    it('devuelve default si el valor persistido NO está en KOKORO_VOICES (defensa contra corrupción)', () => {
+      localStorage.setItem('chagra:tts:voice', 'ef_unknown_alien_voice');
+      expect(getPreferredVoice()).toBe(DEFAULT_KOKORO_VOICE);
+    });
+
+    it('todas las voces de KOKORO_VOICES son selectables (sanity check)', () => {
+      for (const voice of KOKORO_VOICES) {
+        localStorage.setItem('chagra:tts:voice', voice.id);
+        expect(getPreferredVoice()).toBe(voice.id);
+      }
+    });
+  });
+
+  describe('setPreferredVoice', () => {
+    it('persiste voces válidas y devuelve true', () => {
+      expect(setPreferredVoice('ef_aoede')).toBe(true);
+      expect(localStorage.getItem('chagra:tts:voice')).toBe('ef_aoede');
+    });
+
+    it('rechaza voces no listadas y devuelve false', () => {
+      expect(setPreferredVoice('ef_basura')).toBe(false);
+      expect(localStorage.getItem('chagra:tts:voice')).toBeNull();
+    });
+
+    it('idempotencia: setear dos veces la misma voz funciona', () => {
+      setPreferredVoice('em_alex');
+      setPreferredVoice('em_alex');
+      expect(getPreferredVoice()).toBe('em_alex');
+    });
+  });
+
+  describe('getPreferredRate / setPreferredRate', () => {
+    it('getPreferredRate devuelve default si localStorage vacío', () => {
+      expect(getPreferredRate()).toBe(DEFAULT_KOKORO_RATE);
+    });
+
+    it('persiste rate válido', () => {
+      setPreferredRate(1.0);
+      expect(getPreferredRate()).toBeCloseTo(1.0);
+    });
+
+    it('rate fuera del rango se clamp al mín/máx', () => {
+      setPreferredRate(5.0);
+      expect(getPreferredRate()).toBeCloseTo(KOKORO_RATE_MAX);
+      setPreferredRate(0.1);
+      expect(getPreferredRate()).toBeCloseTo(KOKORO_RATE_MIN);
+    });
+
+    it('rate no-finito se rechaza', () => {
+      expect(setPreferredRate(NaN)).toBe(false);
+      expect(setPreferredRate(Infinity)).toBe(false);
+    });
+
+    it('valor corrupto en storage cae a default', () => {
+      localStorage.setItem('chagra:tts:rate', 'not-a-number');
+      expect(getPreferredRate()).toBe(DEFAULT_KOKORO_RATE);
+    });
+  });
+
+  describe('speakKokoro respeta preferencia persistida', () => {
+    it('sin voice explícito usa getPreferredVoice (default ef_dora cuando vacío)', async () => {
+      await speakKokoro('Hola mundo');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.voice).toBe('ef_dora');
+    });
+
+    it('sin voice explícito usa la voz preferida persistida', async () => {
+      setPreferredVoice('ef_kore');
+      await speakKokoro('Hola mundo');
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.voice).toBe('ef_kore');
+    });
+
+    it('voice explícito en options gana sobre la voz preferida (backwards compat)', async () => {
+      setPreferredVoice('ef_kore');
+      await speakKokoro('Hola mundo', { voice: 'em_alex' });
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.voice).toBe('em_alex');
+    });
+
+    it('voice explícito ef_dora también gana aunque sea el default (asegura no se "promueve" preferencia)', async () => {
+      setPreferredVoice('ef_aoede');
+      await speakKokoro('Hola', { voice: 'ef_dora' });
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+      expect(body.voice).toBe('ef_dora');
+    });
+  });
+});

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -6,6 +6,148 @@
  */
 
 /**
+ * Task #124 (2026-05-24): voces Kokoro curadas para español.
+ *
+ * Kokoro-82M expone 53 voces. Las que llevan prefix `ef_` (English Female)
+ * o `em_` (English Male) sintetizan español tomando el modelo fonético
+ * inglés como base, por lo que tienden a sonar con "acento gringo" al
+ * hablar castellano. El operador reportó que el default `ef_dora` no
+ * suena naturalmente colombiana en finca.
+ *
+ * NO podemos verificar acento real desde el cliente (eso es operator-
+ * action: probar samples y elegir). Curamos un set acotado de candidatas
+ * que la comunidad upstream (kokoro/VOICES.md) reporta como las más
+ * neutras / menos marcadamente anglo al sintetizar lenguas romances:
+ *
+ *   - `ef_dora`   : default histórico, voz femenina suave. Operador la
+ *                   reporta como "gringa". La dejamos como opción porque
+ *                   algunos usuarios ya se acostumbraron a su tono.
+ *   - `ef_aoede`  : reportada como una de las voces femeninas más
+ *                   neutras/musicales (Aoede = musa griega). Buen
+ *                   candidato para "acento más neutro hispano".
+ *   - `ef_kore`   : voz femenina firme, articulación clara. Buena para
+ *                   instrucciones de campo donde se necesita claridad
+ *                   por ruido ambiente (motosierra, viento).
+ *   - `em_alex`   : voz masculina cálida, articulación clara. Alternativa
+ *                   para operadores que prefieren voz masculina.
+ *
+ * Esta lista NO es exhaustiva; el operador puede experimentar con las
+ * otras voces ef_ / em_ en futuras iteraciones. Si descubrimos una voz
+ * específicamente colombiana en upstream, la agregamos acá.
+ */
+export const KOKORO_VOICES = Object.freeze([
+  {
+    id: 'ef_dora',
+    label: 'Dora (femenina, default)',
+    description: 'Voz por defecto. Tono suave. Puede sentirse con acento anglo.',
+    gender: 'femenina',
+  },
+  {
+    id: 'ef_aoede',
+    label: 'Aoede (femenina, más neutra)',
+    description: 'Voz femenina musical. Acento hispano más neutro según comunidad.',
+    gender: 'femenina',
+  },
+  {
+    id: 'ef_kore',
+    label: 'Kore (femenina, articulación firme)',
+    description: 'Voz femenina con articulación clara. Buena para campo con ruido.',
+    gender: 'femenina',
+  },
+  {
+    id: 'em_alex',
+    label: 'Alex (masculina, cálida)',
+    description: 'Voz masculina cálida. Alternativa al perfil femenino.',
+    gender: 'masculina',
+  },
+]);
+
+export const DEFAULT_KOKORO_VOICE = 'ef_dora';
+export const DEFAULT_KOKORO_RATE = 0.9;
+export const KOKORO_RATE_MIN = 0.85;
+export const KOKORO_RATE_MAX = 1.1;
+
+const STORAGE_KEY_VOICE = 'chagra:tts:voice';
+const STORAGE_KEY_RATE = 'chagra:tts:rate';
+
+const VALID_VOICE_IDS = new Set(KOKORO_VOICES.map((v) => v.id));
+
+/**
+ * Task #124: lee la voz Kokoro preferida persistida en localStorage.
+ * Fallback al default si:
+ *   - localStorage no disponible (SSR, jsdom estricto, etc.)
+ *   - clave vacía / null
+ *   - valor no está en KOKORO_VOICES (defensivo contra valores corruptos
+ *     o de futuras versiones que removamos una voz)
+ */
+export function getPreferredVoice() {
+  try {
+    if (typeof localStorage === 'undefined') return DEFAULT_KOKORO_VOICE;
+    const stored = localStorage.getItem(STORAGE_KEY_VOICE);
+    if (stored && VALID_VOICE_IDS.has(stored)) return stored;
+    return DEFAULT_KOKORO_VOICE;
+  } catch (_) {
+    return DEFAULT_KOKORO_VOICE;
+  }
+}
+
+/**
+ * Task #124: persiste la voz Kokoro preferida en localStorage.
+ * Valida contra KOKORO_VOICES antes de guardar — silenciosamente
+ * descarta ids desconocidos para evitar persistir basura.
+ *
+ * @returns {boolean} true si guardó, false si voz inválida o storage falló.
+ */
+export function setPreferredVoice(voiceId) {
+  if (!VALID_VOICE_IDS.has(voiceId)) return false;
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    localStorage.setItem(STORAGE_KEY_VOICE, voiceId);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Task #124: lee la velocidad TTS preferida (rate) persistida.
+ * Clamp a [KOKORO_RATE_MIN, KOKORO_RATE_MAX] para defensa contra valores
+ * corruptos. Fallback a DEFAULT_KOKORO_RATE.
+ */
+export function getPreferredRate() {
+  try {
+    if (typeof localStorage === 'undefined') return DEFAULT_KOKORO_RATE;
+    const stored = localStorage.getItem(STORAGE_KEY_RATE);
+    if (stored === null) return DEFAULT_KOKORO_RATE;
+    const parsed = Number.parseFloat(stored);
+    if (!Number.isFinite(parsed)) return DEFAULT_KOKORO_RATE;
+    if (parsed < KOKORO_RATE_MIN) return KOKORO_RATE_MIN;
+    if (parsed > KOKORO_RATE_MAX) return KOKORO_RATE_MAX;
+    return parsed;
+  } catch (_) {
+    return DEFAULT_KOKORO_RATE;
+  }
+}
+
+/**
+ * Task #124: persiste la velocidad TTS preferida.
+ * Clamp + valida finito antes de guardar.
+ *
+ * @returns {boolean} true si guardó, false si valor inválido o storage falló.
+ */
+export function setPreferredRate(rate) {
+  if (!Number.isFinite(rate)) return false;
+  const clamped = Math.min(KOKORO_RATE_MAX, Math.max(KOKORO_RATE_MIN, rate));
+  try {
+    if (typeof localStorage === 'undefined') return false;
+    localStorage.setItem(STORAGE_KEY_RATE, String(clamped));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
  * Limpia markdown del texto antes de mandarlo al TTS. Sin esto, kokoro y
  * SpeechSynthesis leen literal los caracteres de formato:
  *   "asterisco asterisco bold asterisco asterisco" en lugar de "bold",
@@ -219,7 +361,15 @@ export async function isKokoroAvailable() {
 }
 
 export async function speakKokoro(text, options = {}) {
-  const { voice = 'ef_dora', format = 'opus', lang = 'es' } = options;
+  // Task #124: si el caller NO pasa `voice` explícito, usar la voz
+  // preferida del operador desde localStorage (fallback ef_dora si
+  // no hay preferencia o storage inaccesible). Callers que pasan voice
+  // explícito (tests, casos avanzados) conservan ese override.
+  const {
+    voice = getPreferredVoice(),
+    format = 'opus',
+    lang = 'es',
+  } = options;
 
   stop();
 
@@ -335,4 +485,11 @@ export default {
   replayLast,
   getLastSpoken,
   init,
+  // Task #124: preferencias persistidas de voz Kokoro.
+  getPreferredVoice,
+  setPreferredVoice,
+  getPreferredRate,
+  setPreferredRate,
+  KOKORO_VOICES,
+  DEFAULT_KOKORO_VOICE,
 };


### PR DESCRIPTION
## Summary

Usuarios reportan que la voz default `ef_dora` "suena gringa hablando español". Esta PR introduce VoiceSelector UI con 4 voces curadas + persistencia localStorage + slider velocidad. Backwards-compat: default sigue siendo `ef_dora` (cambio opt-in).

## Voces curadas

| ID | Etiqueta | Razón |
|---|---|---|
| `ef_dora` | Dora (femenina, default) | Mantenida para no romper usuarios. |
| `ef_aoede` | Aoede (femenina, más neutra) | Reportada upstream como una de las más musicales/neutras. |
| `ef_kore` | Kore (femenina, articulación firme) | Mejor en ruido ambiente de finca. |
| `em_alex` | Alex (masculina, cálida) | Alternativa masculina. |

Si el operador descubre una voz específicamente colombiana en `hexgrad/kokoro/VOICES.md` upstream, añadirla al array `KOKORO_VOICES` es trivial.

## Cambios

- **`ttsService.js`**: `KOKORO_VOICES`, getters/setters `getPreferredVoice/setPreferredVoice/getPreferredRate/setPreferredRate`. `speakKokoro` resuelve `voice` a preferencia persistida cuando no se pasa override.
- **`VoiceSelector.jsx`** (nuevo): dropdown + comparador A/B con botón "▶ Probar" por voz + slider velocidad `[0.85, 1.1]` + botón Guardar con flash. Mobile-first.
- **`ProfileScreen.jsx`**: integra `<VoiceSelector />` debajo de `<AgentVoiceSection />`.
- **24 tests nuevos** (16 service + 8 component). Suite total 750/750.

## Persistencia

- `localStorage.chagra:tts:voice` (string id validado vs `KOKORO_VOICES`)
- `localStorage.chagra:tts:rate` (float clamp defensivo)

## Test plan

- [x] `npx vitest run` → **750/750 passed** (era 726)
- [x] `npx eslint . --max-warnings=0` → clean
- [x] `npm run build` → OK (ProfileScreen 24.80 KB / 6.52 KB gzip)
- [ ] (operador) Probar samples las 4 voces en producción, decidir si curar más