### PR TITLE
feat(agent): ejecutar tool_chain del NLU planner (D2 #246)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v265';
+const CACHE_NAME = 'chagra-v266';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -25,7 +25,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter } from '../../services/agentService';
 // PoC alertas meteorológicas tiempo real (#316) — el bell + el agente
 // comparten el mismo snapshot via `climaService` (cache 30 min).
@@ -755,6 +755,18 @@ ${buildProfileContext(finca)}`;
   const TOOL_EVIDENCE_MAX_CHARS = 1500;
 
   const formatToolEvidence = (toolEvidence) => {
+    // D2 (#246): si llega un array de evidences (tool_chain ejecutado),
+    // concatenar bloques individuales. El LLM recibe un bloque "DATOS
+    // VERIFICADOS" por cada tool, en orden de ejecución. Los miss
+    // explícitos (found:false / available:false) se marcan igual que
+    // en el modo simple.
+    if (Array.isArray(toolEvidence)) {
+      if (toolEvidence.length === 0) return '';
+      const blocks = toolEvidence
+        .map((ev) => formatToolEvidence(ev))
+        .filter((b) => b && b.trim().length > 0);
+      return blocks.join('\n');
+    }
     if (!toolEvidence || !toolEvidence.tool || !toolEvidence.result) return '';
 
     // 2026-05-23 incidente test #4: usuario preguntó por "mareñongoño del
@@ -1144,7 +1156,33 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           const tNlu0 = performance.now();
           const plan = await planNlu(textForLLM, contextMemory);
           const tNlu1 = performance.now();
-          if (plan?.useTool && plan.tool && plan.args) {
+          // D2 (#246) — modo cadena: si el sidecar devolvió `tool_chain`
+          // (array no vacío), ejecutamos cada paso en orden y usamos el
+          // array de evidences como toolEvidence. El formatter y el
+          // computeSourceMetadata ya soportan arrays.
+          if (plan?.useTool && Array.isArray(plan.toolChain) && plan.toolChain.length > 0) {
+            const tTool0 = performance.now();
+            const chainEvidences = await executeToolChain(plan.toolChain);
+            const tTool1 = performance.now();
+            const useful = chainEvidences.filter((ev) => ev && ev.result != null);
+            if (useful.length > 0) {
+              toolEvidence = useful;
+              const evidenceBytes = (() => {
+                try { return JSON.stringify(useful.map((e) => e.result)).length; } catch (_) { return 0; }
+              })();
+              console.debug('[sidecar]', {
+                chain: useful.map((e) => e.tool),
+                latencyNlu: Math.round(tNlu1 - tNlu0),
+                latencyChain: Math.round(tTool1 - tTool0),
+                toolEvidenceBytes: evidenceBytes,
+              });
+            } else {
+              console.debug('[sidecar] tool_chain todos null', {
+                latencyNlu: Math.round(tNlu1 - tNlu0),
+                latencyChain: Math.round(tTool1 - tTool0),
+              });
+            }
+          } else if (plan?.useTool && plan.tool && plan.args) {
             const tTool0 = performance.now();
             const result = await callTool(plan.tool, plan.args);
             const tTool1 = performance.now();

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -267,6 +267,21 @@ export async function clearMemory(operatorId) {
  * @returns {{tool_used: string|null, grounded: boolean}}
  */
 export function computeSourceMetadata(toolEvidence) {
+  // D2 (#246): si llega un array de evidences (chain), agrega — grounded
+  // si CUALQUIERA de los tools devolvió payload útil; tool_used reporta
+  // la cadena como "toolA+toolB".
+  if (Array.isArray(toolEvidence)) {
+    if (toolEvidence.length === 0) return { tool_used: null, grounded: false };
+    const inners = toolEvidence
+      .map((ev) => computeSourceMetadata(ev))
+      .filter((m) => m.tool_used != null);
+    if (inners.length === 0) return { tool_used: null, grounded: false };
+    return {
+      tool_used: inners.map((m) => m.tool_used).join('+'),
+      grounded: inners.some((m) => m.grounded === true),
+    };
+  }
+
   if (!toolEvidence || !toolEvidence.tool) {
     return { tool_used: null, grounded: false };
   }

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -188,6 +188,7 @@ async function postJson(path, body, timeoutMs) {
  *   useTool: boolean,
  *   tool: string | null,
  *   args: object | null,
+ *   toolChain: Array<{tool: string, args: object}> | null,
  *   latencyMs: number | null,
  *   modelUsed: string | null,
  *   heuristicSkipped: boolean,
@@ -197,6 +198,11 @@ async function postJson(path, body, timeoutMs) {
  *
  * Normaliza el snake_case del API a camelCase JS-idiomatic. Devuelve null
  * si: flag off, offline, timeout, non-2xx, body inválido.
+ *
+ * D2 (#246) tool composition: cuando el sidecar NLU devuelve `tool_chain`
+ * (array no vacío), se expone como `toolChain` camelCase para que el
+ * cliente ejecute la cadena con `executeToolChain()`. El modo simple
+ * (`tool` + `args`) sigue siendo soportado en paralelo.
  */
 export async function planNlu(userMessage, context) {
   if (!userMessage || typeof userMessage !== 'string') return null;
@@ -206,16 +212,54 @@ export async function planNlu(userMessage, context) {
   const raw = await postJson('/nlu', body, NLU_TIMEOUT_MS);
   if (!raw || typeof raw !== 'object') return null;
 
+  let toolChain = null;
+  if (Array.isArray(raw.tool_chain) && raw.tool_chain.length > 0) {
+    toolChain = raw.tool_chain
+      .filter((step) => step && typeof step === 'object' && typeof step.tool === 'string')
+      .map((step) => ({
+        tool: step.tool,
+        args: (step.args && typeof step.args === 'object') ? step.args : {},
+      }));
+    if (toolChain.length === 0) toolChain = null;
+  }
+
   return {
     useTool: Boolean(raw.use_tool),
     tool: typeof raw.tool === 'string' ? raw.tool : null,
     args: (raw.args && typeof raw.args === 'object') ? raw.args : null,
+    toolChain,
     latencyMs: Number.isFinite(raw.latency_ms) ? raw.latency_ms : null,
     modelUsed: typeof raw.model_used === 'string' ? raw.model_used : null,
     heuristicSkipped: Boolean(raw.heuristic_skipped),
     reason: typeof raw.reason === 'string' ? raw.reason : null,
     error: typeof raw.error === 'string' ? raw.error : null,
   };
+}
+
+/**
+ * D2 (#246) — ejecuta una cadena de tools secuencialmente. Devuelve un
+ * array de evidences (uno por tool), preservando el orden. Tools con
+ * resultado null (timeout/error) se devuelven con `result: null` para
+ * que el formatter pueda señalar el gap al LLM.
+ *
+ * Cap máximo de pasos: 3 (alineado con el contrato NLU del sidecar). Pasos
+ * extra se ignoran para evitar inflar el contexto del LLM.
+ *
+ * @param {Array<{tool: string, args?: object}>} chain
+ * @returns {Promise<Array<{tool: string, args: object, result: any}>>}
+ */
+export async function executeToolChain(chain) {
+  if (!Array.isArray(chain) || chain.length === 0) return [];
+  const MAX_STEPS = 3;
+  const limited = chain.slice(0, MAX_STEPS);
+  const evidences = [];
+  for (const step of limited) {
+    if (!step || typeof step.tool !== 'string') continue;
+    const args = (step.args && typeof step.args === 'object') ? step.args : {};
+    const result = await callTool(step.tool, args);
+    evidences.push({ tool: step.tool, args, result });
+  }
+  return evidences;
 }
 
 /**


### PR DESCRIPTION
## Qué

Conecta la ejecución de **tool_chain** (composición de N tools por turno) que el sidecar NLU ya generaba pero la PWA nunca corría.

Hasta ahora `AgentScreen` solo ejecutaba el modo simple (`tool` + `args`). Cuando el NLU planner devolvía un `tool_chain` (ej. *"¿qué siembro y con qué lo asocio?"* → `get_calendario_siembra` + `get_companions`), la cadena se descartaba silenciosamente y el agente respondía sin grounding compuesto.

## Cambios

- **`sidecarClient.planNlu()`** — expone `toolChain` (camelCase) parseado de `raw.tool_chain`; filtra steps inválidos y normaliza `args`.
- **`sidecarClient.executeToolChain(chain)`** — ejecuta hasta `MAX_STEPS=3` tools en orden vía `callTool` (respeta el whitelist `ALLOWED_TOOLS` — defensa en profundidad), devuelve array de evidences `{tool, args, result}`.
- **`conversationMemory.computeSourceMetadata()`** — agrega arrays de evidences: `grounded` si **cualquier** tool devolvió payload útil; `tool_used` reporta la cadena como `"toolA+toolB"`.
- **`AgentScreen`** — rama de ejecución de cadena **antes** del modo simple; `formatToolEvidence` concatena bloques por-tool; el guard `!toolEvidence` de PASO 3 (heurística clima) suprime correctamente cuando hay array de evidence.

## Notas

- Cap de 3 pasos alineado con el contrato NLU del sidecar (evita inflar el contexto del LLM).
- Modo simple sigue soportado en paralelo — fallback natural si no hay `tool_chain`.
- Lint + build limpios.

Closes #246