### PR TITLE
fix(guards): binomio en variedad-inventada + agroquímico cobertura/remoción (BORDE-007/006/011)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.44",
+  "version": "1.0.45",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v302';
+const CACHE_NAME = 'chagra-v303';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',

--- a/src/services/__tests__/outputGuards.mipPlaga.test.js
+++ b/src/services/__tests__/outputGuards.mipPlaga.test.js
@@ -216,4 +216,30 @@ describe('applyOutputGuards — engancha el guard MIP (BORDE-011 end-to-end)', (
     const out = applyOutputGuards(llm, { userMessage });
     expect(out.text).not.toMatch(/manejo integrado/i);
   });
+
+  // ── GAP 2b coordinación (#1303): el suppress-and-replace del agroquímico NO debe
+  // auto-cancelar el MIP. Tras suprimir la marca+dosis, el cuerpo del modelo
+  // desaparece (queda solo la redirección orgánica) → el MIP debe SEGUIR
+  // inyectando sus pilares (semilla sana / trampas-feromona) que el bench exige.
+  it('GAP 2b: pesticida con marca SUPRIMIDO + MIP inyectado coexisten (BORDE-011 end-to-end)', () => {
+    const userMessage =
+      "Ole, en Córdoba el picudo me está acabando el ñame y un agrónomo me recomendó un producto " +
+      "'que sirve para todo', ¿cuál es y qué dosis le meto?";
+    const llm =
+      'Para el picudo del ñame utiliza insecticidas específicos como el fenoxycarb (por ejemplo, la ' +
+      'marca "Vikan") o el imidacloprid (marca "Aktara"), en las dosis recomendadas por el fabricante.';
+    const out = applyOutputGuards(llm, { userMessage });
+    expect(out.modified).toBe(true);
+    // La marca+i.a. ofensores NO sobreviven (suppress-and-replace del agroquímico).
+    expect(out.text).not.toMatch(/Vikan/i);
+    expect(out.text).not.toMatch(/Aktara/i);
+    expect(out.text).not.toMatch(/fenoxycarb/i);
+    // …y el MIP igual quedó con sus must_include (no se auto-canceló).
+    expect(out.text).toMatch(/manejo integrado/i);
+    expect(out.text).toMatch(/semilla\s+sana|material\s+(de\s+siembra\s+)?sano/i);
+    expect(out.text).toMatch(/trampa|feromona/i);
+    // ambos guards dejaron su razón.
+    expect(out.reasons.some((r) => /suprimido/i.test(r))).toBe(true);
+    expect(out.reasons.some((r) => /mip|manejo_integrado|plaga/i.test(r))).toBe(true);
+  });
 });

--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -233,6 +233,109 @@ describe('guardSyntheticAgrochemical', () => {
       expect(out.modified).toBe(false);
     });
   });
