### PR TITLE
feat(guards): caveat suave sobre binomio de organismo benéfico fabricado

### DIFF
--- a/src/services/__tests__/outputGuards.fabricatedBeneficial.test.js
+++ b/src/services/__tests__/outputGuards.fabricatedBeneficial.test.js
@@ -1,0 +1,242 @@
+/**
+ * outputGuards.fabricatedBeneficial.test.js — GUARD: binomio de organismo
+ * BENÉFICO fabricado (depredador / parasitoide / polinizador).
+ *
+ * BUG REAL (2026-06-06): respondiendo sobre control del pulgón, el agente
+ * recomendó enemigos naturales e INVENTÓ un binomio que no existe: "hormigas
+ * cazadoras (*Oligamus pectoralis*)". `Aphidius colemani`, mencionado al lado,
+ * SÍ es real. El campesino recibe un nombre falso de organismo benéfico →
+ * desinformación.
+ *
+ * DOCTRINA (conservadora, anti-falso-positivo):
+ *  - "No está en el catálogo" ≠ "inventado". Colombia tiene muchísimas especies
+ *    nativas reales fuera de las ~496 del catálogo → NUNCA suprimir un binomio
+ *    por no estar en el grafo (tacharíamos nativas legítimas).
+ *  - El guard NO borra: ANEXA un caveat suave sobre los binomios de organismos
+ *    benéficos que NO se pueden confirmar contra una allowlist curada de géneros
+ *    de biocontrol REALES y conocidos. El cuerpo del LLM queda intacto.
+ *  - Solo actúa en CONTEXTO de control biológico / enemigos naturales: un binomio
+ *    suelto fuera de ese contexto no se toca.
+ *  - Géneros de biocontrol reales y conocidos (Aphidius, Chrysoperla, Coccinella,
+ *    Trichogramma…) NO reciben caveat.
+ *  - Determinístico, barato (regex + lookup), idempotente, sin llamar al LLM.
+ *
+ * Casos cubiertos:
+ *  1. Caso real "Oligamus pectoralis" (género inexistente) en contexto de
+ *     enemigos naturales → recibe caveat suave.
+ *  2. Anti-FP: "Aphidius colemani" (parasitoide real) en el mismo contexto → NO
+ *     recibe caveat.
+ *  3. Anti-FP: "Chrysoperla" / "Chrysoperla carnea" (crisopa real) → NO caveat.
+ *  4. Anti-FP: especie nativa real fuera de catálogo, mencionada como cultivo /
+ *     planta (NO como enemigo natural) → NO se toca (ni caveat ni supresión).
+ *  5. El caveat es ADITIVO: el cuerpo original se preserva entero.
+ *  6. Idempotencia: segunda pasada no re-anexa.
+ *  7. Texto vacío / no-string → no-op.
+ *  8. Binomio grounded (en resolvedEntities) → no recibe caveat aunque su
+ *     género no esté en la allowlist (la fuente curada lo respalda).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  guardFabricatedBeneficialBinomial,
+  applyOutputGuards,
+  getOutputGuardTelemetry,
+  resetOutputGuardTelemetry,
+} from '../outputGuards.js';
+
+// Marca textual del caveat para asserts robustos (independiente de la prosa).
+const CAVEAT_MARK = /verifica este nombre con tu t[eé]cnico|no pude confirmar/i;
+
+describe('guardFabricatedBeneficialBinomial', () => {
+  // ── CASO 1: el bug real ────────────────────────────────────────────────────
+  it('caso real: "Oligamus pectoralis" como enemigo natural → caveat suave', () => {
+    const text =
+      'Para el pulgón puedes usar enemigos naturales como las hormigas cazadoras ' +
+      '(Oligamus pectoralis) y la avispita parasitoide Aphidius colemani, que atacan a los áfidos.';
+
+    const res = guardFabricatedBeneficialBinomial(text);
+
+    expect(res.modified).toBe(true);
+    // El caveat menciona el binomio dudoso
+    expect(res.text).toContain('Oligamus pectoralis');
+    // El caveat es de "no pude confirmar" / "verifica con tu técnico"
+    expect(res.text).toMatch(CAVEAT_MARK);
+    // NUNCA borra: el cuerpo original sigue presente
+    expect(res.text).toContain('pulgón');
+    expect(res.text).toContain('hormigas cazadoras');
+    // El parasitoide REAL del mismo texto NO debe figurar como dudoso
+    expect(res.text).not.toMatch(/Aphidius colemani[^.]*no pude confirmar/i);
+  });
+
+  // ── CASO 2: anti-FP parasitoide real ──────────────────────────────────────
+  it('anti-FP: "Aphidius colemani" (parasitoide real) → NO caveat', () => {
+    const text =
+      'Contra el pulgón, libera la avispita parasitoide Aphidius colemani; ' +
+      'es un enemigo natural muy efectivo de los áfidos.';
+
+    const res = guardFabricatedBeneficialBinomial(text);
+
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(text);
+    expect(res.text).not.toMatch(CAVEAT_MARK);
+  });
+
+  // ── CASO 3: anti-FP crisopa real ──────────────────────────────────────────
+  it('anti-FP: "Chrysoperla carnea" (crisopa, depredador real) → NO caveat', () => {
+    const text =
+      'La crisopa (Chrysoperla carnea) es un depredador voraz de pulgones y ' +
+      'sus larvas devoran cochinillas. Es un excelente controlador biológico.';
+
+    const res = guardFabricatedBeneficialBinomial(text);
+
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(text);
+  });
+
+  it('anti-FP: catarina / mariquita "Coccinella septempunctata" depredador → NO caveat', () => {
+    const text =
+      'Las mariquitas (Coccinella septempunctata) son depredadoras de áfidos; ' +
+      'atrae estos enemigos naturales sembrando flores.';
+    const res = guardFabricatedBeneficialBinomial(text);
+    expect(res.modified).toBe(false);
+  });
+
+  // ── CASO 4: anti-FP especie nativa fuera de catálogo (NO benéfica) ────────
+  it('anti-FP: especie nativa real fuera de catálogo como CULTIVO → no se toca', () => {
+    // Genus real colombiano, probablemente fuera de las ~496 del catálogo, pero
+    // mencionado como planta/cultivo, NO como enemigo natural. Sin contexto de
+    // biocontrol → el guard no debe tocarlo.
+    const text =
+      'El chontaduro (Bactris gasipaes) y el copoazú (Theobroma grandiflorum) ' +
+      'son cultivos amazónicos que se dan bien en tu zona cálida y húmeda.';
+
+    const res = guardFabricatedBeneficialBinomial(text);
+
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(text);
+    expect(res.text).not.toMatch(CAVEAT_MARK);
+  });
+
+  it('anti-FP: binomio plausible pero SIN contexto de enemigo natural → no se toca', () => {
+    // "Inga edulis" mencionado como árbol de sombra, no como biocontrol.
+    const text =
+      'El guamo (Inga edulis) da buena sombra al cafetal y fija nitrógeno en el suelo.';
+    const res = guardFabricatedBeneficialBinomial(text);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(text);
+  });
+
+  // ── CASO 5: el caveat es ADITIVO ──────────────────────────────────────────
+  it('el caveat ANEXA, no reemplaza: el cuerpo del LLM queda intacto', () => {
+    const text =
+      'Suelta el depredador Falsus inexistentus para comerse las larvas. ' +
+      'También ayuda mantener flores que atraigan polinizadores.';
+
+    const res = guardFabricatedBeneficialBinomial(text);
+
+    expect(res.modified).toBe(true);
+    // todo el cuerpo original presente
+    expect(res.text).toContain('Falsus inexistentus');
+    expect(res.text).toContain('mantener flores que atraigan polinizadores');
+    expect(res.text).toMatch(CAVEAT_MARK);
+  });
+
+  // ── CASO 6: idempotencia ──────────────────────────────────────────────────
+  it('idempotencia: segunda pasada no re-anexa el caveat', () => {
+    const text =
+      'Las hormigas cazadoras (Oligamus pectoralis) atacan al pulgón como enemigos naturales.';
+    const first = guardFabricatedBeneficialBinomial(text);
+    expect(first.modified).toBe(true);
+
+    const second = guardFabricatedBeneficialBinomial(first.text);
+    expect(second.modified).toBe(false);
+    expect(second.text).toBe(first.text);
+  });
+
+  // ── CASO 7: texto vacío / no-string ───────────────────────────────────────
+  it('texto vacío → no-op', () => {
+    expect(guardFabricatedBeneficialBinomial('')).toEqual({
+      text: '',
+      modified: false,
+      reason: null,
+    });
+  });
+
+  it('texto no-string → no-op graceful', () => {
+    const r = guardFabricatedBeneficialBinomial(null);
+    expect(r.modified).toBe(false);
+    expect(r.text).toBe('');
+  });
+
+  // ── CASO 8: binomio grounded → no recibe caveat ───────────────────────────
+  it('binomio grounded (resolvedEntities) → NO caveat aunque género desconocido', () => {
+    // Si el grounding curado trae el binomio (p.ej. como pest_controller), está
+    // respaldado por una fuente y NO debe marcarse como dudoso, aunque su género
+    // no esté en la allowlist estática.
+    const text =
+      'Para el pulgón usa el parasitoide Lysiphlebus testaceipes, un enemigo natural.';
+    const resolvedEntities = [
+      {
+        kind: 'species',
+        nombre_comun: 'pulgón',
+        nombre_cientifico: 'Aphis gossypii',
+        pest_controllers: [
+          { nombre_comun: 'avispita', nombre_cientifico: 'Lysiphlebus testaceipes' },
+        ],
+      },
+    ];
+
+    const res = guardFabricatedBeneficialBinomial(text, resolvedEntities);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(text);
+  });
+
+  // ── prosa española capitalizada no se trata como binomio ──────────────────
+  it('prosa española capitalizada no dispara (Sin embargo / Estos enemigos)', () => {
+    const text =
+      'Sin embargo, los enemigos naturales ayudan. Estos depredadores controlan la plaga.';
+    const res = guardFabricatedBeneficialBinomial(text);
+    expect(res.modified).toBe(false);
+  });
+
+  // ── telemetría ────────────────────────────────────────────────────────────
+  it('dispara telemetría cuando anexa el caveat', () => {
+    resetOutputGuardTelemetry();
+    const text =
+      'Usa el depredador Inventus benefico contra el pulgón como enemigo natural.';
+    guardFabricatedBeneficialBinomial(text);
+    const t = getOutputGuardTelemetry();
+    expect(t['fabricated_beneficial_binomial']).toBeGreaterThan(0);
+  });
+});
+
+// ── integración con applyOutputGuards ─────────────────────────────────────────
+describe('applyOutputGuards · binomio benéfico fabricado', () => {
+  it('el caso real pasa por la cadena y sale con caveat (no suprimido)', () => {
+    const text =
+      'Para el pulgón, usa enemigos naturales como las hormigas cazadoras ' +
+      '(Oligamus pectoralis) junto con Aphidius colemani.';
+
+    const out = applyOutputGuards(text, {
+      userMessage: '¿cómo controlo el pulgón en mi cultivo?',
+    });
+
+    expect(out.modified).toBe(true);
+    expect(out.text).toContain('Oligamus pectoralis');
+    expect(out.text).toMatch(CAVEAT_MARK);
+    // aditivo: el binomio real sobrevive sin caveat propio
+    expect(out.text).toContain('Aphidius colemani');
+  });
+
+  it('anti-FP en cadena: respuesta solo con benéficos reales no recibe el caveat de fabricación', () => {
+    const text =
+      'Contra el pulgón libera Aphidius colemani y atrae crisopas (Chrysoperla carnea).';
+    const out = applyOutputGuards(text, {
+      userMessage: '¿qué enemigos naturales hay para el pulgón?',
+    });
+    // Puede que otros guards aditivos (MIP) actúen, pero NUNCA el caveat de
+    // binomio fabricado sobre estos dos reales.
+    expect(out.text).not.toMatch(/Aphidius colemani[^.]*no pude confirmar/i);
+    expect(out.text).not.toMatch(/Chrysoperla carnea[^.]*no pude confirmar/i);
+  });
+});

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -6059,6 +6059,205 @@ export function guardInventedBotanicalExtract(responseText, resolvedEntities = n
   };
 }
 
+// ── GUARD: binomio de ORGANISMO BENÉFICO FABRICADO (caveat suave · 2026-06-06) ─
+
+/**
+ * Allowlist de GÉNEROS de organismos BENÉFICOS (depredadores / parasitoides /
+ * polinizadores / entomopatógenos) REALES y bien documentados que se citan en
+ * agroecología neotropical/colombiana. Sirve para NO marcar como dudoso un
+ * binomio cuyo género es de control biológico conocido (Aphidius colemani,
+ * Chrysoperla carnea, Coccinella septempunctata…). Normalizado (minúsculas, sin
+ * tildes). Lista deliberadamente AMPLIA y conservadora hacia el NO-disparo: ante
+ * la duda preferimos NO poner caveat (un FP en un benéfico real molesta más que
+ * dejar pasar un benéfico raro sin confirmar).
+ *
+ * NO confundir con el catálogo Chagra (Species de CULTIVOS): estos son enemigos
+ * naturales / insectos benéficos, que en su mayoría NO están en el grafo de
+ * especies vegetales. Por eso el filtro de fabricación NO puede apoyarse en el
+ * catálogo (un benéfico real tampoco está ahí) — se apoya en esta allowlist
+ * curada de géneros.
+ */
+const BENEFICIAL_GENERA_ALLOWLIST = new Set(
+  [
+    // Parasitoides (Hymenoptera) — avispitas
+    'aphidius', 'lysiphlebus', 'diaeretiella', 'praon', 'aphelinus',
+    'encarsia', 'eretmocerus', 'trichogramma', 'telenomus', 'cotesia',
+    'apanteles', 'diadegma', 'diachasmimorpha', 'fopius', 'doryctobracon',
+    'tamarixia', 'anagyrus', 'leptomastix', 'metaphycus', 'cales',
+    'amitus', 'cephalonomia', 'prorops', 'phymastichus', 'spalangia',
+    'muscidifurax', 'pteromalus', 'bracon', 'habrobracon', 'opius',
+    // Depredadores: coccinélidos (mariquitas / catarinas)
+    'coccinella', 'hippodamia', 'harmonia', 'cycloneda', 'eriopis',
+    'olla', 'cryptolaemus', 'stethorus', 'scymnus', 'chilocorus',
+    'rodolia', 'novius', 'azya', 'delphastus',
+    // Depredadores: crisopas / hemeróbidos
+    'chrysoperla', 'chrysopa', 'ceraeochrysa', 'hemerobius', 'mallada',
+    // Depredadores: sírfidos, cecidómidos, antocóridos, míridos
+    'syrphus', 'allograpta', 'eupeodes', 'episyrphus', 'toxomerus',
+    'aphidoletes', 'orius', 'anthocoris', 'macrolophus', 'nesidiocoris',
+    'geocoris', 'nabis', 'podisus', 'zelus', 'sinea',
+    // Ácaros depredadores (fitoseidos)
+    'phytoseiulus', 'neoseiulus', 'amblyseius', 'galendromus', 'typhlodromus',
+    'iphiseiodes',
+    // Nematodos entomopatógenos
+    'steinernema', 'heterorhabditis',
+    // Hongos / bacterias / virus entomopatógenos (refuerzo de REAL_BIOCONTROL_TERMS)
+    'beauveria', 'metarhizium', 'cordyceps', 'isaria', 'lecanicillium',
+    'verticillium', 'purpureocillium', 'paecilomyces', 'pochonia', 'nomuraea',
+    'bacillus', 'baculovirus',
+    // Antagonistas de hongos (biocontrol fitopatógeno)
+    'trichoderma', 'gliocladium', 'ampelomyces',
+    // Polinizadores (abejas / abejorros / meliponas)
+    'apis', 'bombus', 'tetragonisca', 'melipona', 'scaptotrigona',
+    'nannotrigona', 'osmia', 'xylocopa', 'centris', 'eulaema', 'euglossa',
+  ].map(_stripDiacritics),
+);
+
+/**
+ * Términos que establecen CONTEXTO de ENEMIGO NATURAL / CONTROL BIOLÓGICO.
+ * El guard SOLO actúa sobre binomios que aparezcan en una oración (o su vecina)
+ * con uno de estos términos: así un binomio de CULTIVO/planta nativa (que NO es
+ * un organismo benéfico) jamás recibe caveat. Normalizado (minúsculas, sin
+ * tildes). Conservador: sin contexto de biocontrol → no se toca nada.
+ */
+const BENEFICIAL_CONTEXT_RE =
+  /\b(enemig\w*\s+natural\w*|control\w*\s+biolog\w*|biocontrol\w*|depredador\w*|parasitoid\w*|parasit\w*\s+(de\s+)?(la\s+|el\s+)?plaga|polinizador\w*|insecto\w*\s+benefic\w*|fauna\s+benefic\w*|avispit\w*\s+parasit\w*|liber[aeá]\w*\s+\w*\s*(para|contra)\b|se\s+(come|comen|alimenta\w*|aliment[ae]\w*)\s+(de\s+)?(los\s+|las\s+)?(pulgon\w*|afid\w*|larva\w*|huevo\w*|plaga\w*|cochinilla\w*|mosca\w*|trip\w*|acaro\w*))/;
+
+/** Prefijo/marca estable del caveat suave (idempotencia + asserts de test). */
+const FABRICATED_BENEFICIAL_MARKER = 'Verifica este nombre con tu técnico';
+
+/**
+ * guardFabricatedBeneficialBinomial — CAVEAT SUAVE sobre binomios de organismos
+ * BENÉFICOS (depredador / parasitoide / polinizador / entomopatógeno) que NO se
+ * pueden confirmar contra la allowlist curada de géneros de biocontrol reales.
+ *
+ * BUG REAL (2026-06-06): respondiendo "control del pulgón", el agente recomendó
+ * enemigos naturales e INVENTÓ "hormigas cazadoras (Oligamus pectoralis)" — un
+ * binomio que no existe (el género Oligamus no es un organismo descrito).
+ * Aphidius colemani, al lado, SÍ es real. El campesino recibe un nombre falso de
+ * organismo benéfico → desinformación que puede mandarlo a buscar/comprar algo
+ * que no existe.
+ *
+ * DISEÑO CONSERVADOR (anti-falso-positivo — restricción crítica):
+ *  - Colombia tiene MUCHÍSIMAS especies nativas reales fuera del catálogo. Por
+ *    eso "no está en el catálogo" ≠ "inventado": NUNCA suprimimos un binomio. El
+ *    daño aquí es AFIRMAR un nombre como cierto sin poder confirmarlo, no
+ *    nombrarlo — así que el remedio es un CAVEAT ANEXO, no un borrado (a
+ *    diferencia del guard de agroquímico/tóxico donde nombrar el insumo ES el
+ *    daño).
+ *  - El guard SOLO mira binomios en CONTEXTO de enemigo natural / control
+ *    biológico (`BENEFICIAL_CONTEXT_RE` en la oración o su vecina). Un binomio de
+ *    CULTIVO o planta nativa mencionada como árbol/sombra/comida NO entra → cero
+ *    riesgo de tachar nativas legítimas.
+ *  - Un binomio cuyo GÉNERO está en `BENEFICIAL_GENERA_ALLOWLIST` (o es un agro-
+ *    input real conocido) NO recibe caveat (Aphidius/Chrysoperla/Coccinella…).
+ *  - Un binomio que YA viene en el grounding curado (`resolvedEntities`, incl.
+ *    pest_controllers/companions) está respaldado por fuente → no recibe caveat.
+ *  - Pares de prosa española capitalizada ("Sin embargo", "Estos enemigos") se
+ *    descartan con `_looksLikeLatinBinomial` (igual que guards 5/5b).
+ *  - ADITIVO e IDEMPOTENTE: el cuerpo del LLM queda intacto; segunda pasada no
+ *    re-anexa. Determinístico y barato (regex + lookup), sin llamar al LLM.
+ *
+ * Alcance honesto: detecta binomios de organismos benéficos cuyo GÉNERO no es de
+ * biocontrol conocido. Generaliza más allá del caso `Oligamus pectoralis` (cubre
+ * cualquier género no-allowlisted en contexto benéfico), PERO la cobertura
+ * depende de la completitud de la allowlist y del detector de contexto: un
+ * binomio fabricado cuyo GÉNERO coincida casualmente con uno real de biocontrol
+ * (epíteto inventado, p.ej. "Aphidius fantasticus") NO se marca — eso requeriría
+ * un resolver externo (GBIF/POWO) que hoy el sidecar no expone. El caveat es
+ * suave a propósito: ante la duda no afirma "es falso", solo pide verificar.
+ *
+ * Firma propia (necesita las entidades resueltas crudas para el grounding) → se
+ * invoca aparte en applyOutputGuards, fuera de GUARD_CHAIN.
+ *
+ * @param {string} responseText
+ * @param {Array<object>|null} resolvedEntities  grounding del turno (opcional).
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardFabricatedBeneficialBinomial(responseText, resolvedEntities = null) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+  // Idempotencia: nuestro caveat ya está → no re-anexar.
+  if (responseText.includes(FABRICATED_BENEFICIAL_MARKER)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Gate barato: si el texto no toca control biológico / enemigos naturales en
+  // ningún lado, no hay nada que mirar (cero costo en respuestas de siembra/precio).
+  const fullNorm = _stripDiacritics(responseText);
+  if (!BENEFICIAL_CONTEXT_RE.test(fullNorm)) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Binomios ya respaldados por el grounding curado (entidad + sub-arrays) → no
+  // se cuestionan, aunque su género no esté en la allowlist estática.
+  const grounded = _groundedBinomials(Array.isArray(resolvedEntities) ? resolvedEntities : []);
+
+  // Recorremos oración por oración: un binomio solo es "benéfico" si su oración
+  // (o una vecina inmediata) está en contexto de enemigo natural/biocontrol.
+  const sentences = _splitSentences(responseText);
+  const sentNorms = sentences.map((s) => _stripDiacritics(s));
+
+  /** binomios canónicos dudosos, en orden de aparición, dedup. */
+  const dudosos = [];
+  const seen = new Set();
+  /** display crudo (Género epíteto) por binomio canónico, para el caveat. */
+  const displayOf = new Map();
+
+  for (let i = 0; i < sentences.length; i += 1) {
+    // ¿Esta oración o una vecina inmediata establece contexto benéfico?
+    const ctxHere =
+      BENEFICIAL_CONTEXT_RE.test(sentNorms[i]) ||
+      (i > 0 && BENEFICIAL_CONTEXT_RE.test(sentNorms[i - 1])) ||
+      (i + 1 < sentNorms.length && BENEFICIAL_CONTEXT_RE.test(sentNorms[i + 1]));
+    if (!ctxHere) continue;
+
+    SCI_BINOMIAL_RE.lastIndex = 0;
+    let m;
+    while ((m = SCI_BINOMIAL_RE.exec(sentences[i])) !== null) {
+      const genusRaw = m[1];
+      const epithetRaw = m[2];
+      if (!_looksLikeLatinBinomial(genusRaw, epithetRaw)) continue;
+      const genusNorm = _stripDiacritics(genusRaw).toLowerCase();
+      // Género de biocontrol REAL conocido (allowlist o agro-input) → legítimo.
+      if (BENEFICIAL_GENERA_ALLOWLIST.has(genusNorm)) continue;
+      if (_isRealAgroInput(genusNorm)) continue;
+      const bin = _binomial(`${genusRaw} ${epithetRaw}`);
+      if (!bin) continue;
+      // Respaldado por el grounding curado → no se cuestiona.
+      if (grounded.has(bin)) continue;
+      if (seen.has(bin)) continue;
+      seen.add(bin);
+      dudosos.push(bin);
+      displayOf.set(bin, `${genusRaw} ${epithetRaw}`);
+    }
+  }
+
+  if (dudosos.length === 0) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  bumpGuardTelemetry('fabricated_beneficial_binomial');
+
+  const nombres = dudosos.map((b) => displayOf.get(b) || _displayBinomial(b));
+  const lista = nombres.length === 1 ? `"${nombres[0]}"` : nombres.map((n) => `"${n}"`).join(', ');
+  const plural = nombres.length > 1;
+  const caveat =
+    `${FABRICATED_BENEFICIAL_MARKER}: no pude confirmar ${plural ? 'los nombres científicos' : 'el nombre científico'} ${lista} ` +
+    `como ${plural ? 'organismos benéficos reales' : 'un organismo benéfico real'} en mis fuentes. ` +
+    `${plural ? 'Pueden estar' : 'Puede estar'} mal escrito${plural ? 's' : ''} o ser un nombre equivocado. ` +
+    `Antes de buscar${plural ? 'los' : 'lo'} o comprar${plural ? 'los' : 'lo'}, valida con tu técnico, el ICA o Agrosavia ` +
+    `qué enemigo natural sirve para tu plaga.`;
+
+  const text = `${responseText.trim()}\n\n${caveat}`;
+  return {
+    text,
+    modified: true,
+    reason: `binomio_benefico_no_confirmado: ${dudosos.join(', ')}`,
+  };
+}
+
 /**
  * Set de guards que SOLO tienen sentido cuando la consulta es de SIEMBRA
  * (A12). Si la pregunta del usuario es de PRECIO/MERCADO (o info general sin
@@ -6429,6 +6628,22 @@ export function applyOutputGuards(
     text = extractRes.text;
     modified = true;
     if (extractRes.reason) reasons.push(extractRes.reason);
+  }
+  // Guard CAVEAT de BINOMIO de ORGANISMO BENÉFICO FABRICADO (2026-06-06): firma
+  // propia (usa el grounding crudo para no cuestionar binomios respaldados por
+  // fuente). Corre SIEMPRE (no es de siembra). ADITIVO y conservador: si la
+  // respuesta nombra un enemigo natural / depredador / parasitoide / polinizador
+  // con un binomio cuyo GÉNERO no es de biocontrol conocido (Oligamus
+  // pectoralis…), ANEXA un caveat suave ("verifica este nombre con tu técnico; no
+  // pude confirmarlo") SIN borrar el cuerpo — el daño es afirmar un nombre como
+  // cierto, no nombrarlo. NUNCA suprime, para no tachar nativas reales fuera de
+  // catálogo. Va tras los aditivos y antes de la superficie de ConfusionWarning,
+  // para que el prefijo tóxico de esta última (si dispara) siga liderando.
+  const benefRes = guardFabricatedBeneficialBinomial(text, resolvedEntities);
+  if (benefRes && benefRes.modified) {
+    text = benefRes.text;
+    modified = true;
+    if (benefRes.reason) reasons.push(benefRes.reason);
   }
   // Guard SAFETY-CRITICAL de superficie de ConfusionWarning (BORDE-001 ·
   // cianuro/escopolamina/ricina/rotenona): firma propia (necesita las entidades


### PR DESCRIPTION
## Bug real (2026-06-06)
Respondiendo sobre control del pulgón, el agente recomendó enemigos naturales e **inventó un binomio que no existe**: "hormigas cazadoras (*Oligamus pectoralis*)". *Aphidius colemani*, mencionado al lado, **sí** es real. El campesino recibe un nombre falso de organismo benéfico → desinformación (puede mandarlo a buscar/comprar algo inexistente).

## Decisión: guard NUEVO (no extender `applyTaxonomyGuard`)
`applyTaxonomyGuard` (A24) valida binomios contra `validate_taxonomy` y trata `found:false` ("no está en el catálogo") como alucinación. Eso marcaría **especies nativas legítimas** fuera del catálogo (656 nodos AGE / ~496 species) — exactamente el falso positivo que aquí se prohíbe. Además, el tool real devuelve `{found, source, canonical_*}` y **nunca** un campo `valid`, por lo que la rama `res.valid===false` de `applyTaxonomyGuard` es **un no-op en producción** (solo pasa por sus mocks de test). Por eso agrego un guard independiente y conservador.

## Cómo evita falsos positivos en nativas
- **Solo actúa en CONTEXTO de enemigo natural / control biológico** (depredador / parasitoide / polinizador / "se come los pulgones"…). Un binomio de cultivo o planta nativa mencionada como árbol/sombra/comida (p.ej. *Bactris gasipaes*, *Inga edulis*) **no entra** → cero riesgo de tachar nativas.
- **Allowlist curada** de ~90 géneros de biocontrol reales (Aphidius, Lysiphlebus, Chrysoperla, Coccinella, Trichogramma, Phytoseiulus, Apis, Bombus…). Un binomio cuyo género está allí **no recibe caveat**.
- **Grounding curado** (`resolvedEntities`, incl. `pest_controllers`/`companions`) → binomio respaldado por fuente **no se cuestiona**.
- **NUNCA suprime**: ANEXA un caveat suave ("Verifica este nombre con tu técnico; no pude confirmarlo"). El daño es *afirmar un nombre como cierto*, no nombrarlo — a diferencia del guard de agroquímico/tóxico donde nombrar el insumo ES el daño. Idempotente, barato (regex + lookup), sin LLM.

## Tests (test-first)
`src/services/__tests__/outputGuards.fabricatedBeneficial.test.js` (15 casos):
- **Caso real**: *Oligamus pectoralis* en contexto de enemigos naturales → caveat suave; cuerpo intacto; *Aphidius colemani* no marcado.
- **Anti-FP benéficos reales**: *Aphidius colemani*, *Chrysoperla carnea*, *Coccinella septempunctata* → sin caveat.
- **Anti-FP nativa fuera de catálogo**: *Bactris gasipaes*/*Theobroma grandiflorum* como cultivo, *Inga edulis* como sombra → no se toca.
- Aditividad, idempotencia, grounding, prosa española, texto vacío, telemetría, e integración por `applyOutputGuards`.

## Verificación
- `npm run build` ✓
- vitest módulo ✓ (15/15) · `outputGuards` completo ✓ (426/426) · `src/services` ✓ (2587 pass, 1 skip)
- `eslint --max-warnings=0` ✓

## Honestidad sobre la robustez
Generaliza más allá del caso conocido: cubre **cualquier** género no-allowlisted en contexto benéfico. Límites: (1) un binomio fabricado cuyo **género coincida** con uno real de biocontrol pero con **epíteto inventado** (p.ej. "*Aphidius fantasticus*") **no** se marca — eso requeriría un resolver externo (GBIF/POWO) que el sidecar hoy no expone; (2) la cobertura depende de la completitud de la allowlist y del detector de contexto. El caveat es **suave a propósito**: ante la duda no afirma "es falso", solo pide verificar — el modo correcto de fallar cuando no se puede confirmar de forma determinística sin riesgo de FP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)