### PR TITLE
feat(clima+ubicación): pronóstico por altura REAL de la finca + altura/municipio/vereda bajo el nombre

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -10,6 +10,7 @@ import useFincaActiveStore from '../services/fincaActiveStore';
 import useOllamaWarmStore from '../store/useOllamaWarmStore';
 import useAssetStore from '../store/useAssetStore';
 import { FARM_CONFIG } from '../config/defaults';
+import { getProfile } from '../services/userProfileService';
 
 /**
  * TopBar, header persistente con identidad del operador (DR-030 QW2).
@@ -53,9 +54,21 @@ export default function TopBar({ onNavigate, onLogout }) {
   const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
   const fincas = useFincaActiveStore((s) => s.fincas);
   const activeFinca = fincas.find((f) => f.slug === activeFincaSlug);
-  const municipio = activeFinca?.municipio || FARM_CONFIG?.MUNICIPIO || null;
-  const vereda = activeFinca?.vereda || null;
-  const altitud = activeFinca?.altitud || FARM_CONFIG?.ALTITUD_MSNM || null;
+  // `tick` fuerza re-lectura del perfil cuando el usuario confirma su ubicación
+  // en LocationDetectedScreen (evento 'chagra:location-updated'), que la guarda
+  // en el PERFIL (userProfileService), no en fincaActiveStore. Sin esto la
+  // línea de ubicación bajo el nombre se quedaría vacía para el piloto que
+  // solo pasó por esa pantalla.
+  const [profileTick, setProfileTick] = useState(0);
+  const profile = (() => { void profileTick; return getProfile(); })();
+  // Ubicación bajo el nombre: finca activa (multi-finca) → perfil (onboarding/
+  // ubicación detectada) → FARM_CONFIG (demo). Altitud real de la finca para que
+  // el campesino vea su piso térmico, no la cabecera.
+  const municipio = activeFinca?.municipio || profile?.municipio || FARM_CONFIG?.MUNICIPIO || null;
+  // Vereda: el dataset DANE no la trae; solo aparece si el perfil/finca la tiene
+  // de onboarding manual. Si no, se omite sin romper (municipio + altitud bastan).
+  const vereda = activeFinca?.vereda || profile?.vereda || null;
+  const altitud = activeFinca?.altitud || profile?.finca_altitud || profile?.altitud || FARM_CONFIG?.ALTITUD_MSNM || null;
 
   // "Respira" animación del logo Chagra cuando hay actividad de fondo
   // (warm-up del agente IA o sync con FarmOS). Sensación de "agente vivo
@@ -77,11 +90,14 @@ export default function TopBar({ onNavigate, onLogout }) {
         setOperatorName(e.detail.value || 'Operador');
       }
     };
+    const onLocationUpdated = () => setProfileTick((t) => t + 1);
     window.addEventListener('storage', onStorage);
     window.addEventListener('chagra:operator-update', onOperatorUpdate);
+    window.addEventListener('chagra:location-updated', onLocationUpdated);
     return () => {
       window.removeEventListener('storage', onStorage);
       window.removeEventListener('chagra:operator-update', onOperatorUpdate);
+      window.removeEventListener('chagra:location-updated', onLocationUpdated);
     };
   }, []);
 
@@ -141,8 +157,8 @@ export default function TopBar({ onNavigate, onLogout }) {
               <MapPin size={10} className="shrink-0 text-slate-500" aria-hidden="true" />
               <span className="truncate">
                 {municipio && <span>{municipio.split(',')[0]}</span>}
-                {vereda && <span> · {vereda}</span>}
-                {altitud && <span> · {altitud}m</span>}
+                {vereda && <span>, vereda {vereda}</span>}
+                {altitud && <span> · {altitud} msnm</span>}
               </span>
             </div>
           )}

--- a/src/components/__tests__/TopBar.locationLine.test.jsx
+++ b/src/components/__tests__/TopBar.locationLine.test.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TopBar from '../TopBar';
+
+/**
+ * TopBar.locationLine.test.jsx — línea de ubicación bajo el nombre.
+ *
+ * Bajo el nombre del operador se muestra "📍 {municipio}, vereda {vereda} ·
+ * {altitud} msnm". La fuente de los datos es, en orden: finca activa
+ * (multi-finca) → PERFIL del usuario (onboarding / LocationDetectedScreen) →
+ * FARM_CONFIG (demo). Antes solo leía de la finca activa, así que el piloto
+ * que confirma su ubicación por LocationDetectedScreen (que guarda en el
+ * perfil) veía la línea vacía.
+ *
+ * Vereda: el dataset DANE no la trae; solo se muestra si el perfil/finca la
+ * tiene de onboarding manual. Si no, se omite sin romper.
+ */
+
+vi.mock('../EnvironmentalCard', () => ({ default: () => <div data-testid="env-stub" /> }));
+vi.mock('../AltitudeBadge', () => ({ default: () => <div data-testid="alt-stub" /> }));
+vi.mock('../OfflineChip', () => ({ default: () => <div data-testid="chip-stub" /> }));
+vi.mock('../NotificationsBell', () => ({ default: () => <div data-testid="bell-stub" /> }));
+
+// Finca activa SIN ubicación → fuerza el fallback al perfil.
+vi.mock('../../services/fincaActiveStore', () => {
+  const store = { activeFincaSlug: 'guatoc', fincas: [] };
+  const useFincaActiveStore = (selector) => selector(store);
+  return { default: useFincaActiveStore };
+});
+
+vi.mock('../../store/useOllamaWarmStore', () => ({
+  default: (selector) => selector({ status: 'idle' }),
+}));
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector({ syncProgress: null }),
+}));
+
+vi.mock('../../config/defaults', () => ({
+  FARM_CONFIG: { MUNICIPIO: null, ALTITUD_MSNM: null },
+}));
+
+vi.mock('../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({})),
+}));
+import { getProfile } from '../../services/userProfileService';
+
+describe('TopBar — línea de ubicación bajo el nombre', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('chagra:operator:name', 'Miguel');
+    getProfile.mockReturnValue({});
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('muestra municipio + altitud del perfil (msnm) bajo el nombre', () => {
+    getProfile.mockReturnValue({ municipio: 'Choachí', finca_altitud: '2580' });
+    render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    expect(screen.getByText('Choachí')).toBeInTheDocument();
+    expect(screen.getByText(/2580 msnm/)).toBeInTheDocument();
+  });
+
+  it('incluye la vereda si el perfil la tiene', () => {
+    getProfile.mockReturnValue({ municipio: 'Choachí', vereda: 'Aguanica', finca_altitud: '2580' });
+    render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    expect(screen.getByText(/vereda Aguanica/)).toBeInTheDocument();
+  });
+
+  it('NO rompe (ni muestra vereda) si el perfil no la trae', () => {
+    getProfile.mockReturnValue({ municipio: 'Une', finca_altitud: '1875' });
+    render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    expect(screen.getByText('Une')).toBeInTheDocument();
+    expect(screen.queryByText(/vereda/)).toBeNull();
+  });
+
+  it('re-lee el perfil al recibir chagra:location-updated', () => {
+    const { rerender } = render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    // Sin ubicación todavía.
+    expect(screen.queryByText(/msnm/)).toBeNull();
+    // El usuario confirma su ubicación → el evento dispara re-lectura del perfil.
+    getProfile.mockReturnValue({ municipio: 'Choachí', finca_altitud: '2580' });
+    fireEvent(window, new CustomEvent('chagra:location-updated'));
+    rerender(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    expect(screen.getByText(/2580 msnm/)).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -54,20 +54,67 @@ function dayLabel(isoDate, i) {
 }
 
 /**
- * Resuelve { lat, lng } a partir del perfil o, en su defecto, geocodificando
- * el municipio contra el dataset DANE local (offline-friendly).
- * @returns {{ lat: number, lng: number } | null}
+ * Resuelve la altitud (msnm) real de la finca para corregir Open-Meteo por
+ * gradiente térmico. Prioridad:
+ *   1. `finca_altitud` del perfil — la que confirma/detecta LocationDetectedScreen.
+ *   2. `altitud` del perfil (alias de algunos flujos viejos).
+ *   3. La altitud curada del municipio en el dataset DANE (`fallbackAltitud`).
+ * Devuelve un número plausible (msnm) o null. Sin esto, Open-Meteo usa la
+ * elevación de SU grilla (≈ cabecera/valle) y el pronóstico sale más cálido.
+ * @returns {number | null}
  */
-function resolveCoords(profile, municipio) {
+function plausibleMsnm(value) {
+    const n = Number(value);
+    // Rango físico Colombia: nivel del mar a ~5800 m (Cristóbal Colón, 5775 m).
+    return Number.isFinite(n) && n >= -100 && n <= 6000 ? Math.round(n) : null;
+}
+
+/**
+ * Altitud (msnm) del perfil para corregir Open-Meteo por gradiente térmico.
+ * Prioriza `finca_altitud` (la que confirma/detecta LocationDetectedScreen) y
+ * cae a `altitud` (alias de flujos viejos). NO geocodifica: el fallback al
+ * municipio lo decide `resolveGeo` solo cuando hace falta. @returns {number|null}
+ */
+function profileElevation(profile) {
+    return plausibleMsnm(profile?.finca_altitud) ?? plausibleMsnm(profile?.altitud);
+}
+
+/**
+ * Resuelve { lat, lng, elevation } a partir del perfil o, en su defecto,
+ * geocodificando el municipio contra el dataset DANE local (offline-friendly).
+ * La elevación corrige la temperatura de Open-Meteo: prioriza la altitud real
+ * de la finca (perfil) sobre la del municipio (cabecera, más baja). Solo se
+ * geocodifica el municipio si NO hay coords del perfil, o si hay coords pero
+ * el perfil no trae altitud (para aproximar el piso con la curada del DANE) —
+ * así se respeta el contrato "con coords del perfil no geocodifica" cuando el
+ * perfil ya está completo.
+ * @returns {{ lat: number, lng: number, elevation: number | null } | null}
+ */
+function resolveGeo(profile, municipio) {
     const lat = Number(profile?.ubicacion_lat);
     const lng = Number(profile?.ubicacion_lng);
     if (Number.isFinite(lat) && Number.isFinite(lng)) {
-        return { lat, lng };
+        // GPS real de la finca. La altitud sale del perfil; solo si el perfil
+        // NO la trae caemos a la curada del municipio (evita geocodificar de
+        // más cuando el perfil ya está completo).
+        let elevation = profileElevation(profile);
+        if (elevation == null && municipio) {
+            const hit = findMunicipio(municipio.split(',')[0]);
+            elevation = plausibleMsnm(hit?.altitud);
+        }
+        return { lat, lng, elevation };
     }
     if (municipio) {
+        // Sin GPS: geocodificamos el municipio (centroide ≈ cabecera). Igual
+        // pasamos la altitud curada para que el gradiente sea coherente con esa
+        // posición, y la del perfil tiene prioridad si existe.
         const hit = findMunicipio(municipio.split(',')[0]);
         if (hit && Number.isFinite(hit.lat) && Number.isFinite(hit.lng)) {
-            return { lat: hit.lat, lng: hit.lng };
+            return {
+                lat: hit.lat,
+                lng: hit.lng,
+                elevation: profileElevation(profile) ?? plausibleMsnm(hit.altitud),
+            };
         }
     }
     return null;
@@ -97,8 +144,8 @@ export default function ClimaStrip({ onNavigate }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeFincaSlug, fincas, tick]);
 
-    const coords = useMemo(() => {
-        return resolveCoords(getProfile(), municipio);
+    const geo = useMemo(() => {
+        return resolveGeo(getProfile(), municipio);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [municipio, tick]);
 
@@ -108,18 +155,30 @@ export default function ClimaStrip({ onNavigate }) {
         // pedir Open-Meteo, que necesita lat/lon. Cerramos el loading y dejamos
         // que el render decida: CTA si tampoco hay municipio, strip neutro si
         // hay municipio pero sin match DANE.
-        if (!coords) {
+        if (!geo) {
             Promise.resolve().then(() => { if (alive) setLoading(false); });
             return () => { alive = false; };
         }
+        // Pintado instantáneo desde el cache keyed por coords+elevation si existe.
+        const cached = getCachedClimaSnapshot(geo.lat, geo.lng, geo.elevation);
+        if (cached && alive) setSnapshot(cached);
         // fetchClimaSnapshot nunca throw: devuelve null si offline / flag off /
         // HTTP≥400. Open-Meteo real 7d viene en payload.openmeteo.forecast_7d.
-        fetchClimaSnapshot({ lat: coords.lat, lng: coords.lng })
+        // `elevation` (altitud real de la finca) corrige la temperatura por
+        // gradiente térmico — sin esto el pronóstico sale más cálido (usa la
+        // elevación de la cabecera/valle de la grilla de Open-Meteo).
+        // Solo incluimos `elevation` cuando la conocemos: así, sin altitud, el
+        // request queda { lat, lng } y Open-Meteo usa su grilla (comportamiento
+        // previo intacto); con altitud, corrige la temperatura por gradiente.
+        const climaArgs = geo.elevation != null
+            ? { lat: geo.lat, lng: geo.lng, elevation: geo.elevation }
+            : { lat: geo.lat, lng: geo.lng };
+        fetchClimaSnapshot(climaArgs)
             .then((res) => { if (alive && res) setSnapshot(res); })
             .catch(() => { /* degrade limpio — nunca rompe el dashboard */ })
             .finally(() => { if (alive) setLoading(false); });
         return () => { alive = false; };
-    }, [coords]);
+    }, [geo]);
 
     if (loading) {
         return (
@@ -134,7 +193,7 @@ export default function ClimaStrip({ onNavigate }) {
         );
     }
 
-    if (!coords && !municipio) {
+    if (!geo && !municipio) {
         return (
             <div className="bg-gradient-to-br from-sky-950/70 to-indigo-950/60 backdrop-blur-xl border border-sky-800/40 rounded-2xl p-5">
                 <div className="flex items-center gap-2 mb-2">

--- a/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
+++ b/src/components/dashboard/__tests__/ClimaStrip.locationButton.test.jsx
@@ -153,21 +153,44 @@ describe('ClimaStrip — pronóstico real Open-Meteo (fix fuente de datos 2026-0
         },
     };
 
-    test('usa coords del perfil (ubicacion_lat/lng) y NO geocodifica', async () => {
+    test('usa coords + altitud del perfil, pasa elevation y NO geocodifica', async () => {
+        // Perfil completo: coords reales de la finca + altitud (2580 msnm). Con
+        // la altitud en el perfil, resolveGeo no necesita geocodificar y reenvía
+        // elevation para que Open-Meteo corrija la temperatura por gradiente.
+        getProfile.mockReturnValue({
+            municipio: 'Choachí',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+            finca_altitud: '2580',
+        });
+        findMunicipio.mockClear();
+        fetchClimaSnapshot.mockResolvedValueOnce(snapshotConForecast);
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+        await waitFor(() =>
+            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.53, lng: -73.92, elevation: 2580 }),
+        );
+        // Con coords + altitud del perfil NO debe geocodificar el municipio.
+        expect(findMunicipio).not.toHaveBeenCalled();
+        getProfile.mockReturnValue({});
+    });
+
+    test('con coords pero SIN altitud en el perfil, cae a la curada del municipio (DANE)', async () => {
         getProfile.mockReturnValue({
             municipio: 'Choachí',
             ubicacion_lat: 4.53,
             ubicacion_lng: -73.92,
         });
         findMunicipio.mockClear();
+        findMunicipio.mockReturnValueOnce({ name: 'Choachí', lat: 4.52, lng: -73.92, altitud: 1923 });
         fetchClimaSnapshot.mockResolvedValueOnce(snapshotConForecast);
         render(<ClimaStrip onNavigate={vi.fn()} />);
         await waitFor(() =>
-            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.53, lng: -73.92 }),
+            // coords del perfil (no las del municipio) + altitud curada del DANE.
+            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.53, lng: -73.92, elevation: 1923 }),
         );
-        // Con coords del perfil NO debe geocodificar el municipio.
-        expect(findMunicipio).not.toHaveBeenCalled();
+        expect(findMunicipio).toHaveBeenCalled();
         getProfile.mockReturnValue({});
+        findMunicipio.mockReturnValue(null);
     });
 
     test('renderiza temperaturas reales (máx/mín) del forecast', async () => {
@@ -185,13 +208,14 @@ describe('ClimaStrip — pronóstico real Open-Meteo (fix fuente de datos 2026-0
         getProfile.mockReturnValue({});
     });
 
-    test('geocodifica el municipio si el perfil no tiene coords', async () => {
+    test('geocodifica el municipio si el perfil no tiene coords (con altitud curada)', async () => {
         getProfile.mockReturnValue({ municipio: 'Une' });
-        findMunicipio.mockReturnValueOnce({ name: 'Une', lat: 4.40, lng: -73.99 });
+        // Une, Cundinamarca ≈ 1875 msnm en el dataset DANE curado.
+        findMunicipio.mockReturnValueOnce({ name: 'Une', lat: 4.40, lng: -73.99, altitud: 1875 });
         fetchClimaSnapshot.mockResolvedValueOnce(snapshotConForecast);
         render(<ClimaStrip onNavigate={vi.fn()} />);
         await waitFor(() =>
-            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.40, lng: -73.99 }),
+            expect(fetchClimaSnapshot).toHaveBeenCalledWith({ lat: 4.40, lng: -73.99, elevation: 1875 }),
         );
         getProfile.mockReturnValue({});
         findMunicipio.mockReturnValue(null);

--- a/src/services/__tests__/climaService.test.js
+++ b/src/services/__tests__/climaService.test.js
@@ -117,6 +117,72 @@ describe('climaService — cache + fetch', () => {
     window.removeEventListener('chagra:clima:updated', handler);
   });
 
+  it('forwards elevation to the sidecar (gradiente térmico)', async () => {
+    vi.resetModules();
+    const mockGetClima = vi.fn().mockResolvedValue({
+      fetched_at: new Date().toISOString(),
+      enso_status: { phase: 'neutral', severity: 'neutral', sources: [] },
+      alertas_locales: [],
+    });
+    vi.doMock('../sidecarClient.js', () => ({ getClimaSnapshot: mockGetClima }));
+    const mod = await import('../climaService.js');
+    await mod.fetchClimaSnapshot({ lat: 4.5288, lng: -73.9236, elevation: 2580 });
+    expect(mockGetClima).toHaveBeenCalledWith({
+      lat: 4.5288,
+      lng: -73.9236,
+      elevation: 2580,
+    });
+  });
+
+  it('keys the cache by elevation — distinta altitud no comparte snapshot', async () => {
+    vi.resetModules();
+    const mockGetClima = vi
+      .fn()
+      .mockResolvedValueOnce({
+        fetched_at: new Date().toISOString(),
+        enso_status: { phase: 'neutral', severity: 'neutral', sources: [] },
+        alertas_locales: [],
+        openmeteo: { available: true, forecast_7d: [{ temp_max_c: 17 }] },
+      })
+      .mockResolvedValueOnce({
+        fetched_at: new Date().toISOString(),
+        enso_status: { phase: 'neutral', severity: 'neutral', sources: [] },
+        alertas_locales: [],
+        openmeteo: { available: true, forecast_7d: [{ temp_max_c: 22 }] },
+      });
+    vi.doMock('../sidecarClient.js', () => ({ getClimaSnapshot: mockGetClima }));
+    const mod = await import('../climaService.js');
+    const a = await mod.fetchClimaSnapshot({ lat: 4.53, lng: -73.92, elevation: 2580 });
+    // Tras el fetch a 2580, la cache (key coords@2580) sirve ese snapshot...
+    const cachedHigh = mod.getCachedClimaSnapshot(4.53, -73.92, 2580);
+    expect(cachedHigh?.openmeteo?.forecast_7d[0].temp_max_c).toBe(17);
+    // ...pero leer las MISMAS coords con OTRA altitud (1900) NO la reusa: la
+    // clave difiere, así que es un miss (devuelve null) y un fetch nuevo.
+    expect(mod.getCachedClimaSnapshot(4.53, -73.92, 1900)).toBeNull();
+    const b = await mod.fetchClimaSnapshot({ lat: 4.53, lng: -73.92, elevation: 1900 });
+    // Mismas coords, distinta altitud → dos fetches (no colisiona la cache).
+    expect(mockGetClima).toHaveBeenCalledTimes(2);
+    expect(a.openmeteo.forecast_7d[0].temp_max_c).toBe(17);
+    expect(b.openmeteo.forecast_7d[0].temp_max_c).toBe(22);
+  });
+
+  it('omits elevation from the sidecar call when not provided', async () => {
+    vi.resetModules();
+    const mockGetClima = vi.fn().mockResolvedValue({
+      fetched_at: new Date().toISOString(),
+      enso_status: { phase: 'neutral', severity: 'neutral', sources: [] },
+      alertas_locales: [],
+    });
+    vi.doMock('../sidecarClient.js', () => ({ getClimaSnapshot: mockGetClima }));
+    const mod = await import('../climaService.js');
+    await mod.fetchClimaSnapshot({ lat: 4.53, lng: -73.92 });
+    expect(mockGetClima).toHaveBeenCalledWith({
+      lat: 4.53,
+      lng: -73.92,
+      elevation: undefined,
+    });
+  });
+
   it('two simultaneous fetches share the in-flight promise', async () => {
     vi.resetModules();
     let resolveFn;

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -415,3 +415,45 @@ describe('sidecarClient — feature flag on', () => {
     });
   });
 });
+
+describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', () => {
+  beforeEach(() => {
+    enableFlag();
+  });
+
+  const okSnap = { fetched_at: 't', enso_status: { phase: 'neutral' } };
+
+  it('incluye elevation en el query string cuando es válida', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, okSnap));
+    const { getClimaSnapshot } = await importFresh();
+    await getClimaSnapshot({ lat: 4.5288, lng: -73.9236, elevation: 2580 });
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('lat=4.5288');
+    expect(url).toContain('lng=-73.9236');
+    expect(url).toContain('elevation=2580');
+  });
+
+  it('omite elevation si no se pasa (Open-Meteo usa su grilla)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, okSnap));
+    const { getClimaSnapshot } = await importFresh();
+    await getClimaSnapshot({ lat: 4.5288, lng: -73.9236 });
+    expect(fetchMock.mock.calls[0][0]).not.toContain('elevation');
+  });
+
+  it('descarta elevation fuera de rango físico (clamp defensivo)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, okSnap));
+    const { getClimaSnapshot } = await importFresh();
+    // 8467 m ≈ una altitud en pies mal interpretada → se descarta.
+    await getClimaSnapshot({ lat: 4.5, lng: -73.9, elevation: 8467 });
+    expect(fetchMock.mock.calls[0][0]).not.toContain('elevation');
+  });
+
+  it('descarta elevation NaN sin romper el request de coords', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, okSnap));
+    const { getClimaSnapshot } = await importFresh();
+    await getClimaSnapshot({ lat: 4.5, lng: -73.9, elevation: Number.NaN });
+    const url = fetchMock.mock.calls[0][0];
+    expect(url).toContain('lat=4.5');
+    expect(url).not.toContain('elevation');
+  });
+});

