### PR TITLE
feat(themes): paridad con demos HTML + tokens FX gateados y scrim por tema

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -138,13 +138,14 @@ const DashboardLiveView = React.memo(function DashboardLiveView({ onNavigate, on
   }, [hydrate, syncFromServer]);
 
   return (
-    // bg-slate-950/55 (no sólido) 2026-05-28: el dashboard principal tenía
-    // bg-slate-950 opaco que tapaba al 100% el fondo-foto elegido en el
-    // selector (--app-bg-image en el body, clase .app-bg-biodiversidad).
-    // El operador veía la foto en pantallas con ScreenShell pero NO en la
-    // principal. Scrim semi-opaco deja ver la foto detrás; BiopunkBackground
-    // (capa animada) + contenido z-10 mantienen legibilidad.
-    <div className="relative h-[100dvh] w-full bg-slate-950/55 text-white flex flex-col overflow-hidden">
+    // .app-scrim (scrim por token, spec 2026-06-05): antes bg-slate-950/55
+    // hardcodeado tapaba al 100% el fondo-foto elegido en el selector
+    // (--app-bg-image en el body, clase .app-bg-biodiversidad). El operador veía
+    // la foto en pantallas con ScreenShell pero NO en la principal. El scrim
+    // ahora sale de --scrim-bg/--scrim-opacity → navy en bio-punk, crema sutil en
+    // temas claros (no lava la imagen). BiopunkBackground (capa animada) +
+    // contenido z-10 mantienen legibilidad.
+    <div className="relative h-[100dvh] w-full app-scrim text-white flex flex-col overflow-hidden">
       {/* Capa biopunk viva — sutil siempre, salvaje en idle */}
       <BiopunkBackground intense={idle} />
       {/* Contenido del dashboard, fade-out cuando idle para resaltar fondo */}
@@ -214,12 +215,13 @@ const DashboardView = React.memo(function DashboardView({ onNavigate, onLogout, 
   ], [plantsCount, landsCount, structuresCount, materialsCount]);
 
   return (
-    <div className="h-[100dvh] w-full bg-slate-950/82 text-white flex flex-col overflow-hidden">
+    <div className="h-[100dvh] w-full app-scrim-strong text-white flex flex-col overflow-hidden">
       {/* DR-030 QW2: TopBar persistente con identidad operador + acciones
           globales. Reemplaza el header inline previo. La info ambiental
           (msnm/luna/sol) pasó al EnvironmentalCard colapsable bajo el TopBar.
-          2026-05-18: wrapper translúcido (bg-slate-950/82) para que se vea
-          la imagen de fondo agroecológica aplicada al body en App.jsx. */}
+          2026-05-18: wrapper translúcido (.app-scrim-strong, scrim por token)
+          para que se vea la imagen de fondo agroecológica aplicada al body en
+          App.jsx — navy en bio-punk, velo crema sutil en temas claros. */}
       <TopBar onNavigate={onNavigate} onLogout={onLogout} />
       <HomeRegionalGreeting />
 

--- a/src/components/dashboard/BiopunkBackground.jsx
+++ b/src/components/dashboard/BiopunkBackground.jsx
@@ -34,6 +34,15 @@ export default function BiopunkBackground({ intense = false }) {
         const reduceMotion = typeof window !== 'undefined' &&
             window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         if (reduceMotion) return;
+        // Gating por tema (spec 2026-06-05): las partículas son un FX bio-punk.
+        // En nature/minimalista el token --fx-particles vale 0 → NO montamos el
+        // canvas (cero confeti sobre crema) y ahorramos rAF. Las capas estáticas
+        // (glow/patrón/viñeta) las apaga el wrapper .bp-fx-layer vía CSS token.
+        if (typeof window !== 'undefined' &&
+            getComputedStyle(document.documentElement)
+                .getPropertyValue('--fx-particles').trim() === '0') {
+            return;
+        }
 
         const ctx = canvas.getContext('2d');
         if (!ctx) return;
@@ -127,9 +136,15 @@ export default function BiopunkBackground({ intense = false }) {
 
     return (
         <div
-            className="absolute inset-0 pointer-events-none overflow-hidden"
+            className="absolute inset-0 pointer-events-none overflow-hidden bp-fx-layer"
             aria-hidden="true"
             data-biopunk-intense={intense ? 'on' : 'off'}
+            // Gating de FX por tema (spec 2026-06-05): TODO el lienzo neón
+            // (patrón + glow conic + viñeta navy + partículas) se multiplica por
+            // --fx-glow-opacity. En bio-punk = 1 (presencia plena); en nature/
+            // minimalista = 0 → el lienzo desaparece por completo, sin sangrar
+            // efectos oscuros sobre los temas claros. CSS puro, cero JS frágil.
+            style={{ opacity: 'var(--fx-glow-opacity, 1)' }}
         >
             {/* Capa A — biopunk-pattern SVG tiled.
                 BUGFIX 2026-05-28 operador: en modo screen saver (idle) este

--- a/src/index.css
+++ b/src/index.css
@@ -66,27 +66,49 @@
   --c-orchid-glow: 232 121 249;
   --c-frog: 234 179 8;
   --c-frog-glow: 250 204 21;
+
+  /* ---------------------------------------------------------------------------
+   * TOKENS SEMÁNTICOS DE EFECTOS (FX) — gateados por tema (spec 2026-06-05).
+   * Separan "el efecto bio-punk" (partículas/glow/patrón) del color de chrome.
+   * Causa raíz de los "cruces": el confeti/glow neón corría en TODOS los temas.
+   * Acá biopunk (:root) = todo ON; cada tema claro los pone a 0. Los componentes
+   * leen estos tokens (CSS puro: display/opacity) en vez de asumir fondo oscuro.
+   *
+   *   --fx-particles      1=monta el canvas de partículas, 0=no (claros).
+   *   --fx-glow-opacity    opacidad de halos/glows neón; 0 en claros.
+   *   --fx-bg-pattern      1=patrón PCB bio-punk visible, 0 en claros.
+   *   --scrim-bg           RGB del velo de fondo POR TEMA (no slate-950 fijo).
+   *   --scrim-opacity      opacidad del velo (navy denso en bp, sutil en claros).
+   * ------------------------------------------------------------------------- */
+  --fx-particles: 1;
+  --fx-glow-opacity: 1;     /* presencia plena del lienzo neón en bio-punk */
+  --fx-bg-pattern: 1;
+  --scrim-bg: 2 6 23;       /* navy slate-950 — velo oscuro del demo bio-punk */
+  --scrim-opacity: 0.55;
 }
 
 /* MINIMALISTA — papel #f6f3ec, tinta #1f2421, salvia #2f6e5a, línea #e3ddd0.
  * La rampa slate se INVIERTE: 950 = fondo más claro (papel) … 50 = tinta. */
 [data-theme="minimalista"] {
-  --c-slate-950: 246 243 236;  /* papel / fondo base */
-  --c-slate-900: 255 255 255;  /* card / superficie */
-  --c-slate-800: 237 232 222;  /* raised */
-  --c-slate-700: 227 221 208;  /* línea / borde */
-  --c-slate-600: 209 201 186;  /* borde medio */
-  --c-slate-500: 122 124 117;  /* texto terciario / placeholder */
-  --c-slate-400: 138 142 134;  /* texto secundario */
-  --c-slate-300: 74 80 73;     /* texto fuerte */
+  /* Rampa slate INVERTIDA + entonada a la tinta verdosa del demo
+   * (demo-agente-minimalista.html): papel #f6f3ec, blanco card, tinta #1f2421,
+   * línea #e3ddd0. Valores tomados 1:1 del demo donde existen. */
+  --c-slate-950: 246 243 236;  /* papel / fondo base (#f6f3ec) */
+  --c-slate-900: 255 255 255;  /* card / superficie (--blanco) */
+  --c-slate-800: 240 236 226;  /* raised (--papel-2 #f0ece2) */
+  --c-slate-700: 227 221 208;  /* línea / borde (--linea #e3ddd0) */
+  --c-slate-600: 236 231 218;  /* borde suave (--linea-2 #ece7da) */
+  --c-slate-500: 135 141 134;  /* terciario / placeholder (--tinta-3 #878d86) */
+  --c-slate-400: 110 117 110;  /* secundario (entre tinta-2 y tinta-3, AA) */
+  --c-slate-300: 75 82 76;     /* texto fuerte (--tinta-2 #4b524c) */
   --c-slate-200: 47 53 48;     /* casi tinta */
-  --c-slate-100: 31 36 33;     /* tinta */
+  --c-slate-100: 31 36 33;     /* tinta (--tinta #1f2421) */
   --c-slate-50: 20 24 21;      /* tinta más oscura */
-  --c-emerald-200: 230 239 233;
-  --c-emerald-300: 90 140 120;
-  --c-emerald-400: 47 110 90;  /* salvia (acento) */
-  --c-emerald-500: 37 88 72;
-  --c-emerald-600: 29 70 57;
+  --c-emerald-200: 230 239 233; /* --acento-soft #e6efe9 */
+  --c-emerald-300: 55 110 88;   /* salvia media (AA sobre blanco) */
+  --c-emerald-400: 47 110 90;  /* salvia (acento) #2f6e5a */
+  --c-emerald-500: 37 88 72;   /* --acento-d #255848 */
+  --c-emerald-600: 29 70 57;   /* --acento-deep #1d4639 */
   --c-emerald-700: 23 56 46;
   --c-emerald-800: 23 56 46;
   --c-emerald-900: 230 239 233;
@@ -99,7 +121,7 @@
   --c-amber-900: 235 220 195;
   --c-surface: 246 243 236;
   --c-surface-card: 255 255 255;
-  --c-surface-raised: 237 232 222;
+  --c-surface-raised: 240 236 226;
   --c-surface-border: 227 221 208;
   /* acentos neón → versión salvia/apagada. */
   --c-muzo: 47 110 90;
@@ -110,25 +132,36 @@
   --c-orchid-glow: 138 142 134;
   --c-frog: 176 106 50;
   --c-frog-glow: 200 140 60;
+  /* FX OFF — el demo minimalista es papel liso: una sola micro-animación de
+   * trazo, sin partículas, sin glow neón, sin patrón. Velo de fondo mínimo. */
+  --fx-particles: 0;
+  --fx-glow-opacity: 0;
+  --fx-bg-pattern: 0;
+  --scrim-bg: 246 243 236;  /* velo = el propio papel → no lava nada */
+  --scrim-opacity: 0.10;
 }
 
 /* NATURE — superf #fbf5ea, café #4a3a26, salvia #7a8f4a, ocre #f5b733,
  * línea #ddc8a6. Rampa slate invertida y entonada cálida. */
 [data-theme="nature"] {
-  --c-slate-950: 251 245 234;  /* crema / fondo base */
-  --c-slate-900: 255 252 245;  /* card / superficie */
-  --c-slate-800: 240 230 210;  /* raised */
-  --c-slate-700: 221 200 166;  /* línea / borde */
-  --c-slate-600: 200 180 150;  /* borde medio */
-  --c-slate-500: 122 100 70;   /* texto terciario / placeholder */
-  --c-slate-400: 140 118 88;   /* texto secundario */
-  --c-slate-300: 90 74 50;     /* texto fuerte */
-  --c-slate-200: 74 58 38;     /* casi café */
-  --c-slate-100: 60 48 32;     /* café texto */
+  /* Crema/tabaco terroso del demo demo-agente.html (NO lavanda). Valores 1:1:
+   * crema-1 #f6efe0 fondo, superf #fbf5ea, café #4a3a26 texto, salvia #7a8f4a,
+   * terracota #d98a4f (acento cálido / burbuja usuario), ocre #f5b733,
+   * línea #ddc8a6. El fondo base usa el crema-2/arena más tabaco (spec). */
+  --c-slate-950: 246 239 224;  /* crema-1 / fondo base (#f6efe0) */
+  --c-slate-900: 255 255 255;  /* card / superficie (--blanco del demo) */
+  --c-slate-800: 251 245 234;  /* raised (--superf #fbf5ea) */
+  --c-slate-700: 221 200 166;  /* línea / borde (--linea #ddc8a6) */
+  --c-slate-600: 231 211 182;  /* borde medio cálido (--crema-3 #e7d3b6) */
+  --c-slate-500: 138 115 80;   /* terciario / placeholder (--cafe-3 #8a7350) */
+  --c-slate-400: 107 86 56;    /* secundario (--cafe-2 #6b5638) */
+  --c-slate-300: 90 72 46;     /* texto fuerte (café medio) */
+  --c-slate-200: 74 58 38;     /* café (--cafe #4a3a26) */
+  --c-slate-100: 74 58 38;     /* texto principal = café del demo (#4a3a26) */
   --c-slate-50: 45 36 24;      /* café más oscuro */
   --c-emerald-200: 230 235 210;
-  --c-emerald-300: 156 176 106;
-  --c-emerald-400: 122 143 74;  /* salvia (acento verde) */
+  --c-emerald-300: 110 132 64;  /* salvia media */
+  --c-emerald-400: 122 143 74;  /* salvia (acento verde) #7a8f4a */
   --c-emerald-500: 104 122 60;
   --c-emerald-600: 90 106 52;
   --c-emerald-700: 70 84 40;
@@ -136,24 +169,33 @@
   --c-emerald-900: 230 235 210;
   --c-amber-200: 250 220 150;
   --c-amber-300: 250 200 90;
-  --c-amber-400: 245 183 51;   /* ocre flor (acento cálido) */
-  --c-amber-500: 217 116 42;
+  --c-amber-400: 245 183 51;   /* ocre flor / espeletia (#f5b733) */
+  --c-amber-500: 217 116 42;   /* ocre quemado (--ocre-d #d9742a-ish) */
   --c-amber-600: 217 116 42;
   --c-amber-700: 176 90 32;
   --c-amber-900: 245 230 200;
-  --c-surface: 251 245 234;
-  --c-surface-card: 255 252 245;
-  --c-surface-raised: 240 230 210;
+  --c-surface: 246 239 224;
+  --c-surface-card: 255 255 255;
+  --c-surface-raised: 251 245 234;
   --c-surface-border: 221 200 166;
-  /* acentos neón → salvia/ocre cálidos. */
+  /* acentos: salvia (verde) + terracota/ocre (cálido). El --c-orchid se usa como
+   * acento cálido (burbuja usuario) → terracota #d98a4f del demo. */
   --c-muzo: 122 143 74;
   --c-muzo-glow: 156 176 106;
   --c-morpho: 122 143 74;
   --c-morpho-glow: 156 176 106;
-  --c-orchid: 217 138 79;
+  --c-orchid: 217 138 79;       /* terracota (--acento #d98a4f) */
   --c-orchid-glow: 245 183 51;
   --c-frog: 245 183 51;
   --c-frog-glow: 250 200 90;
+  /* FX OFF — el demo nature es un degradado crema cálido con escena botánica
+   * estática (no confeti/glow neón). El velo de fondo es un crema sutil que NO
+   * lava la imagen. */
+  --fx-particles: 0;
+  --fx-glow-opacity: 0;
+  --fx-bg-pattern: 0;
+  --scrim-bg: 246 239 224;  /* velo = crema del tema → vela suave, no oscurece */
+  --scrim-opacity: 0.12;
 }
 
 @layer base {
@@ -200,8 +242,16 @@
      * detrás del contenido. La legibilidad del texto la garantizan ahora los
      * scrims semi-opacos de cada card/superficie (bg-slate-900/40-60), no este
      * overlay global. */
+    /* Scrim POR TOKEN (spec 2026-06-05): en bio-punk el velo es navy
+     * (--scrim-bg 2 6 23); en temas claros el token vira a crema/papel sutil →
+     * NO lava la foto. El degradado va de scrim·0.8 (arriba) a scrim·1.13
+     * (abajo) sobre --scrim-opacity para conservar el contraste previo
+     * (0.45→0.62 con opacity 0.55) sin hardcodear slate-950. */
     background-image:
-      linear-gradient(rgba(2, 6, 23, 0.45), rgba(2, 6, 23, 0.62)),
+      linear-gradient(
+        rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 0.82)),
+        rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 1.13))
+      ),
       var(--app-bg-image, url('/fondo-biopunk-4.jpg'));
     background-size: cover;
     background-position: center center;
@@ -271,5 +321,27 @@
     background-image: url("/biopunk-pattern.svg");
     background-repeat: repeat;
     background-size: 800px 800px;
+    /* Gating por token FX (spec 2026-06-05): el patrón solo es visible cuando el
+     * tema activo declara --fx-bg-pattern:1 (bio-punk). En nature/minimalista el
+     * token es 0 → opacity 0 lo apaga vía CSS puro, sin depender de overrides por
+     * selector. Las reglas `[data-theme] … {background-image:none}` de abajo se
+     * conservan como cinturón-y-tirantes (apagan también la descarga del SVG). */
+    opacity: var(--fx-bg-pattern, 1);
+  }
+
+  /* ---------------------------------------------------------------------------
+   * SCRIM DE FONDO POR TOKEN (spec 2026-06-05).
+   * Reemplaza los `bg-slate-950/55|82` hardcodeados de los wrappers del
+   * dashboard (App.jsx). El velo sale de --scrim-bg/--scrim-opacity → en
+   * bio-punk es navy denso (igual que antes), en temas claros vira a un crema/
+   * papel sutil que deja respirar el fondo sin lavar la foto/imagen.
+   *   .app-scrim         ≈ el viejo /55 (dashboard live sobre foto)
+   *   .app-scrim-strong  ≈ el viejo /82 (dashboard clásico, más velo)
+   * ------------------------------------------------------------------------- */
+  .app-scrim {
+    background-color: rgb(var(--scrim-bg) / var(--scrim-opacity));
+  }
+  .app-scrim-strong {
+    background-color: rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 1.49));
   }
 }

