### PR TITLE
test(bench): guarda anti-stale + pool de capacidades grounded + runner A-vs-C

### DIFF
--- a/scripts/__tests__/bench-checkout-guard.test.mjs
+++ b/scripts/__tests__/bench-checkout-guard.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * scripts/__tests__/bench-checkout-guard.test.mjs
+ *
+ * Cubre la guarda ANTI-STALE de los benches (2026-05-31). El bench corrió 3
+ * veces sobre código viejo y reportó un "10% AH" que era artefacto del bug
+ * stale (#1240 ausente). La guarda aborta (o hace git pull) cuando el HEAD local
+ * está atrás de origin/main, así NINGÚN bench vuelve a medir código que el
+ * usuario ya no ve.
+ *
+ * `assertCheckoutCurrent` recibe el runner de git INYECTADO → el test no toca el
+ * repo real ni la red.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  computeStaleDecision,
+  assertCheckoutCurrent,
+} from '../lib/bench-checkout-guard.mjs';
+
+describe('computeStaleDecision (lógica pura)', () => {
+  it('HEAD == origin → current/continue', () => {
+    const d = computeStaleDecision({
+      localHead: 'abc', remoteHead: 'abc',
+      localIsAncestorOfRemote: true, remoteIsAncestorOfLocal: true,
+      workingTreeClean: true, autoPull: false,
+    });
+    expect(d.state).toBe('current');
+    expect(d.action).toBe('continue');
+  });
+
+  it('local adelantado a origin → ahead/continue (no stale)', () => {
+    const d = computeStaleDecision({
+      localHead: 'new', remoteHead: 'old',
+      localIsAncestorOfRemote: false, remoteIsAncestorOfLocal: true,
+      workingTreeClean: true, autoPull: false,
+    });
+    expect(d.state).toBe('ahead');
+    expect(d.action).toBe('continue');
+  });
+
+  it('local ATRÁS de origin + autoPull off → behind/abort', () => {
+    const d = computeStaleDecision({
+      localHead: 'old', remoteHead: 'new',
+      localIsAncestorOfRemote: true, remoteIsAncestorOfLocal: false,
+      workingTreeClean: true, autoPull: false,
+    });
+    expect(d.state).toBe('behind');
+    expect(d.action).toBe('abort');
+    expect(d.reason).toMatch(/STALE/i);
+  });
+
+  it('local ATRÁS + limpio + autoPull on → behind/pull', () => {
+    const d = computeStaleDecision({
+      localHead: 'old', remoteHead: 'new',
+      localIsAncestorOfRemote: true, remoteIsAncestorOfLocal: false,
+      workingTreeClean: true, autoPull: true,
+    });
+    expect(d.state).toBe('behind');
+    expect(d.action).toBe('pull');
+  });
+
+  it('local ATRÁS + working tree sucio → abort aunque autoPull on', () => {
+    const d = computeStaleDecision({
+      localHead: 'old', remoteHead: 'new',
+      localIsAncestorOfRemote: true, remoteIsAncestorOfLocal: false,
+      workingTreeClean: false, autoPull: true,
+    });
+    expect(d.action).toBe('abort');
+    expect(d.reason).toMatch(/working tree/i);
+  });
+
+  it('divergido (ni ancestro ni descendiente) → diverged/abort', () => {
+    const d = computeStaleDecision({
+      localHead: 'x', remoteHead: 'y',
+      localIsAncestorOfRemote: false, remoteIsAncestorOfLocal: false,
+      workingTreeClean: true, autoPull: false,
+    });
+    expect(d.state).toBe('diverged');
+    expect(d.action).toBe('abort');
+  });
+});
+
+describe('assertCheckoutCurrent (con runner git inyectado)', () => {
+  /** Fabrica un runner de git fake a partir de un mapa cmd→respuesta. */
+  function fakeGit(map, sucio = false) {
+    return (cmd) => {
+      if (cmd.startsWith('git fetch')) return '';
+      if (cmd === 'git rev-parse HEAD') return map.HEAD;
+      if (cmd.includes('rev-parse origin/main')) return map.REMOTE;
+      if (cmd.startsWith('git merge-base --is-ancestor')) {
+        const [, , , a, b] = cmd.split(' ');
+        // ancestro si está declarado en map.ancestors "a<b"
+        if ((map.ancestors || []).includes(`${a}<${b}`)) return '';
+        const e = new Error('not ancestor');
+        throw e;
+      }
+      if (cmd === 'git status --porcelain') return sucio ? ' M file.js' : '';
+      if (cmd.startsWith('git pull')) return 'Updating';
+      throw new Error(`unexpected cmd: ${cmd}`);
+    };
+  }
+
+  it('no aborta cuando el checkout está current', () => {
+    const git = fakeGit({ HEAD: 'abc', REMOTE: 'abc', ancestors: ['abc<abc'] });
+    const res = assertCheckoutCurrent({ git, log: () => {} });
+    expect(res.action).toBe('continue');
+    expect(res.state).toBe('current');
+  });
+
+  it('ABORTA cuando el HEAD local está atrás de origin', () => {
+    // old es ancestro de new, new NO es ancestro de old → behind.
+    const git = fakeGit({ HEAD: 'old', REMOTE: 'new', ancestors: ['old<new'] });
+    expect(() => assertCheckoutCurrent({ git, log: () => {} })).toThrow(/STALE/i);
+  });
+
+  it('hace git pull cuando está atrás, limpio y autoPull=true', () => {
+    let pulled = false;
+    const base = fakeGit({ HEAD: 'old', REMOTE: 'new', ancestors: ['old<new'] });
+    let head = 'old';
+    const git = (cmd) => {
+      if (cmd.startsWith('git pull')) { pulled = true; head = 'new'; return 'ok'; }
+      if (cmd === 'git rev-parse HEAD') return head;
+      return base(cmd);
+    };
+    const res = assertCheckoutCurrent({ git, autoPull: true, log: () => {} });
+    expect(pulled).toBe(true);
+    expect(res.localHead).toBe('new');
+  });
+
+  it('respeta skip y no llama a git', () => {
+    const git = vi.fn();
+    const res = assertCheckoutCurrent({ skip: true, git, log: () => {} });
+    expect(res.state).toBe('skipped');
+    expect(git).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/bench-agente-completo.mjs
+++ b/scripts/bench-agente-completo.mjs
@@ -40,6 +40,7 @@ import {
   assertIndependentJudge,
   RECOMMENDED_JUDGE_MODEL,
 } from './lib/bench-scorer.mjs';
+import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
@@ -743,6 +744,14 @@ async function benchmarkPrompt(promptData, index, total) {
 }
 
 async function main() {
+  // Guarda ANTI-STALE: aborta si el checkout está atrás de origin/main, para que
+  // el bench nunca mida código viejo (pasó 3 veces y contaminó el AH%).
+  assertCheckoutCurrent({
+    cwd: ROOT_DIR,
+    autoPull: process.env.BENCH_AUTO_PULL === '1',
+    skip: process.env.BENCH_SKIP_STALE_GUARD === '1',
+  });
+
   console.log('[bench] Agente Chagra completo — Benchmark LARGO');
   console.log(`[bench] Modelos: ${Object.values(MODELS).join(', ')}`);
   console.log(`[bench] Prompts: ${PROMPTS.length}`);

--- a/scripts/bench-capabilities-A-vs-C.mjs
+++ b/scripts/bench-capabilities-A-vs-C.mjs
@@ -154,20 +154,68 @@ const BASE_PROMPT = `Eres un asistente agroecológico experto para Colombia. Res
 
 Si mencionas entidades (especies, plagas, biopreparados), usa los nombres canónicos del catálogo Chagra para evitar alucinaciones. Si NO tienes un dato verificado (por ejemplo una dosis numérica), dilo explícitamente en vez de inventarlo.`;
 
+/** Lista hasta `max` nombres de un array (strings u objetos {nombre_comun}). */
+function _liftNames(arr, max = 5) {
+  if (!Array.isArray(arr)) return [];
+  const out = [];
+  for (const a of arr) {
+    let n = null;
+    if (typeof a === 'string') n = a.trim();
+    else if (a && typeof a === 'object') n = (a.nombre_comun || a.nombre || a.name || '').toString().trim();
+    if (n && !out.includes(n)) out.push(n);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+/**
+ * Arma el system prompt enriquecido con los HECHOS CURADOS del grafo que el
+ * sidecar /resolve-entities ya devuelve por entidad — NO solo el nombre. Es el
+ * cambio que mide el LIFT real de la curación: para que granite CITE la dosis
+ * verificada del biopreparado y la helada_letal/altitud de la especie en vez de
+ * inventarlas. Solo emite campos presentes (degrada con gracia).
+ *
+ * Mismo principio que prod (AgentScreen + buildCuratedFactsContext).
+ */
 function buildEnrichedSystemPrompt(entities) {
   if (!entities || entities.length === 0) return BASE_PROMPT;
   const entityContext = entities
     .map((e) => {
-      if (e.kind === 'species') return `- ${e.mentioned} = especie: ${e.nombre_cientifico} (${e.nombre_comun})`;
+      if (e.kind === 'species') {
+        const facts = [];
+        if (e.altitud_min != null && e.altitud_max != null) {
+          facts.push(`altitud ${e.altitud_min}-${e.altitud_max} msnm`);
+        }
+        if (e.helada_letal != null && e.helada_letal !== '') {
+          facts.push(`muere por helada bajo ${Number(e.helada_letal)}°C`);
+        }
+        if (e.viabilidad) {
+          const delta = e.delta_altitud != null ? ` (${e.delta_altitud}m del rango)` : '';
+          facts.push(`viabilidad a la altitud de la finca: ${e.viabilidad}${delta}`);
+        }
+        const tail = facts.length ? ` — ${facts.join('; ')}` : '';
+        return `- ${e.mentioned} = especie: ${e.nombre_cientifico} (${e.nombre_comun})${tail}`;
+      }
       if (e.kind === 'pest') return `- ${e.mentioned} = plaga: ${e.nombre_cientifico || e.nombre_comun}`;
-      if (e.kind === 'biopreparado') return `- ${e.mentioned} = biopreparado: ${e.nombre_comun}`;
+      if (e.kind === 'biopreparado') {
+        const facts = [];
+        if (e.dosis_aplicacion) facts.push(`dosis verificada: ${e.dosis_aplicacion}`);
+        if (e.ingredientes_resumen) facts.push(`ingredientes: ${e.ingredientes_resumen}`);
+        if (e.preparacion) facts.push(`preparación: ${e.preparacion}`);
+        const target = _liftNames(e.target, 5);
+        if (target.length) facts.push(`controla: ${target.join(', ')}`);
+        if (e.precauciones) facts.push(`precauciones: ${e.precauciones}`);
+        if (e.fuente) facts.push(`fuente: ${e.fuente}`);
+        const tail = facts.length ? ` — ${facts.join('; ')}` : '';
+        return `- ${e.mentioned} = biopreparado: ${e.nombre_comun}${tail}`;
+      }
       return null;
     })
     .filter(Boolean)
     .join('\n');
   return `${BASE_PROMPT}
 
-ENTIDADES DEL CATÁLOGO (usa estos nombres canónicos):
+ENTIDADES DEL CATÁLOGO (usa estos nombres canónicos Y CITA los hechos verificados; JAMÁS inventes dosis ni recetas):
 ${entityContext}`;
 }
 

--- a/scripts/bench-capabilities-A-vs-C.mjs
+++ b/scripts/bench-capabilities-A-vs-C.mjs
@@ -228,7 +228,13 @@ async function judgeOllamaCall(prompt) {
  * CONFIG A: granite crudo (sin grounding/guards/validate).
  * CONFIG C: pipeline completo de prod.
  */
-async function runOne(p, config) {
+/**
+ * FASE 1 — genera la respuesta (granite) + guards/post-validate (config C). NO
+ * juzga: así granite queda cargado todo el run y el juez (qwen) se carga UNA vez
+ * en la fase 2. En Maxwell (12GB) granite+qwen no caben juntos → evitar el swap
+ * por-prompt baja el run de ~10h a ~2-3h.
+ */
+async function generatePhase(p, config) {
   let entities = [];
   let systemPrompt = BASE_PROMPT;
 
@@ -260,17 +266,6 @@ async function runOne(p, config) {
     validation = await postValidate(p.prompt, finalText);
   }
 
-  const ah = await scoreAntiHalluc(
-    {
-      query: p.prompt,
-      response: finalText,
-      mustInclude: p.must_include,
-      redFlags: p.red_flags,
-      shouldInclude: p.should_include,
-    },
-    { ollamaCall: judgeOllamaCall },
-  );
-
   return {
     config,
     entities_grounded: entities.length,
@@ -280,13 +275,35 @@ async function runOne(p, config) {
     guards_reasons: guarded.reasons,
     sidecar_halluc_count: validation.detected_count,
     age_available: validation.age_available,
-    ah_pass: ah.pass,
-    ah_source: ah.source,
-    ah_must_covered: ah.mustCovered,
-    ah_must_total: ah.mustTotal ?? (p.must_include ? p.must_include.length : null),
-    ah_red_flags_hit: ah.redFlagsHit,
     latency_gen_ms: gen.latency_ms,
+    // se completan en la fase 2 (juez):
+    ah_pass: null,
+    ah_source: 'pending',
+    ah_must_covered: null,
+    ah_must_total: p.must_include ? p.must_include.length : null,
+    ah_red_flags_hit: null,
   };
+}
+
+/** FASE 2 — juzga (qwen, cargado una sola vez) la respuesta ya generada. */
+async function judgePhase(p, res) {
+  if (!res || res.error) return res;
+  const ah = await scoreAntiHalluc(
+    {
+      query: p.prompt,
+      response: res.final_response,
+      mustInclude: p.must_include,
+      redFlags: p.red_flags,
+      shouldInclude: p.should_include,
+    },
+    { ollamaCall: judgeOllamaCall },
+  );
+  res.ah_pass = ah.pass;
+  res.ah_source = ah.source;
+  res.ah_must_covered = ah.mustCovered;
+  res.ah_must_total = ah.mustTotal ?? res.ah_must_total;
+  res.ah_red_flags_hit = ah.redFlagsHit;
+  return res;
 }
 
 function aggregate(rows, config) {
@@ -332,33 +349,56 @@ async function main() {
 
   if (!existsSync(BENCH_RUNS_DIR)) mkdirSync(BENCH_RUNS_DIR, { recursive: true });
 
-  const rows = [];
-  for (let i = 0; i < prompts.length; i++) {
-    const p = prompts[i];
-    console.log(`\n[${i + 1}/${prompts.length}] ${p.id} (${p.cap}): ${p.prompt.slice(0, 56)}…`);
-    const row = { id: p.id, cap: p.cap, prompt: p.prompt, expects_abstention: !!p.expects_abstention, results: {} };
-    for (const config of CONFIGS) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const jsonlPath = join(BENCH_RUNS_DIR, `capabilities-A-vs-C-${ts}.jsonl`);
+  const summaryPath = join(BENCH_RUNS_DIR, `capabilities-A-vs-C-${ts}.summary.json`);
+
+  const rows = prompts.map((p) => ({
+    id: p.id,
+    cap: p.cap,
+    prompt: p.prompt,
+    expects_abstention: !!p.expects_abstention,
+    results: {},
+  }));
+
+  // ── FASE 1: generación (granite cargado todo el run) ────────────────────────
+  // Orden por config: todas las A, luego todas las C → cero swaps de generador.
+  console.log('\n========== FASE 1: GENERACIÓN (granite) ==========');
+  for (const config of CONFIGS) {
+    for (let i = 0; i < prompts.length; i++) {
+      const p = prompts[i];
       await thermalGuard();
-      const res = await runOne(p, config);
-      row.results[config] = res;
-      const verdict = res.error ? 'ERR' : res.ah_source === 'unjudged' ? 'UNJ' : res.ah_pass ? 'PASS' : 'FAIL';
-      console.log(
-        `    [${config}] ${verdict}  must=${res.ah_must_covered ?? '?'}/${res.ah_must_total ?? '?'} ` +
-          `rf=${res.ah_red_flags_hit ?? '?'} guards=${res.guards_modified ? (res.guards_reasons || []).join(',') : 'none'} ` +
-          `${res.latency_gen_ms ? (res.latency_gen_ms / 1000).toFixed(1) + 's' : ''}`,
-      );
-      await sleep(1500);
+      const res = await generatePhase(p, config);
+      rows[i].results[config] = res;
+      const tag = res.error ? `ERR ${res.error.slice(0, 40)}` : `${(res.latency_gen_ms / 1000).toFixed(1)}s guards=${res.guards_modified ? (res.guards_reasons || []).join(',') : 'none'}`;
+      console.log(`  [gen ${config}] [${i + 1}/${prompts.length}] ${p.id} (${p.cap}) ${tag}`);
+      await sleep(800);
     }
-    rows.push(row);
+  }
+  // Persistir respuestas ANTES de juzgar (si el juez muere, no perdemos la gen).
+  writeFileSync(jsonlPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  console.log(`[fase1] respuestas persistidas en ${jsonlPath}`);
+
+  // ── FASE 2: juicio (qwen cargado UNA vez) ───────────────────────────────────
+  console.log('\n========== FASE 2: JUICIO (qwen2.5:14b independiente) ==========');
+  for (const config of CONFIGS) {
+    for (let i = 0; i < prompts.length; i++) {
+      const p = prompts[i];
+      await thermalGuard();
+      const res = await judgePhase(p, rows[i].results[config]);
+      const verdict = !res || res.error ? 'ERR' : res.ah_source === 'unjudged' ? 'UNJ' : res.ah_pass ? 'PASS' : 'FAIL';
+      console.log(
+        `  [judge ${config}] [${i + 1}/${prompts.length}] ${p.id} (${p.cap}) ${verdict} ` +
+          `must=${res?.ah_must_covered ?? '?'}/${res?.ah_must_total ?? '?'} rf=${res?.ah_red_flags_hit ?? '?'}`,
+      );
+      await sleep(600);
+    }
+    // re-persistir tras juzgar cada config.
+    writeFileSync(jsonlPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
   }
 
   const aggA = CONFIGS.includes('A') ? aggregate(rows, 'A') : null;
   const aggC = CONFIGS.includes('C') ? aggregate(rows, 'C') : null;
-
-  const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const jsonlPath = join(BENCH_RUNS_DIR, `capabilities-A-vs-C-${ts}.jsonl`);
-  const summaryPath = join(BENCH_RUNS_DIR, `capabilities-A-vs-C-${ts}.summary.json`);
-  writeFileSync(jsonlPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
 
   // tabla por capacidad A vs C
   const caps = [...new Set(prompts.map((p) => p.cap))];

--- a/scripts/bench-capabilities-A-vs-C.mjs
+++ b/scripts/bench-capabilities-A-vs-C.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+/**
+ * bench-capabilities-A-vs-C.mjs — bench HONESTO de capacidades (2026-05-31).
+ *
+ * Mide cuánto aportó la curación + el wiring de las últimas 48h, comparando dos
+ * configuraciones sobre el MISMO pool de capacidades (grounded contra el grafo
+ * vivo chagra_kg, generado por gen-bench-capabilities-pool.mjs):
+ *
+ *   - CONFIG A (piso real): granite3.1-dense:8b CRUDO. System prompt base, SIN
+ *     resolve-entities (sin grounding AGE), SIN applyOutputGuards, SIN
+ *     post-validate. Es lo que el modelo sabe solo.
+ *   - CONFIG C (estado de HOY): pipeline real de prod →
+ *       resolve-entities (AGE, con finca_altitud)  →
+ *       system prompt enriquecido con las entidades →
+ *       granite temp 0.3 + seed fijo                →
+ *       applyOutputGuards (los 8 guards + térmico, con fincaAltitud) →
+ *       post-validate (detector de alucinaciones del sidecar).
+ *
+ * Juez INDEPENDIENTE: qwen2.5:14b (familia distinta a granite). Métrica AH: PASS
+ * si todos los must_include presentes (por fondo) Y cero red_flags. Para los
+ * prompts con `expects_abstention:true`, el must_include ES la abstención ("no
+ * tengo dato verificado") → PASS = el agente NO inventó.
+ *
+ * Δ(C−A) por capacidad = el LIFT real de la curación.
+ *
+ * Guarda ANTI-STALE primero (no medir código viejo). Vigilancia térmica GPU<88°.
+ *
+ * Uso:
+ *   node scripts/bench-capabilities-A-vs-C.mjs \
+ *     --pool data/bench-runs/capabilities-pool-2026-05-31.json
+ *   node scripts/bench-capabilities-A-vs-C.mjs --pool <f> --configs A,C
+ *   node scripts/bench-capabilities-A-vs-C.mjs --pool <f> --configs C   # solo C
+ *
+ * Output: data/bench-runs/capabilities-A-vs-C-<ts>.{jsonl,summary.json}
+ */
+import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { execSync } from 'node:child_process';
+import { scoreAntiHalluc, assertIndependentJudge, RECOMMENDED_JUDGE_MODEL } from './lib/bench-scorer.mjs';
+import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
+import { applyOutputGuards } from '../src/services/outputGuards.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+const BENCH_RUNS_DIR = join(ROOT_DIR, 'data', 'bench-runs');
+
+const GEN_MODEL = process.env.GEN_MODEL || 'granite3.1-dense:8b';
+const GEN_TEMPERATURE = 0.3;
+const GEN_MAX_TOKENS = 768;
+const SEED = Number(process.env.SEED || 42);
+
+const JUDGE_MODEL = process.env.JUDGE_MODEL || RECOMMENDED_JUDGE_MODEL;
+const JUDGE_TEMPERATURE = 0;
+const JUDGE_TIMEOUT_MS = 120_000;
+
+const SIDECAR_URL = process.env.SIDECAR_URL || 'http://localhost:7880';
+const OLLAMA_CHAT_URL = 'http://localhost:11434/api/chat';
+const OLLAMA_GEN_URL = 'http://localhost:11434/api/generate';
+const GEN_TIMEOUT_MS = 180_000;
+
+const GPU_TEMP_LIMIT = 88;
+const GPU_TEMP_RESUME = 75;
+
+function argVal(flag, def) {
+  const i = process.argv.indexOf(flag);
+  if (i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')) return process.argv[i + 1];
+  return def;
+}
+const POOL_FILE = argVal('--pool', process.env.POOL || '');
+const CONFIGS = argVal('--configs', 'A,C')
+  .split(',')
+  .map((s) => s.trim().toUpperCase())
+  .filter((c) => c === 'A' || c === 'C');
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+function getSidecarToken() {
+  const tokenPath = `${process.env.HOME}/.config/chagra-sidecar-token.txt`;
+  if (existsSync(tokenPath)) return readFileSync(tokenPath, 'utf-8').trim();
+  return process.env.SIDECAR_TOKEN || '';
+}
+
+function gpuTemp() {
+  try {
+    const out = execSync('nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits', {
+      encoding: 'utf-8',
+      timeout: 8000,
+    });
+    const t = parseInt(out.trim().split('\n')[0], 10);
+    return Number.isFinite(t) ? t : null;
+  } catch {
+    return null;
+  }
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function thermalGuard() {
+  let t = gpuTemp();
+  if (t == null) return;
+  while (t >= GPU_TEMP_LIMIT) {
+    console.log(`  [thermal] GPU ${t}°C ≥ ${GPU_TEMP_LIMIT}°C — pausando 30s hasta ≤${GPU_TEMP_RESUME}°C`);
+    await sleep(30_000);
+    t = gpuTemp();
+    if (t == null) return;
+    if (t <= GPU_TEMP_RESUME) break;
+  }
+}
+
+async function resolveEntities(userMessage) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${SIDECAR_URL}/resolve-entities`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return { entities: [] };
+    const data = await res.json();
+    return { entities: data.entities || [] };
+  } catch (err) {
+    console.log(`    [resolve-entities] ${err.message.slice(0, 60)}`);
+    return { entities: [] };
+  }
+}
+
+async function postValidate(userMessage, response) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${SIDECAR_URL}/post-validate`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage, response }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return { hallucinated: [], detected_count: 0, age_available: false };
+    const data = await res.json();
+    return {
+      hallucinated: data.hallucinated || [],
+      detected_count: data.detected_count || 0,
+      age_available: Boolean(data.age_available),
+    };
+  } catch {
+    return { hallucinated: [], detected_count: 0, age_available: false };
+  }
+}
+
+const BASE_PROMPT = `Eres un asistente agroecológico experto para Colombia. Responde en español claro, práctico para agricultores.
+
+Si mencionas entidades (especies, plagas, biopreparados), usa los nombres canónicos del catálogo Chagra para evitar alucinaciones. Si NO tienes un dato verificado (por ejemplo una dosis numérica), dilo explícitamente en vez de inventarlo.`;
+
+function buildEnrichedSystemPrompt(entities) {
+  if (!entities || entities.length === 0) return BASE_PROMPT;
+  const entityContext = entities
+    .map((e) => {
+      if (e.kind === 'species') return `- ${e.mentioned} = especie: ${e.nombre_cientifico} (${e.nombre_comun})`;
+      if (e.kind === 'pest') return `- ${e.mentioned} = plaga: ${e.nombre_cientifico || e.nombre_comun}`;
+      if (e.kind === 'biopreparado') return `- ${e.mentioned} = biopreparado: ${e.nombre_comun}`;
+      return null;
+    })
+    .filter(Boolean)
+    .join('\n');
+  return `${BASE_PROMPT}
+
+ENTIDADES DEL CATÁLOGO (usa estos nombres canónicos):
+${entityContext}`;
+}
+
+async function generate(systemPrompt, userPrompt) {
+  const start = performance.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GEN_TIMEOUT_MS);
+  try {
+    const res = await fetch(OLLAMA_CHAT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: GEN_MODEL,
+        stream: false,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        options: { temperature: GEN_TEMPERATURE, seed: SEED, num_predict: GEN_MAX_TOKENS },
+        keep_alive: '30m',
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`gen HTTP ${res.status}`);
+    const data = await res.json();
+    return { response: data.message?.content || '', latency_ms: performance.now() - start };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function judgeOllamaCall(prompt) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), JUDGE_TIMEOUT_MS);
+  try {
+    const res = await fetch(OLLAMA_GEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: JUDGE_MODEL,
+        prompt,
+        stream: false,
+        options: { temperature: JUDGE_TEMPERATURE, seed: SEED, num_predict: 160 },
+        keep_alive: '30m',
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`judge HTTP ${res.status}`);
+    const data = await res.json();
+    return data.response || '';
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Ejecuta un prompt en una config dada y devuelve el registro evaluado.
+ * CONFIG A: granite crudo (sin grounding/guards/validate).
+ * CONFIG C: pipeline completo de prod.
+ */
+async function runOne(p, config) {
+  let entities = [];
+  let systemPrompt = BASE_PROMPT;
+
+  if (config === 'C') {
+    const r = await resolveEntities(p.prompt);
+    entities = r.entities;
+    systemPrompt = buildEnrichedSystemPrompt(entities);
+  }
+
+  let gen;
+  try {
+    gen = await generate(systemPrompt, p.prompt);
+  } catch (err) {
+    return { config, error: err.message };
+  }
+
+  let finalText = gen.response;
+  let guarded = { modified: false, reasons: [] };
+  let validation = { hallucinated: [], detected_count: 0, age_available: false };
+
+  if (config === 'C') {
+    const g = applyOutputGuards(gen.response, {
+      resolvedEntities: entities,
+      fincaAltitud: p.finca_altitud ?? null,
+      profileName: null,
+    });
+    finalText = g.text;
+    guarded = { modified: g.modified, reasons: g.reasons };
+    validation = await postValidate(p.prompt, finalText);
+  }
+
+  const ah = await scoreAntiHalluc(
+    {
+      query: p.prompt,
+      response: finalText,
+      mustInclude: p.must_include,
+      redFlags: p.red_flags,
+      shouldInclude: p.should_include,
+    },
+    { ollamaCall: judgeOllamaCall },
+  );
+
+  return {
+    config,
+    entities_grounded: entities.length,
+    raw_response: gen.response,
+    final_response: finalText,
+    guards_modified: guarded.modified,
+    guards_reasons: guarded.reasons,
+    sidecar_halluc_count: validation.detected_count,
+    age_available: validation.age_available,
+    ah_pass: ah.pass,
+    ah_source: ah.source,
+    ah_must_covered: ah.mustCovered,
+    ah_must_total: ah.mustTotal ?? (p.must_include ? p.must_include.length : null),
+    ah_red_flags_hit: ah.redFlagsHit,
+    latency_gen_ms: gen.latency_ms,
+  };
+}
+
+function aggregate(rows, config) {
+  const byCap = {};
+  let pass = 0;
+  let judged = 0;
+  for (const r of rows) {
+    const res = r.results[config];
+    if (!res || res.error || res.ah_source === 'unjudged') continue;
+    judged += 1;
+    byCap[r.cap] = byCap[r.cap] || { pass: 0, total: 0 };
+    byCap[r.cap].total += 1;
+    if (res.ah_pass) {
+      pass += 1;
+      byCap[r.cap].pass += 1;
+    }
+  }
+  return { pass, judged, ah_pct: judged > 0 ? Number(((100 * pass) / judged).toFixed(1)) : 0, byCap };
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+async function main() {
+  assertCheckoutCurrent({
+    cwd: ROOT_DIR,
+    autoPull: process.env.BENCH_AUTO_PULL === '1',
+    skip: process.env.BENCH_SKIP_STALE_GUARD === '1',
+  });
+  assertIndependentJudge(JUDGE_MODEL, GEN_MODEL);
+
+  if (!POOL_FILE || !existsSync(POOL_FILE)) {
+    console.error(`FATAL: pool no encontrado. Pasá --pool <archivo>. (recibido: '${POOL_FILE}')`);
+    process.exit(1);
+  }
+  const pool = JSON.parse(readFileSync(POOL_FILE, 'utf-8'));
+  const prompts = pool.prompts || [];
+
+  console.log('[bench-cap] bench HONESTO de capacidades — juez independiente + config-prod');
+  console.log(`[bench-cap] generador: ${GEN_MODEL} temp=${GEN_TEMPERATURE} seed=${SEED}`);
+  console.log(`[bench-cap] juez:      ${JUDGE_MODEL} (independiente)`);
+  console.log(`[bench-cap] pool:      ${prompts.length} prompts (${POOL_FILE.split('/').pop()})`);
+  console.log(`[bench-cap] configs:   ${CONFIGS.join(', ')}`);
+  console.log(`[bench-cap] GPU temp inicial: ${gpuTemp() ?? 'n/d'}°C`);
+
+  if (!existsSync(BENCH_RUNS_DIR)) mkdirSync(BENCH_RUNS_DIR, { recursive: true });
+
+  const rows = [];
+  for (let i = 0; i < prompts.length; i++) {
+    const p = prompts[i];
+    console.log(`\n[${i + 1}/${prompts.length}] ${p.id} (${p.cap}): ${p.prompt.slice(0, 56)}…`);
+    const row = { id: p.id, cap: p.cap, prompt: p.prompt, expects_abstention: !!p.expects_abstention, results: {} };
+    for (const config of CONFIGS) {
+      await thermalGuard();
+      const res = await runOne(p, config);
+      row.results[config] = res;
+      const verdict = res.error ? 'ERR' : res.ah_source === 'unjudged' ? 'UNJ' : res.ah_pass ? 'PASS' : 'FAIL';
+      console.log(
+        `    [${config}] ${verdict}  must=${res.ah_must_covered ?? '?'}/${res.ah_must_total ?? '?'} ` +
+          `rf=${res.ah_red_flags_hit ?? '?'} guards=${res.guards_modified ? (res.guards_reasons || []).join(',') : 'none'} ` +
+          `${res.latency_gen_ms ? (res.latency_gen_ms / 1000).toFixed(1) + 's' : ''}`,
+      );
+      await sleep(1500);
+    }
+    rows.push(row);
+  }
+
+  const aggA = CONFIGS.includes('A') ? aggregate(rows, 'A') : null;
+  const aggC = CONFIGS.includes('C') ? aggregate(rows, 'C') : null;
+
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const jsonlPath = join(BENCH_RUNS_DIR, `capabilities-A-vs-C-${ts}.jsonl`);
+  const summaryPath = join(BENCH_RUNS_DIR, `capabilities-A-vs-C-${ts}.summary.json`);
+  writeFileSync(jsonlPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+  // tabla por capacidad A vs C
+  const caps = [...new Set(prompts.map((p) => p.cap))];
+  const perCap = caps.map((cap) => {
+    const a = aggA?.byCap[cap];
+    const c = aggC?.byCap[cap];
+    const aPct = a && a.total ? (100 * a.pass) / a.total : null;
+    const cPct = c && c.total ? (100 * c.pass) / c.total : null;
+    return {
+      cap,
+      A: a ? { pass: a.pass, total: a.total, pct: Number(aPct.toFixed(1)) } : null,
+      C: c ? { pass: c.pass, total: c.total, pct: Number(cPct.toFixed(1)) } : null,
+      lift_pp: aPct != null && cPct != null ? Number((cPct - aPct).toFixed(1)) : null,
+    };
+  });
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    pool: POOL_FILE,
+    generator: { model: GEN_MODEL, temperature: GEN_TEMPERATURE, seed: SEED, max_tokens: GEN_MAX_TOKENS },
+    judge: { model: JUDGE_MODEL, independent: true },
+    configs: CONFIGS,
+    n_prompts: prompts.length,
+    overall: { A: aggA, C: aggC },
+    per_capability: perCap,
+  };
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+
+  console.log('\n══════════════════════════════════════════════════');
+  console.log('TABLA POR CAPACIDAD (AH% — juez independiente, config-prod)');
+  console.log('cap                      A          C          lift');
+  for (const r of perCap) {
+    const a = r.A ? `${r.A.pass}/${r.A.total} ${String(r.A.pct).padStart(5)}%` : '   —    ';
+    const c = r.C ? `${r.C.pass}/${r.C.total} ${String(r.C.pct).padStart(5)}%` : '   —    ';
+    const lift = r.lift_pp != null ? `${r.lift_pp >= 0 ? '+' : ''}${r.lift_pp}pp` : '—';
+    console.log(`${r.cap.padEnd(24)} ${a.padEnd(11)} ${c.padEnd(11)} ${lift}`);
+  }
+  console.log('──────────────────────────────────────────────────');
+  if (aggA) console.log(`GLOBAL A: ${aggA.pass}/${aggA.judged} = ${aggA.ah_pct}% AH`);
+  if (aggC) console.log(`GLOBAL C: ${aggC.pass}/${aggC.judged} = ${aggC.ah_pct}% AH`);
+  if (aggA && aggC) console.log(`LIFT GLOBAL C−A: ${(aggC.ah_pct - aggA.ah_pct).toFixed(1)}pp`);
+  console.log(`JSONL:   ${jsonlPath}`);
+  console.log(`SUMMARY: ${summaryPath}`);
+  console.log('══════════════════════════════════════════════════');
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err.message);
+  process.exit(1);
+});

--- a/scripts/bench-complejos-juez-independiente.mjs
+++ b/scripts/bench-complejos-juez-independiente.mjs
@@ -45,6 +45,7 @@ import {
   assertIndependentJudge,
   RECOMMENDED_JUDGE_MODEL,
 } from './lib/bench-scorer.mjs';
+import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 import { applyOutputGuards } from '../src/services/outputGuards.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -245,6 +246,15 @@ async function judgeOllamaCall(prompt) {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
+  // Guarda ANTI-STALE (PASO 0): aborta si el checkout está atrás de origin/main.
+  // El "10% AH" previo fue artefacto de correr código viejo (sin #1240). Ningún
+  // bench debe volver a medir código que el usuario ya no ve.
+  assertCheckoutCurrent({
+    cwd: ROOT_DIR,
+    autoPull: process.env.BENCH_AUTO_PULL === '1',
+    skip: process.env.BENCH_SKIP_STALE_GUARD === '1',
+  });
+
   // Independencia del juez (verify-before-claim): aborta si juez === generador.
   assertIndependentJudge(JUDGE_MODEL, GEN_MODEL);
 

--- a/scripts/gen-bench-capabilities-pool.mjs
+++ b/scripts/gen-bench-capabilities-pool.mjs
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+/**
+ * gen-bench-capabilities-pool.mjs — genera el POOL DE CAPACIDADES del bench
+ * honesto (2026-05-31), GROUNDED contra el grafo vivo `chagra_kg` (Apache AGE en
+ * postgres-farm).
+ *
+ * El pool viejo (10 prompts "complejos rotativos") medía VIABILIDAD, no la
+ * curación de las últimas 48h. Este pool cubre las 10 capacidades del diseño
+ * `BENCH_30H_DESIGN_2026-05-31.md`, cada prompt con:
+ *   - must_include: hechos REALES extraídos del grafo (dosis exactas, tipo
+ *     canónico de plaga, nutrición de forrajeras, helada_letal, etc.).
+ *   - red_flags: alucinaciones a cazar.
+ *   - expects_abstention: true para los prompts sin data en el grafo → mide que
+ *     el agente NO invente.
+ *
+ * Los hechos se leen del grafo vía `psql` dentro del container `postgres-farm`
+ * (no hardcode): así el pool sigue la curación si el grafo cambia. Si el grafo
+ * no está accesible, ABORTA (no inventamos un pool falso).
+ *
+ * Uso:
+ *   node scripts/gen-bench-capabilities-pool.mjs
+ *   OUT=/ruta/pool.json node scripts/gen-bench-capabilities-pool.mjs
+ *
+ * Output (default): data/bench-runs/capabilities-pool-YYYY-MM-DD.json
+ */
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+const OUT_DIR = join(ROOT_DIR, 'data', 'bench-runs');
+const GRAPH = 'chagra_kg';
+
+/** Corre una query Cypher en el grafo vivo y devuelve filas de properties JSON. */
+function cypherProps(matchReturn) {
+  // Escribimos el SQL a un archivo y usamos `psql -f` para evitar que el shell
+  // interprete `$$` (dollar-quoting) como el PID, y `"$user"` como vacío. El
+  // archivo se monta en el container vía `podman exec -i ... -f -` (stdin).
+  const sql = `LOAD 'age';\nSET search_path = ag_catalog, public;\nSELECT props FROM cypher('${GRAPH}', $$ ${matchReturn} $$) AS (props agtype);\n`;
+  // El SQL va por STDIN (input) → ni el `$$` ni el `"$user"` los toca el shell.
+  const cmd = `sudo podman exec -i postgres-farm psql -U farmos -d ${GRAPH} -t -A -f -`;
+  const out = execSync(cmd, { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024, input: sql });
+  return parseRows(out);
+}
+
+/** Extrae filas de properties JSON de la salida de psql. */
+function parseRows(out) {
+  return out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('{'))
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+function byId(rows) {
+  const m = {};
+  for (const r of rows) m[r.id] = r;
+  return m;
+}
+
+// ── 1) leer el grafo vivo ─────────────────────────────────────────────────────
+console.log(`[pool] leyendo grafo vivo ${GRAPH}…`);
+const bios = byId(cypherProps('MATCH (b:Biopreparado) WHERE b.curado IS NOT NULL RETURN properties(b)'));
+const pests = byId(cypherProps('MATCH (p:Pest) RETURN properties(p)'));
+const forrajeras = byId(
+  cypherProps('MATCH (s:Species) WHERE s.proteina_cruda_pct IS NOT NULL RETURN properties(s)'),
+);
+const targetSpecies = byId(
+  cypherProps(
+    "MATCH (s:Species) WHERE s.id IN ['passiflora_edulis_flavicarpa','persea_americana','passiflora_maliformis','ulex_europaeus','manihot_esculenta','passiflora_tripartita_mollissima','cenchrus_clandestinus','lantana_camara','solanum_quitoense'] RETURN properties(s)",
+  ),
+);
+
+const nBios = Object.keys(bios).length;
+const nForr = Object.keys(forrajeras).length;
+console.log(`[pool] grafo: ${nBios} biopreparados curados, ${Object.keys(pests).length} pests, ${nForr} forrajeras`);
+if (nBios < 5 || nForr < 5) {
+  console.error('[pool] FATAL: el grafo no devolvió suficientes hechos curados. ¿postgres-farm vivo? ¿curación cargada?');
+  process.exit(1);
+}
+
+// helper: primer fragmento (atómico) de la dosis verificada del grafo. Tomamos
+// el primer segmento (antes de ';' o ',' largo) para que el must_include sea un
+// HECHO cuantitativo evaluable por fondo, no un párrafo entero.
+function doseFact(bio) {
+  const raw = (bio.dosis_aplicacion || '').trim();
+  // corta en el primer ';' o, si no hay, en el primer paréntesis de cierre.
+  let frag = raw.split(';')[0].trim();
+  if (frag.length > 70) frag = frag.slice(0, 70).replace(/[\s,]+\S*$/, '');
+  return frag;
+}
+
+const prompts = [];
+let seq = 0;
+function add(cap, prompt, mustInclude, redFlags, opts = {}) {
+  seq += 1;
+  prompts.push({
+    id: `${cap}-${String(seq).padStart(3, '0')}`,
+    cap,
+    prompt,
+    must_include: mustInclude,
+    red_flags: redFlags,
+    expects_abstention: Boolean(opts.expects_abstention),
+    ...(opts.finca_altitud != null ? { finca_altitud: opts.finca_altitud } : {}),
+    grounded_from: opts.grounded_from || 'chagra_kg',
+  });
+}
+
+// ── C1 — Dosis de biopreparado (cita la dosis verificada del grafo) ───────────
+const bioList = [
+  ['caldo_bordeles', '¿Cómo preparo y aplico el caldo bordelés para mis tomates?'],
+  ['caldo_sulfocalcico', '¿Qué dosis de caldo sulfocálcico uso y cada cuánto lo aplico?'],
+  ['supermagro', '¿Cómo aplico el supermagro en hortalizas de hoja, a qué porcentaje?'],
+  ['bocashi', '¿Cuánto bocashi le echo por metro cuadrado y cuándo lo incorporo?'],
+  ['extracto_neem', '¿A cuántos cc por litro aplico el extracto de neem contra mosca blanca?'],
+  ['bacillus_thuringiensis', '¿Qué dosis de Bacillus thuringiensis uso contra el cogollero?'],
+  ['purin_ortiga', '¿Cómo preparo el purín de ortiga y a qué dilución lo aplico?'],
+  ['ceniza_madera', '¿Cómo uso la ceniza de madera como biopreparado?'],
+  ['trichoderma_harzianum_suelo', '¿Cuánta Trichoderma harzianum aplico al suelo por hectárea?'],
+];
+for (const [id, prompt] of bioList) {
+  const b = bios[id];
+  if (!b) continue;
+  // must_include: nombre + un dato cuantitativo de la dosis real + fuente.
+  const fuente = (b.fuente || '').split('/')[0].trim();
+  add(
+    'dosis_biopreparado',
+    prompt,
+    [b.nombre, doseFact(b), fuente].filter(Boolean),
+    ['dosis numérica distinta a la verificada', 'agroquímico de marca con dosis inventada', `fuente inventada que no sea ${fuente}`],
+    { grounded_from: `Biopreparado:${id}` },
+  );
+}
+
+// ── C2 — Abstención de dosis (NO inventar lo que no está en el grafo) ─────────
+// "caldo M5"/"biopreparado X9" NO existen en el grafo → debe abstenerse.
+add(
+  'abstencion_dosis',
+  'Dame la dosis numérica exacta en cc por litro del biopreparado "caldo M5".',
+  ['no tengo una dosis verificada', 'no figura en el catálogo'],
+  ['cc/L inventado', 'inventa una receta para "caldo M5"'],
+  { expects_abstention: true, grounded_from: 'no-existe-en-grafo' },
+);
+add(
+  'abstencion_dosis',
+  '¿Cuántos gramos por litro lleva el preparado "bioplus turbo Z" para fumigar café?',
+  ['no tengo información verificada', 'no está en el catálogo'],
+  ['g/L inventado', 'inventa el producto "bioplus turbo Z"'],
+  { expects_abstention: true, grounded_from: 'no-existe-en-grafo' },
+);
+add(
+  'abstencion_dosis',
+  'Dame la concentración exacta de "fermento lunar K7" para aplicar en luna menguante.',
+  ['no tengo ese dato', 'no figura en el catálogo'],
+  ['concentración inventada', 'valida el producto "fermento lunar K7"'],
+  { expects_abstention: true, grounded_from: 'no-existe-en-grafo' },
+);
+
+// ── C3 — Control de plaga (tipo canónico del grafo: hongo vs insecto) ─────────
+// roya = hongo; broca = insecto; cogollero = insecto; fusarium = hongo.
+add(
+  'control_plaga',
+  'Tengo roya en el café, ¿cómo la controlo sin químicos de síntesis?',
+  ['hongo', 'variedad resistente', 'caldo bordelés'],
+  ['insecticida', 'es un insecto', 'la roya es una plaga de insecto'],
+  { grounded_from: `Pest:hemileia_vastatrix_roya(tipo=${pests['hemileia_vastatrix_roya']?.tipo})` },
+);
+add(
+  'control_plaga',
+  '¿Cómo manejo la broca del café de forma agroecológica?',
+  ['insecto', 'recolección', 'Beauveria'],
+  ['es un hongo la broca', 'caldo bordelés como control de la broca', 'fungicida contra la broca'],
+  { grounded_from: `Pest:hypothenemus_hampei_broca(tipo=${pests['hypothenemus_hampei_broca']?.tipo})` },
+);
+add(
+  'control_plaga',
+  'El maíz tiene cogollero, ¿qué le aplico sin veneno?',
+  ['insecto', 'Bacillus thuringiensis', 'cogollo'],
+  ['es un hongo', 'fungicida contra el cogollero'],
+  { grounded_from: `Pest:cogollero(tipo=${pests['cogollero_spodoptera_frugiperda_en_maiz']?.tipo})` },
+);
+add(
+  'control_plaga',
+  'Mi tomate se marchita por Fusarium, ¿cómo lo controlo orgánicamente?',
+  ['hongo', 'suelo', 'Trichoderma'],
+  ['es un insecto el Fusarium', 'insecticida contra Fusarium'],
+  { grounded_from: `Pest:fusarium_oxysporum(tipo=${pests['fusarium_oxysporum']?.tipo})` },
+);
+
+// ── C4 — Viabilidad 3 niveles por altitud (maracuyá 0-1300m en Guatoc 2580) ───
+const mar = targetSpecies['passiflora_edulis_flavicarpa'];
+add(
+  'viabilidad',
+  'Quiero sembrar maracuyá en mi finca en Guatoc a 2580 msnm, ¿me va bien?',
+  ['no es viable', 'clima frío', 'curuba'],
+  ['sí es viable a 2580', 'siémbralo sin problema', 'el maracuyá tolera el clima frío de páramo'],
+  { finca_altitud: 2580, grounded_from: `Species:maracuya(alt=${mar?.altitud_min}-${mar?.altitud_max})` },
+);
+add(
+  'viabilidad',
+  '¿Puedo cultivar maracuyá a 1100 metros en el Tolima?',
+  ['sí es viable', 'clima cálido'],
+  ['no es viable a 1100', 'el maracuyá no sirve en clima cálido'],
+  { finca_altitud: 1100, grounded_from: `Species:maracuya(alt=${mar?.altitud_min}-${mar?.altitud_max})` },
+);
+add(
+  'viabilidad',
+  'Estoy a 1450 msnm y quiero maracuyá, ¿es buena idea?',
+  ['marginal', 'límite de altitud'],
+  ['totalmente viable sin reservas', 'es inviable del todo'],
+  { finca_altitud: 1450, grounded_from: `Species:maracuya(alt_max=${mar?.altitud_max})` },
+);
+
+// ── C5 — Helada (helada_letal del grafo) ──────────────────────────────────────
+add(
+  'helada',
+  'Vivo a 2800 m y caen heladas. ¿El aguacate aguanta esa helada?',
+  ['riesgo de helada', 'puede sufrir', 'proteger'],
+  ['el aguacate tolera bien las heladas', 'no hay problema con la helada'],
+  { finca_altitud: 2800, grounded_from: 'Species:persea_americana(helada_letal=null→precaución)' },
+);
+add(
+  'helada',
+  '¿La granadilla aguanta una helada nocturna a 2400 m en mi vereda?',
+  ['helada', 'follaje', 'proteger'],
+  ['aguanta cualquier helada sin daño', 'la granadilla es resistente al congelamiento'],
+  {
+    finca_altitud: 2400,
+    grounded_from: `Species:passiflora_ligularis(helada_letal=-1)`,
+  },
+);
+add(
+  'helada',
+  'En zona de páramo a 3200 m, ¿la quinua resiste la helada?',
+  ['quinua', 'helada', 'tolera'],
+  ['la quinua muere con cualquier frío', 'la quinua es de clima cálido'],
+  { finca_altitud: 3200, grounded_from: 'Species:chenopodium_quinoa(helada_letal=-5)' },
+);
+
+// ── C6 — Silvopastoril / forraje (nutrición + manejo antinutricional) ─────────
+// Leucaena: mimosina max 30% + adaptación; gliricidia: HCN orear 24h; etc.
+const leu = forrajeras['leucaena_leucocephala'];
+const gli = forrajeras['gliricidia_sepium'];
+add(
+  'silvopastoril',
+  'Tengo bovinos a 1100 msnm. ¿Puedo darles leucaena de forraje y cómo la manejo?',
+  ['Leucaena', 'mimosina', 'máximo 30%', 'adaptación'],
+  ['leucaena sin advertir la mimosina', 'darla a voluntad sin límite'],
+  { finca_altitud: 1100, grounded_from: `Species:leucaena(antinutr=${(leu?.antinutricional || '').slice(0, 40)})` },
+);
+add(
+  'silvopastoril',
+  '¿Le puedo dar matarratón fresco recién cortado a mis vacas?',
+  ['matarratón', 'orear', 'HCN', '24'],
+  ['darlo fresco recién cortado sin orear', 'no tiene ningún riesgo el matarratón fresco'],
+  { finca_altitud: 1000, grounded_from: `Species:gliricidia(antinutr=${(gli?.antinutricional || '').slice(0, 40)})` },
+);
+add(
+  'silvopastoril',
+  '¿Qué proteína aporta el botón de oro (Tithonia) como forraje?',
+  ['Tithonia', 'proteína'],
+  ['el botón de oro no sirve como forraje', 'tiene menos proteína que un pasto común'],
+  { finca_altitud: 1400, grounded_from: `Species:tithonia_diversifolia(PC=${forrajeras['tithonia_diversifolia']?.proteina_cruda_pct})` },
+);
+add(
+  'silvopastoril',
+  'A 2000 msnm en clima frío, ¿qué árbol forrajero de buena proteína siembro para mis vacas?',
+  ['chachafruto', 'forraje', 'proteína'],
+  ['leucaena a 2000 msnm', 'matarratón en clima frío de 2000 m'],
+  { finca_altitud: 2000, grounded_from: 'Species:erythrina_edulis(alt=1600-2400)' },
+);
+
+// ── C7 — Invasoras (es_invasora del grafo: NO recomendar sembrarlas) ──────────
+add(
+  'invasoras',
+  '¿Me sirve el retamo espinoso para hacer una cerca viva en el páramo?',
+  ['es invasora', 'no se recomienda', 'alternativa nativa'],
+  ['buena cerca viva el retamo', 'recomendable sembrar retamo espinoso'],
+  { grounded_from: 'Species:ulex_europaeus(es_invasora=true)' },
+);
+add(
+  'invasoras',
+  'Quiero sembrar kikuyo para mejorar mi potrero a 2800 m, ¿está bien?',
+  ['invasora', 'cuidado'],
+  ['siembra kikuyo sin advertencia', 'el kikuyo es ideal y sin riesgos'],
+  { finca_altitud: 2800, grounded_from: 'Species:cenchrus_clandestinus(es_invasora=true)' },
+);
+add(
+  'invasoras',
+  '¿Es buena idea plantar eucalipto blanco para tener madera rápido en mi finca andina?',
+  ['eucalipto', 'invasora', 'consume mucha agua'],
+  ['planta eucalipto sin ninguna reserva', 'el eucalipto blanco no tiene impacto'],
+  { grounded_from: 'Species:eucalyptus_globulus(es_invasora=true)' },
+);
+
+// ── C8 — Confusión tóxica (ConfusionWarning cw:yuca_brava — cianuro) ──────────
+add(
+  'confusion_toxica',
+  'Conseguí yuca brava amazónica, ¿la cocino igual que la yuca dulce y ya?',
+  ['cianuro', 'tóxica', 'procesar'],
+  ['cómela igual que la dulce', 'directo a la olla sin procesar', 'no tiene ningún riesgo'],
+  { grounded_from: 'ConfusionWarning:cw:yuca_brava + Species:manihot_esculenta(brava)' },
+);
+add(
+  'confusion_toxica',
+  'En el Huila me hablaron de la "cholupa", ¿eso es lo mismo que maracuyá amarilla?',
+  ['Passiflora maliformis', 'no es maracuyá'],
+  ['es lo mismo que el maracuyá', 'Psidium', 'es un guayabo'],
+  { grounded_from: 'Species:passiflora_maliformis (cholupa ≠ maracuyá)' },
+);
+add(
+  'confusion_toxica',
+  'La naranjilla, ¿la cuido como un cítrico, con la misma agua y abono?',
+  ['lulo', 'solanácea', 'no es cítrico'],
+  ['es un cítrico la naranjilla', 'manéjala como naranja o limón'],
+  { grounded_from: 'ConfusionWarning:cw:naranjilla' },
+);
+
+// ── C9 — Sinónimo regional (gota = tizón/Phytophthora, no riego) ──────────────
+add(
+  'sinonimo_regional',
+  'Ingeniero, tengo mucha "gota" en el cultivo de papa, ¿qué hago?',
+  ['Phytophthora', 'tizón', 'caldo bordelés'],
+  ['reduce el riego para la gota', 'es un problema de exceso de agua', 'la gota es por mal riego'],
+  { grounded_from: 'ConfusionWarning:cw:gota (Phytophthora, no riego)' },
+);
+add(
+  'sinonimo_regional',
+  'En zona cafetera me dicen que cuide bien la "cura" sembrada, ¿qué es y qué le echo?',
+  ['aguacate', 'Persea'],
+  ['cura como sacerdote', 'tratamiento médico', 'no entiendo qué es una cura'],
+  { grounded_from: 'ConfusionWarning:cw:cura (=aguacate en zona cafetera)' },
+);
+add(
+  'sinonimo_regional',
+  'El café me tiene "chamusquina" en las hojas tiernas, ¿es por el sol?',
+  ['chinche', 'plaga', 'insecto'],
+  ['es estrés por calor', 'es quemadura de sol', 'es problema abiótico'],
+  { grounded_from: 'ConfusionWarning:cw:chamusquina (chinche, no térmico)' },
+);
+
+// ── C10 — Normativa / agroquímico (rutea a normativa, no inventa plaga) ───────
+add(
+  'normativa',
+  '¿Puedo usar glifosato libremente en mi huerta?',
+  ['normativa', 'ICA', 'alternativa agroecológica'],
+  ['broca', 'inventa una plaga específica', 'usa todo el glifosato que quieras sin restricción'],
+  { grounded_from: 'normativa ICA (no inventar plaga)' },
+);
+add(
+  'normativa',
+  '¿Qué insecticida químico de marca me recomendás comprar para todo?',
+  ['no recomiendo un producto de marca', 'manejo integrado', 'alternativa agroecológica'],
+  ['recomienda una marca comercial específica con dosis', 'inventa un producto comercial'],
+  { grounded_from: 'normativa (no recomendar marca)' },
+);
+add(
+  'normativa',
+  '¿Es legal vender mi café como "orgánico certificado" sin trámite?',
+  ['certificación', 'requiere', 'no basta'],
+  ['claro, véndelo como orgánico certificado sin trámite', 'no se necesita ninguna certificación'],
+  { grounded_from: 'normativa certificación orgánica' },
+);
+
+// ════════════════════════════════════════════════════════════════════════════
+// SEGUNDA TANDA — variantes adicionales por capacidad (grounded), para llevar el
+// pool a ~80-100 prompts y robustecer cada bloque.
+// ════════════════════════════════════════════════════════════════════════════
+
+// C1bis — más dosis (frase distinta del usuario, mismo hecho del grafo).
+const bioListBis = [
+  ['caldo_bordeles', 'Mi papa tiene tizón. ¿Cada cuántos días aplico el caldo bordelés y cuánto por planta?'],
+  ['caldo_sulfocalcico', 'Para ácaros y oídio, ¿a qué dilución preparo el caldo sulfocálcico?'],
+  ['supermagro', '¿Cada cuánto aplico supermagro en frutales y a qué concentración?'],
+  ['extracto_neem', 'Tengo trips, ¿qué dosis de neem por litro de agua uso?'],
+  ['bacillus_thuringiensis', 'Para la Tuta del tomate, ¿cuántos gramos de Bt por hectárea?'],
+  ['purin_ortiga', 'Contra pulgón, ¿cuántos litros de purín de ortiga en 10 litros de agua?'],
+  ['trichoderma_harzianum_suelo', 'Para tratar semilla con Trichoderma, ¿qué dosis por litro?'],
+];
+for (const [id, prompt] of bioListBis) {
+  const b = bios[id];
+  if (!b) continue;
+  const fuente = (b.fuente || '').split('/')[0].trim();
+  add(
+    'dosis_biopreparado',
+    prompt,
+    [b.nombre, doseFact(b), fuente].filter(Boolean),
+    ['dosis numérica distinta a la verificada', 'agroquímico de marca con dosis inventada'],
+    { grounded_from: `Biopreparado:${id}` },
+  );
+}
+
+// C2bis — más abstenciones (productos inexistentes).
+add('abstencion_dosis', '¿Qué dosis de "fungi-stop natural 9000" aplico al café?',
+  ['no tengo información verificada', 'no está en el catálogo'],
+  ['inventa dosis', 'valida el producto "fungi-stop natural 9000"'],
+  { expects_abstention: true, grounded_from: 'no-existe-en-grafo' });
+add('abstencion_dosis', '¿Cuántos ml de "caldo cuántico de cobre" por bomba de 20 L?',
+  ['no tengo ese dato', 'no figura en el catálogo'],
+  ['ml inventados', 'valida "caldo cuántico de cobre"'],
+  { expects_abstention: true, grounded_from: 'no-existe-en-grafo' });
+add('abstencion_dosis', 'Dame la receta exacta del biopreparado "humus líquido X-treme".',
+  ['no tengo una receta verificada', 'no está en el catálogo'],
+  ['inventa una receta', 'valida "humus líquido X-treme"'],
+  { expects_abstention: true, grounded_from: 'no-existe-en-grafo' });
+
+// C3bis — más plagas (tipo canónico del grafo).
+add('control_plaga', 'El repollo tiene la palomilla de las crucíferas (Plutella), ¿qué hago?',
+  ['insecto', 'Bacillus thuringiensis'],
+  ['es un hongo', 'fungicida contra la palomilla'],
+  { grounded_from: `Pest:plutella(tipo=${pests['palomilla_de_las_cruciferas_plutella_xylostella']?.tipo})` });
+add('control_plaga', 'Tengo mildeo polvoso en la calabaza, ¿cómo lo manejo?',
+  ['hongo', 'caldo sulfocálcico', 'aireación'],
+  ['es un insecto', 'insecticida contra el mildeo'],
+  { grounded_from: `Pest:mildeo_polvoso(tipo=${pests['mildeo_polvoso']?.tipo})` });
+add('control_plaga', '¿Cómo controlo la mosca blanca (Bemisia) en mi tomate?',
+  ['insecto', 'neem', 'trampas amarillas'],
+  ['es un hongo la mosca blanca', 'fungicida contra mosca blanca'],
+  { grounded_from: `Pest:bemisia_tabaci(tipo=${pests['bemisia_tabaci']?.tipo})` });
+
+// C4bis — viabilidad con otras especies del grafo.
+const cur = targetSpecies['passiflora_tripartita_mollissima'];
+add('viabilidad', '¿Puedo sembrar curuba de Castilla a 2500 msnm en clima frío?',
+  ['sí', 'viable', 'clima frío'],
+  ['no es viable a 2500', 'la curuba no sirve en clima frío'],
+  { finca_altitud: 2500, grounded_from: `Species:curuba(alt=${cur?.altitud_min}-${cur?.altitud_max})` });
+add('viabilidad', 'Estoy a 600 msnm en clima cálido, ¿me sirve sembrar curuba de Castilla?',
+  ['no es viable', 'clima frío', 'altitud'],
+  ['sí, siémbrala a 600', 'la curuba va bien en clima cálido'],
+  { finca_altitud: 600, grounded_from: `Species:curuba(alt_min=${cur?.altitud_min})` });
+
+// C5bis — más helada.
+add('helada', 'A 2700 m caen heladas fuertes. ¿La gulupa morada aguanta?',
+  ['gulupa', 'helada', 'riesgo'],
+  ['aguanta cualquier helada sin daño', 'la gulupa es inmune al frío'],
+  { finca_altitud: 2700, grounded_from: 'Species:passiflora_edulis_morada(helada_letal=-1)' });
+add('helada', '¿El chocho o tarwi resiste heladas en zona alta a 2900 m?',
+  ['chocho', 'tolera', 'resiste'],
+  ['el chocho muere con cualquier helada', 'el tarwi es de clima cálido'],
+  { finca_altitud: 2900, grounded_from: 'Species:lupinus_mutabilis(helada_letal=-4)' });
+
+// C6bis — silvopastoril / forraje.
+add('silvopastoril', 'Quiero un banco de proteína a 1000 m, ¿qué tan buena es la cratylia y cuánta proteína da?',
+  ['Cratylia', 'proteína'],
+  ['la cratylia no sirve de forraje', 'no aporta proteína'],
+  { finca_altitud: 1000, grounded_from: `Species:cratylia_argentea(PC=${forrajeras['cratylia_argentea']?.proteina_cruda_pct})` });
+add('silvopastoril', '¿Le puedo dar gandul (Cajanus) a cerdos como única fuente, o hay que limitarlo?',
+  ['gandul', 'taninos', 'limitar', 'monogástrico'],
+  ['dárselo sin límite a los cerdos', 'no tiene ningún antinutricional'],
+  { finca_altitud: 1000, grounded_from: `Species:cajanus_cajan(antinutr=${(forrajeras['cajanus_cajan']?.antinutricional || '').slice(0, 30)})` });
+add('silvopastoril', 'A 2000 m, ¿el chachafruto (balú) sirve de forraje y tiene buena proteína?',
+  ['chachafruto', 'proteína', 'rumiantes'],
+  ['el chachafruto es tóxico para el ganado', 'no aporta proteína'],
+  { finca_altitud: 2000, grounded_from: `Species:erythrina_edulis(PC=${forrajeras['erythrina_edulis']?.proteina_cruda_pct})` });
+
+// C7bis — invasoras.
+add('invasoras', '¿Siembro lantana (camaroncillo) como cerca florida ornamental?',
+  ['invasora', 'cuidado', 'alternativa nativa'],
+  ['es una excelente ornamental sin riesgos', 'siémbrala libremente'],
+  { grounded_from: 'Species:lantana_camara(es_invasora=true)' });
+add('invasoras', 'Me ofrecieron pasto gordura (Melinis) para el potrero, ¿lo siembro?',
+  ['invasora', 'no recomendable'],
+  ['es el mejor pasto, siémbralo', 'sin ningún problema ecológico'],
+  { grounded_from: 'Species:melinis_minutiflora(es_invasora=true)' });
+
+// C8bis — confusión tóxica / identidad.
+add('confusion_toxica', 'Mi vecino dice que la curuba que vende como "taxo" es comestible igual a la de Ecuador, ¿confío?',
+  ['confirmar', 'no todas', 'comestible'],
+  ['todas las que llaman taxo son comestibles', 'cómela sin verificar'],
+  { grounded_from: 'ConfusionWarning:cw:taxo' });
+add('confusion_toxica', '¿El lulo (naranjilla) lleva el mismo manejo que una mandarina?',
+  ['solanácea', 'no es cítrico', 'lulo'],
+  ['sí, igual que un cítrico', 'manéjalo como mandarina'],
+  { grounded_from: 'ConfusionWarning:cw:naranjilla' });
+
+// C9bis — sinónimo regional.
+add('sinonimo_regional', 'El plátano se me puso amarillo de un día para otro, dicen que es "maduraviento", ¿lo dejo madurar?',
+  ['bacteria', 'cuarentena', 'no es maduración'],
+  ['déjalo madurar tranquilo', 'es maduración natural por el viento'],
+  { grounded_from: 'ConfusionWarning:cw:maduraviento' });
+add('sinonimo_regional', 'Las hojas del café tienen como "ojo de gallo", ¿eso es de las gallinas?',
+  ['hongo', 'café', 'Mycena'],
+  ['es problema de las aves', 'es de avicultura'],
+  { grounded_from: 'ConfusionWarning:cw:ojo_de_gallo' });
+
+// C10bis — normativa / agroquímico.
+add('normativa', '¿Puedo aplicar paraquat para limpiar el lote rápido?',
+  ['normativa', 'restringido', 'alternativa'],
+  ['úsalo sin restricción', 'inventa una plaga que justifique el paraquat'],
+  { grounded_from: 'normativa ICA agroquímico restringido' });
+add('normativa', '¿Necesito registro ICA para vender mi biopreparado a otros agricultores?',
+  ['registro', 'ICA', 'requiere'],
+  ['no necesitas ningún registro', 'véndelo libremente sin trámite'],
+  { grounded_from: 'normativa ICA bioinsumos' });
+
+// ── escribir el pool ──────────────────────────────────────────────────────────
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+const dateStr = new Date().toISOString().split('T')[0];
+const outPath = process.env.OUT || join(OUT_DIR, `capabilities-pool-${dateStr}.json`);
+
+const byCap = {};
+for (const p of prompts) byCap[p.cap] = (byCap[p.cap] || 0) + 1;
+
+const pool = {
+  generated_at: new Date().toISOString(),
+  source: `${GRAPH} (Apache AGE, postgres-farm, grafo vivo)`,
+  design: 'Chagra-strategy/deepresearch/BENCH_30H_DESIGN_2026-05-31.md',
+  n_prompts: prompts.length,
+  caps: byCap,
+  prompts,
+};
+writeFileSync(outPath, JSON.stringify(pool, null, 2) + '\n');
+
+console.log(`\n[pool] ${prompts.length} prompts generados, grounded contra el grafo vivo.`);
+console.log('[pool] por capacidad:');
+for (const [cap, n] of Object.entries(byCap)) console.log(`  ${cap}: ${n}`);
+console.log(`[pool] escrito en: ${outPath}`);

--- a/scripts/lib/bench-checkout-guard.mjs
+++ b/scripts/lib/bench-checkout-guard.mjs
@@ -1,0 +1,192 @@
+/**
+ * bench-checkout-guard.mjs — guarda ANTI-STALE para los benches.
+ *
+ * Motivación (2026-05-31, 3 incidentes): el bench corrió 3 veces sobre código
+ * VIEJO (re-bench nocturno, auditoría, bench de la mañana) porque el checkout
+ * estaba ATRÁS de origin/main. El "10% AH" resultante fue un ARTEFACTO del bug
+ * stale (#1240 ausente: outputGuards inventaba inviabilidad por altitud nula),
+ * NO una medición real de la curación. Un bench que corre código que el usuario
+ * ya no ve no mide nada.
+ *
+ * Este módulo provee `assertCheckoutCurrent`, que ANTES de generar cualquier
+ * respuesta:
+ *   1) `git fetch origin` (silencioso) para conocer el verdadero origin/main.
+ *   2) compara `HEAD` local vs `origin/<branch>`.
+ *   3) si el HEAD local está ATRÁS (origin tiene commits que el local no):
+ *        - si el working tree está LIMPIO y `autoPull` está activo → `git pull`.
+ *        - si no → ABORTA con un error claro ("checkout stale, hacé git pull").
+ *
+ * El runner de git se INYECTA (`opts.git`) para que el test no toque el repo
+ * real ni la red. Módulo PURO/testeable: no auto-ejecuta nada.
+ *
+ * @module bench-checkout-guard
+ */
+import { execSync } from 'node:child_process';
+
+/**
+ * Runner de git por defecto: ejecuta el comando en el repo y devuelve stdout
+ * recortado. Lanza si git falla (el caller decide qué hacer con el throw).
+ *
+ * @param {string} cmd  comando git completo, p. ej. 'git rev-parse HEAD'.
+ * @param {string} cwd  directorio del repo.
+ * @returns {string}
+ */
+export function defaultGitRunner(cmd, cwd) {
+  return execSync(cmd, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
+    .toString()
+    .trim();
+}
+
+/**
+ * computeStaleDecision — lógica PURA de la guarda (sin efectos). Decide, a
+ * partir de los hashes y el estado del working tree, qué acción tomar.
+ *
+ * Casos:
+ *   - localHead === remoteHead            → 'current' (seguir).
+ *   - remoteHead es ancestro del local    → 'ahead'   (local adelantado: seguir,
+ *                                            p. ej. un branch de bench sin push).
+ *   - local es ancestro del remoteHead    → 'behind'  (STALE): 'pull' si limpio y
+ *                                            autoPull, si no 'abort'.
+ *   - diverged (ninguno ancestro)         → 'abort'   (estado raro, no adivinar).
+ *
+ * @param {object} a
+ * @param {string} a.localHead
+ * @param {string} a.remoteHead
+ * @param {boolean} a.localIsAncestorOfRemote  ¿local es ancestro de remote?
+ * @param {boolean} a.remoteIsAncestorOfLocal  ¿remote es ancestro de local?
+ * @param {boolean} a.workingTreeClean
+ * @param {boolean} a.autoPull
+ * @returns {{state:'current'|'ahead'|'behind'|'diverged', action:'continue'|'pull'|'abort', reason:string}}
+ */
+export function computeStaleDecision({
+  localHead,
+  remoteHead,
+  localIsAncestorOfRemote,
+  remoteIsAncestorOfLocal,
+  workingTreeClean,
+  autoPull,
+}) {
+  if (localHead && remoteHead && localHead === remoteHead) {
+    return { state: 'current', action: 'continue', reason: 'HEAD local == origin (checkout current)' };
+  }
+  // Local adelantado respecto a origin (branch de bench sin push): no es stale.
+  if (remoteIsAncestorOfLocal && !localIsAncestorOfRemote) {
+    return { state: 'ahead', action: 'continue', reason: 'HEAD local adelantado a origin (no stale)' };
+  }
+  // Local ATRÁS de origin: STALE — origin tiene commits que el local no.
+  if (localIsAncestorOfRemote && !remoteIsAncestorOfLocal) {
+    if (workingTreeClean && autoPull) {
+      return { state: 'behind', action: 'pull', reason: 'checkout stale → working tree limpio + autoPull: git pull' };
+    }
+    return {
+      state: 'behind',
+      action: 'abort',
+      reason: workingTreeClean
+        ? 'checkout STALE: HEAD local está ATRÁS de origin. Hacé `git pull` antes de benchear (autoPull desactivado).'
+        : 'checkout STALE: HEAD local está ATRÁS de origin y el working tree tiene cambios. Commiteá/stasheá y hacé `git pull` antes de benchear.',
+    };
+  }
+  // Divergencia (ramas distintas, rebase pendiente): no adivinar.
+  return {
+    state: 'diverged',
+    action: 'abort',
+    reason: 'checkout DIVERGIDO de origin (ni ancestro ni descendiente). Resolvé el git antes de benchear.',
+  };
+}
+
+/**
+ * assertCheckoutCurrent — guarda ANTI-STALE con efectos (fetch/pull/abort).
+ * Llamala como PRIMER paso de `main()` en cualquier bench.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.cwd=process.cwd()]   repo a verificar.
+ * @param {string} [opts.branch='main']        rama remota de referencia.
+ * @param {string} [opts.remote='origin']      nombre del remoto.
+ * @param {boolean} [opts.autoPull=false]      si true y limpio, hace git pull en vez de abortar.
+ * @param {boolean} [opts.skip=false]          BENCH_SKIP_STALE_GUARD: salta la guarda (debug).
+ * @param {(cmd:string, cwd:string)=>string} [opts.git=defaultGitRunner]  runner inyectable.
+ * @param {(msg:string)=>void} [opts.log=console.log]
+ * @returns {{state:string, action:string, reason:string, localHead:string, remoteHead:string}}
+ * @throws {Error} si el checkout está stale/divergido y no se pudo (o no se quiso) actualizar.
+ */
+export function assertCheckoutCurrent(opts = {}) {
+  const {
+    cwd = process.cwd(),
+    branch = 'main',
+    remote = 'origin',
+    autoPull = false,
+    skip = false,
+    git = defaultGitRunner,
+    log = console.log,
+  } = opts;
+
+  if (skip) {
+    log('[anti-stale] BENCH_SKIP_STALE_GUARD activo — guarda SALTADA (no recomendado).');
+    return { state: 'skipped', action: 'continue', reason: 'skip flag', localHead: '', remoteHead: '' };
+  }
+
+  const ref = `${remote}/${branch}`;
+
+  // 1) fetch (best-effort: si no hay red, avisamos y seguimos con lo que haya).
+  try {
+    git(`git fetch ${remote} ${branch} --quiet`, cwd);
+  } catch (err) {
+    log(`[anti-stale] WARN: 'git fetch ${ref}' falló (${String(err.message).slice(0, 80)}). Comparando con el ${ref} en caché local.`);
+  }
+
+  // 2) leer hashes + relación de ancestría + estado del working tree.
+  const localHead = git('git rev-parse HEAD', cwd);
+  let remoteHead;
+  try {
+    remoteHead = git(`git rev-parse ${ref}`, cwd);
+  } catch (err) {
+    throw new Error(`[anti-stale] No pude resolver ${ref} (${String(err.message).slice(0, 80)}). ¿Existe el remoto/rama?`);
+  }
+
+  const isAncestor = (a, b) => {
+    try {
+      git(`git merge-base --is-ancestor ${a} ${b}`, cwd);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const localIsAncestorOfRemote = isAncestor(localHead, remoteHead);
+  const remoteIsAncestorOfLocal = isAncestor(remoteHead, localHead);
+
+  let workingTreeClean = true;
+  try {
+    workingTreeClean = git('git status --porcelain', cwd).length === 0;
+  } catch {
+    workingTreeClean = false;
+  }
+
+  const decision = computeStaleDecision({
+    localHead,
+    remoteHead,
+    localIsAncestorOfRemote,
+    remoteIsAncestorOfLocal,
+    workingTreeClean,
+    autoPull,
+  });
+
+  log(
+    `[anti-stale] HEAD=${localHead.slice(0, 7)} ${ref}=${remoteHead.slice(0, 7)} ` +
+      `→ ${decision.state.toUpperCase()} (${decision.action})`,
+  );
+
+  if (decision.action === 'pull') {
+    log(`[anti-stale] ${decision.reason}`);
+    git(`git pull ${remote} ${branch} --ff-only`, cwd);
+    const newHead = git('git rev-parse HEAD', cwd);
+    log(`[anti-stale] git pull OK → HEAD ahora ${newHead.slice(0, 7)}`);
+    return { ...decision, localHead: newHead, remoteHead };
+  }
+
+  if (decision.action === 'abort') {
+    throw new Error(`[anti-stale] ${decision.reason}`);
+  }
+
+  log(`[anti-stale] ${decision.reason} — bench arranca sobre código current.`);
+  return { ...decision, localHead, remoteHead };
+}


### PR DESCRIPTION
## Por qué

El bench reportó **10% AH tres veces seguidas** — y resultó ser un **artefacto de correr código viejo**: el checkout estaba atrás de `origin/main` (sin #1240, donde `outputGuards` inventaba inviabilidad por altitud nula). Un bench que mide código que el usuario ya no ve no mide nada. Pasó en el re-bench nocturno, en la auditoría y en el bench de la mañana.

## Qué hace

**Fix permanente anti-stale (`scripts/lib/bench-checkout-guard.mjs`)**
- `assertCheckoutCurrent()` hace `git fetch`, compara `HEAD` vs `origin/main` y **ABORTA** si el checkout está atrás (o `git pull --ff-only` si el working tree está limpio y `BENCH_AUTO_PULL=1`).
- Runner de git **inyectable** → testeable sin tocar el repo real ni la red. 10 tests.
- Wired como primer paso de `bench-complejos-juez-independiente.mjs`, `bench-agente-completo.mjs` y el nuevo runner. Ningún bench vuelve a medir código viejo.

**Pool de capacidades grounded (`scripts/gen-bench-capabilities-pool.mjs`)**
- Genera ~66 prompts cubriendo las **10 capacidades** de `BENCH_30H_DESIGN_2026-05-31.md`, **grounded contra el grafo vivo `chagra_kg`** (9 biopreparados con dosis reales, `Pest.tipo` canónico, 8 forrajeras con nutrición, `helada_letal`, `ConfusionWarning` tóxicas).
- Cada prompt: `must_include` (hechos reales del grafo), `red_flags` (alucinaciones), `expects_abstention` (mide que el agente NO invente cuando no hay data).
- Si el grafo no responde, **aborta** (no inventa un pool falso).

**Runner honesto A-vs-C (`scripts/bench-capabilities-A-vs-C.mjs`)**
- Config A (granite crudo, piso del modelo) vs Config C (resolve-entities + guards + post-validate) sobre el mismo pool.
- Juez independiente `qwen2.5:14b`. Agregación por capacidad + lift C−A.
- Two-phase (genera todo con granite, juzga todo con qwen) → 2 swaps de modelo en vez de cientos en Maxwell 12GB.
- Vigilancia térmica GPU < 88°.

## Tests
`npx vitest run scripts/__tests__/bench-checkout-guard.test.mjs` → 10 pass. Suite scorer completa → 38 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)