### PR TITLE
feat(voseo): cablear region del perfil al filtro region-aware (C1/C2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v287';
+const CACHE_NAME = 'chagra-v288';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -48,7 +48,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, postValidate, getClimaIdeam } from '../../services/sidecarClient';
-import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, stripRoleLeak } from '../../services/agentService';
+import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak } from '../../services/agentService';
 import { applyOutputGuards } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
@@ -1457,11 +1457,14 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
       const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities);
       // DR-LANG-1: filtro post-process anti-voseo argentino. Es la última
-      // línea de defensa estructural — garantiza que ningún marcador
-      // voseo (vos, tenés, querés, dale, acá con contexto fuerte, etc.)
-      // llegue al usuario campesino colombiano, independientemente de lo
-      // que el modelo decida emitir. Default formality='usted'. La
-      // función es idempotente y O(n) sobre el largo del texto.
+      // línea de defensa estructural — garantiza que el léxico rioplatense
+      // (che, laburar, etc.) NUNCA llegue al usuario campesino colombiano,
+      // independientemente de lo que el modelo decida emitir. La función es
+      // idempotente y O(n) sobre el largo del texto.
+      // C1/C2 (2026-06-02): region-aware. Pasamos la región lingüística del
+      // perfil del usuario para que el voseo AUTÉNTICO se preserve donde es el
+      // registro propio (paisa/pacífico/pastuso) y se aplane donde no (tú en
+      // caribe, usted por defecto). Sin región conocida → default seguro.
       // BUG A fix (fuga de roles, prod 2026-05-30): defensa #2 post-proceso.
       // Trunca cualquier turno falso "Usuario:"/"Asistente:" que el modelo
       // haya inventado (el path de streaming del sidecar NO reenvía las stop
@@ -1469,7 +1472,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // cubre el 100% de los casos). Va ANTES del voseo para no analizar
       // basura, y el resultado se persiste/renderea/habla ya saneado.
       const deLeaked = stripRoleLeak(rawResponse);
-      const voseoSafe = applyVoseoFilter(deLeaked, { formality: 'usted' });
+      const voseoSafe = applyVoseoFilter(deLeaked, { formality: 'usted', region: resolveUserRegion() });
       // GUARDAS DETERMINISTAS sobre la SALIDA (bench 10 prompts 2026-05-30: el
       // modelo TIENE los hechos en el grounding pero razona mal —invierte
       // viabilidad, INVENTA agroquímicos sintéticos, recomienda invasoras—).

