### PR TITLE
feat(agent): paridad visual completa AgentScreen-AgentHero (11 cambios)

### DIFF
--- a/public/cycle-content/manifest.json
+++ b/public/cycle-content/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-08T03:10:28.046Z",
+  "generated_at": "2026-06-08T13:51:48.278Z",
   "slugs": [
     "acacia_melanoxylon",
     "acanthus_mollis",

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X } from 'lucide-react';
+import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
 import { transcribe } from '../../services/voiceService';
 // Outbox DURABLE (compositor multimodal del home). El AgentScreen es el
@@ -103,9 +103,12 @@ import SuggestedActions from './SuggestedActions';
 import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import ChagraAgentAvatarColibri3D from '../ChagraAgentAvatarColibri3D';
+import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
 import QuickChipsBar from '../QuickChipsBar';
 import ChipsToolbar from '../ChipsToolbar';
 import AgentDemoExample from '../AgentDemoExample';
+import { captureAndCompress } from '../../services/photoService';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
@@ -164,6 +167,11 @@ export default function AgentScreen({ onBack, initialContext }) {
   const [messages, setMessages] = useState([]);
   const [inputText, setInputText] = useState('');
   const [state, setState] = useState(STATE_IDLE);
+  // Compositor inline (foto adjuntada directamente en AgentScreen, sin outbox).
+  // Independiente de la outbox — el operador ya está en la pantalla del agente.
+  const cameraInputAgentRef = useRef(null);
+  const [agentAttachment, setAgentAttachment] = useState(null); // {blob,mime,previewUrl,fileName}
+  const [agentPickError, setAgentPickError] = useState('');
   const [streamingContent, setStreamingContent] = useState('');
   const [isOnline, setIsOnline] = useState(navigator.onLine);
   const [error, setError] = useState('');
@@ -2472,6 +2480,84 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     setActiveIntent((prev) => (prev === intent ? null : intent));
   };
 
+  // ── Foto inline desde el compositor del AgentScreen ───────────────────────
+  // Independiente del outbox: el operador ya está en la pantalla del agente,
+  // así que la foto se procesa directamente (captureAndCompress → preview).
+  // Al enviar: processPhotoItem inline → handleSubmit(prompt, suppressUserBubble).
+  const handleAgentPhotoPick = async (e) => {
+    const file = e.target.files && e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+    const looksLikeImage =
+      (file.type && file.type.startsWith('image/')) ||
+      isAnalyzableImageAttachment({ mime: file.type, fileName: file.name });
+    if (!looksLikeImage) {
+      setAgentPickError('Por ahora solo puedo ver fotos. Mándame una foto de tu planta o cultivo.');
+      return;
+    }
+    setAgentPickError('');
+    try {
+      const { blob, mime } = await captureAndCompress(file);
+      const previewUrl = URL.createObjectURL(blob);
+      photoObjectUrlsRef.current.push(previewUrl);
+      setAgentAttachment({ blob, mime, previewUrl, fileName: file.name || 'foto.jpg', kind: 'photo' });
+    } catch (err) {
+      console.error('[AgentScreen] no se pudo procesar la foto:', err);
+      setAgentPickError('No pude procesar esa foto. Inténtalo de nuevo.');
+    }
+  };
+
+  const clearAgentAttachment = () => {
+    if (agentAttachment?.previewUrl) URL.revokeObjectURL(agentAttachment.previewUrl);
+    setAgentAttachment(null);
+    setAgentPickError('');
+  };
+
+  const handleAgentSend = async () => {
+    if (state === STATE_RECORDING) return;
+    if (agentAttachment) {
+      // Foto inline: armar burbuja + correr visión + handleSubmit
+      const item = {
+        kind: 'photo',
+        blob: agentAttachment.blob,
+        mime: agentAttachment.mime,
+        text: inputText.trim(),
+      };
+      // Pintar burbuja con la imagen DE INMEDIATO
+      const createUrl = (blob) => {
+        if (typeof URL === 'undefined' || !URL.createObjectURL) return null;
+        const url = URL.createObjectURL(blob);
+        photoObjectUrlsRef.current.push(url);
+        return url;
+      };
+      const { message } = buildPhotoUserMessage(item, createUrl);
+      setMessages((prev) => [...prev, message]);
+      // Correr visión y armar prompt
+      const { prompt, finding } = await processPhotoItem(item, {
+        analyze: analyzeFoliage,
+        createUrl: null,
+      });
+      setInputText('');
+      clearAgentAttachment();
+      setActiveIntent(null);
+      setAlertContextBanner(null);
+      await handleSubmit(prompt, {
+        suppressUserBubble: true,
+        visionContext: {
+          hadVision: true,
+          visionConfidence:
+            finding && typeof finding.confidence === 'number' ? finding.confidence : null,
+        },
+      });
+      return;
+    }
+    if (!inputText.trim()) return;
+    handleSubmit(inputText, { forcedIntent: activeIntent });
+    setInputText('');
+    setActiveIntent(null);
+    setAlertContextBanner(null);
+  };
+
   // ── Consumo de la OUTBOX DURABLE del compositor del home ───────────────────
   // El usuario disparó una consulta multimodal desde AgentHero; el item ya
   // está persistido en IndexedDB. Aquí la procesamos como "ya enviada":
