### PR TITLE
feat(ux): UX-13 — tipos de zona urbana (balcón/terraza/ventana/matera)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.15",
+  "version": "0.13.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v247';
+const CACHE_NAME = 'chagra-v248';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -18,6 +18,7 @@ import { usePhotoUrl } from '../hooks/usePhotoUrl';
 import { findBiopreparadosByIngredient } from '../db/catalogDB';
 import { generatePlanForPlant } from '../services/planGeneratorService';
 import { enrichEntity } from '../services/voiceRagEnricher';
+import { LAND_TYPES, isUrbanLandType } from '../utils/landTypes';
 import { getAccessToken } from '../services/authService';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
 import { savePhoto } from '../services/photoService';
@@ -109,13 +110,10 @@ const ASSET_TABS = [
   { id: 'material', label: 'Insumos', icon: Leaf, color: 'sky', desc: 'Stock de biopreparados, semillas, fertilizantes' },
 ];
 
-const LAND_TYPES = [
-  { value: 'field', label: 'Lote / Campo abierto' },
-  { value: 'bed', label: 'Cama / Huerta' },
-  { value: 'greenhouse', label: 'Invernadero' },
-  { value: 'paddock', label: 'Pastizal' },
-  { value: 'building', label: 'Edificación' },
-];
+// UX-13 (#286) 2026-05-27: LAND_TYPES + helpers urban-aware extraídos a
+// src/utils/landTypes.js para cumplir react-refresh/only-export-components
+// y permitir reuso desde otros componentes (UX-15/UX-16) sin acoplarse al
+// dashboard. La data sigue siendo single-source-of-truth allí.
 
 const DEFAULT_LOCATION_ID = FARM_CONFIG.LOCATION_ID;
 
