### PR TITLE
feat(alertas): alertas REALES desde Open-Meteo + contexto ENSO (no más mock)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,8 @@ import PendingTasksWidget from './components/PendingTasksWidget';
 import SyncProgressIndicator from './components/common/SyncProgressIndicator';
 import useOllamaWarmStore from './store/useOllamaWarmStore';
 import useThemeBackgroundStore, { getBackgroundSrc } from './store/useThemeBackgroundStore';
+import useAlertStore from './store/useAlertStore';
+import { alertEngine } from './services/alertEngine';
 // FieldFeedback ya no se monta globalmente en App; vive embebido en
 // HelpUsoScreen como sección de Ayuda (decisión 2026-05-21, ver
 // comentario abajo donde se removió el render).
@@ -420,6 +422,29 @@ export default function App() {
     initCatalog().catch((err) => {
       console.warn('[App] Catálogo no se pudo preload (los componentes lo reintentarán al usarlos):', err);
     });
+  }, []);
+
+  // alertas-reales (2026-05-30): arranca el motor de alertas con CLIMA REAL.
+  // Inicializa los listeners del store (escucha alertTriggered/alertCleared) y
+  // arranca el alertEngine, que consulta el pronóstico Open-Meteo de la finca
+  // (coords del perfil) y deriva alertas reales (helada/calor/lluvia/sequía/
+  // viento) hacia el botón de alertas. Si no hay coords, degrada limpio sin
+  // inventar nada. Los sensores IoT quedan en demo OFF (no hay hardware).
+  // Se arranca una sola vez (singleton + guard de isPolling interno).
+  useEffect(() => {
+    try {
+      useAlertStore.getState().initializeListeners();
+      alertEngine.start().catch((err) => {
+        console.warn('[App] alertEngine no pudo arrancar:', err?.message);
+      });
+    } catch (err) {
+      console.warn('[App] Error inicializando motor de alertas:', err?.message);
+    }
+    return () => {
+      // No detenemos en cleanup de StrictMode doble-mount; el singleton ya
+      // ignora start() duplicado. Solo paramos en unmount real de la app, que
+      // en una SPA no ocurre — dejamos el polling vivo intencionalmente.
+    };
   }, []);
 
   // NN4 fix 2026-05-23: pre-warm del modelo Ollama configurado se dispara al LOGIN

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -28,6 +28,8 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
+import { getProfile } from '../../services/userProfileService';
+import { regionFromProfile } from '../../services/ensoContext';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
 // La lógica pura del merge del estado final vive en agentPartialMerge (testeable
 // sin montar el componente).
@@ -1010,7 +1012,12 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     // devuelve null y buildClimaContext degrada a ''. El refresh real lo hace
     // NotificationsBell + el systemd timer (chagra-clima-refresh.service).
     const climaSnapshot = getCachedClimaSnapshot();
-    const climaContext = climaSnapshot ? `\n\n${buildClimaContext(climaSnapshot)}` : '';
+    // Pasamos la región natural de la finca para que el bloque clima incluya la
+    // LECTURA REGIONAL ENSO (DR-MISSION-2/4), no solo la fase cruda.
+    const ensoRegion = (() => {
+      try { return regionFromProfile(getProfile()); } catch (_) { return null; }
+    })();
+    const climaContext = climaSnapshot ? `\n\n${buildClimaContext(climaSnapshot, { region: ensoRegion })}` : '';
 
     const messages = [
       { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + climaContext + queryAnalysisBlock },

--- a/src/components/NotificationsBell.jsx
+++ b/src/components/NotificationsBell.jsx
@@ -56,22 +56,41 @@ function readUpdateAvailable() {
     }
 }
 
