### PR TITLE
fix(rag): paralelizar loadCorpus + pre-warm — agente colgaba 3min/query en prod

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
 import SyncProgressIndicator from './components/common/SyncProgressIndicator';
 import useOllamaWarmStore from './store/useOllamaWarmStore';
+import { prewarmCorpus } from './services/ragRetriever';
 import useThemeBackgroundStore, { getBackgroundSrc } from './store/useThemeBackgroundStore';
 import useAlertStore from './store/useAlertStore';
 import { alertEngine } from './services/alertEngine';
@@ -485,6 +486,12 @@ export default function App() {
     if (status === 'unknown') {
       startWarmup();
     }
+    // Hotfix prod-down 2026-06-02: pre-cargar el corpus RAG al llegar al
+    // dashboard (fallback al pre-warm de LoginScreen/OAuthCallback, cubre el
+    // refresh-con-sesión-persistida que arranca directo al dashboard sin
+    // re-login). prewarmCorpus es idempotente: si el corpus ya está cacheado o
+    // cargándose, no dispara trabajo extra. Fire-and-forget, no bloqueante.
+    prewarmCorpus();
   }, [currentView]);
 
   // 2026-05-18 (operator request): la imagen de fondo agroecológica de

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -8,6 +8,7 @@ import ChagraGrowLoader from './ChagraGrowLoader';
 import LegalLinks from './LegalLinks';
 import WelcomeStatsHero from './WelcomeStatsHero';
 import useOllamaWarmStore from '../store/useOllamaWarmStore';
+import { prewarmCorpus } from '../services/ragRetriever';
 import useThemeBackgroundStore, { getBackgroundSrc } from '../store/useThemeBackgroundStore';
 
 export default function LoginScreen({ onLoginSuccess, onSave }) {
@@ -82,6 +83,16 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
       } catch (err) {
         // No bloquear login si falla (ej. tests sin fetch global).
         console.warn('[LoginScreen] ollama warm-up dispatch failed:', err);
+      }
+      // Hotfix prod-down 2026-06-02: pre-cargar el corpus RAG en background
+      // junto al warm-up de Ollama. Antes, loadCorpus() corría serial al
+      // disparar la PRIMERA query (incluido un saludo) y colgaba ~3min. Pre-
+      // cargándolo acá (fire-and-forget, no bloqueante) el corpus queda
+      // cacheado durante el tiempo humano login→dashboard→agente.
+      try {
+        prewarmCorpus();
+      } catch (err) {
+        console.warn('[LoginScreen] corpus pre-warm dispatch failed:', err);
       }
       setLoading(false);
       onLoginSuccess();

--- a/src/components/OAuthCallback.jsx
+++ b/src/components/OAuthCallback.jsx
@@ -4,6 +4,7 @@ import { handleOAuthCallback } from '../services/authService';
 import { setCurrentOperator } from '../services/operatorIdentityService';
 import { setActiveTenantId } from '../services/tenantContext';
 import useOllamaWarmStore from '../store/useOllamaWarmStore';
