### PR TITLE
fix(sync): 4xx → quarantine en vez de delete silencioso (BUG-CRITICAL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.8",
+  "version": "0.13.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v240';
+const CACHE_NAME = 'chagra-v241';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 14;
+export const DB_VERSION = 15;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -56,6 +56,7 @@ export const STORES = {
   CONVERSATION_MEMORY: 'conversation_memory',
   LLM_TELEMETRY: 'llm_telemetry',
   RAG_TELEMETRY: 'rag_telemetry',
+  FAILED_TX: 'failed_transactions',
 };
 
 let dbInstance = null;
@@ -205,6 +206,21 @@ export const openDB = async () => {
           store.createIndex('created_at', 'created_at', { unique: false });
           store.createIndex('status', 'status', { unique: false });
           store.createIndex('synced', 'synced', { unique: false });
+        }
+      }
+
+      // v15: failed_transactions — quarantine bucket post-rechazo HTTP del
+      // servidor. Reemplaza el `deleteTransaction()` silencioso que purgaba
+      // pendientes con 4xx. El user ve un banner "X transacciones bloqueadas"
+      // y puede revisar/reintentar/descartar manualmente. Spec en
+      // Chagra-strategy/ops/specs/sync-error-handling-spec.md.
+      if (event.oldVersion < 15) {
+        if (!db.objectStoreNames.contains(STORES.FAILED_TX)) {
+          const store = db.createObjectStore(STORES.FAILED_TX, { keyPath: 'id', autoIncrement: true });
+          store.createIndex('original_tx_id', 'original_tx_id', { unique: false });
+          store.createIndex('error_status', 'error_status', { unique: false });
+          store.createIndex('failed_at', 'failed_at', { unique: false });
+          store.createIndex('error_class', 'error_class', { unique: false });
         }
       }
 

--- a/src/services/syncManager.js
+++ b/src/services/syncManager.js
@@ -129,6 +129,107 @@ class SyncManager {
     });
   }
 
