### PR TITLE
feat(catalog): add AMB-28/29 validators for taxonomic confusion and mislocated species

### DIFF
--- a/scripts/__tests__/validate-catalog.test.mjs
+++ b/scripts/__tests__/validate-catalog.test.mjs
@@ -22,6 +22,8 @@ import {
   validateAmb25_autoridadCanonicaEstricta,
   validateAmb26_validationLevelCanonico,
   validateAmb27_toxicoSinAdvertencia,
+  validateAmb28_taxonomicConfusion,
+  validateAmb29_speciesInBiopreparados,
 } from '../validate-catalog.mjs';
 
 describe('AMB-25 — autoridad canónica estricta', () => {
@@ -194,5 +196,229 @@ describe('AMB-27 — toxico_sin_advertencia (WARN-only)', () => {
   it('ignora species sin valor_pedagogico', () => {
     const catalog = { species: [{ id: 'sin_vp' }] };
     expect(validateAmb27_toxicoSinAdvertencia(catalog)).toEqual([]);
+  });
+});
+
+describe('AMB-28 — confusión taxonómica conocida', () => {
+  it('detecta gulupa confundida con guayaba en nombre_comun', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'passiflora_edulis_morada',
+          nombre_comun: 'Guayaba', // ERROR: debería ser 'Gulupa'
+          nombre_cientifico: 'Passiflora edulis f. edulis',
+        },
+      ],
+    };
+    const errors = validateAmb28_taxonomicConfusion(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('passiflora_edulis_morada');
+    expect(errors[0]).toContain('guayaba');
+    expect(errors[0]).toContain('gulupa');
+  });
+
+  it('detecta aguacate confundido con guayaba en nombre_comun', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'persea_americana',
+          nombre_comun: 'Guayaba', // ERROR: debería ser 'Aguacate'
+          nombre_cientifico: 'Persea americana',
+        },
+      ],
+    };
+    const errors = validateAmb28_taxonomicConfusion(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('persea_americana');
+    expect(errors[0]).toContain('aguacate');
+  });
+
+  it('detecta confusión en nombres_comunes_regionales', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'passiflora_edulis_morada',
+          nombre_comun: 'Gulupa',
+          nombres_comunes_regionales: ['Guayaba de pasiflora', 'Curuba'], // ERROR: 'Guayaba' en Passiflora es confusión
+        },
+      ],
+    };
+    const errors = validateAmb28_taxonomicConfusion(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('guayaba de pasiflora');
+  });
+
+  it('acepta nombres correctos sin error', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'passiflora_edulis_morada',
+          nombre_comun: 'Gulupa',
+          nombre_cientifico: 'Passiflora edulis f. edulis',
+          nombres_comunes_regionales: ['Gulupa morada', 'Curuba de tierra fría'],
+        },
+        {
+          id: 'psidium_guajava',
+          nombre_comun: 'Guayaba',
+          nombre_cientifico: 'Psidium guajava',
+        },
+        {
+          id: 'persea_americana',
+          nombre_comun: 'Aguacate',
+          nombre_cientifico: 'Persea americana',
+        },
+      ],
+    };
+    expect(validateAmb28_taxonomicConfusion(catalog)).toEqual([]);
+  });
+
+  it('ignora species sin nombre_comun', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'sin_nombre',
+          nombre_cientifico: 'Species unknown',
+        },
+      ],
+    };
+    expect(validateAmb28_taxonomicConfusion(catalog)).toEqual([]);
+  });
+
+  it('detecta múltiples confusiones en una sola especie', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'passiflora_edulis_morada',
+          nombre_comun: 'Gulupa con confusiones',
+          nombres_comunes_regionales: [
+            'Aguacate de pasiflora', // ERROR: aguacate en Passiflora
+            'Guayaba de montaña'      // ERROR: guayaba en Passiflora
+          ],
+        },
+      ],
+    };
+    const errors = validateAmb28_taxonomicConfusion(catalog);
+    // Debería detectar al menos 2 errores (aguacate y guayaba)
+    expect(errors.length).toBeGreaterThanOrEqual(2);
+    // Verificar que ambos errores están presentes
+    const hasAguacateError = errors.some(e => e.includes('aguacate'));
+    const hasGuayabaError = errors.some(e => e.includes('guayaba'));
+    expect(hasAguacateError).toBe(true);
+    expect(hasGuayabaError).toBe(true);
+  });
+});
+
+describe('AMB-29 — species en array biopreparados', () => {
+  it('detecta species insertada dentro de biopreparados array', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'psidium_guajava',
+          nombre_comun: 'Guayaba',
+          nombre_cientifico: 'Psidium guajava',
+        },
+      ],
+      biopreparados: [
+        {
+          id: 'bocashi',
+          nombre: 'Bocashi',
+          tipo: 'fermentado',
+        },
+        {
+          // ERROR: esto es una species, no un biopreparado
+          id: 'passiflora_edulis_morada',
+          nombre_comun: 'Gulupa',
+          nombre_cientifico: 'Passiflora edulis f. edulis',
+          companions: ['psidium_guajava'],
+        },
+      ],
+    };
+    const errors = validateAmb29_speciesInBiopreparados(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('biopreparados');
+    expect(errors[0]).toContain('passiflora_edulis_morada');
+    expect(errors[0]).toContain('nombre_cientifico');
+  });
+
+  it('detecta múltiples species mal insertadas', () => {
+    const catalog = {
+      species: [],
+      biopreparados: [
+        {
+          id: 'bocashi',
+          nombre: 'Bocashi',
+          tipo: 'fermentado',
+        },
+        {
+          id: 'persea_americana',
+          nombre_comun: 'Aguacate',
+          nombre_cientifico: 'Persea americana',
+          category: 'frutales',
+        },
+        {
+          id: 'psidium_guajava',
+          nombre_comun: 'Guayaba',
+          nombre_cientifico: 'Psidium guajava',
+          companions: ['persea_americana'],
+        },
+      ],
+    };
+    const errors = validateAmb29_speciesInBiopreparados(catalog);
+    expect(errors).toHaveLength(2);
+  });
+
+  it('acepta biopreparados válidos sin error', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'psidium_guajava',
+          nombre_comun: 'Guayaba',
+        },
+      ],
+      biopreparados: [
+        {
+          id: 'bocashi',
+          nombre: 'Bocashi',
+          tipo: 'fermentado',
+          ingredientes: ['gallinaza', 'melaza'],
+        },
+        {
+          id: 'biol',
+          nombre: 'Biol',
+          tipo: 'fermentado',
+          ingredientes: ['estiércol', 'melaza'],
+        },
+      ],
+    };
+    expect(validateAmb29_speciesInBiopreparados(catalog)).toEqual([]);
+  });
+
+  it('ignora catálogos sin biopreparados', () => {
+    const catalog = {
+      species: [
+        {
+          id: 'psidium_guajava',
+          nombre_comun: 'Guayaba',
+        },
+      ],
+    };
+    expect(validateAmb29_speciesInBiopreparados(catalog)).toEqual([]);
+  });
+
+  it('detecta species markers sutiles (companions/antagonists sin target)', () => {
+    const catalog = {
+      biopreparados: [
+        {
+          id: 'algo_raro',
+          nombre: 'Algo Raro',
+          tipo: 'fermentado',
+          // ERROR: companions es un campo de species, no de biopreparados
+          companions: ['otra_especie'],
+        },
+      ],
+    };
+    const errors = validateAmb29_speciesInBiopreparados(catalog);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('companions');
   });
 });

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -646,6 +646,117 @@ export function validateAmb27_toxicoSinAdvertencia(catalog) {
   return warnings;
 }
 
