### PR TITLE
feat(home): araña integrada al agente — sin marco, sin sheet aparte (+fix picks muertos)

### DIFF
--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -43,8 +43,8 @@ import ChagraAgentAvatar from '../ChagraAgentAvatar';
  *   │  [¿Qué siembro?] [Plagas] [Clima]            │ ← chips
  *   │  ╭───────────────────────────────────────╮  │
  *   │  │ Pregúntale a Chagra…                  │  │ ← compositor pill anclado
- *   │  │ Ⓐ            📷 📎      🎤  ⬆          │  │   Ⓐ (izq) abre el menú de
- *   │  ╰───────────────────────────────────────╯  │   capacidades (bottom-sheet)
+ *   │  │ Ⓐ            📷 📎      🎤  ⬆          │  │   Ⓐ (izq) despliega la red
+ *   │  ╰───────────────────────────────────────╯  │   de capacidades EN el hero
  *   └─────────────────────────────────────────────┘
  *
  * QUÉ ES FIEL AL DEMO:
@@ -60,8 +60,10 @@ import ChagraAgentAvatar from '../ChagraAgentAvatar';
  *   - Toggle Campesino/Experto cableado al motor REAL `nivel_respuestas`
  *     (simple/detallado en userProfileService) — mueve el perfil de verdad y
  *     cambia el saludo, como el demo (COPY.campesino/experto).
- *   - Botón Ⓐ a la izquierda del compositor abre un bottom-sheet (.sheet del
- *     demo) con TODAS las capacidades reales de Chagra, cada una con su routing.
+ *   - Botón Ⓐ a la izquierda del compositor despliega la red de capacidades
+ *     (AgentRedMenu) INTEGRADA al hero: el saludo/chips se pliegan y la red
+ *     brota en la zona-respiro, sobre el mismo lienzo del tema (operador
+ *     2026-06-09: nada de bottom-sheet/modal aparte). Cada rama rutea real.
  *
  * QUÉ NO SE PORTÓ (y por qué, honesto):
  *   - El avatar 3D (ChagraAgentAvatar) + halo conic: ELIMINADOS por orden del
