### PR TITLE
feat(agent): conectar Tareas/Observaciones del ciclo — DailyTasksView + observación (antes oscuro)

### DIFF
--- a/src/components/CicloCultivoScreen.jsx
+++ b/src/components/CicloCultivoScreen.jsx
@@ -6,6 +6,8 @@ import { getTasksForCycle, getUrgentTasks } from '../services/cycleTaskService';
 import { getPestRisksByStage } from '../services/climateCycleService';
 import FarmProcessSummary from './FarmProcessSummary';
 import PhenologyTimeline from './PhenologyTimeline';
+import DailyTasksView from './DailyTasksView';
+import CicloObservacion from './CicloObservacion';
 import ChagraGrowLoader from './ChagraGrowLoader';
 
 /**
@@ -107,6 +109,7 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
         {Header}
         <div className="px-4 pb-10 flex flex-col gap-4">
           <FarmProcessSummary process={selected} pestRisks={pestRisks} />
+          <CicloObservacion processId={selectedId} onSaved={load} />
           <section>
             <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
             <PhenologyTimeline
@@ -151,7 +154,10 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
           </button>
         </div>
       ) : (
-        <ul className="px-4 pb-10 flex flex-col gap-2">
+        <div className="px-4 pb-10 flex flex-col gap-3">
+          {/* Digest "para hoy": labores urgentes agregadas de todos los ciclos. */}
+          <DailyTasksView processes={cycles} />
+          <ul className="flex flex-col gap-2">
           {cycles.map((c) => {
             const a = c.attributes || {};
             const id = c.process_id || c.id;
@@ -174,7 +180,8 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
               </li>
             );
           })}
-        </ul>
+          </ul>
+        </div>
       )}
     </div>
   );

