### PR TITLE
fix(sources): no linkear a homepage cuando no hay recurso citado

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.37",
+  "version": "1.0.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v295';
+const CACHE_NAME = 'chagra-v296';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/ChatBubble.jsx
+++ b/src/components/AgentScreen/ChatBubble.jsx
@@ -130,36 +130,62 @@ function SourceBadge({ metadata }) {
 }
 
 /**
- * #18 — FuenteBadge: link clickeable a la fuente verificable del grounding curado
- * (p.ej. una dosis de biopreparado respaldada por Agrosavia / FAO). Aparece solo
- * cuando el turno trae `metadata.fuente_url` (URL http/https). CSP-safe: es un
- * `<a href target="_blank">` nativo (NO onclick inline) — no requiere
- * 'unsafe-inline' ni viola `script-src 'self'`. `rel="noopener noreferrer"`
- * evita fuga de window.opener al sitio externo.
+ * #18 (+ refinamiento 2026-06-03) — FuenteBadge: surfacéa la fuente de un turno
+ * grounded al MÁXIMO de trazabilidad HONESTA disponible. Dos formas:
  *
- * El label es `metadata.fuente` (ej. "Agrosavia"); si no viene, cae a un texto
- * genérico. Wording cero hype: "Fuente verificable".
+ *   1. LINK (`metadata.fuente_url` http/https): la cita lleva al RECURSO citado
+ *      (deep-link de ficha, sección del dato, o búsqueda del concepto). CSP-safe:
+ *      `<a href target="_blank">` nativo (NO onclick inline) — no requiere
+ *      'unsafe-inline'. `rel="noopener noreferrer"` evita fuga de window.opener.
+ *   2. TEXTO PLANO (`metadata.fuente_texto === true`, sin URL válida): la fuente
+ *      es institucional reconocida pero NO hay recurso puntual al que acercar
+ *      (p.ej. IDEAM/Open-Meteo, cuyo portal no permite deep-link al pronóstico
+ *      citado). Mostramos "Fuente: X" como `<span>` — NUNCA un link a la
+ *      homepage genérica (eso sería trazabilidad teatral). Honestidad ante todo.
+ *
+ * Si no hay ni URL ni `fuente_texto`, no renderiza nada (graceful).
  */
 function FuenteBadge({ metadata }) {
   const md = metadata || {};
   const url = typeof md.fuente_url === 'string' ? md.fuente_url.trim() : '';
-  if (!/^https?:\/\//i.test(url)) return null;
   const label = (typeof md.fuente === 'string' && md.fuente.trim()) || 'fuente externa';
-  return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      data-testid="fuente-badge"
-      data-source="verifiable-source"
-      title={`Esta respuesta cita una fuente verificable (${label}). Abre el documento original en una pestaña nueva.`}
-      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
-    >
-      <ShieldCheck size={12} aria-hidden="true" />
-      <span>Fuente verificable: {label}</span>
-      <ExternalLink size={11} aria-hidden="true" />
-    </a>
-  );
+
+  // Forma 1: recurso citado → link clickeable.
+  if (/^https?:\/\//i.test(url)) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-testid="fuente-badge"
+        data-source="verifiable-source"
+        title={`Esta respuesta cita una fuente verificable (${label}). Abre el recurso citado en una pestaña nueva.`}
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
+      >
+        <ShieldCheck size={12} aria-hidden="true" />
+        <span>Fuente verificable: {label}</span>
+        <ExternalLink size={11} aria-hidden="true" />
+      </a>
+    );
+  }
+
+  // Forma 2: institución reconocida pero sin recurso puntual → texto plano.
+  // NO emitimos <a> (no linkeamos a la homepage): solo citamos honestamente.
+  if (md.fuente_texto === true) {
+    return (
+      <span
+        data-testid="fuente-badge-text"
+        data-source="cited-source-text"
+        title={`Esta respuesta cita a ${label}. La institución no expone un enlace directo al dato citado, por eso se muestra como referencia (sin enlace).`}
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 mt-1 bg-slate-600/20 text-slate-300 border border-slate-700"
+      >
+        <ShieldCheck size={12} aria-hidden="true" />
+        <span>Fuente: {label}</span>
+      </span>
+    );
+  }
+
+  return null;
 }
 
 /**

--- a/src/components/__tests__/ChatBubble.test.jsx
+++ b/src/components/__tests__/ChatBubble.test.jsx
@@ -376,9 +376,10 @@ describe('ChatBubble — badges anti-alucinación (#18 fuente · #19 auto-correg
     expect(link).not.toHaveAttribute('onclick');
   });
 
-  test('#18 sin fuente_url → NO renderiza el badge de fuente', () => {
+  test('#18 sin fuente_url ni fuente_texto → NO renderiza el badge de fuente', () => {
     render(<ChatBubble message={base({ tool_used: 'get_species', grounded: true })} />);
     expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('fuente-badge-text')).not.toBeInTheDocument();
   });
 
   test('#18 fuente_url no http(s) → NO renderiza link (no inyección)', () => {
@@ -388,6 +389,63 @@ describe('ChatBubble — badges anti-alucinación (#18 fuente · #19 auto-correg
       />,
     );
     expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
+  });
+
+  // ── refinamiento 2026-06-03: fuente sin recurso puntual → TEXTO PLANO ──
+  test('fuente_texto:true (sin URL) → renderiza "Fuente: X" como TEXTO, NO un <a>', () => {
+    render(
+      <ChatBubble
+        message={base({ tool_used: 'get_clima_ideam', grounded: true, fuente: 'IDEAM', fuente_texto: true })}
+      />,
+    );
+    // No hay link de homepage.
+    expect(screen.queryByTestId('fuente-badge')).not.toBeInTheDocument();
+    // Sí hay una referencia de texto.
+    const text = screen.getByTestId('fuente-badge-text');
+    expect(text).toBeInTheDocument();
+    expect(text.tagName).not.toBe('A'); // <span>, jamás <a>
+    expect(text.querySelector('a')).toBeNull();
+    expect(text).not.toHaveAttribute('href');
+    expect(text).toHaveTextContent(/Fuente:\s*IDEAM/i);
+  });
+
+  test('fuente_texto NUNCA produce un link a la homepage de la institución', () => {
+    render(
+      <ChatBubble
+        message={base({ tool_used: 'get_clima_ideam', grounded: true, fuente: 'IDEAM', fuente_texto: true })}
+      />,
+    );
+    // Aserción central del operador: ningún <a> apunta al HOST institucional.
+    // Comparamos por hostname parseado (no substring de regex) para no caer en
+    // el anti-patrón de regex sin anclar (js/regex/missing-regexp-anchor).
+    const institutionalHosts = ['ideam.gov.co', 'www.ideam.gov.co'];
+    const anchors = document.querySelectorAll('a[href]');
+    for (const a of anchors) {
+      const href = a.getAttribute('href') || '';
+      let host = '';
+      try {
+        host = new URL(href, 'https://chagra.app').hostname;
+      } catch {
+        host = '';
+      }
+      expect(institutionalHosts).not.toContain(host);
+    }
+  });
+
+  test('fuente_url presente gana sobre fuente_texto (link, no texto)', () => {
+    render(
+      <ChatBubble
+        message={base({
+          tool_used: 'get_biopreparados',
+          grounded: true,
+          fuente: 'Agrosavia',
+          fuente_url: 'https://repository.agrosavia.co/search?query=lulo',
+          fuente_texto: true,
+        })}
+      />,
+    );
+    expect(screen.getByTestId('fuente-badge')).toBeInTheDocument();
+    expect(screen.queryByTestId('fuente-badge-text')).not.toBeInTheDocument();
   });
 
   // ── #19: auto-corregida ──

--- a/src/services/__tests__/conversationMemory.sourceMetadata.test.js
+++ b/src/services/__tests__/conversationMemory.sourceMetadata.test.js
@@ -372,33 +372,71 @@ describe('extractGroundingBadges (#18 fuente_url + #20 confianza)', () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────
-  // #356 — FUENTE → LINK. Cuando una entidad cita una fuente INSTITUCIONAL
-  // (Agrosavia, IDEAM, SIPSA, ICA, Cenicafé…) pero NO trae un deep-link, el
-  // badge debe linkear a la PÁGINA institucional real (no quedar como texto
-  // muerto). Si la entidad sí trae un fuente_url http(s), ese deep-link manda.
+  // #356 + refinamiento 2026-06-03 — FUENTE → RECURSO CITADO, NUNCA homepage.
+  // Una fuente con buscador (Agrosavia/ICA/Cenicafé/FAO/INVIMA) linkea a la
+  // BÚSQUEDA del concepto de la entidad. Una fuente sin sección/buscador
+  // (IDEAM/Open-Meteo/DANE) queda como TEXTO PLANO (fuente_texto:true), nunca
+  // un link a la portada. El deep-link http(s) de la entidad siempre gana.
   // ──────────────────────────────────────────────────────────────────────
-  describe('#356 — fuente institucional sin deep-link → link a la institución', () => {
-    test('biopreparado con fuente "Agrosavia" y sin fuente_url → linkea a Agrosavia', () => {
+  describe('#356-refino — link al recurso citado o texto plano, nunca homepage', () => {
+    test('biopreparado "Agrosavia" sin URL → búsqueda del concepto (NO la home del repo)', () => {
       const out = extractGroundingBadges([
         { kind: 'biopreparado', nombre_comun: 'Caldo bordelés', fuente: 'Agrosavia', confianza: 'alta' },
       ]);
       expect(out.fuente).toBe('Agrosavia');
-      expect(out.fuente_url).toContain('agrosavia.co');
+      expect(out.fuente_url).toContain('agrosavia.co/search');
+      expect(out.fuente_url).toContain('query=');
+      expect(out.fuente_texto).toBeUndefined();
       expect(out.confianza).toBe('alta');
     });
 
-    test('species citando ICA sin URL → link a ica.gov.co', () => {
+    test('species citando ICA con nombre → búsqueda en ICA (no su home)', () => {
       const out = extractGroundingBadges([
         { kind: 'species', nombre_comun: 'Aguacate', fuente: 'ICA' },
       ]);
       expect(out.fuente).toBe('ICA');
-      expect(out.fuente_url).toContain('ica.gov.co');
+      expect(out.fuente_url).toContain('ica.gov.co/buscador');
+      expect(out.fuente_url).toContain('Aguacate');
     });
 
-    test('el deep-link http(s) de la entidad gana sobre el mapeo institucional', () => {
+    test('prefiere el nombre CIENTÍFICO como término de búsqueda (más preciso)', () => {
+      const out = extractGroundingBadges([
+        { kind: 'species', nombre_comun: 'Lulo', nombre_cientifico: 'Solanum quitoense', fuente: 'Agrosavia' },
+      ]);
+      expect(out.fuente_url).toContain('Solanum');
+    });
+
+    test('fuente institucional sin sección/buscador (IDEAM) → TEXTO PLANO, sin URL', () => {
+      const out = extractGroundingBadges([
+        { kind: 'species', nombre_comun: 'Maíz', fuente: 'IDEAM' },
+      ]);
+      expect(out.fuente).toBe('IDEAM');
+      expect(out.fuente_texto).toBe(true);
+      expect(out.fuente_url).toBeUndefined();
+    });
+
+    test('fuente con buscador pero entidad SIN concepto → texto plano (no buscador vacío)', () => {
+      const out = extractGroundingBadges([{ kind: 'biopreparado', fuente: 'Cenicafé' }]);
+      expect(out.fuente).toBe('Cenicafé');
+      expect(out.fuente_texto).toBe(true);
+      expect(out.fuente_url).toBeUndefined();
+    });
+
+    test('un LINK de un turno posterior mejora el texto-plano provisional', () => {
+      const out = extractGroundingBadges([
+        { kind: 'species', fuente: 'IDEAM' }, // texto plano
+        { kind: 'biopreparado', nombre_comun: 'Caldo bordelés', fuente: 'Agrosavia' }, // link
+      ]);
+      expect(out.fuente).toBe('Agrosavia');
+      expect(out.fuente_url).toContain('agrosavia.co/search');
+      expect(out.fuente_texto).toBeUndefined();
+    });
+
+    test('el deep-link http(s) de la entidad gana sobre la búsqueda', () => {
       const out = extractGroundingBadges([
         {
           kind: 'biopreparado',
+          nombre_comun: 'Caldo bordelés',
           fuente: 'Agrosavia',
           fuente_url: 'https://repository.agrosavia.co/handle/123/ficha-real',
         },
@@ -406,46 +444,51 @@ describe('extractGroundingBadges (#18 fuente_url + #20 confianza)', () => {
       expect(out.fuente_url).toBe('https://repository.agrosavia.co/handle/123/ficha-real');
     });
 
-    test('fuente NO institucional sin URL → NO inventa link', () => {
+    test('fuente NO institucional sin URL → NO inventa link ni texto', () => {
       const out = extractGroundingBadges([
         { kind: 'species', nombre_comun: 'Lulo', fuente: 'apuntes de un taller' },
       ]);
       expect(out.fuente_url).toBeUndefined();
+      expect(out.fuente_texto).toBeUndefined();
+      expect(out.fuente).toBeUndefined();
     });
 
-    test('fuente_url inseguro pero fuente institucional → cae al link institucional', () => {
+    test('fuente_url inseguro pero fuente institucional con buscador → cae a la búsqueda', () => {
       const out = extractGroundingBadges([
-        { kind: 'biopreparado', fuente: 'IDEAM', fuente_url: 'javascript:alert(1)' },
+        { kind: 'biopreparado', nombre_comun: 'Caldo bordelés', fuente: 'Agrosavia', fuente_url: 'javascript:alert(1)' },
       ]);
-      expect(out.fuente_url).toContain('ideam.gov.co');
-      expect(out.fuente).toBe('IDEAM');
+      expect(out.fuente_url).toContain('agrosavia.co/search');
     });
   });
 });
 
 // ────────────────────────────────────────────────────────────────────────
-// #356 — fuente de un TOOL (no entidad). El clima viene de get_clima_ideam:
-// la institución emisora (IDEAM) no es una entidad del grounding sino el
-// tool mismo. deriveEvidenceSourceLink mapea el tool / sus sources a un link.
+// #356 + refinamiento 2026-06-03 — fuente de un TOOL (no entidad). El clima
+// viene de get_clima_ideam: IDEAM no expone un deep-link al pronóstico, así
+// que la cita se presenta como TEXTO PLANO. Las fuentes con buscador linkean a
+// la búsqueda del concepto del tool. NUNCA se linkea a una homepage.
 // ────────────────────────────────────────────────────────────────────────
-describe('deriveEvidenceSourceLink (#356 — fuente del tool → link)', () => {
-  test('get_clima_ideam → link a IDEAM', () => {
+describe('deriveEvidenceSourceLink (#356-refino — recurso citado o texto plano)', () => {
+  test('get_clima_ideam → TEXTO PLANO "Fuente: IDEAM" (no link a la home)', () => {
     const out = deriveEvidenceSourceLink({
       tool: 'get_clima_ideam',
       args: { municipio: 'Choachí' },
       result: { available: true, monthly_avg: 120 },
     });
     expect(out.fuente).toBe('IDEAM');
-    expect(out.fuente_url).toContain('ideam.gov.co');
+    expect(out.fuente_texto).toBe(true);
+    expect(out.fuente_url).toBeUndefined();
   });
 
-  test('result con sources[] institucionales → primer link reconocido', () => {
+  test('result con sources[] institucional con buscador + concepto en args → búsqueda', () => {
     const out = deriveEvidenceSourceLink({
       tool: 'get_species',
+      args: { name: 'lulo' },
       result: { found: true, sources: ['Agrosavia', 'Wikipedia'] },
     });
     expect(out.fuente).toBe('Agrosavia');
-    expect(out.fuente_url).toContain('agrosavia.co');
+    expect(out.fuente_url).toContain('agrosavia.co/search');
+    expect(out.fuente_url).toContain('lulo');
   });
 
   test('result.fuente_url deep-link válido gana', () => {
@@ -462,11 +505,21 @@ describe('deriveEvidenceSourceLink (#356 — fuente del tool → link)', () => {
     expect(deriveEvidenceSourceLink({ tool: 'get_clima_ideam', result: { found: false } })).toEqual({});
   });
 
-  test('array de evidences (tool_chain) → primer link encontrado', () => {
+  test('array de evidences (tool_chain): un LINK gana sobre un texto-plano', () => {
+    const out = deriveEvidenceSourceLink([
+      { tool: 'get_clima_ideam', result: { available: true } }, // texto plano
+      { tool: 'get_species', args: { name: 'lulo' }, result: { found: true, sources: ['Agrosavia'] } }, // link
+    ]);
+    expect(out.fuente_url).toContain('agrosavia.co');
+  });
+
+  test('array de evidences: si ninguna linkea pero hay institución de texto → texto plano', () => {
     const out = deriveEvidenceSourceLink([
       { tool: 'get_companions', result: { companions: [{ id: 'a' }] } },
       { tool: 'get_clima_ideam', result: { available: true } },
     ]);
-    expect(out.fuente_url).toContain('ideam.gov.co');
+    expect(out.fuente).toBe('IDEAM');
+    expect(out.fuente_texto).toBe(true);
+    expect(out.fuente_url).toBeUndefined();
   });
 });

--- a/src/services/__tests__/institutionalSources.test.js
+++ b/src/services/__tests__/institutionalSources.test.js
@@ -1,72 +1,102 @@
 /**
- * institutionalSources.test.js — #356: la cita "Fuente: IDEAM/SIPSA/Agrosavia"
- * debe poder convertirse en un link clickeable a la página institucional real.
+ * institutionalSources.test.js — #356 + refinamiento 2026-06-03.
  *
- * Reglas:
- *   - Mapea nombres de fuentes institucionales colombianas a URLs REALES que
- *     resuelven (NO inventadas).
- *   - Prefiere un deep-link si el caller lo pasa (p.ej. ficha de especie
- *     Agrosavia con species_id); cae a la página/boletín de la institución.
- *   - Tolerante a tildes, mayúsculas y fuentes compuestas ("Agrosavia / FAO",
- *     "NOAA CPC · IDEAM").
- *   - Devuelve null si la fuente no es institucional reconocida (no inventa).
+ * Regla del operador: un link de fuente debe llevar al RECURSO citado, NUNCA a
+ * la homepage/landing genérica de la institución (trazabilidad teatral).
+ *
+ * Contrato verificado acá:
+ *   - 'section' (SIPSA→boletín precios, NOAA→tabla ONI): la URL ES la sección
+ *     del dato → se linkea directo, sin concepto.
+ *   - 'search' (Agrosavia/ICA/Cenicafé/FAO/INVIMA): con concepto → URL de
+ *     búsqueda del concepto; SIN concepto → NO se linkea (homepage disfrazada).
+ *   - 'text' (IDEAM/Open-Meteo/DANE): nunca link → `fuente_texto:true` (texto
+ *     plano "Fuente: X"), jamás un <a> a la portada.
+ *   - deep-link curado (opts.deepLink) http(s): gana siempre.
+ *   - fuente no institucional → {} (no inventa nada).
  */
 
 import { describe, test, expect } from 'vitest';
 import {
   institutionalSourceUrl,
+  classifySource,
   resolveSourceLink,
 } from '../institutionalSources.js';
 
