### PR TITLE
fix(pwa): un solo click para actualizar + banner instalar en Android Chrome

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Chagra",
   "short_name": "Chagra",
+  "id": "/",
   "description": "Sistema de gestión agrícola inteligente con IA",
   "start_url": "/",
   "display": "standalone",

--- a/public/sw.js
+++ b/public/sw.js
@@ -10,12 +10,18 @@ const ASSETS_TO_CACHE = [
   '/icon-512.png'
 ];
 
-// Instalación del Service Worker
+// Instalación del Service Worker.
+// SIN self.skipWaiting() automático: el SW nuevo queda en `waiting` para que
+// el cliente muestre el banner "nueva versión disponible" y el operador
+// decida cuándo actualizar. El skipWaiting solo ocurre vía mensaje
+// SKIP_WAITING (click "Actualizar" en UpdateAvailableBanner). Con el
+// auto-skip el SW activaba solo, controllerchange disparaba el banner
+// DESPUÉS de aplicada la actualización y el operador debía dar "Actualizar"
+// N veces (bug 2026-06-10).
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then(cache => cache.addAll(ASSETS_TO_CACHE))
-      .then(() => self.skipWaiting())
   );
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
 import Confetti from './components/common/Confetti';
 import IosInstallBanner from './components/IosInstallBanner';
+import AndroidInstallBanner from './components/AndroidInstallBanner';
 import UpdateAvailableBanner from './components/UpdateAvailableBanner';
 import GpsFincaBanner from './components/GpsFincaBanner';
 import DataLossBanner from './components/DataLossBanner';
