### PR TITLE
feat(catalog): schema v3.2 + backfill restauración/incendios Fase 1

### DIFF
--- a/catalog/chagra-catalog-oss-subset-v3.2.json
+++ b/catalog/chagra-catalog-oss-subset-v3.2.json
@@ -20,7 +20,7 @@
     "alcance_seed": "7 especies migradas desde v3.0. Las DRs por piso térmico poblarán hasta ~400 especies totales (100 × 4 pisos).",
     "advertencia": "Validar con: node scripts/validate-catalog.mjs --seed-mode. Refs a species aún no migradas aparecen como warnings."
   },
-  "schema_version": "3.1",
+  "schema_version": "3.2",
   "seed_version": "0.2.0-oss-subset-v3.2",
   "generated_at": "2026-05-25T23:11:20.222Z",
   "generated_by": "scripts/extract-oss-subset-v32.mjs",
@@ -297,6 +297,10 @@
       ],
       "cultivable": true,
       "conservation_status": "nativo_silvestre",
+      "rol_restauracion": "pionera",
+      "resistencia_fuego": null,
+      "apta_ribera": true,
+      "invasora_combustible": false,
       "cycleMonths": null,
       "habito": "arbol deciduo semicaducifolio, 15-25m altura",
       "altitud_msnm": {
@@ -2408,6 +2412,75 @@
       "cultivar": false
     },
     {
+      "id": "pinus_patula",
+      "_curation_status": "BORRADOR_IA — Fase 1 módulo reforestación/incendios; binomio y datos de fuego/invasión respaldados por MODULO_REFORESTACION_INCENDIOS_2026-06-02 §2.1 + IAvH/Humboldt. Pendiente validación triple-DR (Fase 2).",
+      "_anti_confusion": "NO confundir con eucalipto (Eucalyptus globulus, Myrtaceae) ni con ciprés (Cupressus). Pinus patula es Pinaceae, conífera de acículas largas en grupos de 3.",
+      "nombre_comun": "Pino pátula",
+      "nombre_comunes_regionales": [
+        "pino crespo",
+        "pino llorón",
+        "pino colombiano"
+      ],
+      "nombre_cientifico": "Pinus patula Schiede ex Schltdl. & Cham.",
+      "familia_botanica": "Pinaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "emergente",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
+      "origen": "México (Sierra Madre Oriental)",
+      "habito": "conífera de hasta 30-40 m, acículas largas (10-25 cm) en fascículos de 3",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3500
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo",
+        "bordes_de_plantacion_forestal",
+        "areas_quemadas"
+      ],
+      "mecanismos_invasion": [
+        "Resinas y aceites esenciales altamente inflamables que amplifican incendios de alta severidad (doc §2.1)",
+        "Acículas impermeables que forman mantillo ácido y suprimen la germinación de especies nativas (doc §2.1)",
+        "Dispersión de semillas aladas por viento desde plantaciones forestales hacia áreas naturales adyacentes",
+        "Regeneración favorecida tras el fuego en algunas condiciones (serotinia parcial)"
+      ],
+      "especies_nativas_sustitutas": [
+        "quercus_humboldtii",
+        "weinmannia_tomentosa",
+        "polylepis_quadrijuga"
+      ],
+      "protocolo_post_remocion": "Tala dirigida + extracción de regeneración natural; restauración activa con nativas altoandinas (roble negro, encenillo, coloradito) al siguiente semestre lluvioso; remoción del mantillo de acículas para liberar el banco de semillas nativo; monitoreo de rebrote/germinación 5 años.",
+      "riesgo_rebrote": "medio",
+      "validation_level": "claude_draft",
+      "source_ids": [
+        "humboldt-invasoras-andes",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El pino pátula (Pinus patula) es una conífera mexicana introducida masivamente en los Andes colombianos para plantaciones forestales y de papel desde mediados del siglo XX. En piso frío y subpáramo (1.800-3.500 msnm) se comporta como invasora combustible: sus resinas y aceites esenciales son altamente inflamables y amplifican incendios de alta severidad, mientras que sus acículas largas e impermeables forman un mantillo ácido que suprime la germinación de la flora nativa altoandina. Donde reemplaza coberturas naturales reduce la regulación hídrica y la biodiversidad. La alternativa de restauración es el bosque nativo de roble negro (Quercus humboldtii), encenillo (Weinmannia tomentosa) y, en cota alta, coloradito (Polylepis quadrijuga). Manejo: tala dirigida, retiro del mantillo de acículas y revegetación con nativas, con monitoreo de regeneración por al menos cinco años. Fuente principal: repositorio IAvH/Humboldt sobre especies con comportamiento invasor en los Andes; binomio verificado contra POWO/GBIF.",
+      "tracking_mode": null
+    },
+    {
       "id": "psidium_guajava_manzana",
       "nombre_comun": "Guayaba manzana",
       "nombre_cientifico": "Psidium guajava 'Manzana'",
@@ -2596,6 +2669,10 @@
       ],
       "cultivable": false,
       "conservation_status": "nativo_protegido",
