### PR TITLE
feat(vision): offline photo + post-sync diagnosis queue (V-07 #228)

### DIFF
--- a/src/components/EvidenceCapture.jsx
+++ b/src/components/EvidenceCapture.jsx
@@ -4,6 +4,7 @@ import { optimizeImage, blobToDataUrl } from '../utils/imageProcessor';
 import { compressImage, IMAGE_TOO_LARGE_MESSAGE } from '../utils/imageCompress';
 import { mediaCache } from '../db/mediaCache';
 import { analyzeFoliage } from '../services/aiService';
+import { enqueuePhoto } from '../services/visionQueueService';
 import { proximityCheck } from '../utils/spatialAnalysis';
 import { wktToGeoJson } from '../utils/geo';
 import AIStreamPanel from './common/AIStreamPanel';
@@ -212,6 +213,23 @@ export const EvidenceCapture = ({
         }
       } else if (diagnosis) {
         console.info('[Evidence] Diagnóstico cacheado, omitiendo inferencia.');
+      } else if (!navigator.onLine) {
+        // V-07 #228: offline → encolar la foto en vez de perder la captura.
+        // visionQueueService corre el diagnóstico al volver la conexión
+        // (syncManager dispara flushVisionQueue en el evento 'online').
+        try {
+          await enqueuePhoto({
+            imageBlob: optimized,
+            kind: 'foliage',
+            meta: { speciesSlug, assetId },
+          });
+          console.info('[Evidence] Sin conexión — foto encolada para diagnóstico diferido.');
+          window.dispatchEvent(new CustomEvent('chagraToast', {
+            detail: { message: 'Sin conexión: la foto se diagnosticará al reconectar.' },
+          }));
+        } catch (qErr) {
+          console.warn('[Evidence] No se pudo encolar la foto offline:', qErr?.message || qErr);
+        }
       }
     } catch (err) {
       console.error('[EvidenceCapture] Error procesando imagen:', err);

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 15;
+export const DB_VERSION = 16;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -57,6 +57,7 @@ export const STORES = {
   LLM_TELEMETRY: 'llm_telemetry',
   RAG_TELEMETRY: 'rag_telemetry',
   FAILED_TX: 'failed_transactions',
+  VISION_QUEUE: 'vision_queue',
 };
 
 let dbInstance = null;
@@ -238,6 +239,21 @@ export const openDB = async () => {
           store.createIndex('created_at', 'created_at', { unique: false });
           store.createIndex('has_results', 'has_results', { unique: false });
           store.createIndex('error_kind', 'error_kind', { unique: false });
+        }
+      }
+
+      // v16: vision_queue (V-07 #228) — cola offline de fotos de visión.
+      // Cuando el operario captura una foto para diagnóstico foliar o ID de
+      // especie SIN conexión, el blob + metadata se encolan aquí en vez de
+      // perderse. Al volver la conexión, visionQueueService.flushVisionQueue()
+      // corre la inferencia y deja el resultado en el propio registro.
+      // Blobs grandes → IndexedDB (NO localStorage). keyPath autoIncrement.
+      if (event.oldVersion < 16) {
+        if (!db.objectStoreNames.contains(STORES.VISION_QUEUE)) {
+          const store = db.createObjectStore(STORES.VISION_QUEUE, { keyPath: 'id', autoIncrement: true });
+          store.createIndex('status', 'status', { unique: false });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+          store.createIndex('kind', 'kind', { unique: false });
         }
       }
     };