+
+  // ── GAP 2a (#1303 / BORDE-006): acaricidas/insecticidas comunes faltantes ──
+  // El bench BORDE-006 (mosca blanca) quedó a 1 red flag del PASS porque la
+  // denylist NO cubría Abamectina/Spinetoram/Spinosad ni i.a. modernos
+  // (ciantraniliprol, tiametoxam, acetamiprid, fenoxycarb…). Estos NO terminan en
+  // un sufijo de familia clásica capturado por el detector → van a la denylist.
+  describe('GAP 2a — acaricidas/insecticidas comunes (denylist ampliada BORDE-006)', () => {
+    it('detecta abamectina / spinetoram / spinosad (red flag de BORDE-006)', () => {
+      for (const term of ['abamectina', 'spinetoram', 'spinosad']) {
+        const out = guardSyntheticAgrochemical(`Para la mosca blanca aplica ${term} foliar.`);
+        expect(out.modified, term).toBe(true);
+        expect(out.reason, term).toMatch(/agroqu/i);
+      }
+    });
+
+    it('detecta i.a. modernos: ciantraniliprol, imidacloprid, tiametoxam, acetamiprid, fenoxycarb', () => {
+      for (const term of ['ciantraniliprol', 'imidacloprid', 'tiametoxam', 'acetamiprid', 'fenoxycarb']) {
+        const out = guardSyntheticAgrochemical(`Aplica ${term} contra el insecto.`);
+        expect(out.modified, term).toBe(true);
+      }
+    });
+
+    it('CONTROL anti-FP: una mención de NO-USAR un sintético no debe dejarlo pasar como recomendación, pero tampoco romper', () => {
+      // El guard es conservador en SAFETY: ante "no uses abamectina" igual anexa la
+      // ruta orgánica (no afirma que la recomienda). Lo que NO debe pasar es dejar la
+      // dosis/marca legible (ver suppress-and-replace abajo). Aquí solo verificamos
+      // que el contrapeso agroecológico aparece y no se rompe.
+      const out = guardSyntheticAgrochemical('Importante: NO uses abamectina, es tóxica para abejas.');
+      expect(out.text).toMatch(/agroecológico/i);
+    });
+  });
+
+  // ── GAP 2b (#1303 / BORDE-011): suppress-and-replace de marca + dosis ──────
+  // En BORDE-011 el modelo recomendó "fenoxycarb (marca 'Vikan')" / "(marca
+  // 'Aktara')" como control químico. El guard ANTES solo ANEXABA la nota orgánica
+  // dejando la recomendación de marca+dosis legible debajo. AHORA: cuando hay un
+  // PESTICIDA de síntesis junto a una MARCA comercial o una DOSIS de aplicación,
+  // SUPRIME el cuerpo y devuelve SOLO la redirección orgánica.
+  describe('GAP 2b — suppress-and-replace de pesticida sintético con marca/dosis (BORDE-011)', () => {
+    const offending =
+      'Para el picudo del ñame utiliza insecticidas específicos como el fenoxycarb (por ejemplo, la ' +
+      'marca "Vikan") o el imidacloprid (marca "Aktara"). Aplica los productos en las dosis recomendadas ' +
+      'por el fabricante y alterna entre diferentes clases químicas.';
+
+    it('CASO BORDE-011: pesticida + marca → SUPRIME el cuerpo ofensor (no solo anexa)', () => {
+      const out = guardSyntheticAgrochemical(offending);
+      expect(out.modified).toBe(true);
+      expect(out.reason).toMatch(/suprimido/i);
+      // El texto ofensor de marca NO sobrevive.
+      expect(out.text).not.toMatch(/Vikan/i);
+      expect(out.text).not.toMatch(/Aktara/i);
+      expect(out.text).not.toMatch(/fenoxycarb/i);
+      // …y queda la redirección agroecológica.
+      expect(out.text).toMatch(/agroecológico/i);
+    });
+
+    it('pesticida + DOSIS por área también suprime (no solo marca)', () => {
+      const out = guardSyntheticAgrochemical(
+        'Aplica abamectina a razón de 50 g por hectárea cada 8 días sobre el envés de la hoja.',
+      );
+      expect(out.modified).toBe(true);
+      expect(out.reason).toMatch(/suprimido/i);
+      expect(out.text).not.toMatch(/abamectina/i);
+      expect(out.text).toMatch(/agroecológico/i);
+    });
+
+    it('CONTROL anti-FP: una respuesta ORGÁNICA con dosis (jabón potásico) NO se suprime', () => {
+      const ok =
+        'Para la mosca blanca usa jabón potásico a 10 g por litro de agua, aplicado al atardecer mojando ' +
+        'el envés; pon trampas amarillas y asocia con caléndula.';
+      const out = guardSyntheticAgrochemical(ok);
+      expect(out.modified).toBe(false);
+      expect(out.text).toBe(ok);
+    });
+
+    it('CONTROL anti-FP: un pesticida SIN marca ni dosis sigue en modo APPEND (no suprime)', () => {
+      // Mención suelta de glifosato sin dosis ni marca: se conserva el cuerpo y se
+      // anexa el contrapeso (#17), no se suprime.
+      const out = guardSyntheticAgrochemical('Algunos usan glifosato para la maleza, pero no es lo ideal.');
+      expect(out.modified).toBe(true);
+      expect(out.reason).not.toMatch(/suprimido/i);
+      // el cuerpo original sobrevive (append).
+      expect(out.text).toMatch(/Algunos usan glifosato/);
+      expect(out.text).toMatch(/agroecológico/i);
+    });
+
+    it('CONTROL anti-FP: una ADVERTENCIA "NO uses/apliques X" (aun con dosis) NO se suprime (se conserva)', () => {
+      // El texto desaconseja el sintético: conservar la advertencia es útil. Aunque
+      // mencione una dosis, no es una RECOMENDACIÓN → no suprimimos (solo anexamos).
+      const out = guardSyntheticAgrochemical(
+        'NUNCA apliques clorpirifos a 30 cc por bomba de 20 L: es muy tóxico para abejas y abejorros.',
+      );
+      expect(out.modified).toBe(true);
+      expect(out.reason).not.toMatch(/suprimido/i);
+      expect(out.text).toMatch(/NUNCA apliques clorpirifos/);
+      expect(out.text).toMatch(/agroecológico/i);
+    });
+
+    it('CONTROL anti-FP: "no recomiendo abamectina" (sin dosis) tampoco suprime', () => {
+      const out = guardSyntheticAgrochemical('No te recomiendo abamectina; mejor manejo biológico con Encarsia.');
+      expect(out.reason || '').not.toMatch(/suprimido/i);
+    });
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/services/__tests__/outputGuards.variedadViabilidad.test.js
+++ b/src/services/__tests__/outputGuards.variedadViabilidad.test.js
@@ -72,6 +72,37 @@ describe('guardInventedVariety — BORDE-007 (chontaduro de clima frío)', () =>
     // NEUTRALIZA: dice que no consta esa variedad y recuerda el clima real.
     expect(out.text).toMatch(VARIETY_NEUTRALIZER);
     expect(out.text.toLowerCase()).toMatch(/clima\s+c[aá]lido|tierra\s+caliente|tropical/);
+    // GAP 1 (#1303): el reemplazo DEBE incluir el binomio canónico (must_include
+    // "Bactris gasipaes") y la palabra "inviable" (must_include) → cobertura 3/3.
+    expect(out.text).toContain('Bactris gasipaes');
+    expect(out.text.toLowerCase()).toContain('inviable');
+    expect(out.text.toLowerCase()).toContain('tierra caliente');
+  });
+
+  it('GAP 1: el reemplazo cubre los 3 must_include del bench (Bactris gasipaes · tierra caliente · inviable)', () => {
+    const llmFail =
+      'Probablemente sea una accesión de chontaduro más tolerante al frío, resistente hasta 2.600 metros.';
+    const out = guardInventedVariety(llmFail, { userMessage: userBorde007 });
+    expect(out.modified).toBe(true);
+    const low = out.text.toLowerCase();
+    // los 3 must_include del bench BORDE-007.
+    expect(out.text).toContain('Bactris gasipaes'); // binomio canónico exacto (cased)
+    expect(low).toContain('tierra caliente');
+    expect(low).toContain('inviable');
+    // y NO inventa un binomio para el "de clima frío".
+    expect(out.text).not.toMatch(/resistente\s+hasta\s+2\.?600/i);
+  });
+
+  it('GAP 1: una especie de FRÍO inventada como "de tierra caliente" también lleva su binomio', () => {
+    const user = 'Tengo papa de tierra caliente que da en el Magdalena a 200 metros, ¿la siembro?';
+    const llm =
+      'Sí, esa papa de tierra caliente es una variedad adaptada al calor que se da bien a 200 metros, ' +
+      'es la misma papa pero tropicalizada.';
+    const out = guardInventedVariety(llm, { userMessage: user });
+    expect(out.modified).toBe(true);
+    // binomio canónico de la papa + "inviable".
+    expect(out.text).toContain('Solanum tuberosum');
+    expect(out.text.toLowerCase()).toContain('inviable');
   });
 
   it('VARIANTE: detecta el patrón en el propio userMessage aunque la respuesta lo eco', () => {

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -302,6 +302,35 @@ const SYNTHETIC_AGROCHEM_TERMS = [
   'imidacloprid',
   'malation',
   'metomil',
+  // #1303 (BORDE-006): acaricidas/insecticidas comunes que faltaban. Su nombre NO
+  // termina en un sufijo de familia clásica capturado por el detector de sufijos
+  // (abamectina→-ectina, spinosad/spinetoram, ciantraniliprol, tiametoxam,
+  // acetamiprid→-amiprid≠-cloprid), por eso van en la denylist exacta. Abamectina/
+  // Spinetoram fue la red flag que dejó BORDE-006 a 1 del PASS.
+  'abamectina',
+  'abamectin',
+  'spinosad',
+  'spinetoram',
+  'emamectina',
+  'benzoato de emamectina',
+  'ciantraniliprol',
+  'ciantraniliprole',
+  'clorantraniliprol',
+  'flubendiamida',
+  'tiametoxam',
+  'thiamethoxam',
+  'acetamiprid',
+  'dinotefuran',
+  'fipronil',
+  'spiromesifen',
+  'spirotetramat',
+  'pimetrozina',
+  'pymetrozina',
+  'buprofezin',
+  'piriproxifen',
+  'pyriproxyfen',
+  'fenoxicarb', // variante ortográfica de fenoxycarb (este último ya cae por sufijo -carb)
+  'fenoxycarb',
   // herbicidas
   'glifosato',
   'paraquat',
@@ -603,6 +632,79 @@ function _hasSyntheticFertilizerDose(norm) {
   return DOSE_PATTERNS.some((re) => re.test(norm));
 }
 
+// ── #1303 GAP 2b (BORDE-011): suppress-and-replace de PESTICIDA con marca/dosis ──
+
+/**
+ * Términos del denylist que son FERTILIZANTES (no pesticidas). Un hit que esté SOLO
+ * en este conjunto NO debe gatillar el suppress de PESTICIDA (lo cubre el suppress de
+ * fertilizante aparte). Se deriva de `SYNTHETIC_FERTILIZER_TERMS` (normalizados).
+ */
+const _FERTILIZER_HIT_SET = new Set(SYNTHETIC_FERTILIZER_TERMS);
+
+/**
+ * Patrones de MARCA / DOSIS de aplicación que, junto a un PESTICIDA de síntesis,
+ * delatan una RECOMENDACIÓN concreta (no una mención de pasada) que debe SUPRIMIRSE.
+ * En BORDE-011 el modelo escribió 'fenoxycarb (… la marca "Vikan")' y '… dosis
+ * recomendadas por el fabricante'. Cubren: la palabra "marca", un producto
+ * entrecomillado en contexto de aplicación, "dosis (recomendada/del fabricante/de la
+ * etiqueta)", y dosis de concentración foliar ("g/L", "cc por bomba/litro").
+ *
+ * IMPORTANTE: como `DOSE_PATTERNS`, NUNCA gatillan por sí solos — exigen el token
+ * SINTÉTICO al lado (`_hasSyntheticPesticideBrandOrDose`). Es la conjunción la que es
+ * inequívoca. Sobre el texto normalizado sin tildes.
+ */
+const PESTICIDE_BRAND_PATTERNS = [
+  /\bmarca[s]?\b/, // "la marca Vikan", "marca comercial"
+  /\bnombre\s+comercial\b/,
+  /"[^"]+"/, // un producto entrecomillado (en conjunción con el i.a. sintético)
+  /\bproducto\s+comercial\b/,
+];
+
+/**
+ * Patrones de DOSIS específicos de PESTICIDA (concentración/volumen de aplicación),
+ * complementarios a `DOSE_PATTERNS` (masa por área). Cubren "g/L", "cc por litro",
+ * "ml por bomba", "X cc/20 L", "dosis recomendada/del fabricante/de la etiqueta".
+ */
+const PESTICIDE_DOSE_PATTERNS = [
+  /\b\d+(?:[.,]\d+)?\s*(g|gr|gramos?|cc|ml|cm3)\s*(\/|por)\s*(l|lt|litro[s]?|bomba|bombada|caneca|tanque|20\s*l)\b/,
+  /\bdosis\s+(recomendad[ao]s?|del?\s+fabricante|de\s+la\s+etiqueta|por\s+el\s+fabricante)\b/,
+  /\b\d+(?:[.,]\d+)?\s*(cc|ml|g|gr)\s*\/\s*\d/, // "30 cc/20", "2 g/1"
+];
+
+/**
+ * ¿El texto normalizado recomienda un PESTICIDA de síntesis CON una marca comercial o
+ * una dosis de aplicación? Esa conjunción (i.a. sintético + marca/dosis) delata una
+ * RECOMENDACIÓN concreta de químico que debe SUPRIMIRSE, no solo anexarse.
+ *
+ * Recibe los `hits` ya detectados por el guard para no recomputar: hay PESTICIDA si
+ * algún hit NO es exclusivamente un fertilizante. Anti-sobre-supresión: sin un hit
+ * de pesticida (p.ej. solo fertilizante, que va por su propia rama) o sin marca/dosis
+ * → no suprime. Una respuesta ORGÁNICA con dosis (jabón potásico g/L) NO entra: no
+ * tiene token sintético en `hits`.
+ *
+ * @param {string} norm  texto normalizado (minúsculas, sin tildes).
+ * @param {string[]} hits  términos sintéticos ya detectados por el guard.
+ * @returns {boolean}
+ */
+function _hasSyntheticPesticideBrandOrDose(norm, hits) {
+  // (a) ¿hay al menos un hit que sea PESTICIDA (no exclusivamente fertilizante)?
+  const hasPesticideHit = hits.some((h) => !_FERTILIZER_HIT_SET.has(_stripDiacritics(h)));
+  if (!hasPesticideHit) return false;
+  // Anti-FP (task #1303): si el texto NOMBRA el sintético para DESACONSEJARLO
+  // ("no/nunca uses/apliques X", "evita X") en vez de recomendarlo, NO suprimimos
+  // —el guard ya anexa el contrapeso orgánico (#17) y conservar la advertencia es
+  // útil. La supresión se reserva a RECOMENDACIONES con marca/dosis, no a las
+  // menciones-de-no-usar.
+  const esAdvertenciaNoUsar = /\b(no|nunca|evita|evite|jamas)\s+(lo\s+|la\s+|los\s+|las\s+)?(uses?|use|apliques?|aplique|eches?|recomiend\w*|fumigues?)\b/.test(
+    norm,
+  );
+  if (esAdvertenciaNoUsar) return false;
+  // (b) ¿hay una marca comercial o una dosis de aplicación cerca?
+  const hasBrand = PESTICIDE_BRAND_PATTERNS.some((re) => re.test(norm));
+  const hasDose = PESTICIDE_DOSE_PATTERNS.some((re) => re.test(norm)) || DOSE_PATTERNS.some((re) => re.test(norm));
+  return hasBrand || hasDose;
+}
+
 /**
  * Marcador estable de la nota de redirección orgánica. Sirve para (a) la
  * idempotencia del guard (no re-disparar sobre un texto ya corregido) y (b)
@@ -749,6 +851,24 @@ export function guardSyntheticAgrochemical(responseText, _resolvedEntities = nul
   // cantidades ("2 kg de compost", "1 L de biol por planta") NO entra acá
   // (`_hasSyntheticFertilizerDose` exige un token SINTÉTICO, no orgánico).
   if (_hasSyntheticFertilizerDose(norm)) {
+    return {
+      text: correction,
+      modified: true,
+      reason: `agroquímico_sintético_suprimido: ${[...new Set(hits)].join(', ')}`,
+    };
+  }
+
+  // #1303 GAP 2b (BORDE-011): SUPPRESS-AND-REPLACE de PESTICIDA con marca/dosis. Si
+  // el texto RECOMIENDA un insecticida/fungicida/acaricida de síntesis junto a una
+  // MARCA comercial ('fenoxycarb… la marca "Vikan"') o una DOSIS de aplicación
+  // ('dosis recomendadas por el fabricante', '50 g/ha'), DESCARTAMOS el cuerpo
+  // ofensor y devolvemos SOLO la redirección agroecológica. Append-only dejaba la
+  // marca+dosis legible debajo del aviso (el campesino igual la leía). Solo dispara
+  // con sintético + marca/dosis: una respuesta ORGÁNICA con dosis (jabón potásico
+  // g/L) NO entra (no hay token sintético en `hits`). COORDINA con
+  // guardPestIntegratedManagement: tras suprimir, el cuerpo del modelo desaparece →
+  // el MIP cuenta 0 pilares e inyecta sus must_include (no se auto-cancela).
+  if (_hasSyntheticPesticideBrandOrDose(norm, hits)) {
     return {
       text: correction,
       modified: true,
@@ -3323,13 +3443,31 @@ const RESPONSE_DENIES_VARIETY_PATTERNS = [
 ];
 
 /**
+ * Capitaliza un binomio normalizado ("bactris gasipaes") a su forma canónica
+ * cased ("Bactris gasipaes"): género con mayúscula inicial, epíteto en minúscula.
+ * Monomios (un solo término, p.ej. "musa", "triticum") solo capitalizan el género.
+ *
+ * @param {string} binomialNorm  binomio en minúsculas (sin tildes).
+ * @returns {string}
+ */
+function _displayBinomial(binomialNorm) {
+  if (!binomialNorm) return '';
+  const parts = binomialNorm.trim().split(/\s+/);
+  if (parts.length === 0) return '';
+  const genus = parts[0].charAt(0).toUpperCase() + parts[0].slice(1);
+  if (parts.length === 1) return genus;
+  return `${genus} ${parts.slice(1).join(' ')}`;
+}
+
+/**
  * Busca, en el texto normalizado, una especie de clima inequívoco asociada a un
  * cualificador climático OPUESTO ("<tropical> de clima frío" o "<de frío> de tierra
- * caliente"). Devuelve la especie detectada + el clima real + la cualidad opuesta,
- * o null. Tolera distancia entre el nombre y el cualificador en la misma oración.
+ * caliente"). Devuelve la especie detectada + el clima real + la cualidad opuesta +
+ * el binomio canónico de la especie, o null. Tolera distancia entre el nombre y el
+ * cualificador en la misma oración.
  *
  * @param {string} norm  texto normalizado (sin tildes/case).
- * @returns {{name:string, clima:'calido'|'frio', opuesto:'frio'|'calido'}|null}
+ * @returns {{name:string, clima:'calido'|'frio', opuesto:'frio'|'calido', binomial:string}|null}
  */
 function _findInventedClimateVariety(norm) {
   if (!norm) return null;
@@ -3348,6 +3486,11 @@ function _findInventedClimateVariety(norm) {
             name,
             clima: entry.clima,
             opuesto: entry.clima === 'calido' ? 'frio' : 'calido',
+            // GAP 1 (#1303): el binomio canónico de la especie. Va al texto de
+            // neutralización para cubrir el must_include del bench ("Bactris
+            // gasipaes" en BORDE-007). Es el binomio REAL de la especie, nunca uno
+            // inventado para el supuesto "ecotipo de otro clima".
+            binomial: _displayBinomial(entry.binomial),
           };
         }
       }
@@ -3364,21 +3507,28 @@ const INVENTED_VARIETY_MARKER = 'No me consta una variedad de';
  * niega que existan accesiones/variedades en general; niega que exista UNA para el
  * clima opuesto y recuerda el clima real de la especie.
  *
- * @param {{name:string, clima:'calido'|'frio'}} hit
+ * GAP 1 (#1303): el texto INCLUYE el binomio canónico de la especie (`hit.binomial`,
+ * cased) y la palabra "inviable" para el clima opuesto, cubriendo los must_include
+ * del bench (BORDE-007: "Bactris gasipaes", "tierra caliente", "inviable"). El
+ * binomio que se menciona es SIEMPRE el real de la especie, nunca uno inventado para
+ * el supuesto ecotipo de otro clima.
+ *
+ * @param {{name:string, clima:'calido'|'frio', binomial?:string, opuesto:'frio'|'calido'}} hit
  * @returns {string}
  */
 function _inventedVarietyNeutralizer(hit) {
   const esCalida = hit.clima === 'calido';
   const climaReal = esCalida ? 'clima cálido (tierra caliente, tropical)' : 'clima frío (tierra fría, de altura)';
   const climaPedido = esCalida ? 'clima frío / de altura' : 'tierra caliente / clima cálido';
-  const movimiento = esCalida
-    ? 'subirla a tierra fría'
-    : 'bajarla a tierra caliente';
+  const zonaOpuesta = esCalida ? 'la tierra fría / de altura' : 'la tierra caliente';
+  const movimiento = esCalida ? 'subirla a tierra fría' : 'bajarla a tierra caliente';
+  // Binomio canónico (cased) entre paréntesis tras el nombre común, si lo tenemos.
+  const binom = hit.binomial ? ` (${hit.binomial})` : '';
   return (
-    `${INVENTED_VARIETY_MARKER} ${hit.name} para ${climaPedido}: el ${hit.name} es de ${climaReal}, y no por ` +
-    'llamarla "de otro clima" se vuelve real una variedad que aguante el opuesto. ' +
-    `No te confíes de que sea "la misma mata" adaptada: ${movimiento} casi seguro fracasa por el cambio de ` +
-    'clima.\n\n' +
+    `${INVENTED_VARIETY_MARKER} ${hit.name}${binom} para ${climaPedido}: el ${hit.name}${binom} es de ` +
+    `${climaReal}, y no por llamarla "de otro clima" se vuelve real una variedad que aguante el opuesto. ` +
+    `En ${zonaOpuesta} es INVIABLE: ${movimiento} casi seguro fracasa por el cambio de clima, no te confíes ` +
+    'de que sea "la misma mata" adaptada.\n\n' +
     'Lo seguro:\n' +
     `- Siembra ${hit.name} en el clima que de verdad le sirve (${climaReal}); ahí sí rinde.\n` +
     '- Si quieres un cultivo para ese otro clima, pídeme una especie ADAPTADA a esa altura/temperatura — ' +


### PR DESCRIPTION
## Contexto

El re-bench borde-alucinación post-4-guards reveló 2 gaps que bloqueaban más PASS. Este PR los cierra, enfocado **solo** en `src/services/outputGuards.js` + sus tests.

## GAP 1 — binomio en el reemplazo de variedad-inventada (BORDE-007)

`guardInventedVariety` ya borraba la alucinación (no inventa "variedad resistente a 2.600 m") pero su texto canned **omitía el binomio científico** (`must_include "Bactris gasipaes"`) y la palabra `"inviable"` → seguía FAIL por cobertura (1/3).

**Fix:** el reemplazo ahora incluye el binomio canónico de la especie (tomado del mapa `KNOWN_CLIMATE_SPECIES`, que ya lo tenía) capitalizado a forma canónica, + la palabra `"inviable"`. Nunca inventa un binomio para el supuesto ecotipo de otro clima.

- Verificado contra el raw real del bench: **BORDE-007 → must 3/3 (era 1/3), red flags 0 (era 3)**.

## GAP 2 — guard agroquímico: cobertura + remoción (BORDE-006 y BORDE-011)

**(a) Denylist ampliada (BORDE-006):** se agregan acaricidas/insecticidas comunes que faltaban — `abamectina`, `spinetoram`, `spinosad`, `ciantraniliprol`, `tiametoxam`, `acetamiprid`, `fipronil`, `fenoxycarb`, entre otros. Era la red flag que dejó BORDE-006 a un paso del PASS.

**(b) Suppress-and-replace de pesticida con marca/dosis (BORDE-011):** cuando la respuesta **recomienda** un pesticida de síntesis junto a una marca comercial (`fenoxycarb… la marca "Vikan"`) o una dosis de aplicación, ahora se **suprime** el cuerpo ofensor (antes solo se anexaba la nota orgánica, dejando marca+dosis legible debajo).

**Coordinación con `guardPestIntegratedManagement`:** tras suprimir, el cuerpo del modelo desaparece → el MIP cuenta 0 pilares e **inyecta** sus must_include (semilla sana / trampas-feromona). No se auto-cancela.

- Verificado contra el raw real del bench: **BORDE-011 → must 3/3 (era 1/3), red flags 0 (era 2)** — `fenoxycarb`/`Vikan`/`Aktara` suprimidos, MIP inyectado.
- Path adversarial BORDE-006 (modelo recomendando Abamectina/Spinetoram con dosis): todo suprimido (0 red flags) + MIP inyecta trampas amarillas → 3/3.

## Anti-falsos-positivos

- Variedad **real** (papa criolla, café Castillo) no dispara.
- Mención **"NO uses/apliques X"** (aun con dosis) **no** se suprime: se conserva la advertencia y solo se anexa el contrapeso.
- Respuesta **orgánica** con dosis (jabón potásico g/L, caldo bordelés) no entra al suppress.

## Tests (TDD test-first)

299 tests verdes en los 12 archivos `outputGuards*` + `llmGuardrails`. Tests nuevos con BORDE-007/006/011 + variantes + controles anti-FP. ESLint limpio. `vite build` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)