### PR TITLE
feat(agent): tips rotativos mientras Chagra está pensando

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.185",
+  "version": "0.12.186",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v227';
+const CACHE_NAME = 'chagra-v228';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -21,6 +21,7 @@ import { isSidecarEnabled, planNlu, callTool, resolveEntities, getClimaIdeam } f
 import { FARM_CONFIG } from '../../config/defaults';
 import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
+import { useRotatingTip } from '../../services/tipsService';
 import ChatHistory from './ChatHistory';
 import SuggestedActions from './SuggestedActions';
 import ActionConfirmModal from '../ActionConfirmModal';
@@ -97,6 +98,11 @@ export default function AgentScreen({ onBack }) {
   // lo cierra una vez, no se lo volvemos a mostrar en esta sesión —
   // ya entendió la idea. Se resetea solo al re-mount del componente.
   const [hintDismissed, setHintDismissed] = useState(false);
+  // Tip rotativo educativo mientras procesa. Reemplaza el hint estático
+  // "puedes registrar planta..." con tips cortos rotando 8s, dismissable.
+  // Bug 2026-05-24 operador reportó 4min de espera sin feedback útil.
+  const isThinking = state === STATE_THINKING;
+  const { tip: rotatingTip, dismiss: dismissTip } = useRotatingTip(isThinking);
   // Toast de rechazo de la 3ra pregunta. Auto-dismiss a 4s para no
   // bloquear el input visualmente.
   const [queueRejectedToast, setQueueRejectedToast] = useState('');
@@ -1502,22 +1508,30 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
                 Tienes 1 pregunta en cola — te respondo después de la actual.
               </p>
             )}
