### PR TITLE
feat(agent): el clima nombra la vereda+municipio del usuario (#357)

### DIFF
--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -652,6 +652,60 @@ describe('agentService — Task #202 Profile Context', () => {
       expect(ctx).toContain('YA TIENE registrado');
       expect(ctx).toContain('Maíz amarillo');
     });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // #357 — CLIMA NOMBRA LA VEREDA. Cuando la finca está geocodeada a una
+    // vereda (reverse-geocoding DANE MGN, #338), la ubicación inyectada al
+    // prompt debe nombrar "vereda X, Municipio" para que el agente localice
+    // la respuesta de clima en la vereda específica, no un genérico "tu zona".
+    // El DATO de IDEAM sigue siendo municipal — solo se PRESENTA localizado.
+    // ──────────────────────────────────────────────────────────────────────
+    describe('#357 — vereda en el contexto de ubicación', () => {
+      it('nombra "vereda X, Municipio" cuando el perfil trae vereda', () => {
+        const ctx = buildFincaContext({
+          profile: { ...choachiProfile, vereda: 'El Curí' },
+          month: 5,
+        });
+        expect(ctx).toContain('vereda El Curí');
+        expect(ctx).toContain('Choachí');
+      });
+
+      it('toma la vereda de la finca activa sobre la del perfil', () => {
+        const ctx = buildFincaContext({
+          profile: { ...choachiProfile, vereda: 'Perfil Vereda' },
+          finca: { nombre: 'La Esperanza', vereda: 'El Curí' },
+          month: 5,
+        });
+        expect(ctx).toContain('vereda El Curí');
+        expect(ctx).not.toContain('Perfil Vereda');
+      });
+
+      it('cae a municipio sin romper cuando NO hay vereda', () => {
+        const ctx = buildFincaContext({ profile: choachiProfile, month: 5 });
+        expect(ctx).toContain('Choachí');
+        expect(ctx).not.toContain('vereda');
+      });
+
+      it('instruye al agente a NOMBRAR la vereda al hablar de clima/pronóstico', () => {
+        const ctx = buildFincaContext({
+          profile: { ...choachiProfile, vereda: 'El Curí' },
+          month: 5,
+        });
+        // El prompt debe pedir explícitamente nombrar el lugar específico
+        // (vereda + municipio) en vez de un genérico "tu zona"/"tu finca".
+        expect(ctx).toMatch(/vereda.*municipio|nombra.*lugar|tu zona/i);
+      });
+
+      it('no duplica la vereda cuando ya viene dentro de region/municipio', () => {
+        // Defensa: si municipio ya incluyera la vereda no debe quedar "vereda El Curí, vereda El Curí".
+        const ctx = buildFincaContext({
+          profile: { ...choachiProfile, vereda: 'El Curí' },
+          month: 5,
+        });
+        const matches = ctx.match(/vereda El Curí/gi) || [];
+        expect(matches.length).toBe(1);
+      });
+    });
   });
 
   // ────────────────────────────────────────────────────────────────────────

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -1309,6 +1309,16 @@ export function buildFincaContext({
   // ── Ubicación ───────────────────────────────────────────────────────────
   const municipio = p.municipio || null;
   const departamento = p.departamento || null;
+  // #357 — vereda: la finca activa manda sobre el perfil (igual que TopBar).
+  // El dataset DANE municipal NO la trae; solo existe si el onboarding manual
+  // o el reverse-geocoding fino (DANE MGN, #338) la resolvió. Cuando existe,
+  // el agente debe localizar la respuesta de clima en "vereda X, Municipio"
+  // en vez de un genérico "tu zona" — el DATO de IDEAM es municipal, pero se
+  // PRESENTA en la vereda específica del usuario.
+  const vereda =
+    (finca && typeof finca.vereda === 'string' && finca.vereda.trim()) ||
+    (typeof p.vereda === 'string' && p.vereda.trim()) ||
+    null;
   const altitud = p.finca_altitud || (finca && finca.altitud) || null;
   const piso =
     (p.piso_termico && String(p.piso_termico).trim()) ||
@@ -1317,7 +1327,14 @@ export function buildFincaContext({
   const lat = Number(p.ubicacion_lat);
   const lng = Number(p.ubicacion_lng);
   const ubic = [];
-  const lugar = [municipio, departamento].filter(Boolean).join(', ');
+  // "vereda El Curí, Choachí, Cundinamarca" — antepone la vereda al municipio
+  // solo si la tenemos y no está ya contenida en el municipio (defensa contra
+  // duplicado "vereda X, ... vereda X").
+  const veredaPrefix =
+    vereda && !(municipio && municipio.toLowerCase().includes(vereda.toLowerCase()))
+      ? `vereda ${vereda}`
+      : null;
+  const lugar = [veredaPrefix, municipio, departamento].filter(Boolean).join(', ');
   if (lugar) ubic.push(lugar);
   if (altitud) ubic.push(`~${altitud} msnm`);
   if (piso) ubic.push(`piso ${piso}`);
@@ -1328,6 +1345,21 @@ export function buildFincaContext({
     lines.push(`Finca activa: "${finca.nombre}"${ubic.length ? ` — ${ubic.join(', ')}` : ''}.`);
   } else if (ubic.length) {
     lines.push(`Ubicación: ${ubic.join(', ')}.`);
+  }
+
+  // #357 — instrucción de LOCALIZACIÓN: cuando reporte clima/pronóstico, que
+  // nombre el lugar específico del usuario (vereda + municipio si la hay; si no,
+  // el municipio) en vez de un genérico "tu zona"/"tu finca". El pronóstico de
+  // IDEAM es municipal, así que el agente NO debe afirmar precisión sub-municipal:
+  // solo PRESENTA el dato municipal localizado a la vereda del usuario.
+  if (vereda && municipio) {
+    lines.push(
+      `LOCALIZACIÓN DE CLIMA: al dar el pronóstico o reporte de clima, nómbralo para "${vereda}, ${municipio}" (la vereda del usuario), no como un genérico "tu zona" ni "tu finca". El dato meteorológico es del municipio de ${municipio} (IDEAM/Open-Meteo); preséntalo localizado a la vereda, sin prometer precisión de finca exacta.`,
+    );
+  } else if (municipio) {
+    lines.push(
+      `LOCALIZACIÓN DE CLIMA: al dar el pronóstico o reporte de clima, nómbralo para ${municipio} (el municipio del usuario), no como un genérico "tu zona".`,
+    );
   }
 
   // ── Temporada (calendárica, local — sin red) ────────────────────────────


### PR DESCRIPTION
## Qué

La respuesta de clima decía un genérico **"tu zona"/"tu finca"**. Ahora, cuando la finca está geocodeada a una vereda, el agente la localiza en **"vereda X, Municipio"** (ej. *"El Curí, Choachí · esta semana…"*).

El dato meteorológico de IDEAM es **municipal**; solo se **presenta** localizado a la vereda del usuario, sin prometer precisión sub-municipal.

## Cómo

`buildFincaContext` (`src/services/agentService.js`):
- Lee `vereda` con precedencia **finca activa > perfil** (igual que TopBar), proveniente del onboarding manual o del reverse-geocoding fino (DANE MGN, #338).
- Antepone `vereda X, Municipio` a la ubicación inyectada al system prompt, con defensa anti-duplicado si el municipio ya la contiene.
- Agrega una instrucción explícita de **LOCALIZACIÓN DE CLIMA** para que el agente nombre la vereda al reportar pronóstico, en vez de un genérico.
- Degrada con gracia: sin vereda → municipio; sin municipio → comportamiento previo.

## Tests (TDD)

`src/services/__tests__/agentService.test.js` — nuevo bloque `#357 — vereda en el contexto de ubicación` (5 casos: nombra vereda+municipio, precedencia finca>perfil, fallback sin vereda, instrucción de localización, anti-duplicado). Suite completa verde.

## Deploy

El merge a `main` dispara `deploy.yml` (rsync a producción + cache-bust por SHA).