### PR TITLE
feat(ux): FAB acciones rápidas agregar planta + ayuda (#197)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.21",
+  "version": "0.13.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v253';
+const CACHE_NAME = 'chagra-v254';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import useOllamaWarmStore from './store/useOllamaWarmStore';
 // import FieldFeedback from './components/FieldFeedback';
 import MicFab from './components/MicFab';
 import AgentFab from './components/AgentFab';
+import QuickActionsPanel from './components/QuickActionsPanel';
 import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
 import IosInstallBanner from './components/IosInstallBanner';
@@ -511,6 +512,7 @@ export default function App() {
           `embedded` desde HelpUsoScreen. */}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <MicFab onNavigate={navigate} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'voz' && currentView !== 'agente' && <AgentFab onNavigate={navigate} />}
+      {currentView === 'dashboard' && <QuickActionsPanel onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
       {currentView !== 'loading' && currentView !== 'login' && <SyncProgressIndicator />}
       {toast && (

--- a/src/components/QuickActionsPanel.jsx
+++ b/src/components/QuickActionsPanel.jsx
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef } from 'react';
+import { Plus, Sprout, HelpCircle, X } from 'lucide-react';
+
+export default function QuickActionsPanel({ onNavigate }) {
+    const [open, setOpen] = useState(false);
+    const panelRef = useRef(null);
+
+    useEffect(() => {
+        if (!open) return undefined;
+        function onClickOutside(e) {
+            if (panelRef.current && !panelRef.current.contains(e.target)) {
+                setOpen(false);
+            }
+        }
+        function onKey(e) {
+            if (e.key === 'Escape') setOpen(false);
+        }
+        document.addEventListener('mousedown', onClickOutside);
+        document.addEventListener('keydown', onKey);
+        return () => {
+            document.removeEventListener('mousedown', onClickOutside);
+            document.removeEventListener('keydown', onKey);
+        };
+    }, [open]);
+
+    function handleAction(view) {
+        setOpen(false);
+        onNavigate(view);
+    }
+
+    return (
+        <div ref={panelRef}>
+            <button
+                type="button"
+                aria-label={open ? 'Cerrar acciones rápidas' : 'Abrir acciones rápidas'}
+                aria-expanded={open}
+                onClick={() => setOpen((v) => !v)}
+                className="fixed right-[18px] flex items-center justify-center rounded-full shadow-lg transition-all active:scale-95"
+                style={{
+                    bottom: 'calc(18px + env(safe-area-inset-bottom))',
+                    width: 56,
+                    height: 56,
+                    background: 'linear-gradient(135deg, #65a30d 0%, #4d7c0f 100%)',
+                    border: '2px solid #bef264',
+                    color: '#0f172a',
+                    zIndex: 50,
+                    boxShadow: '0 4px 16px rgba(0,0,0,0.4), 0 0 14px #bef26455',
+                }}
+            >
+                {open ? <X size={24} strokeWidth={2.5} /> : <Plus size={26} strokeWidth={2.5} />}
+            </button>
+
+            {open && (
+                <div
+                    role="menu"
+                    aria-label="Acciones rápidas"
+                    className="fixed right-[18px] flex flex-col gap-2"
+                    style={{
+                        bottom: 'calc(90px + env(safe-area-inset-bottom))',
+                        zIndex: 50,
+                    }}
+                >
+                    <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => handleAction('sembrar')}
+                        className="flex items-center gap-3 pl-4 pr-5 py-3 rounded-2xl bg-slate-900 border-2 border-lime-700/50 text-lime-100 font-bold shadow-xl hover:bg-slate-800 active:scale-95 transition-all min-h-[52px]"
+                    >
+                        <Sprout size={20} className="text-lime-400" aria-hidden="true" />
+                        <span>Agregar planta a mi finca</span>
+                    </button>
+                    <button
+                        type="button"
+                        role="menuitem"
+                        onClick={() => handleAction('help')}
+                        className="flex items-center gap-3 pl-4 pr-5 py-3 rounded-2xl bg-slate-900 border-2 border-amber-700/50 text-amber-100 font-bold shadow-xl hover:bg-slate-800 active:scale-95 transition-all min-h-[52px]"
+                    >
+                        <HelpCircle size={20} className="text-amber-400" aria-hidden="true" />
+                        <span>Consultar ayuda</span>
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/__tests__/QuickActionsPanel.smoke.test.jsx
+++ b/src/components/__tests__/QuickActionsPanel.smoke.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import QuickActionsPanel from '../QuickActionsPanel';
+
+describe('QuickActionsPanel smoke', () => {
+    it('renderiza FAB cerrado por default', () => {
+        render(<QuickActionsPanel onNavigate={vi.fn()} />);
+        const fab = screen.getByLabelText('Abrir acciones rápidas');
+        expect(fab).toBeInTheDocument();
+        expect(fab).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('abre menu con 2 acciones', () => {
+        render(<QuickActionsPanel onNavigate={vi.fn()} />);
+        fireEvent.click(screen.getByLabelText('Abrir acciones rápidas'));
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+        expect(screen.getByText('Agregar planta a mi finca')).toBeInTheDocument();
+        expect(screen.getByText('Consultar ayuda')).toBeInTheDocument();
+    });
+
+    it('click "Agregar planta" navega a sembrar y cierra', () => {
+        const onNavigate = vi.fn();
+        render(<QuickActionsPanel onNavigate={onNavigate} />);
+        fireEvent.click(screen.getByLabelText('Abrir acciones rápidas'));
+        fireEvent.click(screen.getByText('Agregar planta a mi finca'));
+        expect(onNavigate).toHaveBeenCalledWith('sembrar');
+        expect(screen.queryByRole('menu')).toBeNull();
+    });
+
+    it('click "Consultar ayuda" navega a help y cierra', () => {
+        const onNavigate = vi.fn();
+        render(<QuickActionsPanel onNavigate={onNavigate} />);
+        fireEvent.click(screen.getByLabelText('Abrir acciones rápidas'));
+        fireEvent.click(screen.getByText('Consultar ayuda'));
+        expect(onNavigate).toHaveBeenCalledWith('help');
+    });
+
+    it('Escape cierra el menu', () => {
+        render(<QuickActionsPanel onNavigate={vi.fn()} />);
+        fireEvent.click(screen.getByLabelText('Abrir acciones rápidas'));
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByRole('menu')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- FAB redondo bottom-right (dashboard only) que despliega menu vertical con 2 acciones de alta frecuencia.
- Acciones: \"Agregar planta a mi finca\" (→ sembrar) + \"Consultar ayuda\" (→ help).
- z-50 entre MicFab/AgentFab (z-9000) y Toast (z-100). Respeta safe-area-inset-bottom.
- Cierra con click outside / Escape. Aria completo (menu, menuitem, aria-expanded).

## Justificación
Operator pidió side-panel dinámico con links rápidos (#197). Frecuencia: agregar planta y abrir ayuda son las 2 acciones más comunes después de la query al agente.

## Test plan
- [x] 5/5 unit tests pass: cerrado por default, abre con 2 acciones, navega sembrar, navega help, Escape cierra
- [ ] Manual smoke: tap FAB → ver menu → tap acción → ver navegación correcta
- [ ] iPhone Safari PWA: no choca con MicFab izquierda ni Toast centro

🤖 Generated with [Claude Code](https://claude.com/claude-code)