### PR TITLE
feat(suelos): modulo de diagnostico sin laboratorio (DR-SUELOS-1, 3/3 DeepSeek+Gemini+Meta)

### DIFF
--- a/src/data/soil-diagnostics.json
+++ b/src/data/soil-diagnostics.json
@@ -1,0 +1,354 @@
+{
+  "fuente": "DR-SUELOS-1-consolidado (3/3 DeepSeek+Gemini+Meta, 2026-06-11)",
+  "referencias": ["IGAC", "AGROSAVIA", "CIPAV", "FAO", "SENA", "USDA-NRCS", "CENICAFE", "Jaramillo 2002"],
+  "indicadores": [
+    {
+      "id": "textura_frasco",
+      "nombre": "Textura del frasco (sedimentación)",
+      "que_mide": "% arena / limo / arcilla",
+      "confiabilidad": "alta",
+      "como_se_hace": [
+        "Llenar frasco 1/3 con suelo seco y tamizado (sin piedras ni raíces)",
+        "Agregar agua hasta 2/3 y 1 cucharada de detergente",
+        "Agitar fuerte 2 minutos",
+        "Dejar reposar: arena sedimenta en 1 minuto, limo en 2 horas, arcilla en 24-48 horas",
+        "Medir capas con regla y calcular porcentajes"
+      ],
+      "fuente": "USDA-NRCS, adaptación AGROSAVIA"
+    },
+    {
+      "id": "textura_cinta",
+      "nombre": "Textura de la cinta (al tacto)",
+      "que_mide": "Contenido aproximado de arcilla",
+      "confiabilidad": "media_alta",
+      "como_se_hace": [
+        "Humedecer una porción de suelo",
+        "Amasar hasta formar una cinta entre los dedos",
+        "Si la cinta mide más de 5 cm antes de romperse: suelo arcilloso",
+        "Si no forma cinta: arenoso"
+      ],
+      "fuente": "USDA-NRCS"
+    },
+    {
+      "id": "ph_tiras",
+      "nombre": "pH con tiras (suelo:agua 1:2)",
+      "que_mide": "pH del suelo con precisión ±0.5",
+      "confiabilidad": "alta",
+      "como_se_hace": [
+        "Mezclar 1 parte de suelo seco con 2 partes de agua destilada",
+        "Agitar y dejar reposar 10 minutos",
+        "Sumergir tira de pH en el sobrenadante",
+        "Comparar color con escala"
+      ],
+      "fuente": "AGROSAVIA, protocolo estándar de laboratorio de suelos"
+    },
+    {
+      "id": "ph_repollo",
+      "nombre": "pH con repollo morado",
+      "que_mide": "pH cualitativo (±1.5)",
+      "confiabilidad": "baja",
+      "como_se_hace": [
+        "Hervir hojas de repollo morado en agua destilada 15 min",
+        "Filtrar el líquido (será morado neutro, rojo ácido, verde alcalino)",
+        "Agregar 1 cucharada de suelo y observar cambio de color"
+      ],
+      "fuente": "SENA, cartillas de química casera"
+    },
+    {
+      "id": "vinagre_bicarbonato",
+      "nombre": "Vinagre y bicarbonato",
+      "que_mide": "Solo carbonatos masivos (pH>7.5) o acidez extrema",
+      "confiabilidad": "mito",
+      "como_se_hace": [
+        "Vinagre sobre suelo: si burbujea → carbonatos (alcalino raro en suelos andinos)",
+        "Bicarbonato + agua + suelo: si burbujea → muy ácido (poco confiable)"
+      ],
+      "advertencia": "NO sirve para decidir dosis de cal. El vinagre NO detecta acidez intercambiable (Al³⁺) que es la que daña los cultivos en Colombia. Riesgo: falso negativo → no encalar cuando SÍ se necesita, o falso positivo → sobre-encalar y arruinar el lote.",
+      "fuente": "USDA-NRCS (descartado para diagnóstico), validación IGAC"
+    },
+    {
+      "id": "infiltracion_hoyo",
+      "nombre": "Infiltración del hoyo (doble llenado)",
+      "que_mide": "Velocidad de drenaje",
+      "confiabilidad": "alta",
+      "como_se_hace": [
+        "Cavar hoyo de 30x30x30 cm",
+        "Llenar con agua, dejar drenar completamente",
+        "Llenar de nuevo y medir cuánto baja en 1 hora",
+        "Menos de 1 cm/hora: drenaje muy lento (encharcamiento)",
+        "Más de 10 cm/hora: drenaje excesivo (arenoso)"
+      ],
+      "fuente": "USDA-NRCS, adaptación CIPAV"
+    },
+    {
+      "id": "varilla_penetracion",
+      "nombre": "Varilla de penetración",
+      "que_mide": "Compactación / pie de arado",
+      "confiabilidad": "media",
+      "como_se_hace": [
+        "Insertar varilla metálica de 6mm en suelo húmedo",
+        "Si se frena antes de 20 cm: hay capa compactada (pie de arado)"
+      ],
+      "fuente": "AGROSAVIA, manual de labranza de conservación"
+    },
+    {
+      "id": "terron_agua",
+      "nombre": "Terrón en agua (slake test)",
+      "que_mide": "Estabilidad de agregados / glomalina",
+      "confiabilidad": "media",
+      "como_se_hace": [
+        "Tomar 2 terrones secos: uno del lote cultivado, otro de zona no perturbada (lindero)",
+        "Poner cada uno en una canastilla de alambre",
+        "Sumergir simultáneamente en agua",
+        "Si el terrón del lote se deshace rápido y el del lindero no: falta materia orgánica y cementantes biológicos"
+      ],
+      "fuente": "USDA-NRCS (slake test), refinamiento Gemini con control comparativo"
+    },
+    {
+      "id": "calicata_simple",
+      "nombre": "Calicata simple (50-60 cm)",
+      "que_mide": "Profundidad efectiva, moteados, horizontes",
+      "confiabilidad": "alta",
+      "como_se_hace": [
+        "Cavar un hueco de 50-60 cm de profundidad en una pared vertical",
+        "Observar colores, raíces, manchas grises/azuladas (mal drenaje)",
+        "Medir profundidad hasta capa dura o roca",
+        "Menos de 40 cm: limita cultivos perennes"
+      ],
+      "fuente": "FAO, guía de campo para evaluación de suelos"
+    },
+    {
+      "id": "test_mostaza",
+      "nombre": "Test de la mostaza para lombrices",
+      "que_mide": "Actividad biológica (lombrices)",
+      "confiabilidad": "alta",
+      "como_se_hace": [
+        "Disolver 3 cucharadas de mostaza en polvo en 1 litro de agua",
+        "Verter dentro de un anillo de 30 cm de diámetro en el suelo",
+        "Esperar 10 minutos y contar las lombrices que salen",
+        "0 lombrices = crítico (1/10), ~5 = moderado (5/10), 10+ = excelente (10/10)"
+      ],
+      "advertencia": "Confiabilidad ALTA solo con humedad moderada. En sequía extrema o inundación las lombrices migran profundo → falsos negativos.",
+      "fuente": "AGROSAVIA, protocolo estándar de macrofauna del suelo"
+    }
+  ],
+  "bioindicadores": [
+    {
+      "id": "helecho_marranero",
+      "nombre": "Helecho marranero (Pteridium aquilinum)",
+      "indica": "acidez",
+      "detalle": "pH<5, posible toxicidad de aluminio",
+      "confiabilidad": "media_alta"
+    },
+    {
+      "id": "lombrices",
+      "nombre": "Lombrices (> 20 por palada)",
+      "indica": "suelo_vivo",
+      "detalle": "Buena actividad biológica y materia orgánica",
+      "confiabilidad": "alta"
+    },
+    {
+      "id": "micorriza",
+      "nombre": "Micorriza (pelusa blanca en raíz)",
+      "indica": "suelo_vivo",
+      "detalle": "Hongos benéficos asociados a raíces",
+      "confiabilidad": "alta"
+    },
+    {
+      "id": "cortadera_coquito",
+      "nombre": "Cortadera / Coquito (Cyperus spp.)",
+      "indica": "compactacion_encharcamiento",
+      "detalle": "Aerénquima en raíz indica hipoxia por mal drenaje",
+      "confiabilidad": "media_alta"
+    },
+    {
+      "id": "bledo_amaranto",
+      "nombre": "Bledo / Amaranto (Amaranthus spp.)",
+      "indica": "fertilidad_nitrogeno",
+      "detalle": "Planta nitrófila — indica buen contenido de N",
+      "confiabilidad": "media"
+    },
+    {
+      "id": "escobilla_babosa",
+      "nombre": "Escobilla / Babosa (Waltheria indica / Sida spp.)",
+      "indica": "compactacion_fisica",
+      "detalle": "Raíz pivotante perfora capas duras — indica compactación crónica",
+      "confiabilidad": "alta"
+    },
+    {
+      "id": "costra_dura",
+      "nombre": "Costra dura superficial",
+      "indica": "degradacion",
+      "detalle": "Suelo desnudo, encostramiento por impacto de lluvia sin cobertura",
+      "confiabilidad": "media"
+    },
+    {
+      "id": "hormiga_arriera",
+      "nombre": "Hormiga arriera (Atta spp.)",
+      "indica": "mito",
+      "detalle": "MITO: 'donde hay arriera la tierra es buena'. No es indicador de fertilidad — la arriera prefiere suelos degradados y bordes de bosque intervenido.",
+      "confiabilidad": "mito"
+    },
+    {
+      "id": "vendeaguja_imperata",
+      "nombre": "Vendeaguja (Imperata cylindrica)",
+      "indica": "mito",
+      "detalle": "MITO: 'indica acidez'. No es confiable — vive en pH hasta 8. Puede ser señal de degradación pero NO de acidez específica.",
+      "confiabilidad": "mito"
+    },
+    {
+      "id": "musgo_solo",
+      "nombre": "Musgo",
+      "indica": "mito",
+      "detalle": "MITO: 'musgo = acidez'. Puede indicar solo sombra o humedad alta, no necesariamente acidez.",
+      "confiabilidad": "mito"
+    }
+  ],
+  "tipos_suelo": [
+    {
+      "id": "andisol",
+      "nombre": "Andisol — Suelo de ceniza volcánica",
+      "ph_rango": "4.8-5.5",
+      "piso_termico": "andino_alto",
+      "retos": ["fija fósforo irreversiblemente (trampa del P)", "aluminio activo", "alta materia orgánica pero ácido"],
+      "recomendacion": "Cal dolomítica en dosis bajas fraccionadas + roca fosfórica molida (NO DAP) + compost maduro + micorrizas. Las alófanas fijan el P — los ácidos húmicos del compost compiten por los sitios de fijación."
+    },
+    {
+      "id": "oxisol_ultisol",
+      "nombre": "Oxisol / Ultisol — Suelo tropical antiguo",
+      "ph_rango": "4.0-5.0",
+      "piso_termico": "calido",
+      "retos": ["acidez extrema", "aluminio neurotóxico para raíces (Al³⁺)", "fertilidad muy baja"],
+      "recomendacion": "Encalado inicial 3-5 t/ha (dosis ALTA) + abonos verdes (mucuna, canavalia) obligatorios + Brachiaria para construir horizonte fértil. SEMBRAR DIRECTO SIN ENCALAR = FRACASO 100%."
+    },
+    {
+      "id": "inceptisol",
+      "nombre": "Inceptisol — Suelo joven de ladera",
+      "ph_rango": "5.0-6.5",
+      "piso_termico": "medio",
+      "retos": ["erosión", "poca profundidad efectiva", "pedregosidad"],
+      "recomendacion": "Cobertura vegetal permanente + curvas a nivel + barreras vivas (vetiver, limoncillo). No arar en pendiente."
+    },
+    {
+      "id": "mollisol",
+      "nombre": "Mollisol — Suelo de pradera fértil",
+      "ph_rango": "6.0-7.5",
+      "piso_termico": "medio_bajo",
+      "retos": ["inundación en valle", "salinidad en zonas áridas", "agrietamiento en seco (vertisol)"],
+      "recomendacion": "Drenaje + rotación de cultivos. Vigilar salinidad si riego con agua dura."
+    },
+    {
+      "id": "vertisol",
+      "nombre": "Vertisol — Suelo arcilloso expansivo",
+      "ph_rango": "6.5-8.0",
+      "piso_termico": "calido_medio",
+      "retos": ["agrietamiento severo en seco", "inundación en lluvia", "muy pesado para labranza"],
+      "recomendacion": "Incorporar materia orgánica + yeso agrícola para mejorar estructura. NO trabajar en húmedo. Momento justo de humedad es clave."
+    },
+    {
+      "id": "entisol",
+      "nombre": "Entisol — Suelo muy joven o degradado",
+      "ph_rango": "variable",
+      "piso_termico": "todos",
+      "retos": ["sin horizonte definido", "pedregoso o arenoso", "fertilidad variable"],
+      "recomendacion": "Construir suelo desde cero: materia orgánica masiva + abonos verdes + cobertura. Puede tomar 1-3 años."
+    }
+  ],
+  "enmiendas": [
+    {
+      "id": "cal_dolomitica",
+      "nombre": "Cal dolomítica (Ca+Mg)",
+      "problema_que_corrige": "acidez",
+      "dosis_orientativa": "1-2 t/ha en franco, 2-4 t/ha en arcilloso. Máximo 1 t/ha/año sin análisis de laboratorio",
+      "precaucion": "NO sobre-encalar: pH>7 bloquea hierro y zinc. NO aplicar con urea o estiércol fresco (pérdida de N por volatilización). En Andisoles: dosis bajas fraccionadas por la alta capacidad buffer. SOLO si pH<5.5 confirmado por tiras o helecho.",
+      "fuente": "AGROSAVIA, CENICAFÉ"
+    },
+    {
+      "id": "ceniza_madera",
+      "nombre": "Ceniza de madera",
+      "problema_que_corrige": "acidez_leve",
+      "dosis_orientativa": "1-2 t/ha",
+      "precaucion": "JAMÁS en suelo alcalino (pH>7). No usar ceniza tratada, pintada o de carbón mineral. Aporta potasio pero puede salinizar en exceso. No mezclar con nitrato de amonio.",
+      "fuente": "FAO, manual de fertilización orgánica"
+    },
+    {
+      "id": "roca_fosforica",
+      "nombre": "Roca fosfórica molida",
+      "problema_que_corrige": "deficit_fosforo_acido",
+      "dosis_orientativa": "200-500 kg/ha",
+      "precaucion": "SOLO funciona en pH<5.5 con microorganismos activos. Inútil en suelo neutro o alcalino. Requiere tiempo (liberación lenta). No es DAP — no esperar respuesta inmediata.",
+      "fuente": "CIPAV, AGROSAVIA"
+    },
+    {
+      "id": "compost_bocashi",
+      "nombre": "Compost maduro / Bocashi",
+      "problema_que_corrige": "baja_materia_organica",
+      "dosis_orientativa": "Compost 5-10 t/ha (2-3 kg/m²); mulch 5-10 cm de espesor",
+      "precaucion": "Debe estar bien descompuesto (olor a tierra de bosque, no a podrido). El bocashi inmaduro quema raíces. No incorporar en exceso bajo cultivos que prefieren suelo pobre (algunas aromáticas).",
+      "fuente": "AGROSAVIA, CIPAV, manual de abonos orgánicos"
+    },
+    {
+      "id": "abonos_verdes",
+      "nombre": "Abonos verdes de raíz profunda (mucuna, canavalia, crotalaria, nabo forrajero)",
+      "problema_que_corrige": "compactacion",
+      "dosis_orientativa": "Nabo forrajero 20 kg/ha; mucuna 30-40 kg/ha",
+      "precaucion": "Incorporar en floración (máximo N). Cincel solo en suelo seco para romper capa compactada. No voltear capas del suelo (labranza mínima). La mucuna puede volverse invasora si no se maneja.",
+      "fuente": "CIPAV, AGROSAVIA, FAO"
+    },
+    {
+      "id": "camellones_drenaje",
+      "nombre": "Camellones altos / zanjas de drenaje",
+      "problema_que_corrige": "encharcamiento",
+      "dosis_orientativa": "Camellones de 20-30 cm de alto; zanjas con pendiente para escurrir",
+      "precaucion": "Nunca sembrar aguacate en plano con mal drenaje → muerte segura por Phytophthora. Camellones DEBEN tener salida de agua. En pendiente fuerte, las zanjas necesitan barreras para no erosionar.",
+      "fuente": "AGROSAVIA, CENICAFÉ (manejo de Phytophthora en aguacate)"
+    },
+    {
+      "id": "barreras_vivas",
+      "nombre": "Barreras vivas (vetiver, limoncillo, botón de oro)",
+      "problema_que_corrige": "erosion",
+      "dosis_orientativa": "Cada 10-15 metros en curvas a nivel",
+      "precaucion": "Nunca dejar suelo desnudo. Las barreras necesitan 6-12 meses para establecerse. Combinar con cobertura muerta (mulch) mientras crecen.",
+      "fuente": "CIPAV, FAO"
+    },
+    {
+      "id": "yeso_agricola",
+      "nombre": "Yeso agrícola (sulfato de calcio)",
+      "problema_que_corrige": "suelo_sodico_arcilloso",
+      "dosis_orientativa": "1-3 t/ha según análisis",
+      "precaucion": "NO es cal — no sube el pH. Solo para suelos sódicos (PSI>15) o arcillosos dispersos. No sustituye la cal para acidez.",
+      "fuente": "USDA-NRCS"
+    }
+  ],
+  "senales_voz": {
+    "tierra_amarilla_pegajosa": { "problemas": ["arcilla", "acidez", "mal_drenaje"], "prueba": "textura_cinta", "confianza": "media" },
+    "tierra_colorada": { "problemas": ["oxido_hierro", "acidez_potencial"], "prueba": "ph_tiras", "confianza": "media" },
+    "se_empoza": { "problemas": ["mal_drenaje", "arcilla"], "prueba": "infiltracion_hoyo", "confianza": "alta" },
+    "la_tierra_llora_el_agua": { "problemas": ["mal_drenaje", "napa_alta"], "prueba": "calicata_simple", "confianza": "alta" },
+    "queda_barro": { "problemas": ["arcilla", "mal_drenaje"], "prueba": "textura_frasco", "confianza": "alta" },
+    "tierra_cansada_no_da": { "problemas": ["baja_materia_organica", "deficit_nutrientes"], "prueba": "test_mostaza", "confianza": "media" },
+    "tierra_flojita": { "problemas": ["baja_materia_organica"], "prueba": "test_mostaza", "confianza": "media" },
+    "dura_como_piedra": { "problemas": ["compactacion"], "prueba": "varilla_penetracion", "confianza": "alta" },
+    "el_palin_rebota": { "problemas": ["compactacion"], "prueba": "varilla_penetracion", "confianza": "alta" },
+    "no_entra_el_palin": { "problemas": ["compactacion", "pedregosidad"], "prueba": "varilla_penetracion", "confianza": "alta" },
+    "tierra_negra_buena": { "problemas": ["ninguno"], "prueba": null, "confianza": "media" },
+    "huele_a_monte_bueno": { "problemas": ["ninguno"], "prueba": null, "confianza": "media" },
+    "negra_y_sueltica": { "problemas": ["ninguno"], "prueba": null, "confianza": "alta" },
+    "se_rueda_pal_rio": { "problemas": ["erosion"], "prueba": "calicata_simple", "confianza": "alta" },
+    "se_lava_cuando_llueve": { "problemas": ["erosion"], "prueba": "calicata_simple", "confianza": "alta" },
+    "sale_helecho": { "problemas": ["acidez"], "prueba": "ph_tiras", "confianza": "media_alta" },
+    "sale_mortino": { "problemas": ["acidez"], "prueba": "ph_tiras", "confianza": "media" },
+    "no_amarra": { "problemas": ["arenoso", "baja_retencion"], "prueba": "textura_frasco", "confianza": "media" },
+    "lama_musgo": { "problemas": ["acidez_posible", "humedad_alta"], "prueba": "ph_tiras", "confianza": "baja" },
+    "pura_greda_chiclosa": { "problemas": ["arcilla_pesada"], "prueba": "textura_cinta", "confianza": "alta" },
+    "la_huerta_esta_cansada": { "problemas": ["baja_materia_organica", "agotamiento"], "prueba": "test_mostaza", "confianza": "media" }
+  },
+  "cultivo_suelo": {
+    "cafe": { "ph_min": 5.0, "ph_max": 6.0, "textura": "franco", "drenaje": "bueno", "profundidad_min_cm": 60, "fuente": "CENICAFE" },
+    "maiz": { "ph_min": 5.5, "ph_max": 7.5, "textura": "franco", "drenaje": "moderado", "fuente": "AGROSAVIA" },
+    "frijol": { "ph_min": 6.0, "ph_max": 7.0, "textura": "franco", "drenaje": "bueno", "nota": "NO tolera encharcamiento", "fuente": "AGROSAVIA" },
+    "papa": { "ph_min": 5.0, "ph_max": 6.5, "textura": "franco_arenoso", "drenaje": "bueno", "fuente": "AGROSAVIA" },
+    "aguacate": { "ph_min": 5.5, "ph_max": 6.5, "textura": "franco", "drenaje": "excelente", "nota": "DRENAJE PERFECTO OBLIGATORIO. Si hoyo >4h encharcado: ALERTA CRITICA (Phytophthora). Camellones altos o zanjas obligatorios.", "fuente": "CENICAFE, AGROSAVIA" },
+    "tomate": { "ph_min": 6.0, "ph_max": 7.0, "textura": "franco", "drenaje": "bueno", "materia_organica": "alta", "fuente": "AGROSAVIA" }
+  }
+}

