### PR TITLE
fix(ui): botón Volver siempre alcanzable en el agente + acción visible en la última tarjeta

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -2633,7 +2633,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     : 'Escribe tu pregunta...';
 
   return (
-    <div className={`h-full flex flex-col bg-slate-950 ${entranceClassRef.current}`}>
+    <div className={`h-[100dvh] flex flex-col bg-slate-950 overflow-hidden ${entranceClassRef.current}`}>
       {/* B1: animación de entrada (fade+rise) para que se perciba el cruce al
           agente. Respeta prefers-reduced-motion vía @media en el CSS. */}
       <style>{AGENT_ENTRANCE_CSS}</style>
@@ -2770,6 +2770,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         onCancelDeepResearch={handleCancelDeepResearch}
         proactiveGreeting={proactiveGreeting}
         onGreetingPrompt={(prompt) => prompt && setInputText(prompt)}
+        onBack={onBack}
       />
 
       {/* Error */}

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -1,10 +1,29 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { ArrowLeft } from 'lucide-react';
 import ChatBubble from './ChatBubble';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 import DeepResearchCard from '../DeepResearchCard';
 
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, proactiveGreeting = null, onGreetingPrompt }) {
+// Bug piloto 2026-06-04 (B): "para devolverme tengo que ir hasta el inicio de
+// la conversación sin importar lo larga que sea". El único "Volver" vivía en el
+// header. Umbral en px a partir del cual mostramos un botón "Volver" FLOTANTE
+// dentro del área de chat — así el operador puede salir sin scrollear hasta
+// arriba. 160px ≈ un par de mensajes desplazados: suficiente para saber que ya
+// no estamos viendo el header.
+const FLOATING_BACK_THRESHOLD_PX = 160;
+
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, proactiveGreeting = null, onGreetingPrompt, onBack }) {
   const bottomRef = useRef(null);
+  const scrollRef = useRef(null);
+  // (B) Botón "Volver" flotante: visible solo cuando el operador se alejó del
+  // inicio (header fuera de vista). Arriba del todo lo ocultamos porque el
+  // header ya ofrece su propio "Volver" y no queremos duplicar affordance.
+  const [showFloatingBack, setShowFloatingBack] = useState(false);
+
+  const handleScroll = useCallback((e) => {
+    const top = e?.target?.scrollTop ?? scrollRef.current?.scrollTop ?? 0;
+    setShowFloatingBack(top > FLOATING_BACK_THRESHOLD_PX);
+  }, []);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -56,7 +75,30 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
   };
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto p-4 pb-2">
+    <div className="relative flex-1 min-h-0">
+      {/* (B) Botón "Volver" FLOTANTE: sticky-ish respecto al área de chat,
+          aparece al alejarse del inicio. Resuelve "tengo que ir hasta el
+          inicio para devolverme". La animación de entrada respeta
+          prefers-reduced-motion vía el CSS de abajo. */}
+      {typeof onBack === 'function' && showFloatingBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          data-testid="chat-floating-back"
+          aria-label="Volver"
+          className="chagra-floating-back absolute top-3 left-3 z-20 flex items-center gap-1.5 pl-2 pr-3 py-2 rounded-full bg-slate-900/90 backdrop-blur-sm border border-slate-700 text-amber-300 shadow-lg active:scale-95 hover:bg-slate-800"
+        >
+          <ArrowLeft size={18} className="text-amber-400" />
+          <span className="text-xs font-semibold">Volver</span>
+        </button>
+      )}
+      <style>{FLOATING_BACK_CSS}</style>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        data-testid="chat-scroll"
+        className="h-full overflow-y-auto p-4 pb-28"
+      >
       {messages.map((msg, idx) => {
         // Deep Research (A6/A7): si el mensaje lleva _deepResearch, renderizamos
         // el card de progreso/informe en lugar de (o junto a) la burbuja.
@@ -123,10 +165,29 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
         />
       )}
 
-      <div ref={bottomRef} />
+        <div ref={bottomRef} />
+      </div>
     </div>
   );
 }
