### PR TITLE
feat(agente): memoria episódica activa de la finca en el grounding del chat

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -804,6 +804,28 @@ export default function AgentScreen({ onBack, initialContext }) {
     const asociacionBlock = buildAssociationContext({ resolvedEntities, groupedCultivos });
     const asociacionContext = asociacionBlock ? `\n\n${asociacionBlock}` : '';
 
+    // MEMORIA EPISÓDICA de la finca (TIER 2 #6): lo que la finca YA VIVIÓ con
+    // lo que el usuario pregunta este turno (siembras/etapas/manejos de plaga
+    // del event store FarmProcess en IndexedDB) + máx. 2 señales de
+    // anticipación (transición de etapa inminente por fenología desde la fecha
+    // de siembra REAL, recurrencia estacional de manejo de plagas). CERO
+    // invención: solo eventos registrados; sin historial relevante o con IDB
+    // caído → '' (no-op silencioso). GATE de precio: igual que finca/viabilidad,
+    // no aplica a consultas de mercado. Entra al promptAssembler como
+    // 'memoria' (prioridad media, sacrificable — nunca desplaza guardas ni
+    // evidencia).
+    const memoriaBlock = isPriceQuery
+      ? ''
+      : await (async () => {
+          try {
+            const { buildEpisodicMemoryContext } = await import('../../services/episodicMemoryService');
+            return await buildEpisodicMemoryContext({ query, resolvedEntities, fincaAltitud });
+          } catch {
+            return '';
+          }
+        })();
+    const memoriaContext = memoriaBlock ? `\n\n${memoriaBlock}` : '';
+
     // SEGURIDAD: invasoras / conservación sensible. Bloqueo determinístico de
     // recomendación de siembra. Cero red.
     const seguridadBlock = buildInvasiveSafetyContext({ resolvedEntities });
@@ -863,6 +885,7 @@ export default function AgentScreen({ onBack, initialContext }) {
       clima: { variants: [climaContext, ''] },
       finca: { variants: [fincaContext, ''] },
       asociacion: { variants: [asociacionContext, ''] },
+      memoria: { variants: [memoriaContext, ''] },
       corpus: { variants: corpusVariants },
       frostHeat: { variants: [frostHeatContext, ''] },
       viabilidad: viabilidadContext,

--- a/src/services/__tests__/episodicMemoryService.test.js
+++ b/src/services/__tests__/episodicMemoryService.test.js
@@ -1,0 +1,316 @@
+/**
+ * episodicMemoryService.test.js — TIER 2 #6: memoria episódica activa.
+ *
+ * Garantías que se prueban (TDD):
+ *   1. CON historial relevante a la query → el bloque se inyecta con los
+ *      eventos REALES (fecha de siembra, etapa, días) — cero invención.
+ *   2. SIN historial (o historial irrelevante a la query) → no-op ('').
+ *   3. ANTICIPACIÓN solo con dato real: transición de etapa inminente
+ *      (fenología desde la fecha de siembra REAL) y recurrencia estacional
+ *      (manejo de plagas registrado por estas fechas en temporada pasada).
+ *      Sin plantilla fenológica ni historial estacional → sin señales.
+ *   4. ANTI-SPAM: máximo EPISODIC_MAX_ANTICIPATIONS señales.
+ *   5. Degradación limpia: si la lectura de IndexedDB falla → ''.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(),
+  getFarmEvents: vi.fn(),
+}));
+
+import {
+  buildEpisodicMemoryBlock,
+  buildEpisodicMemoryContext,
+  matchRelevantProcesses,
+  EPISODIC_MAX_ANTICIPATIONS,
+} from '../episodicMemoryService.js';
+import { listFarmProcesses, getFarmEvents } from '../../db/farmProcessCache';
+
+const DAY = 86400000;
+// "Hoy" fijo para tests deterministas: 10 de junio de 2026, 12:00 COT.
+const NOW = new Date('2026-06-10T12:00:00-05:00').getTime();
+
+const mkProcess = (over = {}, attrs = {}) => ({
+  process_id: over.process_id || `proc_${Math.random().toString(36).slice(2)}`,
+  type: 'farm_process',
+  attributes: {
+    process_type: 'sowing',
+    subject_kind: 'aggregate',
+    subject_slug: 'zea_mays',
+    subject_label: 'Maíz',
+    quantity: 100,
+    unit: 'semillas',
+    location_land_asset_id: 'land-1',
+    status: 'active',
+    current_stage: 'vegetative',
+    created_at: NOW - 40 * DAY,
+    updated_at: NOW - 2 * DAY,
+    ...attrs,
+  },
+});
+
+const SPECIES_ENTITY_MAIZ = {
+  mentioned: 'maíz',
+  kind: 'species',
+  canonical_id: 'zea_mays',
+  nombre_comun: 'Maíz',
+  nombre_cientifico: 'Zea mays',
+  confidence: 0.95,
+};
+
+describe('matchRelevantProcesses', () => {
+  it('matchea por canonical_id (slug) de la entidad resuelta', () => {
+    const procs = [mkProcess(), mkProcess({}, { subject_slug: 'coffea_arabica', subject_label: 'Café' })];
+    const out = matchRelevantProcesses({
+      query: '¿cómo abono esto?',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: procs,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0].attributes.subject_slug).toBe('zea_mays');
+  });
+
+  it('matchea por texto de la query (sin NLU) contra subject_label, con acentos normalizados', () => {
+    const procs = [mkProcess({}, { subject_label: 'Maíz amarillo' })];
+    const out = matchRelevantProcesses({ query: 'como va mi maiz', resolvedEntities: null, processes: procs });
+    expect(out).toHaveLength(1);
+  });
+
+  it('NO matchea procesos de otra especie (query irrelevante → vacío)', () => {
+    const procs = [mkProcess()];
+    const out = matchRelevantProcesses({ query: '¿qué le sirve a la papa?', resolvedEntities: null, processes: procs });
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('buildEpisodicMemoryBlock — memoria relevante', () => {
+  it('CON historial: inyecta bloque con fecha de siembra real, días y etapa', () => {
+    const block = buildEpisodicMemoryBlock({
+      query: '¿cómo va mi maíz?',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [mkProcess({ process_id: 'p1' })],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).toContain('MEMORIA DE TU FINCA');
+    expect(block).toContain('Maíz');
+    expect(block).toContain('hace 40 días');
+    expect(block).toMatch(/etapa/i);
+    // Regla anti-invención presente
+    expect(block).toMatch(/JAMÁS inventes/i);
+  });
+
+  it('SIN historial → no-op (cadena vacía)', () => {
+    const block = buildEpisodicMemoryBlock({
+      query: '¿cómo va mi maíz?',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).toBe('');
+  });
+
+  it('historial IRRELEVANTE a la query → no-op (no spamea con toda la finca)', () => {
+    const block = buildEpisodicMemoryBlock({
+      query: '¿qué biopreparado sirve para la cebolla?',
+      resolvedEntities: [],
+      processes: [mkProcess()],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).toBe('');
+  });
+
+  it('incluye la última observación REAL registrada del proceso', () => {
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [mkProcess({ process_id: 'p1' })],
+      eventsByProcess: {
+        p1: [
+          {
+            event_id: 'e1',
+            type: 'farm_process_event',
+            attributes: {
+              process_id: 'p1',
+              event_type: 'observation',
+              occurred_at: NOW - 5 * DAY,
+              payload: { text: 'hojas amarillas en el borde del lote' },
+            },
+          },
+        ],
+      },
+      now: NOW,
+    });
+    expect(block).toContain('hojas amarillas en el borde del lote');
+  });
+
+  it('NO menciona especies que no están en el historial (cero invención)', () => {
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [mkProcess()],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).not.toMatch(/café|tomate|papa/i);
+  });
+});
+
+describe('buildEpisodicMemoryBlock — anticipación proactiva', () => {
+  it('señala transición de etapa inminente con plantilla fenológica + fecha de siembra real', () => {
+    // zea_mays a ≤1000 msnm: vegetative termina día 45, flowering arranca día 46.
+    // Sembrado hace 44 días → flowering arranca en ~2 días (dentro de 14 días).
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [mkProcess({ process_id: 'p1' }, { created_at: NOW - 44 * DAY })],
+      eventsByProcess: {},
+      fincaAltitud: 800,
+      now: NOW,
+    });
+    expect(block).toContain('ANTICIPACIÓN');
+    expect(block).toMatch(/OJO/);
+    expect(block).toMatch(/Floración/i);
+  });
+
+  it('sin plantilla fenológica para la especie → memoria sí, señal de etapa NO', () => {
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi cidra',
+      resolvedEntities: [{ ...SPECIES_ENTITY_MAIZ, canonical_id: 'sechium_edule', nombre_comun: 'Cidra', mentioned: 'cidra' }],
+      processes: [mkProcess({ process_id: 'p1' }, { subject_slug: 'sechium_edule', subject_label: 'Cidra', created_at: NOW - 44 * DAY })],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).toContain('MEMORIA DE TU FINCA');
+    expect(block).not.toMatch(/OJO/);
+  });
+
+  it('recurrencia estacional: manejo de plagas registrado por estas fechas en temporada pasada', () => {
+    const lastYearSameMonth = NOW - 365 * DAY;
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [
+        mkProcess({ process_id: 'p1' }),
+        mkProcess(
+          { process_id: 'p2' },
+          {
+            process_type: 'pest_management',
+            status: 'completed',
+            current_stage: 'pest_management',
+            created_at: lastYearSameMonth,
+            updated_at: lastYearSameMonth,
+            unit: 'plantas',
+          },
+        ),
+      ],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).toMatch(/temporada pasada/i);
+    expect(block).toMatch(/manejo de plagas/i);
+  });
+
+  it('manejo de plagas FUERA de temporada (hace 4 meses) → sin señal estacional', () => {
+    const fourMonthsAgo = NOW - 120 * DAY;
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      processes: [
+        mkProcess({ process_id: 'p1' }),
+        mkProcess(
+          { process_id: 'p2' },
+          {
+            process_type: 'pest_management',
+            status: 'completed',
+            current_stage: 'pest_management',
+            created_at: fourMonthsAgo,
+            updated_at: fourMonthsAgo,
+            unit: 'plantas',
+          },
+        ),
+      ],
+      eventsByProcess: {},
+      now: NOW,
+    });
+    expect(block).not.toMatch(/temporada pasada/i);
+  });
+
+  it(`anti-spam: nunca más de ${EPISODIC_MAX_ANTICIPATIONS} señales de anticipación`, () => {
+    const lastYear = NOW - 365 * DAY;
+    const block = buildEpisodicMemoryBlock({
+      query: 'mi maíz y mi fríjol y mi tomate',
+      resolvedEntities: [
+        SPECIES_ENTITY_MAIZ,
+        { ...SPECIES_ENTITY_MAIZ, canonical_id: 'phaseolus_vulgaris', nombre_comun: 'Fríjol', mentioned: 'fríjol' },
+        { ...SPECIES_ENTITY_MAIZ, canonical_id: 'solanum_lycopersicum', nombre_comun: 'Tomate', mentioned: 'tomate' },
+      ],
+      processes: [
+        // 2 transiciones inminentes + 1 estacional = 3 candidatas
+        mkProcess({ process_id: 'p1' }, { created_at: NOW - 44 * DAY }),
+        mkProcess({ process_id: 'p2' }, { subject_slug: 'phaseolus_vulgaris', subject_label: 'Fríjol', created_at: NOW - 33 * DAY }),
+        mkProcess(
+          { process_id: 'p3' },
+          {
+            subject_slug: 'solanum_lycopersicum',
+            subject_label: 'Tomate',
+            process_type: 'pest_management',
+            status: 'completed',
+            current_stage: 'pest_management',
+            created_at: lastYear,
+            updated_at: lastYear,
+          },
+        ),
+      ],
+      eventsByProcess: {},
+      fincaAltitud: 800,
+      now: NOW,
+    });
+    const anticipSection = block.split('ANTICIPACIÓN')[1] || '';
+    const lineas = anticipSection.split('\n').filter((l) => l.trim().startsWith('- '));
+    expect(lineas.length).toBeLessThanOrEqual(EPISODIC_MAX_ANTICIPATIONS);
+    expect(lineas.length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildEpisodicMemoryContext — loader con degradación limpia', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lee farmProcessCache y arma el bloque', async () => {
+    listFarmProcesses.mockResolvedValue([mkProcess({ process_id: 'p1' })]);
+    getFarmEvents.mockResolvedValue([]);
+    const block = await buildEpisodicMemoryContext({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      now: NOW,
+    });
+    expect(block).toContain('MEMORIA DE TU FINCA');
+    expect(listFarmProcesses).toHaveBeenCalled();
+  });
+
+  it('si IndexedDB falla → no-op silencioso (cadena vacía, sin throw)', async () => {
+    listFarmProcesses.mockRejectedValue(new Error('IDB not available'));
+    const block = await buildEpisodicMemoryContext({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      now: NOW,
+    });
+    expect(block).toBe('');
+  });
+
+  it('sin procesos en la finca → no-op', async () => {
+    listFarmProcesses.mockResolvedValue([]);
+    const block = await buildEpisodicMemoryContext({
+      query: 'mi maíz',
+      resolvedEntities: [SPECIES_ENTITY_MAIZ],
+      now: NOW,
+    });
+    expect(block).toBe('');
+  });
+});

--- a/src/services/__tests__/promptAssembler.test.js
+++ b/src/services/__tests__/promptAssembler.test.js
@@ -132,6 +132,41 @@ describe('assembleSystemContent — presupuesto y degradación', () => {
     }
   });
 
+  it('MEMORIA EPISÓDICA (TIER 2 #6): va ANTES del grounding y se sacrifica tras el corpus, sin tocar la evidencia', () => {
+    // Orden: memoria entre el contexto ambiental y el corpus — nunca después
+    // del grounding (la evidencia debe dominar por recency).
+    const ordered = assembleSystemContent({
+      base: 'BASE',
+      asociacion: 'BLOQUE_ASOCIACION',
+      memoria: 'BLOQUE_MEMORIA',
+      corpus: { variants: ['BLOQUE_CORPUS', ''] },
+      evidence: 'BLOQUE_EVIDENCIA',
+    });
+    const idx = (s) => ordered.content.indexOf(s);
+    expect(idx('BLOQUE_MEMORIA')).toBeGreaterThan(idx('BLOQUE_ASOCIACION'));
+    expect(idx('BLOQUE_MEMORIA')).toBeLessThan(idx('BLOQUE_CORPUS'));
+    expect(idx('BLOQUE_MEMORIA')).toBeLessThan(idx('BLOQUE_EVIDENCIA'));
+
+    // Sacrificio bajo presión: corpus cede primero, luego memoria; el
+    // grounding (evidence) queda intacto.
+    const big = 'm'.repeat(3200); // ~1208 tokens
+    const small = 'y'.repeat(265); // ~100 tokens
+    const r = assembleSystemContent(
+      {
+        base: small,
+        memoria: { variants: [big, ''] },
+        corpus: { variants: [big, ''] },
+        evidence: small,
+      },
+      { budget: 300 },
+    );
+    expect(r.breakdown.find((b) => b.name === 'corpus').degraded).toBe(true);
+    expect(r.breakdown.find((b) => b.name === 'memoria').degraded).toBe(true);
+    expect(r.breakdown.find((b) => b.name === 'evidence').degraded).toBe(false);
+    expect(r.content).toContain(small);
+    expect(r.content).not.toContain(big);
+  });
+
   it('exporta presupuestos coherentes con num_ctx 6144 → headroom 8192 (GR-10)', () => {
     expect(SYSTEM_PROMPT_TOKEN_BUDGET).toBe(6144);
     expect(PROMPT_TOKEN_BUDGET).toBe(8192);

--- a/src/services/episodicMemoryService.js
+++ b/src/services/episodicMemoryService.js
@@ -1,0 +1,326 @@
+/**
+ * episodicMemoryService — MEMORIA EPISÓDICA ACTIVA de la finca (TIER 2 #6).
+ *
+ * Problema que resuelve: el agente usaba el estado event-sourced (FarmProcess
+ * + farm_process_events en IndexedDB) solo de forma REACTIVA (auditoría IA:
+ * 3.0/5). Este módulo construye un bloque de system prompt con lo que la
+ * finca YA VIVIÓ respecto a lo que el usuario pregunta este turno:
+ *
+ *   1. MEMORIA RELEVANTE: si la query menciona una especie/plaga con
+ *      historial real ("sembraste tomate el 1/5, está en floración";
+ *      "registraste manejo de plagas en café en mayo"). Sale del event
+ *      store REAL — cero invención.
+ *   2. ANTICIPACIÓN PROACTIVA (máx. EPISODIC_MAX_ANTICIPATIONS señales):
+ *      - transición de etapa fenológica inminente (próximos
+ *        STAGE_LOOKAHEAD_DAYS días), calculada desde la fecha de siembra
+ *        REAL + la plantilla fenológica versionada (phenologyCalculator);
+ *      - recurrencia estacional: un manejo de plagas registrado por estas
+ *        mismas fechas en una temporada pasada.
+ *      Sin dato real (sin plantilla, sin historial estacional) → sin señal.
+ *
+ * DEGRADACIÓN LIMPIA: sin historial, historial irrelevante a la query o
+ * fallo de IndexedDB → '' (no-op silencioso). El bloque entra al
+ * promptAssembler como 'memoria' (prioridad media, SACRIFICABLE): jamás
+ * desplaza guardas ni grounding.
+ *
+ * @module episodicMemoryService
+ */
+import { calculateWindows } from './phenologyCalculator';
+import { listFarmProcesses, getFarmEvents } from '../db/farmProcessCache';
+
+const DAY = 86400000;
+
+/** Máximo de procesos narrados en el bloque de memoria (anti-spam). */
+export const EPISODIC_MAX_PROCESSES = 3;
+/** Máximo de señales de anticipación por turno (anti-spam). */
+export const EPISODIC_MAX_ANTICIPATIONS = 2;
+/** Ventana hacia adelante para señalar transición de etapa (días). */
+export const STAGE_LOOKAHEAD_DAYS = 14;
+/** Edad mínima de un manejo de plagas para contar como "temporada pasada". */
+const SEASONAL_MIN_AGE_DAYS = 60;
+
+/** Etiquetas legibles por etapa (acepta ambos vocabularios de farmProcess). */
+const STAGE_LABELS = {
+  sowing: 'Siembra',
+  sowing_confirmed: 'Siembra confirmada',
+  emergence: 'Emergencia (brotó)',
+  germination: 'Germinación',
+  vegetative: 'Crecimiento vegetativo',
+  growth: 'Crecimiento',
+  flowering: 'Floración',
+  fruiting: 'Formación de fruto',
+  harvest_window: 'Ventana de cosecha',
+  harvest: 'Cosecha',
+  post_harvest: 'Poscosecha',
+  pest_management: 'Manejo de plagas',
+  closed: 'Terminado',
+  fallow: 'Descanso',
+};
+
+/** Verbo de apertura por tipo de proceso (lo que el usuario REGISTRÓ). */
+const PROCESS_VERBS = {
+  sowing: 'Sembraste',
+  restoration: 'Registraste restauración con',
+  silvopasture: 'Registraste silvopastoreo con',
+  harvest: 'Registraste cosecha de',
+  post_harvest: 'Registraste poscosecha de',
+  pest_management: 'Registraste manejo de plagas en',
+};
+
+const _norm = (s) =>
+  String(s || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim();
+
+/** Tokens útiles (≥4 chars) de un texto normalizado. */
+const _tokens = (s) => _norm(s).split(/[^a-z0-9]+/).filter((t) => t.length >= 4);
+
+const _fmtFecha = (ts) =>
+  new Date(ts).toLocaleDateString('es-CO', { day: 'numeric', month: 'long', year: 'numeric' });
+
+const _fmtMesAno = (ts) =>
+  new Date(ts).toLocaleDateString('es-CO', { month: 'long', year: 'numeric' });
+
+const _truncate = (s, max = 140) => (s.length > max ? `${s.slice(0, max - 1)}…` : s);
+
+const _isSpeciesKind = (kind) => {
+  const k = String(kind || '').toLowerCase();
+  return k === '' || k === 'species' || k === 'planta' || k === 'especie' || k === 'cultivo';
+};
+
+/**
+ * matchRelevantProcesses — selecciona los procesos del historial que son
+ * RELEVANTES a la query de este turno. Doble vía:
+ *   a) slug canónico: subject_slug ∈ canonical_id de las entidades resueltas;
+ *   b) texto plano (degradación sin NLU): algún token (≥4 chars, acentos
+ *      normalizados) del subject_label/slug aparece en la query, o algún
+ *      token del nombre de una entidad aparece en el label/notas del proceso.
+ *
+ * Orden: activos primero, luego por updated_at descendente.
+ *
+ * @param {object} args
+ * @param {string} [args.query]
+ * @param {Array<object>|null} [args.resolvedEntities]
+ * @param {Array<import('../types/farmProcess').FarmProcess>} [args.processes]
+ * @returns {Array<import('../types/farmProcess').FarmProcess>}
+ */
+export function matchRelevantProcesses({ query = '', resolvedEntities = null, processes = [] } = {}) {
+  if (!Array.isArray(processes) || processes.length === 0) return [];
+
+  const slugSet = new Set();
+  const entityTokens = new Set();
+  if (Array.isArray(resolvedEntities)) {
+    for (const e of resolvedEntities) {
+      if (!e || typeof e !== 'object') continue;
+      if (_isSpeciesKind(e.kind) && e.canonical_id) slugSet.add(String(e.canonical_id));
+      for (const name of [e.nombre_comun, e.mentioned]) {
+        for (const t of _tokens(name)) entityTokens.add(t);
+      }
+    }
+  }
+  const queryNorm = _norm(query);
+
+  const matched = processes.filter((p) => {
+    const at = p && p.attributes;
+    if (!at) return false;
+    if (at.subject_slug && slugSet.has(at.subject_slug)) return true;
+
+    const procText = _norm(`${at.subject_label || ''} ${String(at.subject_slug || '').replace(/_/g, ' ')} ${at.notes || ''}`);
+    // b1) token del proceso mencionado en la query (sin NLU)
+    for (const t of _tokens(`${at.subject_label || ''} ${String(at.subject_slug || '').replace(/_/g, ' ')}`)) {
+      if (queryNorm.includes(t)) return true;
+    }
+    // b2) token de una entidad resuelta presente en label/notas del proceso
+    for (const t of entityTokens) {
+      if (procText.includes(t)) return true;
+    }
+    return false;
+  });
+
+  const rank = (p) => (p.attributes.status === 'active' ? 0 : 1);
+  matched.sort((a, b) => rank(a) - rank(b) || (b.attributes.updated_at || 0) - (a.attributes.updated_at || 0));
+  return matched;
+}
+
+/** Última observación/nota REAL con texto usable de un proceso (o null). */
+function _lastObservation(events) {
+  if (!Array.isArray(events)) return null;
+  for (const ev of events) {
+    const at = ev && ev.attributes;
+    if (!at) continue;
+    if (at.event_type !== 'observation' && at.event_type !== 'note') continue;
+    const text =
+      (at.payload && typeof at.payload.text === 'string' && at.payload.text.trim()) ||
+      (at.payload && typeof at.payload.note === 'string' && at.payload.note.trim()) ||
+      (typeof at.evidence === 'string' && at.evidence.trim()) ||
+      null;
+    if (text) return { occurred_at: at.occurred_at, text };
+  }
+  return null;
+}
+
+/** Línea de memoria de UN proceso (solo datos reales del agregado). */
+function _memoryLine(p, events, now) {
+  const at = p.attributes;
+  const label = at.subject_label || String(at.subject_slug || '').replace(/_/g, ' ') || 'ese cultivo';
+  const verb = PROCESS_VERBS[at.process_type] || 'Registraste';
+  const fecha = at.created_at ? _fmtFecha(at.created_at) : null;
+  const dias = at.created_at ? Math.max(0, Math.round((now - at.created_at) / DAY)) : null;
+
+  const partes = [`- ${verb} ${label}${fecha ? ` el ${fecha}` : ''}`];
+  if (at.status === 'active') {
+    const stageBase = String(at.current_stage || '').replace(/_confirmed$/, '');
+    const stageLbl = STAGE_LABELS[at.current_stage] || STAGE_LABELS[stageBase] || stageBase;
+    partes.push(` (hace ${dias} días): etapa actual ${stageLbl}.`);
+  } else {
+    partes.push(` (ciclo ${at.status === 'cancelled' ? 'cancelado' : 'terminado'}).`);
+  }
+  if (at.notes && typeof at.notes === 'string' && at.notes.trim()) {
+    partes.push(` Nota registrada: "${_truncate(at.notes.trim(), 100)}".`);
+  }
+  const obs = _lastObservation(events);
+  if (obs) {
+    partes.push(`\n  Última observación (${_fmtFecha(obs.occurred_at)}): "${_truncate(obs.text)}".`);
+  }
+  return partes.join('');
+}
+
+/** Señales de anticipación (solo con dato real; máx. EPISODIC_MAX_ANTICIPATIONS). */
+function _anticipationLines(matched, fincaAltitud, now) {
+  const lines = [];
+
+  // 1) Transición de etapa inminente: fecha de siembra REAL + plantilla
+  //    fenológica versionada. Sin plantilla → sin señal (degradación limpia).
+  for (const p of matched) {
+    const at = p.attributes;
+    if (at.status !== 'active') continue;
+    if (!['sowing', 'restoration', 'silvopasture'].includes(at.process_type)) continue;
+    if (!at.subject_slug || !at.created_at) continue;
+    let windows;
+    try {
+      windows = calculateWindows({ speciesSlug: at.subject_slug, sowingDate: at.created_at, altitudeM: fincaAltitud || undefined });
+    } catch {
+      continue;
+    }
+    const upcoming = (windows || []).find(
+      (w) =>
+        w.status === 'computed' &&
+        Number.isFinite(w.windowStart) &&
+        w.windowStart > now &&
+        w.windowStart <= now + STAGE_LOOKAHEAD_DAYS * DAY,
+    );
+    if (!upcoming) continue;
+    const label = at.subject_label || at.subject_slug;
+    const hasta = upcoming.windowEnd ? ` y el ${_fmtFecha(upcoming.windowEnd)}` : ' en adelante';
+    lines.push(
+      `- OJO: según tu fecha de siembra real, tu ${label} entra a ${upcoming.label} aproximadamente entre el ${_fmtFecha(upcoming.windowStart)}${hasta} (estimado fenológico, no fecha exacta).`,
+    );
+  }
+
+  // 2) Recurrencia estacional: manejo de plagas registrado por estas mismas
+  //    fechas (mes ±1) en una temporada pasada (≥ SEASONAL_MIN_AGE_DAYS).
+  for (const p of matched) {
+    const at = p.attributes;
+    if (at.process_type !== 'pest_management' || !at.created_at) continue;
+    const age = now - at.created_at;
+    if (age < SEASONAL_MIN_AGE_DAYS * DAY) continue;
+    const m1 = new Date(at.created_at).getMonth();
+    const m2 = new Date(now).getMonth();
+    const monthDist = Math.min((m1 - m2 + 12) % 12, (m2 - m1 + 12) % 12);
+    if (monthDist > 1) continue;
+    const label = at.subject_label || at.subject_slug || 'ese cultivo';
+    lines.push(
+      `- La temporada pasada registraste manejo de plagas en ${label} por estas mismas fechas (${_fmtMesAno(at.created_at)}) — vale la pena monitorear el cultivo esta semana.`,
+    );
+  }
+
+  return lines.slice(0, EPISODIC_MAX_ANTICIPATIONS);
+}
+
+/**
+ * buildEpisodicMemoryBlock — formateador PURO del bloque de memoria episódica.
+ * Solo narra eventos REALES del event store; sin historial relevante → ''.
+ *
+ * @param {object} args
+ * @param {string} [args.query]
+ * @param {Array<object>|null} [args.resolvedEntities]
+ * @param {Array<import('../types/farmProcess').FarmProcess>} [args.processes]
+ * @param {Object<string, Array<import('../types/farmProcess').FarmProcessEvent>>} [args.eventsByProcess]
+ *   eventos por process_id, ordenados por occurred_at DESC (como getFarmEvents).
+ * @param {number|null} [args.fincaAltitud] — msnm para la corrección fenológica.
+ * @param {number} [args.now=Date.now()]
+ * @returns {string} bloque de system prompt, o '' (no-op).
+ */
+export function buildEpisodicMemoryBlock({
+  query = '',
+  resolvedEntities = null,
+  processes = [],
+  eventsByProcess = {},
+  fincaAltitud = null,
+  now = Date.now(),
+} = {}) {
+  const matched = matchRelevantProcesses({ query, resolvedEntities, processes });
+  if (matched.length === 0) return '';
+
+  const narrados = matched.slice(0, EPISODIC_MAX_PROCESSES);
+  const memLines = narrados.map((p) => _memoryLine(p, eventsByProcess[p.process_id], now));
+  const anticipaciones = _anticipationLines(matched, fincaAltitud, now);
+
+  const secciones = [
+    `=== MEMORIA DE TU FINCA (historial REAL registrado — personaliza con esto) ===
+${memLines.join('\n')}`,
+  ];
+  if (anticipaciones.length > 0) {
+    secciones.push(`ANTICIPACIÓN (derivada de tu historial + fenología — menciónala solo si aporta):
+${anticipaciones.join('\n')}`);
+  }
+  secciones.push(`REGLA: estos son los ÚNICOS eventos registrados en la finca del usuario sobre lo que pregunta. Úsalos para personalizar la respuesta ("tu lote que sembraste el…"). JAMÁS inventes eventos, fechas, plagas ni cosechas que no estén listados aquí; si el usuario pregunta por algo sin registro, dilo honestamente.
+=== FIN MEMORIA DE TU FINCA ===`);
+
+  return secciones.join('\n\n');
+}
+
+/**
+ * buildEpisodicMemoryContext — loader + formateador. Lee el event store local
+ * (farmProcessCache en IndexedDB) y arma el bloque. CUALQUIER fallo (IDB no
+ * disponible, datos corruptos) degrada a '' sin romper el turno.
+ *
+ * @param {object} args
+ * @param {string} [args.query]
+ * @param {Array<object>|null} [args.resolvedEntities]
+ * @param {number|null} [args.fincaAltitud]
+ * @param {number} [args.now=Date.now()]
+ * @returns {Promise<string>}
+ */
+export async function buildEpisodicMemoryContext({
+  query = '',
+  resolvedEntities = null,
+  fincaAltitud = null,
+  now = Date.now(),
+} = {}) {
+  try {
+    const processes = (await listFarmProcesses()) || [];
+    if (processes.length === 0) return '';
+
+    const matched = matchRelevantProcesses({ query, resolvedEntities, processes });
+    if (matched.length === 0) return '';
+
+    const eventsByProcess = {};
+    await Promise.all(
+      matched.slice(0, EPISODIC_MAX_PROCESSES).map(async (p) => {
+        try {
+          eventsByProcess[p.process_id] = (await getFarmEvents(p.process_id)) || [];
+        } catch {
+          eventsByProcess[p.process_id] = [];
+        }
+      }),
+    );
+
+    return buildEpisodicMemoryBlock({ query, resolvedEntities, processes, eventsByProcess, fincaAltitud, now });
+  } catch (err) {
+    console.warn('[EpisodicMemory] degradando a no-op:', err && err.message);
+    return '';
+  }
+}

--- a/src/services/promptAssembler.js
+++ b/src/services/promptAssembler.js
@@ -75,6 +75,7 @@ export const BLOCK_ORDER = [
   'clima', // contexto ambiental — sacrificable en emergencia
   'finca', // contexto ambiental — sacrificable en emergencia
   'asociacion', // policultivo — sacrificable en emergencia
+  'memoria', // MEMORIA EPISÓDICA de la finca (TIER 2 #6) — prioridad media, sacrificable
   'corpus', // RAG — PRIMER sacrificio (por variantes con menos chunks)
   'frostHeat', // riesgo térmico por cultivo
   'viabilidad', // GUARDA viabilidad/altitud (protegido)
@@ -95,11 +96,13 @@ export const BLOCK_ORDER = [
  * resto (base, guardas, grounding, análisis) es intocable.
  */
 // Orden de sacrificio bajo presión de presupuesto: primero el corpus RAG (por
-// chunks), luego el contexto AMBIENTAL (asociaciones, fase ENSO, riesgo
-// térmico y por último el marco de finca — su altitud también la cita el
-// bloque de viabilidad). El grounding duro (evidencia, entidades, dosis
-// curadas, cadena del grafo) y las guardas NUNCA están aquí: jamás se recortan.
-const SACRIFICE_ORDER = ['corpus', 'asociacion', 'clima', 'frostHeat', 'finca'];
+// chunks), luego la MEMORIA EPISÓDICA (personalización: valiosa pero nunca por
+// encima de las guardas ni la evidencia — TIER 2 #6), luego el contexto
+// AMBIENTAL (asociaciones, fase ENSO, riesgo térmico y por último el marco de
+// finca — su altitud también la cita el bloque de viabilidad). El grounding
+// duro (evidencia, entidades, dosis curadas, cadena del grafo) y las guardas
+// NUNCA están aquí: jamás se recortan.
+const SACRIFICE_ORDER = ['corpus', 'memoria', 'asociacion', 'clima', 'frostHeat', 'finca'];
 
 const _normalize = (t) => (typeof t === 'string' ? t.replace(/^\n+|\n+$/g, '') : '');
 


### PR DESCRIPTION
## Qué hace

TIER 2 #6 — la auditoría IA puntuó 3.0/5 ("usa estado event-sourced pero es reactivo"). Este PR hace que el agente USE el historial real de la finca para PERSONALIZAR y ANTICIPAR.

### 1. Bloque de memoria relevante a la query (`episodicMemoryService`)
- Lee el event store REAL: `FarmProcess` + `farm_process_events` en IndexedDB (`farmProcessCache`).
- Si la query menciona una especie/cultivo con historial, inyecta lo que la finca YA vivió: *"Sembraste Maíz el 1 de mayo de 2026 (hace 40 días): etapa actual Crecimiento vegetativo"*, manejos de plaga registrados, última observación con texto real.
- Matching doble vía: `canonical_id` del grounding AGE (entidades resueltas) + fallback por texto normalizado sin acentos (funciona aun degradado sin NLU).

### 2. Anticipación proactiva (máx. 2 señales — anti-spam)
- **Transición de etapa inminente** (≤14 días): fecha de siembra REAL + plantilla fenológica versionada (`phenologyCalculator`, con corrección por altitud de la finca). *"OJO: tu Maíz entra a Floración aprox. entre el …"*
- **Recurrencia estacional**: manejo de plagas registrado por estas mismas fechas (mes ±1) en una temporada pasada (≥60 días).
- Solo con dato real: sin plantilla o sin historial estacional → sin señal.

### 3. Cero fabricación / degradación limpia
- El bloque narra ÚNICAMENTE eventos del event store y cierra con regla explícita: *"JAMÁS inventes eventos, fechas, plagas ni cosechas que no estén listados aquí"*.
- Sin historial, historial irrelevante a la query, o IndexedDB caído → `''` (no-op silencioso, el turno no se rompe).
- Gate de precio: igual que finca/viabilidad, no se inyecta en consultas de mercado.

### 4. Respeta promptAssembler (#1392)
- Nuevo bloque `memoria` con prioridad MEDIA: entra al presupuesto, va entre el contexto ambiental y el corpus (antes del grounding), y en `SACRIFICE_ORDER` cede justo después del corpus RAG — **jamás desplaza guardas ni evidencia**.

## Tests (TDD)
- `episodicMemoryService.test.js` (16 tests): con historial → bloque inyectado con datos reales; sin historial / irrelevante → no-op; anticipación solo con plantilla + dato real; fuera de temporada → sin señal; anti-spam ≤2 señales; IDB falla → `''`.
- `promptAssembler.test.js`: orden del bloque `memoria` + sacrificio tras corpus sin tocar la evidencia.
- `eslint --max-warnings=0` limpio en los 5 archivos tocados.
- Suite completa: 4261 passed; los 15 fails existentes (visionCache/sidecarClient/mediaCache/AgentHero) son pre-existentes en `origin/main` limpio (verificado con `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)