+import { prewarmCorpus } from '../services/ragRetriever';
 import ChagraGrowLoader from './ChagraGrowLoader';
 
 /**
@@ -68,6 +69,13 @@ export default function OAuthCallback({ onSuccess, onError }) {
           useOllamaWarmStore.getState().startWarmup();
         } catch (err) {
           console.warn('[OAuthCallback] ollama warm-up dispatch failed:', err);
+        }
+        // Hotfix prod-down 2026-06-02: pre-cargar el corpus RAG en background
+        // junto al warm-up de Ollama (ver LoginScreen). Fire-and-forget.
+        try {
+          prewarmCorpus();
+        } catch (err) {
+          console.warn('[OAuthCallback] corpus pre-warm dispatch failed:', err);
         }
         // Limpiar los params OAuth de la URL para que un refresh no reintente
         // el intercambio con un code ya consumido (one-time use).

--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -233,3 +233,134 @@ describe('ragRetriever — pre-tokenize perf fix', () => {
     expect(stats.avgDocLen).toBeGreaterThan(0);
   });
 });
+
+/**
+ * Cobertura del HOTFIX prod-down 2026-06-02: loadCorpus paralelo-acotado.
+ *
+ * El bug: loadCorpus hacía `for (const slug) { await fetch }` SERIAL sobre los
+ * ~491 slugs del manifest → la PRIMERA query de cada sesión (incluido un
+ * saludo) colgaba ~3min porque cada fetch esperaba al anterior. El chat nunca
+ * respondía en prod.
+ *
+ * El fix dispara los fetches en lotes con concurrencia acotada
+ * (CORPUS_FETCH_CONCURRENCY = 12). Estos tests verifican empíricamente:
+ *   - loadCorpus COMPLETA (no cuelga) con un corpus grande (>concurrency).
+ *   - El fetch NO es estrictamente secuencial — hay >1 request en vuelo a la vez.
+ *   - El nivel de concurrencia NO excede el límite (no abre 491 sockets juntos).
+ *   - prewarmCorpus() deja el corpus listo (cacheado) para que retrieve sea
+ *     instantáneo después, y nunca lanza aunque la carga falle.
+ */
+describe('ragRetriever — loadCorpus paralelo-acotado (hotfix prod-down 2026-06-02)', () => {
+  const CONCURRENCY_LIMIT = 12;
+
+  // Manifest grande para ejercitar varios lotes (3 lotes de 12 + resto).
+  function makeBigManifest(n) {
+    return { generated_at: '2026-06-02T00:00:00Z', slugs: Array.from({ length: n }, (_, i) => `sp_${i}`) };
+  }
+
+  // Mock de fetch con timing controlado: cada fetch de doc se resuelve tras un
+  // tick, permitiendo que múltiples queden en vuelo simultáneamente. Trackea el
+  // pico de concurrencia para asertar paralelismo acotado.
+  function setupConcurrencyFetchMock(manifest) {
+    const tracker = { inFlight: 0, peak: 0, docFetches: 0 };
+    globalThis.fetch = vi.fn((url) => {
+      const u = String(url);
+      if (u.endsWith('/cycle-content/manifest.json')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+          json: () => Promise.resolve(manifest),
+        });
+      }
+      const match = u.match(/\/cycle-content\/(sp_\d+)\.json/);
+      if (match) {
+        tracker.docFetches += 1;
+        tracker.inFlight += 1;
+        tracker.peak = Math.max(tracker.peak, tracker.inFlight);
+        const slug = match[1];
+        const doc = {
+          species_slug: slug,
+          valor_pedagogico: `Documento sintético ${slug} para verificar carga paralela del corpus con suficiente texto indexable por BM25 en el retriever.`,
+        };
+        // Resolver en un macrotask para que varios fetches coexistan en vuelo.
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            tracker.inFlight -= 1;
+            resolve({
+              ok: true,
+              status: 200,
+              headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+              json: () => Promise.resolve(doc),
+            });
+          }, 5);
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, headers: { get: () => '' } });
+    });
+    return tracker;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete globalThis.fetch;
+    vi.clearAllMocks();
+  });
+
+  it('loadCorpus completa con corpus grande y NO es estrictamente secuencial (peak concurrency > 1)', async () => {
+    const N = 40; // > CONCURRENCY_LIMIT → varios lotes
+    const tracker = setupConcurrencyFetchMock(makeBigManifest(N));
+    const { retrieve, getCorpusStats } = await import('../ragRetriever.js');
+
+    // Fuerza la carga del corpus completo. Si fuera serial-bloqueante, esto
+    // tomaría N×delay; con batches corre en ceil(N/12) barreras.
+    await retrieve('documento sintético corpus indexable', 5);
+
+    const stats = await getCorpusStats();
+    expect(stats.totalDocs).toBe(N); // los N docs se cargaron (corpus completo)
+    expect(tracker.docFetches).toBe(N); // un fetch por slug, sin duplicar
+    // La prueba central del fix: hubo MÁS DE UN fetch en vuelo a la vez.
+    // En el código serial viejo, peak sería exactamente 1.
+    expect(tracker.peak).toBeGreaterThan(1);
+  });
+
+  it('respeta el límite de concurrencia — peak nunca excede CORPUS_FETCH_CONCURRENCY', async () => {
+    const N = 50;
+    const tracker = setupConcurrencyFetchMock(makeBigManifest(N));
+    const { retrieve } = await import('../ragRetriever.js');
+    await retrieve('documento sintético corpus indexable', 5);
+    // Con batches de 12, jamás debe haber 13+ requests simultáneos. Esto evita
+    // abrir 491 sockets juntos contra el server / saturar la red móvil rural.
+    expect(tracker.peak).toBeLessThanOrEqual(CONCURRENCY_LIMIT);
+    // Y debe haber alcanzado el techo (o casi), confirmando que SÍ paraleliza
+    // hasta el límite y no se queda en concurrencia 1-2.
+    expect(tracker.peak).toBeGreaterThanOrEqual(2);
+  });
+
+  it('prewarmCorpus() deja el corpus cacheado y no relanza fetches en el primer retrieve', async () => {
+    const N = 20;
+    const tracker = setupConcurrencyFetchMock(makeBigManifest(N));
+    const { prewarmCorpus, retrieve } = await import('../ragRetriever.js');
+
+    await prewarmCorpus();
+    const fetchesAfterPrewarm = tracker.docFetches;
+    expect(fetchesAfterPrewarm).toBe(N); // pre-warm cargó todo
+
+    // Tras el pre-warm, retrieve usa corpusCache: NO debe disparar más fetches
+    // de docs (el corpus ya está caliente). Esto es lo que en prod elimina el
+    // cuelgue de la primera query.
+    const hits = await retrieve('documento sintético corpus indexable', 5);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(tracker.docFetches).toBe(fetchesAfterPrewarm); // sin fetches nuevos
+  });
+
+  it('prewarmCorpus() nunca lanza aunque el manifest/fetch falle', async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('red caída')));
+    const { prewarmCorpus } = await import('../ragRetriever.js');
+    // No debe rechazar: el pre-warm es fire-and-forget y degrada en silencio.
+    await expect(prewarmCorpus()).resolves.toBeUndefined();
+  });
+});

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -11,6 +11,23 @@ const BM25_PARAMS = {
 let corpusCache = null;
 let avgDocLen = 0;
 
+// Promesa en vuelo de loadCorpus(). Sin esto, dos callers concurrentes
+// (ej. pre-warm fire-and-forget + primera query del usuario que llega antes
+// de que el pre-warm complete) dispararían DOS cargas completas del corpus en
+// paralelo — 2× los fetches de ~491 docs. Coalescemos: si ya hay una carga en
+// vuelo, todos los callers esperan la misma promesa.
+let corpusLoadPromise = null;
+
+// Concurrencia del prefetch de docs del corpus. El bug de prod (2026-06-02):
+// loadCorpus hacía `for (const slug) { await fetch }` SERIAL sobre los ~491
+// slugs del manifest → ~491 × ~390ms = ~3.2min bloqueando la primera query de
+// cada sesión (incluido un simple saludo), y el chat nunca respondía. Con
+// batches acotados de 12, los fetches corren en paralelo de a 12 → ~15-20s.
+// El límite evita saturar la conexión móvil rural o gatillar throttling del
+// servidor (no queremos 491 sockets simultáneos). La lógica per-doc
+// (flattenDoc + pre-tokenize) se conserva idéntica; solo cambia serial→batch.
+const CORPUS_FETCH_CONCURRENCY = 12;
+
 function tokenize(text) {
   if (!text || typeof text !== 'string') return [];
   return text
@@ -115,9 +132,48 @@ async function loadManifest() {
   }
 }
 
-async function loadCorpus() {
-  if (corpusCache) return corpusCache;
+/**
+ * Carga UN slug del corpus y devuelve sus passages pre-tokenizados.
+ *
+ * Extraído del loop de loadCorpus sin cambiar la lógica per-doc: mismo
+ * content-type guard, mismo flattenDoc, mismo pre-tokenize (tokenized /
+ * termCounts / docLen). Se separa solo para poder dispararlo en paralelo
+ * acotado (ver loadCorpus). Devuelve [] ante 404, no-json o error de red
+ * (degradación silenciosa: un doc faltante no debe tumbar el corpus entero).
+ */
+async function loadSlugDocs(slug) {
+  try {
+    const res = await fetch(`${CORPUS_PATH}${slug}.json`);
+    if (!res.ok) return [];
+    const ct = res.headers.get('content-type') || '';
+    if (!ct.includes('json')) return [];
+    const data = await res.json();
+    const passages = flattenDoc(data);
+    passages.forEach((p) => {
+      // Pre-tokenize cada passage una sola vez en carga del corpus.
+      // Trade-off de memoria: ~2-5MB extra para 10K docs con ~50 tokens promedio
+      // (tokenized[] + termCounts Map). Aceptable a cambio de evitar re-tokenizar
+      // 5K-15K docs × cada query (que bloqueaba el main thread 500ms-2s y
+      // generaba la latencia post-voz que motivó ese fix).
+      const tokenized = tokenize(p.text);
+      const termCounts = new Map();
+      tokenized.forEach((t) => termCounts.set(t, (termCounts.get(t) || 0) + 1));
+      p.tokenized = tokenized;
+      p.termCounts = termCounts;
+      p.docLen = tokenized.length;
+    });
+    return passages;
+  } catch (e) {
+    console.warn(`[RAG] Failed to load ${slug}:`, e);
+    return [];
+  }
+}
 
+/**
+ * Implementación real de la carga del corpus. NO llamar directo — usar
+ * loadCorpus(), que coalesce llamadas concurrentes en una sola promesa.
+ */
+async function buildCorpus() {
   // Manifest first: si existe, itera solo los slugs presentes.
   // Fallback: iterar CROP_TAXONOMY (legacy, con N-3 fetches fallidos).
   const manifestSlugs = await loadManifest();
@@ -126,31 +182,18 @@ async function loadCorpus() {
   );
   const docs = [];
 
-  for (const slug of species) {
-    try {
-      const res = await fetch(`${CORPUS_PATH}${slug}.json`);
-      if (!res.ok) continue;
-      const ct = res.headers.get('content-type') || '';
-      if (!ct.includes('json')) continue;
-      const data = await res.json();
-      const passages = flattenDoc(data);
-      passages.forEach((p) => {
-        // Pre-tokenize cada passage una sola vez en carga del corpus.
-        // Trade-off de memoria: ~2-5MB extra para 10K docs con ~50 tokens promedio
-        // (tokenized[] + termCounts Map). Aceptable a cambio de evitar re-tokenizar
-        // 5K-15K docs × cada query (que bloqueaba el main thread 500ms-2s y
-        // generaba la latencia post-voz que motivó este fix).
-        const tokenized = tokenize(p.text);
-        const termCounts = new Map();
-        tokenized.forEach((t) => termCounts.set(t, (termCounts.get(t) || 0) + 1));
-        p.tokenized = tokenized;
-        p.termCounts = termCounts;
-        p.docLen = tokenized.length;
-        docs.push(p);
-      });
-    } catch (e) {
-      console.warn(`[RAG] Failed to load ${slug}:`, e);
-    }
+  // Prefetch PARALELO-ACOTADO: en vez del loop serial que bloqueaba ~3min la
+  // primera query (491 fetches secuenciales), procesamos los slugs en lotes de
+  // CORPUS_FETCH_CONCURRENCY. Dentro de cada lote los fetches corren en
+  // paralelo (Promise.all); entre lotes hay una barrera, así nunca hay más de
+  // `CORPUS_FETCH_CONCURRENCY` requests en vuelo a la vez. El orden de inserción
+  // de docs es estable lote-a-lote, lo que mantiene determinístico el retrieve.
+  for (let i = 0; i < species.length; i += CORPUS_FETCH_CONCURRENCY) {
+    const batch = species.slice(i, i + CORPUS_FETCH_CONCURRENCY);
+    const batchResults = await Promise.all(batch.map((slug) => loadSlugDocs(slug)));
+    batchResults.forEach((passages) => {
+      passages.forEach((p) => docs.push(p));
+    });
   }
 
   const totalLen = docs.reduce((sum, d) => sum + d.docLen, 0);
@@ -160,6 +203,40 @@ async function loadCorpus() {
   const idf = computeIDF(df, docs.length);
   corpusCache = { docs, idf };
   return corpusCache;
+}
+
+async function loadCorpus() {
+  if (corpusCache) return corpusCache;
+  // Coalesce: si ya hay una carga en vuelo (ej. pre-warm), reusala en vez de
+  // arrancar una segunda. Limpiamos la promesa al fallar para permitir reintento.
+  if (!corpusLoadPromise) {
+    corpusLoadPromise = buildCorpus().catch((err) => {
+      corpusLoadPromise = null;
+      throw err;
+    });
+  }
+  return corpusLoadPromise;
+}
+
+/**
+ * Pre-carga el corpus en background (fire-and-forget). Pensado para llamarse
+ * al login / post-OAuth, junto al pre-warm de Ollama, de modo que el corpus
+ * esté cacheado en `corpusCache` ANTES de la primera query del usuario.
+ *
+ * NO bloqueante y nunca lanza: si la carga falla, el primer `retrieve()` real
+ * reintentará (loadCorpus limpia la promesa fallida). Idempotente: si el
+ * corpus ya está cacheado o cargándose, no dispara trabajo extra.
+ *
+ * @returns {Promise<void>} resuelve cuando el pre-warm termina (callers la
+ *   ignoran; existe para tests).
+ */
+export function prewarmCorpus() {
+  return loadCorpus().then(
+    () => undefined,
+    (err) => {
+      console.warn('[RAG] prewarmCorpus falló (se reintentará en la primera query):', err?.message);
+    },
+  );
 }
 
 /**
@@ -260,4 +337,5 @@ export async function getCorpusStats() {
 export const RAG_SERVICE = {
   retrieve,
   getCorpusStats,
+  prewarmCorpus,
 };


### PR DESCRIPTION
## HOTFIX prod-down

El agente IA de Chagra colgaba **~3min en la PRIMERA query de cada sesión** (incluido un simple saludo). Causa raíz 100% frontend: `src/services/ragRetriever.js` `loadCorpus()` hacía un loop **SERIAL** `for (const slug) { await fetch }` sobre los ~491 slugs del manifest de cycle-content. 491 × ~390ms = ~3.2min bloqueando, y el chat nunca respondía.

**Evidencia E2E (Playwright contra chagra.guatoc.co):** "di hola" / query simple → input nunca se re-habilita, 150s+ en "PENSANDO…", 491 fetches seriales a `/cycle-content/<slug>.json`. Backend sano (sidecar `/health` ok, chat proxy 200 en 3.4s).

## Fix (mínimo, conserva la función)

1. **Prefetch paralelo-acotado**: batches de 12 fetches concurrentes (`CORPUS_FETCH_CONCURRENCY`) en vez de serial. ~3.2min → ~15-20s. La lógica per-doc (`flattenDoc` + pre-tokenize `tokenized`/`termCounts`/`docLen`) se conserva **idéntica**; solo cambia serial→batch. Orden de inserción estable → retrieve sigue determinístico.
2. **`prewarmCorpus()` fire-and-forget**: pre-carga el corpus al login / OAuth callback / entrada al dashboard, junto al warm-up de Ollama (mismo punto NN4), para que el corpus esté cacheado **ANTES** de la primera query. No bloqueante, nunca lanza.
3. **Coalesce** de `loadCorpus()` concurrente en una sola promesa (evita doble carga si pre-warm y primera query se solapan).
4. `corpusCache`, algoritmo BM25 y API pública del módulo **sin cambios**.

## Tests
Nueva cobertura en `ragRetriever.test.js`: verifica que `loadCorpus` completa con corpus grande, que el fetch es **paralelo** (peak concurrency > 1, no serial) y **acotado** (≤ 12), y que `prewarmCorpus` deja el corpus cacheado sin relanzar fetches. `npm run test:unit` (subset RAG + impactados) verde — 119 tests pass. `eslint --max-warnings=0` limpio.

## Verificación empírica
- **ANTES**: probe `diag-agent-turn.mjs` contra prod → input nunca se re-habilita en 150s, falla al screenshot tras ~3.5min. Agente NO responde.
- **DESPUÉS**: se re-corre el probe post-deploy (reportado en el comentario de merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)