### PR TITLE
feat(voz): flujo de voz punta-a-punta con estados visibles para baja alfabetización

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { ArrowLeft, Mic, MicOff, Send, Sparkles, Wifi, WifiOff, Volume2, VolumeX, RotateCcw, X, Home, Camera, Square } from 'lucide-react';
 import useVoiceRecorder from '../../hooks/useVoiceRecorder';
-import { transcribe } from '../../services/voiceService';
+import { transcribe, queueForRetry } from '../../services/voiceService';
+import VoiceStatusStrip from './VoiceStatusStrip';
 import {
   claimNext as outboxClaimNext,
   markAnswered as outboxMarkAnswered,
@@ -87,7 +88,7 @@ import { mergePartialOnInterruption } from '../../services/agentPartialMerge';
 // comparten el mismo snapshot via `climaService` (cache 30 min).
 import { getCachedClimaSnapshot, fetchClimaSnapshot, resolveClimaLocation } from '../../services/climaService';
 import { FARM_CONFIG } from '../../config/defaults';
-import { speak, speakSentences, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking } from '../../services/ttsService';
+import { speak, speakSentences, stop, init as initTTS, isSupported, isKokoroAvailable, replayLast, isSpeaking, onSpeakingChange, isAudioPlaying, getLastSpoken } from '../../services/ttsService';
 import { executeAction, setActionGateCallback } from '../../services/actionExecutor';
 import { getToolsForLLM } from '../../services/llmTools';
 import { useRotatingTip } from '../../services/tipsService';
@@ -170,6 +171,15 @@ export default function AgentScreen({ onBack, initialContext }) {
   const [feedbackConsentModal, setFeedbackConsentModal] = useState({ isOpen: false, pendingAction: null });
   const ttsSupported = isSupported();
   const [kokoroReady, setKokoroReady] = useState(false);
+  // TIER 2 #5 (voz punta-a-punta): estado "hablando" observable. ttsService
+  // notifica true/false cuando arranca/termina audio (Kokoro single, cadena
+  // frase-por-frase, Web Speech). Alimenta el VoiceStatusStrip y el sub-
+  // título del header — el campesino VE cuándo Chagra habla, no lo adivina.
+  const [isVoicePlaying, setIsVoicePlaying] = useState(false);
+  // Aviso amable de degradación de voz (STT/TTS caído): NUNCA error mudo y
+  // NUNCA banner rojo de error — el flujo cae a texto sin romper.
+  const [voiceNotice, setVoiceNotice] = useState('');
+  useEffect(() => onSpeakingChange(setIsVoicePlaying), []);
   // Bug 2026-05-18 (Karen reportó stuck-pensando): tras 20s sin token visible,
   // mostrar mensaje "Aún pensando, toca cancelar si quieres reintentar" y
   // habilitar botón cancelar que dispara AbortController. Si pasan 30s sin
@@ -1720,14 +1730,28 @@ export default function AgentScreen({ onBack, initialContext }) {
 
       if (ttsEnabled && response) {
         stop();
+        // TIER 2 #5: degradación amable. Si TODO el stack de voz falla
+        // (Kokoro caído + Web Speech ausente), avisamos en el strip — la
+        // respuesta YA está escrita arriba, nada se rompe ni queda mudo.
+        // Damos 1.2s de gracia porque Web Speech puede demorar el onstart.
+        const warnIfMute = () => {
+          setTimeout(() => {
+            if (!isAudioPlaying() && !isSpeaking()) {
+              setVoiceNotice('Ahora no puedo hablarte — te dejé la respuesta escrita aquí arriba.');
+            }
+          }, 1200);
+        };
         if (kokoroReady) {
           // Free 7→10 fix-pack #4: streaming frase-por-frase reduce la
           // latencia hasta-primer-audio de "esperar respuesta entera"
           // (3-23s) a "esperar primera frase" (<2s). Internamente fallback
           // a speakKokoro/speak en caso de error en la primera frase.
-          speakSentences(response, { rate: 0.9, pitch: 1.0 });
+          speakSentences(response, { rate: 0.9, pitch: 1.0 })
+            .then((ok) => { if (!ok) warnIfMute(); })
+            .catch(() => warnIfMute());
         } else {
-          speak(response, { rate: 0.9, pitch: 1.0 });
+          const utterance = speak(response, { rate: 0.9, pitch: 1.0 });
+          if (!utterance) warnIfMute();
         }
       }
 
@@ -2164,17 +2188,32 @@ export default function AgentScreen({ onBack, initialContext }) {
           await handleSubmit(text, { fromVoice: true });
         } else {
           setState(STATE_IDLE);
-          setError('No entendí el audio. Prueba de nuevo.');
+          setVoiceNotice('No te entendí bien. Intenta de nuevo, o escribe tu pregunta aquí abajo.');
         }
-        } catch (err) {
-          setState(STATE_IDLE);
-          setError(`Error al transcribir audio: ${err.message || 'Habla más claro'}`);
+      } catch (err) {
+        // TIER 2 #5 degradación: Whisper caído NO rompe el flujo ni grita en
+        // rojo. (1) Guardamos el audio para reintento cuando vuelva el
+        // servicio (pending_voice_recordings), (2) avisamos amable y dejamos
+        // el teclado como camino. Nunca error mudo.
+        setState(STATE_IDLE);
+        queueForRetry(blob, {
+          reason: err?.message || 'whisper failed',
+          durationMs: result.durationMs || 0,
+        }).catch(() => {});
+        setVoiceNotice('No pude escucharte esta vez — guardé tu audio para reintentarlo. Mientras tanto puedes escribir tu pregunta aquí abajo.');
       }
     } else {
       resetRecord();
-      startRecord();
+      // Permiso de micrófono denegado / sin MediaRecorder → degradar a texto
+      // con aviso amable (antes: unhandled rejection silenciosa).
+      startRecord().catch((err) => {
+        console.warn('[Agent] no se pudo iniciar grabación:', err?.message);
+        setState(STATE_IDLE);
+        setVoiceNotice('No pude usar el micrófono. Revisa el permiso del navegador, o escribe tu pregunta aquí abajo.');
+      });
       setState(STATE_RECORDING);
       setError('');
+      setVoiceNotice('');
       agentSounds.listen();
     }
   };
