### PR TITLE
feat: conectar cosecha, post-cosecha y manejo de plagas (FarmProcess)

### DIFF
--- a/src/components/FarmProcessConfirmCard.jsx
+++ b/src/components/FarmProcessConfirmCard.jsx
@@ -86,7 +86,13 @@ export default function FarmProcessConfirmCard({
             ? '🌳 Ciclo de reforestación / restauración'
             : draft.process_type === 'silvopasture'
               ? '🐄 Ciclo silvopastoril'
-              : '🌿 Nuevo ciclo de siembra'}
+              : draft.process_type === 'harvest'
+                ? '🌾 Ciclo de cosecha'
+                : draft.process_type === 'post_harvest'
+                  ? '📦 Post-cosecha'
+                  : draft.process_type === 'pest_management'
+                    ? '🐛 Manejo de plagas'
+                    : '🌿 Nuevo ciclo de siembra'}
         </p>
       </section>
 
@@ -170,6 +176,10 @@ export default function FarmProcessConfirmCard({
             <option value="árboles">árboles</option>
             <option value="esquejes">esquejes</option>
             <option value="bulbos">bulbos</option>
+            <option value="kg">kg</option>
+            <option value="arrobas">arrobas</option>
+            <option value="bultos">bultos</option>
+            <option value="litros">litros</option>
             <option value="kilos">kilos</option>
             <option value="libras">libras</option>
             <option value="gramos">gramos</option>
@@ -266,7 +276,17 @@ export default function FarmProcessConfirmCard({
           disabled={!allValid || isSaving}
           className="flex-1 px-4 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 text-white rounded-xl font-bold flex items-center justify-center gap-2 disabled:opacity-50 disabled:bg-slate-700"
         >
-          <Check size={18} /> {isSaving ? 'Guardando…' : `Confirmar siembra (${quantity} ${unit})`}
+          <Check size={18} /> {isSaving ? 'Guardando…' : (() => {
+            const label = (() => {
+              if (draft.process_type === 'harvest') return 'Confirmar cosecha';
+              if (draft.process_type === 'post_harvest') return 'Confirmar post-cosecha';
+              if (draft.process_type === 'pest_management') return 'Confirmar manejo de plagas';
+              if (draft.process_type === 'restoration') return 'Confirmar reforestación';
+              if (draft.process_type === 'silvopasture') return 'Confirmar silvopastoreo';
+              return 'Confirmar siembra';
+            })();
+            return `${label} (${quantity} ${unit})`;
+          })()}
         </button>
       </div>
     </div>

--- a/src/components/__tests__/FarmProcessConfirmCard.test.jsx
+++ b/src/components/__tests__/FarmProcessConfirmCard.test.jsx
@@ -158,4 +158,56 @@ describe('FarmProcessConfirmCard', () => {
       expect(input.disabled).toBe(true);
     });
   });
+
+  it('renderiza encabezado de cosecha (harvest)', () => {
+    const harvestDraft = { ...baseDraft, process_type: 'harvest', unit: 'kg' };
+    render(
+      <FarmProcessConfirmCard
+        draft={harvestDraft}
+        locationOptions={locationOptions}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Ciclo de cosecha/)).toBeDefined();
+  });
+
+  it('renderiza encabezado de post-cosecha (post_harvest)', () => {
+    const postDraft = { ...baseDraft, process_type: 'post_harvest', unit: 'kg' };
+    render(
+      <FarmProcessConfirmCard
+        draft={postDraft}
+        locationOptions={locationOptions}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Post-cosecha/)).toBeDefined();
+  });
+
+  it('renderiza encabezado de manejo de plagas (pest_management)', () => {
+    const pestDraft = { ...baseDraft, process_type: 'pest_management', unit: 'litros' };
+    render(
+      <FarmProcessConfirmCard
+        draft={pestDraft}
+        locationOptions={locationOptions}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Manejo de plagas/)).toBeDefined();
+  });
+
+  it('muestra unidad kg y unidades de cosecha en harvest', () => {
+    const harvestDraft = { ...baseDraft, process_type: 'harvest', unit: 'kg' };
+    render(
+      <FarmProcessConfirmCard
+        draft={harvestDraft}
+        locationOptions={locationOptions}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByDisplayValue('kg')).toBeDefined();
+  });
 });

--- a/src/hooks/__tests__/useFarmProcessConfirm.test.js
+++ b/src/hooks/__tests__/useFarmProcessConfirm.test.js
@@ -97,4 +97,52 @@ describe('useFarmProcessConfirm', () => {
     const call = createFarmProcess.mock.lastCall[0];
     expect(call.attributes.created_at).toBe(172800000000);
   });
