### PR TITLE
feat(bench): juez Claude Haiku (Anthropic API) + fallback determinístico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,14 @@ dist-ssr
 .env.local
 .claude/
 
+# Secretos del juez Anthropic del bench. La key vive fuera del repo
+# (~/.config/chagra-anthropic-judge-key, chmod 600) y se lee solo en runtime —
+# JAMÁS se commitea. Estos patrones son defensa extra por si alguien deja una
+# copia en el árbol del repo. Ver scripts/lib/bench-scorer.mjs (readAnthropicKey).
+chagra-anthropic-judge-key
+*anthropic*key*
+*.apikey
+
 # Playwright
 /test-results/
 /playwright-report/

--- a/scripts/__tests__/bench-scorer.test.mjs
+++ b/scripts/__tests__/bench-scorer.test.mjs
@@ -14,7 +14,7 @@
  * deja el evaluador listo + esta cobertura unitaria del scorer.
  */
 import { describe, it, expect } from 'vitest';
-import { writeFileSync, rmSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -289,15 +289,16 @@ describe('readAnthropicKey (sin tocar el entorno/disco real)', () => {
   });
 
   it('cae al archivo gitignored si no hay env', () => {
-    // Escribimos un archivo temporal con un valor NO-secreto (placeholder) para
-    // verificar la lectura + trim. NUNCA usamos una key real.
-    const tmpPath = join(tmpdir(), `chagra-judge-key-test-${process.pid}-${Date.now()}`);
+    // Escribimos un archivo en un directorio temporal ÚNICO (mkdtemp, permisos
+    // 0700) con un valor NO-secreto (placeholder). NUNCA usamos una key real.
+    const dir = mkdtempSync(join(tmpdir(), 'chagra-judge-key-test-'));
+    const tmpPath = join(dir, 'key');
     writeFileSync(tmpPath, '  not-a-real-key-PLACEHOLDER\n', 'utf-8');
     try {
       const key = readAnthropicKey({ env: {}, keyPath: tmpPath });
       expect(key).toBe('not-a-real-key-PLACEHOLDER'); // trim aplicado
     } finally {
-      rmSync(tmpPath, { force: true });
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 
@@ -347,7 +348,7 @@ describe('makeAnthropicJudgeCall (fetch mockeado, sin key real)', () => {
     expect(raw).toBe('{"pass": true, "must_covered": 2, "must_total": 2, "red_flags_hit": 0}');
 
     // contrato del request: endpoint + headers anthropic + modelo Haiku + temp 0
-    expect(captured.url).toMatch(/api\.anthropic\.com\/v1\/messages/);
+    expect(captured.url).toBe('https://api.anthropic.com/v1/messages');
     expect(captured.init.headers['x-api-key']).toBe('sk-test-FAKE');
     expect(captured.init.headers['anthropic-version']).toBeTruthy();
     const body = JSON.parse(captured.init.body);

--- a/scripts/__tests__/bench-scorer.test.mjs
+++ b/scripts/__tests__/bench-scorer.test.mjs
@@ -14,6 +14,9 @@
  * deja el evaluador listo + esta cobertura unitaria del scorer.
  */
 import { describe, it, expect } from 'vitest';
+import { writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   scoreKeywordsFlexible,
   buildJudgePrompt,
@@ -21,10 +24,18 @@ import {
   scoreWithJudge,
   assertIndependentJudge,
   RECOMMENDED_JUDGE_MODEL,
+  RECOMMENDED_ANTHROPIC_JUDGE_MODEL,
+  RECOMMENDED_OLLAMA_JUDGE_MODEL,
   GENERATOR_MODEL,
   buildAntiHallucPrompt,
   parseAHVerdict,
   scoreAntiHalluc,
+  readAnthropicKey,
+  extractAnthropicText,
+  makeAnthropicJudgeCall,
+  scoreAntiHallucDeterministic,
+  selectJudgeProvider,
+  ANTHROPIC_JUDGE_KEY_PATH,
 } from '../lib/bench-scorer.mjs';
 
 describe('scoreKeywordsFlexible', () => {
@@ -247,5 +258,223 @@ describe('scoreAntiHalluc (caller inyectado, sin GPU)', () => {
     );
     expect(out.source).toBe('unjudged');
     expect(out.pass).toBeNull();
+  });
+});
+
+// ── R5: juez Claude Haiku (Anthropic) + fallback determinístico ───────────────
+//
+// NOTA DE SEGURIDAD: ningún test usa una API key real ni llama a la red. La
+// llamada HTTP se mockea (`fetchImpl`) y la lectura de la key se inyecta (`env`
+// / `keyPath`). Estos tests pasan en CI SIN ANTHROPIC_API_KEY.
+
+describe('RECOMMENDED_JUDGE_MODEL ahora es Claude Haiku (local roto en Maxwell)', () => {
+  it('el default es el modelo Anthropic, no un modelo de ollama', () => {
+    expect(RECOMMENDED_JUDGE_MODEL).toBe('claude-haiku-4-5');
+    expect(RECOMMENDED_JUDGE_MODEL).toBe(RECOMMENDED_ANTHROPIC_JUDGE_MODEL);
+  });
+
+  it('conserva el id del juez local solo para uso forzado en GPU compatible', () => {
+    expect(RECOMMENDED_OLLAMA_JUDGE_MODEL).toBe('qwen2.5:14b');
+  });
+
+  it('el juez recomendado sigue siendo independiente del generador', () => {
+    expect(() => assertIndependentJudge(RECOMMENDED_JUDGE_MODEL, GENERATOR_MODEL)).not.toThrow();
+  });
+});
+
+describe('readAnthropicKey (sin tocar el entorno/disco real)', () => {
+  it('lee de ANTHROPIC_API_KEY del env primero', () => {
+    const key = readAnthropicKey({ env: { ANTHROPIC_API_KEY: ' sk-test-env ' }, keyPath: '/no/existe' });
+    expect(key).toBe('sk-test-env'); // trim aplicado
+  });
+
+  it('cae al archivo gitignored si no hay env', () => {
+    // Escribimos un archivo temporal con un valor NO-secreto (placeholder) para
+    // verificar la lectura + trim. NUNCA usamos una key real.
+    const tmpPath = join(tmpdir(), `chagra-judge-key-test-${process.pid}-${Date.now()}`);
+    writeFileSync(tmpPath, '  not-a-real-key-PLACEHOLDER\n', 'utf-8');
+    try {
+      const key = readAnthropicKey({ env: {}, keyPath: tmpPath });
+      expect(key).toBe('not-a-real-key-PLACEHOLDER'); // trim aplicado
+    } finally {
+      rmSync(tmpPath, { force: true });
+    }
+  });
+
+  it('devuelve null si no hay env ni archivo', () => {
+    expect(readAnthropicKey({ env: {}, keyPath: '/ruta/que/no/existe/jamas' })).toBeNull();
+  });
+
+  it('no lanza si el path es inválido (degrada a null)', () => {
+    expect(() => readAnthropicKey({ env: {}, keyPath: '\0invalid' })).not.toThrow();
+  });
+
+  it('expone la ruta esperada del archivo gitignored (~/.config/...)', () => {
+    expect(ANTHROPIC_JUDGE_KEY_PATH).toMatch(/\.config\/chagra-anthropic-judge-key$/);
+  });
+});
+
+describe('extractAnthropicText', () => {
+  it('extrae el texto de content[] de la respuesta de Messages', () => {
+    const data = { content: [{ type: 'text', text: '{"pass": true}' }] };
+    expect(extractAnthropicText(data)).toBe('{"pass": true}');
+  });
+
+  it('concatena múltiples bloques de texto e ignora no-texto', () => {
+    const data = { content: [{ type: 'text', text: 'VEREDICTO: ' }, { type: 'thinking', text: 'x' }, { type: 'text', text: 'PASS' }] };
+    expect(extractAnthropicText(data)).toBe('VEREDICTO: PASS');
+  });
+
+  it('forma inesperada → string vacío (no lanza)', () => {
+    expect(extractAnthropicText(null)).toBe('');
+    expect(extractAnthropicText({})).toBe('');
+    expect(extractAnthropicText({ content: 'x' })).toBe('');
+  });
+});
+
+describe('makeAnthropicJudgeCall (fetch mockeado, sin key real)', () => {
+  it('arma el request a la API de Anthropic y devuelve el texto del veredicto', async () => {
+    let captured = null;
+    const fakeFetch = async (url, init) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        json: async () => ({ content: [{ type: 'text', text: '{"pass": true, "must_covered": 2, "must_total": 2, "red_flags_hit": 0}' }] }),
+      };
+    };
+    const judgeCall = makeAnthropicJudgeCall({ apiKey: 'sk-test-FAKE', fetchImpl: fakeFetch });
+    const raw = await judgeCall('PROMPT DEL JUEZ');
+    expect(raw).toBe('{"pass": true, "must_covered": 2, "must_total": 2, "red_flags_hit": 0}');
+
+    // contrato del request: endpoint + headers anthropic + modelo Haiku + temp 0
+    expect(captured.url).toMatch(/api\.anthropic\.com\/v1\/messages/);
+    expect(captured.init.headers['x-api-key']).toBe('sk-test-FAKE');
+    expect(captured.init.headers['anthropic-version']).toBeTruthy();
+    const body = JSON.parse(captured.init.body);
+    expect(body.model).toBe('claude-haiku-4-5');
+    expect(body.temperature).toBe(0);
+    expect(body.messages[0].content).toBe('PROMPT DEL JUEZ');
+  });
+
+  it('enchufa directo en scoreAntiHalluc como ollamaCall (mismo contrato)', async () => {
+    const fakeFetch = async () => ({
+      ok: true,
+      json: async () => ({ content: [{ type: 'text', text: '{"pass": false, "must_covered": 1, "must_total": 2, "red_flags_hit": 1}' }] }),
+    });
+    const judgeCall = makeAnthropicJudgeCall({ apiKey: 'sk-test-FAKE', fetchImpl: fakeFetch });
+    const out = await scoreAntiHalluc(
+      { query: 'q', response: 'r', mustInclude: ['a', 'b'], redFlags: ['x'] },
+      { ollamaCall: judgeCall },
+    );
+    expect(out.source).toBe('judge');
+    expect(out.pass).toBe(false);
+    expect(out.redFlagsHit).toBe(1);
+  });
+
+  it('HTTP no-ok lanza → scoreAntiHalluc lo cuenta como unjudged (no inventa)', async () => {
+    const fakeFetch = async () => ({ ok: false, status: 429, json: async () => ({}) });
+    const judgeCall = makeAnthropicJudgeCall({ apiKey: 'sk-test-FAKE', fetchImpl: fakeFetch });
+    const out = await scoreAntiHalluc(
+      { query: 'q', response: 'r', mustInclude: ['a'], redFlags: [] },
+      { ollamaCall: judgeCall },
+    );
+    expect(out.source).toBe('unjudged');
+  });
+
+  it('lanza si no hay apiKey (sin exponer su valor)', () => {
+    expect(() => makeAnthropicJudgeCall({ apiKey: '' })).toThrow(/apiKey/);
+  });
+});
+
+describe('scoreAntiHallucDeterministic (fallback sin LLM)', () => {
+  it('PASS: todos los must_include presentes y ningún red_flag', () => {
+    const out = scoreAntiHallucDeterministic({
+      response: 'La chugua es Ullucus tuberosus, resiste heladas con buen drenaje.',
+      mustInclude: ['Ullucus tuberosus', 'drenaje'],
+      redFlags: ['Solanum tuberosum'],
+    });
+    expect(out.pass).toBe(true);
+    expect(out.mustCovered).toBe(2);
+    expect(out.mustTotal).toBe(2);
+    expect(out.redFlagsHit).toBe(0);
+    expect(out.source).toBe('deterministic');
+  });
+
+  it('FAIL: aparece un red_flag', () => {
+    const out = scoreAntiHallucDeterministic({
+      response: 'La chugua en realidad es Solanum tuberosum.',
+      mustInclude: ['Ullucus tuberosus'],
+      redFlags: ['Solanum tuberosum'],
+    });
+    expect(out.pass).toBe(false);
+    expect(out.redFlagsHit).toBe(1);
+  });
+
+  it('FAIL: falta un must_include', () => {
+    const out = scoreAntiHallucDeterministic({
+      response: 'Es una planta andina.',
+      mustInclude: ['Ullucus tuberosus', 'drenaje'],
+      redFlags: [],
+    });
+    expect(out.pass).toBe(false);
+    expect(out.mustCovered).toBeLessThan(out.mustTotal);
+  });
+
+  it('entrada vacía / no-string → no crashea', () => {
+    const out = scoreAntiHallucDeterministic({ response: null, mustInclude: ['a'], redFlags: [] });
+    expect(out.pass).toBe(false);
+    expect(out.source).toBe('deterministic');
+  });
+});
+
+describe('selectJudgeProvider', () => {
+  it('AUTO con key → anthropic + judgeCall listo', () => {
+    const sel = selectJudgeProvider({ env: { ANTHROPIC_API_KEY: 'sk-test-FAKE' }, fetchImpl: async () => ({}) });
+    expect(sel.provider).toBe('anthropic');
+    expect(sel.judgeModel).toBe('claude-haiku-4-5');
+    expect(typeof sel.judgeCall).toBe('function');
+    expect(sel.deterministic).toBe(false);
+  });
+
+  it('AUTO sin key → deterministic (degradación graceful, judgeCall null)', () => {
+    const sel = selectJudgeProvider({ env: {}, keyPath: '/no/existe' });
+    expect(sel.provider).toBe('deterministic');
+    expect(sel.judgeCall).toBeNull();
+    expect(sel.deterministic).toBe(true);
+  });
+
+  it('JUDGE_PROVIDER=anthropic sin key → degrada a deterministic (no crashea)', () => {
+    const sel = selectJudgeProvider({ env: { JUDGE_PROVIDER: 'anthropic' }, keyPath: '/no/existe' });
+    expect(sel.provider).toBe('deterministic');
+    expect(sel.deterministic).toBe(true);
+  });
+
+  it('JUDGE_PROVIDER=ollama → usa el ollamaCall inyectado y el modelo local', () => {
+    const ollamaCall = async () => '{"pass": true}';
+    const sel = selectJudgeProvider({ env: { JUDGE_PROVIDER: 'ollama' }, ollamaCall });
+    expect(sel.provider).toBe('ollama');
+    expect(sel.judgeModel).toBe('qwen2.5:14b');
+    expect(sel.judgeCall).toBe(ollamaCall);
+    expect(sel.deterministic).toBe(false);
+  });
+
+  it('JUDGE_PROVIDER=deterministic → fuerza determinístico aunque haya key', () => {
+    const sel = selectJudgeProvider({ env: { JUDGE_PROVIDER: 'deterministic', ANTHROPIC_API_KEY: 'sk-test-FAKE' } });
+    expect(sel.provider).toBe('deterministic');
+    expect(sel.judgeCall).toBeNull();
+  });
+
+  it('arg provider explícito gana sobre la env', () => {
+    const sel = selectJudgeProvider({ provider: 'deterministic', env: { JUDGE_PROVIDER: 'anthropic', ANTHROPIC_API_KEY: 'sk-test-FAKE' } });
+    expect(sel.provider).toBe('deterministic');
+  });
+
+  it('nunca expone la key en el objeto devuelto', () => {
+    const sel = selectJudgeProvider({ env: { ANTHROPIC_API_KEY: 'sk-test-SECRET' }, fetchImpl: async () => ({}) });
+    expect(JSON.stringify(Object.keys(sel))).not.toMatch(/key|apiKey|secret/i);
+    // ningún valor string del objeto contiene la key
+    for (const v of Object.values(sel)) {
+      if (typeof v === 'string') expect(v).not.toContain('sk-test-SECRET');
+    }
   });
 });

--- a/scripts/bench-agente-completo.mjs
+++ b/scripts/bench-agente-completo.mjs
@@ -38,7 +38,7 @@ import {
   scoreKeywordsFlexible,
   scoreWithJudge,
   assertIndependentJudge,
-  RECOMMENDED_JUDGE_MODEL,
+  RECOMMENDED_OLLAMA_JUDGE_MODEL,
 } from './lib/bench-scorer.mjs';
 import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 
@@ -52,12 +52,16 @@ const OLLAMA_URL = 'http://localhost:11434/api/chat';
 const OLLAMA_GEN_URL = process.env.OLLAMA_GEN_URL || 'http://localhost:11434/api/generate';
 const TIMEOUT_MS = 180_000; // 3 min timeout por modelo
 
-// R4 — juez INDEPENDIENTE. `--judge [modelo]` activa el LLM-judge. El default ya
-// NO es el generador (granite = auto-eval) ni mistral-nemo (crashea Maxwell):
-// es qwen2.5:14b, de otra familia y estable en sm_52. Precedencia del modelo:
+// R4 — juez INDEPENDIENTE (COBERTURA de keywords, no anti-alucinación). `--judge
+// [modelo]` activa el LLM-judge LOCAL contra ollama. OJO: los jueces locales
+// están rotos en Maxwell (devuelven vacío / rubber-stamp); el juez confiable es
+// Claude Haiku, cableado en los benches de anti-alucinación
+// (bench-complejos-juez-independiente / bench-capabilities-A-vs-C) vía
+// selectJudgeProvider. Aquí el default sigue siendo el modelo local solo para
+// quien lo fuerce en GPU compatible. Precedencia del modelo:
 //   1) argumento posicional tras --judge   (--judge qwen2.5:14b)
 //   2) env JUDGE_MODEL
-//   3) RECOMMENDED_JUDGE_MODEL (qwen2.5:14b)
+//   3) RECOMMENDED_OLLAMA_JUDGE_MODEL (qwen2.5:14b)
 // Sin la flag, el scoring es keyword-FLEXIBLE (sinónimos/lemas).
 const USE_JUDGE = process.argv.includes('--judge');
 function parseJudgeArg() {
@@ -68,7 +72,7 @@ function parseJudgeArg() {
   }
   return null;
 }
-const JUDGE_MODEL = parseJudgeArg() || process.env.JUDGE_MODEL || RECOMMENDED_JUDGE_MODEL;
+const JUDGE_MODEL = parseJudgeArg() || process.env.JUDGE_MODEL || RECOMMENDED_OLLAMA_JUDGE_MODEL;
 const JUDGE_TIMEOUT_MS = 60_000;
 
 const MODELS = {

--- a/scripts/bench-capabilities-A-vs-C.mjs
+++ b/scripts/bench-capabilities-A-vs-C.mjs
@@ -43,7 +43,6 @@ import {
   scoreAntiHallucDeterministic,
   assertIndependentJudge,
   selectJudgeProvider,
-  RECOMMENDED_OLLAMA_JUDGE_MODEL,
 } from './lib/bench-scorer.mjs';
 import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 import { applyOutputGuards } from '../src/services/outputGuards.js';

--- a/scripts/bench-capabilities-A-vs-C.mjs
+++ b/scripts/bench-capabilities-A-vs-C.mjs
@@ -38,7 +38,13 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { performance } from 'node:perf_hooks';
 import { execSync } from 'node:child_process';
-import { scoreAntiHalluc, assertIndependentJudge, RECOMMENDED_JUDGE_MODEL } from './lib/bench-scorer.mjs';
+import {
+  scoreAntiHalluc,
+  scoreAntiHallucDeterministic,
+  assertIndependentJudge,
+  selectJudgeProvider,
+  RECOMMENDED_OLLAMA_JUDGE_MODEL,
+} from './lib/bench-scorer.mjs';
 import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 import { applyOutputGuards } from '../src/services/outputGuards.js';
 
@@ -51,7 +57,10 @@ const GEN_TEMPERATURE = 0.3;
 const GEN_MAX_TOKENS = 768;
 const SEED = Number(process.env.SEED || 42);
 
-const JUDGE_MODEL = process.env.JUDGE_MODEL || RECOMMENDED_JUDGE_MODEL;
+// Juez: Anthropic (Claude Haiku) si hay API key; si no, scorer DETERMINÍSTICO.
+// `JUDGE_PROVIDER=ollama` fuerza el juez local (roto en Maxwell, solo Ampere+).
+const JUDGE = selectJudgeProvider({ ollamaCall: judgeOllamaCall });
+const JUDGE_MODEL = process.env.JUDGE_MODEL || JUDGE.judgeModel;
 const JUDGE_TEMPERATURE = 0;
 const JUDGE_TIMEOUT_MS = 120_000;
 
@@ -333,19 +342,23 @@ async function generatePhase(p, config) {
   };
 }
 
-/** FASE 2 — juzga (qwen, cargado una sola vez) la respuesta ya generada. */
+/**
+ * FASE 2 — juzga la respuesta ya generada. Con proveedor Anthropic/ollama usa el
+ * LLM-judge; sin API key (determinístico) usa `scoreAntiHallucDeterministic` (no
+ * carga ningún modelo).
+ */
 async function judgePhase(p, res) {
   if (!res || res.error) return res;
-  const ah = await scoreAntiHalluc(
-    {
-      query: p.prompt,
-      response: res.final_response,
-      mustInclude: p.must_include,
-      redFlags: p.red_flags,
-      shouldInclude: p.should_include,
-    },
-    { ollamaCall: judgeOllamaCall },
-  );
+  const item = {
+    query: p.prompt,
+    response: res.final_response,
+    mustInclude: p.must_include,
+    redFlags: p.red_flags,
+    shouldInclude: p.should_include,
+  };
+  const ah = JUDGE.deterministic
+    ? scoreAntiHallucDeterministic(item)
+    : await scoreAntiHalluc(item, { ollamaCall: JUDGE.judgeCall });
   res.ah_pass = ah.pass;
   res.ah_source = ah.source;
   res.ah_must_covered = ah.mustCovered;
@@ -379,7 +392,8 @@ async function main() {
     autoPull: process.env.BENCH_AUTO_PULL === '1',
     skip: process.env.BENCH_SKIP_STALE_GUARD === '1',
   });
-  assertIndependentJudge(JUDGE_MODEL, GEN_MODEL);
+  // Independencia solo aplica a un juez LLM (no al scorer determinístico).
+  if (!JUDGE.deterministic) assertIndependentJudge(JUDGE_MODEL, GEN_MODEL);
 
   if (!POOL_FILE || !existsSync(POOL_FILE)) {
     console.error(`FATAL: pool no encontrado. Pasá --pool <archivo>. (recibido: '${POOL_FILE}')`);
@@ -390,7 +404,7 @@ async function main() {
 
   console.log('[bench-cap] bench HONESTO de capacidades — juez independiente + config-prod');
   console.log(`[bench-cap] generador: ${GEN_MODEL} temp=${GEN_TEMPERATURE} seed=${SEED}`);
-  console.log(`[bench-cap] juez:      ${JUDGE_MODEL} (independiente)`);
+  console.log(`[bench-cap] juez:      ${JUDGE_MODEL} (provider=${JUDGE.provider})`);
   console.log(`[bench-cap] pool:      ${prompts.length} prompts (${POOL_FILE.split('/').pop()})`);
   console.log(`[bench-cap] configs:   ${CONFIGS.join(', ')}`);
   console.log(`[bench-cap] GPU temp inicial: ${gpuTemp() ?? 'n/d'}°C`);
@@ -467,7 +481,7 @@ async function main() {
     generated_at: new Date().toISOString(),
     pool: POOL_FILE,
     generator: { model: GEN_MODEL, temperature: GEN_TEMPERATURE, seed: SEED, max_tokens: GEN_MAX_TOKENS },
-    judge: { model: JUDGE_MODEL, independent: true },
+    judge: { model: JUDGE_MODEL, provider: JUDGE.provider, independent: !JUDGE.deterministic },
     configs: CONFIGS,
     n_prompts: prompts.length,
     overall: { A: aggA, C: aggC },

--- a/scripts/bench-complejos-juez-independiente.mjs
+++ b/scripts/bench-complejos-juez-independiente.mjs
@@ -42,8 +42,9 @@ import { performance } from 'node:perf_hooks';
 import { execSync } from 'node:child_process';
 import {
   scoreAntiHalluc,
+  scoreAntiHallucDeterministic,
   assertIndependentJudge,
-  RECOMMENDED_JUDGE_MODEL,
+  selectJudgeProvider,
 } from './lib/bench-scorer.mjs';
 import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 import { applyOutputGuards } from '../src/services/outputGuards.js';
@@ -67,9 +68,18 @@ function parseJudgeArg() {
   }
   return null;
 }
-const JUDGE_MODEL = parseJudgeArg() || process.env.JUDGE_MODEL || RECOMMENDED_JUDGE_MODEL;
+// Juez: por defecto Anthropic (Claude Haiku) si hay API key; si no, scorer
+// DETERMINÍSTICO. Un `--judge <modelo>` o `JUDGE_PROVIDER=ollama` explícito
+// fuerza el juez local de ollama (roto en Maxwell — solo GPU Ampere+).
+const JUDGE_ARG = parseJudgeArg() || process.env.JUDGE_MODEL || null;
+const JUDGE = selectJudgeProvider({
+  provider: JUDGE_ARG ? 'ollama' : undefined,
+  ollamaCall: judgeOllamaCall,
+  ollamaModel: JUDGE_ARG || undefined,
+});
+const JUDGE_MODEL = JUDGE.judgeModel;
 const JUDGE_TEMPERATURE = 0; // determinismo del juez.
-const JUDGE_TIMEOUT_MS = 120_000; // qwen2.5:14b en Maxwell es lento.
+const JUDGE_TIMEOUT_MS = 120_000; // el juez local en Maxwell es lento (si se fuerza).
 
 const SIDECAR_URL = process.env.SIDECAR_URL || 'http://localhost:7880';
 const OLLAMA_CHAT_URL = 'http://localhost:11434/api/chat';
@@ -256,14 +266,15 @@ async function main() {
   });
 
   // Independencia del juez (verify-before-claim): aborta si juez === generador.
-  assertIndependentJudge(JUDGE_MODEL, GEN_MODEL);
+  // Solo aplica a un juez LLM; el scorer determinístico no es un generador.
+  if (!JUDGE.deterministic) assertIndependentJudge(JUDGE_MODEL, GEN_MODEL);
 
   const fixture = JSON.parse(readFileSync(PROMPTS_FILE, 'utf-8'));
   const prompts = fixture.prompts || [];
 
-  console.log('[bench-complejos] re-bench HONESTO — juez independiente + config-prod');
+  console.log('[bench-complejos] re-bench HONESTO — juez confiable + config-prod');
   console.log(`[bench-complejos] generador: ${GEN_MODEL} temp=${GEN_TEMPERATURE} seed=${SEED} max_tokens=${GEN_MAX_TOKENS}`);
-  console.log(`[bench-complejos] juez:      ${JUDGE_MODEL} (independiente, temp=${JUDGE_TEMPERATURE})`);
+  console.log(`[bench-complejos] juez:      ${JUDGE_MODEL} (provider=${JUDGE.provider}, temp=${JUDGE_TEMPERATURE})`);
   console.log(`[bench-complejos] prompts:   ${prompts.length} (${PROMPTS_FILE.split('/').pop()})`);
   console.log(`[bench-complejos] GPU temp inicial: ${gpuTemp() ?? 'n/d'}°C`);
 
@@ -305,17 +316,18 @@ async function main() {
     // 4) post-validate (detector de alucinaciones del sidecar)
     const validation = await postValidate(p.prompt, finalText);
 
-    // 5) juez ANTI-ALUCINACIÓN independiente (must_include / red_flags)
-    const ah = await scoreAntiHalluc(
-      {
-        query: p.prompt,
-        response: finalText,
-        mustInclude: p.must_include,
-        redFlags: p.red_flags,
-        shouldInclude: p.should_include,
-      },
-      { ollamaCall: judgeOllamaCall },
-    );
+    // 5) juez ANTI-ALUCINACIÓN (must_include / red_flags). Anthropic/ollama vía
+    //    LLM-judge; sin API key cae al scorer determinístico (no carga modelo).
+    const ahItem = {
+      query: p.prompt,
+      response: finalText,
+      mustInclude: p.must_include,
+      redFlags: p.red_flags,
+      shouldInclude: p.should_include,
+    };
+    const ah = JUDGE.deterministic
+      ? scoreAntiHallucDeterministic(ahItem)
+      : await scoreAntiHalluc(ahItem, { ollamaCall: JUDGE.judgeCall });
 
     if (ah.source === 'unjudged') unjudged++;
     else if (ah.pass) pass++;
@@ -364,7 +376,7 @@ async function main() {
   const summary = {
     generated_at: new Date().toISOString(),
     generator: { model: GEN_MODEL, temperature: GEN_TEMPERATURE, seed: SEED, max_tokens: GEN_MAX_TOKENS, config: 'PROD (llmRouter chat_complex)' },
-    judge: { model: JUDGE_MODEL, independent: true, temperature: JUDGE_TEMPERATURE },
+    judge: { model: JUDGE_MODEL, provider: JUDGE.provider, independent: !JUDGE.deterministic, temperature: JUDGE_TEMPERATURE },
     fixture: PROMPTS_FILE,
     n_prompts: prompts.length,
     pass,

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -26,10 +26,24 @@
  * perdona sus propias alucinaciones). El default histórico apuntaba al generador
  * (granite3.1-dense:8b) / a mistral-nemo:12b (que CRASHEA en Maxwell sm_52 con
  * 'signal during cgo'). `assertIndependentJudge` rechaza explícitamente usar el
- * generador como juez. Juez independiente recomendado en Maxwell sin API
- * Anthropic disponible: `qwen2.5:14b` (corre estable en sm_52, familia distinta
- * a granite). Ideal cuando hay ANTHROPIC_API_KEY: un Haiku cloud, vía el pipeline
- * Python `tools/llm-judge/` (Chagra-strategy) — NO hay key en este entorno.
+ * generador como juez.
+ *
+ * JUEZ ANTHROPIC (R5, 2026-06-01): NINGÚN juez LLM *local* es confiable en la
+ * Maxwell M6000 (sm_52):
+ *   - `qwen2.5:14b`      → devuelve respuesta VACÍA (no juzga nada).
+ *   - `llama3.1:8b`      → devuelve respuesta VACÍA.
+ *   - `mistral-nemo:12b` → aprueba TODO (rubber-stamp; además crash cgo).
+ * Por eso el juez confiable por defecto pasa a ser **Claude Haiku** vía la API de
+ * Anthropic (`claude-haiku-4-5`: modelo de juez barato y estable). El proveedor
+ * se elige con la env `JUDGE_PROVIDER` (anthropic|ollama|deterministic). Si NO
+ * hay API key disponible, se degrada de forma graceful al scorer DETERMINÍSTICO
+ * (substring de must_include + ausencia de red_flags) — nunca crashea.
+ *
+ * LECTURA SEGURA DE LA KEY (R5): la API key se lee SOLO en runtime, primero de
+ * `process.env.ANTHROPIC_API_KEY` y, si no está, del archivo gitignored
+ * `~/.config/chagra-anthropic-judge-key` (chmod 600). JAMÁS se imprime, loguea ni
+ * se incluye en commits / tests / fixtures. Los tests mockean la llamada HTTP y
+ * NO necesitan key real para pasar.
  *
  * Módulo PURO y sin efectos secundarios (no auto-ejecuta nada) → importable por
  * el bench y por el test unitario.
@@ -37,12 +51,34 @@
  * @module bench-scorer
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 /**
- * Juez independiente recomendado para correr en Maxwell (sm_52) sin acceso a la
- * API Anthropic. Familia distinta al generador (granite) → no es auto-eval.
- * mistral-nemo:12b queda DESCARTADO como default por crash en Maxwell.
+ * Modelo Anthropic de juez (barato y confiable). Se usa cuando
+ * `JUDGE_PROVIDER=anthropic` (default si hay API key disponible).
  */
-export const RECOMMENDED_JUDGE_MODEL = 'qwen2.5:14b';
+export const RECOMMENDED_ANTHROPIC_JUDGE_MODEL = 'claude-haiku-4-5';
+
+/**
+ * Juez recomendado por defecto: Claude Haiku vía API de Anthropic. Los jueces
+ * LOCALES están ROTOS en Maxwell (qwen2.5:14b y llama3.1:8b devuelven vacío;
+ * mistral-nemo:12b aprueba todo = rubber-stamp). Cuando no hay API key, el
+ * pipeline degrada al scorer determinístico (ver `selectJudgeProvider`).
+ *
+ * NOTA: este es un *modelo de Anthropic*, no de ollama. Los benches que corren
+ * con `JUDGE_PROVIDER=ollama` deben usar `RECOMMENDED_OLLAMA_JUDGE_MODEL`.
+ */
+export const RECOMMENDED_JUDGE_MODEL = RECOMMENDED_ANTHROPIC_JUDGE_MODEL;
+
+/**
+ * Juez LOCAL (ollama) — DESCARTADO como default en Maxwell sm_52: qwen2.5:14b y
+ * llama3.1:8b devuelven respuesta vacía, mistral-nemo:12b aprueba todo. Se
+ * conserva el identificador solo para quien fuerce `JUDGE_PROVIDER=ollama` en
+ * una GPU compatible (Ampere+); en Maxwell NO produce veredictos creíbles.
+ */
+export const RECOMMENDED_OLLAMA_JUDGE_MODEL = 'qwen2.5:14b';
 
 /** El generador del bench cuyo uso como juez = auto-evaluación (prohibido). */
 export const GENERATOR_MODEL = 'granite3.1-dense:8b';
@@ -415,4 +451,208 @@ export async function scoreAntiHalluc(item, { ollamaCall } = {}) {
   } catch (_) {
     return unjudged;
   }
+}
+
+// ── R5: juez Claude Haiku (Anthropic API) + fallback determinístico ───────────
+
+/**
+ * Ruta del archivo gitignored con la API key del juez Anthropic. chmod 600. El
+ * archivo lo crea el operador; NUNCA lo escribe este módulo ni se commitea.
+ */
+export const ANTHROPIC_JUDGE_KEY_PATH = join(homedir(), '.config', 'chagra-anthropic-judge-key');
+
+/**
+ * readAnthropicKey — lee la API key SOLO en runtime. Orden: (1) env
+ * `ANTHROPIC_API_KEY`, (2) archivo gitignored `~/.config/chagra-anthropic-judge-key`.
+ * Devuelve el string de la key o `null` si no hay ninguna. JAMÁS loguea/imprime
+ * la key. No lanza si el archivo no existe ni si no se puede leer.
+ *
+ * @param {{ env?: Record<string,string|undefined>, keyPath?: string }} [opts]
+ *   `env` y `keyPath` se inyectan en tests para no tocar el entorno/disco real.
+ * @returns {string|null}
+ */
+export function readAnthropicKey({ env = process.env, keyPath = ANTHROPIC_JUDGE_KEY_PATH } = {}) {
+  const fromEnv = (env && env.ANTHROPIC_API_KEY ? String(env.ANTHROPIC_API_KEY) : '').trim();
+  if (fromEnv) return fromEnv;
+  try {
+    if (keyPath && existsSync(keyPath)) {
+      const fromFile = readFileSync(keyPath, 'utf-8').trim();
+      if (fromFile) return fromFile;
+    }
+  } catch (_) {
+    /* archivo ilegible → tratamos como ausencia de key (degrada graceful) */
+  }
+  return null;
+}
+
+/**
+ * extractAnthropicText — saca el texto de la respuesta de la API de Messages de
+ * Anthropic: `{ content: [{ type:'text', text:'...' }, ...] }`. Devuelve string
+ * (posiblemente vacío). Tolerante a formas inesperadas.
+ *
+ * @param {any} data
+ * @returns {string}
+ */
+export function extractAnthropicText(data) {
+  if (!data || !Array.isArray(data.content)) return '';
+  return data.content
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text)
+    .join('')
+    .trim();
+}
+
+/**
+ * makeAnthropicJudgeCall — fabrica un caller de juez `(prompt) => Promise<string>`
+ * que llama a la API de Anthropic (Messages) con un modelo Haiku barato y
+ * devuelve el TEXTO del veredicto, con el MISMO contrato que el `ollamaCall`
+ * inyectable. Así enchufa directo en `scoreAntiHalluc` / `scoreWithJudge` sin
+ * cambiarlos.
+ *
+ * La llamada `fetch` se inyecta (`fetchImpl`) para testear sin red ni key real.
+ * Si la llamada falla / responde no-ok, lanza → `scoreAntiHalluc` cuenta el item
+ * como `unjudged` (no inventa un veredicto). La key NUNCA se loguea.
+ *
+ * @param {{
+ *   apiKey: string,
+ *   model?: string,
+ *   fetchImpl?: typeof fetch,
+ *   timeoutMs?: number,
+ *   maxTokens?: number,
+ *   apiUrl?: string,
+ *   anthropicVersion?: string,
+ * }} opts
+ * @returns {(prompt:string)=>Promise<string>}
+ */
+export function makeAnthropicJudgeCall({
+  apiKey,
+  model = RECOMMENDED_ANTHROPIC_JUDGE_MODEL,
+  fetchImpl,
+  timeoutMs = 60_000,
+  maxTokens = 256,
+  apiUrl = 'https://api.anthropic.com/v1/messages',
+  anthropicVersion = '2023-06-01',
+} = {}) {
+  if (!apiKey || typeof apiKey !== 'string') {
+    throw new Error('makeAnthropicJudgeCall: falta apiKey (no se loguea su valor).');
+  }
+  const doFetch = fetchImpl || (typeof fetch === 'function' ? fetch : null);
+  if (typeof doFetch !== 'function') {
+    throw new Error('makeAnthropicJudgeCall: no hay implementación de fetch disponible.');
+  }
+  return async function anthropicJudgeCall(prompt) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await doFetch(apiUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': anthropicVersion,
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: maxTokens,
+          // temperatura 0 → veredicto determinista (igual que el juez local).
+          temperature: 0,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        // No incluimos cuerpo (podría reflejar la key en algún proxy) — solo status.
+        throw new Error(`anthropic judge HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      return extractAnthropicText(data);
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * scoreAntiHallucDeterministic — fallback SIN LLM para anti-alucinación. PASS si
+ * TODOS los `mustInclude` aparecen por substring/lema/sinónimo (vía
+ * `scoreKeywordsFlexible`) Y NINGÚN `redFlags` aparece. Es conservador: un
+ * red_flag textual presente = FAIL; un must_include ausente = FAIL. NO detecta
+ * alucinaciones semánticas finas (para eso está el juez Claude), pero da una
+ * señal honesta y reproducible cuando no hay key. NO crashea.
+ *
+ * @param {{response:string, mustInclude?:string[], redFlags?:string[]}} item
+ * @returns {{pass:boolean, mustCovered:number, mustTotal:number, redFlagsHit:number, source:'deterministic'}}
+ */
+export function scoreAntiHallucDeterministic(item = {}) {
+  const must = Array.isArray(item.mustInclude) ? item.mustInclude : [];
+  const red = Array.isArray(item.redFlags) ? item.redFlags : [];
+  const response = typeof item.response === 'string' ? item.response : '';
+
+  const mustFlex = scoreKeywordsFlexible(response, must);
+  const mustCovered = mustFlex.matched;
+  const mustTotal = must.length;
+
+  const redFlex = scoreKeywordsFlexible(response, red);
+  const redFlagsHit = redFlex.matched;
+
+  const pass = mustCovered === mustTotal && redFlagsHit === 0;
+  return { pass, mustCovered, mustTotal, redFlagsHit, source: 'deterministic' };
+}
+
+/**
+ * selectJudgeProvider — elige el proveedor de juez y resuelve el caller. Reglas:
+ *
+ *   - `provider` explícito (env `JUDGE_PROVIDER`): 'anthropic' | 'ollama' |
+ *     'deterministic'. Si no se da, AUTO: 'anthropic' si hay API key disponible,
+ *     si no 'deterministic'.
+ *   - 'anthropic' sin key → degrada a 'deterministic' (graceful, no crashea).
+ *   - 'ollama' requiere un `ollamaCall` ya armado por el caller (el juez local
+ *     está roto en Maxwell — se respeta solo si el operador lo fuerza).
+ *
+ * Devuelve `{ provider, judgeModel, judgeCall, deterministic }`:
+ *   - `judgeCall`: `(prompt)=>Promise<string>` para inyectar en scoreAntiHalluc,
+ *     o `null` si el proveedor es determinístico.
+ *   - `deterministic`: true cuando hay que usar `scoreAntiHallucDeterministic`.
+ *
+ * La key se lee vía `readAnthropicKey` (env o archivo gitignored) y NUNCA se
+ * expone en el objeto devuelto ni se loguea.
+ *
+ * @param {{
+ *   provider?: string,
+ *   env?: Record<string,string|undefined>,
+ *   ollamaCall?: (prompt:string)=>Promise<string>,
+ *   ollamaModel?: string,
+ *   fetchImpl?: typeof fetch,
+ *   keyPath?: string,
+ *   anthropicModel?: string,
+ * }} [opts]
+ * @returns {{ provider:'anthropic'|'ollama'|'deterministic', judgeModel:string, judgeCall:((p:string)=>Promise<string>)|null, deterministic:boolean }}
+ */
+export function selectJudgeProvider({
+  provider,
+  env = process.env,
+  ollamaCall,
+  ollamaModel = RECOMMENDED_OLLAMA_JUDGE_MODEL,
+  fetchImpl,
+  keyPath,
+  anthropicModel = RECOMMENDED_ANTHROPIC_JUDGE_MODEL,
+} = {}) {
+  const apiKey = readAnthropicKey({ env, keyPath });
+  const requested = (provider || (env && env.JUDGE_PROVIDER) || '').trim().toLowerCase();
+  const resolved = requested || (apiKey ? 'anthropic' : 'deterministic');
+
+  if (resolved === 'anthropic') {
+    if (!apiKey) {
+      // Pedido anthropic pero sin key → degradación graceful a determinístico.
+      return { provider: 'deterministic', judgeModel: 'deterministic', judgeCall: null, deterministic: true };
+    }
+    const judgeCall = makeAnthropicJudgeCall({ apiKey, model: anthropicModel, fetchImpl });
+    return { provider: 'anthropic', judgeModel: anthropicModel, judgeCall, deterministic: false };
+  }
+
+  if (resolved === 'ollama') {
+    return { provider: 'ollama', judgeModel: ollamaModel, judgeCall: ollamaCall || null, deterministic: false };
+  }
+
+  return { provider: 'deterministic', judgeModel: 'deterministic', judgeCall: null, deterministic: true };
 }


### PR DESCRIPTION
## Por qué

Ningún juez LLM **local** es confiable en la Maxwell M6000 (sm_52):

- `qwen2.5:14b` → devuelve respuesta **vacía** (no juzga nada)
- `llama3.1:8b` → devuelve respuesta **vacía**
- `mistral-nemo:12b` → **aprueba todo** (rubber-stamp; además crash cgo)

Por eso el juez del bench pasa a ser **Claude Haiku** (`claude-haiku-4-5`) vía la API de Anthropic, con **fallback determinístico** cuando no hay API key disponible.

## Qué cambia

`scripts/lib/bench-scorer.mjs`:
- `readAnthropicKey()` — lee la key en runtime de `process.env.ANTHROPIC_API_KEY` o, si no está, del archivo gitignored `~/.config/chagra-anthropic-judge-key` (chmod 600). Nunca la imprime/loguea. No crashea si el archivo no existe.
- `makeAnthropicJudgeCall()` — fabrica un caller `(prompt) => Promise<string>` con el **mismo contrato** que el `ollamaCall` inyectable, así enchufa directo en `scoreAntiHalluc`/`scoreWithJudge` sin tocarlos. `fetch` inyectable para tests.
- `extractAnthropicText()` — parsea `content[]` de la API de Messages.
- `scoreAntiHallucDeterministic()` — PASS si todos los `must_include` presentes (substring/lema/sinónimo) y cero `red_flags`. No carga ningún modelo.
- `selectJudgeProvider()` — elige proveedor por `JUDGE_PROVIDER=anthropic|ollama|deterministic`. AUTO: `anthropic` si hay key, si no `deterministic`. `anthropic` sin key → degrada graceful a `deterministic`.
- `RECOMMENDED_JUDGE_MODEL` → `claude-haiku-4-5` (antes `qwen2.5:14b`, roto). El id local roto se conserva en `RECOMMENDED_OLLAMA_JUDGE_MODEL` solo para forzar ollama en GPU Ampere+.

Benches: los de anti-alucinación (`bench-complejos-juez-independiente`, `bench-capabilities-A-vs-C`) ahora resuelven el juez vía `selectJudgeProvider` (Anthropic si hay key, determinístico si no). El de cobertura (`bench-agente-completo`) apunta su default local al nuevo `RECOMMENDED_OLLAMA_JUDGE_MODEL`.

## Seguridad

La API key **jamás** vive en código/commits/logs/tests. Se lee solo en runtime de env o del archivo gitignored. Los tests mockean `fetch` y la lectura de la key con placeholders (`sk-test-FAKE`) — **pasan sin key real, sin tocar la red**. `.gitignore` cubre patrones de archivos de key como defensa extra.

## Cómo lo activa el operador

`echo -n "<key>" > ~/.config/chagra-anthropic-judge-key && chmod 600 ~/.config/chagra-anthropic-judge-key` (o exportar `ANTHROPIC_API_KEY`). El bench usará Claude Haiku automáticamente. Sin key, corre con el scorer determinístico.

## Tests

54 tests del scorer + suite completa (2987) en verde. eslint `--max-warnings=0` limpio en los archivos tocados. **No se corrió el bench real** (no hay key aún).

🤖 Generated with [Claude Code](https://claude.com/claude-code)