### PR TITLE
feat(bench): juez claude-cli vía claude-code -p + rescore secuencial batch

### DIFF
--- a/scripts/__tests__/bench-scorer.test.mjs
+++ b/scripts/__tests__/bench-scorer.test.mjs
@@ -10,6 +10,10 @@
  *   - LLM-judge (buildJudgePrompt / parseJudgeVerdict / scoreWithJudge) con el
  *     caller de ollama INYECTADO → testeable sin GPU.
  *
+ * R6 (2026-06-02): juez claude-cli — shell-out a `claude-code -p` (suscripción
+ * del operador). Los tests del proveedor claude-cli mockean el shell-out vía
+ * `spawnImpl` inyectado; NUNCA invocan claude-code real en CI.
+ *
  * NO re-corre el bench completo (eso carga GPU + lo decide el operador): solo
  * deja el evaluador listo + esta cobertura unitaria del scorer.
  */
@@ -36,6 +40,10 @@ import {
   scoreAntiHallucDeterministic,
   selectJudgeProvider,
   ANTHROPIC_JUDGE_KEY_PATH,
+  buildBatchAHPrompt,
+  parseBatchAHVerdicts,
+  makeClaudeCliJudgeCall,
+  scoreAntiHallucBatch,
 } from '../lib/bench-scorer.mjs';
 
 describe('scoreKeywordsFlexible', () => {
@@ -476,6 +484,263 @@ describe('selectJudgeProvider', () => {
     // ningún valor string del objeto contiene la key
     for (const v of Object.values(sel)) {
       if (typeof v === 'string') expect(v).not.toContain('sk-test-SECRET');
+    }
+  });
+
+  // ── R6: claude-cli AUTO-fallback ────────────────────────────────────────────
+
+  it('JUDGE_PROVIDER=claude-cli sin key → claude-cli con spawnImpl inyectado', () => {
+    const fakeSpawn = async () => '[{"pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0}]';
+    const sel = selectJudgeProvider({
+      env: { JUDGE_PROVIDER: 'claude-cli' },
+      keyPath: '/no/existe',
+      spawnImpl: fakeSpawn,
+    });
+    expect(sel.provider).toBe('claude-cli');
+    expect(typeof sel.judgeCall).toBe('function');
+    expect(sel.deterministic).toBe(false);
+  });
+
+  it('AUTO sin key + claude-code en PATH → degradación graceful a deterministic (no llama claude-code)', () => {
+    // Sin key Y sin forzar claude-cli el AUTO sigue siendo deterministic para no
+    // depender del PATH en tests de CI (claude-code real lanzaría un proceso).
+    const sel = selectJudgeProvider({ env: {}, keyPath: '/no/existe' });
+    expect(sel.provider).toBe('deterministic');
+    expect(sel.deterministic).toBe(true);
+  });
+});
+
+// ── R6: buildBatchAHPrompt ────────────────────────────────────────────────────
+
+describe('buildBatchAHPrompt (prompt batch para claude-cli)', () => {
+  const items = [
+    {
+      id: 'p1',
+      query: '¿Aguanta la chugua helada?',
+      response: 'La chugua (Ullucus tuberosus) tolera heladas leves con buen drenaje.',
+      mustInclude: ['Ullucus tuberosus', 'drenaje'],
+      redFlags: ['Solanum tuberosum'],
+    },
+    {
+      id: 'p2',
+      query: '¿Cuál es la dosis del caldo bordelés?',
+      response: 'Caldo bordelés: 2% sulfato de cobre + cal, aplicar preventivo.',
+      mustInclude: ['sulfato de cobre', 'cal'],
+      redFlags: ['Mancozeb', 'dosis inventada'],
+    },
+  ];
+
+  it('retorna un string con el prompt batch completo', () => {
+    const prompt = buildBatchAHPrompt(items);
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  it('incluye todos los ids de item en el prompt', () => {
+    const prompt = buildBatchAHPrompt(items);
+    expect(prompt).toMatch(/p1/);
+    expect(prompt).toMatch(/p2/);
+  });
+
+  it('incluye must_include y red_flags de cada item', () => {
+    const prompt = buildBatchAHPrompt(items);
+    expect(prompt).toMatch(/Ullucus tuberosus/);
+    expect(prompt).toMatch(/Solanum tuberosum/);
+    expect(prompt).toMatch(/sulfato de cobre/);
+    expect(prompt).toMatch(/Mancozeb/);
+  });
+
+  it('pide un array JSON como respuesta', () => {
+    const prompt = buildBatchAHPrompt(items);
+    expect(prompt).toMatch(/\[\s*\{/); // formato de array JSON en el prompt
+  });
+
+  it('lista vacía → prompt mínimo sin romper', () => {
+    const prompt = buildBatchAHPrompt([]);
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+});
+
+// ── R6: parseBatchAHVerdicts ──────────────────────────────────────────────────
+
+describe('parseBatchAHVerdicts (parseo del array JSON de claude-cli)', () => {
+  it('parsea array JSON con varios veredictos', () => {
+    const raw = '[{"id":"p1","pass":true,"must_covered":2,"must_total":2,"red_flags_hit":0},{"id":"p2","pass":false,"must_covered":1,"must_total":2,"red_flags_hit":1}]';
+    const out = parseBatchAHVerdicts(raw);
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe('p1');
+    expect(out[0].pass).toBe(true);
+    expect(out[0].mustCovered).toBe(2);
+    expect(out[0].redFlagsHit).toBe(0);
+    expect(out[1].id).toBe('p2');
+    expect(out[1].pass).toBe(false);
+  });
+
+  it('extrae el array JSON aunque haya prosa del modelo antes y después', () => {
+    const raw = 'Aquí está la evaluación solicitada:\n[{"id":"p1","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0}]\nFin de evaluación.';
+    const out = parseBatchAHVerdicts(raw);
+    expect(out).toHaveLength(1);
+    expect(out[0].pass).toBe(true);
+  });
+
+  it('maneja array con un solo item', () => {
+    const raw = '[{"id":"x","pass":false,"must_covered":0,"must_total":1,"red_flags_hit":2}]';
+    const out = parseBatchAHVerdicts(raw);
+    expect(out[0].mustTotal).toBe(1);
+    expect(out[0].redFlagsHit).toBe(2);
+  });
+
+  it('devuelve null si la salida es ilegible (no inventa)', () => {
+    expect(parseBatchAHVerdicts('bla bla sin JSON')).toBeNull();
+    expect(parseBatchAHVerdicts('')).toBeNull();
+    expect(parseBatchAHVerdicts(null)).toBeNull();
+  });
+
+  it('es tolerante a campos numéricos como string', () => {
+    const raw = '[{"id":"p1","pass":true,"must_covered":"2","must_total":"2","red_flags_hit":"0"}]';
+    const out = parseBatchAHVerdicts(raw);
+    expect(out[0].mustCovered).toBe(2);
+    expect(out[0].mustTotal).toBe(2);
+    expect(out[0].redFlagsHit).toBe(0);
+  });
+});
+
+// ── R6: makeClaudeCliJudgeCall ─────────────────────────────────────────────────
+//
+// CRÍTICO: spawnImpl se inyecta — NUNCA se llama al claude-code real en CI.
+// El proceso real se usa solo post-merge en el rescore manual.
+
+describe('makeClaudeCliJudgeCall (spawnImpl mockeado, sin claude-code real)', () => {
+  const items = [
+    {
+      id: 'p1',
+      query: '¿Aguanta helada?',
+      response: 'Sí, tolera bien la helada con buen drenaje.',
+      mustInclude: ['drenaje'],
+      redFlags: ['aguacate'],
+    },
+    {
+      id: 'p2',
+      query: '¿Qué dosis del caldo?',
+      response: 'Caldo bordelés al 2%.',
+      mustInclude: ['caldo bordelés'],
+      redFlags: ['Mancozeb'],
+    },
+  ];
+
+  it('devuelve array de veredictos con el mismo contrato que scoreAntiHalluc', async () => {
+    const batchResp = '[{"id":"p1","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0},{"id":"p2","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0}]';
+    const fakeSpawn = async (_prompt) => batchResp;
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    const out = await judgeCall(items);
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe('p1');
+    expect(out[0].pass).toBe(true);
+    expect(out[0].source).toBe('judge');
+    expect(out[1].id).toBe('p2');
+    expect(out[1].pass).toBe(true);
+  });
+
+  it('spawnImpl recibe un prompt batch (string largo con todos los items)', async () => {
+    let capturedPrompt = '';
+    const fakeSpawn = async (prompt) => {
+      capturedPrompt = prompt;
+      return '[{"id":"p1","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0},{"id":"p2","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0}]';
+    };
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    await judgeCall(items);
+    // el prompt batch contiene los dos ids y los campos relevantes
+    expect(capturedPrompt).toMatch(/p1/);
+    expect(capturedPrompt).toMatch(/p2/);
+    expect(capturedPrompt).toMatch(/drenaje/);
+  });
+
+  it('spawnImpl se llama UNA sola vez para todos los items del lote (no en paralelo)', async () => {
+    let callCount = 0;
+    const fakeSpawn = async () => {
+      callCount += 1;
+      return '[{"id":"p1","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0},{"id":"p2","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0}]';
+    };
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    await judgeCall(items);
+    expect(callCount).toBe(1); // un solo spawn, no 2
+  });
+
+  it('spawnImpl falla → todos los items devuelven unjudged (no inventa)', async () => {
+    const fakeSpawn = async () => { throw new Error('claude-code crash'); };
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    const out = await judgeCall(items);
+    expect(out).toHaveLength(2);
+    for (const v of out) {
+      expect(v.pass).toBeNull();
+      expect(v.source).toBe('unjudged');
+    }
+  });
+
+  it('spawnImpl devuelve JSON ilegible → items unjudged (no inventa)', async () => {
+    const fakeSpawn = async () => 'bla bla sin JSON';
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    const out = await judgeCall(items);
+    for (const v of out) {
+      expect(v.source).toBe('unjudged');
+    }
+  });
+
+  it('id no encontrado en el batch respuesta → item unjudged (no casa con otro)', async () => {
+    // El batch de spawnImpl responde solo para p1, no para p2
+    const fakeSpawn = async () => '[{"id":"p1","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0}]';
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    const out = await judgeCall(items);
+    const p2 = out.find((v) => v.id === 'p2');
+    expect(p2.source).toBe('unjudged');
+  });
+});
+
+// ── R6: scoreAntiHallucBatch ──────────────────────────────────────────────────
+
+describe('scoreAntiHallucBatch (lote con claude-cli mock)', () => {
+  const items = [
+    {
+      id: 'cap1-p1',
+      query: '¿Aguanta helada la chugua?',
+      response: 'La chugua (Ullucus tuberosus) tolera heladas con buen drenaje.',
+      mustInclude: ['Ullucus tuberosus'],
+      redFlags: ['Solanum tuberosum'],
+    },
+    {
+      id: 'cap2-p1',
+      query: '¿Dosis de caldo bordelés?',
+      response: 'Aplicar 2% sulfato de cobre con cal como preventivo.',
+      mustInclude: ['sulfato de cobre'],
+      redFlags: ['Mancozeb'],
+    },
+  ];
+
+  it('devuelve un veredicto por item con source="judge" cuando el mock funciona', async () => {
+    const fakeSpawn = async () =>
+      '[{"id":"cap1-p1","pass":true,"must_covered":1,"must_total":1,"red_flags_hit":0},{"id":"cap2-p1","pass":false,"must_covered":0,"must_total":1,"red_flags_hit":1}]';
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    const out = await scoreAntiHallucBatch(items, { judgeCall });
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe('cap1-p1');
+    expect(out[0].pass).toBe(true);
+    expect(out[0].source).toBe('judge');
+    expect(out[1].id).toBe('cap2-p1');
+    expect(out[1].pass).toBe(false);
+  });
+
+  it('lista vacía → resultado vacío sin romper', async () => {
+    const fakeSpawn = async () => '[]';
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl: fakeSpawn });
+    const out = await scoreAntiHallucBatch([], { judgeCall });
+    expect(out).toHaveLength(0);
+  });
+
+  it('sin judgeCall → todos unjudged (graceful)', async () => {
+    const out = await scoreAntiHallucBatch(items, {});
+    for (const v of out) {
+      expect(v.source).toBe('unjudged');
     }
   });
 });

--- a/scripts/bench-rescore-claude-cli.mjs
+++ b/scripts/bench-rescore-claude-cli.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * bench-rescore-claude-cli.mjs — re-puntúa un JSONL existente del bench
+ * capabilities-A-vs-C con el juez `claude-code -p` (suscripción del operador).
+ *
+ * USO:
+ *   JUDGE_PROVIDER=claude-cli \
+ *   node scripts/bench-rescore-claude-cli.mjs \
+ *     --jsonl data/bench-runs/capabilities-A-vs-C-<ts>.jsonl \
+ *     --pool  data/bench-runs/capabilities-pool-2026-05-31.json
+ *
+ *   # Re-score solo config C:
+ *   node scripts/bench-rescore-claude-cli.mjs \
+ *     --jsonl <jsonl> --pool <pool> --configs C
+ *
+ * QUÉ HACE:
+ *   1. Lee el JSONL ya generado (con respuestas A y/o C de granite3.1).
+ *   2. Lee el pool para obtener must_include / red_flags / expects_abstention.
+ *   3. Re-juzga SECUENCIALMENTE con claude-code -p en batches de BATCH_SIZE items
+ *      (default 8) para minimizar spawns (límite alpha = 2 procesos TOTAL).
+ *   4. Escribe un nuevo JSONL y summary con sufijo `.rescore-cli.<ts>`.
+ *
+ * RESTRICCIONES:
+ *   - NUNCA lanza `claude-code` en paralelo.
+ *   - No regenera respuestas (granite no se toca).
+ *   - No requiere Anthropic API key — usa la suscripción vía `claude-code -p`.
+ *
+ * SEGURIDAD DE PROCESOS (alpha, Maxwell M6000):
+ *   - BATCH_SIZE=8 → ~1-2 spawns totales para un pool de 66 prompts × 2 configs.
+ *   - Hay 30s de sleep entre batches para evitar presión de memoria simultánea.
+ */
+
+import { writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import {
+  makeClaudeCliJudgeCall,
+  scoreAntiHallucBatch,
+} from './lib/bench-scorer.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+function argVal(flag, def) {
+  const i = process.argv.indexOf(flag);
+  if (i >= 0 && process.argv[i + 1] && !process.argv[i + 1].startsWith('--')) return process.argv[i + 1];
+  return def;
+}
+
+const JSONL_FILE = argVal('--jsonl', process.env.JSONL || '');
+const POOL_FILE = argVal('--pool', process.env.POOL || '');
+const CONFIGS = argVal('--configs', 'A,C')
+  .split(',')
+  .map((s) => s.trim().toUpperCase())
+  .filter((c) => c === 'A' || c === 'C');
+const BATCH_SIZE = Number(argVal('--batch-size', process.env.BATCH_SIZE || '8'));
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── aggregate helper (igual que el bench principal) ───────────────────────────
+function aggregate(rows, config) {
+  const byCap = {};
+  let pass = 0;
+  let judged = 0;
+  let unjudged = 0;
+  for (const r of rows) {
+    const res = r.results[config];
+    if (!res || res.error) continue;
+    if (res.ah_source === 'unjudged') { unjudged += 1; continue; }
+    judged += 1;
+    byCap[r.cap] = byCap[r.cap] || { pass: 0, total: 0 };
+    byCap[r.cap].total += 1;
+    if (res.ah_pass) {
+      pass += 1;
+      byCap[r.cap].pass += 1;
+    }
+  }
+  return { pass, judged, unjudged, ah_pct: judged > 0 ? Number(((100 * pass) / judged).toFixed(1)) : 0, byCap };
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+async function main() {
+  if (!JSONL_FILE || !existsSync(JSONL_FILE)) {
+    console.error(`FATAL: JSONL no encontrado. Pasá --jsonl <archivo>. (recibido: '${JSONL_FILE}')`);
+    process.exit(1);
+  }
+  if (!POOL_FILE || !existsSync(POOL_FILE)) {
+    console.error(`FATAL: pool no encontrado. Pasá --pool <archivo>. (recibido: '${POOL_FILE}')`);
+    process.exit(1);
+  }
+
+  const pool = JSON.parse(readFileSync(POOL_FILE, 'utf-8'));
+  const promptsPool = pool.prompts || [];
+
+  // Indexar pool por id para lookup rápido.
+  const poolById = new Map(promptsPool.map((p) => [p.id, p]));
+
+  // Leer JSONL existente.
+  const rawLines = readFileSync(JSONL_FILE, 'utf-8').split('\n').filter((l) => l.trim());
+  const rows = rawLines.map((l) => JSON.parse(l));
+
+  console.log('[rescore] bench-rescore-claude-cli');
+  console.log(`[rescore] JSONL:    ${JSONL_FILE}`);
+  console.log(`[rescore] pool:     ${promptsPool.length} prompts`);
+  console.log(`[rescore] rows:     ${rows.length}`);
+  console.log(`[rescore] configs:  ${CONFIGS.join(', ')}`);
+  console.log(`[rescore] batch:    ${BATCH_SIZE} items/llamada`);
+  console.log('[rescore] juez:     claude-code -p (suscripción — SECUENCIAL)');
+
+  // Fabricar el caller de juez (spawnImpl por defecto = spawnClaudeCode real).
+  const judgeCall = makeClaudeCliJudgeCall({ timeoutMs: 600_000 });
+
+  const t0 = performance.now();
+
+  for (const config of CONFIGS) {
+    console.log(`\n══ CONFIG ${config} ══`);
+
+    // Construir los items a juzgar desde el JSONL + pool.
+    const items = rows
+      .map((row) => {
+        const res = row.results?.[config];
+        if (!res || res.error || !res.final_response) return null;
+        const p = poolById.get(row.id);
+        if (!p) return null;
+        return {
+          id: row.id,
+          query: row.prompt,
+          response: res.final_response,
+          mustInclude: p.must_include || [],
+          redFlags: p.red_flags || [],
+        };
+      })
+      .filter(Boolean);
+
+    console.log(`[rescore] items válidos config ${config}: ${items.length}`);
+
+    // Procesar en batches secuenciales.
+    let totalJudged = 0;
+    let totalUnjudged = 0;
+
+    for (let i = 0; i < items.length; i += BATCH_SIZE) {
+      const batch = items.slice(i, i + BATCH_SIZE);
+      const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+      const batchTotal = Math.ceil(items.length / BATCH_SIZE);
+      console.log(`  [batch ${batchNum}/${batchTotal}] items ${i + 1}-${Math.min(i + BATCH_SIZE, items.length)} — llamando claude-code -p…`);
+
+      const batchStart = performance.now();
+      const verdicts = await scoreAntiHallucBatch(batch, { judgeCall });
+      const batchMs = performance.now() - batchStart;
+
+      // Pegar veredictos de vuelta en rows.
+      for (const v of verdicts) {
+        const row = rows.find((r) => r.id === v.id);
+        if (!row || !row.results[config]) continue;
+        row.results[config].ah_pass = v.pass;
+        row.results[config].ah_source = v.source;
+        row.results[config].ah_must_covered = v.mustCovered;
+        row.results[config].ah_must_total = v.mustTotal ?? row.results[config].ah_must_total;
+        row.results[config].ah_red_flags_hit = v.redFlagsHit;
+      }
+
+      const judged = verdicts.filter((v) => v.source === 'judge').length;
+      const unjudged = verdicts.filter((v) => v.source === 'unjudged').length;
+      totalJudged += judged;
+      totalUnjudged += unjudged;
+      const passCount = verdicts.filter((v) => v.pass === true).length;
+      console.log(`    → ${judged} juzgados (${passCount} PASS, ${judged - passCount} FAIL), ${unjudged} unjudged — ${(batchMs / 1000).toFixed(1)}s`);
+
+      // Sleep entre batches para no presionar memoria (claude-code es pesado).
+      if (i + BATCH_SIZE < items.length) {
+        console.log('    [sleep] 30s antes del siguiente batch…');
+        await sleep(30_000);
+      }
+    }
+
+    console.log(`[rescore] config ${config}: ${totalJudged} juzgados, ${totalUnjudged} unjudged`);
+  }
+
+  const elapsedSec = ((performance.now() - t0) / 1000).toFixed(1);
+
+  // ── escribir outputs ────────────────────────────────────────────────────────
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const base = basename(JSONL_FILE, '.jsonl');
+  const outDir = dirname(JSONL_FILE);
+  const rescoreJsonlPath = join(outDir, `${base}.rescore-cli.${ts}.jsonl`);
+  const rescoreSummaryPath = join(outDir, `${base}.rescore-cli.${ts}.summary.json`);
+
+  writeFileSync(rescoreJsonlPath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+  // ── aggregar y mostrar tabla ────────────────────────────────────────────────
+  const aggA = CONFIGS.includes('A') ? aggregate(rows, 'A') : null;
+  const aggC = CONFIGS.includes('C') ? aggregate(rows, 'C') : null;
+
+  const caps = [...new Set(rows.map((r) => r.cap).filter(Boolean))];
+  const perCap = caps.map((cap) => {
+    const a = aggA?.byCap[cap];
+    const c = aggC?.byCap[cap];
+    const aPct = a && a.total ? (100 * a.pass) / a.total : null;
+    const cPct = c && c.total ? (100 * c.pass) / c.total : null;
+    return {
+      cap,
+      A: a ? { pass: a.pass, total: a.total, pct: Number(aPct.toFixed(1)) } : null,
+      C: c ? { pass: c.pass, total: c.total, pct: Number(cPct.toFixed(1)) } : null,
+      lift_pp: aPct != null && cPct != null ? Number((cPct - aPct).toFixed(1)) : null,
+    };
+  });
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    source_jsonl: JSONL_FILE,
+    pool: POOL_FILE,
+    judge: { provider: 'claude-cli', model: 'claude-code-subscription', independent: true },
+    configs: CONFIGS,
+    batch_size: BATCH_SIZE,
+    elapsed_sec: Number(elapsedSec),
+    overall: { A: aggA, C: aggC },
+    per_capability: perCap,
+  };
+  writeFileSync(rescoreSummaryPath, JSON.stringify(summary, null, 2) + '\n');
+
+  console.log('\n══════════════════════════════════════════════════════════════════');
+  console.log('TABLA POR CAPACIDAD — juez: claude-code (suscripción)');
+  console.log('cap                      A          C          lift');
+  for (const r of perCap) {
+    const a = r.A ? `${r.A.pass}/${r.A.total} ${String(r.A.pct).padStart(5)}%` : '      —  ';
+    const c = r.C ? `${r.C.pass}/${r.C.total} ${String(r.C.pct).padStart(5)}%` : '      —  ';
+    const lift = r.lift_pp != null ? `${r.lift_pp >= 0 ? '+' : ''}${r.lift_pp}pp` : '—';
+    console.log(`${r.cap.padEnd(24)} ${a.padEnd(11)} ${c.padEnd(11)} ${lift}`);
+  }
+  console.log('──────────────────────────────────────────────────────────────────');
+  if (aggA) console.log(`GLOBAL A: ${aggA.pass}/${aggA.judged} = ${aggA.ah_pct}% AH  (${aggA.unjudged} unjudged)`);
+  if (aggC) console.log(`GLOBAL C: ${aggC.pass}/${aggC.judged} = ${aggC.ah_pct}% AH  (${aggC.unjudged} unjudged)`);
+  if (aggA && aggC) console.log(`LIFT GLOBAL C−A: ${(aggC.ah_pct - aggA.ah_pct).toFixed(1)}pp`);
+  console.log(`JSONL re-scoreado: ${rescoreJsonlPath}`);
+  console.log(`SUMMARY:           ${rescoreSummaryPath}`);
+  console.log(`Tiempo total:      ${elapsedSec}s`);
+  console.log('══════════════════════════════════════════════════════════════════');
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err.message);
+  process.exit(1);
+});

--- a/scripts/lib/bench-scorer.mjs
+++ b/scripts/lib/bench-scorer.mjs
@@ -602,16 +602,19 @@ export function scoreAntiHallucDeterministic(item = {}) {
 /**
  * selectJudgeProvider — elige el proveedor de juez y resuelve el caller. Reglas:
  *
- *   - `provider` explícito (env `JUDGE_PROVIDER`): 'anthropic' | 'ollama' |
- *     'deterministic'. Si no se da, AUTO: 'anthropic' si hay API key disponible,
- *     si no 'deterministic'.
+ *   - `provider` explícito (env `JUDGE_PROVIDER`): 'anthropic' | 'claude-cli' |
+ *     'ollama' | 'deterministic'. Si no se da, AUTO: 'anthropic' si hay API key
+ *     disponible, si no 'deterministic'.
  *   - 'anthropic' sin key → degrada a 'deterministic' (graceful, no crashea).
+ *   - 'claude-cli' usa `claude-code -p` vía shell-out. Requiere `spawnImpl`
+ *     inyectado (tests) o usa `spawnClaudeCode` por defecto (producción). NUNCA
+ *     lanza `claude-code` en paralelo — siempre secuencial.
  *   - 'ollama' requiere un `ollamaCall` ya armado por el caller (el juez local
  *     está roto en Maxwell — se respeta solo si el operador lo fuerza).
  *
  * Devuelve `{ provider, judgeModel, judgeCall, deterministic }`:
- *   - `judgeCall`: `(prompt)=>Promise<string>` para inyectar en scoreAntiHalluc,
- *     o `null` si el proveedor es determinístico.
+ *   - `judgeCall`: para 'claude-cli', es `(items[])=>Promise<verdict[]>` (batch).
+ *     Para otros, es `(prompt:string)=>Promise<string>` o `null` (determinístico).
  *   - `deterministic`: true cuando hay que usar `scoreAntiHallucDeterministic`.
  *
  * La key se lee vía `readAnthropicKey` (env o archivo gitignored) y NUNCA se
@@ -625,8 +628,9 @@ export function scoreAntiHallucDeterministic(item = {}) {
  *   fetchImpl?: typeof fetch,
  *   keyPath?: string,
  *   anthropicModel?: string,
+ *   spawnImpl?: (prompt:string)=>Promise<string>,
  * }} [opts]
- * @returns {{ provider:'anthropic'|'ollama'|'deterministic', judgeModel:string, judgeCall:((p:string)=>Promise<string>)|null, deterministic:boolean }}
+ * @returns {{ provider:'anthropic'|'claude-cli'|'ollama'|'deterministic', judgeModel:string, judgeCall:Function|null, deterministic:boolean }}
  */
 export function selectJudgeProvider({
   provider,
@@ -636,6 +640,7 @@ export function selectJudgeProvider({
   fetchImpl,
   keyPath,
   anthropicModel = RECOMMENDED_ANTHROPIC_JUDGE_MODEL,
+  spawnImpl,
 } = {}) {
   const apiKey = readAnthropicKey({ env, keyPath });
   const requested = (provider || (env && env.JUDGE_PROVIDER) || '').trim().toLowerCase();
@@ -650,9 +655,250 @@ export function selectJudgeProvider({
     return { provider: 'anthropic', judgeModel: anthropicModel, judgeCall, deterministic: false };
   }
 
+  if (resolved === 'claude-cli') {
+    const judgeCall = makeClaudeCliJudgeCall({ spawnImpl });
+    return { provider: 'claude-cli', judgeModel: 'claude-code-subscription', judgeCall, deterministic: false };
+  }
+
   if (resolved === 'ollama') {
     return { provider: 'ollama', judgeModel: ollamaModel, judgeCall: ollamaCall || null, deterministic: false };
   }
 
   return { provider: 'deterministic', judgeModel: 'deterministic', judgeCall: null, deterministic: true };
+}
+
+// ── R6: juez claude-cli (claude-code -p, suscripción operador) ─────────────────
+//
+// DISEÑO DE SEGURIDAD DE PROCESOS:
+// - `claude-code -p <PROMPT>` es SECUENCIAL (nunca paralelo). En alpha el límite
+//   es 2 procesos claude-code TOTAL; spawnar en paralelo causa SIGILL/SIGSEGV.
+// - Se BATCHEAN ~8-10 respuestas por llamada para minimizar spawns.
+// - `spawnImpl` se inyecta para que CI mockee sin lanzar claude-code real.
+
+/**
+ * buildBatchAHPrompt — construye el prompt batch para el juez claude-cli. Pide
+ * evaluar N respuestas en una sola llamada y devolver un array JSON con un
+ * veredicto por item. Minimiza spawns de `claude-code -p`.
+ *
+ * El JSON de retorno esperado es:
+ *   [{"id":"...", "pass":bool, "must_covered":int, "must_total":int, "red_flags_hit":int}, ...]
+ *
+ * @param {Array<{id:string, query:string, response:string, mustInclude?:string[], redFlags?:string[]}>} items
+ * @returns {string}
+ */
+export function buildBatchAHPrompt(items) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return [
+      'Eres un evaluador experto en agroecología colombiana.',
+      'No hay items que evaluar. Devuelve: []',
+    ].join('\n');
+  }
+
+  const itemsText = items
+    .map((item, idx) => {
+      const must = (item.mustInclude || []).map((m) => `    - ${m}`).join('\n') || '    - (ninguno)';
+      const red = (item.redFlags || []).map((r) => `    - ${r}`).join('\n') || '    - (ninguno)';
+      return [
+        `### ITEM ${idx + 1} — id: "${item.id}"`,
+        `PREGUNTA: ${item.query || ''}`,
+        `RESPUESTA DEL MODELO: ${item.response || ''}`,
+        `DEBE INCLUIR (conceptos obligatorios, por fondo no literalidad):`,
+        must,
+        `NO DEBE INCLUIR — RED FLAGS (si aparece cualquiera = FAIL):`,
+        red,
+      ].join('\n');
+    })
+    .join('\n\n');
+
+  return [
+    'Eres un evaluador EXPERTO en agroecología colombiana y detector estricto de alucinaciones.',
+    'Evalúa CADA ITEM de la lista y devuelve un array JSON con un objeto por item.',
+    '',
+    'REGLAS DE VEREDICTO por item:',
+    '- "pass": true SOLO si TODOS los DEBE INCLUIR están cubiertos por fondo (no literalidad) Y',
+    '  NINGÚN red flag aparece en la respuesta.',
+    '- "must_covered": cuántos de los DEBE INCLUIR están cubiertos.',
+    '- "must_total": total de DEBE INCLUIR.',
+    '- "red_flags_hit": cuántos red flags aparecen en la respuesta.',
+    '',
+    'Devuelve SOLO el array JSON en una sola línea, sin prosa adicional antes ni después:',
+    '[{"id":"<id>","pass":<bool>,"must_covered":<int>,"must_total":<int>,"red_flags_hit":<int>}, ...]',
+    '',
+    '═══════════════════════════════════════════════════════',
+    'ITEMS A EVALUAR:',
+    '',
+    itemsText,
+    '',
+    '═══════════════════════════════════════════════════════',
+    'RESPONDE ÚNICAMENTE con el array JSON de veredictos, uno por item, en el mismo orden:',
+  ].join('\n');
+}
+
+/**
+ * parseBatchAHVerdicts — interpreta el array JSON de veredictos que devuelve el
+ * juez claude-cli. Acepta JSON embebido aunque haya prosa antes/después. Devuelve
+ * null si el output es ilegible (no inventa veredictos). Cada elemento del array
+ * devuelto sigue el mismo contrato que `parseAHVerdict` + campo `id`.
+ *
+ * @param {string} raw
+ * @returns {Array<{id:string, pass:boolean, mustCovered:number, mustTotal:number, redFlagsHit:number}>|null}
+ */
+export function parseBatchAHVerdicts(raw) {
+  if (typeof raw !== 'string' || raw.trim().length === 0) return null;
+
+  // Extrae el primer array JSON del output (puede haber prosa del modelo alrededor).
+  const arrayMatch = raw.match(/\[[\s\S]*?\]/);
+  if (!arrayMatch) return null;
+
+  try {
+    const arr = JSON.parse(arrayMatch[0]);
+    if (!Array.isArray(arr)) return null;
+    const num = (v) => {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : null;
+    };
+    return arr.map((obj) => ({
+      id: typeof obj.id === 'string' ? obj.id : String(obj.id ?? ''),
+      pass: typeof obj.pass === 'boolean' ? obj.pass : Boolean(obj.pass),
+      mustCovered: num(obj.must_covered),
+      mustTotal: num(obj.must_total),
+      redFlagsHit: num(obj.red_flags_hit),
+    }));
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * spawnClaudeCode — implementación REAL del shell-out a `claude-code -p`. Se usa
+ * solo en producción (no en tests, que inyectan `spawnImpl`). Lanza UN proceso
+ * claude-code secuencial y espera su stdout completo. NUNCA crea procesos en
+ * paralelo.
+ *
+ * El timeout por defecto es 5 minutos (un batch de ~10 juicios tarda ~60-90s).
+ *
+ * @param {string} prompt
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<string>}
+ */
+export async function spawnClaudeCode(prompt, { timeoutMs = 300_000 } = {}) {
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+  const execFileAsync = promisify(execFile);
+  const { stdout } = await execFileAsync('claude-code', ['-p', prompt], {
+    timeout: timeoutMs,
+    maxBuffer: 1024 * 1024 * 4, // 4MB — suficiente para un batch de 10 veredictos
+    encoding: 'utf-8',
+  });
+  return stdout;
+}
+
+/**
+ * makeClaudeCliJudgeCall — fabrica un caller de juez BATCH para el proveedor
+ * claude-cli. En vez de la firma `(prompt:string)=>string` de los otros callers,
+ * aquí el caller acepta un ARRAY de items y devuelve un ARRAY de veredictos:
+ *
+ *   `(items: AHItem[]) => Promise<AHVerdict[]>`
+ *
+ * Diseño:
+ *   - Construye UN prompt batch con `buildBatchAHPrompt`.
+ *   - Llama a `spawnImpl` (o `spawnClaudeCode`) UNA VEZ por lote (secuencial).
+ *   - Parsea la respuesta con `parseBatchAHVerdicts`.
+ *   - Si falla o es ilegible → todos los items del lote quedan `unjudged`.
+ *   - El id de cada item es la clave de mapeo: sin id presente en la respuesta
+ *     el item queda `unjudged` (no se asigna el veredicto de otro item).
+ *
+ * @param {{
+ *   spawnImpl?: (prompt:string)=>Promise<string>,
+ *   timeoutMs?: number,
+ * }} [opts]
+ * @returns {(items:Array<{id:string,query:string,response:string,mustInclude?:string[],redFlags?:string[]}>)=>Promise<Array<{id:string,pass:boolean|null,mustCovered:number|null,mustTotal:number|null,redFlagsHit:number|null,source:'judge'|'unjudged'}>>}
+ */
+export function makeClaudeCliJudgeCall({ spawnImpl, timeoutMs = 300_000 } = {}) {
+  const doSpawn = typeof spawnImpl === 'function'
+    ? spawnImpl
+    : (prompt) => spawnClaudeCode(prompt, { timeoutMs });
+
+  return async function claudeCliJudgeCall(items) {
+    const arr = Array.isArray(items) ? items : [];
+    const unjudgedAll = arr.map((item) => ({
+      id: item.id,
+      pass: null,
+      mustCovered: null,
+      mustTotal: Array.isArray(item.mustInclude) ? item.mustInclude.length : null,
+      redFlagsHit: null,
+      source: 'unjudged',
+    }));
+
+    if (arr.length === 0) return [];
+
+    let raw;
+    try {
+      const prompt = buildBatchAHPrompt(arr);
+      raw = await doSpawn(prompt);
+    } catch (_) {
+      return unjudgedAll;
+    }
+
+    const verdicts = parseBatchAHVerdicts(raw);
+    if (!verdicts) return unjudgedAll;
+
+    // Mapear veredicto por id; items no encontrados → unjudged.
+    const byId = new Map(verdicts.map((v) => [v.id, v]));
+    return arr.map((item) => {
+      const v = byId.get(item.id);
+      if (!v) {
+        return {
+          id: item.id,
+          pass: null,
+          mustCovered: null,
+          mustTotal: Array.isArray(item.mustInclude) ? item.mustInclude.length : null,
+          redFlagsHit: null,
+          source: 'unjudged',
+        };
+      }
+      return {
+        id: item.id,
+        pass: v.pass,
+        mustCovered: v.mustCovered,
+        mustTotal: v.mustTotal,
+        redFlagsHit: v.redFlagsHit,
+        source: 'judge',
+      };
+    });
+  };
+}
+
+/**
+ * scoreAntiHallucBatch — evalúa anti-alucinación de un LOTE de items con el
+ * juez claude-cli (batch). Contrato de salida: un array con el veredicto de cada
+ * item en el mismo orden que la entrada. Si `judgeCall` no está disponible, todos
+ * los items quedan `unjudged`.
+ *
+ * Se usa en el script `bench-rescore-claude-cli.mjs` para re-puntuar un JSONL
+ * existente sin regenerar con granite.
+ *
+ * @param {Array<{id:string,query:string,response:string,mustInclude?:string[],redFlags?:string[]}>} items
+ * @param {{ judgeCall?: Function }} opts
+ * @returns {Promise<Array<{id:string,pass:boolean|null,mustCovered:number|null,mustTotal:number|null,redFlagsHit:number|null,source:'judge'|'unjudged'}>>}
+ */
+export async function scoreAntiHallucBatch(items, { judgeCall } = {}) {
+  const arr = Array.isArray(items) ? items : [];
+  const unjudgedAll = arr.map((item) => ({
+    id: item.id,
+    pass: null,
+    mustCovered: null,
+    mustTotal: Array.isArray(item.mustInclude) ? item.mustInclude.length : null,
+    redFlagsHit: null,
+    source: 'unjudged',
+  }));
+
+  if (typeof judgeCall !== 'function') return unjudgedAll;
+  if (arr.length === 0) return [];
+
+  try {
+    return await judgeCall(arr);
+  } catch (_) {
+    return unjudgedAll;
+  }
 }


### PR DESCRIPTION
## Summary

- Agrega el proveedor `claude-cli` a `bench-scorer.mjs`: shell-out a `claude-code -p` (suscripción del operador) que **no requiere API key Anthropic** y esquiva los jueces locales rotos en Maxwell sm_52.
- Batching de 8-10 respuestas por llamada para minimizar spawns; ejecución **siempre secuencial** (límite alpha = 2 procesos claude-code total).
- Nuevas exports: `buildBatchAHPrompt`, `parseBatchAHVerdicts`, `makeClaudeCliJudgeCall`, `scoreAntiHallucBatch`. `selectJudgeProvider` acepta `JUDGE_PROVIDER=claude-cli`.
- Script `bench-rescore-claude-cli.mjs`: lee un JSONL existente (respuestas ya generadas), re-juzga en batches secuenciales, escribe nuevo JSONL + summary con AH% por capacidad + lift C−A.
- 21 tests nuevos (TDD red→green); total scorer: **75/75 pasan**. `spawnImpl` inyectable → CI no invoca `claude-code` real.

## Re-score real (post-merge, secuencial)

Una vez mergeado, ejecutar desde alpha:

```sh
JUDGE_PROVIDER=claude-cli \
node scripts/bench-rescore-claude-cli.mjs \
  --jsonl data/bench-runs/capabilities-A-vs-C-<ts>.jsonl \
  --pool  data/bench-runs/capabilities-pool-2026-05-31.json
```

El script imprime la tabla AH% por capacidad y el lift global C−A con juez confiable.

## Test plan

- [x] `npm run test:unit -- scripts/__tests__/bench-scorer.test.mjs` → 75/75 pass
- [x] `npm run test:unit` completo → 187 archivos / 3043 tests pass
- [x] `eslint --max-warnings=0` limpio en archivos modificados
- [ ] Re-score real post-merge (manual, secuencial, en alpha)

🤖 Generated with [Claude Code](https://claude.com/claude-code)