### PR TITLE
feat(arana): raíz+micorriza notables, soldadas a la Ⓐ sin cortes, cero choque nodo/red/texto

### DIFF
--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -826,7 +826,12 @@ export default function AgentHero({ onNavigate }) {
                    colibrí). Sin avatar 3D: el protagonista es el colibrí 2D. */
                 .agentport-stage {
                     position: relative;
-                    z-index: 1;
+                    /* z-index 2 > compositor (1): los trazos de la red que
+                       DESBORDAN el lienzo hacia abajo pintan sobre el borde del
+                       compositor y se sueldan al botón Ⓐ — continuidad raíz↔red
+                       sin corte (operador 2026-06-10). El SVG es pointer-events
+                       none y la caja del stage no tapa el compositor. */
+                    z-index: 2;
                     flex: 1 1 auto;
                     min-height: 180px;
                 }
@@ -1005,7 +1010,9 @@ export default function AgentHero({ onNavigate }) {
                     display: block; font-size: .78rem; line-height: 1.4; margin-top: 2px;
                     color: rgb(var(--c-slate-300));
                 }
-                .agentport-red-body { flex: 1 1 auto; min-height: 0; position: relative; overflow: hidden; }
+                /* overflow VISIBLE: las raicillas/vena bajan del lienzo al
+                   botón Ⓐ real (un solo trazo, sin clip en el borde). */
+                .agentport-red-body { flex: 1 1 auto; min-height: 0; position: relative; overflow: visible; }
 
                 /* con la red abierta, la escena ambiente baja el volumen (misma
                    pantalla, foco en la red — no un modal encima) */
@@ -1020,7 +1027,7 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-scene.is-quiet .agentport-net,
                 .agentport-scene.is-quiet .agentport-spore,
                 .agentport-scene.is-quiet .agentport-roots,
