### PR TITLE
feat(suelos): wire soilDiagnostic al agente — grounding automatico con guardas anti-mito

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -56,7 +56,7 @@ import { planForcedIntent, isStubIntent, isDeepResearchIntent, CHIP_DEFS } from 
 // (entidad resuelta o keyword → get_species/get_pest_controllers/get_biopreparados)
 // para intentar AL MENOS una consulta al grafo en vez de caer a generativo puro.
 import { planNluFallback } from '../../services/agentNluFallback';
-import { planKnowledgeIntent } from '../../services/knowledgeIntentRouter';
+import { planKnowledgeIntent, hasSoilDiagnosticIntent } from '../../services/knowledgeIntentRouter';
 // Deep Research (A6/A7): cliente HTTP del endpoint async de investigación
 // profunda del sidecar. Feature flag VITE_DEEP_RESEARCH_ENABLED (default false).
 import { submitDeepResearch, pollDeepResearch, isDeepResearchEnabled } from '../../services/deepResearchClient';
@@ -1307,6 +1307,28 @@ export default function AgentScreen({ onBack, initialContext }) {
                 }
               }
             } catch (_) { /* graceful: sigue el flujo NLU normal */ }
+
+            // Suelo-diagnostico: si el campesino describe su terreno, injectamos
+            // diagnosticarSuelo() al grounding. Es cliente-side (sin sidecar),
+            // usa los datos del DR-SUELOS-1. Las guardas anti-mito (vinagre/bicarbonato,
+            // no sobre-encalar) afloran en la respuesta del agente.
+            if (!toolEvidence && hasSoilDiagnosticIntent(textForLLM)) {
+              try {
+                const { diagnosticarSuelo, formatearGroundingSuelo } = await import('../../services/soilDiagnostic');
+                const diag = diagnosticarSuelo(textForLLM);
+                if (diag && !diag.sin_datos) {
+                  const bloque = formatearGroundingSuelo(diag);
+                  if (bloque) {
+                    toolEvidence = {
+                      tool: 'soil_diagnostic',
+                      args: { query: textForLLM },
+                      result: { found: true, bloque },
+                    };
+                    nluRoute = 'suelo:diagnostico';
+                  }
+                }
+              } catch (_) { /* graceful: sin diagnosticar no rompe */ }
+            }
           }
 
           // PASO 2 — routing del tool.

--- a/src/services/knowledgeIntentRouter.js
+++ b/src/services/knowledgeIntentRouter.js
@@ -132,3 +132,21 @@ export const __TEST__ = {
   PLAGA_GUARD_RE,
   _norm,
 };
+
+/** Señal de DIAGNÓSTICO de suelo — descripción del terreno del campesino. */
+const SUELO_DIAG_RE =
+  /\b(tierra|suelo|terreno|lote|parcela)\b.*\b(amarilla|colorada|pegajosa|greda|chiclosa|empoza|encharca|barro|dura|piedra|pal[ií]n|rebota|cansad[ao]|flojita|negr[ao]|sueltica|se\s+lava|helecho|cortadera|coquito|lombriz|vinagre|bicarbonato|cal|encalar)\b|^\s*(m[ií]\s+tierra|la\s+tierra|el\s+suelo|el\s+lote)/i;
+
+/**
+ * Detecta si el mensaje del campesino describe su suelo (diagnóstico).
+ * A diferencia de SUELO_RE (que busca requerimientos de suelo por especie),
+ * esta detecta descripciones del terreno para activar diagnosticarSuelo().
+ *
+ * @param {string} userMessage
+ * @returns {boolean}
+ */
+export function hasSoilDiagnosticIntent(userMessage) {
+  if (typeof userMessage !== 'string' || userMessage.trim().length < 5) return false;
+  const norm = _norm(userMessage);
+  return SUELO_DIAG_RE.test(norm);
+}


### PR DESCRIPTION
Wire de soilDiagnostic (#1423) al agente. hasSoilDiagnosticIntent() detecta descripciones de terreno. AgentScreen inyecta diagnosticarSuelo() al grounding con todas las guardas (mitos, no sobre-encalar, Phytophthora). Degradacion: sin_datos → no inyecta.