### PR TITLE
feat(safety): refinar guards post-rebench — viabilidad altitud-directa + stopwords NLU + evaluador semántico

### DIFF
--- a/scripts/__tests__/bench-scorer.test.mjs
+++ b/scripts/__tests__/bench-scorer.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * scripts/lib/__tests__/bench-scorer.test.mjs
+ *
+ * R3 (re-bench post-guards 2026-05-31): el scoring del bench era match LITERAL
+ * de cadenas (`countKeywords` con `String.includes`). granite decía lo correcto
+ * con OTRAS palabras (sinónimos / lemas) y sacaba 0/10 — un falso negativo que
+ * engañaba el ranking. Este módulo introduce:
+ *   - scoreKeywordsFlexible: match insensible a tildes/case + lema (stem) +
+ *     sinónimos del dominio agroecológico colombiano.
+ *   - LLM-judge (buildJudgePrompt / parseJudgeVerdict / scoreWithJudge) con el
+ *     caller de ollama INYECTADO → testeable sin GPU.
+ *
+ * NO re-corre el bench completo (eso carga GPU + lo decide el operador): solo
+ * deja el evaluador listo + esta cobertura unitaria del scorer.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  scoreKeywordsFlexible,
+  buildJudgePrompt,
+  parseJudgeVerdict,
+  scoreWithJudge,
+} from '../lib/bench-scorer.mjs';
+
+describe('scoreKeywordsFlexible', () => {
+  it('cuenta match literal igual que antes (no regresiona)', () => {
+    const resp = 'La fresa requiere drenaje, riego por goteo y protección contra heladas.';
+    const kws = ['drenaje', 'riego', 'heladas', 'poda'];
+    const out = scoreKeywordsFlexible(resp, kws);
+    expect(out.matched).toBe(3); // drenaje, riego, heladas (falta poda)
+    expect(out.total).toBe(4);
+  });
+
+  it('ignora tildes y mayúsculas', () => {
+    const resp = 'Aplicá CALDO BORDELÉS como preventivo; mejora la AIREACIÓN.';
+    const out = scoreKeywordsFlexible(resp, ['caldo bordeles', 'aireacion']);
+    expect(out.matched).toBe(2);
+  });
+
+  it('match por LEMA: "podas"/"podar"/"podado" cuentan por keyword "poda"', () => {
+    expect(scoreKeywordsFlexible('Hacé podas de renovación.', ['poda']).matched).toBe(1);
+    expect(scoreKeywordsFlexible('Conviene podar las hojas secas.', ['poda']).matched).toBe(1);
+    expect(scoreKeywordsFlexible('El cafetal ya está podado.', ['poda']).matched).toBe(1);
+  });
+
+  it('match por LEMA en la keyword multi-palabra: "variedad resistente" ~ "variedades resistentes"', () => {
+    const resp = 'Usá variedades resistentes como Castillo.';
+    expect(scoreKeywordsFlexible(resp, ['variedades resistentes']).matched).toBe(1);
+    // y la forma singular del keyword también casa con el plural del texto
+    expect(scoreKeywordsFlexible(resp, ['variedad resistente']).matched).toBe(1);
+  });
+
+  it('match por SINÓNIMO del dominio: keyword "heladas" casa con "frío intenso"', () => {
+    const resp = 'Protegé el cultivo del frío intenso en las madrugadas.';
+    const out = scoreKeywordsFlexible(resp, ['heladas']);
+    expect(out.matched).toBe(1);
+  });
+
+  it('match por SINÓNIMO: "nitrógeno" casa con "fijar nitrógeno"/"abono nitrogenado"/"leguminosas"', () => {
+    expect(scoreKeywordsFlexible('Las leguminosas aportan al suelo.', ['nitrógeno']).matched).toBe(1);
+    expect(scoreKeywordsFlexible('Usá un abono nitrogenado.', ['nitrógeno']).matched).toBe(1);
+  });
+
+  it('NO infla: keyword ausente sin sinónimo ni lema sigue sin contar', () => {
+    const out = scoreKeywordsFlexible('La planta necesita sol.', ['drenaje', 'poda']);
+    expect(out.matched).toBe(0);
+  });
+
+  it('expone qué keywords casaron (para diagnóstico)', () => {
+    const out = scoreKeywordsFlexible('Drenaje y podas.', ['drenaje', 'poda', 'riego']);
+    expect(out.matchedKeywords).toContain('drenaje');
+    expect(out.matchedKeywords).toContain('poda');
+    expect(out.matchedKeywords).not.toContain('riego');
+  });
+
+  it('entrada vacía / no-string → 0 sin romper', () => {
+    expect(scoreKeywordsFlexible('', ['x']).matched).toBe(0);
+    expect(scoreKeywordsFlexible(null, ['x']).matched).toBe(0);
+    expect(scoreKeywordsFlexible('algo', []).total).toBe(0);
+  });
+});
+
+describe('buildJudgePrompt', () => {
+  it('incluye pregunta, respuesta del modelo y los keywords esperados', () => {
+    const p = buildJudgePrompt({
+      query: '¿Cómo se maneja la roya del café?',
+      response: 'Variedades resistentes y caldo bordelés.',
+      expectedKeywords: ['variedades resistentes', 'poda', 'caldo bordelés'],
+    });
+    expect(p).toMatch(/roya del café/);
+    expect(p).toMatch(/Variedades resistentes y caldo bordelés/);
+    expect(p).toMatch(/variedades resistentes/);
+    // debe pedir un veredicto parseable (JSON o CUMPLE/NO_CUMPLE)
+    expect(p).toMatch(/CUMPLE|veredicto|JSON/i);
+  });
+});
+
+describe('parseJudgeVerdict', () => {
+  it('parsea JSON {"cumple": true, "score": 0.8}', () => {
+    const v = parseJudgeVerdict('Análisis... {"cumple": true, "score": 0.8} fin.');
+    expect(v.cumple).toBe(true);
+    expect(v.score).toBeCloseTo(0.8);
+  });
+
+  it('parsea "VEREDICTO: CUMPLE" en texto plano', () => {
+    expect(parseJudgeVerdict('La respuesta es buena. VEREDICTO: CUMPLE').cumple).toBe(true);
+    expect(parseJudgeVerdict('Le falta. VEREDICTO: NO_CUMPLE').cumple).toBe(false);
+  });
+
+  it('score fuera de [0,1] o ausente → derivado del booleano cumple', () => {
+    expect(parseJudgeVerdict('{"cumple": true}').score).toBe(1);
+    expect(parseJudgeVerdict('{"cumple": false}').score).toBe(0);
+  });
+
+  it('verdict ilegible → null (no inventa)', () => {
+    const v = parseJudgeVerdict('bla bla sin veredicto');
+    expect(v).toBeNull();
+  });
+});
+
+describe('scoreWithJudge (caller de ollama inyectado, sin GPU)', () => {
+  it('usa el veredicto del judge cuando responde bien', async () => {
+    const fakeOllama = async () => '{"cumple": true, "score": 0.9}';
+    const out = await scoreWithJudge(
+      { query: 'q', response: 'r', expectedKeywords: ['a'] },
+      { ollamaCall: fakeOllama },
+    );
+    expect(out.cumple).toBe(true);
+    expect(out.score).toBeCloseTo(0.9);
+    expect(out.source).toBe('judge');
+  });
+
+  it('cae a keyword-flexible si el judge falla/timeout (graceful)', async () => {
+    const failOllama = async () => { throw new Error('timeout'); };
+    const out = await scoreWithJudge(
+      { query: 'q', response: 'Drenaje y poda.', expectedKeywords: ['drenaje', 'poda'] },
+      { ollamaCall: failOllama },
+    );
+    // fallback: usó keyword-flexible (2/2)
+    expect(out.source).toBe('keywords');
+    expect(out.score).toBeCloseTo(1);
+  });
+
+  it('cae a keyword-flexible si el judge responde ilegible', async () => {
+    const junkOllama = async () => 'no entiendo nada';
+    const out = await scoreWithJudge(
+      { query: 'q', response: 'Solo sol.', expectedKeywords: ['drenaje', 'poda'] },
+      { ollamaCall: junkOllama },
+    );
+    expect(out.source).toBe('keywords');
+    expect(out.score).toBeCloseTo(0);
+  });
+});