-                .agentport-scene.is-quiet .agentport-sprig { opacity: .22; }
+                .agentport-scene.is-quiet .agentport-sprig { opacity: .14; }
 
                 /* Transición de envío: shimmer + lift (contrato de tests). */
                 @keyframes chagra-send-shimmer {

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
+import {
+  relax, nodeRect, rimPoint, shelfPack, treeLadder, placeLeavesNoClash,
+} from './agentRedMenuGeom';
 
 /**
  * AgentRedMenu — menú VIVO de capacidades de Chagra (red/árbol orgánico).
@@ -25,8 +28,15 @@ import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
  *   - UNA SOLA Ⓐ (operador 2026-06-10): el menú NO renderiza nodo raíz propio.
  *     La raíz geométrica de la red ES el botón Ⓐ real del compositor (vive en
  *     AgentHero, abajo-izquierda); el padre lo comparte vía `anchorRef` y acá
- *     se mide su centro en coordenadas del lienzo (queda bajo el borde
- *     inferior — las ramas brotan del borde apuntando exactamente al botón).
+ *     se mide su centro REAL en coordenadas del lienzo. Con overflow visible
+ *     (refinamiento sin-cortes 2026-06-10) cada trazo NACE dentro del disco
+ *     del botón (rimPoint) y viaja sobre el borde del compositor — la unión
+ *     raíz↔red es un solo trazo continuo, sin gap ni salto de color (en
+ *     nature, gradiente savia-acento → madera en la vena).
+ *   - Anticolisión reforzada (mandato 2026-06-10): relax anisotrópico (más
+ *     aire vertical por las etiquetas bajo el nodo) + obstáculos fijos (hub,
+ *     yemas, miga, grupos atenuados) — nodos/etiquetas NUNCA encimados y la
+ *     red pasa por detrás de etiquetas OPACAS (z: web 1 < nodos 3).
  *   - `prefers-reduced-motion` → sin loop rAF: un solo paint al estado final.
  *   - Cleanup completo: rAF, timers, ResizeObserver, MutationObserver, paths.
  *
@@ -141,29 +151,9 @@ function clearDash(p) {
   p.removeAttribute('stroke-dashoffset');
 }
 
-/** Relajación anticolisión: separa puntos a minD dentro del bound bd. */
-function relax(pts, minD, bd) {
-  for (let it = 0; it < 32; it++) {
-    let moved = false;
-    for (let a = 0; a < pts.length; a++) {
-      for (let b = a + 1; b < pts.length; b++) {
-        let dx = pts[b].x - pts[a].x, dy = pts[b].y - pts[a].y, d = Math.hypot(dx, dy);
-        if (d < minD) {
-          moved = true;
-          if (d < 1) { dx = 1; dy = 0; d = 1; }
-          const push = (minD - d) / 2 / d;
-          pts[a].x -= dx * push; pts[a].y -= dy * push;
-          pts[b].x += dx * push; pts[b].y += dy * push;
-        }
-      }
-    }
-    pts.forEach((p) => { p.x = clampN(p.x, bd.x0, bd.x1); p.y = clampN(p.y, bd.y0, bd.y1); });
-    if (!moved) break;
-  }
-}
-
-/* Factores radiales por grupo (alterna lejos/cerca para look orgánico). */
-const KS = [0.98, 0.62, 0.95, 0.73, 0.95, 0.62, 0.98];
+/* relax (anticolisión anisotrópica + obstáculos fijos) y rimPoint (origen
+   del trazo DENTRO del disco del botón Ⓐ) viven en agentRedMenuGeom.js —
+   puros y testeados aparte. */
 
 /* Esporas/polen/hojas ambiente — parámetros sembrados, estables. */
 const SPORES = Array.from({ length: 16 }, (_, k) => ({
@@ -205,16 +195,19 @@ const CSS = `
    alto. Solo overflow:hidden para que esporas/ramas no se salgan. */
 .arm-root{
   position:relative;width:100%;height:100%;min-height:380px;
-  overflow:hidden;background:transparent;
+  /* overflow VISIBLE (2026-06-10): los trazos bajan hasta el botón Ⓐ real
+     (vive en el compositor, fuera de este lienzo) — la unión raíz↔red es un
+     solo trazo continuo, sin el corte que daba el clip del borde inferior. */
+  overflow:visible;background:transparent;
   -webkit-tap-highlight-color:transparent;
   /* ---- tema biopunk (base) ---- */
   --fam:ui-monospace,'Cascadia Mono',Menlo,Consolas,monospace;
   --lblSize:13px; --lblSp:.01em; --lblW:800;
-  --lblC:#ffffff; --lblBg:rgba(3,12,9,.9); --lblEdge:rgba(25,199,154,.55);
-  --lblShadow:0 2px 8px rgba(0,0,0,.6);
-  --branch:#19c79a; --coreW:2.2px;
-  --glowC:rgba(25,199,154,.30); --glowW:8px; --glowO:1; --glowBlur:3px;
-  --twigC:rgba(25,199,154,.55);
+  --lblC:#ffffff; --lblBg:rgba(4,14,11,.97); --lblEdge:rgba(25,199,154,.6);
+  --lblShadow:0 2px 10px rgba(0,0,0,.65);
+  --branch:#19c79a; --coreW:3px;
+  --glowC:rgba(25,199,154,.48); --glowW:13px; --glowO:1; --glowBlur:4px;
+  --twigC:rgba(25,199,154,.75);
   --orbBg:radial-gradient(circle at 32% 28%,#15222e,#0b121b 72%);
   --ringGroup:rgba(25,199,154,.85); --ringLeaf:rgba(25,199,154,.6); --ringW:2px;
   --orbShadow:0 0 22px rgba(25,199,154,.32),0 0 6px rgba(25,199,154,.5),inset 0 0 16px rgba(25,199,154,.10);
@@ -230,11 +223,11 @@ const CSS = `
 .arm-root[data-armtheme="nature"]{
   --fam:'Iowan Old Style','Palatino Linotype','Book Antiqua',Palatino,Georgia,serif;
   --lblSize:13.5px; --lblSp:0; --lblW:700;
-  --lblC:#2e2414; --lblBg:rgba(255,250,238,.95); --lblEdge:rgba(121,87,53,.5);
-  --lblShadow:0 2px 6px rgba(90,60,30,.22);
-  --branch:#6e4f2e; --coreW:4px;
-  --glowC:rgba(121,87,53,.22); --glowW:9px; --glowO:1; --glowBlur:1.5px;
-  --twigC:rgba(110,79,46,.6);
+  --lblC:#2e2414; --lblBg:rgba(255,250,238,.98); --lblEdge:rgba(121,87,53,.55);
+  --lblShadow:0 2px 8px rgba(90,60,30,.3);
+  --branch:#6e4f2e; --coreW:4.6px;
+  --glowC:rgba(121,87,53,.32); --glowW:12px; --glowO:1; --glowBlur:1.5px;
+  --twigC:rgba(110,79,46,.75);
   --orbBg:radial-gradient(circle at 35% 30%,#fffdf4,#efe3c6 78%);
   --ringGroup:rgba(110,79,46,.85); --ringLeaf:rgba(95,124,66,.95); --ringW:2.5px;
   --orbShadow:0 4px 14px rgba(90,60,30,.25),inset 0 1px 0 #fff;
@@ -251,11 +244,11 @@ const CSS = `
 .arm-root[data-armtheme="min"]{
   --fam:Futura,'Avenir Next','Century Gothic','Trebuchet MS',Verdana,sans-serif;
   --lblSize:12.5px; --lblSp:.02em; --lblW:700;
-  --lblC:#143d31; --lblBg:rgba(255,255,255,.96); --lblEdge:rgba(47,110,90,.35);
-  --lblShadow:0 1px 4px rgba(30,40,35,.12);
-  --branch:#2f6e5a; --coreW:1.6px;
+  --lblC:#143d31; --lblBg:#ffffff; --lblEdge:rgba(47,110,90,.4);
+  --lblShadow:0 1px 5px rgba(30,40,35,.16);
+  --branch:#2f6e5a; --coreW:2.1px;
   --glowC:transparent; --glowW:0px; --glowO:0; --glowBlur:0px;
-  --twigC:rgba(47,110,90,.45);
+  --twigC:rgba(47,110,90,.6);
   --orbBg:#ffffff;
   --ringGroup:rgba(47,110,90,.6); --ringLeaf:rgba(47,110,90,.45); --ringW:1.5px;
   --orbShadow:0 2px 6px rgba(30,40,35,.1);
@@ -277,16 +270,21 @@ const CSS = `
 .arm-gtrunk .tkO{stroke:var(--trunkC);stroke-width:10px}
 .arm-gtrunk .tkI{stroke:var(--trunkHi);stroke-width:3.5px;opacity:.8}
 /* vena Ⓐ→tronco (nature): raíz superficial que conecta el botón del agente
-   con la base del tronco centrado — un solo organismo, no dos piezas. */
-.arm-gtrunk .vnO{stroke:var(--trunkC);stroke-width:8px;opacity:.95}
-.arm-gtrunk .vnI{stroke:var(--trunkHi);stroke-width:2.6px;opacity:.75}
+   con la base del tronco centrado — un solo organismo, no dos piezas.
+   El stroke se pinta con gradiente userSpaceOnUse (savia ocre del botón →
+   madera del tronco) puesto inline desde layout(): cero salto de color. */
+.arm-gtrunk .vnO{stroke:var(--trunkC);stroke-width:13px;opacity:1}
+.arm-gtrunk .vnI{stroke:var(--trunkHi);stroke-width:3.4px;opacity:.8}
 .arm-gglow{opacity:var(--glowO);filter:blur(var(--glowBlur));animation:armBreathe 4.5s ease-in-out infinite}
 .arm-gglow path{stroke:var(--glowC);stroke-width:var(--glowW);fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gcore path{stroke:var(--branch);stroke-width:var(--coreW);fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gcore path.lf{stroke-width:calc(var(--coreW)*.78)}
 .arm-gtwig path{stroke:var(--twigC);stroke-width:1.1px;fill:none;stroke-linecap:round;transition:stroke .5s}
-.arm-gtwig path.rt{opacity:.62;stroke-width:1.4px}
-.arm-gtwig path.gd{opacity:.65;stroke-width:2.2px}
+/* boca de raíz: las raicillas que asoman del botón Ⓐ — presencia subida
+   (operador 2026-06-10: "la raíz debe notarse"): color de rama pleno,
+   trazo grueso. */
+.arm-gtwig path.rt{opacity:.85;stroke-width:2.6px;stroke:var(--branch)}
+.arm-gtwig path.gd{opacity:.7;stroke-width:2.6px}
 @keyframes armBreathe{0%,100%{opacity:var(--glowO)}50%{opacity:calc(var(--glowO)*.55)}}
 .arm-spores{position:absolute;inset:0;z-index:2;pointer-events:none;overflow:hidden}
 .arm-sp{position:absolute;left:var(--lx);bottom:30px;width:3px;height:3px;border-radius:50%;
@@ -356,7 +354,7 @@ const CSS = `
 .arm-node.arm-soon .arm-orb{border-style:dashed}
 /* pista de uso — abajo-derecha: la esquina libre con la red brotando del
    botón Ⓐ (abajo-izquierda) hacia arriba-derecha. */
-.arm-hint{position:absolute;right:14px;bottom:10px;z-index:4;
+.arm-hint{position:absolute;right:14px;bottom:10px;z-index:2;
   font-family:var(--fam);font-size:13.5px;font-weight:700;letter-spacing:.04em;color:var(--hintC);
   pointer-events:none;transition:opacity .6s;white-space:nowrap}
 .arm-hint.off{opacity:0}
@@ -377,6 +375,9 @@ const CSS = `
 .arm-toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
 @media (prefers-reduced-motion: reduce){
   .arm-root *,.arm-root *::before,.arm-root *::after{animation:none !important;transition:none !important}
+  /* glow apagado en reduced-motion; la CONTINUIDAD raíz↔red la garantiza el
+     trazo core (que nace dentro del disco del botón Ⓐ), no el glow. */
+  .arm-gglow{display:none}
 }
 `;
 
@@ -457,6 +458,7 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
     const N = sim.length;
     const denom = Math.max(1, N - 1);
     let W = 0, H = 0, cx = 0, rootPt = { x: 0, y: 0 }, hub = { x: 0, y: 0 };
+    let btnR = 23; /* radio del botón Ⓐ — los trazos nacen DENTRO de su disco */
     let posOver = [], posBud = [];
     let trunkBez = null, trunkLen = 1, venaLen = 1, attachPts = [], treePos = [], treeFocus = [];
     let trunkV = 0, trunkVT = 0;
@@ -472,65 +474,107 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       cx = W / 2;
 
       /* LA RAÍZ ES EL BOTÓN Ⓐ REAL del compositor (vive en AgentHero, abajo-
-         izquierda). Medimos su centro en coordenadas de este lienzo: queda
-         BAJO el borde inferior (el compositor está debajo de la zona-respiro),
-         así las ramas brotan del borde apuntando exactamente al botón — una
-         sola Ⓐ, un solo organismo. Sin ancla (tests/jsdom): fallback
-         abajo-izquierda equivalente. */
+         izquierda). Medimos su centro REAL en coordenadas de este lienzo:
+         queda BAJO el borde inferior (el compositor está debajo de la
+         zona-respiro). Con overflow visible los trazos VIAJAN hasta el disco
+         del botón y nacen dentro de él (rimPoint) — una sola Ⓐ, un solo
+         organismo, sin el corte del borde (operador 2026-06-10). Sin ancla
+         (tests/jsdom): fallback abajo-izquierda equivalente. */
       const aEl = anchorRef && anchorRef.current;
       const rb = root.getBoundingClientRect();
       if (aEl && rb.width > 0) {
         const ab = aEl.getBoundingClientRect();
         rootPt = {
-          x: clampN(ab.left + ab.width / 2 - rb.left, 24, W - 24),
-          y: Math.max(H - 8, ab.top + ab.height / 2 - rb.top),
+          x: ab.left + ab.width / 2 - rb.left,
+          y: ab.top + ab.height / 2 - rb.top,
         };
+        btnR = Math.max(16, Math.min(ab.width, ab.height) / 2);
       } else {
         rootPt = { x: 46, y: H + 58 };
+        btnR = 23;
       }
       svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+      svg.style.overflow = 'visible';
 
-      /* micorriza (biopunk/min): abanico diagonal hacia ARRIBA-DERECHA desde
-         la Ⓐ (operador 2026-06-10) — del origen abajo-izquierda al espacio
-         libre del hero. */
+      /* fundido bajo el lienzo: pleno hasta el borde inferior (y=H), ~50% al
+         centro del botón — los trazos siguen continuos y soldados a la Ⓐ sin
+         enterrar el placeholder del compositor. */
+      const ug = root.querySelector('[data-arm="underGrad"]');
+      const umr = root.querySelector('[data-arm="underMaskRect"]');
+      const um = root.querySelector('[data-arm="underMask"]');
+      if (ug && umr && um) {
+        ug.setAttribute('x1', '0'); ug.setAttribute('y1', r1(H));
+        ug.setAttribute('x2', '0'); ug.setAttribute('y2', r1(Math.max(H + 24, rootPt.y)));
+        /* región del mask Y rect: misma caja generosa — sin la región
+           explícita el default (120% del viewport) recorta el desborde. */
+        const my0 = -60, myH = Math.max(H, rootPt.y) + btnR + 120;
+        for (const el of [um, umr]) {
+          el.setAttribute('x', r1(-60)); el.setAttribute('y', r1(my0));
+          el.setAttribute('width', r1(W + 120)); el.setAttribute('height', r1(myH));
+        }
+      }
+
+      /* micorriza (biopunk/min): red diagonal desde la Ⓐ (abajo-izquierda)
+         hacia ARRIBA-DERECHA (operador 2026-06-10). La colocación es por
+         ESTANTES con las cajas reales orbe+etiqueta (shelfPack): CERO encime
+         de nodos/etiquetas POR CONSTRUCCIÓN (7 cajas grandes no caben con
+         relajación sola en un celular — mandato anticolisión 2026-06-10).
+         El primer grupo queda arriba-izquierda y el último abajo-derecha:
+         la diagonal viva se conserva; el zigzag de filas rompe la grilla. */
       const a0 = -1.45, a1 = -0.30; /* casi vertical → casi horizontal der. */
-      const Rx = Math.max(120, W - rootPt.x - 84);
-      const Ry = Math.max(140, rootPt.y - 96);
-      posOver = sim.map((s, i) => {
-        const a = a0 + (a1 - a0) * i / denom;
-        const k = KS[i % KS.length];
-        return {
-          x: rootPt.x + Math.cos(a) * Rx * k + (rand(i + 31) - 0.5) * 18,
-          y: rootPt.y + Math.sin(a) * Ry * k + (rand(i + 47) - 0.5) * 18,
-        };
-      });
-      /* y1 deja libre la franja inferior (pista "toque una rama" + labels) */
-      relax(posOver, 106, { x0: 62, x1: W - 62, y0: 82, y1: H - 118 });
+      const gBoxes = sim.map((s) => nodeRect(s.lblEl, 36));
+      posOver = shelfPack(
+        gBoxes,
+        /* banda de RECTS: bordes reales del lienzo; el piso (H-58) deja
+           libre la pista "⸙ toque una rama" de la esquina inferior */
+        { x0: 10, x1: W - 10, y0: 44, y1: H - 58 },
+        { pad: 9, jitter: 8, rand },
+      );
 
       /* yemas: recogidas junto al origen (abajo-izquierda, sobre la Ⓐ) */
       posBud = sim.map((s, i) => {
         const a = a0 + (a1 - a0) * i / denom, r = i % 2 ? 152 : 110;
         return { x: rootPt.x + Math.cos(a) * r, y: rootPt.y + Math.sin(a) * r * 0.9 };
       });
-      relax(posBud, 46, { x0: 40, x1: W - 44, y0: H - 158, y1: H - 26 });
+      relax(posBud, 46, { x0: 40, x1: W - 44, y0: H - 150, y1: H - 30 });
 
       /* hub del foco: sobre la diagonal, dejando aire arriba-derecha para
          que el follaje del grupo enfocado respire */
       hub = {
         x: clampN(rootPt.x + Math.min(132, W * 0.30), 96, Math.max(98, W - 150)),
-        y: Math.max(132, H * 0.46),
+        /* 0.52H: deja ventana real ARRIBA del hub para hojas (entre la miga
+           y el nodo grande) — con 0.46H esa franja era infactible y la hoja
+           oscilaba encimada al orbe (medido 2026-06-10). */
+        y: Math.max(150, H * 0.52),
       };
       const Lrx = Math.max(96, Math.min(152, W - hub.x - 62));
       const Lry = Math.max(72, Math.min(176, hub.y - 100, H - hub.y - 96));
-      sim.forEach((s) => {
-        const n = s.leaves.length;
-        const sp = n > 1 ? Math.min(2.6, 0.9 * (n - 1)) : 0;
-        const center = -0.55; /* abanico sesgado hacia arriba-derecha */
-        s.leafAbsR = s.leaves.map((lf, j) => {
-          const a = center + (n > 1 ? -sp / 2 + sp * j / (n - 1) : 0);
-          return { x: hub.x + Math.cos(a) * Lrx, y: hub.y + Math.sin(a) * Lry };
+      /* yemas como obstáculos (orbes chicos sin etiqueta, escala .55) y la
+         miga "‹ volver" arriba-izquierda. */
+      const budBoxes = posBud.map((p) => ({ x: p.x, y: p.y, hw: 24, hh: 24 }));
+      const crumbBox = { x: 95, y: 33, hw: 90, hh: 32 }; /* tamaño real de la miga */
+      sim.forEach((s, i) => {
+        /* ANILLO proporcional alrededor del hub: cada hoja recibe arco según
+           el ancho real de su caja (no se montan entre sí ni sobre el grupo
+           del centro); el arco evita el lado de la Ⓐ (abajo-izquierda).
+           placeLeavesNoClash VERIFICA cero choque y reintenta con radios
+           mayores si el sistema completo (yemas+miga) quedó infactible. */
+        const lBoxes = s.leaves.map((lf) => nodeRect(lf.lblEl, 33, lf.soon));
+        const hubBox = {
+          x: hub.x, y: hub.y + gBoxes[i].oy * 1.1,
+          hw: gBoxes[i].hw * 1.1, hh: gBoxes[i].hh * 1.1,
+        };
+        const maxHw = Math.max(...lBoxes.map((b) => b.hw));
+        const maxHh = Math.max(...lBoxes.map((b) => b.hh));
+        s.leafAbsR = placeLeavesNoClash(hub, lBoxes, {
+          a0: -2.35, a1: 0.85, /* arriba-izq → derecha → abajo-der */
+          rx: Math.max(Lrx, hubBox.hw + maxHw * 0.7),
+          ry: Math.max(Lry, hubBox.hh + maxHh * 0.7),
+          bd: { x0: 56, x1: W - 56, y0: 84, y1: H - 76 },
+          pad: 6,
+          hard: [hubBox, crumbBox],
+          soft: budBoxes,
         });
-        relax(s.leafAbsR, 96, { x0: 60, x1: W - 60, y0: 84, y1: H - 70 });
         s.leafOffR = s.leafAbsR.map((p) => ({ x: p.x - hub.x, y: p.y - hub.y }));
       });
 
@@ -550,13 +594,16 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       tkO.setAttribute('d', trunkBez.d);
       tkI.setAttribute('d', trunkBez.d);
 
-      /* la VENA Ⓐ→tronco: raíz superficial que nace en el botón del agente
-         y repta por el suelo hasta la base del tronco — la conexión elegante
-         (un solo organismo, no dos piezas pegadas). */
+      /* la VENA Ⓐ→tronco: raíz superficial que nace DENTRO del disco del
+         botón del agente (rimPoint: soldada al botón, sin gap) y repta por
+         el suelo hasta la base del tronco — un solo organismo. El gradiente
+         userSpaceOnUse (savia ocre del botón → madera) elimina el salto de
+         color en la unión. */
+      const vC1 = { x: rootPt.x + 6, y: rootPt.y - Math.max(40, (rootPt.y - baseT.y - 26) * 0.55) };
       const venaBez = bezObj(
-        rootPt,
+        rimPoint(rootPt, Math.max(0, btnR - 5), vC1),
         /* sube casi vertical sobre la Ⓐ (asoma temprano en el lienzo)… */
-        { x: rootPt.x + 6, y: rootPt.y - Math.max(40, (rootPt.y - baseT.y - 26) * 0.55) },
+        vC1,
         /* …y repta por el suelo hasta la base del tronco */
         { x: rootPt.x + (baseT.x - rootPt.x) * 0.45, y: baseT.y + 18 },
         { x: baseT.x - 2, y: baseT.y + 6 },
@@ -564,32 +611,70 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       venaLen = Math.hypot(baseT.x - rootPt.x, baseT.y - rootPt.y) * 1.3 + 1;
       vnO.setAttribute('d', venaBez.d);
       vnI.setAttribute('d', venaBez.d);
+      /* gradiente de la vena en coords reales: ocre (botón) → madera, ya
+         dentro del lienzo; vnO lo usa inline (gana sobre el CSS). */
+      const vg = root.querySelector('[data-arm="venaGrad"]');
+      if (vg) {
+        vg.setAttribute('x1', r1(rootPt.x)); vg.setAttribute('y1', r1(rootPt.y));
+        vg.setAttribute('x2', r1(rootPt.x + (baseT.x - rootPt.x) * 0.6));
+        vg.setAttribute('y2', r1(baseT.y + 12));
+        vnO.style.stroke = 'url(#arm-vena-grad)';
+      }
 
+      /* ramas del árbol: ESCALERA copa→base con columnas alternadas a los
+         lados del tronco (treeLadder): las columnas opuestas nunca chocan en
+         X y dentro de cada columna el paso respeta las cajas reales — cero
+         choque por construcción (antes no había anticolisión: capturas del
+         operador con "Planear" encima del ojo). El orbe queda a una
+         distancia del tronco que deja la etiqueta completa EN pantalla. */
       attachPts = []; treePos = []; treeFocus = [];
+      const treeY = treeLadder(gBoxes, N, 56, baseT.y - 36, 6);
       sim.forEach((s, i) => {
         const t = 0.15 + 0.72 * i / denom;
-        const ap = cubicPt(trunkBez, t);
-        attachPts.push(ap);
+        attachPts.push(cubicPt(trunkBez, t));
         const side = i % 2 === 0 ? -1 : 1;
-        const len = 128 + rand(i + 71) * 22;
-        const nx = clampN(cx + side * len, 68, W - 68);
-        const ny = ap.y - 30 - rand(i + 83) * 16;
-        treePos.push({ x: nx, y: ny });
-        treeFocus.push({ x: nx - side * 34, y: ny + 8 });
+        const len = 96 + rand(i + 71) * 18;
+        const nx = clampN(cx + side * len, gBoxes[i].hw + 6, W - gBoxes[i].hw - 6);
+        treePos.push({ x: nx, y: treeY[i] });
+      });
+      treeFocus = treePos.map((p, i) => {
+        const side = i % 2 === 0 ? -1 : 1;
+        return { x: p.x - side * 30, y: p.y + 6 };
       });
 
       sim.forEach((s, i) => {
-        const n = s.leaves.length;
         const side = i % 2 === 0 ? -1 : 1;
         const fp = treeFocus[i];
-        const center = side < 0 ? -0.18 : Math.PI + 0.18; /* abanico hacia adentro */
-        const spread = n > 1 ? Math.min(1.9, 0.85 * (n - 1)) : 0;
-        const r = n > 3 ? 112 : 100;
-        s.leafAbsT = s.leaves.map((lf, j) => {
-          const a = center + (n > 1 ? -spread / 2 + spread * j / (n - 1) : 0) * (side < 0 ? 1 : -1);
-          return { x: fp.x + Math.cos(a) * r, y: fp.y + Math.sin(a) * r };
+        /* ANILLO proporcional hacia ADENTRO (el lado del tronco/espacio
+           libre) + pulido contra el grupo enfocado y los orbes atenuados —
+           las hojas brotan ENTRE los nodos, sin encimarse (2026-06-10).
+           placeLeavesNoClash verifica CERO choque medido y reintenta con
+           radios mayores soltando los orbes atenuados (soft) si el sistema
+           quedó infactible — medido: Biodiversidad encimaba el hub. */
+        const lBoxesT = s.leaves.map((lf) => nodeRect(lf.lblEl, 33, lf.soon));
+        const gBoxT = nodeRect(s.lblEl, 36);
+        const fpBox = {
+          x: fp.x, y: fp.y + gBoxT.oy * 1.12,
+          hw: gBoxT.hw * 1.12, hh: gBoxT.hh * 1.12,
+        };
+        const maxHwT = Math.max(...lBoxesT.map((b) => b.hw));
+        const maxHhT = Math.max(...lBoxesT.map((b) => b.hh));
+        /* inclinación del arco según altura: grupos bajos abanican hacia
+           ARRIBA (no hay piso debajo), grupos altos hacia abajo */
+        const tilt = clampN((fp.y - H * 0.45) / H, -0.35, 0.45) * 2.0;
+        const centerA = side < 0 ? -tilt : Math.PI + tilt; /* hacia adentro */
+        s.leafAbsT = placeLeavesNoClash(fp, lBoxesT, {
+          a0: centerA - 1.85, a1: centerA + 1.85,
+          rx: fpBox.hw + maxHwT * 0.7,
+          ry: fpBox.hh + maxHhT * 0.7,
+          bd: { x0: 58, x1: W - 58, y0: 78, y1: baseT.y - 54 },
+          pad: 6,
+          hard: [fpBox],
+          /* atenuados: sin etiqueta visible — solo el orbe (esc .84) */
+          soft: treePos
+            .filter((p, k) => k !== i)
+            .map((p) => ({ x: p.x, y: p.y, hw: 33, hh: 33 })),
         });
-        relax(s.leafAbsT, 96, { x0: 64, x1: W - 64, y0: 78, y1: baseT.y - 54 });
         s.leafOffT = s.leafAbsT.map((p) => ({ x: p.x - fp.x, y: p.y - fp.y }));
       });
 
@@ -608,15 +693,20 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
           d += `M${r1(baseT.x)} ${r1(baseT.y + 8)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
         }
       } else {
+        /* boca de raíz: 7 raicillas que nacen DENTRO del disco de la Ⓐ
+           (soldadas, sin gap) y asoman bien adentro del lienzo — presencia
+           subida (operador 2026-06-10). */
         const depth = Math.max(0, rootPt.y - H);
-        for (let k = 0; k < 5; k++) {
-          const a = -1.32 + 1.0 * k / 4; /* -76°..-18°: hacia arriba-derecha */
-          const len = (depth + 26 + rand(k + 40) * 46) / Math.max(0.3, -Math.sin(a));
+        for (let k = 0; k < 7; k++) {
+          const a = -1.38 + 1.14 * k / 6; /* -79°..-14°: hacia arriba-derecha */
+          const sx = rootPt.x + Math.cos(a) * Math.max(0, btnR - 5);
+          const sy = rootPt.y + Math.sin(a) * Math.max(0, btnR - 5);
+          const len = (depth + 38 + rand(k + 40) * 58) / Math.max(0.3, -Math.sin(a));
           const ex = clampN(rootPt.x + Math.cos(a) * len, 16, W - 28);
           const ey = rootPt.y + Math.sin(a) * len;
           const mx = rootPt.x + (ex - rootPt.x) * 0.45 + (rand(k + 60) - 0.5) * 14;
           const my = rootPt.y + Math.sin(a) * len * 0.45;
-          d += `M${r1(rootPt.x)} ${r1(rootPt.y)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
+          d += `M${r1(sx)} ${r1(sy)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
         }
       }
       rootlets.setAttribute('d', d.trim());
@@ -677,7 +767,11 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
         g.scl += (ts - g.scl) * ka; g.alp += (ta - g.alp) * ka; g.lbl += (tl - g.lbl) * ka;
         md = Math.max(md, Math.abs(tp.x - g.x), Math.abs(tp.y - g.y), 200 * Math.abs(g.visT - g.vis));
 
-        const start = treeMode ? attachPts[i] : rootPt;
+        /* micorriza: cada hifa NACE dentro del disco del botón Ⓐ (rimPoint)
+           — mismo color que el relleno del botón abierto → unión soldada. */
+        const start = treeMode
+          ? attachPts[i]
+          : rimPoint(rootPt, Math.max(0, btnR - 5), { x: g.x, y: g.y });
         const b = organic(start, { x: g.x, y: g.y }, i * 13 + 5);
         g.pCore.setAttribute('d', b.d); g.pGlow.setAttribute('d', b.d);
         const ve = ease3(g.vis);
@@ -844,19 +938,51 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       <style>{CSS}</style>
 
       <svg className="arm-web" data-arm="web" preserveAspectRatio="none" aria-hidden="true">
-        <g className="arm-gtrunk" data-arm="gTrunk">
-          {/* vena Ⓐ→tronco primero: la base del tronco tapa la unión */}
-          <path className="vnO" data-arm="vnO" />
-          <path className="vnI" data-arm="vnI" />
-          <path className="tkB" data-arm="tkB" />
-          <path className="tkO" data-arm="tkO" />
-          <path className="tkI" data-arm="tkI" />
-        </g>
-        <g className="arm-gglow" data-arm="gGlow" />
-        <g className="arm-gcore" data-arm="gCore" />
-        <g className="arm-gtwig" data-arm="gTwig">
-          <path className="rt" data-arm="rootlets" />
-          <path className="gd" data-arm="ground" />
+        <defs>
+          {/* savia de la Ⓐ (acento) → madera del tronco: el gradiente vive en
+              coords del lienzo (layout() fija x1/y1 en el botón) para que la
+              vena nature arranque EXACTAMENTE del color del botón — sin salto
+              de color en la unión (operador 2026-06-10). */}
+          <linearGradient id="arm-vena-grad" data-arm="venaGrad" gradientUnits="userSpaceOnUse">
+            <stop offset="0" style={{ stopColor: 'rgb(var(--t-accent-rgb))' }} />
+            <stop offset="0.45" style={{ stopColor: 'var(--trunkC)' }} />
+            <stop offset="1" style={{ stopColor: 'var(--trunkC)' }} />
+          </linearGradient>
+          {/* fundido bajo el lienzo (latitud 2026-06-10): los trazos que
+              DESBORDAN hacia el compositor pierden peso gradualmente (~50%
+              al llegar al botón) — siguen CONTINUOS y soldados a la Ⓐ, pero
+              no entierran el placeholder "Pregúntale a Chagra…". layout()
+              fija y1=H (borde del lienzo) y y2=centro del botón. */}
+          <linearGradient id="arm-under-grad" data-arm="underGrad" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stopColor="#fff" />
+            <stop offset="1" stopColor="#fff" stopOpacity="0.55" />
+          </linearGradient>
+          {/* maskType ALPHA: con luminance (default) el 50% sRGB se evalúa
+              en linearRGB ≈ 21% y los trazos se EXTINGUEN antes del botón —
+              el corte regresaba (medido 2026-06-10). Alpha es literal.
+              OJO: la REGIÓN del mask (x/y/width/height) por defecto es
+              -10%..120% del viewport → recortaba el desborde en y≈1.2H con
+              una línea dura (el corte, medido) — layout() la fija explícita
+              hasta pasado el botón Ⓐ. */}
+          <mask id="arm-under-mask" data-arm="underMask" maskUnits="userSpaceOnUse" style={{ maskType: 'alpha' }}>
+            <rect data-arm="underMaskRect" fill="url(#arm-under-grad)" />
+          </mask>
+        </defs>
+        <g mask="url(#arm-under-mask)">
+          <g className="arm-gtrunk" data-arm="gTrunk">
+            {/* vena Ⓐ→tronco primero: la base del tronco tapa la unión */}
+            <path className="vnO" data-arm="vnO" />
+            <path className="vnI" data-arm="vnI" />
+            <path className="tkB" data-arm="tkB" />
+            <path className="tkO" data-arm="tkO" />
+            <path className="tkI" data-arm="tkI" />
+          </g>
+          <g className="arm-gglow" data-arm="gGlow" />
+          <g className="arm-gcore" data-arm="gCore" />
+          <g className="arm-gtwig" data-arm="gTwig">
+            <path className="rt" data-arm="rootlets" />
+            <path className="gd" data-arm="ground" />
+          </g>
         </g>
       </svg>
 

--- a/src/components/dashboard/__tests__/AgentRedMenu.smoke.test.jsx
+++ b/src/components/dashboard/__tests__/AgentRedMenu.smoke.test.jsx
@@ -12,8 +12,128 @@ globalThis.ResizeObserver = globalThis.ResizeObserver || class {
 };
 
 import AgentRedMenu from '../AgentRedMenu';
+import * as __geom from '../agentRedMenuGeom';
 
 afterEach(() => cleanup());
+
+describe('AgentRedMenu — geometría de continuidad (raíz↔red sin cortes)', () => {
+  it('rimPoint nace EN el borde del botón Ⓐ (a distancia r del centro, hacia el destino)', () => {
+    const c = { x: 100, y: 200 };
+    const p = __geom.rimPoint(c, 20, { x: 100, y: 100 });
+    // hacia arriba: mismo x, 20px más arriba — el trazo arranca dentro del disco
+    expect(p.x).toBeCloseTo(100, 5);
+    expect(p.y).toBeCloseTo(180, 5);
+    const d = Math.hypot(p.x - c.x, p.y - c.y);
+    expect(d).toBeCloseTo(20, 5);
+  });
+
+  it('rimPoint degenera al centro si el destino está más cerca que el radio (sin NaN)', () => {
+    const c = { x: 50, y: 50 };
+    const p = __geom.rimPoint(c, 30, { x: 52, y: 50 });
+    // destino a 2px < radio 30 → no sobrepasa el destino
+    expect(Math.hypot(p.x - c.x, p.y - c.y)).toBeLessThanOrEqual(2 + 1e-6);
+    expect(Number.isFinite(p.x) && Number.isFinite(p.y)).toBe(true);
+  });
+
+  it('relax separa nodos a la distancia mínima (sin encimes) dentro del bound', () => {
+    const pts = [
+      { x: 100, y: 100 }, { x: 102, y: 101 }, { x: 104, y: 99 }, { x: 98, y: 103 },
+    ];
+    __geom.relax(pts, 60, { x0: 0, x1: 400, y0: 0, y1: 400 });
+    for (let a = 0; a < pts.length; a++) {
+      for (let b = a + 1; b < pts.length; b++) {
+        const d = Math.hypot(pts[b].x - pts[a].x, pts[b].y - pts[a].y);
+        expect(d).toBeGreaterThanOrEqual(60 - 1);
+      }
+    }
+  });
+
+  it('relax anisotrópico (ky<1) exige MÁS separación vertical (etiquetas debajo del nodo)', () => {
+    const pts = [{ x: 200, y: 100 }, { x: 200, y: 160 }];
+    __geom.relax(pts, 80, { x0: 0, x1: 400, y0: 0, y1: 400 }, { ky: 0.8 });
+    const dy = Math.abs(pts[1].y - pts[0].y);
+    // métrica: hypot(dx, dy*0.8) >= 80 → con dx=0, dy >= 100
+    expect(dy).toBeGreaterThanOrEqual(80 / 0.8 - 1);
+  });
+
+  it('relaxRects separa cajas nodo+etiqueta hasta CERO intersección (mandato no-choque)', () => {
+    // dos nodos casi encimados, cajas 120x100 (orbe 72 + etiqueta debajo)
+    const pts = [{ x: 200, y: 200 }, { x: 210, y: 215 }];
+    const boxes = [
+      { hw: 60, hh: 50, oy: 15 },
+      { hw: 60, hh: 50, oy: 15 },
+    ];
+    __geom.relaxRects(pts, boxes, { x0: 0, x1: 600, y0: 0, y1: 600 }, { pad: 4 });
+    const rect = (p, b) => ({
+      x0: p.x - b.hw, x1: p.x + b.hw,
+      y0: p.y + b.oy - b.hh, y1: p.y + b.oy + b.hh,
+    });
+    const A = rect(pts[0], boxes[0]), B = rect(pts[1], boxes[1]);
+    const ox = Math.min(A.x1, B.x1) - Math.max(A.x0, B.x0);
+    const oy = Math.min(A.y1, B.y1) - Math.max(A.y0, B.y0);
+    expect(ox <= 0 || oy <= 0).toBe(true); // rectángulos disjuntos
+  });
+
+  it('relaxRects respeta obstáculos fijos (hub) sin moverlos', () => {
+    const pts = [{ x: 300, y: 300 }];
+    const boxes = [{ hw: 50, hh: 45, oy: 10 }];
+    const hub = { x: 305, y: 310, hw: 55, hh: 50 };
+    __geom.relaxRects(pts, boxes, { x0: 0, x1: 600, y0: 0, y1: 600 }, { fixed: [hub], pad: 4 });
+    expect(hub.x).toBe(305);
+    const ox = Math.min(pts[0].x + 50, hub.x + 55) - Math.max(pts[0].x - 50, hub.x - 55);
+    const oy = Math.min(pts[0].y + 10 + 45, hub.y + 50) - Math.max(pts[0].y + 10 - 45, hub.y - 50);
+    expect(ox <= 0 || oy <= 0).toBe(true);
+  });
+
+  it('rectsOverlap detecta intersección caja-caja y caja-obstáculo (y su ausencia)', () => {
+    const boxes = [{ hw: 50, hh: 40, oy: 10 }, { hw: 50, hh: 40, oy: 10 }];
+    // encimadas
+    expect(__geom.rectsOverlap(
+      [{ x: 100, y: 100 }, { x: 120, y: 110 }], boxes, [], 2,
+    )).toBe(true);
+    // disjuntas
+    expect(__geom.rectsOverlap(
+      [{ x: 100, y: 100 }, { x: 300, y: 100 }], boxes, [], 2,
+    )).toBe(false);
+    // contra obstáculo fijo
+    expect(__geom.rectsOverlap(
+      [{ x: 100, y: 100 }], [boxes[0]], [{ x: 110, y: 115, hw: 40, hh: 40 }], 2,
+    )).toBe(true);
+  });
+
+  it('placeLeavesNoClash entrega hojas SIN choque visible aun si el sistema con soft es infactible', () => {
+    // hub grande centrado + 3 hojas anchas en banda angosta (caso nature
+    // enfocado medido 2026-06-10) + soft obstacles que asfixian el espacio
+    const hub = { x: 113, y: 306, hw: 58, hh: 58 };
+    const boxes = [
+      { hw: 64, hh: 54, oy: 15 }, { hw: 63, hh: 49, oy: 14 }, { hw: 55, hh: 49, oy: 14 },
+    ];
+    const soft = [
+      { x: 240, y: 130, hw: 33, hh: 33 }, { x: 118, y: 200, hw: 33, hh: 33 },
+      { x: 250, y: 280, hw: 33, hh: 33 }, { x: 120, y: 360, hw: 33, hh: 33 },
+    ];
+    const pts = __geom.placeLeavesNoClash(hub, boxes, {
+      a0: -1.85, a1: 1.85, rx: 110, ry: 96,
+      bd: { x0: 58, x1: 300, y0: 78, y1: 391 },
+      pad: 6, hard: [hub], soft,
+    });
+    // CERO choque hoja-hoja y hoja-hub (lo VISIBLE) — el mandato del operador
+    expect(__geom.rectsOverlap(pts, boxes, [hub], 2)).toBe(false);
+    pts.forEach((p) => expect(Number.isFinite(p.x) && Number.isFinite(p.y)).toBe(true));
+  });
+
+  it('relax con obstáculos fijos: los puntos huyen del hub, el hub NO se mueve', () => {
+    const hub = { x: 200, y: 200 };
+    const pts = [{ x: 202, y: 201 }, { x: 198, y: 199 }];
+    __geom.relax(pts, 50, { x0: 0, x1: 400, y0: 0, y1: 400 }, { fixed: [hub], fixedD: 90 });
+    expect(hub.x).toBe(200);
+    expect(hub.y).toBe(200);
+    pts.forEach((p) => {
+      const d = Math.hypot(p.x - hub.x, p.y - hub.y);
+      expect(d).toBeGreaterThanOrEqual(90 - 1);
+    });
+  });
+});
 
 describe('AgentRedMenu — smoke', () => {
   it('renderiza sin crashear y monta la raíz', () => {

--- a/src/components/dashboard/agentRedMenuGeom.js
+++ b/src/components/dashboard/agentRedMenuGeom.js
@@ -1,0 +1,315 @@
+/**
+ * agentRedMenuGeom — helpers geométricos PUROS del menú-red (AgentRedMenu).
+ * Viven en módulo aparte (regla react-refresh: el componente solo exporta
+ * componentes) y se testean directo en jsdom sin montar el motor rAF.
+ */
+
+const clampN = (v, a, b) => Math.max(a, Math.min(b, v));
+
+/**
+ * Relajación anticolisión: separa puntos a minD dentro del bound bd.
+ * Mandato operador 2026-06-10 (nodos+etiquetas NO chocan con la red):
+ *   - `ky` (<1) = métrica anisotrópica: la distancia vertical "cuenta menos",
+ *     o sea exige MÁS separación en Y — las etiquetas viven DEBAJO del nodo
+ *     y necesitan más aire vertical que horizontal.
+ *   - `fixed` = obstáculos inmóviles (hub del grupo enfocado, yemas, miga):
+ *     repelen a los puntos a `fixedD` (o a su radio propio `f.d`) pero no
+ *     se mueven.
+ */
+export function relax(pts, minD, bd, opts = {}) {
+  const ky = opts.ky ?? 1;
+  const fixed = opts.fixed || [];
+  const fixedD = opts.fixedD ?? minD;
+  for (let it = 0; it < 48; it++) {
+    let moved = false;
+    for (let a = 0; a < pts.length; a++) {
+      for (let b = a + 1; b < pts.length; b++) {
+        let dx = pts[b].x - pts[a].x, dy = pts[b].y - pts[a].y;
+        let d = Math.hypot(dx, dy * ky);
+        if (d < minD) {
+          moved = true;
+          if (d < 1) { dx = 1; dy = 0; d = 1; }
+          const push = (minD - d) / 2 / d;
+          pts[a].x -= dx * push; pts[a].y -= dy * push;
+          pts[b].x += dx * push; pts[b].y += dy * push;
+        }
+      }
+      for (let f = 0; f < fixed.length; f++) {
+        const fD = fixed[f].d ?? fixedD; /* radio propio del obstáculo */
+        let dx = pts[a].x - fixed[f].x, dy = pts[a].y - fixed[f].y;
+        let d = Math.hypot(dx, dy * ky);
+        if (d < fD) {
+          moved = true;
+          if (d < 1) { dx = 1; dy = 0; d = 1; }
+          const push = (fD - d) / d;
+          pts[a].x += dx * push; pts[a].y += dy * push;
+        }
+      }
+    }
+    pts.forEach((p) => { p.x = clampN(p.x, bd.x0, bd.x1); p.y = clampN(p.y, bd.y0, bd.y1); });
+    if (!moved) break;
+  }
+}
+
+/**
+ * Relajación de RECTÁNGULOS nodo+etiqueta (mandato CERO choque 2026-06-10).
+ * pts[i] = centro del orbe; boxes[i] = { hw, hh, oy } — semiancho/semialto de
+ * la caja COMBINADA (orbe + etiqueta debajo, medida real del DOM) y offset
+ * vertical de su centro respecto al orbe. Dos cajas se separan empujando por
+ * el EJE DE MENOR SOLAPE (los rects son disjuntos si despeja UN eje — mucho
+ * menos restrictivo que la métrica radial, cabe en pantallas campesinas).
+ * `fixed` = cajas inmóviles { x, y, hw, hh } (hub, miga, yemas, atenuados).
+ */
+export function relaxRects(pts, boxes, bd, opts = {}) {
+  const fixed = opts.fixed || [];
+  const pad = opts.pad ?? 6;
+  for (let it = 0; it < 96; it++) {
+    let moved = false;
+    for (let a = 0; a < pts.length; a++) {
+      for (let b = a + 1; b < pts.length; b++) {
+        const dx = pts[b].x - pts[a].x;
+        const dy = (pts[b].y + boxes[b].oy) - (pts[a].y + boxes[a].oy);
+        const ox = boxes[a].hw + boxes[b].hw + pad - Math.abs(dx);
+        const oy = boxes[a].hh + boxes[b].hh + pad - Math.abs(dy);
+        if (ox > 0 && oy > 0) {
+          moved = true;
+          if (ox < oy) {
+            const s = (dx >= 0 ? 1 : -1) * ox / 2;
+            pts[a].x -= s; pts[b].x += s;
+          } else {
+            const s = (dy >= 0 ? 1 : -1) * oy / 2;
+            pts[a].y -= s; pts[b].y += s;
+          }
+        }
+      }
+      for (let f = 0; f < fixed.length; f++) {
+        const dx = pts[a].x - fixed[f].x;
+        const dy = (pts[a].y + boxes[a].oy) - fixed[f].y;
+        const ox = boxes[a].hw + fixed[f].hw + pad - Math.abs(dx);
+        const oy = boxes[a].hh + fixed[f].hh + pad - Math.abs(dy);
+        if (ox > 0 && oy > 0) {
+          moved = true;
+          /* BOUNDS-AWARE (deadlock medido 2026-06-10): si el empuje por el
+             eje de menor solape cae fuera del bound, el clamp final lo anula
+             y el punto queda encimado al obstáculo PARA SIEMPRE (oscilación
+             nature/enfocado: hoja clavada en y1 contra el hub). En ese caso
+             empujamos por el OTRO eje, que sí puede despejar. */
+          const sx = (dx >= 0 ? 1 : -1) * ox, sy = (dy >= 0 ? 1 : -1) * oy;
+          const xOk = pts[a].x + sx >= bd.x0 && pts[a].x + sx <= bd.x1;
+          const yOk = pts[a].y + sy >= bd.y0 && pts[a].y + sy <= bd.y1;
+          if ((ox < oy && xOk) || !yOk) pts[a].x = clampN(pts[a].x + sx, bd.x0, bd.x1);
+          else pts[a].y += sy;
+        }
+      }
+    }
+    pts.forEach((p) => { p.x = clampN(p.x, bd.x0, bd.x1); p.y = clampN(p.y, bd.y0, bd.y1); });
+    if (!moved) break;
+  }
+}
+
+/**
+ * Caja combinada orbe+etiqueta de un nodo de la red, medida del DOM real
+ * (offsetWidth/Height); si el nodo aún está display:none (hojas plegadas),
+ * estima por longitud de texto — coherente con --lblSize 12.5-13.5px y
+ * max-width 128px.
+ */
+export function nodeRect(lblEl, orbHalf, soon = false) {
+  let lw = lblEl ? lblEl.offsetWidth : 0;
+  let lh = lblEl ? lblEl.offsetHeight : 0;
+  if (!lw && lblEl && lblEl.closest) {
+    /* hoja plegada (display:none): destapar, medir y volver a tapar en el
+       mismo frame síncrono (sin paint intermedio) — la medida REAL evita
+       los choques que daba estimar el wrapping (p. ej. "Agregar planta por
+       foto" rompe en 3 líneas según la fuente del tema). */
+    const host = lblEl.closest('.arm-node');
+    if (host && host.style.display === 'none') {
+      host.style.display = '';
+      lw = lblEl.offsetWidth;
+      lh = lblEl.offsetHeight;
+      host.style.display = 'none';
+    }
+  }
+  if (!lw) {
+    const txt = ((lblEl && lblEl.textContent) || '').trim();
+    const est = Math.round(txt.length * 7.4) + 18;
+    lw = clampN(est, 58, 128);
+    lh = (est > 128 ? 42 : 26) + (soon ? 20 : 0);
+  }
+  const top = -orbHalf - 2;
+  const bottom = orbHalf + 4 + lh;
+  return { hw: Math.max(orbHalf + 1, lw / 2), hh: (bottom - top) / 2, oy: (top + bottom) / 2 };
+}
+
+/**
+ * Empaquetado por ESTANTES (shelf packing) — colocación determinista SIN
+ * solapes para el overview micorriza: 7 nodos+etiquetas en un lienzo de
+ * celular no caben con relajación sola (mínimos locales contra los bordes);
+ * los estantes garantizan cero choque POR CONSTRUCCIÓN. El orden de entrada
+ * (abanico desde la Ⓐ) se respeta: primer nodo arriba-izquierda, último
+ * abajo-derecha — la diagonal viva de la micorriza. Filas alternas van
+ * derecha→izquierda (zigzag orgánico, no grilla).
+ * `jitter(seed)` rompe la rigidez sin romper el pad.
+ */
+export function shelfPack(boxes, band, opts = {}) {
+  const pad = opts.pad ?? 8;
+  const jit = opts.jitter ?? 0;
+  const rnd = opts.rand || (() => 0.5);
+  const width = band.x1 - band.x0;
+  /* 1) partir en estantes por ancho */
+  const shelves = [];
+  let cur = [], curW = 0;
+  boxes.forEach((b, i) => {
+    const w = b.hw * 2 + pad;
+    if (cur.length && curW + w > width) { shelves.push(cur); cur = []; curW = 0; }
+    cur.push(i); curW += w;
+  });
+  if (cur.length) shelves.push(cur);
+  /* 2) altura total y reparto del aire vertical sobrante */
+  const shelfH = shelves.map((sh) => Math.max(...sh.map((i) => boxes[i].hh * 2)));
+  const totalH = shelfH.reduce((a, b) => a + b, 0) + pad * (shelves.length - 1);
+  const gap = Math.max(0, (band.y1 - band.y0 - totalH) / (shelves.length + 1));
+  /* 3) colocar centros (zigzag en filas impares) */
+  const pts = new Array(boxes.length);
+  let yTop = band.y0 + gap;
+  shelves.forEach((sh, s) => {
+    const items = s % 2 ? [...sh].reverse() : sh;
+    const sumW = sh.reduce((a, i) => a + boxes[i].hw * 2, 0);
+    const lead = Math.max(0, (width - sumW - pad * (sh.length - 1)) / (sh.length + 1));
+    let x = band.x0 + lead;
+    items.forEach((i) => {
+      const b = boxes[i];
+      pts[i] = {
+        x: x + b.hw + (rnd(i) - 0.5) * jit,
+        y: yTop + b.hh - b.oy + (rnd(i + 50) - 0.5) * jit * 0.6,
+      };
+      x += b.hw * 2 + pad + lead;
+    });
+    yTop += shelfH[s] + pad + gap;
+  });
+  return pts;
+}
+
+/**
+ * Escalera del ÁRBOL (nature): filas copa→base alternando columna izquierda/
+ * derecha del tronco. Las columnas opuestas nunca chocan en X (los orbes
+ * flanquean el tronco); dentro de la MISMA columna (vecino = fila r-2) el
+ * paso vertical respeta las cajas reales (etiqueta debajo) — cero choque
+ * por construcción. Si el total excede el suelo, comprime proporcional.
+ * Devuelve array de y por índice de nodo (i mayor = copa).
+ */
+export function treeLadder(boxes, n, y0, y1, pad = 6) {
+  const ys = new Array(n);
+  const step = n > 1 ? (y1 - y0) / (n - 1) : 0;
+  for (let r = 0; r < n; r++) {
+    const i = n - 1 - r;        /* fila 0 = copa */
+    const prev = i + 2;          /* vecino de la misma columna, arriba */
+    let y = y0 + r * step;
+    if (prev < n && ys[prev] != null) {
+      const need = boxes[prev].hh + boxes[i].hh + pad +
+        (boxes[prev].oy - boxes[i].oy);
+      y = Math.max(y, ys[prev] + need);
+    }
+    ys[i] = y;
+  }
+  const bottom = ys[0] ?? y0;
+  if (bottom > y1 && bottom > y0) {
+    const k = (y1 - y0) / (bottom - y0);
+    for (let i = 0; i < n; i++) ys[i] = y0 + (ys[i] - y0) * k;
+  }
+  return ys;
+}
+
+/**
+ * Anillo proporcional alrededor del hub (hojas del grupo enfocado): reparte
+ * los ángulos del arco [a0,a1] según el ANCHO ANGULAR real de cada caja
+ * (cajas anchas reciben más arco) — las hojas no se montan entre sí ni
+ * sobre el grupo del centro. Pulir después con relaxRects.
+ */
+export function ringPlace(center, boxes, opts) {
+  const { a0, a1, rx, ry, pad = 8 } = opts;
+  const rAvg = (rx + ry) / 2;
+  const widths = boxes.map((b) => {
+    const half = Math.hypot(b.hw, b.hh) + pad;
+    return 2 * Math.asin(Math.min(0.95, half / Math.max(1, rAvg)));
+  });
+  const total = widths.reduce((a, b) => a + b, 0);
+  const span = a1 - a0;
+  const scale = total > 0 ? Math.min(1.25, span / total) : 1;
+  const lead = Math.max(0, (span - total * scale) / 2);
+  let cum = a0 + lead;
+  return boxes.map((b, i) => {
+    const a = cum + widths[i] * scale / 2;
+    cum += widths[i] * scale;
+    return { x: center.x + Math.cos(a) * rx, y: center.y + Math.sin(a) * ry };
+  });
+}
+
+/**
+ * Verificación de CERO choque (mandato 2026-06-10): ¿alguna caja nodo+etiqueta
+ * se intersecta con otra o con un obstáculo fijo? relaxRects puede oscilar sin
+ * converger cuando el sistema queda sobre-restringido (hub + orbes atenuados +
+ * bordes de un celular) — esta función lo DETECTA para reintentar la colocación
+ * con radios mayores / menos obstáculos, en vez de aceptar un encime visible.
+ */
+export function rectsOverlap(pts, boxes, fixed = [], pad = 0) {
+  const rect = (p, b) => ({
+    x0: p.x - b.hw, x1: p.x + b.hw,
+    y0: p.y + b.oy - b.hh, y1: p.y + b.oy + b.hh,
+  });
+  const hit = (A, B) =>
+    Math.min(A.x1, B.x1) - Math.max(A.x0, B.x0) > pad &&
+    Math.min(A.y1, B.y1) - Math.max(A.y0, B.y0) > pad;
+  const rs = pts.map((p, i) => rect(p, boxes[i]));
+  for (let a = 0; a < rs.length; a++) {
+    for (let b = a + 1; b < rs.length; b++) if (hit(rs[a], rs[b])) return true;
+    for (let f = 0; f < fixed.length; f++) {
+      const F = {
+        x0: fixed[f].x - fixed[f].hw, x1: fixed[f].x + fixed[f].hw,
+        y0: fixed[f].y - fixed[f].hh, y1: fixed[f].y + fixed[f].hh,
+      };
+      if (hit(rs[a], F)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Colocación de hojas GARANTIZADA sin choque visible (anillo + relax +
+ * verificación + reintento). En un celular el sistema completo (hub + miga +
+ * yemas/orbes atenuados + bordes) puede ser infactible y relaxRects oscila;
+ * medido 2026-06-10: nature/grupo-enfocado dejaba la hoja encimada al hub.
+ * Estrategia por intentos:
+ *   1º: todos los obstáculos (hard + soft) — el ideal.
+ *   2º+: SOLO los hard (hub/miga: lo que el usuario está leyendo) y radios
+ *        crecientes — los soft (orbes atenuados ~25% opacidad, sin etiqueta)
+ *        son sacrificables ANTES que permitir un encime de nodos/texto vivos.
+ * Devuelve el primer arreglo verificado sin intersección (rectsOverlap);
+ * si ninguno verifica, el último (mejor esfuerzo, radios máximos).
+ */
+export function placeLeavesNoClash(center, boxes, opts) {
+  const { a0, a1, rx, ry, bd, hard = [], soft = [], pad = 6 } = opts;
+  let pts = null, kx = 1, ky = 1;
+  for (let t = 0; t < 4; t++) {
+    const fixed = t === 0 ? [...hard, ...soft] : hard;
+    pts = ringPlace(center, boxes, { a0, a1, rx: rx * kx, ry: ry * ky, pad: 8 });
+    relaxRects(pts, boxes, bd, { pad, fixed });
+    if (!rectsOverlap(pts, boxes, hard, 2)) return pts;
+    kx *= 1.18; ky *= 1.12;
+  }
+  return pts;
+}
+
+/**
+ * Punto sobre el borde del botón Ⓐ (radio r desde el centro c, mirando a
+ * target). Es el origen de cada trazo: el trazo NACE dentro del disco del
+ * botón (mismo color que su relleno) → la unión raíz↔red queda soldada,
+ * sin gap ni borde (continuidad pedida por el operador 2026-06-10).
+ * Si el destino está más cerca que r, no lo sobrepasa (clamp, sin NaN).
+ */
+export function rimPoint(c, r, target) {
+  const dx = target.x - c.x, dy = target.y - c.y;
+  const len = Math.hypot(dx, dy);
+  if (len < 1e-6) return { x: c.x, y: c.y };
+  const t = Math.min(r, len) / len;
+  return { x: c.x + dx * t, y: c.y + dy * t };
+}


### PR DESCRIPTION
## Qué hace

Refinamiento visual sobre #1394 según feedback del operador con capturas de prod (2026-06-10), en los 3 temas (biopunk · nature · min) y 3 estados (cerrado · abierto · grupo-enfocado):

### 1. Raíz + micorriza MÁS notables
- biopunk: core 2.2→3px, glow 8→13px (alpha .30→.48), twigs .55→.75
- nature: vena Ⓐ→tronco 8→13px, core 4→4.6px, glow 9→12px
- min: core 1.6→2.1px, twigs .45→.6 (sin glow, fiel al tema)
- Boca de raíz: 5→7 raicillas, color de rama pleno, 2.6px, opacidad .85

### 2. Continuidad raíz↔red SIN cortes
- `overflow: visible` (lienzo + body + stage z2): los trazos viajan sobre el borde del compositor hasta el botón Ⓐ real
- `rimPoint`: cada hifa/raicilla/vena **nace dentro del disco del botón** (soldada, sin gap)
- nature: gradiente `userSpaceOnUse` savia-acento→madera en la vena (cero salto de color)
- Fundido alfa bajo el lienzo: los trazos pierden ~45% de peso sobre el compositor — continuos hasta la Ⓐ sin enterrar el placeholder. Dos pitfalls medidos y documentados: mask **luminance** evalúa 50% sRGB ≈ 21% linearRGB (extinción) y la **región default del mask** (120% del viewport) recorta el desborde con línea dura

### 3. CERO choque nodo/red/texto (mandato)
- `agentRedMenuGeom.js` (módulo puro testeado): `shelfPack` por estantes para el overview micorriza (cero encime POR CONSTRUCCIÓN), `treeLadder` copa→base para nature, `ringPlace` proporcional al ancho angular real, `relaxRects` con cajas DOM reales orbe+etiqueta, `nodeRect` mide hojas plegadas destapando en el mismo frame
- `relaxRects` **bounds-aware**: si el clamp del bound anula el empuje del eje de menor solape, empuja por el otro eje (deadlock medido: hoja clavada en y1 contra el hub en nature/enfocado)
- `placeLeavesNoClash`: coloca, **verifica** (`rectsOverlap`) y reintenta con radios mayores, soltando obstáculos soft (orbes atenuados) antes de permitir un encime visible
- La red pasa por detrás de los nodos (z web 1 < nodos 3) y las etiquetas son opacas

## Validación EN VIVO (chromium nix-store, 390×844)

9 mediciones (3 temas × abierto/enfocado/reduced-motion) **ok=true**: origen de cada trazo dentro del disco Ⓐ, 0 intersecciones de cajas orbe/etiqueta, glow apagado en reduced-motion conservando el trazo continuo. Evidencia: `chagra-pw-suite/artifacts/arana-raiz-2026-06-10/` (18 capturas + report.json).

## Tests
- 12 smoke (geometría pura + render) verdes; eslint --max-warnings=0 OK en los archivos tocados
- Suite completa: 4182 pass; los 14 fails (sidecarClient/visionCache/mediaCache/mipPlaga) son pre-existentes en main — verificado corriendo los mismos archivos sin este cambio

**NO mergear** — Opus revisa el look en vivo contra las capturas del operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)