### PR TITLE
feat(agent): E3 — feedback 👍👎 lleva edges del grafo (A-15 #248)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v272';
+const CACHE_NAME = 'chagra-v273';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -7,6 +7,7 @@ import {
   getFullHistory,
   getContextString,
   computeSourceMetadata,
+  extractEdges,
   clearMemory,
   shouldStartNewSession,
 } from '../../services/conversationMemory';
@@ -1294,11 +1295,18 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // para renderizar el badge verde/amber/gris (ver computeSourceMetadata).
       const sourceMetadata = computeSourceMetadata(toolEvidence);
 
+      // A-15 (#248): extraer los edges del grafo AGE que ESTE turno usó como
+      // evidencia (café→guamo COMPATIBLE_WITH, plaga→biopreparado CONTROLS,
+      // etc.) para que el feedback 👍👎 los lleve al motor E3. Si el turno no
+      // tocó relaciones del grafo → [] (sin regresión).
+      const turnEdges = extractEdges(toolEvidence);
+
       const assistantMessage = {
         role: 'assistant',
         content: response,
         timestamp: Date.now(),
         metadata: sourceMetadata,
+        _edges: turnEdges,
       };
 
       await addTurn(operatorId, {

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -191,6 +191,7 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
               <FeedbackButtons
                 prompt={promptText || ''}
                 response={message.content || ''}
+                edges={Array.isArray(message._edges) ? message._edges : []}
                 onConsentNeeded={onConsentNeeded}
               />
             </div>

--- a/src/components/FeedbackButtons.jsx
+++ b/src/components/FeedbackButtons.jsx
@@ -11,11 +11,12 @@ import { sendFeedback, hasConsent } from '../services/feedbackService';
  *
  * Si no hay consentimiento, muestra el modal de consentimiento primero.
  */
-export default function FeedbackButtons({ 
-  prompt, 
-  response, 
+export default function FeedbackButtons({
+  prompt,
+  response,
+  edges = [],
   onConsentNeeded,
-  onFeedbackSent 
+  onFeedbackSent
 }) {
   const [selectedThumb, setSelectedThumb] = useState(null);
   const [isSending, setIsSending] = useState(false);
@@ -49,6 +50,9 @@ export default function FeedbackButtons({
         response,
         thumb,
         comment: commentText,
+        // A-15 (#248): edges del grafo AGE usados en este turno. El motor E3
+        // (sidecar) los mapea a aristas reales para ajustar r.confidence.
+        edges: Array.isArray(edges) ? edges : [],
       });
 
       if (success) {

--- a/src/components/__tests__/FeedbackButtons.test.jsx
+++ b/src/components/__tests__/FeedbackButtons.test.jsx
@@ -66,7 +66,26 @@ describe('FeedbackButtons', () => {
         response: 'El café es una planta...',
         thumb: 'up',
         comment: null,
+        edges: [],
       });
+    });
+  });
+
+  it('A-15 (#248): forwardea los edges del mensaje al payload de feedback', async () => {
+    vi.mocked(feedbackService.hasConsent).mockReturnValue(true);
+    vi.mocked(feedbackService.sendFeedback).mockResolvedValue(true);
+
+    const edges = [
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'inga_edulis' },
+    ];
+    render(<FeedbackButtons {...defaultProps} edges={edges} />);
+
+    fireEvent.click(screen.getByTitle('Esta respuesta fue útil'));
+
+    await waitFor(() => {
+      expect(feedbackService.sendFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({ edges }),
+      );
     });
   });
 
@@ -121,6 +140,7 @@ describe('FeedbackButtons', () => {
         response: 'El café es una planta...',
         thumb: 'down',
         comment: 'Falta información sobre el riego',
+        edges: [],
       });
     });
   });