+  // Bug-critical fix (2026-05-27): clasificación de errores HTTP para
+  // decidir strategy (quarantine vs auto-retry). Ver
+  // Chagra-strategy/ops/specs/sync-error-handling-spec.md.
+  classifyHttpError(status) {
+    if (status === 401) return 'auth_expired';
+    if (status === 403) return 'forbidden';
+    if (status === 404) return 'not_found';
+    if (status === 409) return 'conflict';
+    if (status === 422) return 'validation';
+    if (status === 429) return 'rate_limit';
+    if (status >= 400 && status < 500) return 'client_other';
+    if (status >= 500) return 'server';
+    return 'unknown';
+  }
+
+  // Mover transacción a `failed_transactions` (quarantine bucket). El user
+  // ve un banner "X transacciones bloqueadas" y puede revisar/reintentar/
+  // descartar manual. Reemplaza el `deleteTransaction()` silencioso.
+  async quarantineTransaction(transaction, error) {
+    if (!this.db) await this.initDB();
+    const errorClass = this.classifyHttpError(error.status || 0);
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction([STORES.FAILED_TX], 'readwrite');
+      const store = tx.objectStore(STORES.FAILED_TX);
+      const record = {
+        original_tx_id: transaction.id,
+        type: transaction.type,
+        endpoint: transaction.endpoint || null,
+        payload: transaction.payload,
+        error_status: error.status || 0,
+        error_class: errorClass,
+        error_message: error.message || String(error),
+        retries: transaction.retries || 0,
+        failed_at: Date.now(),
+        original_timestamp: transaction.timestamp || null,
+      };
+      store.add(record);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  // Obtener todas las transacciones en quarantine. Para UI "Sincronización
+  // bloqueada" donde el user revisa/reintenta/descarta.
+  async getFailedTransactions() {
+    if (!this.db) await this.initDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction([STORES.FAILED_TX], 'readonly');
+      const store = tx.objectStore(STORES.FAILED_TX);
+      const req = store.getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  // Reintentar una transacción quarantine: la mueve de vuelta a
+  // pending_transactions con retries=0 y dispara syncAll. Útil para 422
+  // donde el user editó el payload, o 401 donde refrescó el token.
+  async requeueFailedTransaction(failedId, mutatedPayload = null) {
+    if (!this.db) await this.initDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction([STORES.FAILED_TX, STORE_NAME], 'readwrite');
+      const failedStore = tx.objectStore(STORES.FAILED_TX);
+      const pendingStore = tx.objectStore(STORE_NAME);
+      const getReq = failedStore.get(failedId);
+      getReq.onsuccess = () => {
+        const failed = getReq.result;
+        if (!failed) return resolve(false);
+        pendingStore.add({
+          type: failed.type,
+          endpoint: failed.endpoint,
+          payload: mutatedPayload || failed.payload,
+          timestamp: Date.now(),
+          synced: false,
+          retries: 0,
+        });
+        failedStore.delete(failedId);
+      };
+      getReq.onerror = () => reject(getReq.error);
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  // Descartar definitivamente una transacción en quarantine (decisión del
+  // user en UI). El payload se loguea por privacidad pero el record se
+  // elimina del IDB.
+  async discardFailedTransaction(failedId) {
+    if (!this.db) await this.initDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction([STORES.FAILED_TX], 'readwrite');
+      tx.objectStore(STORES.FAILED_TX).delete(failedId);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
   // Marcar retries en una transacción
   async markRetry(id, errorMsg) {
     if (!this.db) await this.initDB();
@@ -218,21 +319,41 @@ class SyncManager {
           }));
         } catch (error) {
           if (error.status && error.status >= 400 && error.status < 500) {
-            console.error(`[SyncManager] Error no recuperable HTTP ${error.status}. Descartando transacción ${transaction.id}.`, error);
+            // Bug-critical fix (2026-05-27): el `deleteTransaction()` previo
+            // descartaba el payload del usuario sin manera de recuperarlo.
+            // Ahora movemos la transacción a `failed_transactions` (quarantine
+            // bucket) donde el user puede revisar/reintentar/descartar manual.
+            // Spec: Chagra-strategy/ops/specs/sync-error-handling-spec.md.
+            const errorClass = this.classifyHttpError(error.status);
+            console.error(`[SyncManager] HTTP ${error.status} (${errorClass}). Moviendo transacción ${transaction.id} a quarantine.`, error);
+            await this.quarantineTransaction(transaction, error);
             await this.deleteTransaction(transaction.id);
             failed++;
             const name = transaction.payload?.data?.attributes?.name || transaction.type;
             window.dispatchEvent(new CustomEvent('syncError', {
-              detail: { message: `Transacción "${name}" descartada (HTTP ${error.status}).` },
+              detail: {
+                message: `Transacción "${name}" bloqueada (HTTP ${error.status}). Revisa en "Sincronización" para reintentar.`,
+                status: error.status,
+                errorClass,
+                quarantined: true,
+              },
             }));
           } else {
             const retries = await this.markRetry(transaction.id, error.message);
             console.warn(`[SyncManager] Fallo de red/servidor en transacción ${transaction.id} (intento ${retries}/${MAX_RETRIES}). Marcando para reintento.`, error);
             if (retries >= MAX_RETRIES) {
+              // Max retries con 5xx — también quarantine para que el user vea.
+              await this.quarantineTransaction(transaction, error);
+              await this.deleteTransaction(transaction.id);
               failed++;
               const name = transaction.payload?.data?.attributes?.name || transaction.type;
               window.dispatchEvent(new CustomEvent('syncError', {
-                detail: { message: `Fallo permanente al sincronizar "${name}". Verifique conexión con FarmOS.` },
+                detail: {
+                  message: `Fallo permanente al sincronizar "${name}". Bloqueada en "Sincronización".`,
+                  status: error.status || 0,
+                  errorClass: 'max_retries',
+                  quarantined: true,
+                },
               }));
             }
           }


### PR DESCRIPTION
## Summary

- **Bug-critical data-loss**: `syncManager.js:220` ejecutaba `deleteTransaction()` permanente cuando farmOS rechazaba un POST con HTTP 4xx. El payload del usuario se purgaba sin posibilidad de recuperación y sin notificación visible.
- **Diagnóstico**: el operador reportó "veo 43 plantas en cultivos pero las que agregué se borraron como si nunca se hubieran sincronizado en farmOS, me pasa igual". Logs del backend confirmaron: último POST exitoso del browser a `/api/asset/plant` fue 2026-05-19; desde entonces todos los intentos terminaron en 400/422/404 y se perdieron silenciosamente.
- **Fix**: cuando una transacción falla con 4xx (o 5xx tras max retries), se mueve a un nuevo objectStore `failed_transactions` (quarantine bucket) en vez de borrarse. La UI puede mostrar "X transacciones bloqueadas — revisar" para que el usuario reintente, edite el payload (para 422) o descarte manualmente.

## Cambios

- `src/db/dbCore.js`: bump `DB_VERSION` 14 → 15, agrega objectStore `FAILED_TX` con índices `original_tx_id`, `error_status`, `error_class`, `failed_at`.
- `src/services/syncManager.js`:
  - `classifyHttpError(status)` — taxonomía 401/403/404/409/422/429/5xx → `auth_expired` | `forbidden` | `not_found` | `conflict` | `validation` | `rate_limit` | `client_other` | `server`.
  - `quarantineTransaction(transaction, error)` — move a `failed_transactions` con metadata (payload preservado, error_status, error_class, retries, failed_at, original_timestamp).
  - `getFailedTransactions()` / `requeueFailedTransaction(failedId, mutatedPayload?)` / `discardFailedTransaction(failedId)` — API para la UI.
  - Path 4xx: emite `syncError` con `quarantined:true` y `errorClass`, NO ejecuta delete silencioso.
  - Path max_retries: también preserva el payload (antes solo loggeaba).

## Spec relacionada

`Chagra-strategy/ops/specs/sync-error-handling-spec.md`

## Pendientes en PRs siguientes (NO en este PR)

- UI "Sincronización bloqueada" — lista quarantine + acciones reintentar / editar / descartar.
- 401 auto-refresh token + auto-requeue del bucket.
- Telemetría privacy-safe de fail rate por error_class (Eco-Oracle Dashboard).
- Filter multifinca (PR #948 `filter[uid.name]`) — separate review: oculta plants de otros usernames OAuth, pero NO es causa de data-loss (solo de visibilidad). Considerar feature flag para deshabilitarlo en demos.

## Test plan

- [x] `npm run test:unit -- --run src/services/__tests__/syncManager.test.js` — 10/10 passing.
- [x] `npx eslint src/services/syncManager.js src/db/dbCore.js --max-warnings=0` — clean.
- [ ] Manual smoke en PWA local con farmOS dev: simular POST con payload inválido (422), verificar que aparece en quarantine.
- [ ] Verificar migration v14 → v15 no rompe DBs existentes (las pestañas abiertas reciben `onversionchange` y cierran su conexión).
- [ ] E2E mobile (iPhone + Android) post-deploy: agregar planta + verificar que tras error queda en quarantine, no se purga del IDB.

Closes #297, #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)