### PR TITLE
feat(agente): captura server-side de conversaciones para el demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,13 @@ VITE_CHAGRA_CATALOG_URL=
 # Cuando exista el sistema de tier/allowlist, el gating por tier
 # se agregará en deepResearchClient.js sin necesidad de cambiar este flag.
 VITE_DEEP_RESEARCH_ENABLED=false
+
+# Captura de conversaciones del agente (entrega usuarios gente-cercana
+# 2026-06-05). Cuando está en `true`, cada turno del chat (pregunta del
+# usuario + respuesta del agente + grounding) se envía fire-and-forget al
+# sidecar (POST /log-conversation → JSONL durable) para revisar las pruebas
+# al final del día. Default `false` → respeta la privacidad de grupos
+# futuros, que requieren consentimiento Habeas Data (Ley 1581 / DR-F).
+# El operador lo pone `true` SOLO en el build del demo. Reusa
+# VITE_SIDECAR_URL + VITE_CHAGRA_MCP_TOKEN.
+VITE_CAPTURE_CONVERSATIONS=false

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -78,6 +78,7 @@ import DeepResearchCard from '../DeepResearchCard';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity } from '../../services/agentService';
 import { applyOutputGuards, applyTaxonomyGuard, classifyQueryIntent } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
+import { captureExchange } from '../../services/conversationCaptureService';
 import { regionFromProfile, getEnsoOutlook } from '../../services/ensoContext';
 // SALUDO PROACTIVO (#162 alertas + #298 tareas + #331 análisis): el agente, de
 // entrada, lidera con lo MÁS importante (1-2 pendientes) si los hay, o da una
@@ -1740,7 +1741,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         }
       }
 
+      // Demo-captura (2026-06-05): marca de inicio para medir la latencia del
+      // turno (solo del callLLM) que se adjunta al evento de captura.
+      const tLLM0 = performance.now();
       const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock);
+      const turnLatencyMs = Math.round(performance.now() - tLLM0);
       // DR-LANG-1: filtro post-process anti-voseo argentino. Es la última
       // línea de defensa estructural — garantiza que el léxico rioplatense
       // (che, laburar, etc.) NUNCA llegue al usuario campesino colombiano,
@@ -1931,6 +1936,43 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         metadata: sourceMetadata,
       });
       setMessages((prev) => [...prev, assistantMessage]);
+
+      // Demo-captura de conversaciones (entrega usuarios gente-cercana
+      // 2026-06-05). Fire-and-forget, gated por VITE_CAPTURE_CONVERSATIONS
+      // (OFF default). Persiste el turno completo (pregunta + respuesta +
+      // grounding) en el sidecar (/log-conversation → JSONL durable) para
+      // revisar las pruebas al final del día. PURO side-effect best-effort:
+      // jamás bloquea ni cambia el flujo del chat; lo que no esté disponible va
+      // null/[] (el servicio tolera nulls). Lo que SÍ tenemos del turno se pasa.
+      try {
+        const captureProfile = (() => { try { return getProfile(); } catch (_) { return null; } })();
+        captureExchange({
+          userText: text,
+          agentText: response,
+          identity: {
+            user_id: operatorId,
+            user_name: (captureProfile && captureProfile.nombre) || null,
+            finca_slug: (fincaActiva && fincaActiva.slug) || activeFincaSlug || null,
+            finca_nombre: (fincaActiva && fincaActiva.nombre) || null,
+          },
+          meta: {
+            session_id: operatorId,
+            // Índice del turno = nº de mensajes ya en el hilo antes de este
+            // assistant (puede ser null si no hay; el servicio tolera null).
+            turn_index: Array.isArray(messages) ? messages.length : null,
+            nlu_route: (() => { try { return selectChatRoute(textForLLM); } catch (_) { return null; } })(),
+            entities_grounded: Array.isArray(resolvedEntities)
+              ? resolvedEntities.map((e) => (e && (e.id || e.nombre_cientifico || e.nombre)) || null).filter(Boolean)
+              : [],
+            guards_fired: Array.isArray(guarded.reasons) ? guarded.reasons : [],
+            grounded_status: (sourceMetadata && (sourceMetadata.fuente || sourceMetadata.source)) || null,
+            latency_ms: turnLatencyMs,
+            model: (() => { try { return buildLLMRequest(selectChatRoute(textForLLM), messages).body.model; } catch (_) { return null; } })(),
+          },
+        });
+      } catch (_) {
+        // La captura JAMÁS degrada el chat — la respuesta ya está mostrada.
+      }
 
       // Task #122: cachear el último mensaje del agente en el store global
       // para que el doble-click del avatar (cualquier pantalla) pueda re-

