### PR TITLE
fix(agent): idle-timeout + stream-aware para no abortar respuestas largas

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -48,6 +48,9 @@ import { buildLLMRequest, selectChatRoute } from '../../services/llmRouter';
 // igual que con cualquier otro fallo del LLM. Para forzar fallback al
 // path directo en un sólo turn → desactivar la flag y recargar.
 import { streamChatViaSidecar, isAgentStreamingEnabled } from '../../services/streamChatViaSidecar';
+// FIX prod P0 (2026-06-02): deadline stream-aware (idle-timeout + techo). Un
+// stream que avanza NO se aborta; ver streamDeadline.js.
+import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
@@ -215,9 +218,10 @@ export default function AgentScreen({ onBack, initialContext }) {
   // LLM / watchdog sin tokens), 'cancel' (operador tocó Cancelar) o 'abort'
   // (genérico, ej. red caída). Se setea antes de disparar controller.abort().
   const cancelReasonRef = useRef(null);
-  // Watchdog stall (#sin-token): timer que se RESETEA en cada token. Solo
-  // dispara si pasa STALL_WATCHDOG_MS sin ningún token nuevo (stall real),
-  // independiente del tiempo total de una respuesta lenta-pero-avanzando.
+  // Holder del deadline stream-aware activo (createStreamDeadline). FIX prod
+  // P0 (2026-06-02): combina idle-timeout (reinicia por token → no aborta
+  // streams vivos) + techo absoluto. Reemplaza al watchdog/timer total previo.
+  // Se conserva el nombre del ref por compatibilidad con cleanup paths.
   const stallTimerRef = useRef(null);
   // 057.4 integration: resolver del Promise pendiente del actionExecutor gate.
   // El callback registrado en setActionGateCallback abre el modal y retorna
@@ -827,22 +831,22 @@ ${buildProfileContext(finca)}`;
   // Solución v2 (2026-05-18): AbortController con timeout 30s + ref externo
   // para botón Cancelar + warning visible a los 20s ("Aún pensando…").
   //
-  // 2026-05-19 ajuste timeout 30s→60s: operator perdió respuesta porque
-  // el agente tardaba demasiado (cold-load del modelo + RAG context).
-  // Según bench interno hay outliers post-cold-load altos. 60s los cubre
-  // sin sacrificar UX (el warning a 20s ya le dice al operator que algo
-  // está lento). Pre-condicion: OLLAMA_KEEP_ALIVE=24h en alpha para que
-  // modelos no hagan cold-load entre conversaciones.
-  const LLM_TIMEOUT_MS = 60000;
-
-  // Watchdog "sin token" (#sin-token). Distinto del deadline total de arriba:
-  // mide el GAP entre tokens, no el tiempo total. Se RESETEA en cada token, así
-  // una respuesta lenta-pero-avanzando NO se aborta — solo dispara ante un
-  // stall real (el backend dejó de emitir). El comment histórico de runLLM
-  // hablaba de "30s sin token" pero solo existía el deadline total de 60s; esto
-  // implementa el comportamiento que el comment prometía. Backstop de 60s queda
-  // como red de seguridad para streams que avanzan token-a-token eternamente.
-  const STALL_WATCHDOG_MS = 30000;
+  // FIX prod P0 (2026-06-02): el deadline TOTAL de 60s tumbaba respuestas
+  // largas-pero-vivas. Bajo carga las completions de granite rozan 20-29s y,
+  // sumando cold-load + RAG + tool-chain, una respuesta sana cruzaba los 60s y
+  // moría a mitad de stream. Bench prod 2026-06-02: 4 de 6 prompts murieron por
+  // este abort. La política ahora es STREAM-AWARE (ver streamDeadline.js):
+  //
+  //   - IDLE-timeout (criterio primario): mide el GAP entre tokens y se
+  //     REINICIA con cada token. Un stream que avanza NUNCA se aborta por más
+  //     largo que sea en total; solo un STALL real (backend mudo) dispara.
+  //   - HARD-CEILING: techo absoluto (no reinicia) como backstop extremo para
+  //     no colgar la UI ante un backend que gotea tokens para siempre. NO es
+  //     infinito a propósito.
+  //
+  // El botón "Cancelar" (handleCancelLLM) sigue intacto: cancelación manual del
+  // operador es independiente de estos plazos. Pre-condición operativa:
+  // OLLAMA_KEEP_ALIVE=24h en alpha para minimizar cold-loads.
 
   // Task #121: safety cap del while loop que drena el queue. Con QUEUE_MAX=2
   // (1 processing + 1 pending) jamás debería haber más de 2 iteraciones,
@@ -1186,32 +1190,35 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     const controller = new AbortController();
     activeControllerRef.current = controller;
     cancelReasonRef.current = null;
-    // Deadline TOTAL (backstop): aborta a los 60s aunque el stream avance.
-    const timer = setTimeout(() => {
-      console.warn(`[Agent] LLM timeout ${LLM_TIMEOUT_MS}ms — aborting`);
-      cancelReasonRef.current = 'timeout';
-      controller.abort();
-    }, LLM_TIMEOUT_MS);
 
-    // Watchdog "sin token": se arma acá y se REINICIA en cada token (markToken).
-    // Solo dispara si el backend deja de emitir por STALL_WATCHDOG_MS — stall
-    // real, no respuesta lenta-pero-avanzando.
-    const armStallTimer = () => {
-      stallTimerRef.current = setTimeout(() => {
-        console.warn(`[Agent] LLM stall ${STALL_WATCHDOG_MS}ms sin token — aborting`);
+    // Deadline STREAM-AWARE (FIX prod P0 2026-06-02). Un único controlador que
+    // combina el idle-timeout (reinicia por token → no aborta streams vivos) y
+    // el techo absoluto (backstop extremo). Reemplaza el deadline TOTAL de 60s
+    // que tumbaba respuestas largas-pero-vivas. La lógica pura vive en
+    // streamDeadline.js (testeada con fake timers).
+    const deadline = createStreamDeadline({
+      onTimeout: (reason) => {
+        console.warn(`[Agent] LLM deadline (${reason}) — aborting`);
+        // Ambas razones ('idle'/'ceiling') se reportan como 'timeout' al merge
+        // de estado: para el operador es el mismo caso "se cortó, reintenta".
         cancelReasonRef.current = 'timeout';
         controller.abort();
-      }, STALL_WATCHDOG_MS);
-    };
+      },
+    });
+    // Conservamos el ref histórico (`stallTimerRef`) como holder del deadline
+    // para que handlers externos (unmount/cleanup) puedan detenerlo igual que
+    // antes detenían el watchdog.
+    stallTimerRef.current = deadline;
+
     const markToken = (fullText) => {
-      // Reset del watchdog: llegó un token, el stream está vivo.
-      if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
-      armStallTimer();
+      // Llegó un token: el stream está vivo → reinicia el idle-timer. El techo
+      // absoluto sigue corriendo intacto.
+      deadline.onToken();
       // Espejo del parcial en ref para que el catch lo preserve sin closure stale.
       streamingContentRef.current = fullText;
       setStreamingContent(fullText);
     };
-    armStallTimer();
+    deadline.start();
 
     try {
       // Routing dual 2026-05-23: queries complejas (plagas regionales,
@@ -1298,11 +1305,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       }
       throw new Error('IA no disponible, intenta de nuevo en un momento');
     } finally {
-      clearTimeout(timer);
-      if (stallTimerRef.current) {
-        clearTimeout(stallTimerRef.current);
-        stallTimerRef.current = null;
+      // Detiene idle + techo del deadline stream-aware (limpia ambos timers).
+      if (stallTimerRef.current && typeof stallTimerRef.current.stop === 'function') {
+        stallTimerRef.current.stop();
       }
+      stallTimerRef.current = null;
       activeControllerRef.current = null;
     }
   };

--- a/src/services/__tests__/streamDeadline.test.js
+++ b/src/services/__tests__/streamDeadline.test.js
@@ -1,0 +1,208 @@
+/**
+ * streamDeadline.test.js — TDD test-first para el deadline stream-aware del
+ * agente (FIX prod P0 2026-06-02).
+ *
+ * Contexto del bug: el cliente de chat abortaba respuestas largas con "Tiempo
+ * agotado" porque el deadline TOTAL (60s) tumbaba completions de granite que
+ * bajo carga rozan 20-29s + cold-load + RAG + tool-chain, AUNQUE el stream
+ * estuviera avanzando token a token. Bench prod 2026-06-02: 4 de 6 prompts
+ * murieron por este abort.
+ *
+ * Fix: el deadline debe ser un IDLE-timeout (se reinicia con cada token). Un
+ * stream que avanza NUNCA se aborta por deadline; solo un STALL real (el
+ * backend dejó de emitir) o el techo absoluto (backstop extremo) abortan.
+ *
+ * Estos tests verifican la lógica pura del factory `createStreamDeadline`
+ * con fake timers (sin red, sin React, sin Ollama).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createStreamDeadline,
+  IDLE_TIMEOUT_MS,
+  HARD_CEILING_MS,
+} from '../streamDeadline.js';
+
+describe('streamDeadline — constantes de política', () => {
+  it('idle-timeout tolera ~40-60s de generación bajo carga (>= 35s)', () => {
+    // El idle-timeout es el GAP máximo entre tokens. granite bajo carga sigue
+    // emitiendo dentro de ese gap; solo un stall real (backend mudo) lo supera.
+    expect(IDLE_TIMEOUT_MS).toBeGreaterThanOrEqual(35000);
+  });
+
+  it('techo absoluto es generoso pero NO infinito (entre 60s y 180s)', () => {
+    // Backstop extremo: una respuesta sana termina mucho antes. NO debe cortar
+    // streams que avanzan, pero evita colgar la UI para siempre.
+    expect(HARD_CEILING_MS).toBeGreaterThanOrEqual(60000);
+    expect(HARD_CEILING_MS).toBeLessThanOrEqual(180000);
+  });
+
+  it('el techo absoluto es estrictamente mayor que el idle-timeout', () => {
+    expect(HARD_CEILING_MS).toBeGreaterThan(IDLE_TIMEOUT_MS);
+  });
+});
+
+describe('streamDeadline — comportamiento idle (no abortar mientras streamea)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('aborta si NUNCA llega un token y pasa el idle-timeout', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 5000, onTimeout });
+    dl.start();
+    vi.advanceTimersByTime(1000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledWith('idle');
+    dl.stop();
+  });
+
+  it('NO aborta un stream que avanza token a token, aunque el total supere el idle-timeout', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 100000, onTimeout });
+    dl.start();
+    // 10 tokens, uno cada 800ms (< idle 1000ms). Total transcurrido = 8000ms,
+    // muy por encima del idle-timeout de 1000ms. Un deadline TOTAL habría
+    // abortado a los 1000ms; el idle-timeout NO porque cada token lo reinicia.
+    for (let i = 0; i < 10; i += 1) {
+      vi.advanceTimersByTime(800);
+      dl.onToken();
+    }
+    expect(onTimeout).not.toHaveBeenCalled();
+    dl.stop();
+  });
+
+  it('aborta con razón "idle" cuando el stream avanza y luego SE ESTANCA', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 100000, onTimeout });
+    dl.start();
+    // Avanza 3 tokens vivos...
+    for (let i = 0; i < 3; i += 1) {
+      vi.advanceTimersByTime(500);
+      dl.onToken();
+    }
+    expect(onTimeout).not.toHaveBeenCalled();
+    // ...y luego el backend se queda mudo: el idle-timeout dispara.
+    vi.advanceTimersByTime(1000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledWith('idle');
+    dl.stop();
+  });
+
+  it('cada token reinicia el idle-timer (no se acumulan disparos)', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 100000, onTimeout });
+    dl.start();
+    vi.advanceTimersByTime(900);
+    dl.onToken(); // reset
+    vi.advanceTimersByTime(900);
+    dl.onToken(); // reset
+    vi.advanceTimersByTime(900);
+    // En total pasaron 2700ms pero nunca 1000ms seguidos sin token.
+    expect(onTimeout).not.toHaveBeenCalled();
+    dl.stop();
+  });
+});
+
+describe('streamDeadline — techo absoluto (backstop extremo)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('aborta con razón "ceiling" si el stream avanza eternamente más allá del techo', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 5000, ceilingMs: 10000, onTimeout });
+    dl.start();
+    // Tokens cada 1s (< idle 5s) → idle nunca dispara. Pero pasa el techo 10s.
+    for (let i = 0; i < 15; i += 1) {
+      vi.advanceTimersByTime(1000);
+      dl.onToken();
+    }
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledWith('ceiling');
+    dl.stop();
+  });
+
+  it('el techo NO se reinicia con tokens (es absoluto desde start)', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 100000, ceilingMs: 3000, onTimeout });
+    dl.start();
+    dl.onToken();
+    vi.advanceTimersByTime(1500);
+    dl.onToken();
+    vi.advanceTimersByTime(1500); // total 3000ms desde start → techo dispara
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    expect(onTimeout).toHaveBeenCalledWith('ceiling');
+    dl.stop();
+  });
+});
+
+describe('streamDeadline — ciclo de vida y limpieza', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('stop() limpia ambos timers — no dispara onTimeout tras completar', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 5000, onTimeout });
+    dl.start();
+    dl.onToken();
+    dl.stop(); // respuesta completa → limpiar
+    vi.advanceTimersByTime(60000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('onToken() después de stop() es no-op (no re-arma timers)', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 5000, onTimeout });
+    dl.start();
+    dl.stop();
+    dl.onToken();
+    vi.advanceTimersByTime(60000);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('onTimeout dispara una sola vez aunque ambos plazos se crucen', () => {
+    const onTimeout = vi.fn();
+    // idle y ceiling muy cercanos: tras disparar uno, el otro NO debe re-disparar.
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 1000, onTimeout });
+    dl.start();
+    vi.advanceTimersByTime(5000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    dl.stop();
+  });
+
+  it('usa los defaults de política si no se pasan idleMs/ceilingMs', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ onTimeout });
+    dl.start();
+    // Antes del idle-timeout default no dispara nada.
+    vi.advanceTimersByTime(IDLE_TIMEOUT_MS - 1);
+    expect(onTimeout).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onTimeout).toHaveBeenCalledWith('idle');
+    dl.stop();
+  });
+
+  it('start() es idempotente — doble start no deja timers huérfanos', () => {
+    const onTimeout = vi.fn();
+    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 5000, onTimeout });
+    dl.start();
+    dl.start(); // re-arranque: no debe acumular dos idle-timers
+    vi.advanceTimersByTime(1000);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    dl.stop();
+  });
+});

--- a/src/services/streamDeadline.js
+++ b/src/services/streamDeadline.js
@@ -1,0 +1,133 @@
+/**
+ * streamDeadline.js — Deadline stream-aware (idle-timeout) para la inferencia
+ * del agente.
+ *
+ * FIX prod P0 (2026-06-02): el cliente de chat abortaba respuestas largas con
+ * "Tiempo agotado". El deadline era TOTAL: arrancaba un `setTimeout` de 60s al
+ * iniciar la inferencia y disparaba `controller.abort()` aunque el stream
+ * estuviera avanzando token a token. Bajo carga las completions del modelo de
+ * chat rozan 20-29s y, sumando cold-load + RAG + tool-chain, una respuesta
+ * sana-pero-lenta podía cruzar los 60s y morir a mitad de generación. Bench
+ * prod 2026-06-02: 4 de 6 prompts murieron por este abort.
+ *
+ * Política nueva:
+ *
+ *   1. IDLE-timeout (criterio primario): mide el GAP entre tokens, NO el total.
+ *      Se reinicia con cada token recibido. Un stream que avanza nunca lo
+ *      cruza; solo un STALL real (el backend dejó de emitir) lo dispara. Esto
+ *      tolera respuestas largas bajo carga sin techarlas artificialmente.
+ *
+ *   2. HARD-CEILING (backstop extremo): un techo absoluto desde el inicio que
+ *      NO se reinicia con tokens. Generoso (no infinito) para que la UI no
+ *      quede colgada para siempre si el backend emite un token cada N segundos
+ *      indefinidamente (caso patológico). Una respuesta sana termina mucho
+ *      antes de tocarlo.
+ *
+ * Se mantiene como factory puro (sin React, sin DOM, sin red) para testearlo
+ * con fake timers, igual que `agentPartialMerge.js`. El componente sólo cablea
+ * `start()` / `onToken()` / `stop()` y un `onTimeout(reason)` que dispara el
+ * `controller.abort()`.
+ */
+
+/**
+ * Idle-timeout por defecto: GAP máximo tolerado entre tokens antes de
+ * considerar el stream estancado. 35s deja margen cómodo sobre el peor caso
+ * observado de first-token bajo carga (cold-load del modelo + prefill del
+ * system prompt + RAG context). Mientras el modelo siga emitiendo dentro de
+ * esa ventana, la respuesta NO se aborta por más larga que sea en total.
+ */
+export const IDLE_TIMEOUT_MS = 40000;
+
+/**
+ * Techo absoluto desde el arranque (backstop extremo). NO se reinicia con
+ * tokens. 120s es ampliamente suficiente para cualquier respuesta legítima del
+ * agente (incluyendo planes multi-aspecto largos en el modelo complejo); su
+ * único fin es evitar que la UI quede colgada indefinidamente ante un backend
+ * que gotea tokens para siempre. NO es infinito a propósito.
+ */
+export const HARD_CEILING_MS = 120000;
+
+/**
+ * Crea un controlador de deadline stream-aware.
+ *
+ * @param {Object}   [params]
+ * @param {number}   [params.idleMs=IDLE_TIMEOUT_MS]   idle-timeout (reinicia por token).
+ * @param {number}   [params.ceilingMs=HARD_CEILING_MS] techo absoluto (no reinicia).
+ * @param {Function} params.onTimeout  callback `(reason: 'idle'|'ceiling') => void`
+ *                                      invocado UNA sola vez cuando vence alguno
+ *                                      de los plazos. Típicamente dispara
+ *                                      `controller.abort()`.
+ * @returns {{
+ *   start: () => void,
+ *   onToken: () => void,
+ *   stop: () => void,
+ * }}
+ *   - `start()`   arma idle + ceiling. Idempotente (re-arma limpio).
+ *   - `onToken()` reinicia SOLO el idle-timer (señal de que el stream vive).
+ *                 No-op si ya se detuvo o ya disparó.
+ *   - `stop()`    limpia ambos timers. Llamar al completar/abortar la respuesta.
+ */
+export function createStreamDeadline({
+  idleMs = IDLE_TIMEOUT_MS,
+  ceilingMs = HARD_CEILING_MS,
+  onTimeout,
+} = {}) {
+  let idleTimer = null;
+  let ceilingTimer = null;
+  // Latch: el deadline sólo puede disparar/limpiar una vez. Evita que idle y
+  // ceiling se pisen (doble onTimeout) y que un onToken tardío re-arme tras fin.
+  let finished = false;
+
+  const clearTimers = () => {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+    if (ceilingTimer !== null) {
+      clearTimeout(ceilingTimer);
+      ceilingTimer = null;
+    }
+  };
+
+  const fire = (reason) => {
+    if (finished) return;
+    finished = true;
+    clearTimers();
+    if (typeof onTimeout === 'function') {
+      try {
+        onTimeout(reason);
+      } catch (_) {
+        // El callback (abort) jamás debe romper el deadline.
+      }
+    }
+  };
+
+  const armIdle = () => {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer);
+    }
+    idleTimer = setTimeout(() => fire('idle'), idleMs);
+  };
+
+  return {
+    start() {
+      // Idempotente: re-arranque limpio (no acumula timers huérfanos).
+      clearTimers();
+      finished = false;
+      armIdle();
+      ceilingTimer = setTimeout(() => fire('ceiling'), ceilingMs);
+    },
+    onToken() {
+      // Llegó un token: el stream está vivo → reinicia SOLO el idle-timer.
+      // El techo absoluto sigue corriendo sin tocar. No-op tras stop/disparo.
+      if (finished || idleTimer === null) return;
+      armIdle();
+    },
+    stop() {
+      finished = true;
+      clearTimers();
+    },
+  };
+}
+
+export default createStreamDeadline;


### PR DESCRIPTION
## Bug
El agente IA abortaba respuestas largas con "Tiempo agotado". Bench prod 2026-06-02: 4 de 6 prompts murieron por este abort.

## Causa raíz
El deadline del cliente de chat era **TOTAL**: un `setTimeout(60000)` desde el inicio de la inferencia disparaba `controller.abort()` aunque el stream estuviera avanzando token a token. Bajo carga las completions de granite rozan 20-29s y, sumando cold-load + RAG + tool-chain, una respuesta sana-pero-lenta cruzaba los 60s y moría a mitad de generación. El watchdog idle previo se reseteaba bien, pero el deadline total de 60s lo sobrepasaba como guillotina.

## Cambios
- **`src/services/streamDeadline.js`** (nuevo): factory puro `createStreamDeadline` con política stream-aware:
  - **IDLE-timeout (40s)** — mide el GAP entre tokens y se REINICIA con cada token (`onToken()`). Un stream que avanza NUNCA se aborta; solo un stall real (backend mudo) dispara. El timeout cuenta contra el ÚLTIMO token, no el total.
  - **HARD-CEILING (120s)** — techo absoluto que NO se reinicia, backstop extremo para no colgar la UI ante un backend que gotea tokens. No infinito a propósito.
- **`src/components/AgentScreen/AgentScreen.jsx`**: reemplaza el `LLM_TIMEOUT_MS`/`STALL_WATCHDOG_MS` inline por `createStreamDeadline`. Cablea `start()`/`onToken()`/`stop()`. Ambas razones (`idle`/`ceiling`) se reportan como `timeout` al merge de estado.
- El primer token ya se renderiza apenas llega (`setStreamingContent` en cada `markToken`).
- UX al expirar: `mergePartialOnInterruption` preserva el parcial + botón "Reintentar" (vía `_orphan_recovery`/`handleRetryOrphan`, ya existente, verificado). Cancelación manual del operador (`handleCancelLLM` sobre `activeControllerRef`) queda intacta e independiente de los plazos.

## Tests
- 14 casos vitest fake-timers en `streamDeadline.test.js` (test-first): idle no aborta stream vivo aunque el total supere el idle-timeout, aborta en stall real con razón `idle`, techo absoluto con razón `ceiling`, ciclo de vida (`stop`/`onToken` post-stop no-op), idempotencia de `start`, defaults de política.
- Suite full verde: 196 archivos / 3251 tests passing, 0 regresiones.
- ESLint `--max-warnings=0` limpio.

Refs: bench prod 2026-06-02, SPEED-1 #253 (streaming base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)