### PR TITLE
refactor(home): una sola Ⓐ — la red brota del botón real, despliegue arriba-derecha

### DIFF
--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -181,6 +181,10 @@ export default function AgentHero({ onNavigate }) {
 
     const textareaRef = useRef(null);
     const cameraInputRef = useRef(null);
+    // Ancla de la red Ⓐ: el botón del agente en el compositor ES la raíz
+    // geométrica del menú (operador 2026-06-10: una sola Ⓐ — la red nace
+    // del botón real, no de un nodo duplicado dentro del menú).
+    const aButtonRef = useRef(null);
 
     // Sistema de temas REAL de la app (data-theme en <html>, persiste en
     // localStorage). Aquí solo LEEMOS el tema para pintar el ícono de la marca
@@ -904,9 +908,16 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-tool:not(.is-open) {
                     animation: agentport-pulse-ring 3.6s cubic-bezier(.22,.61,.36,1) infinite;
                 }
+                /* Abierto = la Ⓐ ES la raíz viva de la red: se rellena con el
+                   acento y respira (glow suave) — la misma savia de las ramas
+                   que brotan de ella en la zona-respiro (un solo organismo). */
                 .agentport-tool.is-open {
                     background: rgb(var(--t-accent-rgb)); border-color: rgb(var(--t-accent-rgb));
-                    animation: none;
+                    animation: agentport-root-breathe 3.4s ease-in-out infinite;
+                }
+                @keyframes agentport-root-breathe {
+                    0%, 100% { box-shadow: 0 0 12px -2px rgb(var(--t-accent-rgb) / 0.55); }
+                    50% { box-shadow: 0 0 24px 2px rgb(var(--t-accent-rgb) / 0.85); }
                 }
                 /* al abrir, el ícono se vuelve blanco para contrastar con el acento */
                 .agentport-tool.is-open .agentport-tool-ico path,
@@ -1039,6 +1050,7 @@ export default function AgentHero({ onNavigate }) {
                     .agentport-net .spark { display: none !important; }
                     .agentport-sprig path { stroke-dashoffset: 0 !important; animation: none !important; }
                     .agentport-tool:not(.is-open) { animation: none !important; }
+                    .agentport-tool.is-open { animation: none !important; }
                     .agentport-greet { animation: none !important; }
                     .agentport-foldaway, .agentport-redpanel { transition: none !important; animation: none !important; }
                     .chagra-composer-shimmer::after, .chagra-composer-sending { animation: none !important; }
@@ -1231,7 +1243,7 @@ export default function AgentHero({ onNavigate }) {
                             </span>
                         </div>
                         <div className="agentport-red-body">
-                            <AgentRedMenu onPick={pickCapability} disabled={busy} />
+                            <AgentRedMenu onPick={pickCapability} disabled={busy} anchorRef={aButtonRef} />
                         </div>
                     </div>
                 )}
@@ -1369,9 +1381,12 @@ export default function AgentHero({ onNavigate }) {
 
                     {/* Fila 2: Ⓐ a la izquierda · cámara/adjuntar · mic/enviar a la derecha */}
                     <div className="flex items-center gap-2 px-1 pb-1 pt-0.5">
-                        {/* Botón Ⓐ — despliega/pliega la red de capacidades EN el hero */}
+                        {/* Botón Ⓐ — despliega/pliega la red de capacidades EN el
+                            hero. Es LA raíz de la red (única Ⓐ): el menú lee su
+                            posición vía aButtonRef y las ramas brotan de aquí. */}
                         <button
                             type="button"
+                            ref={aButtonRef}
                             onClick={toggleMenu}
                             disabled={isRecording}
                             aria-label="Ver todo lo que puede hacer Chagra"

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -43,8 +43,8 @@ import ChagraAgentAvatar from '../ChagraAgentAvatar';
  *   │  [¿Qué siembro?] [Plagas] [Clima]            │ ← chips
  *   │  ╭───────────────────────────────────────╮  │
  *   │  │ Pregúntale a Chagra…                  │  │ ← compositor pill anclado
- *   │  │ Ⓐ            📷 📎      🎤  ⬆          │  │   Ⓐ (izq) abre el menú de
- *   │  ╰───────────────────────────────────────╯  │   capacidades (bottom-sheet)
+ *   │  │ Ⓐ            📷 📎      🎤  ⬆          │  │   Ⓐ (izq) despliega la red
+ *   │  ╰───────────────────────────────────────╯  │   de capacidades EN el hero
  *   └─────────────────────────────────────────────┘
  *
  * QUÉ ES FIEL AL DEMO:
@@ -60,8 +60,10 @@ import ChagraAgentAvatar from '../ChagraAgentAvatar';
  *   - Toggle Campesino/Experto cableado al motor REAL `nivel_respuestas`
  *     (simple/detallado en userProfileService) — mueve el perfil de verdad y
  *     cambia el saludo, como el demo (COPY.campesino/experto).
- *   - Botón Ⓐ a la izquierda del compositor abre un bottom-sheet (.sheet del
- *     demo) con TODAS las capacidades reales de Chagra, cada una con su routing.
+ *   - Botón Ⓐ a la izquierda del compositor despliega la red de capacidades
+ *     (AgentRedMenu) INTEGRADA al hero: el saludo/chips se pliegan y la red
+ *     brota en la zona-respiro, sobre el mismo lienzo del tema (operador
+ *     2026-06-09: nada de bottom-sheet/modal aparte). Cada rama rutea real.
  *
  * QUÉ NO SE PORTÓ (y por qué, honesto):
  *   - El avatar 3D (ChagraAgentAvatar) + halo conic: ELIMINADOS por orden del
@@ -163,8 +165,13 @@ export default function AgentHero({ onNavigate }) {
     const [busy, setBusy] = useState(false);
     // Fase de la transición de envío: 'idle' | 'sending'.
     const [phase, setPhase] = useState('idle');
-    // Menú Ⓐ (bottom-sheet de capacidades). false=cerrado | true=abierto.
-    const [sheetOpen, setSheetOpen] = useState(false);
+    // Menú Ⓐ (la red de capacidades). Integrado AL hero (operador 2026-06-09:
+    // nada de bottom-sheet aparte): al abrir, el saludo/chips se PLIEGAN y la
+    // red brota en la zona-respiro, sobre el mismo lienzo del tema.
+    // menuOpen=montado · menuClosing=animando el cierre antes de desmontar.
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [menuClosing, setMenuClosing] = useState(false);
+    const menuCloseTimerRef = useRef(null);
     // Nivel de respuestas del perfil (campesino=simple / experto=detallado).
     // Lo leemos del perfil real al montar; el toggle lo persiste de verdad.
     const [nivel, setNivel] = useState(() => {
@@ -321,15 +328,50 @@ export default function AgentHero({ onNavigate }) {
         try { saveProfile({ nivel_respuestas: next }); } catch { /* perfil opcional */ }
     };
 
-    // ── Menú Ⓐ (bottom-sheet de capacidades) ─────────────────────────────────
-    const toggleSheet = () => setSheetOpen((o) => !o);
-    const closeSheet = () => setSheetOpen(false);
+    // ── Menú Ⓐ (red de capacidades INTEGRADA al hero) ────────────────────────
+    // Abrir = plegar saludo/chips y brotar la red en la zona-respiro.
+    // Cerrar = breve fade de salida (MENU_CLOSE_MS) y desmontar; con
+    // prefers-reduced-motion el cierre es inmediato.
+    const MENU_CLOSE_MS = 300;
+    const openMenu = () => {
+        window.clearTimeout(menuCloseTimerRef.current);
+        setMenuClosing(false);
+        setMenuOpen(true);
+    };
+    const closeMenu = () => {
+        if (prefersReducedMotion()) {
+            setMenuOpen(false);
+            setMenuClosing(false);
+            return;
+        }
+        setMenuClosing(true);
+        menuCloseTimerRef.current = window.setTimeout(() => {
+            setMenuOpen(false);
+            setMenuClosing(false);
+        }, MENU_CLOSE_MS);
+    };
+    const toggleMenu = () => {
+        if (menuOpen && !menuClosing) closeMenu();
+        else openMenu();
+    };
 
-    // Despacha una capacidad del sheet a su routing real.
+    // Limpia el timer de cierre al desmontar y cierra con Escape (a11y).
+    useEffect(() => () => window.clearTimeout(menuCloseTimerRef.current), []);
+    useEffect(() => {
+        if (!menuOpen) return undefined;
+        const onKey = (e) => { if (e.key === 'Escape') closeMenu(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [menuOpen]);
+
+    // Despacha una capacidad de la red a su routing real. El manifiesto
+    // unificado (agentCapabilities.js) llama `heroRoute` al routing del hero;
+    // leer `cap.route` dejaba TODOS los picks muertos en silencio (bug
+    // pre-existente de main, detectado en la validación visual 2026-06-09).
     const pickCapability = (cap) => {
-        if (cap.status === 'soon' || !cap.route || cap.route.kind === 'unavailable') return;
-        closeSheet();
-        const r = cap.route;
+        const r = cap.heroRoute || cap.route;
+        if (cap.status === 'soon' || !r || r.kind === 'unavailable') return;
+        closeMenu();
         if (r.kind === 'ask') {
             handleChipSend(r.prompt);
         } else if (r.kind === 'nav') {
@@ -909,31 +951,65 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-hint { text-align: center; font-size: 0.72rem; margin-top: 9px; color: rgb(var(--c-slate-500)); }
                 .agentport-hint b { color: rgb(var(--t-accent-rgb)); font-weight: 700; }
 
-                /* ===================== BOTTOM SHEET (menú Ⓐ) ===================== */
-                .agentport-scrim {
-                    position: fixed; inset: 0; background: rgba(10, 8, 4, 0.5);
-                    backdrop-filter: blur(2px); opacity: 0; pointer-events: none;
-                    transition: opacity 0.42s cubic-bezier(.32,.72,0,1); z-index: 60;
+                /* ============== MENÚ Ⓐ INTEGRADO (la red en el hero) ==============
+                   Nada de bottom-sheet/scrim/modal (operador 2026-06-09: "que se
+                   abra APARTE del agente lo vuelve feo"). Mecánica: al tocar Ⓐ,
+                   el saludo+chips se PLIEGAN (grid 1fr→0fr) y la zona-respiro
+                   (flex:1) absorbe el espacio; allí BROTA la red, full-bleed y
+                   transparente, sobre la misma escena del tema. El compositor no
+                   se mueve: el árbol crece desde el mismo lienzo donde está Ⓐ. */
+
+                /* plegado fluido del saludo/alerta/chips al abrir el menú */
+                .agentport-foldaway {
+                    display: grid; grid-template-rows: 1fr;
+                    transition: grid-template-rows .5s cubic-bezier(.32,.72,0,1),
+                                opacity .32s ease;
                 }
-                .agentport-scrim.is-open { opacity: 1; pointer-events: auto; }
-                .agentport-sheet {
-                    position: fixed; left: 0; right: 0; bottom: 0; z-index: 61;
-                    max-width: 640px; margin: 0 auto;
-                    background: rgb(var(--c-surface-raised));
-                    border-radius: 26px 26px 0 0;
-                    box-shadow: 0 -16px 40px -16px rgba(0, 0, 0, 0.55);
-                    border-top: 1px solid rgb(var(--c-surface-border));
-                    transform: translateY(110%); transition: transform 0.5s cubic-bezier(.32,.72,0,1);
-                    max-height: 92dvh; display: flex; flex-direction: column; will-change: transform;
+                .agentport-foldaway.is-folded {
+                    grid-template-rows: 0fr; opacity: 0; pointer-events: none;
                 }
-                .agentport-sheet.is-open { transform: translateY(0); }
-                .agentport-grab { width: 42px; height: 5px; background: rgb(var(--c-surface-border)); border-radius: 5px; margin: 10px auto 4px; flex: none; }
-                .agentport-sheet-h { padding: 6px 22px 4px; text-align: center; flex: none; }
-                .agentport-sheet-h .t { font-size: 1.18rem; font-weight: 800; color: rgb(var(--c-slate-100)); letter-spacing: -.01em; }
-                .agentport-sheet-h .s { font-size: .86rem; color: rgb(var(--c-slate-300)); margin-top: 4px; line-height: 1.45; }
-                [data-nivel="detallado"] .agentport-sheet-h .s { font-size: .8rem; }
-                .agentport-sheet-foot { padding: 6px 22px calc(18px + env(safe-area-inset-bottom)); text-align: center; font-size: .72rem; color: rgb(var(--c-slate-500)); flex: none; }
-                .agentport-sheet-foot b { color: rgb(var(--t-accent-rgb)); }
+                .agentport-foldaway-in { min-height: 0; overflow: hidden; }
+
+                /* panel de la red: vive DENTRO de la zona-respiro, sin caja */
+                .agentport-redpanel {
+                    position: absolute; inset: 0;
+                    display: flex; flex-direction: column;
+                    animation: agentport-red-in .5s cubic-bezier(.32,.72,0,1) both;
+                }
+                .agentport-redpanel.is-closing {
+                    transition: opacity .28s ease, transform .28s ease;
+                    opacity: 0; transform: translateY(10px) scale(.985);
+                    pointer-events: none;
+                }
+                @keyframes agentport-red-in {
+                    from { opacity: 0; transform: translateY(16px) scale(.985); }
+                    to { opacity: 1; transform: none; }
+                }
+                .agentport-red-h { flex: none; text-align: center; padding: 0 14px 2px; }
+                .agentport-red-h .t {
+                    font-size: 1.02rem; font-weight: 800; letter-spacing: -.01em;
+                    color: rgb(var(--c-slate-100));
+                }
+                .agentport-red-h .s {
+                    display: block; font-size: .78rem; line-height: 1.4; margin-top: 2px;
+                    color: rgb(var(--c-slate-300));
+                }
+                .agentport-red-body { flex: 1 1 auto; min-height: 0; position: relative; overflow: hidden; }
+
+                /* con la red abierta, la escena ambiente baja el volumen (misma
+                   pantalla, foco en la red — no un modal encima) */
+                .agentport-sun, .agentport-astro, .agentport-mtn, .agentport-pollen,
+                .agentport-hummer, .agentport-net, .agentport-spore,
+                .agentport-roots, .agentport-sprig { transition: opacity .5s ease; }
+                .agentport-scene.is-quiet .agentport-sun,
+                .agentport-scene.is-quiet .agentport-astro,
+                .agentport-scene.is-quiet .agentport-mtn,
+                .agentport-scene.is-quiet .agentport-pollen,
+                .agentport-scene.is-quiet .agentport-hummer,
+                .agentport-scene.is-quiet .agentport-net,
+                .agentport-scene.is-quiet .agentport-spore,
+                .agentport-scene.is-quiet .agentport-roots,
+                .agentport-scene.is-quiet .agentport-sprig { opacity: .22; }
 
                 /* Transición de envío: shimmer + lift (contrato de tests). */
                 @keyframes chagra-send-shimmer {
@@ -964,13 +1040,18 @@ export default function AgentHero({ onNavigate }) {
                     .agentport-sprig path { stroke-dashoffset: 0 !important; animation: none !important; }
                     .agentport-tool:not(.is-open) { animation: none !important; }
                     .agentport-greet { animation: none !important; }
+                    .agentport-foldaway, .agentport-redpanel { transition: none !important; animation: none !important; }
                     .chagra-composer-shimmer::after, .chagra-composer-sending { animation: none !important; }
                 }
             `}</style>
 
             {/* ===================== ESCENA AMBIENTE (por tema) ===================== */}
             <div
-                className={['agentport-scene', night ? 'is-night' : 'is-day'].join(' ')}
+                className={[
+                    'agentport-scene',
+                    night ? 'is-night' : 'is-day',
+                    menuOpen && !menuClosing ? 'is-quiet' : '',
+                ].join(' ')}
                 aria-hidden="true"
             >
                 {/* — SOL/LUNA delicado, universal, según hora (operador 2026-06-06) — */}
@@ -1131,9 +1212,34 @@ export default function AgentHero({ onNavigate }) {
                 </div>
             </header>
 
-            {/* ===================== ZONA-RESPIRO (escena vive detrás) ===================== */}
-            <div className="agentport-stage" aria-hidden="true" />
+            {/* ============ ZONA-RESPIRO (escena detrás · red Ⓐ al abrir) ============
+                Con el menú abierto, la red de capacidades BROTA aquí mismo —
+                integrada al lienzo del hero, sin sheet ni scrim. */}
+            <div className="agentport-stage" aria-hidden={menuOpen ? undefined : 'true'}>
+                {menuOpen && (
+                    <div
+                        className={['agentport-redpanel', menuClosing ? 'is-closing' : ''].join(' ')}
+                        role="group"
+                        aria-label="Capacidades de Chagra"
+                    >
+                        <div className="agentport-red-h">
+                            <span className="t">La mano de Chagra</span>
+                            <span className="s">
+                                {expertoActive
+                                    ? 'Cada rama, una capacidad conectada. Las opacas están por llegar.'
+                                    : 'Mi mano en tu campo: cada rama es una ayuda. Las opacas llegan pronto.'}
+                            </span>
+                        </div>
+                        <div className="agentport-red-body">
+                            <AgentRedMenu onPick={pickCapability} disabled={busy} />
+                        </div>
+                    </div>
+                )}
+            </div>
 
+            {/* ======= SALUDO + ALERTA + CHIPS (se pliegan al abrir el menú Ⓐ) ======= */}
+            <div className={['agentport-foldaway', menuOpen && !menuClosing ? 'is-folded' : ''].join(' ')}>
+            <div className="agentport-foldaway-in">
             {/* ===================== SALUDO ===================== */}
             <div className="agentport-greet">
                 <h2 className="agentport-hi">
@@ -1190,6 +1296,8 @@ export default function AgentHero({ onNavigate }) {
                         {chip.label}
                     </button>
                 ))}
+            </div>
+            </div>
             </div>
 
             {/* ===================== COMPOSITOR MULTIMODAL ===================== */}
@@ -1261,14 +1369,14 @@ export default function AgentHero({ onNavigate }) {
 
                     {/* Fila 2: Ⓐ a la izquierda · cámara/adjuntar · mic/enviar a la derecha */}
                     <div className="flex items-center gap-2 px-1 pb-1 pt-0.5">
-                        {/* Botón Ⓐ — abre el menú de capacidades (bottom-sheet) */}
+                        {/* Botón Ⓐ — despliega/pliega la red de capacidades EN el hero */}
                         <button
                             type="button"
-                            onClick={toggleSheet}
+                            onClick={toggleMenu}
                             disabled={isRecording}
                             aria-label="Ver todo lo que puede hacer Chagra"
-                            aria-expanded={sheetOpen}
-                            className={['agentport-iconbtn agentport-tool !w-11 !h-11', sheetOpen ? 'is-open' : ''].join(' ')}
+                            aria-expanded={menuOpen && !menuClosing}
+                            className={['agentport-iconbtn agentport-tool !w-11 !h-11', menuOpen && !menuClosing ? 'is-open' : ''].join(' ')}
                         >
                             <span className="agentport-tool-ico" aria-hidden="true">{iconForTheme(theme)}</span>
                         </button>
@@ -1336,10 +1444,15 @@ export default function AgentHero({ onNavigate }) {
                     />
                 </div>
 
-                {/* Hint bajo la pill (réplica de .hintbar del demo). */}
+                {/* Hint bajo la pill (réplica de .hintbar del demo). Con la red
+                    abierta muta a la línea de fuentes (antes pie del sheet). */}
                 {!isRecording && !attachment && (
                     <p className="agentport-hint">
-                        Toca <b>Ⓐ</b> para ver todo lo que sé hacer, o escríbeme aquí
+                        {menuOpen && !menuClosing ? (
+                            <>Chagra responde con información de <b>AGROSAVIA</b>, <b>ICA</b> e <b>IDEAM</b>.</>
+                        ) : (
+                            <>Toca <b>Ⓐ</b> para ver todo lo que sé hacer, o escríbeme aquí</>
+                        )}
                     </p>
                 )}
 
@@ -1356,36 +1469,6 @@ export default function AgentHero({ onNavigate }) {
                 )}
             </div>
 
-            {/* ===================== SCRIM + BOTTOM SHEET (menú Ⓐ) ===================== */}
-            <div
-                className={['agentport-scrim', sheetOpen ? 'is-open' : ''].join(' ')}
-                onClick={closeSheet}
-                aria-hidden="true"
-            />
-            <section
-                className={['agentport-sheet', sheetOpen ? 'is-open' : ''].join(' ')}
-                role="dialog"
-                aria-modal={sheetOpen}
-                aria-label="Capacidades de Chagra"
-                aria-hidden={!sheetOpen}
-            >
-                <div className="agentport-grab" aria-hidden="true" />
-                <div className="agentport-sheet-h">
-                    <div className="t">La mano de Chagra</div>
-                    <div className="s">
-                        {expertoActive
-                            ? 'Cada rama, una capacidad conectada. Las opacas están por llegar.'
-                            : 'Mi mano en tu campo: cada rama es una ayuda. Las opacas llegan pronto.'}
-                    </div>
-                </div>
-                {/* La mano de Chagra (emblema + capacidades) — componente único
-                    compartido con el panel inline. Solo se monta cuando el sheet
-                    está abierto, para que el dibujado se reproduzca al desplegar. */}
-                {sheetOpen && <AgentRedMenu onPick={pickCapability} disabled={busy} />}
-                <div className="agentport-sheet-foot">
-                    Chagra responde con información de <b>AGROSAVIA</b>, <b>ICA</b> e <b>IDEAM</b>.
-                </div>
-            </section>
         </section>
     );
 }

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -18,8 +18,10 @@ import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
  *   - El tema se LEE de <html data-theme> (lo escribe useTheme/applyTheme;
  *     biopunk = sin atributo). MutationObserver re-evalúa cambios en vivo.
  *     Sin barra selectora propia (eso vive en Perfil).
- *   - Sin FAB Ⓐ ni sheet propios: se renderiza DENTRO del bottom-sheet del
- *     AgentHero. El nodo Ⓐ abajo-centro es la raíz del árbol (y "volver").
+ *   - Sin FAB Ⓐ, sin sheet y SIN MARCO propio: se renderiza INTEGRADO en el
+ *     lienzo del AgentHero (la zona-respiro), full-bleed y transparente — la
+ *     escena del hero por tema es el fondo. El contenedor padre decide el
+ *     alto (height:100%). El nodo Ⓐ abajo-centro es la raíz (y "volver").
  *   - `prefers-reduced-motion` → sin loop rAF: un solo paint al estado final.
  *   - Cleanup completo: rAF, timers, ResizeObserver, MutationObserver, paths.
  *
@@ -190,21 +192,18 @@ function bounce(el) {
 /* ══════════════ estilos (CSS del demo, scoped arm-) ══════════════ */
 
 const CSS = `
+/* SIN MARCO (operador 2026-06-09): nada de caja con borde/radius/fondo —
+   la red respira full-bleed sobre el lienzo del AgentHero; el padre da el
+   alto. Solo overflow:hidden para que esporas/ramas no se salgan. */
 .arm-root{
-  position:relative;width:100%;height:560px;max-height:calc(100dvh - 170px);min-height:420px;
-  overflow:hidden;border-radius:24px;
-  background:var(--sheetBg);border:1px solid var(--sheetEdge);
+  position:relative;width:100%;height:100%;min-height:380px;
+  overflow:hidden;background:transparent;
   -webkit-tap-highlight-color:transparent;
   /* ---- tema biopunk (base) ---- */
   --fam:ui-monospace,'Cascadia Mono',Menlo,Consolas,monospace;
   --lblSize:13px; --lblSp:.01em; --lblW:800;
   --lblC:#ffffff; --lblBg:rgba(3,12,9,.9); --lblEdge:rgba(25,199,154,.55);
   --lblShadow:0 2px 8px rgba(0,0,0,.6);
-  --sheetBg:
-    radial-gradient(135% 95% at 50% 103%,rgba(25,199,154,.20),rgba(25,199,154,.05) 42%,transparent 64%),
-    radial-gradient(90% 55% at 86% -6%,rgba(38,110,160,.16),transparent 60%),
-    linear-gradient(180deg,#0d1422,#0a0e14 85%);
-  --sheetEdge:rgba(25,199,154,.35);
   --branch:#19c79a; --coreW:2.2px;
   --glowC:rgba(25,199,154,.30); --glowW:8px; --glowO:1; --glowBlur:3px;
   --twigC:rgba(25,199,154,.55);
@@ -213,7 +212,7 @@ const CSS = `
   --orbShadow:0 0 22px rgba(25,199,154,.32),0 0 6px rgba(25,199,154,.5),inset 0 0 16px rgba(25,199,154,.10);
   --orbRadA:50%; --orbRadB:50%;
   --pulse:rgba(25,199,154,.55);
-  --spore:#19c79a; --spO:.7; --noiseO:.05;
+  --spore:#19c79a; --spO:.7;
   --rootBg:radial-gradient(circle at 35% 28%,#34efbe,#129b78 75%);
   --rootGlyph:#06231b; --rootShadow:0 0 26px rgba(25,199,154,.55),0 4px 14px rgba(0,0,0,.5);
   --crumbBg:rgba(25,199,154,.16); --crumbC:#c8f3e2; --crumbEdge:rgba(25,199,154,.45);
@@ -227,11 +226,6 @@ const CSS = `
   --lblSize:13.5px; --lblSp:0; --lblW:700;
   --lblC:#2e2414; --lblBg:rgba(255,250,238,.95); --lblEdge:rgba(121,87,53,.5);
   --lblShadow:0 2px 6px rgba(90,60,30,.22);
-  --sheetBg:
-    radial-gradient(85% 45% at 80% -8%,rgba(241,199,118,.42),transparent 58%),
-    linear-gradient(to top,rgba(108,139,77,.30),rgba(108,139,77,.08) 130px,transparent 210px),
-    linear-gradient(180deg,#f3ead4,#faf3e2 40%,#f5edd9);
-  --sheetEdge:rgba(121,87,53,.35);
   --branch:#6e4f2e; --coreW:4px;
   --glowC:rgba(121,87,53,.22); --glowW:9px; --glowO:1; --glowBlur:1.5px;
   --twigC:rgba(110,79,46,.6);
@@ -241,7 +235,7 @@ const CSS = `
   --orbRadA:58% 42% 55% 45% / 45% 58% 42% 55%;
   --orbRadB:44% 56% 48% 52% / 56% 44% 58% 42%;
   --pulse:rgba(95,124,66,.5);
-  --spore:#7c9a4e; --spO:.6; --noiseO:.08;
+  --spore:#7c9a4e; --spO:.6;
   --rootBg:radial-gradient(circle at 35% 28%,#8fae62,#5f7c42 78%);
   --rootGlyph:#fdf8e9; --rootShadow:0 5px 16px rgba(80,60,30,.4);
   --crumbBg:rgba(255,250,238,.9); --crumbC:#4a3a1f; --crumbEdge:rgba(121,87,53,.45);
@@ -255,8 +249,6 @@ const CSS = `
   --lblSize:12.5px; --lblSp:.02em; --lblW:700;
   --lblC:#143d31; --lblBg:rgba(255,255,255,.96); --lblEdge:rgba(47,110,90,.35);
   --lblShadow:0 1px 4px rgba(30,40,35,.12);
-  --sheetBg:linear-gradient(180deg,#f9f6ee,#f6f3ec);
-  --sheetEdge:rgba(47,110,90,.28);
   --branch:#2f6e5a; --coreW:1.6px;
   --glowC:transparent; --glowW:0px; --glowO:0; --glowBlur:0px;
   --twigC:rgba(47,110,90,.45);
@@ -265,7 +257,7 @@ const CSS = `
   --orbShadow:0 2px 6px rgba(30,40,35,.1);
   --orbRadA:50%; --orbRadB:50%;
   --pulse:transparent;
-  --spore:transparent; --spO:0; --noiseO:.03;
+  --spore:transparent; --spO:0;
   --rootBg:#2f6e5a;
   --rootGlyph:#f6f3ec; --rootShadow:0 3px 10px rgba(30,50,42,.25);
   --crumbBg:#ffffff; --crumbC:#1f5847; --crumbEdge:rgba(47,110,90,.35);
@@ -274,10 +266,9 @@ const CSS = `
   --trunkC:#2f6e5a; --trunkHi:#5ea58d;
 }
 .arm-root.arm-disabled{pointer-events:none;opacity:.55}
-.arm-root::after{content:"";position:absolute;inset:0;z-index:6;pointer-events:none;
-  opacity:var(--noiseO);mix-blend-mode:overlay;
-  background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='160' height='160' filter='url(%23n)' opacity='0.65'/></svg>");
-}
+/* La textura de ruido del demo se quitó en la integración: sobre el lienzo
+   transparente del hero dibujaba un rectángulo "sucio" (el marco que el
+   operador rechazó). El grano ambiente lo pone la escena del hero. */
 .arm-web{position:absolute;inset:0;width:100%;height:100%;z-index:1;pointer-events:none}
 .arm-gtrunk path{fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gtrunk .tkB{stroke:var(--trunkC);stroke-width:17px}

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -21,15 +21,23 @@ import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
  *   - Sin FAB Ⓐ, sin sheet y SIN MARCO propio: se renderiza INTEGRADO en el
  *     lienzo del AgentHero (la zona-respiro), full-bleed y transparente — la
  *     escena del hero por tema es el fondo. El contenedor padre decide el
- *     alto (height:100%). El nodo Ⓐ abajo-centro es la raíz (y "volver").
+ *     alto (height:100%).
+ *   - UNA SOLA Ⓐ (operador 2026-06-10): el menú NO renderiza nodo raíz propio.
+ *     La raíz geométrica de la red ES el botón Ⓐ real del compositor (vive en
+ *     AgentHero, abajo-izquierda); el padre lo comparte vía `anchorRef` y acá
+ *     se mide su centro en coordenadas del lienzo (queda bajo el borde
+ *     inferior — las ramas brotan del borde apuntando exactamente al botón).
  *   - `prefers-reduced-motion` → sin loop rAF: un solo paint al estado final.
  *   - Cleanup completo: rAF, timers, ResizeObserver, MutationObserver, paths.
  *
- * Mecánicas por tema (idénticas al demo):
- *   - biopunk / minimalista → "micorriza": ramas radiales desde la raíz Ⓐ;
- *     al enfocar, el grupo VIAJA al hub y los demás se vuelven yemas.
- *   - nature → "árbol": tronco vertical que brota + ramas alternadas; al
- *     enfocar, el follaje brota EN SITIO y las demás ramas se atenúan.
+ * Mecánicas por tema (refinamiento 2026-06-10):
+ *   - biopunk / minimalista → "micorriza": la red brota del botón Ⓐ
+ *     (abajo-izquierda) y se despliega en diagonal hacia ARRIBA-DERECHA,
+ *     al espacio libre del hero. Al enfocar, el grupo VIAJA al hub (sobre la
+ *     diagonal) y los demás se vuelven yemas recogidas junto al origen.
+ *   - nature → "árbol": tronco vertical CENTRADO que brota + ramas alternadas;
+ *     una vena/raíz orgánica conecta el botón Ⓐ con la base del tronco (un
+ *     solo organismo). Al enfocar, el follaje brota EN SITIO.
  */
 
 /* ══════════════ datos: grupos derivados del manifiesto ══════════════ */
@@ -213,8 +221,6 @@ const CSS = `
   --orbRadA:50%; --orbRadB:50%;
   --pulse:rgba(25,199,154,.55);
   --spore:#19c79a; --spO:.7;
-  --rootBg:radial-gradient(circle at 35% 28%,#34efbe,#129b78 75%);
-  --rootGlyph:#06231b; --rootShadow:0 0 26px rgba(25,199,154,.55),0 4px 14px rgba(0,0,0,.5);
   --crumbBg:rgba(25,199,154,.16); --crumbC:#c8f3e2; --crumbEdge:rgba(25,199,154,.45);
   --toastBg:#0e1a18; --toastC:#d8f7e9; --toastEdge:rgba(25,199,154,.45);
   --hintC:rgba(190,240,220,.85);
@@ -236,8 +242,6 @@ const CSS = `
   --orbRadB:44% 56% 48% 52% / 56% 44% 58% 42%;
   --pulse:rgba(95,124,66,.5);
   --spore:#7c9a4e; --spO:.6;
-  --rootBg:radial-gradient(circle at 35% 28%,#8fae62,#5f7c42 78%);
-  --rootGlyph:#fdf8e9; --rootShadow:0 5px 16px rgba(80,60,30,.4);
   --crumbBg:rgba(255,250,238,.9); --crumbC:#4a3a1f; --crumbEdge:rgba(121,87,53,.45);
   --toastBg:#fffaf0; --toastC:#3c2f18; --toastEdge:rgba(121,87,53,.4);
   --hintC:rgba(74,58,31,.8);
@@ -258,8 +262,6 @@ const CSS = `
   --orbRadA:50%; --orbRadB:50%;
   --pulse:transparent;
   --spore:transparent; --spO:0;
-  --rootBg:#2f6e5a;
-  --rootGlyph:#f6f3ec; --rootShadow:0 3px 10px rgba(30,50,42,.25);
   --crumbBg:#ffffff; --crumbC:#1f5847; --crumbEdge:rgba(47,110,90,.35);
   --toastBg:#ffffff; --toastC:#1f5847; --toastEdge:rgba(47,110,90,.3);
   --hintC:rgba(31,88,71,.7);
@@ -274,12 +276,16 @@ const CSS = `
 .arm-gtrunk .tkB{stroke:var(--trunkC);stroke-width:17px}
 .arm-gtrunk .tkO{stroke:var(--trunkC);stroke-width:10px}
 .arm-gtrunk .tkI{stroke:var(--trunkHi);stroke-width:3.5px;opacity:.8}
+/* vena Ⓐ→tronco (nature): raíz superficial que conecta el botón del agente
+   con la base del tronco centrado — un solo organismo, no dos piezas. */
+.arm-gtrunk .vnO{stroke:var(--trunkC);stroke-width:8px;opacity:.95}
+.arm-gtrunk .vnI{stroke:var(--trunkHi);stroke-width:2.6px;opacity:.75}
 .arm-gglow{opacity:var(--glowO);filter:blur(var(--glowBlur));animation:armBreathe 4.5s ease-in-out infinite}
 .arm-gglow path{stroke:var(--glowC);stroke-width:var(--glowW);fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gcore path{stroke:var(--branch);stroke-width:var(--coreW);fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gcore path.lf{stroke-width:calc(var(--coreW)*.78)}
 .arm-gtwig path{stroke:var(--twigC);stroke-width:1.1px;fill:none;stroke-linecap:round;transition:stroke .5s}
-.arm-gtwig path.rt{opacity:.5;stroke-width:1.3px}
+.arm-gtwig path.rt{opacity:.62;stroke-width:1.4px}
 .arm-gtwig path.gd{opacity:.65;stroke-width:2.2px}
 @keyframes armBreathe{0%,100%{opacity:var(--glowO)}50%{opacity:calc(var(--glowO)*.55)}}
 .arm-spores{position:absolute;inset:0;z-index:2;pointer-events:none;overflow:hidden}
@@ -311,6 +317,8 @@ const CSS = `
 }
 .arm-node::before{content:"";position:absolute;inset:-10px} /* target de toque >= 92px */
 .arm-node.arm-leaf{width:66px;height:66px;margin:-33px 0 0 -33px;z-index:5}
+/* (el nodo raíz Ⓐ propio del menú se ELIMINÓ — operador 2026-06-10: una sola
+   Ⓐ, la del botón del agente en el compositor; la red nace de ese ancla) */
 .arm-orb{
   position:absolute;inset:0;display:grid;place-items:center;
   background:var(--orbBg);border:var(--ringW) solid var(--ringGroup);
@@ -320,17 +328,12 @@ const CSS = `
 }
 .arm-node:nth-child(even) .arm-orb{border-radius:var(--orbRadB)}
 .arm-node.arm-leaf .arm-orb{border-color:var(--ringLeaf)}
-.arm-node.arm-rootn{z-index:4;width:78px;height:78px;margin:-39px 0 0 -39px}
-.arm-node.arm-rootn .arm-orb{background:var(--rootBg);border:none;box-shadow:var(--rootShadow);border-radius:50%;
-  animation:armSprout .6s cubic-bezier(.34,1.55,.5,1) both .12s}
-.arm-node.arm-rootn .arm-ic{font-family:Georgia,serif;font-size:38px;color:var(--rootGlyph);font-style:normal}
-.arm-node.arm-group .arm-orb::after,.arm-node.arm-rootn .arm-orb::after{
+.arm-node.arm-group .arm-orb::after{
   content:"";position:absolute;inset:-5px;border-radius:inherit;
   border:1px solid var(--pulse);animation:armPing 3.4s ease-out infinite;
   animation-delay:var(--pd,0s);
 }
 @keyframes armPing{0%{transform:scale(.88);opacity:.8}70%,100%{transform:scale(1.4);opacity:0}}
-@keyframes armSprout{from{transform:scale(0)}to{transform:scale(1)}}
 .arm-ic{display:block;font-size:35px;font-style:normal;
   animation:armSway var(--swD,5s) ease-in-out var(--swDel,0s) infinite alternate}
 .arm-node.arm-leaf .arm-ic{font-size:31px}
@@ -351,7 +354,9 @@ const CSS = `
   padding:2px 7px;opacity:.9}
 .arm-node.arm-soon{cursor:default}
 .arm-node.arm-soon .arm-orb{border-style:dashed}
-.arm-hint{position:absolute;left:50%;bottom:120px;transform:translateX(-50%);z-index:4;
+/* pista de uso — abajo-derecha: la esquina libre con la red brotando del
+   botón Ⓐ (abajo-izquierda) hacia arriba-derecha. */
+.arm-hint{position:absolute;right:14px;bottom:10px;z-index:4;
   font-family:var(--fam);font-size:13.5px;font-weight:700;letter-spacing:.04em;color:var(--hintC);
   pointer-events:none;transition:opacity .6s;white-space:nowrap}
 .arm-hint.off{opacity:0}
@@ -377,7 +382,7 @@ const CSS = `
 
 /* ══════════════ componente ══════════════ */
 
-export default function AgentRedMenu({ onPick, disabled = false }) {
+export default function AgentRedMenu({ onPick, disabled = false, anchorRef = null }) {
   const rootRef = useRef(null);
   const engineRef = useRef(null);
   const toastTimerRef = useRef(null);
@@ -413,10 +418,11 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
     const tkB = root.querySelector('[data-arm="tkB"]');
     const tkO = root.querySelector('[data-arm="tkO"]');
     const tkI = root.querySelector('[data-arm="tkI"]');
+    const vnO = root.querySelector('[data-arm="vnO"]');
+    const vnI = root.querySelector('[data-arm="vnI"]');
     const rootlets = root.querySelector('[data-arm="rootlets"]');
     const ground = root.querySelector('[data-arm="ground"]');
     const hintEl = root.querySelector('[data-arm="hint"]');
-    const rootNodeEl = root.querySelector('[data-arm="rootnode"]');
 
     /* estado de simulación por grupo/hoja (paths SVG creados acá). */
     const sim = GROUPS.map((g, i) => {
@@ -452,7 +458,7 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
     const denom = Math.max(1, N - 1);
     let W = 0, H = 0, cx = 0, rootPt = { x: 0, y: 0 }, hub = { x: 0, y: 0 };
     let posOver = [], posBud = [];
-    let trunkBez = null, trunkLen = 1, attachPts = [], treePos = [], treeFocus = [];
+    let trunkBez = null, trunkLen = 1, venaLen = 1, attachPts = [], treePos = [], treeFocus = [];
     let trunkV = 0, trunkVT = 0;
     let focused = null;
     let rafId = null, last = 0, animUntil = 0;
@@ -464,43 +470,73 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
       H = root.clientHeight;
       if (!W || !H) return;
       cx = W / 2;
-      rootPt = { x: cx, y: H - 76 };
+
+      /* LA RAÍZ ES EL BOTÓN Ⓐ REAL del compositor (vive en AgentHero, abajo-
+         izquierda). Medimos su centro en coordenadas de este lienzo: queda
+         BAJO el borde inferior (el compositor está debajo de la zona-respiro),
+         así las ramas brotan del borde apuntando exactamente al botón — una
+         sola Ⓐ, un solo organismo. Sin ancla (tests/jsdom): fallback
+         abajo-izquierda equivalente. */
+      const aEl = anchorRef && anchorRef.current;
+      const rb = root.getBoundingClientRect();
+      if (aEl && rb.width > 0) {
+        const ab = aEl.getBoundingClientRect();
+        rootPt = {
+          x: clampN(ab.left + ab.width / 2 - rb.left, 24, W - 24),
+          y: Math.max(H - 8, ab.top + ab.height / 2 - rb.top),
+        };
+      } else {
+        rootPt = { x: 46, y: H + 58 };
+      }
       svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
 
-      /* radial (biopunk/min): micorriza que explota desde la raíz */
-      const Rx = cx - 64, Ry = rootPt.y - 110;
-      const a0 = -Math.PI + 0.30, a1 = -0.30;
+      /* micorriza (biopunk/min): abanico diagonal hacia ARRIBA-DERECHA desde
+         la Ⓐ (operador 2026-06-10) — del origen abajo-izquierda al espacio
+         libre del hero. */
+      const a0 = -1.45, a1 = -0.30; /* casi vertical → casi horizontal der. */
+      const Rx = Math.max(120, W - rootPt.x - 84);
+      const Ry = Math.max(140, rootPt.y - 96);
       posOver = sim.map((s, i) => {
         const a = a0 + (a1 - a0) * i / denom;
         const k = KS[i % KS.length];
         return {
-          x: cx + Math.cos(a) * Rx * k + (rand(i + 31) - 0.5) * 18,
+          x: rootPt.x + Math.cos(a) * Rx * k + (rand(i + 31) - 0.5) * 18,
           y: rootPt.y + Math.sin(a) * Ry * k + (rand(i + 47) - 0.5) * 18,
         };
       });
-      relax(posOver, 106, { x0: 62, x1: W - 62, y0: 78, y1: rootPt.y - 84 });
+      /* y1 deja libre la franja inferior (pista "toque una rama" + labels) */
+      relax(posOver, 106, { x0: 62, x1: W - 62, y0: 82, y1: H - 118 });
 
+      /* yemas: recogidas junto al origen (abajo-izquierda, sobre la Ⓐ) */
       posBud = sim.map((s, i) => {
-        const a = a0 + (a1 - a0) * i / denom, r = i % 2 ? 100 : 66;
-        return { x: cx + Math.cos(a) * r, y: rootPt.y + Math.sin(a) * r * 0.82 };
+        const a = a0 + (a1 - a0) * i / denom, r = i % 2 ? 152 : 110;
+        return { x: rootPt.x + Math.cos(a) * r, y: rootPt.y + Math.sin(a) * r * 0.9 };
       });
-      relax(posBud, 46, { x0: 44, x1: W - 44, y0: rootPt.y - 128, y1: rootPt.y - 16 });
+      relax(posBud, 46, { x0: 40, x1: W - 44, y0: H - 158, y1: H - 26 });
 
-      hub = { x: cx, y: rootPt.y - Math.min(180, H * 0.31) };
-      const Lrx = Math.min(158, cx - 68), Lry = Math.min(188, hub.y - 114);
+      /* hub del foco: sobre la diagonal, dejando aire arriba-derecha para
+         que el follaje del grupo enfocado respire */
+      hub = {
+        x: clampN(rootPt.x + Math.min(132, W * 0.30), 96, Math.max(98, W - 150)),
+        y: Math.max(132, H * 0.46),
+      };
+      const Lrx = Math.max(96, Math.min(152, W - hub.x - 62));
+      const Lry = Math.max(72, Math.min(176, hub.y - 100, H - hub.y - 96));
       sim.forEach((s) => {
         const n = s.leaves.length;
         const sp = n > 1 ? Math.min(2.6, 0.9 * (n - 1)) : 0;
+        const center = -0.55; /* abanico sesgado hacia arriba-derecha */
         s.leafAbsR = s.leaves.map((lf, j) => {
-          const a = -Math.PI / 2 + (n > 1 ? -sp / 2 + sp * j / (n - 1) : 0);
+          const a = center + (n > 1 ? -sp / 2 + sp * j / (n - 1) : 0);
           return { x: hub.x + Math.cos(a) * Lrx, y: hub.y + Math.sin(a) * Lry };
         });
-        relax(s.leafAbsR, 96, { x0: 60, x1: W - 60, y0: 78, y1: hub.y + 8 });
+        relax(s.leafAbsR, 96, { x0: 60, x1: W - 60, y0: 84, y1: H - 70 });
         s.leafOffR = s.leafAbsR.map((p) => ({ x: p.x - hub.x, y: p.y - hub.y }));
       });
 
-      /* árbol (nature): tronco vertical + ramas alternadas */
-      const baseT = { x: cx, y: rootPt.y - 4 };
+      /* árbol (nature): tronco vertical CENTRADO (correcto funcional y
+         visualmente — operador 2026-06-10) + ramas alternadas */
+      const baseT = { x: cx, y: H - 56 };
       const topT = { x: cx + 10, y: Math.max(92, H * 0.14) };
       const Lh = baseT.y - topT.y;
       trunkBez = bezObj(
@@ -513,6 +549,21 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
       tkB.setAttribute('d', trunkBez.d);
       tkO.setAttribute('d', trunkBez.d);
       tkI.setAttribute('d', trunkBez.d);
+
+      /* la VENA Ⓐ→tronco: raíz superficial que nace en el botón del agente
+         y repta por el suelo hasta la base del tronco — la conexión elegante
+         (un solo organismo, no dos piezas pegadas). */
+      const venaBez = bezObj(
+        rootPt,
+        /* sube casi vertical sobre la Ⓐ (asoma temprano en el lienzo)… */
+        { x: rootPt.x + 6, y: rootPt.y - Math.max(40, (rootPt.y - baseT.y - 26) * 0.55) },
+        /* …y repta por el suelo hasta la base del tronco */
+        { x: rootPt.x + (baseT.x - rootPt.x) * 0.45, y: baseT.y + 18 },
+        { x: baseT.x - 2, y: baseT.y + 6 },
+      );
+      venaLen = Math.hypot(baseT.x - rootPt.x, baseT.y - rootPt.y) * 1.3 + 1;
+      vnO.setAttribute('d', venaBez.d);
+      vnI.setAttribute('d', venaBez.d);
 
       attachPts = []; treePos = []; treeFocus = [];
       sim.forEach((s, i) => {
@@ -538,25 +589,39 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
           const a = center + (n > 1 ? -spread / 2 + spread * j / (n - 1) : 0) * (side < 0 ? 1 : -1);
           return { x: fp.x + Math.cos(a) * r, y: fp.y + Math.sin(a) * r };
         });
-        relax(s.leafAbsT, 96, { x0: 64, x1: W - 64, y0: 78, y1: rootPt.y - 46 });
+        relax(s.leafAbsT, 96, { x0: 64, x1: W - 64, y0: 78, y1: baseT.y - 54 });
         s.leafOffT = s.leafAbsT.map((p) => ({ x: p.x - fp.x, y: p.y - fp.y }));
       });
 
-      rootNodeEl.style.transform = `translate(${r1(rootPt.x)}px,${r1(rootPt.y)}px)`;
-
-      /* raicillas decorativas bajo el nodo raíz */
+      /* decoración del arraigo:
+         - nature: raicillas bajo la base del tronco + arco de suelo.
+         - micorriza: boca de raicillas que brota de la Ⓐ hacia arriba-derecha
+           (largos calculados para asomar SIEMPRE sobre el borde inferior). */
       let d = '';
-      for (let k = 0; k < 5; k++) {
-        const a = Math.PI * (0.15 + 0.7 * k / 4);
-        const ex = rootPt.x + Math.cos(a) * (24 + rand(k + 40) * 34);
-        const ey = rootPt.y + 10 + Math.sin(a) * (16 + rand(k + 50) * 30);
-        const mx = rootPt.x + (ex - rootPt.x) * 0.35 + (rand(k + 60) - 0.5) * 10;
-        const my = rootPt.y + 12;
-        d += `M${r1(rootPt.x)} ${r1(rootPt.y + 8)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
+      if (treeMode) {
+        for (let k = 0; k < 5; k++) {
+          const a = Math.PI * (0.15 + 0.7 * k / 4);
+          const ex = baseT.x + Math.cos(a) * (24 + rand(k + 40) * 34);
+          const ey = baseT.y + 10 + Math.sin(a) * (16 + rand(k + 50) * 30);
+          const mx = baseT.x + (ex - baseT.x) * 0.35 + (rand(k + 60) - 0.5) * 10;
+          const my = baseT.y + 12;
+          d += `M${r1(baseT.x)} ${r1(baseT.y + 8)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
+        }
+      } else {
+        const depth = Math.max(0, rootPt.y - H);
+        for (let k = 0; k < 5; k++) {
+          const a = -1.32 + 1.0 * k / 4; /* -76°..-18°: hacia arriba-derecha */
+          const len = (depth + 26 + rand(k + 40) * 46) / Math.max(0.3, -Math.sin(a));
+          const ex = clampN(rootPt.x + Math.cos(a) * len, 16, W - 28);
+          const ey = rootPt.y + Math.sin(a) * len;
+          const mx = rootPt.x + (ex - rootPt.x) * 0.45 + (rand(k + 60) - 0.5) * 14;
+          const my = rootPt.y + Math.sin(a) * len * 0.45;
+          d += `M${r1(rootPt.x)} ${r1(rootPt.y)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
+        }
       }
       rootlets.setAttribute('d', d.trim());
       ground.setAttribute('d',
-        `M${r1(cx - 108)} ${r1(rootPt.y + 12)} Q${r1(cx)} ${r1(rootPt.y + 26)} ${r1(cx + 108)} ${r1(rootPt.y + 12)}`);
+        `M${r1(cx - 108)} ${r1(baseT.y + 12)} Q${r1(cx)} ${r1(baseT.y + 26)} ${r1(cx + 108)} ${r1(baseT.y + 12)}`);
     }
 
     /* ── bucle rAF (con reduced-motion: un solo paint al estado final) ── */
@@ -578,10 +643,16 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
         md = Math.max(md, 200 * Math.abs(trunkVT - trunkV));
         const te = ease3(trunkV);
         if (trunkV < 0.995) {
+          /* la vena brota PRIMERO desde la Ⓐ; el tronco la sigue */
+          setDash(vnO, venaLen, Math.min(1, te * 2.6));
+          setDash(vnI, venaLen, Math.min(1, te * 2.6));
           setDash(tkB, trunkLen, Math.min(1, te * 4));
           setDash(tkO, trunkLen, te);
           setDash(tkI, trunkLen, te);
-        } else { clearDash(tkB); clearDash(tkO); clearDash(tkI); }
+        } else {
+          clearDash(tkB); clearDash(tkO); clearDash(tkI);
+          clearDash(vnO); clearDash(vnI);
+        }
         gTrunk.style.opacity = f == null ? 1 : 0.55;
       }
 
@@ -735,7 +806,7 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
       });
       engineRef.current = null;
     };
-  }, [treeMode]);
+  }, [treeMode, anchorRef]);
 
   function showToast(msg) {
     setToastMsg(msg);
@@ -774,6 +845,9 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
 
       <svg className="arm-web" data-arm="web" preserveAspectRatio="none" aria-hidden="true">
         <g className="arm-gtrunk" data-arm="gTrunk">
+          {/* vena Ⓐ→tronco primero: la base del tronco tapa la unión */}
+          <path className="vnO" data-arm="vnO" />
+          <path className="vnI" data-arm="vnI" />
           <path className="tkB" data-arm="tkB" />
           <path className="tkO" data-arm="tkO" />
           <path className="tkI" data-arm="tkI" />
@@ -866,17 +940,9 @@ export default function AgentRedMenu({ onPick, disabled = false }) {
           }),
         )}
 
-        <div
-          className="arm-node arm-rootn"
-          role="button"
-          tabIndex={0}
-          aria-label="Volver al inicio del menú"
-          data-arm="rootnode"
-          onClick={handleRootTap}
-          onKeyDown={(ev) => pressKey(ev, handleRootTap)}
-        >
-          <div className="arm-orb"><i className="arm-ic">Ⓐ</i></div>
-        </div>
+        {/* SIN nodo raíz Ⓐ propio (operador 2026-06-10): la única Ⓐ es el
+            botón del agente en el compositor — la red nace de él. "Volver"
+            vive en la miga (crumb) cuando hay un grupo enfocado. */}
       </div>
 
       <div className="arm-hint" data-arm="hint">⸙ toque una rama</div>

--- a/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
@@ -101,6 +101,12 @@ vi.mock('../../ChagraAgentAvatar', () => ({
   ),
 }));
 
+// jsdom no trae ResizeObserver (lo usa el motor de AgentRedMenu, que ahora
+// se monta INTEGRADO en el hero al abrir el menú Ⓐ).
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
 import AgentHero from '../AgentHero';
 import { getProfile, saveProfile, getProfileMunicipio } from '../../../services/userProfileService';
 
@@ -466,6 +472,79 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
       
       // NO debe persistir (ya está en ese nivel)
       expect(saveProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('6. menú Ⓐ integrado al hero (sin bottom-sheet)', () => {
+    test('tocar Ⓐ brota la red EN la zona-respiro y pliega saludo/chips', async () => {
+      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+
+      // Cerrado: nada de red ni de sheet/scrim (el modal aparte murió).
+      expect(container.querySelector('.agentport-redpanel')).toBeNull();
+      expect(container.querySelector('.agentport-sheet')).toBeNull();
+      expect(container.querySelector('.agentport-scrim')).toBeNull();
+
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+      await act(async () => { fireEvent.click(aBtn); });
+
+      // Abierto: la red vive DENTRO de la zona-respiro del hero.
+      const stage = container.querySelector('.agentport-stage');
+      const panel = stage.querySelector('.agentport-redpanel');
+      expect(panel).toBeTruthy();
+      expect(panel.querySelector('.arm-root')).toBeTruthy();
+      expect(container.querySelector('.agentport-sheet')).toBeNull();
+      expect(aBtn).toHaveAttribute('aria-expanded', 'true');
+
+      // El saludo/chips quedan plegados (misma pantalla, no scrim encima).
+      expect(container.querySelector('.agentport-foldaway')).toHaveClass('is-folded');
+      // La escena ambiente baja el volumen pero sigue siendo el mismo lienzo.
+      expect(container.querySelector('.agentport-scene')).toHaveClass('is-quiet');
+    });
+
+    test('tocar Ⓐ de nuevo cierra y devuelve el saludo (reduced-motion: inmediato)', async () => {
+      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+
+      await act(async () => { fireEvent.click(aBtn); });
+      expect(container.querySelector('.agentport-redpanel')).toBeTruthy();
+
+      await act(async () => { fireEvent.click(aBtn); });
+      expect(container.querySelector('.agentport-redpanel')).toBeNull();
+      expect(container.querySelector('.agentport-foldaway')).not.toHaveClass('is-folded');
+      expect(aBtn).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('tocar una hoja viva rutea de verdad (heroRoute → outbox → chat)', async () => {
+      const onNavigate = vi.fn();
+      render(<AgentHero onNavigate={onNavigate} />);
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+      await act(async () => { fireEvent.click(aBtn); });
+
+      // 'Plaga' es una capacidad live del manifiesto real con
+      // heroRoute {kind:'ask'} — el bug de main leía cap.route (undefined)
+      // y mataba el pick en silencio. Este test lo clava.
+      const leaf = screen.getByLabelText('Plaga');
+      await act(async () => { fireEvent.click(leaf); });
+
+      await waitFor(() => {
+        expect(sendMock).toHaveBeenCalledWith(
+          expect.objectContaining({ kind: 'text', text: expect.stringMatching(/plagas/i) }),
+        );
+      });
+      await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('agente'));
+    });
+
+    test('Escape cierra el menú (a11y teclado)', async () => {
+      const { container } = render(<AgentHero onNavigate={vi.fn()} />);
+      const aBtn = screen.getByLabelText('Ver todo lo que puede hacer Chagra');
+
+      await act(async () => { fireEvent.click(aBtn); });
+      expect(container.querySelector('.agentport-redpanel')).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.keyDown(window, { key: 'Escape' });
+      });
+      expect(container.querySelector('.agentport-redpanel')).toBeNull();
     });
   });
 

--- a/src/components/dashboard/__tests__/AgentRedMenu.smoke.test.jsx
+++ b/src/components/dashboard/__tests__/AgentRedMenu.smoke.test.jsx
@@ -20,4 +20,19 @@ describe('AgentRedMenu — smoke', () => {
     const { container } = render(<AgentRedMenu onPick={vi.fn()} />);
     expect(container.querySelector('.arm-root')).toBeTruthy();
   });
+
+  it('NO duplica la Ⓐ: el menú no trae nodo raíz propio (la raíz es el botón Ⓐ del hero)', () => {
+    const { container } = render(<AgentRedMenu onPick={vi.fn()} />);
+    // Operador 2026-06-10: una SOLA Ⓐ — la del botón del agente (AgentHero).
+    // El menú no renderiza su propio nodo Ⓐ; la red nace del ancla del padre.
+    expect(container.querySelector('.arm-rootn')).toBeNull();
+    // ningún nodo interactivo del menú pinta el glifo Ⓐ (el <style> no cuenta)
+    expect(container.querySelector('.arm-nodes').textContent).not.toContain('Ⓐ');
+  });
+
+  it('acepta el ancla del botón Ⓐ del hero (anchorRef) sin crashear', () => {
+    const anchorRef = { current: null };
+    const { container } = render(<AgentRedMenu onPick={vi.fn()} anchorRef={anchorRef} />);
+    expect(container.querySelector('.arm-root')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Refinamiento del menú Ⓐ in-place sobre `feat/arana-integracion-limpia` (feedback del operador 2026-06-10). **NO mergear** — revisión visual en vivo pendiente.

## Qué cambia
1. **Una sola Ⓐ**: se elimina el nodo raíz Ⓐ duplicado del menú (abajo-centro). El botón Ⓐ del compositor (AgentHero) ES la raíz: el menú mide su posición vía `anchorRef` y toda la red nace de ese punto real (abajo-izquierda).
2. **Despliegue arriba-derecha** (biopunk/minimalista): abanico diagonal desde la Ⓐ hacia el espacio libre del hero. Yemas recogidas junto al origen, hub del foco sobre la diagonal, follaje sesgado arriba-derecha, pista ("toque una rama") abajo-derecha y miga "volver" coherentes.
3. **Nature**: el tronco se conserva CENTRADO; una vena/raíz orgánica nace en la Ⓐ y repta por el suelo hasta la base del tronco (brota antes que el tronco) — un solo organismo continuo.
4. **Conexión viva**: el botón Ⓐ abierto se llena de acento y respira (glow), la misma savia de las ramas. `prefers-reduced-motion` apaga todo.

## Conservado
- Concepto aprobado (red/árbol/yemas por tema), 3 temas (min intacto), in-place sin marco, `onPick` → capacidad → chat real, fix `heroRoute` de la branch.

## Validación
- `AgentRedMenu.smoke.test` ampliado: sin `.arm-rootn`, sin glifo Ⓐ en los nodos, `anchorRef` opcional. Verde.
- eslint --max-warnings=0 en los archivos tocados. Fallos de vitest/lint restantes son pre-existentes en la base (verificado con stash).
- EN VIVO con chromium del nix-store (vite dev :5199, SW bloqueado): 3 temas × cerrado/abierto/enfocado en `/tmp/arana-refinamiento/`. Confirmado: una sola Ⓐ, abanico arriba-derecha, tronco centrado, picks rutean al chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)