### PR TITLE
feat(notifications): conectar tareas vencidas reales al bell (TDD)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v269';
+const CACHE_NAME = 'chagra-v270';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/NotificationsBell.jsx
+++ b/src/components/NotificationsBell.jsx
@@ -5,6 +5,7 @@ import useAlertStore from '../store/useAlertStore';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import { aggregateNotifications, dismissNotification } from '../services/notificationsService';
 import { syncManager } from '../services/syncManager';
+import { useLogStore } from '../store/useLogStore';
 // PoC alertas meteorológicas (#316) — fuente de verdad ENSO + alertas locales.
 import {
     getCachedClimaSnapshot,
@@ -87,6 +88,9 @@ export default function NotificationsBell({ onNavigate }) {
     // bell nunca mostraba "sync stuck". Conecta el estado de sincronización al
     // centro de notificaciones.
     const [failedTxCount, setFailedTxCount] = useState(0);
+    // tasks vencidas reales desde useLogStore (log--task pending). Antes estaba
+    // hardcodeado a [], así que el bell nunca mostraba "tareas vencidas".
+    const [pendingTasks, setPendingTasks] = useState([]);
 
     const plants = useAssetStore((s) => s.plants);
     const sensorAlerts = useAlertStore((s) => s.activeAlerts);
@@ -113,6 +117,9 @@ export default function NotificationsBell({ onNavigate }) {
         let alive = true;
         syncManager.getFailedTransactions()
             .then((txs) => { if (alive) setFailedTxCount(Array.isArray(txs) ? txs.length : 0); })
+            .catch(() => {});
+        useLogStore.getState().getPendingTasks()
+            .then((tasks) => { if (alive) setPendingTasks(Array.isArray(tasks) ? tasks : []); })
             .catch(() => {});
         return () => { alive = false; };
     }, [open, tick]);
@@ -143,7 +150,7 @@ export default function NotificationsBell({ onNavigate }) {
         const finca = fincas.find((f) => f.slug === activeFincaSlug);
         return aggregateNotifications({
             plants,
-            tasks: [],
+            tasks: pendingTasks,
             failedTxCount,
             hasUpdate: readUpdateAvailable(),
             onboardingComplete: readOnboardingComplete(),
@@ -152,7 +159,7 @@ export default function NotificationsBell({ onNavigate }) {
             iotAlerts: mapSensorAlertsToIot(sensorAlerts),
         });
         // tick force re-run on dismiss event
-    }, [plants, sensorAlerts, activeFincaSlug, fincas, tick, failedTxCount]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [plants, sensorAlerts, activeFincaSlug, fincas, tick, failedTxCount, pendingTasks]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // PoC #316 — el clima cuenta para los badges del bell. Las alertas
     // locales de Open-Meteo (helada/calor/torrencial/etc) escalan severity;

--- a/src/services/__tests__/notificationsService.test.js
+++ b/src/services/__tests__/notificationsService.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { aggregateNotifications, setDemoSeedHelada } from '../notificationsService.js';
+
+/**
+ * Tests del bloque de tareas de aggregateNotifications.
+ *
+ * Contrato: las tareas vencidas (due_date en el pasado) generan una
+ * notificación `tasks_pending`. Los logs FarmOS de tipo `log--task` no traen
+ * `due_date` sino `timestamp` (Unix en segundos), así que el agregador debe
+ * aceptar ese campo como fallback para que las tareas atrasadas reales —las
+ * que llegan desde useLogStore.getPendingTasks()— efectivamente se muestren.
+ */
+
+const DAY = 86400000;
+
+beforeEach(() => {
+  localStorage.clear();
+  setDemoSeedHelada(false); // evita el seed demo de helada en el agregado
+});
+
+function taskNotifs(sources) {
+  return aggregateNotifications(sources).filter((n) => n.type === 'tasks_pending');
+}
+
+describe('aggregateNotifications — tareas vencidas', () => {
+  it('no genera notificación sin tareas', () => {
+    expect(taskNotifs({ tasks: [] })).toHaveLength(0);
+    expect(taskNotifs({})).toHaveLength(0);
+  });
+
+  it('una tarea con due_date en el pasado se reporta como vencida', () => {
+    const past = new Date(Date.now() - DAY).toISOString();
+    const out = taskNotifs({ tasks: [{ due_date: past, title: 'Podar tomate' }] });
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe('warning');
+    expect(out[0].title).toMatch(/1 tarea vencida/);
+  });
+
+  it('NO reporta tareas con fecha futura', () => {
+    const future = new Date(Date.now() + DAY).toISOString();
+    expect(taskNotifs({ tasks: [{ due_date: future, title: 'Cosechar' }] })).toHaveLength(0);
+  });
+
+  it('FALLBACK: un log--task con timestamp Unix (segundos) en el pasado se reporta vencido', () => {
+    const pastUnix = Math.floor((Date.now() - DAY) / 1000); // FarmOS usa segundos
+    const out = taskNotifs({ tasks: [{ timestamp: pastUnix, name: 'Regar invernadero' }] });
+    expect(out).toHaveLength(1);
+    expect(out[0].type).toBe('tasks_pending');
+  });
+
+  it('FALLBACK: un log--task con timestamp Unix futuro NO se reporta', () => {
+    const futureUnix = Math.floor((Date.now() + DAY) / 1000);
+    expect(taskNotifs({ tasks: [{ timestamp: futureUnix, name: 'Sembrar' }] })).toHaveLength(0);
+  });
+
+  it('más de 3 tareas vencidas eleva la severidad a crítica', () => {
+    const past = Math.floor((Date.now() - DAY) / 1000);
+    const tasks = Array.from({ length: 4 }, (_, i) => ({ timestamp: past, name: `Tarea ${i}` }));
+    const out = taskNotifs({ tasks });
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe('critical');
+  });
+});

--- a/src/services/notificationsService.js
+++ b/src/services/notificationsService.js
@@ -158,8 +158,13 @@ export function aggregateNotifications(sources = {}) {
     // 4. Tareas vencidas
     if (Array.isArray(sources.tasks) && sources.tasks.length > 0) {
         const overdue = sources.tasks.filter((t) => {
-            if (!t.due_date) return false;
-            return new Date(t.due_date).getTime() < now;
+            // Los logs FarmOS (log--task) traen `timestamp` (Unix en segundos)
+            // en vez de `due_date`; aceptamos ambos para que las tareas reales
+            // que llegan desde useLogStore.getPendingTasks() se reporten.
+            const dueMs = t.due_date
+                ? new Date(t.due_date).getTime()
+                : (typeof t.timestamp === 'number' ? t.timestamp * 1000 : NaN);
+            return Number.isFinite(dueMs) && dueMs < now;
         });
         if (overdue.length > 0) {
             out.push({


### PR DESCRIPTION
## Summary
El centro de notificaciones (`NotificationsBell`) pasaba `tasks: []` hardcodeado, así que la notificación de **tareas vencidas** nunca aparecía aunque la lógica del agregador ya existía. Este PR conecta la fuente real.

- `NotificationsBell`: carga `useLogStore.getPendingTasks()` (logs `log--task` con status pending) en un `useEffect` que reusa el patrón ya establecido de `failedTxCount`.
- `notificationsService.aggregateNotifications`: acepta `timestamp` Unix (segundos, formato FarmOS) como fallback de `due_date`, porque los `log--task` no traen `due_date`.

## Test plan (TDD test-first)
- Nuevo `notificationsService.test.js` (6 tests). El caso del fallback `timestamp` se escribió **primero** y falla en rojo; pasa tras el fix.
- `npx vitest run` → 6/6 verde · `eslint --max-warnings=0` limpio · `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)