### PR TITLE
feat(guards): auto-validar binomios vs catálogo post-LLM (A24)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -58,7 +58,7 @@ import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities,
 // los chips cuyo backend aún no existe (precio/deep).
 import { planForcedIntent, isStubIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak } from '../../services/agentService';
-import { applyOutputGuards } from '../../services/outputGuards';
+import { applyOutputGuards, applyTaxonomyGuard } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
@@ -1607,7 +1607,30 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       if (guarded.modified) {
         console.debug('[guards] salida corregida', { reasons: guarded.reasons });
       }
-      const response = guarded.text;
+      // A24 — guard ASYNC anti-alucinación taxonómica: valida binomios Linneanos
+      // del texto contra el catálogo vía `validate_taxonomy`. Solo corrige cuando
+      // el tool confirma explícitamente `valid:false`; ante tool caído / offline /
+      // flag off → no-op (conservador, no rompe respuestas correctas). Corre AQUÍ
+      // (después de applyOutputGuards, antes de postValidate) para que la
+      // corrección quede en la respuesta final que se persiste y se muestra.
+      let response = guarded.text;
+      let taxonomyModified = false;
+      if (isOnline && isSidecarEnabled()) {
+        try {
+          const taxResult = await applyTaxonomyGuard(response, {
+            callTool,
+            resolvedEntities,
+          });
+          if (taxResult.modified) {
+            response = taxResult.text;
+            taxonomyModified = true;
+            console.debug('[guards] taxonomía corregida', { reason: taxResult.reason });
+          }
+        } catch (taxErr) {
+          // Jamás bloquea el chat — la respuesta ya está disponible.
+          console.debug('[guards] taxonomy-guard fail (sigo sin corrección):', taxErr?.message);
+        }
+      }
       agentSounds.chime();
 
       const { intent } = parseIntent(text);
@@ -1628,7 +1651,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       sourceMetadata = {
         ...sourceMetadata,
         ...groundingBadges,
-        auto_corrected: guarded.modified === true,
+        auto_corrected: guarded.modified === true || taxonomyModified === true,
       };
 
       // Capa 2 anti-alucinación — cross-check de contexto (operador 2026-05-30).