--- a/src/components/CicloObservacion.jsx
+++ b/src/components/CicloObservacion.jsx
@@ -1,0 +1,124 @@
+import { useCallback, useState } from 'react';
+import { Mic, MicOff, NotebookPen, Check } from 'lucide-react';
+import useVoiceRecorder from '../hooks/useVoiceRecorder';
+import { transcribe } from '../services/voiceService';
+import { registerObservation } from '../services/observationService';
+import { registerVoiceObservation } from '../services/voiceObservationService';
+
+/**
+ * CicloObservacion — anotar una observación de campo en un ciclo (FarmProcess),
+ * por texto o por voz. Cablea el track de observaciones del subsistema
+ * FarmProcess (PR #1370, ADR-050) que estaba "oscuro": observationService
+ * (texto) + voiceObservationService (voz) → recordFarmEvent (evento del ciclo
+ * en IndexedDB). ADITIVO: NO reemplaza el ObservationScreen general (que sigue
+ * registrando contra FarmOS); esto ata la nota al ciclo.
+ */
+export default function CicloObservacion({ processId, onSaved }) {
+  const { durationMs, start, stop, reset, error: recorderError } = useVoiceRecorder();
+  const [text, setText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [savedMsg, setSavedMsg] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const flashSaved = useCallback((msg) => {
+    setSavedMsg(msg);
+    setText('');
+    onSaved?.();
+    setTimeout(() => setSavedMsg(''), 2500);
+  }, [onSaved]);
+
+  const saveText = useCallback(async () => {
+    const t = text.trim();
+    if (!t || saving) return;
+    setSaving(true);
+    setErrorMsg('');
+    try {
+      await registerObservation({ processId, text: t, actor: 'operator', source: 'text' });
+      flashSaved('Observación guardada.');
+    } catch (err) {
+      setErrorMsg(`No se pudo guardar: ${err.message}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [text, saving, processId, flashSaved]);
+
+  const toggleVoice = useCallback(async () => {
+    if (saving) return;
+    if (!recording) {
+      setErrorMsg('');
+      try {
+        await start();
+        setRecording(true);
+      } catch (err) {
+        setErrorMsg(err.message || 'No se pudo grabar');
+      }
+      return;
+    }
+    // detener + transcribir + registrar como observación de voz
+    setRecording(false);
+    setSaving(true);
+    try {
+      const result = await stop();
+      if (!result || !result.blob || result.blob.size === 0) {
+        setErrorMsg('Grabación vacía.');
+        return;
+      }
+      const transcription = await transcribe(result.blob);
+      await registerVoiceObservation({ processId, transcription, actor: 'operator' });
+      flashSaved('Observación de voz guardada.');
+    } catch (err) {
+      setErrorMsg(`No se pudo guardar la voz: ${err.message}`);
+    } finally {
+      reset();
+      setSaving(false);
+    }
+  }, [recording, saving, start, stop, reset, processId, flashSaved]);
+
+  return (
+    <section className="bg-slate-900 border border-slate-800 rounded-xl p-3 flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <NotebookPen size={14} className="text-lime-400" />
+        <span className="text-2xs uppercase font-bold text-slate-400 tracking-wide">Anotar observación</span>
+      </div>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={2}
+        placeholder="¿Qué viste en el cultivo? (ej. aparecieron pulgones en las hojas nuevas)"
+        aria-label="Observación de campo"
+        disabled={saving || recording}
+        className="w-full bg-slate-950/60 border border-slate-800 rounded-lg px-3 py-2 text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none focus:border-lime-700 resize-none"
+      />
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={toggleVoice}
+          disabled={saving && !recording}
+          aria-label={recording ? 'Detener y guardar observación de voz' : 'Anotar observación por voz'}
+          className={`w-11 h-11 shrink-0 rounded-full flex items-center justify-center ${
+            recording ? 'bg-red-600 hover:bg-red-500 animate-pulse' : 'bg-slate-800 hover:bg-slate-700'
+          }`}
+        >
+          {recording ? <MicOff size={18} className="text-white" /> : <Mic size={18} className="text-slate-200" />}
+        </button>
+        {recording ? (
+          <span className="flex-1 text-sm text-red-400 tabular-nums">Grabando… {Math.floor((durationMs || 0) / 1000)}s</span>
+        ) : (
+          <button
+            type="button"
+            onClick={saveText}
+            disabled={!text.trim() || saving}
+            className="flex-1 px-4 py-2.5 min-h-[44px] bg-lime-700 hover:bg-lime-600 disabled:bg-slate-700 disabled:text-slate-500 text-white rounded-lg font-bold text-sm"
+          >
+            {saving ? 'Guardando…' : 'Guardar nota'}
+          </button>
+        )}
+      </div>
+      {savedMsg && (
+        <p className="text-xs text-green-400 flex items-center gap-1"><Check size={12} /> {savedMsg}</p>
+      )}
+      {(errorMsg || recorderError) && <p className="text-xs text-amber-400">{errorMsg || recorderError}</p>}
+    </section>
+  );
+}

--- a/src/components/__tests__/CicloCultivoScreen.test.jsx
+++ b/src/components/__tests__/CicloCultivoScreen.test.jsx
@@ -18,6 +18,8 @@ vi.mock('../../services/cycleTaskService', () => ({
   getUrgentTasks: () => [],
 }));
 vi.mock('../../services/climateCycleService', () => ({ getPestRisksByStage: () => [] }));
+// El widget de observación tiene su propio test; acá se stubea para aislar.
+vi.mock('../CicloObservacion', () => ({ default: () => null }));
 
 import CicloCultivoScreen from '../CicloCultivoScreen';
 
@@ -51,8 +53,9 @@ describe('CicloCultivoScreen — ciclo del cultivo (fenología wired)', () => {
   it('lista los ciclos y abre el detalle con la línea de tiempo', async () => {
     listFarmProcesses.mockResolvedValue([CYCLE]);
     render(<CicloCultivoScreen onBack={() => {}} onNavigate={() => {}} />);
-    // La lista muestra el cultivo.
-    const card = await screen.findByText('Fresa');
+    // La tarjeta de la lista es un botón con el cultivo (hay otros "Fresa" en el
+    // digest DailyTasksView, por eso se apunta al botón, no al texto suelto).
+    const card = await screen.findByRole('button', { name: /Fresa/ });
     fireEvent.click(card);
     // El detalle muestra la sección de línea de tiempo y las labores cableadas.
     await waitFor(() => expect(screen.getByText(/Línea de tiempo/i)).toBeTruthy());

--- a/src/components/__tests__/CicloObservacion.test.jsx
+++ b/src/components/__tests__/CicloObservacion.test.jsx
@@ -1,0 +1,53 @@
+/**
+ * CicloObservacion — cablea el track de observaciones (antes "oscuro").
+ *
+ * Contrato cubierto: anotar una observación de TEXTO en un ciclo llama a
+ * observationService.registerObservation con el processId y el texto, y limpia
+ * el campo. (La voz reusa el mismo pipeline; cubierta por su propio servicio.)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const { registerObservation, registerVoiceObservation, transcribe } = vi.hoisted(() => ({
+  registerObservation: vi.fn(),
+  registerVoiceObservation: vi.fn(),
+  transcribe: vi.fn(),
+}));
+
+vi.mock('../../hooks/useVoiceRecorder', () => ({
+  default: () => ({ durationMs: 0, start: vi.fn(), stop: vi.fn(), reset: vi.fn(), error: null }),
+}));
+vi.mock('../../services/voiceService', () => ({ transcribe }));
+vi.mock('../../services/observationService', () => ({ registerObservation }));
+vi.mock('../../services/voiceObservationService', () => ({ registerVoiceObservation }));
+
+import CicloObservacion from '../CicloObservacion';
+
+beforeEach(() => {
+  registerObservation.mockReset().mockResolvedValue({ ok: true });
+  registerVoiceObservation.mockReset().mockResolvedValue({ ok: true });
+});
+afterEach(() => cleanup());
+
+describe('CicloObservacion — anotar observación en un ciclo', () => {
+  it('guarda una nota de texto vía observationService.registerObservation', async () => {
+    const onSaved = vi.fn();
+    render(<CicloObservacion processId="p1" onSaved={onSaved} />);
+
+    fireEvent.change(screen.getByLabelText('Observación de campo'), {
+      target: { value: 'aparecieron pulgones en las hojas' },
+    });
+    fireEvent.click(screen.getByText('Guardar nota'));
+
+    await waitFor(() => expect(registerObservation).toHaveBeenCalledTimes(1));
+    const arg = registerObservation.mock.calls[0][0];
+    expect(arg.processId).toBe('p1');
+    expect(arg.text).toMatch(/pulgones/);
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+  });
+
+  it('no guarda con el campo vacío', () => {
+    render(<CicloObservacion processId="p1" onSaved={() => {}} />);
+    expect(screen.getByText('Guardar nota').disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Qué
Parte **4 de 4** (final) de la conexión del backend oscuro (auditoría 48h). Conecta el track de **tareas-por-ciclo** y **observaciones** del subsistema FarmProcess (PR #1370, ADR-050).

**ADITIVO, sin regresión**: NO reemplaza `TaskLogScreen` ni `ObservationScreen` (siguen funcionando contra FarmOS). El código nuevo es *cycle-scoped* y **complementa** — al leer el código, `DailyTasksView`/`observationService` no son drop-in de las vistas viejas (esas son la cola FarmOS y la observación general), así que reemplazarlas habría **regresado** funcionalidad viva.

## Cambios
- `DailyTasksView` (antes huérfano) → digest **"para hoy"** de labores urgentes agregadas de todos los ciclos activos, en la lista de Ciclo del cultivo.
- `CicloObservacion.jsx` (nuevo) → anotar observación en un ciclo por **texto** (`observationService.registerObservation`) o **voz** (`voiceObservationService.registerVoiceObservation` → `recordFarmEvent`), en el detalle del ciclo.
- Tests — guarda nota de texto + invariante "no guarda vacío"; ajuste del test del ciclo.

## Verificación
ESLint ✓; vitest (CicloObservacion 2, CicloCultivo 2, audit 23) ✓. Build local OOM (memoria alpha) → CI. Gate offline-first cubre regresión.

Cierra el subsistema FarmProcess: **voz→ciclo · fenología · alertas · tareas · observaciones**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)