### PR TITLE
feat(restauracion): especies nativas reales por piso térmico (anti-fabricación)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1333,14 +1333,17 @@ export default function AgentScreen({ onBack, initialContext }) {
               // Carbono/PSA (Task 3): detectarAlertaCarbono
               modules.push([
                 (text) => /\b(bonos?\s+carbono|pagar\s+por\s+sembrar|carbono\b.*\bpagar|PSA|Decreto\s+1007)\b/i.test(text),
-                async () => { const c = await import('../../services/carbonoAlerta'); const p = await import('../../data/carbono-alertas.json'); return { diagnosticar: (t) => c.detectarAlertaCarbono(t), formatear: (d) => d ? `ALERTA BONOS DE CARBONO: ${d.alerta}\n\nTrampas:\n${d.trampas.map((t) => `- ${t.nombre}: ${t.riesgo}`).join('\n')}\n\nRecomendacion: ${d.recomendacion}` : '' }; },
+                async () => { const c = await import('../../services/carbonoAlerta'); return { diagnosticar: (t) => c.detectarAlertaCarbono(t), formatear: (d) => d ? `ALERTA BONOS DE CARBONO: ${d.alerta}\n\nTrampas:\n${d.trampas.map((t) => `- ${t.nombre}: ${t.riesgo}`).join('\n')}\n\nRecomendacion: ${d.recomendacion}` : '' }; },
                 'carbono_alerta', 'carbono',
               ]);
+              // Altitud del perfil de finca activa → el grounding de restauración
+              // elige especies nativas REALES del piso térmico (anti-fabricación).
+              const restAltitud = fincas?.find((f) => f.slug === activeFincaSlug)?.altitud ?? null;
               for (const [hasIntent, loadMod, tool, label] of modules) {
                 if (hasIntent(textForLLM)) {
                   try {
                     const mod = await loadMod();
-                    const diag = mod.diagnosticar(textForLLM);
+                    const diag = mod.diagnosticar(textForLLM, { altitud: restAltitud });
                     if (diag && (diag.sin_datos === false || diag.alerta)) {
                       const bloque = mod.formatear(diag);
                       if (bloque) {

--- a/src/services/__tests__/restauracionDiagnostic.test.js
+++ b/src/services/__tests__/restauracionDiagnostic.test.js
@@ -48,3 +48,26 @@ describe('formatearGroundingRestauracion', () => {
     expect(f).toContain('GUARDAS');
   });
 });
+
+describe('especies nativas reales (anti-fabricacion — escenario Daniel)', () => {
+  it('la altitud del perfil deriva el piso y trae especies del catalogo', () => {
+    const d = diagnosticarRestauracion('quiero proteger el nacimiento de agua', { altitud: 2600 });
+    expect(d.especies).toBeTruthy();
+    expect(d.especies.pioneras.length).toBeGreaterThan(0);
+  });
+  it('Daniel (nacimiento, 2600m frio) → grounding con especies reales con nombre cientifico + NO inventes', () => {
+    const d = diagnosticarRestauracion('arboles nativos en el nacimiento de agua', { altitud: 2600 });
+    const f = formatearGroundingRestauracion(d);
+    expect(f).toContain('Alnus acuminata'); // Aliso — piso frio, cientifico real del catalogo
+    expect(f).toMatch(/NO inventes/i);
+  });
+  it('la altitud mapea al piso correcto (calido vs paramo)', () => {
+    expect(formatearGroundingRestauracion(diagnosticarRestauracion('recuperar el bosque', { altitud: 400 }))).toContain('Ochroma pyramidale'); // Balso, calido
+    expect(formatearGroundingRestauracion(diagnosticarRestauracion('recuperar el bosque', { altitud: 3200 }))).toContain('Espeletia'); // Frailejon, paramo
+  });
+  it('sin altitud ni piso en el texto → especies null (NO inventa), pero la guarda anti-fabricacion sigue', () => {
+    const d = diagnosticarRestauracion('quiero proteger el nacimiento de agua');
+    expect(d.especies).toBeNull();
+    expect(formatearGroundingRestauracion(d)).toMatch(/NUNCA inventes/i);
+  });
+});

--- a/src/services/restauracionDiagnostic.js
+++ b/src/services/restauracionDiagnostic.js
@@ -8,15 +8,27 @@
  * paramo→pasiva+Ley 1930, retamo NO quemar, densidad excesiva MITO.
  */
 import REST_DATA from '../data/restauracion.json';
+import ESPECIES_DATA from '../data/restauracion-especies.json';
 
-export function diagnosticarRestauracion(descripcion) {
+/** Deriva el piso térmico desde la altitud (m s.n.m.) del perfil de la finca. */
+function pisoDesdeAltitud(alt) {
+  const a = Number(alt);
+  if (alt == null || Number.isNaN(a)) return null;
+  if (a >= 3000) return 'paramo_3000';
+  if (a >= 2000) return 'frio_2000_3000';
+  if (a >= 1000) return 'templado_1000_2000';
+  return 'calido_0_1000';
+}
+
+export function diagnosticarRestauracion(descripcion, opts = {}) {
   if (!descripcion || descripcion.trim().length < 3) {
-    return { arreglo: null, roles: null, alertas: [], guardas: [REST_DATA.guardas.pino_eucalipto], sin_datos: true, fuente: REST_DATA.fuente };
+    return { arreglo: null, roles: null, especies: null, alertas: [], guardas: [REST_DATA.guardas.pino_eucalipto], sin_datos: true, fuente: REST_DATA.fuente };
   }
   const texto = descripcion.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   const alertas = [];
   let arregloId = null;
-  let piso = null;
+  // Prioridad: piso/altitud del perfil de la finca; luego señales del texto.
+  let piso = opts.piso || pisoDesdeAltitud(opts.altitud);
 
   for (const [clave, senal] of Object.entries(REST_DATA.senales_voz)) {
     const palabras = clave.split('_');
@@ -31,31 +43,42 @@ export function diagnosticarRestauracion(descripcion) {
   }
 
   if (texto.includes('paramo') || texto.includes('frailejon')) {
-    piso = 'paramo_3000';
+    piso = piso || 'paramo_3000';
     alertas.push(REST_DATA.guardas.paramo_pasivo);
-  } else if (texto.includes('calido') || texto.includes('tropical')) piso = 'calido_0_1000';
-  else if (texto.includes('templado') || texto.includes('andino')) piso = 'templado_1000_2000';
-  else if (texto.includes('frio')) piso = 'frio_2000_3000';
+  }
+  // Detección por texto solo si el perfil no dio piso (cubre fría/frío, cálido/cálida…).
+  if (!piso) {
+    if (texto.includes('calid') || texto.includes('tropical')) piso = 'calido_0_1000';
+    else if (texto.includes('templad') || texto.includes('andino')) piso = 'templado_1000_2000';
+    else if (texto.includes('fri')) piso = 'frio_2000_3000';
+  }
 
   const arreglo = arregloId ? REST_DATA.arreglos.find((a) => a.id === arregloId) : null;
   const roles = piso ? REST_DATA.roles_sucesion[piso] : null;
+  const especies = piso ? (ESPECIES_DATA.especies_por_rol[piso] || null) : null;
 
   if (texto.includes('pino') || texto.includes('eucalipto')) alertas.push(REST_DATA.guardas.pino_eucalipto);
   if (texto.includes('carbono') || texto.includes('pagar') || texto.includes('bonos')) alertas.push(REST_DATA.guardas.bonos_carbono);
 
   const guardas = [REST_DATA.guardas.pino_eucalipto, REST_DATA.guardas.densidad_excesiva];
   if (!arreglo && !alertas.length && !roles) {
-    return { arreglo: null, roles: null, alertas, guardas, sin_datos: true, fuente: REST_DATA.fuente };
+    return { arreglo: null, roles: null, especies, alertas, guardas, sin_datos: true, fuente: REST_DATA.fuente };
   }
 
-  return { arreglo, roles, alertas, guardas, sin_datos: false, fuente: REST_DATA.fuente };
+  return { arreglo, roles, especies, alertas, guardas, sin_datos: false, fuente: REST_DATA.fuente };
 }
 
 export function formatearGroundingRestauracion(d) {
   if (!d || d.sin_datos) return '';
   const partes = [];
   if (d.arreglo) partes.push(`**Arreglo recomendado:** ${d.arreglo.nombre} — ${d.arreglo.detalle} (${d.arreglo.densidad}).`);
-  if (d.roles) {
+  if (d.especies) {
+    partes.push('**Sucesion ecologica — especies nativas de tu piso termico (usa SOLO estas, NO inventes otras):**');
+    const fmt = (arr) => arr.map((e) => `${e.nombre} (${e.cientifico})${e.nota ? ` — ${e.nota}` : ''}`).join('; ');
+    if (d.especies.pioneras) partes.push(`- Pioneras: ${fmt(d.especies.pioneras)}`);
+    if (d.especies.intermedias) partes.push(`- Intermedias: ${fmt(d.especies.intermedias)}`);
+    if (d.especies.climax) partes.push(`- Climax: ${fmt(d.especies.climax)}`);
+  } else if (d.roles) {
     partes.push('**Sucesion ecologica:**');
     if (d.roles.pioneras) partes.push(`- Pioneras: ${d.roles.pioneras.join(', ')}`);
     if (d.roles.intermedias) partes.push(`- Intermedias: ${d.roles.intermedias.join(', ')}`);
@@ -63,6 +86,7 @@ export function formatearGroundingRestauracion(d) {
   }
   if (d.alertas.length > 0) { partes.push('**ALERTAS:**'); d.alertas.forEach((a) => partes.push(`- ${a}`)); }
   if (d.guardas.length > 0) { partes.push('**GUARDAS:**'); d.guardas.forEach((g) => partes.push(`- ${g}`)); }
+  partes.push('IMPORTANTE: recomienda SOLO especies nativas verificadas de la lista anterior; si no hay lista para este piso, dilo y sugiere el vivero local o la CAR. NUNCA inventes nombres de especies.');
   partes.push(`Fuente: ${d.fuente}`);
   return partes.join('\n\n');
 }


### PR DESCRIPTION
El botón de reforestación daba método pero NO especies → el modelo inventaba (*Acoelus hirtzellus*, *Jatropha physostegia* — no existen). Ahora wirea el `restauracion-especies.json` (ya existía, sin conectar) y deriva el piso de la **altitud del perfil**, así Daniel (nacimiento 2600m) recibe Aliso/Encenillo/Nogal reales con nombre científico + guarda 'NUNCA inventes especies'. 14/14 tests. Hueco #1 de activación del botón 🌳.

🤖 Generated with [Claude Code](https://claude.com/claude-code)