--- a/src/services/__tests__/conversationMemory.extractEdges.test.js
+++ b/src/services/__tests__/conversationMemory.extractEdges.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests del helper puro `extractEdges` (A-15 #248), que mapea el toolEvidence
+ * de un turno del agente a las aristas del grafo AGE en el shape que el motor
+ * E3 (`feedback-to-confidence.mjs`) necesita: {species_id, edge_type, target_id}.
+ *
+ * El helper es puro (sin red, sin estado) — alimenta el payload del feedback
+ * 👍👎 para que la señal se mapee a aristas reales del KG.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractEdges } from '../conversationMemory';
+
+describe('extractEdges', () => {
+  it('null/undefined → []', () => {
+    expect(extractEdges(null)).toEqual([]);
+    expect(extractEdges(undefined)).toEqual([]);
+  });
+
+  it('toolEvidence sin result/relaciones → [] (sin regresión)', () => {
+    expect(extractEdges({ tool: 'get_species', args: {}, result: { found: true, species: { id: 'x' } } })).toEqual([]);
+    expect(extractEdges({ tool: 'get_companions', args: {}, result: null })).toEqual([]);
+    expect(extractEdges({ tool: 'get_companions', args: {}, result: { found: false } })).toEqual([]);
+  });
+
+  it('get_companions → COMPATIBLE_WITH edges species_id→companion.id', () => {
+    const edges = extractEdges({
+      tool: 'get_companions',
+      args: { species_id: 'coffea_arabica' },
+      result: {
+        found: true,
+        species_id: 'coffea_arabica',
+        companions_count: 2,
+        companions: [
+          { id: 'inga_edulis', nombre_comun: 'guamo' },
+          { id: 'musa_paradisiaca', nombre_comun: 'plátano' },
+        ],
+      },
+    });
+    expect(edges).toEqual([
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'inga_edulis' },
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'musa_paradisiaca' },
+    ]);
+  });
+
+  it('get_multihop_companions → COMPATIBLE_WITH edges', () => {
+    const edges = extractEdges({
+      tool: 'get_multihop_companions',
+      args: { species_id: 'coffea_arabica' },
+      result: {
+        available: true,
+        species_id: 'coffea_arabica',
+        companions: [{ id: 'gliricidia_sepium' }],
+      },
+    });
+    expect(edges).toEqual([
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'gliricidia_sepium' },
+    ]);
+  });
+
+  it('get_pest_controllers → CONTROLS (biopreparado→pest) + TARGETS_PEST (species→pest)', () => {
+    const edges = extractEdges({
+      tool: 'get_pest_controllers',
+      args: { pest: 'broca' },
+      result: {
+        available: true,
+        matches_count: 1,
+        matches: [
+          {
+            pest_id: 'hypothenemus_hampei',
+            biopreparados: [{ id: 'beauveria_bassiana' }],
+            target_species: [{ id: 'tagetes_erecta' }],
+          },
+        ],
+      },
+    });
+    expect(edges).toEqual([
+      { species_id: 'beauveria_bassiana', edge_type: 'CONTROLS', target_id: 'hypothenemus_hampei' },
+      { species_id: 'tagetes_erecta', edge_type: 'TARGETS_PEST', target_id: 'hypothenemus_hampei' },
+    ]);
+  });
+
+  it('array (tool_chain) → agrega edges de todos los evidences y deduplica', () => {
+    const edges = extractEdges([
+      {
+        tool: 'get_companions',
+        args: {},
+        result: {
+          species_id: 'coffea_arabica',
+          companions: [{ id: 'inga_edulis' }],
+        },
+      },
+      {
+        // duplicado del primero — debe deduplicarse
+        tool: 'get_multihop_companions',
+        args: {},
+        result: {
+          species_id: 'coffea_arabica',
+          companions: [{ id: 'inga_edulis' }, { id: 'cordia_alliodora' }],
+        },
+      },
+    ]);
+    expect(edges).toEqual([
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'inga_edulis' },
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'cordia_alliodora' },
+    ]);
+  });
+
+  it('ignora self-edges y companions sin id string', () => {
+    const edges = extractEdges({
+      tool: 'get_companions',
+      args: {},
+      result: {
+        species_id: 'coffea_arabica',
+        companions: [
+          { id: 'coffea_arabica' }, // self → ignorado
+          { id: 42 },               // id no string → ignorado
+          { nombre_comun: 'x' },    // sin id → ignorado
+          { id: 'inga_edulis' },
+        ],
+      },
+    });
+    expect(edges).toEqual([
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'inga_edulis' },
+    ]);
+  });
+
+  it('cota el total de edges (MAX_EDGES=50)', () => {
+    const companions = Array.from({ length: 80 }, (_, i) => ({ id: `sp_${i}` }));
+    const edges = extractEdges({
+      tool: 'get_companions',
+      args: {},
+      result: { species_id: 'coffea_arabica', companions },
+    });
+    expect(edges.length).toBe(50);
+  });
+});

