### PR TITLE
fix(chips): chips de modo en flex-wrap — silvo/paramo/restauracion visibles

### DIFF
--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -85,8 +85,7 @@ export default function ChipsToolbar({
       <div
         role="toolbar"
         aria-label="Modos del asistente"
-        className="flex gap-2 overflow-x-auto pb-1 -mb-1 scrollbar-none"
-        style={{ scrollbarWidth: 'none', WebkitOverflowScrolling: 'touch' }}
+        className="flex flex-wrap gap-2 pb-1 -mb-1"
       >
         {/* Chip 📷 foto: primero y SOLO si hay imagen adjunta. */}
         {hasAttachment && (


### PR DESCRIPTION
Bug del operador: no veia los botones silvo/paramo/restauracion abajo. El test de arana confirmo que SI estan en CHIP_DEFS pero quedaban fuera del viewport (overflow-x-auto sin affordance). flex-wrap los muestra todos. Solo aparece en pantalla vacia (espacio disponible).