### PR TITLE
fix(home): widget tareas pendientes auto-scroll + max-height

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.8",
+  "version": "0.13.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v240';
+const CACHE_NAME = 'chagra-v241';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/PendingTasksWidget.jsx
+++ b/src/components/PendingTasksWidget.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { AlertTriangle, Clock, RefreshCw, Wifi, WifiOff, ChevronUp, ChevronDown, Edit2 } from 'lucide-react';
 import { syncManager } from '../services/syncManager';
 import useFincaActiveStore from '../services/fincaActiveStore';
@@ -28,6 +28,12 @@ export default function PendingTasksWidget({ onEdit }) {
   const [error, setError] = useState(null);
   const [cacheAgeMinutes, setCacheAgeMinutes] = useState(null);
   const [expanded, setExpanded] = useState(false);
+  // 2026-05-27 fix: cuando el widget está al final del scroll del home y el
+  // user toca el header para expandir, el contenido desplegado quedaba
+  // fuera del viewport (no se notaba nada). Ahora el contenido scrolea hasta
+  // hacerse visible y el contenedor tiene max-height + overflow-y propio
+  // para que el comportamiento sea consistente en todo el scroll del home.
+  const contentRef = useRef(null);
   // 062.5: re-fetch al cambiar de finca activa para que las tasks reflejen
   // el endpoint farmOS de la finca donde el operador está físicamente.
   // apiService.js:161 ya hace el routing dinámico; aquí solo nos enganchamos
@@ -82,6 +88,18 @@ export default function PendingTasksWidget({ onEdit }) {
     };
   }, [activeFincaSlug]);
 
+  // 2026-05-27 fix: al expandir, asegurar que el contenido sea visible.
+  // Si el widget está al final del scroll y el user toca el header, el
+  // contenido queda debajo del fold sin esta llamada. `block: 'nearest'`
+  // evita scrolear si ya está visible (no molesta al user).
+  useEffect(() => {
+    if (expanded && contentRef.current) {
+      requestAnimationFrame(() => {
+        contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    }
+  }, [expanded]);
+
   const getSeverityConfig = (severity) => {
     switch (severity) {
       case 'critical': return { color: 'bg-red-600', text: 'text-red-400', badge: 'CRÍTICA', icon: AlertTriangle };
@@ -133,7 +151,11 @@ export default function PendingTasksWidget({ onEdit }) {
       </button>
 
       {expanded && (
-        <div id="pending-tasks-content" className="px-4 pb-4 border-t border-slate-800">
+        <div
+          ref={contentRef}
+          id="pending-tasks-content"
+          className="px-4 pb-4 border-t border-slate-800 max-h-[60vh] overflow-y-auto overscroll-contain"
+        >
           {!isOnline && cacheAgeMinutes !== null && (
             <p className="text-xs text-amber-400 mt-2">
               Caché de hace {cacheAgeMinutes} {cacheAgeMinutes === 1 ? 'minuto' : 'minutos'}


### PR DESCRIPTION
## Summary

- Cuando el widget de "Cola de tareas" está cerca del final del scroll en el Dashboard, expandirlo no producía efecto visible (contenido caía fuera del viewport).
- Si había muchas tareas, la lista expandida empujaba todo el layout.

## Cambios

- Auto-scroll del contenido expandido al viewport (`scrollIntoView` con `block:'nearest'`).
- Max-height interno `60vh` + scroll propio para contener listas largas sin afectar el scroll padre.

## Test plan

- [x] Lint clean.
- [ ] Manual: scrolear al final del Dashboard, expandir widget — debe ser visible.
- [ ] Manual: con muchas tareas, scroll interno dentro del widget.

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)