+
+  it('cosecha: crea proceso con status completed y current_stage closed', async () => {
+    createFarmProcess.mockResolvedValue({ process: {}, event: {} });
+    const harvestDraft = { ...validDraft, process_type: 'harvest', unit: 'kg' };
+    const { result } = renderHook(() => useFarmProcessConfirm());
+
+    await act(async () => {
+      await result.current.confirm(harvestDraft);
+    });
+
+    const call = createFarmProcess.mock.lastCall[0];
+    expect(call.attributes.process_type).toBe('harvest');
+    expect(call.attributes.status).toBe('completed');
+    expect(call.attributes.current_stage).toBe('closed');
+    expect(call.attributes.unit).toBe('kg');
+  });
+
+  it('post-cosecha: crea proceso con status active y current_stage post_harvest', async () => {
+    createFarmProcess.mockResolvedValue({ process: {}, event: {} });
+    const postDraft = { ...validDraft, process_type: 'post_harvest', unit: 'kg' };
+    const { result } = renderHook(() => useFarmProcessConfirm());
+
+    await act(async () => {
+      await result.current.confirm(postDraft);
+    });
+
+    const call = createFarmProcess.mock.lastCall[0];
+    expect(call.attributes.process_type).toBe('post_harvest');
+    expect(call.attributes.status).toBe('active');
+    expect(call.attributes.current_stage).toBe('post_harvest');
+    expect(call.attributes.unit).toBe('kg');
+  });
+
+  it('manejo de plagas: crea proceso con status active y current_stage pest_management', async () => {
+    createFarmProcess.mockResolvedValue({ process: {}, event: {} });
+    const pestDraft = { ...validDraft, process_type: 'pest_management', unit: 'litros' };
+    const { result } = renderHook(() => useFarmProcessConfirm());
+
+    await act(async () => {
+      await result.current.confirm(pestDraft);
+    });
+
+    const call = createFarmProcess.mock.lastCall[0];
+    expect(call.attributes.process_type).toBe('pest_management');
+    expect(call.attributes.status).toBe('active');
+    expect(call.attributes.current_stage).toBe('pest_management');
+    expect(call.attributes.unit).toBe('litros');
+  });
 });

