### PR TITLE
fix(grounding): distinguir match exacto vs variedad/híbrido stripped (V-03 #241/#242)

### DIFF
--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -637,8 +637,10 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                 Especie sugerida ({Math.round((aiResult.confidence || 0) * 100)}% confianza)
               </p>
               {/* Badge grounded contra catálogo (V-05 — anti-alucinación con
-                  shape estructurado). `_grounded.status` distingue 6 estados:
-                    verified         → verde, sugerencia confirmada.
+                  shape estructurado). `_grounded.status` distingue 7 estados:
+                    verified         → verde, sugerencia confirmada exacta.
+                    partial-match    → amber tibio, base verificada pero
+                                       variedad/híbrido no validado (V-03 #241/#242).
                     rejected         → amber, sugerencia rechazada por catálogo.
                     sidecar-disabled → slate info, validación desactivada.
                     offline          → slate info, sin red para verificar.
@@ -652,6 +654,16 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
                 >
                   <Check size={14} aria-hidden="true" />
                   Verificado en catálogo
+                </span>
+              )}
+              {aiResult._grounded?.status === 'partial-match' && (
+                <span
+                  data-testid="grounded-badge-partial-match"
+                  className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-amber-500/20 text-amber-200 border border-amber-600 mb-1"
+                  title={aiResult._grounded.reason}
+                >
+                  <AlertCircle size={14} aria-hidden="true" />
+                  Coincidencia parcial
                 </span>
               )}
               {aiResult._grounded?.status === 'rejected' && (

--- a/src/services/__tests__/aiService.grounded.test.js
+++ b/src/services/__tests__/aiService.grounded.test.js
@@ -4,8 +4,13 @@
  * visión (PR chagra-pro #48 expuso la tool, este PR la consume).
  *
  * V-05 (audit-vision-chagra-2026-05-26): `_grounded` ahora es objeto
- * estructurado `{ status, reason, validation }` con 6 statuses posibles:
- *   verified, rejected, sidecar-disabled, offline, no-binomial, sidecar-error.
+ * estructurado `{ status, reason, validation }` con 7 statuses posibles:
+ *   verified, partial-match, rejected, sidecar-disabled, offline,
+ *   no-binomial, sidecar-error.
+ *
+ * V-03 #241/#242 (2026-05-28): partial-match cubre el caso "catálogo dice
+ * valid:true pero el binomial input tenía variedad/cultivar/híbrido que se
+ * stripó al resolver el species_id" — el badge "verificado" sería engañoso.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -211,6 +216,89 @@ describe('recognizeSpeciesGrounded', () => {
     );
   });
 
+  it('status:partial-match cuando catálogo valida la base pero input tenía variedad stripped (V-03 #241)', async () => {
+    mockVisionResponse({
+      common_name_es: 'papa pastusa',
+      scientific_name: "Solanum tuberosum 'Pastusa'",
+      confidence: 0.86,
+      alternatives: [],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce({
+      available: true,
+      results: [
+        {
+          species_id: 'solanum_tuberosum',
+          valid: true,
+          confidence_input: 0.86,
+          confidence_adjusted: 0.86,
+          nombre_comun: 'Papa',
+          nombre_cientifico: 'Solanum tuberosum',
+        },
+      ],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded.status).toBe('partial-match');
+    expect(result._grounded.reason).toMatch(/variedad|cultivar/i);
+    expect(result._grounded.validation).toBeTruthy();
+    expect(result._grounded.validation.valid).toBe(true);
+    expect(result._match_type).toBe('stripped-variety');
+  });
+
+  it('status:partial-match cuando vision emite híbrido pero catálogo solo tiene base (V-03 #242)', async () => {
+    mockVisionResponse({
+      common_name_es: 'toronja',
+      scientific_name: 'Citrus × paradisi',
+      confidence: 0.91,
+      alternatives: [],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce({
+      available: true,
+      results: [
+        {
+          species_id: 'citrus_paradisi',
+          valid: true,
+          confidence_input: 0.91,
+          confidence_adjusted: 0.91,
+          nombre_comun: 'Toronja',
+          nombre_cientifico: 'Citrus paradisi',
+        },
+      ],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded.status).toBe('partial-match');
+    expect(result._grounded.reason).toMatch(/híbrido/i);
+    expect(result._match_type).toBe('stripped-hybrid');
+  });
+
+  it('status:verified (no partial-match) cuando se quita SOLO autoría taxonómica', async () => {
+    // Autoría "L." es parte del binomial científico oficial, no afecta la
+    // identidad de la especie. Por lo tanto sigue siendo "verified" pleno.
+    mockVisionResponse({
+      common_name_es: 'café',
+      scientific_name: 'Coffea arabica L.',
+      confidence: 0.93,
+      alternatives: [],
+    });
+    sidecarClient.callTool.mockResolvedValueOnce({
+      available: true,
+      results: [
+        { species_id: 'coffea_arabica', valid: true, confidence_adjusted: 0.93 },
+      ],
+    });
+
+    const blob = new Blob(['fake'], { type: 'image/jpeg' });
+    const result = await recognizeSpeciesGrounded(blob);
+
+    expect(result._grounded.status).toBe('verified');
+    expect(result._match_type).toBe('stripped-authority');
+  });
+
   it('status:sidecar-error si el sidecar tool falla (devuelve null)', async () => {
     mockVisionResponse({
       common_name_es: 'aguacate',
@@ -279,7 +367,32 @@ describe('recognizeSpeciesGrounded', () => {
       expect(resolved.grounded_status).toBe('rejected');
     });
 
-    it('thunk resuelve grounded_status=null cuando sidecar disabled (degraded path)', async () => {
+    it('thunk resuelve grounded_status="partial-match" cuando hubo variedad stripped (V-03 #241)', async () => {
+      mockVisionResponse({
+        common_name_es: 'papa pastusa',
+        scientific_name: "Solanum tuberosum 'Pastusa'",
+        confidence: 0.81,
+        alternatives: [],
+      });
+      sidecarClient.callTool.mockResolvedValueOnce({
+        available: true,
+        results: [{ species_id: 'solanum_tuberosum', valid: true, confidence_adjusted: 0.81 }],
+      });
+
+      const blob = new Blob(['fake'], { type: 'image/jpeg' });
+      await recognizeSpeciesGrounded(blob);
+
+      const [, , , opts] = ollamaStream.streamOllama.mock.calls[0];
+      const resolved = opts.meta();
+      expect(resolved.confidence).toBeCloseTo(0.81);
+      expect(resolved.grounded_status).toBe('partial-match');
+    });
+
+    it('thunk resuelve grounded_status="sidecar-disabled" cuando sidecar off (degraded path)', async () => {
+      // V-03 2026-05-28: el finalize marca explícitamente el status de
+      // cualquier early-return en la telemetría (incluido degraded). El
+      // test legacy esperaba null porque asumía que finalize no escribía
+      // en degraded paths — pero sí lo hace desde V-05.
       sidecarClient.isSidecarEnabled.mockReturnValue(false);
       mockVisionResponse({
         common_name_es: 'tomate',
@@ -294,7 +407,7 @@ describe('recognizeSpeciesGrounded', () => {
       const [, , , opts] = ollamaStream.streamOllama.mock.calls[0];
       const resolved = opts.meta();
       expect(resolved.confidence).toBeCloseTo(0.6);
-      expect(resolved.grounded_status).toBeNull();
+      expect(resolved.grounded_status).toBe('sidecar-disabled');
     });
   });
 });

--- a/src/services/__tests__/scientificToSpeciesId.test.js
+++ b/src/services/__tests__/scientificToSpeciesId.test.js
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
 
 import { describe, it, expect } from 'vitest';
-import { _scientificToSpeciesId as toId } from '../aiService';
+import { _scientificToSpeciesId as toId, _scientificToMatchInfo as toMatch } from '../aiService';
 
 describe('scientificToSpeciesId (QUICK-17)', () => {
   it('canónicos simples', () => {
@@ -42,5 +42,61 @@ describe('scientificToSpeciesId (QUICK-17)', () => {
 
   it('preserva caso real con grupo cultivar suprimido', () => {
     expect(toId('Solanum tuberosum Grupo Phureja')).toBe('solanum_tuberosum');
+  });
+});
+
+describe('scientificToMatchInfo (V-03 #241/#242 — granularidad del match)', () => {
+  it('matchType="exact" para binomial puro sin stripping', () => {
+    expect(toMatch('Coffea arabica')).toEqual({ id: 'coffea_arabica', matchType: 'exact' });
+    expect(toMatch('Solanum betaceum')).toEqual({ id: 'solanum_betaceum', matchType: 'exact' });
+  });
+
+  it('matchType="stripped-authority" cuando se quita autoría taxonómica', () => {
+    expect(toMatch('Coffea arabica L.')).toEqual({ id: 'coffea_arabica', matchType: 'stripped-authority' });
+    expect(toMatch('Erythrina edulis Triana ex Micheli')).toEqual({
+      id: 'erythrina_edulis',
+      matchType: 'stripped-authority',
+    });
+  });
+
+  it('matchType="stripped-variety" cuando se quita cultivar/variedad/grupo', () => {
+    expect(toMatch("Solanum tuberosum 'Pastusa'")).toEqual({
+      id: 'solanum_tuberosum',
+      matchType: 'stripped-variety',
+    });
+    expect(toMatch('Solanum tuberosum Grupo Phureja')).toEqual({
+      id: 'solanum_tuberosum',
+      matchType: 'stripped-variety',
+    });
+    expect(toMatch('Coffea arabica var. typica')).toEqual({
+      id: 'coffea_arabica',
+      matchType: 'stripped-variety',
+    });
+    expect(toMatch('Coffea arabica cv. Bourbon')).toEqual({
+      id: 'coffea_arabica',
+      matchType: 'stripped-variety',
+    });
+    expect(toMatch('Brassica oleracea subsp. capitata')).toEqual({
+      id: 'brassica_oleracea',
+      matchType: 'stripped-variety',
+    });
+  });
+
+  it('matchType="stripped-hybrid" cuando se quita el marcador × o x separador', () => {
+    expect(toMatch('Citrus × paradisi')).toEqual({
+      id: 'citrus_paradisi',
+      matchType: 'stripped-hybrid',
+    });
+    expect(toMatch('Fragaria x ananassa')).toEqual({
+      id: 'fragaria_ananassa',
+      matchType: 'stripped-hybrid',
+    });
+  });
+
+  it('retorna null para inputs inválidos consistente con scientificToSpeciesId', () => {
+    expect(toMatch('')).toBe(null);
+    expect(toMatch('SoloUnaPalabra')).toBe(null);
+    expect(toMatch(null)).toBe(null);
+    expect(toMatch(undefined)).toBe(null);
   });
 });

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -306,29 +306,46 @@ const runSpeciesRecognition = async (model, base64, { onToken, signal, telemetry
 
 /**
  * Convierte un nombre científico binomial ("Coffea arabica L.") a un
- * `species_id` snake_case canónico ("coffea_arabica") compatible con el
- * catálogo Chagra. Quita autoría taxonómica (L., Mart., Kunth, etc.) y
- * cualquier sufijo descriptivo después del epíteto específico.
+ * `species_id` snake_case canónico ("coffea_arabica") + metadata del match
+ * (qué tanto se stripó del input para llegar al binomial base). Esto permite
+ * al caller distinguir cuándo el species_id derivado representa exactamente
+ * lo que dijo el modelo vs. cuándo es una aproximación (variedad → base).
+ *
+ * Retorna `{ id, matchType }` donde `matchType`:
+ *   - 'exact'             — el binomial input es exactamente `Genus species`
+ *                           (con autoría opcional pero sin variedad/grupo/×).
+ *   - 'stripped-authority'— se quitó autoría taxonómica (L., Mart., etc.),
+ *                           pero el binomial base es el mismo.
+ *   - 'stripped-variety'  — se quitó variedad/cultivar/grupo (ej. 'Pastusa',
+ *                           Grupo Phureja). El id base puede no representar
+ *                           bien la entidad del input.
+ *   - 'stripped-hybrid'   — se quitó el marcador de híbrido (× / x). El id
+ *                           ignora que la planta es híbrida formal.
  *
  * Ejemplos:
- *   "Coffea arabica L."                       → "coffea_arabica"
- *   "Solanum betaceum"                        → "solanum_betaceum"
- *   "Erythrina edulis Triana ex Micheli"      → "erythrina_edulis"
- *   "Solanum tuberosum Grupo Phureja"         → "solanum_tuberosum"  (sin Grupo)
+ *   "Coffea arabica"                          → { id: "coffea_arabica",   matchType: "exact" }
+ *   "Coffea arabica L."                       → { id: "coffea_arabica",   matchType: "stripped-authority" }
+ *   "Solanum tuberosum 'Pastusa'"             → { id: "solanum_tuberosum", matchType: "stripped-variety" }
+ *   "Solanum tuberosum Grupo Phureja"         → { id: "solanum_tuberosum", matchType: "stripped-variety" }
+ *   "Citrus × paradisi"                       → { id: "citrus_paradisi",   matchType: "stripped-hybrid" }
  *
- * Esto es heurística, no taxonomía perfecta. La validación final la hace
- * el catálogo: si el id derivado no existe, validate_visual_match lo
- * rechaza con `valid:false`.
+ * V-03 #241/#242 (2026-05-28): el caller usa `matchType` para downgrade el
+ * status de grounded de 'verified' a 'partial-match' cuando el id resuelto
+ * NO representa fielmente el binomial input (variedad o hybrid stripped).
+ *
+ * Si el input no es parseable retorna `null`.
  */
-function scientificToSpeciesId(scientific) {
+function scientificToMatchInfo(scientific) {
   if (typeof scientific !== 'string' || scientific.trim().length === 0) return null;
 
   // QUICK-17 (#280) 2026-05-27: normalizar Unicode + quitar diacríticos
-  // ANTES del regex. Permite que vision-model que emite "Niño" como token
-  // colateral o nombres científicos con acentos (raros, pero pasan) no
-  // sean rechazados. NFD descompone á→a+combining-acute, luego strip
-  // del bloque ̀-ͯ deja solo ASCII letter base.
+  // ANTES del regex.
   const ascii = scientific.normalize('NFD').replace(/[̀-ͯ]/g, '').trim();
+
+  // Detectar marcador de híbrido (× explícito o `x` como separador entre
+  // 2 epítetos válidos). NO confundir con `x` parte de un nombre.
+  const hasHybridMark = /(^|\s)[×]($|\s)/.test(ascii)
+    || /(^|\s)x($|\s)/.test(ascii.toLowerCase().split(/\s+/).slice(0, 3).join(' '));
 
   // QUICK-17: hybrid mark `×` o `x` separador (ej. "Citrus × paradisi" o
   // "Fragaria x ananassa") se omite. Tomar primeras 2 palabras NO-`×`.
@@ -341,13 +358,48 @@ function scientificToSpeciesId(scientific) {
   if (!/^[A-Za-z-]+$/.test(genus) || !/^[a-z-]+$/.test(species)) return null;
   const id = `${genus}_${species}`.toLowerCase();
   // QUICK-17 post-validate: doble check que el id final sea snake_case
-  // ASCII estricto (sin underscore inicial, sin caracteres raros).
+  // ASCII estricto.
   if (!/^[a-z][a-z0-9_]*$/.test(id)) return null;
-  return id;
+
+  // Clasificar matchType. Orden de prioridad: hybrid > variety > authority > exact.
+  let matchType = 'exact';
+  if (hasHybridMark) {
+    matchType = 'stripped-hybrid';
+  } else if (parts.length > 2) {
+    // Hay tokens después del epíteto. Distinguir variedad/grupo vs autoría.
+    // Heurística: variedad/cultivar suele venir con marcador explícito
+    // (`var.`, `cv.`, `subsp.`, `ssp.`, `f.`) o nombre entre comillas
+    // simples (`'Pastusa'`) o la palabra "Grupo". Autoría suele ser nombre
+    // propio capitalizado SIN esos marcadores (L., Mart., Kunth, etc.).
+    // Nota: `\b...\.\b` no funciona porque `\b` después de `.` no es
+    // word boundary. Anclamos por inicio de token (espacio o ^).
+    const rest = parts.slice(2).join(' ');
+    const varietyMarkers = /(?:^|\s)(var|cv|subsp|ssp|f)\.(?=\s|$)|(?:^|\s)(grupo|group)(?=\s|$)|['‘]/i;
+    if (varietyMarkers.test(rest)) {
+      matchType = 'stripped-variety';
+    } else {
+      matchType = 'stripped-authority';
+    }
+  }
+
+  return { id, matchType };
+}
+
+/**
+ * Convierte un nombre científico binomial a `species_id` snake_case.
+ * Wrapper backwards-compat de `scientificToMatchInfo` que solo devuelve el id.
+ *
+ * Mantenido para callers existentes y tests. Para grounding granular,
+ * usar `scientificToMatchInfo` directamente.
+ */
+function scientificToSpeciesId(scientific) {
+  const info = scientificToMatchInfo(scientific);
+  return info ? info.id : null;
 }
 
 // Export para tests (no usar en runtime fuera de aiService).
 export { scientificToSpeciesId as _scientificToSpeciesId };
+export { scientificToMatchInfo as _scientificToMatchInfo };
 
 /**
  * Versión grounded de recognizeSpecies. Llama al modelo de visión Y
@@ -357,7 +409,12 @@ export { scientificToSpeciesId as _scientificToSpeciesId };
  * Anti-alucinación: si el modelo vision devuelve "Mangosteenia colombiana"
  * (especie inexistente), el catálogo lo rechaza con `valid:false`. El
  * caller obtiene `_grounded.status` para decidir qué UX mostrar:
- *   - 'verified'         → catálogo confirma la sugerencia (verde).
+ *   - 'verified'         → catálogo confirma la sugerencia exacta (verde).
+ *   - 'partial-match'    → catálogo encontró el binomial base pero el input
+ *                          incluía variedad/cultivar/marcador híbrido que se
+ *                          stripó (amber-tibio). V-03 #241/#242: el mensaje
+ *                          "verificado" sería engañoso porque el id resuelto
+ *                          no representa fielmente lo que dijo el modelo.
  *   - 'rejected'         → catálogo rechaza la sugerencia (amber).
  *   - 'sidecar-disabled' → feature flag off (info).
  *   - 'offline'          → sin conexión, no se pudo verificar (info).
@@ -408,12 +465,13 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
     return finalize('offline', 'Sin conexión, no se pudo verificar.');
   }
 
-  // Derive species_id from scientific_name. Si no podemos derivar (binomial
-  // ausente o malformado), tampoco podemos validar — degradamos.
-  const speciesId = scientificToSpeciesId(visionResult.scientific_name);
-  if (!speciesId) {
+  // Derive species_id + match metadata desde scientific_name. Si no podemos
+  // derivar (binomial ausente o malformado), tampoco podemos validar.
+  const matchInfo = scientificToMatchInfo(visionResult.scientific_name);
+  if (!matchInfo) {
     return finalize('no-binomial', 'Nombre científico ambiguo.');
   }
+  const speciesId = matchInfo.id;
 
   // Construir lista de candidates: el principal + alternatives si vienen.
   const candidates = [
@@ -443,14 +501,40 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
 
   // Buscar el match del candidato primario en results.
   const primary = (result.results || []).find((r) => r.species_id === speciesId);
-  const verified = primary?.valid === true;
+  const validInCatalog = primary?.valid === true;
+  if (!validInCatalog) {
+    return finalize(
+      'rejected',
+      'Sugerencia no encontrada en catálogo.',
+      primary || null,
+      { _all_validations: result.results || [] },
+    );
+  }
+
+  // V-03 #241/#242 (2026-05-28): el catálogo dice "valid:true" pero el
+  // binomial input incluía variedad/cultivar/híbrido que se stripó para
+  // resolver el id base. Marcar como 'partial-match' para que UX no muestre
+  // "verificado" engañoso. Solo 'exact' y 'stripped-authority' (autoría
+  // taxonómica como "L.", "Mart.") cuentan como verificación plena, porque
+  // el binomial taxonómico subyacente sigue siendo el mismo.
+  if (matchInfo.matchType === 'stripped-variety' || matchInfo.matchType === 'stripped-hybrid') {
+    const reasonByType = {
+      'stripped-variety': 'Base verificada; variedad o cultivar específico no validado.',
+      'stripped-hybrid': 'Base verificada; el catálogo no distingue el híbrido formal.',
+    };
+    return finalize(
+      'partial-match',
+      reasonByType[matchInfo.matchType],
+      primary,
+      { _all_validations: result.results || [], _match_type: matchInfo.matchType },
+    );
+  }
+
   return finalize(
-    verified ? 'verified' : 'rejected',
-    verified
-      ? 'Verificado en catálogo Chagra.'
-      : 'Sugerencia no encontrada en catálogo.',
-    primary || null,
-    { _all_validations: result.results || [] },
+    'verified',
+    'Verificado en catálogo Chagra.',
+    primary,
+    { _all_validations: result.results || [], _match_type: matchInfo.matchType },
   );
 };
 


### PR DESCRIPTION
## Resumen

El badge \"verificado en catálogo\" era engañoso cuando el modelo vision emitía un binomial con variedad o marcador híbrido (ej. \`Solanum tuberosum 'Pastusa'\`, \`Citrus × paradisi\`) y el id snake_case se resolvía a la base sin verificar la fidelidad del epíteto.

Este PR introduce granularidad de match:

- \`scientificToMatchInfo\` retorna \`{id, matchType}\` clasificando \`exact\`, \`stripped-authority\`, \`stripped-variety\`, \`stripped-hybrid\`.
- Nuevo status \`partial-match\` en \`_grounded.status\` para los casos donde el catálogo valida la base pero hubo strip de variedad/híbrido. Solo \`exact\` y \`stripped-authority\` (autoría taxonómica L., Mart., etc.) siguen siendo \`verified\` pleno.
- Badge UI amber-tibio \"Coincidencia parcial\" con \`AlertCircle\`.

## Cambios

- \`src/services/aiService.js\`: nueva función \`scientificToMatchInfo\`, refactor de \`recognizeSpeciesGrounded\` para downgrade a \`partial-match\`.
- \`src/components/SpeciesSelect.jsx\`: badge nuevo + comentario actualizado a 7 estados.
- Tests:
  - \`scientificToSpeciesId.test.js\`: 5 nuevos casos cubriendo \`matchType\` para binomial puro, autoría (L., Triana ex Micheli), variedad ('Pastusa', var., cv., subsp., Grupo), híbrido (× y x).
  - \`aiService.grounded.test.js\`: 3 nuevos tests para \`partial-match\` (variedad, híbrido, verified-con-stripped-authority) + telemetría thunk + fix tangencial test legacy \`sidecar-disabled\`.

## Resultado UX

El campesino ya NO ve \"verificado\" cuando el modelo vio una variedad específica que el catálogo no documenta — ahora ve \"Coincidencia parcial\" con el motivo claro (\"Base verificada; variedad o cultivar específico no validado\").

## Test plan

- [x] \`npx vitest run scientificToSpeciesId aiService.grounded\` → 26/26 verde.
- [x] \`npx vitest run SpeciesSelect.smoke\` → 7/7 verde.
- [x] \`npx eslint\` sobre archivos cambiados → sin warnings.
- [x] \`npm run build\` → verde.
- [ ] Verificar manualmente badge \"Coincidencia parcial\" en device real con foto de papa Pastusa (post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)