### PR TITLE
feat(evolution): tarjeta FincaEvolutionCard para Hoy en finca

### DIFF
--- a/src/components/hoy/FincaEvolutionCard.jsx
+++ b/src/components/hoy/FincaEvolutionCard.jsx
@@ -1,0 +1,119 @@
+import { useMemo } from 'react';
+import { TrendingUp, Info } from 'lucide-react';
+import { evaluarEvolucionFinca, getGliessmanLabel } from '../../services/fincaEvolutionService';
+import indicatorsData from '../../data/agroecology-indicators.json';
+
+/**
+ * FincaEvolutionCard — tarjeta 'Como evoluciona tu finca' para Hoy en finca.
+ *
+ * Muestra el nivel de Gliessman (0-4) como subtítulo y los 5 atributos MESMIS
+ * como barras horizontales. Consume evaluarEvolucionFinca({processes, observations})
+ * y las etiquetas de agroecology-indicators.json. Cero fabricación: si no hay
+ * datos para un indicador → 'sin datos aun', NUNCA muestra 0.
+ *
+ * @param {Object} props
+ * @param {Array} props.processes - procesos de finca (requerido)
+ * @param {Array} props.observations - observaciones (opcional, default [])
+ * @param {Function} props.onNavigate - callback para navegación (opcional)
+ */
+export default function FincaEvolutionCard({ processes = [], observations = [], onNavigate }) {
+  // Obtener etiquetas MESMIS desde el JSON
+  const mesmisLabels = useMemo(() => {
+    return indicatorsData.mesmis_5_atributos.reduce((acc, item) => {
+      acc[item.id] = item.nombre;
+      return acc;
+    }, {});
+  }, []);
+
+  // Calcular evolución de la finca
+  const evolution = useMemo(() => {
+    return evaluarEvolucionFinca({ processes, observations });
+  }, [processes, observations]);
+
+  // Obtener label del nivel Gliessman
+  const gliessmanLabel = useMemo(() => {
+    return getGliessmanLabel(evolution.nivelGliessman);
+  }, [evolution.nivelGliessman]);
+
+  // Renderizar barra horizontal para un atributo MESMIS
+  const renderMesmisBar = (key, score) => {
+    const label = mesmisLabels[key] || key;
+    const hasData = score !== null && score !== undefined;
+
+    return (
+      <div key={key} className="mb-2 last:mb-0">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-medium text-slate-300">{label}</span>
+          <span className="text-xs font-bold text-emerald-300">
+            {hasData ? `${score}/4` : 'sin datos aun'}
+          </span>
+        </div>
+        <div className="h-2 bg-slate-800/50 rounded-full overflow-hidden">
+          {hasData ? (
+            <div
+              className="h-full bg-gradient-to-r from-emerald-600 to-emerald-400 rounded-full transition-all duration-500"
+              style={{ width: `${(score / 4) * 100}%` }}
+              aria-label={`${label}: ${score} de 4`}
+            />
+          ) : (
+            <div
+              className="h-full bg-slate-700/30 rounded-full"
+              aria-label={`${label}: sin datos`}
+            />
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <section
+      data-testid="finca-evolution-card"
+      className="bg-gradient-to-br from-slate-900/80 to-slate-800/70 backdrop-blur-xl border border-slate-700/40 rounded-2xl p-4"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <TrendingUp size={20} className="text-emerald-300" aria-hidden="true" />
+          <h3 className="text-base font-bold text-white">Cómo evoluciona tu finca</h3>
+        </div>
+        <button
+          type="button"
+          onClick={() => onNavigate?.('evolucion')}
+          aria-label="Ver más sobre evolución de finca"
+          className="text-xs text-emerald-300/70 hover:text-emerald-300 underline decoration-dotted underline-offset-2"
+        >
+          ¿Qué es esto?
+        </button>
+      </div>
+
+      {/* Nivel Gliessman */}
+      <div className="mb-3 pb-3 border-b border-slate-700/40">
+        <p className="text-sm text-slate-400 mb-1">Nivel de transición agroecológica</p>
+        <p className="text-lg font-bold text-emerald-300">{gliessmanLabel}</p>
+      </div>
+
+      {/* Barras MESMIS */}
+      <div className="mb-3">
+        <p className="text-xs font-bold text-slate-400 uppercase tracking-wide mb-2">
+          Indicadores de sustentabilidad
+        </p>
+        {renderMesmisBar('productividad', evolution.mesmis.productividad)}
+        {renderMesmisBar('estabilidad_resiliencia', evolution.mesmis.estabilidad_resiliencia)}
+        {renderMesmisBar('adaptabilidad', evolution.mesmis.adaptabilidad)}
+        {renderMesmisBar('equidad', evolution.mesmis.equidad)}
+        {renderMesmisBar('autodependencia', evolution.mesmis.autodependencia)}
+      </div>
+
+      {/* Footer informativo */}
+      <div className="flex items-start gap-2 pt-2 border-t border-slate-700/40">
+        <Info size={14} className="text-slate-500 shrink-0 mt-0.5" aria-hidden="true" />
+        <p className="text-xs text-slate-500 leading-relaxed">
+          Estos indicadores miden qué tan sano está tu sistema productivo. A medida
+          que registras cosechas, observaciones y prácticas, Chagra aprende sobre tu
+          finca y te muestra cómo evolucionas hacia la agroecología.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/hoy/__tests__/FincaEvolutionCard.test.jsx
+++ b/src/components/hoy/__tests__/FincaEvolutionCard.test.jsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FincaEvolutionCard from '../FincaEvolutionCard';
+
+describe('FincaEvolutionCard', () => {
+  beforeEach(() => {
+    // Limpiar cualquier estado previo
+    vi.clearAllMocks();
+  });
+
+  it('muestra el título "Cómo evoluciona tu finca"', () => {
+    render(<FincaEvolutionCard processes={[]} />);
+    expect(screen.getByText('Cómo evoluciona tu finca')).toBeTruthy();
+  });
+
+  it('maneja todos los scores null sin romper (sin datos aun)', () => {
+    render(<FincaEvolutionCard processes={[]} observations={[]} />);
+    
+    // Debería mostrar las barras con "sin datos aun"
+    expect(screen.getAllByText('sin datos aun').length).toBe(5);
+    
+    // El nivel Gliessman debería ser "0. Convencional (monocultivo)"
+    expect(screen.getByText(/0\. Convencional/)).toBeTruthy();
+  });
+
+  it('muestra scores cuando hay datos de procesos', () => {
+    const processesWithHarvests = [
+      {
+        process_id: 'p1',
+        process_type: 'sowing',
+        status: 'active',
+        current_stage: 'vegetative',
+        subject_slug: 'caffea_arabica',
+        events: [
+          {
+            event_type: 'harvest_confirmed',
+            payload: { quantity: 100 }
+          }
+        ]
+      },
+      {
+        process_id: 'p2',
+        process_type: 'sowing',
+        status: 'active',
+        current_stage: 'flowering',
+        subject_slug: 'theobroma_cacao',
+        events: [
+          {
+            event_type: 'harvest_confirmed',
+            payload: { quantity: 50 }
+          }
+        ]
+      }
+    ];
+
+    render(<FincaEvolutionCard processes={processesWithHarvests} />);
+    
+    // Debería mostrar el título
+    expect(screen.getByText('Cómo evoluciona tu finca')).toBeTruthy();
+    
+    // Debería mostrar algún score numérico (no todos "sin datos aun")
+    const sinDatosTexts = screen.getAllByText('sin datos aun');
+    expect(sinDatosTexts.length).toBeLessThan(5);
+  });
+
+  it('muestra el nivel Gliessman correcto', () => {
+    render(<FincaEvolutionCard processes={[]} />);
+    
+    // Nivel Gliessman 0 es el default sin datos
+    expect(screen.getByText(/0\. Convencional \(monocultivo\)/)).toBeTruthy();
+  });
+
+  it('renderiza todas las barras MESMIS', () => {
+    render(<FincaEvolutionCard processes={[]} />);
+    
+    // Verificar que las etiquetas MESMIS estén presentes
+    expect(screen.getByText('Productividad')).toBeTruthy();
+    expect(screen.getByText('Estabilidad y resiliencia')).toBeTruthy();
+    expect(screen.getByText('Adaptabilidad')).toBeTruthy();
+    expect(screen.getByText('Equidad')).toBeTruthy();
+    expect(screen.getByText('Autodependencia')).toBeTruthy();
+  });
+
+  it('muestra el texto informativo sobre los indicadores', () => {
+    render(<FincaEvolutionCard processes={[]} />);
+    
+    expect(screen.getByText(/Estos indicadores miden qué tan sano está tu sistema productivo/)).toBeTruthy();
+  });
+
+  it('no rompe con observations vacío', () => {
+    render(<FincaEvolutionCard processes={[]} observations={[]} />);
+    
+    expect(screen.getByText('Cómo evoluciona tu finca')).toBeTruthy();
+    expect(screen.getByText(/0\. Convencional/)).toBeTruthy();
+  });
+
+  it('maneja onNavigate opcional sin errores', () => {
+    const onNavigate = vi.fn();
+    render(<FincaEvolutionCard processes={[]} onNavigate={onNavigate} />);
+    
+    // El botón de "¿Qué es esto?" debería llamar onNavigate
+    const queEsButton = screen.getByLabelText('Ver más sobre evolución de finca');
+    queEsButton.click();
+    
+    expect(onNavigate).toHaveBeenCalledWith('evolucion');
+  });
+});


### PR DESCRIPTION
## Summary

Crea la tarjeta `FincaEvolutionCard` para la sección "Hoy en finca", que muestra la evolución agroecológica de la finca usando indicadores MESMIS y el nivel de Gliessman.

## Cambios

- **Nuevo componente**: `src/components/hoy/FincaEvolutionCard.jsx`
  - Consume `fincaEvolutionService.evaluarEvolucionFinca({processes, observations})`
  - Muestra nivel de Gliessman (0-4) como subtítulo
  - Muestra 5 atributos MESMIS como barras horizontales (más accesible que radar)
  - Usa etiquetas de `src/data/agroecology-indicators.json`
  - Estilo coherente con `JourneyGuideCard.jsx` (tailwind dark, rounded-2xl, aria)
  - Español campesino, CERO fabricación (null = 'sin datos aun')

- **Tests**: `src/components/hoy/__tests__/FincaEvolutionCard.test.jsx`
  - Verifica título presente
  - Maneja todos-null sin romper
  - Muestra scores cuando hay datos
  - Verifica renderizado de barras MESMIS
  - Prueba onNavigate opcional

## Test plan

✅ Tests vitest: 8/8 passing
```
npx vitest run src/components/hoy/__tests__/FincaEvolutionCard.test.jsx
Test Files  1 passed (1)
     Tests  8 passed (8)
```

✅ ESLint clean: `npx eslint src/components/hoy/FincaEvolutionCard.jsx --max-warnings=0`

✅ Build OK: `npm run build` - built in 4.11s

## Riesgos conocidos

- Ninguno. El componente está aislado y no afecta código existente.
- El servicio `fincaEvolutionService` ya está probado y en producción.
- Tests cubren edge cases (null/empty arrays).

## Notas para revisión

- Siguió el patrón de `JourneyGuideCard.jsx` para consistencia.
- No se mencionan stakeholders ni decisiones políticas (solo código).
- Solo se agregaron 2 archivos específicos al commit (NO node_modules ni dist).