### PR TITLE
fix(ci): bump de versión a deploy-time (elimina colisión auto-bump)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,20 @@ jobs:
           VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
 
       - if: env.SKIP_DEPLOY != '1'
+        name: Set deploy-time version
+        # Bump de versión movido de pre-commit (lefthook auto-bump-version) a
+        # deploy-time para eliminar colisiones entre PRs paralelos — raíz del
+        # "versión pegada" (label v1.0.32 congelado, no avanzaba pese a deploys).
+        # Versión monotónica 1.0.<commit-count>, única por deploy: el label
+        # v{APP_VERSION} (TopBar/LoginScreen leen package.json baked en build)
+        # siempre avanza. El CACHE_NAME del SW lo bumpea el step post-deploy.
+        run: |
+          COUNT=$(git rev-list --count HEAD)
+          VERSION="1.0.${COUNT}"
+          npm pkg set version="$VERSION"
+          echo "Deploy version set to $VERSION"
+
+      - if: env.SKIP_DEPLOY != '1'
         name: Build
         run: npm run build
         env:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -88,13 +88,11 @@ pre-commit:
       exclude: '\.d\.ts$'
       run: npx eslint {staged_files} --max-warnings=0
 
-    auto-bump-version:
-      # Auto-bumpea package.json version + sw.js CACHE_NAME en patch si
-      # cambian archivos críticos (src/**, public/**) y el dev olvidó
-      # hacerlo manual. Evita conflicts en PRs paralelos (sesión 2026-04-30/05-01
-      # tuvo ~6 conflicts repetidos en estos 2 archivos).
-      # Convención: el dev NO bumpea, el hook sí.
-      run: node scripts/auto-bump-version.mjs
+    # auto-bump-version REMOVIDO 2026-06-02: el bump de versión se movió a
+    # deploy-time (.github/workflows/deploy.yml → step "Set deploy-time version")
+    # para eliminar las colisiones de auto-bump entre PRs paralelos que dejaban
+    # la versión pegada (raíz del "no actualiza" / label v1.0.32 congelado).
+    # El CACHE_NAME del SW lo sigue bumpeando el step post-deploy (per-SHA).
 
     cycle-content-anti-overpromise:
       # Valida /public/cycle-content/<slug>.json contra rangos agroecológicos


### PR DESCRIPTION
Mueve el bump de versión de pre-commit (lefthook) a deploy-time. Raíz del "versión pegada 1.0.32 / no actualiza": el hook bumpeaba desde la base de rama → PRs paralelos colisionaban. Ahora: commits no tocan versión (cero colisión); deploy.yml setea `1.0.<commit-count>` antes del build (label siempre avanza); SW CACHE_NAME per-SHA sigue disparando el banner. Decisión operador 2026-06-02.