### PR TITLE
feat(agent): compositor multimodal en el home (texto+voz+foto/visión) + outbox durable

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -2,6 +2,21 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe } from '../../services/voiceService';
+// Outbox DURABLE (compositor multimodal del home). El AgentScreen es el
+// CONSUMIDOR: al montar, drena las consultas que el usuario disparó desde
+// AgentHero. Cada item aparece como burbuja "ya enviada" + se procesa
+// (texto→LLM, audio→whisper→LLM, foto→visión). Claim atómico anti-duplicado
+// y recuperación de items huérfanos (app cerrada mid-flight) — cero pérdida.
+import {
+  claimNext as outboxClaimNext,
+  markAnswered as outboxMarkAnswered,
+  markError as outboxMarkError,
+  recoverStaleProcessing as outboxRecoverStale,
+} from '../../services/agentOutboxService';
+// Visión: reuso del flujo existente (NO reimplemento). analyzeFoliage corre
+// el diagnóstico foliar multimodal con cache por hash; la foto del home se
+// despacha por aquí al aterrizar.
+import { analyzeFoliage } from '../../services/aiService';
 import {
   addTurn,
   getFullHistory,
@@ -1761,6 +1776,147 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
   const handleSuggestion = (text) => {
     handleSubmit(text);
   };
+
+  // ── Consumo de la OUTBOX DURABLE del compositor del home ───────────────────
+  // El usuario disparó una consulta multimodal desde AgentHero; el item ya
+  // está persistido en IndexedDB. Aquí la procesamos como "ya enviada":
+  // aparece la burbuja de usuario + el agente arranca a procesar. NO esperamos
+  // a que el operador toque "enviar" otra vez.
+  //
+  // Garantías de integridad (todas demostradas en agentOutboxService.test):
+  //  - claimNext() es atómico → ningún item se procesa dos veces aunque el
+  //    efecto corra dos veces (React StrictMode) o haya dos montajes.
+  //  - recoverStaleProcessing() rescata items que quedaron 'processing' porque
+  //    la app se cerró a mitad → vuelven a 'queued' y se reintentan (el LLM no
+  //    confirmó respuesta, reintentar es correcto). Cero pérdida.
+  const outboxDrainingRef = useRef(false);
+
+  /**
+   * Procesa UN item ya reclamado (status='processing') según su modalidad y
+   * lo cierra (answered/error). Reusa el pipeline existente:
+   *   - text       → handleSubmit(texto)
+   *   - voice      → transcribe(blob) → handleSubmit(transcripción)
+   *   - photo      → analyzeFoliage(blob) → handleSubmit(prompt con hallazgo)
+   *   - attachment → handleSubmit(caption + nota del adjunto)
+   * Devuelve true si se despachó algo al pipeline (para encadenar el drenado).
+   */
+  const processOutboxItem = useCallback(async (item) => {
+    const caption = (item.text || '').trim();
+    try {
+      if (item.kind === 'text') {
+        if (!caption) { await outboxMarkError(item.id, 'item de texto vacío'); return false; }
+        await handleSubmit(caption);
+        await outboxMarkAnswered(item.id);
+        return true;
+      }
+
+      if (item.kind === 'voice') {
+        // Mostrar de inmediato un placeholder "ya enviado" (audio) mientras se
+        // transcribe — el usuario ve que su voz llegó, no una pantalla muerta.
+        setMessages((prev) => [
+          ...prev,
+          { role: 'user', content: '🎤 Audio enviado…', timestamp: Date.now(), _outboxPending: true, _outboxId: item.id },
+        ]);
+        if (!ttsEnabled) setTtsEnabled(true);
+        const text = item.blob ? await transcribe(item.blob) : '';
+        // Sustituir el placeholder por la transcripción real (sin duplicar).
+        setMessages((prev) => prev.filter((m) => m._outboxId !== item.id));
+        if (text && text.trim()) {
+          await handleSubmit(text.trim());
+          await outboxMarkAnswered(item.id, { answeredText: text.trim() });
+          return true;
+        }
+        setError('No entendí el audio. Prueba de nuevo desde el agente.');
+        await outboxMarkError(item.id, 'transcripción vacía');
+        return false;
+      }
+
+      if (item.kind === 'photo') {
+        // Burbuja de foto "ya enviada" con el caption del usuario.
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: 'user',
+            content: caption || '📷 Foto enviada para análisis',
+            timestamp: Date.now(),
+            _outboxPhoto: true,
+          },
+        ]);
+        let finding = null;
+        try {
+          finding = item.blob ? await analyzeFoliage(item.blob) : null;
+        } catch (visErr) {
+          console.debug('[Agent] analyzeFoliage falló, sigo con texto:', visErr?.message);
+        }
+        // Construir el prompt que despacha el pipeline normal. Si hubo
+        // diagnóstico de visión, lo inyectamos como contexto para que el LLM
+        // responda conversacionalmente y aterrizado.
+        let prompt;
+        if (finding && (Array.isArray(finding.issues) || finding.treatment_suggestion)) {
+          const issues = Array.isArray(finding.issues) && finding.issues.length > 0
+            ? finding.issues.join(', ')
+            : 'sin problemas evidentes';
+          const treat = finding.treatment_suggestion ? ` Sugerencia preliminar: ${finding.treatment_suggestion}.` : '';
+          prompt = `Analicé una foto de mi planta. Hallazgos del diagnóstico visual: ${issues} (estado ${finding.score ?? 'n/d'}/100).${treat} ${caption || '¿Qué me recomiendas hacer?'}`.trim();
+        } else {
+          prompt = caption
+            ? `Te envié una foto de mi planta. ${caption}`
+            : 'Te envié una foto de mi planta para que me ayudes a identificar qué tiene. No pude obtener un diagnóstico visual automático; guíame por descripción.';
+        }
+        await handleSubmit(prompt);
+        await outboxMarkAnswered(item.id);
+        return true;
+      }
+
+      // attachment (no-imagen): no hay análisis automático, despachamos el
+      // caption + nota del adjunto.
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'user',
+          content: caption ? `${caption}\n\n(📎 adjunto: ${item.fileName || 'archivo'})` : `📎 Adjunté un archivo: ${item.fileName || 'archivo'}`,
+          timestamp: Date.now(),
+          _outboxAttachment: true,
+        },
+      ]);
+      const attachPrompt = caption
+        ? caption
+        : `Adjunté un archivo (${item.fileName || 'archivo'}). Por ahora no puedo leer archivos directamente; cuéntame qué necesitas y te ayudo.`;
+      await handleSubmit(attachPrompt);
+      await outboxMarkAnswered(item.id);
+      return true;
+    } catch (e) {
+      console.warn('[Agent] processOutboxItem falló:', e?.message);
+      await outboxMarkError(item.id, e?.message || 'fallo procesando item');
+      return false;
+    }
+  }, [ttsEnabled, setTtsEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const drainOutbox = useCallback(async () => {
+    if (outboxDrainingRef.current) return;
+    outboxDrainingRef.current = true;
+    try {
+      // Rescatar primero cualquier item huérfano en 'processing' (app cerrada
+      // a mitad). Vuelven a 'queued' para reintento — no se pierden.
+      await outboxRecoverStale();
+      let item = await outboxClaimNext();
+      let guard = 0;
+      while (item && guard < 25) {
+        guard += 1;
+        await processOutboxItem(item);
+        item = await outboxClaimNext();
+      }
+    } finally {
+      outboxDrainingRef.current = false;
+    }
+  }, [processOutboxItem]);
+
+  // Drenar la outbox al montar el AgentScreen. Corre una sola vez por montaje
+  // efectivo; claimNext garantiza que StrictMode (doble efecto) no duplique.
+  useEffect(() => {
+    drainOutbox();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="h-full flex flex-col bg-slate-950">

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -1,6 +1,10 @@
-import { useEffect, useState } from 'react';
-import { Mic, Sparkles, ArrowRight } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Mic, Square, Camera, Paperclip, ArrowUp, X } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import useVoiceRecorder from '../../hooks/useVoiceRecorder';
+import { captureAndCompress } from '../../services/photoService';
+import useAgentOutboxStore from '../../store/useAgentOutboxStore';
+import { agentSounds } from '../../services/agentSoundService';
 
 // 2026-05-28: el R3F (ChagraAgentAvatarColibri3D) fue retirado del flujo.
 // Operador: "no me gusta nada y desatina con todo lo que ya está".
@@ -10,20 +14,33 @@ import ChagraAgentAvatar from '../ChagraAgentAvatar';
 
 /**
  * AgentHero — protagonista del dashboard. El agente Chagra como ser vivo,
- * grande, respirando. Click → AgentScreen fullscreen.
+ * grande, respirando, y AHORA con un COMPOSITOR MULTIMODAL REAL como puerta
+ * de entrada.
  *
- * Diseño 2026-05-28 cervezas-test:
- *  - Avatar 96-128px con halo cónico que rota lento (sensación de aura viva).
- *  - Headline: "Pregúntale a Chagra" — directo, sin jerga, niño-11-friendly.
- *  - Sub: rotación suave de tips ("Cuento de tu chagra", "Te ayudo con plagas").
- *  - Input glassmorphism con mic integrado.
- *  - 3 chips de sugerencia con iconos agro.
- *  - Toda la zona es clickable y navega a 'agente'.
+ * Antes (≤1.0.18) la "caja de entrada" era un <div role=button> falso: al
+ * tocarla navegaba al AgentScreen y solo PRE-RELLENABA el texto. No escribía,
+ * no grababa, no fotografiaba — era un teaser.
+ *
+ * Ahora es un compositor de verdad:
+ *  - <textarea> auto-grow (Enter=enviar, Shift+Enter=nueva línea).
+ *  - 🎤 micrófono → graba audio (useVoiceRecorder + flujo whisper del agente).
+ *  - 📷 cámara/foto → toma o elige foto (photoService + visión en el agente).
+ *  - 📎 adjuntar → file picker (imagen/archivo).
+ *  - ⬆️ enviar.
+ *
+ * Al enviar: el item se PERSISTE en la outbox durable (IndexedDB) ANTES de
+ * navegar. El AgentScreen lo consume como burbuja "ya enviada" y arranca a
+ * procesar (texto→LLM, audio→transcribe, foto→visión). Si el usuario da
+ * "atrás" o cierra la app a mitad → al volver el item sigue ahí y no se pierde
+ * ni se duplica (ver agentOutboxService).
+ *
+ * El alma del diseño previo se conserva: avatar vivo + halo cónico + headline +
+ * tips rotativos. Respeta prefers-reduced-motion para la transición de envío.
  */
 
 const TIPS = [
-    'Te ayudo con tu siembra, plagas y clima.',
-    'Cuéntame qué estás cultivando hoy.',
+    'Escribe, habla o muéstrame una foto de tu cultivo.',
+    'Cuéntame qué estás sembrando hoy.',
     'Tomo foto, escucho, recuerdo lo que me dices.',
     'Sé del campo colombiano y respeto tu tierra.',
     'Pregúntame en voz, te entiendo con tu acento.',
@@ -35,9 +52,38 @@ const QUICK_CHIPS = [
     { icon: '🌧️', label: 'Clima', prompt: 'Dame el reporte del clima de mi zona.' },
 ];
 
+function prefersReducedMotion() {
+    return typeof window !== 'undefined' && window.matchMedia
+        ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        : false;
+}
+
 export default function AgentHero({ onNavigate }) {
     const [tipIndex, setTipIndex] = useState(0);
-    const [pressed, setPressed] = useState(false);
+    const [text, setText] = useState('');
+    // Adjunto en staging (foto/archivo) antes de enviar. { blob, mime, fileName,
+    // previewUrl, kind } — kind: 'photo' | 'attachment'.
+    const [attachment, setAttachment] = useState(null);
+    const [busy, setBusy] = useState(false);
+    // Fase de la transición de envío: 'idle' | 'sending'. En 'sending' el
+    // compositor hace un shimmer breve y el avatar pasa a 'thinking' antes de
+    // navegar — sensación de "lanzar" la consulta hacia el chat.
+    const [phase, setPhase] = useState('idle');
+
+    const textareaRef = useRef(null);
+    const cameraInputRef = useRef(null);
+    const fileInputRef = useRef(null);
+
+    const sendToOutbox = useAgentOutboxStore((s) => s.send);
+    const {
+        isRecording,
+        audioLevel,
+        durationMs,
+        start: startRecord,
+        stop: stopRecord,
+        reset: resetRecord,
+        error: recorderError,
+    } = useVoiceRecorder();
 
     useEffect(() => {
         const interval = setInterval(() => {
@@ -46,17 +92,158 @@ export default function AgentHero({ onNavigate }) {
         return () => clearInterval(interval);
     }, []);
 
-    const goAgent = (prefill) => {
-        if (prefill) {
-            try { sessionStorage.setItem('chagra:agent:prefill', prefill); } catch { /* ignore */ }
-        }
-        onNavigate?.('agente');
+    // Limpia el ObjectURL del preview al desmontar o cambiar de adjunto.
+    useEffect(() => {
+        return () => {
+            if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+        };
+    }, [attachment]);
+
+    // Auto-grow del textarea: crece hasta ~5 líneas, luego scrollea.
+    const autoGrow = (el) => {
+        if (!el) return;
+        el.style.height = 'auto';
+        el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
     };
+
+    /**
+     * Navega al agente disparando una transición premium: el avatar pasa a
+     * 'thinking', el compositor hace un shimmer corto de "enviando" y luego
+     * monta el AgentScreen. Respeta reduced-motion (sin retardo de animación).
+     */
+    const launchToAgent = () => {
+        const reduce = prefersReducedMotion();
+        setPhase('sending');
+        try { agentSounds.start(); } catch { /* sonido opcional */ }
+        const go = () => onNavigate?.('agente');
+        if (reduce) {
+            go();
+        } else {
+            // Retardo corto para que el shimmer del compositor + el avatar
+            // thinking se perciban antes del cambio de pantalla. Suave, digno.
+            window.setTimeout(go, 280);
+        }
+    };
+
+    /**
+     * Persiste la consulta en la outbox DURABLE y navega. El orden es estricto:
+     * (1) persistir → (2) navegar. Si la persistencia falla NO navegamos en
+     * silencio: dejamos el texto/adjunto en el compositor para que el usuario
+     * reintente (cero pérdida de datos).
+     */
+    const send = async (payload) => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await sendToOutbox(payload);
+            // Limpiar el compositor solo tras confirmar persistencia.
+            setText('');
+            if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+            setAttachment(null);
+            launchToAgent();
+        } catch (err) {
+            console.error('[AgentHero] no se pudo guardar la consulta, no navego:', err);
+            setBusy(false);
+            // El texto/adjunto permanecen — el usuario puede reintentar.
+        }
+    };
+
+    const handleSendText = () => {
+        const trimmed = text.trim();
+        if (attachment) {
+            // Foto/archivo + caption opcional → un solo item multimodal.
+            send({
+                kind: attachment.kind,
+                text: trimmed,
+                blob: attachment.blob,
+                mime: attachment.mime,
+                fileName: attachment.fileName,
+            });
+            return;
+        }
+        if (!trimmed) return;
+        send({ kind: 'text', text: trimmed });
+    };
+
+    const handleChipSend = (prompt) => {
+        if (busy) return;
+        send({ kind: 'text', text: prompt });
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSendText();
+        }
+    };
+
+    // ── Micrófono ────────────────────────────────────────────────────────────
+    const handleMic = async () => {
+        if (busy) return;
+        if (isRecording) {
+            const result = await stopRecord();
+            if (result && result.blob) {
+                // El texto escrito (si lo hay) acompaña al audio como contexto.
+                send({
+                    kind: 'voice',
+                    text: text.trim(),
+                    blob: result.blob,
+                    mime: result.mimeType || result.blob.type,
+                    meta: { durationMs: result.durationMs },
+                });
+            }
+        } else {
+            resetRecord();
+            try { agentSounds.listen(); } catch { /* opcional */ }
+            startRecord();
+        }
+    };
+
+    // ── Cámara / foto ─────────────────────────────────────────────────────────
+    const handlePhotoPick = async (e, kind) => {
+        const file = e.target.files && e.target.files[0];
+        // Permitir re-seleccionar el mismo archivo después.
+        e.target.value = '';
+        if (!file) return;
+        setBusy(true);
+        try {
+            // Reusa la compresión/normalización HEIC→JPEG de photoService para
+            // imágenes; los adjuntos no-imagen van tal cual.
+            if (file.type.startsWith('image/')) {
+                const { blob, mime } = await captureAndCompress(file);
+                const previewUrl = URL.createObjectURL(blob);
+                setAttachment({ blob, mime, fileName: file.name || 'foto.jpg', previewUrl, kind: 'photo' });
+            } else {
+                setAttachment({
+                    blob: file,
+                    mime: file.type || 'application/octet-stream',
+                    fileName: file.name || 'archivo',
+                    previewUrl: null,
+                    kind: 'attachment',
+                });
+            }
+            // Devolver foco al textarea para que pueda escribir un caption.
+            requestAnimationFrame(() => textareaRef.current?.focus());
+        } catch (err) {
+            console.error('[AgentHero] no se pudo procesar el archivo:', err);
+        } finally {
+            setBusy(false);
+        }
+        void kind;
+    };
+
+    const clearAttachment = () => {
+        if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+        setAttachment(null);
+    };
+
+    const canSend = !busy && (text.trim().length > 0 || Boolean(attachment));
+    const recSeconds = Math.floor((durationMs || 0) / 1000);
 
     return (
         <section
             aria-label="Agente Chagra"
-            className="relative w-full px-4 pt-6 pb-4 select-none"
+            className="relative w-full px-4 pt-6 pb-4"
         >
             <style>{`
                 @keyframes chagra-halo-rotate {
@@ -66,6 +253,15 @@ export default function AgentHero({ onNavigate }) {
                 @keyframes chagra-avatar-breathe {
                     0%, 100% { transform: scale(1); }
                     50% { transform: scale(1.025); }
+                }
+                @keyframes chagra-send-shimmer {
+                    0% { transform: translateX(-120%); opacity: 0; }
+                    40% { opacity: 0.9; }
+                    100% { transform: translateX(120%); opacity: 0; }
+                }
+                @keyframes chagra-send-lift {
+                    0% { transform: translateY(0) scale(1); }
+                    100% { transform: translateY(-10px) scale(0.985); opacity: 0.85; }
                 }
                 .chagra-hero-halo {
                     position: absolute;
@@ -93,23 +289,38 @@ export default function AgentHero({ onNavigate }) {
                 .chagra-hero-avatar-wrap {
                     animation: chagra-avatar-breathe 4s ease-in-out infinite;
                 }
-                .chagra-hero-press {
-                    transition: transform 200ms ease;
+                .chagra-composer-shimmer::after {
+                    content: '';
+                    position: absolute;
+                    inset: 0;
+                    border-radius: inherit;
+                    background: linear-gradient(
+                        100deg,
+                        transparent 20%,
+                        rgba(163, 230, 53, 0.35) 50%,
+                        transparent 80%
+                    );
+                    animation: chagra-send-shimmer 0.6s ease-out forwards;
+                    pointer-events: none;
+                    overflow: hidden;
                 }
-                .chagra-hero-press:active {
-                    transform: scale(0.98);
+                .chagra-composer-sending {
+                    animation: chagra-send-lift 0.28s ease-in forwards;
+                }
+                @media (prefers-reduced-motion: reduce) {
+                    .chagra-hero-halo,
+                    .chagra-hero-avatar-wrap { animation: none !important; }
+                    .chagra-composer-shimmer::after,
+                    .chagra-composer-sending { animation: none !important; }
                 }
             `}</style>
 
+            {/* Avatar vivo + headline. Toda la zona del avatar abre el agente
+                directo (sin escribir) — atajo para quien solo quiere "entrar". */}
             <button
                 type="button"
-                onClick={() => goAgent()}
-                onMouseDown={() => setPressed(true)}
-                onMouseUp={() => setPressed(false)}
-                onMouseLeave={() => setPressed(false)}
-                onTouchStart={() => setPressed(true)}
-                onTouchEnd={() => setPressed(false)}
-                className="relative w-full flex flex-col items-center text-center chagra-hero-press focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 rounded-3xl"
+                onClick={launchToAgent}
+                className="relative w-full flex flex-col items-center text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 rounded-3xl"
                 aria-label="Abrir agente Chagra"
             >
                 <div className="relative w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-3">
@@ -117,7 +328,7 @@ export default function AgentHero({ onNavigate }) {
                     <div className="chagra-hero-halo-inner" aria-hidden="true" />
                     <div className="chagra-hero-avatar-wrap relative">
                         <ChagraAgentAvatar
-                            state={pressed ? 'thinking' : 'idle'}
+                            state={phase === 'sending' || isRecording ? 'thinking' : 'idle'}
                             size={140}
                         />
                     </div>
@@ -135,39 +346,165 @@ export default function AgentHero({ onNavigate }) {
                 </p>
             </button>
 
-            {/* Input grande de entrada al agente */}
+            {/* COMPOSITOR MULTIMODAL REAL */}
             <div className="mt-5 w-full max-w-xl mx-auto">
                 <div
-                    onClick={() => goAgent()}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={(e) => { if (e.key === 'Enter') goAgent(); }}
-                    aria-label="Escribir o hablar al agente"
-                    className="relative flex items-center gap-3 px-4 py-3.5 rounded-2xl bg-white/[0.06] backdrop-blur-xl border border-white/10 hover:border-emerald-500/50 hover:bg-white/[0.08] active:bg-white/[0.04] transition-all cursor-pointer min-h-[56px]"
+                    className={[
+                        'relative overflow-hidden rounded-2xl bg-white/[0.06] backdrop-blur-xl border transition-colors',
+                        isRecording ? 'border-rose-500/60' : 'border-white/10 focus-within:border-emerald-500/60',
+                        phase === 'sending' ? 'chagra-composer-shimmer chagra-composer-sending' : '',
+                    ].join(' ')}
                 >
-                    <Sparkles size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
-                    <span className="flex-1 text-base text-slate-300 font-medium select-none">
-                        Escribe o toca para hablar…
-                    </span>
-                    <button
-                        type="button"
-                        onClick={(e) => { e.stopPropagation(); goAgent('VOICE'); }}
-                        aria-label="Hablar con el agente por voz"
-                        className="shrink-0 w-10 h-10 rounded-full bg-gradient-to-br from-lime-400 to-emerald-500 hover:from-lime-300 hover:to-emerald-400 active:scale-95 flex items-center justify-center text-slate-900 shadow-lg shadow-emerald-500/30 transition-all"
-                    >
-                        <Mic size={18} strokeWidth={2.5} aria-hidden="true" />
-                    </button>
-                    <ArrowRight size={16} className="text-slate-500 shrink-0" aria-hidden="true" />
+                    {/* Preview del adjunto en staging */}
+                    {attachment && (
+                        <div className="flex items-center gap-3 px-3 pt-3">
+                            {attachment.previewUrl ? (
+                                <img
+                                    src={attachment.previewUrl}
+                                    alt="Foto adjunta"
+                                    className="w-14 h-14 rounded-lg object-cover border border-white/15"
+                                />
+                            ) : (
+                                <div className="w-14 h-14 rounded-lg bg-slate-800 border border-white/15 flex items-center justify-center">
+                                    <Paperclip size={20} className="text-slate-300" aria-hidden="true" />
+                                </div>
+                            )}
+                            <span className="flex-1 text-xs text-slate-300 truncate">
+                                {attachment.kind === 'photo' ? 'Foto lista para enviar' : attachment.fileName}
+                            </span>
+                            <button
+                                type="button"
+                                onClick={clearAttachment}
+                                aria-label="Quitar adjunto"
+                                className="shrink-0 w-7 h-7 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center text-slate-300"
+                            >
+                                <X size={14} aria-hidden="true" />
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Estado grabando: barra de nivel + cronómetro */}
+                    {isRecording ? (
+                        <div className="flex items-center gap-3 px-4 py-3.5 min-h-[56px]">
+                            <span className="relative flex h-3 w-3 shrink-0">
+                                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-rose-400 opacity-75" />
+                                <span className="relative inline-flex rounded-full h-3 w-3 bg-rose-500" />
+                            </span>
+                            <span className="flex-1 text-base text-rose-200 font-medium tabular-nums">
+                                Grabando… {recSeconds}s
+                            </span>
+                            {/* Mini visualizador del nivel de voz */}
+                            <span
+                                aria-hidden="true"
+                                className="h-6 w-1.5 rounded-full bg-rose-400 origin-bottom transition-transform"
+                                style={{ transform: `scaleY(${Math.max(0.2, Math.min(1, audioLevel || 0.2))})` }}
+                            />
+                        </div>
+                    ) : (
+                        <textarea
+                            ref={textareaRef}
+                            value={text}
+                            onChange={(e) => { setText(e.target.value); autoGrow(e.target); }}
+                            onKeyDown={handleKeyDown}
+                            rows={1}
+                            placeholder={attachment ? 'Añade una nota a tu foto (opcional)…' : 'Escribe tu pregunta al agente…'}
+                            aria-label="Escribe tu pregunta al agente"
+                            className="w-full bg-transparent resize-none px-4 py-3.5 text-base text-slate-100 placeholder:text-slate-400 focus:outline-none leading-snug"
+                            disabled={busy}
+                        />
+                    )}
+
+                    {/* Barra de acciones del compositor */}
+                    <div className="flex items-center gap-1.5 px-3 pb-2.5 pt-0.5">
+                        {/* Cámara / foto */}
+                        <button
+                            type="button"
+                            onClick={() => cameraInputRef.current?.click()}
+                            disabled={busy || isRecording}
+                            aria-label="Tomar o elegir foto"
+                            className="w-9 h-9 rounded-full hover:bg-white/10 active:bg-white/15 flex items-center justify-center text-slate-300 disabled:opacity-40 transition-colors"
+                        >
+                            <Camera size={19} aria-hidden="true" />
+                        </button>
+                        {/* Adjuntar archivo */}
+                        <button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            disabled={busy || isRecording}
+                            aria-label="Adjuntar archivo"
+                            className="w-9 h-9 rounded-full hover:bg-white/10 active:bg-white/15 flex items-center justify-center text-slate-300 disabled:opacity-40 transition-colors"
+                        >
+                            <Paperclip size={18} aria-hidden="true" />
+                        </button>
+
+                        <div className="flex-1" />
+
+                        {/* Micrófono (toggle grabar/detener) */}
+                        <button
+                            type="button"
+                            onClick={handleMic}
+                            disabled={busy}
+                            aria-label={isRecording ? 'Detener y enviar audio' : 'Grabar audio'}
+                            aria-pressed={isRecording}
+                            className={[
+                                'w-10 h-10 rounded-full flex items-center justify-center transition-all active:scale-95 disabled:opacity-40',
+                                isRecording
+                                    ? 'bg-rose-500 hover:bg-rose-400 text-white shadow-lg shadow-rose-500/30'
+                                    : 'bg-white/10 hover:bg-white/20 text-slate-100',
+                            ].join(' ')}
+                        >
+                            {isRecording ? <Square size={16} strokeWidth={2.5} aria-hidden="true" /> : <Mic size={18} strokeWidth={2.5} aria-hidden="true" />}
+                        </button>
+
+                        {/* Enviar */}
+                        <button
+                            type="button"
+                            onClick={handleSendText}
+                            disabled={!canSend}
+                            aria-label="Enviar al agente"
+                            className={[
+                                'w-10 h-10 rounded-full flex items-center justify-center transition-all active:scale-95',
+                                canSend
+                                    ? 'bg-gradient-to-br from-lime-400 to-emerald-500 hover:from-lime-300 hover:to-emerald-400 text-slate-900 shadow-lg shadow-emerald-500/30'
+                                    : 'bg-white/8 text-slate-500 cursor-not-allowed',
+                            ].join(' ')}
+                        >
+                            <ArrowUp size={18} strokeWidth={2.75} aria-hidden="true" />
+                        </button>
+                    </div>
+
+                    {/* Inputs ocultos: cámara (capture) y archivo genérico */}
+                    <input
+                        ref={cameraInputRef}
+                        type="file"
+                        accept="image/*"
+                        capture="environment"
+                        className="hidden"
+                        onChange={(e) => handlePhotoPick(e, 'photo')}
+                    />
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        className="hidden"
+                        onChange={(e) => handlePhotoPick(e, 'attachment')}
+                    />
                 </div>
 
-                {/* Chips de sugerencia rápida */}
+                {recorderError && (
+                    <p className="mt-2 text-xs text-rose-300 px-1" role="alert">
+                        No pude acceder al micrófono. Revisa los permisos.
+                    </p>
+                )}
+
+                {/* Chips de sugerencia rápida — envían directo (consulta de texto) */}
                 <div className="mt-3 flex gap-2 overflow-x-auto pb-1 scrollbar-none">
                     {QUICK_CHIPS.map((chip) => (
                         <button
                             key={chip.label}
                             type="button"
-                            onClick={() => goAgent(chip.prompt)}
-                            className="shrink-0 px-3.5 py-2 rounded-full bg-white/5 hover:bg-white/10 active:bg-white/15 border border-white/10 text-sm text-slate-200 font-medium transition-all flex items-center gap-2 backdrop-blur-md"
+                            onClick={() => handleChipSend(chip.prompt)}
+                            disabled={busy}
+                            className="shrink-0 px-3.5 py-2 rounded-full bg-white/5 hover:bg-white/10 active:bg-white/15 border border-white/10 text-sm text-slate-200 font-medium transition-all flex items-center gap-2 backdrop-blur-md disabled:opacity-50"
                         >
                             <span aria-hidden="true" className="text-base leading-none">{chip.icon}</span>
                             {chip.label}

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -1,0 +1,201 @@
+/**
+ * AgentHero.composer.test.jsx — el compositor multimodal REAL del home.
+ *
+ * Verifica que el AgentHero ya NO es un teaser falso, sino un compositor que:
+ *   1. Tiene un <textarea> real (Enter envía, Shift+Enter no).
+ *   2. Al enviar texto → persiste en la outbox (store.send) ANTES de navegar.
+ *   3. El micrófono graba y, al detener, envía un item de voz con el blob.
+ *   4. La cámara/foto procesa la imagen y la deja en staging para enviar.
+ *   5. Cada envío navega a 'agente' (onNavigate) — pero SOLO tras persistir.
+ *   6. Si la persistencia falla, NO navega (cero pérdida de datos).
+ *
+ * Mockea: useAgentOutboxStore.send, useVoiceRecorder, photoService, agentSounds.
+ * NO toca IndexedDB real — el contrato de durabilidad se prueba en
+ * agentOutboxService.test.js. Aquí probamos el cableado del compositor.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock del store outbox (send durable) ─────────────────────────────────────
+const sendMock = vi.fn(async () => 1);
+vi.mock('../../../store/useAgentOutboxStore', () => ({
+  default: (selector) => selector({ send: sendMock, items: [], inFlight: [], refresh: vi.fn() }),
+}));
+
+// ── Mock del recorder de voz ────────────────────────────────────────────────
+const recorderState = {
+  isRecording: false,
+  audioLevel: 0.5,
+  durationMs: 0,
+  start: vi.fn(() => { recorderState.isRecording = true; }),
+  stop: vi.fn(async () => ({ blob: new Blob(['audio'], { type: 'audio/webm' }), durationMs: 3000, mimeType: 'audio/webm' })),
+  reset: vi.fn(),
+  error: null,
+};
+vi.mock('../../../hooks/useVoiceRecorder', () => ({
+  default: () => recorderState,
+}));
+
+// ── Mock de photoService (compresión) ───────────────────────────────────────
+vi.mock('../../../services/photoService', () => ({
+  captureAndCompress: vi.fn(async () => ({
+    blob: new Blob(['jpeg'], { type: 'image/jpeg' }),
+    mime: 'image/jpeg',
+    width: 800,
+    height: 600,
+  })),
+}));
+
+// ── Mock de sonidos (no-op) ─────────────────────────────────────────────────
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { start: vi.fn(), listen: vi.fn(), chime: vi.fn(), cancel: vi.fn() },
+}));
+
+// ── Mock del avatar (evita cargar el wrapper pesado) ────────────────────────
+vi.mock('../../ChagraAgentAvatar', () => ({
+  default: ({ state }) => <div data-testid="avatar" data-state={state} />,
+}));
+
+import AgentHero from '../AgentHero';
+
+beforeEach(() => {
+  sendMock.mockClear();
+  recorderState.isRecording = false;
+  recorderState.start.mockClear();
+  recorderState.stop.mockClear();
+  recorderState.reset.mockClear();
+  // Sin reduced-motion → la navegación usa setTimeout(280). Forzamos
+  // reduced-motion=true en los tests de envío para navegar sincrónicamente.
+  window.matchMedia = vi.fn().mockImplementation((q) => ({
+    matches: q.includes('reduce'),
+    media: q,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+  window.URL.createObjectURL = vi.fn(() => 'blob:preview');
+  window.URL.revokeObjectURL = vi.fn();
+});
+
+describe('AgentHero — compositor real (no teaser)', () => {
+  test('renderiza un <textarea> real, no un div falso', () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+    expect(ta.tagName).toBe('TEXTAREA');
+  });
+
+  test('escribir + Enter → persiste texto en la outbox y navega a agente', async () => {
+    const onNavigate = vi.fn();
+    render(<AgentHero onNavigate={onNavigate} />);
+    const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+    fireEvent.change(ta, { target: { value: '¿qué siembro?' } });
+    fireEvent.keyDown(ta, { key: 'Enter', shiftKey: false });
+
+    await waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'text', text: '¿qué siembro?' }),
+      );
+    });
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('agente'));
+  });
+
+  test('Shift+Enter NO envía (nueva línea)', () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+    fireEvent.change(ta, { target: { value: 'línea uno' } });
+    fireEvent.keyDown(ta, { key: 'Enter', shiftKey: true });
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  test('botón enviar deshabilitado sin texto ni adjunto', () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    expect(screen.getByLabelText('Enviar al agente')).toBeDisabled();
+  });
+
+  test('chip de sugerencia envía su prompt como texto', async () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    fireEvent.click(screen.getByText('Plagas'));
+    await waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'text', text: expect.stringMatching(/plagas/i) }),
+      );
+    });
+  });
+
+  test('micrófono: grabar y detener envía item de voz con el blob', async () => {
+    const onNavigate = vi.fn();
+    render(<AgentHero onNavigate={onNavigate} />);
+    const micBtn = screen.getByLabelText('Grabar audio');
+    fireEvent.click(micBtn);
+    expect(recorderState.start).toHaveBeenCalled();
+
+    // Re-render en estado grabando.
+    recorderState.isRecording = true;
+    render(<AgentHero onNavigate={onNavigate} />);
+    const stopBtn = screen.getAllByLabelText('Detener y enviar audio')[0];
+    await act(async () => {
+      fireEvent.click(stopBtn);
+    });
+    await waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'voice', blob: expect.any(Blob) }),
+      );
+    });
+  });
+
+  test('foto: seleccionar imagen la deja lista y al enviar va como item photo', async () => {
+    const onNavigate = vi.fn();
+    const { container } = render(<AgentHero onNavigate={onNavigate} />);
+    const file = new File(['img'], 'planta.jpg', { type: 'image/jpeg' });
+    const cameraInput = container.querySelector('input[capture]');
+    await act(async () => {
+      fireEvent.change(cameraInput, { target: { files: [file] } });
+    });
+    // Aparece el preview de "foto lista".
+    await screen.findByText('Foto lista para enviar');
+    // Enviar (ya habilitado por el adjunto).
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Enviar al agente'));
+    });
+    await waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'photo', blob: expect.any(Blob), mime: 'image/jpeg' }),
+      );
+    });
+  });
+
+  test('cero pérdida: si send() falla, NO navega y conserva el texto', async () => {
+    sendMock.mockRejectedValueOnce(new Error('idb caída'));
+    const onNavigate = vi.fn();
+    render(<AgentHero onNavigate={onNavigate} />);
+    const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+    fireEvent.change(ta, { target: { value: 'no me pierdas' } });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Enviar al agente'));
+    });
+    await waitFor(() => expect(sendMock).toHaveBeenCalled());
+    expect(onNavigate).not.toHaveBeenCalled();
+    // El texto sigue en el compositor (no se borró).
+    expect(ta.value).toBe('no me pierdas');
+  });
+});
+
+describe('AgentHero — voseo (español colombiano)', () => {
+  test('los textos visibles usan tú/usted, sin voseo argentino', () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const text = container.textContent || '';
+    // Marcadores de voseo prohibidos.
+    expect(text).not.toMatch(/\bescribí\b/);
+    expect(text).not.toMatch(/\btocá\b/);
+    expect(text).not.toMatch(/\benviá\b/);
+    expect(text).not.toMatch(/\bpreguntá\b/);
+    expect(text).not.toMatch(/\bmostrá\b/);
+    expect(text).not.toMatch(/\bcontá\b/);
+    expect(text).not.toMatch(/\btenés\b/);
+    expect(text).not.toMatch(/\bquerés\b/);
+  });
+});

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 16;
+export const DB_VERSION = 17;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -58,6 +58,13 @@ export const STORES = {
   RAG_TELEMETRY: 'rag_telemetry',
   FAILED_TX: 'failed_transactions',
   VISION_QUEUE: 'vision_queue',
+  // v17 (compositor multimodal del home): outbox DURABLE de consultas al
+  // agente disparadas desde el dashboard. El item (texto / blob de audio /
+  // foto / adjunto + metadata) se persiste ANTES de navegar al AgentScreen,
+  // sobrevive a un "atrás" o a un cierre de app a mitad de camino, y se
+  // procesa exactamente UNA vez (claim atómico anti-duplicado). NUNCA se
+  // pierde el dato del usuario — ese es el contrato.
+  AGENT_OUTBOX: 'agent_outbox',
 };
 
 let dbInstance = null;
@@ -251,6 +258,22 @@ export const openDB = async () => {
       if (event.oldVersion < 16) {
         if (!db.objectStoreNames.contains(STORES.VISION_QUEUE)) {
           const store = db.createObjectStore(STORES.VISION_QUEUE, { keyPath: 'id', autoIncrement: true });
+          store.createIndex('status', 'status', { unique: false });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+          store.createIndex('kind', 'kind', { unique: false });
+        }
+      }
+
+      // v17: agent_outbox — cola DURABLE de consultas multimodales al agente
+      // disparadas desde el compositor del dashboard (AgentHero). Antes de
+      // navegar al AgentScreen, el item (texto / audio / foto / adjunto) se
+      // persiste con status='queued'. Si el usuario da "atrás" o CIERRA la
+      // app a mitad → al volver el item sigue intacto con su estado y NO se
+      // pierde ni se duplica (claim atómico via status='processing'). Blobs
+      // grandes → IndexedDB (NO localStorage). keyPath autoIncrement.
+      if (event.oldVersion < 17) {
+        if (!db.objectStoreNames.contains(STORES.AGENT_OUTBOX)) {
+          const store = db.createObjectStore(STORES.AGENT_OUTBOX, { keyPath: 'id', autoIncrement: true });
           store.createIndex('status', 'status', { unique: false });
           store.createIndex('createdAt', 'createdAt', { unique: false });
           store.createIndex('kind', 'kind', { unique: false });

--- a/src/services/__tests__/agentOutboxDrain.test.js
+++ b/src/services/__tests__/agentOutboxDrain.test.js
@@ -1,0 +1,134 @@
+/**
+ * agentOutboxDrain.test.js — contrato de DRENADO que el AgentScreen implementa
+ * al montar (recoverStale → claimNext loop → process → markAnswered).
+ *
+ * Replica EXACTAMENTE el orden de operaciones del `drainOutbox` de
+ * AgentScreen.jsx, pero con un dispatcher de prueba en lugar del pipeline LLM
+ * real. Prueba el invariante que importa al usuario:
+ *   - cada item del home se procesa EXACTAMENTE una vez (sin duplicar burbujas),
+ *   - en orden FIFO,
+ *   - los items huérfanos en 'processing' (app cerrada mid-flight) se recuperan
+ *     y se procesan (no se pierden),
+ *   - un segundo "montaje" (segundo drenado) NO re-procesa lo ya respondido.
+ *
+ * Mismo mock IDB en memoria persistente que agentOutboxService.test.js.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const dbState = { data: new Map(), seq: 0 };
+
+function makeReq(resultFn) {
+  const req = {};
+  queueMicrotask(() => {
+    try {
+      req.result = resultFn();
+      req.onsuccess?.({ target: req });
+    } catch (e) {
+      req.error = e;
+      req.onerror?.({ target: req });
+    }
+  });
+  return req;
+}
+function makeStore() {
+  return {
+    add(r) { return makeReq(() => { const id = r.id != null ? r.id : ++dbState.seq; dbState.data.set(id, { ...r, id }); return id; }); },
+    put(r) { return makeReq(() => { const id = r.id != null ? r.id : ++dbState.seq; dbState.data.set(id, { ...r, id }); return id; }); },
+    get(id) { return makeReq(() => dbState.data.get(id) || undefined); },
+    getAll() { return makeReq(() => [...dbState.data.values()]); },
+    delete(id) { return makeReq(() => { dbState.data.delete(id); return undefined; }); },
+    clear() { return makeReq(() => { dbState.data.clear(); return undefined; }); },
+  };
+}
+function makeDB() {
+  return {
+    transaction() {
+      const tx = {};
+      tx.objectStore = () => makeStore();
+      setTimeout(() => tx.oncomplete?.(), 0);
+      return tx;
+    },
+  };
+}
+vi.mock('../../db/dbCore', () => ({
+  STORES: { AGENT_OUTBOX: 'agent_outbox' },
+  openDB: vi.fn(async () => makeDB()),
+}));
+
+import {
+  enqueue,
+  claimNext,
+  markAnswered,
+  recoverStaleProcessing,
+  getAll,
+} from '../agentOutboxService';
+
+/** Replica del drainOutbox de AgentScreen con un dispatcher inyectable. */
+async function drain(dispatch) {
+  await recoverStaleProcessing();
+  let item = await claimNext();
+  let guard = 0;
+  while (item && guard < 25) {
+    guard += 1;
+    await dispatch(item);
+    await markAnswered(item.id);
+    item = await claimNext();
+  }
+}
+
+beforeEach(() => {
+  dbState.data.clear();
+  dbState.seq = 0;
+});
+
+describe('drenado de la outbox al montar AgentScreen', () => {
+  it('procesa todos los items en orden FIFO, exactamente una vez', async () => {
+    await enqueue({ kind: 'text', text: 'uno', meta: { createdAt: 1 } });
+    await enqueue({ kind: 'voice', blob: new Blob(['a'], { type: 'audio/webm' }), meta: { createdAt: 2 } });
+    await enqueue({ kind: 'text', text: 'tres', meta: { createdAt: 3 } });
+
+    const seen = [];
+    await drain(async (item) => { seen.push(item.kind === 'voice' ? 'voice' : item.text); });
+
+    expect(seen).toEqual(['uno', 'voice', 'tres']);
+    const all = await getAll();
+    expect(all.every((i) => i.status === 'answered')).toBe(true);
+  });
+
+  it('un segundo drenado (re-montaje) NO re-procesa lo ya respondido', async () => {
+    await enqueue({ kind: 'text', text: 'sola' });
+    const first = [];
+    await drain(async (i) => first.push(i.text));
+    expect(first).toEqual(['sola']);
+
+    const second = [];
+    await drain(async (i) => second.push(i.text));
+    expect(second).toEqual([]); // nada que re-procesar
+  });
+
+  it('recupera y procesa un item huérfano en processing (app cerrada mid-flight)', async () => {
+    const id = await enqueue({ kind: 'text', text: 'a mitad' });
+    await claimNext(); // queda 'processing' (simula cierre antes de markAnswered)
+
+    const seen = [];
+    await drain(async (i) => seen.push(i.text));
+    expect(seen).toEqual(['a mitad']); // recuperado y procesado, NO perdido
+
+    const all = await getAll();
+    expect(all.find((i) => i.id === id).status).toBe('answered');
+  });
+
+  it('drenado concurrente (dos montajes) no duplica el procesamiento', async () => {
+    await enqueue({ kind: 'text', text: 'x', meta: { createdAt: 1 } });
+    await enqueue({ kind: 'text', text: 'y', meta: { createdAt: 2 } });
+
+    const seen = [];
+    const dispatch = async (i) => { seen.push(i.text); };
+    // Dos drenados arrancados "a la vez" (claimNext atómico evita duplicar).
+    await Promise.all([drain(dispatch), drain(dispatch)]);
+
+    expect(seen.sort()).toEqual(['x', 'y']);
+    // Cada item visto exactamente una vez.
+    expect(new Set(seen).size).toBe(2);
+  });
+});

--- a/src/services/__tests__/agentOutboxService.test.js
+++ b/src/services/__tests__/agentOutboxService.test.js
@@ -1,0 +1,334 @@
+/**
+ * agentOutboxService.test.js — contrato de INTEGRIDAD de la outbox durable.
+ *
+ * El punto central del compositor multimodal del home: cuando el usuario envía
+ * una consulta (texto / audio / foto / adjunto) desde el dashboard, se persiste
+ * ANTES de navegar. Si da "atrás" o CIERRA la app a mitad → al volver el item
+ * sigue ahí y NO se pierde ni se duplica.
+ *
+ * Mockea `../../db/dbCore` con un Map en memoria que imita la superficie IDB que
+ * el service usa (transaction → objectStore → {add, put, get, getAll, delete,
+ * clear}, oncomplete). autoIncrement simulado. Mismo enfoque que
+ * visionQueueService.test.js / ragTelemetry.test.js — sin fake-indexeddb.
+ *
+ * CRÍTICO: el mock conserva el Map entre `openDB()` sucesivos para simular
+ * persistencia real (sobrevive a "recargas" lógicas). El claim atómico se
+ * verifica simulando dos consumidores concurrentes leyendo la MISMA store.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ─── Fake IndexedDB en memoria, persistente entre openDB() ───────────────────
+const dbState = { data: new Map(), seq: 0 };
+
+function makeReq(resultFn) {
+  const req = {};
+  queueMicrotask(() => {
+    try {
+      req.result = resultFn();
+      req.onsuccess?.({ target: req });
+    } catch (e) {
+      req.error = e;
+      req.onerror?.({ target: req });
+    }
+  });
+  return req;
+}
+
+function makeStore(_tx) {
+  return {
+    add(record) {
+      return makeReq(() => {
+        const id = record.id != null ? record.id : ++dbState.seq;
+        dbState.data.set(id, { ...record, id });
+        return id;
+      });
+    },
+    put(record) {
+      return makeReq(() => {
+        // put sin id (no debería pasar en este service) → autoIncrement
+        const id = record.id != null ? record.id : ++dbState.seq;
+        dbState.data.set(id, { ...record, id });
+        return id;
+      });
+    },
+    get(id) {
+      return makeReq(() => dbState.data.get(id) || undefined);
+    },
+    getAll() {
+      return makeReq(() => [...dbState.data.values()]);
+    },
+    delete(id) {
+      return makeReq(() => {
+        dbState.data.delete(id);
+        return undefined;
+      });
+    },
+    clear() {
+      return makeReq(() => {
+        dbState.data.clear();
+        return undefined;
+      });
+    },
+  };
+}
+
+function makeDB() {
+  return {
+    transaction() {
+      const tx = {};
+      const store = makeStore(tx);
+      tx.objectStore = () => store;
+      // oncomplete: dispara tras un macrotask (setTimeout 0) — DESPUÉS de que
+      // los requests (microtasks) resuelvan y de que el service haya tenido la
+      // chance de adjuntar tx.oncomplete vía txDone(). Imita la confirmación de
+      // durabilidad de IndexedDB sin perder handlers adjuntados tarde.
+      setTimeout(() => tx.oncomplete?.(), 0);
+      return tx;
+    },
+  };
+}
+
+vi.mock('../../db/dbCore', () => ({
+  STORES: { AGENT_OUTBOX: 'agent_outbox' },
+  openDB: vi.fn(async () => makeDB()),
+}));
+
+import {
+  enqueue,
+  getAll,
+  getQueued,
+  getInFlight,
+  claimNext,
+  getById,
+  markAnswered,
+  markError,
+  requeue,
+  recoverStaleProcessing,
+  remove,
+  clearOutbox,
+} from '../agentOutboxService';
+
+beforeEach(() => {
+  dbState.data.clear();
+  dbState.seq = 0;
+});
+
+describe('agentOutboxService — persistencia / restauración', () => {
+  it('enqueue persiste un item de texto con status=queued', async () => {
+    const id = await enqueue({ kind: 'text', text: '¿qué siembro este mes?' });
+    expect(id).toBeGreaterThan(0);
+    const all = await getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({
+      kind: 'text',
+      text: '¿qué siembro este mes?',
+      status: 'queued',
+    });
+    expect(typeof all[0].createdAt).toBe('number');
+  });
+
+  it('enqueue persiste un blob de audio (voz) sin perderlo', async () => {
+    const blob = new Blob(['fake-audio'], { type: 'audio/webm' });
+    const id = await enqueue({ kind: 'voice', blob });
+    const rec = await getById(id);
+    expect(rec.kind).toBe('voice');
+    expect(rec.blob).toBe(blob);
+    expect(rec.mime).toBe('audio/webm');
+    expect(rec.status).toBe('queued');
+  });
+
+  it('enqueue persiste una foto + texto (caption) juntos', async () => {
+    const blob = new Blob(['jpeg'], { type: 'image/jpeg' });
+    const id = await enqueue({ kind: 'photo', text: '¿qué plaga es esta?', blob });
+    const rec = await getById(id);
+    expect(rec.kind).toBe('photo');
+    expect(rec.text).toBe('¿qué plaga es esta?');
+    expect(rec.blob).toBe(blob);
+  });
+
+  it('rechaza un item vacío (ni texto ni blob) — no persiste basura', async () => {
+    await expect(enqueue({ kind: 'text', text: '   ' })).rejects.toThrow();
+    expect(await getAll()).toHaveLength(0);
+  });
+
+  it('rechaza kind inválido', async () => {
+    await expect(enqueue({ kind: 'video', text: 'x' })).rejects.toThrow(/kind inválido/);
+  });
+
+  it('SOBREVIVE a "cierre de app": el item sigue ahí tras re-leer la outbox', async () => {
+    await enqueue({ kind: 'text', text: 'consulta importante' });
+    // Simula que el usuario cerró y reabrió: NO limpiamos dbState (es disco).
+    // Una nueva lectura debe ver el item intacto.
+    const restored = await getInFlight();
+    expect(restored).toHaveLength(1);
+    expect(restored[0].text).toBe('consulta importante');
+    expect(restored[0].status).toBe('queued');
+  });
+});
+
+describe('agentOutboxService — claim atómico anti-duplicado (exactly-once)', () => {
+  it('claimNext transiciona queued→processing y devuelve el item', async () => {
+    await enqueue({ kind: 'text', text: 'A', meta: { createdAt: 1 } });
+    const claimed = await claimNext();
+    expect(claimed.text).toBe('A');
+    expect(claimed.status).toBe('processing');
+    expect(typeof claimed.claimedAt).toBe('number');
+    // En disco quedó como processing.
+    const rec = await getById(claimed.id);
+    expect(rec.status).toBe('processing');
+  });
+
+  it('claimNext respeta orden FIFO por createdAt', async () => {
+    await enqueue({ kind: 'text', text: 'segundo', meta: { createdAt: 200 } });
+    await enqueue({ kind: 'text', text: 'primero', meta: { createdAt: 100 } });
+    const first = await claimNext();
+    expect(first.text).toBe('primero');
+    const second = await claimNext();
+    expect(second.text).toBe('segundo');
+  });
+
+  it('NO duplica: dos claims secuenciales sobre un solo item → uno gana, el otro es null', async () => {
+    await enqueue({ kind: 'text', text: 'único' });
+    const a = await claimNext();
+    const b = await claimNext();
+    expect(a).not.toBeNull();
+    expect(a.text).toBe('único');
+    // El segundo claim ya no encuentra nada queued.
+    expect(b).toBeNull();
+  });
+
+  it('drenar la outbox procesa cada item EXACTAMENTE una vez', async () => {
+    await enqueue({ kind: 'text', text: 'q1', meta: { createdAt: 1 } });
+    await enqueue({ kind: 'text', text: 'q2', meta: { createdAt: 2 } });
+    await enqueue({ kind: 'text', text: 'q3', meta: { createdAt: 3 } });
+
+    const processed = [];
+    let item = await claimNext();
+    let guard = 0;
+    while (item && guard < 10) {
+      guard += 1;
+      processed.push(item.text);
+      await markAnswered(item.id, { answeredText: `resp-${item.text}` });
+      item = await claimNext();
+    }
+    expect(processed).toEqual(['q1', 'q2', 'q3']);
+    // Sin duplicados.
+    expect(new Set(processed).size).toBe(3);
+    // Todos respondidos.
+    const all = await getAll();
+    expect(all.every((i) => i.status === 'answered')).toBe(true);
+  });
+
+  it('claimNext devuelve null cuando no hay nada queued', async () => {
+    expect(await claimNext()).toBeNull();
+  });
+});
+
+describe('agentOutboxService — ciclo de vida del estado', () => {
+  it('markAnswered cierra el item y guarda answeredText', async () => {
+    const id = await enqueue({ kind: 'text', text: 'x' });
+    await claimNext();
+    await markAnswered(id, { answeredText: 'la respuesta' });
+    const rec = await getById(id);
+    expect(rec.status).toBe('answered');
+    expect(rec.answeredText).toBe('la respuesta');
+    expect(typeof rec.answeredAt).toBe('number');
+  });
+
+  it('markError marca error y conserva el item (no se pierde el dato)', async () => {
+    const id = await enqueue({ kind: 'text', text: 'falla' });
+    await claimNext();
+    await markError(id, 'whisper 503');
+    const rec = await getById(id);
+    expect(rec.status).toBe('error');
+    expect(rec.error).toBe('whisper 503');
+    expect(rec.text).toBe('falla'); // el dato sigue ahí
+  });
+
+  it('requeue devuelve un error a queued para reintento explícito', async () => {
+    const id = await enqueue({ kind: 'text', text: 'reintento' });
+    await claimNext();
+    await markError(id, 'timeout');
+    await requeue(id);
+    const rec = await getById(id);
+    expect(rec.status).toBe('queued');
+    expect(rec.error).toBeNull();
+    // Y vuelve a ser reclamable.
+    const claimed = await claimNext();
+    expect(claimed.id).toBe(id);
+  });
+
+  it('requeue NO re-encola un item ya respondido', async () => {
+    const id = await enqueue({ kind: 'text', text: 'ya' });
+    await claimNext();
+    await markAnswered(id);
+    await requeue(id);
+    const rec = await getById(id);
+    expect(rec.status).toBe('answered');
+  });
+});
+
+describe('agentOutboxService — recuperación de trabajo huérfano', () => {
+  it('recoverStaleProcessing rescata items que quedaron en processing (app cerrada mid-flight)', async () => {
+    // Simula: el usuario envió, el AgentScreen reclamó (processing), y la app
+    // se cerró ANTES de markAnswered. El item quedó atascado en processing.
+    const id = await enqueue({ kind: 'text', text: 'a mitad' });
+    await claimNext(); // → processing
+    let rec = await getById(id);
+    expect(rec.status).toBe('processing');
+
+    // Al volver a montar el AgentScreen:
+    const recovered = await recoverStaleProcessing();
+    expect(recovered).toBe(1);
+    rec = await getById(id);
+    expect(rec.status).toBe('queued'); // listo para re-procesar, NO perdido
+    expect(rec.claimedAt).toBeNull();
+  });
+
+  it('recoverStaleProcessing no toca answered/queued/error', async () => {
+    const a = await enqueue({ kind: 'text', text: 'answered', meta: { createdAt: 1 } });
+    const q = await enqueue({ kind: 'text', text: 'queued', meta: { createdAt: 2 } });
+    const e = await enqueue({ kind: 'text', text: 'error', meta: { createdAt: 3 } });
+    await claimNext(); // reclama el más viejo (answered)
+    await markAnswered(a);
+    await markError(e, 'x');
+
+    const recovered = await recoverStaleProcessing();
+    expect(recovered).toBe(0);
+    expect((await getById(a)).status).toBe('answered');
+    expect((await getById(q)).status).toBe('queued');
+    expect((await getById(e)).status).toBe('error');
+  });
+});
+
+describe('agentOutboxService — limpieza', () => {
+  it('getQueued / getInFlight filtran por estado correctamente', async () => {
+    await enqueue({ kind: 'text', text: 'q', meta: { createdAt: 1 } });
+    const id2 = await enqueue({ kind: 'text', text: 'p', meta: { createdAt: 2 } });
+    await enqueue({ kind: 'text', text: 'q2', meta: { createdAt: 3 } });
+    // Reclamar el segundo (p) requiere drenar; reclamamos los dos primeros y
+    // dejamos uno processing.
+    await claimNext(); // q → processing
+    await markAnswered((await getById(1)).id);
+    await claimNext(); // p → processing (queda processing)
+    void id2;
+
+    const queued = await getQueued();
+    expect(queued.map((i) => i.text)).toEqual(['q2']);
+    const inFlight = await getInFlight();
+    expect(inFlight.map((i) => i.text).sort()).toEqual(['p', 'q2']);
+  });
+
+  it('remove borra un item por id', async () => {
+    const id = await enqueue({ kind: 'text', text: 'borrar' });
+    await remove(id);
+    expect(await getById(id)).toBeNull();
+  });
+
+  it('clearOutbox vacía todo', async () => {
+    await enqueue({ kind: 'text', text: 'a' });
+    await enqueue({ kind: 'text', text: 'b' });
+    await clearOutbox();
+    expect(await getAll()).toHaveLength(0);
+  });
+});

--- a/src/services/agentOutboxService.js
+++ b/src/services/agentOutboxService.js
@@ -1,0 +1,336 @@
+/**
+ * agentOutboxService.js — Outbox DURABLE de consultas multimodales al agente.
+ *
+ * Disparada desde el compositor del dashboard (AgentHero). Cuando el usuario
+ * escribe / graba / fotografía / adjunta y toca "enviar", el item se PERSISTE
+ * en IndexedDB (store `agent_outbox`) con status='queued' ANTES de navegar al
+ * AgentScreen. Esto garantiza el contrato de integridad:
+ *
+ *   - Si el usuario da "atrás" o CIERRA la app a mitad de camino → al volver,
+ *     el item sigue ahí con su estado y NO se pierde.
+ *   - El AgentScreen procesa cada item EXACTAMENTE una vez. El claim atómico
+ *     (`claimNext`) transiciona queued→processing dentro de UNA transacción
+ *     readwrite de IndexedDB, así dos montajes/pestañas no pueden procesar el
+ *     mismo item dos veces (anti-duplicado).
+ *
+ * Patrón: réplica de `visionQueueService.js` (enqueue / getAll / flush) pero
+ * orientada a "una consulta del usuario en vuelo" en lugar de "diagnóstico de
+ * foto diferido". Reutiliza la infra `dbCore` (openDB / STORES). Blobs grandes
+ * (audio/foto/adjunto) → IndexedDB, NUNCA localStorage.
+ *
+ * Schema del registro `agent_outbox`:
+ * {
+ *   id: number,                  // autoIncrement (IndexedDB)
+ *   kind: 'text'|'voice'|'photo'|'attachment',
+ *   text: string,                // texto escrito (o '' si modalidad pura)
+ *   blob: Blob|null,             // audio / foto / archivo (NO se pierde)
+ *   mime: string|null,           // tipo MIME del blob
+ *   fileName: string|null,       // nombre original del adjunto (si aplica)
+ *   meta: object,                // passthrough libre (route hint, source, …)
+ *   status: 'queued'|'processing'|'answered'|'error',
+ *   createdAt: number,           // Unix ms — orden FIFO de procesamiento
+ *   claimedAt: number|null,      // cuándo se reclamó (queued→processing)
+ *   answeredAt: number|null,     // cuándo se completó (→answered)
+ *   error: string|null,          // mensaje cuando status='error'
+ * }
+ *
+ * Reglas operativas (tolerante a fallos, offline-first):
+ * - enqueue SOLO persiste; NUNCA llama al LLM / whisper / visión.
+ * - claimNext es el único punto de transición queued→processing y es atómico.
+ * - markAnswered / markError cierran el ciclo de vida del item.
+ * - Falla de persistencia en lectura → [] / null (no throw). En escritura de
+ *   enqueue SÍ se propaga el error: perder el enqueue es perder el dato del
+ *   usuario, y el caller debe poder reaccionar (no navegar en silencio).
+ */
+
+import { openDB, STORES } from '../db/dbCore';
+
+const VALID_KINDS = ['text', 'voice', 'photo', 'attachment'];
+
+/** Ejecuta una IDBRequest como Promise. */
+function reqAsPromise(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Espera a que una transacción complete (durabilidad confirmada). */
+function txDone(tx) {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error || new Error('tx abortada'));
+  });
+}
+
+/**
+ * Persiste una consulta del usuario en la outbox. NO llama a ningún backend —
+ * solo deja el item durable en IndexedDB para que el AgentScreen lo procese.
+ *
+ * @param {Object} args
+ * @param {'text'|'voice'|'photo'|'attachment'} args.kind
+ * @param {string} [args.text]       - texto escrito por el usuario
+ * @param {Blob}   [args.blob]       - audio / foto / archivo adjunto
+ * @param {string} [args.mime]       - MIME del blob (default blob.type)
+ * @param {string} [args.fileName]   - nombre original del adjunto
+ * @param {Object} [args.meta]       - metadata passthrough
+ * @returns {Promise<number>} id del registro encolado
+ */
+export async function enqueue({ kind, text = '', blob = null, mime = null, fileName = null, meta = {} } = {}) {
+  if (!VALID_KINDS.includes(kind)) {
+    throw new Error(`[agentOutbox] kind inválido: ${kind} (debe ser ${VALID_KINDS.join(' | ')})`);
+  }
+  const hasText = typeof text === 'string' && text.trim().length > 0;
+  const hasBlob = blob && typeof blob === 'object';
+  if (!hasText && !hasBlob) {
+    throw new Error('[agentOutbox] enqueue requiere texto o blob (no se persiste un item vacío)');
+  }
+
+  const db = await openDB();
+  const record = {
+    kind,
+    text: typeof text === 'string' ? text : '',
+    blob: hasBlob ? blob : null,
+    mime: mime || (hasBlob ? blob.type || null : null),
+    fileName: fileName || null,
+    meta: meta || {},
+    status: 'queued',
+    createdAt: typeof meta?.createdAt === 'number' ? meta.createdAt : Date.now(),
+    claimedAt: null,
+    answeredAt: null,
+    error: null,
+  };
+  const tx = db.transaction(STORES.AGENT_OUTBOX, 'readwrite');
+  const store = tx.objectStore(STORES.AGENT_OUTBOX);
+  const id = await reqAsPromise(store.add(record));
+  // Esperar oncomplete: confirma que el write llegó a disco ANTES de que el
+  // caller navegue. Si la app se cierra entre el add y el complete, el item
+  // simplemente no existe (no hay estado a medias visible al usuario).
+  await txDone(tx);
+  return id;
+}
+
+/**
+ * Lee todos los items de la outbox (cualquier status), ordenados FIFO.
+ * Tolerante a fallos: [] si la lectura falla.
+ * @returns {Promise<Array>}
+ */
+export async function getAll() {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readonly');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    const all = await reqAsPromise(store.getAll());
+    const list = Array.isArray(all) ? all : [];
+    return list.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+  } catch (e) {
+    console.debug('[agentOutbox] getAll error:', e);
+    return [];
+  }
+}
+
+/**
+ * Items que aún esperan ser procesados (queued). FIFO.
+ * @returns {Promise<Array>}
+ */
+export async function getQueued() {
+  const all = await getAll();
+  return all.filter((i) => i.status === 'queued');
+}
+
+/**
+ * Items todavía en vuelo (queued o processing). Útil para que el AgentScreen
+ * sepa qué burbujas "ya enviadas" debe rehidratar al montar.
+ * @returns {Promise<Array>}
+ */
+export async function getInFlight() {
+  const all = await getAll();
+  return all.filter((i) => i.status === 'queued' || i.status === 'processing');
+}
+
+/**
+ * Reclama atómicamente el SIGUIENTE item procesable (queued, FIFO) y lo
+ * transiciona a 'processing'. Toda la operación —leer candidatos, elegir el
+ * más antiguo, escribir el nuevo status— ocurre dentro de UNA sola transacción
+ * readwrite de IndexedDB. IndexedDB serializa las transacciones readwrite sobre
+ * el mismo store, así que dos montajes concurrentes NO pueden reclamar el mismo
+ * item: el segundo verá el status ya en 'processing' y saltará al siguiente
+ * queued (o a null). Esta es la garantía anti-duplicado.
+ *
+ * @returns {Promise<Object|null>} el item reclamado (ya con status='processing')
+ *   o null si no hay nada queued.
+ */
+export async function claimNext() {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    const all = await reqAsPromise(store.getAll());
+    const list = Array.isArray(all) ? all : [];
+    const queued = list
+      .filter((i) => i.status === 'queued')
+      .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+    if (queued.length === 0) {
+      // Cerrar la tx limpiamente (no escribimos nada).
+      return null;
+    }
+    const claimed = { ...queued[0], status: 'processing', claimedAt: Date.now() };
+    await reqAsPromise(store.put(claimed));
+    await txDone(tx);
+    return claimed;
+  } catch (e) {
+    console.debug('[agentOutbox] claimNext error:', e);
+    return null;
+  }
+}
+
+/** Lee un item por id (o null). */
+export async function getById(id) {
+  if (id == null) return null;
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readonly');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    const rec = await reqAsPromise(store.get(id));
+    return rec || null;
+  } catch (e) {
+    console.debug('[agentOutbox] getById error:', e);
+    return null;
+  }
+}
+
+/** Patch interno de un item por id, preservando lo no especificado. */
+async function patchItem(id, patch) {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    const rec = await reqAsPromise(store.get(id));
+    if (!rec) {
+      return null;
+    }
+    const next = { ...rec, ...patch };
+    await reqAsPromise(store.put(next));
+    await txDone(tx);
+    return next;
+  } catch (e) {
+    console.debug('[agentOutbox] patchItem error:', e);
+    return null;
+  }
+}
+
+/**
+ * Marca un item como respondido (ciclo de vida cerrado). El item se conserva
+ * con status='answered' para que el AgentScreen pueda mostrar el badge correcto
+ * si el usuario vuelve, y NO se re-procese (claimNext solo toma 'queued').
+ */
+export async function markAnswered(id, { answeredText = null } = {}) {
+  return patchItem(id, {
+    status: 'answered',
+    answeredAt: Date.now(),
+    error: null,
+    ...(answeredText != null ? { answeredText } : {}),
+  });
+}
+
+/**
+ * Marca un item como fallido. Lo dejamos como 'error' (NO 'queued') para no
+ * caer en un reintento infinito automático; el AgentScreen ofrece "Reintentar"
+ * explícito, que llama `requeue(id)`.
+ */
+export async function markError(id, message) {
+  return patchItem(id, {
+    status: 'error',
+    error: message || 'fallo desconocido',
+  });
+}
+
+/**
+ * Devuelve un item 'processing' o 'error' a 'queued' para reintento explícito
+ * del usuario. Idempotente sobre items ya 'queued'.
+ */
+export async function requeue(id) {
+  const rec = await getById(id);
+  if (!rec) return null;
+  if (rec.status === 'answered') return rec; // no re-encolar lo ya respondido
+  return patchItem(id, { status: 'queued', claimedAt: null, error: null });
+}
+
+/**
+ * Re-encola cualquier item que haya quedado atascado en 'processing' (la app se
+ * cerró DURANTE el procesamiento, antes de markAnswered/markError). Se llama al
+ * montar el AgentScreen para recuperar trabajo huérfano sin perderlo. Devuelve
+ * cuántos items se recuperaron.
+ *
+ * Esto es lo que cierra el caso "cerré la app mientras pensaba": el item nunca
+ * se pierde — vuelve a 'queued' y se vuelve a procesar (exactly-once efectivo:
+ * el LLM no había confirmado respuesta, así que reintentar es correcto).
+ */
+export async function recoverStaleProcessing() {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    const all = await reqAsPromise(store.getAll());
+    const list = Array.isArray(all) ? all : [];
+    const stale = list.filter((i) => i.status === 'processing');
+    for (const item of stale) {
+      await reqAsPromise(store.put({ ...item, status: 'queued', claimedAt: null }));
+    }
+    await txDone(tx);
+    return stale.length;
+  } catch (e) {
+    console.debug('[agentOutbox] recoverStaleProcessing error:', e);
+    return 0;
+  }
+}
+
+/** Borra un item por id. Tolerante a fallos. */
+export async function remove(id) {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    await reqAsPromise(store.delete(id));
+    await txDone(tx);
+    return true;
+  } catch (e) {
+    console.debug('[agentOutbox] remove error:', e);
+    return false;
+  }
+}
+
+/**
+ * Limpia items ya respondidos más viejos que `maxAgeMs` (default 24h) para que
+ * la outbox no crezca sin límite. Conserva queued/processing/error siempre.
+ */
+export async function pruneAnswered(maxAgeMs = 24 * 60 * 60 * 1000) {
+  try {
+    const all = await getAll();
+    const cutoff = Date.now() - maxAgeMs;
+    const stale = all.filter(
+      (i) => i.status === 'answered' && (i.answeredAt || i.createdAt || 0) < cutoff,
+    );
+    for (const item of stale) {
+      await remove(item.id);
+    }
+    return stale.length;
+  } catch (e) {
+    console.debug('[agentOutbox] pruneAnswered error:', e);
+    return 0;
+  }
+}
+
+/** Vacía la outbox completa (tests / "borrar conversación"). */
+export async function clearOutbox() {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_OUTBOX, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_OUTBOX);
+    await reqAsPromise(store.clear());
+    await txDone(tx);
+  } catch (e) {
+    console.debug('[agentOutbox] clearOutbox error:', e);
+  }
+}

--- a/src/store/useAgentOutboxStore.js
+++ b/src/store/useAgentOutboxStore.js
@@ -1,0 +1,66 @@
+/**
+ * useAgentOutboxStore — capa reactiva sobre `agentOutboxService` (IndexedDB).
+ *
+ * El store NO es la fuente de verdad: IndexedDB lo es (durabilidad ante cierre
+ * de app). Este store es solo un espejo en memoria del estado de la outbox para
+ * que la UI (badge del compositor, indicador "enviando…") reaccione sin pollear.
+ *
+ * Flujo típico:
+ *   - AgentHero.send()  → store.send({ kind, text, blob, … }) → service.enqueue
+ *                         → refresh() → navega
+ *   - AgentScreen mount → store.refresh() para pintar burbujas "ya enviadas"
+ *
+ * Toda mutación delega al service (durable) y luego refresca el snapshot. Si la
+ * persistencia falla en `send`, el error se propaga para que el caller NO
+ * navegue dejando al usuario con la sensación de "se perdió mi mensaje".
+ */
+
+import { create } from 'zustand';
+import {
+  enqueue as svcEnqueue,
+  getAll as svcGetAll,
+  getInFlight as svcGetInFlight,
+} from '../services/agentOutboxService';
+
+const useAgentOutboxStore = create((set) => ({
+  /** Snapshot de TODOS los items (cualquier status), FIFO. */
+  items: [],
+  /** Solo los items en vuelo (queued|processing) — conveniencia derivada. */
+  inFlight: [],
+  /** Marca de refresco en curso (evita parpadeos). */
+  loading: false,
+
+  /**
+   * Recarga el snapshot desde IndexedDB. Idempotente y barato.
+   */
+  refresh: async () => {
+    set({ loading: true });
+    try {
+      const [items, inFlight] = await Promise.all([svcGetAll(), svcGetInFlight()]);
+      set({ items, inFlight, loading: false });
+    } catch (e) {
+      console.debug('[useAgentOutboxStore] refresh error:', e);
+      set({ loading: false });
+    }
+  },
+
+  /**
+   * Persiste una consulta del usuario (durable) y refresca. Devuelve el id.
+   * Propaga el error si el enqueue falla — el caller decide si navegar.
+   *
+   * @param {Object} payload — { kind, text?, blob?, mime?, fileName?, meta? }
+   * @returns {Promise<number>} id del item persistido
+   */
+  send: async (payload) => {
+    const id = await svcEnqueue(payload);
+    try {
+      const [items, inFlight] = await Promise.all([svcGetAll(), svcGetInFlight()]);
+      set({ items, inFlight });
+    } catch (e) {
+      console.debug('[useAgentOutboxStore] post-send refresh error:', e);
+    }
+    return id;
+  },
+}));
+
+export default useAgentOutboxStore;


### PR DESCRIPTION
Reemplaza la caja de entrada falsa del home por un compositor REAL: texto, voz (whisper), foto/visión, adjuntar — todo desde el home. Outbox durable IndexedDB: la consulta se persiste antes de navegar; sobrevive cierre de app, cero pérdida/duplicado (exactly-once). Llega al agente ya enviada + procesando, con transición premium (respeta reduced-motion). 45/45 tests, reusa voz/visión, cero voseo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)