--- a/src/services/__tests__/conversationCaptureService.test.js
+++ b/src/services/__tests__/conversationCaptureService.test.js
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/* eslint-disable no-undef */
+
+/**
+ * conversationCaptureService.test.js — captura server-side de conversaciones
+ * del agente (entrega usuarios gente-cercana 2026-06-05).
+ *
+ * `captureExchange` es fire-and-forget: gated por VITE_CAPTURE_CONVERSATIONS,
+ * NUNCA lanza ni bloquea la UX del chat, y POSTea el turno (pregunta + respuesta
+ * + grounding) a `${base}/log-conversation` con header X-Chagra-Token. Estos
+ * tests verifican:
+ *   - gate: con la flag OFF NO se llama a fetch.
+ *   - gate: con la flag ON SÍ se llama a fetch (POST a /log-conversation).
+ *   - schema del payload (textos, identidad, meta) + header de auth.
+ *   - turnos vacíos no se envían.
+ *   - falla silenciosa (fetch rechaza → no throw).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { captureExchange, isCaptureEnabled } from '../conversationCaptureService';
+
+describe('conversationCaptureService', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+    vi.stubEnv('VITE_SIDECAR_URL', '/api/mcp/agro');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'test-token');
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe('isCaptureEnabled (gate)', () => {
+    it('OFF por defecto (flag vacía)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+      expect(isCaptureEnabled()).toBe(false);
+    });
+
+    it('reconoce "true"/"1"/"on" como ON', () => {
+      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
+        vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', v);
+        expect(isCaptureEnabled()).toBe(true);
+      }
+    });
+
+    it('cualquier otro valor es OFF', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'false');
+      expect(isCaptureEnabled()).toBe(false);
+    });
+  });
+
+  describe('captureExchange', () => {
+    it('NO envía nada cuando la flag está OFF', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('NO envía turnos vacíos aunque la flag esté ON', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({ userText: '', agentText: '' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('con la flag ON, POSTea a /log-conversation con token + schema', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({
+        userText: '¿compañeros del café?',
+        agentText: 'guamo, plátano',
+        identity: {
+          user_id: 'op-3',
+          user_name: 'MonkeyD.Free',
+          finca_slug: 'finca-free',
+          finca_nombre: 'Finca de Free',
+        },
+        meta: {
+          session_id: 'op-3',
+          turn_index: 2,
+          nlu_route: 'chat',
+          entities_grounded: ['coffea_arabica'],
+          guards_fired: [],
+          grounded_status: 'Agrosavia',
+          latency_ms: 980,
+          model: 'granite3.1-dense:8b',
+        },
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = global.fetch.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/log-conversation');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token');
+
+      const body = JSON.parse(opts.body);
+      expect(body.user_text).toBe('¿compañeros del café?');
+      expect(body.agent_text).toBe('guamo, plátano');
+      expect(body.user_id).toBe('op-3');
+      expect(body.user_name).toBe('MonkeyD.Free');
+      expect(body.finca_slug).toBe('finca-free');
+      expect(body.session_id).toBe('op-3');
+      expect(body.turn_index).toBe(2);
+      expect(body.entities_grounded).toEqual(['coffea_arabica']);
+      expect(body.guards_fired).toEqual([]);
+      expect(body.grounded_status).toBe('Agrosavia');
+      expect(body.latency_ms).toBe(980);
+      expect(body.model).toBe('granite3.1-dense:8b');
+      // Sello cliente + id ulid presentes.
+      expect(typeof body.id).toBe('string');
+      expect(typeof body.ts).toBe('number');
+    });
+
+    it('tolera identity/meta ausentes (null/[] defaults)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.user_id).toBeNull();
+      expect(body.user_name).toBeNull();
+      expect(body.entities_grounded).toEqual([]);
+      expect(body.guards_fired).toEqual([]);
+      expect(body.latency_ms).toBeNull();
+    });
+
+    it('falla en silencio si fetch rechaza (no throw, no rompe el chat)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+      expect(() =>
+        captureExchange({ userText: 'x', agentText: 'y' }),
+      ).not.toThrow();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/conversationCaptureService.js
+++ b/src/services/conversationCaptureService.js
@@ -1,0 +1,140 @@
+/**
+ * conversationCaptureService.js — Captura server-side de las conversaciones del
+ * agente para el demo/piloto (entrega de usuarios 2026-06-05).
+ *
+ * POR QUÉ EXISTE: hoy el historial del chat es local-only (IndexedDB de cada
+ * browser, #120) y el chat va directo a Ollama sin pasar por el sidecar, así que
+ * NADA queda guardado central. Para evaluar las pruebas de cada usuario al final
+ * del día, hay que persistir cada turno (pregunta + respuesta + grounding) en el
+ * sidecar. Mirror del patrón de `feedbackService.js` (mismo base URL + token).
+ *
+ * Endpoint sidecar: POST /log-conversation (chagra-pro, append a JSONL durable).
+ *
+ * Reglas:
+ * - Gated por `VITE_CAPTURE_CONVERSATIONS` (ON solo para el demo; OFF default →
+ *   respeta la privacidad de grupos futuros, que requieren Habeas Data / DR-F).
+ * - Fire-and-forget: NUNCA bloquea ni rompe la UX del chat; falla en silencio.
+ * - El grupo del primer demo es gente cercana → captura texto completo + identidad
+ *   (decisión explícita del operador 2026-06-05).
+ *
+ * Schema del evento (1 línea JSONL por turno):
+ * {
+ *   id, ts,
+ *   user_id, user_name,        // identidad del usuario logueado
+ *   finca_slug, finca_nombre,  // finca activa
+ *   session_id, turn_index,
+ *   user_text,                 // pregunta del usuario (limpia)
+ *   agent_text,                // respuesta del agente (final)
+ *   nlu_route,                 // ruta NLU elegida (si la hubo)
+ *   entities_grounded,         // entidades resueltas en el grafo
+ *   guards_fired,              // guards de seguridad que actuaron
+ *   grounded_status,           // _grounded.status
+ *   latency_ms, model
+ * }
+ */
+
+import { ulid } from 'ulid';
+
+const CAPTURE_TIMEOUT_MS = 6000;
+const TEXT_MAX = 16000; // cota por campo (un turno largo del agente ~2-4k; holgado)
+
+/** ¿Captura activa? Gated por env. OFF por defecto. */
+export function isCaptureEnabled() {
+  try {
+    const raw = import.meta.env?.VITE_CAPTURE_CONVERSATIONS;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1' || v === 'on';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+function getBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.trim().replace(/\/+$/, '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '/api';
+}
+
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function clip(s) {
+  if (typeof s !== 'string') return '';
+  return s.length > TEXT_MAX ? `${s.slice(0, TEXT_MAX)}…[clip]` : s;
+}
+
+/**
+ * Captura un turno completo (pregunta del usuario + respuesta del agente).
+ * Fire-and-forget: devuelve void, no espera, no lanza.
+ *
+ * @param {Object} p
+ * @param {string} p.userText      pregunta del usuario
+ * @param {string} p.agentText     respuesta final del agente
+ * @param {Object} [p.identity]    { user_id, user_name, finca_slug, finca_nombre }
+ * @param {Object} [p.meta]        { session_id, turn_index, nlu_route, entities_grounded,
+ *                                   guards_fired, grounded_status, latency_ms, model }
+ */
+export function captureExchange({ userText, agentText, identity = {}, meta = {} } = {}) {
+  if (!isCaptureEnabled()) return;
+  // No capturamos turnos vacíos (p. ej. abortados sin respuesta).
+  if (!userText && !agentText) return;
+
+  const payload = {
+    id: ulid(),
+    ts: Date.now(),
+    user_id: identity.user_id ?? null,
+    user_name: identity.user_name ?? null,
+    finca_slug: identity.finca_slug ?? null,
+    finca_nombre: identity.finca_nombre ?? null,
+    session_id: meta.session_id ?? null,
+    turn_index: typeof meta.turn_index === 'number' ? meta.turn_index : null,
+    user_text: clip(userText),
+    agent_text: clip(agentText),
+    nlu_route: meta.nlu_route ?? null,
+    entities_grounded: Array.isArray(meta.entities_grounded) ? meta.entities_grounded.slice(0, 50) : [],
+    guards_fired: Array.isArray(meta.guards_fired) ? meta.guards_fired.slice(0, 20) : [],
+    grounded_status: meta.grounded_status ?? null,
+    latency_ms: typeof meta.latency_ms === 'number' ? meta.latency_ms : null,
+    model: meta.model ?? null,
+  };
+
+  const base = getBaseUrl();
+  const token = getToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS);
+
+  // Fire-and-forget: no await, no throw. El chat NO depende de esto.
+  fetch(`${base}/log-conversation`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+    keepalive: true, // sobrevive si el usuario navega justo después
+  })
+    .catch((err) => {
+      // Silencioso por diseño: la captura jamás degrada la UX.
+      if (import.meta.env?.DEV) {
+        console.debug('[conversationCapture] envío falló (ignorado):', err?.name || err);
+      }
+    })
+    .finally(() => clearTimeout(timer));
+}


