### PR TITLE
test(offline): estabilizar assert de sync al reconectar (flake sistémico)

### DIFF
--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -248,10 +248,19 @@ test.describe('Offline-first — siembra pendiente y reconexión', () => {
       .poll(() => countPendingTransactions(page), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(1);
 
-    // Reconexión → evento 'online' → NetworkStatusBar entra en SYNCING.
+    // Reconexión → el sync empuja la siembra pendiente y el bar de estado REPORTA
+    // el resultado. OJO con el flake histórico: el bar transitorio "Sincronizando
+    // N registros…" se SUPRIME a propósito durante el sync activo (decisión
+    // 2026-05-18: NetworkStatusBar.refreshStats hace setVisible(false) porque el
+    // rotador del TopBar ya indica el progreso). Asertar /sincronizando/ era doble-
+    // mente frágil: (1) solo capturaba esa ventana suprimida, y (2) NO matchea el
+    // estado terminal SYNCED "N registros sincronizADos" (termina en -ado). La
+    // señal DURABLE es el estado terminal del bar: SYNCED (~4s) o "Error
+    // sincronizando con FarmOS" (ERROR, 8s, red mockeada aborta). /sincroniz/i
+    // cubre ambos de forma estable. Ver feedback-sw-shadows-playwright-route.
     await context.setOffline(false);
     await page.evaluate(() => window.dispatchEvent(new Event('online')));
 
-    await expect(page.getByText(/sincronizando/i)).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(/sincroniz/i).first()).toBeVisible({ timeout: 15_000 });
   });
 });


### PR DESCRIPTION
## Qué

El test `offline.spec.js:255` ("guarda siembra de 10 fresas offline y reporta sincronización al reconectar") era **flaky** y bloqueaba intermitentemente toda la cola de merges (`Offline-first E2E` es required check). Pasó en #1316/17/18, falló en #1310 sobre el mismo main.

## Causa raíz (no es bug de producto)

El assert esperaba `getByText(/sincronizando/i)` visible 15s tras reconectar. Doble fragilidad:
1. El bar **"Sincronizando N registros…"** de `NetworkStatusBar` se **suprime a propósito** durante el sync activo (decisión 2026-05-18: `refreshStats` hace `setVisible(false)`; el rotador del TopBar ya indica progreso). Ventana de captura mínima.
2. `/sincronizando/` **no matchea el estado terminal SYNCED** "N registros sincroniz**ado**s" (termina en -ado). Si el sync resolvía rápido a SYNCED, nunca matcheaba.

## Fix

Asertar el estado **terminal durable** del bar con `/sincroniz/i` (cubre SYNCED ~4s y "Error sincronizando con FarmOS" 8s). No cambia comportamiento de producto; corrige qué señal observa el test.

## Verificación

- Test aislado **3/3 verde** local (`--repeat-each=3`).
- El suite completo local falla solo por inestabilidad del chromium single-process en NixOS (CDP handshake), no por la assertion — CI usa chromium bundled multi-proceso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)