### PR TITLE
fix(guards): prosa española no es binomio — mata falsos positivos 5/5b

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.25",
+  "version": "1.0.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v283';
+const CACHE_NAME = 'chagra-v284';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -1042,7 +1042,63 @@ const EPITHET_STOPWORDS = new Set([
   'de', 'del', 'la', 'el', 'los', 'las', 'un', 'una', 'unos', 'unas',
   'y', 'o', 'u', 'que', 'con', 'sin', 'por', 'para', 'en', 'al', 'a',
   'su', 'sus', 'es', 'son', 'como', 'mas', 'pero', 'este', 'esta', 'ese', 'esa',
+  // Palabras de prosa que aparecían como falso "epíteto" en producción
+  // (2026-06-02, query de precio "¿a cómo está la papa?"): "Sin embargo",
+  // "Estos cultivos", "Marzano debido". El epíteto botánico nunca es un
+  // sustantivo/participio común del español.
+  'embargo', 'cultivos', 'cultivo', 'planta', 'plantas', 'papa', 'papas',
+  'debido', 'mismo', 'misma', 'cuenta', 'ejemplo', 'general', 'caso',
 ]);
+
+/**
+ * Stopwords del español que NO pueden ser GÉNERO de un binomio científico.
+ * El género va capitalizado (inicio de oración, determinante, conector,
+ * fragmento de nombre propio) y `SCI_BINOMIAL_RE` lo captura igual que un
+ * género latino real. El filtro de epíteto solo miraba el SEGUNDO token, así
+ * que "Sin embargo", "Estos cultivos", "La papa", "Marzano debido" pasaban y
+ * los guards 5/5b emitían correcciones absurdas ("...es Alnus acuminata, no
+ * Sin embargo"). Caso real prod 2026-06-02. Comparar en minúsculas sin tildes.
+ */
+const GENUS_STOPWORDS = new Set([
+  // determinantes / artículos / demostrativos
+  'la', 'el', 'los', 'las', 'un', 'una', 'unos', 'unas', 'lo', 'su', 'sus',
+  'mi', 'mis', 'tu', 'tus', 'este', 'esta', 'esto', 'estos', 'estas', 'ese',
+  'esa', 'eso', 'esos', 'esas', 'aquel', 'aquella', 'otro', 'otra', 'otros',
+  'otras', 'cada', 'todo', 'toda', 'todos', 'todas', 'mucho', 'mucha',
+  'muchos', 'muchas', 'algun', 'alguna', 'algunos', 'algunas', 'cualquier',
+  'varios', 'varias',
+  // conjunciones / preposiciones / conectores
+  'sin', 'con', 'por', 'para', 'pero', 'aunque', 'sino', 'mas', 'como',
+  'cuando', 'donde', 'mientras', 'porque', 'pues', 'entonces', 'ademas',
+  'asimismo', 'finalmente', 'recuerda', 'ten', 'segun', 'si', 'no', 'ni',
+  'que', 'quien', 'cual', 'cuales', 'en', 'de', 'del', 'al', 'hasta',
+  'desde', 'sobre', 'entre', 'tras', 'ante', 'bajo',
+  // verbos / adverbios frecuentes en inicio de oración
+  'es', 'son', 'hay', 'esta', 'estan', 'sera', 'puede', 'pueden', 'debe',
+  'deben', 'tiene', 'tienen', 'generalmente', 'normalmente', 'tambien',
+  'solo', 'incluso', 'luego', 'despues', 'ahora', 'aqui', 'alli', 'asi',
+  // fragmentos de nombre común/varietal que se capitalizan
+  'san', 'santa', 'santo', 'marzano',
+]);
+
+/**
+ * ¿El par (género, epíteto) parece un binomio científico latino real y NO
+ * prosa española? Gate compartido por los guards 5 y 5b para no "corregir"
+ * fragmentos de oración. Conservador: ante la duda, rechaza (evita falsos
+ * positivos como "Sin embargo" → solo deja de corregir, nunca alucina).
+ */
+function _looksLikeLatinBinomial(genusRaw, epithetRaw) {
+  const g = _stripDiacritics(genusRaw).toLowerCase();
+  const ep = _stripDiacritics(epithetRaw).toLowerCase();
+  if (GENUS_STOPWORDS.has(g)) return false;
+  if (EPITHET_STOPWORDS.has(ep)) return false;
+  // Los adverbios españoles en -mente jamás son epíteto botánico
+  // ("necesariamente", "generalmente").
+  if (ep.endsWith('mente')) return false;
+  // Epíteto demasiado corto para ser específico latino.
+  if (ep.length < 3) return false;
+  return true;
+}
 
 /**
  * Recolecta TODOS los binomios canónicos que el grounding considera válidos:
@@ -1129,7 +1185,7 @@ export function guardSpeciesSubstitution(responseText, resolvedEntities = null, 
   while ((m = SCI_BINOMIAL_RE.exec(responseText)) !== null) {
     // Descarta "Género preposición" (ej. "Lulo de Castilla" → "Lulo de"): un
     // epíteto botánico nunca es una stopword del español.
-    if (EPITHET_STOPWORDS.has(_stripDiacritics(m[2]))) continue;
+    if (!_looksLikeLatinBinomial(m[1], m[2])) continue;
     const raw = `${m[1]} ${m[2]}`;
     const bin = _binomial(raw);
     if (bin && !grounded.has(bin)) foreign.add(bin);
@@ -1316,7 +1372,7 @@ export function guardCompanionBinomial(responseText, resolvedEntities = null, _f
   let m;
   SCI_BINOMIAL_RE.lastIndex = 0;
   while ((m = SCI_BINOMIAL_RE.exec(responseText)) !== null) {
-    if (EPITHET_STOPWORDS.has(_stripDiacritics(m[2]))) continue;
+    if (!_looksLikeLatinBinomial(m[1], m[2])) continue;
     const bin = _binomial(`${m[1]} ${m[2]}`);
     if (!bin) continue;
     // Si el "binomio" es en realidad un nombre común conocido (capitalizado), no

--- a/tests/unit/outputGuards.test.js
+++ b/tests/unit/outputGuards.test.js
@@ -10,7 +10,10 @@
  * Sigue el patrón de tests/unit/setup.js y usa Vitest.
  */
 import { describe, it, expect } from 'vitest';
