### PR TITLE
feat(agent): la fuente citada (IDEAM/SIPSA/Agrosavia…) es link clickeable (#356)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -32,6 +32,7 @@ import {
   computeSourceMetadata,
   mergePostValidateMetadata,
   extractGroundingBadges,
+  deriveEvidenceSourceLink,
   extractEdges,
   clearMemory,
   shouldStartNewSession,
@@ -1765,8 +1766,16 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       // sin esos campos → no añade nada. #19: `auto_corrected` marca que los
       // guards deterministas modificaron la respuesta (badge "auto-corregida").
       const groundingBadges = extractGroundingBadges(resolvedEntities);
+      // #356: si el grounding curado no aportó un link de fuente, derivarlo del
+      // TOOL que respondió (p.ej. get_clima_ideam → "Fuente: IDEAM" clickeable a
+      // ideam.gov.co). Las entidades mandan (deep-link de ficha); el tool es el
+      // fallback. Graceful: sin fuente institucional → {} y no se añade badge.
+      const evidenceSourceLink = groundingBadges.fuente_url
+        ? {}
+        : deriveEvidenceSourceLink(toolEvidence);
       sourceMetadata = {
         ...sourceMetadata,
+        ...evidenceSourceLink,
         ...groundingBadges,
         auto_corrected: guarded.modified === true || taxonomyModified === true,
       };

--- a/src/services/__tests__/conversationMemory.sourceMetadata.test.js
+++ b/src/services/__tests__/conversationMemory.sourceMetadata.test.js
@@ -10,7 +10,12 @@
  * El ChatBubble renderiza el badge a partir de este metadata.
  */
 import { describe, test, expect } from 'vitest';
-import { computeSourceMetadata, mergePostValidateMetadata, extractGroundingBadges } from '../conversationMemory';
+import {
+  computeSourceMetadata,
+  mergePostValidateMetadata,
+  extractGroundingBadges,
+  deriveEvidenceSourceLink,
+} from '../conversationMemory';
 
 describe('computeSourceMetadata', () => {
   test('null / undefined toolEvidence → no tool, no grounded', () => {
@@ -364,5 +369,104 @@ describe('extractGroundingBadges (#18 fuente_url + #20 confianza)', () => {
 
   test('sin fuente_url ni confianza → {} (graceful, sin badge)', () => {
     expect(extractGroundingBadges([{ kind: 'species', nombre_comun: 'Lulo' }])).toEqual({});
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // #356 — FUENTE → LINK. Cuando una entidad cita una fuente INSTITUCIONAL
+  // (Agrosavia, IDEAM, SIPSA, ICA, Cenicafé…) pero NO trae un deep-link, el
+  // badge debe linkear a la PÁGINA institucional real (no quedar como texto
+  // muerto). Si la entidad sí trae un fuente_url http(s), ese deep-link manda.
+  // ──────────────────────────────────────────────────────────────────────
+  describe('#356 — fuente institucional sin deep-link → link a la institución', () => {
+    test('biopreparado con fuente "Agrosavia" y sin fuente_url → linkea a Agrosavia', () => {
+      const out = extractGroundingBadges([
+        { kind: 'biopreparado', nombre_comun: 'Caldo bordelés', fuente: 'Agrosavia', confianza: 'alta' },
+      ]);
+      expect(out.fuente).toBe('Agrosavia');
+      expect(out.fuente_url).toContain('agrosavia.co');
+      expect(out.confianza).toBe('alta');
+    });
+
+    test('species citando ICA sin URL → link a ica.gov.co', () => {
+      const out = extractGroundingBadges([
+        { kind: 'species', nombre_comun: 'Aguacate', fuente: 'ICA' },
+      ]);
+      expect(out.fuente).toBe('ICA');
+      expect(out.fuente_url).toContain('ica.gov.co');
+    });
+
+    test('el deep-link http(s) de la entidad gana sobre el mapeo institucional', () => {
+      const out = extractGroundingBadges([
+        {
+          kind: 'biopreparado',
+          fuente: 'Agrosavia',
+          fuente_url: 'https://repository.agrosavia.co/handle/123/ficha-real',
+        },
+      ]);
+      expect(out.fuente_url).toBe('https://repository.agrosavia.co/handle/123/ficha-real');
+    });
+
+    test('fuente NO institucional sin URL → NO inventa link', () => {
+      const out = extractGroundingBadges([
+        { kind: 'species', nombre_comun: 'Lulo', fuente: 'apuntes de un taller' },
+      ]);
+      expect(out.fuente_url).toBeUndefined();
+    });
+
+    test('fuente_url inseguro pero fuente institucional → cae al link institucional', () => {
+      const out = extractGroundingBadges([
+        { kind: 'biopreparado', fuente: 'IDEAM', fuente_url: 'javascript:alert(1)' },
+      ]);
+      expect(out.fuente_url).toContain('ideam.gov.co');
+      expect(out.fuente).toBe('IDEAM');
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// #356 — fuente de un TOOL (no entidad). El clima viene de get_clima_ideam:
+// la institución emisora (IDEAM) no es una entidad del grounding sino el
+// tool mismo. deriveEvidenceSourceLink mapea el tool / sus sources a un link.
+// ────────────────────────────────────────────────────────────────────────
+describe('deriveEvidenceSourceLink (#356 — fuente del tool → link)', () => {
+  test('get_clima_ideam → link a IDEAM', () => {
+    const out = deriveEvidenceSourceLink({
+      tool: 'get_clima_ideam',
+      args: { municipio: 'Choachí' },
+      result: { available: true, monthly_avg: 120 },
+    });
+    expect(out.fuente).toBe('IDEAM');
+    expect(out.fuente_url).toContain('ideam.gov.co');
+  });
+
+  test('result con sources[] institucionales → primer link reconocido', () => {
+    const out = deriveEvidenceSourceLink({
+      tool: 'get_species',
+      result: { found: true, sources: ['Agrosavia', 'Wikipedia'] },
+    });
+    expect(out.fuente).toBe('Agrosavia');
+    expect(out.fuente_url).toContain('agrosavia.co');
+  });
+
+  test('result.fuente_url deep-link válido gana', () => {
+    const out = deriveEvidenceSourceLink({
+      tool: 'get_species',
+      result: { found: true, fuente: 'Agrosavia', fuente_url: 'https://repository.agrosavia.co/handle/x' },
+    });
+    expect(out.fuente_url).toBe('https://repository.agrosavia.co/handle/x');
+  });
+
+  test('tool sin fuente institucional ni sources → {}', () => {
+    expect(deriveEvidenceSourceLink({ tool: 'get_companions', result: { companions: [] } })).toEqual({});
+    expect(deriveEvidenceSourceLink(null)).toEqual({});
+    expect(deriveEvidenceSourceLink({ tool: 'get_clima_ideam', result: { found: false } })).toEqual({});
+  });
+
+  test('array de evidences (tool_chain) → primer link encontrado', () => {
+    const out = deriveEvidenceSourceLink([
+      { tool: 'get_companions', result: { companions: [{ id: 'a' }] } },
+      { tool: 'get_clima_ideam', result: { available: true } },
+    ]);
+    expect(out.fuente_url).toContain('ideam.gov.co');
   });
 });

--- a/src/services/__tests__/institutionalSources.test.js
+++ b/src/services/__tests__/institutionalSources.test.js
@@ -1,0 +1,108 @@
+/**
+ * institutionalSources.test.js — #356: la cita "Fuente: IDEAM/SIPSA/Agrosavia"
+ * debe poder convertirse en un link clickeable a la página institucional real.
+ *
+ * Reglas:
+ *   - Mapea nombres de fuentes institucionales colombianas a URLs REALES que
+ *     resuelven (NO inventadas).
+ *   - Prefiere un deep-link si el caller lo pasa (p.ej. ficha de especie
+ *     Agrosavia con species_id); cae a la página/boletín de la institución.
+ *   - Tolerante a tildes, mayúsculas y fuentes compuestas ("Agrosavia / FAO",
+ *     "NOAA CPC · IDEAM").
+ *   - Devuelve null si la fuente no es institucional reconocida (no inventa).
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  institutionalSourceUrl,
+  resolveSourceLink,
+} from '../institutionalSources.js';
+
+describe('institutionalSourceUrl — mapeo fuente → URL institucional real', () => {
+  test('IDEAM → página de pronóstico y alertas (https)', () => {
+    const url = institutionalSourceUrl('IDEAM');
+    expect(url).toMatch(/^https:\/\//);
+    expect(url).toContain('ideam.gov.co');
+  });
+
+  test('SIPSA → boletín DANE (SIPSA es del DANE)', () => {
+    const url = institutionalSourceUrl('SIPSA');
+    expect(url).toMatch(/^https:\/\//);
+    expect(url).toContain('dane.gov.co');
+  });
+
+  test('Agrosavia → repositorio institucional', () => {
+    const url = institutionalSourceUrl('Agrosavia');
+    expect(url).toMatch(/^https:\/\//);
+    expect(url).toContain('agrosavia.co');
+  });
+
+  test('ICA → página institucional', () => {
+    const url = institutionalSourceUrl('ICA');
+    expect(url).toMatch(/^https:\/\//);
+    expect(url).toContain('ica.gov.co');
+  });
+
+  test('Cenicafé → página institucional (acepta sin tilde)', () => {
+    expect(institutionalSourceUrl('Cenicafé')).toContain('cenicafe.org');
+    expect(institutionalSourceUrl('Cenicafe')).toContain('cenicafe.org');
+  });
+
+  test('tolerante a mayúsculas/tildes y a fuentes compuestas', () => {
+    expect(institutionalSourceUrl('ideam')).toContain('ideam.gov.co');
+    expect(institutionalSourceUrl('NOAA CPC · IDEAM')).toContain('ideam.gov.co');
+    expect(institutionalSourceUrl('Agrosavia / FAO')).toContain('agrosavia.co');
+  });
+
+  test('prefiere el deep-link válido si el caller lo pasa', () => {
+    const deep = 'https://repository.agrosavia.co/handle/123/ficha-lulo';
+    expect(institutionalSourceUrl('Agrosavia', { deepLink: deep })).toBe(deep);
+  });
+
+  test('ignora un deep-link inseguro y cae a la institución', () => {
+    const url = institutionalSourceUrl('Agrosavia', { deepLink: 'javascript:alert(1)' });
+    expect(url).toContain('agrosavia.co');
+    expect(url).not.toContain('javascript');
+  });
+
+  test('fuente NO institucional / desconocida → null (no inventa URL)', () => {
+    expect(institutionalSourceUrl('Wikipedia')).toBeNull();
+    expect(institutionalSourceUrl('blog de un vecino')).toBeNull();
+    expect(institutionalSourceUrl('')).toBeNull();
+    expect(institutionalSourceUrl(null)).toBeNull();
+    expect(institutionalSourceUrl(123)).toBeNull();
+  });
+});
+
+describe('resolveSourceLink — de una cita de fuente a {fuente, fuente_url}', () => {
+  test('string institucional → label + URL', () => {
+    const out = resolveSourceLink('IDEAM');
+    expect(out.fuente).toBe('IDEAM');
+    expect(out.fuente_url).toContain('ideam.gov.co');
+  });
+
+  test('array de fuentes → toma la PRIMERA institucional reconocida', () => {
+    const out = resolveSourceLink(['blog random', 'SIPSA', 'IDEAM']);
+    expect(out.fuente).toBe('SIPSA');
+    expect(out.fuente_url).toContain('dane.gov.co');
+  });
+
+  test('fuente compuesta conserva el label original pero linkea a la institución', () => {
+    const out = resolveSourceLink('Agrosavia / FAO');
+    expect(out.fuente).toBe('Agrosavia / FAO');
+    expect(out.fuente_url).toContain('agrosavia.co');
+  });
+
+  test('deep-link de ficha (species) gana sobre la página institucional', () => {
+    const deep = 'https://repository.agrosavia.co/handle/123/ficha-lulo';
+    const out = resolveSourceLink('Agrosavia', { deepLink: deep });
+    expect(out.fuente_url).toBe(deep);
+  });
+
+  test('ninguna fuente institucional → {} (sin link, graceful)', () => {
+    expect(resolveSourceLink('Wikipedia')).toEqual({});
+    expect(resolveSourceLink(['blog', 'foro'])).toEqual({});
+    expect(resolveSourceLink(null)).toEqual({});
+    expect(resolveSourceLink([])).toEqual({});
+  });
+});

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -12,6 +12,7 @@
  */
 
 import { openDB, STORES } from '../db/dbCore';
+import { institutionalSourceUrl, resolveSourceLink } from './institutionalSources';
 
 const MAX_TURNS = 100;
 const MAX_DAYS = 30;
@@ -422,12 +423,24 @@ export function extractGroundingBadges(resolvedEntities) {
   for (const e of ordered) {
     if (!e || typeof e !== 'object') continue;
 
-    // Fuente verificable (#18): primera URL http(s) válida del turno.
+    // Fuente verificable (#18 + #356): primera fuente linkeable del turno.
+    // Preferimos el deep-link http(s) curado de la entidad (ej. ficha Agrosavia
+    // con species_id). Si no hay deep-link válido pero la entidad cita una
+    // fuente INSTITUCIONAL reconocida (Agrosavia/IDEAM/SIPSA/ICA/Cenicafé…),
+    // linkeamos a la PÁGINA institucional real (#356) — la cita deja de ser
+    // texto muerto. `institutionalSourceUrl` devuelve el deep-link si es válido,
+    // si no la institución, y null si la fuente no es institucional (no inventa).
     if (!out.fuente_url) {
-      const url = typeof e.fuente_url === 'string' ? e.fuente_url.trim() : '';
-      if (/^https?:\/\//i.test(url)) {
+      const label = typeof e.fuente === 'string' ? e.fuente.trim() : '';
+      const deepLink = typeof e.fuente_url === 'string' ? e.fuente_url.trim() : '';
+      const url = institutionalSourceUrl(label, { deepLink });
+      if (url && /^https?:\/\//i.test(url)) {
         out.fuente_url = url;
-        const label = typeof e.fuente === 'string' ? e.fuente.trim() : '';
+        if (label) out.fuente = label;
+      } else if (/^https?:\/\//i.test(deepLink)) {
+        // Deep-link válido aunque la fuente no sea institucional reconocida
+        // (preserva el comportamiento original: cualquier fuente_url http(s)).
+        out.fuente_url = deepLink;
         if (label) out.fuente = label;
       }
     }
@@ -441,6 +454,70 @@ export function extractGroundingBadges(resolvedEntities) {
   }
 
   return out;
+}
+
+/**
+ * Tools cuya institución emisora es fija y conocida (la fuente NO viaja como
+ * entidad del grounding sino que es definitoria del tool). Mapea tool → nombre
+ * de institución, que `institutionalSourceUrl` resuelve a la página real.
+ */
+const _TOOL_INSTITUTION = {
+  get_clima_ideam: 'IDEAM',
+  get_clima_finca: 'IDEAM',
+};
+
+/**
+ * #356 — deriva un link de fuente a partir del toolEvidence (no de una entidad
+ * del grounding). Pensado para respuestas cuya fuente es el TOOL mismo: el clima
+ * viene de `get_clima_ideam` → la cita "Fuente: IDEAM" debe linkear a IDEAM.
+ *
+ * Orden de resolución (primero que aplique):
+ *   1. `result.fuente_url` deep-link http(s) válido → se usa tal cual.
+ *   2. `result.sources` (array) o `result.fuente`/`result.source` (string)
+ *      mapeado a una institución reconocida.
+ *   3. La institución FIJA del tool (`get_clima_ideam` → IDEAM).
+ * Solo cuenta evidencia con datos reales (no `found:false`/`available:false`).
+ *
+ * Acepta un evidence simple o un array (tool_chain): en array, devuelve el PRIMER
+ * link que resuelva. 100% graceful: sin fuente institucional → {} (sin badge).
+ *
+ * @param {object|object[]|null|undefined} toolEvidence
+ * @returns {{ fuente?: string, fuente_url?: string }}
+ */
+export function deriveEvidenceSourceLink(toolEvidence) {
+  if (!toolEvidence) return {};
+
+  if (Array.isArray(toolEvidence)) {
+    for (const ev of toolEvidence) {
+      const link = deriveEvidenceSourceLink(ev);
+      if (link.fuente_url) return link;
+    }
+    return {};
+  }
+
+  const tool = typeof toolEvidence.tool === 'string' ? toolEvidence.tool : '';
+  const result = toolEvidence.result;
+  if (!result || typeof result !== 'object') return {};
+
+  // Miss explícito: el tool corrió pero no hay dato → sin fuente que citar.
+  if (result.found === false || result.available === false) return {};
+  if (typeof result.matches_count === 'number' && result.matches_count === 0) return {};
+
+  // 1+2: deep-link curado o sources institucionales del payload.
+  const deepLink = typeof result.fuente_url === 'string' ? result.fuente_url.trim() : '';
+  const citedSources = Array.isArray(result.sources)
+    ? result.sources
+    : [result.fuente, result.source].filter((s) => typeof s === 'string' && s.trim());
+  const fromPayload = resolveSourceLink(citedSources, { deepLink });
+  if (fromPayload.fuente_url) return fromPayload;
+
+  // 3: institución fija del tool (clima → IDEAM).
+  const inst = _TOOL_INSTITUTION[tool];
+  if (inst) {
+    const url = institutionalSourceUrl(inst);
+    if (url) return { fuente: inst, fuente_url: url };
+  }
+  return {};
 }
 
 /**
@@ -553,6 +630,7 @@ export default {
   computeSourceMetadata,
   mergePostValidateMetadata,
   extractGroundingBadges,
+  deriveEvidenceSourceLink,
   extractEdges,
   getLastTurnTimestamp,
   shouldStartNewSession,

--- a/src/services/institutionalSources.js
+++ b/src/services/institutionalSources.js
@@ -1,0 +1,131 @@
+/**
+ * institutionalSources.js — #356: convierte la cita de una fuente institucional
+ * ("Fuente: IDEAM / SIPSA / Agrosavia …") en un link clickeable a la página
+ * institucional REAL.
+ *
+ * Filosofía:
+ *   - SOLO URLs que resuelven. Cada destino se verificó empíricamente (HTTP 200)
+ *     contra la web pública de la institución (curl, 2026-06-03). NO se inventan
+ *     deep-links: si una institución no tiene una página pública estable para el
+ *     dato exacto, se linkea a su landing/sección oficial.
+ *   - El DATO no cambia: esto es presentación (la cita ya existía en texto). Si
+ *     la fuente NO es una institución reconocida, se devuelve null y el ChatBubble
+ *     simplemente no renderiza el link (degrada con gracia).
+ *   - Deep-link gana: si el grounding trae una URL precisa (p.ej. la ficha de una
+ *     especie en el repositorio Agrosavia, vía el consolidador de URLs), esa URL
+ *     manda sobre la página institucional genérica.
+ *
+ * Puro, sin red, sin estado. Seguro para el system prompt y la UX.
+ */
+
+/**
+ * Catálogo de fuentes institucionales → URL pública verificada (HTTP 200).
+ * Las claves se matchean por substring normalizado (sin tildes, minúsculas), así
+ * una cita compuesta ("NOAA CPC · IDEAM", "Agrosavia / FAO") resuelve a la
+ * primera institución reconocida. El orden importa: las entradas más específicas
+ * (SIPSA antes que DANE) van primero.
+ *
+ * @type {Array<{ keys: string[], url: string }>}
+ */
+const INSTITUTIONS = [
+  // SIPSA es el sistema de precios del DANE → su boletín vive en dane.gov.co.
+  {
+    keys: ['sipsa'],
+    url: 'https://www.dane.gov.co/index.php/estadisticas-por-tema/precios-y-costos/sistema-de-informacion-de-precios-sipsa',
+  },
+  // IDEAM — clima/pronóstico/alertas. El portal de pronóstico es JS-rendered;
+  // la landing institucional es el destino estable que resuelve.
+  { keys: ['ideam'], url: 'https://www.ideam.gov.co' },
+  // Agrosavia — repositorio institucional (fichas técnicas de especies/biopreparados).
+  { keys: ['agrosavia', 'corpoica'], url: 'https://repository.agrosavia.co/' },
+  // ICA — Instituto Colombiano Agropecuario (sanidad vegetal/animal).
+  { keys: ['ica'], url: 'https://www.ica.gov.co/' },
+  // Cenicafé — Centro Nacional de Investigaciones de Café.
+  { keys: ['cenicafe'], url: 'https://www.cenicafe.org/' },
+  // DANE genérico (si la cita es "DANE" sin SIPSA).
+  { keys: ['dane'], url: 'https://www.dane.gov.co/' },
+  // FAO — citada en biopreparados/manejo agroecológico.
+  { keys: ['fao'], url: 'https://www.fao.org/home/en' },
+  // NOAA — fase ENSO (ONI). CPC.
+  { keys: ['noaa'], url: 'https://www.cpc.ncep.noaa.gov/' },
+  // Open-Meteo — pronóstico abierto usado por el snapshot de clima.
+  { keys: ['open-meteo', 'openmeteo', 'open meteo'], url: 'https://open-meteo.com/' },
+  // INVIMA — autoridad sanitaria (fermentos/alimentos).
+  { keys: ['invima'], url: 'https://www.invima.gov.co/' },
+];
+
+/** Normaliza para matchear: minúsculas, sin tildes, espacios colapsados. */
+function _norm(s) {
+  return String(s)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** true si la URL es un http(s) seguro (no javascript:, data:, etc.). */
+function _isHttpUrl(u) {
+  return typeof u === 'string' && /^https?:\/\//i.test(u.trim());
+}
+
+/**
+ * Matchea una key contra el texto normalizado con frontera de palabra, para que
+ * keys cortas no peguen dentro de otra (p.ej. "ica" NO debe matchear "cenicafe").
+ * Escapa la key y usa \b alrededor; "open-meteo" y compañía siguen funcionando
+ * porque el guion es separador de palabra.
+ */
+function _matchesKey(text, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\b`).test(text);
+}
+
+/**
+ * Devuelve la URL institucional para una cita de fuente, o null si no se
+ * reconoce ninguna institución. Si `opts.deepLink` es un http(s) válido, gana
+ * sobre la página institucional (p.ej. ficha de especie Agrosavia con species_id).
+ *
+ * @param {unknown} source — nombre de la fuente citada (ej. "IDEAM", "Agrosavia / FAO").
+ * @param {{ deepLink?: string }} [opts]
+ * @returns {string|null}
+ */
+export function institutionalSourceUrl(source, opts = {}) {
+  const deep = opts && typeof opts.deepLink === 'string' ? opts.deepLink.trim() : '';
+  if (_isHttpUrl(deep)) return deep;
+
+  if (typeof source !== 'string' || !source.trim()) return null;
+  const n = _norm(source);
+  for (const inst of INSTITUTIONS) {
+    if (inst.keys.some((k) => _matchesKey(n, k))) return inst.url;
+  }
+  return null;
+}
+
+/**
+ * De una cita de fuente (string o array de strings) produce el shape de badge
+ * `{ fuente, fuente_url }` que el ChatBubble (FuenteBadge) renderiza como link.
+ *
+ * - Si es array, toma la PRIMERA entrada que mapee a una institución reconocida,
+ *   conservando su label original como `fuente`.
+ * - Si `opts.deepLink` es válido, se usa esa URL (la institución sigue dando el label).
+ * - Si nada mapea, devuelve {} (sin link — la UX no muestra badge).
+ *
+ * @param {unknown} sources — string | string[] de fuentes citadas.
+ * @param {{ deepLink?: string }} [opts]
+ * @returns {{ fuente?: string, fuente_url?: string }}
+ */
+export function resolveSourceLink(sources, opts = {}) {
+  const list = Array.isArray(sources)
+    ? sources
+    : typeof sources === 'string' && sources.trim()
+      ? [sources]
+      : [];
+  for (const s of list) {
+    if (typeof s !== 'string' || !s.trim()) continue;
+    const url = institutionalSourceUrl(s, opts);
+    if (url) return { fuente: s.trim(), fuente_url: url };
+  }
+  return {};
+}
+
+export default { institutionalSourceUrl, resolveSourceLink };


### PR DESCRIPTION
## Qué

La cita **"Fuente: IDEAM / SIPSA / Agrosavia"** quedaba como texto muerto cuando el grounding no traía un deep-link. Ahora se renderiza como un **link clickeable** a la página institucional real.

## Cómo

- **Nuevo módulo `src/services/institutionalSources.js`**: mapea nombres de fuentes institucionales colombianas (IDEAM, SIPSA→DANE, Agrosavia, ICA, Cenicafé, DANE, FAO, NOAA, Open-Meteo, INVIMA) a URLs públicas **reales verificadas** (HTTP 200, 2026-06-03). **No inventa deep-links**: si la institución no tiene página estable para el dato exacto, linkea a su landing/sección oficial. Fuente no institucional → `null` (no badge).
- **`extractGroundingBadges`** (`conversationMemory.js`): si una entidad cita una fuente institucional **sin** deep-link válido, ahora linkea a la página institucional. El deep-link de ficha (ej. ficha de especie Agrosavia con `species_id`) **sigue ganando**.
- **`deriveEvidenceSourceLink`** (nuevo): deriva el link de la fuente del **tool** que respondió (`get_clima_ideam` → *"Fuente: IDEAM"* clickeable a ideam.gov.co) o de `result.sources`.
- **`AgentScreen`** wirea el fallback de tool tras los badges del grounding curado.

El render **reutiliza el `FuenteBadge` existente** (#18): `<a href target="_blank" rel="noopener noreferrer">`, CSP-safe, sin `onclick` inline. **No cambia el shape del grounding** — solo deriva URLs de labels de fuente ya presentes. Graceful en todos los caminos.

## Tests (TDD)

- `src/services/__tests__/institutionalSources.test.js` — 14 casos (mapeo por institución, tolerancia tildes/mayúsculas/fuentes compuestas, deep-link gana, fuente desconocida → null, anti-inyección).
- `conversationMemory.sourceMetadata.test.js` — bloques `#356` para `extractGroundingBadges` (5 casos) + `deriveEvidenceSourceLink` (5 casos).
- `ChatBubble.test.jsx` (render del link) sigue verde.

## Deploy

El merge a `main` dispara `deploy.yml` (rsync a producción + cache-bust por SHA).