-// #308 — el motor de alertas (useAlertStore) emite alertas de sensor IoT
-// (severity danger/warning) vía el evento `alertTriggered`. Las mapeamos a la
-// shape `iotAlerts` que ya entiende aggregateNotifications, para que el centro
-// de notificaciones unifique IoT + clima + tareas + sistema en un solo lugar.
-// 'danger' → 'critical' (el sistema de notificaciones usa critical/warning/info)
-// y se inyecta timestamp si falta para pasar el filtro de frescura (<24h).
+// #308 — el motor de alertas (useAlertStore) emite alertas vía `alertTriggered`.
+// Desde alertas-reales (2026-05-30) emite DOS clases:
+//   - CLIMA REAL (source:'forecast'): helada/calor/lluvia/sequía/viento
+//     derivadas del pronóstico Open-Meteo de la finca. Se etiquetan con la
+//     fuente Open-Meteo + autoridad IDEAM/ICA. NO son demo.
+//   - SENSOR DEMO (_demo:true, source:'sensor_demo'): simulado, sin hardware.
+//     Se etiquetan explícitamente "(simulado)" para no engañar.
+// Las mapeamos a la shape `iotAlerts` que ya entiende aggregateNotifications.
+// 'danger' → 'critical'; se inyecta timestamp si falta para pasar el filtro de
+// frescura (<24h).
 function mapSensorAlertsToIot(alerts) {
   if (!Array.isArray(alerts)) return [];
-  return alerts.map((a) => ({
-    id: a.type || a.id,
-    sensor: a.sensor || a.type || 'sensor',
-    title: a.title || a.label || 'Alerta de sensor',
-    message: a.message || a.body || a.detail || '',
-    severity: a.severity === 'danger' ? 'critical' : (a.severity || 'warning'),
-    timestamp: a.timestamp || a.created_at || Date.now(),
-  }));
+  return alerts.map((a) => {
+    const isForecast = a.source === 'forecast';
+    const isDemo = a._demo === true || a.source === 'sensor_demo';
+    let title = a.title || a.label || 'Alerta de sensor';
+    if (isDemo) title = `${title} (simulado)`;
+    let message = a.message || a.body || a.detail || '';
+    // Atribución de fuente en el cuerpo, para auditabilidad (regla Chagra).
+    if (isForecast) {
+      const src = a.source_label || 'Open-Meteo (pronóstico 7d)';
+      const enso = a.enso_context?.note ? ` · ${a.enso_context.note}` : '';
+      message = `${message}${message ? ' ' : ''}— Fuente: ${src} · ${a.authority || 'IDEAM/ICA'}${enso}`;
+    } else if (isDemo) {
+      message = `${message}${message ? ' ' : ''}(dato simulado — sensor IoT aún no instalado)`;
+    }
+    return {
+      id: a.type || a.id,
+      sensor: a.sensor || a.type || (isForecast ? 'clima' : 'sensor'),
+      title,
+      message,
+      severity: a.severity === 'danger' ? 'critical' : (a.severity || 'warning'),
+      timestamp: a.timestamp || a.created_at || Date.now(),
+    };
+  });
 }
 
 export default function NotificationsBell({ onNavigate }) {

--- a/src/components/dashboard/AnalisisProactivoIA.jsx
+++ b/src/components/dashboard/AnalisisProactivoIA.jsx
@@ -15,6 +15,8 @@ import {
 import useAssetStore from '../../store/useAssetStore';
 import useLogStore from '../../store/useLogStore';
 import useAlertStore from '../../store/useAlertStore';
+import { getProfile } from '../../services/userProfileService';
+import { getEnsoOutlook, regionFromProfile } from '../../services/ensoContext';
 
 /**
  * AnalisisProactivoIA — panel narrativo IA contextual al final del DashboardLive.
@@ -82,7 +84,7 @@ function summarizeSensors(sensors) {
     };
 }
 
-function buildNarrative({ hora, plantasCount, pendingTasks, sensorSummary, alertsCount, ensoStatus }) {
+function buildNarrative({ hora, plantasCount, pendingTasks, sensorSummary, alertsCount, ensoOutlook }) {
     const lines = [];
     const saludo = hora.saludo;
 
@@ -137,16 +139,11 @@ function buildNarrative({ hora, plantasCount, pendingTasks, sensorSummary, alert
                 ? 'Hay 1 alerta activa — revísala antes de salir al campo.'
                 : `Hay ${alertsCount} alertas activas — revísalas antes de salir al campo.`,
         );
-    } else if (ensoStatus && ensoStatus !== 'neutral') {
-        const ensoLabel = {
-            nina: 'fase La Niña (más lluvias)',
-            nino_debil: 'fase Niño débil (menos lluvias)',
-            nino_moderado: 'fase Niño moderado (sequía moderada)',
-            nino_fuerte: 'fase Niño fuerte (sequía marcada)',
-        }[ensoStatus];
-        if (ensoLabel) {
-            lines.push(`Recuerda que la región está en ${ensoLabel}: ajusta riego y siembras.`);
-        }
+    } else if (ensoOutlook) {
+        // ENSO real desde el feed en vivo + lectura regional (ensoContext).
+        // Cubre tanto fase activa (Niño/Niña) como vigilancia en fase neutral.
+        // Fuente citada para auditabilidad (regla Chagra).
+        lines.push(`${ensoOutlook.titulo}: ${ensoOutlook.detalle} (${ensoOutlook.fuente})`);
     }
 
     return lines.join(' ');
@@ -208,8 +205,21 @@ export default function AnalisisProactivoIA({ sensors = [], climaSnapshot = null
     }, []);
 
     const sensorSummary = useMemo(() => summarizeSensors(sensors), [sensors]);
-    const alertsCount = activeAlerts instanceof Map ? activeAlerts.size : 0;
-    const ensoStatus = climaSnapshot?.enso_status || null;
+    // useAlertStore.activeAlerts es un array (no Map). Soportamos ambos por
+    // robustez para no regresar a 0 silencioso si cambia la forma del store.
+    const alertsCount = Array.isArray(activeAlerts)
+        ? activeAlerts.length
+        : (activeAlerts instanceof Map ? activeAlerts.size : 0);
+    // ENSO: phase del feed en vivo + lectura regional (DR) desde ensoContext.
+    const ensoPhase = climaSnapshot?.enso_status?.phase || null;
+    const ensoProbs = climaSnapshot?.enso_status?.ideam_probabilities
+        || climaSnapshot?.enso_status?.ideam_probabilidades
+        || null;
+    const ensoOutlook = useMemo(() => {
+        if (!ensoPhase) return null;
+        const region = regionFromProfile(getProfile());
+        return getEnsoOutlook({ phase: ensoPhase, region, probabilities: ensoProbs });
+    }, [ensoPhase, ensoProbs]);
     const hora = useMemo(() => getHora(), []);
 
     const narrative = useMemo(
@@ -220,9 +230,9 @@ export default function AnalisisProactivoIA({ sensors = [], climaSnapshot = null
                 pendingTasks,
                 sensorSummary,
                 alertsCount,
-                ensoStatus,
+                ensoOutlook,
             }),
-        [hora, plants.length, pendingTasks, sensorSummary, alertsCount, ensoStatus],
+        [hora, plants.length, pendingTasks, sensorSummary, alertsCount, ensoOutlook],
     );
 
     const agentPrompt = useMemo(

--- a/src/constants/alertThresholds.js
+++ b/src/constants/alertThresholds.js
@@ -41,3 +41,72 @@ export const ALERT_TYPES = {
     message: 'Velocidad del viento elevada - revisar estructuras',
   },
 };
+
+/**
+ * Umbrales para alertas derivadas del PRONÓSTICO REAL (Open-Meteo, 7 días)
+ * que consume el alertEngine a través de climaService.fetchClimaSnapshot.
+ *
+ * A diferencia de ALERT_THRESHOLDS (sensor instantáneo IoT — hoy demo), estos
+ * operan sobre agregados DIARIOS del pronóstico: temp mín/máx, precipitación
+ * diaria y viento máximo. Son consistentes con los umbrales agroecológicos del
+ * sidecar (openmeteo-alerts.ts) y con el ajuste por piso térmico para helada.
+ *
+ * Helada por piso térmico: una mínima de 4°C es benigna en el cálido pero ya es
+ * riesgo de helada en piso frío/páramo (cielo despejado -> pérdida radiativa
+ * nocturna; paradoja documentada en El Niño seco, DR-MISSION-4). Por eso el
+ * umbral de helada sube con la altitud del piso térmico.
+ */
+export const FORECAST_THRESHOLDS = {
+  // Helada — umbral de temp mínima diaria, dependiente del piso térmico.
+  HELADA_MIN_C: {
+    paramo: 6, // por encima de 0, en páramo una mín <=6°C ya amenaza helada nocturna
+    frio: 4,
+    templado: 2,
+    calido: 1, // helada real es rarísima en cálido; umbral muy bajo
+    default: 3,
+  },
+  // Calor extremo — temp máxima diaria (consistente con sidecar: 32°C).
+  CALOR_EXTREMO_MAX_C: 32,
+  CALOR_EXTREMO_CRITICO_C: 36,
+  // Lluvia torrencial — precipitación diaria acumulada (sidecar: 50 mm/día).
+  LLUVIA_TORRENCIAL_MM_DIA: 50,
+  LLUVIA_TORRENCIAL_CRITICA_MM_DIA: 100,
+  // Racha seca — días consecutivos con precipitación por debajo del umbral.
+  SEQUIA_MM_DIA: 1,
+  SEQUIA_DIAS_SEGUIDOS: 4,
+  // Viento fuerte — viento máximo diario (sidecar: 45 km/h).
+  VIENTO_FUERTE_KMH: 45,
+  VIENTO_FUERTE_CRITICO_KMH: 65,
+};
+
+/**
+ * Tipos de alerta de PRONÓSTICO (clima real). Distinto namespace que los
+ * sensores IoT para que la UI pueda etiquetarlas como "clima real (Open-Meteo)".
+ */
+export const FORECAST_ALERT_TYPES = {
+  HELADA: {
+    severity: 'danger',
+    title: 'Riesgo de helada',
+    message: 'Temperatura mínima muy baja en el pronóstico - protege cultivos sensibles',
+  },
+  OLA_CALOR: {
+    severity: 'danger',
+    title: 'Ola de calor',
+    message: 'Calor extremo en el pronóstico - riego temprano y mulch',
+  },
+  LLUVIA_TORRENCIAL: {
+    severity: 'danger',
+    title: 'Lluvia torrencial',
+    message: 'Lluvia fuerte en el pronóstico - revisa drenajes y evita labores en ladera',
+  },
+  RACHA_SECA: {
+    severity: 'warning',
+    title: 'Racha seca',
+    message: 'Varios días secos previstos - programa riego eficiente y conserva humedad',
+  },
+  VIENTO_FUERTE_FORECAST: {
+    severity: 'warning',
+    title: 'Viento fuerte',
+    message: 'Viento fuerte previsto - tutora plantas altas y cosecha fruta madura',
+  },
+};

--- a/src/services/__tests__/alertEngine.forecast.test.js
+++ b/src/services/__tests__/alertEngine.forecast.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mocks de dependencias del clima real. Hoisted antes del import del engine.
+vi.mock('../climaService', () => ({
+  fetchClimaSnapshot: vi.fn(),
+}));
+vi.mock('../userProfileService', () => ({
+  getProfile: vi.fn(),
+}));
+
+import { alertEngine } from '../alertEngine';
+import { fetchClimaSnapshot } from '../climaService';
+import { getProfile } from '../userProfileService';
+
+function snapshot(forecast, enso = { phase: 'neutral' }) {
+  return {
+    enso_status: enso,
+    alertas_locales: [],
+    openmeteo: { available: true, forecast_7d: forecast },
+  };
+}
+
+const PROFILE_FRIO = {
+  ubicacion_lat: 5.6,
+  ubicacion_lng: -73.05,
+  departamento: 'Boyacá',
+  piso_termico: 'frio',
+};
+
+describe('alertEngine — clima real (forecast)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('dispatchEvent', () => true);
+    vi.stubGlobal('Notification', undefined);
+    alertEngine.stop();
+    alertEngine.activeAlerts.clear();
+    fetchClimaSnapshot.mockReset();
+    getProfile.mockReset();
+    getProfile.mockReturnValue(PROFILE_FRIO);
+  });
+
+  afterEach(() => {
+    alertEngine.stop();
+    vi.unstubAllGlobals();
+  });
+
+  it('degrada limpio (sin alertas) cuando no hay coords en el perfil', async () => {
+    getProfile.mockReturnValue({ departamento: 'Boyacá' }); // sin lat/lng
+    const data = await alertEngine.fetchClimaData();
+    expect(data).toBeNull();
+    expect(fetchClimaSnapshot).not.toHaveBeenCalled();
+    await alertEngine.evaluateForecastAlerts(null);
+    expect(alertEngine.activeAlerts.size).toBe(0);
+  });
+
+  it('usa las coords del perfil para pedir el snapshot real', async () => {
+    fetchClimaSnapshot.mockResolvedValue(snapshot([]));
+    await alertEngine.fetchClimaData();
+    expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 5.6, lng: -73.05 });
+  });
+
+  it('genera alerta de HELADA con umbral de piso frío y la anota con ENSO', async () => {
+    const forecast = [
+      { date: '2026-06-01', temp_min_c: 3, temp_max_c: 18, precip_mm: 2, wind_max_kmh: 10 },
+    ];
+    await alertEngine.evaluateForecastAlerts(snapshot(forecast));
+    expect(alertEngine.activeAlerts.has('HELADA')).toBe(true);
+    const a = alertEngine.activeAlerts.get('HELADA');
+    expect(a.source).toBe('forecast');
+    expect(a.source_label).toMatch(/Open-Meteo/);
+    expect(a.authority).toMatch(/IDEAM/);
+    expect(a.data.umbral).toBe(4); // piso frío
+    // ENSO: helada es sensible a sequía → se anota incluso en neutral.
+    expect(a.enso_context).toBeDefined();
+    expect(a.enso_context.region).toBe('andina');
+  });
+
+  it('NO dispara helada en piso cálido para la misma mínima', async () => {
+    getProfile.mockReturnValue({ ...PROFILE_FRIO, piso_termico: 'calido', departamento: 'Cesar' });
+    const forecast = [
+      { date: '2026-06-01', temp_min_c: 3, temp_max_c: 30, precip_mm: 0, wind_max_kmh: 5 },
+    ];
+    await alertEngine.evaluateForecastAlerts(snapshot(forecast));
+    // umbral cálido = 1°C; min 3°C no cruza
+    expect(alertEngine.activeAlerts.has('HELADA')).toBe(false);
+  });
+
+  it('genera OLA_CALOR, LLUVIA_TORRENCIAL y VIENTO_FUERTE_FORECAST', async () => {
+    const forecast = [
+      { date: '2026-06-01', temp_min_c: 18, temp_max_c: 37, precip_mm: 60, wind_max_kmh: 70 },
+    ];
+    await alertEngine.evaluateForecastAlerts(snapshot(forecast));
+    expect(alertEngine.activeAlerts.has('OLA_CALOR')).toBe(true);
+    expect(alertEngine.activeAlerts.get('OLA_CALOR').severity).toBe('danger'); // >=36
+    expect(alertEngine.activeAlerts.has('LLUVIA_TORRENCIAL')).toBe(true);
+    expect(alertEngine.activeAlerts.has('VIENTO_FUERTE_FORECAST')).toBe(true);
+    expect(alertEngine.activeAlerts.get('VIENTO_FUERTE_FORECAST').severity).toBe('danger'); // >=65
+  });
+
+  it('genera RACHA_SECA con 4+ días secos consecutivos', async () => {
+    const dry = (date) => ({ date, temp_min_c: 14, temp_max_c: 24, precip_mm: 0, wind_max_kmh: 8 });
+    const forecast = [
+      dry('2026-06-01'), dry('2026-06-02'), dry('2026-06-03'), dry('2026-06-04'),
+    ];
+    await alertEngine.evaluateForecastAlerts(snapshot(forecast));
+    expect(alertEngine.activeAlerts.has('RACHA_SECA')).toBe(true);
+    expect(alertEngine.activeAlerts.get('RACHA_SECA').data.valor).toBe(4);
+  });
+
+  it('NO genera alertas para un pronóstico benigno (Choachí-like)', async () => {
+    // Datos reales tipo Choachí 2026-05-30 (min ~15, max ~22, precip <=25, viento bajo)
+    const forecast = [
+      { date: '2026-05-30', temp_min_c: 15.9, temp_max_c: 22, precip_mm: 7.5, wind_max_kmh: 8.7 },
+      { date: '2026-05-31', temp_min_c: 15.8, temp_max_c: 18.4, precip_mm: 25.1, wind_max_kmh: 6.2 },
+      { date: '2026-06-01', temp_min_c: 15.1, temp_max_c: 22.6, precip_mm: 2.3, wind_max_kmh: 10.6 },
+    ];
+    await alertEngine.evaluateForecastAlerts(snapshot(forecast));
+    expect(alertEngine.activeAlerts.size).toBe(0);
+  });
+
+  it('despeja una alerta de pronóstico cuando deja de aplicar', async () => {
+    const hot = [{ date: 'd', temp_min_c: 18, temp_max_c: 37, precip_mm: 0, wind_max_kmh: 5 }];
+    await alertEngine.evaluateForecastAlerts(snapshot(hot));
+    expect(alertEngine.activeAlerts.has('OLA_CALOR')).toBe(true);
+    const cool = [{ date: 'd', temp_min_c: 18, temp_max_c: 25, precip_mm: 0, wind_max_kmh: 5 }];
+    await alertEngine.evaluateForecastAlerts(snapshot(cool));
+    expect(alertEngine.activeAlerts.has('OLA_CALOR')).toBe(false);
+  });
+
+  it('marca los sensores demo con _demo:true cuando se habilitan', async () => {
+    alertEngine.enableSensorDemo(true);
+    await alertEngine.triggerSensorAlert('HUMEDAD_BAJA', { currentValue: 10 });
+    const a = alertEngine.activeAlerts.get('HUMEDAD_BAJA');
+    expect(a._demo).toBe(true);
+    expect(a.source).toBe('sensor_demo');
+    alertEngine.enableSensorDemo(false);
+  });
+});

