### PR TITLE
fix(ui): dedupe agent brand and use live colibri

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -154,11 +154,11 @@ export default function TopBar({ onNavigate, onLogout }) {
           {/* Wordmark completo: visible también en móvil para no dejar el logo vacío. */}
           <div className="flex min-w-0 max-w-[42vw] sm:max-w-none flex-col items-start">
             <span className="text-base font-bold leading-tight text-white">Chagra</span>
-            <span className="text-[10px] leading-tight text-slate-400 font-normal truncate max-w-full">
+            <span className="text-[10px] leading-tight text-emerald-300/90 font-semibold truncate max-w-full">
               su mano en el campo
             </span>
             {locationLabel && (
-              <span className="text-[10px] leading-tight text-emerald-300/90 font-medium truncate max-w-full">
+              <span className="mt-0.5 max-w-full truncate rounded-full border border-emerald-400/20 bg-emerald-950/25 px-1.5 py-0.5 text-[10px] leading-tight text-emerald-200/95 font-medium">
                 {locationLabel}
               </span>
             )}

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -12,12 +12,11 @@ import { useTheme } from '../../hooks/useTheme';
 import {
     getProfile,
     saveProfile,
-    getProfileMunicipio,
     getNotificationStyle,
 } from '../../services/userProfileService';
 import { buildCropSuggestions } from '../../data/cropSuggestions';
 import { iconForTheme } from './themeIcon';
-import ChagraAgentAvatarColibri3D from '../ChagraAgentAvatarColibri3D';
+import ChagraAgentAvatar from '../ChagraAgentAvatar';
 
 /**
  * AgentHero — la PORTADA INMERSIVA del agente Chagra, PRIMERA PANTALLA COMPLETA
@@ -256,24 +255,9 @@ export default function AgentHero({ onNavigate }) {
     // ── Escena: sol de día / luna de noche (operador 2026-06-06) ──────────────
     const night = isNightNow();
 
-    // ── Ubicación real del perfil, bajo la marca ──────────────────────────────
-    // 📍 Vereda · Municipio · altitud. Si falta municipio, no se muestra (no
-    // inventamos ubicación).
-    // Si falta municipio, no se muestra (no inventamos ubicación).
+    // ── Perfil real para sugerencias contextuales ─────────────────────────────
     const profile = getProfile();
-    const municipio = getProfileMunicipio();
     const altitud = profile?.finca_altitud || profile?.altitud || null;
-    // Vereda CONDICIONAL (operador 2026-06-06): si el perfil la tiene
-    // (la escribió en onboarding; NO se auto-detecta), va delante →
-    // "Vereda · Municipio · msnm". Si no, "Municipio · msnm".
-    const vereda = profile?.vereda || profile?.finca_vereda || null;
-    const locationLabel = municipio
-        ? [vereda,
-            municipio.split(',')[0],
-            altitud ? `${altitud} msnm` : null]
-            .filter(Boolean)
-            .join(' · ')
-        : null;
 
     // ── Sugerencias contextuales ROTATIVAS basadas en los cultivos reales ─────
     // Deterministas (cropSuggestions: cultivos del store × mes × piso térmico).
@@ -752,13 +736,13 @@ export default function AgentHero({ onNavigate }) {
                     100% { transform: translate(0,0) rotate(0deg); }
                 }
 
-                /* ===================== MARCA + TOGGLE ===================== */
+                /* ===================== TOGGLE SUPERIOR ===================== */
                 .agentport-topbar {
                     position: relative;
                     z-index: 10;
                     display: flex;
                     align-items: flex-start;
-                    justify-content: space-between;
+                    justify-content: flex-end;
                     gap: 8px;
                     padding: calc(86px + env(safe-area-inset-top)) 0 6px;
                     flex: none;
@@ -1218,26 +1202,8 @@ export default function AgentHero({ onNavigate }) {
                 </div>
             </div>
 
-            {/* ===================== MARCA + TOGGLE Campesino/Experto ===================== */}
-            {/* Operador 2026-06-06: arriba-izq = MARCA (ícono del tema + wordmark
-                "Chagra · tu mano en el campo"), NO el colibrí-video. El colibrí
-                sigue volando en la escena de fondo, y ES el botón de enviar. */}
+            {/* ===================== TOGGLE Campesino/Experto ===================== */}
             <header className="agentport-topbar">
-                <div className="agentport-brand">
-                    <span className="agentport-mark">{iconForTheme(theme)}</span>
-                    <div className="agentport-brand-copy">
-                        <div className="agentport-name">
-                            Chagra<small>su mano en el campo</small>
-                        </div>
-                        {locationLabel && (
-                            <div className="agentport-loc" aria-label={`Ubicación: ${locationLabel}`}>
-                                <span className="pin" aria-hidden="true">📍</span>
-                                <span className="txt">{locationLabel}</span>
-                            </div>
-                        )}
-                    </div>
-                </div>
-
                 <div className="agentport-headtools">
                     <div className="agentport-mode" role="tablist" aria-label="Nivel de respuestas">
                         <button
@@ -1436,7 +1402,7 @@ export default function AgentHero({ onNavigate }) {
                             {isRecording ? <Square size={16} strokeWidth={2.5} aria-hidden="true" /> : <Mic size={18} strokeWidth={2.5} aria-hidden="true" />}
                         </button>
 
-                        {/* Enviar — botón redondo de acento con colibrí 3D animado (el .send del demo) */}
+                        {/* Enviar — usa el mismo colibrí foto/video del FAB global. */}
                         <button
                             type="button"
                             onClick={handleSendText}
@@ -1454,7 +1420,7 @@ export default function AgentHero({ onNavigate }) {
                             }}
                         >
                             <div style={{ width: '100%', height: '100%', position: 'relative' }}>
-                              <ChagraAgentAvatarColibri3D size={36} state={canSend ? 'idle' : 'listening'} />
+                              <ChagraAgentAvatar size={38} state={canSend ? 'idle' : 'listening'} ariaLabel="Enviar al agente" />
                             </div>
                         </button>
                     </div>

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -58,15 +58,6 @@ vi.mock('../../ChagraAgentAvatar', () => ({
   default: ({ state }) => <div data-testid="avatar" data-state={state} />,
 }));
 
-// ── Mock del avatar 3D (evita Three.js en tests) ────────────────────────────
-vi.mock('../../ChagraAgentAvatarColibri3D', () => ({
-  default: ({ size, state }) => (
-    <div data-testid="colibri-3d" data-size={size} data-state={state}>
-      🐦
-    </div>
-  ),
-}));
-
 import AgentHero, { SEND_TRANSITION_MS } from '../AgentHero';
 
 beforeEach(() => {
@@ -336,11 +327,10 @@ describe('AgentHero — foto: cámara O galería, solo imágenes (B2, 2026-06-06
 });
 
 describe('AgentHero — colibrí = enviar + botón de perfil (operador 2026-06-06)', () => {
-  test('el botón de enviar lleva el colibrí 3D (no el 2D ni flecha)', () => {
+  test('el botón de enviar lleva el mismo avatar colibrí del FAB global', () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
     const sendBtn = screen.getByLabelText('Enviar al agente');
-    // El colibrí 3D va dentro del botón (mock devuelve div con data-testid="colibri-3d").
-    expect(sendBtn.querySelector('[data-testid="colibri-3d"]')).toBeTruthy();
+    expect(sendBtn.querySelector('[data-testid="avatar"]')).toBeTruthy();
     // Ya no hay un input que fuerce cámara.
     expect(container.querySelector('input[capture]')).toBeNull();
   });
@@ -362,17 +352,11 @@ describe('AgentHero — voseo (español colombiano)', () => {
     expect(text).not.toMatch(/\bquerés\b/);
   });
 
-  test('el wordmark usa "su mano en el campo" (usted colombiano, NO "tu") — HOME-FIX', () => {
+  test('no duplica el wordmark del TopBar dentro del hero — HOME-FIX', () => {
     const { container } = render(<AgentHero onNavigate={vi.fn()} />);
-    // Buscar específicamente el elemento .agentport-name
-    const wordmark = container.querySelector('.agentport-name');
-    expect(wordmark).toBeTruthy();
-    const text = wordmark.textContent || '';
-    // Debe decir "su mano en el campo" (usted colombiano).
-    // Nota: textContent puede concatenar "Chagra" con el <small>, así que
-    // buscamos la frase sin word boundary estricto al inicio.
-    expect(text).toMatch(/su mano en el campo/i);
-    // NO debe decir "tu mano en el campo" (tú incorrecto).
+    expect(container.querySelector('.agentport-name')).toBeNull();
+    expect(container.querySelector('.agentport-brand')).toBeNull();
+    const text = container.textContent || '';
     expect(text).not.toMatch(/tu mano en el campo/i);
   });
 });

--- a/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
@@ -3,9 +3,9 @@
  * post-pulido (portada fiel del operador 2026-06-06).
  *
  * Cubre los 5 puntos del task #TEST-int:
- *   1. enviar=colibrí navega (el botón de enviar tiene el colibrí 3D y navega)
+ *   1. enviar=colibrí navega (el botón de enviar usa el avatar global y navega)
  *   2. sin clip (no hay botón de adjuntar/clip, solo cámara)
- *   3. ubicación bajo la marca (vereda/municipio/altitud)
+ *   3. marca/ubicación no se duplican dentro del hero
  *   4. sugerencia contextual presente (crop suggestions rotativas)
  *   5. toggle Campesino/Experto cambia nivel_respuestas (persiste el perfil)
  *
@@ -92,11 +92,11 @@ vi.mock('../../../data/exampleQuestions', () => ({
   ],
 }));
 
-// ── Mock del avatar 3D (evita Three.js en tests) ────────────────────────────
-vi.mock('../../ChagraAgentAvatarColibri3D', () => ({
+// ── Mock del avatar global (evita cargar video/foto en tests) ───────────────
+vi.mock('../../ChagraAgentAvatar', () => ({
   default: ({ size, state }) => (
-    <div data-testid="colibri-3d" data-size={size} data-state={state}>
-      🐦
+    <div data-testid="avatar" data-size={size} data-state={state}>
+      colibri
     </div>
   ),
 }));
@@ -137,17 +137,16 @@ beforeEach(() => {
 
 describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
   describe('1. enviar=colibrí navega', () => {
-    test('el botón de enviar tiene el colibrí 3D dentro', () => {
+    test('el botón de enviar tiene el avatar global dentro', () => {
       render(<AgentHero onNavigate={vi.fn()} />);
       const sendBtn = screen.getByLabelText('Enviar al agente');
 
-      // El colibrí 3D va dentro del botón (mock devuelve div con data-testid="colibri-3d")
-      const colibri3d = sendBtn.querySelector('[data-testid="colibri-3d"]');
-      expect(colibri3d).toBeTruthy();
+      const avatar = sendBtn.querySelector('[data-testid="avatar"]');
+      expect(avatar).toBeTruthy();
 
       // Verifica que tiene los atributos correctos
-      expect(colibri3d).toHaveAttribute('data-size', '36');
-      expect(colibri3d).toHaveAttribute('data-state', 'listening');
+      expect(avatar).toHaveAttribute('data-size', '38');
+      expect(avatar).toHaveAttribute('data-state', 'listening');
     });
 
     test('al enviar texto, el colibrí (botón enviar) navega a agente', async () => {
@@ -182,9 +181,8 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
     test('el colibrí NO se usa en otro lugar del compositor (solo en enviar)', () => {
       const { container } = render(<AgentHero onNavigate={vi.fn()} />);
 
-      // Solo debe haber un colibrí 3D con data-testid="colibri-3d" (en el botón de enviar)
-      const colibri3dElements = container.querySelectorAll('[data-testid="colibri-3d"]');
-      expect(colibri3dElements.length).toBe(1);
+      const avatarElements = container.querySelectorAll('[data-testid="avatar"]');
+      expect(avatarElements.length).toBe(1);
 
       // El colibrí de la escena (.agentport-hummer) es separado
       const sceneHummer = container.querySelector('.agentport-hummer');
@@ -232,66 +230,14 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
     });
   });
 
-  describe('3. ubicación bajo la marca', () => {
-    test('con ubicación en el perfil: se muestra bajo el wordmark de Chagra', () => {
-      getProfile.mockReturnValue({
-        nivel_respuestas: 'simple',
-        municipio: 'Subachoque, Cundinamarca',
-        vereda: 'Vereda Test',
-        finca_altitud: 1800,
-      });
-      getProfileMunicipio.mockReturnValue('Subachoque, Cundinamarca');
-      
+  describe('3. marca/ubicación sin duplicar', () => {
+    test('AgentHero no renderiza wordmark ni ubicación propios; eso vive en TopBar', () => {
       const { container } = render(<AgentHero onNavigate={vi.fn()} />);
-      
-      // El chip de ubicación debe estar presente
-      const locChip = container.querySelector('.agentport-loc');
-      expect(locChip).toBeTruthy();
-      
-      // Debe tener el pin de ubicación
-      const pin = locChip.querySelector('.pin');
-      expect(pin).toBeTruthy();
-      expect(pin.textContent).toBe('📍');
-      
-      // Debe mostrar vereda, municipio y altitud (SIN latitud)
-      const txt = locChip.querySelector('.txt');
-      expect(txt).toBeTruthy();
-      expect(txt.textContent).toMatch(/Vereda Test/i);
-      expect(txt.textContent).toMatch(/Subachoque/i);
-      expect(txt.textContent).toMatch(/1800.*msnm/i);
-    });
 
-    test('SIN municipio en el perfil: NO se muestra ubicación', () => {
-      getProfile.mockReturnValue({
-        nivel_respuestas: 'simple',
-        municipio: null,
-        vereda: 'Vereda Test',
-      });
-      getProfileMunicipio.mockReturnValue(null);
-      
-      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
-      
-      // No debe haber chip de ubicación
-      const locChip = container.querySelector('.agentport-loc');
-      expect(locChip).toBeNull();
-    });
-
-    test('la ubicación queda dentro del bloque de marca', () => {
-      getProfile.mockReturnValue({
-        nivel_respuestas: 'simple',
-        municipio: 'Subachoque, Cundinamarca',
-        vereda: 'Vereda Test',
-        finca_altitud: 1800,
-      });
-      getProfileMunicipio.mockReturnValue('Subachoque, Cundinamarca');
-      
-      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
-      const locChip = container.querySelector('.agentport-loc');
-
-      const brand = container.querySelector('.agentport-brand-copy');
-      expect(brand).toBeTruthy();
-      expect(brand.contains(locChip)).toBe(true);
-      expect(locChip.className).toContain('agentport-loc');
+      expect(container.querySelector('.agentport-brand')).toBeNull();
+      expect(container.querySelector('.agentport-brand-copy')).toBeNull();
+      expect(container.querySelector('.agentport-loc')).toBeNull();
+      expect(container.querySelector('.agentport-headtools')).toBeTruthy();
     });
   });
 
@@ -537,16 +483,13 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
       const onNavigate = vi.fn();
       const { container } = render(<AgentHero onNavigate={onNavigate} />);
       
-      // 1. Ve la ubicación
-      const locChip = container.querySelector('.agentport-loc');
-      expect(locChip).toBeTruthy();
-      expect(locChip.textContent).toMatch(/La Esperanza|Subachoque/i);
-      
-      // 2. Ve las sugerencias contextuales
+      expect(container.querySelector('.agentport-loc')).toBeNull();
+
+      // 1. Ve las sugerencias contextuales
       const suggestion = container.querySelector('[data-testid="agentport-suggestion"]');
       expect(suggestion).toBeTruthy();
       
-      // 3. Cambia a Experto
+      // 2. Cambia a Experto
       const expertoBtn = screen.getByText(/experto/i);
       await act(async () => {
         fireEvent.click(expertoBtn);
@@ -555,19 +498,19 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
         expect.objectContaining({ nivel_respuestas: 'detallado' }),
       );
       
-      // 4. Escribe una pregunta
+      // 3. Escribe una pregunta
       const ta = screen.getByLabelText('Escribe tu pregunta al agente');
       fireEvent.change(ta, { target: { value: '¿Cómo abono mis cafés?' } });
       
-      // 5. Envía (tocando el colibrí)
+      // 4. Envía (tocando el colibrí)
       const sendBtn = screen.getByLabelText('Enviar al agente');
-      expect(sendBtn.querySelector('[data-testid="colibri-3d"]')).toBeTruthy();
+      expect(sendBtn.querySelector('[data-testid="avatar"]')).toBeTruthy();
       
       await act(async () => {
         fireEvent.click(sendBtn);
       });
       
-      // 6. Persiste y navega
+      // 5. Persiste y navega
       await waitFor(() => {
         expect(sendMock).toHaveBeenCalledWith(
           expect.objectContaining({ kind: 'text', text: '¿Cómo abono mis cafés?' }),


### PR DESCRIPTION
Corrige dos regresiones visuales reportadas:\n\n- elimina el wordmark duplicado dentro de AgentHero; la marca Chagra + su mano en el campo queda solo en TopBar;\n- mejora la línea vereda/municipio/msnm en TopBar como chip verde compacto;\n- reemplaza el colibrí 3D viejo del botón Enviar por ChagraAgentAvatar, el mismo wrapper del FAB flotante que usa el colibrí foto/video.\n\nVerificado localmente: eslint enfocado, unit tests AgentHero/TopBar, build y bundle audit.