### PR TITLE
feat(vision): switch primary to llama3.2-vision:11b (V-01)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.3",
+  "version": "0.13.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.4",
+  "version": "0.13.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/deploy-marker.txt
+++ b/public/deploy-marker.txt
@@ -1,1 +1,2 @@
 trigger=1779836557
+trigger_1779837288=ok

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v235';
+const CACHE_NAME = 'chagra-v236';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v236';
+const CACHE_NAME = 'chagra-v237';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -29,13 +29,17 @@ const OLLAMA_URL = `${OLLAMA_BASE}/api/generate`;
 // Gemma 3 4B (oficial Google, multimodal nativo). Reemplaza paligemma
 // porque el runner Llama de Ollama crashea con arquitectura PaliGemma.
 const DIAGNOSIS_MODEL = 'gemma3:4b';
-// Vision-specialized model para species recognition. Bench Quadro M6000
-// 2026-05-17: qwen2.5vl:7b da 78 t/s GPU + identificación notablemente
-// mejor que gemma3:4b en frutales/hortalizas latam (11.8 GB VRAM, calza
-// holgado con 24 GB de la Quadro). Caller hace fallback a gemma3:4b si
-// qwen falla (modelo no cargado, OOM transitorio, etc.).
-const VISION_SPECIES_MODEL = 'qwen2.5vl:7b';
+// Vision-specialized model para species recognition. Bench 2026-05-26
+// bench-vision-flora 16 fixtures: llama3.2-vision:11b = 0 parse errors,
+// 18.8% nombre común, 68.8% familia botánica, 18.6s p50; qwen2.5vl:7b
+// = 16/16 parse errors a pesar de format:"json"; llava:13b 15/16 errors.
+// Cambio primary qwen2.5vl → llama3.2-vision por confiabilidad JSON.
+// qwen sigue como segundo fallback porque latencia p50 es 3.3s (5x más
+// rápido que llama32) — útil si llama32 OOM o timeout en hardware
+// constrained.
+const VISION_SPECIES_MODEL = 'llama3.2-vision:11b';
 const VISION_SPECIES_FALLBACK_MODEL = 'gemma3:4b';
+const VISION_SPECIES_FALLBACK_2_MODEL = 'qwen2.5vl:7b';
 
 // Prompt base sin contexto RAG. Fallback usado cuando el corpus no cargó
 // o el retrieve no devolvió passages relevantes.
@@ -374,18 +378,25 @@ export const recognizeSpecies = async (imageBlob, { onToken, signal } = {}) => {
     return null;
   }
 
-  // Primary: qwen2.5vl:7b (vision-specialized, mejor identificación).
+  // Primary: llama3.2-vision:11b (0 parse errors bench 2026-05-26).
   try {
     return await runSpeciesRecognition(VISION_SPECIES_MODEL, base64, { onToken, signal });
   } catch (err) {
     console.warn(`[aiService] ${VISION_SPECIES_MODEL} failed, fallback to ${VISION_SPECIES_FALLBACK_MODEL}:`, err.message);
   }
 
-  // Fallback: gemma3:4b (modelo de diagnóstico, ya cargado en VRAM normalmente).
+  // Fallback 1: gemma3:4b (modelo de diagnóstico, ya cargado en VRAM normalmente).
   try {
     return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_MODEL, base64, { onToken, signal });
   } catch (err) {
-    console.warn('[aiService] Species recognition no disponible (fallback también falló):', err.message);
+    console.warn(`[aiService] ${VISION_SPECIES_FALLBACK_MODEL} failed, fallback 2 to ${VISION_SPECIES_FALLBACK_2_MODEL}:`, err.message);
+  }
+
+  // Fallback 2: qwen2.5vl:7b (rápido pero parse errors frecuentes — último recurso).
+  try {
+    return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_2_MODEL, base64, { onToken, signal });
+  } catch (err) {
+    console.warn('[aiService] Species recognition no disponible (3 fallbacks fallaron):', err.message);
     return null;
   }
 };


### PR DESCRIPTION
## Summary

Audit visión 2026-05-26 V-01: qwen2.5vl:7b (primary anterior) falla 16/16 en bench `vision-flora` con `format:"json"` — JSON malformed. llama3.2-vision:11b tiene 0 parse errors + 18.8% nombre común + 68.8% familia botánica.

## Changes

- Primary: `qwen2.5vl:7b` → `llama3.2-vision:11b`
- Fallback chain: gemma3:4b (1) → qwen2.5vl:7b (2, último recurso)
- Sin breaking changes — API `recognizeSpeciesGrounded` igual

## Bench data

| Modelo | Nombre% | Sci% | Fam% | ParseErr |
|---|---|---|---|---|
| llama3.2-vision:11b | 18.8 | 18.8 | **68.8** | 0 ✅ |
| qwen2.5vl:7b | 0 | 0 | 0 | 16/16 ❌ |
| llava:13b | 0 | 0 | 6.3 | 15/16 ❌ |

## Test plan

- [ ] Unit tests `aiService.test.js` siguen verdes
- [ ] Smoke test SpeciesSelect.jsx con foto real (aguacate)
- [ ] Telemetría confirma fallback chain orden correcto
- [ ] Latencia p50 < 20s (vs qwen 3.3s p50 — trade-off accuracy)

## Refs

- `audit-vision-chagra-2026-05-26.md` V-01
- `data/bench-runs/vision-flora-2026-05-27T02-36-55/summary.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)