### PR TITLE
fix(guards): suppress-and-replace de receta sintética + gate de precio para perfil de finca

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.36",
+  "version": "1.0.37",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v294';
+const CACHE_NAME = 'chagra-v295';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -69,7 +69,7 @@ import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../
 import { getCurrentTier } from '../../services/tierService';
 import DeepResearchCard from '../DeepResearchCard';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity } from '../../services/agentService';
-import { applyOutputGuards, applyTaxonomyGuard } from '../../services/outputGuards';
+import { applyOutputGuards, applyTaxonomyGuard, classifyQueryIntent } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile } from '../../services/ensoContext';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
@@ -1092,6 +1092,19 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     })();
     const climaContext = climaSnapshot ? `\n\n${buildClimaContext(climaSnapshot, { region: ensoRegion })}` : '';
 
+    // FALLO 2 (E2E prod 2026-06-03): GATE de PRECIO para el contexto de finca.
+    // `classifyQueryIntent` ya clasifica "a cómo está el bulto de papa" como
+    // 'precio', pero la inyección del perfil/altitud/viabilidad de finca ocurría
+    // AGUAS ARRIBA del gate de los output-guards, así que la query de precio igual
+    // recibía el pipeline de viabilidad y filtraba el perfil ("…inviables en tu
+    // finca… a 0 msnm…"). Acá cablamos el clasificador AL INYECTOR: si el intent
+    // es 'precio', NO inyectamos contexto de finca NI corremos viabilidad/térmico
+    // (son irrelevantes a una consulta de mercado y filtran datos de finca). Una
+    // query de siembra real ("¿puedo sembrar papa en mi finca?") clasifica como
+    // 'siembra' y SÍ corre el pipeline (no se rompe). Conservador: cualquier otro
+    // intent ('unknown') sí inyecta (no degrada la inteligencia agronómica).
+    const isPriceQuery = classifyQueryIntent(query) === 'precio';
+
     // CONTEXTO AMBIENTAL DE LA FINCA (#202 mejora inteligencia). Bloque PURO
     // armado de datos YA disponibles localmente o en cache — CERO latencia:
     //   - profile / finca: localStorage + store en memoria (síncronos)
@@ -1111,14 +1124,18 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       return Object.entries(counts).map(([name, count]) => ({ name, count }));
     })();
     const fincaProfile = (() => { try { return getProfile(); } catch (_) { return null; } })();
-    const fincaContext = `\n\n${buildFincaContext({
-      profile: fincaProfile,
-      finca: fincaActivaCtx,
-      climaSnapshot,
-      groupedCultivos,
-      resolvedEntities,
-      activeAlerts,
-    })}`;
+    // GATE de precio: en una consulta de mercado NO inyectamos el perfil/altitud
+    // de finca (evita la fuga "Tu finca a 0 msnm…").
+    const fincaContext = isPriceQuery
+      ? ''
+      : `\n\n${buildFincaContext({
+          profile: fincaProfile,
+          finca: fincaActivaCtx,
+          climaSnapshot,
+          groupedCultivos,
+          resolvedEntities,
+          activeAlerts,
+        })}`;
 
     // VIABILIDAD POR ALTITUD (determinístico, sin red). Cruza la altitud de la
     // finca contra el rango altitud_min/altitud_max que el grounding AGE trae
@@ -1128,14 +1145,21 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       (fincaProfile && fincaProfile.finca_altitud) ||
       (fincaActivaCtx && fincaActivaCtx.altitud) ||
       null;
-    const viabilidadBlock = buildViabilityContext({ fincaAltitud, resolvedEntities });
+    // GATE de precio: la viabilidad por altitud es pipeline de SIEMBRA — no corre
+    // en una consulta de precio (evita la cascada "X es inviable en tu finca").
+    const viabilidadBlock = isPriceQuery
+      ? ''
+      : buildViabilityContext({ fincaAltitud, resolvedEntities });
     const viabilidadContext = viabilidadBlock ? `\n\n${viabilidadBlock}` : '';
 
     // RIESGO TÉRMICO POR CULTIVO (heladas/calor en vivo). Cruza temp_min/temp_max
     // de la especie resuelta × la mínima/máxima del pronóstico ya cacheado (el
     // mismo climaSnapshot — NO se re-pide). Cero latencia. Degrada si no hay
     // temp_min/temp_max o no hay forecast.