--- a/src/services/__tests__/agentService.voseoRegion.test.js
+++ b/src/services/__tests__/agentService.voseoRegion.test.js
@@ -1,0 +1,135 @@
+/**
+ * agentService.voseoRegion.test.js — Tareas C1/C2.
+ *
+ * Cablea la región lingüística del perfil del usuario hacia el filtro de
+ * voseo region-aware (voseoFilter.filterVoseo). El engine ya distingue
+ * regiones voseantes (paisa/pacífico/pastuso, donde el voseo es el registro
+ * AUTÉNTICO y se preserva) de las tuteantes (caribe) y ustedeantes (resto).
+ * Lo que faltaba era resolver la región desde el perfil y pasarla en los
+ * call sites. Estos tests cubren:
+ *
+ *   C2 — resolveUserRegion(): del perfil (departamento/municipio/region) a la
+ *        clave de región. Sin señal → null (default seguro).
+ *   C1 — applyVoseoFilter() respeta la región resuelta:
+ *        - usuario de Antioquia (paisa) → su voseo se PRESERVA.
+ *        - usuario de Bogotá (cundiboyacense) → se aplana a usted.
+ *        - usuario sin región → comportamiento default (aplana a usted).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resolveUserRegion, applyVoseoFilter } from '../agentService.js';
+import { saveProfile } from '../userProfileService.js';
+
+describe('C2 — resolveUserRegion (región del perfil)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('sin perfil devuelve null (default seguro)', () => {
+    expect(resolveUserRegion()).toBeNull();
+  });
+
+  it('resuelve paisa desde profile.departamento "Antioquia"', () => {
+    saveProfile({ departamento: 'Antioquia' });
+    expect(resolveUserRegion()).toBe('paisa');
+  });
+
+  it('resuelve cundiboyacense desde profile.departamento "Cundinamarca"', () => {
+    saveProfile({ departamento: 'Cundinamarca' });
+    expect(resolveUserRegion()).toBe('cundiboyacense');
+  });
+
+  it('resuelve cundiboyacense desde el caso especial "Bogotá, D.C."', () => {
+    saveProfile({ departamento: 'Bogotá, D.C.' });
+    expect(resolveUserRegion()).toBe('cundiboyacense');
+  });
+
+  it('resuelve caribe desde el caso especial "La Guajira"', () => {
+    saveProfile({ departamento: 'La Guajira' });
+    expect(resolveUserRegion()).toBe('caribe');
+  });
+
+  it('resuelve pacifico (voseante) desde "Valle del Cauca"', () => {
+    saveProfile({ departamento: 'Valle del Cauca' });
+    expect(resolveUserRegion()).toBe('pacifico');
+  });
+
+  it('resuelve pastuso desde "Nariño" (con tilde)', () => {
+    saveProfile({ departamento: 'Nariño' });
+    expect(resolveUserRegion()).toBe('pastuso');
+  });
+
+  it('cae a municipio cuando no hay departamento directo', () => {
+    // Perfil sin `departamento` pero con `municipio` → findMunicipio resuelve
+    // el departamento del dataset DANE → región.
+    saveProfile({ municipio: 'Medellín' });
+    expect(resolveUserRegion()).toBe('paisa');
+  });
+
+  it('cae a region (texto libre "Municipio, Depto") cuando es lo único disponible', () => {
+    saveProfile({ region: 'Popayán, Cauca' });
+    expect(resolveUserRegion()).toBe('pacifico');
+  });
+
+  it('departamento desconocido o no mapeado devuelve null (seguro)', () => {
+    saveProfile({ departamento: 'Guaviare' });
+    expect(resolveUserRegion()).toBeNull();
+  });
+});
+
+describe('C1 — applyVoseoFilter respeta la región del usuario', () => {
+  const VOSEO_TEXT = 'Vos tenés que regar el cultivo, mirá bien la tierra.';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('usuario paisa (Antioquia): PRESERVA el voseo', () => {
+    saveProfile({ departamento: 'Antioquia' });
+    const out = applyVoseoFilter(VOSEO_TEXT);
+    expect(out).toContain('Vos');
+    expect(out).toContain('tenés');
+    expect(out).toContain('mirá');
+  });
+
+  it('usuario cundiboyacense (Bogotá): aplana a usted', () => {
+    saveProfile({ departamento: 'Cundinamarca' });
+    const out = applyVoseoFilter(VOSEO_TEXT);
+    expect(out).not.toContain('Vos');
+    expect(out).not.toContain('tenés');
+    expect(out).not.toContain('mirá');
+    expect(out.toLowerCase()).toContain('usted');
+  });
+
+  it('usuario sin región: comportamiento default (aplana a usted)', () => {
+    // localStorage limpio → resolveUserRegion null → engine default.
+    const out = applyVoseoFilter(VOSEO_TEXT);
+    expect(out).not.toContain('Vos');
+    expect(out).not.toContain('tenés');
+    expect(out.toLowerCase()).toContain('usted');
+  });
+
+  it('region explícita en opts gana sobre el perfil', () => {
+    // Perfil dice cundiboyacense pero el caller fuerza paisa → preserva voseo.
+    saveProfile({ departamento: 'Cundinamarca' });
+    const out = applyVoseoFilter(VOSEO_TEXT, { region: 'paisa' });
+    expect(out).toContain('tenés');
+  });
+
+  it('region: null explícito en opts fuerza el default (no resuelve del perfil)', () => {
+    // Aunque el perfil sea paisa, region:null pedido explícito → aplana.
+    saveProfile({ departamento: 'Antioquia' });
+    const out = applyVoseoFilter(VOSEO_TEXT, { region: null });
+    expect(out).not.toContain('tenés');
+  });
+
+  it('en región voseante limpia igual el léxico rioplatense', () => {
+    saveProfile({ departamento: 'Antioquia' });
+    const out = applyVoseoFilter('Che, vos tenés que laburar la huerta.');
+    // El voseo se preserva...
+    expect(out).toContain('tenés');
+    // ...pero el léxico argentino SIEMPRE se limpia.
+    expect(out.toLowerCase()).not.toContain('che');
+    expect(out.toLowerCase()).not.toContain('laburar');
+  });
+});

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -19,7 +19,8 @@ import {
   localizeAgentOutput as _localizeCauca,
 } from './glosarioCaucaService.js';
 import { filterVoseo as _filterVoseo } from './voseoFilter.js';
-import { buildUserProfileBlock } from './userProfileService.js';
+import { buildUserProfileBlock, getProfile } from './userProfileService.js';
+import { findMunicipio } from '../utils/colombiaLocations.js';
 import { buildEnsoAgentLines } from './ensoContext.js';
 
 /**
@@ -53,11 +54,109 @@ export function isFincaInCaucaRegion(finca) {
 }
 
 /**
+ * C2 (2026-06-02): convierte el NOMBRE de un departamento (el que trae el
+ * dataset DANE, p. ej. "Antioquia", "Bogotá, D.C.", "Valle del Cauca") a la
+ * clave-slug que `getRegionFromDepartment` / `regionalisms-co.json` esperan
+ * (p. ej. "antioquia", "bogota_dc", "valle_del_cauca").
+ *
+ * La mayoría de departamentos slugifican directo (tildes fuera + espacios a
+ * guion bajo). Un puñado de nombres oficiales DANE no coinciden 1:1 con el
+ * slug del dataset de regionalismos y se mapean a mano.
+ *
+ * @param {string|null|undefined} name
+ * @returns {string|null} slug del departamento, o null si no hay nombre.
+ */
+export function slugifyDepartamento(name) {
+  if (!name || typeof name !== 'string') return null;
+  const base = name
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // quita tildes (diacriticos combinantes)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_') // todo lo no-alfanumérico → "_"
+    .replace(/^_+|_+$/g, ''); // recorta "_" de los bordes
+  if (!base) return null;
+
+  // Casos especiales: nombre oficial DANE ≠ slug de regionalisms-co.json.
+  const SPECIAL = {
+    bogota_d_c: 'bogota_dc',
+    la_guajira: 'guajira',
+    archipielago_de_san_andres_providencia_y_santa_catalina: 'san_andres',
+  };
+  return SPECIAL[base] || base;
+}
+
+/**
+ * C2 (2026-06-02): resuelve la CLAVE de región lingüística del usuario a
+ * partir del perfil del onboarding (#200/#325/#338). Es la señal que el
+ * filtro de voseo region-aware necesita para decidir si PRESERVA el voseo
+ * (regiones voseantes: paisa/pacífico/pastuso) o lo aplana (tú en caribe,
+ * usted en el resto).
+ *
+ * Prioridad de señales (de la más precisa a la más laxa):
+ *   1. `profile.departamento` — campo LIMPIO que LocationDetectedScreen guarda
+ *      al confirmar la ubicación (#338). Nombre DANE → slug → región.
+ *   2. `profile.municipio` — municipio limpio; se resuelve su departamento con
+ *      el dataset DANE embebido (offline).
+ *   3. `profile.region` — texto libre legacy ("Municipio, Departamento"); se
+ *      intenta resolver el municipio contra el dataset DANE.
+ *
+ * Degrada SIEMPRE con gracia: si nada resuelve a una región conocida devuelve
+ * `null`, lo que deja al engine en su comportamiento histórico (aplanar a la
+ * formalidad por defecto). Es PURA respecto a red (solo lee localStorage +
+ * dataset embebido) y nunca lanza.
+ *
+ * @returns {string|null} clave de región (paisa/caribe/cundiboyacense/…) o null.
+ */
+export function resolveUserRegion() {
+  let profile;
+  try {
+    profile = getProfile();
+  } catch (_) {
+    return null;
+  }
+  if (!profile || typeof profile !== 'object') return null;
+
+  // 1) Departamento limpio (la señal más fiable).
+  if (profile.departamento) {
+    const region = getRegionFromDepartment(slugifyDepartamento(profile.departamento));
+    if (region) return region;
+  }
+
+  // 2) Municipio limpio → su departamento vía dataset DANE → región.
+  // 3) Region texto libre legacy → mismo camino.
+  for (const candidate of [profile.municipio, profile.region]) {
+    if (!candidate) continue;
+    try {
+      const hit = findMunicipio(candidate);
+      if (hit && hit.departamento) {
+        const region = getRegionFromDepartment(slugifyDepartamento(hit.departamento));
+        if (region) return region;
+      }
+    } catch (_) {
+      // findMunicipio nunca debería lanzar, pero degradamos por las dudas.
+    }
+  }
+
+  return null;
+}
+
+/**
  * DR-LANG-1 (2026-05-28): aplica el filtro post-process anti-voseo
  * argentino sobre la salida del LLM. Se usa como última etapa antes de
  * exponer el texto al ChatScreen y al TTS, garantizando que ningún
- * marcador voseo llegue al usuario campesino colombiano independientemente
- * de lo que el modelo decida emitir.
+ * marcador voseo argentino llegue al usuario campesino colombiano
+ * independientemente de lo que el modelo decida emitir.
+ *
+ * C1/C2 (2026-06-02): ahora es REGION-AWARE. Si el caller no pasa `region`
+ * en `opts`, se resuelve desde el perfil del usuario con `resolveUserRegion`.
+ * En regiones voseantes (paisa/pacífico/pastuso) el voseo es el registro
+ * AUTÉNTICO del campesino → el engine lo PRESERVA y solo limpia el léxico
+ * rioplatense (che, laburar, etc.). En el resto se aplana (tú en caribe,
+ * usted por defecto). Sin región conocida → comportamiento histórico (aplanar
+ * a `formality`, default usted), seguro y back-compatible.
+ *
+ * Para forzar el comportamiento default ignorando el perfil, el caller puede
+ * pasar `region: null` explícito en `opts`.
  *
  * Default formality='usted' (target campesino piloto Free). El caller
  * puede pasar 'tu' si la región del usuario lo prefiere.
@@ -68,20 +167,27 @@ export function isFincaInCaucaRegion(finca) {
  *
  * Wire en AgentScreen:
  *   const response = await callLLM(...);
- *   const safe = applyVoseoFilter(response);
+ *   const safe = applyVoseoFilter(response, { region: resolveUserRegion() });
  *   // → render(safe), speak(safe), persist(safe)
  *
  * @param {string} text  texto crudo del LLM
  * @param {object} [opts]
  * @param {'tu' | 'usted'} [opts.formality='usted']
+ * @param {string|null} [opts.region]  clave de región; si se omite se resuelve
+ *   del perfil. `null` explícito fuerza el default (no resuelve del perfil).
  * @returns {string}
  */
 export function applyVoseoFilter(text, opts = {}) {
   const { formality = 'usted' } = opts;
+  // Si el caller no especificó `region` (ni siquiera null explícito), la
+  // resolvemos del perfil. `'region' in opts` distingue "no pasado" de
+  // "pasado como null" — este último fuerza el default seguro.
+  const region = 'region' in opts ? opts.region : resolveUserRegion();
   return _filterVoseo(text, {
     formality,
     telemetry: true,
     ...opts,
+    region,
   });
 }
 

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -6,6 +6,7 @@
  */
 
 import { filterVoseo } from './voseoFilter.js';