### PR DESCRIPTION
## Qué

Wire de **captura de conversaciones del agente** en el PWA (entrega usuarios gente-cercana 2026-06-05). Pieza B de 2 (la A es el endpoint `POST /log-conversation` del sidecar, repo chagra-pro PR #183).

**Por qué:** el chat va del browser **directo a Ollama** y el historial es local-only (IndexedDB). Hoy nada queda guardado central para revisar las pruebas de cada usuario al final del día.

## Cómo

- **`conversationCaptureService.js`** (nuevo, provisto por el operador): servicio fire-and-forget que POSTea cada turno (pregunta + respuesta + grounding) al sidecar (`${VITE_SIDECAR_URL}/log-conversation`) con header `X-Chagra-Token`. Gated por `VITE_CAPTURE_CONVERSATIONS`, falla en silencio, `keepalive: true`.
- **`AgentScreen.jsx`**: al **finalizar** la respuesta del agente (justo después del `setMessages` del mensaje assistant, tras los guards/post-validate) dispara `captureExchange`:
  - **identity**: `user_id` (operatorId), `user_name` (getProfile().nombre), `finca_slug`/`finca_nombre` (finca activa).
  - **meta**: `session_id` (operatorId), `turn_index` (largo del hilo), `nlu_route`/`model` (selectChatRoute/buildLLMRequest), `entities_grounded` (resolvedEntities), `guards_fired` (guarded.reasons), `grounded_status` (sourceMetadata), `latency_ms` (medido sobre callLLM).
  - **Puro side-effect best-effort**: envuelto en try/catch, NO bloquea ni cambia el flujo del chat; lo no disponible va `null`/`[]`.
- **`.env.example`**: `VITE_CAPTURE_CONVERSATIONS=false` (default OFF → respeta privacidad de grupos futuros, que requieren Habeas Data / DR-F). El operador la pone `true` SOLO en el build del demo. Reusa `VITE_SIDECAR_URL` + `VITE_CHAGRA_MCP_TOKEN`.
- **`conversationCaptureService.test.js`** (nuevo): gate ON/OFF, schema del payload, header de auth, turnos vacíos no se envían, falla silenciosa si fetch rechaza.

## Validación

- `npx vitest run` del servicio nuevo → 8/8 verdes.
- Tests existentes de AgentScreen → 28/28 verdes (no rotos).
- `eslint --max-warnings=0` sobre los archivos cambiados → OK.
- `npm run build` (vite) → OK.

La flag NO se activa en código — el operador la pone ON en el build del demo.