### PR TITLE
feat(agent): foto al ciclo (photoCycleService) + PhotoViewer

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -3,6 +3,7 @@ import { Sprout, FlaskConical, AlertTriangle } from 'lucide-react';
 import FarmProcessSummary from './FarmProcessSummary';
 import PhenologyTimeline from './PhenologyTimeline';
 import CicloObservacion from './CicloObservacion';
+import CicloFotos from './CicloFotos';
 import { getTasksForCycle, getUrgentTasks } from '../services/cycleTaskService';
 import { getPestRisksByStage, getBiopreparadosForStage, getEnsemblePreventiveTasks } from '../services/climateCycleService';
 import { confirmStage } from '../services/stageConfirmationService';
@@ -98,6 +99,8 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
         <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
         <PhenologyTimeline speciesSlug={a.subject_slug} sowingDate={a.created_at} altitudeM={altitudeM} />
       </section>
+
+      <CicloFotos processId={processId} />
 
       {bios.length > 0 && (
         <section>

--- a/src/components/CicloFotos.jsx
+++ b/src/components/CicloFotos.jsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Camera, X } from 'lucide-react';
+import { captureAndCompress, savePhoto, getPhotoById } from '../services/photoService';
+import { attachPhotoToCycle } from '../services/photoCycleService';
+import { getFarmEvents } from '../db/farmProcessCache';
+import PhotoViewer from './PhotoViewer';
+
+/**
+ * CicloFotos — fotos atadas a un ciclo (FarmProcess). Cablea photoCycleService
+ * (antes huérfano): captura una foto, la guarda en media_cache (photoService),
+ * y la asocia al ciclo (attachPhotoToCycle → evento photo_attached). Muestra las
+ * fotos del ciclo en miniatura + PhotoViewer (cinema-mode) al tocar.
+ *
+ * NOTA: el análisis de visión EN VIVO está deshabilitado por límite de VRAM
+ * (M6000 12GB — el bench de visión falla con "kv cache"). La foto se adjunta
+ * como evidencia con visionResult vacío; cuando la GPU lo permita, se conecta
+ * recognizeSpeciesGrounded/analyzeFoliage acá.
+ */
+export default function CicloFotos({ processId }) {
+  const inputRef = useRef(null);
+  const [photos, setPhotos] = useState([]);
+  const [busy, setBusy] = useState(false);
+  const [viewing, setViewing] = useState(null);
+  const [err, setErr] = useState('');
+
+  const load = useCallback(async () => {
+    try {
+      const events = (await getFarmEvents(processId)) || [];
+      const photoEvents = events.filter((e) => e?.attributes?.event_type === 'photo_attached');
+      const out = [];
+      for (const ev of photoEvents) {
+        const hash = ev?.attributes?.payload?.image_hash;
+        if (!hash) continue;
+        const p = await getPhotoById(hash);
+        if (p?.url) out.push({ hash, url: p.url, revoke: p.revoke });
+      }
+      setPhotos((prev) => { prev.forEach((p) => p.revoke?.()); return out; });
+    } catch (e) { console.warn('[CicloFotos] load:', e.message); }
+  }, [processId]);
+
+  useEffect(() => {
+    load();
+    return () => setPhotos((prev) => { prev.forEach((p) => p.revoke?.()); return []; });
+  }, [load]);
+
+  const handlePick = useCallback(async (e) => {
+    const file = e.target.files && e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+    setBusy(true); setErr('');
+    try {
+      const { blob } = await captureAndCompress(file);
+      const photoId = await savePhoto({ blob, meta: {} });
+      await attachPhotoToCycle({
+        processId,
+        imageHash: String(photoId),
+        visionResult: { diagnosis: null, confidence: 0, is_out_of_domain: false },
+        actor: 'operator',
+      });
+      await load();
+    } catch (e2) { setErr(`No se pudo agregar la foto: ${e2.message}`); }
+    finally { setBusy(false); }
+  }, [processId, load]);
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-2xs uppercase font-bold text-slate-500">Fotos del ciclo</h2>
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          disabled={busy}
+          className="text-xs font-bold text-lime-400 px-2.5 py-1.5 rounded-lg border border-lime-800/60 flex items-center gap-1 disabled:opacity-50"
+        >
+          <Camera size={13} /> {busy ? 'Subiendo…' : 'Agregar foto'}
+        </button>
+      </div>
+      <input ref={inputRef} type="file" accept="image/*" className="hidden" onChange={handlePick} aria-label="Agregar foto al ciclo" />
+      {photos.length > 0 && (
+        <div className="grid grid-cols-4 gap-2">
+          {photos.map((p) => (
+            <button key={p.hash} type="button" onClick={() => setViewing(p.url)} className="aspect-square rounded-lg overflow-hidden border border-slate-800">
+              <img src={p.url} alt="Foto del ciclo" className="w-full h-full object-cover" />
+            </button>
+          ))}
+        </div>
+      )}
+      {photos.length === 0 && !err && (
+        <p className="text-xs text-slate-500">Aún no hay fotos. Toma una para dejar registro del cultivo.</p>
+      )}
+      {err && <p className="text-xs text-amber-400 mt-1">{err}</p>}
+      {viewing && (
+        <div className="fixed inset-0 z-[80] bg-black/90 flex items-center justify-center" onClick={() => setViewing(null)}>
+          <button type="button" className="absolute top-4 right-4 text-white z-10" onClick={() => setViewing(null)} aria-label="Cerrar foto"><X size={24} /></button>
+          <PhotoViewer src={viewing} alt="Foto del ciclo" />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/__tests__/CicloDetalle.test.jsx
+++ b/src/components/__tests__/CicloDetalle.test.jsx
@@ -13,6 +13,7 @@ const { confirmStage, completeTaskByVoice } = vi.hoisted(() => ({
 vi.mock('../FarmProcessSummary', () => ({ default: () => null }));
 vi.mock('../PhenologyTimeline', () => ({ default: () => null }));
 vi.mock('../CicloObservacion', () => ({ default: () => null }));
+vi.mock('../CicloFotos', () => ({ default: () => null }));
 vi.mock('../../services/cycleTaskService', () => ({
   getTasksForCycle: () => [{ id: 't1', label: 'Regar el café' }],
   getUrgentTasks: () => [],

--- a/src/components/__tests__/CicloFotos.test.jsx
+++ b/src/components/__tests__/CicloFotos.test.jsx
@@ -1,0 +1,47 @@
+/**
+ * CicloFotos — cablea photoCycleService (antes huérfano): adjunta una foto a un
+ * ciclo. Contrato: al elegir una foto, la guarda y llama attachPhotoToCycle con
+ * el processId y el hash de la foto. (Análisis de visión en vivo off por VRAM.)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const { captureAndCompress, savePhoto, getPhotoById, attachPhotoToCycle, getFarmEvents } = vi.hoisted(() => ({
+  captureAndCompress: vi.fn(),
+  savePhoto: vi.fn(),
+  getPhotoById: vi.fn(),
+  attachPhotoToCycle: vi.fn(),
+  getFarmEvents: vi.fn(),
+}));
+
+vi.mock('../../services/photoService', () => ({ captureAndCompress, savePhoto, getPhotoById }));
+vi.mock('../../services/photoCycleService', () => ({ attachPhotoToCycle }));
+vi.mock('../../db/farmProcessCache', () => ({ getFarmEvents }));
+vi.mock('../PhotoViewer', () => ({ default: () => null }));
+
+import CicloFotos from '../CicloFotos';
+
+beforeEach(() => {
+  captureAndCompress.mockReset().mockResolvedValue({ blob: new Blob(['x'], { type: 'image/jpeg' }) });
+  savePhoto.mockReset().mockResolvedValue(42);
+  getPhotoById.mockReset().mockResolvedValue(null);
+  attachPhotoToCycle.mockReset().mockResolvedValue({});
+  getFarmEvents.mockReset().mockResolvedValue([]);
+});
+afterEach(() => cleanup());
+
+describe('CicloFotos', () => {
+  it('agregar una foto guarda y la adjunta al ciclo (attachPhotoToCycle)', async () => {
+    const { container } = render(<CicloFotos processId="p1" />);
+    const input = container.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [new File(['x'], 'foto.jpg', { type: 'image/jpeg' })] } });
+    await waitFor(() => expect(attachPhotoToCycle).toHaveBeenCalledTimes(1));
+    expect(savePhoto).toHaveBeenCalledTimes(1);
+    expect(attachPhotoToCycle.mock.calls[0][0]).toMatchObject({ processId: 'p1', imageHash: '42' });
+  });
+
+  it('muestra estado vacío sin fotos', async () => {
+    render(<CicloFotos processId="p1" />);
+    expect(await screen.findByText(/Aún no hay fotos/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Conecta photoCycleService + PhotoViewer + useCinemaMode (antes huérfanos). CicloFotos: captura → savePhoto → attachPhotoToCycle → miniaturas + visor. Visión en vivo off por VRAM (se adjunta como evidencia). Lint ✓, 5 tests ✓, build ✓. Conecta #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)