### PR TITLE
feat(ci): add dev and qa deploy workflows (#050)

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy Chagra PWA (DEV)
+
+on:
+  push:
+    branches: ['dev/*', 'feat/*', 'fix/*']
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+concurrency:
+  group: deploy-chagra-dev-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: [self-hosted, alpha]
+    timeout-minutes: 30
+    steps:
+      - name: Detect runner identity
+        run: |
+          if echo "$HOME" | grep -q claude-runner; then
+            echo "SKIP_DEPLOY=1" >> "$GITHUB_ENV"
+          fi
+
+      - if: env.SKIP_DEPLOY != '1'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Install dependencies
+        run: npm ci
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Build
+        run: npm run build
+        env:
+          VITE_FARMOS_URL: ""
+          VITE_FARMOS_CLIENT_ID: farm
+          VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
+          VITE_USE_SIDECAR_AGRO_MCP: "true"
+          VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Deploy to dev
+        run: |
+          set -e
+          TARGET=/mnt/fast/appdata/farmos-pwa-dev
+          if [ ! -d "$TARGET" ]; then
+            echo "Target $TARGET does not exist — run nixos-rebuild or mkdir first"
+            exit 1
+          fi
+          umask 022
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ "$TARGET/"
+          find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Verify deployment
+        run: |
+          TARGET=/mnt/fast/appdata/farmos-pwa-dev
+          test -f "$TARGET/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/index.html" | cut -d' ' -f1)
+          echo "DEV Deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Bump SW cache version (dev)
+        run: |
+          SW_FILE=/mnt/fast/appdata/farmos-pwa-dev/sw.js
+          if [ -f "$SW_FILE" ]; then
+            COMMIT_SHORT=$(git rev-parse --short HEAD)
+            sed -i -E "s/chagra-[0-9a-z]+/chagra-dev-${COMMIT_SHORT}/" "$SW_FILE"
+            echo "SW cache bumped to chagra-dev-${COMMIT_SHORT}"
+          fi

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -1,0 +1,84 @@
+name: Deploy Chagra PWA (QA)
+
+on:
+  push:
+    branches: [qa]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+concurrency:
+  group: deploy-chagra-qa
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: [self-hosted, alpha]
+    timeout-minutes: 30
+    steps:
+      - name: Detect runner identity
+        run: |
+          if echo "$HOME" | grep -q claude-runner; then
+            echo "SKIP_DEPLOY=1" >> "$GITHUB_ENV"
+          fi
+
+      - if: env.SKIP_DEPLOY != '1'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Install dependencies
+        run: npm ci
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Lint
+        run: |
+          set -o pipefail
+          if ! npm run lint -- --max-warnings 9999 2>&1 | tee /tmp/lint.log; then
+            grep -E "^\s+[0-9]+:[0-9]+\s+error" /tmp/lint.log | head -20 | while read -r line; do
+              echo "::error::qa-deploy lint: $line"
+            done
+            exit 1
+          fi
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Build
+        run: npm run build
+        env:
+          VITE_FARMOS_URL: ""
+          VITE_FARMOS_CLIENT_ID: farm
+          VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
+          VITE_USE_SIDECAR_AGRO_MCP: "true"
+          VITE_CHAGRA_MCP_TOKEN: ${{ secrets.VITE_CHAGRA_MCP_TOKEN }}
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Deploy to qa
+        run: |
+          set -e
+          TARGET=/mnt/fast/appdata/farmos-pwa-qa
+          if [ ! -d "$TARGET" ]; then
+            echo "Target $TARGET does not exist — run nixos-rebuild or mkdir first"
+            exit 1
+          fi
+          umask 022
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ "$TARGET/"
+          find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Verify deployment
+        run: |
+          TARGET=/mnt/fast/appdata/farmos-pwa-qa
+          test -f "$TARGET/index.html" || exit 1
+          HASH=$(sha256sum "$TARGET/index.html" | cut -d' ' -f1)
+          echo "QA Deploy OK: $(date -Iseconds) | index.html sha256: ${HASH:0:12}"
+
+      - if: env.SKIP_DEPLOY != '1'
+        name: Bump SW cache version (qa)
+        run: |
+          SW_FILE=/mnt/fast/appdata/farmos-pwa-qa/sw.js
+          if [ -f "$SW_FILE" ]; then
+            COMMIT_SHORT=$(git rev-parse --short HEAD)
+            sed -i -E "s/chagra-[0-9a-z]+/chagra-qa-${COMMIT_SHORT}/" "$SW_FILE"
+            echo "SW cache bumped to chagra-qa-${COMMIT_SHORT}"
+          fi


### PR DESCRIPTION
## Qué

Workflows de deploy para staging (dev) y pre-prod (qa), siguiendo el diseño de queue/050.

## Workflows

### dev-deploy.yml
- **Trigger**: push a ramas `dev/*`, `feat/*`, `fix/*`
- **Destino**: `/mnt/fast/appdata/farmos-pwa-dev/` → `chagra-dev.guatoc.co`
- **Pasos**: checkout → npm ci → build → rsync → verify → SW cache bump
- **Sin lint**: dev es rápido, los feature branches se mergean via PR con CI

### qa-deploy.yml
- **Trigger**: push a rama `qa`
- **Destino**: `/mnt/fast/appdata/farmos-pwa-qa/` → `qa-chagra.guatoc.co`
- **Pasos**: checkout → npm ci → lint (bloquea deploy si falla) → build → rsync → verify → SW cache bump

### deploy.yml (sin cambios)
- Sigue desplegando `main` a PROD como antes

## NixOS prerequisites (PENDIENTE — PR separado en guatoc-nixos)

El target `/mnt/fast/appdata/farmos-pwa-qa` **no existe aún** en alpha. Se necesita:

1. **vhost** `qa-chagra.guatoc.co` en `hosts/alpha/default.nix` (copiar estructura del vhost dev con root=`/mnt/fast/appdata/farmos-pwa-qa`)
2. **tmpfiles** rule: `d /mnt/fast/appdata/farmos-pwa-qa 02775 kortux chagra-deploy -`
3. **CORS origins**: agregar `qa-chagra.guatoc.co` en `modules/ai/ollama.nix` y `modules/ai/agro-mcp-sidecar.nix`
4. **Runner path**: agregar `/mnt/fast/appdata/farmos-pwa-qa` a `ReadWritePaths` en `modules/cicd-runner.nix`
5. **Backup**: agregar ruta en `modules/backup/restic-b2.nix`
6. **DNS**: agregar registro `qa-chagra.guatoc.co` si no existe

## Test
- YAML válido validado con js-yaml
- Build del repo no afectado (solo archivos .yml en .github/workflows/)

## Nota
El webhook server en alpha (puerto 9000) también despliega DEV en push a main — hay solapamiento con el GHA deploy.yml para prod. No se toca en este PR; requiere decisión del operador.