### PR TITLE
feat(agent): cablear /post-validate al chat — badge 'verifica el nombre científico'

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -26,7 +26,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, getClimaIdeam } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, postValidate, getClimaIdeam } from '../../services/sidecarClient';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
 // La lógica pura del merge del estado final vive en agentPartialMerge (testeable
@@ -1364,7 +1364,36 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // del assistant fue grounded contra el catálogo (tool MCP devolvió
       // match) o fue solo generativo del LLM. ChatBubble lee este metadata
       // para renderizar el badge verde/amber/gris (ver computeSourceMetadata).
-      const sourceMetadata = computeSourceMetadata(toolEvidence);
+      let sourceMetadata = computeSourceMetadata(toolEvidence);
+
+      // Capa 2 anti-alucinación — cross-check de contexto (operador 2026-05-30).
+      // Tras generar la respuesta, le pedimos al sidecar que correlacione cada
+      // binomio Linneano CITADO en el texto con las entidades que la capa 1 ya
+      // resolvió para el turno. Si el LLM citó un nombre científico que SÍ
+      // existe en el catálogo pero NO corresponde a lo que el usuario preguntó
+      // (ej. "Solanum lycopersicum" para 'tomate de árbol' = Solanum betaceum),
+      // lo marcamos como SOSPECHOSO. NO bloquea ni reescribe la respuesta —
+      // solo añade un flag de metadata para un badge no intrusivo ("verifica el
+      // nombre científico"). Solo corre si hubo entidades resueltas (sin ellas
+      // no hay con qué correlacionar). 100% graceful: postValidate devuelve null
+      // ante flag off / offline / timeout / AGE caído → sin advertencia.
+      if (isOnline && isSidecarEnabled() && Array.isArray(resolvedEntities) && resolvedEntities.length > 0) {
+        try {
+          const expected = resolvedEntities
+            .map((e) => e?.nombre_cientifico)
+            .filter((n) => typeof n === 'string' && n.trim().length > 0);
+          if (expected.length > 0) {
+            const pv = await postValidate(response, expected);
+            if (pv && pv.age_available && Array.isArray(pv.suspect) && pv.suspect.length > 0) {
+              sourceMetadata = { ...sourceMetadata, suspect_names: pv.suspect };
+              console.debug('[sidecar] post-validate suspect', { suspect: pv.suspect });
+            }
+          }
+        } catch (pvErr) {
+          // post-validate jamás bloquea el chat — la respuesta ya está lista.
+          console.debug('[sidecar] post-validate fail (sigo sin badge):', pvErr?.message);
+        }
+      }
 
       // A-15 (#248): extraer los edges del grafo AGE que ESTE turno usó como
       // evidencia (café→guamo COMPATIBLE_WITH, plaga→biopreparado CONTROLS,

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -47,6 +47,26 @@ function SourceBadge({ metadata }) {
   const md = metadata || {};
   const toolUsed = md.tool_used || null;
   const grounded = md.grounded === true;
+  // Capa 2 cross-check (operador 2026-05-30): nombres científicos que el
+  // modelo citó y que existen en el catálogo PERO no corresponden a la entidad
+  // que el usuario preguntó (ej. Solanum lycopersicum para 'tomate de árbol').
+  // Badge no intrusivo, convive con el badge de fuente: avisa sin bloquear.
+  const suspectNames = Array.isArray(md.suspect_names) ? md.suspect_names : [];
+  const hasSuspect = suspectNames.length > 0;
+
+  if (hasSuspect) {
+    return (
+      <span
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-amber-600/20 text-amber-300 border border-amber-700"
+        data-testid="suspect-name-badge"
+        data-source="suspect-scientific-name"
+        title={`El nombre científico citado existe en el catálogo pero podría no corresponder a lo que preguntaste: ${suspectNames.join(', ')}. Verifícalo antes de aplicarlo.`}
+      >
+        <AlertTriangle size={12} aria-hidden="true" />
+        <span>Verifica el nombre científico</span>
+      </span>
+    );
+  }
 
   if (toolUsed && grounded) {
     return (

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -89,6 +89,41 @@ describe('ChatBubble — badge de fuente (verificado vs generativo)', () => {
     expect(badge).toHaveTextContent(/Respuesta generativa/i);
   });
 
+  test('Renderiza badge de nombre científico sospechoso cuando metadata.suspect_names tiene datos', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Para el tomate de árbol, Solanum lycopersicum se da en clima frío.',
+      timestamp: Date.now(),
+      metadata: {
+        tool_used: 'get_species',
+        grounded: true,
+        suspect_names: ['Solanum lycopersicum'],
+      },
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('suspect-name-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-source', 'suspect-scientific-name');
+    expect(badge).toHaveTextContent(/nombre científico/i);
+    // El binomio sospechoso va en el title (tooltip), no satura la burbuja.
+    expect(badge).toHaveAttribute('title', expect.stringContaining('Solanum lycopersicum'));
+    // No es voseo: usa "Verifica" (tú/usted colombiano), no "verificá".
+    expect(badge.textContent).not.toMatch(/verificá/i);
+  });
+
+  test('El badge sospechoso NO aparece cuando suspect_names está vacío o ausente', () => {
+    const message = {
+      role: 'assistant',
+      content: 'El tomate de árbol Solanum betaceum se da bien.',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_species', grounded: true, suspect_names: [] },
+    };
+    render(<ChatBubble message={message} />);
+    expect(screen.queryByTestId('suspect-name-badge')).not.toBeInTheDocument();
+    // El badge de fuente normal SÍ sigue apareciendo.
+    expect(screen.getByTestId('source-badge')).toBeInTheDocument();
+  });
+
   // #339: la burbuja del assistant NUNCA debe quedar en blanco. Si el LLM
   // devuelve contenido vacío (respuesta degradada, stream sin tokens), se
   // muestra un fallback visible en español colombiano en lugar de un <p>

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -414,4 +414,84 @@ describe('sidecarClient — feature flag on', () => {
       expect(fetchMock.mock.calls[0][0]).toBe('/api/mcp/agro/tools/get_precio_sipsa');
     });
   });
