### PR TITLE
feat(ux): UX-25 — SeedingLog usa PhotoCaptureField (igual a invasoras)

### DIFF
--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { ArrowLeft, AlertCircle, Camera, Image as ImageIcon, MapPin, CheckCircle } from 'lucide-react';
+import { ArrowLeft, AlertCircle, MapPin, CheckCircle } from 'lucide-react';
 import { savePayload } from '../services/payloadService';
-import { captureAndCompress, savePhoto } from '../services/photoService';
-import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
-import { sanitizeBlobUrl } from '../utils/blobUrl';
+import { savePhoto } from '../services/photoService';
 import DateField from './DateField';
+import PhotoCaptureField from './PhotoCaptureField';
 import { getAllSpecies } from '../db/catalogDB';
 import { extractVarieties, varietyHelpText } from '../utils/speciesVariety';
 
@@ -21,8 +20,11 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
     variety: initialData.variety || '',
     quantity: initialData.quantity || ''
   });
+  // UX-25 (#286) 2026-05-27: SeedingLog ahora usa PhotoCaptureField (mismo
+  // componente bonito que InvasiveObservationLog). Mantenemos solo el
+  // estado photo (blob); el preview/retake/remove/compresión lo maneja
+  // PhotoCaptureField internamente. photoUrl ya NO se usa.
   const [photo, setPhoto] = useState(null);
-  const [photoUrl, setPhotoUrl] = useState(null);
   const [isRecording, setIsRecording] = useState(false);
   const [coordinates, setCoordinates] = useState(initialData.coordinates ? [initialData.coordinates] : []);
   const [notes, setNotes] = useState(initialData.notes || '');
@@ -97,48 +99,11 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
       if (watchIdRef.current !== null) {
         navigator.geolocation.clearWatch(watchIdRef.current);
       }
-      if (photoUrl) URL.revokeObjectURL(photoUrl);
     };
