### PR TITLE
fix(agent): suprimir patógeno/binomio en diagnóstico sin foto (#348)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.38",
+  "version": "1.0.39",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v296';
+const CACHE_NAME = 'chagra-v297';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/outputGuards.diagnosisSuppress.test.js
+++ b/src/services/__tests__/outputGuards.diagnosisSuppress.test.js
@@ -1,0 +1,247 @@
+/**
+ * outputGuards.diagnosisSuppress.test.js — #348 (HARDENING, prod 2026-06-03).
+ *
+ * Contexto (RUNBOOK-NOCTURNO S5): el guard #1280/#348 estaba MERGEADO pero NO
+ * actuaba en el path PWA real. Q6 "manchas en el tomate" (sin foto) seguía
+ * enumerando patógenos con binomio latino sin pedir la foto. Dos huecos:
+ *
+ *   1. CONDICIÓN MUY ESTRECHA — el guard solo disparaba con ≥2 patógenos o
+ *      fraseo "puede ser X o Y". Una respuesta CONFIADA con UN solo patógeno
+ *      ("Es tizón tardío, Phytophthora infestans, aplica…") se le escapaba — y
+ *      ese es justamente el caso más dañino (manda al campesino a tratar a
+ *      ciegas la enfermedad equivocada con plena seguridad). El binomio latino
+ *      en paréntesis también debe contar como diagnóstico específico.
+ *
+ *   2. APPEND, NO SUPPRESS — anteponía una nota pero DEJABA el binomio latino y
+ *      la receta de fungicida legibles debajo. El campesino igual los leía. La
+ *      regla del system prompt es PROHIBIDO nombrar un patógeno/binomio sin foto
+ *      → hay que SUPRIMIR el cuerpo y reemplazarlo por un diferencial sin latín
+ *      + pedido de foto (suppress-and-replace, como con los agroquímicos #351b).
+ *
+ * Ground-truth: AgentScreen.jsx "REGLA CRÍTICA DIAGNÓSTICO-SIN-EVIDENCIA" (~700)
+ * y Chagra-strategy/ops/RUNBOOK-NOCTURNO-2026-06-03.md (S5).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  guardDiagnosisWithoutPhoto,
+  applyOutputGuards,
+  resetOutputGuardTelemetry,
+  getOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+// Binomios/patógenos latinos que NUNCA deben sobrevivir a la supresión. NO es un
+// matcher genérico de "Capitalizada + minúsculas" (eso marcaría prosa española
+// como "Mientras tanto"); es una lista de los géneros/epítetos concretos usados
+// en los fixtures.
+const NO_LATIN =
+  /Phytophthora|infestans|Alternaria|solani|Fusarium|oxysporum|Septoria|Golovinomyces|Cladosporium|fulvum/i;
+
+beforeEach(() => {
+  resetOutputGuardTelemetry();
+});
+
+describe('#348 guardDiagnosisWithoutPhoto — suppress-and-replace (síntoma vago sin foto)', () => {
+  // ── Hueco 1: UN solo patógeno confiado (no enumera) ──────────────────────
+  it('CASO REAL: "manchas en el tomate" + UN patógeno confiado con binomio → suprime y pide foto', () => {
+    const llmFail =
+      'Las manchas en el tomate son tizón tardío (Phytophthora infestans). Aplica un fungicida ' +
+      'preventivo cada 8 días y elimina las hojas afectadas.';
+    const out = guardDiagnosisWithoutPhoto(llmFail, {
+      userMessage: 'tengo manchas en el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reason).toMatch(/diagnostico_sin_foto/);
+    // SUPRIME: el binomio latino y el patógeno específico NO sobreviven.
+    expect(out.text).not.toMatch(NO_LATIN);
+    expect(out.text.toLowerCase()).not.toContain('phytophthora');
+    expect(out.text.toLowerCase()).not.toContain('tizon tardio');
+    expect(out.text.toLowerCase()).not.toContain('tizón tardío'.normalize('NFC'));
+    // PIDE la foto y da un diferencial sencillo.
+    expect(out.text).toMatch(/foto|c[aá]mara/i);
+    expect(out.text).toMatch(/puede|varias?\s+causas|diferentes|sin verla?/i);
+  });
+
+  it('"se me está secando la planta" (sin especie, sin foto) → diferencial sin latín + foto', () => {
+    const llmFail =
+      'Se está secando por Fusarium oxysporum, un hongo del suelo que tapa los vasos. Aplica ' +
+      'Trichoderma al sustrato y reduce el riego.';
+    const out = guardDiagnosisWithoutPhoto(llmFail, {
+      userMessage: 'se me está secando la planta',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.text.toLowerCase()).not.toContain('fusarium');
+    expect(out.text).not.toMatch(NO_LATIN);
+    expect(out.text).toMatch(/foto|c[aá]mara/i);
+  });
+
+  it('binomio latino SUELTO (sin nombre común en denylist) también dispara la supresión', () => {
+    // "Cladosporium fulvum" no está en PATHOGEN_NAME_TERMS, pero es un binomio
+    // latino en contexto de síntoma sin foto → es un diagnóstico específico a
+    // ciegas igual de dañino.
+    const llmFail =
+      'Esas manchas son moho de la hoja, causado por Cladosporium fulvum. Mejora la ventilación ' +
+      'del invernadero y aplica azufre.';
+    const out = guardDiagnosisWithoutPhoto(llmFail, {
+      userMessage: 'manchas raras en las hojas',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.text.toLowerCase()).not.toContain('cladosporium');
+    expect(out.text).not.toMatch(/Cladosporium\s+fulvum/);
+  });
+
+  // ── Hueco 1bis: el caso de la lista (≥2) ahora también SE SUPRIME ─────────
+  it('lista de patógenos (≥2) → suprime la lista entera y reemplaza por diferencial + foto', () => {
+    const llmFail =
+      'Las manchas en el tomate pueden ser tizón tardío (Phytophthora infestans), alternaria o ' +
+      'septoria. Para el tizón aplica preventivos; para alternaria mejora la aireación.';
+    const out = guardDiagnosisWithoutPhoto(llmFail, {
+      userMessage: 'tengo manchas en el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    // Ya NO conservamos la lista latina debajo (cambio vs comportamiento previo).
+    expect(out.text.toLowerCase()).not.toContain('phytophthora');
+    expect(out.text.toLowerCase()).not.toContain('septoria');
+    expect(out.text).not.toMatch(NO_LATIN);
+    expect(out.text).toMatch(/foto|c[aá]mara/i);
+  });
+
+  // ── Controles: NO debe disparar ──────────────────────────────────────────
+  it('CONTROL: con especie clara + FOTO adjunta → SÍ puede diagnosticar (no toca)', () => {
+    const ok =
+      'En tu foto se ve tizón tardío (Phytophthora infestans) en las hojas bajas del tomate. ' +
+      'Aplica caldo bordelés preventivo y retira los focos.';
+    const out = guardDiagnosisWithoutPhoto(ok, {
+      userMessage: 'qué le pasa al tomate, te mando foto',
+      hadVision: true,
+    });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(ok);
+  });
+
+  it('CONTROL: respuesta que YA pide foto y no nombra patógeno → no-op', () => {
+    const ok =
+      'Para saber qué tiene tu tomate necesito ver una foto de las manchas. Mientras tanto, riega por ' +
+      'la base y evita mojar las hojas.';
+    const out = guardDiagnosisWithoutPhoto(ok, {
+      userMessage: 'manchas en el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: manejo cultural genérico SIN patógeno ni binomio → no-op', () => {
+    const ok =
+      'Para que tu cultivo no se enferme, mejora el drenaje, no mojes las hojas al regar y deja ' +
+      'buena distancia entre plantas para que circule el aire.';
+    const out = guardDiagnosisWithoutPhoto(ok, {
+      userMessage: 'se me está secando la planta',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL anti-FP: pregunta de PREVENCIÓN ("cómo evito plagas") + biocontrol latino NO se suprime', () => {
+    // "cómo evito plagas" es prevención, no un síntoma a ciegas. La respuesta cita
+    // Bacillus thuringiensis (binomio legítimo de biocontrol) → NO debe suprimirse.
+    const ok = 'Para el gusano de la papa usa Bacillus thuringiensis y monitoreo del foco.';
+    const out = applyOutputGuards(ok, {
+      userMessage: 'cómo evito plagas en el maíz',
+      hadVision: false,
+    });
+    expect(out.reasons).not.toContain('diagnostico_sin_foto');
+    expect(out.text).toContain('Bacillus thuringiensis');
+  });
+
+  it('CONTROL anti-FP: "qué le echo para el gusano" (manejo) + biocontrol → no-op', () => {
+    const ok = 'Para el gusano de la papa usa Bacillus thuringiensis y monitoreo del foco.';
+    const out = guardDiagnosisWithoutPhoto(ok, {
+      userMessage: 'qué le echo a la papa para el gusano',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(false);
+  });
+
+  it('CONTROL: pregunta que NO es de síntomas (cosecha) → no-op aunque nombre un binomio', () => {
+    const resp =
+      'El tomate (Solanum lycopersicum) a 1923 msnm va bien bajo invernadero; cosechas en ~4 meses.';
+    const out = guardDiagnosisWithoutPhoto(resp, {
+      userMessage: 'cuándo cosecho el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(resp);
+  });
+
+  // ── Idempotencia + telemetría ────────────────────────────────────────────
+  it('idempotente: no re-suprime sobre su propio mensaje de reemplazo', () => {
+    const llmFail = 'Es tizón tardío (Phytophthora infestans), aplica fungicida.';
+    const ctx = { userMessage: 'manchas en el tomate', hadVision: false };
+    const first = guardDiagnosisWithoutPhoto(llmFail, ctx);
+    expect(first.modified).toBe(true);
+    const second = guardDiagnosisWithoutPhoto(first.text, ctx);
+    expect(second.modified).toBe(false);
+  });
+
+  it('emite telemetría diagnosis_without_photo', () => {
+    guardDiagnosisWithoutPhoto('Es alternaria, aplica clorotalonil.', {
+      userMessage: 'manchas en el tomate',
+      hadVision: false,
+    });
+    expect(getOutputGuardTelemetry().diagnosis_without_photo).toBe(1);
+  });
+
+  it('maneja entrada vacía / no-string', () => {
+    expect(
+      guardDiagnosisWithoutPhoto('', { userMessage: 'manchas', hadVision: false }).modified,
+    ).toBe(false);
+    expect(
+      guardDiagnosisWithoutPhoto(null, { userMessage: 'manchas', hadVision: false }).text,
+    ).toBe('');
+  });
+});
+
+describe('#348 applyOutputGuards — integración path PWA (síntoma vago sin foto)', () => {
+  it('"manchas amarillas en el tomate" sin foto → la salida final NO nombra patógeno y pide foto', () => {
+    const llmFail =
+      'Las manchas amarillas en el tomate son tizón temprano (Alternaria solani). Aplica mancozeb ' +
+      'cada 7 días.';
+    const out = applyOutputGuards(llmFail, {
+      userMessage: 'tengo manchas amarillas en el tomate',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reasons).toContain('diagnostico_sin_foto');
+    expect(out.text.toLowerCase()).not.toContain('alternaria');
+    expect(out.text).not.toMatch(/Alternaria\s+solani/);
+    expect(out.text).toMatch(/foto|c[aá]mara/i);
+  });
+
+  it('"se está secando" sin foto → diferencial + foto en la salida final', () => {
+    const llmFail = 'Se está secando por Phytophthora, un hongo de raíz. Aplica fungicida sistémico.';
+    const out = applyOutputGuards(llmFail, {
+      userMessage: 'se me está secando la planta, ayuda',
+      hadVision: false,
+    });
+    expect(out.modified).toBe(true);
+    expect(out.reasons).toContain('diagnostico_sin_foto');
+    expect(out.text.toLowerCase()).not.toContain('phytophthora');
+    expect(out.text).toMatch(/foto|c[aá]mara/i);
+  });
+
+  it('CONTROL integración: con foto (hadVision=true) NO suprime el diagnóstico', () => {
+    const ok =
+      'En la foto se ve tizón tardío (Phytophthora infestans) en las hojas. Retira focos y aplica ' +
+      'caldo bordelés.';
+    const out = applyOutputGuards(ok, {
+      userMessage: 'qué le pasa, mando foto',
+      hadVision: true,
+    });
+    // El guard de diagnóstico-sin-foto no debe disparar con foto real.
+    expect(out.reasons).not.toContain('diagnostico_sin_foto');
+  });
+});

--- a/src/services/__tests__/outputGuards.prodHarm.test.js
+++ b/src/services/__tests__/outputGuards.prodHarm.test.js
@@ -263,7 +263,7 @@ describe('#347 classifyQueryIntent — unidades de comercialización = precio', 
 // #348 — anti-diagnóstico-sin-foto
 // ──────────────────────────────────────────────────────────────────────────
 describe('#348 guardDiagnosisWithoutPhoto', () => {
-  it('"manchas en el tomate" SIN foto + lista de patógenos → antepone petición de foto/datos', () => {
+  it('"manchas en el tomate" SIN foto + lista de patógenos → SUPRIME el latín y pide foto', () => {
     const llmFail =
       'Las manchas en el tomate pueden ser tizón tardío (Phytophthora infestans), alternaria o ' +
       'septoria. Para el tizón aplica preventivos; para alternaria mejora la aireación.';
@@ -273,11 +273,11 @@ describe('#348 guardDiagnosisWithoutPhoto', () => {
     });
     expect(out.modified).toBe(true);
     expect(out.reason).toMatch(/diagnostico_sin_foto/);
-    // La petición de evidencia ENCABEZA la respuesta.
-    expect(out.text.indexOf('Antes de ponerle nombre')).toBe(0);
     expect(out.text).toMatch(/foto|c[aá]mara/i);
-    // La lista del modelo se conserva debajo (como referencia, no como diagnóstico).
-    expect(out.text).toMatch(/tiz[oó]n tard[ií]o/i);
+    // SUPPRESS-AND-REPLACE: el patógeno/binomio NO sobrevive (cambio vs append).
+    expect(out.text.toLowerCase()).not.toContain('phytophthora');
+    expect(out.text.toLowerCase()).not.toContain('septoria');
+    expect(out.text).not.toMatch(/tiz[oó]n tard[ií]o/i);
   });
 
   it('NO dispara cuando SÍ hubo foto (diagnóstico legítimo)', () => {
@@ -290,7 +290,7 @@ describe('#348 guardDiagnosisWithoutPhoto', () => {
     expect(out.modified).toBe(false);
   });
 
-  it('NO dispara si la respuesta NO enumera candidatos (solo pide foto / manejo cultural)', () => {
+  it('NO dispara si la respuesta NO nombra patógeno/binomio (solo pide foto / manejo cultural)', () => {
     const ok =
       'Para saber qué tiene tu tomate necesito ver una foto de las manchas. Mientras tanto, riega por ' +
       'la base y evita mojar las hojas.';
@@ -310,7 +310,7 @@ describe('#348 guardDiagnosisWithoutPhoto', () => {
     expect(out.modified).toBe(false);
   });
 
-  it('idempotente: no re-antepone la nota dos veces', () => {
+  it('idempotente: no re-suprime sobre su propio reemplazo dos veces', () => {
     const llmFail =
       'Las manchas pueden ser tizón tardío o alternaria. Revisa la aireación del cultivo.';
     const ctx = { userMessage: 'manchas en el tomate', hadVision: false };

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2806,11 +2806,22 @@ export function guardOffDomain(responseText, { userMessage = null } = {}) {
 const SYMPTOM_DIAG_INTENT_PATTERNS = [
   /\bmanch(a|as)\b/,
   /\bhojas?\s+(amarill|seca|negra|cafe|marchit|enroll|con\s+hueco)/,
-  /\bse\s+(esta\s+)?(secando|marchitando|muriendo|pudriendo|amarillando)\b/,
+  // "se está secando", "se me está secando", "se me secan", "se le marchitan":
+  // tolera el pronombre/clítico intermedio (me/le/te/nos) y la conjugación 3ª pl.
+  /\bse\s+(me\s+|le\s+|te\s+|nos\s+)?(esta(n)?\s+)?(secand|marchitand|muriend|pudriend|amarilland|enferman|enrollan|cae|caen|secan|marchitan|mueren|pudren)/,
   /\bqu[eé]\s+(tiene|le\s+pasa|enfermedad)\b/,
-  /\b(plaga|enfermedad|hongo|bicho|gusano)\b/,
+  // Un sustantivo de plaga/enfermedad cuenta como REPORTE DE SÍNTOMA solo cuando
+  // viene enmarcado como problema observado ("tiene un hongo", "le salió plaga",
+  // "tengo gusanos", "hay bicho", "con hongo"), NO en una pregunta de PREVENCIÓN
+  // o general ("cómo evito plagas", "qué plagas hay en el maíz") — esas no son un
+  // diagnóstico a ciegas y no deben suprimir biocontroles legítimos (Bt, etc.).
+  /\b(tiene|tengo|hay|salio|sali[oó]|le\s+salio|con|tiene\s+un[ao]?)\s+(un[ao]?\s+)?(plaga|enfermedad|hongo|bicho|gusano|pulgon|acaro)/,
+  /\b(plaga|enfermedad|hongo|bicho|gusano)s?\s+que\s+(no\s+conozco|no\s+s[eé]\s+qu[eé]|no\s+identifico)/,
   /\bpudric(ion|iones)\b/,
   /\bpuntos?\s+(negro|cafe|amarillo)/,
+  // síntomas vagos adicionales reportados en campo
+  /\bse\s+(esta\s+)?(poniend|volviend)\s+(amarill|negr|cafe|seca)/,
+  /\b(esta|se\s+ve)\s+(triste|mal|enferm|marchit|amarill|deca[ií]d)/,
 ];
 
 /** ¿La pregunta del usuario pide un diagnóstico de síntomas? */
@@ -2821,16 +2832,18 @@ function _isSymptomDiagnosisQuery(userMessage) {
 }
 
 /**
- * Nombres de patógenos/plagas frecuentes (normalizados) — si la respuesta
- * enumera ≥2, está dando un diagnóstico diferencial a ciegas. Lista corta de
- * los más nombrados en tomate/papa/hortalizas. No pretende ser exhaustiva: es
- * un detector de "lista de candidatos de enfermedad".
+ * Nombres de patógenos/plagas frecuentes (normalizados) — su sola presencia
+ * (≥1) en respuesta a un síntoma vago SIN foto ya es un diagnóstico a ciegas
+ * (el system prompt PROHÍBE nombrar un patógeno específico sin evidencia). Lista
+ * de los más nombrados en tomate/papa/hortalizas. No pretende ser exhaustiva —
+ * el detector de binomio latino (`_namesLatinBinomial`) cubre los que falten.
  */
 const PATHOGEN_NAME_TERMS = [
   'tizon tardio', 'tizon temprano', 'tizon', 'gota', 'alternaria', 'phytophthora',
   'fusarium', 'verticillium', 'botrytis', 'antracnosis', 'mildeo', 'mildiu', 'oidio',
   'cercospora', 'septoria', 'roya', 'virus del mosaico', 'mosca blanca', 'minador',
   'acaro', 'trips', 'pulgon', 'nematodo', 'bacteriosis', 'cancro', 'moho',
+  'golovinomyces', 'erysiphe', 'xanthomonas', 'pseudomonas', 'ralstonia',
 ];
 
 /** Fraseo de enumeración de candidatos ("puede ser X o Y", "podría tratarse de"). */
@@ -2838,17 +2851,93 @@ const DIFFERENTIAL_PHRASING_RE =
   /(puede\s+ser|podria\s+(ser|tratarse)|posibles?\s+(causa|enfermedad|patogeno|plaga)|entre\s+las?\s+(causa|enfermedad|posibilidad)|podria\s+deberse|se\s+trata\s+(probablemente\s+)?de)/;
 
 /**
- * guardDiagnosisWithoutPhoto — #348. Cuando la pregunta es de diagnóstico de
- * síntomas, NO hubo foto en el turno, y la respuesta enumera candidatos de
- * enfermedad/plaga (≥2 patógenos nombrados o fraseo diferencial), ANTEPONE una
- * nota pidiendo foto/datos. Así el campesino no trata a ciegas la enfermedad
- * equivocada. NO borra la respuesta del modelo (la lista puede orientar); la
- * encabeza con la petición de evidencia.
+ * #348 (hardening) — palabras españolas que, en MAYÚSCULA inicial (arranque de
+ * oración o conector), colisionan con "Género" de un binomio y producirían
+ * falsos positivos en `_namesLatinBinomial` ("Mientras tanto", "Para saber",
+ * "Una mancha", "Esas hojas"). Normalizadas sin tildes/case. NO son géneros
+ * latinos; si el "Género" candidato está acá, no cuenta como binomio.
+ */
+const BINOMIAL_GENUS_STOPWORDS = new Set([
+  'mientras', 'para', 'una', 'unas', 'unos', 'esas', 'esos', 'esta', 'este', 'estas',
+  'estos', 'eso', 'esto', 'cuando', 'donde', 'como', 'porque', 'aunque', 'tambien',
+  'ademas', 'luego', 'antes', 'despues', 'primero', 'segundo', 'tercero', 'mejor',
+  'revisa', 'aplica', 'mira', 'observa', 'cuenta', 'dime', 'manda', 'envia', 'toca',
+  'ahora', 'entonces', 'pero', 'sino', 'tienes', 'puedes', 'debes', 'nota', 'ojo',
+  'hola', 'bueno', 'vale', 'listo', 'tienen', 'suelen', 'algunas', 'algunos', 'muchas',
+  'muchos', 'todas', 'todos', 'ambas', 'ambos', 'otra', 'otras', 'otro', 'otros',
+  'segun', 'sobre', 'desde', 'hasta', 'entre', 'cada', 'siempre', 'nunca', 'casi',
+]);
+
+/**
+ * #348 (hardening) — ¿la respuesta NOMBRA un binomio latino (Género epíteto)?
+ * Un binomio científico en respuesta a un síntoma vago sin foto es un
+ * diagnóstico específico a ciegas aunque su nombre común no esté en la denylist
+ * (p.ej. "Cladosporium fulvum", "Alternaria solani"). Detector LOCAL no-stateful
+ * (no reusamos `SCI_BINOMIAL_RE` que es `/g` con estado compartido).
  *
- * GATING: requiere intención de diagnóstico en userMessage Y hadVision=false. Si
- * hubo foto, el diagnóstico es legítimo (no toca). Si la respuesta no enumera
- * candidatos (p. ej. ya pide foto, o solo da manejo cultural genérico), no-op.
- * Idempotente.
+ * Anti-falso-positivo (3 capas, para no marcar prosa española capitalizada):
+ *  1. el GÉNERO debe tener ≥4 letras (descarta "Un", "El", "Se", "Ya").
+ *  2. el EPÍTETO debe tener ≥4 letras minúsculas (descarta "Para no", "Una de").
+ *  3. el género (normalizado) NO puede ser una palabra española común de arranque
+ *     de oración/conector (`BINOMIAL_GENUS_STOPWORDS`): "Mientras tanto", "Para
+ *     saber", "Esas hojas" NO cuentan como binomio.
+ *
+ * @param {string} text  texto ORIGINAL (con mayúsculas/tildes, no normalizado).
+ * @returns {boolean}
+ */
+function _namesLatinBinomial(text) {
+  if (typeof text !== 'string' || !text) return false;
+  const re = /\b([A-Z][a-zé]{3,})\s+([a-zé]{4,})\b/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    const genus = _stripDiacritics(m[1]);
+    if (!BINOMIAL_GENUS_STOPWORDS.has(genus)) return true;
+  }
+  return false;
+}
+
+/**
+ * #348 (hardening, prod 2026-06-03 · RUNBOOK S5) — SUPPRESS-AND-REPLACE.
+ *
+ * Antes este guard ANTEPONÍA una nota pero dejaba el binomio latino y la receta
+ * de fungicida legibles debajo (el campesino igual los leía) y solo disparaba con
+ * ≥2 patógenos. Hueco real en prod: "manchas en el tomate" (sin foto) con UN
+ * patógeno confiado ("Es tizón tardío, Phytophthora infestans…") se escapaba, y
+ * cuando disparaba dejaba el latín. La regla del system prompt es categórica:
+ * sin foto NO se nombra un patógeno/binomio. Por eso ahora REEMPLAZAMOS el cuerpo
+ * por un diferencial sin latín + pedido de foto. Mismo patrón que #351b (receta
+ * sintética): cuando el cuerpo es intrínsecamente dañino, append-only no basta.
+ */
+const DIAGNOSIS_NEEDS_EVIDENCE_NOTE =
+  'Para no mandarte a tratar la enfermedad equivocada, necesito ver tu planta antes de ponerle nombre a lo que ' +
+  'tiene. Un síntoma como "manchas" o "se está secando" puede venir de varias causas — falta o exceso de agua, ' +
+  'falta de nutrientes en el suelo, un hongo, una plaga o sol muy fuerte — y sin verla no puedo asegurarte cuál ' +
+  'es.\n\n' +
+  'Ayúdame con esto y te doy un diagnóstico confiable:\n' +
+  '- Mándame una FOTO de la hoja o el fruto afectado (toca el botón de cámara). Si puedes, una de cerca y otra ' +
+  'de toda la planta.\n' +
+  '- ¿Qué planta es exactamente y hace cuánto empezó?\n' +
+  '- ¿De qué color es la mancha, está en el haz (arriba) o el envés (abajo) de la hoja, se siente seca o con ' +
+  'humedad?\n' +
+  '- ¿Empezó por las hojas de abajo o de arriba, y cómo ha estado el clima (lluvia, sol fuerte, friajes)?\n\n' +
+  'Con eso sí te puedo decir con seguridad qué es y cómo manejarlo de forma agroecológica.';
+
+/**
+ * guardDiagnosisWithoutPhoto — #348. Cuando la pregunta reporta un SÍNTOMA VAGO,
+ * NO hubo foto en el turno, y la respuesta nombra un patógeno/binomio específico
+ * (≥1 nombre de patógeno, un binomio latino, o fraseo diferencial enumerando
+ * candidatos), SUPRIME el cuerpo y lo REEMPLAZA por un diferencial en lenguaje
+ * sencillo (sin latín) + pedido de foto/datos. Así el campesino no trata a ciegas
+ * la enfermedad equivocada.
+ *
+ * Dispara aunque la pregunta mencione un CULTIVO genérico ("tomate"): nombrar el
+ * cultivo no hace diagnosticable un síntoma vago — la regla del system prompt
+ * (DIAGNÓSTICO-SIN-EVIDENCIA) prohíbe el patógeno/binomio sin foto igual.
+ *
+ * GATING: requiere intención de diagnóstico de síntoma en userMessage Y
+ * hadVision=false. Si hubo foto, el diagnóstico es legítimo (no toca). Si la
+ * respuesta no nombra patógeno/binomio (ya pide foto o da manejo cultural
+ * genérico sin latín), no-op. Idempotente.
  *
  * Firma propia (necesita userMessage + hadVision) → se invoca aparte en
  * applyOutputGuards, no dentro de GUARD_CHAIN.
@@ -2857,12 +2946,6 @@ const DIFFERENTIAL_PHRASING_RE =
  * @param {{userMessage?: string|null, hadVision?: boolean}} [ctx]
  * @returns {{text:string, modified:boolean, reason:string|null}}
  */
