### PR TITLE
fix(ui): quitar altitud repetida de EnvironmentalCard (dejar solo efemérides)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.18",
+  "version": "1.0.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v276';
+const CACHE_NAME = 'chagra-v277';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/EnvironmentalCard.jsx
+++ b/src/components/EnvironmentalCard.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AltitudeBadge from './AltitudeBadge';
 import SkyBadge from './common/SkyBadge';
 import PestMonitoringWindow from './PestMonitoringWindow';
 
@@ -24,13 +23,9 @@ export default function EnvironmentalCard() {
   return (
     <div className="w-full bg-slate-900/60 border-b border-slate-800">
       <section
-        aria-label="Información ambiental: altitud y efemérides"
+        aria-label="Efemérides del cielo: fase lunar y horas solares"
         className="px-4 py-3 flex flex-wrap items-center gap-3"
       >
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">Altitud</span>
-          <AltitudeBadge />
-        </div>
         <div className="flex items-center gap-2">
           <span className="text-xs text-slate-500 font-bold uppercase tracking-wider">Cielo</span>
           <SkyBadge />


### PR DESCRIPTION
El operador: el panel 'Ambiente · altitud · efemérides' repite la altitud que ya sale en el chip de ubicación, ClimaStrip y AltitudeBadge. Se quita el bloque Altitud; quedan luna + sol (únicas, útiles para siembra lunar / ventana plagas ADR-033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)