--- a/scripts/bench-agente-completo.mjs
+++ b/scripts/bench-agente-completo.mjs
@@ -11,14 +11,23 @@
  * Output: data/bench-runs/agente-completo-YYYY-MM-DD.jsonl + summary.md
  * Luego invoca bench-llm-judge.mjs para evaluar calidad.
  *
+ * Scoring (R3, re-bench post-guards 2026-05-31): keyword-FLEXIBLE por defecto
+ * (sinónimos/lemas, ver scripts/lib/bench-scorer.mjs) — antes era match literal
+ * que daba falsos 0/10. Con `--judge` añade un LLM-judge (mistral-nemo:12b vía
+ * ollama) que evalúa si la respuesta cumple el criterio SUSTANTIVO; degrada a
+ * keyword-flexible si el judge no está / falla.
+ *
  * Uso:
  *   node scripts/bench-agente-completo.mjs
+ *   node scripts/bench-agente-completo.mjs --judge        # + LLM-judge semántico
+ *   JUDGE_MODEL=granite3.1-dense:8b node scripts/... --judge
  */
 import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { performance } from 'node:perf_hooks';
 import { execSync } from 'node:child_process';
+import { scoreKeywordsFlexible, scoreWithJudge } from './lib/bench-scorer.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -27,7 +36,15 @@ const BENCH_RUNS_DIR = join(DATA_DIR, 'bench-runs');
 
 const SIDECAR_URL = process.env.SIDECAR_URL || 'http://localhost:7880';
 const OLLAMA_URL = 'http://localhost:11434/api/chat';
+const OLLAMA_GEN_URL = process.env.OLLAMA_GEN_URL || 'http://localhost:11434/api/generate';
 const TIMEOUT_MS = 180_000; // 3 min timeout por modelo
