### PR TITLE
fix(agent): dominant price decline + low-confidence suggestions (P1, P4 anti-halluc)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -65,7 +65,7 @@ import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../
 // sidecarClient/deepResearchClient vía buildSidecarHeaders (defense-in-depth).
 import { getCurrentTier } from '../../services/tierService';
 import DeepResearchCard from '../DeepResearchCard';
-import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak } from '../../services/agentService';
+import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity } from '../../services/agentService';
 import { applyOutputGuards, applyTaxonomyGuard } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
@@ -1023,7 +1023,7 @@ RESPONDE SOLO a lo que el usuario preguntó usando ÚNICAMENTE los datos verific
     return { isEnum, pestsMentioned, topic };
   };
 
-  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities) => {
+  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null) => {
     const systemPrompt = getSystemPrompt();
     const analysis = analyzeQuery(query);
 
@@ -1152,8 +1152,20 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     const curatedFactsBlock = buildCuratedFactsContext({ resolvedEntities });
     const curatedFactsContext = curatedFactsBlock ? `\n\n${curatedFactsBlock}` : '';
 
+    // P4b — POSIBLES COINCIDENCIAS (baja confianza). Va al FINAL del prompt para
+    // que la regla CASO B (pedir confirmación, no afirmar) domine por recency
+    // sobre cualquier dato de altitud/viabilidad que el modelo quiera afirmar.
+    const suggestedBlock = buildSuggestedEntitiesContext({ suggestedEntities });
+
+    // P1 — gating de PRECIO no-disponible. Es la regla MÁS dominante: va de
+    // ÚLTIMA (recency máxima) para que, en una consulta de precio sin dato, el
+    // decline + orientación DANE/SIPSA/Corabastos gane sobre el bloque de
+    // entidades resueltas / viabilidad / altitud. No-op si la query no es de
+    // precio o el tool de precio sí trajo dato.
+    const priceDeclineBlock = buildPriceDeclineContext({ userMessage: query, toolEvidence });
+
     const messages = [
-      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + curatedFactsContext + seguridadContext + viabilidadContext + frostHeatContext + asociacionContext + climaContext + fincaContext + queryAnalysisBlock },
+      { role: 'system', content: systemPrompt + corpusContext + evidenceContext + resolvedEntitiesBlock + curatedFactsContext + seguridadContext + viabilidadContext + frostHeatContext + asociacionContext + climaContext + fincaContext + queryAnalysisBlock + suggestedBlock + priceDeclineBlock },
       ...(contextMemory ? [{ role: 'user', content: contextMemory }] : []),
       { role: 'user', content: query },
     ];
@@ -1342,6 +1354,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // delimitado en el system prompt para grounding citable.
       let toolEvidence = null;
       let resolvedEntities = null;
