### PR TITLE
docs(contributing): add external reviewer onboarding + bug report template (#045/046)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: Reporta un bug o problema técnico (para contribuidores externos)
+title: "[Bug] <descripción corta>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por reportar. Antes de crear, busca si ya existe un issue similar.
+        Si es un problema de seguridad, usa el canal privado (Security Advisories).
+
+  - type: textarea
+    id: descripcion
+    attributes:
+      label: Descripción del bug
+      description: Qué ocurre, qué debería ocurrir.
+      placeholder: "Ej. Al hacer clic en 'Guardar', la pantalla se queda cargando y nunca confirma."
+    validations:
+      required: true
+
+  - type: textarea
+    id: pasos
+    attributes:
+      label: Pasos para reproducir
+      placeholder: |
+        1. Ir a '...'
+        2. Hacer clic en '...'
+        3. Ver error
+    validations:
+      required: true
+
+  - type: input
+    id: entorno
+    attributes:
+      label: Entorno
+      description: Navegador, dispositivo, versión de la app (visible en footer)
+      placeholder: "Ej. Chrome 125, Android 14, Pixel 7, Chagra v0.6.15"
+    validations:
+      required: true
+
+  - type: textarea
+    id: contexto
+    attributes:
+      label: Contexto adicional
+      description: Screenshots, video, console logs. Opcional.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,20 @@ Ver:
 - `src/core/bootstrap-oss.js` — registra módulos OSS en bootstrap.
 - `src/core/loadProModules.js` — carga dinámica de módulos opcionales vía env var.
 
+## Para revisores externos: cómo participar
+
+Valoramos contribuciones de la comunidad. Si eres nuevo en Chagra, este flujo guía tu primer aporte:
+
+1. **Encuentra un issue**: explora los issues abiertos con label `good-first-issue` o `help-wanted`. También puedes reportar bugs o sugerir features abriendo un issue nuevo usando la plantilla `claude-code-request.yml`.
+2. **Comenta que lo tomas**: así evitamos duplicación de trabajo. Un mantenedor asignará el issue y responderá dudas.
+3. **Lee el CLA**: toda contribución requiere firmar el CLA (`CLA.md`). Un comentario "I have read the CLA Document and I hereby sign the CLA" en tu primer PR basta.
+4. **Crea tu rama desde `origin/main`**: asegúrate de que tu fork esté actualizado antes de branchear.
+5. **Sigue el estilo del proyecto**: conventional commits, sin em dashes en texto UI, respeta las reglas anti-leak de infraestructura privada ($6).
+6. **Abre un Pull Request draft**: titúlalo con el prefijo del tipo de cambio (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`). Los checks de CI (CodeQL + Playwright E2E) correrán automáticamente.
+7. **Espera review**: un mantenedor revisará en máximo 5 días hábiles. Si pasa más tiempo sin respuesta, ping en el PR.
+
+**Criterios de merge**: ambos checks CI verdes, sin secretos leakados, CLA firmado, y aprobación de al menos un mantenedor.
+
 ## Reporte responsable de vulnerabilidades
 
 Si detectas un problema de seguridad, por favor no abras un issue público. Usa el canal privado de GitHub Security Advisories sobre este repositorio, o contacta al mantenedor directamente.


### PR DESCRIPTION
## Cambios

### CONTRIBUTING.md
- Nueva sección "Para revisores externos: cómo participar" (7 pasos)
- Criterios de merge claros para contribuyentes externos

### Nuevo: .github/ISSUE_TEMPLATE/bug-report.yml
- Template simple para bugs externos (no requiere CLA ni trigger de runner interno)
- Campos: descripción, pasos, entorno, contexto adicional

### Relacionado
- Chagra-strategy PR #109: queue KANBAN.md + move 045 to _done/ + INDEX.md update
- queue/pre 045: contrato prioridades, source field, priority_override
- queue/046: private reviewer mapping, bug report retention, storyboard demo