### PR TITLE
fix(ci): add guatoc-ecohub to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,7 +47,7 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/guatoc-ecohub/Chagra/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: dependabot[bot],renovate[bot],github-actions[bot]
+          allowlist: dependabot[bot],renovate[bot],github-actions[bot],guatoc-ecohub
           custom-notsigned-prcomment: |
             Hola, gracias por tu PR a Chagra.
 


### PR DESCRIPTION
CLA Assistant v2.6.1 crashes with 'Cannot read properties of undefined' when PR commits are authored by org account (guatoc-ecohub). Adding the org account to the allowlist bypasses the CLA check for bot-authored commits, unblocking PR #1348 and future org-account PRs.

This needs to merge to main FIRST (before PR #1348) because `pull_request_target` runs the workflow from the target branch.