### PR TITLE
feat(ux): UX-14 — variedad dinámica desde catalogDB (oculta si no aplica)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.15",
+  "version": "0.13.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v247';
+const CACHE_NAME = 'chagra-v248';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -5,6 +5,8 @@ import { captureAndCompress, savePhoto } from '../services/photoService';
 import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { sanitizeBlobUrl } from '../utils/blobUrl';
 import DateField from './DateField';
+import { getAllSpecies } from '../db/catalogDB';
+import { extractVarieties, varietyHelpText } from '../utils/speciesVariety';
 
 // Bug 069.10 — validación client-side: límites razonables para evitar
 // payloads inválidos sincronizándose con FarmOS.
@@ -29,6 +31,46 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
   const [view, setView] = useState('form');
   const [touched, setTouched] = useState({});
   const watchIdRef = useRef(null);
+
+  // UX-14 (#286) 2026-05-27: variedad dinámica desde catalogDB.
+  // Cargamos el catálogo una sola vez al montar. Si el operador escribió
+  // un nombre que matchea una species del catálogo CON variedades ICA,
+  // mostramos dropdown; si no matchea o la especie no tiene variedades
+  // registradas, OCULTAMOS el campo (no pedimos algo sin contexto).
+  const [allSpecies, setAllSpecies] = useState([]);
+  useEffect(() => {
+    let cancelled = false;
+    getAllSpecies()
+      .then((rows) => { if (!cancelled && Array.isArray(rows)) setAllSpecies(rows); })
+      .catch(() => { /* graceful: si falla, varieties queda en [] y campo se oculta */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Resuelve la species del catálogo a partir del free-text `crop`.
+  // Match orden: nombre_comun exact (case-insensitive) → id exact →
+  // startsWith (para tolerar "Café arábico" vs "Café"). Si no hay match,
+  // retorna null (varieties = [] → campo oculto).
+  const matchedSpecies = useMemo(() => {
+    const q = (formData.crop || '').trim().toLowerCase();
+    if (!q || allSpecies.length === 0) return null;
+    return (
+      allSpecies.find((s) => (s.nombre_comun || '').toLowerCase() === q) ||
+      allSpecies.find((s) => (s.id || '').toLowerCase() === q) ||
+      allSpecies.find((s) => (s.nombre_comun || '').toLowerCase().startsWith(q) && q.length >= 3) ||
+      null
+    );
+  }, [formData.crop, allSpecies]);
+
+  const varieties = useMemo(() => extractVarieties(matchedSpecies), [matchedSpecies]);
+  const showVarietyField = varieties.length > 0;
+  const varietyHelp = useMemo(() => varietyHelpText(varieties), [varieties]);
+
+  // Si la variedad guardada NO está en la lista actual del catálogo, mostramos
+  // toggle "Otra (escribir)" para fallback texto libre. Estado del toggle
+  // persistente para el ciclo de vida del componente.
+  const [varietyCustom, setVarietyCustom] = useState(
+    !!(formData.variety && !varieties.find((v) => v.value === formData.variety))
+  );
 
   // Bug 069.10 — validación inline (no bloquea submit existente, pero deshabilita el botón
   // y muestra errores para que el operador corrija antes de guardar).
@@ -317,10 +359,61 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
           )}
         </label>
 
-        <label className="flex flex-col gap-2">
-          <span className="text-xl font-bold">Variedad</span>
-          <input type="text" name="variety" value={formData.variety} onChange={handleInput} className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]" />
-        </label>
+        {/* UX-14 (#286) 2026-05-27: variedad dinámica.
+            - Si la especie del catálogo trae variedades_registradas_ica → dropdown.
+            - Si no → campo OCULTO (no pedimos algo sin contexto).
+            - Toggle "Otra" para texto libre cuando la variedad del operador no
+              esté en la lista ICA. */}
+        {showVarietyField && (
+          <label className="flex flex-col gap-2" data-testid="variety-field">
+            <span className="text-xl font-bold">Variedad</span>
+            {!varietyCustom ? (
+              <select
+                name="variety"
+                value={formData.variety}
+                onChange={(e) => {
+                  if (e.target.value === '__custom__') {
+                    setVarietyCustom(true);
+                    setFormData((prev) => ({ ...prev, variety: '' }));
+                  } else {
+                    handleInput(e);
+                  }
+                }}
+                className="p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]"
+              >
+                <option value="">Seleccionar variedad…</option>
+                {varieties.map((v) => (
+                  <option key={v.value} value={v.value}>
+                    {v.label}{v.obtentor ? ` — ${v.obtentor}` : ''}
+                  </option>
+                ))}
+                <option value="__custom__">Otra (escribir nombre)</option>
+              </select>
+            ) : (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  name="variety"
+                  value={formData.variety}
+                  onChange={handleInput}
+                  placeholder="Nombre de la variedad"
+                  className="flex-1 p-4 rounded-xl bg-slate-900 border border-slate-700 text-2xl text-white min-h-[64px]"
+                />
+                <button
+                  type="button"
+                  onClick={() => { setVarietyCustom(false); setFormData((prev) => ({ ...prev, variety: '' })); }}
+                  className="px-3 rounded-xl bg-slate-800 hover:bg-slate-700 text-slate-300 text-sm font-bold min-h-[64px]"
+                  aria-label="Volver al listado del catálogo"
+                >
+                  Lista
+                </button>
+              </div>
+            )}
+            {varietyHelp && !varietyCustom && (
+              <p className="text-xs text-slate-500">{varietyHelp}</p>
+            )}
+          </label>
+        )}
 
         <label className="flex flex-col gap-2">
           <span className="text-xl font-bold">Notas</span>

--- a/src/utils/__tests__/speciesVariety.test.js
+++ b/src/utils/__tests__/speciesVariety.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractVarieties,
+  shouldShowVarietyField,
+  varietyHelpText,
+} from '../speciesVariety';
+
+/**
+ * Tests para UX-14 (#286): variedad dinámica desde catalogDB.
+ *
+ * Verifica:
+ *   - extractVarieties devuelve [] cuando species es null/undefined/sin campo.
+ *   - extractVarieties normaliza {value, label, obtentor} correctamente.
+ *   - shouldShowVarietyField retorna boolean correcto en cada case.
+ *   - varietyHelpText pluraliza correctamente.
+ */
+
+const speciesWithVarieties = {
+  id: 'arracacia_xanthorrhiza',
+  nombre_comun: 'Arracacha',
+  variedades_registradas_ica: [
+    {
+      id_canonico: 'agrosavia-la22-arracacha-2019',
+      nombre_comercial: 'AGROSAVIA La 22',
+      obtentor: { nombre: 'AGROSAVIA' },
+    },
+    {
+      id_canonico: 'agrosavia-criolla',
+      nombre_comercial: 'Criolla',
+      obtentor: { nombre: 'AGROSAVIA' },
+    },
+  ],
+};
+
+const speciesWithoutVarieties = {
+  id: 'fragaria_x_ananassa',
+  nombre_comun: 'Fresa',
+  // sin campo variedades_registradas_ica
+};
+
+const speciesWithEmptyArray = {
+  id: 'rosmarinus_officinalis',
+  nombre_comun: 'Romero',
+  variedades_registradas_ica: [],
+};
+
+describe('UX-14 — speciesVariety', () => {
+  describe('extractVarieties', () => {
+    it('retorna [] para null / undefined / no-object', () => {
+      expect(extractVarieties(null)).toEqual([]);
+      expect(extractVarieties(undefined)).toEqual([]);
+      expect(extractVarieties('not-an-object')).toEqual([]);
+      expect(extractVarieties(42)).toEqual([]);
+    });
+
+    it('retorna [] cuando species no trae campo variedades_registradas_ica', () => {
+      expect(extractVarieties(speciesWithoutVarieties)).toEqual([]);
+    });
+
+    it('retorna [] cuando variedades_registradas_ica es array vacío', () => {
+      expect(extractVarieties(speciesWithEmptyArray)).toEqual([]);
+    });
+
+    it('normaliza variedades al shape {value, label, obtentor}', () => {
+      const result = extractVarieties(speciesWithVarieties);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        value: 'AGROSAVIA La 22',
+        label: 'AGROSAVIA La 22',
+        obtentor: 'AGROSAVIA',
+      });
+      expect(result[1].value).toBe('Criolla');
+    });
+
+    it('descarta variedades sin nombre_comercial ni id_canonico', () => {
+      const species = {
+        variedades_registradas_ica: [
+          { nombre_comercial: 'OK' },
+          { obtentor: { nombre: 'Sin nombre' } },
+          null,
+          { nombre_comercial: '' },
+        ],
+      };
+      const result = extractVarieties(species);
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toBe('OK');
+    });
+
+    it('fallback a id_canonico cuando falta nombre_comercial', () => {
+      const species = {
+        variedades_registradas_ica: [
+          { id_canonico: 'agrosavia-x-2025', obtentor: { nombre: 'AGROSAVIA' } },
+        ],
+      };
+      const result = extractVarieties(species);
+      expect(result[0].label).toBe('agrosavia-x-2025');
+    });
+  });
+
+  describe('shouldShowVarietyField', () => {
+    it('retorna true cuando hay variedades', () => {
+      expect(shouldShowVarietyField(speciesWithVarieties)).toBe(true);
+    });
+    it('retorna false cuando NO hay campo', () => {
+      expect(shouldShowVarietyField(speciesWithoutVarieties)).toBe(false);
+    });
+    it('retorna false cuando array es vacío', () => {
+      expect(shouldShowVarietyField(speciesWithEmptyArray)).toBe(false);
+    });
+    it('retorna false para null', () => {
+      expect(shouldShowVarietyField(null)).toBe(false);
+    });
+  });
+
+  describe('varietyHelpText', () => {
+    it('pluraliza correctamente para 1 variedad', () => {
+      const text = varietyHelpText([{ value: 'X', label: 'X' }]);
+      expect(text).toContain('1 variedad ');
+      expect(text).toContain('registrada ');
+      expect(text).not.toContain('variedades');
+    });
+    it('pluraliza correctamente para 2+ variedades', () => {
+      const text = varietyHelpText([
+        { value: 'X', label: 'X' },
+        { value: 'Y', label: 'Y' },
+      ]);
+      expect(text).toContain('2 variedades');
+      expect(text).toContain('registradas');
+    });
+    it('retorna null para [] o no-array', () => {
+      expect(varietyHelpText([])).toBeNull();
+      expect(varietyHelpText(null)).toBeNull();
+      expect(varietyHelpText('not-array')).toBeNull();
+    });
+    it('menciona "Otra" para que el usuario sepa que puede escribir', () => {
+      const text = varietyHelpText([{ value: 'X', label: 'X' }]);
+      expect(text).toMatch(/otra/i);
+    });
+  });
+});

