### PR TITLE
feat(agent): conectar Alertas del cultivo — cropAlertEngine wired (antes oscuro)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import { prewarmCorpus } from './services/ragRetriever';
 import useThemeBackgroundStore, { getBackgroundSrc } from './store/useThemeBackgroundStore';
 import useAlertStore from './store/useAlertStore';
 import { alertEngine } from './services/alertEngine';
+import { cropAlertEngine } from './services/cropAlertEngine';
 // FieldFeedback ya no se monta globalmente en App; vive embebido en
 // HelpUsoScreen como sección de Ayuda (decisión 2026-05-21, ver
 // comentario abajo donde se removió el render).
@@ -502,6 +503,11 @@ export default function App() {
       useAlertStore.getState().initializeListeners();
       alertEngine.start().catch((err) => {
         console.warn('[App] alertEngine no pudo arrancar:', err?.message);
+      });
+      // Alertas del cultivo (plaga/etapa) desde los ciclos activos (FarmProcess)
+      // hacia el mismo chip de alertas. Degrada limpio si no hay ciclos.
+      cropAlertEngine.start().catch((err) => {
+        console.warn('[App] cropAlertEngine no pudo arrancar:', err?.message);
       });
     } catch (err) {
       console.warn('[App] Error inicializando motor de alertas:', err?.message);

--- a/src/services/__tests__/cropAlertEngine.test.js
+++ b/src/services/__tests__/cropAlertEngine.test.js
@@ -1,0 +1,69 @@
+/**
+ * cropAlertEngine — productor de alertas del cultivo (antes "oscuro").
+ *
+ * Contrato cubierto:
+ *   - Emite 'alertTriggered' (mismo canal que el clima → chip del home) cuando un
+ *     ciclo activo tiene riesgo de plaga crítico/alto en su etapa.
+ *   - severity: crítico→danger, alto→warning.
+ *   - Limpia ('alertCleared') cuando no hay riesgo.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { listFarmProcesses, getPestRisksByStage } = vi.hoisted(() => ({
+  listFarmProcesses: vi.fn(),
+  getPestRisksByStage: vi.fn(),
+}));
+
+vi.mock('../../db/farmProcessCache', () => ({ listFarmProcesses }));
+vi.mock('../climateCycleService', () => ({ getPestRisksByStage }));
+
+import { runCropAlerts } from '../cropAlertEngine';
+
+const cycle = (id, stage = 'vegetative', slug = 'coffea_arabica', label = 'Café') => ({
+  process_id: id,
+  attributes: { current_stage: stage, subject_slug: slug, subject_label: label, status: 'active' },
+});
+
+let events;
+beforeEach(() => {
+  listFarmProcesses.mockReset();
+  getPestRisksByStage.mockReset();
+  events = [];
+  vi.spyOn(window, 'dispatchEvent').mockImplementation((ev) => {
+    events.push({ name: ev.type, detail: ev.detail });
+    return true;
+  });
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('cropAlertEngine.runCropAlerts', () => {
+  it('emite alertTriggered con severity danger ante riesgo crítico', async () => {
+    listFarmProcesses.mockResolvedValue([cycle('p1')]);
+    getPestRisksByStage.mockReturnValue([
+      { pest: 'Broca del café', risk: 'crítico', control: 'Trampas Brocap' },
+    ]);
+    const res = await runCropAlerts();
+    expect(res.emitted).toBe(1);
+    const triggered = events.find((e) => e.name === 'alertTriggered');
+    expect(triggered).toBeTruthy();
+    expect(triggered.detail.type).toBe('crop_pest_p1');
+    expect(triggered.detail.severity).toBe('danger');
+    expect(triggered.detail.message).toMatch(/Broca/);
+  });
+
+  it('emite alertCleared cuando no hay riesgo en la etapa', async () => {
+    listFarmProcesses.mockResolvedValue([cycle('p2', 'sowing')]);
+    getPestRisksByStage.mockReturnValue([]);
+    const res = await runCropAlerts();
+    expect(res.cleared).toBe(1);
+    expect(events.some((e) => e.name === 'alertCleared' && e.detail.type === 'crop_pest_p2')).toBe(true);
+    expect(events.some((e) => e.name === 'alertTriggered')).toBe(false);
+  });
+
+  it('degrada limpio sin ciclos', async () => {
+    listFarmProcesses.mockResolvedValue([]);
+    const res = await runCropAlerts();
+    expect(res).toEqual({ emitted: 0, cleared: 0 });
+    expect(events.length).toBe(0);
+  });
+});

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -238,13 +238,13 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   {
     id: 'alertas-cultivo',
     group: 'cuidar',
-    status: 'soon',
+    status: 'live',
     icon: '🔔',
     label: 'Alertas del cultivo',
     desc: 'Avisos anticipados de riesgo por clima, plagas y etapa.',
     tool: 'crop_alerts',
     hero: true,
-    heroRoute: { kind: 'unavailable' },
+    heroRoute: { kind: 'nav', view: 'ciclo' },
   },
 ]);
 

--- a/src/services/cropAlertEngine.js
+++ b/src/services/cropAlertEngine.js
@@ -1,0 +1,103 @@
+/**
+ * cropAlertEngine — productor de ALERTAS DEL CULTIVO (plaga/etapa).
+ *
+ * Cablea el track de alertas del subsistema FarmProcess (PR #1370, ADR-049) que
+ * estaba "oscuro". Lee los ciclos activos de IndexedDB (farmProcessCache) y, por
+ * la etapa fenológica actual + la especie, deriva el riesgo de plaga dominante
+ * (climateCycleService.getPestRisksByStage) y lo empuja al MISMO canal que las
+ * alertas de clima: el evento 'alertTriggered' → useAlertStore → chip de alerta
+ * del home (AgentHero). Degrada limpio si no hay ciclos o no hay riesgo.
+ *
+ * Reusa la infraestructura existente de alertEngine (clima): cada alerta tiene
+ * un `type` estable (`crop_pest_<processId>`) para de-dup/limpieza, y emite
+ * 'alertCleared' cuando el riesgo desaparece.
+ */
+import { listFarmProcesses } from '../db/farmProcessCache';
+import { getPestRisksByStage } from './climateCycleService';
+
+const SEVERITY_BY_RISK = { 'crítico': 'danger', critico: 'danger', alto: 'warning' };
+
+function emit(name, detail) {
+  try {
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      window.dispatchEvent(new CustomEvent(name, { detail }));
+    }
+  } catch {
+    /* SSR/test sin window — noop */
+  }
+}
+
+/**
+ * Escanea los ciclos activos y emite/limpia alertas de plaga por etapa.
+ * @returns {Promise<{emitted:number, cleared:number}>}
+ */
+export async function runCropAlerts() {
+  let cycles = [];
+  try {
+    cycles = (await listFarmProcesses({ status: 'active' })) || [];
+  } catch {
+    return { emitted: 0, cleared: 0 };
+  }
+
+  let emitted = 0;
+  let cleared = 0;
+  for (const c of cycles) {
+    const a = c?.attributes || {};
+    const id = c?.process_id || c?.id;
+    if (!id) continue;
+    const type = `crop_pest_${id}`;
+
+    let risks = [];
+    try {
+      risks = getPestRisksByStage(a.current_stage, a.subject_slug) || [];
+    } catch {
+      risks = [];
+    }
+    const top = risks.find((r) => r.risk === 'crítico' || r.risk === 'critico')
+      || risks.find((r) => r.risk === 'alto');
+
+    if (top) {
+      emit('alertTriggered', {
+        type,
+        severity: SEVERITY_BY_RISK[top.risk] || 'warning',
+        title: `Riesgo de plaga en ${a.subject_label || 'tu cultivo'}`,
+        message: `${top.pest}. ${top.control}`,
+        source: 'crop',
+        processId: id,
+      });
+      emitted++;
+    } else {
+      emit('alertCleared', { type });
+      cleared++;
+    }
+  }
+  return { emitted, cleared };
+}
+
+let started = false;
+
+export const cropAlertEngine = {
+  /**
+   * Arranca el motor: corre una pasada y re-evalúa cuando cambian los ciclos
+   * ('farmProcessChanged', emitido por farmEventService.createFarmProcess).
+   * Idempotente (singleton).
+   */
+  async start() {
+    if (started) {
+      await runCropAlerts();
+      return this;
+    }
+    started = true;
+    if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+      window.addEventListener('farmProcessChanged', runCropAlerts);
+    }
+    await runCropAlerts();
+    return this;
+  },
+  stop() {
+    if (typeof window !== 'undefined' && typeof window.removeEventListener === 'function') {
+      window.removeEventListener('farmProcessChanged', runCropAlerts);
+    }
+    started = false;
+  },
+};

