### PR TITLE
feat(agent): saludo proactivo dinámico de entrada del agente

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.39",
+  "version": "1.0.40",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v297';
+const CACHE_NAME = 'chagra-v298';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -72,7 +72,14 @@ import DeepResearchCard from '../DeepResearchCard';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity } from '../../services/agentService';
 import { applyOutputGuards, applyTaxonomyGuard, classifyQueryIntent } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
-import { regionFromProfile } from '../../services/ensoContext';
+import { regionFromProfile, getEnsoOutlook } from '../../services/ensoContext';
+// SALUDO PROACTIVO (#162 alertas + #298 tareas + #331 análisis): el agente, de
+// entrada, lidera con lo MÁS importante (1-2 pendientes) si los hay, o da una
+// idea contextual (cultivo/clima/temporada) sin inventar alarmas. Lógica pura
+// y testeable extraída a proactiveGreeting; aquí solo la hidratamos desde los
+// stores en vivo y la pintamos en el empty-state del chat.
+import { resolveProactiveGreeting } from '../../services/proactiveGreeting';
+import useLogStore from '../../store/useLogStore';
 // Bug UX 2026-05-30: preservar respuesta parcial ante abort/timeout/cancel.
 // La lógica pura del merge del estado final vive en agentPartialMerge (testeable
 // sin montar el componente).
@@ -194,6 +201,11 @@ export default function AgentScreen({ onBack, initialContext }) {
   // informe oficial. El banner es dismissable — al primer submit, o cuando
   // el operador cierra, desaparece. NO se persiste entre mounts.
   const [alertContextBanner, setAlertContextBanner] = useState(null);
+  // SALUDO PROACTIVO: objeto {hi, state, lead, items, restCount, prompt} que el
+  // empty-state del chat pinta de entrada. Se resuelve UNA vez al montar (lee
+  // alertas + tareas + clima/cultivos) y solo se muestra mientras el chat esté
+  // vacío e idle. null mientras no haya resuelto (fallback al copy estático).
+  const [proactiveGreeting, setProactiveGreeting] = useState(null);
   // CHIPS DE MODO (A4): modo activo seleccionado en la ChipsToolbar. Cuando
   // hay un modo activo, el siguiente submit fuerza esa intención y rutea
   // DIRECTO al tool determinístico (saltando el NLU, A3). El placeholder del
@@ -392,6 +404,49 @@ export default function AgentScreen({ onBack, initialContext }) {
       }
     });
     return () => { alive = false; };
