### PR TITLE
feat(ux): UX pack batch — offline chip, texto fallback, errores friendly (#286)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.14",
+  "version": "0.13.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v246';
+const CACHE_NAME = 'chagra-v247';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/OfflineChip.jsx
+++ b/src/components/OfflineChip.jsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import { WifiOff } from 'lucide-react';
+
+/**
+ * OfflineChip — indicador ambient persistente del estado offline (UX-2).
+ *
+ * Pequeño chip que vive en el header (top-right, al lado del nombre del
+ * operador) y aparece SOLO cuando `navigator.onLine === false`. Cuando la
+ * conexión vuelve, se oculta automáticamente. No tiene botón de cerrar —
+ * es un indicador ambient, no un banner intermitente.
+ *
+ * Coexiste con `NetworkStatusBar`:
+ *   - `NetworkStatusBar` es la barra full-width que aparece arriba del
+ *     dashboard con detalle (cantidad de registros pendientes, dismiss
+ *     manual, etc.). Se puede ocultar por sesión.
+ *   - `OfflineChip` es el indicador permanente, siempre visible en el
+ *     header cuando estás offline, sin importar si el operador descartó
+ *     la barra. Garantiza que el operador NO se confunda creyendo que
+ *     todo está OK cuando no hay red.
+ *
+ * Decisión UX (#286): el chip NO es interactivo (no abre detalle al
+ * tocar). El detalle vive en `NetworkStatusBar` (que el operador puede
+ * reabrir desde la sección Bitácora). Esto mantiene el header limpio y
+ * el chip cumple un solo trabajo (informar).
+ */
+export default function OfflineChip() {
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  if (isOnline) return null;
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-label="Sin conexión a internet"
+      data-testid="offline-chip"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-900/30 border border-amber-700/60 text-amber-300 text-[10px] font-bold uppercase tracking-wider shrink-0"
+      title="Sin conexión a internet. Tus registros se guardan localmente y se sincronizan al volver."
+    >
+      <WifiOff size={11} aria-hidden="true" />
+      <span className="hidden sm:inline">Sin conexión</span>
+    </span>
+  );
+}

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -11,6 +11,7 @@ import { captureAndCompress } from '../services/photoService';
 import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { recognizeSpeciesGrounded } from '../services/aiService';
 import { getAllSpecies } from '../db/catalogDB';
