### PR TITLE
fix(agent): NLU best-effort — degradar a chat directo cuando /nlu expira, subir timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.35",
+  "version": "1.0.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v293';
+const CACHE_NAME = 'chagra-v294';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -52,6 +52,7 @@ import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/st
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
 import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, postValidate, getClimaIdeam } from '../../services/sidecarClient';
+import { decideNluRouting, NLU_OUTCOME } from '../../services/agentNluBestEffort';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -1487,16 +1488,28 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
             }
           } else {
           // PASO 2b — NLU planner + tool call (flow original, sin chip).
+          //
+          // NLU es BEST-EFFORT (bug prod 2026-06-02): `planNlu` puede devolver
+          // null por timeout (~14s sobre el prefill ~9.5s del planner), 5xx, red
+          // caída o flag/offline. La decisión de routing se centraliza en
+          // `decideNluRouting` (función pura, testeable mockeando el sidecar) con
+          // un invariante duro: `proceedToChat` es SIEMPRE true. Pase lo que pase
+          // con /nlu, el `callLLM` de abajo corre igual con el grounding que ya
+          // tenemos (resolve-entities + system prompt + guardas); el planner solo
+          // AGREGA routing de tools cuando responde a tiempo, nunca bloquea el
+          // turno. El deadline de 60s del chat se arma DENTRO de callLLM, DESPUÉS
+          // de esto → un /nlu lento jamás se come ese presupuesto.
           const tNlu0 = performance.now();
           const plan = await planNlu(textForLLM, contextMemory);
           const tNlu1 = performance.now();
-          // D2 (#246) — modo cadena: si el sidecar devolvió `tool_chain`
-          // (array no vacío), ejecutamos cada paso en orden y usamos el
-          // array de evidences como toolEvidence. El formatter y el
-          // computeSourceMetadata ya soportan arrays.
-          if (plan?.useTool && Array.isArray(plan.toolChain) && plan.toolChain.length > 0) {
+          const nluLatency = Math.round(tNlu1 - tNlu0);
+          const routing = decideNluRouting(plan);
+
+          // D2 (#246) — modo cadena: el planner pidió ejecutar varios tools en
+          // orden. El formatter y computeSourceMetadata ya soportan arrays.
+          if (routing.outcome === NLU_OUTCOME.TOOL_CHAIN) {
             const tTool0 = performance.now();
-            const chainEvidences = await executeToolChain(plan.toolChain);
+            const chainEvidences = await executeToolChain(routing.toolChain);
             const tTool1 = performance.now();
             const useful = chainEvidences.filter((ev) => ev && ev.result != null);
             if (useful.length > 0) {
@@ -1506,37 +1519,48 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
               })();
               console.debug('[sidecar]', {
                 chain: useful.map((e) => e.tool),
-                latencyNlu: Math.round(tNlu1 - tNlu0),
+                latencyNlu: nluLatency,
                 latencyChain: Math.round(tTool1 - tTool0),
                 toolEvidenceBytes: evidenceBytes,
               });
             } else {
               console.debug('[sidecar] tool_chain todos null', {
-                latencyNlu: Math.round(tNlu1 - tNlu0),
+                latencyNlu: nluLatency,
                 latencyChain: Math.round(tTool1 - tTool0),
               });
             }
-          } else if (plan?.useTool && plan.tool && plan.args) {
+          } else if (routing.outcome === NLU_OUTCOME.SINGLE_TOOL) {
             const tTool0 = performance.now();
-            const result = await callTool(plan.tool, plan.args);
+            const result = await callTool(routing.tool, routing.args);
             const tTool1 = performance.now();
             if (result) {
-              toolEvidence = { tool: plan.tool, args: plan.args, result };
+              toolEvidence = { tool: routing.tool, args: routing.args, result };
               const evidenceBytes = (() => {
                 try { return JSON.stringify(result).length; } catch (_) { return 0; }
               })();
               console.debug('[sidecar]', {
-                tool: plan.tool,
-                latencyNlu: Math.round(tNlu1 - tNlu0),
+                tool: routing.tool,
+                latencyNlu: nluLatency,
                 latencyTool: Math.round(tTool1 - tTool0),
                 toolEvidenceBytes: evidenceBytes,
               });
             }
-          } else if (plan) {
+          } else if (routing.degraded) {
+            // NLU null (timeout/5xx/red/flag-off). NO es error del turno: el
+            // planner es opcional. Logueamos EXPLÍCITAMENTE el degrade para que el
+            // operador vea en telemetría que el turno NO murió — cayó a chat
+            // grounded directo. Antes este caso era un fall-through silencioso,
+            // indistinguible de "no_tool", y enmascaraba por qué una query agro
+            // tardaba sin routing.
+            console.debug('[sidecar] NLU null (timeout/fail) — degrado a chat directo', {
+              latencyNlu: nluLatency,
+            });
+          } else {
+            // El planner respondió OK pero decidió no usar tool. Chat directo.
             console.debug('[sidecar]', {
               tool: null,
-              latencyNlu: Math.round(tNlu1 - tNlu0),
-              reason: plan.reason || 'no_tool',
+              latencyNlu: nluLatency,
+              reason: routing.reason || 'no_tool',
             });
           }
           }

