### PR TITLE
feat(agente): pulido de la portada del agente (12 cambios del operador 2026-06-06)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -738,7 +738,11 @@ export default function App() {
           decisión del operador: lo quería fuera. La entrada por voz sigue
           disponible dentro del agente / compositor; este era solo el FAB
           global. */}
-      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && <AgentFab onNavigate={navigate} />}
+      {/* AgentFab (colibrí flotante "respuesta lista") en TODAS las pantallas
+          MENOS el home/dashboard (operador 2026-06-06): en el home el colibrí
+          ya es el botón de ENVIAR del compositor, así que el FAB flotante ahí
+          duplicaría el ave. Sigue en el resto para anunciar "respuesta lista". */}
+      {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && currentView !== 'voz' && currentView !== 'agente' && currentView !== 'dashboard' && <AgentFab onNavigate={navigate} />}
       {currentView === 'dashboard' && <QuickActionsPanel onNavigate={navigate} />}
       {currentView === 'dashboard' && <PendingTasksWidget onEdit={(task) => navigate('edit_task', { task })} />}
       {currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' && <SyncProgressIndicator />}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench, Sprout, ChevronRight } from 'lucide-react';
+import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench, Sprout, ChevronRight, Bell } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import ThemeSelector from './common/ThemeSelector';
 import AgentAvatarSelector from './Settings/AgentAvatarSelector';
