### PR TITLE
feat(notif): conectar conteo de quarantine al centro de notificaciones (#308)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v268';
+const CACHE_NAME = 'chagra-v269';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/NotificationsBell.jsx
+++ b/src/components/NotificationsBell.jsx
@@ -4,6 +4,7 @@ import useAssetStore from '../store/useAssetStore';
 import useAlertStore from '../store/useAlertStore';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import { aggregateNotifications, dismissNotification } from '../services/notificationsService';
+import { syncManager } from '../services/syncManager';
 // PoC alertas meteorológicas (#316) — fuente de verdad ENSO + alertas locales.
 import {
     getCachedClimaSnapshot,
@@ -81,6 +82,11 @@ export default function NotificationsBell({ onNavigate }) {
     const [activeTab, setActiveTab] = useState('notif');
     const [clima, setClima] = useState(() => getCachedClimaSnapshot());
     const [climaLoading, setClimaLoading] = useState(false);
+    // #308 — conteo real de transacciones en quarantine (cambios sin sincronizar),
+    // cargado async desde syncManager. Antes estaba hardcodeado a 0, así que el
+    // bell nunca mostraba "sync stuck". Conecta el estado de sincronización al
+    // centro de notificaciones.
+    const [failedTxCount, setFailedTxCount] = useState(0);
 
     const plants = useAssetStore((s) => s.plants);
     const sensorAlerts = useAlertStore((s) => s.activeAlerts);
@@ -99,6 +105,17 @@ export default function NotificationsBell({ onNavigate }) {
             window.removeEventListener('chagra:clima:updated', onClimaUpdated);
         };
     }, []);
+
+    // #308 — carga el conteo de quarantine al montar y cada vez que se abre el
+    // panel o se descarta una notif. setState dentro del .then() para no
+    // disparar set-state-in-effect sincrónico.
+    useEffect(() => {
+        let alive = true;
+        syncManager.getFailedTransactions()
+            .then((txs) => { if (alive) setFailedTxCount(Array.isArray(txs) ? txs.length : 0); })
+            .catch(() => {});
+        return () => { alive = false; };
+    }, [open, tick]);
 
     // PoC #316 — pide snapshot fresco al abrir el panel. El sidecar tiene su
     // propia cache de 30 min, así que esto es un "ping" barato. setState va
@@ -127,7 +144,7 @@ export default function NotificationsBell({ onNavigate }) {
         return aggregateNotifications({
             plants,
             tasks: [],
-            failedTxCount: 0,
+            failedTxCount,
             hasUpdate: readUpdateAvailable(),
             onboardingComplete: readOnboardingComplete(),
             bioculturalZone: finca?.biocultural_zone || null,
@@ -135,7 +152,7 @@ export default function NotificationsBell({ onNavigate }) {
             iotAlerts: mapSensorAlertsToIot(sensorAlerts),
         });
         // tick force re-run on dismiss event
-    }, [plants, sensorAlerts, activeFincaSlug, fincas, tick]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [plants, sensorAlerts, activeFincaSlug, fincas, tick, failedTxCount]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // PoC #316 — el clima cuenta para los badges del bell. Las alertas
     // locales de Open-Meteo (helada/calor/torrencial/etc) escalan severity;

--- a/src/components/__tests__/CriticalAlertBanner.test.jsx
+++ b/src/components/__tests__/CriticalAlertBanner.test.jsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Mockeamos el canal de notificaciones para controlar las críticas de forma
+// determinística (sin depender del flag localStorage del demo-seed de helada).
+vi.mock('../../services/notificationsService', () => ({
+  aggregateNotifications: vi.fn(() => []),
+  dismissNotification: vi.fn(),
+}));
+
+import CriticalAlertBanner from '../CriticalAlertBanner';
+import { aggregateNotifications, dismissNotification } from '../../services/notificationsService';
+
+const HELADA = {
+  id: 'demo_helada_critical',
+  type: 'climate_critical',
+  severity: 'critical',
+  title: '🥶 Helada esta noche · −2 °C',
+  body: 'Cubre cultivos sensibles antes de las 7 PM.',
+  cta_view: 'agente',
+  cta_label: 'Preguntar al agente',
+  prefilled_prompt: 'Tengo alerta de helada, ¿qué protejo primero?',
+};
+
+describe('CriticalAlertBanner (#315)', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    aggregateNotifications.mockReset();
+    dismissNotification.mockReset();
+  });
+
+  it('no renderiza nada cuando no hay alertas críticas', () => {
+    aggregateNotifications.mockReturnValue([
+      { id: 'x', severity: 'warning', title: 'Algo menor' },
+      { id: 'y', severity: 'info', title: 'Info' },
+    ]);
+    const { container } = render(<CriticalAlertBanner />);
+    expect(screen.queryByTestId('critical-alert-banner')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renderiza el banner cuando hay una crítica (helada)', () => {
+    aggregateNotifications.mockReturnValue([HELADA]);
+    render(<CriticalAlertBanner />);
+    const banner = screen.getByTestId('critical-alert-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveAttribute('role', 'alert');
+    expect(screen.getByText(/Helada esta noche/)).toBeInTheDocument();
+    expect(screen.getByText(/Cubre cultivos sensibles/)).toBeInTheDocument();
+  });
+
+  it('el CTA navega a la vista del agente y pre-carga el prompt', () => {
+    aggregateNotifications.mockReturnValue([HELADA]);
+    const onNavigate = vi.fn();
+    render(<CriticalAlertBanner onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByText(/Preguntar al agente/));
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+    expect(sessionStorage.getItem('chagra:agent:prefilled')).toBe(HELADA.prefilled_prompt);
+  });
+
+  it('descartar oculta el banner y persiste el id en sessionStorage', () => {
+    aggregateNotifications.mockReturnValue([HELADA]);
+    render(<CriticalAlertBanner />);
+    expect(screen.getByTestId('critical-alert-banner')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('critical-alert-dismiss'));
+    expect(screen.queryByTestId('critical-alert-banner')).not.toBeInTheDocument();
+    const dismissed = JSON.parse(sessionStorage.getItem('chagra:critical-banner:dismissed') || '[]');
+    expect(dismissed).toContain('demo_helada_critical');
+  });
+
+  it('muestra "+N más críticas" cuando hay varias', () => {
+    aggregateNotifications.mockReturnValue([
+      HELADA,
+      { id: 'demo_2', severity: 'critical', title: 'Sequía severa' },
+      { id: 'demo_3', severity: 'critical', title: 'Granizada' },
+    ]);
+    render(<CriticalAlertBanner />);
+    expect(screen.getByText(/\+2 más crítica/)).toBeInTheDocument();
+  });
+
+  it('una crítica del demo (id demo_*) NO llama a dismissNotification del servicio (solo por-sesión)', () => {
+    aggregateNotifications.mockReturnValue([HELADA]);
+    render(<CriticalAlertBanner />);
+    fireEvent.click(screen.getByTestId('critical-alert-dismiss'));
+    expect(dismissNotification).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/agentIntentParser.test.js
+++ b/src/services/__tests__/agentIntentParser.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { parseIntent, formatIntentDescription } from '../agentIntentParser.js';
+
+/**
+ * Tests del detector de intenciones accionables (puro, basado en regex).
+ * parseIntent(text) → { intent, confidence }; formatIntentDescription(intent) → string.
+ */
+
+describe('parseIntent — entradas no accionables', () => {
+  it.each([null, undefined, '', '   ', 42, {}])('retorna intent null para entrada inválida: %s', (input) => {
+    const r = parseIntent(input);
+    expect(r.intent).toBeNull();
+    expect(r.confidence).toBe(0);
+  });
+
+  it('no detecta intención en texto conversacional sin acción', () => {
+    const r = parseIntent('hola, cómo estás hoy');
+    expect(r.intent).toBeNull();
+    expect(r.confidence).toBe(0);
+  });
+});
+
+describe('parseIntent — registrar cosecha', () => {
+  it('detecta "registrar cosecha" y mapea a crear_log / log--harvest', () => {
+    const r = parseIntent('registrar cosecha de tomate');
+    expect(r.intent.id).toBe('registrar_cosecha');
+    expect(r.intent.toolName).toBe('crear_log');
+    expect(r.intent.logType).toBe('log--harvest');
+    expect(r.confidence).toBe(0.8);
+    expect(r.intent.originalText).toBe('registrar cosecha de tomate');
+  });
+
+  it('detecta el verbo "cosechar" y "recolectar"', () => {
+    expect(parseIntent('voy a cosechar mañana').intent.id).toBe('registrar_cosecha');
+    expect(parseIntent('necesito recolectar el café').intent.id).toBe('registrar_cosecha');
+  });
+
+  it('extrae cantidad, unidad normalizada y planta', () => {
+    const r = parseIntent('registrar cosecha de tomate 10 kg');
+    expect(r.intent.parameters.quantity).toBe(10);
+    expect(r.intent.parameters.unit).toBe('kg');
+    expect(r.intent.parameters.plantHint).toBe('tomate');
+  });
+
+  it('normaliza "kilos" → kg y "libras" → lb', () => {
+    expect(parseIntent('registrar cosecha de papa 5 kilos').intent.parameters.unit).toBe('kg');
+    expect(parseIntent('registrar cosecha de papa 3 libras').intent.parameters.unit).toBe('lb');
+  });
+
+  it('usa cantidad 1 y unidad "unidades" por defecto sin número', () => {
+    const r = parseIntent('registrar cosecha de aguacate');
+    expect(r.intent.parameters.quantity).toBe(1);
+    expect(r.intent.parameters.unit).toBe('unidades');
+  });
+});
+
+describe('parseIntent — registrar riego', () => {
+  it('detecta "registrar riego" → crear_log / log--input', () => {
+    const r = parseIntent('registrar riego');
+    expect(r.intent.id).toBe('registrar_riego');
+    expect(r.intent.toolName).toBe('crear_log');
+    expect(r.intent.logType).toBe('log--input');
+  });
+
+  it('detecta el verbo conjugado "regué las plantas"', () => {
+    expect(parseIntent('regué las plantas hoy').intent.id).toBe('registrar_riego');
+  });
+
+  it('extrae cantidad y normaliza "galones" a L', () => {
+    const r = parseIntent('registrar riego 20 galones');
+    expect(r.intent.parameters.quantity).toBe(20);
+    expect(r.intent.parameters.unit).toBe('L');
+  });
+
+  it('quirk conocido: "litros" queda como "l" minúscula (la alternativa L del regex captura la l inicial)', () => {
+    // Comportamiento real del parser: el grupo de unidad captura solo "l" de
+    // "litros" antes de poder normalizar. Documentado como característica
+    // actual, no como comportamiento deseado.
+    expect(parseIntent('registrar riego 20 litros').intent.parameters.unit).toBe('l');
+  });
+
+  it('usa unidad L por defecto y cantidad null sin número', () => {
+    const r = parseIntent('registrar riego');
+    expect(r.intent.parameters.quantity).toBeNull();
+    expect(r.intent.parameters.unit).toBe('L');
+  });
+});
+
+describe('parseIntent — registrar observación', () => {
+  it('detecta "observé que..." y limpia el prefijo en las notas', () => {
+    const r = parseIntent('observé que las hojas están amarillas');
+    expect(r.intent.id).toBe('registrar_observacion');
+    expect(r.intent.logType).toBe('log--observation');
+    expect(r.intent.parameters.notes).toContain('hojas');
+    expect(r.intent.parameters.notes).not.toMatch(/^observé/i);
+  });
+
+  it('detecta "vi que..." como observación', () => {
+    expect(parseIntent('vi que hay plaga en el maíz').intent.id).toBe('registrar_observacion');
+  });
+});
+
+describe('parseIntent — registrar aplicación', () => {
+  it('detecta "aboné" → crear_log / log--input con nota de producto', () => {
+    const r = parseIntent('aboné con compost');
+    expect(r.intent.id).toBe('registrar_aplicacion');
+    expect(r.intent.logType).toBe('log--input');
+    expect(r.intent.parameters.notes).toContain('compost');
+  });
+
+  it('detecta "aplicación de neem"', () => {
+    expect(parseIntent('hice aplicación de neem').intent.id).toBe('registrar_aplicacion');
+  });
+});
+
+describe('formatIntentDescription', () => {
+  it('describe una cosecha con planta', () => {
+    const intent = { id: 'registrar_cosecha', parameters: { quantity: 10, unit: 'kg', plantHint: 'tomate' } };
+    expect(formatIntentDescription(intent)).toBe('Registrar cosecha de 10 kg de tomate');
+  });
+
+  it('describe una cosecha sin planta', () => {
+    const intent = { id: 'registrar_cosecha', parameters: { quantity: 1, unit: 'unidades', plantHint: null } };
+    expect(formatIntentDescription(intent)).toBe('Registrar cosecha de 1 unidades');
+  });
+
+  it('describe un riego con y sin cantidad', () => {
+    expect(formatIntentDescription({ id: 'registrar_riego', parameters: { quantity: 20, unit: 'L' } })).toBe('Registrar riego (20 L)');
+    expect(formatIntentDescription({ id: 'registrar_riego', parameters: { quantity: null, unit: 'L' } })).toBe('Registrar riego');
+  });
+
+  it('describe observación y aplicación', () => {
+    expect(formatIntentDescription({ id: 'registrar_observacion', parameters: { notes: 'hojas amarillas' } })).toBe('Registrar observación: "hojas amarillas"');
+    expect(formatIntentDescription({ id: 'registrar_aplicacion', parameters: { notes: 'Aplicación: compost' } })).toBe('Registrar aplicación: Aplicación: compost');
+  });
+
+  it('cae a un texto genérico para un id desconocido', () => {
+    expect(formatIntentDescription({ id: 'accion_rara', parameters: {} })).toBe('Ejecutar acción: accion_rara');
+  });
+});

--- a/src/services/__tests__/externalAiPromptBuilder.test.js
+++ b/src/services/__tests__/externalAiPromptBuilder.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveThermalZoneFromAltitud,
+  buildGuildExternalPrompt,
+  buildDiagnosticExternalPrompt,
+  buildOpenExternalPrompt,
+} from '../externalAiPromptBuilder.js';
+
+/**
+ * Tests del constructor de prompts portables (puro, sin red ni efectos).
+ */
+
+describe('deriveThermalZoneFromAltitud', () => {
+  it.each([
+    [0, 'cálido'],
+    [999, 'cálido'],
+    [1000, 'templado'],
+    [1999, 'templado'],
+    [2000, 'frío'],
+    [2550, 'frío'],
+    [2999, 'frío'],
+    [3000, 'páramo'],
+    [3599, 'páramo'],
+    [3600, 'glacial'],
+    [5000, 'glacial'],
+  ])('clasifica %i msnm como %s', (msnm, zona) => {
+    expect(deriveThermalZoneFromAltitud(msnm)).toBe(zona);
+  });
+
+  it.each([NaN, Infinity, -Infinity, -10, '2550', null, undefined, {}])(
+    'retorna null para entrada inválida: %s',
+    (input) => {
+      expect(deriveThermalZoneFromAltitud(input)).toBeNull();
+    },
+  );
+});
+
+describe('buildGuildExternalPrompt', () => {
+  it('incluye especie con nombre científico y común', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'maíz', scientificName: 'Zea mays' });
+    expect(p).toContain('Zea mays (maíz)');
+  });
+
+  it('deriva el piso térmico desde la altitud cuando no hay thermalZones', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'papa', altitudMsnm: 2550 });
+    expect(p).toContain('piso térmico frío');
+    expect(p).toContain('2550 msnm');
+  });
+
+  it('usa thermalZones explícitos por encima de la altitud', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'papa', altitudMsnm: 2550, thermalZones: ['templado'] });
+    expect(p).toContain('piso térmico templado');
+    expect(p).not.toContain('piso térmico frío');
+  });
+
+  it('marca "no especificado" cuando no hay zona ni altitud', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'yuca' });
+    expect(p).toContain('piso térmico no especificado');
+    expect(p).toContain('altitud no especificada');
+  });
+
+  it('usa los textos por defecto para companions y antagonists vacíos', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'frijol' });
+    expect(p).toContain('Companions ya considerados: ninguno aún');
+    expect(p).toContain('Antagonists conocidos: ninguno conocido');
+  });
+
+  it('lista companions y antagonists provistos', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'maíz', companions: ['frijol', 'calabaza'], antagonists: ['hinojo'] });
+    expect(p).toContain('frijol, calabaza');
+    expect(p).toContain('hinojo');
+  });
+
+  it('incluye el estrato solo cuando se provee', () => {
+    expect(buildGuildExternalPrompt({ speciesName: 'maíz', estrato: 'alto' })).toContain('Estrato: alto');
+    expect(buildGuildExternalPrompt({ speciesName: 'maíz' })).not.toContain('Estrato:');
+  });
+
+  it('pide respuesta en JSON y va recortado', () => {
+    const p = buildGuildExternalPrompt({ speciesName: 'maíz' });
+    expect(p).toContain('JSON');
+    expect(p).toBe(p.trim());
+  });
+
+  it('usa "especie desconocida" si no se da speciesName', () => {
+    expect(buildGuildExternalPrompt({})).toContain('especie desconocida');
+  });
+});
+
+describe('buildDiagnosticExternalPrompt', () => {
+  it('formatea las condiciones ambientales provistas', () => {
+    const p = buildDiagnosticExternalPrompt({ speciesName: 'tomate', humedad: 80, temperatura: 18, lluvia: 40 });
+    expect(p).toContain('HR 80%');
+    expect(p).toContain('temperatura media 18°C');
+    expect(p).toContain('precipitación acumulada 40mm');
+  });
+
+  it('marca "datos no disponibles" sin condiciones', () => {
+    expect(buildDiagnosticExternalPrompt({ speciesName: 'tomate' })).toContain('datos no disponibles');
+  });
+
+  it('compone fase fenológica y días desde siembra', () => {
+    const p = buildDiagnosticExternalPrompt({ speciesName: 'tomate', fase: 'floración', diasDesdeSiembra: 45 });
+    expect(p).toContain('fase fenológica floración');
+    expect(p).toContain('45 días desde siembra');
+  });
+
+  it('marca "fase no especificada" cuando faltan fase y días', () => {
+    expect(buildDiagnosticExternalPrompt({ speciesName: 'tomate' })).toContain('fase no especificada');
+  });
+
+  it('usa el placeholder de síntomas por defecto', () => {
+    expect(buildDiagnosticExternalPrompt({ speciesName: 'tomate' })).toContain('[usuario describe síntomas aquí]');
+  });
+
+  it('incluye los síntomas provistos por el usuario', () => {
+    const p = buildDiagnosticExternalPrompt({ speciesName: 'tomate', sintomas: 'manchas negras en hojas' });
+    expect(p).toContain('manchas negras en hojas');
+  });
+
+  it('prohíbe agroquímicos sintéticos en la tarea', () => {
+    const p = buildDiagnosticExternalPrompt({ speciesName: 'tomate' });
+    expect(p).toContain('NO agroquímicos sintéticos');
+    expect(p).toContain('biopreparado');
+  });
+
+  it('humedad 0 se incluye (no se trata como ausente)', () => {
+    expect(buildDiagnosticExternalPrompt({ speciesName: 'tomate', humedad: 0 })).toContain('HR 0%');
+  });
+});
+
+describe('buildOpenExternalPrompt', () => {
+  it('usa el placeholder de pregunta por defecto', () => {
+    expect(buildOpenExternalPrompt({ speciesName: 'mora' })).toContain('[Escribe tu pregunta aquí]');
+  });
+
+  it('incluye la pregunta del usuario y el piso térmico derivado', () => {
+    const p = buildOpenExternalPrompt({ speciesName: 'mora', altitudMsnm: 2550, pregunta: '¿cuándo podar?' });
+    expect(p).toContain('¿cuándo podar?');
+    expect(p).toContain('piso térmico frío');
+  });
+
+  it('incluye la especie y va recortado', () => {
+    const p = buildOpenExternalPrompt({ speciesName: 'mora', scientificName: 'Rubus glaucus' });
+    expect(p).toContain('Rubus glaucus (mora)');
+    expect(p).toBe(p.trim());
+  });
+});

