### PR TITLE
feat(home): saludo regional dinámico Colombia (#196)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.21",
+  "version": "0.13.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v253';
+const CACHE_NAME = 'chagra-v254';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -57,6 +57,7 @@ const HelpManual = lazy(() => import('./components/HelpManual'));
 const OnboardingHero = lazy(() => import('./components/OnboardingHero'));
 const WelcomeStatsHero = lazy(() => import('./components/WelcomeStatsHero'));
 const TopBar = lazy(() => import('./components/TopBar'));
+import HomeRegionalGreeting from './components/HomeRegionalGreeting';
 
 localforage.config({
   name: 'Chagra',
@@ -152,6 +153,7 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
           2026-05-18: wrapper translúcido (bg-slate-950/82) para que se vea
           la imagen de fondo agroecológica aplicada al body en App.jsx. */}
       <TopBar onNavigate={onNavigate} onLogout={onLogout} />
+      <HomeRegionalGreeting />
 
       {/* Feedback piloto #116: estadísticas al header (siempre visibles).
           Antes: el bloque assetCounts vivía dentro del <main scrollable>,

--- a/src/components/HomeRegionalGreeting.jsx
+++ b/src/components/HomeRegionalGreeting.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { X, Sun, Sunset, Moon } from 'lucide-react';
+import useFincaActiveStore from '../services/fincaActiveStore';
+
+const ZONE_GREETINGS = {
+    andino_alto_páramo: 'Buenas, sumercé. Frío de páramo hoy. Lo del día en tu chagra…',
+    andino_alto: 'Buenas, sumercé. Frío andino hoy. Lo del día en tu chagra…',
+    andino_medio: 'Buenas, mijo. Clima andino templado. Lo del día en tu chagra…',
+    valle_caucano: 'Hola, ¿qué más, mijo? Lo del día en tu chagra del valle…',
+    caribe: '¡Qué calor caribe, mi llave! Lo del día en tu chagra…',
+    pacifico: 'Hola, compa. Lluvia pacífica como siempre. Lo del día en tu chagra…',
+    llanos: 'Buenas, vecino llanero. Lo del día en tu chagra…',
+    amazonia: 'Lo del día en la selva, panita…',
+};
+
+const DEFAULT_GREETING = 'Hola, lo del día en tu chagra…';
+
+const STORAGE_KEY = 'chagra:home-greeting-dismissed:v1';
+
+function dismissedToday() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return false;
+        const stored = new Date(raw);
+        const today = new Date();
+        return stored.toDateString() === today.toDateString();
+    } catch {
+        return false;
+    }
+}
+
+function dayPeriod() {
+    const h = new Date().getHours();
+    if (h < 12) return 'morning';
+    if (h < 18) return 'afternoon';
+    return 'night';
+}
+
+const PERIOD_STYLES = {
+    morning: { bg: 'bg-lime-900/40 border-lime-700/40 text-lime-100', Icon: Sun },
+    afternoon: { bg: 'bg-amber-900/40 border-amber-700/40 text-amber-100', Icon: Sunset },
+    night: { bg: 'bg-slate-800/80 border-slate-700/40 text-slate-200', Icon: Moon },
+};
+
+export default function HomeRegionalGreeting() {
+    const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
+    const fincas = useFincaActiveStore((s) => s.fincas);
+    const [dismissed, setDismissed] = useState(() => dismissedToday());
+
+    useEffect(() => {
+        const onStorage = () => setDismissed(dismissedToday());
+        window.addEventListener('storage', onStorage);
+        return () => window.removeEventListener('storage', onStorage);
+    }, []);
+
+    if (dismissed) return null;
+
+    const finca = (fincas || []).find((f) => f.slug === activeFincaSlug);
+    const zone = finca?.biocultural_zone;
+    const greeting = (zone && ZONE_GREETINGS[zone]) || DEFAULT_GREETING;
+    const period = dayPeriod();
+    const { bg, Icon } = PERIOD_STYLES[period];
+
+    function handleDismiss() {
+        try {
+            localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+        } catch {
+            // private mode / quota — silently ignore, banner stays gone until reload
+        }
+        setDismissed(true);
+    }
+
+    return (
+        <div
+            role="banner"
+            aria-label="Saludo regional Chagra"
+            className={`flex items-center gap-3 px-4 py-2.5 mx-4 mt-3 rounded-xl border ${bg}`}
+        >
+            <Icon size={18} className="shrink-0" aria-hidden="true" />
+            <p className="text-sm font-medium leading-snug flex-1">{greeting}</p>
+            <button
+                type="button"
+                onClick={handleDismiss}
+                aria-label="Cerrar saludo"
+                className="shrink-0 p-1 rounded-full hover:bg-white/10 active:bg-white/20 transition-colors"
+            >
+                <X size={16} aria-hidden="true" />
+            </button>
+        </div>
+    );
+}

--- a/src/components/__tests__/HomeRegionalGreeting.smoke.test.jsx
+++ b/src/components/__tests__/HomeRegionalGreeting.smoke.test.jsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HomeRegionalGreeting from '../HomeRegionalGreeting';
+
+const fincaActiveMock = vi.hoisted(() => ({
+    state: { activeFincaSlug: null, fincas: [] },
+}));
+
+vi.mock('../../services/fincaActiveStore', () => ({
+    __esModule: true,
+    default: (selector) => selector(fincaActiveMock.state),
+}));
+
+describe('HomeRegionalGreeting smoke', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        fincaActiveMock.state = { activeFincaSlug: null, fincas: [] };
+    });
+
+    it('muestra saludo default cuando no hay finca activa', () => {
+        render(<HomeRegionalGreeting />);
+        expect(screen.getByRole('banner')).toHaveTextContent('Hola, lo del día en tu chagra');
+    });
+
+    it('saludo regional según biocultural_zone andino_alto_páramo', () => {
+        fincaActiveMock.state = {
+            activeFincaSlug: 'choachi',
+            fincas: [{ slug: 'choachi', biocultural_zone: 'andino_alto_páramo' }],
+        };
+        render(<HomeRegionalGreeting />);
+        expect(screen.getByRole('banner')).toHaveTextContent('sumercé');
+        expect(screen.getByRole('banner')).toHaveTextContent('Frío de páramo');
+    });
+
+    it('saludo regional caribe', () => {
+        fincaActiveMock.state = {
+            activeFincaSlug: 'barranquilla',
+            fincas: [{ slug: 'barranquilla', biocultural_zone: 'caribe' }],
+        };
+        render(<HomeRegionalGreeting />);
+        expect(screen.getByRole('banner')).toHaveTextContent('calor caribe');
+    });
+
+    it('dismiss persiste en localStorage y oculta banner', () => {
+        const { container } = render(<HomeRegionalGreeting />);
+        const btn = screen.getByLabelText('Cerrar saludo');
+        fireEvent.click(btn);
+        expect(container.querySelector('[role="banner"]')).toBeNull();
+        expect(localStorage.getItem('chagra:home-greeting-dismissed:v1')).toBeTruthy();
+    });
+
+    it('NO contiene voseo argentino (regla CLAUDE.md)', () => {
+        fincaActiveMock.state = {
+            activeFincaSlug: 'choachi',
+            fincas: [{ slug: 'choachi', biocultural_zone: 'andino_medio' }],
+        };
+        render(<HomeRegionalGreeting />);
+        const text = screen.getByRole('banner').textContent;
+        expect(text).not.toMatch(/\btenés\b|\bquerés\b|\belegí\b|\bsumercé\b.*\bvos\b/i);
+    });
+});


### PR DESCRIPTION
## Summary
- Banner top del dashboard con saludo cariñoso colombiano según `biocultural_zone` de la finca activa.
- 8 zonas mapeadas: andino_alto_páramo, andino_alto, andino_medio, valle_caucano, caribe, pacifico, llanos, amazonia + default fallback.
- Icono dinámico por hora (Sun / Sunset / Moon) con colores tonales.
- Dismissable con X — persiste por día en localStorage.

## Justificación
Diferenciador cultural vs apps agro genéricas — el campesino siente que la app habla SU idioma local. Pedido directo del operator (#196 backlog) con copy "Uy sumercé...".

## Test plan
- [x] 5/5 unit tests pass: default render, andino_alto_páramo, caribe, dismiss persiste, anti-voseo
- [ ] Smoke E2E manual: cambiar finca activa → ver saludo cambiar
- [ ] iPhone Safari PWA → safe-area-top no rompe el layout

## Anti-leak
Zero voseo argentino. Sin codenames. Sin regionalismos racistas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)