### PR TITLE
fix(agent): presupuesto separado para el primer token (mata el 'Tiempo agotado' frecuente)

### DIFF
--- a/src/services/__tests__/streamDeadline.firstToken.test.js
+++ b/src/services/__tests__/streamDeadline.firstToken.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createStreamDeadline,
+  FIRST_TOKEN_TIMEOUT_MS,
+  IDLE_TIMEOUT_MS,
+  HARD_CEILING_MS,
+} from '../streamDeadline';
+
+// Fix 2026-06-13: el idle de 40s abortaba ANTES del primer token (95-151s bajo
+// carga) → "Tiempo agotado". Ahora el primer token tiene presupuesto separado.
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('streamDeadline — presupuesto del primer token', () => {
+  it('NO aborta esperando el primer token aunque pase el idle (40s)', () => {
+    const onTimeout = vi.fn();
+    const d = createStreamDeadline({ onTimeout });
+    d.start();
+    vi.advanceTimersByTime(IDLE_TIMEOUT_MS + 5000); // 45s: > idle, < firstToken
+    expect(onTimeout).not.toHaveBeenCalled();
+    d.stop();
+  });
+
+  it('aborta con "first_token" si el primer token nunca llega', () => {
+    const onTimeout = vi.fn();
+    const d = createStreamDeadline({ onTimeout });
+    d.start();
+    vi.advanceTimersByTime(FIRST_TOKEN_TIMEOUT_MS + 1000);
+    expect(onTimeout).toHaveBeenCalledWith('first_token');
+  });
+
+  it('tras el primer token aplica el idle de 40s entre tokens', () => {
+    const onTimeout = vi.fn();
+    const d = createStreamDeadline({ onTimeout });
+    d.start();
+    vi.advanceTimersByTime(60000); // 60s sin token: ok (< firstToken)
+    d.onToken();                    // primer token a los 60s → cambia a idle
+    vi.advanceTimersByTime(IDLE_TIMEOUT_MS + 1000); // gap > idle
+    expect(onTimeout).toHaveBeenCalledWith('idle');
+  });
+
+  it('el techo absoluto dispara aunque sigan llegando tokens', () => {
+    const onTimeout = vi.fn();
+    const d = createStreamDeadline({ onTimeout });
+    d.start();
+    for (let t = 0; t < HARD_CEILING_MS + 10000; t += 10000) {
+      vi.advanceTimersByTime(10000);
+      d.onToken();
+    }
+    expect(onTimeout).toHaveBeenCalledWith('ceiling');
+  });
+});

--- a/src/services/__tests__/streamDeadline.test.js
+++ b/src/services/__tests__/streamDeadline.test.js
@@ -20,6 +20,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   createStreamDeadline,
   IDLE_TIMEOUT_MS,
+  FIRST_TOKEN_TIMEOUT_MS,
   HARD_CEILING_MS,
 } from '../streamDeadline.js';
 
@@ -30,11 +31,11 @@ describe('streamDeadline — constantes de política', () => {
     expect(IDLE_TIMEOUT_MS).toBeGreaterThanOrEqual(35000);
   });
 
