### PR TITLE
feat(agent): reforestación/silvopastoreo + Fenómeno del Niño (ENSO) en el ciclo

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -1,12 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
-import { Sprout, FlaskConical } from 'lucide-react';
+import { Sprout, FlaskConical, AlertTriangle } from 'lucide-react';
 import FarmProcessSummary from './FarmProcessSummary';
 import PhenologyTimeline from './PhenologyTimeline';
 import CicloObservacion from './CicloObservacion';
 import { getTasksForCycle, getUrgentTasks } from '../services/cycleTaskService';
-import { getPestRisksByStage, getBiopreparadosForStage } from '../services/climateCycleService';
+import { getPestRisksByStage, getBiopreparadosForStage, getEnsemblePreventiveTasks } from '../services/climateCycleService';
 import { confirmStage } from '../services/stageConfirmationService';
 import { completeTaskByVoice } from '../services/voiceTaskService';
+import { getEnsoServicePhase, getEnsoLabel } from '../services/ensoService';
 
 /**
  * CicloDetalle — detalle de un ciclo (FarmProcess) con el enriquecimiento del
@@ -33,6 +34,8 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
 
   const pestRisks = useMemo(() => { try { return getPestRisksByStage(a.current_stage, a.subject_slug) || []; } catch { return []; } }, [a.current_stage, a.subject_slug]);
   const bios = useMemo(() => { try { return getBiopreparadosForStage(baseStage(a.current_stage)) || []; } catch { return []; } }, [a.current_stage]);
+  const ensoLabel = getEnsoLabel();
+  const ensoTasks = useMemo(() => { try { return getEnsemblePreventiveTasks(getEnsoServicePhase(), baseStage(a.current_stage)) || []; } catch { return []; } }, [a.current_stage]);
   const tasks = useMemo(() => { try { return getTasksForCycle(cycle) || []; } catch { return []; } }, [cycle]);
   const urgent = useMemo(() => { try { return getUrgentTasks(tasks) || []; } catch { return []; } }, [tasks]);
 
@@ -104,6 +107,20 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
               <li key={b.nombre || i} className="bg-slate-900 border border-slate-800 rounded-xl px-3 py-2 flex items-start gap-2">
                 <FlaskConical size={14} className="text-emerald-400 shrink-0 mt-0.5" />
                 <span className="text-sm text-slate-200"><strong>{b.nombre}</strong> — <span className="text-slate-400">{b.uso}</span></span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {ensoTasks.length > 0 && (
+        <section>
+          <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Por la temporada · {ensoLabel}</h2>
+          <ul className="flex flex-col gap-1.5">
+            {ensoTasks.map((t, i) => (
+              <li key={t.task || i} className="bg-amber-900/10 border border-amber-800/40 rounded-xl px-3 py-2 flex items-start gap-2">
+                <AlertTriangle size={14} className="text-amber-400 shrink-0 mt-0.5" />
+                <span className="text-sm text-slate-200"><strong>{t.task}</strong>{t.description ? <span className="text-slate-400"> — {t.description}</span> : null}</span>
               </li>
             ))}
           </ul>

--- a/src/components/FarmProcessConfirmCard.jsx
+++ b/src/components/FarmProcessConfirmCard.jsx
@@ -82,7 +82,11 @@ export default function FarmProcessConfirmCard({
           <p className="text-sm text-slate-200 italic mb-3">"{draft.transcription}"</p>
         )}
         <p className="text-xs text-slate-400">
-          {draft.process_type === 'restoration' ? '🌱 Ciclo de restauración' : '🌿 Nuevo ciclo de siembra'}
+          {draft.process_type === 'restoration'
+            ? '🌳 Ciclo de reforestación / restauración'
+            : draft.process_type === 'silvopasture'
+              ? '🐄 Ciclo silvopastoril'
+              : '🌿 Nuevo ciclo de siembra'}
         </p>
       </section>
 

--- a/src/components/__tests__/CicloDetalle.test.jsx
+++ b/src/components/__tests__/CicloDetalle.test.jsx
@@ -20,7 +20,9 @@ vi.mock('../../services/cycleTaskService', () => ({
 vi.mock('../../services/climateCycleService', () => ({
   getPestRisksByStage: () => [],
   getBiopreparadosForStage: () => [{ nombre: 'Caldo bordelés', uso: 'Preventivo fungoso' }],
+  getEnsemblePreventiveTasks: () => [],
 }));
+vi.mock('../../services/ensoService', () => ({ getEnsoServicePhase: () => null, getEnsoLabel: () => 'Neutral' }));
 vi.mock('../../services/stageConfirmationService', () => ({ confirmStage }));
 vi.mock('../../services/voiceTaskService', () => ({ completeTaskByVoice }));
 

--- a/src/services/__tests__/voiceToDraft.processType.test.js
+++ b/src/services/__tests__/voiceToDraft.processType.test.js
@@ -1,0 +1,34 @@
+/**
+ * voiceToDraft.detectProcessType — reconoce reforestación/restauración y
+ * silvopastoreo además de la siembra normal, para crear el FarmProcess del tipo
+ * correcto desde la voz (antes solo 'sowing').
+ */
+import { describe, it, expect } from 'vitest';
+import { detectProcessType, buildDraftsFromVoice } from '../voiceToDraft';
+
+describe('detectProcessType', () => {
+  it('detecta reforestación/restauración', () => {
+    expect(detectProcessType('reforesté 50 robles en la cañada')).toBe('restoration');
+    expect(detectProcessType('sembré árboles nativos para restaurar el bosque')).toBe('restoration');
+  });
+  it('detecta silvopastoreo', () => {
+    expect(detectProcessType('hice un sistema silvopastoril con leucaena')).toBe('silvopasture');
+    expect(detectProcessType('sembré árboles con pasto para el ganado')).toBe('silvopasture');
+  });
+  it('por defecto es siembra', () => {
+    expect(detectProcessType('sembré 10 fresas en el invernadero')).toBe('sowing');
+    expect(detectProcessType('')).toBe('sowing');
+  });
+});
+
+describe('buildDraftsFromVoice — process_type', () => {
+  it('propaga el tipo detectado al draft y usa unidad árboles en reforestación', () => {
+    const drafts = buildDraftsFromVoice({
+      transcription: 'reforesté 30 robles en el lote alto',
+      entities: [{ crop: 'roble', quantity: 30, location: { id: 'l1', type: 'asset--land', name: 'Lote' } }],
+    });
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].process_type).toBe('restoration');
+    expect(drafts[0].unit).toBe('árboles');
+  });
+});

