### PR TITLE
feat(safety): guard binomio de compañías/antagonistas — Nogal andino=Juglans no Quercus

### DIFF
--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -17,6 +17,7 @@ import {
   guardInvertedViability,
   guardDoseWithoutSource,
   guardSpeciesSubstitution,
+  guardCompanionBinomial,
   guardVisionWithoutPhoto,
   applyOutputGuards,
   filterNoiseEntities,
@@ -513,6 +514,132 @@ describe('guardSpeciesSubstitution', () => {
   it('maneja entrada vacía / no-string', () => {
     expect(guardSpeciesSubstitution('', luloResolved).modified).toBe(false);
     expect(guardSpeciesSubstitution(null, luloResolved).text).toBe('');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// GUARD 5b — binomio de compañía/antagonista sustituido
+// Caso prod (2026-05-31): hablando de antagonistas de la papa, el agente escribió
+// "Nogal andino (Quercus molinae)". El grounding de la papa trae el antagonist
+// Nogal andino = Juglans neotropica (CORRECTO). El modelo sustituyó el binomio de
+// un ANTAGONISTA (no del cultivo principal), por eso guardSpeciesSubstitution
+// — que solo valida el cultivo preguntado — no lo cubre. guardCompanionBinomial
+// valida los binomios de companions/antagonists/alternativas contra SU PROPIO
+// grounding autoritativo.
+// ──────────────────────────────────────────────────────────────────────────
+describe('guardCompanionBinomial', () => {
+  const papaResolved = [
+    {
+      mentioned: 'papa',
+      kind: 'species',
+      nombre_comun: 'Papa',
+      nombre_cientifico: 'Solanum tuberosum L.',
+      canonical_id: 'solanum_tuberosum',
+      confidence: 0.96,
+      antagonists: [
+        {
+          canonical_id: 'juglans_neotropica',
+          nombre_comun: 'Nogal andino',
+          nombre_cientifico: 'Juglans neotropica Diels',
+        },
+      ],
+      companions: [
+        {
+          canonical_id: 'tagetes_erecta',
+          nombre_comun: 'Caléndula',
+          nombre_cientifico: 'Tagetes erecta L.',
+        },
+      ],
+    },
+  ];
+
+  it('CASO REAL: corrige "Nogal andino (Quercus molinae)" → Juglans neotropica', () => {
+    const llmFail =
+      'Entre los antagonistas de la papa está el Nogal andino (Quercus molinae), que produce ' +
+      'juglona y inhibe el cultivo. Manténlo lejos de tus surcos.';
+    const out = guardCompanionBinomial(llmFail, papaResolved);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/binomio_compa[ñn]/i);
+    // la corrección debe nombrar el binomio correcto y el errado.
+    expect(out.text).toMatch(/Juglans neotropica/);
+    expect(out.text).toMatch(/Quercus molinae/i);
+    expect(out.text).toMatch(/Nogal andino/i);
+  });
+
+  it('NO dispara si el binomio del antagonista SÍ coincide con su grounding', () => {
+    const ok =
+      'Entre los antagonistas de la papa está el Nogal andino (Juglans neotropica), que ' +
+      'produce juglona. Manténlo lejos.';
+    const out = guardCompanionBinomial(ok, papaResolved);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('tolera autoría/variedad en el binomio mencionado (compara solo Género epíteto)', () => {
+    const ok =
+      'El Nogal andino (Juglans neotropica Diels) es antagonista de la papa por la juglona.';
+    const out = guardCompanionBinomial(ok, papaResolved);
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO dispara si el binomio errado no está CERCA del nombre del companion/antagonista', () => {
+    // El binomio foráneo aparece, pero a más de 160 chars del "Nogal andino":
+    // están en bloques temáticos distintos, no es una atribución del binomio al
+    // nombre común. El guard es conservador con la ventana de cercanía.
+    const txt =
+      'El Nogal andino es un árbol valioso que conviene mantener lejos de la papa por su efecto ' +
+      'alelopático sobre el tubérculo, ya que reduce el rendimiento de las matas cercanas con el ' +
+      'paso de las temporadas de cultivo. ' +
+      'En una sección totalmente aparte del documento, hablando de otros robles del sur del país, ' +
+      'se menciona que el Quercus molinae crece en bosques de niebla a gran altitud.';
+    const out = guardCompanionBinomial(txt, papaResolved);
+    expect(out.modified).toBe(false);
+  });
+
+  it('corrige un companion (no solo antagonist) con binomio errado', () => {
+    const llmFail =
+      'Como compañía planta Caléndula (Calendula officinalis) junto a la papa para repeler plagas.';
+    const out = guardCompanionBinomial(llmFail, papaResolved);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/Tagetes erecta/);
+  });
+
+  it('NO dispara sin resolvedEntities', () => {
+    const txt = 'El Nogal andino (Quercus molinae) es antagonista de la papa.';
+    expect(guardCompanionBinomial(txt, null).modified).toBe(false);
+    expect(guardCompanionBinomial(txt, []).modified).toBe(false);
+  });
+
+  it('NO dispara si la entidad no trae companions/antagonists con binomio', () => {
+    const sinSubarrays = [
+      {
+        mentioned: 'papa',
+        kind: 'species',
+        nombre_comun: 'Papa',
+        nombre_cientifico: 'Solanum tuberosum L.',
+      },
+    ];
+    const txt = 'El Nogal andino (Quercus molinae) es antagonista de la papa.';
+    expect(guardCompanionBinomial(txt, sinSubarrays).modified).toBe(false);
+  });
+
+  it('idempotente: no re-corrige si la corrección ya está aplicada', () => {
+    const llmFail = 'El Nogal andino (Quercus molinae) es antagonista de la papa.';
+    const once = guardCompanionBinomial(llmFail, papaResolved);
+    const twice = guardCompanionBinomial(once.text, papaResolved);
+    expect(twice.modified).toBe(false);
+  });
+
+  it('telemetría: cuenta el gatillo', () => {
+    const llmFail = 'El Nogal andino (Quercus molinae) antagoniza a la papa.';
+    guardCompanionBinomial(llmFail, papaResolved);
+    const t = getOutputGuardTelemetry();
+    expect(t.companion_binomial).toBe(1);
+  });
+
+  it('maneja entrada vacía / no-string', () => {
+    expect(guardCompanionBinomial('', papaResolved).modified).toBe(false);
+    expect(guardCompanionBinomial(null, papaResolved).text).toBe('');
   });
 });
 

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -806,6 +806,189 @@ export function guardSpeciesSubstitution(responseText, resolvedEntities = null, 
   return { text, modified: true, reason: `sustitución_especie: ${disparadas.join('; ')}` };
 }
 
+// ── GUARD 5b: binomio de compañía/antagonista sustituido ────────────────────
+
+/**
+ * Sub-arrays de una entidad que listan OTRAS especies relacionadas, cada una con
+ * su propio `nombre_comun` + `nombre_cientifico` autoritativo del grounding.
+ * Estas son las que el guard de compañía valida (companions, antagonists,
+ * alternativas, controladores de plaga).
+ */
+const COMPANION_SUBARRAY_KEYS = [
+  'companions',
+  'antagonists',
+  'alternativas_viables',
+  'alternativas',
+  'pest_controllers',
+];
+
+/**
+ * Construye el mapa `nombreComún(normalizado) → Set<binomio canónico>` a partir
+ * de los sub-arrays de compañía/antagonista de TODAS las entidades resueltas.
+ * Cada compañía aporta su binomio autoritativo (puede haber varias compañías
+ * distintas con el mismo nombre común entre cultivos: se acumulan en el Set).
+ * Solo se incluyen entradas con nombre común usable (≥3 chars en su 1er token) y
+ * binomio parseable.
+ *
+ * @param {Array<object>} entities
+ * @returns {Map<string, {display:string, sci:string, bins:Set<string>}>}
+ */
+function _companionBinomialMap(entities) {
+  /** @type {Map<string, {display:string, sci:string, bins:Set<string>}>} */
+  const map = new Map();
+  for (const e of entities) {
+    if (!e || typeof e !== 'object') continue;
+    for (const key of COMPANION_SUBARRAY_KEYS) {
+      const arr = e[key];
+      if (!Array.isArray(arr)) continue;
+      for (const c of arr) {
+        if (!c || typeof c !== 'object') continue;
+        const nombre = (c.nombre_comun || c.nombre || c.name || '').toString();
+        const sci = (c.nombre_cientifico || c.nombre_científico || '').toString();
+        const bin = _binomial(sci);
+        if (!nombre || !bin) continue;
+        const nombreNorm = _stripDiacritics(nombre.split('/')[0]).replace(/\s+/g, ' ').trim();
+        if (!nombreNorm) continue;
+        const firstWord = nombreNorm.split(/\s+/)[0];
+        if (!firstWord || firstWord.length < 3) continue;
+        let entry = map.get(nombreNorm);
+        if (!entry) {
+          entry = { display: nombre.split('/')[0].trim(), sci: sci.trim() || bin, bins: new Set() };
+          map.set(nombreNorm, entry);
+        }
+        entry.bins.add(bin);
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * Guard 5b — binomio de compañía/antagonista sustituido (TRUTH del catálogo
+ * sobre las especies RELACIONADAS, no el cultivo principal).
+ *
+ * Caso prod (2026-05-31): hablando de antagonistas de la papa, el agente escribió
+ * "Nogal andino (Quercus molinae)". El grounding de la papa trae el antagonist
+ * Nogal andino = Juglans neotropica (CORRECTO). El modelo sustituyó el binomio de
+ * un ANTAGONISTA, no del cultivo principal — por eso `guardSpeciesSubstitution`
+ * (que solo valida el cultivo preguntado) no lo cubre.
+ *
+ * Doctrina: cada companion/antagonist/alternativa del grounding trae su binomio
+ * autoritativo. Si el texto menciona el nombre común de una de esas especies Y le
+ * atribuye un binomio que NO coincide con ninguno de los binomios que el grounding
+ * tiene para ese nombre, se ANEXA una corrección honesta ("el Nogal andino es
+ * Juglans neotropica, no Quercus molinae").
+ *
+ * Anti-falsos-positivos:
+ *  - Solo dispara si el nombre común aparece en el texto CERCA (≤160 chars) de un
+ *    binomio que contradice TODO su grounding (si coincide con cualquiera de sus
+ *    binomios autoritativos, no toca).
+ *  - Tolera autoría/variedad (compara solo "Género epíteto" vía `_binomial`).
+ *  - Ignora binomios "Género preposición" (stopword como epíteto).
+ *  - Idempotente: no re-corrige si la corrección ya está aplicada.
+ *
+ * @param {string} responseText
+ * @param {Array<object>|null} resolvedEntities
+ * @param {number|string|null} _fincaAltitud  (no usado)
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardCompanionBinomial(responseText, resolvedEntities = null, _fincaAltitud = null) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const compMap = _companionBinomialMap(resolvedEntities);
+  if (compMap.size === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const norm = _stripDiacritics(responseText);
+
+  // Conjunto de nombres comunes conocidos (normalizados): un nombre común
+  // capitalizado ("Nogal andino", "Aliso andino") matchea SCI_BINOMIAL_RE pero
+  // NO es un binomio científico — hay que excluirlo de los candidatos para no
+  // tomarlo como "binomio foráneo" de sí mismo.
+  const knownCommonNames = new Set(compMap.keys());
+
+  // Índices de TODOS los binomios candidatos del texto (crudo→canónico), con su
+  // posición sobre el texto normalizado para medir cercanía al nombre común.
+  /** @type {Array<{bin:string, idx:number}>} */
+  const textBinomials = [];
+  let m;
+  SCI_BINOMIAL_RE.lastIndex = 0;
+  while ((m = SCI_BINOMIAL_RE.exec(responseText)) !== null) {
+    if (EPITHET_STOPWORDS.has(_stripDiacritics(m[2]))) continue;
+    const bin = _binomial(`${m[1]} ${m[2]}`);
+    if (!bin) continue;
+    // Si el "binomio" es en realidad un nombre común conocido (capitalizado), no
+    // es un binomio científico → no es candidato a sustitución.
+    if (knownCommonNames.has(bin)) continue;
+    // posición sobre el texto normalizado (mismo offset porque _stripDiacritics
+    // preserva longitud salvo diacríticos NFD; usamos indexOf como aproximación).
+    const idxNorm = norm.indexOf(bin);
+    textBinomials.push({ bin, idx: idxNorm >= 0 ? idxNorm : m.index });
+  }
+  if (textBinomials.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const correcciones = [];
+  const disparadas = [];
+
+  for (const [nombreNorm, entry] of compMap) {
+    const firstWord = nombreNorm.split(/\s+/)[0];
+    const idxNombre = norm.indexOf(nombreNorm) >= 0 ? norm.indexOf(nombreNorm) : norm.indexOf(firstWord);
+    if (idxNombre < 0) continue; // el nombre común no se menciona en el texto.
+
+    // Si ALGÚN binomio autoritativo de este nombre ya está en el texto cerca, el
+    // companion está bien atribuido → no disparamos por él.
+    const algunoCorrecto = textBinomials.some(
+      (tb) => entry.bins.has(tb.bin) && Math.abs(tb.idx - idxNombre) <= 160,
+    );
+    if (algunoCorrecto) continue;
+
+    // ¿Hay un binomio CERCA del nombre que NO esté en su grounding? Ese es el
+    // culpable (sustitución). Tomamos el más cercano dentro de la ventana.
+    let culprit = null;
+    let bestDist = Infinity;
+    for (const tb of textBinomials) {
+      if (entry.bins.has(tb.bin)) continue; // ese binomio es legítimo (otra especie).
+      const dist = Math.abs(tb.idx - idxNombre);
+      if (dist <= 160 && dist < bestDist) {
+        bestDist = dist;
+        culprit = tb.bin;
+      }
+    }
+    if (!culprit) continue;
+
+    const correctoBin = [...entry.bins][0];
+    // Idempotencia: si ya pusimos la corrección de este companion, no repetir.
+    const yaCorregido = new RegExp(
+      `${firstWord}[^.]*${correctoBin.replace(/ /g, '\\s+')}[^.]*no\\s+${culprit.replace(/ /g, '\\s+')}`,
+      'i',
+    ).test(norm);
+    if (yaCorregido) continue;
+
+    const culpritDisplay = culprit.charAt(0).toUpperCase() + culprit.slice(1);
+    disparadas.push(`${entry.display}: ${culprit}→${correctoBin}`);
+    correcciones.push(
+      `Corrección importante: según el catálogo, el ${entry.display.toLowerCase()} es ${entry.sci}, ` +
+        `no ${culpritDisplay}. Ese binomio corresponde a otra planta distinta.`,
+    );
+  }
+
+  if (correcciones.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('companion_binomial');
+  const text = `${correcciones.join('\n\n')}\n\n${responseText.trim()}`;
+  return { text, modified: true, reason: `binomio_compañía: ${disparadas.join('; ')}` };
+}
+
 // ── GUARD 6: diagnóstico visual fabricado SIN foto real ─────────────────────
 
 /**
@@ -988,6 +1171,11 @@ const GUARD_CHAIN = [
   // que la corrección lidere y los demás guards no razonen sobre la especie
   // equivocada. Solo añade una corrección al frente; no altera el resto.
   guardSpeciesSubstitution,
+  // Tras corregir el cultivo principal, validar también los binomios de las
+  // especies RELACIONADAS (companions/antagonists/alternativas) contra su propio
+  // grounding. Caso prod: "Nogal andino (Quercus molinae)" siendo el antagonist
+  // Nogal andino = Juglans neotropica. Solo añade correcciones al frente.
+  guardCompanionBinomial,
   // El de dosis va antes que el agroquímico en detección: el guard agroquímico
   // anexa un bloque que menciona "etiqueta" (cita de fuente), lo que apagaría
   // la suavización de dosis si corriera después. Correr dosis primero evita ese


### PR DESCRIPTION
Último bug del test 'a cómo está la papa': el agente escribió 'Nogal andino (Quercus molinae)' pero el grounding lo trae como Juglans neotropica (antagonista correcto). guardSpeciesSubstitution solo validaba el cultivo principal; guardCompanionBinomial extiende la validación a companions/antagonists/alternativas/pest_controllers: si el texto le atribuye a una especie relacionada un binomio que NO está en su grounding → corrige. Anti-falsos-positivos (autoría/variedad, ventana cercanía, idempotente). 81 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)