### PR TITLE
feat(tier): allowlist pro|free — tierService + sidecar headers + Deep Research gate UI (A1)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -60,6 +60,10 @@ import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from 
 // Deep Research (A6/A7): cliente HTTP del endpoint async de investigación
 // profunda del sidecar. Feature flag VITE_DEEP_RESEARCH_ENABLED (default false).
 import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../../services/deepResearchClient';
+// Tier free|pro (A1): resuelve el tier del usuario logueado contra la allowlist.
+// isPro controla el gate de la UI (chip 🔬); x-chagra-tier se inyecta en el
+// sidecarClient/deepResearchClient vía buildSidecarHeaders (defense-in-depth).
+import { getCurrentTier } from '../../services/tierService';
 import DeepResearchCard from '../DeepResearchCard';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak } from '../../services/agentService';
 import { applyOutputGuards, applyTaxonomyGuard } from '../../services/outputGuards';
@@ -2666,6 +2670,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         activeIntent={activeIntent}
         hasAttachment={false}
         disabled={state === STATE_RECORDING}
+        isPro={getCurrentTier() === 'pro'}
       />
 
       {/* Input */}

--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CHIP_DEFS } from '../services/chipIntentRouter';
+import { CHIP_DEFS, CHIP_INTENTS } from '../services/chipIntentRouter';
 
 /**
  * ChipsToolbar — "caja de herramientas" del agente como CHIPS DE MODO
@@ -20,6 +20,10 @@ import { CHIP_DEFS } from '../services/chipIntentRouter';
  * El chip 📷 foto solo se muestra cuando hay una imagen adjunta lista
  * (`hasAttachment`). Coordina con el flujo de adjuntos del compositor.
  *
+ * Tier gating (A1): el chip 🔬 Investigación profunda (Deep Research) es Pro-only.
+ * Si `isPro` es false, el chip se muestra deshabilitado con copy "función Pro"
+ * para que el usuario free sepa qué existe pero no pueda activarlo.
+ *
  * Props:
  *   - onSelectIntent: callback(intent: string) — el call-site decide qué hacer.
  *                     Recibe el intent enum del chip ('siembro', 'plaga', ...,
@@ -27,12 +31,15 @@ import { CHIP_DEFS } from '../services/chipIntentRouter';
  *   - activeIntent:   string | null — intent del modo activo (resalta el chip).
  *   - hasAttachment:  boolean — si hay imagen adjunta, muestra el chip 📷 foto.
  *   - disabled:       boolean — deshabilita todos los chips (ej. mientras graba).
+ *   - isPro:          boolean — si el usuario actual tiene tier Pro. Los chips
+ *                     Pro-only (🔬) se muestran deshabilitados para free.
  */
 export default function ChipsToolbar({
   onSelectIntent,
   activeIntent = null,
   hasAttachment = false,
   disabled = false,
+  isPro = false,
 }) {
   if (typeof onSelectIntent !== 'function') return null;
 
@@ -47,6 +54,9 @@ export default function ChipsToolbar({
     'bg-slate-700 border-slate-500 text-slate-100 hover:bg-slate-600 hover:border-slate-400';
   const activeChip =
     'bg-emerald-600 border-emerald-300 text-white shadow-md';
+  // Chip Pro bloqueado: apariencia visualmente diferenciada para free users.
+  const proLockedChip =
+    'bg-slate-800 border-slate-700 text-slate-500 cursor-not-allowed';
 
   return (
     <div
@@ -76,20 +86,37 @@ export default function ChipsToolbar({
 
         {CHIP_DEFS.map((def) => {
           const isActive = activeIntent === def.intent;
+          // El chip 🔬 Deep Research es Pro-only. Para usuarios free: deshabilitado
+          // con copy claro "función Pro" y title explicativo. NO se oculta — el
+          // usuario free debe saber que la funcionalidad existe (upsell suave).
+          const isDeepChip = def.intent === CHIP_INTENTS.deep;
+          const isProLocked = isDeepChip && !isPro;
+          const chipDisabled = disabled || isProLocked;
+          const chipClass = isProLocked
+            ? proLockedChip
+            : isActive
+              ? activeChip
+              : inactiveChip;
+          const chipTitle = isProLocked
+            ? 'Función Pro — disponible para usuarios con acceso avanzado'
+            : def.placeholder;
+
           return (
             <button
               key={def.intent}
               type="button"
               data-testid="mode-chip"
               data-intent={def.intent}
-              onClick={() => onSelectIntent(def.intent)}
-              disabled={disabled}
+              data-pro-locked={isProLocked ? 'true' : undefined}
+              onClick={() => !isProLocked && onSelectIntent(def.intent)}
+              disabled={chipDisabled}
               aria-pressed={isActive}
-              title={def.placeholder}
-              className={`${baseChip} ${isActive ? activeChip : inactiveChip}`}
+              aria-label={isProLocked ? `${def.label} — función Pro` : def.label}
+              title={chipTitle}
+              className={`${baseChip} ${chipClass}`}
             >
               <span aria-hidden="true">{def.emoji}</span>
-              <span>{def.label}</span>
+              <span>{isProLocked ? `${def.label} (Pro)` : def.label}</span>
             </button>
           );
         })}

--- a/src/components/__tests__/ChipsToolbar.smoke.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.smoke.test.jsx
@@ -12,17 +12,25 @@ import { CHIP_DEFS } from '../../services/chipIntentRouter';
  *   - el chip activo se marca aria-pressed,
  *   - el chip 📷 foto solo aparece/activa si hay imagen adjunta,
  *   - retorna null si falta el handler (defensa contra mounts incompletos).
+ *   - tier gate A1: chip 🔬 Deep Research deshabilitado para free, activo para pro.
  */
 
 describe('ChipsToolbar — barra de chips de modo', () => {
-  test('renderiza los 7 chips de modo', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} />);
+  test('renderiza los 7 chips de modo (usuario free — deep chip bloqueado)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
     const chips = screen.getAllByTestId('mode-chip');
     expect(chips).toHaveLength(7);
     // El emoji + label del primero (siembro) debe estar presente
     expect(screen.getByText('¿Qué siembro?')).toBeInTheDocument();
     expect(screen.getByText('Plaga')).toBeInTheDocument();
+    // Free users ven el chip con sufijo "(Pro)"
+    expect(screen.getByText('Investigación profunda (Pro)')).toBeInTheDocument();
+  });
+
+  test('renderiza el chip 🔬 sin sufijo cuando isPro=true', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
     expect(screen.getByText('Investigación profunda')).toBeInTheDocument();
+    expect(screen.queryByText('Investigación profunda (Pro)')).not.toBeInTheDocument();
   });
 
   test('clickear un chip llama onSelectIntent con el intent enum', () => {
@@ -79,5 +87,62 @@ describe('ChipsToolbar — barra de chips de modo', () => {
     const { container } = render(<ChipsToolbar onSelectIntent={() => {}} hasAttachment />);
     const VOSEO = /\b(escrib[íi]|tom[áa]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|sab[ée]s)\b/i;
     expect(container.textContent).not.toMatch(VOSEO);
+  });
+
+  // ──── Tier gate A1 ────────────────────────────────────────────────────────
+
+  test('chip 🔬 está deshabilitado (disabled) para usuario free (isPro=false)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).toBeDisabled();
+  });
+
+  test('chip 🔬 está habilitado para usuario pro (isPro=true)', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).not.toBeDisabled();
+  });
+
+  test('click en chip 🔬 llama onSelectIntent para usuario pro', () => {
+    const onSelectIntent = vi.fn();
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro />);
+    fireEvent.click(screen.getByRole('button', { name: /investigación profunda/i }));
+    expect(onSelectIntent).toHaveBeenCalledWith('deep');
+  });
+
+  test('click en chip 🔬 NO llama onSelectIntent para usuario free', () => {
+    const onSelectIntent = vi.fn();
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro={false} />);
+    // El botón está disabled — fireEvent.click no dispara el handler
+    fireEvent.click(screen.getByRole('button', { name: /investigación profunda/i }));
+    expect(onSelectIntent).not.toHaveBeenCalledWith('deep');
+  });
+
+  test('chip 🔬 tiene data-pro-locked cuando usuario es free', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).toHaveAttribute('data-pro-locked', 'true');
+  });
+
+  test('chip 🔬 NO tiene data-pro-locked cuando usuario es pro', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).not.toHaveAttribute('data-pro-locked');
+  });
+
+  test('chip 🔬 tiene title explicativo de función Pro cuando free', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).toHaveAttribute('title', expect.stringContaining('Pro'));
+  });
+
+  test('chips no-Pro (siembro, plaga, etc.) siguen activos para usuario free', () => {
+    const onSelectIntent = vi.fn();
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro={false} />);
+    fireEvent.click(screen.getByText('¿Qué siembro?'));
+    expect(onSelectIntent).toHaveBeenCalledWith('siembro');
+    onSelectIntent.mockClear();
+    fireEvent.click(screen.getByText('Plaga'));
+    expect(onSelectIntent).toHaveBeenCalledWith('plaga');
   });
 });