--- a/src/services/__tests__/outputGuards.taxonomy.test.js
+++ b/src/services/__tests__/outputGuards.taxonomy.test.js
@@ -1,0 +1,259 @@
+/**
+ * outputGuards.taxonomy.test.js — GUARD ASYNC: auto-validación taxonómica (A24).
+ *
+ * `applyTaxonomyGuard` extrae binomios Linneanos de la respuesta del LLM,
+ * los valida contra el catálogo vía `validate_taxonomy` (sidecar), y, si el
+ * tool confirma que un binomio NO existe en el catálogo, ANEXA una corrección
+ * honesta al final del texto.
+ *
+ * Casos cubiertos:
+ *  1. Binomio inválido detectado → corrección anexada.
+ *  2. Binomio válido → no se toca nada.
+ *  3. Tool caído (callTool devuelve null) → no-op (no rompe respuestas).
+ *  4. Binomio ya grounded en resolvedEntities → no se valida (evita dups con guards 5/5b).
+ *  5. Sin binomios en el texto → no-op.
+ *  6. Texto vacío / no-string → no-op.
+ *  7. Múltiples binomios: invalida solo los confirmados inválidos.
+ *  8. Idempotencia: si la corrección ya está aplicada, no re-dispara.
+ *
+ * Mock: callTool inyectado por argumento (no red real, no sidecar).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { applyTaxonomyGuard } from '../outputGuards.js';
+
+// ── helpers de mock ──────────────────────────────────────────────────────────
+
+/** Mock de callTool que marca los binomios dados como inválidos en el catálogo. */
+function mockCallToolInvalid(invalidBinomials) {
+  return vi.fn(async (toolName, args) => {
+    if (toolName !== 'validate_taxonomy') return null;
+    const sci = (args.species_scientific || '').toLowerCase();
+    const isInvalid = invalidBinomials.some((b) => sci.includes(b.toLowerCase()));
+    return {
+      valid: !isInvalid,
+      canonical_id: isInvalid ? null : 'some_id',
+      canonical_name: isInvalid ? null : args.species_scientific,
+    };
+  });
+}
+
+/** Mock de callTool que marca todos como válidos. */
+function mockCallToolAllValid() {
+  return vi.fn(async () => ({
+    valid: true,
+    canonical_id: 'some_id',
+    canonical_name: 'Something validum',
+  }));
+}
+
+/** Mock de callTool que siempre falla (tool caído). */
+function mockCallToolDown() {
+  return vi.fn(async () => null);
+}
+
+/** Entidad resuelta de grounding con binomio dado. */
+function groundedEntity(nombreCientifico, nombreComun = 'especie') {
+  return {
+    kind: 'species',
+    nombre_comun: nombreComun,
+    nombre_cientifico: nombreCientifico,
+    mentioned: nombreComun,
+  };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('applyTaxonomyGuard', () => {
+  // ── CASO 1: binomio inválido → corrección ──────────────────────────────────
+  it('binomio inválido confirmado por el tool → anexa corrección honesta', async () => {
+    const text =
+      'El tomate de árbol (Inventus fakeus) se siembra entre 1500 y 2500 msnm.';
+    const callTool = mockCallToolInvalid(['inventus fakeus']);
+
+    const result = await applyTaxonomyGuard(text, { callTool });
+
+    expect(result.modified).toBe(true);
+    expect(result.reason).toMatch(/taxonom/i);
+    // La corrección honesta menciona el binomio cuestionado
+    expect(result.text).toContain('Inventus fakeus');
+    // Y explica que no está en el catálogo
+    expect(result.text).toMatch(/catálogo|no se encontró/i);
+    // El texto original se preserva (la corrección se ANEXA al final)
+    expect(result.text).toContain('tomate de árbol');
+    expect(result.text).toContain('1500 y 2500 msnm');
+  });
+
+  // ── CASO 2: binomio válido → no se toca ───────────────────────────────────
+  it('binomio válido confirmado por el tool → no-op', async () => {
+    const text =
+      'El tomate de árbol (Solanum betaceum) crece bien a 2000 msnm.';
+    const callTool = mockCallToolAllValid();
+
+    const result = await applyTaxonomyGuard(text, { callTool });
+
+    expect(result.modified).toBe(false);
+    expect(result.text).toBe(text);
+    expect(result.reason).toBeNull();
+  });
+
+  // ── CASO 3: tool caído → no-op ─────────────────────────────────────────────
+  it('tool caído (callTool devuelve null) → no-op conservador', async () => {
+    const text =
+      'El lulo (Inventus inventus) se siembra en clima frío.';
+    const callTool = mockCallToolDown();
+
+    const result = await applyTaxonomyGuard(text, { callTool });
+
+    expect(result.modified).toBe(false);
+    expect(result.text).toBe(text);
+  });
+
+  // ── CASO 4: binomio ya grounded → no se re-valida ─────────────────────────
+  it('binomio que ya viene en resolvedEntities (grounded) → no se llama callTool', async () => {
+    const text =
+      'El café (Coffea arabica) es ideal para piso cafetero.';
+    const callTool = mockCallToolInvalid(['coffea arabica']);
+    const resolvedEntities = [
+      groundedEntity('Coffea arabica Linn.', 'café'),
+    ];
+
+    const result = await applyTaxonomyGuard(text, { callTool, resolvedEntities });
+
+    // Coffea arabica está en el grounding → no se valida → no se modifica
+    expect(result.modified).toBe(false);
+    expect(result.text).toBe(text);
+    // callTool no debe haber sido llamado para este binomio
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  // ── CASO 5: sin binomios en el texto → no-op ──────────────────────────────
+  it('texto sin binomios científicos → no-op, callTool no llamado', async () => {
+    const text = 'El tomate se siembra después de la lluvia. Abónalo bien.';
+    const callTool = vi.fn();
+
+    const result = await applyTaxonomyGuard(text, { callTool });
+
+    expect(result.modified).toBe(false);
+    expect(result.text).toBe(text);
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  // ── CASO 6: texto vacío / no-string → no-op ───────────────────────────────
+  it('texto vacío → no-op, devuelve { text: "", modified: false, reason: null }', async () => {
+    const callTool = vi.fn();
+    const r1 = await applyTaxonomyGuard('', { callTool });
+    expect(r1.modified).toBe(false);
+    expect(r1.text).toBe('');
+    expect(r1.reason).toBeNull();
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('text no-string → no-op graceful', async () => {
+    const callTool = vi.fn();
+    const r = await applyTaxonomyGuard(null, { callTool });
+    expect(r.modified).toBe(false);
+    expect(r.text).toBe('');
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  // ── CASO 7: múltiples binomios, solo invalida los confirmados ─────────────
+  it('múltiples binomios: valida solo los no-grounded, corrige solo los inválidos', async () => {
+    // Texto con 3 binomios:
+    //   - Coffea arabica: grounded (en resolvedEntities) → no se valida
+    //   - Solanum betaceum: válido en catálogo (callTool devuelve valid:true)
+    //   - Inventus fakeus: INVÁLIDO
+    const text =
+      'El café (Coffea arabica) y el tomate de árbol (Solanum betaceum) son buenos cultivos. ' +
+      'También mencionó Inventus fakeus para las plagas.';
+    const callTool = mockCallToolInvalid(['inventus fakeus']);
+    const resolvedEntities = [groundedEntity('Coffea arabica Linn.', 'café')];
+
+    const result = await applyTaxonomyGuard(text, { callTool, resolvedEntities });
+
+    expect(result.modified).toBe(true);
+    // Coffea arabica no debe disparar callTool (grounded)
+    const calls = callTool.mock.calls;
+    expect(calls.every((c) => !(c[1]?.species_scientific || '').toLowerCase().includes('coffea'))).toBe(true);
+    // La corrección menciona el inválido
+    expect(result.text).toContain('Inventus fakeus');
+    // El texto original se preserva intacto
+    expect(result.text).toContain('Solanum betaceum');
+    expect(result.text).toContain('tomate de árbol');
+  });
+
+  // ── CASO 8: idempotencia ──────────────────────────────────────────────────
+  it('idempotencia: si la corrección ya está aplicada, no re-dispara', async () => {
+    const text =
+      'El tomate de árbol (Inventus fakeus) se siembra a 2000 msnm.\n\n' +
+      'Nota taxonómica: el binomio "Inventus fakeus" no se encontró en el catálogo Chagra.';
+    const callTool = mockCallToolInvalid(['inventus fakeus']);
+
+    const result = await applyTaxonomyGuard(text, { callTool });
+
+    expect(result.modified).toBe(false);
+    expect(result.text).toBe(text);
+  });
+
+  // ── coordinación con guards 5/5b: no duplicar binomios de companions ──────
+  it('binomio companion de una entidad resuelta también se salta (grounding completo)', async () => {
+    // Companion trae su propio nombre_cientifico → debe contarse como grounded
+    const text =
+      'El maíz (Zea mays) va bien con el fríjol (Phaseolus vulgaris).';
+    const callTool = mockCallToolInvalid(['phaseolus vulgaris']);
+    const resolvedEntities = [
+      {
+        kind: 'species',
+        nombre_comun: 'maíz',
+        nombre_cientifico: 'Zea mays L.',
+        mentioned: 'maíz',
+        companions: [
+          {
+            nombre_comun: 'fríjol',
+            nombre_cientifico: 'Phaseolus vulgaris L.',
+          },
+        ],
+      },
+    ];
+
+    const result = await applyTaxonomyGuard(text, { callTool, resolvedEntities });
+
+    expect(result.modified).toBe(false);
+    // Phaseolus vulgaris está en el grounding de companion → no se llama el tool
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  // ── callTool no inyectado → no-op graceful ────────────────────────────────
+  it('sin callTool inyectado (undefined) → no-op graceful', async () => {
+    const text = 'Inventus fakeus es la especie recomendada.';
+    const result = await applyTaxonomyGuard(text, {});
+    expect(result.modified).toBe(false);
+    expect(result.text).toBe(text);
+  });
+
+  // ── pares prosa española (falsos positivos) → no se validan ───────────────
+  it('prosa española capitalizada no se trata como binomio', async () => {
+    // "Sin embargo", "La papa", "Estos cultivos" no son binomios.
+    const text = 'Sin embargo, la papa es viable. Estos cultivos no tienen problema.';
+    const callTool = vi.fn();
+
+    const result = await applyTaxonomyGuard(text, { callTool });
+
+    expect(result.modified).toBe(false);
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  // ── telemetría: bump cuando modifica ─────────────────────────────────────
+  it('dispara telemetría cuando corrige', async () => {
+    const text = 'El tomate de árbol es Inventus fakeus.';
+    const callTool = mockCallToolInvalid(['inventus fakeus']);
+
+    const { getOutputGuardTelemetry, resetOutputGuardTelemetry } = await import('../outputGuards.js');
+    resetOutputGuardTelemetry();
+
+    await applyTaxonomyGuard(text, { callTool });
+
+    const telemetry = getOutputGuardTelemetry();
+    expect(telemetry['auto_taxonomy']).toBeGreaterThan(0);
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -1986,3 +1986,158 @@ export function applyOutputGuards(
   }
   return { text, modified, reasons };
 }
+
+// ── GUARD ASYNC: auto-validación taxonómica (A24) ───────────────────────────
+
+/**
+ * _groundedBinomialsFromAll — universo COMPLETO de binomios canónicos ya
+ * conocidos del grounding: el de cada entidad resuelta, MÁS los anidados en
+ * companions / antagonists / alternativas / pest_controllers. Cualquier
+ * binomio presente en este set NO necesita validación externa (ya fue resuelto
+ * por la capa 1 / guards 5 y 5b).
+ *
+ * Reutiliza `_binomial` y `_groundedBinomials` que ya existen en el módulo.
+ * Se define aquí para el guard A24 (separado para legibilidad).
+ *
+ * @param {Array<object>|null} entities
+ * @returns {Set<string>}
+ */
+function _groundedBinomialsForTaxonomy(entities) {
+  if (!Array.isArray(entities) || entities.length === 0) return new Set();
+  return _groundedBinomials(entities);
+}
+
+/**
+ * _extractUngroundedBinomials — extrae los binomios Linneanos del texto que
+ * NO están ya en el conjunto de binomios grounded del turno. Estos son los
+ * candidatos a validar con `validate_taxonomy`.
+ *
+ * Aplica el mismo filtro anti-prosa que los guards 5/5b: usa
+ * `_looksLikeLatinBinomial` para descartar pares del español ("Sin embargo",
+ * "Estos cultivos"). Devuelve un array de binomios canónicos únicos
+ * (normalizado en minúsculas, "genus epiteto").
+ *
+ * @param {string} text
+ * @param {Set<string>} groundedSet
+ * @returns {Array<{raw:string, canonical:string}>}
+ */
+function _extractUngroundedBinomials(text, groundedSet) {
+  const seen = new Set();
+  const out = [];
+  let m;
+  SCI_BINOMIAL_RE.lastIndex = 0;
+  while ((m = SCI_BINOMIAL_RE.exec(text)) !== null) {
+    if (!_looksLikeLatinBinomial(m[1], m[2])) continue;
+    const raw = `${m[1]} ${m[2]}`;
+    const canonical = _binomial(raw);
+    if (!canonical) continue;
+    if (groundedSet.has(canonical)) continue; // ya grounded → saltar
+    if (seen.has(canonical)) continue; // dedup
+    seen.add(canonical);
+    out.push({ raw, canonical });
+  }
+  return out;
+}
+
+/**
+ * applyTaxonomyGuard — capa post-proceso ASYNC anti-alucinación taxonómica
+ * (A24). Extrae los binomios Linneanos que el LLM incluyó en su respuesta y
+ * que NO están cubiertos por el grounding del turno (resolvedEntities ya
+ * resueltos por la capa 1 / guards 5/5b). Para cada uno llama al tool
+ * `validate_taxonomy` del sidecar (vía la función `callTool` inyectada) y, si
+ * el tool confirma que el binomio NO existe en el catálogo Chagra, ANEXA una
+ * nota honesta al final de la respuesta.
+ *
+ * Diseño conservador (anti-falsos-positivos):
+ *  - Solo corrige binomios que el tool confirme EXPLÍCITAMENTE como inválidos
+ *    (`valid: false`). Si el tool devuelve null (caído/timeout/offline) → no-op.
+ *  - Los binomios ya en el grounding (resolvedEntities + companions/alternativas)
+ *    no se validan (ya cubiertos por guards 5/5b — sin duplicar correcciones).
+ *  - Idempotente: si la corrección ya está en el texto, no re-dispara.
+ *  - Pares de prosa española capitalizada ("Sin embargo", "Estos cultivos") se
+ *    descartan con el mismo filtro de los guards 5/5b.
+ *
+ * Firma:
+ * @param {string} responseText  respuesta post-`applyOutputGuards` del LLM.
+ * @param {object} [opts]
+ * @param {Function|null} [opts.callTool]  función `callTool` del sidecarClient
+ *   inyectada por el caller (AgentScreen). Si falta → no-op graceful.
+ * @param {Array<object>|null} [opts.resolvedEntities]  grounding del turno.
+ * @returns {Promise<{text:string, modified:boolean, reason:string|null}>}
+ */
+export async function applyTaxonomyGuard(
+  responseText,
+  { callTool: _callTool = null, resolvedEntities = null } = {},
+) {
+  // Entrada inválida → no-op graceful.
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  // Sin callTool inyectado (flag off, no wired, etc.) → no-op.
+  if (typeof _callTool !== 'function') {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Universo de binomios ya grounded → no los re-validamos.
+  const grounded = _groundedBinomialsForTaxonomy(resolvedEntities);
+
+  // Extrae binomios no-grounded del texto.
+  const candidates = _extractUngroundedBinomials(responseText, grounded);
+  if (candidates.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Para cada candidato, llama validate_taxonomy. Ejecuta en paralelo para
+  // minimizar latencia (cada llamada tiene timeout de 5s en sidecarClient).
+  const results = await Promise.all(
+    candidates.map(async ({ raw, canonical }) => {
+      try {
+        const res = await _callTool('validate_taxonomy', {
+          species_scientific: raw,
+        });
+        return { raw, canonical, res };
+      } catch (_) {
+        return { raw, canonical, res: null };
+      }
+    }),
+  );
+
+  // Filtra los que el tool confirmó como INVÁLIDOS (valid: false).
+  const invalid = results.filter(
+    ({ res }) => res && typeof res === 'object' && res.valid === false,
+  );
+
+  if (invalid.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Idempotencia: construye la nota de corrección solo para los inválidos que
+  // aún no tienen una nota en el texto. Marca textual: "no se encontró en el
+  // catálogo Chagra" + el binomio.
+  const nuevas = invalid.filter(
+    ({ raw }) =>
+      !responseText.includes(
+        `"${raw}" no se encontró en el catálogo Chagra`,
+      ),
+  );
+
+  if (nuevas.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('auto_taxonomy');
+
+  const notas = nuevas.map(
+    ({ raw }) =>
+      `Nota taxonómica: el binomio "${raw}" no se encontró en el catálogo Chagra — puede ser un nombre ` +
+      `incorrecto o una especie no catalogada. Verifica el nombre científico con una fuente confiable ` +
+      `(ICA, Agrosavia, Tropicos) antes de usarlo como referencia.`,
+  );
+
+  const text = `${responseText.trim()}\n\n${notas.join('\n\n')}`;
+  return {
+    text,
+    modified: true,
+    reason: `taxonomía_no_catálogo: ${nuevas.map(({ raw }) => raw).join(', ')}`,
+  };
+}


### PR DESCRIPTION
## Summary

- Añade `applyTaxonomyGuard` (async) en `outputGuards.js`: extrae binomios Linneanos de la respuesta del LLM que **no** están cubiertos por el grounding del turno (`resolvedEntities` + companions/alternativas), llama al tool `validate_taxonomy` del sidecar en paralelo, y anexa una nota taxonómica honesta para cada binomio que el tool confirma como no-catálogo.
- Wiring en `AgentScreen`: se llama después de `applyOutputGuards` y antes de `postValidate`, para que la corrección quede en la respuesta persistida y mostrada.
- El flag `auto_corrected` en `sourceMetadata` también se marca si el taxonomy guard modificó la respuesta.

## Diseño conservador

- Solo corrige cuando el tool dice explícitamente `valid:false`. Ante tool caído / offline / `isSidecarEnabled()=false` → **no-op**.
- Binomios ya en el grounding (`resolvedEntities` + companions/antagonists/alternativas/pest_controllers) se saltan sin llamar al tool — coordina con guards 5/5b sin duplicar correcciones.
- Prosa española capitalizada ("Sin embargo", "Estos cultivos") se descarta con el mismo filtro `_looksLikeLatinBinomial` ya existente.
- Idempotente: si la nota ya está en el texto, no re-dispara.

## Test plan

- [x] 13 tests TDD en `outputGuards.taxonomy.test.js`:
  - Binomio inválido → corrección anexada con mención del binomio y frase "catálogo"
  - Binomio válido → no-op
  - Tool caído (null) → no-op
  - Binomio grounded en resolvedEntities → callTool no llamado
  - Sin binomios en el texto → no-op
  - Texto vacío / null → no-op graceful
  - Múltiples binomios: solo corrige los confirmados inválidos
  - Idempotencia (nota ya aplicada) → no re-dispara
  - Companions grounded → callTool no llamado
  - Sin callTool inyectado → no-op graceful
  - Prosa española capitalizada → no tratada como binomio
  - Telemetría: bump `auto_taxonomy` cuando corrige
- [x] Suite completa: 188 archivos / 3035 tests pasaron, 1 skipped pre-existente
- [x] ESLint max-warnings=0 sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)