+
+  describe('postValidate — capa 2 cross-check', () => {
+    it('devuelve null sin fetch cuando flag off', async () => {
+      disableFlag();
+      const { postValidate } = await importFresh();
+      const res = await postValidate('Solanum betaceum es bueno', ['Solanum betaceum Cav.']);
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando offline', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { postValidate } = await importFresh();
+      const res = await postValidate('Solanum betaceum es bueno', ['Solanum betaceum Cav.']);
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando text vacío/no-string', async () => {
+      const { postValidate } = await importFresh();
+      expect(await postValidate('', ['x'])).toBeNull();
+      expect(await postValidate(null, ['x'])).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('POST /post-validate con expected mapea el report y conserva suspect[]', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        hallucinated: [],
+        validated: [{ scientific_name: 'Solanum lycopersicum', canonical_id: 'solanum_lycopersicum_cerasiforme' }],
+        suspect: ['Solanum lycopersicum'],
+        age_available: true,
+        detected_count: 1,
+      }));
+      const { postValidate } = await importFresh();
+      const res = await postValidate(
+        'Para el tomate de árbol, Solanum lycopersicum.',
+        ['Solanum betaceum Cav.'],
+      );
+      expect(res.suspect).toEqual(['Solanum lycopersicum']);
+      expect(res.age_available).toBe(true);
+      expect(res.detected_count).toBe(1);
+      // El cuerpo enviado lleva text + expected.
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/post-validate');
+      const body = JSON.parse(opts.body);
+      expect(body.text).toContain('Solanum lycopersicum');
+      expect(body.expected).toEqual(['Solanum betaceum Cav.']);
+    });
+
+    it('NO envía expected cuando el array está vacío (sin cross-check)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        hallucinated: [], validated: [], suspect: [], age_available: true, detected_count: 0,
+      }));
+      const { postValidate } = await importFresh();
+      await postValidate('texto sin binomios', []);
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.expected).toBeUndefined();
+    });
+
+    it('normaliza un report parcial del sidecar a la forma contractual', async () => {
+      // Sidecar viejo sin campo suspect → el cliente lo rellena a [].
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        hallucinated: ['Inventus fakeus'],
+        validated: [],
+        age_available: true,
+        detected_count: 1,
+      }));
+      const { postValidate } = await importFresh();
+      const res = await postValidate('Inventus fakeus no existe.', ['Solanum betaceum Cav.']);
+      expect(res.suspect).toEqual([]);
+      expect(res.hallucinated).toEqual(['Inventus fakeus']);
+    });
+
+    it('devuelve null cuando el fetch falla (sidecar caído)', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('network'));
+      const { postValidate } = await importFresh();
+      const res = await postValidate('Solanum betaceum.', ['Solanum betaceum Cav.']);
+      expect(res).toBeNull();
+    });
+  });
 });

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -348,6 +348,45 @@ export async function resolveEntities(userMessage) {
 }
 
 /**
+ * Capa 2 anti-alucinación (cross-check de contexto). Llama
+ * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
+ * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno
+ * (`expected`). El sidecar:
+ *   - extrae los binomios Linneanos del texto,
+ *   - los valida contra Apache AGE (los inexistentes → `hallucinated`),
+ *   - y si pasás `expected`, marca como `suspect` los binomios que SÍ existen
+ *     pero NO corresponden a la entidad que el usuario mencionó (caso "nombre
+ *     correcto, especie equivocada": dice Solanum lycopersicum para 'tomate de
+ *     árbol', que en realidad es Solanum betaceum).
+ *
+ * Se invoca DESPUÉS de `callLLM` (no antes — necesita la respuesta). NUNCA
+ * bloquea: el PWA usa el resultado solo para un badge no intrusivo. Devuelve
+ * null si flag off / offline / sidecar falla / timeout → el caller degrada a
+ * "sin advertencia" (política conservadora: no advertir si no se pudo verificar).
+ *
+ * @param {string} text — respuesta del LLM ya generada.
+ * @param {string[]} [expected] — nombre_cientifico de las entidades resueltas.
+ * @returns {Promise<null | {hallucinated: string[], validated: Array<{scientific_name: string, canonical_id: string}>, suspect: string[], age_available: boolean, detected_count: number}>}
+ */
+export async function postValidate(text, expected) {
+  if (!text || typeof text !== 'string') return null;
+  const body = { text };
+  if (Array.isArray(expected) && expected.length > 0) {
+    const clean = expected.filter((e) => typeof e === 'string' && e.trim().length > 0);
+    if (clean.length > 0) body.expected = clean;
+  }
+  const raw = await postJson('/post-validate', body, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    hallucinated: Array.isArray(raw.hallucinated) ? raw.hallucinated : [],
+    validated: Array.isArray(raw.validated) ? raw.validated : [],
+    suspect: Array.isArray(raw.suspect) ? raw.suspect : [],
+    age_available: raw.age_available === true,
+    detected_count: typeof raw.detected_count === 'number' ? raw.detected_count : 0,
+  };
+}
+
+/**
  * Llama `POST ${BASE}/tools/<toolName>` con los args dados.
  *
  * @param {string} toolName — uno de ALLOWED_TOOLS


### PR DESCRIPTION
Capa-2 anti-alucinación: tras callLLM, llama postValidate(respuesta, entidades resueltas). Si el LLM cita un binomio válido pero de OTRA especie (ej. 'tomate de árbol'→Solanum lycopersicum), badge ámbar no intrusivo 'Verifica el nombre científico'. Nunca bloquea. Verificado en vivo con el caso exacto del operador. Par del branch chagra-pro feat/wire-post-validate-chat. NOTA: AgentScreen.jsx tiene 5 eslint errors PRE-EXISTENTES en main (no de este PR).