### PR TITLE
fix(audit): IN-5 (ruta /chat/stream muerta) + UXC-001 (foto/vision a soon honesto)

### DIFF
--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -192,13 +192,17 @@ export const CAPABILITY_MANIFEST = Object.freeze([
   {
     id: 'foto',
     group: 'observar',
-    status: 'live',
+    status: 'soon',
     icon: '📷',
     label: 'Agregar planta por foto',
     desc: 'Tómale una foto y la identifico y registro.',
     tool: 'vision_identify',
     hero: true,
     heroRoute: { kind: 'photo' },
+    stubMessage:
+      'La identificación por foto necesita mejor hardware (GPU con ≥8GB VRAM). ' +
+      'Por ahora usá la voz o el formulario manual para registrar tus plantas. ' +
+      'Próximamente estará disponible por la nube.',
   },
   {
     id: 'voz',

--- a/src/services/streamChatViaSidecar.js
+++ b/src/services/streamChatViaSidecar.js
@@ -1,6 +1,13 @@
 /**
  * streamChatViaSidecar.js — SSE chat streaming client (SPEED-1).
  *
+ * ⚠️ IN-5 (auditoria 2026-06-10): el endpoint `POST /chat/stream` NO existe
+ * en el sidecar de produccion. Este modulo esta GATEADO detras del flag
+ * `VITE_AGENT_STREAMING` (default OFF en .env). Si se activa, el cliente
+ * intentara conectar a una ruta fantasma → 404. NO activar hasta que el
+ * sidecar implemente el endpoint. Mientras tanto, la PWA usa streamOpenAI
+ * (comportamiento por defecto, estable).
+ *
  * Companion to the sidecar `POST /chat/stream` endpoint. Speaks the
  * sidecar's custom SSE shape (NOT raw Ollama, NOT OpenAI):
  *


### PR DESCRIPTION
IN-5: documentada la ruta fantasma en streamChatViaSidecar.js, gated via VITE_AGENT_STREAMING=OFF. UXC-001: foto pasa de live a soon con mensaje honesto sobre hardware necesario.