### PR TITLE
fix(dashboard): widget de clima con pronóstico REAL Open-Meteo (no IDEAM vacío)

### DIFF
--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -1,33 +1,82 @@
 import { useEffect, useState, useMemo } from 'react';
 import { Cloud, CloudRain, Sun, CloudSun, Droplets, Wind, Thermometer, MapPin } from 'lucide-react';
-import { getClimaIdeam } from '../../services/sidecarClient';
+import { fetchClimaSnapshot, getCachedClimaSnapshot } from '../../services/climaService';
+import { findMunicipio } from '../../utils/colombiaLocations';
 import { FARM_CONFIG } from '../../config/defaults';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 import { getProfile } from '../../services/userProfileService';
 
 /**
- * ClimaStrip — pronóstico IDEAM 7 días debajo del agente.
- * Si tiene municipio (finca activa o FARM_CONFIG): pide get_clima_ideam y muestra.
- * Si no: card invitando a configurar ubicación.
+ * ClimaStrip — pronóstico real de 7 días debajo del agente.
+ *
+ * Fuente: Open-Meteo (`openmeteo.forecast_7d` del snapshot del sidecar). Da
+ * pronóstico real por lat/lon: temp máx/mín + precipitación por día, gratis y
+ * sin key. (Antes pedía `get_clima_ideam('monthly_avg')`, que es climatología
+ * histórica y además devolvía vacío porque la ingesta IDEAM nunca se pobló —
+ * el widget se veía sin datos.)
+ *
+ * Coordenadas (necesarias para Open-Meteo):
+ *   1. Perfil del usuario: `ubicacion_lat`/`ubicacion_lng` — los guarda
+ *      LocationDetectedScreen al confirmar la ubicación (mini mapa, #200).
+ *   2. Fallback offline: geocodificar el `municipio` contra el dataset DANE
+ *      local (`findMunicipio`) → lat/lng. Cubre perfiles viejos que solo
+ *      tienen el nombre del municipio (texto) sin haber pasado por el mapa.
+ *
+ * Estados:
+ *   - loading: skeleton.
+ *   - sin coords NI municipio: CTA "Configurar ubicación".
+ *   - con coords pero Open-Meteo no disponible (offline / sidecar caído):
+ *     degrada limpio — muestra el strip con aviso "pronóstico aún cargando",
+ *     nunca rompe el dashboard.
+ *
+ * Nota: el IDEAM sigue alimentando el grounding histórico del agente por otro
+ * lado (agentService); este cambio solo reapunta la FUENTE de ESTE widget.
  */
 
 const DAY_LABELS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
 
 function pickIcon(precipMm, tempC) {
-    if (precipMm >= 10) return CloudRain;
-    if (precipMm >= 2) return Cloud;
-    if (tempC >= 24) return Sun;
+    if (precipMm != null && precipMm >= 10) return CloudRain;
+    if (precipMm != null && precipMm >= 2) return Cloud;
+    if (tempC != null && tempC >= 28) return Sun;
     return CloudSun;
 }
 
-function formatDay(date) {
-    return DAY_LABELS[date.getDay()];
+function dayLabel(isoDate, i) {
+    if (i === 0) return 'Hoy';
+    try {
+        const d = new Date(isoDate);
+        if (Number.isNaN(d.getTime())) return '–';
+        return DAY_LABELS[d.getDay()];
+    } catch (_) {
+        return '–';
+    }
+}
+
+/**
+ * Resuelve { lat, lng } a partir del perfil o, en su defecto, geocodificando
+ * el municipio contra el dataset DANE local (offline-friendly).
+ * @returns {{ lat: number, lng: number } | null}
+ */
+function resolveCoords(profile, municipio) {
+    const lat = Number(profile?.ubicacion_lat);
+    const lng = Number(profile?.ubicacion_lng);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+        return { lat, lng };
+    }
+    if (municipio) {
+        const hit = findMunicipio(municipio.split(',')[0]);
+        if (hit && Number.isFinite(hit.lat) && Number.isFinite(hit.lng)) {
+            return { lat: hit.lat, lng: hit.lng };
+        }
+    }
+    return null;
 }
 
 export default function ClimaStrip({ onNavigate }) {
     const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
     const fincas = useFincaActiveStore((s) => s.fincas);
-    const [data, setData] = useState(null);
+    const [snapshot, setSnapshot] = useState(() => getCachedClimaSnapshot());
     const [loading, setLoading] = useState(true);
     // Bug fix 2026-05-30: el municipio que el usuario confirma en
     // LocationDetectedScreen se guarda en el perfil (userProfileService), NO en
@@ -48,20 +97,29 @@ export default function ClimaStrip({ onNavigate }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeFincaSlug, fincas, tick]);
 