--- a/src/services/__tests__/feedbackService.edges.test.js
+++ b/src/services/__tests__/feedbackService.edges.test.js
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/* eslint-disable no-undef */
+
+/**
+ * Tests del threading de `edges` en el payload de feedback (A-15 #248).
+ *
+ * El feedback 👍👎 debe llevar las aristas del grafo AGE usadas en el turno
+ * ({species_id, edge_type, target_id}) para que el motor E3 del sidecar mapee
+ * la señal a aristas reales. Verifica: inclusión, sanitización (drop de
+ * entradas malformadas), dedup, default [] (sin regresión) y back-compat
+ * cuando el caller no pasa edges.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { sendFeedback } from '../feedbackService';
+
+describe('feedbackService — edges (A-15 #248)', () => {
+  const originalLocalStorage = global.localStorage;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+
+  afterEach(() => {
+    global.localStorage = originalLocalStorage;
+    global.fetch = originalFetch;
+  });
+
+  function sentBody() {
+    return JSON.parse(global.fetch.mock.calls[0][1].body);
+  }
+
+  it('incluye edges válidos en el payload', async () => {
+    await sendFeedback({
+      prompt: '¿compañeros del café?',
+      response: 'guamo, plátano',
+      thumb: 'up',
+      edges: [
+        { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'inga_edulis' },
+      ],
+    });
+    expect(sentBody().edges).toEqual([
+      { species_id: 'coffea_arabica', edge_type: 'COMPATIBLE_WITH', target_id: 'inga_edulis' },
+    ]);
+  });
+
+  it('default [] cuando el caller no pasa edges (back-compat)', async () => {
+    await sendFeedback({ prompt: 'x', response: 'y', thumb: 'up' });
+    expect(sentBody().edges).toEqual([]);
+  });
+
+  it('sanitiza: descarta entradas malformadas y conserva las válidas', async () => {
+    await sendFeedback({
+      prompt: 'x',
+      response: 'y',
+      thumb: 'down',
+      edges: [
+        { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b' }, // válido
+        { species_id: 'a', edge_type: 'COMPATIBLE_WITH' },                  // falta target_id
+        { species_id: '', edge_type: 'CONTROLS', target_id: 'p' },          // species vacío
+        { species_id: 'c', edge_type: 'CONTROLS', target_id: 5 },           // target no string
+        null,                                                              // no objeto
+        'nope',                                                            // no objeto
+      ],
+    });
+    expect(sentBody().edges).toEqual([
+      { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b' },
+    ]);
+  });
+
+  it('deduplica edges repetidos', async () => {
+    await sendFeedback({
+      prompt: 'x',
+      response: 'y',
+      thumb: 'up',
+      edges: [
+        { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b' },
+        { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b' },
+        { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'c' },
+      ],
+    });
+    expect(sentBody().edges).toEqual([
+      { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b' },
+      { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'c' },
+    ]);
+  });
+
+  it('edges no-array → [] (defensivo)', async () => {
+    await sendFeedback({ prompt: 'x', response: 'y', thumb: 'up', edges: 'oops' });
+    expect(sentBody().edges).toEqual([]);
+  });
+
+  it('drops extra keys de cada edge — solo el shape canónico viaja', async () => {
+    await sendFeedback({
+      prompt: 'x',
+      response: 'y',
+      thumb: 'up',
+      edges: [
+        { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b', confidence: 0.9, extra: 'x' },
+      ],
+    });
+    expect(sentBody().edges).toEqual([
+      { species_id: 'a', edge_type: 'COMPATIBLE_WITH', target_id: 'b' },
+    ]);
+  });
+});

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -318,6 +318,107 @@ export function computeSourceMetadata(toolEvidence) {
   return { tool_used: toolEvidence.tool, grounded: true };
 }
 
+/**
+ * A-15 (#248) — extrae los edges del grafo AGE que un turno del agente usó
+ * como evidencia, en el shape que el motor E3 (`feedback-to-confidence.mjs`
+ * del sidecar) necesita para mapear la señal 👍👎 a aristas reales:
+ *
+ *   { species_id: string, edge_type: string, target_id: string }
+ *
+ * Esto es DISTINTO del grounding de visión (`recognizeSpeciesGrounded`): acá
+ * nos importan las RELACIONES del chat (café→guamo COMPATIBLE_WITH, plaga
+ * controlada por biopreparado, etc.), no la validación de una especie.
+ *
+ * Mapeo por tool (todos los edge_type devueltos son de los que E3 sabe
+ * ajustar: COMPATIBLE_WITH, CONTROLS, TARGETS_PEST):
+ *   - get_companions / get_multihop_companions →
+ *       (species_id) -[COMPATIBLE_WITH]-> (companion.id)
+ *   - get_pest_controllers →
+ *       (biopreparado.id) -[CONTROLS]-> (pest_id)
+ *       (target_species.id) -[TARGETS_PEST]-> (pest_id)
+ *
+ * Acepta un toolEvidence simple `{tool, args, result}` o un array (tool_chain).
+ * Si el turno no usó relaciones del grafo, devuelve `[]` (sin regresión: el
+ * payload de feedback lleva `edges: []` y E3 simplemente no recibe señal).
+ *
+ * Defensivo: ignora entradas malformadas, deduplica, y cota el total a
+ * MAX_EDGES para no inflar el payload de feedback.
+ *
+ * @param {object|object[]|null|undefined} toolEvidence
+ * @returns {Array<{species_id: string, edge_type: string, target_id: string}>}
+ */
+export function extractEdges(toolEvidence) {
+  const MAX_EDGES = 50;
+  if (!toolEvidence) return [];
+
+  // Array (tool_chain): agregamos los edges de cada evidence, en orden.
+  if (Array.isArray(toolEvidence)) {
+    const all = [];
+    for (const ev of toolEvidence) {
+      for (const e of extractEdges(ev)) all.push(e);
+    }
+    return dedupeEdges(all).slice(0, MAX_EDGES);
+  }
+
+  const tool = toolEvidence.tool;
+  const result = toolEvidence.result;
+  if (typeof tool !== 'string' || !result || typeof result !== 'object') return [];
+
+  const edges = [];
+  const pushEdge = (species_id, edge_type, target_id) => {
+    if (
+      typeof species_id === 'string' && species_id &&
+      typeof target_id === 'string' && target_id &&
+      species_id !== target_id
+    ) {
+      edges.push({ species_id, edge_type, target_id });
+    }
+  };
+
+  if (tool === 'get_companions' || tool === 'get_multihop_companions') {
+    const src = typeof result.species_id === 'string' ? result.species_id : null;
+    const companions = Array.isArray(result.companions) ? result.companions : [];
+    if (src) {
+      for (const c of companions) {
+        const tid = c && typeof c.id === 'string' ? c.id : null;
+        if (tid) pushEdge(src, 'COMPATIBLE_WITH', tid);
+      }
+    }
+  } else if (tool === 'get_pest_controllers') {
+    const matches = Array.isArray(result.matches) ? result.matches : [];
+    for (const m of matches) {
+      if (!m || typeof m !== 'object') continue;
+      const pestId = typeof m.pest_id === 'string' ? m.pest_id : null;
+      if (!pestId) continue;
+      const bios = Array.isArray(m.biopreparados) ? m.biopreparados : [];
+      for (const b of bios) {
+        const bid = b && typeof b.id === 'string' ? b.id : null;
+        if (bid) pushEdge(bid, 'CONTROLS', pestId);
+      }
+      const targets = Array.isArray(m.target_species) ? m.target_species : [];
+      for (const t of targets) {
+        const sid = t && typeof t.id === 'string' ? t.id : null;
+        if (sid) pushEdge(sid, 'TARGETS_PEST', pestId);
+      }
+    }
+  }
+
+  return dedupeEdges(edges).slice(0, MAX_EDGES);
+}
+
+/** Deduplica edges por la tupla (species_id, edge_type, target_id). */
+function dedupeEdges(edges) {
+  const seen = new Set();
+  const out = [];
+  for (const e of edges) {
+    const k = `${e.species_id}|${e.edge_type}|${e.target_id}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(e);
+  }
+  return out;
+}
+
 export default {
   addTurn,
   getRecentContext,
@@ -325,6 +426,7 @@ export default {
   getFullHistory,
   clearMemory,
   computeSourceMetadata,
+  extractEdges,
   getLastTurnTimestamp,
   shouldStartNewSession,
   SESSION_GAP_MS,

--- a/src/services/feedbackService.js
+++ b/src/services/feedbackService.js
@@ -11,6 +11,11 @@
  *   response: string,     // Respuesta del agente
  *   thumb: 'up' | 'down', // 👍 o 👎
  *   comment?: string,     // Comentario opcional (solo para 👎)
+ *   edges: Array<{        // A-15 (#248): aristas del grafo AGE usadas en el
+ *     species_id: string, //   turno (café→guamo COMPATIBLE_WITH, etc.). El
+ *     edge_type: string,  //   motor E3 del sidecar las mapea a r.confidence.
+ *     target_id: string,  //   [] si el turno no tocó relaciones del grafo
+ *   }>,                   //   (sin regresión / back-compat).
  *   consentGiven: true,   // Siempre true si se envía
  *   timestamp: number     // Unix timestamp
  * }
@@ -28,6 +33,7 @@ const FEEDBACK_TIMEOUT_MS = 8000;
 const CONSENT_STORAGE_KEY = 'chagra_feedback_consent_v1';
 const QUEUE_STORAGE_KEY = 'chagra_feedback_queue_v1';
 const QUEUE_MAX = 50; // cota: el feedback es chico, pero no crece sin límite
+const EDGES_MAX = 50; // A-15 (#248): cota de edges por feedback (evita payload inflado)
 
 /**
  * Obtiene el operatorId desde localStorage o genera uno temporal.
@@ -104,10 +110,39 @@ export function saveConsent(consent) {
  * @param {string} params.response - Respuesta del agente
  * @param {'up' | 'down'} params.thumb - 👍 o 👎
  * @param {string} [params.comment] - Comentario opcional (solo para thumb down)
+ * @param {Array<{species_id: string, edge_type: string, target_id: string}>} [params.edges]
+ *        - A-15 (#248): aristas del grafo AGE usadas en el turno (default []).
  * @returns {Promise<boolean>} - true si se envió correctamente
  */
+/**
+ * Sanitiza el array de edges que viene del UI a la forma canónica que el
+ * motor E3 espera: solo objetos `{species_id, edge_type, target_id}` con los
+ * tres campos string no vacíos. Deduplica y cota a EDGES_MAX. Defensivo:
+ * cualquier input no-array o entrada malformada → se ignora (devuelve []).
+ */
+function sanitizeEdges(edges) {
+  if (!Array.isArray(edges)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const e of edges) {
+    if (!e || typeof e !== 'object') continue;
+    const { species_id, edge_type, target_id } = e;
+    if (
+      typeof species_id !== 'string' || !species_id ||
+      typeof edge_type !== 'string' || !edge_type ||
+      typeof target_id !== 'string' || !target_id
+    ) continue;
+    const k = `${species_id}|${edge_type}|${target_id}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push({ species_id, edge_type, target_id });
+    if (out.length >= EDGES_MAX) break;
+  }
+  return out;
+}
+
 /** Construye el objeto de feedback canónico a partir de los params del UI. */
