### PR TITLE
fix(offline): precachear bundle de arranque en el SW + guard offline del agente

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -7,7 +7,11 @@ const ASSETS_TO_CACHE = [
   '/favicon.svg',
   '/icon-180.png',
   '/icon-192.png',
-  '/icon-512.png'
+  '/icon-512.png',
+  // Catálogo de especies (sqlite-wasm). Precacheado para que el catálogo sea
+  // consultable OFFLINE aunque el usuario nunca haya abierto una vista que lo
+  // cargue estando online. ~1.2 MB; aceptable para garantizar offline-first.
+  '/catalog.sqlite'
 ];
 
 // Instalación del Service Worker.
@@ -21,7 +25,37 @@ const ASSETS_TO_CACHE = [
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(ASSETS_TO_CACHE))
+      .then(async (cache) => {
+        // 1) Shell estático (HTML/manifest/icons/catálogo). add por item (no
+        //    addAll atómico) para que un 404 transitorio de un asset opcional
+        //    (ej. /catalog.sqlite) no aborte el precache completo del shell.
+        await Promise.all(
+          ASSETS_TO_CACHE.map((u) => cache.add(u).catch(() => undefined))
+        );
+        // 2) Bundle de arranque: parseamos index.html para descubrir los chunks
+        //    de entrada hasheados (`/assets/index-*.js`, rolldown-runtime,
+        //    vendor-react/state, css) y los precacheamos. Sin esto, una recarga
+        //    OFFLINE en frío no podía bootear React (los <script> de /assets/*
+        //    daban ERR_INTERNET_DISCONNECTED). El resto de chunks lazy se cachea
+        //    on-demand vía la estrategia cache-first del handler de fetch.
+        try {
+          const res = await fetch('/index.html', { cache: 'no-store' });
+          if (res && res.ok) {
+            const html = await res.text();
+            const assetRe = /\/assets\/[A-Za-z0-9._-]+\.(?:js|css)/g;
+            const found = Array.from(new Set(html.match(assetRe) || []));
+            // addAll es atómico (falla todo si uno falla); usamos add por chunk
+            // para que un 404 transitorio de un chunk no aborte el precache del
+            // resto del bundle de arranque.
+            await Promise.all(
+              found.map((u) => cache.add(u).catch(() => undefined))
+            );
+          }
+        } catch {
+          // Sin red en el install (raro): el shell quedó cacheado igual; los
+          // chunks se llenarán cache-first en la primera carga online.
+        }
+      })
   );
 });
 
@@ -68,9 +102,44 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // PASSTHROUGH para chunks hasheados de Vite. NO interceptar.
-  if (url.pathname.startsWith('/assets/')) {
-    return; // browser maneja directamente
+  // Chunks hasheados de Vite (`/assets/index-XXXX.js`, vendors, lazy chunks,
+  // CSS): CACHE-FIRST con relleno en background.
+  //
+  // ANTES esto era PASSTHROUGH puro (return; sin cachear). Consecuencia: en una
+  // recarga OFFLINE el shell `/index.html` cargaba del cache, pero TODOS los
+  // <script>/<link> que referencia apuntan a `/assets/*` → el browser intenta
+  // bajarlos de la red → `net::ERR_INTERNET_DISCONNECTED` → React NUNCA monta →
+  // pantalla en blanco / splash colgado. La PWA NO arrancaba offline en frío.
+  // (Evidencia E2E offline-first 2026-06-13: 0/113 chunks cacheados; reload
+  // offline = blank. El guard offline del agente quedaba además inalcanzable
+  // porque su chunk lazy tampoco se cacheaba.)
+  //
+  // El motivo histórico del passthrough (servir chunks viejos tras deploy →
+  // 404 → white screen, incidente 2026-05-06) NO aplica con cache-first sobre
+  // filenames inmutables: cada deploy genera hashes nuevos, el HTML fresco
+  // (Network-First más abajo) referencia los nuevos, y el `activate` borra el
+  // cache viejo entero al bumpear CACHE_NAME (chagra-<sha> por deploy). Un chunk
+  // cacheado solo se sirve si su URL exacta (con hash) sigue referenciada.
+  if (url.pathname.startsWith('/assets/') && event.request.method === 'GET') {
+    event.respondWith(
+      caches.match(event.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(event.request)
+          .then((response) => {
+            // Solo cacheamos respuestas completas y válidas (no opaque/parcial).
+            if (response && response.ok && response.status === 200) {
+              const respClone = response.clone();
+              caches.open(CACHE_NAME).then((cache) => cache.put(event.request, respClone));
+            }
+            return response;
+          })
+          // Offline y sin cache: devolvemos un 504 explícito en vez de dejar
+          // que el browser tire ERR_INTERNET_DISCONNECTED silencioso. El chunk
+          // ya cacheado (caso normal tras una visita online) sí se sirve arriba.
+          .catch(() => new Response('', { status: 504, statusText: 'Offline: chunk no cacheado' }));
+      })
+    );
+    return;
   }
 
   // HTML shell (documento navegable: `/`, `/index.html`, o cualquier navegación

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import { cropAlertEngine } from './services/cropAlertEngine';
 // comentario abajo donde se removió el render).
 // import FieldFeedback from './components/FieldFeedback';
 import AgentFab from './components/AgentFab';