--- a/src/services/__tests__/tierService.test.js
+++ b/src/services/__tests__/tierService.test.js
@@ -1,0 +1,146 @@
+/**
+ * tierService.test.js — TDD para el servicio de tier free|pro.
+ *
+ * Cobertura:
+ *  - resolveTier: username en allowlist → 'pro'.
+ *  - resolveTier: username fuera de allowlist → 'free' (default).
+ *  - resolveTier: null / undefined / empty → 'free' (defensive).
+ *  - resolveTier: matching case-insensitive (farmOS usernames pueden tener
+ *    mezcla de mayúsculas según el cliente web de farmOS).
+ *  - PRO_USERNAMES exporta un Set (editable por el operador).
+ *  - ANA_USERNAME_PENDIENTE exporta el placeholder como señal de que la
+ *    cuenta de Ana está lista para ser activada.
+ *  - buildSidecarHeaders: incluye 'x-chagra-tier' con el tier del usuario actual.
+ *  - buildSidecarHeaders: sin usuario logueado → 'free'.
+ *  - buildSidecarHeaders: incluye X-Chagra-Token cuando se pasa token.
+ *  - getCurrentTier: resuelve tier del tenantId activo en localStorage.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let tierService;
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import('../tierService.js');
+};
+
+describe('tierService — resolveTier', () => {
+  beforeEach(async () => {
+    tierService = await importFresh();
+  });
+
+  it('devuelve "pro" para username en la allowlist', () => {
+    // 'admin' es el usuario principal del operador, siempre pro
+    expect(tierService.resolveTier('admin')).toBe('pro');
+  });
+
+  it('devuelve "free" para username fuera de la allowlist', () => {
+    expect(tierService.resolveTier('campesino_juan')).toBe('free');
+    expect(tierService.resolveTier('visitante')).toBe('free');
+    expect(tierService.resolveTier('random_user_xyz')).toBe('free');
+  });
+
+  it('devuelve "free" para null/undefined/empty (defensive)', () => {
+    expect(tierService.resolveTier(null)).toBe('free');
+    expect(tierService.resolveTier(undefined)).toBe('free');
+    expect(tierService.resolveTier('')).toBe('free');
+  });
+
+  it('matching es case-insensitive', () => {
+    // farmOS usernames suelen ser lowercase, pero el matching debe ser robusto
+    expect(tierService.resolveTier('Admin')).toBe('pro');
+    expect(tierService.resolveTier('ADMIN')).toBe('pro');
+  });
+
+  it('PRO_USERNAMES exporta un Set (editable por el operador)', () => {
+    expect(tierService.PRO_USERNAMES).toBeInstanceOf(Set);
+    expect(tierService.PRO_USERNAMES.size).toBeGreaterThan(0);
+  });
+
+  it('ANA_USERNAME_PENDIENTE está exportado como placeholder', () => {
+    // Señal de que la cuenta de Ana está "lista para activar" cuando
+    // el operador provea el username real
+    expect(typeof tierService.ANA_USERNAME_PENDIENTE).toBe('string');
+    expect(tierService.ANA_USERNAME_PENDIENTE.length).toBeGreaterThan(0);
+  });
+});
+
+describe('tierService — buildSidecarHeaders', () => {
+  let store;
+
+  beforeEach(async () => {
+    store = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => store[k] ?? null,
+      setItem: (k, v) => { store[k] = v; },
+      removeItem: (k) => { delete store[k]; },
+    });
+    tierService = await importFresh();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('incluye x-chagra-tier: "pro" cuando el usuario logueado es pro', () => {
+    store['chagra:active_tenant_id'] = 'admin';
+    const headers = tierService.buildSidecarHeaders('test-token');
+    expect(headers['x-chagra-tier']).toBe('pro');
+  });
+
+  it('incluye x-chagra-tier: "free" cuando el usuario logueado no está en allowlist', () => {
+    store['chagra:active_tenant_id'] = 'campesino_libre';
+    const headers = tierService.buildSidecarHeaders('test-token');
+    expect(headers['x-chagra-tier']).toBe('free');
+  });
+
+  it('incluye x-chagra-tier: "free" cuando no hay usuario logueado', () => {
+    // store vacío → tenantId = null → tier free (safe default)
+    const headers = tierService.buildSidecarHeaders('test-token');
+    expect(headers['x-chagra-tier']).toBe('free');
+  });
+
+  it('incluye X-Chagra-Token cuando se pasa token no vacío', () => {
+    store['chagra:active_tenant_id'] = 'admin';
+    const headers = tierService.buildSidecarHeaders('my-secret-token');
+    expect(headers['X-Chagra-Token']).toBe('my-secret-token');
+  });
+
+  it('no incluye X-Chagra-Token cuando el token es cadena vacía', () => {
+    const headers = tierService.buildSidecarHeaders('');
+    expect(headers['X-Chagra-Token']).toBeUndefined();
+  });
+});
+
+describe('tierService — getCurrentTier', () => {
+  let store;
+
+  beforeEach(async () => {
+    store = {};
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => store[k] ?? null,
+      setItem: (k, v) => { store[k] = v; },
+      removeItem: (k) => { delete store[k]; },
+    });
+    tierService = await importFresh();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('devuelve "pro" para usuario logueado en allowlist', () => {
+    store['chagra:active_tenant_id'] = 'admin';
+    expect(tierService.getCurrentTier()).toBe('pro');
+  });
+
+  it('devuelve "free" para usuario logueado fuera de allowlist', () => {
+    store['chagra:active_tenant_id'] = 'usuario_free';
+    expect(tierService.getCurrentTier()).toBe('free');
+  });
+
+  it('devuelve "free" cuando no hay sesión activa', () => {
+    // Sin tenantId → default free
+    expect(tierService.getCurrentTier()).toBe('free');
+  });
+});

--- a/src/services/deepResearchClient.js
+++ b/src/services/deepResearchClient.js
@@ -8,8 +8,8 @@
  * Feature flag: `VITE_DEEP_RESEARCH_ENABLED` (default false).
  * En pre-prod se activa con VITE_DEEP_RESEARCH_ENABLED=true.
  * En prod-free queda off por defecto — Deep Research es pro-only y pesado.
- * Cuando exista el sistema de tier/allowlist se agregará un check de tier
- * aquí (TODO: gating por tier cuando exista).
+ * El gating de tier (free|pro) se aplica en la UI (ChipsToolbar) y en el
+ * header `x-chagra-tier` enviado al sidecar (ver tierService.js A1).
  *
  * Reglas operativas (idénticas al sidecarClient existente):
  *   - Offline-first: si !navigator.onLine → null inmediato.
@@ -25,7 +25,13 @@
  *   donde hay pasos nuevos o el status cambió.
  *
  * Español colombiano (tú/usted), nunca voseo argentino.
+ *
+ * Tier gating (A1): x-chagra-tier se inyecta en todos los requests vía
+ * `buildSidecarHeaders` (tierService). La allowlist Pro vive en tierService.js.
+ * El gating duro es server-side; este header es defense-in-depth cliente.
  */
