### PR TITLE
fix(agent): clima leak — no redirigir a IDEAM externo (#293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.21",
+  "version": "0.13.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v253';
+const CACHE_NAME = 'chagra-v254';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1059,8 +1059,30 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           // "no tengo IDEAM" en último caso). Solo se ejecuta si NO hubo
           // tool ya invocado vía NLU para no inflar contexto.
           if (!toolEvidence) {
-            const climaKeywords = /clima|lluvia|llueve|llover|temperatura|sequ[íi]a|fr[íi]o|calor|estaci[óo]n\s+meteorol[óo]gica|ideam|precipitaci[óo]n/i;
-            const municipio = FARM_CONFIG?.MUNICIPIO || null;
+            const climaKeywords = /clima|lluvia|llueve|llover|temperatura|sequ[íi]a|fr[íi]o|calor|estaci[óo]n\s+meteorol[óo]gica|ideam|precipitaci[óo]n|pron[óo]stico|reporte\s+(del\s+)?tiempo/i;
+            // Bug piloto 2026-05-27: FARM_CONFIG.MUNICIPIO viene de build-time
+            // env (VITE_FARM_MUNICIPIO). En prod sin esa env queda null y
+            // el tool jamás se llamaba → LLM respondía "no tengo acceso a
+            // datos meteorológicos, consulta IDEAM". Cascade: 1) finca
+            // activa, 2) FARM_CONFIG demo, 3) null + tool con flag
+            // no_municipio para que el LLM PIDA el municipio al usuario.
+            const activeFinca = fincas.find((f) => f.slug === activeFincaSlug);
+            const municipio = activeFinca?.municipio || FARM_CONFIG?.MUNICIPIO || null;
+            if (climaKeywords.test(text) && !municipio) {
+              // Inyectar evidencia explícita "no_municipio" — el LLM
+              // debe pedirle al user su municipio, NO redirigirlo a IDEAM
+              // externo.
+              toolEvidence = {
+                tool: 'get_clima_ideam',
+                args: { action: 'monthly_avg' },
+                result: {
+                  available: false,
+                  reason: 'no_municipio',
+                  hint: 'pedirle al usuario su municipio para consultar IDEAM',
+                },
+              };
+              console.debug('[sidecar] clima sin municipio — evidence no_municipio inyectada');
+            }
             if (climaKeywords.test(text) && municipio) {
               try {
                 const tClima0 = performance.now();

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -172,21 +172,29 @@ export function generateRegionalToneContext(region) {
  * @returns {string} Alertas climáticas para inyectar en prompt
  */
 export function generateClimateAlertsContext(bioculturalZone) {
+  // Bug piloto 2026-05-27: el LLM respondía "no tengo acceso a datos
+  // meteorológicos, consulta IDEAM/AccuWeather" cuando el sidecar SÍ tiene
+  // tool get_clima_ideam funcional. El leak venía de las instrucciones
+  // "recomienda consultar pronóstico IDEAM más reciente" que invitaban al
+  // redirect. Reemplazadas por instrucción CLIMA-DIRECTO honesta: si Chagra
+  // no logró consultar, DECIRLO sin redirigir al user a apps externas.
+  const baseClimateRule = 'REGLA CLIMA: cuando el usuario pregunte por clima, lluvia, temperatura, pronóstico o "reporte del tiempo" para su zona, el sistema DEBE consultar IDEAM vía el tool get_clima_ideam (Chagra lo hace por el usuario). Si en este mensaje no se inyectó evidencia clima del tool, NO inventes datos NI redirijas al usuario a IDEAM/AccuWeather/Weather Channel — dile honestamente: "No logré consultar el reporte del IDEAM para tu zona en este momento, inténtalo en unos minutos". NUNCA digas "no tengo acceso a datos meteorológicos" porque sí lo tenemos; di "no logré consultarlo ahora".';
+
   if (!bioculturalZone) {
-    return 'Cuando menciones clima, cita siempre la fuente (IDEAM, estación meteorológica, etc.). Si no hay datos, recomiendo consultar pronóstico IDEAM.';
+    return baseClimateRule;
   }
 
   const alerts = REGIONAL_CLIMATE_ALERTS[bioculturalZone];
   if (!alerts) {
-    return `Para la zona ${bioculturalZone}, cuando menciones clima, cita siempre la fuente (IDEAM, Corporación Autónoma Regional, etc.). Si no tienes datos actualizados, recomiendo consultar el pronóstico IDEAM más reciente.`;
+    return `${baseClimateRule}\n\nZona biocultural del operador: ${bioculturalZone}.`;
   }
-  
+
   return `ALERTAS CLIMÁTICAS PARA TU ZONA (${bioculturalZone}):
 Riesgos principales: ${alerts.riesgos.join(', ')}.
 Recomendación general: ${alerts.recomendaciones}
 Fuentes: ${alerts.fuentes.join(', ')}.
 
-Cuando el usuario pregunte sobre clima o riesgo, SIEMPRE menciona estos riesgos y cita las fuentes. Si no tienes datos actualizados, recomienda consultar el pronóstico IDEAM más reciente.`;
+${baseClimateRule}`;
 }
 
 /**


### PR DESCRIPTION
## Bug en vivo 2026-05-27 23:17 COT
- **User**: \"dame el último reporte de clima generado para mi zona\"
- **App**: \"no tengo acceso a datos meteorológicos, consulta IDEAM o AccuWeather\"

**Es falso**. El sidecar tiene \`get_clima_ideam\` (ALLOWED_TOOLS) + wrapper \`getClimaIdeam\` en sidecarClient + heurística en AgentScreen.

## Root cause
\`FARM_CONFIG.MUNICIPIO = import.meta.env.VITE_FARM_MUNICIPIO || null\`. En build prod (sin demo mode) esa env está vacía → \`municipio=null\` → el if del heurístico nunca entra → el tool jamás se invoca → LLM responde genérico.

Y el system prompt INVITABA al leak: \"recomiendo consultar el pronóstico IDEAM más reciente\".

## Fix de dos puntas
1. **agentService.js generateClimateAlertsContext**: regla CLIMA explícita que prohíbe redirigir al user a apps externas (IDEAM/AccuWeather/Weather Channel). El mensaje correcto cuando no hay datos: \"No logré consultar el reporte del IDEAM para tu zona en este momento, inténtalo en unos minutos\" — nunca \"no tengo acceso\".
2. **AgentScreen.jsx clima heurística**:
   - Cascade municipio: \`finca.municipio → FARM_CONFIG.MUNICIPIO → null\`
   - Regex amplía: \"reporte del tiempo\", \"pronóstico\"
   - Si municipio sigue null tras cascade, inyecta \`toolEvidence: {available:false, reason:'no_municipio', hint:'pedir municipio'}\` — el LLM pide el municipio en lugar de redirigir al user.

## Pendiente
Agregar campo \`municipio\` a fincas-publicas.json y al onboarding 18-preguntas (#200) — falta para Free/Lili/rookiecol que no tienen finca con municipio aún.

## Test plan
- [ ] Manual smoke: preguntar clima → ya no debe decir \"ve a AccuWeather\"
- [ ] Si finca activa tiene municipio → tool se llama → LLM responde con datos IDEAM
- [ ] Si no hay municipio → LLM pide el municipio al user

🤖 Generated with [Claude Code](https://claude.com/claude-code)