+import AgentOfflineGuard from './components/AgentScreen/AgentOfflineGuard';
 import { ScreenShell } from './components/common/ScreenShell';
 import ChagraGrowLoader from './components/ChagraGrowLoader';
 import Confetti from './components/common/Confetti';
@@ -360,6 +361,23 @@ export default function App() {
   // Solo activos post-login (no en loading ni login para no atrapar shift+?
   // accidental al escribir password).
   const [currentView, setCurrentView] = useState('loading');
+  // Estado online reactivo: usado para mostrar el aviso offline del agente
+  // ANTES de intentar el dynamic import de AgentScreen (ver `case 'agente'`).
+  // Sin esto, abrir el agente offline con su chunk no cacheado caía en el
+  // ErrorBoundary genérico y el guard offline real quedaba inalcanzable.
+  const [isAppOnline, setIsAppOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
+  useEffect(() => {
+    const goOnline = () => setIsAppOnline(true);
+    const goOffline = () => setIsAppOnline(false);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
   useGlobalKeyboardShortcuts({ enabled: currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' });
   const [currentViewData, setCurrentViewData] = useState(null);
   const [toast, setToast] = useState(null);
@@ -861,6 +879,20 @@ export default function App() {
           </ErrorBoundary>
         );
       case 'agente':
+        // Guard offline ANTES del dynamic import (bug offline-first 2026-06-13):
+        // AgentScreen es un chunk lazy. Si se abre el agente OFFLINE con ese
+        // chunk no cacheado por el SW, el import() falla → ErrorBoundary genérico
+        // ("Algo falló") y el guard offline real (ollamaStream) queda
+        // inalcanzable porque el componente nunca monta. Chequear navigator.onLine
+        // acá deja ver el aviso claro ("el asistente necesita internet; tus datos
+        // sí funcionan sin conexión") aunque el chunk no esté disponible.
+        if (!isAppOnline) {
+          return (
+            <ErrorBoundary>
+              <AgentOfflineGuard onBack={() => navigate('dashboard')} />
+            </ErrorBoundary>
+          );
+        }
         // 2026-05-28: pasamos currentViewData como initialContext para que
         // notificaciones críticas (helada, alerta clima) lleguen al agente
         // con prompt pre-cargado + cita de la fuente (IDEAM/NOAA/CIIFEN/

--- a/src/components/AgentScreen/AgentOfflineGuard.jsx
+++ b/src/components/AgentScreen/AgentOfflineGuard.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { WifiOff, ArrowLeft } from 'lucide-react';
+
+/**
+ * AgentOfflineGuard — pantalla de aviso claro cuando se intenta abrir el agente
+ * IA sin conexión.
+ *
+ * POR QUÉ EXISTE (bug offline-first 2026-06-13):
+ * AgentScreen es un chunk lazy (`lazy(() => import('./AgentScreen'))`). Si el
+ * usuario abre el agente OFFLINE y ese chunk nunca se cargó online (no estaba en
+ * el SW precache), el `import()` dinámico falla → el <Suspense>/ErrorBoundary
+ * captura un ChunkLoadError genérico ("Algo falló / Este módulo tuvo un error
+ * inesperado"). El guard offline real (en ollamaStream.js / AgentScreen) queda
+ * INALCANZABLE porque el componente nunca llega a montar.
+ *
+ * Solución: chequear `navigator.onLine` ANTES del dynamic import, en el routing
+ * de App. Si está offline, renderizamos este aviso honesto y específico para el
+ * campesino ("el asistente necesita internet; tus datos sí funcionan sin
+ * conexión") en vez de un error técnico confuso o una pantalla en blanco.
+ *
+ * Es un componente estático (no lazy) → siempre disponible offline.
+ */
+export default function AgentOfflineGuard({ onBack }) {
+  return (
+    <div className="h-[100dvh] w-full bg-slate-950 flex items-center justify-center p-6">
+      <div className="w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl p-6 space-y-5 shadow-2xl">
+        <div className="flex items-center gap-3">
+          <div className="w-12 h-12 bg-amber-900/50 rounded-full flex items-center justify-center shrink-0">
+            <WifiOff size={24} className="text-amber-400" aria-hidden="true" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-lg font-bold text-white">Sin conexión a internet</h2>
+            <p className="text-sm text-slate-400 mt-1">El asistente IA necesita internet</p>
+          </div>
+        </div>
+
+        <div className="p-4 bg-slate-800 rounded-xl border border-slate-700">
+          <p className="text-sm text-slate-300 leading-relaxed">
+            El asistente conversacional necesita conexión a internet para responder.
+            Conéctate y vuelve a intentarlo.
+          </p>
+          <p className="text-sm text-emerald-300 leading-relaxed mt-3">
+            Tus datos de la finca (siembras, zonas, tareas, bitácora y el catálogo
+            de especies) <span className="font-bold">sí funcionan sin conexión</span>.
+            Lo que registres ahora se guarda en tu teléfono y se sincroniza cuando
+            vuelvas a tener internet.
+          </p>
+        </div>
+
+        <button
+          onClick={onBack}
+          className="w-full py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-bold rounded-xl transition-colors text-sm flex items-center justify-center gap-2"
+        >
+          <ArrowLeft size={16} aria-hidden="true" />
+          Volver a la finca
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AgentScreen/__tests__/AgentOfflineGuard.test.jsx
+++ b/src/components/AgentScreen/__tests__/AgentOfflineGuard.test.jsx
@@ -1,0 +1,37 @@
+/**
+ * AgentOfflineGuard.test.jsx — el aviso claro de offline del agente.
+ *
+ * Bug offline-first 2026-06-13: abrir el agente OFFLINE con su chunk lazy no
+ * cacheado caía en el ErrorBoundary genérico ("Algo falló") en vez de avisar
+ * que el asistente necesita internet. El guard ahora se renderiza ANTES del
+ * dynamic import. Este test verifica que el mensaje es claro y específico.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AgentOfflineGuard from '../AgentOfflineGuard';
+
+describe('AgentOfflineGuard', () => {
+  it('muestra aviso CLARO de que el asistente necesita internet', () => {
+    render(<AgentOfflineGuard onBack={() => {}} />);
+    expect(screen.getByText(/sin conexión a internet/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/necesita.*internet/i).length).toBeGreaterThan(0);
+  });
+
+  it('aclara que los datos de la finca SÍ funcionan sin conexión', () => {
+    render(<AgentOfflineGuard onBack={() => {}} />);
+    expect(screen.getByText(/sí funcionan sin conexión/i)).toBeInTheDocument();
+  });
+
+  it('NO muestra el error técnico genérico del ErrorBoundary', () => {
+    render(<AgentOfflineGuard onBack={() => {}} />);
+    expect(screen.queryByText(/algo falló/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/módulo tuvo un error/i)).not.toBeInTheDocument();
+  });
+
+  it('el botón "Volver a la finca" invoca onBack', () => {
+    const onBack = vi.fn();
+    render(<AgentOfflineGuard onBack={onBack} />);
+    fireEvent.click(screen.getByText(/volver a la finca/i));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/__tests__/offlineContracts.test.js
+++ b/src/services/__tests__/offlineContracts.test.js
@@ -1,0 +1,82 @@
+/**
+ * offlineContracts.test.js — contrato OFFLINE de los servicios de Chagra.
+ *
+ * Garantía offline-first a nivel de servicio: con navigator.onLine=false, los
+ * servicios que dependen de red deben DEGRADAR a null / mensaje claro SIN
+ * lanzar excepciones no controladas y SIN colgarse esperando la red. Esto evita
+ * el síntoma "el agente/clima se queda pensando" y el "spinner infinito" que el
+ * usuario reportó offline (Lili/MinAmbiente 2026-06-11).
+ *
+ * Estos contratos corren en CI (vitest jsdom) y son baratos: stubean
+ * navigator.onLine y verifican el comportamiento de degradación, sin red real.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+function setOnline(value) {
+  Object.defineProperty(globalThis.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+describe('offline contracts — servicios degradan a null/mensaje sin throw', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setOnline(false);
+  });
+  afterEach(() => {
+    setOnline(true);
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs?.();
+  });
+
+  describe('ollamaStream (asistente IA)', () => {
+    it('offline → throw con mensaje CLARO de internet (no se cuelga esperando fetch)', async () => {
+      vi.mock('../llmTelemetryService', () => ({ recordLLMEvent: vi.fn() }));
+      const { streamOllama } = await import('../ollamaStream');
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await expect(
+        streamOllama('/api/ollama/api/generate', { model: 'granite3.3:8b', prompt: 'hola' }, () => {})
+      ).rejects.toThrow(/sin conexión|internet/i);
+
+      // El guard debe disparar ANTES de tocar la red: fetch no se llama.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('online → NO corta por el guard (intenta la red)', async () => {
+      vi.mock('../llmTelemetryService', () => ({ recordLLMEvent: vi.fn() }));
+      setOnline(true);
+      vi.resetModules();
+      const { streamOllama } = await import('../ollamaStream');
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+      // online: el guard NO debe abortar; el fetch sí se intenta (y falla por mock).
+      await expect(
+        streamOllama('/api/ollama/api/generate', { model: 'granite3.3:8b', prompt: 'hola' }, () => {})
+      ).rejects.toBeTruthy();
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('deepResearchClient (investigación profunda)', () => {
+    beforeEach(() => {
+      vi.stubEnv('VITE_DEEP_RESEARCH_ENABLED', 'true');
+    });
+
+    it('submitDeepResearch offline → null inmediato sin throw ni red', async () => {
+      const mod = await import('../deepResearchClient');
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const result = await mod.submitDeepResearch('¿qué siembro en junio?');
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('fetchDeepResearchStatus offline → null sin throw ni red', async () => {
+      const mod = await import('../deepResearchClient');
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const result = await mod.fetchDeepResearchStatus('job-123');
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/sw-offline-precache.test.js
+++ b/tests/unit/sw-offline-precache.test.js
@@ -1,0 +1,178 @@
+/**
+ * sw-offline-precache.test.js — contrato OFFLINE-FIRST del Service Worker.
+ *
+ * Regresión del bug offline-first 2026-06-13: el SW hacía PASSTHROUGH puro de
+ * `/assets/*` (return; sin cachear). Resultado: una recarga OFFLINE en frío no
+ * podía bootear React porque los chunks `/assets/index-*.js` daban
+ * ERR_INTERNET_DISCONNECTED → pantalla en blanco. La PWA no era offline-first.
+ *
+ * Este test carga el código real de `public/sw.js` en un entorno con
+ * `self`/`caches`/`fetch` simulados, dispara los eventos `install` y `fetch`, y
+ * verifica el CONTRATO:
+ *   1. install precachea el shell + parsea index.html y precachea el bundle de
+ *      arranque (`/assets/*.js`).
+ *   2. `/assets/*` se sirve CACHE-FIRST (desde cache, sin tocar red, offline).
+ *   3. estando offline y SIN cache, un `/assets/*` devuelve 504 explícito (no
+ *      cuelga el browser con ERR_INTERNET_DISCONNECTED silencioso).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const __dirnameLocal = path.dirname(fileURLToPath(import.meta.url));
+const SW_PATH = path.resolve(__dirnameLocal, '../../public/sw.js');
+
+// --- Fake Cache / CacheStorage ---------------------------------------------
+// `fetchImpl` se inyecta para que cache.add() use la MISMA red simulada que el
+// SW (no la fetch real de jsdom).
+function makeFakeCaches(getFetch) {
+  const stores = new Map(); // name -> Map<pathname, Response-like>
+  const keyOf = (req) => (typeof req === 'string' ? req : req.url);
+  const pathOf = (req) => new URL(keyOf(req), 'https://chagra.guatoc.co').pathname;
+  const cacheApi = (name) => {
+    if (!stores.has(name)) stores.set(name, new Map());
+    const m = stores.get(name);
+    return {
+      async add(req) {
+        const url = keyOf(req);
+        const res = await getFetch()(url);
+        if (res && res.ok) m.set(pathOf(url), { ok: true, status: 200, url, clone() { return this; } });
+      },
+      async addAll(reqs) { for (const r of reqs) await this.add(r); },
+      async put(req, res) { m.set(pathOf(req), res || { ok: true, status: 200, clone() { return this; } }); },
+      async match(req) { return m.get(pathOf(req)) || undefined; },
+      async keys() { return Array.from(m.keys()).map((p) => ({ url: 'https://chagra.guatoc.co' + p })); },
+    };
+  };
+  return {
+    _stores: stores,
+    async open(name) { return cacheApi(name); },
+    async keys() { return Array.from(stores.keys()); },
+    async delete(name) { return stores.delete(name); },
+    async match(req) {
+      for (const name of stores.keys()) {
+        const hit = await cacheApi(name).match(req);
+        if (hit) return hit;
+      }
+      return undefined;
+    },
+  };
+}
+
+// Carga sw.js dentro de un sandbox con globals controlados.
+function loadSW({ online = true, indexHtml, assetExists = () => true } = {}) {
+  const listeners = {};
+  let fetchImpl; // declarado antes para que makeFakeCaches lo use por closure.
+  const fakeCaches = makeFakeCaches(() => fetchImpl);
+
+  fetchImpl = vi.fn(async (input) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const pathname = new URL(url, 'https://x').pathname;
+    if (!online) {
+      // offline: la red falla, salvo lo que ya esté en cache (lo maneja el SW).
+      throw new TypeError('Failed to fetch');
+    }
+    if (pathname === '/index.html') {
+      return { ok: true, status: 200, async text() { return indexHtml; }, clone() { return this; } };
+    }
+    const exists = assetExists(pathname);
+    return { ok: exists, status: exists ? 200 : 404, url, clone() { return { ok: exists, status: this.status, url }; } };
+  });
+
+  const self = {
+    location: { origin: 'https://chagra.guatoc.co' },
+    addEventListener: (type, cb) => { listeners[type] = cb; },
+    skipWaiting: vi.fn(),
+    clients: { claim: vi.fn(async () => {}), matchAll: vi.fn(async () => []) },
+    registration: {},
+  };
+
+  const sandbox = {
+    self,
+    caches: fakeCaches,
+    fetch: fetchImpl,
+    Response: class FakeResponse {
+      constructor(body, init = {}) { this.body = body; this.status = init.status || 200; this.statusText = init.statusText || ''; this.ok = this.status >= 200 && this.status < 300; }
+    },
+    URL,
+    indexedDB: { open: () => ({}) },
+    Promise,
+    setTimeout,
+    Date,
+    console: { log() {}, warn() {}, error() {} },
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  const code = fs.readFileSync(SW_PATH, 'utf8');
+  vm.runInContext(code, sandbox);
+
+  return { listeners, fakeCaches, fetchImpl, self };
+}
+
+// Helper para disparar un evento con waitUntil/respondWith capturados.
+function fireEvent(cb, request) {
+  let waited = null;
+  let responded = null;
+  const event = {
+    request,
+    waitUntil: (p) => { waited = p; },
+    respondWith: (p) => { responded = p; },
+  };
+  cb(event);
+  return { waited, responded };
+}
+
+const SAMPLE_INDEX = `<!doctype html><html><head>
+  <link rel="modulepreload" href="/assets/vendor-react-B9O1K3VS.js">
+  <link rel="stylesheet" href="/assets/index-abc123.css">
+</head><body><div id="root"></div>
+  <script type="module" src="/assets/index-4wTCb2Bn.js"></script>
+</body></html>`;
+
+describe('SW offline-first precache (regresión 2026-06-13)', () => {
+  it('install precachea el shell Y el bundle de arranque (/assets/*) parseando index.html', async () => {
+    const { listeners, fakeCaches } = loadSW({ online: true, indexHtml: SAMPLE_INDEX });
+    expect(typeof listeners.install).toBe('function');
+    const { waited } = fireEvent(listeners.install, {});
+    await waited;
+
+    // Hubo algún cache poblado.
+    const names = await fakeCaches.keys();
+    expect(names.length).toBeGreaterThan(0);
+    const cache = await fakeCaches.open(names[0]);
+    const keys = (await cache.keys()).map((r) => new URL(r.url).pathname);
+
+    // Shell.
+    expect(keys).toContain('/index.html');
+    // Bundle de arranque descubierto en index.html.
+    expect(keys).toContain('/assets/index-4wTCb2Bn.js');
+    expect(keys).toContain('/assets/vendor-react-B9O1K3VS.js');
+    expect(keys).toContain('/assets/index-abc123.css');
+  });
+
+  it('/assets/* se sirve CACHE-FIRST (desde cache, sin red) cuando ya está cacheado', async () => {
+    const { listeners, fetchImpl } = loadSW({ online: true, indexHtml: SAMPLE_INDEX });
+    await fireEvent(listeners.install, {}).waited;
+
+    fetchImpl.mockClear();
+    const req = { url: 'https://chagra.guatoc.co/assets/index-4wTCb2Bn.js', method: 'GET' };
+    const { responded } = fireEvent(listeners.fetch, req);
+    const res = await responded;
+    expect(res).toBeTruthy();
+    expect(res.ok).toBe(true);
+    // No debió ir a la red: el chunk estaba en cache.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('offline + /assets/* NO cacheado → 504 explícito (no cuelga, no ERR silencioso)', async () => {
+    // Cargamos el SW offline y sin haber precacheado nada.
+    const { listeners } = loadSW({ online: false, indexHtml: SAMPLE_INDEX });
+    const req = { url: 'https://chagra.guatoc.co/assets/chunk-no-existe.js', method: 'GET' };
+    const { responded } = fireEvent(listeners.fetch, req);
+    const res = await responded;
+    expect(res).toBeTruthy();
+    expect(res.status).toBe(504);
+  });
+});


### PR DESCRIPTION
## Problema

**Chagra no arranca offline en frío.** El Service Worker (`public/sw.js`) precachea solo el shell (HTML + iconos) y hace **PASSTHROUGH puro de `/assets/*`** (los chunks JS/CSS de Vite, sin cachear). Una recarga sin conexión no puede bootear React: todos los `<script type="module">` (`index-*.js`, `vendor-react`, `rolldown-runtime`, …) fallan con `net::ERR_INTERNET_DISCONNECTED` → el `#pre-loader` 🌱 se queda pegado → pantalla en blanco.

El **guard offline del agente** (`ollamaStream.js`, PR #1487/#1507) existe pero es **inalcanzable** offline: `AgentScreen` es un chunk lazy que tampoco se precachea, su `import()` dinámico falla antes de montar y el usuario ve el `ErrorBoundary` genérico ("Algo falló") en vez del aviso claro de internet.

Evidencia E2E prod (antes): recarga offline = white screen con **28 fallos de chunks `/assets/*.js`**; abrir el agente offline = pantalla en blanco. Baseline: 1 PASS / 4 FAIL / 2 DEGRADADO / 1 N/A sobre 8 requisitos offline-first.

## Cambios

- **`public/sw.js`**: `/assets/*` pasa de PASSTHROUGH a **CACHE-FIRST** (sirve de cache offline; 504 explícito si offline y sin cache, en vez de `ERR_INTERNET_DISCONNECTED` silencioso). El `install` ahora **parsea `index.html` y precachea el bundle de arranque** (`/assets/*.{js,css}`). `/catalog.sqlite` añadido al precache del shell. Precache resiliente (add por item, no `addAll` atómico).
  - Seguro vs el bug histórico de stale-chunk (2026-05-06): filenames inmutables con hash + `activate` borra el cache viejo entero al bumpear `CACHE_NAME` (`chagra-<sha>` por deploy) + el HTML sigue Network-First.
- **`src/App.jsx`**: guard `navigator.onLine` reactivo **ANTES** del dynamic import de `AgentScreen` (`case 'agente'`) → renderiza `<AgentOfflineGuard/>` offline.
- **`src/components/AgentScreen/AgentOfflineGuard.jsx`**: componente **estático** (no lazy, siempre disponible offline) con aviso claro: "el asistente necesita internet; tus datos de la finca sí funcionan sin conexión".

## Tests (vitest, corren en CI)

- `tests/unit/sw-offline-precache.test.js` — contrato del SW: precache de arranque parseando index.html, cache-first de `/assets/*`, 504 offline.
- `src/services/__tests__/offlineContracts.test.js` — los servicios degradan a null/mensaje **sin throw** con `navigator.onLine=false` (ollamaStream lanza mensaje claro sin tocar red; deepResearchClient → null).
- `src/components/AgentScreen/__tests__/AgentOfflineGuard.test.jsx` — el aviso claro renderiza + `onBack`.

## Verificación E2E del fix

Sobre `dist/` construido + servidor estático con MIME correcto (representativo de nginx en prod):
- Recarga offline en frío → **React monta** (`booted:true`), **0 fallos de chunks js/css**, muestra "Sin conexión. Datos guardados localmente. / Offline-First activo".
- Navegación offline (`#agente`/`#hoy`/`#activos`/Home) → **0 white screens, 0 pageErrors**.
- SW online precachea **34 chunks `/assets/*`** (incl. `index-*`, `vendor-react`).

Prueba reusable: `chagra-pw-suite/offline-first.mjs` (8 requisitos R1..R8).

## Fuera de alcance (documentado, requiere decisión de producto)

- Precache de chunks lazy NO de arranque (Mapa, PDFs, AgentScreen): quedan cache-first on-demand (se cachean al visitarlos online).
- Agente realmente offline (LLM on-device): requiere feature mayor; este PR solo entrega el aviso honesto.
- Migrar el merge-gate `tests/offline.spec.js` a correr contra `dist/` servido estático (hoy corre contra dev server y pre-carga módulos online, por eso era ciego a este bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)