### PR TITLE
fix(rag): tier-gate del corpus ciclo-content contra catalogo activo (SEC-002 / UXC-004)

### DIFF
--- a/src/services/__tests__/ragRetriever.test.js
+++ b/src/services/__tests__/ragRetriever.test.js
@@ -364,3 +364,133 @@ describe('ragRetriever — loadCorpus paralelo-acotado (hotfix prod-down 2026-06
     await expect(prewarmCorpus()).resolves.toBeUndefined();
   });
 });
+
+describe('ragRetriever — tier-gate del catalogo (SEC-002 / UXC-004)', () => {
+  const MANIFEST_GATED = {
+    generated_at: '2026-06-10T00:00:00Z',
+    slugs: ['fragaria_test', 'coffea_test', 'lechuga_test', 'pro_only_1', 'pro_only_2'],
+  };
+
+  const OSS_SPECIES = [
+    { id: 'fragaria_test', nombre_comun: 'Fresa' },
+    { id: 'coffea_test', nombre_comun: 'Café' },
+    { id: 'lechuga_test', nombre_comun: 'Lechuga' },
+    // pro_only_1 y pro_only_2 NO estan en el catalogo OSS
+  ];
+
+  function setupGatedFetchMock() {
+    const tracker = { docFetches: new Set() };
+    globalThis.fetch = vi.fn((url) => {
+      const u = String(url);
+      if (u.endsWith('/cycle-content/manifest.json')) {
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+          json: () => Promise.resolve(MANIFEST_GATED),
+        });
+      }
+      const match = u.match(/\/cycle-content\/([^.]+)\.json/);
+      if (match) {
+        tracker.docFetches.add(match[1]);
+        return Promise.resolve({
+          ok: true, status: 200,
+          headers: { get: (h) => (h.toLowerCase() === 'content-type' ? 'application/json' : '') },
+          json: () => Promise.resolve({
+            species_slug: match[1],
+            valor_pedagogico: `Ficha pedagógica de ${match[1]} con suficiente texto para indexar y recuperar por BM25 en el corpus del retriever.`,
+          }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404, headers: { get: () => '' } });
+    });
+    return tracker;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete globalThis.fetch;
+    vi.clearAllMocks();
+  });
+
+  it('SEC-002 — slugs fuera del catalogo OSS NO se fetchean ni entran al corpus', async () => {
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(OSS_SPECIES),
+    }));
+
+    const tracker = setupGatedFetchMock();
+    const { retrieve } = await import('../ragRetriever.js');
+
+    await retrieve('ficha pedagógica', 5);
+
+    // Solo los 3 slugs del catalogo se fetchearon
+    expect(tracker.docFetches.has('fragaria_test')).toBe(true);
+    expect(tracker.docFetches.has('coffea_test')).toBe(true);
+    expect(tracker.docFetches.has('lechuga_test')).toBe(true);
+    expect(tracker.docFetches.has('pro_only_1')).toBe(false);
+    expect(tracker.docFetches.has('pro_only_2')).toBe(false);
+    expect(tracker.docFetches.size).toBe(3);
+  });
+
+  it('SEC-002 — corpusStats refleja solo los docs dentro del catalogo', async () => {
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(OSS_SPECIES),
+    }));
+
+    setupGatedFetchMock();
+    const { retrieve, getCorpusStats } = await import('../ragRetriever.js');
+
+    await retrieve('ficha pedagógica', 5);
+
+    const stats = await getCorpusStats();
+    // 3 en catalogo, 2 fuera → total debe ser 3
+    expect(stats.totalDocs).toBe(3);
+  });
+
+  it('SEC-002 — si el catalogo falla, carga todos los slugs (degradacion segura)', async () => {
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockRejectedValue(new Error('SQLite no disponible')),
+    }));
+
+    const tracker = setupGatedFetchMock();
+    const { retrieve, getCorpusStats } = await import('../ragRetriever.js');
+
+    await retrieve('ficha pedagógica', 5);
+
+    const stats = await getCorpusStats();
+    // Degradacion: sin catalogo, carga los 5 slugs completos
+    expect(stats.totalDocs).toBe(5);
+    expect(tracker.docFetches.size).toBe(5);
+  });
+
+  it('SEC-002 — catalogo vacio (sin especies) carga todos los slugs', async () => {
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue([]),
+    }));
+
+    const tracker = setupGatedFetchMock();
+    const { retrieve } = await import('../ragRetriever.js');
+
+    await retrieve('ficha pedagógica', 5);
+
+    expect(tracker.docFetches.size).toBe(5);
+  });
+
+  it('SEC-002 — retrieve solo devuelve docs dentro del tier', async () => {
+    vi.doMock('../../db/catalogDB', () => ({
+      getAllSpecies: vi.fn().mockResolvedValue(OSS_SPECIES),
+    }));
+
+    setupGatedFetchMock();
+    const { retrieve } = await import('../ragRetriever.js');
+
+    const hits = await retrieve('ficha pedagógica', 10);
+    // Todos los hits deben ser de especies en el catalogo
+    const catalogSlugs = new Set(OSS_SPECIES.map((s) => s.id));
+    for (const hit of hits) {
+      expect(catalogSlugs.has(hit.species)).toBe(true);
+    }
+  });
+});

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -1,5 +1,6 @@
 import { CROP_TAXONOMY } from '../config/taxonomy';
 import { recordRagEvent } from './ragTelemetry';