@@ -753,6 +754,7 @@ export default function App() {
     <>
       <NetworkStatusBar />
       <IosInstallBanner />
+      <AndroidInstallBanner />
       <UpdateAvailableBanner />
       <Confetti />
       <GpsFincaBanner />

--- a/src/components/AndroidInstallBanner.jsx
+++ b/src/components/AndroidInstallBanner.jsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect } from 'react';
+import { Download, X } from 'lucide-react';
+
+export const DISMISS_KEY = 'chagra-android-install-dismissed';
+
+/**
+ * AndroidInstallBanner — botón claro "Instalar Chagra" para Android Chrome.
+ *
+ * Bug operador 2026-06-10: Chrome Android cumple los criterios de
+ * instalabilidad (manifest + íconos + SW fetch + HTTPS) pero sin handler de
+ * `beforeinstallprompt` la única vía era el menú ⋮, que el campesino no
+ * encuentra. Capturamos el evento y lo re-disparamos desde un botón visible.
+ *
+ * Detección de plataforma por CAPACIDAD: solo Chromium (Android Chrome /
+ * Samsung Internet / Edge) emite `beforeinstallprompt`. iOS Safari jamás lo
+ * dispara — su flujo manual ("Compartir → Añadir a inicio") vive en
+ * IosInstallBanner. Por construcción los dos banners no colisionan.
+ *
+ * Theme-aware: las clases slate y muzo-glow pasan por la indirección CSS-var
+ * de tailwind.config.js (--c-slate-*, --c-muzo-glow), igual que los demás
+ * banners.
+ */
+const AndroidInstallBanner = () => {
+  // El evento beforeinstallprompt diferido. null = sin banner.
+  const [deferredPrompt, setDeferredPrompt] = useState(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    // Ya instalada (corre standalone) o descartada antes → no escuchar.
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      window.navigator.standalone === true;
+    if (isStandalone) return undefined;
+    let dismissed = null;
+    try {
+      dismissed = localStorage.getItem(DISMISS_KEY);
+    } catch (_) { /* modo privado — tratamos como no descartado */ }
+    if (dismissed) return undefined;
+
+    const onBeforeInstallPrompt = (event) => {
+      // Cancela el mini-infobar de Chrome y guarda el prompt para dispararlo
+      // desde un botón grande y en español (baja alfabetización digital).
+      event.preventDefault();
+      setDeferredPrompt(event);
+    };
+    const onAppInstalled = () => setDeferredPrompt(null);
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    window.addEventListener('appinstalled', onAppInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', onAppInstalled);
+    };
+  }, []);
+
+  const handleInstall = async () => {
+    const promptEvent = deferredPrompt;
+    if (!promptEvent) return;
+    // prompt() solo se puede llamar UNA vez por evento → soltamos la ref ya.
+    setDeferredPrompt(null);
+    try {
+      promptEvent.prompt();
+      // 'accepted' → Chrome instala y dispara appinstalled.
+      // 'dismissed' → ocultamos igual; Chrome no re-emite el evento pronto.
+      await promptEvent.userChoice;
+    } catch (_) {
+      /* prompt ya consumido o bloqueado por el navegador — silencioso */
+    }
+  };
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, 'true');
+    } catch (_) { /* modo privado — solo oculta esta sesión */ }
+    setDeferredPrompt(null);
+  };
+
+  if (!deferredPrompt) return null;
+
+  return (
+    <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 w-11/12 max-w-md animate-in fade-in slide-in-from-bottom-5 duration-500">
+      <div className="bg-slate-900 border border-slate-700 shadow-2xl rounded-2xl p-4 flex items-center gap-3 relative overflow-hidden">
+        {/* Acento bio-punk, igual que IosInstallBanner */}
+        <div className="absolute top-0 left-0 w-1 h-full bg-muzo-glow" />
+
+        <div className="bg-muzo-glow/20 p-2 rounded-xl flex-shrink-0">
+          <Download className="text-muzo-glow" size={24} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="text-white font-bold text-sm">Instala Chagra</h3>
+          <p className="text-slate-400 text-xs leading-snug">
+            Tenla en tu pantalla de inicio, como una aplicación.
+          </p>
+        </div>
+
+        <button
+          onClick={handleInstall}
+          className="px-3 py-2 bg-muzo-glow/20 hover:bg-muzo-glow/30 text-muzo-glow text-xs font-bold rounded-lg transition-colors whitespace-nowrap"
+          type="button"
+        >
+          Instalar Chagra
+        </button>
+
+        <button
+          onClick={handleDismiss}
+          className="p-1.5 text-slate-500 hover:text-white transition-colors flex-shrink-0"
+          aria-label="Cerrar"
+          type="button"
+        >
+          <X size={18} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AndroidInstallBanner;

--- a/src/components/UpdateAvailableBanner.jsx
+++ b/src/components/UpdateAvailableBanner.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { RefreshCw, Sparkles } from 'lucide-react';
 import { writeAckedVersion } from '../services/swUpdateAck';
+import { reloadPage } from '../services/pageReload';
 
 export default function UpdateAvailableBanner() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
@@ -28,7 +29,7 @@ export default function UpdateAvailableBanner() {
   }, [updateAvailable]);
 
   const handleUpdate = async () => {
-    // Persistimos el ack ANTES del reload: si el reload falla o el usuario
+    // Persistimos el ack ANTES de activar: si la recarga falla o el usuario
     // cierra la pestaña, no queremos repetir el toast en la proxima sesion
     // para una version que ya acepto.
     if (announcedVersionRef.current) {
@@ -36,11 +37,23 @@ export default function UpdateAvailableBanner() {
     }
     try {
       const reg = await navigator.serviceWorker.ready;
+      // Bug operador 2026-06-10 ("dar Actualizar N veces"): si hubo varios
+      // deploys con la pestaña abierta, update() trae el SW MAS NUEVO y el
+      // browser reemplaza el waiting → un click lleva a la ultima version.
+      try {
+        await reg.update();
+      } catch (_) { /* offline — activamos el waiting que ya tengamos */ }
       if (reg.waiting) {
+        // NO recargamos aca. El SW activa → controllerchange → main.jsx
+        // recarga UNA sola vez (patron Workbox). El reload inmediato creaba
+        // la carrera "recarga antes de que el SW nuevo tome control" que
+        // re-mostraba el banner.
         reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+        return;
       }
-    } catch (_) { /* SW not ready — recargar igual abajo */ }
-    window.location.reload();
+    } catch (_) { /* SW no disponible — recargar directo abajo */ }
+    // Sin SW en waiting (banner stale o SW no soportado) → recarga directa.
+    reloadPage();
   };
 
   if (!updateAvailable) return null;

