### PR TITLE
feat(agent): badges anti-alucinación (#18 fuente · #19 auto-corregida · #20 confianza) + allowlist biopreparados (#17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.24",
+  "version": "1.0.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v282';
+const CACHE_NAME = 'chagra-v283';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -27,6 +27,7 @@ import {
   getContextString,
   computeSourceMetadata,
   mergePostValidateMetadata,
+  extractGroundingBadges,
   extractEdges,
   clearMemory,
   shouldStartNewSession,
@@ -1527,6 +1528,19 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // match) o fue solo generativo del LLM. ChatBubble lee este metadata
       // para renderizar el badge verde/amber/gris (ver computeSourceMetadata).
       let sourceMetadata = computeSourceMetadata(toolEvidence);
+
+      // #18 + #20: surfacéa en metadata las señales del grounding curado que la
+      // UX muestra como badges — `fuente_url`/`fuente` (fuente verificable
+      // clickeable, Agrosavia/FAO) y `confianza` ∈ {alta,media,baja} de un
+      // biopreparado/dosis (color del badge). Puro y graceful: sin entidades o
+      // sin esos campos → no añade nada. #19: `auto_corrected` marca que los
+      // guards deterministas modificaron la respuesta (badge "auto-corregida").
+      const groundingBadges = extractGroundingBadges(resolvedEntities);
+      sourceMetadata = {
+        ...sourceMetadata,
+        ...groundingBadges,
+        auto_corrected: guarded.modified === true,
+      };
 
       // Capa 2 anti-alucinación — cross-check de contexto (operador 2026-05-30).
       // Tras generar la respuesta, le pedimos al sidecar que correlacione cada

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { User, BadgeCheck, Info, Sparkles, AlertTriangle } from 'lucide-react';
+import { User, BadgeCheck, Info, Sparkles, AlertTriangle, ExternalLink, ShieldCheck } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import { speak, speakKokoro, stop, isSpeaking, isKokoroAvailable } from '../../services/ttsService';
 import { agentSounds } from '../../services/agentSoundService';
@@ -129,6 +129,111 @@ function SourceBadge({ metadata }) {
   );
 }
 
+/**
+ * #18 — FuenteBadge: link clickeable a la fuente verificable del grounding curado
+ * (p.ej. una dosis de biopreparado respaldada por Agrosavia / FAO). Aparece solo
+ * cuando el turno trae `metadata.fuente_url` (URL http/https). CSP-safe: es un
+ * `<a href target="_blank">` nativo (NO onclick inline) — no requiere
+ * 'unsafe-inline' ni viola `script-src 'self'`. `rel="noopener noreferrer"`
+ * evita fuga de window.opener al sitio externo.
+ *
+ * El label es `metadata.fuente` (ej. "Agrosavia"); si no viene, cae a un texto
+ * genérico. Wording cero hype: "Fuente verificable".
+ */
+function FuenteBadge({ metadata }) {
+  const md = metadata || {};
+  const url = typeof md.fuente_url === 'string' ? md.fuente_url.trim() : '';
+  if (!/^https?:\/\//i.test(url)) return null;
+  const label = (typeof md.fuente === 'string' && md.fuente.trim()) || 'fuente externa';
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid="fuente-badge"
+      data-source="verifiable-source"
+      title={`Esta respuesta cita una fuente verificable (${label}). Abre el documento original en una pestaña nueva.`}
+      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
+    >
+      <ShieldCheck size={12} aria-hidden="true" />
+      <span>Fuente verificable: {label}</span>
+      <ExternalLink size={11} aria-hidden="true" />
+    </a>
+  );
+}
+
+/**
+ * #19 — AutoCorrectedBadge: aviso sutil de que los guards deterministas
+ * (applyOutputGuards) modificaron la respuesta del modelo (corrigieron una
+ * viabilidad invertida, anexaron la ruta orgánica a un agroquímico, advirtieron
+ * una invasora, etc.). Aparece solo si `metadata.auto_corrected === true`.
+ * Reusa el patrón de badge con AlertTriangle. Wording honesto, no alarmista.
+ */
+function AutoCorrectedBadge({ metadata }) {
+  const md = metadata || {};
+  if (md.auto_corrected !== true) return null;
+  return (
+    <span
+      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-violet-600/20 text-violet-300 border border-violet-700"
+      data-testid="auto-corrected-badge"
+      data-source="auto-corrected"
+      title="El sistema ajustó automáticamente esta respuesta para corregir un posible error del modelo (viabilidad, agroquímico sintético, especie invasora, dosis sin fuente). El contenido mostrado ya está corregido."
+    >
+      <AlertTriangle size={12} aria-hidden="true" />
+      <span>Respuesta auto-corregida</span>
+    </span>
+  );
+}
+
+/**
+ * #20 — ConfianzaBadge: refleja en la UX cuán firme es un dato CURADO del
+ * grounding (p.ej. la dosis de un biopreparado). El nivel `metadata.confianza`
+ * ∈ {alta,media,baja} viene del catálogo. Color para que el campesino lo capte
+ * sin leer:
+ *   - alta  → verde   (dato respaldado/curado, alta confianza)
+ *   - media → ámbar   (referencia útil, contrastar)
+ *   - baja  → gris     (tentativo, no actuar sin verificar)
+ * Aparece solo si el turno trae un nivel reconocible.
+ */
+const _CONFIANZA_BADGE = {
+  alta: {
+    label: 'Confianza alta',
+    classes: 'bg-emerald-600/20 text-emerald-300 border-emerald-700',
+    title: 'Dato del catálogo con alta confianza (curado / respaldado por fuente).',
+    Icon: BadgeCheck,
+  },
+  media: {
+    label: 'Confianza media',
+    classes: 'bg-amber-600/20 text-amber-300 border-amber-700',
+    title: 'Dato del catálogo con confianza media — útil de referencia, contrástalo antes de aplicar.',
+    Icon: Info,
+  },
+  baja: {
+    label: 'Confianza baja',
+    classes: 'bg-slate-600/20 text-slate-300 border-slate-600',
+    title: 'Dato del catálogo con confianza baja — tentativo, no actúes sin verificar con un técnico.',
+    Icon: AlertTriangle,
+  },
+};
+
+function ConfianzaBadge({ metadata }) {
+  const md = metadata || {};
+  const cfg = _CONFIANZA_BADGE[md.confianza];
+  if (!cfg) return null;
+  const { Icon } = cfg;
+  return (
+    <span
+      className={`text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 border ${cfg.classes}`}
+      data-testid="confianza-badge"
+      data-confianza={md.confianza}
+      title={cfg.title}
+    >
+      <Icon size={12} aria-hidden="true" />
+      <span>{cfg.label}</span>
+    </span>
+  );
+}
+
 export default function ChatBubble({ message, isStreaming = false, promptText, onConsentNeeded, onRetryOrphan }) {
   const isUser = message.role === 'user';
   const showSourceBadges = usePrefsStore((s) => s.showSourceBadges);
@@ -238,8 +343,14 @@ export default function ChatBubble({ message, isStreaming = false, promptText, o
             />
           )}
           {shouldShowBadge && (
-            <div className="mt-1">
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
               <SourceBadge metadata={message.metadata} />
+              {/* #20: confianza del dato curado (alta/media/baja → verde/ámbar/gris). */}
+              <ConfianzaBadge metadata={message.metadata} />
+              {/* #18: fuente verificable clickeable (Agrosavia/FAO), CSP-safe. */}
+              <FuenteBadge metadata={message.metadata} />
+              {/* #19: aviso de que los guards deterministas corrigieron la respuesta. */}
+              <AutoCorrectedBadge metadata={message.metadata} />
             </div>
           )}
           {message.timestamp && (

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -335,3 +335,134 @@ describe('ChatBubble — badge de fuente (verificado vs generativo)', () => {
     });
   });
 });