--- a/src/services/__tests__/soilDiagnostic.test.js
+++ b/src/services/__tests__/soilDiagnostic.test.js
@@ -1,0 +1,166 @@
+/**
+ * soilDiagnostic.test.js — tests del módulo de suelos (DR-SUELOS-1).
+ *
+ * Verifica: sintoma→prueba correcta, acidez→cal con guarda,
+ * MITOs advertidos, sin datos→no inventa, aguacate→alerta crítica.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { diagnosticarSuelo, formatearGroundingSuelo } from '../soilDiagnostic';
+
+describe('diagnosticarSuelo — árbol de decisión', () => {
+  it('retorna sin_datos si descripción vacía o muy corta', () => {
+    expect(diagnosticarSuelo('').sin_datos).toBe(true);
+    expect(diagnosticarSuelo('ab').sin_datos).toBe(true);
+    expect(diagnosticarSuelo(null).sin_datos).toBe(true);
+    expect(diagnosticarSuelo(undefined).sin_datos).toBe(true);
+  });
+
+  it('"tierra amarilla pegajosa" → problemas de arcilla, acidez, mal drenaje', () => {
+    const d = diagnosticarSuelo('mi tierra es amarilla y pegajosa');
+    expect(d.problemas).toContain('arcilla');
+    expect(d.problemas).toContain('acidez');
+    expect(d.problemas).toContain('mal_drenaje');
+    expect(d.sin_datos).toBe(false);
+  });
+
+  it('"se empoza cuando llueve" → prueba de infiltración del hoyo', () => {
+    const d = diagnosticarSuelo('el lote se empoza cuando llueve');
+    expect(d.problemas).toContain('mal_drenaje');
+    expect(d.pruebas.some((p) => p.id === 'infiltracion_hoyo')).toBe(true);
+  });
+
+  it('"el palín rebota, dura como piedra" → compactación + varilla', () => {
+    const d = diagnosticarSuelo('el palín rebota, está dura como piedra');
+    expect(d.problemas).toContain('compactacion');
+    expect(d.pruebas.some((p) => p.id === 'varilla_penetracion')).toBe(true);
+  });
+
+  it('"tierra negra y sueltica, huele a monte bueno" → sin problemas', () => {
+    const d = diagnosticarSuelo('mi tierra es negra y sueltica, huele a monte bueno');
+    expect(d.problemas).toContain('ninguno');
+    expect(d.pruebas).toHaveLength(0);
+  });
+
+  it('"sale helecho" → acidez + sugiere pH tiras', () => {
+    const d = diagnosticarSuelo('en mi lote sale mucho helecho');
+    expect(d.problemas).toContain('acidez');
+    expect(d.pruebas.some((p) => p.id === 'ph_tiras')).toBe(true);
+  });
+
+  it('"hay cortadera y coquito" → compactación/encharcamiento + varilla', () => {
+    const d = diagnosticarSuelo('hay mucha cortadera y coquito en el lote');
+    expect(d.problemas).toContain('compactacion_encharcamiento');
+    expect(d.pruebas.some((p) => p.id === 'varilla_penetracion')).toBe(true);
+  });
+
+  it('"tierra cansada que ya no da" → baja MO + test mostaza', () => {
+    const d = diagnosticarSuelo('la tierra está cansada, ya no da nada');
+    expect(d.problemas).toContain('baja_materia_organica');
+    expect(d.pruebas.some((p) => p.id === 'test_mostaza')).toBe(true);
+  });
+
+  it('sin datos suficientes no inventa problemas ni enmiendas', () => {
+    const d = diagnosticarSuelo('hola buenos días');
+    expect(d.sin_datos).toBe(true);
+    expect(d.problemas).toHaveLength(0);
+    expect(d.enmiendas).toHaveLength(0);
+  });
+});
+
+describe('diagnosticarSuelo — guardas de seguridad', () => {
+  it('acidez → recomienda cal dolomítica con guarda de NO sobre-encalar', () => {
+    const d = diagnosticarSuelo('tengo tierra amarilla pegajosa');
+    const cal = d.enmiendas.find((e) => e.id === 'cal_dolomitica');
+    expect(cal).toBeDefined();
+    expect(cal.precaucion).toContain('NO sobre-encalar');
+    expect(d.advertencias.some((a) => a.includes('NO sobre-encalar'))).toBe(true);
+  });
+
+  it('acidez → advertencia de no aplicar cal con urea o estiércol fresco', () => {
+    const d = diagnosticarSuelo('tengo tierra amarilla pegajosa y sale helecho');
+    expect(d.advertencias.some((a) => a.includes('urea'))).toBe(true);
+  });
+
+  it('acidez → solo encalar si pH<5.5 confirmado', () => {
+    const d = diagnosticarSuelo('sale helecho en mi lote');
+    expect(d.advertencias.some((a) => a.includes('pH<5.5'))).toBe(true);
+  });
+
+  it('acidez en suelo no alcalino → también sugiere ceniza de madera con guarda', () => {
+    const d = diagnosticarSuelo('tengo tierra amarilla pegajosa');
+    const ceniza = d.enmiendas.find((e) => e.id === 'ceniza_madera');
+    expect(ceniza).toBeDefined();
+    expect(ceniza.precaucion).toContain('JAMÁS en suelo alcalino');
+  });
+
+  it('acidez + tierra colorada → sugiere roca fosfórica con guarda', () => {
+    const d = diagnosticarSuelo('tengo tierra colorada y ácida');
+    const rf = d.enmiendas.find((e) => e.id === 'roca_fosforica');
+    expect(rf).toBeDefined();
+    expect(rf.precaucion).toContain('SOLO funciona en pH<5.5');
+  });
+});
+
+describe('diagnosticarSuelo — MITOS advertidos', () => {
+  it('mencionar vinagre → advertencia de MITO', () => {
+    const d = diagnosticarSuelo('le eché vinagre a la tierra para ver si era ácida');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('vinagre'))).toBe(true);
+    expect(d.advertencias.some((a) => a.includes('tiras de pH'))).toBe(true);
+  });
+
+  it('mencionar bicarbonato → advertencia de MITO', () => {
+    const d = diagnosticarSuelo('hice la prueba del bicarbonato y no burbujeó');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('bicarbonato'))).toBe(true);
+  });
+
+  it('mencionar hormiga arriera → advertencia de MITO', () => {
+    const d = diagnosticarSuelo('donde hay hormiga arriera la tierra es buena');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('arriera'))).toBe(true);
+  });
+
+  it('mencionar vendeaguja → advertencia de MITO', () => {
+    const d = diagnosticarSuelo('hay vendeaguja en mi lote, será ácido?');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.toLowerCase().includes('vendeaguja'))).toBe(true);
+  });
+
+  it('mencionar musgo → advertencia de MITO', () => {
+    const d = diagnosticarSuelo('tiene musgo la tierra');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('musgo'))).toBe(true);
+  });
+});
+
+describe('diagnosticarSuelo — cultivos específicos', () => {
+  it('aguacate + mal drenaje → ALERTA CRITICA Phytophthora', () => {
+    const d = diagnosticarSuelo('quiero sembrar aguacate pero el terreno se empoza');
+    expect(d.advertencias.some((a) => a.includes('ALERTA CRÍTICA') && a.includes('Phytophthora'))).toBe(true);
+    expect(d.advertencias.some((a) => a.includes('Camellones altos'))).toBe(true);
+  });
+
+  it('aguacate + arcilla → ALERTA CRITICA', () => {
+    const d = diagnosticarSuelo('voy a sembrar aguacate en tierra amarilla pegajosa');
+    expect(d.advertencias.some((a) => a.includes('ALERTA CRÍTICA'))).toBe(true);
+  });
+
+  it('aguacate sin problemas de drenaje → sin alerta', () => {
+    const d = diagnosticarSuelo('quiero sembrar aguacate, la tierra está buena');
+    expect(d.advertencias.some((a) => a.includes('ALERTA CRÍTICA'))).toBe(false);
+  });
+});
+
+describe('formatearGroundingSuelo', () => {
+  it('retorna vacío si sin_datos', () => {
+    expect(formatearGroundingSuelo({ sin_datos: true })).toBe('');
+    expect(formatearGroundingSuelo(null)).toBe('');
+  });
+
+  it('incluye problemas, pruebas, enmiendas y guardas', () => {
+    const d = diagnosticarSuelo('tengo tierra amarilla pegajosa y sale helecho');
+    const f = formatearGroundingSuelo(d);
+    expect(f).toContain('Problemas detectados');
+    expect(f).toContain('Pruebas caseras recomendadas');
+    expect(f).toContain('Enmiendas sugeridas');
+    expect(f).toContain('GUARDAS DE SEGURIDAD');
+    expect(f).toContain('DR-SUELOS-1');
+  });
+});

--- a/src/services/soilDiagnostic.js
+++ b/src/services/soilDiagnostic.js
@@ -1,0 +1,265 @@
+/**
+ * soilDiagnostic — diagnóstico de suelo sin laboratorio (DR-SUELOS-1).
+ *
+ * Fuente: DR-SUELOS-1-consolidado (3/3 DeepSeek+Gemini+Meta, 2026-06-11).
+ * Datos: src/data/soil-diagnostics.json
+ *
+ * Árbol de decisión: escuchar → visual → bio-indicadores → textura →
+ * pH → estructura → recomendar enmienda con guarda.
+ *
+ * Guardas de seguridad:
+ * - Vinagre/bicarbonato NO sirve para decidir cal (MITO).
+ * - NO sobre-encalar (pH>7 bloquea Fe/Zn).
+ * - Ceniza JAMÁS en suelo alcalino.
+ * - Cal NO con urea/estiércol fresco.
+ * - Recomendación de cal SOLO si pH<5.5 confirmado.
+ * - Aguacate: si mal drenaje → ALERTA CRÍTICA.
+ *
+ * CERO invención. Solo datos con fuente en el consolidado.
+ */
+
+import SOIL_DATA from '../data/soil-diagnostics.json';
+
+/**
+ * @typedef {Object} DiagnosticoResult
+ * @property {string[]} problemas — lista de problemas detectados
+ * @property {Object[]} pruebas — pruebas caseras sugeridas
+ * @property {Object[]} enmiendas — enmiendas recomendadas con guarda
+ * @property {Object|null} suelo — tipo de suelo estimado (si aplica)
+ * @property {string[]} advertencias — guardas activas
+ * @property {boolean} sin_datos — true si no hay suficiente información
+ * @property {string} fuente — referencia al DR
+ */
+
+/**
+ * Mapea la descripción del campesino a problemas de suelo.
+ * Usa las señales de voz del DR.
+ *
+ * @param {string} descripcion — texto del campesino describiendo su suelo
+ * @returns {DiagnosticoResult}
+ */
+export function diagnosticarSuelo(descripcion) {
+  if (!descripcion || typeof descripcion !== 'string' || descripcion.trim().length < 3) {
+    return {
+      problemas: [],
+      pruebas: [],
+      enmiendas: [],
+      suelo: null,
+      advertencias: [],
+      sin_datos: true,
+      fuente: SOIL_DATA.fuente,
+    };
+  }
+
+  const texto = descripcion.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const problemas = new Set();
+  const pruebasIds = new Set();
+  const advertencias = [];
+
+  // 1. Mapear señales de voz a problemas + pruebas
+  for (const [clave, senal] of Object.entries(SOIL_DATA.senales_voz)) {
+    const palabras = clave.split('_');
+    if (palabras.every((p) => texto.includes(p) || texto.includes(p.replace('a', '')))) {
+      senal.problemas.forEach((p) => problemas.add(p));
+      if (senal.prueba) pruebasIds.add(senal.prueba);
+    }
+  }
+
+  // 2. Bio-indicadores mencionados
+  for (const bio of SOIL_DATA.bioindicadores) {
+    const nombreNorm = bio.nombre.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    // Match más flexible: cada palabra significativa del nombre del bio
+    // debe aparecer en el texto (ignoramos conectores /, (), etc.)
+    const palabrasBio = nombreNorm
+      .replace(/[\/\(\)\[\],.]/g, ' ')
+      .split(/\s+/)
+      .filter((p) => p.length > 3);
+    const matchBio = palabrasBio.some((p) => texto.includes(p));
+
+    if (matchBio) {
+      if (bio.confiabilidad === 'mito') {
+        advertencias.push(`MITO: ${bio.nombre} — ${bio.detalle}`);
+      } else if (bio.indica && bio.indica !== 'mito') {
+        problemas.add(bio.indica);
+        if (bio.indica === 'acidez') pruebasIds.add('ph_tiras');
+        if (bio.indica === 'suelo_vivo') pruebasIds.add('test_mostaza');
+        if (bio.indica.includes('compactacion')) pruebasIds.add('varilla_penetracion');
+        if (bio.indica.includes('encharcamiento')) pruebasIds.add('infiltracion_hoyo');
+        if (bio.indica.includes('fertilidad')) pruebasIds.add('test_mostaza');
+        if (bio.indica === 'degradacion') pruebasIds.add('terron_agua');
+      }
+    }
+  }
+
+  // 2b. Advertencias de mitos si se menciona vinagre/bicarbonato (sin necesidad de bio-indicador)
+  if (texto.includes('vinagre') || texto.includes('bicarbonato')) {
+    advertencias.push(
+      'MITO: Vinagre/bicarbonato NO sirve para decidir dosis de cal. El vinagre solo reacciona con carbonatos masivos (pH>7.5, rarísimo en suelos andinos). No detecta acidez intercambiable (Al³⁺) que es la que daña los cultivos. Use tiras de pH.',
+    );
+  }
+
+  // 3. Detectar cultivo mencionado para alertas específicas
+  const cultivo = detectarCultivo(texto);
+
+  // 4. Si no hay datos, no inventar
+  if (problemas.size === 0 && advertencias.length === 0) {
+    return {
+      problemas: [],
+      pruebas: [],
+      enmiendas: [],
+      suelo: null,
+      advertencias: [],
+      sin_datos: true,
+      fuente: SOIL_DATA.fuente,
+    };
+  }
+
+  // 5. Buscar pruebas sugeridas
+  const pruebas = [];
+  for (const id of pruebasIds) {
+    const indicador = SOIL_DATA.indicadores.find((i) => i.id === id);
+    if (indicador) {
+      pruebas.push({
+        id: indicador.id,
+        nombre: indicador.nombre,
+        confiabilidad: indicador.confiabilidad,
+        como_se_hace: indicador.como_se_hace,
+        advertencia: indicador.advertencia || null,
+      });
+    }
+  }
+
+  // 6. Recomendar enmiendas con guardas
+  const enmiendas = [];
+  const tieneAcidez = problemas.has('acidez') || problemas.has('acidez_potencial') || problemas.has('acidez_leve');
+  if (tieneAcidez) {
+    enmiendas.push(buscarEnmienda('cal_dolomitica'));
+    advertencias.push(
+      'GUARDA: NO sobre-encalar. pH>7 bloquea hierro y zinc. Cal DOLOMITICA (Ca+Mg), no cal viva.',
+      'GUARDA: NO aplicar cal con urea o estiércol fresco — pérdida de nitrógeno por volatilización.',
+      'GUARDA: Solo encalar si pH<5.5 confirmado (tiras o helecho marranero).',
+    );
+    // Ceniza SOLO si no hay señal de alcalinidad
+    if (!problemas.has('alcalino') && !problemas.has('sodico')) {
+      enmiendas.push(buscarEnmienda('ceniza_madera'));
+    }
+  }
+  if (tieneAcidez || problemas.has('deficit_fosforo_acido')) {
+    enmiendas.push(buscarEnmienda('roca_fosforica'));
+    advertencias.push(
+      'GUARDA: Roca fosfórica SOLO funciona en pH<5.5 con microorganismos. No usar DAP en Andisoles (la trampa del P lo vuelve insoluble).',
+    );
+  }
+  if (problemas.has('baja_materia_organica') || problemas.has('deficit_nutrientes') || problemas.has('agotamiento')) {
+    enmiendas.push(buscarEnmienda('compost_bocashi'));
+  }
+  if (problemas.has('compactacion') || problemas.has('compactacion_fisica') || problemas.has('compactacion_encharcamiento')) {
+    enmiendas.push(buscarEnmienda('abonos_verdes'));
+  }
+  if (problemas.has('mal_drenaje') || problemas.has('encharcamiento')) {
+    enmiendas.push(buscarEnmienda('camellones_drenaje'));
+  }
+  if (problemas.has('erosion')) {
+    enmiendas.push(buscarEnmienda('barreras_vivas'));
+  }
+  if (problemas.has('arcilla_pesada') || problemas.has('sodico')) {
+    enmiendas.push(buscarEnmienda('yeso_agricola'));
+  }
+
+  // 7. Alerta de aguacate si se menciona y hay mal drenaje
+  if (cultivo === 'aguacate' && (problemas.has('mal_drenaje') || problemas.has('arcilla') || problemas.has('arcilla_pesada') || problemas.has('encharcamiento'))) {
+    advertencias.push(
+      'ALERTA CRÍTICA: Aguacate con mal drenaje = muerte segura por Phytophthora cinnamomi. Camellones altos (≥60cm) o zanjas de drenaje OBLIGATORIOS. NUNCA sembrar en plano.',
+    );
+  }
+
+  // 8. Advertencias de mitos si se mencionan
+
+  // 9. Estimar tipo de suelo
+  const suelo = estimarTipoSuelo(problemas, texto);
+
+  return {
+    problemas: Array.from(problemas),
+    pruebas,
+    enmiendas: enmiendas.filter(Boolean),
+    suelo,
+    advertencias,
+    sin_datos: false,
+    fuente: SOIL_DATA.fuente,
+  };
+}
+
+function buscarEnmienda(id) {
+  const e = SOIL_DATA.enmiendas.find((enm) => enm.id === id);
+  return e ? { id: e.id, nombre: e.nombre, problema_que_corrige: e.problema_que_corrige, dosis_orientativa: e.dosis_orientativa, precaucion: e.precaucion, fuente: e.fuente } : null;
+}
+
+function detectarCultivo(texto) {
+  for (const cultivo of Object.keys(SOIL_DATA.cultivo_suelo)) {
+    if (texto.includes(cultivo)) return cultivo;
+  }
+  return null;
+}
+
+function estimarTipoSuelo(problemas, texto) {
+  // Heurística simple basada en pisos térmicos y problemas
+  if (texto.includes('paramo') || texto.includes('volcan') || texto.includes('ceniza')) {
+    return SOIL_DATA.tipos_suelo.find((t) => t.id === 'andisol');
+  }
+  if (texto.includes('llano') || texto.includes('amazonia') || texto.includes('selva') || texto.includes('tierra roja')) {
+    if (problemas.has('acidez')) return SOIL_DATA.tipos_suelo.find((t) => t.id === 'oxisol_ultisol');
+  }
+  if (texto.includes('ladera') || texto.includes('pendiente') || texto.includes('loma') && problemas.has('erosion')) {
+    return SOIL_DATA.tipos_suelo.find((t) => t.id === 'inceptisol');
+  }
+  if (problemas.has('arcilla_pesada') && !problemas.has('acidez')) {
+    return SOIL_DATA.tipos_suelo.find((t) => t.id === 'vertisol');
+  }
+  return null;
+}
+
+/**
+ * Retorna solo las guardas activas para los problemas detectados.
+ * Útil para inyectar al grounding del agente como bloque de seguridad.
+ *
+ * @param {DiagnosticoResult} diagnostico
+ * @returns {string}
+ */
+export function formatearGroundingSuelo(diagnostico) {
+  if (!diagnostico || diagnostico.sin_datos) return '';
+
+  const partes = [];
+
+  if (diagnostico.suelo) {
+    partes.push(`**Tipo de suelo estimado:** ${diagnostico.suelo.nombre} (pH ${diagnostico.suelo.ph_rango}). ${diagnostico.suelo.recomendacion}`);
+  }
+
+  if (diagnostico.problemas.length > 0) {
+    partes.push(`**Problemas detectados:** ${diagnostico.problemas.join(', ')}.`);
+  }
+
+  if (diagnostico.pruebas.length > 0) {
+    const confiables = diagnostico.pruebas.filter((p) => p.confiabilidad === 'alta' || p.confiabilidad === 'media_alta');
+    if (confiables.length > 0) {
+      partes.push('**Pruebas caseras recomendadas:**');
+      confiables.forEach((p) => {
+        partes.push(`- ${p.nombre} (confiabilidad: ${p.confiabilidad}). ${p.como_se_hace[0]}`);
+      });
+    }
+  }
+
+  if (diagnostico.enmiendas.length > 0) {
+    partes.push('**Enmiendas sugeridas:**');
+    diagnostico.enmiendas.forEach((e) => {
+      partes.push(`- ${e.nombre}: ${e.dosis_orientativa}. ${e.precaucion}`);
+    });
+  }
+
+  if (diagnostico.advertencias.length > 0) {
+    partes.push('**GUARDAS DE SEGURIDAD:**');
+    diagnostico.advertencias.forEach((a) => partes.push(`- ${a}`));
+  }
+
+  partes.push(`Fuente: ${diagnostico.fuente}`);
+  return partes.join('\n\n');
+}


