### PR TITLE
fix(ux): UX-20/21/22 — foto no aparece en índice + copy zona + reactividad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.15",
+  "version": "0.13.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v247';
+const CACHE_NAME = 'chagra-v248';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetDetailView.jsx
+++ b/src/components/AssetDetailView.jsx
@@ -36,6 +36,18 @@ const PHOTO_LABELS = {
   equipment: 'Agregar foto a este equipo',
   default: 'Agregar foto',
 };
+
+// UX-21 (#286) 2026-05-27 — bug operador: "agrego una foto y al hacerlo
+// me dice 'foto agregada para esta planta' cuando claramente no lo es"
+// (era zona/building). Copy success contextual según tipo de asset.
+const PHOTO_SUCCESS_LABELS = {
+  plant: '✓ Foto guardada para esta planta.',
+  land: '✓ Foto guardada para esta zona.',
+  structure: '✓ Foto guardada para esta estructura.',
+  equipment: '✓ Foto guardada para este equipo.',
+  default: '✓ Foto guardada.',
+};
+
 function AddPhotoSection({ assetId, speciesSlug, assetType }) {
   const [busy, setBusy] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -51,6 +63,14 @@ function AddPhotoSection({ assetId, speciesSlug, assetType }) {
     try {
       const { blob } = await captureAndCompress(file);
       await savePhoto({ blob, assetId, speciesSlug });
+      // UX-20/22 (#286): notificar a todos los hooks usePhotoUrl que
+      // matcheen este asset/species, para que actualicen su URL sin
+      // esperar a un remount. Sin esto, AssetCardThumb / SpeciesPhotoGallery
+      // quedaban en placeholder hasta refresh manual aunque la foto ya
+      // viviera en media_cache.
+      window.dispatchEvent(new CustomEvent('chagra:photo:saved', {
+        detail: { assetId: assetId || null, speciesSlug: speciesSlug || null },
+      }));
       setSuccess(true);
       setTimeout(() => setSuccess(false), 3000);
     } catch (err) {
@@ -87,7 +107,11 @@ function AddPhotoSection({ assetId, speciesSlug, assetType }) {
         </button>
       </div>
       {busy && <p className="text-xs text-slate-400 italic">Procesando...</p>}
-      {success && <p className="text-xs text-emerald-400">✓ Foto guardada para esta planta.</p>}
+      {success && (
+        <p className="text-xs text-emerald-400" data-testid="photo-success">
+          {PHOTO_SUCCESS_LABELS[assetType] || PHOTO_SUCCESS_LABELS.default}
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -670,19 +670,25 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
       });
     }
 
-    // Ejecución atómica vía store (bulk si N>1, single si N=1)
+    // UX-20 (#286) 2026-05-27 — bug operador: "se registra la fresa ya
+    // tiene toda la información pero no veo en el índice de plantas la
+    // foto a pesar de que ya la tiene".
+    //
+    // Root cause: el orden previo era addAsset() → savePhoto(). Pero
+    // `addAsset` updateaba el store → PlantCardThumb re-render → su
+    // `usePhotoUrl(assetId)` se montaba ANTES de que savePhoto hubiera
+    // persistido la foto, devolvía null + caía a placeholder. Como
+    // useEffect solo re-corre cuando cambian sus deps `[assetId, ...]`,
+    // nunca re-fetcheaba aunque la foto llegara después → la card
+    // quedaba para siempre sin imagen hasta refresh manual.
+    //
+    // Fix: PRIMERO guardar la foto (assetId está pre-asignado vía
+    // crypto.randomUUID() arriba, no necesita el store), DESPUÉS crear
+    // el asset. Así cuando PlantCardThumb monta, la foto ya está en
+    // media_cache y se ve inmediato. Bonus: emitimos `chagra:photo:saved`
+    // por si algún componente quiere refrescar listas de fotos
+    // (SpeciesPhotoGallery, etc.).
     try {
-      if (assetCount > 1) {
-        await addAssetsBulk(activeTab, optimisticAssets, pendingTxs);
-      } else {
-        await addAsset(activeTab, optimisticAssets[0], pendingTxs);
-      }
-
-      // Bug fix #2 (2026-05-18): persistir la foto capturada por
-      // SpeciesSelect. La foto sirve doble: identificar especie + quedar
-      // como referencia de la planta. Se ata al primer asset creado y
-      // al speciesSlug para que el resolver de usePhotoUrl la encuentre
-      // por assetId (prioridad alta) o por especie (fallback).
       if (activeTab === 'plant' && formData.photoBlob instanceof Blob) {
         try {
           await savePhoto({
@@ -690,9 +696,23 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             assetId: assetUUIDs[0],
             speciesSlug: formData.speciesId || null,
           });
+          window.dispatchEvent(new CustomEvent('chagra:photo:saved', {
+            detail: {
+              assetId: assetUUIDs[0],
+              speciesSlug: formData.speciesId || null,
+            },
+          }));
         } catch (err) {
           console.warn('[AssetsDashboard] savePhoto falló (no bloquea siembra):', err);
         }
+      }
+
+      // Ahora sí: guardar el asset. PlantCardThumb monta con la foto
+      // ya disponible → render con thumb correcta sin refresh manual.
+      if (assetCount > 1) {
+        await addAssetsBulk(activeTab, optimisticAssets, pendingTxs);
+      } else {
+        await addAsset(activeTab, optimisticAssets[0], pendingTxs);
       }
 
       // Limpiar zona persistida — siembra guardada, próxima abrirá vacía

--- a/src/hooks/__tests__/usePhotoUrl.refetch.test.jsx
+++ b/src/hooks/__tests__/usePhotoUrl.refetch.test.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { usePhotoUrl } from '../usePhotoUrl';
+
+/**
+ * Tests para UX-20 (#286): bug operador 2026-05-27 — "se registra la
+ * fresa ya tiene toda la información pero no veo en el índice de plantas
+ * la foto a pesar de que ya la tiene".
+ *
+ * Verifica que el hook usePhotoUrl re-fetchea cuando recibe el evento
+ * global `chagra:photo:saved` y el detail.assetId / detail.speciesSlug
+ * coincide con sus params.
+ */
+
+let callCount = 0;
+let mockBlobUrl = 'blob://placeholder.svg';
+
+vi.mock('../../services/photoService', () => ({
+  getPhotoUrl: vi.fn(async () => {
+    callCount += 1;
+    // Primera llamada → placeholder. Siguientes → blob (simula que la
+    // foto recién se guardó entre la primera y la segunda invocación).
+    if (callCount === 1) {
+      return { url: '/placeholder-species.svg', source: 'placeholder' };
+    }
+    return { url: mockBlobUrl, source: 'user', revoke: () => {} };
+  }),
+  getPhotoById: vi.fn(),
+}));
+
+function Probe({ assetId, speciesSlug }) {
+  const photo = usePhotoUrl({ assetId, speciesSlug });
+  if (photo.loading) return <span data-testid="probe">loading</span>;
+  return <span data-testid="probe">{photo.source}:{photo.url}</span>;
+}
+
+beforeEach(() => {
+  callCount = 0;
+});
+
+describe('UX-20 — usePhotoUrl re-fetch on chagra:photo:saved', () => {
+  it('re-fetchea cuando assetId matchea el evento global', async () => {
+    render(<Probe assetId="asset-123" />);
+    await waitFor(() => expect(screen.getByTestId('probe').textContent).toMatch(/placeholder/));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('chagra:photo:saved', {
+        detail: { assetId: 'asset-123' },
+      }));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('probe').textContent).toMatch(/user:blob/));
+    expect(callCount).toBe(2);
+  });
+
+  it('re-fetchea cuando speciesSlug matchea el evento global', async () => {
+    render(<Probe speciesSlug="fragaria" />);
+    await waitFor(() => expect(screen.getByTestId('probe').textContent).toMatch(/placeholder/));
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('chagra:photo:saved', {
+        detail: { speciesSlug: 'fragaria' },
+      }));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('probe').textContent).toMatch(/user:blob/));
+  });
+
+  it('NO re-fetchea cuando el evento es de otro asset', async () => {
+    render(<Probe assetId="asset-123" />);
+    await waitFor(() => expect(callCount).toBeGreaterThanOrEqual(1));
+    const before = callCount;
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('chagra:photo:saved', {
+        detail: { assetId: 'asset-OTHER' },
+      }));
+    });
+
+    // Pequeña pausa para que cualquier re-render espurio termine.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(callCount).toBe(before);
+  });
+
+  it('NO re-fetchea cuando el evento no trae detail', async () => {
+    render(<Probe assetId="asset-123" />);
+    await waitFor(() => expect(callCount).toBeGreaterThanOrEqual(1));
+    const before = callCount;
+
+    act(() => {
+      window.dispatchEvent(new Event('chagra:photo:saved'));
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(callCount).toBe(before);
+  });
+});