+
+import { buildSidecarHeaders } from './tierService.js';
 
 const SUBMIT_TIMEOUT_MS = 15000;
 const POLL_TIMEOUT_MS = 10000;
@@ -75,10 +81,9 @@ function getToken() {
 }
 
 function makeHeaders() {
-  const headers = { 'Content-Type': 'application/json' };
-  const token = getToken();
-  if (token) headers['X-Chagra-Token'] = token;
-  return headers;
+  // buildSidecarHeaders agrega Content-Type + X-Chagra-Token + x-chagra-tier.
+  // El tier se resuelve del tenantId activo (defense-in-depth; gating duro es server-side).
+  return buildSidecarHeaders(getToken());
 }
 
 /**
@@ -166,9 +171,9 @@ export async function fetchDeepResearchStatus(jobId, signal) {
     signal.addEventListener('abort', externalAbortListener, { once: true });
   }
 
-  const headers = {};
-  const token = getToken();
-  if (token) headers['X-Chagra-Token'] = token;
+  // Incluir x-chagra-tier en el poll también — el sidecar puede aplicar
+  // rate limits o degradar features Pro según el header.
+  const headers = buildSidecarHeaders(getToken());
 
   try {
     const res = await fetch(url, { method: 'GET', headers, signal: controller.signal });

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -34,6 +34,8 @@
  * telemetría aún — esto se sumará a una task futura si hace falta).
  */
 
