### PR TITLE
feat(auth): OAuth Auth Code + PKCE implementation (#46)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.189",
+  "version": "0.12.190",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v231';
+const CACHE_NAME = 'chagra-v232';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/authService.test.js
+++ b/src/services/__tests__/authService.test.js
@@ -1,0 +1,353 @@
+/* global global */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+    generateCodeVerifier,
+    generateCodeChallenge,
+    initiateAuthorizationCodeFlow,
+    exchangeCodeForToken,
+    authenticateUser,
+    generateOAuthState,
+    handleOAuthCallback,
+} from '../authService';
+
+// Mock localforage
+vi.mock('localforage', () => ({
+    default: {
+        setItem: vi.fn(),
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+    },
+}));
+
+import localforage from 'localforage';
+
+// Mock window.location
+const mockLocation = { href: '' };
+Object.defineProperty(window, 'location', {
+    writable: true,
+    value: mockLocation,
+});
+
+describe('authService — OAuth PKCE flow', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockLocation.href = '';
+    });
+
+    describe('generateCodeVerifier', () => {
+        it('genera un code_verifier válido (43-128 caracteres)', () => {
+            const verifier = generateCodeVerifier();
+            expect(verifier).toBeTruthy();
+            expect(verifier.length).toBeGreaterThanOrEqual(43);
+            expect(verifier.length).toBeLessThanOrEqual(128);
+            // Solo caracteres base64url válidos
+            expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+        });
+
+        it('genera valores únicos en cada llamada', () => {
+            const verifier1 = generateCodeVerifier();
+            const verifier2 = generateCodeVerifier();
+            expect(verifier1).not.toBe(verifier2);
+        });
+    });
+
+    describe('generateCodeChallenge', () => {
+        it('genera un code_challenge válido SHA256 base64url', async () => {
+            const verifier = 'test_verifier_123';
+            const challenge = await generateCodeChallenge(verifier);
+            
+            expect(challenge).toBeTruthy();
+            expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+            // No debe tener padding (=)
+            expect(challenge).not.toContain('=');
+        });
+
+        it('produce el mismo challenge para el mismo verifier', async () => {
+            const verifier = 'consistent_verifier';
+            const challenge1 = await generateCodeChallenge(verifier);
+            const challenge2 = await generateCodeChallenge(verifier);
+            
+            expect(challenge1).toBe(challenge2);
+        });
+    });
+
+    describe('generateOAuthState', () => {
+        it('genera un state válido para CSRF protection', () => {
+            const state = generateOAuthState();
+            
+            expect(state).toBeTruthy();
+            expect(state.length).toBeGreaterThan(0);
+            expect(state).toMatch(/^[A-Za-z0-9_-]+$/);
+        });
+
+        it('genera valores únicos en cada llamada', () => {
+            const state1 = generateOAuthState();
+            const state2 = generateOAuthState();
+            expect(state1).not.toBe(state2);
+        });
+    });
+
+    describe('initiateAuthorizationCodeFlow', () => {
+        it('guarda code_verifier y state en localforage', async () => {
+            const testState = 'test_state_123';
+            
+            await initiateAuthorizationCodeFlow(testState);
+            
+            expect(localforage.setItem).toHaveBeenCalledWith('oauth_code_verifier', expect.any(String));
+            expect(localforage.setItem).toHaveBeenCalledWith('oauth_state', testState);
+        });
+
+        it('redirige a la URL de autorización correcta', async () => {
+            const testState = 'test_state_456';
+
+            await initiateAuthorizationCodeFlow(testState);
+
+            expect(mockLocation.href.length).toBeGreaterThan(0);
+            const redirectUrl = mockLocation.href;
+            expect(redirectUrl).toContain('/oauth/authorize');
+            expect(redirectUrl).toContain('response_type=code');
+            expect(redirectUrl).toContain('code_challenge=');
+            expect(redirectUrl).toContain('code_challenge_method=S256');
+            expect(redirectUrl).toContain(`state=${testState}`);
+        });
+    });
+
+    describe('exchangeCodeForToken', () => {
+        beforeEach(() => {
+            // Mock fetch global
+            global.fetch = vi.fn();
+        });
+
+        it('intercambia código por token exitosamente', async () => {
+            const mockCode = 'auth_code_123';
+            const mockState = 'state_123';
+            const mockVerifier = 'verifier_abc';
+
+            localforage.getItem.mockImplementation((key) => {
+                if (key === 'oauth_state') return mockState;
+                if (key === 'oauth_code_verifier') return mockVerifier;
+                return null;
+            });
+
+            global.fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                headers: {
+                    get: (name) => name === 'content-type' ? 'application/json' : null,
+                },
+                json: async () => ({
+                    access_token: 'token_xyz',
+                    refresh_token: 'refresh_xyz',
+                    expires_in: 3600,
+                }),
+            });
+
+            const result = await exchangeCodeForToken(mockCode, mockState);
+
+            expect(result.success).toBe(true);
+            expect(localforage.setItem).toHaveBeenCalledWith('farmos_access_token', 'token_xyz');
+            expect(localforage.setItem).toHaveBeenCalledWith('farmos_refresh_token', 'refresh_xyz');
+            expect(localforage.removeItem).toHaveBeenCalledWith('oauth_code_verifier');
+            expect(localforage.removeItem).toHaveBeenCalledWith('oauth_state');
+        });
+
+        it('rechaza states que no coinciden (CSRF protection)', async () => {
+            const mockCode = 'auth_code_123';
+            const mockState = 'state_123';
+            const differentState = 'state_different';
+
+            localforage.getItem.mockImplementation((key) => {
+                if (key === 'oauth_state') return differentState;
+                return null;
+            });
+
+            const result = await exchangeCodeForToken(mockCode, mockState);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('State inválido');
+        });
+
+        it('falla si no hay code_verifier', async () => {
+            const mockCode = 'auth_code_123';
+            const mockState = 'state_123';
+
+            localforage.getItem.mockImplementation((key) => {
+                if (key === 'oauth_state') return mockState;
+                if (key === 'oauth_code_verifier') return null;
+                return null;
+            });
+
+            const result = await exchangeCodeForToken(mockCode, mockState);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Code verifier no encontrado');
+        });
+
+        it('maneja errores de red', async () => {
+            const mockCode = 'auth_code_123';
+            const mockState = 'state_123';
+            const mockVerifier = 'verifier_abc';
+
+            localforage.getItem.mockImplementation((key) => {
+                if (key === 'oauth_state') return mockState;
+                if (key === 'oauth_code_verifier') return mockVerifier;
+                return null;
+            });
+
+            global.fetch.mockRejectedValue(new Error('Network error'));
+
+            const result = await exchangeCodeForToken(mockCode, mockState);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Network error');
+        });
+
+        it('maneja respuestas no-JSON del servidor', async () => {
+            const mockCode = 'auth_code_123';
+            const mockState = 'state_123';
+            const mockVerifier = 'verifier_abc';
+
+            localforage.getItem.mockImplementation((key) => {
+                if (key === 'oauth_state') return mockState;
+                if (key === 'oauth_code_verifier') return mockVerifier;
+                return null;
+            });
+
+            global.fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                headers: {
+                    get: (name) => name === 'content-type' ? 'text/html' : null,
+                },
+            });
+
+            const result = await exchangeCodeForToken(mockCode, mockState);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Backend FarmOS no disponible');
+        });
+    });
+
+    describe('authenticateUser (Password Grant - DEPRECATED)', () => {
+        beforeEach(() => {
+            global.fetch = vi.fn();
+        });
+
+        it('autentica exitosamente con password grant (legacy)', async () => {
+            global.fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                headers: {
+                    get: (name) => name === 'content-type' ? 'application/json' : null,
+                },
+                json: async () => ({
+                    access_token: 'token_legacy',
+                    refresh_token: 'refresh_legacy',
+                    expires_in: 3600,
+                }),
+            });
+
+            const result = await authenticateUser('testuser', 'testpass');
+
+            expect(result.success).toBe(true);
+            expect(result.deprecation).toContain('Password Grant será removido');
+            expect(localforage.setItem).toHaveBeenCalledWith('farmos_access_token', 'token_legacy');
+        });
+
+        it('maneja credenciales inválidas', async () => {
+            global.fetch.mockResolvedValue({
+                ok: false,
+                status: 401,
+            });
+
+            const result = await authenticateUser('testuser', 'wrongpass');
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Error de Autenticación');
+        });
+
+        it('maneja errores de red', async () => {
+            global.fetch.mockRejectedValue(new Error('Connection failed'));
+
+            const result = await authenticateUser('testuser', 'testpass');
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Connection failed');
+        });
+    });
+
+    describe('handleOAuthCallback', () => {
+        beforeEach(() => {
+            global.fetch = vi.fn();
+        });
+
+        it('procesa callback exitoso', async () => {
+            const mockCode = 'code_123';
+            const mockState = 'state_123';
+            const mockVerifier = 'verifier_abc';
+
+            localforage.getItem.mockImplementation((key) => {
+                if (key === 'oauth_state') return mockState;
+                if (key === 'oauth_code_verifier') return mockVerifier;
+                return null;
+            });
+
+            global.fetch.mockResolvedValue({
+                ok: true,
+                status: 200,
+                headers: {
+                    get: (name) => name === 'content-type' ? 'application/json' : null,
+                },
+                json: async () => ({
+                    access_token: 'token_callback',
+                    refresh_token: 'refresh_callback',
+                    expires_in: 3600,
+                }),
+            });
+
+            const params = new URLSearchParams({
+                code: mockCode,
+                state: mockState,
+            });
+
+            const result = await handleOAuthCallback(params);
+
+            expect(result.success).toBe(true);
+        });
+
+        it('maneja error en callback', async () => {
+            const params = new URLSearchParams({
+                error: 'access_denied',
+                error_description: 'User denied access',
+            });
+
+            const result = await handleOAuthCallback(params);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('User denied access');
+        });
+
+        it('rechaza callback sin código', async () => {
+            const params = new URLSearchParams({
+                state: 'state_123',
+            });
+
+            const result = await handleOAuthCallback(params);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Parámetros inválidos');
+        });
+
+        it('rechaza callback sin state', async () => {
+            const params = new URLSearchParams({
+                code: 'code_123',
+            });
+
+            const result = await handleOAuthCallback(params);
+
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Parámetros inválidos');
+        });
+    });
+});

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,5 +1,6 @@
 /**
- * authService — Autenticación OAuth2 password-credential contra FarmOS.
+ * authService — Autenticación OAuth2 contra FarmOS.
+ * Soporta Authorization Code + PKCE (recomendado) y Password Grant (legacy).
  * Persiste tokens en localforage (offline-first).
  *
  * @module authService
@@ -10,9 +11,163 @@ import { clearActiveTenantId } from './tenantContext';
 
 const FARMOS_URL = import.meta.env.VITE_FARMOS_URL;
 const CLIENT_ID = import.meta.env.VITE_FARMOS_CLIENT_ID;
+const REDIRECT_URI = `${window.location.origin}/callback`;
 
+/**
+ * DEPRECATION NOTICE: Password grant será removido después de 2026-06-25.
+ * Usar Authorization Code + PKCE en su lugar.
+ */
+const PASSWORD_GRANT_DEPRECATION_DATE = new Date('2026-06-25');
+const PASSWORD_GRANT_DEPRECATED = Date.now() > PASSWORD_GRANT_DEPRECATION_DATE.getTime();
+
+/**
+ * Genera un code_verifier random para PKCE (43-128 caracteres).
+ * @returns {string} code_verifier en base64url sin padding
+ */
+export const generateCodeVerifier = () => {
+    const array = new Uint8Array(32);
+    crypto.getRandomValues(array);
+    return base64UrlEncode(array);
+};
+
+/**
+ * Genera el code_challenge SHA256 para PKCE.
+ * @param {string} codeVerifier
+ * @returns {Promise<string>} code_challenge en base64url sin padding
+ */
+export const generateCodeChallenge = async (codeVerifier) => {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(codeVerifier);
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    return base64UrlEncode(new Uint8Array(hash));
+};
+
+/**
+ * Helper para codificar en base64url sin padding (RFC 4648 §5).
+ * @param {Uint8Array} buffer
+ * @returns {string}
+ */
+const base64UrlEncode = (buffer) => {
+    const base64 = btoa(String.fromCharCode(...buffer));
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+};
+
+/**
+ * Inicia el flujo Authorization Code + PKCE redirigiendo a FarmOS.
+ * @param {string} state - string aleatorio para CSRF protection
+ */
+export const initiateAuthorizationCodeFlow = async (state) => {
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+    // Persistir code_verifier para usarlo en el callback
+    await localforage.setItem('oauth_code_verifier', codeVerifier);
+    await localforage.setItem('oauth_state', state);
+
+    const params = new URLSearchParams({
+        response_type: 'code',
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT_URI,
+        state: state,
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+        scope: 'farm_manager',
+    });
+
+    const authUrl = `${FARMOS_URL}/oauth/authorize?${params.toString()}`;
+    window.location.href = authUrl;
+};
+
+/**
+ * Intercambia el authorization code por tokens (PKCE flow).
+ * @param {string} code - authorization code del callback
+ * @param {string} state - state del callback para validación
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export const exchangeCodeForToken = async (code, state) => {
+    console.log('[Auth] Intercambiando code por token (PKCE)');
+
+    // Validar state
+    const savedState = await localforage.getItem('oauth_state');
+    if (state !== savedState) {
+        return { success: false, error: 'State inválido. Posible ataque CSRF.' };
+    }
+
+    const codeVerifier = await localforage.getItem('oauth_code_verifier');
+    if (!codeVerifier) {
+        return { success: false, error: 'Code verifier no encontrado. Flujo inválido.' };
+    }
+
+    const url = `${FARMOS_URL}/oauth/token`;
+    const payload = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code,
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT_URI,
+        code_verifier: codeVerifier,
+    });
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: payload.toString(),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Error de Autenticación: ${response.status}`);
+        }
+
+        const contentType = response.headers.get('content-type');
+        if (!contentType || !contentType.includes('json')) {
+            throw new Error('Backend FarmOS no disponible (modo instalacion detectado)');
+        }
+
+        const data = await response.json();
+
+        // Almacenamiento Offline-First del Token JWT
+        await localforage.setItem('farmos_access_token', data.access_token);
+        await localforage.setItem('farmos_refresh_token', data.refresh_token);
+        await localforage.setItem('farmos_token_expiry', Date.now() + (data.expires_in * 1000));
+
+        // Limpiar PKCE state
+        await localforage.removeItem('oauth_code_verifier');
+        await localforage.removeItem('oauth_state');
+
+        return { success: true };
+    } catch (error) {
+        console.error("Fallo en el intercambio del token:", error);
+        return { success: false, error: error.message };
+    }
+};
+
+/**
+ * Autenticación OAuth2 Password Grant (LEGACY - DEPRECATED).
+ *
+ * ⚠️ DEPRECATION NOTICE: Este método será removido después de 2026-06-25.
+ * Usar initiateAuthorizationCodeFlow + exchangeCodeForToken en su lugar.
+ *
+ * @param {string} username
+ * @param {string} password
+ * @returns {Promise<{success: boolean, error?: string, deprecation?: string}>}
+ */
 export const authenticateUser = async (username, password) => {
-    console.log('[Auth] Intentando login para:', username);
+    console.log('[Auth] Intentando login password grant (DEPRECATED) para:', username);
+
+    // Aviso de deprecation
+    const daysUntilDeprecation = Math.max(0, Math.ceil(
+        (PASSWORD_GRANT_DEPRECATION_DATE - Date.now()) / (1000 * 60 * 60 * 24)
+    ));
+
+    if (PASSWORD_GRANT_DEPRECATED) {
+        return {
+            success: false,
+            error: 'Password Grant ha sido removido. Usa Authorization Code + PKCE.'
+        };
+    }
+
     const url = `${FARMOS_URL}/oauth/token`;
 
     const payload = new URLSearchParams({
@@ -48,7 +203,12 @@ export const authenticateUser = async (username, password) => {
         await localforage.setItem('farmos_refresh_token', data.refresh_token);
         await localforage.setItem('farmos_token_expiry', Date.now() + (data.expires_in * 1000));
 
-        return { success: true };
+        return {
+            success: true,
+            deprecation: daysUntilDeprecation > 0
+                ? `Password Grant será removido en ${daysUntilDeprecation} días. Migra a Authorization Code + PKCE.`
+                : undefined
+        };
     } catch (error) {
         console.error("Fallo en la negociación del token:", error);
         return { success: false, error: error.message };
@@ -108,4 +268,36 @@ export const logoutUser = async () => {
 export const isAuthenticated = async () => {
     const token = await getAccessToken();
     return !!token;
+};
+
+/**
+ * Genera un state random para protección CSRF en OAuth flow.
+ * @returns {string} state en base64url
+ */
+export const generateOAuthState = () => {
+    const array = new Uint8Array(16);
+    crypto.getRandomValues(array);
+    return base64UrlEncode(array);
+};
+
+/**
+ * Procesa el callback de OAuth desde la URL (después de redirect).
+ * @param {URLSearchParams} params - URL search params del callback
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export const handleOAuthCallback = async (params) => {
+    const code = params.get('code');
+    const state = params.get('state');
+    const error = params.get('error');
+
+    if (error) {
+        const errorDescription = params.get('error_description') || error;
+        return { success: false, error: `Error de autorización: ${errorDescription}` };
+    }
+
+    if (!code || !state) {
+        return { success: false, error: 'Parámetros inválidos en callback' };
+    }
+
+    return await exchangeCodeForToken(code, state);
 };


### PR DESCRIPTION
## Summary

Implementa el flujo de Authorization Code + PKCE para autenticación OAuth2 en Chagra, manteniendo backward compatibility con Password Grant durante 30 días (deprecation until 2026-06-25).

### Cambios implementados

1. **Nuevas funciones PKCE en authService.js:**
   - generateCodeVerifier(): Genera code_verifier random (43-128 caracteres)
   - generateCodeChallenge(): Genera code_challenge SHA256 base64url
   - initiateAuthorizationCodeFlow(): Inicia flujo OAuth con redirect a /authorize
   - exchangeCodeForToken(): Intercambia authorization code por tokens
   - generateOAuthState(): Genera state para CSRF protection
   - handleOAuthCallback(): Procesa callbacks OAuth desde URL params

2. **Modificación de authenticateUser() (Password Grant):**
   - Añade warning de deprecation (remover después de 2026-06-25)
   - Retorna campo deprecation con aviso al operador
   - Bloquea uso si la fecha de deprecation ha pasado

3. **Seguridad mejorada:**
   - Validación de state para protección CSRF
   - Code verifier stored en localforage durante el flujo
   - Limpieza automática de state después del exchange
   - Manejo robusto de errores de red/JSON

4. **Tests unitarios (authService.test.js):**
   - 20 tests cubriendo PKCE flow completo
   - Validación de code_verifier y code_challenge
   - CSRF protection (state validation)
   - Error handling (network, JSON parse, invalid credentials)
   - Backward compatibility con Password Grant
   - Callback handling con error parameters

### Arquitectura

El flujo PKCE implementado sigue RFC 7636:
1. Generar code_verifier random (cryptographically secure)
2. Calcular code_challenge = SHA256(code_verifier) (base64url)
3. Redirect a /oauth/authorize con:
   - response_type=code
   - code_challenge + code_challenge_method=S256
   - state (CSRF protection)
4. Backend FarmOS redirect a /callback con code
5. Exchange code + code_verifier por tokens en /oauth/token

## Test plan

### Tests unitarios (vitest)
npm run test:unit -- src/services/__tests__/authService.test.js
# ✅ 20 tests passed

### Linting
npm run lint
# ✅ No errors (usando /* global global */ para vitest)

### Build
npm run build
# ✅ Build successful (vite 8.0.0)

### Cobertura de tests
- ✅ generateCodeVerifier (2 tests)
- ✅ generateCodeChallenge (2 tests)
- ✅ generateOAuthState (2 tests)
- ✅ initiateAuthorizationCodeFlow (2 tests)
- ✅ exchangeCodeForToken (5 tests)
- ✅ authenticateUser (3 tests)
- ✅ handleOAuthCallback (4 tests)

## MCP tools usados
No se usaron MCP tools para este task (implementación puramente técnica de auth).

## Riesgos conocidos

1. **Deprecation de Password Grant:** Los clientes existentes que usen password grant verán un warning en la respuesta. Después de 2026-06-25, el flujo será bloqueado completamente.

2. **Storage localforage:** El code_verifier se persiste en localforage durante el flujo. Si el usuario cierra el browser antes del callback, el siguiente intento de login fallará con "Code verifier no encontrado".

3. **Dependencia de FarmOS OAuth:** El flujo asume que FarmOS soporta Authorization Code + PKCE en /oauth/authorize y /oauth/token. Si el backend no está actualizado, el flujo fallará.

4. **URL callback hardcoded:** El redirect_uri usa window.location.origin/callback. Si la PWA se sirve desde un path diferente, el flujo fallará.

## Backward compatibility

✅ **Password Grant sigue funcional** (con warnings) hasta 2026-06-25.
- Los clients existentes no se rompen
- La función authenticateUser() mantiene la misma firma
- Se añade campo deprecation en la respuesta con warning

## Escalado a Opus

❌ **NO requiere escalado** - Este cambio es puramente técnico y no afecta decisiones arquitectónicas mayores. Es una implementación estándar de OAuth PKCE que mejora security sin cambiar contratos públicos.

## DEPRECATION-NOTICE

Password Grant será removido después de 2026-06-25.
Migrate clients a Authorization Code + PKCE usando:
- initiateAuthorizationCodeFlow(state) para iniciar el flujo
- handleOAuthCallback(params) para procesar el callback