### PR DESCRIPTION
## Módulo de suelos — diagnóstico sin laboratorio (DR-SUELOS-1)

### Fuente

DR-SUELOS-1-consolidado (triple-validación DeepSeek+Gemini+Meta, 2026-06-11).
Referencias: IGAC, AGROSAVIA, CIPAV, FAO, SENA, USDA-NRCS, CENICAFÉ, Jaramillo 2002.
CERO invención — cada dato tiene fuente.

### Datos ingeridos (`soil-diagnostics.json`)

| Tipo | Conteo | Detalle |
|---|---|---|
| Indicadores (pruebas caseras) | 10 | Textura del frasco, textura cinta, pH tiras, pH repollo, vinagre/bicarbonato, infiltración hoyo, varilla penetración, terrón en agua, calicata simple, test mostaza |
| Bio-indicadores | 10 | Helecho, lombrices, micorriza, cortadera, bledo, escobilla, costra dura + 3 MITOS marcados |
| MITOS marcados | 3 | Hormiga arriera, vendeaguja, musgo — todos con `confiabilidad: "mito"` |
| Tipos de suelo Colombia | 6 | Andisol, Oxisol/Ultisol, Inceptisol, Mollisol, Vertisol, Entisol |
| Enmiendas | 8 | Cal dolomítica, ceniza madera, roca fosfórica, compost/bocashi, abonos verdes, camellones/drenaje, barreras vivas, yeso agrícola |
| Señales de voz | 21 | "tierra amarilla pegajosa", "se empoza", "el palín rebota", "tierra cansada", etc. |
| Cultivos | 6 | Café, maíz, fríjol, papa, aguacate, tomate |

