### PR TITLE
fix(guards): remover guard taxonómico A24 muerto (rama res.valid no-op en prod)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -76,7 +76,7 @@ import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../
 import { getCurrentTier } from '../../services/tierService';
 import DeepResearchCard from '../DeepResearchCard';
 import { buildProfileContext, normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, generateViabilityRules, generateAgronomicGuidanceRules, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity } from '../../services/agentService';
-import { applyOutputGuards, applyTaxonomyGuard, classifyQueryIntent } from '../../services/outputGuards';
+import { applyOutputGuards, classifyQueryIntent } from '../../services/outputGuards';
 import { getProfile } from '../../services/userProfileService';
 import { regionFromProfile, getEnsoOutlook } from '../../services/ensoContext';
 // SALUDO PROACTIVO (#162 alertas + #298 tareas + #331 análisis): el agente, de
@@ -1820,30 +1820,13 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       if (guarded.modified) {
         console.debug('[guards] salida corregida', { reasons: guarded.reasons });
       }
-      // A24 — guard ASYNC anti-alucinación taxonómica: valida binomios Linneanos
-      // del texto contra el catálogo vía `validate_taxonomy`. Solo corrige cuando
-      // el tool confirma explícitamente `valid:false`; ante tool caído / offline /
-      // flag off → no-op (conservador, no rompe respuestas correctas). Corre AQUÍ
-      // (después de applyOutputGuards, antes de postValidate) para que la
-      // corrección quede en la respuesta final que se persiste y se muestra.
+      // A24 (guard ASYNC taxonómico) se REMOVIÓ 2026-06-06: estaba muerto en
+      // producción —filtraba por `res.valid===false` pero el tool real
+      // `validate_taxonomy` devuelve `{found,source,canonical_*}` y nunca
+      // `valid`—. La cobertura taxonómica la dan los guards síncronos de
+      // applyOutputGuards (#1332 binomio benéfico + 5/5b sustitución/companion)
+      // y el grounding de resolve-entities. Ver outputGuards.js.
       let response = guarded.text;
-      let taxonomyModified = false;
-      if (isOnline && isSidecarEnabled()) {
-        try {
-          const taxResult = await applyTaxonomyGuard(response, {
-            callTool,
-            resolvedEntities,
-          });
-          if (taxResult.modified) {
-            response = taxResult.text;
-            taxonomyModified = true;
-            console.debug('[guards] taxonomía corregida', { reason: taxResult.reason });
-          }
-        } catch (taxErr) {
-          // Jamás bloquea el chat — la respuesta ya está disponible.
-          console.debug('[guards] taxonomy-guard fail (sigo sin corrección):', taxErr?.message);
-        }
-      }
       agentSounds.chime();
 
       const { intent } = parseIntent(text);
@@ -1872,7 +1855,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         ...sourceMetadata,
         ...evidenceSourceLink,
         ...groundingBadges,
-        auto_corrected: guarded.modified === true || taxonomyModified === true,
+        auto_corrected: guarded.modified === true,
       };
 
       // Capa 2 anti-alucinación — cross-check de contexto (operador 2026-05-30).