+import { resolveUserRegion } from './agentService.js';
 
 /**
  * DR-LANG-1: guarda defensiva anti-voseo aplicada a la entrada de los
@@ -13,7 +14,14 @@ import { filterVoseo } from './voseoFilter.js';
  * también es invocado desde ChatBubble (re-speak), AgentFab (replayLast)
  * y posibles surfaces futuras. filterVoseo es idempotente — un doble
  * pase es no-op y mantiene la garantía de que el campesino NUNCA escuche
- * vos/tenés/querés/dale en voz alta.
+ * el léxico rioplatense (che, laburar) en voz alta.
+ *
+ * C1/C2 (2026-06-02): region-aware. La voz también debe respetar el
+ * dialecto del usuario: en regiones voseantes (paisa/pacífico/pastuso) el
+ * voseo es el registro AUTÉNTICO y se PRESERVA en el audio; en el resto se
+ * aplana (tú en caribe, usted por defecto). La región se resuelve del
+ * perfil; sin región conocida → default seguro (comportamiento histórico).
+ * resolveUserRegion es defensivo (no lanza); aun así envolvemos en try.
  *
  * @param {string} text
  * @returns {string}
@@ -21,7 +29,9 @@ import { filterVoseo } from './voseoFilter.js';
 function applyVoseoGuard(text) {
   if (typeof text !== 'string' || text.length === 0) return text;
   try {
-    return filterVoseo(text, { formality: 'usted', telemetry: false });
+    let region = null;
+    try { region = resolveUserRegion(); } catch (_) { region = null; }
+    return filterVoseo(text, { formality: 'usted', telemetry: false, region });
   } catch (_) {
     return text;
   }


### PR DESCRIPTION
## Contexto

El PR #1244 mergeó el engine region-aware en `voseoFilter.filterVoseo(text, { region })`: preserva el voseo en regiones voseantes (paisa/pacífico/pastuso), aplana a `tú` en caribe y a `usted` en el resto. Pero los call sites seguían pasando `{ formality: 'usted' }` **sin** `region`, así que el engine caía siempre al default (aplanar todo). Resultado: un campesino paisa/vallecaucano veía su voseo auténtico aplanado.

Este PR **cablea la región del perfil** end-to-end.

## C2 — resolver la región del usuario

- **`resolveUserRegion()`** (nuevo, en `agentService.js`): resuelve la clave de región lingüística desde el perfil del onboarding, con esta prioridad de señales:
  1. `profile.departamento` — campo limpio que `LocationDetectedScreen` guarda al confirmar la ubicación (#338). Es la señal más fiable.
  2. `profile.municipio` — se resuelve su departamento contra el dataset DANE embebido (offline).
  3. `profile.region` — texto libre legacy ("Municipio, Departamento"); mismo camino.
- **`slugifyDepartamento()`** (nuevo): puentea el nombre oficial DANE ("Antioquia", "Bogotá, D.C.", "Valle del Cauca") al slug que `regionalisms-co.json` / `getRegionFromDepartment` esperan (`antioquia`, `bogota_dc`, `valle_del_cauca`). 28/33 departamentos slugifican directo; 3 casos especiales se mapean a mano (`bogota_dc`, `guajira`, `san_andres`).
- Degrada **siempre** con gracia: sin señal conocida → `null` → el engine mantiene su comportamiento histórico (back-compat seguro).

## C1 — cablear `region` en los 3 call sites

- `src/components/AgentScreen/AgentScreen.jsx`: `applyVoseoFilter(deLeaked, { formality: 'usted', region: resolveUserRegion() })`.
- `src/services/agentService.js` (`applyVoseoFilter`): acepta `region`; si el caller no lo pasa, lo resuelve del perfil. `region: null` explícito fuerza el default.
- `src/services/ttsService.js` (`applyVoseoGuard`): la voz también respeta el dialecto vía `resolveUserRegion()`.

La `formality` sigue en `'usted'` por defecto (el engine la usa solo cuando la región no es voseante).

## Tests

`src/services/__tests__/agentService.voseoRegion.test.js` — 16 casos. Demuestran el entregable:
- Usuario con departamento de **Antioquia (paisa)** → su voseo se **PRESERVA**.
- Usuario de **Bogotá (cundiboyacense)** → se **aplana a usted**.
- Usuario **sin región** → comportamiento **default (seguro)**.
- Además: municipio/region como fallback, `region` explícito gana sobre el perfil, `region: null` fuerza default, y en región voseante el léxico rioplatense (che, laburar) se limpia igual.

## Estado de la suite

- Suite completa: **2961 passed, 1 skipped, 0 failed** (184 files).
- `eslint --max-warnings=0` limpio en los archivos tocados.
- Build de producción OK (sin ciclos de import: `ttsService → agentService` es unidireccional).
- Auto-bump (lefthook): `1.0.29 → 1.0.30` + `chagra-v287 → chagra-v288`.

## Notas

- PWA puro — no toca sidecar, GPU ni build/restart de agro-mcp.
- `lint` del repo reporta 2 problemas **preexistentes** en `AIStatusFooter.jsx` y `useIdleDetection.js` (ya en `main`, fuera de este diff). No se tocan para evitar scope-creep / conflictos con PRs paralelos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)