### PR TITLE
fix(voice): whisper transcribe — normalizar language a ISO base (#193)

### DIFF
--- a/src/services/voiceService.js
+++ b/src/services/voiceService.js
@@ -26,7 +26,7 @@ const TIMEOUT_MS = 15000;
  *
  * @param {Blob} blob - audio/webm;codecs=opus (tipicamente de MediaRecorder).
  * @param {Object} [options]
- * @param {string} [options.language='es-CO']
+ * @param {string} [options.language='es'] — códigos ISO-639-1 sin región (whisper rechaza 'es-CO', solo acepta 'es')
  * @returns {Promise<string>} texto transcrito (trim).
  * @throws {Error} si la red falla, el servidor responde no-2xx o el texto esta vacio.
  * @example
@@ -41,9 +41,13 @@ export async function transcribe(blob, options = {}) {
   const filename = `recording.${blob.type.includes('mp4') ? 'mp4' : 'webm'}`;
   form.append('audio_file', blob, filename);
 
+  // Whisper acepta solo códigos ISO-639-1 sin región. 'es-CO' lanza HTTP 500
+  // ValueError: Unsupported language. Normalizar a base.
+  const lang = (options.language || 'es').split('-')[0];
+
   const params = new URLSearchParams({
     task: 'transcribe',
-    language: options.language || 'es-CO',
+    language: lang,
     output: 'json',
     encode: 'true',
   });


### PR DESCRIPTION
Bug whisper 500 confirmado en sudo podman logs whisper-http: 'ValueError: Unsupported language: es-co'. Whisper acepta solo ISO-639-1 sin región. Fix 1 línea normaliza.