@@ -2354,7 +2393,18 @@ export default function AgentScreen({ onBack, initialContext }) {
           { role: 'user', content: '🎤 Audio enviado…', timestamp: Date.now(), _outboxPending: true, _outboxId: item.id },
         ]);
         if (!ttsEnabled) setTtsEnabled(true);
-        const text = item.blob ? await transcribe(item.blob) : '';
+        let text = '';
+        try {
+          text = item.blob ? await transcribe(item.blob) : '';
+        } catch (sttErr) {
+          // TIER 2 #5 degradación: Whisper caído NO rompe el flujo. Guardamos
+          // el audio para reintento + aviso amable (sin banner rojo).
+          setMessages((prev) => prev.filter((m) => m._outboxId !== item.id));
+          if (item.blob) queueForRetry(item.blob, { reason: sttErr?.message || 'whisper failed' }).catch(() => {});
+          setVoiceNotice('No pude escuchar tu audio esta vez — lo guardé para reintentarlo. Mientras tanto puedes escribir tu pregunta.');
+          await outboxMarkError(item.id, sttErr?.message || 'transcripción falló');
+          return false;
+        }
         // Sustituir el placeholder por la transcripción real (sin duplicar).
         setMessages((prev) => prev.filter((m) => m._outboxId !== item.id));
         if (text && text.trim()) {
@@ -2362,7 +2412,7 @@ export default function AgentScreen({ onBack, initialContext }) {
           await outboxMarkAnswered(item.id, { answeredText: text.trim() });
           return true;
         }
-        setError('No entendí el audio. Prueba de nuevo desde el agente.');
+        setVoiceNotice('No te entendí bien. Intenta de nuevo, o escribe tu pregunta aquí abajo.');
         await outboxMarkError(item.id, 'transcripción vacía');
         return false;
       }