+    const coords = useMemo(() => {
+        return resolveCoords(getProfile(), municipio);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [municipio, tick]);
+
     useEffect(() => {
         let alive = true;
-        if (!municipio) {
+        // Sin coords (ni del perfil ni geocodificando el municipio) no podemos
+        // pedir Open-Meteo, que necesita lat/lon. Cerramos el loading y dejamos
+        // que el render decida: CTA si tampoco hay municipio, strip neutro si
+        // hay municipio pero sin match DANE.
+        if (!coords) {
             Promise.resolve().then(() => { if (alive) setLoading(false); });
             return () => { alive = false; };
         }
-        const desde = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-            .toISOString().slice(0, 10);
-        getClimaIdeam('monthly_avg', { municipio, metric: 'precipitation', desde })
-            .then((res) => { if (alive) setData(res); })
-            .catch(() => { if (alive) setData(null); })
+        // fetchClimaSnapshot nunca throw: devuelve null si offline / flag off /
+        // HTTP≥400. Open-Meteo real 7d viene en payload.openmeteo.forecast_7d.
+        fetchClimaSnapshot({ lat: coords.lat, lng: coords.lng })
+            .then((res) => { if (alive && res) setSnapshot(res); })
+            .catch(() => { /* degrade limpio — nunca rompe el dashboard */ })
             .finally(() => { if (alive) setLoading(false); });
         return () => { alive = false; };
-    }, [municipio]);
+    }, [coords]);
 
     if (loading) {
         return (
@@ -76,7 +134,7 @@ export default function ClimaStrip({ onNavigate }) {
         );
     }
 
-    if (!municipio) {
+    if (!coords && !municipio) {
         return (
             <div className="bg-gradient-to-br from-sky-950/70 to-indigo-950/60 backdrop-blur-xl border border-sky-800/40 rounded-2xl p-5">
                 <div className="flex items-center gap-2 mb-2">
@@ -84,7 +142,7 @@ export default function ClimaStrip({ onNavigate }) {
                     <h3 className="text-base font-bold text-white">Clima en tu zona</h3>
                 </div>
                 <p className="text-sm text-slate-300 leading-relaxed">
-                    Cuéntame en qué municipio queda tu finca y te traigo el pronóstico real del IDEAM.
+                    Cuéntame en qué municipio queda tu finca y te traigo el pronóstico real de los próximos 7 días.
                 </p>
                 {/* Bug fix 2026-05-28 (Brave laptop): el botón no tenía
                     onClick — operador clickeaba y nada pasaba.
@@ -117,22 +175,27 @@ export default function ClimaStrip({ onNavigate }) {
         );
     }
 
-    // Genera 7 días mock visual desde data o fallback (mientras get_clima_ideam
-    // devuelve formato variable). Si data tiene .days, úsalo. Si no, dibuja 7
-    // tarjetas neutras para que la UI no rompa.
-    const days = (data?.forecast || data?.days || []).slice(0, 7);
+    // Pronóstico real de Open-Meteo. Cada día: { date, temp_max_c, temp_min_c,
+    // precip_mm } (mismo shape que consume NotificationsBell).
+    const openmeteo = snapshot?.openmeteo;
+    const forecast = openmeteo?.available && Array.isArray(openmeteo.forecast_7d)
+        ? openmeteo.forecast_7d
+        : [];
+
     const today = new Date();
     const filled = Array.from({ length: 7 }, (_, i) => {
-        const d = days[i] || {};
-        const date = new Date(today.getTime() + i * 24 * 60 * 60 * 1000);
+        const d = forecast[i] || {};
+        const fallbackDate = new Date(today.getTime() + i * 24 * 60 * 60 * 1000);
         return {
-            label: i === 0 ? 'Hoy' : formatDay(date),
-            tempC: typeof d.temp === 'number' ? d.temp : null,
-            precipMm: typeof d.precip === 'number' ? d.precip : null,
+            label: dayLabel(d.date || fallbackDate, i),
+            tempMaxC: typeof d.temp_max_c === 'number' ? d.temp_max_c : null,
+            tempMinC: typeof d.temp_min_c === 'number' ? d.temp_min_c : null,
+            precipMm: typeof d.precip_mm === 'number' ? d.precip_mm : null,
         };
     });
 
-    const hasReal = filled.some((d) => d.tempC != null);
+    const hasReal = filled.some((d) => d.tempMaxC != null);
+    const headerLabel = (municipio || '').split(',')[0] || 'tu finca';
 
     return (
         <div className="bg-gradient-to-br from-sky-950/70 to-indigo-950/60 backdrop-blur-xl border border-sky-800/40 rounded-2xl p-5">
@@ -140,11 +203,11 @@ export default function ClimaStrip({ onNavigate }) {
                 <div className="flex items-center gap-2 min-w-0">
                     <Cloud size={20} className="text-sky-300 shrink-0" />
                     <h3 className="text-base font-bold text-white truncate">
-                        Clima en {municipio.split(',')[0]}
+                        Clima en {headerLabel}
                     </h3>
                 </div>
                 <span className="text-[10px] text-sky-300/70 font-bold uppercase tracking-wider shrink-0">
-                    IDEAM · 7 días
+                    Open-Meteo · 7 días
                 </span>
             </div>
 
@@ -156,16 +219,19 @@ export default function ClimaStrip({ onNavigate }) {
 
             <div className="grid grid-cols-7 gap-1.5 sm:gap-2">
                 {filled.map((d, i) => {
-                    const Icon = pickIcon(d.precipMm ?? 0, d.tempC ?? 18);
+                    const Icon = pickIcon(d.precipMm, d.tempMaxC);
                     return (
                         <div
                             key={i}
                             className="flex flex-col items-center gap-1 py-2.5 rounded-xl bg-white/[0.04] border border-white/[0.06]"
                         >
                             <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wide">{d.label}</span>
-                            <Icon size={22} className={d.precipMm >= 10 ? 'text-sky-400' : d.precipMm >= 2 ? 'text-slate-300' : 'text-amber-300'} />
-                            {d.tempC != null && (
-                                <span className="text-sm font-bold text-white tabular-nums">{Math.round(d.tempC)}°</span>
+                            <Icon size={22} className={(d.precipMm ?? 0) >= 10 ? 'text-sky-400' : (d.precipMm ?? 0) >= 2 ? 'text-slate-300' : 'text-amber-300'} />
+                            {d.tempMaxC != null && (
+                                <span className="text-sm font-bold text-white tabular-nums">{Math.round(d.tempMaxC)}°</span>
+                            )}
+                            {d.tempMinC != null && (
+                                <span className="text-[10px] text-slate-400 tabular-nums">{Math.round(d.tempMinC)}°</span>
                             )}
                         </div>
                     );
@@ -175,7 +241,7 @@ export default function ClimaStrip({ onNavigate }) {
             <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
                 <div className="flex items-center gap-1.5 text-slate-300">
                     <Thermometer size={14} className="text-rose-400" />
-                    <span className="truncate">Temp</span>
+                    <span className="truncate">Máx/Mín</span>
                 </div>
                 <div className="flex items-center gap-1.5 text-slate-300">
                     <Droplets size={14} className="text-sky-400" />

--- a/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
+++ b/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
@@ -18,10 +18,22 @@ import '@testing-library/jest-dom';
 import { describe, test, expect, vi } from 'vitest';
 import ClimaStrip from '../ClimaStrip';
 
-// Mock del sidecar para que el componente no intente fetch real.
-vi.mock('../../../services/sidecarClient', () => ({
-    getClimaIdeam: vi.fn(() => Promise.resolve(null)),
+// Mock de climaService para que el componente no haga fetch real al sidecar.
+// Default: sin snapshot (Open-Meteo no disponible). Los tests del pronóstico
+// real lo sobreescriben con `mockResolvedValueOnce`.
+vi.mock('../../../services/climaService', () => ({
+    fetchClimaSnapshot: vi.fn(() => Promise.resolve(null)),
+    getCachedClimaSnapshot: vi.fn(() => null),
 }));
+import { fetchClimaSnapshot } from '../../../services/climaService';
+
+// findMunicipio es real (dataset DANE local) salvo donde un test necesite
+// controlar el match. Mockeamos para tener coords deterministas y evitar
+// acoplar el test a la presencia de un municipio puntual en el dataset.
+vi.mock('../../../utils/colombiaLocations', () => ({
+    findMunicipio: vi.fn(() => null),
+}));
+import { findMunicipio } from '../../../utils/colombiaLocations';
 
 // Mock del store de finca para forzar el branch "sin municipio".
 vi.mock('../../../services/fincaActiveStore', () => {
@@ -93,12 +105,13 @@ describe('ClimaStrip — botón "Configurar ubicación" (bug fix Brave 2026-05-2
  */
 describe('ClimaStrip — municipio desde perfil (bug fix store mismatch 2026-05-30)', () => {
     test('NO muestra "Configurar ubicación" si el perfil tiene municipio', async () => {
-        getProfile.mockReturnValueOnce({ municipio: 'Choachí' });
+        getProfile.mockReturnValue({ municipio: 'Choachí' });
         render(<ClimaStrip onNavigate={vi.fn()} />);
-        // Esperar a que el efecto de carga resuelva (getClimaIdeam mock → null).
+        // Esperar a que el efecto de carga resuelva (fetchClimaSnapshot mock → null).
         await waitFor(() =>
             expect(screen.queryByText('Configurar ubicación')).not.toBeInTheDocument(),
         );
+        getProfile.mockReturnValue({});
     });
 
     test('refresca al recibir el evento "chagra:location-updated"', async () => {
@@ -113,6 +126,86 @@ describe('ClimaStrip — municipio desde perfil (bug fix store mismatch 2026-05-
         await waitFor(() =>
             expect(screen.queryByText('Configurar ubicación')).not.toBeInTheDocument(),
         );
+        getProfile.mockReturnValue({});
+    });
+});
+
+/**
+ * Bug fix 2026-05-30 — el operador reportó que el widget de clima "no funciona"
+ * (no mostraba datos reales). Causa: ClimaStrip pedía `get_clima_ideam('monthly_avg')`,
+ * que es climatología histórica y devolvía VACÍO (la ingesta IDEAM nunca se
+ * pobló). Fix: reapuntar a Open-Meteo (`fetchClimaSnapshot` →
+ * `openmeteo.forecast_7d`), pronóstico real de 7 días por lat/lon.
+ */
+describe('ClimaStrip — pronóstico real Open-Meteo (fix fuente de datos 2026-05-30)', () => {
+    const snapshotConForecast = {
+        openmeteo: {
+            available: true,
+            forecast_7d: [
+                { date: '2026-05-30', temp_max_c: 22.4, temp_min_c: 11.1, precip_mm: 0 },
+                { date: '2026-05-31', temp_max_c: 21.0, temp_min_c: 10.5, precip_mm: 3.2 },
+                { date: '2026-06-01', temp_max_c: 19.8, temp_min_c: 9.9, precip_mm: 14.7 },
+                { date: '2026-06-02', temp_max_c: 23.1, temp_min_c: 12.0, precip_mm: 0.4 },
+                { date: '2026-06-03', temp_max_c: 24.6, temp_min_c: 12.8, precip_mm: 0 },
+                { date: '2026-06-04', temp_max_c: 20.2, temp_min_c: 10.1, precip_mm: 6.5 },
+                { date: '2026-06-05', temp_max_c: 22.0, temp_min_c: 11.3, precip_mm: 1.1 },
+            ],
+        },
+    };
+
+    test('usa coords del perfil (ubicacion_lat/lng) y NO geocodifica', async () => {
+        getProfile.mockReturnValue({
+            municipio: 'Choachí',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+        });
+        findMunicipio.mockClear();
+        fetchClimaSnapshot.mockResolvedValueOnce(snapshotConForecast);
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        await waitFor(() =>
+            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.53, lng: -73.92 }),
+        );
+        // Con coords del perfil NO debe geocodificar el municipio.
+        expect(findMunicipio).not.toHaveBeenCalled();
+        getProfile.mockReturnValue({});
+    });
+
+    test('renderiza temperaturas reales (máx/mín) del forecast', async () => {
+        getProfile.mockReturnValue({ municipio: 'Choachí', ubicacion_lat: 4.53, ubicacion_lng: -73.92 });
+        fetchClimaSnapshot.mockResolvedValueOnce(snapshotConForecast);
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        // Open-Meteo en el header, NO IDEAM.
+        expect(await screen.findByText(/Open-Meteo/i)).toBeInTheDocument();
+        // Temp máxima del día 0 redondeada (22.4 → 22) — hay más de un día a 22°.
+        await waitFor(() => expect(screen.getAllByText('22°').length).toBeGreaterThan(0));
+        // Temp mínima del día 2 redondeada (9.9 → 10).
+        expect(screen.getAllByText('10°').length).toBeGreaterThan(0);
+        // Día con lluvia fuerte (14.7mm el día 2) → ícono de lluvia presente.
+        expect(screen.getByText('25°')).toBeInTheDocument(); // día 4 máx 24.6 → 25
+        getProfile.mockReturnValue({});
+    });
+
+    test('geocodifica el municipio si el perfil no tiene coords', async () => {
+        getProfile.mockReturnValue({ municipio: 'Une' });
+        findMunicipio.mockReturnValueOnce({ name: 'Une', lat: 4.40, lng: -73.99 });
+        fetchClimaSnapshot.mockResolvedValueOnce(snapshotConForecast);
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        await waitFor(() =>
+            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.40, lng: -73.99 }),
+        );
+        getProfile.mockReturnValue({});
+        findMunicipio.mockReturnValue(null);
+    });
+
+    test('degrada limpio (sin romper) si Open-Meteo no está disponible', async () => {
+        getProfile.mockReturnValue({ municipio: 'Choachí', ubicacion_lat: 4.53, ubicacion_lng: -73.92 });
+        fetchClimaSnapshot.mockResolvedValueOnce({ openmeteo: { available: false, reason: 'offline' } });
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        // El strip se muestra (header con municipio) con el aviso de carga, sin
+        // mostrar el CTA de configuración ni lanzar excepción.
+        expect(await screen.findByText(/Clima en/i)).toBeInTheDocument();
+        expect(screen.queryByText('Configurar ubicación')).not.toBeInTheDocument();
+        expect(screen.getByText(/pronóstico fino aún se está cargando/i)).toBeInTheDocument();
         getProfile.mockReturnValue({});
     });
 });


### PR DESCRIPTION
## Bug del operador
El widget de clima 'no funcionaba' — leía de `get_clima_ideam` que devuelve vacío (ingesta IDEAM nunca poblada + es climatología histórica, no pronóstico).

## Fix
ClimaStrip ahora usa `fetchClimaSnapshot({lat,lng})` → `openmeteo.forecast_7d` (pronóstico real 7 días, gratis, sin key). Coords del perfil (`ubicacion_lat/lng`, ya persistidas en #200) o fallback geocode municipio→coords con dataset DANE local (offline-first). Header: 'IDEAM · 7 días' → 'Open-Meteo · 7 días'. Muestra temp máx/mín + precip real por día. Estética conservada. 10/10 tests. El path IDEAM histórico del agente queda intacto.