### PR TITLE
fix(composer): la foto se ve en el chat + transición más suave (520ms)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -17,6 +17,9 @@ import {
 // el diagnóstico foliar multimodal con cache por hash; la foto del home se
 // despacha por aquí al aterrizar.
 import { analyzeFoliage } from '../../services/aiService';
+// Lógica PURA del flujo foto→agente (prompt de visión + texto de burbuja).
+// Extraída para poder testearla sin montar el componente (bug foto 2026-05-31).
+import { processPhotoItem, buildPhotoUserMessage } from '../../services/agentOutboxPhoto';
 import {
   addTurn,
   getFullHistory,
@@ -1233,14 +1236,21 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
   // completo (RAG, sidecar, LLM, TTS, action gate) para UN solo texto.
   // No toca el queue store — eso lo hace handleSubmit antes/después.
   // Tampoco hace re-entry guard porque el queue ya garantiza serialización.
-  const runAgentPipeline = async (text) => {
-    const userMessage = {
-      role: 'user',
-      content: text.trim(),
-      timestamp: Date.now(),
-    };
-
-    setMessages((prev) => [...prev, userMessage]);
+  const runAgentPipeline = async (text, { suppressUserBubble = false } = {}) => {
+    // Bug 2026-05-31: cuando el item viene de la outbox multimodal (foto /
+    // adjunto), el caller YA pintó la burbuja de usuario REAL (con su imagen).
+    // Si además pintáramos aquí una burbuja con el prompt sintético ("Analicé
+    // una foto…") el usuario vería DOS burbujas y la imagen quedaría huérfana.
+    // suppressUserBubble evita ese duplicado: el LLM recibe `text`, pero la UI
+    // ya tiene la burbuja correcta del caller.
+    if (!suppressUserBubble) {
+      const userMessage = {
+        role: 'user',
+        content: text.trim(),
+        timestamp: Date.now(),
+      };
+      setMessages((prev) => [...prev, userMessage]);
+    }
     setStreamingContent('');
     setState(STATE_THINKING);
     setError('');
@@ -1670,7 +1680,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     await handleSubmit(prompt);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSubmit = async (text, { fromVoice = false } = {}) => {
+  const handleSubmit = async (text, { fromVoice = false, suppressUserBubble = false } = {}) => {
     if (!text || !text.trim()) return;
     const trimmed = text.trim();
 
@@ -1679,6 +1689,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     // feedback. El parámetro `fromVoice` queda como hint semántico para
     // futuras políticas (e.g. voice → priority? hoy no se usa).
     void fromVoice;
+    // suppressUserBubble (bug foto 2026-05-31): el caller de la outbox ya pintó
+    // la burbuja de usuario REAL (con imagen / caption). Solo aplica a ESTE
+    // primer texto — los items pending que se promuevan después SÍ pintan su
+    // propia burbuja (son preguntas distintas del usuario).
+    let suppressFirstBubble = suppressUserBubble;
 
     const route = selectChatRoute(trimmed);
     const result = useAgentQueueStore.getState().enqueue(trimmed, route);
@@ -1696,15 +1711,19 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // burbuja "pending" para que sienta que el sistema la escuchó. El
       // procesamiento real arrancará cuando termine la actual via
       // promoción en el finally del pipeline.
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: 'user',
-          content: trimmed,
-          timestamp: Date.now(),
-          _queued: true,
-        },
-      ]);
+      // suppressUserBubble: si el caller (outbox foto/adjunto) ya pintó la
+      // burbuja con su imagen, no la duplicamos aquí.
+      if (!suppressFirstBubble) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: 'user',
+            content: trimmed,
+            timestamp: Date.now(),
+            _queued: true,
+          },
+        ]);
+      }
       return;
     }
 