+
+
+describe('ChatBubble — badges anti-alucinación (#18 fuente · #19 auto-corregida · #20 confianza)', () => {
+  let storeState;
+
+  beforeEach(() => {
+    storeState = { showSourceBadges: true };
+    usePrefsStore.mockImplementation((selector) => selector(storeState));
+  });
+
+  const base = (metadata) => ({
+    role: 'assistant',
+    content: 'El caldo bordelés se aplica 1-2 L por planta, foliar.',
+    timestamp: Date.now(),
+    metadata,
+  });
+
+  // ── #18: fuente verificable clickeable ──
+  test('#18 renderiza link a fuente_url con label (CSP-safe: <a href>, sin onclick)', () => {
+    render(
+      <ChatBubble
+        message={base({
+          tool_used: 'get_biopreparados',
+          grounded: true,
+          fuente: 'Agrosavia',
+          fuente_url: 'https://repository.agrosavia.co/doc/download',
+        })}
+      />,
+    );
+    const link = screen.getByTestId('fuente-badge');
+    expect(link).toBeInTheDocument();
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://repository.agrosavia.co/doc/download');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(link).toHaveTextContent(/Fuente verificable/i);
+    expect(link).toHaveTextContent(/Agrosavia/);
+    // CSP-safe: jamás un handler inline.
+    expect(link).not.toHaveAttribute('onclick');
+  });
+
+  test('#18 sin fuente_url → NO renderiza el badge de fuente', () => {
+    render(<ChatBubble message={base({ tool_used: 'get_species', grounded: true })} />);
+    expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
+  });
+
+  test('#18 fuente_url no http(s) → NO renderiza link (no inyección)', () => {
+    render(
+      <ChatBubble
+        message={base({ tool_used: 'get_biopreparados', grounded: true, fuente_url: 'javascript:alert(1)' })}
+      />,
+    );
+    expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
+  });
+
+  // ── #19: auto-corregida ──
+  test('#19 renderiza badge "Respuesta auto-corregida" cuando auto_corrected === true', () => {
+    render(<ChatBubble message={base({ tool_used: null, grounded: false, auto_corrected: true })} />);
+    const badge = screen.getByTestId('auto-corrected-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent(/auto-corregida/i);
+  });
+
+  test('#19 sin auto_corrected (o false) → NO renderiza el badge', () => {
+    render(<ChatBubble message={base({ tool_used: null, grounded: false, auto_corrected: false })} />);
+    expect(screen.queryByTestId('auto-corrected-badge')).not.toBeInTheDocument();
+    render(<ChatBubble message={base({ tool_used: null, grounded: false })} />);
+    expect(screen.queryByTestId('auto-corrected-badge')).not.toBeInTheDocument();
+  });
+
+  // ── #20: confianza del dato (alta=verde / media=ámbar / baja=gris) ──
+  test('#20 confianza alta → badge verde (emerald)', () => {
+    render(<ChatBubble message={base({ tool_used: 'get_biopreparados', grounded: true, confianza: 'alta' })} />);
+    const badge = screen.getByTestId('confianza-badge');
+    expect(badge).toHaveAttribute('data-confianza', 'alta');
+    expect(badge).toHaveTextContent(/Confianza alta/i);
+    expect(badge.className).toMatch(/emerald/);
+  });
+
+  test('#20 confianza media → badge ámbar (amber)', () => {
+    render(<ChatBubble message={base({ tool_used: 'get_biopreparados', grounded: true, confianza: 'media' })} />);
+    const badge = screen.getByTestId('confianza-badge');
+    expect(badge).toHaveAttribute('data-confianza', 'media');
+    expect(badge.className).toMatch(/amber/);
+  });
+
+  test('#20 confianza baja → badge gris (slate)', () => {
+    render(<ChatBubble message={base({ tool_used: 'get_biopreparados', grounded: true, confianza: 'baja' })} />);
+    const badge = screen.getByTestId('confianza-badge');
+    expect(badge).toHaveAttribute('data-confianza', 'baja');
+    expect(badge.className).toMatch(/slate/);
+  });
+
+  test('#20 sin confianza → NO renderiza el badge', () => {
+    render(<ChatBubble message={base({ tool_used: 'get_species', grounded: true })} />);
+    expect(screen.queryByTestId('confianza-badge')).not.toBeInTheDocument();
+  });
+
+  // ── coexistencia: todos conviven con SourceBadge sin romperse ──
+  test('los nuevos badges conviven con SourceBadge en el mismo turno', () => {
+    render(
+      <ChatBubble
+        message={base({
+          tool_used: 'get_biopreparados',
+          grounded: true,
+          fuente: 'Agrosavia',
+          fuente_url: 'https://agrosavia.co/x',
+          confianza: 'alta',
+          auto_corrected: true,
+        })}
+      />,
+    );
+    expect(screen.getByTestId('source-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('fuente-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('confianza-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('auto-corrected-badge')).toBeInTheDocument();
+  });
+
+  test('con showSourceBadges OFF no se renderiza ninguno de los nuevos badges', () => {
+    storeState = { showSourceBadges: false };
+    usePrefsStore.mockImplementation((selector) => selector(storeState));
+    render(
+      <ChatBubble
+        message={base({ fuente_url: 'https://agrosavia.co/x', confianza: 'alta', auto_corrected: true })}
+      />,
+    );
+    expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('confianza-badge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('auto-corrected-badge')).not.toBeInTheDocument();
+  });
+});

--- a/src/services/__tests__/conversationMemory.sourceMetadata.test.js
+++ b/src/services/__tests__/conversationMemory.sourceMetadata.test.js
@@ -10,7 +10,7 @@
  * El ChatBubble renderiza el badge a partir de este metadata.
  */
 import { describe, test, expect } from 'vitest';
-import { computeSourceMetadata, mergePostValidateMetadata } from '../conversationMemory';
+import { computeSourceMetadata, mergePostValidateMetadata, extractGroundingBadges } from '../conversationMemory';
 
 describe('computeSourceMetadata', () => {
   test('null / undefined toolEvidence → no tool, no grounded', () => {
@@ -297,5 +297,72 @@ describe('mergePostValidateMetadata (FIX 2 — surfacea hallucinated)', () => {
       age_available: true,
     });
     expect(original).toEqual(snapshot);
+  });
+});
+
+
+describe('extractGroundingBadges (#18 fuente_url + #20 confianza)', () => {
+  test('entrada no-array / vacía → {}', () => {
+    expect(extractGroundingBadges(null)).toEqual({});
+    expect(extractGroundingBadges(undefined)).toEqual({});
+    expect(extractGroundingBadges([])).toEqual({});
+    expect(extractGroundingBadges('x')).toEqual({});
+  });
+
+  test('biopreparado con fuente_url + fuente + confianza → surfacéa los tres', () => {
+    const ents = [
+      {
+        mentioned: 'caldo bordelés',
+        kind: 'biopreparado',
+        nombre_comun: 'Caldo bordelés',
+        fuente: 'Agrosavia / FAO',
+        fuente_url: 'https://repository.agrosavia.co/bitstreams/abc/download',
+        confianza: 'alta',
+      },
+    ];
+    const out = extractGroundingBadges(ents);
+    expect(out.fuente_url).toContain('agrosavia.co');
+    expect(out.fuente).toBe('Agrosavia / FAO');
+    expect(out.confianza).toBe('alta');
+  });
+
+  test('normaliza confianza con tildes/case y sinónimos', () => {
+    expect(extractGroundingBadges([{ confianza: 'Alta' }]).confianza).toBe('alta');
+    expect(extractGroundingBadges([{ confianza: 'MEDIA' }]).confianza).toBe('media');
+    expect(extractGroundingBadges([{ confianza: 'baja' }]).confianza).toBe('baja');
+    expect(extractGroundingBadges([{ confianza: 'verificada' }]).confianza).toBe('alta');
+    expect(extractGroundingBadges([{ confianza: 'desconocida' }]).confianza).toBeUndefined();
+  });
+
+  test('elige la confianza MÁS ALTA del turno', () => {
+    const ents = [
+      { kind: 'species', confianza: 'baja' },
+      { kind: 'biopreparado', confianza: 'alta' },
+      { kind: 'biopreparado', confianza: 'media' },
+    ];
+    expect(extractGroundingBadges(ents).confianza).toBe('alta');
+  });
+
+  test('ignora fuente_url no http(s) (no inyecta link inseguro)', () => {
+    const out = extractGroundingBadges([
+      { fuente: 'X', fuente_url: 'javascript:alert(1)', confianza: 'media' },
+    ]);
+    expect(out.fuente_url).toBeUndefined();
+    expect(out.fuente).toBeUndefined();
+    expect(out.confianza).toBe('media');
+  });
+
+  test('prioriza la fuente_url del biopreparado sobre la de otra entidad', () => {
+    const ents = [
+      { kind: 'species', fuente: 'Wiki', fuente_url: 'https://es.wikipedia.org/x' },
+      { kind: 'biopreparado', fuente: 'Agrosavia', fuente_url: 'https://agrosavia.co/y' },
+    ];
+    const out = extractGroundingBadges(ents);
+    expect(out.fuente_url).toContain('agrosavia.co');
+    expect(out.fuente).toBe('Agrosavia');
+  });
+
+  test('sin fuente_url ni confianza → {} (graceful, sin badge)', () => {
+    expect(extractGroundingBadges([{ kind: 'species', nombre_comun: 'Lulo' }])).toEqual({});
   });
 });

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -183,6 +183,56 @@ describe('guardSyntheticAgrochemical', () => {
       }
     });
   });
+
+  // ── #17: biopreparados / caldos minerales PERMITIDOS no se bloquean ──
+  // Son agroecológicos (caldo bordelés, sulfocálcico, ceniza, bocashi,
+  // supermagro, biol). Aunque algún nombre/ingrediente colisione con la
+  // denylist o el detector de sufijos, NUNCA deben marcarse como sintéticos.
+  describe('#17 — biopreparados permitidos (allowlist agroecológica)', () => {
+    it('NO bloquea caldo bordelés, sulfocálcico, ceniza, bocashi, supermagro ni biol', () => {
+      const permitidos = [
+        'caldo bordelés',
+        'caldo sulfocálcico',
+        'sulfocálcico',
+        'ceniza',
+        'bocashi',
+        'supermagro',
+        'biol',
+        'biofermento',
+        'lixiviado de lombriz',
+      ];
+      for (const bio of permitidos) {
+        const out = guardSyntheticAgrochemical(`Para el hongo aplica ${bio} foliar como preventivo.`);
+        expect(out.modified, bio).toBe(false);
+      }
+    });
+
+    it('bordelés NO bloqueado, glifosato SÍ bloqueado (criterio del caso)', () => {
+      const bordeles = guardSyntheticAgrochemical(
+        'Para el tizón aplica caldo bordelés (cal + sulfato de cobre) como preventivo.',
+      );
+      expect(bordeles.modified).toBe(false);
+
+      const glifosato = guardSyntheticAgrochemical('Para la maleza aplica glifosato al lote.');
+      expect(glifosato.modified).toBe(true);
+      expect(glifosato.reason).toMatch(/glifosato/i);
+    });
+
+    it('mezcla: aunque mencione un biopreparado permitido, un sintético en la misma frase SÍ dispara', () => {
+      const out = guardSyntheticAgrochemical(
+        'Usa caldo bordelés como preventivo; si no funciona, mancozeb en dosis foliar.',
+      );
+      expect(out.modified).toBe(true);
+      expect(out.reason).toMatch(/mancozeb/i);
+    });
+
+    it('sulfocálcico no dispara por su terminación (colisión con sufijos químicos)', () => {
+      const out = guardSyntheticAgrochemical(
+        'El caldo sulfocálcico controla ácaros y hongos; aplícalo en dosis diluida.',
+      );
+      expect(out.modified).toBe(false);
+    });
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -359,6 +359,91 @@ export function mergePostValidateMetadata(base, pv) {
 }
 
 /**
+ * Normaliza el nivel de confianza curado del grounding a uno de
+ * {alta, media, baja}. Acepta strings con tildes/case ("Alta", "MEDIA"). Tolera
+ * sinónimos comunes del campo (verificada/confirmada → alta; baja/dudosa → baja).
+ * Devuelve null si no es reconocible (el caller omite el badge de confianza).
+ *
+ * @param {unknown} v
+ * @returns {'alta'|'media'|'baja'|null}
+ */
+function _normConfianza(v) {
+  if (v == null) return null;
+  const s = String(v)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+  if (!s) return null;
+  if (s === 'alta' || s === 'verificada' || s === 'confirmada' || s === 'high') return 'alta';
+  if (s === 'media' || s === 'medio' || s === 'moderada' || s === 'mid' || s === 'medium') return 'media';
+  if (s === 'baja' || s === 'dudosa' || s === 'tentativa' || s === 'low') return 'baja';
+  return null;
+}
+
+/** Prioridad de niveles de confianza para elegir el "representativo" del turno. */
+const _CONFIANZA_RANK = { alta: 3, media: 2, baja: 1 };
+
+/**
+ * #18 + #20 — extrae de las entidades resueltas (grounding AGE del turno) las
+ * señales que la UX muestra como badges, SIN tocar la respuesta del modelo:
+ *
+ *   - `fuente_url` + `fuente` (label): cuando un biopreparado/dato curado trae
+ *     una fuente verificable (Agrosavia, FAO, etc.) tras el wire #146, se
+ *     surfacéa como badge/link clickeable "Fuente verificable: [label]".
+ *   - `confianza` ∈ {alta,media,baja}: el nivel curado del dato (dosis de
+ *     biopreparado), para que el campesino sepa cuán firme es (verde/ámbar/gris).
+ *
+ * Estrategia: recorre las entidades; prioriza las de kind 'biopreparado' (son
+ * las que traen dosis/fuente curada), pero acepta cualquier entidad con
+ * `fuente_url`. Toma la PRIMERA fuente_url válida (http/https) como
+ * representativa del turno y el nivel de confianza MÁS ALTO presente (si un
+ * biopreparado curado es 'alta', ese lidera el badge). 100% graceful: entrada
+ * no-array o sin campos → objeto vacío (el ChatBubble no renderiza badge).
+ *
+ * Puro y sin efectos. No muta las entidades.
+ *
+ * @param {Array<object>|null|undefined} resolvedEntities
+ * @returns {{fuente_url?: string, fuente?: string, confianza?: 'alta'|'media'|'baja'}}
+ */
+export function extractGroundingBadges(resolvedEntities) {
+  if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) return {};
+
+  // Biopreparados primero (traen fuente/dosis curada), luego el resto.
+  const ordered = [...resolvedEntities].sort((a, b) => {
+    const ab = a && a.kind === 'biopreparado' ? 0 : 1;
+    const bb = b && b.kind === 'biopreparado' ? 0 : 1;
+    return ab - bb;
+  });
+
+  const out = {};
+  let bestConfianzaRank = 0;
+
+  for (const e of ordered) {
+    if (!e || typeof e !== 'object') continue;
+
+    // Fuente verificable (#18): primera URL http(s) válida del turno.
+    if (!out.fuente_url) {
+      const url = typeof e.fuente_url === 'string' ? e.fuente_url.trim() : '';
+      if (/^https?:\/\//i.test(url)) {
+        out.fuente_url = url;
+        const label = typeof e.fuente === 'string' ? e.fuente.trim() : '';
+        if (label) out.fuente = label;
+      }
+    }
+
+    // Confianza del dato (#20): nivel más alto presente en el turno.
+    const conf = _normConfianza(e.confianza);
+    if (conf && _CONFIANZA_RANK[conf] > bestConfianzaRank) {
+      bestConfianzaRank = _CONFIANZA_RANK[conf];
+      out.confianza = conf;
+    }
+  }
+
+  return out;
+}
+
+/**
  * A-15 (#248) — extrae los edges del grafo AGE que un turno del agente usó
  * como evidencia, en el shape que el motor E3 (`feedback-to-confidence.mjs`
  * del sidecar) necesita para mapear la señal 👍👎 a aristas reales:
@@ -467,6 +552,7 @@ export default {
   clearMemory,
   computeSourceMetadata,
   mergePostValidateMetadata,
+  extractGroundingBadges,
   extractEdges,
   getLastTurnTimestamp,
   shouldStartNewSession,

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -278,6 +278,63 @@ const SUFFIX_EXCEPTIONS = new Set([
 ]);
 
 /**
+ * #17 — ALLOWLIST de biopreparados / caldos minerales AGROECOLOGICOS permitidos.
+ *
+ * Estos son los preparados que Chagra SI recomienda (caldo bordeles, caldo
+ * sulfocalcico, ceniza, bocashi, supermagro, biol, etc.). Aunque no son
+ * agroquimicos sinteticos, algunos de sus nombres (o de sus ingredientes
+ * minerales) podrian colisionar con la denylist exacta o con el detector de
+ * sufijos de familia quimica (p.ej. "sulfocalcico" termina parecido a un i.a.,
+ * "biol" es corto). Esta lista cerrada GARANTIZA que un biopreparado legitimo
+ * NUNCA se marque como sintetico: cualquier hit que caiga DENTRO de un termino
+ * de esta allowlist se descarta antes de disparar el guard.
+ *
+ * Normalizada sin diacriticos/case. Cubre variantes ortograficas comunes del
+ * campo (bordeles/bordeles, sulfocalcico, supermagro/super magro). Es ADITIVA al
+ * guard, no sustituye su logica: glifosato, mancozeb y demas sinteticos siguen
+ * bloqueandose igual.
+ */
+const ALLOWED_BIOPREPARADO_TERMS = [
+  'caldo bordeles',
+  'bordeles',
+  'caldo sulfocalcico',
+  'sulfocalcico',
+  'sulfocalcio',
+  'polisulfuro de calcio',
+  'ceniza',
+  'cenizas',
+  'caldo de ceniza',
+  'caldo ceniza',
+  'bocashi',
+  'supermagro',
+  'super magro',
+  'biol',
+  'bioles',
+  'biofermento',
+  'biofertilizante',
+  'caldo mineral',
+  'lixiviado de lombriz',
+  'purin',
+  'purines',
+].map(_stripDiacritics);
+
+/**
+ * #17 — el termino/token detectado como "sintetico" es en realidad un
+ * biopreparado permitido (o parte de su nombre)? Compara el hit normalizado
+ * contra la allowlist: coincide si el hit ES un termino permitido o si esta
+ * contenido en uno (p.ej. el sufijo dispara sobre "sulfocalcico", que pertenece
+ * a "caldo sulfocalcico"). Best-effort: hit vacio -> no es permitido.
+ *
+ * @param {string} hit  termino/token candidato a sintetico (puede traer tildes).
+ * @returns {boolean}
+ */
+function _isAllowedBiopreparado(hit) {
+  const h = _stripDiacritics(hit);
+  if (!h) return false;
+  return ALLOWED_BIOPREPARADO_TERMS.some((allowed) => allowed === h || allowed.includes(h));
+}
+
+/**
  * Regex que extrae tokens alfabéticos (con guion interno, p.ej. "lambda-
  * cihalotrina") del texto normalizado, para evaluar su terminación contra los
  * sufijos de familia química.
@@ -377,6 +434,8 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
   const hits = [];
   for (const term of SYNTHETIC_AGROCHEM_TERMS) {
     const t = _stripDiacritics(term);
+    // #17: nunca tratamos un biopreparado permitido como sintético.
+    if (_isAllowedBiopreparado(term)) continue;
     // límite de palabra a ambos lados sobre el texto normalizado.
     const re = new RegExp(`(^|[^a-z0-9])${t.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([^a-z0-9]|$)`);
     if (re.test(norm)) hits.push(term);
@@ -391,7 +450,9 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
   let tok;
   while ((tok = WORD_TOKEN_RE.exec(norm)) !== null) {
     const suf = _agrochemBySuffix(tok[0]);
-    if (suf) hits.push(tok[0]);
+    // #17: un biopreparado permitido (o parte de su nombre) nunca dispara por
+    // sufijo, aunque su terminación colisione con una familia química.
+    if (suf && !_isAllowedBiopreparado(tok[0])) hits.push(tok[0]);
   }
 
   // Códigos inventados SOLO cuentan si hay contexto de aplicación/dosis (para


### PR DESCRIPTION
## Batch de 4 mejoras anti-alucinación de UX

### #17 — `guardSyntheticAgrochemical`: allowlist de biopreparados
Allowlist cerrada de biopreparados/caldos minerales agroecológicos permitidos (caldo bordelés, sulfocálcico, ceniza, bocashi, supermagro, biol, lixiviado de lombriz, purín…). Un biopreparado legítimo **nunca** se marca como agroquímico sintético — ni por la denylist exacta ni por el detector de sufijos de familia química. Los sintéticos (glifosato, mancozeb, clorpirifos, azoxystrobin, epoxiconazol…) siguen bloqueándose igual.
- `src/services/outputGuards.js`: `ALLOWED_BIOPREPARADO_TERMS` + `_isAllowedBiopreparado` (filtro en el loop de denylist y en el de sufijos).
- Test: bordelés NO bloqueado, glifosato SÍ bloqueado.

### #18 — Badge de fuente verificable
Cuando el grounding trae `fuente_url` (biopreparados tras wire #146), se muestra un link clickeable "Fuente verificable: [Agrosavia]". **CSP-safe**: `<a href target="_blank" rel="noopener noreferrer">` nativo, sin `onclick` inline.
- `src/components/AgentScreen/ChatBubble.jsx`: `FuenteBadge`.

### #19 — Badge "Respuesta auto-corregida"
Cuando `applyOutputGuards` modificó la respuesta (`guarded.modified === true`), badge sutil con AlertTriangle.
- `src/components/AgentScreen/ChatBubble.jsx`: `AutoCorrectedBadge`.

### #20 — Confianza de dosis/dato curado
`confianza` ∈ {alta,media,baja} del grounding se refleja por color: alta=verde, media=ámbar, baja=gris.
- `src/components/AgentScreen/ChatBubble.jsx`: `ConfianzaBadge`.

### Wiring
`extractGroundingBadges` (conversationMemory) surfacéa `fuente_url`/`fuente`/`confianza` desde `resolvedEntities` a la metadata del turn. `AgentScreen` mergea eso + `auto_corrected`. Todo puro y graceful (sin grounding → no hay badge; toggle `showSourceBadges` los apaga a todos).

## Verificación
- Suite completa: **2905 passed, 1 skipped, 0 fail**.
- ESLint `--max-warnings=0` limpio en todos los archivos tocados.
- Tests nuevos: outputGuards (#17), conversationMemory.sourceMetadata (`extractGroundingBadges`), ChatBubble (#18/#19/#20 + coexistencia + toggle off).
- Bump auto: 1.0.24 → 1.0.25, `chagra-v282` → `chagra-v283`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)