### PR TITLE
fix(bench): bench-borde medía pipeline parcial (sin userMessage)

### DIFF
--- a/scripts/bench-borde-alucinacion.mjs
+++ b/scripts/bench-borde-alucinacion.mjs
@@ -247,7 +247,7 @@ async function main() {
       continue;
     }
 
-    const guarded = applyOutputGuards(gen.response, { resolvedEntities: entities, profileName: null });
+    const guarded = applyOutputGuards(gen.response, { resolvedEntities: entities, profileName: null, userMessage: p.prompt });
     const finalText = guarded.text;
     const validation = await postValidate(p.prompt, finalText);
 


### PR DESCRIPTION
## Bug del harness
`bench-borde-alucinacion.mjs` llamaba `applyOutputGuards(gen.response, { resolvedEntities, profileName: null })` **sin `userMessage`**. Los guards que gatean en intención del usuario — `guardPestIntegratedManagement` (#1301) y `guardFalsePremise` (#1295) — **nunca disparaban en el bench**, aunque SÍ lo hacen en PROD (`AgentScreen.jsx:1722` pasa `userMessage: text`). → el bench medía un pipeline **parcial** y subestimaba el prod real (BORDE-006/011 daban FAIL en el bench pero reciben la inyección MIP en prod).

## Fix
Una línea: `userMessage: p.prompt` (en este bench el prompt ES el mensaje del usuario). Ahora mide el path PROD completo. Verificado empíricamente: con userMessage, BORDE-006/011 → must 3/3.