--- a/src/services/__tests__/gpuTelemetryService.test.js
+++ b/src/services/__tests__/gpuTelemetryService.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { getGpuSnapshot, listAvailableModels, clearGpuCache } from '../gpuTelemetryService.js';
+
+/**
+ * Tests del snapshot de GPU/Ollama. Las funciones exportadas hacen fetch:
+ * se mockea fetch global para controlar la respuesta de /api/ollama/api/ps.
+ * La lógica bajo prueba (normalizeModel, clasificación gpu/partial/cpu,
+ * cache 5s, manejo de errores) es determinista.
+ */
+
+const GB = 1024 * 1024 * 1024;
+
+function okResponse(json) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => json };
+}
+function errResponse(status, statusText) {
+  return { ok: false, status, statusText, json: async () => ({}) };
+}
+
+beforeEach(() => {
+  clearGpuCache();
+  vi.unstubAllGlobals();
+});
+
+describe('getGpuSnapshot — normalización de modelos', () => {
+  it('clasifica un modelo 100% en GPU (size_vram == size)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({
+      models: [{ name: 'modelo-a', size: 4 * GB, size_vram: 4 * GB, details: { family: 'fam', parameter_size: '4B', quantization_level: 'Q4' } }],
+    })));
+    const snap = await getGpuSnapshot();
+    expect(snap.available).toBe(true);
+    const m = snap.models[0];
+    expect(m.processor).toBe('gpu');
+    expect(m.gpuShare).toBe(1);
+    expect(m.sizeMB).toBe(4096);
+    expect(m.vramMB).toBe(4096);
+    expect(m.details).toEqual({ family: 'fam', parameterSize: '4B', quantization: 'Q4' });
+    expect(snap.hasGpu).toBe(true);
+  });
+
+  it('clasifica un modelo parcial (0 < size_vram < size)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({
+      models: [{ name: 'modelo-b', size: 4 * GB, size_vram: 2 * GB }],
+    })));
+    const snap = await getGpuSnapshot();
+    expect(snap.models[0].processor).toBe('partial');
+    expect(snap.models[0].gpuShare).toBe(0.5);
+    expect(snap.hasGpu).toBe(true);
+  });
+
+  it('clasifica un modelo solo-CPU (size_vram == 0)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({
+      models: [{ name: 'modelo-c', size: 4 * GB, size_vram: 0 }],
+    })));
+    const snap = await getGpuSnapshot();
+    expect(snap.models[0].processor).toBe('cpu');
+    expect(snap.models[0].gpuShare).toBe(0);
+    expect(snap.hasGpu).toBe(false);
+  });
+
+  it('suma totalVramMB de todos los modelos', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({
+      models: [
+        { name: 'a', size: 2 * GB, size_vram: 2 * GB },
+        { name: 'b', size: 1 * GB, size_vram: 1 * GB },
+      ],
+    })));
+    const snap = await getGpuSnapshot();
+    expect(snap.totalVramMB).toBe(3072);
+  });
+
+  it('usa "unknown" cuando el modelo no trae name ni model', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({ models: [{ size: 0, size_vram: 0 }] })));
+    const snap = await getGpuSnapshot();
+    expect(snap.models[0].name).toBe('unknown');
+  });
+
+  it('retorna models vacío si la respuesta no trae array', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({})));
+    const snap = await getGpuSnapshot();
+    expect(snap.models).toEqual([]);
+    expect(snap.totalVramMB).toBe(0);
+  });
+});
+
+describe('getGpuSnapshot — errores (nunca lanza)', () => {
+  it('marca available:false con error HTTP cuando la respuesta no es ok', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errResponse(500, 'Internal Server Error')));
+    const snap = await getGpuSnapshot();
+    expect(snap.available).toBe(false);
+    expect(snap.error).toContain('500');
+    expect(snap.models).toEqual([]);
+  });
+
+  it('marca available:false con error de red cuando fetch lanza', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('connection refused'); }));
+    const snap = await getGpuSnapshot();
+    expect(snap.available).toBe(false);
+    expect(snap.error).toBe('connection refused');
+  });
+
+  it('reporta "timeout" cuando el fetch aborta', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw Object.assign(new Error('aborted'), { name: 'AbortError' }); }));
+    const snap = await getGpuSnapshot();
+    expect(snap.error).toBe('timeout');
+  });
+});
+
+describe('getGpuSnapshot — cache de 5s', () => {
+  it('reutiliza el cache en llamadas sucesivas (un solo fetch)', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ models: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    await getGpuSnapshot();
+    await getGpuSnapshot();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('force:true ignora el cache y refetcha', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ models: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    await getGpuSnapshot();
+    await getGpuSnapshot({ force: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearGpuCache fuerza un nuevo fetch', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ models: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    await getGpuSnapshot();
+    clearGpuCache();
+    await getGpuSnapshot();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('listAvailableModels', () => {
+  it('mapea los modelos disponibles de /api/tags', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse({
+      models: [{ name: 'modelo-x', size: 2 * GB, details: { family: 'fam', parameter_size: '2B', quantization_level: 'Q8' } }],
+    })));
+    const r = await listAvailableModels();
+    expect(r.available).toBe(true);
+    expect(r.models[0]).toEqual({ name: 'modelo-x', sizeMB: 2048, family: 'fam', parameterSize: '2B', quantization: 'Q8' });
+  });
+
+  it('retorna available:false sin lanzar cuando la respuesta no es ok', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => errResponse(404, 'Not Found')));
+    const r = await listAvailableModels();
+    expect(r).toEqual({ available: false, models: [] });
+  });
+
+  it('retorna available:false cuando fetch lanza', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('down'); }));
+    const r = await listAvailableModels();
+    expect(r).toEqual({ available: false, models: [] });
+  });
+});