--- a/src/utils/speciesVariety.js
+++ b/src/utils/speciesVariety.js
@@ -1,0 +1,80 @@
+/**
+ * speciesVariety.js — helpers para resolver variedades registradas ICA por
+ * especie del catálogo (UX-14 / #286).
+ *
+ * Contexto: el catálogo Chagra (`chagra-catalog-seed-v3.1.json`) expone
+ * el campo `variedades_registradas_ica: [{ nombre_comercial, ... }]` para
+ * un subset de especies (papa, arracacha, etc.) donde ICA ha registrado
+ * cultivares oficiales. La mayoría de especies NO trae ese campo.
+ *
+ * Decisión UX-14:
+ *   - SI la especie tiene `variedades_registradas_ica.length > 0` →
+ *     mostrar dropdown con autocomplete + opción "otra".
+ *   - SI no trae el campo / array vacío → OCULTAR el campo "Variedad"
+ *     completo (no pedirle al usuario algo que ni el catálogo conoce).
+ *
+ * El campo "Variedad" actual en SeedingLog era un input ciego sin contexto
+ * que pedía variedad para CUALQUIER cosa (fresa, romero, papayuela) sin
+ * distinción — reportado por operador 2026-05-27.
+ *
+ * Acceso al catálogo: vía `getSpeciesByIdSync(id)` (catalogDB SQLite WASM
+ * ya pre-cargado en App.jsx). Si la DB no está lista, retornamos array
+ * vacío (graceful degradation) y el componente oculta el campo.
+ */
+
+/**
+ * Extrae las variedades formateadas para UI a partir de un objeto species
+ * del catálogo. Returns array de { value, label, obtentor } o [] si no hay.
+ *
+ * @param {object|null|undefined} species — objeto species del catálogo
+ * @returns {Array<{value: string, label: string, obtentor?: string}>}
+ */
+export function extractVarieties(species) {
+  if (!species || typeof species !== 'object') return [];
+  const list = species.variedades_registradas_ica;
+  if (!Array.isArray(list) || list.length === 0) return [];
+  return list
+    .map((v) => {
+      if (!v || typeof v !== 'object') return null;
+      const label = (v.nombre_comercial || v.id_canonico || '').trim();
+      if (!label) return null;
+      return {
+        value: label,
+        label,
+        obtentor: v.obtentor?.nombre || null,
+      };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Decide si el campo "Variedad" debe mostrarse en el form de siembra
+ * para una especie del catálogo dada.
+ *
+ * Reglas:
+ *   - species null/undefined o sin id → false (sin contexto, sin pedirlo).
+ *   - species tiene >=1 variedad ICA → true.
+ *   - species sin el campo / array vacío → false.
+ *
+ * NOTA: cuando el operador escribe el cultivo en free-text (sin elegir
+ * del catálogo), species será null y devolvemos false. El form puede
+ * mostrar un input "opcional" en ese case si el equipo decide.
+ *
+ * @param {object|null|undefined} species
+ * @returns {boolean}
+ */
+export function shouldShowVarietyField(species) {
+  return extractVarieties(species).length > 0;
+}
+
+/**
+ * Mensaje informativo opcional para mostrar arriba del dropdown.
+ * Devuelve string o null si no aplica.
+ *
+ * @param {Array} varieties
+ * @returns {string|null}
+ */
+export function varietyHelpText(varieties) {
+  if (!Array.isArray(varieties) || varieties.length === 0) return null;
+  return `${varieties.length} variedad${varieties.length === 1 ? '' : 'es'} registrada${varieties.length === 1 ? '' : 's'} por ICA. Si la tuya no aparece, elige "Otra" y escríbela.`;
+}


### PR DESCRIPTION
## Summary

El campo \"Variedad\" en `SeedingLog` era un input ciego sin contexto que pedía variedad para CUALQUIER cosa (fresa, romero, papayuela) sin distinción. Reportado por operador 2026-05-27.

Solución:
- Nuevo util `src/utils/speciesVariety.js` que lee `variedades_registradas_ica` del catálogo Chagra v3.1.
- `SeedingLog` ahora hace match del free-text `crop` contra el catálogo (`nombre_comun` exact → `id` exact → startsWith).
- Si la especie tiene variedades ICA → dropdown con autocomplete + opción \"Otra (escribir)\".
- Si NO tiene variedades / no matchea → campo **oculto** (no pedimos algo sin contexto).

## Tests

- 14 tests `speciesVariety.test.js` cubriendo edge cases (null/undefined/empty/non-object), normalización de shape, pluralización 1 vs N, fallback a `id_canonico` cuando falta `nombre_comercial`.
- ESLint clean `--max-warnings=0`.
- Auto-bump: `0.13.15 → 0.13.16`, `chagra-v247 → chagra-v248`.

## Notas técnicas

- En v3.1 el catálogo solo tiene `variedades_registradas_ica` en 2 species (papa, arracacha). Cuando se hidrate con más, el campo aparecerá automáticamente sin tocar código.
- El campo \"Otra (escribir)\" preserva el comportamiento legacy de texto libre para casos donde el operador conoce una variedad no listada por ICA.

## Test plan

- [ ] Smoke manual: escribir \"papa\" → ver dropdown de variedades ICA (AGROSAVIA Alhaja, etc.).
- [ ] Smoke manual: escribir \"romero\" → confirmar que el campo Variedad NO aparece.
- [ ] Smoke manual: elegir \"Otra (escribir)\" → input libre con botón \"Lista\" para volver al dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)