### PR TITLE
fix(ux): copy 'Nueva conversación' más claro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.12",
+  "version": "0.13.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v244';
+const CACHE_NAME = 'chagra-v245';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1431,8 +1431,8 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         <div className="px-4 py-2 mx-4 mt-2 rounded-lg bg-slate-800/60 border border-slate-700/60 flex items-center gap-2">
           <Sparkles size={14} className="text-violet-400 shrink-0" />
           <p className="text-xs text-slate-300" data-testid="fresh-session-badge">
-            Nueva conversación. El historial anterior queda guardado pero no se
-            incluye en el contexto.
+            Empezamos fresco. Tu historial sigue guardado en tu finca; este
+            chat arranca limpio para que el agente se concentre en lo nuevo.
           </p>
         </div>
       )}


### PR DESCRIPTION
Operador dudó si su historial se había borrado. Ahora deja claro que el historial SIGUE guardado y que el chat fresh arranca por diseño (FEAT-A pending). 🤖