--- a/src/components/__tests__/AndroidInstallBanner.test.jsx
+++ b/src/components/__tests__/AndroidInstallBanner.test.jsx
@@ -1,0 +1,110 @@
+/**
+ * AndroidInstallBanner.test.jsx — TDD del banner de instalación PWA para
+ * Android Chrome (Bug 2 operador 2026-06-10: "en Android Chrome no me da la
+ * opción de instalar la PWA").
+ *
+ * Contrato:
+ *  - No renderiza nada hasta que el navegador dispare `beforeinstallprompt`
+ *    (solo Chromium lo emite — iOS jamás, por eso este banner no colisiona
+ *    con IosInstallBanner).
+ *  - Al capturar el evento: preventDefault() (mata el mini-infobar de Chrome)
+ *    y muestra botón claro "Instalar Chagra".
+ *  - Click en instalar → deferredPrompt.prompt() + espera userChoice y oculta.
+ *  - No aparece si ya está instalada (display-mode: standalone) ni si el
+ *    usuario lo descartó antes (localStorage).
+ *  - Se oculta con `appinstalled`.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import AndroidInstallBanner, { DISMISS_KEY } from '../AndroidInstallBanner';
+
+function makeBipEvent(outcome = 'accepted') {
+  const event = new Event('beforeinstallprompt');
+  event.preventDefault = vi.fn();
+  event.prompt = vi.fn().mockResolvedValue(undefined);
+  event.userChoice = Promise.resolve({ outcome });
+  return event;
+}
+
+function setStandalone(matches) {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: query === '(display-mode: standalone)' ? matches : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe('AndroidInstallBanner', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setStandalone(false);
+  });
+
+  it('no renderiza nada antes de beforeinstallprompt', () => {
+    const { container } = render(<AndroidInstallBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('captura beforeinstallprompt: preventDefault + muestra "Instalar Chagra"', () => {
+    render(<AndroidInstallBanner />);
+    const event = makeBipEvent();
+    act(() => { window.dispatchEvent(event); });
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /instalar chagra/i })).toBeInTheDocument();
+  });
+
+  it('click en instalar dispara prompt() y oculta el banner tras userChoice', async () => {
+    render(<AndroidInstallBanner />);
+    const event = makeBipEvent('accepted');
+    act(() => { window.dispatchEvent(event); });
+    fireEvent.click(screen.getByRole('button', { name: /instalar chagra/i }));
+    expect(event.prompt).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('oculta también si el usuario rechaza el prompt nativo (dismissed)', async () => {
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent('dismissed')); });
+    fireEvent.click(screen.getByRole('button', { name: /instalar chagra/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('NO aparece si la app ya corre standalone (instalada)', () => {
+    setStandalone(true);
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent()); });
+    expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
+  });
+
+  it('NO aparece si fue descartado antes (localStorage)', () => {
+    localStorage.setItem(DISMISS_KEY, 'true');
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent()); });
+    expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
+  });
+
+  it('botón cerrar persiste el descarte y oculta', () => {
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent()); });
+    fireEvent.click(screen.getByRole('button', { name: /cerrar/i }));
+    expect(localStorage.getItem(DISMISS_KEY)).toBe('true');
+    expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
+  });
+
+  it('se oculta al recibir appinstalled', () => {
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent()); });
+    expect(screen.getByRole('button', { name: /instalar chagra/i })).toBeInTheDocument();
+    act(() => { window.dispatchEvent(new Event('appinstalled')); });
+    expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/UpdateAvailableBanner.update.test.jsx
+++ b/src/components/__tests__/UpdateAvailableBanner.update.test.jsx
@@ -1,0 +1,104 @@
+/**
+ * UpdateAvailableBanner.update.test.jsx — TDD del flujo "Actualizar" (Bug 1
+ * operador 2026-06-10: "cuando hay muchas actualizaciones debo dar Actualizar
+ * N veces").
+ *
+ * Contrato del nuevo handleUpdate:
+ *  1. Llama `registration.update()` ANTES de skipWaiting → trae el SW MÁS
+ *     NUEVO si hubo varios deploys (un click → última versión).
+ *  2. Manda `{type:'SKIP_WAITING'}` al SW en waiting.
+ *  3. NO recarga acá: la recarga única la hace el listener `controllerchange`
+ *     de main.jsx cuando el SW nuevo toma control (patrón Workbox). Recargar
+ *     inmediato creaba la carrera que re-mostraba el banner.
+ *  4. Fallback: sin SW en waiting (banner stale) → recarga directa.
+ *  5. El ack de versión (localStorage) se persiste antes de activar.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import UpdateAvailableBanner from '../UpdateAvailableBanner';
+import { ACK_STORAGE_KEY } from '../../services/swUpdateAck';
+import { reloadPage } from '../../services/pageReload';
+
+// location.reload es non-configurable en jsdom — la recarga pasa por la
+// indirección pageReload para poder espiarla acá.
+vi.mock('../../services/pageReload', () => ({ reloadPage: vi.fn() }));
+
+function mockServiceWorker(reg) {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: { ready: Promise.resolve(reg) },
+  });
+}
+
+function showBanner(version = 'chagra-v999') {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent('chagra:update-available', { detail: { version } })
+    );
+  });
+}
+
+describe('UpdateAvailableBanner — flujo Actualizar', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete navigator.serviceWorker;
+  });
+
+  it('con SW waiting: update() + SKIP_WAITING, SIN reload inmediato', async () => {
+    const waiting = { postMessage: vi.fn() };
+    const reg = { update: vi.fn().mockResolvedValue(undefined), waiting };
+    mockServiceWorker(reg);
+
+    render(<UpdateAvailableBanner />);
+    showBanner();
+    fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => {
+      expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    });
+    expect(reg.update).toHaveBeenCalled();
+    // La recarga la hace controllerchange (main.jsx), NO el banner.
+    expect(reloadPage).not.toHaveBeenCalled();
+  });
+
+  it('persiste el ack de la versión anunciada antes de activar', async () => {
+    const waiting = { postMessage: vi.fn() };
+    mockServiceWorker({ update: vi.fn().mockResolvedValue(undefined), waiting });
+
+    render(<UpdateAvailableBanner />);
+    showBanner('chagra-v321');
+    fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => expect(waiting.postMessage).toHaveBeenCalled());
+    expect(localStorage.getItem(ACK_STORAGE_KEY)).toBe('chagra-v321');
+  });
+
+  it('sin SW waiting: fallback a recarga directa', async () => {
+    mockServiceWorker({ update: vi.fn().mockResolvedValue(undefined), waiting: null });
+
+    render(<UpdateAvailableBanner />);
+    showBanner();
+    fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => expect(reloadPage).toHaveBeenCalledTimes(1));
+  });
+
+  it('update() que falla (offline) no bloquea: activa el waiting que haya', async () => {
+    const waiting = { postMessage: vi.fn() };
+    mockServiceWorker({ update: vi.fn().mockRejectedValue(new Error('offline')), waiting });
+
+    render(<UpdateAvailableBanner />);
+    showBanner();
+    fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => {
+      expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    });
+    expect(reloadPage).not.toHaveBeenCalled();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -89,9 +89,12 @@ if ('serviceWorker' in navigator) {
     }
   });
 
-  // Banner "nueva version disponible" cuando SW cambia (controllerchange) o
-  // cuando un nuevo SW esta en waiting (updatefound). Reemplaza auto-reload:
-  // el operador decide cuando actualizar via UpdateAvailableBanner.
+  // Banner "nueva version disponible" SOLO cuando hay un SW nuevo en waiting
+  // (registration.waiting / updatefound). NUNCA por controllerchange: ese
+  // evento significa que la actualizacion YA se aplico — dispararlo ahi
+  // re-mostraba el banner despues de actualizar (bug operador 2026-06-10
+  // "debo dar Actualizar N veces"). El operador decide cuando actualizar
+  // via UpdateAvailableBanner.
   //
   // Fix Antigravity QA #18: persistimos el ack en localStorage
   // (`sw:last-acked-version`) para no repetir el toast cada reload. Antes
@@ -122,17 +125,32 @@ if ('serviceWorker' in navigator) {
     }
   };
 
+  // Patron Workbox estandar: click "Actualizar" → SKIP_WAITING → el SW nuevo
+  // toma control → controllerchange → recargar la pagina UNA sola vez.
+  // Guard `reloading` evita bucles de recarga; `hadController` evita recargar
+  // en el primer install (clients.claim() tambien dispara controllerchange
+  // cuando antes no habia controlador — ahi NO hay que recargar).
+  let reloading = false;
+  let hadController = Boolean(navigator.serviceWorker.controller);
   navigator.serviceWorker.addEventListener('controllerchange', () => {
-    maybeDispatchUpdateAvailable(navigator.serviceWorker.controller);
+    if (!hadController) {
+      hadController = true; // primer claim en first install — sin recarga
+      return;
+    }
+    if (reloading) return;
+    reloading = true;
+    window.location.reload();
   });
 
-  // Tambien detectar SW en waiting por si el controllerchange no se dispara
-  // (ej. si el SW no hace skipWaiting automaticamente en el futuro).
+  // Deteccion de SW nuevo en waiting: unica fuente del banner.
   navigator.serviceWorker.ready.then((registration) => {
-    // Estado inicial: si ya hay un SW controlador, sembrar ack para suprimir
-    // toast en cargas siguientes.
-    if (navigator.serviceWorker.controller) {
-      maybeDispatchUpdateAvailable(navigator.serviceWorker.controller);
+    // First install: sembrar el ack con la version del SW activo SIN disparar
+    // banner (la actualizacion ya esta aplicada; anunciar aqui era el bug).
+    const activeSw = navigator.serviceWorker.controller || registration.active;
+    if (activeSw && readAckedVersion() === null) {
+      getSwVersion(activeSw)
+        .then((version) => { if (version) seedFirstInstallAck(version); })
+        .catch(() => { });
     }
     if (registration.waiting) {
       maybeDispatchUpdateAvailable(registration.waiting);

--- a/src/services/pageReload.js
+++ b/src/services/pageReload.js
@@ -1,0 +1,10 @@
+/**
+ * pageReload.js — indirección mínima sobre window.location.reload().
+ *
+ * jsdom define `location.reload` como non-configurable: imposible de espiar
+ * o redefinir en vitest. Esta indirección permite a los tests mockear la
+ * recarga (vi.mock) sin tocar el comportamiento en producción.
+ */
+export function reloadPage() {
+  window.location.reload();
+}