-const DIAGNOSIS_NEEDS_EVIDENCE_NOTE =
-  'Antes de ponerle nombre a lo que tiene tu cultivo necesito verlo: con solo "manchas" puedo equivocarme y ' +
-  'mandarte a tratar la enfermedad que no es. Mándame una foto (toca el botón de cámara) de la hoja o el fruto ' +
-  'afectado, y cuéntame: ¿de qué color son las manchas, son secas o con humedad, empezaron por las hojas de ' +
-  'abajo o de arriba, hace cuánto y con qué clima? Con eso sí te doy un diagnóstico confiable.';
-
 export function guardDiagnosisWithoutPhoto(
   responseText,
   { userMessage = null, hadVision = false } = {},
@@ -2874,25 +2957,31 @@ export function guardDiagnosisWithoutPhoto(
   if (hadVision || !_isSymptomDiagnosisQuery(userMessage)) {
     return { text: responseText, modified: false, reason: null };
   }
-  // Idempotencia: la nota ya está.
-  if (/Antes de ponerle nombre a lo que tiene tu cultivo/i.test(responseText)) {
+  // Idempotencia: el mensaje de reemplazo ya está (no re-suprimir).
+  if (/Para no mandarte a tratar la enfermedad equivocada/i.test(responseText)) {
     return { text: responseText, modified: false, reason: null };
   }
   const norm = _stripDiacritics(responseText);
-  // ¿La respuesta enumera candidatos de enfermedad/plaga? (≥2 patógenos nombrados
-  // o fraseo diferencial). Solo así anteponemos la petición de evidencia: una
-  // respuesta que ya pide la foto o solo da manejo cultural no se toca.
-  const patho = new Set();
+  // ¿La respuesta nombra un patógeno/binomio específico? Basta UNA señal:
+  //   (a) ≥1 nombre de patógeno de la denylist,
+  //   (b) un binomio latino (Género epíteto), o
+  //   (c) fraseo diferencial enumerando candidatos.
+  // Un solo patógeno confiado ("es tizón tardío") es el caso MÁS dañino: manda
+  // a tratar a ciegas con plena seguridad. Una respuesta que solo da manejo
+  // cultural genérico (sin patógeno ni latín) NO entra acá.
+  let nombraPatogeno = false;
   for (const term of PATHOGEN_NAME_TERMS) {
-    if (norm.includes(term)) patho.add(term);
+    if (norm.includes(term)) { nombraPatogeno = true; break; }
   }
-  const enumeraCandidatos = patho.size >= 2 || DIFFERENTIAL_PHRASING_RE.test(norm);
-  if (!enumeraCandidatos) {
+  const especifica =
+    nombraPatogeno || _namesLatinBinomial(responseText) || DIFFERENTIAL_PHRASING_RE.test(norm);
+  if (!especifica) {
     return { text: responseText, modified: false, reason: null };
   }
   bumpGuardTelemetry('diagnosis_without_photo');
-  const text = `${DIAGNOSIS_NEEDS_EVIDENCE_NOTE}\n\n${responseText.trim()}`;
-  return { text, modified: true, reason: 'diagnostico_sin_foto' };
+  // SUPPRESS-AND-REPLACE: descartamos el cuerpo (con su binomio/receta) y
+  // devolvemos SOLO el diferencial sin latín + pedido de foto.
+  return { text: DIAGNOSIS_NEEDS_EVIDENCE_NOTE, modified: true, reason: 'diagnostico_sin_foto' };
 }
 
 // ── GUARD: viabilidad FALSO-NEGATIVO (cultivo viable marcado inviable) ──────
@@ -3255,17 +3344,19 @@ export function applyOutputGuards(
     if (vis.reason) reasons.push(vis.reason);
   }
 
-  // GUARD anti-diagnóstico-a-ciegas (#348): si la pregunta pide diagnóstico de
-  // síntomas ("manchas en el tomate") SIN foto y la respuesta enumera candidatos
-  // de patógeno, ANTEPONE la petición de foto/datos. Va tras el guard de visión
-  // (que cubre el caso distinto de afirmar haber VISTO una foto). Firma propia
-  // (userMessage + hadVision). Solo actúa si el de visión no reemplazó ya el texto.
+  // GUARD anti-diagnóstico-a-ciegas (#348): si la pregunta reporta un síntoma
+  // VAGO ("manchas en el tomate", "se está secando") SIN foto y la respuesta
+  // nombra un patógeno/binomio específico, SUPRIME el cuerpo y lo REEMPLAZA por un
+  // diferencial sin latín + pedido de foto/datos. Va tras el guard de visión (que
+  // cubre el caso distinto de afirmar haber VISTO una foto). Firma propia
+  // (userMessage + hadVision). Solo corre si el de visión no reemplazó ya el texto.
+  // Como REEMPLAZA el texto entero por la petición de evidencia, no tiene sentido
+  // correr los demás guards (no queda cultivo/patógeno/receta que razonar) →
+  // early-return, igual que off-domain y visión-sin-foto.
   if (!(vis && vis.modified)) {
     const dx = guardDiagnosisWithoutPhoto(text, { userMessage, hadVision });
     if (dx && dx.modified) {
-      text = dx.text;
-      modified = true;
-      if (dx.reason) reasons.push(dx.reason);
+      return { text: dx.text, modified: true, reasons: dx.reason ? [dx.reason] : [] };
     }
   }
 


### PR DESCRIPTION
## Problema (#348, RUNBOOK-NOCTURNO S5)

El guard `guardDiagnosisWithoutPhoto` (de #1280) estaba **mergeado pero no actuaba** en el path PWA real. En prod (Choachí, 2026-06-03), Q6 "manchas en el tomate" sin foto seguía nombrando patógenos con binomio latino y receta de fungicida, sin pedir la foto — patrón recurrente "guard mergeado pero no dispara en el path PWA".

El wiring en `applyOutputGuards` (con `userMessage` + `hadVision`) **sí estaba correcto**. El hueco eran las **condiciones del guard**, en dos frentes:

1. **Condición demasiado estrecha.** Solo disparaba con ≥2 patógenos o fraseo "puede ser X o Y". Un diagnóstico **confiado con un solo patógeno** ("Es tizón tardío, *Phytophthora infestans*, aplica…") —el caso **más dañino**, manda a tratar a ciegas con plena seguridad— se le escapaba. Un binomio latino cuyo nombre común no estaba en la denylist tampoco contaba.

2. **Append, no suppress.** Anteponía una nota pero dejaba el binomio latino y la receta legibles debajo. El campesino igual los leía. La regla del system prompt (`REGLA CRÍTICA DIAGNÓSTICO-SIN-EVIDENCIA`) es categórica: sin foto **NO** se nombra un patógeno/binomio.

## Fix

- **Suppress-and-replace** (igual que el guard de fertilizante sintético #351b): cuando hay síntoma vago sin foto y la respuesta nombra un patógeno/binomio, se **descarta el cuerpo** y se reemplaza por un **diferencial en lenguaje sencillo (sin latín)** + pedido de foto/datos.
- **Disparador ampliado**: basta **una** señal — ≥1 patógeno de la denylist, un **binomio latino** (detector local con 3 capas anti-falso-positivo + stopwords de prosa española), o fraseo diferencial.
- **Dispara aunque la pregunta mencione un cultivo genérico** ("tomate"): nombrar el cultivo no hace diagnosticable un síntoma vago.
- **Gating conservador anti-falso-positivo**: el sustantivo de plaga/enfermedad solo cuenta como reporte de síntoma cuando va enmarcado como problema observado ("tiene un hongo"), **no** en preguntas de prevención ("cómo evito plagas") — para no suprimir biocontroles legítimos (Bt, etc.). `applyOutputGuards` hace early-return tras la supresión.

## Tests (TDD)

- **14 tests nuevos** (`outputGuards.diagnosisSuppress.test.js`): suppress de un-patógeno-confiado, "se está secando", binomio suelto fuera de denylist, lista ≥2, + controles (con foto → diagnostica; ya pide foto → no-op; manejo cultural → no-op; **prevención + biocontrol → no-op**; cosecha → no-op) + idempotencia + telemetría.
- **6 tests prodHarm actualizados** al nuevo comportamiento (append → suppress).
- **3121 unit tests verdes**, 0 fallos. Lint limpio en los archivos tocados.

## Notas

- Sin cambios en theming/App/CSS ni scripts de bench.
- `eslint .` reporta 1 error preexistente en `AIStatusFooter.jsx` / `useIdleDetection.js` (idénticos a `origin/main`, no tocados por este PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)