### PR TITLE
fix(pwa): 3 bugs Android prod — Actualizar pegado, dos campanas, instalar en Chrome

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Chagra",
   "short_name": "Chagra",
+  "id": "/",
   "description": "Sistema de gestión agrícola inteligente con IA",
   "start_url": "/",
   "display": "standalone",
@@ -8,6 +9,24 @@
   "theme_color": "#0f172a",
   "orientation": "portrait-primary",
   "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icon-180.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    },
     {
       "src": "/icons.svg",
       "sizes": "512x512",

--- a/public/sw.js
+++ b/public/sw.js
@@ -38,6 +38,10 @@ self.addEventListener('activate', (event) => {
           return undefined;
         })
       ))
+      // La limpieza de caches viejos NUNCA debe bloquear el claim: si falla
+      // (cuota/storage en Android), sin claim() no hay controllerchange y el
+      // boton "Actualizar" del banner queda pegado (bug operador 2026-06-11).
+      .catch(() => undefined)
       .then(() => self.clients.claim())
       .then(() => self.clients.matchAll({ type: 'window' }))
       .then(clients => {
@@ -47,6 +51,7 @@ self.addEventListener('activate', (event) => {
           client.postMessage({ type: 'SW_UPDATED', version: CACHE_NAME });
         });
       })
+      .catch(() => undefined)
   );
 });
 

--- a/src/components/AndroidInstallBanner.jsx
+++ b/src/components/AndroidInstallBanner.jsx
@@ -2,6 +2,28 @@ import React, { useState, useEffect } from 'react';
 import { Download, X } from 'lucide-react';
 
 export const DISMISS_KEY = 'chagra-android-install-dismissed';
