### PR TITLE
fix(hoy): etiquetas de etapas de restauración en Hoy en finca

### DIFF
--- a/src/services/hoyEnFincaService.js
+++ b/src/services/hoyEnFincaService.js
@@ -35,6 +35,12 @@ export const STAGE_LABELS = Object.freeze({
   fruiting: 'Echando fruto',
   harvest_window: 'Cosecha',
   closed: 'Ciclo cerrado',
+  // Restauración/silvopastoreo (no fenología de cultivo): hitos propios.
+  establecimiento: 'Establecimiento',
+  prendimiento: 'Prendimiento',
+  mantenimiento: 'Mantenimiento',
+  monitoreo_sucesion: 'Monitoreo de sucesión',
+  cierre: 'Cierre',
 });
 
 export const STAGE_EMOJIS = Object.freeze({
@@ -45,6 +51,12 @@ export const STAGE_EMOJIS = Object.freeze({
   fruiting: '🍎',
   harvest_window: '🧺',
   closed: '🏁',
+  // Restauración/silvopastoreo.
+  establecimiento: '🌱',
+  prendimiento: '🌿',
+  mantenimiento: '🪴',
+  monitoreo_sucesion: '🌳',
+  cierre: '🏞️',
 });
 
 /**


### PR DESCRIPTION
Cierra la integración de Daniel: hoyEnFincaService solo tenía labels de fenología de cultivo, así que una reforestación (#1514) mostraba el código crudo 'prendimiento'. Agrega labels+emojis de las etapas de restauración. Cero fabricación de tareas — solo el display de la etapa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)