### PR TITLE
feat(agent): contexto ambiental de finca inyectado al system prompt (sin latencia)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -27,7 +27,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, postValidate, getClimaIdeam } from '../../services/sidecarClient';
-import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
+import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
@@ -55,6 +55,7 @@ import useAgentNotificationStore from '../../store/useAgentNotificationStore';
 import useOllamaWarmStore from '../../store/useOllamaWarmStore';
 import useAgentQueueStore from '../../store/useAgentQueueStore';
 import useFincaActiveStore from '../../services/fincaActiveStore';
+import useAlertStore from '../../store/useAlertStore';
 
 // 2026-05-16: migrado a llmRouter (Multi-LLM por tarea). AgentScreen usa
 // la `chat` route con el modelo de chat configurado como hot model. Bench
@@ -94,6 +95,9 @@ export default function AgentScreen({ onBack, initialContext }) {
   const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
   const fincas = useFincaActiveStore((s) => s.fincas);
   const indoorZone = useFincaActiveStore((s) => s.indoorZone);
+  // Contexto ambiental de la finca (#202 mejora inteligencia): alertas activas
+  // del alertEngine para que el agente las tenga en cuenta sin pedir fetch.
+  const activeAlerts = useAlertStore((s) => s.activeAlerts);
 
   const [messages, setMessages] = useState([]);
   const [inputText, setInputText] = useState('');
@@ -1019,8 +1023,35 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     })();
     const climaContext = climaSnapshot ? `\n\n${buildClimaContext(climaSnapshot, { region: ensoRegion })}` : '';
 
+    // CONTEXTO AMBIENTAL DE LA FINCA (#202 mejora inteligencia). Bloque PURO
+    // armado de datos YA disponibles localmente o en cache — CERO latencia:
+    //   - profile / finca: localStorage + store en memoria (síncronos)
+    //   - climaSnapshot: el mismo cache ya leído arriba (NO se re-pide)
+    //   - groupedCultivos: `plants` del asset store (memoria), agrupados aquí
+    //   - resolvedEntities: grounding AGE del turno (ya resuelto, se reutiliza)
+    //   - activeAlerts: useAlertStore (memoria)
+    // Si algún dato no está, buildFincaContext omite su línea (degrada).
+    const fincaActivaCtx = fincas.find((f) => f.slug === activeFincaSlug) || null;
+    const groupedCultivos = (() => {
+      const strip = (name) => (name || '').replace(/\s*#\d+\s*$/, '').trim();
+      const counts = (plants || []).reduce((acc, pl) => {
+        const base = strip(pl.attributes?.name);
+        if (base) acc[base] = (acc[base] || 0) + 1;
+        return acc;
+      }, {});
+      return Object.entries(counts).map(([name, count]) => ({ name, count }));
+    })();
+    const fincaContext = `\n\n${buildFincaContext({
+      profile: (() => { try { return getProfile(); } catch (_) { return null; } })(),
+      finca: fincaActivaCtx,
+      climaSnapshot,
+      groupedCultivos,
+      resolvedEntities,
+      activeAlerts,
+    })}`;
+
     const messages = [
-      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + climaContext + queryAnalysisBlock },
+      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + climaContext + fincaContext + queryAnalysisBlock },
       ...(contextMemory ? [{ role: 'user', content: contextMemory }] : []),
       { role: 'user', content: query },
     ];

