### PR TITLE
feat(safety): guard anti-diagnóstico-visual-sin-foto (P0) — no fabricar análisis sin imagen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.20",
+  "version": "1.0.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v278';
+const CACHE_NAME = 'chagra-v279';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1236,7 +1236,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
   // completo (RAG, sidecar, LLM, TTS, action gate) para UN solo texto.
   // No toca el queue store — eso lo hace handleSubmit antes/después.
   // Tampoco hace re-entry guard porque el queue ya garantiza serialización.
-  const runAgentPipeline = async (text, { suppressUserBubble = false } = {}) => {
+  const runAgentPipeline = async (text, { suppressUserBubble = false, visionContext = null } = {}) => {
     // Bug 2026-05-31: cuando el item viene de la outbox multimodal (foto /
     // adjunto), el caller YA pintó la burbuja de usuario REAL (con su imagen).
     // Si además pintáramos aquí una burbuja con el prompt sintético ("Analicé
@@ -1471,9 +1471,19 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       const guardAltitud =
         (fincaActiva && fincaActiva.altitud) ||
         (() => { try { const p = getProfile(); return (p && p.finca_altitud) || null; } catch (_) { return null; } })();
+      // P0 (prod 2026-05-31): el agente FABRICABA un diagnóstico visual sin foto
+      // real ("Analicé una foto, estado 95/100" + hallazgos de Mapacho del RAG
+      // de tabaco). hadVision marca si ESTE turno trajo una imagen real
+      // (item de foto + analyzeFoliage corrido); sin foto, el guard de visión
+      // reemplaza cualquier afirmación visual por un mensaje honesto que pide la
+      // foto. visionConfidence permite suavizar hallazgos si la visión no fue
+      // concluyente. Para turnos de texto/voz, visionContext es null → hadVision
+      // false → corrige cualquier afirmación visual inventada.
       const guarded = applyOutputGuards(voseoSafe, {
         resolvedEntities,
         fincaAltitud: guardAltitud,
+        hadVision: !!(visionContext && visionContext.hadVision),
+        visionConfidence: (visionContext && visionContext.visionConfidence) ?? null,
       });
       if (guarded.modified) {
         console.debug('[guards] salida corregida', { reasons: guarded.reasons });
@@ -1680,7 +1690,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     await handleSubmit(prompt);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSubmit = async (text, { fromVoice = false, suppressUserBubble = false } = {}) => {
+  const handleSubmit = async (text, { fromVoice = false, suppressUserBubble = false, visionContext = null } = {}) => {
     if (!text || !text.trim()) return;
     const trimmed = text.trim();
 
@@ -1694,6 +1704,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     // primer texto — los items pending que se promuevan después SÍ pintan su
     // propia burbuja (son preguntas distintas del usuario).
     let suppressFirstBubble = suppressUserBubble;
+    // visionContext (P0 visión-sin-foto 2026-05-31): solo el PRIMER texto del
+    // caller lleva el contexto de visión real; los pending promovidos son
+    // preguntas de texto nuevas → sin foto → el guard corrige afirmaciones
+    // visuales fabricadas.
+    let firstVisionContext = visionContext;
 
     const route = selectChatRoute(trimmed);
     const result = useAgentQueueStore.getState().enqueue(trimmed, route);
@@ -1735,10 +1750,15 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       safety += 1;
       let pipelineFailed = false;
       try {
-        await runAgentPipeline(currentText, { suppressUserBubble: suppressFirstBubble });
-        // Solo el primer texto del caller usa la supresión; los promovidos
-        // (pending) son preguntas nuevas y deben pintar su propia burbuja.
+        await runAgentPipeline(currentText, {
+          suppressUserBubble: suppressFirstBubble,
+          visionContext: firstVisionContext,
+        });
+        // Solo el primer texto del caller usa la supresión / el contexto de
+        // visión; los promovidos (pending) son preguntas nuevas: pintan su
+        // propia burbuja y NO arrastran la foto del turno anterior.
         suppressFirstBubble = false;
+        firstVisionContext = null;
       } catch (pipelineErr) {
         // runAgentPipeline ya captura todo internamente; este catch es
         // defensivo (e.g. error fuera del try interno). Marcamos failed
@@ -1910,12 +1930,23 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         // 2) Correr la visión y armar el prompt (degrada a "por descripción"
         //    si analyzeFoliage falla). Reusa processPhotoItem para la parte
         //    pura del prompt (sin re-pintar burbuja: createUrl ya consumido).
-        const { prompt } = await processPhotoItem(item, {
+        const { prompt, finding } = await processPhotoItem(item, {
           analyze: analyzeFoliage,
           createUrl: null,
         });
         // 3) Despachar al pipeline con la burbuja ya pintada (no duplicar).
-        await handleSubmit(prompt, { suppressUserBubble: true });
+        //    visionContext marca que ESTE turno SÍ trajo una foto real: el guard
+        //    de visión NO corrige un diagnóstico visual legítimo. La confianza
+        //    (si analyzeFoliage la expone) permite suavizar hallazgos cuando la
+        //    lectura no fue concluyente.
+        await handleSubmit(prompt, {
+          suppressUserBubble: true,
+          visionContext: {
+            hadVision: true,
+            visionConfidence:
+              finding && typeof finding.confidence === 'number' ? finding.confidence : null,
+          },
+        });
         await outboxMarkAnswered(item.id);
         return true;
       }

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -17,6 +17,7 @@ import {
   guardInvertedViability,
   guardDoseWithoutSource,
   guardSpeciesSubstitution,
+  guardVisionWithoutPhoto,
   applyOutputGuards,
   getOutputGuardTelemetry,
   resetOutputGuardTelemetry,
@@ -401,6 +402,85 @@ describe('guardSpeciesSubstitution', () => {
 // ──────────────────────────────────────────────────────────────────────────
 // ORQUESTADOR + telemetría
 // ──────────────────────────────────────────────────────────────────────────
+// ──────────────────────────────────────────────────────────────────────────
+// GUARD 6 — diagnóstico visual fabricado SIN foto real (P0, prod 2026-05-31)
+// ──────────────────────────────────────────────────────────────────────────
+// El operador cazó 2 veces que el agente FABRICA un diagnóstico visual cuando
+// NO hubo imagen en el turno: respondía "Analicé una foto, estado 95/100" e
+// inventaba hallazgos de Mapacho/Nicotiana attenuata (que venían del RAG textual
+// de un biopreparado de tabaco, NO de visión). Este guard corrige eso de forma
+// determinista cuando hadVision=false.
+describe('guardVisionWithoutPhoto', () => {
+  it('CASO REAL (prod): corrige "Analicé una foto ... estado 95/100" SIN foto en el turno', () => {
+    const llmFail =
+      'Analicé una foto de tu planta de Mapacho (Nicotiana attenuata) y se observa en la imagen ' +
+      'un estado fitosanitario excelente, estado 95/100, sin hallazgos visuales de plagas.';
+    const out = guardVisionWithoutPhoto(llmFail, { hadVision: false });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/visi[oó]n_sin_foto|sin_foto/i);
+    // NO debe seguir afirmando que analizó una foto / dio un puntaje visual.
+    expect(out.text).not.toMatch(/Analic[eé] una foto/i);
+    expect(out.text).not.toMatch(/95\/100/);
+    expect(out.text).not.toMatch(/se observa en la imagen/i);
+    // Debe pedir la foto explícitamente (botón de cámara).
+    expect(out.text).toMatch(/No recib[ií] ninguna foto/i);
+    expect(out.text).toMatch(/c[aá]mara/i);
+  });
+
+  it('corrige variantes: "en la imagen se aprecia" / "según la foto" / "hallazgos visuales"', () => {
+    for (const claim of [
+      'En la imagen se aprecia clorosis en las hojas inferiores.',
+      'Según la foto que me enviaste, la planta tiene buen vigor.',
+      'Los hallazgos visuales indican un estado 88/100.',
+      'Observo en la imagen manchas necróticas.',
+    ]) {
+      const out = guardVisionWithoutPhoto(claim, { hadVision: false });
+      expect(out.modified, claim).toBe(true);
+      expect(out.text).toMatch(/No recib[ií] ninguna foto/i);
+    }
+  });
+
+  it('NO toca la respuesta cuando SÍ hubo foto real con diagnóstico legítimo', () => {
+    const ok =
+      'Analicé la foto de tu planta de café y en la imagen se observa roya en las hojas, ' +
+      'estado 70/100. Te recomiendo caldo bordelés preventivo.';
+    const out = guardVisionWithoutPhoto(ok, { hadVision: true, visionConfidence: 0.82 });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('NO dispara en texto normal sin afirmación visual (aunque hadVision=false)', () => {
+    const ok =
+      'Para sembrar maíz a 2200 msnm te recomiendo variedades de clima frío y preparar el suelo ' +
+      'con abono orgánico.';
+    const out = guardVisionWithoutPhoto(ok, { hadVision: false });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('SUAVIZA cuando hubo foto pero la confianza de visión fue nula y el modelo afirma hallazgos detallados', () => {
+    const detailed =
+      'Analicé la foto y en la imagen se observa un estado 96/100 con hallazgos visuales precisos: ' +
+      'ausencia total de plagas y nutrición óptima.';
+    const out = guardVisionWithoutPhoto(detailed, { hadVision: true, visionConfidence: 0 });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/confianza|baja/i);
+    // No borra la respuesta: anexa una nota de cautela.
+    expect(out.text).toMatch(/no fue concluyente|baja|confirma|descripci[oó]n/i);
+  });
+
+  it('por defecto (sin ctx) asume que NO hubo foto y corrige una afirmación visual', () => {
+    const llmFail = 'Analicé una foto y se observa en la imagen un estado 95/100.';
+    const out = guardVisionWithoutPhoto(llmFail);
+    expect(out.modified).toBe(true);
+  });
+
+  it('maneja entrada vacía / no-string', () => {
+    expect(guardVisionWithoutPhoto('', { hadVision: false }).modified).toBe(false);
+    expect(guardVisionWithoutPhoto(null, { hadVision: false }).text).toBe('');
+  });
+});
+
 describe('applyOutputGuards (cadena)', () => {
   it('encadena varios guards en un mismo texto (agroquímico + dosis)', () => {
     const llmFail = 'Para el tizón aplica Mancozeb 30 ml/L cada semana.';
@@ -446,5 +526,20 @@ describe('applyOutputGuards (cadena)', () => {
     const tel = getOutputGuardTelemetry();
     expect(tel.synthetic_agrochemical).toBeGreaterThanOrEqual(1);
     expect(tel.__total).toBeGreaterThanOrEqual(1);
+  });
+
+  it('cablea hadVision=false: corrige diagnóstico visual fabricado sin foto', () => {
+    const llmFail = 'Analicé una foto de tu Mapacho y se observa en la imagen un estado 95/100.';
+    const out = applyOutputGuards(llmFail, { hadVision: false });
+    expect(out.modified).toBe(true);
+    expect(out.reasons.some((r) => /visi[oó]n_sin_foto|sin_foto/i.test(r))).toBe(true);
+    expect(out.text).toMatch(/No recib[ií] ninguna foto/i);
+  });
+
+  it('cablea hadVision=true: NO toca un diagnóstico visual legítimo con foto real', () => {
+    const ok = 'Analicé la foto y en la imagen se observa roya, estado 70/100.';
+    const out = applyOutputGuards(ok, { hadVision: true, visionConfidence: 0.8 });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
   });
 });

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -725,6 +725,118 @@ export function guardSpeciesSubstitution(responseText, resolvedEntities = null, 
   return { text, modified: true, reason: `sustitución_especie: ${disparadas.join('; ')}` };
 }
 
+// ── GUARD 6: diagnóstico visual fabricado SIN foto real ─────────────────────
+
+/**
+ * Frases con las que el modelo AFIRMA haber analizado/observado una imagen.
+ * Capturadas del caso real de producción (2026-05-31): el agente respondía
+ * "Analicé una foto ... estado 95/100" e inventaba hallazgos de Mapacho /
+ * Nicotiana attenuata que en realidad venían del RAG textual de un biopreparado
+ * de tabaco, NO de un análisis de visión. Normalizado sin tildes/case.
+ */
+const VISION_CLAIM_PATTERNS = [
+  /analic[eé]\s+(?:una?\s+|la\s+|tu\s+|esta\s+)?(?:foto|imagen|fotografia)/,
+  /(?:se\s+observa|se\s+aprecia|se\s+ve|se\s+nota|observo|aprecio|veo|noto)\s+(?:en\s+|que\s+en\s+)?(?:la|tu|esta)\s+(?:foto|imagen|fotografia)/,
+  /en\s+(?:la|tu|esta)\s+(?:foto|imagen|fotografia)\s+se\s+(?:observa|aprecia|ve|nota)/,
+  /seg[uú]n\s+(?:la|tu|esta)\s+(?:foto|imagen|fotografia)/,
+  /(?:en|de)\s+(?:la|tu|esta)\s+(?:foto|imagen|fotografia)\s+(?:que\s+(?:me\s+)?(?:enviaste|mandaste|subiste|compartiste|adjuntaste))/,
+  /hallazgos?\s+visuales?/,
+  /diagn[oó]stico\s+visual/,
+  /an[aá]lisis\s+(?:de\s+)?(?:la\s+)?(?:foto|imagen)/,
+  /estado\s+\d{1,3}\s*\/\s*100/,
+];
+
+/** ¿El texto afirma un análisis visual? (sobre texto normalizado). */
+function _afirmaVision(textNorm) {
+  return VISION_CLAIM_PATTERNS.some((re) => re.test(textNorm));
+}
+
+/**
+ * Mensaje honesto que reemplaza una afirmación de diagnóstico visual fabricado:
+ * deja claro que NO llegó ninguna foto y guía al usuario a usar la cámara.
+ */
+const NO_PHOTO_MESSAGE =
+  'No recibí ninguna foto en este mensaje, así que no puedo darte un diagnóstico visual de tu planta. ' +
+  'Si quieres que la revise por imagen, toca el botón de cámara y envíame la foto; mientras tanto, ' +
+  'cuéntame con palabras qué le ves (color de las hojas, manchas, plagas) y te ayudo igual.';
+
+/**
+ * Nota de cautela cuando SÍ hubo foto pero la visión no fue concluyente y el
+ * modelo igual afirma hallazgos detallados. SUAVIZA, no borra.
+ */
+const LOW_CONFIDENCE_VISION_NOTE =
+  'Nota: el análisis visual de la foto no fue concluyente (la cámara/el modelo no logró una lectura ' +
+  'clara), así que toma estos hallazgos como una primera impresión y no como un diagnóstico cerrado. ' +
+  'Si puedes, mándame una foto más nítida y con buena luz, o descríbeme lo que ves.';
+
+/**
+ * Guard 6 — diagnóstico visual fabricado SIN foto real (P0, prod 2026-05-31).
+ *
+ * El agente NUNCA debe afirmar que analizó/observó una imagen ("Analicé una
+ * foto", "se observa en la imagen", "estado X/100", "hallazgos visuales") si en
+ * el turno NO hubo una imagen real (no fue un item de foto, no corrió
+ * `analyzeFoliage`). El bug se produce porque el RAG textual de un biopreparado
+ * (p.ej. tabaco → Mapacho / Nicotiana attenuata) se cuela y el modelo lo
+ * presenta como "lo que vio".
+ *
+ * Comportamiento (determinista):
+ *   - hadVision === false  Y  el texto afirma visión  → REEMPLAZA el texto por
+ *     un mensaje honesto que pide la foto (botón de cámara). No se intenta
+ *     cirugía de frase (frágil); se sustituye porque una respuesta que afirma
+ *     ver algo inexistente no tiene parte rescatable.
+ *   - hadVision === true   Y  visionConfidence muy baja/nula  Y  el texto
+ *     afirma hallazgos visuales → SUAVIZA (anexa nota de cautela). No borra.
+ *   - hadVision === true con confianza razonable → NO toca (diagnóstico
+ *     legítimo: NO bloquear cuando SÍ hubo foto real).
+ *
+ * PURA y SÍNCRONA. Firma propia (recibe el contexto de visión, no
+ * resolvedEntities/altitud), por eso se invoca directamente desde
+ * applyOutputGuards y no desde GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {object} [ctx]
+ * @param {boolean} [ctx.hadVision=false]  ¿hubo una imagen real en el turno?
+ * @param {number|null} [ctx.visionConfidence=null]  confianza de analyzeFoliage.
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardVisionWithoutPhoto(responseText, { hadVision = false, visionConfidence = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+
+  const norm = _stripDiacritics(responseText);
+  if (!_afirmaVision(norm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // No hubo foto en el turno pero el modelo afirma haber analizado una → la
+  // afirmación es 100% fabricada: la reemplazamos por el mensaje honesto.
+  if (!hadVision) {
+    // Idempotencia: si ya es nuestro mensaje, no re-disparar.
+    if (/No recib[ií] ninguna foto en este mensaje/i.test(responseText)) {
+      return { text: responseText, modified: false, reason: null };
+    }
+    bumpGuardTelemetry('vision_without_photo');
+    return { text: NO_PHOTO_MESSAGE, modified: true, reason: 'visión_sin_foto' };
+  }
+
+  // Sí hubo foto, pero la visión no fue concluyente (confianza nula/baja) y el
+  // modelo igual afirma hallazgos: SUAVIZAMOS (no borramos un posible acierto).
+  const conf = Number(visionConfidence);
+  const lowConfidence = Number.isFinite(conf) && conf <= 0.2;
+  if (lowConfidence) {
+    if (/an[aá]lisis visual de la foto no fue concluyente/i.test(responseText)) {
+      return { text: responseText, modified: false, reason: null };
+    }
+    bumpGuardTelemetry('vision_low_confidence');
+    const text = `${responseText.trim()}\n\n${LOW_CONFIDENCE_VISION_NOTE}`;
+    return { text, modified: true, reason: 'visión_confianza_baja' };
+  }
+
+  // hadVision con confianza razonable (o desconocida) → diagnóstico legítimo.
+  return { text: responseText, modified: false, reason: null };
+}
+
 // ── orquestador ─────────────────────────────────────────────────────────────
 
 /**
@@ -758,15 +870,35 @@ const GUARD_CHAIN = [
  * @param {object} [ctx]
  * @param {Array<object>|null} [ctx.resolvedEntities] — grounding AGE del turno.
  * @param {number|string|null} [ctx.fincaAltitud] — msnm de la finca activa.
+ * @param {boolean} [ctx.hadVision=false] — ¿hubo una imagen real (item foto /
+ *   analyzeFoliage corrido) en ESTE turno? Sin esto el guard de visión asume
+ *   que NO hubo foto y corrige cualquier diagnóstico visual fabricado.
+ * @param {number|null} [ctx.visionConfidence=null] — confianza de analyzeFoliage
+ *   (para suavizar hallazgos detallados cuando la visión no fue concluyente).
  * @returns {{text:string, modified:boolean, reasons:string[]}}
  */
-export function applyOutputGuards(responseText, { resolvedEntities = null, fincaAltitud = null } = {}) {
+export function applyOutputGuards(
+  responseText,
+  { resolvedEntities = null, fincaAltitud = null, hadVision = false, visionConfidence = null } = {},
+) {
   if (typeof responseText !== 'string' || responseText.length === 0) {
     return { text: responseText ?? '', modified: false, reasons: [] };
   }
   let text = responseText;
   let modified = false;
   const reasons = [];
+
+  // GUARD de visión PRIMERO: si la respuesta afirma un diagnóstico visual sin
+  // foto real en el turno, no tiene sentido correr los demás guards sobre un
+  // texto que vamos a reemplazar entero. Firma propia (contexto de visión), por
+  // eso va fuera de GUARD_CHAIN.
+  const vis = guardVisionWithoutPhoto(text, { hadVision, visionConfidence });
+  if (vis && vis.modified) {
+    text = vis.text;
+    modified = true;
+    if (vis.reason) reasons.push(vis.reason);
+  }
+
   for (const guard of GUARD_CHAIN) {
     const res = guard(text, resolvedEntities, fincaAltitud);
     if (res && res.modified) {


### PR DESCRIPTION
El operador: el agente respondió 'Analicé una foto 95/100' + inventó análisis de Mapacho cuando NO llegó imagen. guardVisionWithoutPhoto: si hadVision:false y el texto afirma visión → reemplaza por mensaje honesto pidiendo la foto. hadVision:true + confidence baja → suaviza. Diagnóstico legítimo con foto real → no toca. Cablea hadVision desde processOutboxItem. 48/48 tests con el caso real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)