### PR TITLE
feat(bench): V-03 A/B RAG vs no-RAG en vision pipeline

### DIFF
--- a/data/bench-vision-fixtures-ground-truth.json
+++ b/data/bench-vision-fixtures-ground-truth.json
@@ -1,0 +1,120 @@
+{
+  "version": "1.0",
+  "generated_at": "2026-05-27T00:00:00Z",
+  "source": "/home/kortux/Workspace/Chagra-strategy/ops/antigravity/fixtures-fotos/",
+  "note": "16 fotos JPG aportadas por operador para test Antigravity. Ground-truth derivado del filename + catálogo Chagra v3.2 cuando aplica. Species sin match en catálogo (frambuesa, papayuela) usan binomial científico estándar GBIF/POWO.",
+  "fixtures": [
+    {
+      "file": "aguacate.jpg",
+      "species_id": "persea_americana",
+      "nombre_comun": "aguacate",
+      "scientific": "Persea americana",
+      "in_catalog": true
+    },
+    {
+      "file": "arracacha.jpg",
+      "species_id": "arracacia_xanthorrhiza",
+      "nombre_comun": "arracacha",
+      "scientific": "Arracacia xanthorrhiza",
+      "in_catalog": true
+    },
+    {
+      "file": "cafe.jpg",
+      "species_id": "coffea_arabica",
+      "nombre_comun": "cafe",
+      "scientific": "Coffea arabica",
+      "in_catalog": true
+    },
+    {
+      "file": "cubio.jpg",
+      "species_id": "tropaeolum_tuberosum",
+      "nombre_comun": "cubio",
+      "scientific": "Tropaeolum tuberosum",
+      "in_catalog": true
+    },
+    {
+      "file": "durazno.jpg",
+      "species_id": "prunus_persica",
+      "nombre_comun": "durazno",
+      "scientific": "Prunus persica",
+      "in_catalog": true
+    },
+    {
+      "file": "frambuesa.jpg",
+      "species_id": "rubus_idaeus",
+      "nombre_comun": "frambuesa",
+      "scientific": "Rubus idaeus",
+      "in_catalog": false
+    },
+    {
+      "file": "fresa.jpg",
+      "species_id": "fragaria_ananassa_monterrey",
+      "nombre_comun": "fresa",
+      "scientific": "Fragaria ananassa",
+      "in_catalog": true
+    },
+    {
+      "file": "frijol.jpg",
+      "species_id": "phaseolus_vulgaris",
+      "nombre_comun": "frijol",
+      "scientific": "Phaseolus vulgaris",
+      "in_catalog": true
+    },
+    {
+      "file": "guayaba brasilera.jpg",
+      "species_id": "acca_sellowiana",
+      "nombre_comun": "feijoa",
+      "scientific": "Acca sellowiana",
+      "in_catalog": true
+    },
+    {
+      "file": "limon.jpg",
+      "species_id": "citrus_latifolia",
+      "nombre_comun": "limon tahiti",
+      "scientific": "Citrus latifolia",
+      "in_catalog": true
+    },
+    {
+      "file": "lulo.jpg",
+      "species_id": "solanum_quitoense",
+      "nombre_comun": "lulo",
+      "scientific": "Solanum quitoense",
+      "in_catalog": true
+    },
+    {
+      "file": "mora.jpg",
+      "species_id": "rubus_glaucus",
+      "nombre_comun": "mora",
+      "scientific": "Rubus glaucus",
+      "in_catalog": true
+    },
+    {
+      "file": "papayuela.jpg",
+      "species_id": "vasconcellea_pubescens",
+      "nombre_comun": "papayuela",
+      "scientific": "Vasconcellea pubescens",
+      "in_catalog": false
+    },
+    {
+      "file": "romero.jpg",
+      "species_id": "rosmarinus_officinalis",
+      "nombre_comun": "romero",
+      "scientific": "Rosmarinus officinalis",
+      "in_catalog": true
+    },
+    {
+      "file": "tomate.jpg",
+      "species_id": "solanum_lycopersicum_cherry_estandar",
+      "nombre_comun": "tomate",
+      "scientific": "Solanum lycopersicum",
+      "in_catalog": true
+    },
+    {
+      "file": "uchuva.jpg",
+      "species_id": "physalis_peruviana",
+      "nombre_comun": "uchuva",
+      "scientific": "Physalis peruviana",
+      "in_catalog": true
+    }
+  ]
+}