--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -13,6 +13,9 @@ import {
   buildProfileContext,
   formatClimateAlert,
   buildClimaContext,
+  buildFincaContext,
+  pisoTermicoFromAltitud,
+  temporadaColombiana,
 } from '../agentService.js';
 
 describe('agentService — Task #202 Profile Context', () => {
@@ -476,6 +479,171 @@ describe('agentService — Task #202 Profile Context', () => {
       expect(ctx).toContain('Neutral ENSO');
       expect(ctx).not.toContain('ONI NOAA');
       expect(ctx).not.toContain('Probabilidad IDEAM');
+    });
+  });
+
+  describe('pisoTermicoFromAltitud', () => {
+    it('mapea altitud a piso térmico colombiano', () => {
+      expect(pisoTermicoFromAltitud(3200)).toBe('páramo');
+      expect(pisoTermicoFromAltitud(2580)).toBe('frío');
+      expect(pisoTermicoFromAltitud(1500)).toBe('templado');
+      expect(pisoTermicoFromAltitud(400)).toBe('cálido');
+    });
+    it('acepta string y devuelve null si no es numérico', () => {
+      expect(pisoTermicoFromAltitud('2580')).toBe('frío');
+      expect(pisoTermicoFromAltitud(null)).toBeNull();
+      expect(pisoTermicoFromAltitud(undefined)).toBeNull();
+      expect(pisoTermicoFromAltitud('abc')).toBeNull();
+    });
+  });
+
+  describe('temporadaColombiana', () => {
+    it('régimen bimodal andino por mes', () => {
+      expect(temporadaColombiana(1).nombre).toContain('seca');
+      expect(temporadaColombiana(4).nombre).toContain('primera temporada de lluvias');
+      expect(temporadaColombiana(7).nombre).toContain('segunda temporada seca');
+      expect(temporadaColombiana(10).nombre).toContain('segunda temporada de lluvias');
+    });
+    it('sin argumento usa el mes actual sin lanzar', () => {
+      const t = temporadaColombiana();
+      expect(typeof t.nombre).toBe('string');
+      expect(t.nombre.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('buildFincaContext (#202 contexto ambiental)', () => {
+    const choachiProfile = {
+      municipio: 'Choachí',
+      departamento: 'Cundinamarca',
+      finca_altitud: '2580',
+      ubicacion_lat: 4.529,
+      ubicacion_lng: -73.923,
+    };
+    const cultivosMaiz = [
+      { name: 'Maíz', count: 2 },
+      { name: 'Café', count: 1 },
+      { name: 'Frijol', count: 1 },
+    ];
+
+    it('siempre incluye la temporada y el wrapper, aun sin nada', () => {
+      const ctx = buildFincaContext({ month: 5 });
+      expect(ctx).toContain('=== CONTEXTO AMBIENTAL DE LA FINCA');
+      expect(ctx).toContain('Temporada actual');
+      expect(ctx).toContain('=== FIN CONTEXTO AMBIENTAL ===');
+      expect(ctx).toContain('NO lo recites salvo que sea relevante');
+    });
+
+    it('inyecta ubicación, altitud y piso térmico derivado', () => {
+      const ctx = buildFincaContext({ profile: choachiProfile, month: 5 });
+      expect(ctx).toContain('Choachí');
+      expect(ctx).toContain('Cundinamarca');
+      expect(ctx).toContain('2580 msnm');
+      expect(ctx).toContain('piso frío'); // derivado de 2580
+      expect(ctx).toContain('4.529');
+    });
+
+    it('usa el nombre de la finca activa si está presente', () => {
+      const ctx = buildFincaContext({
+        profile: choachiProfile,
+        finca: { nombre: 'La Esperanza', slug: 'la-esperanza' },
+        month: 5,
+      });
+      expect(ctx).toContain('Finca activa: "La Esperanza"');
+    });
+
+    it('resume cultivos registrados de forma compacta', () => {
+      const ctx = buildFincaContext({ groupedCultivos: cultivosMaiz, month: 5 });
+      expect(ctx).toContain('Cultivos registrados en la finca: Maíz ×2, Café, Frijol');
+    });
+
+    it('colapsa el inventario largo con "y N más"', () => {
+      const muchos = Array.from({ length: 12 }, (_, i) => ({ name: `c${i}`, count: 1 }));
+      const ctx = buildFincaContext({ groupedCultivos: muchos, month: 5 });
+      expect(ctx).toContain('y 4 más');
+    });
+
+    it('reutiliza el snapshot de clima cacheado (hoy + resumen 7d)', () => {
+      const snapshot = {
+        enso_status: { phase: 'nino_moderado', label: 'El Niño moderado' },
+        openmeteo: {
+          available: true,
+          forecast_7d: [
+            { date: '2026-05-30', temp_max_c: 19, temp_min_c: 8, precip_mm: 0 },
+            { date: '2026-05-31', temp_max_c: 18, temp_min_c: 2, precip_mm: 12 },
+            { date: '2026-06-01', temp_max_c: 17, temp_min_c: 3, precip_mm: 5 },
+          ],
+        },
+      };
+      const ctx = buildFincaContext({ climaSnapshot: snapshot, month: 5 });
+      expect(ctx).toContain('Clima local hoy: 8°/19°C');
+      expect(ctx).toContain('El Niño moderado');
+      expect(ctx).toContain('2/7 días con lluvia');
+      expect(ctx).toContain('mínima de la semana 2°C');
+    });
+
+    it('omite el bloque clima si el snapshot no tiene forecast disponible', () => {
+      const ctx = buildFincaContext({
+        climaSnapshot: { openmeteo: { available: false, reason: 'offline' } },
+        month: 5,
+      });
+      expect(ctx).not.toContain('Clima local hoy');
+      expect(ctx).not.toContain('Pronóstico 7d');
+    });
+
+    it('lista alertas activas del alertStore', () => {
+      const ctx = buildFincaContext({
+        activeAlerts: [
+          { type: 'helada', severity: 'danger', title: 'Riesgo de helada', message: 'mín 2°C' },
+        ],
+        month: 5,
+      });
+      expect(ctx).toContain('Alertas activas: Riesgo de helada');
+    });
+
+    it('cruza entidades resueltas (AGE) con el inventario y marca lo que el usuario tiene', () => {
+      const ctx = buildFincaContext({
+        groupedCultivos: cultivosMaiz,
+        resolvedEntities: [
+          { mentioned: 'maíz', kind: 'planta', nombre_comun: 'Maíz', nombre_cientifico: 'Zea mays' },
+        ],
+        month: 5,
+      });
+      expect(ctx).toContain('YA TIENE registrado');
+      expect(ctx).toContain('Maíz');
+    });
+
+    it('NO marca cruce si la entidad mencionada no está en el inventario', () => {
+      const ctx = buildFincaContext({
+        groupedCultivos: cultivosMaiz,
+        resolvedEntities: [
+          { mentioned: 'aguacate', kind: 'planta', nombre_comun: 'Aguacate', nombre_cientifico: 'Persea americana' },
+        ],
+        month: 5,
+      });
+      expect(ctx).not.toContain('YA TIENE registrado');
+    });
+
+    it('ignora plagas en el cruce de inventario', () => {
+      const ctx = buildFincaContext({
+        groupedCultivos: [{ name: 'Café', count: 3 }],
+        resolvedEntities: [
+          { mentioned: 'broca', kind: 'plaga', nombre_comun: 'Broca', nombre_cientifico: 'Hypothenemus hampei' },
+        ],
+        month: 5,
+      });
+      expect(ctx).not.toContain('YA TIENE registrado');
+    });
+
+    it('match laxo: "maíz" mencionado contra "Maíz amarillo" registrado', () => {
+      const ctx = buildFincaContext({
+        groupedCultivos: [{ name: 'Maíz amarillo', count: 4 }],
+        resolvedEntities: [
+          { mentioned: 'maiz', kind: 'planta', nombre_comun: 'Maíz', nombre_cientifico: 'Zea mays' },
+        ],
+        month: 5,
+      });
+      expect(ctx).toContain('YA TIENE registrado');
+      expect(ctx).toContain('Maíz amarillo');
     });
   });
 });

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -498,3 +498,244 @@ export function buildClimaContext(snapshot, opts = {}) {
 
   return lines.join('\n');
 }
+
+/**
+ * Deriva el piso térmico colombiano a partir de la altitud en msnm.
+ * Cotas clásicas (Caldas-Lang / IDEAM) usadas en el resto del código.
+ *
+ * @param {number|string|null|undefined} altitud — msnm
+ * @returns {'cálido'|'templado'|'frío'|'páramo'|null}
+ */
+export function pisoTermicoFromAltitud(altitud) {
+  if (altitud == null || altitud === '') return null;
+  const alt = Number(altitud);
+  if (!Number.isFinite(alt)) return null;
+  if (alt >= 3000) return 'páramo';
+  if (alt >= 2000) return 'frío';
+  if (alt >= 1000) return 'templado';
+  return 'cálido';
+}
+
+/**
+ * Resuelve la temporada climática del régimen bimodal andino colombiano para
+ * un mes dado (1-12). Las dos temporadas secas (DEF y JJA) y las dos lluviosas
+ * (MAM y SON) son el patrón dominante en la región Andina y buena parte del
+ * país. Es una aproximación calendárica — el ENSO la modula y eso lo aporta el
+ * bloque clima. NO hace fetch: solo aritmética del mes local.
+ *
+ * @param {number} [month] — mes 1-12; por defecto el mes actual local.
+ * @returns {{ nombre: string, detalle: string }}
+ */
+export function temporadaColombiana(month) {
+  const m = Number.isFinite(month) ? month : new Date().getMonth() + 1;
+  // Régimen bimodal andino (IDEAM): dos secas + dos lluviosas al año.
+  if (m === 12 || m === 1 || m === 2) {
+    return { nombre: 'temporada seca (diciembre–febrero)', detalle: 'primer veranillo del año' };
+  }
+  if (m >= 3 && m <= 5) {
+    return { nombre: 'primera temporada de lluvias (marzo–mayo)', detalle: 'pico de siembra principal en zona andina' };
+  }
+  if (m >= 6 && m <= 8) {
+    return { nombre: 'segunda temporada seca (junio–agosto)', detalle: 'veranillo de mitad de año (San Juan)' };
+  }
+  return { nombre: 'segunda temporada de lluvias (septiembre–noviembre)', detalle: 'segunda ventana de siembra del año' };
+}
+
+/**
+ * Resume el inventario agrupado de cultivos/plantas del usuario en una línea
+ * compacta. Recibe el array YA agrupado por especie con { name, count }.
+ *
+ * @param {Array<{name:string,count:number}>} grouped
+ * @param {number} [max=8] — cuántas especies listar antes de "y N más".
+ * @returns {string} ej. "maíz ×2, café, frijol y 3 más" o '' si vacío.
+ */
+function summarizeCultivos(grouped, max = 8) {
+  if (!Array.isArray(grouped) || grouped.length === 0) return '';
+  const items = grouped
+    .filter((g) => g && typeof g.name === 'string' && g.name.trim())
+    .map((g) => ({ name: g.name.trim(), count: Number(g.count) || 1 }))
+    .sort((a, b) => b.count - a.count);
+  if (items.length === 0) return '';
+  const shown = items.slice(0, max).map((g) => (g.count > 1 ? `${g.name} ×${g.count}` : g.name));
+  const rest = items.length - shown.length;
+  return rest > 0 ? `${shown.join(', ')} y ${rest} más` : shown.join(', ');
+}
+
+const _stripDiacritics = (s) =>
+  (s || '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+
+/**
+ * Cruza las entidades resueltas por el grounding AGE (este turno) contra el
+ * inventario local del usuario. NO hace queries — `resolvedEntities` ya viene
+ * resuelto por el sidecar y `groupedCultivos` ya está en memoria (asset store).
+ * Marca qué especies mencionadas el usuario YA TIENE registradas para que el
+ * agente personalice ("usted ya tiene X en la finca…").
+ *
+ * Match laxo por substring de nombre común normalizado (sin tildes,
+ * minúsculas) en ambas direcciones, suficiente para "maíz" ↔ "Maíz amarillo".
+ *
+ * @param {Array<object>|null} resolvedEntities — de /resolve-entities (AGE).
+ * @param {Array<{name:string,count:number}>} groupedCultivos
+ * @returns {Array<{nombre:string,count:number}>} especies mencionadas que el
+ *   usuario tiene registradas (deduplicadas).
+ */
+function crossResolvedWithInventory(resolvedEntities, groupedCultivos) {
+  if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) return [];
+  if (!Array.isArray(groupedCultivos) || groupedCultivos.length === 0) return [];
+  const inv = groupedCultivos
+    .filter((g) => g && g.name)
+    .map((g) => ({ name: g.name, count: Number(g.count) || 1, norm: _stripDiacritics(g.name) }))
+    .filter((g) => g.norm.length >= 3);
+  const hits = new Map();
+  for (const e of resolvedEntities) {
+    if (!e || e.kind === 'plaga') continue; // solo plantas/cultivos
+    const cands = [e.nombre_comun, e.mentioned].map(_stripDiacritics).filter((s) => s.length >= 3);
+    for (const item of inv) {
+      const match = cands.some((c) => item.norm.includes(c) || c.includes(item.norm));
+      if (match && !hits.has(item.name)) {
+        hits.set(item.name, { nombre: item.name, count: item.count });
+      }
+    }
+  }
+  return Array.from(hits.values());
+}
+
+/**
+ * buildFincaContext — bloque AMBIENTAL COMPACTO que da al agente conciencia
+ * implícita del contexto físico de la finca: dónde está, qué clima/temporada
+ * vive y qué tiene sembrado, SIN que el usuario lo tenga que repetir.
+ *
+ * RESTRICCIÓN #1 (innegociable): CERO latencia añadida. Esta función es PURA y
+ * SÍNCRONA — NO hace fetch, NO toca red, NO consulta el grafo. Todos sus
+ * insumos ya están disponibles localmente o en cache cuando el chat corre:
+ *   - profile       → localStorage (userProfileService.getProfile, síncrono)
+ *   - finca         → fincaActiveStore (memoria)
+ *   - climaSnapshot → climaService.getCachedClimaSnapshot (cache 30 min, ya se
+ *                     lee en el path del chat; aquí se REUTILIZA, no se re-pide)
+ *   - groupedCultivos → asset store en memoria (plants ya agrupadas)
+ *   - resolvedEntities → grounding AGE del turno (ya resuelto, se REUTILIZA)
+ *   - activeAlerts  → useAlertStore (memoria)
+ * Si algún insumo falta, se OMITE su línea (degradar, no esperar).
+ *
+ * Filosofía de uso (memoria #202): el agente TIENE el contexto para razonar de
+ * forma específica a la finca, pero NO debe recitar estos datos salvo que sean
+ * relevantes a la pregunta. El bloque lo instruye explícitamente.
+ *
+ * @param {object} args
+ * @param {object|null} [args.profile] — userProfileService.getProfile()
+ * @param {object|null} [args.finca] — finca activa (fincaActiveStore)
+ * @param {object|null} [args.climaSnapshot] — getCachedClimaSnapshot()
+ * @param {Array<{name:string,count:number}>} [args.groupedCultivos] — inventario agrupado
+ * @param {Array<object>|null} [args.resolvedEntities] — entidades AGE del turno
+ * @param {Array<object>} [args.activeAlerts] — useAlertStore activeAlerts
+ * @param {number} [args.month] — override de mes para tests (1-12)
+ * @returns {string} bloque compacto (siempre incluye al menos la temporada).
+ */
+export function buildFincaContext({
+  profile = null,
+  finca = null,
+  climaSnapshot = null,
+  groupedCultivos = [],
+  resolvedEntities = null,
+  activeAlerts = [],
+  month,
+} = {}) {
+  const p = profile && typeof profile === 'object' ? profile : {};
+  const lines = [];
+
+  // ── Ubicación ───────────────────────────────────────────────────────────
+  const municipio = p.municipio || null;
+  const departamento = p.departamento || null;
+  const altitud = p.finca_altitud || (finca && finca.altitud) || null;
+  const piso =
+    (p.piso_termico && String(p.piso_termico).trim()) ||
+    pisoTermicoFromAltitud(altitud) ||
+    null;
+  const lat = Number(p.ubicacion_lat);
+  const lng = Number(p.ubicacion_lng);
+  const ubic = [];
+  const lugar = [municipio, departamento].filter(Boolean).join(', ');
+  if (lugar) ubic.push(lugar);
+  if (altitud) ubic.push(`~${altitud} msnm`);
+  if (piso) ubic.push(`piso ${piso}`);
+  if (Number.isFinite(lat) && Number.isFinite(lng)) {
+    ubic.push(`(${lat.toFixed(3)}, ${lng.toFixed(3)})`);
+  }
+  if (finca && finca.nombre) {
+    lines.push(`Finca activa: "${finca.nombre}"${ubic.length ? ` — ${ubic.join(', ')}` : ''}.`);
+  } else if (ubic.length) {
+    lines.push(`Ubicación: ${ubic.join(', ')}.`);
+  }
+
+  // ── Temporada (calendárica, local — sin red) ────────────────────────────
+  const temporada = temporadaColombiana(month);
+  lines.push(`Temporada actual: ${temporada.nombre} — ${temporada.detalle}.`);
+
+  // ── Clima (reutiliza el snapshot YA cacheado) ───────────────────────────
+  if (climaSnapshot && typeof climaSnapshot === 'object') {
+    const enso = climaSnapshot.enso_status;
+    if (enso && typeof enso === 'object' && enso.phase && enso.phase !== 'neutral') {
+      lines.push(`Fenómeno ENSO en curso: ${enso.label || enso.phase} (modula la temporada de arriba).`);
+    }
+    const om = climaSnapshot.openmeteo;
+    const fc = om && om.available && Array.isArray(om.forecast_7d) ? om.forecast_7d : null;
+    if (fc && fc.length > 0) {
+      const hoy = fc[0];
+      const tmax = typeof hoy.temp_max_c === 'number' ? `${Math.round(hoy.temp_max_c)}°` : null;
+      const tmin = typeof hoy.temp_min_c === 'number' ? `${Math.round(hoy.temp_min_c)}°` : null;
+      const lluviaHoy = typeof hoy.precip_mm === 'number' && hoy.precip_mm >= 1
+        ? `, lluvia ~${Math.round(hoy.precip_mm)}mm`
+        : '';
+      const tempHoy = tmax && tmin ? `${tmin}/${tmax}C` : tmax || tmin || '';
+      // Resumen 7d: días con lluvia y mínima absoluta de la semana (heladas).
+      const diasLluvia = fc.filter((d) => typeof d.precip_mm === 'number' && d.precip_mm >= 1).length;
+      const minimas = fc.map((d) => d.temp_min_c).filter((v) => typeof v === 'number');
+      const minAbs = minimas.length ? Math.round(Math.min(...minimas)) : null;
+      const resumen7d = [
+        diasLluvia > 0 ? `${diasLluvia}/7 días con lluvia` : 'semana sin lluvia significativa',
+        minAbs != null ? `mínima de la semana ${minAbs}°C` : null,
+      ].filter(Boolean).join(', ');
+      if (tempHoy) {
+        lines.push(`Clima local hoy: ${tempHoy}${lluviaHoy}. Pronóstico 7d (Open-Meteo / IDEAM): ${resumen7d}.`);
+      } else {
+        lines.push(`Pronóstico 7d (Open-Meteo / IDEAM): ${resumen7d}.`);
+      }
+    }
+  }
+
+  // ── Alertas activas (memoria, sin red) ──────────────────────────────────
+  const alerts = Array.isArray(activeAlerts) ? activeAlerts.filter(Boolean) : [];
+  if (alerts.length > 0) {
+    const top = alerts
+      .slice(0, 3)
+      .map((a) => a.title || a.message || a.type)
+      .filter(Boolean);
+    if (top.length) lines.push(`Alertas activas: ${top.join('; ')}.`);
+  }
+
+  // ── Finca / inventario (resumen compacto, NO el detalle) ────────────────
+  const cultivos = summarizeCultivos(groupedCultivos);
+  if (cultivos) {
+    lines.push(`Cultivos registrados en la finca: ${cultivos}.`);
+  }
+
+  // ── Cruce grounding × inventario (sin queries nuevas) ───────────────────
+  const tieneRegistrado = crossResolvedWithInventory(resolvedEntities, groupedCultivos);
+  if (tieneRegistrado.length > 0) {
+    const nombres = tieneRegistrado.map((t) => t.nombre).join(', ');
+    lines.push(
+      `RELEVANTE A ESTA PREGUNTA: el usuario YA TIENE registrado en su finca lo que mencionó: ${nombres}. Personaliza la respuesta a SUS plantas (no hables en genérico si puedes referirte a las que tiene).`,
+    );
+  }
+
+  return `=== CONTEXTO AMBIENTAL DE LA FINCA (para razonar específico — NO lo recites salvo que sea relevante a la pregunta) ===
+${lines.join('\n')}
+
+INSTRUCCIÓN: usa este contexto para responder específico a la finca del usuario SIN pedirle que repita dónde está, qué clima tiene o qué siembra. Si menciona una planta/cultivo que ya tiene registrado, tenlo en cuenta. Ajusta siembra, manejo y recomendaciones a su altitud, piso térmico, temporada y clima. NO enumeres estos datos como preámbulo: solo menciona los que la pregunta concreta requiera.
+=== FIN CONTEXTO AMBIENTAL ===`;
+}


### PR DESCRIPTION
Inyecta un bloque `=== CONTEXTO AMBIENTAL DE LA FINCA ===` al prompt del agente: ubicación+altitud+piso térmico, temporada bimodal andina, ENSO en curso, clima hoy + resumen 7d, alertas activas, cultivos registrados, y cruce grounding×inventario (marca lo que el usuario YA TIENE).

**Cero latencia:** `buildFincaContext()` es pura/síncrona — todo sale de cache/memoria (getProfile localStorage, finca store, getCachedClimaSnapshot reutilizado, assets store, resolvedEntities del turno). Sin fetch/red/grafo nuevos. ~307 tokens en finca poblada.

Tests: 69/69 en agentService + 113/113 suites relacionadas. Eslint limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)