+import { buildSidecarHeaders } from './tierService.js';
+
 const NLU_TIMEOUT_MS = 10000;
 const TOOL_TIMEOUT_MS = 5000;
 
@@ -105,8 +107,10 @@ async function getJson(path, query, timeoutMs) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  const headers = {};
-  if (token) headers['X-Chagra-Token'] = token;
+  // Incluir x-chagra-tier para que el sidecar aplique gating de features Pro.
+  // buildSidecarHeaders resuelve el tier del usuario logueado (defense-in-depth;
+  // el gating duro es server-side).
+  const headers = buildSidecarHeaders(token);
 
   const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
   try {
@@ -150,8 +154,8 @@ async function postJson(path, body, timeoutMs) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  const headers = { 'Content-Type': 'application/json' };
-  if (token) headers['X-Chagra-Token'] = token;
+  // Incluir x-chagra-tier para gating Pro en el sidecar (defense-in-depth).
+  const headers = buildSidecarHeaders(token);
 
   const t0 = (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
   try {

--- a/src/services/tierService.js
+++ b/src/services/tierService.js
@@ -1,0 +1,117 @@
+/**
+ * tierService.js — Resolución de tier free|pro por allowlist de usernames.
+ *
+ * PROPÓSITO:
+ *   Defense-in-depth cliente-side. El gating DURO es server-side (el sidecar
+ *   degrada a free si el header falta o no coincide con la lógica del backend).
+ *   Esta allowlist controla qué usuarios ven features Pro en la UI (chip
+ *   🔬 Deep Research) y cuál header `x-chagra-tier` se envía al sidecar.
+ *
+ * CÓMO AGREGAR UN USUARIO PRO:
+ *   1. Agregar su username farmOS (exacto, lowercase) a PRO_USERNAMES abajo.
+ *   2. Hacer commit y deploy. No hay otros pasos en el bundle.
+ *
+ * NOTA DE SEGURIDAD:
+ *   La allowlist vive en el bundle (client-side). Cualquier usuario técnico
+ *   puede inspeccionarla. El sidecar aplica su propia validación server-side;
+ *   este tier solo afecta la UX (qué chips se muestran, qué header se envía).
+ *   NO confiar en este tier para decisiones de autorización en el backend.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * CUENTA ANA PENDIENTE (UNGRD Pasto/Galeras)
+ *   Reemplazar el string ANA_USERNAME_PENDIENTE con su username real de farmOS
+ *   cuando el operador lo provea. Ver constante ANA_USERNAME_PENDIENTE abajo.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @module tierService
+ */
+
+import { getActiveTenantId } from './tenantContext.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ALLOWLIST — editar SOLO este Set para activar/desactivar Pro a un usuario.
+// Los usernames están en minúsculas; resolveTier hace toLowerCase() para match.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Placeholder para la cuenta de Ana (UNGRD Pasto/Galeras).
+ * El operador debe reemplazar este string con el username real de farmOS de Ana.
+ * Una vez reemplazado, agregar el username a PRO_USERNAMES y hacer commit.
+ *
+ * ACCIÓN REQUERIDA: reemplazar 'ANA_USERNAME_PENDIENTE' con el username real.
+ *
+ * @constant {string}
+ */
+export const ANA_USERNAME_PENDIENTE = 'ANA_USERNAME_PENDIENTE';
+
+/**
+ * Set de usernames farmOS con acceso Pro.
+ *
+ * Para agregar un usuario Pro: añadir su username (lowercase) a este Set.
+ * Para revocar: eliminar la línea.
+ *
+ * @constant {Set<string>}
+ */
+export const PRO_USERNAMES = new Set([
+  'admin',               // Operador principal (Miguel / Guatoc)
+  // Ana (UNGRD Pasto/Galeras) — reemplazar 'ANA_USERNAME_PENDIENTE' con su username real
+  // cuando el operador lo provea. Ejemplo: 'ana.rodriguez'
+  // ANA_USERNAME_PENDIENTE,
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API pública
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resuelve el tier de un usuario por su username farmOS.
+ *
+ * Matching case-insensitive: farmOS usernames son lowercase por convención,
+ * pero el match es robusto ante capitalización accidental.
+ *
+ * @param {string|null|undefined} username — username farmOS del usuario.
+ * @returns {'free'|'pro'} — 'pro' si está en la allowlist, 'free' en todos
+ *   los demás casos (null, undefined, vacío, fuera de allowlist).
+ */
+export function resolveTier(username) {
+  if (!username || typeof username !== 'string' || username.trim().length === 0) {
+    return 'free';
+  }
+  return PRO_USERNAMES.has(username.toLowerCase()) ? 'pro' : 'free';
+}
+
+/**
+ * Resuelve el tier del usuario actualmente logueado, leyendo el tenantId
+ * persistido por `tenantContext` (se setea en login).
+ *
+ * @returns {'free'|'pro'}
+ */
+export function getCurrentTier() {
+  const username = getActiveTenantId();
+  return resolveTier(username);
+}
+
+/**
+ * Construye los headers HTTP para llamadas al sidecar, inyectando
+ * `x-chagra-tier` con el tier del usuario activo y `X-Chagra-Token`
+ * si se pasa un token no vacío.
+ *
+ * Uso típico en sidecarClient y deepResearchClient:
+ *   const headers = buildSidecarHeaders(getToken());
+ *
+ * @param {string} [token] — VITE_CHAGRA_MCP_TOKEN (puede ser vacío si no está configurado).
+ * @returns {Object.<string, string>} headers listos para inyectar en fetch.
+ */
+export function buildSidecarHeaders(token) {
+  const tier = getCurrentTier();
+  const headers = {
+    'Content-Type': 'application/json',
+    'x-chagra-tier': tier,
+  };
+  if (token && typeof token === 'string' && token.length > 0) {
+    headers['X-Chagra-Token'] = token;
+  }
+  return headers;
+}


### PR DESCRIPTION
## Resumen

- Crea `src/services/tierService.js`: allowlist `PRO_USERNAMES` (Set editable en una línea), `resolveTier(username)` case-insensitive, `getCurrentTier()` (lee tenantId activo), `buildSidecarHeaders(token)` (inyecta `x-chagra-tier` + token).
- `sidecarClient` y `deepResearchClient` usan `buildSidecarHeaders` en todos los requests — el sidecar recibe `x-chagra-tier: free|pro` en cada call (defense-in-depth; gating duro es server-side, igual que `x-chagra-token`).
- `ChipsToolbar` acepta prop `isPro`: chip 🔬 Deep Research deshabilitado con texto "(Pro)" para usuarios free, habilitado y sin sufijo para pro.
- `AgentScreen` pasa `isPro={getCurrentTier() === 'pro'}`.

## Cuenta de Ana (UNGRD Pasto/Galeras)

La allowlist tiene el placeholder listo. Cuando el operador provea el username real de farmOS de Ana:
1. Editar `src/services/tierService.js` línea `PRO_USERNAMES`, descomentar y reemplazar `ANA_USERNAME_PENDIENTE` con el username real.
2. Commit + deploy.

## Tests

- 14 tests nuevos `tierService.test.js` (red→green TDD).
- 9 tests nuevos en `ChipsToolbar.smoke.test.jsx` para el gate Pro/free.
- 191 archivos de test, 3146 tests green, 0 regresiones.
- ESLint `--max-warnings=0` limpio.

## Plan de prueba

- [ ] Login con usuario `admin` → chip 🔬 visible y activo, `x-chagra-tier: pro` en Network.
- [ ] Login con usuario free → chip 🔬 deshabilitado con "(Pro)", click no dispara intent.
- [ ] Sin login (pre-login) → tier default `free`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)