--- a/src/services/__tests__/agentNluBestEffort.test.js
+++ b/src/services/__tests__/agentNluBestEffort.test.js
@@ -1,0 +1,190 @@
+/**
+ * agentNluBestEffort.test.js — robustez del routing NLU best-effort del agente.
+ *
+ * Bug prod 2026-06-02: el planner `/nlu` tiene un prefill de ~9.5s; con el
+ * timeout viejo de 10s abortaba justo en el borde en queries agro legítimas y
+ * `planNlu` devolvía null. El caso null era un fall-through silencioso en el
+ * AgentScreen, dando la impresión de que el turno "moría" (a veces hasta el
+ * deadline de 60s, 0 burbujas).
+ *
+ * Estos tests verifican el INVARIANTE central del fix: NLU es opcional, su
+ * ausencia degrada a "chat grounded directo" pero NUNCA bloquea el turno
+ * (`proceedToChat` siempre true). Se mockea el sidecar (`planNlu`) para
+ * recorrer:
+ *   (a) /nlu timeout/fail (planNlu→null) → outcome 'degraded', proceedToChat true.
+ *   (b) /nlu OK con tool → routing normal (single_tool / tool_chain).
+ *   (c) /nlu OK sin tool → 'no_tool', chat directo (no marcado como degradado).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { decideNluRouting, NLU_OUTCOME } from '../agentNluBestEffort.js';
+
+describe('decideNluRouting — invariante best-effort', () => {
+  it('proceedToChat es SIEMPRE true, pase lo que pase con /nlu', () => {
+    const inputs = [
+      null,
+      undefined,
+      'no-soy-un-objeto',
+      42,
+      {},
+      { useTool: false },
+      { useTool: true, tool: 'get_species', args: { id_or_name: 'maracuya' } },
+      { useTool: true, toolChain: [{ tool: 'get_species', args: {} }] },
+    ];
+    for (const plan of inputs) {
+      expect(decideNluRouting(plan).proceedToChat).toBe(true);
+    }
+  });
+});
+
+describe('decideNluRouting — (a) /nlu timeout/fail → chat directo, NO muere el turno', () => {
+  it('plan === null (timeout sobre el prefill) → outcome degraded, sin tool, chat directo', () => {
+    const r = decideNluRouting(null);
+    expect(r.outcome).toBe(NLU_OUTCOME.DEGRADED);
+    expect(r.degraded).toBe(true);
+    expect(r.proceedToChat).toBe(true);
+    expect(r.toolChain).toBeNull();
+    expect(r.tool).toBeNull();
+    expect(r.args).toBeNull();
+  });
+
+  it('plan undefined / no-objeto → mismo degrade graceful', () => {
+    for (const bad of [undefined, 'x', 7, true, NaN]) {
+      const r = decideNluRouting(bad);
+      expect(r.outcome).toBe(NLU_OUTCOME.DEGRADED);
+      expect(r.degraded).toBe(true);
+      expect(r.proceedToChat).toBe(true);
+    }
+  });
+});
+
+describe('decideNluRouting — (b) /nlu OK con tool → routing normal', () => {
+  it('useTool + tool + args → single_tool (NO degradado)', () => {
+    const plan = { useTool: true, tool: 'get_species', args: { id_or_name: 'maracuya' }, reason: null };
+    const r = decideNluRouting(plan);
+    expect(r.outcome).toBe(NLU_OUTCOME.SINGLE_TOOL);
+    expect(r.degraded).toBe(false);
+    expect(r.proceedToChat).toBe(true);
+    expect(r.tool).toBe('get_species');
+    expect(r.args).toEqual({ id_or_name: 'maracuya' });
+    expect(r.toolChain).toBeNull();
+  });
+
+  it('useTool + toolChain no vacío → tool_chain (NO degradado)', () => {
+    const chain = [
+      { tool: 'get_species', args: { id_or_name: 'maiz' } },
+      { tool: 'get_companions', args: { species_id: 'maiz' } },
+    ];
+    const plan = { useTool: true, toolChain: chain };
+    const r = decideNluRouting(plan);
+    expect(r.outcome).toBe(NLU_OUTCOME.TOOL_CHAIN);
+    expect(r.degraded).toBe(false);
+    expect(r.toolChain).toEqual(chain);
+    expect(r.tool).toBeNull();
+  });
+
+  it('toolChain tiene prioridad sobre tool simple cuando ambos vienen', () => {
+    const plan = {
+      useTool: true,
+      tool: 'get_species',
+      args: { id_or_name: 'x' },
+      toolChain: [{ tool: 'get_companions', args: {} }],
+    };
+    expect(decideNluRouting(plan).outcome).toBe(NLU_OUTCOME.TOOL_CHAIN);
+  });
+});
+
+describe('decideNluRouting — (c) /nlu OK sin tool → chat directo, no degradado', () => {
+  it('useTool=false → no_tool, chat directo, degraded=false', () => {
+    const plan = { useTool: false, reason: 'low_confidence' };
+    const r = decideNluRouting(plan);
+    expect(r.outcome).toBe(NLU_OUTCOME.NO_TOOL);
+    expect(r.degraded).toBe(false);
+    expect(r.proceedToChat).toBe(true);
+    expect(r.reason).toBe('low_confidence');
+  });
+
+  it('useTool=true pero sin args utilizables → no_tool (no rompe, chat directo)', () => {
+    const plan = { useTool: true, tool: 'get_species', args: null };
+    const r = decideNluRouting(plan);
+    expect(r.outcome).toBe(NLU_OUTCOME.NO_TOOL);
+    expect(r.proceedToChat).toBe(true);
+  });
+
+  it('toolChain vacío [] NO se trata como cadena → no_tool', () => {
+    const plan = { useTool: true, toolChain: [] };
+    expect(decideNluRouting(plan).outcome).toBe(NLU_OUTCOME.NO_TOOL);
+  });
+});
+
+/**
+ * Integración con el sidecar real (mockeado): demuestra el flujo end-to-end de
+ * la decisión partiendo del CONTRATO de `planNlu`. Esto ata la robustez al
+ * comportamiento observable del cliente, no solo a la función pura.
+ */
+describe('integración con planNlu mockeado — el turno SIEMPRE puede seguir a chat', () => {
+  const ENV_FLAG = 'VITE_USE_SIDECAR_AGRO_MCP';
+  const ENV_URL = 'VITE_SIDECAR_URL';
+  const ENV_TOKEN = 'VITE_CHAGRA_MCP_TOKEN';
+  let fetchMock;
+  let originalOnLine;
+
+  const importSidecar = async () => {
+    vi.resetModules();
+    return import('../sidecarClient.js');
+  };
+
+  beforeEach(() => {
+    vi.stubEnv(ENV_FLAG, 'true');
+    vi.stubEnv(ENV_URL, '/api/mcp/agro');
+    vi.stubEnv(ENV_TOKEN, 'test-token');
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+    originalOnLine = navigator.onLine;
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: originalOnLine });
+  });
+
+  it('/nlu AbortError (timeout) → planNlu null → decideNluRouting degrada a chat directo', async () => {
+    fetchMock.mockImplementationOnce(() => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      return Promise.reject(err);
+    });
+    const { planNlu } = await importSidecar();
+    const plan = await planNlu('cómo combato la broca del café');
+    expect(plan).toBeNull(); // contrato: timeout → null sin throw.
+    const routing = decideNluRouting(plan);
+    expect(routing.degraded).toBe(true);
+    expect(routing.proceedToChat).toBe(true); // el turno NO muere: sigue a chat.
+  });
+
+  it('/nlu 200 con tool → planNlu parsea → decideNluRouting rutea single_tool', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        use_tool: true,
+        tool: 'get_species',
+        args: { id_or_name: 'maracuya' },
+      }),
+    });
+    const { planNlu } = await importSidecar();
+    const plan = await planNlu('contame de la maracuyá');
+    const routing = decideNluRouting(plan);
+    expect(routing.outcome).toBe(NLU_OUTCOME.SINGLE_TOOL);
+    expect(routing.tool).toBe('get_species');
+    expect(routing.proceedToChat).toBe(true);
+  });
+
+  it('/nlu 503 (sidecar down) → planNlu null → degrade graceful', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) });
+    const { planNlu } = await importSidecar();
+    const plan = await planNlu('test');
+    expect(plan).toBeNull();
+    expect(decideNluRouting(plan).proceedToChat).toBe(true);
+  });
+});

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -246,6 +246,72 @@ describe('sidecarClient — feature flag on', () => {
     });
   });
 
