### PR TITLE
fix(agent): pack guards anti-daño prod Choachí 1923m (#347 #348 #350 #351 #352) · prod-harm fix · espera revisión operador

### DIFF
--- a/src/services/__tests__/outputGuards.prodHarm.test.js
+++ b/src/services/__tests__/outputGuards.prodHarm.test.js
@@ -1,0 +1,351 @@
+/**
+ * outputGuards.prodHarm.test.js — PACK de fixes de daño en producción.
+ *
+ * Contexto: transcript real del operador con el agente Chagra en prod (Choachí,
+ * 1923 msnm, templado) 2026-06-03. Patrón raíz: NLU abortó → todo cayó al LLM
+ * generativo sin grounding y los guards no tenían entidad/data. Estos tests
+ * mockean la SALIDA REAL dañina que produjo el agente y verifican que el guard
+ * AHORA la corrige (antes→después). Ground-truth:
+ *   Chagra-strategy/ops/PROD-ERRORS-TRANSCRIPT-2026-06-03.md
+ *
+ * Cobertura:
+ *   #350 — inverted-viability FALSO-NEGATIVO (papa/fresa @1923 → viable).
+ *   #351 — agroquímico: fertilizantes de síntesis (NPK/urea/fosfato…).
+ *   #352 — guard de dominio (off-domain física/química/matemáticas).
+ *   #347 — fuga de inventario en precio (bulto/arroba/carga → price intent).
+ *   #348 — anti-diagnóstico-sin-foto ("manchas en el tomate" sin imagen).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardFalseInviability,
+  guardSyntheticAgrochemical,
+  guardOffDomain,
+  guardDiagnosisWithoutPhoto,
+  classifyQueryIntent,
+  applyOutputGuards,
+  resetOutputGuardTelemetry,
+  getOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #350 — inverted-viability FALSO-NEGATIVO (CRÍTICO)
+// ──────────────────────────────────────────────────────────────────────────
+describe('#350 guardFalseInviability (papa/fresa viable marcadas inviables)', () => {
+  it('papa @1923 m → corrige a VIABLE (Choachí es zona papera templada)', () => {
+    const llmFail =
+      'En tu finca a 1923 msnm las variedades de papa NO son viables, el clima no les sirve y no vale ' +
+      'la pena el esfuerzo. Mejor siembra Daikon o ajo, que sí aguantan tu altura.';
+    const out = guardFalseInviability(llmFail, null, 1923);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/viabilidad_falso_negativo/);
+    expect(out.reason).toMatch(/papa/);
+    // La corrección afirma viabilidad y lidera.
+    expect(out.text).toMatch(/papa.*S[ÍI] es viable|S[ÍI] es viable/i);
+    expect(out.text.indexOf('Corrección')).toBe(0);
+    // La afirmación FALSA de inviabilidad se elimina.
+    expect(out.text).not.toMatch(/papa NO son viables/i);
+    expect(out.text).not.toMatch(/no vale la pena el esfuerzo/i);
+  });
+
+  it('fresa @1923 m → corrige a VIABLE', () => {
+    const llmFail =
+      'La fresa silvestre andina NO es viable a 1923 msnm en tu finca; su clima no le sirve. ' +
+      'Te sugiero variedades extranjeras como otra cosa.';
+    const out = guardFalseInviability(llmFail, null, 1923);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/fresa/);
+    expect(out.text).toMatch(/S[ÍI] es viable/i);
+    expect(out.text).not.toMatch(/fresa silvestre andina NO es viable/i);
+  });
+
+  it('papa @3500 m → NO corrige (fuera de banda; inviabilidad por frío real es legítima)', () => {
+    // Spec: papa@3500 → inviable. Por encima del techo comercial (3200 m) la papa
+    // entra en zona fría marginal; el guard NO debe inventar viabilidad ahí.
+    const llmFail = 'A 3500 msnm la papa NO es viable, hace demasiado frío para tuberizar bien.';
+    const out = guardFalseInviability(llmFail, null, 3500);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(llmFail);
+  });
+
+  it('NO dispara si el texto NO declara inviabilidad (papa mencionada como viable)', () => {
+    const ok = 'A 1923 msnm la papa se da muy bien; es zona papera tradicional.';
+    const out = guardFalseInviability(ok, null, 1923);
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO dispara sin altitud de finca (no podemos afirmar viabilidad sin saber la altura)', () => {
+    const llmFail = 'La papa NO es viable en tu finca.';
+    const out = guardFalseInviability(llmFail, null, null);
+    expect(out.modified).toBe(false);
+  });
+
+  it('DEFIERE al grounding: si la AGE marca papa inviable autoritativamente, NO afirma viabilidad', () => {
+    // Precedencia: la tabla hardcodeada es RED DE SEGURIDAD para el caso SIN
+    // grounding (NLU abortó). Si el grafo SÍ resolvió viabilidad:inviable para la
+    // papa, la AGE manda — este guard cede (lo corrige guardInvertedViability).
+    const llmFail = 'La papa NO es viable en tu finca a 1923 msnm.';
+    const groundedInviable = [
+      { kind: 'species', nombre_comun: 'papa', mentioned: 'papa', viabilidad: 'inviable', nombre_cientifico: 'Solanum tuberosum' },
+    ];
+    const out = guardFalseInviability(llmFail, groundedInviable, 1923);
+    expect(out.modified).toBe(false);
+  });
+
+  it('dispara cuando NO hay grounding (caso real: NLU abortó, LLM inventó la inviabilidad)', () => {
+    const llmFail = 'La papa NO es viable en tu finca a 1923 msnm.';
+    const out = guardFalseInviability(llmFail, [], 1923);
+    expect(out.modified).toBe(true);
+  });
+
+  it('emite telemetría false_inviability', () => {
+    guardFalseInviability('La papa no es viable a esa altura.', null, 1923);
+    expect(getOutputGuardTelemetry().false_inviability).toBe(1);
+  });
+
+  it('maneja entrada vacía / no-string', () => {
+    expect(guardFalseInviability('', null, 1923).modified).toBe(false);
+    expect(guardFalseInviability(null, null, 1923).text).toBe('');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #351 — fertilizantes de síntesis (extiende guardSyntheticAgrochemical)
+// ──────────────────────────────────────────────────────────────────────────
+describe('#351 guardSyntheticAgrochemical — fertilizantes de síntesis', () => {
+  it('CASO REAL: "plan de alimentación con NPK 5-10-10, foliar 10-10-10" → redirige a orgánico', () => {
+    const llmFail =
+      'Para tu plan de alimentación de las fresas aplica NPK 5-10-10 al suelo y un foliar 10-10-10 ' +
+      'cada quince días para que cuajen bien.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/npk|10-10-10|5-10-10/i);
+    expect(out.text).toMatch(/agroecológico/i);
+    // Redirige a abono orgánico (compost/bocashi/biol), no a un fungicida.
+    expect(out.text).toMatch(/compost|bocashi|biol|humus/i);
+  });
+
+  it('CASO REAL: "mezcla urea + fosfato triple + sulfato de potasio" → bloquea y redirige', () => {
+    const llmFail =
+      'Para hacer tú mismo ese NPK, mezcla urea como fuente de nitrógeno, fosfato triple para el ' +
+      'fósforo y sulfato de potasio para el potasio, en partes iguales.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/urea|fosfato triple|sulfato de potasio/i);
+    expect(out.text).toMatch(/compost|bocashi|biol|humus/i);
+  });
+
+  it('bloquea nitrato de amonio y fosfato diamónico', () => {
+    for (const llmFail of [
+      'Aplica nitrato de amonio para que pegue verde rápido.',
+      'El fosfato diamónico (DAP) es lo mejor para el arranque.',
+    ]) {
+      const out = guardSyntheticAgrochemical(llmFail);
+      expect(out.modified, llmFail).toBe(true);
+    }
+  });
+
+  it('NO bloquea biopreparados/abonos orgánicos legítimos (compost, bocashi, biol, humus)', () => {
+    const ok =
+      'Para nutrir tus fresas usa compost bien maduro, bocashi y biol cada quince días; ' +
+      'alimentan el suelo vivo sin acidificarlo.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('NO marca un rango numérico que no es formulación NPK (ej. "siembra a 30-40 cm")', () => {
+    const ok = 'Siembra las matas de fresa a 30-40 cm entre plantas para buena aireación.';
+    const out = guardSyntheticAgrochemical(ok);
+    // 30-40 es un par, no un triplete N-P-K → no dispara la regla de formulación.
+    expect(out.modified).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #352 — guard de dominio (off-domain)
+// ──────────────────────────────────────────────────────────────────────────
+describe('#352 guardOffDomain', () => {
+  it('"explícame la teoría de cuerdas" → declina amable y redirige, SIN tool/grounding', () => {
+    const llmFail =
+      'La teoría de cuerdas postula que las partículas elementales son cuerdas vibrantes en un ' +
+      'espacio de 11 dimensiones, unificando la relatividad general con la mecánica cuántica.';
+    const out = guardOffDomain(llmFail, { userMessage: 'explícame la teoría de cuerdas' });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/off_domain/);
+    // Declina y redirige al dominio agro, sin mencionar tool ni catálogo.
+    expect(out.text).toMatch(/asistente de cultivos y agroecolog[ií]a/i);
+    expect(out.text).not.toMatch(/get_normativa_ica|cat[aá]logo verificado|tool/i);
+    // No repite la explicación de física.
+    expect(out.text).not.toMatch(/cuerdas vibrantes|11 dimensiones/i);
+  });
+
+  it('declina relatividad y química orgánica/inorgánica', () => {
+    for (const q of [
+      'qué es la teoría de la relatividad',
+      'diferencia entre química orgánica e inorgánica',
+      'resuélveme una ecuación de segundo grado',
+    ]) {
+      const out = guardOffDomain('Una respuesta académica completa.', { userMessage: q });
+      expect(out.modified, q).toBe(true);
+      expect(out.text).toMatch(/asistente de cultivos/i);
+    }
+  });
+
+  it('"qué siembro a 1923 msnm" → pasa (es agro, no toca)', () => {
+    const ok = 'A 1923 msnm te van bien papa, fresa, arveja y hortalizas de clima templado.';
+    const out = guardOffDomain(ok, { userMessage: 'qué siembro a 1923 msnm' });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('NO declina temas agro que comparten vocabulario con química ("química del suelo", "pH")', () => {
+    const ok = 'El pH del suelo afecta la disponibilidad de nutrientes; con cal subes el pH ácido.';
+    const out = guardOffDomain(ok, { userMessage: 'cómo mejoro la química del suelo de mi finca' });
+    expect(out.modified).toBe(false);
+  });
+
+  it('sin userMessage → no-op (no juzgamos el dominio)', () => {
+    const out = guardOffDomain('Algo.', {});
+    expect(out.modified).toBe(false);
+  });
+
+  it('idempotente: no re-dispara sobre su propio mensaje de declinación', () => {
+    const first = guardOffDomain('física pura', { userMessage: 'teoría de cuerdas' });
+    expect(first.modified).toBe(true);
+    const second = guardOffDomain(first.text, { userMessage: 'teoría de cuerdas' });
+    expect(second.modified).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #347 — fuga de inventario en precio (clasificación de unidades de mercado)
+// ──────────────────────────────────────────────────────────────────────────
+describe('#347 classifyQueryIntent — unidades de comercialización = precio', () => {
+  it('"a cómo está el bulto de papa" → precio', () => {
+    expect(classifyQueryIntent('a cómo está el bulto de papa')).toBe('precio');
+  });
+
+  it('"cuánto vale la arroba de fresa" → precio', () => {
+    expect(classifyQueryIntent('cuánto vale la arroba de fresa')).toBe('precio');
+  });
+
+  it('"a cómo la carga de papa" → precio', () => {
+    expect(classifyQueryIntent('a cómo la carga de papa')).toBe('precio');
+  });
+
+  it('una query de precio (bulto) NO corre los guards de siembra ni filtra inventario', () => {
+    // El modelo, en una consulta de precio, NO debe inyectar viabilidad/altitud.
+    // applyOutputGuards con userMessage de precio salta los guards de siembra.
+    const resp = 'No tengo el precio del bulto de papa; consulta SIPSA/DANE o la central de abastos.';
+    const out = applyOutputGuards(resp, {
+      userMessage: 'a cómo está el bulto de papa',
+      fincaAltitud: 1923,
+      resolvedEntities: [
+        { kind: 'species', nombre_comun: 'papa', mentioned: 'papa', viabilidad: 'viable' },
+      ],
+    });
+    // No se le anexa ninguna corrección de siembra.
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(resp);
+  });
+
+  it('"qué papa siembro" sigue siendo siembra (no la confunde con precio)', () => {
+    expect(classifyQueryIntent('qué papa siembro en mi finca')).toBe('siembra');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #348 — anti-diagnóstico-sin-foto
+// ──────────────────────────────────────────────────────────────────────────
+describe('#348 guardDiagnosisWithoutPhoto', () => {
+  it('"manchas en el tomate" SIN foto + lista de patógenos → antepone petición de foto/datos', () => {
+    const llmFail =
+      'Las manchas en el tomate pueden ser tizón tardío (Phytophthora infestans), alternaria o ' +
+      'septoria. Para el tizón aplica preventivos; para alternaria mejora la aireación.';
+    const out = guardDiagnosisWithoutPhoto(llmFail, {
+      userMessage: 'tengo manchas en el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/diagnostico_sin_foto/);
+    // La petición de evidencia ENCABEZA la respuesta.
+    expect(out.text.indexOf('Antes de ponerle nombre')).toBe(0);
+    expect(out.text).toMatch(/foto|c[aá]mara/i);
+    // La lista del modelo se conserva debajo (como referencia, no como diagnóstico).
+    expect(out.text).toMatch(/tiz[oó]n tard[ií]o/i);
+  });
+
+  it('NO dispara cuando SÍ hubo foto (diagnóstico legítimo)', () => {
+    const ok =
+      'En tu foto se ve tizón tardío en las hojas bajas. Aplica caldo bordelés preventivo y retira focos.';
+    const out = guardDiagnosisWithoutPhoto(ok, {
+      userMessage: 'qué le pasa al tomate',
+      hadVision: true,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO dispara si la respuesta NO enumera candidatos (solo pide foto / manejo cultural)', () => {
+    const ok =
+      'Para saber qué tiene tu tomate necesito ver una foto de las manchas. Mientras tanto, riega por ' +
+      'la base y evita mojar las hojas.';
+    const out = guardDiagnosisWithoutPhoto(ok, {
+      userMessage: 'manchas en el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('NO dispara en una pregunta que no es de diagnóstico de síntomas', () => {
+    const resp = 'A 1923 msnm el tomate va bien bajo invernadero. Puede ser de cosecha en 4 meses.';
+    const out = guardDiagnosisWithoutPhoto(resp, {
+      userMessage: 'cuándo cosecho el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('idempotente: no re-antepone la nota dos veces', () => {
+    const llmFail =
+      'Las manchas pueden ser tizón tardío o alternaria. Revisa la aireación del cultivo.';
+    const ctx = { userMessage: 'manchas en el tomate', hadVision: false };
+    const first = guardDiagnosisWithoutPhoto(llmFail, ctx);
+    expect(first.modified).toBe(true);
+    const second = guardDiagnosisWithoutPhoto(first.text, ctx);
+    expect(second.modified).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Integración: applyOutputGuards con userMessage off-domain / diagnóstico
+// ──────────────────────────────────────────────────────────────────────────
+describe('applyOutputGuards (integración prod-harm)', () => {
+  it('off-domain reemplaza la respuesta entera y no corre otros guards', () => {
+    const llmFail =
+      'La teoría de cuerdas unifica la relatividad con la mecánica cuántica en 11 dimensiones.';
+    const out = applyOutputGuards(llmFail, {
+      userMessage: 'explícame la teoría de cuerdas',
+      fincaAltitud: 1923,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reasons).toContain('off_domain');
+    expect(out.text).toMatch(/asistente de cultivos/i);
+  });
+
+  it('papa-inviable-falso + siembra: la cadena corrige a viable', () => {
+    const llmFail =
+      'En tu finca a 1923 msnm la papa NO es viable; mejor siembra Daikon. La papa no vale la pena.';
+    const out = applyOutputGuards(llmFail, {
+      userMessage: 'qué papa siembro a 1923 msnm',
+      fincaAltitud: 1923,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reasons.some((r) => /falso_negativo/.test(r))).toBe(true);
+    expect(out.text).toMatch(/S[ÍI] es viable/i);
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -146,8 +146,15 @@ const PRICE_INTENT_PATTERNS = [
   /\b(donde|a\s+quien)\s+(puedo\s+)?(vendo|vender|comprar|compro)\b/,
   /\b(vendo|vender|venta|comprar|compra|comprador|comercializ)\w*\b/,
   /\bcosecha\s+para\s+(vender|venta)\b/,
+  // #347 (prod 2026-06-03): unidades de comercialización mayorista. "el bulto/
+  // la arroba/la carga de papa" es una consulta de MERCADO, no de siembra. Sin
+  // estas, "a cómo el bulto de papa" filtraba la altitud/municipio de la finca y
+  // disparaba la cascada de viabilidad por variedad.
   /\bbulto[s]?\s+(de|a)\b/,
+  /\barroba[s]?\s+(de|a)\b/,
+  /\bcarga[s]?\s+(de|a)\b/,
   /\bcarga\s+de\b/,
+  /\b(el|la|los|las|una?|cuantas?)\s+(arroba|bulto|carga)[s]?\b/,
 ];
 
 /**
@@ -301,6 +308,41 @@ const SYNTHETIC_AGROCHEM_TERMS = [
   'glufosinato',
   // producto inventado por el modelo en el bench (CPX-007)
   'pirimex',
+  // FERTILIZANTES de síntesis (#351, prod 2026-06-03 Choachí). El bug: el modelo
+  // recomendó "plan de alimentación" con NPK 5-10-10 y, al preguntar cómo
+  // hacerlo, una receta de mezclar urea + fosfato triple + sulfato de potasio.
+  // Son fertilizantes minerales de síntesis (no biopreparados) → contra la
+  // misión agroecológica. Sus nombres NO terminan en sufijo de familia química
+  // (no los captura el detector de sufijos), por eso van en la denylist exacta.
+  // La sigla 'npk' y las formulaciones N-P-K ("5-10-10") se chequean aparte
+  // (`SYNTHETIC_FERTILIZER_PATTERNS`).
+  'urea',
+  'fosfato triple',
+  'superfosfato triple',
+  'fosfato diamonico',
+  'fosfato diamónico',
+  'fosfato monoamonico',
+  'fosfato monoamónico',
+  'sulfato de potasio',
+  'sulfato de amonio',
+  'nitrato de amonio',
+  'nitrato de potasio',
+  'cloruro de potasio',
+  'muriato de potasio',
+];
+
+/**
+ * #351 — la sigla NPK y las FORMULACIONES de fertilizante mineral ("NPK 5-10-10",
+ * "10-10-10", "triple 15", "15-15-15") delatan un fertilizante de síntesis. Van
+ * aparte de la denylist por palabra: "npk" es una sigla corta y las
+ * formulaciones son tripletes numéricos (no nombres de i.a.). En agro un triplete
+ * N-P-K siempre denota un mineral de síntesis. Sobre el texto normalizado.
+ */
+const SYNTHETIC_FERTILIZER_PATTERNS = [
+  /(^|[^a-z])npk([^a-z]|$)/, // sigla NPK (con o sin formulación al lado)
+  /(^|[^a-z])n-p-k([^a-z]|$)/,
+  /\btriple\s+(quince|15|catorce|14|diecisiete|17)\b/, // "triple 15"
+  /\b\d{1,2}\s*[-–]\s*\d{1,2}\s*[-–]\s*\d{1,2}\b/, // formulación "5-10-10", "15-15-15"
 ];
 
 /**
@@ -472,13 +514,28 @@ function _organicRedirect(originalText) {
   const t = _stripDiacritics(originalText);
   const esHongo = /(hongo|tizon|gota|roya|mildeo|mildiu|antracnosis|fungic|enfermedad|mancha)/.test(t);
   const esPlaga = /(plaga|gusano|cogollero|oruga|larva|insecto|pulgon|acaro|trips|mosca|insectic)/.test(t);
+  // #351 — ¿el contexto es FERTILIZACIÓN/nutrición (no plaga ni enfermedad)? Si
+  // el texto habla de alimentar/abonar/nutrir o nombra un fertilizante mineral,
+  // redirigimos a la ruta de abono orgánico (compost/bocashi/biol), no a un
+  // fungicida/insecticida orgánico.
+  const esFertilizante =
+    /(npk|urea|fosfato|sulfato de potasio|nitrato de amonio|fertiliz|abon|nutricion|alimentacion|alimentar|nutrir|fertirrig|formula\s+\d)/.test(
+      t,
+    );
 
   const intro =
-    'Una nota importante: Chagra es agroecológico, no recomendamos agroquímicos sintéticos. ' +
+    'Una nota importante: Chagra es agroecológico, no recomendamos agroquímicos ni fertilizantes sintéticos. ' +
     'Lo que de verdad funciona y cuida tu suelo y tu salud es el manejo orgánico:';
 
   const lineas = [];
-  if (esHongo || (!esHongo && !esPlaga)) {
+  if (esFertilizante) {
+    lineas.push(
+      '- Para nutrir y abonar el cultivo (en vez de NPK, urea o fosfatos de síntesis): compost bien maduro, ' +
+        'bocashi, humus de lombriz, biol (biofertilizante líquido fermentado) y abonos verdes. Alimentan el suelo ' +
+        'vivo y liberan los nutrientes poco a poco, sin acidificarlo ni salinizarlo.',
+    );
+  }
+  if (esHongo || (!esHongo && !esPlaga && !esFertilizante)) {
     lineas.push(
       '- Para hongos y enfermedades (tizón, roya, gota): caldo bordelés (cal + sulfato de cobre) como preventivo, ' +
         'eliminar focos enfermos, mejorar aireación y drenaje, usar semilla sana y rotar el cultivo.',
@@ -528,6 +585,14 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
     // límite de palabra a ambos lados sobre el texto normalizado.
     const re = new RegExp(`(^|[^a-z0-9])${t.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([^a-z0-9]|$)`);
     if (re.test(norm)) hits.push(term);
+  }
+
+  // #351: fertilizantes minerales de síntesis por sigla/formulación (NPK,
+  // "5-10-10", "triple 15"). No tienen sufijo de familia química ni palabra de
+  // denylist clásica; este matcher capta la sigla y los tripletes N-P-K.
+  for (const re of SYNTHETIC_FERTILIZER_PATTERNS) {
+    const m = norm.match(re);
+    if (m) hits.push(m[0].trim());
   }
 
   // HARDENING 1 (audit #21): además de la denylist exacta, detecta agroquímicos
@@ -2323,6 +2388,448 @@ export function guardReforestacionNativasRol(responseText, { userMessage = null 
   return { text, modified: true, reason: 'reforestacion_nativas_rol' };
 }
 
+// ── GUARD: dominio (off-domain física/química/matemáticas) ──────────────────
+
+/**
+ * #352 (prod 2026-06-03 Choachí): el agente respondió completo a "teoría de la
+ * relatividad", "teoría de cuerdas", "química orgánica vs inorgánica" — y peor,
+ * con un badge falso "Catálogo verificado · get_normativa_ica" (grounding
+ * irrelevante) y un typo ("toria de cuerdas") lo buscó como PLANTA. Chagra es un
+ * asistente AGROECOLÓGICO: ante una pregunta fuera de dominio (física, química
+ * teórica, matemáticas, historia, etc.) debe DECLINAR amable y redirigir, SIN
+ * tool ni grounding.
+ *
+ * Estos patrones (sobre el texto normalizado) marcan temas inequívocamente
+ * académicos/no-agro. Son CONSERVADORES: cada uno apunta a un concepto que no
+ * tiene lectura agrícola legítima ("teoria de cuerdas", "relatividad",
+ * "ecuacion de segundo grado"). NO incluye términos que también son agro
+ * ("suelo", "agua", "nitrogeno", "ph", "fotosintesis"): esos pueden ser de
+ * cultivo y NO deben declinarse.
+ */
+const OFF_DOMAIN_TOPIC_PATTERNS = [
+  // física teórica
+  /\bteoria\s+de\s+(la\s+)?relatividad\b/,
+  /\brelatividad\s+(general|especial)\b/,
+  /\bteoria\s+de\s+(las?\s+)?cuerdas\b/,
+  /\bmecanica\s+cuantica\b/,
+  /\bfisica\s+cuantica\b/,
+  /\bagujero[s]?\s+negro[s]?\b/,
+  /\bbig\s+bang\b/,
+  /\bley(es)?\s+de\s+newton\b/,
+  /\btermodinamica\b/,
+  // química teórica (no agro: distinguir de "química del suelo")
+  /\bquimica\s+(organica|inorganica)\b/,
+  /\btabla\s+periodica\b/,
+  /\benlace[s]?\s+(covalente|ionico|metalico)\b/,
+  /\bnumero\s+atomico\b/,
+  // matemáticas puras
+  /\bteorema\s+de\s+pitagoras\b/,
+  /\becuacion\s+(de\s+segundo\s+grado|cuadratica|diferencial)\b/,
+  /\bderivada[s]?\s+(de\s+una\s+funcion|e\s+integrales)\b/,
+  /\bintegral(es)?\s+(definida|indefinida)\b/,
+  /\bcalculo\s+(diferencial|integral)\b/,
+  /\blogaritmo[s]?\b/,
+  /\btrigonometr/,
+  // otros dominios académicos claros
+  /\bteoria\s+de\s+la\s+evolucion\b/,
+  /\bguerra\s+(mundial|fria|de\s+los\s+mil\s+dias)\b/,
+];
+
+/**
+ * ¿La pregunta del usuario es de un dominio claramente NO-agroecológico? Sobre
+ * el texto normalizado del userMessage. Sin userMessage → false (no podemos
+ * juzgar el dominio; conservador: dejamos pasar).
+ *
+ * @param {string|null|undefined} userMessage
+ * @returns {boolean}
+ */
+function _isOffDomainQuery(userMessage) {
+  if (typeof userMessage !== 'string' || !userMessage.trim()) return false;
+  const norm = _stripDiacritics(userMessage);
+  return OFF_DOMAIN_TOPIC_PATTERNS.some((re) => re.test(norm));
+}
+
+/**
+ * Mensaje de declinación amable + redirección al dominio agro. NO cita tool ni
+ * grounding (el bug original mostraba un badge "get_normativa_ica" falso). Es un
+ * reemplazo COMPLETO: una respuesta off-domain no tiene parte rescatable.
+ */
+const OFF_DOMAIN_DECLINE_MESSAGE =
+  'Soy tu asistente de cultivos y agroecología, así que de ese tema no soy quien te puede ayudar bien ' +
+  '(hay mejores fuentes para física, química o matemáticas). Lo que sí manejo es tu finca: qué sembrar ' +
+  'según tu altura y clima, plagas y enfermedades, biopreparados y abonos orgánicos, asociaciones de ' +
+  'cultivos y manejo del suelo. ¿Te ayudo con algo de tu cultivo?';
+
+/**
+ * guardOffDomain — #352. Si la PREGUNTA del usuario es de un dominio claramente
+ * no-agro (física/química teórica/matemáticas) y la respuesta del modelo entró a
+ * contestarla, REEMPLAZA la respuesta por una declinación amable que redirige al
+ * dominio agro. No corre tool ni grounding.
+ *
+ * GATING POR INTENCIÓN: solo actúa si el userMessage matchea un tema off-domain.
+ * Una pregunta agro normal ("¿qué siembro a 1923 msnm?") NO se ve afectada. Sin
+ * userMessage → no-op (conservador: no juzgamos el dominio sin la pregunta).
+ *
+ * Idempotente: si la respuesta ya es nuestro mensaje de declinación, no
+ * re-dispara. Firma propia (necesita userMessage) → se invoca aparte en
+ * applyOutputGuards, no dentro de GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardOffDomain(responseText, { userMessage = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  if (!_isOffDomainQuery(userMessage)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  // Idempotencia: ya declinamos.
+  if (/asistente de cultivos y agroecolog[ií]a/i.test(responseText)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  bumpGuardTelemetry('off_domain');
+  return { text: OFF_DOMAIN_DECLINE_MESSAGE, modified: true, reason: 'off_domain' };
+}
+
+// ── GUARD: diagnóstico sin foto ni datos (anti-dx-a-ciegas) ─────────────────
+
+/**
+ * #348 (prod 2026-06-03 Choachí): "manchas en el tomate" SIN foto → el agente
+ * enumeró una lista de patógenos posibles (tizón tardío, alternaria, etc.) como
+ * si hubiera diagnosticado. Sin la foto ni datos del síntoma, eso es adivinar y
+ * puede mandar al campesino a tratar la enfermedad equivocada. El guard de
+ * visión-sin-foto (`guardVisionWithoutPhoto`) NO lo cubre: ahí el modelo NO
+ * afirma haber visto una foto, simplemente lista diagnósticos sin base.
+ *
+ * Este guard, complementario, detecta: (a) intención de DIAGNÓSTICO de
+ * síntomas en la pregunta ("manchas/hojas amarillas/se está secando/qué tiene
+ * mi…"), (b) ausencia de foto en el turno (hadVision=false), y (c) que la
+ * respuesta ENUMERA candidatos de enfermedad/plaga (≥2 nombres de patógeno o
+ * fraseo "puede ser X o Y"). En ese caso ANTEPONE una nota pidiendo foto/datos
+ * antes de la lista — no borra la lista (puede ser útil como referencia), pero
+ * deja claro que sin foto/datos no es un diagnóstico.
+ */
+const SYMPTOM_DIAG_INTENT_PATTERNS = [
+  /\bmanch(a|as)\b/,
+  /\bhojas?\s+(amarill|seca|negra|cafe|marchit|enroll|con\s+hueco)/,
+  /\bse\s+(esta\s+)?(secando|marchitando|muriendo|pudriendo|amarillando)\b/,
+  /\bqu[eé]\s+(tiene|le\s+pasa|enfermedad)\b/,
+  /\b(plaga|enfermedad|hongo|bicho|gusano)\b/,
+  /\bpudric(ion|iones)\b/,
+  /\bpuntos?\s+(negro|cafe|amarillo)/,
+];
+
+/** ¿La pregunta del usuario pide un diagnóstico de síntomas? */
+function _isSymptomDiagnosisQuery(userMessage) {
+  if (typeof userMessage !== 'string' || !userMessage.trim()) return false;
+  const norm = _stripDiacritics(userMessage);
+  return SYMPTOM_DIAG_INTENT_PATTERNS.some((re) => re.test(norm));
+}
+
+/**
+ * Nombres de patógenos/plagas frecuentes (normalizados) — si la respuesta
+ * enumera ≥2, está dando un diagnóstico diferencial a ciegas. Lista corta de
+ * los más nombrados en tomate/papa/hortalizas. No pretende ser exhaustiva: es
+ * un detector de "lista de candidatos de enfermedad".
+ */
+const PATHOGEN_NAME_TERMS = [
+  'tizon tardio', 'tizon temprano', 'tizon', 'gota', 'alternaria', 'phytophthora',
+  'fusarium', 'verticillium', 'botrytis', 'antracnosis', 'mildeo', 'mildiu', 'oidio',
+  'cercospora', 'septoria', 'roya', 'virus del mosaico', 'mosca blanca', 'minador',
+  'acaro', 'trips', 'pulgon', 'nematodo', 'bacteriosis', 'cancro', 'moho',
+];
+
+/** Fraseo de enumeración de candidatos ("puede ser X o Y", "podría tratarse de"). */
+const DIFFERENTIAL_PHRASING_RE =
+  /(puede\s+ser|podria\s+(ser|tratarse)|posibles?\s+(causa|enfermedad|patogeno|plaga)|entre\s+las?\s+(causa|enfermedad|posibilidad)|podria\s+deberse|se\s+trata\s+(probablemente\s+)?de)/;
+
+/**
+ * guardDiagnosisWithoutPhoto — #348. Cuando la pregunta es de diagnóstico de
+ * síntomas, NO hubo foto en el turno, y la respuesta enumera candidatos de
+ * enfermedad/plaga (≥2 patógenos nombrados o fraseo diferencial), ANTEPONE una
+ * nota pidiendo foto/datos. Así el campesino no trata a ciegas la enfermedad
+ * equivocada. NO borra la respuesta del modelo (la lista puede orientar); la
+ * encabeza con la petición de evidencia.
+ *
+ * GATING: requiere intención de diagnóstico en userMessage Y hadVision=false. Si
+ * hubo foto, el diagnóstico es legítimo (no toca). Si la respuesta no enumera
+ * candidatos (p. ej. ya pide foto, o solo da manejo cultural genérico), no-op.
+ * Idempotente.
+ *
+ * Firma propia (necesita userMessage + hadVision) → se invoca aparte en
+ * applyOutputGuards, no dentro de GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null, hadVision?: boolean}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+const DIAGNOSIS_NEEDS_EVIDENCE_NOTE =
+  'Antes de ponerle nombre a lo que tiene tu cultivo necesito verlo: con solo "manchas" puedo equivocarme y ' +
+  'mandarte a tratar la enfermedad que no es. Mándame una foto (toca el botón de cámara) de la hoja o el fruto ' +
+  'afectado, y cuéntame: ¿de qué color son las manchas, son secas o con humedad, empezaron por las hojas de ' +
+  'abajo o de arriba, hace cuánto y con qué clima? Con eso sí te doy un diagnóstico confiable.';
+
+export function guardDiagnosisWithoutPhoto(
+  responseText,
+  { userMessage = null, hadVision = false } = {},
+) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  // Solo aplica a consultas de diagnóstico de síntomas SIN foto en el turno.
+  if (hadVision || !_isSymptomDiagnosisQuery(userMessage)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  // Idempotencia: la nota ya está.
+  if (/Antes de ponerle nombre a lo que tiene tu cultivo/i.test(responseText)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  const norm = _stripDiacritics(responseText);
+  // ¿La respuesta enumera candidatos de enfermedad/plaga? (≥2 patógenos nombrados
+  // o fraseo diferencial). Solo así anteponemos la petición de evidencia: una
+  // respuesta que ya pide la foto o solo da manejo cultural no se toca.
+  const patho = new Set();
+  for (const term of PATHOGEN_NAME_TERMS) {
+    if (norm.includes(term)) patho.add(term);
+  }
+  const enumeraCandidatos = patho.size >= 2 || DIFFERENTIAL_PHRASING_RE.test(norm);
+  if (!enumeraCandidatos) {
+    return { text: responseText, modified: false, reason: null };
+  }
+  bumpGuardTelemetry('diagnosis_without_photo');
+  const text = `${DIAGNOSIS_NEEDS_EVIDENCE_NOTE}\n\n${responseText.trim()}`;
+  return { text, modified: true, reason: 'diagnostico_sin_foto' };
+}
+
+// ── GUARD: viabilidad FALSO-NEGATIVO (cultivo viable marcado inviable) ──────
+
+/**
+ * #350 (CRÍTICO, prod 2026-06-03 Choachí): el modelo afirmó que papa y fresa
+ * "NO son viables a 1923 msnm" y desvió al campesino a Daikon/ajo + variedades
+ * extranjeras absurdas ('Kennebec', 'Yukon Gold' a -2°C). FALSO: Choachí (1923 m,
+ * templado) es zona PAPERA clásica; papa y fresa SON viables ahí. Causa probable:
+ * sin grounding (NLU abortó), el LLM comparó contra la banda equivocada (ej.
+ * "fresa silvestre andina") y declaró inviabilidad que NO es autoritativa.
+ *
+ * `guardInvertedViability` solo AÑADE correcciones de inviabilidad autoritativa
+ * (campo `viabilidad:inviable` o banda de altitud del grounding); NO cubre el
+ * caso opuesto — el modelo INVENTANDO inviabilidad de un cultivo que sí se da.
+ *
+ * Este guard usa una tabla AUTORITATIVA de bandas de altitud para los cultivos
+ * andinos de base (papa, fresa, etc., con rangos agronómicos bien establecidos).
+ * Si la respuesta declara INVIABLE un cultivo de esa tabla a una altitud que SÍ
+ * cae en su banda viable, CORRIGE: afirma que sí es viable a esa altura y elimina
+ * la afirmación falsa de inviabilidad. Es deliberadamente CONSERVADOR: solo actúa
+ * sobre cultivos de banda conocida y solo cuando la altitud de la finca está
+ * DENTRO de la banda viable — nunca inventa viabilidad fuera de rango (papa a
+ * 3500 m sí es inviable y se respeta).
+ *
+ * Bandas (msnm) de fuentes agronómicas estándar para Colombia (Agrosavia/ICA;
+ * rangos comerciales conservadores):
+ *   - papa (Solanum tuberosum): 1800–3200 m (zona andina fría/templada-alta).
+ *     A 1923 m está en el borde inferior templado donde sí se cultiva → viable.
+ *     El techo se fija en 3200 m (ceiling comercial conservador): por encima la
+ *     papa entra en zona marginal/fría real, así que a 3500 m NO afirmamos
+ *     viabilidad (una advertencia de inviabilidad ahí puede ser legítima).
+ *   - fresa (Fragaria × ananassa): 1300–2800 m (clima templado a frío).
+ *   - arveja, haba, cebolla, zanahoria, repollo, lechuga: bandas templadas
+ *     amplias que cubren 1900 m.
+ * La banda de papa se fija con borde inferior 1800 m para reconocer las zonas
+ * paperas templadas (Cundinamarca/Boyacá/Nariño) — Choachí entra de lleno.
+ */
+const KNOWN_VIABLE_BANDS = [
+  { base: 'papa', binomial: 'solanum tuberosum', min: 1800, max: 3200 },
+  { base: 'fresa', binomial: 'fragaria', min: 1300, max: 2800 },
+  { base: 'frutilla', binomial: 'fragaria', min: 1300, max: 2800 },
+  { base: 'arveja', binomial: 'pisum sativum', min: 1800, max: 3000 },
+  { base: 'haba', binomial: 'vicia faba', min: 2000, max: 3200 },
+  { base: 'cebolla', binomial: 'allium cepa', min: 1500, max: 2800 },
+  { base: 'zanahoria', binomial: 'daucus carota', min: 1700, max: 3000 },
+  { base: 'repollo', binomial: 'brassica oleracea', min: 1800, max: 3000 },
+  { base: 'lechuga', binomial: 'lactuca sativa', min: 1500, max: 2800 },
+  { base: 'maiz', binomial: 'zea mays', min: 0, max: 2800 },
+];
+
+/**
+ * Busca la banda viable conocida para un nombre de cultivo (común o binomio),
+ * normalizado. Devuelve la entrada o null.
+ *
+ * @param {string} nombreNorm  nombre normalizado (común).
+ * @param {string|null} binomialNorm  binomio normalizado, si lo hay.
+ * @returns {{base:string, binomial:string, min:number, max:number}|null}
+ */
+function _knownViableBand(nombreNorm, binomialNorm) {
+  const firstToken = (nombreNorm || '').split(/\s+/)[0];
+  for (const band of KNOWN_VIABLE_BANDS) {
+    if (firstToken === band.base || (nombreNorm && nombreNorm.includes(band.base))) return band;
+    if (binomialNorm && binomialNorm.includes(band.binomial)) return band;
+  }
+  return null;
+}
+
+/**
+ * ¿La respuesta declara INVIABLE el cultivo `bandBase` (a la altitud de la
+ * finca)? Busca, en alguna oración que mencione el cultivo, fraseo de
+ * inviabilidad ("no es viable", "no se da", "no prospera", "no vale la pena",
+ * "no es recomendable sembrar", "el clima/la altura no le sirve"). Sobre el
+ * texto normalizado.
+ *
+ * @param {string} textNorm
+ * @param {string} bandBase  nombre base del cultivo (p. ej. "papa", "fresa").
+ * @returns {boolean}
+ */
+const FALSE_INVIABILITY_RE =
+  /(no\s+es\s+viable|no\s+(es\s+)?(viable|recomendable)\s+(sembrar|cultivar)|inviable|no\s+se\s+da\b|no\s+prosper|no\s+vale\s+la\s+pena|no\s+es\s+(adecuad|apropiad)|clima\s+no\s+(le\s+)?sirve|altura\s+no\s+(le\s+)?sirve|no\s+(te\s+)?sirve\s+(a\s+)?(esa|tu)\s+altura)/;
+
+function _declaraInviable(textNorm, bandBase) {
+  const sentences = _splitSentences(textNorm);
+  for (const s of sentences) {
+    if (!s.includes(bandBase)) continue;
+    if (FALSE_INVIABILITY_RE.test(s)) return true;
+  }
+  // También: el cultivo y la negación de viabilidad en el texto, aunque en
+  // oraciones contiguas (el split puede separar "La papa..." de "...no es viable").
+  if (textNorm.includes(bandBase) && FALSE_INVIABILITY_RE.test(textNorm)) return true;
+  return false;
+}
+
+/**
+ * Elimina las oraciones que declaran falsamente inviable el cultivo `bandBase`,
+ * para que la corrección no quede sobre una autocontradicción. Quirúrgico por
+ * oración: borra las que mencionan el cultivo Y disparan la negación de
+ * viabilidad. Conserva el resto.
+ */
+function _stripFalseInviability(originalText, bandBases) {
+  const sentences = _splitSentences(originalText);
+  const kept = sentences.filter((sentence) => {
+    const sNorm = _stripDiacritics(sentence);
+    for (const base of bandBases) {
+      if (sNorm.includes(base) && FALSE_INVIABILITY_RE.test(sNorm)) return false;
+    }
+    return true;
+  });
+  return kept.join('').trim();
+}
+
+/**
+ * _bandBasesGroundedInviable — devuelve el Set de bases de cultivo (de
+ * `KNOWN_VIABLE_BANDS`) que el GROUNDING marca autoritativamente inviables a la
+ * altitud de la finca. Veredicto idéntico al de `guardInvertedViability`: 1)
+ * campo `viabilidad:'inviable'`; 2) banda de altitud que excluye la altura (con
+ * el margen de 300 m de zona-gris → fuera de ese margen es inviable). Solo así
+ * `guardFalseInviability` cede al grafo y no afirma viabilidad contra una
+ * inviabilidad REAL resuelta por la AGE.
+ *
+ * @param {Array<object>|null} entities
+ * @param {number} alt  altitud de la finca (msnm), ya validada como finita.
+ * @returns {Set<string>}  bases ("papa", "fresa", …) groundeadas inviables.
+ */
+function _bandBasesGroundedInviable(entities, alt) {
+  const out = new Set();
+  if (!Array.isArray(entities) || entities.length === 0) return out;
+  for (const e of entities) {
+    if (!_isSpecies(e)) continue;
+    const nombreNorm = _stripDiacritics(_entityName(e));
+    const binomialNorm = _binomial(e.nombre_cientifico || e.nombre_científico);
+    const band = _knownViableBand(nombreNorm, binomialNorm);
+    if (!band) continue;
+    // Veredicto autoritativo (mismo que guardInvertedViability).
+    let nivel = _normViabilidad(e.viabilidad);
+    if (!nivel) {
+      const hasMin = e.altitud_min != null && e.altitud_min !== '';
+      const hasMax = e.altitud_max != null && e.altitud_max !== '';
+      const min = hasMin ? Number(e.altitud_min) : NaN;
+      const max = hasMax ? Number(e.altitud_max) : NaN;
+      if (!Number.isFinite(min) || !Number.isFinite(max)) continue;
+      if (alt >= min && alt <= max) nivel = 'viable';
+      else {
+        const fuera = alt < min ? min - alt : alt - max;
+        nivel = fuera <= 300 ? 'marginal' : 'inviable';
+      }
+    }
+    if (nivel === 'inviable') out.add(band.base);
+  }
+  return out;
+}
+
+/**
+ * guardFalseInviability — #350. Detector de FALSO-NEGATIVO de viabilidad. Si la
+ * respuesta declara INVIABLE un cultivo de banda conocida (papa, fresa, …) a una
+ * altitud de finca que SÍ cae en su banda viable, ANTEPONE una corrección
+ * afirmando que el cultivo sí es viable a esa altura y ELIMINA la afirmación
+ * falsa de inviabilidad. Conservador: solo cultivos de `KNOWN_VIABLE_BANDS` y
+ * solo cuando la altitud está dentro de la banda (papa a 3500 m → no corrige;
+ * fuera de banda la inviabilidad puede ser legítima).
+ *
+ * Necesita la altitud de la finca para saber si está dentro de la banda. Sin
+ * altitud → no-op (no podemos afirmar viabilidad sin saber la altura). Encaja en
+ * la firma estándar `(text, entities, altitud)` → puede ir en GUARD_CHAIN, pero
+ * solo debe correr en consultas de SIEMBRA (es un guard de siembra), por eso se
+ * agrega a PLANTING_GUARDS.
+ *
+ * PRECEDENCIA — RED DE SEGURIDAD, NO autoridad sobre el grounding (clave #350):
+ * el bug ocurre cuando NLU abortó y NO hubo grounding (el LLM inventó la
+ * inviabilidad). Si el grounding SÍ trae un veredicto AUTORITATIVO de inviable
+ * para ese mismo cultivo (campo `viabilidad:'inviable'` o banda de altitud que
+ * EXCLUYE la altura de la finca), la AGE manda: NO sobreescribimos su veredicto
+ * con la tabla hardcodeada. La tabla solo afirma viabilidad cuando el grounding
+ * NO contradice — así jamás pisa una inviabilidad real resuelta por el grafo.
+ *
+ * @param {string} responseText
+ * @param {Array<object>|null} resolvedEntities  grounding del turno (para deferir
+ *   a un veredicto autoritativo de inviable si lo hay).
+ * @param {number|string|null} fincaAltitud
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardFalseInviability(responseText, resolvedEntities = null, fincaAltitud = null) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  const alt = Number(fincaAltitud);
+  const haveAlt = fincaAltitud != null && fincaAltitud !== '' && Number.isFinite(alt);
+  if (!haveAlt) return { text: responseText, modified: false, reason: null };
+
+  const norm = _stripDiacritics(responseText);
+  const corregidos = [];
+  const basesDisparadas = [];
+  // Bases de cultivo que el grounding marcó AUTORITATIVAMENTE inviables: la AGE
+  // manda sobre la tabla hardcodeada (no afirmamos viabilidad contra el grafo).
+  const groundedInviable = _bandBasesGroundedInviable(resolvedEntities, alt);
+
+  for (const band of KNOWN_VIABLE_BANDS) {
+    // Solo nos importa cuando la altitud de la finca está DENTRO de la banda
+    // viable: ahí una afirmación de inviabilidad es FALSA. Fuera de banda
+    // (papa a 3500 m) la inviabilidad puede ser legítima → no tocamos.
+    if (alt < band.min || alt > band.max) continue;
+    // Si el grounding tiene un veredicto autoritativo de inviable para este
+    // cultivo, la AGE manda: NO lo corregimos a viable (no es el bug #350, que es
+    // el caso SIN grounding / inviabilidad inventada por el LLM).
+    if (groundedInviable.has(band.base)) continue;
+    if (!norm.includes(band.base)) continue;
+    if (!_declaraInviable(norm, band.base)) continue;
+    if (basesDisparadas.includes(band.base)) continue;
+    basesDisparadas.push(band.base);
+    corregidos.push(band.base);
+  }
+
+  if (corregidos.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('false_inviability');
+  const lista = corregidos.join(' y ');
+  const correccion =
+    `Corrección importante: ${lista} SÍ es viable en tu finca a ${alt} msnm — es una altura templada donde ` +
+    `este cultivo se da bien (de hecho es zona de cultivo tradicional). No te desanimes ni cambies de cultivo ` +
+    `por una altura que sí le sirve; si quieres te doy variedades adaptadas a tu zona y el manejo para que ` +
+    `rinda.`;
+  const restoLimpio = _stripFalseInviability(responseText, corregidos);
+  const text = restoLimpio ? `${correccion}\n\n${restoLimpio}` : correccion;
+  return { text, modified: true, reason: `viabilidad_falso_negativo: ${corregidos.join(', ')}` };
+}
+
 /**
  * Set de guards que SOLO tienen sentido cuando la consulta es de SIEMBRA
  * (A12). Si la pregunta del usuario es de PRECIO/MERCADO (o info general sin
@@ -2339,6 +2846,7 @@ const PLANTING_GUARDS = new Set([
   guardCompanionBinomial,
   guardInvasiveSpecies,
   guardInvertedViability,
+  guardFalseInviability,
 ]);
 
 /**
@@ -2365,6 +2873,11 @@ const GUARD_CHAIN = [
   guardSyntheticAgrochemical,
   guardInvasiveSpecies,
   guardInvertedViability,
+  // #350 — FALSO-NEGATIVO de viabilidad: el modelo declaró inviable un cultivo de
+  // banda conocida (papa/fresa) a una altitud que SÍ le sirve. Va DESPUÉS de
+  // invertedViability (que corrige el caso opuesto, inviable autoritativo
+  // promovido como viable). Solo corre en consultas de siembra (PLANTING_GUARDS).
+  guardFalseInviability,
 ];
 
 /**
@@ -2391,10 +2904,13 @@ const GUARD_CHAIN = [
  *   para el riesgo de golpe de calor. Mismo origen.
  * @param {string|null} [ctx.userMessage] — pregunta cruda del usuario (A12). Si
  *   es claramente de PRECIO/MERCADO (no de siembra), los guards de SIEMBRA
- *   (viabilidad/térmico/sustitución/companion/invasora) NO corren —razonan sobre
- *   cultivo y son irrelevantes a "¿a cómo está la papa?". Los de SAFETY (dosis,
- *   agroquímico, visión-sin-foto, nombre-inventado) corren igual. Sin esto, o
- *   ante intención ambigua, TODOS corren (conservador, no rompe la protección).
+ *   (viabilidad/térmico/sustitución/companion/invasora/falso-negativo) NO corren
+ *   —razonan sobre cultivo y son irrelevantes a "¿a cómo está la papa?". Los de
+ *   SAFETY (dosis, agroquímico, visión-sin-foto, nombre-inventado) corren igual.
+ *   Además habilita el guard de DOMINIO (#352, declina off-domain física/química/
+ *   matemáticas) y el anti-diagnóstico-a-ciegas (#348, pide foto/datos ante
+ *   "manchas en el tomate" sin imagen). Sin esto, o ante intención ambigua, los
+ *   guards de siembra corren (conservador, no rompe la protección).
  * @returns {{text:string, modified:boolean, reasons:string[]}}
  */
 export function applyOutputGuards(
@@ -2424,6 +2940,18 @@ export function applyOutputGuards(
   let modified = false;
   const reasons = [];
 
+  // GUARD de DOMINIO el más PRIMERO (#352): si la pregunta es off-domain
+  // (física/química/matemáticas) y el modelo entró a contestarla, REEMPLAZAMOS la
+  // respuesta entera por una declinación amable. No tiene sentido correr ningún
+  // otro guard sobre un texto que se va a reemplazar. Firma propia (necesita
+  // userMessage), por eso va fuera de GUARD_CHAIN. No-op si la query es agro.
+  const offDom = guardOffDomain(text, { userMessage });
+  if (offDom && offDom.modified) {
+    // Respuesta off-domain reemplazada: no corremos más guards sobre la
+    // declinación (no hay cultivo/entidad que razonar).
+    return { text: offDom.text, modified: true, reasons: offDom.reason ? [offDom.reason] : [] };
+  }
+
   // GUARD de visión PRIMERO: si la respuesta afirma un diagnóstico visual sin
   // foto real en el turno, no tiene sentido correr los demás guards sobre un
   // texto que vamos a reemplazar entero. Firma propia (contexto de visión), por
@@ -2433,6 +2961,20 @@ export function applyOutputGuards(
     text = vis.text;
     modified = true;
     if (vis.reason) reasons.push(vis.reason);
+  }
+
+  // GUARD anti-diagnóstico-a-ciegas (#348): si la pregunta pide diagnóstico de
+  // síntomas ("manchas en el tomate") SIN foto y la respuesta enumera candidatos
+  // de patógeno, ANTEPONE la petición de foto/datos. Va tras el guard de visión
+  // (que cubre el caso distinto de afirmar haber VISTO una foto). Firma propia
+  // (userMessage + hadVision). Solo actúa si el de visión no reemplazó ya el texto.
+  if (!(vis && vis.modified)) {
+    const dx = guardDiagnosisWithoutPhoto(text, { userMessage, hadVision });
+    if (dx && dx.modified) {
+      text = dx.text;
+      modified = true;
+      if (dx.reason) reasons.push(dx.reason);
+    }
   }
 
   for (const guard of GUARD_CHAIN) {


### PR DESCRIPTION
## ⚠️ prod-harm fix · ESPERA REVISIÓN OPERADOR · NO MERGEAR EN AUTOPILOT

Son guards de **seguridad** y mergear dispara auto-deploy a prod. El operador debe revisarlos despierto antes de mergear.

## Bug / Feature
Re-implementación (el intento anterior se perdió en un crash) del pack de fixes de daño en producción, a partir del transcript real del operador con el agente Chagra en prod (Choachí, 1923 msnm, templado, 2026-06-03). Raíz: NLU abortó → todo cayó al LLM generativo sin grounding y los guards no tenían entidad/data, produciendo desinformación activa.

## Causa raíz
Sin grounding (NLU-abort), el LLM freestylea: invierte viabilidad, recomienda fertilizantes de síntesis, responde off-domain con badge de tool falso, filtra inventario de finca en consultas de precio, y enumera patógenos sin foto. Los guards existentes no cubrían estos paths.

## Cambios (todos en `src/services/outputGuards.js`)
- **#350 (CRÍTICO) viabilidad FALSO-NEGATIVO** — nuevo `guardFalseInviability`. El modelo declaró papa/fresa "NO viables a 1923 m" (FALSO: Choachí es zona papera templada) y desvió a Daikon/ajo + variedades extranjeras absurdas. Tabla autoritativa de bandas de altitud para cultivos andinos de base; corrige a viable solo DENTRO de banda. **DEFIERE al grounding**: si la AGE marca inviable autoritativamente no la pisa — es red de seguridad para el caso sin grounding, no autoridad sobre el grafo.
- **#351 agroquímico** — extiende `guardSyntheticAgrochemical` a fertilizantes de síntesis (NPK, urea, fosfato triple/diamónico, sulfato de potasio, nitrato de amonio, formulaciones N-P-K tipo "5-10-10") → redirige a compost/bocashi/biol.
- **#352 guard de dominio** — nuevo `guardOffDomain`. Off-domain (física/química/matemáticas) → declina amable y redirige al dominio agro, SIN tool ni grounding (mata el badge falso "get_normativa_ica").
- **#347 fuga inventario en precio** — "bulto/arroba/carga de X" ahora clasifica como `price_intent` → no corre guards de siembra ni filtra altitud/municipio de finca.
- **#348 anti-dx-sin-foto** — nuevo `guardDiagnosisWithoutPhoto`. "manchas en el tomate" sin foto + lista de patógenos → antepone petición de foto/datos en vez de enumerar diagnósticos a ciegas.

Sin cambios de wiring en AgentScreen: `applyOutputGuards` ya recibe `userMessage`/`hadVision`/`fincaAltitud`, los nuevos guards se activan por el call site existente.

## Tests
- 32 casos vitest nuevos en `src/services/__tests__/outputGuards.prodHarm.test.js` (incluye los 3 del spec: papa@1923→viable, fresa@1923→viable, papa@3500→inviable).
- Suite completa verde: **3283 passed | 1 skipped**, 0 fallos.
- eslint `--max-warnings=0` limpio.
- Precedencia validada: el guard de falso-negativo DEFIERE a una inviabilidad autoritativa del grounding (no regresa la protección anti-alucinación existente).

Refs: ops/PROD-ERRORS-TRANSCRIPT-2026-06-03.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)