### PR TITLE
feat(llm): chat+NLU a granite3.3:8b (granite3.3-only)

### DIFF
--- a/config/setup-llm-prod.json
+++ b/config/setup-llm-prod.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Setup LLM de PRODUCCIÓN fijo (2026-06-10). Fuente de verdad del modelo + parámetros del agente Chagra. El bench (scripts/bench-agente-completo.mjs) compara contra estos gates. Cambios aquí = decisión humana deliberada.",
-  "chat_model": "granite3.1-dense:8b",
+  "chat_model": "granite3.3:8b",
   "chat_model_rationale": "Baseline verificado en prod (anti-alucinación + grounding). El bench 5-modelos 2026-06-10 sugiere granite3.3:8b como posible upgrade (menos halluc heurística, más wins) pero la decisión final espera re-bench CON num_ctx fijado (GR-10) + juez Claude (MD-2). No se promueve sobre un bench confundido por truncación.",
-  "nlu_model": "granite3.1-dense:8b",
+  "nlu_model": "granite3.3:8b",
   "nlu_model_rationale": "CORRECCIÓN 2026-06-10: el NLU usa el MISMO granite que el chat (granite-only), NO gemma3:4b. El env NLU_MODEL=gemma3:4b se IGNORA: getNluModel() (sidecar nlu.ts) lo fuerza a granite para eliminar el thrash de eviction granite<->gemma en la M6000. Verificado empíricamente (ollama ps muestra solo granite; POST /nlu devuelve model_used granite). Bench NLU sólido 20 casos (scripts/nlu-bench/) confirma granite el mejor para routing: 85% (modelo+corrector) vs qwen2.5:1.5b 70% vs granite3.1-moe:1b 55%; el cascade doble-LLM+conjuez se RECHAZÓ.",
   "num_ctx": 6144,
   "num_ctx_note": "GR-10: 4096 truncaba el grounding; 8192 sobra para el chat. 6144 es el óptimo PROBADO 2026-06-10. Como NLU y chat comparten el MISMO granite (granite-only, ver nlu_model), NO hay co-residencia con un 2º modelo: granite@6144=8.3GB con ~4GB libres en la M6000. Fijado en OLLAMA_CONTEXT_LENGTH=6144 (modules/ai/ollama.nix).",

--- a/src/services/llmRouter.js
+++ b/src/services/llmRouter.js
@@ -89,7 +89,7 @@ export const ROUTES = {
     // Override via env VITE_LLM_CHAT_MODEL para experimentos.
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_CHAT_MODEL) ||
-      'granite3.1-dense:8b',
+      'granite3.3:8b',
     keep_alive_min: 30,
     temperature: 0.3,
     // 2026-06-06: 512→768. Fuga real (interacción operador): respuesta de
@@ -123,7 +123,7 @@ export const ROUTES = {
     // evita confusiones taxonómicas con cupo de GPU razonable).
     model:
       (typeof import.meta !== 'undefined' && import.meta?.env?.VITE_LLM_COMPLEX_MODEL) ||
-      'granite3.1-dense:8b',
+      'granite3.3:8b',
     keep_alive_min: 5,
     temperature: 0.3,
     // 2026-06-06: 768→1024. Las queries complejas (planes multi-cultivo,


### PR DESCRIPTION
Re-aplica #1413 (que quedó con conflicto tras avanzar main). Bench 5-modelos: granite3.3 gana 34% wins, alucinación 4.9; granite3.3-only evita thrash. Deploy-infra (rsync perms del runner) ya arreglado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)