### PR TITLE
fix(ux): botón ubicación Brave + notif clima → agente con prompt + cita fuente

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -554,9 +554,19 @@ export default function App() {
       case 'help':
         return <HelpManual onBack={() => navigate('dashboard')} onNavigate={navigate} />;
       case 'agente':
+        // 2026-05-28: pasamos currentViewData como initialContext para que
+        // notificaciones críticas (helada, alerta clima) lleguen al agente
+        // con prompt pre-cargado + cita de la fuente (IDEAM/NOAA/CIIFEN/
+        // Open-Meteo) — operador no tiene que re-tipear "tengo alerta de
+        // helada, ¿qué hago?". Si el usuario entra al agente normal (FAB,
+        // tile, etc.), currentViewData es null y el comportamiento previo
+        // se preserva sin cambios.
         return (
           <ErrorBoundary>
-            <AgentScreen onBack={() => navigate('dashboard')} />
+            <AgentScreen
+              onBack={() => navigate('dashboard')}
+              initialContext={currentViewData}
+            />
           </ErrorBoundary>
         );
       default:

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe } from '../../services/voiceService';
 import {
@@ -50,7 +50,7 @@ const STATE_IDLE = 'idle';
 const STATE_RECORDING = 'recording';
 const STATE_THINKING = 'thinking';
 
-export default function AgentScreen({ onBack }) {
+export default function AgentScreen({ onBack, initialContext }) {
   const operatorId = usePrefsStore((s) => s.operatorId) || 'default-operator';
   // Task #122 (2026-05-23): ttsEnabled global persistido en usePrefsStore.
   // Antes era useState local — al cambiarlo en otra pantalla (header
@@ -120,6 +120,13 @@ export default function AgentScreen({ onBack }) {
   // ni se inyecta al messages real. Aparece junto a QuickChipsBar cuando
   // chat está vacío e idle.
   const [showAgentDemo, setShowAgentDemo] = useState(false);
+  // 2026-05-28 UX: cuando el operador llega al agente desde una notificación
+  // climática (NotificationsBell), recibimos `initialContext` con prompt
+  // pre-cargado + cita de la entidad emisora (IDEAM/NOAA/CIIFEN/Open-Meteo).
+  // Mostramos un banner discreto arriba del input con la cita y el link al
+  // informe oficial. El banner es dismissable — al primer submit, o cuando
+  // el operador cierra, desaparece. NO se persiste entre mounts.
+  const [alertContextBanner, setAlertContextBanner] = useState(null);
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -294,6 +301,28 @@ export default function AgentScreen({ onBack }) {
       }
     });
     return () => { alive = false; };
+  }, []);
+
+  // 2026-05-28: aplicar initialContext de notificación climática.
+  // Si el operador llega desde NotificationsBell con prefilledPrompt + cita
+  // de entidad emisora, prellenamos el input y mostramos un banner con el
+  // link al informe oficial. Solo corre al primer mount (deps vacías) — el
+  // initialContext es de un solo uso. Re-entrar al agente desde el menú
+  // normal NO debe re-disparar el prompt.
+  useEffect(() => {
+    if (!initialContext) return;
+    const { prefilledPrompt, sourceLabel, sourceUrl, alertContext } = initialContext;
+    if (typeof prefilledPrompt === 'string' && prefilledPrompt.trim().length > 0) {
+      setInputText(prefilledPrompt);
+    }
+    if (sourceUrl || sourceLabel || alertContext) {
+      setAlertContextBanner({
+        sourceLabel: sourceLabel || null,
+        sourceUrl: sourceUrl || null,
+        alertContext: alertContext || null,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Bug 2026-05-18: health check del LLM al mount. Si /api/ollama/api/tags
@@ -1407,6 +1436,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     e.preventDefault();
     handleSubmit(inputText);
     setInputText('');
+    // El banner de contexto de alerta es de un solo uso — al primer submit
+    // el operador ya está conversando con el agente y el banner queda
+    // redundante. Se reabre solo si vuelve a entrar desde la notificación.
+    setAlertContextBanner(null);
   };
 
   const handleSuggestion = (text) => {
@@ -1585,6 +1618,58 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       )}
       {state === STATE_IDLE && messages.length === 0 && showAgentDemo && (
         <AgentDemoExample onClose={() => setShowAgentDemo(false)} />
+      )}
+
+      {/* 2026-05-28 UX: banner de contexto de alerta climática. Aparece
+          cuando el operador llega desde una notificación con prompt
+          pre-cargado + cita de la entidad emisora (IDEAM/NOAA/CIIFEN/
+          Open-Meteo). Banner discreto arriba del input — el operador ve la
+          fuente del aviso antes de mandar la pregunta. Dismissable. */}
+      {alertContextBanner && (
+        <div
+          className="mx-4 mb-2 p-3 rounded-lg bg-sky-950/40 border border-sky-800/50 flex items-start gap-3"
+          data-testid="agent-alert-context-banner"
+          role="status"
+        >
+          <div className="flex-1 min-w-0">
+            {alertContextBanner.alertContext?.title && (
+              <p className="text-xs font-bold text-sky-200 leading-tight">
+                {alertContextBanner.alertContext.title}
+              </p>
+            )}
+            {alertContextBanner.alertContext?.body && (
+              <p className="text-[11px] text-sky-300/85 mt-0.5 leading-snug">
+                {alertContextBanner.alertContext.body}
+              </p>
+            )}
+            {(alertContextBanner.sourceLabel || alertContextBanner.sourceUrl) && (
+              <p className="text-[10px] text-slate-400 mt-1.5 leading-tight">
+                Fuente:{' '}
+                {alertContextBanner.sourceUrl ? (
+                  <a
+                    href={alertContextBanner.sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sky-300 hover:text-sky-200 underline"
+                    data-testid="agent-alert-source-link"
+                  >
+                    {alertContextBanner.sourceLabel || 'Ver informe oficial'}
+                  </a>
+                ) : (
+                  <span className="text-slate-300">{alertContextBanner.sourceLabel}</span>
+                )}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => setAlertContextBanner(null)}
+            className="shrink-0 p-1 rounded-md hover:bg-white/10 text-slate-400"
+            aria-label="Cerrar contexto de alerta"
+          >
+            <X size={14} />
+          </button>
+        </div>
       )}
 
       {/* Input */}

--- a/src/components/NotificationsBell.jsx
+++ b/src/components/NotificationsBell.jsx
@@ -139,10 +139,86 @@ export default function NotificationsBell({ onNavigate }) {
             return;
         }
         if (notif.cta_view) {
-            onNavigate?.(notif.cta_view);
+            // 2026-05-28: si la notificación va al agente y trae prompt
+            // pre-cargado + fuente, lo pasamos como initialContext para
+            // que AgentScreen prellene el textarea y muestre la cita de
+            // la entidad emisora. Para otros destinos (perfil, task_log,
+            // mapa, etc.) onNavigate se llama sin payload — backwards
+            // compatible.
+            const goingToAgent = notif.cta_view === 'agente';
+            const hasContext = !!(notif.prefilled_prompt || notif.source_url || notif.alert_context);
+            if (goingToAgent && hasContext) {
+                onNavigate?.('agente', {
+                    prefilledPrompt: notif.prefilled_prompt || '',
+                    sourceLabel: notif.source_label || null,
+                    sourceUrl: notif.source_url || null,
+                    alertContext: notif.alert_context || {
+                        title: notif.title || '',
+                        body: notif.body || '',
+                        severity: notif.severity || 'info',
+                        type: notif.type || null,
+                    },
+                });
+            } else {
+                onNavigate?.(notif.cta_view);
+            }
         }
         setOpen(false);
     }, [onNavigate]);
+
+    // 2026-05-28: handler para alertas dentro del ClimaPanel. Cada alerta
+    // local (helada/lluvia/calor/etc.) puede saltar al agente con un prompt
+    // pre-cargado y cita Open-Meteo. La fuente Open-Meteo siempre se cita
+    // como respaldo institucional ("respaldado por IDEAM via Open-Meteo").
+    const handleClimaAlertAction = useCallback((alerta) => {
+        if (!onNavigate) return;
+        const tipoHumano = (alerta.tipo || '').replace(/_/g, ' ');
+        const diasTxt = Array.isArray(alerta.dias) && alerta.dias.length > 0
+            ? ` en ${alerta.dias.slice(0, 3).join(', ')}`
+            : '';
+        const prompt = `Tengo alerta de ${tipoHumano}${diasTxt} (${alerta.mensaje || 'sin detalle adicional'}). ¿Qué hago para proteger mi cultivo?`;
+        const sourceUrl = clima?.openmeteo?.source_url
+            || 'https://open-meteo.com/en/docs';
+        onNavigate('agente', {
+            prefilledPrompt: prompt,
+            sourceLabel: 'Open-Meteo (umbrales agroecológicos Chagra)',
+            sourceUrl,
+            alertContext: {
+                title: `Alerta: ${tipoHumano}`,
+                body: alerta.mensaje || '',
+                severity: alerta.severity || 'warning',
+                type: 'climate_local_alert',
+            },
+        });
+        setOpen(false);
+    }, [onNavigate, clima]);
+
+    // 2026-05-28: handler para ENSO badge → agente con prompt situado.
+    // El operador puede preguntar "qué significa para mi finca" sin re-tipear,
+    // citando NOAA/IDEAM/CIIFEN como fuente.
+    const handleEnsoAction = useCallback(() => {
+        if (!onNavigate || !clima?.enso_status) return;
+        const phase = clima.enso_status.phase || 'neutral';
+        const phaseLabel = describePhase(phase);
+        const sources = Array.isArray(clima.enso_status.sources) ? clima.enso_status.sources.join(', ') : '';
+        const prompt = `Estoy con fase ENSO actual: ${phaseLabel}${sources ? ` (fuentes: ${sources})` : ''}. ¿Cómo afecta a mi finca en los próximos meses y qué medidas tomo?`;
+        // IDEAM es la fuente preferida para Colombia; si no, NOAA CPC global.
+        const sourceUrl = phase === 'neutral'
+            ? 'http://www.pronosticosyalertas.gov.co/clima/condiciones-globales'
+            : 'https://www.cpc.ncep.noaa.gov/products/analysis_monitoring/enso_advisory/';
+        onNavigate('agente', {
+            prefilledPrompt: prompt,
+            sourceLabel: phase === 'neutral' ? 'IDEAM · Condiciones globales' : 'NOAA CPC · ENSO Advisory',
+            sourceUrl,
+            alertContext: {
+                title: `ENSO: ${phaseLabel}`,
+                body: '',
+                severity: clima.enso_status.severity || 'info',
+                type: 'enso_phase',
+            },
+        });
+        setOpen(false);
+    }, [onNavigate, clima]);
 
     const handleDismiss = useCallback((id, e) => {
         e?.stopPropagation();
@@ -314,6 +390,8 @@ export default function NotificationsBell({ onNavigate }) {
                                 loading={climaLoading}
                                 onRefresh={handleClimaRefresh}
                                 climaInfo={climaInfo}
+                                onAlertAction={handleClimaAlertAction}
+                                onEnsoAction={handleEnsoAction}
                             />
                         )}
                     </div>
@@ -388,7 +466,7 @@ function formatDayLabel(isoDate, i) {
  *      vive en el chat del agente, que ya tiene el bloque inyectado).
  *   5. Atribuciones de fuente.
  */
-function ClimaPanel({ snapshot, loading, onRefresh, climaInfo }) {
+function ClimaPanel({ snapshot, loading, onRefresh, climaInfo, onAlertAction, onEnsoAction }) {
     if (!snapshot) {
         return (
             <div className="p-6 text-center text-slate-500 text-sm">
@@ -459,6 +537,23 @@ function ClimaPanel({ snapshot, loading, onRefresh, climaInfo }) {
                         <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
                     </button>
                 </div>
+                {/* 2026-05-28 UX: CTA al agente con ENSO context pre-cargado */}
+                {typeof onEnsoAction === 'function' && (
+                    <div className="mt-3 flex items-center gap-2 flex-wrap">
+                        <button
+                            type="button"
+                            onClick={onEnsoAction}
+                            className="text-xs font-bold px-3 py-1.5 rounded-md bg-white/10 hover:bg-white/20 active:bg-white/30 text-white"
+                        >
+                            Preguntar al agente
+                        </button>
+                        {sources.length > 0 && (
+                            <span className="text-[10px] opacity-70 italic">
+                                Cita: {sources[0]}
+                            </span>
+                        )}
+                    </div>
+                )}
             </section>
 
             {/* Alertas locales */}
@@ -474,6 +569,19 @@ function ClimaPanel({ snapshot, loading, onRefresh, climaInfo }) {
                             <div key={`${a.tipo}-${i}`} className={`text-xs p-2.5 rounded-lg border ${sevClass}`}>
                                 <p className="font-bold capitalize mb-0.5">{a.tipo.replace(/_/g, ' ')}</p>
                                 <p className="opacity-90 leading-relaxed">{a.mensaje}</p>
+                                {/* 2026-05-28 UX: salto al agente con prompt
+                                    contextualizado + cita Open-Meteo */}
+                                {typeof onAlertAction === 'function' && (
+                                    <div className="mt-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => onAlertAction(a)}
+                                            className="text-[11px] font-bold px-2.5 py-1 rounded-md bg-white/10 hover:bg-white/20 active:bg-white/30 text-white"
+                                        >
+                                            Preguntar al agente
+                                        </button>
+                                    </div>
+                                )}
                             </div>
                         );
                     })}

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -23,7 +23,7 @@ function formatDay(date) {
     return DAY_LABELS[date.getDay()];
 }
 
-export default function ClimaStrip() {
+export default function ClimaStrip({ onNavigate }) {
     const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
     const fincas = useFincaActiveStore((s) => s.fincas);
     const [data, setData] = useState(null);
@@ -72,8 +72,26 @@ export default function ClimaStrip() {
                 <p className="text-sm text-slate-300 leading-relaxed">
                     Cuéntame en qué municipio queda tu finca y te traigo el pronóstico real del IDEAM.
                 </p>
+                {/* Bug fix 2026-05-28 (Brave laptop): el botón no tenía
+                    onClick — operador clickeaba y nada pasaba. Ahora navega
+                    a `perfil` donde MultifincaGpsSection permite editar la
+                    finca activa (que incluye municipio). Si no hay onNavigate
+                    (uso aislado en tests o storybook), el handler degrada
+                    a un dispatch del event global `chagra:navigate` que el
+                    App.jsx escucha. Evita el listener inline-string del
+                    feedback CSP-strict (memoria feedback-csp-strict-inline-handlers-bloqueados). */}
                 <button
                     type="button"
+                    onClick={() => {
+                        if (typeof onNavigate === 'function') {
+                            onNavigate('perfil');
+                            return;
+                        }
+                        try {
+                            // App.jsx escucha 'chagra:nav' (string o {view,data})
+                            window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'perfil' }));
+                        } catch (_) { /* noop */ }
+                    }}
                     className="mt-3 px-4 py-2 rounded-xl bg-sky-700/30 hover:bg-sky-600/40 border border-sky-500/40 text-sky-200 text-sm font-bold transition-colors flex items-center gap-2"
                 >
                     <MapPin size={14} aria-hidden="true" />

--- a/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
+++ b/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
@@ -1,0 +1,76 @@
+/**
+ * ClimaStrip.locationButton.test.jsx — bug fix 2026-05-28.
+ *
+ * El operador reportó: el botón "Configurar ubicación" del widget de clima
+ * en Brave laptop no hace nada al click. Causa: el <button> no tenía
+ * onClick definido — Brave shields + CSP strict no era el culpable, el
+ * handler simplemente no existía.
+ *
+ * Esta suite verifica:
+ *   1. El botón se renderiza cuando no hay municipio (fallback CTA).
+ *   2. El click invoca onNavigate('perfil') si el prop está disponible.
+ *   3. Si no hay onNavigate, despacha el evento global 'chagra:nav' para
+ *      que App.jsx lo capture (defensa cross-mount).
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import ClimaStrip from '../ClimaStrip';
+
+// Mock del sidecar para que el componente no intente fetch real.
+vi.mock('../../../services/sidecarClient', () => ({
+    getClimaIdeam: vi.fn(() => Promise.resolve(null)),
+}));
+
+// Mock del store de finca para forzar el branch "sin municipio".
+vi.mock('../../../services/fincaActiveStore', () => {
+    const store = {
+        activeFincaSlug: 'guatoc',
+        fincas: [], // sin fincas con municipio → activeFinca undefined → null
+    };
+    const useFincaActiveStore = (selector) => selector(store);
+    return { default: useFincaActiveStore };
+});
+
+// Mock del config defaults para que FARM_CONFIG.MUNICIPIO sea null.
+vi.mock('../../../config/defaults', () => ({
+    FARM_CONFIG: { MUNICIPIO: null },
+}));
+
+describe('ClimaStrip — botón "Configurar ubicación" (bug fix Brave 2026-05-28)', () => {
+    test('renderiza CTA "Configurar ubicación" cuando no hay municipio', async () => {
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        // Promise.resolve().then(setLoading(false)) → esperar al microtask
+        const cta = await screen.findByText('Configurar ubicación');
+        expect(cta).toBeInTheDocument();
+    });
+
+    test('click "Configurar ubicación" invoca onNavigate("perfil")', async () => {
+        const onNavigate = vi.fn();
+        render(<ClimaStrip onNavigate={onNavigate} />);
+        const cta = await screen.findByText('Configurar ubicación');
+        fireEvent.click(cta);
+        expect(onNavigate).toHaveBeenCalledTimes(1);
+        expect(onNavigate).toHaveBeenCalledWith('perfil');
+    });
+
+    test('si no hay onNavigate, despacha evento global "chagra:nav"', async () => {
+        const eventSpy = vi.fn();
+        window.addEventListener('chagra:nav', eventSpy);
+        render(<ClimaStrip />);
+        const cta = await screen.findByText('Configurar ubicación');
+        fireEvent.click(cta);
+        await waitFor(() => expect(eventSpy).toHaveBeenCalledTimes(1));
+        const event = eventSpy.mock.calls[0][0];
+        expect(event.detail).toBe('perfil');
+        window.removeEventListener('chagra:nav', eventSpy);
+    });
+
+    test('el botón tiene type="button" (evita submits implícitos)', async () => {
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        const cta = await screen.findByText('Configurar ubicación');
+        const btn = cta.closest('button');
+        expect(btn).toHaveAttribute('type', 'button');
+    });
+});

--- a/src/services/__tests__/notificationsService.prefilled.test.js
+++ b/src/services/__tests__/notificationsService.prefilled.test.js
@@ -1,0 +1,72 @@
+/**
+ * notificationsService.prefilled.test.js — UX 2026-05-28.
+ *
+ * El operador pidió: "cuando hago click en las notificaciones y veo helada
+ * esta noche veo que me manda al agente pero creo que lo ideal seria que la
+ * alerta me mandara con el prompt al agente listo con la posibilidad de que
+ * veo el informe directo de ideam por ejemplo que referencia la alerta
+ * climatica o entidad de origen".
+ *
+ * Esta suite verifica que:
+ *   - notificaciones climate_critical/climate_zone/calendar_month traen
+ *     `prefilled_prompt` para que AgentScreen prellene el textarea.
+ *   - notificaciones climate_critical traen `source_url` + `source_label`
+ *     para que el banner del agente cite la entidad emisora.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    aggregateNotifications,
+    setDemoSeedHelada,
+} from '../notificationsService';
+
+beforeEach(() => {
+    try { localStorage.clear(); } catch (_) { /* noop */ }
+});
+
+describe('notificationsService — prefilled_prompt + source_url', () => {
+    it('seed demo helada incluye prefilled_prompt + source_url IDEAM', () => {
+        setDemoSeedHelada(true);
+        const out = aggregateNotifications({});
+        const helada = out.find((n) => n.id === 'demo_helada_critical');
+        expect(helada).toBeDefined();
+        expect(typeof helada.prefilled_prompt).toBe('string');
+        expect(helada.prefilled_prompt.length).toBeGreaterThan(10);
+        expect(helada.prefilled_prompt).toMatch(/helada/i);
+        expect(helada.source_url).toMatch(/ideam|pronosticosyalertas/i);
+        expect(helada.source_label).toMatch(/IDEAM/i);
+        expect(helada.cta_view).toBe('agente');
+    });
+
+    it('climate_zone notif incluye prefilled_prompt con la zona + riesgos', () => {
+        // Stub global del módulo REGIONAL_CLIMATE_ALERTS via la fuente real.
+        // Para test puro, pasamos una zona conocida y verificamos la forma del
+        // prompt si la zona existe (fallback silencioso si no está en el catálogo).
+        const out = aggregateNotifications({
+            bioculturalZone: 'andina_alta_paramo',
+        });
+        // El test es defensivo: si la zona no existe en REGIONAL_CLIMATE_ALERTS
+        // el push se salta. Lo importante es que cuando exista, prefilled_prompt
+        // esté presente.
+        const zoneNotif = out.find((n) => n.type === 'climate_zone');
+        if (zoneNotif) {
+            expect(zoneNotif.prefilled_prompt).toBeDefined();
+            expect(typeof zoneNotif.prefilled_prompt).toBe('string');
+            expect(zoneNotif.cta_view).toBe('agente');
+        }
+    });
+
+    it('calendar_month notif incluye prefilled_prompt con cultivos sugeridos', () => {
+        const out = aggregateNotifications({
+            calendarMonth: {
+                month: '2026-05',
+                cultivos: ['maíz', 'frijol', 'cilantro'],
+            },
+        });
+        const calNotif = out.find((n) => n.type === 'calendar_month');
+        expect(calNotif).toBeDefined();
+        expect(calNotif.prefilled_prompt).toBeDefined();
+        expect(calNotif.prefilled_prompt).toMatch(/maíz|frijol|cilantro/);
+        expect(calNotif.cta_view).toBe('agente');
+    });
+});

--- a/src/services/notificationsService.js
+++ b/src/services/notificationsService.js
@@ -103,6 +103,12 @@ export function aggregateNotifications(sources = {}) {
             body: 'Cubre cultivos sensibles antes de las 7 PM. Riesgo papas, tomate y hortalizas en zona andina alta.',
             cta_view: 'agente',
             cta_label: 'Preguntar al agente',
+            // UX 2026-05-28: cuando la notificación crítica viaja al agente,
+            // pasamos un prompt pre-cargado + cita de la entidad emisora para
+            // que el operador no re-tipee y vea de dónde viene la alerta.
+            prefilled_prompt: 'Tengo alerta de helada esta noche con mínima de −2 °C. ¿Qué debo proteger primero y cómo lo cubro? Considera papas, tomate y hortalizas en zona andina alta.',
+            source_label: 'IDEAM · Pronósticos y Alertas',
+            source_url: 'http://www.pronosticosyalertas.gov.co/clima/condiciones-globales',
             created_at: now,
         });
     }
@@ -175,14 +181,19 @@ export function aggregateNotifications(sources = {}) {
     if (sources.bioculturalZone && REGIONAL_CLIMATE_ALERTS) {
         const zoneAlerts = REGIONAL_CLIMATE_ALERTS[sources.bioculturalZone];
         if (zoneAlerts && Array.isArray(zoneAlerts.riesgos) && zoneAlerts.riesgos.length > 0) {
+            const zonaLabel = sources.bioculturalZone.replace(/_/g, ' ');
+            const riesgosTop = zoneAlerts.riesgos.slice(0, 3).join(', ');
             out.push({
                 id: `climate_zone_${sources.bioculturalZone}`,
                 type: 'climate_zone',
                 severity: 'info',
-                title: `Tu zona: ${sources.bioculturalZone.replace(/_/g, ' ')}`,
-                body: `Riesgos típicos: ${zoneAlerts.riesgos.slice(0, 3).join(', ')}.`,
+                title: `Tu zona: ${zonaLabel}`,
+                body: `Riesgos típicos: ${riesgosTop}.`,
                 cta_view: 'agente',
                 cta_label: 'Preguntar',
+                prefilled_prompt: `Mi zona es ${zonaLabel} y los riesgos típicos son: ${riesgosTop}. ¿Cómo me preparo para mi cultivo?`,
+                source_label: 'IDEAM · Atlas climatológico',
+                source_url: 'http://atlas.ideam.gov.co/visorAtlasClimatologico.html',
                 created_at: now,
             });
         }
@@ -199,6 +210,7 @@ export function aggregateNotifications(sources = {}) {
             body: `Para tu piso térmico: ${cultivosTop}…`,
             cta_view: 'agente',
             cta_label: 'Más info',
+            prefilled_prompt: `Este mes podría sembrar ${cultivosTop}. ¿Cuál me recomiendas según mi finca y cómo lo arranco?`,
             created_at: now,
         });
     }


### PR DESCRIPTION
## Summary

Dos fixes UX reportados por el operador 2026-05-28:

- **Bug 1 — Botón "Configurar ubicación" inerte en Brave laptop.** El widget `ClimaStrip` (dashboard) tenía un `<button>` sin `onClick`. Click no respondía. Fix: el botón ahora navega a la pantalla `perfil` (donde `MultifincaGpsSection` permite editar la finca activa con su municipio). Acepta `onNavigate` prop con fallback al event global `chagra:nav` para defensa cross-mount.

- **Bug 2 — Notif clima → agente con prompt pre-cargado + cita IDEAM/Open-Meteo/NOAA.** Antes, click en notificación crítica saltaba al agente con chat vacío. Ahora:
  - `notificationsService` agrega `prefilled_prompt` + `source_url` + `source_label` a las notificaciones que disparan al agente (helada crítica, climate_zone, calendar_month).
  - `NotificationsBell.handleAction` pasa esos campos como `initialContext` cuando navega a `agente`.
  - `ClimaPanel` ahora tiene botones "Preguntar al agente" en cada alerta local y en el badge ENSO, citando Open-Meteo o IDEAM/NOAA respectivamente.
  - `App.jsx` reenvía `currentViewData` como prop `initialContext` a `AgentScreen`.
  - `AgentScreen` acepta `initialContext`, prellena `inputText` en mount y muestra un banner discreto arriba del input con la cita y link al informe oficial. Dismissable; desaparece al primer submit.

Sin breaking changes: si el operador entra al agente desde el FAB/tile normal, `initialContext` es `null` y todo el flow previo se preserva.

## Test plan

- [x] Lint clean: `npx eslint <archivos-modificados>` → 0 warnings.
- [x] Build clean: `npx vite build` → ✓ built 5.35s.
- [x] Tests nuevos pasan (`ClimaStrip.locationButton.test.jsx` 4/4, `notificationsService.prefilled.test.js` 3/3).
- [x] Tests previos no regresan (11 fallos pre-existentes en `FeedbackButtons`, `TopBar.voicePlant`, `estratoCopy`, `agentService`, `voiceService` — ninguno toca código modificado).
- [ ] Verificación manual operador en Brave laptop:
  - [ ] Sin finca con municipio: click "Configurar ubicación" → navega a Perfil.
  - [ ] Activar demo helada (`?demo=helada`), abrir bell → tab Notificaciones → click "Preguntar al agente": agente abre con input prellenado "Tengo alerta de helada esta noche con mínima de −2 °C…" y banner con link IDEAM `pronosticosyalertas.gov.co`.
  - [ ] Abrir bell tab Clima → botón "Preguntar al agente" en alerta local → agente con prompt situado + cita Open-Meteo.
  - [ ] ENSO badge → "Preguntar al agente" → prompt sobre fase actual + link NOAA/IDEAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)