### PR TITLE
fix(guards): no atribuir binomio de homónimo en guardSpeciesSubstitution

### DIFF
--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -809,6 +809,77 @@ describe('guardSpeciesSubstitution', () => {
     expect(out.modified).toBe(false);
   });
 
+  it('CASO PILOTO 2026-06-04: NO atribuye binomio de "tomate de árbol" a un homónimo ("tomate arandano")', () => {
+    // El resolver fuzzy-matcheó "tomate arandano" → los cultivares "tomate de árbol"
+    // (comparten el token genérico "tomate") y los inyectó al grounding. El guard NO
+    // debe "corregir" que «tomate de árbol es Solanum betaceum, no Solanum lycopersicum»
+    // sobre un texto que habla de OTRO cultivo. Antes disparaba DOS correcciones falsas
+    // (cultivar naranja + morado) porque anclaba solo en "tomate".
+    const resolved = [
+      {
+        mentioned: 'tomate de árbol naranja',
+        kind: 'species',
+        nombre_comun: 'Tomate de árbol naranja',
+        nombre_cientifico: 'Solanum betaceum Cav.',
+        canonical_id: 'solanum_betaceum_naranja',
+        confidence: 0.6,
+      },
+      {
+        mentioned: 'tomate de árbol morado',
+        kind: 'species',
+        nombre_comun: 'Tomate de árbol morado',
+        nombre_cientifico: 'Solanum betaceum Cav.',
+        canonical_id: 'solanum_betaceum_morado',
+        confidence: 0.6,
+      },
+      {
+        mentioned: 'tomate',
+        kind: 'species',
+        nombre_comun: 'Tomate',
+        nombre_cientifico: 'Solanum lycopersicum L.',
+        canonical_id: 'solanum_lycopersicum',
+        confidence: 0.7,
+      },
+    ];
+    const txt =
+      'El tomate arandano (Solanum lycopersicum) es una variedad de tomate cereza. ' +
+      'Prefiere suelos bien drenados y clima templado.';
+    const out = guardSpeciesSubstitution(txt, resolved);
+    expect(out.modified).toBe(false);
+    expect(out.text).toBe(txt);
+    expect(out.text).not.toMatch(/tomate de [aá]rbol[^.]*es Solanum betaceum/i);
+  });
+
+  it('SÍ sigue corrigiendo "tomate de árbol" cuando el TEXTO sí habla de tomate de árbol', () => {
+    // Anti-regresión del fix de ancla: el caso legítimo (el texto menciona el cultivo
+    // multi-palabra real) debe seguir disparando. El modelo le puso un binomio errado
+    // y real del grounding a un cultivo que sí es tomate de árbol.
+    const resolved = [
+      {
+        mentioned: 'tomate de árbol',
+        kind: 'species',
+        nombre_comun: 'Tomate de árbol',
+        nombre_cientifico: 'Solanum betaceum Cav.',
+        canonical_id: 'solanum_betaceum',
+        confidence: 0.9,
+      },
+      {
+        mentioned: 'lulo',
+        kind: 'species',
+        nombre_comun: 'Lulo',
+        nombre_cientifico: 'Solanum quitoense Lam.',
+        canonical_id: 'solanum_quitoense',
+        confidence: 0.9,
+      },
+    ];
+    const txt =
+      'El tomate de árbol (Solanum quitoense) es una fruta andina de clima frío que ' +
+      'se da entre 1800 y 2600 msnm.';
+    const out = guardSpeciesSubstitution(txt, resolved);
+    expect(out.modified).toBe(true);
+    expect(out.text).toMatch(/Solanum betaceum/);
+  });
+
   it('tolera el binomio del catálogo con autoría/variedad (compara solo Género epíteto)', () => {
     // nombre_cientifico del grounding trae "Lam." de autoría; el texto trae el binomio puro.
     const txt = 'El lulo es en realidad Passiflora tripartita, una fruta de clima frío.';

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -2218,10 +2218,18 @@ export function guardSpeciesSubstitution(responseText, resolvedEntities = null, 
     const nombre = (e.nombre_comun || e.mentioned || '').toString();
     if (!nombre) continue;
     // El cultivo debe ser nombrado en el texto para atribuirle una sustitución.
-    // Usamos el primer token del nombre común (ej. "Lulo" de "Lulo / Naranjilla").
-    const nombreNorm = _stripDiacritics(nombre.split('/')[0]);
-    const firstWord = nombreNorm.split(/\s+/)[0];
-    if (!firstWord || firstWord.length < 3 || !norm.includes(firstWord)) continue;
+    // ANCLA: para nombres de UNA palabra usamos el token (ej. "lulo"). Para
+    // nombres MULTI-palabra (ej. "tomate de árbol") exigimos los DOS primeros
+    // tokens contiguos — NO solo el genérico "tomate", que colisiona con
+    // homónimos distintos ("tomate arandano") y disparaba correcciones FALSAS,
+    // atribuyendo el binomio de un cultivo a otro (bug piloto 2026-06-04: el
+    // resolver fuzzy-matcheó "tomate arandano" → cultivares "tomate de árbol" y
+    // el guard "corrigió" Solanum betaceum sobre un texto que no era tomate de árbol).
+    const nombreNorm = _stripDiacritics(nombre.split('/')[0]).trim();
+    const tokens = nombreNorm.split(/\s+/).filter(Boolean);
+    const firstWord = tokens[0];
+    const anchor = tokens.length > 1 ? `${tokens[0]} ${tokens[1]}` : tokens[0];
+    if (!anchor || anchor.length < 3 || !norm.includes(anchor)) continue;
 
     // Si el binomio correcto ya está en el texto, el cultivo está bien atribuido.
     if (norm.includes(correctBin)) continue;
@@ -2230,7 +2238,7 @@ export function guardSpeciesSubstitution(responseText, resolvedEntities = null, 
     // culprit debe ser un binomio real del catálogo (está en `realInText`) y
     // distinto del binomio correcto del cultivo. Si el cultivo no está cerca de
     // ninguno, no atribuimos (conservador).
-    const idxNombre = norm.indexOf(firstWord);
+    const idxNombre = norm.indexOf(anchor);
     let culprit = null;
     for (const fb of realInText) {
       if (fb === correctBin) continue; // su propio binomio correcto no es culprit.


### PR DESCRIPTION
## Qué

`guardSpeciesSubstitution` anclaba la atribución de una sustitución de especie en el **primer token** del nombre común. Para nombres multi-palabra (ej. `tomate de árbol`) eso colisiona con homónimos que comparten solo el token genérico (`tomate arandano`) → corrección FALSA.

## Por qué (bug de piloto 2026-06-04)

Un usuario preguntó **"¿de dónde viene el tomate arandano?"**. El resolver de entidades fuzzy-matcheó `tomate arandano` → los cultivares de catálogo `tomate de árbol naranja/morado` (mismo token `tomate`) y los inyectó al grounding. Entonces el guard prepuso **dos** correcciones equivocadas:

> *Corrección importante: el tomate de árbol naranja es Solanum betaceum, no Solanum lycopersicum…*
> *Corrección importante: el tomate de árbol morado es Solanum betaceum, no Solanum lycopersicum…*

…sobre una respuesta que no trataba de tomate de árbol. Confuso para el usuario y, encima, refuerza una alucinación (el texto generativo igual inventaba que "el tomate viene de Europa").

## Fix

Para nombres comunes **multi-palabra** se exige que los **dos primeros tokens contiguos** aparezcan en el texto (ancla), no solo el genérico inicial. Los nombres de una palabra (`lulo`, `mora`) no cambian de comportamiento.

Defensa en profundidad: el resolver upstream (sidecar `resolve-entities`) sigue siendo el origen del mal-match `tomate arandano`→`tomate de árbol` y debería endurecerse aparte; pero el guard ya no produce la corrección falsa visible al usuario.

## Tests

- `outputGuards.test.js` +2: reproduce el misfire (`tomate arandano` → `modified:false`, texto intacto) + anti-regresión (texto legítimo de `tomate de árbol` → sigue corrigiendo).
- **114/114** del archivo verdes. ESLint `--max-warnings=0` limpio.

Origen: análisis de conversación real del piloto Dante (Choachí). Relacionado con el track de anti-alucinación (DR-AH-1, casos Borde V3).