### PR TITLE
feat(ux): UX-27 — botón unificado "Agregar planta por voz" en TopBar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.15",
+  "version": "0.13.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v247';
+const CACHE_NAME = 'chagra-v248';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { CircleUser, Mic, Plus, ChevronDown, ChevronUp, Home, HelpCircle, LogOut } from 'lucide-react';
+import { CircleUser, Mic, Sprout, ChevronDown, ChevronUp, Home, HelpCircle, LogOut } from 'lucide-react';
 import { version as APP_VERSION } from '../../package.json';
 import EnvironmentalCard from './EnvironmentalCard';
 import AltitudeBadge from './AltitudeBadge';
@@ -132,21 +132,43 @@ export default function TopBar({ onNavigate, onLogout }) {
         >
           <HelpCircle size={24} aria-hidden="true" strokeWidth={2.5} />
         </button>
+        {/* UX-27 (#286) 2026-05-27: botón unificado "Agregar planta por
+            voz". Reemplaza los dos botones previos (Mic solo + Plus solo)
+            que eran:
+              - Mic → onNavigate('voz')         → captura genérica por voz
+              - Plus → onNavigate('plant_asset') → form planta manual
+            Ambos llevaban al MISMO flow de fondo (registro de planta),
+            solo cambiaba la modalidad. Feedback operador 2026-05-27:
+            "borra el + en su lugar mejora el del micrófono con un icono
+            de + y una planta o algo lindo que le permita inferir que es
+            para agregar una planta con voz".
+
+            Diseño:
+              - Mic (lime) como icono principal — comunica "voz".
+              - Sprout decorativo abajo-derecha — comunica "planta".
+              - Halo lime sutil + bg degrado de lime-900/40 → emerald-900/40
+                para que destaque del resto de iconos slate.
+              - Tamaño botón mantenido en 44x44 (touch target iOS).
+              - aria-label explícito "Agregar planta por voz".
+              - Navega a 'voz' (el flow de voz YA permite registrar
+                plantas; ver VoiceCapture + VoiceConfirmation). */}
         <button
           type="button"
           onClick={() => onNavigate('voz')}
-          aria-label="Captura por voz"
-          className="p-2 rounded-lg bg-slate-800/60 hover:bg-slate-700/60 active:bg-slate-700 text-lime-400 min-h-[44px] min-w-[44px] flex items-center justify-center"
+          aria-label="Agregar planta por voz"
+          title="Agregar planta por voz"
+          data-testid="topbar-add-plant-voice"
+          className="relative p-2 rounded-lg bg-gradient-to-br from-lime-900/40 to-emerald-900/30 hover:from-lime-800/50 hover:to-emerald-800/40 active:from-lime-700/60 active:to-emerald-700/50 border border-lime-700/50 text-lime-300 min-h-[44px] min-w-[44px] flex items-center justify-center shadow-[0_0_0_1px_rgba(132,204,22,0.15)]"
         >
-          <Mic size={20} aria-hidden="true" />
-        </button>
-        <button
-          type="button"
-          onClick={() => onNavigate('plant_asset')}
-          aria-label="Capturar planta"
-          className="p-2 rounded-lg bg-slate-800/60 hover:bg-slate-700/60 active:bg-slate-700 text-purple-400 min-h-[44px] min-w-[44px] flex items-center justify-center"
-        >
-          <Plus size={22} aria-hidden="true" strokeWidth={2.5} />
+          <Mic size={20} aria-hidden="true" strokeWidth={2.25} />
+          {/* Sprout decorativo abajo-derecha, sobre un disco oscuro para
+              que se lea claro sobre el fondo del Mic + del header. */}
+          <span
+            aria-hidden="true"
+            className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full bg-slate-950 border border-lime-600/60 flex items-center justify-center"
+          >
+            <Sprout size={10} className="text-emerald-400" strokeWidth={2.5} />
+          </span>
         </button>
         {/* Botón Settings (icono ⚙) eliminado, Feedback piloto #115: era duplicado del
             botón operator name de arriba (ambos onNavigate('perfil')). El

--- a/src/components/__tests__/TopBar.voicePlant.test.jsx
+++ b/src/components/__tests__/TopBar.voicePlant.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TopBar from '../TopBar';
+
+/**
+ * Tests para UX-27 (#286): operador 2026-05-27 — "en la parte de arriba
+ * borra el + en su lugar mejora el de micrófono con un icono de + y una
+ * planta o algo lindo que le permita inferir que es para agregar una
+ * planta con voz".
+ *
+ * Verifica:
+ *   - El botón solo del + (onNavigate='plant_asset') YA NO existe.
+ *   - El botón con icono Mic + decoración Sprout existe.
+ *   - aria-label "Agregar planta por voz" para screenreaders.
+ *   - Tap navega a 'voz' (el flow de voz YA permite registrar plantas).
+ *   - Touch target 44x44 (iOS minimum).
+ */
+
+// Mocks: EnvironmentalCard / AltitudeBadge / OfflineChip son sub-componentes
+// pesados o que tocan store global. No nos importan para este test.
+vi.mock('../EnvironmentalCard', () => ({ default: () => <div data-testid="env-stub" /> }));
+vi.mock('../AltitudeBadge', () => ({ default: () => <div data-testid="alt-stub" /> }));
+vi.mock('../OfflineChip', () => ({ default: () => <div data-testid="chip-stub" /> }));
+
+describe('UX-27 — TopBar botón unificado voz+planta', () => {
+  let onNavigate;
+  let onLogout;
+
+  beforeEach(() => {
+    onNavigate = vi.fn();
+    onLogout = vi.fn();
+  });
+
+  it('existe un único botón de captura ("Agregar planta por voz")', () => {
+    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
+    const btn = screen.getByTestId('topbar-add-plant-voice');
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('aria-label', 'Agregar planta por voz');
+  });
+
+  it('NO existe el botón Plus solo que navegaba a plant_asset', () => {
+    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
+    // El antiguo aria-label "Capturar planta" debe haber desaparecido.
+    expect(screen.queryByLabelText(/^Capturar planta$/i)).toBeNull();
+    // Y el antiguo "Captura por voz" tambien — fue reemplazado por el copy nuevo.
+    expect(screen.queryByLabelText(/^Captura por voz$/i)).toBeNull();
+  });
+
+  it('al tocar el botón navega a "voz" (flow de voz registra planta)', () => {
+    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
+    fireEvent.click(screen.getByTestId('topbar-add-plant-voice'));
+    expect(onNavigate).toHaveBeenCalledWith('voz');
+    // NO debe navegar al form manual.
+    expect(onNavigate).not.toHaveBeenCalledWith('plant_asset');
+  });
+
+  it('cumple touch target iOS 44x44', () => {
+    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
+    const btn = screen.getByTestId('topbar-add-plant-voice');
+    expect(btn.className).toMatch(/min-h-\[44px\]/);
+    expect(btn.className).toMatch(/min-w-\[44px\]/);
+  });
+
+  it('tiene title accesible para tooltip desktop', () => {
+    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
+    const btn = screen.getByTestId('topbar-add-plant-voice');
+    expect(btn).toHaveAttribute('title', 'Agregar planta por voz');
+  });
+});


### PR DESCRIPTION
## Bug

Operador 2026-05-27: \"en la parte de arriba borra el + en su lugar mejora el del micrófono con un icono de + y una planta o algo lindo que le permita inferir que es para agregar una planta con voz\".

Los dos botones (Mic solo + Plus solo) llevaban al mismo flow de fondo (registro de planta) — eran redundantes y no comunicaban su propósito.

## Solución

- **ELIMINADO** botón Plus que navegaba a 'plant_asset' (form manual).
- **REDISEÑADO** botón Mic → botón único \"Agregar planta por voz\":
  - `Mic` (lime) icono principal — voz.
  - `Sprout` decorativo superpuesto abajo-derecha sobre disco oscuro con borde lime — planta.
  - Fondo gradiente `lime-900/40 → emerald-900/30` + halo sutil para destacar del resto.
  - `aria-label=\"Agregar planta por voz\"` + `title` para tooltip.
  - Touch target 44x44 preservado.
- Navega a `'voz'` — el flow VoiceCapture/VoiceConfirmation ya permite registrar plantas hands-free.

## Tests

- 5 tests en `TopBar.voicePlant.test.jsx`: botón único existe con aria correcto, antiguos botones eliminados, tap navega a voz (no plant_asset), touch target 44x44, title presente.
- ESLint clean.

## Test plan

- [ ] Smoke iPhone: ver el botón mic con sprout decorativo en top-right del header.
- [ ] Smoke: tap → abre captura por voz.
- [ ] Smoke: el icono Plus solitario YA NO existe en el header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)