### PR TITLE
fix(piloto): voseo + inventario directo + toast position pre-amigos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.19",
+  "version": "0.13.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.20",
+  "version": "0.13.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v252';
+const CACHE_NAME = 'chagra-v253';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v251';
+const CACHE_NAME = 'chagra-v252';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -517,7 +517,8 @@ export default function App() {
         <div
           role={toast.isError ? 'alert' : 'status'}
           aria-live={toast.isError ? 'assertive' : 'polite'}
-          className={`fixed bottom-8 left-1/2 -translate-x-1/2 p-4 rounded-xl shadow-2xl flex items-center gap-3 z-50 w-11/12 max-w-md border-2 pb-[max(2rem,env(safe-area-inset-bottom))] pointer-events-none ${toast.isError ? 'bg-amber-700 border-amber-500' : 'bg-green-700 border-green-500'}`}
+          className={`fixed left-1/2 -translate-x-1/2 p-4 rounded-xl shadow-2xl flex items-center gap-3 z-[100] w-11/12 max-w-md border-2 pointer-events-none ${toast.isError ? 'bg-amber-700 border-amber-500' : 'bg-green-700 border-green-500'}`}
+          style={{ bottom: 'calc(96px + env(safe-area-inset-bottom))' }}
         >
           {toast.isError ? <WifiOff size={28} className="shrink-0" aria-hidden="true" /> : <CheckCircle size={28} className="shrink-0" aria-hidden="true" />}
           <p className="text-base font-bold text-white leading-tight flex-1">{toast.message}</p>

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -196,7 +196,7 @@ export default function AgentScreen({ onBack }) {
       if (lastTurn && lastTurn.role === 'user') {
         history.push({
           role: 'assistant',
-          content: 'No alcancé a responderte la anterior. ¿Querés que lo intente de nuevo?',
+          content: 'No alcancé a responderte la anterior. ¿Quieres que lo intente de nuevo?',
           timestamp: Date.now(),
           _orphan_recovery: true,
           _orphan_prompt: lastTurn.content || '',
@@ -385,7 +385,13 @@ export default function AgentScreen({ onBack }) {
     // EXACTA esperada (no reconozco el término) en 27 tokens / 8s.
     return `Eres Chagra IA, un asistente agroecológico colombiano. ${fincaContext}${indoorContext}El usuario tiene estas plantas agrupadas por especie con su conteo: ${plantNames}.
 
-REGLA DE FORMATO: cuando hables de las plantas del usuario, agrupá por especie y di cuántas tiene (ej. "tienes 15 fresas, 4 caléndulas, 1 tomate cherry"). NUNCA listes los números individuales de cada planta (#01, #02, etc.) — son identificadores internos, no info útil para el operador. Habla como agrónomo experimentado, no como sistema.
+REGLA DE FORMATO: cuando hables de las plantas del usuario, agrupa por especie y di cuántas tiene (ej. "tienes 15 fresas, 4 caléndulas, 1 tomate cherry"). NUNCA listes los números individuales de cada planta (#01, #02, etc.) — son identificadores internos, no info útil para el operador. Habla como agrónomo experimentado, no como sistema.
+
+REGLA INVENTARIO-DIRECTO: cuando el usuario pregunte literalmente por su inventario ("tengo X registrado/registrada", "tengo X", "ya tengo X", "cuántos X tengo", "tengo tomates", "tengo café", "mis plantas", "qué plantas tengo", "mi finca", "mi cultivo"), responde DIRECTAMENTE con el inventario de arriba. NO le digas "ingresa al sistema y revisa la lista" — TÚ tienes el inventario en este mismo contexto. Ejemplos:
+✓ User: "ya tengo tomates registrados?" → "Sí, tienes 1 tomate cherry (Solanum lycopersicum) en tu finca." (si plantNames contiene tomate)
+✓ User: "ya tengo tomates registrados?" → "No, todavía no tienes tomates registrados. ¿Quieres agregar uno desde la sección Mi Finca?" (si plantNames NO contiene tomate)
+✗ MAL: "Para verificar si ya tienes tomates registrados en tu sistema, debes ingresar al área correspondiente y buscar la sección de cultivos..." (NO redirijas al usuario a buscarlo — el inventario YA está en este contexto).
+Si plantNames es "ninguna", díselo claramente: "No tienes plantas registradas aún. ¿Te ayudo a registrar la primera?".
 
 REGLA NO-PREAMBULAR-INVENTARIO: el inventario de plantas del usuario te lo doy de contexto SOLO para que puedas hablar de "tus 15 fresas" cuando el usuario PREGUNTE explícitamente por sus plantas (qué tengo, cuántas plantas, mis plantas, mi finca, mi cultivo). NUNCA preambules una respuesta con "Usted tiene X plantas..." si el usuario está preguntando otra cosa.
 

--- a/src/components/FieldFeedback.jsx
+++ b/src/components/FieldFeedback.jsx
@@ -321,11 +321,11 @@ export default function FieldFeedback({ embedded = false } = {}) {
               <div className="text-sm text-slate-300 leading-relaxed mb-1 space-y-2">
                 <p>
                   ¿Algo del agente te respondió raro, viste información errónea
-                  o algo no se comporta como esperás?
+                  o algo no se comporta como esperas?
                 </p>
                 <p>
-                  <strong>Grabá un audio</strong> contando qué hiciste y qué fue lo
-                  raro (es más rápido que tipear en el campo). Si querés adjuntar
+                  <strong>Graba un audio</strong> contando qué hiciste y qué fue lo
+                  raro (es más rápido que tipear en el campo). Si quieres adjuntar
                   el contexto en texto también, mejor todavía. Cada reporte ayuda
                   a hacer Chagra más poderoso.
                 </p>

--- a/src/components/VoiceConfirmation.jsx
+++ b/src/components/VoiceConfirmation.jsx
@@ -230,11 +230,22 @@ export default function VoiceConfirmation({
       </section>
 
       {rows.length === 0 && (
-        <div className="bg-amber-900/20 border border-amber-800/50 rounded-xl p-4 flex items-start gap-2">
-          <AlertTriangle size={18} className="text-amber-400 shrink-0 mt-0.5" />
-          <p className="text-sm text-amber-200">
-            No se extrajo ninguna entidad. Cancela y repite el registro con una frase más clara.
-          </p>
+        <div className="bg-amber-900/20 border border-amber-800/50 rounded-xl p-4 flex flex-col gap-3">
+          <div className="flex items-start gap-2">
+            <AlertTriangle size={18} className="text-amber-400 shrink-0 mt-0.5" />
+            <div className="text-sm text-amber-200 space-y-2">
+              <p className="font-bold">No alcancé a identificar el cultivo o la cantidad en tu audio.</p>
+              <p className="text-amber-200/80">
+                Revisa la transcripción arriba. Si Chagra escuchó bien pero el cultivo es una variedad nueva o regional (ej. una cepa específica, una variedad local), todavía no la tengo en mi catálogo.
+              </p>
+              <p className="text-amber-200/80">Tienes 3 opciones:</p>
+              <ul className="list-disc pl-5 space-y-1 text-amber-200/80">
+                <li><strong>Agregar manual abajo</strong>: toca el botón "+" y escribe el cultivo + cantidad directamente.</li>
+                <li><strong>Re-grabar más simple</strong>: cierra esto y vuelve a grabar diciendo solo el nombre común (ej. "5 plantas de tomate") sin variedades.</li>
+                <li><strong>Cancelar</strong>: si era una prueba o no querías registrar nada.</li>
+              </ul>
+            </div>
+          </div>
         </div>
       )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -13,7 +13,13 @@
     margin: 0;
     min-width: 320px;
     min-height: 100vh;
-    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    /* Safe-area: dejamos que cada componente top-of-screen (TopBar,
+     * DataLossBanner, NetworkStatusBar) maneje su propio padding-top
+     * con env(safe-area-inset-top). Aplicarlo aquí EN ADICIÓN duplica
+     * el espacio en iPhone con Dynamic Island / notch — visible como
+     * banda muerta arriba en PWA standalone. Solo padding lateral +
+     * bottom para que el body llegue al borde físico. */
+    padding: 0 env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
     background-color: #020617; /* slate-950 default, evita flash blanco antes de aplicar bg */
   }
 

--- a/src/services/llmGuardrails.js
+++ b/src/services/llmGuardrails.js
@@ -40,7 +40,7 @@ REGLAS DURAS:
 5. Tono "tú" cercano colombiano en todas las respuestas.
 6. CONCISIÓN OBLIGATORIA: responde en MÁXIMO 30 palabras o 2 oraciones.
    La voz de Chagra es agronómica directa, no académica. Si necesitas
-   detalle adicional, terminá con "¿Querés que profundice en X?" para que
+   detalle adicional, termina con "¿Quieres que profundice en X?" para que
    el operador pida más, en vez de soltar toda la información de una.
    (Razón técnica: TTS local es CPU, latencia escala lineal con caracteres
    de salida — 30 palabras ≈ 3s, 150 palabras ≈ 23s; experiencia del


### PR DESCRIPTION
## Bugs detectados con rookiecol piloto 2026-05-27

### 1. Voseo argentino en banner retry
- `AgentScreen.jsx:199`: "Querés que lo intente de nuevo?" → "Quieres..."
- `llmGuardrails.js:43`: "terminá con ¿Querés..." → "termina con ¿Quieres..."
- `FieldFeedback.jsx:323-328`: "esperás / grabá / querés" → "esperas / graba / quieres"

Memoria operador `feedback-spanish-dialect`: tú/usted colombiano, no vos.

### 2. Inventario directo
Bug visto en vivo: user `rookiecol` preguntó *"ya tengo tomates registrados?"* (con su tomate cherry ya seedeado) y el agente respondió *"Para verificar si ya tienes tomates registrados en tu sistema, debes ingresar al área correspondiente y buscar la sección de cultivos..."* — remitió al usuario a buscar en el UI cuando el inventario YA estaba en el system prompt.

Causa: regla `NO-PREAMBULAR-INVENTARIO` era demasiado restrictiva y el modelo prefería remitir al usuario al UI por seguridad.

Fix: añadir regla afirmativa `INVENTARIO-DIRECTO` con ejemplos ✓/✗ y matching por keywords (`tengo`, `ya tengo`, `registrado`, `mis plantas`, `qué tengo`, `mi finca`).

### 3. Toast vs FABs overlap
Bug del operador: toasts se sobreponen con MicFab/AgentFab en zona inferior.

- Toast estaba en `bottom-8` (32px) chocando con FABs en `bottom: 18px + safe-area`.
- Sube toast a `bottom: calc(96px + env(safe-area-inset-bottom))` para libre interacción con FABs.
- z-50 → z-[100] para asegurar stacking sobre los FABs.

### Pendientes
- Voice modal overlap con barra de tareas: falta screenshot del operador para diagnosticar cuál modal exactamente.
- Layout system unified para toasts (sistema de stack tipo react-hot-toast) — sigue como deuda técnica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)