### PR TITLE
feat(agua): modulo de diagnostico + calculadora de captacion (DR-AGUA-1, 3/3)

### DIFF
--- a/src/data/water-diagnostics.json
+++ b/src/data/water-diagnostics.json
@@ -1,0 +1,83 @@
+{
+  "fuente": "DR-AGUA-1-consolidado (3/3 DeepSeek+Gemini+Meta, 2026-06-11)",
+  "referencias": ["IDEAM", "AGROSAVIA", "CIPAV", "FAO", "SENA", "Cenicafe", "CORPOICA", "CIAT", "UICN"],
+  "fuentes_agua": [
+    { "id": "lluvia_techo", "nombre": "Lluvia de techo", "calidad": "buena_con_tratamiento", "nota": "Mejor fuente. Requiere primer-flush + filtro (malla + arena + carbon). Hervir o clorar para consumo humano.", "fuente": "FAO, SENA-CINARA" },
+    { "id": "quebrada_nacimiento", "nombre": "Quebrada o nacimiento", "calidad": "riesgo_coliformes", "nota": "Riesgo de coliformes y agroquimicos rio arriba. Proteger nacimiento: cercar 100m, reforestar nativos, letrina >=30m aguas abajo.", "fuente": "Decreto 2811/1974, Ley 388/1997" },
+    { "id": "aljibe_pozo", "nombre": "Aljibe o pozo", "calidad": "variable", "nota": "Riesgo de nitratos por letrinas cercanas y salinidad (CE<2 dS/m para riego).", "fuente": "FAO" },
+    { "id": "reservorio", "nombre": "Reservorio o jagüey", "calidad": "riego_solamente", "nota": "Solo para riego, no consumo. Tapar para reducir evaporacion (5-7mm/dia en clima calido).", "fuente": "CIPAV" }
+  ],
+  "sistemas_captacion": [
+    { "id": "techo_zinc", "nombre": "Techo de zinc/galvanizado", "ce": 0.90, "unidad": "coeficiente", "fuente": "FAO 2013" },
+    { "id": "techo_cemento", "nombre": "Techo de cemento/placa", "ce": 0.88, "unidad": "coeficiente", "fuente": "FAO 2013" },
+    { "id": "techo_arcilla", "nombre": "Teja de arcilla/barro", "ce": 0.75, "unidad": "coeficiente", "fuente": "FAO 2013" },
+    { "id": "techo_paja", "nombre": "Palma/paja", "ce": 0.55, "unidad": "coeficiente", "fuente": "FAO 2013" },
+    { "id": "superficie_arcilloso", "nombre": "Escorrentia en suelo arcilloso", "ce": 0.55, "unidad": "coeficiente", "fuente": "FAO 2013" },
+    { "id": "superficie_arenoso", "nombre": "Escorrentia en suelo arenoso", "ce": 0.20, "unidad": "coeficiente", "fuente": "FAO 2013" }
+  ],
+  "lluvia_region": {
+    "caribe_seco": { "min_mm": 800, "max_mm": 1200, "nombre": "Caribe seco" },
+    "andina_cafetera": { "min_mm": 1800, "max_mm": 2500, "nombre": "Andina cafetera" },
+    "altiplano": { "min_mm": 600, "max_mm": 1000, "nombre": "Altiplano cundiboyacense" },
+    "pacifica": { "min_mm": 4000, "max_mm": 8000, "nombre": "Pacifico" },
+    "orinoquia_amazonia": { "min_mm": 2000, "max_mm": 4500, "nombre": "Orinoquia/Amazonia" }
+  },
+  "sistemas_riego": [
+    { "id": "goteo_cinta", "nombre": "Goteo con cinta 16mm", "eficiencia": 0.88, "costo": "bajo", "nota": "Funciona por gravedad desde tanque a 1.5m de altura. 1-2 L/h por gotero.", "fuente": "CIPAV, FAO" },
+    { "id": "botella_enterrada", "nombre": "Botella enterrada", "eficiencia": 0.85, "costo": "cero", "nota": "Para frutales jovenes. Botella PET con agujeros, enterrada junto a la raiz.", "fuente": "CIPAV, SENA" },
+    { "id": "mecha_wicking", "nombre": "Riego por mecha (wicking)", "eficiencia": 0.80, "costo": "cero", "nota": "Algodon o tela de mecha entre un reservorio y la planta. Para almácigos y pequeñas areas.", "fuente": "FAO" },
+    { "id": "microaspersion", "nombre": "Microaspersion", "eficiencia": 0.75, "costo": "medio", "nota": "Para cultivos densos. Riesgo de mojar follaje (hongos).", "fuente": "FAO" },
+    { "id": "gravedad_surcos", "nombre": "Gravedad mejorada en surcos", "eficiencia": 0.55, "costo": "cero", "nota": "Surcos en curvas a nivel. Baja eficiencia pero cero inversion.", "fuente": "AGROSAVIA" }
+  ],
+  "practicas_conservacion": [
+    { "id": "mulch", "nombre": "Mulch o cobertura", "reduce_evaporacion_pct": 50, "nota": "Reduce evaporacion 30-70%, uso de agua 29%. Capa >=5cm de residuos vegetales.", "fuente": "Scielo Peru, FAO" },
+    { "id": "zanjas_infiltracion", "nombre": "Zanjas de infiltracion", "aumenta_infiltracion_pct": 25, "nota": "40x40cm en curvas a nivel con nivel-A. 2m largo, tabiques cada 40cm. +15-30% infiltracion.", "fuente": "CIPAV, FAO" },
+    { "id": "medias_lunas", "nombre": "Medias lunas / microcuencas", "efecto": "captacion_in_situ", "nota": "Semicirculos alrededor de arboles en zonas secas. Captan y concentran el agua de escorrentia.", "fuente": "FAO, UICN" },
+    { "id": "barreras_vivas_agua", "nombre": "Barreras vivas (vetiver, boton de oro)", "aumenta_infiltracion_pct": 20, "nota": "En curvas a nivel. Raices profundas que abren el suelo.", "fuente": "CIPAV" },
+    { "id": "materia_organica", "nombre": "Materia organica en el suelo", "retencion_mm_por_pct_mo": 17, "nota": "Cada 1% de MO retiene ~15-20mm mas por metro de suelo. Conecta con modulo de suelos.", "fuente": "FAO" },
+    { "id": "primer_flush", "nombre": "Primer-flush con boya", "nota": "Desviar 1L por m2 de techo en tubo PVC sellado con boya de poliestireno. Lava polvo, heces de aves y hojas del techo. Llave micrometrica drena en 12-24h (auto-resetea).", "fuente": "SENA-CINARA, FAO" }
+  ],
+  "cultivos_agua": {
+    "maiz": { "lamina_mm_ciclo": "500-800", "etapa_critica": "floracion + llenado de grano", "tolerancia_sequia": "baja_en_critica", "fuente": "AGROSAVIA, FAO" },
+    "frijol": { "lamina_mm_ciclo": "350-500", "etapa_critica": "floracion + formacion vainas", "tolerancia_sequia": "baja", "fuente": "AGROSAVIA" },
+    "papa": { "lamina_mm_ciclo": "600-800", "etapa_critica": "tuberizacion", "nota": "Suspender riego 2 semanas antes de cosecha.", "fuente": "AGROSAVIA" },
+    "cafe": { "lamina_mm_anual": "1200-1500", "lamina_dia_planta": "1.8-4.2 L/dia segun densidad y altitud", "fuente": "Cenicafe" },
+    "aguacate": { "lamina_mm_anual": "800-1200", "etapa_critica": "floracion + cuaje", "tolerancia_sequia": "sensible", "nota": "Sensible a helada (-1.1C), abscision floral >28C, polen muere >32C.", "fuente": "AGROSAVIA, CORPOICA" },
+    "cebolla": { "lamina_mm_ciclo": "350-550", "kc": "0.4→1.1", "nota": "SUSPENDER riego 15-25 dias antes de cosecha.", "fuente": "AGROSAVIA, FAO" },
+    "hortalizas": { "lamina_mm_ciclo": "200-400", "tolerancia_sequia": "muy_baja", "fuente": "AGROSAVIA" }
+  },
+  "enso_agua": {
+    "el_nino": {
+      "antes": ["cosechar agua masivo", "reservorios", "mulch en perennes", "reducir area sembrada a lo regable", "cultivos resistentes: frijol caupi/yuca/sorgo (calido), quinua/habas (frio)", "proteger nacimientos"],
+      "durante": ["riego deficitario 50% en etapas criticas, de noche", "sacrificar ordenado: pastos de corte > maiz tardio > hortalizas de hoja", "SALVAR frutales perennes + cafe establecido", "mulch maximo"],
+      "fuente": "IDEAM, CIPAV, FAO"
+    },
+    "la_nina": {
+      "durante": ["drenaje", "camas/camellones altos", "vertederos de excedencia", "conectar con modulo de suelos (drenaje)"],
+      "fuente": "IDEAM, CIPAV"
+    }
+  },
+  "mitos": [
+    { "id": "riego_lunar", "nombre": "Calendario lunar de riego/siembra", "veredicto": "MITO (2-de-3 LLMs)", "detalle": "No hay evidencia fisica. Las mareas terrestres son insignificantes para la humedad del suelo. La humedad depende de evaporacion, viento y temperatura.", "fuente": "DR-AGUA-1 (DeepSeek+Meta lo marcan MITO)" },
+    { "id": "radiestesia_varillas", "nombre": "Radiestesia / pendulo / varillas para hallar agua", "veredicto": "PSEUDOCIENCIA", "detalle": "Usar vegetacion indicadora (helecho, junco, nacedero) + geologia local, NO varillas.", "fuente": "DR-AGUA-1 (consenso)" },
+    { "id": "hidrogel_sintetico", "nombre": "Poliacrilato de potasio / hidrogel sintetico", "veredicto": "NO AGROECOLOGICO", "detalle": "Polimero petroquimico. La alternativa agroecologica es materia organica + mulch (retiene humedad sin sinteticos).", "fuente": "DR-AGUA-1 (Gemini lo propuso; DeepSeek+Meta NO lo avalan)" }
+  ],
+  "senales_voz": {
+    "se_me_seca_el_cultivo": { "problemas": ["deficit_hidrico", "estres_sequia"], "prueba": "punado", "confianza": "alta" },
+    "matas_amanecen_tristes": { "problemas": ["deficit_hidrico"], "prueba": "punado", "confianza": "media" },
+    "no_llueve_hace_meses": { "problemas": ["sequia_prolongada"], "accion": "enso", "confianza": "alta" },
+    "cielo_pelado": { "problemas": ["sequia_prolongada"], "accion": "enso", "confianza": "alta" },
+    "el_agua_no_me_alcanza": { "problemas": ["capacidad_insuficiente"], "accion": "dimensionar_captacion", "confianza": "alta" },
+    "cargar_de_lejos": { "problemas": ["capacidad_insuficiente", "falta_infraestructura"], "accion": "dimensionar_captacion", "confianza": "alta" },
+    "se_seco_la_quebrada": { "problemas": ["fuente_agotada", "sequia"], "accion": "enso", "confianza": "alta" },
+    "se_me_ahogo_la_mata": { "problemas": ["exceso_hidrico", "mal_drenaje"], "accion": "drenaje", "confianza": "alta" },
+    "tanta_lluvia": { "problemas": ["exceso_hidrico"], "accion": "drenaje", "confianza": "media" }
+  },
+  "guardas": {
+    "marchitez_mediodia": "La marchitez al mediodia NO significa que necesita riego — es cierre estomatico normal por calor. Haga la prueba del punado a 15-20cm: si el suelo arena NO forma bola esta seco; si arcilla forma cinta sin escurrir esta en capacidad de campo. Regar con suelo humedo enfria las raices (shock) y desperdicia agua.",
+    "riego_manana": "Regar en la manana o madrugada (menos evaporacion, las plantas absorben antes del calor). Regar de noche puede favorecer hongos en clima frio.",
+    "primer_flush": "Desvie los primeros 0.5-1mm de lluvia (1L por m2 de techo). Lava polvo, heces de aves y hojas acumuladas.",
+    "tanque_tapa": "Tape el tanque con tapa hermosa o malla anti-zancudo. En clima calido la evaporacion puede ser 5-7mm/dia.",
+    "no_regar_suelo_humedo": "Nunca regar si la prueba del punado da humedo. El exceso de agua pudre raices y lava nutrientes."
+  }
+}

