### PR TITLE
test(utils): batch coverage fuzzySearch + dateFormatter + assetRelationships + blobUrl (30 tests)

### DIFF
--- a/src/utils/__tests__/assetRelationships.test.js
+++ b/src/utils/__tests__/assetRelationships.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getParentLandIdFromAsset } from '../assetRelationships.js';
+
+/**
+ * Tests de assetRelationships: resolución del parent-land id desde el shape
+ * JSON:API de un asset. Función pura. Cubre array vs objeto único y el
+ * fallback parent.data → location.data (compat FarmOS v2 + legacy).
+ */
+
+describe('getParentLandIdFromAsset', () => {
+  it('lee parent.data como objeto único', () => {
+    const asset = { relationships: { parent: { data: { id: 'land-1' } } } };
+    expect(getParentLandIdFromAsset(asset)).toBe('land-1');
+  });
+
+  it('lee parent.data como array (toma el primero)', () => {
+    const asset = { relationships: { parent: { data: [{ id: 'land-2' }, { id: 'land-3' }] } } };
+    expect(getParentLandIdFromAsset(asset)).toBe('land-2');
+  });
+
+  it('cae a location.data cuando no hay parent.data', () => {
+    const asset = { relationships: { location: { data: { id: 'loc-9' } } } };
+    expect(getParentLandIdFromAsset(asset)).toBe('loc-9');
+  });
+
+  it('prioriza parent.data sobre location.data', () => {
+    const asset = {
+      relationships: {
+        parent: { data: { id: 'parent-id' } },
+        location: { data: { id: 'loc-id' } },
+      },
+    };
+    expect(getParentLandIdFromAsset(asset)).toBe('parent-id');
+  });
+
+  it('devuelve null para asset nulo o sin relationships', () => {
+    expect(getParentLandIdFromAsset(null)).toBeNull();
+    expect(getParentLandIdFromAsset(undefined)).toBeNull();
+    expect(getParentLandIdFromAsset({})).toBeNull();
+    expect(getParentLandIdFromAsset({ relationships: {} })).toBeNull();
+  });
+
+  it('devuelve null si el array está vacío', () => {
+    const asset = { relationships: { parent: { data: [] } } };
+    expect(getParentLandIdFromAsset(asset)).toBeNull();
+  });
+});

--- a/src/utils/__tests__/blobUrl.test.js
+++ b/src/utils/__tests__/blobUrl.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeBlobUrl } from '../blobUrl.js';
+
+/**
+ * Tests de sanitizeBlobUrl: sanitizer anti-XSS para src de <img> (CodeQL
+ * js/xss-through-dom). Solo deja pasar blob: URLs same-origin; cualquier otro
+ * protocolo/origen o input no-string devuelve ''. jsdom expone
+ * window.location.origin = http://localhost:3000.
+ */
+
+describe('sanitizeBlobUrl', () => {
+  it('devuelve "" para entradas que no son string', () => {
+    expect(sanitizeBlobUrl(null)).toBe('');
+    expect(sanitizeBlobUrl(undefined)).toBe('');
+    expect(sanitizeBlobUrl(123)).toBe('');
+    expect(sanitizeBlobUrl({})).toBe('');
+  });
+
+  it('devuelve "" para string vacío', () => {
+    expect(sanitizeBlobUrl('')).toBe('');
+  });
+
+  it('acepta un blob: URL same-origin', () => {
+    const url = `blob:${window.location.origin}/abc-123`;
+    expect(sanitizeBlobUrl(url)).toBe(url);
+  });
+
+  it('rechaza protocolos que no sean blob:', () => {
+    expect(sanitizeBlobUrl('https://evil.com/x.png')).toBe('');
+    expect(sanitizeBlobUrl('javascript:alert(1)')).toBe('');
+    expect(sanitizeBlobUrl('data:image/svg+xml,<svg/>')).toBe('');
+  });
+
+  it('rechaza un blob: URL de otro origen', () => {
+    expect(sanitizeBlobUrl('blob:https://otro-host.com/abc')).toBe('');
+  });
+
+  it('devuelve "" para strings que no son URLs válidas', () => {
+    expect(sanitizeBlobUrl('no-es-una-url')).toBe('');
+  });
+});

