### PR TITLE
fix(guards): cerrar 3 fugas de seguridad vivas en prod (#347 #351 #1281)

### DIFF
--- a/src/services/__tests__/outputGuards.npkPrecioFermento.test.js
+++ b/src/services/__tests__/outputGuards.npkPrecioFermento.test.js
@@ -1,0 +1,180 @@
+/**
+ * outputGuards.npkPrecioFermento.test.js — fixes confirmados por E2E de
+ * seguridad (Playwright real contra prod, juez mistral-nemo) 2026-06-03.
+ *
+ * Tres casos seguían MAL en prod pese a los guards previos (#1280/#1281):
+ *
+ *   (#351) guardSyntheticAgrochemical NO disparaba con las SIGLAS de fertilizante
+ *          mineral usadas en campo —DAP, MAP, KCl— cuando el modelo las nombra
+ *          sin el nombre largo ("aplica DAP", "agrega KCl"). El nombre largo
+ *          ("fosfato diamónico", "cloruro de potasio") sí estaba; la sigla no.
+ *
+ *   (#347) classifyQueryIntent debe clasificar consultas con UNIDAD DE MERCADO
+ *          (bulto/arroba/carga) como 'precio' para NO inyectar perfil de finca
+ *          (altitud/clima) ni inventario en una consulta de precio. Regresión
+ *          lock del fix de #1280.
+ *
+ *   (#1281) guardFermentoRecipeSafety daba FALSO-POSITIVO: una receta de
+ *           fertilizante de síntesis cuyo texto contenía un token de fermento
+ *           ("biofermento", "encurtido", "fermentada") disparaba el caveat de
+ *           inocuidad INVIMA, mezclando dos dominios. Una consulta de
+ *           fertilizante sintético NUNCA es un fermento alimentario.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardSyntheticAgrochemical,
+  classifyQueryIntent,
+  guardFermentoRecipeSafety,
+  resetOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #351 — siglas de fertilizante mineral (DAP / MAP / KCl) + NPK formulado
+// ──────────────────────────────────────────────────────────────────────────
+describe('#351 guardSyntheticAgrochemical — siglas de fertilizante mineral', () => {
+  it('CASO REAL: "abono completo NPK 10-10-10 a 250 g/planta" → redirige a orgánico', () => {
+    const llmFail = 'Aplica un abono completo NPK 10-10-10 a 250 g/planta cada mes para que produzca.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/npk|10-10-10/i);
+    expect(out.text).toMatch(/agroecológico/i);
+    expect(out.text).toMatch(/compost|bocashi|biol|humus/i);
+  });
+
+  it('CASO REAL: "mezcla urea con fosfato triple y sulfato de potasio" → bloquea y redirige', () => {
+    const llmFail = 'Cómo mezclo urea con fosfato triple y sulfato de potasio en partes iguales.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/urea|fosfato triple|sulfato de potasio/i);
+    expect(out.text).toMatch(/compost|bocashi|biol|humus/i);
+  });
+
+  it('sigla DAP (fosfato diamónico) sola → dispara', () => {
+    const out = guardSyntheticAgrochemical('Para el arranque aplica DAP al fondo del surco.');
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/dap/i);
+  });
+
+  it('sigla MAP (fosfato monoamónico) sola → dispara', () => {
+    const out = guardSyntheticAgrochemical('El MAP es buena fuente de fósforo arrancador.');
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/map/i);
+  });
+
+  it('sigla KCl (cloruro de potasio) sola → dispara', () => {
+    const out = guardSyntheticAgrochemical('Agrega 50 kg de KCl por hectárea para el potasio.');
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/kcl/i);
+  });
+
+  it('DAP y MAP juntos en la misma frase → dispara', () => {
+    const out = guardSyntheticAgrochemical('Puedes usar DAP y MAP combinados al suelo.');
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/dap|map/i);
+  });
+
+  it('CONTROL: NO dispara con biopreparados/abonos orgánicos legítimos', () => {
+    const ok =
+      'Para nutrir tu cultivo usa compost bien maduro, bocashi, humus de lombriz y biol; ' +
+      'alimentan el suelo vivo sin acidificarlo.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('CONTROL: "map" NO debe aparecer como subcadena de palabras comunes (mapa, mapeo)', () => {
+    // El sigla MAP es palabra-aislada; "mapa"/"mapear" no deben dispararla.
+    const ok = 'Haz un mapa de tu finca y un mapeo de las zonas húmedas antes de sembrar.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: un par numérico (no triplete) NO se confunde con formulación NPK', () => {
+    const ok = 'Siembra las matas a 30-40 cm entre plantas para buena aireación.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #347 — unidades de mercado = intención de PRECIO (no inyectar perfil finca)
+// ──────────────────────────────────────────────────────────────────────────
+describe('#347 classifyQueryIntent — unidades de mercado = precio', () => {
+  it('"a cómo está el bulto de papa" → precio', () => {
+    expect(classifyQueryIntent('a cómo está el bulto de papa')).toBe('precio');
+  });
+
+  it('"arroba de cebolla a cómo" → precio', () => {
+    expect(classifyQueryIntent('arroba de cebolla a cómo')).toBe('precio');
+  });
+
+  it('"cuánto cuesta el bulto de papa" → precio', () => {
+    expect(classifyQueryIntent('cuánto cuesta el bulto de papa')).toBe('precio');
+  });
+
+  it('"precio del bulto de papa" → precio', () => {
+    expect(classifyQueryIntent('precio del bulto de papa')).toBe('precio');
+  });
+
+  it('"cuánto vale la carga de papa" → precio', () => {
+    expect(classifyQueryIntent('cuánto vale la carga de papa')).toBe('precio');
+  });
+
+  it('CONTROL: una consulta de siembra normal sigue siendo siembra', () => {
+    expect(classifyQueryIntent('qué puedo sembrar en mi finca a 1923 msnm')).toBe('siembra');
+    expect(classifyQueryIntent('es viable la papa a esta altura')).toBe('siembra');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #1281 — falso-positivo de fermento sobre receta de fertilizante sintético
+// ──────────────────────────────────────────────────────────────────────────
+describe('#1281 guardFermentoRecipeSafety — NO falso-positivo sobre fertilizante', () => {
+  it('FALSO-POSITIVO FIX: receta de urea+sulfato con "biofermento" NO antepone caveat de fermento', () => {
+    const out = guardFermentoRecipeSafety(
+      'Prepara un biofermento mineral mezclando urea y sulfato de potasio, deja fermentar 7 días.',
+      { userMessage: 'cómo preparo un biofermento con urea y sulfato' },
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('FALSO-POSITIVO FIX: "encurtido" + urea/sulfato (contexto fertilizante) NO antepone caveat', () => {
+    const out = guardFermentoRecipeSafety(
+      'Para el encurtido mezcla urea con sulfato y deja fermentar.',
+      { userMessage: 'mezclo urea para encurtir' },
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('FALSO-POSITIVO FIX: "mezclo urea con sulfato … solución fermentada" NO antepone caveat', () => {
+    const out = guardFermentoRecipeSafety(
+      'Mezcla urea con sulfato de potasio; deja reposar la solución fermentada antes de aplicar.',
+      { userMessage: 'cómo mezclo urea con sulfato' },
+    );
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: kombucha SIGUE disparando el caveat de inocuidad (no romper #345)', () => {
+    const out = guardFermentoRecipeSafety(
+      'Para hacer kombucha necesitas té, azúcar y un scoby. Deja fermentar 7 días en un frasco limpio.',
+      { userMessage: 'cómo preparo kombucha' },
+    );
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/receta_fermento/);
+    expect(out.text).toMatch(/INVIMA/);
+  });
+
+  it('CONTROL: receta de masato SIGUE disparando el caveat', () => {
+    const out = guardFermentoRecipeSafety(
+      'El masato se prepara con arroz cocido y panela, se deja fermentar varios días.',
+      { userMessage: 'dame la receta del masato' },
+    );
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/receta_fermento/);
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -341,6 +341,17 @@ const SYNTHETIC_AGROCHEM_TERMS = [
 const SYNTHETIC_FERTILIZER_PATTERNS = [
   /(^|[^a-z])npk([^a-z]|$)/, // sigla NPK (con o sin formulación al lado)
   /(^|[^a-z])n-p-k([^a-z]|$)/,
+  // #351 (E2E 2026-06-03): SIGLAS de campo de fertilizante mineral. El modelo a
+  // veces nombra el producto solo por la sigla ("aplica DAP", "agrega KCl") sin
+  // el nombre largo (que sí está en SYNTHETIC_AGROCHEM_TERMS). Las normalizamos a
+  // minúsculas con límite de palabra (`[^a-z0-9]`) → "dap"/"map"/"kcl" como token
+  // aislado; "mapa"/"mapeo"/"dapper" NO matchean (carácter alfanumérico al lado).
+  //   dap → fosfato diamónico (diammonium phosphate)
+  //   map → fosfato monoamónico (monoammonium phosphate)
+  //   kcl → cloruro de potasio (muriato de potasio)
+  /(^|[^a-z0-9])dap([^a-z0-9]|$)/,
+  /(^|[^a-z0-9])map([^a-z0-9]|$)/,
+  /(^|[^a-z0-9])kcl([^a-z0-9]|$)/,
   /\btriple\s+(quince|15|catorce|14|diecisiete|17)\b/, // "triple 15"
   /\b\d{1,2}\s*[-–]\s*\d{1,2}\s*[-–]\s*\d{1,2}\b/, // formulación "5-10-10", "15-15-15"
 ];
@@ -2080,9 +2091,46 @@ const FERMENTO_RECIPE_PATTERNS = [
 ];
 
 /**
+ * #1281 (E2E 2026-06-03) — tokens de FERTILIZANTE MINERAL DE SÍNTESIS. Si una
+ * receta de fertilizante (urea + sulfato + fosfato…) contiene de paso un token de
+ * fermento ("biofermento mineral", "deja fermentar la solución", "encurtido"), el
+ * gate de fermento daba FALSO-POSITIVO y anteponía el caveat de inocuidad INVIMA
+ * a una consulta agroquímica. Un fertilizante mineral NUNCA es un alimento
+ * fermentado: si la query/respuesta trae estos tokens, NO es fermento alimentario
+ * (ese caso lo maneja `guardSyntheticAgrochemical`). Sobre el texto normalizado.
+ */
+const SYNTHETIC_FERTILIZER_TOKENS = [
+  /(^|[^a-z])urea([^a-z]|$)/,
+  /(^|[^a-z])sulfato\s+de\s+(potasio|amonio)([^a-z]|$)/,
+  /(^|[^a-z])fosfato\s+(triple|diamonico|monoamonico)([^a-z]|$)/,
+  /(^|[^a-z])nitrato\s+de\s+(amonio|potasio)([^a-z]|$)/,
+  /(^|[^a-z0-9])npk([^a-z0-9]|$)/,
+  /(^|[^a-z0-9])dap([^a-z0-9]|$)/,
+  /(^|[^a-z0-9])map([^a-z0-9]|$)/,
+  /(^|[^a-z0-9])kcl([^a-z0-9]|$)/,
+  /(^|[^a-z])cloruro\s+de\s+potasio([^a-z]|$)/,
+];
+
+/**
+ * ¿La query/respuesta menciona un fertilizante mineral de síntesis? Si sí, NO es
+ * un fermento alimentario (es dominio agroquímico). Sobre el texto normalizado.
+ *
+ * @param {string} combinedNorm  user + texto normalizados, sin diacríticos.
+ * @returns {boolean}
+ */
+function _mentionsSyntheticFertilizer(combinedNorm) {
+  return SYNTHETIC_FERTILIZER_TOKENS.some((re) => re.test(combinedNorm));
+}
+
+/**
  * ¿La query/respuesta pide o da una RECETA de fermento? Gate combinado: debe
  * tocar un fermento (FERMENTO_TERMS) Y traer fraseo de receta/preparación, en la
  * pregunta del usuario O en el texto del LLM. Conservador hacia NO disparar.
+ *
+ * Exclusión #1281: si el texto trae tokens de fertilizante mineral de síntesis
+ * (urea/sulfato/fosfato/nitrato/NPK/DAP/MAP/KCl), NO es un fermento alimentario
+ * aunque mencione "biofermento"/"fermentar"/"encurtido" — es agroquímico y lo
+ * cubre `guardSyntheticAgrochemical`, no este caveat de inocuidad de alimentos.
  *
  * @param {string} textNorm  respuesta del LLM normalizada.
  * @param {string} userNorm  pregunta del usuario normalizada (o '').
@@ -2091,6 +2139,8 @@ const FERMENTO_RECIPE_PATTERNS = [
 function _isFermentoRecipe(textNorm, userNorm) {
   if (!_touchesFermento(textNorm, userNorm)) return false;
   const combined = `${userNorm} ${textNorm}`;
+  // #1281: un fertilizante mineral de síntesis NUNCA es un fermento alimentario.
+  if (_mentionsSyntheticFertilizer(combined)) return false;
   return FERMENTO_RECIPE_PATTERNS.some((re) => re.test(combined));
 }
 


### PR DESCRIPTION
## Contexto

Una suite E2E de seguridad (Playwright real contra prod + juez LLM) confirmó **3 casos que seguían mal en producción** pese a los guards previos. Esta PR los cierra con TDD (tests primero).

## Fixes

### #351 — `guardSyntheticAgrochemical` no detectaba siglas de fertilizante mineral
El matcher cubría los nombres largos (`fosfato diamónico`, `cloruro de potasio`) pero **no** las siglas de campo que el modelo usa solas: **DAP / MAP / KCl** ("aplica DAP", "agrega KCl"). Se añaden patrones de sigla con límite de palabra (`[^a-z0-9]`), de modo que **no** colisionan con palabras comunes (`mapa`, `mapeo`, `dapper`). NPK formulado (`10-10-10`) y la lista urea/fosfato/sulfato ya estaban cubiertos.

### #1281 — `guardFermentoRecipeSafety` daba falso-positivo sobre fertilizantes
Una receta de **fertilizante de síntesis** cuyo texto contenía de paso un token de fermento (`biofermento`, `encurtido`, `solución fermentada`) anteponía el caveat de inocuidad de **alimentos** a una consulta agroquímica. Un fertilizante mineral nunca es un fermento alimentario: se excluyen del match de fermento las queries con tokens de fertilizante mineral (urea/sulfato/fosfato/nitrato/NPK/DAP/MAP/KCl). Ese caso lo maneja `guardSyntheticAgrochemical`, no el caveat INVIMA.

### #347 — regresión-lock
Tests de clasificación de unidad de mercado (`bulto`/`arroba`/`carga` → intención de **precio**) para garantizar que no se inyecta perfil de finca (altitud/clima) ni inventario en consultas de precio. (El fix ya estaba en main; estos tests lo bloquean contra regresiones.)

## TDD / cobertura

Nuevo archivo `src/services/__tests__/outputGuards.npkPrecioFermento.test.js` — **20 casos**, incluyendo controles anti-falso-positivo:
- `kombucha` y `masato` **siguen** disparando el caveat de fermento (no rompe #345).
- abonos orgánicos legítimos (compost/bocashi/biol/humus) **no** disparan el guard agroquímico.
- `mapa`/`mapeo` **no** se confunden con la sigla MAP; un par numérico (`30-40 cm`) **no** se confunde con formulación NPK.

## Resultados

- `vitest run` (suite completa): **3317 passed, 1 skipped, 0 failed**.
- Suite de guards (5 archivos): **189 + 20 = 209 passed**, sin regresiones.
- `eslint` sobre los archivos tocados: **0 problemas**.

> Nota: `eslint .` reporta 2 problemas **preexistentes** en `AIStatusFooter.jsx` y `useIdleDetection.js` (ya en `main`, no tocados por esta PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)