--- a/src/services/__tests__/inventoryEvents.test.js
+++ b/src/services/__tests__/inventoryEvents.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  EVENT_TYPES,
+  VALID_EVENT_TYPES,
+  VALID_UNITS,
+  VALID_RECEIVED_SOURCES,
+  VALID_ADJUSTED_REASONS,
+  VALID_LOST_CAUSES,
+  validateLogEntry,
+  createInventoryEvent,
+  ValidationError,
+} from '../inventoryEvents.js';
+
+/**
+ * Tests del validador gatekeeper de inventoryEvents (ADR-027.ii).
+ * validateLogEntry y los enums son puros; createInventoryEvent usa
+ * localStorage + crypto (disponibles en el entorno jsdom de los tests).
+ */
+
+const VALID_ULID = '01ARZ3NDEKTSV4RRFFQ69G5FAV'; // 26 chars Crockford-Base32
+const HASH64 = 'a'.repeat(64);
+
+// Payloads válidos por tipo de evento.
+const PAYLOADS = {
+  [EVENT_TYPES.RECEIVED]: { item_id: 'maiz', delta: 10, unit: 'kg', source: 'compra' },
+  [EVENT_TYPES.CONSUMED]: { item_id: 'maiz', delta: -3, unit: 'kg' },
+  [EVENT_TYPES.TRANSFORMED]: {
+    inputs: [{ item_id: 'cana', delta_consumido: 30, unit: 'kg' }],
+    outputs: [{ item_id: 'panela', delta_producido: 5, unit: 'kg' }],
+  },
+  [EVENT_TYPES.COUNTED]: { item_id: 'maiz', counted_qty: 5, unit: 'kg' },
+  [EVENT_TYPES.ADJUSTED]: { item_id: 'maiz', delta: 2, reason: 'error_registro' },
+  [EVENT_TYPES.TRANSFERRED]: { item_id: 'maiz', from_location_id: 'bodega', to_location_id: 'campo', qty: 5 },
+  [EVENT_TYPES.LOST]: { item_id: 'maiz', delta: -2, cause: 'plaga' },
+  [EVENT_TYPES.PRODUCED]: { item_id: 'panela', delta: 8 },
+};
+
+function validEntry(eventType = EVENT_TYPES.RECEIVED, overrides = {}) {
+  return {
+    id: VALID_ULID,
+    event_type: eventType,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    device_id_lex_hash: 'ABCD2345', // 8 chars
+    sequence_number: 1,
+    operator_id_hash: HASH64,
+    idempotency_key: 'k-1',
+    payload: PAYLOADS[eventType],
+    schema_version: '1',
+    ...overrides,
+  };
+}
+
+describe('enums canónicos', () => {
+  it('EVENT_TYPES está congelado y tiene los 8 tipos', () => {
+    expect(Object.isFrozen(EVENT_TYPES)).toBe(true);
+    expect(Object.keys(EVENT_TYPES)).toHaveLength(8);
+    expect(EVENT_TYPES.RECEIVED).toBe('inventory_received');
+  });
+
+  it('VALID_EVENT_TYPES contiene todos los valores de EVENT_TYPES', () => {
+    Object.values(EVENT_TYPES).forEach((v) => expect(VALID_EVENT_TYPES.has(v)).toBe(true));
+  });
+
+  it('los sets de vocabulario controlado tienen los valores esperados', () => {
+    expect(VALID_UNITS.has('kg')).toBe(true);
+    expect(VALID_UNITS.has('toneladas')).toBe(false);
+    expect(VALID_RECEIVED_SOURCES.has('compra')).toBe(true);
+    expect(VALID_ADJUSTED_REASONS.has('error_registro')).toBe(true);
+    expect(VALID_LOST_CAUSES.has('plaga')).toBe(true);
+  });
+});
+
+describe('ValidationError', () => {
+  it('expone field, expected y got', () => {
+    try {
+      validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { id: 'no-ulid' }));
+      throw new Error('debió lanzar');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect(err.field).toBe('id');
+      expect(err.expected).toContain('regex');
+      expect(err.got).toBe('no-ulid');
+    }
+  });
+});
+
+describe('validateLogEntry — entradas válidas', () => {
+  it.each(Object.values(EVENT_TYPES))('acepta un entry válido de tipo %s', (eventType) => {
+    expect(validateLogEntry(validEntry(eventType))).toBe(true);
+  });
+
+  it('acepta prev_hash y notes opcionales válidos', () => {
+    const entry = validEntry(EVENT_TYPES.RECEIVED, { prev_hash: 'b'.repeat(64), notes: 'todo bien' });
+    expect(validateLogEntry(entry)).toBe(true);
+  });
+});
+
+describe('validateLogEntry — fallos de shape', () => {
+  it('rechaza null o no-objeto', () => {
+    expect(() => validateLogEntry(null)).toThrow(ValidationError);
+    expect(() => validateLogEntry('x')).toThrow(ValidationError);
+  });
+
+  it('rechaza id que no es ULID', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { id: 'abc' }))).toThrow(/id/);
+  });
+
+  it('rechaza event_type desconocido', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { event_type: 'inventory_x' }))).toThrow(ValidationError);
+  });
+
+  it('rechaza timestamp sin formato ISO con offset', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { timestamp: '2026-01-01' }))).toThrow(/timestamp/);
+  });
+
+  it('rechaza device_id_lex_hash que no mide exactamente 8 chars', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { device_id_lex_hash: 'ABC' }))).toThrow(/device_id_lex_hash/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { device_id_lex_hash: 'ABCDEFGHI' }))).toThrow(/device_id_lex_hash/);
+  });
+
+  it('rechaza sequence_number negativo o no entero', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { sequence_number: -1 }))).toThrow(/sequence_number/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { sequence_number: 1.5 }))).toThrow(/sequence_number/);
+  });
+
+  it('rechaza operator_id_hash que no mide 64 chars', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { operator_id_hash: 'short' }))).toThrow(/operator_id_hash/);
+  });
+
+  it('rechaza idempotency_key vacío', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { idempotency_key: '' }))).toThrow(/idempotency_key/);
+  });
+
+  it('rechaza schema_version distinto de "1"', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { schema_version: '2' }))).toThrow(/schema_version/);
+  });
+
+  it('rechaza notes que excede 500 chars', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { notes: 'x'.repeat(501) }))).toThrow(/notes/);
+  });
+});
+
+describe('validateLogEntry — validación de payload por tipo', () => {
+  it('RECEIVED exige delta >= 0, unit válida y source válida', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { payload: { ...PAYLOADS[EVENT_TYPES.RECEIVED], delta: -1 } }))).toThrow(/delta/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { payload: { ...PAYLOADS[EVENT_TYPES.RECEIVED], unit: 'arroba' } }))).toThrow(/unit/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.RECEIVED, { payload: { ...PAYLOADS[EVENT_TYPES.RECEIVED], source: 'robo' } }))).toThrow(/source/);
+  });
+
+  it('CONSUMED exige delta <= 0', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.CONSUMED, { payload: { ...PAYLOADS[EVENT_TYPES.CONSUMED], delta: 5 } }))).toThrow(/delta/);
+  });
+
+  it('TRANSFORMED exige inputs y outputs no vacíos', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.TRANSFORMED, { payload: { inputs: [], outputs: PAYLOADS[EVENT_TYPES.TRANSFORMED].outputs } }))).toThrow(/inputs/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.TRANSFORMED, { payload: { inputs: PAYLOADS[EVENT_TYPES.TRANSFORMED].inputs, outputs: [] } }))).toThrow(/outputs/);
+  });
+
+  it('COUNTED exige counted_qty >= 0', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.COUNTED, { payload: { ...PAYLOADS[EVENT_TYPES.COUNTED], counted_qty: -1 } }))).toThrow(/counted_qty/);
+  });
+
+  it('ADJUSTED exige una reason válida', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.ADJUSTED, { payload: { ...PAYLOADS[EVENT_TYPES.ADJUSTED], reason: 'porque_si' } }))).toThrow(/reason/);
+  });
+
+  it('TRANSFERRED exige from/to location y qty >= 0', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.TRANSFERRED, { payload: { ...PAYLOADS[EVENT_TYPES.TRANSFERRED], to_location_id: '' } }))).toThrow(/to_location_id/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.TRANSFERRED, { payload: { ...PAYLOADS[EVENT_TYPES.TRANSFERRED], qty: -1 } }))).toThrow(/qty/);
+  });
+
+  it('LOST exige delta <= 0 y cause válida', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.LOST, { payload: { ...PAYLOADS[EVENT_TYPES.LOST], cause: 'magia' } }))).toThrow(/cause/);
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.LOST, { payload: { ...PAYLOADS[EVENT_TYPES.LOST], delta: 2 } }))).toThrow(/delta/);
+  });
+
+  it('PRODUCED exige delta >= 0', () => {
+    expect(() => validateLogEntry(validEntry(EVENT_TYPES.PRODUCED, { payload: { ...PAYLOADS[EVENT_TYPES.PRODUCED], delta: -1 } }))).toThrow(/delta/);
+  });
+});
+
+describe('createInventoryEvent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('exige operator_id_hash', async () => {
+    await expect(createInventoryEvent(EVENT_TYPES.RECEIVED, PAYLOADS[EVENT_TYPES.RECEIVED], {})).rejects.toThrow(/operator_id_hash/);
+  });
+
+  it('rechaza un eventType inválido', async () => {
+    await expect(createInventoryEvent('inventory_x', {}, { operator_id_hash: HASH64 })).rejects.toThrow(ValidationError);
+  });
+
+  it('produce un entry válido con id ULID, schema_version y metadatos', async () => {
+    const entry = await createInventoryEvent(EVENT_TYPES.RECEIVED, PAYLOADS[EVENT_TYPES.RECEIVED], { operator_id_hash: HASH64 });
+    expect(validateLogEntry(entry)).toBe(true);
+    expect(entry.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(entry.schema_version).toBe('1');
+    expect(entry.event_type).toBe(EVENT_TYPES.RECEIVED);
+    expect(entry.device_id_lex_hash).toHaveLength(8);
+  });
+
+  it('incrementa sequence_number entre llamadas', async () => {
+    const a = await createInventoryEvent(EVENT_TYPES.RECEIVED, PAYLOADS[EVENT_TYPES.RECEIVED], { operator_id_hash: HASH64 });
+    const b = await createInventoryEvent(EVENT_TYPES.RECEIVED, PAYLOADS[EVENT_TYPES.RECEIVED], { operator_id_hash: HASH64 });
+    expect(b.sequence_number).toBe(a.sequence_number + 1);
+  });
+
+  it('respeta idempotency_key, prev_hash y notes provistos', async () => {
+    const entry = await createInventoryEvent(EVENT_TYPES.RECEIVED, PAYLOADS[EVENT_TYPES.RECEIVED], {
+      operator_id_hash: HASH64,
+      idempotency_key: 'manual-key',
+      prev_hash: 'c'.repeat(64),
+      notes: 'compra semana 1',
+    });
+    expect(entry.idempotency_key).toBe('manual-key');
+    expect(entry.prev_hash).toBe('c'.repeat(64));
+    expect(entry.notes).toBe('compra semana 1');
+  });
+
+  it('reutiliza el mismo device_id_lex_hash en eventos sucesivos', async () => {
+    const a = await createInventoryEvent(EVENT_TYPES.RECEIVED, PAYLOADS[EVENT_TYPES.RECEIVED], { operator_id_hash: HASH64 });
+    const b = await createInventoryEvent(EVENT_TYPES.COUNTED, PAYLOADS[EVENT_TYPES.COUNTED], { operator_id_hash: HASH64 });
+    expect(a.device_id_lex_hash).toBe(b.device_id_lex_hash);
+  });
+});

