### PR TITLE
test+fix(agent): regla dura de binomio + regresión tomate de árbol→Solanum betaceum

### DIFF
--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -177,6 +177,29 @@ describe('agentService — Task #202 Profile Context', () => {
       const rules = generateSourceCitationRules();
       expect(rules).toContain('No tengo una fuente confiable');
     });
+
+    // Regresión anti-alucinación (incidente prod 2026-05-30): "tomate de
+    // árbol" → "Solanum lycopersicum var. cerasiforme" (FALSO; lo correcto es
+    // Solanum betaceum). El grounding del sidecar venía muerto y el LLM
+    // inventó el binomio. Endurecemos la regla: solo se cita un binomio si
+    // viene del grounding/catálogo provisto.
+    it('debería incluir regla dura de binomio solo desde el grounding', () => {
+      const rules = generateSourceCitationRules();
+      expect(rules).toContain('REGLA CRÍTICA DE NOMBRES CIENTÍFICOS');
+      expect(rules).toContain('NO inventes el binomio');
+      expect(rules).toContain('grounding/catálogo provisto');
+    });
+
+    it('debería mandar usar SOLO el nombre común cuando no hay binomio en grounding', () => {
+      const rules = generateSourceCitationRules();
+      expect(rules).toContain('usa SOLO el nombre común');
+    });
+
+    it('debería referenciar el incidente tomate de árbol → betaceum como ejemplo', () => {
+      const rules = generateSourceCitationRules();
+      expect(rules).toContain('tomate de árbol');
+      expect(rules).toContain('Solanum betaceum');
+    });
   });
 
   describe('generateUserDataRules', () => {

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -287,7 +287,9 @@ Toda información técnica (altitud, siembra, cosecha, manejo, plagas, clima, et
 Si NO tienes una fuente verificable para un dato, di explícitamente:
 "No tengo una fuente confiable para este dato específico. Te recomiendo consultar con [técnico local/agrónomo/IDEAM]."
 
-NUNCA inventes datos ni fuentes. Es preferible decir "no tengo el dato" que fabricar una cita.`;
+NUNCA inventes datos ni fuentes. Es preferible decir "no tengo el dato" que fabricar una cita.
+
+REGLA CRÍTICA DE NOMBRES CIENTÍFICOS (BINOMIO): solo puedes citar un nombre científico (binomio Linneano, p. ej. "Solanum betaceum") si proviene del grounding/catálogo provisto en este mensaje — bloques "=== ENTIDADES RESUELTAS ===" o "=== EVIDENCIA AUTORITATIVA ===". Si la planta/plaga NO aparece en esos bloques, NO inventes el binomio: usa SOLO el nombre común tal cual lo dijo el usuario, sin paréntesis con nombre científico. Inventar un binomio por similitud fonética o "porque suena parecido" es alucinación grave (incidente prod 2026-05-30: "tomate de árbol" respondido como "Solanum lycopersicum var. cerasiforme" —cherry— cuando lo correcto es Solanum betaceum). Ante la duda: nombre común, sin binomio.`;
 }
 
 /**

--- a/tests/agent-anti-halluc.spec.js
+++ b/tests/agent-anti-halluc.spec.js
@@ -483,6 +483,63 @@ test.describe('AgentScreen — sidecar pipeline (flag-dependent)', () => {
     expect(llmSeen).toBe(true);
   });
 
+  test('Caso G2 — tomate de árbol inyecta Solanum betaceum y NUNCA el cherry inventado (incidente prod 2026-05-30)', async ({ page }) => {
+    // Regresión del bug de grounding muerto: el sidecar /resolve-entities
+    // devolvía entities:[] y el LLM inventaba "tomate de árbol = Solanum
+    // lycopersicum var. cerasiforme" (eso es tomate CHERRY). Lo correcto es
+    // Solanum betaceum. Con el grounding arreglado, el sidecar resuelve
+    // betaceum y el pipeline DEBE inyectarlo en el system prompt del LLM.
+    //
+    // Verificación fuerte: interceptamos el body de la request al LLM y
+    // asertamos que el binomio CANÓNICO (Solanum betaceum) viaja en el
+    // grounding, y que el binomio FALSO (cerasiforme) NO está presente.
+    let systemPromptSeen = '';
+    await page.context().route('**/api/ollama/v1/chat/completions', (route) => {
+      try {
+        const body = JSON.parse(route.request().postData() || '{}');
+        const sys = (body.messages || [])
+          .filter((m) => m.role === 'system')
+          .map((m) => m.content)
+          .join('\n');
+        systemPromptSeen = sys;
+      } catch {
+        // body no-parseable: dejamos systemPromptSeen vacío, las aserciones
+        // de abajo fallarán con un mensaje claro.
+      }
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: buildSSEResponse(
+          'El tomate de árbol (Solanum betaceum) se siembra entre 1800 y 2800 msnm.'
+        ),
+      });
+    });
+    await mockSidecar(page, {
+      entities: [
+        {
+          mentioned: 'tomate de arbol',
+          kind: 'species',
+          canonical_id: 'solanum_betaceum',
+          nombre_comun: 'Tomate de árbol / Tamarillo',
+          nombre_cientifico: 'Solanum betaceum Cav.',
+          confidence: 1.0,
+        },
+      ],
+    });
+
+    await gotoAgentScreen(page);
+    await askAgent(page, 'dame consejos para sembrar tomate de árbol');
+
+    // La respuesta correcta (betaceum) llega y se renderiza.
+    await expect(page.getByText(/Solanum betaceum/)).toBeVisible({ timeout: 30_000 });
+
+    // El grounding inyectó el binomio canónico al system prompt…
+    expect(systemPromptSeen).toContain('Solanum betaceum');
+    expect(systemPromptSeen).toContain('solanum_betaceum');
+    // …y JAMÁS el binomio cherry que el LLM alucinó en el incidente.
+    expect(systemPromptSeen).not.toContain('cerasiforme');
+  });
+
   test('Caso H — tool MCP grounded produce badge "Catálogo verificado"', async ({ page }) => {
     // NLU devuelve use_tool=true tool=get_species. Tool result trae
     // matches_count=1 → computeSourceMetadata pone grounded=true →


### PR DESCRIPTION
Complementa el fix del grounding (revivido hoy). 
- **Regla dura** en `agentService.generateSourceCitationRules()`: solo citar binomio si viene del grounding/catálogo; si la entidad no resuelve, NO inventar binomio (usar nombre común). Se inyecta en todo system prompt.
- **Regresión E2E** Caso G2: mockea /resolve-entities→betaceum, intercepta el body real al LLM, asierta que el prompt lleva Solanum betaceum y NO cerasiforme.
- 3 specs unitarias de la regla. Suites: agentService 53/53.
Cierra el caso que disparó el incidente 2026-05-30.