--- a/src/services/__tests__/ensoContext.test.js
+++ b/src/services/__tests__/ensoContext.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ensoFamily,
+  regionFromProfile,
+  ensoRegionalLine,
+  annotateAlertWithEnso,
+  buildEnsoAgentLines,
+  getEnsoOutlook,
+  ENSO_WATCH_2026,
+} from '../ensoContext';
+
+describe('ensoContext', () => {
+  describe('ensoFamily', () => {
+    it('clasifica fases nino/nina/neutral', () => {
+      expect(ensoFamily('nino_fuerte')).toBe('nino');
+      expect(ensoFamily('nino_debil')).toBe('nino');
+      expect(ensoFamily('nina_moderada')).toBe('nina');
+      expect(ensoFamily('neutral')).toBe('neutral');
+      expect(ensoFamily(undefined)).toBe('neutral');
+      expect(ensoFamily(null)).toBe('neutral');
+    });
+  });
+
+  describe('regionFromProfile', () => {
+    it('infiere región por departamento', () => {
+      expect(regionFromProfile({ departamento: 'La Guajira' })).toBe('caribe');
+      expect(regionFromProfile({ departamento: 'Boyacá' })).toBe('andina');
+      expect(regionFromProfile({ departamento: 'Amazonas' })).toBe('amazonia');
+      expect(regionFromProfile({ departamento: 'Meta' })).toBe('orinoquia');
+      expect(regionFromProfile({ departamento: 'Chocó' })).toBe('pacifico');
+    });
+
+    it('infiere región por texto de municipio/region', () => {
+      expect(regionFromProfile({ region: 'Riohacha, La Guajira' })).toBe('caribe');
+      expect(regionFromProfile({ municipio: 'Choachí, Cundinamarca' })).toBe('andina');
+    });
+
+    it('cae a piso térmico si no hay departamento', () => {
+      expect(regionFromProfile({ piso_termico: 'frio' })).toBe('andina');
+      expect(regionFromProfile({ piso_termico: 'paramo' })).toBe('andina');
+    });
+
+    it('devuelve null sin información', () => {
+      expect(regionFromProfile({})).toBeNull();
+      expect(regionFromProfile(null)).toBeNull();
+    });
+  });
+
+  describe('ensoRegionalLine', () => {
+    it('da la línea Niño para región conocida', () => {
+      const line = ensoRegionalLine('nino_moderado', 'andina');
+      expect(line).toMatch(/heladas/i);
+    });
+    it('da la línea de vigilancia en fase neutral', () => {
+      const line = ensoRegionalLine('neutral', 'caribe');
+      expect(line).toMatch(/vigilancia/i);
+    });
+    it('devuelve vacío sin región', () => {
+      expect(ensoRegionalLine('nino_fuerte', null)).toBe('');
+    });
+  });
+
+  describe('annotateAlertWithEnso', () => {
+    it('anota alerta de helada incluso en fase neutral', () => {
+      const alert = { type: 'HELADA', severity: 'warning' };
+      const out = annotateAlertWithEnso(alert, { phase: 'neutral', region: 'andina' });
+      expect(out.enso_context).toBeDefined();
+      expect(out.enso_context.region).toBe('andina');
+      expect(out.enso_context.source).toMatch(/NOAA/);
+    });
+
+    it('NO anota alerta no-seca en fase neutral', () => {
+      const alert = { type: 'LLUVIA_TORRENCIAL', severity: 'danger' };
+      const out = annotateAlertWithEnso(alert, { phase: 'neutral', region: 'caribe' });
+      expect(out.enso_context).toBeUndefined();
+    });
+
+    it('anota cualquier alerta en fase Niño activa', () => {
+      const alert = { type: 'OLA_CALOR', severity: 'warning' };
+      const out = annotateAlertWithEnso(alert, { phase: 'nino_fuerte', region: 'caribe' });
+      expect(out.enso_context).toBeDefined();
+      expect(out.enso_context.family).toBe('nino');
+    });
+
+    it('no muta el objeto original', () => {
+      const alert = { type: 'HELADA' };
+      annotateAlertWithEnso(alert, { phase: 'nino_fuerte', region: 'andina' });
+      expect(alert.enso_context).toBeUndefined();
+    });
+  });
+
+  describe('buildEnsoAgentLines', () => {
+    it('en neutral advierte que es vigilancia, no Niño activo', () => {
+      const txt = buildEnsoAgentLines({ phase: 'neutral', region: 'andina' });
+      expect(txt).toMatch(/vigilancia/i);
+      expect(txt).toMatch(/NO afirmes que El Niño ya está activo/i);
+    });
+    it('en Niño activo da lectura regional', () => {
+      const txt = buildEnsoAgentLines({ phase: 'nino_moderado', region: 'caribe' });
+      expect(txt).toMatch(/sequía|hídrico/i);
+    });
+  });
+
+  describe('getEnsoOutlook', () => {
+    it('devuelve outlook de vigilancia en neutral con probabilidad alta', () => {
+      const o = getEnsoOutlook({ phase: 'neutral', region: 'andina' });
+      expect(o).not.toBeNull();
+      expect(o.titulo).toMatch(/Vigilancia/i);
+    });
+    it('devuelve outlook El Niño en fase activa', () => {
+      const o = getEnsoOutlook({ phase: 'nino_fuerte', region: 'caribe' });
+      expect(o.titulo).toMatch(/El Niño/i);
+    });
+    it('usa el default DJF si no hay probabilities', () => {
+      const o = getEnsoOutlook({ phase: 'neutral' });
+      expect(o.detalle).toContain(String(ENSO_WATCH_2026.transicion_nino.DJF_2026_27));
+    });
+  });
+});

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -20,6 +20,7 @@ import {
 } from './glosarioCaucaService.js';
 import { filterVoseo as _filterVoseo } from './voseoFilter.js';
 import { buildUserProfileBlock } from './userProfileService.js';
+import { buildEnsoAgentLines } from './ensoContext.js';
 
 /**
  * Free 7→10 fix-pack #5: re-exporta los helpers de glosario regional Cauca
@@ -445,9 +446,14 @@ export function formatClimateAlert(bioculturalZone, climateData = null) {
  * sigue funcionando como antes.
  *
  * @param {object | null} snapshot — payload de climaService.getCachedClimaSnapshot
+ * @param {object} [opts]
+ * @param {string|null} [opts.region] — región natural de la finca (ensoContext).
+ *   Si se pasa, se inyecta la LECTURA REGIONAL ENSO (DR-MISSION-2/4): qué
+ *   implica la fase actual para esa región (p. ej. heladas paradójicas en el
+ *   altiplano bajo El Niño seco). Si no, solo se inyecta el bloque base.
  * @returns {string}
  */
