### PR TITLE
fix(sw): Network-First para el shell HTML — mata el white screen tras deploy

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -62,7 +62,35 @@ self.addEventListener('fetch', (event) => {
     return; // browser maneja directamente
   }
 
-  // Static shell: Stale-While-Revalidate (sirve cache rápido, refresca async)
+  // HTML shell (documento navegable: `/`, `/index.html`, o cualquier navegación
+  // SPA): NETWORK-FIRST. Un deploy nuevo SIEMPRE entrega el index.html fresco
+  // (que referencia el bundle vivo); sólo cae al cache si el dispositivo está
+  // OFFLINE. Antes el HTML usaba Stale-While-Revalidate → servía un index.html
+  // cacheado de ANTES del deploy, apuntando a un bundle con hash que ya no
+  // existe → <script> 404 → pantalla en blanco (incidente 2026-06-05). El
+  // Network-First mata toda esa clase de "no carga tras deploy".
+  const isHtmlDoc =
+    event.request.mode === 'navigate' ||
+    url.pathname === '/' ||
+    url.pathname === '/index.html';
+  if (isHtmlDoc && event.request.method === 'GET') {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          if (response.ok) {
+            const respClone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put('/index.html', respClone));
+          }
+          return response;
+        })
+        // Offline: cae al index.html cacheado (shell) para que la SPA arranque.
+        .catch(() => caches.match(event.request).then(c => c || caches.match('/index.html')))
+    );
+    return;
+  }
+
+  // Resto del static shell NO-HTML (manifest, iconos): Stale-While-Revalidate
+  // (no referencian hashes de bundle, así que un cache viejo no rompe nada).
   if (ASSETS_TO_CACHE.some(path => url.pathname === path)) {
     event.respondWith(
       caches.match(event.request).then(cachedResponse => {


### PR DESCRIPTION
## Problema
"No carga el login" tras un deploy (reportado 2026-06-05). Diagnóstico con navegador real (Playwright en alpha): prod sana, **0 errores de consola/red**; la causa es el **Service Worker sirviendo un `index.html` cacheado de un deploy ANTERIOR** que referencia un bundle Vite con hash ya inexistente → `<script>` 404 → pantalla en blanco. Sólo reproduce en clientes con SW previo (no en navegador limpio).

## Raíz
El SW servía el documento HTML (`/`, `/index.html`) con **Stale-While-Revalidate** (sirve cache viejo primero). Un `index.html` cacheado pre-deploy apunta a un bundle muerto.

## Fix
Las navegaciones / documentos HTML pasan a **Network-First**: un deploy nuevo siempre entrega el index.html fresco; sólo cae al cache si está **offline** (fallback al shell). Intacto: `/assets/*` passthrough, manifest/iconos siguen SWR (no referencian hashes de bundle).

## Validación
- `node --check public/sw.js` OK
- swUpdateAck **67/67** verde (sin regresión del contrato de update)
- La **Offline-first E2E** del CI ejercita el SW (red de seguridad)

Workaround inmediato para quien ya tenga el SW viejo: Ctrl+Shift+R o unregister SW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)