@@ -2551,6 +2637,13 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       }
 
       if (item.kind === 'photo') {
+        // Bug fix 2026-06-08: IDB puede serializar el Blob perdiendo su MIME type.
+        // Si item.blob.type está vacío pero item.mime existe, reconstruimos el Blob.
+        if (item.blob && !item.blob.type && item.mime) {
+          try {
+            item = { ...item, blob: new Blob([item.blob], { type: item.mime }) };
+          } catch (_) { /* noop: degradamos a prompt sin imagen */ }
+        }
         // Bug 2026-05-31: la foto NO llegaba al chat (solo el texto). Causa
         // raíz doble: (1) la burbuja se pintaba SIN la imagen — el blob se
         // pasaba a analyzeFoliage y se descartaba, y ChatBubble no sabía pintar
@@ -2672,96 +2765,90 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     : 'Escribe tu pregunta...';
 
   return (
-    <div className={`h-[100dvh] flex flex-col bg-slate-950 overflow-hidden ${entranceClassRef.current}`}>
-      {/* B1: animación de entrada (fade+rise) para que se perciba el cruce al
-          agente. Respeta prefers-reduced-motion vía @media en el CSS. */}
+    <div className={`h-[100dvh] flex flex-col bg-slate-950/95 overflow-hidden ${entranceClassRef.current}`}>
+      {/* B1: animación de entrada (fade+rise). Respeta prefers-reduced-motion. */}
       <style>{AGENT_ENTRANCE_CSS}</style>
-      {/* Header con avatar colibrí Chagra IA (operator bug #920 no aplicó el avatar al header) */}
-      <div className="px-4 py-3 flex items-center gap-3 border-b border-slate-800 bg-slate-900/80 backdrop-blur-sm shrink-0">
+
+      {/* ── Header estilo ScreenShell (2026-06-08): scrim + blur + acciones globales ── */}
+      <header className="px-4 py-3 flex items-center gap-2 border-b border-slate-800 bg-slate-900/50 backdrop-blur-md shrink-0">
+        {/* Back */}
         <button
           type="button"
           onClick={onBack}
-          className="p-2 -ml-2 rounded-lg active:bg-slate-800"
+          className="p-2.5 rounded-full bg-slate-800 hover:bg-slate-700 active:scale-95 transition-all"
           aria-label="Volver"
         >
-          <ArrowLeft size={20} className="text-amber-400" />
+          <ArrowLeft size={18} className="text-slate-300" />
         </button>
-        <ChagraAgentAvatar
+        {/* Home */}
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'dashboard' }))}
+          className="p-2.5 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:scale-95 transition-all text-emerald-400"
+          aria-label="Volver al inicio"
+          title="Inicio"
+        >
+          <Home size={18} />
+        </button>
+        {/* Avatar + título */}
+        <ChagraAgentAvatarColibriPhoto
           state={state === STATE_RECORDING ? 'listening' : state === STATE_THINKING ? 'thinking' : 'idle'}
-          size={40}
+          size={36}
           onDoubleClick={async () => {
-            // Task #122: doble-click avatar header silencia/reactiva audio.
-            // Espejo del comportamiento del AgentFab global, pero acá ya
-            // estamos en AgentScreen así que solo tocamos TTS.
             if (isSpeaking() || ttsEnabled) {
-              stop();
-              setTtsEnabled(false);
-              agentSounds.cancel();
-              return;
+              stop(); setTtsEnabled(false); agentSounds.cancel(); return;
             }
-            // Reactivar + replay último mensaje
             setTtsEnabled(true);
             const ok = await replayLast({ useKokoro: kokoroReady });
             if (ok) agentSounds.chime();
           }}
-          ariaLabel="Avatar Chagra IA, doble click para silenciar o reactivar la voz"
+          ariaLabel="Chagra IA — doble click silencia/reactiva voz"
         />
         <div className="flex-1 min-w-0">
-          <h1 className="text-base font-bold text-white leading-tight">Chagra IA</h1>
-          <p className="text-[10px] text-slate-400 uppercase tracking-wider font-bold">
+          <h1 className="text-sm font-bold text-white leading-tight truncate">Chagra IA</h1>
+          <p className="text-[10px] font-semibold uppercase tracking-wider leading-tight"
+             style={{ color: state === STATE_THINKING ? '#f59e0b' : state === STATE_RECORDING ? '#a78bfa' : '#6ee7b7' }}>
             {state === STATE_THINKING && 'pensando…'}
             {state === STATE_RECORDING && 'escuchando…'}
             {state === STATE_IDLE && 'agente agroecológico'}
           </p>
         </div>
-        {/* Bug N3 fix (PR fix/n3-cross-conv-contamination 2026-05-23):
-            botón explícito "Nueva conversación". Llama clearMemory(operatorId)
-            + reset state + marca sesión fresca. Cubre el caso N3 exacto donde
-            el operador hace Volver + reabre rápido (<30min) con tópico distinto
-            y el gap temporal automático NO se dispararía. Sólo habilitado en
-            STATE_IDLE para no interrumpir streaming en curso. */}
+        {/* Acciones: nueva conversación + TTS + online badge */}
         <button
           type="button"
           onClick={handleNewConversation}
           disabled={state !== STATE_IDLE || messages.length === 0}
