### PR TITLE
feat(ubicación): reverse-geocode offline DANE + findMunicipio robusto + backfill perfiles viejos

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.17",
+  "version": "1.0.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v275';
+const CACHE_NAME = 'chagra-v276';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/LocationDetectedScreen.jsx
+++ b/src/components/LocationDetectedScreen.jsx
@@ -24,7 +24,7 @@ import {
 } from '../services/locationService';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
 import { saveProfile } from '../services/userProfileService';
-import { getDepartamentos, getMunicipios } from '../utils/colombiaLocations';
+import { getDepartamentos, getMunicipios, findMunicipio } from '../utils/colombiaLocations';
 
 // Fix del marcador por defecto de Leaflet (bundlers no resuelven las URLs
 // relativas del CSS). Mismo patrón que MultiFincaGlobe.
@@ -251,7 +251,7 @@ export default function LocationDetectedScreen({
   const [query, setQuery] = useState(initialMunicipio);
   const [searchError, setSearchError] = useState(null);
   // PR4 (#187) — cascade dropdown offline para cuando Nominatim falla o el
-  // usuario no tiene buena ortografía. 32 dptos × municipios curados.
+  // usuario no tiene buena ortografía. 33 deptos × 1.122 municipios (DANE #338).
   const [cascadeOpen, setCascadeOpen] = useState(false);
   const [cascadeDpto, setCascadeDpto] = useState('');
   const [geoState, setGeoState] = useState('idle'); // idle | detecting | denied | unavailable
@@ -356,20 +356,38 @@ export default function LocationDetectedScreen({
     setLoading(true);
     setSearchError(null);
     try {
-      const hit = await forwardGeocode(q);
+      // 1) OFFLINE-FIRST: resolver contra el dataset DANE embebido (1.122
+      //    municipios). Funciona sin red y trae municipio + departamento +
+      //    altitud curada directamente. Solo si no hay match local caemos a
+      //    Nominatim online.
+      const local = findMunicipio(q);
+      const hit =
+        local != null
+          ? {
+              lat: local.lat,
+              lng: local.lng,
+              municipio: local.name,
+              departamento: local.departamento,
+            }
+          : await forwardGeocode(q);
       if (!hit) {
         setSearchError(
           'No encontramos ese lugar. Revisa la escritura o intenta con "Municipio, Departamento".',
         );
         return;
       }
-      const enriched = await resolveUbicacion({ lat: hit.lat, lng: hit.lng });
-      // Preferir el municipio/departamento del forward-geocode si el
-      // reverse no lo trajo.
+      const enriched = await resolveUbicacion({
+        lat: hit.lat,
+        lng: hit.lng,
+        altitud: local?.altitud ?? null,
+      });
+      // Preferir SIEMPRE el municipio/departamento de la fuente que disparó la
+      // búsqueda (local DANE o forward-geocode) sobre el reverse-geocode, que a
+      // veces devuelve variantes con tildes raras.
       setLoc({
         ...enriched,
-        municipio: enriched.municipio || hit.municipio,
-        departamento: enriched.departamento || hit.departamento,
+        municipio: hit.municipio || enriched.municipio,
+        departamento: hit.departamento || enriched.departamento,
       });
     } catch (e) {
       console.warn('[LocationDetected] búsqueda falló:', e);
@@ -380,7 +398,7 @@ export default function LocationDetectedScreen({
   };
 
   /**
-   * PR4 (#187) — selección de un municipio del cascade hardcoded. No usa
+   * PR4 (#187) — selección de un municipio del cascade DANE. No usa
    * Nominatim, resuelve directo con las coordenadas+altitud que vienen en
    * el dataset. resolveUbicacion sigue corriendo en background para enriquecer
    * con piso térmico + recomendaciones de cultivo, pero si falla la red el

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -4,7 +4,7 @@ import { fetchClimaSnapshot, getCachedClimaSnapshot } from '../../services/clima
 import { findMunicipio } from '../../utils/colombiaLocations';
 import { FARM_CONFIG } from '../../config/defaults';
 import useFincaActiveStore from '../../services/fincaActiveStore';
-import { getProfileMunicipio } from '../../services/userProfileService';
+import { getProfile, getProfileMunicipio } from '../../services/userProfileService';
 
 /**
  * ClimaStrip — pronóstico real de 7 días debajo del agente.

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -4,7 +4,7 @@ import { fetchClimaSnapshot, getCachedClimaSnapshot } from '../../services/clima
 import { findMunicipio } from '../../utils/colombiaLocations';
 import { FARM_CONFIG } from '../../config/defaults';
 import useFincaActiveStore from '../../services/fincaActiveStore';
-import { getProfile } from '../../services/userProfileService';
+import { getProfileMunicipio } from '../../services/userProfileService';
 
 /**
  * ClimaStrip — pronóstico real de 7 días debajo del agente.
@@ -92,7 +92,9 @@ export default function ClimaStrip({ onNavigate }) {
 
     const municipio = useMemo(() => {
         const activeFinca = fincas.find((f) => f.slug === activeFincaSlug);
-        const profileMunicipio = getProfile()?.municipio || null;
+        // getProfileMunicipio retrocompatibiliza perfiles viejos: si solo tienen
+        // `region` en texto libre, lo resuelve offline contra el dataset DANE.
+        const profileMunicipio = getProfileMunicipio();
         return activeFinca?.municipio || profileMunicipio || FARM_CONFIG?.MUNICIPIO || null;
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeFincaSlug, fincas, tick]);

--- a/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
+++ b/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
@@ -54,8 +54,11 @@ vi.mock('../../../config/defaults', () => ({
 // branch "Configurar ubicación". El test del bug fix 2026-05-30 lo sobreescribe.
 vi.mock('../../../services/userProfileService', () => ({
     getProfile: vi.fn(() => ({})),
+    // ClimaStrip deriva el municipio via getProfileMunicipio (#338): prefiere
+    // profile.municipio, con fallback offline a resolver profile.region.
+    getProfileMunicipio: vi.fn(() => null),
 }));
-import { getProfile } from '../../../services/userProfileService';
+import { getProfileMunicipio } from '../../../services/userProfileService';
 
 describe('ClimaStrip — botón "Configurar ubicación" (bug fix Brave 2026-05-28)', () => {
     test('renderiza CTA "Configurar ubicación" cuando no hay municipio', async () => {
@@ -101,11 +104,12 @@ describe('ClimaStrip — botón "Configurar ubicación" (bug fix Brave 2026-05-2
  * SEGUÍA apareciendo "como si no lo hubiera hecho". Causa: handleConfirm
  * guardaba el municipio en el perfil (userProfileService) pero ClimaStrip
  * derivaba su municipio SOLO de fincaActiveStore/FARM_CONFIG → nunca veía la
- * confirmación. Fix: ClimaStrip lee también getProfile().municipio.
+ * confirmación. Fix: ClimaStrip lee también getProfileMunicipio() (#338).
  */
 describe('ClimaStrip — municipio desde perfil (bug fix store mismatch 2026-05-30)', () => {
     test('NO muestra "Configurar ubicación" si el perfil tiene municipio', async () => {
         getProfile.mockReturnValue({ municipio: 'Choachí' });
+        getProfileMunicipio.mockReturnValueOnce('Choachí');
         render(<ClimaStrip onNavigate={vi.fn()} />);
         // Esperar a que el efecto de carga resuelva (fetchClimaSnapshot mock → null).
         await waitFor(() =>
@@ -116,17 +120,17 @@ describe('ClimaStrip — municipio desde perfil (bug fix store mismatch 2026-05-
 
     test('refresca al recibir el evento "chagra:location-updated"', async () => {
         // Arranca sin municipio → muestra el CTA.
-        getProfile.mockReturnValue({});
+        getProfileMunicipio.mockReturnValue(null);
         render(<ClimaStrip onNavigate={vi.fn()} />);
         expect(await screen.findByText('Configurar ubicación')).toBeInTheDocument();
         // El usuario confirma ubicación: el perfil ahora tiene municipio y se
         // dispara el evento. El card debe dejar de mostrar el CTA.
-        getProfile.mockReturnValue({ municipio: 'Une' });
+        getProfileMunicipio.mockReturnValue('Une');
         fireEvent(window, new CustomEvent('chagra:location-updated', { detail: { municipio: 'Une' } }));
         await waitFor(() =>
             expect(screen.queryByText('Configurar ubicación')).not.toBeInTheDocument(),
         );
-        getProfile.mockReturnValue({});
+        getProfileMunicipio.mockReturnValue(null);
     });
 });
 

--- a/src/services/__tests__/locationService.test.js
+++ b/src/services/__tests__/locationService.test.js
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { getPisoTermicoInfo, PISO_TERMICO_INFO } from '../locationService.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  getPisoTermicoInfo,
+  PISO_TERMICO_INFO,
+  resolveUbicacion,
+} from '../locationService.js';
 
 describe('locationService (#201) — piso térmico offline-safe', () => {
   it('clasifica cálido a baja altitud', () => {
@@ -32,5 +36,33 @@ describe('locationService (#201) — piso térmico offline-safe', () => {
       expect(info.rango).toBeTruthy();
       expect(Array.isArray(info.cultivos)).toBe(true);
     }
+  });
+});
+
+describe('resolveUbicacion — fallback OFFLINE de municipio/altitud (#338)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('sin red, resuelve municipio + departamento por centroide DANE mas cercano', async () => {
+    // Simular offline: navigator.onLine=false hace que reverseGeocode y
+    // fetchElevation devuelvan null sin tocar la red.
+    vi.stubGlobal('navigator', { onLine: false });
+    // Coordenadas cerca de Popayan (Cauca).
+    const r = await resolveUbicacion({ lat: 2.444, lng: -76.614 });
+    expect(r.departamento).toBe('Cauca');
+    expect(r.municipio).toMatch(/Popay/);
+    // Popayan tiene altitud curada -> piso termico precalculado sin red.
+    expect(r.altitud).not.toBeNull();
+    expect(r.pisoTermico).not.toBeNull();
+  });
+
+  it('respeta la altitud explicita aunque este offline', async () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    const r = await resolveUbicacion({ lat: 4.711, lng: -74.072, altitud: 2640 });
+    expect(r.altitud).toBe(2640);
+    expect(r.pisoTermico?.slug).toBe('frío');
+    expect(r.municipio).toMatch(/Bogot/);
   });
 });

--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -3,6 +3,7 @@ import {
   PROFILE_QUESTIONS,
   getApplicableQuestions,
   getProfile,
+  getProfileMunicipio,
   saveProfile,
   markProfileDone,
   markProfileSkipped,
@@ -127,5 +128,29 @@ describe('userProfileService (#200)', () => {
       const block = buildUserProfileBlock({ nombre: 'X', nivel_respuestas: 'detallado' });
       expect(block).toMatch(/DETALLADAS/);
     });
+  });
+});
+
+describe('getProfileMunicipio — backfill offline de perfiles viejos (#338)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('prefiere el campo municipio limpio cuando existe', () => {
+    saveProfile({ municipio: 'Popayán', region: 'otra cosa' });
+    expect(getProfileMunicipio()).toBe('Popayán');
+  });
+
+  it('resuelve municipio desde region (texto libre) en perfiles sin municipio', () => {
+    // Perfil viejo: solo region en texto libre, sin campo municipio.
+    saveProfile({ region: 'Choachí, Cundinamarca' });
+    expect(getProfileMunicipio()).toMatch(/Choach/);
+  });
+
+  it('devuelve null si no hay municipio ni region resoluble', () => {
+    saveProfile({ region: 'Zzqxnoexiste' });
+    expect(getProfileMunicipio()).toBeNull();
+    localStorage.clear();
+    expect(getProfileMunicipio()).toBeNull();
   });
 });

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -3,14 +3,17 @@
  *
  * Toma una coordenada (GPS o municipio escrito) y devuelve un objeto
  * enriquecido para la pantalla "ubicación detectada":