--- a/scripts/bench-vision-ab-rag.mjs
+++ b/scripts/bench-vision-ab-rag.mjs
@@ -201,15 +201,17 @@ async function inferVisionOnce(model, prompt, imageBase64) {
 async function inferVision(model, prompt, imagePath) {
   const buf = fs.readFileSync(imagePath);
   const imageBase64 = buf.toString("base64");
-  // Retry hasta 3 veces si Ollama devuelve HTTP 5xx (típico cuando swap
-  // de modelos en VRAM o backend bajo carga concurrente con bench texto).
+  // Retry hasta 6 veces si Ollama devuelve HTTP 5xx ("model failed to load,
+  // resource limitations"). Pasa cuando otro bench paralelo (texto) hace
+  // swap de modelos en VRAM. Backoff 5s/10s/20s/40s/60s/90s.
   let last = null;
-  for (let i = 0; i < 3; i += 1) {
+  const backoffs = [5000, 10000, 20000, 40000, 60000, 90000];
+  for (let i = 0; i < backoffs.length; i += 1) {
     const r = await inferVisionOnce(model, prompt, imageBase64);
     last = r;
     if (!r.error || !/^HTTP 5/.test(r.error)) return r;
-    // Backoff 2s, 5s
-    await new Promise((res) => setTimeout(res, 2000 + i * 3000));
+    process.stdout.write(`    [retry ${i + 1}] ${r.error.slice(0, 60)} → waiting ${backoffs[i] / 1000}s\n`);
+    await new Promise((res) => setTimeout(res, backoffs[i]));
   }
   return last;
 }


### PR DESCRIPTION
## Summary

Bench A/B sobre `recognizeSpecies` (vision pipeline V-03 del audit visión 2026-05-26): mide si inyectar el catálogo Chagra al prompt del modelo de visión agrega valor sobre el prompt vanilla. Conclusión: **RAG-by-prompt empeora — mantener vanilla + post-validation sidecar (status quo)**.

- `scripts/bench-vision-ab-rag.mjs` — bench dual con misma versión llama3.2-vision:11b sobre cada fixture, una con bloque `<CATALOGO_CHAGRA>` (~186 binomials del catálogo Chagra v3.2) y otra con `SPECIES_PROMPT` vanilla idéntico al de `src/services/aiService.js:recognizeSpecies` hoy.
- `data/bench-vision-fixtures-ground-truth.json` — 16 fixtures con `species_id` + `nombre_comun` + `scientific` + `in_catalog` flag. Faltaba en disco (no estaba versionado); habilita reproducibilidad tanto de este bench como del existente `bench-vision-pipeline.mjs` (V-02).
- Retry robusto: 6 attempts con backoff exponencial 5s/10s/20s/40s/60s/90s para tolerar el HTTP 500 "model failed to load, resource limitations" que Ollama tira cuando hace swap de modelos en VRAM bajo carga concurrente (típicamente cuando otro bench texto pega `/api/generate` en el mismo Ollama).

## Resultados (run 2026-05-27T15-32-26)

Model llama3.2-vision:11b, 16 fixtures ground-truth, sidecar 7880, catalog hint 186 binomials / 5.6KB.

| Métrica | A (con RAG) | B (sin RAG) | Δ (A − B) |
|---|---:|---:|---:|
| Parse rate | 100.0% | 100.0% | 0.0pp |
| Common name accuracy | 6.3% | 25.0% | **-18.8pp** |
| Sci name accuracy (binomial) | 18.8% | 12.5% | +6.3pp |
| **Verified rate (sidecar)** | **6.3%** | **25.0%** | **-18.8pp** |
| **Hallucination rate** (rejected entre in-catalog) | **92.9%** (13/14) | **76.9%** (10/13) | **+15.9pp** |
| Latencia p50 | 26256ms | 4401ms | +21855ms |
| Latencia p95 | 68162ms | 80341ms | -12179ms |

## Interpretación

El catalog hint **degrada precisión**: el modelo escoge entries random del catálogo en vez de identificar honestamente. Ejemplos del raw.jsonl: aguacate A → \"Acacia mangium\" (¿porque empieza con A, primer alfabético?), cafe A → \"Acacia mangium\" (mientras B identifica \"coffea arabica\" correctamente). El catalog hint sesga al modelo hacia patterns equivocados.

La sospecha cualitativa: dar al modelo de visión una lista cerrada en el prompt + foto inflada con num_ctx=8192 le hace gastar atención en el listado en lugar de en la imagen.

## Recomendación

**Mantener `recognizeSpecies` vanilla (sin RAG-by-prompt)**. El post-validation sidecar via `validate_visual_match` (ya en producción tras PR V-02/V-05) sigue siendo el grounding correcto — captura hallucination sin sesgar la inferencia.

Si en el futuro se quiere reducir hallucination via prompt, probar enfoques alternativos: (a) top-K por familia botánica detectada vía pre-pass, (b) hint solo de las 5-10 species más comunes en la región del operador (no las 186 globales), o (c) confiar en post-validation sidecar (status quo).

## Test plan

- [x] Bench ejecutado en alpha host con ollama 11434 + sidecar 7880 reales
- [x] 16 fixtures procesadas, parse 100% en ambas variantes
- [x] summary.md generado en `data/bench-runs/vision-ab-rag-2026-05-27T15-32-26/`
- [x] eslint pasa (`npx eslint scripts/bench-vision-ab-rag.mjs` clean)
- [ ] Re-correr en cold-start (sin bench texto paralelo) para confirmar Δ — el run actual tuvo competencia VRAM con `bench-agente-completo.mjs`
- [ ] Repetir con N=30 (fixtures extended Wikimedia descargadas) para reducir varianza