### PR TITLE
feat(vision): warm-on-click cámara reduce cold-start (opción A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.7",
+  "version": "0.13.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v239';
+const CACHE_NAME = 'chagra-v240';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/PhotoCaptureField.jsx
+++ b/src/components/PhotoCaptureField.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Camera, RotateCcw, Trash2, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
 import { captureAndCompress } from '../services/photoService';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
+import { warmVisionModel } from '../services/visionWarmService';
 
 /**
  * PhotoCaptureField, Componente reutilizable para captura de fotos en campo.
@@ -80,6 +81,17 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
         fileInputRef.current?.click();
     };
 
+    /**
+     * Warm vision on-click (decisión operador 2026-05-27 opción A).
+     * Dispara warm del modelo de visión en background cuando el operador
+     * toca el botón cámara. Mientras enfoca foto/galería (3-5s humano), el
+     * modelo carga en GPU. Idempotente + fire-and-forget.
+     */
+    const handleClickCapture = () => {
+        warmVisionModel().catch(() => {}); // fire-and-forget, ignora errores
+        fileInputRef.current?.click();
+    };
+
     return (
         <div className={`flex flex-col gap-2 ${className}`}>
             <input
@@ -93,7 +105,7 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
             {!previewUrl && !isProcessing && (
                 <button
                     type="button"
-                    onClick={() => fileInputRef.current?.click()}
+                    onClick={handleClickCapture}
                     className="flex flex-col items-center justify-center gap-3 p-8 rounded-2xl bg-slate-900 border-2 border-dashed border-slate-700 hover:border-slate-500 active:bg-slate-800 transition-all min-h-[160px] text-slate-400"
                 >
                     <Camera size={48} className="opacity-50" />
@@ -146,7 +158,7 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
                     <AlertCircle size={16} />
                     <span>{error}</span>
                     <button
-                        onClick={() => fileInputRef.current?.click()}
+                        onClick={handleClickCapture}
                         className="ml-auto underline font-bold"
                     >
                         Reintentar

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
 import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug, Check, AlertCircle } from 'lucide-react';
 import VisionLoadingState from './common/VisionLoadingState';
+import { warmVisionModel } from '../services/visionWarmService';
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { resolveSpeciesDefaults } from '../config/speciesDefaults';
 import { fuzzyFilter } from '../utils/fuzzySearch';
@@ -461,7 +462,11 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
           // Side-by-side en grid 2 columnas. Ambos delegan al mismo handler
           // que (#2) re-emite el blob al parent via onPhoto si está conectado.
           <div className="grid grid-cols-2 gap-2">
-            <label className="w-full p-2.5 rounded-lg bg-amber-900/20 hover:bg-amber-800/30 active:bg-amber-800/50 text-amber-300 border border-amber-800/50 cursor-pointer flex items-center justify-center gap-2 text-xs min-h-[40px] transition-colors">
+            <label
+              className="w-full p-2.5 rounded-lg bg-amber-900/20 hover:bg-amber-800/30 active:bg-amber-800/50 text-amber-300 border border-amber-800/50 cursor-pointer flex items-center justify-center gap-2 text-xs min-h-[40px] transition-colors"
+              onMouseDown={() => warmVisionModel().catch(() => {})}
+              onTouchStart={() => warmVisionModel().catch(() => {})}
+            >
               <Camera size={14} /> Tomar foto
               <input
                 ref={aiCameraRef}
@@ -472,7 +477,11 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                 className="hidden"
               />
             </label>
-            <label className="w-full p-2.5 rounded-lg bg-slate-800 hover:bg-slate-700 active:bg-slate-600 text-amber-300 border border-amber-800/50 cursor-pointer flex items-center justify-center gap-2 text-xs min-h-[40px] transition-colors">
+            <label
+              className="w-full p-2.5 rounded-lg bg-slate-800 hover:bg-slate-700 active:bg-slate-600 text-amber-300 border border-amber-800/50 cursor-pointer flex items-center justify-center gap-2 text-xs min-h-[40px] transition-colors"
+              onMouseDown={() => warmVisionModel().catch(() => {})}
+              onTouchStart={() => warmVisionModel().catch(() => {})}
+            >
               <ImagePlus size={14} /> Elegir foto
               <input
                 ref={aiGalleryRef}

--- a/src/services/visionWarmService.js
+++ b/src/services/visionWarmService.js
@@ -1,0 +1,88 @@
+/**
+ * visionWarmService.js — pre-warm del modelo vision on-click cámara.
+ *
+ * Estrategia "warm-on-click" (decisión operador 2026-05-27): NO pre-warmear
+ * el modelo de visión al login (riesgo VRAM: gemma3:4b + llama3.2-vision:11b
+ * suman ~11.6 GB, justo al límite de 12 GB de la Quadro M6000). En su lugar,
+ * disparar el warm cuando el operador toca el botón "Tomar foto" — mientras
+ * enfoca cámara/galería (3-5 segundos humanos), el modelo carga en GPU.
+ *
+ * Si gemma3:4b ya está cargado, Ollama gestiona el swap automáticamente.
+ * Cuando el operador vuelve al chat texto después, gemma se re-cargará en
+ * cold-start (~25s), pero ese tradeoff es aceptable: la primera identificación
+ * de visión es lo que percibe el operador como "el agente respondió rápido"
+ * y eso impacta más la primera impresión (los testers Android+iOS que pruebas
+ * mañana 2026-05-27).
+ *
+ * Idempotente: usar `warmVisionModel()` múltiples veces no dispara N requests
+ * — un internal lock previene calls concurrentes mientras una request está
+ * en vuelo. El segundo click rápido no quema VRAM extra.
+ *
+ * Fire-and-forget: el caller NO debe esperar la promesa. Si falla (Ollama
+ * down, red intermitente, modelo no instalado), degrada silencioso al
+ * cold-start clásico que verá el operador en el momento del análisis.
+ */
+
+const OLLAMA_URL = '/api/ollama/api/generate';
+const VISION_MODEL = 'llama3.2-vision:11b';
+// keep_alive 5min: si user demora entre click cámara y submit, el modelo
+// sigue caliente. Si user abandona el flow, Ollama lo desaloja en 5min y
+// libera VRAM. Más corto causaría re-warm si el flow toma >2min.
+const KEEP_ALIVE = '5m';
+const WARMUP_TIMEOUT_MS = 30000;
+
+let _warmInFlight = false;
+let _lastWarmAt = 0;
+// Si el último warm exitoso fue hace menos de 4min, asumimos que sigue
+// caliente y no re-disparamos. Threshold defensivo bajo el keep_alive 5min.
+const SKIP_IF_RECENT_MS = 4 * 60 * 1000;
+
+/**
+ * Dispara warm del modelo de visión en background. Idempotente, no-bloqueante.
+ *
+ * @returns {Promise<boolean>} true si disparó (o ya estaba warm), false si error.
+ *   El caller normalmente ignora el retorno.
+ */
+export async function warmVisionModel() {
+  if (_warmInFlight) return true;
+  const now = Date.now();
+  if (now - _lastWarmAt < SKIP_IF_RECENT_MS) return true;
+
+  _warmInFlight = true;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), WARMUP_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(OLLAMA_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: VISION_MODEL,
+        prompt: 'ok',
+        stream: false,
+        keep_alive: KEEP_ALIVE,
+        options: { num_predict: 1 },
+      }),
+      signal: controller.signal,
+    });
+    if (res.ok) {
+      _lastWarmAt = Date.now();
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+    _warmInFlight = false;
+  }
+}
+
+/**
+ * Reset interno — para tests solamente.
+ * @internal
+ */
+export function __resetVisionWarmState() {
+  _warmInFlight = false;
+  _lastWarmAt = 0;
+}


### PR DESCRIPTION
Decisión operador 2026-05-27 opción A: warm vision on-click (no en login) para no arriesgar VRAM.

Trigger en mouseDown/touchStart del botón cámara → warm en background mientras user enfoca foto (3-5s). Ollama gestiona swap si VRAM justo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)