### PR TITLE
feat(agent): harden conversation capture privacy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,14 @@ VITE_CHAGRA_CATALOG_URL=
 # Cuando exista el sistema de tier/allowlist, el gating por tier
 # se agregará en deepResearchClient.js sin necesidad de cambiar este flag.
 VITE_DEEP_RESEARCH_ENABLED=false
+
+# Captura de conversaciones del agente (task #CHAT-CAPTURE). Cuando está en
+# `true`, cada turno del chat se envía fire-and-forget al sidecar
+# (POST /log-conversation). Solo captura si el usuario dio consentimiento.
+# Default `false` → privacy-first.
+VITE_CAPTURE_CONVERSATIONS=false
+
+# Anonimización de PII en la captura de conversaciones (Habeas Data - Ley 1581).
+# Cuando está en `true`, se omiten user_name y finca_nombre del payload, pero se
+# conservan user_id y finca_slug para análisis agregados.
+VITE_CAPTURE_ANONYMIZE=false

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -258,7 +258,7 @@ export function HoyCard({ onNavigate, variant }) {
             title="Hoy en finca"
             subtitle="Lo que toca hacer cerca tuyo"
             tooltip="Tareas pendientes ordenadas por cercanía a tu ubicación actual."
-            onClick={() => onNavigate('javier')}
+            onClick={() => onNavigate('task_log')}
         />
     );
 }

