### PR TITLE
fix(copy): remove garbled CJK characters in help and agent text

### DIFF
--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -137,7 +137,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
               <li>Si el modelo local no responde, usa <strong>Consultar IA externa</strong> en plant detail (genera prompt para Gemini/ChatGPT/Claude).</li>
             </ul>
             <p className="text-[11px] text-slate-400 italic mt-2">
-              Necesita internet. Si no se conecta, te跳 opciones para reintentar.
+              Necesita internet. Si no se conecta, te muestra opciones para reintentar.
             </p>
           </div>
         </Section>

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -316,7 +316,7 @@ export const REGIONAL_CLIMATE_ALERTS = {
   },
   'llanos': {
     riesgos: ['sequías marcadas', 'incendios forestales', 'periodos de inundación'],
-    recomendaciones: 'Implementar sistema de防守 contra incendios. Usar cultivos adaptados a periodos de estrés hídrico. Planificar siembras según régimen de lluvias.',
+    recomendaciones: 'Implementar sistema de prevención contra incendios. Usar cultivos adaptados a periodos de estrés hídrico. Planificar siembras según régimen de lluvias.',
     fuentes: ['IDEAM - Alerta de incendios 2024', 'Corporinoquia - Plan de manejo del fuego'],
   },
   'pacifico': {


### PR DESCRIPTION
## Bug
Caracteres CJK basura (residuos de edición con LLM) visibles en PROD en dos cadenas de la PWA.

## Causa raíz
Edición previa con LLM insertó glifos chinos en medio de cadenas en español que se renderizan tal cual al usuario.

## Cambios
- `src/components/HelpUsoScreen.jsx`: "te跳 opciones para reintentar" → "te muestra opciones para reintentar"
- `src/services/agentService.js` (bloque 'llanos', recomendaciones): "Implementar sistema de防守 contra incendios" → "Implementar sistema de prevención contra incendios"

## Tests
N/A — cambio de string puro, sin lógica modificada. Verificado `grep -rnP '[\x{4e00}-\x{9fff}]' src/` queda vacío (cero caracteres CJK en src/).

Refs: copy fixes en PROD (cambios menores en tiempo real)