### PR TITLE
chore(release): desatascar versión 1.0.32→1.0.33 + deploy-marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.32",
+  "version": "1.0.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/deploy-marker.txt
+++ b/public/deploy-marker.txt
@@ -1,2 +1,1 @@
-trigger=1779836557
-trigger_1779837288=ok
+deploy 2026-06-02T16:34:32Z — version unstick tras colisión auto-bump paralelo

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v290';
+const CACHE_NAME = 'chagra-v291';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',


### PR DESCRIPTION
Los merges paralelos de hoy dejaron la versión pegada en 1.0.32 (todos bumpearon desde la misma base 1.0.31) pese a que el código de main avanzó a 357e435. El operador ve 'v1.0.32 no actualiza' aunque el código SÍ es el último.

Este bump fuerza un deploy con etiqueta nueva (1.0.33) + dispara el aviso de actualización del Service Worker. Solo cambia version + deploy-marker.

Follow-up pendiente: arreglar el auto-bump de lefthook para que calcule la próxima versión relativa a origin/main, no a la base del branch (raíz de la colisión recurrente).