+// El descarte EXPIRA (operador 2026-06-11: "Chrome no me ofrece instalar" —
+// los criterios de instalabilidad PASAN en Chrome; la causa era el descarte
+// PERMANENTE de este banner en localStorage, mientras Brave —perfil sin
+// descarte previo— sí lo mostraba). Tras la ventana, re-ofrecemos.
+export const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 días
+
+/**
+ * ¿Hay un descarte vigente? Se guarda el timestamp del descarte; el valor
+ * legado 'true' (descarte sin fecha, pre-2026-06-11) se trata como expirado
+ * para volver a ofrecer la instalación una vez.
+ */
+function isDismissalActive() {
+  try {
+    const raw = localStorage.getItem(DISMISS_KEY);
+    if (!raw) return false;
+    const ts = Number(raw);
+    if (!Number.isFinite(ts)) return false; // legado 'true' → expirado
+    return Date.now() - ts < DISMISS_TTL_MS;
+  } catch (_) {
+    return false; // modo privado — tratamos como no descartado
+  }
+}
 
 /**
  * AndroidInstallBanner — botón claro "Instalar Chagra" para Android Chrome.
@@ -32,11 +54,7 @@ const AndroidInstallBanner = () => {
       window.matchMedia('(display-mode: standalone)').matches ||
       window.navigator.standalone === true;
     if (isStandalone) return undefined;
-    let dismissed = null;
-    try {
-      dismissed = localStorage.getItem(DISMISS_KEY);
-    } catch (_) { /* modo privado — tratamos como no descartado */ }
-    if (dismissed) return undefined;
+    if (isDismissalActive()) return undefined;
 
     const onBeforeInstallPrompt = (event) => {
       // Cancela el mini-infobar de Chrome y guarda el prompt para dispararlo
@@ -71,7 +89,10 @@ const AndroidInstallBanner = () => {
 
   const handleDismiss = () => {
     try {
-      localStorage.setItem(DISMISS_KEY, 'true');
+      // Timestamp, no 'true': el descarte expira (DISMISS_TTL_MS) y el
+      // banner vuelve a ofrecerse — un "ahora no" de hace meses no debe
+      // esconder la instalación para siempre.
+      localStorage.setItem(DISMISS_KEY, String(Date.now()));
     } catch (_) { /* modo privado — solo oculta esta sesión */ }
     setDeferredPrompt(null);
   };

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -304,21 +304,23 @@ export default function ProfileScreen({ onBack, onHome }) {
             <BackgroundSelector />
             <AgentAvatarSelector />
 
-            {/* Estilo de notificación de alertas (operador 2026-06-06).
-                'demo' = chip llamativo en la portada del agente (por defecto).
-                'actual' = campanita del encabezado. Persiste en el perfil. */}
+            {/* Estilo de notificación (operador 2026-06-06 + 2026-06-11).
+                Decide CUÁL campana única se muestra (bug "dos campanas"):
+                'demo' = campana de la portada del agente + aviso destacado
+                (por defecto). 'actual' = campanita clásica del encabezado.
+                Persiste en el perfil. */}
             <div className="space-y-3 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
               <div className="flex items-center gap-2 px-1">
                 <Bell size={18} className="text-emerald-400" />
-                <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Avisos de clima</h3>
+                <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Botón de avisos</h3>
               </div>
               <p className="text-[11px] text-slate-500 leading-snug px-1">
-                Cómo te muestra Chagra una alerta de clima o helada.
+                Elige cuál campana te muestra los avisos (alertas, tareas y sincronización). Solo se muestra una.
               </p>
               <div className="grid grid-cols-2 gap-3" role="radiogroup" aria-label="Estilo de avisos">
                 {[
-                  { id: 'demo', label: 'Aviso destacado', desc: 'Un cartel grande en la portada' },
-                  { id: 'actual', label: 'Campanita', desc: 'Solo el ícono de la campana' },
+                  { id: 'demo', label: 'Campana de la portada', desc: 'Vive en la portada del agente, con aviso destacado de clima' },
+                  { id: 'actual', label: 'Campana clásica', desc: 'El ícono de arriba, con notificaciones y clima' },
                 ].map((opt) => (
                   <button
                     key={opt.id}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -7,7 +7,7 @@ import useOllamaWarmStore from '../store/useOllamaWarmStore';
 import useAssetStore from '../store/useAssetStore';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import { FARM_CONFIG } from '../config/defaults';
-import { getProfile, getProfileMunicipio } from '../services/userProfileService';
+import { getProfile, getProfileMunicipio, getNotificationStyle } from '../services/userProfileService';
 import { findMunicipio } from '../utils/colombiaLocations';
 import { useTheme } from '../hooks/useTheme';
 import { iconForTheme } from './dashboard/themeIcon';
@@ -95,6 +95,18 @@ export default function TopBar({ onNavigate, onLogout }) {
     const onLocUpdated = () => setProfileTick((t) => t + 1);
     window.addEventListener('chagra:location-updated', onLocUpdated);
     return () => window.removeEventListener('chagra:location-updated', onLocUpdated);
+  }, []);
+
+  // UN solo botón de notificación (operador 2026-06-11, bug "dos campanas"):
+  // la pref `estilo_notificacion` del perfil decide cuál se ve —
+  //   'demo'   → la campana viva de la portada (AgentHero) · aquí NO se pinta
+  //   'actual' → esta campanita clásica del TopBar
+  // Re-lee en vivo cuando el operador la cambia en Perfil.
+  const [notifStyle, setNotifStyle] = useState(() => getNotificationStyle());
+  useEffect(() => {
+    const onStyleChanged = () => setNotifStyle(getNotificationStyle());
+    window.addEventListener('chagra:notif-style-changed', onStyleChanged);
+    return () => window.removeEventListener('chagra:notif-style-changed', onStyleChanged);
   }, []);
 
   // "Respira" animación del logo Chagra cuando hay actividad de fondo
@@ -219,8 +231,11 @@ export default function TopBar({ onNavigate, onLogout }) {
         {/* NotificationsBell — vivo. Pulsa rojo si crítico, ámbar si warning,
             slate si info/empty. Reemplaza el mic+sprout del TopBar
             (operador 2026-05-28: el agregar-planta-por-voz lo hace ahora
-            el agente Chagra directamente). */}
-        <NotificationsBell onNavigate={onNavigate} />
+            el agente Chagra directamente).
+            Solo si el operador eligió 'actual' (campana clásica) en Perfil —
+            con 'demo' la campana visible es la de la portada del agente
+            (una sola campana, operador 2026-06-11). */}
+        {notifStyle === 'actual' && <NotificationsBell onNavigate={onNavigate} />}
         {/* Botón Settings (icono ⚙) eliminado, Feedback piloto #115: era duplicado del
             botón operator name de arriba (ambos onNavigate('perfil')). El
             operator name button es más explícito + el NAV_TILE Perfil del

--- a/src/components/UpdateAvailableBanner.jsx
+++ b/src/components/UpdateAvailableBanner.jsx
@@ -3,8 +3,21 @@ import { RefreshCw, Sparkles } from 'lucide-react';
 import { writeAckedVersion } from '../services/swUpdateAck';
 import { reloadPage } from '../services/pageReload';
 
+// Timeout para reg.update(): en red rural flaky el fetch de sw.js puede
+// colgarse y el click "Actualizar" quedaba pegado esperando para siempre
+// (bug operador 2026-06-11). Pasado el timeout seguimos con el waiting
+// que ya tengamos.
+export const UPDATE_TIMEOUT_MS = 3000;
+// Red de seguridad post-SKIP_WAITING: si controllerchange nunca llega
+// (claim falló en el activate, evento tragado por el guard de first-install,
+// etc.) recargamos directo. Si la página recarga antes, este timer muere
+// con ella — nunca produce doble recarga.
+export const RELOAD_FALLBACK_MS = 8000;
+
 export default function UpdateAvailableBanner() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
+  // Click "Actualizar" en curso: feedback inmediato + evita doble click.
+  const [updating, setUpdating] = useState(false);
   // Capturamos la version reportada por el SW (via event.detail) para
   // persistir el ack en click "Actualizar". Fix Antigravity QA #18.
   const announcedVersionRef = useRef(null);
@@ -29,19 +42,34 @@ export default function UpdateAvailableBanner() {
   }, [updateAvailable]);
 
   const handleUpdate = async () => {
+    if (updating) return;
+    setUpdating(true);
     // Persistimos el ack ANTES de activar: si la recarga falla o el usuario
     // cierra la pestaña, no queremos repetir el toast en la proxima sesion
     // para una version que ya acepto.
     if (announcedVersionRef.current) {
       writeAckedVersion(announcedVersionRef.current);
     }
+    // Aviso a main.jsx: la PROXIMA controllerchange es una actualizacion
+    // pedida por el usuario → recargar SIEMPRE. Sin esto, una pagina que
+    // arranco SIN controller (hard reload / primera carga no controlada) se
+    // tragaba el controllerchange en el guard de first-install y el boton
+    // quedaba pegado (bug operador 2026-06-11, Android).
+    try {
+      window.dispatchEvent(new CustomEvent('chagra:sw-update-requested'));
+    } catch (_) { /* CustomEvent siempre existe en browsers soportados */ }
     try {
       const reg = await navigator.serviceWorker.ready;
       // Bug operador 2026-06-10 ("dar Actualizar N veces"): si hubo varios
       // deploys con la pestaña abierta, update() trae el SW MAS NUEVO y el
       // browser reemplaza el waiting → un click lleva a la ultima version.
+      // Promise.race: en red flaky update() puede colgarse — pasado el
+      // timeout activamos el waiting que ya tengamos.
       try {
-        await reg.update();
+        await Promise.race([
+          reg.update(),
+          new Promise((resolve) => { window.setTimeout(resolve, UPDATE_TIMEOUT_MS); }),
+        ]);
       } catch (_) { /* offline — activamos el waiting que ya tengamos */ }
       if (reg.waiting) {
         // NO recargamos aca. El SW activa → controllerchange → main.jsx
@@ -49,6 +77,10 @@ export default function UpdateAvailableBanner() {
         // la carrera "recarga antes de que el SW nuevo tome control" que
         // re-mostraba el banner.
         reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+        // Red de seguridad: si controllerchange nunca dispara (claim fallido
+        // en el activate del SW), recarga directa — el SW nuevo ya esta
+        // activo y controlara la pagina recargada. El reload mata el timer.
+        window.setTimeout(() => { reloadPage(); }, RELOAD_FALLBACK_MS);
         return;
       }
     } catch (_) { /* SW no disponible — recargar directo abajo */ }
@@ -87,10 +119,12 @@ export default function UpdateAvailableBanner() {
 
         <button
           onClick={handleUpdate}
-          className="px-3 py-1.5 bg-muzo-glow/20 hover:bg-muzo-glow/30 text-muzo-glow text-xs font-bold rounded-lg transition-colors whitespace-nowrap"
+          disabled={updating}
+          className="px-3 py-1.5 bg-muzo-glow/20 hover:bg-muzo-glow/30 disabled:opacity-60 text-muzo-glow text-xs font-bold rounded-lg transition-colors whitespace-nowrap inline-flex items-center gap-1.5"
           type="button"
         >
-          Actualizar
+          {updating && <RefreshCw size={12} className="animate-spin" aria-hidden="true" />}
+          {updating ? 'Actualizando…' : 'Actualizar'}
         </button>
       </div>
     </div>

--- a/src/components/__tests__/AndroidInstallBanner.test.jsx
+++ b/src/components/__tests__/AndroidInstallBanner.test.jsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import AndroidInstallBanner, { DISMISS_KEY } from '../AndroidInstallBanner';
+import AndroidInstallBanner, { DISMISS_KEY, DISMISS_TTL_MS } from '../AndroidInstallBanner';
 
 function makeBipEvent(outcome = 'accepted') {
   const event = new Event('beforeinstallprompt');
@@ -85,18 +85,37 @@ describe('AndroidInstallBanner', () => {
     expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
   });
 
-  it('NO aparece si fue descartado antes (localStorage)', () => {
-    localStorage.setItem(DISMISS_KEY, 'true');
+  it('NO aparece si hay un descarte VIGENTE (timestamp reciente)', () => {
+    localStorage.setItem(DISMISS_KEY, String(Date.now()));
     render(<AndroidInstallBanner />);
     act(() => { window.dispatchEvent(makeBipEvent()); });
     expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
   });
 
-  it('botón cerrar persiste el descarte y oculta', () => {
+  // Bug operador 2026-06-11: el descarte era PERMANENTE → Chrome (donde lo
+  // descartó una vez) nunca volvía a ofrecer instalar, mientras Brave sí.
+  it('SÍ re-aparece si el descarte ya expiró (más de DISMISS_TTL_MS)', () => {
+    localStorage.setItem(DISMISS_KEY, String(Date.now() - DISMISS_TTL_MS - 1000));
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent()); });
+    expect(screen.getByRole('button', { name: /instalar chagra/i })).toBeInTheDocument();
+  });
+
+  it('el descarte legado ("true", sin fecha) se trata como expirado: re-ofrece', () => {
+    localStorage.setItem(DISMISS_KEY, 'true');
+    render(<AndroidInstallBanner />);
+    act(() => { window.dispatchEvent(makeBipEvent()); });
+    expect(screen.getByRole('button', { name: /instalar chagra/i })).toBeInTheDocument();
+  });
+
+  it('botón cerrar persiste el descarte CON timestamp y oculta', () => {
+    const before = Date.now();
     render(<AndroidInstallBanner />);
     act(() => { window.dispatchEvent(makeBipEvent()); });
     fireEvent.click(screen.getByRole('button', { name: /cerrar/i }));
-    expect(localStorage.getItem(DISMISS_KEY)).toBe('true');
+    const stored = Number(localStorage.getItem(DISMISS_KEY));
+    expect(Number.isFinite(stored)).toBe(true);
+    expect(stored).toBeGreaterThanOrEqual(before);
     expect(screen.queryByRole('button', { name: /instalar chagra/i })).not.toBeInTheDocument();
   });
 

--- a/src/components/__tests__/TopBar.voicePlant.test.jsx
+++ b/src/components/__tests__/TopBar.voicePlant.test.jsx
@@ -38,6 +38,7 @@ describe('TopBar — captura por voz removida (#323)', () => {
   beforeEach(() => {
     onNavigate = vi.fn();
     onLogout = vi.fn();
+    localStorage.clear();
   });
 
   it('YA NO existe el botón unificado "Agregar planta por voz"', () => {
@@ -52,8 +53,17 @@ describe('TopBar — captura por voz removida (#323)', () => {
     expect(screen.queryByLabelText(/^Captura por voz$/i)).toBeNull();
   });
 
-  it('en su lugar renderiza el NotificationsBell', () => {
+  // 2026-06-11 (bug "dos campanas"): el NotificationsBell del TopBar solo se
+  // renderiza si el operador eligió 'actual' en Perfil. Con 'demo' (default)
+  // la campana única es la de la portada del agente (AgentHero).
+  it('renderiza el NotificationsBell solo con estilo "actual"', () => {
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ estilo_notificacion: 'actual' }));
     render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
     expect(screen.getByTestId('notifications-bell-stub')).toBeInTheDocument();
+  });
+
+  it('con estilo "demo" (default) NO renderiza el NotificationsBell (campana única en el hero)', () => {
+    render(<TopBar onNavigate={onNavigate} onLogout={onLogout} />);
+    expect(screen.queryByTestId('notifications-bell-stub')).toBeNull();
   });
 });

--- a/src/components/__tests__/UpdateAvailableBanner.update.test.jsx
+++ b/src/components/__tests__/UpdateAvailableBanner.update.test.jsx
@@ -16,7 +16,10 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import UpdateAvailableBanner from '../UpdateAvailableBanner';
+import UpdateAvailableBanner, {
+  UPDATE_TIMEOUT_MS,
+  RELOAD_FALLBACK_MS,
+} from '../UpdateAvailableBanner';
 import { ACK_STORAGE_KEY } from '../../services/swUpdateAck';
 import { reloadPage } from '../../services/pageReload';
 
@@ -100,5 +103,81 @@ describe('UpdateAvailableBanner — flujo Actualizar', () => {
       expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
     });
     expect(reloadPage).not.toHaveBeenCalled();
+  });
+
+  // ── Bug operador 2026-06-11 (Android): botón "Actualizar" pegado ──────────
+
+  it('click muestra "Actualizando…" y deshabilita el botón (feedback inmediato)', async () => {
+    const waiting = { postMessage: vi.fn() };
+    mockServiceWorker({ update: vi.fn().mockResolvedValue(undefined), waiting });
+
+    render(<UpdateAvailableBanner />);
+    showBanner();
+    const btn = screen.getByRole('button', { name: /actualizar/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /actualizando/i })).toBeDisabled();
+    });
+  });
+
+  it('anuncia chagra:sw-update-requested para que main.jsx recargue SIEMPRE en controllerchange', async () => {
+    const waiting = { postMessage: vi.fn() };
+    mockServiceWorker({ update: vi.fn().mockResolvedValue(undefined), waiting });
+    const requested = vi.fn();
+    window.addEventListener('chagra:sw-update-requested', requested);
+
+    render(<UpdateAvailableBanner />);
+    showBanner();
+    fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+    await waitFor(() => expect(waiting.postMessage).toHaveBeenCalled());
+    expect(requested).toHaveBeenCalledTimes(1);
+    window.removeEventListener('chagra:sw-update-requested', requested);
+  });
+
+  it('update() COLGADO (red flaky) no bloquea: SKIP_WAITING sale tras el timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const waiting = { postMessage: vi.fn() };
+      // update() nunca resuelve — simula fetch de sw.js colgado en red rural.
+      mockServiceWorker({ update: vi.fn(() => new Promise(() => {})), waiting });
+
+      render(<UpdateAvailableBanner />);
+      showBanner();
+      fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(UPDATE_TIMEOUT_MS + 50);
+      });
+      expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fallback: si controllerchange nunca recarga, recarga directa tras RELOAD_FALLBACK_MS', async () => {
+    vi.useFakeTimers();
+    try {
+      const waiting = { postMessage: vi.fn() };
+      mockServiceWorker({ update: vi.fn().mockResolvedValue(undefined), waiting });
+
+      render(<UpdateAvailableBanner />);
+      showBanner();
+      fireEvent.click(screen.getByRole('button', { name: /actualizar/i }));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10);
+      });
+      expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+      expect(reloadPage).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RELOAD_FALLBACK_MS + 50);
+      });
+      expect(reloadPage).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -411,9 +411,18 @@ export default function AgentHero({ onNavigate }) {
         activeAlerts.find((a) => a.severity === 'danger') ||
         activeAlerts.find((a) => a.severity === 'warning') ||
         null;
-    // Preferencia de estilo: 'demo' (chip, default) | 'actual' (campanita del
-    // TopBar). En 'actual' NO pintamos el chip aquí (la campanita ya lo cubre).
-    const notifStyle = getNotificationStyle();
+    // Preferencia de estilo: 'demo' (campana de la portada + chip, default) |
+    // 'actual' (campanita clásica del TopBar). Operador 2026-06-11 (bug "dos
+    // campanas"): la pref decide cuál ÚNICA campana se renderiza — con 'demo'
+    // la de la portada vive aquí y el TopBar no pinta la suya; con 'actual'
+    // es al revés. Re-lee en vivo cuando cambia en Perfil.
+    const [notifStyle, setNotifStyle] = useState(() => getNotificationStyle());
+    useEffect(() => {
+        const onStyleChanged = () => setNotifStyle(getNotificationStyle());
+        window.addEventListener('chagra:notif-style-changed', onStyleChanged);
+        return () => window.removeEventListener('chagra:notif-style-changed', onStyleChanged);
+    }, []);
+    const showHeroBell = notifStyle === 'demo';
     const showAlertChip = notifStyle === 'demo' && Boolean(topAlert);
 
     const sendToOutbox = useAgentOutboxStore((s) => s.send);
@@ -586,15 +595,23 @@ export default function AgentHero({ onNavigate }) {
     // Las tareas pendientes vienen del MISMO camino offline-first que el
     // PendingTasksWidget (syncManager cachea farmOS); sin red, falla suave y
     // el badge cuenta solo las alertas locales.
+    // failedTxCount: cambios en quarantine (sin sincronizar). Cuando esta
+    // campana es la ÚNICA (estilo 'demo'), los errores reales de sync de la
+    // campanita clásica NO se pierden: viven aquí (operador 2026-06-11).
+    const [failedTxCount, setFailedTxCount] = useState(0);
     useEffect(() => {
         let alive = true;
         Promise.resolve()
             .then(() => syncManager.fetchPendingTasksFromFarmOS())
             .then((tasks) => { if (alive && Array.isArray(tasks)) setPendingTasks(tasks); })
             .catch(() => { /* offline: el badge usa solo las alertas */ });
+        Promise.resolve()
+            .then(() => syncManager.getFailedTransactions())
+            .then((txs) => { if (alive) setFailedTxCount(Array.isArray(txs) ? txs.length : 0); })
+            .catch(() => { /* sin IDB: el badge usa solo alertas+tareas */ });
         return () => { alive = false; };
-    }, []);
-    const notifCount = activeAlerts.length + pendingTasks.length;
+    }, [notifOpen]);
+    const notifCount = activeAlerts.length + pendingTasks.length + (failedTxCount > 0 ? 1 : 0);
     const toggleNotif = () => {
         setNotifOpen((open) => {
             if (!open && menuOpen) closeMenu(); // excluyentes, como el demo
@@ -1613,26 +1630,30 @@ export default function AgentHero({ onNavigate }) {
                         con Ajustes/Salir. */}
 
                     {/* Campana de alertas/tareas — import del demo biopunk.
-                        Badge = alertas activas + tareas de campo pendientes. */}
-                    <button
-                        type="button"
-                        onClick={toggleNotif}
-                        aria-label="Alertas y tareas pendientes"
-                        aria-expanded={notifOpen}
-                        className={[
-                            'agentport-bell',
-                            notifOpen ? 'is-open' : '',
-                            notifCount > 0 ? 'has-items' : '',
-                        ].join(' ')}
-                    >
-                        <span className="bicon" aria-hidden="true">🔔</span>
-                        {notifCount > 0 && <span className="badge">{notifCount}</span>}
-                    </button>
+                        Badge = alertas activas + tareas de campo + sync con
+                        errores. Solo con estilo 'demo' (es LA campana única;
+                        con 'actual' la única es la del TopBar). */}
+                    {showHeroBell && (
+                        <button
+                            type="button"
+                            onClick={toggleNotif}
+                            aria-label="Alertas y tareas pendientes"
+                            aria-expanded={notifOpen}
+                            className={[
+                                'agentport-bell',
+                                notifOpen ? 'is-open' : '',
+                                notifCount > 0 ? 'has-items' : '',
+                            ].join(' ')}
+                        >
+                            <span className="bicon" aria-hidden="true">🔔</span>
+                            {notifCount > 0 && <span className="badge">{notifCount}</span>}
+                        </button>
+                    )}
                 </div>
             </header>
 
             {/* ============ PANEL DE ALERTAS / TAREAS (demo biopunk) ============ */}
-            {notifOpen && (
+            {showHeroBell && notifOpen && (
                 <section className="agentport-notif" aria-label="Alertas y tareas de campo">
                     <div className="nph">
                         <div className="nt">🔔 Alertas y tareas</div>
@@ -1683,6 +1704,25 @@ export default function AgentHero({ onNavigate }) {
                                 </span>
                             </div>
                         ))}
+                        {/* Errores reales de sincronización (quarantine) — al ser
+                            esta la campana única, el estado de sync de la
+                            campanita clásica vive aquí (operador 2026-06-11). */}
+                        {failedTxCount > 0 && (
+                            <>
+                                <div className="nsec">Sincronización</div>
+                                <div className="nitem is-danger">
+                                    <span className="nico" aria-hidden="true">📡</span>
+                                    <span className="ntxt">
+                                        <span className="ntit">
+                                            {failedTxCount === 1
+                                                ? '1 cambio no se pudo sincronizar'
+                                                : `${failedTxCount} cambios no se pudieron sincronizar`}
+                                        </span>
+                                        <span className="nmeta">Tus datos siguen guardados en el teléfono. Revisa la conexión e intenta de nuevo.</span>
+                                    </span>
+                                </div>
+                            </>
+                        )}
                     </div>
                     <div className="agentport-notif-foot">
                         Lo clave te lo digo en el saludo. Aquí guardo <b>el resto</b>.

--- a/src/components/dashboard/__tests__/AgentHero.bellGate.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.bellGate.test.jsx
@@ -1,0 +1,114 @@
+/**
+ * AgentHero.bellGate.test.jsx — UNA sola campana de notificación (bug
+ * operador 2026-06-11: "salen dos botones de notificación arriba").
+ *
+ * Contrato:
+ *  - estilo 'demo' (default) → la campana de la portada (agentport-bell)
+ *    SE renderiza (es LA campana única; el TopBar esconde la suya).
+ *  - estilo 'actual' → la campana de la portada NO se renderiza (la única
+ *    es la campanita clásica del TopBar).
+ *  - el cambio de preferencia en Perfil (evento chagra:notif-style-changed)
+ *    se refleja EN VIVO sin recargar.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const sendMock = vi.fn(async () => 1);
+vi.mock('../../../store/useAgentOutboxStore', () => ({
+  default: (selector) => selector({ send: sendMock, items: [], inFlight: [], refresh: vi.fn() }),
+}));
+
+vi.mock('../../../hooks/useVoiceRecorder', () => ({
+  default: () => ({
+    isRecording: false,
+    audioLevel: 0,
+    durationMs: 0,
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    error: null,
+  }),
+}));
+
+vi.mock('../../../services/photoService', () => ({
+  captureAndCompress: vi.fn(async () => ({ blob: new Blob(), mime: 'image/jpeg' })),
+}));
+
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { start: vi.fn(), listen: vi.fn(), chime: vi.fn(), cancel: vi.fn() },
+}));
+
+// Preferencia de estilo CONTROLABLE por test.
+const notifStyleMock = vi.fn(() => 'demo');
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({ nivel_respuestas: 'simple' })),
+  saveProfile: vi.fn(),
+  getProfileMunicipio: vi.fn(() => null),
+  getNotificationStyle: (...args) => notifStyleMock(...args),
+}));
+
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'nature', setTheme: vi.fn() }),
+}));
+
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [] }),
+}));
+
+vi.mock('../../../store/useAlertStore', () => ({
+  default: (selector) => selector({ activeAlerts: [] }),
+}));
+
+vi.mock('../../../data/exampleQuestions', () => ({
+  AGENT_HERO_CHIPS: [{ icon: '🌱', label: '¿Qué siembro?', prompt: '¿Qué siembro?' }],
+}));
+
+vi.mock('../../ChagraAgentAvatar', () => ({
+  default: () => <div data-testid="avatar" />,
+}));
+
+vi.mock('../../../services/syncManager', () => ({
+  syncManager: {
+    fetchPendingTasksFromFarmOS: vi.fn(async () => []),
+    getFailedTransactions: vi.fn(async () => []),
+  },
+}));
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+import AgentHero from '../AgentHero';
+
+const BELL_LABEL = /alertas y tareas pendientes/i;
+
+describe('AgentHero — campana única según estilo_notificacion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notifStyleMock.mockReturnValue('demo');
+  });
+
+  test("estilo 'demo' (default): la campana de la portada SÍ se renderiza", () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    expect(screen.getByRole('button', { name: BELL_LABEL })).toBeInTheDocument();
+  });
+
+  test("estilo 'actual': la campana de la portada NO se renderiza (la única es la del TopBar)", () => {
+    notifStyleMock.mockReturnValue('actual');
+    render(<AgentHero onNavigate={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: BELL_LABEL })).toBeNull();
+  });
+
+  test('cambio en vivo: chagra:notif-style-changed re-lee la preferencia', () => {
+    render(<AgentHero onNavigate={vi.fn()} />);
+    expect(screen.getByRole('button', { name: BELL_LABEL })).toBeInTheDocument();
+
+    notifStyleMock.mockReturnValue('actual');
+    act(() => {
+      window.dispatchEvent(new CustomEvent('chagra:notif-style-changed', { detail: { style: 'actual' } }));
+    });
+    expect(screen.queryByRole('button', { name: BELL_LABEL })).toBeNull();
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -131,10 +131,22 @@ if ('serviceWorker' in navigator) {
   // Guard `reloading` evita bucles de recarga; `hadController` evita recargar
   // en el primer install (clients.claim() tambien dispara controllerchange
   // cuando antes no habia controlador — ahi NO hay que recargar).
+  //
+  // `userUpdateRequested` (bug operador 2026-06-11, Android — boton pegado):
+  // si la pagina arranco SIN controller (hard reload / carga no controlada)
+  // pero hay un SW en waiting, el click "Actualizar" disparaba SKIP_WAITING
+  // → claim → controllerchange, y el guard de first-install se TRAGABA el
+  // evento: ni recarga ni banner fuera. Cuando la actualizacion la pidio el
+  // usuario (evento chagra:sw-update-requested del banner), controllerchange
+  // SIEMPRE recarga.
   let reloading = false;
   let hadController = Boolean(navigator.serviceWorker.controller);
+  let userUpdateRequested = false;
+  window.addEventListener('chagra:sw-update-requested', () => {
+    userUpdateRequested = true;
+  });
   navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (!hadController) {
+    if (!hadController && !userUpdateRequested) {
       hadController = true; // primer claim en first install — sin recarga
       return;
     }

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -409,12 +409,20 @@ export function getNotificationStyle() {
  * Persiste el estilo de notificación en el perfil. Ignora valores inválidos
  * (cae al default) para no corromper el perfil.
  *
+ * Emite `chagra:notif-style-changed` para que los consumidores montados
+ * (TopBar, AgentHero) re-lean la preferencia en vivo — desde 2026-06-11 el
+ * estilo decide CUÁL campana se renderiza (una sola, bug "dos campanas").
+ *
  * @param {'demo'|'actual'} style
  * @returns {Object} perfil resultante
  */
 export function setNotificationStyle(style) {
   const next = NOTIFICATION_STYLES.includes(style) ? style : DEFAULT_NOTIFICATION_STYLE;
-  return saveProfile({ estilo_notificacion: next });
+  const profile = saveProfile({ estilo_notificacion: next });
+  try {
+    window.dispatchEvent(new CustomEvent('chagra:notif-style-changed', { detail: { style: next } }));
+  } catch (_) { /* SSR/tests sin window — la pref ya quedó persistida */ }
+  return profile;
 }
 
 /** Marca el onboarding de perfil como completado. */


### PR DESCRIPTION
## Resumen

Tres bugs de PWA reportados por el operador (Android, prod), diagnosticados en runtime y validados EN VIVO con chromium del nix-store (UA Android).

### Bug 1 — Botón "Actualizar" pegado (no actualiza ni desaparece)
**Causa raíz** (3 caminos de bloqueo, el flujo #1432 NO estaba regresado):
1. Página que arrancó **sin controller** (hard reload / carga no controlada): el guard de first-install en `main.jsx` se tragaba el `controllerchange` post-SKIP_WAITING → ni recarga ni banner fuera.
2. `reg.update()` **colgado** en red flaky → el click esperaba para siempre, sin feedback.
3. Si la limpieza de caches del `activate` fallaba, `clients.claim()` nunca corría → `controllerchange` jamás disparaba.

**Fix**: evento `chagra:sw-update-requested` (recarga garantizada cuando la pidió el usuario) + timeout 3s a `update()` + catch antes del `claim` en sw.js + recarga de seguridad a los 8s + botón "Actualizando…" deshabilitado.
**Evidencia E2E** (server local con sw.js mutable): banner aparece → UN click → recarga → cache viejo purgado → banner fuera, 0 pageerrors. `bug1-1-banner-visible.png` / `bug1-2-post-update.png`.

### Bug 2 — Dos botones de notificación arriba
**Causa raíz**: la campana del hero (#1447, demo biopunk) convive con el `NotificationsBell` del TopBar; el selector de Perfil (`estilo_notificacion`, ya definido 2026-06-06) solo gateaba el chip.
**Fix**: la preferencia decide CUÁL campana única se renderiza ('demo' = portada, default del operador; 'actual' = clásica del TopBar), con cambio EN VIVO (`chagra:notif-style-changed`). Lo valioso no se pierde: la campana del hero suma los errores reales de sync (quarantine). Copy del selector actualizado a "Botón de avisos".
**Evidencia E2E**: estilo demo → hero 1 / TopBar 0 · estilo actual → hero 0 / TopBar 1 (`bug2-estilo-demo.png` / `bug2-estilo-actual.png`).

### Bug 3 — Chrome no ofrece instalar (Brave sí)
**Diagnóstico empírico contra prod** (CDP `Page.getInstallabilityErrors`): criterios **PASAN** (`[]`), `beforeinstallprompt` SÍ dispara en perfil no-incógnito, manifest servido OK (id + PNG 192/512). `rag-embeddings.json` (7.5MB) NO está en precache ni en el manifest — no afecta instalabilidad.
**Causa de código**: el descarte del banner era **permanente** → en el Chrome de uso diario un "ahora no" viejo lo escondía para siempre; Brave (perfil limpio) sí lo mostraba. El resto es estado del dispositivo (app ya instalada vía WebAPK → Chrome no re-ofrece, por diseño).
**Fix**: descarte con timestamp que expira a los 14 días; valor legado `'true'` se trata como expirado (re-ofrece una vez). Bonus: manifest.json stale de la raíz sincronizado con el servido.
**Evidencia E2E**: con descarte legado el banner re-aparece (`bug3-reoferta-legado.png`).

## Tests
- 13 tests nuevos/ajustados (banner update, install banner, gating campanas) — verdes.
- ESLint `--max-warnings=0` limpio en todos los archivos tocados.
- Suite completa: 22 fallos **pre-existentes en origin/main** (verificado con baseline sobre checkout limpio: mismos 22) — cero regresiones de este PR.

Screenshots en `/tmp/pwabugs-art/` (alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)