--- a/src/utils/__tests__/dateFormatter.test.js
+++ b/src/utils/__tests__/dateFormatter.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatDate,
+  formatTimestamp,
+  formatRelativeTime,
+  toISODate,
+  toISODateTime,
+} from '../dateFormatter.js';
+
+/**
+ * Tests de dateFormatter: helpers puros de fecha. Cubren el happy path y los
+ * guards de entrada inválida (null/''/NaN) que evitan "Invalid Date" en la UI.
+ */
+
+describe('formatDate (UNIX segundos → "YYYY-MM-DD HH:mm")', () => {
+  it('formatea un timestamp UNIX en segundos', () => {
+    // 2024-05-07T20:30:56Z → la salida depende del TZ del runner, validamos shape
+    expect(formatDate(1715113856)).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+
+  it('devuelve "" para entrada nula/vacía/inválida', () => {
+    expect(formatDate(undefined)).toBe('');
+    expect(formatDate(null)).toBe('');
+    expect(formatDate('')).toBe('');
+    expect(formatDate('abc')).toBe('');
+  });
+});
+
+describe('formatTimestamp (ISO → localizado)', () => {
+  it('formatea una fecha ISO válida', () => {
+    expect(formatTimestamp('2024-05-07T20:30:00')).toMatch(/\d/);
+  });
+
+  it('devuelve guion largo para entrada inválida', () => {
+    expect(formatTimestamp(undefined)).toBe('—');
+    expect(formatTimestamp('no-fecha')).toBe('—');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  it('"Ahora mismo" para el instante actual', () => {
+    expect(formatRelativeTime(new Date())).toBe('Ahora mismo');
+  });
+
+  it('minutos / horas / días recientes', () => {
+    const now = Date.now();
+    expect(formatRelativeTime(now - 2 * 60000)).toBe('Hace 2 min');
+    expect(formatRelativeTime(now - 3 * 3600000)).toBe('Hace 3h');
+    expect(formatRelativeTime(now - 2 * 86400000)).toBe('Hace 2d');
+  });
+
+  it('cae a fecha corta para > 7 días', () => {
+    const old = Date.now() - 30 * 86400000;
+    const r = formatRelativeTime(old);
+    expect(r).not.toMatch(/Hace|Ahora/);
+  });
+
+  it('devuelve "" para entrada inválida', () => {
+    expect(formatRelativeTime(null)).toBe('');
+    expect(formatRelativeTime('x')).toBe('');
+  });
+});
+
+describe('toISODate / toISODateTime', () => {
+  it('toISODate devuelve solo la fecha YYYY-MM-DD', () => {
+    expect(toISODate('2024-05-07T20:30:00Z')).toBe('2024-05-07');
+  });
+
+  it('toISODateTime devuelve ISO-8601 completo', () => {
+    expect(toISODateTime('2024-05-07T20:30:00Z')).toBe('2024-05-07T20:30:00.000Z');
+  });
+
+  it('ambos devuelven "" para entrada inválida', () => {
+    expect(toISODate(null)).toBe('');
+    expect(toISODate('nope')).toBe('');
+    expect(toISODateTime('')).toBe('');
+    expect(toISODateTime('nope')).toBe('');
+  });
+});

--- a/src/utils/__tests__/fuzzySearch.test.js
+++ b/src/utils/__tests__/fuzzySearch.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { fuzzyFilter } from '../fuzzySearch.js';
+
+/**
+ * Tests de fuzzySearch: filtro aproximado del selector de especies.
+ * Función pura. Cubre los casos del módulo: "Gulpa"→"Gulupa",
+ * tolerancia a acentos, prefijo > contención > subsecuencia, y límite.
+ */
+
+const especies = ['Gulupa', 'Guayaba', 'Guanábana', 'Papa', 'Passiflora edulis'];
+
+describe('fuzzyFilter', () => {
+  it('query vacío devuelve los items (hasta el límite)', () => {
+    expect(fuzzyFilter('', especies)).toEqual(especies);
+    expect(fuzzyFilter('   ', especies)).toEqual(especies);
+  });
+
+  it('encuentra por prefijo y lo prioriza', () => {
+    const r = fuzzyFilter('gulu', especies);
+    expect(r[0]).toBe('Gulupa');
+  });
+
+  it('tolera typos por subsecuencia ("gulpa" → "Gulupa")', () => {
+    const r = fuzzyFilter('gulpa', especies);
+    expect(r).toContain('Gulupa');
+  });
+
+  it('es insensible a acentos y mayúsculas', () => {
+    const r = fuzzyFilter('guanabana', especies);
+    expect(r).toContain('Guanábana');
+  });
+
+  it('excluye items sin match de todos los caracteres del query', () => {
+    const r = fuzzyFilter('zzz', especies);
+    expect(r).toHaveLength(0);
+  });
+
+  it('respeta el límite de resultados', () => {
+    const muchos = Array.from({ length: 50 }, (_, i) => `Planta ${i}`);
+    expect(fuzzyFilter('planta', muchos, (x) => x, 10)).toHaveLength(10);
+  });
+
+  it('usa el accessor para objetos', () => {
+    const items = [{ nombre: 'Gulupa' }, { nombre: 'Papa' }];
+    const r = fuzzyFilter('gul', items, (x) => x.nombre);
+    expect(r[0].nombre).toBe('Gulupa');
+  });
+});


### PR DESCRIPTION
## Summary
Batch de cobertura test-first de 4 utils puras (0 imports cada una):
- **fuzzySearch**: prefijo > contención > subsecuencia, tolerancia a acentos, límite, accessor
- **dateFormatter**: formatDate/formatTimestamp/formatRelativeTime/toISODate/toISODateTime + guards de fecha inválida
- **assetRelationships**: `parent.data` → `location.data` fallback JSON:API (array y objeto)
- **blobUrl**: sanitizer anti-XSS `js/xss-through-dom` (solo blob: same-origin)

## Test plan
- `npx vitest run` → 30/30 verde · `eslint --max-warnings=0` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)