--- a/src/services/__tests__/waterDiagnostic.test.js
+++ b/src/services/__tests__/waterDiagnostic.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calcularCaptacion,
+  estimarLluviaRegion,
+  buscarCaptacion,
+  diagnosticarAgua,
+  formatearGroundingAgua,
+} from '../waterDiagnostic';
+
+describe('calcularCaptacion', () => {
+  it('techo 60m2 zinc × 1200mm × Ce=0.90 × 0.85 = 55.080 L/año', () => {
+    const r = calcularCaptacion(60, 1200, 0.90);
+    expect(r).not.toBeNull();
+    expect(r.litros_anuales).toBe(55080);
+    expect(r.litros_diarios).toBe(151);
+  });
+
+  it('techo 50m2 × 1500mm × Ce=0.80 = 51.000 L/año', () => {
+    const r = calcularCaptacion(50, 1500, 0.80);
+    expect(r.litros_anuales).toBe(51000);
+  });
+
+  it('techo 23m2 arcilla × 1800mm × Ce=0.75 ≈ 26393 L', () => {
+    const r = calcularCaptacion(23, 1800, 0.75);
+    expect(r.litros_anuales).toBe(26393);
+  });
+
+  it('retorna null si faltan parametros', () => {
+    expect(calcularCaptacion(0, 1000, 0.8)).toBeNull();
+    expect(calcularCaptacion(50, 0, 0.8)).toBeNull();
+    expect(calcularCaptacion(50, 1000, 0)).toBeNull();
+  });
+});
+
+describe('buscarCaptacion', () => {
+  it('zinc → Ce=0.90', () => {
+    const s = buscarCaptacion('zinc');
+    expect(s).toBeDefined();
+    expect(s.ce).toBe(0.90);
+  });
+
+  it('arcilla → Ce=0.75', () => {
+    const s = buscarCaptacion('arcilla');
+    expect(s).toBeDefined();
+    expect(s.ce).toBe(0.75);
+  });
+
+  it('material desconocido → undefined', () => {
+    expect(buscarCaptacion('vidrio')).toBeNull();
+  });
+});
+
+describe('estimarLluviaRegion', () => {
+  it('andina_cafetera → 1800-2500mm', () => {
+    const r = estimarLluviaRegion('andina_cafetera');
+    expect(r.min_mm).toBe(1800);
+    expect(r.max_mm).toBe(2500);
+  });
+
+  it('region desconocida → null', () => {
+    expect(estimarLluviaRegion('marte')).toBeNull();
+  });
+});
+
+describe('diagnosticarAgua', () => {
+  it('retorna sin_datos si descripcion vacia', () => {
+    expect(diagnosticarAgua('').sin_datos).toBe(true);
+    expect(diagnosticarAgua('ab').sin_datos).toBe(true);
+  });
+
+  it('"se me seca el cultivo" → deficit hidrico + mulch + MO', () => {
+    const d = diagnosticarAgua('se me seca el cultivo');
+    expect(d.problemas).toContain('deficit_hidrico');
+    expect(d.conservacion.some((c) => c.id === 'mulch')).toBe(true);
+    expect(d.conservacion.some((c) => c.id === 'materia_organica')).toBe(true);
+  });
+
+  it('"no llueve hace meses, cielo pelado" → sequia + acciones ENSO', () => {
+    const d = diagnosticarAgua('no llueve hace meses, cielo pelado');
+    expect(d.problemas).toContain('sequia_prolongada');
+    expect(d.enso.length).toBeGreaterThan(0);
+  });
+
+  it('"se me ahogo la mata con tanta lluvia" → exceso hidrico + zanjas', () => {
+    const d = diagnosticarAgua('se me ahogo la mata con tanta lluvia');
+    expect(d.problemas).toContain('exceso_hidrico');
+    expect(d.conservacion.some((c) => c.id === 'zanjas_infiltracion')).toBe(true);
+  });
+
+  it('con datos de techo calcula captacion', () => {
+    const d = diagnosticarAgua('necesito agua para riego', {
+      area_techo_m2: 60, lluvia_mm: 1200, material_techo: 'zinc',
+    });
+    expect(d.captacion).not.toBeNull();
+    expect(d.captacion.litros_anuales).toBe(55080);
+  });
+
+  it('con area < 20m2 recomienda botella enterrada', () => {
+    const d = diagnosticarAgua('riego para arboles', {
+      area_techo_m2: 15, lluvia_mm: 1500, material_techo: 'zinc',
+    });
+    expect(d.riego.some((r) => r.id === 'botella_enterrada')).toBe(true);
+  });
+});
+
+describe('diagnosticarAgua — MITOS y guardas', () => {
+  it('luna/lunar → advertencia de MITO', () => {
+    const d = diagnosticarAgua('debo regar en luna menguante?');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('lunar'))).toBe(true);
+  });
+
+  it('varillas/pendulo → advertencia de MITO', () => {
+    const d = diagnosticarAgua('uso varillas para encontrar agua');
+    expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('Radiestesia'))).toBe(true);
+  });
+
+  it('hidrogel → advertencia NO AGROECOLOGICO', () => {
+    const d = diagnosticarAgua('le pongo hidrogel a la tierra');
+    expect(d.advertencias.some((a) => a.includes('NO AGROECOLOGICO'))).toBe(true);
+  });
+
+  it('siempre incluye guarda de marchitez de mediodia', () => {
+    const d = diagnosticarAgua('se me seca el cultivo');
+    expect(d.advertencias.some((a) => a.includes('marchitez al mediodia') || a.includes('prueba del punado'))).toBe(true);
+  });
+
+  it('siempre incluye guarda de riego en la manana', () => {
+    const d = diagnosticarAgua('se me seca el cultivo');
+    expect(d.advertencias.some((a) => a.includes('manana') || a.includes('madrugada'))).toBe(true);
+  });
+
+  it('con captacion calculada incluye guardas de primer-flush y tapa', () => {
+    const d = diagnosticarAgua('agua', { area_techo_m2: 60, lluvia_mm: 1200, material_techo: 'zinc' });
+    expect(d.advertencias.some((a) => a.includes('primer'))).toBe(true);
+    expect(d.advertencias.some((a) => a.includes('tapa'))).toBe(true);
+  });
+
+  it('sin datos suficientes no inventa problemas', () => {
+    const d = diagnosticarAgua('hola buenos dias');
+    expect(d.sin_datos).toBe(true);
+    expect(d.problemas).toHaveLength(0);
+  });
+});
+
+describe('formatearGroundingAgua', () => {
+  it('retorna vacio si sin_datos', () => {
+    expect(formatearGroundingAgua({ sin_datos: true })).toBe('');
+    expect(formatearGroundingAgua(null)).toBe('');
+  });
+
+  it('incluye captacion, riego, conservacion, guardas', () => {
+    const d = diagnosticarAgua('se me seca el cultivo', {
+      area_techo_m2: 60, lluvia_mm: 1200, material_techo: 'zinc',
+    });
+    const f = formatearGroundingAgua(d);
+    expect(f).toContain('Captacion estimada');
+    expect(f).toContain('55.080');
+    expect(f).toContain('GUARDAS');
+    expect(f).toContain('DR-AGUA-1');
+  });
+});

