### PR TITLE
fix(agent): no anclar la respuesta a la altitud de la cabecera municipal

### DIFF
--- a/src/services/__tests__/agentService.test.js
+++ b/src/services/__tests__/agentService.test.js
@@ -706,6 +706,72 @@ describe('agentService — Task #202 Profile Context', () => {
         expect(matches.length).toBe(1);
       });
     });
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Incidente prod (piloto Choachí): cuando la ÚNICA altitud guardada es la
+    // de la CABECERA municipal (fallback offline DANE, `altitud_source:
+    // 'cabecera'`) — caso en que el GPS se difuminó a la cabecera en el primer
+    // onboarding y no quedó una altitud "buena" que proteger —, el agente la
+    // anclaba como si fuera la finca real (ej. "Choachí, 1923 msnm") y
+    // corrompía piso térmico, ventana de siembra y plagas. Choachí va de ~1.100
+    // a ~3.500 msnm según la vereda: el centroide municipal NO es la finca.
+    // El contexto del agente debe MARCAR esa altitud como incierta (cabecera,
+    // no finca) y pedir confirmar la altitud real, en vez de afirmarla.
+    // ──────────────────────────────────────────────────────────────────────
+    describe('altitud de cabecera (no finca) — no anclar como confirmada', () => {
+      const cabeceraProfile = {
+        municipio: 'Choachí',
+        departamento: 'Cundinamarca',
+        finca_altitud: '1923',
+        altitud_source: 'cabecera',
+        ubicacion_lat: 4.529,
+        ubicacion_lng: -73.923,
+      };
+
+      it('marca la altitud como CABECERA del municipio, no como la de la finca', () => {
+        const ctx = buildFincaContext({ profile: cabeceraProfile, month: 5 });
+        // La altitud sigue presente (es la mejor estimación disponible)…
+        expect(ctx).toContain('1923 msnm');
+        // …pero NO se presenta como dato confirmado de la finca: se rotula
+        // como cabecera/aproximada para que el agente no la afirme.
+        expect(ctx.toLowerCase()).toContain('cabecera');
+      });
+
+      it('instruye al agente a NO afirmar piso térmico/viabilidad sobre la cabecera y a pedir la altitud real', () => {
+        const ctx = buildFincaContext({ profile: cabeceraProfile, month: 5 });
+        expect(ctx).toMatch(/altitud real|confirm/i);
+      });
+
+      it('NO marca cabecera cuando la altitud viene de GPS/elevación (source confiable)', () => {
+        const ctx = buildFincaContext({
+          profile: { ...cabeceraProfile, finca_altitud: '2580', altitud_source: 'elevation_api' },
+          month: 5,
+        });
+        expect(ctx).toContain('2580 msnm');
+        expect(ctx.toLowerCase()).not.toContain('cabecera');
+      });
+
+      it('NO marca cabecera cuando el usuario fijó la altitud a mano (manual)', () => {
+        const ctx = buildFincaContext({
+          profile: { ...cabeceraProfile, finca_altitud: '2580', altitud_source: 'manual' },
+          month: 5,
+        });
+        expect(ctx).toContain('2580 msnm');
+        expect(ctx.toLowerCase()).not.toContain('cabecera');
+      });
+
+      it('la altitud REAL de la finca activa manda sobre la cabecera del perfil', () => {
+        // Si la finca activa trae su propia altitud confirmada, esa es la
+        // verdad: no hay que rotular cabecera aunque el perfil esté contaminado.
+        const ctx = buildFincaContext({
+          profile: cabeceraProfile,
+          finca: { nombre: 'La Esperanza', altitud: 2580 },
+          month: 5,
+        });
+        expect(ctx).toContain('2580 msnm');
+        expect(ctx.toLowerCase()).not.toContain('cabecera');
+      });
+    });
   });
 
   // ────────────────────────────────────────────────────────────────────────

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -1319,9 +1319,36 @@ export function buildFincaContext({
     (finca && typeof finca.vereda === 'string' && finca.vereda.trim()) ||
     (typeof p.vereda === 'string' && p.vereda.trim()) ||
     null;
-  const altitud = p.finca_altitud || (finca && finca.altitud) || null;
+  // Altitud — PRECEDENCIA por confiabilidad (incidente prod piloto Choachí):
+  //   1. La altitud de la FINCA ACTIVA (registro de finca, confirmada).
+  //   2. La altitud del perfil (`finca_altitud`).
+  // La altitud de la finca activa manda: si existe, es la verdad de SU punto,
+  // aunque el perfil esté contaminado con la cabecera municipal.
+  const fincaAltitud = finca && finca.altitud != null ? finca.altitud : null;
+  const altitud = fincaAltitud != null ? fincaAltitud : p.finca_altitud || null;
+
+  // ¿La altitud que vamos a inyectar es SOLO la de la CABECERA municipal
+  // (fallback offline DANE), sin que GPS/elevación/manual la confirmen?
+  //
+  // Caso del piloto: el navegador difuminó el GPS a la cabecera de Choachí en
+  // el primer onboarding (1923 msnm), no quedó una altitud "buena" que el
+  // coalesce de persistencia (resolveAltitudToSave) pudiera proteger, y se
+  // guardó `altitud_source: 'cabecera'`. Choachí va de ~1.100 a ~3.500 msnm
+  // según la vereda: la cabecera NO es la finca. Si el agente ancla TODO a esa
+  // altitud (piso térmico, ventana de siembra, plagas) corrompe la respuesta.
+  //
+  // Solo es cabecera si: viene del perfil (no de la finca activa, que es
+  // confiable) Y su fuente persistida es 'cabecera'. GPS ('elevation_api'),
+  // explícita ('dado') o manual ('manual') son confiables → no se marca.
+  const altitudIsCabecera =
+    fincaAltitud == null &&
+    altitud != null &&
+    p.altitud_source === 'cabecera';
+
   const piso =
-    (p.piso_termico && String(p.piso_termico).trim()) ||
+    (p.piso_termico && String(p.piso_termico).trim() && !altitudIsCabecera
+      ? String(p.piso_termico).trim()
+      : null) ||
     pisoTermicoFromAltitud(altitud) ||
     null;
   const lat = Number(p.ubicacion_lat);
@@ -1336,8 +1363,16 @@ export function buildFincaContext({
       : null;
   const lugar = [veredaPrefix, municipio, departamento].filter(Boolean).join(', ');
   if (lugar) ubic.push(lugar);
-  if (altitud) ubic.push(`~${altitud} msnm`);
-  if (piso) ubic.push(`piso ${piso}`);
+  if (altitud) {
+    // Altitud de cabecera → rótulo explícito "aproximada (cabecera...)" para
+    // que el modelo NO la presente como dato confirmado de la finca.
+    ubic.push(
+      altitudIsCabecera
+        ? `~${altitud} msnm (aproximada — cabecera municipal, NO la finca)`
+        : `~${altitud} msnm`,
+    );
+  }
+  if (piso) ubic.push(`piso ${piso}${altitudIsCabecera ? ' aproximado' : ''}`);
   if (Number.isFinite(lat) && Number.isFinite(lng)) {
     ubic.push(`(${lat.toFixed(3)}, ${lng.toFixed(3)})`);
   }
@@ -1345,6 +1380,17 @@ export function buildFincaContext({
     lines.push(`Finca activa: "${finca.nombre}"${ubic.length ? ` — ${ubic.join(', ')}` : ''}.`);
   } else if (ubic.length) {
     lines.push(`Ubicación: ${ubic.join(', ')}.`);
+  }
+
+  // Incidente prod piloto Choachí: cuando la altitud es solo la de la cabecera
+  // municipal, el agente debe DECIRLE al usuario que esa altura es aproximada
+  // (la del pueblo, no su finca) y pedirle que confirme la altitud real de su
+  // finca, en vez de anclar piso térmico / ventana de siembra / plagas a un
+  // dato que puede estar cientos de metros equivocado.
+  if (altitudIsCabecera) {
+    lines.push(
+      `ALTITUD APROXIMADA: la altitud de arriba (~${altitud} msnm) es la de la CABECERA del municipio, NO la de la finca del usuario — el GPS no precisó su punto. El municipio abarca varios pisos térmicos según la vereda. NO afirmes piso térmico, ventana de siembra ni viabilidad de cultivos como certezas a partir de esta altitud: trátala como referencia gruesa y, cuando sea relevante, pídele al usuario que confirme la altitud REAL de su finca (o que ajuste su ubicación) para darle recomendaciones precisas.`,
+    );
   }
 
   // #357 — instrucción de LOCALIZACIÓN: cuando reporte clima/pronóstico, que


### PR DESCRIPTION
## Bug
En la PWA, todas las respuestas del agente se anclaban a la altitud de la **cabecera del municipio** (ej. "Choachí, 1923 msnm") en vez de a la altitud real de la finca del usuario. Un municipio andino abarca varios pisos térmicos según la vereda (Choachí va de ~1.100 a ~3.500 msnm), así que anclar al centroide del municipio corrompe piso térmico, ventana de siembra y plagas probables. El usuario reportó: "sigue saliendo mi ubicación en el pueblo no en [la finca]".

## Causa raíz
La capa de **persistencia** ya estaba bien protegida: `resolveAltitudToSave` (`userProfileService.js`) etiqueta la altitud con `altitud_source` y evita pisar una buena altitud con el fallback de cabecera (`'cabecera'`). El hueco estaba en la capa de **consumo**:

`buildFincaContext` (`agentService.js:1322`) inyectaba `p.finca_altitud` en el bloque de contexto ambiental del agente **sin mirar nunca `altitud_source`**. Cuando la única altitud que se guardó es la de cabecera —exactamente el caso del piloto: el navegador difuminó el GPS a la cabecera en el primer onboarding y no quedó una altitud "buena" que el coalesce pudiera proteger—, el agente trataba la altitud del pueblo como la de la finca.

Ningún consumidor (`buildFincaContext`, `TopBar`, `ClimaStrip`, `alertEngine`, `sidecarClient`) leía `altitud_source`. Confirmado por grep: cero lecturas fuera de los archivos de persistencia.

Bug secundario detectado por un test: la precedencia `p.finca_altitud || finca.altitud` hacía que el perfil contaminado ganara sobre la altitud real de la finca activa. Corregido: la finca activa manda.

## Cambios
- `src/services/agentService.js` — `buildFincaContext`:
  - precedencia de altitud: finca activa (confirmada) **sobre** perfil;
  - detecta la altitud "solo cabecera" (`altitud_source === 'cabecera'` y sin finca activa que la confirme) y la rotula como aproximada — "cabecera municipal, NO la finca";
  - añade una instrucción al contexto: el agente NO debe afirmar piso térmico/viabilidad como certezas sobre esa altitud y debe pedir la altitud real de la finca;
  - GPS/elevación (`elevation_api`/`dado`) y manual (`manual`) siguen tratándose como confiables; no se rotulan.
- `src/services/__tests__/agentService.test.js` — 5 casos nuevos (TDD test-first).

## Tests
- 5 vitest nuevos passing (cabecera se rotula y pide confirmar; GPS/manual NO se rotulan; finca activa manda sobre perfil contaminado).
- Suite `agentService.test.js` completa verde: 124/124.
- Suites de ubicación relacionadas verdes: 156/156 (colombiaLocations, ClimaStrip.coarseConfidence, TopBar.locationLine, LocationDetectedScreen.coarse).
- ESLint `--max-warnings=0` limpio en los archivos tocados.

> Nota: la suite global mostró fallos intermitentes `spawn ENOMEM` en `styles/themes.coverage.test.js` (CSS, no relacionado) por presión de memoria del host con agentes en paralelo; reproducen sin este cambio.

Refs: incidente piloto Choachí (altitud de pueblo, no de finca)