### PR TITLE
feat(agente): transición home→agente perceptible + adjuntar solo fotos (B1/B2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.31",
+  "version": "1.0.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v289';
+const CACHE_NAME = 'chagra-v290';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -21,6 +21,10 @@ import { analyzeFoliage } from '../../services/aiService';
 // Extraída para poder testearla sin montar el componente (bug foto 2026-05-31).
 import { processPhotoItem, buildPhotoUserMessage } from '../../services/agentOutboxPhoto';
 import { isAnalyzableImageAttachment, buildAttachmentRejection } from '../../services/agentOutboxAttachment';
+// B1 (2026-06-02): animación de ENTRADA al agente. El home anima el envío, pero
+// el cambio de pantalla era un corte seco ("casi no se nota"). El contenedor
+// raíz entra con un fade+rise deliberado (~460ms), respetando reduced-motion.
+import { AGENT_ENTRANCE_CSS, agentEntranceClass } from './agentEntrance';
 import {
   addTurn,
   getFullHistory,
@@ -95,6 +99,10 @@ const STATE_RECORDING = 'recording';
 const STATE_THINKING = 'thinking';
 
 export default function AgentScreen({ onBack, initialContext }) {
+  // B1: clase de animación de entrada, resuelta UNA vez al montar (no en cada
+  // re-render — si no, la animación se reiniciaría con cada mensaje). Vacía bajo
+  // prefers-reduced-motion.
+  const entranceClassRef = useRef(agentEntranceClass());
   const operatorId = usePrefsStore((s) => s.operatorId) || 'default-operator';
   // Task #122 (2026-05-23): ttsEnabled global persistido en usePrefsStore.
   // Antes era useState local — al cambiarlo en otra pantalla (header
@@ -2207,7 +2215,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     : 'Escribe tu pregunta...';
 
   return (
-    <div className="h-full flex flex-col bg-slate-950">
+    <div className={`h-full flex flex-col bg-slate-950 ${entranceClassRef.current}`}>
+      {/* B1: animación de entrada (fade+rise) para que se perciba el cruce al
+          agente. Respeta prefers-reduced-motion vía @media en el CSS. */}
+      <style>{AGENT_ENTRANCE_CSS}</style>
       {/* Header con avatar colibrí Chagra IA (operator bug #920 no aplicó el avatar al header) */}
       <div className="px-4 py-3 flex items-center gap-3 border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm shrink-0">
         <button

--- a/src/components/AgentScreen/__tests__/agentEntrance.test.js
+++ b/src/components/AgentScreen/__tests__/agentEntrance.test.js
@@ -1,0 +1,81 @@
+/**
+ * agentEntrance.test.js — contrato de la animación de ENTRADA al AgentScreen.
+ *
+ * B1 (2026-06-02): el operador reportó que la transición home→agente "es muy
+ * rápida y casi no se nota". El compositor del home ya animaba el envío, pero el
+ * cambio de pantalla era un corte seco. Acá probamos el módulo PURO que define
+ * la animación de entrada: duración deliberada (400–600ms), respeto a
+ * prefers-reduced-motion, y CSS con el @media de reducción de movimiento.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  AGENT_ENTRANCE_MS,
+  AGENT_ENTRANCE_CLASS,
+  AGENT_ENTRANCE_CSS,
+  agentEntranceClass,
+  prefersReducedMotion,
+} from '../agentEntrance.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubReducedMotion(matches) {
+  vi.stubGlobal('matchMedia', (q) => ({
+    matches: q.includes('reduce') ? matches : false,
+    media: q,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe('agentEntrance — duración deliberada', () => {
+  it('la duración está en el rango pedido (400–600ms): perceptible, no lenta', () => {
+    expect(AGENT_ENTRANCE_MS).toBeGreaterThanOrEqual(400);
+    expect(AGENT_ENTRANCE_MS).toBeLessThanOrEqual(600);
+  });
+
+  it('el CSS usa esa misma duración (sin números mágicos desincronizados)', () => {
+    expect(AGENT_ENTRANCE_CSS).toContain(`${AGENT_ENTRANCE_MS}ms`);
+  });
+});
+
+describe('agentEntrance — respeta prefers-reduced-motion', () => {
+  it('con reduced-motion → no emite la clase de animación', () => {
+    stubReducedMotion(true);
+    expect(prefersReducedMotion()).toBe(true);
+    expect(agentEntranceClass()).toBe('');
+  });
+
+  it('sin reduced-motion → emite la clase de entrada', () => {
+    stubReducedMotion(false);
+    expect(prefersReducedMotion()).toBe(false);
+    expect(agentEntranceClass()).toBe(AGENT_ENTRANCE_CLASS);
+  });
+
+  it('acepta override explícito (para tests deterministas)', () => {
+    expect(agentEntranceClass(true)).toBe('');
+    expect(agentEntranceClass(false)).toBe(AGENT_ENTRANCE_CLASS);
+  });
+
+  it('el CSS desactiva la animación bajo @media (prefers-reduced-motion: reduce)', () => {
+    expect(AGENT_ENTRANCE_CSS).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    // Dentro del media query, la clase pone animation: none.
+    const mediaBlock = AGENT_ENTRANCE_CSS.slice(
+      AGENT_ENTRANCE_CSS.indexOf('@media'),
+    );
+    expect(mediaBlock).toContain(AGENT_ENTRANCE_CLASS);
+    expect(mediaBlock).toMatch(/animation:\s*none/);
+  });
+});
+
+describe('agentEntrance — tolerante a entornos sin matchMedia', () => {
+  it('sin window.matchMedia → asume no-reduce (anima)', () => {
+    vi.stubGlobal('matchMedia', undefined);
+    expect(prefersReducedMotion()).toBe(false);
+    expect(agentEntranceClass()).toBe(AGENT_ENTRANCE_CLASS);
+  });
+});

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -1,0 +1,76 @@
+/**
+ * agentEntrance.js — animación de ENTRADA al AgentScreen (B1, 2026-06-02).
+ *
+ * Problema (operador): "en el home de Chagra la transición al agente sigue
+ * siendo muy rápida y casi no se nota". El compositor del home (AgentHero) ya
+ * hacía un shimmer/lift de "envío" (~520ms) antes de navegar, PERO el cambio de
+ * pantalla en sí era un corte seco: el AgentScreen aparecía instantáneo, sin
+ * movimiento de ENTRADA. Resultado: la transición se sentía abrupta y "casi no
+ * se notaba" que el usuario había aterrizado en el agente.
+ *
+ * Fix: el contenedor raíz del AgentScreen entra con un fade + rise suaves y
+ * deliberados (~460ms con easing de salida), de modo que el usuario PERCIBE que
+ * cruzó al agente. Respeta `prefers-reduced-motion` con el patrón establecido
+ * en el resto del código (CSS `@media (prefers-reduced-motion: reduce)` desactiva
+ * la animación) + un helper JS para que el contrato sea testeable sin DOM.
+ *
+ * PURO y SÍNCRONO — sin React. Reutilizable y testeable.
+ */
+
+/**
+ * Duración de la animación de entrada al AgentScreen, en ms. Dentro del rango
+ * "deliberado pero no lento" pedido por el operador (400–600ms). Exportada para
+ * los tests y para poder sincronizar otros efectos si hiciera falta.
+ */
+export const AGENT_ENTRANCE_MS = 460;
+
+/** Clase CSS que dispara la animación de entrada (definida en AGENT_ENTRANCE_CSS). */
+export const AGENT_ENTRANCE_CLASS = 'chagra-agent-enter';
+
+/**
+ * CSS de la animación de entrada. Se inyecta una sola vez vía <style> en el
+ * AgentScreen. El bloque `@media (prefers-reduced-motion: reduce)` apaga la
+ * animación para quien la pidió — mismo patrón que AgentHero/BiopunkBackground.
+ */
+export const AGENT_ENTRANCE_CSS = `
+@keyframes chagra-agent-enter-kf {
+  0% { opacity: 0; transform: translateY(14px) scale(0.985); }
+  60% { opacity: 1; }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+.${AGENT_ENTRANCE_CLASS} {
+  animation: chagra-agent-enter-kf ${AGENT_ENTRANCE_MS}ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  transform-origin: 50% 0%;
+  will-change: opacity, transform;
+}
+@media (prefers-reduced-motion: reduce) {
+  .${AGENT_ENTRANCE_CLASS} { animation: none !important; }
+}
+`;
+
+/**
+ * ¿El usuario pidió reducir el movimiento? Tolerante a entornos sin matchMedia
+ * (SSR/tests): ante la duda, devuelve false (no reduce).
+ *
+ * @returns {boolean}
+ */
+export function prefersReducedMotion() {
+  return typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    : false;
+}
+
+/**
+ * Devuelve la clase de entrada a aplicar al contenedor raíz del AgentScreen.
+ * Si el usuario pidió reduced-motion → cadena vacía (sin animación). El CSS de
+ * arriba ya neutraliza la animación bajo reduced-motion vía @media; este helper
+ * es la defensa JS equivalente (y el contrato testeable): nunca emite la clase
+ * de animación cuando el usuario pidió quietud.
+ *
+ * @param {boolean} [reduce] — override explícito (para tests). Si se omite, se
+ *   consulta `prefersReducedMotion()`.
+ * @returns {string} `AGENT_ENTRANCE_CLASS` o `''`.
+ */
+export function agentEntranceClass(reduce = prefersReducedMotion()) {
+  return reduce ? '' : AGENT_ENTRANCE_CLASS;
+}

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -3,6 +3,7 @@ import { Mic, Square, Camera, Paperclip, ArrowUp, X } from 'lucide-react';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { captureAndCompress } from '../../services/photoService';
+import { isAnalyzableImageAttachment } from '../../services/agentOutboxAttachment';
 import useAgentOutboxStore from '../../store/useAgentOutboxStore';
 import { agentSounds } from '../../services/agentSoundService';
 
@@ -68,9 +69,13 @@ export const SEND_TRANSITION_MS = 520;
 export default function AgentHero({ onNavigate }) {
     const [tipIndex, setTipIndex] = useState(0);
     const [text, setText] = useState('');
-    // Adjunto en staging (foto/archivo) antes de enviar. { blob, mime, fileName,
-    // previewUrl, kind } — kind: 'photo' | 'attachment'.
+    // Adjunto en staging (SIEMPRE una foto) antes de enviar. { blob, mime,
+    // fileName, previewUrl, kind: 'photo' }. B2 (2026-06-02): el agente solo
+    // "ve" imágenes vía visión, así que el compositor solo acepta fotos.
     const [attachment, setAttachment] = useState(null);
+    // Aviso breve cuando el usuario intenta adjuntar algo que no es una imagen
+    // (algunos OS ignoran `accept="image/*"` y dejan elegir cualquier archivo).
+    const [pickError, setPickError] = useState('');
     const [busy, setBusy] = useState(false);
     // Fase de la transición de envío: 'idle' | 'sending'. En 'sending' el
     // compositor hace un shimmer breve y el avatar pasa a 'thinking' antes de
@@ -209,32 +214,37 @@ export default function AgentHero({ onNavigate }) {
     };
 
     // ── Cámara / foto ─────────────────────────────────────────────────────────
+    // B2 (2026-06-02): el agente SOLO "ve" imágenes (vía visión). El botón de
+    // adjuntar y el de cámara usan `accept="image/*"`, pero algunos sistemas
+    // operativos ignoran ese atributo y dejan elegir cualquier archivo. Por eso
+    // validamos también acá: si lo elegido NO es una imagen, NO lo dejamos en
+    // staging y avisamos claro y corto, en castellano colombiano. Reusamos
+    // `isAnalyzableImageAttachment` para clasificar igual que el agente.
     const handlePhotoPick = async (e, kind) => {
         const file = e.target.files && e.target.files[0];
         // Permitir re-seleccionar el mismo archivo después.
         e.target.value = '';
         if (!file) return;
+        const looksLikeImage =
+            (file.type && file.type.startsWith('image/')) ||
+            isAnalyzableImageAttachment({ mime: file.type, fileName: file.name });
+        if (!looksLikeImage) {
+            // No es una foto → rechazo claro, sin staging.
+            setPickError('Por ahora solo puedo ver fotos. Mándame una foto de tu planta o cultivo.');
+            return;
+        }
+        setPickError('');
         setBusy(true);
         try {
-            // Reusa la compresión/normalización HEIC→JPEG de photoService para
-            // imágenes; los adjuntos no-imagen van tal cual.
-            if (file.type.startsWith('image/')) {
-                const { blob, mime } = await captureAndCompress(file);
-                const previewUrl = URL.createObjectURL(blob);
-                setAttachment({ blob, mime, fileName: file.name || 'foto.jpg', previewUrl, kind: 'photo' });
-            } else {
-                setAttachment({
-                    blob: file,
-                    mime: file.type || 'application/octet-stream',
-                    fileName: file.name || 'archivo',
-                    previewUrl: null,
-                    kind: 'attachment',
-                });
-            }
+            // Reusa la compresión/normalización HEIC→JPEG de photoService.
+            const { blob, mime } = await captureAndCompress(file);
+            const previewUrl = URL.createObjectURL(blob);
+            setAttachment({ blob, mime, fileName: file.name || 'foto.jpg', previewUrl, kind: 'photo' });
             // Devolver foco al textarea para que pueda escribir un caption.
             requestAnimationFrame(() => textareaRef.current?.focus());
         } catch (err) {
-            console.error('[AgentHero] no se pudo procesar el archivo:', err);
+            console.error('[AgentHero] no se pudo procesar la foto:', err);
+            setPickError('No pude procesar esa foto. Inténtalo de nuevo con otra imagen.');
         } finally {
             setBusy(false);
         }
@@ -244,6 +254,7 @@ export default function AgentHero({ onNavigate }) {
     const clearAttachment = () => {
         if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
         setAttachment(null);
+        setPickError('');
     };
 
     const canSend = !busy && (text.trim().length > 0 || Boolean(attachment));
@@ -444,12 +455,12 @@ export default function AgentHero({ onNavigate }) {
                         >
                             <Camera size={19} aria-hidden="true" />
                         </button>
-                        {/* Adjuntar archivo */}
+                        {/* Adjuntar foto — B2: solo imágenes (el agente solo ve fotos) */}
                         <button
                             type="button"
                             onClick={() => fileInputRef.current?.click()}
                             disabled={busy || isRecording}
-                            aria-label="Adjuntar archivo"
+                            aria-label="Adjuntar una foto"
                             className="w-9 h-9 rounded-full hover:bg-white/10 active:bg-white/15 flex items-center justify-center text-slate-300 disabled:opacity-40 transition-colors"
                         >
                             <Paperclip size={18} aria-hidden="true" />
@@ -491,7 +502,9 @@ export default function AgentHero({ onNavigate }) {
                         </button>
                     </div>
 
-                    {/* Inputs ocultos: cámara (capture) y archivo genérico */}
+                    {/* Inputs ocultos — AMBOS solo imágenes (B2). La cámara abre
+                        captura en vivo (capture="environment"); el adjuntar abre
+                        la galería de fotos. El agente solo "ve" imágenes. */}
                     <input
                         ref={cameraInputRef}
                         type="file"
@@ -503,14 +516,22 @@ export default function AgentHero({ onNavigate }) {
                     <input
                         ref={fileInputRef}
                         type="file"
+                        accept="image/*"
                         className="hidden"
-                        onChange={(e) => handlePhotoPick(e, 'attachment')}
+                        onChange={(e) => handlePhotoPick(e, 'photo')}
                     />
                 </div>
 
                 {recorderError && (
                     <p className="mt-2 text-xs text-rose-300 px-1" role="alert">
                         No pude acceder al micrófono. Revisa los permisos.
+                    </p>
+                )}
+
+                {/* B2: aviso cuando se intenta adjuntar algo que no es una foto. */}
+                {pickError && (
+                    <p className="mt-2 text-xs text-amber-300 px-1" role="alert">
+                        {pickError}
                     </p>
                 )}
 

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -261,6 +261,69 @@ describe('AgentHero — transición de envío premium (bug 2026-05-31)', () => {
   });
 });
 
+describe('AgentHero — adjuntar SOLO fotos (B2, 2026-06-02)', () => {
+  test('el input de adjuntar acepta solo imágenes (accept="image/*")', () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    // Dos inputs de archivo: cámara (con capture) y adjuntar (sin capture).
+    // Ambos deben restringir a imágenes — el agente solo "ve" fotos vía visión.
+    const inputs = Array.from(container.querySelectorAll('input[type="file"]'));
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    for (const input of inputs) {
+      expect(input.getAttribute('accept')).toBe('image/*');
+    }
+  });
+
+  test('el input de cámara conserva capture="environment" (foto en vivo)', () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const cameraInput = container.querySelector('input[capture]');
+    expect(cameraInput).toBeTruthy();
+    expect(cameraInput.getAttribute('accept')).toBe('image/*');
+    expect(cameraInput.getAttribute('capture')).toBe('environment');
+  });
+
+  test('si se cuela un no-imagen (PDF): NO lo deja en staging y avisa claro', async () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const file = new File(['%PDF-1.4'], 'hoja-de-vida.pdf', { type: 'application/pdf' });
+    // Usamos el input de adjuntar (sin capture). Aunque tenga accept="image/*",
+    // algunos OS dejan elegir cualquier archivo → el guard de pick lo rechaza.
+    const attachInput = container.querySelector('input[type="file"]:not([capture])');
+    await act(async () => {
+      fireEvent.change(attachInput, { target: { files: [file] } });
+    });
+    // No se crea preview de adjunto.
+    expect(screen.queryByText('Foto lista para enviar')).toBeNull();
+    expect(screen.queryByText('hoja-de-vida.pdf')).toBeNull();
+    // Mensaje claro en castellano colombiano.
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/solo puedo ver fotos|solo.*fotos/i);
+    // El botón enviar sigue deshabilitado (no hay adjunto válido ni texto).
+    expect(screen.getByLabelText('Enviar al agente')).toBeDisabled();
+  });
+
+  test('el aviso de no-imagen no usa voseo argentino', async () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const file = new File(['x'], 'audio.mp3', { type: 'audio/mpeg' });
+    const attachInput = container.querySelector('input[type="file"]:not([capture])');
+    await act(async () => {
+      fireEvent.change(attachInput, { target: { files: [file] } });
+    });
+    const alert = await screen.findByRole('alert');
+    const t = alert.textContent || '';
+    expect(t).not.toMatch(/mandá|contame|elegí|tenés|podés|querés|enviá|mostrá/i);
+  });
+
+  test('una imagen válida sí queda en staging (el guard no bloquea fotos)', async () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const file = new File(['img'], 'planta.jpg', { type: 'image/jpeg' });
+    const attachInput = container.querySelector('input[type="file"]:not([capture])');
+    await act(async () => {
+      fireEvent.change(attachInput, { target: { files: [file] } });
+    });
+    await screen.findByText('Foto lista para enviar');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});
+
 describe('AgentHero — voseo (español colombiano)', () => {
   test('los textos visibles usan tú/usted, sin voseo argentino', () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);


### PR DESCRIPTION
## B1 — Transición home→agente perceptible

**Dónde estaba:** El compositor del home (`AgentHero`) ya animaba el ENVÍO (shimmer + lift, `SEND_TRANSITION_MS=520`, #1232) antes de navegar, y respetaba `prefers-reduced-motion`. Pero el cambio de pantalla en sí era un **corte seco**: `App.jsx` renderiza `AgentScreen` dentro de un `<Suspense>` sin transición, así que el agente montaba instantáneo. Resultado: "casi no se nota" que el usuario entró al agente — faltaba el movimiento de **llegada**.

**Qué cambié:** Agregué una animación de **entrada** (fade + rise suave, ~460ms, easing de salida `cubic-bezier(0.22,0.61,0.36,1)`) al contenedor raíz de `AgentScreen`. Cubre **todos** los caminos de entrada (compositor, chips, FAB, tile, alerta crítica), no solo el envío. Lógica en un módulo puro nuevo `agentEntrance.js` (constantes + helper testeable). Respeta `prefers-reduced-motion` con el patrón establecido en el repo: `@media (prefers-reduced-motion: reduce)` en el CSS + helper JS `agentEntranceClass()` que no emite la clase de animación bajo reduced-motion.

> Honesto: el mecanismo de timing del **envío** ya existía y estaba en rango (520ms). El gap real era la ausencia de animación de **arribo** del AgentScreen. No toqué el shimmer/lift del home ni el avatar/colibrí.

## B2 — Adjuntar = SOLO fotos

**Dónde estaba:** `AgentHero` tenía dos inputs — cámara (`accept=image/*` + `capture`) y un input de adjuntar **sin restricción** (cualquier archivo). `handlePhotoPick` incluso tenía una rama `else` que dejaba en staging adjuntos no-imagen. El agente solo "ve" imágenes vía visión; el guard runtime (#1234) ya respondía honesto al llegar al agente, pero el usuario igual podía adjuntar cualquier cosa.

**Qué cambié:** Ambos inputs ahora usan `accept="image/*"` (la cámara conserva `capture="environment"`). El guard de pick clasifica con `isAnalyzableImageAttachment` (reuso del helper del agente) y, si lo elegido NO es imagen (algunos OS ignoran `accept`), **no lo deja en staging** y muestra un aviso claro en castellano colombiano: *"Por ahora solo puedo ver fotos. Mándame una foto de tu planta o cultivo."* El guard runtime del agente se conserva como defensa en profundidad.

## Tests

- `src/components/AgentScreen/__tests__/agentEntrance.test.js` (nuevo): duración en rango 400–600ms, CSS sincronizado, respeto a reduced-motion (con/sin/override + sin matchMedia), `@media` presente.
- `AgentHero.composer.test.jsx` (+5 casos B2): ambos inputs `accept=image/*`, cámara conserva `capture`, PDF/audio rechazados sin staging + alerta clara, sin voseo, foto válida sí entra.

**Suite:** 2996 passed · 1 skipped (187 files). ESLint `--max-warnings=0` limpio en los archivos tocados. Conventional commits + auto-bump (1.0.31→1.0.32, `chagra-v289→v290`) vía lefthook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)