### PR TITLE
feat(vision): remove RAG context from analyzeFoliage (V-03 follow-up)

### DIFF
--- a/src/services/__tests__/aiService.test.js
+++ b/src/services/__tests__/aiService.test.js
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mocks DEBEN declararse antes del import del módulo bajo test.
-// Audit 2026-05-18 #4: integramos RAG en analyzeFoliage; estos tests
-// aíslan el flujo de retrieval + prompt building + propagación de
-// rag_passages_used a la telemetría.
+//
+// Audit 2026-05-18 #4 integró RAG en `analyzeFoliage` (pre-pendiendo passages
+// al prompt). V-03 follow-up 2026-05-27 INVALIDA esa decisión para visión:
+// el bench A/B demostró que el RAG-en-prompt degrada accuracy/latencia. Estos
+// tests reflejan el nuevo régimen:
+//   - `analyzeFoliage` SIEMPRE usa `DIAGNOSIS_BASE_PROMPT` crudo (no RAG).
+//   - Los helpers `buildRagQuery`/`formatRagContext`/`buildDiagnosisPrompt` y
+//     `__retrieveRagContextForFoliage` siguen exportados (benches A/B los
+//     referencian) pero su `describe` block está marcado .skip — ya no son
+//     parte del flujo de producción.
 
 const streamOllamaMock = vi.fn();
 const retrieveMock = vi.fn();
@@ -44,7 +51,10 @@ beforeEach(() => {
   retrieveMock.mockReset();
 });
 
