### PR TITLE
feat(vision): countdown UX realista en SpeciesSelect (mobile testers)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.5",
+  "version": "0.13.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v237';
+const CACHE_NAME = 'chagra-v238';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug, Check, AlertCircle } from 'lucide-react';
+import VisionLoadingState from './common/VisionLoadingState';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { resolveSpeciesDefaults } from '../config/speciesDefaults';
 import { fuzzyFilter } from '../utils/fuzzySearch';
@@ -485,10 +486,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
         )}
 
         {aiState === 'running' && (
-          <div className="p-2.5 rounded-lg bg-slate-800 border border-slate-700 flex items-center gap-2 text-amber-400">
-            <Loader2 size={14} className="animate-spin" />
-            <span className="text-xs">Analizando foto…</span>
-          </div>
+          <VisionLoadingState label="Analizando foto" />
         )}
 
         {aiState === 'done' && aiResult && (

--- a/src/components/common/VisionLoadingState.jsx
+++ b/src/components/common/VisionLoadingState.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+
+const PHASES = [
+  { secs: 0, label: 'Preparando análisis…' },
+  { secs: 3, label: 'Cargando modelo de visión…' },
+  { secs: 8, label: 'Analizando la foto…' },
+  { secs: 15, label: 'Identificando la especie…' },
+  { secs: 22, label: 'Aún procesando, casi listo…' },
+  { secs: 30, label: 'Tomando más de lo normal, esperá un momento…' },
+];
+
+const EXPECTED_SECS = 25;
+
+export default function VisionLoadingState({ label = 'Analizando foto' }) {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    const start = Date.now();
+    const id = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - start) / 1000));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const phase = [...PHASES].reverse().find((p) => elapsed >= p.secs) || PHASES[0];
+  const pct = Math.min(95, Math.round((elapsed / EXPECTED_SECS) * 100));
+
+  return (
+    <div
+      data-testid="vision-loading-state"
+      className="p-3 rounded-lg bg-slate-800 border border-slate-700 space-y-2"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 text-amber-400">
+        <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+        <span className="text-xs font-medium">{label}</span>
+        <span className="ml-auto text-[10px] font-mono text-slate-500">
+          {elapsed}s
+        </span>
+      </div>
+      <p className="text-[11px] text-slate-400">{phase.label}</p>
+      <div
+        className="h-1 rounded-full bg-slate-700 overflow-hidden"
+        aria-hidden="true"
+      >
+        <div
+          className="h-full bg-amber-500/60 transition-all duration-700 ease-out"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Bugfix UX vital para testers mobile que pruebas mañana. Vision model llama3.2-vision:11b tiene latencia p50 18.6s, p95 31.9s. SpeciesSelect mostraba solo `Analizando foto…` estático → users mobile creen colgado.

## Changes

- `VisionLoadingState.jsx` reutilizable: contador segundos + progress bar + mensaje contextual por fases
- `SpeciesSelect.jsx` usa el nuevo componente cuando `aiState === 'running'`

## Mensaje por fase

| Tiempo | Mensaje |
|---|---|
| 0s | Preparando análisis… |
| 3s | Cargando modelo de visión… |
| 8s | Analizando la foto… |
| 15s | Identificando la especie… |
| 22s | Aún procesando, casi listo… |
| 30s | Tomando más de lo normal, esperá un momento… |

## Test plan

- [x] vitest `SpeciesSelect.smoke.test.jsx` siguen verdes (4 tests)
- [x] Build prod OK (sin warnings)
- [ ] Smoke mobile real iPhone Safari + Android Chrome con foto

## Refs

- `audit-vision-chagra-2026-05-26.md` V-01 UX
- `bench-runs/vision-flora-2026-05-27` lat p50 18.6s p95 31.9s

🤖 Generated with [Claude Code](https://claude.com/claude-code)