@@ -12,6 +12,7 @@ import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { stop as stopTTS } from '../services/ttsService';
+import { getNotificationStyle, setNotificationStyle } from '../services/userProfileService';
 
 const TTL_OPTIONS = [
   { id: '1d', label: '1 día' },
@@ -101,6 +102,15 @@ export default function ProfileScreen({ onBack, onHome }) {
   useEffect(() => {
     localStorage.setItem('chagra:profile:modo-tecnico:v1', modoTecnico ? '1' : '0');
   }, [modoTecnico]);
+
+  // Estilo de notificación de alertas (operador 2026-06-06): 'demo' (chip
+  // llamativo estilo demo en la portada del agente, POR DEFECTO) o 'actual'
+  // (campanita del TopBar). Persiste en el perfil (userProfileService).
+  const [notifStyle, setNotifStyle] = useState(() => getNotificationStyle());
+  const handleNotifStyle = (style) => {
+    setNotifStyle(style);
+    setNotificationStyle(style);
+  };
 
   useEffect(() => {
     localStorage.setItem('chagra:voice:telemetry:enabled', telemetryEnabled ? '1' : '0');
@@ -293,6 +303,41 @@ export default function ProfileScreen({ onBack, onHome }) {
             <ThemeSelector />
             <BackgroundSelector />
             <AgentAvatarSelector />
+
+            {/* Estilo de notificación de alertas (operador 2026-06-06).
+                'demo' = chip llamativo en la portada del agente (por defecto).
+                'actual' = campanita del encabezado. Persiste en el perfil. */}
+            <div className="space-y-3 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+              <div className="flex items-center gap-2 px-1">
+                <Bell size={18} className="text-emerald-400" />
+                <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Avisos de clima</h3>
+              </div>
+              <p className="text-[11px] text-slate-500 leading-snug px-1">
+                Cómo te muestra Chagra una alerta de clima o helada.
+              </p>
+              <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Estilo de avisos">
+                {[
+                  { id: 'demo', label: 'Aviso destacado', desc: 'Un cartel grande en la portada' },
+                  { id: 'actual', label: 'Campanita', desc: 'Solo el ícono de la campana' },
+                ].map((opt) => (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    role="radio"
+                    aria-checked={notifStyle === opt.id}
+                    onClick={() => handleNotifStyle(opt.id)}
+                    className={`text-left rounded-2xl p-4 border transition-colors min-h-[64px] ${
+                      notifStyle === opt.id
+                        ? 'bg-emerald-900/30 border-emerald-600/60'
+                        : 'bg-slate-800/40 border-slate-700 hover:bg-slate-800/70'
+                    }`}
+                  >
+                    <p className="text-sm font-bold text-white">{opt.label}</p>
+                    <p className="text-[11px] text-slate-400 mt-0.5 leading-snug">{opt.desc}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
         )}
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { CircleUser, ChevronDown, ChevronUp, HelpCircle, LogOut, MapPin } from 'lucide-react';
+import { CircleUser, HelpCircle, LogOut, MapPin } from 'lucide-react';
 import { version as APP_VERSION } from '../../package.json';
-import EnvironmentalCard from './EnvironmentalCard';
 import AltitudeBadge from './AltitudeBadge';
 import OfflineChip from './OfflineChip';
 import ChagraAgentAvatar from './ChagraAgentAvatar';
@@ -46,7 +45,6 @@ import { findMunicipio } from '../utils/colombiaLocations';
  * para destrabar PWA install Safari iOS).
  */
 export default function TopBar({ onNavigate, onLogout }) {
-  const [envOpen, setEnvOpen] = useState(false);
   const [operatorName, setOperatorName] = useState(() =>
     typeof window !== 'undefined'
       ? localStorage.getItem('chagra:operator:name') || 'Mi finca'
@@ -256,22 +254,10 @@ export default function TopBar({ onNavigate, onLogout }) {
         </button>
       </header>
 
-      {/* Toggle de info ambiental (msnm/luna/sol), colapsado por default */}
-      <button
-        type="button"
-        onClick={() => setEnvOpen((v) => !v)}
-        aria-expanded={envOpen}
-        aria-controls="environmental-card"
-        className="w-full px-3 py-1 flex items-center justify-between text-xs text-slate-400 hover:text-slate-200 bg-slate-900/40 border-b border-slate-800/50"
-      >
-        <span className="font-mono">🌙 Ambiente · altitud · efemérides</span>
-        {envOpen ? <ChevronUp size={14} aria-hidden="true" /> : <ChevronDown size={14} aria-hidden="true" />}
-      </button>
-      {envOpen && (
-        <div id="environmental-card">
-          <EnvironmentalCard />
-        </div>
-      )}
+      {/* Letrero "🌙 Ambiente · altitud · efemérides" + EnvironmentalCard
+          colapsable REMOVIDO 2026-06-06 (operador: "no le veo utilidad" en el
+          home del agente). La altitud sigue visible en el chip de ubicación
+          bajo el nombre del operador (arriba) y en la escena del AgentHero. */}
     </>
   );
 }

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -1,13 +1,21 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Mic, Square, Camera, Paperclip, ArrowUp, X } from 'lucide-react';
+import { Mic, Square, Camera, Settings, X } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { captureAndCompress } from '../../services/photoService';
 import { isAnalyzableImageAttachment } from '../../services/agentOutboxAttachment';
 import useAgentOutboxStore from '../../store/useAgentOutboxStore';
+import useAssetStore from '../../store/useAssetStore';
+import useAlertStore from '../../store/useAlertStore';
 import { agentSounds } from '../../services/agentSoundService';
 import { AGENT_HERO_CHIPS } from '../../data/exampleQuestions';
 import { useTheme } from '../../hooks/useTheme';
-import { getProfile, saveProfile } from '../../services/userProfileService';
+import {
+    getProfile,
+    saveProfile,
+    getProfileMunicipio,
+    getNotificationStyle,
+} from '../../services/userProfileService';
+import { buildCropSuggestions } from '../../data/cropSuggestions';
 
 /**
  * AgentHero — la PORTADA INMERSIVA del agente Chagra, PRIMERA PANTALLA COMPLETA
@@ -115,6 +123,41 @@ const THEME_ICON = {
 // `auto` cae al ícono biopunk (su estética base / default de la app).
 function iconForTheme(theme) {
     return THEME_ICON[theme] || THEME_ICON.biopunk;
+}
+
+// ¿Es de noche? (operador 2026-06-06: sol de día, luna de noche en la escena).
+// Noche = antes de las 6am o desde las 7pm. Puro, fácil de testear vía hora.
+function isNightNow(hour) {
+    const h = Number.isInteger(hour)
+        ? hour
+        : (typeof Date !== 'undefined' ? new Date().getHours() : 9);
+    return h < 6 || h >= 19;
+}
+
+// Colibrí 2D del demo (SVG .hummer). Se usa tanto en la escena ambiente (vuela)
+// como DENTRO del botón de enviar (operador 2026-06-06: "el colibrí es enviar").
+// Se factoriza para que ambos usos compartan exactamente el mismo trazo.
+function HummerSvg({ width = 62, height = 46, flap = true }) {
+    return (
+        <svg width={width} height={height} viewBox="0 0 62 46" aria-hidden="true">
+            {/* cuerpo */}
+            <ellipse cx="34" cy="28" rx="11" ry="6.5" fill="#2f7d6b" />
+            <ellipse cx="34" cy="27" rx="9" ry="4.2" fill="#3fa489" />
+            {/* cabeza */}
+            <circle cx="46" cy="24" r="6" fill="#2a6f60" />
+            <circle cx="48.5" cy="22.5" r="1.4" fill="#11332c" />
+            {/* gorguera roja */}
+            <path d="M44 28 q5 2 8 0 q-3 4 -8 3 z" fill="#d05038" />
+            {/* pico largo */}
+            <path d="M52 24 L62 19" stroke="#3a2a18" strokeWidth="2" strokeLinecap="round" />
+            {/* cola */}
+            <path d="M23 28 L8 22 M23 30 L8 32" stroke="#256155" strokeWidth="3" strokeLinecap="round" />
+            {/* ala (animada solo cuando vuela en la escena) */}
+            <g className={flap ? 'wing' : undefined}>
+                <path d="M30 24 C18 6 6 8 2 16 C12 18 22 24 30 30 Z" fill="#4fb89a" opacity=".9" />
+            </g>
+        </svg>
+    );
 }
 
 // Saludos por hora del día. En modo "experto" (nivel detallado) el demo abre
@@ -241,12 +284,48 @@ export default function AgentHero({ onNavigate }) {
 
     const textareaRef = useRef(null);
     const cameraInputRef = useRef(null);
-    const fileInputRef = useRef(null);
 
     // Sistema de temas REAL de la app (data-theme en <html>, persiste en
     // localStorage). Aquí solo LEEMOS el tema para pintar el ícono de la marca
     // y del botón Ⓐ; el switcher completo vive en Perfil → Apariencia.
     const { theme } = useTheme();
+
+    // ── Escena: sol de día / luna de noche (operador 2026-06-06) ──────────────
+    const night = isNightNow();
+
+    // ── Ubicación real del perfil (arriba-der de la escena) ───────────────────
+    // 📍 Vereda, Municipio · altitud — SIN latitud. Sale del perfil de finca.
+    // Si falta municipio, no se muestra (no inventamos ubicación).
+    const profile = getProfile();
+    const municipio = getProfileMunicipio();
+    const vereda = profile?.vereda || null;
+    const altitud = profile?.finca_altitud || profile?.altitud || null;
+    const locationLabel = municipio
+        ? [vereda ? `${vereda}, ${municipio.split(',')[0]}` : municipio.split(',')[0],
+            altitud ? `${altitud} msnm` : null]
+            .filter(Boolean)
+            .join(' · ')
+        : null;
+
+    // ── Sugerencias contextuales ROTATIVAS basadas en los cultivos reales ─────
+    // Deterministas (cropSuggestions: cultivos del store × mes × piso térmico).
+    // NO llaman al LLM (regla dura del home). Si no hay cultivos → [] y caemos al
+    // subtítulo genérico actual.
+    const plants = useAssetStore((s) => s.plants);
+    const cropSuggestions = buildCropSuggestions(plants, { altitud });
+    const [suggestionIdx, setSuggestionIdx] = useState(0);
+
+    // ── Chip de alerta real (clima/helada) ────────────────────────────────────
+    const activeAlerts = useAlertStore((s) => s.activeAlerts);
+    // Prioriza danger > warning; ignora info (poco accionable en el chip).
+    const topAlert =
+        activeAlerts.find((a) => a.severity === 'danger') ||
+        activeAlerts.find((a) => a.severity === 'warning') ||
+        null;
+    // Preferencia de estilo: 'demo' (chip, default) | 'actual' (campanita del
+    // TopBar). En 'actual' NO pintamos el chip aquí (la campanita ya lo cubre).
+    const notifStyle = getNotificationStyle();
+    const showAlertChip = notifStyle === 'demo' && Boolean(topAlert);
 
     const sendToOutbox = useAgentOutboxStore((s) => s.send);
     const {
@@ -265,6 +344,22 @@ export default function AgentHero({ onNavigate }) {
             if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
         };
     }, [attachment]);
+
+    // Rotación de las sugerencias contextuales cada ~5s (operador 2026-06-06:
+    // "rotan para mostrar info distinta"). Solo si hay >1 sugerencia y el
+    // usuario no pidió reduced-motion. Determinístico en su orden (cropSuggestions).
+    useEffect(() => {
+        if (cropSuggestions.length <= 1 || prefersReducedMotion()) return undefined;
+        const id = window.setInterval(() => {
+            setSuggestionIdx((i) => (i + 1) % cropSuggestions.length);
+        }, 5000);
+        return () => window.clearInterval(id);
+    }, [cropSuggestions.length]);
+
+    // Si la lista de cultivos cambia (sync), evita un índice fuera de rango.
+    useEffect(() => {
+        if (suggestionIdx >= cropSuggestions.length) setSuggestionIdx(0);
+    }, [cropSuggestions.length, suggestionIdx]);
 
     // Auto-grow del textarea: crece hasta ~5 líneas, luego scrollea.
     const autoGrow = (el) => {
@@ -490,10 +585,34 @@ export default function AgentHero({ onNavigate }) {
                     animation: agentport-sun-glow 9s ease-in-out infinite;
                     display: none;
                 }
-                [data-theme="nature"] .agentport-sun { display: block; }
+                [data-theme="nature"] .agentport-scene.is-day .agentport-sun { display: block; }
                 @keyframes agentport-sun-glow {
                     0%, 100% { opacity: 0.85; transform: translateX(-50%) scale(1); }
                     50% { opacity: 1; transform: translateX(-50%) scale(1.05); }
+                }
+
+                /* — SOL/LUNA delicados (operador 2026-06-06) — astro pequeño y
+                   sutil, integrado en la escena de CADA tema, según la hora.
+                   Vive arriba en el aire abierto. Día = sol; noche = luna. El sol
+                   radial grande de nature (.agentport-sun) sigue solo en nature
+                   de día; este astro pequeño es universal y delicado. */
+                .agentport-astro {
+                    position: absolute;
+                    top: 11%;
+                    right: 14%;
+                    width: 46px;
+                    height: 46px;
+                    z-index: 1;
+                    opacity: .9;
+                    filter: drop-shadow(0 0 10px rgba(255, 236, 180, .35));
+                    animation: agentport-astro-breathe 8s ease-in-out infinite;
+                }
+                .agentport-astro.is-moon { filter: drop-shadow(0 0 10px rgba(200, 220, 255, .35)); }
+                [data-theme="nature"] .agentport-astro.is-day { display: none; } /* nature ya tiene el sol radial grande de día */
+                .agentport-astro svg { width: 100%; height: 100%; display: block; }
+                @keyframes agentport-astro-breathe {
+                    0%, 100% { opacity: .85; transform: scale(1); }
+                    50% { opacity: 1; transform: scale(1.04); }
                 }
 
                 /* — MONTAÑAS 3 capas (nature) — paths exactos del demo. La
@@ -710,6 +829,65 @@ export default function AgentHero({ onNavigate }) {
                 [data-theme="biopunk"] .agentport-mode button.is-active { color: #04231b; }
                 .agentport:not([data-theme]) .agentport-mode button.is-active { color: #04231b; }
 
+                /* botón de perfil (engranaje) — arriba-derecha, junto al toggle.
+                   Abre la pantalla de Perfil (prefs). Discreto, redondo. */
+                .agentport-profile {
+                    width: 38px; height: 38px; flex: none; border-radius: 50%;
+                    display: inline-flex; align-items: center; justify-content: center;
+                    background: rgb(var(--c-surface-card) / 0.65);
+                    border: 1px solid rgb(var(--c-surface-border));
+                    color: rgb(var(--c-slate-300)); cursor: pointer;
+                    backdrop-filter: blur(6px);
+                    box-shadow: 0 2px 8px -4px rgba(0,0,0,.35);
+                    transition: transform .16s cubic-bezier(.22,.61,.36,1), color .2s ease, border-color .2s ease;
+                }
+                .agentport-profile:hover { color: rgb(var(--c-slate-100)); border-color: rgb(var(--t-accent-rgb) / 0.5); }
+                .agentport-profile:active { transform: scale(.92); }
+                .agentport-headtools { display: flex; align-items: center; gap: 8px; flex: none; }
+
+                /* chip de UBICACIÓN — arriba-derecha de la escena (donde vuela el
+                   colibrí). 📍 Vereda, Municipio · altitud. Delicado, acento suave. */
+                .agentport-loc {
+                    position: absolute; z-index: 2;
+                    top: calc(90px + env(safe-area-inset-top)); right: 14px;
+                    display: inline-flex; align-items: center; gap: 5px; max-width: 64%;
+                    padding: 5px 10px; border-radius: 14px;
+                    background: rgb(var(--c-surface-card) / 0.55);
+                    border: 1px solid rgb(var(--t-accent-rgb) / 0.22);
+                    color: rgb(var(--c-slate-300)); font-size: .72rem; font-weight: 600;
+                    line-height: 1.1; backdrop-filter: blur(6px);
+                    box-shadow: 0 2px 8px -5px rgba(0,0,0,.35);
+                }
+                .agentport-loc .pin { color: rgb(var(--t-accent-rgb)); font-size: .8rem; flex: none; }
+                .agentport-loc .txt { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+                /* chip de ALERTA real (clima/helada) — estilo demo: borde de
+                   acento llamativo, ⚠. Vive bajo el saludo, sobre los chips. */
+                .agentport-alert {
+                    position: relative; z-index: 1; display: flex; align-items: center; gap: 9px;
+                    margin: 0 0 12px; padding: 11px 13px; border-radius: 16px;
+                    background: rgb(var(--c-surface-card));
+                    border: 1.5px solid rgb(var(--t-accent-rgb) / 0.65);
+                    box-shadow: 0 0 0 0 rgb(var(--t-accent-rgb) / 0.45);
+                    animation: agentport-alert-pulse 2.6s cubic-bezier(.22,.61,.36,1) infinite;
+                }
+                .agentport-alert.is-danger {
+                    border-color: rgb(244 63 94 / 0.8);
+                    animation-name: agentport-alert-pulse-danger;
+                }
+                .agentport-alert .ico { font-size: 1.2rem; flex: none; line-height: 1; }
+                .agentport-alert .txt { flex: 1; min-width: 0; }
+                .agentport-alert .at { font-weight: 800; font-size: .9rem; color: rgb(var(--c-slate-100)); }
+                .agentport-alert .am { font-size: .8rem; color: rgb(var(--c-slate-300)); line-height: 1.35; margin-top: 1px; }
+                @keyframes agentport-alert-pulse {
+                    0%, 100% { box-shadow: 0 0 0 0 rgb(var(--t-accent-rgb) / 0); }
+                    50% { box-shadow: 0 0 0 4px rgb(var(--t-accent-rgb) / 0.16); }
+                }
+                @keyframes agentport-alert-pulse-danger {
+                    0%, 100% { box-shadow: 0 0 0 0 rgb(244 63 94 / 0); }
+                    50% { box-shadow: 0 0 0 4px rgb(244 63 94 / 0.18); }
+                }
+
                 /* ===================== ZONA-RESPIRO ===================== */
                 /* Espacio "respiro" donde vive la escena (sol/montañas/grafo/
                    colibrí). Sin avatar 3D: el protagonista es el colibrí 2D. */
@@ -815,15 +993,31 @@ export default function AgentHero({ onNavigate }) {
                     background: rgb(244 63 94) !important; border-color: rgb(244 63 94) !important;
                     color: #fff !important; box-shadow: 0 4px 14px -4px rgb(244 63 94 / 0.5);
                 }
+                /* ENVIAR = el colibrí (operador 2026-06-06). Botón redondo de
+                   acento con el colibrí 2D del demo dentro (.send-hummer). Al
+                   tocar → envía (toda la lógica intacta). */
                 .agentport-send {
-                    width: 42px; height: 42px; flex: none; border: none; border-radius: 50%;
+                    width: 46px; height: 46px; flex: none; border: none; border-radius: 50%;
                     display: flex; align-items: center; justify-content: center; cursor: pointer;
+                    overflow: hidden; padding: 0;
                     transition: transform 0.16s cubic-bezier(0.22, 0.61, 0.36, 1),
                                 box-shadow 0.25s ease, background 0.2s ease;
                 }
                 .agentport-send:not(:disabled) { box-shadow: 0 4px 14px -4px rgb(var(--t-accent-rgb) / 0.7); }
                 .agentport-send:not(:disabled):active { transform: scale(0.86); }
-                .agentport-send:disabled { background: rgb(var(--c-slate-700)); color: rgb(var(--c-slate-500)); cursor: not-allowed; }
+                .agentport-send:disabled { background: rgb(var(--c-slate-700)); cursor: not-allowed; }
+                .agentport-send .send-hummer { width: 30px; height: 22px; display: block; }
+                .agentport-send .send-hummer svg { width: 100%; height: 100%; display: block; }
+                /* En el botón de enviar el colibrí va en CREMA/blanco para
+                   contrastar sobre el acento sólido (teal/ocre/verde), pase lo
+                   que pase con el tema. Recoloreamos las piezas del SVG. */
+                .agentport-send .send-hummer svg ellipse,
+                .agentport-send .send-hummer svg circle:not([r="1.4"]):not([r="1"]) { fill: #fffdf5; }
+                .agentport-send .send-hummer svg path[fill] { fill: #fbf6e7; }
+                .agentport-send .send-hummer svg path[stroke] { stroke: #f3ecd6; }
+                .agentport-send .send-hummer svg circle[r="1.4"] { fill: #1a3a32; } /* ojo */
+                .agentport-send:not(:disabled) .send-hummer svg { filter: drop-shadow(0 1px 2px rgba(0,0,0,.35)); }
+                .agentport-send:disabled .send-hummer { opacity: .55; }
 
                 .agentport-hint { text-align: center; font-size: 0.72rem; margin-top: 9px; color: rgb(var(--c-slate-500)); }
                 .agentport-hint b { color: rgb(var(--t-accent-rgb)); font-weight: 700; }
@@ -919,7 +1113,53 @@ export default function AgentHero({ onNavigate }) {
             `}</style>
 
             {/* ===================== ESCENA AMBIENTE (por tema) ===================== */}
-            <div className="agentport-scene" aria-hidden="true">
+            <div
+                className={['agentport-scene', night ? 'is-night' : 'is-day'].join(' ')}
+                aria-hidden="true"
+            >
+                {/* — SOL/LUNA delicado, universal, según hora (operador 2026-06-06) — */}
+                <div className={['agentport-astro', night ? 'is-moon' : 'is-day'].join(' ')}>
+                    {night ? (
+                        <svg viewBox="0 0 64 64" aria-hidden="true">
+                            {/* luna creciente delicada */}
+                            <defs>
+                                <radialGradient id="ap-moon" cx="42%" cy="38%" r="65%">
+                                    <stop offset="0%" stopColor="#fdfbf2" />
+                                    <stop offset="100%" stopColor="#d9e2f2" />
+                                </radialGradient>
+                            </defs>
+                            <path
+                                d="M44 8 a26 26 0 1 0 12 40 a20 20 0 1 1 -12 -40 z"
+                                fill="url(#ap-moon)"
+                            />
+                            <circle cx="28" cy="24" r="2.2" fill="#cfd8ea" opacity=".7" />
+                            <circle cx="22" cy="38" r="1.6" fill="#cfd8ea" opacity=".55" />
+                            <circle cx="33" cy="42" r="1.3" fill="#cfd8ea" opacity=".5" />
+                        </svg>
+                    ) : (
+                        <svg viewBox="0 0 64 64" aria-hidden="true">
+                            {/* sol delicado con rayos finos */}
+                            <defs>
+                                <radialGradient id="ap-sun" cx="50%" cy="50%" r="50%">
+                                    <stop offset="0%" stopColor="#fff3cf" />
+                                    <stop offset="100%" stopColor="#f5b733" />
+                                </radialGradient>
+                            </defs>
+                            <g stroke="#f5b733" strokeWidth="2.4" strokeLinecap="round" opacity=".85">
+                                <line x1="32" y1="4" x2="32" y2="13" />
+                                <line x1="32" y1="51" x2="32" y2="60" />
+                                <line x1="4" y1="32" x2="13" y2="32" />
+                                <line x1="51" y1="32" x2="60" y2="32" />
+                                <line x1="12" y1="12" x2="18" y2="18" />
+                                <line x1="46" y1="46" x2="52" y2="52" />
+                                <line x1="52" y1="12" x2="46" y2="18" />
+                                <line x1="18" y1="46" x2="12" y2="52" />
+                            </g>
+                            <circle cx="32" cy="32" r="13" fill="url(#ap-sun)" />
+                        </svg>
+                    )}
+                </div>
+
                 {/* — NATURE: sol + montañas 3 capas + polen — */}
                 <div className="agentport-sun" />
                 <div className="agentport-mtn">
@@ -1001,28 +1241,14 @@ export default function AgentHero({ onNavigate }) {
 
                 {/* — COLIBRÍ 2D — vuela en los 3 temas (SVG del demo nature) — */}
                 <div className="agentport-hummer">
-                    <svg width="62" height="46" viewBox="0 0 62 46">
-                        {/* cuerpo */}
-                        <ellipse cx="34" cy="28" rx="11" ry="6.5" fill="#2f7d6b" />
-                        <ellipse cx="34" cy="27" rx="9" ry="4.2" fill="#3fa489" />
-                        {/* cabeza */}
-                        <circle cx="46" cy="24" r="6" fill="#2a6f60" />
-                        <circle cx="48.5" cy="22.5" r="1.4" fill="#11332c" />
-                        {/* gorguera roja */}
-                        <path d="M44 28 q5 2 8 0 q-3 4 -8 3 z" fill="#d05038" />
-                        {/* pico largo */}
-                        <path d="M52 24 L62 19" stroke="#3a2a18" strokeWidth="2" strokeLinecap="round" />
-                        {/* cola */}
-                        <path d="M23 28 L8 22 M23 30 L8 32" stroke="#256155" strokeWidth="3" strokeLinecap="round" />
-                        {/* ala (animada) */}
-                        <g className="wing">
-                            <path d="M30 24 C18 6 6 8 2 16 C12 18 22 24 30 30 Z" fill="#4fb89a" opacity=".9" />
-                        </g>
-                    </svg>
+                    <HummerSvg />
                 </div>
             </div>
 
             {/* ===================== MARCA + TOGGLE Campesino/Experto ===================== */}
+            {/* Operador 2026-06-06: arriba-izq = MARCA (ícono del tema + wordmark
+                "Chagra · tu mano en el campo"), NO el colibrí-video. El colibrí
+                sigue volando en la escena de fondo, y ES el botón de enviar. */}
             <header className="agentport-topbar">
                 <div className="agentport-brand">
                     <span className="agentport-mark">{iconForTheme(theme)}</span>
@@ -1031,33 +1257,50 @@ export default function AgentHero({ onNavigate }) {
                     </div>
                 </div>
 
-                <div className="agentport-mode" role="tablist" aria-label="Nivel de respuestas">
+                <div className="agentport-headtools">
+                    <div className="agentport-mode" role="tablist" aria-label="Nivel de respuestas">
+                        <button
+                            type="button"
+                            role="tab"
+                            aria-selected={!expertoActive}
+                            onClick={() => setNivelRespuestas('simple')}
+                            className={!expertoActive ? 'is-active' : ''}
+                        >
+                            🌾 Campesino
+                        </button>
+                        <button
+                            type="button"
+                            role="tab"
+                            aria-selected={expertoActive}
+                            onClick={() => setNivelRespuestas('detallado')}
+                            className={expertoActive ? 'is-active' : ''}
+                        >
+                            🔬 Experto
+                        </button>
+                    </div>
+
+                    {/* Botón de perfil (engranaje) → pantalla de Perfil (prefs). */}
                     <button
                         type="button"
-                        role="tab"
-                        aria-selected={!expertoActive}
-                        onClick={() => setNivelRespuestas('simple')}
-                        className={!expertoActive ? 'is-active' : ''}
+                        className="agentport-profile"
+                        aria-label="Perfil"
+                        title="Perfil y preferencias"
+                        onClick={() => onNavigate?.('perfil')}
                     >
-                        🌾 Campesino
-                    </button>
-                    <button
-                        type="button"
-                        role="tab"
-                        aria-selected={expertoActive}
-                        onClick={() => setNivelRespuestas('detallado')}
-                        className={expertoActive ? 'is-active' : ''}
-                    >
-                        🔬 Experto
+                        <Settings size={18} aria-hidden="true" />
                     </button>
                 </div>
             </header>
 
-            {/* TODO ubicación: a=bajo marca, b=pill bajo saludo, c=TopBar — espera
-                decisión operador (a/b/c). El dato sale del perfil de finca:
-                getProfileMunicipio() (municipio/region DANE) + profile.vereda +
-                profile.finca_altitud (msnm). El TopBar ya muestra municipio/vereda
-                bajo el nombre del operador; aquí queda el placeholder limpio. */}
+            {/* UBICACIÓN — arriba-derecha de la escena (donde vuela el colibrí).
+                📍 Vereda, Municipio · altitud, SIN latitud, del perfil real. Si
+                falta el municipio no se muestra (no inventamos ubicación). */}
+            {locationLabel && (
+                <div className="agentport-loc" aria-label={`Ubicación: ${locationLabel}`}>
+                    <span className="pin" aria-hidden="true">📍</span>
+                    <span className="txt">{locationLabel}</span>
+                </div>
+            )}
 
             {/* ===================== ZONA-RESPIRO (escena vive detrás) ===================== */}
             <div className="agentport-stage" aria-hidden="true" />
@@ -1067,10 +1310,42 @@ export default function AgentHero({ onNavigate }) {
                 <h2 className="agentport-hi">
                     {greetingForNow(nivel)}<br />Soy <span className="chagra-wordmark">Chagra</span>.
                 </h2>
-                <p className="agentport-sub">
-                    {expertoActive ? SUB_EXPERTO : SUB_CAMPESINO}
-                </p>
+                {/* Sugerencia contextual ROTATIVA bajo "Soy Chagra": si el usuario
+                    tiene cultivos registrados, mostramos un consejo agronómico
+                    determinístico (cultivo × mes × piso térmico) que rota cada 5s.
+                    Si no tiene cultivos, cae al subtítulo genérico de siempre. */}
+                {cropSuggestions.length > 0 ? (
+                    <p
+                        className="agentport-sub"
+                        key={suggestionIdx}
+                        aria-live="polite"
+                        data-testid="agentport-suggestion"
+                    >
+                        {cropSuggestions[suggestionIdx % cropSuggestions.length]}
+                    </p>
+                ) : (
+                    <p className="agentport-sub">
+                        {expertoActive ? SUB_EXPERTO : SUB_CAMPESINO}
+                    </p>
+                )}
             </div>
+
+            {/* CHIP DE ALERTA real (clima/helada). Solo si el estilo de
+                notificación es 'demo' (default) y hay una alerta activa. En
+                'actual' la campanita del TopBar la cubre. */}
+            {showAlertChip && (
+                <div
+                    className={['agentport-alert', topAlert.severity === 'danger' ? 'is-danger' : ''].join(' ')}
+                    role="status"
+                    data-testid="agentport-alert"
+                >
+                    <span className="ico" aria-hidden="true">⚠️</span>
+                    <span className="txt">
+                        <span className="at">{topAlert.title}</span>
+                        {topAlert.message && <span className="am">{topAlert.message}</span>}
+                    </span>
+                </div>
+            )}
 
             {/* ===================== CHIPS ===================== */}
             <div className="agentport-chiprow">
@@ -1108,7 +1383,7 @@ export default function AgentHero({ onNavigate }) {
                                 />
                             ) : (
                                 <div className="w-14 h-14 rounded-xl bg-[rgb(var(--c-surface-card))] border border-[rgb(var(--c-surface-border))] flex items-center justify-center">
-                                    <Paperclip size={20} className="text-[rgb(var(--c-slate-400))]" aria-hidden="true" />
+                                    <Camera size={20} className="text-[rgb(var(--c-slate-400))]" aria-hidden="true" />
                                 </div>
                             )}
                             <span className="flex-1 text-xs text-[rgb(var(--c-slate-300))] truncate">
@@ -1169,7 +1444,10 @@ export default function AgentHero({ onNavigate }) {
                             <span className="agentport-tool-ico" aria-hidden="true">{iconForTheme(theme)}</span>
                         </button>
 
-                        {/* Cámara / foto */}
+                        {/* Cámara / foto — toma una foto O elige de la galería.
+                            B2: solo imágenes (el agente solo "ve" fotos). El botón
+                            de adjuntar (clip) se quitó (operador 2026-06-06): la
+                            cámara ya cubre tomar foto y galería. */}
                         <button
                             type="button"
                             onClick={() => cameraInputRef.current?.click()}
@@ -1178,16 +1456,6 @@ export default function AgentHero({ onNavigate }) {
                             className="agentport-iconbtn !w-10 !h-10"
                         >
                             <Camera size={19} aria-hidden="true" />
-                        </button>
-                        {/* Adjuntar foto — B2: solo imágenes (el agente solo ve fotos) */}
-                        <button
-                            type="button"
-                            onClick={() => fileInputRef.current?.click()}
-                            disabled={busy || isRecording}
-                            aria-label="Adjuntar una foto"
-                            className="agentport-iconbtn !w-10 !h-10"
-                        >
-                            <Paperclip size={18} aria-hidden="true" />
                         </button>
 
                         <div className="flex-1" />
@@ -1204,29 +1472,28 @@ export default function AgentHero({ onNavigate }) {
                             {isRecording ? <Square size={16} strokeWidth={2.5} aria-hidden="true" /> : <Mic size={18} strokeWidth={2.5} aria-hidden="true" />}
                         </button>
 
-                        {/* Enviar — botón redondo de acento (el .send del demo) */}
+                        {/* ENVIAR = el colibrí (operador 2026-06-06). Botón redondo
+                            de acento con el colibrí 2D del demo dentro. Toda la
+                            lógica de envío intacta (handleSendText → outbox →
+                            navegar, SEND_TRANSITION_MS, disabled/sending). */}
                         <button
                             type="button"
                             onClick={handleSendText}
                             disabled={!canSend}
-                            aria-label="Enviar al agente"
+                            aria-label="Enviar"
                             className={['agentport-send', canSend ? 'agent-send-accent' : ''].join(' ')}
                         >
-                            <ArrowUp size={18} strokeWidth={2.75} aria-hidden="true" />
+                            <span className="send-hummer" aria-hidden="true">
+                                <HummerSvg flap={false} />
+                            </span>
                         </button>
                     </div>
 
-                    {/* Inputs ocultos — AMBOS solo imágenes (B2). */}
+                    {/* Input oculto de foto — solo imágenes (B2). SIN `capture`:
+                        permite tomar foto O elegir de la galería (operador
+                        2026-06-06). */}
                     <input
                         ref={cameraInputRef}
-                        type="file"
-                        accept="image/*"
-                        capture="environment"
-                        className="hidden"
-                        onChange={handlePhotoPick}
-                    />
-                    <input
-                        ref={fileInputRef}
                         type="file"
                         accept="image/*"
                         className="hidden"

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -113,7 +113,7 @@ describe('AgentHero — compositor real (no teaser)', () => {
 
   test('botón enviar deshabilitado sin texto ni adjunto', () => {
     render(<AgentHero onNavigate={vi.fn()} />);
-    expect(screen.getByLabelText('Enviar al agente')).toBeDisabled();
+    expect(screen.getByLabelText('Enviar')).toBeDisabled();
   });
 
   test('chip de sugerencia envía su prompt como texto', async () => {
@@ -151,15 +151,15 @@ describe('AgentHero — compositor real (no teaser)', () => {
     const onNavigate = vi.fn();
     const { container } = render(<AgentHero onNavigate={onNavigate} />);
     const file = new File(['img'], 'planta.jpg', { type: 'image/jpeg' });
-    const cameraInput = container.querySelector('input[capture]');
+    const photoInput = container.querySelector('input[type="file"]');
     await act(async () => {
-      fireEvent.change(cameraInput, { target: { files: [file] } });
+      fireEvent.change(photoInput, { target: { files: [file] } });
     });
     // Aparece el preview de "foto lista".
     await screen.findByText('Foto lista para enviar');
     // Enviar (ya habilitado por el adjunto).
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Enviar al agente'));
+      fireEvent.click(screen.getByLabelText('Enviar'));
     });
     await waitFor(() => {
       expect(sendMock).toHaveBeenCalledWith(
@@ -175,7 +175,7 @@ describe('AgentHero — compositor real (no teaser)', () => {
     const ta = screen.getByLabelText('Escribe tu pregunta al agente');
     fireEvent.change(ta, { target: { value: 'no me pierdas' } });
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Enviar al agente'));
+      fireEvent.click(screen.getByLabelText('Enviar'));
     });
     await waitFor(() => expect(sendMock).toHaveBeenCalled());
     expect(onNavigate).not.toHaveBeenCalled();
@@ -261,34 +261,36 @@ describe('AgentHero — transición de envío premium (bug 2026-05-31)', () => {
   });
 });
 
-describe('AgentHero — adjuntar SOLO fotos (B2, 2026-06-02)', () => {
-  test('el input de adjuntar acepta solo imágenes (accept="image/*")', () => {
+describe('AgentHero — foto: cámara O galería, solo imágenes (B2, 2026-06-06)', () => {
+  test('el input de foto acepta solo imágenes (accept="image/*")', () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
-    // Dos inputs de archivo: cámara (con capture) y adjuntar (sin capture).
-    // Ambos deben restringir a imágenes — el agente solo "ve" fotos vía visión.
+    // Operador 2026-06-06: un solo input de foto (se quitó el botón de adjuntar
+    // clip). Sigue restringido a imágenes — el agente solo "ve" fotos vía visión.
     const inputs = Array.from(container.querySelectorAll('input[type="file"]'));
-    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    expect(inputs.length).toBeGreaterThanOrEqual(1);
     for (const input of inputs) {
       expect(input.getAttribute('accept')).toBe('image/*');
     }
   });
 
-  test('el input de cámara conserva capture="environment" (foto en vivo)', () => {
+  test('el input de foto NO fuerza la cámara (sin capture) → permite galería', () => {
+    // Operador 2026-06-06: se quitó capture="environment" para que el usuario
+    // pueda TOMAR foto O ELEGIR de la galería (antes forzaba la cámara).
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
-    const cameraInput = container.querySelector('input[capture]');
-    expect(cameraInput).toBeTruthy();
-    expect(cameraInput.getAttribute('accept')).toBe('image/*');
-    expect(cameraInput.getAttribute('capture')).toBe('environment');
+    const photoInput = container.querySelector('input[type="file"]');
+    expect(photoInput).toBeTruthy();
+    expect(photoInput.getAttribute('accept')).toBe('image/*');
+    expect(photoInput.hasAttribute('capture')).toBe(false);
   });
 
   test('si se cuela un no-imagen (PDF): NO lo deja en staging y avisa claro', async () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
     const file = new File(['%PDF-1.4'], 'hoja-de-vida.pdf', { type: 'application/pdf' });
-    // Usamos el input de adjuntar (sin capture). Aunque tenga accept="image/*",
-    // algunos OS dejan elegir cualquier archivo → el guard de pick lo rechaza.
-    const attachInput = container.querySelector('input[type="file"]:not([capture])');
+    // Aunque el input tenga accept="image/*", algunos OS dejan elegir cualquier
+    // archivo desde la galería → el guard de pick lo rechaza.
+    const photoInput = container.querySelector('input[type="file"]');
     await act(async () => {
-      fireEvent.change(attachInput, { target: { files: [file] } });
+      fireEvent.change(photoInput, { target: { files: [file] } });
     });
     // No se crea preview de adjunto.
     expect(screen.queryByText('Foto lista para enviar')).toBeNull();
@@ -297,15 +299,15 @@ describe('AgentHero — adjuntar SOLO fotos (B2, 2026-06-02)', () => {
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/solo puedo ver fotos|solo.*fotos/i);
     // El botón enviar sigue deshabilitado (no hay adjunto válido ni texto).
-    expect(screen.getByLabelText('Enviar al agente')).toBeDisabled();
+    expect(screen.getByLabelText('Enviar')).toBeDisabled();
   });
 
   test('el aviso de no-imagen no usa voseo argentino', async () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
     const file = new File(['x'], 'audio.mp3', { type: 'audio/mpeg' });
-    const attachInput = container.querySelector('input[type="file"]:not([capture])');
+    const photoInput = container.querySelector('input[type="file"]');
     await act(async () => {
-      fireEvent.change(attachInput, { target: { files: [file] } });
+      fireEvent.change(photoInput, { target: { files: [file] } });
     });
     const alert = await screen.findByRole('alert');
     const t = alert.textContent || '';
@@ -315,12 +317,30 @@ describe('AgentHero — adjuntar SOLO fotos (B2, 2026-06-02)', () => {
   test('una imagen válida sí queda en staging (el guard no bloquea fotos)', async () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
     const file = new File(['img'], 'planta.jpg', { type: 'image/jpeg' });
-    const attachInput = container.querySelector('input[type="file"]:not([capture])');
+    const photoInput = container.querySelector('input[type="file"]');
     await act(async () => {
-      fireEvent.change(attachInput, { target: { files: [file] } });
+      fireEvent.change(photoInput, { target: { files: [file] } });
     });
     await screen.findByText('Foto lista para enviar');
     expect(screen.queryByRole('alert')).toBeNull();
+  });
+});
+
+describe('AgentHero — colibrí = enviar + botón de perfil (operador 2026-06-06)', () => {
+  test('el botón de enviar lleva el colibrí 2D dentro (no la flecha)', () => {
+    const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+    const sendBtn = screen.getByLabelText('Enviar');
+    // El colibrí va dentro del botón (.send-hummer con su SVG).
+    expect(sendBtn.querySelector('.send-hummer svg')).toBeTruthy();
+    // Ya no hay un input que fuerce cámara.
+    expect(container.querySelector('input[capture]')).toBeNull();
+  });
+
+  test('el botón de perfil navega a la pantalla de Perfil', () => {
+    const onNavigate = vi.fn();
+    render(<AgentHero onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByLabelText('Perfil'));
+    expect(onNavigate).toHaveBeenCalledWith('perfil');
   });
 });
 

--- a/src/data/__tests__/cropSuggestions.test.js
+++ b/src/data/__tests__/cropSuggestions.test.js
@@ -1,0 +1,91 @@
+/**
+ * cropSuggestions.test.js — el generador determinístico de sugerencias
+ * agronómicas contextuales del home (AgentHero).
+ *
+ * Cubre: piso térmico por altitud, matching de cultivo por nombre real de
+ * planta (con tildes y sufijo "#003"), estacionalidad por mes, determinismo,
+ * dedupe por cultivo, fallback vacío sin cultivos, y ausencia de voseo.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  buildCropSuggestions,
+  pisoTermicoFromAltitud,
+  normalizeCropName,
+} from '../cropSuggestions';
+
+describe('pisoTermicoFromAltitud', () => {
+  test('clasifica los pisos térmicos colombianos por msnm', () => {
+    expect(pisoTermicoFromAltitud(450)).toBe('calido');
+    expect(pisoTermicoFromAltitud(1730)).toBe('templado');
+    expect(pisoTermicoFromAltitud(2600)).toBe('frio');
+    expect(pisoTermicoFromAltitud(3400)).toBe('paramo');
+  });
+  test('devuelve null para altitud inválida o ausente', () => {
+    expect(pisoTermicoFromAltitud(null)).toBeNull();
+    expect(pisoTermicoFromAltitud(undefined)).toBeNull();
+    expect(pisoTermicoFromAltitud('—')).toBeNull();
+    expect(pisoTermicoFromAltitud(0)).toBeNull();
+  });
+});
+
+describe('normalizeCropName', () => {
+  test('quita tildes, baja a minúscula y descarta el sufijo "#003"', () => {
+    expect(normalizeCropName('Café')).toBe('cafe');
+    expect(normalizeCropName('Gulupa #003')).toBe('gulupa');
+    expect(normalizeCropName('  Aguacate Hass ')).toBe('aguacate hass');
+  });
+});
+
+describe('buildCropSuggestions', () => {
+  const plants = (names) => names.map((n) => ({ attributes: { name: n } }));
+
+  test('sin cultivos → lista vacía (el llamador cae al tip genérico)', () => {
+    expect(buildCropSuggestions([])).toEqual([]);
+    expect(buildCropSuggestions(null)).toEqual([]);
+  });
+
+  test('sin match en el catálogo → no inventa sugerencia', () => {
+    expect(buildCropSuggestions(plants(['Planta Mock #1', 'Helecho raro']))).toEqual([]);
+  });
+
+  test('aguacate en febrero sugiere biol para fructificación', () => {
+    const out = buildCropSuggestions(plants(['Aguacate Hass']), { month: 2 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatch(/biol/i);
+    expect(out[0]).toMatch(/aguacates/i);
+  });
+
+  test('café en enero sugiere poda; el copy cambia con la estación', () => {
+    expect(buildCropSuggestions(plants(['Café']), { month: 1 })[0]).toMatch(/podar tu café/i);
+    expect(buildCropSuggestions(plants(['Café']), { month: 10 })[0]).toMatch(/cosecha/i);
+  });
+
+  test('dedup por cultivo: 3 aguacates → 1 sola sugerencia', () => {
+    const out = buildCropSuggestions(plants(['Aguacate #1', 'Aguacate #2', 'Aguacate #3']), { month: 2 });
+    expect(out).toHaveLength(1);
+  });
+
+  test('varios cultivos → varias sugerencias en orden de aparición', () => {
+    const out = buildCropSuggestions(plants(['Café', 'Tomate Chonto', 'Mora']), { month: 3 });
+    expect(out.length).toBe(3);
+    expect(out[0]).toMatch(/café/i);
+    expect(out[1]).toMatch(/tomates/i);
+    expect(out[2]).toMatch(/mora/i);
+  });
+
+  test('determinístico: misma entrada ⇒ misma salida', () => {
+    const p = plants(['Tomate', 'Aguacate']);
+    expect(buildCropSuggestions(p, { month: 4 })).toEqual(buildCropSuggestions(p, { month: 4 }));
+  });
+
+  test('respeta el tope `max`', () => {
+    const p = plants(['Café', 'Tomate', 'Mora', 'Lulo', 'Papa', 'Cacao']);
+    expect(buildCropSuggestions(p, { month: 6, max: 3 })).toHaveLength(3);
+  });
+
+  test('ninguna sugerencia usa voseo argentino', () => {
+    const p = plants(['Café', 'Tomate', 'Aguacate', 'Mora', 'Plátano', 'Maíz', 'Papa', 'Lulo', 'Fresa', 'Cebolla']);
+    const all = buildCropSuggestions(p, { month: 5, max: 99 }).join(' ');
+    expect(all).not.toMatch(/mandá|contame|elegí|tenés|podés|querés|enviá|mostrá|preguntá|revisá|aplicá/i);
+  });
+});

--- a/src/data/cropSuggestions.js
+++ b/src/data/cropSuggestions.js
@@ -1,0 +1,286 @@
+/**
+ * cropSuggestions.js — generador DETERMINÍSTICO de sugerencias agronómicas
+ * contextuales para la portada del agente (AgentHero).
+ *
+ * Reemplaza el array de TIPS genérico por sugerencias que se basan en los
+ * CULTIVOS REALES del usuario (las plantas registradas en su finca, vía
+ * `useAssetStore().plants`) cruzadas con el MES del año y el PISO TÉRMICO
+ * (derivado de la altitud del perfil). Rotan en el home cada ~5s.
+ *
+ * REGLA DURA (operador 2026-06-06): NADA de LLM en el home. La portada debe
+ * pintar al instante y offline-first. Por eso esto es 100% reglas/plantillas
+ * puras (sin red, sin IndexedDB pesado, sin async). Si el usuario no tiene
+ * cultivos registrados, el llamador cae al tip genérico actual.
+ *
+ * Cada cultivo conocido declara reglas estacionales. La regla matchea por:
+ *   - keyword normalizado del nombre de la planta (attributes.name) — el mismo
+ *     normalizado de biodiversityStats (lowercase, sin tildes, sin "#001").
+ *   - meses aplicables (1–12). Si la regla no declara meses, aplica todo el año.
+ * El piso térmico (calido/templado/frio/paramo) se usa para afinar el copy
+ * cuando aplica, pero NO es requisito de match (un aguacate sirve consejo
+ * aunque no sepamos su altitud).
+ *
+ * Español colombiano (tú/usted). SIN voseo argentino — validado por el test.
+ *
+ * @module data/cropSuggestions
+ */
+
+/**
+ * Normaliza un nombre de planta para matching contra las keywords de cultivo.
+ * Igual criterio que biodiversityStats.normalizeForMatch: lowercase, sin
+ * tildes, sin sufijo "#003" de siembras bulk-individual.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+export function normalizeCropName(s) {
+  if (!s || typeof s !== 'string') return '';
+  return s
+    .replace(/\s+#\d+$/, '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .trim();
+}
+
+/**
+ * Deriva el piso térmico colombiano a partir de la altitud (msnm).
+ * Cálido <1000 · templado 1000–2000 · frío 2000–3000 · páramo >3000.
+ *
+ * @param {number|string|null|undefined} altitud
+ * @returns {'calido'|'templado'|'frio'|'paramo'|null}
+ */
+export function pisoTermicoFromAltitud(altitud) {
+  const n = Number(altitud);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  if (n < 1000) return 'calido';
+  if (n < 2000) return 'templado';
+  if (n < 3000) return 'frio';
+  return 'paramo';
+}
+
+/**
+ * Catálogo de reglas por cultivo. Cada entrada:
+ *   - keys:   keywords normalizadas que matchean el nombre de la planta.
+ *   - label:  nombre legible del cultivo (para el copy, en plural cuando aplica).
+ *   - rules:  [{ months?: number[], piso?: string[], text: (label)=>string }]
+ *             La primera regla que matchea mes (+ piso si lo declara) gana; si
+ *             ninguna declara meses, se usa como consejo de fondo todo el año.
+ *
+ * Los textos son consejos agronómicos seguros y genéricos (poda, abono, biol,
+ * cosecha, prevención) — NO dosis químicas ni recetas peligrosas (los guards
+ * del chat real cubren ese terreno; aquí solo invitamos a preguntar).
+ */
+const CROP_RULES = [
+  {
+    keys: ['aguacate', 'palta'],
+    label: 'aguacates',
+    rules: [
+      { months: [2, 3, 4, 8, 9, 10], text: (l) => `Te sugiero aplicar biol para mejorar la fructificación de tus ${l}.` },
+      { months: [5, 6, 7], text: (l) => `Es buena época para revisar el drenaje de tus ${l} y prevenir la pudrición de raíz.` },
+      { text: (l) => `Pregúntame cómo nutrir y proteger tus ${l} este mes.` },
+    ],
+  },
+  {
+    keys: ['cafe', 'cafeto'],
+    label: 'café',
+    rules: [
+      { months: [1, 2, 3], text: () => `Es buena época para podar tu café y renovar los tejidos productivos.` },
+      { months: [9, 10, 11, 12], text: () => `Tu café puede estar en cosecha: pregúntame cómo manejar el beneficio y el secado.` },
+      { text: () => `Pregúntame cómo abonar tu café según tu piso térmico.` },
+    ],
+  },
+  {
+    keys: ['tomate'],
+    label: 'tomates',
+    rules: [
+      { months: [3, 4, 5, 9, 10], text: (l) => `Buena época para tutorar y deschuponar tus ${l} y mejorar el cuajado.` },
+      { text: (l) => `Pregúntame un biopreparado para fortalecer tus ${l} contra hongos.` },
+    ],
+  },
+  {
+    keys: ['mora'],
+    label: 'mora',
+    rules: [
+      { months: [1, 2, 6, 7], text: () => `Es buena época para podar tu mora y renovar las cañas que ya produjeron.` },
+      { text: () => `Pregúntame cómo abonar tu mora para una cosecha más pareja.` },
+    ],
+  },
+  {
+    keys: ['platano', 'banano', 'guineo'],
+    label: 'plátano',
+    rules: [
+      { text: () => `Te sugiero deshojar y desguascar tu plátano para prevenir la sigatoka.` },
+    ],
+  },
+  {
+    keys: ['maiz'],
+    label: 'maíz',
+    rules: [
+      { months: [3, 4, 9, 10], text: () => `Buena época de siembra de maíz: pregúntame la distancia y el abono de fondo.` },
+      { text: () => `Pregúntame cómo asociar tu maíz con fríjol y calabaza (milpa).` },
+    ],
+  },
+  {
+    keys: ['frijol', 'frisol', 'habichuela'],
+    label: 'fríjol',
+    rules: [
+      { text: () => `Pregúntame cómo aprovechar tu fríjol para fijar nitrógeno y mejorar el suelo.` },
+    ],
+  },
+  {
+    keys: ['papa'],
+    label: 'papa',
+    rules: [
+      { months: [4, 5, 6], text: () => `Buena época para aporcar tu papa y prevenir la gota (tizón).` },
+      { text: () => `Pregúntame cómo prevenir la gota en tu papa de forma agroecológica.` },
+    ],
+  },
+  {
+    keys: ['cacao'],
+    label: 'cacao',
+    rules: [
+      { text: () => `Te sugiero hacer poda de mantenimiento y manejo de sombra en tu cacao.` },
+    ],
+  },
+  {
+    keys: ['lulo', 'naranjilla'],
+    label: 'lulo',
+    rules: [
+      { text: () => `Pregúntame un biopreparado para fortalecer tu lulo contra la antracnosis.` },
+    ],
+  },
+  {
+    keys: ['cebolla'],
+    label: 'cebolla',
+    rules: [
+      { text: () => `Pregúntame el riego y el abono justo para que tu cebolla engruese bien.` },
+    ],
+  },
+  {
+    keys: ['lechuga'],
+    label: 'lechugas',
+    rules: [
+      { text: (l) => `Tus ${l} agradecen riego parejo y sombra al medio día: pregúntame cómo.` },
+    ],
+  },
+  {
+    keys: ['cilantro', 'culantro'],
+    label: 'cilantro',
+    rules: [
+      { text: () => `Pregúntame cómo escalonar siembras de cilantro para tener cosecha continua.` },
+    ],
+  },
+  {
+    keys: ['gulupa', 'maracuya', 'curuba'],
+    label: 'pasifloras',
+    rules: [
+      { text: (l) => `Te sugiero revisar el tutorado y la polinización de tus ${l}.` },
+    ],
+  },
+  {
+    keys: ['fresa', 'frutilla'],
+    label: 'fresas',
+    rules: [
+      { text: (l) => `Pregúntame cómo poner mulch a tus ${l} para fruta más limpia y sana.` },
+    ],
+  },
+  {
+    keys: ['citrico', 'naranja', 'limon', 'mandarina'],
+    label: 'cítricos',
+    rules: [
+      { text: (l) => `Te sugiero abonar y revisar minador en tus ${l}: pregúntame el manejo.` },
+    ],
+  },
+];
+
+// Índice keyword → regla (O(1) por keyword). Construido una vez al cargar.
+const CROP_INDEX = (() => {
+  const idx = new Map();
+  for (const entry of CROP_RULES) {
+    for (const k of entry.keys) {
+      if (!idx.has(k)) idx.set(k, entry);
+    }
+  }
+  return idx;
+})();
+
+/**
+ * Resuelve la entrada de cultivo (si existe) para un nombre de planta.
+ * Hace match por contención de keyword: "Aguacate Hass" → aguacate.
+ *
+ * @param {string} plantName
+ * @returns {object|null}
+ */
+function matchCropEntry(plantName) {
+  const norm = normalizeCropName(plantName);
+  if (!norm) return null;
+  // Match exacto primero (rápido), luego por contención de palabra.
+  if (CROP_INDEX.has(norm)) return CROP_INDEX.get(norm);
+  for (const [key, entry] of CROP_INDEX) {
+    // \b-ish: la keyword aparece como palabra dentro del nombre.
+    if (norm === key || norm.startsWith(`${key} `) || norm.includes(` ${key}`) || norm.includes(`${key} `) || norm.includes(key)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+/**
+ * Elige el texto de la regla aplicable a una entrada según mes + piso térmico.
+ *
+ * @param {object} entry - entrada de CROP_RULES
+ * @param {number} month - 1–12
+ * @param {string|null} piso
+ * @returns {string}
+ */
+function pickRuleText(entry, month, piso) {
+  // 1) regla que matchea mes (+ piso si lo declara)
+  for (const r of entry.rules) {
+    if (Array.isArray(r.months) && !r.months.includes(month)) continue;
+    if (Array.isArray(r.piso) && piso && !r.piso.includes(piso)) continue;
+    if (Array.isArray(r.months)) return r.text(entry.label);
+  }
+  // 2) regla de fondo (sin meses) — la última suele serlo
+  const fallback = entry.rules.find((r) => !Array.isArray(r.months));
+  return (fallback || entry.rules[entry.rules.length - 1]).text(entry.label);
+}
+
+/**
+ * Construye la lista ROTATIVA de sugerencias contextuales a partir de las
+ * plantas reales del usuario. Determinístico: mismas plantas + mismo mes ⇒
+ * misma lista en el mismo orden.
+ *
+ * @param {Array<{attributes?: {name?: string}, name?: string}>} plants
+ * @param {object} [opts]
+ * @param {number} [opts.month] - mes 1–12 (default: mes actual)
+ * @param {number|string|null} [opts.altitud] - msnm para el piso térmico
+ * @param {number} [opts.max] - máximo de sugerencias (default 5)
+ * @returns {string[]} textos de sugerencia, sin duplicados, en orden estable
+ */
+export function buildCropSuggestions(plants, opts = {}) {
+  const month = Number.isInteger(opts.month) ? opts.month : new Date().getMonth() + 1;
+  const piso = pisoTermicoFromAltitud(opts.altitud);
+  const max = Number.isInteger(opts.max) ? opts.max : 5;
+
+  if (!Array.isArray(plants) || plants.length === 0) return [];
+
+  // Recolecta entradas de cultivo únicas, en orden de aparición de las plantas
+  // (estable). Varias plantas del mismo cultivo ⇒ una sola sugerencia.
+  const seen = new Set();
+  const suggestions = [];
+  for (const p of plants) {
+    const name = p?.attributes?.name || p?.name || '';
+    const entry = matchCropEntry(name);
+    if (!entry) continue;
+    const key = entry.label;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const text = pickRuleText(entry, month, piso);
+    if (text) suggestions.push(text);
+    if (suggestions.length >= max) break;
+  }
+  return suggestions;
+}
+
+export const __CROP_RULES__ = CROP_RULES;

--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -10,6 +10,9 @@ import {
   hasSeenProfileOnboarding,
   buildUserProfileBlock,
   resolveAltitudToSave,
+  getNotificationStyle,
+  setNotificationStyle,
+  DEFAULT_NOTIFICATION_STYLE,
 } from '../userProfileService.js';
 
 describe('userProfileService (#200)', () => {
@@ -244,5 +247,31 @@ describe('resolveAltitudToSave — coalesce no-destructivo (#1213-regresion)', (
     });
     expect(finca_altitud).toBeUndefined();
     expect(altitud_source).toBeUndefined();
+  });
+
+  describe('estilo de notificación (operador 2026-06-06)', () => {
+    it('por defecto es "demo" (chip estilo demo)', () => {
+      expect(DEFAULT_NOTIFICATION_STYLE).toBe('demo');
+      expect(getNotificationStyle()).toBe('demo');
+    });
+
+    it('persiste y relee el estilo seleccionado', () => {
+      setNotificationStyle('actual');
+      expect(getNotificationStyle()).toBe('actual');
+      expect(getProfile().estilo_notificacion).toBe('actual');
+      setNotificationStyle('demo');
+      expect(getNotificationStyle()).toBe('demo');
+    });
+
+    it('un valor inválido cae al default sin corromper el perfil', () => {
+      setNotificationStyle('xyz');
+      expect(getNotificationStyle()).toBe('demo');
+      expect(getProfile().estilo_notificacion).toBe('demo');
+    });
+
+    it('un perfil viejo sin el campo devuelve el default', () => {
+      saveProfile({ nombre: 'Lili' });
+      expect(getNotificationStyle()).toBe('demo');
+    });
   });
 });

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -384,6 +384,39 @@ export function saveProfile(partial = {}) {
   return next;
 }
 
+/**
+ * Estilo de notificación de alertas en la portada del agente (operador
+ * 2026-06-06). Define CÓMO se muestra una alerta clima/helada activa:
+ *   - 'demo':   chip llamativo en la escena (⚠ borde de acento). POR DEFECTO.
+ *   - 'actual': comportamiento clásico (campanita / NotificationsBell).
+ * Se guarda en el perfil (`estilo_notificacion`) como cualquier otra pref.
+ */
+export const NOTIFICATION_STYLES = Object.freeze(['demo', 'actual']);
+export const DEFAULT_NOTIFICATION_STYLE = 'demo';
+
+/**
+ * Lee el estilo de notificación preferido. Si el perfil no lo trae o trae un
+ * valor inválido, devuelve el default ('demo' — chip estilo demo).
+ *
+ * @returns {'demo'|'actual'}
+ */
+export function getNotificationStyle() {
+  const v = getProfile()?.estilo_notificacion;
+  return NOTIFICATION_STYLES.includes(v) ? v : DEFAULT_NOTIFICATION_STYLE;
+}
+
+/**
+ * Persiste el estilo de notificación en el perfil. Ignora valores inválidos
+ * (cae al default) para no corromper el perfil.
+ *
+ * @param {'demo'|'actual'} style
+ * @returns {Object} perfil resultante
+ */
+export function setNotificationStyle(style) {
+  const next = NOTIFICATION_STYLES.includes(style) ? style : DEFAULT_NOTIFICATION_STYLE;
+  return saveProfile({ estilo_notificacion: next });
+}
+
 /** Marca el onboarding de perfil como completado. */
 export function markProfileDone() {
   if (!hasStorage()) return;

--- a/tests/agent-anti-halluc.spec.js
+++ b/tests/agent-anti-halluc.spec.js
@@ -221,8 +221,34 @@ async function mockSidecar(page, opts = {}) {
   });
 }
 
+// Texto neutro de la pregunta de ENTRADA al AgentScreen (ver gotoAgentScreen).
+// No es "tomate"/"maíz"/etc. para no chocar visualmente con las preguntas de
+// los casos que cuentan burbujas/cola por contenido.
+const ENTRY_QUESTION = 'hola chagra';
+
 /**
  * Login + navegación al AgentScreen. Reutilizable en todos los tests.
+ *
+ * CAMINO NUEVO (PR #1336, "pulido del agente"): el AgentFab (colibrí flotante
+ * "Asistente Chagra IA") ya NO se renderiza en el home/dashboard — el operador
+ * pidió que en la portada el colibrí sea el botón de ENVIAR del compositor, no
+ * un FAB duplicado. La única entrada determinística al AgentScreen desde el
+ * home es ahora el COMPOSITOR de la portada (AgentHero):
+ *   - textarea  → aria-label "Escribe tu pregunta al agente"
+ *                 (placeholder "Pregúntale a Chagra…")
+ *   - enviar    → botón colibrí, aria-label "Enviar" (habilitado solo con texto)
+ * Al enviar, AgentHero PERSISTE la consulta en la outbox durable y navega a
+ * 'agente'; al montar, AgentScreen DRENA la outbox y procesa esa consulta por
+ * el mismo pipeline (enqueue → runAgentPipeline → completeProcessing).
+ *
+ * CONSECUENCIA para la cola (task #121, QUEUE_MAX=2): entrar al chat ahora
+ * SIEMBRA 1 mensaje en la cola. Los casos que cuentan la cola (A enquola
+ * exactamente 2; C espera "1 en cola") asumen una cola VACÍA al empezar. Por
+ * eso este helper, tras entrar, ESPERA a que el mensaje de entrada drene por
+ * completo: el placeholder del input vuelve a 'Escribe tu pregunta...' solo
+ * cuando queueProcessing===null y queuePending===[] (cola ociosa). Recién ahí
+ * los casos pueden encolar sus 2 preguntas sobre una cola limpia, sin acoplar
+ * el helper al delay del mock LLM de cada test.
  */
 async function gotoAgentScreen(page) {
   await page.goto('/');
@@ -230,15 +256,30 @@ async function gotoAgentScreen(page) {
   await page.getByLabel(/contraseña/i).fill('e2e-pwd');
   await page.getByRole('button', { name: /ingresar/i }).click();
 
-  // El AgentFab es global pero solo aparece fuera de login/loading/voz/agente.
-  // aria-label exacto: "Asistente Chagra IA" (o "Chagra IA tiene respuesta
-  // nueva" si responseReady=true — no debería al primer login).
-  const fab = page.getByRole('button', { name: /Asistente Chagra IA/i });
-  await expect(fab).toBeVisible({ timeout: 15_000 });
-  await fab.click();
+  // Compositor de la portada (AgentHero): escribir + enviar (colibrí) navega al
+  // AgentScreen. El textarea aparece fuera de login/loading; le damos margen al
+  // primer paint del dashboard.
+  const composer = page.getByLabel('Escribe tu pregunta al agente');
+  await expect(composer).toBeVisible({ timeout: 15_000 });
+  await composer.fill(ENTRY_QUESTION);
+  // El botón de enviar (colibrí) se habilita al haber texto.
+  const sendBtn = page.getByRole('button', { name: /^Enviar$/ });
+  await expect(sendBtn).toBeEnabled({ timeout: 5_000 });
+  await sendBtn.click();
 
   // Confirmar que el AgentScreen ya renderizó el input.
   await expect(page.getByTestId('agent-input')).toBeVisible({ timeout: 10_000 });
+
+  // Esperar a que el mensaje de ENTRADA drene la cola por completo: el
+  // placeholder vuelve al default solo con la cola ociosa (sin processing ni
+  // pending). Sin esto, las preguntas del caso encolarían sobre una cola que
+  // todavía tiene el mensaje de entrada → conteo roto. Timeout holgado: cubre
+  // los mocks con delayMs (p.ej. Caso A/C usan delayMs 3000 en el LLM).
+  await expect(page.getByTestId('agent-input')).toHaveAttribute(
+    'placeholder',
+    'Escribe tu pregunta...',
+    { timeout: 15_000 }
+  );
 }
 
 /**
@@ -646,6 +687,13 @@ test.describe('AgentScreen — sidecar pipeline (flag-dependent)', () => {
     });
 
     await gotoAgentScreen(page);
+    // gotoAgentScreen entra al chat SEMBRANDO 1 mensaje de texto (camino nuevo
+    // del compositor de la portada, PR #1336). Ese mensaje de entrada SÍ pasa
+    // por el NLU normal (no es un chip) → dispararía el counter. Lo reseteamos
+    // ahora que la entrada ya drenó: el contrato que medimos es que el CHIP
+    // (la acción de abajo) NO toque el /nlu, no la pregunta de entrada.
+    nluCalled = false;
+    pestToolCalled = false;
     // Activar el chip Plaga y enviar.
     await page.getByRole('button', { name: /Plaga/i }).click();
     await askAgent(page, 'broca del café');
@@ -684,6 +732,9 @@ test.describe('AgentScreen — sidecar pipeline (flag-dependent)', () => {
     });
 
     await gotoAgentScreen(page);
+    // Reset tras la entrada sembrada (ver Caso L): medimos solo el chip.
+    nluCalled = false;
+    speciesToolCalled = false;
     await page.getByRole('button', { name: /Qué siembro/i }).click();
     await askAgent(page, 'aguacate');
 
@@ -710,6 +761,11 @@ test.describe('AgentScreen — sidecar pipeline (flag-dependent)', () => {
     await mockSidecar(page);
 
     await gotoAgentScreen(page);
+    // Reset tras la entrada sembrada (ver Caso L): la pregunta de entrada SÍ
+    // pasa por NLU+LLM; el contrato que medimos es que el chip Precio resuelva
+    // su STUB honesto sin tocar NI /nlu NI el LLM.
+    nluCalled = false;
+    llmCalled = false;
     await page.getByRole('button', { name: /Precio/i }).click();
     await askAgent(page, 'papa');
 


### PR DESCRIPTION
Ajustes en vivo del operador (2026-06-06) sobre la portada del agente (`AgentHero`). Implementa los 12 puntos pedidos de forma consistente en los 3 temas.

## Qué cambió

**Header**
1. Marca arriba-izq = **ícono del tema** + wordmark **"Chagra · tu mano en el campo"** (el ícono cambia con el tema: nature=manos+frailejón, biopunk=anillo eléctrico + A, minimal=círculo+brote). El colibrí ya no es chrome de cabecera.
2. Removido el letrero **"Ambiente · altitud · efemérides"** + su card colapsable del `TopBar`.
3. **Botón de perfil** (engranaje, arriba-der) → `onNavigate('perfil')`, `aria-label="Perfil"`.
4. Toggle Campesino/Experto se mantiene arriba-der.

**Escena**
5. **Sol de día / luna de noche** (astro delicado por tema, según la hora).
6. **Chip de ubicación** arriba-der de la escena: `📍 Vereda, Municipio · msnm` (sin latitud), del perfil real (`getProfileMunicipio` + `vereda` + `finca_altitud`). Si falta el municipio, no se muestra.

**Bajo "Soy Chagra"**
7. **Sugerencias contextuales rotativas** (cada ~5s) basadas en los **cultivos reales** (`useAssetStore.plants`) × mes × piso térmico. Motor **determinístico** (`src/data/cropSuggestions.js`), **sin LLM**. Sin cultivos → subtítulo genérico.
8. **Chip de alerta real** (clima/helada) estilo demo (⚠ borde de acento). Nueva pref `estilo_notificacion`: `'demo'` (chip, **default**) / `'actual'` (campanita), con control en **Perfil → Apariencia**.

**Compositor**
9. Removido el botón de **adjuntar (clip)**; input de foto **sin `capture`** → permite tomar foto O elegir de galería (sigue solo imágenes, B2).
10. **Enviar = el colibrí 2D** del demo (recoloreado en crema para contraste sobre el acento). Lógica de envío intacta (outbox→navegar, `SEND_TRANSITION_MS`, disabled/sending).

**Otras pantallas**
11. **AgentFab** (colibrí flotante) gateado por ruta: ya **no** en home/dashboard, sigue en el resto.

## Inviolable
Wiring multimodal intacto (outbox, mic, cámara/foto B2, chips, auto-grow, reduced-motion, `onNavigate`). Tests actualizados (los que asumían clip/ArrowUp viejos → galería/colibrí; el contrato de **ENVIAR** sigue cubierto) + nuevos para `cropSuggestions` y `estilo_notificacion`.

## Validación
- `npm run build` ✓ · `eslint` ✓ (archivos tocados; 2 warnings pre-existentes en archivos no tocados).
- Suite unit: **228 archivos / 3718 tests** pasan (1 skip).
- Screenshots reales (Chromium nix-store, mock-login, perfil con 4 cultivos) de los 3 temas verifican: marca con ícono del tema (biopunk=A), sin colibrí-chrome arriba-izq, sin letrero ambiente, botón perfil arriba-der, sol/luna, ubicación arriba-der sin latitud, sugerencia contextual ("…drenaje de tus aguacates…"), compositor sin clip (1 input, 0 con `capture`), enviar=colibrí, sin FAB flotante en home.

## Nota honesta
El FAB `+` de `QuickActionsPanel` (separado del AgentFab) se solapa visualmente con el botón colibrí-enviar en la esquina inferior derecha del compositor inmersivo. Es **pre-existente** al layout inmersivo (afectaba igual al botón ArrowUp anterior) y queda fuera del alcance de estos 12 puntos; el colibrí-enviar es legible y funcional. Se puede abordar en un follow-up si el operador lo quiere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)