### PR TITLE
feat(guards): guard de salida fail-safe para claims de salud de fermentos (DR-FOOD-3)

### DIFF
--- a/src/services/__tests__/outputGuards.fermento.test.js
+++ b/src/services/__tests__/outputGuards.fermento.test.js
@@ -1,0 +1,127 @@
+/**
+ * outputGuards.fermento.test.js — DR-FOOD-3, guard de salida de fermentos
+ * (capa 2 de defensa-en-profundidad del PWA). SAFETY-CRITICAL · FAIL-SAFE.
+ *
+ * Ground-truth: Chagra-strategy/deepresearch/DR-FOOD-3-CONSOLIDADO-2026-06-02.md
+ * §3.3 (veto de claims de salud — catálogo canónico de frase segura).
+ *
+ * Cubre:
+ *   (a) veto-total / refusal lo hace el sidecar; ACÁ el guard de salida redirige
+ *       claims de salud sobre fermentos a la frase segura del catálogo.
+ *   (b) claim de salud sobre fermento → redirigido (alimento ≠ medicamento).
+ *   (c) query/respuesta NO-fermento NO se ve afectada (anti-falso-positivo).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardFermentoHealthClaim,
+  applyOutputGuards,
+  getOutputGuardTelemetry,
+  resetOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+const SAFE_PHRASE = 'un fermento es un alimento, no un medicamento';
+
+describe('guardFermentoHealthClaim', () => {
+  it('(b) "la kombucha cura la gastritis" → redirige a la frase segura', () => {
+    const llm =
+      'Sí, la kombucha cura la gastritis y limpia el hígado; tómala en ayunas todos los días.';
+    const r = guardFermentoHealthClaim(llm, { userMessage: '¿la kombucha cura la gastritis?' });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain(SAFE_PHRASE);
+    expect(r.text.toLowerCase()).toContain('puesto de salud');
+    expect(r.reason).toMatch(/claim_salud_fermento/);
+  });
+
+  it('(b2) "el guarapo cura el cáncer" → redirigido', () => {
+    const r = guardFermentoHealthClaim('El guarapo cura el cáncer si lo tomas a diario.', {
+      userMessage: 'sirve el guarapo para el cancer',
+    });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain(SAFE_PHRASE);
+  });
+
+  it('(b3) "este fermento desintoxica el hígado" → redirigido', () => {
+    const r = guardFermentoHealthClaim('Este fermento desintoxica el hígado y depura la sangre.', {
+      userMessage: 'el masato desintoxica?',
+    });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain(SAFE_PHRASE);
+  });
+
+  it('(b4) gate por la PREGUNTA: respuesta sin término de fermento pero pregunta de kombucha', () => {
+    // El LLM responde sin nombrar el fermento pero afirma el claim; el gate de
+    // intención lo cubre por el userMessage.
+    const r = guardFermentoHealthClaim('Sí, cura la gastritis sin problema.', {
+      userMessage: '¿la kombucha cura la gastritis?',
+    });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain(SAFE_PHRASE);
+  });
+
+  it('(c) ANTI-FALSO-POSITIVO: claim de salud SIN fermento en juego NO dispara', () => {
+    // "previene" sobre una práctica agronómica, no un fermento.
+    const r = guardFermentoHealthClaim(
+      'Rotar el cultivo previene plagas y enfermedades del suelo.',
+      { userMessage: 'cómo evito plagas en el maíz' },
+    );
+    expect(r.modified).toBe(false);
+    expect(r.text).toContain('Rotar el cultivo');
+  });
+
+  it('(c2) ANTI-FALSO-POSITIVO: fermento mencionado SIN claim de salud NO dispara', () => {
+    const r = guardFermentoHealthClaim(
+      'El chucrut se hace con repollo y sal al 2%; déjalo fermentar tapado.',
+      { userMessage: 'cómo hago chucrut' },
+    );
+    expect(r.modified).toBe(false);
+    expect(r.text).toContain('chucrut');
+  });
+
+  it('(c3) ANTI-FALSO-POSITIVO: query de precio NO-fermento intacta', () => {
+    const r = guardFermentoHealthClaim('La papa está a 80 mil el bulto en la plaza.', {
+      userMessage: '¿a cómo está la papa?',
+    });
+    expect(r.modified).toBe(false);
+  });
+
+  it('idempotente: no re-anexa la frase segura si ya está', () => {
+    const ya =
+      'La kombucha cura la gastritis.\n\nUna aclaración importante: un fermento es un alimento, no un medicamento. No cura nada.';
+    const r = guardFermentoHealthClaim(ya, { userMessage: 'kombucha gastritis' });
+    expect(r.modified).toBe(false);
+  });
+
+  it('texto vacío / no-string → no-op seguro', () => {
+    expect(guardFermentoHealthClaim('', { userMessage: 'kombucha' }).modified).toBe(false);
+    expect(guardFermentoHealthClaim(null, { userMessage: 'kombucha' }).modified).toBe(false);
+  });
+
+  it('cuenta telemetría al disparar', () => {
+    guardFermentoHealthClaim('La chicha combate la anemia.', { userMessage: 'chicha anemia' });
+    expect(getOutputGuardTelemetry().fermentoHealthClaim).toBe(1);
+  });
+});
+
+describe('applyOutputGuards — integración guard de fermentos', () => {
+  it('redirige un claim de salud sobre fermento dentro del pipeline completo', () => {
+    const res = applyOutputGuards('La kombucha cura la gastritis, tómala en ayunas.', {
+      userMessage: '¿la kombucha cura la gastritis?',
+    });
+    expect(res.modified).toBe(true);
+    expect(res.text.toLowerCase()).toContain(SAFE_PHRASE);
+    expect(res.reasons.some((r) => /claim_salud_fermento/.test(r))).toBe(true);
+  });
+
+  it('ANTI-FALSO-POSITIVO: respuesta agronómica normal pasa sin el bloque de fermentos', () => {
+    const res = applyOutputGuards(
+      'Para el maíz a 1800 msnm, siembra en abril y rota con frijol; eso previene plagas.',
+      { userMessage: 'cuándo siembro maíz', fincaAltitud: 1800 },
+    );
+    expect(res.text.toLowerCase()).not.toContain(SAFE_PHRASE);
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -1836,6 +1836,162 @@ export function guardInventedName(responseText, { profileName = null } = {}) {
   };
 }
 
+// ── GUARD: claims de salud sobre FERMENTOS (DR-FOOD-3, SAFETY-CRITICAL) ───────
+
+/**
+ * Gatillos de INTENCIÓN-FERMENTO (espejo del pre-filtro del sidecar,
+ * fermento-prefilter.ts). El guard SOLO corre si la query/respuesta toca un
+ * fermento — anti-falso-positivo. Lista cerrada, normalizada (minúsculas, sin
+ * tildes). NO incluye términos agroecológicos generales (siembra, plaga,
+ * precio) para no disparar en queries no-fermento. Fuente de verdad:
+ * Chagra-strategy/deepresearch/DR-FOOD-3-CONSOLIDADO-2026-06-02.md §2.
+ */
+const FERMENTO_TERMS = [
+  'fermento',
+  'fermentado',
+  'fermentacion',
+  'masato',
+  'chicha',
+  'guarapo',
+  'champus',
+  'kombucha',
+  'scoby',
+  'kefir',
+  'chapo',
+  'suero costeno',
+  'cuajada',
+  'yogur',
+  'yogurt',
+  'chucrut',
+  'sauerkraut',
+  'hidromiel',
+  'encurtido',
+];
+
+/**
+ * Verbos/sustantivos de CLAIM DE SALUD prohibidos (§3.3 veto de claims). Si la
+ * respuesta atribuye a un fermento una propiedad diagnóstica/curativa/
+ * preventiva/desintoxicante, el guard la redirige a la frase segura del
+ * catálogo. Normalizado (minúsculas, sin tildes).
+ */
+const HEALTH_CLAIM_TERMS = [
+  'cura',
+  'curar',
+  'cura el',
+  'cura la',
+  'sana',
+  'sanar',
+  'previene',
+  'prevenir',
+  'combate',
+  'combatir',
+  'desintoxica',
+  'desintoxicar',
+  'detoxifica',
+  'depura',
+  'depurar',
+  'limpia el higado',
+  'limpia los rinones',
+  'elimina toxinas',
+  'baja el azucar',
+  'baja la presion',
+  'controla la diabetes',
+  'trata el',
+  'trata la',
+  'remedio para',
+  'medicina para',
+  'medicinal',
+  'propiedades medicinales',
+  'fortalece el sistema inmune',
+  'sube las defensas',
+  'antibiotico natural',
+];
+
+/**
+ * ¿La respuesta toca un fermento? (gate de intención). Mira tanto el texto del
+ * LLM como, si se pasó, la pregunta del usuario — basta con que UNO mencione un
+ * fermento. Conservador hacia NO disparar: sin término de fermento → false.
+ *
+ * @param {string} textNorm  respuesta del LLM normalizada.
+ * @param {string} userNorm  pregunta del usuario normalizada (o '').
+ * @returns {boolean}
+ */
+function _touchesFermento(textNorm, userNorm) {
+  for (const t of FERMENTO_TERMS) {
+    if (textNorm.includes(t) || userNorm.includes(t)) return true;
+  }
+  return false;
+}
+
+/**
+ * Frase segura de redirección (§3.3, catálogo canónico del consolidado). El
+ * fermento es un ALIMENTO, no un medicamento; ante síntomas, deriva al puesto
+ * de salud. NO cita un nombre propio: la autoridad es la pauta institucional
+ * (un fermento no es medicamento — marco INVIMA/Res. 810/2021).
+ */
+const FERMENTO_HEALTH_REDIRECT =
+  'Una aclaración importante: un fermento es un alimento, no un medicamento. ' +
+  'No cura, no previene ni desintoxica ninguna enfermedad. Si tiene un malestar ' +
+  'o una enfermedad, visite el puesto de salud de la vereda para diagnóstico y ' +
+  'tratamiento; ningún alimento reemplaza la atención médica.';
+
+/**
+ * guardFermentoHealthClaim — DR-FOOD-3, capa 2 de defensa-en-profundidad
+ * (guard de salida del PWA). SAFETY-CRITICAL · FAIL-SAFE.
+ *
+ * Si la respuesta del LLM atribuye a un FERMENTO un claim de salud
+ * (diagnóstico/curativo/preventivo/desintoxicante), ANEXA la frase segura del
+ * catálogo. NO intenta cirugía de frase (frágil): preserva la parte útil y
+ * añade la corrección al final, dejando claro que el fermento es alimento, no
+ * medicamento. Idempotente: si la corrección ya está, no re-dispara.
+ *
+ * GATING POR INTENCIÓN (anti-falso-positivo): solo corre si la respuesta o la
+ * pregunta tocan un fermento. En una query no-fermento ("la papa baja el
+ * azúcar" sobre precio de mercado) NO se ve afectada — el verbo de salud por sí
+ * solo no dispara.
+ *
+ * Firma propia (necesita userMessage para el gate) → se invoca aparte en
+ * applyOutputGuards, no dentro de GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardFermentoHealthClaim(responseText, { userMessage = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  const textNorm = _stripDiacritics(responseText);
+  const userNorm = _stripDiacritics(userMessage || '');
+
+  // Gate de intención: sin fermento en juego, no corremos (anti-falso-positivo).
+  if (!_touchesFermento(textNorm, userNorm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Idempotencia: si la frase segura ya está anexada, no re-dispara.
+  if (textNorm.includes(_stripDiacritics('un fermento es un alimento, no un medicamento'))) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // ¿Hay un claim de salud en el texto? Buscamos los términos prohibidos.
+  const hits = [];
+  for (const claim of HEALTH_CLAIM_TERMS) {
+    if (textNorm.includes(claim)) hits.push(claim);
+  }
+  if (hits.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('fermentoHealthClaim');
+  const text = `${responseText.trim()}\n\n${FERMENTO_HEALTH_REDIRECT}`;
+  return {
+    text,
+    modified: true,
+    reason: `claim_salud_fermento: ${[...new Set(hits)].slice(0, 4).join(', ')}`,
+  };
+}
+
 /**
  * Set de guards que SOLO tienen sentido cuando la consulta es de SIEMBRA
  * (A12). Si la pregunta del usuario es de PRECIO/MERCADO (o info general sin
@@ -1983,6 +2139,16 @@ export function applyOutputGuards(
     text = nameRes.text;
     modified = true;
     if (nameRes.reason) reasons.push(nameRes.reason);
+  }
+  // Guard de claims de salud sobre fermentos (DR-FOOD-3, SAFETY): firma propia
+  // (necesita userMessage para el gate de intención-fermento). Corre SIEMPRE
+  // (no es guard de siembra) pero solo actúa si la respuesta/pregunta tocan un
+  // fermento. Fail-safe: ante un claim de salud, redirige a la frase segura.
+  const fermRes = guardFermentoHealthClaim(text, { userMessage });
+  if (fermRes && fermRes.modified) {
+    text = fermRes.text;
+    modified = true;
+    if (fermRes.reason) reasons.push(fermRes.reason);
   }
   return { text, modified, reasons };
 }


### PR DESCRIPTION
## Guard de salida fail-safe — claims de salud de fermentos (DR-FOOD-3)

Capa 2 de defensa-en-profundidad (guard de salida del PWA), complemento del pre-filtro del sidecar (chagra-pro). **SAFETY-CRITICAL.** Este guard **solo puede hacer al agente MAS conservador**: ante un claim de salud sobre un fermento, redirige a la frase segura del catalogo. Nunca habilita un consejo riesgoso.

### Que hace `guardFermentoHealthClaim`
- Detecta claims de salud (diagnostico/curativo/preventivo/desintoxicante) sobre **fermentos** en la salida del LLM y anexa la frase segura del consolidado §3.3: *"un fermento es un alimento, no un medicamento; ante sintomas, visite el puesto de salud de la vereda"*.
- **Gating por intencion-fermento (anti-falso-positivo)**: NO corre en queries no-fermento. Un verbo de salud por si solo no dispara — requiere un fermento en juego (en la respuesta o en la pregunta). Idempotente. Telemetria local.
- Cableado en `applyOutputGuards` como guard de **SAFETY** (corre siempre, gated por intencion), fuera de `GUARD_CHAIN` (firma propia con `userMessage`).
- La autoridad de la advertencia es la **pauta institucional** (alimento != medicamento, marco INVIMA/Res. 810/2021), **nunca un nombre propio**.

### Tests (10 nuevos)
claim redirigido (kombucha/guarapo/masato/chicha) · gate por la pregunta · **anti-falso-positivo** (claim de salud sin fermento, fermento sin claim, query de precio) · idempotencia · integracion en el pipeline completo.

**137/137 verdes** en la familia `outputGuards`. `eslint` limpio. Sin secretos ni refs de infra (pure client-side).

> Fuente de verdad (repo privado): `Chagra-strategy/deepresearch/DR-FOOD-3-CONSOLIDADO-2026-06-02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)