+      // P4 (juez claude-cli 2026-06-02): las entidades de BAJA confianza (<0.7,
+      // p.ej. "culupa"→Gulupa fuzzy a 0.5) NO se descartan más — se separan en
+      // este bucket para presentarlas como SUGERENCIA (CASO B) en vez de
+      // afirmarlas como hecho.
+      let suggestedEntities = null;
       if (isOnline && isSidecarEnabled()) {
         try {
           // PASO 1 — pre-validation AGE (DR taxonómico Tier 1 B, PR #59).
@@ -1357,17 +1374,27 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           const resolved = await resolveEntities(textForLLM, { fincaAltitud: reAltitud });
           const tRE1 = performance.now();
           if (resolved && Array.isArray(resolved.entities) && resolved.entities.length > 0) {
-            // Solo nos quedamos con confidence >= 0.7 para no contaminar con
-            // matches dudosos (resolve-entities devuelve hasta confidence 0.5).
-            const filtered = resolved.entities.filter((e) => (e.confidence ?? 0) >= 0.7);
-            if (filtered.length > 0) {
-              resolvedEntities = filtered;
-              console.debug('[sidecar] resolve-entities', {
-                count: filtered.length,
-                latencyMs: Math.round(tRE1 - tRE0),
-                entities: filtered.map((e) => `${e.mentioned}→${e.canonical_id}`),
-              });
+            // P4: dos buckets. Las de confianza ALTA (>=0.7, sin flag de baja
+            // confianza) van como ENTIDADES RESUELTAS canónicas y alimentan los
+            // bloques de viabilidad/altitud/companions. Las de baja confianza
+            // (low_confidence/suggested/fuzzy/ambiguous o confidence <0.7) NO se
+            // tiran: van a `suggestedEntities` como POSIBLES COINCIDENCIAS que
+            // gatillan CASO B (pedir confirmación), NUNCA como hecho.
+            const canonical = resolved.entities.filter((e) => !isLowConfidenceEntity(e));
+            const suggested = resolved.entities.filter((e) => isLowConfidenceEntity(e));
+            if (canonical.length > 0) {
+              resolvedEntities = canonical;
             }
+            if (suggested.length > 0) {
+              suggestedEntities = suggested;
+            }
+            console.debug('[sidecar] resolve-entities', {
+              canonical: canonical.length,
+              suggested: suggested.length,
+              latencyMs: Math.round(tRE1 - tRE0),
+              entities: canonical.map((e) => `${e.mentioned}→${e.canonical_id}`),
+              suggestedEntities: suggested.map((e) => `${e.mentioned}→${e.canonical_id}@${e.confidence}`),
+            });
           }
 
           // PASO 2 — routing del tool.
@@ -1546,7 +1573,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         }
       }
 
-      const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities);
+      const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities);
       // DR-LANG-1: filtro post-process anti-voseo argentino. Es la última
       // línea de defensa estructural — garantiza que el léxico rioplatense
       // (che, laburar, etc.) NUNCA llegue al usuario campesino colombiano,

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -13,6 +13,7 @@
  */
 
 import { getRegionFromDepartment } from './regionalismsService.js';
