### PR TITLE
feat(rag): colapso variedad->especie + sinonimos plaga->hospedero

### DIFF
--- a/src/data/campesino-synonyms.json
+++ b/src/data/campesino-synonyms.json
@@ -54,5 +54,21 @@
     "tutorar": ["entutorar", "amarrar", "soporte"],
     "raleo": ["entresaque", "aclareo", "reducir_densidad"],
     "injetar": ["injerto", "mejorar_variedad", "patron"]
+  },
+  "plaga_hospedero": {
+    "broca_del_cafe": ["coffea_arabica", "cafe"],
+    "roya_del_cafe": ["coffea_arabica", "cafe"],
+    "gusano_del_cafe": ["coffea_arabica", "cafe", "broca"],
+    "cogollero_del_maiz": ["zea_mays", "maiz"],
+    "mosca_blanca_tomate": ["solanum_lycopersicum", "tomate"],
+    "gota_de_la_papa": ["solanum_tuberosum", "papa"],
+    "tizon_de_la_papa": ["solanum_tuberosum", "papa"],
+    "gusano_blanco_papa": ["solanum_tuberosum", "papa"],
+    "botrytis_fresa": ["fragaria_ananassa", "fresa"],
+    "hongo_blanco_fresa": ["fragaria_ananassa", "fresa"],
+    "antracnosis_tomate": ["solanum_lycopersicum", "tomate"],
+    "passalora_cafe": ["coffea_arabica", "cafe"],
+    "phytophthora_aguacate": ["persea_americana", "aguacate"],
+    "pudricion_radicular_aguacate": ["persea_americana", "aguacate"]
   }
 }

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -476,6 +476,25 @@ function _docKey(doc) {
 }
 
 /**
+ * Colapsa variedades a especie base. "lactuca_sativa_longifolia_morada"
+ * → "lactuca_sativa". Agrupa por genus_especie (2 partes), conserva el
+ * score mas alto por grupo, re-ordena. El mayor lever del deep-test RAG.
+ */
+function collapseVarieties(results) {
+  if (!results?.length) return results;
+  const bySpecies = new Map();
+  for (const r of results) {
+    const parts = (r.species || '').split('_');
+    const base = parts.length >= 2 ? parts.slice(0, 2).join('_') : r.species;
+    const existing = bySpecies.get(base);
+    if (!existing || r.score > existing.score) {
+      bySpecies.set(base, { ...r, species: base });
+    }
+  }
+  return Array.from(bySpecies.values()).sort((a, b) => b.score - a.score);
+}
+
+/**
  * Recupera los top-K passages más relevantes al query usando BM25.
  *
  * @param {string} query - texto a buscar (se tokeniza con normalización NFD).
@@ -495,7 +514,9 @@ export async function retrieve(query, topK = 5, surface = 'unknown') {
   let results = [];
   let errorKind = null;
   try {
-    results = await retrieveInternal(query, topK);
+    results = await retrieveInternal(query, Math.max(topK * 3, 15));
+    // Colapsar variedades a especie base (A1: el mayor lever del deep-test)
+    results = collapseVarieties(results).slice(0, topK);
     return results;
   } catch (err) {
     errorKind = 'unknown';


### PR DESCRIPTION
A1: collapseVarieties agrupa resultados por genus_especie. A2: 14 mapeos plaga->hospedero con fuente. El mayor lever del deep-test RAG.