### PR TITLE
feat(vision): cache de respuestas de visión por hash de imagen (V-11 #231)

### DIFF
--- a/src/services/__tests__/aiService.grounded.test.js
+++ b/src/services/__tests__/aiService.grounded.test.js
@@ -31,6 +31,7 @@ vi.mock('../ragRetriever', () => ({
 }));
 
 import { recognizeSpeciesGrounded } from '../aiService.js';
+import { clearCache } from '../visionCacheService.js';
 import * as sidecarClient from '../sidecarClient.js';
 import * as ollamaStream from '../ollamaStream.js';
 
@@ -41,6 +42,9 @@ function mockVisionResponse(json) {
 describe('recognizeSpeciesGrounded', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // V-11 (#231): recognizeSpecies cachea por hash; los tests reusan los
+    // mismos bytes de blob → limpiar para que cada caso pegue al mock.
+    clearCache();
     sidecarClient.isSidecarEnabled.mockReturnValue(true);
     // Browser online por default.
     Object.defineProperty(globalThis, 'navigator', {

--- a/src/services/__tests__/aiService.test.js
+++ b/src/services/__tests__/aiService.test.js
@@ -30,6 +30,10 @@ if (typeof globalThis.FileReader === 'undefined') {
 }
 
 const { analyzeFoliage, __TEST__, __retrieveRagContextForFoliage } = await import('../aiService');
+// V-11 (#231): analyzeFoliage ahora cachea por hash de contenido. Como estos
+// tests reusan los MISMOS bytes (`makeBlob`), hay que limpiar el cache entre
+// casos o el 2do análisis serviría el resultado del 1ro en vez del mock.
+const { clearCache } = await import('../visionCacheService');
 
 const makeBlob = () => new Blob(['fake image bytes'], { type: 'image/webp' });
 
@@ -42,6 +46,7 @@ const happyDiagnosisJson = JSON.stringify({
 beforeEach(() => {
   streamOllamaMock.mockReset();
   retrieveMock.mockReset();
+  clearCache();
 });
 
 describe('aiService — buildRagQuery (helper)', () => {

--- a/src/services/__tests__/aiService.visionCache.test.js
+++ b/src/services/__tests__/aiService.visionCache.test.js
@@ -1,0 +1,134 @@
+/**
+ * aiService.visionCache.test.js — integración liviana V-11 (#231).
+ *
+ * Verifica el wiring del cache de visión por hash sobre `analyzeFoliage` y
+ * `recognizeSpecies`: la 2da llamada con la MISMA imagen (mismos bytes) debe
+ * servirse del cache SIN re-invocar `streamOllama` (el modelo). Resultados
+ * null (error del modelo) NO se cachean → la siguiente llamada sí reintenta.
+ *
+ * Patrón de mocks copiado de aiService.grounded.test.js: se mockea
+ * `ollamaStream` y `ragRetriever` para no pegar a Ollama ni al corpus.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../ollamaStream', () => ({
+  streamOllama: vi.fn(),
+}));
+vi.mock('../ragRetriever', () => ({
+  retrieve: vi.fn().mockResolvedValue([]),
+}));
+// sidecar deshabilitado: recognizeSpecies (base) no lo toca, pero importarlo
+// limpio evita side-effects.
+vi.mock('../sidecarClient.js', () => ({
+  isSidecarEnabled: vi.fn(() => false),
+  callTool: vi.fn(),
+  judgeVision: vi.fn(),
+  planNlu: vi.fn(),
+}));
+
+import { analyzeFoliage, recognizeSpecies } from '../aiService.js';
+import { clearCache } from '../visionCacheService.js';
+import * as ollamaStream from '../ollamaStream.js';
+
+describe('aiService — cache de visión por hash (V-11)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCache();
+  });
+
+  describe('analyzeFoliage', () => {
+    it('la 2da llamada con la misma imagen NO re-invoca el modelo (cache hit)', async () => {
+      ollamaStream.streamOllama.mockResolvedValue(
+        JSON.stringify({ score: 80, issues: ['mancha'], treatment: 'caldo bordelés' }),
+      );
+      const blob = new Blob(['bytes-de-la-foto'], { type: 'image/jpeg' });
+
+      const first = await analyzeFoliage(blob);
+      expect(first).toBeTruthy();
+      expect(first.score).toBe(80);
+      expect(ollamaStream.streamOllama).toHaveBeenCalledTimes(1);
+
+      // 2da llamada, MISMOS bytes → cache hit, sin nuevo fetch al modelo.
+      const second = await analyzeFoliage(new Blob(['bytes-de-la-foto'], { type: 'image/jpeg' }));
+      expect(ollamaStream.streamOllama).toHaveBeenCalledTimes(1);
+      expect(second.score).toBe(80);
+      expect(second._cached).toBe(true);
+    });
+
+    it('imagen distinta SÍ re-invoca el modelo (cache miss)', async () => {
+      ollamaStream.streamOllama.mockResolvedValue(
+        JSON.stringify({ score: 70, issues: [], treatment: '' }),
+      );
+      await analyzeFoliage(new Blob(['foto-1'], { type: 'image/jpeg' }));
+      await analyzeFoliage(new Blob(['foto-2-distinta'], { type: 'image/jpeg' }));
+      expect(ollamaStream.streamOllama).toHaveBeenCalledTimes(2);
+    });
+
+    it('NO cachea null: si el modelo falla, la siguiente llamada reintenta', async () => {
+      // Primer intento: respuesta no parseable → analyzeFoliage devuelve null.
+      ollamaStream.streamOllama.mockResolvedValueOnce('no-es-json-valido <<<');
+      const blob = new Blob(['foto-error'], { type: 'image/jpeg' });
+      const first = await analyzeFoliage(blob);
+      expect(first).toBeNull();
+
+      // Segundo intento mismos bytes: como null NO se cacheó, debe re-invocar.
+      ollamaStream.streamOllama.mockResolvedValueOnce(
+        JSON.stringify({ score: 90, issues: [], treatment: 'ok' }),
+      );
+      const second = await analyzeFoliage(new Blob(['foto-error'], { type: 'image/jpeg' }));
+      expect(ollamaStream.streamOllama).toHaveBeenCalledTimes(2);
+      expect(second.score).toBe(90);
+    });
+
+    it('el resultado cacheado preserva el shape (sin _cached en la 1ra llamada)', async () => {
+      ollamaStream.streamOllama.mockResolvedValue(
+        JSON.stringify({ score: 60, issues: ['x'], treatment: 'y' }),
+      );
+      const first = await analyzeFoliage(new Blob(['z'], { type: 'image/jpeg' }));
+      expect(first._cached).toBeUndefined();
+    });
+  });
+
+  describe('recognizeSpecies', () => {
+    it('la 2da llamada con la misma imagen NO re-invoca el modelo (cache hit)', async () => {
+      ollamaStream.streamOllama.mockResolvedValue(
+        JSON.stringify({
+          common_name_es: 'café',
+          scientific_name: 'Coffea arabica',
+          confidence: 0.9,
+          alternatives: [],
+        }),
+      );
+      const blob = new Blob(['foto-cafe'], { type: 'image/jpeg' });
+
+      const first = await recognizeSpecies(blob);
+      expect(first).toBeTruthy();
+      expect(first.scientific_name).toBe('Coffea arabica');
+      const callsAfterFirst = ollamaStream.streamOllama.mock.calls.length;
+      expect(callsAfterFirst).toBeGreaterThanOrEqual(1);
+
+      const second = await recognizeSpecies(new Blob(['foto-cafe'], { type: 'image/jpeg' }));
+      // Sin nuevas llamadas al modelo.
+      expect(ollamaStream.streamOllama).toHaveBeenCalledTimes(callsAfterFirst);
+      expect(second.scientific_name).toBe('Coffea arabica');
+      expect(second._cached).toBe(true);
+    });
+
+    it('NO cachea null cuando todos los fallbacks fallan', async () => {
+      // Los 3 modelos devuelven basura no parseable → recognizeSpecies = null.
+      ollamaStream.streamOllama.mockResolvedValue('basura <<<');
+      const blob = new Blob(['foto-mala'], { type: 'image/jpeg' });
+      const first = await recognizeSpecies(blob);
+      expect(first).toBeNull();
+      const callsAfterFirst = ollamaStream.streamOllama.mock.calls.length;
+
+      // Segundo intento: null no se cacheó → re-invoca.
+      ollamaStream.streamOllama.mockResolvedValue(
+        JSON.stringify({ common_name_es: 'mora', scientific_name: 'Rubus glaucus', confidence: 0.8, alternatives: [] }),
+      );
+      const second = await recognizeSpecies(new Blob(['foto-mala'], { type: 'image/jpeg' }));
+      expect(ollamaStream.streamOllama.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+      expect(second.scientific_name).toBe('Rubus glaucus');
+    });
+  });
+});

--- a/src/services/__tests__/visionCacheService.test.js
+++ b/src/services/__tests__/visionCacheService.test.js
@@ -1,0 +1,156 @@
+/**
+ * visionCacheService.test.js — TDD para V-11 (#231): cache de respuestas de
+ * visión por hash de imagen.
+ *
+ * Cubre el contrato público del módulo:
+ *   - hashImage: determinístico (mismo blob → mismo hash, distinto → distinto).
+ *   - getCached / setCached: miss → set → hit.
+ *   - NO cachear null/undefined (resultados de error del modelo).
+ *   - Eviction LRU cuando se supera MAX_ENTRIES.
+ *   - Expiración TTL.
+ *   - clearCache helper.
+ *
+ * Aislamiento: usa `crypto.subtle` (presente en jsdom) y un store en memoria.
+ * No requiere IndexedDB ni red. Cada test parte de cache limpio.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  hashImage,
+  getCached,
+  setCached,
+  clearCache,
+  __TEST__,
+} from '../visionCacheService.js';
+
+const blobOf = (bytes, type = 'image/jpeg') => new Blob([bytes], { type });
+
+describe('visionCacheService', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  describe('hashImage', () => {
+    it('es determinístico: mismos bytes → mismo hash', async () => {
+      const a = blobOf('contenido-foto-A');
+      const b = blobOf('contenido-foto-A');
+      const ha = await hashImage(a);
+      const hb = await hashImage(b);
+      expect(ha).toBe(hb);
+    });
+
+    it('distintos bytes → distinto hash', async () => {
+      const ha = await hashImage(blobOf('foto-A'));
+      const hb = await hashImage(blobOf('foto-B'));
+      expect(ha).not.toBe(hb);
+    });
+
+    it('devuelve un hex SHA-256 de 64 chars', async () => {
+      const h = await hashImage(blobOf('cualquier-cosa'));
+      expect(h).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('hashea solo por bytes, no por el mime type del Blob', async () => {
+      // El contenido es lo que importa; mismo array de bytes con distinto
+      // type debe colisionar (el modelo ve los mismos píxeles decodificados).
+      const ha = await hashImage(blobOf('pixels', 'image/jpeg'));
+      const hb = await hashImage(blobOf('pixels', 'image/webp'));
+      expect(ha).toBe(hb);
+    });
+  });
+
+  describe('getCached / setCached', () => {
+    it('miss → null antes de setear', async () => {
+      const hit = await getCached('hash-inexistente');
+      expect(hit).toBeNull();
+    });
+
+    it('miss → set → hit devuelve el mismo valor', async () => {
+      const hash = 'abc123';
+      const result = { score: 85, issues: ['mancha foliar'], treatment_suggestion: 'caldo bordelés' };
+      expect(await getCached(hash)).toBeNull();
+      await setCached(hash, result);
+      const hit = await getCached(hash);
+      expect(hit).toEqual(result);
+    });
+
+    it('NO cachea null', async () => {
+      await setCached('hash-null', null);
+      expect(await getCached('hash-null')).toBeNull();
+    });
+
+    it('NO cachea undefined', async () => {
+      await setCached('hash-undef', undefined);
+      expect(await getCached('hash-undef')).toBeNull();
+    });
+
+    it('devuelve una copia (no la misma referencia) para evitar mutación accidental', async () => {
+      const result = { score: 50, issues: [] };
+      await setCached('h', result);
+      const hit = await getCached('h');
+      expect(hit).toEqual(result);
+      expect(hit).not.toBe(result);
+    });
+  });
+
+  describe('eviction LRU', () => {
+    it('expulsa la entrada menos recientemente usada al superar MAX_ENTRIES', async () => {
+      const max = __TEST__.MAX_ENTRIES;
+      // Llenar el cache exactamente al límite.
+      for (let i = 0; i < max; i += 1) {
+        await setCached(`k${i}`, { score: i });
+      }
+      // k0 es la más vieja. Insertar una nueva entrada → debe expulsar k0.
+      await setCached('k-new', { score: 999 });
+      expect(await getCached('k0')).toBeNull();
+      expect(await getCached('k-new')).toEqual({ score: 999 });
+      // k1 sigue presente.
+      expect(await getCached('k1')).toEqual({ score: 1 });
+    });
+
+    it('un get refresca el recency (LRU real, no FIFO)', async () => {
+      const max = __TEST__.MAX_ENTRIES;
+      for (let i = 0; i < max; i += 1) {
+        await setCached(`k${i}`, { score: i });
+      }
+      // Tocar k0 → deja de ser el LRU. Ahora k1 es el LRU.
+      await getCached('k0');
+      await setCached('k-new', { score: 999 });
+      expect(await getCached('k0')).toEqual({ score: 0 }); // sobrevivió
+      expect(await getCached('k1')).toBeNull(); // expulsado
+    });
+
+    it('nunca supera MAX_ENTRIES entradas', async () => {
+      const max = __TEST__.MAX_ENTRIES;
+      for (let i = 0; i < max + 25; i += 1) {
+        await setCached(`k${i}`, { score: i });
+      }
+      expect(__TEST__.size()).toBeLessThanOrEqual(max);
+    });
+  });
+
+  describe('expiración TTL', () => {
+    it('una entrada más vieja que TTL_MS se considera miss', async () => {
+      const hash = 'expira';
+      await setCached(hash, { score: 1 });
+      // Forzar timestamp viejo manipulando el reloj interno via __TEST__.
+      __TEST__.expireEntry(hash);
+      expect(await getCached(hash)).toBeNull();
+    });
+
+    it('una entrada dentro de TTL sigue siendo hit', async () => {
+      await setCached('fresca', { score: 1 });
+      expect(await getCached('fresca')).toEqual({ score: 1 });
+    });
+  });
+
+  describe('clearCache', () => {
+    it('vacía todo el store', async () => {
+      await setCached('a', { score: 1 });
+      await setCached('b', { score: 2 });
+      clearCache();
+      expect(await getCached('a')).toBeNull();
+      expect(await getCached('b')).toBeNull();
+      expect(__TEST__.size()).toBe(0);
+    });
+  });
+});

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -22,6 +22,7 @@ import { streamOllama } from './ollamaStream';
 import { retrieve } from './ragRetriever';
 import { callTool, isSidecarEnabled } from './sidecarClient';
 import { parseJsonTolerant } from '../utils/parseJsonTolerant';
+import { hashImage, getCached, setCached } from './visionCacheService';
 
 // Ruta relativa: Nginx proxea /api/ollama/ → http://localhost:11434/
 // Ruta final: /api/ollama/api/generate → http://localhost:11434/api/generate
@@ -191,7 +192,7 @@ export const __retrieveRagContextForFoliage = async (speciesSlug) => {
  * // result => { score: 85, issues: ["mancha foliar"], treatment_suggestion: "aplicar caldo bordelés (Fuente 1)" }
  */
 // eslint-disable-next-line no-unused-vars
-export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, assetId } = {}) => {
+const analyzeFoliageUncached = async (imageBlob, { onToken, signal, speciesSlug, assetId } = {}) => {
   try {
     const base64 = await blobToBase64(imageBlob);
 
@@ -231,6 +232,40 @@ export const analyzeFoliage = async (imageBlob, { onToken, signal, speciesSlug, 
     console.warn('[aiService] Diagnóstico no disponible:', err.message);
     return null;
   }
+};
+
+/**
+ * V-11 (#231): wrapper de cache por hash de contenido para `analyzeFoliage`.
+ *
+ * Re-analizar la MISMA foto (mismos bytes) sirve el resultado cacheado al
+ * instante en vez de re-llamar al modelo multimodal (varios segundos en GPU
+ * Maxwell). El hit trae `_cached: true` para telemetría/debug. Resultados
+ * null/error NUNCA se cachean (la siguiente llamada reintenta). La firma
+ * pública es idéntica a la implementación original — no rompe callers.
+ *
+ * El hashing es best-effort: si `hashImage` falla (ej. blob no leíble) se
+ * degrada a la inferencia directa sin cache. El streaming `onToken` solo se
+ * emite en miss (cache hit es instantáneo, no hay tokens que emitir).
+ */
+export const analyzeFoliage = async (imageBlob, options = {}) => {
+  let hash = null;
+  try {
+    hash = await hashImage(imageBlob);
+    const cached = await getCached(hash);
+    if (cached) return { ...cached, _cached: true };
+  } catch (err) {
+    console.debug('[aiService.analyzeFoliage] cache lookup skipped:', err?.message);
+  }
+
+  const result = await analyzeFoliageUncached(imageBlob, options);
+  if (result && hash) {
+    try {
+      await setCached(hash, result);
+    } catch (err) {
+      console.debug('[aiService.analyzeFoliage] cache write skipped:', err?.message);
+    }
+  }
+  return result;
 };
 
 /**
@@ -532,7 +567,7 @@ export const recognizeSpeciesGrounded = async (imageBlob, options = {}) => {
   );
 };
 
-export const recognizeSpecies = async (imageBlob, { onToken, signal, _telemetryState } = {}) => {
+const recognizeSpeciesUncached = async (imageBlob, { onToken, signal, _telemetryState } = {}) => {
   let base64;
   try {
     base64 = await blobToBase64(imageBlob);
@@ -569,6 +604,41 @@ export const recognizeSpecies = async (imageBlob, { onToken, signal, _telemetryS
     console.warn('[aiService] Species recognition no disponible (3 fallbacks fallaron):', err.message);
     return null;
   }
+};
+
+/**
+ * V-11 (#231): wrapper de cache por hash de contenido para `recognizeSpecies`.
+ *
+ * Misma política que `analyzeFoliage`: re-identificar la MISMA foto sirve el
+ * resultado cacheado (con `_cached: true`) sin re-llamar al modelo de visión
+ * ni a sus fallbacks. Resultados null NUNCA se cachean.
+ *
+ * Nota grounding/telemetría: `recognizeSpeciesGrounded` llama a esta función
+ * pasando `_telemetryState`. En un cache hit no hay inferencia nueva → no se
+ * graba un evento de telemetría LLM nuevo (correcto: no hubo call al modelo).
+ * El objeto cacheado preserva `scientific_name`, `confidence`, `alternatives`,
+ * por lo que el wrapper grounded sigue validando contra catálogo normalmente.
+ * La firma pública es idéntica — no rompe callers.
+ */
+export const recognizeSpecies = async (imageBlob, options = {}) => {
+  let hash = null;
+  try {
+    hash = await hashImage(imageBlob);
+    const cached = await getCached(hash);
+    if (cached) return { ...cached, _cached: true };
+  } catch (err) {
+    console.debug('[aiService.recognizeSpecies] cache lookup skipped:', err?.message);
+  }
+
+  const result = await recognizeSpeciesUncached(imageBlob, options);
+  if (result && hash) {
+    try {
+      await setCached(hash, result);
+    } catch (err) {
+      console.debug('[aiService.recognizeSpecies] cache write skipped:', err?.message);
+    }
+  }
+  return result;
 };
 
 export default analyzeFoliage;

--- a/src/services/visionCacheService.js
+++ b/src/services/visionCacheService.js
@@ -1,0 +1,200 @@
+/**
+ * visionCacheService.js — Cache de respuestas de visión por hash de contenido
+ * (V-11 #231).
+ *
+ * Las inferencias multimodales (`analyzeFoliage`, `recognizeSpecies` en
+ * `aiService.js`) cuestan varios segundos en GPU Maxwell. Cuando el usuario
+ * re-analiza la MISMA foto (mismos bytes), no tiene sentido re-llamar al
+ * modelo: este módulo cachea el resultado keyed por SHA-256 del contenido del
+ * Blob y lo devuelve al instante.
+ *
+ * --- Decisión de almacenamiento (justificada) -------------------------------
+ * Se usa un LRU **en memoria** (Map con orden de inserción nativo) en vez de
+ * IndexedDB. Razones:
+ *   1) Conflict-avoidance: persistir en IndexedDB exigiría bumpear
+ *      `DB_VERSION` en `db/dbCore.js` (schema compartido, alto riesgo de
+ *      conflicto con otras PRs en vuelo) y añadir un objectStore + migración.
+ *   2) Entorno de test: jsdom NO implementa IndexedDB y `fake-indexeddb` no
+ *      está instalado; los unit tests de `src/services/__tests__/*` no tocan
+ *      IDB real (solo los E2E Playwright lo hacen en browser real). Un store en
+ *      memoria es testeable sin nuevas dependencias.
+ *   3) Suficiencia: el beneficio principal es ahorrar la re-inferencia DENTRO
+ *      de una sesión (el usuario re-analizando la foto que acaba de tomar). Un
+ *      cache de sesión cubre ese caso de uso.
+ *
+ * Persistencia liviana best-effort: además del Map en memoria se intenta
+ * espejar el cache a `localStorage` (que jsdom SÍ soporta), de modo que un
+ * reload de la PWA conserve los hits recientes. Es totalmente opcional: si
+ * `localStorage` no está disponible o lanza (quota, modo privado), el cache
+ * sigue funcionando solo en memoria sin romper nada.
+ *
+ * --- Política de retención --------------------------------------------------
+ *   - LRU de `MAX_ENTRIES` (128) entradas. Al insertar la #129 se expulsa la
+ *     menos recientemente usada. Un `getCached` exitoso refresca el recency.
+ *   - TTL de `TTL_MS` (24h). Una entrada más vieja que el TTL se trata como
+ *     miss y se purga en el momento del acceso (lazy expiration).
+ *   - NUNCA se cachean resultados `null`/`undefined` (respuestas de error del
+ *     modelo): se reintenta en la siguiente llamada.
+ *
+ * Privacy: la clave es el hash del contenido (no reversible a la imagen) y el
+ * valor es solo el resultado estructurado del diagnóstico — no se persiste la
+ * imagen ni el base64.
+ */
+
+// Máximo de entradas vivas en el LRU. 128 × (~1 KB por resultado JSON) ≈ 128 KB
+// peak, despreciable y suficiente para una sesión de campo.
+const MAX_ENTRIES = 128;
+
+// Time-to-live de cada entrada. 24h: una foto re-analizada al día siguiente
+// puede haber cambiado de contexto (modelo actualizado, etc.); refrescar.
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+// Prefijo de las claves en localStorage para el mirror de persistencia.
+const LS_KEY = 'chagra:visionCache:v1';
+
+// Store en memoria. `Map` preserva orden de inserción → el primer key es el
+// candidato a expulsión LRU. Cada valor: { value, ts }.
+const store = new Map();
+
+/**
+ * Convierte un ArrayBuffer a string hex.
+ */
+const bufToHex = (buffer) => {
+  const bytes = new Uint8Array(buffer);
+  let hex = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+};
+
+/**
+ * Calcula el SHA-256 hex del contenido binario de un Blob. Determinístico:
+ * mismos bytes → mismo hash. El mime type del Blob NO afecta el hash (solo
+ * cuentan los bytes, que es lo que ve el modelo tras decodificar).
+ *
+ * @param {Blob} blob - imagen (WebP/JPEG) a hashear.
+ * @returns {Promise<string>} hash hex de 64 chars.
+ */
+export const hashImage = async (blob) => {
+  const buffer = await blob.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return bufToHex(digest);
+};
+
+/**
+ * Mirror best-effort del store a localStorage. Silencioso ante cualquier fallo
+ * (quota, modo privado, SSR sin window). Persistir es un nice-to-have; el
+ * cache en memoria es la fuente de verdad.
+ */
+const persist = () => {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const obj = {};
+    for (const [k, v] of store.entries()) obj[k] = v;
+    localStorage.setItem(LS_KEY, JSON.stringify(obj));
+  } catch (_) {
+    // best-effort: ignorar.
+  }
+};
+
+/**
+ * Hidrata el store en memoria desde localStorage al cargar el módulo. Descarta
+ * entradas expiradas y respeta MAX_ENTRIES. Best-effort y silencioso.
+ */
+const hydrate = () => {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return;
+    const obj = JSON.parse(raw);
+    const now = Date.now();
+    const entries = Object.entries(obj)
+      .filter(([, v]) => v && typeof v.ts === 'number' && now - v.ts < TTL_MS)
+      .slice(-MAX_ENTRIES);
+    for (const [k, v] of entries) store.set(k, v);
+  } catch (_) {
+    // best-effort: ignorar.
+  }
+};
+
+hydrate();
+
+/**
+ * Devuelve un clon defensivo (structured) del valor cacheado para que el caller
+ * no pueda mutar el objeto guardado. JSON round-trip basta: los resultados de
+ * visión son JSON-safe (score/issues/strings).
+ */
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+/**
+ * Busca un resultado cacheado por hash. Lazy expiration: si la entrada superó
+ * el TTL se purga y se trata como miss. Un hit refresca el recency LRU
+ * (re-inserción al final del Map).
+ *
+ * @param {string} hash - hash de `hashImage`.
+ * @returns {Promise<Object|null>} copia del resultado, o null si miss/expirado.
+ */
+export const getCached = async (hash) => {
+  const entry = store.get(hash);
+  if (!entry) return null;
+  if (Date.now() - entry.ts >= TTL_MS) {
+    store.delete(hash);
+    persist();
+    return null;
+  }
+  // Refrescar recency: re-insertar al final del orden de iteración.
+  store.delete(hash);
+  store.set(hash, entry);
+  return clone(entry.value);
+};
+
+/**
+ * Cachea un resultado de visión bajo su hash. NUNCA cachea null/undefined
+ * (respuestas de error del modelo). Aplica eviction LRU al superar MAX_ENTRIES.
+ *
+ * @param {string} hash - hash de `hashImage`.
+ * @param {Object|null} result - resultado estructurado del modelo.
+ * @returns {Promise<void>}
+ */
+export const setCached = async (hash, result) => {
+  if (result === null || result === undefined) return;
+
+  // Si ya existe, borrar primero para que la re-inserción quede al final
+  // (recency fresco).
+  if (store.has(hash)) store.delete(hash);
+  store.set(hash, { value: clone(result), ts: Date.now() });
+
+  // Eviction LRU: expulsar las entradas más viejas (inicio del Map) hasta
+  // respetar el límite.
+  while (store.size > MAX_ENTRIES) {
+    const oldestKey = store.keys().next().value;
+    store.delete(oldestKey);
+  }
+  persist();
+};
+
+/**
+ * Vacía todo el cache (memoria + persistencia). Útil para tests y para un
+ * eventual "limpiar caché" en settings.
+ */
+export const clearCache = () => {
+  store.clear();
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.removeItem(LS_KEY);
+  } catch (_) {
+    // best-effort.
+  }
+};
+
+// Test-only: introspección del store interno. NO usar en runtime.
+export const __TEST__ = {
+  MAX_ENTRIES,
+  TTL_MS,
+  size: () => store.size,
+  // Fuerza el timestamp de una entrada al pasado para testear expiración.
+  expireEntry: (hash) => {
+    const entry = store.get(hash);
+    if (entry) entry.ts = Date.now() - TTL_MS - 1;
+  },
+};


### PR DESCRIPTION
## V-11 (#231) — Cache de respuestas de visión por hash de imagen

Las inferencias de visión (`analyzeFoliage`, `recognizeSpecies`) cuestan varios segundos en GPU Maxwell. Si el usuario re-analiza la **misma foto** (mismos bytes), ahora se devuelve el resultado cacheado al instante en vez de re-llamar al modelo. Clave = SHA-256 del contenido del blob.

### Qué hace
- **`src/services/visionCacheService.js`** (nuevo):
  - `hashImage(blob)` → `crypto.subtle.digest('SHA-256', arrayBuffer)` → hex de 64 chars. Determinístico, solo cuenta el contenido (no el mime type).
  - `getCached(hash)` / `setCached(hash, result)` / `clearCache()`.
  - **Política de retención**: LRU de 128 entradas + TTL 24h (lazy expiration). **Nunca** cachea `null`/`undefined` (respuestas de error → se reintenta).
  - **Almacenamiento**: LRU en memoria + mirror best-effort a `localStorage` (sobrevive reload). Se documenta en el header por qué NO se usa IndexedDB: exigiría bumpear `DB_VERSION` (schema compartido, alto riesgo de conflicto) y jsdom no soporta IDB en los unit tests.

- **`src/services/aiService.js`** (wiring quirúrgico):
  - Wrappers de cache sobre `analyzeFoliage` y `recognizeSpecies`. Firmas públicas **intactas**. Cache hit trae `_cached: true` para telemetría/debug.
  - `recognizeSpeciesGrounded` **sin tocar** (sigue llamando a `recognizeSpecies`, que ahora cachea de forma transparente) → minimiza conflicto con la PR de `_grounded.judge` en vuelo.

### Tests (TDD, escritos primero)
- `visionCacheService.test.js`: hash determinístico, miss→set→hit, no-cachear-null/undefined, eviction LRU (real, no FIFO), TTL, clearCache.
- `aiService.visionCache.test.js`: integración — la 2da llamada con la misma imagen **NO** re-invoca `streamOllama`; imagen distinta sí; null no se cachea.
- `aiService.test.js` + `aiService.grounded.test.js`: añadido `clearCache()` en `beforeEach` (reusan los mismos bytes de blob → evitar contaminación cruzada del nuevo cache singleton).

### Validación
- `npx vitest run` sobre los 4 archivos relevantes: **54 passed**.
- Suite completa de servicios: **1700 passed / 1 skipped (80 files)**.
- `eslint --max-warnings=0` limpio en todos los archivos tocados.
- No se corrió `npm run build` (RAM). Validado con vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)