### PR TITLE
fix(chat): subir max_tokens para no truncar respuestas (fuga prod 2026-06-06)

### DIFF
--- a/src/services/__tests__/llmRouter.test.js
+++ b/src/services/__tests__/llmRouter.test.js
@@ -25,6 +25,17 @@ describe('ROUTES y getModelFor', () => {
     }
   });
 
+  it('REGRESIÓN truncamiento (2026-06-06): el cap de chat no baja del piso que evita cortar a media frase', () => {
+    // Fuga real (interacción operador): respuesta de siembra cortada en
+    // "…riego regular para" porque una lista de 5 especies con descripción
+    // supera 512 tokens. Piso defensivo: que un futuro tuning de latencia no
+    // reviva el truncamiento. Subir es libre; bajar de esto NO.
+    expect(ROUTES.chat.max_tokens).toBeGreaterThanOrEqual(768);
+    expect(ROUTES.chat_complex.max_tokens).toBeGreaterThanOrEqual(1024);
+    // chat_complex debe dar MÁS techo que chat (queries más estructuradas).
+    expect(ROUTES.chat_complex.max_tokens).toBeGreaterThanOrEqual(ROUTES.chat.max_tokens);
+  });
+
   it('getModelFor devuelve la ruta de una tarea válida', () => {
     const route = getModelFor('chat');
     expect(route).toBe(ROUTES.chat);

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -92,7 +92,11 @@ export const ROUTES = {
       'granite3.1-dense:8b',
     keep_alive_min: 30,
     temperature: 0.3,
-    max_tokens: 512,
+    // 2026-06-06: 512→768. Fuga real (interacción operador): respuesta de
+    // siembra cortada a media frase ("…riego regular para") porque una lista
+    // de 5 especies con descripción supera 512 tokens. Intelligence-first:
+    // no truncar el consejo agronómico por ahorrar tokens.
+    max_tokens: 768,
     // BUG A fix (2026-05-30): corta turnos falsos "Usuario:"/"Asistente:".
     stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',
@@ -122,7 +126,10 @@ export const ROUTES = {
       'granite3.1-dense:8b',
     keep_alive_min: 5,
     temperature: 0.3,
-    max_tokens: 768,
+    // 2026-06-06: 768→1024. Las queries complejas (planes multi-cultivo,
+    // asocios, enumeraciones con descripción) son justo las que más se
+    // truncaban. Intelligence-first sobre latencia.
+    max_tokens: 1024,
     // BUG A fix (2026-05-30): corta turnos falsos "Usuario:"/"Asistente:".
     stop: CHAT_STOP_SEQUENCES,
     url: '/api/ollama/v1/chat/completions',


### PR DESCRIPTION
## Fuga real (interacción del operador)
La respuesta de siembra se cortó a media frase: *"…mantener un riego regular **para**"*. Causa: una lista de 5 especies con descripción supera los **512 tokens** del cap `chat` (`num_predict`). El campesino ve consejo agronómico incompleto.

## Fix
`llmRouter.js`: `chat` 512→**768**, `chat_complex` 768→**1024**. Las complejas (planes multi-cultivo, asocios, enumeraciones) son justo las que más truncaban. **Intelligence-first** (memoria `feedback-intelligence-first-never-shrink-models`): no recortar el consejo por ahorrar latencia.

## Test
Regresión que fija el **piso** del cap (≥768 / ≥1024) para que un futuro tuning de velocidad no reviva el truncamiento. `llmRouter` 16/16 verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)