### PR TITLE
feat(ui): "Cosecha mística" como fondo por defecto universal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.33",
+  "version": "1.0.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v291';
+const CACHE_NAME = 'chagra-v292';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -13,11 +13,12 @@ import useThemeBackgroundStore, { getBackgroundSrc } from '../store/useThemeBack
 export default function LoginScreen({ onLoginSuccess, onSave }) {
   const [creds, setCreds] = useState({ username: '', password: '' });
   const [loading, setLoading] = useState(false);
-  // Selector de fondos: en login mostramos el fondo curado elegido como
-  // capa de foto detrás del patrón biopunk. Suscribimos solo el id (string)
-  // para evitar React #185. 'default' sigue mostrando solo slate + biopunk.
+  // Selector de fondos: en login mostramos el fondo curado como capa de foto.
+  // Suscribimos solo el id (string) para evitar React #185. SIEMPRE resolvemos
+  // a una foto (getBackgroundSrc) — incluido 'default', que ahora cae a "Cosecha
+  // mística" (DEFAULT_BACKGROUND_SRC). Así el login nunca muestra el patrón viejo.
   const selectedBackground = useThemeBackgroundStore((s) => s.selected);
-  const loginBgSrc = selectedBackground === 'default' ? null : getBackgroundSrc(selectedBackground);
+  const loginBgSrc = getBackgroundSrc(selectedBackground);
 
   const handleLogin = async (e) => {
     e.preventDefault();

--- a/src/index.css
+++ b/src/index.css
@@ -47,7 +47,7 @@
      * overlay global. */
     background-image:
       linear-gradient(rgba(2, 6, 23, 0.45), rgba(2, 6, 23, 0.62)),
-      var(--app-bg-image, url('/biodiversidad-bg.jpg'));
+      var(--app-bg-image, url('/fondo-biopunk-4.jpg'));
     background-size: cover;
     background-position: center center;
     background-repeat: no-repeat;

--- a/src/store/__tests__/useThemeBackgroundStore.test.js
+++ b/src/store/__tests__/useThemeBackgroundStore.test.js
@@ -20,12 +20,12 @@ import useThemeBackgroundStore, {
 describe('useThemeBackgroundStore', () => {
   beforeEach(() => {
     localStorage.clear();
-    // Singleton entre tests: volver a 'default'.
-    useThemeBackgroundStore.getState().setBackground('default');
+    // Singleton entre tests: volver al default universal (Cosecha mística).
+    useThemeBackgroundStore.getState().setBackground('biopunk-4');
   });
 
-  it('estado inicial: selected="default"', () => {
-    expect(useThemeBackgroundStore.getState().selected).toBe('default');
+  it('default universal: selected="biopunk-4" (Cosecha mística, operador 2026-06-02)', () => {
+    expect(useThemeBackgroundStore.getState().selected).toBe('biopunk-4');
   });
 
   it('setBackground cambia el fondo seleccionado', () => {
@@ -70,8 +70,9 @@ describe('useThemeBackgroundStore', () => {
     expect(getBackgroundById('no-existe')).toBe(BACKGROUND_CATALOG[0]);
   });
 
-  it('getBackgroundSrc: default usa la imagen clásica', () => {
+  it('getBackgroundSrc: default cae a Cosecha mística (DEFAULT_BACKGROUND_SRC)', () => {
     expect(getBackgroundSrc('default')).toBe(DEFAULT_BACKGROUND_SRC);
+    expect(DEFAULT_BACKGROUND_SRC).toBe('/fondo-biopunk-4.jpg');
   });
 
   it('getBackgroundSrc: fondo biopunk usa su JPG', () => {

--- a/src/store/useThemeBackgroundStore.js
+++ b/src/store/useThemeBackgroundStore.js
@@ -72,8 +72,13 @@ export const BACKGROUND_CATALOG = Object.freeze([
   }),
 ]);
 
-/** Imagen clásica original — fallback estable para 'default'. */
-export const DEFAULT_BACKGROUND_SRC = '/biodiversidad-bg.jpg';
+/**
+ * Fondo por defecto de TODA la app y el login — "Cosecha mística" (biopunk-4).
+ * Decisión operador 2026-06-02: este es el default universal; cualquier usuario
+ * que no haya elegido explícitamente otro fondo (incluido login/incógnito) lo ve.
+ * (Antes era '/biodiversidad-bg.jpg', el "fondo viejo" que el operador descartó.)
+ */
+export const DEFAULT_BACKGROUND_SRC = '/fondo-biopunk-4.jpg';
 
 /** Set congelado de ids válidos para validar entradas externas. */
 const VALID_IDS = Object.freeze(BACKGROUND_CATALOG.map((b) => b.id));
@@ -98,7 +103,9 @@ export function getBackgroundSrc(id) {
 const useThemeBackgroundStore = create(
   persist(
     (set) => ({
-      selected: 'default',
+      // Default universal "Cosecha mística" (operador 2026-06-02). Usuarios
+      // nuevos / incógnito arrancan en biopunk-4; el chip queda resaltado en Perfil.
+      selected: 'biopunk-4',
 
       /**
        * Cambia el fondo seleccionado. Valida contra el catálogo; un id


### PR DESCRIPTION
## Qué
"Cosecha mística" (biopunk-4) pasa a ser el **fondo por defecto de toda la app y el login**, para cualquier usuario sin selección explícita — incluido login y sesiones nuevas/incógnito.

## Por qué
El operador reportó (verificado en incógnito = sin cache) que el login mostraba el patrón biopunk viejo y la app `/biodiversidad-bg.jpg`. El default `'default'/Clásico` nunca resolvía a una foto en el login. Decisión operador 2026-06-02: mística por defecto para todo.

## Cómo
- `DEFAULT_BACKGROUND_SRC` → `/fondo-biopunk-4.jpg`
- estado inicial del store → `'biopunk-4'`
- fallback CSS de `.app-bg-biodiversidad` → `/fondo-biopunk-4.jpg` (cubre usuarios persistidos en `'default'` donde App.jsx limpia el var)
- `LoginScreen` resuelve **siempre** a foto vía `getBackgroundSrc` — elimina el caso especial que mostraba el patrón viejo
- Tests del store actualizados (9/9 verdes)

Los biopunk-1/2/3 siguen disponibles en el selector de Perfil.