### PR TITLE
fix(guards): cerrar dos fugas anti-alucinación vivas en producción

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.21",
+  "version": "1.0.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v279';
+const CACHE_NAME = 'chagra-v280';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -26,6 +26,7 @@ import {
   getFullHistory,
   getContextString,
   computeSourceMetadata,
+  mergePostValidateMetadata,
   extractEdges,
   clearMemory,
   shouldStartNewSession,
@@ -1506,14 +1507,18 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // Capa 2 anti-alucinación — cross-check de contexto (operador 2026-05-30).
       // Tras generar la respuesta, le pedimos al sidecar que correlacione cada
       // binomio Linneano CITADO en el texto con las entidades que la capa 1 ya
-      // resolvió para el turno. Si el LLM citó un nombre científico que SÍ
-      // existe en el catálogo pero NO corresponde a lo que el usuario preguntó
-      // (ej. "Solanum lycopersicum" para 'tomate de árbol' = Solanum betaceum),
-      // lo marcamos como SOSPECHOSO. NO bloquea ni reescribe la respuesta —
-      // solo añade un flag de metadata para un badge no intrusivo ("verifica el
-      // nombre científico"). Solo corre si hubo entidades resueltas (sin ellas
-      // no hay con qué correlacionar). 100% graceful: postValidate devuelve null
-      // ante flag off / offline / timeout / AGE caído → sin advertencia.
+      // resolvió para el turno. El post-validate devuelve DOS señales:
+      //   - `suspect[]`      → nombre científico que SÍ existe en el catálogo
+      //     pero NO corresponde a lo preguntado (ej. "Solanum lycopersicum" para
+      //     'tomate de árbol' = Solanum betaceum).
+      //   - `hallucinated[]` → binomio 100% INVENTADO por el modelo, que NO
+      //     existe en AGE ni en la realidad (ej. "Neolepidopteron daquila").
+      // FIX 2 (2026-05-31): antes solo consumíamos `suspect` → el binomio
+      // inventado se detectaba y se tiraba en silencio. Ahora `mergePostValidate
+      // Metadata` surfacea AMBOS como flags de metadata para que el ChatBubble
+      // muestre el badge correspondiente. NO bloquea ni reescribe la respuesta.
+      // Solo corre si hubo entidades resueltas. 100% graceful: postValidate
+      // devuelve null ante flag off / offline / timeout / AGE caído → sin badge.
       if (isOnline && isSidecarEnabled() && Array.isArray(resolvedEntities) && resolvedEntities.length > 0) {
         try {
           const expected = resolvedEntities
@@ -1521,9 +1526,12 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
             .filter((n) => typeof n === 'string' && n.trim().length > 0);
           if (expected.length > 0) {
             const pv = await postValidate(response, expected);
-            if (pv && pv.age_available && Array.isArray(pv.suspect) && pv.suspect.length > 0) {
-              sourceMetadata = { ...sourceMetadata, suspect_names: pv.suspect };
-              console.debug('[sidecar] post-validate suspect', { suspect: pv.suspect });
+            sourceMetadata = mergePostValidateMetadata(sourceMetadata, pv);
+            if (sourceMetadata.hallucinated_names || sourceMetadata.suspect_names) {
+              console.debug('[sidecar] post-validate flags', {
+                hallucinated: sourceMetadata.hallucinated_names,
+                suspect: sourceMetadata.suspect_names,
+              });
             }
           }
         } catch (pvErr) {

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -53,6 +53,27 @@ function SourceBadge({ metadata }) {
   // Badge no intrusivo, convive con el badge de fuente: avisa sin bloquear.
   const suspectNames = Array.isArray(md.suspect_names) ? md.suspect_names : [];
   const hasSuspect = suspectNames.length > 0;
+  // FIX 2 (2026-05-31): nombres científicos INVENTADOS — el post-validate los
+  // detectó como binomios que NO existen en el catálogo/AGE (ni en la realidad,
+  // ej. "Neolepidopteron daquila"). Antes el PWA solo consumía `suspect` y el
+  // inventado se tiraba en silencio. Es la señal MÁS fuerte (riesgo mayor que un
+  // nombre real mal atribuido), así que tiene prioridad sobre el resto.
+  const hallucinatedNames = Array.isArray(md.hallucinated_names) ? md.hallucinated_names : [];
+  const hasHallucinated = hallucinatedNames.length > 0;
+
+  if (hasHallucinated) {
+    return (
+      <span
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-red-700/25 text-red-200 border border-red-700"
+        data-testid="hallucinated-name-badge"
+        data-source="hallucinated-scientific-name"
+        title={`La respuesta menciona un nombre científico que NO está verificado en el catálogo y podría estar inventado por el modelo: ${hallucinatedNames.join(', ')}. No lo uses sin confirmarlo.`}
+      >
+        <AlertTriangle size={12} aria-hidden="true" />
+        <span>Nombre científico sin verificar</span>
+      </span>
+    );
+  }
 
   if (hasSuspect) {
     return (

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -124,6 +124,67 @@ describe('ChatBubble — badge de fuente (verificado vs generativo)', () => {
     expect(screen.getByTestId('source-badge')).toBeInTheDocument();
   });
 
+  // FIX 2 (2026-05-31): el post-validate devuelve `hallucinated[]` con binomios
+  // 100% INVENTADOS (no existen en AGE ni en la realidad, ej. "Neolepidopteron
+  // daquila"). Antes el PWA solo consumía `suspect` → el nombre inventado se
+  // detectaba y se TIRABA en silencio. Ahora se surfacéa: badge warning +
+  // tooltip con los nombres no verificados.
+  test('FIX 2 — renderiza badge de nombre científico INVENTADO cuando metadata.hallucinated_names tiene datos', () => {
+    const message = {
+      role: 'assistant',
+      content: 'Para esa plaga, el Neolepidopteron daquila es el principal controlador.',
+      timestamp: Date.now(),
+      metadata: {
+        tool_used: 'get_pest_controllers',
+        grounded: true,
+        hallucinated_names: ['Neolepidopteron daquila'],
+      },
+    };
+    render(<ChatBubble message={message} />);
+    const badge = screen.getByTestId('hallucinated-name-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-source', 'hallucinated-scientific-name');
+    // Señal clara de "nombre no verificado / inventado".
+    expect(badge).toHaveTextContent(/nombre científico/i);
+    // El binomio inventado va en el tooltip (no satura la burbuja).
+    expect(badge).toHaveAttribute('title', expect.stringContaining('Neolepidopteron daquila'));
+    // Español colombiano, sin voseo argentino.
+    expect(badge.textContent).not.toMatch(/verificá/i);
+    // Cero hype.
+    expect(badge.textContent).not.toMatch(/garantizado|perfecto|100%/i);
+  });
+
+  test('FIX 2 — el badge de inventado tiene prioridad sobre suspect y sobre la fuente (es la señal más fuerte)', () => {
+    const message = {
+      role: 'assistant',
+      content: 'El Neolepidopteron daquila controla la plaga.',
+      timestamp: Date.now(),
+      metadata: {
+        tool_used: 'get_species',
+        grounded: true,
+        suspect_names: ['Solanum lycopersicum'],
+        hallucinated_names: ['Neolepidopteron daquila'],
+      },
+    };
+    render(<ChatBubble message={message} />);
+    // Cuando hay un nombre inventado, ese badge gana (riesgo mayor que suspect).
+    expect(screen.getByTestId('hallucinated-name-badge')).toBeInTheDocument();
+    expect(screen.queryByTestId('suspect-name-badge')).not.toBeInTheDocument();
+  });
+
+  test('FIX 2 — el badge de inventado NO aparece cuando hallucinated_names está vacío o ausente', () => {
+    const message = {
+      role: 'assistant',
+      content: 'El aguacate Hass tiene buenas compañeras.',
+      timestamp: Date.now(),
+      metadata: { tool_used: 'get_companions', grounded: true, hallucinated_names: [] },
+    };
+    render(<ChatBubble message={message} />);
+    expect(screen.queryByTestId('hallucinated-name-badge')).not.toBeInTheDocument();
+    // El badge de fuente normal SÍ sigue apareciendo.
+    expect(screen.getByTestId('source-badge')).toBeInTheDocument();
+  });
+
   // #339: la burbuja del assistant NUNCA debe quedar en blanco. Si el LLM
   // devuelve contenido vacío (respuesta degradada, stream sin tokens), se
   // muestra un fallback visible en español colombiano en lugar de un <p>

--- a/src/services/__tests__/conversationMemory.sourceMetadata.test.js
+++ b/src/services/__tests__/conversationMemory.sourceMetadata.test.js
@@ -10,7 +10,7 @@
  * El ChatBubble renderiza el badge a partir de este metadata.
  */
 import { describe, test, expect } from 'vitest';
-import { computeSourceMetadata } from '../conversationMemory';
+import { computeSourceMetadata, mergePostValidateMetadata } from '../conversationMemory';
 
 describe('computeSourceMetadata', () => {
   test('null / undefined toolEvidence → no tool, no grounded', () => {
@@ -215,5 +215,87 @@ describe('computeSourceMetadata', () => {
       ]);
       expect(md.grounded).toBe(true);
     });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// FIX 2 (2026-05-31): mergePostValidateMetadata — surfacea suspect[] Y
+// hallucinated[] del post-validate. El bug vivo: el PWA solo leía suspect, así
+// que un binomio 100% inventado por el modelo se detectaba y se tiraba en
+// silencio. Ahora ambos quedan en metadata para que el ChatBubble los muestre.
+// ──────────────────────────────────────────────────────────────────────────
+describe('mergePostValidateMetadata (FIX 2 — surfacea hallucinated)', () => {
+  const base = { tool_used: 'get_pest_controllers', grounded: true };
+
+  test('pv null → devuelve base sin tocar (no advierte si no se pudo verificar)', () => {
+    expect(mergePostValidateMetadata(base, null)).toEqual(base);
+    expect(mergePostValidateMetadata(base, undefined)).toEqual(base);
+  });
+
+  test('age_available !== true → no confía en el veredicto, devuelve base intacto', () => {
+    const pv = { hallucinated: ['Neolepidopteron daquila'], suspect: [], age_available: false };
+    expect(mergePostValidateMetadata(base, pv)).toEqual(base);
+  });
+
+  test('FUGA CERRADA: hallucinated[] con un binomio inventado → hallucinated_names en metadata', () => {
+    const pv = {
+      hallucinated: ['Neolepidopteron daquila'],
+      suspect: [],
+      validated: [],
+      age_available: true,
+      detected_count: 1,
+    };
+    const md = mergePostValidateMetadata(base, pv);
+    expect(md.hallucinated_names).toEqual(['Neolepidopteron daquila']);
+    // No pierde el metadata de fuente original.
+    expect(md.tool_used).toBe('get_pest_controllers');
+    expect(md.grounded).toBe(true);
+  });
+
+  test('suspect[] sigue surfaceándose (no regresión del badge previo)', () => {
+    const pv = { hallucinated: [], suspect: ['Solanum lycopersicum'], age_available: true };
+    const md = mergePostValidateMetadata(base, pv);
+    expect(md.suspect_names).toEqual(['Solanum lycopersicum']);
+    expect(md.hallucinated_names).toBeUndefined();
+  });
+
+  test('hallucinated Y suspect a la vez → ambos campos presentes', () => {
+    const pv = {
+      hallucinated: ['Neolepidopteron daquila'],
+      suspect: ['Solanum lycopersicum'],
+      age_available: true,
+    };
+    const md = mergePostValidateMetadata(base, pv);
+    expect(md.hallucinated_names).toEqual(['Neolepidopteron daquila']);
+    expect(md.suspect_names).toEqual(['Solanum lycopersicum']);
+  });
+
+  test('arrays vacíos → no añade campos (sin badge espurio)', () => {
+    const pv = { hallucinated: [], suspect: [], age_available: true };
+    const md = mergePostValidateMetadata(base, pv);
+    expect(md.hallucinated_names).toBeUndefined();
+    expect(md.suspect_names).toBeUndefined();
+    expect(md).toEqual(base);
+  });
+
+  test('filtra entradas no-string / vacías del reporte del sidecar', () => {
+    const pv = {
+      hallucinated: ['Neolepidopteron daquila', '', '   ', null, 42],
+      suspect: [],
+      age_available: true,
+    };
+    const md = mergePostValidateMetadata(base, pv);
+    expect(md.hallucinated_names).toEqual(['Neolepidopteron daquila']);
+  });
+
+  test('no muta el objeto base recibido (puro)', () => {
+    const original = { tool_used: 'get_species', grounded: true };
+    const snapshot = { ...original };
+    mergePostValidateMetadata(original, {
+      hallucinated: ['X inventado'],
+      suspect: [],
+      age_available: true,
+    });
+    expect(original).toEqual(snapshot);
   });
 });

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -175,8 +175,51 @@ describe('guardInvertedViability', () => {
     // ANTES: priorizaba maracuyá. DESPUÉS: corrige + lidera con gulupa.
     expect(out.text).toMatch(/NO es viable/i);
     expect(out.text).toMatch(/gulupa/);
-    // La corrección debe ir ANTES del texto original (liderar).
-    expect(out.text.indexOf('Corrección')).toBeLessThan(out.text.indexOf('es recomendable priorizar'));
+    // La corrección debe LIDERAR.
+    expect(out.text.indexOf('Corrección')).toBe(0);
+    // FUGA ANTI-ALUCINACIÓN (2026-05-31): la frase contradictoria del modelo
+    // NO debe sobrevivir debajo de la corrección. El guard REEMPLAZA el párrafo
+    // contradictorio — no deja "NO es viable" arriba y "es recomendable
+    // priorizar la maracuyá" abajo en la MISMA burbuja (autocontradicción
+    // visible al usuario). El veredicto del modelo invertido se borra.
+    expect(out.text).not.toMatch(/es recomendable priorizar la maracuy/i);
+  });
+
+  it('FUGA: la respuesta final NO contiene a la vez "NO es viable" y un fomento de siembra de la MISMA especie (sin autocontradicción)', () => {
+    // Reproduce la fuga viva: el modelo manda a sembrar la inviable en una
+    // oración y el guard, al solo prepender, dejaba ambas afirmaciones
+    // opuestas en la misma burbuja. La salida corregida debe ser COHERENTE.
+    const llmFail =
+      'En tu finca de Sibundoy a 2100 metros, es recomendable priorizar la maracuyá ' +
+      'porque pagan bien. Puedes sembrarla cerca de la casa para tenerla a mano.';
+    const out = guardInvertedViability(llmFail, [maracuyaInviable], 2100);
+    expect(out.modified).toBe(true);
+    // Veredicto correcto presente.
+    expect(out.text).toMatch(/NO es viable/i);
+    // Ninguna frase de fomento de la maracuyá sobrevive.
+    expect(out.text).not.toMatch(/es recomendable priorizar la maracuy/i);
+    expect(out.text).not.toMatch(/puedes sembrarla/i);
+    // Coherencia: el texto final no debe presentar la maracuyá como sembrable.
+    // (la única mención de "maracuyá" sembrable que sobrevive es la negada).
+    const normalized = out.text.toLowerCase();
+    expect(normalized).not.toMatch(/recomendable priorizar|puedes sembrarla|conviene sembrar/);
+  });
+
+  it('FUGA: preserva oraciones legítimas alrededor del párrafo contradictorio', () => {
+    // El reemplazo debe ser quirúrgico: solo borra lo que afirma viabilidad de
+    // la inviable, conservando contexto útil no contradictorio.
+    const llmFail =
+      'El maracuyá es una passiflora trepadora de fruto ácido. ' +
+      'A 2100 metros es recomendable priorizar la maracuyá porque pagan bien. ' +
+      'En general las passifloras necesitan tutorado.';
+    const out = guardInvertedViability(llmFail, [maracuyaInviable], 2100);
+    expect(out.modified).toBe(true);
+    // La oración contradictoria desaparece.
+    expect(out.text).not.toMatch(/es recomendable priorizar la maracuy/i);
+    // El contexto botánico legítimo se conserva.
+    expect(out.text).toMatch(/passiflora trepadora|necesitan tutorado/i);
+    // Y el veredicto correcto lidera.
+    expect(out.text.indexOf('Corrección')).toBe(0);
   });
 
   it('CPX-009 (bench): corrige "puede prosperar sin problemas" / "se cultiva ampliamente" en Chocó', () => {
@@ -187,6 +230,9 @@ describe('guardInvertedViability', () => {
     expect(out.modified).toBe(true);
     expect(out.text).toMatch(/NO es viable/i);
     expect(out.text).toMatch(/chontaduro|plátano/);
+    // El reemplazo borra la frase contradictoria del modelo.
+    expect(out.text).not.toMatch(/se cultiva ampliamente/i);
+    expect(out.text).not.toMatch(/puede prosperar sin problemas/i);
   });
 
   it('CPX-004 (bench): corrige cocona "podría tener éxito" a 2500m (deja puerta abierta a inviable)', () => {
@@ -201,6 +247,8 @@ describe('guardInvertedViability', () => {
     const out = guardInvertedViability(llmFail, [cocona], 2500);
     expect(out.modified).toBe(true);
     expect(out.text).toMatch(/NO es viable/i);
+    // El fraseo invertido del modelo se reemplaza, no se prepende debajo.
+    expect(out.text).not.toMatch(/podría tener éxito/i);
   });
 
   it('CPX-010 (bench): corrige curuba "adecuada para zonas tropicales como las del llano"', () => {
@@ -215,6 +263,8 @@ describe('guardInvertedViability', () => {
     const out = guardInvertedViability(llmFail, [curuba], 450);
     expect(out.modified).toBe(true);
     expect(out.text).toMatch(/chontaduro/);
+    // La afirmación falsa del modelo ("adecuada para zonas tropicales") se borra.
+    expect(out.text).not.toMatch(/adecuada para zonas tropicales/i);
   });
 
   it('NO toca "marginal" (zona gris — posible con cuidados)', () => {
@@ -281,6 +331,8 @@ describe('guardInvertedViability', () => {
       expect(out.reason).toMatch(/viabilidad_invertida/);
       expect(out.text).toMatch(/NO es viable/i);
       expect(out.text).toMatch(/chontaduro/);
+      // El consejo invertido ("te conviene sembrar la curuba") se reemplaza.
+      expect(out.text).not.toMatch(/te conviene sembrar la curuba/i);
     });
 
     it('CPX-001 (escapado): chugua a 3200m fuera de banda, texto la recomienda sembrar', () => {
@@ -302,6 +354,8 @@ describe('guardInvertedViability', () => {
       expect(out.modified).toBe(true);
       expect(out.text).toMatch(/NO es viable/i);
       expect(out.text).toMatch(/papa|haba/);
+      // La invitación a cultivar la especie inviable se reemplaza.
+      expect(out.text).not.toMatch(/puedes cultivar la chugua/i);
     });
 
     it('dispara con "buena para sembrar acá" (fraseo coloquial fuera de la lista)', () => {
@@ -310,6 +364,8 @@ describe('guardInvertedViability', () => {
       const out = guardInvertedViability(llmFail, [maracuya], 2100);
       expect(out.modified).toBe(true);
       expect(out.text).toMatch(/gulupa/);
+      // El fraseo coloquial invertido se reemplaza, no queda debajo.
+      expect(out.text).not.toMatch(/es buena para sembrar acá/i);
     });
 
     it('RESPETA marginal: dentro del margen de 300m NO bloquea aunque la siembre', () => {

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -319,6 +319,46 @@ export function computeSourceMetadata(toolEvidence) {
 }
 
 /**
+ * FIX 2 (2026-05-31) — fusiona el reporte del post-validate (capa 2
+ * anti-alucinación del sidecar) sobre el metadata de fuente del turno, para que
+ * el ChatBubble pueda renderizar los badges de advertencia.
+ *
+ * El sidecar devuelve:
+ *   - `pv.suspect[]`      — binomios que SÍ existen en el catálogo pero NO
+ *     corresponden a la entidad preguntada (nombre real, especie equivocada).
+ *   - `pv.hallucinated[]` — binomios 100% INVENTADOS por el modelo, que NO
+ *     existen en AGE ni en la realidad (ej. "Neolepidopteron daquila").
+ *
+ * ANTES (bug vivo): el PWA solo leía `suspect` → el binomio inventado se
+ * detectaba en el sidecar y se TIRABA en silencio, sin avisar al usuario.
+ * AHORA: ambos se surfacéan como metadata (`suspect_names` / `hallucinated_names`).
+ *
+ * Conservador y puro: si `pv` es null/incompleto, devuelve el `base` sin tocar
+ * (política "no advertir si no se pudo verificar"). Solo añade campos cuando los
+ * arrays traen datos. No muta `base`. Requiere `pv.age_available === true` para
+ * confiar en el veredicto (sin AGE no hay con qué validar binomios).
+ *
+ * @param {object} base — metadata de fuente ya computado (computeSourceMetadata).
+ * @param {null | {hallucinated?: string[], suspect?: string[], age_available?: boolean}} pv
+ * @returns {object} nuevo metadata (copia de base + flags de advertencia).
+ */
+export function mergePostValidateMetadata(base, pv) {
+  const out = { ...(base && typeof base === 'object' ? base : {}) };
+  if (!pv || typeof pv !== 'object' || pv.age_available !== true) return out;
+
+  const suspect = Array.isArray(pv.suspect)
+    ? pv.suspect.filter((s) => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  const hallucinated = Array.isArray(pv.hallucinated)
+    ? pv.hallucinated.filter((s) => typeof s === 'string' && s.trim().length > 0)
+    : [];
+
+  if (suspect.length > 0) out.suspect_names = suspect;
+  if (hallucinated.length > 0) out.hallucinated_names = hallucinated;
+  return out;
+}
+
+/**
  * A-15 (#248) — extrae los edges del grafo AGE que un turno del agente usó
  * como evidencia, en el shape que el motor E3 (`feedback-to-confidence.mjs`
  * del sidecar) necesita para mapear la señal 👍👎 a aristas reales:
@@ -426,6 +466,7 @@ export default {
   getFullHistory,
   clearMemory,
   computeSourceMetadata,
+  mergePostValidateMetadata,
   extractEdges,
   getLastTurnTimestamp,
   shouldStartNewSession,

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -472,11 +472,110 @@ function _fomentaSiembra(textNorm, nombreNorm) {
 }
 
 /**
+ * Divide un texto en oraciones preservando su puntuación final. Heurística
+ * suficiente para español campesino: corta tras `.`, `!`, `?` o salto de línea.
+ * Conserva los delimitadores en cada fragmento.
+ *
+ * @param {string} text
+ * @returns {string[]} oraciones (cada una con su puntuación/espacio final).
+ */
+function _splitSentences(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  // Captura cada oración hasta su signo de cierre (o el fin del texto), con
+  // el espacio/salto que la sigue. El flag `s` no hace falta: `[^.!?\n]`.
+  const matches = text.match(/[^.!?\n]+[.!?\n]*\s*/g);
+  return matches || [text];
+}
+
+/**
+ * REEMPLAZO anti-autocontradicción (fuga viva 2026-05-31). Dado el texto
+ * original del modelo y los nombres (normalizados) de las especies que el
+ * grounding marcó INVIABLE pero el modelo promovió, ELIMINA del texto las
+ * oraciones que presentan esa especie como viable o la fomentan como cultivo.
+ *
+ * Es quirúrgico por oración: solo borra las que (a) mencionan la especie (o su
+ * primer token) Y (b) disparan `_presentaComoViable` o `_fomentaSiembra` para
+ * esa especie. Las oraciones de contexto legítimo (botánica, manejo, frases que
+ * NO la promueven) se conservan. Así la corrección determinística puede liderar
+ * SIN dejar debajo la afirmación opuesta del modelo.
+ *
+ * @param {string} originalText
+ * @param {string[]} nombresNorm — nombres de especies inviables, sin diacríticos.
+ * @returns {string} texto con las oraciones contradictorias removidas (trim).
+ */
+// Fomento ANAFÓRICO: oraciones que mandan a sembrar/plantar/cultivar la
+// especie usando un pronombre objeto ("siémbrala", "plántala", "cultívala",
+// "sembrarla", "ponla") en lugar del nombre. Tras detectar una inviable
+// promovida, estas oraciones de seguimiento también contradicen el veredicto
+// aunque no repitan el nombre. Patrón conservador: verbo de siembra + pronombre
+// femenino/neutro de objeto (-la/-las/-lo/-los) o "ponla/meterla".
+const _ANAPHORIC_PLANTING_RE =
+  /(siembr|sembrar|plant|plantar|cultiv|cultivar|propag|propagar|metel|meterl|pon)[aeiou]*(l[ao]s?)\b/;
+
+/**
+ * REEMPLAZO anti-autocontradicción (fuga viva 2026-05-31). Dado el texto
+ * original del modelo y los nombres (normalizados) de las especies que el
+ * grounding marcó INVIABLE pero el modelo promovió, ELIMINA del texto las
+ * oraciones que presentan esa especie como viable o la fomentan como cultivo.
+ *
+ * Es quirúrgico por oración: borra (a) las que mencionan la especie (o su
+ * primer token) Y disparan promoción para esa especie, y (b) las de fomento
+ * ANAFÓRICO (siémbrala/plántala) que dan seguimiento a la inviable ya nombrada
+ * antes en el texto. Las oraciones de contexto legítimo (botánica, manejo,
+ * frases que NO la promueven) se conservan, para que la corrección
+ * determinística lidere SIN dejar debajo la afirmación opuesta del modelo.
+ *
+ * @param {string} originalText
+ * @param {string[]} nombresNorm — nombres de especies inviables, sin diacríticos.
+ * @returns {string} texto con las oraciones contradictorias removidas (trim).
+ */
+function _stripViabilityPromotion(originalText, nombresNorm) {
+  if (!Array.isArray(nombresNorm) || nombresNorm.length === 0) {
+    return originalText.trim();
+  }
+  const sentences = _splitSentences(originalText);
+  // Una vez que el texto nombró y promovió una inviable, las oraciones de
+  // fomento anafórico que siguen ("siémbrala…") se atribuyen a esa especie.
+  let inviableEnContexto = false;
+  const kept = sentences.filter((sentence) => {
+    const sNorm = _stripDiacritics(sentence);
+    // ¿Alguna especie inviable está promovida EN esta oración (por nombre)?
+    for (const nombreNorm of nombresNorm) {
+      if (!nombreNorm) continue;
+      const first = nombreNorm.split(/\s+/)[0];
+      const mencionada =
+        sNorm.includes(nombreNorm) || (first.length >= 3 && sNorm.includes(first));
+      if (mencionada) {
+        inviableEnContexto = true;
+        if (_presentaComoViable(sNorm, nombreNorm) || _fomentaSiembra(sNorm, nombreNorm)) {
+          return false; // oración contradictoria por nombre → fuera
+        }
+      }
+    }
+    // Fomento anafórico de seguimiento: solo si ya hubo una inviable en el
+    // contexto previo y la oración NO advierte inviabilidad.
+    if (inviableEnContexto && _ANAPHORIC_PLANTING_RE.test(sNorm)) {
+      const advierte =
+        /(no\s+es\s+viable|inviable|no\s+(la?\s+)?siembres|no\s+(te\s+)?sirve|no\s+prosper)/.test(sNorm);
+      if (!advierte) return false;
+    }
+    return true;
+  });
+  return kept.join('').trim();
+}
+
+/**
  * Guard 3 — viabilidad invertida. Si el grounding marca `viabilidad:"inviable"`
  * para una especie a la altitud de la finca y la respuesta la recomienda como
  * viable/buena, CORRIGE ("a tu altura no se da") y lidera con
  * `alternativas_viables`. NO toca "marginal" (eso SÍ es posible con cuidados:
  * doctrina zona-gris).
+ *
+ * REEMPLAZO, no prepend (fix fuga viva 2026-05-31): la corrección lidera Y se
+ * ELIMINAN del texto del modelo las oraciones que promovían la especie
+ * inviable, para no dejar una respuesta autocontradictoria ("NO es viable" +
+ * "sí, siémbrala") en la misma burbuja. El resto del texto (contexto legítimo)
+ * se conserva intacto.
  *
  * @returns {{text:string, modified:boolean, reason:string|null}}
  */
@@ -494,6 +593,7 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
 
   const correcciones = [];
   const disparadas = [];
+  const disparadasNorm = [];
 
   for (const e of resolvedEntities) {
     if (!_isSpecies(e)) continue;
@@ -526,6 +626,7 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
     if (!_presentaComoViable(norm, nombreNorm) && !_fomentaSiembra(norm, nombreNorm)) continue;
 
     disparadas.push(nombre);
+    disparadasNorm.push(nombreNorm);
     const alternativas = _altNames(e.alternativas_viables, 3);
     const altTxt = alternativas.length
       ? ` Para tu altura te irían mejor estas del catálogo: ${alternativas.join(', ')}.`
@@ -542,8 +643,14 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
   }
 
   bumpGuardTelemetry('inverted_viability');
-  // La corrección va PRIMERO (lidera) para no enterrar el veredicto correcto.
-  const text = `${correcciones.join('\n\n')}\n\n${responseText.trim()}`;
+  // REEMPLAZO (no prepend): primero borramos del texto del modelo las oraciones
+  // que promovían la especie inviable — así no queda una respuesta
+  // autocontradictoria ("NO es viable" + "siémbrala") debajo de la corrección.
+  const restoLimpio = _stripViabilityPromotion(responseText, disparadasNorm);
+  // La corrección determinística LIDERA. El resto (contexto legítimo) va después
+  // solo si sobrevivió algo tras quitar las oraciones contradictorias.
+  const correccion = correcciones.join('\n\n');
+  const text = restoLimpio ? `${correccion}\n\n${restoLimpio}` : correccion;
   return { text, modified: true, reason: `viabilidad_invertida: ${disparadas.join(', ')}` };
 }
 


### PR DESCRIPTION
## Contexto

La auditoría integral identificó **2 fugas anti-alucinación vivas en producción**. Este PR cierra ambas, con tests TDD escritos antes del fix.

## FIX 1 — `guardInvertedViability` REEMPLAZA, no prepende

**Antes:** cuando el grounding marcaba una especie como `inviable` a la altitud de la finca pero el modelo la promovía, el guard PREPENDÍA un párrafo de corrección ("NO es viable a esta altura") y dejaba **debajo, intacta, la afirmación opuesta del modelo** ("sí, podés sembrar coco"). Resultado: respuesta autocontradictoria visible en la misma burbuja.

**Ahora:** la corrección determinística lidera Y se eliminan quirúrgicamente, oración por oración, las frases del modelo que promueven la especie inviable:
- por nombre (o su primer token), cuando disparan `_presentaComoViable` / `_fomentaSiembra`;
- por **fomento anafórico** de seguimiento ("siémbrala", "plántala", "cultívala") cuando la inviable ya fue nombrada antes en el texto.

El contexto legítimo no contradictorio (botánica, manejo) se conserva.

`src/services/outputGuards.js`: nuevos helpers `_splitSentences` y `_stripViabilityPromotion`; el ensamblado final pasa de prepend a `corrección + resto_limpio`.

## FIX 2 — `pv.hallucinated[]` → badge UX

**Antes:** el post-validate del sidecar devuelve `pv.hallucinated[]` con binomios 100% inventados por el modelo (no existen en AGE, ej. `Neolepidopteron daquila`), pero el PWA solo consumía `pv.suspect` → el nombre inventado se detectaba y se **descartaba en silencio**.

**Ahora:** nuevo helper puro `mergePostValidateMetadata` (en `conversationMemory.js`) surfacea **`suspect` Y `hallucinated`** como metadata del turno. `ChatBubble` renderiza un badge de advertencia **"Nombre científico sin verificar"** (rojo, ícono warning) con tooltip de los binomios no verificados. El badge de inventado tiene **prioridad** sobre el de sospechoso (riesgo mayor). 100% graceful: sin `age_available` o arrays vacíos no se añade ningún badge.

`AgentScreen.jsx`: el bloque post-validate ahora usa `mergePostValidateMetadata` en lugar de leer solo `pv.suspect`.

## Tests (TDD test-first)

- `outputGuards.test.js`: la viabilidad invertida queda reemplazada **sin contradicción** (asserts `not.toMatch` sobre cada frase de fomento); preserva oraciones legítimas alrededor del párrafo contradictorio.
- `conversationMemory.sourceMetadata.test.js`: `mergePostValidateMetadata` surfacea `hallucinated[]`, conserva `suspect[]`, filtra entradas no-string, es puro (no muta `base`) y graceful (null / `age_available:false` → sin badge).
- `ChatBubble.test.jsx`: badge de nombre inventado + prioridad sobre suspect + ausencia cuando el array está vacío.

**Suite completa:** 2845 passed / 1 skipped / 0 failures. ESLint `--max-warnings=0` limpio. Sin flags de animación nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)