### PR TITLE
chore(release): v0.13.0 OSS->Pro cutover step 4 (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Todas las novedades user-facing de Chagra. Formato basado en [Keep a Changelog](
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-26
+
+### Changed
+- **OSS->Pro cutover step 4**: Preparación de arquitectura para separación OSS/Pro. Separación de MCP servers (`chagra-dev-mcp` vs `chagra-agro-mcp`) para evitar leak de info interna en PWA. (ADR-044, task #75)
+
 ### Added
 - **Manual rediseñado**: 3 sub-vistas grandes (voz / uso / aprende sembrando) en lugar de 12 secciones planas apiladas. Tap targets ≥80px en home, tono `tú` cercano, anti-ladrillo. (PR #202, queue/039 + UX feedback 2026-05-08)
 - **Ayuda interactiva por especie**: accordion individual para lechuga, fresa, tomate chonto. Aguacate y café aparecen con badge `Por agregar` + nota educativa contextual sobre cómo contribuir corpus desde Bitácora. (PR #201)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.12.190",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Release v0.13.0: Bump de versión + CHANGELOG update para OSS->Pro cutover step 4.

### Cambios
- **package.json**: versión bump de 0.12.190 → 0.13.0
- **CHANGELOG.md**: Nueva sección [0.13.0] - 2026-05-26 documentando:
  - OSS->Pro cutover step 4: Preparación de arquitectura para separación OSS/Pro
  - Separación de MCP servers (chagra-dev-mcp vs chagra-agro-mcp) para evitar leak de info interna en PWA
  - Referencias: ADR-044, task #75

## Test plan

- ✅ Unit tests: 69 test files, 842 tests passed (vitest run)
- ✅ Build: vite build successful (2.41s)
- ✅ Lint: eslint clean (no errors)
- ✅ Pre-commit hooks: all checks passed (lefthook)

## Riesgos conocidos

- Sin riesgos: cambio de versión y documentación solamente
- NO incluye cambios en funcionalidad existente
- NO crea tags (solo bump + changelog según especificación task #75)

## Referencias

- ADR-044: MCP boundary split
- Task #75: OSS->Pro cutover step 4 + release v0.13.0