### PR TITLE
feat(agente): captura server-side de conversaciones para todos los usuarios (task #CHAT-CAPTURE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,15 @@ VITE_CHAGRA_CATALOG_URL=
 # Cuando exista el sistema de tier/allowlist, el gating por tier
 # se agregará en deepResearchClient.js sin necesidad de cambiar este flag.
 VITE_DEEP_RESEARCH_ENABLED=false
+
+# Captura de conversaciones del agente (task #CHAT-CAPTURE). Cuando está en
+# `true`, cada turno del chat (pregunta + respuesta + metadata) se envía
+# fire-and-forget al sidecar (POST /log-conversation → JSONL durable) para
+# análisis y mejora del sistema. Solo captura si el usuario dio consentimiento
+# (feedback 👍👎). Default `false` → privacy-first.
+VITE_CAPTURE_CONVERSATIONS=false
+
+# Anonimización de PII en la captura de conversaciones (Habeas Data - Ley 1581).
+# Cuando está en `true`, se omiten user_name y finca_nombre del payload, pero
+# se conservan user_id y finca_slug para análisis agregados. Default `false`.
+VITE_CAPTURE_ANONYMIZE=false

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -96,6 +96,9 @@ import { getCachedClimaSnapshot, fetchClimaSnapshot } from '../../services/clima
 import { FARM_CONFIG } from '../../config/defaults';
 import { speak, speakSentences, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
+// Captura de conversaciones del agente (task #CHAT-CAPTURE). Fire-and-forget,
+// gated por VITE_CAPTURE_CONVERSATIONS + consentimiento del usuario.
+import { captureExchange } from '../../services/conversationCaptureService';
 import { useRotatingTip } from '../../services/tipsService';
 import ChatHistory from './ChatHistory';
 import SuggestedActions from './SuggestedActions';
@@ -1740,7 +1743,10 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         }
       }
 
+      // Medición de latencia del turno (solo del callLLM) para captura.
+      const tLLM0 = performance.now();
       const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock);
+      const turnLatencyMs = Math.round(performance.now() - tLLM0);
       // DR-LANG-1: filtro post-process anti-voseo argentino. Es la última
       // línea de defensa estructural — garantiza que el léxico rioplatense
       // (che, laburar, etc.) NUNCA llegue al usuario campesino colombiano,
@@ -1914,6 +1920,44 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         metadata: sourceMetadata,
       });
       setMessages((prev) => [...prev, assistantMessage]);
+
+      // Captura de conversaciones del agente (task #CHAT-CAPTURE).
+      // Fire-and-forget, gated por VITE_CAPTURE_CONVERSATIONS + consentimiento
+      // del usuario (hasConsent del feedbackService). Persiste el turno completo
+      // (pregunta + respuesta + grounding) en el sidecar (/log-conversation →
+      // JSONL durable) para análisis y mejora del sistema. PURO side-effect
+      // best-effort: jamás bloquea ni cambia el flujo del chat; lo que no esté
+      // disponible va null/[] (el servicio tolera nulls). Lo que SÍ tenemos del
+      // turno se pasa.
+      try {
+        const captureProfile = (() => { try { return getProfile(); } catch (_) { return null; } })();
+        captureExchange({
+          userText: text,
+          agentText: response,
+          identity: {
+            user_id: operatorId,
+            user_name: (captureProfile && captureProfile.nombre) || null,
+            finca_slug: (fincaActiva && fincaActiva.slug) || activeFincaSlug || null,
+            finca_nombre: (fincaActiva && fincaActiva.nombre) || null,
+          },
+          meta: {
+            session_id: operatorId,
+            // Índice del turno = nº de mensajes ya en el hilo antes de este
+            // assistant (puede ser null si no hay; el servicio tolera null).
+            turn_index: Array.isArray(messages) ? messages.length : null,
+            nlu_route: (() => { try { return selectChatRoute(textForLLM); } catch (_) { return null; } })(),
+            entities_grounded: Array.isArray(resolvedEntities)
+              ? resolvedEntities.map((e) => (e && (e.id || e.nombre_cientifico || e.nombre)) || null).filter(Boolean)
+              : [],
+            guards_fired: Array.isArray(guarded.reasons) ? guarded.reasons : [],
+            grounded_status: (sourceMetadata && (sourceMetadata.fuente || sourceMetadata.source)) || null,
+            latency_ms: turnLatencyMs,
+            model: (() => { try { return buildLLMRequest(selectChatRoute(textForLLM), messages).body.model; } catch (_) { return null; } })(),
+          },
+        });
+      } catch (_) {
+        // La captura JAMÁS degrada el chat — la respuesta ya está mostrada.
+      }
 
       // Task #122: cachear el último mensaje del agente en el store global
       // para que el doble-click del avatar (cualquier pantalla) pueda re-

