### PR TITLE
feat(telemetry): capture confidence + grounded status vision (V-12)

### DIFF
--- a/src/services/__tests__/aiService.grounded.test.js
+++ b/src/services/__tests__/aiService.grounded.test.js
@@ -228,4 +228,73 @@ describe('recognizeSpeciesGrounded', () => {
     expect(result._grounded.validation).toBeNull();
     expect(result.scientific_name).toBe('Persea americana');
   });
+
+  // V-12 2026-05-27: telemetría de audit visión.
+  describe('telemetryState V-12 — meta thunk a streamOllama', () => {
+    it('pasa meta como función (thunk) que resuelve confidence + grounded_status="verified"', async () => {
+      mockVisionResponse({
+        common_name_es: 'café',
+        scientific_name: 'Coffea arabica',
+        confidence: 0.88,
+        alternatives: [],
+      });
+      sidecarClient.callTool.mockResolvedValueOnce({
+        available: true,
+        results: [{ species_id: 'coffea_arabica', valid: true, confidence_adjusted: 0.88 }],
+      });
+
+      const blob = new Blob(['fake'], { type: 'image/jpeg' });
+      await recognizeSpeciesGrounded(blob);
+
+      // El 4to argumento de streamOllama es options. meta debe ser función.
+      const [, , , opts] = ollamaStream.streamOllama.mock.calls[0];
+      expect(typeof opts.meta).toBe('function');
+
+      // Resolver el thunk DESPUÉS del flujo completo: debe contener
+      // confidence (set por runSpeciesRecognition) y grounded_status='verified'
+      // (set por recognizeSpeciesGrounded tras validar).
+      const resolved = opts.meta();
+      expect(resolved.confidence).toBeCloseTo(0.88);
+      expect(resolved.grounded_status).toBe('verified');
+    });
+
+    it('thunk resuelve grounded_status="rejected" cuando el catálogo rechaza la especie', async () => {
+      mockVisionResponse({
+        common_name_es: 'inventada',
+        scientific_name: 'Mangosteenia colombiana',
+        confidence: 0.7,
+        alternatives: [],
+      });
+      sidecarClient.callTool.mockResolvedValueOnce({
+        available: true,
+        results: [{ species_id: 'mangosteenia_colombiana', valid: false, confidence_adjusted: 0, reason: 'not_in_catalog' }],
+      });
+
+      const blob = new Blob(['fake'], { type: 'image/jpeg' });
+      await recognizeSpeciesGrounded(blob);
+
+      const [, , , opts] = ollamaStream.streamOllama.mock.calls[0];
+      const resolved = opts.meta();
+      expect(resolved.confidence).toBeCloseTo(0.7);
+      expect(resolved.grounded_status).toBe('rejected');
+    });
+
+    it('thunk resuelve grounded_status=null cuando sidecar disabled (degraded path)', async () => {
+      sidecarClient.isSidecarEnabled.mockReturnValue(false);
+      mockVisionResponse({
+        common_name_es: 'tomate',
+        scientific_name: 'Solanum lycopersicum',
+        confidence: 0.6,
+        alternatives: [],
+      });
+
+      const blob = new Blob(['fake'], { type: 'image/jpeg' });
+      await recognizeSpeciesGrounded(blob);
+
+      const [, , , opts] = ollamaStream.streamOllama.mock.calls[0];
+      const resolved = opts.meta();
+      expect(resolved.confidence).toBeCloseTo(0.6);
+      expect(resolved.grounded_status).toBeNull();
+    });
+  });
 });