--- a/src/services/__tests__/outputGuards.taxonomy.test.js
+++ b/src/services/__tests__/outputGuards.taxonomy.test.js
@@ -1,259 +1,130 @@
 /**
- * outputGuards.taxonomy.test.js — GUARD ASYNC: auto-validación taxonómica (A24).
+ * outputGuards.taxonomy.test.js — REGRESIÓN: el guard A24 (`applyTaxonomyGuard`)
+ * se REMOVIÓ por estar MUERTO en producción (2026-06-06).
  *
- * `applyTaxonomyGuard` extrae binomios Linneanos de la respuesta del LLM,
- * los valida contra el catálogo vía `validate_taxonomy` (sidecar), y, si el
- * tool confirma que un binomio NO existe en el catálogo, ANEXA una corrección
- * honesta al final del texto.
+ * CONTEXTO DEL BUG (confirmado empíricamente, fix/taxonomy-guard-a24-dead):
+ *   `applyTaxonomyGuard` llamaba al tool `validate_taxonomy` del sidecar y
+ *   filtraba sus resultados por `res.valid === false`. Pero el tool REAL
+ *   (`chagra-pro/modules/agro-mcp/src/tools/age-tools.ts` → `validateTaxonomy`)
+ *   NUNCA devuelve un campo `valid`: su contrato es
  *
- * Casos cubiertos:
- *  1. Binomio inválido detectado → corrección anexada.
- *  2. Binomio válido → no se toca nada.
- *  3. Tool caído (callTool devuelve null) → no-op (no rompe respuestas).
- *  4. Binomio ya grounded en resolvedEntities → no se valida (evita dups con guards 5/5b).
- *  5. Sin binomios en el texto → no-op.
- *  6. Texto vacío / no-string → no-op.
- *  7. Múltiples binomios: invalida solo los confirmados inválidos.
- *  8. Idempotencia: si la corrección ya está aplicada, no re-dispara.
+ *     { available, source: "catalog"|"age"|"none", found: boolean,
+ *       canonical_id, canonical_common, canonical_scientific,
+ *       scientific_input_matched?, alternatives, age_enriched?, ... }
  *
- * Mock: callTool inyectado por argumento (no red real, no sidecar).
+ *   El campo `valid` SOLO existe en OTRO tool —`validate_visual_match`
+ *   (pipeline de visión)—, que devuelve un ARRAY de `{species_id, valid, ...}`.
+ *   El servidor MCP serializa el resultado del handler verbatim y el
+ *   `sidecarClient.callTool` lo entrega sin transformar, así que el guard recibía
+ *   `{found, ...}` y `res.valid === false` era SIEMPRE `false`: la rama de
+ *   corrección JAMÁS disparaba fuera de los mocks de test (que falsamente
+ *   devolvían `{valid}`, enmascarando el bug).
+ *
+ * POR QUÉ SE REMOVIÓ (Opción B) en vez de re-wirearlo (Opción A):
+ *   La única señal real disponible es `found === false` = "no está en el
+ *   catálogo Chagra (~496 especies)". Tratar eso como alucinación para un
+ *   binomio ARBITRARIO en CUALQUIER contexto es exactamente el falso-positivo
+ *   que el guard #1332 (`guardFabricatedBeneficialBinomial`) prohíbe: Colombia
+ *   tiene muchísimas especies nativas REALES fuera del catálogo, y "no en
+ *   catálogo" ≠ "inventado". La única versión acotada de A (solo en contexto de
+ *   organismo benéfico) YA la cubre #1332 —determinístico, con allowlist curada
+ *   de géneros de biocontrol, sin round-trip de red—. Re-wirear A duplicaría esa
+ *   cobertura reintroduciendo el FP y la dependencia de red.
+ *
+ * Cobertura taxonómica REAL hoy (sin el guard A24):
+ *   - `guardFabricatedBeneficialBinomial` (#1332): caveat suave a binomios de
+ *     enemigo natural / biocontrol cuyo género no es de biocontrol conocido.
+ *   - `guardSpeciesSubstitution` / `guardCompanionBinomial` (5/5b): corrigen
+ *     binomios errados del CULTIVO principal y de companions/antagonists contra
+ *     el grounding curado del turno.
+ *   - El grounding de `resolve-entities` ancla los binomios en el catálogo/AGE
+ *     antes de generar.
+ *
+ * Este test FIJA el contrato real del tool y verifica que el guard muerto ya no
+ * se exporta, para que nadie re-introduzca una rama `res.valid` contra un tool
+ * que no la produce.
  */
 
-import { describe, it, expect, vi } from 'vitest';
-import { applyTaxonomyGuard } from '../outputGuards.js';
+import { describe, it, expect } from 'vitest';
+import * as outputGuards from '../outputGuards.js';
 
