### PR TITLE
test(services): ampliar cobertura tests computeSourceMetadata - casos array chain #246

### DIFF
--- a/src/services/__tests__/conversationMemory.sourceMetadata.test.js
+++ b/src/services/__tests__/conversationMemory.sourceMetadata.test.js
@@ -105,4 +105,115 @@ describe('computeSourceMetadata', () => {
     });
     expect(md).toEqual({ tool_used: 'get_species', grounded: false });
   });
+
+  describe('chain #246: array de evidences', () => {
+    test('array vacío → no tool, no grounded', () => {
+      expect(computeSourceMetadata([])).toEqual({ tool_used: null, grounded: false });
+    });
+
+    test('array con todos null → no tool, no grounded', () => {
+      expect(computeSourceMetadata([null, null, null])).toEqual({
+        tool_used: null,
+        grounded: false,
+      });
+    });
+
+    test('array con mix de null y evidences válidas → ignora nulls, grounded si alguno útil', () => {
+      const md = computeSourceMetadata([
+        null,
+        {
+          tool: 'get_species',
+          args: { name: 'aguacate' },
+          result: { found: true, species: { name: 'Persea americana' } },
+        },
+        undefined,
+      ]);
+      expect(md).toEqual({ tool_used: 'get_species', grounded: true });
+    });
+
+    test('array con múltiples tools → tool_used concatenados con +', () => {
+      const md = computeSourceMetadata([
+        {
+          tool: 'get_species',
+          args: { name: 'maíz' },
+          result: { found: true, species: { name: 'Zea mays' } },
+        },
+        {
+          tool: 'get_companions',
+          args: { species: 'maíz' },
+          result: { companions: [{ name: 'frijol' }] },
+        },
+      ]);
+      expect(md).toEqual({
+        tool_used: 'get_species+get_companions',
+        grounded: true,
+      });
+    });
+
+    test('array chain: grounded=true si CUALQUIERA tool devuelve payload útil', () => {
+      const md = computeSourceMetadata([
+        {
+          tool: 'get_species',
+          args: { name: 'inexistente' },
+          result: { found: false },
+        },
+        {
+          tool: 'get_companions',
+          args: { species: 'maíz' },
+          result: { companions: [{ name: 'frijol' }] },
+        },
+      ]);
+      expect(md.grounded).toBe(true);
+      expect(md.tool_used).toBe('get_species+get_companions');
+    });
+
+    test('array chain: grounded=false si NINGUNO tool devuelve payload útil', () => {
+      const md = computeSourceMetadata([
+        {
+          tool: 'get_species',
+          args: { name: 'inexistente' },
+          result: { found: false },
+        },
+        {
+          tool: 'get_companions',
+          args: { species: 'inexistente' },
+          result: { matches_count: 0 },
+        },
+      ]);
+      expect(md.grounded).toBe(false);
+      expect(md.tool_used).toBe('get_species+get_companions');
+    });
+
+    test('array chain: un tool con matches_count >0 hace grounded=true', () => {
+      const md = computeSourceMetadata([
+        {
+          tool: 'get_species',
+          args: { name: 'inexistente' },
+          result: { found: false },
+        },
+        {
+          tool: 'get_multihop_companions',
+          args: { species: 'maíz' },
+          result: { matches_count: 3, matches: [{ name: 'frijol' }] },
+        },
+      ]);
+      expect(md.grounded).toBe(true);
+    });
+
+    test('array chain: un tool con available:true hace grounded=true', () => {
+      const md = computeSourceMetadata([
+        {
+          tool: 'get_biopreparados',
+          args: { species: 'inexistente' },
+          result: { available: false },
+        },
+        {
+          tool: 'get_species',
+          args: { name: 'aguacate' },
+          result: { available: true, species: { name: 'Persea americana' } },
+        },
+      ]);
+      expect(md.grounded).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Amplía la cobertura de tests de la función pura `computeSourceMetadata(toolEvidence)` en `src/services/conversationMemory.js`, añadiendo tests para el caso de array de evidences (chain #246).

## Cambios

- Añadida sección `describe('chain #246: array de evidences')` con 9 tests nuevos:
  - `array vacío → no tool, no grounded`
  - `array con todos null → no tool, no grounded`
  - `array con mix de null y evidences válidas → ignora nulls, grounded si alguno útil`
  - `array con múltiples tools → tool_used concatenados con +`
  - `array chain: grounded=true si CUALQUIERA tool devuelve payload útil`
  - `array chain: grounded=false si NINGUNO tool devuelve payload útil`
  - `array chain: un tool con matches_count >0 hace grounded=true`
  - `array chain: un tool con available:true hace grounded=true`

## Test plan

- ✅ `npx vitest run src/services/__tests__/conversationMemory.sourceMetadata.test.js` → 19 tests pasan
- ✅ `npx eslint src/services/__tests__/conversationMemory.sourceMetadata.test.js --max-warnings=0` → 0 warnings
- ✅ `npm run build` → build exitoso
- ✅ Git hooks (lefthook) pasan en commit

## Cobertura

Los tests cubren TODOS los caminos de `computeSourceMetadata`:
1. `null/undefined` → `{tool_used:null, grounded:false}`
2. Un evidence `{tool,args,result}` (ya existente)
3. ARRAY de evidences = chain #246 → `grounded` si CUALQUIERA util, `tool_used` `'toolA+toolB'`
4. Flags `found/available` `true/false` (ya existente)
5. `matches_count >0/===0` (ya existente)
6. Array payload no vacío (ya existente)
7. Array vacío (nuevo)
8. Array con todos null (nuevo)

## Riesgos conocidos

Ninguno. La función `computeSourceMetadata` es pura (sin side effects) y los tests solo verifican su lógica existente sin modificarla.