+// AMB-28: confusión taxonómica conocida. Detecta patrones históricos de
+// confusión entre especies reportados en auditorías agroecológicas (2026-05-21
+// Pasada 3-5-7). Los casos documentados:
+//   - gulupa (Passiflora edulis) frecuentemente confundida con guayaba
+//   - aguacate (Persea americana) frecuentemente confundido con guayaba
+// El validador chequea nombre_comun y nombres_comunes_regionales contra estos
+// patrones de confusión. Match case-insensitive y substring para capturar
+// variantes ("guayaba morada", "guayaba de tierra fría", etc.).
+export const TAXONOMIC_CONFUSION_PATTERNS = new Map([
+  // key: substring sospechoso (lowercase) → value: especie correcta (lowercase)
+  ['gulupa', 'passiflora'], // Si menciona "guayaba" pero el ID sugiere Passiflora → confusión gulupa
+  ['aguacate', 'persea'],   // Si menciona "guayaba" pero el ID sugiere Persea → confusión aguacate
+]);
+export function validateAmb28_taxonomicConfusion(catalog) {
+  const errors = [];
+  for (const sp of catalog.species || []) {
+    const nombreComun = (sp.nombre_comun || '').toLowerCase().trim();
+    const nombresRegionales = (sp.nombres_comunes_regionales || [])
+      .map((n) => String(n).toLowerCase().trim());
+
+    // Detectar patrones de confusión
+    const allNames = [nombreComun, ...nombresRegionales].filter(Boolean);
+    const idLower = String(sp.id || '').toLowerCase();
+
+    // Chequear si menciona "guayaba" pero el ID sugiere otra especie
+    if (allNames.some((n) => n.includes('guayaba'))) {
+      // Si el ID sugiere Passiflora (gulupa/curuba/maracuyá) pero menciona "guayaba"
+      if (idLower.includes('passiflora') && !idLower.includes('guajava')) {
+        // Encontrar qué nombre contiene "guayaba" para reportarlo
+        const guiltyName = allNames.find((n) => n.includes('guayaba'));
+        errors.push(`AMB-28 [${sp.id}]: posible confusión gulupa→guayaba detectada en nombre "${guiltyName}". Passiflora spp. (gulupa, curuba, maracuyá) no deben confundirse con Psidium guajava (guayaba).`);
+      }
+
+      // Si el ID sugiere Persea (aguacate) pero menciona "guayaba"
+      if (idLower.includes('persea') && !idLower.includes('guajava')) {
+        const guiltyName = allNames.find((n) => n.includes('guayaba'));
+        errors.push(`AMB-28 [${sp.id}]: posible confusión aguacate→guayaba detectada en nombre "${guiltyName}". Persea americana (aguacate) no debe confundirse con Psidium guajava (guayaba).`);
+      }
+    }
+
+    // Chequear confusión inversa: menciona gulupa pero el ID sugiere guayaba
+    if (allNames.some((n) => n.includes('gulupa') || n.includes('maracuyá') || n.includes('curuba'))) {
+      if (idLower.includes('guajava')) {
+        const guiltyName = allNames.find((n) => n.includes('gulupa') || n.includes('maracuyá') || n.includes('curuba'));
+        errors.push(`AMB-28 [${sp.id}]: posible confusión guayaba→gulupa detectada en nombre "${guiltyName}". Psidium guajava (guayaba) no debe confundirse con Passiflora spp.`);
+      }
+    }
+
+    // Chequear si menciona "gulupa" pero el ID sugiere aguacate
+    if (allNames.some((n) => n.includes('gulupa'))) {
+      if (idLower.includes('persea')) {
+        const guiltyName = allNames.find((n) => n.includes('gulupa'));
+        errors.push(`AMB-28 [${sp.id}]: posible confusión gulupa→aguacate detectada en nombre "${guiltyName}". Passiflora edulis (gulupa) no debe confundirse con Persea americana (aguacate).`);
+      }
+    }
+
+    // Chequear si menciona "aguacate" pero el ID sugiere gulupa
+    if (allNames.some((n) => n.includes('aguacate'))) {
+      if (idLower.includes('passiflora')) {
+        const guiltyName = allNames.find((n) => n.includes('aguacate'));
+        errors.push(`AMB-28 [${sp.id}]: posible confusión aguacate→gulupa detectada en nombre "${guiltyName}". Persea americana (aguacate) no debe confundirse con Passiflora spp. (gulupa).`);
+      }
+    }
+  }
+  return errors;
+}
+
+// AMB-29: species insertadas en array equivocado. Detecta cuando una especie
+// (con campos propios de species como nombre_cientifico, companions, antagonists,
+// category, etc.) fue insertada incorrectamente dentro del array biopreparados[].
+// Este es un error de estructura de catálogo que rompe validadores posteriores.
+// Los campos distintivos de species que NO deben aparecer en biopreparados:
+//   - nombre_cientifico
+//   - companions / antagonists
+//   - category
+//   - familia_botanica
+//   - altitud_msnm
+//   - propagation
+//   - scale_viability
+// Si alguno de estos campos está presente en un item de biopreparados[],
+// es muy probable que sea una species mal ubicada.
+export const SPECIES_EXCLUSIVE_FIELDS = new Set([
+  'nombre_cientifico',
+  'companions',
+  'antagonists',
+  'category',
+  'familia_botanica',
+  'altitud_msnm',
+  'propagation',
+  'scale_viability',
+  'manejo_por_escala',
+  'recommended_covers',
+  'recommended_fences',
+]);
+export function validateAmb29_speciesInBiopreparados(catalog) {
+  const errors = [];
+  for (const bp of catalog.biopreparados || []) {
+    if (!bp || typeof bp !== 'object') continue;
+
+    // Detectar si tiene campos exclusivos de species
+    const speciesFields = Object.keys(bp).filter((k) => SPECIES_EXCLUSIVE_FIELDS.has(k));
+
+    if (speciesFields.length > 0) {
+      const id = bp.id || '(sin id)';
+      const fieldsList = speciesFields.join(', ');
+      errors.push(`AMB-29 [biopreparados[${id}]]: posible species mal ubicada en array biopreparados (campos de species detectados: ${fieldsList}). ${bp.nombre_comun ? `nombre_comun="${bp.nombre_comun}"` : ''} Revisa si este item debería estar en catalog.species[] en lugar de catalog.biopreparados[].`);
+    }
+  }
+  return errors;
+}
+
 // ----------------------------------------------------------------
 // Main (CLI). Gated por `import.meta.url === file://${process.argv[1]}` para
 // permitir importar las funciones validador desde tests (scripts/__tests__/