--- a/src/hooks/usePhotoUrl.js
+++ b/src/hooks/usePhotoUrl.js
@@ -30,6 +30,27 @@ export function usePhotoUrl({ assetId, speciesSlug, photoId } = {}) {
     source: null,
     loading: true,
   });
+  // UX-20 (#286) 2026-05-27: tick para forzar re-fetch sin cambiar deps.
+  // Lo bumpea el listener de `chagra:photo:saved` cuando un componente
+  // externo (AssetsDashboard post-siembra o AddPhotoSection) acaba de
+  // guardar una foto que matchea este hook. Sin esto, el thumb queda en
+  // placeholder hasta refresh manual.
+  const [refetchTick, setRefetchTick] = useState(0);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handler = (e) => {
+      const d = e.detail || {};
+      if (photoId != null) return; // photoId es específico, no usa cache
+      const matchesAsset = assetId && d.assetId && d.assetId === assetId;
+      const matchesSpecies = speciesSlug && d.speciesSlug && d.speciesSlug === speciesSlug;
+      if (matchesAsset || matchesSpecies) {
+        setRefetchTick((t) => t + 1);
+      }
+    };
+    window.addEventListener('chagra:photo:saved', handler);
+    return () => window.removeEventListener('chagra:photo:saved', handler);
+  }, [assetId, speciesSlug, photoId]);
 
   useEffect(() => {
     let alive = true;
@@ -74,7 +95,7 @@ export function usePhotoUrl({ assetId, speciesSlug, photoId } = {}) {
       alive = false;
       if (revokeFn) revokeFn();
     };
-  }, [assetId, speciesSlug, photoId]);
+  }, [assetId, speciesSlug, photoId, refetchTick]);
 
   return state;
 }