+  }, []);
+
+  // SALUDO PROACTIVO de entrada: resolvemos el saludo dinámico al montar. Lee
+  // alertas activas (alertEngine #162), tareas pendientes (#298 via logStore),
+  // y deriva una idea contextual de cultivos/clima/temporada cuando NO hay nada
+  // urgente. Local-only, una sola vez (NO quema GPU ni red por refresh). Si todo
+  // falla, queda null y el empty-state cae al copy estático.
+  useEffect(() => {
+    let alive = true;
+    const stripPlantNumber = (name) => (name || '').replace(/\s*#\d+\s*$/, '').trim();
+    const grouped = Object.entries(
+      (plants || []).reduce((acc, p) => {
+        const base = stripPlantNumber(p.attributes?.name);
+        if (base) acc[base] = (acc[base] || 0) + 1;
+        return acc;
+      }, {}),
+    ).map(([name, count]) => ({ name, count }));
+    const finca = fincas.find((f) => f.slug === activeFincaSlug);
+    const climaSnapshot = getCachedClimaSnapshot();
+    let ensoOutlook = null;
+    try {
+      const phase = climaSnapshot?.enso_status?.phase;
+      if (phase) {
+        const region = regionFromProfile(getProfile());
+        const probs = climaSnapshot?.enso_status?.ideam_probabilities
+          || climaSnapshot?.enso_status?.ideam_probabilidades
+          || null;
+        ensoOutlook = getEnsoOutlook({ phase, region, probabilities: probs });
+      }
+    } catch (_) { /* sin ENSO no pasa nada — la idea cae a temporada/piso */ }
+    resolveProactiveGreeting({
+      activeAlerts,
+      getPendingTasks: () => useLogStore.getState().getPendingTasks(),
+      cultivos: grouped,
+      altitud: finca?.altitud != null ? Number(finca.altitud) : null,
+      ensoOutlook,
+    }).then((g) => {
+      if (alive) setProactiveGreeting(g);
+    }).catch(() => { /* degrada silencioso al copy estático */ });
+    return () => { alive = false; };
+    // Solo al montar: el saludo es la primera impresión, no debe re-evaluarse en
+    // cada cambio de inventario/alerta mientras el operador ya está leyéndolo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // 2026-05-28: aplicar initialContext de notificación climática.
@@ -2673,6 +2728,8 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         onConsentNeeded={handleFeedbackConsentNeeded}
         onRetryOrphan={handleRetryOrphan}
         onCancelDeepResearch={handleCancelDeepResearch}
+        proactiveGreeting={proactiveGreeting}
+        onGreetingPrompt={(prompt) => prompt && setInputText(prompt)}
       />
 
       {/* Error */}

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -3,7 +3,7 @@ import ChatBubble from './ChatBubble';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import DeepResearchCard from '../DeepResearchCard';
 
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, proactiveGreeting = null, onGreetingPrompt }) {
   const bottomRef = useRef(null);
 
   useEffect(() => {
@@ -14,13 +14,24 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
   // libando en su tamaño más grande de toda la app (size=200). El header
   // ya tiene una versión chiquita (size=40) — acá vive en grande, como
   // primera impresión del agente.
+  //
+  // SALUDO PROACTIVO (#162/#298/#331): si AgentScreen ya resolvió el saludo
+  // dinámico, lideramos con lo clave (1-2 pendientes) o con una idea contextual.
+  // El resto de pendientes vive en la campana/panel — NO los listamos todos
+  // aquí. Si el saludo aún no resolvió, caemos al copy estático de siempre.
   if (messages.length === 0 && !isStreaming) {
     return (
-      <div className="flex-1 flex items-center justify-center p-6">
-        <div className="text-center">
+      <div className="flex-1 flex flex-col items-center justify-center p-6">
+        <div className="text-center max-w-md">
           <ChagraAgentAvatar state="idle" size={200} className="mx-auto mb-4" />
-          <p className="text-slate-200 text-base mb-2 font-medium">¡Hola! Soy tu asistente agroecológico.</p>
-          <p className="text-slate-500 text-xs">Puedes hablarme o escribirme sobre tus plantas.</p>
+          {proactiveGreeting ? (
+            <ProactiveGreeting greeting={proactiveGreeting} onPrompt={onGreetingPrompt} />
+          ) : (
+            <>
+              <p className="text-slate-200 text-base mb-2 font-medium">¡Hola! Soy tu asistente agroecológico.</p>
+              <p className="text-slate-500 text-xs">Puedes hablarme o escribirme sobre tus plantas.</p>
+            </>
+          )}
         </div>
       </div>
     );
@@ -113,6 +124,72 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
       )}
 
       <div ref={bottomRef} />
+    </div>
+  );
+}
+
+/**
+ * ProactiveGreeting — el saludo de entrada DINÁMICO del agente. Lidera con lo
+ * clave: si state==='pending' muestra 1-2 pendientes destacados (la alerta/tarea
+ * top) + un hint de cuántos más hay en la campana; si state==='idea' muestra
+ * una idea contextual sin inventar alarmas. CTA siembra el prompt sugerido en
+ * el input (el operador revisa y envía — no auto-submit).
+ */
+function ProactiveGreeting({ greeting, onPrompt }) {
+  if (!greeting) return null;
+  const { hi, state, lead, items = [], restCount = 0, prompt } = greeting;
+  const isPending = state === 'pending';
+  return (
+    <div data-testid="proactive-greeting" data-greeting-state={state}>
+      <p className="text-slate-200 text-base mb-1.5 font-medium">
+        {hi}. Soy <span className="text-emerald-300">Chagra</span>.
+      </p>
+      <p
+        className="text-slate-300 text-sm leading-relaxed mb-3"
+        data-testid="proactive-greeting-lead"
+      >
+        {lead}
+      </p>
+
+      {isPending && items.length > 0 && (
+        <ul className="text-left space-y-1.5 mb-3" data-testid="proactive-greeting-items">
+          {items.map((it, i) => (
+            <li
+              key={i}
+              className={`flex items-start gap-2 px-2.5 py-1.5 rounded-lg border text-xs ${
+                it.kind === 'alert'
+                  ? 'bg-rose-500/10 border-rose-600/30 text-rose-100'
+                  : 'bg-amber-500/10 border-amber-600/30 text-amber-100'
+              }`}
+            >
+              <span aria-hidden className="shrink-0">{it.icon}</span>
+              <span className="flex-1 min-w-0">
+                <span className="font-medium">{it.title}</span>
+                {it.due && <span className="block opacity-80 text-[11px] mt-0.5">{it.due}</span>}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {isPending && restCount > 0 && (
+        <p className="text-[11px] text-slate-500 mb-3" data-testid="proactive-greeting-rest">
+          {restCount === 1
+            ? 'Hay 1 pendiente más en la campana 🔔.'
+            : `Hay ${restCount} pendientes más en la campana 🔔.`}
+        </p>
+      )}
+
+      {prompt && typeof onPrompt === 'function' && (
+        <button
+          type="button"
+          onClick={() => onPrompt(prompt)}
+          data-testid="proactive-greeting-cta"
+          className="text-xs px-3 py-1.5 rounded-full bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-600/30 text-cyan-100 transition-colors active:scale-95"
+        >
+          {prompt}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/AgentScreen/__tests__/ChatHistory.greeting.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatHistory.greeting.test.jsx
@@ -1,0 +1,73 @@
+/**
+ * ChatHistory.greeting.test.jsx — render del SALUDO PROACTIVO en el empty-state.
+ *
+ * Verifica el cableado visual de la primera impresión del agente:
+ *   - CON pendientes → lidera nombrando la alerta/tarea top + hint del resto.
+ *   - SIN pendientes → idea contextual, sin pintar ítems de alarma.
+ *   - Sin saludo resuelto → cae al copy estático de siempre (backward compat).
+ *   - CTA siembra el prompt sugerido (no auto-submit).
+ *
+ * La LÓGICA del saludo se prueba en services/__tests__/proactiveGreeting.test.js.
+ * Aquí solo probamos que ChatHistory lo renderiza fiel a los datos.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi } from 'vitest';
+import ChatHistory from '../ChatHistory';
+
+// El avatar trae assets/animaciones que no aportan al test del saludo.
+vi.mock('../../ChagraAgentAvatar', () => ({ default: () => <div data-testid="avatar-mock" /> }));
+
+describe('ChatHistory — saludo proactivo (empty state)', () => {
+  it('CON pendientes: lidera nombrando la alerta top y muestra el ítem', () => {
+    const greeting = {
+      hi: 'Buenos días',
+      state: 'pending',
+      lead: 'Ojo: Riesgo de helada esta noche (hoy, 2–6 a.m.). Te lo dejo de primero para que no se pase.',
+      items: [{ kind: 'alert', icon: '❄️', title: 'Riesgo de helada esta noche', due: 'Hoy, 2–6 a.m.' }],
+      restCount: 2,
+      prompt: '¿Qué hago con la alerta de mi finca?',
+    };
+    render(<ChatHistory messages={[]} proactiveGreeting={greeting} />);
+    expect(screen.getByTestId('proactive-greeting')).toHaveAttribute('data-greeting-state', 'pending');
+    expect(screen.getByTestId('proactive-greeting-lead')).toHaveTextContent('Riesgo de helada esta noche');
+    expect(screen.getByTestId('proactive-greeting-items')).toHaveTextContent('Riesgo de helada esta noche');
+    // El resto va a la campana, no se listan todos.
+    expect(screen.getByTestId('proactive-greeting-rest')).toHaveTextContent('2 pendientes más');
+  });
+
+  it('SIN pendientes: idea contextual, sin ítems de alarma', () => {
+    const greeting = {
+      hi: 'Buenas tardes',
+      state: 'idea',
+      lead: 'Todo tranquilo por ahora. Como estamos en segunda temporada seca, es buena semana para revisar tu papa. ¿Te armo un plan?',
+      items: [],
+      restCount: 0,
+      prompt: 'Dame un resumen del estado de mi finca hoy.',
+    };
+    render(<ChatHistory messages={[]} proactiveGreeting={greeting} />);
+    expect(screen.getByTestId('proactive-greeting')).toHaveAttribute('data-greeting-state', 'idea');
+    expect(screen.getByTestId('proactive-greeting-lead')).toHaveTextContent('Todo tranquilo por ahora');
+    // No hay lista de pendientes ni hint de resto en estado idea.
+    expect(screen.queryByTestId('proactive-greeting-items')).toBeNull();
+    expect(screen.queryByTestId('proactive-greeting-rest')).toBeNull();
+  });
+
+  it('CTA siembra el prompt sugerido (no auto-submit)', () => {
+    const onGreetingPrompt = vi.fn();
+    const greeting = {
+      hi: 'Buenos días', state: 'idea', lead: 'Todo tranquilo por ahora.', items: [], restCount: 0,
+      prompt: 'Dame un resumen del estado de mi finca hoy.',
+    };
+    render(<ChatHistory messages={[]} proactiveGreeting={greeting} onGreetingPrompt={onGreetingPrompt} />);
+    fireEvent.click(screen.getByTestId('proactive-greeting-cta'));
+    expect(onGreetingPrompt).toHaveBeenCalledWith('Dame un resumen del estado de mi finca hoy.');
+  });
+
+  it('sin saludo resuelto → copy estático de siempre (backward compat)', () => {
+    render(<ChatHistory messages={[]} proactiveGreeting={null} />);
+    expect(screen.queryByTestId('proactive-greeting')).toBeNull();
+    expect(screen.getByText(/Soy tu asistente agroecológico/i)).toBeInTheDocument();
+  });
+});

--- a/src/services/__tests__/proactiveGreeting.test.js
+++ b/src/services/__tests__/proactiveGreeting.test.js
@@ -1,0 +1,204 @@
+/**
+ * proactiveGreeting.test.js
+ *
+ * Saludo proactivo de entrada del agente (operador 2026-06-03):
+ *   - CON pendientes → el saludo LIDERA con lo más importante (1-2 cosas) y
+ *     NOMBRA la alerta/tarea top. El resto queda como conteo para la campana.
+ *   - SIN pendientes → da una IDEA contextual (cultivo/clima/temporada) y NUNCA
+ *     inventa una alarma (no aparece "helada", "riego", "vencida", etc.).
+ *
+ * Reusa la lógica de AnalisisProactivoIA (#331) + alertEngine (#162) +
+ * getPendingTasks (#298) extraída a un builder puro.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildProactiveGreeting, resolveProactiveGreeting } from '../proactiveGreeting.js';
+
+// Fecha fija (martes 3 jun 2026, 8 a.m.) → "Buenos días" + temporada seca media.
+const MORNING = new Date('2026-06-03T08:00:00');
+
+describe('buildProactiveGreeting — CON pendientes (lidera con lo clave)', () => {
+  it('nombra la alerta top (helada danger) en el lead', () => {
+    const g = buildProactiveGreeting({
+      activeAlerts: [
+        { type: 'helada', severity: 'danger', title: 'Riesgo de helada esta noche', due: 'Hoy, 2–6 a.m.' },
+      ],
+      pendingTasks: [],
+      date: MORNING,
+    });
+    expect(g.state).toBe('pending');
+    expect(g.lead).toContain('Riesgo de helada esta noche');
+    expect(g.items).toHaveLength(1);
+    expect(g.items[0].kind).toBe('alert');
+    expect(g.items[0].icon).toBe('❄️');
+  });
+
+  it('prioriza danger sobre warning y destaca máximo 2, deja el resto en restCount', () => {
+    const g = buildProactiveGreeting({
+      activeAlerts: [
+        { type: 'lluvia', severity: 'warning', title: 'Lluvia fuerte mañana' },
+        { type: 'helada', severity: 'danger', title: 'Helada esta noche' },
+        { type: 'viento', severity: 'info', title: 'Viento moderado' },
+      ],
+      pendingTasks: [],
+      date: MORNING,
+    });
+    expect(g.items).toHaveLength(2);
+    // La danger va primero.
+    expect(g.items[0].title).toBe('Helada esta noche');
+    expect(g.lead).toContain('Helada esta noche');
+    // La tercera no se muestra en el lead, queda contada.
+    expect(g.restCount).toBe(1);
+  });
+
+  it('detecta tarea VENCIDA por timestamp y la nombra con su atraso', () => {
+    const dosDiasAtras = Math.floor(MORNING.getTime() / 1000) - 2 * 24 * 60 * 60;
+    const g = buildProactiveGreeting({
+      activeAlerts: [],
+      pendingTasks: [
+        { type: 'log--task', status: 'pending', name: 'Aplicar caldo bordelés al tomate', timestamp: dosDiasAtras },
+      ],
+      date: MORNING,
+    });
+    expect(g.state).toBe('pending');
+    expect(g.items[0].kind).toBe('task');
+    expect(g.items[0].title).toBe('Aplicar caldo bordelés al tomate');
+    expect(g.items[0].due).toBe('Vencida hace 2 días');
+    expect(g.lead).toContain('Aplicar caldo bordelés al tomate');
+  });
+
+  it('NO destaca tareas FUTURAS como urgentes (solo hoy/vencidas)', () => {
+    const enTresDias = Math.floor(MORNING.getTime() / 1000) + 3 * 24 * 60 * 60;
+    const g = buildProactiveGreeting({
+      activeAlerts: [],
+      pendingTasks: [
+        { type: 'log--task', status: 'pending', name: 'Cosechar arveja', timestamp: enTresDias },
+      ],
+      date: MORNING,
+    });
+    // Sin alertas ni tareas vencidas/hoy → cae a idea contextual.
+    expect(g.state).toBe('idea');
+    expect(g.items).toHaveLength(0);
+  });
+
+  it('mezcla alerta + tarea: alerta danger lidera, tarea de hoy la sigue', () => {
+    const hoy = Math.floor(MORNING.getTime() / 1000);
+    const g = buildProactiveGreeting({
+      activeAlerts: [
+        { type: 'helada', severity: 'danger', title: 'Helada esta noche' },
+      ],
+      pendingTasks: [
+        { type: 'log--task', status: 'pending', name: 'Riego del lote 2', timestamp: hoy },
+      ],
+      date: MORNING,
+    });
+    expect(g.items).toHaveLength(2);
+    expect(g.items[0].kind).toBe('alert');
+    expect(g.items[1].kind).toBe('task');
+    expect(g.lead).toContain('Helada esta noche');
+  });
+
+  it('soporta activeAlerts como Map (forma interna del engine)', () => {
+    const map = new Map();
+    map.set('helada', { type: 'helada', severity: 'danger', title: 'Helada nocturna' });
+    const g = buildProactiveGreeting({ activeAlerts: map, pendingTasks: [], date: MORNING });
+    expect(g.state).toBe('pending');
+    expect(g.lead).toContain('Helada nocturna');
+  });
+});
+
+describe('buildProactiveGreeting — SIN pendientes (idea contextual, NO inventa alarma)', () => {
+  const ALARM_WORDS = /helada|riego pendiente|vencida|alerta activa|⚠️|❄️|🔥|🌧️/i;
+
+  it('sin alertas ni tareas → estado idea y NO menciona ninguna alarma', () => {
+    const g = buildProactiveGreeting({
+      activeAlerts: [],
+      pendingTasks: [],
+      cultivos: [{ name: 'Papa', count: 12 }],
+      altitud: 2600,
+      date: MORNING,
+    });
+    expect(g.state).toBe('idea');
+    expect(g.items).toHaveLength(0);
+    expect(g.restCount).toBe(0);
+    expect(g.lead).not.toMatch(ALARM_WORDS);
+  });
+
+  it('teje el cultivo principal del inventario en la idea', () => {
+    const g = buildProactiveGreeting({
+      activeAlerts: [],
+      pendingTasks: [],
+      cultivos: [{ name: 'Café', count: 30 }, { name: 'Plátano', count: 4 }],
+      altitud: 1500,
+      date: MORNING,
+    });
+    expect(g.state).toBe('idea');
+    expect(g.lead.toLowerCase()).toContain('café');
+    expect(g.lead).not.toMatch(ALARM_WORDS);
+  });
+
+  it('sin cultivos pero con altitud → usa piso térmico, sin inventar alarma', () => {
+    const g = buildProactiveGreeting({
+      activeAlerts: [],
+      pendingTasks: [],
+      cultivos: [],
+      altitud: 2600,
+      date: MORNING,
+    });
+    expect(g.state).toBe('idea');
+    expect(g.lead.toLowerCase()).toContain('frío'); // piso térmico de 2600 msnm
+    expect(g.lead).not.toMatch(ALARM_WORDS);
+  });
+
+  it('sin nada de contexto → fallback amable, jamás una alarma', () => {
+    const g = buildProactiveGreeting({
+      activeAlerts: [],
+      pendingTasks: [],
+      cultivos: [],
+      altitud: null,
+      date: MORNING,
+    });
+    expect(g.state).toBe('idea');
+    expect(g.lead).not.toMatch(ALARM_WORDS);
+    expect(g.lead.length).toBeGreaterThan(20);
+  });
+});
+
+describe('buildProactiveGreeting — saludo según hora', () => {
+  it('mañana → Buenos días', () => {
+    expect(buildProactiveGreeting({ date: new Date('2026-06-03T08:00:00') }).hi).toBe('Buenos días');
+  });
+  it('tarde → Buenas tardes', () => {
+    expect(buildProactiveGreeting({ date: new Date('2026-06-03T15:00:00') }).hi).toBe('Buenas tardes');
+  });
+  it('noche → Buenas noches', () => {
+    expect(buildProactiveGreeting({ date: new Date('2026-06-03T21:00:00') }).hi).toBe('Buenas noches');
+  });
+});
+
+describe('resolveProactiveGreeting — hidrata desde stores async', () => {
+  it('llama getPendingTasks y arma el saludo con pendientes', async () => {
+    const dosDiasAtras = Math.floor(MORNING.getTime() / 1000) - 2 * 24 * 60 * 60;
+    const g = await resolveProactiveGreeting({
+      activeAlerts: [],
+      getPendingTasks: async () => [
+        { type: 'log--task', status: 'pending', name: 'Deshierbe del lote de arveja', timestamp: dosDiasAtras },
+      ],
+      date: MORNING,
+    });
+    expect(g.state).toBe('pending');
+    expect(g.lead).toContain('Deshierbe del lote de arveja');
+  });
+
+  it('degrada a idea si getPendingTasks lanza error (no rompe el render)', async () => {
+    const g = await resolveProactiveGreeting({
+      activeAlerts: [],
+      getPendingTasks: async () => { throw new Error('IndexedDB caído'); },
+      cultivos: [{ name: 'Maíz', count: 5 }],
+      altitud: 1800,
+      date: MORNING,
+    });
+    expect(g.state).toBe('idea');
+    expect(g.lead.toLowerCase()).toContain('maíz');
+  });
+});

--- a/src/services/proactiveGreeting.js
+++ b/src/services/proactiveGreeting.js
@@ -1,0 +1,319 @@
+/**
+ * proactiveGreeting.js — SALUDO PROACTIVO de entrada del agente Chagra.
+ *
+ * Operador 2026-06-03: "que el agente, de entrada, salude de forma proactiva:
+ * SI ve algo pendiente (helada esta noche, riego pendiente, tarea de campo
+ * vencida) → lo DICE (lo más importante, 1-2 cosas, no todo). Si NO hay nada
+ * urgente → NO inventa alarmas, sino que da una IDEA contextual basada en lo
+ * que ya se sabe (cultivos / clima / temporada de la finca)."
+ *
+ * Diseño objetivo: `chagra-pro/.../demo-agente-biopunk.html` (toggle
+ * "Con pendientes | Sin urgencias").
+ *
+ * Esta es la LÓGICA PURA (testeable sin montar el componente). Reutiliza:
+ *   - alertEngine / useAlertStore (#162): alertas clima/sensor activas.
+ *   - useLogStore.getPendingTasks (#298): tareas log--task status=pending.
+ *   - AnalisisProactivoIA (#331): MISMA filosofía (plantillas contextuales
+ *     local-only, cero red, cero quema de GPU por refresh). Aquí extraemos el
+ *     núcleo para que el AgentScreen lo consuma de entrada sin duplicar reglas.
+ *   - agentService.temporadaColombiana / pisoTermicoFromAltitud: idea contextual.
+ *   - ensoContext.getEnsoOutlook: lectura regional ENSO cuando NO hay pendientes.
+ *
+ * Español colombiano (tú/usted, SIN voseo argentino).
+ *
+ * El builder es PURO y SÍNCRONO: recibe datos ya resueltos y devuelve un objeto
+ * de saludo. El wrapper `resolveProactiveGreeting` (async) hidrata desde stores.
+ */
+
+import { temporadaColombiana, pisoTermicoFromAltitud } from './agentService';
+
+/**
+ * @typedef {Object} GreetingItem
+ * @property {string} kind   — 'alert' | 'task'
+ * @property {string} icon   — emoji para el item
+ * @property {string} title  — título corto y humano del pendiente
+ * @property {string} [due]  — vencimiento legible (ej. "Hoy", "Vencida hace 2 días")
+ *
+ * @typedef {Object} Greeting
+ * @property {string} hi      — saludo según hora ("Buenos días" / etc).
+ * @property {('pending'|'idea')} state — con pendientes vs idea contextual.
+ * @property {string} lead    — el texto que LIDERA (lo clave en 1-2 cosas, o la idea).
+ * @property {GreetingItem[]} items — los 1-2 pendientes destacados (vacío si state==='idea').
+ * @property {number} restCount — cuántos pendientes MÁS quedan en la campana/panel.
+ * @property {string|null} prompt — prompt sugerido para sembrar al agente.
+ */
+
+const HORAS = {
+  morning: 'Buenos días',
+  afternoon: 'Buenas tardes',
+  evening: 'Buenas noches',
+  night: 'Buenas noches',
+};
+
+function saludoPorHora(date = new Date()) {
+  const h = date.getHours();
+  if (h >= 5 && h < 12) return HORAS.morning;
+  if (h >= 12 && h < 18) return HORAS.afternoon;
+  return HORAS.evening; // tarde-noche: una sola fórmula natural en Colombia
+}
+
+// Prioridad de severidad para ordenar lo MÁS importante primero.
+const SEVERITY_RANK = { danger: 0, warning: 1, info: 2 };
+
+// Iconos por tipo de alerta del alertEngine (#162). Fallback genérico.
+const ALERT_ICONS = {
+  helada: '❄️',
+  frost: '❄️',
+  calor: '🔥',
+  heat: '🔥',
+  lluvia: '🌧️',
+  rain: '🌧️',
+  sequia: '🌵',
+  drought: '🌵',
+  viento: '💨',
+  wind: '💨',
+  riego: '💧',
+  irrigation: '💧',
+  humedad: '💧',
+  temp: '🌡️',
+};
+
+function alertIcon(type = '') {
+  const t = String(type).toLowerCase();
+  const key = Object.keys(ALERT_ICONS).find((k) => t.includes(k));
+  return key ? ALERT_ICONS[key] : '⚠️';
+}
+
+/**
+ * Normaliza una alerta del alertEngine a GreetingItem. Tolerante a forma:
+ * acepta tanto el objeto del engine ({type,severity,title,message}) como un
+ * shape mínimo. Severidad desconocida cuenta como 'info' (no la subimos sola).
+ */
+function alertToItem(alert) {
+  if (!alert || typeof alert !== 'object') return null;
+  const title = alert.title || alert.message || alert.type || 'Alerta activa';
+  return {
+    kind: 'alert',
+    icon: alertIcon(alert.type),
+    title: String(title).trim(),
+    due: alert.due || null,
+    _severity: SEVERITY_RANK[alert.severity] != null ? SEVERITY_RANK[alert.severity] : SEVERITY_RANK.info,
+  };
+}
+
+/**
+ * Días de atraso de una tarea respecto de hoy. La tarea log--task trae
+ * `timestamp` (Unix en segundos, convención FarmOS) o `due`/`date` ISO. Sin
+ * fecha → null (no la consideramos vencida, solo pendiente).
+ */
+function taskOverdueDays(task, now = Date.now()) {
+  if (!task || typeof task !== 'object') return null;
+  let dueMs = null;
+  if (Number.isFinite(task.timestamp)) {
+    // FarmOS: segundos. Si parece milisegundos (muy grande) lo dejamos igual.
+    dueMs = task.timestamp > 1e12 ? task.timestamp : task.timestamp * 1000;
+  } else if (task.due || task.date || task.due_date) {
+    const parsed = Date.parse(task.due || task.date || task.due_date);
+    if (Number.isFinite(parsed)) dueMs = parsed;
+  }
+  if (dueMs == null) return null;
+  const days = Math.floor((now - dueMs) / (24 * 60 * 60 * 1000));
+  return days; // >0 vencida, 0 hoy, <0 futura
+}
+
+function dueLabel(days) {
+  if (days == null) return null;
+  if (days <= 0 && days > -1) return 'Hoy';
+  if (days < 0) return null; // futura: no la destacamos como urgente
+  if (days === 1) return 'Vencida ayer';
+  return `Vencida hace ${days} días`;
+}
+
+function taskTitle(task) {
+  return (
+    task?.name ||
+    task?.title ||
+    task?.attributes?.name ||
+    task?.label ||
+    'Tarea de campo pendiente'
+  );
+}
+
+/**
+ * Convierte la lista de tareas pendientes en items destacables, ordenados por
+ * atraso (más vencidas primero). Solo las VENCIDAS o de HOY se vuelven items
+ * destacados; las futuras quedan como conteo "resto".
+ */
+function pendingTasksToItems(tasks, now = Date.now()) {
+  if (!Array.isArray(tasks)) return [];
+  return tasks
+    .map((t) => {
+      const days = taskOverdueDays(t, now);
+      return { task: t, days };
+    })
+    .filter((x) => x.days != null && x.days >= 0) // hoy o vencida
+    .sort((a, b) => b.days - a.days) // más vencida primero
+    .map((x) => ({
+      kind: 'task',
+      icon: '🧪',
+      title: String(taskTitle(x.task)).trim(),
+      due: dueLabel(x.days),
+      _severity: x.days > 0 ? SEVERITY_RANK.warning : SEVERITY_RANK.info,
+    }));
+}
+
+/**
+ * Compone la frase que LIDERA con los pendientes destacados (máx 2). NO los
+ * lista todos: el resto vive en la campana/panel. Tono campesino-claro.
+ */
+function buildPendingLead(items) {
+  if (items.length === 1) {
+    const a = items[0];
+    const due = a.due ? ` (${a.due.toLowerCase()})` : '';
+    return `Ojo: ${a.title}${due}. Te lo dejo de primero para que no se pase.`;
+  }
+  const [a, b] = items;
+  const aDue = a.due ? ` (${a.due.toLowerCase()})` : '';
+  const bDue = b.due ? ` (${b.due.toLowerCase()})` : '';
+  return `Lo primero hoy: ${a.title}${aDue}. Y también ${b.title.toLowerCase()}${bDue}.`;
+}
+
+/**
+ * Idea contextual cuando NO hay pendientes — NUNCA inventa una alarma. Teje, en
+ * orden de disponibilidad: cultivo de temporada → piso térmico → temporada
+ * andina → ENSO regional. Si no hay NADA de contexto, fallback amable.
+ *
+ * @param {Object} ctx
+ * @param {Array<{name:string,count:number}>} ctx.cultivos
+ * @param {number|null} ctx.altitud
+ * @param {Object|null} ctx.ensoOutlook — { titulo, detalle, fuente } de getEnsoOutlook.
+ * @param {Date} ctx.date
+ */
+function buildIdeaLead({ cultivos = [], altitud = null, ensoOutlook = null, date = new Date() }) {
+  const temporada = temporadaColombiana(date.getMonth() + 1);
+  const piso = pisoTermicoFromAltitud(altitud);
+  const topCultivo = Array.isArray(cultivos) && cultivos.length > 0
+    ? [...cultivos].sort((a, b) => (b.count || 0) - (a.count || 0))[0]
+    : null;
+
+  if (topCultivo && topCultivo.name) {
+    const nombre = String(topCultivo.name).replace(/\s*#\d+\s*$/, '').trim();
+    return `Todo tranquilo por ahora. Como estamos en ${temporada.nombre}, es buena semana para revisar tu ${nombre.toLowerCase()} — ${temporada.detalle}. ¿Te armo un plan?`;
+  }
+
+  if (piso) {
+    return `Todo tranquilo por ahora. Tu finca está en piso térmico ${piso}; en ${temporada.nombre} (${temporada.detalle}) es buen momento para planear qué sembrar. ¿Te muestro especies que van bien en tu zona?`;
+  }
+
+  if (ensoOutlook && ensoOutlook.titulo) {
+    return `Todo tranquilo por ahora. ${ensoOutlook.titulo}: ${ensoOutlook.detalle} (${ensoOutlook.fuente}). ¿Quieres que ajustemos el calendario a eso?`;
+  }
+
+  return `Todo tranquilo por ahora — no hay nada urgente en tu finca. Estamos en ${temporada.nombre}; cuéntame qué tienes sembrado y te doy una mano con el plan.`;
+}
+
+/**
+ * BUILDER PURO del saludo proactivo. Decide entre estado 'pending' (lidera con
+ * lo clave) e 'idea' (idea contextual, sin inventar alarma).
+ *
+ * @param {Object} input
+ * @param {Array} input.activeAlerts — alertas del alertEngine (#162).
+ * @param {Array} input.pendingTasks — tareas log--task pending (#298).
+ * @param {Array<{name:string,count:number}>} input.cultivos — inventario agrupado.
+ * @param {number|null} input.altitud — altitud de la finca activa (msnm).
+ * @param {Object|null} input.ensoOutlook — getEnsoOutlook (ensoContext).
+ * @param {Date} [input.date] — inyectable para test.
+ * @param {number} [input.maxItems=2] — cuántos pendientes destacar como máximo.
+ * @returns {Greeting}
+ */
+export function buildProactiveGreeting({
+  activeAlerts = [],
+  pendingTasks = [],
+  cultivos = [],
+  altitud = null,
+  ensoOutlook = null,
+  date = new Date(),
+  maxItems = 2,
+} = {}) {
+  const hi = saludoPorHora(date);
+
+  // useAlertStore.activeAlerts es array; el engine internamente usa Map. Soporta
+  // ambas formas por robustez (no regresar a 0 silencioso si cambia el store).
+  const alertsArr = Array.isArray(activeAlerts)
+    ? activeAlerts
+    : (activeAlerts instanceof Map ? Array.from(activeAlerts.values()) : []);
+
+  const alertItems = alertsArr.map(alertToItem).filter(Boolean);
+  const taskItems = pendingTasksToItems(pendingTasks, date.getTime());
+
+  // Combinamos y ordenamos por severidad (danger > warning > info). Empates:
+  // las alertas (ambiente) pesan un pelín más que las tareas a igual severidad.
+  const ranked = [...alertItems, ...taskItems].sort((a, b) => {
+    if (a._severity !== b._severity) return a._severity - b._severity;
+    return (a.kind === 'alert' ? 0 : 1) - (b.kind === 'alert' ? 0 : 1);
+  });
+
+  if (ranked.length > 0) {
+    const top = ranked.slice(0, maxItems).map(({ _severity, ...item }) => item);
+    const restCount = ranked.length - top.length;
+    return {
+      hi,
+      state: 'pending',
+      lead: buildPendingLead(top),
+      items: top,
+      restCount,
+      prompt: top[0].kind === 'alert'
+        ? '¿Qué hago con la alerta de mi finca?'
+        : '¿Por dónde empiezo con las tareas pendientes de hoy?',
+    };
+  }
+
+  // Sin pendientes urgentes → idea contextual (NO inventa alarma).
+  return {
+    hi,
+    state: 'idea',
+    lead: buildIdeaLead({ cultivos, altitud, ensoOutlook, date }),
+    items: [],
+    restCount: 0,
+    prompt: Array.isArray(cultivos) && cultivos.length > 0
+      ? 'Dame un resumen del estado de mi finca hoy.'
+      : 'Quiero planear qué sembrar. ¿Por dónde empiezo?',
+  };
+}
+
+/**
+ * Wrapper que HIDRATA el saludo desde los stores en vivo. async porque
+ * getPendingTasks lee IndexedDB. No falla nunca: degrada a idea/fallback si
+ * algún store no responde. Pensado para llamarse al montar el AgentScreen.
+ *
+ * Las dependencias se inyectan para no acoplar a imports de Zustand en el
+ * builder puro (y para test). El AgentScreen pasa los selectores reales.
+ *
+ * @param {Object} deps
+ * @param {Array} deps.activeAlerts
+ * @param {Function} deps.getPendingTasks — () => Promise<Array>
+ * @param {Array<{name:string,count:number}>} deps.cultivos
+ * @param {number|null} deps.altitud
+ * @param {Object|null} deps.ensoOutlook
+ * @param {Date} [deps.date]
+ * @returns {Promise<Greeting>}
+ */
+export async function resolveProactiveGreeting({
+  activeAlerts = [],
+  getPendingTasks = null,
+  cultivos = [],
+  altitud = null,
+  ensoOutlook = null,
+  date = new Date(),
+} = {}) {
+  let pendingTasks = [];
+  if (typeof getPendingTasks === 'function') {
+    try {
+      const ts = await getPendingTasks();
+      pendingTasks = Array.isArray(ts) ? ts : [];
+    } catch (_) {
+      pendingTasks = [];
+    }
+  }
+  return buildProactiveGreeting({ activeAlerts, pendingTasks, cultivos, altitud, ensoOutlook, date });
+}


### PR DESCRIPTION
## Qué hace

El agente, **de entrada**, saluda de forma proactiva en vez del copy estático "¡Hola! Soy tu asistente agroecológico":

- **Con pendientes** → lidera con lo MÁS importante (máx 1-2), nombrando la alerta/tarea top. El resto queda en la campana/panel (no se listan todos). Prioridad: alertas `danger` > tareas vencidas > `warning` > tareas de hoy.
- **Sin urgencias** → una idea contextual derivada de cultivos + clima + temporada de la finca. **Nunca inventa una alarma.**

Diseño objetivo: el demo bio-punk (`chagra-pro/.../demo-agente-biopunk.html`, toggle "Con pendientes | Sin urgencias").

## Qué reusa (NO recrea)

- **alertEngine #162** / `useAlertStore` — alertas clima/sensor activas (soporta array y Map).
- **tareas #298** — `useLogStore.getPendingTasks()` (log--task status=pending); detecta vencidas por `timestamp`/`due`.
- **AnalisisProactivoIA #331** — misma filosofía (plantillas contextuales local-only, cero red, cero GPU por refresh). Se extrajo el núcleo a un builder PURO testeable.
- `agentService.temporadaColombiana` / `pisoTermicoFromAltitud` + `ensoContext.getEnsoOutlook` — para la idea contextual.

## Cambios

- `src/services/proactiveGreeting.js` — builder PURO `buildProactiveGreeting` + wrapper async `resolveProactiveGreeting` que hidrata stores (degrada silencioso si IndexedDB falla).
- `src/components/AgentScreen/ChatHistory.jsx` — el empty-state renderiza el saludo dinámico (CTA siembra el prompt sugerido en el input, **no** auto-submit). Fallback al copy estático si el saludo aún no resolvió (backward compat).
- `src/components/AgentScreen/AgentScreen.jsx` — resuelve el saludo al montar desde alertas/tareas/clima/cultivos.

La campana/panel de alertas y tareas **siguen intactos** — el saludo solo lidera con lo clave y deja el resto accesible ahí.

## Tests (TDD)

- `proactiveGreeting.test.js` (15) — con pendientes nombra la alerta/tarea top, prioriza danger, máx 2 + restCount, detecta vencidas, ignora futuras; sin pendientes → idea contextual que NO menciona alarmas.
- `ChatHistory.greeting.test.jsx` (4) — render de ambos estados + CTA + fallback estático.
- Suite completa: **207 archivos, 3448 passing** (1 skip). Lint limpio en los archivos tocados.

## Nota bonus #1

El carácter chino `防守` en `agentService.js` ya estaba corregido por PR #1267 (línea de "llanos/incendios" ahora dice "Implementar sistema de **prevención** contra incendios"). El único CJK restante en src es la etimología japonesa intencional de "bocashi" en `dictionary.js`. No requirió acción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)