+import { friendlyMessage } from '../utils/friendlyErrors';
 import AIBetaBadge from './AIBetaBadge';
 
 /**
@@ -97,6 +98,10 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
   const [open, setOpen] = useState(false);
   const [selectedSpeciesId, setSelectedSpeciesId] = useState(null);
   const wrapperRef = useRef(null);
+  // UX-6 (#286) 2026-05-27: ref al input principal del fuzzy search para
+  // que el botón "Mejor escribo el nombre" pueda darle foco al cancelar el
+  // flow de visión.
+  const queryInputRef = useRef(null);
 
   // Catálogo dinámico (v3.1 ≈480 species) con fallback legacy (~77).
   // Se carga async desde catalogDB al mount; si tarda >2s o falla, queda
@@ -147,6 +152,10 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
   const aiGalleryRef = useRef(null);
   const [aiState, setAiState] = useState('idle'); // idle | running | done | error
   const [aiResult, setAiResult] = useState(null);
+  // UX-12 (#286) 2026-05-27: mensaje user-friendly del último error de
+  // visión, mostrado en el bloque aiState='error' en lugar del texto
+  // técnico "El modelo Ollama puede no estar disponible".
+  const [aiErrorMessage, setAiErrorMessage] = useState('');
 
   // UX-3 (#285 hermano) 2026-05-27: cuando la inferencia visión está
   // corriendo (~6-30s), prevenir cierre accidental de la pestaña. El
@@ -171,11 +180,13 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
     const file = e.target.files?.[0];
     if (!file) return;
     if (!file.type.startsWith('image/')) {
+      setAiErrorMessage('El archivo seleccionado no es una imagen.');
       setAiState('error');
       return;
     }
     setAiState('running');
     setAiResult(null);
+    setAiErrorMessage('');
     try {
       // Pre-compresión cliente-lado (operador 2026-05-27): forzamos lado mayor
       // ≤1600 px y JPEG q=0.85 antes de mandar al sidecar / agente. Esto evita
@@ -205,6 +216,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
       }
       const result = await recognizeSpeciesGrounded(blob);
       if (!result) {
+        setAiErrorMessage(friendlyMessage('vision returned empty result'));
         setAiState('error');
         return;
       }
@@ -235,6 +247,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
       }
     } catch (err) {
       console.warn('[SpeciesSelect] AI recognition failed:', err);
+      setAiErrorMessage(friendlyMessage(err));
       setAiState('error');
     } finally {
       if (aiCameraRef.current) aiCameraRef.current.value = '';
@@ -259,6 +272,22 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
       setAiResult(null);
       setAiState('idle');
     }
+  };
+
+  // UX-6 (#286) 2026-05-27: cancela el flow de visión y enfoca el input
+  // principal del fuzzy search para que el operador escriba el nombre.
+  // Se usa desde los estados aiState='running' y aiState='done' (independiente
+  // de la confianza). KISS: reset aiResult/aiState + abrir dropdown + focus.
+  const handleForceTextSearch = () => {
+    setAiResult(null);
+    setAiState('idle');
+    setOpen(true);
+    // setTimeout 0 para que React renderice el <input> antes de pedir focus.
+    setTimeout(() => {
+      if (queryInputRef.current) {
+        try { queryInputRef.current.focus(); } catch (_e) { /* noop */ }
+      }
+    }, 0);
   };
 
   const handleAiReportBug = () => {
@@ -379,6 +408,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
         <Search size={16} className="text-slate-500 shrink-0" />
         {open ? (
           <input
+            ref={queryInputRef}
             autoFocus
             type="text"
             value={query}
@@ -530,7 +560,19 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
         )}
 
         {aiState === 'running' && (
-          <VisionLoadingState label="Analizando foto" />
+          <>
+            <VisionLoadingState label="Analizando foto" />
+            {/* UX-6 (#286): el modelo puede tardar — el operador siempre
+                puede saltarse el flow y escribir el nombre directo. */}
+            <button
+              type="button"
+              onClick={handleForceTextSearch}
+              data-testid="force-text-search-running"
+              className="mt-2 w-full text-[11px] px-2 py-1.5 rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
+            >
+              Mejor escribo el nombre
+            </button>
+          </>
         )}
 
         {/* UX-7 (#287) 2026-05-27: fallback texto cuando la confianza es
@@ -567,6 +609,14 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                 className="flex-1 text-[11px] px-2 py-1.5 rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
               >
                 Tomar otra foto
+              </button>
+              <button
+                type="button"
+                onClick={handleForceTextSearch}
+                data-testid="force-text-search-low-confidence"
+                className="flex-1 text-[11px] px-2 py-1.5 rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
+              >
+                Mejor escribo el nombre
               </button>
               <button
                 type="button"
@@ -725,6 +775,14 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
               </button>
               <button
                 type="button"
+                onClick={handleForceTextSearch}
+                data-testid="force-text-search-done"
+                className="flex-1 text-[11px] px-2 py-1.5 rounded bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
+              >
+                Mejor escribo el nombre
+              </button>
+              <button
+                type="button"
                 onClick={handleAiReportBug}
                 className="text-[11px] px-2 py-1.5 rounded bg-red-900/20 hover:bg-red-800/30 text-red-300 border border-red-800/40 flex items-center gap-1"
                 title="Registrar diagnóstico defectuoso"
@@ -738,14 +796,29 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
         {aiState === 'error' && (
           <div className="p-2.5 rounded-lg bg-red-900/20 border border-red-800/50 text-xs text-red-300">
             <p className="font-bold mb-0.5">No se pudo identificar</p>
-            <p className="text-[11px] text-red-400/80">El modelo Ollama puede no estar disponible o la imagen no pudo procesarse.</p>
-            <button
-              type="button"
-              onClick={() => setAiState('idle')}
-              className="mt-1.5 text-[11px] underline text-red-300"
-            >
-              Reintentar
-            </button>
+            {/* UX-12 (#286): copy friendly mapeado por friendlyErrors.js.
+                Si no hubo mensaje calculado (caso fallback), usamos un
+                texto neutro. */}
+            <p className="text-[11px] text-red-400/80">
+              {aiErrorMessage || 'Algo no funcionó. Intenta de nuevo.'}
+            </p>
+            <div className="mt-1.5 flex gap-3">
+              <button
+                type="button"
+                onClick={() => { setAiState('idle'); setAiErrorMessage(''); }}
+                className="text-[11px] underline text-red-300"
+              >
+                Reintentar
+              </button>
+              <button
+                type="button"
+                onClick={handleForceTextSearch}
+                data-testid="force-text-search-error"
+                className="text-[11px] underline text-red-300"
+              >
+                Mejor escribo el nombre
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -3,6 +3,7 @@ import { CircleUser, Mic, Plus, ChevronDown, ChevronUp, Home, HelpCircle, LogOut
 import { version as APP_VERSION } from '../../package.json';
 import EnvironmentalCard from './EnvironmentalCard';
 import AltitudeBadge from './AltitudeBadge';
+import OfflineChip from './OfflineChip';
 
 /**
  * TopBar, header persistente con identidad del operador (DR-030 QW2).
@@ -103,6 +104,12 @@ export default function TopBar({ onNavigate, onLogout }) {
           <CircleUser size={20} aria-hidden="true" className="shrink-0 text-teal-400" />
           <span className="text-sm font-semibold truncate max-w-[5rem] sm:max-w-[8rem]">{operatorName}</span>
         </button>
+
+        {/* UX-2 (#286) 2026-05-27: indicador ambient persistente del estado
+            offline. Vive justo al lado del nombre del operador para que sea
+            descubrible sin invadir el header. Solo se renderiza cuando
+            navigator.onLine === false (auto-hide al recuperar conexión). */}
+        <OfflineChip />
 
         <AltitudeBadge />
 

--- a/src/components/__tests__/OfflineChip.smoke.test.jsx
+++ b/src/components/__tests__/OfflineChip.smoke.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import OfflineChip from '../OfflineChip';
+
+/**
+ * Smoke tests para OfflineChip (UX-2 / #286).
+ *
+ * El componente debe:
+ *   1. NO renderizar nada cuando navigator.onLine === true.
+ *   2. Renderizar el chip "Sin conexión" cuando navigator.onLine === false.
+ *   3. Reaccionar al evento 'offline' del window mostrándose dinámicamente.
+ *   4. Reaccionar al evento 'online' del window ocultándose dinámicamente.
+ */
+
+// Helper para forzar navigator.onLine sin tocar el global descriptor real.
+const setOnline = (value) => {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+};
+
+describe('OfflineChip', () => {
+  beforeEach(() => {
+    setOnline(true);
+  });
+  afterEach(() => {
+    setOnline(true);
+  });
+
+  it('no renderiza nada cuando hay conexión', () => {
+    setOnline(true);
+    const { container } = render(<OfflineChip />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('offline-chip')).toBeNull();
+  });
+
+  it('renderiza el chip "Sin conexión" cuando está offline', () => {
+    setOnline(false);
+    render(<OfflineChip />);
+    const chip = screen.getByTestId('offline-chip');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute('role', 'status');
+    expect(chip).toHaveTextContent(/sin conexión/i);
+  });
+
+  it('aparece cuando se dispara el evento offline', () => {
+    setOnline(true);
+    render(<OfflineChip />);
+    expect(screen.queryByTestId('offline-chip')).toBeNull();
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(screen.getByTestId('offline-chip')).toBeInTheDocument();
+  });
+
+  it('desaparece cuando se dispara el evento online', () => {
+    setOnline(false);
+    render(<OfflineChip />);
+    expect(screen.getByTestId('offline-chip')).toBeInTheDocument();
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+    expect(screen.queryByTestId('offline-chip')).toBeNull();
+  });
+});

--- a/src/services/syncManager.js
+++ b/src/services/syncManager.js
@@ -5,6 +5,7 @@ import { newId } from '../utils/id';
 import { getCompletedTaskIds } from '../utils/taskCompletionParser';
 import { recordEvent } from './voiceTelemetryService';
 import { tryGeneratePlanFromSeeding } from './planGeneratorService';
+import { friendlyMessage } from '../utils/friendlyErrors';
 
 const STORE_NAME = 'pending_transactions';
 const TASKS_STORE_NAME = 'pending_tasks';
@@ -330,9 +331,15 @@ class SyncManager {
             await this.deleteTransaction(transaction.id);
             failed++;
             const name = transaction.payload?.data?.attributes?.name || transaction.type;
+            // UX-12 (#286) 2026-05-27: mensaje friendly contextualizado en
+            // lugar de exponer "HTTP 422" al operador. La info técnica queda
+            // en `errorClass` + `status` por si la UI quiere mostrar detalle.
+            const friendly = friendlyMessage(error);
             window.dispatchEvent(new CustomEvent('syncError', {
               detail: {
-                message: `Transacción "${name}" bloqueada (HTTP ${error.status}). Revisa en "Sincronización" para reintentar.`,
+                message: `"${name}": ${friendly} Revisa en "Sincronización" para reintentar.`,
+                friendlyMessage: friendly,
+                rawMessage: `Transacción "${name}" bloqueada (HTTP ${error.status}). Revisa en "Sincronización" para reintentar.`,
                 status: error.status,
                 errorClass,
                 quarantined: true,
@@ -347,9 +354,12 @@ class SyncManager {
               await this.deleteTransaction(transaction.id);
               failed++;
               const name = transaction.payload?.data?.attributes?.name || transaction.type;
+              const friendly = friendlyMessage(error);
               window.dispatchEvent(new CustomEvent('syncError', {
                 detail: {
-                  message: `Fallo permanente al sincronizar "${name}". Bloqueada en "Sincronización".`,
+                  message: `"${name}": ${friendly} Quedó bloqueada en "Sincronización".`,
+                  friendlyMessage: friendly,
+                  rawMessage: `Fallo permanente al sincronizar "${name}". Bloqueada en "Sincronización".`,
                   status: error.status || 0,
                   errorClass: 'max_retries',
                   quarantined: true,

--- a/src/utils/__tests__/friendlyErrors.test.js
+++ b/src/utils/__tests__/friendlyErrors.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  friendlyMessage,
+  FRIENDLY_MESSAGES,
+  FRIENDLY_FALLBACK,
+} from '../friendlyErrors';
+
+/**
+ * Tests para friendlyMessage (UX-12 / #286).
+ *
+ * Cubre los 6 cases mencionados en la spec más fallback genérico.
+ */
+
+describe('friendlyMessage', () => {
+  describe('network errors', () => {
+    it('mapea "fetch failed" a NETWORK', () => {
+      expect(friendlyMessage(new Error('TypeError: fetch failed'))).toBe(FRIENDLY_MESSAGES.NETWORK);
+    });
+    it('mapea "Failed to fetch" (Chrome / Firefox) a NETWORK', () => {
+      expect(friendlyMessage(new Error('Failed to fetch'))).toBe(FRIENDLY_MESSAGES.NETWORK);
+    });
+    it('mapea "NetworkError" (Firefox) a NETWORK', () => {
+      expect(friendlyMessage(new Error('NetworkError when attempting to fetch'))).toBe(FRIENDLY_MESSAGES.NETWORK);
+    });
+    it('mapea timeout a NETWORK', () => {
+      expect(friendlyMessage(new Error('Request timed out'))).toBe(FRIENDLY_MESSAGES.NETWORK);
+    });
+    it('mapea AbortError a NETWORK', () => {
+      expect(friendlyMessage(new Error('The operation was aborted'))).toBe(FRIENDLY_MESSAGES.NETWORK);
+    });
+  });
+
+  describe('HTTP 401 / token expired', () => {
+    it('mapea status 401 a AUTH_EXPIRED', () => {
+      expect(friendlyMessage(401)).toBe(FRIENDLY_MESSAGES.AUTH_EXPIRED);
+    });
+    it('mapea status 403 a AUTH_EXPIRED', () => {
+      expect(friendlyMessage(403)).toBe(FRIENDLY_MESSAGES.AUTH_EXPIRED);
+    });
+    it('mapea Error con .status=401 a AUTH_EXPIRED', () => {
+      const err = new Error('Unauthorized');
+      err.status = 401;
+      expect(friendlyMessage(err)).toBe(FRIENDLY_MESSAGES.AUTH_EXPIRED);
+    });
+    it('mapea "token expired" en el mensaje a AUTH_EXPIRED', () => {
+      expect(friendlyMessage(new Error('OAuth token expired'))).toBe(FRIENDLY_MESSAGES.AUTH_EXPIRED);
+    });
+  });
+
+  describe('HTTP 422 validation', () => {
+    it('mapea status 422 a VALIDATION', () => {
+      expect(friendlyMessage(422)).toBe(FRIENDLY_MESSAGES.VALIDATION);
+    });
+    it('mapea Error con .status=422 a VALIDATION', () => {
+      const err = new Error('Unprocessable Entity');
+      err.status = 422;
+      expect(friendlyMessage(err)).toBe(FRIENDLY_MESSAGES.VALIDATION);
+    });
+    it('mapea "validation" en el mensaje a VALIDATION', () => {
+      expect(friendlyMessage(new Error('Validation failed for field name'))).toBe(FRIENDLY_MESSAGES.VALIDATION);
+    });
+  });
+
+  describe('HTTP 5xx server', () => {
+    it('mapea status 500 a SERVER', () => {
+      expect(friendlyMessage(500)).toBe(FRIENDLY_MESSAGES.SERVER);
+    });
+    it('mapea status 502 a SERVER', () => {
+      expect(friendlyMessage(502)).toBe(FRIENDLY_MESSAGES.SERVER);
+    });
+    it('mapea status 503 a SERVER', () => {
+      expect(friendlyMessage(503)).toBe(FRIENDLY_MESSAGES.SERVER);
+    });
+    it('mapea Error con .status=500 a SERVER', () => {
+      const err = new Error('Internal Server Error');
+      err.status = 500;
+      expect(friendlyMessage(err)).toBe(FRIENDLY_MESSAGES.SERVER);
+    });
+  });
+
+  describe('Ollama down', () => {
+    it('mapea "ollama" en el mensaje a OLLAMA_DOWN', () => {
+      expect(friendlyMessage(new Error('ollama: connect ECONNREFUSED 127.0.0.1:11434'))).toBe(FRIENDLY_MESSAGES.OLLAMA_DOWN);
+    });
+    it('mapea "ECONNREFUSED" a OLLAMA_DOWN', () => {
+      expect(friendlyMessage(new Error('ECONNREFUSED'))).toBe(FRIENDLY_MESSAGES.OLLAMA_DOWN);
+    });
+    it('mapea "llama runner" crash a OLLAMA_DOWN', () => {
+      expect(friendlyMessage(new Error('llama runner exited unexpectedly'))).toBe(FRIENDLY_MESSAGES.OLLAMA_DOWN);
+    });
+  });
+
+  describe('Vision OOM', () => {
+    it('mapea "out of memory" a VISION_OOM', () => {
+      expect(friendlyMessage(new Error('CUDA out of memory'))).toBe(FRIENDLY_MESSAGES.VISION_OOM);
+    });
+    it('mapea status 413 (Payload Too Large) a VISION_OOM', () => {
+      expect(friendlyMessage(413)).toBe(FRIENDLY_MESSAGES.VISION_OOM);
+    });
+    it('mapea "imagen muy grande" a VISION_OOM', () => {
+      expect(friendlyMessage(new Error('imagen muy grande para el modelo'))).toBe(FRIENDLY_MESSAGES.VISION_OOM);
+    });
+  });
+
+  describe('fallback genérico', () => {
+    it('retorna FALLBACK para null', () => {
+      expect(friendlyMessage(null)).toBe(FRIENDLY_FALLBACK);
+    });
+    it('retorna FALLBACK para undefined', () => {
+      expect(friendlyMessage(undefined)).toBe(FRIENDLY_FALLBACK);
+    });
+    it('retorna FALLBACK para un error desconocido', () => {
+      expect(friendlyMessage(new Error('something weird happened'))).toBe(FRIENDLY_FALLBACK);
+    });
+    it('retorna FALLBACK para string vacío', () => {
+      expect(friendlyMessage('')).toBe(FRIENDLY_FALLBACK);
+    });
+  });
+
+  describe('orden y precedencia', () => {
+    it('un 401 con mensaje "fetch failed" matchea AUTH antes que NETWORK', () => {
+      const err = new Error('fetch failed: Unauthorized');
+      err.status = 401;
+      expect(friendlyMessage(err)).toBe(FRIENDLY_MESSAGES.AUTH_EXPIRED);
+    });
+    it('un mensaje con "ollama" + "fetch failed" matchea OLLAMA antes que NETWORK', () => {
+      expect(friendlyMessage(new Error('fetch failed: ollama refused connection'))).toBe(FRIENDLY_MESSAGES.OLLAMA_DOWN);
+    });
+    it('reconoce "HTTP 422" parseado desde el mensaje', () => {
+      expect(friendlyMessage(new Error('FarmOS API Error HTTP 422: Unprocessable'))).toBe(FRIENDLY_MESSAGES.VALIDATION);
+    });
+  });
+
+  describe('Colombia / no voseo', () => {
+    it('los mensajes usan "vuelve" / "intenta" — NO "volvé"/"intentá"', () => {
+      const allMessages = Object.values(FRIENDLY_MESSAGES).concat([FRIENDLY_FALLBACK]);
+      for (const msg of allMessages) {
+        expect(msg).not.toMatch(/intentá|volvé|tenés|querés|elegí|avisame|fijate|cerrá|tomá/i);
+      }
+    });
+    it('los mensajes usan "tú/usted" implícito — no "vos"', () => {
+      const allMessages = Object.values(FRIENDLY_MESSAGES).concat([FRIENDLY_FALLBACK]);
+      for (const msg of allMessages) {
+        // \bvos\b atrapa la palabra exacta; "volverá" o "vuelve" no matchean.
+        expect(msg).not.toMatch(/\bvos\b/i);
+      }
+    });
+  });
+});

--- a/src/utils/friendlyErrors.js
+++ b/src/utils/friendlyErrors.js
@@ -1,0 +1,175 @@
+/**
+ * friendlyErrors.js — mapea errores técnicos crudos a copy claro para el
+ * operador agro (UX-12).
+ *
+ * Motivación: los catch blocks de aiService, syncManager, voiceService y
+ * fetch globales devuelven mensajes que reflejan la causa técnica
+ * ("NetworkError when attempting to fetch resource", "HTTP 422", "Ollama
+ * connection refused", etc.). El operador en finca no necesita ni quiere
+ * leer esos detalles — necesita saber qué hacer ahora.
+ *
+ * Estrategia: una sola función `friendlyMessage(error)` que acepta:
+ *   - Un objeto Error (con `message` y opcional `status`/`code`)
+ *   - Un número (status HTTP)
+ *   - Un string (mensaje crudo, ej. de fetch network error)
+ *   - null/undefined → fallback genérico
+ *
+ * Mapeo (ordenado por especificidad — el primer match gana):
+ *   1. Vision OOM (modelo de visión rechazó imagen) → "La foto era muy
+ *      grande para procesar. Toma una más liviana."
+ *   2. Ollama down (connection refused, ECONNREFUSED, fetch failed contra
+ *      ollama/asistente) → "El asistente Chagra se está reiniciando.
+ *      Dame un momento."
+ *   3. Network timeout / fetch failed genérico → "No pude conectarme.
+ *      Revisa tu internet y vuelve a intentar."
+ *   4. HTTP 401 / token expired → "Tu sesión expiró. Vuelve a iniciar
+ *      sesión."
+ *   5. HTTP 422 validation → "Algo en los datos no funcionó. Avísame al
+ *      equipo si esto se repite."
+ *   6. HTTP 5xx server → "El servidor tuvo un problema. Volveré a
+ *      intentar en unos segundos."
+ *   7. Cualquier otro → "Algo no funcionó. Intenta de nuevo."
+ *
+ * Reglas Colombia (no voseo):
+ *   - "vuelve a intentar" / "intenta" — NO "intentá" / "volvé"
+ *   - "tu sesión" — NO "tu sesión vos"
+ *   - "te avisa" / "avísame" — NO "avisame al equipo"
+ *
+ * Uso:
+ *   import { friendlyMessage } from '../utils/friendlyErrors';
+ *   try { ... } catch (err) {
+ *     showToast(friendlyMessage(err), true);
+ *   }
+ */
+
+export const FRIENDLY_FALLBACK = 'Algo no funcionó. Intenta de nuevo.';
+
+export const FRIENDLY_MESSAGES = {
+  NETWORK: 'No pude conectarme. Revisa tu internet y vuelve a intentar.',
+  AUTH_EXPIRED: 'Tu sesión expiró. Vuelve a iniciar sesión.',
+  VALIDATION: 'Algo en los datos no funcionó. Avísame al equipo si esto se repite.',
+  SERVER: 'El servidor tuvo un problema. Volveré a intentar en unos segundos.',
+  OLLAMA_DOWN: 'El asistente Chagra se está reiniciando. Dame un momento.',
+  VISION_OOM: 'La foto era muy grande para procesar. Toma una más liviana.',
+};
+
+/**
+ * Extrae status HTTP de varias formas comunes:
+ *   - Error con propiedad `.status` (apiService.js custom)
+ *   - Error con propiedad `.code` numérico
+ *   - Mensaje string con "HTTP 422" o "status 401"
+ */
+function extractStatus(input) {
+  if (typeof input === 'number') return input;
+  if (input && typeof input === 'object') {
+    if (typeof input.status === 'number') return input.status;
+    if (typeof input.code === 'number') return input.code;
+    if (typeof input.statusCode === 'number') return input.statusCode;
+  }
+  const msg = typeof input === 'string'
+    ? input
+    : (input && typeof input.message === 'string' ? input.message : '');
+  // Busca patterns como "HTTP 422", "status 401", "Error 502: Bad Gateway"
+  const match = msg.match(/\b(?:HTTP|status|Error)\s*[:= ]?\s*(\d{3})\b/i);
+  if (match) return parseInt(match[1], 10);
+  return null;
+}
+
+function extractMessage(input) {
+  if (typeof input === 'string') return input;
+  if (input && typeof input === 'object' && typeof input.message === 'string') {
+    return input.message;
+  }
+  return '';
+}
+
+/**
+ * Mapea un error/status crudo a copy user-friendly.
+ *
+ * @param {Error|number|string|null|undefined} input
+ * @returns {string} mensaje user-friendly listo para toast/banner.
+ */
+export function friendlyMessage(input) {
+  if (input === null || input === undefined) return FRIENDLY_FALLBACK;
+
+  const msg = extractMessage(input).toLowerCase();
+  const status = extractStatus(input);
+
+  // 1. Vision OOM — modelo rechazó imagen por tamaño / memoria
+  if (
+    msg.includes('out of memory') ||
+    msg.includes('oom') ||
+    msg.includes('cuda error') ||
+    msg.includes('image too large') ||
+    msg.includes('imagen muy grande') ||
+    msg.includes('imagen demasiado') ||
+    msg.includes('payload too large') ||
+    status === 413
+  ) {
+    return FRIENDLY_MESSAGES.VISION_OOM;
+  }
+
+  // 2. Ollama down — patrones específicos del asistente
+  if (
+    msg.includes('ollama') ||
+    msg.includes('econnrefused') ||
+    msg.includes('connection refused') ||
+    msg.includes('asistente') ||
+    msg.includes('model not found') ||
+    msg.includes('llama runner')
+  ) {
+    return FRIENDLY_MESSAGES.OLLAMA_DOWN;
+  }
+
+  // 4. HTTP 401 / token expired — antes del check de network genérico
+  if (
+    status === 401 ||
+    status === 403 ||
+    msg.includes('token expired') ||
+    msg.includes('token expirado') ||
+    msg.includes('unauthorized') ||
+    msg.includes('forbidden') ||
+    msg.includes('sesión expir') ||
+    msg.includes('sesion expir')
+  ) {
+    return FRIENDLY_MESSAGES.AUTH_EXPIRED;
+  }
+
+  // 5. HTTP 422 validation
+  if (
+    status === 422 ||
+    status === 400 ||
+    msg.includes('validation') ||
+    msg.includes('validación') ||
+    msg.includes('unprocessable')
+  ) {
+    return FRIENDLY_MESSAGES.VALIDATION;
+  }
+
+  // 6. HTTP 5xx server
+  if (typeof status === 'number' && status >= 500 && status <= 599) {
+    return FRIENDLY_MESSAGES.SERVER;
+  }
+
+  // 3. Network timeout / fetch failed (general — chequear después de auth
+  //    para que un 401 con texto "failed" caiga en AUTH primero)
+  if (
+    msg.includes('fetch failed') ||
+    msg.includes('failed to fetch') ||
+    msg.includes('networkerror') ||
+    msg.includes('network error') ||
+    msg.includes('network request failed') ||
+    msg.includes('timeout') ||
+    msg.includes('timed out') ||
+    msg.includes('aborted') ||
+    msg.includes('offline') ||
+    msg.includes('sin conexión') ||
+    msg.includes('sin conexion')
+  ) {
+    return FRIENDLY_MESSAGES.NETWORK;
+  }
+
+  return FRIENDLY_FALLBACK;
+}
+
+export default friendlyMessage;


### PR DESCRIPTION
## Summary

UX pack batch resolviendo 3 items en un solo PR:

- **UX-2 — Indicador offline persistente**: nuevo componente `OfflineChip` en `src/components/OfflineChip.jsx`, wired al `TopBar` justo al lado del nombre del operador. Aparece solo cuando `navigator.onLine === false`, desaparece al recuperar conexión. NO es banner intermitente ni cerrable manualmente — es un ambient indicator. Complementa `NetworkStatusBar` (que es la barra full-width con detalle) sin reemplazarlo.

- **UX-6 — Forzar búsqueda por texto**: en `SpeciesSelect.jsx`, nuevo botón \"Mejor escribo el nombre\" en los estados `aiState === 'running'`, `'done'` (alto y bajo confidence) y `'error'`. Acción: `setAiResult(null)` + `setAiState('idle')` + abre el dropdown + foco al input principal vía nueva `queryInputRef`.

- **UX-12 — Mensajes friendly por contexto**: nuevo util `src/utils/friendlyErrors.js` con `friendlyMessage(error)` que mapea Error/status/string crudo a copy claro según 6 cases (NETWORK, AUTH_EXPIRED, VALIDATION, SERVER, OLLAMA_DOWN, VISION_OOM) + fallback genérico. Wire en:
  - `syncManager.js`: ambos `dispatchEvent('syncError')` (quarantine y max-retries) ahora exponen `friendlyMessage` además del `rawMessage` técnico; el `message` mostrado al operador usa el friendly.
  - `SpeciesSelect.jsx`: el bloque `aiState === 'error'` ahora muestra el mapeo friendly (Ollama down / network / OOM) en lugar del texto fijo \"El modelo Ollama puede no estar disponible\".

## Tests

- 4 tests `OfflineChip.smoke.test.jsx` (renders offline, hidden online, reacciona a eventos online/offline).
- 31 tests `friendlyErrors.test.js` cubriendo los 6 cases + precedencia + fallback + chequeo de no-voseo.
- Existentes `SpeciesSelect.smoke.test.jsx` (7) y `syncManager.test.js` (10) siguen verdes.
- ESLint clean `--max-warnings=0` sobre los 7 archivos tocados.
- `node scripts/auto-bump-version.mjs` ejecutado: `0.13.14 → 0.13.15` + `chagra-v246 → chagra-v247`.

## Test plan

- [ ] CI verde (lint, vitest, Playwright E2E offline-first, CodeQL).
- [ ] Smoke manual en stg post-merge: airplane mode toggle muestra/oculta el chip del header sin afectar `NetworkStatusBar`.
- [ ] Smoke manual SpeciesSelect: tomar foto → tocar \"Mejor escribo el nombre\" → input fuzzy queda enfocado con el query vacío.
- [ ] Smoke manual sync error: forzar 422 desde stg (ej. payload con campo inválido) y verificar que el toast dice \"Algo en los datos no funcionó. Avísame al equipo si esto se repite.\" en lugar de \"HTTP 422\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)