### PR TITLE
fix(agent): stop sequences + strip role-leak — agente emitía turnos 'Usuario:' falsos

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -27,7 +27,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
-import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter } from '../../services/agentService';
+import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
 // La lógica pura del merge del estado final vive en agentPartialMerge (testeable
 // sin montar el componente).
@@ -1348,7 +1348,14 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // llegue al usuario campesino colombiano, independientemente de lo
       // que el modelo decida emitir. Default formality='usted'. La
       // función es idempotente y O(n) sobre el largo del texto.
-      const response = applyVoseoFilter(rawResponse, { formality: 'usted' });
+      // BUG A fix (fuga de roles, prod 2026-05-30): defensa #2 post-proceso.
+      // Trunca cualquier turno falso "Usuario:"/"Asistente:" que el modelo
+      // haya inventado (el path de streaming del sidecar NO reenvía las stop
+      // sequences de llmRouter, así que el filtro estructural por sí solo no
+      // cubre el 100% de los casos). Va ANTES del voseo para no analizar
+      // basura, y el resultado se persiste/renderea/habla ya saneado.
+      const deLeaked = stripRoleLeak(rawResponse);
+      const response = applyVoseoFilter(deLeaked, { formality: 'usted' });
       agentSounds.chime();
 
       const { intent } = parseIntent(text);

