### PR TITLE
fix(farmprocess): dead-end de zona — location_land_asset_id ahora es OPCIONAL (Opcion A)

### DIFF
--- a/src/components/FarmProcessConfirmCard.jsx
+++ b/src/components/FarmProcessConfirmCard.jsx
@@ -56,7 +56,7 @@ export default function FarmProcessConfirmCard({
   }, [species, allSpecies]);
 
   const handleConfirm = () => {
-    if (!species.trim() || !(Number(quantity) > 0) || !locationId) return;
+    if (!species.trim() || !(Number(quantity) > 0)) return;
     const selected = allSpecies.find((s) => s.commonName === species || s.name === species);
     onConfirm({
       ...draft,
@@ -70,7 +70,7 @@ export default function FarmProcessConfirmCard({
     });
   };
 
-  const allValid = species.trim().length > 0 && Number(quantity) > 0 && locationId;
+  const allValid = species.trim().length > 0 && Number(quantity) > 0;
 
   return (
     <div className="p-4 flex flex-col gap-4">
@@ -187,7 +187,7 @@ export default function FarmProcessConfirmCard({
         </label>
       </div>
 
-      {/* Zona / Lote */}
+      {/* Zona / Lote — opcional; si no hay lotes el ciclo se crea sin ubicacion */}
       <label className="flex flex-col gap-1">
         <span className="text-2xs font-bold text-slate-400 uppercase">Zona / Lote</span>
         <select
@@ -196,11 +196,16 @@ export default function FarmProcessConfirmCard({
           className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
           disabled={isSaving}
         >
-          <option value="">Seleccionar…</option>
+          <option value="">
+            {locationOptions.length === 0 ? 'Sin lotes disponibles' : 'Seleccionar…'}
+          </option>
           {locationOptions.map((o) => (
             <option key={o.id} value={o.id}>{o.label || o.name}</option>
           ))}
         </select>
+        {!locationId && (
+          <span className="text-3xs text-slate-500">Sin asignar (puedes asignarlo despues)</span>
+        )}
       </label>
 
       {/* Fecha */}

--- a/src/types/farmProcess.js
+++ b/src/types/farmProcess.js
@@ -156,7 +156,9 @@ export const validateFarmProcess = (p) => {
   if (!a.subject_slug && !a.subject_label) throw new Error('Need subject_slug or subject_label');
   if (!Number.isInteger(a.quantity) || a.quantity < 1) throw new Error('quantity must be positive integer');
   if (!a.unit) throw new Error('Missing unit');
-  if (!a.location_land_asset_id) throw new Error('Missing location_land_asset_id');
+  // location_land_asset_id es OPCIONAL (fix dead-end sin lotes).
+  // Si no hay lotes en la finca, el ciclo se crea sin ubicacion;
+  // el campesino puede asignarla despues. La UI muestra "Sin asignar".
   if (!VALID_STATUSES.includes(a.status)) throw new Error(`Invalid status: ${a.status}`);
   if (!VALID_STAGES.includes(a.current_stage)) throw new Error(`Invalid current_stage: ${a.current_stage}`);
 };
@@ -186,5 +188,5 @@ export const validatePopulation = (p) => {
   if (!p.population_id) throw new Error('Missing population_id');
   if (!p.species_slug) throw new Error('Missing species_slug');
   if (!Number.isInteger(p.count) || p.count < 1) throw new Error('count must be positive integer');
-  if (!p.location_land_asset_id) throw new Error('Missing location_land_asset_id');
+  // location_land_asset_id es OPCIONAL (mismo criterio que FarmProcess).
 };

--- a/tests/arana-funcional.spec.js
+++ b/tests/arana-funcional.spec.js
@@ -335,15 +335,13 @@ test.describe('BUG conocido — "Procesos por voz" dead-end sin zona', () => {
     await mockOAuth(page);
   });
 
-  test('reproduce el ATASCO: sin zonas/lotes, "Confirmar siembra" queda DESHABILITADO (dead-end total)', async ({ page }) => {
-    // Escenario del operador: usuario nuevo SIN lotes definidos. Llega a la
-    // tarjeta de confirmación tras hablar; especie/cantidad están OK, pero el
-    // selector de Zona/Lote no tiene ninguna opción real → locationId queda ''
-    // → el botón nunca se habilita → no hay forma de avanzar ni de crear zona.
+  test('FIX — sin zonas/lotes, "Confirmar siembra" se HABILITA y permite sembrar sin ubicacion (ya no es dead-end)', async ({ page }) => {
+    // FIX del dead-end: location_land_asset_id ahora es OPCIONAL.
+    // Con 0 lotes, especie y cantidad validas → boton habilitado,
+    // la siembra se confirma con ubicacion vacia (el campesino puede
+    // asignar zona despues). La UI muestra "Sin asignar".
     await bootToDashboard(page, { seedLands: false });
 
-    // Verificamos en el modelo de la tarjeta: con 0 zonas, allValid === false
-    // aunque especie y cantidad sean válidas.
     const verdict = await page.evaluate(() => {
       const draft = {
         process_type: 'seeding',
@@ -351,24 +349,23 @@ test.describe('BUG conocido — "Procesos por voz" dead-end sin zona', () => {
         subject_slug: 'solanum_lycopersicum',
         quantity: 10,
         unit: 'plantas',
-        location_land_asset_id: '', // <- voz NO resolvió zona (caso común)
+        location_land_asset_id: '',
         transcription: 'sembré 10 tomates',
       };
       const species = (draft.subject_label || '').trim();
       const quantity = Number(draft.quantity);
-      const locationOptions = []; // <- NO hay lotes en la finca
+      const locationOptions = [];
       const locationId = draft.location_land_asset_id || '';
-      // Réplica EXACTA de allValid en FarmProcessConfirmCard.jsx (línea 73).
-      const allValid = species.length > 0 && quantity > 0 && Boolean(locationId);
+      // Replica EXACTA de allValid tras el fix (sin locationId en la condicion)
+      const allValid = species.length > 0 && quantity > 0;
       return { allValid, optionsCount: locationOptions.length, locationId };
     });
 
-    // ESTE es el bug: la siembra es válida en todo menos la zona, que NO se
-    // puede seleccionar porque no existe ninguna → botón muerto.
-    expect(verdict.optionsCount, 'sin lotes en la finca = dead-end').toBe(0);
-    expect(verdict.allValid, 'el botón Confirmar siembra NUNCA se habilita sin zona').toBe(false);
+    // FIX: con 0 zonas, allValid AHORA es true (la ubicacion es opcional)
+    expect(verdict.optionsCount, 'sin lotes en la finca').toBe(0);
+    expect(verdict.allValid, 'el boton Confirmar siembra SE habilita aunque no haya zona').toBe(true);
 
-    // Y lo confirmamos en la UI REAL renderizando la tarjeta con locationOptions=[].
+    // UI REAL: el boton esta HABILITADO sin zona
     await page.evaluate(async ([reactDep, reactDomDep]) => {
       const ReactMod = await import(reactDep);
       const ReactDOM = await import(reactDomDep);
@@ -390,7 +387,7 @@ test.describe('BUG conocido — "Procesos por voz" dead-end sin zona', () => {
       createRoot(host).render(
         React.createElement(Card, {
           draft,
-          locationOptions: [], // SIN zonas — el caso del operador
+          locationOptions: [],
           isSaving: false,
           onConfirm: () => { window.__confirmFired = true; },
           onCancel: () => {},
@@ -400,14 +397,22 @@ test.describe('BUG conocido — "Procesos por voz" dead-end sin zona', () => {
 
     const confirmBtn = page.getByRole('button', { name: /Confirmar siembra/i });
     await expect(confirmBtn).toBeVisible({ timeout: 8000 });
-    // El botón existe pero está DESHABILITADO: dead-end reproducido en la UI real.
-    await expect(confirmBtn).toBeDisabled();
+    // FIX: el boton AHORA esta HABILITADO (ya no es dead-end)
+    await expect(confirmBtn).toBeEnabled({ timeout: 5000 });
 
-    // El selector de Zona/Lote solo ofrece "Seleccionar…": no hay salida.
+    // El selector muestra "Sin lotes disponibles" en vez de "Seleccionar..."
     const zoneSelect = page.locator('#e2e-confirm-host select').last();
     const optionTexts = await zoneSelect.locator('option').allInnerTexts();
-    expect(optionTexts).toEqual(['Seleccionar…']);
-    expect(optionTexts.some((t) => /Lote|invernadero|zona/i.test(t))).toBe(false);
+    expect(optionTexts).toEqual(['Sin lotes disponibles']);
+
+    // El hint "Sin asignar" es visible
+    const hint = page.locator('#e2e-confirm-host').locator('text=Sin asignar');
+    await expect(hint).toBeVisible();
+
+    // Al confirmar SIN zona, onConfirm se dispara igual
+    await confirmBtn.click();
+    const fired = await page.evaluate(() => window.__confirmFired === true);
+    expect(fired, 'sin zona, Confirmar siembra IGUAL dispara onConfirm').toBe(true);
   });
 
   test('CON al menos una zona, el flujo SÍ se desbloquea (control positivo)', async ({ page }) => {


### PR DESCRIPTION
## Dead-end de zona arreglado — Opcion A

### Bug (operador)

Sin lotes en la finca, el boton "Confirmar siembra" en `FarmProcessConfirmCard` quedaba **permanentemente deshabilitado**:

1. `locationOptions = []` → el `<select>` solo ofrece `"Seleccionar..."` (`value=""`)
2. `locationId = ''` → `allValid = species && quantity>0 && Boolean(locationId)` → `false`
3. Boton `disabled={!allValid}` → **siempre gris**, sin salida

El campesino quedaba ATASCADO sin poder confirmar la siembra ni crear una zona.

### Opcion A (elegida) — ubicacion OPCIONAL

| Archivo | Cambio |
|---|---|
| `farmProcess.js:159` | `validateFarmProcess` ya NO exige `location_land_asset_id` |
| `farmProcess.js:189` | `validatePopulation` idem |
| `FarmProcessConfirmCard.jsx:59` | `handleConfirm` ya no bloquea por `!locationId` |
| `FarmProcessConfirmCard.jsx:73` | `allValid` ya no incluye `locationId` |
| `FarmProcessConfirmCard.jsx:191-204` | Selector: `"Sin lotes disponibles"` cuando `options=[]`, hint `"Sin asignar (puedes asignarlo despues)"` |

**Por que Opcion A y no B (inline zone creation):**
- `location_land_asset_id` se usa como indice IDB (`dbCore.js:292`) y como dato informativo en UI — pero ninguna logica downstream lo asume no-nulo de forma estructural (nunca es join key ni condicion de existencia de otras entidades)
- Opcion B requeria persitir un asset--land inline, lo cual es mas invasivo y requiere tocar el store de assets + validacion + sync — scope excesivo para un dead-end de UI
- El modelo ADR-019 ya dice que "plantas existen sin zona" (regla 3) — el FarmProcess sigue el mismo principio

### Tests

| Suite | Tests | Estado |
|---|---|---|
| `FarmProcessConfirmCard.test.jsx` | 12 | ✅ todos pasan |
| `farmProcess.test.js` | 17 | ✅ todos pasan |
| `arana-funcional.spec.js` (dead-end) | 1 actualizado | ✅ fix verificado |

El test funcional de la arana ahora assert el comportamiento ARREGLADO:
- `allValid === true` sin zona
- Boton **habilitado** (`toBeEnabled`)
- Selector muestra `"Sin lotes disponibles"` 
- Hint `"Sin asignar"` visible
- `onConfirm` se dispara al clickear

```
npx vitest run: 29 tests pasan
eslint --max-warnings=0 OK
```

### Que NO se rompe aguas abajo

- `dbCore.js:292`: indice `location_land_asset_id` — acepta string vacio sin problema
- `farmProcessCache.js`: `getFarmProcess`, `listFarmProcesses` — no filtran por location
- `FarmProcessSummary.jsx`, `CicloDetalle.jsx`, `CicloCultivoScreen.jsx` — muestran `current_stage` y otros atributos, no dependen de location no-nulo
- `SeedingLog.jsx`: el draft de `buildDraftFromSeeding` ya preve string vacio; el catch ahora loguea (fix #1402) en vez de tragar mudo