--- a/src/services/__tests__/inventoryService.test.js
+++ b/src/services/__tests__/inventoryService.test.js
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from 'vitest';
+import { compareEventOrder, projectStock } from '../inventoryService.js';
+import { EVENT_TYPES } from '../inventoryEvents.js';
+
+/**
+ * Tests del corazón PURO de inventoryService (ADR-027 event sourcing):
+ *   - compareEventOrder: orden canónico determinista
+ *   - projectStock: proyección de stock desde el log de eventos
+ *
+ * No tocan IndexedDB: las funciones bajo prueba son puras y deterministas,
+ * que es justo la garantía crítica del modelo ("dos máquinas con los mismos
+ * eventos producen el MISMO snapshot").
+ */
+
+// Factory de eventos: solo los campos que leen las funciones puras.
+let seq = 0;
+function ev(overrides = {}) {
+  seq += 1;
+  return {
+    id: overrides.id || `e${seq}`,
+    timestamp: overrides.timestamp || '2026-01-01T00:00:00.000Z',
+    device_id_lex_hash: overrides.device_id_lex_hash || 'dev_a',
+    sequence_number: overrides.sequence_number ?? seq,
+    event_type: overrides.event_type || EVENT_TYPES.RECEIVED,
+    idempotency_key: overrides.idempotency_key ?? null,
+    payload: overrides.payload || { item_id: 'maiz', delta: 10, unit: 'kg' },
+  };
+}
+
+describe('compareEventOrder', () => {
+  it('ordena por timestamp ascendente', () => {
+    const a = ev({ timestamp: '2026-01-01T00:00:00.000Z' });
+    const b = ev({ timestamp: '2026-01-02T00:00:00.000Z' });
+    expect(compareEventOrder(a, b)).toBe(-1);
+    expect(compareEventOrder(b, a)).toBe(1);
+  });
+
+  it('desempata por device_id_lex_hash cuando el timestamp es igual', () => {
+    const t = '2026-01-01T00:00:00.000Z';
+    const a = ev({ timestamp: t, device_id_lex_hash: 'dev_a' });
+    const b = ev({ timestamp: t, device_id_lex_hash: 'dev_b' });
+    expect(compareEventOrder(a, b)).toBe(-1);
+    expect(compareEventOrder(b, a)).toBe(1);
+  });
+
+  it('desempata por sequence_number cuando timestamp y device coinciden', () => {
+    const t = '2026-01-01T00:00:00.000Z';
+    const a = ev({ timestamp: t, device_id_lex_hash: 'dev_a', sequence_number: 1 });
+    const b = ev({ timestamp: t, device_id_lex_hash: 'dev_a', sequence_number: 5 });
+    expect(compareEventOrder(a, b)).toBe(-4);
+    expect(compareEventOrder(b, a)).toBe(4);
+  });
+
+  it('retorna 0 cuando los tres criterios son iguales', () => {
+    const base = { timestamp: '2026-01-01T00:00:00.000Z', device_id_lex_hash: 'dev_a', sequence_number: 3 };
+    expect(compareEventOrder(ev(base), ev(base))).toBe(0);
+  });
+
+  it('produce un orden canónico al usarse como comparador de Array.sort', () => {
+    const t1 = '2026-01-01T00:00:00.000Z';
+    const t2 = '2026-01-02T00:00:00.000Z';
+    const e1 = ev({ id: 'x', timestamp: t2, device_id_lex_hash: 'dev_a', sequence_number: 1 });
+    const e2 = ev({ id: 'y', timestamp: t1, device_id_lex_hash: 'dev_b', sequence_number: 1 });
+    const e3 = ev({ id: 'z', timestamp: t1, device_id_lex_hash: 'dev_a', sequence_number: 9 });
+    const ordered = [e1, e2, e3].sort(compareEventOrder).map((e) => e.id);
+    // t1/dev_a antes que t1/dev_b antes que t2
+    expect(ordered).toEqual(['z', 'y', 'x']);
+  });
+});
+
+describe('projectStock — casos base', () => {
+  it('retorna un Map vacío para una lista vacía', () => {
+    const stock = projectStock([]);
+    expect(stock).toBeInstanceOf(Map);
+    expect(stock.size).toBe(0);
+  });
+
+  it('un RECEIVED proyecta cantidad, unidad y metadatos', () => {
+    const e = ev({ id: 'r1', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } });
+    const stock = projectStock([e]);
+    const maiz = stock.get('maiz');
+    expect(maiz.quantity).toBe(10);
+    expect(maiz.unit).toBe('kg');
+    expect(maiz.item_id).toBe('maiz');
+    expect(maiz.last_event_id).toBe('r1');
+    expect(maiz.last_updated).toBe(e.timestamp);
+  });
+
+  it('suma múltiples RECEIVED del mismo item', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', payload: { item_id: 'maiz', delta: 5, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(15);
+  });
+
+  it('PRODUCED se comporta como entrada (suma delta)', () => {
+    const e = ev({ event_type: EVENT_TYPES.PRODUCED, payload: { item_id: 'panela', delta: 8, unit: 'kg' } });
+    expect(projectStock([e]).get('panela').quantity).toBe(8);
+  });
+
+  it('CONSUMED resta (delta negativo)', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', event_type: EVENT_TYPES.CONSUMED, payload: { item_id: 'maiz', delta: -3, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(7);
+  });
+
+  it('LOST y ADJUSTED aplican su delta (negativo)', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', event_type: EVENT_TYPES.LOST, payload: { item_id: 'maiz', delta: -2, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-03T00:00:00.000Z', event_type: EVENT_TYPES.ADJUSTED, payload: { item_id: 'maiz', delta: -1, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(7);
+  });
+
+  it('CONSUMED fija la unidad cuando aún no había unidad', () => {
+    const events = [
+      ev({ event_type: EVENT_TYPES.CONSUMED, payload: { item_id: 'abono', delta: -4, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('abono').unit).toBe('kg');
+  });
+});
+
+describe('projectStock — COUNTED reanchora (LWW honesto)', () => {
+  it('COUNTED fija la cantidad absoluta, descartando entradas previas', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', event_type: EVENT_TYPES.COUNTED, payload: { item_id: 'maiz', counted_qty: 3, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(3);
+  });
+
+  it('un RECEIVED posterior al COUNTED suma sobre la cantidad contada', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', event_type: EVENT_TYPES.COUNTED, payload: { item_id: 'maiz', counted_qty: 3, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', payload: { item_id: 'maiz', delta: 4, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(7);
+  });
+
+  it('un RECEIVED anterior al último COUNTED se ignora', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 100, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', event_type: EVENT_TYPES.COUNTED, payload: { item_id: 'maiz', counted_qty: 5, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(5);
+  });
+
+  it('con dos COUNTED gana el último y se ignora lo intermedio', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', event_type: EVENT_TYPES.COUNTED, payload: { item_id: 'maiz', counted_qty: 50, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-02T00:00:00.000Z', payload: { item_id: 'maiz', delta: 99, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-03T00:00:00.000Z', event_type: EVENT_TYPES.COUNTED, payload: { item_id: 'maiz', counted_qty: 7, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(7);
+  });
+});
+
+describe('projectStock — idempotency LWW dedupe', () => {
+  it('con misma idempotency_key solo contribuye el de mayor timestamp', () => {
+    const events = [
+      ev({ id: 'a', timestamp: '2026-01-01T00:00:00.000Z', idempotency_key: 'k1', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ id: 'b', timestamp: '2026-01-02T00:00:00.000Z', idempotency_key: 'k1', payload: { item_id: 'maiz', delta: 5, unit: 'kg' } }),
+    ];
+    // NO suma 15: el ganador LWW es 'b' (ts mayor) → 5
+    expect(projectStock(events).get('maiz').quantity).toBe(5);
+  });
+
+  it('eventos con idempotency_key distinta sí se suman', () => {
+    const events = [
+      ev({ id: 'a', timestamp: '2026-01-01T00:00:00.000Z', idempotency_key: 'k1', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ id: 'b', timestamp: '2026-01-02T00:00:00.000Z', idempotency_key: 'k2', payload: { item_id: 'maiz', delta: 5, unit: 'kg' } }),
+    ];
+    expect(projectStock(events).get('maiz').quantity).toBe(15);
+  });
+});
+
+describe('projectStock — TRANSFORMED y TRANSFERRED', () => {
+  it('TRANSFORMED resta inputs y suma outputs', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'cana', delta: 100, unit: 'kg' } }),
+      ev({
+        timestamp: '2026-01-02T00:00:00.000Z',
+        event_type: EVENT_TYPES.TRANSFORMED,
+        payload: {
+          inputs: [{ item_id: 'cana', delta_consumido: 30, unit: 'kg' }],
+          outputs: [{ item_id: 'panela', delta_producido: 5, unit: 'kg' }],
+        },
+      }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('cana').quantity).toBe(70);
+    expect(stock.get('panela').quantity).toBe(5);
+  });
+
+  it('TRANSFERRED no altera el stock total (no-op en el snapshot)', () => {
+    const events = [
+      ev({
+        event_type: EVENT_TYPES.TRANSFERRED,
+        payload: { item_id: 'maiz', delta: 10, unit: 'kg', from_location: 'bodega', to_location: 'campo' },
+      }),
+    ];
+    expect(projectStock(events).size).toBe(0);
+  });
+});
+
+describe('projectStock — robustez y determinismo', () => {
+  it('un event_type desconocido no lanza ni modifica el stock', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events = [ev({ event_type: 'inventory_teletransportado', payload: { item_id: 'maiz', delta: 10 } })];
+    expect(() => projectStock(events)).not.toThrow();
+    expect(projectStock(events).size).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('proyecta items independientes sin mezclarlos', () => {
+    const events = [
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } }),
+      ev({ timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'frijol', delta: 4, unit: 'kg' } }),
+    ];
+    const stock = projectStock(events);
+    expect(stock.get('maiz').quantity).toBe(10);
+    expect(stock.get('frijol').quantity).toBe(4);
+    expect(stock.size).toBe(2);
+  });
+
+  it('es determinista: cualquier orden de entrada produce el mismo snapshot', () => {
+    const e1 = ev({ id: 'r1', timestamp: '2026-01-01T00:00:00.000Z', payload: { item_id: 'maiz', delta: 10, unit: 'kg' } });
+    const e2 = ev({ id: 'c1', timestamp: '2026-01-02T00:00:00.000Z', event_type: EVENT_TYPES.CONSUMED, payload: { item_id: 'maiz', delta: -3, unit: 'kg' } });
+    const e3 = ev({ id: 'k1', timestamp: '2026-01-03T00:00:00.000Z', event_type: EVENT_TYPES.COUNTED, payload: { item_id: 'maiz', counted_qty: 20, unit: 'kg' } });
+
+    const inOrder = projectStock([e1, e2, e3]).get('maiz').quantity;
+    const shuffled = projectStock([e3, e1, e2]).get('maiz').quantity;
+    const reversed = projectStock([e3, e2, e1]).get('maiz').quantity;
+
+    expect(inOrder).toBe(20); // el COUNTED final reanchora
+    expect(shuffled).toBe(inOrder);
+    expect(reversed).toBe(inOrder);
+  });
+
+  it('no muta el arreglo de entrada (ordena sobre una copia)', () => {
+    const events = [
+      ev({ id: 'b', timestamp: '2026-01-02T00:00:00.000Z' }),
+      ev({ id: 'a', timestamp: '2026-01-01T00:00:00.000Z' }),
+    ];
+    const idsBefore = events.map((e) => e.id);
+    projectStock(events);
+    expect(events.map((e) => e.id)).toEqual(idsBefore);
+  });
+});

