### PR TITLE
fix: real deploy version count, hide dead-end Deep Research chip, drop Clásico fondo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,15 @@ jobs:
 
       - if: env.SKIP_DEPLOY != '1'
         uses: actions/checkout@v4
+        # fetch-depth: 0 = clone COMPLETO (no shallow). El default de
+        # actions/checkout@v4 es fetch-depth 1 (shallow), con lo que
+        # `git rev-list --count HEAD` del step "Set deploy-time version"
+        # cuenta SIEMPRE 1 → la versión quedaba pegada en `1.0.1` sin
+        # avanzar pese a cada deploy. Con el historial completo el count
+        # da el número real de commits (~185), produciendo una versión
+        # monotónica `1.0.<count>` única por deploy.
+        with:
+          fetch-depth: 0
 
       - if: env.SKIP_DEPLOY != '1'
         name: Install dependencies

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -505,14 +505,12 @@ export default function App() {
   // Perfil. Suscribimos SOLO el id (string) — nunca un objeto inline — para
   // no disparar React #185. Escribimos la variable CSS --app-bg-image en el
   // body (la consume .app-bg-biodiversidad) y precargamos únicamente el
-  // full seleccionado. 'default' limpia la variable → cae al fallback CSS
-  // clásico, sin breaking change.
+  // full seleccionado. Desde 2026-06-02 ya no existe el fondo "Clásico":
+  // CUALQUIER id resuelve vía getBackgroundSrc a una foto biopunk real
+  // (default universal "Cosecha mística"), así que siempre escribimos la
+  // variable y NINGUNA pantalla cae al fondo viejo.
   const selectedBackground = useThemeBackgroundStore((s) => s.selected);
   useEffect(() => {
-    if (selectedBackground === 'default') {
-      document.body.style.removeProperty('--app-bg-image');
-      return;
-    }
     const src = getBackgroundSrc(selectedBackground);
     // Precargar solo el full elegido para que el cambio sea inmediato.
     const img = new Image();

--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CHIP_DEFS, CHIP_INTENTS } from '../services/chipIntentRouter';
+import { isDeepResearchEnabled } from '../services/deepResearchClient';
 
 /**
  * ChipsToolbar — "caja de herramientas" del agente como CHIPS DE MODO
@@ -20,9 +21,18 @@ import { CHIP_DEFS, CHIP_INTENTS } from '../services/chipIntentRouter';
  * El chip 📷 foto solo se muestra cuando hay una imagen adjunta lista
  * (`hasAttachment`). Coordina con el flujo de adjuntos del compositor.
  *
- * Tier gating (A1): el chip 🔬 Investigación profunda (Deep Research) es Pro-only.
- * Si `isPro` es false, el chip se muestra deshabilitado con copy "función Pro"
- * para que el usuario free sepa qué existe pero no pueda activarlo.
+ * Feature flag (Deep Research): el chip 🔬 Investigación profunda SOLO se
+ * renderiza cuando `isDeepResearchEnabled()` es true (flag
+ * `VITE_DEEP_RESEARCH_ENABLED`). Con la flag OFF la feature no tiene backend
+ * disponible para ningún plan, así que mostrar el chip era un dead-end:
+ * cualquier pregunta caía en "no disponible en este plan". Mientras la flag
+ * esté OFF el chip se OCULTA por completo; cuando esté live vuelve a aparecer
+ * con el tier gating Pro de abajo.
+ *
+ * Tier gating (A1): cuando la flag está ON, el chip 🔬 Investigación profunda
+ * (Deep Research) es Pro-only. Si `isPro` es false, el chip se muestra
+ * deshabilitado con copy "función Pro" para que el usuario free sepa qué
+ * existe pero no pueda activarlo.
  *
  * Props:
  *   - onSelectIntent: callback(intent: string) — el call-site decide qué hacer.
@@ -42,6 +52,15 @@ export default function ChipsToolbar({
   isPro = false,
 }) {
   if (typeof onSelectIntent !== 'function') return null;
+
+  // Deep Research dead-end fix: si la flag VITE_DEEP_RESEARCH_ENABLED está
+  // OFF la feature no existe para ningún plan, así que ocultamos el chip 🔬
+  // por completo (no solo lo pro-bloqueamos). Con la flag ON el chip vuelve
+  // y queda pro-gated como el resto de la lógica de abajo.
+  const deepEnabled = isDeepResearchEnabled();
+  const visibleChipDefs = deepEnabled
+    ? CHIP_DEFS
+    : CHIP_DEFS.filter((def) => def.intent !== CHIP_INTENTS.deep);
 
   const baseChip =
     'shrink-0 inline-flex items-center gap-1.5 px-3.5 py-2 rounded-full border ' +
@@ -84,7 +103,7 @@ export default function ChipsToolbar({
           </button>
         )}
 
-        {CHIP_DEFS.map((def) => {
+        {visibleChipDefs.map((def) => {
           const isActive = activeIntent === def.intent;
           // El chip 🔬 Deep Research es Pro-only. Para usuarios free: deshabilitado
           // con copy claro "función Pro" y title explicativo. NO se oculta — el

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -15,8 +15,9 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
   const [loading, setLoading] = useState(false);
   // Selector de fondos: en login mostramos el fondo curado como capa de foto.
   // Suscribimos solo el id (string) para evitar React #185. SIEMPRE resolvemos
-  // a una foto (getBackgroundSrc) — incluido 'default', que ahora cae a "Cosecha
-  // mística" (DEFAULT_BACKGROUND_SRC). Así el login nunca muestra el patrón viejo.
+  // a una foto (getBackgroundSrc); el default universal es "Cosecha mística"
+  // (DEFAULT_BACKGROUND_SRC) tras eliminar el fondo "Clásico" (2026-06-02), así
+  // el login nunca muestra el patrón viejo.
   const selectedBackground = useThemeBackgroundStore((s) => s.selected);
   const loginBgSrc = getBackgroundSrc(selectedBackground);
 

--- a/src/components/Settings/__tests__/BackgroundSelector.smoke.test.jsx
+++ b/src/components/Settings/__tests__/BackgroundSelector.smoke.test.jsx
@@ -8,21 +8,24 @@ import useThemeBackgroundStore, {
 describe('BackgroundSelector smoke', () => {
   beforeEach(() => {
     localStorage.clear();
-    useThemeBackgroundStore.getState().setBackground('default');
+    // Default universal: "Cosecha mística" (biopunk-4). El fondo "Clásico"
+    // fue eliminado del catálogo (operador 2026-06-02).
+    useThemeBackgroundStore.getState().setBackground('biopunk-4');
   });
 
-  it('renderiza las opciones de fondo del catálogo', () => {
+  it('renderiza las opciones de fondo del catálogo (4 biopunk, sin Clásico)', () => {
     render(<BackgroundSelector />);
-    expect(screen.getByText('Clásico')).toBeInTheDocument();
+    expect(screen.queryByText('Clásico')).not.toBeInTheDocument();
     expect(screen.getByText('Páramo completo')).toBeInTheDocument();
     expect(screen.getByText('Colibrí tech')).toBeInTheDocument();
     expect(screen.getByText('Bosque ilustrado')).toBeInTheDocument();
+    expect(screen.getByText('Cosecha mística')).toBeInTheDocument();
   });
 
-  it('Clásico (default) seleccionado por default', () => {
+  it('Cosecha mística (default universal) seleccionado por default', () => {
     render(<BackgroundSelector />);
-    const clasicoBtn = screen.getByText('Clásico').closest('button');
-    expect(clasicoBtn).toHaveAttribute('aria-pressed', 'true');
+    const misticaBtn = screen.getByText('Cosecha mística').closest('button');
+    expect(misticaBtn).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('estado del store preselecciona el fondo al montar', () => {
@@ -76,7 +79,7 @@ describe('BackgroundSelector smoke', () => {
   });
 
   it('botón cerrar (X) descarta el modal sin cambiar la selección', () => {
-    useThemeBackgroundStore.getState().setBackground('default');
+    useThemeBackgroundStore.getState().setBackground('biopunk-4');
     render(<BackgroundSelector />);
     fireEvent.click(screen.getByText('Páramo completo').closest('button'));
 
@@ -85,17 +88,17 @@ describe('BackgroundSelector smoke', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     // la selección NO cambió
-    expect(useThemeBackgroundStore.getState().selected).toBe('default');
+    expect(useThemeBackgroundStore.getState().selected).toBe('biopunk-4');
   });
 
   it('Escape cierra la vista ampliada sin cambiar la selección', () => {
-    useThemeBackgroundStore.getState().setBackground('default');
+    useThemeBackgroundStore.getState().setBackground('biopunk-4');
     render(<BackgroundSelector />);
     fireEvent.click(screen.getByText('Colibrí tech').closest('button'));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    expect(useThemeBackgroundStore.getState().selected).toBe('default');
+    expect(useThemeBackgroundStore.getState().selected).toBe('biopunk-4');
   });
 });

--- a/src/components/__tests__/ChipsToolbar.smoke.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.smoke.test.jsx
@@ -1,36 +1,56 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, test, expect, vi } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import ChipsToolbar from '../ChipsToolbar';
 import { CHIP_DEFS } from '../../services/chipIntentRouter';
+import * as deepResearchClient from '../../services/deepResearchClient';
 
 /**
  * Smoke tests A4/B4 — la barra de CHIPS DE MODO sobre el input del chat.
- *   - renderiza los 7 chips con su emoji + label,
+ *   - renderiza los chips con su emoji + label,
  *   - clickear un chip llama onSelectIntent con el intent enum,
  *   - el chip activo se marca aria-pressed,
  *   - el chip 📷 foto solo aparece/activa si hay imagen adjunta,
  *   - retorna null si falta el handler (defensa contra mounts incompletos).
- *   - tier gate A1: chip 🔬 Deep Research deshabilitado para free, activo para pro.
+ *
+ * Feature flag Deep Research (VITE_DEEP_RESEARCH_ENABLED):
+ *   - flag OFF (default) → el chip 🔬 NO se renderiza (evita dead-end
+ *     "no disponible en este plan"): quedan 6 chips.
+ *   - flag ON → el chip 🔬 reaparece y queda pro-gated (deshabilitado para
+ *     free, activo para pro) — tier gate A1.
+ *
+ * Estos tests controlan la flag mockeando `isDeepResearchEnabled` para no
+ * depender del entorno de build.
  */
 
-describe('ChipsToolbar — barra de chips de modo', () => {
-  test('renderiza los 7 chips de modo (usuario free — deep chip bloqueado)', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
-    const chips = screen.getAllByTestId('mode-chip');
-    expect(chips).toHaveLength(7);
-    // El emoji + label del primero (siembro) debe estar presente
-    expect(screen.getByText('¿Qué siembro?')).toBeInTheDocument();
-    expect(screen.getByText('Plaga')).toBeInTheDocument();
-    // Free users ven el chip con sufijo "(Pro)"
-    expect(screen.getByText('Investigación profunda (Pro)')).toBeInTheDocument();
+// Cantidad de chips NO-deep (siembro, plaga, biopreparado, clima, precio, calendario).
+const NON_DEEP_CHIP_COUNT = CHIP_DEFS.filter((d) => d.intent !== 'deep').length;
+
+describe('ChipsToolbar — flag Deep Research OFF (chip 🔬 oculto)', () => {
+  beforeEach(() => {
+    vi.spyOn(deepResearchClient, 'isDeepResearchEnabled').mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  test('renderiza el chip 🔬 sin sufijo cuando isPro=true', () => {
+  test('el chip 🔬 Investigación profunda NO se renderiza con la flag OFF', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    expect(screen.queryByText(/investigación profunda/i)).not.toBeInTheDocument();
+  });
+
+  test('renderiza solo los chips no-deep (6) con la flag OFF', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    const chips = screen.getAllByTestId('mode-chip');
+    expect(chips).toHaveLength(NON_DEEP_CHIP_COUNT);
+    expect(screen.getByText('¿Qué siembro?')).toBeInTheDocument();
+    expect(screen.getByText('Plaga')).toBeInTheDocument();
+  });
+
+  test('el chip 🔬 tampoco aparece para usuario pro con la flag OFF', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
-    expect(screen.getByText('Investigación profunda')).toBeInTheDocument();
-    expect(screen.queryByText('Investigación profunda (Pro)')).not.toBeInTheDocument();
+    expect(screen.queryByText(/investigación profunda/i)).not.toBeInTheDocument();
   });
 
   test('clickear un chip llama onSelectIntent con el intent enum', () => {
@@ -45,14 +65,14 @@ describe('ChipsToolbar — barra de chips de modo', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} activeIntent="clima" />);
     const climaChip = screen.getByRole('button', { name: /clima/i });
     expect(climaChip).toHaveAttribute('aria-pressed', 'true');
-    // Otro chip cualquiera no debe estar pressed
     const siembroChip = screen.getByRole('button', { name: /siembro/i });
     expect(siembroChip).toHaveAttribute('aria-pressed', 'false');
   });
 
-  test('cada chip de modo expone un accessible name no vacío', () => {
+  test('cada chip no-deep expone un accessible name no vacío', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} />);
     for (const def of CHIP_DEFS) {
+      if (def.intent === 'deep') continue;
       const chip = screen.getByRole('button', { name: new RegExp(def.label, 'i') });
       expect(chip).toBeInTheDocument();
     }
@@ -65,12 +85,7 @@ describe('ChipsToolbar — barra de chips de modo', () => {
 
   test('el chip 📷 foto aparece y es clickable cuando hay imagen adjunta', () => {
     const onSelectIntent = vi.fn();
-    render(
-      <ChipsToolbar
-        onSelectIntent={onSelectIntent}
-        hasAttachment
-      />,
-    );
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} hasAttachment />);
     const fotoChip = screen.getByTestId('mode-chip-foto');
     expect(fotoChip).toBeInTheDocument();
     expect(fotoChip).not.toBeDisabled();
@@ -89,53 +104,6 @@ describe('ChipsToolbar — barra de chips de modo', () => {
     expect(container.textContent).not.toMatch(VOSEO);
   });
 
-  // ──── Tier gate A1 ────────────────────────────────────────────────────────
-
-  test('chip 🔬 está deshabilitado (disabled) para usuario free (isPro=false)', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
-    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
-    expect(deepChip).toBeDisabled();
-  });
-
-  test('chip 🔬 está habilitado para usuario pro (isPro=true)', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
-    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
-    expect(deepChip).not.toBeDisabled();
-  });
-
-  test('click en chip 🔬 llama onSelectIntent para usuario pro', () => {
-    const onSelectIntent = vi.fn();
-    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro />);
-    fireEvent.click(screen.getByRole('button', { name: /investigación profunda/i }));
-    expect(onSelectIntent).toHaveBeenCalledWith('deep');
-  });
-
-  test('click en chip 🔬 NO llama onSelectIntent para usuario free', () => {
-    const onSelectIntent = vi.fn();
-    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro={false} />);
-    // El botón está disabled — fireEvent.click no dispara el handler
-    fireEvent.click(screen.getByRole('button', { name: /investigación profunda/i }));
-    expect(onSelectIntent).not.toHaveBeenCalledWith('deep');
-  });
-
-  test('chip 🔬 tiene data-pro-locked cuando usuario es free', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
-    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
-    expect(deepChip).toHaveAttribute('data-pro-locked', 'true');
-  });
-
-  test('chip 🔬 NO tiene data-pro-locked cuando usuario es pro', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
-    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
-    expect(deepChip).not.toHaveAttribute('data-pro-locked');
-  });
-
-  test('chip 🔬 tiene title explicativo de función Pro cuando free', () => {
-    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
-    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
-    expect(deepChip).toHaveAttribute('title', expect.stringContaining('Pro'));
-  });
-
   test('chips no-Pro (siembro, plaga, etc.) siguen activos para usuario free', () => {
     const onSelectIntent = vi.fn();
     render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro={false} />);
@@ -144,5 +112,57 @@ describe('ChipsToolbar — barra de chips de modo', () => {
     onSelectIntent.mockClear();
     fireEvent.click(screen.getByText('Plaga'));
     expect(onSelectIntent).toHaveBeenCalledWith('plaga');
+  });
+});
+
+// ──── Flag Deep Research ON → chip 🔬 visible + tier gate A1 ─────────────────
+describe('ChipsToolbar — flag Deep Research ON (chip 🔬 visible, pro-gated)', () => {
+  beforeEach(() => {
+    vi.spyOn(deepResearchClient, 'isDeepResearchEnabled').mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('renderiza los 7 chips (incluido 🔬) con la flag ON', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    expect(screen.getAllByTestId('mode-chip')).toHaveLength(7);
+  });
+
+  test('usuario free ve el chip 🔬 con sufijo "(Pro)" y deshabilitado', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    expect(screen.getByText('Investigación profunda (Pro)')).toBeInTheDocument();
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).toBeDisabled();
+    expect(deepChip).toHaveAttribute('data-pro-locked', 'true');
+  });
+
+  test('chip 🔬 tiene title explicativo de función Pro cuando free', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).toHaveAttribute('title', expect.stringContaining('Pro'));
+  });
+
+  test('renderiza el chip 🔬 sin sufijo y habilitado cuando isPro=true', () => {
+    render(<ChipsToolbar onSelectIntent={() => {}} isPro />);
+    expect(screen.getByText('Investigación profunda')).toBeInTheDocument();
+    expect(screen.queryByText('Investigación profunda (Pro)')).not.toBeInTheDocument();
+    const deepChip = screen.getByRole('button', { name: /investigación profunda/i });
+    expect(deepChip).not.toBeDisabled();
+    expect(deepChip).not.toHaveAttribute('data-pro-locked');
+  });
+
+  test('click en chip 🔬 llama onSelectIntent("deep") para usuario pro', () => {
+    const onSelectIntent = vi.fn();
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro />);
+    fireEvent.click(screen.getByRole('button', { name: /investigación profunda/i }));
+    expect(onSelectIntent).toHaveBeenCalledWith('deep');
+  });
+
+  test('click en chip 🔬 NO llama onSelectIntent("deep") para usuario free', () => {
+    const onSelectIntent = vi.fn();
+    render(<ChipsToolbar onSelectIntent={onSelectIntent} isPro={false} />);
+    fireEvent.click(screen.getByRole('button', { name: /investigación profunda/i }));
+    expect(onSelectIntent).not.toHaveBeenCalledWith('deep');
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -32,9 +32,10 @@
    *
    * Selector de fondos 2026-05-28: la URL de la imagen es ahora la variable
    * CSS `--app-bg-image`, escrita por useThemeBackgroundStore cuando el
-   * operador elige otro fondo curado desde Perfil. El fallback de `var()`
-   * es la imagen clásica original → 'default' = comportamiento idéntico al
-   * anterior aunque el store nunca escriba la variable. El overlay de
+   * operador elige otro fondo curado desde Perfil. Desde 2026-06-02 el fondo
+   * "Clásico" fue eliminado: el fallback de `var()` es "Cosecha mística"
+   * (`/fondo-biopunk-4.jpg`), el default universal — ninguna pantalla cae ya
+   * al fondo viejo aunque el store no haya escrito la variable. El overlay de
    * gradiente (legibilidad) se mantiene intacto encima de cualquier imagen.
    */
   body.app-bg-biodiversidad {

--- a/src/store/__tests__/useThemeBackgroundStore.test.js
+++ b/src/store/__tests__/useThemeBackgroundStore.test.js
@@ -1,10 +1,11 @@
 /**
- * useThemeBackgroundStore — selector de fondos 2026-05-28.
+ * useThemeBackgroundStore — selector de fondos.
  *
- * Cubre:
- *   - estado inicial 'default'
+ * Cubre (post 2026-06-02, fondo "Clásico" eliminado):
+ *   - default universal selected="biopunk-4" (Cosecha mística)
+ *   - el catálogo contiene SOLO los 4 fondos biopunk (sin 'default'/Clásico)
  *   - setBackground cambia y persiste en localStorage (chagra:background:v1)
- *   - id inválido cae a 'default' (defensivo)
+ *   - id desconocido (y el legado 'default') cae a "biopunk-4" (defensivo)
  *   - helpers puros getBackgroundById / getBackgroundSrc retornan refs
  *     estables del catálogo congelado (anti React #185)
  *   - catálogo congelado (Object.freeze) — no mutable
@@ -12,6 +13,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import useThemeBackgroundStore, {
   BACKGROUND_CATALOG,
+  DEFAULT_BACKGROUND_ID,
   DEFAULT_BACKGROUND_SRC,
   getBackgroundById,
   getBackgroundSrc,
@@ -26,6 +28,7 @@ describe('useThemeBackgroundStore', () => {
 
   it('default universal: selected="biopunk-4" (Cosecha mística, operador 2026-06-02)', () => {
     expect(useThemeBackgroundStore.getState().selected).toBe('biopunk-4');
+    expect(DEFAULT_BACKGROUND_ID).toBe('biopunk-4');
   });
 
   it('setBackground cambia el fondo seleccionado', () => {
@@ -40,21 +43,28 @@ describe('useThemeBackgroundStore', () => {
     expect(JSON.parse(raw).state.selected).toBe('biopunk-2');
   });
 
-  it('id desconocido cae a "default" (defensivo)', () => {
+  it('id desconocido cae al default universal "biopunk-4" (defensivo)', () => {
     useThemeBackgroundStore.getState().setBackground('biopunk-1');
     useThemeBackgroundStore.getState().setBackground('no-existe');
-    expect(useThemeBackgroundStore.getState().selected).toBe('default');
+    expect(useThemeBackgroundStore.getState().selected).toBe('biopunk-4');
   });
 
-  it('catálogo tiene default + biopunk y está congelado', () => {
-    expect(BACKGROUND_CATALOG).toHaveLength(5);
+  it('el legado "default" (Clásico, eliminado) ya no es válido → cae a biopunk-4', () => {
+    useThemeBackgroundStore.getState().setBackground('default');
+    expect(useThemeBackgroundStore.getState().selected).toBe('biopunk-4');
+  });
+
+  it('catálogo: SOLO 4 fondos biopunk (sin Clásico) y congelado', () => {
+    expect(BACKGROUND_CATALOG).toHaveLength(4);
     expect(BACKGROUND_CATALOG.map((b) => b.id)).toEqual([
-      'default',
       'biopunk-1',
       'biopunk-2',
       'biopunk-3',
       'biopunk-4',
     ]);
+    // El fondo "Clásico"/'default' fue eliminado del catálogo.
+    expect(BACKGROUND_CATALOG.some((b) => b.id === 'default')).toBe(false);
+    expect(BACKGROUND_CATALOG.some((b) => b.label === 'Clásico')).toBe(false);
     expect(Object.isFrozen(BACKGROUND_CATALOG)).toBe(true);
     expect(Object.isFrozen(BACKGROUND_CATALOG[0])).toBe(true);
   });
@@ -63,14 +73,18 @@ describe('useThemeBackgroundStore', () => {
     const a = getBackgroundById('biopunk-1');
     const b = getBackgroundById('biopunk-1');
     expect(a).toBe(b); // misma referencia, no objeto nuevo
-    expect(a).toBe(BACKGROUND_CATALOG[1]);
+    expect(a).toBe(BACKGROUND_CATALOG[0]);
   });
 
-  it('getBackgroundById con id inválido retorna la entrada default estable', () => {
-    expect(getBackgroundById('no-existe')).toBe(BACKGROUND_CATALOG[0]);
+  it('getBackgroundById con id inválido retorna la entrada default (Cosecha mística) estable', () => {
+    const entry = getBackgroundById('no-existe');
+    expect(entry.id).toBe('biopunk-4');
+    // Ref estable entre llamadas (no objeto nuevo).
+    expect(getBackgroundById('otro-invalido')).toBe(entry);
   });
 
-  it('getBackgroundSrc: default cae a Cosecha mística (DEFAULT_BACKGROUND_SRC)', () => {
+  it('getBackgroundSrc: id desconocido cae a Cosecha mística (DEFAULT_BACKGROUND_SRC)', () => {
+    expect(getBackgroundSrc('no-existe')).toBe(DEFAULT_BACKGROUND_SRC);
     expect(getBackgroundSrc('default')).toBe(DEFAULT_BACKGROUND_SRC);
     expect(DEFAULT_BACKGROUND_SRC).toBe('/fondo-biopunk-4.jpg');
   });
@@ -79,5 +93,6 @@ describe('useThemeBackgroundStore', () => {
     expect(getBackgroundSrc('biopunk-1')).toBe('/fondo-biopunk-1.jpg');
     expect(getBackgroundSrc('biopunk-2')).toBe('/fondo-biopunk-2.jpg');
     expect(getBackgroundSrc('biopunk-3')).toBe('/fondo-biopunk-3.jpg');
+    expect(getBackgroundSrc('biopunk-4')).toBe('/fondo-biopunk-4.jpg');
   });
 });

--- a/src/store/useThemeBackgroundStore.js
+++ b/src/store/useThemeBackgroundStore.js
@@ -7,16 +7,17 @@ import { persist, createJSONStorage } from 'zustand/middleware';
  * Selector de fondo de biodiversidad para la app. El operador elige
  * entre los fondos curados por la diseñadora (Lili) desde su Perfil.
  *
- * Hoy el fondo de la app es fijo (`/biodiversidad-bg.jpg`) aplicado vía
- * la clase `body.app-bg-biodiversidad` en src/index.css. Este store
- * permite reemplazar la imagen sin breaking change: 'default' mantiene
- * EXACTAMENTE el comportamiento actual.
+ * Decisión operador 2026-06-02: se ELIMINÓ el fondo "Clásico"
+ * (`/biodiversidad-bg.jpg`). El default universal de TODA la app —desde el
+ * login hasta biodiversidad— es ahora "Cosecha mística" (`biopunk-4`).
+ * El catálogo solo contiene los 4 fondos biopunk curados.
  *
  * El fondo se aplica escribiendo la variable CSS `--app-bg-image` en el
  * <body>; la regla `.app-bg-biodiversidad` la consume con `var(...)` y
- * fallback a la imagen clásica. Así seguimos cubriendo ScreenShell main +
- * DashboardLive + login con un solo punto de verdad, y se preserva el
- * overlay/blur biopunk para legibilidad (capas independientes).
+ * fallback a "Cosecha mística" (`/fondo-biopunk-4.jpg`). Así cubrimos
+ * ScreenShell main + DashboardLive + login con un solo punto de verdad,
+ * y se preserva el overlay/blur biopunk para legibilidad (capas
+ * independientes). NINGUNA pantalla cae ya al fondo clásico viejo.
  *
  * Persiste en localStorage bajo `chagra:background:v1`.
  * ================================================================
@@ -37,15 +38,6 @@ import { persist, createJSONStorage } from 'zustand/middleware';
  * que retornan refs estables del catálogo congelado.
  */
 export const BACKGROUND_CATALOG = Object.freeze([
-  Object.freeze({
-    id: 'default',
-    label: 'Clásico',
-    sub: 'Bosque alto-andino',
-    // null = mantener el comportamiento actual (la imagen original la pone
-    // el fallback de la regla CSS, no este store). Así 'default' nunca
-    // depende de que el store haya escrito la variable.
-    src: null,
-  }),
   Object.freeze({
     id: 'biopunk-1',
     label: 'Páramo completo',
@@ -73,28 +65,41 @@ export const BACKGROUND_CATALOG = Object.freeze([
 ]);
 
 /**
+ * Id del fondo por defecto universal — "Cosecha mística" (biopunk-4).
+ * Decisión operador 2026-06-02. Cualquier id desconocido o localStorage
+ * legado con el viejo 'default' (Clásico, ya eliminado) resuelve acá.
+ */
+export const DEFAULT_BACKGROUND_ID = 'biopunk-4';
+
+/**
  * Fondo por defecto de TODA la app y el login — "Cosecha mística" (biopunk-4).
  * Decisión operador 2026-06-02: este es el default universal; cualquier usuario
  * que no haya elegido explícitamente otro fondo (incluido login/incógnito) lo ve.
- * (Antes era '/biodiversidad-bg.jpg', el "fondo viejo" que el operador descartó.)
+ * (Antes existía '/biodiversidad-bg.jpg', el "fondo Clásico" que el operador eliminó.)
  */
 export const DEFAULT_BACKGROUND_SRC = '/fondo-biopunk-4.jpg';
+
+/** Entrada del catálogo del fondo por defecto (ref estable congelada). */
+const DEFAULT_BACKGROUND_ENTRY = Object.freeze(
+  BACKGROUND_CATALOG.find((b) => b.id === DEFAULT_BACKGROUND_ID) || BACKGROUND_CATALOG[0]
+);
 
 /** Set congelado de ids válidos para validar entradas externas. */
 const VALID_IDS = Object.freeze(BACKGROUND_CATALOG.map((b) => b.id));
 
 /**
  * Helper PURO fuera del store: resuelve la entrada del catálogo por id.
- * Retorna SIEMPRE una ref estable del catálogo congelado (o la de
- * 'default'), nunca un objeto nuevo → seguro para usar en render.
+ * Retorna SIEMPRE una ref estable del catálogo congelado (o la del fondo
+ * por defecto "Cosecha mística"), nunca un objeto nuevo → seguro en render.
  */
 export function getBackgroundById(id) {
-  return BACKGROUND_CATALOG.find((b) => b.id === id) || BACKGROUND_CATALOG[0];
+  return BACKGROUND_CATALOG.find((b) => b.id === id) || DEFAULT_BACKGROUND_ENTRY;
 }
 
 /**
- * Resuelve la URL de imagen efectiva para un id. 'default' (o cualquier id
- * sin src) → imagen clásica. Helper puro, sin tocar el store.
+ * Resuelve la URL de imagen efectiva para un id. Cualquier id desconocido
+ * (incluido el legado 'default' ya eliminado) cae a "Cosecha mística".
+ * Helper puro, sin tocar el store.
  */
 export function getBackgroundSrc(id) {
   return getBackgroundById(id).src || DEFAULT_BACKGROUND_SRC;
@@ -105,23 +110,25 @@ const useThemeBackgroundStore = create(
     (set) => ({
       // Default universal "Cosecha mística" (operador 2026-06-02). Usuarios
       // nuevos / incógnito arrancan en biopunk-4; el chip queda resaltado en Perfil.
-      selected: 'biopunk-4',
+      selected: DEFAULT_BACKGROUND_ID,
 
       /**
        * Cambia el fondo seleccionado. Valida contra el catálogo; un id
-       * desconocido cae a 'default' (defensivo contra localStorage
-       * corrupto o versiones futuras del catálogo).
+       * desconocido cae al default universal "Cosecha mística" (defensivo
+       * contra localStorage corrupto o versiones futuras del catálogo).
        */
       setBackground: (id) =>
-        set({ selected: VALID_IDS.includes(id) ? id : 'default' }),
+        set({ selected: VALID_IDS.includes(id) ? id : DEFAULT_BACKGROUND_ID }),
     }),
     {
       name: 'chagra:background:v1',
       storage: createJSONStorage(() => localStorage),
       // Sanea el valor hidratado por si el catálogo cambió entre versiones.
+      // El legado 'default' (Clásico, eliminado 2026-06-02) ya no es válido →
+      // los usuarios que lo tuvieran persistido migran a "Cosecha mística".
       onRehydrateStorage: () => (state) => {
         if (state && !VALID_IDS.includes(state.selected)) {
-          state.selected = 'default';
+          state.selected = DEFAULT_BACKGROUND_ID;
         }
       },
     }


### PR DESCRIPTION
Three operator-reported bug fixes (2026-06-02). Catálogo de species y chagra-pro intactos.

## FIX 1 — Versión de deploy pegada
`.github/workflows/deploy.yml`: el step "Set deploy-time version" hace `git rev-list --count HEAD`, pero `actions/checkout@v4` clona shallow (fetch-depth 1) → el count era siempre 1 → la versión quedaba pegada en `1.0.1`. Se agregó `with: fetch-depth: 0` al checkout del job de deploy para que el count refleje el historial real (~185) y `1.0.<count>` sea monotónico.

## FIX 2 — Chip Deep Research dead-end
El chip 🔬 "Investigación profunda" se mostraba tappable con `VITE_DEEP_RESEARCH_ENABLED=false`, donde cualquier pregunta caía en "no disponible en este plan". `ChipsToolbar.jsx` ahora **oculta** el chip por completo cuando `isDeepResearchEnabled()` es false. Con la flag ON el chip reaparece, pro-gated como antes.

## FIX 3 — Fondo: "Clásico" eliminado, "Cosecha mística" universal
`useThemeBackgroundStore.js`: se quitó la entrada `id:'default'` (Clásico / `/biodiversidad-bg.jpg`) del `BACKGROUND_CATALOG`. Quedan los 4 fondos biopunk; `biopunk-4` ("Cosecha mística") es el default universal en todas las pantallas (login → biodiversidad). `setBackground`, `onRehydrateStorage`, el efecto de `--app-bg-image` en `App.jsx` y el fallback `var()` en `index.css` resuelven a `/fondo-biopunk-4.jpg`. localStorage legado con `'default'` migra a `biopunk-4`.

## Tests
- `ChipsToolbar.smoke.test.jsx`: chip 🔬 ausente con flag OFF (6 chips) / presente + pro-locked con flag ON (7 chips). Flag mockeada via spy.
- `useThemeBackgroundStore.test.js`: catálogo = 4 biopunk sin Clásico, default `biopunk-4`, migración del legado `'default'`.
- `BackgroundSelector.smoke.test.jsx`: actualizado a "Cosecha mística" como default.
- Suites afectadas verdes (36/36). Suite completa: solo fallan 2 tests pre-existentes de `catalog-count` (schema 3.2 vs 3.1), fuera del scope de esta PR.
- `eslint --max-warnings=0` limpio en todos los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)