### PR TITLE
chore(gitignore): ignorar salida de benchmarks → evita worktrees sucios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ chagra-anthropic-judge-key
 # CI no tiene acceso al repo privado para regenerarlo durante el build.
 # Cuando se actualicen los seeds, regenerar local + commit del .sqlite.
 # public/catalog.sqlite
+
+# Salida de benchmarks: EFÍMERA por defecto. El número que importa va a un doc
+# (BORDE_*_RESULTS) o a la página HYTA, NO al repo. Antes ensuciaba los worktrees
+# de los agentes → bloqueaba el auto-clean del worktree → se acumulaban (66 en una
+# semana) y al borrarlos se perdían artefactos untracked. Para persistir una
+# corrida puntual: `git add -f <ruta>`. (root 2026-06-04 retro worktrees sucios)
+/data/bench-runs/
+/data/bench-runs-test/

--- a/scripts/bench-borde-alucinacion.mjs
+++ b/scripts/bench-borde-alucinacion.mjs
@@ -53,8 +53,14 @@ import { applyOutputGuards } from '../src/services/outputGuards.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
-// BENCH_OUTPUT_DIR persiste FUERA del worktree efímero (al repo principal).
-const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(ROOT_DIR, 'data', 'bench-runs');
+// Default FUERA del repo/worktree (`_bench-results`): así un agente que corre el
+// bench en su worktree efímero NO pierde el artefacto al borrarse el worktree, y no
+// ensucia el árbol git. Override con BENCH_OUTPUT_DIR. Fallback a data/bench-runs
+// (gitignored) solo si el dir externo no es escribible. (retro worktrees 2026-06-04)
+const BENCH_EXTERNAL_DIR = '/home/kortux/Workspace/_bench-results';
+const BENCH_RUNS_DIR =
+  process.env.BENCH_OUTPUT_DIR ||
+  (existsSync(dirname(BENCH_EXTERNAL_DIR)) ? BENCH_EXTERNAL_DIR : join(ROOT_DIR, 'data', 'bench-runs'));
 
 // ── generador config-PROD (= ROUTES.chat_complex de llmRouter.js) ─────────────
 const GEN_MODEL = process.env.GEN_MODEL || 'granite3.1-dense:8b';


### PR DESCRIPTION
Root cause de los 66 worktrees acumulados: el runner escribe en data/bench-runs/ (no ignorado) → worktree sucio → no auto-limpia. Fix de 1 línea de sección. 🤖 Generated with [Claude Code](https://claude.com/claude-code)