### PR TITLE
feat(agent): inyecta hechos curados del grafo al grounding (dosis + helada)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.27",
+  "version": "1.0.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v285';
+const CACHE_NAME = 'chagra-v286';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -48,7 +48,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, postValidate, getClimaIdeam } from '../../services/sidecarClient';
-import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
+import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
 import { applyOutputGuards } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
@@ -1105,8 +1105,16 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     const seguridadBlock = buildInvasiveSafetyContext({ resolvedEntities });
     const seguridadContext = seguridadBlock ? `\n\n${seguridadBlock}` : '';
 
+    // HECHOS CURADOS del grafo que la capa "ENTIDADES RESUELTAS" no emite (solo
+    // pasa el nombre canónico): dosis/preparación verificada de biopreparados +
+    // umbral de helada letal de especies. Es el lever anti-alucinación probado
+    // por bench (2026-05-31): sin esto granite inventa la dosis. Cero red, puro
+    // sobre el grounding ya resuelto. Degrada con gracia si no hay hechos.
+    const curatedFactsBlock = buildCuratedFactsContext({ resolvedEntities });
+    const curatedFactsContext = curatedFactsBlock ? `\n\n${curatedFactsBlock}` : '';
+
     const messages = [
-      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + seguridadContext + viabilidadContext + frostHeatContext + asociacionContext + climaContext + fincaContext + queryAnalysisBlock },
+      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + curatedFactsContext + seguridadContext + viabilidadContext + frostHeatContext + asociacionContext + climaContext + fincaContext + queryAnalysisBlock },
       ...(contextMemory ? [{ role: 'user', content: contextMemory }] : []),
       { role: 'user', content: query },
     ];