-import { guardInvertedViability } from '../../src/services/outputGuards.js';
+import {
+  guardInvertedViability,
+  guardSpeciesSubstitution,
+} from '../../src/services/outputGuards.js';
 
 describe('guardInvertedViability — altitud null (HOTFIX #1240)', () => {
   it('1) altitud null + especie de montaña SIN viabilidad autoritativa → NO dispara', () => {
@@ -78,5 +81,39 @@ describe('guardInvertedViability — altitud null (HOTFIX #1240)', () => {
     // Con altitud válida SÍ menciona los msnm reales.
     expect(res.text).toContain('2580 msnm');
     expect(res.reason).toMatch(/viabilidad_invertida/);
+  });
+});
+
+describe('guardSpeciesSubstitution — prosa española NO es binomio (fix 2026-06-02)', () => {
+  // Caso real prod (query de precio "¿a cómo está la papa?"): el guard tomaba
+  // "Sin embargo", "Estos cultivos", "Marzano debido" como binomios foráneos y
+  // emitía "...es X, no Sin embargo". El gate _looksLikeLatinBinomial lo corta.
+  it('1) "Sin embargo" / "Estos cultivos" NO disparan corrección', () => {
+    const entities = [
+      { kind: 'species', nombre_comun: 'aliso andino', nombre_cientifico: 'Alnus acuminata' },
+    ];
+    const texto =
+      'El aliso andino es un buen árbol de sombra. Sin embargo, necesita suelo húmedo. ' +
+      'Estos cultivos conviven bien con él.';
+    const res = guardSpeciesSubstitution(texto, entities, null);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(texto);
+    expect(res.text).not.toContain('Sin embargo. Ese');
+    expect(res.text).not.toContain('no Sin');
+  });
+
+  it('2) binomio foráneo REAL (Passiflora tripartita atribuido al lulo) SÍ corrige', () => {
+    // No-regresión: el caso para el que se diseñó el guard sigue funcionando.
+    const entities = [
+      { kind: 'species', nombre_comun: 'lulo', nombre_cientifico: 'Solanum quitoense' },
+    ];
+    const texto =
+      'El lulo es una fruta andina; su nombre científico es Passiflora tripartita y ' +
+      'se da bien en clima frío.';
+    const res = guardSpeciesSubstitution(texto, entities, null);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Corrección importante');
+    expect(res.text).toContain('Solanum quitoense');
+    expect(res.reason).toMatch(/sustituci/);
   });
 });


### PR DESCRIPTION
## Bug (prod 2026-06-02)
Query de **precio** "¿a cómo está la papa?" gatilló una cascada de correcciones absurdas:
> Corrección importante: según el catálogo, el aliso andino es Alnus acuminata Kunth, **no Sin embargo**. Ese binomio corresponde a otra planta distinta.

## Causa raíz
`SCI_BINOMIAL_RE` captura `[Capitalizada] [minúscula]` y el filtro de stopwords solo miraba el **epíteto**, nunca el **género**. Así "Sin embargo", "Estos cultivos", "La papa", "Marzano debido" pasaban como binomios foráneos → guards 5 (sustitución) y 5b (companion) emitían correcciones sin sentido.

## Fix
Gate compartido `_looksLikeLatinBinomial(genero, epiteto)`: rechaza género en `GENUS_STOPWORDS`, epíteto en `EPITHET_STOPWORDS` ampliado, adverbios en `-mente`, epítetos <3 chars. Estrictamente **más conservador** — nunca alucina, solo deja de emitir falsos positivos.

El caso legítimo (Passiflora tripartita → lulo) **sigue disparando**. +2 tests regresión, 5/5 verdes, eslint 0.

## Pendiente (NO en este PR, recomendación)
- De-dup de `guardInvertedViability` (4 bloques "NO viable" por variedad de papa).
- Gating por intención: query de precio no debería correr guards de siembra (necesita plomería del query → `applyOutputGuards`).