### PR TITLE
feat(util): parseJsonTolerant — JSON repair fallback LLM (#269)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.9",
+  "version": "0.13.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v241';
+const CACHE_NAME = 'chagra-v242';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -21,6 +21,7 @@
 import { streamOllama } from './ollamaStream';
 import { retrieve } from './ragRetriever';
 import { callTool, isSidecarEnabled } from './sidecarClient';
+import { parseJsonTolerant } from '../utils/parseJsonTolerant';
 
 // Ruta relativa: Nginx proxea /api/ollama/ → http://localhost:11434/
 // Ruta final: /api/ollama/api/generate → http://localhost:11434/api/generate
@@ -216,9 +217,14 @@ export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, 
       { signal, meta: { rag_passages_used: passages.length } },
     )).trim();
 
-    // Parsear JSON (Gemma puede envolver en markdown fences)
-    const cleaned = text.replace(/```json\s*/g, '').replace(/```/g, '').trim();
-    const parsed = JSON.parse(cleaned);
+    // Parser tolerante (QUICK-6 #269): repair_json fallback contra fences,
+    // prosa antes/después, trailing commas, cierres faltantes por num_predict.
+    const r = parseJsonTolerant(text);
+    if (!r.ok) {
+      console.warn('[aiService.analyzeFoliage] JSON irrecuperable:', r.error);
+      return null;
+    }
+    const parsed = r.value;
 
     // Validación y normalización del shape
     if (typeof parsed.score !== 'number') parsed.score = 0;
@@ -273,8 +279,14 @@ const runSpeciesRecognition = async (model, base64, { onToken, signal, telemetry
     onToken,
     { signal, meta: metaThunk },
   )).trim();
-  const cleaned = text.replace(/```json\s*/g, '').replace(/```/g, '').trim();
-  const parsed = JSON.parse(cleaned);
+  // Parser tolerante (QUICK-6 #269): repair_json fallback. Si falla
+  // completo, throw para que el caller maneje (recognizeSpecies tiene try
+  // externo que decide fallback texto).
+  const r = parseJsonTolerant(text);
+  if (!r.ok) {
+    throw new Error(`runSpeciesRecognition: ${r.error}`);
+  }
+  const parsed = r.value;
   const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0;
 
   // Mutar telemetryState (si el caller pasó uno) ANTES de que

--- a/src/utils/__tests__/parseJsonTolerant.test.js
+++ b/src/utils/__tests__/parseJsonTolerant.test.js
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+import { describe, it, expect } from 'vitest';
+import { parseJsonTolerant } from '../parseJsonTolerant';
+
+describe('parseJsonTolerant', () => {
+  it('parsea JSON directo válido', () => {
+    const r = parseJsonTolerant('{"a":1,"b":"hola"}');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ a: 1, b: 'hola' });
+    expect(r.strategy).toBe('direct');
+  });
+
+  it('quita fences markdown', () => {
+    const r = parseJsonTolerant('```json\n{"score":0.8}\n```');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ score: 0.8 });
+  });
+
+  it('extrae JSON con prosa antes y después', () => {
+    const r = parseJsonTolerant('Aquí está el resultado: {"common_name":"café"} fin.');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ common_name: 'café' });
+    expect(r.strategy).toBe('balanced_extract');
+  });
+
+  it('repara trailing comma', () => {
+    const r = parseJsonTolerant('{"a":1,"b":2,}');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ a: 1, b: 2 });
+  });
+
+  it('repara Python keywords (True/False/None)', () => {
+    const r = parseJsonTolerant('{"verified":True,"alt":None,"err":False}');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ verified: true, alt: null, err: false });
+  });
+
+  it('cierra llaves faltantes (truncado por num_predict)', () => {
+    const r = parseJsonTolerant('{"score":0.5,"issues":[{"name":"oidio"');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ score: 0.5, issues: [{ name: 'oidio' }] });
+    expect(r.strategy).toBe('auto_close_braces');
+  });
+
+  it('reconoce arrays como root', () => {
+    const r = parseJsonTolerant('[1,2,3]');
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual([1, 2, 3]);
+  });
+
+  it('falla limpio en input vacío', () => {
+    const r = parseJsonTolerant('');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('empty_input');
+  });
+
+  it('falla con error informativo en JSON irrecuperable', () => {
+    const r = parseJsonTolerant('lorem ipsum totalmente sin estructura');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('json_unparseable');
+  });
+
+  it('preserva el texto raw truncado en fallos', () => {
+    const huge = 'x'.repeat(1000);
+    const r = parseJsonTolerant(huge);
+    expect(r.ok).toBe(false);
+    expect(r.raw.length).toBeLessThanOrEqual(501);
+  });
+
+  it('caso real Gemma con prosa + json + cierre faltante', () => {
+    const realLLMOutput = `Voy a analizar la foto.
+\`\`\`json
+{
+  "score": 0.72,
+  "issues": [
+    {"name": "manchas amarillas", "severity": "media"
+\`\`\``;
+    const r = parseJsonTolerant(realLLMOutput);
+    expect(r.ok).toBe(true);
+    expect(r.value.score).toBe(0.72);
+    expect(Array.isArray(r.value.issues)).toBe(true);
+  });
+});

