### PR TITLE
feat(home): paridad hero↔demos — Ⓐ de herramientas recuperada + campana de alertas + colores nature medidos

### DIFF
--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -16,6 +16,7 @@ import {
     getNotificationStyle,
 } from '../../services/userProfileService';
 import { buildCropSuggestions } from '../../data/cropSuggestions';
+import { syncManager } from '../../services/syncManager';
 import { iconForTheme } from './themeIcon';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
 
@@ -172,6 +173,12 @@ export default function AgentHero({ onNavigate }) {
     const [menuOpen, setMenuOpen] = useState(false);
     const [menuClosing, setMenuClosing] = useState(false);
     const menuCloseTimerRef = useRef(null);
+    // Campana de alertas/tareas (importada del demo biopunk 2026-06-11):
+    // panel con "Alertas ambientales" (useAlertStore) + "Tareas de campo"
+    // (pendientes farmOS, offline-first vía syncManager). Mutuamente
+    // excluyente con el menú Ⓐ, como en el demo.
+    const [notifOpen, setNotifOpen] = useState(false);
+    const [pendingTasks, setPendingTasks] = useState([]);
     // Nivel de respuestas del perfil (campesino=simple / experto=detallado).
     // Lo leemos del perfil real al montar; el toggle lo persiste de verdad.
     const [nivel, setNivel] = useState(() => {
@@ -190,6 +197,13 @@ export default function AgentHero({ onNavigate }) {
     // localStorage). Aquí solo LEEMOS el tema para pintar el ícono de la marca
     // y del botón Ⓐ; el switcher completo vive en Perfil → Apariencia.
     const { theme } = useTheme();
+
+    // ── markSwap del demo: al cambiar de tema, el ícono Ⓐ hace la
+    // micro-animación de intercambio (scale+rotate). Solo en CAMBIO de tema,
+    // no en el primer paint (el demo guarda `first = name !== THEME`).
+    const prevThemeRef = useRef(theme);
+    const themeSwapped = prevThemeRef.current !== theme;
+    useEffect(() => { prevThemeRef.current = theme; }, [theme]);
 
     // ── Escena: sol de día / luna de noche (operador 2026-06-06) ──────────────
     const night = isNightNow();
@@ -307,7 +321,13 @@ export default function AgentHero({ onNavigate }) {
             });
             return;
         }
-        if (!trimmed) return;
+        if (!trimmed) {
+            // Comportamiento del demo (`sendField()` vacío → `openSheet()`):
+            // enviar sin nada escrito abre el menú didáctico de capacidades
+            // en vez de morir en silencio.
+            openMenu();
+            return;
+        }
         send({ kind: 'text', text: trimmed });
     };
 
@@ -340,6 +360,7 @@ export default function AgentHero({ onNavigate }) {
     const openMenu = () => {
         window.clearTimeout(menuCloseTimerRef.current);
         setMenuClosing(false);
+        setNotifOpen(false); // campana y red Ⓐ son mutuamente excluyentes (demo)
         setMenuOpen(true);
     };
     const closeMenu = () => {
@@ -359,14 +380,38 @@ export default function AgentHero({ onNavigate }) {
         else openMenu();
     };
 
+    // ── Campana 🔔 (alertas + tareas) — import del demo biopunk ─────────────
+    // Las tareas pendientes vienen del MISMO camino offline-first que el
+    // PendingTasksWidget (syncManager cachea farmOS); sin red, falla suave y
+    // el badge cuenta solo las alertas locales.
+    useEffect(() => {
+        let alive = true;
+        Promise.resolve()
+            .then(() => syncManager.fetchPendingTasksFromFarmOS())
+            .then((tasks) => { if (alive && Array.isArray(tasks)) setPendingTasks(tasks); })
+            .catch(() => { /* offline: el badge usa solo las alertas */ });
+        return () => { alive = false; };
+    }, []);
+    const notifCount = activeAlerts.length + pendingTasks.length;
+    const toggleNotif = () => {
+        setNotifOpen((open) => {
+            if (!open && menuOpen) closeMenu(); // excluyentes, como el demo
+            return !open;
+        });
+    };
+
     // Limpia el timer de cierre al desmontar y cierra con Escape (a11y).
     useEffect(() => () => window.clearTimeout(menuCloseTimerRef.current), []);
     useEffect(() => {
-        if (!menuOpen) return undefined;
-        const onKey = (e) => { if (e.key === 'Escape') closeMenu(); };
+        if (!menuOpen && !notifOpen) return undefined;
+        const onKey = (e) => {
+            if (e.key !== 'Escape') return;
+            if (notifOpen) setNotifOpen(false);
+            else closeMenu();
+        };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [menuOpen]);
+    }, [menuOpen, notifOpen]);
 
     // Despacha una capacidad de la red a su routing real. El manifiesto
     // unificado (agentCapabilities.js) llama `heroRoute` al routing del hero;
@@ -736,7 +781,10 @@ export default function AgentHero({ onNavigate }) {
                 }
                 .agentport-name small {
                     display: block; font-weight: 600; font-size: .6rem; letter-spacing: .16em;
-                    text-transform: uppercase; color: rgb(var(--t-accent-rgb)); margin-top: -1px;
+                    text-transform: uppercase; margin-top: -1px;
+                    /* matiz profundo del acento (.brand small del demo:
+                       #a8612f nature · #19c79a biopunk · #1d4639 minimal) */
+                    color: rgb(var(--t-accent-deep-rgb, var(--t-accent-rgb)));
                 }
                 /* toggle Campesino | Experto (.modeToggle del demo) */
                 .agentport-mode {
@@ -750,7 +798,8 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-mode button {
                     border: none; background: transparent; font: inherit; cursor: pointer;
                     font-size: .72rem; font-weight: 700; padding: 6px 10px; border-radius: 18px;
-                    color: rgb(var(--c-slate-400));
+                    /* slate-500 = inactivo del demo (nature --cafe-3 #8a7350 MEDIDO) */
+                    color: rgb(var(--c-slate-500));
                     display: flex; align-items: center; gap: 4px; white-space: nowrap;
                     transition: background .3s cubic-bezier(.22,.61,.36,1), color .3s ease, transform .15s ease;
                 }
@@ -778,6 +827,124 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-profile:hover { color: rgb(var(--c-slate-100)); border-color: rgb(var(--t-accent-rgb) / 0.5); }
                 .agentport-profile:active { transform: scale(.92); }
                 .agentport-headtools { display: flex; align-items: center; gap: 8px; flex: none; }
+
+                /* ============ CAMPANA DE ALERTAS/TAREAS (demo biopunk) ============
+                   Import 1:1 del .bellbtn + .notifPanel del demo-agente-biopunk:
+                   campana redonda con anillo que respira + badge ámbar; panel que
+                   baja desde el header con "Alertas ambientales" y "Tareas de
+                   campo". Colores via tokens → theme-aware en los 3 temas. */
+                .agentport-bell {
+                    position: relative; width: 38px; height: 38px; flex: none;
+                    border-radius: 50%; display: inline-flex; align-items: center;
+                    justify-content: center; cursor: pointer; font-size: 1.05rem;
+                    background: rgb(var(--c-surface-card) / 0.65);
+                    border: 1px solid rgb(var(--c-surface-border));
+                    backdrop-filter: blur(6px);
+                    box-shadow: 0 2px 8px -4px rgba(0,0,0,.35);
+                    transition: transform .16s cubic-bezier(.22,.61,.36,1),
+                                background .25s ease, border-color .25s ease, box-shadow .25s ease;
+                }
+                /* el anillo solo respira cuando HAY pendientes (badge > 0) */
+                .agentport-bell.has-items:not(.is-open) {
+                    animation: agentport-pulse-ring 3.6s cubic-bezier(.22,.61,.36,1) infinite;
+                }
+                .agentport-bell:active { transform: scale(.9); }
+                .agentport-bell.is-open {
+                    background: rgb(var(--t-accent-rgb)); border-color: rgb(var(--t-accent-rgb));
+                    animation: none;
+                    box-shadow: 0 0 20px -3px rgb(var(--t-accent-rgb) / 0.85);
+                }
+                .agentport-bell .bicon { transition: transform .3s cubic-bezier(.22,.61,.36,1); }
+                .agentport-bell.is-open .bicon { transform: rotate(8deg); }
+                .agentport-bell .badge {
+                    position: absolute; top: -4px; right: -4px; min-width: 18px; height: 18px;
+                    padding: 0 4px; border-radius: 9px; font-size: .62rem; font-weight: 800;
+                    display: flex; align-items: center; justify-content: center; line-height: 1;
+                    background: rgb(var(--c-amber-400)); color: #3a2208;
+                    border: 1.5px solid rgb(var(--c-surface));
+                    box-shadow: 0 0 10px -1px rgb(var(--c-amber-400) / 0.85);
+                }
+                .agentport-notif {
+                    position: absolute; left: 12px; right: 12px;
+                    top: calc(150px + env(safe-area-inset-top));
+                    z-index: 30; display: flex; flex-direction: column; overflow: hidden;
+                    max-height: 56dvh;
+                    background: rgb(var(--c-surface-card) / 0.97);
+                    border: 1px solid rgb(var(--t-accent-rgb) / 0.4);
+                    border-radius: 20px;
+                    box-shadow: 0 22px 48px -18px rgba(0,0,0,.55),
+                                0 0 36px -10px rgb(var(--t-accent-rgb) / 0.3);
+                    transform-origin: top right;
+                    animation: agentport-notif-in .42s cubic-bezier(.32,.72,0,1) both;
+                }
+                @keyframes agentport-notif-in {
+                    from { opacity: 0; transform: translateY(-14px) scale(.97); }
+                    to { opacity: 1; transform: none; }
+                }
+                .agentport-notif .nph {
+                    display: flex; align-items: center; justify-content: space-between;
+                    padding: 13px 16px 9px; flex: none;
+                    border-bottom: 1px solid rgb(var(--c-surface-border));
+                }
+                .agentport-notif .nph .nt {
+                    font-weight: 800; font-size: .96rem; color: rgb(var(--c-slate-100));
+                    display: flex; align-items: center; gap: 7px;
+                }
+                .agentport-notif .nph .nclose {
+                    border: none; cursor: pointer; width: 28px; height: 28px;
+                    border-radius: 50%; font-size: 1rem;
+                    display: flex; align-items: center; justify-content: center;
+                    background: rgb(var(--t-accent-rgb) / 0.12);
+                    color: rgb(var(--t-accent-deep-rgb, var(--t-accent-rgb)));
+                    transition: background .2s ease, transform .15s ease;
+                }
+                .agentport-notif .nph .nclose:active { transform: scale(.9); }
+                .agentport-notif-body {
+                    overflow-y: auto; -webkit-overflow-scrolling: touch;
+                    padding: 8px 12px 12px; overscroll-behavior: contain;
+                }
+                .agentport-notif .nsec {
+                    font-size: .62rem; font-weight: 800; letter-spacing: .16em;
+                    text-transform: uppercase; color: rgb(var(--c-slate-500));
+                    margin: 9px 6px 6px;
+                }
+                .agentport-notif .nitem {
+                    display: flex; align-items: flex-start; gap: 11px;
+                    background: rgb(var(--c-surface-raised));
+                    border: 1px solid rgb(var(--c-surface-border));
+                    border-radius: 14px; padding: 10px 12px; margin-bottom: 7px;
+                }
+                .agentport-notif .nitem .nico {
+                    width: 34px; height: 34px; flex: none; border-radius: 10px;
+                    display: flex; align-items: center; justify-content: center;
+                    font-size: 1.15rem;
+                    background: rgb(var(--t-accent-rgb) / 0.12);
+                    border: 1px solid rgb(var(--t-accent-rgb) / 0.25);
+                }
+                .agentport-notif .nitem.is-danger .nico {
+                    background: rgb(244 63 94 / 0.12); border-color: rgb(244 63 94 / 0.4);
+                }
+                .agentport-notif .nitem .ntxt { flex: 1; min-width: 0; }
+                .agentport-notif .nitem .ntit {
+                    display: block; font-weight: 700; font-size: .88rem;
+                    color: rgb(var(--c-slate-100)); line-height: 1.3;
+                }
+                .agentport-notif .nitem .nmeta {
+                    display: block; font-size: .74rem; margin-top: 3px;
+                    color: rgb(var(--c-slate-300)); line-height: 1.35;
+                }
+                .agentport-notif .nitem .due { font-weight: 800; color: rgb(var(--c-amber-500)); }
+                .agentport-notif .nitem.is-danger .due { color: rgb(244 63 94); }
+                .agentport-notif .nempty {
+                    text-align: center; font-size: .8rem; color: rgb(var(--c-slate-400));
+                    padding: 10px 6px;
+                }
+                .agentport-notif-foot {
+                    padding: 7px 16px 12px; text-align: center; flex: none;
+                    font-size: .68rem; color: rgb(var(--c-slate-500));
+                    border-top: 1px solid rgb(var(--c-surface-border));
+                }
+                .agentport-notif-foot b { color: rgb(var(--t-accent-deep-rgb, var(--t-accent-rgb))); }
 
                 /* chip de UBICACIÓN — debajo de la marca, conectado al logo.
                    📍 Vereda · Municipio · altitud. */
@@ -849,7 +1016,9 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-hi .chagra-wordmark { color: rgb(var(--t-accent-rgb)); }
                 .agentport-sub {
                     margin-top: 8px; font-size: 1rem; line-height: 1.5;
-                    color: rgb(var(--c-slate-300)); max-width: 34ch;
+                    /* slate-400 = .greet .sub del demo (nature --cafe-2 #6b5638
+                       MEDIDO; en biopunk acerca al teal-grisáceo del demo) */
+                    color: rgb(var(--c-slate-400)); max-width: 34ch;
                     transition: opacity 0.4s ease;
                 }
                 [data-nivel="detallado"] .agentport-sub { font-size: 0.92rem; }
@@ -924,14 +1093,30 @@ export default function AgentHero({ onNavigate }) {
                     0%, 100% { box-shadow: 0 0 12px -2px rgb(var(--t-accent-rgb) / 0.55); }
                     50% { box-shadow: 0 0 24px 2px rgb(var(--t-accent-rgb) / 0.85); }
                 }
-                /* al abrir, el ícono se vuelve blanco para contrastar con el acento */
+                /* al abrir, el ícono se vuelve blanco para contrastar con el acento
+                   (cubre también los rellenos de la Ⓐ de herramientas: cabeza del
+                   azadón, hoja y punta del machete) */
                 .agentport-tool.is-open .agentport-tool-ico path,
-                .agentport-tool.is-open .agentport-tool-ico line { stroke: #fff; }
-                .agentport-tool.is-open .agentport-tool-ico circle[fill] { fill: #fff; }
+                .agentport-tool.is-open .agentport-tool-ico line,
+                .agentport-tool.is-open .agentport-tool-ico circle[stroke] { stroke: #fff; }
+                .agentport-tool.is-open .agentport-tool-ico circle[fill],
+                .agentport-tool.is-open .agentport-tool-ico polygon[fill],
+                .agentport-tool.is-open .agentport-tool-ico path[fill]:not([fill="none"]) { fill: #fff; }
                 @keyframes agentport-pulse-ring {
                     0% { box-shadow: 0 0 0 0 rgb(var(--t-accent-rgb) / 0.45); }
                     70% { box-shadow: 0 0 0 12px rgb(var(--t-accent-rgb) / 0); }
                     100% { box-shadow: 0 0 0 0 rgb(var(--t-accent-rgb) / 0); }
+                }
+                /* markSwap del demo: micro-animación al INTERCAMBIAR el ícono
+                   del tema (scale .6 + rotate -12° → overshoot → reposo). */
+                .agentport-tool-ico.agentport-swap,
+                .agentport-mark.agentport-swap {
+                    animation: agentport-mark-swap .5s cubic-bezier(.16,.84,.3,1);
+                }
+                @keyframes agentport-mark-swap {
+                    0% { transform: scale(.6) rotate(-12deg); opacity: .2; }
+                    60% { transform: scale(1.08) rotate(3deg); }
+                    100% { transform: scale(1) rotate(0); opacity: 1; }
                 }
 
                 .agentport-mic-on {
@@ -951,6 +1136,12 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-send:not(:disabled) { box-shadow: 0 4px 14px -4px rgb(var(--t-accent-rgb) / 0.7); }
                 .agentport-send:not(:disabled):active { transform: scale(0.86); }
                 .agentport-send:disabled { background: rgb(var(--c-slate-700)); cursor: not-allowed; }
+                /* sin texto/adjunto el botón sigue VIVO (demo: vacío → abre el
+                   menú Ⓐ) pero baja el volumen para no competir con el acento */
+                .agentport-send:not(.agent-send-accent):not(:disabled) {
+                    background: rgb(var(--c-slate-700));
+                    box-shadow: none;
+                }
                 .agentport-send .send-hummer { width: 30px; height: 22px; display: block; }
                 .agentport-send .send-hummer svg { width: 100%; height: 100%; display: block; }
                 /* En el botón de enviar el colibrí va en CREMA/blanco para
@@ -965,7 +1156,8 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-send:disabled .send-hummer { opacity: .55; }
 
                 .agentport-hint { text-align: center; font-size: 0.72rem; margin-top: 9px; color: rgb(var(--c-slate-500)); }
-                .agentport-hint b { color: rgb(var(--t-accent-rgb)); font-weight: 700; }
+                /* el Ⓐ del hint usa el matiz profundo (.hintbar b del demo) */
+                .agentport-hint b { color: rgb(var(--t-accent-deep-rgb, var(--t-accent-rgb))); font-weight: 700; }
 
                 /* ============== MENÚ Ⓐ INTEGRADO (la red en el hero) ==============
                    Nada de bottom-sheet/scrim/modal (operador 2026-06-09: "que se
@@ -1058,6 +1250,8 @@ export default function AgentHero({ onNavigate }) {
                     .agentport-sprig path { stroke-dashoffset: 0 !important; animation: none !important; }
                     .agentport-tool:not(.is-open) { animation: none !important; }
                     .agentport-tool.is-open { animation: none !important; }
+                    .agentport-bell, .agentport-notif,
+                    .agentport-tool-ico.agentport-swap { animation: none !important; }
                     .agentport-greet { animation: none !important; }
                     .agentport-foldaway, .agentport-redpanel { transition: none !important; animation: none !important; }
                     .chagra-composer-shimmer::after, .chagra-composer-sending { animation: none !important; }
@@ -1228,8 +1422,84 @@ export default function AgentHero({ onNavigate }) {
                     {/* Engranaje de perfil REMOVIDO (operador 2026-06-06): era
                         redundante — el ícono de usuario del TopBar ya abre el menú
                         con Ajustes/Salir. */}
+
+                    {/* Campana de alertas/tareas — import del demo biopunk.
+                        Badge = alertas activas + tareas de campo pendientes. */}
+                    <button
+                        type="button"
+                        onClick={toggleNotif}
+                        aria-label="Alertas y tareas pendientes"
+                        aria-expanded={notifOpen}
+                        className={[
+                            'agentport-bell',
+                            notifOpen ? 'is-open' : '',
+                            notifCount > 0 ? 'has-items' : '',
+                        ].join(' ')}
+                    >
+                        <span className="bicon" aria-hidden="true">🔔</span>
+                        {notifCount > 0 && <span className="badge">{notifCount}</span>}
+                    </button>
                 </div>
             </header>
+
+            {/* ============ PANEL DE ALERTAS / TAREAS (demo biopunk) ============ */}
+            {notifOpen && (
+                <section className="agentport-notif" aria-label="Alertas y tareas de campo">
+                    <div className="nph">
+                        <div className="nt">🔔 Alertas y tareas</div>
+                        <button
+                            type="button"
+                            className="nclose"
+                            aria-label="Cerrar alertas"
+                            onClick={() => setNotifOpen(false)}
+                        >
+                            ✕
+                        </button>
+                    </div>
+                    <div className="agentport-notif-body">
+                        <div className="nsec">Alertas ambientales</div>
+                        {activeAlerts.length === 0 && (
+                            <p className="nempty">Sin alertas ambientales por ahora.</p>
+                        )}
+                        {activeAlerts.map((a) => (
+                            <div
+                                key={a.type || a.title}
+                                className={['nitem', a.severity === 'danger' ? 'is-danger' : ''].join(' ')}
+                            >
+                                <span className="nico" aria-hidden="true">{a.icon || '⚠️'}</span>
+                                <span className="ntxt">
+                                    <span className="ntit">{a.title}</span>
+                                    {a.message && <span className="nmeta">{a.message}</span>}
+                                </span>
+                            </div>
+                        ))}
+                        <div className="nsec">Tareas de campo</div>
+                        {pendingTasks.length === 0 && (
+                            <p className="nempty">No tienes tareas de campo pendientes.</p>
+                        )}
+                        {pendingTasks.map((t) => (
+                            <div
+                                key={t.id || t.title}
+                                className={[
+                                    'nitem',
+                                    t.severity === 'critical' || t.severity === 'high' ? 'is-danger' : '',
+                                ].join(' ')}
+                            >
+                                <span className="nico" aria-hidden="true">🧑‍🌾</span>
+                                <span className="ntxt">
+                                    <span className="ntit">{t.title}</span>
+                                    {t.deadline && (
+                                        <span className="nmeta"><span className="due">{t.deadline}</span></span>
+                                    )}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="agentport-notif-foot">
+                        Lo clave te lo digo en el saludo. Aquí guardo <b>el resto</b>.
+                    </div>
+                </section>
+            )}
 
             {/* ============ ZONA-RESPIRO (escena detrás · red Ⓐ al abrir) ============
                 Con el menú abierto, la red de capacidades BROTA aquí mismo —
@@ -1400,7 +1670,16 @@ export default function AgentHero({ onNavigate }) {
                             aria-expanded={menuOpen && !menuClosing}
                             className={['agentport-iconbtn agentport-tool !w-11 !h-11', menuOpen && !menuClosing ? 'is-open' : ''].join(' ')}
                         >
-                            <span className="agentport-tool-ico" aria-hidden="true">{iconForTheme(theme)}</span>
+                            {/* key={theme}: al cambiar el tema el ícono se REMONTA →
+                                corre el markSwap del demo (y la "forja" de la Ⓐ de
+                                herramientas vuelve a dibujarse trazo a trazo). */}
+                            <span
+                                key={theme}
+                                className={['agentport-tool-ico', themeSwapped ? 'agentport-swap' : ''].join(' ')}
+                                aria-hidden="true"
+                            >
+                                {iconForTheme(theme)}
+                            </span>
                         </button>
 
                         {/* Cámara / foto — toma una foto O elige de la galería.
@@ -1431,11 +1710,13 @@ export default function AgentHero({ onNavigate }) {
                             {isRecording ? <Square size={16} strokeWidth={2.5} aria-hidden="true" /> : <Mic size={18} strokeWidth={2.5} aria-hidden="true" />}
                         </button>
 
-                        {/* Enviar — usa el mismo colibrí foto/video del FAB global. */}
+                        {/* Enviar — usa el mismo colibrí foto/video del FAB global.
+                            Comportamiento del demo: con el campo VACÍO no se apaga;
+                            tocarlo abre el menú didáctico de capacidades. */}
                         <button
                             type="button"
                             onClick={handleSendText}
-                            disabled={!canSend}
+                            disabled={busy || isRecording}
                             aria-label="Enviar al agente"
                             className={['agentport-send', canSend ? 'agent-send-accent' : ''].join(' ')}
                             style={{

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -111,9 +111,15 @@ describe('AgentHero — compositor real (no teaser)', () => {
     expect(sendMock).not.toHaveBeenCalled();
   });
 
-  test('botón enviar deshabilitado sin texto ni adjunto', () => {
+  test('enviar sin texto ni adjunto NO envía: abre el menú didáctico (demo)', () => {
+    // Port fiel del demo (2026-06-11): `sendField()` con el campo vacío abre
+    // el menú de capacidades en vez de quedar muerto/deshabilitado.
     render(<AgentHero onNavigate={vi.fn()} />);
-    expect(screen.getByLabelText('Enviar al agente')).toBeDisabled();
+    const sendBtn = screen.getByLabelText('Enviar al agente');
+    expect(sendBtn).toBeEnabled();
+    fireEvent.click(sendBtn);
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(screen.getByText('La mano de Chagra')).toBeInTheDocument();
   });
 
   test('chip de sugerencia envía su prompt como texto', async () => {
@@ -298,8 +304,10 @@ describe('AgentHero — foto: cámara O galería, solo imágenes (B2, 2026-06-06
     // Mensaje claro en castellano colombiano.
     const alert = await screen.findByRole('alert');
     expect(alert.textContent).toMatch(/solo puedo ver fotos|solo.*fotos/i);
-    // El botón enviar sigue deshabilitado (no hay adjunto válido ni texto).
-    expect(screen.getByLabelText('Enviar al agente')).toBeDisabled();
+    // Sin adjunto válido ni texto, tocar enviar NO manda nada a la outbox
+    // (abre el menú didáctico — comportamiento del demo).
+    fireEvent.click(screen.getByLabelText('Enviar al agente'));
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
   test('el aviso de no-imagen no usa voseo argentino', async () => {

--- a/src/components/dashboard/__tests__/AgentHero.demoParity.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.demoParity.test.jsx
@@ -1,0 +1,158 @@
+/**
+ * AgentHero.demoParity.test.jsx — paridad con los demos de oracle-lab
+ * (demo-agente.html / demo-agente-biopunk.html) — integración 2026-06-11.
+ *
+ * Cubre las 3 integraciones del operador:
+ *   1. Comportamiento Ⓐ del demo: enviar con el campo VACÍO abre el menú de
+ *      capacidades (en el demo `sendField()` vacío → `openSheet()`), en vez
+ *      de no hacer nada.
+ *   2. Botón de ALERTAS del demo biopunk (campana 🔔 + badge + panel con
+ *      "Alertas ambientales" y "Tareas de campo"), importado al hero y
+ *      conectado a datos REALES (useAlertStore + syncManager offline-first).
+ *   3. La Ⓐ de HERRAMIENTAS DE CAMPO (iteración recuperada de
+ *      Chagra-strategy/ops/icon-explorations/animada-refinada-grunge2.html):
+ *      azadón + rastrillo + machete + círculo — es el ícono biopunk.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock del store outbox (send durable) ─────────────────────────────────────
+const sendMock = vi.fn(async () => 1);
+vi.mock('../../../store/useAgentOutboxStore', () => ({
+  default: (selector) => selector({ send: sendMock, items: [], inFlight: [], refresh: vi.fn() }),
+}));
+
+// ── Mock del recorder de voz ────────────────────────────────────────────────
+vi.mock('../../../hooks/useVoiceRecorder', () => ({
+  default: () => ({
+    isRecording: false,
+    audioLevel: 0,
+    durationMs: 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    error: null,
+  }),
+}));
+
+vi.mock('../../../services/photoService', () => ({
+  captureAndCompress: vi.fn(async () => ({ blob: new Blob(), mime: 'image/jpeg' })),
+}));
+
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { start: vi.fn(), listen: vi.fn(), chime: vi.fn(), cancel: vi.fn() },
+}));
+
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({ nivel_respuestas: 'simple' })),
+  saveProfile: vi.fn(),
+  getProfileMunicipio: vi.fn(() => null),
+  getNotificationStyle: vi.fn(() => 'demo'),
+}));
+
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'biopunk', setTheme: vi.fn() }),
+}));
+
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [] }),
+}));
+
+// ── Alertas reales (1 activa) ───────────────────────────────────────────────
+vi.mock('../../../store/useAlertStore', () => ({
+  default: (selector) => selector({
+    activeAlerts: [
+      {
+        type: 'frost',
+        severity: 'danger',
+        title: 'Riesgo de helada esta noche',
+        message: 'Temperatura mínima cerca de 2 °C.',
+      },
+    ],
+  }),
+}));
+
+// ── Tareas pendientes reales (offline-first vía syncManager) ───────────────
+vi.mock('../../../services/syncManager', () => ({
+  syncManager: {
+    fetchPendingTasksFromFarmOS: vi.fn(async () => [
+      { id: 't1', title: 'Riego del lote 2', severity: 'high', deadline: 'Hoy' },
+    ]),
+  },
+}));
+
+vi.mock('../../../data/exampleQuestions', () => ({
+  AGENT_HERO_CHIPS: [{ icon: '🌱', label: '¿Qué siembro?', prompt: '¿Qué siembro?' }],
+}));
+
+vi.mock('../../ChagraAgentAvatar', () => ({
+  default: () => <div data-testid="avatar">colibri</div>,
+}));
+
+import AgentHero from '../AgentHero';
+import { THEME_ICON } from '../themeIcon';
+
+beforeEach(() => {
+  sendMock.mockClear();
+  window.localStorage.clear();
+});
+
+describe('1. Comportamiento Ⓐ del demo', () => {
+  test('enviar con el campo vacío abre el menú de capacidades (como el demo)', async () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    // el menú no está abierto
+    expect(screen.queryByText('La mano de Chagra')).not.toBeInTheDocument();
+    // botón enviar con campo vacío → abre la red (demo: sendField vacío → openSheet)
+    fireEvent.click(screen.getByRole('button', { name: /enviar al agente/i }));
+    await waitFor(() => {
+      expect(screen.getByText('La mano de Chagra')).toBeInTheDocument();
+    });
+    // y NO mandó nada a la outbox
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('2. Campana de alertas del demo biopunk', () => {
+  test('renderiza la campana con badge = alertas + tareas y abre el panel', async () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    const bell = await screen.findByRole('button', { name: /alertas y tareas/i });
+    // badge: 1 alerta + 1 tarea = 2 (las tareas llegan async)
+    await waitFor(() => {
+      expect(bell).toHaveTextContent('2');
+    });
+    fireEvent.click(bell);
+    // panel con las dos secciones del demo (scoped: el chip de alerta del
+    // hero también muestra el título de la alerta)
+    const panel = await screen.findByRole('region', { name: /alertas y tareas de campo/i });
+    expect(within(panel).getByText(/alertas ambientales/i)).toBeInTheDocument();
+    expect(within(panel).getByText(/tareas de campo/i)).toBeInTheDocument();
+    // contenido real
+    expect(within(panel).getByText('Riesgo de helada esta noche')).toBeInTheDocument();
+    expect(within(panel).getByText('Riego del lote 2')).toBeInTheDocument();
+  });
+
+  test('la campana y el menú Ⓐ son mutuamente excluyentes (como el demo)', async () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    const bell = await screen.findByRole('button', { name: /alertas y tareas/i });
+    fireEvent.click(bell);
+    expect(await screen.findByText(/alertas ambientales/i)).toBeInTheDocument();
+    // abrir la Ⓐ cierra la campana
+    fireEvent.click(screen.getByRole('button', { name: /ver todo lo que puede hacer chagra/i }));
+    await waitFor(() => {
+      expect(screen.queryByText(/alertas ambientales/i)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('3. Ⓐ de herramientas de campo (iteración recuperada)', () => {
+  test('el ícono biopunk es la A de azadón + rastrillo + machete', () => {
+    const { container } = render(<span>{THEME_ICON.biopunk}</span>);
+    expect(container.querySelector('[data-tool="azadon"]')).toBeTruthy();
+    expect(container.querySelector('[data-tool="rastrillo"]')).toBeTruthy();
+    expect(container.querySelector('[data-tool="machete"]')).toBeTruthy();
+    // círculo anarquía presente
+    expect(container.querySelector('circle')).toBeTruthy();
+  });
+});

--- a/src/components/dashboard/themeIcon.jsx
+++ b/src/components/dashboard/themeIcon.jsx
@@ -6,7 +6,14 @@
  *
  * Los 3 SVG son versiones marca de los demos:
  *   - nature: manos + frailejón (Espeletia), acento tierra
- *   - biopunk: anillo eléctrico + A (azadón + rama) + travesaño zigzag
+ *   - biopunk: la Ⓐ DE HERRAMIENTAS DE CAMPO — iteración RECUPERADA
+ *     (Chagra-strategy/ops/icon-explorations/animada-refinada-grunge2.html,
+ *     "ANIM-2 Refinada · Forja", 2026-06-06): círculo anarquía + pata
+ *     izquierda = AZADÓN (cabeza perpendicular al mango, filo rojo) + pata
+ *     derecha = RASTRILLO (travesaño + 5 dientes) + travesaño = MACHETE
+ *     (hoja curva + punta). Versión 28px engrosada (legible en cabecera).
+ *     Las clases `aforge`/`aforge-fill` activan la animación de forja
+ *     one-shot (stroke-dashoffset) definida en index.css.
  *   - minimalista: círculo + brote-horqueta monoline, acento verde sobrio
  */
 
@@ -30,13 +37,68 @@ export const THEME_ICON = {
             <circle cx="60" cy="36" r="6.5" fill="#d9742a" />
         </svg>
     ),
-    // Bio-punk — anillo eléctrico + A (azadón + rama) + travesaño zigzag.
+    // Bio-punk — la Ⓐ de HERRAMIENTAS DE CAMPO (iteración recuperada,
+    // "ANIM-2 Refinada": azadón + rastrillo + machete + círculo anarquía,
+    // rojinegro punk). Geometría 1:1 de la exploración del operador; trazos
+    // de la versión 28px (engrosados) para que lea a tamaño de marca/botón.
     biopunk: (
-        <svg viewBox="0 0 120 120" fill="none" width="100%" height="100%" aria-hidden="true">
-            <circle cx="60" cy="60" r="50" stroke="#19c79a" strokeWidth="7" />
-            <line x1="60" y1="24" x2="34" y2="96" stroke="#f0a060" strokeWidth="9" strokeLinecap="round" />
-            <line x1="60" y1="24" x2="86" y2="96" stroke="#3be8a6" strokeWidth="9" strokeLinecap="round" />
-            <path d="M44 66 L52 60 L60 66 L68 60 L76 67" stroke="#19c79a" strokeWidth="7" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+        <svg viewBox="0 0 100 108" fill="none" width="100%" height="100%" aria-hidden="true">
+            {/* Círculo anarquía */}
+            <circle
+                className="aforge" cx="50" cy="55" r="41" stroke="#c0392b" strokeWidth="5.5"
+                style={{ '--sd': 290 }}
+            />
+            {/* AZADÓN — pata izquierda: mango + cabeza PERPENDICULAR + filo */}
+            <g data-tool="azadon">
+                <line
+                    className="aforge" x1="28" y1="100" x2="46" y2="22"
+                    stroke="#c0392b" strokeWidth="6" strokeLinecap="round"
+                    style={{ '--sd': 96, '--fd': '.18s' }}
+                />
+                <polygon className="aforge-fill" points="34,18 58,24 60,29 36,23" fill="#5a0000" style={{ '--fd': '.26s' }} />
+                <path
+                    className="aforge" d="M34 18 L58 24 L60 29 L36 23 Z"
+                    stroke="#e74c3c" strokeWidth="3" strokeLinejoin="round"
+                    style={{ '--sd': 55, '--fd': '.28s' }}
+                />
+                <line
+                    className="aforge" x1="36" y1="23" x2="60" y2="29"
+                    stroke="#ff6060" strokeWidth="4" strokeLinecap="round"
+                    style={{ '--sd': 32, '--fd': '.34s' }}
+                />
+            </g>
+            {/* RASTRILLO — pata derecha: mango + travesaño + 5 dientes */}
+            <g data-tool="rastrillo">
+                <line
+                    className="aforge" x1="73" y1="100" x2="54" y2="18"
+                    stroke="#c0392b" strokeWidth="5.5" strokeLinecap="round"
+                    style={{ '--sd': 90, '--fd': '.4s' }}
+                />
+                <path
+                    className="aforge" d="M44 20 C51 17 58 15 65 14"
+                    stroke="#e74c3c" strokeWidth="4.5" strokeLinecap="round"
+                    style={{ '--sd': 26, '--fd': '.48s' }}
+                />
+                <line className="aforge" x1="45" y1="20" x2="44" y2="9" stroke="#e74c3c" strokeWidth="3.5" strokeLinecap="round" style={{ '--sd': 14, '--fd': '.52s' }} />
+                <line className="aforge" x1="49" y1="19" x2="48.5" y2="8" stroke="#ff6060" strokeWidth="3" strokeLinecap="round" style={{ '--sd': 14, '--fd': '.55s' }} />
+                <line className="aforge" x1="53" y1="18" x2="53" y2="7.5" stroke="#e74c3c" strokeWidth="3.5" strokeLinecap="round" style={{ '--sd': 14, '--fd': '.58s' }} />
+                <line className="aforge" x1="57" y1="17" x2="57.5" y2="7" stroke="#ff6060" strokeWidth="3" strokeLinecap="round" style={{ '--sd': 14, '--fd': '.61s' }} />
+                <line className="aforge" x1="61" y1="16" x2="62" y2="7.5" stroke="#e74c3c" strokeWidth="3.5" strokeLinecap="round" style={{ '--sd': 14, '--fd': '.64s' }} />
+            </g>
+            {/* MACHETE — travesaño: hoja curva + filo rojo sangre + punta */}
+            <g data-tool="machete">
+                <path
+                    className="aforge-fill"
+                    d="M21 62 C36 57 56 58 70 61 C76 62 80 65 83 67 C78 69 64 68 50 66 C36 64 21 68 21 69Z"
+                    fill="#4a0a00" style={{ '--fd': '.7s' }}
+                />
+                <path
+                    className="aforge" d="M21 62 C36 57 58 58 70 61 C76 62 81 65 84 67"
+                    stroke="#e74c3c" strokeWidth="4" strokeLinecap="round"
+                    style={{ '--sd': 85, '--fd': '.74s' }}
+                />
+                <path className="aforge-fill" d="M81 65 L93 62 L90 69 L80 70Z" fill="#c0392b" style={{ '--fd': '.78s' }} />
+            </g>
         </svg>
     ),
     // Minimalista — círculo + brote-horqueta monoline, acento verde sobrio.

--- a/src/index.css
+++ b/src/index.css
@@ -270,12 +270,15 @@
     background-color: rgb(var(--c-slate-950)) !important;
   }
 
-  /* Nature (N33 2026-06-04): degradado cálido crema→ocre con "sol" tenue arriba,
-   * paridad con el demo demo-agente.html. Minimalista se queda liso tipo papel. */
+  /* Nature: cielo AMANECER 1:1 del demo demo-agente.html (.sky, medido
+   * 2026-06-11 — antes era una aproximación N33 más ocre/oscura abajo):
+   *   radial #ffe8c2 → #f8d9a6 (26%) → #f3c98e (46%) + linear #fbe9c8 →
+   *   #f6ddb6 (30%) → #f1e3cb (56%) → #eef0db (100%).
+   * Minimalista se queda liso tipo papel. */
   [data-theme="nature"] body.app-bg-biodiversidad {
     background-image:
-      radial-gradient(125% 85% at 50% -12%, rgb(245 200 110 / 0.5) 0%, rgb(245 210 140 / 0.18) 38%, transparent 62%),
-      linear-gradient(178deg, rgb(var(--c-slate-950)) 0%, rgb(248 235 205) 62%, rgb(243 224 178) 100%) !important;
+      radial-gradient(120% 70% at 50% -10%, #ffe8c2 0%, #f8d9a6 26%, #f3c98e 46%, transparent 70%),
+      linear-gradient(180deg, #fbe9c8 0%, #f6ddb6 30%, #f1e3cb 56%, #eef0db 100%) !important;
     background-color: rgb(var(--c-slate-950)) !important;
     background-attachment: fixed !important;
   }
@@ -344,4 +347,33 @@
   .app-scrim-strong {
     background-color: rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 1.49));
   }
+}
+
+/* ===========================================================================
+ * Ⓐ DE HERRAMIENTAS DE CAMPO — animación "FORJA" one-shot (iteración
+ * recuperada: Chagra-strategy/ops/icon-explorations/animada-refinada-grunge2
+ * .html, "ANIM-2 Refinada"). Cada trazo del ícono biopunk (azadón → rastrillo
+ * → machete) se dibuja con stroke-dashoffset al montar, una sola vez (en el
+ * exploratorio era loop infinito; en la app sería ruido permanente).
+ * Los elementos llevan clase `aforge` (trazos) / `aforge-fill` (rellenos) con
+ * `--sd` (largo del trazo) y `--fd` (delay) inline desde themeIcon.jsx.
+ * =========================================================================== */
+.aforge {
+  stroke-dasharray: var(--sd, 100);
+  stroke-dashoffset: var(--sd, 100);
+  animation: aforge-draw 0.9s cubic-bezier(0.4, 0, 0.2, 1) var(--fd, 0s) forwards;
+}
+.aforge-fill {
+  opacity: 0;
+  animation: aforge-fill 0.6s ease var(--fd, 0s) forwards;
+}
+@keyframes aforge-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes aforge-fill {
+  to { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .aforge { stroke-dashoffset: 0; animation: none; }
+  .aforge-fill { opacity: 1; animation: none; }
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -39,17 +39,33 @@
  * "Chagra", halo). Antes biopunk no lo tenía y nature usaba oliva → el acento
  * salía verde-lavado en vez del color del demo. Valores = demos 2026-06-05:
  *   biopunk → teal #19c79a · nature → ocre #d98a4f · minimalista → verde #2f6e5a */
+/* Además del acento base, cada demo usa DOS matices del acento que antes no
+ * existían como token (paridad medida 2026-06-11 contra demo-agente*.html):
+ *   --t-accent-strong-rgb → el matiz del wordmark "Soy Chagra" (.greet .hi span):
+ *       biopunk = --teal-br #3be8a6 · nature = --acento-d #b86a32 ·
+ *       minimalista = --acento #2f6e5a.
+ *   --t-accent-deep-rgb   → el matiz del subtítulo de marca y del hint
+ *       (.brand small / .hintbar b): biopunk = --teal #19c79a · nature =
+ *       --acento-deep #a8612f · minimalista = --acento-deep #1d4639.
+ * Sin esto, nature pintaba wordmark/hint con el acento claro #d98a4f (medido)
+ * en vez de los tostados #b86a32/#a8612f del demo. */
 :root {
   --t-accent-rgb: 25, 201, 154;  /* teal neón biopunk (demo #19c79a) */
+  --t-accent-strong-rgb: 59, 232, 166;  /* teal brillante (demo #3be8a6) */
+  --t-accent-deep-rgb: 25, 201, 154;    /* = acento (demo --teal) */
 }
 
 [data-theme="minimalista"] {
   --t-accent-rgb: 47, 110, 90;   /* verde profundo (demo #2f6e5a) */
+  --t-accent-strong-rgb: 47, 110, 90;   /* demo: .hi span usa --acento */
+  --t-accent-deep-rgb: 29, 70, 57;      /* --acento-deep #1d4639 */
   --t-bg-rgb: 246, 243, 236;     /* papel (para el agujero del halo) */
 }
 
 [data-theme="nature"] {
   --t-accent-rgb: 217, 138, 79;  /* ocre cálido (demo #d98a4f) */
+  --t-accent-strong-rgb: 184, 106, 50;  /* --acento-d #b86a32 (wordmark) */
+  --t-accent-deep-rgb: 168, 97, 47;     /* --acento-deep #a8612f (hint/marca) */
   --t-bg-rgb: 251, 245, 234;     /* crema */
 }
 
@@ -71,11 +87,12 @@
   color: #fff !important;
 }
 
-/* Wordmark "Chagra": del degradé al acento sólido del tema */
+/* Wordmark "Chagra": del degradé al matiz FUERTE del acento del tema
+ * (= .greet .hi span del demo: #3be8a6 bp · #b86a32 nature · #2f6e5a min) */
 .chagra-wordmark {
   background-image: none !important;
-  -webkit-text-fill-color: rgb(var(--t-accent-rgb)) !important;
-  color: rgb(var(--t-accent-rgb)) !important;
+  -webkit-text-fill-color: rgb(var(--t-accent-strong-rgb, var(--t-accent-rgb))) !important;
+  color: rgb(var(--t-accent-strong-rgb, var(--t-accent-rgb))) !important;
   font-weight: 900;
 }
 


### PR DESCRIPTION
## Qué hace

Integra el hero del home (prd) con los demos de oracle-lab (`demo-agente.html` / `demo-agente-biopunk.html`) — 3 entregas del operador:

### 1. NATURE — colores medidos 1:1 del demo
- Cielo amanecer EXACTO del demo (`.sky`): `radial #ffe8c2 → #f8d9a6 (26%) → #f3c98e (46%)` + `linear #fbe9c8 → #f6ddb6 → #f1e3cb → #eef0db` (antes: aproximación N33 más ocre).
- Nuevos tokens por tema `--t-accent-strong-rgb` / `--t-accent-deep-rgb`: wordmark "Soy **Chagra**" → `#b86a32` (demo `--acento-d`), hint Ⓐ y subtítulo de marca → `#a8612f` (demo `--acento-deep`). Antes ambos salían con el acento claro `#d98a4f`.
- Subtítulo del saludo → `#6b5638` (demo `--cafe-2`) y toggle inactivo → `#8a7350` (demo `--cafe-3`).
- **Todo validado con `getComputedStyle` en chromium real (nix-store), no a ojo.** Reporte en `/tmp/herohero-art/report.json`.

### 2. BIOPUNK — campana de ALERTAS del demo importada
- `bellbtn` 🔔 + badge ámbar + panel con **"Alertas ambientales"** (useAlertStore real) y **"Tareas de campo"** (pendientes farmOS vía `syncManager`, offline-first con fallo suave).
- Mutuamente excluyente con la red Ⓐ (como el demo), Escape cierra, theme-aware vía tokens (`--c-surface-*`, `--t-accent-rgb`) — funciona en los 3 temas.

### 3. Ⓐ — comportamiento del demo + iteración RECUPERADA
- **Recuperada la "A de herramientas de campo"**: estaba en `Chagra-strategy/ops/icon-explorations/animada-refinada-grunge2.html` ("ANIM-2 Refinada · Forja", 2026-06-06 12:54 — la última iteración, nunca commiteada a prod). Azadón (cabeza PERPENDICULAR al mango + filo rojo) = pata izquierda · rastrillo (travesaño + 5 dientes) = pata derecha · machete (hoja curva + punta) = travesaño · círculo anarquía. Rojinegro punk, trazos de la versión 28px (legible en cabecera). Es ahora el ícono biopunk (marca + botón Ⓐ).
- Animación de **forja** (stroke-dashoffset trazo a trazo) portada como one-shot al montar/cambiar tema (en el exploratorio era loop infinito; respeta `prefers-reduced-motion`).
- Comportamiento del demo portado: **enviar con el campo vacío abre el menú didáctico de capacidades** (antes el botón moría deshabilitado) + **markSwap** (micro-animación al intercambiar el ícono del tema).

## Validación
- `npx vitest run` → 4409 pass; las 9 files que fallan, fallan IDÉNTICAS en main (pre-existentes, verificado con baseline).
- ESLint `--max-warnings=0` limpio en los archivos tocados.
- E2E visual con chromium del nix-store: screenshots prd (biopunk + nature, Ⓐ cerrada/abierta, campana + panel) vs demos en `/tmp/herohero-art/`.
- TDD: 6 tests nuevos (`AgentHero.demoParity.test.jsx`) + contrato del botón enviar actualizado en `AgentHero.composer.test.jsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)