### PR TITLE
feat(agent): viabilidad de cultivo honesta por altitud + presentación de datos locales

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -27,7 +27,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, postValidate, getClimaIdeam } from '../../services/sidecarClient';
-import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
+import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, generateViabilityRules, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
@@ -704,6 +704,8 @@ HERRAMIENTAS NORMATIVA SOLO PARA VALIDACIÓN, NUNCA PRESCRIPCIÓN:
 
 Responde en español colombiano (tú/usted, sin voseo argentino). Sé específico y útil cuando tengas certeza; humilde y preguntón cuando no.
 
+${generateViabilityRules()}
+
 ${buildProfileContext(finca)}`;
   }, [plants, fincas, activeFincaSlug, indoorZone]);
 
@@ -1041,8 +1043,9 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       }, {});
       return Object.entries(counts).map(([name, count]) => ({ name, count }));
     })();
+    const fincaProfile = (() => { try { return getProfile(); } catch (_) { return null; } })();
     const fincaContext = `\n\n${buildFincaContext({
-      profile: (() => { try { return getProfile(); } catch (_) { return null; } })(),
+      profile: fincaProfile,
       finca: fincaActivaCtx,
       climaSnapshot,
       groupedCultivos,
@@ -1050,8 +1053,19 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       activeAlerts,
     })}`;
 
+    // VIABILIDAD POR ALTITUD (determinístico, sin red). Cruza la altitud de la
+    // finca contra el rango altitud_min/altitud_max que el grounding AGE trae
+    // por especie (lo agrega el sidecar). Degrada con gracia: si el rango no
+    // viene, no afirma viabilidad. Cero latencia: pura sobre datos ya en mano.
+    const fincaAltitud =
+      (fincaProfile && fincaProfile.finca_altitud) ||
+      (fincaActivaCtx && fincaActivaCtx.altitud) ||
+      null;
+    const viabilidadBlock = buildViabilityContext({ fincaAltitud, resolvedEntities });
+    const viabilidadContext = viabilidadBlock ? `\n\n${viabilidadBlock}` : '';
+
     const messages = [
-      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + climaContext + fincaContext + queryAnalysisBlock },
+      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + viabilidadContext + climaContext + fincaContext + queryAnalysisBlock },
       ...(contextMemory ? [{ role: 'user', content: contextMemory }] : []),
       { role: 'user', content: query },
     ];

--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -14,6 +14,8 @@ import {
   formatClimateAlert,
   buildClimaContext,
   buildFincaContext,
+  generateViabilityRules,
+  buildViabilityContext,
   pisoTermicoFromAltitud,
   temporadaColombiana,
 } from '../agentService.js';
@@ -644,6 +646,180 @@ describe('agentService — Task #202 Profile Context', () => {
       });
       expect(ctx).toContain('YA TIENE registrado');
       expect(ctx).toContain('Maíz amarillo');
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // Viabilidad honesta de cultivo (feat/agente-viabilidad-cultivo)
+  // El agente debe decir con honestidad cuándo una especie NO es viable para
+  // la altitud de la finca del usuario y sugerir alternativas SOLO del
+  // grounding/catálogo, nunca inventadas. Degrada con gracia cuando faltan
+  // los rangos de altitud (no afirma viabilidad sin datos).
+  // ────────────────────────────────────────────────────────────────────────
+  describe('generateViabilityRules', () => {
+    const rules = generateViabilityRules();
+
+    it('es una regla estática (string no vacío, costo cero de red)', () => {
+      expect(typeof rules).toBe('string');
+      expect(rules.length).toBeGreaterThan(100);
+    });
+
+    it('declara que las preguntas son por defecto sobre la finca del usuario', () => {
+      expect(rules).toContain('POR DEFECTO');
+      expect(rules.toLowerCase()).toContain('finca');
+    });
+
+    it('exige honestidad cuando la altitud de la finca está fuera del rango de la especie', () => {
+      expect(rules).toContain('altitud_min');
+      expect(rules).toContain('altitud_max');
+      expect(rules).toContain('probabilidad de éxito');
+    });
+
+    it('exige que las alternativas salgan SOLO del catálogo/grounding, nunca inventadas', () => {
+      expect(rules).toContain('NUNCA inventes');
+      expect(rules).toContain('get_cultivos_viables');
+    });
+
+    it('degrada con gracia: sin rango no se afirma viabilidad', () => {
+      expect(rules.toLowerCase()).toContain('no afirmes');
+    });
+
+    it('guía la presentación de datos LOCALES como SUYOS', () => {
+      expect(rules).toContain('En tu finca');
+      expect(rules).toContain('SUYOS');
+    });
+
+    it('cero voseo argentino en la regla', () => {
+      expect(rules).not.toMatch(/\btenés\b/);
+      expect(rules).not.toMatch(/\bpodés\b/);
+      expect(rules).not.toMatch(/\bmirá\b/);
+      expect(rules).not.toMatch(/\bacá\b/);
+      expect(rules).not.toMatch(/\bsembrá\b/);
+      expect(rules).not.toMatch(/\belegí\b/);
+    });
+  });
+
+  describe('buildViabilityContext', () => {
+    it('devuelve string vacío sin entidades resueltas', () => {
+      expect(buildViabilityContext({ fincaAltitud: 2580, resolvedEntities: null })).toBe('');
+      expect(buildViabilityContext({ fincaAltitud: 2580, resolvedEntities: [] })).toBe('');
+      expect(buildViabilityContext({})).toBe('');
+    });
+
+    it('degrada con gracia: sin altitud de finca NO emite veredicto de viabilidad', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: null,
+        resolvedEntities: [
+          {
+            mentioned: 'coco', kind: 'species', nombre_comun: 'Coco',
+            nombre_cientifico: 'Cocos nucifera', altitud_min: 0, altitud_max: 1000,
+          },
+        ],
+      });
+      expect(ctx).toBe('');
+    });
+
+    it('degrada con gracia: especie sin rango de altitud NO se evalúa', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: 2580,
+        resolvedEntities: [
+          {
+            mentioned: 'coco', kind: 'species', nombre_comun: 'Coco',
+            nombre_cientifico: 'Cocos nucifera', altitud_min: null, altitud_max: null,
+          },
+        ],
+      });
+      expect(ctx).toBe('');
+    });
+
+    it('caso coco en finca a 2580m: marca probabilidad MUY BAJA (fuera de rango)', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: 2580,
+        resolvedEntities: [
+          {
+            mentioned: 'palmera de coco', kind: 'species', nombre_comun: 'Coco',
+            nombre_cientifico: 'Cocos nucifera', altitud_min: 0, altitud_max: 1000,
+            piso_termico: 'cálido',
+          },
+        ],
+      });
+      expect(ctx).toContain('Coco');
+      expect(ctx).toContain('MUY BAJA');
+      // Debe exponer el porqué: rango de la especie vs altitud de la finca
+      expect(ctx).toContain('0');
+      expect(ctx).toContain('1000');
+      expect(ctx).toContain('2580');
+      // Debe instruir sugerir alternativas del grounding/tool, no inventar
+      expect(ctx).toContain('get_cultivos_viables');
+    });
+
+    it('caso especie VIABLE: altitud de finca dentro del rango → no la marca inviable', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: 2580,
+        resolvedEntities: [
+          {
+            mentioned: 'papa', kind: 'species', nombre_comun: 'Papa',
+            nombre_cientifico: 'Solanum tuberosum', altitud_min: 2000, altitud_max: 3500,
+          },
+        ],
+      });
+      expect(ctx).not.toContain('MUY BAJA');
+    });
+
+    it('marca límite inferior: finca demasiado baja para la especie', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: 200,
+        resolvedEntities: [
+          {
+            mentioned: 'papa', kind: 'species', nombre_comun: 'Papa',
+            nombre_cientifico: 'Solanum tuberosum', altitud_min: 2000, altitud_max: 3500,
+          },
+        ],
+      });
+      expect(ctx).toContain('MUY BAJA');
+      expect(ctx).toContain('200');
+    });
+
+    it('ignora plagas/biopreparados (solo evalúa especies sembrables)', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: 2580,
+        resolvedEntities: [
+          {
+            mentioned: 'broca', kind: 'pest', nombre_comun: 'Broca',
+            nombre_cientifico: 'Hypothenemus hampei', altitud_min: 0, altitud_max: 1800,
+          },
+        ],
+      });
+      expect(ctx).toBe('');
+    });
+
+    it('cero voseo argentino en la salida', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: 2580,
+        resolvedEntities: [
+          {
+            mentioned: 'coco', kind: 'species', nombre_comun: 'Coco',
+            nombre_cientifico: 'Cocos nucifera', altitud_min: 0, altitud_max: 1000,
+          },
+        ],
+      });
+      expect(ctx).not.toMatch(/\btenés\b/);
+      expect(ctx).not.toMatch(/\bpodés\b/);
+      expect(ctx).not.toMatch(/\bmirá\b/);
+      expect(ctx).not.toMatch(/\bacá\b/);
+    });
+
+    it('tolera altitud de finca como string ("2580")', () => {
+      const ctx = buildViabilityContext({
+        fincaAltitud: '2580',
+        resolvedEntities: [
+          {
+            mentioned: 'coco', kind: 'species', nombre_comun: 'Coco',
+            nombre_cientifico: 'Cocos nucifera', altitud_min: 0, altitud_max: 1000,
+          },
+        ],
+      });
+      expect(ctx).toContain('MUY BAJA');
     });
   });
 });

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -500,6 +500,112 @@ export function buildClimaContext(snapshot, opts = {}) {
 }
 
 /**
+ * generateViabilityRules — regla ESTÁTICA del system prompt para que el agente:
+ *
+ *   1. VIABILIDAD HONESTA: si el usuario quiere sembrar una especie cuya altitud
+ *      de finca cae FUERA del rango [altitud_min, altitud_max] de esa especie,
+ *      lo dice con honestidad directa pero amable (probabilidad muy baja + el
+ *      porqué) y SUGIERE alternativas viables SOLO del catálogo/grounding o del
+ *      tool get_cultivos_viables — NUNCA inventadas. Si no tiene el rango de la
+ *      especie, NO afirma nada sobre viabilidad (degrada con gracia).
+ *   2. DEFAULT FINCA-CONTEXT: las preguntas son POR DEFECTO sobre la finca del
+ *      usuario sin que él lo tenga que decir (lo habilita buildFincaContext;
+ *      aquí solo se declara como comportamiento por defecto).
+ *   3. PRESENTACIÓN LOCAL "linda" (costo CERO de inteligencia — solo fraseo): al
+ *      citar datos de la finca, que se note que son SUYOS y LOCALES.
+ *
+ * Es una constante de prompt — sin red, sin estado, sin latencia. Se concatena
+ * una sola vez en el system prompt.
+ *
+ * @returns {string}
+ */
+export function generateViabilityRules() {
+  return `REGLA DE VIABILIDAD HONESTA DE CULTIVO:
+Las preguntas del usuario son POR DEFECTO sobre SU finca (su ubicación, altitud, piso térmico, clima y cultivos), aunque no lo diga explícitamente. Asume ese contexto: ya lo tienes en el bloque "=== CONTEXTO AMBIENTAL DE LA FINCA ===".
+
+Si el usuario quiere sembrar una especie y el grounding ("=== ENTIDADES RESUELTAS ===") trae para esa especie su rango de altitud (altitud_min / altitud_max) Y conoces la altitud de la finca, compara:
+- Si la altitud de la finca está FUERA del rango [altitud_min, altitud_max] de la especie, dilo con HONESTIDAD directa pero amable: la probabilidad de éxito es muy baja y POR QUÉ (ej: el coco necesita 0–1000 m / clima cálido, y tu finca está a 2580 m / piso frío). Dile que no vale la pena el esfuerzo y SUGIERE 2–3 alternativas viables para SU altitud / piso térmico.
+- Las alternativas salen SOLO del catálogo / grounding provisto en este mensaje o del tool get_cultivos_viables. NUNCA inventes especies ni inventes que algo es viable.
+- Si NO tienes el rango de altitud de la especie (no vino en el grounding o viene null), NO afirmes NADA sobre viabilidad: sé neutral, no digas que sí ni que no. Mejor pide o consulta el dato antes de prometer éxito.
+
+Tono: honesto sin ser frío. Ejemplo: "Sembrar coco en tu Guatoc (2580 m, piso frío) tiene una probabilidad de éxito muy baja: el coco es de clima cálido (0–1000 m). No vale la pena el esfuerzo. Para tu altura te irían mejor [2–3 alternativas del catálogo]."
+
+REGLA DE PRESENTACIÓN DE DATOS LOCALES (solo fraseo, sin tablas ni formato pesado):
+Cuando cites datos de la finca del usuario, deja claro que son SUYOS y LOCALES, no generalidades: "En tu finca tienes…", "El clima hoy en tu finca…", "Según lo que registraste…", "Para tu altura (2580 m)…". El usuario puede ser campesino o un niño de 11 años: que entienda al instante que hablas de SUS datos reales. Mantén las respuestas concisas, sin enumerar todo el contexto como preámbulo.`;
+}
+
+/**
+ * buildViabilityContext — bloque DETERMINÍSTICO de viabilidad por especie.
+ *
+ * Cruza la altitud de la finca del usuario contra el rango [altitud_min,
+ * altitud_max] de cada especie resuelta por el grounding AGE (este turno). Para
+ * cada especie SEMBRABLE cuya altitud de finca cae FUERA de su rango, emite una
+ * línea autoritativa "probabilidad MUY BAJA" con el porqué (rango especie vs
+ * altitud finca) para que el LLM no la afirme viable por instinto.
+ *
+ * RESTRICCIÓN #1 (innegociable): CERO latencia. Función PURA y SÍNCRONA — NO
+ * hace fetch, NO toca red, NO consulta el grafo. Reutiliza `resolvedEntities`
+ * (ya resueltas por el sidecar este turno) y la altitud de la finca (ya en
+ * profile/store). Otro agente está agregando altitud_min/altitud_max/piso_termico
+ * por especie al grounding; mientras no lleguen, DEGRADA con gracia: si el campo
+ * no viene (o viene null), esa especie NO se evalúa y NO se afirma viabilidad.
+ *
+ * @param {object} args
+ * @param {number|string|null} [args.fincaAltitud] — msnm de la finca activa.
+ * @param {Array<object>|null} [args.resolvedEntities] — entidades AGE del turno.
+ *   Cada una puede traer { kind, nombre_comun, altitud_min, altitud_max, piso_termico }.
+ * @returns {string} bloque compacto, o '' si no hay nada accionable.
+ */
+export function buildViabilityContext({
+  fincaAltitud = null,
+  resolvedEntities = null,
+} = {}) {
+  if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) return '';
+
+  const alt = Number(fincaAltitud);
+  // Sin altitud de finca NO se puede juzgar viabilidad — degradar a neutral.
+  if (!Number.isFinite(alt)) return '';
+
+  const fincaPiso = pisoTermicoFromAltitud(alt);
+  const inviables = [];
+
+  for (const e of resolvedEntities) {
+    if (!e || typeof e !== 'object') continue;
+    // Solo especies sembrables. Las plagas/biopreparados no se "siembran".
+    const kind = String(e.kind || '').toLowerCase();
+    if (kind && kind !== 'species' && kind !== 'planta' && kind !== 'especie' && kind !== 'cultivo') {
+      continue;
+    }
+    // Degradar con gracia: sin rango usable NO se afirma viabilidad.
+    // Number(null) === 0, así que hay que descartar null/undefined/'' ANTES
+    // de coaccionar — si no, una especie sin altitud_min se leería como 0 m.
+    if (e.altitud_min == null || e.altitud_min === '') continue;
+    if (e.altitud_max == null || e.altitud_max === '') continue;
+    const min = Number(e.altitud_min);
+    const max = Number(e.altitud_max);
+    if (!Number.isFinite(min) || !Number.isFinite(max)) continue;
+
+    if (alt < min || alt > max) {
+      const nombre = e.nombre_comun || e.mentioned || 'esa especie';
+      const pisoSp = e.piso_termico ? `, piso ${e.piso_termico}` : '';
+      const fincaPisoTxt = fincaPiso ? `, piso ${fincaPiso}` : '';
+      inviables.push(
+        `- ${nombre}: rango de la especie ${min}–${max} msnm${pisoSp}; la finca está a ${alt} msnm${fincaPisoTxt} → probabilidad de éxito MUY BAJA (fuera de rango).`,
+      );
+    }
+  }
+
+  if (inviables.length === 0) return '';
+
+  return `=== VIABILIDAD POR ALTITUD (determinístico, autoritativo — verificado contra el catálogo) ===
+La(s) siguiente(s) especie(s) que el usuario mencionó NO son viables para la altitud de su finca:
+${inviables.join('\n')}
+
+REGLA: si el usuario pregunta por sembrar alguna de estas, sé honesto y amable: dile que la probabilidad de éxito es muy baja y POR QUÉ (rango de la especie vs altitud de su finca), que no vale la pena el esfuerzo, y sugiérele 2–3 alternativas viables para SU altitud. Las alternativas salen SOLO del catálogo / grounding de este mensaje o del tool get_cultivos_viables — NUNCA inventes especies ni inventes viabilidad.
+=== FIN VIABILIDAD POR ALTITUD ===`;
+}
+
+/**
  * Deriva el piso térmico colombiano a partir de la altitud en msnm.
  * Cotas clásicas (Caldas-Lang / IDEAM) usadas en el resto del código.
  *


### PR DESCRIPTION
Pedido del operador: el agente, por defecto en contexto de finca, evalúa la viabilidad de un cultivo y si no es viable da una recomendación honesta sin inventar (ej: 'coco en Guatoc a 2580m → probabilidad muy baja, mejor papa/arveja').

- `generateViabilityRules()`: regla estática del prompt (viabilidad honesta + default finca + fraseo de datos locales 'En tu finca…').
- `buildViabilityContext({fincaAltitud, resolvedEntities})`: bloque determinístico que cruza la altitud de la finca contra `altitud_min/max` que el grounding AGE trae por especie. Degrada con gracia (sin rango → neutral, no inventa).
- Costo CERO latencia (funciones puras/síncronas, reusa resolvedEntities + altitud ya en mano).

Alternativas salen SOLO del catálogo/grounding o get_cultivos_viables — nunca inventadas. Construye sobre el contexto-finca (#1218). 17 tests nuevos, 2585 passed, cero voseo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)