-function buildFeedback({ prompt, response, thumb, comment }) {
+function buildFeedback({ prompt, response, thumb, comment, edges }) {
   return {
     id: ulid(),
     sessionId: getOperatorId() || 'unknown',
@@ -115,6 +150,7 @@ function buildFeedback({ prompt, response, thumb, comment }) {
     response,
     thumb,
     comment: comment || null,
+    edges: sanitizeEdges(edges),
     consentGiven: true,
     timestamp: Date.now(),
   };
@@ -202,8 +238,8 @@ export async function flushFeedbackQueue() {
   return flushed;
 }
 
-export async function sendFeedback({ prompt, response, thumb, comment }) {
-  const feedback = buildFeedback({ prompt, response, thumb, comment });
+export async function sendFeedback({ prompt, response, thumb, comment, edges }) {
+  const feedback = buildFeedback({ prompt, response, thumb, comment, edges });
 
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     console.debug('[feedback] offline — encolado para envío diferido:', feedback.id);


### PR DESCRIPTION
Threadea los edges del chat (toolEvidence → {species_id, edge_type, target_id}) al payload de /agent-feedback, para que el motor E3 mapee la señal a aristas AGE y ajuste su confidence.

- extractEdges() puro en conversationMemory.js (dedup + cota 50)
- AgentScreen stashea _edges en el mensaje; ChatBubble → FeedbackButtons → sendFeedback
- feedbackService incluye edges (default [], sin regresión)
- Sidecar /agent-feedback con edges ya mergeado en chagra-pro main

Tests: 2433 passed PWA. Branch hermana sidecar ya en main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)