--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -19,6 +19,7 @@ import {
   buildFrostHeatContext,
   buildAssociationContext,
   buildInvasiveSafetyContext,
+  buildCuratedFactsContext,
   generateAgronomicGuidanceRules,
   pisoTermicoFromAltitud,
   temporadaColombiana,
@@ -1059,6 +1060,92 @@ describe('agentService — Task #202 Profile Context', () => {
       });
       expect(ctx).not.toMatch(/\btenés\b/);
       expect(ctx).not.toMatch(/\bsembrá\b/);
+    });
+  });
+
+  describe('buildCuratedFactsContext', () => {
+    it('devuelve vacío sin entidades o sin hechos curados', () => {
+      expect(buildCuratedFactsContext({ resolvedEntities: null })).toBe('');
+      expect(buildCuratedFactsContext({ resolvedEntities: [] })).toBe('');
+      // especie sin helada_letal ni biopreparado con dosis → nada accionable
+      expect(buildCuratedFactsContext({ resolvedEntities: [{ kind: 'species', nombre_comun: 'Papa' }] })).toBe('');
+      // biopreparado sin dosis ni preparación → nada accionable
+      expect(buildCuratedFactsContext({ resolvedEntities: [{ kind: 'biopreparado', nombre_comun: 'Bocashi' }] })).toBe('');
+    });
+
+    it('biopreparado: CITA la dosis verificada del grafo (no la inventa)', () => {
+      const ctx = buildCuratedFactsContext({
+        resolvedEntities: [
+          {
+            kind: 'biopreparado',
+            nombre_comun: 'Caldo bordelés',
+            dosis_aplicacion: '1-2 L por planta, foliar, cada 8-15 días (preventivo)',
+            preparacion: 'Disolver sulfato de cobre y cal apagada por separado, mezclar.',
+            ingredientes_resumen: 'Sulfato de cobre + cal apagada + agua',
+            target: ['Phytophthora infestans', 'mildiu', 'roya'],
+            precauciones: 'No aplicar en floración; tóxico para abejas.',
+            fuente: 'Agrosavia',
+          },
+        ],
+      });
+      expect(ctx).toContain('Caldo bordelés');
+      expect(ctx).toContain('1-2 L por planta');
+      expect(ctx).toContain('sulfato de cobre');
+      expect(ctx).toContain('Phytophthora infestans');
+      expect(ctx).toContain('abejas');
+      expect(ctx).toContain('Agrosavia');
+      // La regla obliga a CITAR el dato, no inventar
+      expect(ctx).toContain('CITA');
+    });
+
+    it('biopreparado: emite solo los campos presentes (degrada con gracia)', () => {
+      const ctx = buildCuratedFactsContext({
+        resolvedEntities: [
+          { kind: 'biopreparado', nombre_comun: 'Bocashi', dosis_aplicacion: '1-2 kg/m2' },
+        ],
+      });
+      expect(ctx).toContain('Bocashi');
+      expect(ctx).toContain('1-2 kg/m2');
+      // sin preparación/target → no aparecen etiquetas vacías
+      expect(ctx).not.toMatch(/preparación:\s*$/im);
+    });
+
+    it('especie: advierte el umbral de helada_letal del grafo', () => {
+      const ctx = buildCuratedFactsContext({
+        resolvedEntities: [
+          { kind: 'species', nombre_comun: 'Aguacate', helada_letal: -2 },
+        ],
+      });
+      expect(ctx).toContain('Aguacate');
+      expect(ctx).toContain('-2');
+      expect(ctx.toLowerCase()).toContain('helada');
+    });
+
+    it('mezcla especie + biopreparado en un solo bloque', () => {
+      const ctx = buildCuratedFactsContext({
+        resolvedEntities: [
+          { kind: 'species', nombre_comun: 'Papa', helada_letal: -1.5 },
+          { kind: 'biopreparado', nombre_comun: 'Extracto de neem', dosis_aplicacion: '1-1,5 cc/L de agua' },
+        ],
+      });
+      expect(ctx).toContain('Papa');
+      expect(ctx).toContain('Extracto de neem');
+      expect(ctx).toContain('1-1,5 cc/L');
+    });
+
+    it('cero voseo argentino', () => {
+      const ctx = buildCuratedFactsContext({
+        resolvedEntities: [
+          { kind: 'biopreparado', nombre_comun: 'Neem', dosis_aplicacion: '1 cc/L' },
+          { kind: 'species', nombre_comun: 'Papa', helada_letal: -1 },
+        ],
+      });
+      expect(ctx).not.toMatch(/\btenés\b/);
+      expect(ctx).not.toMatch(/\bpodés\b/);
+      expect(ctx).not.toMatch(/\bmirá\b/);
+      expect(ctx).not.toMatch(/\bacá\b/);
+      expect(ctx).not.toMatch(/\bsembrá\b/);
+      expect(ctx).not.toMatch(/\bdale\b/);
     });
   });
 

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -881,6 +881,80 @@ REGLA: jamás recomiendes sembrar una especie marcada arriba. Sé honesto sobre 
 }
 
 /**
+ * buildCuratedFactsContext — inyecta los HECHOS CURADOS del grafo que las demás
+ * capas no emiten, para que el modelo los CITE en vez de inventarlos. Es el
+ * lever de inteligencia probado por bench (2026-05-31): el grounding base solo
+ * pasaba el NOMBRE canónico de la entidad, así que granite improvisaba la dosis
+ * del biopreparado (ej. "caldo bordelés = Tillandsia complanata" en vez de citar
+ * la dosis curada "1-2 L por planta, foliar"). Esta capa cierra ese hueco.
+ *
+ * Emite SOLO lo que las otras capas NO cubren ya (sin duplicar):
+ *   - biopreparado: dosis_aplicacion (dato anti-alucinación CLAVE) + preparacion
+ *     + ingredientes_resumen + target + precauciones + fuente.
+ *   - especie: helada_letal (°C de muerte por frío) — la viabilidad por altitud,
+ *     el riesgo térmico (temp_min/max), companions/antagonists y seguridad de
+ *     invasoras ya los emiten sus propios bloques.
+ *
+ * PURA y SÍNCRONA, CERO latencia: opera sobre los campos que el sidecar
+ * /resolve-entities ya trajo (misma query AGE). Degrada con gracia: si ninguna
+ * entidad trae hechos curados, devuelve '' y no contamina el prompt.
+ *
+ * @param {object} args
+ * @param {Array<object>|null} [args.resolvedEntities] — entidades AGE del turno.
+ *   biopreparado puede traer { dosis_aplicacion, preparacion, ingredientes_resumen,
+ *   target[], precauciones, fuente }; especie puede traer { helada_letal }.
+ * @returns {string} bloque compacto, o '' si no hay nada accionable.
+ */
+export function buildCuratedFactsContext({ resolvedEntities = null } = {}) {
+  if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) return '';
+
+  const _str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+
+  const lineas = [];
+  for (const e of resolvedEntities) {
+    if (!e || typeof e !== 'object') continue;
+    const kind = String(e.kind || '').toLowerCase();
+
+    if (kind === 'biopreparado') {
+      const nombre = e.nombre_comun || e.mentioned || 'ese biopreparado';
+      const dosis = _str(e.dosis_aplicacion);
+      const prep = _str(e.preparacion);
+      const ingredientes = _str(e.ingredientes_resumen);
+      const target = _altNames(e.target, 5);
+      const precauciones = _str(e.precauciones);
+      const fuente = _str(e.fuente);
+      // Sin dosis NI preparación no hay nada anti-alucinación que aportar.
+      if (!dosis && !prep) continue;
+
+      const partes = [];
+      if (dosis) partes.push(`dosis verificada: ${dosis}`);
+      if (ingredientes) partes.push(`ingredientes: ${ingredientes}`);
+      if (prep) partes.push(`preparación: ${prep}`);
+      if (target.length > 0) partes.push(`controla: ${target.join(', ')}`);
+      if (precauciones) partes.push(`precauciones: ${precauciones}`);
+      if (fuente) partes.push(`fuente: ${fuente}`);
+      lineas.push(`- ${nombre} (biopreparado) → ${partes.join('; ')}.`);
+      continue;
+    }
+
+    if (kind === 'species' || kind === 'planta' || kind === 'especie' || kind === 'cultivo' || kind === '') {
+      const helada = e.helada_letal != null && e.helada_letal !== '' ? Number(e.helada_letal) : NaN;
+      if (!Number.isFinite(helada)) continue;
+      const nombre = e.nombre_comun || e.mentioned || 'esa especie';
+      lineas.push(`- ${nombre} (especie) → muere por helada bajo ${helada}°C (dato del catálogo; advierte si la finca puede bajar de ahí).`);
+    }
+  }
+
+  if (lineas.length === 0) return '';
+
+  return `=== HECHOS CURADOS DEL CATÁLOGO (autoritativo, verificado en Apache AGE) ===
+${lineas.join('\n')}
+
+REGLA: si el usuario pregunta por la dosis, preparación o uso de un biopreparado listado arriba, CITA el dato verificado tal cual — JAMÁS inventes una dosis ni una receta. Si el dato no está aquí ni en otro bloque, dilo honestamente en vez de improvisar. Para el umbral de helada, advierte el riesgo solo si es pertinente al clima de la finca.
+=== FIN HECHOS CURADOS ===`;
+}
+
+/**
  * generateAgronomicGuidanceRules — DOCTRINA ESTÁTICA concisa (intelligence-first)
  * que el agente aplica a las 4 dimensiones nuevas (viabilidad 3 niveles, riesgo
  * térmico, asociaciones, diseño de finca) + seguridad de invasoras. Es una


### PR DESCRIPTION
## Qué

El grounding del agente solo inyectaba el **nombre canónico** de cada entidad al system prompt. Para biopreparados tiraba `dosis_aplicacion`/`preparacion`; para especies tiraba `helada_letal`. El sidecar `/resolve-entities` YA devuelve esos campos (los lee del grafo Apache AGE), pero el consumidor los ignoraba.

Consecuencia medida en bench (2026-05-31): granite **inventa la dosis** del biopreparado (ej. "caldo bordelés" respondido como *Tillandsia complanata* en vez de citar la receta curada sulfato+cal), y la capacidad `dosis_biopreparado` quedó en 25% pese a 9 dosis curadas en el grafo.

## Cambios

- **`agentService.js`**: nuevo builder puro y síncrono `buildCuratedFactsContext({ resolvedEntities })`. Emite SOLO los hechos curados que las demás capas NO cubren ya (sin duplicar viabilidad/térmico/asociaciones/seguridad):
  - **biopreparado**: dosis verificada + preparación + ingredientes + target + precauciones + fuente.
  - **especie**: umbral de `helada_letal` (°C de muerte por frío).
  - Regla explícita: **CITA** el dato, JAMÁS inventes dosis/receta; si falta, dilo honesto. Degrada con gracia (devuelve `''` si no hay hechos).
- **`AgentScreen.jsx`**: wireado en `callLLM` justo después del bloque "ENTIDADES RESUELTAS", antes de los bloques de seguridad/viabilidad.

## Tests (TDD, test-first)

6 tests nuevos: dosis citada, degradación parcial (solo campos presentes), helada, mezcla especie+biopreparado, y guard de voseo. Suite completa: 114/114 verde. eslint `--max-warnings=0` limpio en los archivos tocados.

## Nota de despliegue (separado de este PR)

Este PR cubre el **lado consumidor (PWA)**. El sidecar `chagra-pro` ya tiene el código fuente que devuelve estos campos, pero su `dist/` compilado en producción está **STALE** (no incluye la resolución de biopreparados). Requiere `npm run sidecar:build` + `sudo systemctl restart agro-mcp-sidecar` en alpha para que `/resolve-entities` realmente devuelva los biopreparados con dosis. Reportado aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)