### PR TITLE
fix(agent): header (volver/silenciar) se iba con el scroll — faltaba min-h-0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.15",
+  "version": "1.0.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v273';
+const CACHE_NAME = 'chagra-v274';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -44,7 +44,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
   };
 
   return (
-    <div className="flex-1 overflow-y-auto p-4 pb-2">
+    <div className="flex-1 min-h-0 overflow-y-auto p-4 pb-2">
       {messages.map((msg, idx) => (
         <ChatBubble
           key={msg.id || idx}


### PR DESCRIPTION
## Reporte del operador
Para **silenciar** la voz o **volver atrás** había que scrollear mucho hacia arriba con respuestas largas.

## Causa
El contenedor de mensajes (`ChatHistory.jsx`) tenía `flex-1 overflow-y-auto` **sin `min-h-0`**. En columna flex, un hijo `flex-1` sin `min-h-0` no se encoge bajo su contenido → crece y empuja la pantalla → scrollea la página entera y el header (back + botón silenciar TTS) se va fuera de vista.

## Fix
Una línea: `min-h-0` en el contenedor de scroll. Confina el scroll al listado; header + input quedan fijos.