--- a/src/services/farmEventService.js
+++ b/src/services/farmEventService.js
@@ -120,7 +120,16 @@ export const createFarmProcess = async (process) => {
 
     evStore.add(event);
 
-    tx.oncomplete = () => resolve({ process, event });
+    tx.oncomplete = () => {
+      // Avisa a quien escuche (cropAlertEngine) que cambió un ciclo, para
+      // re-evaluar alertas de plaga/etapa. Guard SSR/test.
+      try {
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+          window.dispatchEvent(new CustomEvent('farmProcessChanged', { detail: { process_id: process.process_id } }));
+        }
+      } catch { /* noop */ }
+      resolve({ process, event });
+    };
     tx.onerror = () => reject(tx.error);
   });
 };


### PR DESCRIPTION
## Qué
Parte **3 de 4** de la conexión del backend oscuro (auditoría 48h). Conecta el track de **alertas** del subsistema FarmProcess (PR #1370, ADR-049).

Nuevo **`cropAlertEngine`**: lee los ciclos activos (`farmProcessCache.listFarmProcesses` — los crea Procesos por voz) y, por etapa fenológica + especie, deriva el **riesgo de plaga** dominante (`climateCycleService.getPestRisksByStage`) y lo empuja al **mismo canal que el clima**: evento `alertTriggered` → `useAlertStore` → chip de alerta del home (AgentHero). Reusa toda la infra de alertas existente. Degrada limpio sin ciclos/riesgo.

## Cambios
- `cropAlertEngine.js` (nuevo) — `runCropAlerts` + singleton; `type` estable `crop_pest_<id>` para de-dup; `alertCleared` cuando el riesgo desaparece.
- `App.jsx` — arranca `cropAlertEngine` junto a `alertEngine`.
- `farmEventService.createFarmProcess` — emite `farmProcessChanged` → re-evalúa alertas al registrar un ciclo nuevo.
- `agentCapabilities.js` — chip **'alertas-cultivo'** pasa de `soon`/`unavailable` a `live` (nav al ciclo).
- Test — danger ante riesgo crítico, `alertCleared` sin riesgo, degrada vacío.

## Verificación
ESLint ✓; vitest (cropAlertEngine 3, farmEventService 6, audit 23) ✓. Build local OOM (memoria alpha) → CI. Gate offline-first de CI cubre regresión.

Sigue: #4 Tareas/Observaciones al código nuevo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)