-  it('techo absoluto es generoso pero NO infinito (entre 60s y 180s)', () => {
-    // Backstop extremo: una respuesta sana termina mucho antes. NO debe cortar
-    // streams que avanzan, pero evita colgar la UI para siempre.
-    expect(HARD_CEILING_MS).toBeGreaterThanOrEqual(60000);
-    expect(HARD_CEILING_MS).toBeLessThanOrEqual(180000);
+  it('techo absoluto es generoso pero NO infinito (entre 120s y 360s)', () => {
+    // Backstop extremo subido a 300s: tolera respuestas largas bajo contención
+    // de GPU única sin colgar la UI para siempre.
+    expect(HARD_CEILING_MS).toBeGreaterThanOrEqual(120000);
+    expect(HARD_CEILING_MS).toBeLessThanOrEqual(360000);
   });
 
   it('el techo absoluto es estrictamente mayor que el idle-timeout', () => {
@@ -51,13 +52,13 @@ describe('streamDeadline — comportamiento idle (no abortar mientras streamea)'
     vi.useRealTimers();
   });
 
-  it('aborta si NUNCA llega un token y pasa el idle-timeout', () => {
+  it('aborta con "first_token" si NUNCA llega un token y pasa el presupuesto del primer token', () => {
     const onTimeout = vi.fn();
-    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 5000, onTimeout });
+    const dl = createStreamDeadline({ firstTokenMs: 1000, idleMs: 1000, ceilingMs: 5000, onTimeout });
     dl.start();
     vi.advanceTimersByTime(1000);
     expect(onTimeout).toHaveBeenCalledTimes(1);
-    expect(onTimeout).toHaveBeenCalledWith('idle');
+    expect(onTimeout).toHaveBeenCalledWith('first_token');
     dl.stop();
   });
 
@@ -184,23 +185,23 @@ describe('streamDeadline — ciclo de vida y limpieza', () => {
     dl.stop();
   });
 
-  it('usa los defaults de política si no se pasan idleMs/ceilingMs', () => {
+  it('usa los defaults: antes del primer token el presupuesto es FIRST_TOKEN_TIMEOUT_MS (el idle de 40s ya no aborta)', () => {
     const onTimeout = vi.fn();
     const dl = createStreamDeadline({ onTimeout });
     dl.start();
-    // Antes del idle-timeout default no dispara nada.
-    vi.advanceTimersByTime(IDLE_TIMEOUT_MS - 1);
+    // El idle (40s) ya NO aborta antes del primer token; hay que pasar firstToken.
+    vi.advanceTimersByTime(FIRST_TOKEN_TIMEOUT_MS - 1);
     expect(onTimeout).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
-    expect(onTimeout).toHaveBeenCalledWith('idle');
+    expect(onTimeout).toHaveBeenCalledWith('first_token');
     dl.stop();
   });
 
   it('start() es idempotente — doble start no deja timers huérfanos', () => {
     const onTimeout = vi.fn();
-    const dl = createStreamDeadline({ idleMs: 1000, ceilingMs: 5000, onTimeout });
+    const dl = createStreamDeadline({ firstTokenMs: 1000, idleMs: 1000, ceilingMs: 5000, onTimeout });
     dl.start();
-    dl.start(); // re-arranque: no debe acumular dos idle-timers
+    dl.start(); // re-arranque: no debe acumular dos timers
     vi.advanceTimersByTime(1000);
     expect(onTimeout).toHaveBeenCalledTimes(1);
     dl.stop();

--- a/src/services/streamDeadline.js
+++ b/src/services/streamDeadline.js
@@ -39,13 +39,21 @@
 export const IDLE_TIMEOUT_MS = 40000;
 
 /**
- * Techo absoluto desde el arranque (backstop extremo). NO se reinicia con
- * tokens. 120s es ampliamente suficiente para cualquier respuesta legítima del
- * agente (incluyendo planes multi-aspecto largos en el modelo complejo); su
- * único fin es evitar que la UI quede colgada indefinidamente ante un backend
- * que gotea tokens para siempre. NO es infinito a propósito.
+ * Presupuesto para el PRIMER token (distinto del idle entre tokens). Bajo carga
+ * de GPU única el time-to-first-token llega a 95-151s (test integral 2026-06-13);
+ * el idle de 40s abortaba ANTES del primer token y mostraba "Tiempo agotado". Este
+ * presupuesto separado tolera la espera inicial; cuando empieza a fluir, aplica el
+ * idle normal entre tokens.
  */
-export const HARD_CEILING_MS = 120000;
+export const FIRST_TOKEN_TIMEOUT_MS = 200000;
+
+/**
+ * Techo absoluto desde el arranque (backstop extremo). NO se reinicia con
+ * tokens. 300s tolera respuestas legítimas largas bajo contención de GPU única
+ * (antes 120s también abortaba respuestas largas bajo carga); su único fin es
+ * evitar que la UI quede colgada ante un backend que gotea tokens para siempre.
+ */
+export const HARD_CEILING_MS = 300000;
 
 /**
  * Crea un controlador de deadline stream-aware.
@@ -69,6 +77,7 @@ export const HARD_CEILING_MS = 120000;
  */
 export function createStreamDeadline({
   idleMs = IDLE_TIMEOUT_MS,
+  firstTokenMs = FIRST_TOKEN_TIMEOUT_MS,
   ceilingMs = HARD_CEILING_MS,
   onTimeout,
 } = {}) {
@@ -114,7 +123,9 @@ export function createStreamDeadline({
       // Idempotente: re-arranque limpio (no acumula timers huérfanos).
       clearTimers();
       finished = false;
-      armIdle();
+      // Antes del primer token: presupuesto GENEROSO (firstTokenMs), NO el idle
+      // corto — bajo carga el primer token tarda 95-151s. onToken() cambia al idle.
+      idleTimer = setTimeout(() => fire('first_token'), firstTokenMs);
       ceilingTimer = setTimeout(() => fire('ceiling'), ceilingMs);
     },
     onToken() {


### PR DESCRIPTION
El idle de 40s corria desde el inicio y abortaba ANTES del primer token (95-151s bajo carga GPU unica) -> 'Tiempo agotado'. Fix: FIRST_TOKEN_TIMEOUT_MS=200s separado del idle inter-token; techo 120->300s. 18/18 tests. Primer paso del mecanismo resiliente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)