### PR DESCRIPTION
## Resumen

Dos bugs reportados por el operador (2026-06-10):

### Bug 1 — "cuando hay muchas actualizaciones debo dar Actualizar N veces"
Causa raíz: `controllerchange` re-disparaba el banner DESPUÉS de aplicada la actualización, y el banner recargaba inmediato (carrera con la toma de control del SW). Además `sw.js` hacía `self.skipWaiting()` automático en `install`, por lo que casi nunca existía estado `waiting`.

Fix (patrón Workbox estándar):
1. `controllerchange` ya NO dispara el banner: recarga la página **una sola vez** (guard `reloading` anti-bucle + `hadController` para no recargar en el primer install, donde `clients.claim()` también dispara el evento).
2. `handleUpdate` del banner: `registration.update()` antes de `SKIP_WAITING` (si hubo varios deploys, trae el SW más nuevo) y **sin reload inmediato** — recarga el `controllerchange` del punto 1. Fallback a recarga directa solo sin SW en waiting.
3. El banner solo aparece por `registration.waiting` / `updatefound`. Para que ese estado exista, se removió el `skipWaiting()` automático del handler `install` de `sw.js` (el operador decide cuándo actualizar, como ya documentaba el código). El ack en localStorage se conserva; el first-install siembra el ack con la versión del SW activo sin disparar banner.