@@ -766,6 +877,20 @@ function runCli() {
     ['AMB-27 toxico_sin_advertencia (WARN)', (c) => ({
       errors: [],
       warnings: validateAmb27_toxicoSinAdvertencia(c),
+    })],
+    // AMB-28/29 introducidos 2026-06-12 (GLM-4.6 task #6133) para endurecer
+    // validación del catálogo contra patrones de confusión taxonómica conocidos
+    // (gulupa→guayaba, aguacate→guayaba) y detección de species insertadas en
+    // arrays equivocados (species dentro de biopreparados[]). AMB-28 es error
+    // duro porque rompe la integridad del catálogo; AMB-29 también es error
+    // duro porque es un error estructural que rompe validadores posteriores.
+    ['AMB-28 confusión taxonómica conocida', (c) => ({
+      errors: validateAmb28_taxonomicConfusion(c),
+      warnings: [],
+    })],
+    ['AMB-29 species en array biopreparados', (c) => ({
+      errors: validateAmb29_speciesInBiopreparados(c),
+      warnings: [],
     })],
   ];
 


### PR DESCRIPTION
## Summary

Implementa dos nuevos validadores semánticos (AMB-28 y AMB-29) para endurecer la validación del catálogo Chagra contra patrones de confusión taxonómica conocidos y errores de estructura.