+
+// R3 — evaluador semántico. `--judge` activa el LLM-judge (mistral-nemo:12b por
+// defecto: índice de benchmarks lo marca como judge 100% NUEVO). Sin la flag, el
+// scoring es keyword-FLEXIBLE (sinónimos/lemas) en vez del match literal previo.
+const USE_JUDGE = process.argv.includes('--judge');
+const JUDGE_MODEL = process.env.JUDGE_MODEL || 'mistral-nemo:12b';
+const JUDGE_TIMEOUT_MS = 60_000;
 
 const MODELS = {
   gemma3_4b: 'gemma3:4b',
@@ -525,9 +542,39 @@ function checkMaxwellError(error) {
   return MAXWELL_ERROR_PATTERNS.some(pattern => errorLower.includes(pattern.toLowerCase()));
 }
 
+// R3 — scoring keyword-FLEXIBLE (sinónimos/lemas) en vez del match literal que
+// daba falsos 0/10 cuando el modelo decía lo correcto con otras palabras.
 function countKeywords(response, keywords) {
-  const lower = response.toLowerCase();
-  return keywords.filter(kw => lower.includes(kw.toLowerCase())).length;
+  return scoreKeywordsFlexible(response, keywords).matched;
+}
+
+/**
+ * Caller real del LLM-judge contra ollama (mistral-nemo:12b). Devuelve el texto
+ * crudo del modelo; `scoreWithJudge` lo parsea y degrada a keyword-flexible si
+ * falla. NO se llama si --judge está apagado.
+ */
+async function judgeOllamaCall(prompt) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), JUDGE_TIMEOUT_MS);
+  try {
+    const res = await fetch(OLLAMA_GEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: JUDGE_MODEL,
+        prompt,
+        stream: false,
+        options: { temperature: 0.1, num_predict: 120 },
+        keep_alive: '30m',
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`judge HTTP ${res.status}`);
+    const data = await res.json();
+    return data.response || '';
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function benchmarkModel(modelKey, modelName, promptData) {
@@ -548,9 +595,25 @@ async function benchmarkModel(modelKey, modelName, promptData) {
     
     // Step 4: Post-validate
     const validationResult = await postValidate(promptData.query, ollamaResult.response);
-    
+
     clearTimeout(timer);
-    
+
+    // R3 — evaluación semántica opcional (--judge): el LLM-judge dictamina si la
+    // respuesta cumple el criterio SUSTANTIVO (no literal). Degrada a keyword-
+    // flexible si el judge no está / falla. Sin la flag, no se llama (CERO GPU
+    // extra).
+    let judge = null;
+    if (USE_JUDGE) {
+      judge = await scoreWithJudge(
+        {
+          query: promptData.query,
+          response: ollamaResult.response,
+          expectedKeywords: promptData.expected_keywords,
+        },
+        { ollamaCall: judgeOllamaCall },
+      );
+    }
+
     return {
       model: modelName,
       latency_resolve_ms: entitiesResult.latency_ms,
@@ -561,6 +624,9 @@ async function benchmarkModel(modelKey, modelName, promptData) {
       tokens_estimated: ollamaResult.tokens_estimated,
       keywords_matched: countKeywords(ollamaResult.response, promptData.expected_keywords),
       keywords_total: promptData.expected_keywords.length,
+      judge_cumple: judge ? judge.cumple : null,
+      judge_score: judge ? judge.score : null,
+      judge_source: judge ? judge.source : null,
       entities_grounded: entitiesResult.entities.length,
       halluc_count: validationResult.detected_count,
       hallucinated: validationResult.hallucinated,

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -1,0 +1,241 @@
+/**
+ * bench-scorer.mjs — evaluador de respuestas del bench del agente Chagra.
+ *
+ * R3 (re-bench post-guards 2026-05-31): el scoring de `bench-agente-completo`
+ * era match LITERAL de cadenas (`response.includes(keyword)`). granite3.1 decía
+ * lo correcto con OTRAS palabras (sinónimos / lemas) y sacaba 0/10 — un falso
+ * negativo que engañaba el ranking. Este módulo provee:
+ *
+ *   1) scoreKeywordsFlexible — match insensible a tildes/case + lema (stem
+ *      ligero del español) + sinónimos del dominio agroecológico colombiano.
+ *      Reemplaza al `countKeywords` literal sin cambiar el contrato (devuelve
+ *      conteo + total + qué keywords casaron).
+ *
+ *   2) LLM-judge opcional (flag --judge del bench): buildJudgePrompt +
+ *      parseJudgeVerdict + scoreWithJudge. El caller de ollama se INYECTA, así
+ *      el judge es testeable sin GPU y degrada a keyword-flexible si el modelo
+ *      no está / falla / responde ilegible. Modelo recomendado: mistral-nemo:12b
+ *      (índice de benchmarks: judge 100% NUEVO).
+ *
+ * Módulo PURO y sin efectos secundarios (no auto-ejecuta nada) → importable por
+ * el bench y por el test unitario.
+ *
+ * @module bench-scorer
+ */
+
+// ── normalización ───────────────────────────────────────────────────────────
+
+/** minúsculas + sin diacríticos + colapsa espacios. */
+function norm(s) {
+  return (s || '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9ñ\s/-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Stem ligero del español: recorta sufijos flexivos/derivativos comunes para
+ * que "podas/podar/podado/podada" → "pod", "variedades" → "variedad" ~ "varied",
+ * "resistentes" → "resistent". No es Snowball completo; basta para el bench.
+ */
+function stem(word) {
+  let w = word;
+  if (w.length <= 4) return w;
+  const suffixes = [
+    'amientos', 'imientos', 'amiento', 'imiento',
+    'aciones', 'iciones', 'acion', 'icion', 'cion', 'sion',
+    'antes', 'entes', 'ante', 'ente',
+    'ables', 'ibles', 'able', 'ible',
+    'adas', 'idas', 'ados', 'idos', 'ada', 'ido', 'ada', 'ido',
+    'ando', 'iendo', 'ar', 'er', 'ir',
+    'mente',
+    'es', 'as', 'os', 'a', 'o', 's',
+  ];
+  for (const suf of suffixes) {
+    if (w.length - suf.length >= 3 && w.endsWith(suf)) {
+      w = w.slice(0, -suf.length);
+      break;
+    }
+  }
+  return w;
+}
+
+/** stem de cada token de una frase. */
+function stemPhrase(phrase) {
+  return norm(phrase).split(' ').filter(Boolean).map(stem);
+}
+
+// ── sinónimos del dominio ───────────────────────────────────────────────────
+
+/**
+ * Sinónimos / equivalencias del dominio agroecológico colombiano. Cada keyword
+ * canónica lista frases que cuentan como acierto aunque el modelo no use la
+ * palabra exacta. Se comparan ya normalizadas (sin tildes). Lista acotada y
+ * conservadora — solo equivalencias inequívocas vistas en el bench.
+ */
+const DOMAIN_SYNONYMS = {
+  heladas: ['helada', 'frio intenso', 'frio extremo', 'bajas temperaturas', 'temperaturas bajas', 'escarcha', 'congelamiento'],
+  riego: ['regar', 'irrigacion', 'humedad constante', 'agua constante', 'goteo'],
+  drenaje: ['drenar', 'bien drenado', 'suelo drenado', 'sin encharcar', 'sin encharcamiento', 'buen drenaje'],
+  poda: ['podar', 'podas', 'despunte', 'deshoje', 'corte de hojas'],
+  sombra: ['sombrio', 'semisombra', 'media sombra', 'sombreado'],
+  nitrogeno: ['fijar nitrogeno', 'fijacion de nitrogeno', 'abono nitrogenado', 'leguminosas', 'fijadores de nitrogeno', 'fijador de nitrogeno'],
+  'caldo bordeles': ['caldo bordeles', 'cal y sulfato de cobre', 'sulfato de cobre con cal'],
+  'sulfato de cobre': ['sulfato cuprico', 'cobre'],
+  fungicida: ['fungico', 'antifungico', 'control de hongos'],
+  compost: ['compostaje', 'abono organico', 'materia organica descompuesta'],
+  'materia organica': ['abono organico', 'humus', 'composta', 'compost'],
+  'control biologico': ['enemigos naturales', 'depredadores naturales', 'parasitoides', 'controlador biologico'],
+  aireacion: ['ventilacion', 'circulacion de aire', 'buena aireacion'],
+  invernadero: ['cubierta', 'tunel', 'macrotunel', 'casa malla'],
+};
+
+// ── R3.1: keyword-flexible ──────────────────────────────────────────────────
+
+/**
+ * ¿La keyword `kw` aparece en `respNorm` por (a) substring literal, (b) lema, o
+ * (c) sinónimo del dominio? `respStems` es el set de stems del texto.
+ */
+function keywordHits(kw, respNorm, respStems) {
+  const kwNorm = norm(kw);
+  if (!kwNorm) return false;
+
+  // (a) literal (insensible a tildes/case).
+  if (respNorm.includes(kwNorm)) return true;
+
+  // (c) sinónimos del dominio (antes que el lema: más específico).
+  const syns = DOMAIN_SYNONYMS[kwNorm];
+  if (syns) {
+    for (const s of syns) {
+      if (respNorm.includes(norm(s))) return true;
+    }
+  }
+
+  // (b) lema: TODOS los tokens stemmed de la keyword presentes como stems del
+  // texto. Para keyword de una palabra equivale a "stem en el texto".
+  const kwStems = stemPhrase(kwNorm);
+  if (kwStems.length > 0 && kwStems.every((st) => respStems.has(st))) return true;
+
+  return false;
+}
+
+/**
+ * scoreKeywordsFlexible — reemplazo flexible de `countKeywords`. Cuenta cuántas
+ * de `expectedKeywords` están cubiertas por la respuesta vía literal / lema /
+ * sinónimo del dominio.
+ *
+ * @param {string} response
+ * @param {string[]} expectedKeywords
+ * @returns {{ matched:number, total:number, matchedKeywords:string[] }}
+ */
+export function scoreKeywordsFlexible(response, expectedKeywords) {
+  const kws = Array.isArray(expectedKeywords) ? expectedKeywords : [];
+  if (typeof response !== 'string' || response.length === 0 || kws.length === 0) {
+    return { matched: 0, total: kws.length, matchedKeywords: [] };
+  }
+  const respNorm = norm(response);
+  const respStems = new Set(respNorm.split(' ').filter(Boolean).map(stem));
+  const matchedKeywords = [];
+  for (const kw of kws) {
+    if (keywordHits(kw, respNorm, respStems)) matchedKeywords.push(kw);
+  }
+  return { matched: matchedKeywords.length, total: kws.length, matchedKeywords };
+}
+
+// ── R3.2: LLM-judge ─────────────────────────────────────────────────────────
+
+/**
+ * buildJudgePrompt — arma el prompt del juez (mistral-nemo:12b). Le pide evaluar
+ * si la respuesta cumple el criterio SUSTANTIVO de la pregunta (no si repite las
+ * palabras exactas), apoyándose en los keywords esperados como guía de fondo, y
+ * devolver un veredicto parseable.
+ *
+ * @param {{query:string, response:string, expectedKeywords:string[]}} args
+ * @returns {string}
+ */
+export function buildJudgePrompt({ query, response, expectedKeywords = [] }) {
+  const guia = (expectedKeywords || []).join(', ');
+  return [
+    'Eres un evaluador experto en agroecología colombiana. Evalúa si la RESPUESTA',
+    'responde de forma sustantivamente CORRECTA a la PREGUNTA. Importa el FONDO',
+    '(los conceptos correctos), NO que use las palabras exactas: cuenta como',
+    'acierto si dice lo mismo con sinónimos o lemas distintos.',
+    '',
+    `PREGUNTA: ${query}`,
+    '',
+    `CONCEPTOS esperados (guía de fondo, no exige literalidad): ${guia}`,
+    '',
+    `RESPUESTA DEL MODELO: ${response}`,
+    '',
+    'Devuelve SOLO un JSON en una línea con esta forma:',
+    '{"cumple": true|false, "score": 0.0-1.0}',
+    'donde "cumple" indica si la respuesta es sustantivamente correcta y "score"',
+    'la cobertura de los conceptos de fondo. Si no puedes, escribe VEREDICTO: CUMPLE',
+    'o VEREDICTO: NO_CUMPLE.',
+  ].join('\n');
+}
+
+/**
+ * parseJudgeVerdict — interpreta la salida del juez. Acepta JSON
+ * {"cumple":bool,"score":num} o texto "VEREDICTO: CUMPLE|NO_CUMPLE". Devuelve
+ * null si es ilegible (el caller hace fallback). NO inventa veredictos.
+ *
+ * @param {string} raw
+ * @returns {{cumple:boolean, score:number}|null}
+ */
+export function parseJudgeVerdict(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+
+  // 1) JSON embebido.
+  const jsonMatch = raw.match(/\{[^{}]*"cumple"[^{}]*\}/i);
+  if (jsonMatch) {
+    try {
+      const obj = JSON.parse(jsonMatch[0]);
+      if (typeof obj.cumple === 'boolean') {
+        let score = Number(obj.score);
+        if (!Number.isFinite(score) || score < 0 || score > 1) score = obj.cumple ? 1 : 0;
+        return { cumple: obj.cumple, score };
+      }
+    } catch (_) {
+      /* sigue a texto plano */
+    }
+  }
+
+  // 2) Texto plano "VEREDICTO: CUMPLE / NO_CUMPLE".
+  const up = raw.toUpperCase();
+  if (/VEREDICTO\s*:?\s*NO[_\s]?CUMPLE/.test(up)) return { cumple: false, score: 0 };
+  if (/VEREDICTO\s*:?\s*CUMPLE/.test(up)) return { cumple: true, score: 1 };
+
+  return null;
+}
+
+/**
+ * scoreWithJudge — evalúa una respuesta con el LLM-judge, con fallback a
+ * keyword-flexible. El caller de ollama se inyecta (`opts.ollamaCall`) para que
+ * el bench pase el suyo real (mistral-nemo:12b) y el test pase un fake.
+ *
+ * @param {{query:string, response:string, expectedKeywords:string[]}} item
+ * @param {{ ollamaCall: (prompt:string)=>Promise<string> }} opts
+ * @returns {Promise<{cumple:boolean, score:number, source:'judge'|'keywords'}>}
+ */
+export async function scoreWithJudge(item, { ollamaCall } = {}) {
+  const kwFlex = scoreKeywordsFlexible(item.response, item.expectedKeywords);
+  const kwScore = kwFlex.total > 0 ? kwFlex.matched / kwFlex.total : 0;
+  const fallback = { cumple: kwScore >= 0.5, score: kwScore, source: 'keywords' };
+
+  if (typeof ollamaCall !== 'function') return fallback;
+
+  try {
+    const prompt = buildJudgePrompt(item);
+    const raw = await ollamaCall(prompt);
+    const verdict = parseJudgeVerdict(raw);
+    if (!verdict) return fallback;
+    return { cumple: verdict.cumple, score: verdict.score, source: 'judge' };
+  } catch (_) {
+    return fallback;
+  }
+}

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -19,6 +19,7 @@ import {
   guardSpeciesSubstitution,
   guardVisionWithoutPhoto,
   applyOutputGuards,
+  filterNoiseEntities,
   getOutputGuardTelemetry,
   resetOutputGuardTelemetry,
 } from '../outputGuards.js';
@@ -249,6 +250,122 @@ describe('guardInvertedViability', () => {
     const out = guardInvertedViability('Algo es recomendable.', [sinDatos], 2100);
     expect(out.modified).toBe(false);
   });
+
+  // ── R1: detección DIRECTA por banda de altitud (sin frase-gatillo) ──────────
+  // El re-bench post-guards (2026-05-31) mostró que el guard dependía de frases
+  // como "es viable / recomendable / prospera". Cuando el modelo recomendaba
+  // sembrar con OTRO fraseo, se escapaba aunque la altitud estuviera en el
+  // grounding. Estos casos reales (CPX-010 curuba, CPX-001 chugua) deben
+  // corregirse por comparación DETERMINÍSTICA altitud-finca vs banda de la
+  // especie, no por el texto.
+  describe('R1 — detección directa altitud vs banda (sin frase-gatillo)', () => {
+    it('CPX-010 (escapado): curuba inviable, texto la siembra sin "es viable"', () => {
+      // El re-bench: el modelo no usó ninguna frase de la lista recomiendaViable;
+      // simplemente la presentó como cultivo a sembrar. Con viabilidad:inviable
+      // del grounding + mención de siembra, debe corregir igual.
+      const curuba = {
+        kind: 'species',
+        mentioned: 'curuba',
+        nombre_comun: 'curuba',
+        viabilidad: 'inviable',
+        altitud_min: 1800,
+        altitud_max: 3000,
+        alternativas_viables: ['chontaduro'],
+      };
+      const llmFail =
+        'Para tu finca en el llano te conviene sembrar la curuba; plántala al inicio ' +
+        'de las lluvias y dale buen riego.';
+      const out = guardInvertedViability(llmFail, [curuba], 450);
+      expect(out.modified).toBe(true);
+      expect(out.reason).toMatch(/viabilidad_invertida/);
+      expect(out.text).toMatch(/NO es viable/i);
+      expect(out.text).toMatch(/chontaduro/);
+    });
+
+    it('CPX-001 (escapado): chugua a 3200m fuera de banda, texto la recomienda sembrar', () => {
+      // La altitud (3200) estaba en el grounding y supera altitud_max por mucho.
+      // Sin campo viabilidad, el guard debe deducir 'inviable' por la banda y
+      // corregir cuando el texto la siembra, aunque no diga "es viable".
+      const chugua = {
+        kind: 'species',
+        mentioned: 'chugua',
+        nombre_comun: 'chugua',
+        altitud_min: 2000,
+        altitud_max: 2800,
+        alternativas_viables: ['papa', 'haba'],
+      };
+      const llmFail =
+        'En tu parcela puedes cultivar la chugua; prepara el suelo con materia orgánica ' +
+        'y siémbrala en surcos.';
+      const out = guardInvertedViability(llmFail, [chugua], 3200);
+      expect(out.modified).toBe(true);
+      expect(out.text).toMatch(/NO es viable/i);
+      expect(out.text).toMatch(/papa|haba/);
+    });
+
+    it('dispara con "buena para sembrar acá" (fraseo coloquial fuera de la lista)', () => {
+      const maracuya = { ...maracuyaInviable };
+      const llmFail = 'La maracuyá es buena para sembrar acá, ponla cerca de tu casa.';
+      const out = guardInvertedViability(llmFail, [maracuya], 2100);
+      expect(out.modified).toBe(true);
+      expect(out.text).toMatch(/gulupa/);
+    });
+
+    it('RESPETA marginal: dentro del margen de 300m NO bloquea aunque la siembre', () => {
+      // 1500 está a 200m por encima de altitud_max 1300 → marginal (zona gris).
+      const marginalPorBanda = {
+        kind: 'species',
+        mentioned: 'maracuyá',
+        nombre_comun: 'maracuyá',
+        altitud_min: 0,
+        altitud_max: 1300,
+        alternativas_viables: ['gulupa'],
+      };
+      const txt = 'Puedes sembrar la maracuyá con cuidados extra en tu finca.';
+      const out = guardInvertedViability(txt, [marginalPorBanda], 1500);
+      expect(out.modified).toBe(false);
+    });
+
+    it('RESPETA viable: dentro de la banda NO bloquea', () => {
+      const viablePorBanda = {
+        kind: 'species',
+        mentioned: 'maracuyá',
+        nombre_comun: 'maracuyá',
+        altitud_min: 0,
+        altitud_max: 1300,
+      };
+      const txt = 'Siembra la maracuyá, te va a dar buena cosecha.';
+      const out = guardInvertedViability(txt, [viablePorBanda], 800);
+      expect(out.modified).toBe(false);
+    });
+
+    it('NO dispara por banda si el texto NO la recomienda (solo la menciona)', () => {
+      const curuba = {
+        kind: 'species',
+        mentioned: 'curuba',
+        nombre_comun: 'curuba',
+        viabilidad: 'inviable',
+        alternativas_viables: ['chontaduro'],
+      };
+      const txt = 'La curuba es una fruta andina de clima frío. No es para tu zona cálida.';
+      const out = guardInvertedViability(txt, [curuba], 450);
+      expect(out.modified).toBe(false);
+    });
+
+    it('NO dispara si el modelo YA advirtió la inviabilidad (no duplica)', () => {
+      const curuba = {
+        kind: 'species',
+        mentioned: 'curuba',
+        nombre_comun: 'curuba',
+        viabilidad: 'inviable',
+        alternativas_viables: ['chontaduro'],
+      };
+      const ok =
+        'No siembres curuba en el llano: no es viable a esa altura. Mejor el chontaduro.';
+      const out = guardInvertedViability(ok, [curuba], 450);
+      expect(out.modified).toBe(false);
+    });
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -396,6 +513,86 @@ describe('guardSpeciesSubstitution', () => {
   it('maneja entrada vacía / no-string', () => {
     expect(guardSpeciesSubstitution('', luloResolved).modified).toBe(false);
     expect(guardSpeciesSubstitution(null, luloResolved).text).toBe('');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// R2 — filtro de entidades-ruido (stopwords NLU)
+// El re-bench post-guards (2026-05-31): el resolver de entidades devolvía
+// palabras campesinas comunes como si fueran especies ("aquí"→Pteridium,
+// "don"→Oenocarpus, "mano", "pasto"). Esas entidades-ruido disparaban los
+// guards sobre RUIDO (3/5 falsos positivos). filterNoiseEntities las descarta
+// ANTES de applyOutputGuards.
+// ──────────────────────────────────────────────────────────────────────────
+describe('filterNoiseEntities', () => {
+  it('descarta "aquí" aunque haya resuelto a una especie (Pteridium)', () => {
+    const entities = [
+      { mentioned: 'aquí', kind: 'species', nombre_comun: 'helecho marranero', nombre_cientifico: 'Pteridium aquilinum' },
+      { mentioned: 'lulo', kind: 'species', nombre_comun: 'Lulo', nombre_cientifico: 'Solanum quitoense' },
+    ];
+    const out = filterNoiseEntities(entities);
+    expect(out).toHaveLength(1);
+    expect(out[0].mentioned).toBe('lulo');
+  });
+
+  it('descarta "don" (Oenocarpus), "doña", "sumercé"', () => {
+    const entities = [
+      { mentioned: 'don', kind: 'species', nombre_comun: 'milpesos', nombre_cientifico: 'Oenocarpus bataua' },
+      { mentioned: 'doña', kind: 'species', nombre_comun: 'algo' },
+      { mentioned: 'sumercé', kind: 'species', nombre_comun: 'algo' },
+    ];
+    expect(filterNoiseEntities(entities)).toHaveLength(0);
+  });
+
+  it('descarta "mano", "vea", "aquí", "allá", "ahí"', () => {
+    const ruido = ['mano', 'vea', 'aquí', 'allá', 'ahí'].map((m) => ({ mentioned: m, kind: 'species' }));
+    expect(filterNoiseEntities(ruido)).toHaveLength(0);
+  });
+
+  it('descarta "pasto" SOLO (genérico) pero NO un pasto con nombre real', () => {
+    const entities = [
+      { mentioned: 'pasto', kind: 'species', nombre_comun: 'pasto' },
+      { mentioned: 'pasto guinea', kind: 'species', nombre_comun: 'pasto guinea', nombre_cientifico: 'Megathyrsus maximus' },
+    ];
+    const out = filterNoiseEntities(entities);
+    expect(out.map((e) => e.mentioned)).toEqual(['pasto guinea']);
+  });
+
+  it('ignora diacríticos y mayúsculas ("Aquí", "AQUÍ", "aqui")', () => {
+    const entities = ['Aquí', 'AQUÍ', 'aqui'].map((m) => ({ mentioned: m, kind: 'species' }));
+    expect(filterNoiseEntities(entities)).toHaveLength(0);
+  });
+
+  it('NO toca especies legítimas (lulo, maíz, café)', () => {
+    const entities = [
+      { mentioned: 'lulo', kind: 'species' },
+      { mentioned: 'maíz', kind: 'species' },
+      { mentioned: 'café', kind: 'species' },
+    ];
+    expect(filterNoiseEntities(entities)).toHaveLength(3);
+  });
+
+  it('maneja entrada no-array sin romper', () => {
+    expect(filterNoiseEntities(null)).toEqual([]);
+    expect(filterNoiseEntities(undefined)).toEqual([]);
+    expect(filterNoiseEntities('x')).toEqual([]);
+  });
+
+  it('en la cadena: "aquí"→Pteridium NO dispara guard de invasora', () => {
+    // Pteridium (helecho marranero) ES invasora; sin el filtro, "aquí" la
+    // arrastraría y el guard advertiría sobre RUIDO. Con el filtro, no dispara.
+    const resolved = [
+      {
+        mentioned: 'aquí',
+        kind: 'species',
+        nombre_comun: 'helecho marranero',
+        es_invasora: true,
+        alternativas_viables: ['aliso'],
+      },
+    ];
+    const txt = 'Aquí puedes sembrar tus cultivos sin problema, es buena tierra.';
+    const out = applyOutputGuards(txt, { resolvedEntities: resolved });
+    expect(out.modified).toBe(false);
   });
 });
 

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -127,6 +127,46 @@ function _entityName(e) {
   return (e && (e.nombre_comun || e.mentioned)) || 'esa especie';
 }
 
+// ── R2: filtro de entidades-ruido (stopwords NLU) ───────────────────────────
+
+/**
+ * Palabras campesinas/coloquiales comunes que el resolver de entidades a veces
+ * mapea por error a una especie (re-bench 2026-05-31: "aquí"→Pteridium,
+ * "don"→Oenocarpus, "mano", "pasto"). NO son cultivos; si se cuelan en
+ * resolvedEntities, los guards razonan sobre RUIDO y producen falsos positivos.
+ * Se comparan sin diacríticos ni mayúsculas contra el `mentioned` (lo que el
+ * usuario dijo), nunca contra el nombre del catálogo.
+ */
+const NLU_NOISE_MENTIONS = new Set([
+  // deícticos / lugar
+  'aqui', 'aca', 'alla', 'alli', 'ahi', 'ahy',
+  // tratamientos / muletillas campesinas
+  'don', 'dona', 'sumerce', 'su merced', 'vea', 'mano', 'mijo', 'mija', 'mka',
+  'pues', 'bueno', 'oiga', 'oye', 'hombre', 'senor', 'senora',
+  // genéricos vegetales sin especie concreta (solos)
+  'pasto', 'monte', 'hierba', 'yerba', 'mata', 'planta', 'arbol', 'palo',
+]);
+
+/**
+ * filterNoiseEntities — descarta entidades-ruido ANTES de que lleguen a los
+ * guards. Una entidad se considera ruido si su `mentioned` (normalizado) está
+ * en `NLU_NOISE_MENTIONS`. El cotejo es sobre lo que dijo el usuario, no sobre
+ * el nombre del catálogo: "pasto guinea" (mentioned) NO es ruido, "pasto" solo
+ * SÍ. Best-effort: entrada no-array → []. Idempotente y puro.
+ *
+ * @param {Array<object>|null} entities
+ * @returns {Array<object>}
+ */
+export function filterNoiseEntities(entities) {
+  if (!Array.isArray(entities)) return [];
+  return entities.filter((e) => {
+    if (!e || typeof e !== 'object') return false;
+    const mentioned = _stripDiacritics(e.mentioned || '').replace(/\s+/g, ' ').trim();
+    if (!mentioned) return true; // sin mentioned no podemos juzgarlo ruido → conservamos
+    return !NLU_NOISE_MENTIONS.has(mentioned);
+  });
+}
+
 // ── GUARD 1: agroquímico sintético ──────────────────────────────────────────
 
 /**
@@ -395,6 +435,43 @@ function _presentaComoViable(textNorm, nombreNorm) {
 }
 
 /**
+ * R1 — detector DIRECTO de "fomento de siembra", independiente de frases de
+ * viabilidad. El re-bench (2026-05-31) mostró que el detector anterior
+ * (`_presentaComoViable`) se apoyaba en un léxico de viabilidad ("es viable",
+ * "prospera", "recomendable") y se le escapaban respuestas que igual mandaban a
+ * sembrar con otro fraseo (curuba CPX-010, chugua CPX-001). Acá basta con que
+ * el texto INVITE a sembrar/cultivar la especie y NO advierta inviabilidad.
+ *
+ * Esto se usa SOLO cuando el grounding (campo viabilidad o banda de altitud) ya
+ * dictaminó 'inviable' de forma determinística — el texto solo decide si el
+ * modelo la está fomentando, no la viabilidad en sí.
+ */
+function _fomentaSiembra(textNorm, nombreNorm) {
+  // Si el modelo ya advirtió inviabilidad, acertó: no re-disparamos.
+  const yaDiceInviable =
+    /(no\s+es\s+viable|inviable|no\s+(te\s+)?sirve|no\s+prosper|no\s+se\s+da\b|no\s+cuaja|no\s+(la?\s+)?siembres|no\s+es\s+recomendable\s+sembr|no\s+es\s+(adecuad|apropiad)|no\s+es\s+para\s+(tu|esa|esta)|clima\s+(no|demasiado)|altura\s+(no|demasiad)|demasiad[oa]\s+(alt|baj|fri|calient|calid))/.test(
+      textNorm,
+    );
+  if (yaDiceInviable) return false;
+
+  // Verbos / fraseo de fomento de siembra (laxo, coloquial incluido).
+  const fomento =
+    /(siembr|siembr[ae]l|sembrarl|plant[ae]l|plant[ae]\b|plantarl|cultiv|cultivarl|propag|conviene\s+sembr|puedes?\s+(sembr|cultiv|plantar|meter)|buena?\s+para\s+sembr|adecuad[oa]\s+para\s+(tu|esa|esta|el|la|las|los|zona|clima)|apt[oa]\s+para|sirve\s+para\s+tu|priorizar|recomiendo\s+sembr|deberias?\s+sembr|ideal\s+para\s+tu)/.test(
+      textNorm,
+    );
+  if (!fomento) return false;
+
+  // Debe referirse a ESTA especie (nombre o su primer token en el texto).
+  if (nombreNorm && nombreNorm.length >= 3) {
+    const first = nombreNorm.split(/\s+/)[0];
+    if (!textNorm.includes(nombreNorm) && (first.length < 3 || !textNorm.includes(first))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Guard 3 — viabilidad invertida. Si el grounding marca `viabilidad:"inviable"`
  * para una especie a la altitud de la finca y la respuesta la recomienda como
  * viable/buena, CORRIGE ("a tu altura no se da") y lidera con
@@ -442,7 +519,11 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
 
     const nombre = _entityName(e);
     const nombreNorm = _stripDiacritics(nombre);
-    if (!_presentaComoViable(norm, nombreNorm)) continue;
+    // R1: dispara si el modelo la presenta como viable (léxico de viabilidad) O
+    // si simplemente la fomenta como cultivo a sembrar (detección directa, sin
+    // depender de frases-gatillo). El veredicto 'inviable' ya es determinístico
+    // (campo o banda de altitud); el texto solo decide si la está promoviendo.
+    if (!_presentaComoViable(norm, nombreNorm) && !_fomentaSiembra(norm, nombreNorm)) continue;
 
     disparadas.push(nombre);
     const alternativas = _altNames(e.alternativas_viables, 3);
@@ -950,6 +1031,9 @@ export function applyOutputGuards(
   if (typeof responseText !== 'string' || responseText.length === 0) {
     return { text: responseText ?? '', modified: false, reasons: [] };
   }
+  // R2: descarta entidades-ruido NLU ("aquí", "don", "pasto") ANTES de los
+  // guards para no razonar sobre palabras campesinas mal resueltas a especie.
+  const entities = filterNoiseEntities(resolvedEntities);
   let text = responseText;
   let modified = false;
   const reasons = [];
@@ -966,7 +1050,7 @@ export function applyOutputGuards(
   }
 
   for (const guard of GUARD_CHAIN) {
-    const res = guard(text, resolvedEntities, fincaAltitud);
+    const res = guard(text, entities, fincaAltitud);
     if (res && res.modified) {
       text = res.text;
       modified = true;


### PR DESCRIPTION
Lo que pidió el re-bench: R1 guardInvertedViability ahora dispara con fomento-de-siembra coloquial (no solo léxico viabilidad) → caza curuba(CPX-010) y chugua@3200(CPX-001) que se escapaban, respetando marginal. R2 filterNoiseEntities (stopwords aquí/don/pasto) quita falsos positivos del re-bench. R3 bench-scorer.mjs: keyword-flexible (tildes/lemas/sinónimos) + LLM-judge opcional (mistral-nemo, --judge) → el 0/10 dejará de engañar. 86/86 tests.

OJO MERGE: toca outputGuards.js como #1233/#1234 — rebasar al mergear (de a uno).

🤖 Generated with [Claude Code](https://claude.com/claude-code)