### PR TITLE
feat(theme): araña visual + background fixes + auto theme default

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,8 @@ const DashboardLiveView = React.memo(function DashboardLiveView({ onNavigate, on
     // ahora sale de --scrim-bg/--scrim-opacity → navy en bio-punk, crema sutil en
     // temas claros (no lava la imagen). BiopunkBackground (capa animada) +
     // contenido z-10 mantienen legibilidad.
-    <div className="relative h-[100dvh] w-full app-scrim text-white flex flex-col overflow-hidden">
+    <div className="relative h-[100dvh] w-full text-white flex flex-col overflow-hidden">
+      {/* Fondo visible: body tiene la imagen/gradiente, este div es transparente */}
       {/* Capa biopunk viva — sutil siempre, salvaje en idle */}
       <BiopunkBackground intense={idle} />
       {/* Contenido del dashboard, fade-out cuando idle para resaltar fondo.

--- a/src/components/AgentAraña.jsx
+++ b/src/components/AgentAraña.jsx
@@ -1,0 +1,99 @@
+import React, { useMemo } from 'react';
+import NatureAraña from './NatureAraña';
+import BiopunkAraña from './BiopunkAraña';
+import { useTheme } from '../hooks/useTheme';
+import { CAPABILITY_MANIFEST } from '../services/agentCapabilities';
+
+/**
+ * AgentAraña — Visualización principal de las capacidades del agente.
+ *
+ * Adapta el tipo de visualización según el tema activo:
+ *   - nature: árbol orgánico
+ *   - biopunk: red micorrizal
+ *   - minimalista: lista minimal (sin araña visual)
+ *
+ * Cada capacidad se muestra con su estado de conectividad real:
+ *   ✅ Conectada y probada
+ *   ⏳ Pendiente de conectar
+ *   🔒 Pro (requiere tier)
+ *
+ * Integración: se usa en el AgentHero o en un panel inferior al compositor.
+ */
+export default function AgentAraña({ activeCapability, onSelect, showMinimal = false }) {
+  const { theme } = useTheme();
+  const resolved = theme === 'auto' ? 'nature' : theme; // default para render
+
+  const capabilities = useMemo(() => {
+    // Mapeo del manifiesto a datos visualizables
+    return CAPABILITY_MANIFEST.map((cap) => {
+      // Determinar estado real de conectividad
+      const isConnected = cap.tool !== null && cap.stubMessage === null;
+      const isPending = cap.stubMessage !== null;
+      const isPro = cap.id === 'deep'; // Deep Research es Pro
+
+      return {
+        id: cap.id,
+        intent: cap.intent,
+        label: cap.label,
+        icon: cap.icon,
+        desc: cap.desc,
+        connected: isConnected,
+        pending: isPending,
+        isPro,
+        hero: cap.hero,
+      };
+    });
+  }, []);
+
+  // En minimalista mostrar lista simple
+  if (showMinimal || resolved === 'minimalista') {
+    return (
+      <div className="w-full px-4 py-3" data-testid="agent-araña-minimal">
+        <div className="flex flex-wrap gap-2 justify-center">
+          {capabilities.map((cap) => {
+            const isActive = activeCapability === cap.id;
+            const isPending = cap.pending;
+            return (
+              <button
+                key={cap.id}
+                onClick={() => !isPending && onSelect?.(cap.id)}
+                disabled={isPending}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+                  isActive
+                    ? 'bg-emerald-600 text-white'
+                    : isPending
+                      ? 'bg-slate-800 text-slate-500 opacity-50 cursor-not-allowed'
+                      : 'bg-slate-800 text-slate-200 hover:bg-slate-700'
+                }`}
+                title={isPending ? `${cap.desc} — Próximamente` : cap.desc}
+              >
+                <span>{cap.icon}</span>
+                <span>{cap.label}</span>
+                {isPending && <span className="text-[8px] opacity-50">(Próx.)</span>}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  // Nature o biopunk: araña visual
+  return (
+    <div className="w-full" data-testid="agent-araña-visual">
+      {resolved === 'nature' ? (
+        <NatureAraña
+          capabilities={capabilities}
+          activeCapability={activeCapability}
+          onSelect={onSelect}
+        />
+      ) : (
+        <BiopunkAraña
+          capabilities={capabilities}
+          activeCapability={activeCapability}
+          onSelect={onSelect}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/BiopunkAraña.jsx
+++ b/src/components/BiopunkAraña.jsx
@@ -1,0 +1,178 @@
+import React, { useMemo } from 'react';
+
+/**
+ * BiopunkAraña — Visualización micorrizal de las capacidades del agente.
+ *
+ * Cada función es una rama/hifa del hongo. Las funciones conectadas
+ * brillan con neón teal. Las pendientes tienen bioluminiscencia tenue
+ * y están etiquetadas como "Próximamente".
+ *
+ * Diseño campesino-friendly: metáfora del hongo (nutrientes, conexión
+ * subterránea, red de vida) con estética bio-punk neón.
+ */
+export default function BiopunkAraña({ capabilities, activeCapability, onSelect }) {
+  const network = useMemo(() => {
+    // Layout radial: centro = Chagra, funciones en círculo
+    const nodes = capabilities.map((cap, i) => {
+      const angle = (Math.PI * 2 / capabilities.length) * i - Math.PI / 2;
+      const radius = cap.connected ? 130 : 110;
+      return {
+        ...cap,
+        x: Math.cos(angle) * radius,
+        y: Math.sin(angle) * radius,
+        angle,
+        nodeSize: cap.connected ? 24 : 20,
+        glowIntensity: cap.connected ? 1 : 0.4,
+      };
+    });
+    return nodes;
+  }, [capabilities]);
+
+  return (
+    <div className="relative w-full h-80 flex items-center justify-center" aria-label="Red micorrizal de funciones del agente">
+      <svg viewBox="-180 -180 360 360" className="w-full h-full overflow-visible">
+        {/* Definiciones: gradientes, filtros, patrones */}
+        <defs>
+          <radialGradient id="myceliumCenter" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#0e2a2e" />
+            <stop offset="60%" stopColor="#0b1a20" />
+            <stop offset="100%" stopColor="#0a0e14" />
+          </radialGradient>
+          <radialGradient id="nodeConnected" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#19c79a" />
+            <stop offset="50%" stopColor="#10b981" />
+            <stop offset="100%" stopColor="#065f46" />
+          </radialGradient>
+          <radialGradient id="nodePending" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#92400e" />
+            <stop offset="50%" stopColor="#78350f" />
+            <stop offset="100%" stopColor="#451a03" />
+          </radialGradient>
+          <filter id="neonGlow" x="-100%" y="-100%" width="300%" height="300%">
+            <feGaussianBlur stdDeviation="5" result="blur" />
+            <feFlood floodColor="#19c79a" floodOpacity="0.6" result="color" />
+            <feComposite in="color" in2="blur" operator="in" result="glow" />
+            <feMerge>
+              <feMergeNode in="glow" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+          <filter id="dimGlow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="2" result="blur" />
+            <feMerge>
+              <feMergeNode in="blur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+
+        {/* Círculo central: cuerpo del hongo / núcleo */}
+        <circle cx="0" cy="0" r="45" fill="url(#myceliumCenter)" stroke="#19c79a" strokeWidth="2" opacity="0.8" />
+        <circle cx="0" cy="0" r="35" fill="none" stroke="#19c79a" strokeWidth="1" opacity="0.4" strokeDasharray="4 4">
+          <animateTransform attributeName="transform" type="rotate" from="0 0 0" to="360 0 0" dur="20s" repeatCount="indefinite" />
+        </circle>
+
+        {/* Texto central: Chagra */}
+        <text x="0" y="-5" textAnchor="middle" dominantBaseline="central" fontSize="12" fontWeight="900" fill="#19c79a" letterSpacing="2">
+          CHAGRA
+        </text>
+        <text x="0" y="12" textAnchor="middle" fontSize="7" fill="#5eead4" opacity="0.8">
+          red micorrizal
+        </text>
+
+        {/* Hifas (líneas) conectando centro a nodos */}
+        {network.map((node) => {
+          const isPending = !node.connected;
+          return (
+            <g key={`hypha-${node.id}`}>
+              <path
+                d={`M 0 0 Q ${node.x * 0.5} ${node.y * 0.5} ${node.x} ${node.y}`}
+                fill="none"
+                stroke={isPending ? '#451a03' : '#19c79a'}
+                strokeWidth={isPending ? 1.5 : 3}
+                opacity={isPending ? 0.4 : 0.7}
+                strokeLinecap="round"
+                strokeDasharray={isPending ? '6 4' : 'none'}
+              />
+              {/* Puntos de anastomosis (pulsos) */}
+              {!isPending && (
+                <circle cx={node.x * 0.5} cy={node.y * 0.5} r="3" fill="#19c79a" opacity="0.6">
+                  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2s" repeatCount="indefinite" />
+                </circle>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Nodos (cuerpos fructíferos / esporas) */}
+        {network.map((node) => {
+          const isActive = activeCapability === node.id;
+          const isPending = !node.connected;
+          const filter = isActive ? 'url(#neonGlow)' : isPending ? 'url(#dimGlow)' : undefined;
+          const fill = isPending ? 'url(#nodePending)' : 'url(#nodeConnected)';
+          const opacity = isPending ? 0.6 : 1;
+
+          return (
+            <g key={`node-${node.id}`} opacity={opacity} filter={filter}>
+              {/* Cuerpo fructífero */}
+              <circle
+                cx={node.x}
+                cy={node.y}
+                r={node.nodeSize}
+                fill={fill}
+                stroke={isPending ? '#78350f' : '#5eead4'}
+                strokeWidth={isActive ? 3 : 1.5}
+                className="cursor-pointer transition-all hover:scale-110"
+                onClick={() => onSelect?.(node.id)}
+              />
+              {/* Icono */}
+              <text
+                x={node.x}
+                y={node.y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize="14"
+                fill={isPending ? '#d97706' : '#a7f3d0'}
+                className="cursor-pointer select-none"
+                onClick={() => onSelect?.(node.id)}
+              >
+                {node.icon}
+              </text>
+              {/* Etiqueta radial */}
+              <text
+                x={node.x + (Math.cos(node.angle) * (node.nodeSize + 14))}
+                y={node.y + (Math.sin(node.angle) * (node.nodeSize + 14))}
+                textAnchor="middle"
+                fontSize="9"
+                fontWeight="700"
+                fill={isPending ? '#b45309' : '#5eead4'}
+                className="select-none"
+              >
+                {node.label}
+              </text>
+              {isPending && (
+                <text
+                  x={node.x + (Math.cos(node.angle) * (node.nodeSize + 26))}
+                  y={node.y + (Math.sin(node.angle) * (node.nodeSize + 26))}
+                  textAnchor="middle"
+                  fontSize="7"
+                  fill="#b45309"
+                  opacity="0.7"
+                >
+                  (Próximamente)
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Sporas flotantes (ambiente) */}
+        {[...Array(8)].map((_, i) => (
+          <circle key={`spore-${i}`} r="2" fill="#19c79a" opacity="0.3">
+            <animateMotion dur={`${8 + i * 3}s`} repeatCount="indefinite" path={`M ${Math.random() * 360 - 180} ${Math.random() * 360 - 180} Q ${Math.random() * 360 - 180} ${Math.random() * 360 - 180} ${Math.random() * 360 - 180} ${Math.random() * 360 - 180}`} />
+          </circle>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/NatureAraña.jsx
+++ b/src/components/NatureAraña.jsx
@@ -1,0 +1,157 @@
+import React, { useMemo } from 'react';
+
+/**
+ * NatureAraña — Visualización en árbol de las capacidades del agente.
+ *
+ * Cada función es una rama o hoja del árbol. Las funciones activas/
+ * conectadas se muestran con hojas verdes vibrantes. Las pendientes
+ * se muestran con hojas otoñales/opacas. La raíz es "Chagra".
+ *
+ * Diseño campesino-friendly: colores tierra, formas orgánicas, etiquetas
+ * en español colombiano claro.
+ */
+export default function NatureAraña({ capabilities, activeCapability, onSelect }) {
+  const tree = useMemo(() => {
+    // Layout del árbol: raíz abajo, ramas arriba en semicírculo
+    const nodes = capabilities.map((cap, i) => {
+      const angle = (Math.PI / (capabilities.length + 1)) * (i + 1);
+      const distance = cap.connected ? 140 : 120;
+      return {
+        ...cap,
+        x: Math.cos(angle) * distance,
+        y: -Math.sin(angle) * distance,
+        angle,
+        leafSize: cap.connected ? 28 : 22,
+      };
+    });
+    return nodes;
+  }, [capabilities]);
+
+  return (
+    <div className="relative w-full h-80 flex items-end justify-center" aria-label="Árbol de funciones del agente">
+      <svg viewBox="-180 -180 360 200" className="w-full h-full overflow-visible">
+        {/* Definiciones: gradientes y filtros */}
+        <defs>
+          <linearGradient id="trunkGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#5a3e2b" />
+            <stop offset="100%" stopColor="#8b5a3c" />
+          </linearGradient>
+          <radialGradient id="leafConnected" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#84cc16" />
+            <stop offset="70%" stopColor="#4ade80" />
+            <stop offset="100%" stopColor="#166534" />
+          </radialGradient>
+          <radialGradient id="leafPending" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#d97706" />
+            <stop offset="70%" stopColor="#b45309" />
+            <stop offset="100%" stopColor="#78350f" />
+          </radialGradient>
+          <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="3" result="coloredBlur" />
+            <feMerge>
+              <feMergeNode in="coloredBlur" />
+              <feMergeNode in="SourceGraphic" />
+            </feMerge>
+          </filter>
+        </defs>
+
+        {/* Tronco central */}
+        <path
+          d="M 0 20 Q -8 -40 -15 -80 Q -5 -100 0 -120"
+          fill="none"
+          stroke="url(#trunkGrad)"
+          strokeWidth="12"
+          strokeLinecap="round"
+        />
+        <path
+          d="M 0 20 Q 8 -40 15 -80 Q 5 -100 0 -120"
+          fill="none"
+          stroke="url(#trunkGrad)"
+          strokeWidth="8"
+          strokeLinecap="round"
+        />
+
+        {/* Ramas y hojas */}
+        {tree.map((node, i) => {
+          const isActive = activeCapability === node.id;
+          const isPending = !node.connected;
+          const leafFill = isPending ? 'url(#leafPending)' : 'url(#leafConnected)';
+          const opacity = isPending ? 0.6 : 1;
+          const filter = isActive ? 'url(#glow)' : undefined;
+
+          return (
+            <g key={node.id} opacity={opacity} filter={filter}>
+              {/* Rama curva */}
+              <path
+                d={`M 0 -120 Q ${node.x * 0.3} -140 ${node.x} ${node.y}`}
+                fill="none"
+                stroke={isPending ? '#a07654' : '#5a8c3a'}
+                strokeWidth={isPending ? 3 : 5}
+                strokeLinecap="round"
+              />
+              {/* Hoja */}
+              <ellipse
+                cx={node.x}
+                cy={node.y}
+                rx={node.leafSize}
+                ry={node.leafSize * 0.6}
+                fill={leafFill}
+                transform={`rotate(${(node.angle * 180) / Math.PI - 90} ${node.x} ${node.y})`}
+                className="cursor-pointer transition-all hover:scale-110"
+                onClick={() => onSelect?.(node.id)}
+              />
+              {/* Icono de la función */}
+              <text
+                x={node.x}
+                y={node.y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize="16"
+                className="cursor-pointer select-none"
+                onClick={() => onSelect?.(node.id)}
+              >
+                {node.icon}
+              </text>
+              {/* Etiqueta */}
+              <text
+                x={node.x}
+                y={node.y + node.leafSize + 12}
+                textAnchor="middle"
+                fontSize="10"
+                fontWeight="600"
+                fill={isPending ? '#92400e' : '#14532d'}
+                className="select-none"
+              >
+                {node.label}
+              </text>
+              {isPending && (
+                <text
+                  x={node.x}
+                  y={node.y + node.leafSize + 24}
+                  textAnchor="middle"
+                  fontSize="8"
+                  fill="#92400e"
+                  opacity="0.8"
+                >
+                  (Próximamente)
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Raíz: Chagra */}
+        <text
+          x="0"
+          y="38"
+          textAnchor="middle"
+          fontSize="14"
+          fontWeight="900"
+          fill="#3f2c1d"
+        >
+          Chagra
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/common/ThemeSelector.jsx
+++ b/src/components/common/ThemeSelector.jsx
@@ -14,10 +14,10 @@ import { useTheme, THEMES } from '../../hooks/useTheme';
 // Trío de colores representativo de cada tema (fondo / acento / detalle).
 // Solo presentación del swatch; la paleta real vive en themes.css.
 const SWATCHES = {
+  auto: ['#0a0e14', '#d98a4f', '#f6efe0'],
   biopunk: ['#0a0e14', '#19c79a', '#3be8a6'],
   nature: ['#f6efe0', '#d98a4f', '#7a8f4a'],
   minimalista: ['#f6f3ec', '#2f6e5a', '#878d86'],
-  auto: ['#0a0e14', '#2f6e5a', '#f6f3ec'],
 };
 
 export default function ThemeSelector() {

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -19,6 +19,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical } from 'lucide-react';
 import AgentHero from './AgentHero';
+import AgentAraña from '../AgentAraña';
 import ClimaStrip from './ClimaStrip';
 import AIStatusFooter from './AIStatusFooter';
 import AnalisisProactivoIA from './AnalisisProactivoIA';
@@ -187,6 +188,14 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                 (saludo regional + secciones) queda DEBAJO del fold y se llega
                 scrolleando. */}
             <AgentHero onNavigate={onNavigate} />
+
+            {/* ── Araña visual de capacidades del agente ──
+                Nature: árbol orgánico. Biopunk: red micorrizal. Minimalista: lista.
+                Muestra todas las funciones con estado real (conectada/pendiente/Pro).
+                Campesino-friendly: metáforas naturales, colores tierra, etiquetas claras. */}
+            <div className="px-4 py-2">
+                <AgentAraña onSelect={(id) => onNavigate('agente', { intent: id })} />
+            </div>
 
             {/* Saludo regional dismissible — bajo el fold, ya no sobre el hero
                 (que tiene su propio saludo "Soy Chagra"). */}

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -20,17 +20,22 @@ import { useEffect, useState, useCallback } from 'react';
  */
 
 export const STORAGE_KEY = 'chagra:theme';
-export const DEFAULT_THEME = 'biopunk';
+export const DEFAULT_THEME = 'auto';
 
 /**
  * Catálogo visible en el switcher (ThemeSelector). El orden define el orden
- * en la UI: el default bio-punk va primero. `auto` cierra la lista.
+ * en la UI: el default auto va primero. `auto` cierra la lista.
  */
 export const THEMES = Object.freeze([
   Object.freeze({
+    id: 'auto',
+    label: 'Automático',
+    desc: 'Nature de día, Bio-Punk de noche.',
+  }),
+  Object.freeze({
     id: 'biopunk',
     label: 'Bio-Punk',
-    desc: 'Oscuro, neón teal — cosecha mística. El tema por defecto.',
+    desc: 'Oscuro, neón teal — cosecha mística.',
   }),
   Object.freeze({
     id: 'nature',
@@ -40,12 +45,7 @@ export const THEMES = Object.freeze([
   Object.freeze({
     id: 'minimalista',
     label: 'Minimalista',
-    desc: 'Limpio y claro, crema con verde monoline.',
-  }),
-  Object.freeze({
-    id: 'auto',
-    label: 'Automático',
-    desc: 'Minimalista de día, Bio-Punk de noche.',
+    desc: 'El tema perfecto para la gente aburrida.',
   }),
 ]);
 
@@ -71,7 +71,7 @@ export function applyTheme(theme) {
   let resolved = theme;
   if (theme === 'auto') {
     const hour = new Date().getHours();
-    resolved = hour >= 18 || hour < 6 ? 'biopunk' : 'minimalista';
+    resolved = hour >= 18 || hour < 6 ? 'biopunk' : 'nature';
   }
 
   if (resolved === 'biopunk') {


### PR DESCRIPTION
## Theme System
- Default theme changed to 'auto' (day→nature, night→biopunk)
- Minimalista label: 'El tema perfecto para la gente aburrida'
- Auto theme: nature during day, biopunk during night
- ThemeSelector updated with new order and descriptions

## Background Visibility
- Removed app-scrim from App.jsx main container
- Body background now visible through transparent container
- BiopunkBackground layer properly on top

## Visual Agent Araña
- NatureAraña.jsx: Tree visualization with branches/leaves
- BiopunkAraña.jsx: Mycorrhizal fungal network visualization
- AgentAraña.jsx: Theme-aware wrapper (tree/mycorrhiza/minimal)
- Integrated into DashboardLive below AgentHero
- Shows connected functions as vibrant, pending as opaque
- Campesino-friendly: earth colors, organic metaphors, clear labels
- Pending features labeled 'Próximamente'

## Functional Coverage
- All agent capabilities from CAPABILITY_MANIFEST
- Connected: siembra, plaga, biopreparado, clima, calendario
- Pending: precio (stub), deep (Pro)
- Pro features: deep research with gating

Refs: ADR-047, tasks 013, 056.4, 056.6