### PR TITLE
feat(phenology): getCurrentStage — función de producción + tests + wiring a PhenologyTimeline

### DIFF
--- a/src/components/PhenologyTimeline.jsx
+++ b/src/components/PhenologyTimeline.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
-import { Clock, Eye, HelpCircle, AlertTriangle, CheckCircle, Sprout } from 'lucide-react';
-import { calculateWindows, formatWindow } from '../services/phenologyCalculator';
+import { Clock, Eye, HelpCircle, AlertTriangle, CheckCircle, Sprout, Timer } from 'lucide-react';
+import { calculateWindows, formatWindow, getCurrentStage } from '../services/phenologyCalculator';
 
 const confidenceColor = (c) => {
   if (c >= 0.9) return 'text-emerald-400';
@@ -44,6 +44,11 @@ export default function PhenologyTimeline({
     return calculateWindows({ speciesSlug, sowingDate, altitudeM });
   }, [speciesSlug, sowingDate, altitudeM]);
 
+  const estimatedCurrent = useMemo(() => {
+    if (!speciesSlug || !sowingDate) return null;
+    return getCurrentStage({ speciesSlug, sowingDate, altitudeM });
+  }, [speciesSlug, sowingDate, altitudeM]);
+
   const observedMap = useMemo(() => {
     const m = {};
     observedStages.forEach((os) => { m[os.code] = os; });
@@ -79,26 +84,32 @@ export default function PhenologyTimeline({
       <div className="flex flex-col gap-2">
         {windows.map((win, i) => {
           const obs = observedMap[win.code];
-          const isCurrent = obs && obs.code === win.code;
+          const isObservedCurrent = obs && obs.code === win.code;
+          const isEstimatedCurrent = estimatedCurrent && estimatedCurrent.stage.code === win.code && !isObservedCurrent;
           const isPast = obs && windows.findIndex((w) => w.code === obs.code) > i;
 
           return (
             <div key={win.code} className={`flex gap-2 ${compact ? 'items-center' : ''}`}>
               {/* Indicador de etapa */}
               <div className="flex flex-col items-center gap-0.5 shrink-0">
-                <div className={`w-3 h-3 rounded-full border ${stageColor(win.code)} ${isCurrent ? 'ring-2 ring-lime-400/50' : ''} ${isPast ? 'opacity-50' : ''}`} />
+                <div className={`w-3 h-3 rounded-full border ${stageColor(win.code)} ${isObservedCurrent ? 'ring-2 ring-lime-400/50' : ''} ${isEstimatedCurrent ? 'ring-2 ring-sky-400/40 border-dashed' : ''} ${isPast ? 'opacity-50' : ''}`} />
                 {i < windows.length - 1 && <div className="w-px h-4 bg-slate-700" />}
               </div>
 
               {/* Contenido */}
               <div className={`flex-1 min-w-0 ${compact ? 'flex items-center gap-2' : ''}`}>
                 <div className={`flex items-center gap-1.5 ${isPast ? 'opacity-50' : ''}`}>
-                  <span className={`text-sm font-medium ${isCurrent ? 'text-lime-300' : 'text-slate-200'}`}>
+                  <span className={`text-sm font-medium ${isObservedCurrent ? 'text-lime-300' : 'text-slate-200'}`}>
                     {win.label}
                   </span>
                   {obs && (
                     <span className="inline-flex items-center gap-0.5 text-2xs text-emerald-400" title="Observado">
                       <Eye size={10} />
+                    </span>
+                  )}
+                  {isEstimatedCurrent && (
+                    <span className="inline-flex items-center gap-0.5 text-2xs text-sky-400" title={`Estimado: ${estimatedCurrent.daysElapsed} días desde siembra`}>
+                      <Timer size={10} />
                     </span>
                   )}
                 </div>

--- a/src/services/__tests__/phenologyCalculator.test.js
+++ b/src/services/__tests__/phenologyCalculator.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateWindows, formatWindow } from '../phenologyCalculator';
+import { calculateWindows, formatWindow, getCurrentStage } from '../phenologyCalculator';
 
 const SOWING = 1700000000000; // fixed timestamp
 
@@ -67,120 +67,93 @@ describe('calculateWindows', () => {
   });
 });
 
-/**
- * Helper de test: determina la etapa actual y días transcurridos
- * a partir de las ventanas retornadas por calculateWindows. NO es
- * una función de producción — solo para verificar el cálculo de etapa.
- *
- * @param {ReturnType<calculateWindows>} windows
- * @param {number} today — timestamp ms actual
- * @returns {{ stageCode: string, daysElapsed: number, window: object|null }}
- */
-function deriveCurrentStage(windows, today) {
-  const daysElapsed = Math.floor((today - windows[0]?.windowStart) / 86400000);
-  // Recorrer ventanas en orden inverso para encontrar la última que aplica
-  for (let i = windows.length - 1; i >= 0; i--) {
-    const w = windows[i];
-    if (w.status !== 'computed' || w.windowStart === null) continue;
-    const afterStart = today >= w.windowStart;
-    const beforeEnd = w.windowEnd === null || today <= w.windowEnd;
-    if (afterStart && beforeEnd) {
-      return { stageCode: w.code, daysElapsed, window: w };
-    }
-  }
-  // Si today es anterior a la siembra, devolver sowing
-  return { stageCode: 'sowing', daysElapsed: Math.max(0, daysElapsed), window: null };
-}
-
-describe('cálculo de etapa actual (derivado de calculateWindows)', () => {
+describe('getCurrentStage', () => {
   const SOWING_DAY = 1700000000000;
   const DAY_MS = 86400000;
 
-  it('día 0 → sowing con días transcurridos = 0', () => {
-    const windows = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
-    const { stageCode, daysElapsed } = deriveCurrentStage(windows, SOWING_DAY);
-    expect(stageCode).toBe('sowing');
-    expect(daysElapsed).toBe(0);
+  it('retorna null si la especie no tiene plantilla', () => {
+    const r = getCurrentStage({ speciesSlug: 'no_existe', sowingDate: SOWING_DAY });
+    expect(r).toBeNull();
   });
 
-  it('día 10 en tomate → vegetative (minDays=1, maxDays=25)', () => {
-    const windows = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 10 * DAY_MS;
-    const { stageCode, daysElapsed } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('vegetative');
-    expect(daysElapsed).toBe(10);
+  it('retorna null si sowingDate es 0', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: 0 });
+    expect(r).toBeNull();
   });
 
-  it('día 30 en tomate → flowering (minDays=25, maxDays=45)', () => {
-    const windows = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 30 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('flowering');
+  it('día 0 → sowing con stageIndex 0 y daysElapsed = 0', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY, now: SOWING_DAY });
+    expect(r).not.toBeNull();
+    expect(r.stage.code).toBe('sowing');
+    expect(r.stageIndex).toBe(0);
+    expect(r.daysElapsed).toBe(0);
   });
 
-  it('día 60 en tomate → fruiting (minDays=45, maxDays=80)', () => {
-    const windows = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 60 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('fruiting');
+  it('día 10 en tomate → vegetative (stageIndex 1)', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY, now: SOWING_DAY + 10 * DAY_MS });
+    expect(r.stage.code).toBe('vegetative');
+    expect(r.stageIndex).toBe(1);
+    expect(r.daysElapsed).toBe(10);
   });
 
-  it('día 90 en tomate → harvest_window (minDays=75, maxDays=120)', () => {
-    const windows = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 90 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('harvest_window');
+  it('día 30 en tomate → flowering', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY, now: SOWING_DAY + 30 * DAY_MS });
+    expect(r.stage.code).toBe('flowering');
   });
 
-  it('día 150 en tomate → closed (más allá de harvest_window maxDays=120)', () => {
-    const windows = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 150 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('closed');
+  it('día 60 en tomate → fruiting', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY, now: SOWING_DAY + 60 * DAY_MS });
+    expect(r.stage.code).toBe('fruiting');
   });
 
-  it('días transcurridos se calculan correctamente con altitud', () => {
-    const windows = calculateWindows({ speciesSlug: 'coffea_arabica', sowingDate: SOWING_DAY, altitudeM: 2600 });
-    const today = SOWING_DAY + 60 * DAY_MS;
-    const { daysElapsed } = deriveCurrentStage(windows, today);
-    expect(daysElapsed).toBe(60);
+  it('día 90 en tomate → harvest_window', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY, now: SOWING_DAY + 90 * DAY_MS });
+    expect(r.stage.code).toBe('harvest_window');
   });
 
-  it('maíz en día 7 → emergence (minDays=4, maxDays=10)', () => {
-    const windows = calculateWindows({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 7 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('emergence');
+  it('día 150 en tomate → closed (más allá de maxDays=120)', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY, now: SOWING_DAY + 150 * DAY_MS });
+    expect(r.stage.code).toBe('closed');
+    expect(r.stageIndex).toBe(5);
   });
 
-  it('maíz en día 120 → harvest_window (minDays=100, maxDays=130)', () => {
-    const windows = calculateWindows({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 120 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('harvest_window');
+  it('daysElapsed se calcula correctamente con altitud', () => {
+    const r = getCurrentStage({ speciesSlug: 'coffea_arabica', sowingDate: SOWING_DAY, altitudeM: 2600, now: SOWING_DAY + 60 * DAY_MS });
+    expect(r.daysElapsed).toBe(60);
+  });
+
+  it('maíz en día 7 → emergence', () => {
+    const r = getCurrentStage({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY, now: SOWING_DAY + 7 * DAY_MS });
+    expect(r.stage.code).toBe('emergence');
+  });
+
+  it('maíz en día 120 → harvest_window', () => {
+    const r = getCurrentStage({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY, now: SOWING_DAY + 120 * DAY_MS });
+    expect(r.stage.code).toBe('harvest_window');
   });
 
   it('maíz en día 200 → closed (más allá de maxDays=130)', () => {
-    const windows = calculateWindows({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 200 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('closed');
+    const r = getCurrentStage({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY, now: SOWING_DAY + 200 * DAY_MS });
+    expect(r.stage.code).toBe('closed');
   });
 
-  it('lechuga en día 50 → harvest_window a pesar de solapamiento con cogollo', () => {
-    // lactuca: fruiting(cogollo) minDays=25 maxDays=50, harvest minDays=45 maxDays=65
-    // día 50 cae en ambas ventanas; deriveCurrentStage itera al revés
-    // y retorna harvest_window (la más avanzada entre las que aplican)
-    const windows = calculateWindows({ speciesSlug: 'lactuca_sativa', sowingDate: SOWING_DAY });
-    const today = SOWING_DAY + 50 * DAY_MS;
-    const { stageCode } = deriveCurrentStage(windows, today);
-    expect(stageCode).toBe('harvest_window');
+  it('lechuga en día 50 → harvest_window (solapamiento, retorna la más avanzada)', () => {
+    const r = getCurrentStage({ speciesSlug: 'lactuca_sativa', sowingDate: SOWING_DAY, now: SOWING_DAY + 50 * DAY_MS });
+    expect(r.stage.code).toBe('harvest_window');
   });
 
-  it('especie sin plantilla retorna stageCode sowing por defecto', () => {
-    const windows = calculateWindows({ speciesSlug: 'no_existe', sowingDate: SOWING_DAY });
-    const { stageCode } = deriveCurrentStage(windows, SOWING_DAY);
-    expect(stageCode).toBe('sowing');
+  it('now por defecto usa Date.now() (no lanza)', () => {
+    const r = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING_DAY });
+    expect(r).not.toBeNull();
+    expect(typeof r.stage.code).toBe('string');
+    expect(typeof r.daysElapsed).toBe('number');
+  });
+
+  it('now anterior a la siembra retorna sowing con daysElapsed 0', () => {
+    const r = getCurrentStage({ speciesSlug: 'zea_mays', sowingDate: SOWING_DAY, now: SOWING_DAY - 10 * DAY_MS });
+    expect(r.stage.code).toBe('sowing');
+    expect(r.stageIndex).toBe(0);
+    expect(r.daysElapsed).toBe(0);
   });
 });
 

--- a/src/services/phenologyCalculator.js
+++ b/src/services/phenologyCalculator.js
@@ -110,6 +110,55 @@ export function calculateWindows({ speciesSlug, sowingDate, altitudeM }) {
 }
 
 /**
+ * @typedef {Object} CurrentStageResult
+ * @property {PhenologyWindow} stage — la ventana que contiene `now`
+ * @property {number} stageIndex — índice en el array de etapas del template
+ * @property {number} daysElapsed — días transcurridos desde la siembra
+ */
+
+/**
+ * Determina la etapa fenológica estimada actual según `now`.
+ * Usa `calculateWindows` internamente y busca la ventana cuyo
+ * [windowStart, windowEnd] contiene el timestamp `now`.
+ *
+ * - `now` anterior a la primera ventana → etapa sowing.
+ * - `now` posterior a la última ventana → etapa closed.
+ * - Sin plantilla o sin sowingDate → null (degradación limpia).
+ *
+ * @param {Object} input
+ * @param {string} input.speciesSlug
+ * @param {number} input.sowingDate — timestamp ms del evento de siembra
+ * @param {number} [input.altitudeM]
+ * @param {number} [input.now=Date.now()] — timestamp ms para el cual calcular la etapa
+ * @returns {CurrentStageResult|null}
+ */
+export function getCurrentStage({ speciesSlug, sowingDate, altitudeM, now }) {
+  const windows = calculateWindows({ speciesSlug, sowingDate, altitudeM });
+
+  if (!windows.length || (windows.length === 1 && windows[0].status !== 'computed')) {
+    return null;
+  }
+
+  const today = now && now > 0 ? now : Date.now();
+  const daysElapsed = Math.floor((today - windows[0].windowStart) / 86400000);
+
+  // Recorrer de la última etapa hacia atrás: en caso de solapamiento,
+  // retorna la etapa más avanzada que aún aplica.
+  for (let i = windows.length - 1; i >= 0; i--) {
+    const w = windows[i];
+    if (w.status !== 'computed' || w.windowStart === null) continue;
+    const afterStart = today >= w.windowStart;
+    const beforeEnd = w.windowEnd === null || today <= w.windowEnd;
+    if (afterStart && beforeEnd) {
+      return { stage: w, stageIndex: i, daysElapsed };
+    }
+  }
+
+  // today anterior a la primera ventana
+  return { stage: windows[0], stageIndex: 0, daysElapsed: Math.max(0, daysElapsed) };
+}
+
+/**
  * Ventana legible para el campesino.
  * @param {PhenologyWindow} w
  * @returns {string}


### PR DESCRIPTION
## `getCurrentStage` — llena el hueco del PR #1400

### Función de producción

```js
getCurrentStage({ speciesSlug, sowingDate, altitudeM, now })
// → { stage: PhenologyWindow, stageIndex: number, daysElapsed: number } | null
```

- Usa `calculateWindows` internamente. Busca la ventana cuyo [windowStart, windowEnd] contiene `now`.
- Itera de la última etapa hacia atrás: en caso de solapamiento, retorna la etapa más avanzada.
- `now` anterior a la 1a ventana → sowing. `now` posterior a la última → closed.
- Sin plantilla o sin sowingDate → `null` (degradación limpia, no throw).
- `now` por defecto usa `Date.now()`.

### Tests (15 nuevos, 26 total en el archivo)

| Caso | Especie | Resultado |
|---|---|---|
| Día 0 | tomate | sowing, index 0, elapsed 0 |
| Día 10 | tomate | vegetative, index 1 |
| Día 30 | tomate | flowering |
| Día 60 | tomate | fruiting |
| Día 90 | tomate | harvest_window |
| Día 150 | tomate | closed, index 5 |
| Día 7 | maíz | emergence |
| Día 120 | maíz | harvest_window |
| Día 200 | maíz | closed |
| Día 50 | lechuga | harvest_window (solapamiento → más avanzada) |
| Sin plantilla | — | null |
| sowingDate=0 | — | null |
| now antes de siembra | maíz | sowing, elapsed 0 |
| now por defecto | tomate | stage válido |

Cobertura: annual (maíz, lechuga) + perenne (café con altitud).

### Wiring

```
PhenologyTimeline.jsx  ←  getCurrentStage
```

- Indicador visual: icono Timer + anillo sky-400 dashed en la etapa estimada actual.
- Diferenciado del indicador de etapa observada (Eye + anillo lime-400 solid).
- Sin romper el comportamiento existente de `observedStages`.

Punto de consumo claro porque PhenologyTimeline ya usaba `calculateWindows` y es el renderizador natural de la fenología estimada.

### Verificación

```
npx vitest run src/services/__tests__/phenologyCalculator.test.js src/components/__tests__/PhenologyTimeline.test.jsx
 Test Files  2 passed (2)
      Tests  33 passed (33)
```

eslint `--max-warnings=0` ✅

### Nota sobre wiring adicional

`CicloDetalle.jsx` usa `a.current_stage` (observado/confirmado), no derivado de fenología estimada. `CicloCultivoScreen.jsx` idem. Son puntos de consumo potenciales para una iteración futura donde se muestre "Etapa estimada: X / Observada: Y" pero exceden el scope de este PR.