-    const frostHeatBlock = buildFrostHeatContext({ resolvedEntities, climaSnapshot });
+    // GATE de precio: también es pipeline de SIEMBRA → no corre en consulta de precio.
+    const frostHeatBlock = isPriceQuery
+      ? ''
+      : buildFrostHeatContext({ resolvedEntities, climaSnapshot });
     const frostHeatContext = frostHeatBlock ? `\n\n${frostHeatBlock}` : '';
 
     // ASOCIACIONES / POLICULTIVO. companions/antagonists del grounding cruzados

--- a/src/services/__tests__/outputGuards.suppressReplacePrecio.test.js
+++ b/src/services/__tests__/outputGuards.suppressReplacePrecio.test.js
@@ -1,0 +1,149 @@
+/**
+ * outputGuards.suppressReplacePrecio.test.js — dos fallos CRÍTICOS confirmados
+ * por E2E real contra prod (Playwright, #1282 ya desplegado) 2026-06-03.
+ *
+ *   FALLO 1 — guardSyntheticAgrochemical era APPEND-ONLY: concatenaba el aviso
+ *   orgánico DESPUÉS de la receta sintética que el LLM ya había escrito, pero NO
+ *   la suprimía. El campesino igual leía la dosis sintética ("10 kg de urea, 20
+ *   kg de TSP y 15 kg de sulfato de potasio por cada 100 m²…"). FIX: cuando hay
+ *   un token de fertilizante SINTÉTICO + un patrón de DOSIS, DESCARTAR el cuerpo
+ *   con la receta y devolver SOLO el bloque de redirección orgánica
+ *   (suppress-and-replace), nunca concatenar. Anti-sobre-supresión: una
+ *   respuesta orgánica con cantidades ("2 kg de compost", "1 L de biol por
+ *   planta") NO se suprime — la supresión SOLO dispara con sintético + dosis.
+ *
+ *   FALLO 2 — fuga de inventario/perfil de finca en queries de PRECIO. A "a cómo
+ *   está el bulto de papa" el agente respondió con viabilidad/altitud de finca
+ *   ("…inviables en tu finca… Tu finca se encuentra a 0 msnm…"). classifyQueryIntent
+ *   YA clasifica esas queries como 'precio'; este test fija el contrato del
+ *   clasificador que el inyector de contexto de finca debe respetar (gate:
+ *   intent !== 'precio' para inyectar perfil/viabilidad).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardSyntheticAgrochemical,
+  classifyQueryIntent,
+  resetOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// FALLO 1 — suppress-and-replace (NO append) de receta sintética + dosis
+// ──────────────────────────────────────────────────────────────────────────
+describe('FALLO 1 — guardSyntheticAgrochemical suppress-and-replace (sintético + dosis)', () => {
+  it('CASO REAL PROD: receta urea+TSP+sulfato de potasio "por cada 100 m²" → SUPRIME el cuerpo, solo redirección orgánica', () => {
+    const llmFail =
+      'Para abonar tu cultivo, una mezcla típica podría ser 10 kg de urea, 20 kg de TSP y 15 kg de ' +
+      'sulfato de potasio por cada 100 m². Agrega primero el sulfato de potasio, luego la urea y ' +
+      'finalmente el TSP.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    // Suppress-and-replace: el cuerpo con la receta sintética NO debe quedar.
+    expect(out.text).not.toMatch(/10\s*kg de urea/i);
+    expect(out.text).not.toMatch(/20\s*kg de TSP/i);
+    expect(out.text).not.toMatch(/15\s*kg de sulfato de potasio/i);
+    expect(out.text).not.toMatch(/por cada 100 m²/i);
+    // Solo queda el bloque de redirección orgánica.
+    expect(out.text).toMatch(/agroecológico/i);
+    expect(out.text).toMatch(/compost|bocashi|biol|humus/i);
+  });
+
+  it('CASO REAL PROD: "250 g/planta de NPK 10-10-10 cada mes" → SUPRIME la dosis sintética', () => {
+    const llmFail =
+      'Aplica un abono completo NPK 10-10-10 a 250 g/planta cada mes para que produzca bien.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/250\s*g\/planta/i);
+    expect(out.text).not.toMatch(/10-10-10/);
+    expect(out.text).toMatch(/agroecológico/i);
+    expect(out.text).toMatch(/compost|bocashi|biol|humus/i);
+  });
+
+  it('urea "50 kg por hectárea" → SUPRIME (sintético + dosis kg/ha)', () => {
+    const llmFail = 'Para que pegue verde, aplica 50 kg de urea por hectárea al voleo.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/50\s*kg de urea/i);
+    expect(out.text).toMatch(/agroecológico/i);
+  });
+
+  it('KCl "2 bultos por lote" → SUPRIME (sigla sintética + dosis en bultos)', () => {
+    const llmFail = 'Echa 2 bultos de KCl por lote para subir el potasio.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    expect(out.text).not.toMatch(/2 bultos de KCl/i);
+    expect(out.text).toMatch(/agroecológico/i);
+  });
+
+  // ── CONTROLES NEGATIVOS (anti-sobre-supresión) ──
+  it('CONTROL NEGATIVO: respuesta orgánica con "2 kg de compost por planta" NO se suprime (ni se modifica)', () => {
+    const ok = 'Aplica 2 kg de compost bien maduro por planta cada dos meses; alimenta el suelo vivo.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('CONTROL NEGATIVO: receta de biopreparado (biol) con cantidades NO se suprime', () => {
+    const ok =
+      'Prepara biol: 50 L de agua, 10 kg de estiércol fresco, 2 kg de melaza y 1 L de leche. ' +
+      'Aplica 1 L de biol diluido por planta cada quince días.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('CONTROL NEGATIVO: bocashi con dosis en kg/m² NO se suprime', () => {
+    const ok = 'Incorpora 3 kg/m² de bocashi maduro antes de sembrar; es un abono orgánico fermentado.';
+    const out = guardSyntheticAgrochemical(ok);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('sintético SIN dosis sigue comportándose (modificado): glifosato suelto NO desencadena suppress pero igual corrige', () => {
+    // Sin patrón de dosis no suprimimos el cuerpo (puede ser una mención de
+    // advertencia/validación); el guard sigue añadiendo el contrapeso orgánico
+    // como antes (#17). Lo que cambia con dosis es la SUPRESIÓN.
+    const llmFail = 'Para la maleza algunos aplican glifosato al lote.';
+    const out = guardSyntheticAgrochemical(llmFail);
+    expect(out.modified).toBe(true);
+    // Append-mode: la advertencia orgánica está presente.
+    expect(out.text).toMatch(/agroecológico/i);
+  });
+
+  it('idempotencia: pasar dos veces una receta sintética+dosis no rompe (sigue suprimida)', () => {
+    const llmFail = 'Aplica 10 kg de urea y 5 kg de sulfato de amonio por cada 100 m².';
+    const once = guardSyntheticAgrochemical(llmFail);
+    const twice = guardSyntheticAgrochemical(once.text);
+    expect(once.modified).toBe(true);
+    expect(twice.modified).toBe(false); // ya es solo redirección orgánica
+    expect(twice.text).toMatch(/agroecológico/i);
+    expect(twice.text).not.toMatch(/10 kg de urea/i);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// FALLO 2 — gate de PRECIO para NO inyectar perfil/viabilidad de finca
+// ──────────────────────────────────────────────────────────────────────────
+describe('FALLO 2 — classifyQueryIntent gate de precio (no inyectar finca)', () => {
+  it('"a cómo está el bulto de papa" → precio (NO debe inyectar finca)', () => {
+    expect(classifyQueryIntent('a cómo está el bulto de papa')).toBe('precio');
+  });
+
+  it('"precio de la arroba de cebolla" → precio', () => {
+    expect(classifyQueryIntent('precio de la arroba de cebolla')).toBe('precio');
+  });
+
+  it('"cuánto vale la carga de papa en plaza" → precio', () => {
+    expect(classifyQueryIntent('cuánto vale la carga de papa en plaza')).toBe('precio');
+  });
+
+  it('CONTROL: query de siembra real SÍ corre viabilidad (no romperla)', () => {
+    expect(classifyQueryIntent('¿puedo sembrar papa en mi finca?')).toBe('siembra');
+    expect(classifyQueryIntent('qué puedo sembrar en mi finca a 1923 msnm')).toBe('siembra');
+    expect(classifyQueryIntent('es viable la papa a esta altura')).toBe('siembra');
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -516,6 +516,102 @@ function _agrochemBySuffix(token) {
  */
 const FAKE_CHEM_CODE_RE = /\b[MIFH]-\d{1,3}\b/g;
 
