### PR TITLE
fix(test): debug Offline-first E2E (#171)

### DIFF
--- a/docs/known-issues/offline-first-e2e.md
+++ b/docs/known-issues/offline-first-e2e.md
@@ -1,0 +1,119 @@
+# Offline-first E2E — Known Issues
+
+## Issue: ECONNREFUSED en tests E2E sin mocks adecuados
+
+**Fecha**: 2026-05-25  
+**Workflow**: Playwright E2E  
+**Run ID**: 26384011054  
+**Branch**: `glm/171-playwright-mock-sidecar-v2` (never merged)
+
+### Causa raíz
+
+El test `anti-halluc-mock-sidecar.spec.js` falló con múltiples errores `ECONNREFUSED` porque intentaba conectarse a servicios backend que no estaban disponibles en el entorno de CI:
+
+```
+AggregateError [ECONNREFUSED]: 
+- /api/mcp/agro/resolve-entities
+- /oauth/token  
+- /api/log/seeding, /api/log/harvest, /api/log/input
+- /api/ollama/api/generate
+```
+
+**Test específico que falló**:
+```javascript
+// tests/anti-halluc-mock-sidecar.spec.js:140
+const fab = page.locator('[data-testid="agent-fab"], button[aria-label*="agente" i]').first();
+await expect(fab).toBeVisible({ timeout: 5000 }); // ❌ Timeout: element(s) not found
+```
+
+### Diagnóstico
+
+El test no incluía los mocks necesarios para:
+1. **OAuth2 authentication**: Endpoint `/oauth/token` debía ser mockeado
+2. **Backend APIs**: Todos los endpoints `/api/**` debían ser mockeados o bloqueados
+3. **MCP services**: `/api/mcp/agro/*` debían tener respuestas simuladas
+4. **LLM services**: `/api/ollama/*` debían ser mockeados
+
+### Patrón correcto (referencia)
+
+El test `tests/offline.spec.js` implementa correctamente los mocks:
+
+```javascript
+test.beforeEach(async ({ context }) => {
+  // ✅ Mock OAuth2 token
+  await context.route('**/oauth/token', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'e2e-fake-access',
+        refresh_token: 'e2e-fake-refresh',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }),
+    })
+  );
+
+  // ✅ Bloquear tráfico al backend real
+  await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+});
+```
+
+### Recomendaciones
+
+#### Para nuevos tests E2E
+
+1. **Siempre incluir mocks de OAuth2**:
+   ```javascript
+   await context.route('**/oauth/token', (route) => route.fulfill({...}));
+   ```
+
+2. **Decidir estrategia para `/api/**`**:
+   - **Opción A**: Bloquear todo el tráfico al backend (tests offline-first)
+     ```javascript
+     await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+     ```
+   - **Opción B**: Mockear respuestas específicas
+     ```javascript
+     await context.route('**/api/mcp/agro/resolve-entities', (route) => 
+       route.fulfill({ body: JSON.stringify({...mockData...}) })
+     );
+     ```
+
+3. **Validar que el UI se renderiza sin dependencias externas**:
+   ```javascript
+   // Esperar a que el UI principal esté listo
+   await expect(page.getByText('Cola de tareas')).toBeVisible({ timeout: 15_000 });
+   ```
+
+#### Para debugging de failures
+
+1. **Revisar logs de GitHub Actions**:
+   ```bash
+   gh run view <run-id> --log-failed | grep -A 30 "ECONNREFUSED"
+   ```
+
+2. **Verificar que los tests no tienen dependencias ocultas**:
+   - Imports dinámicos que pueden fallar offline
+   - WebSockets o SSEs que requieren conexión
+   - llamadas `fetch()` o `XMLHttpRequest` no mockeadas
+
+3. **Usar timeouts generosos**:
+   ```javascript
+   await expect(element).toBeVisible({ timeout: 15_000 }); // CI es más lento
+   ```
+
+### Estado
+
+✅ **Resuelto**: El test problematico `anti-halluc-mock-sidecar.spec.js` fue removido en el PR que nunca se hizo merge. Los tests actuales en `tests/offline.spec.js` implementan correctamente el patrón de mocks.
+
+### Referencias
+
+- Test correcto: `tests/offline.spec.js`
+- Wiki Playwright network mocking: https://playwright.dev/docs/network
+- ADR sobre offline-first: (referencia al ADR correspondiente si existe)
+
+---
+
+**Última revisión**: 2026-05-26  
+**Responsable**: GLM-4.6 (TASK #171)

--- a/tests/e2e-mock-validation.spec.js
+++ b/tests/e2e-mock-validation.spec.js
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Test de verificación de mocks para E2E
+ * 
+ * Este test asegura que los mocks de red estén correctamente configurados
+ * para evitar fallos tipo ECONNREFUSED en el entorno de CI.
+ * 
+ * Referencia: docs/known-issues/offline-first-e2e.md
+ */
+
+test.describe('Validación de mocks E2E — prevención de ECONNREFUSED', () => {
+  test('verifica que OAuth2 mock está configurado correctamente', async ({ context }) => {
+    // Configurar mock de OAuth2 (patrón estándar)
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-fake-access',
+          refresh_token: 'e2e-fake-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+    );
+
+    const page = await context.newPage();
+    
+    // Verificar que el mock responde correctamente
+    const response = await page.goto('https://example.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.access_token).toBe('e2e-fake-access');
+    expect(body.token_type).toBe('Bearer');
+  });
+
+  test('verifica que /api/** routes están configurados (block o mock)', async ({ context }) => {
+    let mockConfigured = false;
+
+    // Configurar mock para /api/** (bloqueo es aceptable para tests offline-first)
+    await context.route('**/api/**', (route) => {
+      mockConfigured = true;
+      route.abort('blockedbyclient');
+    });
+
+    const page = await context.newPage();
+    
+    // Intentar hacer request a /api/ endpoint
+    try {
+      await page.goto('https://example.com/api/test', { timeout: 5000 });
+    } catch (_error) {
+      // Expected: request aborted por el mock
+    }
+
+    // Verificar que el mock fue invocado
+    expect(mockConfigured).toBe(true);
+  });
+
+  test('verifica que UI puede cargar sin dependencias externas', async ({ context }) => {
+    // Configurar todos los mocks necesarios
+    await context.route('**/oauth/token', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-fake-access',
+          refresh_token: 'e2e-fake-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+      })
+    );
+
+    // Bloquear tráfico al backend
+    await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+
+    // Permitir recursos estáticos (JS, CSS, imágenes)
+    await context.route('**/src/**', (route) => route.continue());
+    await context.route('**/*.js', (route) => route.continue());
+    await context.route('**/*.css', (route) => route.continue());
+
+    const page = await context.newPage();
+    
+    // Navegar a la app
+    await page.goto('/');
+
+    // Verificar que la página carga sin errores de red
+    const errors = [];
+    page.on('pageerror', (error) => {
+      errors.push(error.message);
+    });
+
+    // Esperar a que el UI principal esté visible
+    await expect(page.getByLabel(/usuario/i)).toBeVisible({ timeout: 15_000 });
+
+    // Verificar que no hubo errores críticos de carga
+    const networkErrors = errors.filter(e => 
+      e.includes('ECONNREFUSED') || 
+      e.includes('Failed to fetch') ||
+      e.includes('Network request failed')
+    );
+    
+    expect(networkErrors).toHaveLength(0);
+  });
+
+  test('verifica timeout generoso para CI', async () => {
+    // Este test solo documenta el patrón correcto de timeouts
+    // CI puede ser significativamente más lento que desarrollo local
+    
+    const recommendedTimeouts = {
+      pageLoad: 30_000,      // 30 segundos para navegación
+      elementVisible: 15_000, // 15 segundos para encontrar elementos
+      networkIdle: 10_000,    // 10 segundos para que la red se estabilice
+    };
+
+    // Verificar que los timeouts sean generosos
+    expect(recommendedTimeouts.elementVisible).toBeGreaterThanOrEqual(15_000);
+    expect(recommendedTimeouts.pageLoad).toBeGreaterThanOrEqual(30_000);
+  });
+});


### PR DESCRIPTION
## Summary

Debug del fallo en E2E workflow identificado en el run #26384011054 (branch `glm/171-playwright-mock-sidecar-v2`).

## Cambios

1. **Documentación de causa raíz**: `docs/known-issues/offline-first-e2e.md`
   - Análisis completo del fallo ECONNREFUSED en tests E2E
   - Identificación del test problemático: `anti-halluc-mock-sidecar.spec.js`
   - Patrones correctos de mocks (referencia: `tests/offline.spec.js`)
   - Recomendaciones para evitar fallos similares

2. **Test de validación de mocks**: `tests/e2e-mock-validation.spec.js`
   - Verifica que OAuth2 mock esté configurado correctamente
   - Valida que `/api/**` routes estén mockeadas o bloqueadas
   - Test de carga de UI sin dependencias externas
   - Documentación de timeouts apropiados para CI

## Causa raíz identificada

El test `anti-halluc-mock-sidecar.spec.js` falló por falta de mocks:
- `/oauth/token` → ECONNREFUSED
- `/api/mcp/agro/resolve-entities` → ECONNREFUSED
- `/api/log/*` → ECONNREFUSED
- `/api/ollama/api/generate` → ECONNREFUSED

El botón del agente `[data-testid="agent-fab"]` nunca aparecía porque la app no podía inicializarse sin los servicios backend.

## Test plan

- ✅ `npm run test:unit` → 817 tests pasan
- ✅ `npm run lint` → 0 errores, 0 warnings
- ✅ `npm run build` → build exitoso (2.37s)
- ℹ️ `npm run tsc:check` → errores preexistentes en proyecto (leaflet, React components)

## MCP tools utilizados

- `gh run list` — identificar últimos runs del workflow
- `gh run view <id> --log-failed` — obtener logs fallidos
- `grep` — filtrar errores ECONNREFUSED específicos

## Riesgos conocidos

- **Riesgo bajo**: Cambios son solo documentación + test de validación
- **No afecta**: código de producción, dependencias, UI existente
- **Test nuevo**: `e2e-mock-validation.spec.js` sigue patrones establecidos en `tests/offline.spec.js`

## Estado

✅ **Resuelto**: El test problemático fue removido en un PR anterior que nunca se hizo merge. Los tests actuales implementan correctamente el patrón de mocks.

## Referencias

- Run fallido: #26384011054
- Test correcto: `tests/offline.spec.js`  
- Documentación: `docs/known-issues/offline-first-e2e.md`
