### PR TITLE
feat(agente): grounding de conocimiento del grafo — saberes/toxicidad/variedades/suelo

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -55,6 +55,7 @@ import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from 
 // (entidad resuelta o keyword → get_species/get_pest_controllers/get_biopreparados)
 // para intentar AL MENOS una consulta al grafo en vez de caer a generativo puro.
 import { planNluFallback } from '../../services/agentNluFallback';
+import { planKnowledgeIntent } from '../../services/knowledgeIntentRouter';
 // Deep Research (A6/A7): cliente HTTP del endpoint async de investigación
 // profunda del sidecar. Feature flag VITE_DEEP_RESEARCH_ENABLED (default false).
 import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../../services/deepResearchClient';
@@ -1225,6 +1226,39 @@ export default function AgentScreen({ onBack, initialContext }) {
             }
           } catch (_) { /* graceful: subgrafoBloque queda '' */ }
 
+          // PASO 2-pre — routing determinístico de CONOCIMIENTO del grafo
+          // (usos tradicionales / toxicidad / variedades / suelo). Igual que el
+          // chip forzado, salta el planner NLU cuando la intención es inequívoca
+          // y hay una especie ya resuelta: "¿la yuca brava es tóxica?",
+          // "¿para qué sirve la ruda?", "¿qué variedades de café hay?",
+          // "¿qué pH necesita la papa?". El resultado entra como toolEvidence →
+          // bloque de grounding del system prompt (promptAssembler, intocable).
+          // found:false TAMBIÉN es evidencia útil: trae la nota anti-invención
+          // y el agente responde neutral en vez de fabricar. No corre bajo chip
+          // forzado (el chip ya decidió el tool determinístico).
+          if (!forcedIntent) {
+            try {
+              const kPlan = planKnowledgeIntent(textForLLM, resolvedEntities);
+              if (kPlan && kPlan.tool) {
+                const tK0 = performance.now();
+                const kResult = await callTool(kPlan.tool, kPlan.args);
+                const tK1 = performance.now();
+                // available:false = grafo caído → NO inyectamos (dejamos que el
+                // planner NLU / fallback decidan); null = error de red, ídem.
+                if (kResult && kResult.available !== false) {
+                  toolEvidence = { tool: kPlan.tool, args: kPlan.args, result: kResult };
+                  nluRoute = `conocimiento:${kPlan.tool}`;
+                  console.debug('[sidecar] conocimiento del grafo (NLU saltado)', {
+                    tool: kPlan.tool,
+                    source: kPlan.source,
+                    found: kResult.found,
+                    latencyTool: Math.round(tK1 - tK0),
+                  });
+                }
+              }
+            } catch (_) { /* graceful: sigue el flujo NLU normal */ }
+          }
+
           // PASO 2 — routing del tool.
           //
           // CHIPS DE MODO (A3): si el usuario forzó la intención tocando un
@@ -1275,8 +1309,9 @@ export default function AgentScreen({ onBack, initialContext }) {
                 }
               }
             }