--- a/src/services/cropAlertEngine.js
+++ b/src/services/cropAlertEngine.js
@@ -14,6 +14,7 @@
  */
 import { listFarmProcesses } from '../db/farmProcessCache';
 import { getPestRisksByStage } from './climateCycleService';
+import { getEnsoServicePhase, getEnsoLabel } from './ensoService';
 
 const SEVERITY_BY_RISK = { 'crítico': 'danger', critico: 'danger', alto: 'warning' };
 
@@ -71,6 +72,25 @@ export async function runCropAlerts() {
       cleared++;
     }
   }
+
+  // Alerta de TEMPORADA ENSO (El Niño/La Niña) — una sola, no por ciclo. Solo
+  // tiene sentido si hay ciclos activos; se limpia si la fase vuelve a neutral.
+  if (cycles.length > 0) {
+    const ensoPhase = getEnsoServicePhase();
+    if (ensoPhase) {
+      emit('alertTriggered', {
+        type: 'enso_season',
+        severity: 'warning',
+        title: `Temporada ${getEnsoLabel()}`,
+        message: 'Revisa las labores preventivas de la temporada en cada ciclo (riego, drenajes, hongos).',
+        source: 'enso',
+      });
+      emitted++;
+    } else {
+      emit('alertCleared', { type: 'enso_season' });
+    }
+  }
+
   return { emitted, cleared };
 }
 

