### PR TITLE
feat(image): client-side compression + camera-prominent button (#279 #287 part)

### DIFF
--- a/src/components/BitacoraEntryDetail.jsx
+++ b/src/components/BitacoraEntryDetail.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { ArrowLeft, Edit2, Calendar, MapPin, FileText, Cpu, Hash, Camera, Loader2, Sparkles, AlertTriangle, Bug } from 'lucide-react';
+import { ArrowLeft, Edit2, Calendar, MapPin, FileText, Cpu, Hash, Camera, Image as ImageIcon, Loader2, Sparkles, AlertTriangle, Bug } from 'lucide-react';
 import StatusBadge from './StatusBadge';
 import useAssetStore from '../store/useAssetStore';
 import { captureAndCompress, getPhotoForLog } from '../services/photoService';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { analyzeFoliage } from '../services/aiService';
 
 /**
@@ -117,7 +118,9 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
   const plants = useAssetStore((s) => s.plants);
   const [photoState, setPhotoState] = useState('idle'); // idle | uploading | success | error
   const [photoMsg, setPhotoMsg] = useState('');
-  const fileInputRef = useRef(null);
+  // Dual capture (2026-05-27): cámara + galería para post-attach a entry.
+  const cameraInputRef = useRef(null);
+  const galleryInputRef = useRef(null);
 
   // Audit 2026-05-18 #4: derivar speciesSlug del asset relacionado al log
   // para que `analyzeFoliage` consulte RAG con contexto específico de la
@@ -180,7 +183,19 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
     setAiStream('');
     setAiState('idle');
     try {
-      const { blob } = await captureAndCompress(file);
+      // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG 0.85
+      // → fallback 0.7 → reject > 2 MB antes de persistir + analizar.
+      const preCompressed = await compressImage(file);
+      if (!preCompressed.ok) {
+        setPhotoState('error');
+        setPhotoMsg(
+          preCompressed.reason === 'too_large'
+            ? IMAGE_TOO_LARGE_MESSAGE
+            : 'No se pudo procesar la foto',
+        );
+        return;
+      }
+      const { blob } = await captureAndCompress(preCompressed.blob);
       const result = await attachPhotoToLog(entry.id, blob);
       if (result?.success === false) {
         setPhotoState('error');
@@ -196,8 +211,9 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
       setPhotoState('error');
       setPhotoMsg(err?.message || 'Error procesando foto');
     } finally {
-      // Reset input para permitir re-attach mismo archivo si user reintenta
-      if (fileInputRef.current) fileInputRef.current.value = '';
+      // Reset inputs para permitir re-attach mismo archivo si user reintenta
+      if (cameraInputRef.current) cameraInputRef.current.value = '';
+      if (galleryInputRef.current) galleryInputRef.current.value = '';
     }
   };
 
@@ -372,30 +388,53 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
               La foto se asocia a este evento sin modificarlo (append-only).
               Útil para documentar evidencia post-registro.
             </p>
-            <label className={`w-full p-3 rounded-xl flex items-center justify-center gap-2 cursor-pointer transition-all min-h-[44px] ${
-              photoState === 'uploading'
-                ? 'bg-slate-800 text-slate-500 cursor-wait'
-                : photoState === 'success'
-                  ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-700'
-                  : photoState === 'error'
-                    ? 'bg-red-900/30 text-red-300 border border-red-800'
-                    : 'bg-slate-800 hover:bg-slate-700 text-slate-200 border border-slate-700'
-            }`}>
-              {photoState === 'uploading' ? (
-                <><Loader2 size={18} className="animate-spin" /> Procesando…</>
-              ) : (
-                <><Camera size={18} /> {photoState === 'success' ? 'Adjuntar otra' : 'Tomar / elegir foto'}</>
-              )}
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-               
-                onChange={handlePhotoCapture}
-                disabled={photoState === 'uploading'}
-                className="hidden"
-              />
-            </label>
+            {/* Dual capture (2026-05-27): cámara prominente + galería. El estado
+                de upload se refleja en color de borde del contenedor. */}
+            <input
+              ref={cameraInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              onChange={handlePhotoCapture}
+              disabled={photoState === 'uploading'}
+              className="hidden"
+            />
+            <input
+              ref={galleryInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handlePhotoCapture}
+              disabled={photoState === 'uploading'}
+              className="hidden"
+            />
+            {photoState === 'uploading' ? (
+              <div className="w-full p-3 rounded-xl flex items-center justify-center gap-2 min-h-[44px] bg-slate-800 text-slate-500">
+                <Loader2 size={18} className="animate-spin" /> Procesando…
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  onClick={() => cameraInputRef.current?.click()}
+                  className={`p-3 rounded-xl flex items-center justify-center gap-2 min-h-[44px] border transition-all ${
+                    photoState === 'success'
+                      ? 'bg-emerald-900/40 text-emerald-300 border-emerald-700'
+                      : photoState === 'error'
+                        ? 'bg-red-900/30 text-red-300 border-red-800'
+                        : 'bg-emerald-900/30 hover:bg-emerald-800/40 text-emerald-100 border-emerald-700/60'
+                  }`}
+                >
+                  <Camera size={18} /> Tomar foto
+                </button>
+                <button
+                  type="button"
+                  onClick={() => galleryInputRef.current?.click()}
+                  className="p-3 rounded-xl flex items-center justify-center gap-2 min-h-[44px] border border-slate-700 bg-slate-800 hover:bg-slate-700 text-slate-200"
+                >
+                  <ImageIcon size={18} /> Subir desde galería
+                </button>
+              </div>
+            )}
             {photoMsg && (
               <p className={`text-xs ${photoState === 'error' ? 'text-red-400' : 'text-emerald-400'}`}>
                 {photoMsg}

--- a/src/components/EvidenceCapture.jsx
+++ b/src/components/EvidenceCapture.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Camera, Trash2, Loader2, Image as ImageIcon, Brain, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { optimizeImage, blobToDataUrl } from '../utils/imageProcessor';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { mediaCache } from '../db/mediaCache';
 import { analyzeFoliage } from '../services/aiService';
 import { proximityCheck } from '../utils/spatialAnalysis';
@@ -45,6 +46,12 @@ export const EvidenceCapture = ({
   // muestra con efecto typewriter mientras `diagnosing` es true.
   const [liveDiagnosis, setLiveDiagnosis] = useState('');
   const { request: requestGeo } = useGeolocation();
+  // Dual capture (2026-05-27): cámara prominente (capture="environment") +
+  // galería. Mobile abre cámara nativa con el primero, picker SO con el segundo.
+  const cameraInputRef = useRef(null);
+  const galleryInputRef = useRef(null);
+  // Alias para retro-compat con handlers que limpian el input tras procesar.
+  // Apunta a "el último input que disparó el change" — set en handleCapture.
   const inputRef = useRef(null);
 
   // Cargar evidencias existentes + historial anterior del asset
@@ -91,6 +98,9 @@ export const EvidenceCapture = ({
   const handleCapture = async (e) => {
     const file = e.target.files?.[0];
     if (!file || !logId) return;
+    // Marca cuál input disparó el change para que el cleanup `value=''` toque
+    // el correcto (cualquiera de los dos: cámara o galería).
+    inputRef.current = e.target;
 
     // Proximity gate: verificar que el operario esté cerca del activo
     if (assetGeometry) {
@@ -121,7 +131,22 @@ export const EvidenceCapture = ({
 
     setProcessing(true);
     try {
-      const optimized = await optimizeImage(file);
+      // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG 0.85
+      // → fallback 0.7 → reject > 2 MB. Aplica ANTES de optimizeImage para
+      // bajar el insumo del WebP optimizer y proteger al sidecar de payloads
+      // que excedan su bodyLimit.
+      const preCompressed = await compressImage(file);
+      if (!preCompressed.ok) {
+        if (preCompressed.reason === 'too_large') {
+          window.dispatchEvent(new CustomEvent('chagraToast', {
+            detail: { message: IMAGE_TOO_LARGE_MESSAGE },
+          }));
+        }
+        setProcessing(false);
+        if (inputRef.current) inputRef.current.value = '';
+        return;
+      }
+      const optimized = await optimizeImage(preCompressed.blob);
       const mediaId = await mediaCache.save(logId, optimized, { assetId });
       const dataUrl = await blobToDataUrl(optimized);
 
@@ -309,28 +334,47 @@ export const EvidenceCapture = ({
         </ErrorBoundary>
       )}
 
-      {/* Botón de captura */}
-      <button
-        type="button"
-        onClick={() => inputRef.current?.click()}
-        disabled={disabled || processing}
-        className="w-full py-2.5 bg-slate-800 hover:bg-slate-700 disabled:bg-slate-900 disabled:text-slate-600 text-slate-200 rounded-lg text-sm font-bold flex items-center justify-center gap-2 transition-colors min-h-[44px] border border-slate-700"
-      >
-        {processing ? (
-          <Loader2 size={16} className="animate-spin" />
-        ) : previews.length === 0 ? (
-          <Camera size={16} />
-        ) : (
-          <ImageIcon size={16} />
-        )}
-        {processing ? 'Optimizando…' : previews.length === 0 ? 'Capturar Evidencia' : 'Agregar otra foto'}
-      </button>
+      {/* Dual capture (2026-05-27): cámara prominente + galería. Mientras
+          procesa, un único bloque muestra el spinner. */}
+      {processing ? (
+        <div className="w-full py-2.5 bg-slate-900 text-slate-500 rounded-lg text-sm font-bold flex items-center justify-center gap-2 min-h-[44px] border border-slate-800">
+          <Loader2 size={16} className="animate-spin" /> Optimizando…
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={() => cameraInputRef.current?.click()}
+            disabled={disabled}
+            className="py-2.5 bg-emerald-900/40 hover:bg-emerald-800/50 disabled:bg-slate-900 disabled:text-slate-600 text-emerald-100 rounded-lg text-sm font-bold flex items-center justify-center gap-2 transition-colors min-h-[44px] border border-emerald-700/60"
+          >
+            <Camera size={16} />
+            Tomar foto
+          </button>
+          <button
+            type="button"
+            onClick={() => galleryInputRef.current?.click()}
+            disabled={disabled}
+            className="py-2.5 bg-slate-800 hover:bg-slate-700 disabled:bg-slate-900 disabled:text-slate-600 text-slate-200 rounded-lg text-sm font-bold flex items-center justify-center gap-2 transition-colors min-h-[44px] border border-slate-700"
+          >
+            <ImageIcon size={16} />
+            Subir desde galería
+          </button>
+        </div>
+      )}
 
       <input
-        ref={inputRef}
+        ref={cameraInputRef}
         type="file"
         accept="image/*"
-       
+        capture="environment"
+        className="hidden"
+        onChange={handleCapture}
+      />
+      <input
+        ref={galleryInputRef}
+        type="file"
+        accept="image/*"
         className="hidden"
         onChange={handleCapture}
       />

--- a/src/components/MaintenanceScreen.jsx
+++ b/src/components/MaintenanceScreen.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { ArrowLeft, Camera } from 'lucide-react';
+import React, { useState, useRef } from 'react';
+import { ArrowLeft, Camera, Image as ImageIcon } from 'lucide-react';
 import DateField from './DateField';
 import { syncManager } from '../services/syncManager';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 
 function MaintenanceScreen({ onBack, onSave }) {
   const [formData, setFormData] = useState({
@@ -13,18 +14,32 @@ function MaintenanceScreen({ onBack, onSave }) {
   });
   const [photo, setPhoto] = useState(null);
   const [photoUrl, setPhotoUrl] = useState(null);
+  const cameraInputRef = useRef(null);
+  const galleryInputRef = useRef(null);
 
   const handleInput = (e) => {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
-  const handlePhotoCapture = (e) => {
+  const handlePhotoCapture = async (e) => {
     const file = e.target.files[0];
-    if (file) {
-      setPhoto(file);
-      if (photoUrl) URL.revokeObjectURL(photoUrl);
-      setPhotoUrl(URL.createObjectURL(file));
+    if (!file) return;
+    // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG 0.85
+    // → fallback 0.7 → reject > 2 MB.
+    const compressed = await compressImage(file);
+    if (!compressed.ok) {
+      if (compressed.reason === 'too_large') {
+        window.dispatchEvent(new CustomEvent('chagraToast', {
+          detail: { message: IMAGE_TOO_LARGE_MESSAGE },
+        }));
+      }
+      if (e.target) e.target.value = '';
+      return;
     }
+    setPhoto(compressed.blob);
+    if (photoUrl) URL.revokeObjectURL(photoUrl);
+    setPhotoUrl(URL.createObjectURL(compressed.blob));
+    if (e.target) e.target.value = '';
   };
 
   const handleSave = async () => {
@@ -121,14 +136,32 @@ function MaintenanceScreen({ onBack, onSave }) {
           <textarea name="notes" value={formData.notes} onChange={handleInput} rows="2" className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-xl text-white min-h-[80px]" />
         </label>
 
-        <label className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto</span>
-          <input type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
-          <button onClick={() => document.querySelector('input[type="file"]').click()} className="p-5 rounded-xl text-2xl font-bold flex justify-center items-center gap-3 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700">
-            <Camera size={32} />
-            <span>{photo ? photo.name.substring(0, 15) + '...' : 'Capturar Foto'}</span>
-          </button>
-        </label>
+          <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          <input ref={galleryInputRef} type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => cameraInputRef.current?.click()}
+              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-emerald-900/40 border-2 border-emerald-700/60 text-emerald-100 active:bg-emerald-800/60"
+            >
+              <Camera size={28} />
+              <span>Tomar foto</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => galleryInputRef.current?.click()}
+              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700"
+            >
+              <ImageIcon size={28} />
+              <span>Subir desde galería</span>
+            </button>
+          </div>
+          {photo && (
+            <p className="text-sm text-emerald-300">Foto lista ({Math.round(photo.size / 1024)} KB).</p>
+          )}
+        </div>
 
         <button onClick={handleSave} className="mt-4 p-6 rounded-xl bg-slate-600 active:bg-slate-500 text-2xl lg:text-3xl font-black shadow-xl min-h-[80px] border-b-4 border-slate-800">
           Guardar Mantenimiento

--- a/src/components/ObservationScreen.jsx
+++ b/src/components/ObservationScreen.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
-import { ArrowLeft, AlertCircle, Camera, Sparkles } from 'lucide-react';
+import { ArrowLeft, AlertCircle, Camera, Image as ImageIcon, Sparkles } from 'lucide-react';
 import DateField from './DateField';
 import CaseLinkModal from './CaseLinkModal';
 import { syncManager } from '../services/syncManager';
 import useAssetStore from '../store/useAssetStore';
 import { getParentLandIdFromAsset } from '../utils/assetRelationships';
 import { retrieve as ragRetrieve } from '../services/ragRetriever';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 
 // Bug 069.10 — observation requiere descripción mínima útil + ubicación.
 // Mínimo de 5 caracteres descarta entries vacíos tipo "ok" o "test".
@@ -149,13 +150,28 @@ function ObservationScreen({ onBack, onSave }) {
     });
   };
 
-  const handlePhotoCapture = (e) => {
+  const cameraInputRef = useRef(null);
+  const galleryInputRef = useRef(null);
+
+  const handlePhotoCapture = async (e) => {
     const file = e.target.files[0];
-    if (file) {
-      setPhoto(file);
-      if (photoUrl) URL.revokeObjectURL(photoUrl);
-      setPhotoUrl(URL.createObjectURL(file));
+    if (!file) return;
+    // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG 0.85
+    // → fallback 0.7 → reject > 2 MB.
+    const compressed = await compressImage(file);
+    if (!compressed.ok) {
+      if (compressed.reason === 'too_large') {
+        window.dispatchEvent(new CustomEvent('chagraToast', {
+          detail: { message: IMAGE_TOO_LARGE_MESSAGE },
+        }));
+      }
+      if (e.target) e.target.value = '';
+      return;
     }
+    setPhoto(compressed.blob);
+    if (photoUrl) URL.revokeObjectURL(photoUrl);
+    setPhotoUrl(URL.createObjectURL(compressed.blob));
+    if (e.target) e.target.value = '';
   };
 
   const handleSave = async () => {
@@ -434,14 +450,32 @@ function ObservationScreen({ onBack, onSave }) {
           <textarea name="notes" value={formData.notes} onChange={handleInput} rows="2" className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-xl text-white min-h-[80px]" />
         </label>
 
-        <label className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto</span>
-          <input type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
-          <button onClick={() => document.querySelector('input[type="file"]').click()} className="p-5 rounded-xl text-2xl font-bold flex justify-center items-center gap-3 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700">
-            <Camera size={32} />
-            <span>{photo ? photo.name.substring(0, 15) + '...' : 'Capturar Foto'}</span>
-          </button>
-        </label>
+          <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          <input ref={galleryInputRef} type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => cameraInputRef.current?.click()}
+              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-emerald-900/40 border-2 border-emerald-700/60 text-emerald-100 active:bg-emerald-800/60"
+            >
+              <Camera size={28} />
+              <span>Tomar foto</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => galleryInputRef.current?.click()}
+              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700"
+            >
+              <ImageIcon size={28} />
+              <span>Subir desde galería</span>
+            </button>
+          </div>
+          {photo && (
+            <p className="text-sm text-emerald-300">Foto lista ({Math.round(photo.size / 1024)} KB).</p>
+          )}
+        </div>
 
         <button
           onClick={handleSave}

--- a/src/components/PhotoCaptureField.jsx
+++ b/src/components/PhotoCaptureField.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Camera, RotateCcw, Trash2, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
+import { Camera, Image as ImageIcon, RotateCcw, Trash2, Loader2, AlertCircle, CheckCircle } from 'lucide-react';
 import { captureAndCompress } from '../services/photoService';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
 import { warmVisionModel } from '../services/visionWarmService';
 
@@ -20,7 +21,11 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
     const [previewUrl, setPreviewUrl] = useState(null);
     const [isProcessing, setIsProcessing] = useState(false);
     const [error, setError] = useState(null);
-    const fileInputRef = useRef(null);
+    // Dual capture (2026-05-27): cámara prominente (capture=environment) +
+    // galería como secundario. En mobile el `capture` fuerza la cámara nativa
+    // sin picker intermedio; en desktop solo se renderiza el de galería.
+    const cameraInputRef = useRef(null);
+    const galleryInputRef = useRef(null);
 
     // Sincronizar preview con el valor prop
     useEffect(() => {
@@ -58,15 +63,29 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
         setError(null);
 
         try {
-            const { blob } = await captureAndCompress(file);
+            // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG
+            // 0.85 → fallback 0.7 → reject > 2 MB. Aplica ANTES de
+            // captureAndCompress para garantizar que el blob persistido nunca
+            // venga del path full-size de la cámara.
+            const preCompressed = await compressImage(file);
+            if (!preCompressed.ok) {
+                if (preCompressed.reason === 'too_large') {
+                    setError(IMAGE_TOO_LARGE_MESSAGE);
+                } else {
+                    setError('No se pudo procesar la foto. Reintenta.');
+                }
+                return;
+            }
+            const { blob } = await captureAndCompress(preCompressed.blob);
             onPhoto(blob);
         } catch (err) {
             console.error('[PhotoField] Error procesando foto:', err);
             setError('Error al procesar la foto. Reintenta.');
         } finally {
             setIsProcessing(false);
-            // Reset input para permitir seleccionar la misma foto si se desea tras eliminar
-            if (fileInputRef.current) fileInputRef.current.value = '';
+            // Reset inputs para permitir seleccionar la misma foto si se desea tras eliminar
+            if (cameraInputRef.current) cameraInputRef.current.value = '';
+            if (galleryInputRef.current) galleryInputRef.current.value = '';
         }
     };
 
@@ -78,7 +97,8 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
     };
 
     const handleRetake = () => {
-        fileInputRef.current?.click();
+        // Por defecto re-tomar usa la cámara — coherente con el botón primario.
+        cameraInputRef.current?.click();
     };
 
     /**
@@ -87,30 +107,61 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
      * toca el botón cámara. Mientras enfoca foto/galería (3-5s humano), el
      * modelo carga en GPU. Idempotente + fire-and-forget.
      */
-    const handleClickCapture = () => {
+    const handleClickCamera = () => {
         warmVisionModel().catch(() => {}); // fire-and-forget, ignora errores
-        fileInputRef.current?.click();
+        cameraInputRef.current?.click();
+    };
+
+    const handleClickGallery = () => {
+        warmVisionModel().catch(() => {}); // fire-and-forget, ignora errores
+        galleryInputRef.current?.click();
     };
 
     return (
         <div className={`flex flex-col gap-2 ${className}`}>
+            {/* Dual input (2026-05-27): cámara con capture="environment" (mobile
+                abre cámara nativa) + galería sin capture (picker SO). */}
+            <input
+                type="file"
+                accept="image/*"
+                capture="environment"
+                onChange={handleFileChange}
+                ref={cameraInputRef}
+                className="hidden"
+            />
             <input
                 type="file"
                 accept="image/*"
                 onChange={handleFileChange}
-                ref={fileInputRef}
+                ref={galleryInputRef}
                 className="hidden"
             />
 
             {!previewUrl && !isProcessing && (
-                <button
-                    type="button"
-                    onClick={handleClickCapture}
-                    className="flex flex-col items-center justify-center gap-3 p-8 rounded-2xl bg-slate-900 border-2 border-dashed border-slate-700 hover:border-slate-500 active:bg-slate-800 transition-all min-h-[160px] text-slate-400"
-                >
-                    <Camera size={48} className="opacity-50" />
-                    <span className="text-xl font-bold">{label}</span>
-                </button>
+                // Mobile-first: dos botones lado a lado. Cámara primario (más
+                // grande visualmente, color brand) + galería secundario.
+                // Se mantienen ambos en desktop — algunos navegadores ignoran
+                // `capture` y el de cámara cae a picker normal igual.
+                <div className="grid grid-cols-2 gap-2">
+                    <button
+                        type="button"
+                        onClick={handleClickCamera}
+                        className="flex flex-col items-center justify-center gap-2 p-6 rounded-2xl bg-emerald-900/30 hover:bg-emerald-800/40 active:bg-emerald-800/60 border-2 border-emerald-700/60 transition-all min-h-[160px] text-emerald-200"
+                    >
+                        <Camera size={40} className="text-emerald-300" />
+                        <span className="text-base font-bold leading-tight text-center">Tomar foto</span>
+                        <span className="text-[10px] text-emerald-400/80 uppercase tracking-wider">Cámara</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleClickGallery}
+                        className="flex flex-col items-center justify-center gap-2 p-6 rounded-2xl bg-slate-900 hover:bg-slate-800 active:bg-slate-700 border-2 border-dashed border-slate-700 transition-all min-h-[160px] text-slate-400"
+                    >
+                        <ImageIcon size={40} className="opacity-60" />
+                        <span className="text-base font-bold leading-tight text-center">Subir desde galería</span>
+                        <span className="text-[10px] text-slate-500 uppercase tracking-wider">{label}</span>
+                    </button>
+                </div>
             )}
 
             {isProcessing && (
@@ -158,7 +209,7 @@ const PhotoCaptureField = ({ onPhoto, onRemove, label = "Capturar Foto", value =
                     <AlertCircle size={16} />
                     <span>{error}</span>
                     <button
-                        onClick={handleClickCapture}
+                        onClick={handleClickCamera}
                         className="ml-auto underline font-bold"
                     >
                         Reintentar

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { ArrowLeft, AlertCircle, Camera, MapPin, CheckCircle } from 'lucide-react';
+import { ArrowLeft, AlertCircle, Camera, Image as ImageIcon, MapPin, CheckCircle } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
 import { captureAndCompress, savePhoto } from '../services/photoService';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
 import DateField from './DateField';
 
@@ -62,6 +63,9 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
   };
 
+  const cameraInputRef = useRef(null);
+  const galleryInputRef = useRef(null);
+
   const handlePhotoCapture = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -70,13 +74,28 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
       return;
     }
     try {
-      const { blob } = await captureAndCompress(file);
+      // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG 0.85
+      // → fallback 0.7 → reject > 2 MB.
+      const preCompressed = await compressImage(file);
+      if (!preCompressed.ok) {
+        if (preCompressed.reason === 'too_large') {
+          window.dispatchEvent(new CustomEvent('chagraToast', {
+            detail: { message: IMAGE_TOO_LARGE_MESSAGE },
+          }));
+        } else {
+          onSave('Error procesando foto', true);
+        }
+        return;
+      }
+      const { blob } = await captureAndCompress(preCompressed.blob);
       setPhoto(blob);
       if (photoUrl) URL.revokeObjectURL(photoUrl);
       setPhotoUrl(URL.createObjectURL(blob));
     } catch (err) {
       console.error('Error comprimir foto:', err);
       onSave('Error procesando foto', true);
+    } finally {
+      if (e.target) e.target.value = '';
     }
   };
 
@@ -236,16 +255,33 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
         {/* Hero foto, primer paso del flujo (DR-030 QW3) */}
         <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto de la planta</span>
-          <label className="flex flex-col items-center justify-center gap-3 p-6 rounded-xl bg-slate-900 border-2 border-dashed border-slate-600 active:bg-slate-800 cursor-pointer min-h-[140px] overflow-hidden relative">
-            {sanitizeBlobUrl(photoUrl) ? (
-              <img src={sanitizeBlobUrl(photoUrl)} alt="Preview" className="absolute inset-0 w-full h-full object-cover opacity-60" />
-            ) : null}
-            <div className="z-10 flex flex-col items-center gap-2 drop-shadow-md">
-              <Camera size={48} />
-              <span className="text-xl font-bold">{photo ? '📸 Cambiar foto' : '📸 Foto de la planta'}</span>
+          {/* Dual capture (2026-05-27): cámara con capture="environment" +
+              galería. La preview vive arriba; los botones abajo. */}
+          {sanitizeBlobUrl(photoUrl) && (
+            <div className="relative w-full h-40 rounded-xl overflow-hidden border-2 border-slate-700">
+              <img src={sanitizeBlobUrl(photoUrl)} alt="Preview" className="absolute inset-0 w-full h-full object-cover" />
             </div>
-            <input type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
-          </label>
+          )}
+          <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
+          <input ref={galleryInputRef} type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => cameraInputRef.current?.click()}
+              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-emerald-900/40 border-2 border-emerald-700/60 text-emerald-100 active:bg-emerald-800/60"
+            >
+              <Camera size={28} />
+              <span>{photo ? 'Cambiar' : 'Tomar foto'}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => galleryInputRef.current?.click()}
+              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700"
+            >
+              <ImageIcon size={28} />
+              <span>Subir desde galería</span>
+            </button>
+          </div>
         </div>
 
         <DateField

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -8,6 +8,7 @@ import { fuzzyFilter } from '../utils/fuzzySearch';
 import { usePhotoUrl } from '../hooks/usePhotoUrl';
 import useAssetStore from '../store/useAssetStore';
 import { captureAndCompress } from '../services/photoService';
+import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { recognizeSpeciesGrounded } from '../services/aiService';
 import { getAllSpecies } from '../db/catalogDB';
 import AIBetaBadge from './AIBetaBadge';
@@ -157,7 +158,21 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
     setAiState('running');
     setAiResult(null);
     try {
-      const { blob } = await captureAndCompress(file);
+      // Pre-compresión cliente-lado (operador 2026-05-27): forzamos lado mayor
+      // ≤1600 px y JPEG q=0.85 antes de mandar al sidecar / agente. Esto evita
+      // payloads gigantes hacia /judge-vision y similares. Si NI con quality
+      // 0.7 entra en 2 MB, abortamos con toast y no subimos nada.
+      const compressed = await compressImage(file);
+      if (!compressed.ok) {
+        setAiState('idle');
+        if (compressed.reason === 'too_large') {
+          window.dispatchEvent(new CustomEvent('chagraToast', {
+            detail: { message: IMAGE_TOO_LARGE_MESSAGE },
+          }));
+        }
+        return;
+      }
+      const { blob } = await captureAndCompress(compressed.blob);
       // Bug fix #2 (2026-05-18): la foto sirve tanto para identificar como
       // para persistirse como foto de la planta. Si el parent pasó onPhoto,
       // le delegamos el blob ya comprimido (mismo blob que enviamos a Ollama)

--- a/src/components/__tests__/SpeciesSelect.smoke.test.jsx
+++ b/src/components/__tests__/SpeciesSelect.smoke.test.jsx
@@ -31,6 +31,22 @@ vi.mock('../../services/photoService', () => ({
   }),
 }));
 
+// Mock imageCompress.compressImage → blob sintético sin tocar canvas. jsdom
+// no implementa Canvas realmente, así que la compresión real fallaría —
+// devolvemos el "blob" tal cual para que el flow llegue a captureAndCompress.
+vi.mock('../../utils/imageCompress', () => ({
+  compressImage: vi.fn().mockImplementation(async (blob) => ({
+    ok: true,
+    blob,
+    width: 1600,
+    height: 1200,
+    quality: 0.85,
+    size: typeof blob?.size === 'number' ? blob.size : 1024,
+    originalSize: typeof blob?.size === 'number' ? blob.size : 1024,
+  })),
+  IMAGE_TOO_LARGE_MESSAGE: 'La foto es muy grande, intentá una más liviana',
+}));
+
 // Mock hook usePhotoUrl — sin foto, no relevante para el badge.
 vi.mock('../../hooks/usePhotoUrl', () => ({
   usePhotoUrl: () => ({ url: null, source: null, loading: false }),

--- a/src/utils/__tests__/imageCompress.test.js
+++ b/src/utils/__tests__/imageCompress.test.js
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * imageCompress.test.js — verifica la política de compresión cliente-lado
+ * antes de mandar al sidecar / agente.
+ *
+ * jsdom no implementa Canvas/Image realmente — mockeamos las APIs mínimas
+ * (createImageBitmap, OffscreenCanvas/canvas.toBlob) y devolvemos blobs de
+ * tamaño controlado para verificar que la lógica del retry/fallback/reject
+ * funciona como está escrito en la spec.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let compressImage;
+let IMAGE_TOO_LARGE_MESSAGE;
+let __test;
+
+// State global para el mock de canvasToBlob — cada test ajusta los tamaños
+// que devolverán los toBlob calls en orden.
+let blobSizesQueue = [];
+
+beforeEach(async () => {
+  blobSizesQueue = [];
+
+  // 1) Mock createImageBitmap — devuelve un "bitmap" con dims conocidas.
+  globalThis.createImageBitmap = vi.fn().mockImplementation(async () => ({
+    width: 4000,
+    height: 3000,
+    close: vi.fn(),
+  }));
+
+  // 2) Mock OffscreenCanvas para que sea predictible (presente y funcional).
+  class MockOffscreenCanvas {
+    constructor(w, h) {
+      this.width = w;
+      this.height = h;
+    }
+    getContext() {
+      return { drawImage: vi.fn() };
+    }
+    async convertToBlob({ type } = { type: 'image/jpeg' }) {
+      const size = blobSizesQueue.shift() ?? 100 * 1024; // default 100 KB
+      // En entornos jsdom no podemos generar un JPEG real — fabricamos un Blob
+      // con tamaño controlado vía un Uint8Array. El contenido es irrelevante:
+      // los assertions miran .size, no los bytes.
+      const buf = new Uint8Array(size);
+      return new Blob([buf], { type });
+    }
+  }
+  globalThis.OffscreenCanvas = MockOffscreenCanvas;
+
+  // Reset del module registry para que el `typeof OffscreenCanvas === 'function'`
+  // chequeado dentro de imageCompress.js refleje el mock recién instalado.
+  vi.resetModules();
+  const mod = await import('../imageCompress.js');
+  compressImage = mod.compressImage;
+  IMAGE_TOO_LARGE_MESSAGE = mod.IMAGE_TOO_LARGE_MESSAGE;
+  __test = mod.__test;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('compressImage', () => {
+  it('exporta una constante con el mensaje toast canónico', () => {
+    expect(IMAGE_TOO_LARGE_MESSAGE).toMatch(/muy grande/i);
+  });
+
+  it('expone defaults verificables vía __test', () => {
+    expect(__test.DEFAULT_MAX_DIMENSION).toBe(1600);
+    expect(__test.DEFAULT_QUALITY_PRIMARY).toBeCloseTo(0.85, 5);
+    expect(__test.DEFAULT_QUALITY_FALLBACK).toBeCloseTo(0.7, 5);
+    expect(__test.DEFAULT_MAX_BYTES).toBe(2 * 1024 * 1024);
+    expect(__test.DEFAULT_MIME).toBe('image/jpeg');
+  });
+
+  it('comprime un blob 4000x3000 a lado mayor 1600 manteniendo aspect ratio', async () => {
+    blobSizesQueue.push(300 * 1024); // 300 KB en primer intento
+    const input = new Blob([new Uint8Array(5 * 1024 * 1024)], { type: 'image/jpeg' });
+
+    const result = await compressImage(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.width).toBe(1600);
+      expect(result.height).toBe(1200); // 3000 * (1600/4000)
+      expect(result.size).toBe(300 * 1024);
+      expect(result.originalSize).toBe(5 * 1024 * 1024);
+      expect(result.quality).toBeCloseTo(0.85, 5);
+      expect(result.blob.type).toBe('image/jpeg');
+    }
+  });
+
+  it('NO escala si la imagen ya es menor que maxDimension', async () => {
+    // Tweak: bitmap más chico que el techo.
+    globalThis.createImageBitmap = vi.fn().mockResolvedValue({
+      width: 800,
+      height: 600,
+      close: vi.fn(),
+    });
+    blobSizesQueue.push(150 * 1024);
+
+    const input = new Blob([new Uint8Array(200 * 1024)], { type: 'image/jpeg' });
+    const result = await compressImage(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.width).toBe(800);
+      expect(result.height).toBe(600);
+    }
+  });
+
+  it('reintenta con quality 0.7 si la primera compresión queda > 2 MB', async () => {
+    blobSizesQueue.push(3 * 1024 * 1024); // 3 MB primer intento → demasiado
+    blobSizesQueue.push(1.5 * 1024 * 1024); // 1.5 MB con quality 0.7 → ok
+
+    const input = new Blob([new Uint8Array(10 * 1024 * 1024)], { type: 'image/jpeg' });
+    const result = await compressImage(input);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.quality).toBeCloseTo(0.7, 5);
+      expect(result.size).toBe(1.5 * 1024 * 1024);
+    }
+  });
+
+  it('rechaza con reason="too_large" si NI el reintento entra en 2 MB', async () => {
+    blobSizesQueue.push(3 * 1024 * 1024); // primer intento — demasiado
+    blobSizesQueue.push(2.5 * 1024 * 1024); // segundo intento — todavía demasiado
+
+    const input = new Blob([new Uint8Array(15 * 1024 * 1024)], { type: 'image/jpeg' });
+    const result = await compressImage(input);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('too_large');
+      expect(result.size).toBe(2.5 * 1024 * 1024);
+      expect(result.originalSize).toBe(15 * 1024 * 1024);
+    }
+  });
+
+  it('rechaza con reason="decode_failed" si createImageBitmap tira', async () => {
+    globalThis.createImageBitmap = vi.fn().mockRejectedValue(new Error('decode bug'));
+    // El fallback decodeViaImg también va a fallar en jsdom porque <img> no
+    // dispara onload sobre data URLs sintéticas — preempt eso mockeando Image.
+    class BrokenImage {
+      set src(_v) {
+        // dispara onerror async
+        queueMicrotask(() => this.onerror && this.onerror());
+      }
+    }
+    globalThis.Image = BrokenImage;
+
+    const input = new Blob([new Uint8Array(1024)], { type: 'image/jpeg' });
+    const result = await compressImage(input);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('decode_failed');
+    }
+  });
+
+  it('rechaza con reason="decode_failed" si el blob es null', async () => {
+    const result = await compressImage(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('decode_failed');
+    }
+  });
+
+  it('permite override de opts.maxBytes y opts.maxDimension', async () => {
+    // Si subimos maxBytes a 5 MB, un blob de 3 MB en el primer intento debería
+    // pasar sin retry.
+    blobSizesQueue.push(3 * 1024 * 1024);
+
+    const input = new Blob([new Uint8Array(10 * 1024 * 1024)], { type: 'image/jpeg' });
+    const result = await compressImage(input, { maxBytes: 5 * 1024 * 1024, maxDimension: 800 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.width).toBe(800);
+      expect(result.height).toBe(600);
+      expect(result.size).toBe(3 * 1024 * 1024);
+      expect(result.quality).toBeCloseTo(0.85, 5);
+    }
+  });
+});

--- a/src/utils/imageCompress.js
+++ b/src/utils/imageCompress.js
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * imageCompress.js — compresión cliente-lado de imágenes antes de mandarlas
+ * al sidecar / agente de visión.
+ *
+ * Política (operador 2026-05-27):
+ *   - Lado mayor máx 1600 px (aspect ratio preservado).
+ *   - Output JPEG quality 0.85.
+ *   - Si el blob resultante sigue > 2 MB, bajamos quality a 0.7 y
+ *     reintentamos UNA vez.
+ *   - Si sigue > 2 MB, la función devuelve `{ ok: false, reason: 'too_large', ... }`
+ *     y el caller muestra toast "La foto es muy grande, intentá una más liviana"
+ *     SIN subir nada.
+ *
+ * Esta es la primera capa de defensa contra payloads gigantes hacia el
+ * sidecar agro-mcp (que arranca con `bodyLimit` chico). Es complementaria a
+ * `photoService.captureAndCompress` que apunta a 500 KB para persistencia
+ * local — acá apuntamos a un techo distinto (2 MB) porque el sidecar es
+ * quien define el límite de red.
+ *
+ * Diseño puro: NO toca IndexedDB, NO toca red, NO toca catálogo. Recibe un
+ * Blob (o File) y devuelve un Blob comprimido. El caller decide qué hacer.
+ */
+
+const DEFAULT_MAX_DIMENSION = 1600;
+const DEFAULT_QUALITY_PRIMARY = 0.85;
+const DEFAULT_QUALITY_FALLBACK = 0.7;
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024; // 2 MB
+const DEFAULT_MIME = 'image/jpeg';
+
+/**
+ * Comprime un blob de imagen siguiendo la política descrita arriba.
+ *
+ * @param {Blob|File} blob — imagen original (cámara, galería, o blob ya
+ *   procesado por otro path).
+ * @param {Object}    [opts]
+ * @param {number}    [opts.maxDimension=1600]    — lado mayor en px
+ * @param {number}    [opts.quality=0.85]         — JPEG quality 1er intento
+ * @param {number}    [opts.qualityFallback=0.7]  — JPEG quality 2do intento
+ * @param {number}    [opts.maxBytes=2097152]     — techo de bytes para subir
+ * @param {string}    [opts.mime='image/jpeg']    — MIME de salida
+ *
+ * @returns {Promise<
+ *   | { ok: true,  blob: Blob, width: number, height: number, quality: number, size: number, originalSize: number }
+ *   | { ok: false, reason: 'too_large' | 'decode_failed' | 'canvas_failed', size?: number, originalSize?: number }
+ * >}
+ */
+export async function compressImage(blob, opts = {}) {
+  const maxDimension = opts.maxDimension ?? DEFAULT_MAX_DIMENSION;
+  const qualityPrimary = opts.quality ?? DEFAULT_QUALITY_PRIMARY;
+  const qualityFallback = opts.qualityFallback ?? DEFAULT_QUALITY_FALLBACK;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const mime = opts.mime ?? DEFAULT_MIME;
+
+  if (!blob) {
+    return { ok: false, reason: 'decode_failed' };
+  }
+  const originalSize = typeof blob.size === 'number' ? blob.size : 0;
+
+  // 1) decode → bitmap
+  let bitmap;
+  try {
+    bitmap = await decodeToBitmap(blob);
+  } catch {
+    return { ok: false, reason: 'decode_failed', originalSize };
+  }
+
+  const naturalW = bitmap.naturalWidth || bitmap.width || 0;
+  const naturalH = bitmap.naturalHeight || bitmap.height || 0;
+  if (!naturalW || !naturalH) {
+    closeBitmap(bitmap);
+    return { ok: false, reason: 'decode_failed', originalSize };
+  }
+
+  // 2) calcular target dims manteniendo aspect ratio
+  const longest = Math.max(naturalW, naturalH);
+  const scale = longest > maxDimension ? maxDimension / longest : 1;
+  const targetW = Math.max(1, Math.round(naturalW * scale));
+  const targetH = Math.max(1, Math.round(naturalH * scale));
+
+  // 3) render a canvas
+  let canvas;
+  try {
+    canvas = renderToCanvas(bitmap, targetW, targetH);
+  } catch {
+    closeBitmap(bitmap);
+    return { ok: false, reason: 'canvas_failed', originalSize };
+  } finally {
+    closeBitmap(bitmap);
+  }
+
+  // 4) primer intento — quality primaria
+  let compressed;
+  try {
+    compressed = await canvasToBlob(canvas, mime, qualityPrimary);
+  } catch {
+    return { ok: false, reason: 'canvas_failed', originalSize };
+  }
+
+  if (compressed.size <= maxBytes) {
+    return {
+      ok: true,
+      blob: compressed,
+      width: targetW,
+      height: targetH,
+      quality: qualityPrimary,
+      size: compressed.size,
+      originalSize,
+    };
+  }
+
+  // 5) fallback — quality secundaria, UN reintento
+  let fallback;
+  try {
+    fallback = await canvasToBlob(canvas, mime, qualityFallback);
+  } catch {
+    return { ok: false, reason: 'canvas_failed', originalSize };
+  }
+
+  if (fallback.size <= maxBytes) {
+    return {
+      ok: true,
+      blob: fallback,
+      width: targetW,
+      height: targetH,
+      quality: qualityFallback,
+      size: fallback.size,
+      originalSize,
+    };
+  }
+
+  // 6) ni con quality 0.7 entra — el caller debe avisar al usuario.
+  return {
+    ok: false,
+    reason: 'too_large',
+    size: fallback.size,
+    originalSize,
+  };
+}
+
+/** Mensaje canónico para mostrar al usuario cuando compressImage rechaza. */
+export const IMAGE_TOO_LARGE_MESSAGE =
+  'La foto es muy grande, intentá una más liviana';
+
+// ────────────────────────────────────────────────────────────
+// Helpers internos
+// ────────────────────────────────────────────────────────────
+
+async function decodeToBitmap(blob) {
+  // Preferimos createImageBitmap (rápido + soporta HEIC en iOS Safari).
+  if (typeof createImageBitmap === 'function') {
+    try {
+      return await createImageBitmap(blob);
+    } catch {
+      // cae al fallback HTMLImageElement
+    }
+  }
+  return await decodeViaImg(blob);
+}
+
+function decodeViaImg(blob) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('img decode failed'));
+    };
+    img.src = url;
+  });
+}
+
+function renderToCanvas(bitmap, w, h) {
+  const canvas =
+    typeof OffscreenCanvas === 'function'
+      ? new OffscreenCanvas(w, h)
+      : (() => {
+          const c = document.createElement('canvas');
+          c.width = w;
+          c.height = h;
+          return c;
+        })();
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('canvas 2d unavailable');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  return canvas;
+}
+
+function canvasToBlob(canvas, mime, quality) {
+  // OffscreenCanvas: convertToBlob({ type, quality })
+  if (typeof canvas.convertToBlob === 'function') {
+    return canvas.convertToBlob({ type: mime, quality });
+  }
+  // HTMLCanvasElement: toBlob(cb, type, quality)
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('toBlob returned null'))),
+      mime,
+      quality,
+    );
+  });
+}
+
+function closeBitmap(bitmap) {
+  if (bitmap && typeof bitmap.close === 'function') {
+    try {
+      bitmap.close();
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+// Export interno para tests (defaults verificables sin importar el módulo
+// entero).
+export const __test = {
+  DEFAULT_MAX_DIMENSION,
+  DEFAULT_QUALITY_PRIMARY,
+  DEFAULT_QUALITY_FALLBACK,
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MIME,
+};


### PR DESCRIPTION
## Summary
- Nuevo `src/utils/imageCompress.js` con `compressImage(blob, opts)`: lado mayor ≤1600px, JPEG quality 0.85, fallback 0.7, reject explícito si pasa de 2MB.
- Botón "Tomar foto" prominente con `capture="environment"` + "Subir desde galería" como secundario, lado a lado mobile-first. Cubre `SpeciesSelect`, `EvidenceCapture`, `PhotoCaptureField`, `MaintenanceScreen`, `ObservationScreen`, `SeedingLog`, `BitacoraEntryDetail`.
- Toast "La foto es muy grande, intentá una más liviana" cuando NI con quality 0.7 entra en 2MB — primera capa de defensa antes de que el payload llegue al sidecar agro-mcp.

## Test plan
- [x] `npx vitest run src/utils/__tests__/imageCompress.test.js` — 9/9 verde (compresión + retry + reject + override).
- [x] `npx vitest run src/components/__tests__/SpeciesSelect.smoke.test.jsx` — 7/7 verde (mock de compressImage agregado).
- [x] ESLint `--max-warnings=0` en todos los archivos tocados.
- [x] `npm run build` verde.
- [ ] Smoke manual en mobile: tap "Tomar foto" abre cámara nativa (capture="environment"), tap "Subir desde galería" abre picker SO.
- [ ] Smoke manual: foto > 2MB tras compresión dispara toast y NO sube nada.

## Notes
- Sidecar size-guard 2MB pareja en PR separado contra `chagra-pro` (branch `feature/sidecar-image-size-guard-2mb`).