@@ -1716,7 +1735,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       safety += 1;
       let pipelineFailed = false;
       try {
-        await runAgentPipeline(currentText);
+        await runAgentPipeline(currentText, { suppressUserBubble: suppressFirstBubble });
+        // Solo el primer texto del caller usa la supresión; los promovidos
+        // (pending) son preguntas nuevas y deben pintar su propia burbuja.
+        suppressFirstBubble = false;
       } catch (pipelineErr) {
         // runAgentPipeline ya captura todo internamente; este catch es
         // defensivo (e.g. error fuera del try interno). Marcamos failed
@@ -1811,6 +1833,19 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
   //    la app se cerró a mitad → vuelven a 'queued' y se reintentan (el LLM no
   //    confirmó respuesta, reintentar es correcto). Cero pérdida.
   const outboxDrainingRef = useRef(false);
+  // Object URLs de las fotos del compositor que pintamos en las burbujas
+  // (bug 2026-05-31). Los acumulamos para revocarlos al desmontar y no fugar
+  // memoria. No los revocamos en cada render: la burbuja vive mientras el chat
+  // esté montado.
+  const photoObjectUrlsRef = useRef([]);
+  useEffect(() => {
+    const urls = photoObjectUrlsRef.current;
+    return () => {
+      for (const url of urls) {
+        try { URL.revokeObjectURL(url); } catch { /* noop */ }
+      }
+    };
+  }, []);
 
   /**
    * Procesa UN item ya reclamado (status='processing') según su modalidad y
@@ -1853,38 +1888,34 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       }
 
       if (item.kind === 'photo') {
-        // Burbuja de foto "ya enviada" con el caption del usuario.
-        setMessages((prev) => [
-          ...prev,
-          {
-            role: 'user',
-            content: caption || '📷 Foto enviada para análisis',
-            timestamp: Date.now(),
-            _outboxPhoto: true,
-          },
-        ]);
-        let finding = null;
-        try {
-          finding = item.blob ? await analyzeFoliage(item.blob) : null;
-        } catch (visErr) {
-          console.debug('[Agent] analyzeFoliage falló, sigo con texto:', visErr?.message);
-        }
-        // Construir el prompt que despacha el pipeline normal. Si hubo
-        // diagnóstico de visión, lo inyectamos como contexto para que el LLM
-        // responda conversacionalmente y aterrizado.
-        let prompt;
-        if (finding && (Array.isArray(finding.issues) || finding.treatment_suggestion)) {
-          const issues = Array.isArray(finding.issues) && finding.issues.length > 0
-            ? finding.issues.join(', ')
-            : 'sin problemas evidentes';
-          const treat = finding.treatment_suggestion ? ` Sugerencia preliminar: ${finding.treatment_suggestion}.` : '';
-          prompt = `Analicé una foto de mi planta. Hallazgos del diagnóstico visual: ${issues} (estado ${finding.score ?? 'n/d'}/100).${treat} ${caption || '¿Qué me recomiendas hacer?'}`.trim();
-        } else {
-          prompt = caption
-            ? `Te envié una foto de mi planta. ${caption}`
-            : 'Te envié una foto de mi planta para que me ayudes a identificar qué tiene. No pude obtener un diagnóstico visual automático; guíame por descripción.';
-        }
-        await handleSubmit(prompt);
+        // Bug 2026-05-31: la foto NO llegaba al chat (solo el texto). Causa
+        // raíz doble: (1) la burbuja se pintaba SIN la imagen — el blob se
+        // pasaba a analyzeFoliage y se descartaba, y ChatBubble no sabía pintar
+        // imágenes; (2) handleSubmit→runAgentPipeline pintaba OTRA burbuja con
+        // el prompt sintético → duplicado y la imagen huérfana.
+        //
+        // Fix: processPhotoItem (pure, testeado) corre la visión + arma la
+        // burbuja con `imageUrl`. La pintamos ANTES de mandar el prompt y
+        // pasamos suppressUserBubble:true para no duplicarla.
+        const createUrl = (blob) => {
+          if (typeof URL === 'undefined' || !URL.createObjectURL) return null;
+          const url = URL.createObjectURL(blob);
+          photoObjectUrlsRef.current.push(url);
+          return url;
+        };
+        // 1) Pintar la burbuja con la imagen DE INMEDIATO (antes de la visión)
+        //    para que el usuario vea su foto sin esperar el diagnóstico.
+        const { message } = buildPhotoUserMessage(item, createUrl);
+        setMessages((prev) => [...prev, message]);
+        // 2) Correr la visión y armar el prompt (degrada a "por descripción"
+        //    si analyzeFoliage falla). Reusa processPhotoItem para la parte
+        //    pura del prompt (sin re-pintar burbuja: createUrl ya consumido).
+        const { prompt } = await processPhotoItem(item, {
+          analyze: analyzeFoliage,
+          createUrl: null,
+        });
+        // 3) Despachar al pipeline con la burbuja ya pintada (no duplicar).
+        await handleSubmit(prompt, { suppressUserBubble: true });
         await outboxMarkAnswered(item.id);
         return true;
       }
@@ -1903,7 +1934,9 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       const attachPrompt = caption
         ? caption
         : `Adjunté un archivo (${item.fileName || 'archivo'}). Por ahora no puedo leer archivos directamente; cuéntame qué necesitas y te ayudo.`;
-      await handleSubmit(attachPrompt);
+      // Burbuja del adjunto ya pintada arriba → suppressUserBubble:true para no
+      // duplicarla (mismo bug que la foto, 2026-05-31).
+      await handleSubmit(attachPrompt, { suppressUserBubble: true });
       await outboxMarkAnswered(item.id);
       return true;
     } catch (e) {

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -181,6 +181,20 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
           onDoubleClick={handleBubbleDoubleClick}
           title={!isUser && !isStreaming ? 'Doble click reproduce o silencia esta respuesta' : undefined}
         >
+          {/* Bug 2026-05-31: la foto del compositor del home NO llegaba al chat,
+              solo el texto. Si el mensaje trae `imageUrl` (foto adjuntada en
+              AgentHero → outbox → AgentScreen), la pintamos como miniatura
+              DENTRO de la burbuja de usuario, encima del caption. El object URL
+              lo revoca el AgentScreen al desmontar (no aquí: re-renders no deben
+              invalidar el preview). */}
+          {message.imageUrl && (
+            <img
+              src={message.imageUrl}
+              alt={message.imageAlt || 'Foto enviada al agente'}
+              data-testid="chat-bubble-image"
+              className="mb-2 rounded-xl max-h-56 w-auto object-cover border border-white/15"
+            />
+          )}
           {/* #339: fallback visible si el contenido del assistant llega vacío
               (respuesta degradada del LLM, stream sin tokens, etc.). Nunca
               dejamos la burbuja en blanco — el usuario campesino no debe ver

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -230,4 +230,47 @@ describe('ChatBubble — badge de fuente (verificado vs generativo)', () => {
     const badge = screen.getByTestId('source-badge');
     expect(badge).toHaveTextContent(/get_brand_new_tool/);
   });
+
+  // Bug 2026-05-31: la foto del compositor del home no llegaba al chat — solo
+  // el texto. Ahora la burbuja de usuario con `imageUrl` la renderiza.
+  describe('foto en la burbuja (compositor multimodal)', () => {
+    test('Renderiza la imagen cuando el mensaje de usuario trae imageUrl', () => {
+      const message = {
+        role: 'user',
+        content: '📷 Foto enviada para análisis',
+        timestamp: Date.now(),
+        imageUrl: 'blob:http://localhost/abc-123',
+      };
+      render(<ChatBubble message={message} />);
+      const img = screen.getByTestId('chat-bubble-image');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', 'blob:http://localhost/abc-123');
+      // alt accesible por defecto.
+      expect(img).toHaveAttribute('alt', expect.stringMatching(/foto/i));
+      // El caption sigue visible bajo la imagen.
+      expect(screen.getByText(/Foto enviada para análisis/i)).toBeInTheDocument();
+    });
+
+    test('Sin imageUrl no renderiza ninguna imagen', () => {
+      const message = {
+        role: 'user',
+        content: '¿Qué le pasa a mi planta?',
+        timestamp: Date.now(),
+      };
+      render(<ChatBubble message={message} />);
+      expect(screen.queryByTestId('chat-bubble-image')).not.toBeInTheDocument();
+    });
+
+    test('imageAlt personalizado se respeta', () => {
+      const message = {
+        role: 'user',
+        content: '',
+        timestamp: Date.now(),
+        imageUrl: 'blob:http://localhost/xyz',
+        imageAlt: 'Hoja de tomate con manchas',
+      };
+      render(<ChatBubble message={message} />);
+      expect(screen.getByTestId('chat-bubble-image')).toHaveAttribute('alt', 'Hoja de tomate con manchas');
+    });
+  });
 });

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -58,6 +58,13 @@ function prefersReducedMotion() {
         : false;
 }
 
+// Duración de la transición premium de envío (shimmer + lift del compositor +
+// avatar 'thinking') antes de montar el AgentScreen. 2026-05-31 el operador
+// reportó que 280ms se sentía brusco/apurado — lo subimos a 520ms con easing
+// suave para que se perciba especial, no atropellado. Bajo reduced-motion el
+// retardo es 0 (navega de inmediato, sin animación). Exportado para tests.
+export const SEND_TRANSITION_MS = 520;
+
 export default function AgentHero({ onNavigate }) {
     const [tipIndex, setTipIndex] = useState(0);
     const [text, setText] = useState('');
@@ -119,9 +126,11 @@ export default function AgentHero({ onNavigate }) {
         if (reduce) {
             go();
         } else {
-            // Retardo corto para que el shimmer del compositor + el avatar
-            // thinking se perciban antes del cambio de pantalla. Suave, digno.
-            window.setTimeout(go, 280);
+            // Retardo para que el shimmer del compositor + el lift + el avatar
+            // thinking se perciban completos antes del cambio de pantalla. A
+            // 520ms con easing suave la transición se siente premium y elegante,
+            // no apurada (operador 2026-05-31).
+            window.setTimeout(go, SEND_TRANSITION_MS);
         }
     };
 
@@ -255,13 +264,15 @@ export default function AgentHero({ onNavigate }) {
                     50% { transform: scale(1.025); }
                 }
                 @keyframes chagra-send-shimmer {
-                    0% { transform: translateX(-120%); opacity: 0; }
-                    40% { opacity: 0.9; }
-                    100% { transform: translateX(120%); opacity: 0; }
+                    0% { transform: translateX(-130%); opacity: 0; }
+                    25% { opacity: 1; }
+                    70% { opacity: 1; }
+                    100% { transform: translateX(130%); opacity: 0; }
                 }
                 @keyframes chagra-send-lift {
-                    0% { transform: translateY(0) scale(1); }
-                    100% { transform: translateY(-10px) scale(0.985); opacity: 0.85; }
+                    0% { transform: translateY(0) scale(1); opacity: 1; }
+                    35% { transform: translateY(-4px) scale(1.012); opacity: 1; }
+                    100% { transform: translateY(-16px) scale(0.978); opacity: 0.82; }
                 }
                 .chagra-hero-halo {
                     position: absolute;
@@ -294,18 +305,25 @@ export default function AgentHero({ onNavigate }) {
                     position: absolute;
                     inset: 0;
                     border-radius: inherit;
+                    /* Brillo más ancho y visible que recorre el compositor de
+                       lado a lado — la sensación de "lanzar" la consulta. */
                     background: linear-gradient(
                         100deg,
-                        transparent 20%,
-                        rgba(163, 230, 53, 0.35) 50%,
-                        transparent 80%
+                        transparent 12%,
+                        rgba(163, 230, 53, 0.55) 50%,
+                        transparent 88%
                     );
-                    animation: chagra-send-shimmer 0.6s ease-out forwards;
+                    /* Más lento (520ms) + easing suave (no ease-out brusco) para
+                       que el barrido se perciba elegante, no un flash. */
+                    animation: chagra-send-shimmer 0.52s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
                     pointer-events: none;
                     overflow: hidden;
                 }
                 .chagra-composer-sending {
-                    animation: chagra-send-lift 0.28s ease-in forwards;
+                    /* Lift suave y un pelín más largo, sincronizado con el
+                       retardo de navegación (SEND_TRANSITION_MS). Easing
+                       cubic-bezier "salida suave" para que se sienta digno. */
+                    animation: chagra-send-lift 0.52s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
                 }
                 @media (prefers-reduced-motion: reduce) {
                     .chagra-hero-halo,

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -58,7 +58,7 @@ vi.mock('../../ChagraAgentAvatar', () => ({
   default: ({ state }) => <div data-testid="avatar" data-state={state} />,
 }));
 
-import AgentHero from '../AgentHero';
+import AgentHero, { SEND_TRANSITION_MS } from '../AgentHero';
 
 beforeEach(() => {
   sendMock.mockClear();
@@ -181,6 +181,83 @@ describe('AgentHero — compositor real (no teaser)', () => {
     expect(onNavigate).not.toHaveBeenCalled();
     // El texto sigue en el compositor (no se borró).
     expect(ta.value).toBe('no me pierdas');
+  });
+});
+
+describe('AgentHero — transición de envío premium (bug 2026-05-31)', () => {
+  test('SEND_TRANSITION_MS está en el rango premium pedido (450–600ms)', () => {
+    expect(SEND_TRANSITION_MS).toBeGreaterThanOrEqual(450);
+    expect(SEND_TRANSITION_MS).toBeLessThanOrEqual(600);
+  });
+
+  test('sin reduced-motion: la navegación se difiere SEND_TRANSITION_MS (no instantánea/brusca)', async () => {
+    vi.useFakeTimers();
+    try {
+      // reduced-motion OFF → debe esperar el retardo de la animación.
+      window.matchMedia = vi.fn().mockImplementation((q) => ({
+        matches: false,
+        media: q,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+      const onNavigate = vi.fn();
+      render(<AgentHero onNavigate={onNavigate} />);
+      const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+      fireEvent.change(ta, { target: { value: '¿qué siembro?' } });
+
+      // El send es async (persiste en outbox) → dejamos resolver el microtask
+      // de sendMock antes de avanzar el timer de navegación.
+      await act(async () => {
+        fireEvent.keyDown(ta, { key: 'Enter', shiftKey: false });
+      });
+
+      // Justo ANTES del umbral: aún NO navegó (transición en curso, se siente).
+      await act(async () => { vi.advanceTimersByTime(SEND_TRANSITION_MS - 1); });
+      expect(onNavigate).not.toHaveBeenCalled();
+
+      // Al cumplirse el retardo: navega.
+      await act(async () => { vi.advanceTimersByTime(1); });
+      expect(onNavigate).toHaveBeenCalledWith('agente');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('con reduced-motion: navega de inmediato (sin retardo de animación)', async () => {
+    // matchMedia ya devuelve matches=true para 'reduce' (beforeEach).
+    const onNavigate = vi.fn();
+    render(<AgentHero onNavigate={onNavigate} />);
+    const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+    fireEvent.change(ta, { target: { value: 'directo' } });
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter', shiftKey: false });
+    });
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('agente'));
+  });
+
+  test('al enviar, el compositor entra en fase sending (clases shimmer + lift)', async () => {
+    // reduced-motion OFF para que se aplique la clase de animación.
+    window.matchMedia = vi.fn().mockImplementation((q) => ({
+      matches: false,
+      media: q,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const ta = screen.getByLabelText('Escribe tu pregunta al agente');
+    fireEvent.change(ta, { target: { value: 'mira esto' } });
+    await act(async () => {
+      fireEvent.keyDown(ta, { key: 'Enter', shiftKey: false });
+    });
+    await waitFor(() => {
+      expect(container.querySelector('.chagra-composer-shimmer.chagra-composer-sending')).toBeTruthy();
+    });
   });
 });
 

--- a/src/services/__tests__/agentOutboxPhoto.test.js
+++ b/src/services/__tests__/agentOutboxPhoto.test.js
@@ -1,0 +1,176 @@
+/**
+ * Tests del helper PURO del flujo "foto del compositor → agente"
+ * (bug 2026-05-31: la foto no llegaba al chat, solo el texto).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  hasVisionFinding,
+  buildVisionPrompt,
+  photoBubbleText,
+  buildPhotoUserMessage,
+  processPhotoItem,
+} from '../agentOutboxPhoto';
+
+describe('agentOutboxPhoto.hasVisionFinding', () => {
+  it('null / undefined / no-objeto → false', () => {
+    expect(hasVisionFinding(null)).toBe(false);
+    expect(hasVisionFinding(undefined)).toBe(false);
+    expect(hasVisionFinding('foo')).toBe(false);
+  });
+
+  it('issues array (aunque vacío) → true', () => {
+    expect(hasVisionFinding({ issues: [] })).toBe(true);
+    expect(hasVisionFinding({ issues: ['clorosis'] })).toBe(true);
+  });
+
+  it('treatment_suggestion no vacío → true', () => {
+    expect(hasVisionFinding({ treatment_suggestion: 'aplicar caldo bordelés' })).toBe(true);
+  });
+
+  it('objeto sin issues ni tratamiento → false', () => {
+    expect(hasVisionFinding({ score: 80 })).toBe(false);
+    expect(hasVisionFinding({ treatment_suggestion: '   ' })).toBe(false);
+  });
+});
+
+describe('agentOutboxPhoto.buildVisionPrompt', () => {
+  it('con hallazgos: inyecta issues + estado + caption', () => {
+    const finding = { issues: ['clorosis', 'manchas foliares'], score: 62, treatment_suggestion: 'caldo bordelés' };
+    const prompt = buildVisionPrompt(finding, '¿le echo algo?');
+    expect(prompt).toContain('clorosis, manchas foliares');
+    expect(prompt).toContain('62/100');
+    expect(prompt).toContain('Sugerencia preliminar: caldo bordelés');
+    expect(prompt).toContain('¿le echo algo?');
+  });
+
+  it('con hallazgos sin issues: usa "sin problemas evidentes"', () => {
+    const prompt = buildVisionPrompt({ issues: [], score: 95 }, '');
+    expect(prompt).toContain('sin problemas evidentes');
+    expect(prompt).toContain('95/100');
+    // Sin caption usa la pregunta por defecto.
+    expect(prompt).toContain('¿Qué me recomiendas hacer?');
+  });
+
+  it('score ausente → n/d', () => {
+    const prompt = buildVisionPrompt({ issues: ['oídio'] }, '');
+    expect(prompt).toContain('n/d/100');
+  });
+
+  it('sin diagnóstico + con caption: prompt conversacional con caption', () => {
+    const prompt = buildVisionPrompt(null, 'esta mata de tomate está rara');
+    expect(prompt).toBe('Te envié una foto de mi planta. esta mata de tomate está rara');
+  });
+
+  it('sin diagnóstico + sin caption: pide guía por descripción', () => {
+    const prompt = buildVisionPrompt(null, '');
+    expect(prompt).toContain('No pude obtener un diagnóstico visual automático');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it('nunca devuelve vacío (siempre hay algo que despachar)', () => {
+    expect(buildVisionPrompt(null, '   ').trim().length).toBeGreaterThan(0);
+    expect(buildVisionPrompt({ issues: [] }, '   ').trim().length).toBeGreaterThan(0);
+  });
+
+  it('español colombiano — sin voseo argentino', () => {
+    const a = buildVisionPrompt({ issues: ['x'], score: 1 }, 'mirá che');
+    const b = buildVisionPrompt(null, '');
+    for (const p of [a, b]) {
+      // El generado por nosotros no debe traer voseo (el caption del usuario es suyo).
+      expect(p).not.toMatch(/\btenés\b|\bquerés\b|\belegí\b|\bpodés\b/);
+    }
+  });
+});
+
+describe('agentOutboxPhoto.photoBubbleText', () => {
+  it('con caption → el caption tal cual', () => {
+    expect(photoBubbleText('mi tomate')).toBe('mi tomate');
+  });
+
+  it('sin caption → fallback con icono', () => {
+    expect(photoBubbleText('')).toBe('📷 Foto enviada para análisis');
+    expect(photoBubbleText('   ')).toBe('📷 Foto enviada para análisis');
+  });
+});
+
+describe('agentOutboxPhoto.buildPhotoUserMessage', () => {
+  const blob = new Blob(['jpeg'], { type: 'image/jpeg' });
+
+  it('adjunta imageUrl a la burbuja cuando hay blob (LA FOTO LLEGA AL CHAT)', () => {
+    const createUrl = vi.fn(() => 'blob:preview-123');
+    const { message, imageUrl } = buildPhotoUserMessage(
+      { kind: 'photo', text: 'mírala', blob },
+      createUrl,
+    );
+    expect(createUrl).toHaveBeenCalledWith(blob);
+    expect(imageUrl).toBe('blob:preview-123');
+    expect(message.role).toBe('user');
+    expect(message.imageUrl).toBe('blob:preview-123'); // ← la imagen va en la burbuja
+    expect(message.imageAlt).toMatch(/foto/i);
+    expect(message.content).toBe('mírala');
+    expect(message._outboxPhoto).toBe(true);
+  });
+
+  it('sin caption usa el texto fallback pero igual lleva la imagen', () => {
+    const { message } = buildPhotoUserMessage({ kind: 'photo', text: '', blob }, () => 'blob:x');
+    expect(message.content).toBe('📷 Foto enviada para análisis');
+    expect(message.imageUrl).toBe('blob:x');
+  });
+
+  it('sin blob → sin imageUrl (no rompe)', () => {
+    const { message, imageUrl } = buildPhotoUserMessage({ kind: 'photo', text: 'hola' }, () => 'blob:y');
+    expect(imageUrl).toBeNull();
+    expect(message.imageUrl).toBeUndefined();
+    expect(message.content).toBe('hola');
+  });
+
+  it('createUrl que lanza → degrada a sin imagen, no propaga', () => {
+    const { imageUrl } = buildPhotoUserMessage({ kind: 'photo', blob }, () => { throw new Error('no DOM'); });
+    expect(imageUrl).toBeNull();
+  });
+});
+
+describe('agentOutboxPhoto.processPhotoItem (drain → visión + foto)', () => {
+  const blob = new Blob(['jpeg'], { type: 'image/jpeg' });
+
+  it('DISPARA la visión con el blob y arma prompt con el hallazgo', async () => {
+    const analyze = vi.fn(async () => ({ issues: ['clorosis'], score: 70, treatment_suggestion: 'caldo' }));
+    const createUrl = vi.fn(() => 'blob:pic');
+    const { message, prompt, finding, imageUrl } = await processPhotoItem(
+      { kind: 'photo', text: '¿qué hago?', blob },
+      { analyze, createUrl },
+    );
+    // Visión disparada con el blob exacto.
+    expect(analyze).toHaveBeenCalledWith(blob);
+    expect(finding.issues).toEqual(['clorosis']);
+    // La foto llega al chat.
+    expect(message.imageUrl).toBe('blob:pic');
+    expect(imageUrl).toBe('blob:pic');
+    // El prompt incluye el diagnóstico + el caption.
+    expect(prompt).toContain('clorosis');
+    expect(prompt).toContain('70/100');
+    expect(prompt).toContain('¿qué hago?');
+  });
+
+  it('si la visión falla, degrada a prompt por descripción (no rompe) y la foto sigue', async () => {
+    const analyze = vi.fn(async () => { throw new Error('ollama caído'); });
+    const { message, prompt, finding } = await processPhotoItem(
+      { kind: 'photo', text: '', blob },
+      { analyze, createUrl: () => 'blob:still-here' },
+    );
+    expect(finding).toBeNull();
+    expect(prompt).toContain('No pude obtener un diagnóstico visual automático');
+    // Aun sin diagnóstico, la imagen llega al chat.
+    expect(message.imageUrl).toBe('blob:still-here');
+  });
+
+  it('sin blob no llama a la visión y pide guía por descripción', async () => {
+    const analyze = vi.fn();
+    const { prompt } = await processPhotoItem(
+      { kind: 'photo', text: '' },
+      { analyze, createUrl: () => null },
+    );
+    expect(analyze).not.toHaveBeenCalled();
+    expect(prompt.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/agentOutboxPhoto.js
+++ b/src/services/agentOutboxPhoto.js
@@ -1,0 +1,135 @@
+/**
+ * agentOutboxPhoto.js — lógica PURA del flujo "foto del compositor → agente".
+ *
+ * Extraída de AgentScreen.processOutboxItem para poder testearla sin montar el
+ * componente (que arrastra ~25 servicios). Aquí vive SOLO la construcción del
+ * prompt que se le pasa al LLM a partir del diagnóstico de visión + el caption
+ * del usuario. El despacho real (analyzeFoliage, handleSubmit, setMessages,
+ * object URLs) queda en el componente.
+ *
+ * Bug 2026-05-31 (operador probando el compositor EN VIVO): la foto adjuntada
+ * en AgentHero NO llegaba al chat — solo el texto. Dos causas acopladas:
+ *   1. La burbuja de usuario de la foto se creaba SIN la imagen (el blob se
+ *      pasaba a analyzeFoliage y se descartaba; ChatBubble nunca renderizaba
+ *      imagen). → fix: adjuntar imageUrl a la burbuja + ChatBubble la pinta.
+ *   2. processOutboxItem empujaba una burbuja y luego handleSubmit→
+ *      runAgentPipeline empujaba OTRA con el prompt sintético → duplicado y
+ *      el prompt sintético se veía como si lo hubiera escrito el usuario.
+ *      → fix: suppressUserBubble cuando el caller ya pintó la burbuja real.
+ */
+
+/**
+ * ¿El diagnóstico de visión trae información aprovechable? (issues o
+ * sugerencia de tratamiento). Tolerante a null/forma inesperada.
+ * @param {object|null} finding
+ * @returns {boolean}
+ */
+export function hasVisionFinding(finding) {
+  if (!finding || typeof finding !== 'object') return false;
+  const hasIssues = Array.isArray(finding.issues);
+  const hasTreatment =
+    typeof finding.treatment_suggestion === 'string' &&
+    finding.treatment_suggestion.trim().length > 0;
+  return hasIssues || hasTreatment;
+}
+
+/**
+ * Construye el prompt que se despacha al pipeline del agente para una foto.
+ *
+ * - Con diagnóstico de visión → inyecta hallazgos (issues + estado + sugerencia)
+ *   como contexto para que el LLM responda aterrizado, anexando el caption.
+ * - Sin diagnóstico útil → prompt conversacional que pide guía por descripción,
+ *   preservando el caption si lo hubo.
+ *
+ * @param {object|null} finding   resultado de analyzeFoliage (o null si falló)
+ * @param {string} [caption='']   nota/caption escrito por el usuario
+ * @returns {string} prompt no vacío listo para handleSubmit
+ */
+export function buildVisionPrompt(finding, caption = '') {
+  const cap = (caption || '').trim();
+  if (hasVisionFinding(finding)) {
+    const issues =
+      Array.isArray(finding.issues) && finding.issues.length > 0
+        ? finding.issues.join(', ')
+        : 'sin problemas evidentes';
+    const treat = finding.treatment_suggestion
+      ? ` Sugerencia preliminar: ${finding.treatment_suggestion}.`
+      : '';
+    return `Analicé una foto de mi planta. Hallazgos del diagnóstico visual: ${issues} (estado ${
+      finding.score ?? 'n/d'
+    }/100).${treat} ${cap || '¿Qué me recomiendas hacer?'}`.trim();
+  }
+  return cap
+    ? `Te envié una foto de mi planta. ${cap}`
+    : 'Te envié una foto de mi planta para que me ayudes a identificar qué tiene. No pude obtener un diagnóstico visual automático; guíame por descripción.';
+}
+
+/**
+ * Texto de la burbuja de usuario para una foto (el contenido textual visible).
+ * La imagen va aparte en `imageUrl` del mensaje — esto es solo el caption o un
+ * fallback descriptivo cuando no hay caption.
+ * @param {string} [caption='']
+ * @returns {string}
+ */
+export function photoBubbleText(caption = '') {
+  const cap = (caption || '').trim();
+  return cap || '📷 Foto enviada para análisis';
+}
+
+/**
+ * Construye la burbuja de usuario para una foto (con imagen) a partir del blob.
+ * Pura salvo por la fábrica de object URL inyectada (para testear sin DOM).
+ *
+ * @param {object} item                 item de la outbox (kind 'photo')
+ * @param {(blob:Blob)=>string|null} createUrl  fábrica de object URL
+ * @returns {{message: object, imageUrl: string|null}}
+ */
+export function buildPhotoUserMessage(item, createUrl) {
+  const caption = (item && item.text ? item.text : '').trim();
+  let imageUrl = null;
+  if (item && item.blob && typeof createUrl === 'function') {
+    try {
+      imageUrl = createUrl(item.blob) || null;
+    } catch {
+      imageUrl = null;
+    }
+  }
+  const message = {
+    role: 'user',
+    content: photoBubbleText(caption),
+    timestamp: Date.now(),
+    _outboxPhoto: true,
+    ...(imageUrl ? { imageUrl, imageAlt: 'Foto de tu planta enviada al agente' } : {}),
+  };
+  return { message, imageUrl };
+}
+
+/**
+ * Orquesta el procesamiento PURO de un item de foto: corre la visión y arma
+ * el prompt + la burbuja de usuario con imagen. NO toca React ni IndexedDB —
+ * recibe `analyze` (analyzeFoliage) y `createUrl` inyectados para ser testeable.
+ *
+ * Garantiza:
+ *  - la burbuja SIEMPRE lleva la imagen si el blob existe (bug foto 2026-05-31);
+ *  - la visión SIEMPRE se intenta cuando hay blob (analyzeFoliage), y si falla
+ *    se degrada a prompt por descripción (no rompe el flujo);
+ *  - el prompt resultante nunca es vacío.
+ *
+ * @param {object} item                          item outbox (kind 'photo')
+ * @param {{analyze:(b:Blob)=>Promise<any>, createUrl:(b:Blob)=>string|null}} deps
+ * @returns {Promise<{message:object, prompt:string, finding:any, imageUrl:string|null}>}
+ */
+export async function processPhotoItem(item, { analyze, createUrl } = {}) {
+  const caption = (item && item.text ? item.text : '').trim();
+  const { message, imageUrl } = buildPhotoUserMessage(item, createUrl);
+  let finding = null;
+  if (item && item.blob && typeof analyze === 'function') {
+    try {
+      finding = await analyze(item.blob);
+    } catch {
+      finding = null;
+    }
+  }
+  const prompt = buildVisionPrompt(finding, caption);
+  return { message, prompt, finding, imageUrl };
+}


### PR DESCRIPTION
El operador: la foto no llegaba al agente (solo texto) + transición muy rápida. Diagnóstico: el blob SÍ se persistía y analizaba, pero ChatBubble no tenía ruta para renderizar imágenes + la burbuja se creaba solo-texto + burbuja duplicada por handleSubmit. Fix: ChatBubble renderiza imageUrl (miniatura), processOutboxItem adjunta object URL + pinta de inmediato + suppressUserBubble evita duplicado. Transición 280→520ms, easing suave, respeta reduced-motion. 2745 tests verdes.

Nota: la alucinación de visión (Mapacho 95/100) es SEPARADA — la cubre el guard de visión en la cola nocturna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)