### PR TITLE
feat(agente): chips de modo que rutean directo al tool saltando el NLU (A3/A4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.30",
+  "version": "1.0.31",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v288';
+const CACHE_NAME = 'chagra-v289';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -48,6 +48,11 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, postValidate, getClimaIdeam } from '../../services/sidecarClient';
+// CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
+// la intención forzada del chip → tool determinístico, SALTANDO el NLU
+// (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
+// los chips cuyo backend aún no existe (precio/deep).
+import { planForcedIntent, isStubIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak } from '../../services/agentService';
 import { applyOutputGuards } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
@@ -69,6 +74,7 @@ import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import QuickChipsBar from '../QuickChipsBar';
+import ChipsToolbar from '../ChipsToolbar';
 import AgentDemoExample from '../AgentDemoExample';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
@@ -168,6 +174,12 @@ export default function AgentScreen({ onBack, initialContext }) {
   // informe oficial. El banner es dismissable — al primer submit, o cuando
   // el operador cierra, desaparece. NO se persiste entre mounts.
   const [alertContextBanner, setAlertContextBanner] = useState(null);
+  // CHIPS DE MODO (A4): modo activo seleccionado en la ChipsToolbar. Cuando
+  // hay un modo activo, el siguiente submit fuerza esa intención y rutea
+  // DIRECTO al tool determinístico (saltando el NLU, A3). El placeholder del
+  // input también cambia para guiar al campesino sobre qué escribir. Es un
+  // toggle: tocar el mismo chip lo desactiva (vuelve al routing NLU normal).
+  const [activeIntent, setActiveIntent] = useState(null);
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -1247,7 +1259,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
   // completo (RAG, sidecar, LLM, TTS, action gate) para UN solo texto.
   // No toca el queue store — eso lo hace handleSubmit antes/después.
   // Tampoco hace re-entry guard porque el queue ya garantiza serialización.
-  const runAgentPipeline = async (text, { suppressUserBubble = false, visionContext = null } = {}) => {
+  const runAgentPipeline = async (text, { suppressUserBubble = false, visionContext = null, forcedIntent = null } = {}) => {
     // Bug 2026-05-31: cuando el item viene de la outbox multimodal (foto /
     // adjunto), el caller YA pintó la burbuja de usuario REAL (con su imagen).
     // Si además pintáramos aquí una burbuja con el prompt sintético ("Analicé
@@ -1331,7 +1343,56 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
             }
           }
 
-          // PASO 2 — NLU planner + tool call (flow original).
+          // PASO 2 — routing del tool.
+          //
+          // CHIPS DE MODO (A3): si el usuario forzó la intención tocando un
+          // chip, NO consultamos el NLU planner — su misrouting es justo lo
+          // que el chip evita (incidente "papa precio"). `planForcedIntent`
+          // mapea (intent, texto) → tool determinístico + args, y lo llamamos
+          // directo. El municipio sale de la finca activa para el modo clima.
+          // Si no hay chip activo, conservamos el flujo NLU original.
+          if (forcedIntent) {
+            const activeFincaClima = fincas.find((f) => f.slug === activeFincaSlug);
+            const municipioClima =
+              activeFincaClima?.municipio || FARM_CONFIG?.MUNICIPIO || null;
+            const forcedPlan = planForcedIntent(forcedIntent, textForLLM, {
+              municipio: municipioClima,
+            });
+            if (forcedPlan && forcedPlan.tool) {
+              if (forcedPlan.stub && forcedPlan.stubResult) {
+                // Modo clima sin municipio: inyectamos evidence sintética que
+                // obliga al LLM a PEDIR el municipio (NO inventar datos IDEAM).
+                toolEvidence = {
+                  tool: forcedPlan.tool,
+                  args: forcedPlan.args,
+                  result: forcedPlan.stubResult,
+                };
+                console.debug('[sidecar] chip forzado — evidence sintética', {
+                  intent: forcedIntent,
+                  tool: forcedPlan.tool,
+                  reason: forcedPlan.stubResult.reason,
+                });
+              } else {
+                const tTool0 = performance.now();
+                const result = await callTool(forcedPlan.tool, forcedPlan.args);
+                const tTool1 = performance.now();
+                if (result) {
+                  toolEvidence = { tool: forcedPlan.tool, args: forcedPlan.args, result };
+                  console.debug('[sidecar] chip forzado (NLU saltado)', {
+                    intent: forcedIntent,
+                    tool: forcedPlan.tool,
+                    latencyTool: Math.round(tTool1 - tTool0),
+                  });
+                } else {
+                  console.debug('[sidecar] chip forzado tool null', {
+                    intent: forcedIntent,
+                    tool: forcedPlan.tool,
+                  });
+                }
+              }
+            }
+          } else {
+          // PASO 2b — NLU planner + tool call (flow original, sin chip).
           const tNlu0 = performance.now();
           const plan = await planNlu(textForLLM, contextMemory);
           const tNlu1 = performance.now();
@@ -1384,6 +1445,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
               reason: plan.reason || 'no_tool',
             });
           }
+          }
 
           // PASO 3 — detección heurística frontend de intent climática
           // mientras NLU sidecar no se actualiza (TODO en nlu.ts del sidecar).
@@ -1392,8 +1454,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           // grounding macro. Optimista no-estricto: si falla → seguimos sin
           // clima inyectado (graceful degrade — el LLM tira de RAG y dice
           // "no tengo IDEAM" en último caso). Solo se ejecuta si NO hubo
