### PR TITLE
feat(ux): UX-16 — gremio condicional urbano (balcón/terraza/matera)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.18",
+  "version": "0.13.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v250';
+const CACHE_NAME = 'chagra-v251';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1025,13 +1025,32 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
         );
       })()}
 
-      {/* Gremio / Función en el sistema */}
-      <div className="space-y-1.5">
+      {/* UX-16 (#286) 2026-05-27: gremio condicional urbano. La jerga
+          "fijador de nitrógeno", "atrayente de polinizadores",
+          "productor de biomasa" es agroecología de sistemas grandes —
+          no aplica a balcón / matera / ventana. Si la zona parent es
+          urbana, ocultamos el bloque entero (mismo patrón que UX-15
+          hizo para Capa del cultivo). */}
+      {(() => {
+        const parentLand = formData.parentLandId
+          ? lands.find((l) => l.id === formData.parentLandId)
+          : null;
+        const parentLandType = parentLand?.attributes?.land_type;
+        if (isUrbanLandType(parentLandType)) {
+          return (
+            <p className="text-xs text-slate-500 italic px-1" data-testid="gremio-hidden-urban">
+              Zona urbana: no necesitas indicar función ecológica.
+            </p>
+          );
+        }
+        return (
+      <div className="space-y-1.5" data-testid="gremio-field">
         <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">Gremio / Función ecológica</label>
         <div className="flex flex-wrap gap-1.5">
           {GREMIO_OPTIONS.map(opt => (
             <button
               key={opt.value}
+              type="button"
               onClick={() => setFormData({ ...formData, gremio: formData.gremio === opt.value ? '' : opt.value })}
               className={`text-xs px-3 py-2 rounded-full transition-all active:scale-95 min-h-[36px] ${formData.gremio === opt.value
                 ? 'bg-lime-600/30 text-lime-300 border border-lime-500 font-bold'
@@ -1043,6 +1062,8 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
           ))}
         </div>
       </div>
+        );
+      })()}
 
       {/* Cantidad de plantas (ADR-030: visible/editable según tracking_mode).
           - aggregate: input grande prominente (cama corrida, qty=N en 1 asset)

--- a/src/components/__tests__/AssetsDashboard.urbanForm.test.jsx
+++ b/src/components/__tests__/AssetsDashboard.urbanForm.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Tests para UX-16 (#286): form planta condicional cuando la zona parent
+ * es URBANA (balcón/terraza/ventana/matera/jardín urbano).
+ *
+ * UX-15 ya ocultó "Capa del cultivo" en contexto urbano. UX-16 extiende
+ * el patrón a "Gremio / Función ecológica" — jerga agroecológica que no
+ * aplica a balcón / matera.
+ *
+ * Como AssetsDashboard es un componente gigante con muchos stores y mocks
+ * complejos, validamos via source introspection (mismo patrón que
+ * estratoCopy.test.jsx para UX-15) que las dos condicionales urbanas
+ * existan: estrato + gremio.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SOURCE = readFileSync(
+  resolve(__dirname, '..', 'AssetsDashboard.jsx'),
+  'utf-8',
+);
+
+describe('UX-16 — gremio condicional urbano', () => {
+  it('source declara data-testid="gremio-hidden-urban" (fallback urbano)', () => {
+    expect(SOURCE).toContain('data-testid="gremio-hidden-urban"');
+  });
+
+  it('source declara data-testid="gremio-field" (campo normal)', () => {
+    expect(SOURCE).toContain('data-testid="gremio-field"');
+  });
+
+  it('copy del fallback urbano dice "no necesitas indicar función ecológica"', () => {
+    expect(SOURCE).toMatch(/Zona urbana:\s*no necesitas indicar función ecológica/);
+  });
+
+  it('mantiene el patrón análogo a UX-15 (estrato condicional urbano)', () => {
+    // Las dos guardas urbanas deben coexistir.
+    expect(SOURCE).toContain('data-testid="estrato-hidden-urban"');
+    expect(SOURCE).toContain('data-testid="gremio-hidden-urban"');
+  });
+
+  it('helper isUrbanLandType viene del módulo canónico utils/landTypes', () => {
+    expect(SOURCE).toMatch(/import\s*\{[^}]*isUrbanLandType[^}]*\}\s*from\s*'\.\.\/utils\/landTypes'/);
+  });
+});


### PR DESCRIPTION
## Summary

Extiende el patrón urbano de UX-15 (Capa del cultivo) al campo \"Gremio / Función ecológica\". La jerga agroecológica (\"fijador de nitrógeno\", \"atrayente de polinizadores\", \"productor de biomasa\") no aplica a balcón / matera / ventana / jardín urbano.

## Cambios

- `AssetsDashboard.jsx`: bloque GREMIO envuelto en IIFE condicional con `isUrbanLandType` (del módulo canónico `utils/landTypes`).
  - Si urbano: \"Zona urbana: no necesitas indicar función ecológica\" con `data-testid=\"gremio-hidden-urban\"`.
  - Si no urbano: render normal con `data-testid=\"gremio-field\"`.
- Agregado `type=\"button\"` al botón del gremio (evita submit accidental).

## Tests

- 5 tests en `AssetsDashboard.urbanForm.test.jsx` via source introspection (patrón ya usado por UX-15).
- ESLint clean.

## Test plan

- [ ] Smoke: registrar planta en zona tipo \"Balcón\" → el bloque Gremio NO aparece (queda nota neutra).
- [ ] Smoke: registrar planta en zona tipo \"Lote\" → el bloque Gremio aparece normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)