### PR TITLE
fix(guards): endurecer agroquímico por sufijos (#21) + guard de viabilidad térmica (#23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.22",
+  "version": "1.0.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v280';
+const CACHE_NAME = 'chagra-v281';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1483,12 +1483,36 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // false → corrige cualquier afirmación visual inventada.
       const guardProfileName =
         (() => { try { const p = getProfile(); return (p && p.nombre) || null; } catch (_) { return null; } })();
+      // HARDENING térmico (audit #23): mínima/máxima esperadas del pronóstico ya
+      // cacheado (mismo snapshot que buildFrostHeatContext — NO se re-pide).
+      // Habilita guardThermalViability para advertir helada/golpe de calor sobre
+      // un cultivo recomendado. Degrada con gracia: sin snapshot/forecast → null
+      // → el guard es no-op.
+      const { forecastTempMin, forecastTempMax } = (() => {
+        try {
+          const snap = getCachedClimaSnapshot();
+          const om = snap && typeof snap === 'object' ? snap.openmeteo : null;
+          const fc = om && om.available && Array.isArray(om.forecast_7d) ? om.forecast_7d : null;
+          if (!fc || fc.length === 0) return { forecastTempMin: null, forecastTempMax: null };
+          let min = null;
+          let max = null;
+          for (const d of fc) {
+            if (d && typeof d.temp_min_c === 'number' && (min == null || d.temp_min_c < min)) min = d.temp_min_c;
+            if (d && typeof d.temp_max_c === 'number' && (max == null || d.temp_max_c > max)) max = d.temp_max_c;
+          }
+          return { forecastTempMin: min, forecastTempMax: max };
+        } catch (_) {
+          return { forecastTempMin: null, forecastTempMax: null };
+        }
+      })();
       const guarded = applyOutputGuards(voseoSafe, {
         resolvedEntities,
         fincaAltitud: guardAltitud,
         hadVision: !!(visionContext && visionContext.hadVision),
         visionConfidence: (visionContext && visionContext.visionConfidence) ?? null,
         profileName: guardProfileName,
+        forecastTempMin,
+        forecastTempMax,
       });
       if (guarded.modified) {
         console.debug('[guards] salida corregida', { reasons: guarded.reasons });

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -19,6 +19,7 @@ import {
   guardSpeciesSubstitution,
   guardCompanionBinomial,
   guardVisionWithoutPhoto,
+  guardThermalViability,
   applyOutputGuards,
   filterNoiseEntities,
   getOutputGuardTelemetry,
@@ -91,6 +92,96 @@ describe('guardSyntheticAgrochemical', () => {
   it('redirige a manejo de plaga cuando el texto habla de gusanos/cogollero', () => {
     const out = guardSyntheticAgrochemical('Para el gusano cogollero aplica cipermetrina.');
     expect(out.text).toMatch(/Bacillus thuringiensis|Bt/);
+  });
+
+  // ── HARDENING 1 (audit #21): detección por SUFIJOS de familia química ──
+  // La denylist exacta dejaba pasar cualquier agroquímico no enumerado. Ahora
+  // se detectan también por el sufijo de su familia química (word-boundary +
+  // longitud mínima + excepciones para palabras legítimas).
+  describe('detección por sufijos de familia química (no solo denylist exacta)', () => {
+    it('triazoles fuera de la lista (-azol/-conazol): ciproconazol, epoxiconazol, tetraconazol', () => {
+      for (const term of ['ciproconazol', 'epoxiconazol', 'tetraconazol']) {
+        const out = guardSyntheticAgrochemical(`Para el hongo aplica ${term} en dosis foliar.`);
+        expect(out.modified, term).toBe(true);
+        expect(out.reason, term).toMatch(/agroqu/i);
+      }
+    });
+
+    it('organofosforados (-fos/-tion): profenofos, fention, paration', () => {
+      for (const term of ['profenofos', 'fention', 'paration']) {
+        const out = guardSyntheticAgrochemical(`Aplica ${term} contra el gusano del cultivo.`);
+        expect(out.modified, term).toBe(true);
+      }
+    });
+
+    it('piretroides (-trina/-metrina) fuera de la lista: bifentrina, permetrina, teflutrina', () => {
+      for (const term of ['bifentrina', 'permetrina', 'teflutrina']) {
+        const out = guardSyntheticAgrochemical(`Para el insecto aplica ${term}.`);
+        expect(out.modified, term).toBe(true);
+      }
+    });
+
+    it('neonicotinoides (-cloprid): tiacloprid', () => {
+      const out = guardSyntheticAgrochemical('Aplica tiacloprid contra el pulgón.');
+      expect(out.modified).toBe(true);
+    });
+
+    it('organoclorados (-clor/-cloro): metoxicloro, heptacloro', () => {
+      for (const term of ['metoxicloro', 'heptacloro']) {
+        const out = guardSyntheticAgrochemical(`Aplica ${term} como tratamiento.`);
+        expect(out.modified, term).toBe(true);
+      }
+    });
+
+    it('carbamatos (-carb): aldicarb, metiocarb', () => {
+      for (const term of ['aldicarb', 'metiocarb']) {
+        const out = guardSyntheticAgrochemical(`Aplica ${term} como insecticida.`);
+        expect(out.modified, term).toBe(true);
+      }
+    });
+
+    // ── ANTI-FALSOS-POSITIVOS: palabras legítimas que terminan parecido ──
+    it('NO bloquea biopreparados permitidos: sulfocálcico / sulfocalcio', () => {
+      const ok =
+        'Para el ácaro y la roya usa caldo sulfocálcico (azufre + cal), un biopreparado tradicional, ' +
+        'aplicado en luna menguante. El sulfocalcio es seguro y agroecológico.';
+      const out = guardSyntheticAgrochemical(ok);
+      expect(out.modified).toBe(false);
+      expect(out.text).toBe(ok);
+    });
+
+    it('NO bloquea caldo bordelés ni ceniza (caldos minerales tradicionales)', () => {
+      const ok =
+        'Para el tizón aplica caldo bordelés (cal + sulfato de cobre) y espolvorea ceniza de fogón ' +
+        'alrededor de la mata.';
+      const out = guardSyntheticAgrochemical(ok);
+      expect(out.modified).toBe(false);
+    });
+
+    it('NO bloquea palabras comunes que terminan parecido: metro, ajo, diablo', () => {
+      const out = guardSyntheticAgrochemical(
+        'Siembra el ajo a un metro de distancia y cuida el riego; no dejes el suelo como un diablo de seco.',
+      );
+      expect(out.modified).toBe(false);
+    });
+
+    it('NO bloquea "control" / "controlar" (no es -clor con límite de palabra)', () => {
+      const out = guardSyntheticAgrochemical('Haz control biológico y controla la plaga con trampas.');
+      expect(out.modified).toBe(false);
+    });
+
+    it('NO bloquea palabras cortas (< longitud mínima) que casualmente terminen en sufijo', () => {
+      // "fos", "carb", "azol" sueltos / nombres cortos no superan el umbral de longitud.
+      const out = guardSyntheticAgrochemical('El pasto está fos; la señora Trina riega temprano.');
+      expect(out.modified).toBe(false);
+    });
+
+    it('sigue detectando los términos exactos de la denylist original (no regresión)', () => {
+      for (const term of ['mancozeb', 'glifosato', 'imidacloprid', 'clorpirifos']) {
+        const out = guardSyntheticAgrochemical(`Aplica ${term}.`);
+        expect(out.modified, term).toBe(true);
+      }
+    });
   });
 });
 
@@ -861,7 +952,160 @@ describe('guardVisionWithoutPhoto', () => {
   });
 });
 
+// ──────────────────────────────────────────────────────────────────────────
+// HARDENING 2 (audit #23) — viabilidad TÉRMICA (helada / golpe de calor)
+// ──────────────────────────────────────────────────────────────────────────
+describe('guardThermalViability', () => {
+  // Cultivo de clima cálido: muere con frío (temp_min alta). Si el pronóstico
+  // baja por debajo de su temp_min → riesgo de helada.
+  const tomateEntity = {
+    kind: 'species',
+    mentioned: 'tomate',
+    nombre_comun: 'Tomate',
+    nombre_cientifico: 'Solanum lycopersicum',
+    temp_min: 12,
+    temp_max: 30,
+  };
+  // Cultivo de clima frío: se estresa con calor (temp_max baja).
+  const papaEntity = {
+    kind: 'species',
+    mentioned: 'papa',
+    nombre_comun: 'Papa',
+    nombre_cientifico: 'Solanum tuberosum',
+    temp_min: 5,
+    temp_max: 20,
+  };
+
+  it('detecta riesgo de HELADA: el pronóstico baja por debajo de temp_min del cultivo recomendado', () => {
+    const txt = 'El tomate va muy bien en tu finca, siémbralo ahora que está la temporada.';
+    const out = guardThermalViability(txt, [tomateEntity], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 18,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/helada|frio|t[eé]rmic/i);
+    expect(out.text).toMatch(/helada|frío|protec/i);
+  });
+
+  it('detecta riesgo de GOLPE DE CALOR: el pronóstico sube por encima de temp_max del cultivo', () => {
+    const txt = 'La papa es buena opción, plántala en este lote.';
+    const out = guardThermalViability(txt, [papaEntity], null, {
+      forecastTempMin: 10,
+      forecastTempMax: 28,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/calor|t[eé]rmic/i);
+    expect(out.text).toMatch(/calor|sombra|protec/i);
+  });
+
+  it('tono HUMILDE / zona gris: ADVIERTE, no bloquea ni borra el texto del modelo', () => {
+    const txt = 'El tomate va muy bien, siémbralo ahora.';
+    const out = guardThermalViability(txt, [tomateEntity], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 18,
+    });
+    // El texto original se conserva; solo se ANEXA la advertencia.
+    expect(out.text).toContain('El tomate va muy bien');
+    expect(out.text).toMatch(/ojo|riesgo/i);
+  });
+
+  it('NO dispara si el cultivo NO se está recomendando sembrar (solo se menciona)', () => {
+    const txt = 'El tomate es una solanácea originaria de los Andes; tiene muchas variedades.';
+    const out = guardThermalViability(txt, [tomateEntity], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 18,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO dispara si el pronóstico está dentro del rango térmico del cultivo (margen OK)', () => {
+    const txt = 'Siembra el tomate, va perfecto en tu clima.';
+    const out = guardThermalViability(txt, [tomateEntity], null, {
+      forecastTempMin: 16,
+      forecastTempMax: 26,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO-OP graceful sin temperatura de pronóstico en el contexto', () => {
+    const txt = 'Siembra el tomate, va perfecto.';
+    expect(guardThermalViability(txt, [tomateEntity], null, {}).modified).toBe(false);
+    expect(guardThermalViability(txt, [tomateEntity], null).modified).toBe(false);
+    expect(
+      guardThermalViability(txt, [tomateEntity], null, { forecastTempMin: null, forecastTempMax: null })
+        .modified,
+    ).toBe(false);
+  });
+
+  it('NO-OP sin entidades resueltas', () => {
+    const out = guardThermalViability('Siembra el tomate.', [], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 18,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO-OP si la entidad no trae temp_min/temp_max (grounding incompleto)', () => {
+    const sinTemp = { kind: 'species', mentioned: 'yuca', nombre_comun: 'Yuca' };
+    const out = guardThermalViability('Siembra la yuca, va muy bien.', [sinTemp], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 40,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('maneja entrada vacía / no-string', () => {
+    expect(guardThermalViability('', [tomateEntity], null, { forecastTempMin: 4 }).modified).toBe(false);
+    expect(guardThermalViability(null, [tomateEntity], null, { forecastTempMin: 4 }).text).toBe('');
+  });
+
+  it('idempotente: no re-anexa la advertencia si ya está aplicada', () => {
+    const txt = 'El tomate va muy bien, siémbralo ahora.';
+    const once = guardThermalViability(txt, [tomateEntity], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 18,
+    });
+    const twice = guardThermalViability(once.text, [tomateEntity], null, {
+      forecastTempMin: 4,
+      forecastTempMax: 18,
+    });
+    expect(twice.modified).toBe(false);
+  });
+});
+
 describe('applyOutputGuards (cadena)', () => {
+  it('cablea forecastTempMin/Max: advierte helada para cultivo recomendado vía applyOutputGuards', () => {
+    const resolved = [
+      {
+        kind: 'species',
+        mentioned: 'tomate',
+        nombre_comun: 'Tomate',
+        nombre_cientifico: 'Solanum lycopersicum',
+        temp_min: 12,
+        temp_max: 30,
+      },
+    ];
+    const llmFail = 'El tomate va muy bien en tu finca, siémbralo ahora.';
+    const out = applyOutputGuards(llmFail, {
+      resolvedEntities: resolved,
+      forecastTempMin: 3,
+      forecastTempMax: 17,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reasons.some((r) => /helada|t[eé]rmic|calor/i.test(r))).toBe(true);
+    expect(out.text).toMatch(/helada|protec/i);
+  });
+
+  it('cadena: sin forecastTemp el guard térmico es no-op (no rompe la cadena)', () => {
+    const resolved = [
+      { kind: 'species', mentioned: 'tomate', nombre_comun: 'Tomate', temp_min: 12, temp_max: 30 },
+    ];
+    const ok = 'El tomate es una buena opción para tu clima templado.';
+    const out = applyOutputGuards(ok, { resolvedEntities: resolved });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
   it('encadena varios guards en un mismo texto (agroquímico + dosis)', () => {
     const llmFail = 'Para el tizón aplica Mancozeb 30 ml/L cada semana.';
     const out = applyOutputGuards(llmFail, {});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -215,6 +215,99 @@ const SYNTHETIC_AGROCHEM_TERMS = [
 ];
 
 /**
+ * HARDENING 1 (audit #21) — SUFIJOS de familias químicas sintéticas. La denylist
+ * exacta de arriba es CERRADA: cualquier ingrediente activo no enumerado se
+ * colaba. Estos sufijos capturan FAMILIAS enteras por la terminación del nombre
+ * común del i.a. (convención de nomenclatura química), no por una lista cerrada:
+ *
+ *   -azol / -conazol  → triazoles fungicidas (ciproconazol, epoxiconazol…)
+ *   -fos              → organofosforados (profenofos, clorpirifos…)
+ *   -tion             → organofosforados -tión (paratión, malatión, fentión…)
+ *   -trina / -metrina → piretroides (cipermetrina, bifentrina, deltametrina…)
+ *   -cloprid          → neonicotinoides (imidacloprid, tiacloprid…)
+ *   -clor / -cloro    → organoclorados (metoxicloro, heptacloro…)
+ *   -carb             → carbamatos (aldicarb, metiocarb, carbofurano≈carb…)
+ *
+ * Anti-falsos-positivos (3 capas):
+ *  1. word-boundary: la palabra debe TERMINAR en el sufijo (`\b…sufijo\b`),
+ *     no contenerlo (así "control"/"controlar" no matchea -clor).
+ *  2. longitud mínima del token (≥6 chars): descarta colisiones cortas como
+ *     "fos", "carb", "trina" (nombre propio), "azol" sueltos.
+ *  3. lista de EXCEPCIONES (`SUFFIX_EXCEPTIONS`): palabras legítimas que terminan
+ *     igual. Incluye biopreparados PERMITIDOS (sulfocálcico/sulfocalcio) y, sobre
+ *     todo, los sustantivos españoles en -stión (gestión, digestión, combustión)
+ *     que colisionan con -tion. Además, el sufijo -tion exige que el carácter
+ *     previo NO sea 's' (los químicos son -atión/-otión/-ntión; el ruido español
+ *     es -stión), reforzando la capa de excepciones.
+ */
+const SYNTHETIC_AGROCHEM_SUFFIXES = [
+  'conazol', // específico antes que 'azol' (no cambia el match, documental)
+  'azol',
+  'metrina', // específico antes que 'trina'
+  'trina',
+  'cloprid',
+  'cloro',
+  'clor',
+  'fos',
+  'tion',
+  'carb',
+];
+
+/** Longitud mínima del token para que un sufijo cuente (anti-colisión corta). */
+const SUFFIX_MIN_LEN = 6;
+
+/**
+ * Palabras legítimas (sin diacríticos) que terminan en alguno de los sufijos
+ * pero NO son agroquímicos. Biopreparados permitidos + sustantivos españoles
+ * comunes en -stión/-tión que no deben bloquearse.
+ */
+const SUFFIX_EXCEPTIONS = new Set([
+  // biopreparados / caldos minerales PERMITIDOS
+  'sulfocalcico',
+  'sulfocalcio',
+  // sustantivos españoles en -stion (colisionan con -tion)
+  'gestion',
+  'digestion',
+  'indigestion',
+  'autogestion',
+  'combustion',
+  'cuestion',
+  'congestion',
+  'sugestion',
+  'autocombustion',
+]);
+
+/**
+ * Regex que extrae tokens alfabéticos (con guion interno, p.ej. "lambda-
+ * cihalotrina") del texto normalizado, para evaluar su terminación contra los
+ * sufijos de familia química.
+ */
+const WORD_TOKEN_RE = /[a-z]+(?:-[a-z]+)*/g;
+
+/**
+ * ¿El token (normalizado, sin diacríticos) es un agroquímico sintético inferido
+ * por el sufijo de su familia química? Aplica las 3 capas anti-falso-positivo.
+ *
+ * @param {string} token  palabra normalizada (minúsculas, sin tildes).
+ * @returns {string|null} el sufijo que disparó, o null si no aplica.
+ */
+function _agrochemBySuffix(token) {
+  if (!token || token.length < SUFFIX_MIN_LEN) return null;
+  if (SUFFIX_EXCEPTIONS.has(token)) return null;
+  for (const suf of SYNTHETIC_AGROCHEM_SUFFIXES) {
+    if (!token.endsWith(suf)) continue;
+    // El sufijo -tion solo cuenta si NO viene precedido de 's' (los químicos son
+    // -atión/-otión/-ntión; el ruido español es -stión).
+    if (suf === 'tion') {
+      const prev = token.charAt(token.length - suf.length - 1);
+      if (prev === 's') return null;
+    }
+    return suf;
+  }
+  return null;
+}
+
+/**
  * Códigos de catálogo INVENTADOS tipo "M-02", "I-05", "M-03" que el modelo
  * fabricó en CPX-005 para dar apariencia de receta oficial. Patrón: una letra
  * mayúscula (M/I/F/H), guion, 1-3 dígitos, como token suelto. Defensivo: solo
@@ -287,6 +380,18 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
     // límite de palabra a ambos lados sobre el texto normalizado.
     const re = new RegExp(`(^|[^a-z0-9])${t.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([^a-z0-9]|$)`);
     if (re.test(norm)) hits.push(term);
+  }
+
+  // HARDENING 1 (audit #21): además de la denylist exacta, detecta agroquímicos
+  // por el SUFIJO de su familia química (token que TERMINA en -azol/-fos/-tion/
+  // -trina/-cloprid/-clor/-carb), con longitud mínima + excepciones. Captura i.a.
+  // sintéticos que no están enumerados arriba sin bloquear biopreparados ni
+  // palabras comunes (ver `_agrochemBySuffix`).
+  WORD_TOKEN_RE.lastIndex = 0;
+  let tok;
+  while ((tok = WORD_TOKEN_RE.exec(norm)) !== null) {
+    const suf = _agrochemBySuffix(tok[0]);
+    if (suf) hits.push(tok[0]);
   }
 
   // Códigos inventados SOLO cuentan si hay contexto de aplicación/dosis (para
@@ -652,6 +757,125 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
   const correccion = correcciones.join('\n\n');
   const text = restoLimpio ? `${correccion}\n\n${restoLimpio}` : correccion;
   return { text, modified: true, reason: `viabilidad_invertida: ${disparadas.join(', ')}` };
+}
+
+// ── GUARD 3b: viabilidad TÉRMICA (helada / golpe de calor) ──────────────────
+
+/** Margen °C de seguridad para el cruce pronóstico × tolerancia de la especie. */
+const THERMAL_MARGIN_C = 2;
+
+/** Idempotencia: marca textual que deja este guard al anexar su advertencia. */
+const THERMAL_NOTE_MARK = /ojo[^.]*riesgo de (helada|golpe de calor)/i;
+
+/**
+ * Guard 3b — viabilidad TÉRMICA (audit #23). Análogo a `guardInvertedViability`
+ * pero para TEMPERATURA: cruza la tolerancia térmica de la especie
+ * (`temp_min`/`temp_max` que ya vienen en el grounding / resolvedEntities) contra
+ * la temperatura esperada del PRONÓSTICO (forecastTempMin / forecastTempMax,
+ * derivadas de `climaSnapshot.openmeteo.forecast_7d` en la pantalla y pasadas por
+ * ctx — el grounding NO trae la temp del pronóstico, solo la tolerancia de la
+ * especie; ver gap documentado abajo).
+ *
+ * Lógica (solo para especies que el texto FOMENTA sembrar):
+ *   - Si la mínima pronosticada ≤ (temp_min + margen) → riesgo de HELADA/frío que
+ *     puede matar el cultivo.
+ *   - Si la máxima pronosticada ≥ (temp_max - margen) → riesgo de GOLPE DE CALOR.
+ *
+ * Doctrina zona-gris (intelligence-first, tono HUMILDE): ADVIERTE, no bloquea ni
+ * borra. Anexa una nota ("ojo, riesgo de helada, requiere protección") sin tocar
+ * el texto del modelo. La experiencia del campesino manda; esto solo alerta.
+ *
+ * GRACEFUL: si no hay temp del pronóstico (forecastTempMin/Max ausentes o no
+ * numéricas), o la especie no trae temp_min/temp_max, o el texto no fomenta
+ * sembrarla, el guard es NO-OP.
+ *
+ * Firma extendida: recibe un 4º arg `ctx` con la temp del pronóstico, porque la
+ * cadena estándar `(text, entities, altitud)` no la transporta. Se invoca aparte
+ * en `applyOutputGuards` (como los guards de visión/nombre), no dentro de
+ * GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {Array<object>|null} resolvedEntities  cada una puede traer temp_min/temp_max.
+ * @param {number|string|null} _fincaAltitud      (no usado: la temp viene del pronóstico)
+ * @param {object} [ctx]
+ * @param {number|null} [ctx.forecastTempMin]  mínima esperada del pronóstico (°C).
+ * @param {number|null} [ctx.forecastTempMax]  máxima esperada del pronóstico (°C).
+ * @param {number} [ctx.marginC=2]              margen de seguridad °C.
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardThermalViability(
+  responseText,
+  resolvedEntities = null,
+  _fincaAltitud = null,
+  { forecastTempMin = null, forecastTempMax = null, marginC = THERMAL_MARGIN_C } = {},
+) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const fMin = forecastTempMin != null && forecastTempMin !== '' ? Number(forecastTempMin) : NaN;
+  const fMax = forecastTempMax != null && forecastTempMax !== '' ? Number(forecastTempMax) : NaN;
+  const haveMin = Number.isFinite(fMin);
+  const haveMax = Number.isFinite(fMax);
+  // Sin NINGÚN dato de pronóstico → no-op graceful (gap documentado).
+  if (!haveMin && !haveMax) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Idempotencia: si ya anexamos una advertencia térmica, no repetir.
+  if (THERMAL_NOTE_MARK.test(responseText)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  const norm = _stripDiacritics(responseText);
+  const advertencias = [];
+  const disparadas = [];
+
+  for (const e of resolvedEntities) {
+    if (!_isSpecies(e)) continue;
+    const tMin = e.temp_min != null && e.temp_min !== '' ? Number(e.temp_min) : NaN;
+    const tMax = e.temp_max != null && e.temp_max !== '' ? Number(e.temp_max) : NaN;
+    if (!Number.isFinite(tMin) && !Number.isFinite(tMax)) continue; // grounding sin temp.
+
+    const nombre = _entityName(e);
+    const nombreNorm = _stripDiacritics(nombre);
+    // Solo advierte si el texto está FOMENTANDO sembrar este cultivo (no si solo
+    // lo menciona). Reusa el detector directo de fomento.
+    if (!_fomentaSiembra(norm, nombreNorm)) continue;
+
+    const partes = [];
+    if (Number.isFinite(tMin) && haveMin && fMin <= tMin + marginC) {
+      partes.push(
+        `riesgo de helada: ${nombre} sufre por debajo de ~${tMin}°C y el pronóstico baja a ` +
+          `${Math.round(fMin)}°C`,
+      );
+    }
+    if (Number.isFinite(tMax) && haveMax && fMax >= tMax - marginC) {
+      partes.push(
+        `riesgo de golpe de calor: ${nombre} se estresa por encima de ~${tMax}°C y el pronóstico sube a ` +
+          `${Math.round(fMax)}°C`,
+      );
+    }
+    if (partes.length === 0) continue;
+
+    disparadas.push(nombre);
+    advertencias.push(
+      `Ojo con ${nombre}: ${partes.join('; y ')}. No te digo que no lo siembres —hay quien lo logra con ` +
+        `cuidados— pero requiere protección (cobertor/manta térmica en las noches frías, o sombra y mulch ` +
+        `para el calor). Tenlo en cuenta antes de arriesgar la semilla.`,
+    );
+  }
+
+  if (advertencias.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('thermal_viability');
+  const text = `${responseText.trim()}\n\n${advertencias.join('\n\n')}`;
+  return { text, modified: true, reason: `viabilidad_térmica: ${disparadas.join(', ')}` };
 }
 
 // ── GUARD 4: dosis sin fuente (suaviza, no borra) ───────────────────────────
@@ -1311,6 +1535,11 @@ const GUARD_CHAIN = [
  *   (para suavizar hallazgos detallados cuando la visión no fue concluyente).
  * @param {string|null} [ctx.profileName] — nombre del usuario (getProfile().nombre)
  *   para el guard de nombre inventado. Si falta, cualquier saludo con nombre se remueve.
+ * @param {number|null} [ctx.forecastTempMin] — mínima esperada del pronóstico (°C),
+ *   derivada de climaSnapshot.openmeteo.forecast_7d. Habilita el guard térmico
+ *   (riesgo de helada). Sin esto, el guard térmico es no-op.
+ * @param {number|null} [ctx.forecastTempMax] — máxima esperada del pronóstico (°C)
+ *   para el riesgo de golpe de calor. Mismo origen.
  * @returns {{text:string, modified:boolean, reasons:string[]}}
  */
 export function applyOutputGuards(
@@ -1321,6 +1550,8 @@ export function applyOutputGuards(
     hadVision = false,
     visionConfidence = null,
     profileName = null,
+    forecastTempMin = null,
+    forecastTempMax = null,
   } = {},
 ) {
   if (typeof responseText !== 'string' || responseText.length === 0) {
@@ -1351,6 +1582,20 @@ export function applyOutputGuards(
       modified = true;
       if (res.reason) reasons.push(res.reason);
     }
+  }
+  // Guard TÉRMICO (audit #23): tras viabilidad por altitud, advierte riesgo de
+  // helada / golpe de calor cruzando temp_min/temp_max de la especie (grounding)
+  // contra la temp del PRONÓSTICO (ctx). Va después de la cadena (después de
+  // viabilidad) y antes de inventedName. Firma propia porque la cadena estándar
+  // no transporta la temp del pronóstico. No-op si no hay forecastTemp.
+  const thermalRes = guardThermalViability(text, entities, fincaAltitud, {
+    forecastTempMin,
+    forecastTempMax,
+  });
+  if (thermalRes && thermalRes.modified) {
+    text = thermalRes.text;
+    modified = true;
+    if (thermalRes.reason) reasons.push(thermalRes.reason);
   }
   // Guard de nombre inventado: firma propia (necesita el nombre del perfil).
   const nameRes = guardInventedName(text, { profileName });


### PR DESCRIPTION
## Resumen

Dos guard-hardenings deterministas de la auditoría sobre `src/services/outputGuards.js` (puro JS, cero LLM, cero latencia nueva). TDD test-first.

### HARDENING 1 — `guardSyntheticAgrochemical` por SUFIJOS (audit #21)
La denylist exacta era CERRADA → cualquier agroquímico no enumerado pasaba. Ahora también se detecta por el **sufijo de la familia química**:
- `-azol`/`-conazol` (triazoles), `-fos`/`-tion` (organofosforados), `-trina`/`-metrina` (piretroides), `-cloprid` (neonicotinoides), `-clor`/`-cloro` (organoclorados), `-carb` (carbamatos).

**3 capas anti-falso-positivo:**
1. word-boundary: el token debe **terminar** en el sufijo (no contenerlo) → "control"/"controlar" no matchea `-clor`.
2. longitud mínima ≥6 chars → descarta "fos", "carb", "trina" (nombre propio) sueltos.
3. lista de excepciones: biopreparados **permitidos** (`sulfocálcico`/`sulfocalcio`) + sustantivos españoles en `-stión` (gestión, digestión, combustión). Además `-tion` exige que el carácter previo no sea `s` (químicos `-atión/-otión` vs ruido `-stión`).

Biopreparados / caldos minerales tradicionales (bordelés, sulfocálcico, ceniza) **no se tocan**.

### HARDENING 2 — `guardThermalViability` NUEVO (audit #23)
Análogo a `guardInvertedViability` pero por **temperatura**. Cruza `temp_min`/`temp_max` de la especie (grounding/`resolvedEntities`) contra la temp esperada del **pronóstico**:
- mínima pronosticada ≤ `temp_min + margen` → riesgo de **helada**.
- máxima pronosticada ≥ `temp_max - margen` → riesgo de **golpe de calor**.

Doctrina zona-gris (tono humilde): **ADVIERTE, no bloquea ni borra** — solo anexa la nota cuando el modelo fomenta sembrar el cultivo. **No-op graceful** sin temp de pronóstico, sin entidades, o sin `temp_min`/`temp_max`.

Cableado en `applyOutputGuards` **después de viabilidad, antes de inventedName**, recibiendo `forecastTempMin`/`forecastTempMax` derivadas del `climaSnapshot` ya cacheado en `AgentScreen` (mismo snapshot que `buildFrostHeatContext`; cero red).

## Tests (TDD test-first)
+24 tests en `outputGuards.test.js`: agroquímico por sufijo bloqueado, biopreparado permitido NO bloqueado, falsos positivos descartados (metro/ajo/diablo/control/gestión), helada y golpe de calor detectados, no-op sin pronóstico, idempotencia, cadena vía `applyOutputGuards`.

- Suite `outputGuards`: **99/99 verde**.
- Suite completa: **2869 verde** (181 files), 1 skip.
- ESLint `--max-warnings=0`: limpio.
- Sanity extra: 0 falsos positivos en 15 frases agroecológicas legítimas; 9/9 agroquímicos detectados por sufijo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)