+
+/**
+ * CSS del botón "Volver" flotante. Fade+rise corto al aparecer; neutralizado
+ * bajo prefers-reduced-motion siguiendo el patrón del proyecto (agentEntrance,
+ * BiopunkBackground). Inyectado una vez vía <style> en el área de chat.
+ */
+const FLOATING_BACK_CSS = `
+@keyframes chagra-floating-back-kf {
+  0% { opacity: 0; transform: translateY(-6px); }
+  100% { opacity: 1; transform: translateY(0); }
+}
+.chagra-floating-back {
+  animation: chagra-floating-back-kf 200ms ease-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chagra-floating-back { animation: none !important; }
+}
+`;
 
 /**
  * ProactiveGreeting — el saludo de entrada DINÁMICO del agente. Lidera con lo

--- a/src/components/AgentScreen/__tests__/ChatHistory.backButton.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatHistory.backButton.test.jsx
@@ -1,0 +1,86 @@
+/**
+ * ChatHistory.backButton.test.jsx — botón "Volver" flotante siempre alcanzable.
+ *
+ * Bug reportado por piloto (2026-06-04): "para devolverme tengo que ir hasta el
+ * inicio de la conversación sin importar lo larga que sea". El único botón de
+ * volver vivía SOLO en el header; en una conversación larga el operador tenía
+ * que hacer scroll completo hasta arriba para salir.
+ *
+ * Fix: ChatHistory (dueño del contenedor scrollable) expone un botón "Volver"
+ * FLOTANTE que aparece cuando el operador hace scroll hacia abajo y se aleja del
+ * inicio. Queda fijo respecto al área de chat → alcanzable sin importar el largo.
+ *
+ * Estos tests cubren el CONTRATO de visibilidad/acción del botón flotante:
+ *   - No aparece cuando estamos arriba (el header ya tiene su "Volver").
+ *   - Aparece al hacer scroll hacia abajo.
+ *   - Al tocarlo, dispara onBack.
+ *   - Sin handler onBack, no se renderiza (backward compat / empty state).
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import ChatHistory from '../ChatHistory';
+
+// jsdom no implementa scrollIntoView — ChatHistory lo llama en su efecto de
+// auto-scroll al fondo. Lo stubeamos para que el render no reviente.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+// El avatar trae assets/animaciones que no aportan a este test.
+vi.mock('../../ChagraAgentAvatar', () => ({ default: () => <div data-testid="avatar-mock" /> }));
+// ChatBubble importa servicios pesados (TTS/audio); lo simplificamos al texto.
+vi.mock('../ChatBubble', () => ({
+  default: ({ message }) => <div data-testid="bubble">{message.content}</div>,
+}));
+
+const longConversation = Array.from({ length: 20 }).flatMap((_, i) => ([
+  { id: `u${i}`, role: 'user', content: `pregunta ${i}` },
+  { id: `a${i}`, role: 'assistant', content: `respuesta ${i}` },
+]));
+
+/** Empuja el scroll del contenedor scrollable simulando que el usuario bajó. */
+function scrollContainerTo(scroller, top) {
+  Object.defineProperty(scroller, 'scrollTop', { value: top, configurable: true });
+  fireEvent.scroll(scroller);
+}
+
+describe('ChatHistory — botón Volver flotante (alcanzable sin scroll al inicio)', () => {
+  it('arriba del todo: NO muestra el botón flotante (el header ya lo tiene)', () => {
+    render(<ChatHistory messages={longConversation} onBack={vi.fn()} />);
+    expect(screen.queryByTestId('chat-floating-back')).toBeNull();
+  });
+
+  it('al bajar el scroll: aparece el botón flotante "Volver"', () => {
+    const { container } = render(<ChatHistory messages={longConversation} onBack={vi.fn()} />);
+    const scroller = container.querySelector('[data-testid="chat-scroll"]');
+    expect(scroller).not.toBeNull();
+    scrollContainerTo(scroller, 400);
+    expect(screen.getByTestId('chat-floating-back')).toBeInTheDocument();
+  });
+
+  it('tocar el botón flotante dispara onBack', () => {
+    const onBack = vi.fn();
+    const { container } = render(<ChatHistory messages={longConversation} onBack={onBack} />);
+    const scroller = container.querySelector('[data-testid="chat-scroll"]');
+    scrollContainerTo(scroller, 400);
+    fireEvent.click(screen.getByTestId('chat-floating-back'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('sin handler onBack: nunca renderiza el botón flotante', () => {
+    const { container } = render(<ChatHistory messages={longConversation} />);
+    const scroller = container.querySelector('[data-testid="chat-scroll"]');
+    scrollContainerTo(scroller, 400);
+    expect(screen.queryByTestId('chat-floating-back')).toBeNull();
+  });
+
+  it('el contenedor scrollable reserva padding inferior para que el último mensaje no quede tapado por el input fijo', () => {
+    const { container } = render(<ChatHistory messages={longConversation} onBack={vi.fn()} />);
+    const scroller = container.querySelector('[data-testid="chat-scroll"]');
+    // pb-28 (7rem) reserva sitio bajo el último mensaje para que sus acciones
+    // (👍/👎, Reintentar) no queden bajo el footer fijo (input + chips).
+    expect(scroller.className).toMatch(/pb-28/);
+  });
+});


### PR DESCRIPTION
## Bug
Dos problemas reportados por piloto real en la interfaz del agente (chat Ⓐ):
- **(B)** "para devolverme tengo que ir hasta el inicio de la conversación sin importar lo larga que sea" — el único botón "Volver" vivía en el header; en conversaciones largas había que scrollear hasta arriba para salir.
- **(A)** "en la última no veo dónde hacer clic" — las acciones de la última tarjeta (👍/👎, Reintentar) quedaban tapadas/abajo del fold.

## Causa raíz
El root de `AgentScreen` usaba `h-full`, pero `#root` no tiene altura definida (`body { min-height: 100vh }`, sin `height` fijo). Con `height:100%` contra un padre de altura `auto`, el contenedor crece al tamaño del contenido: en conversaciones largas **scrollea la página entera** en vez del `ChatHistory` interno (su `overflow-y-auto` nunca se activa). Resultado: el header (con el "Volver") sale de vista → hay que subir hasta el inicio (B). Y el último mensaje compite con el footer por el fondo, dejando sus acciones tapadas (A). Todas las demás pantallas full-screen usan `h-[100dvh] … overflow-hidden` (convención `ScreenShell`); `AgentScreen` era el outlier.

## Cambios
- `src/components/AgentScreen/AgentScreen.jsx`: root `h-full` → `h-[100dvh] … overflow-hidden`. Deja `ChatHistory` como **único scroller**, con header y footer fijos → el "Volver" del header queda siempre visible (fix raíz de B). Pasa `onBack` a `ChatHistory`.
- `src/components/AgentScreen/ChatHistory.jsx`:
  - Botón **"Volver" FLOTANTE** dentro del área de chat (defensa adicional para B): aparece al alejarse del inicio (umbral 160px de scroll), dispara `onBack`. Animación de entrada detrás de `prefers-reduced-motion` (patrón del proyecto).
  - El contenedor scrollable sube de `pb-2` a `pb-28` para que el último mensaje y sus acciones (👍/👎, Reintentar) no queden bajo el footer fijo (input + chips) → **fix de A**.

## (A) — acotado y corregido
Investigado: las CTAs de la última tarjeta (`FeedbackButtons`, "Reintentar", badges) renderizan al fondo de la burbuja, dentro del scroller que solo reservaba `pb-2`. Bajo el mismo bug de altura colapsada, el footer fijo (ChipsToolbar + input) tapaba esa zona. No es un estado de streaming sin botón ni un CTA inexistente: es padding insuficiente + scroll de página completa. Corregido con `pb-28` + el contenedor de altura constreñida (footer ahora fijo, no compitiendo). Auto-scroll al fondo ya existía.

## Tests
- 5 casos vitest nuevos (`ChatHistory.backButton.test.jsx`): visibilidad del botón flotante arriba/abajo, disparo de `onBack`, backward-compat sin handler, y reserva de `pb-28`.
- Suites de componentes verdes: **159/159**.

Refs: feedback piloto 2026-06-04, rediseño interfaz agente 2026-06-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)