### PR TITLE
docs(help): auditar ayuda PWA contra capacidades actuales (jun 2026)

### DIFF
--- a/src/components/HelpAgentSection.jsx
+++ b/src/components/HelpAgentSection.jsx
@@ -87,15 +87,16 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
             <p>
               No es un humano. Se llama &ldquo;agente&rdquo; porque puede usar
               herramientas (consultar el catálogo de plantas, mirar un grafo
-              de relaciones entre especies) para responder con datos reales,
-              no solo con lo que recuerda el modelo de IA.
+              de relaciones entre especies, revisar toxicidad, variedades, suelo
+              y saberes) para responder con datos reales, no solo con lo que
+              recuerda el modelo de IA.
             </p>
             <p>
-              Por dentro usa un modelo de inteligencia artificial llamado{' '}
-              <strong className="text-sky-300">gemma3:4b</strong> que corre en
-              nuestros servidores en Colombia. Es un modelo abierto publicado
-              por Google DeepMind. Lo escogimos pequeño a propósito: responde
-              rápido y no necesita una supercomputadora.
+              Para conversar usa un modelo de inteligencia artificial abierto
+              llamado <strong className="text-sky-300">Granite 3.1</strong> (de
+              IBM) que corre en nuestros servidores en Colombia. Lo anclamos al
+              catálogo: si un dato no está en las fichas, el agente lo dice en
+              vez de inventarlo.
             </p>
           </div>
         </section>
@@ -126,12 +127,8 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
                 </p>
                 <p className="text-xs text-slate-400 mt-1">
                   Ejemplo: pregúntale &ldquo;qué plantas van con el
-                  café&rdquo; y te responde con datos del catálogo Chagra (495
-                  especies curadas a la fecha, ver{' '}
-                  <code className="text-emerald-300">
-                    catalog/chagra-catalog-seed-v3.1.json
-                  </code>
-                  ).
+                  café&rdquo; y te responde con datos del catálogo Chagra (263
+                  especies curadas a la fecha, incluidas 60 de páramo).
                 </p>
               </div>
             </li>
@@ -191,6 +188,26 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
                 <p>
                   <strong>Te lee las respuestas en voz alta</strong> si tienes
                   las manos sucias o no puedes leer la pantalla.
+                </p>
+              </div>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckCircle2
+                size={16}
+                className="text-emerald-400 mt-1 shrink-0"
+                aria-hidden="true"
+              />
+              <div>
+                <p>
+                  <strong>Te muestra todo lo que sabe hacer</strong> en un menú
+                  que se abre desde el agente.
+                </p>
+                <p className="text-xs text-slate-400 mt-1">
+                  Del agente brota una red de opciones, como las ramas de un
+                  árbol. Toca una rama y se abren sus capacidades (plantas
+                  compañeras, biopreparados, toxicidad, variedades, suelo,
+                  saberes). Lo que aún no está listo aparece marcado como &ldquo;por
+                  lanzarse&rdquo;.
                 </p>
               </div>
             </li>
@@ -357,9 +374,9 @@ export default function HelpAgentSection({ onBackToHome, onNavigate }) {
           </h3>
           <ul className="space-y-3 text-sm text-slate-200 leading-relaxed">
             <li>
-              <strong>El catálogo tiene 495 especies hoy</strong> (revisado
-              2026-05-23). Si tu planta no está, el agente te lo dirá. Crece
-              con aportes de la comunidad.
+              <strong>El catálogo abierto tiene 263 especies hoy</strong>{' '}
+              (incluidas 60 de páramo). Si tu planta no está, el agente te lo
+              dirá. Crece con aportes de la comunidad.
             </li>
             <li>
               <strong>El modelo se equivoca</strong> en cierto porcentaje de

--- a/src/components/HelpUsoScreen.jsx
+++ b/src/components/HelpUsoScreen.jsx
@@ -185,7 +185,7 @@ export default function HelpUsoScreen({ onBackToHome, onNavigate }) {
         </Section>
 
         {/* 5. Reportar problema / sugerir mejora — embed del FieldFeedback
-            form. Antes vivía como FAB flotante 💬 global; movido acá
+            form. Antes vivía como FAB flotante 💬 global; movido aquí
             2026-05-21 por feedback usuario (más discoverable + no tapa
             contenido). isNew=true para resaltar la nueva ubicación. */}
         <Section

--- a/src/components/HelpVozScreen.jsx
+++ b/src/components/HelpVozScreen.jsx
@@ -128,7 +128,7 @@ export default function HelpVozScreen({ onBackToHome, onNavigate }) {
 
         {/* Sin red */}
         <p className="text-xs text-slate-500 italic mt-2 leading-relaxed">
-          ¿Sin red en campo? La voz funciona offline igual. La transcripción local guarda el audio y reintenta cuando vuelves a tener señal.
+          ¿Sin red en campo? Puedes grabar igual: la app guarda tu audio y lo transcribe en cuanto vuelves a tener señal (la transcripción usa el servidor). Lo que registras nunca se pierde.
         </p>
 
         {/* CTA bottom secundaria — backup si scrolleó hasta abajo */}


### PR DESCRIPTION
## Resumen
Auditoría de **contenido** de la ayuda in-app (`src/components/Help*.jsx`) para que refleje las capacidades actuales. Sin cambios de arquitectura ni de lógica — solo strings JSX. **No mergear hasta revisión de contenido customer-facing.**

## Correcciones (todas verificadas)
| Archivo | Antes | Ahora | Fuente |
|---|---|---|---|
| HelpAgentSection | modelo chat = `gemma3:4b` (Google DeepMind) | **Granite 3.1** (IBM); `gemma3:4b` hoy es el NLU | `config/setup-llm-prod.json` (`chat_model`) + `useOllamaWarmStore.js` |
| HelpAgentSection | catálogo "495 especies" | **263** (incl. **60 de páramo**) | `public/catalog.sqlite` |
| HelpAgentSection | (faltaba) | añade **menú vivo de capacidades** (la red que brota del agente) + conocimiento del grafo (toxicidad/variedades/suelo/saberes) | spec + `setup-llm-prod` num_ctx grounding |
| HelpVozScreen | "la voz funciona offline igual, transcripción local" | grabás offline; la **transcripción (Whisper) usa servidor** y corre al volver la señal | `INFRA_FACTS` (whisper-http) + HelpUsoScreen ya lo decía bien |
| HelpUsoScreen | comentario con voseo "acá" | "aquí" | regla dialecto |

## Verificación
- `npx eslint Help* --max-warnings=0` → **limpio (0 warnings)**.
- `npx vitest run` smoke de Help → **14/14 verde** (HelpAgentSection / HelpDatosScreen / HelpHomeScreen).
- Las 14 fallas de la suite completa están en `src/db|services` (env `crypto.subtle`/sidecar), son **pre-existentes** (diff vs `origin/main` vacío en esos archivos) y **ajenas** a este cambio (solo edité strings JSX en 3 Help).

## Reglas respetadas
- Español de Colombia, sin voseo. Sin codenames/política. Sin secretos (secret-scan ✔). Conventional commit ✔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)