### PR TITLE
fix(seeding): SeedingLog crashea con initialData=null (regresión #1102)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "0.13.23",
+  "version": "0.13.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v255';
+const CACHE_NAME = 'chagra-v256';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/SeedingLog.jsx
+++ b/src/components/SeedingLog.jsx
@@ -12,7 +12,13 @@ import { extractVarieties, varietyHelpText } from '../utils/speciesVariety';
 const MAX_QUANTITY = 100000; // sanity cap: 100k plántulas en una siembra es ya raro
 const MIN_CROP_LEN = 2;
 
-export default function SeedingLog({ onBack, onSave, initialData = {} }) {
+export default function SeedingLog({ onBack, onSave, initialData: initialDataRaw }) {
+  // Bug B4 piloto 2026-05-28: QuickActionsPanel "Agregar planta" navega a
+  // 'sembrar' sin pasar currentViewData → App.jsx pasa initialData={null} →
+  // default param `= {}` NO aplica con null (solo con undefined) → línea 18
+  // intentaba leer `null.crop` y crasheaba el ErrorBoundary del componente.
+  // Coalesce explícito null/undefined → {}.
+  const initialData = initialDataRaw || {};
   const [formData, setFormData] = useState({
     date: new Date().toISOString().split('T')[0],
     crop: initialData.crop || '', // String para UI legacy o label


### PR DESCRIPTION
## Bug en vivo piloto 2026-05-28
User clickea \"Agregar planta a mi finca\" del FAB QuickActionsPanel → ErrorBoundary atrapa:
\`\`\`
Cannot read properties of null (reading 'crop')
\`\`\`

## Root cause (regresión directa de PR #1102 de hoy)
1. \`QuickActionsPanel.handleAction('sembrar')\` → \`onNavigate('sembrar')\` sin setear \`currentViewData\`
2. App.jsx queda con \`currentViewData = null\` (default \`useState(null)\`)
3. Render: \`<SeedingLog initialData={null} />\`
4. Signature \`function ({ initialData = {} })\` solo aplica default con **undefined**, NO con null
5. Línea 18: \`crop: initialData.crop || ''\` → \`null.crop\` → 💥

Otros call-sites de SeedingLog pasan \`{}\` u objeto real → solo crashea desde el FAB nuevo.

## Fix
1 línea: coalesce explícito \`const initialData = initialDataRaw || {}\` en el cuerpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)