@@ -2525,7 +2575,7 @@ export default function AgentScreen({ onBack, initialContext }) {
         </button>
         {/* Avatar + título */}
         <ChagraAgentAvatarColibriPhoto
-          state={state === STATE_RECORDING ? 'listening' : state === STATE_THINKING ? 'thinking' : 'idle'}
+          state={state === STATE_RECORDING ? 'listening' : (state === STATE_THINKING || isVoicePlaying) ? 'thinking' : 'idle'}
           size={36}
           onDoubleClick={async () => {
             if (isSpeaking() || ttsEnabled) {
@@ -2539,11 +2589,17 @@ export default function AgentScreen({ onBack, initialContext }) {
         />
         <div className="flex-1 min-w-0">
           <h1 className="text-sm font-bold text-white leading-tight truncate">Chagra IA</h1>
-          <p className="text-[10px] font-semibold uppercase tracking-wider leading-tight"
-             style={{ color: state === STATE_THINKING ? '#f59e0b' : state === STATE_RECORDING ? '#a78bfa' : '#6ee7b7' }}>
+          {/* Theme-aware (2026-06-10): clases Tailwind (van por --c-*) en vez
+              de hex inline que ignoraba los temas. + estado "hablando". */}
+          <p className={`text-[10px] font-semibold uppercase tracking-wider leading-tight ${
+            state === STATE_THINKING ? 'text-amber-500'
+              : state === STATE_RECORDING ? 'text-violet-400'
+              : isVoicePlaying ? 'text-emerald-400'
+              : 'text-emerald-300'
+          }`}>
             {state === STATE_THINKING && 'pensando…'}
             {state === STATE_RECORDING && 'escuchando…'}
-            {state === STATE_IDLE && 'agente agroecológico'}
+            {state === STATE_IDLE && (isVoicePlaying ? 'hablando…' : 'agente agroecológico')}
           </p>
         </div>
         {/* Acciones: nueva conversación + TTS + online badge */}
@@ -2745,6 +2801,31 @@ export default function AgentScreen({ onBack, initialContext }) {
           <p className="text-xs text-red-400 mb-2 px-1">{agentPickError}</p>
         )}
 
+        {/* TIER 2 #5 — estado de VOZ evidente para baja alfabetización:
+            "Chagra te escucha / está pensando / está hablando" con ícono+
+            animación, botón Parar mientras habla, botón GRANDE "Volver a oír"
+            cuando ya hay una respuesta hablada, y aviso amable si el oído
+            (Whisper) o la voz (Kokoro/Web Speech) se degradan. */}
+        <VoiceStatusStrip
+          phase={
+            state === STATE_RECORDING ? 'listening'
+              : state === STATE_THINKING ? 'thinking'
+              : isVoicePlaying ? 'speaking'
+              : 'idle'
+          }
+          canRepeat={Boolean(getLastSpoken())}
+          notice={voiceNotice}
+          onRepeat={async () => {
+            setVoiceNotice('');
+            const ok = await replayLast({ useKokoro: kokoroReady });
+            if (!ok) {
+              setVoiceNotice('No pude repetir la respuesta — la tienes escrita aquí arriba.');
+            }
+          }}
+          onStopSpeaking={() => { stop(); agentSounds.cancel(); }}
+          onDismissNotice={() => setVoiceNotice('')}
+        />
+
         {/* Pill — unified with AgentHero (as-bar CSS tokens) */}
         <div
           className={[
@@ -2762,6 +2843,9 @@ export default function AgentScreen({ onBack, initialContext }) {
               </span>
               <span className="flex-1 text-sm text-rose-400 font-medium tabular-nums">
                 Grabando… {Math.floor(durationMs / 1000)}s
+                <span className="block text-[11px] text-rose-300/80 font-normal">
+                  Habla tranquilo. Toca el botón rojo cuando termines.
+                </span>
               </span>
             </div>
           ) : (
@@ -2822,18 +2906,22 @@ export default function AgentScreen({ onBack, initialContext }) {
 
             <div className="flex-1" />
 
-            {/* Micrófono (toggle) */}
+            {/* Micrófono (toggle) — GRANDE (TIER 2 #5): el camino principal
+                del campesino que casi no lee es HABLAR, no escribir. 54px
+                con anillo de acento; en grabación se vuelve el botón rojo
+                de "detener y enviar". */}
             <button
               type="button"
               onClick={handleVoiceRecord}
               disabled={queuePending.length >= 1}
-              aria-label={state === STATE_RECORDING ? 'Detener y enviar audio' : 'Grabar audio'}
+              aria-label={state === STATE_RECORDING ? 'Detener y enviar audio' : 'Hablar con Chagra'}
               aria-pressed={state === STATE_RECORDING}
-              className={['as-iconbtn', state === STATE_RECORDING ? 'as-mic-on' : ''].join(' ')}
+              data-testid="agent-mic-btn"
+              className={['as-iconbtn as-mic-big', state === STATE_RECORDING ? 'as-mic-on' : ''].join(' ')}
             >
               {state === STATE_RECORDING
-                ? <Square size={15} strokeWidth={2.5} />
-                : <Mic size={17} strokeWidth={2} />}
+                ? <Square size={20} strokeWidth={2.5} />
+                : <Mic size={24} strokeWidth={2} />}
             </button>
 
             {/* Enviar — ChagraAgentAvatar idéntico al Home */}

--- a/src/components/AgentScreen/VoiceStatusStrip.jsx
+++ b/src/components/AgentScreen/VoiceStatusStrip.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { Mic, Volume2, Square, Info, X } from 'lucide-react';
+
+/**
+ * VoiceStatusStrip — superficie de estado del flujo de VOZ punta-a-punta
+ * (TIER 2 #5, 2026-06-10) para baja alfabetización.
+ *
+ * El campesino que casi no lee debe ENTENDER de un vistazo qué está pasando
+ * cuando le habla a Chagra. Tres estados evidentes con ícono+animación (no
+ * solo texto), más el botón GRANDE "Volver a oír" y el aviso amable de
+ * degradación cuando el oído (Whisper) o la voz (Kokoro/Web Speech) fallan:
+ *
+ *   - listening → "Chagra te escucha"  (mic con ondas)
+ *   - thinking  → "Chagra está pensando" (puntos que respiran)
+ *   - speaking  → "Chagra está hablando" (ecualizador animado) + Parar
+ *   - idle + canRepeat → botón "Volver a oír" (replayLast)
+ *   - notice    → degradación amable: nunca error mudo, nunca pantalla rota
+ *
+ * Theme-aware: SOLO clases Tailwind (slate/emerald/amber/rose/violet van por
+ * la indirección CSS-var --c-*) y `currentColor` en las animaciones. Cero
+ * hex hardcodeado. Respeta prefers-reduced-motion (las keyframes custom se
+ * apagan vía @media).
+ */
+
+// Ecualizador de "hablando": 4 barras que suben/bajan con currentColor.
+// Inyectado una vez por render del strip — string estático, costo nulo.
+const STRIP_CSS = `
+@keyframes vsb-eq {
+  0%, 100% { transform: scaleY(0.35); }
+  50% { transform: scaleY(1); }
+}
+.vsb-eq-bar {
+  display: inline-block; width: 4px; height: 18px; border-radius: 2px;
+  background: currentColor; transform-origin: 50% 100%;
+  animation: vsb-eq 0.9s ease-in-out infinite;
+}
+@keyframes vsb-dot {
+  0%, 100% { opacity: 0.25; transform: scale(0.8); }
+  50% { opacity: 1; transform: scale(1); }
+}
+.vsb-dot {
+  display: inline-block; width: 8px; height: 8px; border-radius: 9999px;
+  background: currentColor; animation: vsb-dot 1.2s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .vsb-eq-bar, .vsb-dot { animation: none !important; }
+}
+`;
+
+function Equalizer() {
+  return (
+    <span className="flex items-end gap-[3px] h-[18px]" aria-hidden="true">
+      {[0, 1, 2, 3].map((i) => (
+        <span key={i} className="vsb-eq-bar" style={{ animationDelay: `${i * 0.14}s` }} />
+      ))}
+    </span>
+  );
+}
+
+function ThinkingDots() {
+  return (
+    <span className="flex items-center gap-1.5" aria-hidden="true">
+      {[0, 1, 2].map((i) => (
+        <span key={i} className="vsb-dot" style={{ animationDelay: `${i * 0.22}s` }} />
+      ))}
+    </span>
+  );
+}
+
+export default function VoiceStatusStrip({
+  phase = 'idle',
+  canRepeat = false,
+  notice = '',
+  onRepeat,
+  onStopSpeaking,
+  onDismissNotice,
+}) {
+  const isListening = phase === 'listening';
+  const isThinking = phase === 'thinking';
+  const isSpeaking = phase === 'speaking';
+  const showRepeat = phase === 'idle' && canRepeat && typeof onRepeat === 'function';
+  const showNotice = typeof notice === 'string' && notice.length > 0;
+
+  if (!isListening && !isThinking && !isSpeaking && !showRepeat && !showNotice) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 pb-1" data-testid="voice-status-strip">
+      <style>{STRIP_CSS}</style>
+
+      {/* Estado activo: ícono + animación + frase corta, grande y legible */}
+      {(isListening || isThinking || isSpeaking) && (
+        <div
+          className={`flex items-center gap-3 rounded-2xl px-4 py-3 border ${
+            isListening
+              ? 'bg-rose-900/30 border-rose-700/50 text-rose-300'
+              : isThinking
+                ? 'bg-violet-900/30 border-violet-700/50 text-violet-300'
+                : 'bg-emerald-900/30 border-emerald-700/50 text-emerald-300'
+          }`}
+        >
+          <span className="shrink-0 flex items-center justify-center w-9 h-9 rounded-full bg-slate-900/60">
+            {isListening && <Mic size={20} className="animate-pulse" aria-hidden="true" />}
+            {isThinking && <ThinkingDots />}
+            {isSpeaking && <Equalizer />}
+          </span>
+          <p
+            className="flex-1 text-base font-bold leading-tight"
+            data-testid="voice-state-label"
+            aria-live="polite"
+          >
+            {isListening && 'Chagra te escucha'}
+            {isThinking && 'Chagra está pensando'}
+            {isSpeaking && 'Chagra está hablando'}
+          </p>
+          {isSpeaking && typeof onStopSpeaking === 'function' && (
+            <button
+              type="button"
+              onClick={onStopSpeaking}
+              data-testid="voice-stop-btn"
+              aria-label="Parar la voz de Chagra"
+              className="shrink-0 flex items-center gap-1.5 px-3 min-h-[44px] rounded-full bg-slate-800 hover:bg-slate-700 active:scale-95 text-slate-200 text-sm font-bold border border-slate-600 transition-all"
+            >
+              <Square size={14} strokeWidth={2.5} aria-hidden="true" />
+              Parar
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Botón GRANDE "Volver a oír" — re-reproduce la última respuesta */}
+      {showRepeat && (
+        <button
+          type="button"
+          onClick={onRepeat}
+          data-testid="voice-repeat-btn"
+          aria-label="Volver a oír la última respuesta de Chagra"
+          className="w-full min-h-[52px] mt-1 flex items-center justify-center gap-2.5 rounded-2xl bg-emerald-900/40 hover:bg-emerald-800/50 active:scale-[0.99] text-emerald-200 text-base font-bold border border-emerald-700/60 transition-all"
+        >
+          <Volume2 size={20} aria-hidden="true" />
+          Volver a oír
+        </button>
+      )}
+
+      {/* Aviso amable de degradación (STT/TTS caído) — nunca error mudo */}
+      {showNotice && (
+        <div
+          className="flex items-start gap-2 mt-1.5 px-3 py-2.5 rounded-xl bg-amber-900/30 border border-amber-800/50"
+          role="status"
+          aria-live="polite"
+        >
+          <Info size={15} className="text-amber-400 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="flex-1 text-xs text-amber-200 leading-snug" data-testid="voice-notice">
+            {notice}
+          </p>
+          {typeof onDismissNotice === 'function' && (
+            <button
+              type="button"
+              onClick={onDismissNotice}
+              data-testid="voice-notice-dismiss"
+              aria-label="Cerrar aviso"
+              className="shrink-0 p-1 rounded-md hover:bg-white/10 text-amber-400"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AgentScreen/__tests__/VoiceStatusStrip.test.jsx
+++ b/src/components/AgentScreen/__tests__/VoiceStatusStrip.test.jsx
@@ -1,0 +1,73 @@
+/**
+ * Tests para VoiceStatusStrip (TIER 2 #5 — voz punta-a-punta).
+ *
+ * El strip es la superficie de estado de voz para baja alfabetización:
+ * estados visuales evidentes con ícono+animación, no solo texto:
+ *   - listening → "Chagra te escucha"
+ *   - thinking  → "Chagra está pensando"
+ *   - speaking  → "Chagra está hablando" + botón Parar
+ *   - idle + canRepeat → botón GRANDE "Volver a oír"
+ *   - notice    → aviso amable de degradación (STT/TTS caído) + cerrar
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VoiceStatusStrip from '../VoiceStatusStrip.jsx';
+
+describe('VoiceStatusStrip — estados de voz para baja alfabetización', () => {
+  it('phase=listening muestra "Chagra te escucha" con aria-live', () => {
+    render(<VoiceStatusStrip phase="listening" />);
+    const strip = screen.getByTestId('voice-status-strip');
+    expect(strip).toBeTruthy();
+    expect(screen.getByText(/Chagra te escucha/i)).toBeTruthy();
+    const label = screen.getByTestId('voice-state-label');
+    expect(label.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('phase=thinking muestra "Chagra está pensando"', () => {
+    render(<VoiceStatusStrip phase="thinking" />);
+    expect(screen.getByText(/Chagra está pensando/i)).toBeTruthy();
+  });
+
+  it('phase=speaking muestra "Chagra está hablando" + botón Parar que dispara onStopSpeaking', () => {
+    const onStop = vi.fn();
+    render(<VoiceStatusStrip phase="speaking" onStopSpeaking={onStop} />);
+    expect(screen.getByText(/Chagra está hablando/i)).toBeTruthy();
+    const btn = screen.getByTestId('voice-stop-btn');
+    fireEvent.click(btn);
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it('phase=idle + canRepeat muestra botón "Volver a oír" que dispara onRepeat', () => {
+    const onRepeat = vi.fn();
+    render(<VoiceStatusStrip phase="idle" canRepeat onRepeat={onRepeat} />);
+    const btn = screen.getByTestId('voice-repeat-btn');
+    expect(btn.textContent).toMatch(/Volver a oír/i);
+    fireEvent.click(btn);
+    expect(onRepeat).toHaveBeenCalledTimes(1);
+  });
+
+  it('phase=idle sin canRepeat ni notice no renderiza nada', () => {
+    const { container } = render(<VoiceStatusStrip phase="idle" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('notice muestra el aviso amable y el botón de cierre dispara onDismissNotice', () => {
+    const onDismiss = vi.fn();
+    render(
+      <VoiceStatusStrip
+        phase="idle"
+        notice="No pude escucharte esta vez. Escribe tu pregunta abajo o intenta de nuevo."
+        onDismissNotice={onDismiss}
+      />
+    );
+    expect(screen.getByTestId('voice-notice').textContent).toMatch(/No pude escucharte/i);
+    fireEvent.click(screen.getByTestId('voice-notice-dismiss'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('mientras habla NO muestra el botón Volver a oír (evita doble audio)', () => {
+    render(<VoiceStatusStrip phase="speaking" canRepeat onRepeat={() => {}} onStopSpeaking={() => {}} />);
+    expect(screen.queryByTestId('voice-repeat-btn')).toBeNull();
+  });
+});

--- a/src/components/AgentScreen/agentEntrance.js
+++ b/src/components/AgentScreen/agentEntrance.js
@@ -91,6 +91,20 @@ export const AGENT_COMPOSITOR_CSS = `
     background: rgb(244,63,94) !important; border-color: rgb(244,63,94) !important;
     color: #fff !important; box-shadow: 0 4px 14px -4px rgba(244,63,94,0.5);
   }
+  /* TIER 2 #5 (voz punta-a-punta): mic GRANDE — el camino principal para
+     baja alfabetización es hablar. 54px + anillo de acento del TEMA
+     (--t-accent-rgb, con fallback al teal biopunk) que respira suave para
+     invitar al toque. En grabación as-mic-on lo pinta rojo (detener). */
+  .as-mic-big {
+    width: 54px; height: 54px;
+    border-color: rgba(var(--t-accent-rgb, 25, 201, 154), 0.55);
+    color: rgb(var(--t-accent-rgb, 25, 201, 154));
+    animation: as-mic-breathe 3.2s ease-in-out infinite;
+  }
+  @keyframes as-mic-breathe {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(var(--t-accent-rgb, 25, 201, 154), 0.35); }
+    50%      { box-shadow: 0 0 0 7px rgba(var(--t-accent-rgb, 25, 201, 154), 0); }
+  }
   .as-send {
     width: 46px; height: 46px; flex: none; border: none; border-radius: 50%;
     display: flex; align-items: center; justify-content: center; cursor: pointer;
@@ -151,6 +165,7 @@ export const AGENT_COMPOSITOR_CSS = `
   @media (prefers-reduced-motion: reduce) {
     .as-shimmer::after, .as-sending { animation: none !important; }
     .as-tool { animation: none !important; }
+    .as-mic-big { animation: none !important; }
   }
 `;
 

--- a/src/services/__tests__/ttsService.speakingState.test.js
+++ b/src/services/__tests__/ttsService.speakingState.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests para el estado observable de reproducción TTS (TIER 2 #5 — voz
+ * punta-a-punta). El AgentScreen necesita saber CUÁNDO Chagra está hablando
+ * para pintar el estado "hablando" (ícono+animación) al campesino que casi
+ * no lee. ttsService expone:
+ *
+ *   - onSpeakingChange(cb) → unsubscribe — notifica true/false en cambios.
+ *   - isAudioPlaying()     → bool — estado actual (Kokoro Audio o Web Speech).
+ *
+ * Cubre:
+ *   - speakKokoro notifica true al arrancar y false al onended
+ *   - stop() notifica false
+ *   - unsubscribe deja de notificar
+ *   - speak() (Web Speech) notifica vía utterance.onstart/onend
+ *   - speakSentences notifica true al primer audio y false al terminar la cadena
+ *   - no notifica duplicados (solo cambios de estado)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  speak,
+  speakKokoro,
+  speakSentences,
+  stop,
+  onSpeakingChange,
+  isAudioPlaying,
+} from '../ttsService.js';
+
+// Mock Audio: play() resuelve y dispara onended en el próximo tick para
+// simular un audio corto. Guardamos las instancias para control manual.
+const audioInstances = [];
+class MockAudio {
+  constructor(url) {
+    this.url = url;
+    this.paused = true;
+    this.onended = null;
+    this.onerror = null;
+    audioInstances.push(this);
+  }
+  play() {
+    this.paused = false;
+    return Promise.resolve();
+  }
+  pause() {
+    this.paused = true;
+  }
+}
+
+class MockUtterance {
+  constructor(text) {
+    this.text = text;
+    this.onstart = null;
+    this.onend = null;
+    this.onerror = null;
+  }
+}
+
+describe('ttsService — estado observable de reproducción (voz punta-a-punta)', () => {
+  let fetchMock;
+  let originalAudio;
+  let originalCreateObjectURL;
+  let originalRevokeObjectURL;
+  let originalUtterance;
+  let speechSynthesisMock;
+
+  beforeEach(() => {
+    audioInstances.length = 0;
+    localStorage.clear();
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(['fake-audio'], { type: 'audio/opus' }),
+    });
+    globalThis.fetch = fetchMock;
+    originalAudio = globalThis.Audio;
+    globalThis.Audio = MockAudio;
+    originalCreateObjectURL = URL.createObjectURL;
+    originalRevokeObjectURL = URL.revokeObjectURL;
+    URL.createObjectURL = vi.fn(() => `blob:fake-${Math.random()}`);
+    URL.revokeObjectURL = vi.fn();
+    originalUtterance = globalThis.SpeechSynthesisUtterance;
+    globalThis.SpeechSynthesisUtterance = MockUtterance;
+    speechSynthesisMock = {
+      speak: vi.fn(),
+      cancel: vi.fn(),
+      getVoices: vi.fn(() => []),
+      speaking: false,
+      paused: false,
+    };
+    window.speechSynthesis = speechSynthesisMock;
+  });
+
+  afterEach(() => {
+    stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    globalThis.SpeechSynthesisUtterance = originalUtterance;
+    delete window.speechSynthesis;
+    vi.restoreAllMocks();
+  });
+
+  it('speakKokoro notifica true al arrancar y false al onended', async () => {
+    const events = [];
+    const unsub = onSpeakingChange((v) => events.push(v));
+
+    const audio = await speakKokoro('Hola, soy Chagra.');
+    expect(audio).not.toBeNull();
+    expect(events).toContain(true);
+    expect(isAudioPlaying()).toBe(true);
+
+    audio.onended();
+    expect(events[events.length - 1]).toBe(false);
+    expect(isAudioPlaying()).toBe(false);
+    unsub();
+  });
+
+  it('stop() notifica false y resetea isAudioPlaying', async () => {
+    const events = [];
+    const unsub = onSpeakingChange((v) => events.push(v));
+
+    await speakKokoro('Texto de prueba para detener.');
+    expect(isAudioPlaying()).toBe(true);
+
+    stop();
+    expect(isAudioPlaying()).toBe(false);
+    expect(events[events.length - 1]).toBe(false);
+    unsub();
+  });
+
+  it('unsubscribe deja de notificar', async () => {
+    const events = [];
+    const unsub = onSpeakingChange((v) => events.push(v));
+    unsub();
+
+    await speakKokoro('Texto que ya no notifica.');
+    expect(events).toHaveLength(0);
+  });
+
+  it('speak() Web Speech notifica vía utterance.onstart/onend', () => {
+    const events = [];
+    const unsub = onSpeakingChange((v) => events.push(v));
+
+    const utterance = speak('Hola desde Web Speech.');
+    expect(utterance).not.toBeNull();
+
+    utterance.onstart();
+    expect(isAudioPlaying()).toBe(true);
+    expect(events).toContain(true);
+
+    utterance.onend();
+    expect(isAudioPlaying()).toBe(false);
+    expect(events[events.length - 1]).toBe(false);
+    unsub();
+  });
+
+  it('speakSentences notifica true al primer audio y false al terminar la cadena', async () => {
+    const events = [];
+    const unsub = onSpeakingChange((v) => events.push(v));
+
+    // Dos frases largas (>40 chars) para activar el pipeline frase-por-frase.
+    const text =
+      'La primera frase del agente es suficientemente larga para el split. ' +
+      'La segunda frase también supera el umbral mínimo de caracteres.';
+
+    const promise = speakSentences(text);
+    // Dejar que los plays arranquen y terminar cada audio a medida que aparece.
+    for (let guard = 0; guard < 20; guard++) {
+      await new Promise((r) => setTimeout(r, 0));
+      const playing = audioInstances.find((a) => !a.paused && a.onended);
+      if (playing) {
+        playing.paused = true;
+        playing.onended();
+      }
+    }
+    const ok = await promise;
+
+    expect(ok).toBe(true);
+    expect(events[0]).toBe(true); // primer audio de la cadena
+    expect(events).toContain(true);
+    expect(events[events.length - 1]).toBe(false);
+    expect(isAudioPlaying()).toBe(false);
+    unsub();
+  });
+
+  it('no notifica duplicados — solo cambios de estado', async () => {
+    const events = [];
+    const unsub = onSpeakingChange((v) => events.push(v));
+
+    const audio = await speakKokoro('Frase para verificar deduplicación.');
+    audio.onended();
+    stop(); // ya está en false — no debe re-notificar
+
+    const trues = events.filter((v) => v === true).length;
+    const falses = events.filter((v) => v === false).length;
+    expect(trues).toBe(1);
+    expect(falses).toBeLessThanOrEqual(2); // stop() inicial + onended
+    unsub();
+  });
+});

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -286,6 +286,53 @@ let lastSpoken = null;
 let lastSpokenOptions = null;
 
 // ──────────────────────────────────────────────────────────────────────────
+// Estado observable de reproducción (TIER 2 #5 — voz punta-a-punta)
+// ──────────────────────────────────────────────────────────────────────────
+// El campesino que casi no lee necesita VER cuándo Chagra está hablando
+// (estado "hablando" con ícono+animación en AgentScreen). El problema:
+// la reproducción Kokoro vive en elementos Audio internos de este módulo
+// y Web Speech en utterances — nada de eso es observable desde React.
+//
+// Solución mínima: pub/sub de un booleano. notifySpeaking(bool) se llama
+// en los puntos de arranque/fin de audio (Kokoro single, cadena de
+// speakSentences, Web Speech onstart/onend, stop()). Solo notifica en
+// CAMBIOS de estado — sin flicker entre frases de la cadena (la cadena
+// notifica true al primer audio y false al terminar TODA la cadena).
+let audioPlaying = false;
+const speakingListeners = new Set();
+
+function notifySpeaking(value) {
+  if (audioPlaying === value) return;
+  audioPlaying = value;
+  for (const cb of speakingListeners) {
+    try { cb(value); } catch (_) { /* listener roto no tumba el TTS */ }
+  }
+}
+
+/**
+ * Suscripción a cambios del estado "está sonando audio del agente".
+ *
+ * @param {(speaking: boolean) => void} cb
+ * @returns {() => void} unsubscribe
+ */
+export function onSpeakingChange(cb) {
+  if (typeof cb !== 'function') return () => {};
+  speakingListeners.add(cb);
+  return () => speakingListeners.delete(cb);
+}
+
+/**
+ * Estado actual de reproducción (Kokoro Audio o Web Speech). A diferencia
+ * de isSpeaking() (que solo mira window.speechSynthesis), esto también
+ * cubre los Audio elements de Kokoro/XTTS y la cadena de speakSentences.
+ *
+ * @returns {boolean}
+ */
+export function isAudioPlaying() {
+  return audioPlaying;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Streaming sentence-by-sentence (Free 7→10 fix-pack)
 // ──────────────────────────────────────────────────────────────────────────
 // Bug observado: Kokoro TTS CPU es lineal con el largo del texto. Una
@@ -397,6 +444,10 @@ function playSentenceBlob(url) {
     };
     audio.onended = () => { cleanup(); resolve(); };
     audio.onerror = (e) => { cleanup(); reject(e); };
+    // Estado "hablando": true al arrancar la frase. El false lo emite el
+    // FIN DE LA CADENA en speakSentences (no acá) — así no hay flicker
+    // true→false→true entre frase y frase.
+    notifySpeaking(true);
     audio.play().catch((e) => { cleanup(); reject(e); });
   });
 }
@@ -486,26 +537,37 @@ export async function speakSentences(text, options = {}) {
     return r !== null;
   }
 
-  for (let i = 0; i < sentences.length; i++) {
-    if (sentenceQueueCancelled) break;
-    // Disparar prefetch de la siguiente mientras suena la actual
-    const next = i + 1 < sentences.length ? prefetch(i + 1) : null;
-    if (prefetched) {
-      try {
-        await playSentenceBlob(prefetched);
-        firstFrameSucceeded = true;
-      } catch (e) {
-        console.warn('[TTS streaming] playback error frase', i, ':', e?.message || e);
-        // Para frases tardías que fallan, fallback Web Speech por frase.
-        if (i > 0 && !sentenceQueueCancelled) {
-          try { speak(sentences[i], options); } catch (_) { /* ignore */ }
+  // Capturamos NUESTRO controller: si otro speakSentences/stop() arranca
+  // mientras esta cadena sigue viva, el notifySpeaking(false) del final solo
+  // debe emitirse si seguimos siendo la cadena activa (evita clobber del
+  // estado "hablando" de la cadena nueva).
+  const myController = sentenceQueueController;
+
+  try {
+    for (let i = 0; i < sentences.length; i++) {
+      if (sentenceQueueCancelled) break;
+      // Disparar prefetch de la siguiente mientras suena la actual
+      const next = i + 1 < sentences.length ? prefetch(i + 1) : null;
+      if (prefetched) {
+        try {
+          await playSentenceBlob(prefetched);
+          firstFrameSucceeded = true;
+        } catch (e) {
+          console.warn('[TTS streaming] playback error frase', i, ':', e?.message || e);
+          // Para frases tardías que fallan, fallback Web Speech por frase.
+          if (i > 0 && !sentenceQueueCancelled) {
+            try { speak(sentences[i], options); } catch (_) { /* ignore */ }
+          }
         }
       }
+      prefetched = next ? await next : null;
     }
-    prefetched = next ? await next : null;
+  } finally {
+    if (sentenceQueueController === myController) {
+      sentenceQueueController = null;
+      notifySpeaking(false);
+    }
   }
-
-  sentenceQueueController = null;
   return firstFrameSucceeded;
 }
 
@@ -612,6 +674,12 @@ export function speak(text, options = {}) {
 
   utterance.lang = 'es-CO';
 
+  // Estado "hablando" observable (TIER 2 #5): Web Speech expone onstart/
+  // onend/onerror en el utterance — los usamos para notificar a la UI.
+  utterance.onstart = () => notifySpeaking(true);
+  utterance.onend = () => notifySpeaking(false);
+  utterance.onerror = () => notifySpeaking(false);
+
   // Task #122: guardar para replayLast(). Texto vacío no se cachea para
   // evitar replayLast() repitiendo nada cuando el operador hizo speak('').
   if (typeof text === 'string' && text.trim().length > 0) {
@@ -638,6 +706,7 @@ export function stop() {
     URL.revokeObjectURL(currentKokoroUrl);
     currentKokoroUrl = null;
   }
+  notifySpeaking(false);
 }
 
 export function pause() {
@@ -725,12 +794,18 @@ export async function speakKokoro(text, options = {}) {
         currentKokoroAudio = null;
         currentKokoroUrl = null;
       }
+      notifySpeaking(false);
     };
+    audio.onerror = () => notifySpeaking(false);
 
     await audio.play();
+    notifySpeaking(true);
     return audio;
   } catch (e) {
     console.warn('[TTS] Kokoro failed, fallback to Web Speech:', e.message);
+    // Si el play() falló después de notificar, limpiar antes del fallback —
+    // speak() gestionará su propio onstart/onend.
+    notifySpeaking(false);
     speak(text, options);
     return null;
   }
@@ -803,13 +878,17 @@ export async function speakXTTS(text, options = {}) {
         currentKokoroAudio = null;
         currentKokoroUrl = null;
       }
+      notifySpeaking(false);
     };
+    audio.onerror = () => notifySpeaking(false);
 
     await audio.play();
+    notifySpeaking(true);
     return audio;
   } catch (e) {
     // Fallback a Kokoro si XTTS falla (timeout, error HTTP, XTTS not available)
     console.warn('[TTS] XTTS failed, fallback to Kokoro:', e.message);
+    notifySpeaking(false);
     return await speakKokoro(text, options);
   }
 }
@@ -878,6 +957,9 @@ export default {
   isPaused,
   isSupported,
   isKokoroAvailable,
+  // TIER 2 #5: estado observable de reproducción para la UI "hablando".
+  onSpeakingChange,
+  isAudioPlaying,
   getVoices,
   getSpanishVoice,
   replayLast,


### PR DESCRIPTION
## TIER 2 #5 — Voz punta-a-punta

El campesino que casi no lee puede **hablarle** a Chagra y que Chagra le **responda en voz**, con estados visuales evidentes y degradación amable.

### Qué había (reusado, no reinventado)
- Mic en compositor AgentScreen + `useVoiceRecorder` + whisper (`transcribe`, ISO-639-1 base).
- Kokoro con **streaming frase-por-frase** (`speakSentences`: la primera frase suena mientras se sintetiza la siguiente — latencia hasta-primer-audio <2s en vez de esperar toda la respuesta).
- `replayLast` existía pero escondido en un doble-click (gesto invisible para baja alfabetización).

### Qué agrega este PR
1. **Estado "hablando" observable** — `ttsService.onSpeakingChange()` / `isAudioPlaying()`: pub/sub que cubre Kokoro single, la cadena frase-por-frase (true al primer audio, false al final de TODA la cadena, sin flicker) y Web Speech (onstart/onend).
2. **`VoiceStatusStrip`** — los 3 estados con ícono+animación, no solo texto:
   - 🎙️ "Chagra te escucha" (mic pulsante, rose)
   - ⋯ "Chagra está pensando" (puntos que respiran, violet)
   - 🔊 "Chagra está hablando" (ecualizador animado, emerald) + botón **Parar**
   - Botón GRANDE **"Volver a oír"** (52px min-h) cuando ya hay respuesta hablada.
3. **Mic GRANDE** (54px) con anillo de acento del **tema** (`--t-accent-rgb`) que respira; header con "hablando…" y hex inline reemplazado por clases theme-aware.
4. **Degradación offline-first, nunca error mudo**:
   - Whisper caído → audio guardado en `pending_voice_recordings` (`queueForRetry`) + aviso amable + el teclado sigue como camino. También en el path outbox-voice. Permiso de mic denegado ya no es unhandled rejection.
   - Kokoro **y** Web Speech caídos → "Ahora no puedo hablarte — te dejé la respuesta escrita aquí arriba" (1.2s de gracia para el onstart de Web Speech).

### Evidencia (validado EN VIVO, chromium nix-store + fake media stream)
Flujo completo mic → grabar → whisper → agente → kokoro por frases → reproducción → repetir → degradación 503:
capturas `/tmp/voz-shots/{03-escucha,04-piensa,05-habla,06-repetir,08-degradacion-stt}.png` en alpha.

### Tests
- TDD: `ttsService.speakingState.test.js` (6) + `VoiceStatusStrip.test.jsx` (7) escritos antes de implementar.
- Suites tts + AgentScreen: 109/109 verdes. ESLint `--max-warnings=0` limpio.
- Fallos pre-existentes en main (visionCache/sidecarClient/mediaCache, crypto/env) verificados como NO relacionados.

### Theme-aware
Solo Tailwind (`--c-*`), `currentColor` en animaciones y `rgba(var(--t-accent-rgb))`. `prefers-reduced-motion` respetado en todas las animaciones nuevas.

NO mergear sin visto bueno del operador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)