### PR TITLE
feat(temas): sistema de 3 temas visuales app-wide desde el login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.37",
+  "version": "1.0.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v295';
+const CACHE_NAME = 'chagra-v296';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -115,7 +115,7 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
       {loginBgSrc && (
         <div
           aria-hidden="true"
-          className="absolute inset-0 pointer-events-none bg-cover bg-center"
+          className="login-bg-photo absolute inset-0 pointer-events-none bg-cover bg-center"
           style={{
             backgroundImage: `linear-gradient(rgba(2,6,23,0.62), rgba(2,6,23,0.86)), url('${loginBgSrc}')`,
           }}

--- a/src/components/common/ThemeSelector.jsx
+++ b/src/components/common/ThemeSelector.jsx
@@ -1,42 +1,76 @@
 import React from 'react';
-import { useTheme } from '../../hooks/useTheme';
+import { useTheme, THEMES } from '../../hooks/useTheme';
 
-const THEMES = [
-    { id: 'biopunk', label: 'Biopunk (clásico)', desc: 'El tema original. Acentos neón.' },
-    { id: 'dark-sober', label: 'Oscuro sobrio', desc: 'Modo oscuro discreto sin neón.' },
-    { id: 'light', label: 'Claro', desc: 'Tema claro para uso diurno.' },
-    { id: 'auto', label: 'Automático', desc: 'Cambia entre claro y oscuro según la hora.' },
-];
+/**
+ * ThemeSelector — switcher de tema visual (skin) de la app.
+ * Vive en Perfil. Default bio-punk; el usuario puede cambiar a Nature o
+ * Minimalista (persistido en localStorage vía useTheme). El tema se aplica
+ * app-wide desde el login mediante data-theme en <html>.
+ *
+ * Cada tema muestra un swatch con sus colores característicos para que el
+ * cambio sea evidente antes de aplicarlo.
+ */
+
+// Trío de colores representativo de cada tema (fondo / acento / detalle).
+// Solo presentación del swatch; la paleta real vive en themes.css.
+const SWATCHES = {
+  biopunk: ['#0a0e14', '#19c79a', '#3be8a6'],
+  nature: ['#f6efe0', '#d98a4f', '#7a8f4a'],
+  minimalista: ['#f6f3ec', '#2f6e5a', '#878d86'],
+  auto: ['#0a0e14', '#2f6e5a', '#f6f3ec'],
+};
 
 export default function ThemeSelector() {
-    const { theme, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
-    return (
-        <div className="space-y-3">
-            <div className="flex flex-col gap-2">
-                {THEMES.map((t) => (
-                    <button
-                        key={t.id}
-                        onClick={() => setTheme(t.id)}
-                        className={`w-full p-4 rounded-xl text-left border-2 transition-all active:scale-95 ${theme === t.id
-                                ? 'border-emerald-500 bg-emerald-900/20'
-                                : 'border-slate-800 bg-slate-900/40 hover:border-slate-700'
-                            }`}
-                    >
-                        <div className="flex justify-between items-center mb-1">
-                            <span className={`text-base font-black ${theme === t.id ? 'text-emerald-400' : 'text-slate-100'}`}>
-                                {t.label}
-                            </span>
-                            {theme === t.id && (
-                                <div className="w-2 h-2 bg-emerald-500 rounded-full shadow-[0_0_8px_rgba(16,185,129,0.6)]"></div>
-                            )}
-                        </div>
-                        <span className="block text-xs text-slate-400 leading-relaxed">
-                            {t.desc}
-                        </span>
-                    </button>
-                ))}
-            </div>
-        </div>
-    );
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-2">
+        {THEMES.map((t) => {
+          const active = theme === t.id;
+          const swatch = SWATCHES[t.id] || SWATCHES.biopunk;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => setTheme(t.id)}
+              className={`w-full p-4 rounded-xl text-left border-2 transition-all active:scale-95 ${
+                active
+                  ? 'border-emerald-500 bg-emerald-900/20'
+                  : 'border-slate-800 bg-slate-900/40 hover:border-slate-700'
+              }`}
+            >
+              <div className="flex justify-between items-center mb-1">
+                <span
+                  className={`text-base font-black ${
+                    active ? 'text-emerald-400' : 'text-slate-100'
+                  }`}
+                >
+                  {t.label}
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="flex gap-1" aria-hidden="true">
+                    {swatch.map((c, i) => (
+                      <span
+                        key={i}
+                        className="w-4 h-4 rounded-full border border-black/20"
+                        style={{ backgroundColor: c }}
+                      />
+                    ))}
+                  </span>
+                  {active && (
+                    <div className="w-2 h-2 bg-emerald-500 rounded-full shadow-[0_0_8px_rgba(16,185,129,0.6)]" />
+                  )}
+                </div>
+              </div>
+              <span className="block text-xs text-slate-400 leading-relaxed">
+                {t.desc}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/src/components/common/__tests__/ThemeSelector.test.jsx
+++ b/src/components/common/__tests__/ThemeSelector.test.jsx
@@ -1,0 +1,69 @@
+/**
+ * ThemeSelector — switcher de tema visual (Perfil / Ajustes).
+ *
+ * Cubre:
+ *   - renderiza los 3 temas curados (bio-punk, Nature, Minimalista) + auto
+ *   - el tema activo aparece marcado (aria-pressed)
+ *   - al elegir un tema se persiste en localStorage y se aplica a <html>
+ *   - default = bio-punk
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import ThemeSelector from '../ThemeSelector';
+import { STORAGE_KEY } from '../../../hooks/useTheme';
+
+describe('ThemeSelector — switcher de tema', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  // El nombre accesible del botón empieza por su label (texto en negrita) y
+  // sigue con la descripción. Anclamos al inicio (^) para no chocar con la
+  // mención de "Bio-Punk" en la descripción del modo Automático.
+  const bioBtn = () => screen.getByRole('button', { name: /^Bio-Punk/i });
+  const natureBtn = () => screen.getByRole('button', { name: /^Nature/i });
+  const miniBtn = () => screen.getByRole('button', { name: /^Minimalista/i });
+  const autoBtn = () => screen.getByRole('button', { name: /^Autom/i });
+
+  it('renderiza los 3 temas curados + el modo automático', () => {
+    render(<ThemeSelector />);
+    expect(bioBtn()).toBeTruthy();
+    expect(natureBtn()).toBeTruthy();
+    expect(miniBtn()).toBeTruthy();
+    expect(autoBtn()).toBeTruthy();
+  });
+
+  it('marca bio-punk como activo por defecto (aria-pressed)', () => {
+    render(<ThemeSelector />);
+    expect(bioBtn().getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('al elegir Nature persiste en localStorage y aplica data-theme', () => {
+    render(<ThemeSelector />);
+    fireEvent.click(natureBtn());
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('nature');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('nature');
+  });
+
+  it('al elegir Minimalista marca aria-pressed y desmarca bio-punk', () => {
+    render(<ThemeSelector />);
+    fireEvent.click(miniBtn());
+    expect(miniBtn().getAttribute('aria-pressed')).toBe('true');
+    expect(bioBtn().getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('volver a bio-punk limpia data-theme (estilos base)', () => {
+    render(<ThemeSelector />);
+    fireEvent.click(natureBtn());
+    expect(document.documentElement.getAttribute('data-theme')).toBe('nature');
+    fireEvent.click(bioBtn());
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('biopunk');
+  });
+});

--- a/src/hooks/__tests__/useTheme.test.js
+++ b/src/hooks/__tests__/useTheme.test.js
@@ -1,0 +1,128 @@
+/**
+ * useTheme — sistema de temas visuales de la app.
+ *
+ * Tres temas curados (operador 2026-06-03, demo Bogotá):
+ *   - bio-punk (DEFAULT)  → oscuro neón teal "cosecha mística"
+ *   - nature              → cálido botánico (terracota/salvia/ocre)
+ *   - minimalista         → limpio, crema, monoline verde
+ * Más un modo `auto` (alterna minimalista/biopunk según la hora).
+ *
+ * Cubre:
+ *   - default = bio-punk (sin localStorage previo)
+ *   - applyTheme escribe / limpia data-theme en <html> (biopunk = sin attr)
+ *   - setTheme persiste en localStorage (chagra:theme) y rechaza ids inválidos
+ *   - THEME_IDS expone exactamente los 3 temas + auto
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useTheme,
+  applyTheme,
+  THEME_IDS,
+  THEMES,
+  DEFAULT_THEME,
+  STORAGE_KEY,
+} from '../useTheme';
+
+describe('useTheme — sistema de temas', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('default es bio-punk cuando no hay nada en localStorage', () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('biopunk');
+    expect(DEFAULT_THEME).toBe('biopunk');
+  });
+
+  it('THEME_IDS expone los 3 temas curados + auto', () => {
+    expect(THEME_IDS).toContain('biopunk');
+    expect(THEME_IDS).toContain('nature');
+    expect(THEME_IDS).toContain('minimalista');
+    expect(THEME_IDS).toContain('auto');
+    // El catálogo visible al usuario contiene los 3 temas explícitos + auto.
+    expect(THEMES.map((t) => t.id)).toEqual([
+      'biopunk',
+      'nature',
+      'minimalista',
+      'auto',
+    ]);
+  });
+
+  it('applyTheme(biopunk) NO pone data-theme (biopunk = estilos base)', () => {
+    document.documentElement.setAttribute('data-theme', 'nature');
+    const resolved = applyTheme('biopunk');
+    expect(resolved).toBe('biopunk');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('applyTheme(nature) escribe data-theme="nature" en <html>', () => {
+    const resolved = applyTheme('nature');
+    expect(resolved).toBe('nature');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('nature');
+  });
+
+  it('applyTheme(minimalista) escribe data-theme="minimalista" en <html>', () => {
+    const resolved = applyTheme('minimalista');
+    expect(resolved).toBe('minimalista');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'minimalista'
+    );
+  });
+
+  it('applyTheme(auto) de día resuelve a minimalista (data-theme escrito)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T12:00:00'));
+    const resolved = applyTheme('auto');
+    expect(resolved).toBe('minimalista');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'minimalista'
+    );
+  });
+
+  it('applyTheme(auto) de noche resuelve a biopunk (sin data-theme)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T22:00:00'));
+    const resolved = applyTheme('auto');
+    expect(resolved).toBe('biopunk');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('setTheme persiste en localStorage (chagra:theme) y aplica al DOM', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setTheme('nature'));
+    expect(result.current.theme).toBe('nature');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('nature');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('nature');
+  });
+
+  it('setTheme rechaza ids inválidos (no muta estado ni storage)', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => result.current.setTheme('minimalista'));
+    act(() => result.current.setTheme('no-existe'));
+    expect(result.current.theme).toBe('minimalista');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('minimalista');
+  });
+
+  it('al montar, lee el tema persistido y lo aplica (minimalista → data-theme)', () => {
+    localStorage.setItem(STORAGE_KEY, 'minimalista');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('minimalista');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'minimalista'
+    );
+  });
+
+  it('migra ids legados (dark-sober/light) al default bio-punk en el getter', () => {
+    // dark-sober y light fueron reemplazados por los 3 temas curados.
+    localStorage.setItem(STORAGE_KEY, 'dark-sober');
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe('biopunk');
+  });
+});

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,43 +1,106 @@
 import { useEffect, useState, useCallback } from 'react';
 
-const STORAGE_KEY = 'chagra:theme';
-const VALID = ['biopunk', 'dark-sober', 'light', 'auto'];
+/**
+ * useTheme — sistema de temas visuales de la app (skin global).
+ * ================================================================
+ * Tres temas curados (operador 2026-06-03, demo Bogotá). El tema se aplica
+ * desde el LOGIN y en toda la app vía el atributo `data-theme` en <html>;
+ * las variables y overrides viven en `src/styles/themes.css`:
+ *
+ *   - bio-punk (DEFAULT)  → oscuro #0a0e14, neón teal #19c79a "cosecha mística".
+ *                           Es el estilo BASE de la app → NO escribe data-theme.
+ *   - nature              → cálido botánico (terracota/salvia/ocre).
+ *   - minimalista         → limpio, crema, monoline verde #2f6e5a.
+ *
+ * Más un modo `auto` que alterna entre minimalista (día) y bio-punk (noche).
+ *
+ * Persistencia híbrida: default bio-punk + override del usuario en
+ * localStorage (`chagra:theme`). Un id legado/desconocido cae al default.
+ * ================================================================
+ */
 
-function applyTheme(theme) {
-    // Si "auto", resolver según hora local
-    let resolved = theme;
-    if (theme === 'auto') {
-        const hour = new Date().getHours();
-        resolved = (hour >= 18 || hour < 6) ? 'dark-sober' : 'light';
-    }
+export const STORAGE_KEY = 'chagra:theme';
+export const DEFAULT_THEME = 'biopunk';
 
-    if (resolved === 'biopunk') {
-        document.documentElement.removeAttribute('data-theme');
-    } else {
-        document.documentElement.setAttribute('data-theme', resolved);
-    }
-    return resolved;
+/**
+ * Catálogo visible en el switcher (ThemeSelector). El orden define el orden
+ * en la UI: el default bio-punk va primero. `auto` cierra la lista.
+ */
+export const THEMES = Object.freeze([
+  Object.freeze({
+    id: 'biopunk',
+    label: 'Bio-Punk',
+    desc: 'Oscuro, neón teal — cosecha mística. El tema por defecto.',
+  }),
+  Object.freeze({
+    id: 'nature',
+    label: 'Nature',
+    desc: 'Cálido botánico: terracota, salvia y ocre.',
+  }),
+  Object.freeze({
+    id: 'minimalista',
+    label: 'Minimalista',
+    desc: 'Limpio y claro, crema con verde monoline.',
+  }),
+  Object.freeze({
+    id: 'auto',
+    label: 'Automático',
+    desc: 'Minimalista de día, Bio-Punk de noche.',
+  }),
+]);
+
+/** Ids válidos seleccionables (los 3 temas curados + auto). */
+export const THEME_IDS = Object.freeze(THEMES.map((t) => t.id));
+
+/**
+ * Normaliza un id persistido: cualquier valor desconocido o legado
+ * (`dark-sober`, `light`, etc., reemplazados por los 3 temas curados) cae al
+ * default bio-punk. Defensivo contra localStorage de versiones anteriores.
+ */
+export function normalizeTheme(id) {
+  return THEME_IDS.includes(id) ? id : DEFAULT_THEME;
+}
+
+/**
+ * Aplica un tema al <html>. bio-punk es el estilo BASE → se quita data-theme;
+ * el resto escribe `data-theme="<id>"` que activa las variables/overrides de
+ * themes.css. Para `auto` resuelve según la hora local (día→minimalista,
+ * noche→biopunk). Devuelve el tema EFECTIVO ya resuelto (útil en tests).
+ */
+export function applyTheme(theme) {
+  let resolved = theme;
+  if (theme === 'auto') {
+    const hour = new Date().getHours();
+    resolved = hour >= 18 || hour < 6 ? 'biopunk' : 'minimalista';
+  }
+
+  if (resolved === 'biopunk') {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', resolved);
+  }
+  return resolved;
 }
 
 export function useTheme() {
-    const [theme, setThemeState] = useState(() => {
-        return localStorage.getItem(STORAGE_KEY) || 'biopunk';
-    });
+  const [theme, setThemeState] = useState(() =>
+    normalizeTheme(localStorage.getItem(STORAGE_KEY))
+  );
 
-    useEffect(() => {
-        applyTheme(theme);
-        if (theme === 'auto') {
-            // Re-evaluar cada 10 min para auto-switching
-            const id = setInterval(() => applyTheme('auto'), 10 * 60 * 1000);
-            return () => clearInterval(id);
-        }
-    }, [theme]);
+  useEffect(() => {
+    applyTheme(theme);
+    if (theme === 'auto') {
+      // Re-evaluar cada 10 min para el auto-switching día/noche.
+      const id = setInterval(() => applyTheme('auto'), 10 * 60 * 1000);
+      return () => clearInterval(id);
+    }
+  }, [theme]);
 
-    const setTheme = useCallback((next) => {
-        if (!VALID.includes(next)) return;
-        localStorage.setItem(STORAGE_KEY, next);
-        setThemeState(next);
-    }, []);
+  const setTheme = useCallback((next) => {
+    if (!THEME_IDS.includes(next)) return;
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  }, []);
 
-    return { theme, setTheme };
+  return { theme, setTheme };
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,130 +1,258 @@
-/* src/styles/themes.css */
+/* src/styles/themes.css
+ * ============================================================================
+ * SISTEMA DE TEMAS (skin global de la app) — operador 2026-06-03, demo Bogotá.
+ *
+ * Tres temas curados, aplicados app-wide desde el LOGIN vía `data-theme` en
+ * <html> (lo escribe useTheme.js). Paletas tomadas 1:1 de los demos de
+ * referencia (oracle-lab demo-agente-{biopunk,minimalista}.html + demo-agente.html):
+ *
+ *   - bio-punk (DEFAULT)  → estilo BASE de la app. NO lleva data-theme; ya vive
+ *                           en index.css + tailwind.config (neón teal, fondo
+ *                           "cosecha mística" /fondo-biopunk-4.jpg). No se toca.
+ *   - nature              → cálido botánico: crema, terracota (#d98a4f),
+ *                           salvia (#7a8f4a), ocre (#f5b733).
+ *   - minimalista         → claro y limpio: crema (#f6f3ec), verde monoline
+ *                           (#2f6e5a), tinta casi negra.
+ *
+ * Estrategia: la app está escrita con utilidades Tailwind slate-* (fondo
+ * oscuro). Para los temas claros remapeamos esas clases a las variables del
+ * tema con overrides `!important` acotados a `[data-theme="..."]`. Es la misma
+ * técnica que ya usaban los temas previos (dark-sober/light), ahora con las
+ * paletas curadas. Bio-punk no se ve afectado (sin data-theme = sin override).
+ * ============================================================================
+ */
 
-/* 1. Root variables for each theme */
+/* ===========================================================================
+ * 1. VARIABLES POR TEMA
+ * =========================================================================== */
 
-[data-theme="dark-sober"] {
-  --color-bg-primary: #0a0a0a;
-  --color-bg-secondary: #0f172a;
-  --color-text-primary: #e5e5e5;
-  --color-text-secondary: #a3a3a3;
-  --color-accent: #475569; /* slate-600 — sin neón */
-  --color-border: #1e293b;
-  --color-card: #111827;
+[data-theme="nature"] {
+  --t-bg: #f6efe0;          /* crema clara amanecer */
+  --t-bg-2: #efe1c8;        /* crema media */
+  --t-surface: #fbf5ea;     /* superficie barra / card */
+  --t-surface-2: #ffffff;
+  --t-text: #4a3a26;        /* café texto principal */
+  --t-text-2: #6b5638;      /* secundario */
+  --t-text-3: #8a7350;      /* terciario / placeholder */
+  --t-line: #ddc8a6;        /* bordes suaves */
+  --t-accent: #d98a4f;      /* terracota acento */
+  --t-accent-d: #b86a32;    /* terracota oscuro */
+  --t-accent-2: #7a8f4a;    /* salvia (verde) */
+  --t-accent-warm: #f5b733; /* ocre flor */
+  --t-accent-rgb: 217, 138, 79;
 }
 
-[data-theme="light"] {
-  --color-bg-primary: #ffffff;
-  --color-bg-secondary: #f8fafc;
-  --color-text-primary: #0f172a;
-  --color-text-secondary: #475569;
-  --color-accent: #059669; /* emerald-600 */
-  --color-border: #e2e8f0;
-  --color-card: #f1f5f9;
+[data-theme="minimalista"] {
+  --t-bg: #f6f3ec;          /* fondo principal crema */
+  --t-bg-2: #f0ece2;        /* crema más cálida */
+  --t-surface: #ffffff;     /* superficie / card */
+  --t-surface-2: #ffffff;
+  --t-text: #1f2421;        /* tinta casi negra verdosa */
+  --t-text-2: #4b524c;      /* secundario */
+  --t-text-3: #878d86;      /* terciario / placeholder */
+  --t-line: #e3ddd0;        /* bordes finos */
+  --t-accent: #2f6e5a;      /* verde monoline */
+  --t-accent-d: #255848;    /* verde oscuro */
+  --t-accent-2: #2f6e5a;
+  --t-accent-warm: #f5b733;
+  --t-accent-rgb: 47, 110, 90;
 }
 
-/* 2. Global Overrides for Tailwind hardcoded classes */
+/* ===========================================================================
+ * 2. FONDO DE LA APP Y DEL LOGIN
+ *    Bio-punk usa la foto "cosecha mística" (index.css). Los temas claros la
+ *    reemplazan por un lavado crema suave para no oscurecer la UI clara.
+ * =========================================================================== */
 
-/* --- BACKGROUNDS --- */
-[data-theme="dark-sober"] .bg-slate-950,
-[data-theme="dark-sober"] .bg-slate-900 {
-  background-color: var(--color-bg-primary) !important;
+/* Body global: color de fondo base por tema (evita flash oscuro). */
+[data-theme="nature"] body,
+[data-theme="minimalista"] body {
+  background-color: var(--t-bg) !important;
 }
 
-[data-theme="light"] .bg-slate-950,
-[data-theme="light"] .bg-slate-900 {
-  background-color: var(--color-bg-primary) !important;
+/* La capa de foto biopunk del body (.app-bg-biodiversidad) se sustituye por
+ * un degradado crema en los temas claros. */
+[data-theme="nature"] body.app-bg-biodiversidad {
+  background-image: linear-gradient(160deg, var(--t-bg) 0%, var(--t-bg-2) 100%) !important;
+}
+[data-theme="minimalista"] body.app-bg-biodiversidad {
+  background-image: linear-gradient(160deg, var(--t-bg) 0%, var(--t-bg-2) 100%) !important;
 }
 
-[data-theme="dark-sober"] .bg-slate-900\/50,
-[data-theme="dark-sober"] .bg-slate-900\/60 {
-  background-color: rgba(10, 10, 10, 0.6) !important;
-}
-
-[data-theme="light"] .bg-slate-900\/50,
-[data-theme="light"] .bg-slate-900\/60 {
-  background-color: rgba(248, 250, 252, 0.6) !important;
-}
-
-[data-theme] .bg-biopunk-pattern {
+/* El patrón biopunk (login + superficies) se apaga en temas claros. */
+[data-theme="nature"] .bg-biopunk-pattern,
+[data-theme="minimalista"] .bg-biopunk-pattern {
   background-image: none !important;
 }
 
-/* --- TEXT COLORS --- */
-[data-theme="dark-sober"] .text-white,
-[data-theme="dark-sober"] .text-slate-100,
-[data-theme="dark-sober"] .text-slate-200 {
-  color: var(--color-text-primary) !important;
+/* La capa de foto oscura del login (.login-bg-photo) se oculta en los temas
+ * claros: su overlay slate-950 oscurecería la UI clara. Bio-punk la conserva. */
+[data-theme="nature"] .login-bg-photo,
+[data-theme="minimalista"] .login-bg-photo {
+  display: none !important;
 }
 
-[data-theme="light"] .text-white,
-[data-theme="light"] .text-slate-100,
-[data-theme="light"] .text-slate-200 {
-  color: var(--color-text-primary) !important;
+/* ===========================================================================
+ * 3. SUPERFICIES (fondos)
+ * =========================================================================== */
+
+[data-theme="nature"] .bg-slate-950,
+[data-theme="nature"] .bg-slate-900,
+[data-theme="minimalista"] .bg-slate-950,
+[data-theme="minimalista"] .bg-slate-900 {
+  background-color: var(--t-bg) !important;
 }
 
-[data-theme="light"] .text-slate-400,
-[data-theme="light"] .text-slate-500 {
-  color: var(--color-text-secondary) !important;
+[data-theme="nature"] .bg-slate-900\/60,
+[data-theme="nature"] .bg-slate-900\/50,
+[data-theme="nature"] .bg-slate-900\/40,
+[data-theme="nature"] .bg-slate-800,
+[data-theme="nature"] .bg-slate-800\/70,
+[data-theme="minimalista"] .bg-slate-900\/60,
+[data-theme="minimalista"] .bg-slate-900\/50,
+[data-theme="minimalista"] .bg-slate-900\/40,
+[data-theme="minimalista"] .bg-slate-800,
+[data-theme="minimalista"] .bg-slate-800\/70 {
+  background-color: var(--t-surface) !important;
 }
 
-/* --- ACCENTS & GLOWS --- */
-[data-theme="dark-sober"] .text-muzo-glow {
-  color: var(--color-text-primary) !important;
+/* ===========================================================================
+ * 4. TEXTO
+ * =========================================================================== */
+
+[data-theme="nature"] .text-white,
+[data-theme="nature"] .text-slate-100,
+[data-theme="nature"] .text-slate-200,
+[data-theme="nature"] .text-slate-300,
+[data-theme="minimalista"] .text-white,
+[data-theme="minimalista"] .text-slate-100,
+[data-theme="minimalista"] .text-slate-200,
+[data-theme="minimalista"] .text-slate-300 {
+  color: var(--t-text) !important;
+}
+
+[data-theme="nature"] .text-slate-400,
+[data-theme="nature"] .text-slate-500,
+[data-theme="minimalista"] .text-slate-400,
+[data-theme="minimalista"] .text-slate-500 {
+  color: var(--t-text-3) !important;
+}
+
+/* ===========================================================================
+ * 5. ACENTOS, GLOWS Y NEONES
+ *    Bio-punk usa muzo/morpho neón; en temas claros viran al acento del tema
+ *    y se apagan las sombras neón (no pegan sobre fondo claro).
+ * =========================================================================== */
+
+[data-theme="nature"] .text-muzo,
+[data-theme="nature"] .text-muzo-glow,
+[data-theme="nature"] .text-morpho-glow,
+[data-theme="nature"] .text-emerald-400,
+[data-theme="nature"] .text-emerald-500,
+[data-theme="nature"] .text-green-400,
+[data-theme="nature"] .text-green-500 {
+  color: var(--t-accent) !important;
+  text-shadow: none !important;
+}
+[data-theme="minimalista"] .text-muzo,
+[data-theme="minimalista"] .text-muzo-glow,
+[data-theme="minimalista"] .text-morpho-glow,
+[data-theme="minimalista"] .text-emerald-400,
+[data-theme="minimalista"] .text-emerald-500,
+[data-theme="minimalista"] .text-green-400,
+[data-theme="minimalista"] .text-green-500 {
+  color: var(--t-accent) !important;
   text-shadow: none !important;
 }
 
-[data-theme="light"] .text-muzo-glow {
-  color: var(--color-accent) !important;
-  text-shadow: none !important;
-}
-
-[data-theme] .shadow-neon-muzo,
-[data-theme] .shadow-neon-morpho,
-[data-theme] .shadow-neon-orchid,
-[data-theme] .shadow-neon-frog {
+[data-theme="nature"] .shadow-neon-muzo,
+[data-theme="nature"] .shadow-neon-morpho,
+[data-theme="nature"] .shadow-neon-orchid,
+[data-theme="nature"] .shadow-neon-frog,
+[data-theme="minimalista"] .shadow-neon-muzo,
+[data-theme="minimalista"] .shadow-neon-morpho,
+[data-theme="minimalista"] .shadow-neon-orchid,
+[data-theme="minimalista"] .shadow-neon-frog {
   box-shadow: none !important;
 }
 
-/* --- BORDERS --- */
-[data-theme="dark-sober"] .border-slate-800,
-[data-theme="dark-sober"] .border-slate-700 {
-  border-color: var(--color-border) !important;
+/* Halo del logo en login (bg-muzo/20): tinte suave del acento. */
+[data-theme="nature"] .bg-muzo\/20,
+[data-theme="minimalista"] .bg-muzo\/20 {
+  background-color: rgba(var(--t-accent-rgb), 0.14) !important;
 }
 
-[data-theme="light"] .border-slate-800,
-[data-theme="light"] .border-slate-700 {
-  border-color: var(--color-border) !important;
+/* ===========================================================================
+ * 6. BORDES
+ * =========================================================================== */
+
+[data-theme="nature"] .border-slate-800,
+[data-theme="nature"] .border-slate-700,
+[data-theme="nature"] .border-slate-600,
+[data-theme="minimalista"] .border-slate-800,
+[data-theme="minimalista"] .border-slate-700,
+[data-theme="minimalista"] .border-slate-600 {
+  border-color: var(--t-line) !important;
 }
 
-/* --- COMPONENTS SPECIFIC OVERRIDES --- */
-
-/* Input/Select */
-[data-theme="light"] input, 
-[data-theme="light"] select, 
-[data-theme="light"] textarea {
-  background-color: white !important;
-  color: var(--color-text-primary) !important;
-  border-color: var(--color-border) !important;
+[data-theme="nature"] .divide-slate-800 > *,
+[data-theme="minimalista"] .divide-slate-800 > * {
+  border-color: var(--t-line) !important;
 }
 
-/* Action Buttons */
-[data-theme="light"] .bg-slate-800 {
-  background-color: var(--color-bg-secondary) !important;
-  color: var(--color-text-primary) !important;
+/* ===========================================================================
+ * 7. FORMULARIOS (login + toda la app)
+ * =========================================================================== */
+
+[data-theme="nature"] input,
+[data-theme="nature"] select,
+[data-theme="nature"] textarea,
+[data-theme="minimalista"] input,
+[data-theme="minimalista"] select,
+[data-theme="minimalista"] textarea {
+  background-color: var(--t-surface-2) !important;
+  color: var(--t-text) !important;
+  border-color: var(--t-line) !important;
 }
 
-/* ScreenShell and Header */
-[data-theme="light"] header {
-  background-color: white !important;
-  border-color: var(--color-border) !important;
+/* ===========================================================================
+ * 8. BOTONES PRIMARIOS (CTA verde del login y acciones)
+ * =========================================================================== */
+
+[data-theme="nature"] .bg-green-600,
+[data-theme="nature"] .active\:bg-green-500:active {
+  background-color: var(--t-accent) !important;
+  border-color: var(--t-accent-d) !important;
+  color: #fff !important;
+}
+[data-theme="minimalista"] .bg-green-600,
+[data-theme="minimalista"] .active\:bg-green-500:active {
+  background-color: var(--t-accent) !important;
+  border-color: var(--t-accent-d) !important;
+  color: #fff !important;
 }
 
-/* Dashboard Tiles - Adjusting for Light Theme */
-[data-theme="light"] .bg-slate-900\/60 {
-  background-color: white !important;
-  border-color: var(--color-border) !important;
+/* ===========================================================================
+ * 9. HEADER / TOPBAR
+ * =========================================================================== */
+
+[data-theme="nature"] header,
+[data-theme="minimalista"] header {
+  background-color: var(--t-surface) !important;
+  border-color: var(--t-line) !important;
 }
 
-[data-theme="light"] .divide-slate-800 > * {
-  border-color: var(--color-border) !important;
+/* ===========================================================================
+ * 10. GRADIENTES OSCUROS EMBEBIDOS (WelcomeStatsHero "Chagra · impacto", etc.)
+ *     Algunas tarjetas usan bg-gradient-to-br from-slate-950 to-slate-900 con
+ *     identidad propia oscura. En temas claros neutralizamos el degradado a una
+ *     superficie del tema para que no quede un bloque oscuro flotando.
+ * =========================================================================== */
+
+[data-theme="nature"] .from-slate-950.to-slate-900,
+[data-theme="nature"] .bg-gradient-to-br.from-slate-950,
+[data-theme="minimalista"] .from-slate-950.to-slate-900,
+[data-theme="minimalista"] .bg-gradient-to-br.from-slate-950 {
+  background-image: none !important;
+  background-color: var(--t-surface) !important;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -149,11 +149,15 @@ export default {
             },
         },
     },
-    darkMode: ['class', '[data-theme="dark-sober"]'],
+    // Bio-punk (default) es el modo oscuro base de la app (sin data-theme).
+    // 'class' se mantiene por compatibilidad con utilidades dark: existentes.
+    darkMode: 'class',
     plugins: [
+        // Variantes para condicionar estilos por tema curado (operador 2026-06-03).
+        // bio-punk es el base → no necesita variante; nature/minimalista sí.
         function ({ addVariant }) {
-            addVariant('theme-light', '[data-theme="light"] &');
-            addVariant('theme-dark-sober', '[data-theme="dark-sober"] &');
+            addVariant('theme-nature', '[data-theme="nature"] &');
+            addVariant('theme-minimalista', '[data-theme="minimalista"] &');
         },
     ],
 }

--- a/tests/themes.spec.js
+++ b/tests/themes.spec.js
@@ -18,7 +18,7 @@ test.describe('Themes — Perfil de usuario y persistencia', () => {
         await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
     });
 
-    test('cambia tema a claro y persiste tras recarga', async ({ page }) => {
+    test('cambia tema a Nature y persiste tras recarga', async ({ page }) => {
         await page.goto('/');
 
         // Login
@@ -26,29 +26,30 @@ test.describe('Themes — Perfil de usuario y persistencia', () => {
         await page.getByLabel(/contraseña/i).fill('e2e-pass');
         await page.getByRole('button', { name: /ingresar/i }).click();
 
-        // Entrar a Perfil
+        // Entrar a Perfil > Apariencia
         await page.getByRole('button', { name: /perfil del operador/i }).click();
         await page.getByRole('tab', { name: /apariencia/i }).click();
-        await expect(page.getByText(/Oscuro sobrio/i)).toBeVisible();
+        // El switcher muestra los 3 temas curados.
+        await expect(page.getByRole('button', { name: /^Nature/i })).toBeVisible();
 
-        // Seleccionar tema "Claro"
-        await page.click('button:has-text("Claro")');
+        // Seleccionar tema "Nature"
+        await page.getByRole('button', { name: /^Nature/i }).click();
 
         // Verificar atributo en <html>
-        await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+        await expect(page.locator('html')).toHaveAttribute('data-theme', 'nature');
 
         // Recargar y verificar persistencia
         await page.reload();
-        await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+        await expect(page.locator('html')).toHaveAttribute('data-theme', 'nature');
 
-        // Volver a Biopunk
+        // Volver a Bio-Punk (default = sin data-theme)
         await page.getByRole('button', { name: /perfil del operador/i }).click();
         await page.getByRole('tab', { name: /apariencia/i }).click();
-        await page.click('button:has-text("Biopunk")');
+        await page.getByRole('button', { name: /^Bio-Punk/i }).click();
         await expect(page.locator('html')).not.toHaveAttribute('data-theme');
     });
 
-    test('tema oscuro sobrio aplica el atributo correcto', async ({ page }) => {
+    test('tema Minimalista aplica el atributo correcto', async ({ page }) => {
         await page.goto('/');
         await page.getByLabel(/usuario/i).fill('e2e-operator');
         await page.getByLabel(/contraseña/i).fill('e2e-pass');
@@ -56,8 +57,8 @@ test.describe('Themes — Perfil de usuario y persistencia', () => {
 
         await page.getByRole('button', { name: /perfil del operador/i }).click();
         await page.getByRole('tab', { name: /apariencia/i }).click();
-        await page.click('button:has-text("Oscuro sobrio")');
+        await page.getByRole('button', { name: /^Minimalista/i }).click();
 
-        await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark-sober');
+        await expect(page.locator('html')).toHaveAttribute('data-theme', 'minimalista');
     });
 });


### PR DESCRIPTION
## Qué

Sistema de **temas visuales (skin global)** aplicado **app-wide desde el login**, vía `data-theme` en `<html>`. Tres temas curados + modo automático:

| Tema | Look | `data-theme` |
|---|---|---|
| **Bio-Punk** (default) | Oscuro neón teal, fondo "cosecha mística" | _(ninguno — estilo base)_ |
| **Nature** | Cálido botánico: terracota / salvia / ocre | `nature` |
| **Minimalista** | Claro, crema, verde monoline | `minimalista` |
| Automático | Minimalista de día / Bio-Punk de noche | resuelto |

## Cómo

- **`useTheme.js`**: catálogo `THEMES` + `applyTheme` + `normalizeTheme`. Default **bio-punk**; persistencia híbrida en `localStorage` (`chagra:theme`); ids legados migran al default. API exportada y testeable.
- **`themes.css`**: paletas `nature`/`minimalista` (tomadas 1:1 de los demos de referencia) mapeadas sobre las utilidades existentes con overrides acotados a `[data-theme="..."]`. **Bio-punk no se toca** (sin `data-theme` = sin override).
- **`ThemeSelector.jsx`**: switcher en Perfil > Apariencia, con swatch de color por tema y `aria-pressed`.
- **Fondo "cosecha mística"** (`/fondo-biopunk-4.jpg`): ya era el default universal del login; en temas claros se sustituye por un lavado crema.
- **`tailwind.config.js`**: variantes `theme-nature` / `theme-minimalista`.

## Tests (TDD)

- `useTheme.test.js` — default, persistencia, `applyTheme`, auto día/noche, migración de ids legados.
- `ThemeSelector.test.jsx` — render de los 3 temas, `aria-pressed`, switcher persiste y aplica.
- `npm run test:unit`: **3377 passed**. Lint: 0 warnings en archivos nuevos (solo los 2 preexistentes conocidos).
- Verificación visual con Chromium real (login en los 3 temas): bio-punk impecable; nature/minimalista cohesivos.

## Nota

El fallback de `prebuild` (`better-sqlite3` native binding) es un problema de entorno local del worktree, ajeno a este cambio; `vite build` compila limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)