### PR TITLE
feat(vision): _grounded structured status + UX hints (V-05)

### DIFF
--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useEffect } from 'react';
-import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug, Check, AlertCircle } from 'lucide-react';
+import { Search, ChevronDown, X, Clock, Sparkles, Camera, ImagePlus, Loader2, Bug, Check, AlertCircle, AlertTriangle, HelpCircle, Info, WifiOff } from 'lucide-react';
 import VisionLoadingState from './common/VisionLoadingState';
 import { warmVisionModel } from '../services/visionWarmService';
 import { CROP_TAXONOMY } from '../config/taxonomy';
@@ -504,26 +504,72 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
               <p className="text-[10px] uppercase tracking-wider text-emerald-500 font-bold mb-0.5">
                 Especie sugerida ({Math.round((aiResult.confidence || 0) * 100)}% confianza)
               </p>
-              {/* Badge grounded contra catálogo (PR #114 — anti-alucinación).
-                  _grounded === true  → verde "Verificado catálogo".
-                  _grounded === false → amber "No verificado — revisar manualmente".
-                  _grounded === null  → sidecar offline o no aplica, sin badge. */}
-              {aiResult._grounded === true && (
+              {/* Badge grounded contra catálogo (V-05 — anti-alucinación con
+                  shape estructurado). `_grounded.status` distingue 6 estados:
+                    verified         → verde, sugerencia confirmada.
+                    rejected         → amber, sugerencia rechazada por catálogo.
+                    sidecar-disabled → slate info, validación desactivada.
+                    offline          → slate info, sin red para verificar.
+                    no-binomial      → amber, nombre científico ambiguo.
+                    sidecar-error    → amber, error temporal del catálogo. */}
+              {aiResult._grounded?.status === 'verified' && (
                 <span
                   data-testid="grounded-badge-verified"
                   className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-green-600/20 text-green-300 border border-green-700 mb-1"
+                  title={aiResult._grounded.reason}
                 >
                   <Check size={14} aria-hidden="true" />
-                  Verificado catálogo
+                  Verificado en catálogo
                 </span>
               )}
-              {aiResult._grounded === false && (
+              {aiResult._grounded?.status === 'rejected' && (
                 <span
-                  data-testid="grounded-badge-unverified"
+                  data-testid="grounded-badge-rejected"
                   className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-amber-600/20 text-amber-300 border border-amber-700 mb-1"
+                  title={aiResult._grounded.reason}
                 >
                   <AlertCircle size={14} aria-hidden="true" />
-                  No verificado — revisar manualmente
+                  No encontrado en catálogo
+                </span>
+              )}
+              {aiResult._grounded?.status === 'sidecar-disabled' && (
+                <span
+                  data-testid="grounded-badge-sidecar-disabled"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-slate-600/20 text-slate-300 border border-slate-700 mb-1"
+                  title={aiResult._grounded.reason}
+                >
+                  <Info size={14} aria-hidden="true" />
+                  Validación deshabilitada
+                </span>
+              )}
+              {aiResult._grounded?.status === 'offline' && (
+                <span
+                  data-testid="grounded-badge-offline"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-slate-600/20 text-slate-300 border border-slate-700 mb-1"
+                  title={aiResult._grounded.reason}
+                >
+                  <WifiOff size={14} aria-hidden="true" />
+                  Sin conexión
+                </span>
+              )}
+              {aiResult._grounded?.status === 'no-binomial' && (
+                <span
+                  data-testid="grounded-badge-no-binomial"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-amber-600/20 text-amber-300 border border-amber-700 mb-1"
+                  title={aiResult._grounded.reason}
+                >
+                  <HelpCircle size={14} aria-hidden="true" />
+                  Nombre ambiguo
+                </span>
+              )}
+              {aiResult._grounded?.status === 'sidecar-error' && (
+                <span
+                  data-testid="grounded-badge-sidecar-error"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-amber-600/20 text-amber-300 border border-amber-700 mb-1"
+                  title={aiResult._grounded.reason}
+                >
+                  <AlertTriangle size={14} aria-hidden="true" />
+                  Error temporal
                 </span>
               )}
               <p className="text-sm text-emerald-200 font-bold">
@@ -535,10 +581,11 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                 </p>
               )}
             </div>
-            {/* Si el primario NO está verificado pero el sidecar encontró
-                candidates alternativos válidos en el catálogo, ofrecerlos
-                como sugerencias confiables. */}
-            {aiResult._grounded === false && Array.isArray(aiResult._all_validations) && (() => {
+            {/* Si el primario fue rechazado por el catálogo pero el sidecar
+                encontró candidates alternativos válidos, ofrecerlos como
+                sugerencias confiables. Solo aplica al status 'rejected'
+                (no a 'sidecar-error'/'no-binomial' donde no hubo validación). */}
+            {aiResult._grounded?.status === 'rejected' && Array.isArray(aiResult._all_validations) && (() => {
               const validCandidates = aiResult._all_validations.filter(
                 (v) => v && v.valid === true && v.species_id
               );

--- a/src/components/__tests__/SpeciesSelect.smoke.test.jsx
+++ b/src/components/__tests__/SpeciesSelect.smoke.test.jsx
@@ -3,13 +3,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // Smoke tests para la migración de SpeciesSelect a recognizeSpeciesGrounded
-// (PR #114). Cubre los tres valores observables de `_grounded`:
-//   - true  → badge VERDE "Verificado catálogo".
-//   - false → badge AMBER "No verificado — revisar manualmente" + bloque
-//             "Coincidencias en catálogo" cuando hay alternativas válidas
-//             en `_all_validations`.
-//   - null  → sidecar offline o no aplica → ningún badge se renderiza
-//             (degradación graceful).
+// (PR #114) + V-05 (audit-vision-chagra-2026-05-26): shape estructurado.
+// Cubre los 6 statuses observables de `_grounded.status`:
+//   verified         → badge VERDE "Verificado en catálogo".
+//   rejected         → badge AMBER "No encontrado en catálogo" + bloque
+//                      "Coincidencias en catálogo" cuando hay alternativas
+//                      válidas en `_all_validations`.
+//   sidecar-disabled → badge SLATE "Validación deshabilitada" (info).
+//   offline          → badge SLATE "Sin conexión" (info).
+//   no-binomial      → badge AMBER "Nombre ambiguo".
+//   sidecar-error    → badge AMBER "Error temporal".
 
 // Mock del store: lista vacía para evitar el chip "Recientes" (no toca el badge).
 vi.mock('../../store/useAssetStore', () => ({
@@ -33,8 +36,8 @@ vi.mock('../../hooks/usePhotoUrl', () => ({
   usePhotoUrl: () => ({ url: null, source: null, loading: false }),
 }));
 
-// Mock aiService.recognizeSpeciesGrounded — se reescribe per-test con el valor
-// de `_grounded` que queremos validar.
+// Mock aiService.recognizeSpeciesGrounded — se reescribe per-test con el
+// status de `_grounded` que queremos validar.
 const mockRecognizeSpeciesGrounded = vi.fn();
 vi.mock('../../services/aiService', () => ({
   recognizeSpeciesGrounded: (...args) => mockRecognizeSpeciesGrounded(...args),
@@ -42,12 +45,16 @@ vi.mock('../../services/aiService', () => ({
 
 import SpeciesSelect from '../SpeciesSelect';
 
-const buildResult = (grounded, extra = {}) => ({
+const buildResult = (status, extra = {}) => ({
   common_name_es: 'Tomate',
   scientific_name: 'Solanum lycopersicum',
   confidence: 0.85,
   alternatives: [],
-  _grounded: grounded,
+  _grounded: {
+    status,
+    reason: extra.reason ?? 'mock reason',
+    validation: extra.validation ?? null,
+  },
   _validation: extra.validation ?? null,
   _all_validations: extra.all_validations ?? [],
 });
@@ -62,14 +69,15 @@ const triggerCapture = async () => {
   await fireEvent.change(fileInput, { target: { files: [file] } });
 };
 
-describe('SpeciesSelect — badges grounded (PR #114)', () => {
+describe('SpeciesSelect — badges grounded (V-05 structured status)', () => {
   beforeEach(() => {
     mockRecognizeSpeciesGrounded.mockReset();
   });
 
-  it('renderiza badge VERDE "Verificado catálogo" cuando _grounded === true', async () => {
+  it('status:verified → badge VERDE "Verificado en catálogo"', async () => {
     mockRecognizeSpeciesGrounded.mockResolvedValue(
-      buildResult(true, {
+      buildResult('verified', {
+        reason: 'Verificado en catálogo Chagra.',
         validation: { valid: true, species_id: 'solanum_lycopersicum', confidence_adjusted: 0.92 },
       })
     );
@@ -78,15 +86,20 @@ describe('SpeciesSelect — badges grounded (PR #114)', () => {
     await waitFor(() => {
       const badge = screen.getByTestId('grounded-badge-verified');
       expect(badge).toBeTruthy();
-      expect(badge.textContent).toMatch(/Verificado catálogo/i);
+      expect(badge.textContent).toMatch(/Verificado en catálogo/i);
     });
-    // El badge unverified NO debe estar.
-    expect(screen.queryByTestId('grounded-badge-unverified')).toBeNull();
+    // Ningún otro badge debe estar.
+    expect(screen.queryByTestId('grounded-badge-rejected')).toBeNull();
+    expect(screen.queryByTestId('grounded-badge-sidecar-disabled')).toBeNull();
+    expect(screen.queryByTestId('grounded-badge-offline')).toBeNull();
+    expect(screen.queryByTestId('grounded-badge-no-binomial')).toBeNull();
+    expect(screen.queryByTestId('grounded-badge-sidecar-error')).toBeNull();
   });
 
-  it('renderiza badge AMBER "No verificado" cuando _grounded === false', async () => {
+  it('status:rejected → badge AMBER "No encontrado en catálogo"', async () => {
     mockRecognizeSpeciesGrounded.mockResolvedValue(
-      buildResult(false, {
+      buildResult('rejected', {
+        reason: 'Sugerencia no encontrada en catálogo.',
         validation: { valid: false, species_id: 'mangosteenia_colombiana', reason: 'not_in_catalog' },
         all_validations: [
           { valid: false, species_id: 'mangosteenia_colombiana', source_label: 'Mangosteenia colombiana' },
@@ -96,17 +109,16 @@ describe('SpeciesSelect — badges grounded (PR #114)', () => {
     render(<SpeciesSelect value="" onChange={() => {}} />);
     await triggerCapture();
     await waitFor(() => {
-      const badge = screen.getByTestId('grounded-badge-unverified');
+      const badge = screen.getByTestId('grounded-badge-rejected');
       expect(badge).toBeTruthy();
-      expect(badge.textContent).toMatch(/No verificado/i);
-      expect(badge.textContent).toMatch(/revisar manualmente/i);
+      expect(badge.textContent).toMatch(/No encontrado/i);
     });
     expect(screen.queryByTestId('grounded-badge-verified')).toBeNull();
   });
 
-  it('muestra "Coincidencias en catálogo" si _grounded === false y _all_validations trae candidates válidos', async () => {
+  it('status:rejected con candidates válidos → muestra "Coincidencias en catálogo"', async () => {
     mockRecognizeSpeciesGrounded.mockResolvedValue(
-      buildResult(false, {
+      buildResult('rejected', {
         validation: { valid: false, species_id: 'mangosteenia_colombiana' },
         all_validations: [
           { valid: false, species_id: 'mangosteenia_colombiana', source_label: 'Mangosteenia colombiana' },
@@ -124,17 +136,57 @@ describe('SpeciesSelect — badges grounded (PR #114)', () => {
     });
   });
 
-  it('NO renderiza badge cuando _grounded === null (degradación graceful)', async () => {
-    mockRecognizeSpeciesGrounded.mockResolvedValue(buildResult(null));
+  it('status:sidecar-disabled → badge SLATE "Validación deshabilitada"', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult('sidecar-disabled', { reason: 'Validación catálogo deshabilitada.' })
+    );
     render(<SpeciesSelect value="" onChange={() => {}} />);
     await triggerCapture();
-    // Esperamos a que el resultado AI aparezca (Especie sugerida) para
-    // confirmar que llegamos al render del bloque 'done'.
     await waitFor(() => {
-      expect(screen.getByText(/Especie sugerida/i)).toBeTruthy();
+      const badge = screen.getByTestId('grounded-badge-sidecar-disabled');
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toMatch(/Validación deshabilitada/i);
     });
     expect(screen.queryByTestId('grounded-badge-verified')).toBeNull();
-    expect(screen.queryByTestId('grounded-badge-unverified')).toBeNull();
-    expect(screen.queryByTestId('grounded-valid-candidates')).toBeNull();
+    expect(screen.queryByTestId('grounded-badge-rejected')).toBeNull();
+  });
+
+  it('status:offline → badge SLATE "Sin conexión"', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult('offline', { reason: 'Sin conexión, no se pudo verificar.' })
+    );
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    await waitFor(() => {
+      const badge = screen.getByTestId('grounded-badge-offline');
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toMatch(/Sin conexión/i);
+    });
+  });
+
+  it('status:no-binomial → badge AMBER "Nombre ambiguo"', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult('no-binomial', { reason: 'Nombre científico ambiguo.' })
+    );
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    await waitFor(() => {
+      const badge = screen.getByTestId('grounded-badge-no-binomial');
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toMatch(/Nombre ambiguo/i);
+    });
+  });
+
+  it('status:sidecar-error → badge AMBER "Error temporal"', async () => {
+    mockRecognizeSpeciesGrounded.mockResolvedValue(
+      buildResult('sidecar-error', { reason: 'Error temporal del catálogo.' })
+    );
+    render(<SpeciesSelect value="" onChange={() => {}} />);
+    await triggerCapture();
+    await waitFor(() => {
+      const badge = screen.getByTestId('grounded-badge-sidecar-error');
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toMatch(/Error temporal/i);
+    });
   });
 });

--- a/src/services/__tests__/aiService.grounded.test.js
+++ b/src/services/__tests__/aiService.grounded.test.js
@@ -2,6 +2,10 @@
  * Tests para `recognizeSpeciesGrounded` y `scientificToSpeciesId` —
  * wiring de validate_visual_match al pipeline de foto. Anti-hallucination
  * visión (PR chagra-pro #48 expuso la tool, este PR la consume).
+ *
+ * V-05 (audit-vision-chagra-2026-05-26): `_grounded` ahora es objeto
+ * estructurado `{ status, reason, validation }` con 6 statuses posibles:
+ *   verified, rejected, sidecar-disabled, offline, no-binomial, sidecar-error.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -44,7 +48,7 @@ describe('recognizeSpeciesGrounded', () => {
     vi.restoreAllMocks();
   });
 
-  it('cuando el vision identifica species válida del catálogo, marca _grounded:true', async () => {
+  it('status:verified cuando el vision identifica species válida del catálogo', async () => {
     mockVisionResponse({
       common_name_es: 'café',
       scientific_name: 'Coffea arabica L.',
@@ -69,7 +73,11 @@ describe('recognizeSpeciesGrounded', () => {
     const result = await recognizeSpeciesGrounded(blob);
 
     expect(result).toBeTruthy();
-    expect(result._grounded).toBe(true);
+    expect(result._grounded.status).toBe('verified');
+    expect(result._grounded.reason).toMatch(/catálogo/i);
+    expect(result._grounded.validation).toBeTruthy();
+    expect(result._grounded.validation.valid).toBe(true);
+    // backwards-compat alias
     expect(result._validation.valid).toBe(true);
     expect(sidecarClient.callTool).toHaveBeenCalledWith(
       'validate_visual_match',
@@ -81,7 +89,7 @@ describe('recognizeSpeciesGrounded', () => {
     );
   });
 
-  it('cuando el vision alucina una especie inexistente, marca _grounded:false', async () => {
+  it('status:rejected cuando el vision alucina una especie inexistente', async () => {
     mockVisionResponse({
       common_name_es: 'planta inventada',
       scientific_name: 'Mangosteenia colombiana',
@@ -104,12 +112,14 @@ describe('recognizeSpeciesGrounded', () => {
     const blob = new Blob(['fake'], { type: 'image/jpeg' });
     const result = await recognizeSpeciesGrounded(blob);
 
-    expect(result._grounded).toBe(false);
+    expect(result._grounded.status).toBe('rejected');
+    expect(result._grounded.reason).toMatch(/no encontrada/i);
+    expect(result._grounded.validation.valid).toBe(false);
     expect(result._validation.valid).toBe(false);
     expect(result._validation.confidence_adjusted).toBe(0);
   });
 
-  it('si el sidecar está disabled, degrada a recognizeSpecies sin validar', async () => {
+  it('status:sidecar-disabled si el sidecar está apagado vía feature flag', async () => {
     sidecarClient.isSidecarEnabled.mockReturnValue(false);
     mockVisionResponse({
       common_name_es: 'tomate',
@@ -121,11 +131,13 @@ describe('recognizeSpeciesGrounded', () => {
     const blob = new Blob(['fake'], { type: 'image/jpeg' });
     const result = await recognizeSpeciesGrounded(blob);
 
-    expect(result._grounded).toBeNull();
+    expect(result._grounded.status).toBe('sidecar-disabled');
+    expect(result._grounded.reason).toMatch(/deshabilitada/i);
+    expect(result._grounded.validation).toBeNull();
     expect(sidecarClient.callTool).not.toHaveBeenCalled();
   });
 
-  it('si offline, degrada sin validar', async () => {
+  it('status:offline si el browser no tiene conexión', async () => {
     Object.defineProperty(globalThis, 'navigator', {
       value: { onLine: false },
       configurable: true,
@@ -140,11 +152,13 @@ describe('recognizeSpeciesGrounded', () => {
     const blob = new Blob(['fake'], { type: 'image/jpeg' });
     const result = await recognizeSpeciesGrounded(blob);
 
-    expect(result._grounded).toBeNull();
+    expect(result._grounded.status).toBe('offline');
+    expect(result._grounded.reason).toMatch(/conexión/i);
+    expect(result._grounded.validation).toBeNull();
     expect(sidecarClient.callTool).not.toHaveBeenCalled();
   });
 
-  it('si scientific_name está vacío o malformado, no llama al sidecar', async () => {
+  it('status:no-binomial si scientific_name está vacío o malformado', async () => {
     mockVisionResponse({
       common_name_es: 'desconocido',
       scientific_name: '', // vacío
@@ -155,7 +169,9 @@ describe('recognizeSpeciesGrounded', () => {
     const blob = new Blob(['fake'], { type: 'image/jpeg' });
     const result = await recognizeSpeciesGrounded(blob);
 
-    expect(result._grounded).toBeNull();
+    expect(result._grounded.status).toBe('no-binomial');
+    expect(result._grounded.reason).toMatch(/ambiguo/i);
+    expect(result._grounded.validation).toBeNull();
     expect(sidecarClient.callTool).not.toHaveBeenCalled();
   });
 
@@ -181,7 +197,7 @@ describe('recognizeSpeciesGrounded', () => {
     const blob = new Blob(['fake'], { type: 'image/jpeg' });
     const result = await recognizeSpeciesGrounded(blob);
 
-    expect(result._grounded).toBe(true);
+    expect(result._grounded.status).toBe('verified');
     expect(result._all_validations).toHaveLength(3);
     expect(sidecarClient.callTool).toHaveBeenCalledWith(
       'validate_visual_match',
@@ -195,7 +211,7 @@ describe('recognizeSpeciesGrounded', () => {
     );
   });
 
-  it('si el sidecar tool falla (devuelve null), degrada', async () => {
+  it('status:sidecar-error si el sidecar tool falla (devuelve null)', async () => {
     mockVisionResponse({
       common_name_es: 'aguacate',
       scientific_name: 'Persea americana',
@@ -207,7 +223,9 @@ describe('recognizeSpeciesGrounded', () => {
     const blob = new Blob(['fake'], { type: 'image/jpeg' });
     const result = await recognizeSpeciesGrounded(blob);
 
-    expect(result._grounded).toBeNull();
+    expect(result._grounded.status).toBe('sidecar-error');
+    expect(result._grounded.reason).toMatch(/temporal/i);
+    expect(result._grounded.validation).toBeNull();
     expect(result.scientific_name).toBe('Persea americana');
   });
 });

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -303,34 +303,69 @@ function scientificToSpeciesId(scientific) {
  *
  * Anti-alucinación: si el modelo vision devuelve "Mangosteenia colombiana"
  * (especie inexistente), el catálogo lo rechaza con `valid:false`. El
- * caller puede usar el campo `_grounded` para decidir:
- *   - _grounded === true  → mostrar al usuario con confianza alta
- *   - _grounded === false → mostrar advertencia "no verificado en catálogo"
+ * caller obtiene `_grounded.status` para decidir qué UX mostrar:
+ *   - 'verified'         → catálogo confirma la sugerencia (verde).
+ *   - 'rejected'         → catálogo rechaza la sugerencia (amber).
+ *   - 'sidecar-disabled' → feature flag off (info).
+ *   - 'offline'          → sin conexión, no se pudo verificar (info).
+ *   - 'no-binomial'      → modelo no produjo binomial parseable (amber).
+ *   - 'sidecar-error'    → sidecar timeout / 5xx (amber).
  *
- * Si el sidecar no está disponible (feature flag off o offline),
- * recognizeSpeciesGrounded degrada al comportamiento de recognizeSpecies
- * (sin validación). Caller obtiene _grounded:null para distinguir.
+ * V-05: shape estructurado reemplaza el ambiguo `_grounded: boolean|null`
+ * que mezclaba 3 modos de "no validable" en un solo `null`. Cada early-return
+ * ahora trae `reason` en español colombiano para mostrar al operador rural.
  *
  * @param {Blob} imageBlob — foto del usuario.
  * @param {Object} options — { onToken, signal } pasados al modelo vision.
  * @returns {Promise<Object|null>} estructura igual a recognizeSpecies +
- *   `_grounded: boolean|null`,
- *   `_validation: { valid, confidence_adjusted, ... }` cuando aplique.
+ *   `_grounded: { status, reason, validation }`,
+ *   `_validation: { valid, confidence_adjusted, ... }` cuando aplique
+ *   (alias backwards-compat con `_grounded.validation`),
+ *   `_all_validations` cuando hubo callTool exitoso.
  */
 export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   const visionResult = await recognizeSpecies(imageBlob, options);
   if (!visionResult) return null;
 
-  // Si sidecar disabled / offline, devolver lo del vision sin validar.
-  if (!isSidecarEnabled() || !navigator.onLine) {
-    return { ...visionResult, _grounded: null };
+  // Si sidecar disabled, devolver lo del vision sin validar.
+  if (!isSidecarEnabled()) {
+    return {
+      ...visionResult,
+      _grounded: {
+        status: 'sidecar-disabled',
+        reason: 'Validación catálogo deshabilitada.',
+        validation: null,
+      },
+      _validation: null,
+    };
+  }
+
+  // Si offline, no podemos pegar al sidecar.
+  if (!navigator.onLine) {
+    return {
+      ...visionResult,
+      _grounded: {
+        status: 'offline',
+        reason: 'Sin conexión, no se pudo verificar.',
+        validation: null,
+      },
+      _validation: null,
+    };
   }
 
   // Derive species_id from scientific_name. Si no podemos derivar (binomial
   // ausente o malformado), tampoco podemos validar — degradamos.
   const speciesId = scientificToSpeciesId(visionResult.scientific_name);
   if (!speciesId) {
-    return { ...visionResult, _grounded: null };
+    return {
+      ...visionResult,
+      _grounded: {
+        status: 'no-binomial',
+        reason: 'Nombre científico ambiguo.',
+        validation: null,
+      },
+      _validation: null,
+    };
   }
 
   // Construir lista de candidates: el principal + alternatives si vienen.
@@ -356,14 +391,29 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   const result = await callTool('validate_visual_match', { candidates });
   if (!result) {
     // Sidecar timeout / 5xx — fallback al resultado vision sin validar.
-    return { ...visionResult, _grounded: null };
+    return {
+      ...visionResult,
+      _grounded: {
+        status: 'sidecar-error',
+        reason: 'Error temporal del catálogo.',
+        validation: null,
+      },
+      _validation: null,
+    };
   }
 
   // Buscar el match del candidato primario en results.
   const primary = (result.results || []).find((r) => r.species_id === speciesId);
+  const verified = primary?.valid === true;
   return {
     ...visionResult,
-    _grounded: primary?.valid === true,
+    _grounded: {
+      status: verified ? 'verified' : 'rejected',
+      reason: verified
+        ? 'Verificado en catálogo Chagra.'
+        : 'Sugerencia no encontrada en catálogo.',
+      validation: primary || null,
+    },
     _validation: primary || null,
     _all_validations: result.results || [],
   };


### PR DESCRIPTION
## Summary

Refactor `recognizeSpeciesGrounded._grounded` de `boolean | null` ambiguo a shape estructurado `{ status, reason, validation }` con 6 statuses. Antes 3 escenarios distintos (`sidecar-disabled`, `offline`, `no-binomial`) colapsaban al mismo `_grounded: null`, así que la UI mostraba la misma badge genérica al operador rural sin distinguir causa raíz. Audit V-05 (`audit-vision-chagra-2026-05-26`).

## 6 estados de `_grounded.status`

| status              | trigger                                          | badge | icono lucide-react | copy               |
|---------------------|--------------------------------------------------|-------|--------------------|--------------------|
| `verified`          | `validate_visual_match` confirmó sugerencia      | verde | `Check`            | "Verificado en catálogo" |
| `rejected`          | `validate_visual_match` rechazó sugerencia       | amber | `AlertCircle`      | "No encontrado en catálogo" |
| `sidecar-disabled`  | `isSidecarEnabled() === false` (feature flag)    | slate | `Info`             | "Validación deshabilitada" |
| `offline`           | `navigator.onLine === false`                     | slate | `WifiOff`          | "Sin conexión" |
| `no-binomial`       | `scientificToSpeciesId()` no pudo derivar id    | amber | `HelpCircle`       | "Nombre ambiguo" |
| `sidecar-error`     | `callTool('validate_visual_match')` devolvió null | amber | `AlertTriangle`   | "Error temporal" |

Cada badge muestra el campo `_grounded.reason` en español colombiano como tooltip (`title`).

## Backward compat

- `_validation` se mantiene como alias del primary match (`_grounded.validation`) para callers que ya lo consumían.
- `_all_validations` no cambia.
- Grep `_grounded` en `src/` cubre solo dos puntos de uso: `aiService.js` (productor) y `SpeciesSelect.jsx` (consumidor). `EvidenceCapture.jsx` no toca `_grounded` — sin cambios.
- Bloque "Coincidencias en catálogo" ahora gate por `status === 'rejected'` (antes `=== false` ambiguo).

## Test plan

- [x] `npx vitest run src/services/__tests__/aiService.grounded.test.js` — 7 tests, 1 por status + 1 alternativas.
- [x] `npx vitest run src/components/__tests__/SpeciesSelect.smoke.test.jsx` — 7 tests, 1 por status + 1 candidates.
- [x] `npm run build` sin warnings.
- [x] `npx eslint <archivos> --max-warnings=0` clean.
- [ ] Manual: verificar badges en `/cultivos/agregar` con sidecar on/off + offline + species inventada (fixture `Mangosteenia colombiana`).

Refs: `audits/audit-vision-chagra-2026-05-26.md` V-05.