### PR TITLE
feat(chips): exponer Restauración, Silvopastoreo y Páramo como chips de modo

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -64,7 +64,7 @@ import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../
 // sidecarClient/deepResearchClient vía buildSidecarHeaders (defense-in-depth).
 import { getCurrentTier } from '../../services/tierService';
 import DeepResearchCard from '../DeepResearchCard';
-import { normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity, buildFallbackResponse } from '../../services/agentService';
+import { normalizeUserInputForRegion, buildClimaContext, buildFincaContext, buildViabilityContext, buildFrostHeatContext, buildAssociationContext, buildInvasiveSafetyContext, buildCuratedFactsContext, applyVoseoFilter, resolveUserRegion, stripRoleLeak, buildPriceDeclineContext, buildSuggestedEntitiesContext, isLowConfidenceEntity, buildFallbackResponse, pisoTermicoFromAltitud } from '../../services/agentService';
 import { buildBasePrompt, analyzeQuery, buildQueryAnalysisBlock, buildCorpusVariants, buildResolvedEntitiesBlock, formatToolEvidence } from '../../services/agentPromptBase';
 import { assembleSystemContent } from '../../services/promptAssembler';
 import { applyOutputGuards, classifyQueryIntent } from '../../services/outputGuards';
@@ -1271,8 +1271,28 @@ export default function AgentScreen({ onBack, initialContext }) {
             const activeFincaClima = fincas.find((f) => f.slug === activeFincaSlug);
             const municipioClima =
               activeFincaClima?.municipio || FARM_CONFIG?.MUNICIPIO || null;
+            // Altura + piso térmico para los chips de diseño (restauración,
+            // silvopastoreo, páramo). El chip salta el NLU, así que el contexto
+            // de altura lo aporta el perfil/finca aquí. Silvopastoreo EXIGE
+            // altura: sin ella el router devuelve un stub que pide la altura.
+            const fincaAltitudChip = (() => {
+              try {
+                const p = getProfile();
+                if (p && p.finca_altitud != null && p.finca_altitud !== '') return p.finca_altitud;
+              } catch (_) { /* noop */ }
+              return activeFincaClima?.altitud ?? null;
+            })();
+            const pisoTermicoChip = (() => {
+              try {
+                const p = getProfile();
+                if (p && p.piso_termico) return p.piso_termico;
+              } catch (_) { /* noop */ }
+              return pisoTermicoFromAltitud(fincaAltitudChip);
+            })();
             const forcedPlan = planForcedIntent(forcedIntent, textForLLM, {
               municipio: municipioClima,
+              altitud: fincaAltitudChip,
+              pisoTermico: pisoTermicoChip,
             });
             if (forcedPlan && forcedPlan.tool) {
               if (forcedPlan.stub && forcedPlan.stubResult) {
@@ -1302,7 +1322,21 @@ export default function AgentScreen({ onBack, initialContext }) {
                   });
                   nluRoute = `chip:${forcedIntent}:${forcedPlan.tool}`;
                 } else {
-                  console.debug('[sidecar] chip forzado tool null', {
+                  // DEGRADACIÓN AMABLE: el tool no respondió (sin red / sidecar
+                  // caído / timeout). En vez de un error mudo, inyectamos
+                  // evidence sintética available:false para que el agente
+                  // responda con un mensaje amable y NO invente datos.
+                  toolEvidence = {
+                    tool: forcedPlan.tool,
+                    args: forcedPlan.args,
+                    result: {
+                      available: false,
+                      reason: 'sin_respuesta',
+                      hint: 'la herramienta no respondió — pedirle al usuario revisar su conexión e intentar de nuevo, sin inventar datos',
+                    },
+                  };
+                  nluRoute = `chip:${forcedIntent}:${forcedPlan.tool}:sin_respuesta`;
+                  console.debug('[sidecar] chip forzado tool null — degradación amable', {
                     intent: forcedIntent,
                     tool: forcedPlan.tool,
                   });

--- a/src/components/__tests__/ChipsToolbar.smoke.test.jsx
+++ b/src/components/__tests__/ChipsToolbar.smoke.test.jsx
@@ -195,9 +195,11 @@ describe('ChipsToolbar — flag Deep Research ON (chip 🔬 visible, pro-gated)'
     vi.restoreAllMocks();
   });
 
-  test('renderiza los 7 chips (incluido 🔬) con la flag ON', () => {
+  test('renderiza todos los chips (incluido 🔬) con la flag ON', () => {
     render(<ChipsToolbar onSelectIntent={() => {}} isPro={false} />);
-    expect(screen.getAllByTestId('mode-chip')).toHaveLength(7);
+    // Con la flag ON se ven los 10 chips del manifiesto (deep incluido, aunque
+    // quede pro-locked para free).
+    expect(screen.getAllByTestId('mode-chip')).toHaveLength(CHIP_DEFS.length);
   });
 
   test('usuario free ve el chip 🔬 con sufijo "(Pro)" y deshabilitado', () => {

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -58,6 +58,7 @@ const GROUP_META = Object.freeze({
   cultivo: { icon: '🌱', label: 'Mis cultivos' },
   cuidar: { icon: '🐛', label: 'Cuidar y prevenir' },
   observar: { icon: '👁️', label: 'Mirar la finca' },
+  restaurar: { icon: '🌳', label: 'Restaurar y conservar' },
   registrar: { icon: '📝', label: 'Guardar lo que hago' },
   planear: { icon: '📅', label: 'Planear' },
   aprender: { icon: '📚', label: 'Aprender' },
@@ -65,7 +66,7 @@ const GROUP_META = Object.freeze({
 });
 
 const GROUP_ORDER = Object.freeze([
-  'cultivo', 'cuidar', 'observar', 'registrar', 'planear', 'aprender', 'vender',
+  'cultivo', 'cuidar', 'observar', 'restaurar', 'registrar', 'planear', 'aprender', 'vender',
 ]);
 
 const GROUPS = GROUP_ORDER

--- a/src/services/__tests__/agentCapabilities.audit.test.js
+++ b/src/services/__tests__/agentCapabilities.audit.test.js
@@ -15,7 +15,7 @@
  *   - MCP sin datos: available:false / found:false → mensaje honesto
  *   - función no disponible por plan → stubMessage claro (ej. precio)
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { CHIP_INTENTS, CHIP_DEFS, planForcedIntent } from '../chipIntentRouter.js';
 
 // ---------------------------------------------------------------------------
@@ -85,6 +85,33 @@ const CHIP_REGISTRY = [
     tool: null,
     stub: false,
     deep: true,
+  },
+  {
+    intent: 'restauracion',
+    label: 'Restauración',
+    emoji: '🌳',
+    kind: 'tool',
+    tool: 'get_diseno_restauracion',
+    stub: false,
+    deep: false,
+  },
+  {
+    intent: 'silvopastoreo',
+    label: 'Silvopastoreo',
+    emoji: '🐄',
+    kind: 'tool',
+    tool: 'get_diseno_silvopastoril',
+    stub: false,
+    deep: false,
+  },
+  {
+    intent: 'paramo',
+    label: 'Páramo',
+    emoji: '⛰️',
+    kind: 'tool',
+    tool: 'get_diseno_restauracion',
+    stub: false,
+    deep: false,
   },
 ];
 
@@ -164,6 +191,8 @@ describe('agentCapabilities — cada tool del chip está en ALLOWED_TOOLS', () =
     const knownTools = new Set([
       'get_species', 'get_companions', 'get_biopreparados',
       'get_pest_controllers', 'get_multihop_companions',
+      'get_subgrafo_relacional', 'get_diseno_restauracion',
+      'get_diseno_silvopastoril',
       'validate_visual_match', 'validate_taxonomy',
       'get_normativa_ica', 'get_clima_ideam', 'get_precio_sipsa',
       'get_enso_status', 'get_alertas_clima_zona',
@@ -293,13 +322,16 @@ describe('agentCapabilities — Deep Research (backend live)', () => {
 // 7. Contrato anti-regresión — si alguien cambia labels o tools sin aviso
 // ---------------------------------------------------------------------------
 describe('agentCapabilities — contrato anti-regresión', () => {
-  it('el número total de chips visibles es 7', () => {
-    expect(CHIP_DEFS).toHaveLength(7);
-    expect(CHIP_REGISTRY).toHaveLength(7);
+  it('el número total de chips visibles es 10', () => {
+    expect(CHIP_DEFS).toHaveLength(10);
+    expect(CHIP_REGISTRY).toHaveLength(10);
   });
 
-  it('los intents visibles son exactamente los 7 contratados', () => {
-    const expected = ['siembro', 'plaga', 'biopreparado', 'clima', 'precio', 'calendario', 'deep'];
+  it('los intents visibles son exactamente los 10 contratados', () => {
+    const expected = [
+      'siembro', 'plaga', 'biopreparado', 'clima', 'precio', 'calendario', 'deep',
+      'restauracion', 'silvopastoreo', 'paramo',
+    ];
     const actual = CHIP_DEFS.map((d) => d.intent);
     expect(actual).toEqual(expected);
   });

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -21,7 +21,7 @@ import {
  */
 
 describe('chipIntentRouter — enum y definiciones', () => {
-  it('expone los 7 intents del enum', () => {
+  it('expone los 10 intents del enum (incluye restauración, silvopastoreo, páramo)', () => {
     expect(CHIP_INTENTS).toEqual({
       siembro: 'siembro',
       plaga: 'plaga',
@@ -30,10 +30,13 @@ describe('chipIntentRouter — enum y definiciones', () => {
       precio: 'precio',
       calendario: 'calendario',
       deep: 'deep',
+      restauracion: 'restauracion',
+      silvopastoreo: 'silvopastoreo',
+      paramo: 'paramo',
     });
   });
 
-  it('CHIP_DEFS tiene los 7 chips con label en español colombiano (sin voseo)', () => {
+  it('CHIP_DEFS tiene los 10 chips con label en español colombiano (sin voseo)', () => {
     const ids = CHIP_DEFS.map((c) => c.intent);
     expect(ids).toEqual([
       'siembro',
@@ -43,6 +46,9 @@ describe('chipIntentRouter — enum y definiciones', () => {
       'precio',
       'calendario',
       'deep',
+      'restauracion',
+      'silvopastoreo',
+      'paramo',
     ]);
     // Labels presentes y emoji declarado
     for (const def of CHIP_DEFS) {
@@ -168,6 +174,80 @@ describe('chipIntentRouter — intents con tool determinístico (saltan NLU)', (
   });
 });
 
+describe('chipIntentRouter — chips de diseño (capacidades antes dark)', () => {
+  it('restauración → get_diseno_restauracion objetivo=bosque por defecto + altitud del perfil', () => {
+    const plan = planForcedIntent('restauracion', 'quiero recuperar este lote', { altitud: 2600 });
+    expect(plan.tool).toBe('get_diseno_restauracion');
+    expect(plan.args.objetivo).toBe('bosque');
+    expect(plan.args.altitud_msnm).toBe(2600);
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('restauración infiere objetivo del texto (ribera / quemado / cortafuegos / páramo)', () => {
+    expect(planForcedIntent('restauracion', 'la orilla de la quebrada').args.objetivo).toBe('ribera');
+    expect(planForcedIntent('restauracion', 'un sitio que se quemó').args.objetivo).toBe('post_incendio');
+    expect(planForcedIntent('restauracion', 'quiero un cortafuego vivo').args.objetivo).toBe('cortafuegos');
+    expect(planForcedIntent('restauracion', 'restaurar el páramo').args.objetivo).toBe('paramo');
+  });
+
+  it('restauración pasa invasora_mencionada cuando el usuario la nombra (retamo/eucalipto)', () => {
+    const plan = planForcedIntent('restauracion', 'tengo retamo espinoso, ¿qué hago?');
+    expect(plan.args.invasora_mencionada).toBe('retamo');
+  });
+
+  it('restauración sin altitud NO incluye altitud_msnm (la tool la trata como opcional)', () => {
+    const plan = planForcedIntent('restauracion', 'recuperar bosque');
+    expect(plan.tool).toBe('get_diseno_restauracion');
+    expect(plan.args).not.toHaveProperty('altitud_msnm');
+  });
+
+  it('páramo → get_diseno_restauracion objetivo=paramo SIN pasar la altura de la finca', () => {
+    // La altura de la finca puede estar por debajo del páramo; el objetivo
+    // 'paramo' ya fuerza ≥3000 msnm en la tool. No la pasamos para no vaciar.
+    const plan = planForcedIntent('paramo', 'especies de páramo', { altitud: 2600 });
+    expect(plan.tool).toBe('get_diseno_restauracion');
+    expect(plan.args).toEqual({ objetivo: 'paramo' });
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('silvopastoreo → get_diseno_silvopastoril con altura + piso del perfil', () => {
+    const plan = planForcedIntent('silvopastoreo', 'forraje para mis vacas', {
+      altitud: 1800,
+      pisoTermico: 'templado',
+    });
+    expect(plan.tool).toBe('get_diseno_silvopastoril');
+    expect(plan.args.altitud).toBe(1800);
+    expect(plan.args.piso_termico).toBe('templado');
+    expect(plan.args.animal).toBe('bovino');
+    expect(plan.stub).toBe(false);
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('silvopastoreo normaliza el piso con tilde del perfil (frío→frio, páramo→paramo)', () => {
+    expect(planForcedIntent('silvopastoreo', 'forraje', { altitud: 2500, pisoTermico: 'frío' }).args.piso_termico).toBe('frio');
+    expect(planForcedIntent('silvopastoreo', 'forraje', { altitud: 3100, pisoTermico: 'páramo' }).args.piso_termico).toBe('paramo');
+  });
+
+  it('silvopastoreo detecta el animal del texto (oveja→ovino, cabra→caprino)', () => {
+    expect(planForcedIntent('silvopastoreo', 'forraje para ovejas', { altitud: 2500 }).args.animal).toBe('ovino');
+    expect(planForcedIntent('silvopastoreo', 'sombra para mis cabras', { altitud: 1500 }).args.animal).toBe('caprino');
+  });
+
+  it('silvopastoreo SIN altura → stub no_altitud (pide la altura, NO inventa)', () => {
+    const plan = planForcedIntent('silvopastoreo', 'forraje para el ganado');
+    expect(plan.tool).toBe('get_diseno_silvopastoril');
+    expect(plan.stub).toBe(true);
+    expect(plan.stubResult).toMatchObject({ available: false, reason: 'no_altitud' });
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('silvopastoreo acepta altitud como string del perfil (coerción a número)', () => {
+    const plan = planForcedIntent('silvopastoreo', 'forraje', { altitud: '2100' });
+    expect(plan.args.altitud).toBe(2100);
+  });
+});
+
 describe('chipIntentRouter — intents STUB (backend no existe aún)', () => {
   it('precio → stub claro "aún no disponible" (NO inventa backend de precio)', () => {
     const plan = planForcedIntent('precio', 'papa');
@@ -223,15 +303,15 @@ describe('chipIntentRouter — Deep Research (A6/A7, backend live)', () => {
 });
 
 describe('chipIntentRouter — contrato de orden y consistencia del índice', () => {
-  it('CHIP_DEFS mantiene el orden de render estable (siembro, plaga, biopreparado, clima, precio, calendario, deep)', () => {
+  it('CHIP_DEFS mantiene el orden de render estable (chips base + restauración/silvopastoreo/páramo al final)', () => {
     const order = CHIP_DEFS.map((d) => d.intent);
     expect(order).toEqual([
       'siembro', 'plaga', 'biopreparado', 'clima', 'precio', 'calendario', 'deep',
+      'restauracion', 'silvopastoreo', 'paramo',
     ]);
   });
 
-  it('DEF_BY_INTENT indexa todos los 7 intents sin entradas extra', async () => {
-    const { default: mod } = await import('../chipIntentRouter.js');
+  it('DEF_BY_INTENT indexa todos los intents sin entradas extra', () => {
     // DEF_BY_INTENT no es exportado, así que verificamos indirectamente:
     // isStubIntent e isDeepResearchIntent cubren todos los intents sin error.
     for (const intent of Object.keys(CHIP_INTENTS)) {
@@ -286,14 +366,12 @@ describe('chipIntentRouter — cross-reference con ALLOWED_TOOLS del sidecar', (
     }
   });
 
-  it('ningún kind:stub o kind:deep tiene tool en ALLOWED_TOOLS', async () => {
-    const { __TEST__ } = await import('../sidecarClient.js');
-    const allowed = __TEST__.ALLOWED_TOOLS;
+  it('ningún kind:stub o kind:deep tiene tool en ALLOWED_TOOLS', () => {
     const nonToolIntents = CHIP_DEFS.filter((d) => d.kind !== 'tool');
     for (const def of nonToolIntents) {
       const plan = planForcedIntent(def.intent, 'test');
-      expect(plan.tool).toBeNull();
       // Ningún stub/deep debe tener un tool asignado (ni siquiera por error)
+      expect(plan.tool).toBeNull();
     }
   });
 });

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -121,6 +121,70 @@ export const CAPABILITY_MANIFEST = Object.freeze([
     hero: true,
     heroRoute: { kind: 'ask', prompt: 'Quiero hacer una investigación profunda sobre mi finca.' },
   },
+  {
+    // Capacidad ya viva en el backend (get_diseno_restauracion: sucesión
+    // ecológica con nativas del grafo AGE) pero SIN chip — la auditoría IA la
+    // marcó "dark". El chip la fuerza saltando el NLU y le pasa la altura del
+    // perfil. El `objetivo` (bosque/ribera/cortafuegos/post_incendio) lo infiere
+    // el router del texto del usuario; por defecto 'bosque'.
+    id: 'restauracion',
+    group: 'restaurar',
+    status: 'live',
+    intent: 'restauracion',
+    kind: 'tool',
+    icon: '🌳',
+    label: 'Restauración',
+    desc: 'Recuperar un terreno con nativas, de pioneras a bosque maduro.',
+    placeholder: 'Cuéntame qué quieres recuperar: bosque, orilla de quebrada o sitio quemado',
+    tool: 'get_diseno_restauracion',
+    stubMessage: null,
+    hero: true,
+    heroRoute: {
+      kind: 'ask',
+      prompt: 'Quiero restaurar un terreno con árboles nativos. ¿Qué especies siembro y en qué orden?',
+    },
+  },
+  {
+    // get_diseno_silvopastoril estaba viva en el sidecar pero NI en el
+    // allow-list del cliente NI con chip. El chip la fuerza con la altura del
+    // perfil (requerida por la tool) y, opcional, el animal inferido del texto.
+    id: 'silvopastoreo',
+    group: 'restaurar',
+    status: 'live',
+    intent: 'silvopastoreo',
+    kind: 'tool',
+    icon: '🐄',
+    label: 'Silvopastoreo',
+    desc: 'Forraje y árboles para tu ganado según tu altura.',
+    placeholder: 'Escribe tu animal o el forraje que buscas: banco de proteína, cerca viva, sombra',
+    tool: 'get_diseno_silvopastoril',
+    stubMessage: null,
+    hero: true,
+    heroRoute: {
+      kind: 'ask',
+      prompt: 'Quiero un arreglo silvopastoril con forraje y árboles para mi ganado.',
+    },
+  },
+  {
+    // Páramo: reutiliza get_diseno_restauracion con objetivo='paramo' (la tool
+    // filtra a especies que alcanzan ≥3000 msnm). NO inventamos tool nuevo.
+    id: 'paramo',
+    group: 'restaurar',
+    status: 'live',
+    intent: 'paramo',
+    kind: 'tool',
+    icon: '⛰️',
+    label: 'Páramo',
+    desc: 'Especies nativas para restaurar el páramo, por encima de 3000 metros.',
+    placeholder: 'Pregunta por especies nativas para restaurar el páramo',
+    tool: 'get_diseno_restauracion',
+    stubMessage: null,
+    hero: true,
+    heroRoute: {
+      kind: 'ask',
+      prompt: 'Quiero restaurar el páramo. ¿Qué especies nativas siembro?',
+    },
+  },
 
   // ═══════════════════════════════════════════════════════════════════════
   // AGENTHERO ACTIONS — aparecen solo en menú Ⓐ del AgentHero

--- a/src/services/capabilityHealth.js
+++ b/src/services/capabilityHealth.js
@@ -19,6 +19,7 @@ export const SIDECAR_TOOL_NAMES = new Set([
   'get_multihop_companions',
   'get_subgrafo_relacional',
   'get_diseno_restauracion',
+  'get_diseno_silvopastoril',
   'validate_visual_match',
   'validate_taxonomy',
   'get_normativa_ica',

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -25,6 +25,10 @@
  *   - plaga        → get_pest_controllers  (controladores agroecológicos de la plaga)
  *   - biopreparado → get_biopreparados     (recetas de biopreparados)
  *   - clima        → get_clima_ideam       (IDEAM nacional; requiere municipio)
+ *   - restauracion → get_diseno_restauracion (sucesión ecológica con nativas;
+ *                                           objetivo inferido del texto, default bosque)
+ *   - silvopastoreo→ get_diseno_silvopastoril (forrajeras CIPAV; requiere altura)
+ *   - paramo       → get_diseno_restauracion (objetivo='paramo'; especies ≥3000 msnm)
  *
  * Intents STUB (el backend aún NO existe — NO inventamos endpoints):
  *   - precio → SIPSA/DANE consulta directa no disponible (dataset ZIP federado).
@@ -77,6 +81,10 @@ export function isDeepResearchIntent(intent) {
  * @param {string} text — texto crudo del usuario (lo que escribió en el input).
  * @param {object} [opts]
  * @param {string|null} [opts.municipio] — municipio de la finca activa (para clima).
+ * @param {number|string|null} [opts.altitud] — altura de la finca/perfil en msnm
+ *   (para restauración y silvopastoreo; silvopastoreo la EXIGE).
+ * @param {string|null} [opts.pisoTermico] — piso térmico del perfil
+ *   (frío/templado/cálido/páramo; se prioriza en silvopastoreo).
  * @returns {null | {
  *   intent: string,
  *   tool: string | null,        // tool determinístico, o null si stub
@@ -151,6 +159,59 @@ export function planForcedIntent(intent, text, opts = {}) {
       };
     }
 
+    case CHIP_INTENTS.restauracion: {
+      // Plan de sucesión ecológica con nativas (get_diseno_restauracion). El
+      // objetivo se infiere del texto (ribera/quemado/cortafuegos/páramo/bosque).
+      // La altura del perfil afina el rango altitudinal (opcional en la tool).
+      // NO pasamos región: el set de restauración es pequeño (~17 especies) y
+      // un filtro de región exclusivo vaciaría buckets — la altura ya acota el
+      // piso térmico de forma robusta.
+      const args = { objetivo: detectObjetivoRestauracion(prompt) };
+      const altRest = toAltitud(opts.altitud);
+      if (altRest != null) args.altitud_msnm = altRest;
+      const invasora = detectInvasoraMencionada(prompt);
+      if (invasora) args.invasora_mencionada = invasora;
+      return { ...base, tool: 'get_diseno_restauracion', args };
+    }
+
+    case CHIP_INTENTS.paramo:
+      // Restauración de páramo: reusa get_diseno_restauracion con objetivo
+      // 'paramo' (la tool fuerza ≥3000 msnm). NO pasamos la altura de la finca:
+      // puede estar por debajo del páramo y vaciaría el resultado — el objetivo
+      // 'paramo' ya es el discriminador correcto.
+      return {
+        ...base,
+        tool: 'get_diseno_restauracion',
+        args: { objetivo: 'paramo' },
+      };
+
+    case CHIP_INTENTS.silvopastoreo: {
+      // Arreglo silvopastoril (get_diseno_silvopastoril). La tool EXIGE altura.
+      const altSilvo = toAltitud(opts.altitud);
+      if (altSilvo == null) {
+        // Sin altura NO llamamos el tool: evidence sintética que obliga al LLM
+        // a PEDIR la altura/municipio (NO inventar). Mismo contrato que clima
+        // sin municipio.
+        return {
+          ...base,
+          tool: 'get_diseno_silvopastoril',
+          args: null,
+          stub: true,
+          stubResult: {
+            available: false,
+            reason: 'no_altitud',
+            hint: 'pedirle al usuario la altura de su finca (msnm) o su municipio para calcular el arreglo silvopastoril',
+          },
+        };
+      }
+      const args = { altitud: altSilvo };
+      const piso = normalizePiso(opts.pisoTermico);
+      if (piso) args.piso_termico = piso;
+      const animal = detectAnimalSilvo(prompt);
+      if (animal) args.animal = animal;
+      return { ...base, tool: 'get_diseno_silvopastoril', args };
+    }
+
     case CHIP_INTENTS.precio:
       // STUB: backend no implementado. NO inventamos endpoint.
       return { ...base, stub: true, stubMessage: def.stubMessage };
@@ -177,4 +238,98 @@ function isoDaysAgo(days) {
   return new Date(Date.now() - days * 24 * 60 * 60 * 1000)
     .toISOString()
     .slice(0, 10);
+}
+
+/**
+ * Coerce una altitud (number|string) a un entero msnm válido (0..6500), o null.
+ * El rango lo exige el zod de las tools de diseño en el sidecar.
+ * @param {number|string|null|undefined} raw
+ * @returns {number|null}
+ */
+function toAltitud(raw) {
+  if (raw == null || raw === '') return null;
+  const n = typeof raw === 'number' ? raw : Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 6500) return null;
+  return Math.round(n);
+}
+
+/**
+ * Normaliza el piso térmico del perfil al vocabulario del enum de la tool
+ * silvopastoril (frio|templado|calido|paramo, SIN tildes). Devuelve null si no
+ * mapea (la tool lo trata como opcional).
+ * @param {string|null|undefined} piso
+ * @returns {('frio'|'templado'|'calido'|'paramo')|null}
+ */
+const PISO_NORMALIZE = Object.freeze({
+  frio: 'frio',
+  frío: 'frio',
+  templado: 'templado',
+  medio: 'templado',
+  calido: 'calido',
+  cálido: 'calido',
+  paramo: 'paramo',
+  páramo: 'paramo',
+});
+
+function normalizePiso(piso) {
+  if (typeof piso !== 'string') return null;
+  const key = piso.trim().toLowerCase();
+  return PISO_NORMALIZE[key] ?? null;
+}
+
+// Detección IN-MEMORY (determinística, sin red) del objetivo de restauración a
+// partir del texto del usuario. Orden de prioridad: páramo > cortafuegos >
+// post-incendio > ribera > bosque (default). Coincide con el enum de la tool.
+const RE_PARAMO = /\bp[áa]ramo\b/i;
+const RE_CORTAFUEGO = /\bcorta\s?fuego|barrera.*fuego\b/i;
+const RE_INCENDIO = /\b(quem[aoóéá]|incendi|chamusc|carboniz|conato)/i;
+const RE_RIBERA = /\b(ribera|orilla|quebrada|r[íi]o|ca[ñn]o|nacimiento|humedal|ronda h[íi]drica)\b/i;
+
+/**
+ * Infiere el `objetivo` de get_diseno_restauracion del texto libre del usuario.
+ * @param {string} text
+ * @returns {'bosque'|'ribera'|'cortafuegos'|'post_incendio'|'paramo'}
+ */
+function detectObjetivoRestauracion(text) {
+  const t = String(text).toLowerCase();
+  if (RE_PARAMO.test(t)) return 'paramo';
+  if (RE_CORTAFUEGO.test(t)) return 'cortafuegos';
+  if (RE_INCENDIO.test(t)) return 'post_incendio';
+  if (RE_RIBERA.test(t)) return 'ribera';
+  return 'bosque';
+}
+
+// Animales del enum silvopastoril (bovino|ovino|caprino) ↔ palabras campesinas.
+const ANIMAL_PATTERNS = [
+  [/\b(vaca|vacas|res|reses|bovin[oa]s?|ganad[oa]|novill[oa]s?|terner[oa]s?|leche|lecher[íi]a)\b/i, 'bovino'],
+  [/\b(oveja|ovejas|ovin[oa]s?|corder[oa]s?|borreg[oa]s?)\b/i, 'ovino'],
+  [/\b(cabra|cabras|caprin[oa]s?|chiv[oa]s?)\b/i, 'caprino'],
+];
+
+/**
+ * Infiere el `animal` de get_diseno_silvopastoril del texto, o null.
+ * @param {string} text
+ * @returns {('bovino'|'ovino'|'caprino')|null}
+ */
+function detectAnimalSilvo(text) {
+  const t = String(text);
+  for (const [re, animal] of ANIMAL_PATTERNS) {
+    if (re.test(t)) return animal;
+  }
+  return null;
+}
+
+// Invasoras combustibles que la tool sabe reemplazar (devuelve nativas
+// sustitutas en invasora_aviso, NUNCA las recomienda).
+const RE_INVASORA = /\b(retamo|eucalipto|pino\s?p[áa]tula|pasto\s?gordura|le[uú]caena)\b/i;
+
+/**
+ * Si el usuario menciona una invasora combustible, devuelve su nombre para que
+ * la tool responda con la nota de reemplazo. Null si no menciona ninguna.
+ * @param {string} text
+ * @returns {string|null}
+ */
+function detectInvasoraMencionada(text) {
+  const m = String(text).match(RE_INVASORA);
+  return m ? m[0].toLowerCase() : null;
 }

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -299,6 +299,10 @@ const ALLOWED_TOOLS = new Set([
   // GraphRAG multi-hop + restauración (sidecar feat/graphrag-multihop, 2026-06-10).
   'get_subgrafo_relacional',
   'get_diseno_restauracion',
+  // Silvopastoril (chip Silvopastoreo, 2026-06-10): forrajeras multipropósito
+  // CIPAV/Agrosavia del grafo AGE. La tool existía en el sidecar pero no estaba
+  // en esta allow-list — el chip la expone.
+  'get_diseno_silvopastoril',
   'validate_visual_match',
   'validate_taxonomy',
   'get_normativa_ica',


### PR DESCRIPTION
## Qué

Tres capacidades **ya vivas en el backend pero sin chip** (la auditoría IA las marcó *dark*) ahora son clickeables. Reusan el patrón existente de **chips de modo** (`chipIntentRouter.planForcedIntent`): al tocar el chip la intención queda **forzada** y rutea directo al tool determinístico, **saltando el NLU** (que es el que misroutea).

| Chip | Tool que invoca | Notas |
|------|-----------------|-------|
| 🌳 Restauración | `get_diseno_restauracion` | `objetivo` inferido del texto (bosque por defecto; ribera/post_incendio/cortafuegos/paramo por keywords) + `altitud_msnm` del perfil + `invasora_mencionada` si el usuario la nombra |
| 🐄 Silvopastoreo | `get_diseno_silvopastoril` | `altitud` (requerida) + `piso_termico` del perfil + `animal` del texto. Sin altitud → stub que pide la altura (no inventa) |
| ⛰️ Páramo | `get_diseno_restauracion` (`objetivo='paramo'`) | reusa la tool de restauración, **sin tool nuevo** |

## Wiring

- `get_diseno_silvopastoril` añadido al **`ALLOWED_TOOLS`** del cliente (`sidecarClient.js`) — antes ni estaba — y a `SIDECAR_TOOL_NAMES` (`capabilityHealth.js`) para el estado live/down en la araña.
- 3 entradas nuevas en `CAPABILITY_MANIFEST` (`hero:true`) → aparecen también en la **araña #1404** bajo un grupo nuevo **"Restaurar y conservar"** 🌳.
- `AgentScreen` pasa **altitud + piso térmico del perfil** a `planForcedIntent`.
- **Degradación amable**: si el tool no responde (sin red / sidecar caído) se inyecta evidence `available:false` → el agente responde amable, no error mudo.

## Evidencia (chromium nix-store, en vivo)

- ChipsToolbar con los 3 chips nuevos (legibles, alto contraste): `chips-CLEAN-right.png`
- Estado activo/seleccionado (emerald): `chips-CLEAN-restauracion-active.png`
- Araña con el grupo "Restaurar y conservar": `chips-arana-open.png`
- Envío con intención forzada: `chips-restauracion-fullview.png`

## Tests / lint

- TDD: routing por chip + smoke + auditoría contractual actualizada (CHIP_DEFS 7→10).
- `vitest run`: verde (suite completa sin regresiones; +10 tests nuevos).
- `eslint --max-warnings=0`: verde.
- Español Colombia (sin voseo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)