### PR TITLE
fix(guards): suprimir agroquímico NOMBRADO en recomendación sin dosis (fuga prod 2026-06-06)

### DIFF
--- a/src/services/__tests__/outputGuards.test.js
+++ b/src/services/__tests__/outputGuards.test.js
@@ -335,6 +335,20 @@ describe('guardSyntheticAgrochemical', () => {
       const out = guardSyntheticAgrochemical('No te recomiendo abamectina; mejor manejo biológico con Encarsia.');
       expect(out.reason || '').not.toMatch(/suprimido/i);
     });
+
+    it('FUGA prod 2026-06-06: "Control químico: Aplica acetamiprid o imidacloprid" (SIN dosis) → SUPRIME', () => {
+      // Interacción real del operador: el agente recomendó neonicotinoides por
+      // nombre, sin dosis ni marca. La nota anexa NO basta — nombrar el activo en
+      // una recomendación ya es el daño. Debe suprimirse el cuerpo.
+      const out = guardSyntheticAgrochemical(
+        'Para controlar el pulgón:\n2. **Control químico**: Aplica insecticidas específicos para pulgones, como acetamiprid o imidacloprid, siguiendo las instrucciones del fabricante.',
+      );
+      expect(out.modified).toBe(true);
+      expect(out.reason).toMatch(/suprimido/i);
+      expect(out.text).not.toMatch(/imidacloprid/i);
+      expect(out.text).not.toMatch(/acetamiprid/i);
+      expect(out.text).toMatch(/agroecológico/i);
+    });
   });
 });
 

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -672,6 +672,28 @@ const PESTICIDE_DOSE_PATTERNS = [
 ];
 
 /**
+ * Verbos/giros de RECOMENDACIÓN o APLICACIÓN que, junto a un PESTICIDA sintético
+ * NOMBRADO (hit del denylist), delatan que el modelo lo está RECETANDO — no
+ * mencionándolo de pasada ni desaconsejándolo. Cubren el fraseo real de prod
+ * ("Control químico: Aplica insecticidas específicos... como acetamiprid o
+ * imidacloprid"). Nombrar el activo ya es la fuga: el campesino lee "aplica
+ * imidacloprid" aunque no venga dosis. El gate `esAdvertenciaNoUsar` (arriba) ya
+ * excluye "no/nunca uses/recomiendes X", así que esto NO sobre-suprime
+ * advertencias. Sobre texto normalizado sin tildes.
+ */
+const PESTICIDE_RECOMMEND_PATTERNS = [
+  // "Control químico:" como sección/opción (el fraseo exacto de la fuga prod).
+  /\bcontrol\s+quimic\w*\b/,
+  // "insecticida(s) específico(s)/sistémico(s)/químico(s)/de síntesis" — recomendar la CLASE.
+  /\binsecticidas?\s+(especific\w*|sistemic\w*|quimic\w*|de\s+sintesis)\b/,
+  // IMPERATIVO de aplicación dirigido al usuario (no el descriptivo "algunos usan").
+  // OJO: `recomiend\w*`/`usa\w*` se EXCLUYEN a propósito: "algunos usan glifosato"
+  // y "no te recomiendo abamectina" NO son recomendaciones (falsos positivos).
+  /\b(aplica|aplique|apliquen|fumiga|fumigue|fumiguen|asperja|asperje)\b/,
+  /\bpuedes?\s+(usar|aplicar|fumigar|asperjar)\b/,
+];
+
+/**
  * ¿El texto normalizado recomienda un PESTICIDA de síntesis CON una marca comercial o
  * una dosis de aplicación? Esa conjunción (i.a. sintético + marca/dosis) delata una
  * RECOMENDACIÓN concreta de químico que debe SUPRIMIRSE, no solo anexarse.
@@ -702,7 +724,15 @@ function _hasSyntheticPesticideBrandOrDose(norm, hits) {
   // (b) ¿hay una marca comercial o una dosis de aplicación cerca?
   const hasBrand = PESTICIDE_BRAND_PATTERNS.some((re) => re.test(norm));
   const hasDose = PESTICIDE_DOSE_PATTERNS.some((re) => re.test(norm)) || DOSE_PATTERNS.some((re) => re.test(norm));
-  return hasBrand || hasDose;
+  // (c) FUGA real prod 2026-06-06 (interacción operador: "Control químico: Aplica
+  // insecticidas específicos para pulgones, como acetamiprid o imidacloprid").
+  // NOMBRAR un neonicotinoide/sintético como RECOMENDACIÓN ya es el daño — el
+  // campesino lee "aplica imidacloprid" aunque no haya marca ni dosis, y la nota
+  // anexa NO basta. Si hay un verbo de aplicación/recomendación (y NO es la
+  // advertencia de no-usar, ya descartada arriba) → SUPRIMIR. El gate
+  // `esAdvertenciaNoUsar` + el requisito de hit-pesticida evitan sobre-supresión.
+  const esRecomendacion = PESTICIDE_RECOMMEND_PATTERNS.some((re) => re.test(norm));
+  return hasBrand || hasDose || esRecomendacion;
 }
 
 // ── PATRÓN (b) BORDE-020: combustible/solvente disfrazado de "adyuvante" ─────


### PR DESCRIPTION
## Fuga real (interacción del operador)
El agente respondió: *"Control químico: **Aplica** insecticidas específicos para pulgones, como **acetamiprid o imidacloprid**"*. El guard solo **anexó** la nota agroecológica y dejó "aplica imidacloprid" **en el cuerpo** → el campesino lo lee igual. Daño real.

## Causa
El suppress-and-replace de pesticida exigía **marca o dosis**. Un neonicotinoide **nombrado sin dosis** caía en modo append (solo nota).

## Fix
`PESTICIDE_RECOMMEND_PATTERNS`: sintético del denylist NOMBRADO + verbo de aplicación dirigido ("aplica/fumiga", "control químico", "insecticida específico") → **suprime-y-reemplaza**. Nombrar el activo en una recomendación ya es el daño.

**Anti-falso-positivo conservado** (excluidos `recomiend\w*`/`usa\w*`): *"algunos usan glifosato"* (descriptivo) y *"no te recomiendo abamectina"* (advertencia) siguen en append, NO se suprimen.

## Validación
- Test del caso real agregado · outputGuards **411/411** verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)