### PR TITLE
chore(oss): genericizar comentarios con bench-stats + modelos puntuales (proteger moat)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -422,7 +422,7 @@ export default function App() {
     });
   }, []);
 
-  // NN4 fix 2026-05-23: pre-warm Ollama gemma3:4b se dispara al LOGIN
+  // NN4 fix 2026-05-23: pre-warm del modelo Ollama configurado se dispara al LOGIN
   // SUCCESS (LoginScreen → useOllamaWarmStore.startWarmup()), NO al
   // dashboard. Esto da ~15-30s de margen humano antes que el operador
   // llegue al agente, eliminando el cold-start 116s observado en

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -50,9 +50,9 @@ import useAgentQueueStore from '../../store/useAgentQueueStore';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 
 // 2026-05-16: migrado a llmRouter (Multi-LLM por tarea). AgentScreen usa
-// `chat` route → gemma3:4b 15 t/s con keep_alive=5m (hot model). Bench
+// la `chat` route con el modelo de chat configurado como hot model. Bench
 // completo en docs operativos internos del proyecto.
-// Para NLU/tools usar llmRouter('nlu') → qwen2.5-coder:7b.
+// Para NLU/tools usar llmRouter('nlu') → modelo NLU configurado.
 
 const STATE_IDLE = 'idle';
 const STATE_RECORDING = 'recording';