+      "rol_restauracion": "climax",
+      "resistencia_fuego": "alta",
+      "apta_ribera": false,
+      "invasora_combustible": false,
       "altitud_msnm": {
         "min_absoluto": 1500,
         "optimo_min": 2400,
@@ -3364,6 +3441,10 @@
       ],
       "cultivable": false,
       "conservation_status": "invasor",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
       "habito": "arbusto espinoso 1-3m",
       "origen": "Europa occidental (Islas Británicas a Iberia)",
       "clasificacion_uicn": "Entre las 100 peores especies invasoras del mundo (ISSG/UICN)",
@@ -3853,6 +3934,10 @@
       ],
       "cultivable": false,
       "conservation_status": "nativo_silvestre",
+      "rol_restauracion": "secundaria",
+      "resistencia_fuego": "media",
+      "apta_ribera": false,
+      "invasora_combustible": false,
       "altitud_msnm": {
         "min_absoluto": 2000,
         "optimo_min": 2500,
@@ -4920,6 +5005,10 @@
       ],
       "cultivable": false,
       "conservation_status": "nativo_protegido",
+      "rol_restauracion": "climax",
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": false,
       "altitud_msnm": {
         "min_absoluto": 2800,
         "optimo_min": 3000,
@@ -5381,6 +5470,10 @@
       ],
       "cultivable": true,
       "conservation_status": "nativo_silvestre",
+      "rol_restauracion": null,
+      "resistencia_fuego": "media",
+      "apta_ribera": true,
+      "invasora_combustible": false,
       "altitud_msnm": {
         "min_absoluto": 0,
         "optimo_min": 500,
@@ -8901,6 +8994,10 @@
       ],
       "cultivar": false,
       "conservation_status": "naturalizada",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
       "altitud_msnm": {
         "min_absoluto": 1400,
         "optimo_min": 2000,
@@ -9086,6 +9183,10 @@
       ],
       "cultivar": false,
       "conservation_status": "invasor",
+      "rol_restauracion": null,
+      "resistencia_fuego": null,
+      "apta_ribera": false,
+      "invasora_combustible": true,
       "altitud_msnm": {
         "min_absoluto": 1800,
         "optimo_min": 2200,
@@ -9865,7 +9966,7 @@
       },
       "source_ids": [
         "powo-kew",
-        "gbif-taxomic-backbone"
+        "gbif-taxonomic-backbone"
       ],
       "valor_pedagogico": "El cardamomo (Elettaria cardamomum) es una hierba perenne de la familia Zingiberaceae, nativa de India, cultivado por sus cápsulas verdes (cardamomo verde). Planta de 1-3 m, hojas lanceoladas, flores blancas/verdosas, cápsulas verdes triangulares con semillas negras aromáticas. Tercera especia más cara del mundo (después de azafrán, vainilla). Sabor: dulce, picante, floral, cítrico (complejo). Usos: repostería india, chai, café árabe, curries. Requiere sombra (30-50%), alta humedad (>70%), suelo bien drenado fértil. Escala pequeña en Colombia (Cundinamarca, Boyacá). Lección: muestra especias de alto valor, cultivo en sombra (agroforestería), y sabor complejo en gastronomía. Fuentes: POWO Kew, GBIF.",
       "validation_level": "claude_draft",