--- a/src/services/__tests__/agentService.stripRoleLeak.test.js
+++ b/src/services/__tests__/agentService.stripRoleLeak.test.js
@@ -1,0 +1,78 @@
+/**
+ * agentService.stripRoleLeak.test.js — BUG A (fuga de roles, prod 2026-05-30).
+ *
+ * El agente generó una respuesta catastrófica donde, tras su respuesta real,
+ * el modelo siguió generando PASADO su turno e inventó un turno falso del
+ * usuario ("Usuario: Hola Dante, gracias por tu consulta...") con contenido
+ * de asistente, mezclando roles.
+ *
+ * Causa raíz: `conversationMemory.getContextString` inyecta el historial con
+ * etiquetas "Usuario:" / "Asistente:" y la llamada al LLM NO pasaba stop
+ * sequences. La defensa #1 son las stop sequences (llmRouter). Esta es la
+ * defensa #2: un post-proceso determinístico que TRUNCA todo lo que venga
+ * desde el primer turno falso en adelante — necesaria porque el path de
+ * streaming del sidecar NO reenvía `stop`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripRoleLeak } from '../agentService.js';
+
+describe('stripRoleLeak — BUG A fuga de roles', () => {
+  it('corta el incidente exacto de producción (turno "Usuario:" falso)', () => {
+    const leaked =
+      'El tomate de árbol (Solanum betaceum) se siembra a 1800-2600 msnm.\n' +
+      'Usuario: Hola Dante, gracias por tu consulta. El nombre científico está mal...\n' +
+      'Asistente: Tienes razón, corrijo...';
+    const out = stripRoleLeak(leaked);
+    expect(out).toBe(
+      'El tomate de árbol (Solanum betaceum) se siembra a 1800-2600 msnm.',
+    );
+    expect(out).not.toMatch(/Usuario:/);
+    expect(out).not.toMatch(/Asistente:/);
+  });
+
+  it('corta también la variante en inglés "User:" / "Assistant:"', () => {
+    const leaked = 'Respuesta válida.\nUser: otra cosa\nAssistant: ...';
+    expect(stripRoleLeak(leaked)).toBe('Respuesta válida.');
+  });
+
+  it('corta el marcador de chat-template de Ollama (<|im_start|>)', () => {
+    const leaked = 'Respuesta válida.<|im_start|>user\nmás texto';
+    expect(stripRoleLeak(leaked)).toBe('Respuesta válida.');
+  });
+
+  it('corta "Usuario :" con espacio antes de los dos puntos', () => {
+    const leaked = 'Respuesta válida.\nUsuario : pregunta inventada';
+    expect(stripRoleLeak(leaked)).toBe('Respuesta válida.');
+  });
+
+  it('NO toca respuestas legítimas que mencionan la palabra "usuario" en prosa', () => {
+    const ok =
+      'El usuario debe regar al atardecer. Recuerda que el riego del usuario es clave.';
+    expect(stripRoleLeak(ok)).toBe(ok);
+  });
+
+  it('NO corta cuando "Asistente:" aparece a mitad de una oración (no inicio de línea)', () => {
+    // Solo cortamos turnos falsos: etiqueta de rol al inicio de línea.
+    const ok = 'Soy tu Asistente: te ayudo con tu cultivo.';
+    expect(stripRoleLeak(ok)).toBe(ok);
+  });
+
+  it('es idempotente', () => {
+    const leaked = 'Hola.\nUsuario: x';
+    const once = stripRoleLeak(leaked);
+    expect(stripRoleLeak(once)).toBe(once);
+  });
+
+  it('trimea el resultado y maneja entradas vacías / no-string', () => {
+    expect(stripRoleLeak('')).toBe('');
+    expect(stripRoleLeak(null)).toBe('');
+    expect(stripRoleLeak(undefined)).toBe('');
+    expect(stripRoleLeak('   hola  \n')).toBe('hola');
+  });
+
+  it('si TODO el output es un turno falso, devuelve string vacío (no propaga basura)', () => {
+    const leaked = 'Usuario: pregunta inventada sin respuesta previa';
+    expect(stripRoleLeak(leaked)).toBe('');
+  });
+});

--- a/src/services/__tests__/llmRouter.test.js
+++ b/src/services/__tests__/llmRouter.test.js
@@ -68,6 +68,46 @@ describe('buildLLMRequest', () => {
   it('lanza para tarea desconocida (vía getModelFor)', () => {
     expect(() => buildLLMRequest('nope', messages)).toThrow(/Tarea desconocida/);
   });
+
+  // BUG A (fuga de roles, 2026-05-30): el modelo generaba turnos falsos
+  // ("Usuario: ...", "Asistente: ...") porque conversationMemory inyecta el
+  // historial con esas etiquetas y la request NO pasaba stop sequences. Sin
+  // stop tokens el modelo autocompleta el patrón del diálogo y "alucina" un
+  // turno del usuario. Estructura mínima: toda ruta de CHAT debe traer stops.
+  describe('BUG A — stop sequences anti fuga-de-roles', () => {
+    it('las rutas de chat incluyen body.stop con las etiquetas de rol', () => {
+      for (const task of ['chat', 'chat_complex']) {
+        const { body } = buildLLMRequest(task, messages);
+        expect(Array.isArray(body.stop), task).toBe(true);
+        // Debe cortar tanto al inicio de línea como tras newline, ES y EN,
+        // y el marcador de chat-template de Ollama.
+        expect(body.stop, task).toEqual(
+          expect.arrayContaining([
+            '\nUsuario:',
+            '\nAsistente:',
+            '\nUser:',
+            '\nUsuario :',
+          ]),
+        );
+      }
+    });
+
+    it('ROUTES.chat.stop está definido y es no vacío', () => {
+      expect(Array.isArray(ROUTES.chat.stop)).toBe(true);
+      expect(ROUTES.chat.stop.length).toBeGreaterThan(0);
+    });
+
+    it('un override de stop reemplaza el de la ruta', () => {
+      const { body } = buildLLMRequest('chat', messages, { stop: ['###'] });
+      expect(body.stop).toEqual(['###']);
+    });
+
+    it('las rutas no-chat (nlu) no rompen si no definen stop', () => {
+      const { body } = buildLLMRequest('nlu', messages);
+      // nlu puede no traer stop; si lo trae, debe ser array.
+      if (body.stop !== undefined) expect(Array.isArray(body.stop)).toBe(true);
+    });
+  });
 });
 
 describe('selectChatRoute', () => {

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -85,6 +85,59 @@ export function applyVoseoFilter(text, opts = {}) {
 }
 
 /**
+ * BUG A (fuga de roles, incidente prod 2026-05-30) — defensa #2 (post-proceso).
+ *
+ * `conversationMemory.getContextString` inyecta el historial al prompt con
+ * etiquetas "Usuario:" / "Asistente:". Si el modelo no se detiene a tiempo
+ * (la defensa #1 son las stop sequences de `llmRouter`, pero el path de
+ * streaming del sidecar NO reenvía `stop`), sigue generando PASADO su turno
+ * e inventa un turno falso del usuario, p.ej.:
+ *
+ *   "El tomate de árbol se siembra a 1800 msnm.
+ *    Usuario: Hola Dante, gracias por tu consulta..."
+ *
+ * Esta función TRUNCA la respuesta en el primer marcador de turno falso —
+ * etiqueta de rol al INICIO de línea (ES/EN) o marcador de chat-template de
+ * Ollama/llama.cpp. Es determinística, idempotente y O(n).
+ *
+ * Diseño conservador para no mutilar respuestas legítimas:
+ *   - Solo corta etiquetas de rol al inicio de línea (`^` o tras `\n`), NO
+ *     a mitad de oración ("Soy tu Asistente: ..." se respeta).
+ *   - Los marcadores de chat-template (`<|im_start|>`, etc.) sí cortan en
+ *     cualquier posición — nunca aparecen en prosa legítima.
+ *
+ * @param {string} text  texto crudo del LLM (idealmente ya pos-voseo)
+ * @returns {string} texto truncado y trim. '' si entrada vacía/no-string.
+ */
+export function stripRoleLeak(text) {
+  if (typeof text !== 'string' || text.length === 0) return '';
+
+  let cut = text.length;
+
+  // 1) Marcadores de chat-template: cortan en cualquier posición.
+  const templateMarkers = ['<|im_start|>', '<|im_end|>', '<|user|>', '<|assistant|>'];
+  for (const marker of templateMarkers) {
+    const idx = text.indexOf(marker);
+    if (idx !== -1 && idx < cut) cut = idx;
+  }
+
+  // 2) Etiquetas de rol SOLO al inicio de línea (inicio del texto o tras
+  //    newline). Tolera espacios antes de los dos puntos ("Usuario :").
+  //    `m` flag → ^ matchea inicio de cada línea.
+  const roleAtLineStart =
+    /(^|\n)[ \t]*(?:Usuario|Asistente|User|Assistant)[ \t]*:/m;
+  const m = roleAtLineStart.exec(text);
+  if (m) {
+    // Si el match es al inicio absoluto (m[1] === ''), cut = 0.
+    // Si arranca tras un newline, cortamos en la posición del newline.
+    const idx = m.index + (m[1] ? m[1].length : 0);
+    if (idx < cut) cut = idx;
+  }
+
+  return text.slice(0, cut).trim();
+}
+
+/**
  * Mapeo de zonas bioculturales a regiones lingüísticas.
  * Basado en correlación geográfica y cultural de Colombia.
  */

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -20,6 +20,36 @@
 import { analyzeQueryComplexity } from './queryComplexityAnalyzer';
 
 /**
+ * BUG A (fuga de roles, incidente prod 2026-05-30) — stop sequences anti
+ * "turno falso". `conversationMemory.getContextString` inyecta el historial
+ * con etiquetas `Usuario:` / `Asistente:`. Sin `stop` tokens, el modelo de
+ * chat (granite/gemma) autocompleta el patrón del diálogo y emite un turno
+ * inventado del usuario ("Usuario: Hola Dante, gracias por tu consulta...").
+ * Estos tokens cortan la generación EN CUANTO el modelo intenta abrir un
+ * turno nuevo. Cubrimos: inicio-de-línea (\n + etiqueta), variantes con
+ * espacio antes de los dos puntos, ES + EN, y el marcador de chat-template
+ * de Ollama/llama.cpp (`<|im_start|>`, `<|im_end|>`, `<|user|>`).
+ *
+ * Nota: es defensa estructural #1. La defensa #2 (post-proceso que trunca
+ * cualquier turno falso que igual se cuele, p.ej. por el path de streaming
+ * del sidecar que no reenvía `stop`) vive en `agentService.stripRoleLeak`.
+ */
+export const CHAT_STOP_SEQUENCES = Object.freeze([
+  '\nUsuario:',
+  '\nUsuario :',
+  '\nAsistente:',
+  '\nAsistente :',
+  '\nUser:',
+  '\nAssistant:',
+  '\n\nUsuario:',
+  '\n\nAsistente:',
+  '<|im_start|>',
+  '<|im_end|>',
+  '<|user|>',
+  '<|assistant|>',
+]);
+
+/**
  * Tipos de tarea soportadas por el router.
  *
  * `chat`         → modelo rápido para queries simples del agente Chagra IA.
@@ -63,6 +93,8 @@ export const ROUTES = {
     keep_alive_min: 30,
     temperature: 0.3,
     max_tokens: 512,
+    // BUG A fix (2026-05-30): corta turnos falsos "Usuario:"/"Asistente:".
+    stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
     rationale:
       'Swap 2026-05-24 post-bug producción: granite3.1-dense:8b promovido a ' +
@@ -91,6 +123,8 @@ export const ROUTES = {
     keep_alive_min: 5,
     temperature: 0.3,
     max_tokens: 768,
+    // BUG A fix (2026-05-30): corta turnos falsos "Usuario:"/"Asistente:".
+    stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
     rationale:
       'Bench 2026-05-23 anti-alucinación: granite3.1-dense:8b 37 t/s, ' +
@@ -181,18 +215,23 @@ export function getModelFor(task) {
  */
 export function buildLLMRequest(task, messages, overrides = {}) {
   const route = getModelFor(task);
-  return {
-    url: route.url,
-    body: {
-      model: route.model,
-      messages,
-      temperature: overrides.temperature ?? route.temperature,
-      max_tokens: overrides.max_tokens ?? route.max_tokens,
-      // keep_alive controla cuánto Ollama mantiene el modelo en RAM tras
-      // esta request. Formato Ollama: número en segundos o sufijo "m"/"h".
-      keep_alive: `${route.keep_alive_min}m`,
-    },
+  const body = {
+    model: route.model,
+    messages,
+    temperature: overrides.temperature ?? route.temperature,
+    max_tokens: overrides.max_tokens ?? route.max_tokens,
+    // keep_alive controla cuánto Ollama mantiene el modelo en RAM tras
+    // esta request. Formato Ollama: número en segundos o sufijo "m"/"h".
+    keep_alive: `${route.keep_alive_min}m`,
   };
+  // BUG A fix (2026-05-30): forward stop sequences (de la ruta o del
+  // override). Ollama OpenAI-compat respeta `stop` (string[]). Solo se
+  // setea cuando hay algo que cortar, para no enviar `stop: undefined`.
+  const stop = overrides.stop ?? route.stop;
+  if (Array.isArray(stop) && stop.length > 0) {
+    body.stop = stop;
+  }
+  return { url: route.url, body };
 }
 
 /**


### PR DESCRIPTION
## Incidente prod 2026-05-30
El agente emitía respuestas catastróficas: escribía `Usuario: ...` confabulando un diálogo falso, y divagaba/se auto-envenenaba turno a turno.

## Causa raíz (verificada)
1. `conversationMemory.js` inyecta el historial con etiquetas literales `Usuario:/Asistente:` como mensaje `user`.
2. **No había stop sequences en ningún path del LLM** → granite ve el patrón de diálogo y autocompleta el siguiente turno → emite un `Usuario:` falso. Clásico de falta de stop sequences.

(El comentario del 👎 NO se reenvía al LLM — esa hipótesis quedó descartada; el leak ocurre con cualquier turno cuando hay historial.)

## Fix
- **Defensa estructural**: `llmRouter.js` → `CHAT_STOP_SEQUENCES` (`\nUsuario:`, `\nAsistente:`, variantes ES/EN) en `body.stop` para rutas chat/chat_complex.
- **Defensa post-proceso**: `agentService.stripRoleLeak()` trunca cualquier turno falso al inicio de línea (necesaria porque el path streaming del sidecar no reenvía `stop`). Wired antes de `applyVoseoFilter`.
- Tests: 4 (stop seqs) + 9 (stripRoleLeak, incluye el string exacto del incidente).

Relacionado: grounding fix en chagra-pro (BUG B, binomio tomate de árbol).