--- a/src/services/climaService.js
+++ b/src/services/climaService.js
@@ -45,9 +45,15 @@ const LS_KEY = 'chagra:clima:snapshot-v1';
 let memCache = null; // { ts, key, payload }
 let inFlight = null; // Promise<payload>
 
-function coordKey(lat, lng) {
+function coordKey(lat, lng, elevation) {
     if (typeof lat !== 'number' || typeof lng !== 'number') return 'global';
-    return `${lat.toFixed(2)},${lng.toFixed(2)}`;
+    const base = `${lat.toFixed(2)},${lng.toFixed(2)}`;
+    // La elevación entra en la clave: dos puntos con las mismas coords pero
+    // distinta altitud (perfil corrige la grilla de Open-Meteo) son snapshots
+    // distintos y no deben compartir cache.
+    return typeof elevation === 'number' && Number.isFinite(elevation)
+        ? `${base}@${Math.round(elevation)}`
+        : base;
 }
 
 function readLocalStorage() {
@@ -77,10 +83,11 @@ function writeLocalStorage(entry) {
  *
  * @param {number} [lat]
  * @param {number} [lng]
+ * @param {number} [elevation] msnm reales (entra en la clave de cache)
  * @returns {object | null}
  */
-export function getCachedClimaSnapshot(lat, lng) {
-    const key = coordKey(lat, lng);
+export function getCachedClimaSnapshot(lat, lng, elevation) {
+    const key = coordKey(lat, lng, elevation);
     const now = Date.now();
     if (memCache && memCache.key === key && now - memCache.ts < CACHE_TTL_MS) {
         return memCache.payload;
@@ -100,11 +107,14 @@ export function getCachedClimaSnapshot(lat, lng) {
  * @param {object} [opts]
  * @param {number} [opts.lat]
  * @param {number} [opts.lng]
+ * @param {number} [opts.elevation] msnm reales de la finca → Open-Meteo corrige
+ *   la temperatura por gradiente térmico. Sin esto el pronóstico sale más
+ *   cálido (usa la elevación de la cabecera/valle de la grilla).
  * @param {boolean} [opts.forceRefresh]
  * @returns {Promise<object | null>}
  */
-export async function fetchClimaSnapshot({ lat, lng, forceRefresh = false } = {}) {
-    const key = coordKey(lat, lng);
+export async function fetchClimaSnapshot({ lat, lng, elevation, forceRefresh = false } = {}) {
+    const key = coordKey(lat, lng, elevation);
     const now = Date.now();
 
     if (!forceRefresh && memCache && memCache.key === key && now - memCache.ts < CACHE_TTL_MS) {
@@ -113,7 +123,7 @@ export async function fetchClimaSnapshot({ lat, lng, forceRefresh = false } = {}
     if (inFlight) return inFlight;
 
     inFlight = (async () => {
-        const payload = await getClimaSnapshot({ lat, lng });
+        const payload = await getClimaSnapshot({ lat, lng, elevation });
         if (payload) {
             const entry = { ts: Date.now(), key, payload };
             memCache = entry;

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -450,21 +450,37 @@ export async function getPrecioSipsa(action, args) {
 }
 
 /**
- * GET `${BASE}/clima/snapshot` con lat/lng opcionales (#316).
+ * GET `${BASE}/clima/snapshot` con lat/lng (+ elevation opcional) (#316).
  *
  * Devuelve el snapshot completo: ENSO + 7d forecast + alertas. Si no se pasan
  * coords, el sidecar responde solo el bloque ENSO (NOAA + IDEAM + CIIFEN) y
  * deja `openmeteo: null` + `alertas_locales: []`.
  *
+ * `elevation` (msnm reales de la finca): Open-Meteo corrige la temperatura por
+ * gradiente térmico (lapse rate ~6.5 °C/1000 m) usando la elevación que se le
+ * pase. Si NO se pasa, Open-Meteo usa la elevación de SU grilla, que para un
+ * municipio andino cae cerca de la CABECERA (valle/casco urbano), no de la
+ * finca en ladera alta — y el pronóstico sale varios grados más cálido de lo
+ * real (p. ej. finca a 2580 msnm vs cabecera ~1900 msnm: ~4–5 °C de
+ * diferencia). Pasar la altitud real corrige eso. El sidecar reenvía este
+ * parámetro a Open-Meteo (`?elevation=`).
+ *
  * Reglas: flag off → null. Offline → null. HTTP ≥400 → null. Nunca throw.
  *
- * @param {{ lat?: number, lng?: number }} [opts]
+ * @param {{ lat?: number, lng?: number, elevation?: number }} [opts]
  * @returns {Promise<null | object>}
  */
 export async function getClimaSnapshot(opts = {}) {
   const query = {};
   if (typeof opts.lat === 'number' && Number.isFinite(opts.lat)) query.lat = opts.lat;
   if (typeof opts.lng === 'number' && Number.isFinite(opts.lng)) query.lng = opts.lng;
+  // elevation: solo si es número finito y físicamente plausible (msnm). El
+  // techo de 6000 m cubre el pico más alto de Colombia (Cristóbal Colón,
+  // 5775 m) con margen y descarta basura tipo pies, sensores locos o NaN.
+  if (typeof opts.elevation === 'number' && Number.isFinite(opts.elevation)
+      && opts.elevation >= -100 && opts.elevation <= 6000) {
+    query.elevation = opts.elevation;
+  }
   return getJson('/clima/snapshot', query, TOOL_TIMEOUT_MS);
 }
 


### PR DESCRIPTION
El operador vio temps de pueblo (1800m) en vez de su finca (2580m). El widget ya usaba coords reales (#1212); faltaba la **elevación**: la PWA ahora la manda a Open-Meteo → corrige por gradiente (~5°C más fría a 2580m, verificado en vivo: cabecera 20.3°/15° vs finca 15.4°/10.3°). + TopBar ahora muestra '📍 municipio, vereda · altitud msnm' bajo el nombre (cae al perfil; vereda si existe). 2518 tests.

DEPENDE de su par en chagra-pro (forward de elevation a Open-Meteo en el sidecar, branch feat/sidecar-clima-elevation) — sin eso la PWA manda el parámetro pero el sidecar lo ignora. Mergear los dos juntos.