### PR TITLE
fix(store): zona se guardaba en insumos — routing 'land' faltaba

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v260';
+const CACHE_NAME = 'chagra-v261';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/store/__tests__/useAssetStore.routing.test.js
+++ b/src/store/__tests__/useAssetStore.routing.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock deps externas — IDB y servicios. Necesarios para que importar el
+// store no rompa en JSDOM. El foco del test es ÚNICAMENTE el routing por
+// assetType en las funciones mutadoras del store.
+vi.mock('../../db/assetCache', () => ({
+  assetCache: {
+    commitOptimisticUpdate: vi.fn().mockResolvedValue(undefined),
+    getByType: vi.fn().mockResolvedValue([]),
+    getLastSync: vi.fn().mockResolvedValue(null),
+    getAllTaxonomyTerms: vi.fn().mockResolvedValue([]),
+  },
+  openDB: vi.fn(),
+  STORES: { ASSETS: 'assets', PENDING_TX: 'pending_tx' },
+}));
+vi.mock('../../db/logCache', () => ({ logCache: {} }));
+vi.mock('../useLogStore', () => ({ useLogStore: { getState: () => ({}) } }));
+vi.mock('../../services/payloadService', () => ({
+  savePayload: vi.fn(),
+  updatePayload: vi.fn(),
+}));
+vi.mock('../../services/authService', () => ({
+  getAccessToken: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../services/emptyDbDetector', () => ({ markHadData: vi.fn() }));
+
+const STORE_PATH = '../useAssetStore';
+
+/**
+ * Regression test for BUG 2026-05-28 (operador): "al agregar una nueva
+ * zona en zonas la información se guarda en insumos". Causa raíz: el
+ * mapping ternary en las 4 funciones mutadoras no contemplaba 'land' y
+ * caía silenciosamente al fallback 'materials'. Cubre cada tipo válido
+ * (plant/land/structure/equipment/material) + el caso de tipo desconocido.
+ */
+describe('useAssetStore — assetType → storeKey routing (regression #327)', () => {
+  let useAssetStore;
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import(STORE_PATH);
+    useAssetStore = mod.default;
+    useAssetStore.setState({
+      plants: [],
+      lands: [],
+      structures: [],
+      equipment: [],
+      materials: [],
+    });
+  });
+
+  const cases = [
+    ['plant', 'plants'],
+    ['land', 'lands'],
+    ['structure', 'structures'],
+    ['equipment', 'equipment'],
+    ['material', 'materials'],
+  ];
+
+  for (const [assetType, expectedKey] of cases) {
+    it(`addAsset(${assetType}) llena el array ${expectedKey} (y solo ése)`, async () => {
+      const asset = { id: `id-${assetType}`, type: `asset--${assetType}`, attributes: { name: `T-${assetType}` } };
+      await useAssetStore.getState().addAsset(assetType, asset);
+      const state = useAssetStore.getState();
+      expect(state[expectedKey]).toHaveLength(1);
+      expect(state[expectedKey][0].id).toBe(`id-${assetType}`);
+      // El resto de arrays NO debe haber sido tocado.
+      for (const [, otherKey] of cases) {
+        if (otherKey !== expectedKey) {
+          expect(state[otherKey]).toHaveLength(0);
+        }
+      }
+    });
+  }
+
+  it('addAsset con tipo desconocido NO muta el store y avisa por consola', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const asset = { id: 'id-bogus', type: 'asset--bogus', attributes: { name: 'X' } };
+    await useAssetStore.getState().addAsset('bogus_type_inexistente', asset);
+    const state = useAssetStore.getState();
+    expect(state.plants).toHaveLength(0);
+    expect(state.lands).toHaveLength(0);
+    expect(state.materials).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('addAssetsBulk(land, [a,b,c]) llena lands con los 3', async () => {
+    const assets = [
+      { id: 'l1', type: 'asset--land', attributes: { name: 'L1' } },
+      { id: 'l2', type: 'asset--land', attributes: { name: 'L2' } },
+      { id: 'l3', type: 'asset--land', attributes: { name: 'L3' } },
+    ];
+    await useAssetStore.getState().addAssetsBulk('land', assets);
+    expect(useAssetStore.getState().lands).toHaveLength(3);
+    expect(useAssetStore.getState().materials).toHaveLength(0);
+  });
+});

--- a/src/store/useAssetStore.js
+++ b/src/store/useAssetStore.js
@@ -17,10 +17,48 @@ import { markHadData } from '../services/emptyDbDetector';
  * Patrón Offline-First: memoria (Zustand) ← IndexedDB ← FarmOS API
  *
  * Tipos de activos FarmOS v2:
+ *   - plant:     Siembras y cultivos
+ *   - land:      Zonas geográficas (lotes, potreros, balcones)
  *   - structure: Invernaderos, Composteras, Infraestructura bioclimática
  *   - equipment: Azadones, Carretillas, Herramientas manuales
  *   - material:  Biol, Lombricompost, Insumos orgánicos
  */
+
+/**
+ * BUG FIX CRITICAL 2026-05-28 (operador): "al agregar una nueva zona en
+ * zonas la información se guarda en insumos arregla eso y revisa el flujo
+ * de todo lo que se guarda para que no tengan líos similares".
+ *
+ * Root cause: las 4 funciones mutadoras (addAsset, addAssetsBulk,
+ * updateAsset, removeAsset) tenían un mapping inline assetType→storeKey
+ * con cascada ternary, y FALTABA el caso 'land'. El fallback default
+ * ':materials' atrapaba silenciosamente cualquier tipo no listado, así
+ * que toda Zona nueva se guardaba en el array `materials` (insumos).
+ *
+ * Fix: tabla central + helper con validación estricta + warn explícito.
+ * Si algún caller pasa un tipo desconocido (futura regresión), no se hace
+ * el set y queda log visible en consola en lugar de corromper datos.
+ */
+const ASSET_TYPE_TO_STORE_KEY = Object.freeze({
+  plant: 'plants',
+  land: 'lands',
+  structure: 'structures',
+  equipment: 'equipment',
+  material: 'materials',
+});
+
+function getStoreKeyForAssetType(assetType) {
+  const key = ASSET_TYPE_TO_STORE_KEY[assetType];
+  if (!key) {
+    console.warn(
+      `[useAssetStore] assetType desconocido "${assetType}"; no se actualiza el store local. ` +
+      `Tipos válidos: ${Object.keys(ASSET_TYPE_TO_STORE_KEY).join(', ')}. ` +
+      `Esto es un bug del caller — el asset igual puede haberse encolado en pendingTxs.`
+    );
+    return null;
+  }
+  return key;
+}
 
 const useAssetStore = create((set, get) => ({
   // Estado
@@ -231,10 +269,12 @@ const useAssetStore = create((set, get) => ({
     try {
       await assetCache.commitOptimisticUpdate([{ assetType, asset }], pendingTxs);
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        // BUG FIX 2026-05-28: ver comentario sobre ASSET_TYPE_TO_STORE_KEY
+        // arriba del create(). Helper centralizado garantiza que 'land' y
+        // cualquier tipo futuro se ruteen al array correcto en vez de
+        // caer silenciosamente al fallback 'materials'.
+        const key = getStoreKeyForAssetType(assetType);
+        if (!key) return state;
         return { [key]: [...state[key], asset] };
       });
       // emptyDbDetector: huella para post-clear-cache detection.
@@ -270,10 +310,12 @@ const useAssetStore = create((set, get) => ({
       const updates = assets.map((asset) => ({ assetType, asset }));
       await assetCache.commitOptimisticUpdate(updates, pendingTxs);
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        // BUG FIX 2026-05-28: ver comentario sobre ASSET_TYPE_TO_STORE_KEY
+        // arriba del create(). Helper centralizado garantiza que 'land' y
+        // cualquier tipo futuro se ruteen al array correcto en vez de
+        // caer silenciosamente al fallback 'materials'.
+        const key = getStoreKeyForAssetType(assetType);
+        if (!key) return state;
         return { [key]: [...state[key], ...assets] };
       });
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
@@ -288,10 +330,12 @@ const useAssetStore = create((set, get) => ({
     try {
       await assetCache.commitOptimisticUpdate([{ assetType, asset }], pendingTxs);
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        // BUG FIX 2026-05-28: ver comentario sobre ASSET_TYPE_TO_STORE_KEY
+        // arriba del create(). Helper centralizado garantiza que 'land' y
+        // cualquier tipo futuro se ruteen al array correcto en vez de
+        // caer silenciosamente al fallback 'materials'.
+        const key = getStoreKeyForAssetType(assetType);
+        if (!key) return state;
         return { [key]: state[key].map((a) => a.id === asset.id ? asset : a) };
       });
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });
@@ -330,10 +374,12 @@ const useAssetStore = create((set, get) => ({
       });
 
       set((state) => {
-        const key = assetType === 'plant' ? 'plants'
-          : assetType === 'structure' ? 'structures'
-            : assetType === 'equipment' ? 'equipment'
-              : 'materials';
+        // BUG FIX 2026-05-28: ver comentario sobre ASSET_TYPE_TO_STORE_KEY
+        // arriba del create(). Helper centralizado garantiza que 'land' y
+        // cualquier tipo futuro se ruteen al array correcto en vez de
+        // caer silenciosamente al fallback 'materials'.
+        const key = getStoreKeyForAssetType(assetType);
+        if (!key) return state;
         return { [key]: state[key].filter((a) => a.id !== assetId) };
       });
       navigator.serviceWorker?.controller?.postMessage({ type: 'SYNC_REQUESTED' });


### PR DESCRIPTION
## Summary

🚨 **BUG-CRITICAL data-integrity** reportado por el operador 2026-05-28: al crear nueva **Zona** desde el tab Zonas, la información se persistía en el array `materials` (Insumos).

### Root cause

Las 4 funciones mutadoras de \`useAssetStore.js\` (\`addAsset\`, \`addAssetsBulk\`, \`updateAsset\`, \`removeAsset\`) tenían un mapping ternary inline assetType→storeKey **sin caso 'land'**:

\`\`\`js
const key = assetType === 'plant' ? 'plants'
  : assetType === 'structure' ? 'structures'
    : assetType === 'equipment' ? 'equipment'
      : 'materials';  // ← FALLBACK silencioso
\`\`\`

Cualquier \`assetType\` no listado (incluyendo \`'land'\`) caía al fallback \`'materials'\`, corrompiendo el array de insumos con datos de zonas.

### Fix

- **Tabla central** \`ASSET_TYPE_TO_STORE_KEY\` con los 5 tipos válidos (plant, land, structure, equipment, material)
- **Helper** \`getStoreKeyForAssetType\` con validación estricta + \`console.warn\` para tipos desconocidos (previene corrupción silenciosa futura)
- **Reemplazo** de las 4 ocurrencias inline en una sola operación (replace_all)
- **Test de regresión** \`useAssetStore.routing.test.js\` — 7/7 pass (1 por tipo válido + bulk + tipo desconocido)

### Audit "revisa el flujo de todo lo que se guarda" (#328)

Grep cross-repo confirmó que el bug estaba **confinado** a \`useAssetStore.js\`:
- \`assetCache.put\` recibe el tipo como parámetro sin discriminación → IDB OK
- \`syncFromServer\`/\`hydrate\` ya cargaban 'land' correctamente al iniciar
- El bug era **solo al CREAR/MODIFICAR/BORRAR** zonas en runtime

## Test plan

- [ ] Login → tab Zonas → crear nueva zona → verificar que aparece en tab **Zonas** (no en Insumos)
- [ ] Tab Insumos → verificar que no contiene zonas accidentales
- [ ] Crear bulk de plantas individuales (qty>1) → todas aparecen en Plantas
- [ ] Crear estructura → aparece en Infraestructura
- [ ] Editar/borrar zona existente → cambio se aplica al array correcto
- [ ] (Test automático) \`npm test src/store/__tests__/useAssetStore.routing.test.js\` debería pasar 7/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)