### PR TITLE
feat(multihop): cablear get_multihop_companions como capa complementaria al subgrafo relacional (AIA-008)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1217,24 +1217,41 @@ export default function AgentScreen({ onBack, initialContext }) {
 
           // GraphRAG multi-hop: si hay plaga y/o cultivo resueltos, traemos del
           // grafo AGE la CADENA de relaciones (cultivo→plaga→controladores/
-          // biopreparados + asocios) e inyectamos el bloque al grounding. La
-          // tool es sub-segundo y no-throw; si no hay cadena, queda '' (no-op).
-          try {
-            const pestEnt = (resolvedEntities || []).find((e) => e.kind === 'pest' || e.kind === 'plaga');
-            const cropEnt = (resolvedEntities || []).find((e) => ['cultivo', 'especie', 'species', 'planta'].includes(e.kind));
-            const subArgs = {};
-            if (pestEnt) subArgs.pest = pestEnt.canonical_id || pestEnt.mentioned;
-            if (cropEnt) subArgs.cultivo = cropEnt.canonical_id || cropEnt.mentioned;
-            if (subArgs.pest || subArgs.cultivo) {
-              const sub = await callTool('get_subgrafo_relacional', subArgs);
+          // biopreparados + asocios) e inyectamos el bloque al grounding.
+          // Tambien invocamos get_multihop_companions (AIA-008): cadenas de N
+          // saltos de asociacion ecologica (companeras que controlan plagas).
+          // Ambas tools son sub-segundo y no-throw; si no hay dato, no-op.
+          const pestEnt = (resolvedEntities || []).find((e) => e.kind === 'pest' || e.kind === 'plaga');
+          const cropEnt = (resolvedEntities || []).find((e) => ['cultivo', 'especie', 'species', 'planta'].includes(e.kind));
+          const relArgs = {};
+          if (pestEnt) relArgs.pest = pestEnt.canonical_id || pestEnt.mentioned;
+          if (cropEnt) relArgs.cultivo = cropEnt.canonical_id || cropEnt.mentioned;
+
+          if (relArgs.pest || relArgs.cultivo) {
+            // Capa 1: subgrafo estructural (todas las relaciones del grafo)
+            try {
+              const sub = await callTool('get_subgrafo_relacional', relArgs);
               if (sub && sub.found && typeof sub.bloque === 'string' && sub.bloque.trim()) {
                 subgrafoBloque = sub.bloque;
                 console.debug('[sidecar] subgrafo-relacional', {
                   nodes: sub.nodes?.length, rels: sub.relaciones?.length,
                 });
               }
-            }
-          } catch (_) { /* graceful: subgrafoBloque queda '' */ }
+            } catch (_) { /* graceful */ }
+
+            // Capa 2 (AIA-008): multihop funcional (cadenas de control biologico
+            // a N saltos — NO redundante con el subgrafo: el subgrafo da
+            // adyacencia estructural, multihop da cadenas ecologicas funcionales)
+            try {
+              const mh = await callTool('get_multihop_companions', relArgs);
+              if (mh && mh.found && typeof mh.bloque === 'string' && mh.bloque.trim()) {
+                subgrafoBloque = [subgrafoBloque, mh.bloque].filter(Boolean).join('\n\n');
+                console.debug('[sidecar] multihop-companions', {
+                  hops: mh.hops, chains: mh.cadenas?.length,
+                });
+              }
+            } catch (_) { /* graceful: sin multihop sigue funcionando */ }
+          }
 
           // PASO 2-pre — routing determinístico de CONOCIMIENTO del grafo
           // (usos tradicionales / toxicidad / variedades / suelo). Igual que el

--- a/src/services/__tests__/capabilityHealth.test.js
+++ b/src/services/__tests__/capabilityHealth.test.js
@@ -50,10 +50,11 @@ describe('getDegradedCapabilities', () => {
 
 describe('getCapabilityHealth — estado real por capacidad', () => {
   it('SIDECAR_TOOL_NAMES contiene las tools que dependen del sidecar', () => {
-    expect(SIDECAR_TOOL_NAMES.has('get_species')).toBe(true);
-    expect(SIDECAR_TOOL_NAMES.has('get_biopreparados')).toBe(true);
-    expect(SIDECAR_TOOL_NAMES.has('get_clima_ideam')).toBe(true);
-    expect(SIDECAR_TOOL_NAMES.has('get_pest_controllers')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_multihop_companions')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_subgrafo_relacional')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_saberes')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_toxicidad')).toBe(true);
+    expect(SIDECAR_TOOL_NAMES.has('get_suelo')).toBe(true);
     // Locales/offline NO están
     expect(SIDECAR_TOOL_NAMES.has('assets')).toBe(false);
     expect(SIDECAR_TOOL_NAMES.has('voice_capture')).toBe(false);


### PR DESCRIPTION
## AIA-008: razonamiento multi-hop — cableado

### Decision: cablear `get_multihop_companions` como capa ADICIONAL

**NO es redundante con `get_subgrafo_relacional`** — son angulos distintos:

| Tool | Que da | Angulo |
|---|---|---|
| `get_subgrafo_relacional` | Todas las relaciones estructurales del grafo en la vecindad pest+crop | Adyacencia, nodos conectados |
| `get_multihop_companions` | Cadenas funcionales de control biologico a N saltos | Companeras que controlan plagas via enemigos naturales, repelencia, alelopatia |

**Evidencia del NLU bench** (`nlu-bench-cases.json`, caso C12):
```json
{
  "prompt": "con que asocio la papa para protegerla del gusano blanco?",
  "expected_tool": "get_multihop_companions",
  "why": "Pide asociacion de SEGUNDO grado... es el diferencial de get_multihop_companions vs get_companions (primer grado)."
}
```

### Cambio en AgentScreen.jsx

```js
// Capa 1: subgrafo estructural (existente, sin cambios)
const sub = await callTool('get_subgrafo_relacional', relArgs);

// Capa 2 (NUEVO): multihop funcional
const mh = await callTool('get_multihop_companions', relArgs);

// Ambos resultados se fusionan
subgrafoBloque = [subBloque, mhBloque].filter(Boolean).join('\n\n');
```

- Las entidades pest+crop se resuelven UNA vez (antes se hacian en scopes separados)
- Degradacion: cada capa tiene su propio `try/catch`; si una falla, la otra sigue

### Infraestructura YA existente (sin cambios)

- `ALLOWED_TOOLS` incluye `get_multihop_companions` desde antes (sidecarClient.js:298)
- `SIDECAR_TOOL_NAMES` idem (capabilityHealth.js:19)
- `capabilityHealth.test.js` verifica ambas tools en los sets
- Tool label en ChatBubble: "companeras multi-salto"

### Tests

```
npx vitest run src/services/__tests__/capabilityHealth.test.js
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

eslint `--max-warnings=0` OK