--- a/src/hooks/useFarmProcessConfirm.js
+++ b/src/hooks/useFarmProcessConfirm.js
@@ -26,12 +26,23 @@ export function useFarmProcessConfirm() {
       const now = Date.now();
       const processId = newUlid();
 
+      // Determina status y current_stage según el tipo de proceso
+      const processType = draft.process_type || 'sowing';
+      const isHarvest = processType === 'harvest';
+      const status = isHarvest ? 'completed' : 'active';
+      const currentStage = (() => {
+        if (isHarvest) return 'closed';
+        if (processType === 'post_harvest') return 'post_harvest';
+        if (processType === 'pest_management') return 'pest_management';
+        return 'sowing_confirmed';
+      })();
+
       // Build FarmProcess from edited draft
       const process = {
         process_id: processId,
         type: 'farm_process',
         attributes: {
-          process_type: draft.process_type || 'sowing',
+          process_type: processType,
           subject_kind: draft.subject_kind || 'individual',
           subject_slug: draft.subject_slug || '',
           subject_label: draft.subject_label,
@@ -39,8 +50,8 @@ export function useFarmProcessConfirm() {
           quantity: draft.quantity,
           unit: draft.unit || 'plantas',
           location_land_asset_id: draft.location_land_asset_id,
-          status: 'active',
-          current_stage: 'sowing_confirmed',
+          status,
+          current_stage: currentStage,
           created_at: draft.suggested_date || now,
           updated_at: now,
         },

--- a/src/services/__tests__/voiceToDraft.processType.test.js
+++ b/src/services/__tests__/voiceToDraft.processType.test.js
@@ -19,6 +19,26 @@ describe('detectProcessType', () => {
     expect(detectProcessType('sembré 10 fresas en el invernadero')).toBe('sowing');
     expect(detectProcessType('')).toBe('sowing');
   });
+
+  it('detecta cosecha (harvest)', () => {
+    expect(detectProcessType('coseché 20 kilos de café')).toBe('harvest');
+    expect(detectProcessType('recolectamos la arveja')).toBe('harvest');
+    expect(detectProcessType('vamos a cosechar el tomate')).toBe('harvest');
+  });
+
+  it('detecta post-cosecha (post_harvest)', () => {
+    expect(detectProcessType('secado el café en la plataforma')).toBe('post_harvest');
+    expect(detectProcessType('almacenamos la cosecha en bodega')).toBe('post_harvest');
+    expect(detectProcessType('hicimos poscosecha del maíz')).toBe('post_harvest');
+    expect(detectProcessType('beneficiado el café')).toBe('post_harvest');
+  });
+
+  it('detecta manejo de plagas (pest_management)', () => {
+    expect(detectProcessType('fumigamos el tomate')).toBe('pest_management');
+    expect(detectProcessType('control de broca en el café')).toBe('pest_management');
+    expect(detectProcessType('aplicamos biol en las matas')).toBe('pest_management');
+    expect(detectProcessType('control de plaga en el lote norte')).toBe('pest_management');
+  });
 });
 
 describe('buildDraftsFromVoice — process_type', () => {
@@ -30,5 +50,35 @@ describe('buildDraftsFromVoice — process_type', () => {
     expect(drafts).toHaveLength(1);
     expect(drafts[0].process_type).toBe('restoration');
     expect(drafts[0].unit).toBe('árboles');
+  });
+
+  it('usa unidad kg en cosecha por defecto', () => {
+    const drafts = buildDraftsFromVoice({
+      transcription: 'coseché 50 kilos de café',
+      entities: [{ crop: 'café', quantity: 50, location: 'lote norte' }],
+    });
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].process_type).toBe('harvest');
+    expect(drafts[0].unit).toBe('kg');
+  });
+
+  it('usa unidad kg en post-cosecha por defecto', () => {
+    const drafts = buildDraftsFromVoice({
+      transcription: 'secado 30 kilos de café',
+      entities: [{ crop: 'café', quantity: 30, location: 'bodega' }],
+    });
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].process_type).toBe('post_harvest');
+    expect(drafts[0].unit).toBe('kg');
+  });
+
+  it('usa unidad litros en manejo de plagas por defecto', () => {
+    const drafts = buildDraftsFromVoice({
+      transcription: 'aplicamos 2 litros de biol en el tomate',
+      entities: [{ crop: 'tomate', quantity: 2, location: 'invernadero' }],
+    });
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].process_type).toBe('pest_management');
+    expect(drafts[0].unit).toBe('litros');
   });
 });