--- a/src/services/__tests__/iotMockService.test.js
+++ b/src/services/__tests__/iotMockService.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isSensorUnavailable,
+  generateMockSensorReadings,
+  generateMockHistory,
+  hasAnomalyNow,
+  isMockActive,
+  setMockActive,
+} from '../iotMockService.js';
+
+/**
+ * Tests del generador de readings IoT mock (determinista por minuto).
+ * Se usan timestamps fijos para controlar el ciclo de anomalías:
+ *   minuteSinceEpoch = floor(nowMs/60000); anomalyCycle = minute % 12.
+ *   cycle 0 → spike humedad invernadero · cycle 6 → spike temperatura.
+ */
+
+const MIN = 60000;
+const ANOMALY_HUMIDITY_MS = 0;        // minuto 0 → cycle 0
+const ANOMALY_TEMP_MS = 6 * MIN;      // minuto 6 → cycle 6
+const NO_ANOMALY_MS = 3 * MIN;        // minuto 3 → cycle 3
+
+describe('isSensorUnavailable', () => {
+  it.each([
+    [null, true],
+    [undefined, true],
+    [{ state: 'unavailable' }, true],
+    [{ state: 'UNAVAILABLE' }, true],
+    [{ state: 'unknown' }, true],
+    [{ state: '' }, true],
+    [{ state: 'null' }, true],
+    [{ state: '23.5' }, false],
+    [{ state: '0' }, false],
+  ])('para %o retorna %s', (reading, expected) => {
+    expect(isSensorUnavailable(reading)).toBe(expected);
+  });
+});
+
+describe('generateMockSensorReadings', () => {
+  it('genera los 4 sensores con estructura HA-like y flags de mock', () => {
+    const r = generateMockSensorReadings(NO_ANOMALY_MS);
+    const keys = Object.keys(r);
+    expect(keys).toContain('invernaderoHumidity');
+    expect(keys).toContain('invernaderoTemperature');
+    expect(keys).toContain('tabacoHumidity');
+    expect(keys).toContain('tabacoTemperature');
+    expect(keys).toHaveLength(4);
+    const s = r.invernaderoHumidity;
+    expect(s._mock).toBe(true);
+    expect(s._mock_reason).toBe('zigbee_offline');
+    expect(s.attributes.unit_of_measurement).toBe('%');
+    expect(Number.isNaN(Number(s.state))).toBe(false);
+  });
+
+  it('es determinista: mismo timestamp → mismas lecturas', () => {
+    expect(generateMockSensorReadings(NO_ANOMALY_MS)).toEqual(generateMockSensorReadings(NO_ANOMALY_MS));
+  });
+
+  it('en ciclo de anomalía la humedad del invernadero supera 85%', () => {
+    const r = generateMockSensorReadings(ANOMALY_HUMIDITY_MS);
+    expect(Number(r.invernaderoHumidity.state)).toBeGreaterThan(85);
+  });
+
+  it('en ciclo de anomalía de temperatura el invernadero supera 30°C', () => {
+    const r = generateMockSensorReadings(ANOMALY_TEMP_MS);
+    expect(Number(r.invernaderoTemperature.state)).toBeGreaterThan(30);
+  });
+});
+
+describe('generateMockHistory', () => {
+  it('genera 4 entidades con 48 puntos cada una', () => {
+    const h = generateMockHistory(NO_ANOMALY_MS);
+    const entities = Object.keys(h);
+    expect(entities).toHaveLength(4);
+    entities.forEach((e) => expect(h[e]).toHaveLength(48));
+  });
+
+  it('cada punto trae entity_id, state, last_changed ISO y _mock', () => {
+    const h = generateMockHistory(NO_ANOMALY_MS);
+    const p = h['sensor.hobeian_zg_303z_humidity'][0];
+    expect(p.entity_id).toBe('sensor.hobeian_zg_303z_humidity');
+    expect(typeof p.state).toBe('string');
+    expect(p._mock).toBe(true);
+    expect(() => new Date(p.last_changed).toISOString()).not.toThrow();
+    expect(p.last_changed).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('la serie va de más antiguo a más reciente', () => {
+    const h = generateMockHistory(NO_ANOMALY_MS);
+    const series = h['sensor.hobeian_zg_303z_humidity'];
+    const first = new Date(series[0].last_changed).getTime();
+    const last = new Date(series[series.length - 1].last_changed).getTime();
+    expect(last).toBeGreaterThan(first);
+  });
+});
+
+describe('hasAnomalyNow', () => {
+  it('detecta anomalía en el ciclo de humedad (minuto 0)', () => {
+    expect(hasAnomalyNow(ANOMALY_HUMIDITY_MS)).toBe(true);
+  });
+
+  it('detecta anomalía en el ciclo de temperatura (minuto 6)', () => {
+    expect(hasAnomalyNow(ANOMALY_TEMP_MS)).toBe(true);
+  });
+
+  it('no reporta anomalía fuera de los ciclos (minuto 3)', () => {
+    expect(hasAnomalyNow(NO_ANOMALY_MS)).toBe(false);
+  });
+});
+
+describe('isMockActive / setMockActive', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('arranca inactivo', () => {
+    expect(isMockActive()).toBe(false);
+  });
+
+  it('setMockActive(true) lo activa y (false) lo desactiva', () => {
+    setMockActive(true);
+    expect(isMockActive()).toBe(true);
+    setMockActive(false);
+    expect(isMockActive()).toBe(false);
+  });
+});

--- a/src/services/__tests__/llmTelemetryService.test.js
+++ b/src/services/__tests__/llmTelemetryService.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  aggregateLLMMetrics,
+  setLLMTelemetryEnabled,
+  isLLMTelemetryEnabled,
+} from '../llmTelemetryService.js';
+
+/**
+ * Tests de la parte pura de llmTelemetryService: aggregateLLMMetrics
+ * (totals / byModel / byFlujo) y el flag de habilitación (localStorage).
+ * Las funciones IndexedDB (record/get/prune/export) quedan fuera de este set.
+ * Fixtures con nombres de modelo genéricos.
+ */
+
+const EVENTS = [
+  { status: 'success', processor: 'gpu', total_ms: 100, eval_rate: 20, eval_count: 50, model: 'modelo-a', flujo: 'chat' },
+  { status: 'success', processor: 'gpu', total_ms: 200, eval_rate: 30, eval_count: 60, model: 'modelo-a', flujo: 'chat' },
+  { status: 'error', processor: 'cpu', total_ms: 50, model: 'modelo-b', flujo: 'vision' },
+  { status: 'abort', processor: 'gpu', model: 'modelo-a', flujo: 'chat' },
+];
+
+describe('aggregateLLMMetrics — totals', () => {
+  it('retorna ceros para lista vacía o no-array', () => {
+    for (const input of [[], null, undefined, 'x']) {
+      const { totals, byModel, byFlujo } = aggregateLLMMetrics(input);
+      expect(totals.total).toBe(0);
+      expect(totals.successRate).toBe(0);
+      expect(byModel).toEqual({});
+      expect(byFlujo).toEqual({});
+    }
+  });
+
+  it('cuenta success / error / abort y la tasa de éxito', () => {
+    const { totals } = aggregateLLMMetrics(EVENTS);
+    expect(totals.total).toBe(4);
+    expect(totals.success).toBe(2);
+    expect(totals.error).toBe(1);
+    expect(totals.abort).toBe(1);
+    expect(totals.successRate).toBe(0.5);
+  });
+
+  it('cuenta llamadas por procesador', () => {
+    const { totals } = aggregateLLMMetrics(EVENTS);
+    expect(totals.gpuCalls).toBe(3);
+    expect(totals.cpuCalls).toBe(1);
+  });
+
+  it('promedia y calcula p95 ignorando valores no numéricos', () => {
+    const { totals } = aggregateLLMMetrics(EVENTS);
+    // total_ms presentes: [100, 200, 50] (el abort no trae total_ms)
+    expect(totals.avgTotalMs).toBe(117); // round(350/3)
+    expect(totals.p95TotalMs).toBe(200); // sorted [50,100,200], idx floor(3*0.95)=2
+    expect(totals.avgEvalRate).toBe(25); // avg([20,30])
+  });
+});
+
+describe('aggregateLLMMetrics — byModel', () => {
+  it('agrupa por modelo con conteos, tasa de error y gpuShare', () => {
+    const { byModel } = aggregateLLMMetrics(EVENTS);
+    expect(byModel['modelo-a'].count).toBe(3);
+    expect(byModel['modelo-a'].success).toBe(2);
+    expect(byModel['modelo-a'].errorRate).toBe(0);
+    expect(byModel['modelo-a'].gpuShare).toBe(1);
+    expect(byModel['modelo-a'].avgTotalMs).toBe(150); // avg([100,200])
+    expect(byModel['modelo-b'].count).toBe(1);
+    expect(byModel['modelo-b'].errorRate).toBe(1);
+    expect(byModel['modelo-b'].gpuShare).toBe(0);
+  });
+
+  it('usa "unknown" cuando falta el modelo', () => {
+    const { byModel } = aggregateLLMMetrics([{ status: 'success', total_ms: 10 }]);
+    expect(byModel.unknown.count).toBe(1);
+  });
+});
+
+describe('aggregateLLMMetrics — byFlujo', () => {
+  it('agrupa por flujo con conteo y tasa de error', () => {
+    const { byFlujo } = aggregateLLMMetrics(EVENTS);
+    expect(byFlujo.chat.count).toBe(3);
+    expect(byFlujo.chat.errorRate).toBe(0);
+    expect(byFlujo.vision.count).toBe(1);
+    expect(byFlujo.vision.errorRate).toBe(1);
+  });
+
+  it('usa "other" cuando falta el flujo', () => {
+    const { byFlujo } = aggregateLLMMetrics([{ status: 'success' }]);
+    expect(byFlujo.other.count).toBe(1);
+  });
+});
+
+describe('flag de telemetría (localStorage)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('persiste el toggle activado y desactivado', () => {
+    setLLMTelemetryEnabled(true);
+    expect(isLLMTelemetryEnabled()).toBe(true);
+    setLLMTelemetryEnabled(false);
+    expect(isLLMTelemetryEnabled()).toBe(false);
+  });
+});

