### PR TITLE
feat(ux): batch quick-wins demo Diana — 5-8 items menor riesgo mayor impacto

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 import { useScrollRestoration } from './hooks/useScrollRestoration';
 import useIdleDetection from './hooks/useIdleDetection';
+import useGlobalKeyboardShortcuts from './hooks/useGlobalKeyboardShortcuts';
 import BiopunkBackground from './components/dashboard/BiopunkBackground';
 
 import { isAuthenticated, logoutUser } from './services/authService';
@@ -302,7 +303,11 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
 
 export default function App() {
   useTheme();
+  // Atajos teclado globales (?, g+h). Quick-win UX 2026-05-28 demo Diana.
+  // Solo activos post-login (no en loading ni login para no atrapar shift+?
+  // accidental al escribir password).
   const [currentView, setCurrentView] = useState('loading');
+  useGlobalKeyboardShortcuts({ enabled: currentView !== 'loading' && currentView !== 'login' });
   const [currentViewData, setCurrentViewData] = useState(null);
   const [toast, setToast] = useState(null);
   const [lastLogMessage, setLastLogMessage] = useState('');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import AgentFab from './components/AgentFab';
 import QuickActionsPanel from './components/QuickActionsPanel';
 import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
+import Confetti from './components/common/Confetti';
 import IosInstallBanner from './components/IosInstallBanner';
 import UpdateAvailableBanner from './components/UpdateAvailableBanner';
 import GpsFincaBanner from './components/GpsFincaBanner';
@@ -568,6 +569,7 @@ export default function App() {
       <NetworkStatusBar />
       <IosInstallBanner />
       <UpdateAvailableBanner />
+      <Confetti />
       <GpsFincaBanner />
       {/* Detector de vaciado IDB (post clear-cache).
           2026-05-19: el operador perdió plantas con foto + 100 species por

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,7 +117,8 @@ const ACCENT_CLASSES = {
 // Mantiene shell (TopBar + HomeRegionalGreeting) y delega contenido a
 // DashboardLive (src/components/dashboard/DashboardLive.jsx).
 const DashboardLiveView = React.memo(function DashboardLiveView({ onNavigate, onLogout }) {
-  useScrollRestoration('dashboard-live');
+  // Scroll restoration vive DENTRO de DashboardLive (apunta a su propio
+  // scroller — no hay <main> en DashboardLiveView).
   const hydrate = useAssetStore((s) => s.hydrate);
   const syncFromServer = useAssetStore((s) => s.syncFromServer);
   const idle = useIdleDetection(12000);

--- a/src/components/HomeRegionalGreeting.jsx
+++ b/src/components/HomeRegionalGreeting.jsx
@@ -2,18 +2,22 @@ import { useEffect, useState } from 'react';
 import { X, Sun, Sunset, Moon } from 'lucide-react';
 import useFincaActiveStore from '../services/fincaActiveStore';
 
+// Saludo regional con period-of-day. El "{period}" se interpola con
+// "Buenos días" / "Buenas tardes" / "Buenas noches" según la hora local,
+// y "{name}" con el nombre del operador (TopBar lo persiste en
+// localStorage 'chagra:operator:name'). Quick-win UX 2026-05-28 demo Diana.
 const ZONE_GREETINGS = {
-    andino_alto_páramo: 'Buenas, sumercé. Frío de páramo hoy. Lo del día en tu chagra…',
-    andino_alto: 'Buenas, sumercé. Frío andino hoy. Lo del día en tu chagra…',
-    andino_medio: 'Buenas, mijo. Clima andino templado. Lo del día en tu chagra…',
-    valle_caucano: 'Hola, ¿qué más, mijo? Lo del día en tu chagra del valle…',
-    caribe: '¡Qué calor caribe, mi llave! Lo del día en tu chagra…',
-    pacifico: 'Hola, compa. Lluvia pacífica como siempre. Lo del día en tu chagra…',
-    llanos: 'Buenas, vecino llanero. Lo del día en tu chagra…',
-    amazonia: 'Lo del día en la selva, panita…',
+    andino_alto_páramo: '{period}, sumercé{nameSuffix}. Frío de páramo hoy. Lo del día en tu chagra…',
+    andino_alto: '{period}, sumercé{nameSuffix}. Frío andino hoy. Lo del día en tu chagra…',
+    andino_medio: '{period}, mijo{nameSuffix}. Clima andino templado. Lo del día en tu chagra…',
+    valle_caucano: '{period}{nameSuffix}, ¿qué más? Lo del día en tu chagra del valle…',
+    caribe: '{period}{nameSuffix}. ¡Qué calor caribe! Lo del día en tu chagra…',
+    pacifico: '{period}, compa{nameSuffix}. Lluvia pacífica como siempre. Lo del día en tu chagra…',
+    llanos: '{period}, vecino llanero{nameSuffix}. Lo del día en tu chagra…',
+    amazonia: '{period}{nameSuffix}. Lo del día en la selva, panita…',
 };
 
-const DEFAULT_GREETING = 'Hola, lo del día en tu chagra…';
+const DEFAULT_GREETING = '{period}{nameSuffix}. Lo del día en tu chagra…';
 
 const STORAGE_KEY = 'chagra:home-greeting-dismissed:v1';
 
@@ -37,29 +41,68 @@ function dayPeriod() {
 }
 
 const PERIOD_STYLES = {
-    morning: { bg: 'bg-lime-900/40 border-lime-700/40 text-lime-100', Icon: Sun },
-    afternoon: { bg: 'bg-amber-900/40 border-amber-700/40 text-amber-100', Icon: Sunset },
-    night: { bg: 'bg-slate-800/80 border-slate-700/40 text-slate-200', Icon: Moon },
+    morning: { bg: 'bg-lime-900/40 border-lime-700/40 text-lime-100', Icon: Sun, label: 'Buenos días' },
+    afternoon: { bg: 'bg-amber-900/40 border-amber-700/40 text-amber-100', Icon: Sunset, label: 'Buenas tardes' },
+    night: { bg: 'bg-slate-800/80 border-slate-700/40 text-slate-200', Icon: Moon, label: 'Buenas noches' },
 };
+
+// Extrae "Miguel" de "Miguel Ángel Martínez" o "miguel.angel" o "Mi finca".
+// Devuelve el primer nombre con caso normalizado (Capitalized). Si el storage
+// trae el placeholder genérico ("Mi finca" / "Operador"), devolvemos ''.
+function getFirstName() {
+    try {
+        const raw = localStorage.getItem('chagra:operator:name');
+        if (!raw) return '';
+        const trimmed = raw.trim();
+        if (!trimmed || trimmed === 'Mi finca' || trimmed === 'Operador') return '';
+        // Tomar primer token alfabético (separadores: espacio, punto, guion)
+        const first = trimmed.split(/[\s.\-_]+/)[0];
+        if (!first) return '';
+        return first.charAt(0).toUpperCase() + first.slice(1).toLowerCase();
+    } catch {
+        return '';
+    }
+}
 
 export default function HomeRegionalGreeting() {
     const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
     const fincas = useFincaActiveStore((s) => s.fincas);
     const [dismissed, setDismissed] = useState(() => dismissedToday());
+    const [firstName, setFirstName] = useState(() => getFirstName());
 
     useEffect(() => {
-        const onStorage = () => setDismissed(dismissedToday());
+        const onStorage = (e) => {
+            if (!e.key || e.key === 'chagra:operator:name') {
+                setFirstName(getFirstName());
+            }
+            setDismissed(dismissedToday());
+        };
+        const onOperatorUpdate = (e) => {
+            if (e.detail?.key === 'chagra:operator:name') {
+                setFirstName(getFirstName());
+            }
+        };
         window.addEventListener('storage', onStorage);
-        return () => window.removeEventListener('storage', onStorage);
+        window.addEventListener('chagra:operator-update', onOperatorUpdate);
+        return () => {
+            window.removeEventListener('storage', onStorage);
+            window.removeEventListener('chagra:operator-update', onOperatorUpdate);
+        };
     }, []);
 
     if (dismissed) return null;
 
     const finca = (fincas || []).find((f) => f.slug === activeFincaSlug);
     const zone = finca?.biocultural_zone;
-    const greeting = (zone && ZONE_GREETINGS[zone]) || DEFAULT_GREETING;
+    const template = (zone && ZONE_GREETINGS[zone]) || DEFAULT_GREETING;
     const period = dayPeriod();
-    const { bg, Icon } = PERIOD_STYLES[period];
+    const { bg, Icon, label: periodLabel } = PERIOD_STYLES[period];
+    // nameSuffix arranca con coma+espacio cuando hay nombre, vacío si no.
+    // Patrón colombiano: "Buenos días, Miguel" (no "Buenos días Miguel").
+    const nameSuffix = firstName ? `, ${firstName}` : '';
+    const greeting = template
+        .replace('{period}', periodLabel)
+        .replace('{nameSuffix}', nameSuffix);
 
     function handleDismiss() {
         try {

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -7,6 +7,8 @@ import OfflineChip from './OfflineChip';
 import ChagraAgentAvatar from './ChagraAgentAvatar';
 import NotificationsBell from './NotificationsBell';
 import useFincaActiveStore from '../services/fincaActiveStore';
+import useOllamaWarmStore from '../store/useOllamaWarmStore';
+import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
 
 /**
@@ -55,6 +57,13 @@ export default function TopBar({ onNavigate, onLogout }) {
   const vereda = activeFinca?.vereda || null;
   const altitud = activeFinca?.altitud || FARM_CONFIG?.ALTITUD_MSNM || null;
 
+  // "Respira" animación del logo Chagra cuando hay actividad de fondo
+  // (warm-up del agente IA o sync con FarmOS). Sensación de "agente vivo
+  // está pensando" estilo iconos pulsantes Apple. Quick-win UX 2026-05-28.
+  const warmupStatus = useOllamaWarmStore((s) => s.status);
+  const syncProgress = useAssetStore((s) => s.syncProgress);
+  const isBreathing = warmupStatus === 'warming' || (syncProgress && !syncProgress.isComplete && !syncProgress.isCancelled);
+
   // Re-leer si cambia desde otro tab (storage event nativo) O desde el mismo
   // tab via ProfileScreen (chagra:operator-update CustomEvent).
   useEffect(() => {
@@ -90,14 +99,30 @@ export default function TopBar({ onNavigate, onLogout }) {
         <button
           type="button"
           onClick={() => onNavigate('dashboard')}
-          aria-label="Volver al inicio"
-          title="Volver al inicio"
+          aria-label={isBreathing ? 'Chagra está procesando' : 'Volver al inicio'}
+          title={isBreathing ? 'Chagra está pensando…' : 'Volver al inicio'}
           className="font-bold flex items-center gap-2 shrink-0 rounded-lg px-1 py-1 hover:bg-slate-800/60 active:bg-slate-700 transition-colors min-h-[44px]"
         >
-          <ChagraAgentAvatar size={32} state="idle" />
+          <span
+            className={isBreathing ? 'chagra-topbar-breathe' : ''}
+            style={{ display: 'inline-flex' }}
+            aria-hidden="true"
+          >
+            <ChagraAgentAvatar size={32} state={isBreathing ? 'thinking' : 'idle'} />
+          </span>
           <span className="hidden sm:inline text-base">Chagra</span>
           <span className="hidden md:inline text-[10px] text-slate-500 font-mono font-normal">v{APP_VERSION}</span>
         </button>
+        <style>{`
+          @keyframes chagra-topbar-breathe {
+            0%, 100% { transform: scale(1); filter: drop-shadow(0 0 0 rgba(16,185,129,0)); }
+            50% { transform: scale(1.06); filter: drop-shadow(0 0 6px rgba(16,185,129,.55)); }
+          }
+          .chagra-topbar-breathe { animation: chagra-topbar-breathe 2.4s ease-in-out infinite; }
+          @media (prefers-reduced-motion: reduce) {
+            .chagra-topbar-breathe { animation: none; }
+          }
+        `}</style>
 
         {/* Operador + ubicación (tap → perfil). Nombre real grande + ubicación
             municipio · vereda · msnm en pill pequeño debajo. */}

--- a/src/components/UpdateAvailableBanner.jsx
+++ b/src/components/UpdateAvailableBanner.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { RefreshCw } from 'lucide-react';
+import { RefreshCw, Sparkles } from 'lucide-react';
 import { writeAckedVersion } from '../services/swUpdateAck';
 
 export default function UpdateAvailableBanner() {
@@ -17,6 +17,15 @@ export default function UpdateAvailableBanner() {
     window.addEventListener('chagra:update-available', handler);
     return () => window.removeEventListener('chagra:update-available', handler);
   }, []);
+
+  // Pulso sutil del badge (sparkle) — solo durante los primeros 8s.
+  // Después se queda quieto para no ser ansioso. Quick-win UX 2026-05-28.
+  const [pulsing, setPulsing] = useState(true);
+  useEffect(() => {
+    if (!updateAvailable) return undefined;
+    const t = setTimeout(() => setPulsing(false), 8000);
+    return () => clearTimeout(t);
+  }, [updateAvailable]);
 
   const handleUpdate = async () => {
     // Persistimos el ack ANTES del reload: si el reload falla o el usuario
@@ -48,12 +57,19 @@ export default function UpdateAvailableBanner() {
       <div className="pointer-events-auto bg-slate-900 border border-slate-700 shadow-2xl rounded-2xl p-4 flex items-center gap-3 relative overflow-hidden">
         <div className="absolute top-0 left-0 w-1 h-full bg-muzo-glow" />
 
-        <div className="bg-muzo-glow/20 p-2 rounded-xl flex-shrink-0">
+        <div className={`bg-muzo-glow/20 p-2 rounded-xl flex-shrink-0 relative ${pulsing ? 'ring-2 ring-muzo-glow/60' : ''}`}>
           <RefreshCw className="text-muzo-glow" size={20} />
+          {pulsing && (
+            <Sparkles
+              className="absolute -top-1 -right-1 text-muzo-glow w-3 h-3 animate-pulse"
+              aria-hidden="true"
+            />
+          )}
         </div>
 
         <div className="flex-1 min-w-0">
           <p className="text-white font-bold text-sm">Nueva versión disponible</p>
+          <p className="text-slate-400 text-xs leading-snug">Actualiza para ver las mejoras más recientes.</p>
         </div>
 
         <button

--- a/src/components/__tests__/HomeRegionalGreeting.smoke.test.jsx
+++ b/src/components/__tests__/HomeRegionalGreeting.smoke.test.jsx
@@ -18,8 +18,13 @@ describe('HomeRegionalGreeting smoke', () => {
     });
 
     it('muestra saludo default cuando no hay finca activa', () => {
+        // El saludo ahora interpola period-of-day ("Buenos días" / "Buenas
+        // tardes" / "Buenas noches"). Test agnostic a la hora del runner: el
+        // patrón "Lo del día en tu chagra" sí es invariante del default.
         render(<HomeRegionalGreeting />);
-        expect(screen.getByRole('banner')).toHaveTextContent('Hola, lo del día en tu chagra');
+        const text = screen.getByRole('banner').textContent;
+        expect(text).toMatch(/Buenos días|Buenas tardes|Buenas noches/);
+        expect(text).toContain('Lo del día en tu chagra');
     });
 
     it('saludo regional según biocultural_zone andino_alto_páramo', () => {

--- a/src/components/common/Confetti.jsx
+++ b/src/components/common/Confetti.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Confetti — micro-animación de celebración sin dependencias.
+ *
+ * Quick-win UX 2026-05-28 demo Diana: cuando el usuario registra su primera
+ * planta (count 0 → 1), aparecen partículas verdes/lima que caen 2.5s y
+ * desaparecen. Sensación de "cosecha" / "logro". Sin libs externas.
+ *
+ * Listener global de CustomEvent('chagra:celebrate'):
+ *   { detail: { reason?: string, durationMs?: number } }
+ * Emisor (en useAssetStore.addAsset) dispara cuando plants pasa de 0 → 1.
+ *
+ * Implementación: 32 spans posicionados absolute con animación CSS keyframes
+ * (fall + spin). Cada uno tiene delay/duración/color randomized en JS, pero
+ * la animación es 100% GPU (transform + opacity). No bloquea main thread.
+ *
+ * Reducción de movimiento: respeta prefers-reduced-motion (no anima si user
+ * tiene OS preference set).
+ */
+
+const PARTICLE_COUNT = 36;
+const COLORS = ['#84cc16', '#22c55e', '#10b981', '#06b6d4', '#facc15', '#f97316'];
+
+function buildParticles(count) {
+  const arr = [];
+  for (let i = 0; i < count; i += 1) {
+    arr.push({
+      id: i,
+      left: Math.random() * 100, // %
+      color: COLORS[Math.floor(Math.random() * COLORS.length)],
+      delay: Math.random() * 400, // ms
+      duration: 1800 + Math.random() * 1500, // ms
+      size: 6 + Math.random() * 8, // px
+      drift: (Math.random() - 0.5) * 80, // px lateral drift
+      rotate: Math.random() * 720 - 360, // deg final rotation
+    });
+  }
+  return arr;
+}
+
+export default function Confetti() {
+  const [active, setActive] = useState(false);
+  const [particles, setParticles] = useState([]);
+
+  useEffect(() => {
+    let timer;
+    const handler = (event) => {
+      // Respect reduced-motion: no confetti for users with prefers-reduced-motion.
+      const reduce = typeof window !== 'undefined' && window.matchMedia
+        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        : false;
+      if (reduce) return;
+      const duration = event?.detail?.durationMs || 2500;
+      setParticles(buildParticles(PARTICLE_COUNT));
+      setActive(true);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setActive(false), duration);
+    };
+    window.addEventListener('chagra:celebrate', handler);
+    return () => {
+      window.removeEventListener('chagra:celebrate', handler);
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <div
+      aria-hidden="true"
+      className="fixed inset-0 z-[200] pointer-events-none overflow-hidden"
+    >
+      <style>{`
+        @keyframes chagra-confetti-fall {
+          0% {
+            transform: translate3d(0, -20vh, 0) rotate(0deg);
+            opacity: 1;
+          }
+          100% {
+            transform: translate3d(var(--cf-drift, 0px), 110vh, 0) rotate(var(--cf-rotate, 360deg));
+            opacity: 0;
+          }
+        }
+        .chagra-confetti-particle {
+          position: absolute;
+          top: -20px;
+          border-radius: 2px;
+          will-change: transform, opacity;
+          animation-name: chagra-confetti-fall;
+          animation-timing-function: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+          animation-fill-mode: forwards;
+        }
+      `}</style>
+      {particles.map((p) => (
+        <span
+          key={p.id}
+          className="chagra-confetti-particle"
+          style={{
+            left: `${p.left}%`,
+            width: `${p.size}px`,
+            height: `${p.size * 1.4}px`,
+            backgroundColor: p.color,
+            animationDelay: `${p.delay}ms`,
+            animationDuration: `${p.duration}ms`,
+            '--cf-drift': `${p.drift}px`,
+            '--cf-rotate': `${p.rotate}deg`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/common/Skeleton.jsx
+++ b/src/components/common/Skeleton.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+/**
+ * Skeleton — placeholder de carga reutilizable con shimmer suave.
+ *
+ * Quick-win UX 2026-05-28 (batch demo Diana): los counters del dashboard
+ * mostraban "0" durante el primer paint, mientras `useAssetStore.hydrate()`
+ * leía IndexedDB. Sensación de app vacía aunque tuviera 100 plantas. El
+ * skeleton da feedback visual de "estoy cargando" sin spinner técnico.
+ *
+ * Variantes:
+ *   - "line"    → rect 4px alto, sirve para títulos/etiquetas (default)
+ *   - "rect"    → rect cualquier alto/ancho, sirve para cards
+ *   - "circle"  → círculo, sirve para avatars
+ *
+ * Sin dependencias: pure tailwind + animate-pulse del propio Tailwind 3.
+ */
+export default function Skeleton({
+  variant = 'line',
+  width,
+  height,
+  className = '',
+  rounded = 'md',
+  ariaLabel = 'Cargando…',
+}) {
+  const base = 'bg-slate-700/40 animate-pulse';
+  const roundedClass = {
+    none: '',
+    sm: 'rounded-sm',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    full: 'rounded-full',
+  }[rounded] || 'rounded-md';
+
+  let style;
+  let shapeClass;
+  if (variant === 'circle') {
+    const size = width || height || 32;
+    style = { width: size, height: size };
+    shapeClass = 'rounded-full';
+  } else if (variant === 'rect') {
+    style = { width: width || '100%', height: height || 80 };
+    shapeClass = roundedClass;
+  } else {
+    style = { width: width || '60%', height: height || 12 };
+    shapeClass = roundedClass;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-label={ariaLabel}
+      aria-busy="true"
+      className={`${base} ${shapeClass} ${className}`}
+      style={style}
+    />
+  );
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useScrollRestoration } from '../../hooks/useScrollRestoration';
 import {
     DndContext,
     closestCenter,
@@ -142,6 +143,10 @@ export default function DashboardLive({ onNavigate }) {
     const [order, setOrder] = useState(readOrder);
     const iotAlerts = useAssetStore((s) => s.iotAlerts) || [];
 
+    // Persist scroll position al volver de detalle (mismo bug que App.jsx
+    // resolvió para Dashboard clásico). Quick-win UX 2026-05-28 demo Diana.
+    useScrollRestoration('dashboard-live', '[data-scroll-key="dashboard-live"]');
+
     useEffect(() => {
         writeOrder(order);
     }, [order]);
@@ -164,7 +169,10 @@ export default function DashboardLive({ onNavigate }) {
     }, []);
 
     return (
-        <div className="flex flex-col w-full h-full overflow-y-auto pb-24">
+        <div
+            className="flex flex-col w-full h-full overflow-y-auto pb-24"
+            data-scroll-key="dashboard-live"
+        >
             {/* Agente: fijo arriba, no draggable. Protagonista. */}
             <AgentHero onNavigate={onNavigate} />
 

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -1,5 +1,6 @@
 import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf } from 'lucide-react';
 import useAssetStore from '../../store/useAssetStore';
+import Skeleton from '../common/Skeleton';
 
 /**
  * FincaCards — secciones del dashboard re-organizadas con sensibilidad
@@ -76,8 +77,11 @@ const SECTION_STYLES = {
     },
 };
 
-function Card({ section, title, subtitle, value, onClick, badge, variant = 'list' }) {
+function Card({ section, title, subtitle, value, onClick, badge, variant = 'list', loading = false, tooltip }) {
     const style = SECTION_STYLES[section] || SECTION_STYLES.plantas;
+    // Tooltip nativo (title) funciona bien en desktop hover y NO bloquea
+    // touch en mobile (Safari/Chrome lo muestran on long-press). Sin libs.
+    const titleAttr = tooltip || (subtitle ? `${title} — ${subtitle}` : title);
 
     // GRID variant: layout cuadrado, emoji grande centrado arriba, title abajo,
     // value en corner top-right. Optimizado para cuadrícula 2-col/3-col que
@@ -87,10 +91,16 @@ function Card({ section, title, subtitle, value, onClick, badge, variant = 'list
             <button
                 type="button"
                 onClick={onClick}
+                title={titleAttr}
+                aria-label={titleAttr}
                 className={`group relative w-full text-left rounded-2xl bg-gradient-to-br ${style.accent} backdrop-blur-xl border ${style.border} p-4 ring-2 ${style.ring} transition-all active:scale-[0.96] hover:-translate-y-0.5 aspect-square flex flex-col items-center justify-between min-h-[120px]`}
             >
                 {/* Badge / value top-right */}
-                {(value != null || badge != null) && (
+                {loading ? (
+                    <div className="absolute top-2 right-2">
+                        <Skeleton variant="rect" width={28} height={16} rounded="md" ariaLabel="Cargando contador" />
+                    </div>
+                ) : (value != null || badge != null) && (
                     <div className="absolute top-2 right-2 px-1.5 py-0.5 rounded-md text-[11px] font-black bg-black/35 backdrop-blur text-white tabular-nums">
                         {value != null ? value : badge}
                     </div>
@@ -111,6 +121,8 @@ function Card({ section, title, subtitle, value, onClick, badge, variant = 'list
         <button
             type="button"
             onClick={onClick}
+            title={titleAttr}
+            aria-label={titleAttr}
             className={`group relative w-full text-left rounded-2xl bg-gradient-to-br ${style.accent} backdrop-blur-xl border ${style.border} p-4 ring-2 ${style.ring} transition-all active:scale-[0.98]`}
         >
             <div className="flex items-center gap-3">
@@ -126,11 +138,19 @@ function Card({ section, title, subtitle, value, onClick, badge, variant = 'list
                             </span>
                         )}
                     </div>
-                    {subtitle && (
+                    {loading ? (
+                        <div className="mt-1.5">
+                            <Skeleton variant="line" width="80%" height={10} ariaLabel="Cargando descripción" />
+                        </div>
+                    ) : subtitle && (
                         <p className="text-xs text-slate-300/80 mt-0.5 truncate">{subtitle}</p>
                     )}
                 </div>
-                {value != null && (
+                {loading ? (
+                    <div className="shrink-0">
+                        <Skeleton variant="rect" width={32} height={28} rounded="md" ariaLabel="Cargando contador" />
+                    </div>
+                ) : value != null && (
                     <div className="shrink-0 text-right">
                         <div className="text-2xl font-black text-white leading-none tabular-nums">{value}</div>
                     </div>
@@ -143,14 +163,23 @@ function Card({ section, title, subtitle, value, onClick, badge, variant = 'list
 
 export function PlantasCard({ onNavigate, variant }) {
     const plants = useAssetStore((s) => s.plants);
+    const isHydrated = useAssetStore((s) => s.isHydrated);
     const count = plants.length;
+    // Empty-state amistoso cuando ya hidrato y sigue en cero (no esperar más).
+    const subtitle = !isHydrated
+        ? 'Cargando…'
+        : count > 0
+            ? (count === 1 ? 'planta sembrada' : 'plantas sembradas')
+            : '¡Agrega tu primera planta!';
     return (
         <Card
             variant={variant}
             section="plantas"
             title="Mis plantas"
-            subtitle={count > 0 ? `${count === 1 ? 'planta sembrada' : 'plantas sembradas'}` : 'Aún no has registrado nada'}
-            value={count}
+            subtitle={subtitle}
+            value={isHydrated ? count : null}
+            loading={!isHydrated}
+            tooltip="Cultivos registrados en tu chagra. Tócalo para ver el inventario, agregar o consultar el detalle."
             onClick={() => onNavigate('activos')}
         />
     );
@@ -158,14 +187,22 @@ export function PlantasCard({ onNavigate, variant }) {
 
 export function ZonasCard({ onNavigate, variant }) {
     const lands = useAssetStore((s) => s.lands);
+    const isHydrated = useAssetStore((s) => s.isHydrated);
     const count = lands.length;
+    const subtitle = !isHydrated
+        ? 'Cargando…'
+        : count > 0
+            ? (count === 1 ? 'área de tu finca' : 'áreas de tu finca')
+            : 'Define dónde cultivas';
     return (
         <Card
             variant={variant}
             section="zonas"
             title="Mis zonas"
-            subtitle={count > 0 ? `${count === 1 ? 'área de tu finca' : 'áreas de tu finca'}` : 'Define dónde cultivas'}
-            value={count}
+            subtitle={subtitle}
+            value={isHydrated ? count : null}
+            loading={!isHydrated}
+            tooltip="Parcelas, camas, invernaderos y áreas de tu finca. Define dónde está cada cultivo."
             onClick={() => onNavigate('mapa')}
         />
     );
@@ -173,14 +210,22 @@ export function ZonasCard({ onNavigate, variant }) {
 
 export function InsumosCard({ onNavigate, variant }) {
     const materials = useAssetStore((s) => s.materials);
+    const isHydrated = useAssetStore((s) => s.isHydrated);
     const count = materials.length;
+    const subtitle = !isHydrated
+        ? 'Cargando…'
+        : count > 0
+            ? 'Biopreparados y materiales'
+            : 'Lleva control de lo que tienes';
     return (
         <Card
             variant={variant}
             section="insumos"
             title="Insumos"
-            subtitle={count > 0 ? 'Biopreparados y materiales' : 'Lleva control de lo que tienes'}
-            value={count}
+            subtitle={subtitle}
+            value={isHydrated ? count : null}
+            loading={!isHydrated}
+            tooltip="Bioinsumos (bocashi, biol, caldos), semillas, herramientas. Stock disponible en bodega."
             onClick={() => onNavigate('bodega')}
         />
     );
@@ -193,6 +238,7 @@ export function BitacoraCard({ onNavigate, variant }) {
             section="bitacora"
             title="Bitácora"
             subtitle="Todo lo que has hecho en tu finca"
+            tooltip="Historial cronológico: siembras, cosechas, aplicaciones de bioinsumo, observaciones."
             onClick={() => onNavigate('historial')}
         />
     );
@@ -205,6 +251,7 @@ export function HoyCard({ onNavigate, variant }) {
             section="hoy"
             title="Hoy en finca"
             subtitle="Lo que toca hacer cerca tuyo"
+            tooltip="Tareas pendientes ordenadas por cercanía a tu ubicación actual."
             onClick={() => onNavigate('javier')}
         />
     );
@@ -217,6 +264,7 @@ export function PlagasCard({ onNavigate, variant }) {
             section="plagas"
             title="Plagas"
             subtitle="Reporta y consulta"
+            tooltip="Reporta una plaga o invasora con foto. Chagra sugiere manejo agroecológico sin químicos."
             onClick={() => onNavigate('reportar_invasora')}
         />
     );
@@ -229,6 +277,7 @@ export function BiodiversidadCard({ onNavigate, variant }) {
             section="biodiversidad"
             title="Flora y fauna"
             subtitle="Ecosistema de tu chagra"
+            tooltip="Catálogo de especies nativas, endémicas y polinizadores que viven en tu finca."
             onClick={() => onNavigate('biodiversidad')}
         />
     );
@@ -241,6 +290,7 @@ export function InformesCard({ onNavigate, variant }) {
             section="informes"
             title="Informes"
             subtitle="Descarga reportes en CSV"
+            tooltip="Exporta cuaderno de campo, inventario, registros de cosecha y aplicaciones a CSV/PDF."
             onClick={() => onNavigate('informes')}
         />
     );

--- a/src/hooks/useGlobalKeyboardShortcuts.js
+++ b/src/hooks/useGlobalKeyboardShortcuts.js
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+
+/**
+ * useGlobalKeyboardShortcuts — atajos de teclado globales.
+ *
+ * Quick-win UX 2026-05-28 demo Diana: el usuario power (en laptop o iPad
+ * con teclado externo) puede invocar Ayuda con "?" desde cualquier pantalla
+ * sin tener que volver al dashboard. Es el patrón que usan Slack/Linear/
+ * GitHub y la gente lo descubre por accidente (positivo).
+ *
+ * Mapeo:
+ *   - "?"           → abre help (manual de uso) navegando con CustomEvent.
+ *   - "g" + "h"     → go home (dashboard). Patrón Gmail/Linear.
+ *
+ * No interfiere con inputs (chequea event.target tagName + isContentEditable
+ * + role="textbox"). Solo en touch puro no se activa (no hay teclado).
+ */
+export function useGlobalKeyboardShortcuts({ enabled = true } = {}) {
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    let gPressed = false;
+    let gTimer = null;
+
+    const isEditableTarget = (target) => {
+      if (!target) return false;
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+      if (target.isContentEditable) return true;
+      if (target.getAttribute?.('role') === 'textbox') return true;
+      return false;
+    };
+
+    const navigateGlobal = (view) => {
+      window.dispatchEvent(new CustomEvent('chagra:nav', { detail: view }));
+    };
+
+    const onKeyDown = (e) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isEditableTarget(e.target)) return;
+
+      // "?" abre ayuda — typical es shift+/ en QWERTY ES/EN.
+      if (e.key === '?') {
+        e.preventDefault();
+        navigateGlobal('help');
+        return;
+      }
+
+      // "g" + "h" → go home. Inspirado en Gmail/Linear.
+      if (e.key === 'g' && !gPressed) {
+        gPressed = true;
+        if (gTimer) clearTimeout(gTimer);
+        gTimer = setTimeout(() => {
+          gPressed = false;
+          gTimer = null;
+        }, 800);
+        return;
+      }
+      if (gPressed && e.key === 'h') {
+        e.preventDefault();
+        gPressed = false;
+        if (gTimer) {
+          clearTimeout(gTimer);
+          gTimer = null;
+        }
+        navigateGlobal('dashboard');
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      if (gTimer) clearTimeout(gTimer);
+    };
+  }, [enabled]);
+}
+
+export default useGlobalKeyboardShortcuts;

--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -27,12 +27,15 @@ import { useEffect, useRef } from 'react';
  * minimizar writes (sessionStorage es sync). Restore es instantáneo en
  * mount.
  */
-export function useScrollRestoration(viewKey) {
+export function useScrollRestoration(viewKey, selector = 'main') {
   const restoredRef = useRef(false);
 
   useEffect(() => {
     const key = `chagra:scroll:${viewKey}`;
-    const mainEl = document.querySelector('main');
+    // selector: 'main' por defecto (ScreenShell). Para vistas custom como
+    // DashboardLive que no usan ScreenShell, pasar otro selector
+    // (ej. `[data-scroll-restore="dashboard-live"]`).
+    const mainEl = document.querySelector(selector);
     if (!mainEl) return;
 
     // Restore en mount (single shot por mount)
@@ -69,5 +72,5 @@ export function useScrollRestoration(viewKey) {
         sessionStorage.setItem(key, String(mainEl.scrollTop));
       }
     };
-  }, [viewKey]);
+  }, [viewKey, selector]);
 }

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -32,6 +32,12 @@ const useAssetStore = create((set, get) => ({
   taxonomyTerms: [],
   lastSync: null,
   isLoading: false,
+  // isHydrated: true tras el primer hydrate() exitoso (lectura IndexedDB).
+  // Sirve para distinguir "todavía no leí del IDB" (mostrar skeletons) vs
+  // "leí del IDB y efectivamente tiene 0 plantas" (mostrar empty-state).
+  // Quick-win UX 2026-05-28: counters mostraban "0" durante el primer
+  // paint mientras el store hidrataba — sensación de app vacía falso.
+  isHydrated: false,
   error: null,
   syncProgress: null, // { current, total, assetType, isComplete, isCancelled, error }
 
@@ -52,7 +58,7 @@ const useAssetStore = create((set, get) => ({
         assetCache.getAllTaxonomyTerms(),
       ]);
       const lastSync = await assetCache.getLastSync();
-      set({ plants, structures, equipment, materials, lands, taxonomyTerms, lastSync });
+      set({ plants, structures, equipment, materials, lands, taxonomyTerms, lastSync, isHydrated: true });
 
       // emptyDbDetector: si hidratamos con assets reales, dejamos huella en
       // localStorage de "este dispositivo tuvo datos". Sirve para detectar
@@ -64,6 +70,9 @@ const useAssetStore = create((set, get) => ({
       }
     } catch (err) {
       console.error('Error rehidratando asset store desde IndexedDB:', err);
+      // Marcamos isHydrated igual: aunque falló, no queremos quedar atascados
+      // en skeleton perpetuo. UI mostrará empty-state real.
+      set({ isHydrated: true });
     }
   },
 

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -225,6 +225,9 @@ const useAssetStore = create((set, get) => ({
 
   // Crear asset con commit atómico: IDB (assets + pending_transactions) en una sola tx
   addAsset: async (assetType, asset, pendingTxs = []) => {
+    // Snapshot pre-commit para detectar "primera planta" (count 0 → 1).
+    // Quick-win UX 2026-05-28: dispara confetti celebratorio.
+    const prevPlantsCount = get().plants.length;
     try {
       await assetCache.commitOptimisticUpdate([{ assetType, asset }], pendingTxs);
       set((state) => {
@@ -238,6 +241,17 @@ const useAssetStore = create((set, get) => ({
       const totalNow = get().plants.length + get().structures.length + get().equipment.length + get().materials.length + get().lands.length;
       markHadData(totalNow);
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
+
+      // Celebración primera planta (count 0 → 1). El listener vive en
+      // Confetti (montado global en App.jsx). Wrap try/catch defensivo:
+      // window/CustomEvent puede no existir en SSR o tests sin jsdom event.
+      if (assetType === 'plant' && prevPlantsCount === 0) {
+        try {
+          window.dispatchEvent(new CustomEvent('chagra:celebrate', {
+            detail: { reason: 'first-plant', durationMs: 2800 },
+          }));
+        } catch (_) { /* test env may not support */ }
+      }
     } catch (error) {
       console.error('[Store] Fallo en addAsset atómico:', error);
       throw error;


### PR DESCRIPTION
## Resumen

Batch de quick-wins UX de menor riesgo y mayor impacto visible para la demo Diana lunes 2026-06-01. Cero lógica core tocada (agente, sidecar, AGE, catálogo intactos). Cero dependencias nuevas. Cero breaking changes APIs.

## Items implementados (8)

- [x] **Loading skeleton** en cards del dashboard mientras hidratan stores (Plantas, Zonas, Insumos)
- [x] **Empty state amistoso** cuando no hay plantas (`"¡Agrega tu primera planta!"` en lugar del frío `"Aún no has registrado nada"`)
- [x] **Tooltip explicativo** en TODAS las cards del dashboard (hover desktop + long-press touch via `title` + `aria-label`)
- [x] **Saludo time-of-day** con nombre del operador (`"Buenos días, Miguel"` / `"Buenas tardes, sumercé"` según hora local + nombre desde localStorage)
- [x] **Atajo `?`** abre Ayuda en cualquier pantalla post-login (+ `g+h` go-home estilo Linear/Gmail)
- [x] **Persistir scroll position** en DashboardLive al volver de detalle (mismo patrón ya funcionaba en DashboardView clásico)
- [x] **Badge `nueva versión` sutil** con sparkle pulsante 8s + ring esmeralda + subtítulo contextual
- [x] **Confetti micro-animación** al registrar primera planta (count 0→1), 36 partículas verdes/lima/amarillas/naranja, 2.8s, respeta `prefers-reduced-motion`
- [x] **Animación "respira"** del logo Chagra en TopBar cuando agente IA pre-warming o sync FarmOS en curso

## Items skipped (intencionalmente)

- **Onboarding tour 3 pasos**: requiere highlight + arrow + popover system — overhead alto vs visibilidad marginal en demo.
- **Modo claro/oscuro toggle**: ya existe en `ThemeSelector` (perfil → temas).
- **Modal floating "?" help**: ya hay 3 FABs en pantalla (Mic + Agent + QuickActions), agregar un cuarto satura.
- **Tag "primer cultivo del año"**: depende de fecha de siembra parseable y branding bandera — siguiente iteración.
- **Bottom sheet `¿Necesitas ayuda?` sticky**: redundante con FABs existentes y botón Help en TopBar.

## Test plan

- [ ] Smoke `npm run test:unit` — confirmar nuevos pasos (Skeleton + greeting period-of-day) y que las 1237 tests verdes siguen verdes
- [ ] Smoke `npm run build` — verificado localmente OK (2.88s, DashboardLive 67.49kB, sin warnings nuevos)
- [ ] Demo manual Chrome/Chromium android viewport:
  - [ ] Cards dashboard muestran skeleton ~200ms al cold-start, luego count real
  - [ ] Tooltip aparece on long-press en cada card
  - [ ] Saludo dice `Buenos días/tardes/noches` + primer nombre si está en perfil
  - [ ] Tocar `?` con teclado en laptop → abre Help desde cualquier pantalla
  - [ ] Scroll dashboard-live + tap card + back → scroll preservado
  - [ ] Registrar nueva planta con 0 plantas previas → confetti 2.8s
  - [ ] Agente warming → logo Chagra TopBar pulsa con drop-shadow esmeralda

## Notas

- Anti-leak verificado: cero codenames internos, cero referencias estratégicas, cero IPs privadas. Solo cambios UX en `src/`.
- Spanish colombiano (`tú`/`usted`), zero voseo argentino.
- Pre-existing lint warning (`useIdleDetection.js:71` unused eslint-disable) no relacionado con este batch.
- Pre-existing test failures (FeedbackButtons, voiceService, agentService, TopBar.voicePlant, estratoCopy) no relacionadas con este batch — verificadas en stash sin mis cambios.

Refs: brainstorm UX_TESTING_BRAINSTORM_2026-05-27.md task #289.