### PR TITLE
feat(agent): enriquecer detalle del ciclo — etapa/biopreparados/labores

### DIFF
--- a/src/components/CicloCultivoScreen.jsx
+++ b/src/components/CicloCultivoScreen.jsx
@@ -2,12 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, Sprout, Mic, RotateCcw, AlertTriangle } from 'lucide-react';
 import { listFarmProcesses } from '../db/farmProcessCache';
 import { getProfile } from '../services/userProfileService';
-import { getTasksForCycle, getUrgentTasks } from '../services/cycleTaskService';
-import { getPestRisksByStage } from '../services/climateCycleService';
-import FarmProcessSummary from './FarmProcessSummary';
-import PhenologyTimeline from './PhenologyTimeline';
 import DailyTasksView from './DailyTasksView';
-import CicloObservacion from './CicloObservacion';
+import CicloDetalle from './CicloDetalle';
 import ChagraGrowLoader from './ChagraGrowLoader';
 
 /**
@@ -94,46 +90,10 @@ export default function CicloCultivoScreen({ onBack, onNavigate }) {
 
   // Detalle de un ciclo
   if (selected) {
-    const a = selected.attributes || {};
-    const pestRisks = (() => {
-      try { return getPestRisksByStage(a.current_stage, a.subject_slug) || []; } catch { return []; }
-    })();
-    const tasks = (() => {
-      try { return getTasksForCycle(selected) || []; } catch { return []; }
-    })();
-    const urgent = (() => {
-      try { return getUrgentTasks(tasks) || []; } catch { return []; }
-    })();
     return (
       <div className="min-h-[100dvh] text-white">
         {Header}
-        <div className="px-4 pb-10 flex flex-col gap-4">
-          <FarmProcessSummary process={selected} pestRisks={pestRisks} />
-          <CicloObservacion processId={selectedId} onSaved={load} />
-          <section>
-            <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
-            <PhenologyTimeline
-              speciesSlug={a.subject_slug}
-              sowingDate={a.created_at}
-              altitudeM={altitudeM}
-            />
-          </section>
-          {tasks.length > 0 && (
-            <section>
-              <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">
-                Labores de esta etapa {urgent.length > 0 && <span className="text-amber-400">· {urgent.length} urgente(s)</span>}
-              </h2>
-              <ul className="flex flex-col gap-1.5">
-                {tasks.map((t, i) => (
-                  <li key={t.id || t.code || i} className="bg-slate-900 border border-slate-800 rounded-xl px-3 py-2 text-sm text-slate-200 flex items-center gap-2">
-                    <Sprout size={14} className="text-lime-400 shrink-0" />
-                    <span>{t.label || t.name || t.title || String(t)}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-        </div>
+        <CicloDetalle cycle={selected} altitudeM={altitudeM} onReload={load} />
       </div>
     );
   }

--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -1,0 +1,142 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Sprout, FlaskConical } from 'lucide-react';
+import FarmProcessSummary from './FarmProcessSummary';
+import PhenologyTimeline from './PhenologyTimeline';
+import CicloObservacion from './CicloObservacion';
+import { getTasksForCycle, getUrgentTasks } from '../services/cycleTaskService';
+import { getPestRisksByStage, getBiopreparadosForStage } from '../services/climateCycleService';
+import { confirmStage } from '../services/stageConfirmationService';
+import { completeTaskByVoice } from '../services/voiceTaskService';
+
+/**
+ * CicloDetalle — detalle de un ciclo (FarmProcess) con el enriquecimiento del
+ * subsistema antes "oscuro": además del resumen + fenología + labores, cablea:
+ *   - confirmar/corregir la ETAPA del ciclo (stageConfirmationService)
+ *   - BIOPREPARADOS recomendados por etapa (climateCycleService)
+ *   - marcar una LABOR como hecha por voz/tap (voiceTaskService)
+ * (La sugerencia de etapa desde la observación vive en CicloObservacion.)
+ */
+const STAGE_LABELS = {
+  sowing: 'Siembra', emergence: 'Brotó', vegetative: 'Creciendo',
+  flowering: 'Floración', fruiting: 'Frutos', harvest_window: 'Cosecha', closed: 'Terminado',
+};
+const STAGE_ORDER = ['sowing', 'emergence', 'vegetative', 'flowering', 'fruiting', 'harvest_window', 'closed'];
+const baseStage = (code) => String(code || '').replace(/_confirmed$/, '');
+const stageLabel = (code) => STAGE_LABELS[baseStage(code)] || code || '—';
+
+export default function CicloDetalle({ cycle, altitudeM, onReload }) {
+  const a = cycle.attributes || {};
+  const processId = cycle.process_id || cycle.id;
+  const [pickStage, setPickStage] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [doneTasks, setDoneTasks] = useState({});
+
+  const pestRisks = useMemo(() => { try { return getPestRisksByStage(a.current_stage, a.subject_slug) || []; } catch { return []; } }, [a.current_stage, a.subject_slug]);
+  const bios = useMemo(() => { try { return getBiopreparadosForStage(baseStage(a.current_stage)) || []; } catch { return []; } }, [a.current_stage]);
+  const tasks = useMemo(() => { try { return getTasksForCycle(cycle) || []; } catch { return []; } }, [cycle]);
+  const urgent = useMemo(() => { try { return getUrgentTasks(tasks) || []; } catch { return []; } }, [tasks]);
+
+  const handleStage = useCallback(async (newStage) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await confirmStage({ processId, newStage, actor: 'operator', reason: 'observado en campo' });
+      setPickStage(false);
+      onReload?.();
+    } catch (e) { console.warn('[CicloDetalle] confirmStage:', e.message); }
+    finally { setBusy(false); }
+  }, [busy, processId, onReload]);
+
+  const handleDone = useCallback(async (taskName) => {
+    if (doneTasks[taskName]) return;
+    try {
+      await completeTaskByVoice({ processId, taskName, actor: 'operator' });
+      setDoneTasks((d) => ({ ...d, [taskName]: true }));
+    } catch (e) { console.warn('[CicloDetalle] completeTask:', e.message); }
+  }, [processId, doneTasks]);
+
+  return (
+    <div className="px-4 pb-10 flex flex-col gap-4">
+      <FarmProcessSummary process={cycle} pestRisks={pestRisks} />
+
+      {/* Etapa actual + confirmar cambio (stageConfirmationService) */}
+      <section className="bg-slate-900 border border-slate-800 rounded-xl p-3">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm text-slate-300">Etapa: <strong className="text-lime-300">{stageLabel(a.current_stage)}</strong></span>
+          <button
+            type="button"
+            onClick={() => setPickStage((o) => !o)}
+            className="text-xs font-bold text-lime-400 px-2.5 py-1.5 rounded-lg border border-lime-800/60 shrink-0"
+          >
+            ¿Cambió de etapa?
+          </button>
+        </div>
+        {pickStage && (
+          <div className="mt-2.5 flex flex-wrap gap-1.5">
+            {STAGE_ORDER.map((s) => (
+              <button
+                key={s}
+                type="button"
+                disabled={busy}
+                onClick={() => handleStage(s)}
+                aria-label={`Confirmar etapa ${STAGE_LABELS[s]}`}
+                className="text-xs px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 disabled:opacity-50"
+              >
+                {STAGE_LABELS[s]}
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <CicloObservacion processId={processId} currentStage={a.current_stage} onSaved={onReload} />
+
+      <section>
+        <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
+        <PhenologyTimeline speciesSlug={a.subject_slug} sowingDate={a.created_at} altitudeM={altitudeM} />
+      </section>
+
+      {bios.length > 0 && (
+        <section>
+          <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Biopreparados para esta etapa</h2>
+          <ul className="flex flex-col gap-1.5">
+            {bios.map((b, i) => (
+              <li key={b.nombre || i} className="bg-slate-900 border border-slate-800 rounded-xl px-3 py-2 flex items-start gap-2">
+                <FlaskConical size={14} className="text-emerald-400 shrink-0 mt-0.5" />
+                <span className="text-sm text-slate-200"><strong>{b.nombre}</strong> — <span className="text-slate-400">{b.uso}</span></span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {tasks.length > 0 && (
+        <section>
+          <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">
+            Labores de esta etapa {urgent.length > 0 && <span className="text-amber-400">· {urgent.length} urgente(s)</span>}
+          </h2>
+          <ul className="flex flex-col gap-1.5">
+            {tasks.map((t, i) => {
+              const label = t.label || t.name || t.title || String(t);
+              const done = !!doneTasks[label];
+              return (
+                <li key={t.id || t.code || i} className="bg-slate-900 border border-slate-800 rounded-xl px-3 py-2 text-sm text-slate-200 flex items-center gap-2">
+                  <Sprout size={14} className="text-lime-400 shrink-0" />
+                  <span className="flex-1 min-w-0">{label}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleDone(label)}
+                    disabled={done}
+                    className={`text-xs font-bold px-2.5 py-1 rounded-lg shrink-0 ${done ? 'text-green-400' : 'text-slate-200 bg-slate-800 hover:bg-slate-700'}`}
+                  >
+                    {done ? '✓ Hecho' : 'Marcar hecha'}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/CicloObservacion.jsx
+++ b/src/components/CicloObservacion.jsx
@@ -4,6 +4,14 @@ import useVoiceRecorder from '../hooks/useVoiceRecorder';
 import { transcribe } from '../services/voiceService';
 import { registerObservation } from '../services/observationService';
 import { registerVoiceObservation } from '../services/voiceObservationService';
+import { suggestStageFromText } from '../services/stageSuggestionService';
+import { confirmStage } from '../services/stageConfirmationService';
+
+const STAGE_LABELS = {
+  sowing: 'Siembra', emergence: 'Brotó', vegetative: 'Creciendo',
+  flowering: 'Floración', fruiting: 'Frutos', harvest_window: 'Cosecha', closed: 'Terminado',
+};
+const baseStage = (c) => String(c || '').replace(/_confirmed$/, '');
 
 /**
  * CicloObservacion — anotar una observación de campo en un ciclo (FarmProcess),
@@ -13,13 +21,14 @@ import { registerVoiceObservation } from '../services/voiceObservationService';
  * en IndexedDB). ADITIVO: NO reemplaza el ObservationScreen general (que sigue
  * registrando contra FarmOS); esto ata la nota al ciclo.
  */
-export default function CicloObservacion({ processId, onSaved }) {
+export default function CicloObservacion({ processId, currentStage, onSaved }) {
   const { durationMs, start, stop, reset, error: recorderError } = useVoiceRecorder();
   const [text, setText] = useState('');
   const [saving, setSaving] = useState(false);
   const [recording, setRecording] = useState(false);
   const [savedMsg, setSavedMsg] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
+  const [suggestion, setSuggestion] = useState(null);
 
   const flashSaved = useCallback((msg) => {
     setSavedMsg(msg);
@@ -28,6 +37,26 @@ export default function CicloObservacion({ processId, onSaved }) {
     setTimeout(() => setSavedMsg(''), 2500);
   }, [onSaved]);
 
+  // Sugiere una etapa fenológica a partir del texto observado; solo si difiere
+  // de la etapa actual del ciclo. No cambia nada — espera confirmación humana.
+  const maybeSuggestStage = useCallback((observed) => {
+    try {
+      const s = suggestStageFromText(observed);
+      if (s && s.suggestedStage && s.suggestedStage !== baseStage(currentStage)) {
+        setSuggestion(s);
+      }
+    } catch { /* heurística opcional */ }
+  }, [currentStage]);
+
+  const confirmSuggested = useCallback(async () => {
+    if (!suggestion) return;
+    try {
+      await confirmStage({ processId, newStage: suggestion.suggestedStage, actor: 'operator', reason: 'sugerida por observación', confidence: suggestion.confidence });
+      setSuggestion(null);
+      onSaved?.();
+    } catch (err) { setErrorMsg(`No se pudo confirmar la etapa: ${err.message}`); }
+  }, [suggestion, processId, onSaved]);
+
   const saveText = useCallback(async () => {
     const t = text.trim();
     if (!t || saving) return;
@@ -35,13 +64,14 @@ export default function CicloObservacion({ processId, onSaved }) {
     setErrorMsg('');
     try {
       await registerObservation({ processId, text: t, actor: 'operator', source: 'text' });
+      maybeSuggestStage(t);
       flashSaved('Observación guardada.');
     } catch (err) {
       setErrorMsg(`No se pudo guardar: ${err.message}`);
     } finally {
       setSaving(false);
     }
-  }, [text, saving, processId, flashSaved]);
+  }, [text, saving, processId, flashSaved, maybeSuggestStage]);
 
   const toggleVoice = useCallback(async () => {
     if (saving) return;
@@ -66,6 +96,7 @@ export default function CicloObservacion({ processId, onSaved }) {
       }
       const transcription = await transcribe(result.blob);
       await registerVoiceObservation({ processId, transcription, actor: 'operator' });
+      maybeSuggestStage(transcription);
       flashSaved('Observación de voz guardada.');
     } catch (err) {
       setErrorMsg(`No se pudo guardar la voz: ${err.message}`);
@@ -73,7 +104,7 @@ export default function CicloObservacion({ processId, onSaved }) {
       reset();
       setSaving(false);
     }
-  }, [recording, saving, start, stop, reset, processId, flashSaved]);
+  }, [recording, saving, start, stop, reset, processId, flashSaved, maybeSuggestStage]);
 
   return (
     <section className="bg-slate-900 border border-slate-800 rounded-xl p-3 flex flex-col gap-2">
@@ -117,6 +148,15 @@ export default function CicloObservacion({ processId, onSaved }) {
       </div>
       {savedMsg && (
         <p className="text-xs text-green-400 flex items-center gap-1"><Check size={12} /> {savedMsg}</p>
+      )}
+      {suggestion && (
+        <div className="mt-1 bg-lime-900/20 border border-lime-800/50 rounded-lg p-2.5 flex items-center gap-2">
+          <span className="flex-1 text-xs text-lime-200">
+            Por lo que anotaste, parece etapa <strong>{STAGE_LABELS[suggestion.suggestedStage] || suggestion.suggestedStage}</strong>. ¿La confirmas?
+          </span>
+          <button type="button" onClick={confirmSuggested} className="text-xs font-bold px-2.5 py-1.5 rounded-lg bg-lime-700 hover:bg-lime-600 text-white shrink-0">Sí</button>
+          <button type="button" onClick={() => setSuggestion(null)} className="text-xs font-bold px-2 py-1.5 rounded-lg bg-slate-800 text-slate-300 shrink-0">No</button>
+        </div>
       )}
       {(errorMsg || recorderError) && <p className="text-xs text-amber-400">{errorMsg || recorderError}</p>}
     </section>

--- a/src/components/__tests__/CicloDetalle.test.jsx
+++ b/src/components/__tests__/CicloDetalle.test.jsx
@@ -1,0 +1,57 @@
+/**
+ * CicloDetalle — enriquecimiento del detalle del ciclo (antes "oscuro"):
+ * confirmar etapa (stageConfirmationService), biopreparados por etapa
+ * (climateCycleService) y completar labor (voiceTaskService).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const { confirmStage, completeTaskByVoice } = vi.hoisted(() => ({
+  confirmStage: vi.fn(), completeTaskByVoice: vi.fn(),
+}));
+
+vi.mock('../FarmProcessSummary', () => ({ default: () => null }));
+vi.mock('../PhenologyTimeline', () => ({ default: () => null }));
+vi.mock('../CicloObservacion', () => ({ default: () => null }));
+vi.mock('../../services/cycleTaskService', () => ({
+  getTasksForCycle: () => [{ id: 't1', label: 'Regar el café' }],
+  getUrgentTasks: () => [],
+}));
+vi.mock('../../services/climateCycleService', () => ({
+  getPestRisksByStage: () => [],
+  getBiopreparadosForStage: () => [{ nombre: 'Caldo bordelés', uso: 'Preventivo fungoso' }],
+}));
+vi.mock('../../services/stageConfirmationService', () => ({ confirmStage }));
+vi.mock('../../services/voiceTaskService', () => ({ completeTaskByVoice }));
+
+import CicloDetalle from '../CicloDetalle';
+
+const CYCLE = { process_id: 'p1', attributes: { subject_label: 'Café', subject_slug: 'coffea_arabica', current_stage: 'vegetative', status: 'active' } };
+
+beforeEach(() => { confirmStage.mockReset().mockResolvedValue({}); completeTaskByVoice.mockReset().mockResolvedValue({}); });
+afterEach(() => cleanup());
+
+describe('CicloDetalle', () => {
+  it('muestra biopreparados de la etapa y la labor', () => {
+    render(<CicloDetalle cycle={CYCLE} altitudeM={1500} onReload={() => {}} />);
+    expect(screen.getByText('Caldo bordelés')).toBeTruthy();
+    expect(screen.getByText('Regar el café')).toBeTruthy();
+  });
+
+  it('confirmar etapa llama a confirmStage con el processId', async () => {
+    const onReload = vi.fn();
+    render(<CicloDetalle cycle={CYCLE} altitudeM={1500} onReload={onReload} />);
+    fireEvent.click(screen.getByText('¿Cambió de etapa?'));
+    fireEvent.click(screen.getByLabelText('Confirmar etapa Floración'));
+    await waitFor(() => expect(confirmStage).toHaveBeenCalledTimes(1));
+    expect(confirmStage.mock.calls[0][0]).toMatchObject({ processId: 'p1', newStage: 'flowering' });
+    await waitFor(() => expect(onReload).toHaveBeenCalled());
+  });
+
+  it('marcar labor hecha llama a completeTaskByVoice', async () => {
+    render(<CicloDetalle cycle={CYCLE} altitudeM={1500} onReload={() => {}} />);
+    fireEvent.click(screen.getByText('Marcar hecha'));
+    await waitFor(() => expect(completeTaskByVoice).toHaveBeenCalledTimes(1));
+    expect(completeTaskByVoice.mock.calls[0][0]).toMatchObject({ processId: 'p1', taskName: 'Regar el café' });
+  });
+});


### PR DESCRIPTION
Conexión del subsistema FarmProcess (antes oscuro) en el detalle del ciclo (CicloDetalle):
- Confirmar/corregir ETAPA (stageConfirmationService) + sugerencia desde observación (stageSuggestionService) en CicloObservacion.
- BIOPREPARADOS por etapa (climateCycleService.getBiopreparadosForStage).
- Marcar LABOR hecha (voiceTaskService.completeTaskByVoice).
Conecta #4 + #5 + biopreparado de #6. Lint ✓, 7 tests ✓, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)