-// ── helpers de mock ──────────────────────────────────────────────────────────
-
-/** Mock de callTool que marca los binomios dados como inválidos en el catálogo. */
-function mockCallToolInvalid(invalidBinomials) {
-  return vi.fn(async (toolName, args) => {
-    if (toolName !== 'validate_taxonomy') return null;
-    const sci = (args.species_scientific || '').toLowerCase();
-    const isInvalid = invalidBinomials.some((b) => sci.includes(b.toLowerCase()));
-    return {
-      valid: !isInvalid,
-      canonical_id: isInvalid ? null : 'some_id',
-      canonical_name: isInvalid ? null : args.species_scientific,
-    };
+describe('applyTaxonomyGuard (A24) — guard muerto removido', () => {
+  it('ya NO se exporta desde outputGuards (rama res.valid era no-op en prod)', () => {
+    expect(outputGuards.applyTaxonomyGuard).toBeUndefined();
+    expect('applyTaxonomyGuard' in outputGuards).toBe(false);
   });
-}
 
-/** Mock de callTool que marca todos como válidos. */
-function mockCallToolAllValid() {
-  return vi.fn(async () => ({
-    valid: true,
-    canonical_id: 'some_id',
-    canonical_name: 'Something validum',
-  }));
-}
+  it('la cobertura taxonómica viva sigue exportada (no se removió protección real)', () => {
+    // #1332 — binomio de organismo benéfico fabricado.
+    expect(typeof outputGuards.guardFabricatedBeneficialBinomial).toBe('function');
+    // 5/5b — sustitución de especie y binomio de companion.
+    expect(typeof outputGuards.guardSpeciesSubstitution).toBe('function');
+    expect(typeof outputGuards.guardCompanionBinomial).toBe('function');
+  });
+});
 
-/** Mock de callTool que siempre falla (tool caído). */
-function mockCallToolDown() {
-  return vi.fn(async () => null);
-}
+describe('contrato REAL de validate_taxonomy (fijado para evitar regresión)', () => {
+  // Snapshots de las 4 formas que devuelve `validateTaxonomy` en el sidecar
+  // (age-tools.ts). NINGUNA tiene `valid` — esa era la premisa falsa del guard
+  // muerto. Si el tool cambiara su contrato, este test debe revisarse a mano.
 
-/** Entidad resuelta de grounding con binomio dado. */
-function groundedEntity(nombreCientifico, nombreComun = 'especie') {
-  return {
-    kind: 'species',
-    nombre_comun: nombreComun,
-    nombre_cientifico: nombreCientifico,
-    mentioned: nombreComun,
+  /** match en catálogo */
+  const catalogHit = {
+    available: true,
+    source: 'catalog',
+    found: true,
+    canonical_id: '42',
+    canonical_common: 'gulupa',
+    canonical_scientific: 'Passiflora edulis f. edulis',
+    scientific_input_matched: false,
+    confidence_min: 0.5,
+    alternatives: [],
+    age_enriched: false,
   };
-}
 
-// ── tests ─────────────────────────────────────────────────────────────────────
+  /** sin match (AGE caído o AGE sin match): la ÚNICA señal negativa es found:false */
+  const notFound = {
+    available: true,
+    source: 'none',
+    found: false,
+    query: { species_common: null, species_scientific: 'Inventus fakeus' },
+    alternatives: [],
+    hint: 'No species matched in catalog or AGE.',
+  };
 
-describe('applyTaxonomyGuard', () => {
-  // ── CASO 1: binomio inválido → corrección ──────────────────────────────────
-  it('binomio inválido confirmado por el tool → anexa corrección honesta', async () => {
-    const text =
-      'El tomate de árbol (Inventus fakeus) se siembra entre 1500 y 2500 msnm.';
-    const callTool = mockCallToolInvalid(['inventus fakeus']);
+  /** match vía AGE (Species ∪ Pest) */
+  const ageHit = {
+    available: true,
+    source: 'age',
+    found: true,
+    canonical_id: '900',
+    canonical_common: 'roya',
+    canonical_scientific: 'Hemileia vastatrix',
+    scientific_input_matched: null,
+    alternatives: [],
+    age_enriched: true,
+  };
 
-    const result = await applyTaxonomyGuard(text, { callTool });
-
-    expect(result.modified).toBe(true);
-    expect(result.reason).toMatch(/taxonom/i);
-    // La corrección honesta menciona el binomio cuestionado
-    expect(result.text).toContain('Inventus fakeus');
-    // Y explica que no está en el catálogo
-    expect(result.text).toMatch(/catálogo|no se encontró/i);
-    // El texto original se preserva (la corrección se ANEXA al final)
-    expect(result.text).toContain('tomate de árbol');
-    expect(result.text).toContain('1500 y 2500 msnm');
+  it('ninguna forma de validate_taxonomy expone un campo `valid`', () => {
+    for (const shape of [catalogHit, notFound, ageHit]) {
+      expect(shape).not.toHaveProperty('valid');
+      // `res.valid === false` (la condición del guard muerto) era siempre false.
+      expect(shape.valid === false).toBe(false);
+    }
   });
 
-  // ── CASO 2: binomio válido → no se toca ───────────────────────────────────
-  it('binomio válido confirmado por el tool → no-op', async () => {
-    const text =
-      'El tomate de árbol (Solanum betaceum) crece bien a 2000 msnm.';
-    const callTool = mockCallToolAllValid();
-
-    const result = await applyTaxonomyGuard(text, { callTool });
-
-    expect(result.modified).toBe(false);
-    expect(result.text).toBe(text);
-    expect(result.reason).toBeNull();
+  it('la señal negativa real es `found === false`, no `valid === false`', () => {
+    expect(notFound.found).toBe(false);
+    expect(catalogHit.found).toBe(true);
+    expect(ageHit.found).toBe(true);
   });
 
-  // ── CASO 3: tool caído → no-op ─────────────────────────────────────────────
-  it('tool caído (callTool devuelve null) → no-op conservador', async () => {
-    const text =
-      'El lulo (Inventus inventus) se siembra en clima frío.';
-    const callTool = mockCallToolDown();
-
-    const result = await applyTaxonomyGuard(text, { callTool });
-
-    expect(result.modified).toBe(false);
-    expect(result.text).toBe(text);
-  });
-
-  // ── CASO 4: binomio ya grounded → no se re-valida ─────────────────────────
-  it('binomio que ya viene en resolvedEntities (grounded) → no se llama callTool', async () => {
-    const text =
-      'El café (Coffea arabica) es ideal para piso cafetero.';
-    const callTool = mockCallToolInvalid(['coffea arabica']);
-    const resolvedEntities = [
-      groundedEntity('Coffea arabica Linn.', 'café'),
-    ];
-
-    const result = await applyTaxonomyGuard(text, { callTool, resolvedEntities });
-
-    // Coffea arabica está en el grounding → no se valida → no se modifica
-    expect(result.modified).toBe(false);
-    expect(result.text).toBe(text);
-    // callTool no debe haber sido llamado para este binomio
-    expect(callTool).not.toHaveBeenCalled();
-  });
-
-  // ── CASO 5: sin binomios en el texto → no-op ──────────────────────────────
-  it('texto sin binomios científicos → no-op, callTool no llamado', async () => {
-    const text = 'El tomate se siembra después de la lluvia. Abónalo bien.';
-    const callTool = vi.fn();
-
-    const result = await applyTaxonomyGuard(text, { callTool });
-
-    expect(result.modified).toBe(false);
-    expect(result.text).toBe(text);
-    expect(callTool).not.toHaveBeenCalled();
-  });
-
-  // ── CASO 6: texto vacío / no-string → no-op ───────────────────────────────
-  it('texto vacío → no-op, devuelve { text: "", modified: false, reason: null }', async () => {
-    const callTool = vi.fn();
-    const r1 = await applyTaxonomyGuard('', { callTool });
-    expect(r1.modified).toBe(false);
-    expect(r1.text).toBe('');
-    expect(r1.reason).toBeNull();
-    expect(callTool).not.toHaveBeenCalled();
-  });
-
-  it('text no-string → no-op graceful', async () => {
-    const callTool = vi.fn();
-    const r = await applyTaxonomyGuard(null, { callTool });
-    expect(r.modified).toBe(false);
-    expect(r.text).toBe('');
-    expect(callTool).not.toHaveBeenCalled();
-  });
-
-  // ── CASO 7: múltiples binomios, solo invalida los confirmados ─────────────
-  it('múltiples binomios: valida solo los no-grounded, corrige solo los inválidos', async () => {
-    // Texto con 3 binomios:
-    //   - Coffea arabica: grounded (en resolvedEntities) → no se valida
-    //   - Solanum betaceum: válido en catálogo (callTool devuelve valid:true)
-    //   - Inventus fakeus: INVÁLIDO
-    const text =
-      'El café (Coffea arabica) y el tomate de árbol (Solanum betaceum) son buenos cultivos. ' +
-      'También mencionó Inventus fakeus para las plagas.';
-    const callTool = mockCallToolInvalid(['inventus fakeus']);
-    const resolvedEntities = [groundedEntity('Coffea arabica Linn.', 'café')];
-
-    const result = await applyTaxonomyGuard(text, { callTool, resolvedEntities });
-
-    expect(result.modified).toBe(true);
-    // Coffea arabica no debe disparar callTool (grounded)
-    const calls = callTool.mock.calls;
-    expect(calls.every((c) => !(c[1]?.species_scientific || '').toLowerCase().includes('coffea'))).toBe(true);
-    // La corrección menciona el inválido
-    expect(result.text).toContain('Inventus fakeus');
-    // El texto original se preserva intacto
-    expect(result.text).toContain('Solanum betaceum');
-    expect(result.text).toContain('tomate de árbol');
-  });
-
-  // ── CASO 8: idempotencia ──────────────────────────────────────────────────
-  it('idempotencia: si la corrección ya está aplicada, no re-dispara', async () => {
-    const text =
-      'El tomate de árbol (Inventus fakeus) se siembra a 2000 msnm.\n\n' +
-      'Nota taxonómica: el binomio "Inventus fakeus" no se encontró en el catálogo Chagra.';
-    const callTool = mockCallToolInvalid(['inventus fakeus']);
-
-    const result = await applyTaxonomyGuard(text, { callTool });
-
-    expect(result.modified).toBe(false);
-    expect(result.text).toBe(text);
-  });
-
-  // ── coordinación con guards 5/5b: no duplicar binomios de companions ──────
-  it('binomio companion de una entidad resuelta también se salta (grounding completo)', async () => {
-    // Companion trae su propio nombre_cientifico → debe contarse como grounded
-    const text =
-      'El maíz (Zea mays) va bien con el fríjol (Phaseolus vulgaris).';
-    const callTool = mockCallToolInvalid(['phaseolus vulgaris']);
-    const resolvedEntities = [
-      {
-        kind: 'species',
-        nombre_comun: 'maíz',
-        nombre_cientifico: 'Zea mays L.',
-        mentioned: 'maíz',
-        companions: [
-          {
-            nombre_comun: 'fríjol',
-            nombre_cientifico: 'Phaseolus vulgaris L.',
-          },
-        ],
-      },
-    ];
-
-    const result = await applyTaxonomyGuard(text, { callTool, resolvedEntities });
-
-    expect(result.modified).toBe(false);
-    // Phaseolus vulgaris está en el grounding de companion → no se llama el tool
-    expect(callTool).not.toHaveBeenCalled();
-  });
-
-  // ── callTool no inyectado → no-op graceful ────────────────────────────────
-  it('sin callTool inyectado (undefined) → no-op graceful', async () => {
-    const text = 'Inventus fakeus es la especie recomendada.';
-    const result = await applyTaxonomyGuard(text, {});
-    expect(result.modified).toBe(false);
-    expect(result.text).toBe(text);
-  });
-
-  // ── pares prosa española (falsos positivos) → no se validan ───────────────
-  it('prosa española capitalizada no se trata como binomio', async () => {
-    // "Sin embargo", "La papa", "Estos cultivos" no son binomios.
-    const text = 'Sin embargo, la papa es viable. Estos cultivos no tienen problema.';
-    const callTool = vi.fn();
-
-    const result = await applyTaxonomyGuard(text, { callTool });
-
-    expect(result.modified).toBe(false);
-    expect(callTool).not.toHaveBeenCalled();
-  });
-
-  // ── telemetría: bump cuando modifica ─────────────────────────────────────
-  it('dispara telemetría cuando corrige', async () => {
-    const text = 'El tomate de árbol es Inventus fakeus.';
-    const callTool = mockCallToolInvalid(['inventus fakeus']);
-
-    const { getOutputGuardTelemetry, resetOutputGuardTelemetry } = await import('../outputGuards.js');
-    resetOutputGuardTelemetry();
-
-    await applyTaxonomyGuard(text, { callTool });
-
-    const telemetry = getOutputGuardTelemetry();
-    expect(telemetry['auto_taxonomy']).toBeGreaterThan(0);
+  it('`found:false` NO implica alucinación (puede ser nativa real fuera del catálogo)', () => {
+    // Documenta la razón de Opción B: el catálogo es ~496 especies; un binomio
+    // ausente puede ser una nativa colombiana legítima. Por eso `found:false`
+    // por sí solo NUNCA debe suprimir ni marcar como inventado un binomio
+    // arbitrario — sólo el contexto acotado de #1332 puede anexar caveat suave.
+    expect(notFound.found).toBe(false);
+    expect(notFound.source).toBe('none');
   });
 });

--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -6663,157 +6663,27 @@ export function applyOutputGuards(
   return { text, modified, reasons };
 }
 
-// ── GUARD ASYNC: auto-validación taxonómica (A24) ───────────────────────────
-
-/**
- * _groundedBinomialsFromAll — universo COMPLETO de binomios canónicos ya
- * conocidos del grounding: el de cada entidad resuelta, MÁS los anidados en
- * companions / antagonists / alternativas / pest_controllers. Cualquier
- * binomio presente en este set NO necesita validación externa (ya fue resuelto
- * por la capa 1 / guards 5 y 5b).
- *
- * Reutiliza `_binomial` y `_groundedBinomials` que ya existen en el módulo.
- * Se define aquí para el guard A24 (separado para legibilidad).
- *
- * @param {Array<object>|null} entities
- * @returns {Set<string>}
- */
-function _groundedBinomialsForTaxonomy(entities) {
-  if (!Array.isArray(entities) || entities.length === 0) return new Set();
-  return _groundedBinomials(entities);
-}
-
-/**
- * _extractUngroundedBinomials — extrae los binomios Linneanos del texto que
- * NO están ya en el conjunto de binomios grounded del turno. Estos son los
- * candidatos a validar con `validate_taxonomy`.
- *
- * Aplica el mismo filtro anti-prosa que los guards 5/5b: usa
- * `_looksLikeLatinBinomial` para descartar pares del español ("Sin embargo",
- * "Estos cultivos"). Devuelve un array de binomios canónicos únicos
- * (normalizado en minúsculas, "genus epiteto").
- *
- * @param {string} text
- * @param {Set<string>} groundedSet
- * @returns {Array<{raw:string, canonical:string}>}
- */
-function _extractUngroundedBinomials(text, groundedSet) {
-  const seen = new Set();
-  const out = [];
-  let m;
-  SCI_BINOMIAL_RE.lastIndex = 0;
-  while ((m = SCI_BINOMIAL_RE.exec(text)) !== null) {
-    if (!_looksLikeLatinBinomial(m[1], m[2])) continue;
-    const raw = `${m[1]} ${m[2]}`;
-    const canonical = _binomial(raw);
-    if (!canonical) continue;
-    if (groundedSet.has(canonical)) continue; // ya grounded → saltar
-    if (seen.has(canonical)) continue; // dedup
-    seen.add(canonical);
-    out.push({ raw, canonical });
-  }
-  return out;
-}
-
-/**
- * applyTaxonomyGuard — capa post-proceso ASYNC anti-alucinación taxonómica
- * (A24). Extrae los binomios Linneanos que el LLM incluyó en su respuesta y
- * que NO están cubiertos por el grounding del turno (resolvedEntities ya
- * resueltos por la capa 1 / guards 5/5b). Para cada uno llama al tool
- * `validate_taxonomy` del sidecar (vía la función `callTool` inyectada) y, si
- * el tool confirma que el binomio NO existe en el catálogo Chagra, ANEXA una
- * nota honesta al final de la respuesta.
- *
- * Diseño conservador (anti-falsos-positivos):
- *  - Solo corrige binomios que el tool confirme EXPLÍCITAMENTE como inválidos
- *    (`valid: false`). Si el tool devuelve null (caído/timeout/offline) → no-op.
- *  - Los binomios ya en el grounding (resolvedEntities + companions/alternativas)
- *    no se validan (ya cubiertos por guards 5/5b — sin duplicar correcciones).
- *  - Idempotente: si la corrección ya está en el texto, no re-dispara.
- *  - Pares de prosa española capitalizada ("Sin embargo", "Estos cultivos") se
- *    descartan con el mismo filtro de los guards 5/5b.
- *
- * Firma:
- * @param {string} responseText  respuesta post-`applyOutputGuards` del LLM.
- * @param {object} [opts]
- * @param {Function|null} [opts.callTool]  función `callTool` del sidecarClient
- *   inyectada por el caller (AgentScreen). Si falta → no-op graceful.
- * @param {Array<object>|null} [opts.resolvedEntities]  grounding del turno.
- * @returns {Promise<{text:string, modified:boolean, reason:string|null}>}
- */
-export async function applyTaxonomyGuard(
-  responseText,
-  { callTool: _callTool = null, resolvedEntities = null } = {},
-) {
-  // Entrada inválida → no-op graceful.
-  if (typeof responseText !== 'string' || responseText.length === 0) {
-    return { text: responseText ?? '', modified: false, reason: null };
-  }
-  // Sin callTool inyectado (flag off, no wired, etc.) → no-op.
-  if (typeof _callTool !== 'function') {
-    return { text: responseText, modified: false, reason: null };
-  }
-
-  // Universo de binomios ya grounded → no los re-validamos.
-  const grounded = _groundedBinomialsForTaxonomy(resolvedEntities);
-
-  // Extrae binomios no-grounded del texto.
-  const candidates = _extractUngroundedBinomials(responseText, grounded);
-  if (candidates.length === 0) {
-    return { text: responseText, modified: false, reason: null };
-  }
-
-  // Para cada candidato, llama validate_taxonomy. Ejecuta en paralelo para
-  // minimizar latencia (cada llamada tiene timeout de 5s en sidecarClient).
-  const results = await Promise.all(
-    candidates.map(async ({ raw, canonical }) => {
-      try {
-        const res = await _callTool('validate_taxonomy', {
-          species_scientific: raw,
-        });
-        return { raw, canonical, res };
-      } catch (_) {
-        return { raw, canonical, res: null };
-      }
-    }),
-  );
-
-  // Filtra los que el tool confirmó como INVÁLIDOS (valid: false).
-  const invalid = results.filter(
-    ({ res }) => res && typeof res === 'object' && res.valid === false,
-  );
-
-  if (invalid.length === 0) {
-    return { text: responseText, modified: false, reason: null };
-  }
-
-  // Idempotencia: construye la nota de corrección solo para los inválidos que
-  // aún no tienen una nota en el texto. Marca textual: "no se encontró en el
-  // catálogo Chagra" + el binomio.
-  const nuevas = invalid.filter(
-    ({ raw }) =>
-      !responseText.includes(
-        `"${raw}" no se encontró en el catálogo Chagra`,
-      ),
-  );
-
-  if (nuevas.length === 0) {
-    return { text: responseText, modified: false, reason: null };
-  }
-
-  bumpGuardTelemetry('auto_taxonomy');
-
-  const notas = nuevas.map(
-    ({ raw }) =>
-      `Nota taxonómica: el binomio "${raw}" no se encontró en el catálogo Chagra — puede ser un nombre ` +
-      `incorrecto o una especie no catalogada. Verifica el nombre científico con una fuente confiable ` +
-      `(ICA, Agrosavia, Tropicos) antes de usarlo como referencia.`,
-  );
-
-  const text = `${responseText.trim()}\n\n${notas.join('\n\n')}`;
-  return {
-    text,
-    modified: true,
-    reason: `taxonomía_no_catálogo: ${nuevas.map(({ raw }) => raw).join(', ')}`,
-  };
-}
+// ── GUARD ASYNC taxonómico (A24) — REMOVIDO 2026-06-06 ──────────────────────
+//
+// `applyTaxonomyGuard` se eliminó por estar MUERTO en producción. Llamaba al
+// tool `validate_taxonomy` del sidecar y filtraba por `res.valid === false`,
+// pero el tool REAL (chagra-pro/modules/agro-mcp/src/tools/age-tools.ts →
+// `validateTaxonomy`) NUNCA devuelve `valid`. Su contrato es
+//   { available, source:'catalog'|'age'|'none', found, canonical_id,
+//     canonical_common, canonical_scientific, scientific_input_matched?,
+//     alternatives, age_enriched?, ... }
+// El campo `valid` sólo existe en OTRO tool, `validate_visual_match` (visión),
+// que devuelve un array de `{species_id, valid, ...}`. El servidor MCP
+// serializa el resultado del handler verbatim y `sidecarClient.callTool` lo
+// entrega sin transformar, así que la rama de corrección JAMÁS disparaba en
+// prod (solo los mocks del test, que devolvían `{valid}`, la enmascaraban).
+//
+// No se re-wireó a la señal real (`found === false`) porque eso reintroduce el
+// falso-positivo que el guard #1332 (`guardFabricatedBeneficialBinomial`)
+// prohíbe: `found:false` = 'no está en el catálogo (~496 especies)', y Colombia
+// tiene muchísimas nativas reales fuera del catálogo — 'no en catálogo' ≠
+// 'inventado'. La única versión acotada (solo contexto de organismo benéfico)
+// ya la cubre #1332, determinístico y sin round-trip de red. La cobertura
+// taxonómica viva hoy: guardFabricatedBeneficialBinomial (#1332) +
+// guardSpeciesSubstitution / guardCompanionBinomial (5/5b) + el grounding de
+// resolve-entities. Ver fix/taxonomy-guard-a24-dead-2026-06-06.


### PR DESCRIPTION
## Hallazgo confirmado empíricamente

El guard taxonómico viejo **A24** (`applyTaxonomyGuard` en `src/services/outputGuards.js`) estaba **MUERTO en producción**.

El guard extraía los binomios Linneanos no-grounded de la respuesta del LLM, llamaba al tool `validate_taxonomy` del sidecar y filtraba los resultados por `res.valid === false`.

El tool **REAL** (`chagra-pro/modules/agro-mcp/src/tools/age-tools.ts` → `validateTaxonomy`) **nunca devuelve un campo `valid`**. Su contrato, verificado en las 4 ramas de retorno (catalog hit, AGE hit, catalog miss + AGE down, catalog miss + AGE miss):

```
{ available, source: "catalog"|"age"|"none", found, canonical_id,
  canonical_common, canonical_scientific, scientific_input_matched?,
  alternatives, age_enriched?, family?, roles?, hint? }
```

El campo `valid` solo existe en **otro** tool, `validate_visual_match` (pipeline de visión, líneas 285/296 de age-tools.ts), que devuelve un array de `{species_id, valid, ...}`.

Cadena de evidencia (el shape real llega al guard sin transformar):
- `server.ts` (MCP) serializa el resultado del handler verbatim: `JSON.stringify(result)`.
- `sidecarClient.callTool` → `postJson` retorna `await res.json()` sin reshape.
- `applyTaxonomyGuard` recibe `{found, ...}` → `res.valid === false` evalúa **siempre** a `false`.

Resultado: la rama de corrección **jamás disparaba** fuera de los mocks de test, que devolvían `{valid}` (una forma que el tool nunca produce) y enmascaraban el bug. El propio commit de #1332 ya lo había documentado de pasada; este PR lo confirma y lo resuelve.

## Decisión: Opción B (remover el branch muerto)

Descartada la Opción A (re-wirear a la señal real `found === false`): reintroduce el **falso-positivo que #1332 (`guardFabricatedBeneficialBinomial`) prohíbe explícitamente**. `found:false` = "no está en el catálogo (~496 especies)", y Colombia tiene muchísimas especies nativas **reales** fuera del catálogo. "No en catálogo" ≠ "inventado". `applyTaxonomyGuard` valida binomios en **cualquier** contexto (cultivo, árbol de sombra, alimento), así que `found:false`→nota marcaría nativas legítimas — FP imposible de acotar dentro de este guard.

La única versión acotada de A (solo en contexto de organismo benéfico) **ya la cubre #1332**, determinística, con allowlist curada de géneros de biocontrol y sin round-trip de red por binomio. Re-wirear duplicaría esa cobertura reintroduciendo el FP y la dependencia de red. Por eso B: eliminar el código que finge proteger y no protege, con comentario claro de dónde vive la cobertura real.

## Cambios

- **`outputGuards.js`**: eliminar `applyTaxonomyGuard` + helpers exclusivos (`_groundedBinomialsForTaxonomy`, `_extractUngroundedBinomials`). Se conservan los helpers compartidos (`_groundedBinomials`, `_binomial`, `SCI_BINOMIAL_RE`, `_looksLikeLatinBinomial`) usados por otros guards. Comentario que documenta el porqué.
- **`AgentScreen.jsx`**: quitar import y call-site; eliminar `taxonomyModified` (siempre false sin el guard) y simplificar `auto_corrected`.
- **`outputGuards.taxonomy.test.js`**: reemplazar los tests que pasaban contra el mock `{valid}` por un test de regresión que (1) verifica que el guard muerto ya no se exporta y que la cobertura viva (#1332 + 5/5b) sigue exportada, y (2) **fija el contrato REAL** de `validate_taxonomy` (`{found,...}`, nunca `valid`) para que nadie re-introduzca una rama `res.valid` contra un tool que no la produce.

## Cobertura / huecos

**No queda hueco nuevo**: la rama removida nunca protegió nada en producción. La cobertura taxonómica viva tras el cambio:
- `guardFabricatedBeneficialBinomial` (#1332) — caveat suave a binomios de enemigo natural/biocontrol cuyo género no es de biocontrol conocido.
- `guardSpeciesSubstitution` / `guardCompanionBinomial` (5/5b) — corrigen binomios errados del cultivo principal y de companions/antagonists contra el grounding.
- El grounding de `resolve-entities` ancla los binomios en catálogo/AGE antes de generar.

## Verificación

- `npm run build` ✓
- `vitest run src/services/__tests__/` ✓ (127 archivos, 2579 tests, 1 skip)
- `eslint --max-warnings=0` ✓ sobre los 3 archivos tocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)