### PR TITLE
feat(seguridad): guardas sobre el canal de streaming — el display vivo nunca pinta peligro sin guardar (SEC-001)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -67,6 +67,7 @@ import { normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buil
 import { buildBasePrompt, analyzeQuery, buildQueryAnalysisBlock, buildCorpusVariants, buildResolvedEntitiesBlock, formatToolEvidence } from '../../services/agentPromptBase';
 import { assembleSystemContent } from '../../services/promptAssembler';
 import { applyOutputGuards, classifyQueryIntent } from '../../services/outputGuards';
+import { createStreamGuard } from '../../services/streamGuards';
 import { getProfile } from '../../services/userProfileService';
 import { captureExchange } from '../../services/conversationCaptureService';
 import { regionFromProfile, getEnsoOutlook } from '../../services/ensoContext';
@@ -894,13 +895,27 @@ export default function AgentScreen({ onBack, initialContext }) {
     // antes detenían el watchdog.
     stallTimerRef.current = deadline;
 
+    // SEC-001 (DR-CHAGRA-AUDIT-IA-001): guard del canal de STREAMING. El guard
+    // final (applyOutputGuards sobre el texto completo) NO cambia — esto es una
+    // capa ADICIONAL sobre el display EN VIVO: el sniff local (mismos guards de
+    // peligro de outputGuards, cero latencia, throttle incremental + latch)
+    // retiene el parcial con un placeholder si un patrón peligroso dispara
+    // (sintético+dosis, mezcla incompatible, tóxico en comida…). Las respuestas
+    // seguras y las dosis orgánicas legítimas fluyen token a token sin cambio.
+    const streamGuard = createStreamGuard({ userMessage: query });
+
     const markToken = (fullText) => {
       // Llegó un token: el stream está vivo → reinicia el idle-timer. El techo
       // absoluto sigue corriendo intacto.
       deadline.onToken();
+      // SEC-001: lo que se pinta (y lo que el catch preserva ante una
+      // interrupción) es SIEMPRE la versión segura del parcial — si el sniff
+      // latcheó peligro, es el placeholder; el final guardado reemplaza limpio.
+      // En streams seguros safeDisplay === fullText (passthrough idéntico).
+      const safeDisplay = streamGuard.check(fullText);
       // Espejo del parcial en ref para que el catch lo preserve sin closure stale.
-      streamingContentRef.current = fullText;
-      setStreamingContent(fullText);
+      streamingContentRef.current = safeDisplay;
+      setStreamingContent(safeDisplay);
     };
     deadline.start();
 

--- a/src/services/__tests__/streamGuards.test.js
+++ b/src/services/__tests__/streamGuards.test.js
@@ -1,0 +1,209 @@
+/**
+ * streamGuards.test.js — SEC-001: guardas de seguridad en el canal de STREAMING.
+ *
+ * PROBLEMA (auditoría DR-CHAGRA-AUDIT-IA-001, SEC-001, ALTO): el display en vivo
+ * pinta cada token del LLM ANTES de que `applyOutputGuards` corra sobre el texto
+ * FINAL. El usuario alcanza a LEER la dosis/receta peligrosa en pantalla aunque
+ * el guard final la reemplace después. En campo eso es daño físico real.
+ *
+ * FIX bajo prueba: `createStreamGuard` envuelve el display del parcial. Reutiliza
+ * los guards de PELIGRO ya existentes en outputGuards.js (sniff local, cero
+ * latencia). Cuando un patrón peligroso dispara sobre el parcial, el display
+ * pasa a un placeholder y NUNCA vuelve a pintar el crudo (latch) hasta que llega
+ * el final ya guardado (que reemplaza limpio el stream).
+ *
+ * Doctrina anti-sobre-supresión (CRÍTICO):
+ *  - Respuestas SEGURAS fluyen token a token IDÉNTICAS al crudo (cero cambio).
+ *  - Dosis ORGÁNICAS legítimas ("2 kg de compost", "5 ml de jabón potásico")
+ *    NO se suprimen — la batería reusa los anti-falsos-positivos de cada guard
+ *    y EXCLUYE guards aditivos que disparan sobre contenido inocuo
+ *    (guardDoseWithoutSource) y guards de siembra/cosmética.
+ *
+ * Doctrina perf (anti-O(n²)):
+ *  - Latch: tras disparar, check() es O(1) — no se escanea más.
+ *  - Throttle incremental: la batería corre como máximo cada `scanMinChars`
+ *    chars nuevos; un hint barato (dígitos/keywords de riesgo) sobre SOLO el
+ *    delta nuevo adelanta el scan sin re-escanear todo en cada token.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createStreamGuard,
+  sniffStreamDanger,
+  STREAM_GUARD_PLACEHOLDER,
+} from '../streamGuards.js';
+
+/**
+ * Simula el stream real: el LLM emite el texto en chunks y cada onToken recibe
+ * el ACUMULADO (igual que markToken en AgentScreen). Devuelve la secuencia de
+ * displays que el usuario habría visto en pantalla.
+ */
+function simulateStream(fullResponse, guard, chunkSize = 6) {
+  const displays = [];
+  for (let i = chunkSize; i < fullResponse.length + chunkSize; i += chunkSize) {
+    displays.push(guard.check(fullResponse.slice(0, i)));
+  }
+  return displays;
+}
+
+const DANGEROUS_SYNTH_DOSE =
+  'Para el gusano cogollero te recomiendo aplicar glifosato en dosis de 50 ml ' +
+  'por bomba de 20 litros cada 8 días sobre el follaje afectado.';
+
+const DANGEROUS_SYNTH_NO_DIGITS =
+  'Para ese problema del lote te recomiendo aplicar glifosato sobre el follaje ' +
+  'afectado con calma y luego seguir con el manejo habitual del cultivo para ' +
+  'que la maleza no vuelva a aparecer en la temporada.';
+
+const DANGEROUS_MIX =
+  'Mezcla el caldo bordelés con el caldo sulfocálcico en el mismo tanque y ' +
+  'aplica la mezcla al follaje cada semana para controlar el hongo.';
+
+const SAFE_NO_HINTS =
+  'El maíz se asocia muy bien con el frijol y la calabaza porque comparten ' +
+  'nutrientes, dan sombra al suelo y se protegen entre ellas. Esa asociación ' +
+  'tradicional mejora la vida del suelo y reduce las plagas sin químicos.';
+
+const SAFE_ORGANIC_DOSES =
+  'Para mejorar tu suelo aplica 2 kg de compost por árbol y 1 L de biol por ' +
+  'planta cada mes. Para los pulgones prepara jabón potásico a 5 ml por litro ' +
+  'de agua y aplica al envés de las hojas al atardecer.';
+
+describe('sniffStreamDanger — batería de peligro sobre el parcial', () => {
+  it('dispara con pesticida sintético + dosis', () => {
+    const res = sniffStreamDanger(DANGEROUS_SYNTH_DOSE);
+    expect(res.danger).toBe(true);
+    expect(res.reason).toBeTruthy();
+  });
+
+  it('dispara con mezcla incompatible de biopreparados en el mismo tanque', () => {
+    expect(sniffStreamDanger(DANGEROUS_MIX).danger).toBe(true);
+  });
+
+  it('NO dispara con respuesta segura sin dosis', () => {
+    expect(sniffStreamDanger(SAFE_NO_HINTS).danger).toBe(false);
+  });
+
+  it('NO dispara con dosis orgánicas legítimas (compost, biol, jabón potásico)', () => {
+    expect(sniffStreamDanger(SAFE_ORGANIC_DOSES).danger).toBe(false);
+  });
+
+  it('no-op con vacío / no-string', () => {
+    expect(sniffStreamDanger('').danger).toBe(false);
+    expect(sniffStreamDanger(null).danger).toBe(false);
+    expect(sniffStreamDanger(undefined).danger).toBe(false);
+  });
+});
+
+describe('createStreamGuard — display en vivo', () => {
+  it('stream SEGURO fluye token a token idéntico al crudo (cero placeholder)', () => {
+    const guard = createStreamGuard();
+    const displays = simulateStream(SAFE_NO_HINTS, guard);
+    displays.forEach((d, i) => {
+      expect(d).toBe(SAFE_NO_HINTS.slice(0, Math.min((i + 1) * 6, SAFE_NO_HINTS.length)));
+    });
+    expect(displays.some((d) => d === STREAM_GUARD_PLACEHOLDER)).toBe(false);
+    expect(guard.isDangerLatched()).toBe(false);
+  });
+
+  it('dosis ORGÁNICAS legítimas NO se suprimen (anti-sobre-supresión)', () => {
+    const guard = createStreamGuard();
+    const displays = simulateStream(SAFE_ORGANIC_DOSES, guard);
+    expect(displays.some((d) => d === STREAM_GUARD_PLACEHOLDER)).toBe(false);
+    expect(displays[displays.length - 1]).toBe(SAFE_ORGANIC_DOSES);
+    expect(guard.isDangerLatched()).toBe(false);
+  });
+
+  it('stream PELIGROSO (sintético + dosis): el display queda guardado y la dosis cruda NUNCA se pinta', () => {
+    const guard = createStreamGuard();
+    const displays = simulateStream(DANGEROUS_SYNTH_DOSE, guard);
+    // La cifra de la dosis jamás llega a pantalla (el hint de dígito fuerza el
+    // scan en el mismo token en que aparece).
+    expect(displays.some((d) => /50\s*ml/.test(d))).toBe(false);
+    // El último display es el placeholder, no el crudo.
+    expect(displays[displays.length - 1]).toBe(STREAM_GUARD_PLACEHOLDER);
+    expect(guard.isDangerLatched()).toBe(true);
+  });
+
+  it('latch: tras disparar, TODOS los displays siguientes son placeholder (nunca vuelve el crudo)', () => {
+    const guard = createStreamGuard();
+    const displays = simulateStream(DANGEROUS_SYNTH_DOSE, guard);
+    const firstHit = displays.indexOf(STREAM_GUARD_PLACEHOLDER);
+    expect(firstHit).toBeGreaterThanOrEqual(0);
+    for (let i = firstHit; i < displays.length; i += 1) {
+      expect(displays[i]).toBe(STREAM_GUARD_PLACEHOLDER);
+    }
+  });
+
+  it('throttle de piso garantiza detección aun SIN dígitos ni hints en el peligro', () => {
+    const guard = createStreamGuard();
+    const displays = simulateStream(DANGEROUS_SYNTH_NO_DIGITS, guard);
+    // El piso de chars del throttle escanea periódicamente: al terminar el
+    // stream el peligro quedó latcheado sí o sí.
+    expect(displays[displays.length - 1]).toBe(STREAM_GUARD_PLACEHOLDER);
+    expect(guard.isDangerLatched()).toBe(true);
+  });
+
+  it('mezcla incompatible de biopreparados → placeholder', () => {
+    const guard = createStreamGuard();
+    const displays = simulateStream(DANGEROUS_MIX, guard);
+    expect(displays[displays.length - 1]).toBe(STREAM_GUARD_PLACEHOLDER);
+  });
+
+  it('perf: latch congela los scans (O(1) tras disparo)', () => {
+    const guard = createStreamGuard();
+    simulateStream(DANGEROUS_SYNTH_DOSE, guard);
+    const scansAtLatch = guard.getScanCount();
+    // Seguir alimentando tokens tras el latch no escanea más.
+    guard.check(`${DANGEROUS_SYNTH_DOSE} y además`);
+    guard.check(`${DANGEROUS_SYNTH_DOSE} y además repite`);
+    expect(guard.getScanCount()).toBe(scansAtLatch);
+  });
+
+  it('perf: texto seguro SIN hints escanea solo por el piso del throttle (no por token)', () => {
+    const scanMinChars = 64;
+    const guard = createStreamGuard({ scanMinChars });
+    const long = `${SAFE_NO_HINTS} ${SAFE_NO_HINTS}`;
+    const displays = simulateStream(long, guard);
+    // Cota: un scan como máximo cada `scanMinChars` chars nuevos — muy por
+    // debajo de un scan por token.
+    expect(guard.getScanCount()).toBeLessThanOrEqual(Math.ceil(long.length / scanMinChars) + 1);
+    expect(guard.getScanCount()).toBeLessThan(displays.length);
+  });
+
+  it('reset en stream nuevo (segunda pasada tool-call): el latch NO contamina la respuesta nueva', () => {
+    const guard = createStreamGuard();
+    simulateStream(DANGEROUS_SYNTH_DOSE, guard);
+    expect(guard.isDangerLatched()).toBe(true);
+    // Texto más CORTO que el último parcial = stream nuevo (mismo patrón que
+    // el reset streamingContentRef('') + segunda llamada del action loop).
+    const displays = simulateStream(SAFE_NO_HINTS, guard);
+    expect(guard.isDangerLatched()).toBe(false);
+    expect(displays[displays.length - 1]).toBe(SAFE_NO_HINTS);
+  });
+
+  it('no-string / vacío: no revienta y devuelve string', () => {
+    const guard = createStreamGuard();
+    expect(guard.check(null)).toBe('');
+    expect(guard.check(undefined)).toBe('');
+    expect(guard.check('')).toBe('');
+  });
+
+  it('el placeholder es texto visible en español (tú/usted, sin voseo)', () => {
+    expect(typeof STREAM_GUARD_PLACEHOLDER).toBe('string');
+    expect(STREAM_GUARD_PLACEHOLDER.length).toBeGreaterThan(10);
+    // Anti-voseo: nada de "tenés/querés/mostrarte vos".
+    expect(/ten[eé]s|quer[eé]s|\bvos\b/i.test(STREAM_GUARD_PLACEHOLDER)).toBe(false);
+  });
+});
+
+describe('createStreamGuard — receta de fermento sin caveat (DR-FOOD-3, caveat debe LIDERAR)', () => {
+  it('la receta cruda no se pinta en vivo: el final guardado antepone el caveat', () => {
+    const recipe =
+      'Para preparar la kombucha necesitas un scoby, té negro y azúcar. Deja ' +
+      'fermentar diez días en un frasco limpio y luego embotella con cuidado.';
+    const guard = createStreamGuard({ userMessage: '¿cómo preparo kombucha en casa?' });
+    const displays = simulateStream(recipe, guard);
+    expect(displays[displays.length - 1]).toBe(STREAM_GUARD_PLACEHOLDER);
+  });
+});

--- a/src/services/streamGuards.js
+++ b/src/services/streamGuards.js
@@ -1,0 +1,218 @@
+/**
+ * streamGuards — SEC-001: guardas de seguridad sobre el canal de STREAMING.
+ *
+ * PROBLEMA (auditoría DR-CHAGRA-AUDIT-IA-001, SEC-001, ALTO): el agente pinta
+ * cada token en vivo (markToken en AgentScreen) pero `applyOutputGuards` corre
+ * SOLO sobre el texto FINAL. El usuario alcanza a LEER la dosis/receta
+ * peligrosa en pantalla ANTES de que el guard final la reemplace. En campo eso
+ * es daño físico real.
+ *
+ * FIX: capa ADICIONAL sobre el canal VISUAL (el guard final no cambia). Antes
+ * de pintar el parcial, un sniff LOCAL y barato reutiliza los guards de PELIGRO
+ * que YA existen en outputGuards.js (no se reinventa detección). Si un patrón
+ * peligroso dispara sobre el parcial → el display pasa a un placeholder y se
+ * LATCHEA: nunca vuelve a pintar el crudo ni un guardado-a-medias; el FINAL ya
+ * guardado reemplaza limpio el stream al terminar.
+ *
+ * BATERÍA (solo guards de SEGURIDAD FÍSICA, puros, síncronos, cero latencia):
+ *   - guardToxicFoodPreparation        (preparar/comer tóxico, envenenar agua)
+ *   - guardSyntheticAgrochemical       (sintético + dosis/marca, combustible)
+ *   - guardIncompatibleBiopreparadoMix (bordelés + sulfocálcico mismo tanque)
+ *   - guardInventedProductRecipe       (producto inventado con dosis)
+ *   - guardInventedBrand               (marca comercial inventada recomendada)
+ *   - guardToxicResidueOnFood          (higuerilla sobre papa almacenada)
+ *   - guardFermentoRecipeSafety        (receta de fermento sin caveat — el
+ *     caveat debe LIDERAR, DR-FOOD-3: el crudo en vivo lo mostraría después)
+ *
+ * ANTI-SOBRE-SUPRESIÓN (crítico): NO corren aquí los guards que disparan sobre
+ * contenido inocuo o incompleto — guardDoseWithoutSource (anexa caveat a
+ * CUALQUIER dosis sin fuente, incluidas las orgánicas legítimas "2 kg de
+ * compost"), guards de SIEMBRA/viabilidad (necesitan grounding y razonan sobre
+ * el turno completo), concisión, nombre, visión, off-domain. Cada guard de la
+ * batería trae su propio diseño anti-falso-positivo (denylists cerradas,
+ * gates de conjunción término+dosis), así que una respuesta segura u orgánica
+ * con cantidades fluye token a token sin cambio alguno.
+ *
+ * PERF (anti-O(n²) por token):
+ *   - LATCH: tras el primer disparo, check() es O(1) (devuelve placeholder).
+ *   - THROTTLE incremental: la batería corre como máximo cada `scanMinChars`
+ *     chars nuevos (piso que GARANTIZA detección sin depender de hints).
+ *   - HINT fast-path: un regex barato sobre SOLO el delta nuevo (dígitos =
+ *     dosis, keywords de riesgo) adelanta el scan al token exacto en que
+ *     aparece la cifra — la dosis cruda no llega a pintarse. El hint solo
+ *     ACELERA; nunca se usa para saltarse el piso (cero huecos de recall).
+ *   Con num_predict acotado (~80-512 tokens) el costo total medido es <1 ms.
+ *
+ * Nota de telemetría: el scan que latchea incrementa una vez los contadores
+ * de `chagra:output_guard_triggers` del guard que disparó (además del bump del
+ * guard final). Inflación ≤1 por turno peligroso — aceptable y útil.
+ *
+ * @module streamGuards
+ */
+
+import {
+  guardSyntheticAgrochemical,
+  guardIncompatibleBiopreparadoMix,
+  guardToxicFoodPreparation,
+  guardInventedProductRecipe,
+  guardInventedBrand,
+  guardToxicResidueOnFood,
+  guardFermentoRecipeSafety,
+} from './outputGuards';
+
+/**
+ * Placeholder que el usuario ve EN VIVO mientras el parcial peligroso queda
+ * retenido. Breve, honesto, español de Colombia (tú/usted, sin voseo). El
+ * texto final guardado lo reemplaza al terminar la inferencia.
+ */
+export const STREAM_GUARD_PLACEHOLDER =
+  'Un momento… estoy verificando esta recomendación con las guías de seguridad antes de mostrártela.';
+
+/**
+ * Batería de PROBES de peligro. Cada probe adapta la firma del guard real
+ * (algunos reciben `{ userMessage }`) a `(text, userMessage) → {modified,...}`.
+ * El ORDEN va de lo más grave/barato a lo más específico (cortocircuito en el
+ * primer disparo).
+ */
+const DANGER_PROBES = [
+  (text) => guardToxicFoodPreparation(text),
+  (text) => guardSyntheticAgrochemical(text),
+  (text, userMessage) => guardIncompatibleBiopreparadoMix(text, { userMessage }),
+  (text) => guardInventedProductRecipe(text),
+  (text) => guardInventedBrand(text),
+  (text, userMessage) => guardToxicResidueOnFood(text, { userMessage }),
+  (text, userMessage) => guardFermentoRecipeSafety(text, { userMessage }),
+];
+
+/**
+ * Hint barato de riesgo sobre el DELTA nuevo del stream (no el texto entero).
+ * Es SOLO un acelerador del scan (recall-oriented, los falsos positivos solo
+ * cuestan una corrida de batería): dígitos (toda dosis trae cifra), palabra
+ * "dosis"/"mezcl-", combustibles y sufijos de familia química. La GARANTÍA de
+ * detección NO depende de este regex sino del piso del throttle.
+ */
+const RISK_HINT_RE =
+  /[0-9]|dosis|mezcl|aplic|marca|acpm|di[eé]sel|gasolina|kerosen|fermento|kombucha|(?:azol|fos|tion|trina|cloprid|carb)(?=[^a-zá-ú]|$)/i;
+
+/** Piso del throttle: chars nuevos máximos entre scans de batería. */
+const DEFAULT_SCAN_MIN_CHARS = 64;
+
+/**
+ * Piso del fast-path por hint: aun con hints en cada token (texto denso en
+ * cifras), la batería no corre más de una vez cada estos chars nuevos. Acota
+ * el costo en el peor caso sin abrir una ventana de fuga relevante (~24 chars
+ * ≈ 6 tokens ≈ 0.25 s a 24 tok/s).
+ */
+const HINT_MIN_CHARS = 24;
+
+/**
+ * Solape al recortar el delta nuevo, para que un keyword partido entre dos
+ * chunks ("glifo|sato", "5|0 ml") igual matchee el hint.
+ */
+const HINT_OVERLAP_CHARS = 16;
+
+/**
+ * sniffStreamDanger — corre la batería de peligro sobre un parcial. PURO,
+ * SÍNCRONO, 100% local (mismos guards del guard final → cero latencia nueva).
+ * Un probe que reviente jamás tumba el stream (try/catch por probe).
+ *
+ * @param {string} partialText — texto acumulado del stream hasta ahora.
+ * @param {{userMessage?: string|null}} [ctx] — pregunta cruda del usuario
+ *   (gates de intención de los guards de mezcla/fermento/residuo).
+ * @returns {{danger: boolean, reason: string|null}}
+ */
+export function sniffStreamDanger(partialText, { userMessage = null } = {}) {
+  if (typeof partialText !== 'string' || partialText.length === 0) {
+    return { danger: false, reason: null };
+  }
+  for (const probe of DANGER_PROBES) {
+    try {
+      const res = probe(partialText, userMessage);
+      if (res && res.modified) {
+        return { danger: true, reason: res.reason || 'stream_guard' };
+      }
+    } catch (_) {
+      // Defensa: un guard roto no puede tumbar el canal visual.
+    }
+  }
+  return { danger: false, reason: null };
+}
+
+/**
+ * createStreamGuard — fábrica del guard de streaming POR TURNO (estado propio:
+ * latch, throttle). Crear una instancia junto a `markToken` y pasar cada
+ * parcial acumulado por `check()`; pintar SIEMPRE lo que `check()` devuelve.
+ *
+ * Maneja el reset implícito del action-loop (segunda llamada al LLM tras
+ * tool_calls): si llega un parcial MÁS CORTO que el último visto, es un stream
+ * nuevo → estado limpio (el latch del stream anterior no contamina la
+ * respuesta nueva; el final de ESA respuesta pasa igual por el guard final).
+ *
+ * @param {object} [opts]
+ * @param {string|null} [opts.userMessage] — pregunta cruda del usuario.
+ * @param {number} [opts.scanMinChars] — piso del throttle (chars nuevos).
+ * @param {string} [opts.placeholder] — texto visible mientras se retiene.
+ * @returns {{
+ *   check: (fullText: string) => string,
+ *   isDangerLatched: () => boolean,
+ *   getScanCount: () => number,
+ * }}
+ */
+export function createStreamGuard({
+  userMessage = null,
+  scanMinChars = DEFAULT_SCAN_MIN_CHARS,
+  placeholder = STREAM_GUARD_PLACEHOLDER,
+} = {}) {
+  let lastLen = 0; // longitud del último parcial visto.
+  let lastScanLen = 0; // longitud del parcial en el último scan de batería.
+  let danger = false; // LATCH: una vez true, nunca vuelve a pintarse el crudo.
+  let scanCount = 0; // corridas de batería (telemetría/tests de perf).
+
+  const reset = () => {
+    lastLen = 0;
+    lastScanLen = 0;
+    danger = false;
+  };
+
+  const check = (fullText) => {
+    if (typeof fullText !== 'string') return '';
+    // Stream NUEVO (parcial más corto que el anterior = reset del action-loop
+    // o reintento): estado limpio para no sobre-suprimir la respuesta nueva.
+    if (fullText.length < lastLen) reset();
+
+    if (danger) {
+      lastLen = fullText.length;
+      return placeholder;
+    }
+
+    // Delta nuevo + solape (keywords partidos entre chunks igual matchean).
+    const sliceFrom = Math.max(0, lastLen - HINT_OVERLAP_CHARS);
+    const newSlice = fullText.slice(sliceFrom);
+    lastLen = fullText.length;
+
+    const newCharsSinceScan = fullText.length - lastScanLen;
+    const floorDue = newCharsSinceScan >= scanMinChars;
+    const hintDue = newCharsSinceScan >= HINT_MIN_CHARS && RISK_HINT_RE.test(newSlice);
+    // Primer contenido del stream con hint: escanear ya (sin esperar piso) —
+    // una dosis peligrosa puede caber entera en los primeros tokens.
+    const firstHint = lastScanLen === 0 && RISK_HINT_RE.test(newSlice);
+
+    if (!floorDue && !hintDue && !firstHint) return fullText;
+
+    scanCount += 1;
+    lastScanLen = fullText.length;
+    const res = sniffStreamDanger(fullText, { userMessage });
+    if (res.danger) {
+      danger = true;
+      console.debug('[streamGuard] peligro retenido en vivo (SEC-001)', { reason: res.reason });
+      return placeholder;
+    }
+    return fullText;
+  };
+
+  return {
+    check,
+    isDangerLatched: () => danger,
+    getScanCount: () => scanCount,
+  };
+}


### PR DESCRIPTION
## Problema (auditoría DR-CHAGRA-AUDIT-IA-001 · SEC-001 · ALTO)

El agente pinta cada token EN VIVO (`markToken`), pero `applyOutputGuards` corre solo sobre el texto FINAL. El usuario alcanzaba a LEER la dosis/receta peligrosa en pantalla antes de que el guard la reemplazara. En campo eso es daño físico real.

## Fix (capa ADICIONAL sobre el canal visual — el guard final no cambia)

- **Nuevo `src/services/streamGuards.js`**: `createStreamGuard` + `sniffStreamDanger`. Reutiliza los guards de PELIGRO ya existentes en `outputGuards.js` (100% local, cero latencia): sintético+dosis/marca, mezcla incompatible de biopreparados, tóxico en comida/agua, producto/marca inventada, residuo tóxico en alimento, receta de fermento sin caveat.
- **`markToken`** pasa cada parcial por `streamGuard.check()`: si un patrón peligroso dispara → placeholder ("verificando esta recomendación…") con **latch** (nunca vuelve el crudo ni un guardado-a-medias) hasta que el FINAL ya guardado reemplaza limpio.
- `streamingContentRef` espeja la versión SEGURA → el merge de interrupción (cancel/timeout) tampoco preserva crudo peligroso.

## Anti-sobre-supresión (crítico)

- Streams SEGUROS: passthrough idéntico token a token (cero placeholder).
- Dosis orgánicas legítimas ("2 kg de compost", "5 ml de jabón potásico") NO se suprimen: la batería EXCLUYE `guardDoseWithoutSource` (aditivo, dispara sobre dosis inocuas) y los guards de siembra/cosmética; cada guard incluido trae su propio anti-falso-positivo.

## Perf (anti-O(n²))

- Latch: O(1) tras el primer disparo.
- Throttle: batería como máximo cada 64 chars nuevos (piso que garantiza detección sin hints).
- Hint barato (dígitos/keywords de riesgo) SOLO sobre el delta nuevo: adelanta el scan al token exacto donde aparece la cifra — la dosis cruda no llega a pintarse. El hint nunca salta el piso (cero huecos de recall).

## Tests / lint

- TDD: 17 tests nuevos en `streamGuards.test.js` (peligroso→guardado, seguro→idéntico, dosis orgánicas, latch, throttle sin hints, perf/scan-count, reset del action-loop, placeholder sin voseo). Verdes.
- Suite completa: los únicos fallos son los 14 pre-existentes en origin/main (crypto/sandbox: visionCache, sidecarClient, mediaCache, mipPlaga) — verificado con `git stash` sobre baseline limpio.
- `eslint --max-warnings=0` limpio en los 3 archivos tocados.

Se conservan intactos: guard final (~L1545), `streamingContentRef`, cancelación/deadline, reduced-motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)