### PR TITLE
feat(agent): conectar Ciclo del cultivo — fenología wired (antes oscuro)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,6 +61,7 @@ const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
 const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const ProcesosPorVozScreen = lazy(() => import('./components/ProcesosPorVozScreen'));
+const CicloCultivoScreen = lazy(() => import('./components/CicloCultivoScreen'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
@@ -699,6 +700,8 @@ export default function App() {
         );
       case 'procesos':
         return <ProcesosPorVozScreen onBack={() => navigate('dashboard')} onSave={showToast} />;
+      case 'ciclo':
+        return <CicloCultivoScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />;
       case 'perfil':
         return <ProfileScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />;
       case 'casos':

--- a/src/components/CicloCultivoScreen.jsx
+++ b/src/components/CicloCultivoScreen.jsx
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, Sprout, Mic, RotateCcw, AlertTriangle } from 'lucide-react';
+import { listFarmProcesses } from '../db/farmProcessCache';
+import { getProfile } from '../services/userProfileService';
+import { getTasksForCycle, getUrgentTasks } from '../services/cycleTaskService';
+import { getPestRisksByStage } from '../services/climateCycleService';
+import FarmProcessSummary from './FarmProcessSummary';
+import PhenologyTimeline from './PhenologyTimeline';
+import ChagraGrowLoader from './ChagraGrowLoader';
+
+/**
+ * CicloCultivoScreen — "Ciclo del cultivo": muestra los ciclos productivos
+ * (FarmProcess) registrados, con su fenología (línea de tiempo de etapas),
+ * tareas de la etapa actual y riesgos de plaga.
+ *
+ * Cablea el track de fenología/ciclo del subsistema FarmProcess (PR #1370,
+ * ADR-047/049) que estaba "oscuro". Lee los ciclos de IndexedDB
+ * (farmProcessCache.listFarmProcesses) — los crea "Procesos por voz" — y arma
+ * la vista con piezas que estaban huérfanas: FarmProcessSummary +
+ * PhenologyTimeline + cycleTaskService + climateCycleService. Todo client-side.
+ */
+export default function CicloCultivoScreen({ onBack, onNavigate }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [cycles, setCycles] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+
+  const altitudeM = useMemo(() => {
+    const v = getProfile()?.finca_altitud;
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const list = await listFarmProcesses({ status: 'active' });
+      setCycles(Array.isArray(list) ? list : []);
+    } catch (err) {
+      setError(`No pude leer tus ciclos: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const selected = useMemo(
+    () => cycles.find((c) => (c.process_id || c.id) === selectedId) || null,
+    [cycles, selectedId],
+  );
+
+  const Header = (
+    <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+      <button
+        type="button"
+        onClick={selected ? () => setSelectedId(null) : onBack}
+        aria-label="Volver"
+        className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center"
+      >
+        <ChevronLeft size={20} />
+      </button>
+      <div>
+        <h1 className="text-lg font-bold leading-tight text-white">Ciclo del cultivo</h1>
+        <p className="text-xs text-slate-400 leading-tight">Etapas, labores y riesgos según el desarrollo.</p>
+      </div>
+    </header>
+  );
+
+  if (loading) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <div className="flex flex-col items-center gap-3 py-16"><ChagraGrowLoader size={56} /><p className="text-sm text-slate-400">Cargando tus ciclos…</p></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <div className="flex flex-col items-center gap-4 py-12 px-4">
+          <AlertTriangle size={44} className="text-amber-400" />
+          <p className="text-sm text-amber-200 text-center max-w-sm">{error}</p>
+          <button onClick={load} className="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2"><RotateCcw size={16} /> Reintentar</button>
+        </div>
+      </div>
+    );
+  }
+
+  // Detalle de un ciclo
+  if (selected) {
+    const a = selected.attributes || {};
+    const pestRisks = (() => {
+      try { return getPestRisksByStage(a.current_stage, a.subject_slug) || []; } catch { return []; }
+    })();
+    const tasks = (() => {
+      try { return getTasksForCycle(selected) || []; } catch { return []; }
+    })();
+    const urgent = (() => {
+      try { return getUrgentTasks(tasks) || []; } catch { return []; }
+    })();
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <div className="px-4 pb-10 flex flex-col gap-4">
+          <FarmProcessSummary process={selected} pestRisks={pestRisks} />
+          <section>
+            <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
+            <PhenologyTimeline
+              speciesSlug={a.subject_slug}
+              sowingDate={a.created_at}
+              altitudeM={altitudeM}
+            />
+          </section>
+          {tasks.length > 0 && (
+            <section>
+              <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">
+                Labores de esta etapa {urgent.length > 0 && <span className="text-amber-400">· {urgent.length} urgente(s)</span>}
+              </h2>
+              <ul className="flex flex-col gap-1.5">
+                {tasks.map((t, i) => (
+                  <li key={t.id || t.code || i} className="bg-slate-900 border border-slate-800 rounded-xl px-3 py-2 text-sm text-slate-200 flex items-center gap-2">
+                    <Sprout size={14} className="text-lime-400 shrink-0" />
+                    <span>{t.label || t.name || t.title || String(t)}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Lista de ciclos (o vacío)
+  return (
+    <div className="min-h-[100dvh] text-white">
+      {Header}
+      {cycles.length === 0 ? (
+        <div className="flex flex-col items-center gap-4 py-14 px-6 text-center">
+          <Sprout size={48} className="text-lime-500/70" />
+          <p className="text-sm text-slate-300 max-w-xs">Aún no tienes ciclos de cultivo. Registra uno contándole a Chagra qué sembraste.</p>
+          <button
+            onClick={() => onNavigate?.('procesos')}
+            className="px-6 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 rounded-xl font-bold flex items-center gap-2"
+          >
+            <Mic size={18} /> Registrar por voz
+          </button>
+        </div>
+      ) : (
+        <ul className="px-4 pb-10 flex flex-col gap-2">
+          {cycles.map((c) => {
+            const a = c.attributes || {};
+            const id = c.process_id || c.id;
+            return (
+              <li key={id}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedId(id)}
+                  className="w-full text-left bg-slate-900 border border-slate-800 hover:border-lime-700/50 rounded-xl p-3 flex items-center gap-3"
+                >
+                  <span className="w-10 h-10 rounded-full bg-lime-900/40 border border-lime-800/50 flex items-center justify-center shrink-0">
+                    <Sprout size={18} className="text-lime-400" />
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-sm font-bold text-slate-100 truncate">{a.subject_label || 'Ciclo'}</span>
+                    <span className="block text-xs text-slate-400">Etapa: {a.current_stage || '—'}{a.quantity ? ` · ${a.quantity} ${a.unit || ''}` : ''}</span>
+                  </span>
+                  <ChevronLeft size={18} className="text-slate-600 rotate-180" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/CicloCultivoScreen.test.jsx
+++ b/src/components/__tests__/CicloCultivoScreen.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * CicloCultivoScreen — cablea el track de fenología/ciclo (antes "oscuro").
+ *
+ * Contrato cubierto:
+ *   - Vacío: invita a registrar por voz (tie-in con Procesos por voz).
+ *   - Con ciclos: lista los FarmProcess y, al tocar uno, muestra el detalle con
+ *     la línea de tiempo fenológica (PhenologyTimeline) — piezas antes huérfanas.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const { listFarmProcesses } = vi.hoisted(() => ({ listFarmProcesses: vi.fn() }));
+
+vi.mock('../../db/farmProcessCache', () => ({ listFarmProcesses }));
+vi.mock('../../services/userProfileService', () => ({ getProfile: () => ({ finca_altitud: 2600 }) }));
+vi.mock('../../services/cycleTaskService', () => ({
+  getTasksForCycle: () => [{ id: 't1', label: 'Regar' }],
+  getUrgentTasks: () => [],
+}));
+vi.mock('../../services/climateCycleService', () => ({ getPestRisksByStage: () => [] }));
+
+import CicloCultivoScreen from '../CicloCultivoScreen';
+
+const CYCLE = {
+  process_id: 'p1',
+  type: 'farm_process',
+  attributes: {
+    subject_label: 'Fresa',
+    subject_slug: 'fragaria_x_ananassa',
+    current_stage: 'sowing_confirmed',
+    created_at: 1749500000000,
+    quantity: 5,
+    unit: 'plantas',
+    status: 'active',
+  },
+};
+
+beforeEach(() => { listFarmProcesses.mockReset(); });
+afterEach(() => cleanup());
+
+describe('CicloCultivoScreen — ciclo del cultivo (fenología wired)', () => {
+  it('estado vacío invita a registrar por voz', async () => {
+    listFarmProcesses.mockResolvedValue([]);
+    const onNavigate = vi.fn();
+    render(<CicloCultivoScreen onBack={() => {}} onNavigate={onNavigate} />);
+    const btn = await screen.findByText(/Registrar por voz/i);
+    fireEvent.click(btn);
+    expect(onNavigate).toHaveBeenCalledWith('procesos');
+  });
+
+  it('lista los ciclos y abre el detalle con la línea de tiempo', async () => {
+    listFarmProcesses.mockResolvedValue([CYCLE]);
+    render(<CicloCultivoScreen onBack={() => {}} onNavigate={() => {}} />);
+    // La lista muestra el cultivo.
+    const card = await screen.findByText('Fresa');
+    fireEvent.click(card);
+    // El detalle muestra la sección de línea de tiempo y las labores cableadas.
+    await waitFor(() => expect(screen.getByText(/Línea de tiempo/i)).toBeTruthy());
+    expect(screen.getByText('Regar')).toBeTruthy();
+  });
+});

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -216,13 +216,13 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   {
     id: 'ciclo',
     group: 'cultivo',
-    status: 'soon',
+    status: 'live',
     icon: '🌾',
     label: 'Ciclo del cultivo',
     desc: 'Etapas, labores y alertas según el desarrollo.',
     tool: 'phenology_cycle',
     hero: true,
-    heroRoute: { kind: 'unavailable' },
+    heroRoute: { kind: 'nav', view: 'ciclo' },
   },
   {
     id: 'procesos',


### PR DESCRIPTION
## Qué
Parte **2 de 4** de la conexión del backend oscuro (auditoría 48h). Conecta el track de **fenología/ciclo** del subsistema FarmProcess (PR #1370, ADR-047/049), que estaba mergeado sin cablear.

Nueva pantalla **`CicloCultivoScreen`** (ruta `ciclo`) que lee los ciclos de IndexedDB (`farmProcessCache.listFarmProcesses` — los crea **Procesos por voz** de la PR #1376) y arma la vista con piezas antes **huérfanas**:
- `FarmProcessSummary` — estado / etapa / riesgo
- `PhenologyTimeline` — línea de tiempo por etapa (`phenologyCalculator.calculateWindows`, altitud del perfil)
- `cycleTaskService.getTasksForCycle` — labores de la etapa actual
- `climateCycleService.getPestRisksByStage` — riesgos de plaga

Vacío → invita a **registrar por voz** (tie-in con #1376). Todo client-side, offline-first.

## Cambios
- `CicloCultivoScreen.jsx` (nuevo).
- `App.jsx` — lazy route `ciclo`.
- `agentCapabilities.js` — chip **'ciclo'** pasa de `soon`/`unavailable` a `live`/`nav`.
- Test — estado vacío + lista→detalle con línea de tiempo y labores.

## Verificación
ESLint ✓; vitest (CicloCultivo 2, agentCapabilities.audit 23) ✓. Build local OOM (memoria alpha, no código) → lo cubre CI. No pude E2E en vivo (chromium OOM); gate offline-first de CI cubre regresión.

Siguen: #3 Alertas, #4 Tareas/Observaciones al código nuevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)