### PR TITLE
fix(guards): guardFermentoRecipeSafety — caveat de inocuidad determinístico en recetas de fermento (#345) · espera revisión operador · NO MERGEAR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.35",
+  "version": "1.0.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v293';
+const CACHE_NAME = 'chagra-v294';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/outputGuards.fermento.test.js
+++ b/src/services/__tests__/outputGuards.fermento.test.js
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   guardFermentoHealthClaim,
+  guardFermentoRecipeSafety,
   applyOutputGuards,
   getOutputGuardTelemetry,
   resetOutputGuardTelemetry,
@@ -125,3 +126,133 @@ describe('applyOutputGuards — integración guard de fermentos', () => {
     expect(res.text.toLowerCase()).not.toContain(SAFE_PHRASE);
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// guardFermentoRecipeSafety — DR-FOOD-3, capa 2b · #345
+//
+// Bug prod 2026-06-03: "cómo preparo kombucha" devolvía la receta CRUDA sin el
+// caveat de inocuidad/INVIMA. El prefilter del sidecar SÍ arma el bloque
+// disclaimer_fuerte y SÍ se inyecta al system prompt, pero el LLM lo ignora bajo
+// carga ("grounding muerto"). guardFermentoHealthClaim NO cubre el caso: una
+// receta limpia no trae claim de salud, así que pasaba sin contrapeso. Este
+// guard determinístico antepone el caveat institucional a CUALQUIER receta de
+// fermento, sin depender del LLM.
+// ──────────────────────────────────────────────────────────────────────────
+
+const CAVEAT_MARK = 'antes de preparar este fermento';
+
+describe('guardFermentoRecipeSafety', () => {
+  it('(#345) "cómo preparo kombucha" + receta del LLM → antepone el caveat institucional', () => {
+    const llm =
+      'Para hacer kombucha necesitas té negro, azúcar y un SCOBY. Prepara 1L de té dulce, ' +
+      'añade el SCOBY y deja fermentar 7 a 10 días tapado con una tela. Listo.';
+    const r = guardFermentoRecipeSafety(llm, { userMessage: 'cómo preparo kombucha' });
+    expect(r.modified).toBe(true);
+    // El caveat LIDERA (prepend), para que se lea antes que la receta.
+    expect(r.text.toLowerCase().indexOf(CAVEAT_MARK)).toBeLessThan(
+      r.text.toLowerCase().indexOf('para hacer kombucha'),
+    );
+    // Contenido de inocuidad institucional.
+    expect(r.text.toLowerCase()).toContain('invima');
+    expect(r.text.toLowerCase()).toContain('higiene');
+    expect(r.text.toLowerCase()).toContain('puesto de salud');
+    expect(r.reason).toMatch(/receta_fermento/);
+  });
+
+  it('(#345) autoridad SIEMPRE institucional, NUNCA un nombre de persona', () => {
+    const r = guardFermentoRecipeSafety('Receta de masato: cocina el maíz, agrega panela…', {
+      userMessage: 'receta de masato paso a paso',
+    });
+    expect(r.modified).toBe(true);
+    // Marco institucional presente.
+    expect(r.text.toLowerCase()).toMatch(/invima|res(\.|olución)? ?810|inocuidad/);
+    // Ningún nombre propio del operador / personas (anti-leak).
+    expect(r.text.toLowerCase()).not.toMatch(/miguel|kortux|lili|diego/);
+  });
+
+  it('(#345) menciona poblaciones que deben abstenerse y el riesgo de contaminación/pH', () => {
+    const r = guardFermentoRecipeSafety('Para el chucrut pica el repollo con sal al 2%…', {
+      userMessage: 'cómo hago chucrut en casa',
+    });
+    expect(r.modified).toBe(true);
+    const t = r.text.toLowerCase();
+    expect(t).toMatch(/embarazad|gestant|niñ|defensas|inmun/);
+    expect(t).toMatch(/contamin|higiene|ph/);
+  });
+
+  it('gate por la PREGUNTA: pide receta de fermento aunque el texto del LLM sea escueto', () => {
+    const r = guardFermentoRecipeSafety('Mezcla los ingredientes y deja reposar.', {
+      userMessage: 'dame la receta del guarapo de caña',
+    });
+    expect(r.modified).toBe(true);
+    expect(r.text.toLowerCase()).toContain(CAVEAT_MARK);
+  });
+
+  it('(c) ANTI-FALSO-POSITIVO: fermento mencionado SIN intención de receta NO dispara', () => {
+    const r = guardFermentoRecipeSafety(
+      'El masato es una bebida tradicional del Pacífico colombiano.',
+      { userMessage: 'qué es el masato' },
+    );
+    expect(r.modified).toBe(false);
+    expect(r.text).toContain('El masato es una bebida');
+  });
+
+  it('(c2) ANTI-FALSO-POSITIVO: receta NO-fermento (sopa) intacta', () => {
+    const r = guardFermentoRecipeSafety(
+      'Para el ajiaco: cocina las papas con pollo, mazorca y guascas.',
+      { userMessage: 'cómo preparo ajiaco' },
+    );
+    expect(r.modified).toBe(false);
+    expect(r.text).toContain('ajiaco');
+  });
+
+  it('(c3) ANTI-FALSO-POSITIVO: query de precio NO-fermento intacta', () => {
+    const r = guardFermentoRecipeSafety('La papa está a 80 mil el bulto.', {
+      userMessage: '¿a cómo está la papa?',
+    });
+    expect(r.modified).toBe(false);
+  });
+
+  it('idempotente: no re-antepone el caveat si ya está', () => {
+    const llm =
+      'Para hacer kombucha necesitas té, azúcar y SCOBY; fermenta 7 días.';
+    const r1 = guardFermentoRecipeSafety(llm, { userMessage: 'cómo preparo kombucha' });
+    expect(r1.modified).toBe(true);
+    const r2 = guardFermentoRecipeSafety(r1.text, { userMessage: 'cómo preparo kombucha' });
+    expect(r2.modified).toBe(false);
+  });
+
+  it('texto vacío / no-string → no-op seguro', () => {
+    expect(guardFermentoRecipeSafety('', { userMessage: 'kombucha receta' }).modified).toBe(false);
+    expect(guardFermentoRecipeSafety(null, { userMessage: 'kombucha receta' }).modified).toBe(false);
+  });
+
+  it('cuenta telemetría al disparar', () => {
+    guardFermentoRecipeSafety('Receta de chicha: maíz, panela, fermenta…', {
+      userMessage: 'cómo se hace la chicha',
+    });
+    expect(getOutputGuardTelemetry().fermentoRecipeSafety).toBe(1);
+  });
+});
+
+describe('applyOutputGuards — integración receta de fermento (#345)', () => {
+  it('antepone el caveat de inocuidad a una receta de kombucha en el pipeline completo', () => {
+    const res = applyOutputGuards(
+      'Para hacer kombucha: té negro, azúcar, SCOBY; fermenta 7-10 días tapado.',
+      { userMessage: 'cómo preparo kombucha' },
+    );
+    expect(res.modified).toBe(true);
+    expect(res.text.toLowerCase()).toContain('invima');
+    expect(res.text.toLowerCase()).toContain(CAVEAT_MARK);
+    expect(res.reasons.some((r) => /receta_fermento/.test(r))).toBe(true);
+  });
+
+  it('ANTI-FALSO-POSITIVO: receta agronómica (biopreparado) no dispara el caveat de fermento', () => {
+    const res = applyOutputGuards(
+      'Para el caldo bordelés: disuelve cal y sulfato de cobre, aplica en preventivo.',
+      { userMessage: 'cómo preparo caldo bordelés' },
+    );
+    expect(res.text.toLowerCase()).not.toContain(CAVEAT_MARK);
+  });
+});
+

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -1992,6 +1992,123 @@ export function guardFermentoHealthClaim(responseText, { userMessage = null } = 
   };
 }
 
+// ── GUARD: receta de fermento sin caveat de inocuidad (DR-FOOD-3 · #345) ─────
+
+/**
+ * Patrones de INTENCIÓN-RECETA / preparación (sobre el texto normalizado sin
+ * tildes). Si la PREGUNTA del usuario o la RESPUESTA del LLM traen fraseo de
+ * "cómo se prepara / receta / pasos / ingredientes / fermentar X días", es una
+ * receta. Cerrado y conservador hacia NO disparar fuera de recetas.
+ */
+const FERMENTO_RECIPE_PATTERNS = [
+  /\bcomo\s+(se\s+)?(prepar|hac|elabor|hago|preparo|fabric|fermenta?)/,
+  /\b(la\s+)?receta\b/,
+  /\bpaso\s+a\s+paso\b/,
+  /\bpasos\s+(para|de)\b/,
+  /\bingredientes?\b/,
+  /\bmodo\s+de\s+(preparacion|empleo|hacerlo)\b/,
+  /\b(prepar|elabor|fabric)(ar|acion|a|o|amos)\b/,
+  /\bfermenta?\s+(por\s+)?\d/, // "fermenta 7 días"
+  /\bdeja(r|l[ao])?\s+(reposar|fermentar|tapad)/,
+  /\bme\s+ensenas?\s+a\s+(hacer|preparar)\b/,
+  /\bdame\s+(la\s+)?receta\b/,
+];
+
+/**
+ * ¿La query/respuesta pide o da una RECETA de fermento? Gate combinado: debe
+ * tocar un fermento (FERMENTO_TERMS) Y traer fraseo de receta/preparación, en la
+ * pregunta del usuario O en el texto del LLM. Conservador hacia NO disparar.
+ *
+ * @param {string} textNorm  respuesta del LLM normalizada.
+ * @param {string} userNorm  pregunta del usuario normalizada (o '').
+ * @returns {boolean}
+ */
+function _isFermentoRecipe(textNorm, userNorm) {
+  if (!_touchesFermento(textNorm, userNorm)) return false;
+  const combined = `${userNorm} ${textNorm}`;
+  return FERMENTO_RECIPE_PATTERNS.some((re) => re.test(combined));
+}
+
+/**
+ * Marca textual idempotente + frase líder del caveat de inocuidad. NO cita un
+ * nombre propio: la autoridad es SIEMPRE institucional (INVIMA / Res. 810-2021,
+ * FDA/EFSA), nunca una persona. Cubre los ejes del DR-FOOD-3: riesgo por
+ * higiene/agua/temperatura, control de pH/acidez, contaminación, poblaciones que
+ * deben abstenerse y derivación al puesto de salud.
+ *
+ * Fuente de verdad: Chagra-strategy/deepresearch/DR-FOOD-3-CONSOLIDADO §3.2/§4
+ * (disclaimer fuerte + marco INVIMA Res. 2674/2013 · Res. 810/2021).
+ */
+const FERMENTO_RECIPE_CAVEAT =
+  '⚠️ Antes de preparar este fermento, una advertencia de inocuidad que no se ' +
+  'puede saltar: es un alimento fermentado de riesgo y, si falla la higiene, el ' +
+  'agua, la acidez (pH) o la temperatura, se puede contaminar y enfermar a quien ' +
+  'lo tome. Trabaja con utensilios limpios, recipientes de vidrio o acero ' +
+  'inoxidable (nunca cerámica con plomo ni plástico), agua segura y la acidez ' +
+  'correcta. Deben ABSTENERSE las mujeres embarazadas, los niños pequeños, las ' +
+  'personas con defensas bajas (inmunocomprometidas) y quien toma anticoagulantes. ' +
+  'Ante cualquier mal olor, moho o señal de que salió mal, NO lo consuma. Si lo va ' +
+  'a vender, requiere registro/notificación sanitaria ante el INVIMA (Res. ' +
+  '2674/2013) y está prohibido atribuirle propiedades de salud en la etiqueta ' +
+  '(Res. 810/2021). Ante cualquier síntoma, acuda al puesto de salud de la vereda. ' +
+  'Esta pauta sigue el marco institucional de inocuidad (INVIMA · FDA/EFSA), no ' +
+  'una opinión personal.';
+
+/**
+ * guardFermentoRecipeSafety — DR-FOOD-3, capa 2b de defensa-en-profundidad
+ * (guard de salida del PWA). SAFETY-CRITICAL · FAIL-SAFE · #345.
+ *
+ * PROBLEMA (prod 2026-06-03): "cómo preparo kombucha" devolvía la receta CRUDA
+ * sin el caveat de inocuidad/INVIMA. El pre-filtro del sidecar SÍ arma el bloque
+ * `disclaimer_fuerte` (verificado en vivo) y SÍ se inyecta al system prompt, pero
+ * el LLM lo IGNORA bajo carga (patrón "grounding muerto"). El otro guard de
+ * fermentos (`guardFermentoHealthClaim`) NO cubre este caso: una receta limpia no
+ * trae claim de salud, así que pasaba sin contrapeso. Este guard es la red
+ * determinística: si la query/respuesta es una RECETA de fermento, ANTEPONE el
+ * caveat institucional — sin depender del prompt ni del modelo.
+ *
+ * PREPEND (no append): el caveat LIDERA para que el campesino lo lea ANTES de la
+ * receta. La receta del modelo se conserva intacta debajo (no se borra: la
+ * preparación es información útil; solo le anteponemos la seguridad).
+ *
+ * GATING POR INTENCIÓN (anti-falso-positivo, doble): (1) debe tocar un fermento
+ * (FERMENTO_TERMS) Y (2) traer fraseo de receta/preparación. Una receta de sopa,
+ * un biopreparado agroecológico (caldo bordelés), o una consulta de precio NO
+ * disparan. Idempotente: si el caveat ya está, no re-antepone.
+ *
+ * Autoridad SIEMPRE institucional (INVIMA / FDA/EFSA / Res. 810/2021), NUNCA un
+ * nombre propio.
+ *
+ * Firma propia (necesita userMessage para el gate) → se invoca aparte en
+ * applyOutputGuards, no dentro de GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {{userMessage?: string|null}} [ctx]
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardFermentoRecipeSafety(responseText, { userMessage = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  const textNorm = _stripDiacritics(responseText);
+  const userNorm = _stripDiacritics(userMessage || '');
+
+  // Gate doble: receta + fermento. Sin ambos, no corremos (anti-falso-positivo).
+  if (!_isFermentoRecipe(textNorm, userNorm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Idempotencia: si el caveat de inocuidad ya está anexado, no re-dispara.
+  if (textNorm.includes(_stripDiacritics('antes de preparar este fermento'))) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('fermentoRecipeSafety');
+  // PREPEND: el caveat lidera; la receta del modelo va intacta debajo.
+  const text = `${FERMENTO_RECIPE_CAVEAT}\n\n${responseText.trim()}`;
+  return { text, modified: true, reason: 'receta_fermento_sin_caveat' };
+}
+
 // ── GUARD: reforestación con especie invasora/combustible ───────────────────
 
 /**
@@ -2480,6 +2597,19 @@ export function applyOutputGuards(
     text = fermRes.text;
     modified = true;
     if (fermRes.reason) reasons.push(fermRes.reason);
+  }
+  // Guard de RECETA de fermento sin caveat de inocuidad (DR-FOOD-3, SAFETY · #345):
+  // firma propia (necesita userMessage para el gate de intención-receta-fermento).
+  // Corre SIEMPRE pero solo actúa si la query/respuesta es una RECETA de fermento.
+  // Red determinística contra el "grounding muerto" del prefilter: ANTEPONE el
+  // caveat institucional (INVIMA/FDA, pH, contaminación, abstención) sin depender
+  // del LLM. Va DESPUÉS del guard de claims de salud (su redirect queda debajo de
+  // la receta; el caveat de inocuidad lidera arriba).
+  const fermRecipeRes = guardFermentoRecipeSafety(text, { userMessage });
+  if (fermRecipeRes && fermRecipeRes.modified) {
+    text = fermRecipeRes.text;
+    modified = true;
+    if (fermRecipeRes.reason) reasons.push(fermRecipeRes.reason);
   }
   // Guard de reforestación con invasora-combustible (DR-RESTAURACION-INCENDIOS,
   // SAFETY ecológica): firma propia (necesita userMessage para el gate de


### PR DESCRIPTION
## Cierra #345

En prod **"cómo preparo kombucha"** devolvía la receta cruda **sin el caveat de inocuidad/INVIMA**, pese a que /fermento-prefilter existe y está vivo.

## Diagnóstico (investigado EN VIVO en alpha)

1. **El prefilter NO está vacío y SÍ matchea.** Golpeé POST /fermento-prefilter con `{"user_message":"cómo preparo kombucha"}` (token del env del sidecar). Devuelve `is_fermento_intent:true`, `disclaimer_fuerte:true` y un `system_prompt_block` completo con autoridad institucional (FDA/EFSA, FDA BAM plomo, vidrio/acero inox). Sidecar sano (build_sha 7028880, port 7880, 401 sin token → ruta viva auth-gated, coincide con el reporte). **Causa (a) descartada.**
2. **El bloque SÍ llega al system prompt.** En AgentScreen.jsx el system_prompt_block se captura en `fermentoBlock` (~L1407) y se concatena de ÚLTIMO (recency máxima) como `fermentoSafetyBlock` (~L1176). El wiring está bien.
3. **Dónde se perdía el caveat:** el LLM **ignora el bloque del prompt bajo carga** (patrón "grounding muerto"). El único guard determinístico de fermentos, `guardFermentoHealthClaim`, **solo dispara ante un CLAIM de salud** (cura/previene/desintoxica). Una receta limpia de kombucha no trae claim → el guard es no-op → **la receta sale sin contrapeso.** **Causas (b)+(c) confirmadas.**

## Fix (causa c — guard de SALIDA determinístico)

Nuevo `guardFermentoRecipeSafety` en outputGuards.js:
- Gate doble anti-falso-positivo: **fermento** (FERMENTO_TERMS) **+ fraseo de receta/preparación**.
- **ANTEPONE** (prepend, lidera) el caveat institucional: higiene/agua/pH/temperatura, contaminación, poblaciones que deben abstenerse (embarazadas/niños/inmunocomprometidos/anticoagulantes), registro **INVIMA** (Res. 2674/2013), veto de claims de salud en etiqueta (**Res. 810/2021**), derivación al puesto de salud.
- **Autoridad SIEMPRE institucional** (INVIMA · FDA/EFSA), **nunca un nombre propio**.
- No depende del prompt ni del modelo. Idempotente. La receta del modelo se conserva debajo.
- Wired en applyOutputGuards tras guardFermentoHealthClaim.

## Tests (TDD test-first)

outputGuards.fermento.test.js: **11 casos nuevos + 2 de integración** (escenario exacto del bug, caveat lidera, autoridad institucional sin nombre propio, poblaciones/pH/contaminación, gate por la pregunta, anti-falso-positivo sopa/biopreparado/precio, idempotencia, telemetría).

- outputGuards.fermento: 24/24 verde
- suite outputGuards completa: 159/159 verde
- suite src/services completa: 2225 passed / 1 skipped verde
- ESLint: limpio (exit 0)

## Colisión con PR #1280

fix/prod-harm-guards-2026-06-03 (#1280, sin mergear) también toca outputGuards.js pero **NO toca código de fermentos** (verificado: grep vacío). Sus añadidos van tras los guards de reforestación (L2388); mi guard va tras guardFermentoHealthClaim (zona distinta). El único punto compartido es una línea dentro de applyOutputGuards, en bloques separados. **Rebase esperado limpio** — anotado por si acaso.

## NO MERGEAR

Auto-deploy + seguridad alimentaria. Requiere revisión del operador. Labels `prod-harm fix` + `needs-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
