### PR TITLE
feat(agent): botón Reintentar en mensaje orphan_recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.6",
+  "version": "0.13.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v238';
+const CACHE_NAME = 'chagra-v239';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -178,14 +178,21 @@ export default function AgentScreen({ onBack }) {
       // 2026-05-19: detectar pregunta huérfana — si el último turn es del
       // usuario sin respuesta del agente, agregar mensaje informativo para
       // que el operator entienda que la respuesta anterior se perdió
-      // (timeout, unmount accidental, etc.) y pueda re-preguntar.
+      // (timeout, unmount accidental, app cerrada en mobile, etc.). El
+      // mensaje incluye el prompt original via `_orphan_prompt` para que
+      // ChatBubble pueda renderizar un botón "Reintentar" que dispare
+      // handleSubmit automáticamente sin que el operador re-tipee.
+      // Bug 2026-05-27: testers móviles cambian de app durante inferencia
+      // y al volver re-tipear es fricción alta. Botón retry one-click es
+      // significativamente mejor UX que el copy anterior.
       const lastTurn = history[history.length - 1];
       if (lastTurn && lastTurn.role === 'user') {
         history.push({
           role: 'assistant',
-          content: 'Tu pregunta anterior no recibió respuesta (timeout o sesión interrumpida). Vuelve a preguntarla si quieres seguir.',
+          content: 'No alcancé a responderte la anterior. ¿Querés que lo intente de nuevo?',
           timestamp: Date.now(),
           _orphan_recovery: true,
+          _orphan_prompt: lastTurn.content || '',
         });
       }
       setMessages(history);
@@ -1170,6 +1177,39 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
   // pending. Si entra como queued, solo agrega visualmente el mensaje al
   // chat (lo procesará la promoción cuando termine el actual). Si entra
   // rejected, muestra toast.
+  /**
+   * Retry de pregunta huérfana — botón "Reintentar" en mensaje
+   * `_orphan_recovery`. Re-envía el prompt original via handleSubmit
+   * sin que el operador tenga que re-tipear. Antes del retry limpia
+   * los dos mensajes huérfanos (user original + orphan_recovery) para
+   * que el nuevo turno quede limpio.
+   *
+   * Bug fix 2026-05-27: el copy anterior pedía "Vuelve a preguntarla"
+   * sin acción asociada. Testers móviles cambian de app durante
+   * inferencia y al volver el re-tipear es fricción alta.
+   */
+  const handleRetryOrphan = useCallback(async (prompt) => {
+    if (typeof prompt !== 'string' || prompt.trim().length === 0) return;
+    setMessages((prev) => {
+      const clone = [...prev];
+      // Quitar el orphan_recovery + el user message que lo originó.
+      while (clone.length > 0) {
+        const last = clone[clone.length - 1];
+        if (last._orphan_recovery) {
+          clone.pop();
+          continue;
+        }
+        if (last.role === 'user') {
+          clone.pop();
+          break;
+        }
+        break;
+      }
+      return clone;
+    });
+    await handleSubmit(prompt);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleSubmit = async (text, { fromVoice = false } = {}) => {
     if (!text || !text.trim()) return;
     const trimmed = text.trim();
@@ -1425,6 +1465,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         streamingContent={streamingContent}
         isStreaming={state === STATE_THINKING}
         onConsentNeeded={handleFeedbackConsentNeeded}
+        onRetryOrphan={handleRetryOrphan}
       />
 
       {/* Error */}

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -87,7 +87,7 @@ function SourceBadge({ metadata }) {
   );
 }
 
-export default function ChatBubble({ message, isStreaming = false, promptText, onConsentNeeded }) {
+export default function ChatBubble({ message, isStreaming = false, promptText, onConsentNeeded, onRetryOrphan }) {
   const isUser = message.role === 'user';
   const showSourceBadges = usePrefsStore((s) => s.showSourceBadges);
   // Badge "fuente" solo aplica a respuestas del agente, no del usuario, y
@@ -182,6 +182,28 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
                 response={message.content || ''}
                 onConsentNeeded={onConsentNeeded}
               />
+            </div>
+          )}
+          {/* Bug fix 2026-05-27: botón Reintentar en mensaje _orphan_recovery.
+              Re-envía el prompt original via onRetryOrphan sin re-tipear.
+              Si no hay handler o no hay prompt original, no se renderiza
+              el botón (fallback al copy estático). */}
+          {!isUser && !isStreaming && message._orphan_recovery
+            && typeof onRetryOrphan === 'function'
+            && typeof message._orphan_prompt === 'string'
+            && message._orphan_prompt.length > 0 && (
+            <div className="mt-2 pt-2 border-t border-slate-700/50">
+              <button
+                type="button"
+                onClick={() => onRetryOrphan(message._orphan_prompt)}
+                className="w-full px-3 py-2 rounded-lg bg-emerald-700/40 hover:bg-emerald-700/60 active:bg-emerald-700/80 text-emerald-200 text-sm font-bold border border-emerald-700/60 min-h-[44px] transition-colors"
+                data-testid="orphan-recovery-retry"
+              >
+                Reintentar
+              </button>
+              <p className="text-[10px] text-slate-500 mt-1 italic">
+                Volvemos a procesar tu pregunta anterior.
+              </p>
             </div>
           )}
         </div>

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import ChatBubble from './ChatBubble';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan }) {
   const bottomRef = useRef(null);
 
   useEffect(() => {
@@ -52,6 +52,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
           isStreaming={false}
           promptText={msg.role === 'assistant' ? findPromptForResponse(idx) : undefined}
           onConsentNeeded={onConsentNeeded}
+          onRetryOrphan={onRetryOrphan}
         />
       ))}
 


### PR DESCRIPTION
Bug operador 2026-05-27: testers móviles cambian de app durante inferencia → al volver veían el mensaje sin acción de recovery. Ahora botón verde 'Reintentar' re-envía el prompt original.

Backward compat sin breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)