-          } else {
-          // PASO 2b — NLU planner + tool call (flow original, sin chip).
+          } else if (!toolEvidence) {
+          // PASO 2b — NLU planner + tool call (flow original, sin chip y sin
+          // evidencia ya resuelta por el routing de conocimiento del PASO 2-pre).
           const tNlu0 = performance.now();
           const plan = await planNlu(textForLLM, contextMemory);
           if (plan?.tool) nluRoute = `nlu:${plan.tool}`;

--- a/src/services/__tests__/knowledgeIntentRouter.test.js
+++ b/src/services/__tests__/knowledgeIntentRouter.test.js
@@ -1,0 +1,124 @@
+/**
+ * knowledgeIntentRouter.test.js — routing determinístico de intenciones de
+ * conocimiento del grafo (usos tradicionales / toxicidad / variedades / suelo).
+ *
+ * Contrato:
+ *   - SOLO dispara con una ESPECIE resuelta (ancla canónica del grafo).
+ *   - Prioridad: toxicidad > saberes > variedades > suelo.
+ *   - Señal de plaga inhibe saberes ("qué remedio le echo a la broca" es
+ *     control, no etnobotánica).
+ *   - Sin intención clara → null (el planner NLU decide).
+ */
+import { describe, it, expect } from 'vitest';
+import { planKnowledgeIntent } from '../knowledgeIntentRouter.js';
+
+const sp = (id, mentioned = null) => ({
+  kind: 'species',
+  canonical_id: id,
+  mentioned: mentioned ?? id,
+});
+
+describe('planKnowledgeIntent — guardas', () => {
+  it('mensaje vacío / no-string → null', () => {
+    for (const bad of [null, undefined, '', '   ', 42, {}]) {
+      expect(planKnowledgeIntent(bad, [sp('ruta_graveolens')])).toBeNull();
+    }
+  });
+
+  it('sin especie resuelta → null (sin ancla no hay a quién apuntar)', () => {
+    expect(planKnowledgeIntent('¿para qué sirve la ruda?', null)).toBeNull();
+    expect(planKnowledgeIntent('¿para qué sirve la ruda?', [])).toBeNull();
+    expect(
+      planKnowledgeIntent('¿para qué sirve la ruda?', [
+        { kind: 'pest', canonical_id: 'broca_cafe' },
+      ]),
+    ).toBeNull();
+  });
+
+  it('sin intención de conocimiento → null (el NLU decide)', () => {
+    expect(
+      planKnowledgeIntent('¿cómo controlo la broca del café?', [sp('coffea_arabica')]),
+    ).toBeNull();
+    expect(
+      planKnowledgeIntent('¿a cómo está el bulto de papa?', [sp('solanum_tuberosum')]),
+    ).toBeNull();
+  });
+});
+
+describe('planKnowledgeIntent — las 4 intenciones', () => {
+  it('toxicidad: "¿la yuca brava es tóxica?" → get_toxicidad con la entidad', () => {
+    const plan = planKnowledgeIntent('¿la yuca brava es tóxica?', [sp('manihot_esculenta', 'yuca brava')]);
+    expect(plan).toEqual({
+      tool: 'get_toxicidad',
+      args: { species_id_or_name: 'manihot_esculenta' },
+      source: 'knowledge_toxicidad',
+    });
+  });
+
+  it('toxicidad: "¿puedo comer las hojas de la yuca?" dispara sin la palabra tóxico', () => {
+    const plan = planKnowledgeIntent('¿puedo comer las hojas de la yuca?', [sp('manihot_esculenta')]);
+    expect(plan?.tool).toBe('get_toxicidad');
+  });
+
+  it('saberes: "¿para qué sirve la ruda?" → get_saberes', () => {
+    const plan = planKnowledgeIntent('¿Para qué sirve la ruda?', [sp('ruta_graveolens', 'ruda')]);
+    expect(plan).toEqual({
+      tool: 'get_saberes',
+      args: { species_id_or_name: 'ruta_graveolens' },
+      source: 'knowledge_saberes',
+    });
+  });
+
+  it('saberes: "usos medicinales del sauco" → get_saberes', () => {
+    const plan = planKnowledgeIntent('usos medicinales del sauco', [sp('sambucus_peruviana', 'sauco')]);
+    expect(plan?.tool).toBe('get_saberes');
+  });
+
+  it('variedades: "¿qué variedades de café hay?" → get_variedades', () => {
+    const plan = planKnowledgeIntent('¿Qué variedades de café me recomiendas?', [sp('coffea_arabica', 'café')]);
+    expect(plan).toEqual({
+      tool: 'get_variedades',
+      args: { species_id_or_name: 'coffea_arabica' },
+      source: 'knowledge_variedades',
+    });
+  });
+
+  it('suelo: "¿qué pH necesita la papa?" → get_suelo', () => {
+    const plan = planKnowledgeIntent('¿Qué pH necesita la papa?', [sp('solanum_tuberosum', 'papa')]);
+    expect(plan).toEqual({
+      tool: 'get_suelo',
+      args: { species_id_or_name: 'solanum_tuberosum' },
+      source: 'knowledge_suelo',
+    });
+  });
+
+  it('suelo: "síntomas de deficiencia en el café" → get_suelo', () => {
+    const plan = planKnowledgeIntent('síntomas de deficiencia en el café', [sp('coffea_arabica')]);
+    expect(plan?.tool).toBe('get_suelo');
+  });
+});
+
+describe('planKnowledgeIntent — prioridades y guardas cruzadas', () => {
+  it('toxicidad gana a saberes (seguridad primero)', () => {
+    const plan = planKnowledgeIntent(
+      '¿para qué sirve el borrachero y es venenoso?',
+      [sp('brugmansia_arborea', 'borrachero')],
+    );
+    expect(plan?.tool).toBe('get_toxicidad');
+  });
+
+  it('señal de plaga inhibe saberes: "qué remedio natural le echo a la broca del café" → null', () => {
+    const plan = planKnowledgeIntent(
+      '¿qué remedio natural le echo a la broca del café?',
+      [sp('coffea_arabica', 'café'), { kind: 'pest', canonical_id: 'hypothenemus_hampei_broca' }],
+    );
+    expect(plan).toBeNull();
+  });
+
+  it('usa mentioned cuando falta canonical_id', () => {
+    const plan = planKnowledgeIntent('¿la adelfa es venenosa?', [
+      { kind: 'species', canonical_id: null, mentioned: 'adelfa' },
+    ]);
+    expect(plan?.args).toEqual({ species_id_or_name: 'adelfa' });
+  });
+});

--- a/src/services/knowledgeIntentRouter.js
+++ b/src/services/knowledgeIntentRouter.js
@@ -1,0 +1,134 @@
+/**
+ * knowledgeIntentRouter.js — routing determinístico de intenciones de
+ * CONOCIMIENTO del grafo (usos tradicionales / toxicidad / variedades / suelo).
+ *
+ * Por qué existe: el grafo de conocimiento tiene datos curados de usos
+ * tradicionales documentados, perfil de toxicidad, variedades/cultivares
+ * registrados (ICA/Cenicafé) y requerimientos de suelo/nutrición por especie,
+ * pero el planner NLU (LLM pequeño) no siempre los enruta — "¿para qué sirve
+ * la ruda?" caía a ficha genérica o a generativo puro. Este router replica el
+ * patrón de `chipIntentRouter`/`agentNluFallback`: PURO, SÍNCRONO, cero red.
+ * El caller (AgentScreen) ejecuta el plan con `callTool(plan.tool, plan.args)`
+ * y la evidencia entra al bloque de grounding del system prompt (mismo
+ * mecanismo `toolEvidence` → promptAssembler, presupuesto respetado).
+ *
+ * Doctrina (conservadora a propósito):
+ *   - SOLO dispara si hay una ESPECIE ya resuelta por `resolveEntities`
+ *     (canónica, validada contra el grafo). Sin ancla de especie, el matcher
+ *     del sidecar no tiene a quién apuntar — dejamos que el NLU decida.
+ *   - Si hay señal de PLAGA (entidad o keywords), las intenciones de saberes
+ *     se inhiben: "qué remedio le echo a la broca" es CONTROL, no etnobotánica.
+ *   - Prioridad: toxicidad > saberes > variedades > suelo. La seguridad
+ *     (¿puedo comer esto?) domina sobre lo informativo.
+ *   - CERO fabricación: si el grafo no tiene el dato, la tool devuelve
+ *     found:false con una nota anti-invención y el agente responde neutral.
+ */
+
+/** ¿Pregunta por TOXICIDAD / comestibilidad? → get_toxicidad. */
+const TOXICIDAD_RE =
+  /\b(toxic[ao]s?|toxicidad|venenos[ao]s?|veneno|intoxicacion(es)?|envenenamiento|comestible[s]?)\b|puedo\s+comer|se\s+puede[n]?\s+comer|es\s+peligros[oa]\s+(comer|consumir)|parte[s]?\s+toxica/;
+
+/** ¿Pregunta por USOS TRADICIONALES / medicinales? → get_saberes. */
+const SABERES_RE =
+  /para\s+que\s+(sirve|se\s+usa)|uso[s]?\s+(tradicional|medicinal|ancestral)\w*|propiedades\s+(medicinales|curativas)|planta\s+medicinal|remedio\s+(casero|tradicional|natural)|\bsahumerio[s]?\b|\binfusion\b/;
+
+/** ¿Pregunta por VARIEDADES / cultivares? → get_variedades. */
+const VARIEDADES_RE = /\bvariedad(es)?\b|\bcultivar(es)?\b/;
+
+/** ¿Pregunta por SUELO / pH / nutrición? → get_suelo. */
+const SUELO_RE =
+  /\bph\b|que\s+suelo|suelo\s+(necesita|requiere|para|ideal)|deficiencia[s]?\b|\bencalar\b|plan\s+de\s+nutricion|como\s+abon(ar|o)\b/;
+
+/**
+ * Señal de PLAGA/CONTROL que inhibe el routing de saberes (la intención
+ * dominante es control, no etnobotánica). Subconjunto conservador del regex
+ * de `agentNluFallback`.
+ */
+const PLAGA_GUARD_RE =
+  /\b(plaga[s]?|broca|roya|pulgon(es)?|trips|cogollero|mosca\s+blanca|picudo|barrenador|minador|nematodo[s]?|gusano[s]?|chinche[s]?|controlar|combatir|fumigar)\b|que\s+le\s+echo/;
+
+/** Normaliza a minúsculas SIN tildes (criterio del resto del pipeline). */
+function _norm(text) {
+  return String(text)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, ''); // quita tildes (diacríticos combinantes)
+}
+
+function _isPest(e) {
+  const kind = String(e?.kind || '').toLowerCase();
+  return kind === 'pest' || kind === 'plaga';
+}
+
+function _isSpecies(e) {
+  const kind = String(e?.kind || '').toLowerCase();
+  return kind === 'species' || kind === 'planta' || kind === 'especie' || kind === 'cultivo';
+}
+
+/**
+ * Deriva un plan determinístico { tool, args, source } para las intenciones de
+ * conocimiento del grafo, o null si no hay señal clara (el NLU decide).
+ *
+ * @param {string} userMessage — texto crudo del usuario.
+ * @param {Array<object>|null} [resolvedEntities] — entidades canónicas ya
+ *   resueltas por `resolveEntities` ({ kind, canonical_id, mentioned, ... }).
+ * @returns {null | { tool: string, args: { species_id_or_name: string }, source: string }}
+ */
+export function planKnowledgeIntent(userMessage, resolvedEntities = null) {
+  if (typeof userMessage !== 'string' || userMessage.trim().length === 0) {
+    return null;
+  }
+  const norm = _norm(userMessage);
+  const entities = Array.isArray(resolvedEntities) ? resolvedEntities : [];
+
+  // Ancla OBLIGATORIA: una especie canónica validada por el grafo. Sin ella no
+  // disparamos (el matcher del sidecar no puede resolver la frase completa).
+  const speciesEntity = entities.find(
+    (e) => _isSpecies(e) && (e.canonical_id || e.mentioned),
+  );
+  if (!speciesEntity) return null;
+  const anchor = speciesEntity.canonical_id || speciesEntity.mentioned;
+
+  const hasPestSignal = entities.some(_isPest) || PLAGA_GUARD_RE.test(norm);
+
+  // Prioridad: toxicidad (seguridad) > saberes > variedades > suelo.
+  if (TOXICIDAD_RE.test(norm)) {
+    return {
+      tool: 'get_toxicidad',
+      args: { species_id_or_name: anchor },
+      source: 'knowledge_toxicidad',
+    };
+  }
+  if (!hasPestSignal && SABERES_RE.test(norm)) {
+    return {
+      tool: 'get_saberes',
+      args: { species_id_or_name: anchor },
+      source: 'knowledge_saberes',
+    };
+  }
+  if (VARIEDADES_RE.test(norm)) {
+    return {
+      tool: 'get_variedades',
+      args: { species_id_or_name: anchor },
+      source: 'knowledge_variedades',
+    };
+  }
+  if (SUELO_RE.test(norm)) {
+    return {
+      tool: 'get_suelo',
+      args: { species_id_or_name: anchor },
+      source: 'knowledge_suelo',
+    };
+  }
+  return null;
+}
+
+// Export interno para testabilidad de los regex.
+export const __TEST__ = {
+  TOXICIDAD_RE,
+  SABERES_RE,
+  VARIEDADES_RE,
+  SUELO_RE,
+  PLAGA_GUARD_RE,
+  _norm,
+};

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -308,6 +308,15 @@ const ALLOWED_TOOLS = new Set([
   // Cache compartida con `/clima/snapshot` y refrescada por systemd timer.
   'get_enso_status',
   'get_alertas_clima_zona',
+  // Grounding de conocimiento del grafo (2026-06-10): usos tradicionales
+  // documentados (siempre con descargo educativo), perfil de toxicidad,
+  // variedades/cultivares registrados y requerimientos de suelo/nutrición.
+  // Si el grafo no tiene el dato, la tool devuelve found:false y el agente
+  // responde neutral — NUNCA inventa.
+  'get_saberes',
+  'get_toxicidad',
+  'get_variedades',
+  'get_suelo',
 ]);
 
 const NORMATIVA_ICA_ACTIONS = new Set([


### PR DESCRIPTION
## Qué hace

Habilita en el cliente las 4 tools de conocimiento del grafo (`get_saberes`, `get_toxicidad`, `get_variedades`, `get_suelo`) que el sidecar expone (PR pareja en el repo del sidecar, #191):

1. **sidecarClient**: las 4 entran a la whitelist `ALLOWED_TOOLS` (defensa en profundidad).
2. **knowledgeIntentRouter** (nuevo, puro/síncrono, patrón `chipIntentRouter`/`agentNluFallback`): detecta la intención (prioridad toxicidad > saberes > variedades > suelo), SOLO dispara con una especie ya resuelta contra el grafo (ancla canónica), y la señal de plaga inhibe saberes ("qué remedio le echo a la broca" es control, no etnobotánica).
3. **AgentScreen PASO 2-pre**: ejecuta el plan ANTES del planner NLU (mismo mecanismo que el chip forzado / `forcedPlan`) y mete el resultado como `toolEvidence` → bloque de grounding del system prompt (`messages[0].content`), vía `formatToolEvidence` + `assembleSystemContent` (presupuesto del promptAssembler respetado; evidence es bloque intocable). `found:false` TAMBIÉN se inyecta: trae la nota anti-invención y el agente responde neutral — cero fabricación. `available:false` (grafo caído) NO se inyecta y el flujo NLU normal continúa.

## Tests / lint

- 13 tests nuevos (`knowledgeIntentRouter.test.js`): guardas, las 4 intenciones, prioridades, inhibición por plaga, `mentioned` como fallback de ancla.
- Suite completa: 4163 passed (15 fallos PRE-EXISTENTES en origin/main, verificado con worktree pristino de main — vision cache/mediaCache/phenology/sidecarClient whitelist, no tocados acá).
- `eslint --max-warnings=0` limpio en los 4 archivos tocados.

## Verificación en vivo (sidecar local de prueba, puerto 7899 — prod NO tocado)

Las 4 tools respondieron groundeadas desde el grafo real: ruda → usos tradicionales con descargo educativo; yuca brava → perfil de toxicidad (linamarina, manejo seguro); café → 9 cultivares Cenicafé con resistencias; papa → pH 5.0-6.0 + corrección (Agrosavia). Caso inexistente → `found:false` + nota anti-invención.

🤖 Generated with [Claude Code](https://claude.com/claude-code)