## Cambios

### AMB-28: Confusión taxonómica conocida
- Detecta patrones históricos de confusión reportados en auditorías agroecológicas:
  - gulupa (Passiflora edulis) confundida con guayaba (Psidium guajava)
  - aguacate (Persea americana) confundido con guayaba
- Chequea nombre_comun y nombres_comunes_regionales con match case-insensitive
- Reporta errores específicos identificando el campo problemático

### AMB-29: Species en array biopreparados
- Detecta cuando una species (con campos propios como nombre_cientifico, companions, antagonists, etc.) fue insertada incorrectamente en biopreparados[]
- Valida contra un set de campos exclusivos de species:
  - nombre_cientifico, companions, antagonists, category, familia_botanica
  - altitud_msnm, propagation, scale_viability, manejo_por_escala
  - recommended_covers, recommended_fences
- Reporta el ID del item y los campos de species detectados

## Test plan

Tests añadidos en scripts/__tests__/validate-catalog.test.mjs:
- `detecta gulupa confundida con guayaba en nombre_comun`
- `detecta aguacate confundido con guayaba en nombre_comun`
- `detecta confusión en nombres_comunes_regionales`
- `acepta nombres correctos sin error`
- `ignora species sin nombre_comun`
- `detecta múltiples confusiones en una sola especie`
- `detecta species insertada dentro de biopreparados array`
- `detecta múltiples species mal insertadas`
- `acepta biopreparados válidos sin error`
- `ignora catálogos sin biopreparados`
- `detecta species markers sutiles (companions/antagonists sin target)`

Todos los tests pasan (26/26):
```
npx vitest run scripts/__tests__/validate-catalog.test.mjs
✓ All tests passed
```

## Verificaciones

- ✅ Tests: `npx vitest run scripts/__tests__/validate-catalog.test.mjs` (26/26 pass)
- ✅ ESLint: `npx eslint scripts/validate-catalog.mjs scripts/__tests__/validate-catalog.test.mjs --max-warnings=0`
- ✅ Build: `npm run build` (success)
- ✅ Validación manual: `node scripts/validate-catalog.mjs catalog/chagra-catalog-seed-v3.1.json catalog/schema-v3.1.json --lenient-schema` (AMB-28/29 pass)

## Riesgos conocidos

Ninguno. Los validadores son read-only y no modifican el catálogo. Los patrones de confusión están basados en casos documentados en auditorías agroecológicas 2026-05-21 Pasadas 3-5-7.