-          // tool ya invocado vía NLU para no inflar contexto.
-          if (!toolEvidence) {
+          // tool ya invocado vía NLU para no inflar contexto. Tampoco corre
+          // bajo chip forzado: el chip ya decidió el tool determinístico (el
+          // modo clima tiene su propia rama), no re-inferimos por keywords.
+          if (!toolEvidence && !forcedIntent) {
             const climaKeywords = /clima|lluvia|llueve|llover|temperatura|sequ[íi]a|fr[íi]o|calor|estaci[óo]n\s+meteorol[óo]gica|ideam|precipitaci[óo]n|pron[óo]stico|reporte\s+(del\s+)?tiempo/i;
             // Bug piloto 2026-05-27: FARM_CONFIG.MUNICIPIO viene de build-time
             // env (VITE_FARM_MUNICIPIO). En prod sin esa env queda null y
@@ -1757,9 +1821,35 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     await handleSubmit(prompt);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSubmit = async (text, { fromVoice = false, suppressUserBubble = false, visionContext = null } = {}) => {
+  const handleSubmit = async (text, { fromVoice = false, suppressUserBubble = false, visionContext = null, forcedIntent = null } = {}) => {
     if (!text || !text.trim()) return;
     const trimmed = text.trim();
+
+    // CHIPS DE MODO — STUB (A3): precio/deep no tienen backend todavía. NO
+    // routeamos a un tool fantasma ni gastamos una inferencia del LLM:
+    // pintamos la pregunta del usuario + una respuesta honesta "aún no
+    // disponible" y salimos. Esto evita el misrouting del NLU (que mandaba
+    // "papa" al tool de precio inexistente) y es transparente con el campesino.
+    if (forcedIntent && isStubIntent(forcedIntent)) {
+      const stubPlan = planForcedIntent(forcedIntent, trimmed);
+      if (stubPlan && stubPlan.stub && stubPlan.stubMessage) {
+        const userMessage = { role: 'user', content: trimmed, timestamp: Date.now() };
+        const assistantMessage = {
+          role: 'assistant',
+          content: stubPlan.stubMessage,
+          timestamp: Date.now(),
+        };
+        setMessages((prev) => [...prev, userMessage, assistantMessage]);
+        try {
+          await addTurn(operatorId, { role: 'user', content: trimmed });
+          await addTurn(operatorId, { role: 'assistant', content: stubPlan.stubMessage });
+        } catch (e) {
+          console.warn('[Agent] stub addTurn failed (continuo):', e?.message);
+        }
+        setActiveIntent(null);
+        return;
+      }
+    }
 
     // El queue ya serializa. NO replicamos el guard `state !== STATE_IDLE`
     // del flow previo — eso hacía que la 2da pregunta se perdiera sin
@@ -1776,6 +1866,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     // preguntas de texto nuevas → sin foto → el guard corrige afirmaciones
     // visuales fabricadas.
     let firstVisionContext = visionContext;
+    // CHIPS DE MODO (A3): la intención forzada del chip aplica SOLO al primer
+    // texto de este submit. Los pending promovidos son preguntas nuevas — sin
+    // chip activo → rutean por el NLU normal.
+    let firstForcedIntent = forcedIntent;
 
     const route = selectChatRoute(trimmed);
     const result = useAgentQueueStore.getState().enqueue(trimmed, route);
@@ -1820,12 +1914,15 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         await runAgentPipeline(currentText, {
           suppressUserBubble: suppressFirstBubble,
           visionContext: firstVisionContext,
+          forcedIntent: firstForcedIntent,
         });
         // Solo el primer texto del caller usa la supresión / el contexto de
-        // visión; los promovidos (pending) son preguntas nuevas: pintan su
-        // propia burbuja y NO arrastran la foto del turno anterior.
+        // visión / la intención forzada del chip; los promovidos (pending) son
+        // preguntas nuevas: pintan su propia burbuja, NO arrastran la foto ni
+        // el modo del turno anterior.
         suppressFirstBubble = false;
         firstVisionContext = null;
+        firstForcedIntent = null;
       } catch (pipelineErr) {
         // runAgentPipeline ya captura todo internamente; este catch es
         // defensivo (e.g. error fuera del try interno). Marcamos failed
@@ -1895,8 +1992,13 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
   const handleTextSubmit = (e) => {
     e.preventDefault();
-    handleSubmit(inputText);
+    // CHIPS DE MODO (A3): si hay un modo activo, el submit lleva la intención
+    // forzada → runAgentPipeline salta el NLU y rutea directo al tool.
+    handleSubmit(inputText, { forcedIntent: activeIntent });
     setInputText('');
+    // El modo es de un solo uso por pregunta: tras enviar volvemos al routing
+    // NLU normal para el siguiente turno (igual que Gemini desactiva el chip).
+    setActiveIntent(null);
     // El banner de contexto de alerta es de un solo uso — al primer submit
     // el operador ya está conversando con el agente y el banner queda
     // redundante. Se reabre solo si vuelve a entrar desde la notificación.
@@ -1905,6 +2007,15 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
   const handleSuggestion = (text) => {
     handleSubmit(text);
+  };
+
+  // CHIPS DE MODO (A4): toggle del chip. Tocar un chip activa su modo (el
+  // próximo submit fuerza esa intención y salta el NLU); tocar el mismo chip
+  // de nuevo lo desactiva (vuelve al routing NLU normal). El chip 'foto' no
+  // se maneja acá — el flujo de foto vive en el compositor multimodal.
+  const handleChipSelect = (intent) => {
+    if (intent === 'foto') return; // reservado al flujo de adjuntos
+    setActiveIntent((prev) => (prev === intent ? null : intent));
   };
 
   // ── Consumo de la OUTBOX DURABLE del compositor del home ───────────────────
@@ -2088,6 +2199,12 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     drainOutbox();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // CHIPS DE MODO (A4): placeholder guía según el modo activo. Sin modo →
+  // placeholder genérico. Español colombiano (tú/usted), nunca voseo.
+  const activePlaceholder = activeIntent
+    ? (CHIP_DEFS.find((c) => c.intent === activeIntent)?.placeholder || 'Escribe tu pregunta...')
+    : 'Escribe tu pregunta...';
 
   return (
     <div className="h-full flex flex-col bg-slate-950">
@@ -2315,6 +2432,18 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         </div>
       )}
 
+      {/* CHIPS DE MODO (A4/B4): "caja de herramientas" estilo Gemini, fila
+          scrollable JUSTO sobre el input. Persistente durante toda la
+          conversación. Tocar un chip fuerza la intención del próximo submit y
+          rutea directo al tool (saltando el NLU, A3). El chip 📷 foto solo
+          aparece si hay imagen adjunta. */}
+      <ChipsToolbar
+        onSelectIntent={handleChipSelect}
+        activeIntent={activeIntent}
+        hasAttachment={false}
+        disabled={state === STATE_RECORDING}
+      />
+
       {/* Input */}
       <div className="p-4 border-t border-slate-800 bg-slate-900/80 shrink-0">
         <form onSubmit={handleTextSubmit} className="flex items-center gap-2">
@@ -2343,7 +2472,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
                 ? 'Espera — ya hay una en cola'
                 : queueProcessing
                   ? 'Adelanta otra pregunta (cola: 1 más)'
-                  : 'Escribe tu pregunta...'
+                  : activePlaceholder
             }
             disabled={state === STATE_RECORDING || queuePending.length >= 1}
             data-testid="agent-input"

--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { CHIP_DEFS } from '../services/chipIntentRouter';
+
+/**
+ * ChipsToolbar — "caja de herramientas" del agente como CHIPS DE MODO
+ * (estilo Gemini). Fila horizontal scrollable que vive JUSTO sobre el input
+ * del chat (A4/B4). Al tocar un chip, la intención queda forzada y rutea
+ * DIRECTO a la capacidad determinística, SALTANDO el NLU (A3) — el routing
+ * vive en `chipIntentRouter.planForcedIntent` y lo ejecuta AgentScreen.
+ *
+ * Diferencia frente a `QuickChipsBar`: aquél es un atajo de pantalla-nueva
+ * que inyecta texto y pasa por el NLU normal. ChipsToolbar es una barra
+ * PERSISTENTE de modos que se queda visible durante toda la conversación y
+ * fuerza la intención sin inferencia.
+ *
+ * Diseño: píldoras táctiles, alto contraste (legible al sol, campesino), área
+ * de toque cómoda (min 44px alto efectivo), scroll horizontal sin barra
+ * visible. Cada chip es un <button> con aria-pressed para el estado activo.
+ *
+ * El chip 📷 foto solo se muestra cuando hay una imagen adjunta lista
+ * (`hasAttachment`). Coordina con el flujo de adjuntos del compositor.
+ *
+ * Props:
+ *   - onSelectIntent: callback(intent: string) — el call-site decide qué hacer.
+ *                     Recibe el intent enum del chip ('siembro', 'plaga', ...,
+ *                     o 'foto' para el chip de imagen).
+ *   - activeIntent:   string | null — intent del modo activo (resalta el chip).
+ *   - hasAttachment:  boolean — si hay imagen adjunta, muestra el chip 📷 foto.
+ *   - disabled:       boolean — deshabilita todos los chips (ej. mientras graba).
+ */
+export default function ChipsToolbar({
+  onSelectIntent,
+  activeIntent = null,
+  hasAttachment = false,
+  disabled = false,
+}) {
+  if (typeof onSelectIntent !== 'function') return null;
+
+  const baseChip =
+    'shrink-0 inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full border ' +
+    'text-sm font-semibold whitespace-nowrap transition-all active:scale-95 ' +
+    'focus:outline-none focus:ring-2 focus:ring-emerald-400/60 ' +
+    'disabled:opacity-40 disabled:cursor-not-allowed';
+  // Alto contraste: activo = verde sólido sobre texto blanco; inactivo =
+  // slate-700 con borde claro (legible al sol). Toque ≥44px efectivo por padding.
+  const inactiveChip =
+    'bg-slate-700 border-slate-500 text-slate-100 hover:bg-slate-600 hover:border-slate-400';
+  const activeChip =
+    'bg-emerald-600 border-emerald-300 text-white shadow-md';
+
+  return (
+    <div
+      data-testid="chips-toolbar"
+      className="px-3 py-2 border-t border-slate-800/70 bg-slate-900/70"
+    >
+      <div
+        role="toolbar"
+        aria-label="Modos del asistente"
+        className="flex gap-2 overflow-x-auto pb-1 -mb-1 scrollbar-none"
+        style={{ scrollbarWidth: 'none', WebkitOverflowScrolling: 'touch' }}
+      >
+        {/* Chip 📷 foto: primero y SOLO si hay imagen adjunta. */}
+        {hasAttachment && (
+          <button
+            type="button"
+            data-testid="mode-chip-foto"
+            onClick={() => onSelectIntent('foto')}
+            disabled={disabled}
+            aria-pressed={activeIntent === 'foto'}
+            className={`${baseChip} ${activeIntent === 'foto' ? activeChip : inactiveChip}`}
+          >
+            <span aria-hidden="true">📷</span>
+            <span>Foto</span>
+          </button>
+        )}
+
+        {CHIP_DEFS.map((def) => {
+          const isActive = activeIntent === def.intent;
+          return (
+            <button
+              key={def.intent}
+              type="button"
+              data-testid="mode-chip"
+              data-intent={def.intent}
+              onClick={() => onSelectIntent(def.intent)}
+              disabled={disabled}
+              aria-pressed={isActive}
+              title={def.placeholder}
+              className={`${baseChip} ${isActive ? activeChip : inactiveChip}`}
+            >
+              <span aria-hidden="true">{def.emoji}</span>
+              <span>{def.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/ChipsToolbar.smoke.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.smoke.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import ChipsToolbar from '../ChipsToolbar';
+import { CHIP_DEFS } from '../../services/chipIntentRouter';
+
+/**
+ * Smoke tests A4/B4 — la barra de CHIPS DE MODO sobre el input del chat.
+ *   - renderiza los 7 chips con su emoji + label,
+ *   - clickear un chip llama onSelectIntent con el intent enum,
+ *   - el chip activo se marca aria-pressed,
+ *   - el chip 📷 foto solo aparece/activa si hay imagen adjunta,
+ *   - retorna null si falta el handler (defensa contra mounts incompletos).
+ */
+
+describe('ChipsToolbar — barra de chips de modo', () => {
+  test('renderiza los 7 chips de modo', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    const chips = screen.getAllByTestId('mode-chip');
+    expect(chips).toHaveLength(7);
+    // El emoji + label del primero (siembro) debe estar presente
+    expect(screen.getByText('¿Qué siembro?')).toBeInTheDocument();
+    expect(screen.getByText('Plaga')).toBeInTheDocument();
+    expect(screen.getByText('Investigación profunda')).toBeInTheDocument();
+  });
+
+  test('clickear un chip llama onSelectIntent con el intent enum', () => {
+    const onSelectIntent = vi.fn();
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} />);
+    fireEvent.click(screen.getByText('Plaga'));
+    expect(onSelectIntent).toHaveBeenCalledTimes(1);
+    expect(onSelectIntent).toHaveBeenCalledWith('plaga');
+  });
+
+  test('el chip activo se marca aria-pressed=true', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} activeIntent="clima" />);
+    const climaChip = screen.getByRole('button', { name: /clima/i });
+    expect(climaChip).toHaveAttribute('aria-pressed', 'true');
+    // Otro chip cualquiera no debe estar pressed
+    const siembroChip = screen.getByRole('button', { name: /siembro/i });
+    expect(siembroChip).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('cada chip de modo expone un accessible name no vacío', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} />);
+    for (const def of CHIP_DEFS) {
+      const chip = screen.getByRole('button', { name: new RegExp(def.label, 'i') });
+      expect(chip).toBeInTheDocument();
+    }
+  });
+
+  test('el chip 📷 foto NO aparece sin imagen adjunta', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} hasAttachment={false} />);
+    expect(screen.queryByTestId('mode-chip-foto')).not.toBeInTheDocument();
+  });
+
+  test('el chip 📷 foto aparece y es clickable cuando hay imagen adjunta', () => {
+    const onSelectIntent = vi.fn();
+    render(
+      <ChipsToolbar
+        onSelectIntent={onSelectIntent}
+        hasAttachment
+      />,
+    );
+    const fotoChip = screen.getByTestId('mode-chip-foto');
+    expect(fotoChip).toBeInTheDocument();
+    expect(fotoChip).not.toBeDisabled();
+    fireEvent.click(fotoChip);
+    expect(onSelectIntent).toHaveBeenCalledWith('foto');
+  });
+
+  test('retorna null si no hay handler onSelectIntent (defensa)', () => {
+    const { container } = render(<ChipsToolbar />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('ningún label de chip usa voseo argentino', () => {
+    const { container } = render(<ChipsToolbar onSelectIntent={() => {}} hasAttachment />);
+    const VOSEO = /\b(escrib[íi]|tom[áa]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|sab[ée]s)\b/i;
+    expect(container.textContent).not.toMatch(VOSEO);
+  });
+});

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHIP_INTENTS,
+  CHIP_DEFS,
+  planForcedIntent,
+  isStubIntent,
+} from '../chipIntentRouter.js';
+
+/**
+ * Tests del router de CHIPS DE MODO (A3/A4). Decisión operador 2026-06-02:
+ * los chips fuerzan la intención y rutean DIRECTO a la capacidad
+ * determinística, SALTANDO el NLU planner (que es el que misroutea, ej.
+ * el bug "papa precio"). Este módulo es PURO y testeable sin red ni montar
+ * el componente.
+ *
+ * Contrato:
+ *   planForcedIntent(intent, text, opts) → {
+ *     intent, tool, args, stub, stubMessage, prompt, skipNlu: true,
+ *   } | null  (null si intent desconocido o text vacío)
+ */
+
+describe('chipIntentRouter — enum y definiciones', () => {
+  it('expone los 7 intents del enum', () => {
+    expect(CHIP_INTENTS).toEqual({
+      siembro: 'siembro',
+      plaga: 'plaga',
+      biopreparado: 'biopreparado',
+      clima: 'clima',
+      precio: 'precio',
+      calendario: 'calendario',
+      deep: 'deep',
+    });
+  });
+
+  it('CHIP_DEFS tiene los 7 chips con label en español colombiano (sin voseo)', () => {
+    const ids = CHIP_DEFS.map((c) => c.intent);
+    expect(ids).toEqual([
+      'siembro',
+      'plaga',
+      'biopreparado',
+      'clima',
+      'precio',
+      'calendario',
+      'deep',
+    ]);
+    // Labels presentes y emoji declarado
+    for (const def of CHIP_DEFS) {
+      expect(typeof def.label).toBe('string');
+      expect(def.label.length).toBeGreaterThan(0);
+      expect(typeof def.emoji).toBe('string');
+      expect(def.emoji.length).toBeGreaterThan(0);
+      expect(typeof def.placeholder).toBe('string');
+    }
+  });
+
+  it('ningún string del chip usa voseo argentino', () => {
+    // tú/usted colombiano — NUNCA escribí/tomá/tenés/querés/elegí/dale/acá.
+    const VOSEO = /\b(escrib[íi]|tom[áa]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|dale|sab[ée]s|and[áa]|fij[áa]te)\b/i;
+    for (const def of CHIP_DEFS) {
+      expect(def.label).not.toMatch(VOSEO);
+      expect(def.placeholder).not.toMatch(VOSEO);
+      if (def.stubMessage) expect(def.stubMessage).not.toMatch(VOSEO);
+    }
+  });
+});
+
+describe('chipIntentRouter — entradas inválidas', () => {
+  it('retorna null para intent desconocido', () => {
+    expect(planForcedIntent('xxx', 'hola')).toBeNull();
+    expect(planForcedIntent(null, 'hola')).toBeNull();
+    expect(planForcedIntent(undefined, 'hola')).toBeNull();
+  });
+
+  it('retorna null para texto vacío', () => {
+    expect(planForcedIntent('siembro', '')).toBeNull();
+    expect(planForcedIntent('siembro', '   ')).toBeNull();
+    expect(planForcedIntent('siembro', null)).toBeNull();
+  });
+});
+
+describe('chipIntentRouter — intents con tool determinístico (saltan NLU)', () => {
+  it('siembro → get_species con query del texto + skipNlu', () => {
+    const plan = planForcedIntent('siembro', '¿qué tal el aguacate?');
+    expect(plan.intent).toBe('siembro');
+    expect(plan.tool).toBe('get_species');
+    expect(plan.args).toEqual({ query: '¿qué tal el aguacate?' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('plaga → get_pest_controllers con pest del texto + skipNlu', () => {
+    const plan = planForcedIntent('plaga', 'broca del café');
+    expect(plan.tool).toBe('get_pest_controllers');
+    expect(plan.args).toEqual({ pest: 'broca del café' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('biopreparado → get_biopreparados con query del texto + skipNlu', () => {
+    const plan = planForcedIntent('biopreparado', 'algo para hongos en tomate');
+    expect(plan.tool).toBe('get_biopreparados');
+    expect(plan.args).toEqual({ query: 'algo para hongos en tomate' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('clima → get_clima_ideam (action monthly_avg) con municipio del opts + skipNlu', () => {
+    const plan = planForcedIntent('clima', '¿va a llover?', { municipio: 'Choachí' });
+    expect(plan.tool).toBe('get_clima_ideam');
+    expect(plan.args.action).toBe('monthly_avg');
+    expect(plan.args.municipio).toBe('Choachí');
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('clima sin municipio → evidence stub no_municipio (pide municipio, NO inventa)', () => {
+    const plan = planForcedIntent('clima', '¿va a llover?');
+    expect(plan.tool).toBe('get_clima_ideam');
+    // sin municipio NO se llama el tool: evidence sintética que pide municipio
+    expect(plan.stub).toBe(true);
+    expect(plan.stubResult).toMatchObject({ available: false, reason: 'no_municipio' });
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('calendario → get_species con query del texto + skipNlu (no existe tool calendario dedicado)', () => {
+    // No hay get_calendario_siembra en el sidecar; el calendario se deriva de
+    // la ficha de especie (época de siembra / piso térmico). Routeamos a
+    // get_species y dejamos que el grounding traiga la info de ciclo.
+    const plan = planForcedIntent('calendario', 'maíz');
+    expect(plan.tool).toBe('get_species');
+    expect(plan.args).toEqual({ query: 'maíz' });
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+});
+
+describe('chipIntentRouter — intents STUB (backend no existe aún)', () => {
+  it('precio → stub claro "aún no disponible" (NO inventa backend de precio)', () => {
+    const plan = planForcedIntent('precio', 'papa');
+    expect(plan.intent).toBe('precio');
+    expect(plan.stub).toBe(true);
+    expect(plan.tool).toBeNull();
+    expect(typeof plan.stubMessage).toBe('string');
+    expect(plan.stubMessage.toLowerCase()).toContain('no');
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('deep → stub claro "aún no disponible" (investigación profunda)', () => {
+    const plan = planForcedIntent('deep', 'sistema agroforestal cacao');
+    expect(plan.intent).toBe('deep');
+    expect(plan.stub).toBe(true);
+    expect(plan.tool).toBeNull();
+    expect(typeof plan.stubMessage).toBe('string');
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('isStubIntent reconoce precio y deep como stub', () => {
+    expect(isStubIntent('precio')).toBe(true);
+    expect(isStubIntent('deep')).toBe(true);
+    expect(isStubIntent('siembro')).toBe(false);
+    expect(isStubIntent('plaga')).toBe(false);
+    expect(isStubIntent('clima')).toBe(false);
+    expect(isStubIntent('xxx')).toBe(false);
+  });
+});
+
+describe('chipIntentRouter — el prompt se preserva tal cual lo escribió el usuario', () => {
+  it('plan.prompt es el texto original trimmeado para todos los intents', () => {
+    for (const intent of Object.keys(CHIP_INTENTS)) {
+      const plan = planForcedIntent(intent, '  tomate cherry  ', { municipio: 'Choachí' });
+      expect(plan.prompt).toBe('tomate cherry');
+    }
+  });
+});

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -1,0 +1,238 @@
+/**
+ * chipIntentRouter.js — Router PURO de los CHIPS DE MODO (A3/A4).
+ *
+ * Decisión operador 2026-06-02: la "caja de herramientas" del agente se
+ * expone como chips de modo (estilo Gemini). Al tocar un chip, la intención
+ * queda FORZADA y rutea DIRECTO a la capacidad determinística (un MCP tool
+ * concreto), SALTANDO el NLU planner del sidecar.
+ *
+ * Racional: el NLU es el que misroutea (incidente "papa precio": el planner
+ * mandaba una pregunta de precio al tool de precio cuando el usuario quería
+ * la ficha de la papa, y viceversa). Si el usuario YA declaró su intención
+ * tocando un chip, no hay nada que inferir — vamos directo al tool.
+ *
+ * Este módulo es PURO (sin red, sin React): mapea (intent, texto, opts) a un
+ * "plan forzado" que el AgentScreen ejecuta sin pasar por `planNlu()`. Toda la
+ * lógica de routing vive acá para poder testearla en aislamiento (TDD).
+ *
+ * Enum de intención: { siembro, plaga, biopreparado, clima, precio,
+ *                      calendario, deep }.
+ *
+ * Tools determinísticos (ya existen en el sidecar, ver sidecarClient.ALLOWED_TOOLS):
+ *   - siembro      → get_species          (ficha + viabilidad de la especie)
+ *   - calendario   → get_species          (época de siembra se deriva de la ficha;
+ *                                           NO existe get_calendario_siembra dedicado)
+ *   - plaga        → get_pest_controllers  (controladores agroecológicos de la plaga)
+ *   - biopreparado → get_biopreparados     (recetas de biopreparados)
+ *   - clima        → get_clima_ideam       (IDEAM nacional; requiere municipio)
+ *
+ * Intents STUB (el backend aún NO existe — NO inventamos endpoints):
+ *   - precio → SIPSA/DANE consulta directa no disponible (dataset ZIP federado).
+ *   - deep   → investigación profunda multi-fuente sin pipeline implementado.
+ *   Ambos devuelven un mensaje honesto "aún no disponible" en vez de routear
+ *   a un tool fantasma.
+ *
+ * IMPORTANTE — español colombiano (tú/usted), NUNCA voseo argentino. Todos los
+ * strings visibles al campesino se redactan en neutro colombiano.
+ */
+
+/** Enum de intención de los chips. Las claves == valores (string union). */
+export const CHIP_INTENTS = Object.freeze({
+  siembro: 'siembro',
+  plaga: 'plaga',
+  biopreparado: 'biopreparado',
+  clima: 'clima',
+  precio: 'precio',
+  calendario: 'calendario',
+  deep: 'deep',
+});
+
+/**
+ * Definiciones declarativas de los 7 chips. El orden de este array es el orden
+ * de render en la barra. `placeholder` reemplaza el placeholder del input
+ * cuando el modo está activo, para guiar al campesino sobre qué escribir.
+ *
+ * `kind`:
+ *   - 'tool' → rutea a un tool determinístico (planForcedIntent.tool).
+ *   - 'stub' → backend no implementado; planForcedIntent.stubMessage explica.
+ */
+export const CHIP_DEFS = Object.freeze([
+  {
+    intent: CHIP_INTENTS.siembro,
+    emoji: '🌱',
+    label: '¿Qué siembro?',
+    kind: 'tool',
+    placeholder: 'Escribe la planta o di qué quieres sembrar',
+  },
+  {
+    intent: CHIP_INTENTS.plaga,
+    emoji: '🐛',
+    label: 'Plaga',
+    kind: 'tool',
+    placeholder: 'Escribe la plaga o describe el daño que ves',
+  },
+  {
+    intent: CHIP_INTENTS.biopreparado,
+    emoji: '🧪',
+    label: 'Biopreparado',
+    kind: 'tool',
+    placeholder: 'Escribe para qué plaga o planta quieres el biopreparado',
+  },
+  {
+    intent: CHIP_INTENTS.clima,
+    emoji: '🌦️',
+    label: 'Clima',
+    kind: 'tool',
+    placeholder: 'Pregunta por la lluvia o el clima de tu zona',
+  },
+  {
+    intent: CHIP_INTENTS.precio,
+    emoji: '💰',
+    label: 'Precio',
+    kind: 'stub',
+    placeholder: 'Escribe el producto del que quieres saber el precio',
+    stubMessage:
+      'La consulta de precios todavía no está disponible en Chagra. ' +
+      'Por ahora el precio mayorista lo publica el DANE (SIPSA) como archivo descargable, ' +
+      'sin consulta directa. Si quieres, te oriento a la fuente o a Corabastos.',
+  },
+  {
+    intent: CHIP_INTENTS.calendario,
+    emoji: '📅',
+    label: 'Calendario',
+    kind: 'tool',
+    placeholder: 'Escribe la planta para ver su época de siembra',
+  },
+  {
+    intent: CHIP_INTENTS.deep,
+    emoji: '🔬',
+    label: 'Investigación profunda',
+    kind: 'stub',
+    placeholder: 'Escribe el tema que quieres investigar a fondo',
+    stubMessage:
+      'La investigación profunda multi-fuente todavía no está disponible. ' +
+      'Por ahora puedo responder con el catálogo Chagra y conocimiento agronómico general. ' +
+      'Pregúntame de forma concreta y te ayudo con lo que tengo.',
+  },
+]);
+
+const DEF_BY_INTENT = Object.freeze(
+  CHIP_DEFS.reduce((acc, def) => {
+    acc[def.intent] = def;
+    return acc;
+  }, {}),
+);
+
+/**
+ * ¿Este intent es un STUB (backend no implementado)?
+ * @param {string} intent
+ * @returns {boolean}
+ */
+export function isStubIntent(intent) {
+  const def = DEF_BY_INTENT[intent];
+  return Boolean(def && def.kind === 'stub');
+}
+
+/**
+ * Mapea un chip (intención forzada) + texto del usuario a un plan
+ * determinístico que el AgentScreen ejecuta SIN pasar por el NLU.
+ *
+ * @param {string} intent — uno de CHIP_INTENTS.
+ * @param {string} text — texto crudo del usuario (lo que escribió en el input).
+ * @param {object} [opts]
+ * @param {string|null} [opts.municipio] — municipio de la finca activa (para clima).
+ * @returns {null | {
+ *   intent: string,
+ *   tool: string | null,        // tool determinístico, o null si stub
+ *   args: object | null,        // args del tool (forma específica por tool)
+ *   stub: boolean,              // true → no hay tool real
+ *   stubResult: object | null,  // evidence sintética inyectable (ej. clima no_municipio)
+ *   stubMessage: string | null, // mensaje honesto "aún no disponible" para el usuario
+ *   prompt: string,             // texto del usuario trimmeado (lo que se manda al LLM/burbuja)
+ *   skipNlu: true,              // SIEMPRE true: el chip salta el NLU planner
+ * }}
+ */
+export function planForcedIntent(intent, text, opts = {}) {
+  const def = DEF_BY_INTENT[intent];
+  if (!def) return null;
+  if (typeof text !== 'string') return null;
+  const prompt = text.trim();
+  if (!prompt) return null;
+
+  const base = {
+    intent,
+    tool: null,
+    args: null,
+    stub: false,
+    stubResult: null,
+    stubMessage: null,
+    prompt,
+    skipNlu: true,
+  };
+
+  switch (intent) {
+    case CHIP_INTENTS.siembro:
+    case CHIP_INTENTS.calendario:
+      // Ficha de especie. El calendario/época de siembra se deriva de la ficha
+      // (no hay get_calendario_siembra dedicado en el sidecar). El grounding
+      // trae piso térmico / ciclo y el LLM lo expone como época de siembra.
+      return { ...base, tool: 'get_species', args: { query: prompt } };
+
+    case CHIP_INTENTS.plaga:
+      // Controladores agroecológicos de la plaga (AGE Cypher).
+      return { ...base, tool: 'get_pest_controllers', args: { pest: prompt } };
+
+    case CHIP_INTENTS.biopreparado:
+      // Recetas de biopreparados del catálogo.
+      return { ...base, tool: 'get_biopreparados', args: { query: prompt } };
+
+    case CHIP_INTENTS.clima: {
+      const municipio =
+        typeof opts.municipio === 'string' && opts.municipio.trim()
+          ? opts.municipio.trim()
+          : null;
+      if (!municipio) {
+        // Sin municipio NO llamamos el tool: inyectamos evidence sintética
+        // que obliga al LLM a PEDIR el municipio (NO inventar datos de IDEAM).
+        // Mismo contrato que la heurística de clima existente en AgentScreen.
+        return {
+          ...base,
+          tool: 'get_clima_ideam',
+          args: { action: 'monthly_avg' },
+          stub: true,
+          stubResult: {
+            available: false,
+            reason: 'no_municipio',
+            hint: 'pedirle al usuario su municipio para consultar IDEAM',
+          },
+        };
+      }
+      const desde = isoDaysAgo(30);
+      return {
+        ...base,
+        tool: 'get_clima_ideam',
+        args: { action: 'monthly_avg', municipio, metric: 'precipitation', desde },
+      };
+    }
+
+    case CHIP_INTENTS.precio:
+    case CHIP_INTENTS.deep:
+      // STUB: backend no implementado. NO inventamos endpoint.
+      return { ...base, stub: true, stubMessage: def.stubMessage };
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fecha ISO (YYYY-MM-DD) de hace N días. Aislado para testabilidad y para no
+ * acoplar el router a Date.now() en el switch.
+ * @param {number} days
+ * @returns {string}
+ */
+function isoDaysAgo(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+}

--- a/tests/agent-anti-halluc.spec.js
+++ b/tests/agent-anti-halluc.spec.js
@@ -607,6 +607,117 @@ test.describe('AgentScreen — sidecar pipeline (flag-dependent)', () => {
     await expect(badge.last()).toBeVisible({ timeout: 30_000 });
     await expect(badge.last()).toHaveAttribute('data-source', 'tool-no-match');
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02) — el chip fuerza la
+  // intención y rutea DIRECTO al tool determinístico, SALTANDO el NLU. Estos
+  // tests prueban el contrato observable: con un chip activo, el front llama
+  // el tool correcto y NUNCA toca el endpoint /nlu del sidecar.
+  // ──────────────────────────────────────────────────────────────────────
+
+  test('Caso L — chip Plaga rutea a get_pest_controllers SIN llamar /nlu', async ({ page }) => {
+    let nluCalled = false;
+    let pestToolCalled = false;
+    // Interceptamos ANTES de mockSidecar para contar los hits (last-added wins
+    // por URL exacta, así que registramos el counter en page.route que gana).
+    await page.context().route('**/api/mcp/agro/nlu', (route) => {
+      nluCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ use_tool: false, tool: null, args: null }),
+      });
+    });
+    await page.context().route('**/api/mcp/agro/tools/get_pest_controllers', (route) => {
+      pestToolCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          found: true,
+          pest: 'broca del café',
+          controllers: [{ id: 'beauveria_bassiana', nombre: 'Beauveria bassiana' }],
+        }),
+      });
+    });
+    await mockSidecar(page);
+    await mockLLM(page, {
+      content: 'Para la broca del café usa Beauveria bassiana, un hongo entomopatógeno.',
+    });
+
+    await gotoAgentScreen(page);
+    // Activar el chip Plaga y enviar.
+    await page.getByRole('button', { name: /Plaga/i }).click();
+    await askAgent(page, 'broca del café');
+
+    await expect(page.getByText(/Beauveria bassiana/)).toBeVisible({ timeout: 30_000 });
+    expect(pestToolCalled).toBe(true);
+    expect(nluCalled).toBe(false); // ← el contrato clave: el chip SALTA el NLU.
+  });
+
+  test('Caso M — chip ¿Qué siembro? rutea a get_species SIN llamar /nlu', async ({ page }) => {
+    let nluCalled = false;
+    let speciesToolCalled = false;
+    await page.context().route('**/api/mcp/agro/nlu', (route) => {
+      nluCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ use_tool: false, tool: null, args: null }),
+      });
+    });
+    await page.context().route('**/api/mcp/agro/tools/get_species', (route) => {
+      speciesToolCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          found: true,
+          matches_count: 1,
+          nombre_cientifico: 'Persea americana Mill.',
+        }),
+      });
+    });
+    await mockSidecar(page);
+    await mockLLM(page, {
+      content: 'El aguacate (Persea americana Mill.) crece bien entre 1000 y 2000 msnm.',
+    });
+
+    await gotoAgentScreen(page);
+    await page.getByRole('button', { name: /Qué siembro/i }).click();
+    await askAgent(page, 'aguacate');
+
+    await expect(page.getByText(/Persea americana/)).toBeVisible({ timeout: 30_000 });
+    expect(speciesToolCalled).toBe(true);
+    expect(nluCalled).toBe(false);
+  });
+
+  test('Caso N — chip Precio responde stub honesto SIN llamar /nlu ni LLM', async ({ page }) => {
+    let nluCalled = false;
+    let llmCalled = false;
+    await page.context().route('**/api/mcp/agro/nlu', (route) => {
+      nluCalled = true;
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+    await page.context().route('**/api/ollama/v1/chat/completions', (route) => {
+      llmCalled = true;
+      route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: buildSSEResponse('respuesta del LLM que NO debería aparecer'),
+      });
+    });
+    await mockSidecar(page);
+
+    await gotoAgentScreen(page);
+    await page.getByRole('button', { name: /Precio/i }).click();
+    await askAgent(page, 'papa');
+
+    // El stub responde con un mensaje honesto "no disponible" sin tocar red.
+    await expect(page.getByText(/no está disponible/i)).toBeVisible({ timeout: 15_000 });
+    expect(nluCalled).toBe(false);
+    expect(llmCalled).toBe(false);
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Qué

Implementa la "caja de herramientas" del agente como **chips de modo estilo Gemini** (A4/B4) que **rutean directo a la capacidad determinística, saltando el NLU** (A3). Decisión operador 2026-06-02: el NLU es el que misroutea (incidente "papa precio"); si el usuario declara su intención tocando un chip, no hay nada que inferir.

## Cómo

- **`src/services/chipIntentRouter.js`** — router PURO (sin red, sin React). Enum `{siembro,plaga,biopreparado,clima,precio,calendario,deep}` → plan determinístico:
  - `siembro` / `calendario` → `get_species` (la época de siembra se deriva de la ficha; no existe un `get_calendario_siembra` dedicado en el sidecar)
  - `plaga` → `get_pest_controllers`
  - `biopreparado` → `get_biopreparados`
  - `clima` → `get_clima_ideam` (si no hay municipio, inyecta evidence sintética `no_municipio` que obliga al LLM a pedirlo — NO inventa datos IDEAM)
  - `precio` / `deep` → **stub honesto "aún no disponible"** (no se inventa backend; responde sin tocar el LLM)
- **`src/components/ChipsToolbar.jsx`** — fila scrollable de chips, alto contraste, táctil, accesible (`aria-pressed`, `role="toolbar"`). Chip 📷 foto condicional a imagen adjunta.
- **`AgentScreen.jsx`** — `forcedIntent` viaja por `handleSubmit` → `runAgentPipeline`. Con chip activo se llama el tool directo y **se omite `planNlu`**; el flujo NLU original queda intacto cuando no hay chip. Placeholder del input guía según el modo.

## Tests

- `chipIntentRouter.test.js` (15) — enum, routing por intent, stubs, anti-voseo.
- `ChipsToolbar.smoke.test.jsx` (8) — render de los 7 chips, `onSelectIntent`, estado activo, chip foto condicional, anti-voseo.
- E2E `agent-anti-halluc.spec.js` Caso L/M/N (flag-gated) — **chip → tool correcto y `/nlu` NUNCA llamado**; stub responde sin red.
- Suite unit completa verde (186 archivos / 2984 tests). `eslint --max-warnings=0` limpio en los archivos del PR.

## Notas

- Strings en español colombiano (tú/usted), sin voseo argentino (verificado por test).
- PWA puro — no toca sidecar/agro-mcp ni infra.
- Chips `precio` y `deep` quedan **explícitamente como stub** (backend inexistente) — honesto, no fantasma.
- `lefthook` no estaba en PATH del worktree → bump de versión (1.0.30→1.0.31 + `chagra-v289`), eslint, secret-scan, infra-refs-scan, pro-import-scan y tests corridos a mano. La build de Vite compila limpio (el `prebuild` de catálogo SQLite falla solo por ABI mismatch de `better-sqlite3` en el entorno local, ajeno a este cambio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)