@@ -163,8 +165,13 @@ export default function AgentHero({ onNavigate }) {
     const [busy, setBusy] = useState(false);
     // Fase de la transición de envío: 'idle' | 'sending'.
     const [phase, setPhase] = useState('idle');
-    // Menú Ⓐ (bottom-sheet de capacidades). false=cerrado | true=abierto.
-    const [sheetOpen, setSheetOpen] = useState(false);
+    // Menú Ⓐ (la red de capacidades). Integrado AL hero (operador 2026-06-09:
+    // nada de bottom-sheet aparte): al abrir, el saludo/chips se PLIEGAN y la
+    // red brota en la zona-respiro, sobre el mismo lienzo del tema.
+    // menuOpen=montado · menuClosing=animando el cierre antes de desmontar.
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [menuClosing, setMenuClosing] = useState(false);
+    const menuCloseTimerRef = useRef(null);
     // Nivel de respuestas del perfil (campesino=simple / experto=detallado).
     // Lo leemos del perfil real al montar; el toggle lo persiste de verdad.
     const [nivel, setNivel] = useState(() => {
@@ -321,15 +328,50 @@ export default function AgentHero({ onNavigate }) {
         try { saveProfile({ nivel_respuestas: next }); } catch { /* perfil opcional */ }
     };
 
-    // ── Menú Ⓐ (bottom-sheet de capacidades) ─────────────────────────────────
-    const toggleSheet = () => setSheetOpen((o) => !o);
-    const closeSheet = () => setSheetOpen(false);
+    // ── Menú Ⓐ (red de capacidades INTEGRADA al hero) ────────────────────────
+    // Abrir = plegar saludo/chips y brotar la red en la zona-respiro.
+    // Cerrar = breve fade de salida (MENU_CLOSE_MS) y desmontar; con
+    // prefers-reduced-motion el cierre es inmediato.
+    const MENU_CLOSE_MS = 300;
+    const openMenu = () => {
+        window.clearTimeout(menuCloseTimerRef.current);
+        setMenuClosing(false);
+        setMenuOpen(true);
+    };
+    const closeMenu = () => {
+        if (prefersReducedMotion()) {
+            setMenuOpen(false);
+            setMenuClosing(false);
+            return;
+        }
+        setMenuClosing(true);
+        menuCloseTimerRef.current = window.setTimeout(() => {
+            setMenuOpen(false);
+            setMenuClosing(false);
+        }, MENU_CLOSE_MS);
+    };
+    const toggleMenu = () => {
+        if (menuOpen && !menuClosing) closeMenu();
+        else openMenu();
+    };
 
-    // Despacha una capacidad del sheet a su routing real.
+    // Limpia el timer de cierre al desmontar y cierra con Escape (a11y).
+    useEffect(() => () => window.clearTimeout(menuCloseTimerRef.current), []);
+    useEffect(() => {
+        if (!menuOpen) return undefined;
+        const onKey = (e) => { if (e.key === 'Escape') closeMenu(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [menuOpen]);
+
+    // Despacha una capacidad de la red a su routing real. El manifiesto
+    // unificado (agentCapabilities.js) llama `heroRoute` al routing del hero;
+    // leer `cap.route` dejaba TODOS los picks muertos en silencio (bug
+    // pre-existente de main, detectado en la validación visual 2026-06-09).
     const pickCapability = (cap) => {
-        if (cap.status === 'soon' || !cap.route || cap.route.kind === 'unavailable') return;
-        closeSheet();
-        const r = cap.route;
+        const r = cap.heroRoute || cap.route;
+        if (cap.status === 'soon' || !r || r.kind === 'unavailable') return;
+        closeMenu();
         if (r.kind === 'ask') {
             handleChipSend(r.prompt);
         } else if (r.kind === 'nav') {
@@ -909,31 +951,65 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-hint { text-align: center; font-size: 0.72rem; margin-top: 9px; color: rgb(var(--c-slate-500)); }
                 .agentport-hint b { color: rgb(var(--t-accent-rgb)); font-weight: 700; }
 
-                /* ===================== BOTTOM SHEET (menú Ⓐ) ===================== */
-                .agentport-scrim {
-                    position: fixed; inset: 0; background: rgba(10, 8, 4, 0.5);
-                    backdrop-filter: blur(2px); opacity: 0; pointer-events: none;
-                    transition: opacity 0.42s cubic-bezier(.32,.72,0,1); z-index: 60;
+                /* ============== MENÚ Ⓐ INTEGRADO (la red en el hero) ==============
+                   Nada de bottom-sheet/scrim/modal (operador 2026-06-09: "que se
+                   abra APARTE del agente lo vuelve feo"). Mecánica: al tocar Ⓐ,
+                   el saludo+chips se PLIEGAN (grid 1fr→0fr) y la zona-respiro
+                   (flex:1) absorbe el espacio; allí BROTA la red, full-bleed y
+                   transparente, sobre la misma escena del tema. El compositor no
+                   se mueve: el árbol crece desde el mismo lienzo donde está Ⓐ. */
+
+                /* plegado fluido del saludo/alerta/chips al abrir el menú */
+                .agentport-foldaway {
+                    display: grid; grid-template-rows: 1fr;
+                    transition: grid-template-rows .5s cubic-bezier(.32,.72,0,1),
+                                opacity .32s ease;
                 }
-                .agentport-scrim.is-open { opacity: 1; pointer-events: auto; }
-                .agentport-sheet {
-                    position: fixed; left: 0; right: 0; bottom: 0; z-index: 61;
-                    max-width: 640px; margin: 0 auto;
-                    background: rgb(var(--c-surface-raised));
-                    border-radius: 26px 26px 0 0;
-                    box-shadow: 0 -16px 40px -16px rgba(0, 0, 0, 0.55);
-                    border-top: 1px solid rgb(var(--c-surface-border));
-                    transform: translateY(110%); transition: transform 0.5s cubic-bezier(.32,.72,0,1);
-                    max-height: 92dvh; display: flex; flex-direction: column; will-change: transform;
+                .agentport-foldaway.is-folded {
+                    grid-template-rows: 0fr; opacity: 0; pointer-events: none;
                 }
-                .agentport-sheet.is-open { transform: translateY(0); }
-                .agentport-grab { width: 42px; height: 5px; background: rgb(var(--c-surface-border)); border-radius: 5px; margin: 10px auto 4px; flex: none; }
-                .agentport-sheet-h { padding: 6px 22px 4px; text-align: center; flex: none; }
-                .agentport-sheet-h .t { font-size: 1.18rem; font-weight: 800; color: rgb(var(--c-slate-100)); letter-spacing: -.01em; }
-                .agentport-sheet-h .s { font-size: .86rem; color: rgb(var(--c-slate-300)); margin-top: 4px; line-height: 1.45; }
-                [data-nivel="detallado"] .agentport-sheet-h .s { font-size: .8rem; }
-                .agentport-sheet-foot { padding: 6px 22px calc(18px + env(safe-area-inset-bottom)); text-align: center; font-size: .72rem; color: rgb(var(--c-slate-500)); flex: none; }
-                .agentport-sheet-foot b { color: rgb(var(--t-accent-rgb)); }
+                .agentport-foldaway-in { min-height: 0; overflow: hidden; }
+
+                /* panel de la red: vive DENTRO de la zona-respiro, sin caja */
+                .agentport-redpanel {
+                    position: absolute; inset: 0;
+                    display: flex; flex-direction: column;
+                    animation: agentport-red-in .5s cubic-bezier(.32,.72,0,1) both;
+                }
+                .agentport-redpanel.is-closing {
+                    transition: opacity .28s ease, transform .28s ease;
+                    opacity: 0; transform: translateY(10px) scale(.985);
+                    pointer-events: none;
+                }
+                @keyframes agentport-red-in {
+                    from { opacity: 0; transform: translateY(16px) scale(.985); }
+                    to { opacity: 1; transform: none; }
+                }
+                .agentport-red-h { flex: none; text-align: center; padding: 0 14px 2px; }
+                .agentport-red-h .t {
+                    font-size: 1.02rem; font-weight: 800; letter-spacing: -.01em;
+                    color: rgb(var(--c-slate-100));
+                }
+                .agentport-red-h .s {
+                    display: block; font-size: .78rem; line-height: 1.4; margin-top: 2px;
+                    color: rgb(var(--c-slate-300));
+                }
+                .agentport-red-body { flex: 1 1 auto; min-height: 0; position: relative; overflow: hidden; }
+
+                /* con la red abierta, la escena ambiente baja el volumen (misma
+                   pantalla, foco en la red — no un modal encima) */
+                .agentport-sun, .agentport-astro, .agentport-mtn, .agentport-pollen,
+                .agentport-hummer, .agentport-net, .agentport-spore,
+                .agentport-roots, .agentport-sprig { transition: opacity .5s ease; }
+                .agentport-scene.is-quiet .agentport-sun,
+                .agentport-scene.is-quiet .agentport-astro,
+                .agentport-scene.is-quiet .agentport-mtn,
+                .agentport-scene.is-quiet .agentport-pollen,
+                .agentport-scene.is-quiet .agentport-hummer,
+                .agentport-scene.is-quiet .agentport-net,
+                .agentport-scene.is-quiet .agentport-spore,
+                .agentport-scene.is-quiet .agentport-roots,
+                .agentport-scene.is-quiet .agentport-sprig { opacity: .22; }
 
                 /* Transición de envío: shimmer + lift (contrato de tests). */
                 @keyframes chagra-send-shimmer {
@@ -964,13 +1040,18 @@ export default function AgentHero({ onNavigate }) {
                     .agentport-sprig path { stroke-dashoffset: 0 !important; animation: none !important; }
                     .agentport-tool:not(.is-open) { animation: none !important; }
                     .agentport-greet { animation: none !important; }
+                    .agentport-foldaway, .agentport-redpanel { transition: none !important; animation: none !important; }
                     .chagra-composer-shimmer::after, .chagra-composer-sending { animation: none !important; }
                 }
             `}</style>
 
             {/* ===================== ESCENA AMBIENTE (por tema) ===================== */}
             <div
-                className={['agentport-scene', night ? 'is-night' : 'is-day'].join(' ')}
+                className={[
+                    'agentport-scene',
+                    night ? 'is-night' : 'is-day',
+                    menuOpen && !menuClosing ? 'is-quiet' : '',
+                ].join(' ')}
                 aria-hidden="true"
             >
                 {/* — SOL/LUNA delicado, universal, según hora (operador 2026-06-06) — */}
@@ -1131,9 +1212,34 @@ export default function AgentHero({ onNavigate }) {
                 </div>
             </header>
 
-            {/* ===================== ZONA-RESPIRO (escena vive detrás) ===================== */}
-            <div className="agentport-stage" aria-hidden="true" />
+            {/* ============ ZONA-RESPIRO (escena detrás · red Ⓐ al abrir) ============
+                Con el menú abierto, la red de capacidades BROTA aquí mismo —
+                integrada al lienzo del hero, sin sheet ni scrim. */}
+            <div className="agentport-stage" aria-hidden={menuOpen ? undefined : 'true'}>
+                {menuOpen && (
+                    <div
+                        className={['agentport-redpanel', menuClosing ? 'is-closing' : ''].join(' ')}
+                        role="group"
+                        aria-label="Capacidades de Chagra"
+                    >
+                        <div className="agentport-red-h">
+                            <span className="t">La mano de Chagra</span>
+                            <span className="s">
+                                {expertoActive
+                                    ? 'Cada rama, una capacidad conectada. Las opacas están por llegar.'
+                                    : 'Mi mano en tu campo: cada rama es una ayuda. Las opacas llegan pronto.'}
+                            </span>
+                        </div>
+                        <div className="agentport-red-body">
+                            <AgentRedMenu onPick={pickCapability} disabled={busy} />
+                        </div>
+                    </div>
+                )}
+            </div>
 
+            {/* ======= SALUDO + ALERTA + CHIPS (se pliegan al abrir el menú Ⓐ) ======= */}
+            <div className={['agentport-foldaway', menuOpen && !menuClosing ? 'is-folded' : ''].join(' ')}>
+            <div className="agentport-foldaway-in">
             {/* ===================== SALUDO ===================== */}
             <div className="agentport-greet">
                 <h2 className="agentport-hi">
@@ -1190,6 +1296,8 @@ export default function AgentHero({ onNavigate }) {
                         {chip.label}
                     </button>
                 ))}
+            </div>
+            </div>
             </div>
 
             {/* ===================== COMPOSITOR MULTIMODAL ===================== */}
@@ -1261,14 +1369,14 @@ export default function AgentHero({ onNavigate }) {
 
                     {/* Fila 2: Ⓐ a la izquierda · cámara/adjuntar · mic/enviar a la derecha */}
                     <div className="flex items-center gap-2 px-1 pb-1 pt-0.5">
-                        {/* Botón Ⓐ — abre el menú de capacidades (bottom-sheet) */}
+                        {/* Botón Ⓐ — despliega/pliega la red de capacidades EN el hero */}
                         <button
                             type="button"
-                            onClick={toggleSheet}
+                            onClick={toggleMenu}
                             disabled={isRecording}
                             aria-label="Ver todo lo que puede hacer Chagra"
-                            aria-expanded={sheetOpen}
-                            className={['agentport-iconbtn agentport-tool !w-11 !h-11', sheetOpen ? 'is-open' : ''].join(' ')}
+                            aria-expanded={menuOpen && !menuClosing}
+                            className={['agentport-iconbtn agentport-tool !w-11 !h-11', menuOpen && !menuClosing ? 'is-open' : ''].join(' ')}
                         >
                             <span className="agentport-tool-ico" aria-hidden="true">{iconForTheme(theme)}</span>
                         </button>
@@ -1336,10 +1444,15 @@ export default function AgentHero({ onNavigate }) {
                     />
                 </div>
 
-                {/* Hint bajo la pill (réplica de .hintbar del demo). */}
+                {/* Hint bajo la pill (réplica de .hintbar del demo). Con la red
+                    abierta muta a la línea de fuentes (antes pie del sheet). */}
                 {!isRecording && !attachment && (
                     <p className="agentport-hint">
-                        Toca <b>Ⓐ</b> para ver todo lo que sé hacer, o escríbeme aquí
+                        {menuOpen && !menuClosing ? (
+                            <>Chagra responde con información de <b>AGROSAVIA</b>, <b>ICA</b> e <b>IDEAM</b>.</>
+                        ) : (
+                            <>Toca <b>Ⓐ</b> para ver todo lo que sé hacer, o escríbeme aquí</>
+                        )}
                     </p>
                 )}
 
@@ -1356,36 +1469,6 @@ export default function AgentHero({ onNavigate }) {
                 )}
             </div>
 
-            {/* ===================== SCRIM + BOTTOM SHEET (menú Ⓐ) ===================== */}
-            <div
-                className={['agentport-scrim', sheetOpen ? 'is-open' : ''].join(' ')}
-                onClick={closeSheet}
-                aria-hidden="true"
-            />
-            <section
-                className={['agentport-sheet', sheetOpen ? 'is-open' : ''].join(' ')}
-                role="dialog"
-                aria-modal={sheetOpen}
-                aria-label="Capacidades de Chagra"
-                aria-hidden={!sheetOpen}
-            >
-                <div className="agentport-grab" aria-hidden="true" />
-                <div className="agentport-sheet-h">
-                    <div className="t">La mano de Chagra</div>
-                    <div className="s">
-                        {expertoActive
-                            ? 'Cada rama, una capacidad conectada. Las opacas están por llegar.'
-                            : 'Mi mano en tu campo: cada rama es una ayuda. Las opacas llegan pronto.'}
-                    </div>
-                </div>
-                {/* La mano de Chagra (emblema + capacidades) — componente único
-                    compartido con el panel inline. Solo se monta cuando el sheet
-                    está abierto, para que el dibujado se reproduzca al desplegar. */}
-                {sheetOpen && <AgentRedMenu onPick={pickCapability} disabled={busy} />}
-                <div className="agentport-sheet-foot">
-                    Chagra responde con información de <b>AGROSAVIA</b>, <b>ICA</b> e <b>IDEAM</b>.
-                </div>
-            </section>
         </section>
     );
 }

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -18,8 +18,10 @@ import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
  *   - El tema se LEE de <html data-theme> (lo escribe useTheme/applyTheme;
  *     biopunk = sin atributo). MutationObserver re-evalúa cambios en vivo.
  *     Sin barra selectora propia (eso vive en Perfil).
- *   - Sin FAB Ⓐ ni sheet propios: se renderiza DENTRO del bottom-sheet del
- *     AgentHero. El nodo Ⓐ abajo-centro es la raíz del árbol (y "volver").
+ *   - Sin FAB Ⓐ, sin sheet y SIN MARCO propio: se renderiza INTEGRADO en el
+ *     lienzo del AgentHero (la zona-respiro), full-bleed y transparente — la
+ *     escena del hero por tema es el fondo. El contenedor padre decide el
+ *     alto (height:100%). El nodo Ⓐ abajo-centro es la raíz (y "volver").
  *   - `prefers-reduced-motion` → sin loop rAF: un solo paint al estado final.
  *   - Cleanup completo: rAF, timers, ResizeObserver, MutationObserver, paths.
  *
@@ -190,21 +192,18 @@ function bounce(el) {
 /* ══════════════ estilos (CSS del demo, scoped arm-) ══════════════ */
 
 const CSS = `
+/* SIN MARCO (operador 2026-06-09): nada de caja con borde/radius/fondo —
+   la red respira full-bleed sobre el lienzo del AgentHero; el padre da el
+   alto. Solo overflow:hidden para que esporas/ramas no se salgan. */
 .arm-root{
-  position:relative;width:100%;height:560px;max-height:calc(100dvh - 170px);min-height:420px;
-  overflow:hidden;border-radius:24px;
-  background:var(--sheetBg);border:1px solid var(--sheetEdge);
+  position:relative;width:100%;height:100%;min-height:380px;
+  overflow:hidden;background:transparent;
   -webkit-tap-highlight-color:transparent;
   /* ---- tema biopunk (base) ---- */
   --fam:ui-monospace,'Cascadia Mono',Menlo,Consolas,monospace;
   --lblSize:13px; --lblSp:.01em; --lblW:800;
   --lblC:#ffffff; --lblBg:rgba(3,12,9,.9); --lblEdge:rgba(25,199,154,.55);
   --lblShadow:0 2px 8px rgba(0,0,0,.6);
-  --sheetBg:
-    radial-gradient(135% 95% at 50% 103%,rgba(25,199,154,.20),rgba(25,199,154,.05) 42%,transparent 64%),
-    radial-gradient(90% 55% at 86% -6%,rgba(38,110,160,.16),transparent 60%),
-    linear-gradient(180deg,#0d1422,#0a0e14 85%);
-  --sheetEdge:rgba(25,199,154,.35);
   --branch:#19c79a; --coreW:2.2px;
   --glowC:rgba(25,199,154,.30); --glowW:8px; --glowO:1; --glowBlur:3px;
   --twigC:rgba(25,199,154,.55);
@@ -213,7 +212,7 @@ const CSS = `
   --orbShadow:0 0 22px rgba(25,199,154,.32),0 0 6px rgba(25,199,154,.5),inset 0 0 16px rgba(25,199,154,.10);
   --orbRadA:50%; --orbRadB:50%;
   --pulse:rgba(25,199,154,.55);
-  --spore:#19c79a; --spO:.7; --noiseO:.05;
+  --spore:#19c79a; --spO:.7;
   --rootBg:radial-gradient(circle at 35% 28%,#34efbe,#129b78 75%);
   --rootGlyph:#06231b; --rootShadow:0 0 26px rgba(25,199,154,.55),0 4px 14px rgba(0,0,0,.5);
   --crumbBg:rgba(25,199,154,.16); --crumbC:#c8f3e2; --crumbEdge:rgba(25,199,154,.45);
@@ -227,11 +226,6 @@ const CSS = `
   --lblSize:13.5px; --lblSp:0; --lblW:700;
   --lblC:#2e2414; --lblBg:rgba(255,250,238,.95); --lblEdge:rgba(121,87,53,.5);
   --lblShadow:0 2px 6px rgba(90,60,30,.22);
-  --sheetBg:
-    radial-gradient(85% 45% at 80% -8%,rgba(241,199,118,.42),transparent 58%),
-    linear-gradient(to top,rgba(108,139,77,.30),rgba(108,139,77,.08) 130px,transparent 210px),
-    linear-gradient(180deg,#f3ead4,#faf3e2 40%,#f5edd9);
-  --sheetEdge:rgba(121,87,53,.35);
   --branch:#6e4f2e; --coreW:4px;
   --glowC:rgba(121,87,53,.22); --glowW:9px; --glowO:1; --glowBlur:1.5px;
   --twigC:rgba(110,79,46,.6);
@@ -241,7 +235,7 @@ const CSS = `
   --orbRadA:58% 42% 55% 45% / 45% 58% 42% 55%;
   --orbRadB:44% 56% 48% 52% / 56% 44% 58% 42%;
   --pulse:rgba(95,124,66,.5);
-  --spore:#7c9a4e; --spO:.6; --noiseO:.08;
+  --spore:#7c9a4e; --spO:.6;
   --rootBg:radial-gradient(circle at 35% 28%,#8fae62,#5f7c42 78%);
   --rootGlyph:#fdf8e9; --rootShadow:0 5px 16px rgba(80,60,30,.4);
   --crumbBg:rgba(255,250,238,.9); --crumbC:#4a3a1f; --crumbEdge:rgba(121,87,53,.45);
@@ -255,8 +249,6 @@ const CSS = `
   --lblSize:12.5px; --lblSp:.02em; --lblW:700;
   --lblC:#143d31; --lblBg:rgba(255,255,255,.96); --lblEdge:rgba(47,110,90,.35);
   --lblShadow:0 1px 4px rgba(30,40,35,.12);
-  --sheetBg:linear-gradient(180deg,#f9f6ee,#f6f3ec);
-  --sheetEdge:rgba(47,110,90,.28);
   --branch:#2f6e5a; --coreW:1.6px;
   --glowC:transparent; --glowW:0px; --glowO:0; --glowBlur:0px;
   --twigC:rgba(47,110,90,.45);
@@ -265,7 +257,7 @@ const CSS = `
   --orbShadow:0 2px 6px rgba(30,40,35,.1);
   --orbRadA:50%; --orbRadB:50%;
   --pulse:transparent;
-  --spore:transparent; --spO:0; --noiseO:.03;
+  --spore:transparent; --spO:0;
   --rootBg:#2f6e5a;
   --rootGlyph:#f6f3ec; --rootShadow:0 3px 10px rgba(30,50,42,.25);
   --crumbBg:#ffffff; --crumbC:#1f5847; --crumbEdge:rgba(47,110,90,.35);
@@ -274,10 +266,9 @@ const CSS = `
   --trunkC:#2f6e5a; --trunkHi:#5ea58d;
 }
 .arm-root.arm-disabled{pointer-events:none;opacity:.55}
-.arm-root::after{content:"";position:absolute;inset:0;z-index:6;pointer-events:none;
-  opacity:var(--noiseO);mix-blend-mode:overlay;
-  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='160' height='160' filter='url(%23n)' opacity='0.65'/></svg>");
-}
+/* La textura de ruido del demo se quitó en la integración: sobre el lienzo
+   transparente del hero dibujaba un rectángulo "sucio" (el marco que el
+   operador rechazó). El grano ambiente lo pone la escena del hero. */
 .arm-web{position:absolute;inset:0;width:100%;height:100%;z-index:1;pointer-events:none}
 .arm-gtrunk path{fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gtrunk .tkB{stroke:var(--trunkC);stroke-width:17px}

--- a/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
@@ -101,6 +101,12 @@ vi.mock('../../ChagraAgentAvatar', () => ({
   ),
 }));
 
+// jsdom no trae ResizeObserver (lo usa el motor de AgentRedMenu, que ahora
+// se monta INTEGRADO en el hero al abrir el menú Ⓐ).
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
 import AgentHero from '../AgentHero';
 import { getProfile, saveProfile, getProfileMunicipio } from '../../../services/userProfileService';
 
@@ -466,6 +472,79 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
       
       // NO debe persistir (ya está en ese nivel)
       expect(saveProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('6. menú Ⓐ integrado al hero (sin bottom-sheet)', () => {
+    test('tocar Ⓐ brota la red EN la zona-respiro y pliega saludo/chips', async () => {
+      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+
+      // Cerrado: nada de red ni de sheet/scrim (el modal aparte murió).
+      expect(container.querySelector('.agentport-redpanel')).toBeNull();
+      expect(container.querySelector('.agentport-sheet')).toBeNull();
+      expect(container.querySelector('.agentport-scrim')).toBeNull();
+
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+      await act(async () => { fireEvent.click(aBtn); });
+
+      // Abierto: la red vive DENTRO de la zona-respiro del hero.
+      const stage = container.querySelector('.agentport-stage');
+      const panel = stage.querySelector('.agentport-redpanel');
+      expect(panel).toBeTruthy();
+      expect(panel.querySelector('.arm-root')).toBeTruthy();
+      expect(container.querySelector('.agentport-sheet')).toBeNull();
+      expect(aBtn).toHaveAttribute('aria-expanded', 'true');
+
+      // El saludo/chips quedan plegados (misma pantalla, no scrim encima).
+      expect(container.querySelector('.agentport-foldaway')).toHaveClass('is-folded');
+      // La escena ambiente baja el volumen pero sigue siendo el mismo lienzo.
+      expect(container.querySelector('.agentport-scene')).toHaveClass('is-quiet');
+    });
+
+    test('tocar Ⓐ de nuevo cierra y devuelve el saludo (reduced-motion: inmediato)', async () => {
+      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+
+      await act(async () => { fireEvent.click(aBtn); });
+      expect(container.querySelector('.agentport-redpanel')).toBeTruthy();
+
+      await act(async () => { fireEvent.click(aBtn); });
+      expect(container.querySelector('.agentport-redpanel')).toBeNull();
+      expect(container.querySelector('.agentport-foldaway')).not.toHaveClass('is-folded');
+      expect(aBtn).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('tocar una hoja viva rutea de verdad (heroRoute → outbox → chat)', async () => {
+      const onNavigate = vi.fn();
+      render(<AgentHero onNavigate={onNavigate} />);
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+      await act(async () => { fireEvent.click(aBtn); });
+
+      // 'Plaga' es una capacidad live del manifiesto real con
+      // heroRoute {kind:'ask'} — el bug de main leía cap.route (undefined)
+      // y mataba el pick en silencio. Este test lo clava.
+      const leaf = screen.getByLabelText('Plaga');
+      await act(async () => { fireEvent.click(leaf); });
+
+      await waitFor(() => {
+        expect(sendMock).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: 'text', text: expect.stringMatching(/plagas/i) }),
+        );
+      });
+      await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('agente'));
+    });
+
+    test('Escape cierra el menú (a11y teclado)', async () => {
+      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+
+      await act(async () => { fireEvent.click(aBtn); });
+      expect(container.querySelector('.agentport-redpanel')).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.keyDown(window, { key: 'Escape' });
+      });
+      expect(container.querySelector('.agentport-redpanel')).toBeNull();
     });
   });
 


### PR DESCRIPTION
HELD para revisión visual del operador/Opus en vivo — **NO mergear todavía**.

## Qué cambia
El menú-red de capacidades (`AgentRedMenu`, la "araña") estaba sucio por dos cosas (palabras del operador): el **MARCO** (caja de 560px con borde + radius + fondo propio) y que se abría **APARTE** del agente (bottom-sheet con scrim encima del hero).

1. **Marco fuera** (`AgentRedMenu`): `.arm-root` ya no es una caja — transparente, sin borde, sin radius, sin textura de ruido, `height:100%` del contenedor. La red respira full-bleed sobre el lienzo del hero. El concepto red/árbol aprobado (geometría, mecánicas micorriza/árbol, 3 temas con el min del último demo intacto) NO se tocó.
2. **Integración al agente** (`AgentHero`): muere el bottom-sheet + scrim. Al tocar Ⓐ, el saludo/alerta/chips se pliegan (grid `1fr→0fr`), la zona-respiro absorbe el espacio y ahí **brota** la red sobre la misma escena del tema (que baja el volumen a `.22`). El compositor queda anclado y usable; el hint muta a la línea de fuentes (AGROSAVIA/ICA/IDEAM). Escape cierra; `prefers-reduced-motion` = sin animación.
3. **Bonus fix (bug pre-existente en main)**: `pickCapability` leía `cap.route` pero el manifiesto unificado (036f549) usa `heroRoute` → **todos** los picks morían en silencio. Ahora `heroRoute || route`, con test.

## Validación visual REAL (chromium nix-store, viewport 412×915)
Screenshots en alpha: `/tmp/arana-integracion/` (`{tema}-{1-cerrado,2-red-abierta,3-grupo-enfocado,4-post-pick}.png`, 3 temas).
- `getComputedStyle(.arm-root)` en los 3 temas: `border 0px · radius 0px · bg transparente`.
- Pick de hoja viva ("Plaga") → outbox → navega al chat real y el agente responde.

## Tests
- 4 tests nuevos (menú integrado ×3 + pick heroRoute ×1); suite dashboard 65/65 verde.
- `eslint --max-warnings=0` verde en los 3 archivos tocados.
- Fallos pre-existentes de main (15, en sidecarClient/mediaCache/visionCache/boundaryAudit por artefactos bench trackeados) NO relacionados — verificado con stash en baseline limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)