--- a/src/services/__tests__/visionQueueService.test.js
+++ b/src/services/__tests__/visionQueueService.test.js
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests de la cola offline de fotos de visión (V-07 #228).
+ *
+ * Cuando el usuario captura una foto para diagnóstico/ID de especie SIN
+ * conexión (navigator.onLine === false), la foto se encola en IndexedDB
+ * (store dedicado `vision_queue`) en vez de perderse. Al volver la conexión,
+ * `flushVisionQueue()` corre el diagnóstico de cada item encolado y deja el
+ * resultado disponible.
+ *
+ * Patrón: réplica de feedbackService.offline.test.js pero con IndexedDB
+ * (los blobs de imagen son grandes — NO localStorage) y mock de aiService
+ * (analyzeFoliage / recognizeSpeciesGrounded) para no pegar al modelo.
+ */
+
+// ─── Mock de dbCore: IndexedDB en memoria mínimo para el store vision_queue ──
+// Imita la superficie de IDBDatabase que visionQueueService usa: transaction →
+// objectStore → {add, getAll, put, delete, get}. autoIncrement simulado.
+function makeFakeDB() {
+  const data = new Map();
+  let seq = 0;
+  const makeReq = (resultFn) => {
+    const req = {};
+    queueMicrotask(() => {
+      try {
+        req.result = resultFn();
+        req.onsuccess?.({ target: req });
+      } catch (e) {
+        req.error = e;
+        req.onerror?.({ target: req });
+      }
+    });
+    return req;
+  };
+  return {
+    transaction() {
+      return {
+        objectStore() {
+          return {
+            add(record) {
+              return makeReq(() => {
+                const id = record.id != null ? record.id : ++seq;
+                data.set(id, { ...record, id });
+                return id;
+              });
+            },
+            put(record) {
+              return makeReq(() => {
+                data.set(record.id, { ...record });
+                return record.id;
+              });
+            },
+            get(id) {
+              return makeReq(() => data.get(id) || undefined);
+            },
+            delete(id) {
+              return makeReq(() => {
+                data.delete(id);
+                return undefined;
+              });
+            },
+            getAll() {
+              return makeReq(() => Array.from(data.values()));
+            },
+          };
+        },
+      };
+    },
+    __data: data,
+  };
+}
+
+let fakeDB;
+
+vi.mock('../../db/dbCore', () => ({
+  openDB: vi.fn(async () => fakeDB),
+  STORES: { VISION_QUEUE: 'vision_queue' },
+}));
+
+// Mock de aiService — las funciones de visión NO deben pegar al modelo en tests.
+const analyzeFoliage = vi.fn();
+const recognizeSpeciesGrounded = vi.fn();
+vi.mock('../aiService', () => ({
+  analyzeFoliage: (...a) => analyzeFoliage(...a),
+  recognizeSpeciesGrounded: (...a) => recognizeSpeciesGrounded(...a),
+}));
+
+import {
+  enqueuePhoto,
+  flushVisionQueue,
+  getQueuedPhotos,
+  clearVisionQueue,
+} from '../visionQueueService.js';
+
+function setOnline(value) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+const fakeBlob = () => new Blob(['x'], { type: 'image/jpeg' });
+
+beforeEach(() => {
+  fakeDB = makeFakeDB();
+  analyzeFoliage.mockReset();
+  recognizeSpeciesGrounded.mockReset();
+  setOnline(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setOnline(true);
+});
+
+describe('visionQueueService — enqueue', () => {
+  it('enqueuePhoto persiste y getQueuedPhotos lo lee', async () => {
+    const id = await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage', meta: { speciesSlug: 'cafe' } });
+    expect(id).toBeTruthy();
+    const q = await getQueuedPhotos();
+    expect(q).toHaveLength(1);
+    expect(q[0].kind).toBe('foliage');
+    expect(q[0].status).toBe('pending');
+    expect(q[0].imageBlob).toBeInstanceOf(Blob);
+    expect(q[0].meta.speciesSlug).toBe('cafe');
+    expect(q[0].createdAt).toBeTruthy();
+  });
+
+  it('rechaza un kind inválido', async () => {
+    await expect(
+      enqueuePhoto({ imageBlob: fakeBlob(), kind: 'invalido' })
+    ).rejects.toThrow();
+  });
+
+  it('rechaza si falta el imageBlob', async () => {
+    await expect(enqueuePhoto({ kind: 'foliage' })).rejects.toThrow();
+  });
+});
+
+describe('visionQueueService — flush con éxito', () => {
+  it('corre analyzeFoliage para items foliage y guarda el resultado', async () => {
+    analyzeFoliage.mockResolvedValue({ score: 80, issues: [], treatment_suggestion: '' });
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage', meta: { speciesSlug: 'cafe' } });
+
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(1);
+    expect(analyzeFoliage).toHaveBeenCalledTimes(1);
+    // Propaga meta (speciesSlug) a las opts del modelo
+    expect(analyzeFoliage.mock.calls[0][1]).toMatchObject({ speciesSlug: 'cafe' });
+
+    const q = await getQueuedPhotos();
+    expect(q).toHaveLength(1);
+    expect(q[0].status).toBe('done');
+    expect(q[0].result).toMatchObject({ score: 80 });
+  });
+
+  it('corre recognizeSpeciesGrounded para items species', async () => {
+    recognizeSpeciesGrounded.mockResolvedValue({ common_name_es: 'cafe', confidence: 0.9 });
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'species' });
+
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(1);
+    expect(recognizeSpeciesGrounded).toHaveBeenCalledTimes(1);
+    expect(analyzeFoliage).not.toHaveBeenCalled();
+
+    const q = await getQueuedPhotos();
+    expect(q[0].status).toBe('done');
+    expect(q[0].result).toMatchObject({ common_name_es: 'cafe' });
+  });
+
+  it('flushVisionQueue no hace nada con la cola vacía', async () => {
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(0);
+    expect(analyzeFoliage).not.toHaveBeenCalled();
+    expect(recognizeSpeciesGrounded).not.toHaveBeenCalled();
+  });
+
+  it('no reprocesa items ya en done', async () => {
+    analyzeFoliage.mockResolvedValue({ score: 50, issues: [] });
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage' });
+    await flushVisionQueue();
+    analyzeFoliage.mockClear();
+
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(0);
+    expect(analyzeFoliage).not.toHaveBeenCalled();
+  });
+});
+
+describe('visionQueueService — flush con fallo', () => {
+  it('un item que falla (throw) queda en cola con status error (no se pierde)', async () => {
+    analyzeFoliage.mockRejectedValue(new Error('modelo caido'));
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage' });
+
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(0); // 0 exitosos
+
+    const q = await getQueuedPhotos();
+    expect(q).toHaveLength(1); // sigue en cola
+    expect(q[0].status).toBe('error');
+    expect(q[0].imageBlob).toBeInstanceOf(Blob); // conserva la captura
+  });
+
+  it('un item con resultado null (modelo no parseable) queda en error para reintentar', async () => {
+    analyzeFoliage.mockResolvedValue(null);
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage' });
+
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(0);
+    const q = await getQueuedPhotos();
+    expect(q[0].status).toBe('error');
+  });
+
+  it('un item que falla NO impide procesar los demás', async () => {
+    analyzeFoliage
+      .mockRejectedValueOnce(new Error('falla 1'))
+      .mockResolvedValueOnce({ score: 90, issues: [] });
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage', meta: { tag: 'a' } });
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage', meta: { tag: 'b' } });
+
+    const processed = await flushVisionQueue();
+    expect(processed).toBe(1); // el segundo sí
+    expect(analyzeFoliage).toHaveBeenCalledTimes(2);
+
+    const q = await getQueuedPhotos();
+    const errored = q.filter((i) => i.status === 'error');
+    const done = q.filter((i) => i.status === 'done');
+    expect(errored).toHaveLength(1);
+    expect(done).toHaveLength(1);
+  });
+});
+
+describe('visionQueueService — orden', () => {
+  it('procesa en orden de captura (FIFO por createdAt)', async () => {
+    const order = [];
+    analyzeFoliage.mockImplementation(async (_blob, opts) => {
+      order.push(opts.__tag);
+      return { score: 1, issues: [] };
+    });
+    // Encolar con createdAt explícitos desordenados para forzar el sort.
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage', meta: { __tag: 'segundo', createdAt: 2000 } });
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage', meta: { __tag: 'primero', createdAt: 1000 } });
+
+    await flushVisionQueue();
+    expect(order).toEqual(['primero', 'segundo']);
+  });
+});
+
+describe('visionQueueService — offline encola sin llamar al modelo', () => {
+  it('offline: enqueuePhoto NO invoca aiService, solo persiste', async () => {
+    setOnline(false);
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage' });
+    expect(analyzeFoliage).not.toHaveBeenCalled();
+    expect(recognizeSpeciesGrounded).not.toHaveBeenCalled();
+    const q = await getQueuedPhotos();
+    expect(q).toHaveLength(1);
+    expect(q[0].status).toBe('pending');
+  });
+
+  it('clearVisionQueue vacía la cola', async () => {
+    await enqueuePhoto({ imageBlob: fakeBlob(), kind: 'foliage' });
+    expect(await getQueuedPhotos()).toHaveLength(1);
+    await clearVisionQueue();
+    expect(await getQueuedPhotos()).toHaveLength(0);
+  });
+});

