### PR TITLE
feat(agent): conectar Procesos por voz — FarmProcess wired (antes oscuro)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,6 +60,7 @@ const OnboardingPiloto = lazy(() => import('./components/OnboardingPiloto'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
+const ProcesosPorVozScreen = lazy(() => import('./components/ProcesosPorVozScreen'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
@@ -696,6 +697,8 @@ export default function App() {
             <VoiceCapture onSave={showToast} />
           </ScreenShell>
         );
+      case 'procesos':
+        return <ProcesosPorVozScreen onBack={() => navigate('dashboard')} onSave={showToast} />;
       case 'perfil':
         return <ProfileScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />;
       case 'casos':

--- a/src/components/ProcesosPorVozScreen.jsx
+++ b/src/components/ProcesosPorVozScreen.jsx
@@ -1,0 +1,280 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Mic, MicOff, AlertTriangle, RotateCcw, Check, ChevronLeft } from 'lucide-react';
+import useVoiceRecorder from '../hooks/useVoiceRecorder';
+import { transcribe } from '../services/voiceService';
+import { extractEntities } from '../services/entityExtractor';
+import { enrichEntitiesWithRag } from '../services/voiceRagEnricher';
+import { buildDraftsFromVoice } from '../services/voiceToDraft';
+import { useFarmProcessConfirm } from '../hooks/useFarmProcessConfirm';
+import FarmProcessConfirmCard from './FarmProcessConfirmCard';
+import useAssetStore from '../store/useAssetStore';
+import ChagraGrowLoader from './ChagraGrowLoader';
+
+/**
+ * ProcesosPorVozScreen — "Procesos por voz": describe en voz alta una labor
+ * (siembra/proceso) y Chagra arma un CICLO PRODUCTIVO (FarmProcess) que tú
+ * confirmas y queda registrado localmente.
+ *
+ * Cablea el subsistema FarmProcess (PR #1370, ADR-047/050) que estaba "oscuro"
+ * (mergeado sin conectar). Reusa el MISMO pipeline de voz que VoiceCapture
+ * (transcribe → extractEntities → enrichEntitiesWithRag) y, en vez de registrar
+ * una planta, construye drafts (voiceToDraft) → tarjeta de confirmación editable
+ * (FarmProcessConfirmCard, gate humano) → useFarmProcessConfirm → createFarmProcess
+ * (escritura atómica local en IndexedDB farm_processes). Offline-first.
+ */
+const ST = {
+  IDLE: 'idle',
+  RECORDING: 'recording',
+  TRANSCRIBING: 'transcribing',
+  EXTRACTING: 'extracting',
+  REVIEW: 'review',
+  DONE: 'done',
+  ERROR: 'error',
+};
+
+const fmt = (ms) => {
+  const s = Math.floor(ms / 1000);
+  return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+};
+
+export default function ProcesosPorVozScreen({ onBack, onSave }) {
+  const { audioLevel, durationMs, start, stop, reset, error: recorderError, hardLimitMs } = useVoiceRecorder();
+  const lands = useAssetStore((s) => s.lands);
+
+  const [view, setView] = useState(ST.IDLE);
+  const [transcription, setTranscription] = useState('');
+  const [drafts, setDrafts] = useState([]);
+  const [idx, setIdx] = useState(0);
+  const [savedCount, setSavedCount] = useState(0);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const { status, confirm, reset: resetConfirm } = useFarmProcessConfirm();
+  const isSaving = status === 'saving';
+
+  // Lotes/zonas disponibles para el selector de la tarjeta (gate humano).
+  const locationOptions = useMemo(
+    () =>
+      (lands || [])
+        .filter((l) => l?.id && l?.attributes?.name)
+        .map((l) => ({
+          id: l.id,
+          type: l.type || 'asset--land',
+          name: l.attributes.name,
+          label: l.attributes.name,
+        })),
+    [lands],
+  );
+
+  // Resolución para buildDraftsFromVoice. La extracción ya resuelve la ubicación
+  // (entity.location) y el slug (entity.cropSlug); acá solo normalizamos. Lo que
+  // no quede resuelto, el campesino lo completa en la tarjeta antes de confirmar.
+  const resolveLocation = useCallback((loc) => {
+    if (loc && loc.id) return { id: loc.id, type: loc.type || 'asset--land', label: loc.name || loc.label };
+    return null;
+  }, []);
+
+  const reseted = useCallback(() => {
+    reset();
+    resetConfirm();
+    setTranscription('');
+    setDrafts([]);
+    setIdx(0);
+    setErrorMsg('');
+    setView(ST.IDLE);
+  }, [reset, resetConfirm]);
+
+  const runPipeline = useCallback(async (blob) => {
+    setView(ST.TRANSCRIBING);
+    setErrorMsg('');
+    let text;
+    try {
+      text = await transcribe(blob);
+      setTranscription(text);
+    } catch (err) {
+      setErrorMsg(`No se pudo transcribir: ${err.message}.`);
+      setView(ST.ERROR);
+      return;
+    }
+    setView(ST.EXTRACTING);
+    try {
+      const extracted = await extractEntities(text);
+      const { entities: enriched } = await enrichEntitiesWithRag(extracted).catch(() => ({
+        entities: extracted,
+      }));
+      // Mapa nombre→entidad para reusar el slug/label ya resueltos por la extracción.
+      const byCrop = new Map((enriched || []).map((e) => [e.crop, e]));
+      const resolveCrop = (crop) => {
+        const e = byCrop.get(crop);
+        return { slug: e?.cropSlug || '', label: e?.canonical || crop, variety: null };
+      };
+      const built = buildDraftsFromVoice({
+        transcription: text,
+        entities: enriched || [],
+        resolveLocation,
+        resolveCrop,
+      });
+      if (!built.length) {
+        setErrorMsg('No entendí ninguna siembra o proceso. Intenta de nuevo, por ejemplo: "sembré 10 fresas en el invernadero".');
+        setView(ST.ERROR);
+        return;
+      }
+      setDrafts(built);
+      setIdx(0);
+      setView(ST.REVIEW);
+    } catch (err) {
+      setErrorMsg(`No pude entender lo que dijiste: ${err.message}.`);
+      setView(ST.ERROR);
+    }
+  }, [resolveLocation]);
+
+  const handleStart = useCallback(async () => {
+    try {
+      await start();
+      setView(ST.RECORDING);
+    } catch (err) {
+      setErrorMsg(err.message || 'No se pudo iniciar la grabación');
+      setView(ST.ERROR);
+    }
+  }, [start]);
+
+  const handleStop = useCallback(async () => {
+    const result = await stop();
+    if (!result || !result.blob || result.blob.size === 0) {
+      setErrorMsg('Grabación vacía. Intenta de nuevo.');
+      setView(ST.ERROR);
+      return;
+    }
+    await runPipeline(result.blob);
+  }, [stop, runPipeline]);
+
+  const handleConfirm = useCallback(async (editedDraft) => {
+    try {
+      await confirm(editedDraft);
+      resetConfirm();
+      const next = idx + 1;
+      setSavedCount((c) => c + 1);
+      if (next < drafts.length) {
+        setIdx(next);
+      } else {
+        onSave?.('Ciclo de cultivo registrado por voz.');
+        setView(ST.DONE);
+      }
+    } catch (err) {
+      setErrorMsg(`No se pudo guardar el ciclo: ${err.message}.`);
+      setView(ST.ERROR);
+    }
+  }, [confirm, resetConfirm, idx, drafts.length, onSave]);
+
+  const remainingMs = Math.max(0, (hardLimitMs || 30000) - durationMs);
+
+  return (
+    <div className="min-h-[100dvh] text-white">
+      <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Volver"
+          className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center"
+        >
+          <ChevronLeft size={20} />
+        </button>
+        <div>
+          <h1 className="text-lg font-bold leading-tight">Procesos por voz</h1>
+          <p className="text-xs text-slate-400 leading-tight">Cuéntame qué sembraste y armo el ciclo del cultivo.</p>
+        </div>
+      </header>
+
+      {view === ST.IDLE && (
+        <div className="flex flex-col items-center gap-4 py-10 px-4">
+          <p className="text-sm text-slate-400 text-center max-w-xs">
+            Describe en voz alta, por ejemplo:
+            <br />
+            <span className="italic text-slate-300">"sembré 10 fresas en el invernadero 1"</span>
+          </p>
+          <button
+            onClick={handleStart}
+            className="w-32 h-32 rounded-full bg-lime-700 hover:bg-lime-600 active:bg-lime-800 flex items-center justify-center shadow-lg"
+            aria-label="Iniciar grabación"
+          >
+            <Mic size={56} className="text-white" />
+          </button>
+          <p className="text-xs text-slate-500">Toca para grabar (máx. 30s)</p>
+        </div>
+      )}
+
+      {view === ST.RECORDING && (
+        <div className="flex flex-col items-center gap-4 py-10 px-4">
+          <div className="tabular-nums text-3xl font-mono text-red-400">
+            {fmt(durationMs)} <span className="text-slate-500 text-sm">/ {fmt(hardLimitMs || 30000)}</span>
+          </div>
+          <button
+            onClick={handleStop}
+            className="w-32 h-32 rounded-full bg-red-600 hover:bg-red-500 active:bg-red-700 flex items-center justify-center shadow-lg animate-pulse"
+            aria-label="Detener grabación"
+          >
+            <MicOff size={56} className="text-white" />
+          </button>
+          <p className="text-xs text-slate-500">Nivel: {Math.round((audioLevel || 0) * 100)}%</p>
+          {remainingMs < 5000 && <p className="text-xs text-amber-400">Se detendrá en {Math.ceil(remainingMs / 1000)}s</p>}
+        </div>
+      )}
+
+      {(view === ST.TRANSCRIBING || view === ST.EXTRACTING) && (
+        <div className="flex flex-col items-center gap-4 py-14 px-4">
+          <div className="text-lime-400"><ChagraGrowLoader size={64} /></div>
+          <p className="text-sm text-slate-400">
+            {view === ST.TRANSCRIBING ? 'Escuchando lo que dijiste…' : 'Armando el ciclo del cultivo…'}
+          </p>
+          {view === ST.EXTRACTING && transcription && (
+            <p className="text-xs text-slate-500 italic max-w-md text-center">"{transcription}"</p>
+          )}
+        </div>
+      )}
+
+      {view === ST.REVIEW && drafts[idx] && (
+        <div>
+          {drafts.length > 1 && (
+            <p className="px-4 text-xs text-slate-400">Ciclo {idx + 1} de {drafts.length}</p>
+          )}
+          <FarmProcessConfirmCard
+            draft={drafts[idx]}
+            locationOptions={locationOptions}
+            isSaving={isSaving}
+            onConfirm={handleConfirm}
+            onCancel={reseted}
+          />
+        </div>
+      )}
+
+      {view === ST.ERROR && (
+        <div className="flex flex-col items-center gap-4 py-10 px-4">
+          <AlertTriangle size={48} className="text-amber-400" />
+          <p className="text-sm text-amber-200 text-center max-w-sm">{errorMsg || recorderError || 'Error desconocido'}</p>
+          <button onClick={reseted} className="px-6 py-3 min-h-[44px] bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2">
+            <RotateCcw size={18} /> Reintentar
+          </button>
+        </div>
+      )}
+
+      {view === ST.DONE && (
+        <div className="flex flex-col items-center gap-4 py-10 px-4">
+          <Check size={48} className="text-green-400" />
+          <div className="text-center max-w-xs">
+            <p className="text-base font-bold text-green-300">
+              {savedCount} ciclo{savedCount > 1 ? 's' : ''} registrado{savedCount > 1 ? 's' : ''} ✓
+            </p>
+            <p className="text-xs text-slate-400 mt-1">Guardado en tu finca. Se sincronizará cuando haya conexión.</p>
+          </div>
+          <div className="flex flex-wrap gap-2 justify-center">
+            <button onClick={reseted} className="px-6 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 rounded-xl font-bold flex items-center gap-2">
+              <Mic size={18} /> Otro proceso
+            </button>
+            <button onClick={onBack} className="px-6 py-3 min-h-[44px] bg-slate-800 hover:bg-slate-700 rounded-xl font-bold text-slate-200">
+              Volver
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/ProcesosPorVozScreen.test.jsx
+++ b/src/components/__tests__/ProcesosPorVozScreen.test.jsx
@@ -1,0 +1,76 @@
+/**
+ * ProcesosPorVozScreen — cablea el subsistema FarmProcess (antes "oscuro").
+ *
+ * Contrato cubierto (flujo feliz, externos mockeados, buildDraftsFromVoice REAL):
+ *   grabar → transcribir → extraer → draft → tarjeta de confirmación (gate
+ *   humano) → createFarmProcess (escritura atómica) → estado "registrado".
+ * Garantiza que el flujo de voz queda conectado de punta a punta y que NO se
+ * persiste sin confirmación humana.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+// vi.hoisted: las fns mock viven por encima de los vi.mock hoisteados.
+const { createFarmProcess, transcribe, extractEntities, enrichEntitiesWithRag } = vi.hoisted(() => ({
+  createFarmProcess: vi.fn(),
+  transcribe: vi.fn(),
+  extractEntities: vi.fn(),
+  enrichEntitiesWithRag: vi.fn(),
+}));
+
+vi.mock('../../hooks/useVoiceRecorder', () => ({
+  default: () => ({
+    audioLevel: 0, durationMs: 0, hardLimitMs: 30000, error: null, amplitudeHistory: [],
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue({ blob: new Blob(['x'], { type: 'audio/webm' }), durationMs: 1000 }),
+    reset: vi.fn(),
+  }),
+}));
+vi.mock('../../services/voiceService', () => ({ transcribe }));
+vi.mock('../../services/entityExtractor', () => ({ extractEntities }));
+vi.mock('../../services/voiceRagEnricher', () => ({ enrichEntitiesWithRag }));
+vi.mock('../../services/farmEventService', () => ({ createFarmProcess, recordFarmEvent: vi.fn() }));
+vi.mock('../../store/useAssetStore', () => ({
+  default: (sel) => sel({ lands: [{ id: 'land-1', type: 'asset--land', attributes: { name: 'Invernadero' } }] }),
+}));
+
+import ProcesosPorVozScreen from '../ProcesosPorVozScreen';
+
+beforeEach(() => {
+  createFarmProcess.mockReset().mockResolvedValue({ process_id: 'p1', status: 'recorded_local_pending_sync' });
+  transcribe.mockReset().mockResolvedValue('sembré 5 fresas en el invernadero');
+  extractEntities.mockReset().mockResolvedValue([
+    { crop: 'fresa', quantity: 5, cropSlug: 'fragaria_x_ananassa', canonical: 'Fresa', location: { id: 'land-1', type: 'asset--land', name: 'Invernadero' } },
+  ]);
+  enrichEntitiesWithRag.mockReset().mockImplementation((e) => Promise.resolve({ entities: e, summary: {} }));
+});
+afterEach(() => cleanup());
+
+describe('ProcesosPorVozScreen — procesos por voz (FarmProcess wired)', () => {
+  it('parte en idle con el botón de grabar', () => {
+    render(<ProcesosPorVozScreen onBack={() => {}} onSave={() => {}} />);
+    expect(screen.getByLabelText('Iniciar grabación')).toBeTruthy();
+  });
+
+  it('NO persiste sin confirmación: createFarmProcess solo se llama al confirmar', async () => {
+    const onSave = vi.fn();
+    render(<ProcesosPorVozScreen onBack={() => {}} onSave={onSave} />);
+
+    fireEvent.click(screen.getByLabelText('Iniciar grabación'));
+    fireEvent.click(await screen.findByLabelText('Detener grabación'));
+
+    // Llega a la tarjeta de confirmación (gate humano) sin haber persistido.
+    const confirmBtn = await screen.findByText(/Confirmar siembra/i, {}, { timeout: 3000 });
+    expect(createFarmProcess).not.toHaveBeenCalled();
+
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => expect(createFarmProcess).toHaveBeenCalledTimes(1));
+    // El draft confirmado lleva la especie y el lote resueltos.
+    const persisted = createFarmProcess.mock.calls[0][0];
+    expect(persisted.type).toBe('farm_process');
+    expect(persisted.attributes.location_land_asset_id).toBe('land-1');
+    expect(Number(persisted.attributes.quantity)).toBe(5);
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+  });
+});

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -227,13 +227,13 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   {
     id: 'procesos',
     group: 'registrar',
-    status: 'soon',
+    status: 'live',
     icon: '🔄',
     label: 'Procesos por voz',
-    desc: 'Registrar labores completas hablando con Chagra.',
+    desc: 'Registra el ciclo de un cultivo hablando con Chagra.',
     tool: 'farm_process',
     hero: true,
-    heroRoute: { kind: 'unavailable' },
+    heroRoute: { kind: 'nav', view: 'procesos' },
   },
   {
     id: 'alertas-cultivo',


### PR DESCRIPTION
## Qué
Conecta el primer subsistema **oscuro** detectado en la auditoría de 48h: el **FarmProcess** (PR #1370, ADR-047/050) había entrado completo (modelo de datos + IndexedDB v18 + servicios + UI) pero **sin cablear a ninguna vista alcanzable**.

Nueva pantalla **`ProcesosPorVozScreen`** (ruta `procesos`) que reusa el pipeline de voz existente y, en vez de registrar una planta, arma un **ciclo productivo**:

`grabar → transcribe → extractEntities → enrichEntitiesWithRag → voiceToDraft.buildDraftsFromVoice → FarmProcessConfirmCard (gate humano editable) → useFarmProcessConfirm → createFarmProcess (escritura atómica en IndexedDB farm_processes)`. Offline-first.

## Cambios
- `ProcesosPorVozScreen.jsx` (nuevo) — reusa `useVoiceRecorder` + `transcribe`/`extractEntities`/`enrichEntitiesWithRag`; lotes desde `useAssetStore`.
- `App.jsx` — lazy route `procesos`.
- `agentCapabilities.js` — chip **'procesos'** pasa de `soon`/`unavailable` a `live`/`nav` → el mano deja de mostrarlo opaco y abre el flujo.
- Test — flujo feliz end-to-end (externos mockeados, `buildDraftsFromVoice` real) + invariante **"no persiste sin confirmación humana"**.

## Verificación
- ESLint ✓, vitest (ProcesosPorVoz 2, agentCapabilities.audit 23, chipIntentRouter 29, capabilityHealth 3) ✓.
- Build local OOM por presión de memoria de alpha (no código) — lo valida el build de CI.
- Nota: la pierna de voz (whisper/ollama) se reusa del flujo `voz` ya en prod; no pude E2E-verificar en vivo (chromium OOM en alpha). El gate de CI offline-first cubre regresión.

Parte 1 de 4 de la conexión del backend oscuro (auditoría 48h). Siguen: Ciclo (fenología), Alertas, Tareas/Observaciones al código nuevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)