@@ -77,8 +77,8 @@ export default function AgentScreen({ onBack, initialContext }) {
   const ollamaWarmStatus = useOllamaWarmStore((s) => s.status);
   // Task #121: queue UX del agente. Permite 2 preguntas max (1 procesando +
   // 1 pendiente). 3ra rechazada con toast claro. ETA dinámico basado en
-  // EMA de latencia por modelo (llama3.1:8b ~12.9s, granite3.1-dense:8b
-  // ~24.7s — bench nocturno 2026-05-24).
+  // EMA de latencia por modelo (ruta simple más rápida, ruta complex más
+  // lenta — según bench interno).
   const queueProcessing = useAgentQueueStore((s) => s.processing);
   const queuePending = useAgentQueueStore((s) => s.pending);
   const plants = useAssetStore((s) => s.plants);
@@ -435,9 +435,9 @@ export default function AgentScreen({ onBack, initialContext }) {
     // REGLA ANTI-ALUCINACIÓN: "Si no sabes algo, dilo honestamente" (versión
     // previa) era demasiado débil — el modelo lo ignoraba y rellenaba con
     // confianza. Incidente 2026-05-17: operador escribió "chorcho" (typo de
-    // chocho/Lupinus mutabilis) y gemma3:4b inventó "sistema de agricultura
-    // de bajo impacto". Probado en bench: 12b inventó OTRA cosa distinta
-    // (Alternaria solani). Subir parámetros no ayuda. Solución: prompt
+    // chocho/Lupinus mutabilis) y el modelo inventó "sistema de agricultura
+    // de bajo impacto". Probado en bench: un modelo más grande inventó OTRA
+    // cosa distinta (Alternaria solani). Subir parámetros no ayuda. Solución: prompt
     // agresivo con respuesta literal exigida + ejemplo + bajar temperature
     // a 0.3. Bench 2026-05-17 con esta versión devolvió la respuesta
     // EXACTA esperada (no reconozco el término) en 27 tokens / 8s.
@@ -736,8 +736,8 @@ ${buildProfileContext(finca)}`;
   // para botón Cancelar + warning visible a los 20s ("Aún pensando…").
   //
   // 2026-05-19 ajuste timeout 30s→60s: operator perdió respuesta porque
-  // el agente tardaba >30s (cold-load qwen2.5vl/gemma3 + RAG context).
-  // Bench p95 22s, pero outliers post-cold-load 40s+. 60s cubre p99
+  // el agente tardaba demasiado (cold-load del modelo + RAG context).
+  // Según bench interno hay outliers post-cold-load altos. 60s los cubre
   // sin sacrificar UX (el warning a 20s ya le dice al operator que algo
   // está lento). Pre-condicion: OLLAMA_KEEP_ALIVE=24h en alpha para que
   // modelos no hagan cold-load entre conversaciones.
@@ -771,7 +771,7 @@ ${buildProfileContext(finca)}`;
 
     // 2026-05-23 incidente test #4: usuario preguntó por "mareñongoño del
     // Tolima" (especie NO en catálogo). El tool devolvió {found:false,
-    // hint:"..."} pero gemma3:4b IGNORÓ el flag found:false y mapeó
+    // hint:"..."} pero el modelo IGNORÓ el flag found:false y mapeó
     // creativamente "mareñongoño" → "Ullucus tuberosus" inventando una
     // equivalencia, luego listó companions reales de Ullucus pretendiendo
     // que eran de mareñongoño. Alucinación creativa grave.
@@ -874,7 +874,7 @@ RESPONDE SOLO a lo que el usuario preguntó usando ÚNICAMENTE los datos verific
   };
 
   // NN2+NN3 (2026-05-23): análisis de query en frontend para inyectar
-  // señales específicas al system prompt. El LLM gemma3:4b ignora reglas
+  // señales específicas al system prompt. El LLM configurado ignora reglas
   // generales bajo presión — necesita instrucción concreta sobre ESTA
   // query.
   const analyzeQuery = (q) => {
@@ -958,7 +958,7 @@ ${analysis.pestsMentioned.map((p) => `  · "${p.name}" → ${p.canonical}`).join
 
 REGLA CRÍTICA SOBRE ESTE BLOQUE: este análisis es autoritativo para ESTA query. Si dice "Es enumerativa: NO", el CASO C del system prompt NO aplica aunque tu instinto te diga lo contrario. Si lista plagas, usa ESOS nombres científicos exactos (jamás otros, jamás "Fusarium spp" para chinches, jamás géneros inventados).
 === FIN ANÁLISIS ===`;
-    // 2026-05-19: incidente alucinación tomate — gemma3:4b confundía el
+    // 2026-05-19: incidente alucinación tomate — el modelo confundía el
     // corpus RAG con lo que el usuario dijo (atribuía síntomas "hojas
     // amarillas" del documento de referencia al operador). Fix: delimitar
     // EXPLÍCITAMENTE el corpus + instrucción literal de no citarlo como
@@ -998,10 +998,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     try {
       // Routing dual 2026-05-23: queries complejas (plagas regionales,
       // pasifloras confundibles, planes multi-aspecto, queries largas)
-      // se enrutan a `chat_complex` (granite3.1-dense:8b por default)
-      // que es ~2× más lento pero clavó Monalonion velezangeli sin
-      // pifia en bench anti-alucinación. Resto sigue en gemma3:4b
-      // (hot, 118 t/s). `selectChatRoute` emite console.debug con
+      // se enrutan a `chat_complex` (modelo complex configurado por default)
+      // que es más lento pero evita confusiones taxonómicas en bench
+      // anti-alucinación. Resto sigue en el modelo de chat configurado
+      // (hot). `selectChatRoute` emite console.debug con
       // la decisión para diagnóstico en field testing.
       const chatRoute = selectChatRoute(query);
       const { url, body } = buildLLMRequest(chatRoute, messages);

--- a/src/components/ChagraAgentAvatarColibri3D.jsx
+++ b/src/components/ChagraAgentAvatarColibri3D.jsx
@@ -9,7 +9,7 @@ import ChagraAgentAvatarColibri from './ChagraAgentAvatarColibri';
  *
  * Diseñado para ser DIGNO del HUD de HYTA (oracle-lab MainHud con sistema
  * solar 3D). Mismo nivel de profundidad visual, render en GPU del cliente
- * (no la M6000 del servidor — esa es para Ollama).
+ * (no la GPU del servidor — esa es para Ollama).
  *
  * Geometría:
  *   - Cuerpo: SphereGeometry escalada en X (torpedo aerodinámico).

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -66,7 +66,7 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
       } catch (err) {
         console.warn('[LoginScreen] setActiveTenantId failed:', err);
       }
-      // NN4 fix 2026-05-23: disparar pre-warm Ollama gemma3:4b ANTES de
+      // NN4 fix 2026-05-23: disparar pre-warm del modelo Ollama configurado ANTES de
       // navegar al dashboard. Esto da ~15-30s de margen humano (el operador
       // mira el dashboard, escoge una tile, abre el agente) durante los
       // cuales el modelo se carga en GPU en background. Sin esto, la

--- a/src/components/SpeciesSelect.jsx
+++ b/src/components/SpeciesSelect.jsx
@@ -144,7 +144,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
   const recentSpecies = useMemo(() => computeRecentSpecies(plants, allSpecies), [plants, allSpecies]);
 
   // Autopilot H (2026-05-03): identificación de especie por foto.
-  // Vision model qwen2.5vl:7b (con fallback gemma3:4b en aiService).
+  // Modelo de visión configurado (con fallback definido en aiService).
   // confidence ≥0.7 auto-selecciona si match en catálogo, sino muestra
   // alternativas + bug report button para validar.
   // Dual capture (2026-05-18): camera (capture=environment) + gallery.
@@ -506,7 +506,7 @@ export const SpeciesSelect = ({ value, onChange, onAutoFill, onPhoto }) => {
         Búsqueda aproximada. Los campos de estrato y gremio se sugieren al seleccionar.
       </p>
 
-      {/* Autopilot H, Identificación por foto (experimental gemma3:4b) */}
+      {/* Autopilot H, Identificación por foto (experimental) */}
       <div className="mt-3 pt-3 border-t border-slate-800">
         <div className="flex items-center gap-2 mb-2">
           <Sparkles size={12} className="text-amber-400" />

--- a/src/components/TelemetryAlerts.jsx
+++ b/src/components/TelemetryAlerts.jsx
@@ -21,7 +21,7 @@ import {
  * Flujo:
  *   1. Suscripción WebSocket a Home Assistant para sensores configurados.
  *   2. Detección de valor anormal (umbral por especie/zona).
- *   3. Streaming de análisis agronómico via Ollama (gemma3:4b).
+ *   3. Streaming de análisis agronómico via Ollama (modelo configurado).
  *   4. Acción dispatched por operador → log--maintenance + cooldown idempotente.
  *
  * LLM constraints (v0.7.2):

--- a/src/components/VoiceCapture.jsx
+++ b/src/components/VoiceCapture.jsx
@@ -54,7 +54,7 @@ const STATE_DONE = 'done';
 /**
  * VoiceCapture, UI principal del módulo de ingreso acústico.
  *
- * Pipeline: grabar → transcribir (Whisper) → extraer (gemma3:4b) → revisar
+ * Pipeline: grabar → transcribir (Whisper) → extraer (modelo configurado) → revisar
  * humano (VoiceConfirmation) → encolar en pending_transactions.
  *
  * Si transcripción o extracción fallan con error de red, ofrece encolar el

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -27,17 +27,11 @@ import { parseJsonTolerant } from '../utils/parseJsonTolerant';
 // Ruta final: /api/ollama/api/generate → http://localhost:11434/api/generate
 const OLLAMA_BASE = '/api/ollama';
 const OLLAMA_URL = `${OLLAMA_BASE}/api/generate`;
-// Gemma 3 4B (oficial Google, multimodal nativo). Reemplaza paligemma
-// porque el runner Llama de Ollama crashea con arquitectura PaliGemma.
+// Modelo de diagnóstico multimodal configurado.
 const DIAGNOSIS_MODEL = 'gemma3:4b';
-// Vision-specialized model para species recognition. Bench 2026-05-26
-// bench-vision-flora 16 fixtures: llama3.2-vision:11b = 0 parse errors,
-// 18.8% nombre común, 68.8% familia botánica, 18.6s p50; qwen2.5vl:7b
-// = 16/16 parse errors a pesar de format:"json"; llava:13b 15/16 errors.
-// Cambio primary qwen2.5vl → llama3.2-vision por confiabilidad JSON.
-// qwen sigue como segundo fallback porque latencia p50 es 3.3s (5x más
-// rápido que llama32) — útil si llama32 OOM o timeout en hardware
-// constrained.
+// Modelo de visión configurado para reconocimiento de especies. La
+// selección de primary y de los fallbacks se basa en bench interno de
+// confiabilidad del parseo JSON y de latencia en GPU local.
 const VISION_SPECIES_MODEL = 'llama3.2-vision:11b';
 const VISION_SPECIES_FALLBACK_MODEL = 'gemma3:4b';
 const VISION_SPECIES_FALLBACK_2_MODEL = 'qwen2.5vl:7b';
@@ -114,7 +108,7 @@ const buildDiagnosisPrompt = (ragContext) => {
 };
 
 // Species recognition (EXPERIMENTAL — feature flag operador 2026-05-03 Miguel).
-// Mismo modelo gemma3:4b multimodal pero distinto prompt. Output JSON
+// Mismo modelo multimodal configurado pero distinto prompt. Output JSON
 // estructurado para que la UI pueda autocompletar SpeciesSelect con la
 // sugerencia + confidence. Scope esperado: vegetales y frutales latinoamericanos
 // comunes (café, gulupa, mora, fresa, lechuga, tomate, papa, plátano, etc.).
@@ -241,7 +235,7 @@ export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, 
 
 /**
  * Reconoce especie de planta a partir de una foto (EXPERIMENTAL - Miguel
- * 2026-05-03). Mismo backend gemma3:4b multimodal pero prompt distinto.
+ * 2026-05-03). Mismo backend multimodal configurado pero prompt distinto.
  *
  * @param {Blob} imageBlob - foto JPEG/WebP comprimida
  * @param {Object} [options]
@@ -554,21 +548,21 @@ export const recognizeSpecies = async (imageBlob, { onToken, signal, _telemetryS
   // `recognizeSpeciesGrounded` lo pasan para extender la grabación.
   const telemetryState = _telemetryState || {};
 
-  // Primary: llama3.2-vision:11b (0 parse errors bench 2026-05-26).
+  // Primary: modelo de visión configurado.
   try {
     return await runSpeciesRecognition(VISION_SPECIES_MODEL, base64, { onToken, signal, telemetryState });
   } catch (err) {
     console.warn(`[aiService] ${VISION_SPECIES_MODEL} failed, fallback to ${VISION_SPECIES_FALLBACK_MODEL}:`, err.message);
   }
 
-  // Fallback 1: gemma3:4b (modelo de diagnóstico, ya cargado en VRAM normalmente).
+  // Fallback 1: modelo de diagnóstico configurado (normalmente ya cargado en GPU).
   try {
     return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_MODEL, base64, { onToken, signal, telemetryState });
   } catch (err) {
     console.warn(`[aiService] ${VISION_SPECIES_FALLBACK_MODEL} failed, fallback 2 to ${VISION_SPECIES_FALLBACK_2_MODEL}:`, err.message);
   }
 
-  // Fallback 2: qwen2.5vl:7b (rápido pero parse errors frecuentes — último recurso).
+  // Fallback 2: modelo de visión alterno configurado (último recurso).
   try {
     return await runSpeciesRecognition(VISION_SPECIES_FALLBACK_2_MODEL, base64, { onToken, signal, telemetryState });
   } catch (err) {

--- a/src/services/caseStudyVoiceExtractor.js
+++ b/src/services/caseStudyVoiceExtractor.js
@@ -6,12 +6,12 @@
  *
  * Pipeline (referenced en DR-044 sub-viii Feature 1):
  *   1. Operator dicta caso → Whisper transcribe.
- *   2. extractCaseFromText(transcript) → Ollama qwen2.5:7b structured JSON.
+ *   2. extractCaseFromText(transcript) → Ollama, structured JSON.
  *   3. UI pre-fill form, operator confirma.
  *
- * Patrón espejado de `entityExtractor.js` (gemma3:4b para extracción simple).
- * Para casos de estudio elegimos `qwen2.5:7b` por mejor razonamiento con
- * campos múltiples + reasoning sobre pest taxonomy + count parsing.
+ * Patrón espejado de `entityExtractor.js` (modelo de extracción simple).
+ * Para casos de estudio se usa el modelo configurado por su mejor razonamiento
+ * con campos múltiples + reasoning sobre pest taxonomy + count parsing.
  *
  * Privacy: el prompt + transcripción NUNCA salen del host alpha. Si
  * Ollama no responde (down, timeout), retorna `null` y la UI cae a modo
@@ -24,9 +24,9 @@
 import { streamOllama } from './ollamaStream';
 
 const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
-// qwen2.5:7b: mejor estructura JSON sobre campos múltiples vs gemma3:4b.
-// Bench 2026-05-15 (CPU): ~25-35s. Post-GPU sm_52 target ~5-10s.
-// Fallback: gemma3:4b si qwen2.5:7b no responde (ver llmRouter pattern).
+// Modelo configurado: mejor estructura JSON sobre campos múltiples que el
+// modelo de extracción simple. Fallback al modelo simple si no responde
+// (ver llmRouter pattern).
 const MODEL = 'qwen2.5:7b';
 const TIMEOUT_MS = 90000; // 90s CPU; ajustar post-GPU
 const PROMPT_VERSION = 'v1.0-2026-05-17';

--- a/src/services/entityExtractor.js
+++ b/src/services/entityExtractor.js
@@ -1,5 +1,5 @@
 /**
- * entityExtractor.js — Extracción de entidades agrícolas vía Ollama / gemma3:4b.
+ * entityExtractor.js — Extracción de entidades agrícolas vía Ollama.
  *
  * Toma una transcripción en español y devuelve un array estricto de
  * { crop, quantity, location }. Aplica AbortController (timeout 20s) y
@@ -17,9 +17,8 @@
  * `streamOllama` y acepta `onToken` para que la UI muestre el JSON
  * apareciendo carácter-a-carácter mientras el modelo genera.
  *
- * 2026-05-13: swap qwen3.5:4b → gemma3:4b. qwen35 architecture cuelga
- * determinísticamente en Ollama 0.23.x (timeout >120s, retorna 500).
- * gemma3:4b responde ~10s con calidad equivalente para extracción JSON.
+ * El modelo configurado se eligió por estabilidad en Ollama y por calidad
+ * equivalente para extracción JSON frente a alternativas que colgaban.
  */
 
 import { streamOllama } from './ollamaStream';
@@ -27,7 +26,7 @@ import { registry } from '../core/moduleRegistry';
 
 const OLLAMA_CHAT_URL = '/api/ollama/api/chat';
 const MODEL = 'gemma3:4b';
-// gemma3:4b en CPU responde ~10-15s para extracción JSON con format:json.
+// El modelo configurado responde en pocos segundos para extracción JSON con format:json.
 // Nginx permite hasta 120s en /api/ollama/; 60s cliente es el punto medio seguro.
 const TIMEOUT_MS = 60000;
 
@@ -120,7 +119,7 @@ const parseJsonTolerant = (raw) => {
   const cleaned = raw.replace(/```json\s*/gi, '').replace(/```/g, '').trim();
   const cleanedParsed = (() => { try { return JSON.parse(cleaned); } catch (_) { return null; } })();
   if (cleanedParsed !== null) return cleanedParsed;
-  // Bench gemma3:4b 2026-05-15 (Ollama 0.23.x): cuando el modelo es chico
+  // Según bench interno: cuando el modelo es chico
   // a veces emite texto antes/después del JSON. Última red: extraer el
   // primer [...] balanceado del raw. Solo soporta arrays top-level (que
   // es el schema esperado del SYSTEM_PROMPT).
@@ -148,7 +147,7 @@ export async function extractEntities(text, { onToken } = {}) {
 
   try {
     const systemPrompt = await resolveSystemPrompt();
-    // Bench 2026-05-15 en gemma3:4b: con `format: 'json'` Ollama fuerza
+    // Según bench interno: con `format: 'json'` Ollama fuerza
     // un objeto JSON top-level único, lo que colapsa la salida a UN solo
     // `{crop, quantity, location}` incluso cuando el operador menciona
     // múltiples cultivos ("dos arvejas y tres papas" → solo extrae arvejas).
@@ -177,7 +176,7 @@ export async function extractEntities(text, { onToken } = {}) {
       if (Array.isArray(parsed?.entities)) parsed = parsed.entities;
       else if (Array.isArray(parsed?.data)) parsed = parsed.data;
       // Fallback: un único objeto {crop, quantity, location} → wrap en array.
-      // Algunos modelos chicos (gemma3:4b sin format:json en edge cases)
+      // Algunos modelos chicos (sin format:json en edge cases)
       // emiten una sola entidad como objeto plano.
       else if (parsed && typeof parsed === 'object' && 'crop' in parsed) parsed = [parsed];
       else parsed = [];

--- a/src/services/gpuTelemetryService.js
+++ b/src/services/gpuTelemetryService.js
@@ -16,7 +16,7 @@
  *
  * `size_vram > 0` con `size_vram == size` => 100% GPU offload.
  * `size_vram == 0` => CPU only.
- * `0 < size_vram < size` => parcial (warning para nuestro caso M6000 12GB).
+ * `0 < size_vram < size` => parcial (warning para nuestra GPU local).
  */
 
 const OLLAMA_PS_URL = '/api/ollama/api/ps';

--- a/src/services/llmGuardrails.js
+++ b/src/services/llmGuardrails.js
@@ -206,7 +206,7 @@ const OLLAMA_GENERATE_URL = `${OLLAMA_BASE}/api/generate`;
  *
  * @param {string} userPrompt - Pregunta del operador en texto libre.
  * @param {Object} options
- * @param {string}   [options.model='qwen2.5:3b']       - Modelo Ollama a usar.
+ * @param {string}   [options.model]                     - Modelo Ollama a usar.
  * @param {string}   [options.domain='general']          - Dominio para heurísticas.
  * @param {Object}   [options.catalogContext]             - { species: string[] }
  * @param {Function} [options.onToken]                   - Streaming token callback.

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -1,33 +1,20 @@
 /**
  * llmRouter.js — Selector de modelo LLM según tarea (Multi-LLM routing).
  *
- * Decisión de modelo basada en bench empírico CPU 2026-05-15/16 + bench
- * GPU Quadro M6000 sm_52 2026-05-17. Resultados detallados en docs
+ * Decisión de modelo basada en bench interno. Resultados detallados en docs
  * operacionales internos (no en este repo).
  *
- * Estado actual: GPU offload 35/35 layers para todos los modelos listados.
- * Eval rate chat gemma3:4b 13.5 t/s CPU → 118 t/s GPU (+8.7×); load time
- * 7.6s → 3.0s (2.5× más rápido).
+ * Estado actual: los modelos listados corren con offload completo en GPU
+ * local, con mejoras de throughput y de tiempo de carga frente a CPU.
  *
- * Estrategia: 1 modelo "hot" para chat (gemma3:4b keep_alive=30m, viable
- * post-GPU porque load es barato y VRAM 4 GB) + 2 modelos "on-demand"
- * para tareas especializadas (qwen2.5-coder:7b NLU/JSON, gemma2:9b
- * reasoning) + 1 vision (qwen2.5vl:7b on-demand, nuevo post-GPU).
+ * Estrategia: 1 modelo "hot" para chat (keep_alive prolongado) + modelos
+ * "on-demand" para tareas especializadas (NLU/JSON, reasoning) + 1 de
+ * visión on-demand.
  *
- * Budget VRAM M6000 (12 GB): gemma3:4b hot (4.0 GB) + cualquier 7B/8B
- * on-demand (~5-7 GB). gemma3:12b (9.6 GB) y llava:13b (11.6 GB) caben
- * solos pero requieren unload de hot. nlu/reasoning unload tras request
- * (keep_alive=0) para liberar VRAM al siguiente turno chat.
- *
- * Modelos HABILITADOS post-GPU (antes inviables en CPU):
- * - qwen2.5vl:7b vision (78 t/s GPU, 11.8 GB VRAM)
- * - gemma3:12b reasoning (37.6 t/s GPU, 9.6 GB VRAM)
- * - deepseek-r1:8b reasoning chain-of-thought (46 t/s GPU)
- * - llava:13b vision alt (22.94 t/s GPU)
- *
- * Modelos DESCARTADOS por bench:
- * - qwen3.5:4b: qwen35 arch hang en Ollama 0.23.x
- * - qwen3:8b: output vacío con prompts JSON estrictos
+ * Presupuesto de GPU local: el modelo de chat queda caliente y los modelos
+ * on-demand se cargan según necesidad. Los modelos más grandes caben solos
+ * pero requieren liberar el hot. nlu/reasoning hacen unload tras la request
+ * (keep_alive=0) para liberar memoria al siguiente turno de chat.
  */
 
 import { analyzeQueryComplexity } from './queryComplexityAnalyzer';
@@ -38,11 +25,12 @@ import { analyzeQueryComplexity } from './queryComplexityAnalyzer';
  * `chat`         → modelo rápido para queries simples del agente Chagra IA.
  * `chat_complex` → modelo con mayor capacidad anti-alucinación para queries
  *                  complejas (plagas regionales, pasifloras confundibles,
- *                  planes multi-aspecto, queries largas). Bench 2026-05-23:
- *                  granite3.1-dense:8b clavó "Monalonion velezangeli" donde
- *                  gemma3:4b alucinaba. Override via env VITE_LLM_COMPLEX_MODEL.
- *                  Routing se decide en frontend con `selectChatRoute(query)`
- *                  (importable desde `./queryComplexityAnalyzer`).
+ *                  planes multi-aspecto, queries largas). Según bench interno,
+ *                  el modelo complex evita confusiones taxonómicas donde el
+ *                  modelo simple alucinaba. Override via env
+ *                  VITE_LLM_COMPLEX_MODEL. Routing se decide en frontend con
+ *                  `selectChatRoute(query)` (importable desde
+ *                  `./queryComplexityAnalyzer`).
  *
  * @typedef {'chat' | 'chat_complex' | 'nlu' | 'reasoning' | 'vision'} LLMTask
  */
@@ -50,7 +38,7 @@ import { analyzeQueryComplexity } from './queryComplexityAnalyzer';
 /**
  * Configuración por tarea.
  * @typedef {Object} ModelRoute
- * @property {string} model           - Nombre del modelo en Ollama (ej. "gemma3:4b").
+ * @property {string} model           - Nombre del modelo en Ollama.
  * @property {number} keep_alive_min  - Minutos que Ollama mantiene el modelo cargado tras última request.
  *                                       0 = unload inmediato; 5 = caliente para próxima petición.
  * @property {number} temperature     - Default per task.
@@ -62,14 +50,12 @@ import { analyzeQueryComplexity } from './queryComplexityAnalyzer';
 /** @type {Record<LLMTask, ModelRoute>} */
 export const ROUTES = {
   chat: {
-    // Swap 2026-05-24 (post-bug "Shoeachi"/Choachí + recomendaciones erradas):
-    // promoviendo granite3.1-dense:8b (#1 bench Phase C con tools, 56% AH) al
-    // baseline chat. llama3.1:8b (#2, 44% AH) se retira — diferencia 12 puntos
-    // AH es la única solución para mitigar alucinaciones geográficas + piso
-    // térmico observadas en producción. Plus: usar el mismo modelo para chat
-    // simple y complex elimina el cold-start cuando router escala (no hay 2do
-    // modelo que cargar). Tradeoff: +11.8s latencia (24.7s vs 12.9s),
-    // amortizado por UX queueing PR #1031 + tip flotante (próximo PR).
+    // Swap post-bug producción: se promueve el modelo de chat configurado al
+    // baseline. La selección prioriza anti-alucinación (factor decisivo para
+    // mitigar errores geográficos + piso térmico observados en producción).
+    // Plus: usar el mismo modelo para chat simple y complex elimina el
+    // cold-start cuando el router escala (no hay 2do modelo que cargar).
+    // Tradeoff de latencia amortizado por UX queueing + tip flotante.
     // Override via env VITE_LLM_CHAT_MODEL para experimentos.
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_CHAT_MODEL) ||
@@ -95,10 +81,10 @@ export const ROUTES = {
       'derivados de llama ignorando evidence de tools.',
   },
   chat_complex: {
-    // Override por env para que el operador pueda probar gemma3:12b u otros
+    // Override por env para que el operador pueda probar otros modelos
     // sin redeploy de código. Si VITE_LLM_COMPLEX_MODEL no está seteado,
-    // default a granite3.1-dense:8b (bench 2026-05-23: única opción que
-    // clavó Monalonion velezangeli sin alucinación + cupo VRAM razonable).
+    // usa el modelo complex configurado (según bench interno, la opción que
+    // evita confusiones taxonómicas con cupo de GPU razonable).
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_COMPLEX_MODEL) ||
       'granite3.1-dense:8b',

--- a/src/services/llmTelemetryService.js
+++ b/src/services/llmTelemetryService.js
@@ -12,7 +12,7 @@
  * Schema del evento:
  *   {
  *     id: 'lm_<ts36><rand36>',
- *     model: 'gemma3:4b',
+ *     model: '<modelo-configurado>',
  *     endpoint: '/api/ollama/api/chat',
  *     flujo: 'chat' | 'extract' | 'vision' | 'summarize' | 'recommend' | 'help' | 'other',
  *     status: 'success' | 'error' | 'abort',

--- a/src/services/llmTools.js
+++ b/src/services/llmTools.js
@@ -4,8 +4,8 @@
  * Implementa el patrón de registry paralelo a moduleRegistry.js.
  * Herramientas mínimas para DR-034 + tool use básico.
  *
- * Pre-requisito: GLM-4.6 (z.ai) o modelo que soporte function calling.
- * Los modelos locales (qwen2.5:4b, OLMoE) NO soportan function calling.
+ * Pre-requisito: un modelo que soporte function calling.
+ * Algunos modelos locales NO soportan function calling.
  */
 
 import useAssetStore from '../store/useAssetStore';

--- a/src/services/ollamaStream.js
+++ b/src/services/ollamaStream.js
@@ -92,7 +92,7 @@ const extractChunk = (parsed) => {
  * @returns {Promise<string>} texto completo concatenado al terminar.
  * @throws {Error} si el fetch falla, el servidor responde no-2xx o el body no es streameable.
  * @example
- * const full = await streamOllama('/api/ollama/api/generate', { model: 'gemma3:4b', prompt: 'hola' }, tok => setText(tok));
+ * const full = await streamOllama('/api/ollama/api/generate', { model: '<modelo-configurado>', prompt: 'hola' }, tok => setText(tok));
  * // full => "Hola, en que puedo ayudarte?"
  */
 export async function streamOllama(url, body, onToken, { signal, onDone, meta } = {}) {

--- a/src/services/queryComplexityAnalyzer.js
+++ b/src/services/queryComplexityAnalyzer.js
@@ -2,24 +2,19 @@
  * queryComplexityAnalyzer.js — Routing dinámico de modelo LLM según
  * complejidad de la query del agente Chagra IA.
  *
- * Contexto bench 2026-05-23 (alpha, GPU M6000 sm_52):
- *  - gemma3:4b      → 118 t/s, 4 GB VRAM. Rápido (~20s avg) pero confunde
- *                     plagas regionales conocidas-confundibles (chiza vs
- *                     larvas defoliadoras genéricas, monalonion vs Fusarium)
- *                     y mete pifias taxonómicas en pasifloras (gulupa /
- *                     curuba / chulupa).
- *  - granite3.1-dense:8b → 37 t/s, ~6 GB VRAM. ~2× más lento (~37s avg)
- *                     pero clavó "Monalonion velezangeli" sin pestañear
- *                     en bench anti-alucinación.
- *  - gemma3:12b     → 37 t/s pero 9.6 GB VRAM (apretado contra hot model)
- *                     y latencia percibida 3× (~53s con context completo
- *                     RAG + tool evidence).
+ * Contexto (según bench interno en GPU local):
+ *  - Modelo "simple" configurado → más rápido pero confunde plagas
+ *    regionales conocidas-confundibles (chiza vs larvas defoliadoras
+ *    genéricas, monalonion vs Fusarium) y mete pifias taxonómicas en
+ *    pasifloras (gulupa / curuba / chulupa).
+ *  - Modelo "complex" configurado → más lento pero clavó "Monalonion
+ *    velezangeli" sin pestañear en bench anti-alucinación.
  *
  * Estrategia: queries simples (atributo puntual, planta conocida sin
- * confundibles, manejo estándar) → gemma3:4b → respuesta rápida. Queries
- * complejas (plagas regionales, pasifloras confundibles, planes
- * multi-aspecto, queries largas) → granite3.1-dense:8b → vale la pena
- * pagar latencia para no alucinar.
+ * confundibles, manejo estándar) → modelo simple → respuesta rápida.
+ * Queries complejas (plagas regionales, pasifloras confundibles, planes
+ * multi-aspecto, queries largas) → modelo complex → vale la pena pagar
+ * latencia para no alucinar.
  *
  * Diseño pure-function: el módulo no toca DOM, no hace I/O y no depende
  * de stores — sólo recibe el string de la query y devuelve un veredicto.
@@ -28,7 +23,7 @@
  */
 
 /**
- * Plagas regionales colombianas que gemma3:4b confunde en bench. La sola
+ * Plagas regionales colombianas que el modelo simple confunde en bench. La sola
  * mención de cualquiera de éstas dispara routing a modelo "complex" porque
  * el costo de equivocar el binomio (e.g. chiza → "Neolepidopteron daquila"
  * inventado) es peor que pagar 2× latencia.
@@ -58,7 +53,7 @@ const REGIONAL_PESTS = [
 
 /**
  * Plantas colombianas con alta tasa de confusión taxonómica observada en
- * bench gemma3:4b. Pasifloras (gulupa/curuba/chulupa/badea) son el caso
+ * bench interno. Pasifloras (gulupa/curuba/chulupa/badea) son el caso
  * clásico — el modelo intercambia familias y géneros con confianza alta.
  * Tubérculos andinos (cubio/oca/ulluco) y subutilizadas (chachafruto)
  * también disparan errores frecuentes.
@@ -93,7 +88,7 @@ const CONFUSABLE_PLANTS = [
 /**
  * Triggers léxicos de queries multi-aspecto. Una "asocia X con Y" o
  * "plan de manejo integral para Z" requiere conectar varios nodos del
- * KG y reflexionar — gemma3:4b tiende a saltar pasos o inventar relaciones
+ * KG y reflexionar — el modelo simple tiende a saltar pasos o inventar relaciones
  * que el catálogo no documenta. Granite reflexiona mejor antes de
  * comprometer la respuesta.
  *

--- a/src/services/streamChatViaSidecar.js
+++ b/src/services/streamChatViaSidecar.js
@@ -109,7 +109,7 @@ function parseSseLine(line) {
  * Stream chat from the sidecar.
  *
  * @param {Object}   params
- * @param {string}   params.model     — Ollama tag (e.g. "granite3.1-dense:8b")
+ * @param {string}   params.model     — Ollama tag (e.g. "<modelo-configurado>")
  * @param {Array}    params.messages  — OpenAI-style [{role, content}, ...]
  * @param {string}   [params.system]  — optional system prepended by sidecar
  *                                       if first message isn't already system

--- a/src/services/visionWarmService.js
+++ b/src/services/visionWarmService.js
@@ -2,21 +2,22 @@
  * visionWarmService.js — pre-warm del modelo vision on-click cámara.
  *
  * Estrategia "warm-on-click" (decisión operador 2026-05-27): NO pre-warmear
- * el modelo de visión al login (riesgo VRAM: gemma3:4b + llama3.2-vision:11b
- * suman ~11.6 GB, justo al límite de 12 GB de la Quadro M6000). En su lugar,
- * disparar el warm cuando el operador toca el botón "Tomar foto" — mientras
- * enfoca cámara/galería (3-5 segundos humanos), el modelo carga en GPU.
+ * el modelo de visión al login (riesgo de presión sobre la GPU local: el
+ * modelo de chat más el de visión juntos quedan cerca del tope de memoria).
+ * En su lugar, disparar el warm cuando el operador toca el botón "Tomar
+ * foto" — mientras enfoca cámara/galería (3-5 segundos humanos), el modelo
+ * carga en GPU.
  *
- * Si gemma3:4b ya está cargado, Ollama gestiona el swap automáticamente.
- * Cuando el operador vuelve al chat texto después, gemma se re-cargará en
- * cold-start (~25s), pero ese tradeoff es aceptable: la primera identificación
+ * Si el modelo de chat ya está cargado, Ollama gestiona el swap
+ * automáticamente. Cuando el operador vuelve al chat texto después, se
+ * re-cargará en cold-start, pero ese tradeoff es aceptable: la primera identificación
  * de visión es lo que percibe el operador como "el agente respondió rápido"
  * y eso impacta más la primera impresión (los testers Android+iOS que pruebas
  * mañana 2026-05-27).
  *
  * Idempotente: usar `warmVisionModel()` múltiples veces no dispara N requests
  * — un internal lock previene calls concurrentes mientras una request está
- * en vuelo. El segundo click rápido no quema VRAM extra.
+ * en vuelo. El segundo click rápido no quema memoria de GPU extra.
  *
  * Fire-and-forget: el caller NO debe esperar la promesa. Si falla (Ollama
  * down, red intermitente, modelo no instalado), degrada silencioso al
@@ -27,7 +28,7 @@ const OLLAMA_URL = '/api/ollama/api/generate';
 const VISION_MODEL = 'llama3.2-vision:11b';
 // keep_alive 5min: si user demora entre click cámara y submit, el modelo
 // sigue caliente. Si user abandona el flow, Ollama lo desaloja en 5min y
-// libera VRAM. Más corto causaría re-warm si el flow toma >2min.
+// libera memoria de GPU. Más corto causaría re-warm si el flow toma >2min.
 const KEEP_ALIVE = '5m';
 const WARMUP_TIMEOUT_MS = 30000;
 

--- a/src/services/voiceRagEnricher.js
+++ b/src/services/voiceRagEnricher.js
@@ -1,6 +1,6 @@
 /**
  * voiceRagEnricher.js — Conecta la salida del entityExtractor (voz / Whisper +
- * gemma3:4b) con el corpus RAG en `public/cycle-content/` para enriquecer
+ * modelo configurado) con el corpus RAG en `public/cycle-content/` para enriquecer
  * cada entidad reconocida con contexto agronómico del catálogo.
  *
  * Motivación (audit deep finding 2026-05-18):
@@ -35,7 +35,7 @@
  *   con `_ragInsights` opcional. Nunca lanza: errores se loguean con
  *   `console.warn` y la entidad queda sin enriquecer.
  *
- * NO toca el LLM prompt de gemma3:4b ni la integración Whisper. Es estrictamente
+ * NO toca el LLM prompt del modelo configurado ni la integración Whisper. Es estrictamente
  * post-procesamiento sobre el array de entidades ya extraído.
  */
 

--- a/src/store/useAgentQueueStore.js
+++ b/src/store/useAgentQueueStore.js
@@ -5,8 +5,8 @@ import { create } from 'zustand';
  * (task #121, 2026-05-24).
  *
  * Problema (UX 2026-05-23 testing manual con operadora real):
- * Cuando una pregunta al agente tarda 12-25s en responder (router dual
- * model: llama3.1:8b ~12.9s simple, granite3.1-dense:8b ~24.7s complex),
+ * Cuando una pregunta al agente tarda varios segundos en responder (router
+ * dual model: una ruta simple más rápida y una ruta complex más lenta),
  * el operador no espera quieto: dispara 2-3 preguntas seguidas. Con el
  * guard `state !== STATE_IDLE` actual en `handleSubmit`, las preguntas
  * 2 y 3 se ignoraban silenciosamente (`return` mudo). El operador veía
@@ -27,7 +27,7 @@ import { create } from 'zustand';
  *   - pending:      Array de { id, prompt, enqueuedAt }; max 1 elemento
  *                   (allow 2 total = 1 processing + 1 pending).
  *   - latencyEma:   Object { [model]: emaMs }. Init defaults por modelo
- *                   del bench nocturno 2026-05-24. Se actualiza con
+ *                   según bench interno. Se actualiza con
  *                   alpha 0.3 cada `completeProcessing`.
  *   - rejectedCount: contador defensivo para telemetría (cuántas veces
  *                   el operador trató de mandar una 3ra mientras había 2).
@@ -39,11 +39,11 @@ import { create } from 'zustand';
  */
 
 /**
- * Defaults de latencia inicial por route del router (selectChatRoute).
- * Bench nocturno 2026-05-24 (DR bench-modelos-nocturno-2026-05-24.md):
- *   - 'chat' (llama3.1:8b)             ≈ 12.9s avg
- *   - 'chat_complex' (granite3.1-dense:8b) ≈ 24.7s avg
- *   - 'unknown' (fallback defensivo)   ≈ 15.0s
+ * Defaults de latencia inicial por route del router (selectChatRoute),
+ * según bench interno:
+ *   - 'chat' (ruta simple)            → latencia menor
+ *   - 'chat_complex' (ruta complex)   → latencia mayor
+ *   - 'unknown' (fallback defensivo)  → valor intermedio
  * Si en el futuro se agrega otro route al router, se cae al fallback
  * limpio en lugar de explotar.
  */
@@ -57,7 +57,7 @@ export const DEFAULT_EMA_MS = {
  * Alpha del Exponential Moving Average. 0.3 da peso suave al sample
  * nuevo (30%) preservando inercia histórica (70%). Equilibrio entre
  * reaccionar a degradaciones reales del modelo (cold-start tras swap
- * de VRAM) y no oscilar ante un single outlier.
+ * en GPU) y no oscilar ante un single outlier.
  */
 const EMA_ALPHA = 0.3;
 

--- a/src/store/useOllamaWarmStore.js
+++ b/src/store/useOllamaWarmStore.js
@@ -2,13 +2,13 @@ import { create } from 'zustand';
 
 /**
  * useOllamaWarmStore — bus global de estado warm-up del modelo Ollama
- * (gemma3:4b) que usa el agente Chagra IA.
+ * configurado que usa el agente Chagra IA.
  *
  * Problema (NN4, Playwright 2026-05-23 Q1 curuba): la primera query al
- * agente tras una sesión fresca tardaba 116s porque Ollama carga el modelo
- * en GPU bajo demanda (~4.6 GB VRAM). PR #1020 introdujo pre-warm al entrar
+ * agente tras una sesión fresca tardaba mucho porque Ollama carga el modelo
+ * en GPU bajo demanda. PR #1020 introdujo pre-warm al entrar
  * al dashboard, pero el `keep_alive=30m` se mide desde el último request:
- * si entre sesiones de Playwright el modelo se descargó del VRAM, el
+ * si entre sesiones de Playwright el modelo se descargó de la GPU, el
  * pre-warm al dashboard llegaba tarde si el operador iba directo al agente.
  *
  * Solución (este PR): disparar el pre-warm al login success ANTES de
@@ -42,9 +42,9 @@ import { create } from 'zustand';
  * resuelve el estado real al primer intento.
  */
 
-// Timeout total del pre-warm. La primera carga gemma3:4b en GPU M6000
-// tarda ~25-40s. 180s es defensivo para casos de Ollama recuperándose
-// de un crash de runner o swap en disco.
+// Timeout total del pre-warm. La primera carga del modelo en GPU local
+// puede tardar varias decenas de segundos. 180s es defensivo para casos de
+// Ollama recuperándose de un crash de runner o swap en disco.
 const WARMUP_TIMEOUT_MS = 180000;
 
 const useOllamaWarmStore = create((set, get) => ({

--- a/src/utils/parseJsonTolerant.js
+++ b/src/utils/parseJsonTolerant.js
@@ -4,7 +4,7 @@
 /**
  * parseJsonTolerant — parser JSON robusto para output de LLMs locales.
  *
- * Los modelos Ollama (gemma3:4b, llama3.2-vision, granite3.1-dense) a veces
+ * Los modelos locales en Ollama a veces
  * envuelven el JSON en markdown fences, agregan prosa antes/después, truncan
  * por num_predict, o emiten trailing commas. `JSON.parse` directo rompe en
  * esos casos y la respuesta del agente se pierde, aunque el contenido sea


### PR DESCRIPTION
## Qué

Scrub de **comentarios y docstrings** bajo `src/` que filtraban know-how interno en el repo público (PWA). Protege el moat de selección de modelos en hardware limitado y resultados de benchmark.

Genericizado o removido, **solo en comentarios** (`//`, `/* */`, JSDoc `*`, JSX `{/* */}`):

- **Números de benchmark**: parse errors, % de acierto por campo, p50/p95, latencias, AH%, throughput t/s, referencias a archivos DR de bench. → "según bench interno" / cifra removida.
- **VRAM / hardware**: cifras de VRAM, `sm_52`, `Maxwell`, `Quadro M6000`, presupuestos de memoria por modelo. → "GPU local" / cifra removida.
- **Rationale de elección de modelo**: comparativas cuantitativas y razones específicas. → "modelo configurado" sin nombrarlo ni el porqué cuantitativo.
- **Nombres de modelo puntuales en comentarios** (incl. ejemplos JSDoc). → genéricos.

## Qué NO se tocó

- **Cero código funcional.** Constantes (`VISION_SPECIES_MODEL`, `DIAGNOSIS_MODEL`, `MODEL`, los `model:`/defaults del `ROUTES` y signaturas), string literals ejecutables, tests, lógica, imports y firmas quedan idénticos. Esto es para Fase 2.
- Verificación: el diff completo contiene únicamente líneas de comentario.

## Casos dudosos dejados sin tocar

- `src/services/llmRouter.js` — los campos `rationale:` del objeto `ROUTES` contienen mucho detalle de bench, pero son **string literals en código ejecutable** (valores de propiedad), no comentarios. Fuera de scope (Fase 2).
- `src/data/dictionary.js:659` — `definicion_ampliada` menciona modelos locales, pero es **contenido educativo renderizado al usuario** (dato funcional), no comentario.
- `VRAM` genérico en `HytaPanel.jsx` / `gpuTelemetryService.js` y nombres de campo `p95LatencyMs`/`avgLatencyMs` en `ragTelemetry.js` JSDoc — términos estándar sin cifras ni hardware específico; se dejaron como inocuos.

## Verificación

- `eslint` sobre los archivos tocados: **0 errores, 0 warnings**. (Hay 2 errores preexistentes en `AIStatusFooter.jsx` y `useIdleDetection.js`, fuera de este changeset.)
- `vite build`: **OK** (built in 2.84s).
- 23 archivos, ~50 comentarios genericizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)