### PR TITLE
feat(safety): rechazar PDF/adjunto no-planta + validar cultivos registrados + respetar nombre del perfil

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -20,6 +20,7 @@ import { analyzeFoliage } from '../../services/aiService';
 // Lógica PURA del flujo foto→agente (prompt de visión + texto de burbuja).
 // Extraída para poder testearla sin montar el componente (bug foto 2026-05-31).
 import { processPhotoItem, buildPhotoUserMessage } from '../../services/agentOutboxPhoto';
+import { isAnalyzableImageAttachment, buildAttachmentRejection } from '../../services/agentOutboxAttachment';
 import {
   addTurn,
   getFullHistory,
@@ -1479,11 +1480,14 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // foto. visionConfidence permite suavizar hallazgos si la visión no fue
       // concluyente. Para turnos de texto/voz, visionContext es null → hadVision
       // false → corrige cualquier afirmación visual inventada.
+      const guardProfileName =
+        (() => { try { const p = getProfile(); return (p && p.nombre) || null; } catch (_) { return null; } })();
       const guarded = applyOutputGuards(voseoSafe, {
         resolvedEntities,
         fincaAltitud: guardAltitud,
         hadVision: !!(visionContext && visionContext.hadVision),
         visionConfidence: (visionContext && visionContext.visionConfidence) ?? null,
+        profileName: guardProfileName,
       });
       if (guarded.modified) {
         console.debug('[guards] salida corregida', { reasons: guarded.reasons });
@@ -1951,8 +1955,9 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         return true;
       }
 
-      // attachment (no-imagen): no hay análisis automático, despachamos el
-      // caption + nota del adjunto.
+      // attachment: SIEMPRE pintamos la burbuja del usuario con su adjunto.
+      // Si NO es imagen analizable, el guard de abajo responde honesto sin
+      // correr el pipeline (no se fabrica diagnostico).
       setMessages((prev) => [
         ...prev,
         {
@@ -1962,6 +1967,24 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           _outboxAttachment: true,
         },
       ]);
+      // Guard adjunto (bug 2026-05-31, HOJA DE VIDA PDF): si el adjunto NO es
+      // una imagen analizable (PDF, documento, audio...), NO corremos el
+      // pipeline agronomico -el LLM, sin poder leer el archivo, FABRICABA
+      // consejos de finca (alucino 'tomate fresa arandano' + un nombre
+      // inventado)-. Respondemos HONESTO y corto, sin tocar el pipeline. Las
+      // imagenes de verdad si bajan al flujo de vision (el guard
+      // imagen-sin-planta va aparte: branch feat/guard-vision-sin-foto).
+      if (!isAnalyzableImageAttachment(item)) {
+        const rejection = buildAttachmentRejection(item);
+        setMessages((prev) => [
+          ...prev,
+          { role: 'assistant', content: rejection, timestamp: Date.now() },
+        ]);
+        if (ttsEnabled) { try { speak(rejection, { rate: 0.9, pitch: 1.0 }); } catch (_) { /* noop */ } }
+        await outboxMarkAnswered(item.id, { answeredText: rejection });
+        return true;
+      }
+
       const attachPrompt = caption
         ? caption
         : `Adjunté un archivo (${item.fileName || 'archivo'}). Por ahora no puedo leer archivos directamente; cuéntame qué necesitas y te ayudo.`;

--- a/src/services/__tests__/agentOutboxAttachment.test.js
+++ b/src/services/__tests__/agentOutboxAttachment.test.js
@@ -1,0 +1,80 @@
+/**
+ * agentOutboxAttachment.test.js — rechazo honesto de adjuntos no-analizables.
+ *
+ * Incidente prod (2026-05-31): el operador le pasó su HOJA DE VIDA (PDF) al
+ * agente con "analiza". El agente, en vez de decir honesto que solo lee fotos
+ * de plantas, FABRICÓ consejos de finca (alucinó "tomate fresa arandano" y un
+ * nombre de usuario inventado). Causa: la rama `attachment` de processOutboxItem
+ * despachaba el caption al pipeline agronómico SIN importar el tipo de archivo.
+ *
+ * Fix testeado aquí: clasificar el adjunto y, si NO es una imagen analizable
+ * (PDF, doc, audio, etc.), responder con un mensaje honesto y CORTO SIN correr
+ * el pipeline. PURO y SÍNCRONO — sin React ni IndexedDB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isAnalyzableImageAttachment,
+  buildAttachmentRejection,
+} from '../agentOutboxAttachment.js';
+
+describe('isAnalyzableImageAttachment', () => {
+  it('PDF (hoja de vida) NO es imagen analizable', () => {
+    expect(
+      isAnalyzableImageAttachment({ mime: 'application/pdf', fileName: 'hoja-de-vida.pdf' }),
+    ).toBe(false);
+  });
+
+  it('reconoce PDF por extensión aunque el mime falte', () => {
+    expect(isAnalyzableImageAttachment({ mime: null, fileName: 'CV_Miguel.PDF' })).toBe(false);
+  });
+
+  it('documento Word NO es imagen analizable', () => {
+    expect(
+      isAnalyzableImageAttachment({
+        mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        fileName: 'doc.docx',
+      }),
+    ).toBe(false);
+  });
+
+  it('audio adjunto NO es imagen analizable', () => {
+    expect(isAnalyzableImageAttachment({ mime: 'audio/mpeg', fileName: 'nota.mp3' })).toBe(false);
+  });
+
+  it('imagen JPEG SÍ es analizable (la atiende el flujo de visión, no el de rechazo)', () => {
+    expect(isAnalyzableImageAttachment({ mime: 'image/jpeg', fileName: 'planta.jpg' })).toBe(true);
+  });
+
+  it('imagen por extensión aunque el mime venga vacío', () => {
+    expect(isAnalyzableImageAttachment({ mime: '', fileName: 'foto.png' })).toBe(true);
+  });
+
+  it('item null/sin datos → no analizable (degradar a rechazo seguro)', () => {
+    expect(isAnalyzableImageAttachment(null)).toBe(false);
+    expect(isAnalyzableImageAttachment({})).toBe(false);
+  });
+});
+
+describe('buildAttachmentRejection', () => {
+  it('menciona que no lee PDF ni hojas de vida y pide una foto de planta', () => {
+    const msg = buildAttachmentRejection({ mime: 'application/pdf', fileName: 'hoja-de-vida.pdf' });
+    expect(msg).toMatch(/fotos de plantas|foto de tu planta/i);
+    expect(msg).toMatch(/pdf|documento|hoja de vida/i);
+    // No inventa diagnóstico agronómico.
+    expect(msg).not.toMatch(/tomate fresa arandano/i);
+  });
+
+  it('es honesto, corto y en castellano colombiano (sin voseo)', () => {
+    const msg = buildAttachmentRejection({ mime: 'application/pdf', fileName: 'cv.pdf' });
+    // Cero voseo: nada de "mandá/contame/elegí/tenés/podés/enviá".
+    expect(msg).not.toMatch(/mandá|contame|elegí|tenés|podés|querés|enviá/i);
+    expect(msg.length).toBeLessThan(280);
+  });
+
+  it('texto no vacío incluso sin fileName/mime', () => {
+    const msg = buildAttachmentRejection({});
+    expect(typeof msg).toBe('string');
+    expect(msg.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/__tests__/agentService.cultivosValidation.test.js
+++ b/src/services/__tests__/agentService.cultivosValidation.test.js
@@ -1,0 +1,110 @@
+/**
+ * agentService.cultivosValidation.test.js
+ *
+ * Bug prod (2026-05-31): el agente habló con seguridad de "tomate fresa
+ * arandano" — un cultivo INEXISTENTE (alucinación canónica) — como si fuera un
+ * cultivo registrado del usuario. Causa: buildFincaContext inyectaba TODO el
+ * inventario de useAssetStore (groupedCultivos) como cultivos AUTORITATIVOS,
+ * sin validar contra el catálogo/grounding. Un dato basura del asset store
+ * (3 especies distintas mashed: tomate + fresa + arándano) entraba como verdad.
+ *
+ * Fix: validateCultivos parte el inventario en {verificados, sinVerificar}.
+ * buildFincaContext inyecta los verificados como cultivos del usuario y NO
+ * afirma autoridad sobre los sin verificar (los omite del bloque autoritativo
+ * y deja una nota/log para que el operador limpie el dato).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { validateCultivos, buildFincaContext } from '../agentService.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('validateCultivos — separa cultivos reales de basura del asset store', () => {
+  it('marca "tomate fresa arandano" como SIN verificar (3 especies distintas mashed)', () => {
+    const grouped = [
+      { name: 'tomate fresa arandano', count: 1 },
+      { name: 'café', count: 3 },
+    ];
+    const { verificados, sinVerificar } = validateCultivos(grouped);
+    expect(sinVerificar.map((c) => c.name)).toContain('tomate fresa arandano');
+    expect(verificados.map((c) => c.name)).not.toContain('tomate fresa arandano');
+    // El cultivo legítimo sí pasa.
+    expect(verificados.map((c) => c.name)).toContain('café');
+  });
+
+  it('cultivos legítimos de 1-2 palabras pasan como verificados', () => {
+    const grouped = [
+      { name: 'maíz', count: 2 },
+      { name: 'tomate cherry', count: 5 },
+      { name: 'caléndula', count: 4 },
+    ];
+    const { verificados, sinVerificar } = validateCultivos(grouped);
+    expect(sinVerificar).toHaveLength(0);
+    expect(verificados.map((c) => c.name).sort()).toEqual(
+      ['caléndula', 'maíz', 'tomate cherry'].sort(),
+    );
+  });
+
+  it('si se pasa catalogNames, valida contra el catálogo (no-match → sin verificar)', () => {
+    const grouped = [
+      { name: 'plántula misteriosa', count: 1 },
+      { name: 'lulo', count: 2 },
+    ];
+    const catalogNames = ['lulo', 'café', 'maíz', 'tomate'];
+    const { verificados, sinVerificar } = validateCultivos(grouped, { catalogNames });
+    expect(verificados.map((c) => c.name)).toEqual(['lulo']);
+    expect(sinVerificar.map((c) => c.name)).toEqual(['plántula misteriosa']);
+  });
+
+  it('catalogNames hace match laxo por substring (tomate ↔ tomate cherry)', () => {
+    const grouped = [{ name: 'tomate cherry', count: 1 }];
+    const { verificados } = validateCultivos(grouped, { catalogNames: ['tomate'] });
+    expect(verificados.map((c) => c.name)).toEqual(['tomate cherry']);
+  });
+
+  it('entradas vacías/no-array → {verificados:[], sinVerificar:[]}', () => {
+    expect(validateCultivos(null)).toEqual({ verificados: [], sinVerificar: [] });
+    expect(validateCultivos([])).toEqual({ verificados: [], sinVerificar: [] });
+  });
+});
+
+describe('buildFincaContext — NO inyecta el cultivo fantasma como autoritativo', () => {
+  it('omite "tomate fresa arandano" de la línea de cultivos registrados', () => {
+    const ctx = buildFincaContext({
+      groupedCultivos: [
+        { name: 'tomate fresa arandano', count: 1 },
+        { name: 'café', count: 2 },
+      ],
+      month: 4,
+    });
+    const linea = ctx.split('\n').find((l) => l.startsWith('Cultivos registrados'));
+    expect(linea).toBeTruthy();
+    expect(linea).toContain('café');
+    expect(linea).not.toContain('tomate fresa arandano');
+  });
+
+  it('deja una nota/log para que el operador limpie el dato basura', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    buildFincaContext({
+      groupedCultivos: [{ name: 'tomate fresa arandano', count: 1 }],
+      month: 4,
+    });
+    const logged = warn.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).toMatch(/tomate fresa arandano/i);
+  });
+
+  it('si TODOS los cultivos son legítimos, no hay omisiones ni warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ctx = buildFincaContext({
+      groupedCultivos: [{ name: 'maíz', count: 2 }, { name: 'frijol', count: 1 }],
+      month: 4,
+    });
+    const linea = ctx.split('\n').find((l) => l.startsWith('Cultivos registrados'));
+    expect(linea).toContain('maíz');
+    expect(linea).toContain('frijol');
+    const logged = warn.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).not.toMatch(/sin verificar|fantasma/i);
+  });
+});

--- a/src/services/__tests__/outputGuards.inventedName.test.js
+++ b/src/services/__tests__/outputGuards.inventedName.test.js
@@ -1,0 +1,74 @@
+/**
+ * outputGuards.inventedName.test.js
+ *
+ * Bug prod (2026-05-31): el agente saludó al usuario como "Dante" — un nombre
+ * INVENTADO. El usuario es Miguel y su profile NO trae nombre. El modelo
+ * alucinó un nombre propio y abrió la respuesta con él ("Hola Dante, …").
+ *
+ * Fix: guardInventedName remueve un saludo con nombre propio al INICIO de la
+ * respuesta cuando ese nombre NO coincide con getProfile().nombre. Si el
+ * profile tiene nombre y coincide, se respeta. PURO y SÍNCRONO.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { guardInventedName, applyOutputGuards } from '../outputGuards.js';
+
+describe('guardInventedName', () => {
+  it('remueve "Hola Dante," cuando el profile NO tiene nombre', () => {
+    const llm = 'Hola Dante, para tu cultivo de café te recomiendo podar en marzo.';
+    const out = guardInventedName(llm, { profileName: null });
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/dante/i);
+    expect(out.text).toMatch(/^Para tu cultivo de café/);
+  });
+
+  it('remueve el nombre inventado cuando NO coincide con el del profile (Miguel)', () => {
+    const llm = '¡Hola Dante! El maíz a esa altitud va bien.';
+    const out = guardInventedName(llm, { profileName: 'Miguel' });
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/dante/i);
+    expect(out.text).toMatch(/maíz/i);
+  });
+
+  it('RESPETA el nombre cuando coincide con el profile', () => {
+    const llm = 'Hola Miguel, el café necesita sombra.';
+    const out = guardInventedName(llm, { profileName: 'Miguel' });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(llm);
+  });
+
+  it('match del nombre del profile es insensible a tildes/caso', () => {
+    const llm = 'Hola José, revisa el riego.';
+    const out = guardInventedName(llm, { profileName: 'jose' });
+    expect(out.modified).toBe(false);
+  });
+
+  it('no toca respuestas que no abren con saludo+nombre', () => {
+    const llm = 'El cubio se siembra entre 2800 y 3500 msnm.';
+    const out = guardInventedName(llm, { profileName: null });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(llm);
+  });
+
+  it('no confunde una palabra común tras "Hola" con un nombre propio', () => {
+    // "Hola, claro que sí" — "claro" no es nombre propio (minúscula).
+    const llm = 'Hola, claro que sí: el tomate aguanta hasta 2600 msnm.';
+    const out = guardInventedName(llm, { profileName: null });
+    expect(out.modified).toBe(false);
+  });
+
+  it('maneja texto vacío / no-string', () => {
+    expect(guardInventedName('', { profileName: null }).modified).toBe(false);
+    expect(guardInventedName(null, { profileName: null }).modified).toBe(false);
+  });
+});
+
+describe('applyOutputGuards — integra el guard de nombre inventado', () => {
+  it('pasa profileName por las opciones y limpia el saludo inventado', () => {
+    const llm = 'Hola Dante, el frijol se asocia bien con el maíz.';
+    const out = applyOutputGuards(llm, { profileName: null });
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/dante/i);
+    expect(out.reasons.join(' ')).toMatch(/nombre/i);
+  });
+});

--- a/src/services/agentOutboxAttachment.js
+++ b/src/services/agentOutboxAttachment.js
@@ -1,0 +1,60 @@
+/**
+ * agentOutboxAttachment.js — lógica PURA del flujo "adjunto no-foto → agente".
+ *
+ * Incidente prod (2026-05-31): el operador le pasó su HOJA DE VIDA (PDF) con
+ * "analiza". La rama `attachment` de processOutboxItem despachaba el caption al
+ * pipeline agronómico SIN mirar el tipo de archivo, y el LLM —sin poder leer el
+ * PDF— FABRICÓ consejos de finca: alucinó un cultivo inexistente ("tomate fresa
+ * arandano") y un nombre de usuario inventado ("Dante").
+ *
+ * Fix (este módulo): clasificar el adjunto. Si NO es una imagen analizable
+ * (PDF, documento, audio, zip, etc.), el agente debe RESPONDER HONESTO y CORTO
+ * —"solo analizo fotos de plantas"— SIN correr el pipeline. Solo las imágenes
+ * de verdad bajan al flujo de visión (donde un guard aparte —branch
+ * feat/guard-vision-sin-foto— maneja la imagen-sin-planta).
+ *
+ * PURO y SÍNCRONO — sin React ni IndexedDB. Testeable sin montar el componente.
+ */
+
+/** Extensiones de imagen que el flujo de visión sí puede intentar analizar. */
+const IMAGE_EXT_RE = /\.(jpe?g|png|webp|gif|bmp|heic|heif|tiff?)$/i;
+
+/**
+ * ¿El adjunto es una imagen que el flujo de visión puede intentar analizar?
+ *
+ * Detecta por MIME (`image/*`) y, como respaldo, por extensión del fileName
+ * (los navegadores a veces no setean el mime). Tolerante a null/forma rara:
+ * ante la duda devuelve false (degradar al rechazo honesto es lo seguro — el
+ * costo de un falso "no es imagen" es solo pedir la foto de nuevo; el costo de
+ * un falso "sí es imagen" es alucinar sobre un PDF).
+ *
+ * @param {object|null} item — item outbox (kind 'attachment') con { mime, fileName }
+ * @returns {boolean}
+ */
+export function isAnalyzableImageAttachment(item) {
+  if (!item || typeof item !== 'object') return false;
+  const mime = (item.mime || '').toString().toLowerCase().trim();
+  if (mime.startsWith('image/')) return true;
+  // Mime ausente o genérico (application/octet-stream): caer a la extensión.
+  if (!mime || mime === 'application/octet-stream') {
+    const fileName = (item.fileName || '').toString();
+    return IMAGE_EXT_RE.test(fileName);
+  }
+  return false;
+}
+
+/**
+ * Mensaje HONESTO y corto cuando el usuario adjunta algo que NO es una foto de
+ * planta (PDF, hoja de vida, documento, audio…). NO inventa diagnóstico. En
+ * castellano colombiano, sin voseo.
+ *
+ * @param {object|null} item — item outbox con { mime, fileName }
+ * @returns {string} mensaje no vacío para mostrar/hablar al usuario.
+ */
+export function buildAttachmentRejection(item) {
+  const fileName = item && item.fileName ? String(item.fileName).trim() : '';
+  const mime = item && item.mime ? String(item.mime).toLowerCase() : '';
+  const esPdf = mime.includes('pdf') || /\.pdf$/i.test(fileName);
+  const tipo = esPdf ? 'documentos PDF ni hojas de vida' : 'documentos ni archivos';
+  return `Solo puedo analizar fotos de plantas o cultivos, no ${tipo} 😅. Mándame una foto de tu planta y te ayudo.`;
+}

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -948,6 +948,81 @@ export function temporadaColombiana(month) {
  * @param {number} [max=8] — cuántas especies listar antes de "y N más".
  * @returns {string} ej. "maíz ×2, café, frijol y 3 más" o '' si vacío.
  */
+/**
+ * Nombres comunes de cultivos/hortalizas/frutas conocidos en Colombia, usados
+ * como heuristica de validacion cuando NO se pasa un catalogo explicito. NO es
+ * el catalogo completo (eso vive en catalogDB, async): es el set minimo para
+ * detectar la basura canonica del asset store. La regla clave es que un nombre
+ * formado por VARIOS de estos tokens distintos ("tomate fresa arandano") NO es
+ * una especie real sino tres cultivos mashed.
+ */
+const KNOWN_CROP_TOKENS = new Set([
+  'tomate', 'fresa', 'arandano', 'mora', 'lulo', 'curuba', 'uchuva', 'cafe',
+  'maiz', 'frijol', 'arveja', 'papa', 'yuca', 'platano', 'banano', 'aguacate',
+  'mango', 'guayaba', 'naranja', 'limon', 'mandarina', 'cebolla', 'ajo',
+  'zanahoria', 'remolacha', 'lechuga', 'espinaca', 'cilantro', 'apio',
+  'calabacin', 'ahuyama', 'pepino', 'pimenton', 'aji', 'cacao', 'cana',
+  'cubio', 'ibia', 'oca', 'quinua', 'amaranto', 'caña', 'arandanos',
+]);
+
+/**
+ * Valida un inventario agrupado contra el catalogo/grounding y lo separa en
+ * cultivos VERIFICADOS (especies reales) y SIN VERIFICAR (datos sospechosos del
+ * asset store, p.ej. la basura canonica "tomate fresa arandano").
+ *
+ * Estrategia:
+ *  - Si se pasa `catalogNames` (nombres reales del catalogo, sincronos en
+ *    memoria), un cultivo es VERIFICADO solo si hace match laxo (substring en
+ *    cualquier direccion, sin tildes) con alguno; lo demas queda sin verificar.
+ *  - Sin catalogNames, aplica una heuristica deterministica: un nombre formado
+ *    por >=3 tokens y compuesto MAYORITARIAMENTE por nombres de cultivos
+ *    DISTINTOS conocidos ("tomate fresa arandano") es un mash de varias especies
+ *    -> sin verificar. Los nombres de 1-2 palabras pasan (no penalizamos
+ *    cultivos legitimos compuestos como "tomate cherry").
+ *
+ * PURA y SINCRONA. CERO latencia. Tolerante a entradas raras.
+ *
+ * @param {Array<{name:string,count:number}>} grouped
+ * @param {{catalogNames?: string[]}} [opts]
+ * @returns {{verificados: Array<{name:string,count:number}>, sinVerificar: Array<{name:string,count:number}>}}
+ */
+export function validateCultivos(grouped, { catalogNames = null } = {}) {
+  if (!Array.isArray(grouped) || grouped.length === 0) {
+    return { verificados: [], sinVerificar: [] };
+  }
+  const items = grouped.filter((g) => g && typeof g.name === 'string' && g.name.trim());
+
+  let catNorm = null;
+  if (Array.isArray(catalogNames) && catalogNames.length > 0) {
+    catNorm = catalogNames
+      .map((n) => _stripDiacritics(n))
+      .filter((n) => n.length >= 3);
+  }
+
+  const verificados = [];
+  const sinVerificar = [];
+
+  for (const g of items) {
+    const norm = _stripDiacritics(g.name);
+
+    let ok;
+    if (catNorm) {
+      // Match laxo por substring en ambas direcciones (tomate <-> tomate cherry).
+      ok = catNorm.some((c) => norm.includes(c) || c.includes(norm));
+    } else {
+      // Heuristica sin catalogo: detectar mash de varias especies distintas.
+      const tokens = norm.split(/\s+/).filter((t) => t.length >= 3);
+      const distinctCrops = new Set(tokens.filter((t) => KNOWN_CROP_TOKENS.has(t)));
+      // >=3 tokens y >=3 cultivos conocidos DISTINTOS => mash inexistente.
+      ok = !(tokens.length >= 3 && distinctCrops.size >= 3);
+    }
+
+    (ok ? verificados : sinVerificar).push({ name: g.name, count: Number(g.count) || 1 });
+  }
+
+  return { verificados, sinVerificar };
+}
+
 function summarizeCultivos(grouped, max = 8) {
   if (!Array.isArray(grouped) || grouped.length === 0) return '';
   const items = grouped
@@ -1032,6 +1107,8 @@ function crossResolvedWithInventory(resolvedEntities, groupedCultivos) {
  * @param {Array<{name:string,count:number}>} [args.groupedCultivos] — inventario agrupado
  * @param {Array<object>|null} [args.resolvedEntities] — entidades AGE del turno
  * @param {Array<object>} [args.activeAlerts] — useAlertStore activeAlerts
+ * @param {string[]|null} [args.catalogNames] — nombres reales del catalogo (sync, opcional);
+ *   si se pasa, valida cultivos contra el catalogo; si no, usa heuristica anti-mash.
  * @param {number} [args.month] — override de mes para tests (1-12)
  * @returns {string} bloque compacto (siempre incluye al menos la temporada).
  */
@@ -1042,6 +1119,7 @@ export function buildFincaContext({
   groupedCultivos = [],
   resolvedEntities = null,
   activeAlerts = [],
+  catalogNames = null,
   month,
 } = {}) {
   const p = profile && typeof profile === 'object' ? profile : {};
@@ -1118,13 +1196,27 @@ export function buildFincaContext({
   }
 
   // ── Finca / inventario (resumen compacto, NO el detalle) ────────────────
-  const cultivos = summarizeCultivos(groupedCultivos);
+  // Bug prod 2026-05-31: un dato basura del asset store ("tomate fresa
+  // arandano" = 3 especies mashed, INEXISTENTE) se inyectaba como cultivo
+  // AUTORITATIVO y el agente hablaba de el con seguridad. validateCultivos
+  // separa lo verificado de lo sospechoso; SOLO inyectamos lo verificado y
+  // dejamos una nota para que el operador limpie el dato.
+  const { verificados, sinVerificar } = validateCultivos(groupedCultivos, { catalogNames });
+  if (sinVerificar.length > 0) {
+    const basura = sinVerificar.map((c) => c.name).join(', ');
+    console.warn(
+      `[agentService] Cultivos SIN VERIFICAR omitidos del contexto (no son especies del catalogo, revisar/limpiar en el asset store): ${basura}`,
+    );
+  }
+  const cultivos = summarizeCultivos(verificados);
   if (cultivos) {
     lines.push(`Cultivos registrados en la finca: ${cultivos}.`);
   }
 
   // ── Cruce grounding × inventario (sin queries nuevas) ───────────────────
-  const tieneRegistrado = crossResolvedWithInventory(resolvedEntities, groupedCultivos);
+  // Solo cruzamos contra lo verificado: nunca afirmamos que el usuario "ya
+  // tiene" un cultivo fantasma.
+  const tieneRegistrado = crossResolvedWithInventory(resolvedEntities, verificados);
   if (tieneRegistrado.length > 0) {
     const nombres = tieneRegistrado.map((t) => t.nombre).join(', ');
     lines.push(

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -840,6 +840,64 @@ export function guardVisionWithoutPhoto(responseText, { hadVision = false, visio
 // ── orquestador ─────────────────────────────────────────────────────────────
 
 /**
+ * guardInventedName — remueve un saludo con NOMBRE PROPIO inventado al inicio de
+ * la respuesta cuando ese nombre NO coincide con el del perfil del usuario.
+ *
+ * Bug prod (2026-05-31): el agente saludo al usuario como "Dante" — un nombre
+ * INVENTADO (el usuario es Miguel y su perfil no trae nombre). El modelo alucino
+ * un nombre propio y abrio con el. Este guard detecta el patron de apertura
+ * "Hola <Nombre>," / "Buenas <Nombre>:" / "Hola <Nombre>!" y, si <Nombre> no es
+ * el del perfil, lo elimina dejando el resto de la respuesta intacto.
+ *
+ * Conservador (anti-falso-positivo): solo actua si lo que sigue al saludo es UNA
+ * palabra capitalizada que parece nombre propio (no una palabra comun en
+ * minuscula como "claro"). Si el perfil tiene nombre y coincide, NO toca nada.
+ *
+ * Firma distinta al resto de la cadena (necesita el nombre del perfil): se
+ * invoca aparte en applyOutputGuards, no dentro de GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {{profileName?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+const GREETING_NAME_RE =
+  /^[\s¡!]*(?:hola|buenas|buenos d[ií]as|buenas tardes|buenas noches|qu[eé] m[aá]s|saludos)\s+([A-ZÁÉÍÓÚÑ][a-záéíóúñ]+)\s*(?:[,:!.]|$)/i;
+
+export function guardInventedName(responseText, { profileName = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  const m = responseText.match(GREETING_NAME_RE);
+  if (!m) return { text: responseText, modified: false, reason: null };
+
+  const saludoNombre = m[1];
+  // Solo nombres PROPIOS: la palabra tras el saludo debe ir capitalizada. Una
+  // palabra comun en minuscula ("Hola, claro que si") no es un nombre inventado.
+  const firstChar = saludoNombre.charAt(0);
+  if (firstChar !== firstChar.toUpperCase() || firstChar === firstChar.toLowerCase()) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  // Si coincide con el nombre del perfil (sin tildes/caso), es legitimo.
+  const profNorm = _stripDiacritics(profileName || '');
+  const nameNorm = _stripDiacritics(saludoNombre);
+  if (profNorm && nameNorm && (profNorm === nameNorm || profNorm.split(/\s+/).includes(nameNorm))) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Nombre no-grounded: remover SOLO el saludo+nombre+puntuacion inicial y
+  // recapitalizar la primera letra del resto.
+  let rest = responseText.replace(GREETING_NAME_RE, '').replace(/^[\s,:!.¡¿-]+/, '');
+  if (!rest) return { text: responseText, modified: false, reason: null };
+  rest = rest.charAt(0).toUpperCase() + rest.slice(1);
+  bumpGuardTelemetry('inventedName');
+  return {
+    text: rest,
+    modified: true,
+    reason: `nombre propio no-grounded removido del saludo: "${saludoNombre}"`,
+  };
+}
+
+/**
  * Cadena ordenada de guards. El agroquímico va primero (lo más urgente:
  * SAFETY), luego invasoras, viabilidad y por último la suavización de dosis.
  */
@@ -875,11 +933,19 @@ const GUARD_CHAIN = [
  *   que NO hubo foto y corrige cualquier diagnóstico visual fabricado.
  * @param {number|null} [ctx.visionConfidence=null] — confianza de analyzeFoliage
  *   (para suavizar hallazgos detallados cuando la visión no fue concluyente).
+ * @param {string|null} [ctx.profileName] — nombre del usuario (getProfile().nombre)
+ *   para el guard de nombre inventado. Si falta, cualquier saludo con nombre se remueve.
  * @returns {{text:string, modified:boolean, reasons:string[]}}
  */
 export function applyOutputGuards(
   responseText,
-  { resolvedEntities = null, fincaAltitud = null, hadVision = false, visionConfidence = null } = {},
+  {
+    resolvedEntities = null,
+    fincaAltitud = null,
+    hadVision = false,
+    visionConfidence = null,
+    profileName = null,
+  } = {},
 ) {
   if (typeof responseText !== 'string' || responseText.length === 0) {
     return { text: responseText ?? '', modified: false, reasons: [] };
@@ -906,6 +972,13 @@ export function applyOutputGuards(
       modified = true;
       if (res.reason) reasons.push(res.reason);
     }
+  }
+  // Guard de nombre inventado: firma propia (necesita el nombre del perfil).
+  const nameRes = guardInventedName(text, { profileName });
+  if (nameRes && nameRes.modified) {
+    text = nameRes.text;
+    modified = true;
+    if (nameRes.reason) reasons.push(nameRes.reason);
   }
   return { text, modified, reasons };
 }


### PR DESCRIPTION
3 fixes de los tests del operador: (1) PDF/hoja de vida → mensaje honesto 'solo analizo fotos de plantas', sin fabricar consejo. (2) cultivos registrados validados vs catálogo: 'tomate fresa arandano' (dato fantasma del useAssetStore del usuario) se omite del contexto autoritativo + console.warn para limpieza. (3) guardInventedName: usa el nombre del perfil (Dante=perro del operador, legítimo), solo quita nombres NO grounded. 2781 tests verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)