### PR TITLE
fix(sidecar): coerce altitud_msnm a number en callTool (P0 Daniel)

### DIFF
--- a/src/services/__tests__/sidecarClient.coerce.test.js
+++ b/src/services/__tests__/sidecarClient.coerce.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { coerceNumericArgs } from '../sidecarClient';
+
+// Fix P0 (test integral Daniel 2026-06-13): el sidecar (Zod) espera number en
+// altitud_msnm; el chat LLM lo pasaba como string → 502 → Daniel sin respuesta.
+describe('coerceNumericArgs', () => {
+  it('coerce altitud_msnm string a number', () => {
+    expect(coerceNumericArgs({ objetivo: 'ribera', altitud_msnm: '2600' }))
+      .toEqual({ objetivo: 'ribera', altitud_msnm: 2600 });
+  });
+
+  it('deja un number intacto (misma referencia, sin cambios)', () => {
+    const a = { altitud_msnm: 2600 };
+    expect(coerceNumericArgs(a)).toBe(a);
+  });
+
+  it('elimina string no numérico (no manda basura al sidecar)', () => {
+    expect(coerceNumericArgs({ altitud_msnm: 'alto' })).toEqual({});
+  });
+
+  it('coerce también altitud y altura', () => {
+    expect(coerceNumericArgs({ altitud: '1800', altura: '50' }))
+      .toEqual({ altitud: 1800, altura: 50 });
+  });
+
+  it('args no-objeto pasa intacto', () => {
+    expect(coerceNumericArgs(null)).toBe(null);
+    expect(coerceNumericArgs(undefined)).toBe(undefined);
+  });
+
+  it('no toca otros campos', () => {
+    expect(coerceNumericArgs({ objetivo: 'ribera', altitud_msnm: '2600', invasora_mencionada: 'retamo' }))
+      .toEqual({ objetivo: 'ribera', altitud_msnm: 2600, invasora_mencionada: 'retamo' });
+  });
+});

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -486,13 +486,35 @@ export async function postValidate(text, expected) {
  * @param {object} args — body raw (forma específica por tool)
  * @returns {Promise<null | object | ToolError>}
  */
+/**
+ * Coerción defensiva de argumentos numéricos. El sidecar (Zod) espera `number`
+ * en argumentos como `altitud_msnm`; el chat LLM a veces los genera como string
+ * → el sidecar respondía 502 (invalid_type) y Daniel recibía respuesta vacía.
+ * Coercionamos en el chokepoint para que TODO caller (chat LLM, chips, plan
+ * determinístico) sea robusto. Fix P0 — test integral Daniel 2026-06-13.
+ */
+const NUMERIC_TOOL_ARGS = new Set(['altitud_msnm', 'altitud', 'altura']);
+export function coerceNumericArgs(args) {
+  if (!args || typeof args !== 'object') return args;
+  let changed = false;
+  const out = { ...args };
+  for (const k of NUMERIC_TOOL_ARGS) {
+    if (typeof out[k] === 'string' && out[k].trim() !== '') {
+      const n = Number(out[k]);
+      if (Number.isFinite(n)) out[k] = n; else delete out[k];
+      changed = true;
+    }
+  }
+  return changed ? out : args;
+}
+
 export async function callTool(toolName, args) {
   if (!toolName || typeof toolName !== 'string') return null;
   if (!ALLOWED_TOOLS.has(toolName)) {
     console.debug('[sidecar] tool no permitido', toolName);
     return { _error: true, reason: 'not_allowed', tool: toolName };
   }
-  const result = await postJson(`/tools/${toolName}`, args || {}, TOOL_TIMEOUT_MS);
+  const result = await postJson(`/tools/${toolName}`, coerceNumericArgs(args || {}), TOOL_TIMEOUT_MS);
   if (result !== null) return result;
   // postJson retornó null. Distinguir: tool fue intentado pero falló
   // (timeout / HTTP error / network) vs. ni siquiera se intentó (flag off / offline).


### PR DESCRIPTION
Test integral encontró que get_diseno_restauracion daba 502: el chat LLM pasaba altitud_msnm como string y el sidecar (Zod) espera number → Daniel sin respuesta. coerceNumericArgs() coacciona en el chokepoint callTool. Desbloquea el botón de reforestación. 6 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)