### PR TITLE
feat(ux): UX-1 beta badge + UX-5 quick chips (#284 #286)

### DIFF
--- a/src/components/AIBetaBadge.jsx
+++ b/src/components/AIBetaBadge.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+/**
+ * AIBetaBadge — pill discreto que marca cualquier respuesta o sugerencia
+ * generada por IA dentro de la PWA (chat del agente, identificación por foto,
+ * sugerencias del catálogo, etc.).
+ *
+ * Decisión UX-1 (issue #284): comunicar de forma persistente y sin friccionar
+ * la lectura que el contenido proviene de un modelo generativo y debe
+ * verificarse antes de actuar sobre el cultivo. NO reemplaza a SourceBadge
+ * (que indica si la respuesta fue grounded contra el catálogo); convive con
+ * él porque cubre una dimensión distinta — "esto es IA, no oráculo".
+ *
+ * Diseño:
+ *   - Texto 10px-11px, opacidad media para no competir con el contenido.
+ *   - Pill gris pálido (slate-500/30) coherente con el design system Chagra.
+ *   - Tooltip `title` HTML nativo → mobile-friendly via long-press / tap en
+ *     navegadores que lo soportan (iOS Safari ≥16, Chrome móvil).
+ *   - aria-label para lectores de pantalla.
+ *
+ * Props:
+ *   - className: clases extra para ajustar margenes desde el call-site.
+ *   - title:     override opcional del tooltip por si un call-site necesita
+ *                un copy más específico (e.g. "Identificación generativa…").
+ */
+export default function AIBetaBadge({ className = '', title }) {
+  const tooltip = title || 'Respuesta generada por IA — verifica antes de actuar.';
+  return (
+    <span
+      data-testid="ai-beta-badge"
+      role="note"
+      aria-label={tooltip}
+      title={tooltip}
+      className={`inline-flex items-center px-1.5 py-0.5 rounded-full bg-slate-500/20 text-slate-400 border border-slate-600/40 text-[10px] font-medium uppercase tracking-wide opacity-80 ${className}`}
+    >
+      beta
+    </span>
+  );
+}

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -28,6 +28,7 @@ import SuggestedActions from './SuggestedActions';
 import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import QuickChipsBar from '../QuickChipsBar';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
@@ -1478,6 +1479,13 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       {/* Suggestions */}
       {state === STATE_IDLE && messages.length < 3 && (
         <SuggestedActions onSelect={handleSuggestion} />
+      )}
+
+      {/* UX-5 (#286): chips de preguntas rápidas. Solo en pantalla nueva
+          (chat vacío) e idle — al primer turn desaparecen para no llenar la
+          UI con sugerencias mientras hay conversación visible. */}
+      {state === STATE_IDLE && messages.length === 0 && (
+        <QuickChipsBar onSelect={handleSuggestion} />
       )}
 
       {/* Input */}

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -5,6 +5,7 @@ import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../s
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import FeedbackButtons from '../FeedbackButtons';
+import AIBetaBadge from '../AIBetaBadge';
 
 function formatTime(timestamp) {
   if (!timestamp) return '';
@@ -161,6 +162,13 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
           title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
         >
           <p className="text-sm leading-relaxed whitespace-pre-wrap">{message.content}</p>
+          {/* UX-1 (#284): badge "beta" permanente cerca de cualquier respuesta
+              IA del agente. NO reemplaza a SourceBadge (que es la fuente
+              grounded vs generativa) — convive. Suprimido para mensajes de
+              recuperación huérfana porque no son respuesta real del modelo. */}
+          {!isUser && !isStreaming && !message._orphan_recovery && (
+            <AIBetaBadge className="mt-1" />
+          )}
           {shouldShowBadge && (
             <div className="mt-1">
               <SourceBadge metadata={message.metadata} />

--- a/src/components/QuickChipsBar.jsx
+++ b/src/components/QuickChipsBar.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+/**
+ * QuickChipsBar — tres chips clickables con preguntas frecuentes para que el
+ * operador arranque el chat sin tener que escribir.
+ *
+ * Decisión UX-5 (issue #286): reducir la fricción del "qué le pregunto" en
+ * la primera interacción con el agente. Aparece SOLO cuando el chat está
+ * vacío; tras la primera respuesta del agente la barra desaparece para no
+ * llenar la UI mientras hay historial visible.
+ *
+ * Diferencia frente a `SuggestedActions`: QuickChipsBar es el atajo de la
+ * pantalla nueva (estado inicial), pensado para mostrarse JUSTO sobre el
+ * input. `SuggestedActions` sigue cubriendo el flow de re-engagement con
+ * iconos y wording distinto.
+ *
+ * Props:
+ *   - onSelect: callback(query: string) — el call-site decide qué hacer.
+ *               Típicamente AgentScreen llama directo a handleSubmit(query).
+ */
+
+const DEFAULT_QUICK_QUESTIONS = [
+  '¿Qué siembro este mes?',
+  'Tengo plaga en mis plantas',
+  'Receta de biopreparado para tomate',
+];
+
+export default function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUESTIONS }) {
+  if (typeof onSelect !== 'function') return null;
+  return (
+    <div
+      data-testid="quick-chips-bar"
+      className="px-4 py-2 border-t border-slate-800/60 bg-slate-900/40"
+    >
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-2">
+        Preguntas rápidas
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {questions.map((q) => (
+          <button
+            key={q}
+            type="button"
+            onClick={() => onSelect(q)}
+            data-testid="quick-chip"
+            className="px-3 py-1.5 rounded-full bg-slate-800/80 hover:bg-slate-700/80 active:scale-95 border border-slate-700/60 text-xs text-slate-200 transition-all"
+          >
+            {q}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -10,6 +10,7 @@ import useAssetStore from '../store/useAssetStore';
 import { captureAndCompress } from '../services/photoService';
 import { recognizeSpeciesGrounded } from '../services/aiService';
 import { getAllSpecies } from '../db/catalogDB';
+import AIBetaBadge from './AIBetaBadge';
 
 /**
  * SpeciesSelect, Selector de especie con fuzzy search y autocompletado de defaults.
@@ -580,6 +581,10 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                   {aiResult.scientific_name}
                 </p>
               )}
+              {/* UX-1 (#284): badge "beta" debajo del nombre sugerido por
+                  el modelo de visión. Recordatorio sutil de que la
+                  identificación es generativa, aun cuando esté grounded. */}
+              <AIBetaBadge className="mt-1" title="Identificación generada por IA — verifica antes de actuar." />
             </div>
             {/* Si el primario fue rechazado por el catálogo pero el sidecar
                 encontró candidates alternativos válidos, ofrecerlos como

--- a/src/components/__tests__/AIBetaBadge.smoke.test.jsx
+++ b/src/components/__tests__/AIBetaBadge.smoke.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect } from 'vitest';
+import AIBetaBadge from '../AIBetaBadge';
+
+// Smoke tests UX-1 (#284) — el badge debe:
+//   - renderizar sin crashear,
+//   - exponer un testid estable para los call-sites (chat, species select),
+//   - llevar el tooltip default ("Respuesta generada por IA — verifica…"),
+//   - permitir override del tooltip vía prop `title`.
+
+describe('AIBetaBadge — pill discreto de respuesta IA', () => {
+  test('renderiza con texto "beta" y testid estable', () => {
+    render(<AIBetaBadge />);
+    const badge = screen.getByTestId('ai-beta-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toMatch(/beta/i);
+  });
+
+  test('expone tooltip default vía title + aria-label', () => {
+    render(<AIBetaBadge />);
+    const badge = screen.getByTestId('ai-beta-badge');
+    expect(badge.getAttribute('title')).toMatch(/Respuesta generada por IA/i);
+    expect(badge.getAttribute('aria-label')).toMatch(/verifica/i);
+  });
+
+  test('respeta override de title cuando el call-site lo pasa', () => {
+    render(<AIBetaBadge title="Identificación generada por IA — verifica." />);
+    const badge = screen.getByTestId('ai-beta-badge');
+    expect(badge.getAttribute('title')).toBe('Identificación generada por IA — verifica.');
+    expect(badge.getAttribute('aria-label')).toBe('Identificación generada por IA — verifica.');
+  });
+
+  test('aplica className extra sin perder las clases base', () => {
+    render(<AIBetaBadge className="mt-4" />);
+    const badge = screen.getByTestId('ai-beta-badge');
+    expect(badge.className).toMatch(/mt-4/);
+    expect(badge.className).toMatch(/rounded-full/);
+  });
+});

--- a/src/components/__tests__/QuickChipsBar.smoke.test.jsx
+++ b/src/components/__tests__/QuickChipsBar.smoke.test.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import QuickChipsBar from '../QuickChipsBar';
+
+// Smoke tests UX-5 (#286) — los chips deben:
+//   - renderizar los 3 textos default,
+//   - invocar onSelect con el texto exacto del chip clickeado,
+//   - aceptar override de questions vía prop,
+//   - retornar null si no hay handler (defensa contra mounts incompletos).
+
+describe('QuickChipsBar — chips de preguntas rápidas', () => {
+  test('renderiza los 3 chips default', () => {
+    render(<QuickChipsBar onSelect={() => {}} />);
+    expect(screen.getByText('¿Qué siembro este mes?')).toBeInTheDocument();
+    expect(screen.getByText('Tengo plaga en mis plantas')).toBeInTheDocument();
+    expect(screen.getByText('Receta de biopreparado para tomate')).toBeInTheDocument();
+  });
+
+  test('clickear un chip llama onSelect con el texto exacto', () => {
+    const onSelect = vi.fn();
+    render(<QuickChipsBar onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('Tengo plaga en mis plantas'));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('Tengo plaga en mis plantas');
+  });
+
+  test('respeta override de questions', () => {
+    const onSelect = vi.fn();
+    render(<QuickChipsBar onSelect={onSelect} questions={['Pregunta A', 'Pregunta B']} />);
+    const chips = screen.getAllByTestId('quick-chip');
+    expect(chips).toHaveLength(2);
+    expect(screen.getByText('Pregunta A')).toBeInTheDocument();
+    expect(screen.getByText('Pregunta B')).toBeInTheDocument();
+  });
+
+  test('retorna null si no hay handler onSelect (defensa)', () => {
+    const { container } = render(<QuickChipsBar />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Dos quick wins de UX en un PR.

**UX-1 (#284) — Badge \"beta\" permanente en respuestas IA**
- Componente reutilizable `<AIBetaBadge />` (pill discreto, 10px, opacidad media, tooltip nativo \"Respuesta generada por IA — verifica antes de actuar.\").
- Wireado en:
  - `ChatBubble.jsx` (todas las respuestas del agente, salvo mensajes `_orphan_recovery` y streaming).
  - `SpeciesSelect.jsx` (debajo del nombre sugerido por el vision model, con tooltip override \"Identificación generada por IA — verifica antes de actuar.\").
- Convive con `SourceBadge` (grounded vs generativo) sin reemplazarlo — cubren dimensiones distintas.

**UX-5 (#286) — 3 chips de preguntas rápidas en chat**
- Componente `<QuickChipsBar onSelect={...} />`.
- 3 preguntas default: \"¿Qué siembro este mes?\", \"Tengo plaga en mis plantas\", \"Receta de biopreparado para tomate\".
- Visible SOLO cuando `state === STATE_IDLE && messages.length === 0` — desaparece tras el primer turn para no llenar la UI mientras hay historial.
- Al tocar un chip se envía la pregunta vía `handleSuggestion` (flow existente).

**Nota sobre `FoliageAnalysisResult.jsx`**
- No existe ese componente en el repo. El flow de identificación visual se renderiza dentro de `SpeciesSelect.jsx`, donde sí se wireó el badge. No hay componente separado de \"foliage analysis\" — la sugerencia AI y el `_grounded.status` se muestran en línea con el selector de especies.

## Test plan

- [x] `npx eslint` clean sobre los archivos modificados y los nuevos (max-warnings=0).
- [x] Pre-flight manual de los scans de lefthook (infra-refs, strategic-content, pro-import) — clean.
- [ ] Smoke a ojo en AgentScreen: abrir chat vacío → ver 3 chips arriba del input → tocar uno → se envía + chips desaparecen tras la respuesta.
- [ ] Smoke a ojo en AgentScreen: cualquier respuesta del agente muestra pill \"beta\" debajo del texto (long-press en mobile abre tooltip).
- [ ] Smoke a ojo en SpeciesSelect: subir foto → sugerencia con pill \"beta\" debajo del nombre científico.

Tests unitarios smoke incluidos (`AIBetaBadge.smoke.test.jsx` + `QuickChipsBar.smoke.test.jsx`) pero NO ejecutados acá: el alpha runner tiró ENOMEM al spawnear forks de vitest. CI debería correrlos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)