### PR TITLE
feat(farmprocess): etapas de ciclo propias de restauración (no fenología de cultivo)

### DIFF
--- a/src/types/__tests__/farmProcess.test.js
+++ b/src/types/__tests__/farmProcess.test.js
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isFarmProcess, isFarmProcessEvent, isPopulation,
   validateFarmProcess, validateFarmProcessEvent, validatePopulation,
+  stageSequenceForProcessType, RESTORATION_STAGE_SEQUENCE,
 } from '../farmProcess';
 
 // ─── Fixtures (Task 14) ────────────────────────────────────────
@@ -189,5 +190,31 @@ describe('Population validator', () => {
 
   it('rejects count < 1', () => {
     expect(() => validatePopulation(makePopulation({ count: 0 }))).toThrow(/count/);
+  });
+});
+
+describe('etapas propias de restauración (no fenología de cultivo)', () => {
+  it('valida un proceso de restauración en etapa propia (prendimiento)', () => {
+    expect(() => validateFarmProcess(makeProcess({ process_type: 'restoration', current_stage: 'prendimiento' }))).not.toThrow();
+  });
+
+  it('valida monitoreo_sucesion y cierre (restoration/silvopasture)', () => {
+    expect(() => validateFarmProcess(makeProcess({ process_type: 'restoration', current_stage: 'monitoreo_sucesion' }))).not.toThrow();
+    expect(() => validateFarmProcess(makeProcess({ process_type: 'silvopasture', current_stage: 'cierre' }))).not.toThrow();
+  });
+
+  it('stageSequenceForProcessType(restoration) trae hitos de restauración, no floración/cosecha', () => {
+    const seq = stageSequenceForProcessType('restoration');
+    expect(seq).toBe(RESTORATION_STAGE_SEQUENCE);
+    const codigos = seq.map((s) => s.stage);
+    expect(codigos).toContain('prendimiento');
+    expect(codigos).not.toContain('flowering');
+    expect(codigos).not.toContain('harvest');
+  });
+
+  it('stageSequenceForProcessType(sowing) sí trae fenología de cultivo', () => {
+    const codigos = stageSequenceForProcessType('sowing').map((s) => s.stage);
+    expect(codigos).toContain('germination');
+    expect(codigos).toContain('harvest');
   });
 });

--- a/src/types/farmProcess.js
+++ b/src/types/farmProcess.js
@@ -125,6 +125,13 @@ const VALID_STAGES = [
   'pest_management',
   'closed',
   'fallow',
+  // Restauración/silvopastoreo: NO siguen fenología de cultivo (germina→florece→
+  // cosecha); usan hitos propios de establecimiento ecológico.
+  'establecimiento',
+  'prendimiento',
+  'mantenimiento',
+  'monitoreo_sucesion',
+  'cierre',
 ];
 const VALID_EVENT_TYPES = [
   'sowing_confirmed',
@@ -140,6 +147,34 @@ const VALID_EVENT_TYPES = [
   'weather_snapshot',
   'note',
 ];
+
+/**
+ * Secuencia de etapas + etiquetas por tipo de proceso. La restauración/silvopastoreo
+ * NO sigue fenología de cultivo; usa hitos de establecimiento ecológico, de modo que
+ * el ciclo de una reforestación no "florece y cosecha".
+ */
+export const RESTORATION_STAGE_SEQUENCE = [
+  { stage: 'establecimiento', label: 'Establecimiento (siembra/plantación)' },
+  { stage: 'prendimiento', label: 'Prendimiento (¿pegaron las plántulas?)' },
+  { stage: 'mantenimiento', label: 'Mantenimiento (replante y control de competencia)' },
+  { stage: 'monitoreo_sucesion', label: 'Monitoreo de sucesión (cómo avanza el bosque)' },
+  { stage: 'cierre', label: 'Cierre (rodal autosostenible)' },
+];
+
+const SOWING_STAGE_SEQUENCE = [
+  { stage: 'sowing_confirmed', label: 'Siembra confirmada' },
+  { stage: 'germination', label: 'Germinación' },
+  { stage: 'vegetative', label: 'Crecimiento vegetativo' },
+  { stage: 'flowering', label: 'Floración' },
+  { stage: 'fruiting', label: 'Fructificación' },
+  { stage: 'harvest', label: 'Cosecha' },
+];
+
+/** Secuencia de etapas (con etiqueta) apropiada para el tipo de proceso. */
+export const stageSequenceForProcessType = (processType) =>
+  processType === 'restoration' || processType === 'silvopasture'
+    ? RESTORATION_STAGE_SEQUENCE
+    : SOWING_STAGE_SEQUENCE;
 
 /**
  * Valida un objeto FarmProcess.


### PR DESCRIPTION
El ciclo de restauración reusaba la fenología de cultivo (germinación→floración→cosecha) y `validateFarmProcess` rechazaba cualquier otra etapa → una reforestación 'florecía y cosechaba'. Ahora `VALID_STAGES` suma establecimiento/prendimiento/mantenimiento/monitoreo_sucesion/cierre + `stageSequenceForProcessType()` da la secuencia correcta por tipo. 21/21 tests. Hueco #2 de activación del botón 🌳.

🤖 Generated with [Claude Code](https://claude.com/claude-code)