### PR TITLE
feat(ux): UX-4 botón "Ver ejemplo" con demo simulada agente (#285)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.12",
+  "version": "0.13.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v244';
+const CACHE_NAME = 'chagra-v245';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentDemoExample.jsx
+++ b/src/components/AgentDemoExample.jsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { User } from 'lucide-react';
+import ChagraAgentAvatar from './ChagraAgentAvatar';
+import AIBetaBadge from './AIBetaBadge';
+
+/**
+ * AgentDemoExample — mini-demo predefinida del agente Chagra para que el
+ * operador vea "qué puede hacer" sin tener que tomar una foto ni redactar
+ * una pregunta.
+ *
+ * Decisión UX-4 (issue #285): cuando un operador nuevo abre la pantalla del
+ * agente sin historial, la falta de fricción para arrancar es crítica. El
+ * botón "Ver ejemplo (sin foto)" del AgentScreen monta este componente, que
+ * inyecta un turno simulado user + una respuesta simulada del agente con
+ * delay realista (1s), badge "beta" y disclaimer claro de que es
+ * demostrativo. Cero llamadas al LLM, cero costo de inferencia, cero riesgo
+ * de alucinación — el contenido es texto fijo curado.
+ *
+ * Diseño:
+ *   - Replica la apariencia de ChatBubble (mismo avatar, misma burbuja
+ *     emerald para user, slate para agente) para que el operador entienda
+ *     visualmente cómo se ve una conversación real.
+ *   - Delay 1s antes de mostrar la respuesta del agente — comunica que el
+ *     agente "está pensando" sin engaño (no decimos que sea inferencia
+ *     real, el disclaimer lo aclara).
+ *   - AIBetaBadge para coherencia con respuestas reales del agente
+ *     (UX-1, #284).
+ *   - Disclaimer pequeño debajo: "Ejemplo demostrativo. Tu situación real
+ *     puede variar." — wording sobrio, sin hype.
+ *
+ * Props:
+ *   - onClose: callback opcional sin args. Si se pasa, renderiza un botón
+ *              pequeño "Cerrar ejemplo" para que el operador limpie la
+ *              demo y siga con su flow normal.
+ *   - autoStart: bool, default true. Si false, el componente arranca en
+ *              estado "vacío" y espera a que el caller llame start() — por
+ *              ahora solo lo usa el test para inspeccionar el estado
+ *              previo al delay.
+ *
+ * NO se persiste en IndexedDB (esto NO es una conversación real). NO se
+ * agrega a `conversationMemory` ni al `messages` state del AgentScreen.
+ * El componente es completamente self-contained.
+ */
+
+const DEMO_USER_PROMPT = 'Tengo gulupa con mancha amarilla en las hojas, ¿qué hago?';
+
+const DEMO_AGENT_RESPONSE = `Por la descripción puede ser deficiencia de hierro o ataque de la mancha café (Septoria passiflorae). Te sugiero:
+
+1. Toma una foto de la hoja afectada para confirmar.
+2. Si confirmamos Septoria, biopreparado base: extracto de cola de caballo (Equisetum arvense) al 2%, foliar cada 8 días.
+3. Mejora drenaje del suelo si lluvia >100mm/semana.
+
+¿Tomamos la foto ahora?`;
+
+const AGENT_REPLY_DELAY_MS = 1000;
+
+export default function AgentDemoExample({ onClose, autoStart = true }) {
+  const [showAgentReply, setShowAgentReply] = useState(false);
+  const timerRef = useRef(null);
+
+  // El delay del reply del agente lo manejamos como un timer puro en
+  // useEffect. NO hacemos setState síncrono dentro del effect (eso es
+  // anti-patrón react-hooks/set-state-in-effect) — solo agendamos el
+  // setTimeout, que despertará al setShowAgentReply(true) cuando expire.
+  // La condición `autoStart` decide si arrancamos; si false, el componente
+  // queda en "Pensando…" hasta que el caller lo desmonte o re-monte.
+  useEffect(() => {
+    if (!autoStart) {
+      return undefined;
+    }
+    timerRef.current = setTimeout(() => {
+      setShowAgentReply(true);
+      timerRef.current = null;
+    }, AGENT_REPLY_DELAY_MS);
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [autoStart]);
+
+  return (
+    <div
+      data-testid="agent-demo-example"
+      className="px-4 py-3 border-t border-slate-800/60 bg-slate-900/30"
+      role="region"
+      aria-label="Ejemplo demostrativo del agente"
+    >
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-3">
+        Ejemplo
+      </p>
+
+      {/* Burbuja simulada del usuario — coherente con ChatBubble. */}
+      <div className="flex justify-end mb-3">
+        <div className="flex gap-2 max-w-[85%] flex-row-reverse">
+          <div className="shrink-0 w-8 h-8 rounded-full flex items-center justify-center bg-emerald-600">
+            <User size={16} className="text-white" aria-hidden="true" />
+          </div>
+          <div
+            data-testid="agent-demo-user-bubble"
+            className="rounded-2xl px-4 py-2.5 bg-emerald-700/60 text-white rounded-tr-sm"
+          >
+            <p className="text-sm leading-relaxed whitespace-pre-wrap">
+              {DEMO_USER_PROMPT}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Burbuja simulada del agente — aparece tras 1s. */}
+      {showAgentReply ? (
+        <div className="flex justify-start mb-2" data-testid="agent-demo-agent-bubble">
+          <div className="flex gap-2 max-w-[85%] flex-row">
+            <div className="shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-slate-900 border border-emerald-700/40 overflow-hidden">
+              <ChagraAgentAvatar state="thinking" size={32} ariaLabel="Chagra IA" />
+            </div>
+            <div className="rounded-2xl px-4 py-2.5 bg-slate-800/80 text-slate-100 rounded-tl-sm">
+              <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                {DEMO_AGENT_RESPONSE}
+              </p>
+              <AIBetaBadge className="mt-1" />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div
+          className="flex justify-start mb-2"
+          data-testid="agent-demo-thinking"
+          aria-live="polite"
+        >
+          <div className="flex gap-2 max-w-[85%] flex-row">
+            <div className="shrink-0 w-9 h-9 rounded-full flex items-center justify-center bg-slate-900 border border-amber-400/60 overflow-hidden">
+              <ChagraAgentAvatar state="thinking" size={32} ariaLabel="Chagra IA" />
+            </div>
+            <div className="rounded-2xl px-4 py-2.5 bg-slate-800/60 text-slate-400">
+              <p className="text-sm leading-relaxed italic">Pensando…</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Disclaimer + cerrar. */}
+      <div className="mt-2 flex items-center justify-between gap-3 flex-wrap">
+        <p className="text-[11px] text-slate-500 italic" data-testid="agent-demo-disclaimer">
+          Ejemplo demostrativo. Tu situación real puede variar.
+        </p>
+        {typeof onClose === 'function' && (
+          <button
+            type="button"
+            onClick={onClose}
+            data-testid="agent-demo-close"
+            className="text-[11px] text-slate-400 hover:text-slate-200 underline-offset-2 hover:underline transition-colors"
+          >
+            Cerrar ejemplo
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -29,6 +29,7 @@ import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import QuickChipsBar from '../QuickChipsBar';
+import AgentDemoExample from '../AgentDemoExample';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
@@ -111,6 +112,11 @@ export default function AgentScreen({ onBack }) {
   // Toast de rechazo de la 3ra pregunta. Auto-dismiss a 4s para no
   // bloquear el input visualmente.
   const [queueRejectedToast, setQueueRejectedToast] = useState('');
+  // UX-4 (#285): demo predefinida del agente para operadores que abren la
+  // pantalla por primera vez (sin historial). Toggle local — NO se persiste
+  // ni se inyecta al messages real. Aparece junto a QuickChipsBar cuando
+  // chat está vacío e idle.
+  const [showAgentDemo, setShowAgentDemo] = useState(false);
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -1486,6 +1492,27 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           UI con sugerencias mientras hay conversación visible. */}
       {state === STATE_IDLE && messages.length === 0 && (
         <QuickChipsBar onSelect={handleSuggestion} />
+      )}
+
+      {/* UX-4 (#285): botón "Ver ejemplo" para operadores nuevos sin
+          historial. Monta una demo simulada (mensaje user + respuesta
+          predefinida con delay 1s) sin llamar al LLM — cero costo, cero
+          alucinación. Solo en pantalla nueva e idle, alineado con la
+          ventana donde QuickChipsBar también vive. */}
+      {state === STATE_IDLE && messages.length === 0 && !showAgentDemo && (
+        <div className="px-4 pb-2 pt-1 bg-slate-900/40">
+          <button
+            type="button"
+            onClick={() => setShowAgentDemo(true)}
+            data-testid="agent-demo-trigger"
+            className="w-full px-3 py-2 rounded-lg bg-slate-800/60 hover:bg-slate-700/70 active:scale-[0.99] border border-slate-700/50 text-xs text-slate-300 transition-all"
+          >
+            Ver ejemplo (sin foto)
+          </button>
+        </div>
+      )}
+      {state === STATE_IDLE && messages.length === 0 && showAgentDemo && (
+        <AgentDemoExample onClose={() => setShowAgentDemo(false)} />
       )}
 
       {/* Input */}

--- a/src/components/__tests__/AgentDemoExample.test.jsx
+++ b/src/components/__tests__/AgentDemoExample.test.jsx
@@ -1,0 +1,83 @@
+/**
+ * Tests UX-4 (#285) — AgentDemoExample.
+ *
+ * Verifica que el componente:
+ *   1. Renderiza inmediatamente la burbuja simulada del usuario con el
+ *      prompt curado.
+ *   2. Muestra estado "Pensando…" mientras transcurre el delay (1s).
+ *   3. Tras avanzar timers ~1s aparece la respuesta del agente con
+ *      AIBetaBadge + disclaimer demostrativo.
+ *   4. El botón "Cerrar ejemplo" dispara onClose si está provisto.
+ *
+ * Foco unit-puro: NO renderea el AgentScreen completo — eso requeriría
+ * stub de ~25 servicios y trae fragilidad. Es el mismo patrón usado por
+ * los demás smoke tests del directorio (AIBetaBadge, etc.).
+ */
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import AgentDemoExample from '../AgentDemoExample';
+
+describe('AgentDemoExample — demo simulada del agente (UX-4 #285)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('renderiza la burbuja del usuario con el prompt curado al montar', () => {
+    render(<AgentDemoExample />);
+    const userBubble = screen.getByTestId('agent-demo-user-bubble');
+    expect(userBubble).toBeInTheDocument();
+    expect(userBubble.textContent).toMatch(/gulupa/i);
+    expect(userBubble.textContent).toMatch(/mancha amarilla/i);
+  });
+
+  test('muestra estado "Pensando…" antes del delay', () => {
+    render(<AgentDemoExample />);
+    expect(screen.getByTestId('agent-demo-thinking')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-demo-agent-bubble')).not.toBeInTheDocument();
+  });
+
+  test('tras 1s aparece la respuesta del agente con badge beta y disclaimer', () => {
+    render(<AgentDemoExample />);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    const reply = screen.getByTestId('agent-demo-agent-bubble');
+    expect(reply).toBeInTheDocument();
+    expect(reply.textContent).toMatch(/Septoria passiflorae/);
+    expect(reply.textContent).toMatch(/cola de caballo/);
+    // Badge "beta" UX-1 (#284) presente.
+    expect(screen.getByTestId('ai-beta-badge')).toBeInTheDocument();
+    // Disclaimer demostrativo visible.
+    const disclaimer = screen.getByTestId('agent-demo-disclaimer');
+    expect(disclaimer.textContent).toMatch(/Ejemplo demostrativo/i);
+    expect(disclaimer.textContent).toMatch(/situación real/i);
+  });
+
+  test('el botón "Cerrar ejemplo" dispara onClose cuando está provisto', () => {
+    const onClose = vi.fn();
+    render(<AgentDemoExample onClose={onClose} />);
+    const closeBtn = screen.getByTestId('agent-demo-close');
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('sin prop onClose el botón cerrar no se renderiza', () => {
+    render(<AgentDemoExample />);
+    expect(screen.queryByTestId('agent-demo-close')).not.toBeInTheDocument();
+  });
+
+  test('autoStart=false mantiene el estado "Pensando…" indefinido hasta avanzar timers manualmente', () => {
+    render(<AgentDemoExample autoStart={false} />);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.getByTestId('agent-demo-thinking')).toBeInTheDocument();
+    expect(screen.queryByTestId('agent-demo-agent-bubble')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **UX-4 (#285)**: nuevo botón "Ver ejemplo (sin foto)" en `AgentScreen` cuando el chat está vacío e idle. Al activarlo monta `AgentDemoExample` — un turno user simulado ("Tengo gulupa con mancha amarilla en las hojas, ¿qué hago?") y, tras 1s de delay, respuesta predefinida del agente con `AIBetaBadge` + disclaimer "Ejemplo demostrativo. Tu situación real puede variar."
- Cero llamadas al LLM, cero costo de inferencia, cero riesgo de alucinación — el contenido es texto curado. Reduce la fricción del "qué le pregunto" para operadores nuevos sin historial.
- Complementa `QuickChipsBar` (UX-5 #286) y `AIBetaBadge` (UX-1 #284) sin duplicar ni sustituirlos. Convive en la misma ventana de estado `STATE_IDLE && messages.length === 0`.

## Implementación

- `src/components/AgentDemoExample.jsx` — encapsula el flujo: burbuja user inmediata + estado "Pensando…" + burbuja agente tras 1s. Replica look-and-feel de `ChatBubble` (avatar, colores) para que el operador entienda visualmente cómo se ve una conversación real. NO se persiste en IndexedDB ni se inyecta a `conversationMemory`.
- `src/components/AgentScreen/AgentScreen.jsx` — toggle `showAgentDemo` local. Botón visible cuando `state === STATE_IDLE && messages.length === 0 && !showAgentDemo`. Demo render cuando toggle es true. Botón "Cerrar ejemplo" en el componente.
- Patrón anti-`react-hooks/set-state-in-effect`: el delay se maneja como timer puro dentro de `useEffect` (sin `setState` síncrono en el body del effect).
- Bump 0.13.12 → 0.13.13 + sw cache v244 → v245 (SOP §3.2).

## Test plan

- [x] `npx vitest run src/components/__tests__/AgentDemoExample.test.jsx` — 6 casos OK (render inmediato user bubble, estado "Pensando…", aparición de respuesta tras delay, badge beta + disclaimer, onClose handler, autoStart=false).
- [x] `npx vitest run src/components/AgentScreen/__tests__/` — 12 casos OK (queue store sin regresiones).
- [x] `npx eslint src/components/AgentDemoExample.jsx src/components/__tests__/AgentDemoExample.test.jsx src/components/AgentScreen/AgentScreen.jsx --max-warnings=0` — clean.
- [ ] Smoke manual en `chagra.guatoc.co` tras merge: abrir agente sin historial → ver botón → click → ver demo aparecer con delay → cerrar y volver al estado inicial.