--- a/src/services/syncManager.js
+++ b/src/services/syncManager.js
@@ -6,6 +6,7 @@ import { getCompletedTaskIds } from '../utils/taskCompletionParser';
 import { recordEvent } from './voiceTelemetryService';
 import { tryGeneratePlanFromSeeding } from './planGeneratorService';
 import { friendlyMessage } from '../utils/friendlyErrors';
+import { flushVisionQueue } from './visionQueueService';
 
 const STORE_NAME = 'pending_transactions';
 const TASKS_STORE_NAME = 'pending_tasks';
@@ -645,6 +646,11 @@ class SyncManager {
       this.isOnline = true;
       this.syncAll();
       this.notifyPendingVoiceRecordings();
+      // V-07 #228: al reconectar, correr el diagnóstico de las fotos de visión
+      // encoladas offline. Tolerante a fallos — no debe romper el resto del sync.
+      flushVisionQueue().catch((e) =>
+        console.debug('[sync] flushVisionQueue error:', e?.message || e)
+      );
       recordEvent({
         event_type: 'connectivity_state',
         flujo: 'sync_manager',

--- a/src/services/visionQueueService.js
+++ b/src/services/visionQueueService.js
@@ -1,0 +1,181 @@
+/**
+ * visionQueueService.js — Cola offline de fotos de visión (V-07 #228).
+ *
+ * Cuando el operario captura una foto para diagnóstico foliar o ID de especie
+ * SIN conexión (navigator.onLine === false), la foto se encola en IndexedDB
+ * (store dedicado `vision_queue`) en vez de perderse. Al volver la conexión,
+ * `flushVisionQueue()` corre el diagnóstico de cada item encolado y deja el
+ * resultado disponible en el propio registro (status: 'done', result: {...}).
+ *
+ * Patrón: réplica de `feedbackService.js` (queueFeedbackOffline /
+ * flushFeedbackQueue / getQueuedFeedback) pero con IndexedDB en vez de
+ * localStorage — los blobs de imagen son grandes y no caben en localStorage.
+ * Reutiliza la infra `dbCore` (openDB / STORES) ya usada por photoService.
+ *
+ * Schema del registro `vision_queue`:
+ * {
+ *   id: number,            // autoIncrement (IndexedDB)
+ *   imageBlob: Blob,       // la captura JPEG comprimida (NO se pierde)
+ *   kind: 'foliage'|'species',
+ *   meta: object,          // { speciesSlug?, assetId?, ... } passthrough a las opts del modelo
+ *   createdAt: number,     // Unix ms — orden FIFO de procesamiento
+ *   status: 'pending'|'done'|'error',
+ *   result: object|null,   // resultado del modelo cuando status='done'
+ *   error: string|null,    // mensaje cuando status='error'
+ *   processedAt: number|null,
+ * }
+ *
+ * Reglas operativas (tolerante a fallos como feedbackService):
+ * - Offline-first: enqueuePhoto solo persiste, NUNCA llama al modelo.
+ * - flushVisionQueue procesa solo items 'pending' o 'error' (reintenta fallos).
+ * - Un item que falla queda con status='error' conservando el blob → se
+ *   reintenta en el próximo flush. Un fallo no aborta el procesamiento del resto.
+ * - Falla de persistencia → console.debug, no throw (excepto validación de input).
+ */
+
+import { openDB, STORES } from '../db/dbCore';
+import { analyzeFoliage, recognizeSpeciesGrounded } from './aiService';
+
+const VALID_KINDS = ['foliage', 'species'];
+
+/** Ejecuta una IDBRequest como Promise. */
+function reqAsPromise(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Encola una foto para diagnóstico diferido. NO llama al modelo — solo persiste
+ * el blob + metadata en IndexedDB. El flush posterior (al volver la conexión)
+ * corre la inferencia.
+ *
+ * @param {Object} args
+ * @param {Blob}   args.imageBlob - captura JPEG/WebP comprimida (obligatorio)
+ * @param {'foliage'|'species'} args.kind - tipo de análisis a correr al volver online
+ * @param {Object} [args.meta] - metadata passthrough a las opts del modelo
+ *                               (speciesSlug, assetId, createdAt opcional…)
+ * @returns {Promise<number>} id del registro encolado
+ */
+export async function enqueuePhoto({ imageBlob, kind, meta = {} } = {}) {
+  if (!imageBlob || typeof imageBlob !== 'object') {
+    throw new Error('[visionQueue] enqueuePhoto requiere imageBlob');
+  }
+  if (!VALID_KINDS.includes(kind)) {
+    throw new Error(`[visionQueue] kind inválido: ${kind} (debe ser 'foliage' | 'species')`);
+  }
+  const db = await openDB();
+  const record = {
+    imageBlob,
+    kind,
+    meta: meta || {},
+    // createdAt explícito en meta permite tests deterministas del orden FIFO.
+    createdAt: typeof meta?.createdAt === 'number' ? meta.createdAt : Date.now(),
+    status: 'pending',
+    result: null,
+    error: null,
+    processedAt: null,
+  };
+  const tx = db.transaction(STORES.VISION_QUEUE, 'readwrite');
+  const store = tx.objectStore(STORES.VISION_QUEUE);
+  return reqAsPromise(store.add(record));
+}
+
+/**
+ * Lee todos los items encolados (cualquier status). Tolerante a fallos:
+ * devuelve [] si la lectura falla.
+ * @returns {Promise<Array>}
+ */
+export async function getQueuedPhotos() {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.VISION_QUEUE, 'readonly');
+    const store = tx.objectStore(STORES.VISION_QUEUE);
+    const all = await reqAsPromise(store.getAll());
+    return Array.isArray(all) ? all : [];
+  } catch (e) {
+    console.debug('[visionQueue] getQueuedPhotos error:', e);
+    return [];
+  }
+}
+
+/** Vacía la cola completa (uso interno + tests). */
+export async function clearVisionQueue() {
+  try {
+    const items = await getQueuedPhotos();
+    if (items.length === 0) return;
+    const db = await openDB();
+    const tx = db.transaction(STORES.VISION_QUEUE, 'readwrite');
+    const store = tx.objectStore(STORES.VISION_QUEUE);
+    await Promise.all(items.map((i) => reqAsPromise(store.delete(i.id))));
+  } catch (e) {
+    console.debug('[visionQueue] clearVisionQueue error:', e);
+  }
+}
+
+/** Corre la inferencia de visión correspondiente al kind del item. */
+async function runInference(item) {
+  const opts = { ...(item.meta || {}) };
+  if (item.kind === 'species') {
+    return recognizeSpeciesGrounded(item.imageBlob, opts);
+  }
+  // default: foliage
+  return analyzeFoliage(item.imageBlob, opts);
+}
+
+/** Persiste el resultado/estado actualizado de un item en IndexedDB. */
+async function persistItem(item) {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.VISION_QUEUE, 'readwrite');
+    const store = tx.objectStore(STORES.VISION_QUEUE);
+    await reqAsPromise(store.put(item));
+  } catch (e) {
+    console.debug('[visionQueue] persistItem error:', e);
+  }
+}
+
+/**
+ * Procesa la cola: corre el diagnóstico de cada item 'pending'/'error' en orden
+ * FIFO (createdAt) y guarda el resultado. Conserva en cola (status='error') lo
+ * que falle, para reintentar en el próximo flush. Un fallo individual no aborta
+ * el resto.
+ *
+ * @returns {Promise<number>} cuántos items se procesaron con éxito (status='done')
+ */
+export async function flushVisionQueue() {
+  const all = await getQueuedPhotos();
+  const pending = all
+    .filter((i) => i.status === 'pending' || i.status === 'error')
+    .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+  if (pending.length === 0) return 0;
+
+  let processed = 0;
+  for (const item of pending) {
+    try {
+      const result = await runInference(item);
+      if (result == null) {
+        // El modelo no devolvió nada parseable — tratar como fallo recuperable.
+        item.status = 'error';
+        item.error = 'modelo no devolvió resultado parseable';
+        item.processedAt = Date.now();
+        await persistItem(item);
+        continue;
+      }
+      item.status = 'done';
+      item.result = result;
+      item.error = null;
+      item.processedAt = Date.now();
+      await persistItem(item);
+      processed++;
+    } catch (err) {
+      item.status = 'error';
+      item.error = err?.message || String(err);
+      item.processedAt = Date.now();
+      await persistItem(item);
+      console.debug('[visionQueue] item falló, sigue en cola:', item.id, item.error);
+    }
+  }
+  return processed;
+}