Resultado: **un click → última versión**, sin bucle de banners.

### Bug 2 — "en Android Chrome no me da la opción de instalar la PWA"
Los criterios de instalabilidad se cumplen, pero no había handler de `beforeinstallprompt` → dependía del menú ⋮ de Chrome.

- Nuevo `AndroidInstallBanner`: captura `beforeinstallprompt` (`preventDefault` + deferred prompt), botón claro **"Instalar Chagra"**, maneja `userChoice`, se oculta si ya corre standalone, tras `appinstalled` o si fue descartado (localStorage). Detección de plataforma por capacidad: iOS jamás emite el evento (su flujo manual sigue en `IosInstallBanner`), así que no colisionan. Theme-aware vía la indirección CSS-var de las clases slate/muzo-glow. Montado junto a `IosInstallBanner` en `App.jsx`.
- `manifest.json`: agrega `"id": "/"`.

## Tests y evidencia
- 12 tests nuevos (vitest, TDD): `AndroidInstallBanner.test.jsx` (8) + `UpdateAvailableBanner.update.test.jsx` (4). Indirección `services/pageReload.js` para espiar la recarga en jsdom (`location.reload` es non-configurable).
- `npx vitest run`: las 16 fallas restantes pre-existen en `main` (verificado en checkout limpio, archivos no relacionados).
- `eslint --max-warnings=0` limpio en los archivos tocados.
- Validación EN VIVO con chromium nix-store (UA Android): `preventDefault` OK, banner visible (screenshot), `prompt()` llamado al click, oculto tras `userChoice`, y `controllerchange` recarga una sola vez.

## Nota de upgrade
Los clientes con el SW viejo (auto-skipWaiting) reciben este SW como update normal: el nuevo queda en `waiting`, sale el banner y un click activa + recarga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)