--- a/catalog/schema-v3.1.json
+++ b/catalog/schema-v3.1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://chagra.guatoc.co/schema/catalog/v3.1.json",
-  "title": "Chagra Species Catalog — Schema v3.1",
-  "description": "Schema formal para catálogo agroecológico Chagra. Consolida v3.0 con las 16 ambigüedades resueltas (ver chagra-catalog-seed-v3.0.json §ambiguedades_detectadas_en_schema_v3). Validador: scripts/validate-catalog.mjs",
+  "title": "Chagra Species Catalog — Schema v3.2",
+  "description": "Schema formal para catálogo agroecológico Chagra. Consolida v3.0 con las 16 ambigüedades resueltas (ver chagra-catalog-seed-v3.0.json §ambiguedades_detectadas_en_schema_v3). v3.2 (2026-06-02, Módulo Reforestación+Incendios Fase 1) añade 4 campos OPCIONALES de restauración en species: rol_restauracion (enum pionera|secundaria|climax|nodriza|null), resistencia_fuego (enum alta|media|baja|null), apta_ribera (bool|null), invasora_combustible (bool|null). Validador: scripts/validate-catalog.mjs",
   "type": "object",
   "required": [
     "schema_version",
@@ -175,6 +175,35 @@
             "naturalizada",
             "no_evaluada"
           ]
