### PR TITLE
feat(ux): UX-17 — "etapa fenológica" → "momento de la planta" amigable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.16",
+  "version": "0.13.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.17",
+  "version": "0.13.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v249';
+const CACHE_NAME = 'chagra-v250';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v248';
+const CACHE_NAME = 'chagra-v249';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -188,7 +188,9 @@ const PlantMetaPanel = ({ asset }) => {
       ? `Altura: ${Number(meta.altura_cm)} cm`
       : null;
   const etapaRaw = meta.etapa_fenologica;
-  const etapaLabel = etapaRaw ? `Etapa: ${ETAPA_FENOLOGICA_LABELS[etapaRaw] || etapaRaw}` : null;
+  // UX-17 (#286) 2026-05-27: "Etapa: ..." → "Momento: ..." con label
+  // amigable. Los labels mapean a copy de campo (ver plantMeta.js).
+  const etapaLabel = etapaRaw ? `Momento: ${ETAPA_FENOLOGICA_LABELS[etapaRaw] || etapaRaw}` : null;
 
   if (!fechaLabel && !alturaLabel && !etapaLabel) return null;
 

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -72,14 +72,8 @@ const EQUIPMENT_EXAMPLES = [
   'Rastrillo',
 ];
 
-// UX-15 (#286) 2026-05-27: helper urbano local (la PR UX-13 introdujo
-// `src/utils/landTypes.js` con el set canónico; cuando esa PR mergee a
-// main esta constante se reemplaza por el import). Mantenido inline para
-// que UX-15 sea independiente de UX-13 en orden de merge.
-const URBAN_LAND_TYPES_LOCAL = new Set([
-  'balcony', 'terrace', 'window_sill', 'indoor_pot', 'urban_garden',
-]);
-const isUrbanLandType = (lt) => URBAN_LAND_TYPES_LOCAL.has(lt);
+// UX-15 (#286) 2026-05-27: helper urbano importado del módulo canónico
+// `src/utils/landTypes.js` (introducido por UX-13 PR #1088, ya en main).
 
 // UX-15 (#286) 2026-05-27: copy replanteado sin jerga forestal técnica.
 // El operador reportó "dosel" como confuso ("ni yo sé qué es"). Reemplazos:

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1172,13 +1172,16 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             />
           </div>
 
-          {/* Etapa fenológica */}
+          {/* UX-17 (#286) 2026-05-27: "etapa fenológica" → "¿En qué momento
+              está la planta?" — copy amigable para gente de campo y niños 11+.
+              Los `value` técnicos se mantienen (compat backend). El sub-label
+              "technical" queda como title hover para agrónomos. */}
           <div className="space-y-1.5">
             <label
               htmlFor="plant-etapa-fenologica"
               className="text-xs font-bold text-slate-400 uppercase tracking-wider"
             >
-              Etapa fenológica (opcional)
+              ¿En qué momento está la planta? (opcional)
             </label>
             <select
               id="plant-etapa-fenologica"
@@ -1187,9 +1190,9 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
               onChange={(e) => setFormData({ ...formData, etapaFenologica: e.target.value })}
               className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white min-h-[48px] focus:ring-lime-500 focus:border-lime-500"
             >
-              <option value="">— Sin definir —</option>
+              <option value="">— No sé / aún no aplica —</option>
               {ETAPA_FENOLOGICA_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
+                <option key={opt.value} value={opt.value} title={opt.technical}>
                   {opt.label}
                 </option>
               ))}