### Servicio (`soilDiagnostic.js`)

Árbol de decisión: escuchar → voz → bio-indicadores → prueba → enmienda con guarda.

### Guardas de seguridad (críticas)

| Guarda | Descripción |
|---|---|
| Vinagre/bicarbonato | MITO — NO sirve para decidir dosis de cal. Advertencia activa. |
| NO sobre-encalar | pH>7 bloquea hierro y zinc. |
| Ceniza JAMÁS en alcalino | Saliniza si exceso. |
| Cal NO con urea/estiércol fresco | Pérdida de N por volatilización. |
| Cal solo si pH<5.5 | Confirmado por tiras o helecho marranero. |
| Aguacate + mal drenaje | ALERTA CRÍTICA — Phytophthora cinnamomi. Camellones OBLIGATORIOS. |

### Tests (24)

| Categoría | Tests |
|---|---|
| Árbol de decisión | sintoma→problema, señal de voz→prueba sugerida |
| Guardas | acidez→cal+guarda, NO sobre-encalar, ceniza con restricción, roca fosfórica con guarda |
| MITOS | vinagre, bicarbonato, hormiga arriera, vendeaguja, musgo — todos advertidos |
| Cultivos | aguacate+mal drenaje→ALERTA CRÍTICA |
| Degradación | sin datos → `sin_datos: true`, no inventa problemas ni enmiendas |
| Grounding | `formatearGroundingSuelo()` produce bloque para el agente |

```
npx vitest run: 24 tests pasan
eslint --max-warnings=0 OK
```

### Integración con el agente (pendiente)

`formatearGroundingSuelo()` está listo para ser inyectado al grounding del
agente. El punto de conexión es `knowledgeIntentRouter` o `AgentScreen`
cuando el usuario pregunte sobre suelos. La función retorna un bloque de
texto formateado con problemas, pruebas, enmiendas y guardas.
