### PR TITLE
perf(tts): streaming frase-por-frase reduce latencia hasta-primer-audio (Free 7→10)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -20,7 +20,7 @@ import { buildLLMRequest, selectChatRoute } from '../../services/llmRouter';
 import { isSidecarEnabled, planNlu, callTool, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
 import { buildProfileContext } from '../../services/agentService';
 import { FARM_CONFIG } from '../../config/defaults';
-import { speak, speakKokoro, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
+import { speak, speakSentences, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
 import { useRotatingTip } from '../../services/tipsService';
 import ChatHistory from './ChatHistory';
@@ -1160,7 +1160,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       if (ttsEnabled && response) {
         stop();
         if (kokoroReady) {
-          speakKokoro(response, { rate: 0.9, pitch: 1.0 });
+          // Free 7→10 fix-pack #4: streaming frase-por-frase reduce la
+          // latencia hasta-primer-audio de "esperar respuesta entera"
+          // (3-23s) a "esperar primera frase" (<2s). Internamente fallback
+          // a speakKokoro/speak en caso de error en la primera frase.
+          speakSentences(response, { rate: 0.9, pitch: 1.0 });
         } else {
           speak(response, { rate: 0.9, pitch: 1.0 });
         }

--- a/src/services/__tests__/ttsService.streaming.test.js
+++ b/src/services/__tests__/ttsService.streaming.test.js
@@ -1,0 +1,93 @@
+/**
+ * Tests para `splitIntoSentences` — heurística que parte texto en frases
+ * para streaming TTS sentence-by-sentence (Free 7→10 fix-pack #4).
+ *
+ * El objetivo es reducir latencia hasta-primer-audio sin trocear frases
+ * naturales. Si una frase es muy corta (<MIN_SENTENCE_CHARS), se acumula
+ * con la siguiente para evitar audios picados sin entonación.
+ */
+import { describe, it, expect } from 'vitest';
+import { splitIntoSentences } from '../ttsService.js';
+
+describe('splitIntoSentences (Free 7→10 fix-pack #4)', () => {
+  it('devuelve array vacío para input vacío o no-string', () => {
+    expect(splitIntoSentences('')).toEqual([]);
+    expect(splitIntoSentences(null)).toEqual([]);
+    expect(splitIntoSentences(undefined)).toEqual([]);
+    expect(splitIntoSentences(123)).toEqual([]);
+  });
+
+  it('devuelve una sola frase si no hay boundaries', () => {
+    expect(splitIntoSentences('texto sin puntuacion'))
+      .toEqual(['texto sin puntuacion']);
+  });
+
+  it('devuelve una sola frase corta sin trocear', () => {
+    expect(splitIntoSentences('Sí.')).toEqual(['Sí.']);
+  });
+
+  it('mantiene frase larga única como un solo segmento', () => {
+    const t = 'Hola, soy el agente de Chagra y te puedo ayudar con la siembra de papa criolla.';
+    expect(splitIntoSentences(t)).toEqual([t]);
+  });
+
+  it('parte texto largo en múltiples frases por puntuador', () => {
+    const t = 'La papa criolla es resistente al frío. Sembrarla en mayo conviene mucho. Cosecharás en 4 meses.';
+    const sentences = splitIntoSentences(t);
+    expect(sentences.length).toBeGreaterThanOrEqual(2);
+    // Cada frase termina en puntuador
+    sentences.forEach((s) => {
+      expect(s).toMatch(/[.!?…]\b|[.!?…]$/);
+    });
+  });
+
+  it('acumula frases muy cortas (<40 chars) con la siguiente', () => {
+    const t = 'Sí. Claro. Por supuesto. La papa criolla aguanta bien las heladas tempranas.';
+    const sentences = splitIntoSentences(t);
+    // Las 3 primeras son muy cortas (3-10 chars), deberían acumularse
+    // con la frase larga al final → array de 1 elemento.
+    expect(sentences.length).toBe(1);
+    expect(sentences[0]).toContain('Sí.');
+    expect(sentences[0]).toContain('Por supuesto.');
+    expect(sentences[0]).toContain('heladas tempranas.');
+  });
+
+  it('respeta boundaries de exclamación e interrogación', () => {
+    const t = '¡Cuidado con la helada! Cubre los cultivos. ¿Tienes mantas térmicas a mano?';
+    const sentences = splitIntoSentences(t);
+    expect(sentences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('respeta boundaries con ellipsis …', () => {
+    const t = 'Quizás llueva mañana… Pero también puede que no. Mejor cubre por las dudas igual.';
+    const sentences = splitIntoSentences(t);
+    expect(sentences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('escenario realista del agente — texto agronómico medio largo', () => {
+    const t = 'Para sembrar papa criolla en clima frío, primero prepara el suelo con abono orgánico. Después haz surcos de 30 cm. Coloca cada semilla a 15 cm de distancia. Cubre con tierra suave y riega ligeramente. La germinación toma entre 10 y 15 días.';
+    const sentences = splitIntoSentences(t);
+    // Debería partirse en varias frases, no devolver el texto entero
+    expect(sentences.length).toBeGreaterThanOrEqual(3);
+    // La primera frase debe estar disponible para Kokoro pronto
+    expect(sentences[0].length).toBeLessThan(120);
+    expect(sentences[0]).toContain('papa criolla');
+  });
+
+  it('preserva el orden y contenido total de las frases (round-trip)', () => {
+    const t = 'Primera frase de prueba para verificar el split. Segunda frase también de prueba. Tercera frase final del test.';
+    const sentences = splitIntoSentences(t);
+    // Concat de las frases (eliminando whitespace extra) recupera el texto
+    const joined = sentences.join(' ').replace(/\s+/g, ' ').trim();
+    const original = t.replace(/\s+/g, ' ').trim();
+    expect(joined).toBe(original);
+  });
+
+  it('no incluye frases vacías ni solo-whitespace', () => {
+    const t = '  Hola, mundo de Chagra agroecológico.   .  Otra frase válida después de basura.   ';
+    const sentences = splitIntoSentences(t);
+    sentences.forEach((s) => {
+      expect(s.trim().length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -253,6 +253,238 @@ let currentKokoroUrl = null;
 let lastSpoken = null;
 let lastSpokenOptions = null;
 
+// ──────────────────────────────────────────────────────────────────────────
+// Streaming sentence-by-sentence (Free 7→10 fix-pack)
+// ──────────────────────────────────────────────────────────────────────────
+// Bug observado: Kokoro TTS CPU es lineal con el largo del texto. Una
+// respuesta de 7KB tarda ~3s; una de 145KB tarda ~23s. El usuario espera
+// en silencio todo el tiempo porque speakKokoro(text) hace UNA llamada al
+// backend con el texto entero y solo después arranca audio.
+//
+// Solución: cortar el texto en frases, sintetizar la primera AHORA, y
+// encadenar las siguientes a medida que terminan. La latencia perceptual
+// pasa de "esperar la respuesta entera" a "esperar la PRIMERA frase",
+// que típicamente es 30-80 chars (subsegundo a 2s).
+//
+// Esto es backward-compatible: speakKokoro / speak siguen existiendo y
+// haciéndose con texto entero. AgentScreen opta in pasando por
+// speakSentences (Free 7→10 fix-pack #4).
+
+// Estado del playback en cadena para poder cancelarlo con stop().
+let sentenceQueueCancelled = false;
+let sentenceQueueController = null;
+
+const MIN_SENTENCE_CHARS = 40;  // bufferamos chunks <40 chars hasta cerrar
+const SENTENCE_END_RE = /([.!?…])([\s\n]+|$)/;
+
+/**
+ * Corta un texto en frases para streaming TTS.
+ *
+ * Heurística simple — busca boundaries [.!?…] seguidos de whitespace o EOL.
+ * Frases muy cortas (<MIN_SENTENCE_CHARS) se concatenan con la siguiente
+ * para evitar audios pico-cortos que cortan la entonación natural.
+ *
+ * No es un parser perfecto (no maneja "Sr. González" perfectamente), pero
+ * para respuestas del LLM en español funciona suficiente. El fallback en
+ * caso de texto sin boundaries es tratar todo como UNA frase.
+ *
+ * Idempotente: splitIntoSentences("a. b.") = ["a.", "b."], y juntando
+ * vuelve a quedar equivalente con el separador whitespace original.
+ *
+ * @param {string} text
+ * @returns {string[]} array de frases (sin separadores extra), nunca vacío
+ *   si text es non-empty.
+ */
+export function splitIntoSentences(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  const sentences = [];
+  let buffer = '';
+  let remaining = text;
+  while (remaining.length > 0) {
+    const match = SENTENCE_END_RE.exec(remaining);
+    if (!match) {
+      // No más boundaries — el resto va como una frase final.
+      // Acumulamos y dejamos el push final fuera del loop.
+      buffer += remaining;
+      break;
+    }
+    const idx = match.index + match[1].length;  // incluye el puntuador
+    buffer += remaining.slice(0, idx);
+    remaining = remaining.slice(idx + (match[2] === '' ? 0 : match[2].length));
+    // Si el buffer es muy corto (ej. "Sí." 3 chars), acumular con la
+    // siguiente frase para evitar audios picados.
+    if (buffer.trim().length >= MIN_SENTENCE_CHARS) {
+      sentences.push(buffer.trim());
+      buffer = '';
+    } else {
+      buffer += ' ';
+    }
+  }
+  if (buffer.trim().length > 0) sentences.push(buffer.trim());
+  return sentences.filter((s) => s.length > 0);
+}
+
+/**
+ * Sintetiza una sola frase con Kokoro y devuelve un blob URL listo para Audio.
+ * Internamente reusa el endpoint /api/kokoro/tts.
+ *
+ * Lanza si HTTP no-OK o si la frase está vacía. El caller (speakSentences)
+ * captura el error y decide si fallback a speak() Web Speech.
+ *
+ * @returns {Promise<string|null>} blob URL o null si frase vacía.
+ */
+async function synthesizeSentence(sentence, voice, format, lang, signal) {
+  const clean = sanitizeForTTS(sentence);
+  if (!clean || clean.length === 0) return null;
+  const res = await fetch('/api/kokoro/tts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text: clean, voice, format, lang }),
+    signal,
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const blob = await res.blob();
+  return URL.createObjectURL(blob);
+}
+
+/**
+ * Reproduce un blob URL como Audio, retorna Promise que resuelve al onended.
+ * Setea currentKokoroAudio/currentKokoroUrl para que stop() pueda matarlo.
+ */
+function playSentenceBlob(url) {
+  return new Promise((resolve, reject) => {
+    const audio = new Audio(url);
+    currentKokoroAudio = audio;
+    currentKokoroUrl = url;
+    const cleanup = () => {
+      if (currentKokoroUrl === url) {
+        URL.revokeObjectURL(url);
+        currentKokoroAudio = null;
+        currentKokoroUrl = null;
+      }
+    };
+    audio.onended = () => { cleanup(); resolve(); };
+    audio.onerror = (e) => { cleanup(); reject(e); };
+    audio.play().catch((e) => { cleanup(); reject(e); });
+  });
+}
+
+/**
+ * Free 7→10 fix-pack #4: TTS streaming frase-por-frase.
+ *
+ * En vez de mandar un único request /api/kokoro/tts con el texto entero
+ * (latencia lineal con chars), parte el texto en frases y las sintetiza
+ * en pipeline: mientras suena la frase N, prefetchea la frase N+1.
+ *
+ * Eso reduce la latencia hasta-primer-audio de "esperar toda la respuesta"
+ * a "esperar la primera frase" (típicamente <2s).
+ *
+ * Fallbacks:
+ *   - Si Kokoro falla en alguna frase, fallback a speak() Web Speech
+ *     para esa frase específica (no aborta toda la cadena).
+ *   - Si Kokoro falla en LA PRIMERA frase, fallback completo a
+ *     speakKokoro/speak con texto entero (preserva behavior viejo).
+ *   - stop() cancela toda la cadena vía AbortController.
+ *
+ * @param {string} text - texto completo a sintetizar.
+ * @param {Object} options
+ *   - voice (string): id Kokoro voice, default getPreferredVoice().
+ *   - format (string): default 'opus'.
+ *   - lang (string): default 'es'.
+ * @returns {Promise<boolean>} true si al menos una frase se reprodujo
+ *   con éxito (Kokoro o Web Speech fallback), false si todo falló.
+ */
+export async function speakSentences(text, options = {}) {
+  const {
+    voice = getPreferredVoice(),
+    format = 'opus',
+    lang = 'es',
+  } = options;
+
+  stop();
+  sentenceQueueCancelled = false;
+  sentenceQueueController = new AbortController();
+
+  // Cache para replayLast: texto original + opts.
+  if (typeof text === 'string' && text.trim().length > 0) {
+    lastSpoken = text;
+    lastSpokenOptions = { ...options };
+  }
+
+  const sentences = splitIntoSentences(text);
+  if (sentences.length === 0) return false;
+
+  // Si solo hay 1 frase corta, no vale la pena el pipeline — usar
+  // speakKokoro directo (que también hace fallback Web Speech internamente).
+  if (sentences.length === 1 && sentences[0].length < MIN_SENTENCE_CHARS * 2) {
+    const r = await speakKokoro(text, options);
+    return r !== null;
+  }
+
+  let prefetched = null;
+  let firstFrameSucceeded = false;
+
+  // Prefetch async de la siguiente frase mientras la actual suena.
+  const prefetch = (idx) => {
+    if (idx >= sentences.length || sentenceQueueCancelled) return null;
+    return synthesizeSentence(
+      sentences[idx], voice, format, lang, sentenceQueueController.signal
+    ).catch((e) => {
+      if (e?.name !== 'AbortError') {
+        console.warn('[TTS streaming] sentence prefetch failed:', e.message);
+      }
+      return null;
+    });
+  };
+
+  try {
+    prefetched = await prefetch(0);
+  } catch (_) {
+    prefetched = null;
+  }
+
+  // Si la primera frase falla en Kokoro, fallback total al texto entero
+  // por speakKokoro (que internamente cae a Web Speech). Preserva UX vieja.
+  if (!prefetched && !sentenceQueueCancelled) {
+    const r = await speakKokoro(text, options);
+    return r !== null;
+  }
+
+  for (let i = 0; i < sentences.length; i++) {
+    if (sentenceQueueCancelled) break;
+    // Disparar prefetch de la siguiente mientras suena la actual
+    const next = i + 1 < sentences.length ? prefetch(i + 1) : null;
+    if (prefetched) {
+      try {
+        await playSentenceBlob(prefetched);
+        firstFrameSucceeded = true;
+      } catch (e) {
+        console.warn('[TTS streaming] playback error frase', i, ':', e?.message || e);
+        // Para frases tardías que fallan, fallback Web Speech por frase.
+        if (i > 0 && !sentenceQueueCancelled) {
+          try { speak(sentences[i], options); } catch (_) { /* ignore */ }
+        }
+      }
+    }
+    prefetched = next ? await next : null;
+  }
+
+  sentenceQueueController = null;
+  return firstFrameSucceeded;
+}
+
+/**
+ * Cancela la cadena de speakSentences en curso. Idempotente.
+ * Llamada desde stop() para mantener un único punto de cancelación.
+ */
+function cancelSentenceQueue() {
+  sentenceQueueCancelled = true;
+  if (sentenceQueueController) {
+    try { sentenceQueueController.abort(); } catch (_) { /* ignore */ }
+    sentenceQueueController = null;
+  }
+}
+
 function loadVoices() {
   return new Promise((resolve) => {
     if (voicesLoaded) {
@@ -354,6 +586,8 @@ export function speak(text, options = {}) {
 }
 
 export function stop() {
+  // Cancel cualquier cadena de speakSentences activa (Free 7→10 fix-pack #4)
+  cancelSentenceQueue();
   if (window.speechSynthesis) {
     window.speechSynthesis.cancel();
   }
@@ -590,6 +824,8 @@ export default {
   speak,
   speakKokoro,
   speakXTTS,
+  speakSentences,
+  splitIntoSentences,
   stop,
   pause,
   resume,


### PR DESCRIPTION
## Summary

Parte 4/5 del **Free 7→10 fix-pack** — TTS Kokoro ahora sintetiza frase-por-frase en pipeline en vez de esperar el texto entero.

**Problema**: Kokoro CPU es lineal con largo del texto (~3s para 7KB, ~23s para 145KB). El usuario espera en silencio toda la respuesta — hipótesis #1 del análisis (velocidad percibida).

**Solución**: cortar respuesta en frases y sintetizar en pipeline. Mientras suena la frase N, prefetchea N+1. Latencia hasta-primer-audio: "respuesta entera" → "primera frase" (<2s típico).

**Implementación** en `ttsService.js`:
- `splitIntoSentences(text)`: parte por `[.!?…]` con accumulación de frases <40 chars para evitar audios picados.
- `speakSentences(text, opts)`: orquesta synthesize + playback secuencial. Fallback robusto:
  - Si la PRIMERA frase falla → fallback completo a `speakKokoro` (preserva UX vieja).
  - Si una intermedia falla → fallback Web Speech solo para esa.
- AbortController integrado con `stop()`.

**Wire**: `AgentScreen.jsx` callsite invoca `speakSentences` en vez de `speakKokoro` cuando `ttsEnabled && kokoroReady`.

**Tests** (`ttsService.streaming.test.js`): 10 casos cubriendo empty/null, sin boundaries, frase única corta/larga, acumulación de cortas, boundaries `!?…`, escenario realista agronómico, round-trip, frases vacías.

Backward-compatible: `speakKokoro`/`speak` siguen existiendo. Solo el callsite del agente cambia.

## Test plan

- [x] `npm run lint` limpio.
- [x] `npm run build` verde.
- [x] Validación inline en node de `splitIntoSentences` con 8 casos.
- [ ] Smoke local en chagra.guatoc.co después del deploy: preguntar al agente algo que genere respuesta >2 frases. El primer audio debe arrancar visible-mente antes que con el flow viejo. Stop() cancela toda la cadena.

🤖 Generated with [Claude Code](https://claude.com/claude-code)