### PR TITLE
test(themes): alinear assert ámbar con el ocre AA explícito rgb(160,76,20)

### DIFF
--- a/src/styles/__tests__/themes.coverage.test.js
+++ b/src/styles/__tests__/themes.coverage.test.js
@@ -105,7 +105,10 @@ describe('themes.css — remapeo de clases NO-var-aware (la raíz del repeye)', 
     for (const sel of ['.text-amber-300', '.text-amber-400']) {
       expect(coveredForBothThemes(sel), `falta override ámbar ${sel}`).toBe(true);
     }
-    expect(themesCss).toMatch(/color:\s*rgb\(var\(--c-amber-700\)/);
+    // El override usa el ocre oscuro EXPLÍCITO rgb(160,76,20) (AA ≥4.5 sobre el
+    // crema de nature). El token --c-amber-700 (176,90,32) daba 4.02 < AA, por eso
+    // NO se usa la var sino el rgb literal — el assert sigue ese hecho del CSS.
+    expect(themesCss).toMatch(/color:\s*rgb\(160,\s*76,\s*20\)/);
   });
 
   it('neutraliza las tarjetas tonales del impacto hero (bloques oscuros)', () => {


### PR DESCRIPTION
## Qué
El test `themes.coverage.test.js` fallaba en main: asertaba `color: rgb(var(--c-amber-700))` para el override de texto ámbar en temas claros, pero el CSS (correctamente) usa el ocre oscuro literal `rgb(160, 76, 20)`.

## Por qué
El token `--c-amber-700` (176,90,32) da **4.02 de contraste — bajo AA 4.5** sobre el crema de nature; por eso #1318 usó el rgb explícito accesible. El assert quedó desalineado con esa decisión, dejando la suite roja en main (1 failed | 3683 passed).

## Cambio
Solo el assert del test → `rgb(160, 76, 20)`. **El CSS no se toca** (es correcto y AA-compliant). Suite del archivo: 10/10 verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)