### PR TITLE
feat(agente): UI Deep Research A6/A7 — chip 🔬 funcional con progreso + informe citado

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,9 @@ VITE_CHAGRA_MCP_TOKEN=
 # set, el loader cae a OSS con warning — no rompe deploy.
 VITE_CHAGRA_TIER=OSS
 VITE_CHAGRA_CATALOG_URL=
+
+# Deep Research (A6/A7) — pro-only, pesado. Default false (prod-free).
+# Activar en pre-prod con VITE_DEEP_RESEARCH_ENABLED=true.
+# Cuando exista el sistema de tier/allowlist, el gating por tier
+# se agregará en deepResearchClient.js sin necesidad de cambiar este flag.
+VITE_DEEP_RESEARCH_ENABLED=false

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -56,7 +56,11 @@ import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities,
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
 // los chips cuyo backend aún no existe (precio/deep).
-import { planForcedIntent, isStubIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
+import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from '../../services/chipIntentRouter';
+// Deep Research (A6/A7): cliente HTTP del endpoint async de investigación
+// profunda del sidecar. Feature flag VITE_DEEP_RESEARCH_ENABLED (default false).
+import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../../services/deepResearchClient';
+import DeepResearchCard from '../DeepResearchCard';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak } from '../../services/agentService';
 import { applyOutputGuards, applyTaxonomyGuard } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
