### PR TITLE
feat(biopreparados): diagrama visual paso a paso para baja alfabetización

### DIFF
--- a/src/components/BiopreparadoDiagrama.jsx
+++ b/src/components/BiopreparadoDiagrama.jsx
@@ -1,0 +1,227 @@
+import React from 'react';
+import { Clock, ShieldAlert, ScrollText, Sprout } from 'lucide-react';
+import {
+  getDiagramaBiopreparado,
+  iconoIngrediente,
+} from '../data/biopreparado-diagramas';
+
+/**
+ * BiopreparadoDiagrama — diagrama visual PASO A PASO de un biopreparado,
+ * pensado para campesinos de baja alfabetización: el usuario debería poder
+ * PREPARARLO mirando el dibujo, casi sin leer.
+ *
+ * Renderiza desde dos fuentes, ninguna inventada:
+ *   - el objeto del catálogo (`biopreparado`, de catalog/biopreparados-seed.json):
+ *     ingredientes, tiempo de elaboración, precaución de seguridad, fuente.
+ *   - el overlay visual (src/data/biopreparado-diagramas.js): los pasos
+ *     numerados, que RE-EXPRESAN el `proceso_resumen`/`dosis_aplicacion` del
+ *     mismo catálogo. Cero fabricación de recetas/dosis.
+ *
+ * Si no hay overlay curado para `biopreparado.id`, devuelve null y el llamador
+ * cae con elegancia al texto plano (`proceso_resumen`).
+ *
+ * Theme-aware: usa SOLO familias redefinidas por `[data-theme]` (slate /
+ * emerald / amber / surface) + el acento de marca `--t-accent-rgb`
+ * (teal biopunk · ocre nature · verde minimalista). Nada de sky/lime/cyan.
+ *
+ * Props:
+ *   - biopreparado: objeto del catálogo (requiere id, ingredientes, fuente…)
+ *   - highlightIngredient: (opcional) nombre del ingrediente a resaltar
+ *     (Miguel UX: el material que el usuario acaba de agregar a la bodega)
+ *   - compact: (opcional) oculta el encabezado de nombre (cuando ya hay título)
+ */
+export default function BiopreparadoDiagrama({
+  biopreparado,
+  highlightIngredient = '',
+  compact = false,
+}) {
+  if (!biopreparado || !biopreparado.id) return null;
+  const diagrama = getDiagramaBiopreparado(biopreparado.id);
+  if (!diagrama) return null;
+
+  const {
+    nombre,
+    ingredientes = [],
+    tiempo_elaboracion_dias: dias,
+    precaucion_seguridad: precaucion,
+    fuente,
+  } = biopreparado;
+
+  const hl = highlightIngredient.trim().toLowerCase();
+
+  return (
+    <section
+      data-testid="biopreparado-diagrama"
+      aria-label={`Cómo preparar ${nombre || 'el biopreparado'} paso a paso`}
+      className="space-y-4"
+    >
+      {!compact && (
+        <header className="flex items-center gap-2">
+          <Sprout size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
+          <h4 className="text-sm font-bold text-slate-100">{nombre}</h4>
+          {diagrama.rinde && (
+            <span className="ml-auto text-[10px] text-slate-400 bg-slate-800/70 px-2 py-0.5 rounded-full">
+              {diagrama.rinde}
+            </span>
+          )}
+        </header>
+      )}
+
+      {/* ── Ingredientes: fichas con ícono concreto ─────────────────────── */}
+      {ingredientes.length > 0 && (
+        <div>
+          <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-2">
+            Necesita
+          </p>
+          <ul className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+            {ingredientes.map((ing, i) => {
+              const isMatch = hl && ing.toLowerCase().includes(hl);
+              return (
+                <li
+                  key={i}
+                  className={`flex flex-col items-center gap-1 rounded-xl border p-2 text-center ${
+                    isMatch
+                      ? 'border-emerald-700 bg-emerald-900/30'
+                      : 'border-slate-800 bg-slate-900/60'
+                  }`}
+                >
+                  <span className="text-2xl leading-none" aria-hidden="true">
+                    {iconoIngrediente(ing)}
+                  </span>
+                  <span
+                    className={`text-[10px] leading-tight ${
+                      isMatch ? 'text-emerald-300 font-semibold' : 'text-slate-400'
+                    }`}
+                  >
+                    {ing}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {/* ── Pasos: stepper vertical con número SVG + emoji ──────────────── */}
+      <div>
+        <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-2">
+          Paso a paso
+        </p>
+        <ol className="space-y-0">
+          {diagrama.pasos.map((paso, idx) => {
+            const isLast = idx === diagrama.pasos.length - 1;
+            return (
+              <li key={paso.n} className="flex gap-3">
+                {/* Columna izquierda: badge SVG numerado + línea conectora */}
+                <div className="flex flex-col items-center shrink-0">
+                  <svg
+                    width="32"
+                    height="32"
+                    viewBox="0 0 32 32"
+                    role="img"
+                    aria-label={`Paso ${paso.n}`}
+                    className="shrink-0"
+                  >
+                    <circle
+                      cx="16"
+                      cy="16"
+                      r="15"
+                      style={{ fill: 'rgb(var(--t-accent-rgb))' }}
+                    />
+                    <text
+                      x="16"
+                      y="17"
+                      textAnchor="middle"
+                      dominantBaseline="central"
+                      style={{ fill: '#04231b', fontSize: '15px', fontWeight: 700 }}
+                    >
+                      {paso.n}
+                    </text>
+                  </svg>
+                  {!isLast && (
+                    <span
+                      aria-hidden="true"
+                      className="w-0.5 flex-1 min-h-[1.25rem] bg-slate-700 my-1"
+                    />
+                  )}
+                </div>
+
+                {/* Columna derecha: emoji + título + detalle */}
+                <div className={`flex-1 pb-4 ${isLast ? '' : ''}`}>
+                  <div className="flex items-start gap-2">
+                    <span className="text-2xl leading-none shrink-0" aria-hidden="true">
+                      {paso.icon}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="text-sm font-semibold text-slate-100 flex items-center flex-wrap gap-1.5">
+                        {paso.titulo}
+                        {paso.cantidad && (
+                          <span className="text-[11px] font-bold text-emerald-300 bg-emerald-900/40 px-1.5 py-0.5 rounded">
+                            {paso.cantidad}
+                          </span>
+                        )}
+                      </p>
+                      <p
+                        className={`text-xs leading-relaxed mt-0.5 ${
+                          paso.alerta ? 'text-amber-300' : 'text-slate-300'
+                        }`}
+                      >
+                        {paso.alerta && (
+                          <ShieldAlert
+                            size={12}
+                            className="inline-block mr-1 -mt-0.5 text-amber-400"
+                            aria-label="Cuidado"
+                          />
+                        )}
+                        {paso.detalle}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      {/* ── Tiempo de fermentación / elaboración ───────────────────────── */}
+      {dias != null && (
+        <div className="flex items-center gap-2 rounded-xl border border-slate-800 bg-slate-900/60 px-3 py-2">
+          <Clock size={16} className="text-emerald-400 shrink-0" aria-hidden="true" />
+          <span className="text-xs text-slate-300">
+            {dias <= 1 ? (
+              <>Se usa el <strong className="text-slate-100">mismo día</strong></>
+            ) : (
+              <>
+                Listo en{' '}
+                <strong className="text-slate-100">~{dias} días</strong> de
+                fermentación
+              </>
+            )}
+          </span>
+        </div>
+      )}
+
+      {/* ── Banda de seguridad (guarda existente del catálogo) ─────────── */}
+      {precaucion && (
+        <div className="flex items-start gap-2 rounded-xl border border-amber-800/60 bg-amber-900/20 px-3 py-2">
+          <ShieldAlert size={16} className="text-amber-400 shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="text-[10px] uppercase tracking-wider text-amber-400/80 font-bold mb-0.5">
+              Cuidado
+            </p>
+            <p className="text-xs text-amber-200/90 leading-relaxed">{precaucion}</p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Fuente (trazabilidad — no se inventa nada) ─────────────────── */}
+      {fuente && (
+        <div className="flex items-start gap-2 pt-1">
+          <ScrollText size={12} className="text-slate-600 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-[10px] text-slate-500 italic leading-relaxed">{fuente}</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/BiopreparadoSuggestionModal.jsx
+++ b/src/components/BiopreparadoSuggestionModal.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { X, Beaker, Clock, ChevronDown, ChevronRight, BookOpen } from 'lucide-react';
+import BiopreparadoDiagrama from './BiopreparadoDiagrama';
+import { tieneDiagrama } from '../data/biopreparado-diagramas';
 
 /**
  * BiopreparadoSuggestionModal, Modal sugerencia de biopreparados para un
@@ -78,39 +80,47 @@ export default function BiopreparadoSuggestionModal({ ingredientName, bioprepara
                 </button>
 
                 {isOpen && (
-                  <div className="px-4 pb-4 pt-1 text-xs text-slate-300 space-y-3 border-t border-slate-800">
-                    {bp.ingredientes && bp.ingredientes.length > 0 && (
-                      <div>
-                        <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">Ingredientes</p>
-                        <div className="flex flex-wrap gap-1">
-                          {bp.ingredientes.map((ing, i) => {
-                            const isMatch = ing.toLowerCase().includes(ingredientName.toLowerCase());
-                            return (
-                              <span
-                                key={i}
-                                className={`text-[11px] px-2 py-0.5 rounded ${
-                                  isMatch
-                                    ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-800'
-                                    : 'bg-slate-800 text-slate-400'
-                                }`}
-                              >
-                                {ing}
-                              </span>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    )}
-                    {bp.proceso_resumen && (
-                      <div>
-                        <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1 flex items-center gap-1">
-                          <BookOpen size={10} /> Proceso
-                        </p>
-                        <p className="text-xs text-slate-300 leading-relaxed">{bp.proceso_resumen}</p>
-                      </div>
+                  <div className="px-4 pb-4 pt-3 text-xs text-slate-300 space-y-3 border-t border-slate-800">
+                    {/* Diagrama visual paso a paso (baja alfabetización) cuando
+                        existe receta curada; si no, cae al texto del proceso. */}
+                    {tieneDiagrama(bp.id) ? (
+                      <BiopreparadoDiagrama biopreparado={bp} highlightIngredient={ingredientName} compact />
+                    ) : (
+                      <>
+                        {bp.ingredientes && bp.ingredientes.length > 0 && (
+                          <div>
+                            <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">Ingredientes</p>
+                            <div className="flex flex-wrap gap-1">
+                              {bp.ingredientes.map((ing, i) => {
+                                const isMatch = ing.toLowerCase().includes(ingredientName.toLowerCase());
+                                return (
+                                  <span
+                                    key={i}
+                                    className={`text-[11px] px-2 py-0.5 rounded ${
+                                      isMatch
+                                        ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-800'
+                                        : 'bg-slate-800 text-slate-400'
+                                    }`}
+                                  >
+                                    {ing}
+                                  </span>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        )}
+                        {bp.proceso_resumen && (
+                          <div>
+                            <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1 flex items-center gap-1">
+                              <BookOpen size={10} /> Proceso
+                            </p>
+                            <p className="text-xs text-slate-300 leading-relaxed">{bp.proceso_resumen}</p>
+                          </div>
+                        )}
+                      </>
                     )}
                     <div className="flex flex-wrap gap-3 text-[10px] text-slate-500">
-                      {bp.tiempo_elaboracion_dias && (
+                      {!tieneDiagrama(bp.id) && bp.tiempo_elaboracion_dias && (
                         <span className="inline-flex items-center gap-1">
                           <Clock size={10} /> Elaboración: {bp.tiempo_elaboracion_dias} días
                         </span>

--- a/src/components/__tests__/BiopreparadoDiagrama.smoke.test.jsx
+++ b/src/components/__tests__/BiopreparadoDiagrama.smoke.test.jsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect } from 'vitest';
+import BiopreparadoDiagrama from '../BiopreparadoDiagrama';
+import {
+  getDiagramaBiopreparado,
+  tieneDiagrama,
+  iconoIngrediente,
+} from '../../data/biopreparado-diagramas';
+
+/**
+ * Smoke tests — BiopreparadoDiagrama (TIER 2 #4: diagramas de biopreparados).
+ *
+ * Verifican que:
+ *   - se renderiza el diagrama paso a paso de un biopreparado con receta curada,
+ *   - los pasos están numerados (badges SVG accesibles) y traen título + detalle,
+ *   - los ingredientes salen como fichas con su nombre,
+ *   - `highlightIngredient` resalta el material recién agregado a la bodega,
+ *   - la banda de seguridad y la fuente del catálogo se muestran (trazabilidad),
+ *   - si el biopreparado NO tiene receta curada, devuelve null (la UI cae al texto),
+ *   - ningún texto usa voseo argentino (español de Colombia).
+ *
+ * Fixtures fieles a catalog/biopreparados-seed.json (no se inventan dosis).
+ */
+
+const CALDO_BORDELES = {
+  id: 'caldo_bordeles',
+  nombre: 'Caldo bordelés',
+  tipo: 'caldo',
+  ingredientes: ['sulfato de cobre', 'cal hidratada', 'agua'],
+  proceso_resumen: '100g sulfato + 100g cal en 10L agua…',
+  tiempo_elaboracion_dias: 1,
+  vida_util_dias: 1,
+  precaucion_seguridad:
+    'TOXICOLOGIA COBRE: metal pesado. EPI: guantes, careta y gafas. NO mezclar con caldo sulfocalcico.',
+  fuente: 'Restrepo Rivera, J.; Agrosavia/ICA; Resolucion ICA 698/2011.',
+};
+
+const BOCASHI = {
+  id: 'bocashi',
+  nombre: 'Bocashi',
+  tipo: 'fermentado',
+  ingredientes: ['gallinaza', 'cascarilla de arroz', 'melaza', 'agua'],
+  proceso_resumen: 'Fermentación aeróbica 15-21 días…',
+  tiempo_elaboracion_dias: 18,
+  precaucion_seguridad: 'Bajo riesgo. Aplicar MADURO y frio.',
+  fuente: 'Restrepo Rivera, J. — ABC de la agricultura organica.',
+};
+
+const SIN_DIAGRAMA = {
+  id: 'roca_fosforica',
+  nombre: 'Roca fosfórica',
+  ingredientes: ['roca fosfórica molida'],
+  proceso_resumen: 'Aplicación directa al suelo.',
+};
+
+describe('BiopreparadoDiagrama — render del diagrama paso a paso', () => {
+  test('renderiza el diagrama de caldo bordelés con sus 5 pasos numerados', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    expect(screen.getByTestId('biopreparado-diagrama')).toBeInTheDocument();
+    const pasos = getDiagramaBiopreparado('caldo_bordeles').pasos;
+    for (const paso of pasos) {
+      expect(screen.getByLabelText(`Paso ${paso.n}`)).toBeInTheDocument();
+      expect(screen.getByText(paso.titulo)).toBeInTheDocument();
+    }
+  });
+
+  test('muestra las cantidades destacadas (100 g) tomadas del catálogo', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    expect(screen.getAllByText('100 g').length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('renderiza las fichas de ingredientes con su nombre', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    for (const ing of CALDO_BORDELES.ingredientes) {
+      expect(screen.getByText(ing)).toBeInTheDocument();
+    }
+  });
+
+  test('muestra la banda de seguridad (precaución) del catálogo', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    expect(screen.getByText(/TOXICOLOGIA COBRE/)).toBeInTheDocument();
+  });
+
+  test('muestra la fuente del catálogo (trazabilidad)', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    expect(screen.getByText(/Resolucion ICA 698\/2011/)).toBeInTheDocument();
+  });
+
+  test('"se usa el mismo día" cuando tiempo_elaboracion_dias <= 1', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    expect(screen.getAllByText(/mismo día/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('muestra "~N días de fermentación" para bocashi (18 días)', () => {
+    render(<BiopreparadoDiagrama biopreparado={BOCASHI} />);
+    expect(screen.getByText(/18 días/)).toBeInTheDocument();
+    expect(screen.getByText(/fermentación/i)).toBeInTheDocument();
+  });
+
+  test('resalta el ingrediente recién agregado vía highlightIngredient', () => {
+    render(
+      <BiopreparadoDiagrama biopreparado={CALDO_BORDELES} highlightIngredient="cal" />,
+    );
+    // La ficha "cal hidratada" toma la clase de resaltado emerald.
+    const cal = screen.getByText('cal hidratada');
+    expect(cal.className).toMatch(/emerald/);
+  });
+
+  test('en modo compact NO renderiza el encabezado con el nombre', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} compact />);
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  test('en modo normal SÍ renderiza el nombre como encabezado', () => {
+    render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    expect(screen.getByRole('heading', { name: /Caldo bordelés/ })).toBeInTheDocument();
+  });
+});
+
+describe('BiopreparadoDiagrama — defensa y degradación elegante', () => {
+  test('devuelve null si el biopreparado no tiene receta curada', () => {
+    const { container } = render(<BiopreparadoDiagrama biopreparado={SIN_DIAGRAMA} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('devuelve null si no hay biopreparado', () => {
+    const { container } = render(<BiopreparadoDiagrama biopreparado={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('devuelve null si el objeto no trae id', () => {
+    const { container } = render(<BiopreparadoDiagrama biopreparado={{ nombre: 'X' }} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('ningún texto del diagrama usa voseo argentino', () => {
+    const { container } = render(<BiopreparadoDiagrama biopreparado={CALDO_BORDELES} />);
+    // Regex de voseo establecida en el repo (ChipsToolbar.smoke): solo formas
+    // imperativas con vocal final acentuada (escribí/tomá/tenés…). El diagrama
+    // usa imperativos de USTED (Disuelva/Prepare/Vierta/Asperje) → no debe matchear.
+    const VOSEO = /\b(escrib[íi]|ten[ée]s|quer[ée]s|eleg[íi]|pod[ée]s|sab[ée]s|aplicá|prepará|verté)\b/i;
+    expect(container.textContent).not.toMatch(VOSEO);
+  });
+});
+
+describe('overlay de datos biopreparado-diagramas', () => {
+  test('tieneDiagrama es true para los 3 biopreparados de prueba', () => {
+    expect(tieneDiagrama('caldo_bordeles')).toBe(true);
+    expect(tieneDiagrama('bocashi')).toBe(true);
+    expect(tieneDiagrama('biol')).toBe(true);
+  });
+
+  test('tieneDiagrama es false para ids sin receta curada o vacíos', () => {
+    expect(tieneDiagrama('roca_fosforica')).toBe(false);
+    expect(tieneDiagrama('')).toBe(false);
+    expect(tieneDiagrama(undefined)).toBe(false);
+  });
+
+  test('cada diagrama tiene pasos numerados de 1..N en orden', () => {
+    for (const id of ['caldo_bordeles', 'bocashi', 'biol']) {
+      const { pasos } = getDiagramaBiopreparado(id);
+      expect(pasos.length).toBeGreaterThanOrEqual(3);
+      pasos.forEach((p, i) => {
+        expect(p.n).toBe(i + 1);
+        expect(p.titulo).toBeTruthy();
+        expect(p.detalle).toBeTruthy();
+        expect(p.icon).toBeTruthy();
+      });
+    }
+  });
+
+  test('iconoIngrediente mapea claves conocidas y cae a 🌿 por defecto', () => {
+    expect(iconoIngrediente('agua')).toBe('💧');
+    expect(iconoIngrediente('sulfato de cobre')).toBe('🔷');
+    expect(iconoIngrediente('algo desconocido xyz')).toBe('🌿');
+  });
+});

--- a/src/data/biopreparado-diagramas.js
+++ b/src/data/biopreparado-diagramas.js
@@ -1,0 +1,216 @@
+// biopreparado-diagramas.js — Capa de PRESENTACIÓN para los diagramas
+// visuales paso a paso de biopreparados (TIER 2 #4).
+//
+// REGLA DURA — CERO FABRICACIÓN DE RECETAS:
+// Toda cantidad, proporción, tiempo y dilución de este archivo proviene
+// TEXTUALMENTE de catalog/biopreparados-seed.json (campos `proceso_resumen`,
+// `dosis_aplicacion`, `ingredientes`, `tiempo_elaboracion_dias`). Acá NO se
+// inventan dosis: solo se RE-EXPRESA en pasos discretos + íconos el mismo
+// contenido validado por Restrepo Rivera / Agrosavia / ICA que ya vive en el
+// catálogo, para que un campesino de baja alfabetización pueda prepararlo
+// mirando el dibujo. La fuente real se cita desde el objeto del catálogo
+// (`biopreparado.fuente`), no desde acá.
+//
+// Cobertura inicial (prueba TIER 2 #4): caldo bordelés + bocashi + biol.
+// Para los demás biopreparados sin entrada acá, el componente devuelve null y
+// la UI cae con elegancia al `proceso_resumen` en texto (sin diagrama).
+
+/**
+ * Mapa palabra-clave → emoji concreto para los ingredientes. El emoji es
+ * ILUSTRATIVO (no es una afirmación de dosis), elegido por concreción visual
+ * para baja alfabetización. Se evalúa por `includes` sobre el nombre en
+ * minúsculas; el primer match gana, de ahí el orden (más específico primero).
+ * @type {Array<[string, string]>}
+ */
+const ICONOS_INGREDIENTE = [
+  ['sulfato de cobre', '🔷'],
+  ['cobre', '🔷'],
+  ['cal', '⚪'],
+  ['gallinaza', '🐔'],
+  ['estiércol', '🐄'],
+  ['estiercol', '🐄'],
+  ['leche', '🥛'],
+  ['suero', '🥛'],
+  ['melaza', '🍯'],
+  ['ceniza', '🌫️'],
+  ['cascarilla de arroz', '🌾'],
+  ['afrecho', '🌾'],
+  ['carbón', '⚫'],
+  ['carbon', '⚫'],
+  ['tierra', '🟤'],
+  ['capote', '🟤'],
+  ['levadura', '🫧'],
+  ['roca fosfórica', '🪨'],
+  ['roca fosforica', '🪨'],
+  ['agua', '💧'],
+];
+
+/**
+ * Devuelve el emoji ilustrativo de un ingrediente por nombre.
+ * @param {string} nombre
+ * @returns {string}
+ */
+export function iconoIngrediente(nombre) {
+  const n = String(nombre || '').toLowerCase();
+  for (const [clave, emoji] of ICONOS_INGREDIENTE) {
+    if (n.includes(clave)) return emoji;
+  }
+  return '🌿';
+}
+
+/**
+ * Overlay visual por `biopreparado.id`. Cada paso:
+ *   - n:        número de orden (1-based)
+ *   - icon:     emoji concreto del paso (ilustrativo)
+ *   - titulo:   acción corta en imperativo (español de Colombia)
+ *   - detalle:  cantidades/condiciones — TEXTUALES del catálogo
+ *   - cantidad: (opcional) etiqueta de cantidad destacada
+ *   - alerta:   (opcional) marca el paso como crítico (banda ámbar)
+ *
+ * @type {Record<string, { rinde?: string, pasos: Array<{
+ *   n:number, icon:string, titulo:string, detalle:string,
+ *   cantidad?:string, alerta?:boolean }> }>}
+ */
+export const DIAGRAMAS_BIOPREPARADO = {
+  // Fuente: catalog/biopreparados-seed.json → caldo_bordeles.dosis_aplicacion
+  // (1% para 10 L: 100 g sulfato + 100 g cal; cobre SOBRE la cal; prueba del
+  // clavo; foliar haz y envés, sin diluir, el mismo día).
+  caldo_bordeles: {
+    rinde: 'Rinde 10 litros',
+    pasos: [
+      {
+        n: 1,
+        icon: '🔷',
+        titulo: 'Disuelva el cobre',
+        detalle: '100 g de sulfato de cobre en agua tibia. Use un recipiente que NO sea de metal.',
+        cantidad: '100 g',
+      },
+      {
+        n: 2,
+        icon: '⚪',
+        titulo: 'Prepare la cal aparte',
+        detalle: '100 g de cal en otra parte del agua, en un balde distinto.',
+        cantidad: '100 g',
+      },
+      {
+        n: 3,
+        icon: '🔄',
+        titulo: 'Junte cobre sobre cal',
+        detalle: 'Vierta el cobre SOBRE la cal (nunca al revés). Complete hasta los 10 litros.',
+        alerta: true,
+      },
+      {
+        n: 4,
+        icon: '🔩',
+        titulo: 'Prueba del clavo',
+        detalle: 'Meta un clavo de hierro: NO debe ponerse cobrizo. Esa es la señal de que ya está neutro.',
+      },
+      {
+        n: 5,
+        icon: '🌿',
+        titulo: 'Asperje el mismo día',
+        detalle: 'Foliar, cubriendo el haz y el envés de la hoja. Se aplica sin diluir y el mismo día.',
+      },
+    ],
+  },
+
+  // Fuente: catalog/biopreparados-seed.json → bocashi.proceso_resumen +
+  // dosis_aplicacion (fermentación aeróbica 15-21 días, volteo diario, <40-50 °C,
+  // prueba de puño; aplicar maduro y frío).
+  bocashi: {
+    rinde: 'Abono sólido para el suelo',
+    pasos: [
+      {
+        n: 1,
+        icon: '🌾',
+        titulo: 'Mezcle los secos',
+        detalle: 'Gallinaza, cascarilla de arroz, tierra de capote, carbón triturado y afrecho. Revuelva todo.',
+      },
+      {
+        n: 2,
+        icon: '🍯',
+        titulo: 'Riegue con melaza',
+        detalle: 'Disuelva la melaza y la levadura en agua. Riegue sobre la mezcla mientras revuelve.',
+      },
+      {
+        n: 3,
+        icon: '✊',
+        titulo: 'Prueba de puño',
+        detalle: 'Apriete un puñado: el agua no debe gotear, pero la mano queda húmeda. Esa es la humedad justa.',
+      },
+      {
+        n: 4,
+        icon: '🔄',
+        titulo: 'Voltee cada día',
+        detalle: 'Voltee la pila todos los días. Mantenga la temperatura por debajo de 50 °C.',
+      },
+      {
+        n: 5,
+        icon: '✅',
+        titulo: 'Listo a los 15-21 días',
+        detalle: 'Cuando se enfría (menos de 40 °C) ya está maduro. Aplíquelo FRÍO: caliente quema la raíz.',
+        alerta: true,
+      },
+    ],
+  },
+
+  // Fuente: catalog/biopreparados-seed.json → biol.proceso_resumen +
+  // dosis_aplicacion (digestión anaeróbica 30-45 días en caneca con sello de
+  // agua; filtrar; foliar 1-2 L de biol por 10 L de agua).
+  biol: {
+    rinde: 'Abono líquido foliar',
+    pasos: [
+      {
+        n: 1,
+        icon: '🐄',
+        titulo: 'Cargue la caneca',
+        detalle: 'Estiércol fresco con agua. Agregue leche o suero, melaza y ceniza.',
+      },
+      {
+        n: 2,
+        icon: '🛢️',
+        titulo: 'Selle con válvula',
+        detalle: 'Tape la caneca con sello de agua (válvula de gases). No debe entrar aire.',
+        alerta: true,
+      },
+      {
+        n: 3,
+        icon: '⏳',
+        titulo: 'Espere 30-45 días',
+        detalle: 'Fermenta sin aire. No destape hasta que deje de borbotear.',
+      },
+      {
+        n: 4,
+        icon: '🫗',
+        titulo: 'Cuele el líquido',
+        detalle: 'Filtre. El líquido colado es el biol.',
+      },
+      {
+        n: 5,
+        icon: '🌿',
+        titulo: 'Diluya y aplique',
+        detalle: '1 a 2 litros de biol por cada 10 litros de agua. Foliar, al amanecer.',
+      },
+    ],
+  },
+};
+
+/**
+ * Devuelve el overlay de diagrama para un id de biopreparado, o null si no
+ * hay diagrama curado (la UI cae al texto `proceso_resumen`).
+ * @param {string} id
+ * @returns {{ rinde?: string, pasos: Array<object> } | null}
+ */
+export function getDiagramaBiopreparado(id) {
+  if (!id) return null;
+  return DIAGRAMAS_BIOPREPARADO[id] || null;
+}
+
+/**
+ * ¿Existe un diagrama paso a paso para este id?
+ * @param {string} id
+ * @returns {boolean}
+ */
+export function tieneDiagrama(id) {
+  return Boolean(id && DIAGRAMAS_BIOPREPARADO[id]);
+}


### PR DESCRIPTION
## Qué

Los biopreparados (caldo bordelés, bocashi, biol, supermagro, EM, Trichoderma…) se explicaban **solo en texto** (`proceso_resumen`), difícil para campesinos de baja alfabetización. Este PR agrega un **diagrama visual paso a paso** para que se pueda PREPARAR mirando el dibujo: ingredientes con íconos + cantidades, pasos numerados ilustrados y tiempo de fermentación.

## Dónde estaban las recetas

`catalog/biopreparados-seed.json` (16 biopreparados, validados por Restrepo Rivera / Agrosavia / ICA). El proceso vivía como prosa en `proceso_resumen` / `dosis_aplicacion`, sin pasos estructurados.

## Qué se agrega

- **`src/data/biopreparado-diagramas.js`** — capa de presentación con los pasos numerados + mapa ingrediente→emoji. **Cero fabricación**: toda cantidad/tiempo/dilución es TEXTUAL del catálogo; la fuente real se cita desde el objeto del catálogo (`fuente`).
- **`src/components/BiopreparadoDiagrama.jsx`** — componente reutilizable. Stepper con badges **SVG numerados** + emoji concretos, fichas de ingredientes, banda de seguridad (respeta `precaucion_seguridad`) y fuente. Si no hay receta curada para el id → devuelve `null` (degradación elegante a texto).
- **`BiopreparadoSuggestionModal`** — usa el diagrama cuando existe; si no, cae al texto plano previo.

Prueba inicial: **caldo bordelés + bocashi + biol**.

## Theme-aware

Usa solo familias redefinidas por `[data-theme]` (slate / emerald / amber) + el acento de marca `--t-accent-rgb`. Sin sky/lime/cyan hardcodeados. Validado **en vivo** con chromium del nix-store en los 3 temas — el badge de paso adapta el acento: teal (biopunk) · verde (minimalista) · ocre (nature); superficies invierten en los temas claros.

## Pruebas

- `BiopreparadoDiagrama.smoke.test.jsx`: **18 tests** vitest en verde (pasos numerados, cantidades del catálogo, banda de seguridad, fuente, highlight de ingrediente, degradación a null, sin voseo).
- `eslint --max-warnings=0`: limpio.

No mergear todavía.

🤖 Generated with [Claude Code](https://claude.com/claude-code)