--- a/src/services/waterDiagnostic.js
+++ b/src/services/waterDiagnostic.js
@@ -1,0 +1,227 @@
+/**
+ * waterDiagnostic — diagnóstico y calculadora de captación de agua (DR-AGUA-1).
+ *
+ * Fuente: DR-AGUA-1-consolidado (3/3 DeepSeek+Gemini+Meta, 2026-06-11).
+ * Referencias: IDEAM, AGROSAVIA, CIPAV, FAO, SENA, Cenicafe, CORPOICA, CIAT, UICN.
+ *
+ * Fórmula de captación: Vc = area × lluvia(mm) × Ce × η (η≈0.85).
+ * 1mm de lluvia sobre 1m² = 1 litro.
+ *
+ * EXCLUIDO del módulo:
+ * - Calendario lunar de riego (MITO 2-de-3 LLMs)
+ * - Poliacrilato/hidrogel sintetico (NO agroecologico)
+ * - Radiestesia/pendulo/varillas (PSEUDOCIENCIA)
+ *
+ * CERO invencion. Solo datos con fuente en el DR.
+ */
+
+import WATER_DATA from '../data/water-diagnostics.json';
+
+/**
+ * @typedef {Object} CaptacionResult
+ * @property {number} area_m2 — area del techo en m2
+ * @property {number} lluvia_mm — precipitacion anual en mm
+ * @property {number} ce — coeficiente de escorrentia
+ * @property {number} litros_anuales — volumen captado en litros/ano
+ * @property {number} litros_diarios — promedio diario
+ */
+
+/**
+ * Calcula el volumen de agua captable de un techo.
+ * Vc = area × lluvia × Ce × η
+ *
+ * @param {number} area_m2 — area del techo en metros cuadrados
+ * @param {number} lluvia_mm — precipitacion anual en mm (IDEAM)
+ * @param {number} ce — coeficiente de escorrentia del material del techo
+ * @param {number} [eta=0.85] — eficiencia (filtros, perdidas). Default 0.85
+ * @returns {CaptacionResult|null}
+ */
+export function calcularCaptacion(area_m2, lluvia_mm, ce, eta = 0.85) {
+  if (!area_m2 || area_m2 <= 0 || !lluvia_mm || lluvia_mm <= 0 || !ce || ce <= 0) return null;
+  const litros_anuales = Math.round(area_m2 * lluvia_mm * ce * eta);
+  return {
+    area_m2,
+    lluvia_mm,
+    ce,
+    eta,
+    litros_anuales,
+    litros_diarios: Math.round(litros_anuales / 365),
+  };
+}
+
+/**
+ * Estima la lluvia anual segun region colombiana.
+ *
+ * @param {string} region — clave de la region (caribe_seco, andina_cafetera, etc.)
+ * @returns {{min_mm:number, max_mm:number, nombre:string}|null}
+ */
+export function estimarLluviaRegion(region) {
+  return WATER_DATA.lluvia_region[region] || null;
+}
+
+/**
+ * Busca un sistema de captacion por material del techo.
+ *
+ * @param {string} material — 'zinc', 'cemento', 'arcilla', 'paja', etc.
+ * @returns {Object|null}
+ */
+export function buscarCaptacion(material) {
+  return WATER_DATA.sistemas_captacion.find((s) =>
+    s.id.includes(material) || s.nombre.toLowerCase().includes(material),
+  ) || null;
+}
+
+/**
+ * @typedef {Object} DiagnosticoAguaResult
+ * @property {string[]} problemas
+ * @property {Object|null} captacion — resultado de calcularCaptacion si hay datos
+ * @property {Object[]} riego — sistemas de riego recomendados
+ * @property {Object[]} conservacion — practicas de conservacion sugeridas
+ * @property {string[]} enso — acciones ENSO si hay sequia/exceso
+ * @property {string[]} advertencias — guardas activas
+ * @property {boolean} sin_datos
+ * @property {string} fuente
+ */
+
+/**
+ * Diagnostica la situacion hidrica a partir de la descripcion del campesino.
+ *
+ * @param {string} descripcion
+ * @param {Object} [opts]
+ * @param {number} [opts.area_techo_m2]
+ * @param {number} [opts.lluvia_mm]
+ * @param {string} [opts.material_techo]
+ * @param {string} [opts.cultivo]
+ * @returns {DiagnosticoAguaResult}
+ */
+export function diagnosticarAgua(descripcion, opts = {}) {
+  if (!descripcion || typeof descripcion !== 'string' || descripcion.trim().length < 3) {
+    return { problemas: [], captacion: null, riego: [], conservacion: [], enso: [], advertencias: [], sin_datos: true, fuente: WATER_DATA.fuente };
+  }
+
+  const texto = descripcion.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  const problemas = new Set();
+  const advertencias = [];
+
+  // 1. Senales de voz
+  for (const [clave, senal] of Object.entries(WATER_DATA.senales_voz)) {
+    const palabras = clave.split('_');
+    if (palabras.every((p) => texto.includes(p))) {
+      senal.problemas?.forEach((p) => problemas.add(p));
+    }
+  }
+
+  // 2. Calcular captacion si hay datos
+  let captacion = null;
+  if (opts.area_techo_m2 && opts.lluvia_mm && opts.material_techo) {
+    const sist = buscarCaptacion(opts.material_techo);
+    if (sist) {
+      captacion = calcularCaptacion(opts.area_techo_m2, opts.lluvia_mm, sist.ce);
+    }
+  }
+
+  // 3. Recomendar riego
+  const riego = [];
+  if (opts.area_techo_m2 && opts.area_techo_m2 < 20) {
+    riego.push(WATER_DATA.sistemas_riego.find((r) => r.id === 'botella_enterrada'));
+  }
+  if (captacion && captacion.litros_anuales > 10000) {
+    riego.push(WATER_DATA.sistemas_riego.find((r) => r.id === 'goteo_cinta'));
+  }
+  riego.push(WATER_DATA.sistemas_riego.find((r) => r.id === 'mecha_wicking'));
+
+  // 4. Conservacion
+  const conservacion = [];
+  if (problemas.has('deficit_hidrico') || problemas.has('estres_sequia') || problemas.has('sequia_prolongada')) {
+    conservacion.push(WATER_DATA.practicas_conservacion.find((p) => p.id === 'mulch'));
+    conservacion.push(WATER_DATA.practicas_conservacion.find((p) => p.id === 'materia_organica'));
+  }
+  if (problemas.has('exceso_hidrico') || problemas.has('mal_drenaje')) {
+    conservacion.push(WATER_DATA.practicas_conservacion.find((p) => p.id === 'zanjas_infiltracion'));
+  }
+
+  // 5. ENSO
+  const enso = [];
+  if (problemas.has('sequia_prolongada') || problemas.has('fuente_agotada') || problemas.has('deficit_hidrico')) {
+    enso.push(...WATER_DATA.enso_agua.el_nino.antes.slice(0, 3));
+  }
+
+  // 6. Guardas
+  advertencias.push(WATER_DATA.guardas.marchitez_mediodia);
+  advertencias.push(WATER_DATA.guardas.riego_manana);
+  if (captacion && captacion.litros_anuales > 0) {
+    advertencias.push(WATER_DATA.guardas.primer_flush);
+    advertencias.push(WATER_DATA.guardas.tanque_tapa);
+  }
+
+  // 7. Mitos detectados en el texto
+  if (texto.includes('luna') || texto.includes('lunar') || texto.includes('menguante') || texto.includes('creciente')) {
+    const mito = WATER_DATA.mitos.find((m) => m.id === 'riego_lunar');
+    advertencias.push(`MITO: ${mito.nombre} — ${mito.detalle}`);
+  }
+  if (texto.includes('varilla') || texto.includes('pendulo') || texto.includes('radiestesia')) {
+    const mito = WATER_DATA.mitos.find((m) => m.id === 'radiestesia_varillas');
+    advertencias.push(`MITO: ${mito.nombre} — ${mito.detalle}`);
+  }
+  if (texto.includes('hidrogel') || texto.includes('poliacrilato')) {
+    const mito = WATER_DATA.mitos.find((m) => m.id === 'hidrogel_sintetico');
+    advertencias.push(`NO AGROECOLOGICO: ${mito.nombre} — ${mito.detalle}`);
+  }
+
+  if (problemas.size === 0 && !captacion && advertencias.length <= 2) {
+    return { problemas: [], captacion: null, riego: [], conservacion: [], enso: [], advertencias, sin_datos: true, fuente: WATER_DATA.fuente };
+  }
+
+  return {
+    problemas: Array.from(problemas),
+    captacion,
+    riego: riego.filter(Boolean),
+    conservacion: conservacion.filter(Boolean),
+    enso,
+    advertencias,
+    sin_datos: false,
+    fuente: WATER_DATA.fuente,
+  };
+}
+
+/**
+ * Formatea el diagnostico para inyectar al grounding del agente.
+ *
+ * @param {DiagnosticoAguaResult} d
+ * @returns {string}
+ */
+export function formatearGroundingAgua(d) {
+  if (!d || d.sin_datos) return '';
+  const partes = [];
+
+  if (d.captacion) {
+    partes.push(`**Captacion estimada:** ${d.captacion.litros_anuales.toLocaleString()} L/año (${d.captacion.litros_diarios.toLocaleString()} L/dia) desde ${d.captacion.area_m2}m² de techo con ${d.captacion.lluvia_mm}mm de lluvia y Ce=${d.captacion.ce}.`);
+  }
+
+  if (d.problemas.length > 0) {
+    partes.push(`**Problemas detectados:** ${d.problemas.join(', ')}.`);
+  }
+
+  if (d.riego.length > 0) {
+    partes.push('**Sistemas de riego recomendados:**');
+    d.riego.forEach((r) => partes.push(`- ${r.nombre} (eficiencia ${Math.round(r.eficiencia * 100)}%, ${r.nota})`));
+  }
+
+  if (d.conservacion.length > 0) {
+    partes.push('**Practicas de conservacion:**');
+    d.conservacion.forEach((c) => partes.push(`- ${c.nombre}: ${c.nota}`));
+  }
+
+  if (d.enso.length > 0) {
+    partes.push('**Acciones ante sequia/ENSO:**');
+    d.enso.forEach((a) => partes.push(`- ${a}`));
+  }
+
+  if (d.advertencias.length > 0) {
+    partes.push('**GUARDAS:**');
+    d.advertencias.forEach((a) => partes.push(`- ${a}`));
+  }
+
+  partes.push(`Fuente: ${d.fuente}`);
+  return partes.join('\n\n');
+}