@@ -188,6 +192,10 @@ export default function AgentScreen({ onBack, initialContext }) {
   // input también cambia para guiar al campesino sobre qué escribir. Es un
   // toggle: tocar el mismo chip lo desactiva (vuelve al routing NLU normal).
   const [activeIntent, setActiveIntent] = useState(null);
+  // Deep Research (A6/A7): refs para los AbortControllers de los jobs en vuelo.
+  // Guardamos en un Map (msgId → AbortController) para poder cancelar jobs
+  // individuales. Al desmontar el componente cancelamos todos.
+  const deepResearchControllersRef = useRef(new Map());
 
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
   const chatEndRef = useRef(null);
@@ -1852,11 +1860,174 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     await handleSubmit(prompt);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Deep Research (A6/A7): cancela el job en vuelo del card identificado por msgId.
+  const handleCancelDeepResearch = useCallback((msgId) => {
+    const ctrl = deepResearchControllersRef.current.get(msgId);
+    if (ctrl) {
+      ctrl.abort();
+      deepResearchControllersRef.current.delete(msgId);
+    }
+    // Marcar el card como cancelado en el historial
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === msgId && m._deepResearch
+          ? { ...m, _deepResearch: { ...m._deepResearch, status: 'error' } }
+          : m,
+      ),
+    );
+  }, []);
+
   const handleSubmit = async (text, { fromVoice = false, suppressUserBubble = false, visionContext = null, forcedIntent = null } = {}) => {
     if (!text || !text.trim()) return;
     const trimmed = text.trim();
 
-    // CHIPS DE MODO — STUB (A3): precio/deep no tienen backend todavía. NO
+    // DEEP RESEARCH (A6/A7): chip 🔬 con backend live. Interceptamos ANTES del
+    // stub-check y del pipeline NLU. Lanzamos el job async y ponemos un card
+    // de progreso en el chat que se actualiza vía polling hasta status=done.
+    // Gate: VITE_DEEP_RESEARCH_ENABLED + online. Si la flag está off o no hay
+    // conexión, devuelve el mensaje honesto de no disponibilidad.
+    if (forcedIntent && isDeepResearchIntent(forcedIntent)) {
+      const userMessage = { role: 'user', content: trimmed, timestamp: Date.now() };
+      setMessages((prev) => [...prev, userMessage]);
+      try {
+        await addTurn(operatorId, { role: 'user', content: trimmed });
+      } catch (e) {
+        console.warn('[DeepResearch] addTurn user failed:', e?.message);
+      }
+      setActiveIntent(null);
+
+      // Gate: feature flag + online
+      if (!isDeepResearchEnabled()) {
+        const notAvailMsg = {
+          role: 'assistant',
+          content: '',
+          timestamp: Date.now(),
+          _deepResearch: { status: 'disabled', steps: [], report: '', citations: [], query: trimmed },
+        };
+        setMessages((prev) => [...prev, notAvailMsg]);
+        return;
+      }
+      if (!navigator.onLine) {
+        const offlineMsg = {
+          role: 'assistant',
+          content: '',
+          timestamp: Date.now(),
+          _deepResearch: { status: 'offline', steps: [], report: '', citations: [], query: trimmed },
+        };
+        setMessages((prev) => [...prev, offlineMsg]);
+        return;
+      }
+
+      // Añadir card de progreso con status 'submitting'
+      const drMsgId = `dr-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const progressMsg = {
+        id: drMsgId,
+        role: 'assistant',
+        content: '',
+        timestamp: Date.now(),
+        _deepResearch: { status: 'submitting', steps: [], report: '', citations: [], query: trimmed },
+      };
+      setMessages((prev) => [...prev, progressMsg]);
+
+      // Lanzar el job async — NO esperamos el resultado para no bloquear el UI
+      (async () => {
+        const controller = new AbortController();
+        deepResearchControllersRef.current.set(drMsgId, controller);
+
+        try {
+          const jobResult = await submitDeepResearch(trimmed);
+          if (!jobResult || !jobResult.job_id) {
+            // submit falló
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === drMsgId
+                  ? { ...m, _deepResearch: { ...m._deepResearch, status: 'error' } }
+                  : m,
+              ),
+            );
+            return;
+          }
+
+          // Cambiar a 'running'
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === drMsgId
+                ? { ...m, _deepResearch: { ...m._deepResearch, status: 'running' } }
+                : m,
+            ),
+          );
+
+          // Polling hasta done/error/cancel
+          const finalResult = await pollDeepResearch(
+            jobResult.job_id,
+            (steps, status) => {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === drMsgId
+                    ? { ...m, _deepResearch: { ...m._deepResearch, steps, status } }
+                    : m,
+                ),
+              );
+            },
+            controller.signal,
+          );
+
+          if (controller.signal.aborted) return;
+
+          if (finalResult) {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === drMsgId
+                  ? {
+                    ...m,
+                    _deepResearch: {
+                      status: finalResult.status,
+                      steps: finalResult.steps,
+                      report: finalResult.report,
+                      citations: finalResult.citations,
+                      query: trimmed,
+                    },
+                  }
+                  : m,
+              ),
+            );
+            // Persistir el informe en la memoria de conversación
+            if (finalResult.report) {
+              const reportContent = `[Investigación profunda] ${trimmed}\n\n${finalResult.report}`;
+              try {
+                await addTurn(operatorId, { role: 'assistant', content: reportContent });
+              } catch (e) {
+                console.warn('[DeepResearch] addTurn report failed:', e?.message);
+              }
+            }
+          } else {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === drMsgId
+                  ? { ...m, _deepResearch: { ...m._deepResearch, status: 'error' } }
+                  : m,
+              ),
+            );
+          }
+        } catch (e) {
+          if (!controller.signal.aborted) {
+            console.warn('[DeepResearch] job failed:', e?.message);
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === drMsgId
+                  ? { ...m, _deepResearch: { ...m._deepResearch, status: 'error' } }
+                  : m,
+              ),
+            );
+          }
+        } finally {
+          deepResearchControllersRef.current.delete(drMsgId);
+        }
+      })();
+      return;
+    }
+
+    // CHIPS DE MODO — STUB (A3): precio no tiene backend todavía. NO
     // routeamos a un tool fantasma ni gastamos una inferencia del LLM:
     // pintamos la pregunta del usuario + una respuesta honesta "aún no
     // disponible" y salimos. Esto evita el misrouting del NLU (que mandaba
@@ -2073,6 +2244,17 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       for (const url of urls) {
         try { URL.revokeObjectURL(url); } catch { /* noop */ }
       }
+    };
+  }, []);
+
+  // Deep Research (A6/A7): cancelar todos los jobs en vuelo al desmontar.
+  useEffect(() => {
+    const controllers = deepResearchControllersRef.current;
+    return () => {
+      for (const ctrl of controllers.values()) {
+        try { ctrl.abort(); } catch { /* noop */ }
+      }
+      controllers.clear();
     };
   }, []);
 
@@ -2372,6 +2554,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         isStreaming={state === STATE_THINKING}
         onConsentNeeded={handleFeedbackConsentNeeded}
         onRetryOrphan={handleRetryOrphan}
+        onCancelDeepResearch={handleCancelDeepResearch}
       />
 
       {/* Error */}

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useRef } from 'react';
 import ChatBubble from './ChatBubble';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import DeepResearchCard from '../DeepResearchCard';
 
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch }) {
   const bottomRef = useRef(null);
 
   useEffect(() => {
@@ -45,16 +46,41 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto p-4 pb-2">
-      {messages.map((msg, idx) => (
-        <ChatBubble
-          key={msg.id || idx}
-          message={msg}
-          isStreaming={false}
-          promptText={msg.role === 'assistant' ? findPromptForResponse(idx) : undefined}
-          onConsentNeeded={onConsentNeeded}
-          onRetryOrphan={onRetryOrphan}
-        />
-      ))}
+      {messages.map((msg, idx) => {
+        // Deep Research (A6/A7): si el mensaje lleva _deepResearch, renderizamos
+        // el card de progreso/informe en lugar de (o junto a) la burbuja.
+        if (msg._deepResearch) {
+          const dr = msg._deepResearch;
+          return (
+            <div key={msg.id || idx} className="mb-3">
+              {/* Burbuja del usuario ya está en el mensaje anterior — el card es
+                  la "respuesta" del asistente: no pintamos burbuja de asistente vacía */}
+              <DeepResearchCard
+                status={dr.status}
+                steps={dr.steps}
+                report={dr.report}
+                citations={dr.citations}
+                query={dr.query}
+                onCancel={
+                  typeof onCancelDeepResearch === 'function' && msg.id
+                    ? () => onCancelDeepResearch(msg.id)
+                    : undefined
+                }
+              />
+            </div>
+          );
+        }
+        return (
+          <ChatBubble
+            key={msg.id || idx}
+            message={msg}
+            isStreaming={false}
+            promptText={msg.role === 'assistant' ? findPromptForResponse(idx) : undefined}
+            onConsentNeeded={onConsentNeeded}
+            onRetryOrphan={onRetryOrphan}
+          />
+        );
+      })}
 
       {/* Placeholder visible mientras llega el primer token (pre-stream).
           Sin esto el chat se ve "muerto" entre el envío del usuario y la

--- a/src/components/DeepResearchCard.jsx
+++ b/src/components/DeepResearchCard.jsx
@@ -1,0 +1,303 @@
+import React, { useState } from 'react';
+import { Microscope, ChevronDown, ChevronUp, ExternalLink, ShieldCheck, Clock, AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
+
+/**
+ * DeepResearchCard — card de progreso + informe para el chip 🔬 "Investigación profunda".
+ *
+ * A6 — Card de progreso:
+ *   Muestra el estado "Investigando a fondo…" con los steps[] visibles
+ *   mientras status='running'. Polling real via pollDeepResearch (el caller
+ *   gestiona el loop; este componente solo renderiza el estado recibido).
+ *   Microcopy honesto sobre la espera en Maxwell (puede tardar 2–5 min).
+ *
+ * A7 — Informe citado:
+ *   Cuando status='done', renderiza el `report` con un FuenteBadge por
+ *   cada citation que traiga url. Si el informe es el fallback determinista
+ *   (lista de evidencia en vez de síntesis), se muestra igual de útil.
+ *   El card es colapsable (acordeón) para no invadir el chat.
+ *
+ * Gate pro-only + feature flag:
+ *   Si `enabled=false` (VITE_DEEP_RESEARCH_ENABLED=false), el componente
+ *   no se renderiza — la decisión del gate vive en el caller (AgentScreen).
+ *
+ * Props:
+ *   status  {string}   — 'submitting'|'running'|'done'|'error'|'offline'|'disabled'
+ *   steps   {string[]} — sub-preguntas investigadas (pueden crecer en tiempo real)
+ *   report  {string}   — informe final (vacío si running)
+ *   citations {Array}  — [{ source_id, label?, url? }]
+ *   query   {string}   — pregunta original del usuario
+ *   onCancel {function} — callback para cancelar el job en curso
+ *
+ * Español colombiano (tú/usted), nunca voseo argentino.
+ */
+
+/**
+ * FuenteBadge para citas del informe Deep Research.
+ * Reutiliza el mismo patrón que el FuenteBadge de ChatBubble (#1241):
+ * link <a> CSP-safe, rel="noopener noreferrer".
+ */
+function CitationBadge({ citation, index }) {
+  if (!citation) return null;
+  const label = citation.label || citation.source_id || `Fuente ${index + 1}`;
+  if (citation.url && /^https?:\/\//i.test(citation.url)) {
+    return (
+      <a
+        href={citation.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="deep-research-citation-badge"
+        data-source-id={citation.source_id}
+        title={`Fuente verificable: ${label}. Abre el documento original en una pestaña nueva.`}
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
+      >
+        <ShieldCheck size={11} aria-hidden="true" />
+        <span>{label}</span>
+        <ExternalLink size={10} aria-hidden="true" />
+      </a>
+    );
+  }
+  // Sin URL: badge no-link (source_id textual del RAG)
+  return (
+    <span
+      data-testid="deep-research-citation-badge"
+      data-source-id={citation.source_id}
+      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-slate-600/20 text-slate-300 border border-slate-600"
+    >
+      <ShieldCheck size={11} aria-hidden="true" />
+      <span>{label}</span>
+    </span>
+  );
+}
+
+/**
+ * StepsList — lista de sub-preguntas investigadas hasta ahora.
+ * Aparece durante el progreso y en el informe colapsado.
+ */
+function StepsList({ steps }) {
+  if (!steps || steps.length === 0) return null;
+  return (
+    <ul
+      className="mt-2 space-y-1"
+      aria-label="Sub-preguntas investigadas"
+      data-testid="deep-research-steps"
+    >
+      {steps.map((step, i) => (
+        <li
+          key={i}
+          className="flex items-start gap-2 text-xs text-slate-300"
+        >
+          <CheckCircle2 size={12} className="text-emerald-400 mt-0.5 shrink-0" aria-hidden="true" />
+          <span>{step}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * ETA honesto para Maxwell. El sidecar puede tardar 2–5 min en maxwell
+ * dependiendo del número de pasos. Mostramos un texto realista sin prometer
+ * nada exacto (microcopy honesto, no hype).
+ */
+function MaxwellEtaHint({ steps }) {
+  const stepCount = steps.length;
+  const hint = stepCount === 0
+    ? 'Iniciando investigación… puede tardar unos minutos.'
+    : stepCount < 3
+      ? `Investigando… ${stepCount} de varias sub-preguntas completadas.`
+      : `Investigando… ${stepCount} sub-preguntas completadas, casi listo.`;
+  return (
+    <p className="text-xs text-slate-400 mt-1 flex items-center gap-1">
+      <Clock size={11} aria-hidden="true" />
+      <span>{hint}</span>
+    </p>
+  );
+}
+
+export default function DeepResearchCard({
+  status,
+  steps = [],
+  report = '',
+  citations = [],
+  query = '',
+  onCancel,
+}) {
+  const [expanded, setExpanded] = useState(true);
+
+  // Guard: si no hay estado reconocible, no renderizar nada
+  if (!status) return null;
+
+  const isRunning = status === 'running' || status === 'submitting';
+  const isDone = status === 'done';
+  const isError = status === 'error';
+  const isOffline = status === 'offline';
+  const isDisabled = status === 'disabled';
+
+  if (isDisabled) {
+    return (
+      <div
+        data-testid="deep-research-card"
+        data-status="disabled"
+        className="rounded-xl border border-slate-700 bg-slate-800/60 px-4 py-3 mt-2 text-sm text-slate-400"
+      >
+        <span className="flex items-center gap-2">
+          <Microscope size={14} aria-hidden="true" />
+          La investigación profunda no está disponible en este plan.
+        </span>
+      </div>
+    );
+  }
+
+  if (isOffline) {
+    return (
+      <div
+        data-testid="deep-research-card"
+        data-status="offline"
+        className="rounded-xl border border-amber-700/50 bg-amber-900/20 px-4 py-3 mt-2 text-sm text-amber-300"
+      >
+        <span className="flex items-center gap-2">
+          <AlertTriangle size={14} aria-hidden="true" />
+          Sin conexión — la investigación profunda requiere internet.
+        </span>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div
+        data-testid="deep-research-card"
+        data-status="error"
+        className="rounded-xl border border-red-700/50 bg-red-900/20 px-4 py-3 mt-2 text-sm text-red-300"
+      >
+        <span className="flex items-center gap-2">
+          <AlertTriangle size={14} aria-hidden="true" />
+          Ocurrió un error al investigar. Intenta de nuevo con la pregunta.
+        </span>
+        {steps.length > 0 && (
+          <details className="mt-2">
+            <summary className="cursor-pointer text-xs text-red-400">Ver pasos completados antes del error</summary>
+            <StepsList steps={steps} />
+          </details>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="deep-research-card"
+      data-status={status}
+      className="rounded-xl border border-violet-700/40 bg-slate-800/70 mt-2 overflow-hidden"
+    >
+      {/* Header del card — siempre visible */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        data-testid="deep-research-card-toggle"
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-slate-700/30 transition-colors focus:outline-none focus:ring-2 focus:ring-violet-400/60"
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-violet-200">
+          {isRunning ? (
+            <Loader2 size={14} className="animate-spin text-violet-400" aria-hidden="true" />
+          ) : (
+            <Microscope size={14} className="text-violet-400" aria-hidden="true" />
+          )}
+          {isRunning
+            ? 'Investigando a fondo…'
+            : isDone
+              ? 'Informe de investigación'
+              : 'Investigación profunda'}
+        </span>
+        <span className="flex items-center gap-2">
+          {isRunning && typeof onCancel === 'function' && (
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); onCancel(); }}
+              data-testid="deep-research-cancel"
+              className="text-xs text-slate-400 hover:text-slate-200 px-2 py-0.5 rounded border border-slate-600 hover:border-slate-400 transition-colors"
+              aria-label="Cancelar investigación"
+            >
+              Cancelar
+            </button>
+          )}
+          {expanded ? (
+            <ChevronUp size={14} className="text-slate-400" aria-hidden="true" />
+          ) : (
+            <ChevronDown size={14} className="text-slate-400" aria-hidden="true" />
+          )}
+        </span>
+      </button>
+
+      {/* Cuerpo colapsable */}
+      {expanded && (
+        <div className="px-4 pb-4 pt-1">
+          {/* Pregunta original */}
+          {query && (
+            <p
+              className="text-xs text-slate-400 italic border-l-2 border-violet-700/40 pl-2 mb-2"
+              data-testid="deep-research-query"
+            >
+              "{query}"
+            </p>
+          )}
+
+          {/* Progreso: pasos + ETA */}
+          {isRunning && (
+            <>
+              <MaxwellEtaHint steps={steps} />
+              <StepsList steps={steps} />
+            </>
+          )}
+
+          {/* Informe final */}
+          {isDone && (
+            <>
+              {report ? (
+                <div
+                  data-testid="deep-research-report"
+                  className="text-sm text-slate-100 leading-relaxed whitespace-pre-wrap mt-1"
+                >
+                  {report}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-400 italic mt-1">
+                  La investigación completó sin generar un informe. Los pasos investigados están abajo.
+                </p>
+              )}
+
+              {/* Sub-preguntas como contexto del informe */}
+              {steps.length > 0 && (
+                <details className="mt-3">
+                  <summary
+                    className="cursor-pointer text-xs text-violet-300 hover:text-violet-100 transition-colors"
+                    data-testid="deep-research-steps-summary"
+                  >
+                    Ver {steps.length} sub-preguntas investigadas
+                  </summary>
+                  <StepsList steps={steps} />
+                </details>
+              )}
+
+              {/* Citas / fuentes */}
+              {citations.length > 0 && (
+                <div
+                  className="mt-3 pt-2 border-t border-slate-700/50"
+                  data-testid="deep-research-citations"
+                >
+                  <p className="text-xs text-slate-500 mb-1.5">Fuentes consultadas:</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {citations.map((c, i) => (
+                      <CitationBadge key={c.source_id || i} citation={c} index={i} />
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/DeepResearchCard.test.jsx
+++ b/src/components/__tests__/DeepResearchCard.test.jsx
@@ -1,0 +1,268 @@
+/**
+ * DeepResearchCard.test.jsx — TDD del card de progreso + informe Deep Research (A6/A7).
+ *
+ * Valida:
+ *   A6 — Card de progreso: estado 'submitting'/'running' muestra spinner +
+ *        steps visibles + ETA honesto + botón Cancelar.
+ *   A7 — Informe citado: status='done' renderiza report + CitationBadge por
+ *        citation. Si el informe está vacío, muestra texto útil (no pantalla en blanco).
+ *   Gate: status='disabled' y status='offline' muestran mensajes honestos.
+ *   Colapsable: el toggle abre/cierra el cuerpo.
+ *   Microcopy colombiano: nunca voseo argentino.
+ *   Accessibility: aria-expanded en el toggle, roles y data-testid presentes.
+ *
+ * Mocking: ninguno — el componente es presentacional puro (no hace fetch).
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi } from 'vitest';
+import DeepResearchCard from '../DeepResearchCard';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function renderCard(props) {
+  return render(<DeepResearchCard {...props} />);
+}
+
+// ── Gate: disabled y offline ────────────────────────────────────────────────
+
+describe('DeepResearchCard — gate: no disponible', () => {
+  test('status=disabled muestra mensaje de plan no disponible', () => {
+    renderCard({ status: 'disabled', steps: [], report: '', citations: [], query: '' });
+    const card = screen.getByTestId('deep-research-card');
+    expect(card).toHaveAttribute('data-status', 'disabled');
+    expect(card).toHaveTextContent(/no está disponible en este plan/i);
+  });
+
+  test('status=offline muestra mensaje de sin conexión', () => {
+    renderCard({ status: 'offline', steps: [], report: '', citations: [], query: '' });
+    const card = screen.getByTestId('deep-research-card');
+    expect(card).toHaveAttribute('data-status', 'offline');
+    expect(card).toHaveTextContent(/sin conexión/i);
+  });
+
+  test('status=error muestra mensaje de error honesto', () => {
+    renderCard({ status: 'error', steps: [], report: '', citations: [], query: '' });
+    const card = screen.getByTestId('deep-research-card');
+    expect(card).toHaveAttribute('data-status', 'error');
+    expect(card).toHaveTextContent(/error/i);
+  });
+
+  test('sin status → no renderiza nada', () => {
+    const { container } = renderCard({});
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ── A6: estado de progreso ──────────────────────────────────────────────────
+
+describe('DeepResearchCard — A6: progreso (running/submitting)', () => {
+  test('status=submitting muestra spinner y header "Investigando a fondo…"', () => {
+    renderCard({ status: 'submitting', steps: [], report: '', citations: [], query: 'cacao' });
+    expect(screen.getByTestId('deep-research-card')).toHaveAttribute('data-status', 'submitting');
+    expect(screen.getByRole('button', { name: /investigando a fondo/i })).toBeInTheDocument();
+  });
+
+  test('status=running muestra los steps visibles', () => {
+    renderCard({
+      status: 'running',
+      steps: ['¿Qué es el cacao?', '¿Cuándo se siembra?'],
+      report: '',
+      citations: [],
+      query: 'cacao agroforestal',
+    });
+    const stepsList = screen.getByTestId('deep-research-steps');
+    expect(stepsList).toBeInTheDocument();
+    expect(within(stepsList).getByText('¿Qué es el cacao?')).toBeInTheDocument();
+    expect(within(stepsList).getByText('¿Cuándo se siembra?')).toBeInTheDocument();
+  });
+
+  test('ETA honesto visible mientras running con 0 steps', () => {
+    renderCard({ status: 'running', steps: [], report: '', citations: [], query: 'achiote' });
+    // El hint de ETA contiene "Iniciando"
+    expect(screen.getByText(/iniciando investigación/i)).toBeInTheDocument();
+  });
+
+  test('ETA progresa con más steps', () => {
+    renderCard({
+      status: 'running',
+      steps: ['Paso A', 'Paso B', 'Paso C'],
+      report: '',
+      citations: [],
+      query: 'agroforestería',
+    });
+    expect(screen.getByText(/3 sub-preguntas/i)).toBeInTheDocument();
+  });
+
+  test('botón Cancelar visible mientras running + llama onCancel', () => {
+    const onCancel = vi.fn();
+    renderCard({
+      status: 'running',
+      steps: [],
+      report: '',
+      citations: [],
+      query: 'cacao',
+      onCancel,
+    });
+    const cancelBtn = screen.getByTestId('deep-research-cancel');
+    expect(cancelBtn).toBeInTheDocument();
+    fireEvent.click(cancelBtn);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  test('botón Cancelar NO aparece si no hay onCancel', () => {
+    renderCard({ status: 'running', steps: [], report: '', citations: [], query: 'cacao' });
+    expect(screen.queryByTestId('deep-research-cancel')).not.toBeInTheDocument();
+  });
+
+  test('la query del usuario aparece como contexto', () => {
+    renderCard({
+      status: 'running',
+      steps: [],
+      report: '',
+      citations: [],
+      query: 'sistema agroforestal con cacao y plátano',
+    });
+    expect(screen.getByTestId('deep-research-query')).toHaveTextContent(
+      'sistema agroforestal con cacao y plátano',
+    );
+  });
+});
+
+// ── A7: informe citado ──────────────────────────────────────────────────────
+
+describe('DeepResearchCard — A7: informe citado (done)', () => {
+  const DONE_PROPS = {
+    status: 'done',
+    steps: ['¿Qué es el achiote?', '¿Cuándo se cosecha?'],
+    report: 'El achiote (Bixa orellana) es un arbusto nativo de América tropical.',
+    citations: [
+      { source_id: 'agrosavia-1', label: 'Agrosavia', url: 'https://agrosavia.co/doc' },
+      { source_id: 'fao-2', label: 'FAO', url: 'https://fao.org/doc' },
+      { source_id: 'sin-url-3', label: 'Catálogo Chagra' }, // sin URL
+    ],
+    query: 'achiote cultivo colombia',
+  };
+
+  test('renderiza el informe cuando status=done', () => {
+    renderCard(DONE_PROPS);
+    const report = screen.getByTestId('deep-research-report');
+    expect(report).toBeInTheDocument();
+    expect(report).toHaveTextContent('El achiote');
+  });
+
+  test('muestra un CitationBadge por cada citation', () => {
+    renderCard(DONE_PROPS);
+    const badges = screen.getAllByTestId('deep-research-citation-badge');
+    expect(badges).toHaveLength(3);
+  });
+
+  test('citations con URL son links clickeables (CSP-safe: <a> nativo)', () => {
+    renderCard(DONE_PROPS);
+    const agrosaviaLink = screen.getByRole('link', { name: /agrosavia/i });
+    expect(agrosaviaLink).toHaveAttribute('href', 'https://agrosavia.co/doc');
+    expect(agrosaviaLink).toHaveAttribute('target', '_blank');
+    expect(agrosaviaLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('citations sin URL son badges de solo texto (sin <a>)', () => {
+    renderCard(DONE_PROPS);
+    // "Catálogo Chagra" no tiene URL → span, no anchor
+    const badges = screen.getAllByTestId('deep-research-citation-badge');
+    const chagraBadge = badges.find((b) => b.textContent.includes('Catálogo Chagra'));
+    expect(chagraBadge).toBeTruthy();
+    expect(chagraBadge.tagName).toBe('SPAN');
+  });
+
+  test('data-source-id en badges refleja el source_id real', () => {
+    renderCard(DONE_PROPS);
+    const agrosaviaLink = screen.getByRole('link', { name: /agrosavia/i });
+    expect(agrosaviaLink).toHaveAttribute('data-source-id', 'agrosavia-1');
+  });
+
+  test('sub-preguntas visibles en un <details> colapsable', () => {
+    renderCard(DONE_PROPS);
+    const summary = screen.getByTestId('deep-research-steps-summary');
+    expect(summary).toHaveTextContent(/2 sub-preguntas/i);
+  });
+
+  test('cuando report está vacío muestra texto útil (no pantalla en blanco)', () => {
+    renderCard({
+      ...DONE_PROPS,
+      report: '',
+      citations: [],
+    });
+    // No debe haber un div de report vacío — debe mostrar un texto alternativo
+    expect(screen.queryByTestId('deep-research-report')).not.toBeInTheDocument();
+    expect(screen.getByText(/completó sin generar un informe/i)).toBeInTheDocument();
+  });
+
+  test('area de citations NO aparece si citations está vacía', () => {
+    renderCard({ ...DONE_PROPS, citations: [] });
+    expect(screen.queryByTestId('deep-research-citations')).not.toBeInTheDocument();
+  });
+});
+
+// ── Colapsable ─────────────────────────────────────────────────────────────
+
+describe('DeepResearchCard — colapsable', () => {
+  test('el toggle abre y cierra el cuerpo con aria-expanded', () => {
+    renderCard({
+      status: 'done',
+      steps: ['Paso A'],
+      report: 'Informe completo.',
+      citations: [],
+      query: 'aguacate',
+    });
+    const toggle = screen.getByTestId('deep-research-card-toggle');
+    // Empieza expandido
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('deep-research-report')).toBeInTheDocument();
+
+    // Colapsar
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByTestId('deep-research-report')).not.toBeInTheDocument();
+
+    // Expandir de nuevo
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('deep-research-report')).toBeInTheDocument();
+  });
+});
+
+// ── Microcopy colombiano (sin voseo) ──────────────────────────────────────
+
+describe('DeepResearchCard — microcopy colombiano', () => {
+  const VOSEO = /\b(escrib[íi]|tom[áa]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|sab[ée]s|and[áa]|dale)\b/i;
+
+  test('ningún texto del card usa voseo argentino (running)', () => {
+    const { container } = renderCard({
+      status: 'running',
+      steps: ['Paso A'],
+      report: '',
+      citations: [],
+      query: 'maíz',
+      onCancel: vi.fn(),
+    });
+    expect(container.textContent).not.toMatch(VOSEO);
+  });
+
+  test('ningún texto del card usa voseo argentino (done)', () => {
+    const { container } = renderCard({
+      status: 'done',
+      steps: ['Paso A'],
+      report: 'Informe listo.',
+      citations: [{ source_id: 'src', label: 'Fuente', url: 'https://ejemplo.co' }],
+      query: 'frijol',
+    });
+    expect(container.textContent).not.toMatch(VOSEO);
+  });
+
+  test('ningún texto del card usa voseo argentino (offline)', () => {
+    const { container } = renderCard({ status: 'offline', steps: [], report: '', citations: [], query: '' });
+    expect(container.textContent).not.toMatch(VOSEO);
+  });
+});

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -4,6 +4,7 @@ import {
   CHIP_DEFS,
   planForcedIntent,
   isStubIntent,
+  isDeepResearchIntent,
 } from '../chipIntentRouter.js';
 
 /**
@@ -145,22 +146,46 @@ describe('chipIntentRouter — intents STUB (backend no existe aún)', () => {
     expect(plan.skipNlu).toBe(true);
   });
 
-  it('deep → stub claro "aún no disponible" (investigación profunda)', () => {
-    const plan = planForcedIntent('deep', 'sistema agroforestal cacao');
-    expect(plan.intent).toBe('deep');
-    expect(plan.stub).toBe(true);
-    expect(plan.tool).toBeNull();
-    expect(typeof plan.stubMessage).toBe('string');
-    expect(plan.skipNlu).toBe(true);
-  });
-
-  it('isStubIntent reconoce precio y deep como stub', () => {
+  it('isStubIntent reconoce precio como stub y deep como NO stub (backend live)', () => {
     expect(isStubIntent('precio')).toBe(true);
-    expect(isStubIntent('deep')).toBe(true);
+    // Deep Research ya tiene backend live — ya NO es stub
+    expect(isStubIntent('deep')).toBe(false);
     expect(isStubIntent('siembro')).toBe(false);
     expect(isStubIntent('plaga')).toBe(false);
     expect(isStubIntent('clima')).toBe(false);
     expect(isStubIntent('xxx')).toBe(false);
+  });
+});
+
+describe('chipIntentRouter — Deep Research (A6/A7, backend live)', () => {
+  it('deep → plan con deep=true + skipNlu + tool null (el AgentScreen lo intercepta)', () => {
+    const plan = planForcedIntent('deep', 'sistema agroforestal cacao');
+    expect(plan.intent).toBe('deep');
+    expect(plan.deep).toBe(true);
+    expect(plan.stub).toBe(false);
+    expect(plan.tool).toBeNull();
+    expect(plan.stubMessage).toBeNull();
+    expect(plan.skipNlu).toBe(true);
+    expect(plan.prompt).toBe('sistema agroforestal cacao');
+  });
+
+  it('isDeepResearchIntent reconoce solo el intent deep', () => {
+    expect(isDeepResearchIntent('deep')).toBe(true);
+    expect(isDeepResearchIntent('precio')).toBe(false);
+    expect(isDeepResearchIntent('siembro')).toBe(false);
+    expect(isDeepResearchIntent('plaga')).toBe(false);
+    expect(isDeepResearchIntent('clima')).toBe(false);
+    expect(isDeepResearchIntent('xxx')).toBe(false);
+    expect(isDeepResearchIntent(null)).toBe(false);
+    expect(isDeepResearchIntent(undefined)).toBe(false);
+  });
+
+  it('deep chip tiene kind=deep en CHIP_DEFS (no stub)', () => {
+    const deepDef = CHIP_DEFS.find((d) => d.intent === 'deep');
+    expect(deepDef).toBeTruthy();
+    expect(deepDef.kind).toBe('deep');
+    // Ya no tiene stubMessage
+    expect(deepDef.stubMessage).toBeUndefined();
   });
 });
 

--- a/src/services/__tests__/deepResearchClient.test.js
+++ b/src/services/__tests__/deepResearchClient.test.js
@@ -1,0 +1,377 @@
+/**
+ * deepResearchClient.test.js — TDD del cliente HTTP de Deep Research (A6/A7).
+ *
+ * Tests escritos ANTES del código (TDD). Validan:
+ *   - isDeepResearchEnabled() lee correctamente la flag de entorno.
+ *   - submitDeepResearch() retorna null con flag off / offline / fetch fail.
+ *   - submitDeepResearch() retorna { job_id } en happy path.
+ *   - fetchDeepResearchStatus() normaliza correctamente el body del sidecar.
+ *   - normalizeStatus() maneja campos faltantes con defaults seguros.
+ *   - pollDeepResearch() invoca onUpdate en cada tick y resuelve al done.
+ *   - pollDeepResearch() respeta AbortSignal (cancel-on-demand).
+ *   - Backoff exponencial — usa los pasos definidos en BACKOFF_STEPS_MS.
+ *
+ * Mocking: solo fetch global — sin net real, sin sidecar, sin timer real.
+ * Español colombiano en strings, nunca voseo argentino.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isDeepResearchEnabled,
+  submitDeepResearch,
+  fetchDeepResearchStatus,
+  normalizeStatus,
+  pollDeepResearch,
+  BACKOFF_STEPS_MS,
+} from '../deepResearchClient.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+let fetchMock;
+
+function mockEnv(value) {
+  // Parchea import.meta.env.VITE_DEEP_RESEARCH_ENABLED
+  vi.stubEnv('VITE_DEEP_RESEARCH_ENABLED', value);
+}
+
+function setOnline(online) {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    value: online,
+  });
+}
+
+function mockFetchOnce(body, { status = 200, ok = true } = {}) {
+  const jsonFn = vi.fn().mockResolvedValueOnce(body);
+  const res = { ok, status, json: jsonFn };
+  fetchMock.mockResolvedValueOnce(res);
+  return jsonFn;
+}
+
+function mockFetchFail(error = new Error('network error')) {
+  fetchMock.mockRejectedValueOnce(error);
+}
+
+// ── Setup global ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  globalThis.fetch = fetchMock;
+  setOnline(true);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  setOnline(true);
+});
+
+// ── isDeepResearchEnabled ──────────────────────────────────────────────────
+
+describe('isDeepResearchEnabled', () => {
+
+  it('retorna false si la flag no está definida (default seguro)', () => {
+    vi.unstubAllEnvs();
+    expect(isDeepResearchEnabled()).toBe(false);
+  });
+
+  it('retorna true con "true"', () => {
+    mockEnv('true');
+    expect(isDeepResearchEnabled()).toBe(true);
+  });
+
+  it('retorna true con "1"', () => {
+    mockEnv('1');
+    expect(isDeepResearchEnabled()).toBe(true);
+  });
+
+  it('retorna false con "false"', () => {
+    mockEnv('false');
+    expect(isDeepResearchEnabled()).toBe(false);
+  });
+
+  it('retorna false con string vacío', () => {
+    mockEnv('');
+    expect(isDeepResearchEnabled()).toBe(false);
+  });
+
+  it('acepta boolean true directamente', () => {
+    // import.meta.env puede devolver boolean en algunos bundlers
+    mockEnv(true);
+    expect(isDeepResearchEnabled()).toBe(true);
+  });
+});
+
+// ── normalizeStatus ────────────────────────────────────────────────────────
+
+describe('normalizeStatus', () => {
+  it('normaliza body completo correctamente', () => {
+    const result = normalizeStatus({
+      status: 'done',
+      steps: ['¿Qué es el achiote?', '¿Cuándo se siembra?'],
+      report: 'El achiote es una especie nativa.',
+      citations: [{ source_id: 'agrosavia-1', label: 'Agrosavia', url: 'https://agrosavia.co/doc' }],
+      timings: { total_ms: 12000 },
+    });
+    expect(result.status).toBe('done');
+    expect(result.steps).toHaveLength(2);
+    expect(result.report).toBe('El achiote es una especie nativa.');
+    expect(result.citations).toHaveLength(1);
+    expect(result.timings.total_ms).toBe(12000);
+  });
+
+  it('usa valores por defecto seguros si faltan campos', () => {
+    const result = normalizeStatus({});
+    expect(result.status).toBe('running'); // default si no hay status válido
+    expect(result.steps).toEqual([]);
+    expect(result.report).toBe('');
+    expect(result.citations).toEqual([]);
+    expect(result.timings).toEqual({});
+  });
+
+  it('filtra steps que no son strings no vacíos', () => {
+    const result = normalizeStatus({
+      status: 'running',
+      steps: ['paso válido', '', null, 42, '  '],
+    });
+    expect(result.steps).toEqual(['paso válido']);
+  });
+
+  it('filtra citations que no son objetos', () => {
+    const result = normalizeStatus({
+      status: 'done',
+      citations: [{ source_id: 'ok' }, null, 'no-objeto', 42],
+    });
+    expect(result.citations).toHaveLength(1);
+    expect(result.citations[0].source_id).toBe('ok');
+  });
+
+  it('acepta status running, done y error', () => {
+    for (const s of ['running', 'done', 'error']) {
+      expect(normalizeStatus({ status: s }).status).toBe(s);
+    }
+  });
+
+  it('status desconocido cae a "running" (defensa)', () => {
+    expect(normalizeStatus({ status: 'unknown-estado' }).status).toBe('running');
+    expect(normalizeStatus({ status: null }).status).toBe('running');
+  });
+});
+
+// ── submitDeepResearch ─────────────────────────────────────────────────────
+
+describe('submitDeepResearch', () => {
+  it('retorna null si la flag está off (default)', async () => {
+    // flag off → no hay fetch
+    const result = await submitDeepResearch('¿Qué siembro en diciembre?');
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('retorna null para query vacía', async () => {
+    mockEnv('true');
+    expect(await submitDeepResearch('')).toBeNull();
+    expect(await submitDeepResearch('   ')).toBeNull();
+    expect(await submitDeepResearch(null)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('retorna null si está offline', async () => {
+    mockEnv('true');
+    setOnline(false);
+    const result = await submitDeepResearch('¿Qué siembro?');
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('retorna { job_id } en happy path', async () => {
+    mockEnv('true');
+    mockFetchOnce({ job_id: 'abc-123' }, { status: 200, ok: true });
+    const result = await submitDeepResearch('Sistema agroforestal cacao');
+    expect(result).toEqual({ job_id: 'abc-123' });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/deep-research'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('retorna null si el server responde non-2xx', async () => {
+    mockEnv('true');
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: vi.fn() });
+    const result = await submitDeepResearch('agroforestería');
+    expect(result).toBeNull();
+  });
+
+  it('retorna null si el body no trae job_id', async () => {
+    mockEnv('true');
+    mockFetchOnce({ error: 'no job' });
+    const result = await submitDeepResearch('agroforestería');
+    expect(result).toBeNull();
+  });
+
+  it('retorna null ante error de red (catch silencioso)', async () => {
+    mockEnv('true');
+    mockFetchFail();
+    const result = await submitDeepResearch('agroforestería');
+    expect(result).toBeNull();
+  });
+});
+
+// ── fetchDeepResearchStatus ────────────────────────────────────────────────
+
+describe('fetchDeepResearchStatus', () => {
+  it('retorna null si la flag está off', async () => {
+    const result = await fetchDeepResearchStatus('abc-123');
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('retorna null para jobId vacío', async () => {
+    mockEnv('true');
+    expect(await fetchDeepResearchStatus('')).toBeNull();
+    expect(await fetchDeepResearchStatus(null)).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('retorna el status normalizado en happy path', async () => {
+    mockEnv('true');
+    mockFetchOnce({
+      status: 'running',
+      steps: ['Paso uno', 'Paso dos'],
+      report: '',
+      citations: [],
+    });
+    const result = await fetchDeepResearchStatus('abc-123');
+    expect(result).not.toBeNull();
+    expect(result.status).toBe('running');
+    expect(result.steps).toHaveLength(2);
+  });
+
+  it('retorna null ante non-2xx', async () => {
+    mockEnv('true');
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 404, json: vi.fn() });
+    expect(await fetchDeepResearchStatus('abc-123')).toBeNull();
+  });
+
+  it('retorna null ante error de red', async () => {
+    mockEnv('true');
+    mockFetchFail();
+    expect(await fetchDeepResearchStatus('abc-123')).toBeNull();
+  });
+
+  it('respeta AbortSignal externo', async () => {
+    mockEnv('true');
+    // La señal ya está abortada cuando se llama — debe fallar el fetch
+    const controller = new AbortController();
+    controller.abort();
+    // fetch con señal abortada lanza AbortError inmediato
+    fetchMock.mockRejectedValueOnce(
+      Object.assign(new Error('Aborted'), { name: 'AbortError' }),
+    );
+    const result = await fetchDeepResearchStatus('abc-123', controller.signal);
+    expect(result).toBeNull();
+  });
+});
+
+// ── pollDeepResearch ───────────────────────────────────────────────────────
+
+describe('pollDeepResearch', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retorna null si jobId está vacío', async () => {
+    const result = await pollDeepResearch('', vi.fn());
+    expect(result).toBeNull();
+  });
+
+  it('resuelve con status=done en primer tick (sin backoff)', async () => {
+    mockEnv('true');
+    // Si el primer fetch devuelve done, el loop termina sin esperar
+    fetchMock.mockResolvedValueOnce({
+      ok: true, status: 200,
+      json: () => Promise.resolve({
+        status: 'done',
+        steps: ['Solo un paso'],
+        report: 'Informe rápido.',
+        citations: [{ source_id: 'src-1', url: 'https://ejemplo.co' }],
+      }),
+    });
+
+    const onUpdate = vi.fn();
+    const result = await pollDeepResearch('job-fast', onUpdate);
+
+    expect(result.status).toBe('done');
+    expect(result.report).toBe('Informe rápido.');
+    expect(result.citations).toHaveLength(1);
+    expect(onUpdate).toHaveBeenCalledOnce();
+    expect(onUpdate).toHaveBeenCalledWith(['Solo un paso'], 'done');
+  });
+
+  it('resuelve con status=error cuando el sidecar devuelve error', async () => {
+    mockEnv('true');
+    fetchMock.mockResolvedValueOnce({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ status: 'error', steps: [], report: '', citations: [] }),
+    });
+
+    const result = await pollDeepResearch('job-err', vi.fn());
+    expect(result.status).toBe('error');
+  });
+
+  it('llama onUpdate en cada tick con pasos nuevos y resuelve al done', async () => {
+    mockEnv('true');
+    // Usamos fake timers para controlar el backoff sin esperar 1s real
+    vi.useFakeTimers();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: () => Promise.resolve({ status: 'running', steps: ['Paso A'], report: '', citations: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: () => Promise.resolve({ status: 'done', steps: ['Paso A', 'Paso B'], report: 'Informe final.', citations: [] }),
+      });
+
+    const onUpdate = vi.fn();
+    // Lanzar el poll (llama fetch inmediatamente, luego duerme 1000ms antes del 2do)
+    const pollPromise = pollDeepResearch('job-1', onUpdate);
+
+    // Primer fetch ya corrió (resolve inmediato del mock) — avanzar el timer del backoff
+    await vi.runAllTimersAsync();
+    const result = await pollPromise;
+
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate.mock.calls[0]).toEqual([['Paso A'], 'running']);
+    expect(onUpdate.mock.calls[1]).toEqual([['Paso A', 'Paso B'], 'done']);
+    expect(result.status).toBe('done');
+    expect(result.report).toBe('Informe final.');
+  });
+
+  it('cancela el loop cuando el AbortSignal se aborta antes del primer fetch', async () => {
+    mockEnv('true');
+    const controller = new AbortController();
+    controller.abort(); // abortar ANTES de llamar a poll
+
+    // fetch rechazará con AbortError por la señal
+    fetchMock.mockRejectedValueOnce(
+      Object.assign(new Error('Aborted'), { name: 'AbortError' }),
+    );
+
+    const onUpdate = vi.fn();
+    const result = await pollDeepResearch('job-cancel', onUpdate, controller.signal);
+    expect(result).toBeNull();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('BACKOFF_STEPS_MS tiene 5 entradas con el cap correcto', () => {
+    expect(BACKOFF_STEPS_MS).toHaveLength(5);
+    expect(BACKOFF_STEPS_MS[0]).toBe(1000);
+    expect(BACKOFF_STEPS_MS[1]).toBe(2000);
+    expect(BACKOFF_STEPS_MS[2]).toBe(4000);
+    expect(BACKOFF_STEPS_MS[3]).toBe(8000);
+    expect(BACKOFF_STEPS_MS[4]).toBe(8000); // cap
+  });
+});

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -107,12 +107,8 @@ export const CHIP_DEFS = Object.freeze([
     intent: CHIP_INTENTS.deep,
     emoji: '🔬',
     label: 'Investigación profunda',
-    kind: 'stub',
+    kind: 'deep',
     placeholder: 'Escribe el tema que quieres investigar a fondo',
-    stubMessage:
-      'La investigación profunda multi-fuente todavía no está disponible. ' +
-      'Por ahora puedo responder con el catálogo Chagra y conocimiento agronómico general. ' +
-      'Pregúntame de forma concreta y te ayudo con lo que tengo.',
   },
 ]);
 
@@ -125,12 +121,25 @@ const DEF_BY_INTENT = Object.freeze(
 
 /**
  * ¿Este intent es un STUB (backend no implementado)?
+ * Devuelve false para 'deep' — Deep Research ya tiene backend live.
  * @param {string} intent
  * @returns {boolean}
  */
 export function isStubIntent(intent) {
   const def = DEF_BY_INTENT[intent];
   return Boolean(def && def.kind === 'stub');
+}
+
+/**
+ * ¿Este intent es Deep Research?
+ * Permite al AgentScreen interceptar el flujo ANTES del stub-check y del
+ * pipeline NLU/tool, lanzando el job async de deep research.
+ * @param {string} intent
+ * @returns {boolean}
+ */
+export function isDeepResearchIntent(intent) {
+  const def = DEF_BY_INTENT[intent];
+  return Boolean(def && def.kind === 'deep');
 }
 
 /**
@@ -216,9 +225,15 @@ export function planForcedIntent(intent, text, opts = {}) {
     }
 
     case CHIP_INTENTS.precio:
-    case CHIP_INTENTS.deep:
       // STUB: backend no implementado. NO inventamos endpoint.
       return { ...base, stub: true, stubMessage: def.stubMessage };
+
+    case CHIP_INTENTS.deep:
+      // Deep Research: el backend está live (POST /deep-research → GET /deep-research/:id).
+      // Devolvemos el plan con kind='deep' para que AgentScreen lo intercepte
+      // ANTES del flujo NLU/tool y lance el job async. El caller (AgentScreen)
+      // gestiona el polling y actualiza el card en el historial de chat.
+      return { ...base, deep: true };
 
     default:
       return null;

--- a/src/services/deepResearchClient.js
+++ b/src/services/deepResearchClient.js
@@ -1,0 +1,263 @@
+/**
+ * deepResearchClient.js — Cliente HTTP del endpoint Deep Research del sidecar.
+ *
+ * El sidecar expone:
+ *   POST /deep-research        → 202 { job_id }
+ *   GET  /deep-research/:jobId → { status: 'running'|'done', steps[], report, citations[], timings }
+ *
+ * Feature flag: `VITE_DEEP_RESEARCH_ENABLED` (default false).
+ * En pre-prod se activa con VITE_DEEP_RESEARCH_ENABLED=true.
+ * En prod-free queda off por defecto — Deep Research es pro-only y pesado.
+ * Cuando exista el sistema de tier/allowlist se agregará un check de tier
+ * aquí (TODO: gating por tier cuando exista).
+ *
+ * Reglas operativas (idénticas al sidecarClient existente):
+ *   - Offline-first: si !navigator.onLine → null inmediato.
+ *   - Timeout: submit 15s, poll 10s.
+ *   - Falla silenciosa: catch → null, el caller decide el UX.
+ *   - Auth: header X-Chagra-Token igual que el sidecarClient.
+ *   - Sin dependencias: fetch puro + AbortController.
+ *
+ * Polling:
+ *   `pollDeepResearch(jobId, onUpdate, signal)` hace GET con backoff
+ *   exponencial (1s→2s→4s→8s cap) hasta status=done o señal de abort.
+ *   `onUpdate` recibe (steps: string[], status: string) en cada tick
+ *   donde hay pasos nuevos o el status cambió.
+ *
+ * Español colombiano (tú/usted), nunca voseo argentino.
+ */
+
+const SUBMIT_TIMEOUT_MS = 15000;
+const POLL_TIMEOUT_MS = 10000;
+
+// Backoff exponencial para polling: 1s→2s→4s→8s (cap). Aislado para tests.
+export const BACKOFF_STEPS_MS = [1000, 2000, 4000, 8000, 8000];
+
+/**
+ * Lee la flag `VITE_DEEP_RESEARCH_ENABLED`. Acepta 'true'/'1' como activado.
+ * Exportado para que el caller pueda desactivar la UI sin llamar las funciones.
+ *
+ * @returns {boolean}
+ */
+export function isDeepResearchEnabled() {
+  try {
+    const raw = import.meta.env?.VITE_DEEP_RESEARCH_ENABLED;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+function getBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.trim().replace(/\/+$/, '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '/api/mcp/agro';
+}
+
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function makeHeaders() {
+  const headers = { 'Content-Type': 'application/json' };
+  const token = getToken();
+  if (token) headers['X-Chagra-Token'] = token;
+  return headers;
+}
+
+/**
+ * Envía la pregunta al endpoint POST /deep-research.
+ *
+ * @param {string} query — pregunta del usuario
+ * @returns {Promise<null | { job_id: string }>}
+ *   null si: flag off, offline, timeout, non-2xx, body inválido.
+ */
+export async function submitDeepResearch(query) {
+  if (!isDeepResearchEnabled()) return null;
+  if (!query || typeof query !== 'string' || !query.trim()) return null;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    console.debug('[deep-research] offline — skip submit');
+    return null;
+  }
+
+  const base = getBaseUrl();
+  const url = `${base}/deep-research`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
+
+  const t0 = Date.now();
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: makeHeaders(),
+      body: JSON.stringify({ query: query.trim() }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.debug('[deep-research] submit non-2xx', { status: res.status });
+      return null;
+    }
+    const json = await res.json();
+    const latency = Date.now() - t0;
+    console.debug('[deep-research] submit ok', { job_id: json?.job_id, latency_ms: latency });
+    if (!json || typeof json.job_id !== 'string') return null;
+    return { job_id: json.job_id };
+  } catch (err) {
+    const reason = err?.name === 'AbortError' ? 'timeout' : (err?.message || 'unknown');
+    console.debug('[deep-research] submit fail', { reason });
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Lee el estado actual de un job (GET /deep-research/:jobId).
+ *
+ * @param {string} jobId
+ * @param {AbortSignal} [signal]
+ * @returns {Promise<null | DeepResearchStatus>}
+ *
+ * @typedef {Object} DeepResearchStatus
+ * @property {'running'|'done'|'error'} status
+ * @property {string[]} steps   — sub-preguntas investigadas hasta ahora
+ * @property {string}   report  — informe acumulado (vacío si running)
+ * @property {Citation[]} citations
+ * @property {object}   timings — métricas opcionales del sidecar
+ *
+ * @typedef {Object} Citation
+ * @property {string} source_id
+ * @property {string} [label]
+ * @property {string} [url]
+ */
+export async function fetchDeepResearchStatus(jobId, signal) {
+  if (!isDeepResearchEnabled()) return null;
+  if (!jobId || typeof jobId !== 'string') return null;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    console.debug('[deep-research] offline — skip poll');
+    return null;
+  }
+
+  const base = getBaseUrl();
+  const url = `${base}/deep-research/${encodeURIComponent(jobId)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), POLL_TIMEOUT_MS);
+
+  // Conectar señal externa para cancel-on-demand
+  let externalAbortListener;
+  if (signal) {
+    externalAbortListener = () => controller.abort();
+    signal.addEventListener('abort', externalAbortListener, { once: true });
+  }
+
+  const headers = {};
+  const token = getToken();
+  if (token) headers['X-Chagra-Token'] = token;
+
+  try {
+    const res = await fetch(url, { method: 'GET', headers, signal: controller.signal });
+    if (!res.ok) {
+      console.debug('[deep-research] poll non-2xx', { jobId, status: res.status });
+      return null;
+    }
+    const json = await res.json();
+    if (!json || typeof json !== 'object') return null;
+    return normalizeStatus(json);
+  } catch (err) {
+    const reason = err?.name === 'AbortError' ? 'timeout/cancelled' : (err?.message || 'unknown');
+    console.debug('[deep-research] poll fail', { jobId, reason });
+    return null;
+  } finally {
+    clearTimeout(timer);
+    if (signal && externalAbortListener) {
+      signal.removeEventListener('abort', externalAbortListener);
+    }
+  }
+}
+
+/**
+ * Normaliza el body del sidecar a una forma canónica y defensiva.
+ * No falla si algún campo falta — degrada con valores vacíos seguros.
+ * @param {object} raw
+ * @returns {DeepResearchStatus}
+ */
+export function normalizeStatus(raw) {
+  const validStatuses = new Set(['running', 'done', 'error']);
+  const status = validStatuses.has(raw.status) ? raw.status : 'running';
+  const steps = Array.isArray(raw.steps)
+    ? raw.steps.filter((s) => typeof s === 'string' && s.trim().length > 0)
+    : [];
+  const report = typeof raw.report === 'string' ? raw.report : '';
+  const citations = Array.isArray(raw.citations)
+    ? raw.citations.filter((c) => c && typeof c === 'object')
+    : [];
+  const timings = (raw.timings && typeof raw.timings === 'object') ? raw.timings : {};
+  return { status, steps, report, citations, timings };
+}
+
+/**
+ * Polling loop completo con backoff exponencial.
+ * Llama `fetchDeepResearchStatus` hasta status=done o signal abortado.
+ *
+ * @param {string} jobId
+ * @param {function(steps: string[], status: string): void} onUpdate
+ *   Callback en cada tick con pasos nuevos o cambio de status.
+ * @param {AbortSignal} [signal] — para cancelar el loop desde fuera.
+ * @returns {Promise<DeepResearchStatus | null>}
+ *   Resuelve con el estado final (done/error), o null si cancelado.
+ */
+export async function pollDeepResearch(jobId, onUpdate, signal) {
+  if (!jobId) return null;
+  let attempt = 0;
+  let lastStepCount = 0;
+
+  while (true) {
+    if (signal?.aborted) return null;
+
+    const result = await fetchDeepResearchStatus(jobId, signal);
+
+    if (signal?.aborted) return null;
+
+    if (result) {
+      if (result.steps.length > lastStepCount || result.status === 'done' || result.status === 'error') {
+        lastStepCount = result.steps.length;
+        if (typeof onUpdate === 'function') {
+          onUpdate(result.steps, result.status);
+        }
+      }
+      if (result.status === 'done' || result.status === 'error') {
+        return result;
+      }
+    }
+
+    // Esperar con backoff antes del siguiente poll
+    const delay = BACKOFF_STEPS_MS[Math.min(attempt, BACKOFF_STEPS_MS.length - 1)];
+    attempt++;
+    await new Promise((resolve, reject) => {
+      const t = setTimeout(resolve, delay);
+      if (signal) {
+        const onAbort = () => {
+          clearTimeout(t);
+          reject(new DOMException('Aborted', 'AbortError'));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }).catch(() => null); // abort durante sleep → el while-guard lo captura
+  }
+}


### PR DESCRIPTION
## Summary

- **A6 — Card de progreso**: el chip 🔬 ya no es stub. Al tocarlo se lanza un job `POST /deep-research`, el chat muestra un card `DeepResearchCard` con estado *Investigando a fondo…*, pasos visibles en tiempo real vía polling (backoff 1s→8s), ETA honesto para Maxwell (puede tardar 2–5 min), y botón Cancelar.
- **A7 — Informe citado**: cuando `status=done`, el card renderiza el `report` con un `CitationBadge` por cada citation (link `<a>` CSP-safe o span sin URL). Colapsable. Si el informe es el fallback determinista, se muestra igualmente útil.
- **Gate pro-only**: `VITE_DEEP_RESEARCH_ENABLED` (default `false`). En pre-prod se activa con `=true`. Hay un gate adicional de conexión (offline → mensaje honesto). El gating por tier se documentó como TODO para cuando exista el allowlist.

## Archivos cambiados

| Archivo | Tipo |
|---|---|
| `src/services/deepResearchClient.js` | nuevo — cliente HTTP + polling |
| `src/components/DeepResearchCard.jsx` | nuevo — card A6/A7 |
| `src/services/chipIntentRouter.js` | modificado — 'deep' de stub→live, `isDeepResearchIntent()` |
| `src/components/AgentScreen/AgentScreen.jsx` | modificado — intercept + job async + cancel |
| `src/components/AgentScreen/ChatHistory.jsx` | modificado — renderiza `DeepResearchCard` |
| `.env.example` | modificado — documenta `VITE_DEEP_RESEARCH_ENABLED` |
| `src/services/__tests__/deepResearchClient.test.js` | nuevo — 31 tests |
| `src/components/__tests__/DeepResearchCard.test.jsx` | nuevo — 23 tests |
| `src/services/__tests__/chipIntentRouter.test.js` | modificado — 17 tests actualizados |

## Test plan

- [x] Suite completa: 190 archivos / 3112 tests / 0 fallos (1 skip pre-existente)
- [x] ESLint max-warnings=0 en todos los archivos modificados
- [x] `deepResearchClient`: flag off/online/offline/happy-path/non-2xx/abort/backoff
- [x] `DeepResearchCard`: gate disabled/offline/error, A6 progreso, A7 informe citado, colapsable, microcopy sin voseo, CitationBadge CSP-safe
- [x] `chipIntentRouter`: 'deep' ya no es stub, `isDeepResearchIntent` reconoce solo 'deep'
- [ ] Smoke contra endpoint real: requiere `VITE_DEEP_RESEARCH_ENABLED=true` + sidecar live en alpha

🤖 Generated with [Claude Code](https://claude.com/claude-code)