-describe('aiService — buildRagQuery (helper)', () => {
+// V-03 follow-up 2026-05-27: helpers RAG ya no se usan en prod. Tests skipped
+// pero preservados para que benches A/B (`bench-foliage-ab-rag`) tengan
+// referencia ejecutable si alguien los reactiva en experimentación.
+describe.skip('aiService — buildRagQuery (helper, deprecated en prod)', () => {
   it('con speciesSlug → query especifica + tokens fitosanitarios', () => {
     const q = __TEST__.buildRagQuery('fragaria_ananassa_monterrey');
     expect(q).toContain('fragaria ananassa monterrey');
@@ -65,7 +75,7 @@ describe('aiService — buildRagQuery (helper)', () => {
   });
 });
 
-describe('aiService — formatRagContext (helper)', () => {
+describe.skip('aiService — formatRagContext (helper, deprecated en prod)', () => {
   it('passages vacíos → string vacío (caller usa prompt base)', () => {
     expect(__TEST__.formatRagContext([])).toBe('');
     expect(__TEST__.formatRagContext(null)).toBe('');
@@ -104,7 +114,7 @@ describe('aiService — formatRagContext (helper)', () => {
   });
 });
 
-describe('aiService — buildDiagnosisPrompt (helper)', () => {
+describe.skip('aiService — buildDiagnosisPrompt (helper, deprecated en prod)', () => {
   it('sin contexto → usa DIAGNOSIS_BASE_PROMPT crudo (degrade graceful)', () => {
     expect(__TEST__.buildDiagnosisPrompt('')).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
     expect(__TEST__.buildDiagnosisPrompt(null)).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
@@ -120,7 +130,7 @@ describe('aiService — buildDiagnosisPrompt (helper)', () => {
   });
 });
 
-describe('aiService — __retrieveRagContextForFoliage (graceful degrade)', () => {
+describe.skip('aiService — __retrieveRagContextForFoliage (graceful degrade, deprecated en prod)', () => {
   it('retrieve falla → retorna [] sin propagar la excepción', async () => {
     retrieveMock.mockRejectedValueOnce(new Error('corpus boom'));
     const result = await __retrieveRagContextForFoliage('cualquier');
@@ -141,30 +151,22 @@ describe('aiService — __retrieveRagContextForFoliage (graceful degrade)', () =
   });
 });
 
-describe('aiService — analyzeFoliage integración RAG', () => {
-  it('con speciesSlug → retrieve query incluye el slug + 3 passages al prompt', async () => {
-    retrieveMock.mockResolvedValueOnce([
-      { text: 'Mancha foliar en fresa por Mycosphaerella fragariae.', species: 'fragaria_ananassa_monterrey', key: 'valor_pedagogico' },
-      { text: 'Manejo: caldo bordelés 1%, podar foliolos enfermos.', species: 'fragaria_ananassa_monterrey', key: 'manejo_agroecologico' },
-      { text: 'AGROSAVIA recomienda inspección semanal en clima frío húmedo.', species: 'fragaria_ananassa_monterrey', key: 'monitoreo' },
-    ]);
+describe('aiService — analyzeFoliage (V-03 follow-up: sin RAG en prompt visión)', () => {
+  it('con speciesSlug → NO invoca retrieve y usa DIAGNOSIS_BASE_PROMPT crudo', async () => {
     streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
 
     const result = await analyzeFoliage(makeBlob(), { speciesSlug: 'fragaria_ananassa_monterrey' });
 
-    expect(retrieveMock).toHaveBeenCalledTimes(1);
-    const [retrieveQuery, retrieveK] = retrieveMock.mock.calls[0];
-    expect(retrieveQuery).toContain('fragaria ananassa monterrey');
-    expect(retrieveK).toBe(3);
+    // V-03 follow-up: retrieve NO debe invocarse desde analyzeFoliage en prod.
+    expect(retrieveMock).not.toHaveBeenCalled();
 
     expect(streamOllamaMock).toHaveBeenCalledTimes(1);
     const [, body, , options] = streamOllamaMock.mock.calls[0];
     expect(body.model).toBe('gemma3:4b');
-    expect(body.prompt).toContain('<CONTEXTO_CIENTÍFICO>');
-    expect(body.prompt).toContain('Mycosphaerella fragariae');
-    expect(body.prompt).toContain('caldo bordelés');
-    expect(body.prompt).toMatch(/cit.*fuente/i);
-    expect(options.meta).toEqual({ rag_passages_used: 3 });
+    expect(body.prompt).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
+    expect(body.prompt).not.toContain('<CONTEXTO_CIENTÍFICO>');
+    // Telemetría siempre 0 ahora: facilita distinguir el régimen post-V-03.
+    expect(options.meta).toEqual({ rag_passages_used: 0 });
 
     expect(result).toEqual({
       score: 78,
@@ -174,50 +176,28 @@ describe('aiService — analyzeFoliage integración RAG', () => {
     });
   });
 
-  it('sin speciesSlug → fallback query genérica + prompt aún incluye contexto si RAG matchea', async () => {
-    retrieveMock.mockResolvedValueOnce([
-      { text: 'Pautas generales de manejo agroecológico colombiano.', species: 'general', key: 'guía' },
-    ]);
+  it('sin speciesSlug → mismo régimen, prompt base crudo, sin retrieve', async () => {
     streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
 
     await analyzeFoliage(makeBlob(), {});
 
-    const [retrieveQuery] = retrieveMock.mock.calls[0];
-    expect(retrieveQuery).toBe(__TEST__.RAG_FALLBACK_QUERY);
-
+    expect(retrieveMock).not.toHaveBeenCalled();
     const [, body, , options] = streamOllamaMock.mock.calls[0];
-    expect(body.prompt).toContain('<CONTEXTO_CIENTÍFICO>');
-    expect(options.meta).toEqual({ rag_passages_used: 1 });
+    expect(body.prompt).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
+    expect(options.meta).toEqual({ rag_passages_used: 0 });
   });
 
-  it('RAG retorna [] (cold-start / sin matches) → usa DIAGNOSIS_BASE_PROMPT crudo', async () => {
-    retrieveMock.mockResolvedValueOnce([]);
+  it('ignora speciesSlug aunque venga válido (parámetro aceptado por compat)', async () => {
     streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
 
     await analyzeFoliage(makeBlob(), { speciesSlug: 'planta_inexistente' });
 
-    const [, body, , options] = streamOllamaMock.mock.calls[0];
+    expect(retrieveMock).not.toHaveBeenCalled();
+    const [, body] = streamOllamaMock.mock.calls[0];
     expect(body.prompt).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
-    expect(body.prompt).not.toContain('<CONTEXTO_CIENTÍFICO>');
-    expect(options.meta).toEqual({ rag_passages_used: 0 });
-  });
-
-  it('RAG lanza excepción → degrade graceful al prompt base sin romper analyzeFoliage', async () => {
-    retrieveMock.mockRejectedValueOnce(new Error('boom corpus'));
-    streamOllamaMock.mockResolvedValueOnce(happyDiagnosisJson);
-
-    const result = await analyzeFoliage(makeBlob(), { speciesSlug: 'cualquier' });
-
-    expect(result).not.toBeNull();
-    expect(result.score).toBe(78);
-
-    const [, body, , options] = streamOllamaMock.mock.calls[0];
-    expect(body.prompt).toBe(__TEST__.DIAGNOSIS_BASE_PROMPT);
-    expect(options.meta).toEqual({ rag_passages_used: 0 });
   });
 
   it('streamOllama falla → retorna null sin romper (contrato legacy preservado)', async () => {
-    retrieveMock.mockResolvedValueOnce([]);
     streamOllamaMock.mockRejectedValueOnce(new Error('ollama down'));
 
     const result = await analyzeFoliage(makeBlob(), {});
@@ -225,7 +205,6 @@ describe('aiService — analyzeFoliage integración RAG', () => {
   });
 
   it('response con markdown fences → JSON.parse robusto', async () => {
-    retrieveMock.mockResolvedValueOnce([]);
     streamOllamaMock.mockResolvedValueOnce('```json\n' + happyDiagnosisJson + '\n```');
 
     const result = await analyzeFoliage(makeBlob(), {});
@@ -234,7 +213,6 @@ describe('aiService — analyzeFoliage integración RAG', () => {
   });
 
   it('legacy: respuesta sin field treatment → treatment_suggestion vacío', async () => {
-    retrieveMock.mockResolvedValueOnce([]);
     streamOllamaMock.mockResolvedValueOnce(JSON.stringify({ score: 95, issues: [] }));
     const result = await analyzeFoliage(makeBlob(), {});
     expect(result.treatment_suggestion).toBe('');

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -6,11 +6,18 @@
  * respuesta en streaming NDJSON via `streamOllama`, permitiendo a la UI
  * mostrar el diagnóstico token-por-token con efecto typewriter.
  *
- * Audit 2026-05-18 finding #4 (P2): `analyzeFoliage` ahora consume RAG
- * (`ragRetriever.retrieve`) para pre-pendear top-3 passages del corpus
- * `cycle-content/*.json` al prompt. Resultado: diagnóstico contextualizado
- * con `valor_pedagogico`, manejo agroecológico y fuentes del catálogo
- * (AGROSAVIA / IDEAM / POWO) en lugar de respuesta genérica.
+ * Audit 2026-05-18 finding #4 (P2): `analyzeFoliage` originalmente consumía
+ * RAG (`ragRetriever.retrieve`) para pre-pendear top-3 passages del corpus
+ * `cycle-content/*.json` al prompt del modelo de visión.
+ *
+ * V-03 follow-up 2026-05-27 — INVALIDA decisión #4 para visión: el bench A/B
+ * (bench-foliage-ab-rag) demostró que inyectar contexto RAG al prompt del
+ * modelo multimodal PERJUDICA: 5x más latencia, 62.5% vs 50% halluc proxy,
+ * treatments verbose alucinatorios (342 vs 53 chars). El bench V-03 paralelo
+ * sobre `recognizeSpecies` mostró -18.8pp accuracy con catalog hint. Por eso
+ * `analyzeFoliage` ahora usa `DIAGNOSIS_BASE_PROMPT` crudo. El corpus RAG
+ * sigue intacto (`ragRetriever.js`) y útil para post-validate, resolve-entities
+ * y agent text chat — la regresión solo aplica al prompt del modelo de visión.
  *
  * @typedef {import('../types').ChagraAsset} ChagraAsset
  * @typedef {import('../types').ChagraLog} ChagraLog
@@ -41,8 +48,9 @@ const VISION_SPECIES_MODEL = 'llama3.2-vision:11b';
 const VISION_SPECIES_FALLBACK_MODEL = 'gemma3:4b';
 const VISION_SPECIES_FALLBACK_2_MODEL = 'qwen2.5vl:7b';
 
-// Prompt base sin contexto RAG. Fallback usado cuando el corpus no cargó
-// o el retrieve no devolvió passages relevantes.
+// Prompt base del modelo de visión. Desde V-03 follow-up 2026-05-27 es el
+// único prompt usado por `analyzeFoliage` en producción — inyectar contexto
+// RAG en el prompt degrada accuracy/latencia (ver docblock superior).
 const DIAGNOSIS_BASE_PROMPT = 'detect disease, nutrient deficiency, and overall plant health. Output JSON: {"score": 0-100, "issues": [], "treatment": ""}';
 
 // Query genérica para fallback cuando no conocemos la especie. Apunta a
@@ -150,7 +158,13 @@ const blobToBase64 = (blob) =>
  * Recupera contexto RAG para `analyzeFoliage` con tolerancia total a fallos.
  * Cualquier excepción (corpus no cargado, fetch failure, BM25 vacío) retorna
  * `[]` para que el caller use el prompt base sin contexto. Audit finding #4
- * exige degrade graceful: vision diagnóstico nunca debe romperse por RAG.
+ * exigía degrade graceful: vision diagnóstico nunca debe romperse por RAG.
+ *
+ * @deprecated V-03 follow-up 2026-05-27 — RAG perjudica en prompt visión.
+ *   Ya no se invoca desde `analyzeFoliage` en producción. Se mantiene exportada
+ *   porque tests internos y benches A/B (`bench-foliage-ab-rag`) la referencian.
+ *   NO usar en nuevo código de visión; el corpus sigue siendo válido para
+ *   `voiceRagEnricher`, post-validate y agent text chat.
  *
  * @internal exportado solo para tests.
  */
@@ -168,12 +182,15 @@ export const __retrieveRagContextForFoliage = async (speciesSlug) => {
 /**
  * Analiza una imagen de follaje via Ollama (modelo multimodal) en streaming.
  *
- * Desde audit 2026-05-18 #4: pre-pende top-3 passages del RAG (`ragRetriever`)
- * al `DIAGNOSIS_BASE_PROMPT` para que el modelo cite catálogo agroecológico
- * (`valor_pedagogico`, manejo plagas, etc.) en lugar de alucinar treatments.
- * Si `speciesSlug` está disponible, el RAG query es específico; si no, usa
- * fallback genérico. Cold-start o fallo RAG → degrade transparente al prompt
- * estático original.
+ * V-03 follow-up 2026-05-27 — invalida la integración RAG en prompt visión
+ * introducida por audit 2026-05-18 #4. El bench A/B (`bench-foliage-ab-rag`)
+ * demostró que inyectar passages al prompt del modelo multimodal degrada el
+ * resultado: 5x más latencia, halluc proxy 62.5% vs 50%, treatments verbose
+ * alucinatorios. Por eso `analyzeFoliage` ahora usa SIEMPRE el prompt base
+ * crudo (`DIAGNOSIS_BASE_PROMPT`). El parámetro `speciesSlug` se mantiene en
+ * la firma porque varios callers lo pasan, pero ya no se usa internamente
+ * para RAG. El corpus sigue intacto para post-validate, resolve-entities y
+ * agent text chat — la regresión solo aplica al prompt del modelo de visión.
  *
  * @param {Blob} imageBlob - imagen optimizada (WebP)
  * @param {Object} [options]
@@ -181,31 +198,31 @@ export const __retrieveRagContextForFoliage = async (speciesSlug) => {
  *        por cada token emitido por el modelo. La UI lo usa para mostrar el
  *        diagnóstico apareciendo caracter-a-caracter.
  * @param {AbortSignal} [options.signal] - cancelación externa.
- * @param {string} [options.speciesSlug] - slug del catálogo (ej.
- *        `fragaria_ananassa_monterrey`). Cuando se conoce, el retrieve apunta
- *        al passage de esa especie. Si es null/undefined, fallback genérico.
+ * @param {string} [options.speciesSlug] - slug del catálogo. Aceptado por
+ *        compatibilidad con callers existentes pero NO se usa internamente
+ *        desde V-03 follow-up. Reservado para futuros experimentos no-prompt.
  * @param {string} [options.assetId] - solo telemetría, opcional. No se
  *        persiste (privacy-safe).
  * @returns {Promise<{score: number, issues: string[], treatment_suggestion: string} | null>}
  *          null si el modelo no responde o no es multimodal.
  * @example
  * const result = await analyzeFoliage(imageBlob, {
- *   speciesSlug: 'fragaria_ananassa_monterrey',
  *   onToken: (chunk, text) => setDiagnosis(text),
  * });
- * // result => { score: 85, issues: ["mancha foliar"], treatment_suggestion: "aplicar caldo bordelés (Fuente 1)" }
+ * // result => { score: 85, issues: ["mancha foliar"], treatment_suggestion: "aplicar caldo bordelés" }
  */
 // eslint-disable-next-line no-unused-vars
 export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, assetId } = {}) => {
   try {
     const base64 = await blobToBase64(imageBlob);
 
-    // 1) RAG context (graceful degrade — nunca rompe el call si falla)
-    const passages = await __retrieveRagContextForFoliage(speciesSlug);
-    const ragContext = formatRagContext(passages);
-    const prompt = buildDiagnosisPrompt(ragContext);
+    // V-03 follow-up 2026-05-27: prompt base crudo, sin contexto RAG. El bench
+    // A/B demostró que inyectar passages al prompt visión degrada accuracy y
+    // latencia. `speciesSlug` queda en la firma pero no se usa acá.
+    const prompt = DIAGNOSIS_BASE_PROMPT;
 
-    // 2) Vision call con telemetría enriquecida (`rag_passages_used`).
+    // Vision call. Telemetría reporta `rag_passages_used:0` siempre para que
+    // el dashboard distinga claramente este régimen del histórico pre-V-03.
     // streamOllama hace fetch con stream:true y procesa el NDJSON del body.
     // No usa fetchFromFarmOS para evitar inyección de headers OAuth — Ollama
     // local no requiere autenticación.
@@ -213,7 +230,7 @@ export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, 
       OLLAMA_URL,
       { model: DIAGNOSIS_MODEL, prompt, images: [base64] },
       onToken,
-      { signal, meta: { rag_passages_used: passages.length } },
+      { signal, meta: { rag_passages_used: 0 } },
     )).trim();
 
     // Parsear JSON (Gemma puede envolver en markdown fences)


### PR DESCRIPTION
## Summary

- V-03 bench (recognizeSpecies con/sin catalog hint) y bench-foliage-ab-rag (analyzeFoliage con/sin RAG mock) concluyen que inyectar contexto RAG en el prompt del modelo de vision PERJUDICA: recognizeSpecies -18.8pp accuracy; analyzeFoliage 5x mas latencia, 62.5% vs 50% halluc proxy, treatments verbose alucinatorios (342 vs 53 chars).
- `analyzeFoliage` ahora usa SIEMPRE `DIAGNOSIS_BASE_PROMPT` crudo. La llamada a `__retrieveRagContextForFoliage` se removio del flujo de produccion.
- `speciesSlug` se mantiene como parametro por compatibilidad con callers existentes pero ya no se usa internamente para RAG.
- `__retrieveRagContextForFoliage` queda exportada y marcada `@deprecated` (benches A/B y tests internos siguen referenciandola).
- El corpus RAG (`ragRetriever.js`) sigue intacto y util para post-validate, resolve-entities y agent text chat — la regresion solo aplica al prompt del modelo de vision.

## Cambios concretos

- `src/services/aiService.js`:
  - Docblock superior actualizado citando V-03 follow-up como invalidacion de la decision audit 2026-05-18 #4 para el prompt del modelo de vision.
  - `analyzeFoliage` ahora arma `prompt = DIAGNOSIS_BASE_PROMPT` directamente, sin retrieve ni formatRagContext.
  - Telemetria `meta.rag_passages_used` queda fija en 0 para distinguir el regimen post-V-03 en el dashboard.
  - `__retrieveRagContextForFoliage` marcada `@deprecated` con referencia al follow-up.
- `src/services/__tests__/aiService.test.js`:
  - Tests integracion `analyzeFoliage` adaptados al nuevo regimen sin RAG: verifican que `retrieve` NUNCA se invoca y que el prompt es exactamente `DIAGNOSIS_BASE_PROMPT`.
  - Tests de helpers RAG (`buildRagQuery`, `formatRagContext`, `buildDiagnosisPrompt`, `__retrieveRagContextForFoliage`) marcados `describe.skip` con comentario explicativo (siguen ejecutables si benches A/B los reactivan).

## Test plan

- [x] `npm test --silent` (vitest): 1022 tests pasan. Los unicos 2 failures (grounded `sidecar-disabled` y voiceService `language=es-CO`) son pre-existentes en `main` y no se relacionan con este cambio.
- [x] `npm run build` (vite): build exitoso en ~2.5s.
- [x] `npx eslint` en archivos modificados: sin warnings.
- [ ] Smoke test en preview deploy: foto de hoja → diagnostico aparece con latencia menor que antes y sin treatments fabricados con citas "Fuente X".