### PR TITLE
fix(i18n): corregir hallazgos auditoría lingüística (whopping + menores)

### DIFF
--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -389,7 +389,7 @@ export function generateRegionalToneContext(region) {
     'opita': 'Usa español opita/tolimense: "paisano", "jue", "ah pues". Tono tolima-huila.',
     'pastuso': 'Usa español pastuso: "taita", "guagua", "pues si". Tono nariñense.',
     'pacifico': 'Usa español del Pacífico: "compadre", "hermano de la mar". Tono afrocolombiano.',
-    'santandereano': 'Usa español santandereano: "¿qui whopping?", "mano". Tono canchón.',
+    'santandereano': 'Usa español santandereano: "¡quiubo, mano!", "mano". Tono canchón.',
     'amazonica': 'Usa español suave amazónico. Reconoce diversidad cultural. Evita imitar acentos específicos.',
   };
   


### PR DESCRIPTION
## Qué

Aplica el hallazgo de **severidad ALTA** de la auditoría lingüística (2026-06-02): el anglicismo roto `whopping` en el saludo santandereano.

La auditoría lo detectó en `src/data/regionalisms-co.json` (ya corregido en #1268/#1269), pero existía una **copia paralela viva** que el auditor no escaneó: el `toneMap` de `generateRegionalToneContext()` en `src/services/agentService.js`. Esa cadena se inyecta **directamente al system prompt del LLM** como instrucción de "habla así", por lo que el agente podía emitir `¿qui whopping?` literalmente al usuario campesino — exactamente la incidencia de alto impacto que la auditoría marcó como la más urgente.

## Cambio

```diff
- 'santandereano': 'Usa español santandereano: "¿qui whopping?", "mano". Tono canchón.',
+ 'santandereano': 'Usa español santandereano: "¡quiubo, mano!", "mano". Tono canchón.',
```

Alineado con el saludo ya corregido en `regionalisms-co.json` (`¡Quiubo, mano!`).

## Resto de la auditoría

Los otros 8 fixes menores de la tabla 4.1 (`houve`→`Quiubo, paisano`, tú/usted en help-tips, `estilan`→`ahílan`, `tip burn` glosado, `contradiciones`, gramática maíz, `¿` en chip) **ya estaban aplicados en main** vía PRs #1268 y #1269. Verificado uno por uno. Este era el único `whopping` vivo que quedaba — ahora cero en todo el repo.

## Validación

- `grep -rni whopping src/` → cero ocurrencias repo-wide.
- `eslint src/services/agentService.js` → limpio.
- `vitest run src/services/__tests__/agentService.test.js` → 119/119 pasan.
- Secret-scan + gates lefthook (secret/strategic/infra/eslint/conventional) → verdes.
- Registro: español colombiano, cero voseo, cero anglicismos rotos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)