### PR TITLE
test(guardas): suite integradora de guardas de seguridad + schema-check anti-fabricación

### DIFF
--- a/src/data/__tests__/dataSchema.fuente.test.js
+++ b/src/data/__tests__/dataSchema.fuente.test.js
@@ -1,0 +1,162 @@
+/**
+ * dataSchema.fuente.test.js — SCHEMA-CHECK MECÁNICO + ANTI-FABRICACIÓN.
+ *
+ * Política Chagra: "dato con fuente o no va". Una recomendación agronómica sin
+ * procedencia es indistinguible de una alucinación; en boca de un campesino,
+ * peligrosa. Este test recorre TODOS los `src/data/*.json` (+ el seed de
+ * biopreparados) y afirma, de forma puramente mecánica (sin red, sin LLM):
+ *
+ *   (a) cada archivo es JSON VÁLIDO (atrapa un `""` de más, una coma colgante,
+ *       un cierre roto que se haya colado en un merge);
+ *   (b) los módulos de conocimiento curado declaran procedencia top-level;
+ *   (c) ANTI-FABRICACIÓN: si un arreglo de objetos ya trae `fuente` por entrada
+ *       (convención de lista citada), TODAS sus entradas deben traer `fuente`
+ *       no vacía — así, una entrada sin fuente colada en una lista citada
+ *       (el vector real de fabricación) enrojece el test;
+ *   (d) las guardas de seguridad son strings NO vacíos (una guarda vacía = una
+ *       guarda que se dispara pero no dice nada);
+ *   (e) el seed de biopreparados: cada receta tiene procedencia (fuente o
+ *       source_ids) y —la invariante clave anti-alucinación— si trae dosis,
+ *       la dosis viene con `fuente` (la dosis sale del seed, NO la inventa el
+ *       modelo). Las entradas-semilla sin dosis aún se permiten: en prod
+ *       buildCuratedFactsContext simplemente no emite línea de dosis para ellas.
+ *
+ * Es un guard mecánico de la política: si alguien agrega un dato sin fuente,
+ * este test lo bloquea en CI antes de que llegue al campesino.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = join(__dirname, '..'); // src/data
+const SEED_PATH = join(__dirname, '..', '..', '..', 'catalog', 'biopreparados-seed.json');
+
+const DATA_FILES = readdirSync(DATA_DIR).filter((f) => f.endsWith('.json'));
+
+/**
+ * Módulos de CONOCIMIENTO CURADO (DR-*): deben declarar procedencia top-level.
+ * Los demás .json son geográficos/lingüísticos/crowdsourced (DANE, veredas,
+ * regionalismos) con su propio modelo de procedencia y se validan solo por (a).
+ */
+const MODULE_KNOWLEDGE_FILES = [
+  'animal-diagnostics.json',
+  'water-diagnostics.json',
+  'soil-diagnostics.json',
+  'restauracion.json',
+  'glosario.json',
+];
+
+const isNonEmptyStr = (v) => typeof v === 'string' && v.trim().length > 0;
+
+function loadRaw(file) {
+  return readFileSync(join(DATA_DIR, file), 'utf8');
+}
+
+describe('schema-check (a) — todos los src/data/*.json son JSON VÁLIDO', () => {
+  it('encuentra archivos de datos', () => {
+    expect(DATA_FILES.length).toBeGreaterThan(0);
+  });
+
+  it.each(DATA_FILES)('%s parsea sin error', (file) => {
+    const raw = loadRaw(file);
+    expect(() => JSON.parse(raw), `${file} NO es JSON válido`).not.toThrow();
+  });
+});
+
+describe('schema-check (b) — módulos de conocimiento declaran fuente top-level', () => {
+  it.each(MODULE_KNOWLEDGE_FILES)('%s tiene fuente no vacía', (file) => {
+    expect(DATA_FILES, `${file} no existe en src/data/ (¿módulo sin mergear?)`).toContain(file);
+    const d = JSON.parse(loadRaw(file));
+    expect(isNonEmptyStr(d.fuente), `${file} sin campo "fuente" top-level`).toBe(true);
+  });
+});
+
+describe('schema-check (c) — ANTI-FABRICACIÓN: ninguna entrada sin fuente en una lista citada', () => {
+  /**
+   * Recolecta violaciones: por cada array-de-objetos donde AL MENOS UNA entrada
+   * trae `fuente` no vacía (convención de lista citada), reporta las entradas
+   * que NO la traen. Esas son fabricación: dato sin procedencia en una lista que
+   * sí la exige.
+   */
+  function collectViolations(obj, path, out) {
+    if (Array.isArray(obj)) {
+      const objs = obj.filter((x) => x && typeof x === 'object' && !Array.isArray(x));
+      const anySourced = objs.some((x) => isNonEmptyStr(x.fuente));
+      if (anySourced) {
+        obj.forEach((x, i) => {
+          if (x && typeof x === 'object' && !Array.isArray(x) && !isNonEmptyStr(x.fuente)) {
+            out.push(`${path}[${i}] (id=${x.id ?? x.nombre ?? '?'}) sin fuente en lista citada`);
+          }
+        });
+      }
+      obj.forEach((x, i) => collectViolations(x, `${path}[${i}]`, out));
+    } else if (obj && typeof obj === 'object') {
+      for (const [k, v] of Object.entries(obj)) collectViolations(v, path ? `${path}.${k}` : k, out);
+    }
+    return out;
+  }
+
+  it.each(DATA_FILES)('%s — toda entrada de lista citada trae fuente', (file) => {
+    const d = JSON.parse(loadRaw(file));
+    const violations = collectViolations(d, '', []);
+    expect(violations, `${file}: entradas sin fuente en listas citadas:\n${violations.join('\n')}`).toEqual([]);
+  });
+});
+
+describe('schema-check (d) — guardas de seguridad son strings NO vacíos', () => {
+  const filesWithGuardas = MODULE_KNOWLEDGE_FILES.filter((f) => {
+    if (!DATA_FILES.includes(f)) return false;
+    const d = JSON.parse(loadRaw(f));
+    return d.guardas && typeof d.guardas === 'object';
+  });
+
+  it('al menos un módulo expone bloque de guardas', () => {
+    expect(filesWithGuardas.length).toBeGreaterThan(0);
+  });
+
+  it.each(filesWithGuardas)('%s — cada guarda tiene texto no vacío', (file) => {
+    const d = JSON.parse(loadRaw(file));
+    const vacias = Object.entries(d.guardas)
+      .filter(([, v]) => !isNonEmptyStr(v))
+      .map(([k]) => k);
+    expect(vacias, `${file}: guardas vacías (se disparan pero no dicen nada): ${vacias.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('anti-fabricación (e) — el seed de biopreparados: dosis sale del seed con fuente', () => {
+  const hasProvenance = (b) =>
+    isNonEmptyStr(b.fuente) || (Array.isArray(b.source_ids) && b.source_ids.length > 0);
+  const hasDose = (b) => isNonEmptyStr(b.dosis_aplicacion) || isNonEmptyStr(b.dosis);
+
+  it('el seed parsea y tiene biopreparados', () => {
+    const seed = JSON.parse(readFileSync(SEED_PATH, 'utf8'));
+    expect(Array.isArray(seed.biopreparados)).toBe(true);
+    expect(seed.biopreparados.length).toBeGreaterThan(0);
+  });
+
+  it('cada biopreparado tiene procedencia (fuente o source_ids) — ninguno sin respaldo', () => {
+    const seed = JSON.parse(readFileSync(SEED_PATH, 'utf8'));
+    const huerfanos = seed.biopreparados.filter((b) => !hasProvenance(b)).map((b) => b.id ?? b.nombre ?? '?');
+    expect(huerfanos, `biopreparados sin procedencia alguna: ${huerfanos.join(', ')}`).toEqual([]);
+  });
+
+  it('INVARIANTE clave: todo biopreparado CON dosis trae `fuente` (la dosis NO se inventa)', () => {
+    const seed = JSON.parse(readFileSync(SEED_PATH, 'utf8'));
+    // Si una entrada expone una dosis accionable, esa dosis DEBE venir con fuente
+    // citable. Una dosis sin fuente es exactamente el vector de alucinación que
+    // este test bloquea: el campesino la aplicaría como si fuera verificada.
+    const dosisSinFuente = seed.biopreparados
+      .filter((b) => hasDose(b) && !isNonEmptyStr(b.fuente))
+      .map((b) => b.id ?? b.nombre ?? '?');
+    expect(dosisSinFuente, `dosis sin fuente (se aplicaría como verificada sin serlo): ${dosisSinFuente.join(', ')}`).toEqual([]);
+  });
+
+  it('al menos un biopreparado expone dosis curada con fuente (el camino feliz existe)', () => {
+    const seed = JSON.parse(readFileSync(SEED_PATH, 'utf8'));
+    const conDosisYFuente = seed.biopreparados.filter((b) => hasDose(b) && isNonEmptyStr(b.fuente));
+    expect(conDosisYFuente.length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/__tests__/guardasSeguridad.integrator.test.js
+++ b/src/services/__tests__/guardasSeguridad.integrator.test.js
@@ -1,0 +1,278 @@
+/**
+ * guardasSeguridad.integrator.test.js — SUITE INTEGRADORA de guardas de
+ * seguridad campesina (DR-SUELOS-1, DR-AGUA-1, DR-ANIMAL-1, DR-RESTAURACION-1).
+ *
+ * Por qué existe: el patrón de fallo real de una guarda es que quede MUERTA —
+ * el código la "tiene" pero chequea un campo/condición que ya no se dispara, así
+ * que nunca emite el aviso y el campesino recibe un consejo peligroso. Estos
+ * tests son TDD-real: cada fila de GUARD_MATRIX afirma que UNA guarda concreta
+ * SE DISPARA con su input. Si se borra/rompe la guarda en prod, su fila falla.
+ *
+ * Probado borrando guardas en prod (cada fila enrojece su guarda):
+ *   - Animal: quitar leucaena_toxica de getGuardas → 4 filas monogástrico rojas.
+ *   - Suelo:  quitar el push de 'pH<5.5' → fila cal-bloqueada-hasta-pH roja.
+ *   - Agua:   quitar el branch de 'hidrogel' → fila hidrogel roja.
+ *   - Restauración: quitar guardas.pino_eucalipto → fila greenwashing roja.
+ *
+ * Las filas de CONTROL prueban especificidad (la guarda NO se dispara donde no
+ * debe): una guarda always-on que "siempre dispara" es tan mala como una muerta.
+ *
+ * Español Colombia (tú/usted), CERO voseo. CERO fabricación: todo sale del seed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  diagnosticarSuelo,
+} from '../soilDiagnostic.js';
+import {
+  diagnosticarAgua,
+  calcularCaptacion,
+} from '../waterDiagnostic.js';
+import {
+  getGuardas,
+  diagnosticarAnimal,
+} from '../animalDiagnostic.js';
+import {
+  diagnosticarRestauracion,
+} from '../restauracionDiagnostic.js';
+
+const has = (arr, ...needles) =>
+  Array.isArray(arr) && arr.some((s) => needles.every((n) => String(s).includes(n)));
+
+/**
+ * MATRIZ DE GUARDAS — cada fila: { id, modulo, run(), fires(result) }.
+ * `fires` DEBE devolver true cuando la guarda está viva. Si la guarda se quita,
+ * `fires` devuelve false y la fila falla → hallazgo de seguridad.
+ */
+const GUARD_MATRIX = [
+  // ── SUELO ────────────────────────────────────────────────────────────────
+  {
+    id: 'suelo/vinagre = MITO (bloqueado, NO decide cal)',
+    modulo: 'suelo',
+    run: () => diagnosticarSuelo('le eché vinagre a la tierra'),
+    fires: (r) =>
+      has(r.advertencias, 'MITO', 'vinagre') &&
+      has(r.advertencias, 'tiras de pH') &&
+      // bloqueado de verdad: del vinagre NO sale ninguna enmienda accionable (sin "botón de confirmar")
+      r.enmiendas.length === 0,
+  },
+  {
+    id: 'suelo/bicarbonato = MITO (bloqueado)',
+    modulo: 'suelo',
+    run: () => diagnosticarSuelo('hice la prueba del bicarbonato y no burbujeó'),
+    fires: (r) =>
+      has(r.advertencias, 'MITO', 'bicarbonato') && r.enmiendas.length === 0,
+  },
+  {
+    id: 'suelo/cal BLOQUEADA hasta confirmar pH<5.5',
+    modulo: 'suelo',
+    run: () => diagnosticarSuelo('en mi lote sale mucho helecho'),
+    fires: (r) =>
+      has(r.advertencias, 'pH<5.5') &&
+      // si recomienda cal, debe venir con la guarda de NO sobre-encalar
+      r.enmiendas.some((e) => e.id === 'cal_dolomitica' && /NO sobre-encalar/.test(e.precaucion)),
+  },
+  {
+    id: 'suelo/aguacate + mal drenaje = ALERTA CRÍTICA Phytophthora',
+    modulo: 'suelo',
+    run: () => diagnosticarSuelo('quiero sembrar aguacate pero el terreno se empoza'),
+    fires: (r) => has(r.advertencias, 'ALERTA CRÍTICA', 'Phytophthora'),
+  },
+
+  // ── AGUA ─────────────────────────────────────────────────────────────────
+  {
+    id: 'agua/calendario LUNAR = MITO (excluido)',
+    modulo: 'agua',
+    run: () => diagnosticarAgua('debo regar en luna menguante?'),
+    fires: (r) =>
+      has(r.advertencias, 'MITO', 'lunar') &&
+      // y NUNCA lo recomienda como práctica
+      !r.riego.some((x) => /luna/i.test(x.nombre)) &&
+      !r.conservacion.some((x) => /luna/i.test(x.nombre)),
+  },
+  {
+    id: 'agua/radiestesia (varillas) = MITO (excluido)',
+    modulo: 'agua',
+    run: () => diagnosticarAgua('uso varillas para encontrar agua'),
+    fires: (r) => has(r.advertencias, 'MITO', 'Radiestesia'),
+  },
+  {
+    id: 'agua/hidrogel sintético = NO AGROECOLOGICO (excluido)',
+    modulo: 'agua',
+    run: () => diagnosticarAgua('le pongo hidrogel a la tierra'),
+    fires: (r) =>
+      has(r.advertencias, 'NO AGROECOLOGICO') &&
+      !r.conservacion.some((x) => /hidrogel|poliacrilato/i.test(x.nombre)),
+  },
+  {
+    id: 'agua/marchitez de mediodía NO = sed (guarda siempre activa)',
+    modulo: 'agua',
+    run: () => diagnosticarAgua('se me seca el cultivo'),
+    fires: (r) => has(r.advertencias, 'marchitez al mediodia'),
+  },
+
+  // ── ANIMAL — Leucaena/mimosina PROHIBIDA a CADA monogástrico + equino ─────
+  {
+    id: 'animal/Leucaena PROHIBIDA a CERDO (porcino)',
+    modulo: 'animal',
+    run: () => getGuardas('porcino'),
+    fires: (g) => has(g, 'PROHIBIDA', 'Leucaena') && has(g, 'mimosina'),
+  },
+  {
+    id: 'animal/Leucaena PROHIBIDA a CONEJO (cunícola)',
+    modulo: 'animal',
+    run: () => getGuardas('cunicola'),
+    fires: (g) => has(g, 'PROHIBIDA', 'Leucaena'),
+  },
+  {
+    id: 'animal/Leucaena PROHIBIDA a AVE (avícola)',
+    modulo: 'animal',
+    run: () => getGuardas('avicola'),
+    fires: (g) => has(g, 'PROHIBIDA', 'Leucaena'),
+  },
+  {
+    id: 'animal/Leucaena PROHIBIDA a EQUINO',
+    modulo: 'animal',
+    run: () => getGuardas('equino'),
+    fires: (g) => has(g, 'PROHIBIDA', 'EQUINOS'),
+  },
+  {
+    id: 'animal/flujo: "leucaena a los marranos" levanta la guarda',
+    modulo: 'animal',
+    run: () => diagnosticarAnimal('les doy leucaena a los marranos'),
+    fires: (d) => has(d.guardas, 'PROHIBIDA', 'Leucaena'),
+  },
+
+  // ── RESTAURACIÓN ─────────────────────────────────────────────────────────
+  {
+    id: 'restauracion/anti-greenwashing: pino/eucalipto NO es restauración',
+    modulo: 'restauracion',
+    run: () => diagnosticarRestauracion('voy a sembrar pino para restaurar'),
+    fires: (r) =>
+      has(r.alertas, 'Pino') || has(r.guardas, 'Pino') ||
+      has(r.alertas, 'NO son restauracion') || has(r.guardas, 'NO son restauracion'),
+  },
+  {
+    id: 'restauracion/eucalipto también dispara la guarda anti-exóticas',
+    modulo: 'restauracion',
+    run: () => diagnosticarRestauracion('quiero sembrar eucalipto en la ronda'),
+    fires: (r) => has(r.alertas, 'eucalipto') || has(r.guardas, 'eucalipto') ||
+      has(r.alertas, 'Pino') || has(r.guardas, 'Pino'),
+  },
+  {
+    id: 'restauracion/bonos de carbono: "me quieren pagar por sembrar" = ALERTA',
+    modulo: 'restauracion',
+    run: () => diagnosticarRestauracion('me quieren pagar por sembrar arboles'),
+    fires: (r) => has(r.alertas, 'BONOS') || has(r.alertas, 'carbono'),
+  },
+  {
+    id: 'restauracion/páramo (Ley 1930) = restauración PASIVA primero',
+    modulo: 'restauracion',
+    run: () => diagnosticarRestauracion('el paramo se esta secando'),
+    fires: (r) => has(r.alertas, 'PARAMO') || has(r.alertas, '1930') || has(r.alertas, 'pasiva') || has(r.alertas, 'PASIVA'),
+  },
+  {
+    id: 'restauracion/retamo invasor = NO quemar (rebrota)',
+    modulo: 'restauracion',
+    run: () => diagnosticarRestauracion('tengo retamo invadiendo el lote'),
+    fires: (r) => r.alertas.some((a) => a.includes('NO') && /quem/.test(a)),
+  },
+];
+
+describe('GUARDAS DE SEGURIDAD — integrador: cada guarda SE DISPARA con su input', () => {
+  it('la matriz cubre las 4 dimensiones (suelo/agua/animal/restauración)', () => {
+    const modulos = new Set(GUARD_MATRIX.map((g) => g.modulo));
+    expect(modulos).toEqual(new Set(['suelo', 'agua', 'animal', 'restauracion']));
+    expect(GUARD_MATRIX.length).toBeGreaterThanOrEqual(17);
+  });
+
+  it.each(GUARD_MATRIX.map((g) => [g.id, g]))(
+    'guarda VIVA → %s',
+    (_id, guard) => {
+      const result = guard.run();
+      expect(result, `la guarda "${guard.id}" devolvió un resultado vacío/nulo`).toBeTruthy();
+      // Si esto falla, la guarda está MUERTA: no se disparó con su input → HALLAZGO DE SEGURIDAD.
+      expect(
+        guard.fires(result),
+        `GUARDA MUERTA: "${guard.id}" NO se disparó con su input. El campesino recibiría un consejo peligroso.`,
+      ).toBe(true);
+    },
+  );
+});
+
+describe('GUARDAS — especificidad (control): NO se disparan donde NO deben', () => {
+  it('animal/rumiante (bovino) NO recibe la guarda Leucaena PROHIBIDA', () => {
+    // Leucaena SÍ es forrajera válida para rumiantes; una guarda always-on aquí
+    // sería un falso positivo que confunde al ganadero.
+    expect(has(getGuardas('bovino'), 'PROHIBIDA', 'Leucaena')).toBe(false);
+  });
+
+  it('suelo/aguacate en suelo BUENO (sin mal drenaje) NO dispara ALERTA CRÍTICA', () => {
+    const d = diagnosticarSuelo('quiero sembrar aguacate, la tierra está negra y sueltica');
+    expect(has(d.advertencias, 'ALERTA CRÍTICA')).toBe(false);
+  });
+
+  it('agua/sin mito mencionado NO inventa advertencia de mito lunar/hidrogel', () => {
+    const d = diagnosticarAgua('se me seca el cultivo');
+    expect(d.advertencias.some((a) => a.includes('MITO') || a.includes('NO AGROECOLOGICO'))).toBe(false);
+  });
+
+  it('restauración/recuperar el monte (sin exóticas) NO mete alerta de bonos', () => {
+    const r = diagnosticarRestauracion('quiero recuperar el monte');
+    expect(has(r.alertas, 'BONOS')).toBe(false);
+  });
+});
+
+describe('AGUA — calculadora de captación Vc = A × lluvia × Ce × η da el valor correcto', () => {
+  it('60m² × 1200mm × Ce=0.90 × η=0.85 = 55.080 L/año (151 L/día)', () => {
+    const r = calcularCaptacion(60, 1200, 0.9);
+    expect(r.litros_anuales).toBe(55080);
+    expect(r.litros_diarios).toBe(151);
+  });
+
+  it('la fórmula es lineal y multiplicativa en sus 4 factores (no inventada)', () => {
+    // 1mm sobre 1m² = 1L; con Ce=1 y η=1 los litros = A×lluvia exactos.
+    expect(calcularCaptacion(10, 100, 1, 1).litros_anuales).toBe(1000);
+    // doblar el área dobla el volumen
+    expect(calcularCaptacion(20, 100, 1, 1).litros_anuales).toBe(2000);
+    // η por defecto 0.85
+    expect(calcularCaptacion(10, 100, 1).litros_anuales).toBe(850);
+  });
+
+  it('parámetros inválidos → null (no inventa un número)', () => {
+    expect(calcularCaptacion(0, 1200, 0.9)).toBeNull();
+    expect(calcularCaptacion(60, 0, 0.9)).toBeNull();
+    expect(calcularCaptacion(60, 1200, 0)).toBeNull();
+  });
+});
+
+describe('MÓDULOS — flujo descripción→diagnóstico→guarda + degradación sin romper', () => {
+  const modulos = [
+    ['suelo', diagnosticarSuelo, 'tengo tierra amarilla pegajosa y sale helecho'],
+    ['agua', (t) => diagnosticarAgua(t), 'se me seca el cultivo, no llueve hace meses'],
+    ['animal', diagnosticarAnimal, 'tengo 5 vacas lecheras'],
+    ['restauracion', diagnosticarRestauracion, 'quiero recuperar el monte en tierra fria'],
+  ];
+
+  it.each(modulos)('%s: descripción real → diagnóstico con datos + fuente citada', (_n, fn, texto) => {
+    const d = fn(texto);
+    expect(d).toBeTruthy();
+    expect(d.sin_datos).toBe(false);
+    expect(typeof d.fuente).toBe('string');
+    expect(d.fuente.length).toBeGreaterThan(0);
+  });
+
+  // Degradación: estos módulos son PUROS (sin red/sidecar). Ante entrada vacía,
+  // nula o ruido deben devolver sin_datos:true SIN lanzar — NUNCA inventar.
+  const degradaInputs = ['', '  ', null, undefined, 'ab', 'hola buenos dias'];
+  it.each(modulos)('%s: degrada sin romper ante entrada vacía/ruido (no inventa)', (_n, fn) => {
+    for (const inp of degradaInputs) {
+      let d;
+      expect(() => { d = fn(inp); }).not.toThrow();
+      expect(d).toBeTruthy();
+      if (inp === '' || inp == null || inp === '  ' || inp === 'ab' || inp === 'hola buenos dias') {
+        expect(d.sin_datos).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Qué

Tests de QA de seguridad para los módulos DR recién mergeados (suelo/agua/animal/restauración). Verifican que las **guardas de seguridad campesina NO estén MUERTAS** y que los data files sean válidos y con fuente (anti-fabricación). **Cero cambios a lógica de prod.**

El patrón de fallo real que esto ataca: una guarda que chequea un campo/condición que ya no se dispara queda "presente pero muerta" → el campesino recibe un consejo peligroso sin aviso.

## Tests nuevos

### `src/services/__tests__/guardasSeguridad.integrator.test.js` (integrador)
Matriz que recorre **todas** las guardas, una por una, y afirma que cada una **se dispara** con su input:
- **Animal:** Leucaena/mimosina PROHIBIDA a CADA monogástrico (cerdo, conejo, ave) + equino — un caso por especie. Control: rumiante (bovino) NO la recibe (especificidad).
- **Suelo:** vinagre/bicarbonato = MITO bloqueado (sin enmienda accionable, sin "botón de confirmar"); cal bloqueada hasta confirmar pH<5.5; aguacate + mal drenaje = ALERTA CRÍTICA Phytophthora.
- **Agua:** calendario lunar e hidrogel excluidos como mito/no-agroecológico (y nunca recomendados como práctica); calculadora `Vc = A×lluvia×Ce×η` da el valor correcto (60m²×1200mm×0.90×0.85 = 55.080 L/año).
- **Restauración:** anti-greenwashing (pino/eucalipto NO es restauración), alerta de bonos de carbono ("me quieren pagar por sembrar"), páramo Ley 1930 (restauración pasiva), retamo NO quemar.
- Flujo descripción→diagnóstico→guarda + degradación sin romper (entrada vacía/ruido → `sin_datos`, nunca inventa). Los módulos son puros (sin sidecar/red), degradan por diseño.

### `src/data/__tests__/dataSchema.fuente.test.js` (schema-check mecánico)
Recorre todos los `src/data/*.json` + el seed de biopreparados:
- (a) JSON válido; (b) módulos de conocimiento con `fuente` top-level; (c) **anti-fabricación:** ninguna entrada sin `fuente` en una lista citada; (d) guardas no vacías; (e) toda dosis de biopreparado viene con `fuente` (la dosis sale del seed, NO la inventa el modelo).

## TDD real (probado)
- Quitar `leucaena_toxica` de `getGuardas` → enrojecen las 4 filas monogástrico + equino + el flujo.
- Quitar el branch de hidrogel → enrojece la fila hidrogel.
- Colar una entrada sin `fuente` en `sistemas_riego` → enrojece el schema-check (c).
- Restaurado todo; prod intacto.

## Hallazgos
- **Sin guardas muertas** en los módulos mergeados — todas firman.
- **Schema-check:** 0 JSON inválidos, 0 entradas sin fuente. Los data files IoT/social/clima de #1444-1446 (incl. `social-aviso-legal.json`) **aún NO están en main** — no había `""` que arreglar; el test los cubrirá automáticamente al mergearse.
- **PSA** y la lista discreta de "13 prohibiciones de páramo (altitud>3000)" no existen como módulo/data propios en main; la cobertura de páramo vive en la guarda `paramo_pasivo` (Ley 1930) y se testea.

## Verde
- Nuevos: **68 tests passed** (eslint --max-warnings=0 limpio).
- Suite completa: +68 passed, **+0 nuevos fallos**. Hay 17 fallos pre-existentes en `origin/main` (AgentHero, sidecarClient, visionCache, mediaCache, outputGuards.mipPlaga, restauracionDiagnostic "tierra fria"≠"frio", etc.) — **no introducidos por este PR** (baseline sin estos archivos: 17 failed / 4399 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)