### PR TITLE
test(agent): test permanente de las preguntas-ejemplo (punto de acceso #1)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,17 +1,24 @@
 name: Unit Tests (vitest)
 
-# Gate de tests unitarios (vitest). Hasta ahora la suite vitest NO corría en
-# CI — solo Playwright E2E. Este job cierra ese hueco y, en particular, hace
-# que el test del PUNTO DE ACCESO #1 (preguntas-ejemplo / chips:
-# tests/unit/exampleQuestions.entrypoint.test.jsx) corra en CADA PR.
+# Gate de tests unitarios del PUNTO DE ACCESO #1 (preguntas-ejemplo / chips).
+# Hasta ahora la suite vitest NO corría en CI — solo Playwright E2E. Este job
+# cierra ese hueco para lo más sensible: que el test
+# tests/unit/exampleQuestions.entrypoint.test.jsx corra en CADA PR.
 #
 # Política del operador ("esto debe probarse cada vez que valga la pena"): el
-# job corre SIEMPRE en PRs a main y en push a main — es barato (~1 min, sin GPU,
-# sin red). Los `paths` de abajo NO restringen la ejecución (corre siempre);
-# están documentados como la SUPERFICIE del agente que, al cambiar, hace
-# imprescindible este gate: si tocás el AgentScreen, los guards de salida, el
-# filtro de voseo, el agentService o los componentes de chips, este test debe
-# pasar antes del merge.
+# job corre SIEMPRE en PRs a main y en push a main — es barato (segundos, sin
+# GPU, sin red). Los `paths` de abajo están documentados como la SUPERFICIE del
+# agente que, al cambiar, hace imprescindible este gate: si tocás el AgentScreen,
+# los guards de salida, el filtro de voseo, el agentService o los componentes de
+# chips, este test debe pasar antes del merge.
+#
+# ALCANCE (por qué no la suite completa todavía): el job arranca enfocado en el
+# test del entrypoint + sus dependencias deterministas (chips, outputGuards,
+# voseoFilter, catalog-count) porque 2 tests preexistentes de visión
+# (aiService.visionCache / visionCacheService) son CI-flaky por diferencias de
+# SubtleCrypto.digest entre runners — pasan local pero fallan en ubuntu-latest.
+# Ampliar este gate a `npm run test:unit` (suite completa) queda pendiente de
+# estabilizar esos 2 tests; ver el cuerpo del PR para el detalle.
 on:
   pull_request:
     branches: [main]
@@ -29,6 +36,7 @@ permissions:
 #   - src/components/QuickChipsBar.jsx
 #   - src/components/AgentScreen/SuggestedActions.jsx
 #   - src/components/dashboard/AgentHero.jsx
+#   - src/data/exampleQuestions.js
 #   - tests/unit/exampleQuestions.*
 
 jobs:
@@ -49,5 +57,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run unit tests
-        run: npm run test:unit
+      # Test del PUNTO DE ACCESO #1 + dependencias deterministas. Determinista
+      # en CI (sin crypto/IndexedDB/red). Falla RUIDOSAMENTE si un chip-ejemplo
+      # devuelve vacío/error tras el pipeline de salida.
+      - name: Run entrypoint unit tests
+        run: >-
+          npm run test:unit --
+          tests/unit/exampleQuestions.entrypoint.test.jsx
+          tests/unit/outputGuards.test.js
+          tests/unit/catalog-count.test.js
+          src/components/__tests__/QuickChipsBar.smoke.test.jsx
+          src/components/__tests__/ChipsToolbar.smoke.test.jsx

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,53 @@
+name: Unit Tests (vitest)
+
+# Gate de tests unitarios (vitest). Hasta ahora la suite vitest NO corría en
+# CI — solo Playwright E2E. Este job cierra ese hueco y, en particular, hace
+# que el test del PUNTO DE ACCESO #1 (preguntas-ejemplo / chips:
+# tests/unit/exampleQuestions.entrypoint.test.jsx) corra en CADA PR.
+#
+# Política del operador ("esto debe probarse cada vez que valga la pena"): el
+# job corre SIEMPRE en PRs a main y en push a main — es barato (~1 min, sin GPU,
+# sin red). Los `paths` de abajo NO restringen la ejecución (corre siempre);
+# están documentados como la SUPERFICIE del agente que, al cambiar, hace
+# imprescindible este gate: si tocás el AgentScreen, los guards de salida, el
+# filtro de voseo, el agentService o los componentes de chips, este test debe
+# pasar antes del merge.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Superficie del agente cubierta por este gate (referencia, no filtro):
+#   - src/components/AgentScreen/**
+#   - src/services/outputGuards.js
+#   - src/services/voseoFilter.js
+#   - src/services/agentService.js
+#   - src/components/QuickChipsBar.jsx
+#   - src/components/AgentScreen/SuggestedActions.jsx
+#   - src/components/dashboard/AgentHero.jsx
+#   - tests/unit/exampleQuestions.*
+
+jobs:
+  unit:
+    name: vitest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/src/components/AgentScreen/SuggestedActions.jsx
+++ b/src/components/AgentScreen/SuggestedActions.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
-
-const SUGGESTIONS = [
-  { text: 'Cuándo planto tomates?', icon: '🌱' },
-  { text: 'Mi planta tiene manchas amarillas', icon: '🔍' },
-  { text: 'Registra que regué las lechugas', icon: '💧' },
-  { text: 'Consejos para el invernadero', icon: '🏠' },
-];
+// Fuente única de las preguntas-ejemplo de sugerencia. Importada del módulo
+// de datos compartido para que el test del punto de acceso #1 las cubra sin
+// exportar constantes desde un componente (react-refresh/only-export-components).
+import { SUGGESTED_ACTIONS_CHIPS as SUGGESTIONS } from '../../data/exampleQuestions';
 
 export default function SuggestedActions({ onSelect }) {
   return (

--- a/src/components/QuickChipsBar.jsx
+++ b/src/components/QuickChipsBar.jsx
@@ -1,4 +1,8 @@
 import React from 'react';
+// Fuente única de las preguntas-ejemplo (chips). Vive en un módulo de datos
+// compartido para que el test del PUNTO DE ACCESO #1 las cubra sin que el
+// componente exporte constantes (regla react-refresh/only-export-components).
+import { QUICK_CHIPS_BAR_QUESTIONS as DEFAULT_QUICK_QUESTIONS } from '../data/exampleQuestions';
 
 /**
  * QuickChipsBar — tres chips clickables con preguntas frecuentes para que el
@@ -18,12 +22,6 @@ import React from 'react';
  *   - onSelect: callback(query: string) — el call-site decide qué hacer.
  *               Típicamente AgentScreen llama directo a handleSubmit(query).
  */
-
-const DEFAULT_QUICK_QUESTIONS = [
-  '¿Qué siembro este mes?',
-  'Tengo plaga en mis plantas',
-  'Receta de biopreparado para tomate',
-];
 
 export default function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUESTIONS }) {
   if (typeof onSelect !== 'function') return null;

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -6,6 +6,7 @@ import { captureAndCompress } from '../../services/photoService';
 import { isAnalyzableImageAttachment } from '../../services/agentOutboxAttachment';
 import useAgentOutboxStore from '../../store/useAgentOutboxStore';
 import { agentSounds } from '../../services/agentSoundService';
+import { AGENT_HERO_CHIPS } from '../../data/exampleQuestions';
 
 // 2026-05-28: el R3F (ChagraAgentAvatarColibri3D) fue retirado del flujo.
 // Operador: "no me gusta nada y desatina con todo lo que ya está".
@@ -47,11 +48,10 @@ const TIPS = [
     'Pregúntame en voz, te entiendo con tu acento.',
 ];
 
-const QUICK_CHIPS = [
-    { icon: '🌱', label: '¿Qué siembro?', prompt: '¿Qué puedo sembrar este mes en mi zona?' },
-    { icon: '🐛', label: 'Plagas', prompt: '¿Cómo controlo plagas sin químicos?' },
-    { icon: '🌧️', label: 'Clima', prompt: 'Dame el reporte del clima de mi zona.' },
-];
+// Fuente única de los chips del home. Importada del módulo de datos compartido
+// para que el test del punto de acceso #1 los cubra sin exportar constantes
+// desde un componente (regla react-refresh/only-export-components).
+const QUICK_CHIPS = AGENT_HERO_CHIPS;
 
 function prefersReducedMotion() {
     return typeof window !== 'undefined' && window.matchMedia

--- a/src/data/exampleQuestions.js
+++ b/src/data/exampleQuestions.js
@@ -1,0 +1,73 @@
+/**
+ * exampleQuestions.js — FUENTE ÚNICA de las PREGUNTAS-EJEMPLO del agente
+ * (chips/sugerencias que el usuario campesino solo clickea).
+ *
+ * Son el PUNTO DE ACCESO #1: si un chip de ejemplo produce respuesta vacía,
+ * error o alucinación, perdemos al usuario en el primer toque. Por eso las
+ * preguntas viven en UN solo lugar (este módulo de datos, no React) que:
+ *   - consumen los componentes de UI (QuickChipsBar, SuggestedActions, AgentHero), y
+ *   - cubre el test permanente del punto de acceso #1
+ *     (tests/unit/exampleQuestions.entrypoint.test.jsx).
+ *
+ * Tenerlas acá (y no inline en cada componente) garantiza que NO puedan
+ * divergir entre la UI y el test: el test importa exactamente estos arrays.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino (memoria
+ * feedback-spanish-dialect) — el test valida cada string contra el filtro de
+ * voseo.
+ */
+
+/**
+ * QuickChipsBar — atajo de pantalla-nueva del agente (UX-5 / issue #286).
+ * Aparece SOLO con el chat vacío, JUSTO sobre el input. Pasa por el NLU normal
+ * vía AgentScreen.handleSuggestion → handleSubmit.
+ */
+export const QUICK_CHIPS_BAR_QUESTIONS = Object.freeze([
+  '¿Qué siembro este mes?',
+  'Tengo plaga en mis plantas',
+  'Receta de biopreparado para tomate',
+]);
+
+/**
+ * SuggestedActions — chips de re-engagement con icono. Cada item es
+ * { text, icon }; `text` es lo que se envía como pregunta.
+ */
+export const SUGGESTED_ACTIONS_CHIPS = Object.freeze([
+  { text: 'Cuándo planto tomates?', icon: '🌱' },
+  { text: 'Mi planta tiene manchas amarillas', icon: '🔍' },
+  { text: 'Registra que regué las lechugas', icon: '💧' },
+  { text: 'Consejos para el invernadero', icon: '🏠' },
+]);
+
+/**
+ * AgentHero (home) — el compositor del dashboard, el PRIMER lugar donde el
+ * usuario ve preguntas-ejemplo, antes incluso de entrar al AgentScreen. Cada
+ * item es { icon, label, prompt }; `prompt` es la pregunta que se envía.
+ */
+export const AGENT_HERO_CHIPS = Object.freeze([
+  { icon: '🌱', label: '¿Qué siembro?', prompt: '¿Qué puedo sembrar este mes en mi zona?' },
+  { icon: '🐛', label: 'Plagas', prompt: '¿Cómo controlo plagas sin químicos?' },
+  { icon: '🌧️', label: 'Clima', prompt: 'Dame el reporte del clima de mi zona.' },
+]);
+
+/** Textos planos de SuggestedActions (lo que se envía al agente). */
+export const SUGGESTED_ACTIONS_QUESTIONS = Object.freeze(
+  SUGGESTED_ACTIONS_CHIPS.map((c) => c.text),
+);
+
+/** Prompts planos del home AgentHero (lo que se envía al agente). */
+export const AGENT_HERO_QUESTIONS = Object.freeze(AGENT_HERO_CHIPS.map((c) => c.prompt));
+
+/**
+ * Lista plana, deduplicada, de TODAS las preguntas-ejemplo clickables. Es la
+ * que recorre el test del entrypoint (una aserción de pipeline por pregunta).
+ */
+export const ALL_EXAMPLE_QUESTIONS = Object.freeze(
+  Array.from(
+    new Set([
+      ...QUICK_CHIPS_BAR_QUESTIONS,
+      ...SUGGESTED_ACTIONS_QUESTIONS,
+      ...AGENT_HERO_QUESTIONS,
+    ]),
+  ),
+);

--- a/tests/e2e-real/example-questions-real.smoke.mjs
+++ b/tests/e2e-real/example-questions-real.smoke.mjs
@@ -1,0 +1,132 @@
+/**
+ * example-questions-real.smoke.mjs — SMOKE @real del PUNTO DE ACCESO #1.
+ *
+ * Corre 1-2 PREGUNTAS-EJEMPLO (chips) contra el agente Chagra REAL (GPU,
+ * sidecar NLU, Ollama). Es GPU-pesado y depende de prod → se corre A MANO, NO
+ * en cada CI. Por eso vive fuera de la suite vitest/playwright automática:
+ *   - NO es `*.test.jsx` (vitest lo ignora),
+ *   - NO es `*.spec.js` (playwright lo ignora),
+ *   - es un script .mjs autónomo que se invoca explícitamente.
+ *
+ * Uso (en alpha, NixOS):
+ *   node tests/e2e-real/example-questions-real.smoke.mjs
+ *
+ * Requisitos:
+ *   - chromium del nix-store (memoria reference-playwright-nixos-setup): el
+ *     bundled de Playwright falla en NixOS por libnspr4/libglib.
+ *   - El agente real respondiendo (cold start puede tardar hasta ~60s incluso
+ *     con pre-warm; NO bajar los timeouts de espera de respuesta <5s).
+ *
+ * Qué verifica por cada chip clickeado:
+ *   - el click pinta una respuesta del agente (burbuja assistant no vacía),
+ *   - la respuesta NO es la burbuja de error/fallback,
+ *   - 0 errores de página / 0 warnings SVG NaN en consola.
+ *
+ * Salida: tabla por chip (#, chip, lat 1er token aprox, lat total, verdict,
+ * snippet) + errores de consola observados.
+ */
+import { chromium } from 'playwright';
+
+// Resolución del chromium del nix-store. Si el hash cambió tras un switch,
+// pasá PLAYWRIGHT_CHROMIUM_PATH o ajustá esta constante.
+const CHROMIUM =
+  process.env.PLAYWRIGHT_CHROMIUM_PATH ||
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium';
+
+const URL = process.env.CHAGRA_URL || 'https://chagra.guatoc.co/';
+const ANSWER_TIMEOUT_MS = Number(process.env.CHAGRA_ANSWER_TIMEOUT_MS || 90000);
+
+// Subconjunto de chips para el smoke (1-2 basta — esto es GPU-pesado). Deben
+// existir como chips visibles del home/agente. La lista canónica está en
+// src/data/exampleQuestions.js (la consume la UI y el test unitario).
+//
+// IMPORTANTE: los chips del home (AgentHero) solo aparecen tras login +
+// onboarding. Este smoke asume una SESIÓN AUTENTICADA — corre con un
+// storageState ya logueado (CHAGRA_STORAGE_STATE) o tras un login manual. Sin
+// sesión, los chips no se renderizan y el smoke reporta "no encontrado" en vez
+// de un falso BIEN. Credenciales válidas en /run/secrets/oracle-lab-env (no se
+// hardcodean acá — repo público).
+const SMOKE_CHIPS = ['¿Qué siembro?', '¿Cómo controlo plagas sin químicos?'];
+
+const ERROR_BUBBLE_RE = /(No recibí respuesta del asistente|No pude conectarme al asistente)/i;
+
+async function main() {
+  const browser = await chromium.launch({ executablePath: CHROMIUM, headless: true });
+  // Reusa una sesión autenticada si se pasa CHAGRA_STORAGE_STATE (json de
+  // storageState exportado tras login). Sin él, arranca sesión limpia (los
+  // chips del home no aparecerán hasta loguear).
+  const ctx = await browser.newContext(
+    process.env.CHAGRA_STORAGE_STATE ? { storageState: process.env.CHAGRA_STORAGE_STATE } : {},
+  );
+  const page = await ctx.newPage();
+
+  const consoleMessages = [];
+  const pageErrors = [];
+  page.on('console', (m) => consoleMessages.push({ type: m.type(), text: m.text() }));
+  page.on('pageerror', (e) => pageErrors.push({ message: e.message }));
+
+  await page.goto(URL, { waitUntil: 'networkidle', timeout: 30000 }).catch((e) => {
+    console.log('goto err:', e.message);
+  });
+  await page.waitForTimeout(4000);
+
+  const results = [];
+  for (const chip of SMOKE_CHIPS) {
+    const verdict = { chip, verdict: 'MAL', latTotalMs: null, snippet: '', note: '' };
+    try {
+      const chipLocator = page.getByText(chip, { exact: true }).first();
+      await chipLocator.waitFor({ state: 'visible', timeout: 15000 });
+      const t0 = Date.now();
+      await chipLocator.click();
+
+      // Espera a que aparezca una burbuja de respuesta del asistente con texto.
+      // El selector exacto depende del DOM de ChatBubble; usamos el texto de la
+      // burbuja assistant. Ajustá el selector si el markup cambia.
+      await page.waitForFunction(
+        () => {
+          const bubbles = Array.from(document.querySelectorAll('[class*="whitespace-pre-wrap"]'));
+          // La última burbuja con texto sustancial que NO sea el del chip.
+          return bubbles.some((b) => (b.textContent || '').trim().length > 30);
+        },
+        { timeout: ANSWER_TIMEOUT_MS },
+      );
+      verdict.latTotalMs = Date.now() - t0;
+
+      const bodyText = await page.locator('body').innerText();
+      verdict.snippet = bodyText.slice(0, 200).replace(/\s+/g, ' ');
+
+      if (ERROR_BUBBLE_RE.test(bodyText)) {
+        verdict.verdict = 'MAL';
+        verdict.note = 'burbuja de error/fallback visible';
+      } else {
+        verdict.verdict = 'BIEN';
+      }
+    } catch (e) {
+      verdict.note = `timeout/err esperando respuesta: ${e.message}`;
+    }
+    results.push(verdict);
+    await page.screenshot({ path: `/tmp/example-chip-${results.length}.png` }).catch(() => {});
+  }
+
+  const svgNaNWarnings = consoleMessages.filter((m) => /NaN/.test(m.text) && /path|svg|d=/.test(m.text));
+
+  console.log('\n=== SMOKE @real preguntas-ejemplo ===');
+  for (const [i, r] of results.entries()) {
+    console.log(
+      `#${i + 1} | "${r.chip}" | lat ${r.latTotalMs ?? '—'}ms | ${r.verdict}${r.note ? ' (' + r.note + ')' : ''}\n     ${r.snippet}`,
+    );
+  }
+  console.log('\npageErrors:', pageErrors.length, JSON.stringify(pageErrors.slice(0, 3)));
+  console.log('SVG NaN warnings:', svgNaNWarnings.length);
+  console.log('screenshots: /tmp/example-chip-*.png');
+
+  await browser.close();
+
+  const anyBad = results.some((r) => r.verdict !== 'BIEN');
+  process.exit(anyBad || pageErrors.length > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('smoke fatal:', e);
+  process.exit(1);
+});

--- a/tests/unit/catalog-count.test.js
+++ b/tests/unit/catalog-count.test.js
@@ -17,15 +17,22 @@ describe('Catalog Count - Task #189', () => {
     
     expect(catalog.species).toBeDefined();
     expect(catalog.species.length).toBeGreaterThanOrEqual(200);
-    expect(catalog.species.length).toBe(204); // Count exacto después de task #189
+    // El subset v3.2 quedó con 205 species (el archivo y schema_version ya son
+    // v3.2). El test seguía clavado en el conteo de v3.1 (204) y fallaba en main
+    // — actualizado al dato real para no nacer rojo el gate de vitest.
+    expect(catalog.species.length).toBe(205);
   });
-  
+
   it('should have proper schema version', () => {
     const catalogPath = path.join(__dirname, '../../catalog/chagra-catalog-oss-subset-v3.2.json');
     const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf-8'));
-    
-    expect(catalog.schema_version).toBe('3.1');
+
+    expect(catalog.schema_version).toBe('3.2');
     expect(catalog._subset_meta).toBeDefined();
+    // NOTA: _subset_meta.species_count quedó en 204 mientras species.length es
+    // 205 (off-by-one en la metadata del subset, NO en este test). Se asserta el
+    // valor real para no enmascarar la inconsistencia; corregir la metadata es
+    // tarea aparte del owner del catálogo.
     expect(catalog._subset_meta.species_count).toBe(204);
   });
   

--- a/tests/unit/exampleQuestions.entrypoint.test.jsx
+++ b/tests/unit/exampleQuestions.entrypoint.test.jsx
@@ -1,0 +1,355 @@
+/**
+ * exampleQuestions.entrypoint.test.jsx — TEST PERMANENTE del PUNTO DE ACCESO #1.
+ *
+ * Las PREGUNTAS-EJEMPLO (chips/sugerencias que el usuario solo clickea) son la
+ * primera interacción del campesino con el agente. Si un chip de ejemplo
+ * produce respuesta vacía, burbuja de error o alucinación, perdemos al usuario
+ * en el primer toque. Política del operador: "esto debe probarse cada vez que
+ * valga la pena" → este test corre en CADA PR (job vitest, sin GPU).
+ *
+ * ── DOS CAPAS ─────────────────────────────────────────────────────────────
+ *  (a) FUENTE ÚNICA ⇄ UI : los chips se definen en src/data/exampleQuestions.js
+ *      (consumido por QuickChipsBar, SuggestedActions y AgentHero) y este test
+ *      importa el MISMO módulo. La lista no puede divergir entre UI y test. El
+ *      test verifica además que el componente PINTA cada pregunta canónica.
+ *
+ *  (b) WIRING DEL CLICK : QuickChipsBar y SuggestedActions disparan onSelect con
+ *      el texto EXACTO del chip (lo que AgentScreen pasa a handleSubmit).
+ *
+ *  (c) PIPELINE DE SALIDA : para CADA pregunta-ejemplo corremos una respuesta
+ *      representativa del modelo por la MISMA cadena de post-proceso que
+ *      AgentScreen aplica en producción (AgentScreen.jsx ~L1565-1625):
+ *          stripRoleLeak → applyVoseoFilter → applyOutputGuards
+ *      y asertamos que la respuesta renderizada:
+ *        · NO está vacía,
+ *        · NO es la burbuja de error/fallback ("No recibí respuesta…",
+ *          "No pude conectarme…"),
+ *        · NO contiene patrones prohibidos (voseo argentino, "Corrección
+ *          importante" duplicada, fuga de rol "Usuario:"/"Asistente:").
+ *      El sidecar/LLM va MOCKEADO (texto fijo) — cero GPU, cero red.
+ *
+ * El smoke contra el agente REAL (chromium del nix-store) vive aparte y
+ * marcado @real (tests/e2e-real/example-questions-real.smoke.mjs): se corre a
+ * mano, NO en cada CI, porque es GPU-pesado.
+ *
+ * Convenciones: Vitest + @testing-library/react, patrón tests/unit/setup.js.
+ */
+import { describe, it, test, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import QuickChipsBar from '../../src/components/QuickChipsBar.jsx';
+import SuggestedActions from '../../src/components/AgentScreen/SuggestedActions.jsx';
+
+import { applyVoseoFilter, stripRoleLeak } from '../../src/services/agentService.js';
+import { applyOutputGuards } from '../../src/services/outputGuards.js';
+import { filterVoseo } from '../../src/services/voseoFilter.js';
+
+// FUENTE ÚNICA: tanto los componentes de UI como este test importan estos
+// arrays del mismo módulo de datos, así que la lista de chips NO puede divergir
+// entre la pantalla y el test (no hay "registro paralelo" que mantener).
+import {
+  ALL_EXAMPLE_QUESTIONS,
+  QUICK_CHIPS_BAR_QUESTIONS,
+  SUGGESTED_ACTIONS_QUESTIONS,
+  AGENT_HERO_QUESTIONS,
+} from '../../src/data/exampleQuestions.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * runProductionTail — replica EXACTA de la cadena de post-proceso que
+ * AgentScreen.jsx corre sobre la respuesta cruda del LLM antes de pintarla
+ * (stripRoleLeak → applyVoseoFilter(usted) → applyOutputGuards). Sin grounding
+ * (resolvedEntities=null) corre tal cual el peor caso "RAG-only / sidecar caído",
+ * que es justamente cuando un chip degrada. Devuelve el texto final renderizado.
+ */
+function runProductionTail(rawResponse, opts = {}) {
+  const deLeaked = stripRoleLeak(rawResponse);
+  const voseoSafe = applyVoseoFilter(deLeaked, { formality: 'usted', region: null });
+  const guarded = applyOutputGuards(voseoSafe, {
+    resolvedEntities: opts.resolvedEntities ?? null,
+    fincaAltitud: opts.fincaAltitud ?? null,
+    hadVision: false,
+    visionConfidence: null,
+    profileName: opts.profileName ?? null,
+    forecastTempMin: null,
+    forecastTempMax: null,
+    userMessage: opts.userMessage ?? null,
+  });
+  return guarded.text;
+}
+
+/** Burbuja de error / fallback que el usuario NUNCA debe ver como "respuesta". */
+const ERROR_BUBBLE_PATTERNS = [
+  /No recibí respuesta del asistente/i, // ChatBubble fallback vacío (#339)
+  /No pude conectarme al asistente/i, // setError() de handleSubmit
+  /Error al transcribir/i,
+  /^\s*undefined\s*$/i,
+  /^\s*null\s*$/i,
+];
+
+/** Marcadores de fuga de rol que stripRoleLeak debe haber cortado. */
+const ROLE_LEAK_PATTERNS = [
+  /^\s*Usuario:\s/m,
+  /^\s*Asistente:\s/m,
+  /<\|im_start\|>/,
+  /<\|user\|>/,
+];
+
+/**
+ * assertHealthyAnswer — el corazón del test: una respuesta de chip es SANA si
+ * no está vacía, no es burbuja de error y no tiene patrones prohibidos. Falla
+ * RUIDOSAMENTE (mensaje con la pregunta y el snippet) si algo de eso ocurre.
+ */
+function assertHealthyAnswer(question, finalText) {
+  const snippet = (finalText || '').slice(0, 200);
+
+  // 1) NO vacía.
+  expect(
+    typeof finalText === 'string' && finalText.trim().length > 0,
+    `CHIP "${question}" → respuesta VACÍA tras el pipeline (regresión crítica del punto de acceso #1). snippet="${snippet}"`,
+  ).toBe(true);
+
+  // 2) NO burbuja de error / fallback.
+  for (const re of ERROR_BUBBLE_PATTERNS) {
+    expect(
+      re.test(finalText),
+      `CHIP "${question}" → renderizó burbuja de ERROR/fallback (${re}). snippet="${snippet}"`,
+    ).toBe(false);
+  }
+
+  // 3) NO fuga de rol.
+  for (const re of ROLE_LEAK_PATTERNS) {
+    expect(
+      re.test(finalText),
+      `CHIP "${question}" → fuga de rol no truncada (${re}). snippet="${snippet}"`,
+    ).toBe(false);
+  }
+
+  // 4) NO voseo argentino residual (re-aplica el filtro: si cambia algo, había voseo).
+  const reFiltered = filterVoseo(finalText, { formality: 'usted', region: null });
+  expect(
+    reFiltered,
+    `CHIP "${question}" → quedó voseo argentino tras el filtro. snippet="${snippet}"`,
+  ).toBe(finalText);
+
+  // 5) "Corrección importante" no debe aparecer DUPLICADA (cascada de guards).
+  const correcciones = (finalText.match(/Corrección importante/gi) || []).length;
+  expect(
+    correcciones <= 1,
+    `CHIP "${question}" → "Corrección importante" duplicada x${correcciones} (cascada de guards). snippet="${snippet}"`,
+  ).toBe(true);
+}
+
+// ── Respuestas representativas del modelo por pregunta-ejemplo ───────────────
+// Texto fijo curado (NO inferencia real): simula lo que el agente devolvería
+// para cada chip. Redactado en español colombiano (tú/usted), grounded y sano.
+// El propósito NO es validar el contenido del modelo, sino que la cadena de
+// post-proceso del AgentScreen no convierta una respuesta sana en vacía/error.
+const MODEL_ANSWERS = Object.freeze({
+  '¿Qué siembro este mes?':
+    'En tu zona, este mes va bien sembrar frijol, maíz y hortalizas de hoja como acelga y lechuga. ' +
+    'Si me dices tu municipio y altitud te afino la lista.',
+  'Tengo plaga en mis plantas':
+    'Para ayudarte necesito un par de datos: ¿qué planta es y qué daño ves (hojas comidas, manchas, ' +
+    'insectos visibles)? Con eso te recomiendo un control agroecológico concreto.',
+  'Receta de biopreparado para tomate':
+    'Un biopreparado útil para tomate es el caldo de ceniza: 1 kg de ceniza cernida en 10 L de agua, ' +
+    'reposar 24 horas, colar y aplicar foliar cada 8 días. Ayuda contra hongos y aporta potasio.',
+  'Cuándo planto tomates?':
+    'El tomate se siembra en almácigo y se trasplanta a los 25-30 días. En clima medio se puede sembrar ' +
+    'casi todo el año evitando los picos de lluvia. ¿En qué municipio estás?',
+  'Mi planta tiene manchas amarillas':
+    'Las manchas amarillas pueden venir de varias cosas: falta de nutrientes, exceso o falta de riego, o ' +
+    'un hongo. ¿Qué planta es y me puedes enviar una foto de la hoja? ¿La mancha está por encima o por debajo?',
+  'Registra que regué las lechugas':
+    'Listo, registro un riego para tus lechugas con la fecha de hoy. ¿Quieres anotar cuánta agua aplicaste ' +
+    'o alguna observación?',
+  'Consejos para el invernadero':
+    'Para el invernadero cuida tres cosas: ventilación diaria para bajar humedad, riego por la mañana, y ' +
+    'monitoreo de plagas en el envés de las hojas. ¿Qué cultivo tienes adentro?',
+  '¿Qué puedo sembrar este mes en mi zona?':
+    'Depende de tu altitud y clima. En tierra fría van bien papa, arveja y cebolla; en tierra media, frijol, ' +
+    'maíz y tomate. Dime tu municipio y te concreto.',
+  '¿Cómo controlo plagas sin químicos?':
+    'Hay varias opciones agroecológicas: trampas cromáticas, extractos de ají y ajo, caldo de ceniza, y ' +
+    'plantas repelentes como la caléndula. ¿Qué plaga y qué cultivo tienes?',
+  'Dame el reporte del clima de mi zona.':
+    'Para darte el clima de tu zona necesito tu municipio. Con eso consulto el pronóstico del IDEAM y te ' +
+    'digo lluvia y temperatura de los próximos días.',
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CAPA (a): los chips REALES (renderizados) muestran la pregunta canónica.
+// Las constantes vienen de la fuente única src/data/exampleQuestions.js, que
+// los propios componentes consumen — así que esto verifica que el componente
+// efectivamente PINTA cada pregunta (no que solo importe el array).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Preguntas-ejemplo — los chips renderizan la pregunta canónica', () => {
+  test('QuickChipsBar pinta las 3 preguntas rápidas', () => {
+    render(<QuickChipsBar onSelect={() => {}} />);
+    for (const q of QUICK_CHIPS_BAR_QUESTIONS) {
+      expect(screen.getByText(q)).toBeInTheDocument();
+    }
+  });
+
+  test('SuggestedActions pinta las 4 sugerencias', () => {
+    render(<SuggestedActions onSelect={() => {}} />);
+    for (const q of SUGGESTED_ACTIONS_QUESTIONS) {
+      expect(screen.getByText(q)).toBeInTheDocument();
+    }
+  });
+
+  test('toda pregunta-ejemplo tiene una respuesta-modelo curada en el fixture', () => {
+    const sinCobertura = ALL_EXAMPLE_QUESTIONS.filter((q) => !(q in MODEL_ANSWERS));
+    expect(
+      sinCobertura,
+      `Estos chips no tienen respuesta-modelo curada (agregala a MODEL_ANSWERS): ${JSON.stringify(sinCobertura)}`,
+    ).toEqual([]);
+  });
+
+  test('ninguna pregunta-ejemplo tiene voseo argentino', () => {
+    for (const q of ALL_EXAMPLE_QUESTIONS) {
+      const filtrada = filterVoseo(q, { formality: 'usted', region: null });
+      expect(filtrada, `La pregunta-ejemplo "${q}" contiene voseo argentino`).toBe(q);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CAPA (b): el click del chip dispara el turno con el texto EXACTO.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Preguntas-ejemplo — el click del chip dispara el turno (wiring)', () => {
+  test('QuickChipsBar: cada chip llama onSelect con su texto exacto', () => {
+    const onSelect = vi.fn();
+    render(<QuickChipsBar onSelect={onSelect} />);
+    for (const q of QUICK_CHIPS_BAR_QUESTIONS) {
+      fireEvent.click(screen.getByText(q));
+    }
+    expect(onSelect).toHaveBeenCalledTimes(QUICK_CHIPS_BAR_QUESTIONS.length);
+    for (const q of QUICK_CHIPS_BAR_QUESTIONS) {
+      expect(onSelect).toHaveBeenCalledWith(q);
+    }
+  });
+
+  test('SuggestedActions: cada chip llama onSelect con su texto exacto', () => {
+    const onSelect = vi.fn();
+    render(<SuggestedActions onSelect={onSelect} />);
+    for (const q of SUGGESTED_ACTIONS_QUESTIONS) {
+      fireEvent.click(screen.getByText(q));
+    }
+    expect(onSelect).toHaveBeenCalledTimes(SUGGESTED_ACTIONS_QUESTIONS.length);
+    for (const q of SUGGESTED_ACTIONS_QUESTIONS) {
+      expect(onSelect).toHaveBeenCalledWith(q);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CAPA (c): la respuesta de CADA pregunta-ejemplo sobrevive sana al pipeline.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Preguntas-ejemplo — la respuesta sobrevive sana al pipeline de salida', () => {
+  it.each(ALL_EXAMPLE_QUESTIONS)('chip "%s" → respuesta no vacía / no error / sin patrones prohibidos', (question) => {
+    const raw = MODEL_ANSWERS[question];
+    expect(typeof raw === 'string' && raw.length > 0, `falta MODEL_ANSWERS["${question}"]`).toBe(true);
+    const finalText = runProductionTail(raw, { userMessage: question });
+    assertHealthyAnswer(question, finalText);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CAPA (c-bis): respuestas MALAS del modelo para los chips. Aquí simulamos lo
+// que un modelo real DEVUELVE mal en producción (los bugs recurrentes del
+// stack) y verificamos que la cadena de guards las SANEA — y, sobre todo, que
+// NUNCA convierte la respuesta del chip en una burbuja vacía. Si un guard
+// borrara la respuesta entera, el chip del punto de acceso #1 quedaría en
+// blanco: eso es exactamente lo que este bloque previene.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Preguntas-ejemplo — guards sanean respuestas MALAS sin blanquear el chip', () => {
+  test('voseo argentino en la respuesta del chip "Tengo plaga" → se normaliza a usted, no vacío', () => {
+    const malo =
+      'Vos tenés que revisar el envés de las hojas. Si querés, te ayudo a identificar la plaga.';
+    const finalText = runProductionTail(malo, { userMessage: 'Tengo plaga en mis plantas' });
+    assertHealthyAnswer('Tengo plaga en mis plantas', finalText);
+    // El filtro normaliza los marcadores fuertes (pronombre + morfología voseo).
+    expect(finalText).not.toMatch(/\bvos\b/i);
+    expect(finalText).not.toMatch(/tenés|querés/i);
+    // NOTA (hallazgo): el filtro NO cubre el imperativo enclítico voseante
+    // ("mandame", "contame", "fijate"). Ver voseoFilter.js — gap conocido, no
+    // bloquea este test (lo dejamos documentado para un fix futuro del filtro).
+  });
+
+  test('fuga de rol en respuesta del chip "Cuándo planto tomates" → se trunca, no vacío', () => {
+    const malo =
+      'El tomate se trasplanta a los 25-30 días.\nUsuario: gracias, y el maíz?\nAsistente: el maíz...';
+    const finalText = runProductionTail(malo, { userMessage: 'Cuándo planto tomates?' });
+    assertHealthyAnswer('Cuándo planto tomates?', finalText);
+    expect(finalText).toContain('El tomate se trasplanta');
+  });
+
+  test('binomio inventado de plaga (chiza) en respuesta del chip de plagas → respuesta sigue no vacía', () => {
+    // El guard de nombres inventados / taxonomía no debe vaciar la respuesta;
+    // como mínimo, el pipeline la deja renderizable y sin error.
+    const malo =
+      'La chiza (Neolepidopteron daquila) se controla con hongos entomopatógenos. Aplica Beauveria al suelo.';
+    const finalText = runProductionTail(malo, { userMessage: '¿Cómo controlo plagas sin químicos?' });
+    assertHealthyAnswer('¿Cómo controlo plagas sin químicos?', finalText);
+  });
+
+  test('preámbulo de inventario fuera de lugar en chip de siembra → respuesta sigue sana', () => {
+    const malo =
+      'Usted tiene 21 fresas y 4 caléndulas. En tu zona puedes sembrar frijol, maíz y hortalizas de hoja este mes.';
+    const finalText = runProductionTail(malo, { userMessage: '¿Qué siembro este mes?' });
+    assertHealthyAnswer('¿Qué siembro este mes?', finalText);
+    expect(finalText).toMatch(/sembrar/i);
+  });
+
+  test('viabilidad invertida con grounding "inviable" → corrige UNA vez, no duplica, no vacío', () => {
+    // Caso #1240/#1237: el guard REEMPLAZA texto. Verificamos que corrige
+    // (una sola "Corrección importante") y deja respuesta renderizable.
+    const entities = [
+      {
+        kind: 'species',
+        nombre_comun: 'curuba',
+        viabilidad: 'inviable',
+        altitud_min: 1800,
+        altitud_max: 2600,
+        alternativas_viables: ['lulo', 'mora'],
+      },
+    ];
+    const malo = 'La curuba es excelente para tu finca, puedes sembrarla este invierno sin problema.';
+    const finalText = runProductionTail(malo, {
+      userMessage: '¿Qué puedo sembrar este mes en mi zona?',
+      resolvedEntities: entities,
+      fincaAltitud: 300,
+    });
+    assertHealthyAnswer('¿Qué puedo sembrar este mes en mi zona?', finalText);
+    expect(finalText).toMatch(/Corrección importante/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// META: el test DEBE fallar ruidosamente ante respuesta vacía/error. Probamos
+// que assertHealthyAnswer detecta los tres modos de fallo — si esta protección
+// se rompiera, el test entero dejaría de proteger el punto de acceso #1.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Preguntas-ejemplo — el detector de fallos funciona (auto-test)', () => {
+  test('detecta respuesta VACÍA', () => {
+    expect(() => assertHealthyAnswer('Q', runProductionTail('', { userMessage: 'Q' }))).toThrow();
+  });
+
+  test('detecta burbuja de ERROR', () => {
+    expect(() =>
+      assertHealthyAnswer('Q', runProductionTail('No pude conectarme al asistente. Intenta de nuevo.', { userMessage: 'Q' })),
+    ).toThrow();
+  });
+
+  test('detecta fuga de rol Usuario:/Asistente: (post stripRoleLeak)', () => {
+    // stripRoleLeak corta el rol al inicio de línea; pero si una versión futura
+    // dejara pasar el marcador, assertHealthyAnswer lo atrapa. Forzamos el caso
+    // saltándonos stripRoleLeak para validar el detector.
+    const leaked = 'Respuesta real.\nAsistente: turno falso inventado por el modelo.';
+    expect(() => assertHealthyAnswer('Q', leaked)).toThrow();
+  });
+});


### PR DESCRIPTION
## Por qué

Las **preguntas-ejemplo** (chips/sugerencias que el usuario campesino solo clickea) son el **PUNTO DE ACCESO #1** al agente. Si un chip produce respuesta vacía, burbuja de error o alucinación, perdemos al usuario en el primer toque. No había cobertura para esto y, además, la suite **vitest no corría en CI** (solo Playwright E2E).

## Qué hace

**Capa (a) unit/integration — vitest, rápido, sin GPU** (`tests/unit/exampleQuestions.entrypoint.test.jsx`):
1. **Render**: cada chip pinta su pregunta canónica.
2. **Wiring**: el click del chip dispara el turno con el texto exacto (lo que `AgentScreen` pasa a `handleSubmit`).
3. **Pipeline de salida**: para CADA pregunta-ejemplo, una respuesta del modelo recorre la **misma cadena de post-proceso de producción** (`stripRoleLeak` → `applyVoseoFilter` → `applyOutputGuards`, igual que `AgentScreen.jsx`). Se asserta que la respuesta **NO** queda vacía, **NO** es burbuja de error/fallback (`No recibí respuesta…`, `No pude conectarme…`), y **NO** tiene patrones prohibidos (voseo argentino, fuga de rol `Usuario:`/`Asistente:`, `Corrección importante` duplicada).
4. **Regresión de bugs reales**: respuestas MALAS (voseo, fuga de rol, binomio inventado de plaga, leak de inventario, viabilidad invertida) → los guards las **sanean sin blanquear el chip**.
5. **Auto-test del detector**: prueba que el test **falla ruidosamente** ante respuesta vacía / error / fuga de rol — ese es el punto.

**Fuente única** (`src/data/exampleQuestions.js`): las preguntas se mueven a un módulo de datos consumido por `QuickChipsBar`, `SuggestedActions` y `AgentHero`, y por el test. Imposible que diverjan UI ↔ test (antes estaban inline en cada componente).

**Capa (b) smoke @real opcional** (`tests/e2e-real/example-questions-real.smoke.mjs`): 1-2 chips contra el agente real (chromium del nix-store). **Manual, NO en CI** (GPU-pesado). Aislado de vitest y playwright.

## CI — cómo queda gateado

Nuevo workflow `.github/workflows/unit-tests.yml` con job `vitest` que **corre en CADA PR a main y push a main** (no había gate vitest en CI). Corre el test del punto de acceso #1 + dependencias **deterministas** (outputGuards, catalog-count, smoke de chips). Segundos, sin GPU/red.

**Por qué el gate NO corre `npm run test:unit` completo (todavía)**: la suite completa **no es CI-clean** — 2 tests preexistentes de visión (`aiService.visionCache.test.js`, `visionCacheService.test.js`) son **flaky en ubuntu-latest** por diferencias de `SubtleCrypto.digest` entre runners (pasan local en NixOS, fallan en CI). Un gate que nace rojo por fallas ajenas se ignora. Ampliar a la suite completa queda pendiente de estabilizar esos 2 tests.

## Preguntas-ejemplo cubiertas (10 chips, 10 únicas)

- **QuickChipsBar**: `¿Qué siembro este mes?` · `Tengo plaga en mis plantas` · `Receta de biopreparado para tomate`
- **SuggestedActions**: `Cuándo planto tomates?` · `Mi planta tiene manchas amarillas` · `Registra que regué las lechugas` · `Consejos para el invernadero`
- **AgentHero (home)**: `¿Qué puedo sembrar este mes en mi zona?` · `¿Cómo controlo plagas sin químicos?` · `Dame el reporte del clima de mi zona.`

Por cada una se asserta: respuesta del pipeline **no vacía**, **no** burbuja de error, **sin** voseo, **sin** fuga de rol, **sin** `Corrección importante` duplicada; y que el chip **renderiza** su texto y el **click** dispara el turno con el texto exacto.

## Hallazgos (no bloquean este PR)

- **El filtro de voseo NO cubre el imperativo enclítico voseante** (`mandame`, `contame`, `fijate`): normaliza `vos`/`tenés`/`querés` pero deja pasar `mandame`. Documentado en el test; fix del filtro es aparte.
- **`tests/unit/catalog-count.test.js` fallaba en `main`** (asertaba schema v3.1/204 species; el subset ya es v3.2/205). Corregido acá. La metadata `_subset_meta.species_count` (204) sigue desfasada vs `species.length` (205) — corregir la data es tarea del owner del catálogo.
- **`main` falla `npm run lint`** por errores preexistentes en `AIStatusFooter.jsx` y `useIdleDetection.js` (ajenos a este PR).
- **2 tests de visión CI-flaky** (ver sección CI).

## Verificación

- Comando exacto del gate CI, local: 5 archivos, **70 pass**.
- Suite vitest completa local: 192 archivos, 3174 pass, 1 skip.
- `eslint` sobre los archivos tocados: 0 problemas (max-warnings=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)