### PR DESCRIPTION
## Bugs reportados

**UX-20**: \"se registra la fresa ya tiene toda la información pero no veo en el índice de plantas la foto a pesar de que ya la tiene\".

**UX-21**: \"agrego una foto y al hacerlo me dice 'foto agregada para esta planta' cuando claramente no lo es\" (era zona / building).

**UX-22**: foto en zona \"no guarda\" / \"estilos parecen versión vieja\". Mismo root cause que UX-20 pero desde `AssetDetailView`.

## Root cause común

`usePhotoUrl` solo re-fetcheaba cuando cambiaban sus deps `[assetId, speciesSlug, photoId]`. Si una foto se guardaba **después** del primer render del thumb, la card quedaba en placeholder hasta un refresh manual aunque la foto ya viviera en `media_cache`.

## Fixes

1. **`AssetsDashboard.handleSave` invierte el orden**: `savePhoto()` PRIMERO (con el UUID pre-generado), `addAsset()` DESPUÉS. Cuando `PlantCardThumb` monta tras `addAsset`, la foto ya está en `media_cache`.
2. **Evento global `chagra:photo:saved`** se emite tras cada `savePhoto` exitoso con `{assetId, speciesSlug}`.
3. **`usePhotoUrl` escucha el evento** y bumpea un tick interno cuando matchea sus params → useEffect re-corre el fetch.
4. **`AddPhotoSection` copy success contextual** (`PHOTO_SUCCESS_LABELS`) por `assetType`: planta / zona / estructura / equipo / default.
5. **`AddPhotoSection` también emite el evento** → AssetCardThumb / SpeciesPhotoGallery se refrescan en tiempo real al agregar foto a una zona/estructura.

## Tests

- 4 nuevos en `hooks/__tests__/usePhotoUrl.refetch.test.jsx`: re-fetch con event match (assetId), re-fetch con event match (speciesSlug), NO re-fetch con event de otro asset, NO crash con detail vacío.
- ESLint clean `--max-warnings=0`.
- Auto-bump: `0.13.15 → 0.13.16`.

## Test plan

- [ ] Smoke iPhone: registrar fresa con foto → ver el thumb en el índice inmediato sin refresh.
- [ ] Smoke iPhone: en zona Robles building, agregar foto → ver \"Foto guardada para esta zona\" (no \"...para esta planta\").
- [ ] Smoke iPhone: el thumb de la zona en el índice se actualiza tras agregar foto sin refresh manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)