### PR TITLE
test(suite): reparar 14 tests stale → suite unit 100% verde

### DIFF
--- a/src/components/Settings/__tests__/BackgroundSelector.smoke.test.jsx
+++ b/src/components/Settings/__tests__/BackgroundSelector.smoke.test.jsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import BackgroundSelector from '../BackgroundSelector';
-import useThemeBackgroundStore from '../../../store/useThemeBackgroundStore';
+import useThemeBackgroundStore, {
+  BACKGROUND_CATALOG,
+} from '../../../store/useThemeBackgroundStore';
 
 describe('BackgroundSelector smoke', () => {
   beforeEach(() => {
@@ -47,7 +49,7 @@ describe('BackgroundSelector smoke', () => {
   it('cada opción muestra un thumbnail img', () => {
     render(<BackgroundSelector />);
     const imgs = document.querySelectorAll('img');
-    expect(imgs.length).toBe(4);
+    expect(imgs.length).toBe(BACKGROUND_CATALOG.length);
     imgs.forEach((img) => expect(img).toHaveAttribute('loading', 'lazy'));
   });
 });

--- a/src/components/__tests__/FeedbackButtons.test.jsx
+++ b/src/components/__tests__/FeedbackButtons.test.jsx
@@ -70,39 +70,48 @@ describe('FeedbackButtons', () => {
     });
   });
 
-  it('debe mostrar caja de comentario al hacer clic en thumbs down', async () => {
-    vi.mocked(feedbackService.hasConsent).mockReturnValue(true);
-
-    render(<FeedbackButtons {...defaultProps} />);
-
-    const thumbsDownButton = screen.getByTitle('Esta respuesta necesita mejorar');
-    fireEvent.click(thumbsDownButton);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/Describe qué falta/)).toBeInTheDocument();
-    });
-  });
-
-  it('debe enviar feedback con comentario', async () => {
+  // UX-8 (#288) 2026-05-27: ambos pulgares envían en 1-click. El comentario
+  // es opt-in tras enviar — se abre con "Agregar detalle", no al pulsar 👎.
+  it('debe ofrecer caja de comentario opt-in tras enviar feedback (thumbs down)', async () => {
     vi.mocked(feedbackService.hasConsent).mockReturnValue(true);
     vi.mocked(feedbackService.sendFeedback).mockResolvedValue(true);
 
     render(<FeedbackButtons {...defaultProps} />);
 
-    // Click en thumbs down
     const thumbsDownButton = screen.getByTitle('Esta respuesta necesita mejorar');
     fireEvent.click(thumbsDownButton);
 
-    // Esperar a que aparezca la caja de comentario
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText(/Describe qué falta/)).toBeInTheDocument();
-    });
+    // El 👎 envía de inmediato; aparece el agradecimiento + "Agregar detalle".
+    const addDetailButton = await screen.findByText('Agregar detalle');
+    fireEvent.click(addDetailButton);
 
-    // Escribir comentario
-    const textarea = screen.getByPlaceholderText(/Describe qué falta/);
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(/Cuéntanos qué falta o está incorrecto/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('debe enriquecer el feedback con comentario opt-in', async () => {
+    vi.mocked(feedbackService.hasConsent).mockReturnValue(true);
+    vi.mocked(feedbackService.sendFeedback).mockResolvedValue(true);
+
+    render(<FeedbackButtons {...defaultProps} />);
+
+    // Click en thumbs down → envía 1-click.
+    const thumbsDownButton = screen.getByTitle('Esta respuesta necesita mejorar');
+    fireEvent.click(thumbsDownButton);
+
+    // Abrir la caja opt-in.
+    const addDetailButton = await screen.findByText('Agregar detalle');
+    fireEvent.click(addDetailButton);
+
+    const textarea = await screen.findByPlaceholderText(
+      /Cuéntanos qué falta o está incorrecto/
+    );
     fireEvent.change(textarea, { target: { value: 'Falta información sobre el riego' } });
 
-    // Click en enviar
+    // Click en enviar (reenvía enriquecido con el comentario).
     const sendButton = screen.getByText('Enviar');
     fireEvent.click(sendButton);
 
@@ -116,27 +125,34 @@ describe('FeedbackButtons', () => {
     });
   });
 
-  it('debe cancelar comentario al hacer clic en Cancelar', async () => {
+  it('debe cerrar la caja de comentario al hacer clic en Listo', async () => {
     vi.mocked(feedbackService.hasConsent).mockReturnValue(true);
+    vi.mocked(feedbackService.sendFeedback).mockResolvedValue(true);
 
     render(<FeedbackButtons {...defaultProps} />);
 
-    // Click en thumbs down
+    // Click en thumbs down → envía 1-click.
     const thumbsDownButton = screen.getByTitle('Esta respuesta necesita mejorar');
     fireEvent.click(thumbsDownButton);
 
-    // Esperar a que aparezca la caja de comentario
+    // Abrir la caja opt-in.
+    const addDetailButton = await screen.findByText('Agregar detalle');
+    fireEvent.click(addDetailButton);
+
     await waitFor(() => {
-      expect(screen.getByPlaceholderText(/Describe qué falta/)).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(/Cuéntanos qué falta o está incorrecto/)
+      ).toBeInTheDocument();
     });
 
-    // Click en cancelar
-    const cancelButton = screen.getByText('Cancelar');
-    fireEvent.click(cancelButton);
+    // Click en Listo (cierra la caja).
+    const doneButton = screen.getByText('Listo');
+    fireEvent.click(doneButton);
 
-    // Verificar que la caja de comentario desapareció
     await waitFor(() => {
-      expect(screen.queryByPlaceholderText(/Describe qué falta/)).not.toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText(/Cuéntanos qué falta o está incorrecto/)
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/TopBar.voicePlant.test.jsx
+++ b/src/components/__tests__/TopBar.voicePlant.test.jsx
@@ -1,29 +1,37 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import TopBar from '../TopBar';
 
 /**
- * Tests para UX-27 (#286): operador 2026-05-27 — "en la parte de arriba
- * borra el + en su lugar mejora el de micrófono con un icono de + y una
- * planta o algo lindo que le permita inferir que es para agregar una
- * planta con voz".
+ * Tests del TopBar tras el rediseño #323 (2026-05-28).
  *
- * Verifica:
- *   - El botón solo del + (onNavigate='plant_asset') YA NO existe.
- *   - El botón con icono Mic + decoración Sprout existe.
- *   - aria-label "Agregar planta por voz" para screenreaders.
- *   - Tap navega a 'voz' (el flow de voz YA permite registrar plantas).
- *   - Touch target 44x44 (iOS minimum).
+ * Historia:
+ *   - UX-27 (#286, 2026-05-27): se unificaron los dos botones de captura
+ *     (Mic solo + Plus solo) en un único "Agregar planta por voz"
+ *     (data-testid="topbar-add-plant-voice").
+ *   - #323 (2026-05-28): el operador pidió quitar el botón de voz flotante
+ *     en toda la app; el agregar-planta-por-voz lo hace ahora el agente
+ *     Chagra directamente. El mic+sprout del TopBar fue REEMPLAZADO por el
+ *     NotificationsBell (ver comentario en TopBar.jsx ~L192-196).
+ *
+ * Por eso este test verifica el estado ACTUAL:
+ *   - El botón unificado "Agregar planta por voz" YA NO existe.
+ *   - Tampoco existen los botones legacy (Plus "Capturar planta" / "Captura
+ *     por voz").
+ *   - En su lugar aparece el NotificationsBell.
  */
 
-// Mocks: EnvironmentalCard / AltitudeBadge / OfflineChip son sub-componentes
-// pesados o que tocan store global. No nos importan para este test.
+// Mocks: sub-componentes pesados o que tocan store global. No nos importan
+// para este test del TopBar.
 vi.mock('../EnvironmentalCard', () => ({ default: () => <div data-testid="env-stub" /> }));
 vi.mock('../AltitudeBadge', () => ({ default: () => <div data-testid="alt-stub" /> }));
 vi.mock('../OfflineChip', () => ({ default: () => <div data-testid="chip-stub" /> }));
+vi.mock('../NotificationsBell', () => ({
+  default: () => <div data-testid="notifications-bell-stub" />,
+}));
 
-describe('UX-27 — TopBar botón unificado voz+planta', () => {
+describe('TopBar — captura por voz removida (#323)', () => {
   let onNavigate;
   let onLogout;
 
@@ -32,39 +40,20 @@ describe('UX-27 — TopBar botón unificado voz+planta', () => {
     onLogout = vi.fn();
   });
 
-  it('existe un único botón de captura ("Agregar planta por voz")', () => {
+  it('YA NO existe el botón unificado "Agregar planta por voz"', () => {
     render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
-    const btn = screen.getByTestId('topbar-add-plant-voice');
-    expect(btn).toBeInTheDocument();
-    expect(btn).toHaveAttribute('aria-label', 'Agregar planta por voz');
+    expect(screen.queryByTestId('topbar-add-plant-voice')).toBeNull();
+    expect(screen.queryByLabelText(/^Agregar planta por voz$/i)).toBeNull();
   });
 
-  it('NO existe el botón Plus solo que navegaba a plant_asset', () => {
+  it('tampoco existen los botones legacy (Plus / Captura por voz)', () => {
     render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
-    // El antiguo aria-label "Capturar planta" debe haber desaparecido.
     expect(screen.queryByLabelText(/^Capturar planta$/i)).toBeNull();
-    // Y el antiguo "Captura por voz" tambien — fue reemplazado por el copy nuevo.
     expect(screen.queryByLabelText(/^Captura por voz$/i)).toBeNull();
   });
 
-  it('al tocar el botón navega a "voz" (flow de voz registra planta)', () => {
+  it('en su lugar renderiza el NotificationsBell', () => {
     render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
-    fireEvent.click(screen.getByTestId('topbar-add-plant-voice'));
-    expect(onNavigate).toHaveBeenCalledWith('voz');
-    // NO debe navegar al form manual.
-    expect(onNavigate).not.toHaveBeenCalledWith('plant_asset');
-  });
-
-  it('cumple touch target iOS 44x44', () => {
-    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
-    const btn = screen.getByTestId('topbar-add-plant-voice');
-    expect(btn.className).toMatch(/min-h-\[44px\]/);
-    expect(btn.className).toMatch(/min-w-\[44px\]/);
-  });
-
-  it('tiene title accesible para tooltip desktop', () => {
-    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
-    const btn = screen.getByTestId('topbar-add-plant-voice');
-    expect(btn).toHaveAttribute('title', 'Agregar planta por voz');
+    expect(screen.getByTestId('notifications-bell-stub')).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/estratoCopy.test.jsx
+++ b/src/components/__tests__/estratoCopy.test.jsx
@@ -60,10 +60,17 @@ describe('UX-15 — copy de "Capa del cultivo" sin dosel', () => {
     expect(source).not.toMatch(/label:\s*'Bajo \(/);
   });
 
-  it('declara los 5 tipos urbanos en URBAN_LAND_TYPES_LOCAL', () => {
-    expect(source).toMatch(/URBAN_LAND_TYPES_LOCAL\s*=\s*new Set\(/);
+  it('declara los 5 tipos urbanos en URBAN_LAND_TYPES (utils/landTypes)', () => {
+    // UX-13 (#286): el set urbano se extrajo de AssetsDashboard.jsx a
+    // utils/landTypes.js (regla react-refresh/only-export-components).
+    // La fuente de verdad ahora es URBAN_LAND_TYPES, derivado de LAND_TYPES.
+    const landTypesSource = readFileSync(
+      resolve(__dirname, '..', '..', 'utils', 'landTypes.js'),
+      'utf-8'
+    );
+    expect(landTypesSource).toMatch(/URBAN_LAND_TYPES\s*=\s*new Set\(/);
     for (const v of ['balcony', 'terrace', 'window_sill', 'indoor_pot', 'urban_garden']) {
-      expect(source).toContain(`'${v}'`);
+      expect(landTypesSource).toContain(`'${v}'`);
     }
   });
 

--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -131,14 +131,18 @@ describe('agentService — Task #202 Profile Context', () => {
     });
 
     it('debería recomendar IDEAM para zona desconocida', () => {
+      // Bug piloto 2026-05-27: la regla CLIMA ahora consulta IDEAM vía el
+      // tool get_clima_ideam y prohíbe redirigir al user a apps externas.
       const context = generateClimateAlertsContext('zona_inexistente');
       expect(context).toContain('IDEAM');
-      expect(context).toContain('pronóstico IDEAM');
+      expect(context).toContain('get_clima_ideam');
+      // Zona desconocida igual deja constancia de la zona del operador.
+      expect(context).toContain('zona_inexistente');
     });
 
     it('debería recomendar IDEAM para null', () => {
       const context = generateClimateAlertsContext(null);
-      expect(context).toContain('cita siempre la fuente');
+      expect(context).toContain('REGLA CLIMA');
       expect(context).toContain('IDEAM');
     });
   });

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -143,6 +143,8 @@ describe('sidecarClient — feature flag on', () => {
         useTool: true,
         tool: 'get_species',
         args: { id_or_name: 'maracuya' },
+        // D2 (#246): sin tool_chain en la respuesta → toolChain queda null.
+        toolChain: null,
         latencyMs: 187,
         modelUsed: 'gemma3:4b',
         heuristicSkipped: false,

--- a/src/services/__tests__/voiceService.test.js
+++ b/src/services/__tests__/voiceService.test.js
@@ -33,7 +33,7 @@ describe('voiceService', () => {
   });
 
   describe('transcribe', () => {
-    it('usa lang=es-CO por defecto', async () => {
+    it('usa lang=es por defecto (whisper rechaza es-CO con HTTP 500)', async () => {
       const mockFetch = vi.fn();
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -49,7 +49,9 @@ describe('voiceService', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       
       const url = mockFetch.mock.calls[0][0];
-      expect(url).toContain('language=es-CO');
+      // Whisper acepta solo ISO-639-1 sin región; 'es-CO' se normaliza a 'es'.
+      expect(url).toContain('language=es');
+      expect(url).not.toContain('language=es-CO');
       expect(url).toContain('task=transcribe');
       expect(url).toContain('output=json');
     });

--- a/src/store/__tests__/useThemeBackgroundStore.test.js
+++ b/src/store/__tests__/useThemeBackgroundStore.test.js
@@ -46,13 +46,14 @@ describe('useThemeBackgroundStore', () => {
     expect(useThemeBackgroundStore.getState().selected).toBe('default');
   });
 
-  it('catálogo tiene 4 fondos (default + 3 biopunk) y está congelado', () => {
-    expect(BACKGROUND_CATALOG).toHaveLength(4);
+  it('catálogo tiene default + biopunk y está congelado', () => {
+    expect(BACKGROUND_CATALOG).toHaveLength(5);
     expect(BACKGROUND_CATALOG.map((b) => b.id)).toEqual([
       'default',
       'biopunk-1',
       'biopunk-2',
       'biopunk-3',
+      'biopunk-4',
     ]);
     expect(Object.isFrozen(BACKGROUND_CATALOG)).toBe(true);
     expect(Object.isFrozen(BACKGROUND_CATALOG[0])).toBe(true);


### PR DESCRIPTION
## Qué

14 tests rojos en 8 archivos quedaron stale tras cambios deliberados del código fuente. Esta PR los actualiza para reflejar el comportamiento actual correcto. **Ningún test revelaba un bug real** — todos eran stale.

## Por archivo (todos STALE)

| Archivo | Qué cambió en el código | Fix del test |
|---|---|---|
| `useThemeBackgroundStore.test.js` | catálogo creció a 5 fondos (biopunk-4 "Cosecha mística") | conteo 4→5 + id `biopunk-4` |
| `BackgroundSelector.smoke.test.jsx` | 1 img por entrada del catálogo | atado a `BACKGROUND_CATALOG.length` (no número mágico) |
| `estratoCopy.test.jsx` | `URBAN_LAND_TYPES_LOCAL` se extrajo a `utils/landTypes.js` como `URBAN_LAND_TYPES` (UX-13 #286, regla `react-refresh/only-export-components`) | test apunta a la nueva fuente de verdad |
| `FeedbackButtons.test.jsx` | rediseño UX-8 (#288): 1-click en ambos pulgares + comentario opt-in tras enviar ("Agregar detalle" → "Listo"/"Enviar") | 3 tests reescritos al flujo opt-in |
| `TopBar.voicePlant.test.jsx` | botón mic+sprout removido en #323 (2026-05-28), reemplazado por `NotificationsBell` (el agente hace add-plant-by-voice) | tests reescritos: verifican ausencia del botón + presencia del bell |
| `agentService.test.js` | `generateClimateAlertsContext` migró a regla CLIMA-DIRECTO honesta (fix piloto 2026-05-27: `get_clima_ideam`, sin redirect a apps externas) | aserciones actualizadas |
| `sidecarClient.test.js` | `planNlu` normaliza `tool_chain` → `toolChain` (D2 #246) | agregado `toolChain: null` al objeto esperado |
| `voiceService.test.js` | whisper rechaza `es-CO` con HTTP 500 → cliente normaliza a `es` | test espera `language=es` |

## Resultado

- Suite unit: **2246 passed, 1 skipped, 0 failed** (139 archivos).
- `eslint <archivos tocados> --max-warnings=0`: limpio.
- **0 bugs reales pendientes de decisión** — todos los rojos eran stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)