### PR TITLE
fix(agent): saludo proactivo no afirma el clima como hecho (#364)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.41",
+  "version": "1.0.42",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v299';
+const CACHE_NAME = 'chagra-v300';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/proactiveGreeting.test.js
+++ b/src/services/__tests__/proactiveGreeting.test.js
@@ -162,6 +162,25 @@ describe('buildProactiveGreeting — SIN pendientes (idea contextual, NO inventa
     expect(g.lead).not.toMatch(ALARM_WORDS);
     expect(g.lead.length).toBeGreaterThan(20);
   });
+
+  // Fix 2026-06-03: el saludo afirmaba la temporada como HECHO ("Como estamos en
+  // segunda temporada seca…") en plena época de lluvias → falso. Ahora la enmarca
+  // como referencia de calendario que SIEMPRE cede al clima real de la finca.
+  it('NO afirma el clima de hoy como hecho — enmarca la temporada como calendario y defiere al clima real', () => {
+    for (const ctx of [
+      { cultivos: [{ name: 'Fresa', count: 8 }], altitud: 2600 }, // rama cultivo
+      { cultivos: [], altitud: 2600 }, // rama piso térmico
+      { cultivos: [], altitud: null }, // rama fallback
+    ]) {
+      const g = buildProactiveGreeting({ activeAlerts: [], pendingTasks: [], date: MORNING, ...ctx });
+      expect(g.state).toBe('idea');
+      // NUNCA debe afirmar la temporada como un parte meteorológico presente.
+      expect(g.lead).not.toMatch(/(como )?estamos en .*temporada/i);
+      // SÍ debe enmarcarla como calendario y deferir explícitamente al clima real.
+      expect(g.lead.toLowerCase()).toContain('el calendario marca');
+      expect(g.lead.toLowerCase()).toContain('clima real');
+    }
+  });
 });
 
 describe('buildProactiveGreeting — saludo según hora', () => {

--- a/src/services/proactiveGreeting.js
+++ b/src/services/proactiveGreeting.js
@@ -189,6 +189,18 @@ function buildPendingLead(items) {
  * @param {Object|null} ctx.ensoOutlook — { titulo, detalle, fuente } de getEnsoOutlook.
  * @param {Date} ctx.date
  */
+/**
+ * Enmarca la temporada bimodal como TENDENCIA de calendario — NUNCA como
+ * afirmación del clima de HOY. `temporadaColombiana` es pura aritmética del mes;
+ * el ENSO y la variabilidad del año la modulan, y el clima real de la finca
+ * manda. (Fix 2026-06-03: el saludo afirmaba "estamos en temporada seca" en
+ * plena época de lluvias — falso. Ahora es una referencia calendárica, no un
+ * parte meteorológico, y siempre cede ante lo que el campesino ve en su finca.)
+ */
+function marcoCalendario(temporada) {
+  return `el calendario marca ${temporada.nombre}, pero el clima real de tu finca manda`;
+}
+
 function buildIdeaLead({ cultivos = [], altitud = null, ensoOutlook = null, date = new Date() }) {
   const temporada = temporadaColombiana(date.getMonth() + 1);
   const piso = pisoTermicoFromAltitud(altitud);
@@ -198,18 +210,18 @@ function buildIdeaLead({ cultivos = [], altitud = null, ensoOutlook = null, date
 
   if (topCultivo && topCultivo.name) {
     const nombre = String(topCultivo.name).replace(/\s*#\d+\s*$/, '').trim();
-    return `Todo tranquilo por ahora. Como estamos en ${temporada.nombre}, es buena semana para revisar tu ${nombre.toLowerCase()} — ${temporada.detalle}. ¿Te armo un plan?`;
+    return `Todo tranquilo por ahora. Buena semana para echarle un ojo a tu ${nombre.toLowerCase()} — ${marcoCalendario(temporada)}. ¿Cómo viene el tiempo por allá? ¿Te armo un plan?`;
   }
 
   if (piso) {
-    return `Todo tranquilo por ahora. Tu finca está en piso térmico ${piso}; en ${temporada.nombre} (${temporada.detalle}) es buen momento para planear qué sembrar. ¿Te muestro especies que van bien en tu zona?`;
+    return `Todo tranquilo por ahora. Tu finca está en piso térmico ${piso} — ${marcoCalendario(temporada)}. Buen momento para planear qué sembrar; ¿te muestro especies que van bien en tu zona?`;
   }
 
   if (ensoOutlook && ensoOutlook.titulo) {
     return `Todo tranquilo por ahora. ${ensoOutlook.titulo}: ${ensoOutlook.detalle} (${ensoOutlook.fuente}). ¿Quieres que ajustemos el calendario a eso?`;
   }
 
-  return `Todo tranquilo por ahora — no hay nada urgente en tu finca. Estamos en ${temporada.nombre}; cuéntame qué tienes sembrado y te doy una mano con el plan.`;
+  return `Todo tranquilo por ahora — no hay nada urgente en tu finca. El calendario marca ${temporada.nombre}, pero el clima real manda; cuéntame qué tienes sembrado y cómo viene el tiempo, y te doy una mano con el plan.`;
 }
 
 /**


### PR DESCRIPTION
## Problema
El saludo proactivo de entrada (#1296) decía, sin pendientes: *"Todo tranquilo por ahora. Como estamos en segunda temporada seca (junio–agosto), es buena semana para revisar tu fresa — veranillo de mitad de año (San Juan). ¿Te armo un plan?"* — **afirmando la temporada como hecho presente** cuando en realidad estaba lloviendo. `temporadaColombiana()` es pura aritmética del mes (régimen bimodal andino) y NO mira clima real → claim falso.

## Fix
`buildIdeaLead` deja de afirmar la temporada y la enmarca como **referencia de calendario que cede al clima real**: *"…el calendario marca segunda temporada seca (junio–agosto), pero el clima real de tu finca manda. ¿Cómo viene el tiempo por allá?"*. Aplica a las 3 ramas (cultivo / piso / fallback). La rama ENSO ya citaba fuente, intacta.

## Tests
- `proactiveGreeting.test.js`: nuevo test verifica que el lead "idea" NO afirma la temporada y SÍ incluye "el calendario marca" + "clima real". 20/20 verdes.

## Pendiente (no este PR)
Grounding real: usar forecast IDEAM / lluvia reciente para preferir el dato real sobre el calendario (#364 capa profunda) + bug Brave geo (#334).