--- a/src/services/__tests__/conversationCaptureService.test.js
+++ b/src/services/__tests__/conversationCaptureService.test.js
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/* eslint-disable no-undef */
+
+/**
+ * conversationCaptureService.test.js — captura server-side de conversaciones
+ * del agente (task #CHAT-CAPTURE).
+ *
+ * `captureExchange` es fire-and-forget: gated por VITE_CAPTURE_CONVERSATIONS +
+ * consentimiento del usuario (hasConsent del feedbackService). NUNCA lanza ni
+ * bloquea la UX del chat, y POSTea el turno (pregunta + respuesta + grounding)
+ * a `${base}/log-conversation` con header X-Chagra-Token. Estos tests verifican:
+ *   - gate: con la flag OFF NO se llama a fetch.
+ *   - gate: con la flag ON pero SIN consentimiento NO se llama a fetch.
+ *   - gate: con la flag ON + consentimiento SÍ se llama a fetch.
+ *   - schema del payload (textos, identidad, meta) + header de auth.
+ *   - turnos vacíos no se envían.
+ *   - anonimización PII: con VITE_CAPTURE_ANONYMIZE=true se omiten user_name y
+ *     finca_nombre (Habeas Data).
+ *   - falla silenciosa (fetch rechaza → no throw).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { captureExchange, isCaptureEnabled, shouldAnonymizePII } from '../conversationCaptureService';
+import * as feedbackService from '../feedbackService';
+
+describe('conversationCaptureService', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+    vi.stubEnv('VITE_CAPTURE_ANONYMIZE', '');
+    vi.stubEnv('VITE_SIDECAR_URL', '/api/mcp/agro');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'test-token');
+    // Mockear hasConsent para que devuelva true por defecto en los tests
+    vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe('isCaptureEnabled (gate)', () => {
+    it('OFF por defecto (flag vacía)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+      expect(isCaptureEnabled()).toBe(false);
+    });
+
+    it('reconoce "true"/"1"/"on" como ON', () => {
+      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
+        vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', v);
+        expect(isCaptureEnabled()).toBe(true);
+      }
+    });
+
+    it('cualquier otro valor es OFF', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'false');
+      expect(isCaptureEnabled()).toBe(false);
+    });
+  });
+
+  describe('shouldAnonymizePII (Habeas Data)', () => {
+    it('OFF por defecto (flag vacía)', () => {
+      vi.stubEnv('VITE_CAPTURE_ANONYMIZE', '');
+      expect(shouldAnonymizePII()).toBe(false);
+    });
+
+    it('reconoce "true"/"1"/"on" como ON', () => {
+      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
+        vi.stubEnv('VITE_CAPTURE_ANONYMIZE', v);
+        expect(shouldAnonymizePII()).toBe(true);
+      }
+    });
+
+    it('cualquier otro valor es OFF', () => {
+      vi.stubEnv('VITE_CAPTURE_ANONYMIZE', 'false');
+      expect(shouldAnonymizePII()).toBe(false);
+    });
+  });
+
+  describe('captureExchange', () => {
+    it('NO envía nada cuando la flag está OFF', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('NO envía nada cuando la flag está ON pero NO hay consentimiento', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(false);
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('NO envía turnos vacíos aunque la flag esté ON', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({ userText: '', agentText: '' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('SÍ envía cuando la flag está ON + hay consentimiento', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(true);
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('con la flag ON, POSTea a /log-conversation con token + schema', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({
+        userText: '¿compañeros del café?',
+        agentText: 'guamo, plátano',
+        identity: {
+          user_id: 'op-3',
+          user_name: 'MonkeyD.Free',
+          finca_slug: 'finca-free',
+          finca_nombre: 'Finca de Free',
+        },
+        meta: {
+          session_id: 'op-3',
+          turn_index: 2,
+          nlu_route: 'chat',
+          entities_grounded: ['coffea_arabica'],
+          guards_fired: [],
+          grounded_status: 'Agrosavia',
+          latency_ms: 980,
+          model: 'granite3.1-dense:8b',
+        },
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = global.fetch.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/log-conversation');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token');
+
+      const body = JSON.parse(opts.body);
+      expect(body.user_text).toBe('¿compañeros del café?');
+      expect(body.agent_text).toBe('guamo, plátano');
+      expect(body.user_id).toBe('op-3');
+      expect(body.user_name).toBe('MonkeyD.Free');
+      expect(body.finca_slug).toBe('finca-free');
+      expect(body.session_id).toBe('op-3');
+      expect(body.turn_index).toBe(2);
+      expect(body.entities_grounded).toEqual(['coffea_arabica']);
+      expect(body.guards_fired).toEqual([]);
+      expect(body.grounded_status).toBe('Agrosavia');
+      expect(body.latency_ms).toBe(980);
+      expect(body.model).toBe('granite3.1-dense:8b');
+      // Sello cliente + id ulid presentes.
+      expect(typeof body.id).toBe('string');
+      expect(typeof body.ts).toBe('number');
+    });
+
+    it('con VITE_CAPTURE_ANONYMIZE=true, omite user_name y finca_nombre (Habeas Data)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      vi.stubEnv('VITE_CAPTURE_ANONYMIZE', 'true');
+      captureExchange({
+        userText: '¿compañeros del café?',
+        agentText: 'guamo, plátano',
+        identity: {
+          user_id: 'op-3',
+          user_name: 'MonkeyD.Free',
+          finca_slug: 'finca-free',
+          finca_nombre: 'Finca de Free',
+        },
+        meta: {
+          session_id: 'op-3',
+          turn_index: 2,
+          nlu_route: 'chat',
+          entities_grounded: ['coffea_arabica'],
+          guards_fired: [],
+          grounded_status: 'Agrosavia',
+          latency_ms: 980,
+          model: 'granite3.1-dense:8b',
+        },
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      // PII anonimizado
+      expect(body.user_name).toBeNull();
+      expect(body.finca_nombre).toBeNull();
+      // IDs conservados para análisis agregados
+      expect(body.user_id).toBe('op-3');
+      expect(body.finca_slug).toBe('finca-free');
+      // Resto del payload intacto
+      expect(body.user_text).toBe('¿compañeros del café?');
+      expect(body.agent_text).toBe('guamo, plátano');
+    });
+
+    it('tolera identity/meta ausentes (null/[] defaults)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.user_id).toBeNull();
+      expect(body.user_name).toBeNull();
+      expect(body.entities_grounded).toEqual([]);
+      expect(body.guards_fired).toEqual([]);
+      expect(body.latency_ms).toBeNull();
+    });
+
+    it('falla en silencio si fetch rechaza (no throw, no rompe el chat)', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+      expect(() =>
+        captureExchange({ userText: 'x', agentText: 'y' }),
+      ).not.toThrow();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/conversationCaptureService.js
+++ b/src/services/conversationCaptureService.js
@@ -1,0 +1,182 @@
+/**
+ * conversationCaptureService.js — Captura server-side de las conversaciones del
+ * agente para TODOS los usuarios (task #CHAT-CAPTURE).
+ *
+ * POR QUÉ EXISTE: hoy el historial del chat es local-only (IndexedDB de cada
+ * browser, #120) y el chat va directo a Ollama sin pasar por el sidecar, así que
+ * NADA queda guardado central. Para análisis, debugging y mejora del sistema,
+ * hay que persistir cada turno (pregunta + respuesta + grounding) en el sidecar.
+ * Mirror del patrón de `feedbackService.js` (mismo base URL + token).
+ *
+ * Endpoint sidecar: POST /log-conversation (chagra-pro, append a JSONL durable).
+ *
+ * Reglas:
+ * - Gated por `VITE_CAPTURE_CONVERSATIONS` (OFF default → privacy-first).
+ * - Solo captura si el usuario dio consentimiento (hasConsent() del feedbackService).
+ * - Fire-and-forget: NUNCA bloquea ni rompe la UX del chat; falla en silencio.
+ * - Opcionalmente anonimiza PII (VITE_CAPTURE_ANONYMIZE=true) → user_name y
+ *   finca_nombre se omiten para cumplir Habeas Data (Ley 1581).
+ *
+ * Schema del evento (1 línea JSONL por turno):
+ * {
+ *   id, ts,
+ *   user_id, user_name,        // identidad del usuario (user_name omitido si anonymize)
+ *   finca_slug, finca_nombre,  // finca activa (finca_nombre omitido si anonymize)
+ *   session_id, turn_index,
+ *   user_text,                 // pregunta del usuario (limpia)
+ *   agent_text,                // respuesta del agente (final)
+ *   nlu_route,                 // ruta NLU elegida (si la hubo)
+ *   entities_grounded,         // entidades resueltas en el grafo
+ *   guards_fired,              // guards de seguridad que actuaron
+ *   grounded_status,           // _grounded.status
+ *   latency_ms, model
+ * }
+ */
+
+import { ulid } from 'ulid';
+import { hasConsent } from './feedbackService';
+
+const CAPTURE_TIMEOUT_MS = 6000;
+const TEXT_MAX = 16000; // cota por campo (un turno largo del agente ~2-4k; holgado)
+
+/** ¿Captura activa? Gated por env. OFF por defecto. */
+export function isCaptureEnabled() {
+  try {
+    const raw = import.meta.env?.VITE_CAPTURE_CONVERSATIONS;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1' || v === 'on';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+function getBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.trim().replace(/\/+$/, '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '/api';
+}
+
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function clip(s) {
+  if (typeof s !== 'string') return '';
+  return s.length > TEXT_MAX ? `${s.slice(0, TEXT_MAX)}…[clip]` : s;
+}
+
+/** ¿Anonimizar PII? Gated por VITE_CAPTURE_ANONYMIZE (para Habeas Data). Exportado para tests. */
+export function shouldAnonymizePII() {
+  try {
+    const raw = import.meta.env?.VITE_CAPTURE_ANONYMIZE;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1' || v === 'on';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+/** Anonimiza campos PII si está activado el flag (Habeas Data). */
+function anonymizeIdentity(identity) {
+  if (!shouldAnonymizePII()) {
+    return identity;
+  }
+
+  return {
+    user_id: identity.user_id ?? null,
+    user_name: null,  // Omitir nombre por privacidad
+    finca_slug: identity.finca_slug ?? null,
+    finca_nombre: null,  // Omitir nombre de finca por privacidad
+  };
+}
+
+/**
+ * Captura un turno completo (pregunta del usuario + respuesta del agente).
+ * Fire-and-forget: devuelve void, no espera, no lanza.
+ *
+ * Solo captura si:
+ * - La flag VITE_CAPTURE_CONVERSATIONS está activada
+ * - El usuario dio consentimiento (hasConsent() del feedbackService)
+ *
+ * @param {Object} p
+ * @param {string} p.userText      pregunta del usuario
+ * @param {string} p.agentText     respuesta final del agente
+ * @param {Object} [p.identity]    { user_id, user_name, finca_slug, finca_nombre }
+ * @param {Object} [p.meta]        { session_id, turn_index, nlu_route, entities_grounded,
+ *                                   guards_fired, grounded_status, latency_ms, model }
+ */
+export function captureExchange({ userText, agentText, identity = {}, meta = {} } = {}) {
+  // Gate por variable de entorno
+  if (!isCaptureEnabled()) return;
+
+  // Gate por consentimiento del usuario (feedback 👍👎)
+  if (!hasConsent()) return;
+
+  // No capturamos turnos vacíos (p. ej. abortados sin respuesta).
+  if (!userText && !agentText) return;
+
+  // Anonimizar PII si está activado el flag (Habeas Data)
+  const sanitizedIdentity = anonymizeIdentity(identity);
+
+  const payload = {
+    id: ulid(),
+    ts: Date.now(),
+    user_id: sanitizedIdentity.user_id ?? null,
+    user_name: sanitizedIdentity.user_name ?? null,
+    finca_slug: sanitizedIdentity.finca_slug ?? null,
+    finca_nombre: sanitizedIdentity.finca_nombre ?? null,
+    session_id: meta.session_id ?? null,
+    turn_index: typeof meta.turn_index === 'number' ? meta.turn_index : null,
+    user_text: clip(userText),
+    agent_text: clip(agentText),
+    nlu_route: meta.nlu_route ?? null,
+    entities_grounded: Array.isArray(meta.entities_grounded) ? meta.entities_grounded.slice(0, 50) : [],
+    guards_fired: Array.isArray(meta.guards_fired) ? meta.guards_fired.slice(0, 20) : [],
+    grounded_status: meta.grounded_status ?? null,
+    latency_ms: typeof meta.latency_ms === 'number' ? meta.latency_ms : null,
+    model: meta.model ?? null,
+  };
+
+  const base = getBaseUrl();
+  const token = getToken();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) headers['X-Chagra-Token'] = token;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS);
+
+  // Fire-and-forget: no await, no throw. El chat NO depende de esto.
+  fetch(`${base}/log-conversation`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+    signal: controller.signal,
+    keepalive: true, // sobrevive si el usuario navega justo después
+  })
+    .catch((err) => {
+      // Silencioso por diseño: la captura jamás degrada la UX.
+      if (import.meta.env?.DEV) {
+        console.debug('[conversationCapture] envío falló (ignorado):', err?.name || err);
+      }
+    })
+    .finally(() => clearTimeout(timer));
+}