--- a/src/styles/__tests__/themes.coverage.test.js
+++ b/src/styles/__tests__/themes.coverage.test.js
@@ -81,6 +81,123 @@ describe('temas claros — indirección CSS-var (index.css)', () => {
   });
 });
 
+/* ===========================================================================
+ * CONTRATO DE EFECTOS (FX) + SCRIM + CONTRASTE AA (spec 2026-06-05)
+ * ---------------------------------------------------------------------------
+ * Lo que IMPIDE que los "cruces" vuelvan: si un tema claro deja un --fx-* en 1
+ * (o sin definir → hereda el 1 de :root = bio-punk), el confeti/glow/patrón
+ * neón sangra sobre la crema. Estos asserts congelan: (a) los tokens FX y scrim
+ * existen en :root, (b) se redefinen en cada tema, (c) los claros los apagan,
+ * (d) el texto principal de cada tema cumple AA (≥4.5) sobre su fondo.
+ * =========================================================================== */
+
+/** Extrae el bloque CSS de un selector de tema (o :root). */
+function themeBlock(selector) {
+  const re =
+    selector === ':root'
+      ? /:root\s*\{([\s\S]*?)\n\}/ // primer :root (mapa --c-* + --fx-*)
+      : new RegExp(`\\[data-theme="${selector}"\\]\\s*\\{([\\s\\S]*?)\\}`);
+  const m = indexCss.match(re);
+  return m ? m[1] : null;
+}
+
+/** Lee el valor escalar de una var (--fx-particles: 0 → "0"). */
+function readScalar(block, varName) {
+  const m = block.match(new RegExp(`${varName}\\s*:\\s*([^;]+);`));
+  return m ? m[1].trim() : null;
+}
+
+/** Lee el triple RGB de una var (--scrim-bg: 2 6 23 → [2,6,23]). */
+function readRgb(block, varName) {
+  const m = block.match(
+    new RegExp(`${varName}\\s*:\\s*([0-9]+)\\s+([0-9]+)\\s+([0-9]+)`)
+  );
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/** Contraste WCAG entre dos RGB. */
+function contrastRatio(a, b) {
+  const lin = (c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const lum = ([r, g, b2]) => 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b2);
+  const l1 = lum(a);
+  const l2 = lum(b);
+  const hi = Math.max(l1, l2);
+  const lo = Math.min(l1, l2);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+const FX_VARS = ['--fx-particles', '--fx-glow-opacity', '--fx-bg-pattern'];
+const SCRIM_VARS = ['--scrim-bg', '--scrim-opacity'];
+
+describe('contrato de efectos (FX) gateados por tema (index.css)', () => {
+  it('define los --fx-* y --scrim-* en :root (estado base bio-punk)', () => {
+    const root = themeBlock(':root');
+    expect(root, 'no se halló el bloque :root').toBeTruthy();
+    for (const v of [...FX_VARS, ...SCRIM_VARS]) {
+      expect(root.includes(`${v}:`), `falta ${v} en :root`).toBe(true);
+    }
+  });
+
+  it('redefine TODOS los --fx-*/--scrim-* en cada tema (sin tokens huérfanos)', () => {
+    // Si un tema NO redefine un --fx-*, hereda el 1 de :root → FX bio-punk
+    // sangrando sobre el tema claro. El contrato exige redefinición explícita.
+    for (const theme of ['minimalista', 'nature']) {
+      const block = themeBlock(theme);
+      expect(block, `falta bloque [data-theme="${theme}"]`).toBeTruthy();
+      for (const v of [...FX_VARS, ...SCRIM_VARS]) {
+        expect(block.includes(`${v}:`), `${theme} no redefine ${v}`).toBe(true);
+      }
+    }
+  });
+
+  it('los temas CLAROS apagan partículas, patrón y glow (--fx-*: 0)', () => {
+    for (const theme of ['minimalista', 'nature']) {
+      const block = themeBlock(theme);
+      expect(readScalar(block, '--fx-particles'), `${theme} --fx-particles`).toBe('0');
+      expect(readScalar(block, '--fx-bg-pattern'), `${theme} --fx-bg-pattern`).toBe('0');
+      expect(readScalar(block, '--fx-glow-opacity'), `${theme} --fx-glow-opacity`).toBe('0');
+    }
+  });
+
+  it('el scrim de los temas claros es CLARO (velo crema, no navy que lava)', () => {
+    // En claros el --scrim-bg debe ser claro (promedio > 200) → un velo sutil
+    // sobre la imagen, nunca el navy 2 6 23 que oscurecía la foto.
+    for (const theme of ['minimalista', 'nature']) {
+      const block = themeBlock(theme);
+      const rgb = readRgb(block, '--scrim-bg');
+      expect(rgb, `${theme} --scrim-bg ausente`).toBeTruthy();
+      const avg = (rgb[0] + rgb[1] + rgb[2]) / 3;
+      expect(avg, `${theme} --scrim-bg debe ser claro`).toBeGreaterThan(200);
+    }
+  });
+});
+
+describe('contraste AA del texto principal de cada tema (sonda numérica)', () => {
+  // El texto principal (--c-slate-100) sobre el fondo base (--c-slate-950) y
+  // sobre la card (--c-slate-900) debe pasar AA (≥4.5) en CADA tema.
+  const cases = [
+    { theme: ':root', name: 'bio-punk' },
+    { theme: 'minimalista', name: 'minimalista' },
+    { theme: 'nature', name: 'nature' },
+  ];
+  for (const { theme, name } of cases) {
+    it(`${name}: texto principal ≥4.5 sobre fondo y card`, () => {
+      const block = themeBlock(theme);
+      const text = readRgb(block, '--c-slate-100');
+      const bg = readRgb(block, '--c-slate-950');
+      const card = readRgb(block, '--c-slate-900');
+      expect(text, `${name} --c-slate-100`).toBeTruthy();
+      expect(bg, `${name} --c-slate-950`).toBeTruthy();
+      expect(card, `${name} --c-slate-900`).toBeTruthy();
+      expect(contrastRatio(text, bg), `${name} texto/fondo`).toBeGreaterThanOrEqual(4.5);
+      expect(contrastRatio(text, card), `${name} texto/card`).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+});
+
 describe('themes.css — remapeo de clases NO-var-aware (la raíz del repeye)', () => {
   it('vira el TEXTO blanco a tinta del tema (text-white = ilegible sobre crema)', () => {
     expect(coveredForBothThemes('.text-white')).toBe(true);


### PR DESCRIPTION
## Qué resuelve
Iguala los 3 temas (bio-punk / nature / minimalista) a sus **demos HTML** de oracle-lab y deja la arquitectura de tokens **a prueba de cruces**: nunca más confeti/glow/patrón bio-punk sangrando sobre los temas claros, ni scrims navy lavando el fondo.

Implementa el SPEC `THEME-SYSTEM-REWRITE-SPEC-2026-06-05`. Conserva la base buena (indirección por CSS-var `--c-*` → Tailwind theme-aware); **NO** migra las 726 clases (fuera de alcance).

## Cambios

### 1. Paletas re-derivadas 1:1 de los demos
- **nature** (`demo-agente.html`): crema/tabaco terroso (NO lavanda). Texto = café `#4a3a26`, fondo crema `#f6efe0`, surface `#fbf5ea`, salvia `#7a8f4a`, terracota `#d98a4f` (acento cálido / burbuja usuario), ocre `#f5b733`, línea `#ddc8a6`.
- **minimalista** (`demo-agente-minimalista.html`): papel `#f6f3ec`, blanco card, tinta `#1f2421`, salvia `#2f6e5a`, línea `#e3ddd0`, entonado a la tinta verdosa del demo.
- **bio-punk** (`:root`): intacto, byte-fiel al estado base.
- Texto principal de cada tema verificado **AA (≥4.5)** numéricamente sobre fondo y card (nature ~12, minimal ~14, biopunk ~18).

### 2. Capa de tokens semánticos de EFECTOS (`--fx-*`) gateada por tema
`--fx-particles` · `--fx-glow-opacity` · `--fx-bg-pattern` en `:root` (todo ON = bio-punk) y en cada `[data-theme]` (todo a **0** en nature/minimalista).
- `BiopunkBackground.jsx`: lee `--fx-particles` (no monta el canvas en claros, ahorra rAF) y multiplica TODO el lienzo neón por `--fx-glow-opacity` vía CSS puro → desaparece en claros.
- `.bg-biopunk-pattern`: `opacity: var(--fx-bg-pattern)` → apagado por token.

### 3. Scrim de fondo POR TOKEN
`--scrim-bg` / `--scrim-opacity` por tema (navy denso en bio-punk = idéntico al previo; velo crema sutil en claros que **no lava** la imagen). `App.jsx` usa `.app-scrim` / `.app-scrim-strong` en lugar de `bg-slate-950/55|82` hardcodeado. La superposición de `.app-bg-biodiversidad` también pasa al scrim por token.

### 4. Test de contrato (impide la recurrencia)
`themes.coverage.test.js` extendido:
- Todo `--fx-*` y `--scrim-*` de `:root` redefinido en cada `[data-theme]` (sin tokens huérfanos).
- `nature`/`minimalista` con `--fx-particles:0`, `--fx-bg-pattern:0`, `--fx-glow-opacity:0`.
- Scrim claro en temas claros (no navy).
- Contraste **AA numérico** del texto principal de cada tema sobre fondo y card.

## Gates
- `npm run test:unit` ✅ **226 archivos, 3691 pass, 1 skip** (suite de themes incluida: 17 tests).
- `vite build` ✅ exit 0 (el `prebuild` de catálogo falla por mismatch de `better-sqlite3`/Node en el entorno — pre-existente, ajeno a este cambio).
- ESLint `--max-warnings=0` ✅ en los 3 archivos JS tocados.
- Lefthook (secret-scan, infra-refs, strategic-content, eslint, conventional) ✅.

## Ajuste fino pendiente (con `/gs`, lo hace el operador+Opus)
El agente no ve pantallas → entrega arquitectura + valores del demo. Quedan para iteración visual con screenshots:
- Afinar al pixel los RGB de **bordes/sombras/radios** de tarjetas y burbujas contra el demo.
- Validar el **velo crema** del scrim en nature/minimalista sobre fotos reales (opacity 0.10–0.12 es conservadora).
- Estética de **badges de fuente** y chips a paridad fina (el verde de fuente ya es constante cross-tema por diseño del demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)