+// ── #351b (FALLO 1, E2E prod 2026-06-03): suppress-and-replace ───────────────
+
+/**
+ * Subconjunto de la denylist que son FERTILIZANTES minerales de síntesis (no
+ * fungicidas/insecticidas/herbicidas). Solo estos, junto con una DOSIS, gatillan
+ * la SUPRESIÓN del cuerpo (suppress-and-replace). Un fungicida/insecticida sin
+ * dosis sigue en modo append (#17): se le anexa el contrapeso orgánico sin
+ * borrar el texto. La supresión se reserva a la RECETA de fertilizante mineral,
+ * que es la fuga viva de prod (el campesino leía "10 kg de urea… por cada 100 m²").
+ * Normalizados sin diacríticos/case.
+ */
+const SYNTHETIC_FERTILIZER_TERMS = [
+  'urea',
+  'fosfato triple',
+  'superfosfato triple',
+  'fosfato diamonico',
+  'fosfato monoamonico',
+  'sulfato de potasio',
+  'sulfato de amonio',
+  'nitrato de amonio',
+  'nitrato de potasio',
+  'cloruro de potasio',
+  'muriato de potasio',
+  // siglas de campo (TSP = triple super phosphate / fosfato triple)
+  'tsp',
+].map(_stripDiacritics);
+
+/**
+ * Patrones de DOSIS de aplicación. Disparan la SUPRESIÓN solo en combinación con
+ * un fertilizante SINTÉTICO (ver `_hasSyntheticFertilizerDose`). Cubren el fraseo
+ * de campo: "kg/m²", "g/planta", "kg por cada 100 m²", "250 g/planta", "2 bultos
+ * por lote", "50 kg por hectárea", etc. Sobre el texto normalizado sin tildes.
+ *
+ * IMPORTANTE: estos patrones también matchean dosis ORGÁNICAS ("2 kg de
+ * compost") — por eso NUNCA gatillan supresión por sí solos: requieren el token
+ * sintético al lado. Es la conjunción (sintético + dosis) la que es inequívoca.
+ */
+const DOSE_PATTERNS = [
+  // unidad de masa/volumen por unidad de área o planta: "kg/m2", "g/planta", "kg / ha"
+  /\b\d+(?:[.,]\d+)?\s*(kg|g|gr|gramos?|kilos?|cc|ml|l|litros?)\s*\/\s*(m2|m²|planta|mata|ha|hectarea|surco|sitio|hoyo)\b/,
+  // "N kg/g por planta / por mata / por m2 / por cada X m2 / por hectarea / por sitio"
+  /\b\d+(?:[.,]\d+)?\s*(kg|g|gr|gramos?|kilos?|cc|ml|l|litros?)\s+por\s+(cada\s+\d+\s*)?(planta|mata|m2|m²|metro|metros|ha|hectarea|hectareas|surco|sitio|hoyo|lote|arbol|arboles)\b/,
+  // "N bultos/sacos/cargas (de X) por lote / por hectarea / por planta"
+  /\b\d+(?:[.,]\d+)?\s*(bulto[s]?|saco[s]?|carga[s]?|arroba[s]?|costal(?:es)?)\s+(de\s+\S+\s+)?(por|\/|a)\s+/,
+  // dosis genérica de masa "10 kg de <algo>" cuando ya hay sintético en el texto
+  // (el guard exige el sintético aparte; aquí basta el "N kg/g de").
+  /\b\d+(?:[.,]\d+)?\s*(kg|g|gr|gramos?|kilos?)\s+de\b/,
+];
+
+/**
+ * ¿El texto normalizado contiene a la vez (a) un fertilizante SINTÉTICO y (b) un
+ * patrón de DOSIS? Esa conjunción es la que delata una RECETA sintética con
+ * cantidades, que debe SUPRIMIRSE (no concatenar). El NPK formulado / triplete /
+ * siglas DAP·MAP·KCl también cuentan como fertilizante sintético.
+ *
+ * Anti-sobre-supresión: la dosis sola (respuesta orgánica con "2 kg de compost")
+ * NO basta — hace falta el token sintético. Un biopreparado permitido nunca es
+ * sintético (no entra acá).
+ *
+ * @param {string} norm  texto ya normalizado (minúsculas, sin tildes).
+ * @returns {boolean}
+ */
+function _hasSyntheticFertilizerDose(norm) {
+  // (a) ¿hay un fertilizante mineral de síntesis?
+  let hasSynthFert = false;
+  for (const term of SYNTHETIC_FERTILIZER_TERMS) {
+    const re = new RegExp(`(^|[^a-z0-9])${term.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}([^a-z0-9]|$)`);
+    if (re.test(norm)) {
+      hasSynthFert = true;
+      break;
+    }
+  }
+  if (!hasSynthFert) {
+    // NPK / triplete N-P-K / siglas DAP·MAP·KCl también son fertilizante sintético.
+    for (const re of SYNTHETIC_FERTILIZER_PATTERNS) {
+      if (re.test(norm)) {
+        hasSynthFert = true;
+        break;
+      }
+    }
+  }
+  if (!hasSynthFert) return false;
+
+  // (b) ¿hay un patrón de dosis?
+  return DOSE_PATTERNS.some((re) => re.test(norm));
+}
+
+/**
+ * Marcador estable de la nota de redirección orgánica. Sirve para (a) la
+ * idempotencia del guard (no re-disparar sobre un texto ya corregido) y (b)
+ * identificar el bloque en tests/telemetría. Debe coincidir EXACTAMENTE con el
+ * `intro` de `_organicRedirect`.
+ */
+const ORGANIC_REDIRECT_MARKER =
+  'Chagra es agroecológico, no recomendamos agroquímicos ni fertilizantes sintéticos';
+
 /**
  * Texto de corrección honesta que reemplaza una recomendación de sintético.
  * Redirige a la ruta orgánica/biopreparado del catálogo según el tipo de
@@ -535,7 +631,7 @@ function _organicRedirect(originalText) {
     );
 
   const intro =
-    'Una nota importante: Chagra es agroecológico, no recomendamos agroquímicos ni fertilizantes sintéticos. ' +
+    `Una nota importante: ${ORGANIC_REDIRECT_MARKER}. ` +
     'Lo que de verdad funciona y cuida tu suelo y tu salud es el manejo orgánico:';
 
   const lineas = [];
@@ -587,6 +683,15 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
     return { text: responseText ?? '', modified: false, reason: null };
   }
 
+  // Idempotencia: si la corrección orgánica YA está en el texto (append previo o
+  // un suppress-and-replace anterior), no re-disparamos. La nota de redirección
+  // menciona "urea/NPK/fosfatos" de forma EDUCATIVA ("en vez de NPK, urea…"), lo
+  // que de otro modo volvería a marcar el bloque como sintético en un segundo
+  // pase. El marcador es estable (`ORGANIC_REDIRECT_MARKER`).
+  if (responseText.includes(ORGANIC_REDIRECT_MARKER)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
   const norm = _stripDiacritics(responseText);
   const hits = [];
   for (const term of SYNTHETIC_AGROCHEM_TERMS) {
@@ -634,6 +739,26 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
 
   bumpGuardTelemetry('synthetic_agrochemical');
   const correction = _organicRedirect(responseText);
+
+  // #351b (FALLO 1, E2E prod 2026-06-03): SUPPRESS-AND-REPLACE. Si el texto trae
+  // una RECETA de fertilizante mineral de síntesis CON DOSIS ("10 kg de urea…
+  // por cada 100 m²", "250 g/planta de NPK 10-10-10"), DESCARTAMOS el cuerpo y
+  // devolvemos SOLO el bloque de redirección orgánica. Append-only dejaba la
+  // dosis sintética legible debajo del aviso (el campesino igual la leía). La
+  // supresión SOLO dispara con sintético + dosis: una respuesta orgánica con
+  // cantidades ("2 kg de compost", "1 L de biol por planta") NO entra acá
+  // (`_hasSyntheticFertilizerDose` exige un token SINTÉTICO, no orgánico).
+  if (_hasSyntheticFertilizerDose(norm)) {
+    return {
+      text: correction,
+      modified: true,
+      reason: `agroquímico_sintético_suprimido: ${[...new Set(hits)].join(', ')}`,
+    };
+  }
+
+  // Resto de casos (sintético sin dosis, p.ej. una mención de glifosato o un
+  // fungicida nombrado sin cantidades): se conserva el comportamiento previo
+  // (#17) — se ANEXA el contrapeso orgánico sin borrar el texto.
   const text = `${responseText.trim()}\n\n${correction}`;
   return {
     text,


### PR DESCRIPTION
## Contexto

Un E2E real contra prod (Playwright, sobre #1282 ya desplegado) confirmó **2 fallos CRÍTICOS de seguridad** que los guards actuales no cerraban.

## FALLO 1 — `guardSyntheticAgrochemical` era APPEND-ONLY (contra la misión agroecológica)

Concatenaba el aviso orgánico **después** de la receta sintética que el LLM ya había escrito, sin suprimirla. El usuario igual leía la dosis sintética:

> «…una mezcla típica podría ser 10 kg de urea, 20 kg de TSP y 15 kg de sulfato de potasio por cada 100 m²… Agrega primero el sulfato de potasio, luego la urea… Una nota importante: Chagra es agroecológico, no recomendamos agroquímicos…»

**Fix:** *suppress-and-replace*. Cuando la respuesta trae un token de fertilizante **SINTÉTICO** (urea, NPK `\d+-\d+-\d+`, fosfato triple/TSP/DAP/MAP, sulfato de potasio/KCl, nitrato/sulfato de amonio, etc.) **JUNTO CON** un patrón de **DOSIS** (kg/m², g/planta, kg por cada N m², bultos por lote…), se **descarta el cuerpo** y se devuelve **solo** el bloque de redirección orgánica (compost/bocashi/biol/humus). Nunca se concatena la receta.

**Anti-sobre-supresión (controles negativos en TDD):**
- Una respuesta orgánica con cantidades (`2 kg de compost por planta`, `1 L de biol por planta`) **NO** se suprime.
- Una receta de biopreparado (biol/bocashi) con cantidades **NO** se suprime.
- La supresión SOLO dispara con token **sintético** + dosis. Un sintético **sin** dosis sigue en modo *append* (#17, sin regresión).
- Idempotente vía marcador estable de la nota de redirección.

## FALLO 2 — Fuga de perfil/viabilidad de finca en queries de PRECIO

`classifyQueryIntent` ya clasificaba `a cómo está el bulto de papa` → `'precio'`, pero la inyección del contexto de finca (`buildFincaContext` / `buildViabilityContext` / `buildFrostHeatContext`) ocurría **aguas arriba** del gate. A una pregunta de precio respondía:

> «…la Papa Sabanera y la Papa Argentina son inviables en tu finca… Tu finca se encuentra a 0 msnm…»

**Fix:** se cabla el clasificador al inyector. Si `classifyQueryIntent(query) === 'precio'`, **NO** se inyecta perfil/altitud de finca **NI** corre el pipeline de viabilidad/térmico. Una query de siembra real (`¿puedo sembrar papa en mi finca?`) clasifica como `'siembra'` y **SÍ** corre viabilidad (no se rompe).

## Tests

Nuevo `src/services/__tests__/outputGuards.suppressReplacePrecio.test.js` con los controles negativos. `npm run test:unit` → **3330 passed | 1 skipped**. Lint de los archivos tocados en **0 warnings** (los 2 errores preexistentes en `AIStatusFooter.jsx` / `useIdleDetection.js` no son de este PR).

## Alcance

No toca grafo AGE ni sidecar. El merge dispara `deploy.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)