-          className={`p-2 rounded-full transition-colors ${
+          className={`p-2 rounded-full transition-all ${
             state !== STATE_IDLE || messages.length === 0
               ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
               : 'bg-slate-800 text-slate-300 hover:bg-slate-700 active:scale-95'
           }`}
-          title="Nueva conversación (borra historial)"
+          title="Nueva conversación"
           aria-label="Iniciar nueva conversación"
           data-testid="new-conversation-btn"
         >
-          <RotateCcw size={16} />
+          <RotateCcw size={15} />
         </button>
         <button
           type="button"
           disabled={!ttsSupported}
-          onClick={() => {
-            if (ttsEnabled) {
-              stop();
-            }
-            setTtsEnabled(!ttsEnabled);
-          }}
-          className={`p-2 rounded-full transition-colors ${
-            !ttsSupported
-              ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
-              : ttsEnabled
-                ? 'bg-violet-900/40 text-violet-400'
-                : 'bg-slate-800 text-slate-500'
+          onClick={() => { if (ttsEnabled) stop(); setTtsEnabled(!ttsEnabled); }}
+          className={`p-2 rounded-full transition-all ${
+            !ttsSupported ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
+              : ttsEnabled ? 'bg-violet-900/40 text-violet-400'
+              : 'bg-slate-800 text-slate-500'
           }`}
-          title={!ttsSupported ? 'Tu navegador no soporta sintesis de voz' : ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
+          title={ttsEnabled ? 'Silenciar voz' : 'Activar voz'}
         >
-          {ttsEnabled ? <Volume2 size={16} /> : <VolumeX size={16} />}
+          {ttsEnabled ? <Volume2 size={15} /> : <VolumeX size={15} />}
         </button>
-        <div className={`flex items-center gap-1 px-2 py-1 rounded-full text-[10px] ${
+        <div className={`hidden sm:flex items-center gap-1 px-2 py-1 rounded-full text-[10px] ${
           isOnline ? 'bg-emerald-900/40 text-emerald-400' : 'bg-red-900/40 text-red-400'
         }`}>
-          {isOnline ? <Wifi size={12} /> : <WifiOff size={12} />}
+          {isOnline ? <Wifi size={11} /> : <WifiOff size={11} />}
           {isOnline ? 'Online' : 'Offline'}
         </div>
-      </div>
+      </header>
 
       {/* Bug N3 fix: badge "nueva sesión" cuando reseteamos por gap temporal
           o por botón explícito. Sin esto el operador no entendería por qué su
@@ -2917,56 +3004,143 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         isPro={getCurrentTier() === 'pro'}
       />
 
-      {/* Input */}
-      <div className="p-4 border-t border-slate-800 bg-slate-900/80 shrink-0">
-        <form onSubmit={handleTextSubmit} className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={handleVoiceRecord}
-            className={`shrink-0 w-12 h-12 rounded-full flex items-center justify-center transition-colors ${
-              state === STATE_RECORDING
-                ? 'bg-red-600 animate-pulse'
-                : 'bg-violet-700 hover:bg-violet-600'
-            }`}
-          >
-            {state === STATE_RECORDING ? (
-              <MicOff size={20} className="text-white" />
-            ) : (
-              <Mic size={20} className="text-white" />
-            )}
-          </button>
+      {/* ── Compositor pill — paridad visual con AgentHero (2026-06-08) ── */}
+      <div className="px-3 pb-3 pt-2 border-t border-slate-800 bg-slate-900/70 backdrop-blur-md shrink-0">
 
-          <input
-            type="text"
+        {/* Preview de foto adjunta inline */}
+        {agentAttachment && (
+          <div className="flex items-center gap-2 mb-2 px-1">
+            <img
+              src={agentAttachment.previewUrl}
+              alt="Foto adjunta"
+              className="w-14 h-14 rounded-lg object-cover border border-slate-700"
+            />
+            <p className="text-xs text-slate-400 flex-1 leading-snug">
+              📷 Foto lista — añade una nota opcional
+            </p>
+            <button
+              type="button"
+              onClick={clearAgentAttachment}
+              className="p-1.5 rounded-full bg-slate-700 hover:bg-slate-600 text-slate-300"
+              aria-label="Quitar foto"
+            >
+              <X size={13} />
+            </button>
+          </div>
+        )}
+        {agentPickError && (
+          <p className="text-xs text-red-400 mb-2 px-1">{agentPickError}</p>
+        )}
+
+        {/* Pill */}
+        <div
+          className="rounded-2xl border bg-slate-800/80 overflow-hidden"
+          style={{ borderColor: 'rgba(100,116,139,0.4)' }}
+        >
+          {/* Fila 1: textarea */}
+          <textarea
+            rows={1}
             value={inputText}
-            onChange={(e) => setInputText(e.target.value)}
+            onChange={(e) => {
+              setInputText(e.target.value);
+              // auto-grow hasta ~5 líneas
+              e.target.style.height = 'auto';
+              e.target.style.height = `${Math.min(e.target.scrollHeight, 140)}px`;
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleAgentSend();
+              }
+            }}
             placeholder={
               queuePending.length >= 1
-                ? 'Espera — ya hay una en cola'
+                ? 'Espera — ya hay una en cola…'
                 : queueProcessing
-                  ? 'Adelanta otra pregunta (cola: 1 más)'
-                  : activePlaceholder
+                  ? 'Adelanta otra pregunta (máx 1 en cola)'
+                  : agentAttachment
+                    ? 'Añade una nota a tu foto (opcional)…'
+                    : activePlaceholder
             }
             disabled={state === STATE_RECORDING || queuePending.length >= 1}
             data-testid="agent-input"
-            className="flex-1 px-4 py-3 rounded-full bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:outline-none focus:border-violet-500/50 disabled:opacity-50"
+            className="w-full bg-transparent resize-none px-4 py-3 text-sm text-white placeholder-slate-500 focus:outline-none leading-snug disabled:opacity-50"
+            style={{ minHeight: '44px', maxHeight: '140px' }}
           />
 
-          <button
-            type="submit"
-            aria-label="Enviar"
-            disabled={
-              !inputText.trim() ||
-              state === STATE_RECORDING ||
-              queuePending.length >= 1
-            }
-            data-testid="agent-submit"
-            className="shrink-0 w-12 h-12 rounded-full bg-emerald-600 hover:bg-emerald-500 disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center transition-colors"
-          >
-            <Send size={18} className="text-white" />
-          </button>
-        </form>
+          {/* Fila 2: botones */}
+          <div className="flex items-center gap-1.5 px-2 pb-2">
+            {/* Micrófono */}
+            <button
+              type="button"
+              onClick={handleVoiceRecord}
+              disabled={queuePending.length >= 1}
+              aria-label={state === STATE_RECORDING ? 'Detener y enviar audio' : 'Grabar audio'}
+              className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${
+                state === STATE_RECORDING
+                  ? 'bg-red-600 text-white animate-pulse'
+                  : 'bg-slate-700 text-slate-300 hover:bg-violet-700/60 hover:text-violet-200'
+              }`}
+            >
+              {state === STATE_RECORDING
+                ? <Square size={15} strokeWidth={2.5} />
+                : <Mic size={17} strokeWidth={2} />}
+            </button>
 
+            {/* Cámara / foto (igual que AgentHero: sin `capture`, abre galería+cámara) */}
+            <button
+              type="button"
+              onClick={() => cameraInputAgentRef.current?.click()}
+              disabled={state === STATE_RECORDING || queuePending.length >= 1}
+              aria-label="Tomar o elegir foto"
+              className="w-10 h-10 rounded-full flex items-center justify-center bg-slate-700 text-slate-300 hover:bg-emerald-700/50 hover:text-emerald-200 transition-all disabled:opacity-40"
+            >
+              <Camera size={17} strokeWidth={2} />
+            </button>
+
+            <div className="flex-1" />
+
+            {/* Enviar — botón Colibrí 3D (misma lógica que AgentHero) */}
+            <button
+              type="button"
+              onClick={handleAgentSend}
+              disabled={
+                (!inputText.trim() && !agentAttachment) ||
+                state === STATE_RECORDING ||
+                queuePending.length >= 1
+              }
+              data-testid="agent-submit"
+              aria-label="Enviar al agente"
+              className="w-11 h-11 rounded-full flex items-center justify-center transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              style={{
+                background:
+                  (!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1
+                    ? 'rgba(51,65,85,0.8)'
+                    : 'linear-gradient(135deg, #10b981 0%, #0891b2 100%)',
+                boxShadow:
+                  (!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1
+                    ? 'none'
+                    : '0 0 16px rgba(16,185,129,0.45)',
+              }}
+            >
+              <ChagraAgentAvatarColibri3D
+                size={34}
+                state={state === STATE_THINKING ? 'thinking' : 'idle'}
+              />
+            </button>
+          </div>
+        </div>
+
+        {/* Input oculto de foto */}
+        <input
+          ref={cameraInputAgentRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+          onChange={handleAgentPhotoPick}
+        />
         {state === STATE_RECORDING && (
           <p className="text-center text-xs text-red-400 mt-2 animate-pulse">
             Grabando... {Math.floor(durationMs / 1000)}s

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -2775,20 +2775,20 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         <button
           type="button"
           onClick={onBack}
-          className="p-2.5 rounded-full bg-slate-800 hover:bg-slate-700 active:scale-95 transition-all"
+          className="p-3 rounded-full bg-slate-800 hover:bg-slate-700 active:scale-95 transition-all min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
           aria-label="Volver"
         >
-          <ArrowLeft size={18} className="text-slate-300" />
+          <ArrowLeft size={20} className="text-slate-300" />
         </button>
         {/* Home */}
         <button
           type="button"
           onClick={() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'dashboard' }))}
-          className="p-2.5 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:scale-95 transition-all text-emerald-400"
+          className="p-3 rounded-full bg-slate-800 hover:bg-emerald-700/40 hover:text-emerald-200 active:bg-emerald-700/60 transition-all text-emerald-400 min-h-[44px] min-w-[44px] flex items-center justify-center cursor-pointer"
           aria-label="Volver al inicio"
           title="Inicio"
         >
-          <Home size={18} />
+          <Home size={20} />
         </button>
         {/* Avatar + título */}
         <ChagraAgentAvatarColibriPhoto

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -24,7 +24,7 @@ import { isAnalyzableImageAttachment, buildAttachmentRejection } from '../../ser
 // B1 (2026-06-02): animación de ENTRADA al agente. El home anima el envío, pero
 // el cambio de pantalla era un corte seco ("casi no se nota"). El contenedor
 // raíz entra con un fade+rise deliberado (~460ms), respetando reduced-motion.
-import { AGENT_ENTRANCE_CSS, agentEntranceClass } from './agentEntrance';
+import { AGENT_ENTRANCE_CSS, AGENT_COMPOSITOR_CSS, agentEntranceClass } from './agentEntrance';
 import {
   addTurn,
   getFullHistory,
@@ -103,11 +103,9 @@ import SuggestedActions from './SuggestedActions';
 import ActionConfirmModal from '../ActionConfirmModal';
 import FeedbackConsentModal from '../FeedbackConsentModal';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
-import ChagraAgentAvatarColibri3D from '../ChagraAgentAvatarColibri3D';
 import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
 import QuickChipsBar from '../QuickChipsBar';
 import ChipsToolbar from '../ChipsToolbar';
-import AgentDemoExample from '../AgentDemoExample';
 import { captureAndCompress } from '../../services/photoService';
 import { agentSounds } from '../../services/agentSoundService';
 import usePrefsStore from '../../store/usePrefsStore';
@@ -204,11 +202,6 @@ export default function AgentScreen({ onBack, initialContext }) {
   // Toast de rechazo de la 3ra pregunta. Auto-dismiss a 4s para no
   // bloquear el input visualmente.
   const [queueRejectedToast, setQueueRejectedToast] = useState('');
-  // UX-4 (#285): demo predefinida del agente para operadores que abren la
-  // pantalla por primera vez (sin historial). Toggle local — NO se persiste
-  // ni se inyecta al messages real. Aparece junto a QuickChipsBar cuando
-  // chat está vacío e idle.
-  const [showAgentDemo, setShowAgentDemo] = useState(false);
   // 2026-05-28 UX: cuando el operador llega al agente desde una notificación
   // climática (NotificationsBell), recibimos `initialContext` con prompt
   // pre-cargado + cita de la entidad emisora (IDEAM/NOAA/CIIFEN/Open-Meteo).
@@ -227,6 +220,10 @@ export default function AgentScreen({ onBack, initialContext }) {
   // input también cambia para guiar al campesino sobre qué escribir. Es un
   // toggle: tocar el mismo chip lo desactiva (vuelve al routing NLU normal).
   const [activeIntent, setActiveIntent] = useState(null);
+  // Hoja de capacidades (paridad AgentHero Ⓐ).
+  const [sheetOpen, setSheetOpen] = useState(false);
+  // Fase del compositor para la animación shimmer/lift al enviar.
+  const [composerPhase, setComposerPhase] = useState('idle'); // 'idle' | 'sending'
   // Deep Research (A6/A7): refs para los AbortControllers de los jobs en vuelo.
   // Guardamos en un Map (msgId → AbortController) para poder cancelar jobs
   // individuales. Al desmontar el componente cancelamos todos.
@@ -2515,6 +2512,9 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
 
   const handleAgentSend = async () => {
     if (state === STATE_RECORDING) return;
+    // Shimmer/lift animation al enviar (paridad AgentHero).
+    setComposerPhase('sending');
+    setTimeout(() => setComposerPhase('idle'), 560);
     if (agentAttachment) {
       // Foto inline: armar burbuja + correr visión + handleSubmit
       const item = {
@@ -2765,9 +2765,11 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
     : 'Escribe tu pregunta...';
 
   return (
-    <div className={`h-[100dvh] flex flex-col bg-slate-950/95 overflow-hidden ${entranceClassRef.current}`}>
+    <div className={`h-[100dvh] flex flex-col overflow-hidden relative text-white ${entranceClassRef.current}`}>
+      {/* Scrim semitransparente: deja ver --app-bg-image del body */}
+      <div className="absolute inset-0 bg-slate-950/82 backdrop-blur-sm pointer-events-none" aria-hidden="true" />
       {/* B1: animación de entrada (fade+rise). Respeta prefers-reduced-motion. */}
-      <style>{AGENT_ENTRANCE_CSS}</style>
+      <style>{AGENT_ENTRANCE_CSS}{AGENT_COMPOSITOR_CSS}</style>
 
       {/* ── Header estilo ScreenShell (2026-06-08): scrim + blur + acciones globales ── */}
       <header className="px-4 py-3 flex items-center gap-2 border-b border-slate-800 bg-slate-900/50 backdrop-blur-md shrink-0">
@@ -2818,7 +2820,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           type="button"
           onClick={handleNewConversation}
           disabled={state !== STATE_IDLE || messages.length === 0}
-          className={`p-2 rounded-full transition-all ${
+          className={`p-2.5 rounded-full min-h-[44px] min-w-[44px] flex items-center justify-center transition-all ${
             state !== STATE_IDLE || messages.length === 0
               ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
               : 'bg-slate-800 text-slate-300 hover:bg-slate-700 active:scale-95'
@@ -2833,7 +2835,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           type="button"
           disabled={!ttsSupported}
           onClick={() => { if (ttsEnabled) stop(); setTtsEnabled(!ttsEnabled); }}
-          className={`p-2 rounded-full transition-all ${
+          className={`p-2.5 rounded-full min-h-[44px] min-w-[44px] flex items-center justify-center transition-all ${
             !ttsSupported ? 'bg-slate-800 text-slate-600 cursor-not-allowed'
               : ttsEnabled ? 'bg-violet-900/40 text-violet-400'
               : 'bg-slate-800 text-slate-500'
@@ -2918,26 +2920,6 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         <QuickChipsBar onSelect={handleSuggestion} />
       )}
 
-      {/* UX-4 (#285): botón "Ver ejemplo" para operadores nuevos sin
-          historial. Monta una demo simulada (mensaje user + respuesta
-          predefinida con delay 1s) sin llamar al LLM — cero costo, cero
-          alucinación. Solo en pantalla nueva e idle, alineado con la
-          ventana donde QuickChipsBar también vive. */}
-      {state === STATE_IDLE && messages.length === 0 && !showAgentDemo && (
-        <div className="px-4 pb-2 pt-1 bg-slate-900/40">
-          <button
-            type="button"
-            onClick={() => setShowAgentDemo(true)}
-            data-testid="agent-demo-trigger"
-            className="w-full px-3 py-2 rounded-lg bg-slate-800/60 hover:bg-slate-700/70 active:scale-[0.99] border border-slate-700/50 text-xs text-slate-300 transition-all"
-          >
-            Ver ejemplo (sin foto)
-          </button>
-        </div>
-      )}
-      {state === STATE_IDLE && messages.length === 0 && showAgentDemo && (
-        <AgentDemoExample onClose={() => setShowAgentDemo(false)} />
-      )}
 
       {/* 2026-05-28 UX: banner de contexto de alerta climática. Aparece
           cuando el operador llega desde una notificación con prompt
@@ -2991,21 +2973,21 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
         </div>
       )}
 
-      {/* CHIPS DE MODO (A4/B4): "caja de herramientas" estilo Gemini, fila
-          scrollable JUSTO sobre el input. Persistente durante toda la
-          conversación. Tocar un chip fuerza la intención del próximo submit y
-          rutea directo al tool (saltando el NLU, A3). El chip 📷 foto solo
-          aparece si hay imagen adjunta. */}
-      <ChipsToolbar
-        onSelectIntent={handleChipSelect}
-        activeIntent={activeIntent}
-        hasAttachment={false}
-        disabled={state === STATE_RECORDING}
-        isPro={getCurrentTier() === 'pro'}
-      />
+      {/* ── Chips (modo) — fila scrollable unificada.
+          Oculta en pantalla vacía donde QuickChipsBar ya muestra ejemplos
+          (issue #5 duplicación resuelta 2026-06-08). ── */}
+      {(state !== STATE_IDLE || messages.length > 0) && (
+        <ChipsToolbar
+          onSelectIntent={handleChipSelect}
+          activeIntent={activeIntent}
+          hasAttachment={false}
+          disabled={state === STATE_RECORDING}
+          isPro={getCurrentTier() === 'pro'}
+        />
+      )}
 
-      {/* ── Compositor pill — paridad visual con AgentHero (2026-06-08) ── */}
-      <div className="px-3 pb-3 pt-2 border-t border-slate-800 bg-slate-900/70 backdrop-blur-md shrink-0">
+      {/* ── Compositor pill — paridad completa AgentHero (2026-06-08) ── */}
+      <div className="relative z-10 px-3 pb-[calc(env(safe-area-inset-bottom,0px)+8px)] pt-2 border-t border-slate-800/60 bg-slate-900/70 backdrop-blur-md shrink-0">
 
         {/* Preview de foto adjunta inline */}
         {agentAttachment && (
@@ -3032,75 +3014,98 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           <p className="text-xs text-red-400 mb-2 px-1">{agentPickError}</p>
         )}
 
-        {/* Pill */}
+        {/* Pill — unified with AgentHero (as-bar CSS tokens) */}
         <div
-          className="rounded-2xl border bg-slate-800/80 overflow-hidden"
-          style={{ borderColor: 'rgba(100,116,139,0.4)' }}
+          className={[
+            'as-bar',
+            state === STATE_RECORDING ? 'is-recording' : '',
+            composerPhase === 'sending' ? 'as-shimmer as-sending' : '',
+          ].join(' ')}
         >
-          {/* Fila 1: textarea */}
-          <textarea
-            rows={1}
-            value={inputText}
-            onChange={(e) => {
-              setInputText(e.target.value);
-              // auto-grow hasta ~5 líneas
-              e.target.style.height = 'auto';
-              e.target.style.height = `${Math.min(e.target.scrollHeight, 140)}px`;
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                handleAgentSend();
+          {/* Fila 1: textarea o waveform de grabación */}
+          {state === STATE_RECORDING ? (
+            <div className="flex items-center gap-3 px-3 py-3 min-h-[52px]">
+              <span className="relative flex h-3 w-3 shrink-0">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-rose-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-3 w-3 bg-rose-500" />
+              </span>
+              <span className="flex-1 text-sm text-rose-400 font-medium tabular-nums">
+                Grabando… {Math.floor(durationMs / 1000)}s
+              </span>
+            </div>
+          ) : (
+            <textarea
+              rows={1}
+              value={inputText}
+              onChange={(e) => {
+                setInputText(e.target.value);
+                e.target.style.height = 'auto';
+                e.target.style.height = `${Math.min(e.target.scrollHeight, 140)}px`;
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleAgentSend();
+                }
+              }}
+              placeholder={
+                queuePending.length >= 1
+                  ? 'Espera — ya hay una en cola…'
+                  : queueProcessing
+                    ? 'Adelanta otra pregunta (máx 1 en cola)'
+                    : agentAttachment
+                      ? 'Añade una nota a tu foto (opcional)…'
+                      : activePlaceholder
               }
-            }}
-            placeholder={
-              queuePending.length >= 1
-                ? 'Espera — ya hay una en cola…'
-                : queueProcessing
-                  ? 'Adelanta otra pregunta (máx 1 en cola)'
-                  : agentAttachment
-                    ? 'Añade una nota a tu foto (opcional)…'
-                    : activePlaceholder
-            }
-            disabled={state === STATE_RECORDING || queuePending.length >= 1}
-            data-testid="agent-input"
-            className="w-full bg-transparent resize-none px-4 py-3 text-sm text-white placeholder-slate-500 focus:outline-none leading-snug disabled:opacity-50"
-            style={{ minHeight: '44px', maxHeight: '140px' }}
-          />
+              disabled={queuePending.length >= 1}
+              data-testid="agent-input"
+              className="w-full bg-transparent resize-none px-3 py-3 text-sm text-white placeholder-slate-500 focus:outline-none leading-snug"
+              style={{ minHeight: '44px', maxHeight: '140px' }}
+            />
+          )}
 
-          {/* Fila 2: botones */}
-          <div className="flex items-center gap-1.5 px-2 pb-2">
-            {/* Micrófono */}
+          {/* Fila 2: Ⓐ | 📷 | spacer | 🎤 | Enviar */}
+          <div className="flex items-center gap-2 px-1 pb-1 pt-0.5">
+            {/* Botón Ⓐ — abre hoja de capacidades */}
+            <button
+              type="button"
+              onClick={() => setSheetOpen((o) => !o)}
+              disabled={state === STATE_RECORDING}
+              aria-label="Ver todo lo que puede hacer Chagra"
+              aria-expanded={sheetOpen}
+              className={['as-iconbtn as-tool', sheetOpen ? 'is-open' : ''].join(' ')}
+            >
+              <Sparkles size={18} strokeWidth={2} aria-hidden="true" />
+            </button>
+
+            {/* Cámara — sin `capture`, abre galería+cámara igual que AgentHero */}
+            <button
+              type="button"
+              onClick={() => cameraInputAgentRef.current?.click()}
+              disabled={state === STATE_RECORDING || queuePending.length >= 1}
+              aria-label="Tomar o elegir foto"
+              className="as-iconbtn"
+            >
+              <Camera size={19} strokeWidth={2} aria-hidden="true" />
+            </button>
+
+            <div className="flex-1" />
+
+            {/* Micrófono (toggle) */}
             <button
               type="button"
               onClick={handleVoiceRecord}
               disabled={queuePending.length >= 1}
               aria-label={state === STATE_RECORDING ? 'Detener y enviar audio' : 'Grabar audio'}
-              className={`w-10 h-10 rounded-full flex items-center justify-center transition-all ${
-                state === STATE_RECORDING
-                  ? 'bg-red-600 text-white animate-pulse'
-                  : 'bg-slate-700 text-slate-300 hover:bg-violet-700/60 hover:text-violet-200'
-              }`}
+              aria-pressed={state === STATE_RECORDING}
+              className={['as-iconbtn', state === STATE_RECORDING ? 'as-mic-on' : ''].join(' ')}
             >
               {state === STATE_RECORDING
                 ? <Square size={15} strokeWidth={2.5} />
                 : <Mic size={17} strokeWidth={2} />}
             </button>
 
-            {/* Cámara / foto (igual que AgentHero: sin `capture`, abre galería+cámara) */}
-            <button
-              type="button"
-              onClick={() => cameraInputAgentRef.current?.click()}
-              disabled={state === STATE_RECORDING || queuePending.length >= 1}
-              aria-label="Tomar o elegir foto"
-              className="w-10 h-10 rounded-full flex items-center justify-center bg-slate-700 text-slate-300 hover:bg-emerald-700/50 hover:text-emerald-200 transition-all disabled:opacity-40"
-            >
-              <Camera size={17} strokeWidth={2} />
-            </button>
-
-            <div className="flex-1" />
-
-            {/* Enviar — botón Colibrí 3D (misma lógica que AgentHero) */}
+            {/* Enviar — ChagraAgentAvatar idéntico al Home */}
             <button
               type="button"
               onClick={handleAgentSend}
@@ -3111,25 +3116,33 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
               }
               data-testid="agent-submit"
               aria-label="Enviar al agente"
-              className="w-11 h-11 rounded-full flex items-center justify-center transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+              className="as-send"
               style={{
                 background:
                   (!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1
                     ? 'rgba(51,65,85,0.8)'
-                    : 'linear-gradient(135deg, #10b981 0%, #0891b2 100%)',
+                    : 'linear-gradient(135deg,#10b981 0%,#0891b2 100%)',
                 boxShadow:
                   (!inputText.trim() && !agentAttachment) || state === STATE_RECORDING || queuePending.length >= 1
                     ? 'none'
-                    : '0 0 16px rgba(16,185,129,0.45)',
+                    : '0 0 18px rgba(16,185,129,0.5)',
               }}
             >
-              <ChagraAgentAvatarColibri3D
-                size={34}
+              <ChagraAgentAvatar
+                size={38}
                 state={state === STATE_THINKING ? 'thinking' : 'idle'}
+                ariaLabel="Enviar al agente"
               />
             </button>
           </div>
         </div>
+
+        {/* Hint educativo bajo el pill */}
+        {state !== STATE_RECORDING && !agentAttachment && (
+          <p className="mt-1 text-center text-[11px] text-slate-500 leading-tight">
+            Toca <b className="text-emerald-400">✦</b> para ver todo lo que sé hacer
+          </p>
+        )}
 
         {/* Input oculto de foto */}
         <input
@@ -3141,11 +3154,7 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
           tabIndex={-1}
           onChange={handleAgentPhotoPick}
         />
-        {state === STATE_RECORDING && (
-          <p className="text-center text-xs text-red-400 mt-2 animate-pulse">
-            Grabando... {Math.floor(durationMs / 1000)}s
-          </p>
-        )}
+
 
         {state === STATE_THINKING && (
           <div className="flex flex-col items-center gap-2 mt-2">
@@ -3253,6 +3262,48 @@ Usa esta referencia para informar tu respuesta, pero RESPONDE SOLO a lo que el u
       </div>
 
       <div ref={chatEndRef} />
+
+      {/* Hoja de capacidades (Ⓐ) — misma UX que AgentHero */}
+      {sheetOpen && (
+        <>
+          <div className="as-sheet-scrim" onClick={() => setSheetOpen(false)} aria-hidden="true" />
+          <section
+            className="as-sheet"
+            role="dialog"
+            aria-modal
+            aria-label="Capacidades de Chagra"
+          >
+            <div className="as-sheet-grab" aria-hidden="true" />
+            <div className="px-5 pb-2 pt-1 text-center">
+              <p className="text-lg font-bold text-white">¿En qué te ayudo?</p>
+              <p className="text-sm text-slate-400 mt-1">Toca una opción para empezar. Toda respuesta viene con su fuente.</p>
+            </div>
+            <div className="px-4 pb-4 overflow-y-auto flex flex-col gap-3">
+              {CHIP_DEFS.map((chip) => (
+                <button
+                  key={chip.intent}
+                  type="button"
+                  className="as-cap"
+                  onClick={() => {
+                    handleChipSelect(chip.intent);
+                    setSheetOpen(false);
+                  }}
+                >
+                  <span className="as-cap-ico" aria-hidden="true">{chip.emoji}</span>
+                  <span className="flex-1 min-w-0 text-left">
+                    <span className="font-bold text-white block">{chip.label}</span>
+                    <span className="text-sm text-slate-400 block mt-0.5">{chip.placeholder}</span>
+                  </span>
+                  <span className="text-emerald-400 text-lg self-center" aria-hidden="true">›</span>
+                </button>
+              ))}
+            </div>
+            <p className="px-5 pb-5 text-center text-xs text-slate-500">
+              Chagra responde con información de <b className="text-emerald-400">AGROSAVIA</b>, <b className="text-emerald-400">ICA</b> e <b className="text-emerald-400">IDEAM</b>.
+            </p>
+          </section>
+        </>
+      )}
 
       {/* Action Confirmation Modal — alimentado por actionExecutor gate callback (057.4) */}
       <ActionConfirmModal

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -49,6 +49,113 @@ export const AGENT_ENTRANCE_CSS = `
 `;
 
 /**
+ * CSS del compositor multimodal del AgentScreen. Idéntico a los tokens de
+ * AgentHero para garantizar paridad visual completa (2026-06-08).
+ */
+export const AGENT_COMPOSITOR_CSS = `
+  .as-bar {
+    display: flex; align-items: center; gap: 8px;
+    background: rgba(30,41,59,0.85); border: 1px solid rgba(100,116,139,0.4);
+    border-radius: 20px; padding: 7px 8px;
+    box-shadow: 0 10px 30px -12px rgba(0,0,0,0.5);
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
+    position: relative; overflow: hidden;
+    flex-direction: column; align-items: stretch;
+  }
+  .as-bar.is-recording { border-color: rgba(244,63,94,0.6); }
+  .as-bar:focus-within {
+    border-color: rgba(16,185,129,0.55);
+    box-shadow: 0 10px 30px -12px rgba(0,0,0,0.5), 0 0 0 3px rgba(16,185,129,0.12);
+  }
+  .as-iconbtn {
+    width: 44px; height: 44px; flex: none; border-radius: 50%;
+    background: rgba(30,41,59,0.9); border: 1px solid rgba(100,116,139,0.4);
+    display: flex; align-items: center; justify-content: center;
+    color: rgb(148,163,184); cursor: pointer; position: relative;
+    transition: transform 0.16s cubic-bezier(0.22,0.61,0.36,1),
+                background 0.25s ease, border-color 0.25s ease, color 0.2s ease;
+  }
+  .as-iconbtn:hover { color: #fff; border-color: rgba(16,185,129,0.5); }
+  .as-iconbtn:active { transform: scale(0.9); }
+  .as-iconbtn:disabled { opacity: 0.4; cursor: not-allowed; }
+  .as-tool { animation: as-pulse-ring 3.6s cubic-bezier(.22,.61,.36,1) infinite; }
+  .as-tool.is-open {
+    background: rgb(16,185,129); border-color: rgb(16,185,129); animation: none;
+  }
+  @keyframes as-pulse-ring {
+    0%   { box-shadow: 0 0 0 0 rgba(16,185,129,0.45); }
+    70%  { box-shadow: 0 0 0 12px rgba(16,185,129,0); }
+    100% { box-shadow: 0 0 0 0 rgba(16,185,129,0); }
+  }
+  .as-mic-on {
+    background: rgb(244,63,94) !important; border-color: rgb(244,63,94) !important;
+    color: #fff !important; box-shadow: 0 4px 14px -4px rgba(244,63,94,0.5);
+  }
+  .as-send {
+    width: 46px; height: 46px; flex: none; border: none; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center; cursor: pointer;
+    overflow: hidden; padding: 0;
+    transition: opacity 0.25s ease, box-shadow 0.25s ease;
+  }
+  .as-send:disabled { opacity: 0.35; cursor: not-allowed; }
+  @keyframes as-send-shimmer {
+    0%   { transform: translateX(-130%); opacity: 0; }
+    25%  { opacity: 1; }
+    70%  { opacity: 1; }
+    100% { transform: translateX(130%); opacity: 0; }
+  }
+  @keyframes as-send-lift {
+    0%   { transform: translateY(0) scale(1); opacity: 1; }
+    35%  { transform: translateY(-4px) scale(1.012); opacity: 1; }
+    100% { transform: translateY(-16px) scale(0.978); opacity: 0.82; }
+  }
+  .as-shimmer::after {
+    content: ''; position: absolute; inset: 0; border-radius: inherit;
+    background: linear-gradient(100deg, transparent 12%, rgba(16,185,129,0.55) 50%, transparent 88%);
+    animation: as-send-shimmer 0.52s cubic-bezier(0.22,0.61,0.36,1) forwards;
+    pointer-events: none;
+  }
+  .as-sending { animation: as-send-lift 0.52s cubic-bezier(0.22,0.61,0.36,1) forwards; }
+  /* Hoja de capacidades */
+  .as-sheet-scrim {
+    position: fixed; inset: 0; z-index: 50;
+    background: rgba(10,8,4,0.5);
+    transition: opacity 0.3s ease;
+  }
+  .as-sheet {
+    position: fixed; left: 0; right: 0; bottom: 0; z-index: 51;
+    max-width: 640px; margin: 0 auto;
+    background: rgb(15,23,42);
+    border-radius: 26px 26px 0 0;
+    box-shadow: 0 -16px 40px -16px rgba(0,0,0,0.55);
+    border-top: 1px solid rgba(100,116,139,0.3);
+    transform: translateY(0); max-height: 84dvh;
+    display: flex; flex-direction: column;
+  }
+  .as-sheet-grab { width: 42px; height: 5px; background: rgba(100,116,139,0.4); border-radius: 5px; margin: 10px auto 4px; flex: none; }
+  .as-cap {
+    display: flex; align-items: flex-start; gap: 13px; width: 100%;
+    font: inherit; text-align: left;
+    background: rgba(30,41,59,0.6); border: 1px solid rgba(100,116,139,0.3);
+    border-radius: 18px; padding: 13px 14px; cursor: pointer;
+    transition: transform 0.16s cubic-bezier(0.22,0.61,0.36,1), background 0.18s ease;
+    box-shadow: 0 3px 10px -7px rgba(0,0,0,0.5);
+  }
+  .as-cap:active { transform: scale(0.98); }
+  .as-cap:hover { border-color: rgba(16,185,129,0.45); box-shadow: 0 0 18px -7px rgba(16,185,129,0.5); }
+  .as-cap-ico {
+    width: 46px; height: 46px; flex: none; border-radius: 13px;
+    display: flex; align-items: center; justify-content: center; font-size: 1.5rem;
+    background: rgba(16,185,129,0.12); border: 1px solid rgba(16,185,129,0.22);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .as-shimmer::after, .as-sending { animation: none !important; }
+    .as-tool { animation: none !important; }
+  }
+`;
+
+
+/**
  * ¿El usuario pidió reducir el movimiento? Tolerante a entornos sin matchMedia
  * (SSR/tests): ante la duda, devuelve false (no reduce).
  *

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -152,13 +152,13 @@ export default function TopBar({ onNavigate, onLogout }) {
             {iconForTheme(theme)}
           </span>
           {/* Wordmark completo: visible también en móvil para no dejar el logo vacío. */}
-          <div className="flex min-w-0 max-w-[42vw] sm:max-w-none flex-col items-start">
+          <div className="flex flex-col items-start min-w-0 text-left ml-1">
             <span className="text-base font-bold leading-tight text-white">Chagra</span>
-            <span className="text-[10px] leading-tight text-emerald-300/90 font-semibold truncate max-w-full">
+            <span className="text-[10px] leading-tight text-emerald-300/90 font-semibold">
               su mano en el campo
             </span>
             {locationLabel && (
-              <span className="mt-0.5 max-w-full truncate rounded-full border border-emerald-400/20 bg-emerald-950/25 px-1.5 py-0.5 text-[10px] leading-tight text-emerald-200/95 font-medium">
+              <span className="mt-1 inline-block whitespace-normal break-words rounded-lg border border-emerald-400/20 bg-emerald-950/25 px-2 py-1 text-[10px] leading-snug text-emerald-200/95 font-medium max-w-[50vw]">
                 {locationLabel}
               </span>
             )}

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -527,7 +527,7 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-sun {
                     position: absolute;
                     top: 8%;
-                    left: 50%;
+                    left: 25%;
                     transform: translateX(-50%);
                     width: 240px;
                     height: 240px;

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -610,7 +610,8 @@ export default function AgentHero({ onNavigate }) {
                    sin data-theme) — la ocultamos en nature/minimalista. */
                 .agentport-bp { display: block; }
                 [data-theme] .agentport-bp { display: none; }
-                [data-theme="biopunk"] .agentport-bp { display: block; }
+                body:not([data-custom-bg]) [data-theme="biopunk"] .agentport-bp { display: block; }
+                :global(body[data-custom-bg]) .agentport-bp, body[data-custom-bg] .agentport-bp { display: none !important; }
 
                 /* base oscura con glow teal central + glow inferior (HYTA) */
                 .agentport-void {

--- a/tests/agent-anti-halluc.spec.js
+++ b/tests/agent-anti-halluc.spec.js
@@ -352,7 +352,7 @@ test.describe('AgentScreen — pipeline anti-halluc + queue UX (task #171)', () 
     await submit.click();
     await expect(input).toHaveAttribute(
       'placeholder',
-      'Espera — ya hay una en cola',
+      'Espera — ya hay una en cola…',
       { timeout: 5_000 }
     );
   });

--- a/tests/agent-anti-halluc.spec.js
+++ b/tests/agent-anti-halluc.spec.js
@@ -343,7 +343,7 @@ test.describe('AgentScreen — pipeline anti-halluc + queue UX (task #171)', () 
     await submit.click();
     await expect(input).toHaveAttribute(
       'placeholder',
-      'Adelanta otra pregunta (cola: 1 más)',
+      'Adelanta otra pregunta (máx 1 en cola)',
       { timeout: 5_000 }
     );
 


### PR DESCRIPTION
## Cambios

### Paridad visual AgentScreen → AgentHero (11 problemas resueltos)

**Ya implementado:**
- Fondo solido bg-slate-950/95 → scrim translucido con backdrop-blur (deja ver foto personalizada)
- Boton A con hoja de capacidades (sheet con CHIP_DEFS)
- Avatar de envio: Colibri3D → ChagraAgentAvatar (2D, identico al Home)
- Estado de grabacion: texto estatico → dot rojo pulsante + contador de segundos
- Shimmer/lift animation al enviar (composerPhase → 520ms)
- Hitbox botones TTS/RotateCcw: p-2 → p-2.5 min-h-11 min-w-11

**Adicional:**
- ChipsToolbar oculto en pantalla vacia (solo QuickChipsBar visible)
- Orphan cleanup: imports muertos eliminados (ChagraAgentAvatarColibri3D, AgentDemoExample, showAgentDemo)
- CSS del compositor extraido a AGENT_COMPOSITOR_CSS en agentEntrance.js

### Commits incluidos (4 locales sin publicar)
ea016f1 9022c0b f2977ee 31a827e

### Tests
62/62 passing, ESLint sin nuevos warnings, sin archivos eliminados