### PR TITLE
fix(location): detectar ubicación gruesa (Brave) + altitud manual real de la finca

### DIFF
--- a/src/components/LocationDetectedScreen.jsx
+++ b/src/components/LocationDetectedScreen.jsx
@@ -16,11 +16,13 @@ import {
   ChevronDown,
   LocateFixed,
   Move,
+  Pencil,
 } from 'lucide-react';
 import {
   resolveUbicacion,
   forwardGeocode,
   getPisoTermicoInfo,
+  isCoarseLocation,
 } from '../services/locationService';
 import { useFincaActiveStore } from '../services/fincaActiveStore';
 import { saveProfile } from '../services/userProfileService';
@@ -255,6 +257,11 @@ export default function LocationDetectedScreen({
   const [cascadeOpen, setCascadeOpen] = useState(false);
   const [cascadeDpto, setCascadeDpto] = useState('');
   const [geoState, setGeoState] = useState('idle'); // idle | detecting | denied | unavailable
+  // #coarse-location (2026-05-30): altitud editable por el usuario. Si la
+  // ubicación es gruesa (Brave/escritorio sin GPS → cabecera municipal) NO
+  // confiamos en la altitud derivada; el campesino corrige su altura real
+  // (ej. finca a 2580 msnm vs cabecera 1923). Vacío = usar la derivada.
+  const [manualAltitud, setManualAltitud] = useState('');
   const markerRef = useRef(null);
   const setFincaIndoorZone = useFincaActiveStore((s) => s.setIndoorZone);
 
@@ -294,10 +301,14 @@ export default function LocationDetectedScreen({
     setLoading(true);
     navigator.geolocation.getCurrentPosition(
       (pos) => {
-        const { latitude, longitude, altitude } = pos.coords;
+        const { latitude, longitude, altitude, accuracy } = pos.coords;
+        // #coarse-location: arrastramos `accuracy` (radio de incertidumbre en
+        // metros) para decidir si confiamos en la altitud derivada de ESTA
+        // posición. En Brave/escritorio sin GPS llega en varios km y cae en la
+        // cabecera; ahí NO auto-derivamos como verdad — pedimos corrección.
         resolveUbicacion({ lat: latitude, lng: longitude, altitud: altitude ?? null })
           .then((r) => {
-            setLoc(r);
+            setLoc({ ...r, accuracy: accuracy ?? null });
             setGeoState('idle');
           })
           .catch(() => setGeoState('idle'))
@@ -336,15 +347,20 @@ export default function LocationDetectedScreen({
     setLoading(true);
     try {
       const enriched = await resolveUbicacion({ lat, lng });
+      // #coarse-location: al fijar el pin manualmente la posición pasa a ser
+      // PRECISA por definición del usuario → limpiamos `accuracy` para que el
+      // aviso de "ubicación aproximada" desaparezca y la altitud derivada de
+      // este punto exacto vuelva a ser confiable.
       setLoc((prev) => ({
         ...(prev || {}),
         ...enriched,
         lat,
         lng,
+        accuracy: null,
       }));
     } catch (e) {
       console.warn('[LocationDetected] drag resolve falló:', e);
-      setLoc((prev) => ({ ...(prev || {}), lat, lng }));
+      setLoc((prev) => ({ ...(prev || {}), lat, lng, accuracy: null }));
     } finally {
       setLoading(false);
     }
@@ -441,12 +457,31 @@ export default function LocationDetectedScreen({
     }
   };
 
-  // Piso térmico derivado en vivo (offline-safe) si tenemos altitud.
+  // #coarse-location: ¿la lectura GPS fue gruesa? (Brave/escritorio sin GPS
+  // ubica por IP/wifi → varios km → cabecera municipal). Si lo es, NO tratamos
+  // la altitud derivada como verdad y empujamos al usuario a corregir.
+  const isCoarse = isCoarseLocation(loc?.accuracy);
+
+  // Altitud manual válida (rango físico Colombia: -100 a 6000 msnm). El campo
+  // editable gana SIEMPRE sobre la derivada cuando trae un número plausible.
+  const manualAltitudNum = useMemo(() => {
+    const t = manualAltitud.trim();
+    if (t === '') return null;
+    const n = Number(t);
+    return Number.isFinite(n) && n >= -100 && n <= 6000 ? Math.round(n) : null;
+  }, [manualAltitud]);
+
+  // Altitud efectiva: la manual gana sobre la derivada. Es la que se guarda,
+  // alimenta el piso térmico y la montaña, y va al perfil (viabilidad + helada).
+  const effectiveAltitud = manualAltitudNum != null ? manualAltitudNum : (loc?.altitud ?? null);
+  const altitudSource = manualAltitudNum != null ? 'manual' : 'derived';
+
+  // Piso térmico derivado en vivo (offline-safe) de la altitud EFECTIVA.
   const pisoInfo = useMemo(() => {
+    if (effectiveAltitud != null) return getPisoTermicoInfo(effectiveAltitud);
     if (loc?.pisoTermico) return loc.pisoTermico;
-    if (loc?.altitud != null) return getPisoTermicoInfo(loc.altitud);
     return null;
-  }, [loc]);
+  }, [effectiveAltitud, loc?.pisoTermico]);
 
   const handleConfirm = () => {
     if (!loc) return;
@@ -466,7 +501,16 @@ export default function LocationDetectedScreen({
       region: loc.municipio
         ? [loc.municipio, loc.departamento].filter(Boolean).join(', ')
         : undefined,
-      finca_altitud: loc.altitud != null ? String(loc.altitud) : undefined,
+      // #coarse-location: guardamos la altitud EFECTIVA (manual gana sobre
+      // derivada) y de DÓNDE viene. ClimaStrip / alertEngine / viabilidad del
+      // agente leen `finca_altitud`; `altitud_source: 'manual'` señala que el
+      // usuario la fijó a mano y NO debe sobrescribirse con una lectura gruesa.
+      finca_altitud: effectiveAltitud != null ? String(effectiveAltitud) : undefined,
+      altitud_source: effectiveAltitud != null ? altitudSource : undefined,
+      // Radio de incertidumbre de la última lectura (metros). Útil para
+      // diagnosticar perfiles con altitud sospechosa de cabecera. null si
+      // la ubicación se fijó a mano (pin/búsqueda) y no hubo lectura GPS.
+      ubicacion_accuracy: loc.accuracy != null ? Math.round(loc.accuracy) : undefined,
       piso_termico: pisoInfo?.slug,
     });
     // Avisar a la UI montada (ClimaStrip, dashboard) que la ubicación cambió,
@@ -489,7 +533,14 @@ export default function LocationDetectedScreen({
         /* no-op */
       }
     }
-    if (onConfirm) onConfirm({ ...loc, pisoTermico: pisoInfo });
+    if (onConfirm) {
+      onConfirm({
+        ...loc,
+        altitud: effectiveAltitud,
+        altitud_source: effectiveAltitud != null ? altitudSource : undefined,
+        pisoTermico: pisoInfo,
+      });
+    }
   };
 
   const center = loc
@@ -724,18 +775,78 @@ export default function LocationDetectedScreen({
               </div>
             </div>
 
+            {/* #coarse-location: aviso de ubicación aproximada. En Brave/
+                escritorio sin GPS la posición cae en la cabecera municipal, así
+                que su altitud NO es la de la finca. Empujamos a corregir: mover
+                el pin o escribir la altura real. */}
+            {isCoarse && (
+              <div
+                data-testid="coarse-location-warning"
+                className="rounded-xl bg-amber-950/30 border border-amber-800/40 p-3 text-xs text-amber-200 flex gap-2"
+              >
+                <AlertCircle size={14} className="shrink-0 mt-0.5" />
+                <span>
+                  No pudimos ubicarte con precisión (señal aproximada). La altura
+                  mostrada puede ser la de la cabecera del municipio, no la de tu
+                  finca. Mueve el pin del mapa a tu finca o escribe tu altura en
+                  metros aquí abajo.
+                </span>
+              </div>
+            )}
+
             <div className="flex items-center gap-3 flex-wrap">
               <span className="inline-flex items-center gap-1.5 text-sm text-slate-300">
                 <Mountain size={16} className="text-slate-400" />
-                {loc.altitud != null ? `${loc.altitud} msnm` : 'Altitud no disponible'}
+                {effectiveAltitud != null ? `${effectiveAltitud} msnm` : 'Altitud no disponible'}
               </span>
               <PisoTermicoBadge info={pisoInfo} />
             </div>
 
-            {loc.altitud != null && (
+            {/* #coarse-location: altura editable. (a) corrige perfiles con la
+                altitud de la cabecera ya guardada; (b) el campesino conoce su
+                altura. Si escribe un valor, gana sobre la derivada
+                (altitud_source: 'manual'). Vacío = se usa la derivada. */}
+            <div className="pt-2 border-t border-slate-800">
+              <label
+                htmlFor="altitud-manual"
+                className="block text-xs font-medium text-slate-400 mb-1.5 flex items-center gap-1.5"
+              >
+                <Pencil size={12} className="text-emerald-400" />
+                Tu altura real (msnm)
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="altitud-manual"
+                  data-testid="altitud-manual-input"
+                  type="number"
+                  inputMode="numeric"
+                  value={manualAltitud}
+                  onChange={(e) => setManualAltitud(e.target.value)}
+                  placeholder={
+                    loc.altitud != null ? `Detectada: ${loc.altitud}` : 'Ej: 2580'
+                  }
+                  className="w-32 px-3 py-2 rounded-xl bg-slate-900 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-emerald-500/60"
+                />
+                <span className="text-xs text-slate-500">msnm</span>
+                {manualAltitudNum != null && (
+                  <span
+                    data-testid="altitud-source-manual"
+                    className="text-2xs text-emerald-300 bg-emerald-950/40 border border-emerald-800/40 rounded-full px-2 py-0.5"
+                  >
+                    Tu altura
+                  </span>
+                )}
+              </div>
+              <p className="text-2xs text-slate-500 mt-1.5">
+                Si conoces la altura exacta de tu finca, escríbela. Tu valor manda
+                sobre el detectado.
+              </p>
+            </div>
+
+            {effectiveAltitud != null && (
               <div className="pt-2 border-t border-slate-800">
                 <ThermalMountain
-                  altitud={loc.altitud}
+                  altitud={effectiveAltitud}
                   pisoSlug={pisoInfo?.slug}
                 />
               </div>

--- a/src/components/__tests__/LocationDetectedScreen.coarse.test.jsx
+++ b/src/components/__tests__/LocationDetectedScreen.coarse.test.jsx
@@ -1,0 +1,169 @@
+/**
+ * LocationDetectedScreen.coarse.test.jsx — corrección de ubicación gruesa
+ * (#coarse-location, 2026-05-30).
+ *
+ * El operador reportó: en Brave/NixOS sin GPS, `navigator.geolocation` ubica
+ * por IP/wifi con accuracy de varios km → cae en la cabecera municipal y la
+ * altitud derivada es la de la cabecera (ej. Choachí 1923 msnm), no la de la
+ * finca real (2580 msnm). Esa altitud equivocada envenena la viabilidad de
+ * cultivos y las alertas de helada del agente.
+ *
+ * Esta suite verifica el comportamiento de la pantalla:
+ *   1. Lectura gruesa (accuracy > umbral) → muestra el aviso de corrección.
+ *   2. Lectura fina (accuracy < 50 m, GPS celular) → NO muestra el aviso.
+ *   3. La altitud manual escrita gana sobre la derivada y se guarda con
+ *      `altitud_source: 'manual'`.
+ *   4. Al confirmar se dispara `chagra:location-updated` (ClimaStrip refresca).
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// react-leaflet es pesado (canvas/tiles) — lo stubbeamos. No es lo que
+// probamos acá; solo necesitamos que el componente monte.
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }) => <div data-testid="map">{children}</div>,
+  TileLayer: () => null,
+  Marker: () => null,
+}));
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+vi.mock('leaflet', () => ({
+  default: { icon: () => ({}), Marker: { prototype: { options: {} } } },
+}));
+vi.mock('leaflet/dist/images/marker-icon.png', () => ({ default: 'icon.png' }));
+vi.mock('leaflet/dist/images/marker-shadow.png', () => ({ default: 'shadow.png' }));
+
+// locationService: mockeamos solo la red (resolveUbicacion / forwardGeocode);
+// isCoarseLocation y getPisoTermicoInfo se mantienen REALES (lógica pura que
+// queremos ejercitar de verdad).
+vi.mock('../../services/locationService', async (importOriginal) => {
+  const real = await importOriginal();
+  return {
+    ...real,
+    resolveUbicacion: vi.fn(async ({ lat, lng, altitud }) => ({
+      lat,
+      lng,
+      municipio: 'Choachí',
+      departamento: 'Cundinamarca',
+      // Simula la altitud DERIVADA de la cabecera (Open-Elevation en el
+      // centroide del municipio): 1923 msnm. Es la altitud "mala".
+      altitud: altitud != null ? Math.round(altitud) : 1923,
+      pisoTermico: null,
+      cultivosRecomendados: [],
+    })),
+    forwardGeocode: vi.fn(async () => null),
+  };
+});
+
+const saveProfile = vi.fn();
+vi.mock('../../services/userProfileService', () => ({
+  saveProfile: (...a) => saveProfile(...a),
+}));
+
+vi.mock('../../services/fincaActiveStore', () => {
+  const store = { setIndoorZone: vi.fn() };
+  const useFincaActiveStore = (selector) => selector(store);
+  return { useFincaActiveStore, default: useFincaActiveStore };
+});
+
+vi.mock('../../utils/colombiaLocations', () => ({
+  getDepartamentos: () => [],
+  getMunicipios: () => [],
+  findMunicipio: () => null,
+}));
+
+import LocationDetectedScreen from '../LocationDetectedScreen';
+
+function mockGeolocation(accuracy) {
+  const getCurrentPosition = vi.fn((success) => {
+    success({
+      coords: {
+        latitude: 4.5306,
+        longitude: -73.9247,
+        altitude: null, // navegador de escritorio no entrega altitud GPS
+        accuracy,
+      },
+    });
+  });
+  Object.defineProperty(globalThis.navigator, 'geolocation', {
+    configurable: true,
+    value: { getCurrentPosition },
+  });
+  return getCurrentPosition;
+}
+
+describe('LocationDetectedScreen — corrección de ubicación gruesa', () => {
+  beforeEach(() => {
+    saveProfile.mockClear();
+  });
+
+  test('lectura GRUESA (accuracy 12 km) muestra el aviso de corrección', async () => {
+    mockGeolocation(12000);
+    render(<LocationDetectedScreen onConfirm={vi.fn()} onBack={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('coarse-location-warning')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('coarse-location-warning')).toHaveTextContent(
+      /señal aproximada/i,
+    );
+  });
+
+  test('lectura FINA (accuracy 30 m, GPS celular) NO muestra el aviso', async () => {
+    mockGeolocation(30);
+    render(<LocationDetectedScreen onConfirm={vi.fn()} onBack={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByTestId('map')).toBeInTheDocument());
+    // Esperar a que la altitud derivada aparezca → el bloque enriquecido montó.
+    await screen.findByTestId('altitud-manual-input');
+    expect(screen.queryByTestId('coarse-location-warning')).not.toBeInTheDocument();
+  });
+
+  test('la altitud manual GANA sobre la derivada y se guarda como manual', async () => {
+    mockGeolocation(12000); // gruesa → derivada 1923 (cabecera)
+    const onConfirm = vi.fn();
+    render(<LocationDetectedScreen onConfirm={onConfirm} onBack={vi.fn()} />);
+
+    const input = await screen.findByTestId('altitud-manual-input');
+    // El operador escribe su altura real: 2580 msnm.
+    fireEvent.change(input, { target: { value: '2580' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /confirmar/i }));
+
+    expect(saveProfile).toHaveBeenCalledTimes(1);
+    const saved = saveProfile.mock.calls[0][0];
+    expect(saved.finca_altitud).toBe('2580'); // NO 1923
+    expect(saved.altitud_source).toBe('manual');
+
+    // onConfirm también recibe la altitud efectiva (manual).
+    expect(onConfirm.mock.calls[0][0].altitud).toBe(2580);
+    expect(onConfirm.mock.calls[0][0].altitud_source).toBe('manual');
+  });
+
+  test('sin altitud manual, se guarda la derivada con source derived', async () => {
+    mockGeolocation(30); // fina → confiamos en la derivada
+    render(<LocationDetectedScreen onConfirm={vi.fn()} onBack={vi.fn()} />);
+
+    await screen.findByTestId('altitud-manual-input');
+    fireEvent.click(screen.getByRole('button', { name: /confirmar/i }));
+
+    const saved = saveProfile.mock.calls[0][0];
+    expect(saved.finca_altitud).toBe('1923');
+    expect(saved.altitud_source).toBe('derived');
+    expect(saved.ubicacion_accuracy).toBe(30);
+  });
+
+  test('al confirmar dispara chagra:location-updated (ClimaStrip refresca)', async () => {
+    mockGeolocation(30);
+    const listener = vi.fn();
+    window.addEventListener('chagra:location-updated', listener);
+    render(<LocationDetectedScreen onConfirm={vi.fn()} onBack={vi.fn()} />);
+
+    await screen.findByTestId('altitud-manual-input');
+    fireEvent.click(screen.getByRole('button', { name: /confirmar/i }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener('chagra:location-updated', listener);
+  });
+});

--- a/src/services/__tests__/locationService.coarse.test.js
+++ b/src/services/__tests__/locationService.coarse.test.js
@@ -1,0 +1,49 @@
+/**
+ * locationService.coarse.test.js — umbral de geolocalización gruesa (#coarse-location).
+ *
+ * El operador reportó: en Brave/NixOS sin GPS, `navigator.geolocation` ubica
+ * por IP/wifi con accuracy de varios km → cae en la cabecera municipal y la
+ * altitud derivada es la de la cabecera (1923 msnm), no la de la finca real
+ * (2580 msnm). Esa altitud equivocada envenena la viabilidad de cultivos y las
+ * alertas de helada del agente.
+ *
+ * Esta suite verifica el predicado puro que decide si una lectura es gruesa.
+ */
+import { describe, test, expect } from 'vitest';
+import { isCoarseLocation, COARSE_ACCURACY_THRESHOLD_M } from '../locationService';
+
+describe('isCoarseLocation — umbral de geolocalización gruesa', () => {
+  test('el umbral por defecto es 5000 m (conservador)', () => {
+    expect(COARSE_ACCURACY_THRESHOLD_M).toBe(5000);
+  });
+
+  test('GPS de celular preciso (<50 m) NO es grueso', () => {
+    expect(isCoarseLocation(35)).toBe(false);
+    expect(isCoarseLocation(50)).toBe(false);
+  });
+
+  test('lectura por IP/wifi de varios km SÍ es gruesa', () => {
+    expect(isCoarseLocation(12000)).toBe(true);
+    expect(isCoarseLocation(45000)).toBe(true);
+  });
+
+  test('exactamente en el umbral NO es gruesa (estricto >)', () => {
+    expect(isCoarseLocation(5000)).toBe(false);
+  });
+
+  test('justo por encima del umbral es gruesa', () => {
+    expect(isCoarseLocation(5001)).toBe(true);
+  });
+
+  test('umbral parametrizable', () => {
+    expect(isCoarseLocation(1500, 1000)).toBe(true);
+    expect(isCoarseLocation(1500, 2000)).toBe(false);
+  });
+
+  test('accuracy no numérico/ausente NO se considera grueso', () => {
+    expect(isCoarseLocation(null)).toBe(false);
+    expect(isCoarseLocation(undefined)).toBe(false);
+    expect(isCoarseLocation(NaN)).toBe(false);
+    expect(isCoarseLocation('no-soy-numero')).toBe(false);
+  });
+});

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -31,6 +31,42 @@ import { findNearestMunicipio } from '../utils/colombiaLocations.js';
 const NOMINATIM_TIMEOUT_MS = 8000;
 
 /**
+ * Umbral (en metros) del radio de incertidumbre `position.coords.accuracy`
+ * por encima del cual NO confiamos en la posición para derivar la altitud de
+ * la finca (#coarse-location, 2026-05-30).
+ *
+ * Contexto: `navigator.geolocation` reporta `accuracy` como el radio del
+ * círculo de confianza. GPS real de celular suele dar <50 m; un navegador de
+ * escritorio sin GPS (Brave/Chromium en NixOS) ubica por IP/wifi y da varios
+ * kilómetros — cae en la cabecera municipal o en Bogotá, no en la finca. Si
+ * derivamos la altitud de ESA posición guardamos la altura de la cabecera
+ * (ej. Choachí 1923 msnm) en vez de la finca real (ej. 2580 msnm), lo que
+ * envenena la viabilidad de cultivos y las alertas de helada del agente.
+ *
+ * 5000 m es un umbral conservador: deja pasar GPS de celular y la mayoría de
+ * lecturas wifi urbanas precisas, pero atrapa la geolocalización gruesa por IP.
+ */
+export const COARSE_ACCURACY_THRESHOLD_M = 5000;
+
+/**
+ * ¿La lectura de geolocalización es DEMASIADO gruesa para derivar la altitud
+ * de la finca de forma confiable?
+ *
+ * @param {number|null|undefined} accuracy - radio de incertidumbre en metros
+ *   (`position.coords.accuracy`).
+ * @param {number} [threshold] - umbral en metros (default
+ *   COARSE_ACCURACY_THRESHOLD_M). Parametrizable para tests / ajustes.
+ * @returns {boolean} true si la posición es gruesa (accuracy > threshold).
+ *   Si `accuracy` no es un número finito, devolvemos false (no podemos afirmar
+ *   que es gruesa; el navegador no reportó incertidumbre).
+ */
+export function isCoarseLocation(accuracy, threshold = COARSE_ACCURACY_THRESHOLD_M) {
+  const n = Number(accuracy);
+  if (!Number.isFinite(n)) return false;
+  return n > threshold;
+}
+
+/**
  * Metadatos visuales + cultivos recomendados por piso térmico colombiano.
  * Clasificación IDEAM / Caldas. Conocimiento agronómico público (OSS-safe):
  * los cultivos típicos de cada piso térmico son hechos de extensión rural


### PR DESCRIPTION
El navegador (Brave/escritorio) da ubicación gruesa → el perfil guardaba la altitud de la cabecera (1923m Choachí) en vez de la finca real (2580m). Fix: detecta accuracy>5km, fuerza pin manual + campo de altitud editable. El operador puede setear sus 2580 reales (altitud_source='manual' pisa la derivada). 12/12 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)