--- a/src/services/ensoService.js
+++ b/src/services/ensoService.js
@@ -1,0 +1,41 @@
+/**
+ * ensoService — fase del Fenómeno del Niño / Oscilación del Sur (ENSO).
+ *
+ * Aún NO hay fuente automática en el cliente (IDEAM publica boletines mensuales,
+ * sin API estable). Por ahora la fase es CONFIGURABLE y persiste en localStorage,
+ * con default 'neutral'. La consumen climateCycleService (tareas preventivas y
+ * recálculo de fenología) y cropAlertEngine (alerta de temporada). Cuando haya
+ * fuente IDEAM/Open-Meteo se reemplaza getEnsoPhase por un fetch cacheado.
+ */
+const KEY = 'chagra:enso:phase';
+
+export const ENSO_PHASES = Object.freeze(['neutral', 'el_nino', 'la_nina']);
+export const ENSO_LABELS = Object.freeze({ neutral: 'Neutral', el_nino: 'El Niño', la_nina: 'La Niña' });
+// Forma que espera climateCycleService.getEnsemblePreventiveTasks.
+const ENSO_SERVICE_PHASE = Object.freeze({ neutral: null, el_nino: 'el_nino', la_nina: 'la_nina' });
+
+/** Fase actual ('neutral' | 'el_nino' | 'la_nina'). Default 'neutral'. */
+export function getEnsoPhase() {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (ENSO_PHASES.includes(v)) return v;
+  } catch { /* SSR/test sin localStorage */ }
+  return 'neutral';
+}
+
+/** Fija la fase (la elige el operador hasta tener fuente automática). */
+export function setEnsoPhase(phase) {
+  try {
+    if (ENSO_PHASES.includes(phase)) localStorage.setItem(KEY, phase);
+  } catch { /* SSR/test */ }
+}
+
+/** Etiqueta humana de la fase actual. */
+export function getEnsoLabel() {
+  return ENSO_LABELS[getEnsoPhase()] || 'Neutral';
+}
+
+/** Valor de fase en el formato que consume climateCycleService (null si neutral). */
+export function getEnsoServicePhase() {
+  return ENSO_SERVICE_PHASE[getEnsoPhase()] || null;
+}

--- a/src/services/voiceToDraft.js
+++ b/src/services/voiceToDraft.js
@@ -42,13 +42,34 @@ import { resolveSpeciesDefaults } from '../config/speciesDefaults';
  * @param {function} [input.resolveCrop] — (cropName) => {slug, label, variety, tracking_mode}
  * @returns {FarmProcessDraft[]} — un draft por entidad
  */
+/**
+ * Detecta el TIPO de proceso productivo desde la transcripción (heurística por
+ * palabras clave). Soporta reforestación/restauración y silvopastoreo además de
+ * la siembra normal. process_type válido en types/farmProcess.
+ * @param {string} text
+ * @returns {'sowing'|'restoration'|'silvopasture'}
+ */
+export function detectProcessType(text) {
+  const t = (text || '').toLowerCase();
+  if (/silvopast|silvo-?past|\bganad\w* con (árbol|arbol|sombr)|leucaena|sombr\w* para (el )?ganado|árboles? con (pasto|ganado)/.test(t)) {
+    return 'silvopasture';
+  }
+  if (/reforest|restaur|reforesté|árboles? (nativ|para|en el bosque)|\bbosque\b|revegetar?|enriquec\w* el bosque|roble|quercus|nogal|cativo/.test(t)) {
+    return 'restoration';
+  }
+  return 'sowing';
+}
+
 export const buildDraftsFromVoice = ({
   transcription,
   entities,
+  processType,
   resolveLocation = defaultResolveLocation,
   resolveCrop = defaultResolveCrop,
 }) => {
   if (!Array.isArray(entities) || entities.length === 0) return [];
+
+  const ptype = processType || detectProcessType(transcription);
 
   return entities.map((e) => {
     const cropInfo = resolveCrop(e.crop);
@@ -60,12 +81,14 @@ export const buildDraftsFromVoice = ({
     return {
       draft_id: newUlid(),
       transcription,
-      process_type: 'sowing',
+      process_type: ptype,
       subject_slug: cropInfo.slug || '',
       subject_label: cropInfo.label || e.crop,
       variety: cropInfo.variety || undefined,
       quantity: e.quantity || 1,
-      unit: trackingMode === 'individual' ? 'plantas' : 'semillas',
+      unit: (ptype === 'restoration' || ptype === 'silvopasture')
+        ? 'árboles'
+        : (trackingMode === 'individual' ? 'plantas' : 'semillas'),
       subject_kind: trackingMode,
       location_land_asset_id: locInfo?.id || '',
       location_land_label: locInfo?.label || undefined,


### PR DESCRIPTION
Conexión clima/especies del subsistema FarmProcess:
- voiceToDraft.detectProcessType: reconoce reforestación/restauración y silvopastoreo desde la voz → FarmProcess del tipo correcto (unidad 'árboles'); FarmProcessConfirmCard muestra el tipo.
- ensoService (nuevo): fase ENSO configurable (default neutral). CicloDetalle suma tareas preventivas por temporada; cropAlertEngine emite alerta El Niño/La Niña al home.
Conecta #11 + #12 + ENSO de #6. Lint ✓, 10 tests ✓, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)