### PR TITLE
fix(geo): degradar confianza de clima con ubicación guardada gruesa + re-pin prominente (#364)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.42",
+  "version": "1.0.43",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v300';
+const CACHE_NAME = 'chagra-v301';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/components/dashboard/ClimaStrip.jsx
+++ b/src/components/dashboard/ClimaStrip.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useMemo } from 'react';
-import { Cloud, CloudRain, Sun, CloudSun, Droplets, Wind, Thermometer, MapPin } from 'lucide-react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
+import { Cloud, CloudRain, Sun, CloudSun, Droplets, Wind, Thermometer, MapPin, AlertCircle, Pencil } from 'lucide-react';
 import { fetchClimaSnapshot, getCachedClimaSnapshot } from '../../services/climaService';
 import { findMunicipio } from '../../utils/colombiaLocations';
+import { isSavedLocationCoarse } from '../../services/locationService';
 import { FARM_CONFIG } from '../../config/defaults';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 import { getProfile, getProfileMunicipio } from '../../services/userProfileService';
@@ -151,6 +152,32 @@ export default function ClimaStrip({ onNavigate }) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [municipio, tick]);
 
+    // mitad geo de #364 (2026-06-03): ¿la ubicación GUARDADA es demasiado
+    // gruesa para afirmar el municipio/zona con confianza? Pasa cuando el
+    // onboarding grabó la cabecera del municipio grande (Brave difuminó el GPS)
+    // y el usuario no corrigió la altura a mano. NO bloquea el pronóstico
+    // (Open-Meteo ya corrige por altitud); solo degrada la CONFIANZA en el
+    // municipio mostrado y empuja a confirmar la ubicación real.
+    const coarse = useMemo(() => {
+        return isSavedLocationCoarse(getProfile());
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tick]);
+
+    // Navegación a la pantalla de ubicación (mini-mapa + piso térmico). Reusada
+    // por el CTA "Configurar ubicación" (sin ubicación), el aviso de confianza
+    // gruesa y el botón de re-pin del header. Degrada al evento global
+    // 'chagra:nav' (que App.jsx escucha) si no hay onNavigate — evita el
+    // listener inline-string del feedback CSP-strict.
+    const goToLocation = useCallback(() => {
+        if (typeof onNavigate === 'function') {
+            onNavigate('ubicacion-detectada');
+            return;
+        }
+        try {
+            window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'ubicacion-detectada' }));
+        } catch (_) { /* noop */ }
+    }, [onNavigate]);
+
     useEffect(() => {
         let alive = true;
         // Sin coords (ni del perfil ni geocodificando el municipio) no podemos
@@ -217,16 +244,7 @@ export default function ClimaStrip({ onNavigate }) {
                     feedback-csp-strict-inline-handlers-bloqueados). */}
                 <button
                     type="button"
-                    onClick={() => {
-                        if (typeof onNavigate === 'function') {
-                            onNavigate('ubicacion-detectada');
-                            return;
-                        }
-                        try {
-                            // App.jsx escucha 'chagra:nav' (string o {view,data})
-                            window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'ubicacion-detectada' }));
-                        } catch (_) { /* noop */ }
-                    }}
+                    onClick={goToLocation}
                     className="mt-3 px-4 py-2 rounded-xl bg-sky-700/30 hover:bg-sky-600/40 border border-sky-500/40 text-sky-200 text-sm font-bold transition-colors flex items-center gap-2"
                 >
                     <MapPin size={14} aria-hidden="true" />