+        },
+        "rol_restauracion": {
+          "type": ["string", "null"],
+          "enum": [
+            "pionera",
+            "secundaria",
+            "climax",
+            "nodriza",
+            null
+          ],
+          "description": "Módulo Reforestación+Incendios (Fase 1, schema v3.2 — MODULO_REFORESTACION_INCENDIOS_2026-06-02). Rol sucesional de la especie en restauración ecológica: 'pionera' (coloniza áreas degradadas/post-incendio, crecimiento rápido, facilita sucesión), 'secundaria' (etapa intermedia, se establece bajo pioneras), 'climax' (bosque maduro estable, dosel denso), 'nodriza' (nurse plant: protege/facilita el establecimiento de otras especies sin ser necesariamente sucesional). null = sin rol de restauración asignado o no respaldado por fuente. Regla anti-alucinación: solo valor no-null con respaldo de fuente Tier-A o DR citado."
+        },
+        "resistencia_fuego": {
+          "type": ["string", "null"],
+          "enum": [
+            "alta",
+            "media",
+            "baja",
+            null
+          ],
+          "description": "Módulo Reforestación+Incendios (Fase 1, schema v3.2). Aptitud de la especie como cortafuego vivo / baja inflamabilidad foliar: 'alta' (hoja húmeda/suculenta, baja inflamabilidad, útil como cortafuego), 'media', 'baja'. null = sin dato verificado (NO inferir). Regla anti-alucinación (doc §2.3): este campo solo recibe valor no-null con fuente Tier-A verificada. NO es lo mismo que invasora_combustible (especies pirofíticas/inflamables tienen resistencia_fuego=null, no 'baja', porque el campo mide aptitud cortafuego, no la peligrosidad)."
+        },
+        "apta_ribera": {
+          "type": ["boolean", "null"],
+          "description": "Módulo Reforestación+Incendios (Fase 1, schema v3.2). true si la especie es apta para restauración riparia / estabilización de orillas y cauces; false si no lo es; null si no se ha evaluado. Respaldo requerido por fuente o DR."
+        },
+        "invasora_combustible": {
+          "type": ["boolean", "null"],
+          "description": "Módulo Reforestación+Incendios (Fase 1, schema v3.2). true si la especie es invasora con alta carga combustible que amplifica incendios (pirofítica/inflamable), p.ej. Ulex europaeus, Genista monspessulana, Eucalyptus globulus, Melinis minutiflora, Pinus patula; false si no; null si no se ha evaluado. Independiente de category/conservation_status: una especie marcada naturalizada (no 'invasor') puede tener invasora_combustible=true si la fuente lo respalda."
         },
         "cites_appendix": {
           "type": "string",


### PR DESCRIPTION
## Resumen

Capa de **datos** del módulo Reforestación + Riesgo de Incendios (mission-core, **Fase 1**), prerequisito de las tools MCP (`get_diseno_restauracion`, `get_invasoras_alternativas`) y la UI. Diseño: `Chagra-strategy/ops/MODULO_REFORESTACION_INCENDIOS_2026-06-02.md`. No requiere triple-DR (usa solo evidencia ya documentada en ese doc).

Alcance: una sola PR coherente — catálogo + schema + validador. **No toca el array de biopreparados.** El chip "Invasoras" de la PWA es otra superficie y no va aquí.

## 1. Schema v3.2 — 4 campos opcionales nuevos en `species`

`additionalProperties: true` ya los permitía a nivel de validación; aquí se **formalizan con enums documentados** (queryability + guía anti-alucinación):

| Campo | Tipo / enum |
|---|---|
| `rol_restauracion` | `pionera` \| `secundaria` \| `climax` \| `nodriza` \| `null` |
| `resistencia_fuego` | `alta` \| `media` \| `baja` \| `null` |
| `apta_ribera` | `boolean` \| `null` |
| `invasora_combustible` | `boolean` \| `null` |

`schema_version` del catálogo: `3.1` → `3.2` (el enum del schema ya aceptaba ambas).

## 2. Backfill (valores respaldados por el doc — Apéndice A + §2 + §5)

Regla anti-alucinación (doc §2.3): donde el doc **no** respalda un valor de fuego se deja `null`.

| Species | rol_restauracion | resistencia_fuego | apta_ribera | invasora_combustible | Fuente |
|---|---|---|---|---|---|
| `quercus_humboldtii` | climax | **alta** | false | false | Scielo CR 2024 (único valor de fuego Tier-A verificado, doc §2.3) |
| `weinmannia_tomentosa` | secundaria | media | false | false | doc §5.2 + Apéndice A cortafuego |
| `polylepis_quadrijuga` | climax | null | false | false | Apéndice A "clímax/bosque denso" |
| `alnus_acuminata` | pionera | null | **true** | false | Apéndice A "pionera post-incendio" + "riparia piso frío" |
| `trichanthera_gigantea` | null | media | **true** | false | Apéndice A cortafuego + §1.1 (riparia) |
| `ulex_europaeus` | null | null | false | **true** | doc §1.2 + Apéndice A |
| `genista_monspessulana` | null | null | false | **true** | doc §1.2 + Apéndice A |
| `eucalyptus_globulus` | null | null | false | **true** | doc §1.2 + Apéndice A (no se altera category/conservation_status) |

## 3. Nueva species: `pinus_patula`

`Pinus patula Schiede ex Schltdl. & Cham.` (Pinaceae) — `especies_invasoras` / `invasor` / `invasora_combustible: true` (doc §2.1, IAvH/Humboldt). 4 fuentes Tier-A (Humboldt, Bernal, POWO, GBIF). Sustitutas nativas: roble negro, encenillo, coloradito. **Total invasoras: 11** (test exige ≥10). Incluye `_anti_confusion` (no confundir con eucalipto/ciprés).

## 4. Fix incidental

`source_id` `gbif-taxomic-backbone` → `gbif-taxonomic-backbone` en `elettaria_cardamomum` (typo pre-existente que rompía AMB-11; necesario para dejar el validador verde).

## Validación

- `node scripts/validate-catalog.mjs --seed-mode --lenient-schema catalog/chagra-catalog-oss-subset-v3.2.json catalog/schema-v3.1.json` → **exit 0** (205 species, 36 biopreparados, 68 sources). 66 warnings de schema son legacy pre-existentes (`_url_pendiente`, `estrato` faltante) — idénticos antes/después (cero regresión).
- Tests de catálogo (vitest): `build-catalog-sqlite.invasoras` + `validate-catalog` + `build-oss-subset` → **22/22 pass**.

## Nota de archivo (verify-before-claim)

Se editó `catalog/chagra-catalog-oss-subset-v3.2.json` (204→205 spp) porque empíricamente es la fuente que `scripts/build-catalog-sqlite.mjs` consume por defecto y donde viven 8/9 de las species del módulo; `catalog/chagra-catalog-seed-v3.1.json` en este repo es un subset de 50 spp que **no** contiene 8 de las 9 species objetivo. El seed canónico de 495 spp vive en el repo privado `chagra-pro` (fuera de scope).

## Gaps para Fase 2 (triple-DR)

- `resistencia_fuego` de Polylepis quadrijuga y Alnus acuminata: el doc no da valor → `null`.
- `melinis_minutiflora` (pasto gordura): listada como invasora combustible en el doc pero **ausente de este subset** (no se pudo backfillear aquí).
- Species nuevas Galeras/Nariño (Chusquea, Clusia, Myrsine, Diplostephium, etc.): doc §2 las marca `[verificar-antes]` (sin URL-200) → Fase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)