### PR TITLE
feat(capability): getCapabilityHealth — estado real live/soon/down por capacidad + wiring en arana

### DIFF
--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -1,5 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useMemo } from 'react';
 import { CAPABILITY_MANIFEST } from '../../services/agentCapabilities';
+import { getCapabilityHealth, SIDECAR_TOOL_NAMES } from '../../services/capabilityHealth';
+import { isSidecarEnabled } from '../../services/sidecarClient';
 import {
   relax, nodeRect, rimPoint, shelfPack, treeLadder, placeLeavesNoClash,
 } from './agentRedMenuGeom';
@@ -352,6 +354,10 @@ const CSS = `
   padding:2px 7px;opacity:.9}
 .arm-node.arm-soon{cursor:default}
 .arm-node.arm-soon .arm-orb{border-style:dashed}
+.arm-node.arm-down{cursor:default}
+.arm-node.arm-down .arm-orb{border-style:dashed;opacity:.55}
+.arm-node.arm-down .arm-lbl{opacity:.6}
+.arm-badge-down{color:var(--warnC, #f59e0b);border-color:var(--warnC, #f59e0b40)}
 /* pista de uso — abajo-derecha: la esquina libre con la red brotando del
    botón Ⓐ (abajo-izquierda) hacia arriba-derecha. */
 .arm-hint{position:absolute;right:14px;bottom:10px;z-index:2;
@@ -403,6 +409,26 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
 
   const treeMode = themeKind === 'nature';
 
+  /* Estado real de cada capacidad: live (pleno), soon (por lanzar),
+     down (dependencia rota, ej. sidecar caido). Deterministico,
+     sin side-effects ocultos — las dependencias vienen de imports. */
+  const capabilityHealth = useMemo(() => {
+    try {
+      const sidecarOn = isSidecarEnabled();
+      return new Map(CAPABILITY_MANIFEST.map((cap) => [
+        cap.id,
+        getCapabilityHealth(cap.id, {
+          manifest: CAPABILITY_MANIFEST,
+          isSidecarEnabled: sidecarOn,
+          sidecarToolNames: SIDECAR_TOOL_NAMES,
+        }),
+      ]));
+    } catch {
+      // Degradacion total: todo live (el menu nunca se rompe)
+      return new Map(CAPABILITY_MANIFEST.map((cap) => [cap.id, 'live']));
+    }
+  }, []);
+
   /* Motor imperativo: layout + rAF (port del demo). Re-brota al cambiar
      entre mecánica micorriza (biopunk/min) y árbol (nature). */
   useEffect(() => {
@@ -442,11 +468,13 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
         leafAbsR: [], leafOffR: [], leafAbsT: [], leafOffT: [],
         leaves: g.leaves.map((cap, j) => {
           const lel = root.querySelector(`[data-arm-leaf="${i}-${j}"]`);
+          const health = capabilityHealth.get(cap.id) || 'live';
           return {
             el: lel,
             orb: lel.querySelector('.arm-orb'),
             lblEl: lel.querySelector('.arm-lbl'),
-            soon: cap.status === 'soon',
+            soon: health === 'soon',
+            down: health === 'down',
             pGlow: mkPath(gGlow, 'lf'),
             pCore: mkPath(gCore, 'lf'),
             grow: 0, growT: 0,
@@ -815,7 +843,7 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
             setDash(lf.pCore, L, e); setDash(lf.pGlow, L, e);
           } else { clearDash(lf.pCore); clearDash(lf.pGlow); }
           lf.el.style.transform = `translate(${r1(lx)}px,${r1(ly)}px)`;
-          lf.el.style.opacity = ((lf.soon ? 0.72 : 1) * e).toFixed(3);
+          lf.el.style.opacity = ((lf.soon || lf.down ? 0.72 : 1) * e).toFixed(3);
           lf.orb.style.transform = `scale(${(0.5 + 0.5 * e).toFixed(3)})`;
           lf.lblEl.style.opacity = e.toFixed(3);
         });
@@ -900,7 +928,7 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       });
       engineRef.current = null;
     };
-  }, [treeMode, anchorRef]);
+  }, [treeMode, anchorRef, capabilityHealth]);
 
   function showToast(msg) {
     setToastMsg(msg);
@@ -916,8 +944,13 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
   function handleLeafTap(ev, cap) {
     if (disabled) return;
     bounce(ev.currentTarget);
-    if (cap.status === 'soon') {
+    const health = capabilityHealth.get(cap.id) || 'live';
+    if (health === 'soon') {
       showToast(`${cap.icon} ${cap.label} — por lanzar`);
+      return;
+    }
+    if (health === 'down') {
+      showToast(`${cap.icon} ${cap.label} — no disponible sin conexión al servidor`);
       return;
     }
     if (onPick) onPick(cap);
@@ -1027,15 +1060,18 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
 
         {GROUPS.map((g, i) =>
           g.leaves.map((cap, j) => {
-            const soon = cap.status === 'soon';
+            const health = capabilityHealth.get(cap.id) || 'live';
+            const isSoon = health === 'soon';
+            const isDown = health === 'down';
+            const dimmed = isSoon || isDown;
             return (
               <div
                 key={cap.id}
-                className={`arm-node arm-leaf${soon ? ' arm-soon' : ''}`}
+                className={`arm-node arm-leaf${isSoon ? ' arm-soon' : ''}${isDown ? ' arm-down' : ''}`}
                 role="button"
-                tabIndex={soon ? -1 : 0}
-                aria-label={soon ? `${cap.label} (por lanzar)` : cap.label}
-                aria-disabled={soon || disabled || undefined}
+                tabIndex={dimmed ? -1 : 0}
+                aria-label={isSoon ? `${cap.label} (por lanzar)` : isDown ? `${cap.label} (sin conexión al servidor)` : cap.label}
+                aria-disabled={dimmed || disabled || undefined}
                 data-arm-leaf={`${i}-${j}`}
                 style={{ display: 'none' }}
                 onClick={(ev) => handleLeafTap(ev, cap)}
@@ -1054,10 +1090,16 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
                 </div>
                 <div className="arm-lbl">
                   {cap.label}
-                  {soon && (
+                  {isSoon && (
                     <>
                       <br />
                       <span className="arm-badge">por lanzar</span>
+                    </>
+                  )}
+                  {isDown && (
+                    <>
+                      <br />
+                      <span className="arm-badge arm-badge-down">sin servidor</span>
                     </>
                   )}
                 </div>

--- a/src/services/__tests__/capabilityHealth.test.js
+++ b/src/services/__tests__/capabilityHealth.test.js
@@ -2,7 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../db/dbCore', () => ({ openDB: () => Promise.resolve({}) }));
 
-import { checkCapabilityHealth, hasCriticalFailure, getDegradedCapabilities } from '../capabilityHealth';
+import {
+  checkCapabilityHealth,
+  hasCriticalFailure,
+  getDegradedCapabilities,
+  getCapabilityHealth,
+  SIDECAR_TOOL_NAMES,
+} from '../capabilityHealth';
+import { CAPABILITY_MANIFEST } from '../agentCapabilities';
+
+const makeDeps = (overrides = {}) => ({
+  manifest: overrides.manifest ?? CAPABILITY_MANIFEST,
+  isSidecarEnabled: overrides.isSidecarEnabled ?? true,
+  sidecarToolNames: overrides.sidecarToolNames ?? SIDECAR_TOOL_NAMES,
+});
 
 describe('checkCapabilityHealth', () => {
   beforeEach(() => {
@@ -32,5 +45,89 @@ describe('getDegradedCapabilities', () => {
   it('filtra solo no-ok', () => {
     const r = getDegradedCapabilities([{ status: 'ok' }, { status: 'down' }, { status: 'degraded' }]);
     expect(r).toHaveLength(2);
+  });
+});
+
+describe('getCapabilityHealth — estado real por capacidad', () => {
+  it('SIDECAR_TOOL_NAMES contiene las tools que dependen del sidecar', () => {
+    expect(SIDECAR_TOOL_NAMES.has('get_species')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_biopreparados')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_clima_ideam')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_pest_controllers')).toBe(true);
+    // Locales/offline NO están
+    expect(SIDECAR_TOOL_NAMES.has('assets')).toBe(false);
+    expect(SIDECAR_TOOL_NAMES.has('voice_capture')).toBe(false);
+    expect(SIDECAR_TOOL_NAMES.has('farm_process')).toBe(false);
+  });
+
+  it('capacidades offline-first retornan live siempre', () => {
+    const deps = makeDeps({ isSidecarEnabled: false });
+    expect(getCapabilityHealth('plantas', deps)).toBe('live');
+    expect(getCapabilityHealth('tareas', deps)).toBe('live');
+    expect(getCapabilityHealth('observaciones', deps)).toBe('live');
+    expect(getCapabilityHealth('mapa', deps)).toBe('live');
+    expect(getCapabilityHealth('historial', deps)).toBe('live');
+    expect(getCapabilityHealth('biodiversidad', deps)).toBe('live');
+    expect(getCapabilityHealth('ciclo', deps)).toBe('live');
+    expect(getCapabilityHealth('procesos', deps)).toBe('live');
+    expect(getCapabilityHealth('voz', deps)).toBe('live');
+    expect(getCapabilityHealth('foto', deps)).toBe('live');
+  });
+
+  it('capacidades sidecar-dependent retornan live con sidecar habilitado', () => {
+    const deps = makeDeps({ isSidecarEnabled: true });
+    expect(getCapabilityHealth('siembro', deps)).toBe('live');
+    expect(getCapabilityHealth('plaga', deps)).toBe('live');
+    expect(getCapabilityHealth('biopreparado', deps)).toBe('live');
+    expect(getCapabilityHealth('clima', deps)).toBe('live');
+    expect(getCapabilityHealth('calendario', deps)).toBe('live');
+  });
+
+  it('capacidades sidecar-dependent retornan down con sidecar deshabilitado', () => {
+    const deps = makeDeps({ isSidecarEnabled: false });
+    expect(getCapabilityHealth('siembro', deps)).toBe('down');
+    expect(getCapabilityHealth('plaga', deps)).toBe('down');
+    expect(getCapabilityHealth('biopreparado', deps)).toBe('down');
+    expect(getCapabilityHealth('clima', deps)).toBe('down');
+    expect(getCapabilityHealth('calendario', deps)).toBe('down');
+  });
+
+  it('precio retorna soon (explicito en manifest)', () => {
+    const deps = makeDeps({ isSidecarEnabled: true });
+    expect(getCapabilityHealth('precio', deps)).toBe('soon');
+    // sidecar no afecta: aunque este habilitado, el manifest dice soon
+    const depsOff = makeDeps({ isSidecarEnabled: false });
+    expect(getCapabilityHealth('precio', depsOff)).toBe('soon');
+  });
+
+  it('deep retorna live (sin dependencia de sidecar)', () => {
+    expect(getCapabilityHealth('deep', makeDeps({ isSidecarEnabled: false }))).toBe('live');
+    expect(getCapabilityHealth('deep', makeDeps({ isSidecarEnabled: true }))).toBe('live');
+  });
+
+  it('alertas-cultivo retorna live (sin dependencia de sidecar)', () => {
+    expect(getCapabilityHealth('alertas-cultivo', makeDeps({ isSidecarEnabled: false }))).toBe('live');
+  });
+
+  it('capacidad desconocida retorna live (degradacion segura)', () => {
+    expect(getCapabilityHealth('capacidad-que-no-existe', makeDeps({}))).toBe('live');
+  });
+
+  it('sin manifest (null/undefined) retorna live', () => {
+    expect(getCapabilityHealth('siembro', makeDeps({ manifest: [] }))).toBe('live');
+    expect(getCapabilityHealth('plaga', makeDeps({ manifest: null }))).toBe('live');
+  });
+
+  it('sidecarToolNames vacio trata todas como offline (live)', () => {
+    const deps = makeDeps({ isSidecarEnabled: false, sidecarToolNames: new Set() });
+    expect(getCapabilityHealth('siembro', deps)).toBe('live');
+  });
+
+  it('acepta sidecarToolNames como Set o array-like', () => {
+    const setDeps = makeDeps({ isSidecarEnabled: false, sidecarToolNames: new Set(['get_species']) });
+    expect(getCapabilityHealth('siembro', setDeps)).toBe('down');
+
+    const arrDeps = makeDeps({ isSidecarEnabled: false, sidecarToolNames: ['get_species'] });
+    expect(getCapabilityHealth('siembro', arrDeps)).toBe('down');
   });
 });

--- a/src/services/capabilityHealth.js
+++ b/src/services/capabilityHealth.js
@@ -6,6 +6,33 @@
  */
 
 /**
+ * Tools que dependen del sidecar MCP agro (ALLOWED_TOOLS en sidecarClient).
+ * Si el sidecar está caído/deshabilitado, las capacidades que usan estas
+ * tools se marcan 'down'. Las capacidades con tools NO listadas acá son
+ * offline-first y siempre están 'live'.
+ */
+export const SIDECAR_TOOL_NAMES = new Set([
+  'get_species',
+  'get_companions',
+  'get_biopreparados',
+  'get_pest_controllers',
+  'get_multihop_companions',
+  'get_subgrafo_relacional',
+  'get_diseno_restauracion',
+  'validate_visual_match',
+  'validate_taxonomy',
+  'get_normativa_ica',
+  'get_clima_ideam',
+  'get_precio_sipsa',
+  'get_enso_status',
+  'get_alertas_clima_zona',
+  'get_saberes',
+  'get_toxicidad',
+  'get_variedades',
+  'get_suelo',
+]);
+
+/**
  * @typedef {Object} CapabilityStatus
  * @property {string} name — nombre legible
  * @property {'ok'|'degraded'|'down'} status
@@ -67,4 +94,49 @@ export function hasCriticalFailure(statuses) {
  */
 export function getDegradedCapabilities(statuses) {
   return statuses.filter((s) => s.status !== 'ok');
+}
+
+/**
+ * Determina el estado real de una capacidad individual.
+ *
+ * Reglas determinísticas, sin side-effects ocultos:
+ * 1. Si el manifest marca `status: 'soon'` → 'soon' (futura).
+ * 2. Si la tool de la capacidad está en `sidecarToolNames` y el sidecar
+ *    NO está habilitado → 'down' (dependencia rota).
+ * 3. En cualquier otro caso → 'live' (offline-first o sidecar activo).
+ *
+ * Degradación segura: si el capabilityId no está en el manifest,
+ * retorna 'live' (asume offline-first, no rompe el menú).
+ *
+ * @param {string} capabilityId — id de la capacidad (ej. 'siembro')
+ * @param {Object} deps — dependencias inyectadas (testeable)
+ * @param {Array<{id:string, status:string, tool:string|null}>} [deps.manifest]
+ * @param {boolean} [deps.isSidecarEnabled=true]
+ * @param {Set<string>|Array<string>} [deps.sidecarToolNames]
+ * @returns {'live'|'soon'|'down'}
+ */
+export function getCapabilityHealth(capabilityId, deps = {}) {
+  const {
+    manifest = [],
+    isSidecarEnabled = false,
+    sidecarToolNames = SIDECAR_TOOL_NAMES,
+  } = deps;
+
+  const toolsSet = sidecarToolNames instanceof Set
+    ? sidecarToolNames
+    : new Set(sidecarToolNames);
+
+  const cap = Array.isArray(manifest)
+    ? manifest.find((c) => c.id === capabilityId)
+    : null;
+
+  if (!cap) return 'live';
+
+  if (cap.status === 'soon') return 'soon';
+
+  if (cap.tool && toolsSet.has(cap.tool) && !isSidecarEnabled) {
+    return 'down';
+  }
+
+  return 'live';
 }


### PR DESCRIPTION
## `getCapabilityHealth` — estado REAL por capacidad en la araña

### Servicio puro (`capabilityHealth.js`)

```js
getCapabilityHealth(capabilityId, { manifest, isSidecarEnabled, sidecarToolNames })
// → 'live' | 'soon' | 'down'
```

- **Determinístico y testeable**: recibe todas sus dependencias por parámetro (sin side-effects ocultos)
- **Reglas**:
  - `manifest.status === 'soon'` → `'soon'` (futura, ej. `precio`)
  - `cap.tool` en `sidecarToolNames` + sidecar deshabilitado → `'down'`
  - Todo lo demás → `'live'` (offline-first o sidecar activo)
- **`SIDECAR_TOOL_NAMES`**: constante exportada con las 18 tools que dependen del sidecar MCP agro. Capacidades con tools NO listadas (plantas, tareas, mapa, voz, foto, ciclo, procesos, etc.) son offline-first → siempre `'live'`
- **Degradación**: capabilityId desconocido, manifest vacío, o error → `'live'` (el menú nunca se rompe)

### Wiring en AgentRedMenu.jsx

| Punto | Antes | Ahora |
|---|---|---|
| Leaf setup (engine) | `soon: cap.status === 'soon'` | `soon/down` desde `capabilityHealth.get(cap.id)` |
| `handleLeafTap` | solo toast para `'soon'` | toast diferenciado: `'soon'` ("por lanzar") y `'down'` ("no disponible sin conexión al servidor") |
| JSX rendering | clase `arm-soon` + badge "por lanzar" | + clase `arm-down` + badge "sin servidor" + aria-label honesto |
| CSS | solo `.arm-soon` | + `.arm-down` (orb punteado opacity .55, label opacity .6, badge-down color warn) |

Sin romper el diseño de la araña (#1404) — solo se conecta el estado real a las clases y badges existentes.

### Tests

```
npx vitest run (26 tests, 2 files)
 Test Files  2 passed (2)
      Tests  26 passed (33)
```

| Archivo | Tests | Cobertura |
|---|---|---|
| `capabilityHealth.test.js` | 14 | offline-first → live, sidecar-dep → live/down, soon, degradación, Set/array |
| `AgentRedMenu.smoke.test.jsx` | 12 | renderiza, no duplica Ⓐ, ancla, todos los tests de humo existentes |

eslint `--max-warnings=0` OK
