### PR TITLE
fix(ux): UX-23 — iPhone GPS "Caminar" y "Mi ubicación" no responden

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.15",
+  "version": "0.13.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v247';
+const CACHE_NAME = 'chagra-v248';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/MapPicker.jsx
+++ b/src/components/MapPicker.jsx
@@ -179,11 +179,27 @@ export const MapPicker = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Toggle del modo "trazar caminando": al activar, arranca un watchPosition
-  // con alta precision que va anadiendo vertices al polygon a medida que el
-  // GPS reporta nuevas coordenadas (tipicamente cada 1-3s segun el dispositivo).
-  // Desactivar detiene la captura, el polygon queda con los vertices
-  // acumulados y el usuario puede editarlo con Undo / Cerrar polígono.
+  // UX-23 (#286) 2026-05-27 — bug operador iPhone: "cuando doy clic en
+  // una propiedad caminar para registrarla el botón no funciona ni el
+  // de mi ubicación me devuelve".
+  //
+  // Root cause: iOS Safari es estricto con geolocation:
+  //   - watchPosition con enableHighAccuracy=true + timeout 15s a veces
+  //     se cuelga silenciosamente sin disparar success ni error si el
+  //     usuario no aceptó el prompt o si el permiso está "Solo una vez".
+  //   - getCurrentPosition con highAccuracy tarda 30-60s en cold-start
+  //     A-GPS en iPhone — timeout 15s es muy agresivo.
+  //   - Si el permiso está denied, navigator.geolocation existe pero
+  //     toda llamada devuelve error code=1 — la UI debe mostrar copy
+  //     accionable ("Abre Ajustes > Safari > Ubicación").
+  //
+  // Fixes:
+  //   1. Pre-flight check con getCurrentPosition para asegurar permiso
+  //      antes de arrancar watchPosition (iOS confiable así).
+  //   2. Timeout extendido a 30s (iOS A-GPS realista).
+  //   3. Mensajes de error específicos por err.code con guía iOS.
+  //   4. Fallback enableHighAccuracy=false si el primer intento falla
+  //      por timeout (algunos iPhones viejos no capturan high-accuracy).
   const toggleWalkRecording = () => {
     if (mode !== 'polygon') return;
     if (isWalking) {
@@ -195,39 +211,82 @@ export const MapPicker = ({
       return;
     }
     if (!navigator.geolocation) {
-      console.warn('[MapPicker] Geolocalización no disponible para modo walk');
+      setGpsStatus('failed');
+      setGpsError('Geolocalización no disponible en este navegador.');
       return;
     }
-    // Limpia cualquier vertice previo y arranca la captura
-    setPoints([]);
-    const map = mapRef.current;
-    if (layerRef.current) {
-      map.removeLayer(layerRef.current);
-      layerRef.current = null;
-    }
-    setIsWalking(true);
-    watchIdRef.current = navigator.geolocation.watchPosition(
-      (pos) => {
-        const latlng = { lat: pos.coords.latitude, lng: pos.coords.longitude };
-        setPoints((prev) => {
-          const next = [...prev, latlng];
-          if (layerRef.current) map.removeLayer(layerRef.current);
-          if (next.length >= 2) {
-            layerRef.current = L.polyline(next, { color: '#10b981', weight: 4, opacity: 0.85 }).addTo(map);
+
+    const startWatch = (highAccuracy) => {
+      // Limpia cualquier vertice previo y arranca la captura
+      setPoints([]);
+      const map = mapRef.current;
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current);
+        layerRef.current = null;
+      }
+      setIsWalking(true);
+      setGpsError(null);
+      watchIdRef.current = navigator.geolocation.watchPosition(
+        (pos) => {
+          const latlng = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+          setPoints((prev) => {
+            const next = [...prev, latlng];
+            if (layerRef.current) map.removeLayer(layerRef.current);
+            if (next.length >= 2) {
+              layerRef.current = L.polyline(next, { color: '#10b981', weight: 4, opacity: 0.85 }).addTo(map);
+            }
+            map.panTo([latlng.lat, latlng.lng]);
+            return next;
+          });
+        },
+        (err) => {
+          let msg = 'Error capturando GPS al caminar.';
+          if (err.code === 1) msg = 'Permiso de ubicación denegado. Abre Ajustes > Safari > Ubicación para permitirlo.';
+          else if (err.code === 2) msg = 'GPS no disponible (sin señal o desactivado).';
+          else if (err.code === 3) msg = 'Tiempo agotado esperando GPS. Sal al exterior y vuelve a intentar.';
+          console.error('[MapPicker] Error watchPosition:', err.code, err.message);
+          setGpsStatus('failed');
+          setGpsError(msg);
+          setIsWalking(false);
+          if (watchIdRef.current !== null) {
+            navigator.geolocation.clearWatch(watchIdRef.current);
+            watchIdRef.current = null;
           }
-          map.panTo([latlng.lat, latlng.lng]);
-          return next;
-        });
+        },
+        {
+          enableHighAccuracy: highAccuracy,
+          maximumAge: 0,
+          // Extendido de 15s a 30s — iOS A-GPS cold-start típico.
+          timeout: 30000,
+        },
+      );
+    };
+
+    // Pre-flight con getCurrentPosition para asegurar permiso iOS antes
+    // de arrancar watchPosition. Si el permiso no está, fallamos rápido
+    // con mensaje claro en lugar de un watchPosition colgado.
+    setGpsStatus('locating');
+    navigator.geolocation.getCurrentPosition(
+      () => {
+        setGpsStatus('located');
+        startWatch(true);
       },
       (err) => {
-        console.error('[MapPicker] Error watchPosition:', err.message);
-        setIsWalking(false);
+        // Primer intento high-accuracy falló — si fue timeout, reintentar
+        // sin highAccuracy (iPhone viejo / Android sin GPS asistido).
+        if (err.code === 3) {
+          console.warn('[MapPicker] Timeout high-accuracy, reintento low-accuracy');
+          startWatch(false);
+          return;
+        }
+        let msg = 'No se pudo iniciar la captura GPS.';
+        if (err.code === 1) msg = 'Permiso de ubicación denegado. En iPhone: Ajustes > Safari > Ubicación.';
+        else if (err.code === 2) msg = 'GPS no disponible. Sal al exterior y verifica que el GPS esté activo.';
+        console.error('[MapPicker] Error pre-flight GPS:', err.code, err.message);
+        setGpsStatus('failed');
+        setGpsError(msg);
       },
-      {
-        enableHighAccuracy: true,
-        maximumAge: 0,
-        timeout: 15000
-      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 },
     );
   };
 
@@ -289,17 +348,25 @@ export const MapPicker = ({
         }
       },
       (err) => {
+        // UX-23 (#286) 2026-05-27: copy iOS-aware. iOS Safari requiere
+        // permiso explícito vía Ajustes si fue denegado una vez.
         let msg = 'No se pudo obtener tu ubicación.';
-        if (err.code === 1) msg = 'Permiso de ubicación denegado por el navegador.';
-        else if (err.code === 2) msg = 'GPS no disponible (sin señal o desactivado).';
-        else if (err.code === 3) msg = 'Tiempo agotado esperando al GPS (15s).';
+        if (err.code === 1) {
+          msg = 'Permiso de ubicación denegado. En iPhone: Ajustes > Safari > Ubicación. En Android: toca el candado de la barra de URL.';
+        } else if (err.code === 2) {
+          msg = 'GPS no disponible. Verifica que el GPS esté activo y que estés al exterior (no en sótano / lejos de ventana).';
+        } else if (err.code === 3) {
+          msg = 'Tiempo agotado esperando al GPS (30s). En iPhone, el GPS puede tardar más al aire libre — espera unos segundos y vuelve a tocar "Mi ubicación".';
+        }
         console.error('[MapPicker] Error GPS:', err.code, err.message);
         setGpsStatus('failed');
         setGpsError(msg);
       },
       {
         enableHighAccuracy: true,
-        timeout: 15000,
+        // UX-23: timeout extendido de 15s a 30s — A-GPS de iPhone tarda
+        // 20-60s en cold-start.
+        timeout: 30000,
         maximumAge: 30000
       }
     );
@@ -406,7 +473,7 @@ export const MapPicker = ({
           {gpsStatus === 'failed' && (
             <>
               <AlertTriangle size={14} className="shrink-0" />
-              <span className="flex-1">{gpsError || 'GPS no disponible.'} Podés marcar el punto haciendo click en el mapa.</span>
+              <span className="flex-1">{gpsError || 'GPS no disponible.'} Puedes marcar el punto tocando el mapa.</span>
               <button
                 type="button"
                 onClick={() => captureGps(true)}

--- a/src/hooks/__tests__/useGeolocation.ios.test.jsx
+++ b/src/hooks/__tests__/useGeolocation.ios.test.jsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useGeolocation } from '../useGeolocation';
+
+/**
+ * Tests para UX-23 (#286): bug operador iPhone 2026-05-27 — "cuando doy
+ * clic en una propiedad caminar para registrarla el botón no funciona ni
+ * el de mi ubicación me devuelve".
+ *
+ * Verifica:
+ *   1. Timeout default es 30s (no 15s) — iOS A-GPS cold-start realista.
+ *   2. Si el primer intento high-accuracy timeoutea, reintentamos con
+ *      enableHighAccuracy=false automáticamente.
+ *   3. Si el caller override enableHighAccuracy=false, NO reintenta.
+ *   4. Error code 1 (denied) → errorType 'denied' (mapping correcto).
+ *   5. Error code 3 (timeout) tras retry → errorType 'timeout' propaga.
+ */
+
+function Probe({ requestArgs = {} }) {
+  const { position, error, loading, request } = useGeolocation();
+  return (
+    <>
+      <button data-testid="trigger" onClick={() => request(requestArgs)}>req</button>
+      <span data-testid="loading">{loading ? 'loading' : 'idle'}</span>
+      <span data-testid="error">{error || 'noerror'}</span>
+      <span data-testid="lat">{position?.lat ?? 'nolat'}</span>
+    </>
+  );
+}
+
+let attempts = [];
+const mockSuccess = (lat, lng) => ({
+  coords: {
+    latitude: lat, longitude: lng, accuracy: 20,
+    altitude: null, altitudeAccuracy: null,
+  },
+  timestamp: Date.now(),
+});
+
+beforeEach(() => {
+  attempts = [];
+  navigator.geolocation = {
+    getCurrentPosition: vi.fn((success, error, config) => {
+      attempts.push({ ...config });
+      // Mock behavior is set per-test via attempts[].behavior
+    }),
+  };
+});
+
+describe('UX-23 — useGeolocation iOS fixes', () => {
+  it('timeout default es 30000ms (era 15000)', () => {
+    render(<Probe />);
+    fireEvent.click(screen.getByTestId('trigger'));
+    expect(attempts[0].timeout).toBe(30000);
+  });
+
+  it('reintenta con enableHighAccuracy=false si primer intento timeoutea', () => {
+    navigator.geolocation.getCurrentPosition = vi.fn((success, error, config) => {
+      attempts.push({ ...config });
+      if (attempts.length === 1) {
+        // primer call: high-accuracy timeout
+        error({ code: 3, message: 'Timeout' });
+      } else {
+        // segundo call: success low-accuracy
+        success(mockSuccess(4.5, -73.9));
+      }
+    });
+
+    render(<Probe />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0].enableHighAccuracy).toBe(true);
+    expect(attempts[1].enableHighAccuracy).toBe(false);
+  });
+
+  it('NO reintenta si el caller override enableHighAccuracy=false', () => {
+    navigator.geolocation.getCurrentPosition = vi.fn((success, error, config) => {
+      attempts.push({ ...config });
+      error({ code: 3, message: 'Timeout' });
+    });
+
+    render(<Probe requestArgs={{ enableHighAccuracy: false }} />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0].enableHighAccuracy).toBe(false);
+  });
+
+  it('mapea err.code=1 (PERMISSION_DENIED) a errorType "denied"', async () => {
+    const onError = vi.fn();
+    navigator.geolocation.getCurrentPosition = vi.fn((success, error) => {
+      error({ code: 1, message: 'Denied' });
+    });
+
+    render(<Probe requestArgs={{ onError }} />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('denied'));
+    expect(screen.getByTestId('error').textContent).toBe('denied');
+  });
+
+  it('mapea err.code=3 (TIMEOUT) tras retry a errorType "timeout"', async () => {
+    const onError = vi.fn();
+    navigator.geolocation.getCurrentPosition = vi.fn((success, error, config) => {
+      attempts.push({ ...config });
+      error({ code: 3, message: 'Timeout' });
+    });
+
+    render(<Probe requestArgs={{ onError }} />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('timeout'));
+    // 2 intentos: high-accuracy + low-accuracy retry, ambos fallaron.
+    expect(attempts).toHaveLength(2);
+    expect(screen.getByTestId('error').textContent).toBe('timeout');
+  });
+
+  it('llama onSuccess y setea position cuando GPS resuelve', async () => {
+    const onSuccess = vi.fn();
+    navigator.geolocation.getCurrentPosition = vi.fn((success) => {
+      success(mockSuccess(4.5, -73.9));
+    });
+
+    render(<Probe requestArgs={{ onSuccess }} />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    await waitFor(() => expect(screen.getByTestId('lat').textContent).toBe('4.5'));
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('NO reintenta para errores no-timeout (code=1 / code=2)', () => {
+    navigator.geolocation.getCurrentPosition = vi.fn((success, error) => {
+      attempts.push({});
+      error({ code: 1, message: 'Denied' });
+    });
+
+    render(<Probe />);
+    fireEvent.click(screen.getByTestId('trigger'));
+
+    expect(attempts).toHaveLength(1);
+  });
+});

--- a/src/hooks/useGeolocation.js
+++ b/src/hooks/useGeolocation.js
@@ -4,8 +4,13 @@ import { useState, useCallback } from 'react';
  * useGeolocation Hook
  * Optimized for iOS Safari:
  * 1. Requires manual trigger (request) to satisfy user gesture requirement.
- * 2. High timeout (15s) for cold GPS starts.
+ * 2. High timeout (30s) for cold GPS starts — UX-23 (#286) 2026-05-27.
+ *    iOS A-GPS cold-start regularly takes 20-60s. El timeout previo de
+ *    15s causaba que el botón "Mi ubicación" fallara silenciosamente en
+ *    iPhones recién despertados.
  * 3. Maps error codes to semantic types for instructional UI.
+ * 4. Retry automático con enableHighAccuracy=false si el primer intento
+ *    timeoutea — algunos iPhones viejos no entregan high-accuracy ever.
  */
 export function useGeolocation() {
     const [position, setPosition] = useState(null);
@@ -22,37 +27,60 @@ export function useGeolocation() {
         setLoading(true);
         setError(null);
 
-        const config = {
-            enableHighAccuracy: true,
-            timeout: 15000, // 15s recommended for iOS Safari cold start
-            maximumAge: 30000,
-            ...options
+        const buildConfig = (highAccuracy) => {
+            // UX-23: defaults seguros + caller override. Si el caller pasa
+            // enableHighAccuracy/timeout explícitos, respetamos su valor.
+            const cfg = {
+                enableHighAccuracy: highAccuracy,
+                timeout: 30000,
+                maximumAge: 30000,
+                ...options,
+            };
+            if (options.enableHighAccuracy == null) cfg.enableHighAccuracy = highAccuracy;
+            if (options.timeout == null) cfg.timeout = 30000;
+            return cfg;
+        };
+
+        const success = (pos) => {
+            const result = {
+                lat: pos.coords.latitude,
+                lon: pos.coords.longitude,
+                accuracy: pos.coords.accuracy,
+                altitude: pos.coords.altitude,
+                altitudeAccuracy: pos.coords.altitudeAccuracy,
+                timestamp: pos.timestamp,
+            };
+            setPosition(result);
+            setLoading(false);
+            options.onSuccess?.(pos);
+        };
+
+        const handleError = (err, didRetry) => {
+            let errorType = 'unavailable';
+            if (err.code === 1) errorType = 'denied';
+            if (err.code === 3) errorType = 'timeout';
+
+            // UX-23: si el primer intento high-accuracy timeoutea y el
+            // caller NO override enableHighAccuracy, reintentamos con
+            // low-accuracy. iPhones viejos / sin A-GPS funcionan así.
+            if (errorType === 'timeout' && !didRetry && options.enableHighAccuracy == null) {
+                navigator.geolocation.getCurrentPosition(
+                    success,
+                    (e2) => handleError(e2, true),
+                    buildConfig(false),
+                );
+                return;
+            }
+
+            setError(errorType);
+            setLoading(false);
+            options.onError?.(errorType);
         };
 
         navigator.geolocation.getCurrentPosition(
-            (pos) => {
-                const result = {
-                    lat: pos.coords.latitude,
-                    lon: pos.coords.longitude,
-                    accuracy: pos.coords.accuracy,
-                    altitude: pos.coords.altitude,
-                    altitudeAccuracy: pos.coords.altitudeAccuracy,
-                    timestamp: pos.timestamp
-                };
-                setPosition(result);
-                setLoading(false);
-                options.onSuccess?.(pos);
-            },
-            (err) => {
-                let errorType = 'unavailable';
-                if (err.code === 1) errorType = 'denied';
-                if (err.code === 3) errorType = 'timeout';
-
-                setError(errorType);
-                setLoading(false);
-                options.onError?.(errorType);
-            },
-            config
+            success,
+            (err) => handleError(err, false),
+            buildConfig(true),
         );
     }, []);
 


### PR DESCRIPTION
## Bug

Operador iPhone 2026-05-27: \"cuando doy clic en una propiedad caminar para registrarla el botón no funciona ni el de mi ubicación me devuelve\".

## Root cause

iOS Safari es estricto con geolocation; nuestro código asumía comportamiento Chrome desktop:
1. Timeout 15s agresivo — A-GPS iPhone cold-start tarda 20-60s. Botón timeouteaba silencioso sin retry.
2. `watchPosition(highAccuracy=true)` sin pre-flight de permiso se cuelga en iOS — ni success ni error.
3. Sin fallback `enableHighAccuracy=false` para iPhones viejos sin GPS asistido.
4. Mensajes de error genéricos sin guía iOS (\"Ajustes > Safari > Ubicación\").

## Fixes

**`src/hooks/useGeolocation.js`** (hook central, afecta a TODOS los callers AssetsDashboard / EvidenceCapture / WorkerDashboard):
- Timeout default 15s → 30s.
- Retry automático con `enableHighAccuracy=false` si el primer intento tira `code=3` (timeout).

**`src/components/MapPicker.jsx`** (\"Caminar\" + \"Mi ubicación\"):
- `toggleWalkRecording` ahora hace pre-flight `getCurrentPosition` para asegurar permiso antes de arrancar `watchPosition`. Sin esto iOS deja el watch colgado silente.
- Mensajes de error iOS-aware: \"Ajustes > Safari > Ubicación\", \"Sal al exterior y vuelve a intentar\".
- Timeout `watchPosition` 15s → 30s.
- Fallback `enableHighAccuracy=false` si pre-flight high-accuracy timeoutea.
- Fix de voseo: \"Podés marcar...\" → \"Puedes marcar...\".

## Tests

- 7 tests `hooks/__tests__/useGeolocation.ios.test.jsx`: timeout 30s, retry low-accuracy on timeout, NO retry si caller override, NO retry para errores no-timeout, mapping `err.code` → errorType, success path.
- ESLint clean `--max-warnings=0`.
- Auto-bump: `0.13.15 → 0.13.16`.

## Test plan

- [ ] Smoke iPhone Safari: \"Caminar\" en MapPicker → permite trazar polígono caminando con feedback de error claro si denegado.
- [ ] Smoke iPhone Safari: \"Mi ubicación\" en MapPicker → captura GPS con timeout 30s y reintenta low-accuracy si timeoutea.
- [ ] Smoke iPhone con ubicación denegada: ver mensaje \"En iPhone: Ajustes > Safari > Ubicación\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)