### PR TITLE
fix(guards): no inventar inviabilidad por altitud cuando la finca no tiene altitud (#1240)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.23",
+  "version": "1.0.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v281';
+const CACHE_NAME = 'chagra-v282';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -694,7 +694,11 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
 
   const norm = _stripDiacritics(responseText);
   const alt = Number(fincaAltitud);
-  const haveAlt = Number.isFinite(alt);
+  // `Number(null) === 0` (NO NaN): sin esta guarda, una finca sin altitud
+  // configurada se trataba como 0 msnm y la rama de fallback-por-rango marcaba
+  // cultivos de montaña como "inviable a 0 msnm" en FALSO (fuga viva #1240). La
+  // rama autoritativa (`_normViabilidad(e.viabilidad)`) NO depende de esto.
+  const haveAlt = fincaAltitud != null && fincaAltitud !== '' && Number.isFinite(alt);
 
   const correcciones = [];
   const disparadas = [];

--- a/tests/unit/outputGuards.test.js
+++ b/tests/unit/outputGuards.test.js
@@ -1,0 +1,82 @@
+/**
+ * outputGuards.test.js — tests unitarios para guardInvertedViability (#1240).
+ *
+ * Foco: HOTFIX del bug anti-alucinación donde `fincaAltitud === null` (finca sin
+ * altitud configurada / geolocalización fallida) hacía que `Number(null) === 0`
+ * tratara la finca como 0 msnm. En la rama de fallback-por-rango eso marcaba
+ * cultivos de MONTAÑA como "inviable a 0 msnm" en FALSO, y como #1237 hizo que el
+ * guard REEMPLACE el texto del modelo, borraba respuestas correctas.
+ *
+ * Sigue el patrón de tests/unit/setup.js y usa Vitest.
+ */
+import { describe, it, expect } from 'vitest';
+import { guardInvertedViability } from '../../src/services/outputGuards.js';
+
+describe('guardInvertedViability — altitud null (HOTFIX #1240)', () => {
+  it('1) altitud null + especie de montaña SIN viabilidad autoritativa → NO dispara', () => {
+    // Especie de montaña (banda 1800–2600 msnm). Sin campo `viabilidad`, el guard
+    // cae al fallback-por-rango. Con altitud null NO debe inventar "inviable a 0 msnm".
+    const entities = [
+      {
+        kind: 'species',
+        nombre_comun: 'curuba',
+        altitud_min: 1800,
+        altitud_max: 2600,
+        // sin `viabilidad`: fuerza la rama de fallback-por-rango
+      },
+    ];
+    const texto = 'La curuba es buena para tu zona, puedes sembrarla sin problema.';
+    const res = guardInvertedViability(texto, entities, null);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(texto);
+    expect(res.reason).toBeNull();
+  });
+
+  it('2) altitud null + especie con viabilidad:"inviable" autoritativa → SÍ corrige', () => {
+    // La rama autoritativa NO depende de la altitud: si el grafo ya dictaminó
+    // 'inviable', el guard debe corregir aunque la altitud sea null.
+    const entities = [
+      {
+        kind: 'species',
+        nombre_comun: 'curuba',
+        viabilidad: 'inviable',
+        altitud_min: 1800,
+        altitud_max: 2600,
+        alternativas_viables: ['lulo', 'mora'],
+      },
+    ];
+    const texto = 'La curuba es excelente para tu finca, puedes sembrarla este invierno.';
+    const res = guardInvertedViability(texto, entities, null);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Corrección importante');
+    expect(res.text).toContain('curuba');
+    expect(res.text).toContain('NO es viable');
+    // Sin altitud no debe inventar "a 0 msnm".
+    expect(res.text).not.toContain('0 msnm');
+    expect(res.text).not.toContain('msnm');
+    expect(res.reason).toMatch(/viabilidad_invertida/);
+  });
+
+  it('3) altitud 2580 válida + especie inviable por banda → sigue corrigiendo (no-regresión)', () => {
+    // Finca a 2580 msnm; especie de tierra caliente (0–1000) → fuera de banda por
+    // >300m → inviable por fallback. Debe seguir corrigiendo con la altitud real.
+    const entities = [
+      {
+        kind: 'species',
+        nombre_comun: 'cacao',
+        altitud_min: 0,
+        altitud_max: 1000,
+        // sin `viabilidad`: usa el fallback-por-rango con la altitud real
+      },
+    ];
+    const texto = 'El cacao es ideal para tu finca, deberías sembrarlo ya.';
+    const res = guardInvertedViability(texto, entities, 2580);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Corrección importante');
+    expect(res.text).toContain('cacao');
+    expect(res.text).toContain('NO es viable');
+    // Con altitud válida SÍ menciona los msnm reales.
+    expect(res.text).toContain('2580 msnm');
+    expect(res.reason).toMatch(/viabilidad_invertida/);
+  });
+});


### PR DESCRIPTION
## Bug (regresión viva en prod)

`guardInvertedViability` (`src/services/outputGuards.js`) calculaba la altitud disponible así:

```js
const alt = Number(fincaAltitud);
const haveAlt = Number.isFinite(alt);
```

Pero `Number(null) === 0` (no `NaN`). Para una finca **sin altitud configurada** o con **geolocalización fallida** (`fincaAltitud === null`), esto daba `alt = 0` y `haveAlt = true`. En la **rama de fallback-por-rango**, la finca se trataba como **0 msnm** y los cultivos de **montaña** quedaban marcados como "inviable a 0 msnm" en **falso**.

Como #1237 hizo que el guard **REEMPLACE** el texto del modelo (no que lo prepende), esto **borraba** la respuesta correcta y la sustituía por un veredicto falso de inviabilidad. El re-bench (juez independiente, 2026-05-31) lo vio disparar en **5/10** respuestas, incluida una correcta (**CPX-002**).

## Fix (1 línea)

```diff
-  const haveAlt = Number.isFinite(alt);
+  const haveAlt = fincaAltitud != null && fincaAltitud !== '' && Number.isFinite(alt);
```

Sin altitud → `haveAlt = false` → en el fallback `if (!haveAlt || !rangoOk) continue;` el guard queda **NEUTRAL** (no inventa inviabilidad).

La **rama autoritativa** (`viabilidad:'inviable'` del grafo, vía `_normViabilidad`) **NO depende de la altitud** y sigue corrigiendo igual aunque la altitud sea null. Bonus: sin altitud ya no se inyecta el texto espurio "a 0 msnm".

## Tests (TDD test-first — `tests/unit/outputGuards.test.js`)

1. `fincaAltitud=null` + especie de montaña (1800–2600) **sin** `viabilidad` autoritativo + texto que la fomenta → guard NO dispara (`modified:false`). *(Reproduce el bug antes del fix; pasa con el fix.)*
2. `fincaAltitud=null` + especie con `viabilidad:'inviable'` autoritativo + texto que la fomenta → guard SÍ corrige (rama autoritativa intacta, sin "0 msnm").
3. `fincaAltitud=2580` válida + especie inviable por banda → sigue corrigiendo con los msnm reales (no-regresión).

## Verificación

- `vitest run tests/unit/outputGuards.test.js` → 3/3 verde
- Suite completa → 182 files, 2883 passed, 1 skipped
- `eslint src/services/outputGuards.js tests/unit/outputGuards.test.js --max-warnings=0` → exit 0
- Secret-scan SOP → limpio
- Auto-bump aplicado: `1.0.23 → 1.0.24`, `chagra-v281 → chagra-v282`

🤖 Generated with [Claude Code](https://claude.com/claude-code)