### PR TITLE
fix(ui): sweep textual jerga + version footer v1.0.0 (Free 7→10)

### DIFF
--- a/src/components/BitacoraEntryDetail.jsx
+++ b/src/components/BitacoraEntryDetail.jsx
@@ -317,7 +317,7 @@ export default function BitacoraEntryDetail({ entry, onBack, onEdit }) {
           </span>
           {entry?._pending && (
             <span className="text-xs font-bold text-amber-400 px-2 py-1 rounded-full bg-amber-900/30 border border-amber-800/50">
-              Sin sincronizar
+              Pendiente de subir
             </span>
           )}
         </section>

--- a/src/components/FincaCard.jsx
+++ b/src/components/FincaCard.jsx
@@ -7,10 +7,23 @@ const estadoColors = {
     pendiente: 'bg-slate-800 text-slate-400 border-slate-700/30',
 };
 
+// Etiquetas legibles para `biocultural_zone`. La clave del dato sigue siendo
+// el slug interno (snake_case), pero al usuario público le mostramos un
+// nombre natural de "tu zona ecológica" para evitar leak de jerga.
 const zoneLabels = {
     andino_alto_páramo: 'Alto Andino - Páramo',
+    andino_alto: 'Alto Andino',
     andino_medio: 'Andino Medio',
-    valle_caucano: 'Valle Cauca',
+    andino_medio_invernadero: 'Andino Medio (invernadero)',
+    valle_caucano: 'Valle del Cauca',
+    cafetero: 'Eje Cafetero',
+    caribe: 'Caribe',
+    llanos: 'Llanos',
+    amazonia: 'Amazonía',
+    pacifico: 'Pacífico',
+    nariño: 'Nariño',
+    santander: 'Santanderes',
+    tolima_huila: 'Tolima - Huila',
 };
 
 export function FincaCard({finca, onSelect, onConfigure}) {

--- a/src/components/MultiFincaGlobe.jsx
+++ b/src/components/MultiFincaGlobe.jsx
@@ -27,6 +27,25 @@ const FADED_OPACITY = 0.4;
 const COLOMBIA_VIEW = { center: [4.5, -74.5], zoom: 6 };
 const CHOACHI_VIEW = { center: [4.5167, -73.9333], zoom: 9 };
 
+// Etiquetas legibles para `biocultural_zone` en la UI pública del globo de fincas.
+// El dato interno conserva el slug (snake_case); aquí lo presentamos como "tu
+// zona ecológica" para evitar leak de jerga.
+const ZONE_LABELS = {
+    andino_alto_páramo: 'Alto Andino - Páramo',
+    andino_alto: 'Alto Andino',
+    andino_medio: 'Andino Medio',
+    andino_medio_invernadero: 'Andino Medio (invernadero)',
+    valle_caucano: 'Valle del Cauca',
+    cafetero: 'Eje Cafetero',
+    caribe: 'Caribe',
+    llanos: 'Llanos',
+    amazonia: 'Amazonía',
+    pacifico: 'Pacífico',
+    nariño: 'Nariño',
+    santander: 'Santanderes',
+    tolima_huila: 'Tolima - Huila',
+};
+
 function MapEntryFlyTo({ phase }) {
     const map = useMap();
     useEffect(() => {
@@ -146,7 +165,7 @@ export const MultiFincaGlobe = ({ onSelect }) => {
                                     <div>
                                         <h3 className="font-bold text-lg leading-tight text-white">{finca.nombre}</h3>
                                         <p className="text-[10px] text-emerald-500 uppercase font-bold tracking-widest mt-0.5">
-                                            {finca.biocultural_zone?.replace(/_/g, ' ')}
+                                            {ZONE_LABELS[finca.biocultural_zone] || finca.biocultural_zone?.replace(/_/g, ' ')}
                                         </p>
                                     </div>
 

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -148,7 +148,7 @@ export default function ProfileScreen({ onBack, onHome }) {
             {savedFlash ? <><Check size={18} /> Guardado</> : <><Save size={18} /> Guardar cambios</>}
           </button>
           <p className="text-[10px] text-slate-500 text-center leading-relaxed">
-            Los cambios se persisten localmente. Sin sincronización con FarmOS aún (planeado v1.x).
+            Los cambios se guardan en tu dispositivo. Subida al servidor pendiente (planeado v1.x).
           </p>
         </div>
 
@@ -237,7 +237,7 @@ export default function ProfileScreen({ onBack, onHome }) {
         {/* App Info Footer */}
         <div className="mt-8 pt-6 border-t border-slate-800/50 text-center">
           <p className="text-[10px] text-slate-600 font-mono tracking-tighter uppercase">
-            Chagra Eco-OS • v0.8.4
+            Chagra • v1.0.0
           </p>
           <p className="text-[9px] text-slate-700 mt-1 max-w-[200px] mx-auto leading-tight">
             Diseñado para la soberanía alimentaria y la regeneración ecosistémica.


### PR DESCRIPTION
## Summary

Parte 1/5 del **Free 7→10 fix-pack** — cierra rincones técnicos del UI público que pueden hacer sentir al campesino-target (Free, Cauca, Android, 7/10) que la app no es para él.

- `ProfileScreen.jsx`: footer "Chagra Eco-OS • v0.8.4" → **"Chagra • v1.0.0"**. Copia "Sin sincronización con FarmOS" → "Subida al servidor pendiente" (evita exponer nombre del backend).
- `BitacoraEntryDetail.jsx`: badge "Sin sincronizar" → **"Pendiente de subir"** (lenguaje natural, no de operaciones).
- `FincaCard.jsx` + `MultiFincaGlobe.jsx`: mapeo `biocultural_zone` → etiquetas legibles ("Valle del Cauca", "Alto Andino - Páramo", "Eje Cafetero", etc.) en lugar de mostrar el slug raw. El dato interno conserva el slug, solo cambia la presentación pública.

Cierra hipótesis #4 del análisis [`project-free-7-10-analysis-2026-05-28`](https://github.com/guatoc-ecohub/Chagra/issues): "UX 1.0 todavía con rincones técnicos".

## Test plan

- [x] `npm run lint` limpio en archivos cambiados (max-warnings=0).
- [x] `npm run build` verde (no rompe import graph).
- [ ] Smoke local en chagra.guatoc.co después del deploy: footer Profile muestra v1.0.0, badge Bitácora dice "Pendiente de subir", popup del globo muestra zona legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)