### PR TITLE
test(bench): fix judge pipeline to score REAL data + adversarial border bench

### DIFF
--- a/scripts/__tests__/bench-judge-wiring.test.mjs
+++ b/scripts/__tests__/bench-judge-wiring.test.mjs
@@ -1,0 +1,182 @@
+/**
+ * scripts/__tests__/bench-judge-wiring.test.mjs
+ *
+ * TDD del FIX del pipeline judge (2026-06-03). El bug: bench-llm-judge.mjs
+ * evaluaba MOCK data aunque bench-agente-completo.mjs le pasara el JSONL real,
+ * por TRES fallas:
+ *   1. `--from <path>` (separado por espacio) no se parseaba (solo `--from=path`).
+ *   2. auto-discovery solo globeaba `.json`, pero el bench escribe `.jsonl`.
+ *   3. el formato del JSONL real (per-model anidado, sin ground_truth ni
+ *      model_response plano) no se transformaba a items evaluables.
+ *
+ * Estos tests cubren las funciones PURAS exportadas por bench-llm-judge.mjs
+ * tras el refactor (parseFromArg, loadBenchData con .jsonl, normalizeBenchData).
+ */
+import { describe, it, expect } from 'vitest';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  parseFromArg,
+  loadBenchData,
+  normalizeBenchData,
+} from '../bench-llm-judge.mjs';
+
+describe('parseFromArg — acepta --from path Y --from=path', () => {
+  it('parsea --from <path> separado por espacio (como lo invoca el bench)', () => {
+    const argv = ['node', 'bench-llm-judge.mjs', '--from', '/data/run.jsonl'];
+    expect(parseFromArg(argv)).toBe('/data/run.jsonl');
+  });
+
+  it('parsea --from=<path> con igual', () => {
+    const argv = ['node', 'bench-llm-judge.mjs', '--from=/data/run.jsonl'];
+    expect(parseFromArg(argv)).toBe('/data/run.jsonl');
+  });
+
+  it('devuelve null si no hay --from', () => {
+    const argv = ['node', 'bench-llm-judge.mjs', '--judge'];
+    expect(parseFromArg(argv)).toBeNull();
+  });
+
+  it('no confunde --from con el flag siguiente', () => {
+    const argv = ['node', 'bench-llm-judge.mjs', '--from', '--other'];
+    // --from sin valor (lo siguiente es otro flag) → null, no '--other'.
+    expect(parseFromArg(argv)).toBeNull();
+  });
+});
+
+describe('normalizeBenchData — transforma el JSONL real del bench a items evaluables', () => {
+  // Una línea del JSONL que escribe bench-agente-completo.mjs: per-model anidado,
+  // sin ground_truth ni model_response plano.
+  const benchLine = {
+    prompt_id: 1,
+    category: 'species',
+    query: '¿Qué cuidados requiere la fresa en clima frío?',
+    expected_keywords: ['drenaje', 'riego', 'heladas', 'poda'],
+    timestamp: '2026-06-03T00:00:00.000Z',
+    granite3_1_8b: {
+      model: 'granite3.1-dense:8b',
+      response: 'La fresa necesita buen drenaje y protección contra heladas.',
+      keywords_matched: 3,
+      keywords_total: 4,
+      halluc_count: 0,
+      error: null,
+    },
+    winner: 'granite3_1_8b',
+  };
+
+  it('extrae la respuesta del modelo objetivo (granite por defecto) a model_response', () => {
+    const norm = normalizeBenchData([benchLine]);
+    expect(norm.results).toHaveLength(1);
+    const item = norm.results[0];
+    expect(item.model_response).toBe(
+      'La fresa necesita buen drenaje y protección contra heladas.',
+    );
+    expect(item.query).toBe('¿Qué cuidados requiere la fresa en clima frío?');
+    expect(item.id).toBe(1);
+  });
+
+  it('deriva ground_truth de los expected_keywords cuando no hay uno explícito', () => {
+    const norm = normalizeBenchData([benchLine]);
+    const item = norm.results[0];
+    // El ground_truth debe mencionar los conceptos esperados (guía del juez).
+    expect(item.ground_truth).toContain('drenaje');
+    expect(item.ground_truth).toContain('heladas');
+  });
+
+  it('propaga expected_keywords y halluc_count del sidecar al item', () => {
+    const norm = normalizeBenchData([benchLine]);
+    const item = norm.results[0];
+    expect(item.expected_keywords).toEqual(['drenaje', 'riego', 'heladas', 'poda']);
+    expect(item.sidecar_halluc_count).toBe(0);
+  });
+
+  it('respeta TARGET_MODEL para elegir qué modelo evaluar', () => {
+    const multi = {
+      ...benchLine,
+      gemma3_4b: { model: 'gemma3:4b', response: 'Respuesta de gemma.', error: null },
+    };
+    const norm = normalizeBenchData([multi], { targetModel: 'gemma3:4b' });
+    expect(norm.results[0].model_response).toBe('Respuesta de gemma.');
+  });
+
+  it('omite items donde el modelo objetivo falló (error != null) sin crashear', () => {
+    const errored = {
+      ...benchLine,
+      granite3_1_8b: { model: 'granite3.1-dense:8b', response: null, error: 'Timeout' },
+    };
+    const norm = normalizeBenchData([errored]);
+    expect(norm.results).toHaveLength(0);
+    expect(norm.skipped).toBe(1);
+  });
+
+  it('pasa por alto datos ya en formato judge (model_response plano)', () => {
+    const flat = {
+      id: 7,
+      query: '¿Test?',
+      ground_truth: 'Respuesta correcta.',
+      model_response: 'Respuesta similar.',
+    };
+    const norm = normalizeBenchData([flat]);
+    expect(norm.results[0].model_response).toBe('Respuesta similar.');
+    expect(norm.results[0].ground_truth).toBe('Respuesta correcta.');
+  });
+});
+
+describe('loadBenchData — lee el JSONL real, NO cae a mock cuando --from existe', () => {
+  it('carga un .jsonl per-model y lo normaliza (no mock)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bench-judge-'));
+    try {
+      const path = join(dir, 'agente-completo-2026-06-03.jsonl');
+      const lines = [
+        JSON.stringify({
+          prompt_id: 1,
+          category: 'species',
+          query: '¿Cuidados de la fresa?',
+          expected_keywords: ['drenaje', 'heladas'],
+          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'Buen drenaje.', error: null },
+        }),
+        JSON.stringify({
+          prompt_id: 2,
+          category: 'species',
+          query: '¿Roya del café?',
+          expected_keywords: ['variedades resistentes'],
+          granite3_1_8b: { model: 'granite3.1-dense:8b', response: 'Variedades resistentes.', error: null },
+        }),
+      ];
+      writeFileSync(path, lines.join('\n') + '\n');
+
+      const data = loadBenchData(path);
+      expect(data.results).toHaveLength(2);
+      expect(data.results[0].model_response).toBe('Buen drenaje.');
+      expect(data.usedMock).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('lanza (no usa mock silencioso) si --from apunta a un archivo inexistente', () => {
+    expect(() => loadBenchData('/no/existe/jamas.jsonl')).toThrow();
+  });
+
+  it('carga un .json single-object con results[] sin normalizar de más', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'bench-judge-'));
+    try {
+      const path = join(dir, 'legacy.json');
+      const payload = {
+        timestamp: '2026-06-03T00:00:00.000Z',
+        model: 'granite3.1-dense:8b',
+        results: [
+          { id: 1, query: '¿Q?', ground_truth: 'GT.', model_response: 'R.' },
+        ],
+      };
+      writeFileSync(path, JSON.stringify(payload));
+      const data = loadBenchData(path);
+      expect(data.results).toHaveLength(1);
+      expect(data.results[0].model_response).toBe('R.');
+      expect(data.usedMock).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/bench-agente-completo.mjs
+++ b/scripts/bench-agente-completo.mjs
@@ -45,7 +45,9 @@ import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
 const DATA_DIR = join(ROOT_DIR, 'data');
-const BENCH_RUNS_DIR = join(DATA_DIR, 'bench-runs');
+// BENCH_OUTPUT_DIR permite PERSISTIR los resultados FUERA del worktree efímero
+// (p. ej. al repo principal), para que sobrevivan al cleanup del worktree.
+const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(DATA_DIR, 'bench-runs');
 
 const SIDECAR_URL = process.env.SIDECAR_URL || 'http://localhost:7880';
 const OLLAMA_URL = 'http://localhost:11434/api/chat';

--- a/scripts/bench-borde-alucinacion.mjs
+++ b/scripts/bench-borde-alucinacion.mjs
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+/**
+ * bench-borde-alucinacion.mjs — busca el BORDE de alucinación de granite3.1-dense:8b
+ * a CONFIG-PROD, con JUEZ FUERTE INDEPENDIENTE (claude-cli, Claude Code subscription).
+ *
+ * Por qué existe (2026-06-03): el bench-agente-completo medía cobertura por
+ * keywords y su juez corría sobre MOCK; bench-complejos usaba juez local roto en
+ * Maxwell o el scorer determinístico (que no detecta alucinaciones semánticas).
+ * Este script cierra el bucle de medición REAL:
+ *
+ *   GENERADOR (config-PROD = ROUTES.chat_complex de llmRouter):
+ *     granite3.1-dense:8b, temp 0.3, seed fijo, max_tokens 768.
+ *     Pipeline real: resolve-entities (AGE) → enriched system prompt →
+ *     applyOutputGuards (guards deterministas de prod) → post-validate (sidecar).
+ *
+ *   JUEZ (fuerte, independiente, NO auto-eval):
+ *     selectJudgeProvider('claude-cli') → Claude Code (-p) BATCH. No requiere
+ *     API key (suscripción del operador). Métrica AH: PASS solo si TODOS los
+ *     must_include cubiertos por FONDO Y CERO red_flags. SECUENCIAL (un solo
+ *     claude-code a la vez — límite de alpha).
+ *     Si claude-cli no está → degrada al scorer DETERMINÍSTICO (substring) y lo
+ *     ANOTA en el summary (limitación explícita, no número inflado).
+ *
+ *   FIXTURE (prompts adversariales — el borde):
+ *     deepresearch/TEST_PROMPTS_BORDE_ALUCINACION_2026-06-03.json (12 prompts):
+ *     confusión tóxica (yuca brava→cianuro), homonimia misma-especie (lulo==
+ *     naranjilla), dosis específicas de biopreparados, viabilidad por altitud en
+ *     casos límite, precio+clima combinados, multi-hop, y trampas que TIENTAN al
+ *     modelo a inventar dosis/agroquímicos/variedades.
+ *
+ * Output (persistible FUERA del worktree con BENCH_OUTPUT_DIR):
+ *   <dir>/borde-alucinacion-YYYY-MM-DD.jsonl
+ *   <dir>/borde-alucinacion-YYYY-MM-DD.summary.json
+ *
+ * Uso:
+ *   node scripts/bench-borde-alucinacion.mjs                         # juez claude-cli (default)
+ *   JUDGE_PROVIDER=deterministic node scripts/bench-borde-alucinacion.mjs   # sin GPU del juez
+ *   BENCH_OUTPUT_DIR=/repo/data/bench-runs node scripts/bench-borde-alucinacion.mjs
+ *   PROMPTS_FILE=/ruta/otra.json node scripts/bench-borde-alucinacion.mjs
+ */
+import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { performance } from 'node:perf_hooks';
+import { execSync } from 'node:child_process';
+import {
+  scoreAntiHallucBatch,
+  scoreAntiHallucDeterministic,
+  selectJudgeProvider,
+} from './lib/bench-scorer.mjs';
+import { assertCheckoutCurrent } from './lib/bench-checkout-guard.mjs';
+import { applyOutputGuards } from '../src/services/outputGuards.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..');
+// BENCH_OUTPUT_DIR persiste FUERA del worktree efímero (al repo principal).
+const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(ROOT_DIR, 'data', 'bench-runs');
+
+// ── generador config-PROD (= ROUTES.chat_complex de llmRouter.js) ─────────────
+const GEN_MODEL = process.env.GEN_MODEL || 'granite3.1-dense:8b';
+const GEN_TEMPERATURE = 0.3; // PROD. NO 0.7.
+const GEN_MAX_TOKENS = 768; // chat_complex
+const SEED = Number(process.env.SEED || 42);
+
+// ── juez fuerte: claude-cli por defecto; degrada a determinístico ─────────────
+const JUDGE = selectJudgeProvider({
+  provider: process.env.JUDGE_PROVIDER || 'claude-cli',
+});
+
+const SIDECAR_URL = process.env.SIDECAR_URL || 'http://localhost:7880';
+const OLLAMA_CHAT_URL = 'http://localhost:11434/api/chat';
+const GEN_TIMEOUT_MS = 180_000;
+
+const PROMPTS_FILE =
+  process.env.PROMPTS_FILE ||
+  '/home/kortux/Workspace/Chagra-strategy/deepresearch/TEST_PROMPTS_BORDE_ALUCINACION_2026-06-03.json';
+
+// Tamaño de lote para el juez claude-cli (un spawn por lote, secuencial).
+const JUDGE_BATCH_SIZE = Number(process.env.JUDGE_BATCH_SIZE || 6);
+
+const GPU_TEMP_LIMIT = 88;
+const GPU_TEMP_RESUME = 75;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function getSidecarToken() {
+  const tokenPath = `${process.env.HOME}/.config/chagra-sidecar-token.txt`;
+  if (existsSync(tokenPath)) return readFileSync(tokenPath, 'utf-8').trim();
+  return process.env.SIDECAR_TOKEN || '';
+}
+
+function gpuTemp() {
+  try {
+    const out = execSync('nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits', {
+      encoding: 'utf-8',
+      timeout: 8000,
+    });
+    const t = parseInt(out.trim().split('\n')[0], 10);
+    return Number.isFinite(t) ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function thermalGuard() {
+  let t = gpuTemp();
+  if (t == null) return;
+  while (t >= GPU_TEMP_LIMIT) {
+    console.log(`  [thermal] GPU ${t}°C ≥ ${GPU_TEMP_LIMIT}°C — pausando 30s hasta ≤${GPU_TEMP_RESUME}°C`);
+    await sleep(30_000);
+    t = gpuTemp();
+    if (t == null) return;
+    if (t <= GPU_TEMP_RESUME) break;
+  }
+}
+
+async function resolveEntities(userMessage) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${SIDECAR_URL}/resolve-entities`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return { entities: [] };
+    const data = await res.json();
+    return { entities: data.entities || [] };
+  } catch (err) {
+    console.log(`    [resolve-entities] ${err.message.slice(0, 60)}`);
+    return { entities: [] };
+  }
+}
+
+async function postValidate(userMessage, response) {
+  const token = getSidecarToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+  try {
+    const res = await fetch(`${SIDECAR_URL}/post-validate`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ user_message: userMessage, response }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) return { hallucinated: [], detected_count: 0, age_available: false };
+    const data = await res.json();
+    return {
+      hallucinated: data.hallucinated || [],
+      detected_count: data.detected_count || 0,
+      age_available: Boolean(data.age_available),
+    };
+  } catch {
+    return { hallucinated: [], detected_count: 0, age_available: false };
+  }
+}
+
+function buildEnrichedSystemPrompt(entities) {
+  const basePrompt = `Eres un asistente agroecológico experto para Colombia. Responde en español claro, práctico para agricultores.
+
+Si mencionas entidades (especies, plagas, biopreparados), usa los nombres canónicos del catálogo Chagra para evitar alucinaciones.`;
+  if (!entities || entities.length === 0) return basePrompt;
+  const entityContext = entities
+    .map((e) => {
+      if (e.kind === 'species') return `- ${e.mentioned} = especie: ${e.nombre_cientifico} (${e.nombre_comun})`;
+      if (e.kind === 'pest') return `- ${e.mentioned} = plaga: ${e.nombre_cientifico || e.nombre_comun}`;
+      if (e.kind === 'biopreparado') return `- ${e.mentioned} = biopreparado: ${e.nombre_comun}`;
+      return null;
+    })
+    .filter(Boolean)
+    .join('\n');
+  return `${basePrompt}
+
+ENTIDADES DEL CATÁLOGO (usa estos nombres canónicos):
+${entityContext}`;
+}
+
+async function generate(systemPrompt, userPrompt) {
+  const start = performance.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GEN_TIMEOUT_MS);
+  try {
+    const res = await fetch(OLLAMA_CHAT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: GEN_MODEL,
+        stream: false,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        options: { temperature: GEN_TEMPERATURE, seed: SEED, num_predict: GEN_MAX_TOKENS },
+        keep_alive: '30m',
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`gen HTTP ${res.status}`);
+    const data = await res.json();
+    return { response: data.message?.content || '', latency_ms: performance.now() - start };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  assertCheckoutCurrent({
+    cwd: ROOT_DIR,
+    autoPull: process.env.BENCH_AUTO_PULL === '1',
+    skip: process.env.BENCH_SKIP_STALE_GUARD === '1',
+  });
+
+  const fixture = JSON.parse(readFileSync(PROMPTS_FILE, 'utf-8'));
+  const prompts = fixture.prompts || [];
+
+  console.log('[bench-borde] BORDE de alucinación — generador config-prod + juez fuerte');
+  console.log(`[bench-borde] generador: ${GEN_MODEL} temp=${GEN_TEMPERATURE} seed=${SEED} max_tokens=${GEN_MAX_TOKENS}`);
+  console.log(`[bench-borde] juez:      ${JUDGE.judgeModel} (provider=${JUDGE.provider}, deterministic=${JUDGE.deterministic})`);
+  console.log(`[bench-borde] fixture:   ${PROMPTS_FILE.split('/').pop()} (${prompts.length} prompts)`);
+  console.log(`[bench-borde] output:    ${BENCH_RUNS_DIR}`);
+  console.log(`[bench-borde] GPU temp inicial: ${gpuTemp() ?? 'n/d'}°C`);
+
+  if (!existsSync(BENCH_RUNS_DIR)) mkdirSync(BENCH_RUNS_DIR, { recursive: true });
+
+  // ── Fase 1: GENERAR todas las respuestas (granite) ──────────────────────────
+  const generated = [];
+  for (let i = 0; i < prompts.length; i++) {
+    const p = prompts[i];
+    console.log(`\n[gen ${i + 1}/${prompts.length}] ${p.id} (${p.region}/${p.complexity}): ${p.prompt.slice(0, 56)}...`);
+    await thermalGuard();
+
+    const { entities } = await resolveEntities(p.prompt);
+    const systemPrompt = buildEnrichedSystemPrompt(entities);
+
+    let gen;
+    try {
+      gen = await generate(systemPrompt, p.prompt);
+    } catch (err) {
+      console.log(`    GEN ERROR: ${err.message}`);
+      generated.push({ p, entities, error: err.message });
+      continue;
+    }
+
+    const guarded = applyOutputGuards(gen.response, { resolvedEntities: entities, profileName: null });
+    const finalText = guarded.text;
+    const validation = await postValidate(p.prompt, finalText);
+
+    console.log(
+      `    gen ${(gen.latency_ms / 1000).toFixed(1)}s  entities=${entities.length}  ` +
+        `guards=${guarded.modified ? guarded.reasons.join(',') : 'none'}  sidecar_halluc=${validation.detected_count}`,
+    );
+
+    generated.push({ p, entities, gen, finalText, guarded, validation });
+    await sleep(1500);
+  }
+
+  // ── Fase 2: JUZGAR (batch claude-cli, secuencial) ───────────────────────────
+  const judgeItems = generated
+    .filter((g) => !g.error)
+    .map((g) => ({
+      id: g.p.id,
+      query: g.p.prompt,
+      response: g.finalText,
+      mustInclude: g.p.must_include,
+      redFlags: g.p.red_flags,
+      shouldInclude: g.p.should_include,
+    }));
+
+  const verdictById = new Map();
+  if (JUDGE.deterministic) {
+    console.log(`\n[bench-borde] juez DETERMINÍSTICO (sin claude-cli) — limitación: no detecta alucinación semántica fina.`);
+    for (const it of judgeItems) {
+      const v = scoreAntiHallucDeterministic(it);
+      verdictById.set(it.id, { ...v, source: 'deterministic' });
+    }
+  } else {
+    console.log(`\n[bench-borde] juzgando ${judgeItems.length} respuestas con ${JUDGE.judgeModel} en lotes de ${JUDGE_BATCH_SIZE} (secuencial)...`);
+    for (let i = 0; i < judgeItems.length; i += JUDGE_BATCH_SIZE) {
+      const batch = judgeItems.slice(i, i + JUDGE_BATCH_SIZE);
+      const t0 = performance.now();
+      const verdicts = await scoreAntiHallucBatch(batch, { judgeCall: JUDGE.judgeCall });
+      console.log(`  lote ${i / JUDGE_BATCH_SIZE + 1}: ${batch.length} items en ${((performance.now() - t0) / 1000).toFixed(1)}s`);
+      for (const v of verdicts) verdictById.set(v.id, v);
+    }
+  }
+
+  // ── Fase 3: armar resultados + summary ──────────────────────────────────────
+  const results = [];
+  let pass = 0;
+  let fail = 0;
+  let unjudged = 0;
+
+  for (const g of generated) {
+    if (g.error) {
+      results.push({ id: g.p.id, region: g.p.region, error: g.error });
+      unjudged++;
+      continue;
+    }
+    const v = verdictById.get(g.p.id) || { pass: null, source: 'unjudged' };
+    const verdict = v.source === 'unjudged' || v.pass == null ? 'UNJUDGED' : v.pass ? 'PASS' : 'FAIL';
+    if (verdict === 'PASS') pass++;
+    else if (verdict === 'FAIL') fail++;
+    else unjudged++;
+
+    console.log(
+      `  ${verdict.padEnd(8)} ${g.p.id} (${g.p.region}/${g.p.axes ? g.p.axes[0] : '?'})  ` +
+        `must=${v.mustCovered ?? '?'}/${v.mustTotal ?? g.p.must_include?.length ?? '?'} red_flags_hit=${v.redFlagsHit ?? '?'} ` +
+        `sidecar_halluc=${g.validation.detected_count}`,
+    );
+
+    results.push({
+      id: g.p.id,
+      region: g.p.region,
+      axes: g.p.axes,
+      complexity: g.p.complexity,
+      prompt: g.p.prompt,
+      entities_grounded: g.entities.length,
+      generator: { model: GEN_MODEL, temperature: GEN_TEMPERATURE, seed: SEED, max_tokens: GEN_MAX_TOKENS },
+      raw_response: g.gen.response,
+      guarded_response: g.finalText,
+      guards_modified: g.guarded.modified,
+      guards_reasons: g.guarded.reasons,
+      sidecar_hallucinated: g.validation.hallucinated,
+      sidecar_halluc_count: g.validation.detected_count,
+      age_available: g.validation.age_available,
+      judge: { model: JUDGE.judgeModel, provider: JUDGE.provider, source: v.source },
+      ah_pass: v.pass,
+      ah_must_covered: v.mustCovered,
+      ah_must_total: v.mustTotal ?? (g.p.must_include ? g.p.must_include.length : null),
+      ah_red_flags_hit: v.redFlagsHit,
+      latency_gen_ms: g.gen.latency_ms,
+    });
+  }
+
+  const judged = pass + fail;
+  const ahPct = judged > 0 ? (100 * pass) / judged : 0;
+
+  // AH% por eje (primer axis) y por región, para localizar el borde.
+  const byAxis = {};
+  const byRegion = {};
+  for (const r of results) {
+    if (r.ah_pass == null) continue;
+    const axis = (r.axes && r.axes[0]) || 'sin_eje';
+    byAxis[axis] = byAxis[axis] || { pass: 0, total: 0 };
+    byAxis[axis].total++;
+    if (r.ah_pass) byAxis[axis].pass++;
+    const reg = r.region || 'sin_region';
+    byRegion[reg] = byRegion[reg] || { pass: 0, total: 0 };
+    byRegion[reg].total++;
+    if (r.ah_pass) byRegion[reg].pass++;
+  }
+
+  const dateStr = new Date().toISOString().split('T')[0];
+  const jsonlPath = join(BENCH_RUNS_DIR, `borde-alucinacion-${dateStr}.jsonl`);
+  const summaryPath = join(BENCH_RUNS_DIR, `borde-alucinacion-${dateStr}.summary.json`);
+
+  writeFileSync(jsonlPath, results.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    generator: { model: GEN_MODEL, temperature: GEN_TEMPERATURE, seed: SEED, max_tokens: GEN_MAX_TOKENS, config: 'PROD (llmRouter chat_complex)' },
+    judge: { model: JUDGE.judgeModel, provider: JUDGE.provider, independent: !JUDGE.deterministic },
+    fixture: PROMPTS_FILE,
+    n_prompts: prompts.length,
+    pass,
+    fail,
+    unjudged,
+    judged,
+    ah_pct: Number(ahPct.toFixed(1)),
+    by_axis: Object.fromEntries(
+      Object.entries(byAxis).map(([k, v]) => [k, { pass: v.pass, total: v.total, ah_pct: Number(((100 * v.pass) / v.total).toFixed(1)) }]),
+    ),
+    by_region: Object.fromEntries(
+      Object.entries(byRegion).map(([k, v]) => [k, { pass: v.pass, total: v.total, ah_pct: Number(((100 * v.pass) / v.total).toFixed(1)) }]),
+    ),
+    failed: results.filter((r) => r.ah_pass === false).map((r) => ({ id: r.id, axes: r.axes, red_flags_hit: r.ah_red_flags_hit, must: `${r.ah_must_covered}/${r.ah_must_total}` })),
+    unjudged_ids: results.filter((r) => r.judge && r.judge.source === 'unjudged').map((r) => r.id),
+  };
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + '\n');
+
+  console.log('\n══════════════════════════════════════════════════');
+  console.log(`RESULTADO  PASS=${pass}  FAIL=${fail}  UNJUDGED=${unjudged}  (juzgados=${judged})`);
+  console.log(`AH% (juez ${JUDGE.provider}, config-prod) = ${ahPct.toFixed(1)}%`);
+  console.log(`Por eje:    ${JSON.stringify(summary.by_axis)}`);
+  console.log(`JSONL:   ${jsonlPath}`);
+  console.log(`SUMMARY: ${summaryPath}`);
+  console.log('══════════════════════════════════════════════════');
+}
+
+const INVOKED_DIRECTLY = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (INVOKED_DIRECTLY) {
+  main().catch((err) => {
+    console.error('FATAL:', err.message);
+    process.exit(1);
+  });
+}
+
+export { main };

--- a/scripts/bench-complejos-juez-independiente.mjs
+++ b/scripts/bench-complejos-juez-independiente.mjs
@@ -51,7 +51,9 @@ import { applyOutputGuards } from '../src/services/outputGuards.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
-const BENCH_RUNS_DIR = join(ROOT_DIR, 'data', 'bench-runs');
+// BENCH_OUTPUT_DIR permite PERSISTIR los resultados FUERA del worktree efímero
+// (p. ej. al repo principal), para que sobrevivan al cleanup del worktree.
+const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(ROOT_DIR, 'data', 'bench-runs');
 
 // ── config-prod del generador (= ROUTES.chat_complex de llmRouter.js) ─────────
 const GEN_MODEL = process.env.GEN_MODEL || 'granite3.1-dense:8b';

--- a/scripts/bench-llm-judge.mjs
+++ b/scripts/bench-llm-judge.mjs
@@ -12,13 +12,26 @@
  *
  * Uso:
  *   node scripts/bench-llm-judge.mjs                  # smoke con datos mock
- *   node scripts/bench-llm-judge.mjs --from data/bench-runs/results.json
+ *   node scripts/bench-llm-judge.mjs --from data/bench-runs/results.jsonl
+ *   node scripts/bench-llm-judge.mjs --from=data/bench-runs/results.jsonl
  *
  * Output: data/bench-judge-scores/{YYYY-MM-DD}.jsonl + summary.md
  *
+ * FIX 2026-06-03 (pipeline-rework): el judge corría sobre MOCK aunque el bench
+ * le pasara el JSONL real, por TRES fallas que este módulo arregla:
+ *   1. `--from <path>` (separado por espacio, como lo invoca bench-agente-completo)
+ *      no se parseaba — solo `--from=path`. Ahora parseFromArg cubre ambos.
+ *   2. auto-discovery solo globeaba `.json`; el bench escribe `.jsonl`. Ahora
+ *      loadBenchData reconoce ambos y prioriza el más reciente.
+ *   3. el JSONL real es per-model anidado (sin ground_truth ni model_response
+ *      plano). normalizeBenchData lo transforma a items evaluables tomando la
+ *      respuesta del modelo objetivo (TARGET_MODEL, default granite) y derivando
+ *      un ground_truth de los expected_keywords cuando no hay uno explícito.
+ *   + Si `--from` apunta a un archivo inexistente, se LANZA (no mock silencioso).
+ *
  * Smoke con 10 prompts vs granite/llama/gemma.
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { performance } from 'node:perf_hooks';
@@ -26,12 +39,28 @@ import { performance } from 'node:perf_hooks';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
 const DATA_DIR = join(ROOT_DIR, 'data');
-const BENCH_RUNS_DIR = join(DATA_DIR, 'bench-runs');
-const OUTPUT_DIR = join(DATA_DIR, 'bench-judge-scores');
+const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(DATA_DIR, 'bench-runs');
+const OUTPUT_DIR = process.env.BENCH_JUDGE_OUTPUT_DIR || join(DATA_DIR, 'bench-judge-scores');
 
 const OLLAMA_URL = 'http://localhost:11434/api/generate';
 const JUDGE_MODEL = process.env.JUDGE_MODEL || 'gemma3:4b';
 const TIMEOUT_MS = 60_000;
+
+// Modelo cuyo turno se evalúa cuando el JSONL es per-model (bench-agente-completo).
+// Default granite3.1-dense:8b = el chat de PROD (llmRouter chat_complex).
+const TARGET_MODEL = process.env.TARGET_MODEL || 'granite3.1-dense:8b';
+
+// Mapa modelKey (clave del objeto per-model en el JSONL) → nombre ollama, para
+// poder seleccionar por nombre real del modelo cuando TARGET_MODEL es un nombre.
+const MODEL_KEY_BY_NAME = {
+  'gemma3:4b': 'gemma3_4b',
+  'granite3.1-dense:8b': 'granite3_1_8b',
+  'ministral-3:latest': 'ministral_3b',
+  'aya:8b': 'aya_8b',
+  'mistral-nemo:12b': 'mistral_nemo_12b',
+  'ministral-3:14b': 'ministral_14b',
+  'qwen3:30b': 'qwen3_30b',
+};
 
 // Prompts mock para el smoke test si no hay datos reales
 const MOCK_BENCH_DATA = {
@@ -162,25 +191,223 @@ IMPORTANTE: Tu respuesta debe ser ÚNICAMENTE un JSON con esta estructura exacta
 
 Sin texto adicional, solo el JSON.`;
 
-function loadBenchData(fromPath) {
-  if (fromPath && existsSync(fromPath)) {
-    const raw = readFileSync(fromPath, 'utf-8');
-    return JSON.parse(raw);
+/**
+ * parseFromArg — extrae el path de `--from`. Acepta DOS formas:
+ *   - `--from <path>` (separado por espacio) → la forma que usa el bench.
+ *   - `--from=<path>` (con igual).
+ * Devuelve null si no hay `--from` o si lo que sigue es otro flag.
+ *
+ * @param {string[]} argv  típicamente process.argv.
+ * @returns {string|null}
+ */
+export function parseFromArg(argv = process.argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--from') {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) return next;
+      return null;
+    }
+    if (a.startsWith('--from=')) {
+      const v = a.slice('--from='.length);
+      return v.length > 0 ? v : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * derivedGroundTruth — cuando el bench NO trae un ground_truth explícito (el
+ * caso de bench-agente-completo, que solo tiene expected_keywords), arma una
+ * referencia legible para el juez a partir de los conceptos esperados. No es una
+ * verdad canónica perfecta, pero ancla al juez en los conceptos correctos en vez
+ * de dejarlo sin referencia.
+ *
+ * @param {string[]} keywords
+ * @returns {string}
+ */
+function derivedGroundTruth(keywords) {
+  const kw = Array.isArray(keywords) ? keywords.filter(Boolean) : [];
+  if (kw.length === 0) return '';
+  return `Una respuesta correcta debe cubrir, por fondo: ${kw.join(', ')}.`;
+}
+
+/**
+ * pickModelKey — elige la clave per-model del objeto del JSONL para el modelo
+ * objetivo. Acepta un nombre ollama (granite3.1-dense:8b) o ya una clave
+ * (granite3_1_8b). Devuelve la clave si está presente en el item, o null.
+ *
+ * @param {Record<string, any>} item
+ * @param {string} target
+ * @returns {string|null}
+ */
+function pickModelKey(item, target) {
+  const asKey = MODEL_KEY_BY_NAME[target] || target;
+  if (item[asKey] && typeof item[asKey] === 'object') return asKey;
+  // fallback: buscar cualquier sub-objeto cuyo .model coincida con el nombre.
+  for (const [k, v] of Object.entries(item)) {
+    if (v && typeof v === 'object' && v.model === target) return k;
+  }
+  return null;
+}
+
+/**
+ * normalizeBenchData — transforma las líneas del JSONL del bench a un payload
+ * `{ timestamp, model, results: [...] }` con items PLANOS evaluables por el juez
+ * ({ id, query, ground_truth, model_response, ... }).
+ *
+ * Maneja tres formas de entrada por item:
+ *   (a) per-model anidado (bench-agente-completo): toma `item[modelKey].response`
+ *       del modelo objetivo; deriva ground_truth de expected_keywords.
+ *   (b) ya-plano formato judge (model_response o response + ground_truth): pasa.
+ *   (c) modelo objetivo con error → se OMITE (no se evalúa una no-respuesta).
+ *
+ * @param {Array<Record<string,any>>} lines
+ * @param {{ targetModel?: string }} [opts]
+ * @returns {{ timestamp:string, model:string, results:Array, skipped:number }}
+ */
+export function normalizeBenchData(lines, { targetModel = TARGET_MODEL } = {}) {
+  const arr = Array.isArray(lines) ? lines : [];
+  const results = [];
+  let skipped = 0;
+
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') {
+      skipped++;
+      continue;
+    }
+
+    // (b) ya está en formato judge plano.
+    const flatResponse = item.model_response ?? item.response;
+    const isFlat = typeof flatResponse === 'string' && !pickModelKey(item, targetModel);
+    if (isFlat) {
+      results.push({
+        id: item.id ?? item.prompt_id ?? results.length + 1,
+        category: item.category,
+        query: item.query,
+        ground_truth: item.ground_truth ?? derivedGroundTruth(item.expected_keywords),
+        model_response: flatResponse,
+        expected_keywords: item.expected_keywords ?? [],
+        sidecar_halluc_count: item.sidecar_halluc_count ?? item.halluc_count ?? null,
+      });
+      continue;
+    }
+
+    // (a) per-model anidado.
+    const key = pickModelKey(item, targetModel);
+    if (!key) {
+      skipped++;
+      continue;
+    }
+    const m = item[key];
+    if (m.error || typeof m.response !== 'string' || m.response.length === 0) {
+      skipped++;
+      continue;
+    }
+    results.push({
+      id: item.prompt_id ?? item.id ?? results.length + 1,
+      category: item.category,
+      query: item.query,
+      ground_truth: item.ground_truth ?? derivedGroundTruth(item.expected_keywords),
+      model_response: m.response,
+      expected_keywords: item.expected_keywords ?? [],
+      sidecar_halluc_count: m.halluc_count ?? null,
+    });
   }
 
-  // Buscar archivos en data/bench-runs/
+  return {
+    timestamp: new Date().toISOString(),
+    model: targetModel,
+    results,
+    skipped,
+  };
+}
+
+/**
+ * loadBenchData — carga datos de bench y los normaliza a `{ results, ... }`.
+ *
+ * Orden de resolución:
+ *   1. `fromPath` explícito. Si NO existe → LANZA (NO mock silencioso: el bug
+ *      original enmascaraba un path roto evaluando mock).
+ *   2. Si no hay fromPath, auto-discovery en data/bench-runs/ del más reciente
+ *      `.jsonl`/`.json` (por mtime). El bench escribe `.jsonl`.
+ *   3. Si no hay nada → mock (solo el smoke test sin args).
+ *
+ * Soporta JSONL (varias líneas) y JSON (un objeto `{ results: [...] }`).
+ * Marca `usedMock` para que el caller pueda distinguir.
+ *
+ * @param {string|null} fromPath
+ * @returns {{ timestamp:string, model:string, results:Array, usedMock:boolean, skipped?:number, source?:string }}
+ */
+export function loadBenchData(fromPath) {
+  if (fromPath) {
+    if (!existsSync(fromPath)) {
+      throw new Error(
+        `[judge] --from apunta a un archivo inexistente: ${fromPath}. ` +
+          `NO se cae a mock para no enmascarar un path roto.`,
+      );
+    }
+    return { ...parseBenchFile(fromPath), usedMock: false, source: fromPath };
+  }
+
+  // Auto-discovery: el más reciente .jsonl o .json en bench-runs/.
   if (existsSync(BENCH_RUNS_DIR)) {
-    const files = readdirSync(BENCH_RUNS_DIR).filter((f) => f.endsWith('.json'));
-    if (files.length > 0) {
-      const latest = files.sort().reverse()[0];
-      const raw = readFileSync(join(BENCH_RUNS_DIR, latest), 'utf-8');
-      return JSON.parse(raw);
+    const candidates = readdirSync(BENCH_RUNS_DIR)
+      .filter((f) => f.endsWith('.jsonl') || f.endsWith('.json'))
+      .map((f) => {
+        const full = join(BENCH_RUNS_DIR, f);
+        let mtime = 0;
+        try {
+          mtime = statSync(full).mtimeMs;
+        } catch {
+          /* ignore */
+        }
+        return { full, mtime };
+      })
+      .sort((a, b) => b.mtime - a.mtime);
+    if (candidates.length > 0) {
+      const latest = candidates[0].full;
+      return { ...parseBenchFile(latest), usedMock: false, source: latest };
     }
   }
 
-  // Si no hay datos, usar mock
   console.log('[judge] No se encontraron datos de bench, usando mock data (smoke test)');
-  return MOCK_BENCH_DATA;
+  return { ...MOCK_BENCH_DATA, usedMock: true, source: 'mock' };
+}
+
+/**
+ * parseBenchFile — lee un archivo de bench (.jsonl o .json), detecta el formato
+ * y devuelve `{ timestamp, model, results, skipped }` normalizado.
+ *
+ * @param {string} path
+ * @returns {{ timestamp:string, model:string, results:Array, skipped:number }}
+ */
+function parseBenchFile(path) {
+  const raw = readFileSync(path, 'utf-8');
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { timestamp: new Date().toISOString(), model: TARGET_MODEL, results: [], skipped: 0 };
+
+  // JSONL: varias líneas, cada una un objeto. Detecta por ≥2 líneas JSON o
+  // por extensión .jsonl.
+  const lines = trimmed.split('\n').filter((l) => l.trim().length > 0);
+  const looksJsonl = path.endsWith('.jsonl') || lines.length > 1;
+
+  if (looksJsonl) {
+    const parsed = lines.map((l) => JSON.parse(l));
+    // Si ya viene en formato judge `{ results: [...] }` por línea, aplanar.
+    if (parsed.length === 1 && Array.isArray(parsed[0].results)) {
+      return normalizeBenchData(parsed[0].results);
+    }
+    return normalizeBenchData(parsed);
+  }
+
+  // JSON: un objeto. Puede ser `{ results: [...] }` (judge) o un único item.
+  const obj = JSON.parse(trimmed);
+  if (Array.isArray(obj.results)) {
+    const norm = normalizeBenchData(obj.results);
+    return { ...norm, timestamp: obj.timestamp ?? norm.timestamp, model: obj.model ?? norm.model };
+  }
+  return normalizeBenchData([obj]);
 }
 
 async function callJudge(prompt, signal) {
@@ -283,12 +510,20 @@ async function main() {
   console.log(`[judge] Modelo juez: ${JUDGE_MODEL}`);
   console.log(`[judge] Directorio output: ${OUTPUT_DIR}`);
 
-  const fromPath = process.argv.find((arg) => arg.startsWith('--from'))?.split('=')[1] || null;
+  const fromPath = parseFromArg(process.argv);
   const benchData = loadBenchData(fromPath);
 
+  console.log(`[judge] Fuente: ${benchData.source || 'N/A'}${benchData.usedMock ? ' (MOCK — smoke test)' : ' (datos REALES)'}`);
+  if (typeof benchData.skipped === 'number' && benchData.skipped > 0) {
+    console.log(`[judge] Items omitidos (modelo objetivo con error/sin respuesta): ${benchData.skipped}`);
+  }
   console.log(`[judge] Datos cargados: ${benchData.results.length} items`);
   console.log(`[judge] Timestamp bench: ${benchData.timestamp}`);
   console.log(`[judge] Modelo evaluado: ${benchData.model || 'N/A'}`);
+
+  if (benchData.results.length === 0) {
+    throw new Error('[judge] 0 items evaluables tras normalizar. Revisá el JSONL de origen / TARGET_MODEL.');
+  }
 
   const results = [];
   const startTime = performance.now();
@@ -395,7 +630,13 @@ ${successful.map((s) => {
   console.log(`[judge]   Summary: ${summaryPath}`);
 }
 
-main().catch((err) => {
-  console.error('[judge] FATAL:', err);
-  process.exit(1);
-});
+// Solo auto-ejecuta cuando se invoca directamente (no al importar en tests).
+const INVOKED_DIRECTLY = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (INVOKED_DIRECTLY) {
+  main().catch((err) => {
+    console.error('[judge] FATAL:', err);
+    process.exit(1);
+  });
+}
+
+export { main };


### PR DESCRIPTION
## Qué

Repara el pipeline bench → juez para que el LLM-judge puntúe **datos REALES** (no el mock) y agrega un bench adversarial que busca el **borde de alucinación** de granite3.1-dense:8b a config de producción.

### Bug raíz (3 fallas que hacían que el juez puntuara MOCK)
1. `--from <path>` (separado por espacio) no se parseaba — solo `--from=path`.
2. Auto-discovery solo globeaba `.json`, pero el bench escribe `.jsonl`.
3. El JSONL real (per-model anidado, sin `ground_truth` ni `model_response` plano) no se transformaba a items evaluables.

### Cambios
- **`bench-llm-judge.mjs`**: `parseFromArg` acepta ambas formas; `loadBenchData` prioriza el `.jsonl/.json` más reciente por mtime y **lanza** si `--from` apunta a un archivo inexistente (no mock silencioso); `normalizeBenchData` transforma el per-model anidado a items con `ground_truth` derivado de `expected_keywords`; `main()` solo auto-ejecuta si se invoca directo (importable por tests); `BENCH_OUTPUT_DIR`/`BENCH_JUDGE_OUTPUT_DIR` persisten fuera del worktree efímero.
- **`bench-borde-alucinacion.mjs`** (nuevo): pipeline real (resolve-entities AGE → enriched prompt → applyOutputGuards → post-validate) + juez independiente claude-cli. Métrica AH = must_include por fondo + cero red_flags; reporta AH% por eje y región.
- **`bench-agente-completo` / `bench-complejos`**: `BENCH_OUTPUT_DIR` para persistir fuera del worktree.

### Tests (TDD test-first)
`scripts/__tests__/bench-judge-wiring.test.mjs` — 13 casos sobre las funciones puras (`parseFromArg`, `loadBenchData` con `.jsonl`, `normalizeBenchData`). **13/13 verdes** (`vitest run`). Lint `eslint . --max-warnings=0` limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)