--- a/src/utils/parseJsonTolerant.js
+++ b/src/utils/parseJsonTolerant.js
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * parseJsonTolerant — parser JSON robusto para output de LLMs locales.
+ *
+ * Los modelos Ollama (gemma3:4b, llama3.2-vision, granite3.1-dense) a veces
+ * envuelven el JSON en markdown fences, agregan prosa antes/después, truncan
+ * por num_predict, o emiten trailing commas. `JSON.parse` directo rompe en
+ * esos casos y la respuesta del agente se pierde, aunque el contenido sea
+ * casi-recuperable.
+ *
+ * Estrategia (en cascada, devuelve el primer parse exitoso):
+ *   1. Limpia fences markdown ` ```json ... ``` ` y prosa fuera del balance.
+ *   2. Intenta `JSON.parse` directo.
+ *   3. Busca el primer `{` o `[` y el último `}` o `]` balanceado y parsea
+ *      esa sub-cadena (rescata JSON con prosa pegada).
+ *   4. Repara fallas comunes: trailing commas, comillas simples → dobles,
+ *      `True`/`False`/`None` (Python) → `true`/`false`/`null`.
+ *   5. Trailing brace insertion: si el texto queda con `{` o `[` sin cerrar
+ *      (truncado por num_predict), agrega `}` o `]` faltantes y reintenta.
+ *
+ * Si todas las estrategias fallan, retorna `{ ok: false, error, raw }` —
+ * el caller decide si mostrar error al user, fallback texto, o reintentar.
+ *
+ * NO usa eval ni Function — todo es parser puro.
+ *
+ * @param {string} text - output del LLM (potencialmente "sucio")
+ * @returns {{ ok: true, value: unknown, strategy: string } | { ok: false, error: string, raw: string }}
+ */
+export function parseJsonTolerant(text) {
+  if (typeof text !== 'string' || text.length === 0) {
+    return { ok: false, error: 'empty_input', raw: '' };
+  }
+
+  const stripFences = (s) => s.replace(/```(?:json|JSON)?\s*/g, '').replace(/```/g, '').trim();
+
+  const tryParse = (s, strategy) => {
+    try {
+      return { ok: true, value: JSON.parse(s), strategy };
+    } catch {
+      return null;
+    }
+  };
+
+  const cleaned = stripFences(text);
+
+  // Strategy 1: parse directo del texto limpio
+  const direct = tryParse(cleaned, 'direct');
+  if (direct) return direct;
+
+  // Strategy 2: extraer subcadena desde el primer opener (balanceado, o si
+  // no, desde el opener hasta el final — para que las siguientes etapas
+  // reparen el cierre faltante).
+  const startIdx = cleaned.search(/[{[]/);
+  const fromOpener = startIdx >= 0 ? cleaned.slice(startIdx) : cleaned;
+  const balanced = extractBalanced(cleaned);
+  if (balanced) {
+    const r = tryParse(balanced, 'balanced_extract');
+    if (r) return r;
+  }
+
+  // Strategy 3: reparar fallas comunes sobre la subcadena más probable.
+  const candidate = balanced || fromOpener;
+  const repaired = applyCommonRepairs(candidate);
+  const repairResult = tryParse(repaired, 'common_repairs');
+  if (repairResult) return repairResult;
+
+  // Strategy 4: agregar cierres faltantes (truncado por num_predict)
+  const closed = autoCloseBraces(repaired);
+  const closeResult = tryParse(closed, 'auto_close_braces');
+  if (closeResult) return closeResult;
+
+  return {
+    ok: false,
+    error: 'json_unparseable',
+    raw: text.length > 500 ? `${text.slice(0, 500)}…` : text,
+  };
+}
+
+/**
+ * Busca el primer carácter de apertura (`{` o `[`) y devuelve la subcadena
+ * hasta el cierre balanceado correspondiente, respetando strings escapados.
+ *
+ * Si nunca se balancea (faltan cierres), devuelve null.
+ */
+function extractBalanced(s) {
+  const startIdx = s.search(/[{[]/);
+  if (startIdx === -1) return null;
+
+  const open = s[startIdx];
+  const close = open === '{' ? '}' : ']';
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = startIdx; i < s.length; i++) {
+    const ch = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return s.slice(startIdx, i + 1);
+    }
+  }
+  return null;
+}
+
+/**
+ * Aplica las reparaciones más comunes en output LLM:
+ *   - trailing commas: `,}` → `}`, `,]` → `]`
+ *   - comillas simples a dobles (sólo cuando no rompen un string ya válido —
+ *     heurística simple: reemplazo en líneas donde no hay `"`)
+ *   - keywords Python: True/False/None → true/false/null (whole word)
+ */
+function applyCommonRepairs(s) {
+  if (!s) return s;
+  let out = s;
+
+  // trailing commas antes de cierre
+  out = out.replace(/,(\s*[}\]])/g, '$1');
+
+  // Python booleans/None → JSON
+  out = out.replace(/\bTrue\b/g, 'true')
+    .replace(/\bFalse\b/g, 'false')
+    .replace(/\bNone\b/g, 'null');
+
+  // Comillas simples a dobles solo si no aparecen comillas dobles en la
+  // misma línea (heurística defensiva, no perfect pero atrapa el caso común
+  // de un modelo que olvida cambiar entre Python-style y JSON).
+  out = out.split('\n').map((line) => {
+    if (line.includes('"')) return line;
+    return line.replace(/'/g, '"');
+  }).join('\n');
+
+  return out;
+}
+
+/**
+ * Si el balance de llaves/corchetes queda abierto (truncado por
+ * `num_predict` o stream cortado), añade los cierres faltantes en el orden
+ * inverso de apertura. NO inventa valores: si el último token abierto es un
+ * string o un par clave-sin-valor, queda inválido y la siguiente etapa
+ * fallará — pero al menos lo intenta.
+ */
+function autoCloseBraces(s) {
+  if (!s) return s;
+  const stack = [];
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (escape) { escape = false; continue; }
+    if (ch === '\\' && inString) { escape = true; continue; }
+    if (ch === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (ch === '{' || ch === '[') stack.push(ch);
+    else if (ch === '}' && stack[stack.length - 1] === '{') stack.pop();
+    else if (ch === ']' && stack[stack.length - 1] === '[') stack.pop();
+  }
+
+  if (stack.length === 0) return s;
+
+  // Si quedó un string abierto, cerrarlo primero
+  let suffix = '';
+  if (inString) suffix += '"';
+  // Si terminó con coma o dos puntos colgando, recortar
+  let trimmed = s.replace(/[,:\s]+$/, '');
+  while (stack.length > 0) {
+    const opener = stack.pop();
+    suffix += opener === '{' ? '}' : ']';
+  }
+  return trimmed + suffix;
+}


### PR DESCRIPTION
## Summary

- Parser JSON tolerante para output de LLMs locales (gemma3:4b, llama3.2-vision, granite3.1-dense).
- Estrategia en cascada: strip fences → balanced extract → common repairs (trailing commas, Python keywords) → auto-close braces.
- Wire en `aiService.js` (`analyzeFoliage` + `runSpeciesRecognition`).
- 11/11 unit tests covering JSON limpio, fences, prosa, trailing commas, Python keywords, cierre faltante, arrays root, input vacío, irrecuperable, raw truncation, caso real Gemma combinado.

## Por qué importa para la ronda de amigos

Sin esto, una respuesta del agente con `{...` cortado por `num_predict` se perdía completa. Ahora la mayoría de fallos de parse se recuperan. Reduce respuestas perdidas en mobile (Safari/Android Chrome stream rarito).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)