--- a/src/services/__tests__/llmTelemetry.visionFields.test.js
+++ b/src/services/__tests__/llmTelemetry.visionFields.test.js
@@ -1,0 +1,196 @@
+/**
+ * llmTelemetry.visionFields.test.js — V-12 2026-05-27.
+ *
+ * Cobertura del schema extendido de `recordLLMEvent` para audit visión:
+ * - `confidence` (number 0-1, opcional): persistido cuando el caller lo provee
+ *   tras parsear el JSON del modelo de visión.
+ * - `grounded_status` (string|null, opcional): persistido tal cual, distinguiendo
+ *   `'verified'` / `'rejected'` / `null` (sidecar offline / no-grounding flow).
+ *
+ * Backward-compat strict: si el caller no pasa los campos, NO deben aparecer
+ * en el record. Esto preserva el shape histórico para eventos no-visión
+ * (chat/extract/summarize) y evita pollution del store IDB.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('llmTelemetryService — campos visión V-12', () => {
+  let inMemoryStore;
+  let llmTelemetry;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    inMemoryStore = new Map();
+
+    const asyncReq = (resultFactory) => {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = resultFactory();
+        req.onsuccess?.({ target: req });
+      });
+      return req;
+    };
+
+    const stubStore = {
+      add: (record) => asyncReq(() => {
+        inMemoryStore.set(record.id, record);
+        return record;
+      }),
+      count: () => asyncReq(() => inMemoryStore.size),
+      clear: () => asyncReq(() => { inMemoryStore.clear(); return undefined; }),
+      index: () => ({ openCursor: () => asyncReq(() => null) }),
+    };
+
+    const stubTx = () => {
+      const tx = {
+        oncomplete: null,
+        onerror: null,
+        onabort: null,
+        objectStore: () => stubStore,
+        error: null,
+      };
+      Promise.resolve().then(() => tx.oncomplete?.());
+      return tx;
+    };
+
+    const stubDb = { transaction: () => stubTx() };
+
+    vi.doMock('../../db/dbCore.js', () => ({
+      openDB: vi.fn().mockResolvedValue(stubDb),
+      STORES: { LLM_TELEMETRY: 'llm_telemetry' },
+    }));
+
+    localStorage.clear();
+    llmTelemetry = await import('../llmTelemetryService.js');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persiste confidence cuando el caller lo provee (number 0-1)', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'llama3.2-vision:11b',
+      endpoint: '/api/ollama/api/generate',
+      flujo: 'vision',
+      status: 'success',
+      total_ms: 4321,
+      confidence: 0.87,
+    });
+
+    expect(record).not.toBeNull();
+    expect(record.confidence).toBe(0.87);
+  });
+
+  it('persiste confidence = 0 (caso edge: modelo no identifica con seguridad)', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'gemma3:4b',
+      flujo: 'vision',
+      confidence: 0,
+    });
+
+    expect(record.confidence).toBe(0);
+  });
+
+  it('omite confidence del payload cuando el caller no lo pasa (backward-compat)', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'gemma3:4b',
+      flujo: 'chat',
+      status: 'success',
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(record, 'confidence')).toBe(false);
+  });
+
+  it('omite confidence cuando el caller pasa un valor no-number (defensivo)', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'gemma3:4b',
+      flujo: 'vision',
+      confidence: 'high', // shape inválido — debe ignorarse
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(record, 'confidence')).toBe(false);
+  });
+
+  it('persiste grounded_status = "verified" cuando el catálogo valida', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'llama3.2-vision:11b',
+      flujo: 'vision',
+      grounded_status: 'verified',
+    });
+
+    expect(record.grounded_status).toBe('verified');
+  });
+
+  it('persiste grounded_status = "rejected" cuando el modelo alucinó', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'llama3.2-vision:11b',
+      flujo: 'vision',
+      grounded_status: 'rejected',
+    });
+
+    expect(record.grounded_status).toBe('rejected');
+  });
+
+  it('persiste grounded_status = null cuando sidecar disabled / offline', async () => {
+    // null explícito ES distinto de undefined: el caller intentó grounding
+    // pero degradó. Telemetría debe reflejar ese intento.
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'llama3.2-vision:11b',
+      flujo: 'vision',
+      grounded_status: null,
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(record, 'grounded_status')).toBe(true);
+    expect(record.grounded_status).toBeNull();
+  });
+
+  it('omite grounded_status cuando el caller no lo pasa (flujos no-vision)', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'gemma3:4b',
+      flujo: 'extract',
+      status: 'success',
+    });
+
+    expect(Object.prototype.hasOwnProperty.call(record, 'grounded_status')).toBe(false);
+  });
+
+  it('confidence + grounded_status conviven en el mismo record (caso normal V-12)', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'llama3.2-vision:11b',
+      endpoint: '/api/ollama/api/generate',
+      flujo: 'vision',
+      status: 'success',
+      total_ms: 5200,
+      eval_count: 42,
+      confidence: 0.92,
+      grounded_status: 'verified',
+    });
+
+    expect(record.confidence).toBe(0.92);
+    expect(record.grounded_status).toBe('verified');
+    expect(record.model).toBe('llama3.2-vision:11b');
+    expect(record.flujo).toBe('vision');
+  });
+
+  it('shape histórico preservado: campos legacy intactos cuando no se pasa nada V-12', async () => {
+    const record = await llmTelemetry.recordLLMEvent({
+      model: 'gemma3:4b',
+      endpoint: '/api/ollama/api/chat',
+      flujo: 'chat',
+      status: 'success',
+      total_ms: 1000,
+      eval_count: 50,
+      processor: 'gpu',
+    });
+
+    // Sanity check: ningún campo V-12 contamina records no-vision.
+    expect(record.confidence).toBeUndefined();
+    expect(record.grounded_status).toBeUndefined();
+    // Legacy intacto.
+    expect(record.rag_passages_used).toBeNull();
+    expect(record.error_kind).toBeNull();
+    expect(record.synced).toBe(false);
+  });
+});

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -249,19 +249,44 @@ export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, 
  * const species = await recognizeSpecies(imageBlob);
  * // species => { common_name_es: "cafe", scientific_name: "Coffea arabica", confidence: 0.92, alternatives: [] }
  */