+  describe('timeouts por endpoint (robustez NLU best-effort)', () => {
+    // Bug prod 2026-06-02: el planner `/nlu` tiene un prefill conocido de ~9.5s.
+    // Con el timeout viejo de 10s abortaba justo en el borde en queries agro
+    // legítimas, perdiendo el routing de tools y dejando al operador con un
+    // stall de 10s antes del chat. Subimos `/nlu` a 14s (margen sobre el
+    // prefill). El resto de RPCs del sidecar (resolve-entities, post-validate)
+    // y el fermento-prefilter quedan en 10s; los tools en 5s.
+    it('constantes expuestas: /nlu 14s > RPC 10s > tools 5s', async () => {
+      const { __TEST__ } = await importFresh();
+      expect(__TEST__.NLU_TIMEOUT_MS).toBe(14000);
+      expect(__TEST__.SIDECAR_RPC_TIMEOUT_MS).toBe(10000);
+      expect(__TEST__.TOOL_TIMEOUT_MS).toBe(5000);
+      // El planner DEBE tener más budget que el resto de RPCs (sobre el prefill).
+      expect(__TEST__.NLU_TIMEOUT_MS).toBeGreaterThan(__TEST__.SIDECAR_RPC_TIMEOUT_MS);
+    });
+
+    it('planNlu arma el AbortController con 14000ms (sobre el prefill ~9.5s)', async () => {
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { use_tool: false }));
+      const { planNlu } = await importFresh();
+      await planNlu('contame de la maracuyá');
+      // El primer setTimeout que arma postJson es el del abort del fetch.
+      const abortDelays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+      expect(abortDelays).toContain(14000);
+      expect(abortDelays).not.toContain(10000);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('resolveEntities arma el AbortController con 10000ms (no hereda el budget del planner)', async () => {
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { entities: [] }));
+      const { resolveEntities } = await importFresh();
+      await resolveEntities('aguacate');
+      const abortDelays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+      expect(abortDelays).toContain(10000);
+      expect(abortDelays).not.toContain(14000);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('postValidate arma el AbortController con 10000ms', async () => {
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+        hallucinated: [], validated: [], suspect: [], age_available: true, detected_count: 0,
+      }));
+      const { postValidate } = await importFresh();
+      await postValidate('La gulupa es Passiflora ligularis.', ['Passiflora ligularis']);
+      const abortDelays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+      expect(abortDelays).toContain(10000);
+      expect(abortDelays).not.toContain(14000);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('planNlu timeout (AbortError tras el budget) → null sin throw (best-effort)', async () => {
+      // Aunque subimos el budget, el contrato sigue siendo T|null: si el planner
+      // NO responde a tiempo, planNlu degrada a null y el caller cae a chat directo.
+      fetchMock.mockImplementationOnce((_url, _opts) => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        return Promise.reject(err);
+      });
+      const { planNlu } = await importFresh();
+      const res = await planNlu('contame de la maracuyá');
+      expect(res).toBeNull();
+    });
+  });
+
   describe('callTool — happy path + whitelist', () => {
     it('200 con ficha species → devuelve el body tal cual', async () => {
       const ficha = {

--- a/src/services/agentNluBestEffort.js
+++ b/src/services/agentNluBestEffort.js
@@ -1,0 +1,117 @@
+/**
+ * agentNluBestEffort.js — Lógica pura del routing NLU "best-effort" del agente.
+ *
+ * Contexto (bug prod 2026-06-02): el planner `/nlu` del sidecar tiene un prefill
+ * conocido de ~9.5s. Con el timeout cliente viejo de 10s, una query agro legítima
+ * abortaba justo en el borde → `planNlu` devolvía null → se perdía el routing de
+ * herramientas. Peor: el caso `plan === null` era un fall-through SILENCIOSO en el
+ * AgentScreen, indistinguible de "el planner decidió no usar tool". Eso dificultaba
+ * diagnosticar y daba la impresión de que el turno "moría" sin razón.
+ *
+ * Este módulo concentra la DECISIÓN PURA de qué hacer con el resultado del planner,
+ * con un invariante duro: **el NLU es opcional. Su ausencia NUNCA bloquea el turno.**
+ * Pase lo que pase con `/nlu`, `proceedToChat` siempre es true — el AgentScreen sigue
+ * a `callLLM` con el grounding que ya tiene (resolve-entities + system prompt +
+ * guardas), solo SIN el routing de tools cuando el planner no respondió.
+ *
+ * Mantenerlo como función pura (sin React, sin red, sin DOM) lo hace testeable en
+ * vitest mockeando el sidecar, y deja el AgentScreen delgado y auditable.
+ */
+
+/**
+ * Outcomes posibles del routing del planner. Sirven para telemetría
+ * (`console.debug`) y para que el caller sepa qué ejecutar a continuación.
+ *
+ * - `tool_chain`  → el planner pidió una cadena de tools (ejecutar executeToolChain).
+ * - `single_tool` → el planner pidió un tool simple (ejecutar callTool).
+ * - `no_tool`     → el planner respondió OK pero decidió no usar tool (chat directo).
+ * - `degraded`    → el planner devolvió null (timeout/5xx/red/flag-off): chat directo.
+ *                   Es el caso que ANTES era silencioso. NO es un error del turno.
+ */
+export const NLU_OUTCOME = Object.freeze({
+  TOOL_CHAIN: 'tool_chain',
+  SINGLE_TOOL: 'single_tool',
+  NO_TOOL: 'no_tool',
+  DEGRADED: 'degraded',
+});
+
+/**
+ * Decide el routing a partir del resultado de `planNlu`.
+ *
+ * @param {null | {
+ *   useTool?: boolean,
+ *   tool?: string|null,
+ *   args?: object|null,
+ *   toolChain?: Array<{tool: string, args: object}>|null,
+ *   reason?: string|null,
+ * }} plan — el objeto que devuelve `planNlu` (o null en timeout/fail).
+ * @returns {{
+ *   outcome: 'tool_chain'|'single_tool'|'no_tool'|'degraded',
+ *   proceedToChat: true,
+ *   degraded: boolean,
+ *   toolChain: Array<{tool: string, args: object}>|null,
+ *   tool: string|null,
+ *   args: object|null,
+ *   reason: string|null,
+ * }}
+ *   `proceedToChat` es SIEMPRE true (invariante best-effort). `degraded` marca el
+ *   caso `plan === null` para que el caller lo loguee como "caí a chat directo"
+ *   (no como error). El resto de campos guían la ejecución de tools cuando aplica.
+ */
+export function decideNluRouting(plan) {
+  // Caso degradado: el planner no devolvió nada utilizable (timeout sobre el
+  // prefill ~9.5-14s, 5xx, red caída, flag off, offline). El turno NO muere:
+  // seguimos a chat grounded directo SIN routing de tools.
+  if (!plan || typeof plan !== 'object') {
+    return {
+      outcome: NLU_OUTCOME.DEGRADED,
+      proceedToChat: true,
+      degraded: true,
+      toolChain: null,
+      tool: null,
+      args: null,
+      reason: null,
+    };
+  }
+
+  // Modo cadena (D2 #246): el planner pidió ejecutar varios tools en orden.
+  if (plan.useTool && Array.isArray(plan.toolChain) && plan.toolChain.length > 0) {
+    return {
+      outcome: NLU_OUTCOME.TOOL_CHAIN,
+      proceedToChat: true,
+      degraded: false,
+      toolChain: plan.toolChain,
+      tool: null,
+      args: null,
+      reason: plan.reason || null,
+    };
+  }
+
+  // Modo simple: el planner pidió un único tool con args.
+  if (plan.useTool && plan.tool && plan.args) {
+    return {
+      outcome: NLU_OUTCOME.SINGLE_TOOL,
+      proceedToChat: true,
+      degraded: false,
+      toolChain: null,
+      tool: plan.tool,
+      args: plan.args,
+      reason: plan.reason || null,
+    };
+  }
+
+  // El planner respondió OK pero decidió no usar tool (o le faltaban tool/args).
+  // Chat directo, igual que el degradado, pero NO marcamos `degraded` porque el
+  // planner SÍ respondió a tiempo: es una decisión deliberada, no una falla.
+  return {
+    outcome: NLU_OUTCOME.NO_TOOL,
+    proceedToChat: true,
+    degraded: false,
+    toolChain: null,
+    tool: null,
+    args: null,
+    reason: plan.reason || 'no_tool',
+  };
+}
+
+export default decideNluRouting;

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -18,7 +18,13 @@
  *
  * Reglas operativas:
  * - Offline-first: si `!navigator.onLine` → null inmediato, no fetch.
- * - Timeout corto: NLU 10s, tools 5s (cap defensivo p99 sidecar).
+ * - Timeout por endpoint: `/nlu` 14s (el planner tiene un prefill conocido de
+ *   ~9.5s en prod — 10s lo abortaba justo en el borde en queries agro
+ *   legítimas, matando el routing de tools; 14s da margen sobre el prefill sin
+ *   colgar el turno: si igual expira, `planNlu` devuelve null y el caller
+ *   degrada a chat grounded directo). El resto de RPCs del sidecar
+ *   (`/resolve-entities`, `/post-validate`) quedan en 10s, y los tools en 5s
+ *   (cap defensivo p99 del sidecar).
  * - Falla silenciosa: en error/non-200/abort → null + console.debug.
  *   NUNCA throw — el caller espera contract `T | null`.
  * - Auth: header `X-Chagra-Token: ${VITE_CHAGRA_MCP_TOKEN}` siempre.
@@ -36,7 +42,21 @@
 
 import { buildSidecarHeaders } from './tierService.js';
 
-const NLU_TIMEOUT_MS = 10000;
+// Timeout del planner NLU (`POST /nlu`). El sidecar tiene un prefill conocido
+// de ~9.5s en prod (system prompt grande del planner). Con 10s, una query agro
+// legítima abortaba justo en el borde → planNlu null → se perdía el routing de
+// tools (y, peor, el operador percibía un stall de 10s antes de que arrancara
+// el chat). 14s deja margen sobre el prefill medido sin volverse un cuelgue: si
+// el planner igual no responde a tiempo, planNlu degrada a null y el AgentScreen
+// sigue a chat grounded directo (NLU es best-effort, su ausencia NO mata el
+// turno). NO subir mucho más: el chat real corre DESPUÉS de esto, así que cada
+// segundo acá es latencia percibida pura. SPEED-6 (comprimir el prompt del
+// planner en el sidecar) baja el prefill en origen — es el fix de raíz; este
+// timeout es la red de seguridad del lado PWA.
+const NLU_TIMEOUT_MS = 14000;
+// Timeout genérico para el resto de RPCs JSON del sidecar (/resolve-entities,
+// /post-validate). Más cortos que el planner: no cargan el prompt grande.
+const SIDECAR_RPC_TIMEOUT_MS = 10000;
 const TOOL_TIMEOUT_MS = 5000;
 
 /**
@@ -362,7 +382,7 @@ export async function resolveEntities(userMessage, opts = {}) {
   const body = { user_message: userMessage };
   const alt = opts && opts.fincaAltitud != null ? Number(opts.fincaAltitud) : NaN;
   if (Number.isFinite(alt)) body.finca_altitud = alt;
-  const raw = await postJson('/resolve-entities', body, NLU_TIMEOUT_MS);
+  const raw = await postJson('/resolve-entities', body, SIDECAR_RPC_TIMEOUT_MS);
   if (!raw || typeof raw !== 'object') return null;
   if (!Array.isArray(raw.entities)) return { entities: [] };
   return { entities: raw.entities };
@@ -397,7 +417,7 @@ export async function resolveEntities(userMessage, opts = {}) {
  */
 export async function fermentoPrefilter(userMessage) {
   if (!userMessage || typeof userMessage !== 'string') return null;
-  const raw = await postJson('/fermento-prefilter', { user_message: userMessage }, NLU_TIMEOUT_MS);
+  const raw = await postJson('/fermento-prefilter', { user_message: userMessage }, SIDECAR_RPC_TIMEOUT_MS);
   if (!raw || typeof raw !== 'object') return null;
   return {
     is_fermento_intent: raw.is_fermento_intent === true,
@@ -438,7 +458,7 @@ export async function postValidate(text, expected) {
     const clean = expected.filter((e) => typeof e === 'string' && e.trim().length > 0);
     if (clean.length > 0) body.expected = clean;
   }
-  const raw = await postJson('/post-validate', body, NLU_TIMEOUT_MS);
+  const raw = await postJson('/post-validate', body, SIDECAR_RPC_TIMEOUT_MS);
   if (!raw || typeof raw !== 'object') return null;
   return {
     hallucinated: Array.isArray(raw.hallucinated) ? raw.hallucinated : [],
@@ -622,4 +642,9 @@ export const __TEST__ = {
   PRECIO_SIPSA_ACTIONS,
   getBaseUrl,
   getToken,
+  // Timeouts expuestos para que los tests verifiquen que `/nlu` usa un budget
+  // mayor (sobre el prefill ~9.5s) que el resto de RPCs del sidecar.
+  NLU_TIMEOUT_MS,
+  SIDECAR_RPC_TIMEOUT_MS,
+  TOOL_TIMEOUT_MS,
 };


### PR DESCRIPTION
## Problema (medido en prod 2026-06-02)

El planner `/nlu` del sidecar tiene un prefill conocido de ~9.5s. El cliente PWA abortaba el fetch a los 10s, justo en el borde, y en queries agro legítimas:
- perdía el routing de herramientas, y
- el caso `plan === null` (timeout) era un **fall-through silencioso** en `AgentScreen` — indistinguible de "el planner decidió no usar tool" — que hacía parecer que el turno "moría" (a veces hasta el deadline total de 60s, 0 burbujas).

El backend está sano (granite ~5.5s, gemma ~1.5s). El problema era de **manejo de timeout/fallback en el PWA**, no del sidecar.

## Cambios (solo lado PWA — NO toca el sidecar; eso es SPEED-6)

1. **`sidecarClient.js`** — sube el timeout de `/nlu` de 10s → **14s** (`NLU_TIMEOUT_MS`), con margen sobre el prefill medido. El resto de RPCs (`/resolve-entities`, `/post-validate`, `/fermento-prefilter`) quedan en 10s vía el nuevo `SIDECAR_RPC_TIMEOUT_MS` (preserva su comportamiento previo). Timeouts expuestos en `__TEST__`.

2. **`agentNluBestEffort.js`** (nuevo) — helper puro `decideNluRouting(plan)` con un invariante duro: `proceedToChat` es **siempre true**. NLU es opcional: ante `null` (timeout/5xx/red/offline) el outcome es `degraded` → el turno sigue a **chat grounded directo** (resolve-entities + system prompt + bloques de guardas) SIN routing de tools. Nunca bloquea el turno.

3. **`AgentScreen.jsx`** — PASO 2b usa `decideNluRouting`; la rama `degraded` ahora es **explícita y logueada** (antes silenciosa). El deadline de 60s del chat se arma **dentro de `callLLM`, después** del NLU → un `/nlu` lento jamás consume ese presupuesto.

## Tests

- `agentNluBestEffort.test.js` — helper puro (invariante best-effort, todas las ramas) + integración con `planNlu` mockeado: `/nlu` timeout/5xx → `plan===null` → chat directo (no muere el turno); `/nlu` OK → routing normal con tool.
- `sidecarClient.test.js` — timeouts por endpoint (`/nlu` 14s > RPC 10s, vía spy de `setTimeout` + constantes expuestas).
- **3246 unit tests verdes** (`npm run test:unit`), eslint limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)