### PR TITLE
fix(agent): prod-harm fix · espera revisión operador — guards viabilidad/agroquímico/dominio/precio/dosis

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1118,6 +1118,8 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       groupedCultivos,
       resolvedEntities,
       activeAlerts,
+      // #347: en consulta de precio NO inyectar ubicación/inventario de la finca.
+      userMessage: query,
     })}`;
 
     // VIABILIDAD POR ALTITUD (determinístico, sin red). Cruza la altitud de la

--- a/src/services/__tests__/outputGuards.prodHarm20260603.test.js
+++ b/src/services/__tests__/outputGuards.prodHarm20260603.test.js
@@ -1,0 +1,296 @@
+/**
+ * outputGuards.prodHarm20260603.test.js — PACK de fixes de DAÑO en producción
+ * (transcript real operador, Choachí 1923 msnm, templado — 2026-06-03).
+ *
+ * Ground-truth del bug:
+ *   Chagra-strategy/ops/PROD-ERRORS-TRANSCRIPT-2026-06-03.md
+ *
+ * Cubre cinco fallas observadas EN VIVO en la finca del operador:
+ *  1. CRÍTICO inverted-viability FALSO-NEGATIVO (#350): papa y fresa a 1923 m
+ *     son VIABLES (Choachí es zona papera templada); el guard las marcaba
+ *     "NO viable" y desviaba a Daikon/variedades extranjeras. Un staple dentro
+ *     de su piso real NUNCA debe marcarse inviable. No-regresión: papa@3500 sí
+ *     es inviable (demasiado alto).
+ *  2. CRÍTICO agroquímico (#351): "NPK", "urea", "fosfato triple/diamónico",
+ *     "sulfato de potasio", "nitrato de amonio" deben disparar el redirect a
+ *     abono orgánico/biopreparado/compost.
+ *  3. Guard de dominio (#352): consultas off-domain (física/química/matemáticas)
+ *     se declinan amable y se redirigen, SIN tool ni grounding falso.
+ *  4. Fuga inventario en precio (#347): "bulto/arroba/carga de X" = price_intent
+ *     → los guards de siembra y la inyección de finca NO corren.
+ *  5. Disclaimer de dosis mal ubicado (#8): en biopreparado CASERO no decir
+ *     "confirma con la etiqueta del producto".
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  guardInvertedViability,
+  guardSyntheticAgrochemical,
+  guardOffDomain,
+  guardDoseWithoutSource,
+  classifyQueryIntent,
+  applyOutputGuards,
+} from '../outputGuards.js';
+
+// ───────────────────────────────────────────────────────────────────────────
+// #1 — inverted-viability FALSO-NEGATIVO: papa/fresa a 1923 m son VIABLES
+// ───────────────────────────────────────────────────────────────────────────
+describe('#350 inverted-viability falso-negativo (staple en su piso)', () => {
+  // El sidecar mal-matcheó la base (ej. "fresa silvestre andina") y devolvió
+  // viabilidad:'inviable' con una banda equivocada para un staple templado.
+  const papaMalMarcada = {
+    kind: 'species',
+    mentioned: 'papa',
+    nombre_comun: 'papa',
+    nombre_cientifico: 'Solanum tuberosum',
+    viabilidad: 'inviable', // ← veredicto ERRÓNEO heredado del grounding
+    altitud_min: 2500,
+    altitud_max: 3500,
+    alternativas_viables: ['daikon', 'ajo'],
+  };
+  const fresaMalMarcada = {
+    kind: 'species',
+    mentioned: 'fresa',
+    nombre_comun: 'fresa',
+    nombre_cientifico: 'Fragaria × ananassa',
+    viabilidad: 'inviable', // ← matcheó "fresa silvestre andina", banda alta
+    altitud_min: 2400,
+    altitud_max: 3000,
+    alternativas_viables: ['mora', 'uchuva'],
+  };
+
+  it('papa a 1923 m NO se marca inviable (Choachí, zona papera templada)', () => {
+    const txt = 'En tu finca puedes sembrar papa, es un buen cultivo para la zona.';
+    const out = guardInvertedViability(txt, [papaMalMarcada], 1923);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+    expect(out.text).not.toMatch(/no es viable/i);
+    // No debe empujar las alternativas extranjeras/absurdas.
+    expect(out.text).not.toMatch(/daikon/i);
+  });
+
+  it('fresa a 1923 m NO se marca inviable (templado, viable)', () => {
+    const txt = 'La fresa se da bien acá, puedes sembrarla en camas altas.';
+    const out = guardInvertedViability(txt, [fresaMalMarcada], 1923);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+    expect(out.text).not.toMatch(/no es viable/i);
+  });
+
+  it('NO-REGRESIÓN: papa a 3500 m SÍ es inviable (demasiado alto, fuera del piso)', () => {
+    const papaAlta = {
+      kind: 'species',
+      mentioned: 'papa',
+      nombre_comun: 'papa',
+      nombre_cientifico: 'Solanum tuberosum',
+      viabilidad: 'inviable',
+      altitud_min: 2000,
+      altitud_max: 3000,
+      alternativas_viables: ['nabo', 'haba'],
+    };
+    const txt = 'Puedes sembrar papa en tu parcela, es buena opción.';
+    // 3600 está por encima del techo real del staple (3400) → inviable real.
+    const out = guardInvertedViability(txt, [papaAlta], 3600);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/NO es viable/i);
+  });
+
+  it('NO-REGRESIÓN: el guard sigue corrigiendo un cultivo NO-staple realmente inviable (maracuyá a 2100 m)', () => {
+    const maracuya = {
+      kind: 'species',
+      mentioned: 'maracuyá',
+      nombre_comun: 'maracuyá',
+      viabilidad: 'inviable',
+      altitud_min: 0,
+      altitud_max: 1300,
+      alternativas_viables: ['gulupa'],
+    };
+    const txt = 'Es recomendable priorizar la maracuyá en tu finca a 2100 m.';
+    const out = guardInvertedViability(txt, [maracuya], 2100);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/NO es viable/i);
+    expect(out.text).toMatch(/gulupa/);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// #2 — agroquímico: fertilizantes minerales de síntesis (NPK/urea/etc.)
+// ───────────────────────────────────────────────────────────────────────────
+describe('#351 guardSyntheticAgrochemical cubre fertilizantes minerales de síntesis', () => {
+  const casos = [
+    ['NPK', 'Para alimentar las fresas aplica NPK 5-10-10 cada quince días.'],
+    ['urea', 'Echa urea para que crezca verde y frondoso el tomate.'],
+    ['fosfato triple', 'Mezcla fosfato triple con la tierra antes de trasplantar.'],
+    ['fosfato diamónico', 'El fosfato diamónico (DAP) le sube el fósforo al cultivo.'],
+    ['sulfato de potasio', 'Aplica sulfato de potasio para el cuaje de los frutos.'],
+    ['nitrato de amonio', 'Un poco de nitrato de amonio acelera el crecimiento.'],
+  ];
+
+  it.each(casos)('dispara y redirige a orgánico ante "%s"', (_label, texto) => {
+    const out = guardSyntheticAgrochemical(texto);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/agroquímico_sintético/);
+    // Redirige a la ruta agroecológica.
+    expect(out.text).toMatch(/agroecol|org[aá]nic|biopreparado|compost|bocashi/i);
+  });
+
+  it('receta del transcript (urea + fosfato triple + sulfato de potasio) dispara', () => {
+    const receta =
+      'Para hacer tu propio NPK casero mezcla urea, fosfato triple y sulfato de potasio ' +
+      'en partes iguales y aplícalo a las fresas.';
+    const out = guardSyntheticAgrochemical(receta);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/agroquímico_sintético/);
+  });
+
+  it('NO-REGRESIÓN: "compost" / "bocashi" (abono orgánico) NO disparan', () => {
+    const ok = 'Para alimentar tus fresas usa compost maduro y bocashi, son los mejores abonos.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO falso-positivo: "potasio" mencionado como nutriente del suelo, sin la sal de síntesis', () => {
+    const ok = 'Las fresas necesitan potasio para el fruto; te lo da la ceniza de leña y la cáscara de banano.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// #3 — guard de DOMINIO: off-domain declina, no inventa tool/grounding
+// ───────────────────────────────────────────────────────────────────────────
+describe('#352 guardOffDomain — declina consultas fuera de agro', () => {
+  it('declina "teoría de cuerdas" (física) sin tool', () => {
+    const respuestaFisica =
+      'La teoría de cuerdas postula que las partículas elementales son vibraciones ' +
+      'de cuerdas unidimensionales en un espacio de 11 dimensiones...';
+    const out = guardOffDomain(respuestaFisica, { userMessage: 'explícame la teoría de cuerdas' });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/off_domain/);
+    // Declina amable y redirige al dominio agro.
+    expect(out.text).toMatch(/cultivo|finca|agro/i);
+    // No deja la disertación de física.
+    expect(out.text).not.toMatch(/once dimensiones|11 dimensiones|vibraciones de cuerdas/i);
+  });
+
+  it('declina "teoría de la relatividad" (física)', () => {
+    const out = guardOffDomain('E = mc² describe la equivalencia masa-energía...', {
+      userMessage: 'qué es la teoría de la relatividad',
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/off_domain/);
+  });
+
+  it('declina química inorgánica pura (sin agro)', () => {
+    const out = guardOffDomain('La diferencia entre química orgánica e inorgánica es el carbono...', {
+      userMessage: 'diferencia entre química orgánica e inorgánica',
+    });
+    expect(out.modified).toBe(true);
+  });
+
+  it('NO toca una consulta agro normal ("qué siembro en mi finca")', () => {
+    const out = guardOffDomain('En tu finca a 1923 m te recomiendo papa, arveja y fresa.', {
+      userMessage: '¿qué siembro en mi finca?',
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO toca consulta de plaga/biopreparado (dominio agro)', () => {
+    const out = guardOffDomain('Para el gusano trozador usa Bacillus thuringiensis y trampas.', {
+      userMessage: 'cómo controlo el gusano trozador en mis tomates',
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO actúa sin userMessage (fail-open al resto de la cadena)', () => {
+    const out = guardOffDomain('La teoría de cuerdas...', {});
+    expect(out.modified).toBe(false);
+  });
+
+  it('"química orgánica para mi compost" SÍ es agro (no declina)', () => {
+    const out = guardOffDomain('La materia orgánica del compost...', {
+      userMessage: 'cómo mejoro la química orgánica de mi compost en la finca',
+    });
+    expect(out.modified).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// #4 — fuga de inventario en consulta de PRECIO: "bulto/arroba/carga de X"
+// ───────────────────────────────────────────────────────────────────────────
+describe('#347 price_intent para bulto/arroba/carga', () => {
+  it('clasifica "a cómo el bulto de papa" como precio', () => {
+    expect(classifyQueryIntent('¿a cómo está el bulto de papa?')).toBe('precio');
+  });
+
+  it('clasifica "cuánto vale la arroba de fresa" como precio', () => {
+    expect(classifyQueryIntent('¿cuánto vale la arroba de fresa?')).toBe('precio');
+  });
+
+  it('clasifica "precio de la carga de papa" como precio', () => {
+    expect(classifyQueryIntent('precio de la carga de papa en plaza')).toBe('precio');
+  });
+
+  it('"arroba de X" sin más contexto de siembra es precio', () => {
+    expect(classifyQueryIntent('la arroba de papa')).toBe('precio');
+  });
+
+  it('siembra sigue ganando: "siembro una arroba de papa" → siembra', () => {
+    expect(classifyQueryIntent('cuántas semillas siembro por arroba de papa')).toBe('siembra');
+  });
+
+  it('en applyOutputGuards: query de precio NO corre el guard de siembra (no inyecta "NO viable")', () => {
+    const maracuya = {
+      kind: 'species',
+      mentioned: 'maracuyá',
+      nombre_comun: 'maracuyá',
+      viabilidad: 'inviable',
+      altitud_min: 0,
+      altitud_max: 1300,
+      alternativas_viables: ['gulupa'],
+    };
+    const respuesta = 'La maracuyá es recomendable y se vende bien.';
+    const out = applyOutputGuards(respuesta, {
+      resolvedEntities: [maracuya],
+      fincaAltitud: 2100,
+      userMessage: '¿a cómo está la arroba de maracuyá?',
+    });
+    // El guard de siembra NO corre → no se inyecta el bloque de viabilidad.
+    expect(out.text).not.toMatch(/NO es viable/i);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// #5 — disclaimer de dosis mal ubicado en biopreparado CASERO
+// ───────────────────────────────────────────────────────────────────────────
+describe('#8 disclaimer de dosis: biopreparado casero no menciona "etiqueta del producto"', () => {
+  it('en receta de biopreparado casero, la nota NO dice "etiqueta del producto"', () => {
+    const receta =
+      'Para el caldo sulfocálcico casero usa 2 kg de azufre por cada 10 litros de agua, ' +
+      'hierve 45 minutos y aplica 250 ml por bomba de 20 litros.';
+    const out = guardDoseWithoutSource(receta, null, null, {
+      userMessage: 'cómo preparo caldo sulfocálcico casero en mi finca',
+    });
+    expect(out.modified).toBe(true);
+    // No hay etiqueta en un preparado casero.
+    expect(out.text).not.toMatch(/etiqueta del producto/i);
+    // Sí debe orientar a una referencia válida para lo casero (Restrepo / técnico / receta).
+    expect(out.text).toMatch(/casero|receta|t[eé]cnico|Restrepo|fuente confiable/i);
+  });
+
+  it('en dosis de PRODUCTO comercial, sí puede mencionar la etiqueta', () => {
+    const txt = 'Aplica 30 ml por litro de este producto comercial sobre el cultivo.';
+    const out = guardDoseWithoutSource(txt, null, null, {
+      userMessage: 'qué dosis de fungicida comercial uso',
+    });
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/etiqueta/i);
+  });
+
+  it('NO-REGRESIÓN: sin userMessage el comportamiento previo se conserva (nota genérica)', () => {
+    const txt = 'Aplica 5 g por planta del preparado.';
+    const out = guardDoseWithoutSource(txt);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/confirma la dosis/i);
+  });
+});

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -13,7 +13,7 @@
  */
 
 import { getRegionFromDepartment } from './regionalismsService.js';
-import { classifyQueryIntent } from './outputGuards.js';
+import { classifyQueryIntent, isStapleViableAtAltitude } from './outputGuards.js';
 import {
   isInCaucaRegion as _isInCaucaRegion,
   normalizeUserInput as _normalizeCauca,
@@ -754,6 +754,14 @@ export function buildViabilityContext({
         nivel = fuera <= marginMsnm ? 'marginal' : 'inviable';
       }
     }
+    // #350 (fix DAÑO prod 2026-06-03): un STAPLE en su piso real (papa/fresa a
+    // 1923 m en Choachí) NUNCA se inyecta como inviable, aunque el grounding lo
+    // herede mal (resolver matcheó la base equivocada). Suprimimos el bloque
+    // INVIABLE del prompt para no desviar al campesino de su cultivo principal.
+    // Fuera de la banda real del staple, el veredicto se respeta.
+    if (nivel === 'inviable' && haveAlt && isStapleViableAtAltitude(nombre, alt)) {
+      continue;
+    }
     if (nivel === 'viable') continue; // el agente recomienda directo
 
     const alternativas = _altNames(e.alternativas_viables, 3);
@@ -1302,9 +1310,19 @@ export function buildFincaContext({
   activeAlerts = [],
   catalogNames = null,
   month,
+  userMessage = null,
 } = {}) {
   const p = profile && typeof profile === 'object' ? profile : {};
   const lines = [];
+
+  // #347 (DAÑO prod 2026-06-03) — fuga de inventario en consulta de PRECIO. Si
+  // la pregunta es de precio/mercado ("¿a cómo el bulto/la arroba de papa?"), NO
+  // inyectamos la ubicación (altitud/municipio/coordenadas) ni el inventario de
+  // la finca: son datos personales irrelevantes para un precio y el modelo los
+  // recitaba sin que se los pidieran ("tu finca a 1923 msnm, Choachí, segunda
+  // temporada seca"). Sin userMessage o ante duda → contexto completo (conserva
+  // el comportamiento existente y la personalización).
+  const isPriceIntent = classifyQueryIntent(userMessage) === 'precio';
 
   // ── Ubicación ───────────────────────────────────────────────────────────
   const municipio = p.municipio || null;
@@ -1324,10 +1342,13 @@ export function buildFincaContext({
   if (Number.isFinite(lat) && Number.isFinite(lng)) {
     ubic.push(`(${lat.toFixed(3)}, ${lng.toFixed(3)})`);
   }
-  if (finca && finca.nombre) {
-    lines.push(`Finca activa: "${finca.nombre}"${ubic.length ? ` — ${ubic.join(', ')}` : ''}.`);
-  } else if (ubic.length) {
-    lines.push(`Ubicación: ${ubic.join(', ')}.`);
+  // #347: en consulta de precio NO recitamos ubicación de la finca (fuga).
+  if (!isPriceIntent) {
+    if (finca && finca.nombre) {
+      lines.push(`Finca activa: "${finca.nombre}"${ubic.length ? ` — ${ubic.join(', ')}` : ''}.`);
+    } else if (ubic.length) {
+      lines.push(`Ubicación: ${ubic.join(', ')}.`);
+    }
   }
 
   // ── Temporada (calendárica, local — sin red) ────────────────────────────
@@ -1390,7 +1411,8 @@ export function buildFincaContext({
     );
   }
   const cultivos = summarizeCultivos(verificados);
-  if (cultivos) {
+  // #347: en consulta de precio tampoco recitamos el inventario de la finca.
+  if (cultivos && !isPriceIntent) {
     lines.push(`Cultivos registrados en la finca: ${cultivos}.`);
   }
 

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -148,6 +148,12 @@ const PRICE_INTENT_PATTERNS = [
   /\bcosecha\s+para\s+(vender|venta)\b/,
   /\bbulto[s]?\s+(de|a)\b/,
   /\bcarga\s+de\b/,
+  // #347 (DAÑO prod 2026-06-03) — unidades de COMERCIALIZACIÓN campesina. Una
+  // pregunta por "la arroba/el bulto/la carga de X" es de PRECIO/mercado: no
+  // debe correr los guards de siembra NI inyectar la altitud/municipio de la
+  // finca (fuga de inventario). La siembra sigue ganando si hay verbo de
+  // siembra (PLANTING_INTENT_PATTERNS se evalúa primero en classifyQueryIntent).
+  /\barroba[s]?\b/,
 ];
 
 /**
@@ -301,6 +307,23 @@ const SYNTHETIC_AGROCHEM_TERMS = [
   'glufosinato',
   // producto inventado por el modelo en el bench (CPX-007)
   'pirimex',
+  // #351 (DAÑO prod 2026-06-03) — fertilizantes MINERALES de síntesis. El
+  // transcript real recomendó "NPK 5-10-10" y una receta casera de urea +
+  // fosfato triple + sulfato de potasio. Son fertilizantes de síntesis (contra
+  // la misión agroecológica), no ingredientes activos de plaguicida, pero deben
+  // disparar el mismo redirect a abono orgánico/biopreparado/compost. Las
+  // formas multi-palabra exigen la frase completa (no se confunden con el
+  // nutriente suelto "potasio"/"nitrógeno" en lenguaje natural del campesino).
+  'npk',
+  'urea',
+  'fosfato triple',
+  'fosfato diamonico',
+  'superfosfato triple',
+  'sulfato de potasio',
+  'sulfato de amonio',
+  'nitrato de amonio',
+  'nitrato de potasio',
+  'cloruro de potasio',
 ];
 
 /**
@@ -472,13 +495,24 @@ function _organicRedirect(originalText) {
   const t = _stripDiacritics(originalText);
   const esHongo = /(hongo|tizon|gota|roya|mildeo|mildiu|antracnosis|fungic|enfermedad|mancha)/.test(t);
   const esPlaga = /(plaga|gusano|cogollero|oruga|larva|insecto|pulgon|acaro|trips|mosca|insectic)/.test(t);
+  // #351 — contexto de FERTILIZACIÓN/nutrición (NPK/urea/fosfato/sulfato…): el
+  // redirect debe ofrecer la ruta de abono ORGÁNICO, no solo control de plagas.
+  const esFertilizante =
+    /(npk|urea|fosfato|sulfato\s+de|nitrato\s+de|cloruro\s+de|fertiliz|abon|nutri|aliment|crecimiento|fosforo|potasio|nitrogeno|foliar)/.test(t);
 
   const intro =
-    'Una nota importante: Chagra es agroecológico, no recomendamos agroquímicos sintéticos. ' +
+    'Una nota importante: Chagra es agroecológico, no recomendamos agroquímicos ni fertilizantes sintéticos. ' +
     'Lo que de verdad funciona y cuida tu suelo y tu salud es el manejo orgánico:';
 
   const lineas = [];
-  if (esHongo || (!esHongo && !esPlaga)) {
+  if (esFertilizante) {
+    lineas.push(
+      '- Para nutrir el cultivo (en vez de NPK/urea/fosfato/sulfato de síntesis): compost y bocashi maduros, ' +
+        'humus de lombriz, biol/supermagro como abono foliar, ceniza de leña y cáscaras (potasio), y abonos verdes; ' +
+        'nutren el suelo vivo sin quemar la microbiota ni salinizar.',
+    );
+  }
+  if (esHongo || (!esHongo && !esPlaga && !esFertilizante)) {
     lineas.push(
       '- Para hongos y enfermedades (tizón, roya, gota): caldo bordelés (cal + sulfato de cobre) como preventivo, ' +
         'eliminar focos enfermos, mejorar aireación y drenaje, usar semilla sana y rotar el cultivo.',
@@ -915,11 +949,117 @@ function _groupViabilityHits(hits, dondeTxt) {
 }
 
 /**
+ * #350 — STAPLE-FLOOR: bandas de altitud REALES y AUTORITATIVAS de los cultivos
+ * de pan-coger / staples andinos colombianos. Fuente: rangos agronómicos
+ * consolidados (Agrosavia/ICA, práctica campesina). Cada banda es generosa a
+ * propósito (cubre todas las variedades comunes del cultivo en Colombia).
+ *
+ * PROPÓSITO (fix de DAÑO en producción 2026-06-03, Choachí 1923 msnm): el
+ * sidecar a veces hereda una `viabilidad:'inviable'` ERRÓNEA para un staple —
+ * típicamente porque el resolver matcheó la BASE equivocada (p.ej. "fresa
+ * silvestre andina", de banda alta, en vez de la fresa cultivada) o trajo una
+ * banda estrecha. El guard NO debe propagar esa desinformación: si la finca
+ * está DENTRO de la banda real del staple, el veredicto 'inviable' es casi
+ * seguro un falso-negativo y se SUPRIME (tratamos la especie como neutral/viable
+ * → el guard no corrige). Fuera de la banda real (papa@3600), el veredicto se
+ * respeta: ahí la inviabilidad SÍ es real.
+ *
+ * Conservador por diseño: solo cubre staples inequívocos (papa, fresa, maíz,
+ * fríjol, arveja, etc.); cualquier especie no listada usa la ruta normal
+ * (campo `viabilidad` autoritativo / banda de la entidad). NUNCA marca algo como
+ * inviable que la entidad no marcara; solo PUEDE relajar un 'inviable' dudoso.
+ */
+const STAPLE_ALTITUDE_FLOORS = [
+  // clave normalizada (primer token del nombre común) → [min, max] msnm reales
+  { keys: ['papa'], min: 1800, max: 3400 },          // papa común andina
+  { keys: ['fresa', 'frutilla'], min: 1300, max: 2800 },
+  { keys: ['arveja'], min: 1800, max: 3000 },
+  { keys: ['haba'], min: 2000, max: 3200 },
+  { keys: ['maiz'], min: 0, max: 2800 },
+  { keys: ['frijol', 'frijoles', 'frisol', 'habichuela'], min: 600, max: 2600 },
+  { keys: ['cebolla'], min: 1500, max: 3000 },
+  { keys: ['zanahoria'], min: 1800, max: 3000 },
+  { keys: ['repollo', 'col'], min: 1800, max: 3200 },
+  { keys: ['lechuga'], min: 1500, max: 3000 },
+  { keys: ['tomate'], min: 800, max: 2600 },         // tomate de mesa (no de árbol)
+  { keys: ['trigo'], min: 2200, max: 3200 },
+  { keys: ['cebada'], min: 2200, max: 3400 },
+  // NOTA: los tubérculos altoandinos (chugua/ulluco/oca) NO van aquí a
+  // propósito. Sus bandas varían mucho por variedad y el daño en producción que
+  // motiva este override fue sobre staples TEMPLADOS (papa/fresa) marcados
+  // inviables en su piso medio. Para los altoandinos dejamos que mande la banda
+  // de la entidad del grounding (evita relajar un 'inviable' legítimo por altura).
+];
+
+/**
+ * _stapleFloorBand — devuelve la banda de altitud real del staple cuyo primer
+ * token de nombre común coincide con el de la especie, o null si no es un
+ * staple cubierto. El nombre se normaliza (sin tildes/case) y se compara por
+ * primer token significativo (igual que `_baseCommonName`), de modo que
+ * "Papa criolla", "Papa Sabanera" y "papa" caen en la misma banda.
+ *
+ * @param {string} nombre  nombre común de la especie.
+ * @returns {{min:number, max:number}|null}
+ */
+function _stapleFloorBand(nombre) {
+  const base = _baseCommonName(nombre); // ya normalizado, sin tildes/case
+  if (!base) return null;
+  const first = base.split(/\s+/)[0];
+  if (!first || first.length < 3) return null;
+  for (const entry of STAPLE_ALTITUDE_FLOORS) {
+    if (entry.keys.includes(first)) return { min: entry.min, max: entry.max };
+  }
+  return null;
+}
+
+/**
+ * _isStapleViableAtAltitude — ¿es esta especie un staple cubierto Y la finca
+ * está DENTRO de su banda real? Si sí, un veredicto 'inviable' heredado es muy
+ * probablemente un falso-negativo (#350) y debe SUPRIMIRSE. Requiere altitud de
+ * finca conocida y finita; sin ella no podemos juzgar → false (no relaja nada).
+ *
+ * @param {object} e  entidad de especie del grounding.
+ * @param {number} alt  altitud de la finca (msnm), ya validada como finita.
+ * @returns {boolean}
+ */
+function _isStapleViableAtAltitude(e, alt) {
+  if (!Number.isFinite(alt)) return false;
+  const band = _stapleFloorBand(_entityName(e));
+  if (!band) return false;
+  return alt >= band.min && alt <= band.max;
+}
+
+/**
+ * isStapleViableAtAltitude — versión EXPORTADA del override de staple-floor
+ * (#350), para que `buildViabilityContext` (agentService) suprima el bloque de
+ * prompt "INVIABLE" de un staple en su piso ANTES de que llegue al LLM, igual
+ * que el guard lo hace sobre la salida. Acepta el nombre común directamente (la
+ * forma que tiene a mano agentService) además de altitud.
+ *
+ * @param {string} nombre  nombre común de la especie.
+ * @param {number|string|null} altitud  msnm de la finca.
+ * @returns {boolean}
+ */
+export function isStapleViableAtAltitude(nombre, altitud) {
+  const alt = Number(altitud);
+  if (!Number.isFinite(alt)) return false;
+  const band = _stapleFloorBand(nombre);
+  if (!band) return false;
+  return alt >= band.min && alt <= band.max;
+}
+
+/**
  * Guard 3 — viabilidad invertida. Si el grounding marca `viabilidad:"inviable"`
  * para una especie a la altitud de la finca y la respuesta la recomienda como
  * viable/buena, CORRIGE ("a tu altura no se da") y lidera con
  * `alternativas_viables`. NO toca "marginal" (eso SÍ es posible con cuidados:
  * doctrina zona-gris).
+ *
+ * #350 (fix DAÑO prod 2026-06-03): antes de tratar una especie como 'inviable',
+ * si es un STAPLE cubierto y la finca cae DENTRO de su banda real
+ * (`STAPLE_ALTITUDE_FLOORS`), el veredicto 'inviable' se descarta como
+ * falso-negativo — un staple en su piso JAMÁS se marca inviable ni se desvía a
+ * variedades extranjeras. Fuera de su banda real, la inviabilidad se respeta.
  *
  * REEMPLAZO, no prepend (fix fuga viva 2026-05-31): la corrección lidera Y se
  * ELIMINAN del texto del modelo las oraciones que promovían la especie
@@ -970,6 +1110,16 @@ export function guardInvertedViability(responseText, resolvedEntities = null, fi
         nivel = fuera <= 300 ? 'marginal' : 'inviable';
       }
     }
+    // #350 — STAPLE-FLOOR override: un staple cubierto cuya finca cae DENTRO de
+    // su banda real NUNCA se marca inviable, aunque el grounding así lo herede
+    // (el resolver pudo matchear la base equivocada, p.ej. "fresa silvestre
+    // andina"). Es el fix del daño en prod (Choachí 1923 m: papa/fresa viables).
+    // Solo relaja 'inviable' dudoso; fuera de la banda real el veredicto se
+    // respeta (papa@3600 sigue inviable).
+    if (nivel === 'inviable' && haveAlt && _isStapleViableAtAltitude(e, alt)) {
+      continue;
+    }
+
     // Solo INVIABLE corrige. marginal/viable se respetan (zona gris).
     if (nivel !== 'inviable') continue;
 
@@ -1160,7 +1310,12 @@ const SOURCE_HINT_RE =
  *
  * @returns {{text:string, modified:boolean, reason:string|null}}
  */
-export function guardDoseWithoutSource(responseText, _resolvedEntities = null, _fincaAltitud = null) {
+export function guardDoseWithoutSource(
+  responseText,
+  _resolvedEntities = null,
+  _fincaAltitud = null,
+  { userMessage = null } = {},
+) {
   if (typeof responseText !== 'string' || responseText.length === 0) {
     return { text: responseText ?? '', modified: false, reason: null };
   }
@@ -1173,15 +1328,30 @@ export function guardDoseWithoutSource(responseText, _resolvedEntities = null, _
   if (SOURCE_HINT_RE.test(responseText)) {
     return { text: responseText, modified: false, reason: null };
   }
-  // Evitar duplicar la nota si ya está.
-  if (/confirma la dosis con/i.test(responseText)) {
+  // Evitar duplicar la nota si ya está (cualquiera de las dos variantes).
+  if (/confirma la dosis con|ajusta la receta a tu/i.test(responseText)) {
     return { text: responseText, modified: false, reason: null };
   }
 
   bumpGuardTelemetry('dose_without_source');
-  const nota =
-    'Nota sobre las dosis: confirma la dosis exacta con la etiqueta del producto o con tu técnico agrícola local ' +
-    'antes de aplicar — las cantidades varían según el producto y no conviene guiarse por una cifra sin fuente.';
+  // #8 (DAÑO prod 2026-06-03) — disclaimer mal ubicado. En un biopreparado
+  // CASERO no hay "etiqueta del producto" que consultar; pedirla es absurdo.
+  // Si la respuesta o la pregunta son de preparado casero/biopreparado, usamos
+  // una nota que orienta a la RECETA / fuente campesina (Restrepo, técnico),
+  // no a una etiqueta comercial inexistente.
+  const ctxNorm = _stripDiacritics(`${responseText} ${userMessage || ''}`);
+  const esCasero =
+    /(biopreparado|casero|caldo\s+(bordeles|sulfocalcico|mineral)|sulfocalcic|bocashi|biol\b|supermagro|purin|lixiviad|hecho\s+en\s+(la\s+)?(casa|finca)|en\s+tu\s+finca|prepara(r|s)?\b)/.test(ctxNorm);
+  // Solo casero si NO hay además mención de producto comercial (ante mezcla,
+  // conservador hacia el disclaimer comercial — que sí menciona etiqueta).
+  const esComercial = /(producto\s+comercial|marca\s+comercial|fungicida\s+comercial|insecticida\s+comercial|etiqueta)/.test(ctxNorm);
+
+  const nota = (esCasero && !esComercial)
+    ? 'Nota sobre las cantidades: como es un preparado casero, no hay etiqueta de producto que consultar. ' +
+      'Ajusta la receta a tu volumen y guíate por una fuente confiable de campo (un manual como el de Jairo ' +
+      'Restrepo, tu técnico agrícola local o la receta del catálogo); empieza con poco y observa cómo responde el cultivo.'
+    : 'Nota sobre las dosis: confirma la dosis exacta con la etiqueta del producto o con tu técnico agrícola local ' +
+      'antes de aplicar — las cantidades varían según el producto y no conviene guiarse por una cifra sin fuente.';
   const text = `${responseText.trim()}\n\n${nota}`;
   return { text, modified: true, reason: `dosis_sin_fuente: ${[...new Set(doses)].slice(0, 5).join(', ')}` };
 }
@@ -2323,6 +2493,103 @@ export function guardReforestacionNativasRol(responseText, { userMessage = null 
   return { text, modified: true, reason: 'reforestacion_nativas_rol' };
 }
 
+// ── GUARD DE DOMINIO: off-domain declina (no física/química/mate) ────────────
+
+/**
+ * #352 (DAÑO prod 2026-06-03) — léxico OFF-DOMAIN. Chagra es un asistente
+ * AGROECOLÓGICO; en producción respondió disertaciones completas de física
+ * (relatividad, teoría de cuerdas) y química inorgánica, incluso con un badge de
+ * grounding FALSO ("Catálogo verificado · get_normativa_ica"). Estos términos
+ * (normalizados, sin tildes) señalan una consulta claramente FUERA del dominio
+ * agro. Si la PREGUNTA del usuario los trae y NO hay señal agro, declinamos.
+ *
+ * Conservador: solo dispara sobre la PREGUNTA (no sobre la respuesta), porque la
+ * respuesta agro legítima puede mencionar "química" del suelo de forma válida.
+ */
+const OFF_DOMAIN_TERMS = [
+  // física
+  'teoria de cuerdas', 'teoria de la relatividad', 'relatividad', 'mecanica cuantica',
+  'fisica cuantica', 'agujero negro', 'agujeros negros', 'big bang', 'energia oscura',
+  'materia oscura', 'particula', 'particulas elementales', 'boson', 'higgs', 'leyes de newton',
+  'termodinamica', 'electromagnetismo',
+  // química/matemáticas puras (no agro)
+  'quimica organica e inorganica', 'quimica inorganica', 'tabla periodica',
+  'ecuacion diferencial', 'ecuaciones diferenciales', 'integral definida', 'derivada de',
+  'teorema de pitagoras', 'numeros primos', 'logaritmo',
+  // otros dominios lejanos
+  'codigo penal', 'derecho penal', 'historia universal', 'segunda guerra mundial',
+  'programacion en python', 'lenguaje de programacion', 'inteligencia artificial generativa',
+];
+
+/**
+ * Señales claras de que la consulta SÍ es de agro/finca/cultivo (gate de
+ * seguridad: si están presentes, NO declinamos aunque también aparezca una
+ * palabra como "quimica"). Cubre el caso "química orgánica para mi compost".
+ */
+const AGRO_DOMAIN_HINTS = [
+  'cultiv', 'siembr', 'sembr', 'cosech', 'finca', 'parcela', 'huerta', 'huerto', 'chagra',
+  'planta', 'semilla', 'suelo', 'abono', 'compost', 'biopreparado', 'plaga', 'cultivo',
+  'fertiliz', 'riego', 'germin', 'poda', 'injerto', 'pasto', 'ganado', 'gallina', 'vaca',
+  'cafe', 'platano', 'papa', 'maiz', 'frijol', 'tomate', 'fresa', 'mora', 'aguacate',
+  'agroecolog', 'lombri', 'humus', 'mulch', 'rotacion', 'asociacion de cultivos',
+];
+
+/**
+ * Texto de declinación amable: reconoce el límite de dominio y reconduce a la
+ * finca. NO inventa tool ni grounding. Tono cálido (campesino), tú/usted CO.
+ */
+const OFF_DOMAIN_DECLINE =
+  'Con todo el gusto te ayudaría, pero esa pregunta se sale de lo mío: soy tu ' +
+  'asistente de cultivos y finca agroecológica, no manejo física, química pura ' +
+  'ni esos otros temas. ¿Te ayudo mejor con algo de tu finca —qué sembrar, una ' +
+  'plaga, un biopreparado, el clima o el suelo?';
+
+/**
+ * guardOffDomain — #352. Si la PREGUNTA del usuario es claramente off-domain
+ * (física/química pura/matemáticas/otros) y SIN señal agro, REEMPLAZA la
+ * respuesta del LLM por una declinación amable que reconduce a la finca. Evita
+ * que el agente diserte de relatividad o teoría de cuerdas con badge de
+ * grounding falso. NO corre tool ni grounding (es puro post-proceso de salida).
+ *
+ * Diseño anti-falso-positivo:
+ *  - Solo mira la PREGUNTA (no la respuesta): la respuesta agro válida puede
+ *    mencionar "química del suelo" legítimamente.
+ *  - Gate agro: si la pregunta trae cualquier señal de finca/cultivo, NO
+ *    declina ("química orgánica para mi compost" → pasa).
+ *  - Sin userMessage → no-op (fail-open: deja correr el resto de la cadena).
+ *
+ * Firma propia (necesita userMessage) → se invoca aparte en applyOutputGuards,
+ * fuera de GUARD_CHAIN, y ANTES que los demás (si declinamos, lo demás sobra).
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardOffDomain(responseText, { userMessage = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  // Sin la pregunta no podemos juzgar el dominio → no-op (fail-open).
+  if (typeof userMessage !== 'string' || !userMessage.trim()) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  const qNorm = _stripDiacritics(userMessage);
+  // Gate agro: cualquier señal de finca/cultivo → NO declinamos.
+  if (AGRO_DOMAIN_HINTS.some((h) => qNorm.includes(h))) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  // ¿La pregunta contiene un término off-domain inequívoco?
+  if (!OFF_DOMAIN_TERMS.some((t) => qNorm.includes(t))) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  // Idempotencia: si ya declinamos, no re-disparamos.
+  if (responseText.includes('se sale de lo mío')) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  bumpGuardTelemetry('off_domain');
+  return { text: OFF_DOMAIN_DECLINE, modified: true, reason: 'off_domain' };
+}
+
 /**
  * Set de guards que SOLO tienen sentido cuando la consulta es de SIEMBRA
  * (A12). Si la pregunta del usuario es de PRECIO/MERCADO (o info general sin
@@ -2424,6 +2691,15 @@ export function applyOutputGuards(
   let modified = false;
   const reasons = [];
 
+  // GUARD DE DOMINIO PRIMERO (#352): si la PREGUNTA es claramente off-domain
+  // (física/química pura/mate), REEMPLAZAMOS por una declinación amable y NO
+  // corremos nada más — los demás guards razonarían sobre un texto que ya
+  // descartamos entero. Firma propia (necesita userMessage). No-op sin pregunta.
+  const offDomain = guardOffDomain(text, { userMessage });
+  if (offDomain && offDomain.modified) {
+    return { text: offDomain.text, modified: true, reasons: [offDomain.reason].filter(Boolean) };
+  }
+
   // GUARD de visión PRIMERO: si la respuesta afirma un diagnóstico visual sin
   // foto real en el turno, no tiene sentido correr los demás guards sobre un
   // texto que vamos a reemplazar entero. Firma propia (contexto de visión), por
@@ -2440,7 +2716,10 @@ export function applyOutputGuards(
     // (precio/mercado). Los de SAFETY/inofensivos NO están en PLANTING_GUARDS y
     // corren siempre.
     if (!runPlantingGuards && PLANTING_GUARDS.has(guard)) continue;
-    const res = guard(text, entities, fincaAltitud);
+    // Pasamos userMessage como 4º arg (ctx) a TODA la cadena: los guards que no
+    // lo usan lo ignoran; guardDoseWithoutSource lo necesita para distinguir un
+    // biopreparado CASERO (sin etiqueta) de un producto comercial (#8).
+    const res = guard(text, entities, fincaAltitud, { userMessage });
     if (res && res.modified) {
       text = res.text;
       modified = true;


### PR DESCRIPTION
> **prod-harm fix · espera revisión operador.** NO mergear sin revisión despierto: mergear dispara auto-deploy a producción (Cloudflare Pages) y son guards de SEGURIDAD del agente. Dejar ABIERTO.

## Bug / Feature
Transcript REAL de producción (Choachí, 1923 msnm, templado) donde el agente emitió **desinformación activa** que desviaba al campesino de su cultivo principal. Cinco fixes en el path de guards de salida, en un solo branch/PR (un dueño de `outputGuards`).

Fuente: `Chagra-strategy/ops/PROD-ERRORS-TRANSCRIPT-2026-06-03.md`.

## Causa raíz
El NLU degrada → todo cae al LLM generativo y los guards de salida no contenían (o contenían mal) estos cinco casos. Para el #350 en particular: el guard confiaba en un veredicto `viabilidad:'inviable'` heredado del grounding que estaba equivocado (el resolver matcheó la base errónea, p.ej. "fresa silvestre andina" en vez de la fresa cultivada), y propagaba la inviabilidad de un staple en su piso real.

## Cambios
- **#350 inverted-viability falso-negativo** (`outputGuards.js` + `agentService.js`): tabla `STAPLE_ALTITUDE_FLOORS` con las bandas de altitud REALES de los staples templados/medios (papa, fresa, arveja, maíz, fríjol, tomate de mesa…). Un staple cuya finca cae DENTRO de su banda real NUNCA se marca inviable, aunque el grounding lo herede mal. Aplicado tanto al guard de salida (`guardInvertedViability`) como a la inyección de prompt (`buildViabilityContext`). Conservador: fuera de la banda real el veredicto se respeta (papa@3600 sigue inviable); los tubérculos altoandinos (chugua/ulluco/oca) quedan fuera de la tabla a propósito (banda de la entidad manda).
- **#351 agroquímico** (`outputGuards.js`): `guardSyntheticAgrochemical` ahora cubre fertilizantes minerales de síntesis (`NPK`, `urea`, `fosfato triple/diamónico`, `sulfato de potasio`, `nitrato/cloruro de potasio`, `sulfato/nitrato de amonio`) y el redirect ofrece la ruta de abono orgánico (compost, bocashi, humus de lombriz, biol). Las formas multi-palabra exigen la frase completa (no se confunden con el nutriente suelto "potasio").
- **#352 guard de dominio** (`outputGuards.js`): nuevo `guardOffDomain` — si la PREGUNTA es claramente off-domain (física/química pura/matemáticas) y sin señal agro, declina amable y reconduce a la finca, SIN tool ni grounding falso. Gate agro evita falsos positivos ("química orgánica para mi compost" pasa). Corre primero en `applyOutputGuards` y corto-circuita.
- **#347 fuga de inventario en precio** (`outputGuards.js` + `agentService.js` + `AgentScreen.jsx`): "arroba/bulto/carga de X" se clasifica como `price_intent`; `buildFincaContext` no inyecta ubicación (altitud/municipio/coords) ni inventario en consultas de precio.
- **#8 disclaimer de dosis** (`outputGuards.js`): en biopreparado CASERO la nota ya no pide "etiqueta del producto" (inexistente); orienta a la receta/fuente de campo (manual tipo Restrepo, técnico local).

## Tests
- **29 casos nuevos** en `src/services/__tests__/outputGuards.prodHarm20260603.test.js` (TDD test-first), incluyendo:
  - papa@1923→viable, fresa@1923→viable, papa@3600→inviable (no-regresión), maracuyá@2100→inviable (no-regresión).
  - receta del transcript (urea + fosfato triple + sulfato de potasio) dispara; compost/bocashi y "potasio" suelto NO disparan (no falso-positivo).
  - "teoría de cuerdas"/relatividad/química inorgánica declinan; "qué siembro" y "química orgánica para mi compost" pasan.
  - "arroba/bulto/carga de X" = precio; "siembro una arroba" = siembra; en `applyOutputGuards` la query de precio no inyecta "NO viable".
  - biopreparado casero NO menciona "etiqueta del producto"; producto comercial sí.
- Suite completa verde: **2261 tests** (107 archivos), eslint `max-warnings=0` en los 4 archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)