### PR TITLE
feat(core): unify capability contract + honest MCP errors

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -940,6 +940,26 @@ ${buildProfileContext(finca)}`;
     }
     if (!toolEvidence || !toolEvidence.tool || !toolEvidence.result) return '';
 
+    const result = toolEvidence.result;
+    // ToolError: el tool fue intentado pero falló (timeout, HTTP error,
+    // not allowed). El LLM debe saber que NO hay datos, en vez de asumir
+    // que el tool no se invocó y tratar de responder con su memoria.
+    if (result && typeof result === 'object' && result._error === true) {
+      const errorReason = result.reason || 'unknown';
+      const toolName = toolEvidence.tool;
+      return `
+=== ERROR DE CONSULTA: ${toolName} NO DISPONIBLE ===
+El tool '${toolName}' falló: ${errorReason}.
+
+INSTRUCCIÓN OBLIGATORIA — anti-alucinación por fallo de tool:
+1. NO inventes datos de catálogo ni del sidecar (no hay datos disponibles).
+2. NO uses tu memoria para suplir la información que el tool debía traer.
+3. Responde de forma honesta: "No pude consultar la información técnica necesaria.".
+4. Si puedes responder desde conocimiento general sin inventar datos concretos, hazlo, pero sé explícito: "Esto lo sé por conocimiento general, no por el catálogo Chagra."
+=== FIN ERROR ===
+`;
+    }
+
     // 2026-05-23 incidente test #4: usuario preguntó por "mareñongoño del
     // Tolima" (especie NO en catálogo). El tool devolvió {found:false,
     // hint:"..."} pero el modelo IGNORÓ el flag found:false y mapeó
@@ -949,7 +969,6 @@ ${buildProfileContext(finca)}`;
     //
     // Fix: detectar found:false en el frontend ANTES del LLM call y
     // formatear un bloque hyper-explícito que prohíbe el mapeo creativo.
-    const result = toolEvidence.result;
     const isNotFound =
       result &&
       typeof result === 'object' &&

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -7,6 +7,7 @@ import useAgentOutboxStore from '../../store/useAgentOutboxStore';
 import useAssetStore from '../../store/useAssetStore';
 import useAlertStore from '../../store/useAlertStore';
 import { agentSounds } from '../../services/agentSoundService';