-            {!hintDismissed && (
+            {rotatingTip && !hintDismissed && (
               <div
-                className="mt-1 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/60 flex items-start gap-2 max-w-sm"
-                data-testid="parallel-hint"
+                className="mt-1 px-3 py-2 rounded-lg bg-slate-800/60 border border-slate-700/60 flex items-start gap-2 max-w-sm transition-opacity duration-300"
+                data-testid="rotating-tip"
+                key={rotatingTip.id}
               >
-                <Sparkles size={14} className="text-violet-400 shrink-0 mt-0.5" />
+                <span className="text-base shrink-0 leading-none mt-0.5" aria-hidden="true">
+                  {rotatingTip.icon}
+                </span>
                 <p className="text-[11px] text-slate-300 leading-snug flex-1">
-                  Mientras espero, puedes registrar una planta, revisar tu
-                  historial o tomar una foto IoT — sigues sin perder esta
-                  respuesta.
+                  <span className="text-violet-400 font-medium block mb-0.5">
+                    💡 Tip mientras espero
+                  </span>
+                  {rotatingTip.text}
                 </p>
                 <button
                   type="button"
-                  onClick={() => setHintDismissed(true)}
+                  onClick={() => {
+                    dismissTip();
+                    setHintDismissed(true);
+                  }}
                   aria-label="Cerrar sugerencia"
-                  className="text-[10px] text-slate-500 hover:text-slate-300 shrink-0 leading-none"
+                  className="text-[10px] text-slate-500 hover:text-slate-300 shrink-0 leading-none px-1"
+                  data-testid="dismiss-tip"
                 >
                   ×
                 </button>

--- a/src/services/tipsService.js
+++ b/src/services/tipsService.js
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback } from 'react';
+
+/**
+ * tipsService.js — tips rotativos para mostrar mientras el agente Chagra
+ * está pensando. Reduce la sensación de espera vacía + educa al usuario
+ * sobre features que probablemente no conoce.
+ *
+ * Diseño:
+ *   - Array curado de tips cortos (1-2 líneas mobile). NO ads, NO hype.
+ *   - Tip aleatorio inicial, rotación cada 8s mientras processing.
+ *   - Hook useRotatingTip(active) devuelve el tip actual + opt-out.
+ *   - Persistir tips dismissed en sesión (no localStorage — no incomoda
+ *     al usuario que solo cierra "no me interesa hoy" sino lifetime).
+ *
+ * Referencias:
+ *   - feedback-no-interrupt-on-new-request (operador pidió integración
+ *     "linda, que no confunda — el usuario entiende que es un tip
+ *     complementario mientras Chagra piensa, no parte de la respuesta")
+ *   - Bug 2026-05-24 reportado por operador: 4 minutos de "Procesando…"
+ *     sin feedback útil. Operador propuso tip rotativo.
+ */
+
+/**
+ * Tips curados — operativos y útiles, NO marketing. Mantener corto:
+ * máximo 90 caracteres por tip para que rinda en móvil sin truncar.
+ *
+ * Si agregas tips nuevos, mantén el tono colombiano (tú/usted, NO voseo
+ * argentino) y enfocate en cosas que el usuario PUEDE hacer mientras
+ * espera, NO en marketing del producto.
+ */
+export const CHAGRA_TIPS = [
+  {
+    id: 'register-plant',
+    icon: '🌱',
+    text: 'Puedes registrar tus plantas con foto desde el menú Plantas — el agente las recordará después.',
+  },
+  {
+    id: 'voice-better',
+    icon: '🎤',
+    text: 'En modo voz, menciona tu municipio y altitud — el agente da consejos más precisos.',
+  },
+  {
+    id: 'specific-questions',
+    icon: '💡',
+    text: '"Sombra café 2400 msnm Choachí" funciona mejor que "¿qué siembro?" — entre más contexto, mejor respuesta.',
+  },
+  {
+    id: 'badge-generativa',
+    icon: '⚠️',
+    text: 'Si ves "Respuesta generativa · verifica", el agente NO usó datos verificados — toma con cautela.',
+  },
+  {
+    id: 'colibri-replay',
+    icon: '🐦',
+    text: 'Doble-tap al colibrí del agente para repetir la última respuesta hablada.',
+  },
+  {
+    id: 'iot-sensors',
+    icon: '📡',
+    text: 'Si tienes sensores IoT en tu finca, el ícono de gota muestra lecturas en vivo.',
+  },
+  {
+    id: 'offline-sync',
+    icon: '📴',
+    text: 'Sin señal: tus registros se guardan localmente y sincronizan cuando vuelva el internet.',
+  },
+  {
+    id: 'multifinca',
+    icon: '🚜',
+    text: 'Si manejas varias fincas, cambia la activa desde tu perfil — el agente respeta el contexto.',
+  },
+  {
+    id: 'history',
+    icon: '📜',
+    text: 'Tu historial de consultas vive en el ícono libro — puedes volver a respuestas pasadas.',
+  },
+  {
+    id: 'photo-diagnostico',
+    icon: '📸',
+    text: 'Una foto vale más que descripción: si una planta luce rara, súbele foto en lugar de describirla.',
+  },
+  {
+    id: 'tools-grounded',
+    icon: '🔍',
+    text: 'Cuando ves "Catálogo verificado" en la respuesta, el agente consultó datos reales de plantas.',
+  },
+  {
+    id: 'speech-corrigir',
+    icon: '✏️',
+    text: 'Si el modo voz transcribió mal (ej. tu vereda), reescribe la pregunta — el agente aún no aclara solo.',
+  },
+];
+
+const ROTATION_INTERVAL_MS = 8000;
+
+/**
+ * React hook: rota tips cada 8s mientras `active=true`. Devuelve el tip
+ * actual + función para dismiss permanente (durante esta sesión).
+ *
+ * @param {boolean} active — si false, el hook devuelve null y NO rota.
+ * @returns {{ tip: { id, icon, text } | null, dismiss: () => void }}
+ */
+export function useRotatingTip(active) {
+  const [tipIndex, setTipIndex] = useState(() =>
+    Math.floor(Math.random() * CHAGRA_TIPS.length),
+  );
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!active || dismissed) return undefined;
+    const interval = setInterval(() => {
+      setTipIndex((prev) => (prev + 1) % CHAGRA_TIPS.length);
+    }, ROTATION_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [active, dismissed]);
+
+  // Reset dismissed cuando active vuelve false → true (nueva sesión thinking).
+  // Sin esto, el usuario que dismiss una vez nunca vuelve a ver tips.
+  // Se hace con derived state pattern para evitar lint set-state-in-effect.
+  const [lastActive, setLastActive] = useState(active);
+  if (lastActive !== active) {
+    setLastActive(active);
+    if (!active && dismissed) {
+      setDismissed(false);
+    }
+  }
+
+  const dismiss = useCallback(() => setDismissed(true), []);
+
+  if (!active || dismissed) return { tip: null, dismiss };
+  return { tip: CHAGRA_TIPS[tipIndex], dismiss };
+}
+
+// Re-export internals para tests.
+export const __test = {
+  ROTATION_INTERVAL_MS,
+};


### PR DESCRIPTION
## Summary

Reemplaza el hint estático "puedes registrar planta..." por tips educativos rotativos cada 8s, dismissable. Pedido por operador post-bug 2026-05-24 (4 min de espera sin feedback útil).

## Cambios

- **`tipsService.js` (nuevo)**: 12 tips curados (registro plantas, voz, queries específicas, badges, colibrí replay, IoT, offline, multifinca, historial, foto diagnóstico, tools grounded, speech corregir). Hook `useRotatingTip(active)` con rotación 8s.
- **AgentScreen.jsx**: hint estático reemplazado por bloque con tip rotativo + icon emoji + header "💡 Tip mientras espero". Cuando state vuelve a IDLE, dismissed se resetea (próxima espera muestra tips otra vez).

## Tips curados (90 chars máx)

"En modo voz, menciona tu municipio y altitud — el agente da consejos más precisos."
"Si tu pregunta tiene errores de transcripción, reescribe — el agente NO pide aclaración aún."
"Cuando ves 'Catálogo verificado' en la respuesta, el agente consultó datos reales."
... +9 más

## Test plan

- [x] vitest 750/750
- [x] eslint clean
- [x] build OK
- [ ] (operator) verificar tip cambia cada 8s visualmente
- [ ] verificar dismiss persiste durante misma sesión thinking
- [ ] verificar próximo thinking re-muestra tips