@@ -264,13 +282,61 @@ export default function ClimaStrip({ onNavigate }) {
                 <div className="flex items-center gap-2 min-w-0">
                     <Cloud size={20} className="text-sky-300 shrink-0" />
                     <h3 className="text-base font-bold text-white truncate">
-                        Clima en {headerLabel}
+                        {coarse ? 'Clima en tu zona' : `Clima en ${headerLabel}`}
                     </h3>
                 </div>
-                <span className="text-[10px] text-sky-300/70 font-bold uppercase tracking-wider shrink-0">
-                    Open-Meteo · 7 días
-                </span>
+                <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-[10px] text-sky-300/70 font-bold uppercase tracking-wider">
+                        Open-Meteo · 7 días
+                    </span>
+                    {/* Re-pin SIEMPRE alcanzable (mitad geo de #364): corregir una
+                        ubicación guardada equivocada sin fricción. Navega al
+                        mini-mapa donde el usuario re-fija su vereda real; al
+                        confirmar, LocationDetectedScreen reescribe el perfil y
+                        dispara 'chagra:location-updated' (este card refresca). */}
+                    <button
+                        type="button"
+                        onClick={goToLocation}
+                        data-testid="clima-repin"
+                        aria-label="Corregir mi ubicación"
+                        title="Corregir mi ubicación"
+                        className="p-1.5 rounded-lg bg-white/[0.06] hover:bg-white/[0.12] border border-white/[0.08] text-sky-200 transition-colors"
+                    >
+                        <Pencil size={13} aria-hidden="true" />
+                    </button>
+                </div>
             </div>
+
+            {/* mitad geo de #364: aviso de confianza cuando la ubicación GUARDADA
+                es gruesa (Brave/onboarding grabó la cabecera, no la vereda). NO
+                afirmamos el municipio como cierto; empujamos a confirmar la
+                ubicación real en el mini-mapa. El pronóstico igual se muestra
+                (Open-Meteo corrige por altitud) — lo que degradamos es la
+                confianza en el municipio/zona. */}
+            {coarse && (
+                <div
+                    data-testid="clima-coarse-warning"
+                    className="mb-3 rounded-xl bg-amber-950/30 border border-amber-800/40 p-3 text-xs text-amber-200 flex gap-2"
+                >
+                    <AlertCircle size={14} className="shrink-0 mt-0.5" aria-hidden="true" />
+                    <div className="flex-1 min-w-0">
+                        <p className="leading-relaxed">
+                            Confirma tu ubicación para un clima exacto. La que tenemos
+                            guardada es aproximada (puede ser la cabecera del municipio,
+                            no tu finca).
+                        </p>
+                        <button
+                            type="button"
+                            onClick={goToLocation}
+                            data-testid="clima-coarse-cta"
+                            className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-700/30 hover:bg-amber-600/40 border border-amber-500/40 text-amber-100 font-bold transition-colors"
+                        >
+                            <MapPin size={13} aria-hidden="true" />
+                            Confirmar mi ubicación
+                        </button>
+                    </div>
+                </div>
+            )}
 
             {!hasReal && (
                 <p className="text-xs text-slate-400 mb-3 italic">

--- a/src/components/dashboard/__tests__/ClimaStrip.coarseConfidence.test.jsx
+++ b/src/components/dashboard/__tests__/ClimaStrip.coarseConfidence.test.jsx
@@ -1,0 +1,161 @@
+/**
+ * ClimaStrip.coarseConfidence.test.jsx — confianza de ubicación en el widget de
+ * clima (mitad geo de #364, 2026-06-03).
+ *
+ * Problema del operador: el clima usa la ubicación GUARDADA del perfil. En
+ * Brave los Shields difuminaron el GPS durante el onboarding y se grabó la
+ * cabecera del municipio grande/caliente (no su vereda). El widget afirmaba
+ * "Clima en {municipio}" con plena confianza aunque esa zona esté equivocada.
+ *
+ * Esta suite verifica que:
+ *   (a) ubicación guardada GRUESA → el widget NO afirma el municipio con
+ *       confianza: muestra un aviso "Confirma tu ubicación para un clima
+ *       exacto" con CTA al mini-mapa (ubicacion-detectada).
+ *   (b) ubicación PRECISA o confirmada por el usuario → NO molesta (sin aviso).
+ *   (c) cuando hay municipio, SIEMPRE hay una vía prominente para corregir la
+ *       ubicación (re-pin) que navega a ubicacion-detectada.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import ClimaStrip from '../ClimaStrip';
+
+vi.mock('../../../services/climaService', () => ({
+    fetchClimaSnapshot: vi.fn(() => Promise.resolve(null)),
+    getCachedClimaSnapshot: vi.fn(() => null),
+}));
+import { fetchClimaSnapshot } from '../../../services/climaService';
+
+vi.mock('../../../utils/colombiaLocations', () => ({
+    findMunicipio: vi.fn(() => null),
+}));
+import { findMunicipio } from '../../../utils/colombiaLocations';
+
+vi.mock('../../../services/fincaActiveStore', () => {
+    const store = { activeFincaSlug: 'guatoc', fincas: [] };
+    const useFincaActiveStore = (selector) => selector(store);
+    return { default: useFincaActiveStore };
+});
+
+vi.mock('../../../config/defaults', () => ({
+    FARM_CONFIG: { MUNICIPIO: null },
+}));
+
+vi.mock('../../../services/userProfileService', () => {
+    const getProfile = vi.fn(() => ({}));
+    const getProfileMunicipio = vi.fn(() => getProfile()?.municipio ?? null);
+    return { getProfile, getProfileMunicipio };
+});
+import { getProfile, getProfileMunicipio } from '../../../services/userProfileService';
+
+beforeEach(() => {
+    fetchClimaSnapshot.mockReset();
+    fetchClimaSnapshot.mockResolvedValue(null);
+    findMunicipio.mockReset();
+    findMunicipio.mockReturnValue(null);
+    getProfile.mockReset();
+    getProfile.mockReturnValue({});
+    getProfileMunicipio.mockReset();
+    getProfileMunicipio.mockImplementation(() => getProfile()?.municipio ?? null);
+});
+
+describe('ClimaStrip — degradación de confianza con ubicación guardada gruesa', () => {
+    test('ubicación guardada GRUESA → muestra aviso "Confirma tu ubicación" (no afirma el municipio)', async () => {
+        // Perfil del operador: coords + municipio guardados, PERO la lectura fue
+        // gruesa (accuracy 12 km, Brave) y nunca corrigió la altitud a mano.
+        getProfile.mockReturnValue({
+            municipio: 'Bogotá',
+            ubicacion_lat: 4.61,
+            ubicacion_lng: -74.08,
+            ubicacion_accuracy: 12000,
+        });
+        getProfileMunicipio.mockReturnValue('Bogotá');
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+
+        const warning = await screen.findByTestId('clima-coarse-warning');
+        expect(warning).toHaveTextContent(/confirma tu ubicación/i);
+    });
+
+    test('aviso gruesa → CTA navega a ubicacion-detectada (mini-mapa)', async () => {
+        getProfile.mockReturnValue({
+            municipio: 'Bogotá',
+            ubicacion_lat: 4.61,
+            ubicacion_lng: -74.08,
+            ubicacion_accuracy: 12000,
+        });
+        getProfileMunicipio.mockReturnValue('Bogotá');
+        const onNavigate = vi.fn();
+        render(<ClimaStrip onNavigate={onNavigate} />);
+
+        const cta = await screen.findByTestId('clima-coarse-cta');
+        fireEvent.click(cta);
+        expect(onNavigate).toHaveBeenCalledWith('ubicacion-detectada');
+    });
+
+    test('ubicación PRECISA (accuracy fino) → NO muestra el aviso de confianza', async () => {
+        getProfile.mockReturnValue({
+            municipio: 'Choachí',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+            ubicacion_accuracy: 35,
+        });
+        getProfileMunicipio.mockReturnValue('Choachí');
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+
+        await screen.findByText(/Clima en/i);
+        expect(screen.queryByTestId('clima-coarse-warning')).not.toBeInTheDocument();
+    });
+
+    test('ubicación gruesa pero altitud confirmada a mano → NO molesta', async () => {
+        getProfile.mockReturnValue({
+            municipio: 'Choachí',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+            ubicacion_accuracy: 12000,
+            altitud_source: 'manual',
+        });
+        getProfileMunicipio.mockReturnValue('Choachí');
+        render(<ClimaStrip onNavigate={vi.fn()} />);
+
+        await screen.findByText(/Clima en/i);
+        expect(screen.queryByTestId('clima-coarse-warning')).not.toBeInTheDocument();
+    });
+});
+
+describe('ClimaStrip — re-fijar ubicación siempre alcanzable (re-pin)', () => {
+    test('con municipio, hay un botón prominente para corregir la ubicación → ubicacion-detectada', async () => {
+        getProfile.mockReturnValue({
+            municipio: 'Choachí',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+            ubicacion_accuracy: 35,
+        });
+        getProfileMunicipio.mockReturnValue('Choachí');
+        const onNavigate = vi.fn();
+        render(<ClimaStrip onNavigate={onNavigate} />);
+
+        const repin = await screen.findByTestId('clima-repin');
+        fireEvent.click(repin);
+        expect(onNavigate).toHaveBeenCalledWith('ubicacion-detectada');
+    });
+
+    test('sin onNavigate, el re-pin despacha el evento global chagra:nav', async () => {
+        getProfile.mockReturnValue({
+            municipio: 'Choachí',
+            ubicacion_lat: 4.53,
+            ubicacion_lng: -73.92,
+            ubicacion_accuracy: 35,
+        });
+        getProfileMunicipio.mockReturnValue('Choachí');
+        const eventSpy = vi.fn();
+        window.addEventListener('chagra:nav', eventSpy);
+        render(<ClimaStrip />);
+
+        const repin = await screen.findByTestId('clima-repin');
+        fireEvent.click(repin);
+        await waitFor(() => expect(eventSpy).toHaveBeenCalledTimes(1));
+        expect(eventSpy.mock.calls[0][0].detail).toBe('ubicacion-detectada');
+        window.removeEventListener('chagra:nav', eventSpy);
+    });
+});

--- a/src/services/__tests__/locationService.savedCoarse.test.js
+++ b/src/services/__tests__/locationService.savedCoarse.test.js
@@ -1,0 +1,65 @@
+/**
+ * locationService.savedCoarse.test.js — confianza en la ubicación GUARDADA
+ * (mitad geo de #364, 2026-06-03).
+ *
+ * Contexto del operador: en Brave/escritorio sin GPS, durante el onboarding la
+ * lectura de geolocalización fue GRUESA (Shields difuminan el GPS → varios km)
+ * y se grabó en el perfil la cabecera del municipio grande/caliente, NO su
+ * vereda. El clima/saludo del agente lee esa ubicación GUARDADA y afirma el
+ * municipio equivocado "como si fuera cierto".
+ *
+ * `isSavedLocationCoarse(profile)` es el predicado puro que decide si NO
+ * debemos afirmar el municipio/zona con confianza y, en su lugar, empujar al
+ * usuario a confirmar su ubicación real (mini-mapa). No mira el GPS en vivo:
+ * mira lo que quedó PERSISTIDO (`ubicacion_accuracy` + `altitud_source`).
+ *
+ * Regla:
+ *   - coarse  ⇔ `ubicacion_accuracy` numérico y > umbral (default 5000 m)
+ *              Y el usuario NO corrigió la altitud a mano (`altitud_source`
+ *              !== 'manual'). Una altitud manual = el usuario YA confirmó su
+ *              zona → no molestar.
+ *   - todo lo demás (accuracy fino, ausente, manual) ⇒ NO coarse (no molesta).
+ */
+import { describe, test, expect } from 'vitest';
+import { isSavedLocationCoarse } from '../locationService';
+
+describe('isSavedLocationCoarse — confianza en la ubicación guardada', () => {
+  test('accuracy guardada gruesa (12 km) y sin corrección manual → coarse', () => {
+    expect(
+      isSavedLocationCoarse({ ubicacion_accuracy: 12000 }),
+    ).toBe(true);
+  });
+
+  test('accuracy guardada gruesa pero el usuario fijó la altitud a mano → NO coarse', () => {
+    // El usuario ya confirmó su zona escribiendo su altura real: no molestar.
+    expect(
+      isSavedLocationCoarse({ ubicacion_accuracy: 12000, altitud_source: 'manual' }),
+    ).toBe(false);
+  });
+
+  test('accuracy guardada fina (GPS celular, 35 m) → NO coarse', () => {
+    expect(isSavedLocationCoarse({ ubicacion_accuracy: 35 })).toBe(false);
+  });
+
+  test('justo en el umbral (5000 m) NO es coarse (estricto >)', () => {
+    expect(isSavedLocationCoarse({ ubicacion_accuracy: 5000 })).toBe(false);
+  });
+
+  test('sin ubicacion_accuracy (perfil viejo / fijado a mano) → NO coarse', () => {
+    // Si no guardamos el radio de incertidumbre no podemos afirmar que es
+    // gruesa: no molestamos (false). Perfiles fijados por pin/búsqueda guardan
+    // accuracy = undefined.
+    expect(isSavedLocationCoarse({})).toBe(false);
+    expect(isSavedLocationCoarse({ municipio: 'Choachí' })).toBe(false);
+  });
+
+  test('perfil null/undefined → NO coarse (no lanza)', () => {
+    expect(isSavedLocationCoarse(null)).toBe(false);
+    expect(isSavedLocationCoarse(undefined)).toBe(false);
+  });
+
+  test('umbral parametrizable (segundo argumento)', () => {
+    expect(isSavedLocationCoarse({ ubicacion_accuracy: 1500 }, 1000)).toBe(true);
+    expect(isSavedLocationCoarse({ ubicacion_accuracy: 1500 }, 2000)).toBe(false);
+  });
+});

--- a/src/services/locationService.js
+++ b/src/services/locationService.js
@@ -67,6 +67,34 @@ export function isCoarseLocation(accuracy, threshold = COARSE_ACCURACY_THRESHOLD
 }
 
 /**
+ * ¿La ubicación PERSISTIDA en el perfil es demasiado gruesa para afirmar el
+ * municipio/zona con confianza? (mitad geo de #364, 2026-06-03).
+ *
+ * A diferencia de `isCoarseLocation` (que mira una lectura GPS en vivo), este
+ * predicado mira lo que quedó GUARDADO en el perfil durante el onboarding. El
+ * caso del operador: en Brave los Shields difuminan el GPS y se grabó la
+ * cabecera del municipio grande/caliente (no su vereda) con un radio de
+ * incertidumbre de varios km. El clima/saludo lee esa ubicación guardada y
+ * afirma el municipio equivocado "como si fuera cierto".
+ *
+ * Es coarse ⇔ `ubicacion_accuracy` es un número > umbral Y el usuario NO
+ * corrigió la altitud a mano (`altitud_source !== 'manual'`). Una altitud
+ * manual significa que el usuario YA confirmó su zona → no molestar. Sin
+ * `ubicacion_accuracy` (perfiles fijados por pin/búsqueda, o perfiles viejos)
+ * no podemos afirmar que es gruesa → devolvemos false (no molestamos).
+ *
+ * @param {Object|null|undefined} profile - perfil del usuario (userProfileService).
+ * @param {number} [threshold] - umbral en metros (default COARSE_ACCURACY_THRESHOLD_M).
+ * @returns {boolean}
+ */
+export function isSavedLocationCoarse(profile, threshold = COARSE_ACCURACY_THRESHOLD_M) {
+  if (!profile || typeof profile !== 'object') return false;
+  // El usuario ya fijó su altura real a mano → confirmó su zona, no molestar.
+  if (profile.altitud_source === 'manual') return false;
+  return isCoarseLocation(profile.ubicacion_accuracy, threshold);
+}
+
+/**
  * Metadatos visuales + cultivos recomendados por piso térmico colombiano.
  * Clasificación IDEAM / Caldas. Conocimiento agronómico público (OSS-safe):
  * los cultivos típicos de cada piso térmico son hechos de extensión rural


### PR DESCRIPTION
## Mitad geo de #364

El clima/saludo del agente usan la ubicación **GUARDADA** del perfil (`ubicacion_lat/lng` + `finca_altitud`), no el GPS en vivo. El operador en Brave ve el clima del "pueblo más caliente" porque esa ubicación equivocada quedó **grabada** en su perfil durante el onboarding: Brave Shields difuminó el GPS y dio coords de la cabecera del municipio grande, no su vereda. El widget afirmaba `Clima en {municipio}` con plena confianza aunque la zona esté equivocada.

## Cambios (2 partes)

### 1. No tragarse ubicación gruesa (degradar confianza)
- Nuevo predicado puro `isSavedLocationCoarse(profile)` en `locationService` — `true` cuando la ubicación **persistida** tiene `ubicacion_accuracy > 5000 m` **y** el usuario no corrigió la altitud a mano (`altitud_source !== 'manual'`). Una altitud manual = el usuario ya confirmó su zona → no molestar.
- En ese caso `ClimaStrip` **NO** afirma el municipio: muestra "Clima en tu zona" + aviso **"Confirma tu ubicación para un clima exacto"** con CTA al mini-mapa. El pronóstico igual se muestra (Open-Meteo ya corrige por altitud); lo que degradamos es la **confianza en el municipio/zona**.

### 2. Re-fijar fácil y prominente (re-pin)
- Botón de re-pin (lápiz) **siempre visible** en el header del card de clima → navega a `ubicacion-detectada` (mini-mapa). Al confirmar, `LocationDetectedScreen` reescribe el perfil + dispara `chagra:location-updated` (ya existía) y el card refresca por el listener de `tick`.
- Navegación centralizada en `goToLocation()` (reusa el CTA "Configurar ubicación" existente, el aviso gruesa y el re-pin), con fallback al evento global `chagra:nav` (CSP-safe).

## TDD
- `locationService.savedCoarse.test.js` — 8 casos del predicado.
- `ClimaStrip.coarseConfidence.test.jsx` — aviso gruesa, CTA→mini-mapa, ubicación precisa/confirmada no molesta, re-pin alcanzable con y sin `onNavigate`.
- No rompe los tests coarse existentes: `LocationDetectedScreen.coarse`, `locationService.coarse`, `ClimaStrip.locationButton`. **78/78 pasan** en los archivos tocados. eslint limpio. `vite build` OK.

## Nota importante
Este fix hace **fácil** corregir la ubicación, pero **no** re-fija automáticamente la vereda del operador: su ubicación guardada sigue siendo la vieja (cabecera caliente) hasta que él toque el re-pin / CTA y confirme su finca real en el mini-mapa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)