### PR TITLE
feat(hoy): dashboard proactivo "Hoy en finca" + agenda campesina

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,6 +75,7 @@ const OnboardingHero = lazy(() => import('./components/OnboardingHero'));
 const WelcomeStatsHero = lazy(() => import('./components/WelcomeStatsHero'));
 const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
+const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 import HomeRegionalGreeting from './components/HomeRegionalGreeting';
 
 localforage.config({
@@ -135,6 +136,8 @@ const HASH_VIEW_ROUTES = {
   casos: 'casos',
   tareas: 'task_log',
   task_log: 'task_log',
+  hoy: 'hoy_finca',
+  'hoy-en-finca': 'hoy_finca',
 };
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -643,6 +646,19 @@ export default function App() {
         );
       case 'dashboard':
         return <DashboardLiveView onNavigate={navigate} onLogout={handleLogout} lastLogMessage={lastLogMessage} />;
+      case 'hoy_finca':
+        // Dashboard proactivo "Hoy en finca": clima honesto de hoy + alertas
+        // + tareas del ciclo de la semana + agenda campesina. Todo accionable
+        // (los toques rutean a agente/ciclo/procesos/etc.).
+        return (
+          <ErrorBoundary>
+            <HoyEnFincaScreen
+              onBack={() => navigate('dashboard')}
+              onHome={() => navigate('dashboard')}
+              onNavigate={navigate}
+            />
+          </ErrorBoundary>
+        );
       case 'sembrar':
         return <SeedingLog onBack={() => navigate('dashboard')} onSave={showToast} initialData={currentViewData} />;
       case 'cosechar':

--- a/src/components/__tests__/HoyEnFincaScreen.test.jsx
+++ b/src/components/__tests__/HoyEnFincaScreen.test.jsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ScreenShell trae NotificationsBell (fetch clima, IDB…) — passthrough simple.
+vi.mock('../common/ScreenShell', () => ({
+  ScreenShell: ({ title, children }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+const DAY_MS = 86400000;
+const NOW = Date.now();
+
+const mockGeo = {
+  lat: 4.53, lng: -73.92, elevation: 1950, municipio: 'Choachí', precision: 'exact',
+};
+
+const mockSnapshot = {
+  enso_status: { phase: 'nina_moderada' },
+  openmeteo: {
+    available: true,
+    forecast_7d: [
+      { date: new Date(NOW).toISOString().slice(0, 10), temp_max_c: 18, temp_min_c: 7, precip_mm: 2 },
+    ],
+  },
+};
+
+const mockSky = {
+  current: { cloud_cover_pct: 88, weather_code: 3, precip_mm: 0, is_day: true },
+  daily: [{ date: new Date(NOW).toISOString().slice(0, 10), cloud_cover_mean_pct: 88, weather_code: 3, precip_mm: 2 }],
+};
+
+const mockProcesses = [
+  {
+    process_id: 'p-papa',
+    type: 'farm_process',
+    attributes: {
+      process_type: 'sowing',
+      subject_slug: 'solanum_tuberosum',
+      subject_label: 'Papa pastusa',
+      status: 'active',
+      current_stage: 'vegetative',
+      created_at: NOW - 45 * DAY_MS,
+    },
+  },
+];
+
+vi.mock('../../services/climaService', () => ({
+  resolveClimaLocation: vi.fn(() => mockGeo),
+  getCachedClimaSnapshot: vi.fn(() => mockSnapshot),
+  fetchClimaSnapshot: vi.fn(() => Promise.resolve(mockSnapshot)),
+  describePhase: vi.fn(() => 'La Niña moderada — mas lluvia de lo normal'),
+}));
+
+vi.mock('../../services/skyConditionService', async (importOriginal) => {
+  const real = await importOriginal();
+  return {
+    ...real,
+    getCachedSkyConditions: vi.fn(() => mockSky),
+    fetchSkyConditions: vi.fn(() => Promise.resolve(mockSky)),
+  };
+});
+
+vi.mock('../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(() => Promise.resolve(mockProcesses)),
+}));
+
+vi.mock('../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({ municipio: 'Choachí', finca_altitud: 1950 })),
+}));
+
+import HoyEnFincaScreen from '../hoy/HoyEnFincaScreen';
+import useAlertStore, { resetAlertStore } from '../../store/useAlertStore';
+import { resolveClimaLocation } from '../../services/climaService';
+
+describe('HoyEnFincaScreen', () => {
+  beforeEach(() => {
+    resetAlertStore();
+    sessionStorage.clear();
+    vi.mocked(resolveClimaLocation).mockReturnValue(mockGeo);
+  });
+
+  it('muestra el clima HONESTO de hoy (nublado real, no sol optimista)', async () => {
+    render(<HoyEnFincaScreen onNavigate={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('clima-hoy-label').textContent).toMatch(/nublado/i);
+    });
+    // Temperaturas reales del forecast
+    expect(screen.getByTestId('clima-hoy-card').textContent).toContain('18°');
+    // ENSO en lenguaje llano, no jerga
+    expect(screen.getByTestId('enso-llano').textContent).toMatch(/lluvia de lo normal/);
+    // Fuente citada
+    expect(screen.getByTestId('clima-hoy-card').textContent).toMatch(/Open-Meteo/);
+  });
+
+  it('toque del clima rutea al agente con prompt pre-cargado', async () => {
+    const onNavigate = vi.fn();
+    render(<HoyEnFincaScreen onNavigate={onNavigate} />);
+    await waitFor(() => screen.getByTestId('clima-hoy-label'));
+    fireEvent.click(screen.getByTestId('clima-hoy-card'));
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+    expect(sessionStorage.getItem('chagra:agent:prefilled')).toMatch(/¿Qué me recomiendas hacer hoy/);
+  });
+
+  it('sin alertas: mensaje tranquilo; con alertas: lista accionable → agente', async () => {
+    const onNavigate = vi.fn();
+    const { unmount } = render(<HoyEnFincaScreen onNavigate={onNavigate} />);
+    expect(screen.getByTestId('sin-alertas')).toBeTruthy();
+    unmount();
+
+    useAlertStore.setState({
+      activeAlerts: [{
+        type: 'helada', severity: 'danger', title: 'Riesgo de helada',
+        message: 'Mínima de -1°C esta madrugada', prefilled_prompt: 'Hay alerta de helada, ¿qué hago?',
+      }],
+    });
+    render(<HoyEnFincaScreen onNavigate={onNavigate} />);
+    const alerta = screen.getByRole('button', { name: /Riesgo de helada/ });
+    fireEvent.click(alerta);
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+    expect(sessionStorage.getItem('chagra:agent:prefilled')).toBe('Hay alerta de helada, ¿qué hago?');
+  });
+
+  it('tareas de la semana del ciclo real; toque → vista ciclo', async () => {
+    const onNavigate = vi.fn();
+    render(<HoyEnFincaScreen onNavigate={onNavigate} />);
+    const grupo = await screen.findByRole('button', { name: /Papa pastusa en etapa/ });
+    expect(grupo.textContent).toMatch(/Riego|Monitoreo|drenajes|caldo/i);
+    fireEvent.click(grupo);
+    expect(onNavigate).toHaveBeenCalledWith('ciclo');
+  });
+
+  it('accesos rápidos rutean a su módulo', async () => {
+    const onNavigate = vi.fn();
+    render(<HoyEnFincaScreen onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: /Plagas/ }));
+    expect(onNavigate).toHaveBeenCalledWith('reportar_invasora');
+    fireEvent.click(screen.getByRole('button', { name: /Preguntar/ }));
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+  });
+
+  it('agenda campesina presente con toggle Semana/Mes', async () => {
+    render(<HoyEnFincaScreen onNavigate={vi.fn()} />);
+    await screen.findByTestId('agenda-semana');
+    fireEvent.click(screen.getByRole('tab', { name: /Mes/ }));
+    expect(screen.getByTestId('agenda-mes')).toBeTruthy();
+    expect(screen.getByText('Esta semana')).toBeTruthy();
+  });
+
+  it('sin ubicación guardada: CTA al mini-mapa (no clima inventado)', async () => {
+    vi.mocked(resolveClimaLocation).mockReturnValue(null);
+    const onNavigate = vi.fn();
+    render(<HoyEnFincaScreen onNavigate={onNavigate} />);
+    const cta = screen.getByRole('button', { name: /Configurar ubicación/ });
+    expect(screen.queryByTestId('clima-hoy-card')).toBeNull();
+    fireEvent.click(cta);
+    expect(onNavigate).toHaveBeenCalledWith('ubicacion-detectada');
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -21,6 +21,7 @@ import { GripVertical } from 'lucide-react';
 import AgentHero from './AgentHero';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
 import ClimaStrip from './ClimaStrip';
+import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
 import AnalisisProactivoIA from './AnalisisProactivoIA';
 import useAssetStore from '../../store/useAssetStore';
@@ -50,9 +51,14 @@ import {
 // sección draggable, por defecto justo debajo de 'clima'. Bump de versión
 // para que usuarios con orden v1 reciban el nuevo default en vez de que se
 // les agregue al final.
-const STORAGE_KEY = 'chagra:dashboard-order:v2';
+// v3 (2026-06-11): 'hoyfinca' (HoyEnFincaStrip) — resumen proactivo del día
+// (clima honesto + alertas + tareas + próximo evento de agenda) como PRIMERA
+// sección bajo el hero. Toque → vista completa 'hoy_finca'. Bump para que
+// usuarios con orden v2 lo reciban arriba y no apendizado al final.
+const STORAGE_KEY = 'chagra:dashboard-order:v3';
 
 const DEFAULT_ORDER = [
+    'hoyfinca',
     'clima',
     'analisis',
     'plantas',
@@ -66,6 +72,7 @@ const DEFAULT_ORDER = [
 ];
 
 const SECTION_COMPONENTS = {
+    hoyfinca: { Component: HoyEnFincaStrip, full: true },
     clima: { Component: ClimaStrip, full: true },
     analisis: { Component: AnalisisProactivoIA, full: true },
     plantas: { Component: PlantasCard },

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -251,14 +251,17 @@ export function BitacoraCard({ onNavigate, variant }) {
 }
 
 export function HoyCard({ onNavigate, variant }) {
+    // 2026-06-11: la card "Hoy en finca" deja de ir a la cola de tareas y
+    // abre el dashboard proactivo del día (clima honesto + alertas + tareas
+    // del ciclo + agenda campesina) — vista 'hoy_finca'.
     return (
         <Card
             variant={variant}
             section="hoy"
             title="Hoy en finca"
-            subtitle="Lo que toca hacer cerca tuyo"
-            tooltip="Tareas pendientes ordenadas por cercanía a tu ubicación actual."
-            onClick={() => onNavigate('task_log')}
+            subtitle="El día, las alertas y lo que toca"
+            tooltip="Clima de hoy, alertas, tareas de la semana y agenda de tu finca."
+            onClick={() => onNavigate('hoy_finca')}
         />
     );
 }

--- a/src/components/dashboard/HoyEnFincaStrip.jsx
+++ b/src/components/dashboard/HoyEnFincaStrip.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Sun, CloudSun, Cloud, CloudFog, CloudRain, Sunrise, Bell, ClipboardList, ChevronRight } from 'lucide-react';
+import useAlertStore from '../../store/useAlertStore';
+import { listFarmProcesses } from '../../db/farmProcessCache';
+import {
+    resolveClimaLocation,
+    getCachedClimaSnapshot,
+    fetchClimaSnapshot,
+} from '../../services/climaService';
+import { getCachedSkyConditions, fetchSkyConditions } from '../../services/skyConditionService';
+import { buildClimaHoy, buildTareasSemana, buildAgenda, agendaPorDia } from '../../services/hoyEnFincaService';
+
+/**
+ * HoyEnFincaStrip — resumen proactivo "Hoy en finca" para el dashboard.
+ *
+ * Primera sección bajo el hero: de un vistazo el campesino ve el día
+ * (condición HONESTA del cielo), cuántas alertas hay y cuántas labores
+ * tiene la semana. Tocar cualquier parte → la vista completa 'hoy_finca'.
+ *
+ * Misma dieta offline-first de ClimaStrip: pinta caches al instante y
+ * refresca en background (los fetch nunca lanzan). Sin datos → texto
+ * honesto, sin sol inventado.
+ */
+
+const CONDITION_ICONS = {
+    despejado: { Icon: Sun, cls: 'text-amber-300' },
+    parcial: { Icon: CloudSun, cls: 'text-slate-200' },
+    nublado: { Icon: Cloud, cls: 'text-slate-400' },
+    niebla: { Icon: CloudFog, cls: 'text-slate-300' },
+    lluvia: { Icon: CloudRain, cls: 'text-sky-400' },
+};
+
+export default function HoyEnFincaStrip({ onNavigate }) {
+    const activeAlerts = useAlertStore((s) => s.activeAlerts);
+    const geo = useMemo(() => resolveClimaLocation(), []);
+
+    const [snapshot, setSnapshot] = useState(() => (geo
+        ? getCachedClimaSnapshot(geo.lat, geo.lng, geo.elevation)
+        : getCachedClimaSnapshot()));
+    const [sky, setSky] = useState(() => (geo
+        ? getCachedSkyConditions(geo.lat, geo.lng, geo.elevation)
+        : null));
+    const [processes, setProcesses] = useState([]);
+
+    useEffect(() => {
+        let alive = true;
+        if (geo) {
+            const args = geo.elevation != null
+                ? { lat: geo.lat, lng: geo.lng, elevation: geo.elevation }
+                : { lat: geo.lat, lng: geo.lng };
+            fetchClimaSnapshot(args)
+                .then((res) => { if (alive && res) setSnapshot(res); })
+                .catch(() => { /* degrade limpio */ });
+            fetchSkyConditions(args)
+                .then((res) => { if (alive && res) setSky(res); })
+                .catch(() => { /* degrade limpio */ });
+        }
+        listFarmProcesses({ status: 'active' })
+            .then((list) => { if (alive) setProcesses(Array.isArray(list) ? list : []); })
+            .catch(() => { /* IDB falló — strip sin tareas, no rompe */ });
+        return () => { alive = false; };
+    }, [geo]);
+
+    const elevationM = geo?.elevation ?? null;
+    const ensoPhase = snapshot?.enso_status?.phase || 'neutral';
+    const clima = useMemo(
+        () => buildClimaHoy({ snapshot, sky, elevationM }),
+        [snapshot, sky, elevationM],
+    );
+    const nTareas = useMemo(
+        () => buildTareasSemana({ processes, altitudeM: elevationM, ensoPhase })
+            .reduce((acc, g) => acc + g.tareas.length, 0),
+        [processes, elevationM, ensoPhase],
+    );
+    const proximo = useMemo(() => {
+        const dias = agendaPorDia(buildAgenda({ processes, altitudeM: elevationM }));
+        const conItems = dias.find((d) => d.items.length > 0);
+        return conItems ? { dia: conItems.label, item: conItems.items[0] } : null;
+    }, [processes, elevationM]);
+
+    const fecha = useMemo(
+        () => new Date().toLocaleDateString('es-CO', { weekday: 'long', day: 'numeric', month: 'long' }),
+        [],
+    );
+
+    const { Icon: CondIcon, cls: condCls } = CONDITION_ICONS[clima.condition] || CONDITION_ICONS.parcial;
+
+    return (
+        <button
+            type="button"
+            data-testid="hoy-en-finca-strip"
+            onClick={() => onNavigate?.('hoy_finca')}
+            aria-label="Hoy en finca: ver el día completo, alertas, tareas y agenda"
+            className="group w-full text-left rounded-2xl bg-gradient-to-br from-emerald-950/60 to-slate-900/60 backdrop-blur-xl border border-emerald-800/30 p-4 ring-2 ring-emerald-500/0 hover:ring-emerald-500/30 active:scale-[0.99] transition-all"
+        >
+            <div className="flex items-center justify-between gap-2 mb-2">
+                <h3 className="text-base font-bold text-white flex items-center gap-2 min-w-0">
+                    <Sunrise size={20} style={{ color: 'rgb(var(--t-accent-rgb))' }} aria-hidden="true" />
+                    Hoy en finca
+                </h3>
+                <span className="text-[10px] text-slate-400 capitalize truncate shrink">{fecha}</span>
+                <ChevronRight size={16} className="text-slate-500 group-hover:text-slate-300 shrink-0" aria-hidden="true" />
+            </div>
+
+            <div className="flex items-center gap-3">
+                {/* Clima honesto de hoy */}
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                    {clima.hasData ? (
+                        <>
+                            <CondIcon size={32} className={`${condCls} shrink-0`} aria-hidden="true" />
+                            <div className="min-w-0">
+                                <p className="text-sm font-bold text-white truncate">{clima.label}</p>
+                                {clima.tempMaxC != null && (
+                                    <p className="text-xs text-slate-400 tabular-nums">
+                                        {Math.round(clima.tempMaxC)}°{clima.tempMinC != null ? ` / ${Math.round(clima.tempMinC)}°` : ''}
+                                    </p>
+                                )}
+                            </div>
+                        </>
+                    ) : (
+                        <p className="text-xs text-slate-400">El clima de hoy carga cuando haya señal.</p>
+                    )}
+                </div>
+
+                {/* Chips: alertas + tareas */}
+                <div className="flex items-center gap-2 shrink-0">
+                    {activeAlerts.length > 0 && (
+                        <span className="flex items-center gap-1 px-2 py-1 rounded-lg bg-amber-500/20 border border-amber-600/40 text-amber-300 text-xs font-black tabular-nums">
+                            <Bell size={12} aria-hidden="true" />
+                            {activeAlerts.length}
+                        </span>
+                    )}
+                    {nTareas > 0 && (
+                        <span className="flex items-center gap-1 px-2 py-1 rounded-lg bg-white/[0.07] border border-white/[0.1] text-slate-200 text-xs font-black tabular-nums">
+                            <ClipboardList size={12} aria-hidden="true" />
+                            {nTareas}
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            {/* Próximo evento de agenda (si existe — sin inventar) */}
+            {proximo && (
+                <p className="text-xs text-slate-300 mt-2 truncate">
+                    <span aria-hidden="true">{proximo.item.emoji} </span>
+                    <span className="font-bold">{proximo.dia}:</span>{' '}
+                    {proximo.item.etiqueta} {proximo.item.tipo === 'cosecha' ? 'abre cosecha' : `entra a ${proximo.item.stageLabel}`}
+                </p>
+            )}
+        </button>
+    );
+}

--- a/src/components/dashboard/__tests__/HoyEnFincaStrip.test.jsx
+++ b/src/components/dashboard/__tests__/HoyEnFincaStrip.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+const DAY_MS = 86400000;
+const NOW = Date.now();
+
+const mockGeo = { lat: 4.53, lng: -73.92, elevation: 1950, municipio: 'Choachí', precision: 'exact' };
+const mockSnapshot = {
+  enso_status: { phase: 'neutral' },
+  openmeteo: {
+    available: true,
+    forecast_7d: [{ date: new Date(NOW).toISOString().slice(0, 10), temp_max_c: 17, temp_min_c: 6, precip_mm: 0 }],
+  },
+};
+const mockSky = {
+  current: { cloud_cover_pct: 90, weather_code: 3, precip_mm: 0, is_day: true },
+  daily: [],
+};
+
+vi.mock('../../../services/climaService', () => ({
+  resolveClimaLocation: vi.fn(() => mockGeo),
+  getCachedClimaSnapshot: vi.fn(() => mockSnapshot),
+  fetchClimaSnapshot: vi.fn(() => Promise.resolve(mockSnapshot)),
+}));
+
+vi.mock('../../../services/skyConditionService', async (importOriginal) => {
+  const real = await importOriginal();
+  return {
+    ...real,
+    getCachedSkyConditions: vi.fn(() => mockSky),
+    fetchSkyConditions: vi.fn(() => Promise.resolve(mockSky)),
+  };
+});
+
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(() => Promise.resolve([{
+    process_id: 'p-papa',
+    attributes: {
+      subject_slug: 'solanum_tuberosum',
+      subject_label: 'Papa',
+      status: 'active',
+      current_stage: 'vegetative',
+      created_at: NOW - 45 * DAY_MS,
+    },
+  }])),
+}));
+
+import HoyEnFincaStrip from '../HoyEnFincaStrip';
+import { resetAlertStore } from '../../../store/useAlertStore';
+
+describe('HoyEnFincaStrip', () => {
+  beforeEach(() => resetAlertStore());
+
+  it('muestra clima honesto del día + contador de tareas', async () => {
+    render(<HoyEnFincaStrip onNavigate={vi.fn()} />);
+    const strip = screen.getByTestId('hoy-en-finca-strip');
+    await waitFor(() => {
+      expect(strip.textContent).toMatch(/nublado/i);
+    });
+    expect(strip.textContent).toContain('17°');
+  });
+
+  it('toque → navega a la vista hoy_finca', () => {
+    const onNavigate = vi.fn();
+    render(<HoyEnFincaStrip onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('hoy-en-finca-strip'));
+    expect(onNavigate).toHaveBeenCalledWith('hoy_finca');
+  });
+});

--- a/src/components/hoy/AgendaCampesina.jsx
+++ b/src/components/hoy/AgendaCampesina.jsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react';
+import { CalendarDays, CalendarRange, Sprout } from 'lucide-react';
+import { agendaPorDia, agendaPorSemana } from '../../services/hoyEnFincaService';
+
+/**
+ * AgendaCampesina — calendario LEGIBLE de "qué viene" en la finca.
+ *
+ * Dos vistas con toggle grande (baja alfabetización: dos botones, no tabs
+ * pequeñas): SEMANA (día por día: Hoy, Mañana, mié 13…) y MES (por semanas:
+ * Esta semana, Próxima semana…). Los items son ventanas fenológicas REALES
+ * calculadas de los ciclos registrados (hoyEnFincaService.buildAgenda) — si
+ * no hay ciclos, no se inventa nada: empty-state con CTA a registrar.
+ *
+ * Theme-aware: todo sale de slate-* (indirección CSS-var por tema) + el
+ * acento del tema activo vía --t-accent-rgb.
+ */
+export default function AgendaCampesina({ items = [], now = null, onItemTap, onEmptyCta }) {
+    const [modo, setModo] = useState('semana');
+    // "Ahora" estable por montaje (lazy init — sin Date.now() en render).
+    const [mountedNow] = useState(() => Date.now());
+    const nowTs = now ?? mountedNow;
+
+    const dias = useMemo(() => agendaPorDia(items, { now: nowTs }), [items, nowTs]);
+    const semanas = useMemo(() => agendaPorSemana(items, { now: nowTs }), [items, nowTs]);
+
+    const sinNada = items.length === 0;
+
+    return (
+        <section
+            aria-label="Agenda de la finca"
+            className="bg-slate-900/60 backdrop-blur-xl border border-slate-800 rounded-2xl p-4"
+        >
+            <div className="flex items-center justify-between gap-2 mb-3">
+                <h3 className="text-base font-bold text-white flex items-center gap-2">
+                    <CalendarDays size={20} style={{ color: 'rgb(var(--t-accent-rgb))' }} aria-hidden="true" />
+                    Agenda de la finca
+                </h3>
+                {/* Toggle grande Semana/Mes */}
+                <div className="flex rounded-xl overflow-hidden border border-slate-700" role="tablist" aria-label="Vista de agenda">
+                    {[
+                        { id: 'semana', label: 'Semana', Icon: CalendarDays },
+                        { id: 'mes', label: 'Mes', Icon: CalendarRange },
+                    ].map((tab) => (
+                        <button
+                            key={tab.id}
+                            type="button"
+                            role="tab"
+                            aria-selected={modo === tab.id}
+                            onClick={() => setModo(tab.id)}
+                            className={`px-3 py-2 min-h-[40px] text-xs font-bold flex items-center gap-1.5 transition-colors ${modo === tab.id
+                                ? 'bg-slate-700 text-white'
+                                : 'bg-slate-900/40 text-slate-400 hover:text-slate-200'}`}
+                        >
+                            <tab.Icon size={14} aria-hidden="true" />
+                            {tab.label}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {sinNada ? (
+                <div className="text-center py-6">
+                    <Sprout size={36} className="text-slate-600 mx-auto mb-2" aria-hidden="true" />
+                    <p className="text-sm text-slate-400">
+                        Sin eventos en la agenda todavía.
+                    </p>
+                    <p className="text-xs text-slate-500 mt-1">
+                        Registra qué sembraste y aquí verás cuándo brota, florece y se cosecha.
+                    </p>
+                    {onEmptyCta && (
+                        <button
+                            type="button"
+                            onClick={onEmptyCta}
+                            className="mt-3 px-4 py-2.5 min-h-[44px] rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-700 text-sm font-bold text-white"
+                        >
+                            🎤 Contarle a Chagra qué sembré
+                        </button>
+                    )}
+                </div>
+            ) : modo === 'semana' ? (
+                <ul className="flex flex-col gap-1" data-testid="agenda-semana">
+                    {dias.map((d) => (
+                        <li
+                            key={d.fecha}
+                            className={`flex gap-3 rounded-xl px-2 py-1.5 ${d.esHoy ? 'bg-slate-800/60 border border-slate-700' : ''}`}
+                        >
+                            <span
+                                className={`shrink-0 w-16 pt-1 text-xs font-black uppercase tracking-wide ${d.esHoy ? 'text-white' : 'text-slate-500'}`}
+                            >
+                                {d.label}
+                            </span>
+                            <div className="flex-1 min-w-0 flex flex-col gap-1">
+                                {d.items.length === 0 ? (
+                                    <span className="text-xs text-slate-600 pt-1">—</span>
+                                ) : d.items.map((it, i) => (
+                                    <AgendaItem key={`${it.processId}-${it.stageCode}-${i}`} item={it} onTap={onItemTap} />
+                                ))}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <ul className="flex flex-col gap-2" data-testid="agenda-mes">
+                    {semanas.map((s) => (
+                        <li key={s.inicio}>
+                            <p className="text-xs font-black uppercase tracking-wide text-slate-500 mb-1">{s.label}</p>
+                            {s.items.length === 0 ? (
+                                <p className="text-xs text-slate-600 pl-1">Sin eventos previstos.</p>
+                            ) : (
+                                <div className="flex flex-col gap-1">
+                                    {s.items.map((it, i) => (
+                                        <AgendaItem key={`${it.processId}-${it.stageCode}-${i}`} item={it} onTap={onItemTap} conFecha />
+                                    ))}
+                                </div>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {!sinNada && (
+                <p className="text-[10px] text-slate-500 mt-3 leading-snug">
+                    Las fechas son ventanas estimadas por la etapa del cultivo (fuente: plantillas
+                    fenológicas con literatura citada). El campo manda: confirma con lo que veas en la mata.
+                </p>
+            )}
+        </section>
+    );
+}
+
+/** Item tocable de agenda: "🌸 Papa pastusa entra a Floración". */
+function AgendaItem({ item, onTap, conFecha = false }) {
+    const fechaCorta = conFecha
+        ? new Date(item.fecha).toLocaleDateString('es-CO', { day: 'numeric', month: 'short' })
+        : null;
+    const verbo = item.tipo === 'cosecha' ? 'abre cosecha' : `entra a ${item.stageLabel}`;
+    return (
+        <button
+            type="button"
+            onClick={() => onTap?.(item)}
+            aria-label={`${item.etiqueta} ${verbo}. Ver el ciclo`}
+            className="w-full text-left flex items-center gap-2 px-2 py-1.5 min-h-[40px] rounded-lg bg-white/[0.04] hover:bg-white/[0.08] border border-white/[0.06] transition-colors"
+        >
+            <span className="text-lg shrink-0" aria-hidden="true">{item.emoji}</span>
+            <span className="flex-1 min-w-0 text-xs text-slate-200 truncate">
+                <span className="font-bold">{item.etiqueta}</span> {verbo}
+            </span>
+            {fechaCorta && (
+                <span className="shrink-0 text-[10px] text-slate-400 tabular-nums">{fechaCorta}</span>
+            )}
+        </button>
+    );
+}

--- a/src/components/hoy/HoyEnFincaScreen.jsx
+++ b/src/components/hoy/HoyEnFincaScreen.jsx
@@ -1,0 +1,409 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    Sun, CloudSun, Cloud, CloudFog, CloudRain, Sunrise,
+    Bell, BellOff, MapPin, Droplets, Sprout, Mic, Bug,
+    Package, ClipboardList, MessageCircle, Map as MapIcon, ChevronRight, WifiOff,
+} from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import AgendaCampesina from './AgendaCampesina';
+import useAlertStore from '../../store/useAlertStore';
+import { listFarmProcesses } from '../../db/farmProcessCache';
+import { getProfile } from '../../services/userProfileService';
+import {
+    resolveClimaLocation,
+    getCachedClimaSnapshot,
+    fetchClimaSnapshot,
+    describePhase,
+} from '../../services/climaService';
+import { getCachedSkyConditions, fetchSkyConditions } from '../../services/skyConditionService';
+import { buildClimaHoy, buildTareasSemana, buildAgenda } from '../../services/hoyEnFincaService';
+
+/**
+ * HoyEnFincaScreen — el dashboard proactivo "Hoy en finca".
+ *
+ * La vista que responde de un vistazo: ¿cómo está el día?, ¿hay alertas?,
+ * ¿qué me toca hacer esta semana?, ¿qué viene en el calendario?
+ *
+ * Secciones (todas ACCIONABLES, los toques rutean):
+ *   1. Clima de HOY honesto — skyConditionService (nubosidad real + corrección
+ *      orográfica + ENSO) + climaService (pronóstico Open-Meteo). Ubicación =
+ *      la GUARDADA del perfil (resolveClimaLocation), NUNCA geo en vivo.
+ *      Toque → pregunta pre-cargada al agente. Sin ubicación → CTA al mini-mapa.
+ *   2. Alertas del día — useAlertStore (alertEngine + cropAlertEngine). NO
+ *      duplica el motor de la campana: muestra las mismas alertas activas y
+ *      referencia la campana. Toque → agente con prompt pre-cargado (mismo
+ *      patrón de CriticalAlertBanner).
+ *   3. Tareas del ciclo de ESTA SEMANA — fenología estimada + plantillas por
+ *      etapa + preventivas ENSO (hoyEnFincaService). Toque → Ciclo del cultivo.
+ *   4. Accesos rápidos — sembrar/cosechar/plagas/insumos/tareas/agente.
+ *   5. Agenda campesina — semana/mes con ventanas fenológicas reales.
+ *
+ * Offline-first: pinta primero los caches (getCached*) y luego refresca; los
+ * fetch nunca lanzan (contrato de climaService/skyConditionService). Sin red
+ * y sin cache → estados vacíos honestos, jamás datos inventados.
+ */
+
+const CONDITION_ICONS = {
+    despejado: { Icon: Sun, cls: 'text-amber-300' },
+    parcial: { Icon: CloudSun, cls: 'text-slate-200' },
+    nublado: { Icon: Cloud, cls: 'text-slate-400' },
+    niebla: { Icon: CloudFog, cls: 'text-slate-300' },
+    lluvia: { Icon: CloudRain, cls: 'text-sky-400' },
+};
+
+const SEVERITY_STYLES = {
+    danger: 'bg-red-950/40 border-red-800/60 text-red-200',
+    warning: 'bg-amber-950/40 border-amber-800/60 text-amber-200',
+    info: 'bg-sky-950/40 border-sky-800/60 text-sky-200',
+};
+
+/** Accesos rápidos: ícono GRANDE + una palabra. */
+const QUICK_ACTIONS = [
+    { id: 'procesos', label: 'Sembrar', Icon: Mic, desc: 'Registrar siembra por voz' },
+    { id: 'cosechar', label: 'Cosechar', Icon: Sprout, desc: 'Anotar una cosecha' },
+    { id: 'reportar_invasora', label: 'Plagas', Icon: Bug, desc: 'Reportar plaga o maleza' },
+    { id: 'bodega', label: 'Insumos', Icon: Package, desc: 'Ver bodega de insumos' },
+    { id: 'task_log', label: 'Tareas', Icon: ClipboardList, desc: 'Cola de pendientes' },
+    { id: 'agente', label: 'Preguntar', Icon: MessageCircle, desc: 'Hablar con Chagra' },
+];
+
+/** Pre-carga un prompt para el agente (mismo canal que CriticalAlertBanner). */
+function prefillAgent(prompt) {
+    try {
+        sessionStorage.setItem('chagra:agent:prefilled', prompt);
+    } catch { /* privacy mode — el agente abre vacío, no rompe */ }
+}
+
+export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
+    const activeAlerts = useAlertStore((s) => s.activeAlerts);
+
+    // Ubicación GUARDADA del perfil — nunca geolocalización en vivo (memoria
+    // feedback-clima-usa-ubicacion-guardada-no-geo-vivo).
+    const geo = useMemo(() => resolveClimaLocation(), []);
+    const municipio = useMemo(() => {
+        const m = geo?.municipio || getProfile()?.municipio || '';
+        return String(m).split(',')[0].trim();
+    }, [geo]);
+
+    // Offline-first: cache primero, refresh después (fetch nunca throw).
+    const [snapshot, setSnapshot] = useState(() => (geo
+        ? getCachedClimaSnapshot(geo.lat, geo.lng, geo.elevation)
+        : getCachedClimaSnapshot()));
+    const [sky, setSky] = useState(() => (geo
+        ? getCachedSkyConditions(geo.lat, geo.lng, geo.elevation)
+        : null));
+    const [processes, setProcesses] = useState([]);
+    const [ciclosCargados, setCiclosCargados] = useState(false);
+
+    useEffect(() => {
+        let alive = true;
+        if (geo) {
+            const args = geo.elevation != null
+                ? { lat: geo.lat, lng: geo.lng, elevation: geo.elevation }
+                : { lat: geo.lat, lng: geo.lng };
+            fetchClimaSnapshot(args)
+                .then((res) => { if (alive && res) setSnapshot(res); })
+                .catch(() => { /* degrade limpio */ });
+            fetchSkyConditions(args)
+                .then((res) => { if (alive && res) setSky(res); })
+                .catch(() => { /* degrade limpio */ });
+        }
+        listFarmProcesses({ status: 'active' })
+            .then((list) => { if (alive) setProcesses(Array.isArray(list) ? list : []); })
+            .catch(() => { /* IDB falló: lista vacía honesta */ })
+            .finally(() => { if (alive) setCiclosCargados(true); });
+        return () => { alive = false; };
+    }, [geo]);
+
+    const elevationM = geo?.elevation ?? null;
+    const ensoPhase = snapshot?.enso_status?.phase || 'neutral';
+
+    const clima = useMemo(
+        () => buildClimaHoy({ snapshot, sky, elevationM }),
+        [snapshot, sky, elevationM],
+    );
+    const tareas = useMemo(
+        () => buildTareasSemana({ processes, altitudeM: elevationM, ensoPhase }),
+        [processes, elevationM, ensoPhase],
+    );
+    const agendaItems = useMemo(
+        () => buildAgenda({ processes, altitudeM: elevationM }),
+        [processes, elevationM],
+    );
+
+    const fechaLarga = useMemo(
+        () => new Date().toLocaleDateString('es-CO', { weekday: 'long', day: 'numeric', month: 'long' }),
+        [],
+    );
+
+    const goAgente = useCallback((prompt) => {
+        if (prompt) prefillAgent(prompt);
+        onNavigate?.('agente');
+    }, [onNavigate]);
+
+    const onClimaTap = useCallback(() => {
+        if (!clima.hasData) return;
+        goAgente(
+            `Hoy en mi finca está ${clima.label?.toLowerCase() || 'variable'}`
+            + (clima.tempMaxC != null ? `, con máxima de ${Math.round(clima.tempMaxC)}°C` : '')
+            + '. ¿Qué me recomiendas hacer hoy en los cultivos?',
+        );
+    }, [clima, goAgente]);
+
+    const onAlertTap = useCallback((alert) => {
+        goAgente(
+            alert.prefilled_prompt
+            || `Tengo esta alerta en mi finca: ${alert.title || alert.type}. ${alert.message || ''} ¿Qué debo hacer?`,
+        );
+    }, [goAgente]);
+
+    const { Icon: CondIcon, cls: condCls } = CONDITION_ICONS[clima.condition] || CONDITION_ICONS.parcial;
+
+    return (
+        <ScreenShell title="Hoy en finca" icon={Sunrise} onBack={onBack} onHome={onHome}>
+            <div className="flex flex-col gap-3 px-4 pt-3 pb-8 max-w-2xl mx-auto">
+                {/* Fecha de hoy, grande y en cristiano */}
+                <p className="text-sm text-slate-400 capitalize px-1">{fechaLarga}</p>
+
+                {/* ── 1. CLIMA DE HOY (honesto) ─────────────────────────── */}
+                {!geo ? (
+                    <section className="bg-slate-900/60 backdrop-blur-xl border border-slate-800 rounded-2xl p-4">
+                        <div className="flex items-center gap-2 mb-2">
+                            <Cloud size={20} className="text-sky-300" aria-hidden="true" />
+                            <h3 className="text-base font-bold text-white">El día en tu finca</h3>
+                        </div>
+                        <p className="text-sm text-slate-300">
+                            Cuéntame dónde queda tu finca y te muestro el clima real de hoy.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => onNavigate?.('ubicacion-detectada')}
+                            className="mt-3 px-4 py-2.5 min-h-[44px] rounded-xl bg-sky-700/30 hover:bg-sky-600/40 border border-sky-500/40 text-sky-200 text-sm font-bold flex items-center gap-2"
+                        >
+                            <MapPin size={16} aria-hidden="true" />
+                            Configurar ubicación
+                        </button>
+                    </section>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={onClimaTap}
+                        data-testid="clima-hoy-card"
+                        aria-label={clima.hasData
+                            ? `Clima de hoy: ${clima.label}. Tocar para preguntarle al agente`
+                            : 'Clima de hoy sin datos'}
+                        className="w-full text-left bg-gradient-to-br from-sky-950/70 to-indigo-950/60 backdrop-blur-xl border border-sky-800/40 rounded-2xl p-4 active:scale-[0.99] transition-transform"
+                    >
+                        <div className="flex items-center justify-between mb-1">
+                            <h3 className="text-base font-bold text-white truncate">
+                                {municipio ? `El día en ${municipio}` : 'El día en tu finca'}
+                            </h3>
+                            <span className="text-[10px] text-sky-300/70 font-bold uppercase tracking-wider shrink-0">
+                                {clima.fuente}
+                            </span>
+                        </div>
+                        {clima.hasData ? (
+                            <div className="flex items-center gap-4">
+                                <CondIcon size={52} className={`${condCls} shrink-0`} aria-hidden="true" />
+                                <div className="flex-1 min-w-0">
+                                    <p className="text-xl font-black text-white leading-tight" data-testid="clima-hoy-label">
+                                        {clima.label}
+                                    </p>
+                                    <div className="flex items-center gap-3 mt-1 text-sm text-slate-300">
+                                        {clima.tempMaxC != null && (
+                                            <span className="tabular-nums font-bold">
+                                                {Math.round(clima.tempMaxC)}°
+                                                {clima.tempMinC != null && (
+                                                    <span className="text-slate-400 font-normal"> / {Math.round(clima.tempMinC)}°</span>
+                                                )}
+                                            </span>
+                                        )}
+                                        {clima.precipMm != null && (
+                                            <span className="flex items-center gap-1 tabular-nums">
+                                                <Droplets size={14} className="text-sky-400" aria-hidden="true" />
+                                                {Math.round(clima.precipMm)} mm
+                                            </span>
+                                        )}
+                                    </div>
+                                    {/* ENSO en lenguaje llano (describePhase #1453/#1454) */}
+                                    <p className="text-xs text-slate-400 mt-1.5" data-testid="enso-llano">
+                                        {describePhase(ensoPhase)}
+                                    </p>
+                                </div>
+                                <ChevronRight size={18} className="text-slate-500 shrink-0" aria-hidden="true" />
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-3 text-slate-400">
+                                <WifiOff size={28} className="shrink-0" aria-hidden="true" />
+                                <p className="text-sm">
+                                    Sin señal y sin clima guardado. Cuando vuelva la conexión te muestro el día real.
+                                </p>
+                            </div>
+                        )}
+                    </button>
+                )}
+
+                {/* ── 2. ALERTAS DEL DÍA ────────────────────────────────── */}
+                <section
+                    aria-label="Alertas de hoy"
+                    className="bg-slate-900/60 backdrop-blur-xl border border-slate-800 rounded-2xl p-4"
+                >
+                    <h3 className="text-base font-bold text-white flex items-center gap-2 mb-2">
+                        {activeAlerts.length > 0
+                            ? <Bell size={20} className="text-amber-400" aria-hidden="true" />
+                            : <BellOff size={20} className="text-slate-500" aria-hidden="true" />}
+                        Alertas de hoy
+                        {activeAlerts.length > 0 && (
+                            <span className="px-2 py-0.5 rounded-md bg-amber-500/20 text-amber-300 text-xs font-black tabular-nums">
+                                {activeAlerts.length}
+                            </span>
+                        )}
+                    </h3>
+                    {activeAlerts.length === 0 ? (
+                        <p className="text-sm text-slate-400" data-testid="sin-alertas">
+                            Tranquilidad: no hay alertas activas en tu finca.
+                        </p>
+                    ) : (
+                        <ul className="flex flex-col gap-2">
+                            {activeAlerts.map((a) => (
+                                <li key={a.type}>
+                                    <button
+                                        type="button"
+                                        onClick={() => onAlertTap(a)}
+                                        aria-label={`Alerta: ${a.title || a.type}. Tocar para preguntarle al agente qué hacer`}
+                                        className={`w-full text-left rounded-xl border p-3 min-h-[44px] flex items-center gap-3 active:scale-[0.99] transition-transform ${SEVERITY_STYLES[a.severity] || SEVERITY_STYLES.info}`}
+                                    >
+                                        <span className="text-xl shrink-0" aria-hidden="true">
+                                            {a.severity === 'danger' ? '🚨' : a.severity === 'warning' ? '⚠️' : 'ℹ️'}
+                                        </span>
+                                        <span className="flex-1 min-w-0">
+                                            <span className="block text-sm font-bold truncate">{a.title || a.type}</span>
+                                            {a.message && <span className="block text-xs opacity-80 truncate">{a.message}</span>}
+                                        </span>
+                                        <ChevronRight size={16} className="shrink-0 opacity-60" aria-hidden="true" />
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    {/* Referencia a la campana unificada (#1464): mismas alertas, sin duplicar motor */}
+                    <p className="text-[10px] text-slate-500 mt-2">
+                        Estas son las mismas alertas de la campana 🔔 de arriba. Tócalas para preguntarle a Chagra qué hacer.
+                    </p>
+                </section>
+
+                {/* ── 3. TAREAS DEL CICLO — ESTA SEMANA ─────────────────── */}
+                <section
+                    aria-label="Tareas de la semana"
+                    className="bg-slate-900/60 backdrop-blur-xl border border-slate-800 rounded-2xl p-4"
+                >
+                    <h3 className="text-base font-bold text-white flex items-center gap-2 mb-2">
+                        <ClipboardList size={20} style={{ color: 'rgb(var(--t-accent-rgb))' }} aria-hidden="true" />
+                        Para esta semana
+                    </h3>
+                    {!ciclosCargados ? (
+                        <p className="text-sm text-slate-500">Cargando tus ciclos…</p>
+                    ) : tareas.length === 0 ? (
+                        <div className="text-center py-3">
+                            <p className="text-sm text-slate-400">
+                                Sin ciclos de cultivo registrados todavía.
+                            </p>
+                            <button
+                                type="button"
+                                onClick={() => onNavigate?.('procesos')}
+                                className="mt-3 px-4 py-2.5 min-h-[44px] rounded-xl bg-lime-800/40 hover:bg-lime-700/40 border border-lime-700/50 text-lime-200 text-sm font-bold flex items-center gap-2 mx-auto"
+                            >
+                                <Mic size={16} aria-hidden="true" />
+                                Contarle a Chagra qué sembré
+                            </button>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-3">
+                            {tareas.map((g) => (
+                                <button
+                                    key={g.processId}
+                                    type="button"
+                                    onClick={() => onNavigate?.('ciclo')}
+                                    aria-label={`${g.etiqueta} en etapa ${g.stageLabel}. Tocar para ver el ciclo completo`}
+                                    className="w-full text-left rounded-xl bg-white/[0.04] hover:bg-white/[0.07] border border-white/[0.06] p-3 active:scale-[0.99] transition-transform"
+                                >
+                                    <div className="flex items-center gap-2 mb-1.5">
+                                        <span className="text-xl" aria-hidden="true">{g.emoji}</span>
+                                        <span className="text-sm font-bold text-white truncate">{g.etiqueta}</span>
+                                        <span className="text-xs text-slate-400 truncate">
+                                            · {g.stageLabel}
+                                            {g.diasDesdeSiembra != null && ` · día ${g.diasDesdeSiembra}`}
+                                        </span>
+                                        <ChevronRight size={16} className="text-slate-500 ml-auto shrink-0" aria-hidden="true" />
+                                    </div>
+                                    {g.tareas.length === 0 ? (
+                                        <p className="text-xs text-slate-500">Sin labores sugeridas para esta etapa.</p>
+                                    ) : (
+                                        <ul className="flex flex-col gap-1">
+                                            {g.tareas.map((t, i) => (
+                                                <li
+                                                    key={i}
+                                                    className="flex items-center gap-2 text-xs text-slate-300"
+                                                >
+                                                    <span
+                                                        className={`shrink-0 w-2 h-2 rounded-full ${t.priority === 'alta' ? 'bg-red-400' : t.priority === 'media' ? 'bg-amber-400' : 'bg-slate-500'}`}
+                                                        aria-hidden="true"
+                                                    />
+                                                    <span className="font-medium">{t.task}</span>
+                                                    {t.origen === 'enso' && (
+                                                        <span className="text-[9px] px-1 py-0.5 rounded bg-sky-500/20 text-sky-300 font-bold uppercase">clima</span>
+                                                    )}
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </button>
+                            ))}
+                            <p className="text-[10px] text-slate-500 leading-snug">
+                                Labores sugeridas por la etapa del cultivo
+                                {ensoPhase !== 'neutral' ? ' y el estado del clima (NOAA/IDEAM)' : ''}.
+                                No reemplazan el ojo del campesino.
+                            </p>
+                        </div>
+                    )}
+                </section>
+
+                {/* ── 4. ACCESOS RÁPIDOS ────────────────────────────────── */}
+                <section aria-label="Accesos rápidos">
+                    <div className="grid grid-cols-3 gap-2">
+                        {QUICK_ACTIONS.map((accion) => (
+                            <button
+                                key={accion.id}
+                                type="button"
+                                onClick={() => onNavigate?.(accion.id)}
+                                aria-label={`${accion.label}: ${accion.desc}`}
+                                title={accion.desc}
+                                className="flex flex-col items-center gap-1.5 py-3 min-h-[72px] rounded-2xl bg-slate-900/60 backdrop-blur-xl border border-slate-800 hover:bg-slate-800/60 active:scale-[0.97] transition-all"
+                            >
+                                <accion.Icon size={26} style={{ color: 'rgb(var(--t-accent-rgb))' }} aria-hidden="true" />
+                                <span className="text-xs font-bold text-slate-200">{accion.label}</span>
+                            </button>
+                        ))}
+                    </div>
+                </section>
+
+                {/* ── 5. AGENDA CAMPESINA ───────────────────────────────── */}
+                <AgendaCampesina
+                    items={agendaItems}
+                    onItemTap={() => onNavigate?.('ciclo')}
+                    onEmptyCta={() => onNavigate?.('procesos')}
+                />
+
+                {/* Mapa al cierre: dónde está todo */}
+                <button
+                    type="button"
+                    onClick={() => onNavigate?.('mapa')}
+                    className="w-full flex items-center justify-center gap-2 py-3 min-h-[44px] rounded-2xl bg-slate-900/40 border border-slate-800 text-sm font-bold text-slate-300 hover:bg-slate-800/50"
+                >
+                    <MapIcon size={18} aria-hidden="true" />
+                    Ver el mapa de la finca
+                </button>
+            </div>
+        </ScreenShell>
+    );
+}

--- a/src/services/__tests__/hoyEnFincaService.test.js
+++ b/src/services/__tests__/hoyEnFincaService.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildClimaHoy,
+  buildTareasSemana,
+  buildAgenda,
+  agendaPorDia,
+  agendaPorSemana,
+  ensoTaskPhase,
+  STAGE_LABELS,
+} from '../hoyEnFincaService';
+
+const DAY_MS = 86400000;
+
+/** Snapshot mínimo del sidecar con pronóstico Open-Meteo real. */
+function snapshotConForecast({ ensoPhase = 'neutral', dia0 = {} } = {}) {
+  return {
+    enso_status: { phase: ensoPhase },
+    openmeteo: {
+      available: true,
+      forecast_7d: [
+        {
+          date: '2026-06-11',
+          temp_max_c: 18,
+          temp_min_c: 7,
+          precip_mm: 1.2,
+          ...dia0,
+        },
+      ],
+    },
+  };
+}
+
+/** Ciclo activo de papa sembrado hace `dias` días (tiene plantilla fenológica). */
+function cicloPapa({ dias = 30, now = Date.now(), extra = {} } = {}) {
+  return {
+    process_id: 'p-papa-1',
+    type: 'farm_process',
+    attributes: {
+      process_type: 'sowing',
+      subject_slug: 'solanum_tuberosum',
+      subject_label: 'Papa pastusa',
+      status: 'active',
+      current_stage: 'vegetative',
+      created_at: now - dias * DAY_MS,
+      ...extra,
+    },
+  };
+}
+
+describe('buildClimaHoy', () => {
+  it('sin datos no fabrica nada: hasData false', () => {
+    const r = buildClimaHoy({ snapshot: null, sky: null });
+    expect(r.hasData).toBe(false);
+    expect(r.condition).toBe(null);
+  });
+
+  it('clima honesto: nubosidad real alta → mayormente nublado, no sol', () => {
+    const r = buildClimaHoy({
+      snapshot: snapshotConForecast(),
+      sky: {
+        current: { cloud_cover_pct: 85, weather_code: 3, precip_mm: 0 },
+        daily: [{ date: '2026-06-11', cloud_cover_mean_pct: 85, weather_code: 3, precip_mm: 1.2 }],
+      },
+      elevationM: 1950,
+    });
+    expect(r.hasData).toBe(true);
+    expect(r.condition).toBe('nublado');
+    expect(r.label).toMatch(/nublado/i);
+    expect(r.tempMaxC).toBe(18);
+    expect(r.tempMinC).toBe(7);
+    expect(r.fuente).toMatch(/Open-Meteo/);
+  });
+
+  it('sin nubosidad pero con forecast: usa prior por piso (frío → no promete sol)', () => {
+    const r = buildClimaHoy({
+      snapshot: snapshotConForecast(),
+      sky: null,
+      elevationM: 2200,
+    });
+    expect(r.hasData).toBe(true);
+    // Piso frío sin dato de nube: nunca "despejado" optimista.
+    expect(['parcial', 'nublado', 'lluvia']).toContain(r.condition);
+  });
+
+  it('precipitación fuerte del día gana: lluvia', () => {
+    const r = buildClimaHoy({
+      snapshot: snapshotConForecast({ dia0: { precip_mm: 12 } }),
+      sky: { current: { cloud_cover_pct: null, weather_code: null, precip_mm: null }, daily: [] },
+      elevationM: 1500,
+    });
+    expect(r.condition).toBe('lluvia');
+  });
+});
+
+describe('ensoTaskPhase', () => {
+  it('mapea slugs del sidecar a la fase que entiende climateCycleService', () => {
+    expect(ensoTaskPhase('nina_moderada')).toBe('la_nina');
+    expect(ensoTaskPhase('nino_fuerte')).toBe('el_nino');
+    expect(ensoTaskPhase('neutral')).toBe(null);
+    expect(ensoTaskPhase(undefined)).toBe(null);
+  });
+});
+
+describe('buildTareasSemana', () => {
+  it('sin ciclos → vacío (no inventa tareas)', () => {
+    expect(buildTareasSemana({ processes: [] })).toEqual([]);
+  });
+
+  it('ciclo de papa a 30 días → etapa estimada con tareas de la etapa', () => {
+    const now = Date.now();
+    const grupos = buildTareasSemana({
+      processes: [cicloPapa({ dias: 30, now })],
+      altitudeM: 2000,
+      now,
+    });
+    expect(grupos).toHaveLength(1);
+    const g = grupos[0];
+    expect(g.etiqueta).toBe('Papa pastusa');
+    expect(g.stageLabel).toBe(STAGE_LABELS[g.stageCode]);
+    expect(g.tareas.length).toBeGreaterThan(0);
+    // Cada tarea trae nombre + prioridad (sin fabricar campos vacíos).
+    for (const t of g.tareas) {
+      expect(t.task).toBeTruthy();
+      expect(['alta', 'media', 'baja']).toContain(t.priority);
+    }
+  });
+
+  it('La Niña agrega tareas preventivas ENSO marcadas con origen', () => {
+    const now = Date.now();
+    const grupos = buildTareasSemana({
+      processes: [cicloPapa({ dias: 30, now })],
+      altitudeM: 2000,
+      ensoPhase: 'nina_moderada',
+      now,
+    });
+    const conEnso = grupos[0].tareas.filter((t) => t.origen === 'enso');
+    expect(conEnso.length).toBeGreaterThan(0);
+    expect(conEnso[0].task).toMatch(/drenaje|caldo|pudrición/i);
+  });
+
+  it('ignora ciclos cerrados', () => {
+    const now = Date.now();
+    const cerrado = cicloPapa({ dias: 30, now, extra: { status: 'completed' } });
+    expect(buildTareasSemana({ processes: [cerrado], now })).toEqual([]);
+  });
+
+  it('ciclo sin plantilla usa current_stage del proceso (no descarta)', () => {
+    const now = Date.now();
+    const sinTemplate = {
+      process_id: 'p-x',
+      attributes: {
+        subject_slug: 'especie_sin_template',
+        subject_label: 'Arracacha',
+        status: 'active',
+        current_stage: 'vegetative',
+        created_at: now - 40 * DAY_MS,
+      },
+    };
+    const grupos = buildTareasSemana({ processes: [sinTemplate], now });
+    expect(grupos).toHaveLength(1);
+    expect(grupos[0].stageCode).toBe('vegetative');
+  });
+});
+
+describe('buildAgenda', () => {
+  it('sin ciclos → agenda vacía', () => {
+    expect(buildAgenda({ processes: [] })).toEqual([]);
+  });
+
+  it('ventanas fenológicas próximas entran a la agenda con fuente', () => {
+    const now = Date.now();
+    // Lechuga (ciclo corto): a 10 días de sembrada, vienen etapas pronto.
+    const lechuga = {
+      process_id: 'p-lechuga',
+      attributes: {
+        subject_slug: 'lactuca_sativa',
+        subject_label: 'Lechuga',
+        status: 'active',
+        current_stage: 'emergence',
+        created_at: now - 10 * DAY_MS,
+      },
+    };
+    const items = buildAgenda({ processes: [lechuga], altitudeM: 2000, now, horizonDays: 60 });
+    expect(items.length).toBeGreaterThan(0);
+    // Ordenadas por fecha ascendente
+    for (let i = 1; i < items.length; i++) {
+      expect(items[i].fecha).toBeGreaterThanOrEqual(items[i - 1].fecha);
+    }
+    // Cada item trae proceso + etapa + fuentes (cero fabricación)
+    for (const it of items) {
+      expect(it.etiqueta).toBe('Lechuga');
+      expect(it.stageLabel).toBeTruthy();
+      expect(Array.isArray(it.fuentes)).toBe(true);
+    }
+  });
+
+  it('no incluye ventanas fuera del horizonte', () => {
+    const now = Date.now();
+    const papa = cicloPapa({ dias: 1, now }); // sembrada ayer: cosecha lejana
+    const items = buildAgenda({ processes: [papa], altitudeM: 2000, now, horizonDays: 7 });
+    for (const it of items) {
+      expect(it.fecha).toBeLessThanOrEqual(now + 7 * DAY_MS);
+    }
+  });
+});
+
+describe('agendaPorDia / agendaPorSemana', () => {
+  const now = new Date('2026-06-11T10:00:00').getTime();
+  const items = [
+    { fecha: now + 2 * 3600000, etiqueta: 'A', stageLabel: 'Floración' },
+    { fecha: now + 1 * DAY_MS, etiqueta: 'B', stageLabel: 'Cosecha' },
+    { fecha: now + 10 * DAY_MS, etiqueta: 'C', stageLabel: 'Brote' },
+  ];
+
+  it('agrupa por día con labels Hoy/Mañana', () => {
+    const dias = agendaPorDia(items, { now, dias: 7 });
+    expect(dias).toHaveLength(7);
+    expect(dias[0].label).toBe('Hoy');
+    expect(dias[1].label).toBe('Mañana');
+    expect(dias[0].items.map((i) => i.etiqueta)).toEqual(['A']);
+    expect(dias[1].items.map((i) => i.etiqueta)).toEqual(['B']);
+    // El item a 10 días NO aparece en la semana
+    expect(dias.flatMap((d) => d.items).find((i) => i.etiqueta === 'C')).toBeUndefined();
+  });
+
+  it('agrupa por semana para la vista de mes', () => {
+    const semanas = agendaPorSemana(items, { now, semanas: 4 });
+    expect(semanas).toHaveLength(4);
+    expect(semanas[0].label).toBe('Esta semana');
+    expect(semanas[1].label).toBe('Próxima semana');
+    expect(semanas[0].items.map((i) => i.etiqueta)).toEqual(['A', 'B']);
+    expect(semanas[1].items.map((i) => i.etiqueta)).toEqual(['C']);
+  });
+});

--- a/src/services/hoyEnFincaService.js
+++ b/src/services/hoyEnFincaService.js
@@ -1,0 +1,322 @@
+/**
+ * hoyEnFincaService — agregador PURO para la vista "Hoy en finca".
+ *
+ * Junta lo que la finca necesita saber HOY y ESTA SEMANA a partir de
+ * servicios que ya existen — este módulo NO fabrica datos:
+ *   - Clima de hoy: snapshot del sidecar (climaService) + nubosidad real
+ *     (skyConditionService) → condición honesta del cielo (fix Choachí).
+ *   - Tareas del ciclo: fenología estimada (phenologyCalculator) + plantillas
+ *     por etapa (cycleTaskService) + preventivas ENSO (climateCycleService).
+ *   - Agenda campesina: ventanas fenológicas próximas (calculateWindows)
+ *     agrupadas por día (semana) o por semana (mes).
+ *
+ * Reglas:
+ *   - Funciones puras: reciben datos, devuelven datos. Sin fetch, sin IDB.
+ *     El caller (HoyEnFincaScreen) trae snapshot/sky/procesos de los caches
+ *     offline-first y degrada limpio si no hay nada.
+ *   - Cero fabricación: sin datos → arrays vacíos / hasData:false. Cada
+ *     ventana fenológica conserva sus `fuentes` y `confianza` del template.
+ *   - Lenguaje llano español de Colombia (sin voseo): labels de etapa
+ *     pensados para leerse de un vistazo en el campo.
+ */
+import { skyForDay, classifySkyCondition } from './skyConditionService';
+import { getCurrentStage, calculateWindows } from './phenologyCalculator';
+import { getTasksForStage } from './cycleTaskService';
+import { getEnsemblePreventiveTasks } from './climateCycleService';
+
+const DAY_MS = 86400000;
+
+/** Etapas fenológicas en lenguaje llano (mismos codes de phenologyTemplates). */
+export const STAGE_LABELS = Object.freeze({
+  sowing: 'Siembra',
+  emergence: 'Brote',
+  vegetative: 'Crecimiento',
+  flowering: 'Floración',
+  fruiting: 'Echando fruto',
+  harvest_window: 'Cosecha',
+  closed: 'Ciclo cerrado',
+});
+
+export const STAGE_EMOJIS = Object.freeze({
+  sowing: '🌱',
+  emergence: '🌿',
+  vegetative: '🌳',
+  flowering: '🌸',
+  fruiting: '🍎',
+  harvest_window: '🧺',
+  closed: '🏁',
+});
+
+/**
+ * Mapea el slug ENSO del sidecar ('nina_moderada', 'nino_fuerte', …) a la
+ * fase que entiende getEnsemblePreventiveTasks ('la_nina' | 'el_nino').
+ * Neutral / desconocido → null (sin tareas ENSO, no se inventan).
+ * @param {string} [phase]
+ * @returns {'el_nino'|'la_nina'|null}
+ */
+export function ensoTaskPhase(phase) {
+  if (typeof phase !== 'string') return null;
+  if (phase.startsWith('nino')) return 'el_nino';
+  if (phase.startsWith('nina')) return 'la_nina';
+  return null;
+}
+
+/**
+ * Clima de HOY, honesto. Prefiere la nubosidad ACTUAL medida (sky.current);
+ * cae al promedio diario / forecast del sidecar; sin nada → hasData:false
+ * (el caller muestra "sin datos", nunca un sol inventado).
+ *
+ * @param {object} input
+ * @param {object|null} input.snapshot  payload de clima (getCachedClimaSnapshot/fetchClimaSnapshot)
+ * @param {object|null} input.sky       payload de cielo (getCachedSkyConditions/fetchSkyConditions)
+ * @param {number|null} [input.elevationM]  msnm de la finca (corrección orográfica)
+ * @returns {{ hasData:boolean, condition:string|null, label:string|null,
+ *   tempMaxC:number|null, tempMinC:number|null, precipMm:number|null,
+ *   ensoPhase:string, degraded:boolean, confidence:string|null, fuente:string }}
+ */
+export function buildClimaHoy({ snapshot = null, sky = null, elevationM = null } = {}) {
+  const openmeteo = snapshot?.openmeteo;
+  const forecast = openmeteo?.available && Array.isArray(openmeteo.forecast_7d)
+    ? openmeteo.forecast_7d
+    : [];
+  const d0 = forecast[0] || null;
+  const skyDay0 = Array.isArray(sky?.daily) ? sky.daily[0] || null : null;
+  const current = sky?.current || null;
+  const ensoPhase = snapshot?.enso_status?.phase || 'neutral';
+
+  let cielo = null;
+  if (current && (Number.isFinite(current.cloud_cover_pct) || Number.isFinite(current.weather_code))) {
+    // Nubosidad medida AHORA: la señal más honesta para "hoy".
+    cielo = classifySkyCondition({
+      cloudCoverPct: current.cloud_cover_pct,
+      weatherCode: current.weather_code,
+      precipMm: Number.isFinite(d0?.precip_mm) ? d0.precip_mm : current.precip_mm,
+      elevationM,
+      ensoPhase,
+    });
+  } else if (d0 || skyDay0) {
+    cielo = skyForDay(
+      {
+        precip_mm: Number.isFinite(d0?.precip_mm) ? d0.precip_mm : skyDay0?.precip_mm,
+        cloud_cover_mean_pct: d0?.cloud_cover_mean_pct ?? skyDay0?.cloud_cover_mean_pct,
+        weather_code: d0?.weather_code ?? skyDay0?.weather_code,
+      },
+      { elevationM, ensoPhase },
+    );
+  }
+
+  const tempMaxC = typeof d0?.temp_max_c === 'number' ? d0.temp_max_c : null;
+  const tempMinC = typeof d0?.temp_min_c === 'number' ? d0.temp_min_c : null;
+  const precipMm = typeof d0?.precip_mm === 'number'
+    ? d0.precip_mm
+    : (typeof skyDay0?.precip_mm === 'number' ? skyDay0.precip_mm : null);
+
+  return {
+    hasData: Boolean(cielo) || tempMaxC != null,
+    condition: cielo?.condition ?? null,
+    label: cielo?.label ?? null,
+    tempMaxC,
+    tempMinC,
+    precipMm,
+    ensoPhase,
+    degraded: Boolean(cielo?.degraded),
+    confidence: cielo?.confidence ?? null,
+    fuente: 'Open-Meteo',
+  };
+}
+
+/** ¿El proceso cuenta como ciclo activo? (sin status explícito = activo). */
+function esActivo(proc) {
+  const status = proc?.attributes?.status;
+  return !status || status === 'active';
+}
+
+/**
+ * Tareas del ciclo para ESTA SEMANA, por ciclo activo.
+ * Etapa: estima con fenología (especie + fecha siembra + altitud); si no hay
+ * plantilla cae al current_stage registrado del proceso. Tareas: plantilla de
+ * la etapa + preventivas ENSO (deduplicadas, ENSO primero por urgencia).
+ *
+ * @param {object} input
+ * @param {Array} [input.processes]    FarmProcess[] (listFarmProcesses)
+ * @param {number|null} [input.altitudeM]
+ * @param {string} [input.ensoPhase]   slug del sidecar ('nina_moderada', …)
+ * @param {number} [input.now]
+ * @param {number} [input.maxPorCiclo] tope de tareas por ciclo (legibilidad)
+ * @returns {Array<{processId:string, etiqueta:string, stageCode:string,
+ *   stageLabel:string, emoji:string, diasDesdeSiembra:number|null,
+ *   confianza:number|null, fuentes:string[],
+ *   tareas:Array<{task:string, description:string, priority:string, origen:'etapa'|'enso'}>}>}
+ */
+export function buildTareasSemana({
+  processes = [],
+  altitudeM = null,
+  ensoPhase = 'neutral',
+  now = Date.now(),
+  maxPorCiclo = 4,
+} = {}) {
+  const taskPhase = ensoTaskPhase(ensoPhase);
+  const grupos = [];
+
+  for (const proc of processes) {
+    if (!esActivo(proc)) continue;
+    const a = proc?.attributes || {};
+
+    const est = a.subject_slug && a.created_at
+      ? getCurrentStage({
+        speciesSlug: a.subject_slug,
+        sowingDate: a.created_at,
+        altitudeM: altitudeM ?? undefined,
+        now,
+      })
+      : null;
+    const estCode = est?.stage?.status === 'computed' ? est.stage.code : null;
+    const stageCode = estCode || a.current_stage || null;
+    if (!stageCode) continue;
+
+    const deEtapa = getTasksForStage(stageCode).map((t) => ({ ...t, origen: 'etapa' }));
+    const deEnso = taskPhase
+      ? getEnsemblePreventiveTasks(taskPhase, stageCode).map((t) => ({ ...t, origen: 'enso' }))
+      : [];
+
+    // ENSO primero (urgencia climática), dedupe por nombre de tarea.
+    const vistos = new Set();
+    const tareas = [];
+    for (const t of [...deEnso, ...deEtapa]) {
+      if (vistos.has(t.task)) continue;
+      vistos.add(t.task);
+      tareas.push(t);
+    }
+    const orden = { alta: 0, media: 1, baja: 2 };
+    tareas.sort((x, y) => (orden[x.priority] ?? 3) - (orden[y.priority] ?? 3));
+
+    grupos.push({
+      processId: proc.process_id || proc.id,
+      etiqueta: a.subject_label || 'Ciclo',
+      stageCode,
+      stageLabel: STAGE_LABELS[stageCode] || stageCode,
+      emoji: STAGE_EMOJIS[stageCode] || '🌱',
+      diasDesdeSiembra: est?.daysElapsed ?? null,
+      confianza: est?.stage?.confidence ?? null,
+      fuentes: est?.stage?.sources || [],
+      tareas: tareas.slice(0, maxPorCiclo),
+    });
+  }
+  return grupos;
+}
+
+/**
+ * Agenda campesina: ventanas fenológicas que ABREN dentro del horizonte
+ * (default ~5 semanas), por ciclo activo. Solo lo computable con plantilla +
+ * fecha de siembra reales — sin plantilla no hay item (cero fabricación).
+ *
+ * @param {object} input
+ * @param {Array} [input.processes]
+ * @param {number|null} [input.altitudeM]
+ * @param {number} [input.now]
+ * @param {number} [input.horizonDays]
+ * @returns {Array<{fecha:number, processId:string, etiqueta:string,
+ *   stageCode:string, stageLabel:string, emoji:string,
+ *   tipo:'cosecha'|'etapa', confianza:number, fuentes:string[],
+ *   ventana:{inicio:number, fin:number|null}}>}
+ */
+export function buildAgenda({
+  processes = [],
+  altitudeM = null,
+  now = Date.now(),
+  horizonDays = 35,
+} = {}) {
+  const items = [];
+  const horizonEnd = now + horizonDays * DAY_MS;
+
+  for (const proc of processes) {
+    if (!esActivo(proc)) continue;
+    const a = proc?.attributes || {};
+    if (!a.subject_slug || !a.created_at) continue;
+
+    const windows = calculateWindows({
+      speciesSlug: a.subject_slug,
+      sowingDate: a.created_at,
+      altitudeM: altitudeM ?? undefined,
+    });
+    for (const w of windows) {
+      if (w.status !== 'computed' || w.windowStart == null) continue;
+      if (w.code === 'sowing') continue; // la siembra ya ocurrió: no es agenda
+      if (w.windowStart < now - DAY_MS || w.windowStart > horizonEnd) continue;
+      items.push({
+        fecha: w.windowStart,
+        processId: proc.process_id || proc.id,
+        etiqueta: a.subject_label || 'Ciclo',
+        stageCode: w.code,
+        stageLabel: STAGE_LABELS[w.code] || w.label,
+        emoji: STAGE_EMOJIS[w.code] || '🌱',
+        tipo: w.code === 'harvest_window' ? 'cosecha' : 'etapa',
+        confianza: w.confidence,
+        fuentes: w.sources || [],
+        ventana: { inicio: w.windowStart, fin: w.windowEnd },
+      });
+    }
+  }
+  items.sort((x, y) => x.fecha - y.fecha);
+  return items;
+}
+
+const DIA_CORTO = ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'];
+
+function startOfDay(ts) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Vista SEMANA: agrupa items de agenda por día calendario (Hoy, Mañana, …).
+ * @param {Array<{fecha:number}>} items
+ * @param {{now?:number, dias?:number}} [opts]
+ * @returns {Array<{fecha:number, label:string, esHoy:boolean, items:Array}>}
+ */
+export function agendaPorDia(items = [], { now = Date.now(), dias = 7 } = {}) {
+  const hoy0 = startOfDay(now);
+  return Array.from({ length: dias }, (_, i) => {
+    const dayStart = hoy0 + i * DAY_MS;
+    const dayEnd = dayStart + DAY_MS;
+    const d = new Date(dayStart);
+    const label = i === 0
+      ? 'Hoy'
+      : i === 1
+        ? 'Mañana'
+        : `${DIA_CORTO[d.getDay()]} ${d.getDate()}`;
+    return {
+      fecha: dayStart,
+      label,
+      esHoy: i === 0,
+      items: items.filter((it) => it.fecha >= dayStart && it.fecha < dayEnd),
+    };
+  });
+}
+
+/**
+ * Vista MES: agrupa items por semana ("Esta semana", "Próxima semana", …).
+ * @param {Array<{fecha:number}>} items
+ * @param {{now?:number, semanas?:number}} [opts]
+ * @returns {Array<{inicio:number, fin:number, label:string, items:Array}>}
+ */
+export function agendaPorSemana(items = [], { now = Date.now(), semanas = 5 } = {}) {
+  const hoy0 = startOfDay(now);
+  const fmt = (ts) => new Date(ts).toLocaleDateString('es-CO', { day: 'numeric', month: 'short' });
+  return Array.from({ length: semanas }, (_, i) => {
+    const inicio = hoy0 + i * 7 * DAY_MS;
+    const fin = inicio + 7 * DAY_MS;
+    const label = i === 0
+      ? 'Esta semana'
+      : i === 1
+        ? 'Próxima semana'
+        : `Del ${fmt(inicio)} al ${fmt(fin - DAY_MS)}`;
+    return {
+      inicio,
+      fin,
+      label,
+      items: items.filter((it) => it.fecha >= inicio && it.fecha < fin),
+    };
+  });
+}


### PR DESCRIPTION
## Qué hace

Vista de inicio proactiva **"Hoy en finca"** (`hoy_finca`) + **agenda/calendario campesino** — responde de un vistazo: ¿cómo está el día?, ¿hay alertas?, ¿qué me toca esta semana?, ¿qué viene?

### Las 5 secciones (todas accionables)

1. **Clima de hoy HONESTO** — `skyConditionService` (nubosidad real Open-Meteo + corrección orográfica andina + modulación ENSO, fix Choachí #1452) + `climaService` (pronóstico del sidecar). Ubicación **guardada** del perfil (`resolveClimaLocation`), nunca geo en vivo. "Mayormente nublado" cuando lo está — el ámbar de sol queda reservado para despejado real. Toque → agente con prompt pre-cargado. Sin ubicación → CTA al mini-mapa.
2. **Alertas del día** — `useAlertStore` (alertEngine + cropAlertEngine). Son las **mismas** alertas de la campana unificada (referenciadas en el copy, cero duplicación de motor). Toque → agente con `prefilled_prompt` (mismo patrón de CriticalAlertBanner). Fase ENSO en lenguaje llano vía `describePhase` (#1453/#1454): "el clima viene parejo…".
3. **Tareas del ciclo de esta semana** — etapa estimada con `phenologyCalculator` (especie + fecha siembra + altitud) con fallback al `current_stage` registrado; labores de `cycleTaskService` + preventivas ENSO de `climateCycleService` (deduplicadas, chip "clima"). Toque → Ciclo del cultivo.
4. **Accesos rápidos** — Sembrar (voz) / Cosechar / Plagas / Insumos / Tareas / Preguntar, íconos grandes con acento del tema.
5. **Agenda campesina** (`AgendaCampesina`) — toggle grande Semana/Mes: ventanas fenológicas REALES por día (Hoy, Mañana, lun 15…) o por semana, cada item con fuentes + confianza del template. Toque → ciclo.

### Integración al dashboard

`HoyEnFincaStrip` como **primera sección** draggable del home (order v3): fecha + condición honesta + chips 🔔 alertas / 📋 tareas + próximo evento de agenda → toque abre la vista completa. `HoyCard` re-apuntada de `task_log` a `hoy_finca`. Hash routes `#hoy` / `#hoy-en-finca`.

### Diseño

- `hoyEnFincaService` — agregador **puro** (sin red/IDB): `buildClimaHoy`, `buildTareasSemana`, `buildAgenda`, `agendaPorDia/PorSemana`. **Cero fabricación**: sin datos → `hasData:false` / listas vacías con empty-states honestos y CTA.
- **Offline-first**: pinta caches (`getCached*`) al instante, refresca después; los fetch nunca lanzan.
- **Theme-aware**: superficies `slate-*` (indirección CSS-var por tema) + acento `--t-accent-rgb`; convive con la atmósfera climática (#1448).
- Lenguaje llano es-CO, íconos grandes, taps ≥40px, aria-labels.

## Pruebas

- 24 tests nuevos (servicio 15 · screen 7 · strip 2), `npx vitest run` verde (los 22 fails del suite son pre-existentes en main — verificado corriendo los mismos archivos sobre `origin/main`).
- `eslint --max-warnings=0` limpio en todos los archivos tocados.

## Validación en vivo (chromium nix-store, dev server + farmOS/sidecar locales)

Perfil real Choachí (1.950 msnm): clima honesto **"Lluvia 23°/11° · 1 mm"** (llovía de verdad), ENSO llano "el clima viene parejo", ciclos papa (45d → Brote, corrección por altitud) + lechuga (12d → Crecimiento) con labores reales, agenda "lun 15: Papa pastusa entra a Crecimiento", alerta real de cropAlertEngine (gota/tizón) visible y ruteando al agente, toque de tarea → Ciclo del cultivo OK. Temas **biopunk + nature + minimalista**, 0 page errors. Screenshots: `/tmp/hoyfinca-art/` (01-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)