-const runSpeciesRecognition = async (model, base64, { onToken, signal }) => {
+const runSpeciesRecognition = async (model, base64, { onToken, signal, telemetryState }) => {
+  // V-12 2026-05-27: thunk-meta resuelto en `recordLLMEvent` por
+  // `streamOllama`. Lee el state mutado tras parsear el JSON (confidence)
+  // y tras validar contra catálogo (grounded_status, set por
+  // `recognizeSpeciesGrounded`). Falla silente si `telemetryState` es null.
+  const metaThunk = telemetryState
+    ? () => {
+      const out = {};
+      if (typeof telemetryState.confidence === 'number') {
+        out.confidence = telemetryState.confidence;
+      }
+      if (telemetryState.grounded_status !== undefined) {
+        out.grounded_status = telemetryState.grounded_status;
+      }
+      return out;
+    }
+    : undefined;
+
   const text = (await streamOllama(
     OLLAMA_URL,
     { model, prompt: SPECIES_PROMPT, images: [base64] },
     onToken,
-    { signal },
+    { signal, meta: metaThunk },
   )).trim();
   const cleaned = text.replace(/```json\s*/g, '').replace(/```/g, '').trim();
   const parsed = JSON.parse(cleaned);
+  const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0;
+
+  // Mutar telemetryState (si el caller pasó uno) ANTES de que
+  // `detectProcessorFor` resuelva en streamOllama y dispare recordLLMEvent.
+  // Best-effort: si la grabación dispara antes (carrera microtasks), simplemente
+  // omitirá el campo. Telemetría nunca debe bloquear el caller.
+  if (telemetryState) telemetryState.confidence = confidence;
+
   return {
     common_name_es: (parsed.common_name_es || '').toLowerCase().trim(),
     scientific_name: parsed.scientific_name || '',
-    confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
+    confidence,
     alternatives: Array.isArray(parsed.alternatives) ? parsed.alternatives : [],
     _model: model,
   };
@@ -324,48 +349,42 @@ function scientificToSpeciesId(scientific) {
  *   `_all_validations` cuando hubo callTool exitoso.
  */
 export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
-  const visionResult = await recognizeSpecies(imageBlob, options);
+  // V-12 2026-05-27: state compartido con `recognizeSpecies` para que la
+  // telemetría de la inferencia vision capture `confidence` y
+  // `grounded_status`. Se llena en orden: confidence tras parsear el JSON
+  // del modelo, grounded_status tras validar (o degradar) contra catálogo.
+  const telemetryState = {};
+  const visionResult = await recognizeSpecies(imageBlob, { ...options, _telemetryState: telemetryState });
   if (!visionResult) return null;
+
+  // Helper: anota grounded_status para telemetría y devuelve el visionResult
+  // con la estructura _grounded rica (status, reason, validation). Mutar el
+  // state es best-effort porque la grabación de telemetría corre en background.
+  const finalize = (status, reason, validation = null, extras = {}) => {
+    telemetryState.grounded_status = status;
+    return {
+      ...visionResult,
+      _grounded: { status, reason, validation },
+      _validation: validation,
+      ...extras,
+    };
+  };
 
   // Si sidecar disabled, devolver lo del vision sin validar.
   if (!isSidecarEnabled()) {
-    return {
-      ...visionResult,
-      _grounded: {
-        status: 'sidecar-disabled',
-        reason: 'Validación catálogo deshabilitada.',
-        validation: null,
-      },
-      _validation: null,
-    };
+    return finalize('sidecar-disabled', 'Validación catálogo deshabilitada.');
   }
 
   // Si offline, no podemos pegar al sidecar.
   if (!navigator.onLine) {
-    return {
-      ...visionResult,
-      _grounded: {
-        status: 'offline',
-        reason: 'Sin conexión, no se pudo verificar.',
-        validation: null,
-      },
-      _validation: null,
-    };
+    return finalize('offline', 'Sin conexión, no se pudo verificar.');
   }
 
   // Derive species_id from scientific_name. Si no podemos derivar (binomial
   // ausente o malformado), tampoco podemos validar — degradamos.
   const speciesId = scientificToSpeciesId(visionResult.scientific_name);
   if (!speciesId) {
-    return {
-      ...visionResult,
-      _grounded: {
-        status: 'no-binomial',
-        reason: 'Nombre científico ambiguo.',
-        validation: null,
-      },
-      _validation: null,
-    };
+    return finalize('no-binomial', 'Nombre científico ambiguo.');
   }
 
   // Construir lista de candidates: el principal + alternatives si vienen.
@@ -391,35 +410,23 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   const result = await callTool('validate_visual_match', { candidates });
   if (!result) {
     // Sidecar timeout / 5xx — fallback al resultado vision sin validar.
-    return {
-      ...visionResult,
-      _grounded: {
-        status: 'sidecar-error',
-        reason: 'Error temporal del catálogo.',
-        validation: null,
-      },
-      _validation: null,
-    };
+    return finalize('sidecar-error', 'Error temporal del catálogo.');
   }
 
   // Buscar el match del candidato primario en results.
   const primary = (result.results || []).find((r) => r.species_id === speciesId);
   const verified = primary?.valid === true;
-  return {
-    ...visionResult,
-    _grounded: {
-      status: verified ? 'verified' : 'rejected',
-      reason: verified
-        ? 'Verificado en catálogo Chagra.'
-        : 'Sugerencia no encontrada en catálogo.',
-      validation: primary || null,
-    },
-    _validation: primary || null,
-    _all_validations: result.results || [],
-  };
+  return finalize(
+    verified ? 'verified' : 'rejected',
+    verified
+      ? 'Verificado en catálogo Chagra.'
+      : 'Sugerencia no encontrada en catálogo.',
+    primary || null,
+    { _all_validations: result.results || [] },
+  );
 };
 
-export const recognizeSpecies = async (imageBlob, { onToken, signal } = {}) => {
+export const recognizeSpecies = async (imageBlob, { onToken, signal, _telemetryState } = {}) => {
   let base64;
   try {
     base64 = await blobToBase64(imageBlob);
@@ -428,23 +435,30 @@ export const recognizeSpecies = async (imageBlob, { onToken, signal } = {}) => {
     return null;
   }
 
+  // V-12 2026-05-27: state compartido para enriquecer telemetría vision con
+  // `confidence` (parseado del modelo) y `grounded_status` (set por el
+  // wrapper `recognizeSpeciesGrounded` tras validar contra catálogo).
+  // `_telemetryState` es param interno opcional — wrappers como
+  // `recognizeSpeciesGrounded` lo pasan para extender la grabación.
+  const telemetryState = _telemetryState || {};
+
   // Primary: llama3.2-vision:11b (0 parse errors bench 2026-05-26).
   try {
-    return await runSpeciesRecognition(VISION_SPECIES_MODEL, base64, { onToken, signal });
+    return await runSpeciesRecognition(VISION_SPECIES_MODEL, base64, { onToken, signal, telemetryState });
   } catch (err) {
     console.warn(`[aiService] ${VISION_SPECIES_MODEL} failed, fallback to ${VISION_SPECIES_FALLBACK_MODEL}:`, err.message);
   }
 
   // Fallback 1: gemma3:4b (modelo de diagnóstico, ya cargado en VRAM normalmente).
   try {
-    return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_MODEL, base64, { onToken, signal });
+    return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_MODEL, base64, { onToken, signal, telemetryState });
   } catch (err) {
     console.warn(`[aiService] ${VISION_SPECIES_FALLBACK_MODEL} failed, fallback 2 to ${VISION_SPECIES_FALLBACK_2_MODEL}:`, err.message);
   }
 
   // Fallback 2: qwen2.5vl:7b (rápido pero parse errors frecuentes — último recurso).
   try {
-    return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_2_MODEL, base64, { onToken, signal });
+    return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_2_MODEL, base64, { onToken, signal, telemetryState });
   } catch (err) {
     console.warn('[aiService] Species recognition no disponible (3 fallbacks fallaron):', err.message);
     return null;

--- a/src/services/llmTelemetryService.js
+++ b/src/services/llmTelemetryService.js
@@ -27,6 +27,18 @@
  *                                 // Audit 2026-05-18 #4: tracking hit-rate del
  *                                 // RAG en `analyzeFoliage` y futuros consumers.
  *                                 // null cuando el call no consultó RAG.
+ *     confidence: 0.92,           // V-12 2026-05-27: confianza self-reported por
+ *                                 // el modelo de visión (campo `confidence` del
+ *                                 // JSON parseado en `recognizeSpecies`). Solo
+ *                                 // emitido por callers vision; resto omite.
+ *                                 // Rango esperado 0-1, sin coerción.
+ *     grounded_status: 'verified' // V-12 2026-05-27: resultado de validar contra
+ *                                 // catálogo Chagra vía `validate_visual_match`
+ *                                 // (sidecar agro-mcp). Valores:
+ *                                 //   'verified' → match estricto catálogo
+ *                                 //   'rejected' → modelo alucinó (not_in_catalog)
+ *                                 //   null       → sidecar offline / disabled
+ *                                 //                / call no usó grounding
  *     created_at: ISO,
  *     synced: false,
  *   }
@@ -79,6 +91,18 @@ export const recordLLMEvent = async (event) => {
     created_at: new Date().toISOString(),
     synced: false,
   };
+
+  // V-12 2026-05-27: campos opcionales del flujo visión. Omitir del payload
+  // cuando el caller no los provee (backward-compat strict — eventos no-vision
+  // como chat/extract no deben acarrear keys nulas innecesarias).
+  if (typeof event.confidence === 'number') {
+    record.confidence = event.confidence;
+  }
+  if (event.grounded_status !== undefined) {
+    // Acepta string ('verified'|'rejected'|otros) o null explícito (sidecar off).
+    // Solo omitimos si el caller no pasó la key.
+    record.grounded_status = event.grounded_status;
+  }
 
   try {
     const db = await openDB();
@@ -254,7 +278,7 @@ export const exportLLMTelemetry = async (format = 'json') => {
     const headers = ['id', 'created_at', 'model', 'endpoint', 'flujo', 'status',
                      'processor', 'total_ms', 'load_ms', 'eval_count',
                      'prompt_eval_count', 'eval_rate', 'error_kind',
-                     'rag_passages_used'];
+                     'rag_passages_used', 'confidence', 'grounded_status'];
     const rows = events.map((e) => headers.map((h) => e[h] ?? '').join(','));
     return [headers.join(','), ...rows].join('\n');
   }

--- a/src/services/ollamaStream.js
+++ b/src/services/ollamaStream.js
@@ -82,10 +82,13 @@ const extractChunk = (parsed) => {
  * @param {Function}    [options.onDone] callback invocado con el ultimo objeto
  *        del stream (done:true). Expone metadata de Ollama: model,
  *        total_duration, eval_count, prompt_eval_count, etc.
- * @param {Object}      [options.meta]   campos extra propagados al
+ * @param {Object|Function} [options.meta] campos extra propagados al
  *        `recordLLMEvent` final (solo en `success`). Ej.
  *        `{ rag_passages_used: 3 }` para análisis hit-rate RAG en el
  *        dashboard privado HYTA. Privacy-safe: no debe contener prompt/respuesta.
+ *        V-12 2026-05-27: también acepta función `() => Object` resuelta en
+ *        background al momento de grabar. Útil para campos derivados del
+ *        resultado parseado (ej. `confidence` de visión).
  * @returns {Promise<string>} texto completo concatenado al terminar.
  * @throws {Error} si el fetch falla, el servidor responde no-2xx o el body no es streameable.
  * @example
@@ -217,6 +220,18 @@ export async function streamOllama(url, body, onToken, { signal, onDone, meta } 
     : null;
   // Detección processor non-blocking (no esperamos, schedule en background)
   detectProcessorFor(lastDoneObj?.model || modelHint).then((processor) => {
+    // V-12: si `meta` es función, resolverla al momento de grabar para que
+    // el caller pueda enriquecer con datos derivados del parse (ej.
+    // `confidence`, `grounded_status` del flujo visión). Falla silente.
+    let resolvedMeta = {};
+    if (typeof meta === 'function') {
+      try {
+        const out = meta();
+        if (out && typeof out === 'object') resolvedMeta = out;
+      } catch (_) { /* meta thunk no debe romper telemetría */ }
+    } else if (meta && typeof meta === 'object') {
+      resolvedMeta = meta;
+    }
     recordLLMEvent({
       model: lastDoneObj?.model || modelHint,
       endpoint: url,
@@ -231,7 +246,7 @@ export async function streamOllama(url, body, onToken, { signal, onDone, meta } 
       // Meta extra del caller (ej. rag_passages_used para audit hit-rate RAG).
       // `recordLLMEvent` filtra a campos whitelisted del schema; cualquier
       // otra prop se descarta. Privacy-safe enforced en service layer.
-      ...(meta && typeof meta === 'object' ? meta : {}),
+      ...resolvedMeta,
     });
   });
 


### PR DESCRIPTION
## Summary

Implementa **V-12 audit visión**: telemetría de inferencias visuales se enriquece con `confidence` (self-reported del modelo) y `grounded_status` (resultado de validar contra catálogo Chagra vía `validate_visual_match`).

- **`confidence`** (number 0-1, opcional): leído del JSON parseado en `recognizeSpecies`. Permite distribuciones por modelo (llama3.2-vision vs gemma3:4b vs qwen2.5vl) y por especie.
- **`grounded_status`** (string|null, opcional):
  - `'verified'` → catálogo validó la especie sugerida.
  - `'rejected'` → modelo alucinó (`not_in_catalog`).
  - `null` → sidecar offline / disabled / binomial malformado (caller no pudo validar).

## Backward compatibility

Strict. Si el caller no pasa los campos, NO aparecen en el record. Eventos no-vision (chat / extract / summarize / help) preservan shape histórico — sin keys `null` innecesarias contaminando el store IDB.

## Cambios

| Archivo | Cambio |
|---|---|
| `src/services/llmTelemetryService.js` | Extiende schema `recordLLMEvent` con `confidence` + `grounded_status` opcionales. CSV export incluye las columnas nuevas. |
| `src/services/ollamaStream.js` | `meta` ahora acepta función-thunk resuelta al momento de grabar (necesario porque `confidence` y `grounded_status` son datos derivados disponibles después del stream). |
| `src/services/aiService.js` | `runSpeciesRecognition` mantiene `telemetryState` interno mutado tras parsear. `recognizeSpeciesGrounded` reusa el mismo state para anotar `grounded_status` tras validar contra catálogo. |
| `src/services/__tests__/llmTelemetry.visionFields.test.js` | 10 casos cobertura schema. |
| `src/services/__tests__/aiService.grounded.test.js` | +3 casos verificando el thunk-meta resuelve los 3 paths (verified / rejected / null). |

## Test plan

- [x] `npx vitest run src/services/__tests__/llmTelemetry.visionFields.test.js` → 10/10 pass.
- [x] `npx vitest run src/services/__tests__/aiService.grounded.test.js` → 10/10 pass.
- [x] `npx vitest run src/services/__tests__/aiService.test.js` → 19/19 pass.
- [x] `npx vitest run` → 1033 pass, 1 skip, 1 pre-existing fail no relacionado (`voiceService.test.js` por whisper ISO lang — issue separado documentado).
- [x] `npm run build` → sin warnings.
- [x] ESLint `--max-warnings=0` → clean.
- [ ] Dashboard Eco-Oracle: agregar tarjeta grounding rate por modelo (follow-up, no en este PR).

## Notas

- El thunk-meta es opt-in: el caller pasa función o objeto. Callers existentes (`analyzeFoliage` con `rag_passages_used`) siguen funcionando como objeto literal.
- `telemetryState` mutación es best-effort por timing con `detectProcessorFor` background. En la práctica el sidecar tarda más que la detección, así que el state está completo al grabar. Tests verifican que el thunk resuelve correctamente cuando se invoca después del flujo.