### PR DESCRIPTION
## Summary

Termina la implementación de captura de conversaciones del agente para TODOS los usuarios (no solo demo). El endpoint sidecar `POST /log-conversation` ya existe y está mergeado (chagra-pro #183).

## Cambios

### conversationCaptureService.js (nuevo)
Servicio fire-and-forget que POSTea cada turno al sidecar:

- **Gated por `VITE_CAPTURE_CONVERSATIONS`**: default `false` → privacy-first
- **Respeta consentimiento existente**: solo captura si el usuario dio consentimiento (feedback 👍👎)
- **Anonimización PII opcional**: `VITE_CAPTURE_ANONYMIZE=true` omite `user_name` y `finca_nombre` para cumplir Habeas Data (Ley 1581)
- **Fire-and-forget**: falla en silencio, no bloquea ni degrada la UX del chat
- **Best-effort**: lo no disponible va `null`/`[]`

### AgentScreen.jsx (modificado)
Wiring del servicio tras cada respuesta del agente:

- Medición de latencia del turno (`turnLatencyMs`)
- Captura identidad: `user_id`, `user_name`, `finca_slug`, `finca_nombre`
- Captura metadata: `session_id`, `turn_index`, `nlu_route`, `entities_grounded`, `guards_fired`, `grounded_status`, `latency_ms`, `model`
- Puro side-effect: NO cambia el flujo del chat

### .env.example (modificado)
Nuevas variables:
- `VITE_CAPTURE_CONVERSATIONS=false` (default → privacy-first)
- `VITE_CAPTURE_ANONYMIZE=false` (default → PII visible)

### conversationCaptureService.test.js (nuevo)
Coverage completo (14/14 passing):

- Gate `VITE_CAPTURE_CONVERSATIONS` (ON/OFF)
- Gate por consentimiento (`hasConsent()` del feedbackService)
- Anonimización PII (`VITE_CAPTURE_ANONYMIZE`)
- Schema del payload + header de auth
- Turnos vacíos no se envían
- Fallback silencioso (fetch rechaza → no throw)

## Test plan

- ✅ `npx vitest run` → 3751/3751 passing (229 files)
- ✅ `npx vitest run src/services/__tests__/conversationCaptureService.test.js` → 14/14 passing
- ✅ `npx vitest run src/components/AgentScreen/` → 28/28 passing
- ✅ `npx eslint .` → sin errores en archivos modificados
- ✅ `npm run build` → build OK

## Contracto del endpoint

El servicio POSTea a `POST /log-conversation` con el siguiente schema (JSONL):

```json
{
  "id": "ULID",
  "ts": 1234567890,
  "user_id": "op-3",
  "user_name": "MonkeyD.Free" | null (anonimizado),
  "finca_slug": "finca-free",
  "finca_nombre": "Finca de Free" | null (anonimizado),
  "session_id": "op-3",
  "turn_index": 2,
  "user_text": "¿compañeros del café?",
  "agent_text": "guamo, plátano",
  "nlu_route": "chat",
  "entities_grounded": ["coffea_arabica"],
  "guards_fired": [],
  "grounded_status": "Agrosavia",
  "latency_ms": 980,
  "model": "granite3.1-dense:8b"
}
```

## Consentimiento y privacidad

**GLM solo cablea el mecanismo**. La decisión de política va a revisión del operador:

- **Consentimiento existente**: Reusa el sistema de feedback 👍👎 (modal `FeedbackConsentModal`)
- **Habeas Data**: Flag `VITE_CAPTURE_ANONYMIZE` permite omitir PII (user_name, finca_nombre)
- **Privacy-first**: Default OFF (`VITE_CAPTURE_CONVERSATIONS=false`)

## Riesgos conocidos

- **Decisión de política**: No está definido si "para todos los usuarios" significa eliminar el gating o usar el consentimiento. GLM implementó el mecanismo respetando el consentimiento existente.
- **Habeas Data**: La anonimización es opcional. El operador debe decidir si activarla por default.

## MCP tools usadas

Ninguna. Este task es puramente infrastructural (PWA → sidecar).

## Files changed

- `.env.example`: +10 líneas (vars de entorno)
- `src/services/conversationCaptureService.js`: +182 líneas (nuevo)
- `src/services/__tests__/conversationCaptureService.test.js`: +219 líneas (nuevo)
- `src/components/AgentScreen/AgentScreen.jsx`: +62 líneas (wiring + medición latencia)

**Total**: +457 líneas, -0 líneas