### PR TITLE
fix(agent): conservar respuesta parcial al cortarse + watchdog real por-token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.15",
+  "version": "1.0.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v273';
+const CACHE_NAME = 'chagra-v274';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -28,6 +28,10 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter } from '../../services/agentService';
+// Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
+// La lógica pura del merge del estado final vive en agentPartialMerge (testeable
+// sin montar el componente).
+import { mergePartialOnInterruption } from '../../services/agentPartialMerge';
 // PoC alertas meteorológicas tiempo real (#316) — el bell + el agente
 // comparten el mismo snapshot via `climaService` (cache 30 min).
 import { getCachedClimaSnapshot, fetchClimaSnapshot } from '../../services/climaService';
@@ -142,6 +146,19 @@ export default function AgentScreen({ onBack, initialContext }) {
   // Bug 2026-05-18: ref al AbortController activo para que botón Cancelar
   // pueda abortar la inferencia LLM en curso desde fuera del callLLM scope.
   const activeControllerRef = useRef(null);
+  // Bug UX 2026-05-30: el texto parcial del stream vive en el state
+  // `streamingContent` (lo setea onToken), pero el catch de runLLM/runAgentPipeline
+  // no puede leerlo sin closure stale. Lo espejamos en un ref para que el catch
+  // recupere lo último acumulado y lo preserve en vez de borrarlo.
+  const streamingContentRef = useRef('');
+  // Distingue la causa del abort para el merge final: 'timeout' (deadline del
+  // LLM / watchdog sin tokens), 'cancel' (operador tocó Cancelar) o 'abort'
+  // (genérico, ej. red caída). Se setea antes de disparar controller.abort().
+  const cancelReasonRef = useRef(null);
+  // Watchdog stall (#sin-token): timer que se RESETEA en cada token. Solo
+  // dispara si pasa STALL_WATCHDOG_MS sin ningún token nuevo (stall real),
+  // independiente del tiempo total de una respuesta lenta-pero-avanzando.
+  const stallTimerRef = useRef(null);
   // 057.4 integration: resolver del Promise pendiente del actionExecutor gate.
   // El callback registrado en setActionGateCallback abre el modal y retorna
   // un Promise; el resolver vive aquí para que los handlers approve/reject/
@@ -350,12 +367,15 @@ export default function AgentScreen({ onBack, initialContext }) {
   const handleCancelLLM = () => {
     if (activeControllerRef.current) {
       console.warn('[Agent] User cancelled LLM inference manually');
+      // Bug UX 2026-05-30: marcamos la razón ANTES de abortar para que el
+      // catch de runAgentPipeline preserve el parcial con el marcador
+      // "cancelado por ti" en vez de borrarlo. NO seteamos streamingContent('')
+      // ni error acá: el flujo del pipeline (catch + finally) se encarga del
+      // merge del estado final y empuja la burbuja con el parcial conservado.
+      cancelReasonRef.current = 'cancel';
       activeControllerRef.current.abort();
     }
     agentSounds.cancel();
-    setState(STATE_IDLE);
-    setStreamingContent('');
-    setError('Cancelado. Toca de nuevo si quieres reintentar.');
     // Task #121: al cancelar manualmente, descartamos también la pregunta
     // pendiente (si la hubiera) — el operador puede re-encolarla, pero
     // si presionó Cancelar es porque quiere cortar la cadena, no que
@@ -744,6 +764,15 @@ ${buildProfileContext(finca)}`;
   // modelos no hagan cold-load entre conversaciones.
   const LLM_TIMEOUT_MS = 60000;
 
+  // Watchdog "sin token" (#sin-token). Distinto del deadline total de arriba:
+  // mide el GAP entre tokens, no el tiempo total. Se RESETEA en cada token, así
+  // una respuesta lenta-pero-avanzando NO se aborta — solo dispara ante un
+  // stall real (el backend dejó de emitir). El comment histórico de runLLM
+  // hablaba de "30s sin token" pero solo existía el deadline total de 60s; esto
+  // implementa el comportamiento que el comment prometía. Backstop de 60s queda
+  // como red de seguridad para streams que avanzan token-a-token eternamente.
+  const STALL_WATCHDOG_MS = 30000;
+
   // Task #121: safety cap del while loop que drena el queue. Con QUEUE_MAX=2
   // (1 processing + 1 pending) jamás debería haber más de 2 iteraciones,
   // pero ponemos 10 como guard defensivo contra cualquier bug futuro que
@@ -991,10 +1020,33 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
     const controller = new AbortController();
     activeControllerRef.current = controller;
+    cancelReasonRef.current = null;
+    // Deadline TOTAL (backstop): aborta a los 60s aunque el stream avance.
     const timer = setTimeout(() => {
       console.warn(`[Agent] LLM timeout ${LLM_TIMEOUT_MS}ms — aborting`);
+      cancelReasonRef.current = 'timeout';
       controller.abort();
     }, LLM_TIMEOUT_MS);
+
+    // Watchdog "sin token": se arma acá y se REINICIA en cada token (markToken).
+    // Solo dispara si el backend deja de emitir por STALL_WATCHDOG_MS — stall
+    // real, no respuesta lenta-pero-avanzando.
+    const armStallTimer = () => {
+      stallTimerRef.current = setTimeout(() => {
+        console.warn(`[Agent] LLM stall ${STALL_WATCHDOG_MS}ms sin token — aborting`);
+        cancelReasonRef.current = 'timeout';
+        controller.abort();
+      }, STALL_WATCHDOG_MS);
+    };
+    const markToken = (fullText) => {
+      // Reset del watchdog: llegó un token, el stream está vivo.
+      if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
+      armStallTimer();
+      // Espejo del parcial en ref para que el catch lo preserve sin closure stale.
+      streamingContentRef.current = fullText;
+      setStreamingContent(fullText);
+    };
+    armStallTimer();
 
     try {
       // Routing dual 2026-05-23: queries complejas (plagas regionales,
@@ -1035,7 +1087,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
             num_predict: body.max_tokens,
           },
           keep_alive: body.keep_alive,
-          onToken: (_chunk, full) => setStreamingContent(full),
+          onToken: (_chunk, full) => markToken(full),
           signal: controller.signal,
         });
         console.warn('[Agent] LLM call complete (sidecar stream)', {
@@ -1051,14 +1103,22 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       const result = await streamOpenAI(
         url,
         body,
-        (_chunk, fullText) => setStreamingContent(fullText),
+        (_chunk, fullText) => markToken(fullText),
         { signal: controller.signal },
       );
       console.warn('[Agent] LLM call complete', { responseLen: result?.length || 0 });
       return result;
     } catch (e) {
       if (e.name === 'AbortError') {
-        throw new Error('Tiempo agotado o cancelado. Toca de nuevo.');
+        // Bug UX 2026-05-30: NO aplastamos el parcial acá. Propagamos un error
+        // tipado con la razón de interrupción ('timeout'/'cancel'/'abort') para
+        // que runAgentPipeline corra el merge del estado final y preserve el
+        // texto streamed si lo hubo. cancelReasonRef lo setea handleCancelLLM
+        // (cancel) o el timer/watchdog (timeout); por defecto 'abort' genérico.
+        const interruptErr = new Error('Inferencia interrumpida');
+        interruptErr.interrupted = true;
+        interruptErr.interruptReason = cancelReasonRef.current || 'abort';
+        throw interruptErr;
       }
       const match = e.message.match(/^LLM (\d+)/);
       if (match) {
@@ -1074,6 +1134,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       throw new Error('IA no disponible, intenta de nuevo en un momento');
     } finally {
       clearTimeout(timer);
+      if (stallTimerRef.current) {
+        clearTimeout(stallTimerRef.current);
+        stallTimerRef.current = null;
+      }
       activeControllerRef.current = null;
     }
   };
@@ -1374,10 +1438,47 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       }
     } catch (e) {
       console.error('[Agent] Error:', e);
-      setError(e.message || 'No pude conectarme al asistente. Intenta de nuevo.');
+      // Bug UX 2026-05-30: si la inferencia se interrumpió (abort/timeout/cancel)
+      // y ya había texto parcial streamed, NO lo borramos. El merge decide:
+      //   - con parcial  → conservamos el texto + marcador NO destructivo,
+      //     marcamos el mensaje _incomplete con botón Reintentar, sin banner rojo.
+      //   - sin parcial  → mostramos el mensaje de error completo en el banner
+      //     (abort antes del primer token: comportamiento previo correcto).
+      // Errores NO-interrupción (HTTP 5xx, sesión expirada, etc.) caen al banner
+      // como siempre.
+      if (e?.interrupted) {
+        const partial = streamingContentRef.current || '';
+        const merged = mergePartialOnInterruption({
+          partialContent: partial,
+          reason: e.interruptReason,
+        });
+        if (merged.preservePartial) {
+          const incompleteMessage = {
+            role: 'assistant',
+            content: merged.content,
+            timestamp: Date.now(),
+            _incomplete: true,
+            // Reusa el flujo orphan_recovery para que ChatBubble renderice el
+            // botón "Reintentar" (re-envía el prompt original sin re-tipear) y
+            // suprima 👍👎/TTS sobre una respuesta a medias.
+            _orphan_recovery: true,
+            _orphan_prompt: text.trim(),
+          };
+          setMessages((prev) => [...prev, incompleteMessage]);
+          // NO persistimos el parcial+marcador en conversationMemory: el LLM no
+          // debe arrastrar texto cortado como si fuera contexto válido.
+          setError('');
+        } else {
+          setError(merged.error);
+        }
+      } else {
+        setError(e.message || 'No pude conectarme al asistente. Intenta de nuevo.');
+      }
     } finally {
       setState(STATE_IDLE);
       setStreamingContent('');
+      streamingContentRef.current = '';
+      cancelReasonRef.current = null;
     }
   };
 

--- a/src/services/agentPartialMerge.js
+++ b/src/services/agentPartialMerge.js
@@ -1,0 +1,105 @@
+/**
+ * agentPartialMerge.js — Preservación de respuesta parcial ante interrupción.
+ *
+ * Bug UX (2026-05-30): cuando el stream del LLM se aborta/timeout/cancela a
+ * mitad de respuesta, el texto parcial que el operador YA vio se borraba y se
+ * reemplazaba por un string de error genérico ("Tiempo agotado o cancelado.
+ * Toca de nuevo."), perdiendo contenido útil.
+ *
+ * Este módulo concentra la **lógica pura de merge del estado final**: dado el
+ * texto parcial acumulado del stream y la razón de la interrupción, decide si
+ * se conserva el parcial (apendeando un marcador NO destructivo) o si se
+ * muestra el mensaje de error completo (caso "primer token nunca llegó", que
+ * ya era correcto).
+ *
+ * Mantener esto como función pura (sin React, sin DOM) lo hace testeable en
+ * vitest sin montar el componente y deja AgentScreen delgado.
+ */
+
+/**
+ * Marcadores NO destructivos que se apendean al parcial. Texto plano: el
+ * ChatBubble renderiza `message.content` con `whitespace-pre-wrap` (no es
+ * markdown), así que NO usamos sintaxis `_italic_` que se vería con guiones
+ * bajos literales. El emoji ⚠️ marca visualmente que la respuesta quedó
+ * incompleta sin romper el flujo de lectura.
+ */
+export const PARTIAL_MARKERS = {
+  // timeout total del LLM (LLM_TIMEOUT_MS) o stall sin tokens (watchdog).
+  timeout: '\n\n⚠️ Respuesta incompleta (se cortó). Toca Reintentar.',
+  // AbortError genérico (red caída mid-stream, signal externo no clasificado).
+  abort: '\n\n⚠️ Respuesta incompleta (se cortó). Toca Reintentar.',
+  // El operador tocó "Cancelar" a propósito.
+  cancel: '\n\n⚠️ Cancelado por ti. Toca Reintentar para continuar.',
+};
+
+/**
+ * Mensaje de error completo cuando NO hubo parcial (abort antes del primer
+ * token). Este es el comportamiento que ya era correcto: mostrar el error en
+ * el banner rojo separado, sin burbuja del assistant.
+ */
+export const FULL_ERROR_MESSAGES = {
+  timeout: 'Tiempo agotado. Toca de nuevo para reintentar.',
+  abort: 'Tiempo agotado o cancelado. Toca de nuevo.',
+  cancel: 'Cancelado. Toca de nuevo si quieres reintentar.',
+};
+
+/**
+ * Normaliza una razón de interrupción a una clave conocida. Cualquier valor
+ * desconocido cae a 'abort' (el caso genérico).
+ *
+ * @param {string} reason
+ * @returns {'timeout'|'abort'|'cancel'}
+ */
+export function normalizeInterruptReason(reason) {
+  if (reason === 'timeout' || reason === 'cancel' || reason === 'abort') {
+    return reason;
+  }
+  return 'abort';
+}
+
+/**
+ * Decide el estado final de un turno del assistant interrumpido.
+ *
+ * @param {Object}  params
+ * @param {string}  [params.partialContent]  texto acumulado del stream hasta
+ *                                            el corte (puede ser '' / null).
+ * @param {string}  [params.reason]           'timeout' | 'abort' | 'cancel'.
+ * @returns {{
+ *   preservePartial: boolean,
+ *   content: (string|null),
+ *   error: (string|null),
+ *   incomplete: boolean,
+ *   reason: ('timeout'|'abort'|'cancel'),
+ * }}
+ *   - `preservePartial=true`  → hay parcial: `content` es el parcial + marcador,
+ *     `error` es null (no se muestra banner rojo: la burbuja ya comunica el
+ *     corte vía el marcador). `incomplete=true` para que el caller pueda
+ *     marcar el mensaje (`_incomplete`) y ofrecer Reintentar.
+ *   - `preservePartial=false` → no hubo parcial: `content` es null y `error`
+ *     es el mensaje completo para el banner. Comportamiento previo correcto.
+ */
+export function mergePartialOnInterruption({ partialContent, reason } = {}) {
+  const normReason = normalizeInterruptReason(reason);
+  const partial = typeof partialContent === 'string' ? partialContent : '';
+  const hasPartial = partial.trim().length > 0;
+
+  if (hasPartial) {
+    return {
+      preservePartial: true,
+      content: partial + PARTIAL_MARKERS[normReason],
+      error: null,
+      incomplete: true,
+      reason: normReason,
+    };
+  }
+
+  return {
+    preservePartial: false,
+    content: null,
+    error: FULL_ERROR_MESSAGES[normReason],
+    incomplete: false,
+    reason: normReason,
+  };
+}
+
+export default mergePartialOnInterruption;

--- a/tests/unit/agentPartialMerge.test.js
+++ b/tests/unit/agentPartialMerge.test.js
@@ -1,0 +1,120 @@
+/**
+ * agentPartialMerge.test.js — lógica de merge del estado final ante
+ * interrupción del stream del LLM (abort / timeout / cancel).
+ *
+ * Bug UX 2026-05-30: el texto parcial que el operador YA vio se borraba al
+ * abortar/timeout/cancelar. Estos tests fijan el contrato: con parcial se
+ * CONSERVA + marcador; sin parcial (primer token nunca llegó) se muestra el
+ * error completo.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  mergePartialOnInterruption,
+  normalizeInterruptReason,
+  PARTIAL_MARKERS,
+  FULL_ERROR_MESSAGES,
+} from '../../src/services/agentPartialMerge.js';
+
+describe('mergePartialOnInterruption', () => {
+  describe('abort CON parcial', () => {
+    it('conserva el texto parcial y apenda el marcador (no lo reemplaza)', () => {
+      const partial = 'El café necesita sombra parcial y suelos';
+      const res = mergePartialOnInterruption({ partialContent: partial, reason: 'abort' });
+
+      expect(res.preservePartial).toBe(true);
+      expect(res.incomplete).toBe(true);
+      expect(res.error).toBeNull();
+      // El parcial sobrevive íntegro al inicio del content.
+      expect(res.content.startsWith(partial)).toBe(true);
+      // Y se apendó el marcador no destructivo.
+      expect(res.content).toContain(PARTIAL_MARKERS.abort);
+      // NO es solo el string de error.
+      expect(res.content).not.toBe(FULL_ERROR_MESSAGES.abort);
+      expect(res.content.length).toBeGreaterThan(partial.length);
+    });
+  });
+
+  describe('timeout CON parcial', () => {
+    it('conserva el parcial + marcador de timeout, sin banner de error', () => {
+      const partial = 'Para la broca del café puedes usar Beauveria';
+      const res = mergePartialOnInterruption({ partialContent: partial, reason: 'timeout' });
+
+      expect(res.preservePartial).toBe(true);
+      expect(res.content.startsWith(partial)).toBe(true);
+      expect(res.content).toContain('Respuesta incompleta');
+      expect(res.error).toBeNull();
+      expect(res.reason).toBe('timeout');
+    });
+  });
+
+  describe('abort SIN parcial (primer token nunca llegó)', () => {
+    it('no preserva nada y devuelve el mensaje de error completo en el banner', () => {
+      const res = mergePartialOnInterruption({ partialContent: '', reason: 'abort' });
+
+      expect(res.preservePartial).toBe(false);
+      expect(res.incomplete).toBe(false);
+      expect(res.content).toBeNull();
+      expect(res.error).toBe(FULL_ERROR_MESSAGES.abort);
+    });
+
+    it('trata whitespace-only como sin parcial', () => {
+      const res = mergePartialOnInterruption({ partialContent: '   \n  ', reason: 'timeout' });
+
+      expect(res.preservePartial).toBe(false);
+      expect(res.content).toBeNull();
+      expect(res.error).toBe(FULL_ERROR_MESSAGES.timeout);
+    });
+
+    it('trata null/undefined como sin parcial', () => {
+      expect(mergePartialOnInterruption({ partialContent: null, reason: 'abort' }).preservePartial).toBe(false);
+      expect(mergePartialOnInterruption({ partialContent: undefined, reason: 'abort' }).preservePartial).toBe(false);
+      expect(mergePartialOnInterruption({}).preservePartial).toBe(false);
+    });
+  });
+
+  describe('cancel manual CON parcial', () => {
+    it('conserva el parcial y usa el marcador "cancelado por ti" (no borra)', () => {
+      const partial = 'Las pasifloras confundibles en el Cauca son';
+      const res = mergePartialOnInterruption({ partialContent: partial, reason: 'cancel' });
+
+      expect(res.preservePartial).toBe(true);
+      expect(res.content.startsWith(partial)).toBe(true);
+      expect(res.content).toContain(PARTIAL_MARKERS.cancel);
+      expect(res.content).toContain('Cancelado por ti');
+      expect(res.error).toBeNull();
+      expect(res.reason).toBe('cancel');
+    });
+  });
+
+  describe('cancel manual SIN parcial', () => {
+    it('muestra el error de cancelación completo en el banner', () => {
+      const res = mergePartialOnInterruption({ partialContent: '', reason: 'cancel' });
+
+      expect(res.preservePartial).toBe(false);
+      expect(res.content).toBeNull();
+      expect(res.error).toBe(FULL_ERROR_MESSAGES.cancel);
+    });
+  });
+
+  describe('razón desconocida', () => {
+    it('cae a abort genérico', () => {
+      const res = mergePartialOnInterruption({ partialContent: 'algo', reason: 'wtf' });
+      expect(res.reason).toBe('abort');
+      expect(res.content).toContain(PARTIAL_MARKERS.abort);
+    });
+  });
+});
+
+describe('normalizeInterruptReason', () => {
+  it('pasa claves conocidas tal cual', () => {
+    expect(normalizeInterruptReason('timeout')).toBe('timeout');
+    expect(normalizeInterruptReason('cancel')).toBe('cancel');
+    expect(normalizeInterruptReason('abort')).toBe('abort');
+  });
+
+  it('cae a abort para valores desconocidos / vacíos', () => {
+    expect(normalizeInterruptReason('boom')).toBe('abort');
+    expect(normalizeInterruptReason(undefined)).toBe('abort');
+    expect(normalizeInterruptReason(null)).toBe('abort');
+  });
+});


### PR DESCRIPTION
Bug reportado por operador: el agente streamea, se corta a los 60s (deadline total bajo contención GPU) y BORRA el texto parcial, reemplazándolo por 'Tiempo agotado o cancelado'.

Fix:
- Conserva el parcial + marcador no-destructivo + botón Reintentar (no lo borra). No persiste a conversationMemory (evita arrastrar texto cortado).
- Agrega watchdog real STALL_WATCHDOG_MS=30s que se rearma por token (el '30s sin token' del comentario histórico nunca se había implementado; solo había deadline total 60s).

10/10 tests nuevos (agentPartialMerge), suite 2457 pass, eslint limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)