### PR TITLE
fix(perf): prewarm chat model (granite) en vez de NLU (gemma) + pin keep_alive

### DIFF
--- a/src/store/__tests__/useOllamaWarmStore.test.js
+++ b/src/store/__tests__/useOllamaWarmStore.test.js
@@ -1,7 +1,7 @@
 /**
  * useOllamaWarmStore — NN4 fix 2026-05-23.
  *
- * Cubre el bus global de warm-up del modelo Ollama gemma3:4b:
+ * Cubre el bus global de warm-up del modelo Ollama de CHAT:
  *   - estado inicial 'unknown'
  *   - startWarmup dispara fetch con payload correcto y transiciona
  *     'unknown' → 'warming' → 'warm' al recibir 200 OK
@@ -9,9 +9,16 @@
  *   - idempotencia: llamar startWarmup mientras está 'warming' o 'warm' NO
  *     dispara segunda request
  *   - resetWarmup vuelve al estado inicial limpio
+ *
+ * Fix cold-start (R2, 2026-06-03): el pre-warm DEBE calentar el modelo que
+ * el chat realmente usa (`DEFAULT_MODEL` de llmRouter = ROUTES.chat.model =
+ * granite3.1-dense:8b), NO el NLU (gemma3:4b). Antes calentaba gemma → el
+ * primer chat con granite caía al cold-start de ~46s. Además se pinnea con
+ * keep_alive=-1 (sin expiración por timer) en vez de '30m'.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import useOllamaWarmStore from '../useOllamaWarmStore';
+import { DEFAULT_MODEL } from '../../services/llmRouter';
 
 describe('useOllamaWarmStore — NN4 pre-warm Ollama al login', () => {
   beforeEach(() => {
@@ -44,12 +51,37 @@ describe('useOllamaWarmStore — NN4 pre-warm Ollama al login', () => {
     expect(opts.headers).toMatchObject({ 'Content-Type': 'application/json' });
     const body = JSON.parse(opts.body);
     expect(body).toMatchObject({
-      model: 'gemma3:4b',
+      model: DEFAULT_MODEL,
       prompt: 'ok',
       stream: false,
-      keep_alive: '30m',
+      keep_alive: -1,
       options: { num_predict: 1 },
     });
+  });
+
+  it('pre-warm apunta al modelo de CHAT (granite), no al NLU (gemma)', () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    useOllamaWarmStore.getState().startWarmup();
+
+    const [, opts] = fetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    // El modelo pre-calentado debe ser exactamente el del chat configurado
+    // en llmRouter (ROUTES.chat.model). Si fueran distintos, granite queda
+    // frío y el primer chat sufre el cold-start de ~46s.
+    expect(body.model).toBe(DEFAULT_MODEL);
+    expect(body.model).toBe('granite3.1-dense:8b');
+    expect(body.model).not.toBe('gemma3:4b');
+  });
+
+  it('pre-warm pinnea el modelo con keep_alive=-1 (sin expiración por timer)', () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    useOllamaWarmStore.getState().startWarmup();
+
+    const [, opts] = fetch.mock.calls[0];
+    const body = JSON.parse(opts.body);
+    // keep_alive=-1 mantiene el modelo cargado indefinidamente (no expira a
+    // los 30m). Evita que granite se descargue de GPU entre login y chat.
+    expect(body.keep_alive).toBe(-1);
   });
 
   it('transiciona unknown → warming → warm cuando fetch responde 200', async () => {

--- a/src/store/useOllamaWarmStore.js
+++ b/src/store/useOllamaWarmStore.js
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { DEFAULT_MODEL } from '../services/llmRouter';
 
 /**
  * useOllamaWarmStore — bus global de estado warm-up del modelo Ollama
@@ -16,6 +17,16 @@ import { create } from 'zustand';
  * primera interacción con el agente (el operador tiene que mirar el
  * dashboard, escoger una tile, abrir el agente — tiempo humano natural).
  *
+ * Fix cold-start (R2, 2026-06-03): el pre-warm calentaba `gemma3:4b` (el
+ * modelo de NLU del sidecar), pero el CHAT real usa `granite3.1-dense:8b`
+ * (ver `llmRouter.ROUTES.chat.model` / `DEFAULT_MODEL`). Resultado: granite
+ * quedaba frío y el primer chat sufría ~46s de cold-start. Ahora calentamos
+ * el modelo de chat real (importado de `DEFAULT_MODEL`, así nunca vuelve a
+ * diverger y respeta el override `VITE_LLM_CHAT_MODEL`) y lo pinneamos con
+ * `keep_alive=-1` (sin expiración por timer; no se descarga entre login y
+ * chat). NOTA: esto ataca el cold-start; el thrash por-turno (el NLU gemma
+ * evicta a granite, R1) es un fix aparte fuera de este scope.
+ *
  * El store es la fuente de verdad sobre si el modelo está caliente o no.
  * AgentScreen suscribe a `status` y muestra un banner pequeño "preparando
  * agente IA" si status !== 'warm'. El banner desaparece automáticamente
@@ -24,7 +35,7 @@ import { create } from 'zustand';
  * Estados:
  *   - 'unknown'  : no se ha intentado pre-warm en esta sesión (post-reload).
  *   - 'warming'  : pre-warm en vuelo. Banner visible si user entra al agente.
- *   - 'warm'     : pre-warm OK. Banner oculto. Modelo cargado por ~30 min.
+ *   - 'warm'     : pre-warm OK. Banner oculto. Modelo pinneado (keep_alive=-1).
  *   - 'failed'   : pre-warm falló (red, timeout, Ollama down). Banner
  *                  igualmente oculto — el primer request del agente caerá
  *                  al cold-start clásico y mostrará su propio progreso.
@@ -54,8 +65,9 @@ const useOllamaWarmStore = create((set, get) => ({
 
   /**
    * Dispara el pre-warm POST a `/api/ollama/api/generate` con prompt
-   * mínimo + keep_alive=30m. Fire-and-forget desde el caller (no await).
-   * El store maneja transiciones de status internamente.
+   * mínimo + keep_alive=-1 (pin permanente) sobre el modelo de CHAT
+   * (`DEFAULT_MODEL`). Fire-and-forget desde el caller (no await). El store
+   * maneja transiciones de status internamente.
    *
    * Idempotente: si ya estamos en 'warming' o 'warm', retorna sin
    * disparar nada. Solo re-dispara desde 'unknown' o 'failed'.
@@ -73,10 +85,15 @@ const useOllamaWarmStore = create((set, get) => ({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        model: 'gemma3:4b',
+        // Modelo de CHAT real (granite3.1-dense:8b por defecto, o el override
+        // VITE_LLM_CHAT_MODEL). Antes calentaba gemma3:4b (NLU) → granite
+        // quedaba frío y el primer chat sufría el cold-start de ~46s.
+        model: DEFAULT_MODEL,
         prompt: 'ok',
         stream: false,
-        keep_alive: '30m',
+        // -1 pinnea el modelo sin expiración por timer: no se descarga de GPU
+        // entre el login y la primera interacción con el agente.
+        keep_alive: -1,
         options: { num_predict: 1 },
       }),
       signal: controller.signal,
@@ -85,7 +102,7 @@ const useOllamaWarmStore = create((set, get) => ({
         clearTimeout(timer);
         if (res.ok) {
           set({ status: 'warm', completedAt: Date.now() });
-          console.debug('[useOllamaWarmStore] gemma3:4b warm-up OK');
+          console.debug(`[useOllamaWarmStore] ${DEFAULT_MODEL} warm-up OK (pinned)`);
         } else {
           set({ status: 'failed', completedAt: Date.now() });
           console.debug('[useOllamaWarmStore] warm-up falló: HTTP', res.status);


### PR DESCRIPTION
## Problema

El pre-warm de Ollama al login (`src/store/useOllamaWarmStore.js`) calentaba `gemma3:4b` (el modelo de NLU del sidecar), pero el chat real usa `granite3.1-dense:8b` (`llmRouter.ROUTES.chat.model` / `DEFAULT_MODEL`). Resultado: granite quedaba frío y el **primer chat sufría ~46s de cold-start** (diagnóstico empírico 2026-06-03).

Además, `keep_alive: '30m'` permitía que el modelo se descargara de GPU por timer entre el login y la primera interacción.

## Fix

- El pre-warm ahora importa `DEFAULT_MODEL` de `llmRouter`, así **siempre rastrea el modelo de chat configurado** y respeta el override `VITE_LLM_CHAT_MODEL`. No vuelve a diverger si el modelo de chat cambia.
- `keep_alive` pasa de `'30m'` a `-1` (**pin permanente**): el modelo no se descarga por timer entre login y chat.
- Resto del payload igual (`num_predict: 1`, `stream: false`, prompt mínimo).
- NO se agrega warm de gemma (no caben los dos en 12 GB; el NLU gemma mantiene su keep_alive corto intencional en el sidecar).

## Test (TDD)

`src/store/__tests__/useOllamaWarmStore.test.js`:
- El test de payload existente ahora assertea `model: DEFAULT_MODEL` + `keep_alive: -1`.
- Nuevo: el pre-warm apunta al modelo de CHAT (granite), **no** al NLU (gemma).
- Nuevo: el pre-warm pinnea con `keep_alive: -1`.

`npm run test:unit` (warm store + llmRouter + OAuthCallback + TopBar): **37 passed**. `eslint` archivos tocados: **0 warnings**.

## Scope

Este fix ataca el **cold-start (R2)**. El thrash por-turno (el NLU gemma evicta a granite, **R1**) es un fix aparte (NLU→granite o `NUM_PARALLEL=2`) fuera de este scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)