--- a/src/services/farmEventService.js
+++ b/src/services/farmEventService.js
@@ -105,12 +105,20 @@ export const createFarmProcess = async (process) => {
 
     procStore.put(process);
 
+    const eventType = (() => {
+      const ptype = process.attributes?.process_type || 'sowing';
+      if (ptype === 'harvest') return 'harvest_confirmed';
+      if (ptype === 'post_harvest') return 'post_harvest_confirmed';
+      if (ptype === 'pest_management') return 'pest_management_confirmed';
+      return 'sowing_confirmed';
+    })();
+
     const event = {
       event_id: newUlid(),
       type: 'farm_process_event',
       attributes: {
         process_id: process.process_id,
-        event_type: 'sowing_confirmed',
+        event_type: eventType,
         occurred_at: process.attributes.created_at,
         actor: 'operator',
         source: 'operator',

--- a/src/services/voiceToDraft.js
+++ b/src/services/voiceToDraft.js
@@ -44,10 +44,11 @@ import { resolveSpeciesDefaults } from '../config/speciesDefaults';
  */
 /**
  * Detecta el TIPO de proceso productivo desde la transcripción (heurística por
- * palabras clave). Soporta reforestación/restauración y silvopastoreo además de
- * la siembra normal. process_type válido en types/farmProcess.
+ * palabras clave). Soporta reforestación/restauración, silvopastoreo, cosecha,
+ * post-cosecha y manejo de plagas además de la siembra normal. process_type
+ * válido en types/farmProcess.
  * @param {string} text
- * @returns {'sowing'|'restoration'|'silvopasture'}
+ * @returns {'sowing'|'restoration'|'silvopasture'|'harvest'|'post_harvest'|'pest_management'}
  */
 export function detectProcessType(text) {
   const t = (text || '').toLowerCase();
@@ -56,6 +57,15 @@ export function detectProcessType(text) {
   }
   if (/reforest|restaur|reforesté|árboles? (nativ|para|en el bosque)|\bbosque\b|revegetar?|enriquec\w* el bosque|roble|quercus|nogal|cativo/.test(t)) {
     return 'restoration';
+  }
+  if (/secad|almacen|poscosech|beneficiad/.test(t)) {
+    return 'post_harvest';
+  }
+  if (/fumig|control de (broca|plaga)|aplic/.test(t)) {
+    return 'pest_management';
+  }
+  if (/cosech|recolect/.test(t)) {
+    return 'harvest';
   }
   return 'sowing';
 }
@@ -78,6 +88,13 @@ export const buildDraftsFromVoice = ({
     const trackingMode = defaults?.tracking_mode || 'individual';
     const insights = e._ragInsights || null;
 
+    const unit = (() => {
+      if (ptype === 'restoration' || ptype === 'silvopasture') return 'árboles';
+      if (ptype === 'harvest' || ptype === 'post_harvest') return 'kg';
+      if (ptype === 'pest_management') return 'litros';
+      return trackingMode === 'individual' ? 'plantas' : 'semillas';
+    })();
+
     return {
       draft_id: newUlid(),
       transcription,
@@ -86,9 +103,7 @@ export const buildDraftsFromVoice = ({
       subject_label: cropInfo.label || e.crop,
       variety: cropInfo.variety || undefined,
       quantity: e.quantity || 1,
-      unit: (ptype === 'restoration' || ptype === 'silvopasture')
-        ? 'árboles'
-        : (trackingMode === 'individual' ? 'plantas' : 'semillas'),
+      unit,
       subject_kind: trackingMode,
       location_land_asset_id: locInfo?.id || '',
       location_land_label: locInfo?.label || undefined,

--- a/src/types/farmProcess.js
+++ b/src/types/farmProcess.js
@@ -121,11 +121,16 @@ const VALID_STAGES = [
   'fruiting',
   'harvest_window',
   'harvest',
+  'post_harvest',
+  'pest_management',
   'closed',
   'fallow',
 ];
 const VALID_EVENT_TYPES = [
   'sowing_confirmed',
+  'harvest_confirmed',
+  'post_harvest_confirmed',
+  'pest_management_confirmed',
   'observation',
   'stage_transition',
   'stage_confirmed',


### PR DESCRIPTION
## Resumen

Conecta 3 nuevos tipos de proceso productivo al flujo de voz -> borrador -> confirmación -> createFarmProcess, siguiendo el patrón existente de silvopasture.

## Tipos soportados

| Tipo | Regex | Encabezado | Unidad default | Status | Stage |
|------|-------|------------|----------------|--------|-------|
| harvest | cosech*, recolect* | 🌾 Ciclo de cosecha | kg | completed | closed |
| post_harvest | secad*, almacen*, poscosech*, beneficiad* | 📦 Post-cosecha | kg | active | post_harvest |
| pest_management | fumig*, control de (broca|plaga), aplic* | 🐛 Manejo de plagas | litros | active | pest_management |

## Cambios

### 1. Detección de voz (src/services/voiceToDraft.js)
- : 3 nuevos regex con prioridad post_harvest > pest_management > harvest para evitar que la palabra 'cosecha' (sustantivo) en frases de post-cosecha se clasifique como harvest.
- : unidades por defecto según tipo (kg, litros).

### 2. Core de modelo (src/types/farmProcess.js, src/services/farmEventService.js)
- : agrega post_harvest, pest_management.
- : agrega harvest_confirmed, post_harvest_confirmed, pest_management_confirmed.
- : genera event_type correcto según process_type.

### 3. Hook de confirmación (src/hooks/useFarmProcessConfirm.js)
- : status=completed, current_stage=closed (cierra el ciclo).
- : status=active, current_stage=post_harvest.
- : status=active, current_stage=pest_management.

### 4. UI de confirmación (src/components/FarmProcessConfirmCard.jsx)
- Encabezados dinámicos por tipo.
- Unidades kg, arrobas, bultos, litros en el select.
- Botón de confirmación con label dinámico.

## Tests

- TDD: 13 nuevos tests en vitest, todos verdes.
- ESLint: verde (max-warnings=0).
- Archivos tocados: 8 (4 implementación + 4 tests).
- Sin archivos eliminados.

## Verificación

```bash
npx vitest run src/services/__tests__/voiceToDraft.processType.test.js src/services/__tests__/voiceToDraft.test.js src/components/__tests__/FarmProcessConfirmCard.test.jsx src/hooks/__tests__/useFarmProcessConfirm.test.js
# 36 passed (4 files)
```

## No merge
Opus verifica + mergea.