### PR TITLE
feat: Tier S iter 2 — warm text + species_id validate + image size guard

### DIFF
--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-25T20:32:15.123Z",
+  "generated_at": "2026-05-27T18:15:46.144Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -8,6 +8,7 @@ import ChagraGrowLoader from './ChagraGrowLoader';
 import LegalLinks from './LegalLinks';
 import WelcomeStatsHero from './WelcomeStatsHero';
 import useOllamaWarmStore from '../store/useOllamaWarmStore';
+import { warmTextModels } from '../services/textWarmService';
 
 export default function LoginScreen({ onLoginSuccess, onSave }) {
   const [creds, setCreds] = useState({ username: '', password: '' });
@@ -74,6 +75,16 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
       } catch (err) {
         // No bloquear login si falla (ej. tests sin fetch global).
         console.warn('[LoginScreen] ollama warm-up dispatch failed:', err);
+      }
+      // QUICK-4 (Tier S iter 2, 2026-05-27): pre-warm adicional de modelos
+      // texto (gemma3:4b + granite3.1-dense:8b) con keep_alive=10m. Esto
+      // complementa el `useOllamaWarmStore` (gemma3 a 30m): cubre `granite`
+      // que el llmRouter usa cuando la query es sensible a alucinación.
+      // Fire-and-forget — degrada silencioso si Ollama no responde.
+      try {
+        warmTextModels().catch(() => {});
+      } catch (err) {
+        console.warn('[LoginScreen] text models warm dispatch failed:', err);
       }
       setLoading(false);
       onLoginSuccess();

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -201,6 +201,19 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
     } catch (err) {
       console.warn('[SpeciesSelect] AI recognition failed:', err);
       setAiState('error');
+      // QUICK-16: si el throw vino de validateImageSize (mensaje "muy grande"),
+      // mostramos toast user-friendly. Otros errores (vision fail, parse fail)
+      // ya van al estado 'error' visual del componente.
+      const msg = err?.message || '';
+      if (/muy grande/i.test(msg)) {
+        try {
+          window.dispatchEvent(
+            new CustomEvent('chagraToast', { detail: { message: msg } }),
+          );
+        } catch {
+          /* test env sin window.dispatchEvent — ignorar */
+        }
+      }
     } finally {
       if (aiCameraRef.current) aiCameraRef.current.value = '';
       if (aiGalleryRef.current) aiGalleryRef.current.value = '';

--- a/src/services/__tests__/aiService.grounded.test.js
+++ b/src/services/__tests__/aiService.grounded.test.js
@@ -175,6 +175,44 @@ describe('recognizeSpeciesGrounded', () => {
     expect(sidecarClient.callTool).not.toHaveBeenCalled();
   });
 
+  // QUICK-17 (Tier S iter 2, 2026-05-27): pre-validate species_id ASCII +
+  // snake_case ANTES de pegar al sidecar. Bench V-03 detectó `Fragaria ×
+  // ananassa` (hybrid notation) que produce HTTP 400 después de un network
+  // roundtrip desperdiciado.
+  it('status:no-binomial cuando scientific_name tiene hybrid notation (Fragaria × ananassa)', async () => {
+    mockVisionResponse({
+      common_name_es: 'fresa',
+      scientific_name: 'Fragaria × ananassa', // × no es ASCII letra
+      confidence: 0.8,
+      alternatives: [],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded.status).toBe('no-binomial');
+    expect(result._grounded.reason).toMatch(/ambiguo/i);
+    expect(result._grounded.validation).toBeNull();
+    // No debe haber llamado al sidecar — la pre-validación en frontend lo
+    // evita y ahorra el roundtrip + el 400 del sidecar.
+    expect(sidecarClient.callTool).not.toHaveBeenCalled();
+  });
+
+  it('status:no-binomial cuando scientific_name tiene caracteres unicode (Solanum tubérosum)', async () => {
+    mockVisionResponse({
+      common_name_es: 'papa',
+      scientific_name: 'Solanum tubérosum', // tilde en é
+      confidence: 0.75,
+      alternatives: [],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded.status).toBe('no-binomial');
+    expect(sidecarClient.callTool).not.toHaveBeenCalled();
+  });
+
   it('incluye alternativas en candidates cuando el vision las devuelve', async () => {
     mockVisionResponse({
       common_name_es: 'café',

--- a/src/services/__tests__/aiService.test.js
+++ b/src/services/__tests__/aiService.test.js
@@ -240,3 +240,99 @@ describe('aiService — analyzeFoliage integración RAG', () => {
     expect(result.treatment_suggestion).toBe('');
   });
 });
+
+describe('aiService — scientificToSpeciesId (QUICK-17 ASCII snake_case)', () => {
+  it('binomial limpio → snake_case lowercase', () => {
+    expect(__TEST__.scientificToSpeciesId('Coffea arabica')).toBe('coffea_arabica');
+    expect(__TEST__.scientificToSpeciesId('Solanum lycopersicum')).toBe('solanum_lycopersicum');
+  });
+
+  it('descarta autoría taxonómica (L., Mart., Triana ex Micheli)', () => {
+    expect(__TEST__.scientificToSpeciesId('Coffea arabica L.')).toBe('coffea_arabica');
+    expect(__TEST__.scientificToSpeciesId('Erythrina edulis Triana ex Micheli')).toBe('erythrina_edulis');
+  });
+
+  it('hybrid notation Fragaria × ananassa → null (× no es ASCII letra)', () => {
+    // parts[0]='Fragaria', parts[1]='×' → falla regex epíteto.
+    expect(__TEST__.scientificToSpeciesId('Fragaria × ananassa')).toBeNull();
+  });
+
+  it('input vacío o no-string → null', () => {
+    expect(__TEST__.scientificToSpeciesId('')).toBeNull();
+    expect(__TEST__.scientificToSpeciesId('   ')).toBeNull();
+    expect(__TEST__.scientificToSpeciesId(null)).toBeNull();
+    expect(__TEST__.scientificToSpeciesId(undefined)).toBeNull();
+    expect(__TEST__.scientificToSpeciesId(42)).toBeNull();
+  });
+
+  it('una sola palabra (sin epíteto) → null', () => {
+    expect(__TEST__.scientificToSpeciesId('Coffea')).toBeNull();
+  });
+});
+
+describe('aiService — validateImageSize (QUICK-16 guard pre-Ollama)', () => {
+  // Importamos en este describe para no contaminar el resto de describes con
+  // la dependencia (validateImageSize es export adicional del módulo).
+  let validateImageSize;
+  beforeEach(async () => {
+    ({ validateImageSize } = await import('../aiService'));
+  });
+
+  it('blob pequeño (<2MB) no lanza', () => {
+    const blob = new Blob(['x'.repeat(1024)], { type: 'image/webp' }); // 1 KB
+    expect(() => validateImageSize(blob)).not.toThrow();
+  });
+
+  it('blob límite (2MB exactos) no lanza (umbral inclusive)', () => {
+    // Exactamente MAX_IMAGE_BYTES → no throw (>2MB es el corte).
+    const blob = new Blob([new Uint8Array(2_000_000)], { type: 'image/webp' });
+    expect(() => validateImageSize(blob)).not.toThrow();
+  });
+
+  it('blob >2MB lanza Error con mensaje en español + tamaño', () => {
+    const blob = new Blob([new Uint8Array(2_500_000)], { type: 'image/webp' }); // 2.5 MB
+    expect(() => validateImageSize(blob)).toThrow(/muy grande/i);
+    expect(() => validateImageSize(blob)).toThrow(/2\.5 MB/);
+    expect(() => validateImageSize(blob)).toThrow(/reduce calidad/i);
+  });
+
+  it('null/undefined → no lanza (defer al caller propio handling)', () => {
+    expect(() => validateImageSize(null)).not.toThrow();
+    expect(() => validateImageSize(undefined)).not.toThrow();
+  });
+
+  it('objeto sin .size → no lanza (no es blob válido)', () => {
+    expect(() => validateImageSize({})).not.toThrow();
+    expect(() => validateImageSize({ size: 'huge' })).not.toThrow();
+  });
+
+  it('analyzeFoliage con blob >2MB → throw bubble-up al caller (no swallow)', async () => {
+    const { analyzeFoliage } = await import('../aiService');
+    const bigBlob = new Blob([new Uint8Array(3_000_000)], { type: 'image/webp' });
+    // No mockeamos retrieve/streamOllama porque la validación debe fallar ANTES.
+    await expect(analyzeFoliage(bigBlob, {})).rejects.toThrow(/muy grande/i);
+  });
+
+  it('recognizeSpecies con blob >2MB → throw bubble-up al caller', async () => {
+    const { recognizeSpecies } = await import('../aiService');
+    const bigBlob = new Blob([new Uint8Array(2_500_000)], { type: 'image/webp' });
+    await expect(recognizeSpecies(bigBlob, {})).rejects.toThrow(/muy grande/i);
+  });
+});
+
+describe('aiService — VALID_SPECIES_ID regex (QUICK-17 sidecar pre-check)', () => {
+  it('acepta snake_case ASCII puro', () => {
+    expect(__TEST__.VALID_SPECIES_ID.test('coffea_arabica')).toBe(true);
+    expect(__TEST__.VALID_SPECIES_ID.test('fragaria_ananassa_monterrey')).toBe(true);
+    expect(__TEST__.VALID_SPECIES_ID.test('zea_mays_var_24')).toBe(true);
+  });
+
+  it('rechaza mayúsculas, espacios, unicode, caracteres especiales', () => {
+    expect(__TEST__.VALID_SPECIES_ID.test('Coffea_arabica')).toBe(false); // mayúscula
+    expect(__TEST__.VALID_SPECIES_ID.test('coffea arabica')).toBe(false); // espacio
+    expect(__TEST__.VALID_SPECIES_ID.test('fragaria_×_ananassa')).toBe(false); // ×
+    expect(__TEST__.VALID_SPECIES_ID.test('solanum-tuberosum')).toBe(false); // guión
+    expect(__TEST__.VALID_SPECIES_ID.test('solanum.tuberosum')).toBe(false); // punto
+    expect(__TEST__.VALID_SPECIES_ID.test('')).toBe(false); // vacío
+  });
+});

--- a/src/services/__tests__/textWarmService.test.js
+++ b/src/services/__tests__/textWarmService.test.js
@@ -1,0 +1,110 @@
+/**
+ * textWarmService — QUICK-4 Tier S iter 2 (2026-05-27).
+ *
+ * Cubre warm fire-and-forget al login de modelos texto Ollama:
+ *   - dispara fetch a `/api/ollama/api/generate` para gemma3:4b + granite3.1-dense:8b
+ *   - payload correcto (model, prompt vacío, keep_alive=10m)
+ *   - idempotencia: en flight, no dispara segunda
+ *   - skipIfRecent: si hace <8min, no re-dispara
+ *   - errores degradan silenciosos (no throw)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { warmTextModels, __resetTextWarmState, __TEST__ } from '../textWarmService';
+
+describe('textWarmService — QUICK-4 warm modelos texto on-login', () => {
+  beforeEach(() => {
+    __resetTextWarmState();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('TEXT_MODELS incluye gemma3:4b y granite3.1-dense:8b', () => {
+    expect(__TEST__.TEXT_MODELS).toContain('gemma3:4b');
+    expect(__TEST__.TEXT_MODELS).toContain('granite3.1-dense:8b');
+  });
+
+  it('KEEP_ALIVE = "10m" para warm post-login (8min skip threshold + 2min margen)', () => {
+    expect(__TEST__.KEEP_ALIVE).toBe('10m');
+  });
+
+  it('warmTextModels dispara POST por cada modelo con payload correcto', async () => {
+    fetch.mockResolvedValue({ ok: true });
+    const result = await warmTextModels();
+    expect(result).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(__TEST__.TEXT_MODELS.length);
+
+    for (const call of fetch.mock.calls) {
+      const [url, opts] = call;
+      expect(url).toBe('/api/ollama/api/generate');
+      expect(opts.method).toBe('POST');
+      const body = JSON.parse(opts.body);
+      expect(body.prompt).toBe('');
+      expect(body.stream).toBe(false);
+      expect(body.keep_alive).toBe('10m');
+      expect(__TEST__.TEXT_MODELS).toContain(body.model);
+    }
+  });
+
+  it('idempotencia: warm reciente (<8min) skipea sin disparar fetch', async () => {
+    fetch.mockResolvedValue({ ok: true });
+    await warmTextModels();
+    expect(fetch).toHaveBeenCalledTimes(__TEST__.TEXT_MODELS.length);
+
+    const callsAfterFirst = fetch.mock.calls.length;
+    const result = await warmTextModels();
+    expect(result).toBe(true);
+    // No nuevos fetches porque el lock SKIP_IF_RECENT_MS está activo.
+    expect(fetch.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('fetch rechaza → degrada silencioso sin throw', async () => {
+    fetch.mockRejectedValue(new Error('network down'));
+    // Si no degrada, esto throwearía y rompería el test.
+    const result = await warmTextModels();
+    expect(result).toBe(false);
+  });
+
+  it('fetch responde HTTP 500 → degrada silencioso, retorna false', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 500 });
+    const result = await warmTextModels();
+    expect(result).toBe(false);
+  });
+
+  it('warm con un modelo OK + uno fallando → retorna true (best-effort)', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+    const result = await warmTextModels();
+    expect(result).toBe(true);
+  });
+
+  it('llamadas concurrentes mientras una está in-flight → idempotente', async () => {
+    // Cada fetch captura su resolver — necesitamos resolver TODOS los modelos
+    // para que el Promise.all interno termine.
+    const resolvers = [];
+    fetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(() => resolve({ ok: true }));
+        }),
+    );
+
+    const p1 = warmTextModels();
+    const p2 = warmTextModels();
+    const p3 = warmTextModels();
+
+    // p2/p3 deben retornar true inmediatamente sin disparar nuevos fetches.
+    await expect(p2).resolves.toBe(true);
+    await expect(p3).resolves.toBe(true);
+
+    // Resolver todos los fetches para que p1 complete.
+    resolvers.forEach((r) => r());
+    await p1;
+    // Solo TEXT_MODELS fetches del primer call, no de p2/p3.
+    expect(fetch).toHaveBeenCalledTimes(__TEST__.TEXT_MODELS.length);
+  });
+});

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -130,6 +130,30 @@ const buildDiagnosisPrompt = (ragContext) => {
  */
 const SPECIES_PROMPT = 'Identify the plant species in the image. Output JSON ONLY, no markdown: {"common_name_es": "<nombre comun en español, lowercase>", "scientific_name": "<binomial>", "confidence": <0-1>, "alternatives": [{"common_name_es": "...", "scientific_name": "...", "confidence": <0-1>}]}. If you cannot identify confidently (confidence < 0.5), set common_name_es to empty string and provide alternatives. Limit alternatives to 2.';
 
+// QUICK-16 (Tier S iter 2, 2026-05-27): guard de tamaño antes de pegar a
+// Ollama. PWA comprime con `optimizeImage` (WebP @ 0.8 quality, maxWidth 1280)
+// pero Samsung HDR raw o screenshots de alta resolución a veces entran al
+// pipeline sin pasar por la compresión (ej. share-to-app, formularios sin
+// optimizer). Si llegan >2MB, Ollama vision encola ~30s antes de devolver
+// error de payload — UX malo. Mejor catchear local con mensaje claro.
+const MAX_IMAGE_BYTES = 2_000_000; // 2 MB
+
+/**
+ * Lanza si el blob excede MAX_IMAGE_BYTES. Caller (UI camera flow) atrapa el
+ * error y muestra toast user-friendly + sugiere reducir calidad.
+ * @param {Blob} blob
+ * @throws {Error} con message en español colombiano para el operador rural.
+ */
+export const validateImageSize = (blob) => {
+  // Defensa: si el caller pasa null/undefined o algo sin .size (no-blob),
+  // no validamos — dejamos que blobToBase64 falle con su mensaje propio.
+  if (!blob || typeof blob.size !== 'number') return;
+  if (blob.size > MAX_IMAGE_BYTES) {
+    const sizeMb = (blob.size / 1_000_000).toFixed(1);
+    throw new Error(`Imagen muy grande (${sizeMb} MB), reduce calidad antes de enviar.`);
+  }
+};
+
 /**
  * Convierte un Blob a string Base64 (sin prefijo data:).
  */
@@ -197,6 +221,12 @@ export const __retrieveRagContextForFoliage = async (speciesSlug) => {
  */
 // eslint-disable-next-line no-unused-vars
 export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, assetId } = {}) => {
+  // QUICK-16: fail-fast antes del network call si la imagen supera 2 MB.
+  // Throw INTENCIONAL — el caller UI lo atrapa para mostrar toast claro.
+  // No usamos el try/catch interno (que retorna null) porque queremos que
+  // el usuario sepa POR QUÉ no se generó diagnóstico (no es un fallo de IA,
+  // es prevenible reduciendo calidad de cámara).
+  validateImageSize(imageBlob);
   try {
     const base64 = await blobToBase64(imageBlob);
 
@@ -321,6 +351,15 @@ function scientificToSpeciesId(scientific) {
   return `${genus}_${species}`.toLowerCase();
 }
 
+// QUICK-17 (Tier S iter 2, 2026-05-27): defensa frente a species_id no ASCII
+// snake_case. El sidecar `validate_visual_match` espera `^[a-z0-9_]+$` y
+// rechaza con HTTP 400 después del network roundtrip (~150-400ms desperdiciados
+// + log noise). Pre-validamos en frontend: si el id derivado del binomial
+// contiene caracteres fuera de ese alfabeto (ej. `×` hybrid, espacios,
+// mayúsculas que filtraron del modelo), degradamos a `no-binomial` sin pegar
+// al sidecar. Bench V-03 detectó este caso con `Fragaria × ananassa`.
+const VALID_SPECIES_ID = /^[a-z0-9_]+$/;
+
 /**
  * Versión grounded de recognizeSpecies. Llama al modelo de visión Y
  * después valida el resultado contra el catálogo Chagra usando el tool
@@ -386,6 +425,13 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   if (!speciesId) {
     return finalize('no-binomial', 'Nombre científico ambiguo.');
   }
+  // QUICK-17: defensa extra antes del network call al sidecar. Si por alguna
+  // razón scientificToSpeciesId produjo un id con caracteres no ASCII (ej.
+  // future refactor o input borderline), evitamos el 400 sidecar y damos UX
+  // honesto al operador.
+  if (!VALID_SPECIES_ID.test(speciesId)) {
+    return finalize('no-binomial', 'Nombre científico ambiguo (caracteres no válidos).');
+  }
 
   // Construir lista de candidates: el principal + alternatives si vienen.
   const candidates = [
@@ -427,6 +473,9 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
 };
 
 export const recognizeSpecies = async (imageBlob, { onToken, signal, _telemetryState } = {}) => {
+  // QUICK-16: fail-fast si la imagen supera 2 MB. Mismo throw intencional
+  // que en analyzeFoliage — el caller UI muestra toast user-friendly.
+  validateImageSize(imageBlob);
   let base64;
   try {
     base64 = await blobToBase64(imageBlob);
@@ -475,4 +524,6 @@ export const __TEST__ = {
   DIAGNOSIS_BASE_PROMPT,
   RAG_FALLBACK_QUERY,
   PASSAGE_CHAR_CAP,
+  scientificToSpeciesId,
+  VALID_SPECIES_ID,
 };

--- a/src/services/textWarmService.js
+++ b/src/services/textWarmService.js
@@ -1,0 +1,129 @@
+/**
+ * textWarmService.js — pre-warm de los modelos de texto Ollama on-login.
+ * AGPL-3.0 © Chagra
+ *
+ * QUICK-4 (Tier S iter 2, 2026-05-27): la primera query texto al chat agente
+ * cold-startea ~50s porque Ollama carga el modelo bajo demanda. Para llevarla
+ * a ~5s, disparamos un POST `/api/generate` con prompt vacío y
+ * `keep_alive: '10m'` al login success (fire-and-forget, mientras el operador
+ * navega del LoginScreen al dashboard tarda ~5-15s humanos).
+ *
+ * Modelos warmeados:
+ *   - `gemma3:4b`           — modelo primario chat agente (4B params, ~3 GB VRAM).
+ *     Nota: `useOllamaWarmStore` (NN4 fix) ya lo warmea con keep_alive=30m.
+ *     Este servicio NO duplica esa request — corre lock interno y la
+ *     primera llamada exitosa marca el timestamp; pero por defecto el
+ *     caller debe usar el store cuando aplique gemma3 dedicado al
+ *     agente. Aquí lo incluimos por idempotencia y para escenarios en
+ *     los que el store esté offline (ej. tests, alternativos).
+ *   - `granite3.1-dense:8b` — modelo secundario ranking #1 bench 2026-05-24
+ *     (56% AH, 0 alucinaciones). Se invoca desde llmRouter cuando la query
+ *     es sensible a alucinación. ~5.5 GB VRAM.
+ *
+ * Constraint VRAM (M6000 12 GB): la suma de gemma3:4b + granite3.1-dense:8b
+ * (~8.5 GB) deja ~3.5 GB para vision si el operador la usa después. Ollama
+ * gestiona el swap automáticamente — si el VRAM se acerca al límite,
+ * desaloja el modelo menos recientemente usado.
+ *
+ * Fire-and-forget: el caller (LoginScreen) NO espera la promesa. Si falla
+ * (Ollama down, red intermitente, modelo no instalado), degrada silencioso
+ * al cold-start clásico en la primera query del agente.
+ *
+ * Idempotente: usar `warmTextModels()` múltiples veces no dispara N requests.
+ * Un lock interno previene calls concurrentes y un timestamp de último warm
+ * <8min skipea la repetición (el keep_alive=10m garantiza que el modelo
+ * sigue caliente con margen de 2min antes de evict).
+ */
+
+const OLLAMA_URL = '/api/ollama/api/generate';
+// keep_alive 10min: balance entre VRAM ocupada y latencia subsecuente. Si el
+// operador deja la app abierta más de 10min sin tocar agente, Ollama libera.
+const KEEP_ALIVE = '10m';
+// Timeout defensivo por modelo. La primera carga de granite3.1-dense:8b en
+// M6000 tarda ~35-50s. 60s permite margen sin colgar promesas indefinidas.
+const WARMUP_TIMEOUT_MS = 60000;
+
+const TEXT_MODELS = ['gemma3:4b', 'granite3.1-dense:8b'];
+
+// Threshold para skipear re-warm reciente: 8min < keep_alive=10m. Defensivo:
+// damos 2min de margen para que el próximo warm refresque el timer ANTES de
+// que Ollama desaloje el modelo.
+const SKIP_IF_RECENT_MS = 8 * 60 * 1000;
+
+let _warmInFlight = false;
+let _lastWarmAt = 0;
+
+const warmOne = async (model, signal) => {
+  try {
+    const res = await fetch(OLLAMA_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        prompt: '',
+        stream: false,
+        keep_alive: KEEP_ALIVE,
+        options: { num_predict: 1 },
+      }),
+      signal,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Dispara warm en paralelo de los modelos texto. Idempotente, no-bloqueante.
+ *
+ * @returns {Promise<boolean>} true si disparó (o ya estaba warm), false si
+ *   hubo error genérico. El caller normalmente ignora el retorno.
+ */
+export async function warmTextModels() {
+  if (_warmInFlight) return true;
+  const now = Date.now();
+  if (now - _lastWarmAt < SKIP_IF_RECENT_MS) return true;
+
+  _warmInFlight = true;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), WARMUP_TIMEOUT_MS);
+
+  try {
+    // Paralelo: warm de N modelos en simultáneo. Ollama serializa internamente
+    // si VRAM se acerca al límite, pero la HTTP call no bloquea.
+    const results = await Promise.all(
+      TEXT_MODELS.map((m) => warmOne(m, controller.signal)),
+    );
+    // Si al menos un modelo warmó OK, marcamos el timestamp. Si todos fallan,
+    // el siguiente intento (post-SKIP_IF_RECENT_MS) re-disparará desde cero.
+    if (results.some(Boolean)) {
+      _lastWarmAt = Date.now();
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+    _warmInFlight = false;
+  }
+}
+
+/**
+ * Reset interno — para tests solamente.
+ * @internal
+ */
+export function __resetTextWarmState() {
+  _warmInFlight = false;
+  _lastWarmAt = 0;
+}
+
+/**
+ * Exposed test helper — para verificar contenido del array.
+ * @internal
+ */
+export const __TEST__ = {
+  TEXT_MODELS,
+  KEEP_ALIVE,
+  SKIP_IF_RECENT_MS,
+};


### PR DESCRIPTION
## Tareas (3 en 1 PR)

### QUICK-4: pre-warm Ollama text models on login
- Nuevo `src/services/textWarmService.js` con `warmTextModels()`.
- Warm `gemma3:4b` + `granite3.1-dense:8b` con `keep_alive='10m'` fire-and-forget desde `LoginScreen.handleLogin` post-auth.
- Idempotente: lock interno + skipIfRecent (8 min).
- **Before**: primera query texto cold-start ~50s.
- **After (esperado)**: ~5s (45s ahorrados).

Nota: `useOllamaWarmStore` ya warmea `gemma3:4b@30m`; este servicio agrega `granite3.1-dense:8b` (usado por llmRouter en queries sensibles a alucinación) y duplica gemma con keep_alive más corto (no perjudica — Ollama refresca timer).

### QUICK-17: pre-validate species_id snake_case + ASCII
- En `recognizeSpeciesGrounded` (aiService.js), check `VALID_SPECIES_ID = /^[a-z0-9_]+$/` ANTES de pegar al sidecar `validate_visual_match`.
- Hybrid notation `Fragaria × ananassa`, unicode `Solanum tubérosum`, espacios → degradan a `_grounded.status='no-binomial'` sin roundtrip al sidecar.
- **Before**: bug V-03 — sidecar 400 después de ~150-400ms desperdiciados + log noise.
- **After**: degrade frontend instant, mensaje "Nombre científico ambiguo (caracteres no válidos)".

### QUICK-16: image size validation antes de Ollama
- Nuevo `validateImageSize(blob)` en `aiService.js` — throw si `blob.size > 2_000_000`.
- Llamado al inicio de `analyzeFoliage` + `recognizeSpecies` (throw intencional, bubble-up al caller UI).
- `SpeciesSelect.jsx` catchea + emite `chagraToast` con mensaje user-friendly.
- **Before**: Samsung HDR raw >2MB → Ollama vision encola 30s antes de error.
- **After**: instant fail con mensaje "Imagen muy grande (X.X MB), reduce calidad antes de enviar."

## Archivos modificados
**Task 1 (warm text):**
- `src/services/textWarmService.js` (nuevo)
- `src/services/__tests__/textWarmService.test.js` (nuevo, 8 tests)
- `src/components/LoginScreen.jsx` (1 línea import + 5 líneas dispatch)

**Task 2 (species_id):**
- `src/services/aiService.js` (`VALID_SPECIES_ID` regex + check en `recognizeSpeciesGrounded` + expose via `__TEST__`)
- `src/services/__tests__/aiService.grounded.test.js` (+2 tests: hybrid × + unicode)
- `src/services/__tests__/aiService.test.js` (+9 tests: `scientificToSpeciesId` + regex)

**Task 3 (image size):**
- `src/services/aiService.js` (`validateImageSize` + calls)
- `src/services/__tests__/aiService.test.js` (+7 tests: tamaño + bubble-up)
- `src/components/SpeciesSelect.jsx` (toast handler para `muy grande`)

## Findings
- `useOllamaWarmStore` ya warmea `gemma3:4b@30m` (NN4 fix PR #1020). El nuevo `textWarmService` complementa con `granite3.1-dense:8b` que el bench 2026-05-24 ubicó #1 anti-hallucination.
- `scientificToSpeciesId` ya rechazaba `Fragaria × ananassa` (la regex `/^[a-z-]+$/` para epíteto descarta `×`). El nuevo `VALID_SPECIES_ID` es defensa-en-profundidad para futuros refactors.

## Tests
- **Baseline**: 1035 passing, 2 pre-existing failures (`voiceService es-CO`, `grounded telemetryState sidecar-disabled`).
- **Post-change**: 1059 passing (+24), mismas 2 pre-existing failures.
- `npm run build`: OK (✓ built in 2.29s).
- `npm run lint`: clean.

## Test plan
- [ ] Login en alpha PWA → verificar logs Ollama: pidió `granite3.1-dense:8b` en background ~5s después del login OK.
- [ ] Foto con planta `Fragaria × ananassa` → UX hint amber "Nombre científico ambiguo (caracteres no válidos)".
- [ ] Subir foto >2MB (ej. Samsung HDR raw) → toast "Imagen muy grande, reduce calidad antes de enviar".