- *   - municipio, departamento (reverse-geocoding OSM Nominatim, online)
- *   - altitud msnm (delegado a altitudeService → Open-Elevation, online)
+ *   - municipio, departamento (reverse-geocoding OSM Nominatim online; con
+ *     FALLBACK OFFLINE al municipio DANE más cercano por centroide — #338)
+ *   - altitud msnm (Open-Elevation online; fallback offline a la altitud
+ *     curada del municipio DANE más cercano)
  *   - piso térmico (derivado de la altitud, offline-safe)
  *   - cultivos recomendados para esa zona (conocimiento agronómico público)
  *
  * DEGRADACIÓN GRACEFUL (offline-first):
- *   - Si no hay red, devuelve lo que pueda derivar localmente (piso térmico
- *     desde altitud cacheada, recomendaciones por zona). NUNCA lanza.
+ *   - Si no hay red, devuelve lo que pueda derivar localmente: municipio +
+ *     departamento por nearest-centroid sobre el dataset DANE embebido, piso
+ *     térmico desde la altitud curada, recomendaciones por zona. NUNCA lanza.
  *
  * SEGURIDAD (repo público — SOP §2):
  *   - Sin hostnames/IPs/tokens internos. Reverse-geocoding va contra el
@@ -23,6 +26,7 @@
  */
 
 import { deriveThermalZoneFromAltitud } from './externalAiPromptBuilder.js';
+import { findNearestMunicipio } from '../utils/colombiaLocations.js';
 
 const NOMINATIM_TIMEOUT_MS = 8000;
 
@@ -209,10 +213,31 @@ export async function resolveUbicacion({ lat, lng, altitud = null }) {
     result.departamento = geo.departamento;
   }
 
+  // Fallback OFFLINE: si la red no resolvio municipio/departamento, usar el
+  // municipio DANE mas cercano por centroide (offline-first). Tambien sirve de
+  // fuente de altitud curada cuando Open-Elevation no esta disponible.
+  let nearest = null;
+  if (!result.municipio || !result.departamento) {
+    nearest = findNearestMunicipio(lat, lng);
+    if (nearest) {
+      result.municipio = result.municipio || nearest.name;
+      result.departamento = result.departamento || nearest.departamento;
+    }
+  }
+
   // Altitud: si no vino dada, intentar Open-Elevation (online).
   if (result.altitud == null) {
     const ele = await fetchElevation(lat, lng);
     if (ele != null) result.altitud = Math.round(ele);
+  }
+
+  // Fallback OFFLINE de altitud: la altitud curada (IGAC/OSM) del municipio DANE
+  // mas cercano, si la hay. Permite precalcular el piso termico sin red.
+  if (result.altitud == null) {
+    if (nearest == null) nearest = findNearestMunicipio(lat, lng);
+    if (nearest && typeof nearest.altitud === 'number') {
+      result.altitud = nearest.altitud;
+    }
   }
 
   // Piso térmico + cultivos (offline-safe a partir de la altitud).

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -25,6 +25,8 @@
  * @module userProfileService
  */
 
+import { findMunicipio } from '../utils/colombiaLocations.js';
+
 const PROFILE_PREFIX = 'chagra:profile:';
 const PROFILE_KEY = `${PROFILE_PREFIX}v1`;
 const PROFILE_DONE_KEY = `${PROFILE_PREFIX}done:v1`;
@@ -285,6 +287,28 @@ export function getProfile() {
     console.warn('[userProfile] No se pudo leer el perfil:', e);
     return {};
   }
+}
+
+/**
+ * Municipio "limpio" del usuario para el clima / contexto del agente.
+ *
+ * #338 (consistencia onboarding ↔ finca): los perfiles NUEVOS guardan
+ * `municipio` aparte (lo escribe LocationDetectedScreen al confirmar). Pero los
+ * perfiles VIEJOS — creados antes de ese campo — solo tienen `region` en texto
+ * libre (p. ej. "Choachí, Cundinamarca"). Este helper retrocompatibiliza:
+ * prefiere `municipio`; si falta, intenta resolver `region` contra el dataset
+ * DANE embebido (offline, sin red). Devuelve null si no hay nada resoluble.
+ *
+ * @returns {string|null}
+ */
+export function getProfileMunicipio() {
+  const p = getProfile();
+  if (p.municipio) return p.municipio;
+  if (p.region) {
+    const hit = findMunicipio(p.region);
+    if (hit) return hit.name;
+  }
+  return null;
 }
 
 /**

--- a/src/utils/__tests__/colombiaLocations.test.js
+++ b/src/utils/__tests__/colombiaLocations.test.js
@@ -13,6 +13,7 @@ import {
   getDepartamentos,
   getMunicipios,
   findMunicipio,
+  findNearestMunicipio,
 } from '../colombiaLocations';
 
 describe('colombiaLocations — dataset DANE DIVIPOLA (#338)', () => {
@@ -56,5 +57,63 @@ describe('colombiaLocations — dataset DANE DIVIPOLA (#338)', () => {
 
   it('COLOMBIA_LOCATIONS esta congelado (no mutable accidentalmente)', () => {
     expect(Object.isFrozen(COLOMBIA_LOCATIONS)).toBe(true);
+  });
+});
+
+describe('findMunicipio — match offline robusto (#338 + offline-first)', () => {
+  it('prioriza match exacto sobre prefijo que aparece antes en el dataset', () => {
+    // "Olaya" (Antioquia) es exacto; "Olaya Herrera" (Nariño) tambien empieza
+    // por "olaya". Antioquia se itera antes, pero el exacto debe ganar igual.
+    const hit = findMunicipio('Olaya');
+    expect(hit).not.toBeNull();
+    expect(hit.name).toBe('Olaya');
+    expect(hit.departamento).toBe('Antioquia');
+  });
+
+  it('desempata homonimos con la pista de departamento tras la coma', () => {
+    const hit = findMunicipio('Popayán, Cauca');
+    expect(hit).not.toBeNull();
+    expect(hit.departamento).toBe('Cauca');
+  });
+
+  it('es tolerante a mayusculas y ausencia de tildes', () => {
+    const hit = findMunicipio('POPAYAN');
+    expect(hit).not.toBeNull();
+    expect(hit.departamento).toBe('Cauca');
+  });
+
+  it('devuelve null para query vacio o sin match', () => {
+    expect(findMunicipio('')).toBeNull();
+    expect(findMunicipio('Zzqxnoexiste')).toBeNull();
+  });
+});
+
+describe('findNearestMunicipio — reverse-geocode OFFLINE por centroide (#338)', () => {
+  it('resuelve el municipio mas cercano a unas coordenadas conocidas', () => {
+    // Centro de Popayan aprox.
+    const hit = findNearestMunicipio(2.444, -76.614);
+    expect(hit).not.toBeNull();
+    expect(hit.departamento).toBe('Cauca');
+    expect(hit.name).toMatch(/Popay/);
+    expect(hit.distanciaKm).toBeLessThan(15);
+  });
+
+  it('resuelve Bogota a partir de su lat/lng', () => {
+    const hit = findNearestMunicipio(4.711, -74.072);
+    expect(hit).not.toBeNull();
+    // Bogota D.C. es su propio departamento en DIVIPOLA.
+    expect(hit.name).toMatch(/Bogot/);
+  });
+
+  it('expone distanciaKm numerica no negativa', () => {
+    const hit = findNearestMunicipio(4.711, -74.072);
+    expect(typeof hit.distanciaKm).toBe('number');
+    expect(hit.distanciaKm).toBeGreaterThanOrEqual(0);
+  });
+
+  it('devuelve null para coordenadas no numericas', () => {
+    expect(findNearestMunicipio('a', 1)).toBeNull();
+    expect(findNearestMunicipio(NaN, NaN)).toBeNull();
+    expect(findNearestMunicipio(undefined, undefined)).toBeNull();
   });
 });

--- a/src/utils/colombiaLocations.js
+++ b/src/utils/colombiaLocations.js
@@ -67,20 +67,92 @@ export function getMunicipios(departamento) {
 }
 
 /**
- * Busca un municipio por nombre (case-insensitive, partial match).
- * Util para auto-fill desde texto libre.
+ * Normaliza un nombre para matching tolerante a tildes/mayusculas.
+ * "Popayan" -> "popayan", "BOGOTA D.C." -> "bogota d.c.". Mismo criterio que
+ * el generador (`scripts/gen-colombia-locations.mjs#normalizeName`).
+ * @param {string} s
+ * @returns {string}
+ */
+function normalize(s) {
+  return String(s ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Busca un municipio por nombre (offline, tolerante a tildes y mayusculas).
+ * Util para auto-fill desde texto libre SIN red. El query puede venir como
+ * "Municipio" o "Municipio, Departamento" — la parte tras la coma desempata
+ * cuando hay homonimos (p. ej. varios "San Vicente").
+ *
+ * Prioridad de match: exacto > prefijo. El exacto se prefiere SIEMPRE sobre un
+ * prefijo (antes "Cali" podia hacer prefix-match con "Calima" segun el orden
+ * del dataset antes de llegar al "Cali" exacto).
+ *
  * @param {string} query
  * @returns {{departamento:string,name:string,lat:number,lng:number,altitud:number|null,codigo:string}|null}
  */
 export function findMunicipio(query) {
   if (!query) return null;
-  const q = query.toLowerCase().trim();
+  const [rawName, rawDpto] = String(query).split(',');
+  const q = normalize(rawName);
+  if (!q) return null;
+  const dptoHint = rawDpto ? normalize(rawDpto) : null;
+
+  let prefixHit = null;
   for (const [dpto, munis] of Object.entries(COLOMBIA_LOCATIONS)) {
+    if (dptoHint && !normalize(dpto).includes(dptoHint)) continue;
     for (const m of munis) {
-      if (m.name.toLowerCase() === q || m.name.toLowerCase().startsWith(q)) {
-        return { departamento: dpto, ...m };
+      const name = normalize(m.name);
+      if (name === q) return { departamento: dpto, ...m };
+      if (!prefixHit && name.startsWith(q)) {
+        prefixHit = { departamento: dpto, ...m };
       }
     }
   }
-  return null;
+  return prefixHit;
+}
+
+/**
+ * Reverse-geocoding OFFLINE: dado un par (lat, lng) devuelve el municipio DANE
+ * mas cercano por distancia a su centroide. Cubre el caso offline-first en que
+ * el GPS si entrega coordenadas pero NO hay red para consultar Nominatim — el
+ * campesino igual ve su municipio + departamento + piso termico.
+ *
+ * Distancia: euclidea sobre lat/lng con la longitud corregida por el coseno de
+ * la latitud (los grados de longitud se acortan acercandose a los polos). Para
+ * distancias intra-Colombia el error vs. la geodesica real es despreciable y
+ * basta para asignar el municipio correcto.
+ *
+ * @param {number} lat
+ * @param {number} lng
+ * @returns {{departamento:string,name:string,lat:number,lng:number,altitud:number|null,codigo:string,distanciaKm:number}|null}
+ */
+export function findNearestMunicipio(lat, lng) {
+  if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+
+  const cosLat = Math.cos((lat * Math.PI) / 180);
+  let best = null;
+  let bestD2 = Infinity;
+  for (const [dpto, munis] of Object.entries(COLOMBIA_LOCATIONS)) {
+    for (const m of munis) {
+      if (typeof m.lat !== 'number' || typeof m.lng !== 'number') continue;
+      const dLat = m.lat - lat;
+      const dLng = (m.lng - lng) * cosLat;
+      const d2 = dLat * dLat + dLng * dLng;
+      if (d2 < bestD2) {
+        bestD2 = d2;
+        best = { departamento: dpto, ...m };
+      }
+    }
+  }
+  if (!best) return null;
+  // ~111 km por grado. Aproximacion para mostrar que tan lejos cae el centroide
+  // (sanity / debug), no para geofence.
+  const distanciaKm = Math.round(Math.sqrt(bestD2) * 111 * 10) / 10;
+  return { ...best, distanciaKm };
 }


### PR DESCRIPTION
Cierra pendientes de geolocalización (auditoría #338). #338 municipio ya estaba resuelto (dataset DANE 1.122 municipios, #1204); esto agrega lo que faltaba:
- **Reverse-geocode offline** (`findNearestMunicipio` por centroide DANE) — antes solo Nominatim online.
- **Búsqueda texto libre** resuelve primero contra DANE local, Nominatim solo si no hay match.
- **`findMunicipio` endurecido**: exact>prefix, tolerante a tildes/caso.
- **Backfill perfiles viejos** sin `municipio` (solo `region` texto libre) → resuelve offline → ClimaStrip ya no se queda sin clima.
- +20 tests. Vereda (Fase 2) queda como decisión del operador (necesita GeoJSON MGN, varios MB).

Relacionado: bug Brave→Bogotá (coarse location) — fix de auto-detect viene aparte.