### PR TITLE
fix(login): pantalla de login negra de día (forzar biopunk)

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Sprout } from 'lucide-react';
+import { applyTheme, normalizeTheme, STORAGE_KEY, DEFAULT_THEME } from '../hooks/useTheme';
 import { authenticateUser } from '../services/authService';
 import { setCurrentOperator } from '../services/operatorIdentityService';
 import { setActiveTenantId } from '../services/tenantContext';
@@ -21,6 +22,20 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
   // el login nunca muestra el patrón viejo.
   const selectedBackground = useThemeBackgroundStore((s) => s.selected);
   const loginBgSrc = getBackgroundSrc(selectedBackground);
+
+  // FIX prod 2026-06-10: la login está diseñada en estilo BIOPUNK (dark) —
+  // `bg-slate-950` + `bg-biopunk-pattern` + texto claro. Con el tema 'auto'
+  // resolviendo a NATURE de día, los colores (vía CSS-vars de tema) se
+  // invertían a oscuros → texto/formulario oscuro sobre fondo oscuro = login
+  // INVISIBLE (pantalla negra en Android/Chrome de día). Forzamos biopunk
+  // mientras se muestra el login y restauramos el tema del usuario al salir.
+  useEffect(() => {
+    applyTheme('biopunk');
+    return () => {
+      try { applyTheme(normalizeTheme(localStorage.getItem(STORAGE_KEY))); }
+      catch { applyTheme(DEFAULT_THEME); }
+    };
+  }, []);
 
   const handleLogin = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Bug (prod, demo crítico)
La pantalla de login se ve **completamente negra/invisible** en Android/Chrome de día (deslogueado). El usuario no puede entrar ni instalar la PWA.

## Causa raíz
La login está diseñada en estilo biopunk (dark): `bg-slate-950` + `bg-biopunk-pattern` + texto claro. El tema 'auto' resuelve a **nature** de día (6-18h) → los colores via CSS-vars se invierten a oscuros → texto/formulario oscuro sobre fondo oscuro = invisible. (No es regresión de hoy; nadie la vio deslogueado de día.)

## Fix
Forzar tema **biopunk** mientras se muestra el login (está diseñada dark) + restaurar el tema del usuario al salir.

## Verificado (Playwright)
h1 'Chagra' pasó de oliva oscuro invisible (rgb 122,143,74) a verde brillante (rgb 16,185,129); screenshot 2.7KB→255KB (contenido visible). Captura: login completa renderiza (Chagra + stats IMPACTO + form + fondo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)