### PR DESCRIPTION
## Módulo de agua — diagnóstico + calculadora de captación (DR-AGUA-1)

### Fuente: DR-AGUA-1-consolidado (3/3 DeepSeek+Gemini+Meta)

Referencias: IDEAM, AGROSAVIA, CIPAV, FAO, SENA, Cenicafe, CORPOICA, CIAT, UICN.

### Datos ingeridos

| Tipo | Conteo |
|---|---|
| Fuentes de agua | 4 (lluvia techo, quebrada, aljibe, reservorio) |
| Sistemas captación (con Ce) | 6 (zinc 0.90, arcilla 0.75, paja 0.55…) |
| Regiones lluvia IDEAM | 5 |
| Sistemas riego (con eficiencia) | 5 (goteo 88%, botella 85%…) |
| Prácticas conservación | 6 (mulch -50% evap, zanjas +25% infil…) |
| Cultivos (Kc/lámina) | 7 (café, maíz, aguacate, cebolla…) |
| Acciones ENSO | El Niño (antes+durante), La Niña |
| Señales de voz | 9 |
| MITOS excluidos | 3 (lunar, radiestesia, hidrogel — marcados, NO ingeridos) |

### Servicio

- `calcularCaptacion(area, lluvia, ce, eta=0.85)` → Vc en L/año + L/día
- `diagnosticarAgua(descripcion, opts)` → árbol: voz → captación → riego → conservación → ENSO
- `formatearGroundingAgua()` → bloque para el agente

### Guardas

- Marchitez de mediodía ≠ necesita riego → prueba del puñado
- Regar en la mañana/madrugada
- Primer-flush (1L/m²) + tapa anti-zancudo

### Tests (24)

Cálculo de captación, señales de voz→recomendación, MITOS advertidos, guardas activas, sin datos→no inventa.