### PR DESCRIPTION
## V-07 (#228) — Offline photo + post-sync diagnosis queue

Cuando el usuario toma una foto para diagnóstico/ID de especie **sin conexión** (`navigator.onLine === false`), la captura ya no se pierde: se encola localmente y, al volver la conexión, corre el diagnóstico automáticamente dejando el resultado disponible.

### Qué hace
- **`src/services/visionQueueService.js`** (nuevo): cola offline de fotos de visión.
  - `enqueuePhoto({ imageBlob, kind, meta })` — persiste el blob + metadata en IndexedDB. NO llama al modelo.
  - `flushVisionQueue()` — corre el diagnóstico (`analyzeFoliage` para `foliage`, `recognizeSpeciesGrounded` para `species`) de cada item pendiente en orden FIFO (`createdAt`), guarda `result`/`error`, devuelve cuántos procesó con éxito.
  - `getQueuedPhotos()` — lee la cola.
  - Tolerante a fallos como `feedbackService`: un item que falla queda `status='error'` conservando el blob (se reintenta en el próximo flush); un fallo individual no aborta el resto.
- **`src/db/dbCore.js`**: schema **v16** con store dedicado `vision_queue` (`id` autoIncrement; indexes `status`, `createdAt`, `kind`). Blobs grandes → IndexedDB, **no** localStorage.
- **`src/components/EvidenceCapture.jsx`**: en el flujo de captura, si `!navigator.onLine` → encola la foto (kind `foliage`, propagando `speciesSlug`/`assetId`) en vez de saltar el diagnóstico; toast informativo.
- **`src/services/syncManager.js`**: el listener `window 'online'` (mecanismo de reconexión ya existente del repo) dispara `flushVisionQueue()` junto al resto del sync.

### Patrón
Réplica del patrón offline de `feedbackService.js` (`queueXOffline`/`flushXQueue`/`getQueuedX`) pero con IndexedDB reutilizando la infra `dbCore` ya usada por `photoService`.

### Tests (TDD, vitest) — `src/services/__tests__/visionQueueService.test.js`
13 casos: enqueue + lectura, validación de input, flush con éxito (foliage + species, propagación de meta), cola vacía, no reprocesa `done`, item que falla queda en cola (`error`, blob conservado), `null` del modelo → `error`, un fallo no bloquea los demás, orden FIFO, y que **offline encola sin llamar al modelo**.

**Resultado:** 13 passed (suite nueva). Suite completa `src/services` + `src/db` + `src/store`: **1792 passed, 1 skipped**. ESLint `--max-warnings=0` limpio en todos los archivos tocados. No se corrió `npm run build` (RAM del host) — validado solo con vitest según instrucción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)