-describe('institutionalSourceUrl — mapeo fuente → URL institucional real', () => {
-  test('IDEAM → página de pronóstico y alertas (https)', () => {
-    const url = institutionalSourceUrl('IDEAM');
-    expect(url).toMatch(/^https:\/\//);
-    expect(url).toContain('ideam.gov.co');
-  });
-
-  test('SIPSA → boletín DANE (SIPSA es del DANE)', () => {
+describe('institutionalSourceUrl — al RECURSO citado, nunca a la homepage', () => {
+  // ── 'section': la URL es la sección del dato citado ──
+  test('SIPSA → sección de precios del DANE (sección, no home)', () => {
     const url = institutionalSourceUrl('SIPSA');
     expect(url).toMatch(/^https:\/\//);
-    expect(url).toContain('dane.gov.co');
+    expect(url).toContain('sistema-de-informacion-de-precios-sipsa');
   });
 
-  test('Agrosavia → repositorio institucional', () => {
-    const url = institutionalSourceUrl('Agrosavia');
+  test('NOAA → tabla ONI oficial (sección ENSO, no la home del CPC)', () => {
+    const url = institutionalSourceUrl('NOAA');
     expect(url).toMatch(/^https:\/\//);
-    expect(url).toContain('agrosavia.co');
+    expect(url).toContain('ONI');
   });
 
-  test('ICA → página institucional', () => {
-    const url = institutionalSourceUrl('ICA');
-    expect(url).toMatch(/^https:\/\//);
-    expect(url).toContain('ica.gov.co');
+  // ── 'search': con concepto construye búsqueda; sin concepto NO linkea ──
+  test('Agrosavia + concepto → URL de búsqueda del concepto (DSpace ?query=)', () => {
+    const url = institutionalSourceUrl('Agrosavia', { concept: 'Solanum quitoense' });
+    expect(url).toContain('repository.agrosavia.co/search');
+    expect(url).toContain('query=Solanum%20quitoense');
   });
 
-  test('Cenicafé → página institucional (acepta sin tilde)', () => {
-    expect(institutionalSourceUrl('Cenicafé')).toContain('cenicafe.org');
-    expect(institutionalSourceUrl('Cenicafe')).toContain('cenicafe.org');
+  test('Cenicafé + concepto → búsqueda (?s=); el caso "home a secas" del operador queda resuelto', () => {
+    const url = institutionalSourceUrl('Cenicafé', { concept: 'broca' });
+    expect(url).toContain('cenicafe.org/?s=broca');
   });
 
-  test('tolerante a mayúsculas/tildes y a fuentes compuestas', () => {
-    expect(institutionalSourceUrl('ideam')).toContain('ideam.gov.co');
-    expect(institutionalSourceUrl('NOAA CPC · IDEAM')).toContain('ideam.gov.co');
-    expect(institutionalSourceUrl('Agrosavia / FAO')).toContain('agrosavia.co');
+  test('ICA + concepto → búsqueda', () => {
+    expect(institutionalSourceUrl('ICA', { concept: 'aguacate' })).toContain('ica.gov.co/buscador?q=aguacate');
   });
 
+  test('FAO + concepto → búsqueda', () => {
+    expect(institutionalSourceUrl('FAO', { concept: 'caldo bordeles' })).toContain('fao.org/search');
+  });
+
+  test('INVIMA + concepto → búsqueda', () => {
+    expect(institutionalSourceUrl('INVIMA', { concept: 'fermento' })).toContain('invima.gov.co/buscar?q=fermento');
+  });
+
+  test('fuente "search" SIN concepto → null (no linkeamos a una home/buscador vacío)', () => {
+    expect(institutionalSourceUrl('Agrosavia')).toBeNull();
+    expect(institutionalSourceUrl('Cenicafé')).toBeNull();
+    expect(institutionalSourceUrl('ICA', { concept: 'x' })).toBeNull(); // 1 char no es término útil
+  });
+
+  // ── 'text': nunca link a homepage ──
+  test('IDEAM → null (su portal no permite deep-link al pronóstico citado)', () => {
+    expect(institutionalSourceUrl('IDEAM', { concept: 'lluvia' })).toBeNull();
+  });
+
+  test('Open-Meteo → null (web de docs de API, no acerca al pronóstico)', () => {
+    expect(institutionalSourceUrl('Open-Meteo')).toBeNull();
+  });
+
+  test('DANE genérico (sin SIPSA) → null (no hay sección/búsqueda por dato)', () => {
+    expect(institutionalSourceUrl('DANE')).toBeNull();
+  });
+
+  // ── deep-link curado gana ──
   test('prefiere el deep-link válido si el caller lo pasa', () => {
     const deep = 'https://repository.agrosavia.co/handle/123/ficha-lulo';
     expect(institutionalSourceUrl('Agrosavia', { deepLink: deep })).toBe(deep);
   });
 
-  test('ignora un deep-link inseguro y cae a la institución', () => {
+  test('ignora un deep-link inseguro y NO cae a homepage (sin concepto → null)', () => {
     const url = institutionalSourceUrl('Agrosavia', { deepLink: 'javascript:alert(1)' });
-    expect(url).toContain('agrosavia.co');
-    expect(url).not.toContain('javascript');
+    expect(url).toBeNull();
+  });
+
+  test('tolerante a mayúsculas/tildes y a fuentes compuestas (en section/search)', () => {
+    expect(institutionalSourceUrl('NOAA CPC')).toContain('ONI'); // sección ONI
+    expect(institutionalSourceUrl('Agrosavia / FAO', { concept: 'lulo' })).toContain('agrosavia.co');
   });
 
   test('fuente NO institucional / desconocida → null (no inventa URL)', () => {
-    expect(institutionalSourceUrl('Wikipedia')).toBeNull();
+    expect(institutionalSourceUrl('Wikipedia', { concept: 'lulo' })).toBeNull();
     expect(institutionalSourceUrl('blog de un vecino')).toBeNull();
     expect(institutionalSourceUrl('')).toBeNull();
     expect(institutionalSourceUrl(null)).toBeNull();
@@ -74,35 +104,110 @@ describe('institutionalSourceUrl — mapeo fuente → URL institucional real', (
   });
 });
 
-describe('resolveSourceLink — de una cita de fuente a {fuente, fuente_url}', () => {
-  test('string institucional → label + URL', () => {
-    const out = resolveSourceLink('IDEAM');
-    expect(out.fuente).toBe('IDEAM');
-    expect(out.fuente_url).toContain('ideam.gov.co');
+describe('classifySource — link vs texto plano vs nada', () => {
+  test('section → {fuente, fuente_url} (link)', () => {
+    const r = classifySource('SIPSA');
+    expect(r.fuente).toBe('SIPSA');
+    expect(r.fuente_url).toContain('sipsa');
+    expect(r.fuente_texto).toBeUndefined();
   });
 
-  test('array de fuentes → toma la PRIMERA institucional reconocida', () => {
-    const out = resolveSourceLink(['blog random', 'SIPSA', 'IDEAM']);
+  test('search + concepto → {fuente, fuente_url} (link de búsqueda)', () => {
+    const r = classifySource('Agrosavia', { concept: 'lulo' });
+    expect(r.fuente_url).toContain('agrosavia.co/search');
+  });
+
+  test('search SIN concepto → {fuente, fuente_texto:true} (texto plano, NO homepage)', () => {
+    const r = classifySource('Cenicafé');
+    expect(r.fuente).toBe('Cenicafé');
+    expect(r.fuente_texto).toBe(true);
+    expect(r.fuente_url).toBeUndefined();
+  });
+
+  test('text (IDEAM) → {fuente, fuente_texto:true}, jamás fuente_url', () => {
+    const r = classifySource('IDEAM', { concept: 'lluvia' });
+    expect(r.fuente).toBe('IDEAM');
+    expect(r.fuente_texto).toBe(true);
+    expect(r.fuente_url).toBeUndefined();
+  });
+
+  test('deep-link curado → link aunque la fuente no sea institucional', () => {
+    const r = classifySource('apuntes', { deepLink: 'https://x.org/doc.pdf' });
+    expect(r.fuente_url).toBe('https://x.org/doc.pdf');
+  });
+
+  test('fuente no institucional, sin deep-link → {} (no inventa nada)', () => {
+    expect(classifySource('Wikipedia')).toEqual({});
+    expect(classifySource('')).toEqual({});
+    expect(classifySource(null)).toEqual({});
+  });
+});
+
+describe('resolveSourceLink — de una cita a {fuente, fuente_url|fuente_texto}', () => {
+  test('section institucional → label + URL de sección', () => {
+    const out = resolveSourceLink('SIPSA');
     expect(out.fuente).toBe('SIPSA');
-    expect(out.fuente_url).toContain('dane.gov.co');
+    expect(out.fuente_url).toContain('sipsa');
+  });
+
+  test('search + concepto → label + URL de búsqueda', () => {
+    const out = resolveSourceLink('Agrosavia', { concept: 'lulo' });
+    expect(out.fuente).toBe('Agrosavia');
+    expect(out.fuente_url).toContain('agrosavia.co/search');
+  });
+
+  test('array prefiere la que dé LINK sobre la que solo dé texto plano', () => {
+    // IDEAM (texto) viene antes que SIPSA (sección con link) → debe ganar SIPSA.
+    const out = resolveSourceLink(['IDEAM', 'SIPSA']);
+    expect(out.fuente).toBe('SIPSA');
+    expect(out.fuente_url).toContain('sipsa');
+  });
+
+  test('array sin ninguna con link pero con institución de texto → texto plano', () => {
+    const out = resolveSourceLink(['blog random', 'IDEAM']);
+    expect(out.fuente).toBe('IDEAM');
+    expect(out.fuente_texto).toBe(true);
+    expect(out.fuente_url).toBeUndefined();
   });
 
   test('fuente compuesta conserva el label original pero linkea a la institución', () => {
-    const out = resolveSourceLink('Agrosavia / FAO');
+    const out = resolveSourceLink('Agrosavia / FAO', { concept: 'lulo' });
     expect(out.fuente).toBe('Agrosavia / FAO');
     expect(out.fuente_url).toContain('agrosavia.co');
   });
 
-  test('deep-link de ficha (species) gana sobre la página institucional', () => {
+  test('deep-link de ficha (species) gana sobre la búsqueda', () => {
     const deep = 'https://repository.agrosavia.co/handle/123/ficha-lulo';
-    const out = resolveSourceLink('Agrosavia', { deepLink: deep });
+    const out = resolveSourceLink('Agrosavia', { deepLink: deep, concept: 'lulo' });
     expect(out.fuente_url).toBe(deep);
   });
 
-  test('ninguna fuente institucional → {} (sin link, graceful)', () => {
+  test('ninguna fuente institucional → {} (sin badge, graceful)', () => {
     expect(resolveSourceLink('Wikipedia')).toEqual({});
     expect(resolveSourceLink(['blog', 'foro'])).toEqual({});
     expect(resolveSourceLink(null)).toEqual({});
     expect(resolveSourceLink([])).toEqual({});
+  });
+
+  // ── La regla central del operador, como aserción explícita ──
+  test('NINGÚN destino emitido es una homepage/landing genérica', () => {
+    const isHomepage = (u) => /^https?:\/\/[^/]+\/?$/.test(u); // host + opcional "/"
+    const cases = [
+      resolveSourceLink('SIPSA'),
+      resolveSourceLink('NOAA'),
+      resolveSourceLink('Agrosavia', { concept: 'lulo' }),
+      resolveSourceLink('Cenicafé', { concept: 'broca' }),
+      resolveSourceLink('ICA', { concept: 'aguacate' }),
+      resolveSourceLink('FAO', { concept: 'biopreparado' }),
+      resolveSourceLink('INVIMA', { concept: 'fermento' }),
+    ];
+    for (const c of cases) {
+      expect(c.fuente_url).toBeTruthy();
+      expect(isHomepage(c.fuente_url)).toBe(false);
+    }
+    // Y las institucionales sin recurso no producen URL alguna.
+    expect(resolveSourceLink('IDEAM').fuente_url).toBeUndefined();
+    expect(resolveSourceLink('Open-Meteo').fuente_url).toBeUndefined();
+    expect(resolveSourceLink('Cenicafé').fuente_url).toBeUndefined(); // sin concepto
   });
 });

--- a/src/services/conversationMemory.js
+++ b/src/services/conversationMemory.js
@@ -12,7 +12,7 @@
  */
 
 import { openDB, STORES } from '../db/dbCore';
-import { institutionalSourceUrl, resolveSourceLink } from './institutionalSources';
+import { classifySource, resolveSourceLink } from './institutionalSources';
 
 const MAX_TURNS = 100;
 const MAX_DAYS = 30;
@@ -386,6 +386,20 @@ function _normConfianza(v) {
 const _CONFIANZA_RANK = { alta: 3, media: 2, baja: 1 };
 
 /**
+ * Concepto citado por una entidad del grounding, para construir una URL de
+ * búsqueda en una fuente con buscador (Agrosavia/ICA/Cenicafé/FAO/INVIMA).
+ * Prefiere el nombre científico (término más preciso en un repositorio); cae al
+ * nombre común y luego a lo que el usuario mencionó. '' si no hay concepto.
+ */
+function _entityConcept(e) {
+  if (!e || typeof e !== 'object') return '';
+  const cand = [e.nombre_cientifico, e.nombre_comun, e.mentioned].find(
+    (s) => typeof s === 'string' && s.trim().length >= 2,
+  );
+  return cand ? cand.trim() : '';
+}
+
+/**
  * #18 + #20 — extrae de las entidades resueltas (grounding AGE del turno) las
  * señales que la UX muestra como badges, SIN tocar la respuesta del modelo:
  *
@@ -405,7 +419,7 @@ const _CONFIANZA_RANK = { alta: 3, media: 2, baja: 1 };
  * Puro y sin efectos. No muta las entidades.
  *
  * @param {Array<object>|null|undefined} resolvedEntities
- * @returns {{fuente_url?: string, fuente?: string, confianza?: 'alta'|'media'|'baja'}}
+ * @returns {{fuente_url?: string, fuente?: string, fuente_texto?: boolean, confianza?: 'alta'|'media'|'baja'}}
  */
 export function extractGroundingBadges(resolvedEntities) {
   if (!Array.isArray(resolvedEntities) || resolvedEntities.length === 0) return {};
@@ -423,25 +437,31 @@ export function extractGroundingBadges(resolvedEntities) {
   for (const e of ordered) {
     if (!e || typeof e !== 'object') continue;
 
-    // Fuente verificable (#18 + #356): primera fuente linkeable del turno.
-    // Preferimos el deep-link http(s) curado de la entidad (ej. ficha Agrosavia
-    // con species_id). Si no hay deep-link válido pero la entidad cita una
-    // fuente INSTITUCIONAL reconocida (Agrosavia/IDEAM/SIPSA/ICA/Cenicafé…),
-    // linkeamos a la PÁGINA institucional real (#356) — la cita deja de ser
-    // texto muerto. `institutionalSourceUrl` devuelve el deep-link si es válido,
-    // si no la institución, y null si la fuente no es institucional (no inventa).
+    // Fuente verificable (#18 + #356 + refinamiento 2026-06-03): primera fuente
+    // del turno resuelta al MÁXIMO de trazabilidad honesta.
+    //   - deep-link http(s) curado de la entidad (ej. ficha Agrosavia con
+    //     species_id) → link directo, gana sobre todo.
+    //   - institución con buscador (Agrosavia/ICA/Cenicafé/FAO/INVIMA): se
+    //     construye una URL de BÚSQUEDA del concepto citado por la entidad
+    //     (nombre común/científico). NUNCA se linkea a la homepage genérica.
+    //   - institución sin sección/buscador estable (IDEAM/Open-Meteo/DANE) o
+    //     buscador sin concepto → `fuente_texto:true` (la cita va como texto
+    //     plano "Fuente: X", no como link a portada).
+    // Una vez fijada una fuente con LINK no la pisamos; pero un link de un turno
+    // posterior puede mejorar un texto-plano provisional.
     if (!out.fuente_url) {
       const label = typeof e.fuente === 'string' ? e.fuente.trim() : '';
       const deepLink = typeof e.fuente_url === 'string' ? e.fuente_url.trim() : '';
-      const url = institutionalSourceUrl(label, { deepLink });
-      if (url && /^https?:\/\//i.test(url)) {
-        out.fuente_url = url;
-        if (label) out.fuente = label;
-      } else if (/^https?:\/\//i.test(deepLink)) {
-        // Deep-link válido aunque la fuente no sea institucional reconocida
-        // (preserva el comportamiento original: cualquier fuente_url http(s)).
-        out.fuente_url = deepLink;
-        if (label) out.fuente = label;
+      const concept = _entityConcept(e);
+      const r = classifySource(label, { deepLink, concept });
+      if (r.fuente_url) {
+        out.fuente_url = r.fuente_url;
+        if (r.fuente) out.fuente = r.fuente;
+        delete out.fuente_texto;
+      } else if (r.fuente_texto && !out.fuente_texto && !out.fuente) {
+        // Institución reconocida sin recurso puntual: texto plano provisional.
+        out.fuente_texto = true;
+        if (r.fuente) out.fuente = r.fuente;
       }
     }
 
@@ -459,7 +479,7 @@ export function extractGroundingBadges(resolvedEntities) {
 /**
  * Tools cuya institución emisora es fija y conocida (la fuente NO viaja como
  * entidad del grounding sino que es definitoria del tool). Mapea tool → nombre
- * de institución, que `institutionalSourceUrl` resuelve a la página real.
+ * de institución, que `classifySource` resuelve a recurso/sección/texto plano.
  */
 const _TOOL_INSTITUTION = {
   get_clima_ideam: 'IDEAM',
@@ -467,32 +487,37 @@ const _TOOL_INSTITUTION = {
 };
 
 /**
- * #356 — deriva un link de fuente a partir del toolEvidence (no de una entidad
- * del grounding). Pensado para respuestas cuya fuente es el TOOL mismo: el clima
- * viene de `get_clima_ideam` → la cita "Fuente: IDEAM" debe linkear a IDEAM.
+ * #356 (+ refinamiento 2026-06-03) — deriva la fuente a partir del toolEvidence
+ * (no de una entidad del grounding). Pensado para respuestas cuya fuente es el
+ * TOOL mismo: el clima viene de `get_clima_ideam` → la cita "Fuente: IDEAM".
  *
- * Orden de resolución (primero que aplique):
- *   1. `result.fuente_url` deep-link http(s) válido → se usa tal cual.
- *   2. `result.sources` (array) o `result.fuente`/`result.source` (string)
- *      mapeado a una institución reconocida.
- *   3. La institución FIJA del tool (`get_clima_ideam` → IDEAM).
+ * Devuelve la trazabilidad HONESTA máxima disponible:
+ *   1. `result.fuente_url` deep-link http(s) válido → link directo.
+ *   2. `result.sources`/`result.fuente`/`result.source` mapeado a institución,
+ *      construyendo búsqueda del concepto del tool (args.species/name/query) si
+ *      la institución tiene buscador.
+ *   3. La institución FIJA del tool (`get_clima_ideam` → IDEAM). IDEAM no tiene
+ *      sección/buscador estable → `fuente_texto:true` (texto plano, NO homepage).
  * Solo cuenta evidencia con datos reales (no `found:false`/`available:false`).
  *
- * Acepta un evidence simple o un array (tool_chain): en array, devuelve el PRIMER
- * link que resuelva. 100% graceful: sin fuente institucional → {} (sin badge).
+ * Acepta un evidence simple o un array (tool_chain): en array, prefiere el PRIMER
+ * link; si ninguno linkea pero alguno reconoce institución, devuelve texto plano.
+ * 100% graceful: sin fuente institucional → {} (sin badge).
  *
  * @param {object|object[]|null|undefined} toolEvidence
- * @returns {{ fuente?: string, fuente_url?: string }}
+ * @returns {{ fuente?: string, fuente_url?: string, fuente_texto?: boolean }}
  */
 export function deriveEvidenceSourceLink(toolEvidence) {
   if (!toolEvidence) return {};
 
   if (Array.isArray(toolEvidence)) {
+    let plainFallback = null;
     for (const ev of toolEvidence) {
       const link = deriveEvidenceSourceLink(ev);
       if (link.fuente_url) return link;
+      if (link.fuente_texto && !plainFallback) plainFallback = link;
     }
-    return {};
+    return plainFallback || {};
   }
 
   const tool = typeof toolEvidence.tool === 'string' ? toolEvidence.tool : '';
@@ -503,21 +528,46 @@ export function deriveEvidenceSourceLink(toolEvidence) {
   if (result.found === false || result.available === false) return {};
   if (typeof result.matches_count === 'number' && result.matches_count === 0) return {};
 
+  // Concepto citado por el tool (para búsquedas en fuentes con buscador).
+  const concept = _toolConcept(toolEvidence);
+
   // 1+2: deep-link curado o sources institucionales del payload.
   const deepLink = typeof result.fuente_url === 'string' ? result.fuente_url.trim() : '';
   const citedSources = Array.isArray(result.sources)
     ? result.sources
     : [result.fuente, result.source].filter((s) => typeof s === 'string' && s.trim());
-  const fromPayload = resolveSourceLink(citedSources, { deepLink });
-  if (fromPayload.fuente_url) return fromPayload;
+  const fromPayload = resolveSourceLink(citedSources, { deepLink, concept });
+  if (fromPayload.fuente_url || fromPayload.fuente_texto) return fromPayload;
 
-  // 3: institución fija del tool (clima → IDEAM).
+  // 3: institución fija del tool (clima → IDEAM, hoy texto plano).
   const inst = _TOOL_INSTITUTION[tool];
   if (inst) {
-    const url = institutionalSourceUrl(inst);
-    if (url) return { fuente: inst, fuente_url: url };
+    const r = classifySource(inst, { concept });
+    if (r.fuente_url || r.fuente_texto) return r;
   }
   return {};
+}
+
+/**
+ * Concepto que cita un toolEvidence, para una URL de búsqueda en fuentes con
+ * buscador. Lo toma de los args (la especie/cultivo/término consultado) o del
+ * nombre devuelto. '' si no hay un término usable.
+ */
+function _toolConcept(ev) {
+  if (!ev || typeof ev !== 'object') return '';
+  const args = ev.args && typeof ev.args === 'object' ? ev.args : {};
+  const result = ev.result && typeof ev.result === 'object' ? ev.result : {};
+  const cand = [
+    args.species,
+    args.name,
+    args.nombre,
+    args.query,
+    args.q,
+    result.nombre_cientifico,
+    result.nombre_comun,
+    result.species && result.species.name,
+  ].find((s) => typeof s === 'string' && s.trim().length >= 2);
+  return cand ? cand.trim() : '';
 }
 
 /**

--- a/src/services/institutionalSources.js
+++ b/src/services/institutionalSources.js
@@ -1,57 +1,104 @@
 /**
- * institutionalSources.js — #356: convierte la cita de una fuente institucional
- * ("Fuente: IDEAM / SIPSA / Agrosavia …") en un link clickeable a la página
- * institucional REAL.
+ * institutionalSources.js — #356 (+ refinamiento 2026-06-03): convierte la cita
+ * de una fuente institucional ("Fuente: IDEAM / SIPSA / Agrosavia …") en un link
+ * clickeable AL RECURSO CITADO — nunca a la homepage genérica de la institución.
  *
- * Filosofía:
- *   - SOLO URLs que resuelven. Cada destino se verificó empíricamente (HTTP 200)
- *     contra la web pública de la institución (curl, 2026-06-03). NO se inventan
- *     deep-links: si una institución no tiene una página pública estable para el
- *     dato exacto, se linkea a su landing/sección oficial.
- *   - El DATO no cambia: esto es presentación (la cita ya existía en texto). Si
- *     la fuente NO es una institución reconocida, se devuelve null y el ChatBubble
- *     simplemente no renderiza el link (degrada con gracia).
- *   - Deep-link gana: si el grounding trae una URL precisa (p.ej. la ficha de una
- *     especie en el repositorio Agrosavia, vía el consolidador de URLs), esa URL
- *     manda sobre la página institucional genérica.
+ * Filosofía (regla del operador 2026-06-03):
+ *   - Un link de fuente debe llevar al RECURSO citado, no a la landing genérica.
+ *     Linkear a la homepage es trazabilidad TEATRAL: el usuario hace clic
+ *     esperando el documento y aterriza en una portada que no prueba nada.
+ *     Honestidad > trazabilidad teatral.
+ *   - Tres tipos de destino por institución (campo `kind` del mapa):
+ *       1. 'deeplink' (vía opts.deepLink): URL precisa curada (ficha Agrosavia
+ *          con species_id, dataset SIPSA puntual). Gana SIEMPRE.
+ *       2. 'section': la URL mapeada YA es la sección específica del tipo de dato
+ *          citado (boletín SIPSA de precios, tabla ONI de NOAA-CPC para fase
+ *          ENSO). Acerca al usuario al dato → se linkea directo.
+ *       3. 'search': la institución no tiene una sección estable por dato, PERO
+ *          sí un buscador estable. Si tenemos el CONCEPTO citado (opts.concept),
+ *          construimos una URL de BÚSQUEDA de ese concepto. Sin concepto NO
+ *          linkeamos (un buscador vacío == homepage disfrazada).
+ *   - 'text' (o 'search' sin concepto): no hay forma de acercar al usuario al
+ *     dato → NO se emite <a>. La cita se presenta como TEXTO PLANO ("Fuente: X").
+ *   - SOLO URLs que resuelven. Cada destino se verificó empíricamente (HTTP 200,
+ *     curl 2026-06-03). NO se inventan deep-links.
  *
  * Puro, sin red, sin estado. Seguro para el system prompt y la UX.
  */
 
 /**
- * Catálogo de fuentes institucionales → URL pública verificada (HTTP 200).
- * Las claves se matchean por substring normalizado (sin tildes, minúsculas), así
- * una cita compuesta ("NOAA CPC · IDEAM", "Agrosavia / FAO") resuelve a la
- * primera institución reconocida. El orden importa: las entradas más específicas
- * (SIPSA antes que DANE) van primero.
+ * Catálogo de fuentes institucionales. Cada entrada declara su `kind`:
  *
- * @type {Array<{ keys: string[], url: string }>}
+ *   - kind:'section' + `url`: la URL es la sección del dato citado. Link directo.
+ *   - kind:'search'  + `searchUrl(concept)`: builder de URL de búsqueda estable
+ *     (verificada HTTP 200). Solo se usa si hay concepto; si no, la cita queda
+ *     en texto plano.
+ *   - kind:'text': la institución NO tiene sección por dato ni buscador estable
+ *     parametrizable → su cita SIEMPRE se presenta como texto plano (sin link).
+ *
+ * Las claves se matchean por substring normalizado con frontera de palabra. El
+ * orden importa: entradas más específicas (SIPSA antes que DANE) van primero.
+ *
+ * @type {Array<{ keys: string[], kind: 'section'|'search'|'text', url?: string, searchUrl?: (concept: string) => string }>}
  */
 const INSTITUTIONS = [
-  // SIPSA es el sistema de precios del DANE → su boletín vive en dane.gov.co.
+  // SIPSA — sistema de precios del DANE. La URL ES la sección de precios SIPSA
+  // (no la home del DANE): acerca al dato de precios citado. → section.
   {
     keys: ['sipsa'],
+    kind: 'section',
     url: 'https://www.dane.gov.co/index.php/estadisticas-por-tema/precios-y-costos/sistema-de-informacion-de-precios-sipsa',
   },
-  // IDEAM — clima/pronóstico/alertas. El portal de pronóstico es JS-rendered;
-  // la landing institucional es el destino estable que resuelve.
-  { keys: ['ideam'], url: 'https://www.ideam.gov.co' },
-  // Agrosavia — repositorio institucional (fichas técnicas de especies/biopreparados).
-  { keys: ['agrosavia', 'corpoica'], url: 'https://repository.agrosavia.co/' },
-  // ICA — Instituto Colombiano Agropecuario (sanidad vegetal/animal).
-  { keys: ['ica'], url: 'https://www.ica.gov.co/' },
-  // Cenicafé — Centro Nacional de Investigaciones de Café.
-  { keys: ['cenicafe'], url: 'https://www.cenicafe.org/' },
-  // DANE genérico (si la cita es "DANE" sin SIPSA).
-  { keys: ['dane'], url: 'https://www.dane.gov.co/' },
-  // FAO — citada en biopreparados/manejo agroecológico.
-  { keys: ['fao'], url: 'https://www.fao.org/home/en' },
-  // NOAA — fase ENSO (ONI). CPC.
-  { keys: ['noaa'], url: 'https://www.cpc.ncep.noaa.gov/' },
-  // Open-Meteo — pronóstico abierto usado por el snapshot de clima.
-  { keys: ['open-meteo', 'openmeteo', 'open meteo'], url: 'https://open-meteo.com/' },
-  // INVIMA — autoridad sanitaria (fermentos/alimentos).
-  { keys: ['invima'], url: 'https://www.invima.gov.co/' },
+  // IDEAM — clima/pronóstico/alertas. El portal de pronóstico es JS-rendered y
+  // sus rutas profundas devuelven 404 (verificado); no hay buscador estable
+  // parametrizable. Linkear a la home NO acerca al pronóstico citado → texto.
+  { keys: ['ideam'], kind: 'text' },
+  // Agrosavia — repositorio institucional DSpace con buscador estable por
+  // concepto (?query=). Sin concepto, su home/landing del repo no prueba la
+  // ficha citada → search.
+  {
+    keys: ['agrosavia', 'corpoica'],
+    kind: 'search',
+    searchUrl: (c) => `https://repository.agrosavia.co/search?query=${encodeURIComponent(c)}`,
+  },
+  // ICA — sanidad vegetal/animal. Buscador estable (?q=). → search.
+  {
+    keys: ['ica'],
+    kind: 'search',
+    searchUrl: (c) => `https://www.ica.gov.co/buscador?q=${encodeURIComponent(c)}`,
+  },
+  // Cenicafé — Centro Nacional de Investigaciones de Café. Buscador WordPress
+  // estable (?s=). La home a secas fue justo el caso que reportó el operador. → search.
+  {
+    keys: ['cenicafe'],
+    kind: 'search',
+    searchUrl: (c) => `https://www.cenicafe.org/?s=${encodeURIComponent(c)}`,
+  },
+  // DANE genérico (cita "DANE" sin SIPSA). Sin una sección/búsqueda estable por
+  // dato que acerque a la cifra citada → texto plano.
+  { keys: ['dane'], kind: 'text' },
+  // FAO — citada en biopreparados/manejo agroecológico. Buscador estable (?q=). → search.
+  {
+    keys: ['fao'],
+    kind: 'search',
+    searchUrl: (c) => `https://www.fao.org/search/es/?q=${encodeURIComponent(c)}`,
+  },
+  // NOAA-CPC — fase ENSO (ONI). La URL ES la tabla ONI oficial (el dato citado
+  // cuando se menciona la fase del Niño/Niña), no la home del CPC → section.
+  {
+    keys: ['noaa'],
+    kind: 'section',
+    url: 'https://www.cpc.ncep.noaa.gov/products/analysis_monitoring/ensostuff/ONI_v5.php',
+  },
+  // Open-Meteo — pronóstico abierto vía API. No expone buscador público por
+  // dato; su web es docs de API, no acerca al pronóstico de la finca → texto.
+  { keys: ['open-meteo', 'openmeteo', 'open meteo'], kind: 'text' },
+  // INVIMA — autoridad sanitaria (fermentos/alimentos). Buscador estable (?q=). → search.
+  {
+    keys: ['invima'],
+    kind: 'search',
+    searchUrl: (c) => `https://www.invima.gov.co/buscar?q=${encodeURIComponent(c)}`,
+  },
 ];
 
 /** Normaliza para matchear: minúsculas, sin tildes, espacios colapsados. */
@@ -72,47 +119,114 @@ function _isHttpUrl(u) {
 /**
  * Matchea una key contra el texto normalizado con frontera de palabra, para que
  * keys cortas no peguen dentro de otra (p.ej. "ica" NO debe matchear "cenicafe").
- * Escapa la key y usa \b alrededor; "open-meteo" y compañía siguen funcionando
- * porque el guion es separador de palabra.
  */
 function _matchesKey(text, key) {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(`\\b${escaped}\\b`).test(text);
 }
 
+/** Encuentra la entrada institucional que matchea la cita, o null. */
+function _matchInstitution(source) {
+  if (typeof source !== 'string' || !source.trim()) return null;
+  const n = _norm(source);
+  for (const inst of INSTITUTIONS) {
+    if (inst.keys.some((k) => _matchesKey(n, k))) return inst;
+  }
+  return null;
+}
+
+/** Limpia el concepto citado para usarlo como término de búsqueda. */
+function _cleanConcept(concept) {
+  if (typeof concept !== 'string') return '';
+  // Quitamos el ruido típico de un label de fuente y dejamos el término.
+  const t = concept.replace(/\s+/g, ' ').trim();
+  // Concepto demasiado corto (1 char) o vacío no produce búsqueda útil.
+  return t.length >= 2 ? t : '';
+}
+
 /**
- * Devuelve la URL institucional para una cita de fuente, o null si no se
- * reconoce ninguna institución. Si `opts.deepLink` es un http(s) válido, gana
- * sobre la página institucional (p.ej. ficha de especie Agrosavia con species_id).
+ * Devuelve la URL al RECURSO citado para una fuente institucional, o null si no
+ * hay un recurso al que acercar al usuario (institución 'text', o 'search' sin
+ * concepto, o fuente no reconocida). NUNCA devuelve una homepage genérica.
+ *
+ * Resolución (primero que aplique):
+ *   1. opts.deepLink http(s) válido → se usa tal cual (recurso curado preciso).
+ *   2. institución 'section' → su URL de sección del dato citado.
+ *   3. institución 'search' + opts.concept usable → URL de búsqueda del concepto.
+ *   4. en cualquier otro caso → null (la cita irá como texto plano).
  *
  * @param {unknown} source — nombre de la fuente citada (ej. "IDEAM", "Agrosavia / FAO").
- * @param {{ deepLink?: string }} [opts]
+ * @param {{ deepLink?: string, concept?: string }} [opts]
  * @returns {string|null}
  */
 export function institutionalSourceUrl(source, opts = {}) {
   const deep = opts && typeof opts.deepLink === 'string' ? opts.deepLink.trim() : '';
   if (_isHttpUrl(deep)) return deep;
 
-  if (typeof source !== 'string' || !source.trim()) return null;
-  const n = _norm(source);
-  for (const inst of INSTITUTIONS) {
-    if (inst.keys.some((k) => _matchesKey(n, k))) return inst.url;
+  const inst = _matchInstitution(source);
+  if (!inst) return null;
+
+  if (inst.kind === 'section' && _isHttpUrl(inst.url)) return inst.url;
+
+  if (inst.kind === 'search' && typeof inst.searchUrl === 'function') {
+    const concept = _cleanConcept(opts && opts.concept);
+    if (!concept) return null; // buscador sin término == homepage disfrazada.
+    const url = inst.searchUrl(concept);
+    return _isHttpUrl(url) ? url : null;
   }
+
+  // kind 'text' (o 'search' sin concepto): no hay recurso al que acercar.
   return null;
 }
 
 /**
- * De una cita de fuente (string o array de strings) produce el shape de badge
- * `{ fuente, fuente_url }` que el ChatBubble (FuenteBadge) renderiza como link.
+ * Resuelve el badge de fuente al máximo nivel de trazabilidad HONESTA disponible:
  *
- * - Si es array, toma la PRIMERA entrada que mapee a una institución reconocida,
- *   conservando su label original como `fuente`.
- * - Si `opts.deepLink` es válido, se usa esa URL (la institución sigue dando el label).
- * - Si nada mapea, devuelve {} (sin link — la UX no muestra badge).
+ *   - `{ fuente, fuente_url }`  → la cita lleva a un recurso (deep-link / sección
+ *     / búsqueda del concepto). El badge se renderiza como LINK.
+ *   - `{ fuente, fuente_texto: true }` → la fuente es una institución reconocida
+ *     pero no hay recurso puntual al que acercar (institución 'text', o 'search'
+ *     sin concepto). El badge se renderiza como TEXTO PLANO ("Fuente: X"). NO se
+ *     emite homepage.
+ *   - `{}` → la fuente no es institucional reconocida (no inventamos nada).
+ *
+ * @param {unknown} source — nombre de la fuente citada.
+ * @param {{ deepLink?: string, concept?: string }} [opts]
+ * @returns {{ fuente?: string, fuente_url?: string, fuente_texto?: boolean }}
+ */
+export function classifySource(source, opts = {}) {
+  const deep = opts && typeof opts.deepLink === 'string' ? opts.deepLink.trim() : '';
+  const label = typeof source === 'string' ? source.trim() : '';
+
+  // Deep-link curado preciso: linkea aunque la fuente no sea institucional.
+  if (_isHttpUrl(deep)) {
+    return label ? { fuente: label, fuente_url: deep } : { fuente_url: deep };
+  }
+
+  const inst = _matchInstitution(source);
+  if (!inst) return {};
+
+  const url = institutionalSourceUrl(source, opts);
+  if (url) return { fuente: label, fuente_url: url };
+
+  // Institución reconocida pero sin recurso puntual → texto plano, no homepage.
+  return { fuente: label, fuente_texto: true };
+}
+
+/**
+ * De una cita de fuente (string o array de strings) produce el shape de badge.
+ * Toma la PRIMERA entrada que mapee a una institución reconocida (o que tenga un
+ * deep-link), conservando su label original como `fuente`.
+ *
+ * - Si `opts.deepLink` es válido, se usa esa URL.
+ * - Si la institución tiene recurso (sección o búsqueda con concepto) → link.
+ * - Si la institución NO tiene recurso puntual → `{ fuente, fuente_texto: true }`
+ *   (texto plano, sin link a homepage).
+ * - Si nada mapea, devuelve {} (sin badge).
  *
  * @param {unknown} sources — string | string[] de fuentes citadas.
- * @param {{ deepLink?: string }} [opts]
- * @returns {{ fuente?: string, fuente_url?: string }}
+ * @param {{ deepLink?: string, concept?: string }} [opts]
+ * @returns {{ fuente?: string, fuente_url?: string, fuente_texto?: boolean }}
  */
 export function resolveSourceLink(sources, opts = {}) {
   const list = Array.isArray(sources)
@@ -120,12 +234,16 @@ export function resolveSourceLink(sources, opts = {}) {
     : typeof sources === 'string' && sources.trim()
       ? [sources]
       : [];
+  // 1ª pasada: preferimos una fuente que produzca LINK (recurso real).
+  let plainFallback = null;
   for (const s of list) {
     if (typeof s !== 'string' || !s.trim()) continue;
-    const url = institutionalSourceUrl(s, opts);
-    if (url) return { fuente: s.trim(), fuente_url: url };
+    const r = classifySource(s, opts);
+    if (r.fuente_url) return r;
+    if (r.fuente_texto && !plainFallback) plainFallback = r;
   }
-  return {};
+  // 2ª: ninguna dio link, pero alguna institución reconocida → texto plano.
+  return plainFallback || {};
 }
 
-export default { institutionalSourceUrl, resolveSourceLink };
+export default { institutionalSourceUrl, classifySource, resolveSourceLink };


### PR DESCRIPTION
## Problema

El #356 (fuente→link) linkeaba a la **homepage/landing** de la institución cuando no había un deep-link curado. Eso es **trazabilidad teatral**: el usuario hace clic en "Fuente: Cenicafé" esperando el documento citado y aterriza en `cenicafe.org` a secas, que no prueba nada. Regla del operador: **un link de fuente debe llevar al RECURSO citado, no a la landing genérica.**

## Solución

Cada entrada del mapa de `institutionalSources.js` se reclasifica en tres tipos según si su URL acerca al dato citado:

| Tipo | Fuentes | Comportamiento |
|---|---|---|
| **section** (link directo) | SIPSA → boletín de precios DANE · NOAA → tabla ONI del CPC | la URL ya ES la sección del dato citado |
| **search** (búsqueda del concepto) | Agrosavia · ICA · Cenicafé · FAO · INVIMA | con el concepto citado → URL de búsqueda; **sin concepto → texto plano** (buscador vacío == homepage disfrazada) |
| **text** (texto plano, sin `<a>`) | IDEAM · Open-Meteo · DANE genérico | su portal no expone deep-link/sección/buscador estable al dato → "Fuente: X" sin link |

Nuevo `classifySource()` devuelve `{fuente_url}` (link), `{fuente_texto:true}` (texto plano) o `{}` (no institucional). El deep-link curado (ficha Agrosavia per-especie, etc.) sigue ganando siempre.

`FuenteBadge` renderiza un `<span>` "Fuente: X" (sin `href`) cuando `fuente_texto` — **jamás** un `<a>` a la portada. Honestidad > trazabilidad teatral.

## Destinos verificados

Todos los `search`/`section` verificados HTTP 200 con `curl` (2026-06-03): Agrosavia DSpace `?query=`, ICA `/buscador?q=`, Cenicafé `?s=`, FAO `/search`, INVIMA `/buscar?q=`, SIPSA (sección precios), NOAA ONI_v5.php.

## TDD

- `institutionalSources.test.js`: contrato section/search/text + aserción explícita "ningún destino emitido es una homepage/landing genérica".
- `conversationMemory.sourceMetadata.test.js`: `extractGroundingBadges`/`deriveEvidenceSourceLink` propagan `fuente_texto`; clima IDEAM → texto plano.
- `ChatBubble.test.jsx`: una fuente sin recurso puntual NO produce `<a>` a homepage; renderiza texto.

`npm run test:unit` 3384 verde · eslint 0 warnings en archivos tocados · `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)