### PR TITLE
fix(agent): prevent analyzeFoliage hallucination for non-plant images

### DIFF
--- a/src/services/__tests__/agentOutboxPhoto.test.js
+++ b/src/services/__tests__/agentOutboxPhoto.test.js
@@ -58,7 +58,7 @@ describe('agentOutboxPhoto.buildVisionPrompt', () => {
 
   it('sin diagnóstico + con caption: prompt conversacional con caption', () => {
     const prompt = buildVisionPrompt(null, 'esta mata de tomate está rara');
-    expect(prompt).toBe('Te envié una foto de mi planta. esta mata de tomate está rara');
+    expect(prompt).toBe('Te envié una foto. esta mata de tomate está rara');
   });
 
   it('sin diagnóstico + sin caption: pide guía por descripción', () => {

--- a/src/services/__tests__/aiService.test.js
+++ b/src/services/__tests__/aiService.test.js
@@ -121,7 +121,7 @@ describe('aiService — buildDiagnosisPrompt (helper)', () => {
     expect(prompt).toContain('<CONTEXTO_CIENTÍFICO>');
     expect(prompt).toContain('agroecológico');
     expect(prompt).toMatch(/cit.*fuente/i);
-    expect(prompt).toContain('{"score": 0-100');
+    expect(prompt).toContain('{"isPlant": true/false, "score": 0-100');
   });
 });
 

--- a/src/services/agentOutboxPhoto.js
+++ b/src/services/agentOutboxPhoto.js
@@ -55,13 +55,13 @@ export function buildVisionPrompt(finding, caption = '') {
     const treat = finding.treatment_suggestion
       ? ` Sugerencia preliminar: ${finding.treatment_suggestion}.`
       : '';
-    return `Analicé una foto de mi planta. Hallazgos del diagnóstico visual: ${issues} (estado ${
+    return `Analicé una foto que enviaste. Hallazgos del diagnóstico visual: ${issues} (estado ${
       finding.score ?? 'n/d'
     }/100).${treat} ${cap || '¿Qué me recomiendas hacer?'}`.trim();
   }
   return cap
-    ? `Te envié una foto de mi planta. ${cap}`
-    : 'Te envié una foto de mi planta para que me ayudes a identificar qué tiene. No pude obtener un diagnóstico visual automático; guíame por descripción.';
+    ? `Te envié una foto. ${cap}`
+    : 'Te envié una foto para que me ayudes a identificar qué tiene. No pude obtener un diagnóstico visual automático; guíame por descripción.';
 }
 
 /**

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -39,7 +39,7 @@ const VISION_SPECIES_FALLBACK_2_MODEL = 'qwen2.5vl:7b';
 
 // Prompt base sin contexto RAG. Fallback usado cuando el corpus no cargó
 // o el retrieve no devolvió passages relevantes.
-const DIAGNOSIS_BASE_PROMPT = 'detect disease, nutrient deficiency, and overall plant health. Output JSON: {"score": 0-100, "issues": [], "treatment": ""}';
+const DIAGNOSIS_BASE_PROMPT = 'First, decide if this image contains a living plant. Output JSON: {"isPlant": true/false, "score": 0-100, "issues": [], "treatment": ""}. If isPlant is false, set score to 0, issues to [], and treatment to "".';
 
 // Query genérica para fallback cuando no conocemos la especie. Apunta a
 // passages del corpus que hablen de manejo agroecológico colombiano —
@@ -104,7 +104,7 @@ const buildDiagnosisPrompt = (ragContext) => {
     'arriba + lo que observas en la imagen para diagnosticar. Cita la fuente ' +
     'numérica (ej. "Fuente 1") cuando aplique. Si el contexto no aplica a lo ' +
     'que ves, ignóralo y diagnostica solo por la imagen. ' +
-    'Output JSON: {"score": 0-100, "issues": [], "treatment": ""}'
+    'Output JSON: {"isPlant": true/false, "score": 0-100, "issues": [], "treatment": ""}. If isPlant is false, set score to 0, issues to [], and treatment to "".'
   );
 };
 
@@ -226,6 +226,12 @@ const analyzeFoliageUncached = async (imageBlob, { onToken, signal, speciesSlug,
     if (!Array.isArray(parsed.issues)) parsed.issues = [];
     // Normalizar: PaliGemma usa "treatment", legacy usa "treatment_suggestion"
     parsed.treatment_suggestion = parsed.treatment_suggestion || parsed.treatment || '';
+
+    // Bug P0 (2026-06-08): para imágenes sin planta (toy, paisaje, etc.) el
+    // modelo alucina un diagnóstico completo. Si isPlant es false, devolvemos
+    // null para que el caller use el fallback "guíame por descripción".
+    // Legacy cache (isPlant undefined) se asume plant para no romper.
+    if (parsed.isPlant === false) return null;
 
     return parsed;
   } catch (err) {


### PR DESCRIPTION
## Problem

Bug P0: attaching a non-plant photo (toy, landscape, etc.) triggered analyzeFoliage to fabricate a full plant diagnosis (score, issues, treatment). buildVisionPrompt hardcoded 'Analicé una foto de mi planta' as fact, and the LLM generated harvest plans + log proposals — all from a photo with no plant.

## Fix

Three layers:

1. **DIAGNOSIS_BASE_PROMPT** — Added `isPlant` boolean to the vision model JSON output spec. The model must first decide if the image contains a living plant.

2. **analyzeFoliageUncached** — After parsing, if `parsed.isPlant === false`, return `null` so the caller falls back to the 'guíame por descripción' path. Legacy cache entries (no `isPlant`) pass through (backward compatible).

3. **buildVisionPrompt** — Softened 'de mi planta' to neutral phrasing ('una foto que enviaste' / 'una foto') so the prompt doesn't presume the image is the user's plant.

## Tests

```
Test Files  5 passed (5)
     Tests  202 passed (202)
```