### PR TITLE
test(offline): abort diferido para assert 'sincronizando' determinista

### DIFF
--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -208,7 +208,15 @@ test.describe('Offline-first — siembra pendiente y reconexión', () => {
 
     // Cualquier otro tráfico saliente a FarmOS/HA/Ollama se bloquea —
     // el test depende solo de la capa offline, nunca de red externa.
-    await context.route('**/api/**', (route) => route.abort('blockedbyclient'));
+    // El abort se retrasa ~400ms a propósito: al reconectar, mantiene la petición
+    // de sync "en vuelo" lo suficiente para que NetworkStatusBar permanezca en
+    // estado SYNCING y el toast 'sincronizando' se renderice de forma DETERMINISTA.
+    // Con abort instantáneo, SYNCING colapsaba en un solo tick → test flaky
+    // (bloqueaba merges, ECONNREFUSED del SW re-emitiendo; ver feedback-sw-shadows-playwright-route).
+    await context.route('**/api/**', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      await route.abort('blockedbyclient');
+    });
   });
 
   test('guarda siembra de 10 fresas offline y reporta sincronización al reconectar', async ({


### PR DESCRIPTION
## Qué
El test E2E `Offline-first — siembra pendiente y reconexión` (`tests/offline.spec.js`) era **flaky** y bloqueaba merges intermitentemente.

## Causa raíz
Con `route.abort('blockedbyclient')` instantáneo sobre `**/api/**`, al reconectar la petición de sync abortaba en el mismo tick → el estado `SYNCING` de `NetworkStatusBar` colapsaba antes de renderizar → el toast `sincronizando` a veces no aparecía → `expect(...).toBeVisible({timeout:15s})` hacía timeout.

## Fix
Se difiere el abort **~400 ms** para mantener la petición en vuelo lo suficiente a que `SYNCING` permanezca visible de forma **determinista**. El abort sigue bloqueando todo `/api/**` (el test depende solo de la capa offline, nunca de red externa).

```js
await context.route('**/api/**', async (route) => {
  await new Promise((resolve) => setTimeout(resolve, 400));
  await route.abort('blockedbyclient');
});
```

## Verificación
Verificación local bloqueada por presión de memoria del host (chromium SIGABRT/timeout, no por la lógica). Se delega la validación a **CI Playwright** (recursos limpios + `retries:2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)