+import { classifyQueryIntent } from './outputGuards.js';
 import {
   isInCaucaRegion as _isInCaucaRegion,
   normalizeUserInput as _normalizeCauca,
@@ -1409,4 +1410,168 @@ ${lines.join('\n')}
 
 INSTRUCCIÓN: usa este contexto para responder específico a la finca del usuario SIN pedirle que repita dónde está, qué clima tiene o qué siembra. Si menciona una planta/cultivo que ya tiene registrado, tenlo en cuenta. Ajusta siembra, manejo y recomendaciones a su altitud, piso térmico, temporada y clima. NO enumeres estos datos como preámbulo: solo menciona los que la pregunta concreta requiera.
 === FIN CONTEXTO AMBIENTAL ===`;
+}
+
+// ── P1: gating de PRECIO no-disponible (regla DOMINANTE de recency) ─────────
+
+/**
+ * Detecta si una evidencia de tool corresponde a una consulta de PRECIO que NO
+ * está disponible (SIPSA dataset federado como ZIP, no consulta directa). El
+ * sidecar devuelve `{available:false, ...}` para get_precio_sipsa. Acepta tanto
+ * la forma simple ({tool, result}) como el array de tool_chain (D2 #246).
+ *
+ * @param {object|Array<object>|null} toolEvidence
+ * @returns {boolean}
+ */
+function _hasUnavailablePriceEvidence(toolEvidence) {
+  const isPriceMiss = (ev) => {
+    if (!ev || typeof ev !== 'object') return false;
+    const toolName = String(ev.tool || '').toLowerCase();
+    const r = ev.result;
+    if (!r || typeof r !== 'object') return false;
+    const unavailable = r.available === false;
+    // El tool de precio es get_precio_sipsa; aceptamos cualquier variante que
+    // contenga "precio" o "sipsa" por robustez ante renombres futuros.
+    const isPriceTool = toolName.includes('precio') || toolName.includes('sipsa');
+    return isPriceTool && unavailable;
+  };
+  if (Array.isArray(toolEvidence)) return toolEvidence.some(isPriceMiss);
+  return isPriceMiss(toolEvidence);
+}
+
+/**
+ * buildPriceDeclineContext — bloque de instrucción DOMINANTE para el caso P1
+ * (FALLA juez claude-cli 2026-06-02): "¿a cómo está la papa?" rutea bien a
+ * get_precio_sipsa, la evidencia dice no-disponible, pero granite IGNORA la
+ * señal de precio y divaga sobre viabilidad/altitud de las entidades-papa
+ * resueltas (no inventa precio —bien— pero NO declina ni menciona DANE/SIPSA).
+ *
+ * Causa: el bloque de precio (evidenceContext) va al PRINCIPIO del system
+ * message y queda sepultado bajo la cascada de bloques de entidades/viabilidad/
+ * altitud. Este bloque se inyecta al FINAL del prompt (recency) y se declara
+ * de MÁXIMA PRIORIDAD: para una consulta de precio sin dato, declinar el precio
+ * + orientar a DANE/SIPSA/Corabastos GANA sobre cualquier dato de viabilidad.
+ *
+ * Solo emite cuando AMBAS condiciones se cumplen:
+ *   - la query es intent de PRECIO (classifyQueryIntent === 'precio'), y
+ *   - la evidencia de precio dice no-disponible (available:false).
+ * En cualquier otro caso devuelve '' (no-op, no contamina el prompt).
+ *
+ * @param {object} args
+ * @param {string|null|undefined} args.userMessage — la pregunta del usuario.
+ * @param {object|Array<object>|null} args.toolEvidence — evidencia del sidecar.
+ * @returns {string}
+ */
+export function buildPriceDeclineContext({ userMessage = null, toolEvidence = null } = {}) {
+  if (classifyQueryIntent(userMessage) !== 'precio') return '';
+  if (!_hasUnavailablePriceEvidence(toolEvidence)) return '';
+  return `
+
+=== REGLA DE MÁXIMA PRIORIDAD — CONSULTA DE PRECIO SIN DATO DISPONIBLE ===
+El usuario preguntó por un PRECIO / valor de mercado, y la fuente de precios
+(SIPSA del DANE) NO tiene un dato consultable en este momento (el boletín se
+publica como archivo ZIP federado, no como consulta directa).
+
+ESTA REGLA DOMINA SOBRE CUALQUIER OTRO BLOQUE de este prompt (entidades
+resueltas, viabilidad, altitud, asociaciones, clima). Para ESTA respuesta:
+
+1. DECLINA dar un precio. Di con claridad que NO tienes el precio actualizado
+   y que NUNCA inventas precios.
+2. ORIENTA al usuario a la fuente real: el boletín SIPSA/DANE (precios
+   mayoristas) o una consulta directa en la central de abastos más cercana
+   (p. ej. Corabastos en Bogotá, o la plaza/central mayorista de su región).
+3. NO respondas sobre viabilidad, altitud, clima ni asociaciones del cultivo a
+   menos que el usuario lo haya pedido EXPLÍCITAMENTE en este mismo mensaje. La
+   pregunta fue de PRECIO; no la conviertas en una respuesta de siembra.
+4. Puedes ofrecer, en UNA frase, ayudar con otra cosa del cultivo si lo desea.
+
+Ejemplo correcto:
+Usuario: "¿a cómo está la papa?"
+✓ "No tengo el precio actualizado de la papa y no me invento precios. Para un
+   dato confiable consulta el boletín de precios mayoristas SIPSA del DANE, o
+   pregunta directamente en una central de abastos como Corabastos. Si quieres,
+   te ayudo con la siembra o el manejo de la papa."
+=== FIN REGLA DE PRECIO ===`;
+}
+
+// ── P4b: entidades de BAJA confianza como SUGERENCIA (gatilla CASO B) ───────
+
+/**
+ * Umbral de confianza alineado con el sidecar (LOW_CONFIDENCE_THRESHOLD) y con
+ * el filtro histórico del PWA. Entidades con confidence < este valor NO se
+ * presentan como canónicas: se presentan como SUGERENCIA y el prompt obliga a
+ * preguntar (CASO B) en vez de afirmar.
+ */
+export const LOW_CONFIDENCE_THRESHOLD = 0.7;
+
+/**
+ * isLowConfidenceEntity — ¿debe tratarse esta entidad como SUGERENCIA (no como
+ * hecho)? True si el sidecar la marcó `low_confidence`/`suggested`/`fuzzy`/
+ * `ambiguous`, o si su confidence cae por debajo del umbral. Defensivo ante
+ * sidecars viejos que aún no emiten el flag `low_confidence`.
+ *
+ * @param {object} e
+ * @returns {boolean}
+ */
+export function isLowConfidenceEntity(e) {
+  if (!e || typeof e !== 'object') return false;
+  if (e.low_confidence === true || e.suggested === true || e.fuzzy === true || e.ambiguous === true) {
+    return true;
+  }
+  const c = typeof e.confidence === 'number' ? e.confidence : 0;
+  return c < LOW_CONFIDENCE_THRESHOLD;
+}
+
+/**
+ * buildSuggestedEntitiesContext — bloque para el caso P4 (FALLA juez claude-cli
+ * 2026-06-02): "dame la altitud de Culupa" → el sidecar resuelve "culupa"→
+ * Gulupa a confidence ~0.5 (fuzzy). Antes el PWA descartaba ese match (<0.7) y
+ * el modelo afirmaba la altitud de Gulupa como hecho SIN "¿quisiste decir
+ * Gulupa?".
+ *
+ * En vez de descartarlas, las entidades de baja confianza se presentan como
+ * POSIBLES COINCIDENCIAS (no canónicas) y el prompt obliga a CASO B (pedir
+ * confirmación) ANTES de afirmar cualquier dato de ellas. NUNCA se afirma su
+ * altitud / nombre científico / viabilidad como hecho.
+ *
+ * @param {object} args
+ * @param {Array<object>|null} args.suggestedEntities — entidades < umbral.
+ * @returns {string}
+ */
+export function buildSuggestedEntitiesContext({ suggestedEntities = null } = {}) {
+  if (!Array.isArray(suggestedEntities) || suggestedEntities.length === 0) return '';
+  const lineas = [];
+  const seen = new Set();
+  for (const e of suggestedEntities) {
+    if (!e || typeof e !== 'object') continue;
+    const mentioned = (e.mentioned || '').toString().trim();
+    const nombre = (e.nombre_comun || '').toString().trim();
+    if (!nombre) continue;
+    const key = `${mentioned}|${nombre}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const conf = typeof e.confidence === 'number' ? e.confidence.toFixed(2) : '?';
+    lineas.push(
+      `- El usuario escribió "${mentioned || nombre}" — posible coincidencia: ${nombre}${e.nombre_cientifico ? ` (${e.nombre_cientifico})` : ''} [confianza baja: ${conf}, SIN CONFIRMAR]`,
+    );
+  }
+  if (lineas.length === 0) return '';
+  return `
+
+=== POSIBLES COINCIDENCIAS (BAJA CONFIANZA — NO confirmadas, NO son hechos) ===
+El usuario mencionó términos que el catálogo NO resolvió con certeza. Lo de
+abajo son CONJETURAS por similitud (typo o nombre regional), NO equivalencias
+verificadas:
+
+${lineas.join('\n')}
+
+REGLA DE MÁXIMA PRIORIDAD (CASO B obligatorio):
+1. NO afirmes ningún dato (altitud, temperatura, nombre científico, viabilidad,
+   manejo) de estas posibles coincidencias como si fueran un hecho.
+2. PRIMERO pregunta para confirmar, con el formato CASO B: "No estoy seguro de
+   '[lo que escribió]'. ¿Quisiste decir [posible coincidencia]? Si es otra cosa,
+   cuéntame qué planta es y te ayudo." — y DETENTE ahí para esa entidad.
+3. Solo si el usuario confirma podrás responder con los datos de esa especie.
+4. ES PREFERIBLE PREGUNTAR QUE AFIRMAR LA EQUIVOCADA.
+=== FIN POSIBLES COINCIDENCIAS ===`;
 }

