### PR TITLE
feat(bodega): galeria browsable de recetas de biopreparados

### DIFF
--- a/src/components/BiopreparadoRecetasGallery.jsx
+++ b/src/components/BiopreparadoRecetasGallery.jsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+import { FlaskConical, X } from 'lucide-react';
+import { getAllBiopreparados } from '../db/catalogDB';
+import { tieneDiagrama } from '../data/biopreparado-diagramas';
+import BiopreparadoDiagrama from './BiopreparadoDiagrama';
+
+/**
+ * BiopreparadoRecetasGallery — galería browsable de las recetas de biopreparados
+ * con diagrama gráfico paso-a-paso (BiopreparadoDiagrama).
+ *
+ * Antes, los diagramas SOLO salían vía BiopreparadoSuggestionModal al agregar un
+ * material que matcheara un ingrediente — inalcanzables si la Bodega estaba vacía
+ * (bug operador 2026-06-11: "solo veo Biofábrica vacía y no me deja hacer nada").
+ * Esto los hace visibles directo, sin tener que registrar nada en el inventario.
+ *
+ * Carga la lista de biopreparados (catálogo) y filtra a los que tienen diagrama.
+ * Tolera que listAllBiopreparados sea sync o async (Promise.resolve). Si no hay
+ * recetas con diagrama, el botón no se renderiza.
+ */
+export default function BiopreparadoRecetasGallery() {
+  const [open, setOpen] = useState(false);
+  const [bps, setBps] = useState([]);
+
+  useEffect(() => {
+    let alive = true;
+    Promise.resolve()
+      .then(() => getAllBiopreparados())
+      .then((list) => {
+        if (alive) setBps((list || []).filter((bp) => bp && bp.id && tieneDiagrama(bp.id)));
+      })
+      .catch(() => { /* sin recetas → el botón no aparece, no rompe la Bodega */ });
+    return () => { alive = false; };
+  }, []);
+
+  if (bps.length === 0) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="ver-recetas-biopreparados"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-bold transition-all active:scale-95 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+      >
+        <FlaskConical size={16} aria-hidden="true" />
+        Ver recetas de biopreparados ({bps.length})
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 bg-black/70 flex items-end sm:items-center justify-center sm:p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Recetas de biopreparados"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="bg-slate-900 border border-slate-700 rounded-t-3xl sm:rounded-3xl w-full sm:max-w-2xl max-h-[88vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="sticky top-0 z-10 bg-slate-900/95 backdrop-blur px-4 py-3 border-b border-slate-700 flex items-center justify-between">
+              <h3 className="text-base font-bold text-slate-100">Recetas de biopreparados</h3>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Cerrar"
+                className="p-1.5 rounded-full hover:bg-slate-800 text-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-400/60"
+              >
+                <X size={20} aria-hidden="true" />
+              </button>
+            </div>
+            <div className="p-4 space-y-4">
+              {bps.map((bp) => (
+                <BiopreparadoDiagrama key={bp.id} biopreparado={bp} />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/InventoryDashboard.jsx
+++ b/src/components/InventoryDashboard.jsx
@@ -3,6 +3,7 @@ import { Package, AlertTriangle, Plus, X, Download } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { UNIT_OPTIONS } from '../config/materials';
 import { useConsumptionMetrics } from '../hooks/useConsumptionMetrics';
+import BiopreparadoRecetasGallery from './BiopreparadoRecetasGallery';
 import { Sparkline } from './charts/Sparkline';
 import { exportTraceabilityCsv } from '../services/exportService';
 import { getAllPlans, markStepExecuted } from '../services/planGeneratorService';
@@ -313,6 +314,13 @@ export const InventoryDashboard = () => {
           </div>
         </section>
       )}
+
+      {/* Galería de recetas de biopreparados — visible siempre (no gateada por
+          el inventario). Antes los 15 diagramas eran inalcanzables si la Bodega
+          estaba vacía (bug operador 2026-06-11). */}
+      <div className="mb-5 flex justify-center">
+        <BiopreparadoRecetasGallery />
+      </div>
 
       {materials.length === 0 ? (
         <div className="py-12 text-center text-slate-500">


### PR DESCRIPTION
Bug operador: los 15 diagramas de biopreparados eran inalcanzables (gateados detras de la Bodega vacia + el add roto). Nueva galeria (boton 'Ver recetas' + modal) en la Biofabrica/Bodega, siempre visible, sin tener que registrar nada. Usa getAllBiopreparados (path probado del modal, trae precaucion). Verificar en vivo tras deploy.