--- a/src/services/__tests__/conversationCaptureService.test.js
+++ b/src/services/__tests__/conversationCaptureService.test.js
@@ -1,0 +1,165 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/* eslint-disable no-undef */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { captureExchange, isCaptureEnabled, shouldAnonymizePII } from '../conversationCaptureService';
+import * as feedbackService from '../feedbackService';
+
+describe('conversationCaptureService', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
+    vi.stubEnv('VITE_CAPTURE_ANONYMIZE', '');
+    vi.stubEnv('VITE_SIDECAR_URL', '/api/mcp/agro');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'test-token');
+    vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  describe('isCaptureEnabled', () => {
+    it('queda OFF por defecto', () => {
+      expect(isCaptureEnabled()).toBe(false);
+    });
+
+    it('reconoce true/1/on como ON', () => {
+      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
+        vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', v);
+        expect(isCaptureEnabled()).toBe(true);
+      }
+    });
+
+    it('cualquier otro valor queda OFF', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'false');
+      expect(isCaptureEnabled()).toBe(false);
+    });
+  });
+
+  describe('shouldAnonymizePII', () => {
+    it('queda OFF por defecto', () => {
+      expect(shouldAnonymizePII()).toBe(false);
+    });
+
+    it('reconoce true/1/on como ON', () => {
+      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
+        vi.stubEnv('VITE_CAPTURE_ANONYMIZE', v);
+        expect(shouldAnonymizePII()).toBe(true);
+      }
+    });
+  });
+
+  describe('captureExchange', () => {
+    it('no envía nada cuando la flag está OFF', () => {
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('no envía nada cuando la flag está ON pero no hay consentimiento', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(false);
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('no envía turnos vacíos aunque la flag esté ON', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({ userText: '', agentText: '' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('con flag ON y consentimiento, postea a /log-conversation con token y schema', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({
+        userText: '¿compañeros del café?',
+        agentText: 'guamo, plátano',
+        identity: {
+          user_id: 'op-3',
+          user_name: 'MonkeyD.Free',
+          finca_slug: 'finca-free',
+          finca_nombre: 'Finca de Free',
+        },
+        meta: {
+          session_id: 'op-3',
+          turn_index: 2,
+          nlu_route: 'chat',
+          entities_grounded: ['coffea_arabica'],
+          guards_fired: [],
+          grounded_status: 'Agrosavia',
+          latency_ms: 980,
+          model: 'granite3.1-dense:8b',
+        },
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = global.fetch.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/log-conversation');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token');
+
+      const body = JSON.parse(opts.body);
+      expect(body.user_text).toBe('¿compañeros del café?');
+      expect(body.agent_text).toBe('guamo, plátano');
+      expect(body.user_id).toBe('op-3');
+      expect(body.user_name).toBe('MonkeyD.Free');
+      expect(body.finca_slug).toBe('finca-free');
+      expect(body.session_id).toBe('op-3');
+      expect(body.turn_index).toBe(2);
+      expect(body.entities_grounded).toEqual(['coffea_arabica']);
+      expect(body.guards_fired).toEqual([]);
+      expect(body.grounded_status).toBe('Agrosavia');
+      expect(body.latency_ms).toBe(980);
+      expect(body.model).toBe('granite3.1-dense:8b');
+      expect(typeof body.id).toBe('string');
+      expect(typeof body.ts).toBe('number');
+    });
+
+    it('con VITE_CAPTURE_ANONYMIZE=true omite user_name y finca_nombre', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      vi.stubEnv('VITE_CAPTURE_ANONYMIZE', 'true');
+      captureExchange({
+        userText: '¿compañeros del café?',
+        agentText: 'guamo, plátano',
+        identity: {
+          user_id: 'op-3',
+          user_name: 'MonkeyD.Free',
+          finca_slug: 'finca-free',
+          finca_nombre: 'Finca de Free',
+        },
+      });
+
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.user_name).toBeNull();
+      expect(body.finca_nombre).toBeNull();
+      expect(body.user_id).toBe('op-3');
+      expect(body.finca_slug).toBe('finca-free');
+    });
+
+    it('tolera identity/meta ausentes', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      captureExchange({ userText: 'hola', agentText: 'buenas' });
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.user_id).toBeNull();
+      expect(body.user_name).toBeNull();
+      expect(body.entities_grounded).toEqual([]);
+      expect(body.guards_fired).toEqual([]);
+      expect(body.latency_ms).toBeNull();
+    });
+
+    it('falla en silencio si fetch rechaza', () => {
+      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+      expect(() => captureExchange({ userText: 'x', agentText: 'y' })).not.toThrow();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/agentService.js
+++ b/src/services/agentService.js
@@ -1090,7 +1090,8 @@ export function generateAgronomicGuidanceRules() {
 Toda regla agronómica es una GUÍA con zona gris. Navégala con los datos del grafo + el clima en vivo + RESPETO a la experiencia del campesino. NUNCA inventes; si falta el dato, sé neutral (no afirmes ni niegues).
 - Viabilidad marginal: nunca "no se puede" — está al límite, posible con cuidados; el campesino que ya lo logró tiene la razón sobre la base de datos.
 - Diseño de finca: si el usuario pregunta cómo mejorar su finca, por qué su cultivo no carga, o qué sembrar alrededor, puedes usar el tool get_diseno_finca(altitud) para sugerir polinizadores (para que cargue la fruta), abonos verdes (suelo), sombra y cercas vivas — del catálogo, viables a su altitud. Úsalo SOLO cuando sea pertinente (no en cada pregunta).
-- Invasoras / conservación: jamás recomiendes sembrar una especie invasora o de conservación sensible; sé honesto y ofrece alternativa nativa.`;
+- Invasoras / conservación: jamás recomiendes sembrar una especie invasora o de conservación sensible; sé honesto y ofrece alternativa nativa.
+- Premisa falsa / cura milagrosa: si el usuario afirma que una mezcla o práctica cura algo y pide dosis o frecuencia exacta, no confirmes ni inventes una cifra para complacer. Primero evalúa si la práctica tiene sustento; si no lo tiene, dilo con respeto y ofrece el manejo real.`;
 }
 
 /**

--- a/src/services/conversationCaptureService.js
+++ b/src/services/conversationCaptureService.js
@@ -1,27 +1,27 @@
 /**
  * conversationCaptureService.js — Captura server-side de las conversaciones del
- * agente para el demo/piloto (entrega de usuarios 2026-06-05).
+ * agente para TODOS los usuarios (task #CHAT-CAPTURE).
  *
  * POR QUÉ EXISTE: hoy el historial del chat es local-only (IndexedDB de cada
  * browser, #120) y el chat va directo a Ollama sin pasar por el sidecar, así que
- * NADA queda guardado central. Para evaluar las pruebas de cada usuario al final
- * del día, hay que persistir cada turno (pregunta + respuesta + grounding) en el
- * sidecar. Mirror del patrón de `feedbackService.js` (mismo base URL + token).
+ * NADA queda guardado central. Para análisis, debugging y mejora del sistema,
+ * hay que persistir cada turno (pregunta + respuesta + grounding) en el sidecar.
+ * Mirror del patrón de `feedbackService.js` (mismo base URL + token).
  *
  * Endpoint sidecar: POST /log-conversation (chagra-pro, append a JSONL durable).
  *
  * Reglas:
- * - Gated por `VITE_CAPTURE_CONVERSATIONS` (ON solo para el demo; OFF default →
- *   respeta la privacidad de grupos futuros, que requieren Habeas Data / DR-F).
+ * - Gated por `VITE_CAPTURE_CONVERSATIONS` (OFF default → privacy-first).
+ * - Solo captura si el usuario dio consentimiento (hasConsent() del feedbackService).
  * - Fire-and-forget: NUNCA bloquea ni rompe la UX del chat; falla en silencio.
- * - El grupo del primer demo es gente cercana → captura texto completo + identidad
- *   (decisión explícita del operador 2026-06-05).
+ * - Opcionalmente anonimiza PII (VITE_CAPTURE_ANONYMIZE=true) → user_name y
+ *   finca_nombre se omiten para cumplir Habeas Data (Ley 1581).
  *
  * Schema del evento (1 línea JSONL por turno):
  * {
  *   id, ts,
- *   user_id, user_name,        // identidad del usuario logueado
- *   finca_slug, finca_nombre,  // finca activa
+ *   user_id, user_name,        // identidad del usuario (user_name omitido si anonymize)
+ *   finca_slug, finca_nombre,  // finca activa (finca_nombre omitido si anonymize)
  *   session_id, turn_index,
  *   user_text,                 // pregunta del usuario (limpia)
  *   agent_text,                // respuesta del agente (final)
@@ -34,6 +34,7 @@
  */
 
 import { ulid } from 'ulid';
+import { hasConsent } from './feedbackService';
 
 const CAPTURE_TIMEOUT_MS = 6000;
 const TEXT_MAX = 16000; // cota por campo (un turno largo del agente ~2-4k; holgado)
@@ -79,9 +80,39 @@ function clip(s) {
   return s.length > TEXT_MAX ? `${s.slice(0, TEXT_MAX)}…[clip]` : s;
 }
 
+/** ¿Anonimizar PII? Gated por VITE_CAPTURE_ANONYMIZE. Exportado para tests. */
+export function shouldAnonymizePII() {
+  try {
+    const raw = import.meta.env?.VITE_CAPTURE_ANONYMIZE;
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1' || v === 'on';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+function anonymizeIdentity(identity) {
+  if (!shouldAnonymizePII()) return identity;
+
+  return {
+    user_id: identity.user_id ?? null,
+    user_name: null,
+    finca_slug: identity.finca_slug ?? null,
+    finca_nombre: null,
+  };
+}
+
 /**
  * Captura un turno completo (pregunta del usuario + respuesta del agente).
  * Fire-and-forget: devuelve void, no espera, no lanza.
+ *
+ * Solo captura si:
+ * - La flag VITE_CAPTURE_CONVERSATIONS está activada.
+ * - El usuario dio consentimiento (hasConsent() del feedbackService).
  *
  * @param {Object} p
  * @param {string} p.userText      pregunta del usuario
@@ -92,16 +123,18 @@ function clip(s) {
  */
 export function captureExchange({ userText, agentText, identity = {}, meta = {} } = {}) {
   if (!isCaptureEnabled()) return;
+  if (!hasConsent()) return;
   // No capturamos turnos vacíos (p. ej. abortados sin respuesta).
   if (!userText && !agentText) return;
 
+  const sanitizedIdentity = anonymizeIdentity(identity);
   const payload = {
     id: ulid(),
     ts: Date.now(),
-    user_id: identity.user_id ?? null,
-    user_name: identity.user_name ?? null,
-    finca_slug: identity.finca_slug ?? null,
-    finca_nombre: identity.finca_nombre ?? null,
+    user_id: sanitizedIdentity.user_id ?? null,
+    user_name: sanitizedIdentity.user_name ?? null,
+    finca_slug: sanitizedIdentity.finca_slug ?? null,
+    finca_nombre: sanitizedIdentity.finca_nombre ?? null,
     session_id: meta.session_id ?? null,
     turn_index: typeof meta.turn_index === 'number' ? meta.turn_index : null,
     user_text: clip(userText),


### PR DESCRIPTION
Integra lo valioso de los PRs pendientes y del trabajo de agente sin arrastrar ramas draft/rotas.\n\nIncluye:\n- captura de conversaciones privacy-first: flag OFF por defecto, consentimiento obligatorio y anonimización opcional de PII;\n- tests unitarios del servicio de captura;\n- regla de agente contra premisas falsas/curas milagrosas con dosis exactas;\n- navegación Hoy en finca hacia task_log.\n\nNo incluye PRs completos obsoletos: #1342 reescribía E2E para saltarse UI ya arreglada en main; #1345 trae marcadores de conflicto en TopBar; #1323 quedó superseded por la versión con consentimiento/anonymize; #1343 se toma como fuente del delta privacy-first.