### PR TITLE
fix(voz): whisper HTTP 500 por blob de audio vacío/truncado en móvil

### DIFF
--- a/src/hooks/useVoiceRecorder.js
+++ b/src/hooks/useVoiceRecorder.js
@@ -152,7 +152,12 @@ export default function useVoiceRecorder() {
         }).catch(() => {});
       };
 
-      rec.start();
+      // timeslice 250ms: fuerza `dataavailable` periódico. Sin él, algunos
+      // navegadores móviles entregan un único chunk al stop() que puede salir
+      // vacío/truncado → webm con header EBML inválido → Whisper HTTP 500
+      // "Failed to load audio: End of file". Con timeslice los chunks se
+      // acumulan y el Blob final siempre tiene contenedor válido.
+      rec.start(250);
       setIsRecording(true);
       startTsRef.current = Date.now();
 

--- a/src/services/__tests__/voiceService.test.js
+++ b/src/services/__tests__/voiceService.test.js
@@ -22,6 +22,11 @@ vi.mock('../syncManager', () => ({
 import { syncManager } from '../syncManager';
 import { transcribe, queueForRetry } from '../voiceService';
 
+// Blob de audio realista (>1024 bytes). transcribe() rechaza blobs diminutos
+// porque una captura fallida en móvil produce un webm vacío/truncado que hace
+// que Whisper responda HTTP 500 "Failed to load audio: End of file".
+const AUDIO_DATA = 'x'.repeat(2048);
+
 describe('voiceService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -42,7 +47,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
       const result = await transcribe(blob);
 
       expect(result).toBe('Choachí está a mil quinientos metros sobre el nivel del mar');
@@ -56,6 +61,21 @@ describe('voiceService', () => {
       expect(url).toContain('output=json');
     });
 
+    it('rechaza un Blob vacío/diminuto SIN llamar a Whisper (evita el HTTP 500)', async () => {
+      const mockFetch = vi.fn();
+      globalThis.fetch = mockFetch;
+
+      // Captura fallida en móvil: webm vacío (0 bytes) o truncado (header roto).
+      const empty = new Blob([], { type: 'audio/webm;codecs=opus' });
+      const truncated = new Blob(['x'.repeat(40)], { type: 'audio/webm' });
+
+      await expect(transcribe(empty)).rejects.toThrow('No se grabó audio');
+      await expect(transcribe(truncated)).rejects.toThrow('No se grabó audio');
+      await expect(transcribe(null)).rejects.toThrow('No se grabó audio');
+      // Nunca debe golpear el backend con basura.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('acepta lenguaje customizado via options.language', async () => {
       const mockFetch = vi.fn();
       mockFetch.mockResolvedValueOnce({
@@ -65,7 +85,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm' });
       const result = await transcribe(blob, { language: 'qu' });
 
       expect(result).toBe('wakichay tukuy imata');
@@ -85,7 +105,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
       const result = await transcribe(blob);
 
       expect(result).toBe('Fincas en Guatoc, La Calera, Sopó y Tabio cultivan café Castillo y lulo');
@@ -102,7 +122,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
       const result = await transcribe(blob);
 
       expect(result).toBe('El café arábica Borbón necesita biopreparados como el Bocashi y el Caldo bordelés');
@@ -117,7 +137,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/mp4' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/mp4' });
       await transcribe(blob);
 
       const formData = mockFetch.mock.calls[0][1].body;
@@ -135,7 +155,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
 
       await expect(transcribe(blob)).rejects.toThrow('Whisper 503');
     });
@@ -149,7 +169,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
 
       await expect(transcribe(blob)).rejects.toThrow('Transcripción vacía');
     });
@@ -163,7 +183,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
 
       await expect(transcribe(blob)).rejects.toThrow('Transcripción vacía');
     });
@@ -177,7 +197,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
       const result = await transcribe(blob);
 
       expect(result).toBe('Choachí');
@@ -195,7 +215,7 @@ describe('voiceService', () => {
       });
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
 
       // Iniciamos la transcripción
       const transcribePromise = transcribe(blob);
@@ -216,7 +236,7 @@ describe('voiceService', () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'));
       globalThis.fetch = mockFetch;
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
 
       await expect(transcribe(blob)).rejects.toThrow('Network error');
     });
@@ -226,7 +246,7 @@ describe('voiceService', () => {
     it('delega en syncManager.saveVoiceRecording con status pending', async () => {
       syncManager.saveVoiceRecording.mockResolvedValueOnce(undefined);
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
       await queueForRetry(blob, { reason: 'Whisper 503', durationMs: 4500 });
 
       expect(syncManager.saveVoiceRecording).toHaveBeenCalledTimes(1);
@@ -242,7 +262,7 @@ describe('voiceService', () => {
     it('usa valores default si metadata está incompleta', async () => {
       syncManager.saveVoiceRecording.mockResolvedValueOnce(undefined);
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
       await queueForRetry(blob, {});
 
       expect(syncManager.saveVoiceRecording).toHaveBeenCalledTimes(1);
@@ -257,7 +277,7 @@ describe('voiceService', () => {
     it('propaga errores de syncManager', async () => {
       syncManager.saveVoiceRecording.mockRejectedValueOnce(new Error('DB error'));
 
-      const blob = new Blob(['audio data'], { type: 'audio/webm;codecs=opus' });
+      const blob = new Blob([AUDIO_DATA], { type: 'audio/webm;codecs=opus' });
 
       await expect(queueForRetry(blob)).rejects.toThrow('DB error');
     });

--- a/src/services/voiceService.js
+++ b/src/services/voiceService.js
@@ -34,6 +34,15 @@ const TIMEOUT_MS = 15000;
  * // text => "wakichay tukuy imata"
  */
 export async function transcribe(blob, options = {}) {
+  // Guard: un Blob vacío o diminuto (captura fallida en móvil — MediaRecorder
+  // a veces produce un webm de 0 bytes o truncado) hace que Whisper responda
+  // HTTP 500 "Failed to load audio: End of file / invalid EBML number". Cortar
+  // acá con un mensaje claro al usuario en vez del round-trip + 500 críptico.
+  const MIN_AUDIO_BYTES = 1024;
+  if (!blob || typeof blob.size !== 'number' || blob.size < MIN_AUDIO_BYTES) {
+    throw new Error('No se grabó audio. Mantén presionado el botón y habla cerca del micrófono.');
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 


### PR DESCRIPTION
## Prod hotfix — la voz del usuario está rota AHORA

**Diagnóstico (en alpha):** whisper-http (:10301) está sano (`/docs`→200, no OOM). El 500 es `Failed to load audio: End of file / invalid EBML number` → le llega un webm **vacío/truncado** desde el teléfono.

**Causa raíz:** `useVoiceRecorder` llamaba `rec.start()` sin timeslice → el único chunk al `stop()` sale vacío/truncado en algunos navegadores móviles.

**Fix (2 capas):**
- `useVoiceRecorder`: `rec.start(250)` → contenedor webm válido.
- `voiceService.transcribe()`: guard de blob <1024 bytes → mensaje claro, no 500 críptico.
- +test (vacío/truncado/null nunca golpean el backend). 15/15 verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)