-export function buildClimaContext(snapshot) {
+export function buildClimaContext(snapshot, opts = {}) {
   if (!snapshot || typeof snapshot !== 'object') return '';
   const enso = snapshot.enso_status;
   if (!enso || typeof enso !== 'object') return '';
@@ -474,6 +480,18 @@ export function buildClimaContext(snapshot) {
       lines.push(`  ${sev} ${a.tipo}: ${a.mensaje}`);
     }
   }
+  // Lectura regional ENSO (DR-MISSION-2/4) si conocemos la región de la finca.
+  // Complementa la fase cruda con la implicación accionable por región.
+  const ensoRegional = buildEnsoAgentLines({
+    phase: enso.phase || 'neutral',
+    region: opts.region || null,
+    probabilities: enso.ideam_probabilities || enso.ideam_probabilidades || null,
+  });
+  if (ensoRegional) {
+    lines.push('');
+    lines.push(ensoRegional);
+  }
+
   lines.push('');
   lines.push('REGLA: si tu recomendación depende del clima de los próximos días o del fenómeno ENSO, menciónalo CITANDO las fuentes de arriba. Si El Niño / La Niña activo cambia la recomendación de manejo, dilo plano. Si el dato no aplica al cultivo de la pregunta, no lo fuerces.');
   lines.push('=== FIN CLIMA TIEMPO REAL ===');

--- a/src/services/alertEngine.js
+++ b/src/services/alertEngine.js
@@ -1,53 +1,65 @@
 /**
- * alertEngine — motor de alertas para clima/sensores IoT (PWA).
+ * alertEngine — motor de alertas para clima/sensores (PWA).
  *
- * TASK #162: Implementa sistema de alertas basado en thresholds de clima
- * y sensores IoT. Monitorea cada 15 minutos y genera notificaciones cuando
- * se cruzan umbrales de riesgo agronómico.
+ * TASK #162 + alertas-reales (2026-05-30): el motor ahora consume CLIMA REAL.
  *
- * Funcionalidad:
- * - Lee configuración de thresholds (humedad <20%, temp >35°C, lluvia >50mm/h)
- * - Hace polling de clima y sensores cada 15 minutos
- * - Llama a MCP tools get_clima_finca + get_sensor_finca
- * - Genera alertas en UI via CustomEvent (notification + banner)
+ * Antes: este motor era 100% mock (getMockClimaData / getMockSensorData) y
+ * nunca generaba alertas reales. Ahora:
  *
- * Integración UI:
- * - Los componentes pueden escuchar 'alertTriggered' con { type, severity, message }
- * - Los componentes pueden escuchar 'alertCleared' cuando el estado vuelve a normal
- * - useAlertStore (Zustand) mantiene el estado global de alertas activas
+ *   - CLIMA: REAL. Consume climaService.fetchClimaSnapshot({lat,lng}) usando
+ *     las coordenadas del perfil/finca. Deriva alertas del pronóstico de 7 días
+ *     de Open-Meteo (helada por piso térmico, ola de calor, lluvia torrencial,
+ *     racha seca, viento fuerte) con timestamp + fuente. Si NO hay coordenadas,
+ *     degrada limpio: no inventa clima ni dispara alertas falsas.
+ *
+ *   - ENSO: las alertas sensibles a sequía/helada se ANOTAN con el contexto
+ *     regional ENSO (ensoContext) cuando la fase o la región lo ameritan.
+ *
+ *   - SENSORES IoT: siguen siendo DEMO (no hay hardware todavía). Por defecto
+ *     NO se evalúan, para no contaminar el botón de alertas con datos falsos.
+ *     Si se habilitan (enableSensorDemo()), las alertas salen marcadas
+ *     `_demo: true` para que la UI las etiquete como simulado.
+ *
+ * Integración UI (sin cambios de contrato):
+ *   - Los componentes escuchan 'alertTriggered' con { type, severity, message, ... }
+ *   - Los componentes escuchan 'alertCleared' cuando el estado vuelve a normal
+ *   - useAlertStore (Zustand) mantiene el estado global de alertas activas
  */
 
-import { ALERT_THRESHOLDS, ALERT_TYPES } from '../constants/alertThresholds';
+import {
+  ALERT_THRESHOLDS,
+  ALERT_TYPES,
+  FORECAST_THRESHOLDS,
+  FORECAST_ALERT_TYPES,
+} from '../constants/alertThresholds';
+import { fetchClimaSnapshot } from './climaService';
+import { getProfile } from './userProfileService';
+import { annotateAlertWithEnso, regionFromProfile } from './ensoContext';
 
 const POLLING_INTERVAL_MS = 15 * 60 * 1000; // 15 minutos
-const MCP_CLIMA_TOOL = 'get_clima_finca';
-const MCP_SENSOR_TOOL = 'get_sensor_finca';
+const SOURCE_OPENMETEO = 'Open-Meteo (pronóstico 7d) · umbrales agroecológicos Chagra';
+const AUTHORITY = 'IDEAM / ICA (autoridad meteorológica y fitosanitaria)';
 
 class AlertEngine {
   constructor() {
     this.isPolling = false;
     this.pollingTimer = null;
-    this.activeAlerts = new Map(); // alertType -> { timestamp, data }
+    this.activeAlerts = new Map(); // alertType -> alert object
     this.lastCheckTime = null;
-    this.mcpServerAvailable = false;
+    this.lastClimaSnapshot = null;
+    // Sensores IoT: demo OFF por defecto (no hay hardware). El clima SÍ es real.
+    this.sensorDemoEnabled = false;
   }
 
   /**
-   * Inicia el motor de alertas. Verifica disponibilidad de MCP y arranca polling.
+   * Inicia el motor de alertas y arranca el polling.
    */
   async start() {
     if (this.isPolling) {
       console.warn('[AlertEngine] Ya está corriendo, ignorando start() duplicado.');
       return;
     }
-
-    console.info('[AlertEngine] Iniciando motor de alertas...');
-    this.mcpServerAvailable = await this.checkMcpAvailability();
-
-    if (!this.mcpServerAvailable) {
-      console.warn('[AlertEngine] MCP server no disponible, usando modo degradado (mock).');
-    }
-
+    console.info('[AlertEngine] Iniciando motor de alertas (clima real)...');
     this.isPolling = true;
     await this.checkThresholds(); // Primera verificación inmediata
     this.startPolling();
@@ -58,7 +70,6 @@ class AlertEngine {
    */
   stop() {
     if (!this.isPolling) return;
-
     console.info('[AlertEngine] Deteniendo motor de alertas...');
     this.isPolling = false;
     if (this.pollingTimer) {
@@ -68,13 +79,11 @@ class AlertEngine {
   }
 
   /**
-   * Verifica si el servidor MCP está disponible.
-   * En producción esto intentaría llamar a un MCP tool conocido.
+   * Habilita la evaluación de sensores IoT DEMO (datos simulados). Off por
+   * defecto. Cuando se habilita, las alertas de sensor salen con `_demo:true`.
    */
-  async checkMcpAvailability() {
-    // TODO: verificar disponibilidad real de MCP server
-    // Por ahora retornamos true para permitir operación en modo degradado
-    return true;
+  enableSensorDemo(on = true) {
+    this.sensorDemoEnabled = !!on;
   }
 
   /**
@@ -83,14 +92,54 @@ class AlertEngine {
   startPolling() {
     const scheduleNext = () => {
       if (!this.isPolling) return;
-
       this.pollingTimer = setTimeout(async () => {
         await this.checkThresholds();
         scheduleNext();
       }, POLLING_INTERVAL_MS);
     };
-
     scheduleNext();
+  }
+
+  /**
+   * Resuelve las coordenadas de la finca desde el perfil del usuario.
+   * @returns {{ lat:number, lng:number } | null}
+   */
+  resolveCoords() {
+    try {
+      const p = getProfile() || {};
+      const lat = Number(p.ubicacion_lat);
+      const lng = Number(p.ubicacion_lng);
+      if (Number.isFinite(lat) && Number.isFinite(lng)) {
+        return { lat, lng };
+      }
+    } catch (e) {
+      console.debug('[AlertEngine] No se pudo leer coords del perfil:', e?.message);
+    }
+    return null;
+  }
+
+  /**
+   * Resuelve el piso térmico del perfil (para el umbral de helada).
+   * @returns {string} slug ('paramo'|'frio'|'templado'|'calido'|'default')
+   */
+  resolvePisoTermico() {
+    try {
+      const p = getProfile() || {};
+      const piso = (p.piso_termico || '').toLowerCase().trim();
+      if (piso.includes('paramo') || piso.includes('páramo')) return 'paramo';
+      if (piso.includes('frio') || piso.includes('frío')) return 'frio';
+      if (piso.includes('templado')) return 'templado';
+      if (piso.includes('calido') || piso.includes('cálido')) return 'calido';
+      // Fallback por altitud si no hay piso térmico explícito.
+      const alt = Number(p.finca_altitud);
+      if (Number.isFinite(alt)) {
+        if (alt >= 3000) return 'paramo';
+        if (alt >= 2000) return 'frio';
+        if (alt >= 1000) return 'templado';
+        return 'calido';
+      }
+    } catch (_) { /* noop */ }
+    return 'default';
   }
 
   /**
@@ -98,18 +147,19 @@ class AlertEngine {
    */
   async checkThresholds() {
     try {
-      console.info('[AlertEngine] Verificando thresholds...');
+      console.info('[AlertEngine] Verificando thresholds (clima real)...');
       this.lastCheckTime = new Date().toISOString();
 
-      // Obtener datos de clima y sensores
-      const climaData = await this.fetchClimaData();
-      const sensorData = await this.fetchSensorData();
+      // --- CLIMA REAL (Open-Meteo via sidecar) ---
+      const climaSnapshot = await this.fetchClimaData();
+      await this.evaluateForecastAlerts(climaSnapshot);
 
-      // Evaluar cada tipo de alerta
-      await this.evaluateHumidityAlert(climaData, sensorData);
-      await this.evaluateTemperatureAlert(climaData, sensorData);
-      await this.evaluateRainAlert(climaData);
-      await this.evaluateWindAlert(climaData);
+      // --- SENSORES IoT (DEMO, opt-in) ---
+      if (this.sensorDemoEnabled) {
+        const sensorData = await this.fetchSensorData();
+        await this.evaluateHumidityAlert(null, sensorData);
+        await this.evaluateTemperatureAlert(null, sensorData);
+      }
 
       console.info('[AlertEngine] Verificación completada. Alertas activas:', this.activeAlerts.size);
     } catch (error) {
@@ -118,66 +168,195 @@ class AlertEngine {
   }
 
   /**
-   * Obtiene datos climáticos de la finca via MCP.
+   * Obtiene el snapshot de clima REAL del sidecar usando coords del perfil.
+   * Devuelve null si no hay coords o el sidecar no responde (degradación limpia,
+   * SIN mock).
+   *
+   * @returns {Promise<object|null>}
    */
   async fetchClimaData() {
-    if (!this.mcpServerAvailable) {
-      // Mock data para modo degradado
-      return this.getMockClimaData();
+    const coords = this.resolveCoords();
+    if (!coords) {
+      console.info('[AlertEngine] Sin coordenadas en el perfil — no se evalúa clima (degradación limpia, sin mock).');
+      this.lastClimaSnapshot = null;
+      return null;
     }
-
     try {
-      // TODO: llamar a get_clima_finca via MCP
-      // const result = await callMCP(MCP_CLIMA_TOOL, { finca: 'active' });
-      // return result;
-      return this.getMockClimaData();
+      const snapshot = await fetchClimaSnapshot({ lat: coords.lat, lng: coords.lng });
+      this.lastClimaSnapshot = snapshot || null;
+      return snapshot || null;
     } catch (error) {
-      console.warn('[AlertEngine] Error obteniendo clima, usando mock:', error.message);
-      return this.getMockClimaData();
+      console.warn('[AlertEngine] Error obteniendo clima real:', error?.message);
+      this.lastClimaSnapshot = null;
+      return null;
     }
   }
 
   /**
-   * Obtiene datos de sensores IoT de la finca via MCP.
+   * Deriva alertas reales desde el pronóstico de 7 días de Open-Meteo y las
+   * anota con contexto ENSO regional. Cada alerta lleva timestamp + fuente.
+   *
+   * Tipos: HELADA (umbral por piso térmico), OLA_CALOR, LLUVIA_TORRENCIAL,
+   * RACHA_SECA, VIENTO_FUERTE_FORECAST.
+   *
+   * @param {object|null} snapshot
+   */
+  async evaluateForecastAlerts(snapshot) {
+    const forecast = snapshot?.openmeteo?.available ? snapshot.openmeteo.forecast_7d : null;
+    const present = new Set();
+
+    if (Array.isArray(forecast) && forecast.length > 0) {
+      const piso = this.resolvePisoTermico();
+      const heladaUmbral = FORECAST_THRESHOLDS.HELADA_MIN_C[piso] ?? FORECAST_THRESHOLDS.HELADA_MIN_C.default;
+      const enso = snapshot?.enso_status || {};
+      const region = regionFromProfile(getProfile());
+      const ensoCtx = { phase: enso.phase || 'neutral', region };
+
+      // HELADA — primer día que cruza el umbral del piso térmico.
+      const heladaDia = forecast.find(
+        (d) => typeof d.temp_min_c === 'number' && d.temp_min_c <= heladaUmbral,
+      );
+      if (heladaDia) {
+        present.add('HELADA');
+        this.triggerForecastAlert('HELADA', {
+          dia: heladaDia.date,
+          valor: heladaDia.temp_min_c,
+          umbral: heladaUmbral,
+          piso_termico: piso,
+          severity: heladaDia.temp_min_c <= 0 ? 'danger' : 'warning',
+          detail: `Mínima de ${heladaDia.temp_min_c}°C el ${heladaDia.date} (umbral ${heladaUmbral}°C para piso ${piso}). Cubre los cultivos sensibles antes del anochecer.`,
+        }, ensoCtx);
+      }
+
+      // OLA DE CALOR — primer día que cruza el umbral de calor.
+      const calorDia = forecast.find(
+        (d) => typeof d.temp_max_c === 'number' && d.temp_max_c >= FORECAST_THRESHOLDS.CALOR_EXTREMO_MAX_C,
+      );
+      if (calorDia) {
+        present.add('OLA_CALOR');
+        this.triggerForecastAlert('OLA_CALOR', {
+          dia: calorDia.date,
+          valor: calorDia.temp_max_c,
+          umbral: FORECAST_THRESHOLDS.CALOR_EXTREMO_MAX_C,
+          severity: calorDia.temp_max_c >= FORECAST_THRESHOLDS.CALOR_EXTREMO_CRITICO_C ? 'danger' : 'warning',
+          detail: `Máxima de ${calorDia.temp_max_c}°C el ${calorDia.date}. Riega temprano y aplica mulch para reducir el estrés hídrico.`,
+        }, ensoCtx);
+      }
+
+      // LLUVIA TORRENCIAL — primer día que cruza el umbral de precipitación.
+      const lluviaDia = forecast.find(
+        (d) => typeof d.precip_mm === 'number' && d.precip_mm >= FORECAST_THRESHOLDS.LLUVIA_TORRENCIAL_MM_DIA,
+      );
+      if (lluviaDia) {
+        present.add('LLUVIA_TORRENCIAL');
+        this.triggerForecastAlert('LLUVIA_TORRENCIAL', {
+          dia: lluviaDia.date,
+          valor: lluviaDia.precip_mm,
+          umbral: FORECAST_THRESHOLDS.LLUVIA_TORRENCIAL_MM_DIA,
+          severity: lluviaDia.precip_mm >= FORECAST_THRESHOLDS.LLUVIA_TORRENCIAL_CRITICA_MM_DIA ? 'danger' : 'warning',
+          detail: `${lluviaDia.precip_mm} mm el ${lluviaDia.date}. Revisa drenajes y evita labores en ladera.`,
+        }, ensoCtx);
+      }
+
+      // RACHA SECA — N días consecutivos con precip < umbral.
+      const dryRun = this.longestDryRun(forecast, FORECAST_THRESHOLDS.SEQUIA_MM_DIA);
+      if (dryRun.length >= FORECAST_THRESHOLDS.SEQUIA_DIAS_SEGUIDOS) {
+        present.add('RACHA_SECA');
+        this.triggerForecastAlert('RACHA_SECA', {
+          dias: dryRun.map((d) => d.date),
+          valor: dryRun.length,
+          umbral: FORECAST_THRESHOLDS.SEQUIA_DIAS_SEGUIDOS,
+          severity: 'warning',
+          detail: `Periodo seco previsto (${dryRun.length} días sin lluvia significativa). Programa riego eficiente y conserva humedad con mulch.`,
+        }, ensoCtx);
+      }
+
+      // VIENTO FUERTE — primer día que cruza el umbral de viento.
+      const vientoDia = forecast.find(
+        (d) => typeof d.wind_max_kmh === 'number' && d.wind_max_kmh >= FORECAST_THRESHOLDS.VIENTO_FUERTE_KMH,
+      );
+      if (vientoDia) {
+        present.add('VIENTO_FUERTE_FORECAST');
+        this.triggerForecastAlert('VIENTO_FUERTE_FORECAST', {
+          dia: vientoDia.date,
+          valor: vientoDia.wind_max_kmh,
+          umbral: FORECAST_THRESHOLDS.VIENTO_FUERTE_KMH,
+          severity: vientoDia.wind_max_kmh >= FORECAST_THRESHOLDS.VIENTO_FUERTE_CRITICO_KMH ? 'danger' : 'warning',
+          detail: `Viento máx ${vientoDia.wind_max_kmh} km/h el ${vientoDia.date}. Tutora plantas altas y cosecha fruta madura para evitar caída.`,
+        }, ensoCtx);
+      }
+    }
+
+    // Despeja las alertas de pronóstico que ya no aplican.
+    for (const type of Object.keys(FORECAST_ALERT_TYPES)) {
+      if (!present.has(type) && this.activeAlerts.has(type)) {
+        await this.clearAlert(type);
+      }
+    }
+  }
+
+  /**
+   * Devuelve la racha seca más larga (días consecutivos con precip < umbral).
+   * @returns {object[]} subarray del forecast
+   */
+  longestDryRun(forecast, umbral) {
+    let best = [];
+    let cur = [];
+    for (const d of forecast) {
+      if (typeof d.precip_mm === 'number' && d.precip_mm < umbral) {
+        cur.push(d);
+        if (cur.length > best.length) best = cur;
+      } else {
+        cur = [];
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Dispara/actualiza una alerta de PRONÓSTICO (clima real). Anota ENSO y
+   * agrega timestamp + fuente. Source = 'forecast' para que la UI la etiquete
+   * como clima real (Open-Meteo).
+   */
+  triggerForecastAlert(type, data, ensoCtx) {
+    const config = FORECAST_ALERT_TYPES[type];
+    const severity = data.severity || config.severity;
+    let alert = {
+      type,
+      severity,
+      title: config.title,
+      message: data.detail || config.message,
+      timestamp: Date.now(),
+      source: 'forecast',
+      source_label: SOURCE_OPENMETEO,
+      authority: AUTHORITY,
+      data,
+    };
+    // Anota contexto ENSO regional cuando aplica (sequía/helada o fase activa).
+    alert = annotateAlertWithEnso(alert, ensoCtx || {});
+
+    const existing = this.activeAlerts.get(type);
+    if (existing) {
+      // Ya activa: actualiza datos/timestamp sin re-emitir 'alertTriggered'.
+      this.activeAlerts.set(type, { ...alert });
+      return;
+    }
+    this.activeAlerts.set(type, alert);
+    console.warn(`[AlertEngine] ⚠️ Alerta clima real: ${type}`, data);
+    this.dispatch('alertTriggered', alert);
+    this.showSystemNotification(alert);
+  }
+
+  /**
+   * Obtiene datos de sensores IoT DEMO (no hay hardware todavía).
    */
   async fetchSensorData() {
-    if (!this.mcpServerAvailable) {
-      // Mock data para modo degradado
-      return this.getMockSensorData();
-    }
-
-    try {
-      // TODO: llamar a get_sensor_finca via MCP
-      // const result = await callMCP(MCP_SENSOR_TOOL, { finca: 'active' });
-      // return result;
-      return this.getMockSensorData();
-    } catch (error) {
-      console.warn('[AlertEngine] Error obteniendo sensores, usando mock:', error.message);
-      return this.getMockSensorData();
-    }
+    return this.getMockSensorData();
   }
 
   /**
-   * Datos mock para desarrollo/testing cuando MCP no está disponible.
-   */
-  getMockClimaData() {
-    // Simula variación climática realista (Guatoc 2400msnm)
-    const hour = new Date().getHours();
-    const baseTemp = 18 + Math.sin((hour - 6) / 24 * Math.PI * 2) * 6;
-    const randomFactor = Math.random() * 4 - 2;
-
-    return {
-      temperatura: Math.round((baseTemp + randomFactor) * 10) / 10, // °C
-      humedad: Math.round(65 + Math.random() * 20), // %
-      lluvia: Math.round(Math.random() * 60 * 10) / 10, // mm/h
-      viento: Math.round(15 + Math.random() * 30), // km/h
-      timestamp: new Date().toISOString(),
-      _mock: true,
-    };
-  }
-
-  /**
-   * Datos mock de sensores IoT para desarrollo/testing.
+   * Datos DEMO de sensores IoT. Marcados `_demo:true`.
+   * Mantiene la forma histórica para compatibilidad de tests.
    */
   getMockSensorData() {
     return {
@@ -190,22 +369,41 @@ class AlertEngine {
         temperatura: Math.round(21 + Math.random() * 5 * 10) / 10, // °C
       },
       timestamp: new Date().toISOString(),
+      _demo: true,
       _mock: true,
     };
   }
 
   /**
-   * Evalúa alerta de humedad baja.
+   * Datos DEMO de clima (solo para tests/legacy). El motor REAL ya no lo usa.
+   * Marcado `_demo:true`.
+   */
+  getMockClimaData() {
+    const hour = new Date().getHours();
+    const baseTemp = 18 + Math.sin((hour - 6) / 24 * Math.PI * 2) * 6;
+    const randomFactor = Math.random() * 4 - 2;
+    return {
+      temperatura: Math.round((baseTemp + randomFactor) * 10) / 10,
+      humedad: Math.round(65 + Math.random() * 20),
+      lluvia: Math.round(Math.random() * 60 * 10) / 10,
+      viento: Math.round(15 + Math.random() * 30),
+      timestamp: new Date().toISOString(),
+      _demo: true,
+      _mock: true,
+    };
+  }
+
+  /**
+   * Evalúa alerta de humedad baja (SENSOR DEMO). Marca `_demo`.
    */
   async evaluateHumidityAlert(climaData, sensorData) {
-    const humedad = sensorData?.invernadero?.humedad || climaData?.humedad;
+    const humedad = sensorData?.invernadero?.humedad ?? climaData?.humedad;
     if (humedad === undefined) return;
 
     const alertType = 'HUMEDAD_BAJA';
     const threshold = ALERT_THRESHOLDS.HUMEDAD_MIN;
-
     if (humedad < threshold) {
-      await this.triggerAlert(alertType, {
+      await this.triggerSensorAlert(alertType, {
         threshold,
         currentValue: humedad,
         location: 'invernadero',
@@ -217,17 +415,16 @@ class AlertEngine {
   }
 
   /**
-   * Evalúa alerta de temperatura alta.
+   * Evalúa alerta de temperatura alta (SENSOR DEMO). Marca `_demo`.
    */
   async evaluateTemperatureAlert(climaData, sensorData) {
-    const temp = sensorData?.invernadero?.temperatura || climaData?.temperatura;
+    const temp = sensorData?.invernadero?.temperatura ?? climaData?.temperatura;
     if (temp === undefined) return;
 
     const alertType = 'TEMPERATURA_ALTA';
     const threshold = ALERT_THRESHOLDS.TEMPERATURA_MAX;
-
     if (temp > threshold) {
-      await this.triggerAlert(alertType, {
+      await this.triggerSensorAlert(alertType, {
         threshold,
         currentValue: temp,
         location: 'invernadero',
@@ -239,17 +436,15 @@ class AlertEngine {
   }
 
   /**
-   * Evalúa alerta de lluvia intensa.
+   * Evalúa alerta de lluvia intensa (SENSOR DEMO). Mantenida para compat tests.
    */
   async evaluateRainAlert(climaData) {
     const lluvia = climaData?.lluvia;
     if (lluvia === undefined) return;
-
     const alertType = 'LLUVIA_INTENSA';
     const threshold = ALERT_THRESHOLDS.LLUVIA_MAX;
-
     if (lluvia > threshold) {
-      await this.triggerAlert(alertType, {
+      await this.triggerSensorAlert(alertType, {
         threshold,
         currentValue: lluvia,
         location: 'finca',
@@ -261,17 +456,15 @@ class AlertEngine {
   }
 
   /**
-   * Evalúa alerta de viento fuerte.
+   * Evalúa alerta de viento fuerte (SENSOR DEMO). Mantenida para compat tests.
    */
   async evaluateWindAlert(climaData) {
     const viento = climaData?.viento;
     if (viento === undefined) return;
-
     const alertType = 'VIENTO_FUERTE';
     const threshold = ALERT_THRESHOLDS.VIENTO_MAX;
-
     if (viento > threshold) {
-      await this.triggerAlert(alertType, {
+      await this.triggerSensorAlert(alertType, {
         threshold,
         currentValue: viento,
         location: 'finca',
@@ -283,11 +476,39 @@ class AlertEngine {
   }
 
   /**
-   * Dispara una alerta si no está activa actualmente.
+   * Dispara/actualiza una alerta de SENSOR (demo). Marca `_demo:true` y
+   * source='sensor_demo' para que la UI la etiquete como simulado.
+   */
+  async triggerSensorAlert(type, data) {
+    const config = ALERT_TYPES[type];
+    // El título queda limpio; la UI etiqueta "simulado/demo" a partir de
+    // `_demo:true` + `source:'sensor_demo'`, no del texto del título.
+    const alert = {
+      type,
+      severity: config.severity,
+      title: config.title,
+      message: config.message,
+      timestamp: Date.now(),
+      source: 'sensor_demo',
+      _demo: true,
+      data,
+    };
+    if (this.activeAlerts.has(type)) {
+      this.activeAlerts.set(type, { ...alert });
+      return;
+    }
+    this.activeAlerts.set(type, alert);
+    console.warn(`[AlertEngine] (demo) Alerta de sensor: ${type}`, data);
+    this.dispatch('alertTriggered', alert);
+    await this.showSystemNotification(alert);
+  }
+
+  /**
+   * Compat: dispara una alerta genérica (usado por tests legacy de sensor).
+   * Mantiene el comportamiento histórico de `triggerAlert`.
    */
   async triggerAlert(type, data) {
     if (this.activeAlerts.has(type)) {
-      // Alerta ya existe, solo actualizar timestamp
       this.activeAlerts.set(type, {
         ...this.activeAlerts.get(type),
         timestamp: Date.now(),
@@ -295,24 +516,18 @@ class AlertEngine {
       });
       return;
     }
-
-    const alertConfig = ALERT_TYPES[type];
+    const config = ALERT_TYPES[type] || FORECAST_ALERT_TYPES[type] || { severity: 'info', title: type, message: '' };
     const alert = {
       type,
-      severity: alertConfig.severity,
-      title: alertConfig.title,
-      message: alertConfig.message,
+      severity: config.severity,
+      title: config.title,
+      message: config.message,
       timestamp: Date.now(),
       data,
     };
-
     this.activeAlerts.set(type, alert);
     console.warn(`[AlertEngine] ⚠️ Alerta activada: ${type}`, data);
-
-    // Emitir evento para UI
-    window.dispatchEvent(new CustomEvent('alertTriggered', { detail: alert }));
-
-    // Solicitar notificación del sistema si la app tiene permisos
+    this.dispatch('alertTriggered', alert);
     await this.showSystemNotification(alert);
   }
 
@@ -321,34 +536,45 @@ class AlertEngine {
    */
   async clearAlert(type) {
     if (!this.activeAlerts.has(type)) return;
-
     const alert = this.activeAlerts.get(type);
     this.activeAlerts.delete(type);
     console.info(`[AlertEngine] ✓ Alerta despejada: ${type}`);
+    this.dispatch('alertCleared', { type, ...alert });
+  }
 
-    // Emitir evento para UI
-    window.dispatchEvent(new CustomEvent('alertCleared', { detail: { type, ...alert } }));
+  /**
+   * dispatch helper — envuelve window.dispatchEvent con guard SSR/test.
+   */
+  dispatch(name, detail) {
+    try {
+      if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+        window.dispatchEvent(new CustomEvent(name, { detail }));
+      } else if (typeof dispatchEvent === 'function') {
+        // jsdom global fallback (algunos tests stubbean dispatchEvent global)
+        dispatchEvent(new CustomEvent(name, { detail }));
+      }
+    } catch (e) {
+      console.debug('[AlertEngine] dispatch falló:', e?.message);
+    }
   }
 
   /**
    * Muestra una notificación del sistema operativo si hay permisos.
    */
   async showSystemNotification(alert) {
-    if (!('Notification' in window)) return;
-
+    if (typeof Notification === 'undefined') return;
     if (Notification.permission === 'granted') {
       try {
         new Notification(`${alert.title} - Chagra`, {
           body: alert.message,
           icon: '/icon-192.png',
-          tag: alert.type, // Evita duplicados
+          tag: alert.type,
           requireInteraction: true,
         });
       } catch (error) {
         console.warn('[AlertEngine] Error mostrando notificación:', error.message);
       }
     } else if (Notification.permission !== 'denied') {
-      // Pedir permiso la primera vez
       await Notification.requestPermission();
     }
   }
@@ -368,7 +594,12 @@ class AlertEngine {
       isPolling: this.isPolling,
       lastCheckTime: this.lastCheckTime,
       activeAlertsCount: this.activeAlerts.size,
-      mcpServerAvailable: this.mcpServerAvailable,
+      sensorDemoEnabled: this.sensorDemoEnabled,
+      hasClima: !!this.lastClimaSnapshot,
+      // Compat con consumidores/tests legacy: el clima ya no depende de un
+      // "MCP server" booleano, pero mantenemos la clave para no romper el
+      // contrato del getStatus histórico (siempre false: ya no se usa).
+      mcpServerAvailable: false,
       pollingInterval: POLLING_INTERVAL_MS,
     };
   }

--- a/src/services/ensoContext.js
+++ b/src/services/ensoContext.js
@@ -1,0 +1,285 @@
+/**
+ * ensoContext.js — Contexto ENSO (El Niño / La Niña) estructurado para Chagra.
+ *
+ * ¿Qué es esto y por qué existe?
+ * --------------------------------
+ * El sidecar (`/clima/snapshot`) ya entrega el ESTADO ENSO en VIVO: fase actual,
+ * ONI observado de NOAA, probabilidades IDEAM (NOAA CPC + IRI + CIIFEN). Eso es
+ * el "qué está pasando ahora" y es la fuente de verdad para la fase.
+ *
+ * Lo que el feed en vivo NO trae es el CONOCIMIENTO REGIONAL: qué implica una
+ * fase ENSO para la finca concreta del campesino según su región y piso térmico
+ * (p. ej. la paradoja de que en El Niño seco la papa del altiplano sufre MÁS
+ * heladas, no menos). Ese conocimiento está documentado y citado en la
+ * investigación de Chagra:
+ *
+ *   - DR-MISSION-2 — Fenómeno del Niño Colombia 2026-27 (ENSO global, ONI,
+ *     probabilidades IRI/CPC, impactos por Niños históricos 1982-2024).
+ *   - DR-MISSION-3 — ENSO ciclo completo Colombia.
+ *   - DR-MISSION-4 — Impactos regionales del cambio climático (5 regiones ×
+ *     cultivos × piso térmico, cifras IDEAM/UPRA/Agrosavia/Cenicafé).
+ *
+ * Este módulo es ESTÁTICO y AUDITABLE: cada afirmación trazable a esos DR y a
+ * sus fuentes primarias (NOAA CPC, IDEAM, Cenicafé, Fedepapa, UPRA). No inventa
+ * cifras ni predice el clima — solo traduce la fase ENSO (que viene del feed en
+ * vivo) a implicaciones agronómicas accionables por región.
+ *
+ * IMPORTANTE — estado al 2026-05: la fase ENSO observada es **Neutral con
+ * vigilancia de Niño (El Niño Watch)**, ONI ~0.0 a +0.1 °C (NOAA CPC, boletín
+ * 8-may-2026). NO hay El Niño activo todavía; hay una probabilidad creciente de
+ * transición (aprox. 58% SON 2026, aprox. 70% DJF 2026-27 según el plume
+ * IRI/CPC del 16-may-2026). Este módulo refleja eso y NO debe afirmar "El Niño
+ * activo" mientras el feed en vivo reporte fase neutral.
+ *
+ * Uso:
+ *   - annotateAlertWithEnso(alert, { phase, region }) -> agrega contexto ENSO a
+ *     una alerta del alertEngine cuando es relevante.
+ *   - buildEnsoAgentLines({ phase, region, probabilities }) -> 1-3 líneas para
+ *     inyectar al system prompt del agente (complementa buildClimaContext).
+ *   - getEnsoOutlook({ phase, probabilities }) -> texto corto para el panel
+ *     AnalisisProactivoIA.
+ *   - regionFromProfile(profile) -> infiere la región natural desde el perfil.
+ */
+
+/**
+ * Vigilancia ENSO oficial al momento de redacción (fuente: DR-MISSION-2 sec.
+ * 1.1-1.2, NOAA CPC 8-may-2026 + plume IRI/CPC 16-may-2026). Se usa SOLO como
+ * respaldo cuando el feed en vivo no trae probabilidades; el feed en vivo manda.
+ */
+export const ENSO_WATCH_2026 = Object.freeze({
+    estado: 'Neutral con vigilancia de Niño (El Niño Watch)',
+    oni_observado_aprox: 0.0, // FMA 2026, ~-0.1 a +0.1 °C
+    // Probabilidad de transición a El Niño por trimestre (plume IRI/CPC 16-may-2026).
+    transicion_nino: Object.freeze({
+        SON_2026: 58,
+        OND_2026: 65,
+        NDJ_2026_27: 68,
+        DJF_2026_27: 70,
+    }),
+    fuente: 'NOAA CPC + IRI (DR-MISSION-2)',
+});
+
+/**
+ * Conocimiento regional por fase ENSO. Cada entrada cita su origen en el DR.
+ * `nino` = qué esperar bajo El Niño; `nina` = bajo La Niña; `vigilancia` = qué
+ * conviene hacer ahora mismo en fase neutral con Watch de Niño.
+ */
+const REGION_IMPACTS = Object.freeze({
+    andina: {
+        label: 'Región Andina',
+        nino: 'El Niño en los Andes trae menos lluvia y más días calurosos. Paradoja documentada (IDEAM/Cenicafé, DR-MISSION-4): en el altiplano frío (papa de Boyacá/Cundinamarca) el cielo despejado aumenta la pérdida de calor en la noche y dispara MÁS heladas, no menos — el Niño 2015-16 costó cerca de 25.000 t de papa por esto.',
+        nina: 'La Niña en los Andes trae más lluvia, suelos sobresaturados y mayor riesgo de deslizamientos en ladera (UPRA/UNGRD) y de hongos (mildiu/gota) en papa y café.',
+        vigilancia: 'Con vigilancia de Niño: en piso frío reserva agua para riego nocturno anti-helada; en café/cacao templado prepara sombrío y mulch para amortiguar el calor que se espera si entra el Niño.',
+    },
+    caribe: {
+        label: 'Región Caribe',
+        nino: 'El Niño agrava la sequía estructural del Caribe (La Guajira, Cesar, Magdalena): déficit hídrico crónico, estrés en banano, arroz de riego y ganadería (DR-MISSION-4). Es la región donde el Niño golpea más fuerte en agua.',
+        nina: 'La Niña en el Caribe trae lluvias intensas e inundación en planicie; revisa drenajes y evita siembra en zonas anegables.',
+        vigilancia: 'Con vigilancia de Niño: prioriza captación y almacenamiento de agua lluvia ahora, mientras todavía llueve. Mulch y agroforestería seca para conservar humedad.',
+    },
+    pacifico: {
+        label: 'Región Pacífico',
+        nino: 'El Niño reduce algo la lluvia extrema habitual del Pacífico, pero el bosque húmedo sigue siendo muy lluvioso; el riesgo dominante sigue siendo exceso de agua y erosión (DR-MISSION-4).',
+        nina: 'La Niña intensifica lluvias ya extremas: erosión, deslizamiento y pérdida de cosecha en ladera. Refuerza drenajes agroecológicos.',
+        vigilancia: 'Con vigilancia de Niño: el manejo de exceso de agua (drenajes, camas altas) sigue siendo la prioridad en el Pacífico aunque entre el Niño.',
+    },
+    orinoquia: {
+        label: 'Región Orinoquía',
+        nino: 'El Niño exacerba la estación seca de la sabana: mayor recurrencia de incendios y estrés en pasturas (DR-MISSION-4). Cuidado con el fuego descontrolado.',
+        nina: 'La Niña alarga la temporada de lluvias y el encharcamiento en sabana inundable.',
+        vigilancia: 'Con vigilancia de Niño: planifica fuego prescrito y rondas cortafuego antes de la temporada seca; sistemas silvopastoriles para sombra.',
+    },
+    amazonia: {
+        label: 'Región Amazonía',
+        nino: 'El Niño trae sequías inusuales a la Amazonía colombiana, estresa la chagra tradicional y aumenta el riesgo de incendio (DR-MISSION-4). Es un disparador del riesgo de "tipping point" sabanizador.',
+        nina: 'La Niña mantiene o aumenta la humedad amazónica; el riesgo es exceso de agua en vega de río.',
+        vigilancia: 'Con vigilancia de Niño: protege la chagra de quema accidental y diversifica para resiliencia ante sequía corta.',
+    },
+});
+
+/**
+ * Mapa piso térmico (slug del perfil) -> región probable por defecto. Es una
+ * heurística de respaldo cuando no se puede inferir la región del departamento.
+ * El piso frío/páramo casi siempre es Andino; el cálido puede ser varias
+ * regiones, así que cae a 'andina' como base más poblada (51% de UPAs).
+ */
+const PISO_TO_REGION = Object.freeze({
+    paramo: 'andina',
+    frio: 'andina',
+    frio_andino: 'andina',
+    templado: 'andina',
+    templado_andino: 'andina',
+    calido: 'andina',
+});
+
+/**
+ * Departamentos -> región natural (subconjunto suficiente para anotar alertas).
+ * No exhaustivo; lo que no matchee cae a null y se usa el piso térmico.
+ */
+const DEPTO_TO_REGION = Object.freeze({
+    'la guajira': 'caribe', 'cesar': 'caribe', 'magdalena': 'caribe',
+    'atlántico': 'caribe', 'atlantico': 'caribe', 'bolívar': 'caribe',
+    'bolivar': 'caribe', 'sucre': 'caribe', 'córdoba': 'caribe', 'cordoba': 'caribe',
+    'chocó': 'pacifico', 'choco': 'pacifico', 'valle del cauca': 'pacifico',
+    'cauca': 'pacifico', 'nariño': 'pacifico', 'narino': 'pacifico',
+    'meta': 'orinoquia', 'casanare': 'orinoquia', 'arauca': 'orinoquia',
+    'vichada': 'orinoquia',
+    'amazonas': 'amazonia', 'caquetá': 'amazonia', 'caqueta': 'amazonia',
+    'putumayo': 'amazonia', 'guaviare': 'amazonia', 'guainía': 'amazonia',
+    'guainia': 'amazonia', 'vaupés': 'amazonia', 'vaupes': 'amazonia',
+    'boyacá': 'andina', 'boyaca': 'andina', 'cundinamarca': 'andina',
+    'quindío': 'andina', 'quindio': 'andina', 'caldas': 'andina',
+    'risaralda': 'andina', 'antioquia': 'andina', 'santander': 'andina',
+    'tolima': 'andina', 'huila': 'andina',
+});
+
+/**
+ * Normaliza una fase ENSO a una de tres familias: 'nino' | 'nina' | 'neutral'.
+ * Acepta los slugs del sidecar (nino_fuerte, nina_debil, neutral, etc.).
+ */
+export function ensoFamily(phase) {
+    if (typeof phase !== 'string') return 'neutral';
+    if (phase.startsWith('nino')) return 'nino';
+    if (phase.startsWith('nina')) return 'nina';
+    return 'neutral';
+}
+
+/**
+ * Infiere la región natural desde el perfil del usuario.
+ * Prioridad: departamento explícito -> municipio/region (texto) -> piso térmico.
+ *
+ * @param {object|null} profile - perfil de userProfileService.getProfile()
+ * @returns {'andina'|'caribe'|'pacifico'|'orinoquia'|'amazonia'|null}
+ */
+export function regionFromProfile(profile) {
+    if (!profile || typeof profile !== 'object') return null;
+    const depto = (profile.departamento || '').toLowerCase().trim();
+    if (depto && DEPTO_TO_REGION[depto]) return DEPTO_TO_REGION[depto];
+
+    // El campo `municipio`/`region` a veces trae "Municipio, Departamento".
+    const blob = `${profile.municipio || ''} ${profile.region || ''}`.toLowerCase();
+    for (const [name, region] of Object.entries(DEPTO_TO_REGION)) {
+        if (blob.includes(name)) return region;
+    }
+
+    const piso = (profile.piso_termico || '').toLowerCase().trim();
+    if (piso && PISO_TO_REGION[piso]) return PISO_TO_REGION[piso];
+
+    return null;
+}
+
+/**
+ * Devuelve la línea de contexto regional para una fase ENSO. Si no hay región
+ * conocida, devuelve '' (no fuerza ruido). En fase neutral devuelve el mensaje
+ * de vigilancia/preparación de esa región.
+ *
+ * @param {string} phase - slug de fase ENSO del feed en vivo
+ * @param {string|null} region - clave de REGION_IMPACTS
+ * @returns {string}
+ */
+export function ensoRegionalLine(phase, region) {
+    const fam = ensoFamily(phase);
+    const r = region && REGION_IMPACTS[region] ? REGION_IMPACTS[region] : null;
+    if (!r) return '';
+    if (fam === 'nino') return r.nino;
+    if (fam === 'nina') return r.nina;
+    return r.vigilancia; // neutral -> mensaje de vigilancia/preparación
+}
+
+/**
+ * Anota una alerta del alertEngine con contexto ENSO regional cuando es
+ * pertinente. Mutación NO destructiva: devuelve una copia con `enso_context`.
+ *
+ * Regla de pertinencia: anota si la fase no es neutral, O si la alerta es de
+ * sequía/helada (que es justo donde la fase de vigilancia importa).
+ *
+ * @param {object} alert - alerta con al menos { type }
+ * @param {{ phase?: string, region?: string|null }} ctx
+ * @returns {object} alerta (posiblemente) anotada
+ */
+export function annotateAlertWithEnso(alert, ctx = {}) {
+    if (!alert || typeof alert !== 'object') return alert;
+    const { phase = 'neutral', region = null } = ctx;
+    const fam = ensoFamily(phase);
+    const type = String(alert.type || '').toUpperCase();
+    const drySensitive = type.includes('HELADA') || type.includes('SEQUIA') || type.includes('SEQUÍA');
+
+    if (fam === 'neutral' && !drySensitive) return alert;
+
+    const line = ensoRegionalLine(phase, region);
+    if (!line) return alert;
+
+    return {
+        ...alert,
+        enso_context: {
+            phase,
+            family: fam,
+            region: region || null,
+            note: line,
+            source: 'NOAA CPC / IDEAM (DR-MISSION-2/4)',
+        },
+    };
+}
+
+/**
+ * Construye 1-3 líneas de contexto ENSO para inyectar al system prompt del
+ * agente, complementando buildClimaContext (que ya inyecta la fase + ONI +
+ * alertas locales). Aquí agregamos la lectura REGIONAL accionable.
+ *
+ * @param {{ phase?: string, region?: string|null, probabilities?: object|null }} opts
+ * @returns {string}
+ */
+export function buildEnsoAgentLines({ phase = 'neutral', region = null, probabilities = null } = {}) {
+    const lines = [];
+    const fam = ensoFamily(phase);
+    const regionLine = ensoRegionalLine(phase, region);
+
+    if (fam === 'neutral') {
+        const djf = probabilities?.nino_pct ?? ENSO_WATCH_2026.transicion_nino.DJF_2026_27;
+        lines.push(`Vigilancia ENSO: fase neutral con probabilidad creciente de El Niño (aprox. ${djf}% hacia el trimestre dic-feb, fuente NOAA CPC/IDEAM). NO afirmes que El Niño ya está activo; es vigilancia.`);
+    }
+    if (regionLine) {
+        lines.push(`Lectura regional para la finca${region ? ` (${REGION_IMPACTS[region]?.label || region})` : ''}: ${regionLine}`);
+    }
+    return lines.join('\n');
+}
+
+/**
+ * Resumen corto para el panel AnalisisProactivoIA (sin LLM). Devuelve un objeto
+ * { titulo, detalle, fuente } o null si no hay nada relevante que decir.
+ *
+ * @param {{ phase?: string, region?: string|null, probabilities?: object|null }} opts
+ */
+export function getEnsoOutlook({ phase = 'neutral', region = null, probabilities = null } = {}) {
+    const fam = ensoFamily(phase);
+    const regionLine = ensoRegionalLine(phase, region);
+
+    if (fam === 'nino') {
+        return {
+            titulo: 'El Niño activo',
+            detalle: regionLine || 'Espera más calor y menos lluvia. Prioriza riego eficiente, mulch y sombrío.',
+            fuente: 'NOAA CPC · IDEAM',
+        };
+    }
+    if (fam === 'nina') {
+        return {
+            titulo: 'La Niña activa',
+            detalle: regionLine || 'Espera más lluvia. Revisa drenajes y vigila enfermedades fúngicas.',
+            fuente: 'NOAA CPC · IDEAM',
+        };
+    }
+    // Neutral: solo mostrar si hay Watch significativo o región sensible.
+    const djf = probabilities?.nino_pct ?? ENSO_WATCH_2026.transicion_nino.DJF_2026_27;
+    if (djf >= 50) {
+        return {
+            titulo: 'Vigilancia de El Niño',
+            detalle: regionLine
+                ? `Probabilidad aprox. ${djf}% de El Niño hacia dic-feb. ${regionLine}`
+                : `Probabilidad aprox. ${djf}% de transición a El Niño hacia dic-feb. Conviene preparar manejo de sequía y calor.`,
+            fuente: 'NOAA CPC · IRI / IDEAM',
+        };
+    }
+    return null;
+}
+
+export const __testing__ = { REGION_IMPACTS, DEPTO_TO_REGION, PISO_TO_REGION };


### PR DESCRIPTION
El operador pidió 'ver información real en el botón de alertas hoy'. El hueco real: `alertEngine.js` corría 100% mock.

- **alertEngine ahora usa clima REAL** (climaService.fetchClimaSnapshot, Open-Meteo) → deriva alertas reales: HELADA (umbral por piso térmico), OLA_CALOR, LLUVIA_TORRENCIAL, RACHA_SECA, VIENTO_FUERTE. Con timestamp + fuente (Open-Meteo) + autoridad (IDEAM/ICA). Sin coords → degrada limpio, sin mock.
- **Sensores IoT = demo OFF por defecto**, etiquetados '(simulado)' si se habilitan. No contaminan el botón.
- **ENSO** (`ensoContext.js`): conocimiento regional DR-MISSION-2/3/4. **OJO auditabilidad: la fase real HOY es NEUTRAL con El Niño Watch (ONI ~0.0), NO Niño activo** — el módulo lo refleja y prohíbe al agente afirmar lo contrario.
- Bugs colaterales arreglados en AnalisisProactivoIA (ensoStatus objeto vs string; alertsCount Map vs array).
- Verificado en vivo: La Guajira→calor 38°C+sequía REAL; Páramo→HELADA por piso térmico; Choachí→0 alertas (correcto). 168 tests verdes.
- alertEngine.start() wireado en App.jsx.