--- a/src/services/__tests__/operatorIdentityService.test.js
+++ b/src/services/__tests__/operatorIdentityService.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getOrCreateAccountUUID,
+  setAccountUUID,
+  computeOperatorHash,
+  setCurrentOperator,
+  getCurrentOperatorHash,
+  clearCurrentOperator,
+  verifyOperatorIdentity,
+  _resetForTests,
+} from '../operatorIdentityService.js';
+
+/**
+ * Tests de pseudonimización determinista (ADR-027.v Habeas Data).
+ * Usa crypto.subtle (PBKDF2 + HMAC-SHA256) disponible en el entorno de test,
+ * y localStorage para el account_uuid_master.
+ */
+
+const FIXED_UUID = 'chagra-test-account-uuid-1234567890';
+
+beforeEach(() => {
+  _resetForTests();
+});
+
+describe('account_uuid_master', () => {
+  it('getOrCreateAccountUUID genera y persiste el mismo UUID', () => {
+    const a = getOrCreateAccountUUID();
+    const b = getOrCreateAccountUUID();
+    expect(a).toBe(b);
+    expect(typeof a).toBe('string');
+    expect(a.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('setAccountUUID acepta un UUID válido y rechaza inválidos', () => {
+    expect(() => setAccountUUID(FIXED_UUID)).not.toThrow();
+    expect(getOrCreateAccountUUID()).toBe(FIXED_UUID);
+    expect(() => setAccountUUID('corto')).toThrow();
+    expect(() => setAccountUUID(123)).toThrow();
+  });
+});
+
+describe('computeOperatorHash', () => {
+  beforeEach(() => setAccountUUID(FIXED_UUID));
+
+  it('retorna 64 chars hex', async () => {
+    const h = await computeOperatorHash('miguel@guatoc.co');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('es determinista: mismo operador + mismo account_uuid → mismo hash', async () => {
+    const h1 = await computeOperatorHash('miguel@guatoc.co');
+    const h2 = await computeOperatorHash('miguel@guatoc.co');
+    expect(h1).toBe(h2);
+  });
+
+  it('operadores distintos → hashes distintos', async () => {
+    const h1 = await computeOperatorHash('miguel@guatoc.co');
+    const h2 = await computeOperatorHash('lili@guatoc.co');
+    expect(h1).not.toBe(h2);
+  });
+
+  it('distinto account_uuid_master → distinto hash para el mismo operador', async () => {
+    const hA = await computeOperatorHash('miguel@guatoc.co');
+    _resetForTests();
+    setAccountUUID('otro-account-uuid-distinto-9876543210');
+    const hB = await computeOperatorHash('miguel@guatoc.co');
+    expect(hA).not.toBe(hB);
+  });
+
+  it('rechaza operatorId vacío o no-string', async () => {
+    await expect(computeOperatorHash('')).rejects.toThrow();
+    await expect(computeOperatorHash(null)).rejects.toThrow();
+  });
+});
+
+describe('operador actual de sesión', () => {
+  beforeEach(() => setAccountUUID(FIXED_UUID));
+
+  it('setCurrentOperator guarda el hash y getCurrentOperatorHash lo lee', async () => {
+    const hash = await setCurrentOperator('miguel@guatoc.co');
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(getCurrentOperatorHash()).toBe(hash);
+  });
+
+  it('clearCurrentOperator borra el hash', async () => {
+    await setCurrentOperator('miguel@guatoc.co');
+    clearCurrentOperator();
+    expect(getCurrentOperatorHash()).toBeNull();
+  });
+});
+
+describe('verifyOperatorIdentity', () => {
+  beforeEach(() => setAccountUUID(FIXED_UUID));
+
+  it('true cuando el hash coincide, false cuando no', async () => {
+    const hash = await computeOperatorHash('miguel@guatoc.co');
+    expect(await verifyOperatorIdentity('miguel@guatoc.co', hash)).toBe(true);
+    expect(await verifyOperatorIdentity('lili@guatoc.co', hash)).toBe(false);
+  });
+});

--- a/src/services/__tests__/visionWarmService.test.js
+++ b/src/services/__tests__/visionWarmService.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { warmVisionModel, __resetVisionWarmState } from '../visionWarmService.js';
+
+/**
+ * Tests del pre-warm del modelo de visión (fire-and-forget, idempotente).
+ * Se mockea fetch global; el estado interno se reinicia con __resetVisionWarmState.
+ * No se asercionan nombres de modelo (se mantienen fuera del test).
+ */
+
+beforeEach(() => {
+  __resetVisionWarmState();
+  vi.unstubAllGlobals();
+});
+
+describe('warmVisionModel', () => {
+  it('dispara un fetch POST al endpoint de ollama y retorna true si responde ok', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    const r = await warmVisionModel();
+    expect(r).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/ollama/api/generate');
+    expect(opts.method).toBe('POST');
+    expect(opts.body).toContain('keep_alive');
+  });
+
+  it('retorna false si la respuesta no es ok', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+    expect(await warmVisionModel()).toBe(false);
+  });
+
+  it('retorna false (degrada silencioso) si fetch lanza', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+    expect(await warmVisionModel()).toBe(false);
+  });
+
+  it('idempotente: tras un warm exitoso reciente NO vuelve a fetchear', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    await warmVisionModel();
+    await warmVisionModel(); // dentro de la ventana SKIP_IF_RECENT
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('tras __resetVisionWarmState vuelve a fetchear', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    await warmVisionModel();
+    __resetVisionWarmState();
+    await warmVisionModel();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('lock in-flight: una segunda llamada concurrente no dispara otro fetch', async () => {
+    let resolveFetch;
+    const fetchMock = vi.fn(() => new Promise((res) => { resolveFetch = () => res({ ok: true }); }));
+    vi.stubGlobal('fetch', fetchMock);
+    const p1 = warmVisionModel();        // queda in-flight
+    const r2 = await warmVisionModel();  // debe cortocircuitar por el lock
+    expect(r2).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    resolveFetch();
+    expect(await p1).toBe(true);
+  });
+});


### PR DESCRIPTION
## Connect que mejora la app

`NotificationsBell` pasaba `failedTxCount: 0` **hardcodeado** → la notificación 'N cambios sin sincronizar' (lógica ya en `aggregateNotifications`) nunca se mostraba. Ahora carga el conteo real de transacciones en **quarantine** (`syncManager.getFailedTransactions()`, el bucket del fix BUG-CRITICAL #300) vía useEffect, refrescando al abrir/descartar.

**Impacto:** el campesino ve cuando hay datos atascados sin sincronizar (antes invisible).

**Verificado:** eslint 0 warnings · build OK · CriticalAlertBanner tests verdes.

**Follow-up (mismo gap, otra pasada):** `tasks` (mapear logs FarmOS→tarea con due_date) y `calendarMonth` (falta fuente local de calendario) siguen desconectados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)