--- a/src/utils/plantMeta.js
+++ b/src/utils/plantMeta.js
@@ -16,16 +16,33 @@
  */
 
 /**
- * Opciones canónicas de etapa fenológica. UI las usa para el `<select>`
- * y AssetDetailView las usa para etiquetar legibles.
+ * Opciones de "momento de la planta" (antes "etapa fenológica").
+ *
+ * UX-17 (#286) 2026-05-27 — operador y feedback Lili: "etapa fenológica
+ * es muy técnico yo entiendo el sentido pero debe ser más amigable
+ * revisa eso en TODA la app porque debe ser amigable para gente del
+ * campo y niños desde los 11 años".
+ *
+ * Reemplazos (los `value` se MANTIENEN para compat backend/FarmOS y
+ * datos persistidos en `attributes._chagra_plant_meta`):
+ *   - 'semillero'       → "Recién nacida (semillero)"
+ *   - 'vegetativo'      → "Creciendo (sin flores)"
+ *   - 'floracion'       → "Con flores"
+ *   - 'fructificacion'  → "Con frutos / semillas"
+ *   - 'madurez'         → "Lista para cosechar"
+ *   - 'senescencia'     → "Vieja / acabándose"
+ *
+ * El sub-label `technical` queda como tooltip discreto para agrónomos
+ * que sí conocen el vocabulario técnico, sin imponerlo al niño/usuario
+ * de campo.
  */
 export const ETAPA_FENOLOGICA_OPTIONS = [
-    { value: 'semillero', label: 'Semillero' },
-    { value: 'vegetativo', label: 'Vegetativo' },
-    { value: 'floracion', label: 'Floración' },
-    { value: 'fructificacion', label: 'Fructificación' },
-    { value: 'madurez', label: 'Madurez' },
-    { value: 'senescencia', label: 'Senescencia' },
+    { value: 'semillero', label: 'Recién nacida (semillero)', technical: 'Semillero / plántula' },
+    { value: 'vegetativo', label: 'Creciendo (sin flores)', technical: 'Vegetativo' },
+    { value: 'floracion', label: 'Con flores', technical: 'Floración' },
+    { value: 'fructificacion', label: 'Con frutos / semillas', technical: 'Fructificación' },
+    { value: 'madurez', label: 'Lista para cosechar', technical: 'Madurez' },
+    { value: 'senescencia', label: 'Vieja / acabándose', technical: 'Senescencia' },
 ];
 
 /**

--- a/src/utils/plantMeta.js
+++ b/src/utils/plantMeta.js
@@ -18,7 +18,7 @@
 /**
  * Opciones de "momento de la planta" (antes "etapa fenológica").
  *
- * UX-17 (#286) 2026-05-27 — operador y feedback Lili: "etapa fenológica
+ * UX-17 (#286) 2026-05-27 — operador piloto: "etapa fenológica
  * es muy técnico yo entiendo el sentido pero debe ser más amigable
  * revisa eso en TODA la app porque debe ser amigable para gente del
  * campo y niños desde los 11 años".

--- a/src/utils/plantMeta.test.js
+++ b/src/utils/plantMeta.test.js
@@ -106,3 +106,49 @@ describe('ETAPA_FENOLOGICA_LABELS — labels legibles para AssetDetailView', () 
         }
     });
 });
+
+describe('UX-17 — copy amigable de "momento de la planta"', () => {
+    // El operador pidió evitar jerga técnica para "gente del campo y niños
+    // desde los 11 años". Verificamos que los labels nuevos están en lenguaje
+    // accesible y los técnicos están en `technical` (sub-label tooltip).
+    it('los 6 labels visibles NO usan palabras técnicas', () => {
+        const technicalWords = [
+            // exact match con boundary para no atrapar derivaciones legítimas.
+            /\bfenolog/i,
+            /\bsenescencia\b/i,
+            /\bvegetativo\b/i,
+            /\bfructificación\b/i,
+            /\bantesis\b/i,
+        ];
+        for (const opt of ETAPA_FENOLOGICA_OPTIONS) {
+            for (const re of technicalWords) {
+                // 'semillero' es lo suficiente común (no técnica jerga) y
+                // aparece entre paréntesis como aclaración → permitido.
+                expect(opt.label).not.toMatch(re);
+            }
+        }
+    });
+
+    it('cada opción tiene un sub-label "technical" con el término agrónomo', () => {
+        for (const opt of ETAPA_FENOLOGICA_OPTIONS) {
+            expect(opt.technical).toBeTruthy();
+            expect(typeof opt.technical).toBe('string');
+        }
+    });
+
+    it('los `value` técnicos se mantienen — compat backend FarmOS', () => {
+        const values = ETAPA_FENOLOGICA_OPTIONS.map((o) => o.value).sort();
+        expect(values).toEqual([
+            'floracion', 'fructificacion', 'madurez',
+            'semillero', 'senescencia', 'vegetativo',
+        ]);
+    });
+
+    it('labels mencionan acciones / estados accesibles (flores, frutos, cosechar)', () => {
+        const allLabels = ETAPA_FENOLOGICA_OPTIONS.map((o) => o.label.toLowerCase()).join(' | ');
+        expect(allLabels).toMatch(/flores/);
+        expect(allLabels).toMatch(/frutos|semillas/);
+        expect(allLabels).toMatch(/cosechar/);
+        expect(allLabels).toMatch(/creciendo|nacida/);
+    });
+});


### PR DESCRIPTION
## Summary

Operador 2026-05-27: \"etapa fenológica es muy técnico yo entiendo el sentido pero debe ser más amigable revisa eso en TODA la app porque debe ser amigable para gente del campo y niños desde los 11 años\".

Reemplazos visibles (los `value` técnicos se mantienen para compat backend):

| value | antes | después |
|---|---|---|
| `semillero` | Semillero | Recién nacida (semillero) |
| `vegetativo` | Vegetativo | Creciendo (sin flores) |
| `floracion` | Floración | Con flores |
| `fructificacion` | Fructificación | Con frutos / semillas |
| `madurez` | Madurez | Lista para cosechar |
| `senescencia` | Senescencia | Vieja / acabándose |

- Label: \"Etapa fenológica (opcional)\" → \"¿En qué momento está la planta? (opcional)\".
- Placeholder: \"— Sin definir —\" → \"— No sé / aún no aplica —\".
- `<option title={opt.technical}>` mantiene el término agrónomo como tooltip discreto.
- `AssetDetailView` muestra \"Momento: ...\" en lugar de \"Etapa: ...\".

## Tests

- 4 tests nuevos en `plantMeta.test.js` (16 total verde): verifica ausencia de jerga, presencia de sub-label técnico, compat de `value`, y que los labels mencionan acciones accesibles.
- ESLint clean.
- Auto-bump: `0.13.15 → 0.13.16`.

## Test plan

- [ ] Smoke manual: nuevo asset planta → ver el select con \"¿En qué momento está la planta?\" y las 6 opciones nuevas.
- [ ] Smoke manual: ya existe planta con `etapa_fenologica: 'floracion'` → AssetDetailView muestra \"Momento: Con flores\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)