+import { getAllSpecies } from '../db/catalogDB';
 
 const CORPUS_PATH = '/cycle-content/';
 
@@ -177,9 +178,29 @@ async function buildCorpus() {
   // Manifest first: si existe, itera solo los slugs presentes.
   // Fallback: iterar CROP_TAXONOMY (legacy, con N-3 fetches fallidos).
   const manifestSlugs = await loadManifest();
-  const species = manifestSlugs ?? Object.values(CROP_TAXONOMY).flatMap((group) =>
+  let species = manifestSlugs ?? Object.values(CROP_TAXONOMY).flatMap((group) =>
     group.species.map((sp) => sp.id)
   );
+
+  // Tier gate (SEC-002 / UXC-004): filtrar slugs contra el catalogo activo.
+  // En OSS el catalogo tiene ~263 especies; el manifest ~491. Los ~296 slugs
+  // sin entrada en el catalogo NO deben groundearse para evitar leak de
+  // contenido Pro a usuarios OSS. Degradacion: si el catalogo falla, se
+  // cargan todos los slugs (mejor grounding completo que ninguno).
+  try {
+    const catalogSpecies = await getAllSpecies();
+    if (catalogSpecies && catalogSpecies.length > 0) {
+      const allowedIds = new Set(catalogSpecies.map((s) => s.id));
+      const before = species.length;
+      species = species.filter((slug) => allowedIds.has(slug));
+      if (before !== species.length) {
+        console.info(`[RAG] Tier gate: ${before} slugs en manifest, ${species.length} dentro del catalogo (${before - species.length} excluidos).`);
+      }
+    }
+  } catch (err) {
+    console.warn('[RAG] No se pudo cargar el catalogo para tier-gate — cargando todos los slugs:', err?.message);
+  }
+
   const docs = [];
 
   // Prefetch PARALELO-ACOTADO: en vez del loop serial que bloqueaba ~3min la


### PR DESCRIPTION
## Tier-gate del RAG — 296 slugs fuera de catalogo OSS ya no entran al grounding

### Bug (auditoria IA 2026-06-10)

`ragRetriever.buildCorpus()` cargaba los **491** slugs del manifest sin filtrar contra el catalogo del tier activo. En OSS el catalogo tiene **263** especies. Resultado: **296** fichas de ciclo-content entraban al grounding sin que la especie tuviera entrada en el catalogo del usuario → respuestas con grounding parcial de especies desconocidas, posible leak de contenido Pro a OSS.

El contraste: `corpusLoader.js` SI tier-gatea el SQLite del catalogo (OSS vs Pro), pero `ragRetriever.js` NO gateaba el fetch de las fichas.

### Fix

En `buildCorpus()`:

```js
const catalogSpecies = await getAllSpecies();
if (catalogSpecies && catalogSpecies.length > 0) {
  const allowedIds = new Set(catalogSpecies.map((s) => s.id));
  species = species.filter((slug) => allowedIds.has(slug));
}
```

- **Degradacion segura**: si el catalogo falla (`getAllSpecies` rechaza), carga todos los slugs (mejor grounding completo que ninguno)
- **Catalogo vacio**: carga todos los slugs (sin especies = sin filtro)
- **Log informativo**: `[RAG] Tier gate: 491 slugs en manifest, 195 dentro del catalogo (296 excluidos)`

### Conteo de slugs gateados

| | Count |
|---|---|
| Manifest slugs | 491 |
| Catalogo OSS especies | 263 |
| Slugs en catalogo OSS (se cargan) | **195** |
| Slugs GATEADOS en OSS (excluidos) | **296** |

En PRO el catalogo es el superset → sin gateo (todas las fichas se cargan).

### Tests (5 nuevos, 18 total)

| Test | Verifica |
|---|---|
| slugs fuera del catalogo NO se fetchean | `pro_only_1`, `pro_only_2` nunca llegan al fetch |
| corpusStats refleja solo docs del tier | totalDocs = 3 (no 5) |
| catalogo falla → degradacion | carga todos los slugs sin romper |
| catalogo vacio → carga todos | sin filtro si no hay especies |
| retrieve solo devuelve docs del tier | todos los hits pertenecen al catalogo OSS |

```
npx vitest run src/services/__tests__/ragRetriever.test.js
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

eslint `--max-warnings=0` OK