--- a/tests/unit/agentAntiHalluc.test.js
+++ b/tests/unit/agentAntiHalluc.test.js
@@ -1,0 +1,178 @@
+/**
+ * agentAntiHalluc.test.js — guardas anti-alucinación del prompt del agente
+ * (FALLAS del juez claude-cli 2026-06-02).
+ *
+ * P1 — gating de precio DOMINANTE: cuando la query es intent de PRECIO y la
+ *      evidencia de precio dice no-disponible, `buildPriceDeclineContext` debe
+ *      forzar el decline + orientación DANE/SIPSA/Corabastos como regla de
+ *      máxima prioridad, e ir al FINAL del prompt (recency) para no competir
+ *      con el bloque de entidades resueltas / viabilidad / altitud.
+ *
+ * P4 — baja confianza como SUGERENCIA: una entidad resuelta por fuzzy a 0.5
+ *      (p.ej. "culupa"→Gulupa) NO se presenta como canónica; se presenta como
+ *      POSIBLE COINCIDENCIA y `buildSuggestedEntitiesContext` instruye CASO B
+ *      ("¿quisiste decir X?") en vez de afirmar la altitud.
+ *
+ * Sigue el patrón de tests/unit/setup.js y usa Vitest.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildPriceDeclineContext,
+  buildSuggestedEntitiesContext,
+  isLowConfidenceEntity,
+  LOW_CONFIDENCE_THRESHOLD,
+} from '../../src/services/agentService.js';
+
+// ── P1 — gating de precio dominante ─────────────────────────────────────────
+
+describe('buildPriceDeclineContext — P1 precio no-disponible dominante', () => {
+  const priceMiss = {
+    tool: 'get_precio_sipsa',
+    args: { producto: 'papa' },
+    result: { available: false, hint: 'no inventes precios, orienta al ZIP DANE' },
+  };
+
+  it('precio-intent + evidencia no-disponible → fuerza decline + DANE/SIPSA/Corabastos', () => {
+    const block = buildPriceDeclineContext({
+      userMessage: '¿a cómo está la papa?',
+      toolEvidence: priceMiss,
+    });
+    expect(block).not.toBe('');
+    // Debe declinar el precio y orientar a las fuentes reales.
+    expect(block).toMatch(/SIPSA/);
+    expect(block).toMatch(/DANE/);
+    expect(block).toMatch(/Corabastos/);
+    expect(block).toMatch(/MÁXIMA PRIORIDAD/);
+    // Debe instruir NO inventar precios y NO derivar a viabilidad/altitud.
+    expect(block.toLowerCase()).toMatch(/no.*invent.*precio/);
+    expect(block.toLowerCase()).toMatch(/viabilidad|altitud/);
+  });
+
+  it('"cuánto vale el aguacate" también dispara el decline', () => {
+    const block = buildPriceDeclineContext({
+      userMessage: 'cuánto vale el aguacate hoy',
+      toolEvidence: { tool: 'get_precio_sipsa', result: { available: false } },
+    });
+    expect(block).not.toBe('');
+  });
+
+  it('NO dispara si la query NO es de precio (intent siembra)', () => {
+    const block = buildPriceDeclineContext({
+      userMessage: 'qué puedo sembrar a 2000 msnm',
+      toolEvidence: priceMiss,
+    });
+    expect(block).toBe('');
+  });
+
+  it('NO dispara si el tool de precio SÍ trajo dato (available !== false)', () => {
+    const block = buildPriceDeclineContext({
+      userMessage: '¿a cómo está la papa?',
+      toolEvidence: { tool: 'get_precio_sipsa', result: { available: true, precio: 1800 } },
+    });
+    expect(block).toBe('');
+  });
+
+  it('NO dispara sin evidencia de precio (otro tool)', () => {
+    const block = buildPriceDeclineContext({
+      userMessage: '¿a cómo está la papa?',
+      toolEvidence: { tool: 'get_species', result: { available: false } },
+    });
+    expect(block).toBe('');
+  });
+
+  it('soporta tool_chain (array de evidences)', () => {
+    const block = buildPriceDeclineContext({
+      userMessage: 'a cómo está la papa',
+      toolEvidence: [
+        { tool: 'get_species', result: { found: true } },
+        { tool: 'get_precio_sipsa', result: { available: false } },
+      ],
+    });
+    expect(block).not.toBe('');
+  });
+
+  it('null-safe: sin argumentos → ""', () => {
+    expect(buildPriceDeclineContext()).toBe('');
+    expect(buildPriceDeclineContext({})).toBe('');
+  });
+});
+
+// ── P4 — baja confianza como sugerencia (CASO B) ─────────────────────────────
+
+describe('isLowConfidenceEntity — clasificación de sugerencias', () => {
+  it('umbral expuesto = 0.7', () => {
+    expect(LOW_CONFIDENCE_THRESHOLD).toBe(0.7);
+  });
+
+  it('confidence 0.5 sin flag → baja confianza', () => {
+    expect(isLowConfidenceEntity({ confidence: 0.5, nombre_comun: 'Gulupa' })).toBe(true);
+  });
+
+  it('confidence 0.9 → NO baja confianza', () => {
+    expect(isLowConfidenceEntity({ confidence: 0.9, nombre_comun: 'Papa' })).toBe(false);
+  });
+
+  it('flag low_confidence:true gana aunque confidence venga alta (defensivo)', () => {
+    expect(isLowConfidenceEntity({ confidence: 0.95, low_confidence: true })).toBe(true);
+  });
+
+  it('flags suggested/fuzzy/ambiguous también marcan baja confianza', () => {
+    expect(isLowConfidenceEntity({ confidence: 0.6, suggested: true })).toBe(true);
+    expect(isLowConfidenceEntity({ confidence: 0.6, fuzzy: true })).toBe(true);
+    expect(isLowConfidenceEntity({ confidence: 0.6, ambiguous: true })).toBe(true);
+  });
+
+  it('justo en el umbral (0.7) → canónica (NO baja confianza)', () => {
+    expect(isLowConfidenceEntity({ confidence: 0.7, nombre_comun: 'X' })).toBe(false);
+  });
+});
+
+describe('buildSuggestedEntitiesContext — P4 Culupa→Gulupa sugerencia', () => {
+  const culupa = {
+    mentioned: 'Culupa',
+    kind: 'species',
+    canonical_id: 'passiflora_edulis',
+    nombre_comun: 'Gulupa',
+    nombre_cientifico: 'Passiflora edulis f. edulis Sims',
+    confidence: 0.5,
+    fuzzy: true,
+    suggested: true,
+    low_confidence: true,
+    altitud_min: 1700,
+    altitud_max: 2200,
+  };
+
+  it('entidad fuzzy 0.5 → bloque de POSIBLES COINCIDENCIAS que obliga CASO B', () => {
+    const block = buildSuggestedEntitiesContext({ suggestedEntities: [culupa] });
+    expect(block).not.toBe('');
+    expect(block).toMatch(/POSIBLES COINCIDENCIAS/);
+    expect(block).toMatch(/BAJA CONFIANZA/);
+    // Debe nombrar lo que escribió + la posible coincidencia.
+    expect(block).toMatch(/Culupa/);
+    expect(block).toMatch(/Gulupa/);
+    // Debe instruir preguntar (CASO B), no afirmar.
+    expect(block).toMatch(/CASO B/);
+    expect(block.toLowerCase()).toMatch(/quisiste decir/);
+    // Debe prohibir afirmar la altitud como hecho.
+    expect(block.toLowerCase()).toMatch(/no afirmes.*(altitud|hecho)|altitud/);
+  });
+
+  it('lista vacía / null → "" (no contamina el prompt)', () => {
+    expect(buildSuggestedEntitiesContext({ suggestedEntities: [] })).toBe('');
+    expect(buildSuggestedEntitiesContext({ suggestedEntities: null })).toBe('');
+    expect(buildSuggestedEntitiesContext()).toBe('');
+  });
+
+  it('dedup por mentioned+nombre y descarta entradas sin nombre_comun', () => {
+    const block = buildSuggestedEntitiesContext({
+      suggestedEntities: [
+        culupa,
+        { ...culupa }, // duplicado exacto
+        { mentioned: 'xyz', confidence: 0.4 }, // sin nombre_comun → descartada
+      ],
+    });
+    // "Gulupa" aparece una sola vez pese al duplicado.
+    const occurrences = (block.match(/Gulupa/g) || []).length;
+    expect(occurrences).toBe(1);
+  });
+});


### PR DESCRIPTION
Cierra dos FALLAS marcadas por el juez claude-cli (test del agente real, 2026-06-02).

## P1 — gating de precio se ahoga
"¿a cómo está la papa?" rutea bien a `get_precio_sipsa` y la evidencia dice no-disponible (`available:false` + "no inventes precios, orienta al ZIP DANE"), pero granite IGNORA la señal de precio y divaga sobre viabilidad/altitud de las entidades-papa resueltas. No inventa precio (bien) pero NO declina ni menciona DANE/SIPSA.

**Causa:** el bloque de precio (`evidenceContext`) va al PRINCIPIO del system message y queda sepultado bajo la cascada de bloques de entidades resueltas / viabilidad / altitud / clima.

**Fix:** `buildPriceDeclineContext({ userMessage, toolEvidence })` — cuando `classifyQueryIntent === 'precio'` (gating #1246) Y la evidencia de precio dice `available:false`, emite una regla de **MÁXIMA PRIORIDAD** (declinar precio + orientar a SIPSA/DANE/Corabastos + NO derivar a siembra). Se inyecta de **última** en el system message (recency) para ganarle a los bloques de viabilidad/altitud. No-op si la query no es de precio o si el tool de precio sí trajo dato.

## P4 — baja confianza se afirma como verdad
"dame la altitud de Culupa" → el sidecar resuelve "culupa"→Gulupa por fuzzy a confidence ~0.5. El PWA descartaba ese match (filtro `>=0.7`) y granite respondía la altitud de Gulupa como HECHO, sin "¿quisiste decir Gulupa?".

**Fix (capa PWA):** las entidades de baja confianza ya NO se descartan. `isLowConfidenceEntity` (flag `low_confidence`/`suggested`/`fuzzy`/`ambiguous` del sidecar, o `confidence < 0.7`) las separa en `suggestedEntities`. `buildSuggestedEntitiesContext` las presenta como **POSIBLES COINCIDENCIAS** (no canónicas) y obliga **CASO B** (pedir confirmación) antes de afirmar altitud/binomio. Los bloques de viabilidad/altitud/companions siguen corriendo SOLO sobre las entidades canónicas (>=0.7). Reusa el umbral 0.7 del sidecar.

Depende del flag `low_confidence` del sidecar (chagra-pro `fix/resolve-entities-low-confidence`), pero degrada igual ante sidecars viejos vía la heurística de `confidence`/flags existentes.

## Tests
- `tests/unit/agentAntiHalluc.test.js` — 16 casos nuevos (P1: dispara/no-dispara por intent + tool_chain + null-safe; P4: `isLowConfidenceEntity` + bloque de sugerencias + dedup).
- Suite completa verde: 193 files, 3191 pass, 1 skip.
- `eslint --max-warnings=0` limpio sobre los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)