+import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
 import { AGENT_HERO_CHIPS } from '../../data/exampleQuestions';
 import { useTheme } from '../../hooks/useTheme';
 import {
@@ -144,75 +145,19 @@ const QUICK_CHIPS = AGENT_HERO_CHIPS;
 /**
  * CAPACIDADES de Chagra para el menú Ⓐ (bottom-sheet .sheet del demo).
  *
- * Son las capacidades REALES de la app — derivadas de los chips del home
- * (AGENT_HERO_CHIPS), de lo que el agente SÍ sabe hacer (HelpAgentSection) y de
- * las tools del catálogo. Cada una declara su `route`:
- *   - kind 'ask'   → envía un prompt por la outbox real → AgentScreen (mismo
- *                    camino que escribir/enviar). Es lo que el demo simula.
- *   - kind 'nav'   → navega a una pantalla dedicada existente (voz, activos…).
- *   - kind 'photo' → abre el selector de foto del compositor (visión del agente).
- *
- * El operador pidió incluir explícitamente "agregar planta por voz o foto".
- * `tool` es la etiqueta técnica (visible en modo experto), igual que el demo.
+ * CAPABILITIES derivadas del manifiesto único (agentCapabilities.js).
+ * NO editar labels, tools o rutas acá — hacerlo en el manifiesto.
  */
-const CAPABILITIES = [
-    {
-        id: 'siembra', icon: '🌱',
-        title: '¿Qué siembro?',
-        desc: 'Qué sembrar según tu clima y tu altura.',
-        tool: 'get_species',
-        route: { kind: 'ask', prompt: '¿Qué puedo sembrar este mes en mi zona?' },
-    },
-    {
-        id: 'plaga', icon: '🐛',
-        title: 'Plaga',
-        desc: 'Controlar una plaga sin veneno.',
-        tool: 'get_pest_controllers',
-        route: { kind: 'ask', prompt: '¿Cómo controlo plagas sin químicos?' },
-    },
-    {
-        id: 'bio', icon: '🧪',
-        title: 'Biopreparado',
-        desc: 'Receta casera para fortalecer tu cultivo.',
-        tool: 'get_biopreparados',
-        route: { kind: 'ask', prompt: '¿Cómo hago un biopreparado para fortalecer mis matas?' },
-    },
-    {
-        id: 'foto', icon: '📷',
-        title: 'Agregar planta por foto',
-        desc: 'Tómale una foto y la identifico y registro.',
-        tool: 'vision_identify',
-        route: { kind: 'photo' },
-    },
-    {
-        id: 'voz', icon: '🎤',
-        title: 'Agregar planta por voz',
-        desc: 'Dime qué sembraste y lo registro en tu finca.',
-        tool: 'voice_capture',
-        route: { kind: 'nav', view: 'voz' },
-    },
-    {
-        id: 'clima', icon: '🌦️',
-        title: 'Clima',
-        desc: 'El clima de tu finca esta semana.',
-        tool: 'get_clima',
-        route: { kind: 'ask', prompt: 'Dame el reporte del clima de mi zona esta semana.' },
-    },
-    {
-        id: 'cal', icon: '📅',
-        title: 'Calendario',
-        desc: 'Cuándo sembrar y cuándo cosechar.',
-        tool: 'get_calendario',
-        route: { kind: 'ask', prompt: '¿Cuándo siembro y cuándo cosecho en mi zona?' },
-    },
-    {
-        id: 'plantas', icon: '🌿',
-        title: 'Mis plantas',
-        desc: 'Ver y manejar lo que tienes en la finca.',
-        tool: 'assets',
-        route: { kind: 'nav', view: 'activos' },
-    },
-];
+const CAPABILITIES = CAPABILITY_MANIFEST
+    .filter((e) => e.hero)
+    .map((e) => ({
+        id: e.id,
+        icon: e.icon,
+        title: e.label,
+        desc: e.desc,
+        tool: e.tool,
+        route: e.heroRoute,
+    }));
 
 function prefersReducedMotion() {
     return typeof window !== 'undefined' && window.matchMedia

--- a/src/services/__tests__/agentCapabilities.audit.test.js
+++ b/src/services/__tests__/agentCapabilities.audit.test.js
@@ -193,10 +193,17 @@ describe('agentCapabilities — fallo explícito corta antes del LLM', () => {
     expect(plan.stubMessage).toBeNull();
   });
 
-  it('callTool con tool no permitido retorna null (no fabrica)', async () => {
+  it('callTool con tool no permitido retorna _error honesto (no fabrica datos)', async () => {
     const { callTool } = await import('../sidecarClient.js');
     const result = await callTool('sell', {});
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result._error).toBe(true);
+    expect(result.reason).toBe('not_allowed');
+    expect(result.tool).toBe('sell');
+    // No fabrica datos reales: el result no tiene species/data simulados.
+    expect(result).not.toHaveProperty('species');
+    expect(result).not.toHaveProperty('found');
+    expect(result).not.toHaveProperty('data');
   });
 
   it('callTool sin toolName retorna null', async () => {

--- a/src/services/__tests__/mcpHonestidad.test.js
+++ b/src/services/__tests__/mcpHonestidad.test.js
@@ -16,16 +16,22 @@ import { describe, it, expect, vi } from 'vitest';
 // 1. callTool nunca fabrica datos en fallo
 // ---------------------------------------------------------------------------
 describe('mcp honestidad — callTool nunca fabrica datos en fallo', () => {
-  it('callTool con tool no permitido retorna null, no objeto vacío ni string', async () => {
+  it('callTool con tool no permitido retorna objeto _error honesto, no null', async () => {
     const { callTool } = await import('../sidecarClient.js');
     const result = await callTool('execute_sql', { query: 'DROP TABLE' });
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result._error).toBe(true);
+    expect(result.reason).toBe('not_allowed');
+    expect(result.tool).toBe('execute_sql');
   });
 
-  it('callTool con tool vacío retorna null', async () => {
+  it('callTool con tool vacío retorna null (no intentado)', async () => {
     const { callTool } = await import('../sidecarClient.js');
+    // '' falla !toolName → null. '   ' no está en whitelist → error honesto.
     expect(await callTool('', {})).toBeNull();
-    expect(await callTool('   ', {})).toBeNull();
+    const ws = await callTool('   ', {});
+    expect(ws._error).toBe(true);
+    expect(ws.reason).toBe('not_allowed');
   });
 
   it('callTool con args no-object no crash — retorna null', async () => {

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -1,0 +1,174 @@
+/**
+ * agentCapabilities.js — Manifiesto ÚNICO de capacidades de Chagra.
+ *
+ * Fuente normativa para chips de modo y menú Ⓐ del AgentHero.
+ * TODO lo demás (chips, tools, labels, placeholders, rutas) se deriva de acá.
+ *
+ * Regla inviolable: un cambio en la UI (nuevo chip, nuevo tool, label distinto)
+ * se hace editando ESTE archivo. NO en CHIP_DEFS ni en CAPABILITIES de AgentHero.
+ */
+
+/** Manifiesto único de capacidades. Orden: chips primero, luego actions. */
+export const CAPABILITY_MANIFEST = Object.freeze([
+  // ═══════════════════════════════════════════════════════════════════════
+  // CHIP INTENTS — aparecen en ChipsToolbar y (algunos) en AgentHero
+  // ═══════════════════════════════════════════════════════════════════════
+  {
+    id: 'siembro',
+    intent: 'siembro',
+    kind: 'tool',
+    icon: '🌱',
+    label: '¿Qué siembro?',
+    desc: 'Qué sembrar según tu clima y tu altura.',
+    placeholder: 'Escribe la planta o di qué quieres sembrar',
+    tool: 'get_species',
+    stubMessage: null,
+    hero: true,
+    heroRoute: { kind: 'ask', prompt: '¿Qué puedo sembrar este mes en mi zona?' },
+  },
+  {
+    id: 'plaga',
+    intent: 'plaga',
+    kind: 'tool',
+    icon: '🐛',
+    label: 'Plaga',
+    desc: 'Controlar una plaga sin veneno.',
+    placeholder: 'Escribe la plaga o describe el daño que ves',
+    tool: 'get_pest_controllers',
+    stubMessage: null,
+    hero: true,
+    heroRoute: { kind: 'ask', prompt: '¿Cómo controlo plagas sin químicos?' },
+  },
+  {
+    id: 'biopreparado',
+    intent: 'biopreparado',
+    kind: 'tool',
+    icon: '🧪',
+    label: 'Biopreparado',
+    desc: 'Receta casera para fortalecer tu cultivo.',
+    placeholder: 'Escribe para qué plaga o planta quieres el biopreparado',
+    tool: 'get_biopreparados',
+    stubMessage: null,
+    hero: true,
+    heroRoute: { kind: 'ask', prompt: '¿Cómo hago un biopreparado para fortalecer mis matas?' },
+  },
+  {
+    id: 'clima',
+    intent: 'clima',
+    kind: 'tool',
+    icon: '🌦️',
+    label: 'Clima',
+    desc: 'El clima de tu finca esta semana.',
+    placeholder: 'Pregunta por la lluvia o el clima de tu zona',
+    tool: 'get_clima_ideam',
+    stubMessage: null,
+    hero: true,
+    heroRoute: { kind: 'ask', prompt: 'Dame el reporte del clima de mi zona esta semana.' },
+  },
+  {
+    id: 'precio',
+    intent: 'precio',
+    kind: 'stub',
+    icon: '💰',
+    label: 'Precio',
+    desc: 'Consultar precios mayoristas del día.',
+    placeholder: 'Escribe el producto del que quieres saber el precio',
+    tool: null,
+    stubMessage:
+      'La consulta de precios todavía no está disponible en Chagra. ' +
+      'Por ahora el precio mayorista lo publica el DANE (SIPSA) como archivo descargable, ' +
+      'sin consulta directa. Si quieres, te oriento a la fuente o a Corabastos.',
+    hero: false,
+    heroRoute: null,
+  },
+  {
+    id: 'calendario',
+    intent: 'calendario',
+    kind: 'tool',
+    icon: '📅',
+    label: 'Calendario',
+    desc: 'Cuándo sembrar y cuándo cosechar.',
+    placeholder: 'Escribe la planta para ver su época de siembra',
+    tool: 'get_species',
+    stubMessage: null,
+    hero: true,
+    heroRoute: { kind: 'ask', prompt: '¿Cuándo siembro y cuándo cosecho en mi zona?' },
+  },
+  {
+    id: 'deep',
+    intent: 'deep',
+    kind: 'deep',
+    icon: '🔬',
+    label: 'Investigación profunda',
+    desc: 'Investigación multi-fuente con fundamento técnico.',
+    placeholder: 'Escribe el tema que quieres investigar a fondo',
+    tool: null,
+    stubMessage: null,
+    hero: false,
+    heroRoute: null,
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // AGENTHERO ACTIONS — aparecen solo en menú Ⓐ del AgentHero
+  // ═══════════════════════════════════════════════════════════════════════
+  {
+    id: 'foto',
+    icon: '📷',
+    label: 'Agregar planta por foto',
+    desc: 'Tómale una foto y la identifico y registro.',
+    tool: 'vision_identify',
+    hero: true,
+    heroRoute: { kind: 'photo' },
+  },
+  {
+    id: 'voz',
+    icon: '🎤',
+    label: 'Agregar planta por voz',
+    desc: 'Dime qué sembraste y lo registro en tu finca.',
+    tool: 'voice_capture',
+    hero: true,
+    heroRoute: { kind: 'nav', view: 'voz' },
+  },
+  {
+    id: 'plantas',
+    icon: '🌿',
+    label: 'Mis plantas',
+    desc: 'Ver y manejar lo que tienes en la finca.',
+    tool: 'assets',
+    hero: true,
+    heroRoute: { kind: 'nav', view: 'activos' },
+  },
+]);
+
+// ── Vistas derivadas ──────────────────────────────────────────────────────
+
+/**
+ * CHIP_INTENTS — enum de intentos de chip. Clave === valor (string union).
+ * Derivado del manifiesto: solo entradas con `intent` definido.
+ */
+export const CHIP_INTENTS = Object.freeze(
+  CAPABILITY_MANIFEST
+    .filter((e) => e.intent)
+    .reduce((acc, e) => {
+      acc[e.intent] = e.intent;
+      return acc;
+    }, {}),
+);
+
+/**
+ * CHIP_DEFS — definiciones de chips de modo para ChipsToolbar.
+ * Orden = orden del manifiesto (filtrado a entradas con intent).
+ * Cada entrada: { intent, emoji, label, kind, placeholder, stubMessage }.
+ */
+export const CHIP_DEFS = Object.freeze(
+  CAPABILITY_MANIFEST
+    .filter((e) => e.intent)
+    .map((e) => ({
+      intent: e.intent,
+      emoji: e.icon,
+      label: e.label,
+      kind: e.kind,
+      placeholder: e.placeholder,
+      ...(e.stubMessage ? { stubMessage: e.stubMessage } : {}),
+    })),
+);

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -15,8 +15,8 @@
  * "plan forzado" que el AgentScreen ejecuta sin pasar por `planNlu()`. Toda la
  * lógica de routing vive acá para poder testearla en aislamiento (TDD).
  *
- * Enum de intención: { siembro, plaga, biopreparado, clima, precio,
- *                      calendario, deep }.
+ * CHIP_INTENTS y CHIP_DEFS se importan de agentCapabilities.js (fuente única
+ * de verdad). Este módulo NO redefine esas constantes.
  *
  * Tools determinísticos (ya existen en el sidecar, ver sidecarClient.ALLOWED_TOOLS):
  *   - siembro      → get_species          (ficha + viabilidad de la especie)
@@ -36,81 +36,8 @@
  * strings visibles al campesino se redactan en neutro colombiano.
  */
 
-/** Enum de intención de los chips. Las claves == valores (string union). */
-export const CHIP_INTENTS = Object.freeze({
-  siembro: 'siembro',
-  plaga: 'plaga',
-  biopreparado: 'biopreparado',
-  clima: 'clima',
-  precio: 'precio',
-  calendario: 'calendario',
-  deep: 'deep',
-});
-
-/**
- * Definiciones declarativas de los 7 chips. El orden de este array es el orden
- * de render en la barra. `placeholder` reemplaza el placeholder del input
- * cuando el modo está activo, para guiar al campesino sobre qué escribir.
- *
- * `kind`:
- *   - 'tool' → rutea a un tool determinístico (planForcedIntent.tool).
- *   - 'stub' → backend no implementado; planForcedIntent.stubMessage explica.
- */
-export const CHIP_DEFS = Object.freeze([
-  {
-    intent: CHIP_INTENTS.siembro,
-    emoji: '🌱',
-    label: '¿Qué siembro?',
-    kind: 'tool',
-    placeholder: 'Escribe la planta o di qué quieres sembrar',
-  },
-  {
-    intent: CHIP_INTENTS.plaga,
-    emoji: '🐛',
-    label: 'Plaga',
-    kind: 'tool',
-    placeholder: 'Escribe la plaga o describe el daño que ves',
-  },
-  {
-    intent: CHIP_INTENTS.biopreparado,
-    emoji: '🧪',
-    label: 'Biopreparado',
-    kind: 'tool',
-    placeholder: 'Escribe para qué plaga o planta quieres el biopreparado',
-  },
-  {
-    intent: CHIP_INTENTS.clima,
-    emoji: '🌦️',
-    label: 'Clima',
-    kind: 'tool',
-    placeholder: 'Pregunta por la lluvia o el clima de tu zona',
-  },
-  {
-    intent: CHIP_INTENTS.precio,
-    emoji: '💰',
-    label: 'Precio',
-    kind: 'stub',
-    placeholder: 'Escribe el producto del que quieres saber el precio',
-    stubMessage:
-      'La consulta de precios todavía no está disponible en Chagra. ' +
-      'Por ahora el precio mayorista lo publica el DANE (SIPSA) como archivo descargable, ' +
-      'sin consulta directa. Si quieres, te oriento a la fuente o a Corabastos.',
-  },
-  {
-    intent: CHIP_INTENTS.calendario,
-    emoji: '📅',
-    label: 'Calendario',
-    kind: 'tool',
-    placeholder: 'Escribe la planta para ver su época de siembra',
-  },
-  {
-    intent: CHIP_INTENTS.deep,
-    emoji: '🔬',
-    label: 'Investigación profunda',
-    kind: 'deep',
-    placeholder: 'Escribe el tema que quieres investigar a fondo',
-  },
-]);
+import { CHIP_INTENTS, CHIP_DEFS } from './agentCapabilities.js';
+export { CHIP_INTENTS, CHIP_DEFS };
 
 const DEF_BY_INTENT = Object.freeze(
   CHIP_DEFS.reduce((acc, def) => {

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -451,20 +451,42 @@ export async function postValidate(text, expected) {
 }
 
 /**
+ * Resultado de error de tool MCP.
+ * @typedef {object} ToolError
+ * @property {true}       _error   — discrimina de resultados exitosos
+ * @property {string}     reason   — 'not_allowed' | 'fetch_failed'
+ * @property {string}     tool     — nombre del tool que falló
+ */
+
+/**
  * Llama `POST ${BASE}/tools/<toolName>` con los args dados.
+ *
+ * El contrato de retorno es tri-estado:
+ *   - object (sin _error) → datos reales del sidecar.
+ *   - ToolError → tool fue intentado pero falló (timeout, HTTP error, not allowed).
+ *   - null → tool NO fue intentado (flag off, offline).
  *
  * @param {string} toolName — uno de ALLOWED_TOOLS
  * @param {object} args — body raw (forma específica por tool)
- * @returns {Promise<null | object>} respuesta del sidecar tal cual, o null
- *   si flag off / offline / tool no permitido / fetch falla.
+ * @returns {Promise<null | object | ToolError>}
  */
 export async function callTool(toolName, args) {
   if (!toolName || typeof toolName !== 'string') return null;
   if (!ALLOWED_TOOLS.has(toolName)) {
     console.debug('[sidecar] tool no permitido', toolName);
-    return null;
+    return { _error: true, reason: 'not_allowed', tool: toolName };
   }
-  return postJson(`/tools/${toolName}`, args || {}, TOOL_TIMEOUT_MS);
+  const result = await postJson(`/tools/${toolName}`, args || {}, TOOL_TIMEOUT_MS);
+  if (result !== null) return result;
+  // postJson retornó null. Distinguir: tool fue intentado pero falló
+  // (timeout / HTTP error / network) vs. ni siquiera se intentó (flag off / offline).
+  const attempted =
+    isSidecarEnabled() &&
+    !(typeof navigator !== 'undefined' && navigator.onLine === false);
+  if (attempted) {
+    return { _error: true, reason: 'fetch_failed', tool: toolName };
+  }
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Cambios

### P1 — Contrato de capacidades unificado
- Creado `src/services/agentCapabilities.js` como fuente única de verdad
- CHIP_DEFS / CHIP_INTENTS ahora se derivan del manifiesto
- AgentHero CAPABILITIES deriva del manifiesto (en vez de inline)
- Bugs corregidos: `get_clima` → `get_clima_ideam`, `get_calendario` → `get_species`

### P2 — Errores MCP honestos
- `callTool` retorna `{ _error, reason, tool }` para fallos de infraestructura en vez de null silencioso
- `formatToolEvidence` produce bloque anti-alucinación cuando un tool falla
- Tests actualizados: 73/73 pasan

## Archivos
```
 .../agentCapabilities.js                   | 174 ++++++++++++++++++
 .../services/chipIntentRouter.js           |  81 +----------
 .../dashboard/AgentHero.jsx                |  81 +++----------
 .../AgentScreen.jsx                        |  21 +++-
 .../sidecarClient.js                       |  31 +++-
 .../agentCapabilities.audit.test.js        |  11 +-
 .../mcpHonestidad.test.js                  |  14 +-
 7 files changed, 265 insertions(+), 148 deletions(-)
```

## Tests
- 83 tests pasan (chipIntentRouter 29 + agentNluFallback 13 + capabilities audit 23 + mcpHonestidad 21)
- ChipsToolbar 24 + agentUserFlow 12 + outputGuards 187 también verdes