### PR TITLE
feat(rag): diccionario de sinonimos campesinos curados

### DIFF
--- a/src/data/campesino-synonyms.json
+++ b/src/data/campesino-synonyms.json
@@ -1,0 +1,43 @@
+{
+  "fuente": "Glosario taxonomico del catalogo + fichas cycle-content + campo Guatoc/Choachi",
+  "plagas": {
+    "gusano": ["plaga", "larva", "oruga"],
+    "gusano_del_cafe": ["broca", "hypothenemus", "gorgojo"],
+    "bicho": ["plaga", "insecto", "afido"],
+    "cogollero": ["gusano", "spodoptera", "plaga"],
+    "broca": ["gorgojo", "barrenador", "hypothenemus"],
+    "roya": ["hongo", "hemileia"],
+    "gota": ["tizon", "phytophthora", "hongo"],
+    "palomilla": ["mariposa", "polilla", "lepidoptera"],
+    "chinche": ["hemiptera", "chupador", "plaga"],
+    "nematodo": ["gusano", "microscopico", "suelo"],
+    "mosca_blanca": ["bemisia", "homoptera"]
+  },
+  "control": {
+    "matamaleza": ["herbicida", "control", "maleza", "arvenses"],
+    "fumigar": ["aplicar", "asperjar", "control", "tratamiento"],
+    "remedio": ["control", "tratamiento", "manejo", "biopreparado"],
+    "caldo": ["bordeles", "fungicida", "preventivo", "cobre"],
+    "ceniza": ["potasio", "mineral", "fertilizante"]
+  },
+  "cultivo": {
+    "sembrar": ["cultivar", "establecer", "siembra", "plantar"],
+    "cosechar": ["recoger", "recoleccion", "cosecha", "produccion"],
+    "abonar": ["fertilizar", "nutrir", "abono", "compost"],
+    "podar": ["cortar", "poda", "formacion", "mantenimiento"],
+    "aporcar": ["arrimar", "tierra", "tuberculo", "cubrir"]
+  },
+  "clima": {
+    "secar": ["marchitar", "estres", "hidrico", "sequia"],
+    "inundar": ["encharcar", "exceso", "agua", "drenaje"],
+    "helada": ["escarcha", "frio", "congelacion", "temperatura"],
+    "verano": ["sequia", "seco", "estiaje", "calor"],
+    "invierno": ["lluvia", "humedo", "temporal", "precipitacion"]
+  },
+  "suelo_vocab": {
+    "tierra": ["suelo", "sustrato", "terreno"],
+    "loma": ["ladera", "pendiente", "colina", "inclinado"],
+    "barrial": ["arcilloso", "pesado", "compacto", "greda"],
+    "cascajo": ["pedregoso", "gravilla", "drenaje", "suelto"]
+  }
+}


### PR DESCRIPTION
Diccionario JSON con 5 categorias (plagas, control, cultivo, clima, suelo). Complementa ragSynonyms.js (#1418).