-  }, [photoUrl]);
+  }, []);
 
   const handleInput = (e) => {
     setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
-  };
-
-  const cameraInputRef = useRef(null);
-  const galleryInputRef = useRef(null);
-
-  const handlePhotoCapture = async (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-    if (!file.type.startsWith('image/')) {
-      onSave('Archivo no es una imagen válida', true);
-      return;
-    }
-    try {
-      // Pre-compresión cliente-lado (operador 2026-05-27): 1600 px / JPEG 0.85
-      // → fallback 0.7 → reject > 2 MB.
-      const preCompressed = await compressImage(file);
-      if (!preCompressed.ok) {
-        if (preCompressed.reason === 'too_large') {
-          window.dispatchEvent(new CustomEvent('chagraToast', {
-            detail: { message: IMAGE_TOO_LARGE_MESSAGE },
-          }));
-        } else {
-          onSave('Error procesando foto', true);
-        }
-        return;
-      }
-      const { blob } = await captureAndCompress(preCompressed.blob);
-      setPhoto(blob);
-      if (photoUrl) URL.revokeObjectURL(photoUrl);
-      setPhotoUrl(URL.createObjectURL(blob));
-    } catch (err) {
-      console.error('Error comprimir foto:', err);
-      onSave('Error procesando foto', true);
-    } finally {
-      if (e.target) e.target.value = '';
-    }
   };
 
   const toggleRecording = () => {
@@ -238,8 +203,8 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
 
       setFormData({ date: new Date().toISOString().split('T')[0], crop: '', variety: '', quantity: '' });
       setPhoto(null);
-      if (photoUrl) URL.revokeObjectURL(photoUrl);
-      setPhotoUrl(null);
+      // UX-25: PhotoCaptureField maneja su preview/ObjectURL internamente
+      // — no necesitamos revoke manual acá.
       setCoordinates([]);
       setTimeout(() => onBack(), 500);
     } catch (error) {
@@ -294,36 +259,20 @@ export default function SeedingLog({ onBack, onSave, initialData = {} }) {
       </header>
 
       <div className="flex-1 p-5 flex flex-col gap-6 pb-24">
-        {/* Hero foto, primer paso del flujo (DR-030 QW3) */}
+        {/* UX-25 (#286) 2026-05-27: hero foto unificado vía
+            PhotoCaptureField — mismo componente bonito que usa
+            InvasiveObservationLog. Operador pidió "que el botón sea
+            igual al de especies invasoras". El componente maneja
+            internamente: dual cámara/galería, preview, re-tomar,
+            eliminar, compresión iterativa y error states. */}
         <div className="flex flex-col gap-2">
           <span className="text-xl font-bold">Foto de la planta</span>
-          {/* Dual capture (2026-05-27): cámara con capture="environment" +
-              galería. La preview vive arriba; los botones abajo. */}
-          {sanitizeBlobUrl(photoUrl) && (
-            <div className="relative w-full h-40 rounded-xl overflow-hidden border-2 border-slate-700">
-              <img src={sanitizeBlobUrl(photoUrl)} alt="Preview" className="absolute inset-0 w-full h-full object-cover" />
-            </div>
-          )}
-          <input ref={cameraInputRef} type="file" accept="image/*" capture="environment" onChange={handlePhotoCapture} className="hidden" />
-          <input ref={galleryInputRef} type="file" accept="image/*" onChange={handlePhotoCapture} className="hidden" />
-          <div className="grid grid-cols-2 gap-2">
-            <button
-              type="button"
-              onClick={() => cameraInputRef.current?.click()}
-              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-emerald-900/40 border-2 border-emerald-700/60 text-emerald-100 active:bg-emerald-800/60"
-            >
-              <Camera size={28} />
-              <span>{photo ? 'Cambiar' : 'Tomar foto'}</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => galleryInputRef.current?.click()}
-              className="p-4 rounded-xl text-lg font-bold flex justify-center items-center gap-2 shadow-md min-h-[80px] bg-slate-800 border-2 border-slate-600 active:bg-slate-700"
-            >
-              <ImageIcon size={28} />
-              <span>Subir desde galería</span>
-            </button>
-          </div>
+          <PhotoCaptureField
+            value={photo}
+            onPhoto={(blob) => setPhoto(blob)}
+            onRemove={() => setPhoto(null)}
+            label="Foto del cultivo"
+          />
         </div>
 
         <DateField

--- a/src/components/__tests__/SeedingLog.photoButton.test.jsx
+++ b/src/components/__tests__/SeedingLog.photoButton.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SeedingLog from '../SeedingLog';
+
+/**
+ * Tests para UX-25 (#286): operador 2026-05-27 — "en siembras el botón
+ * agregar y tomar foto debe ser igual al de especies invasoras".
+ *
+ * Verifica que SeedingLog ahora usa PhotoCaptureField (mismo componente
+ * que InvasiveObservationLog) — vs el manual inline grid que tenía
+ * antes.
+ */
+
+// Mock pesado de servicios externos no relevantes al smoke.
+vi.mock('../../services/payloadService', () => ({
+  savePayload: vi.fn().mockResolvedValue({ success: true, message: 'ok' }),
+}));
+vi.mock('../../services/photoService', () => ({
+  savePhoto: vi.fn(),
+}));
+
+// Mock de PhotoCaptureField para verificar que SeedingLog lo monta
+// con los props correctos (sin necesidad de simular cámara real).
+vi.mock('../PhotoCaptureField', () => ({
+  default: (props) => (
+    <div
+      data-testid="photo-capture-field-stub"
+      data-label={props.label}
+      data-has-onphoto={typeof props.onPhoto === 'function' ? 'yes' : 'no'}
+      data-has-onremove={typeof props.onRemove === 'function' ? 'yes' : 'no'}
+    />
+  ),
+}));
+
+describe('UX-25 — SeedingLog usa PhotoCaptureField', () => {
+  it('monta PhotoCaptureField (mismo componente que invasoras)', () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByTestId('photo-capture-field-stub')).toBeInTheDocument();
+  });
+
+  it('pasa onPhoto y onRemove como callbacks', () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    const stub = screen.getByTestId('photo-capture-field-stub');
+    expect(stub.dataset.hasOnphoto).toBe('yes');
+    expect(stub.dataset.hasOnremove).toBe('yes');
+  });
+
+  it('pasa label "Foto del cultivo"', () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    const stub = screen.getByTestId('photo-capture-field-stub');
+    expect(stub.dataset.label).toBe('Foto del cultivo');
+  });
+
+  it('NO renderiza los antiguos botones manuales "Tomar foto" / "Subir desde galería"', () => {
+    render(<SeedingLog onBack={() => {}} onSave={() => {}} />);
+    // El botón manual antiguo tenía esos textos directos. Como ahora
+    // PhotoCaptureField está stubeado, no deben aparecer en el render
+    // de SeedingLog directamente.
+    expect(screen.queryByText('Subir desde galería')).toBeNull();
+    // El "Tomar foto" puede aparecer en otros contextos; verificamos
+    // específicamente que NO hay un button con onClick directo a un
+    // cameraInputRef (el patrón viejo).
+    const buttons = screen.queryAllByRole('button');
+    const oldStyle = buttons.find((b) =>
+      b.textContent?.includes('Subir desde galería') ||
+      b.querySelector('input[type="file"]'),
+    );
+    expect(oldStyle).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Operador 2026-05-27: \"en siembras el botón agregar y tomar foto debe ser igual al de especies invasoras\".

`SeedingLog` tenía un bloque manual feo de captura (refs + handler propio + preview inline + grid de botones tosco). InvasiveObservationLog ya tenía un componente pulido `PhotoCaptureField` que es lo que pidió el operador.

## Cambios

- `SeedingLog.jsx` ahora monta `<PhotoCaptureField>` — el mismo componente que usa `InvasiveObservationLog`.
- El componente maneja dual cámara/galería, preview con checkmark overlay, re-tomar / eliminar, compresión iterativa, estados de loading + error, y warm-up del modelo de visión en background.
- Imports residuales eliminados (Camera, ImageIcon, compressImage, sanitizeBlobUrl, IMAGE_TOO_LARGE_MESSAGE).
- Estado `photoUrl` + revoke manual eliminados — PhotoCaptureField maneja su ciclo de vida.

## Tests

- 4 tests en `SeedingLog.photoButton.test.jsx`: monta PhotoCaptureField, pasa onPhoto/onRemove, propaga label, no quedan rastros del antiguo botón manual.
- ESLint clean.

## Test plan

- [ ] Smoke iPhone: registrar siembra → ver el mismo bloque de foto que en \"Reportar invasora\" (dos cards grandes — cámara verde + galería gris).
- [ ] Smoke: tomar foto → ver el preview con checkmark verde + botones de re-tomar / eliminar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)