@@ -775,6 +773,17 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
 
   const getPlaceholder = () => {
     if (activeTab === 'plant') return 'Ej: Café, Aguacate, Guanábana...';
+    // UX-13 (#286): placeholder contextual según tipo de zona.
+    if (activeTab === 'land' && isUrbanLandType(formData.landType)) {
+      const urbanExamples = {
+        balcony: 'Ej: Balcón cocina, Balcón principal...',
+        terrace: 'Ej: Terraza norte, Terraza azotea...',
+        window_sill: 'Ej: Ventana cocina, Ventana sala...',
+        indoor_pot: 'Ej: Matera sala, Matera comedor...',
+        urban_garden: 'Ej: Huerta patio, Huerta vecinos...',
+      };
+      return urbanExamples[formData.landType] || 'Ej: Mi zona urbana...';
+    }
     if (activeTab === 'structure') return 'Ej: ' + STRUCTURE_EXAMPLES[Math.floor(Math.random() * STRUCTURE_EXAMPLES.length)];
     if (activeTab === 'equipment') return 'Ej: ' + EQUIPMENT_EXAMPLES[Math.floor(Math.random() * EQUIPMENT_EXAMPLES.length)];
     return 'Ej: Bokashi, Biol, Purín de Ortiga...';
@@ -1227,8 +1236,17 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
         className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white text-sm min-h-[56px]"
       />
 
-      {/* Geometría obligatoria para land y structure (polygon); point para equipment */}
-      {activeTab === 'land' && renderGeometryField('polygon')}
+      {/* Geometría obligatoria para land y structure (polygon); point para equipment.
+          UX-13 (#286): para land URBANO (balcón/terraza/ventana/matera/jardín
+          urbano) no mostramos el picker de polígono — un balcón no tiene
+          contorno cartográfico útil. El operador puede igual agregar GPS
+          después editando el asset si quiere. */}
+      {activeTab === 'land' && !isUrbanLandType(formData.landType) && renderGeometryField('polygon')}
+      {activeTab === 'land' && isUrbanLandType(formData.landType) && (
+        <p className="text-xs text-slate-500 italic px-1">
+          Zona urbana: no necesitas marcar un área en el mapa.
+        </p>
+      )}
       {activeTab === 'structure' && renderGeometryField('polygon')}
       {activeTab === 'equipment' && renderGeometryField('point')}
     </>

--- a/src/components/OnboardingPiloto.jsx
+++ b/src/components/OnboardingPiloto.jsx
@@ -32,6 +32,11 @@ const VOCACIONES = [
   { value: 'invernadero', label: 'Invernadero hortícola' },
   { value: 'bosque',      label: 'Bosque / restauración / agroforestal' },
   { value: 'paramo',      label: 'Páramo / alto andino / conservación' },
+  // UX-13 (#286) 2026-05-27: vocación urbana / apartamento — cubre el caso
+  // de usuarios que cultivan en balcón, terraza, ventana o matera interior
+  // sin acceso a terreno rural. Defaults downstream: zonas urbanas sin GPS
+  // ni polígono, estrato condicional, sin gremios agroforestales.
+  { value: 'urbana',      label: 'Urbana / apartamento (balcón, terraza, matera)' },
   { value: 'mixto',       label: 'Mixto (más de una vocación)' },
   { value: 'otro',        label: 'Otro (especifica en notas)' },
 ];

--- a/src/utils/__tests__/landTypes.test.js
+++ b/src/utils/__tests__/landTypes.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { URBAN_LAND_TYPES, isUrbanLandType, LAND_TYPES } from '../landTypes';
+
+/**
+ * Tests para UX-13 (#286): land types urbanos (balcón/terraza/ventana/
+ * matera/jardín urbano) y helper isUrbanLandType.
+ *
+ * Verifica:
+ *   - El set URBAN_LAND_TYPES contiene exactamente los 5 tipos urbanos.
+ *   - isUrbanLandType acepta strings urbanos y rechaza rurales.
+ *   - isUrbanLandType es robusto a null/undefined/empty.
+ */
+
+describe('UX-13 — urban land types', () => {
+  it('URBAN_LAND_TYPES contiene exactamente los 5 tipos urbanos definidos', () => {
+    const expected = ['balcony', 'terrace', 'window_sill', 'indoor_pot', 'urban_garden'];
+    expect(URBAN_LAND_TYPES.size).toBe(expected.length);
+    for (const t of expected) {
+      expect(URBAN_LAND_TYPES.has(t)).toBe(true);
+    }
+  });
+
+  it('LAND_TYPES sigue exponiendo los 5 rurales legacy + 5 urbanos = 10 total', () => {
+    expect(LAND_TYPES).toHaveLength(10);
+    const rural = LAND_TYPES.filter((lt) => !lt.urban).map((lt) => lt.value);
+    expect(rural).toEqual(['field', 'bed', 'greenhouse', 'paddock', 'building']);
+  });
+
+  describe('isUrbanLandType', () => {
+    it('retorna true para balcony', () => {
+      expect(isUrbanLandType('balcony')).toBe(true);
+    });
+    it('retorna true para terrace', () => {
+      expect(isUrbanLandType('terrace')).toBe(true);
+    });
+    it('retorna true para window_sill', () => {
+      expect(isUrbanLandType('window_sill')).toBe(true);
+    });
+    it('retorna true para indoor_pot', () => {
+      expect(isUrbanLandType('indoor_pot')).toBe(true);
+    });
+    it('retorna true para urban_garden', () => {
+      expect(isUrbanLandType('urban_garden')).toBe(true);
+    });
+    it('retorna false para field (rural)', () => {
+      expect(isUrbanLandType('field')).toBe(false);
+    });
+    it('retorna false para greenhouse', () => {
+      expect(isUrbanLandType('greenhouse')).toBe(false);
+    });
+    it('retorna false para paddock', () => {
+      expect(isUrbanLandType('paddock')).toBe(false);
+    });
+    it('retorna false para bed', () => {
+      expect(isUrbanLandType('bed')).toBe(false);
+    });
+    it('retorna false para building', () => {
+      expect(isUrbanLandType('building')).toBe(false);
+    });
+    it('retorna false para null / undefined / "" / number', () => {
+      expect(isUrbanLandType(null)).toBe(false);
+      expect(isUrbanLandType(undefined)).toBe(false);
+      expect(isUrbanLandType('')).toBe(false);
+      expect(isUrbanLandType(42)).toBe(false);
+    });
+  });
+});

--- a/src/utils/landTypes.js
+++ b/src/utils/landTypes.js
@@ -1,0 +1,36 @@
+/**
+ * landTypes.js — fuente de verdad de tipos de zona (LAND_TYPES) + helpers.
+ *
+ * UX-13 (#286) 2026-05-27: extraído de AssetsDashboard.jsx para cumplir
+ * con la regla react-refresh/only-export-components (un archivo .jsx no
+ * puede exportar constantes junto con componentes). Mover a un util
+ * independiente nos da:
+ *   - Tests unitarios livianos sin cargar todo AssetsDashboard.
+ *   - Reuso desde otros componentes (form siembra, estrato condicional,
+ *     UX-15/UX-16) sin acoplarse al dashboard.
+ *
+ * URBAN_LAND_TYPES es el subset usado downstream para:
+ *   - Ocultar/relajar campos sin sentido en apartamento (estrato dosel).
+ *   - Saltar prompts de polígono GPS (un balcón no tiene contorno útil).
+ *   - Adaptar placeholders y copy contextual.
+ */
+
+export const LAND_TYPES = [
+  { value: 'field', label: 'Lote / Campo abierto' },
+  { value: 'bed', label: 'Cama / Huerta' },
+  { value: 'greenhouse', label: 'Invernadero' },
+  { value: 'paddock', label: 'Pastizal' },
+  { value: 'building', label: 'Edificación' },
+  // Urbano — apartamento / casa con cultivo doméstico
+  { value: 'balcony', label: 'Balcón', urban: true },
+  { value: 'terrace', label: 'Terraza', urban: true },
+  { value: 'window_sill', label: 'Ventana', urban: true },
+  { value: 'indoor_pot', label: 'Matera interior', urban: true },
+  { value: 'urban_garden', label: 'Jardín / huerta urbana', urban: true },
+];
+
+export const URBAN_LAND_TYPES = new Set(
+  LAND_TYPES.filter((lt) => lt.urban).map((lt) => lt.value)
+);
+
+export const isUrbanLandType = (landType) => URBAN_LAND_TYPES.has(landType);


### PR DESCRIPTION
## Summary

- Agrega 5 tipos de zona urbana (balcón, terraza, ventana, matera interior, jardín urbano) a `LAND_TYPES` para que usuarios de apartamento puedan crear propiedades sin elegir tipos rurales que no aplican.
- Nueva vocación \"Urbana / apartamento\" en el onboarding de pilotos.
- Cuando se elige una zona urbana, el form **NO pide GPS / polígono** (cero geo para urbano — decisión operador 2026-05-27) y muestra placeholders contextuales (\"Ej: Balcón cocina, Balcón principal...\").

## Architecture

- `LAND_TYPES` + helpers movidos a `src/utils/landTypes.js` (regla `react-refresh/only-export-components` impedía exportar constantes desde `AssetsDashboard.jsx`).
- `URBAN_LAND_TYPES` + `isUrbanLandType()` exportados para reuso por UX-15 (estrato condicional) y UX-16 (form siembra urbano).

## Tests

- 13 tests en `src/utils/__tests__/landTypes.test.js`.
- ESLint `--max-warnings=0` clean sobre los 4 archivos tocados.
- Auto-bump: `0.13.15 → 0.13.16`, `chagra-v247 → chagra-v248`.

## Test plan

- [ ] CI verde.
- [ ] Smoke manual: crear zona tipo \"Balcón\" desde AssetsDashboard → confirmar que NO pide polígono y que el placeholder del nombre sugiere \"Balcón cocina\".
- [ ] Smoke manual: onboarding piloto → elegir vocación \"Urbana / apartamento\" → guardar OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)