### PR TITLE
feat(agent): crea agenteRequestQueue - cola durable + telemetria rica

### DIFF
--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 19;
+export const DB_VERSION = 20;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -67,6 +67,12 @@ export const STORES = {
   // procesa exactamente UNA vez (claim atómico anti-duplicado). NUNCA se
   // pierde el dato del usuario — ese es el contrato.
   AGENT_OUTBOX: 'agent_outbox',
+  // v20: agent_requests — cola durable de requests al agente + telemetría rica.
+  // Cada item incluye prompt, ruta, modelo, grounding (entities, tools, RAG),
+  // latencias (t_first_token_ms, t_total_ms, queue_wait_ms), response, tokens,
+  // retries y status (queued/sending/done/failed/offline). Permite debuggear
+  // inteligencia+velocidad de Chagra y garantiza que ninguna pregunta se pierda.
+  AGENT_REQUESTS: 'agent_requests',
 };
 
 let dbInstance = null;
@@ -316,6 +322,25 @@ export const openDB = async () => {
         }
         if (fpeStore && !fpeStore.indexNames.contains('process_id')) {
           fpeStore.createIndex('process_id', 'attributes.process_id', { unique: false });
+        }
+      }
+
+      // v20: agent_requests — cola durable de requests al agente + telemetría rica.
+      // Alimenta el dashboard de debug de Chagra (inteligencia + velocidad) y
+      // garantiza que ninguna pregunta se pierda. Schema:
+      //   { id, ts_submit, prompt, route, model, grounding: {entities, tools,
+      //     rag_chunks, nlu_route, grounded_status}, latency: {t_first_token_ms,
+      //     t_total_ms, queue_wait_ms}, response, tokens_in, tokens_out, retries,
+      //     status: queued/sending/done/failed/offline, ts_done }
+      // keyPath autoIncrement (como vision_queue). Índices para drainPending
+      // (status, ts_submit) y queries (model, route).
+      if (event.oldVersion < 20) {
+        if (!db.objectStoreNames.contains(STORES.AGENT_REQUESTS)) {
+          const store = db.createObjectStore(STORES.AGENT_REQUESTS, { keyPath: 'id', autoIncrement: true });
+          store.createIndex('status', 'status', { unique: false });
+          store.createIndex('ts_submit', 'ts_submit', { unique: false });
+          store.createIndex('model', 'model', { unique: false });
+          store.createIndex('route', 'route', { unique: false });
         }
       }
     };

--- a/src/services/__tests__/agentRequestQueue.test.js
+++ b/src/services/__tests__/agentRequestQueue.test.js
@@ -1,0 +1,594 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests de la cola durable de requests al agente + telemetría rica (v20 2026-06-13).
+ *
+ * Garantiza que ninguna pregunta se pierda y captura metadata completa para
+ * debuggear inteligencia + velocidad de Chagra. Tests cubren:
+ * - enqueue persiste y devuelve id
+ * - drainPending serializa uno a uno
+ * - retry con backoff exponencial
+ * - resumePending reactiva 'offline'
+ * - captura latencia + grounding
+ * - nunca pierde requests (tolerante a fallos)
+ * - offline mantiene 'queued' (o los marca 'offline')
+ */
+
+// ─── Mock de dbCore: IndexedDB en memoria para el store agent_requests ───
+function makeFakeDB() {
+  const data = new Map();
+  let seq = 0;
+  const makeReq = (resultFn) => {
+    const req = {};
+    queueMicrotask(() => {
+      try {
+        req.result = resultFn();
+        req.onsuccess?.({ target: req });
+      } catch (e) {
+        req.error = e;
+        req.onerror?.({ target: req });
+      }
+    });
+    return req;
+  };
+  return {
+    transaction() {
+      return {
+        objectStore() {
+          return {
+            add(record) {
+              return makeReq(() => {
+                const id = record.id != null ? record.id : ++seq;
+                data.set(id, { ...record, id });
+                return id;
+              });
+            },
+            put(record) {
+              return makeReq(() => {
+                data.set(record.id, { ...record });
+                return record.id;
+              });
+            },
+            get(id) {
+              return makeReq(() => data.get(id) || undefined);
+            },
+            delete(id) {
+              return makeReq(() => {
+                data.delete(id);
+                return undefined;
+              });
+            },
+            getAll() {
+              return makeReq(() => Array.from(data.values()));
+            },
+          };
+        },
+      };
+    },
+    __data: data,
+  };
+}
+
+let fakeDB;
+
+vi.mock('../../db/dbCore.js', () => ({
+  openDB: vi.fn(async () => fakeDB),
+  STORES: { AGENT_REQUESTS: 'agent_requests' },
+}));
+
+import {
+  enqueueRequest,
+  listRequests,
+  getRequest,
+  markRequestOffline,
+  resumePending,
+  processRequest,
+  drainPending,
+  clearAgentRequests,
+  aggregateRequestMetrics,
+} from '../agentRequestQueue.js';
+
+function setOnline(value) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+beforeEach(() => {
+  fakeDB = makeFakeDB();
+  setOnline(true);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setOnline(true);
+});
+
+describe('agentRequestQueue — enqueueRequest', () => {
+  it('enqueueRequest persiste y devuelve id', async () => {
+    const id = await enqueueRequest({ 
+      prompt: '¿Qué le pasa a mi café?', 
+      route: 'chat',
+      model: 'llama3:70b'
+    });
+    
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe('number');
+    
+    const all = await listRequests();
+    expect(all).toHaveLength(1);
+    expect(all[0].prompt).toBe('¿Qué le pasa a mi café?');
+    expect(all[0].route).toBe('chat');
+    expect(all[0].model).toBe('llama3:70b');
+    expect(all[0].status).toBe('queued');
+    expect(all[0].ts_submit).toBeTruthy();
+    expect(all[0].grounding).toEqual({
+      entities: [],
+      tools: [],
+      rag_chunks: 0,
+      nlu_route: 'chat',
+      grounded_status: 'none',
+    });
+    expect(all[0].latency).toEqual({
+      t_first_token_ms: null,
+      t_total_ms: null,
+      queue_wait_ms: null,
+    });
+  });
+
+  it('enqueueRequest usa defaults para route y model', async () => {
+    const id = await enqueueRequest({ prompt: 'hola' });
+    
+    expect(id).toBeTruthy();
+    const all = await listRequests();
+    expect(all[0].route).toBe('unknown');
+    expect(all[0].model).toBe('default');
+  });
+
+  it('enqueueRequest rechaza prompt inválido y devuelve null (NUNCA lanza)', async () => {
+    const id1 = await enqueueRequest({ prompt: null });
+    expect(id1).toBeNull();
+    
+    const id2 = await enqueueRequest({ prompt: '' });
+    expect(id2).toBeNull();
+    
+    const id3 = await enqueueRequest({ prompt: 123 });
+    expect(id3).toBeNull();
+    
+    const all = await listRequests();
+    expect(all).toHaveLength(0);
+  });
+
+  it('enqueueRequest sobrevive error de IndexedDB y devuelve null', async () => {
+    // Simular error de IndexedDB
+    fakeDB = null; // openDB devolverá null → transaction fallará
+    const id = await enqueueRequest({ prompt: 'test' });
+    expect(id).toBeNull();
+  });
+});
+
+describe('agentRequestQueue — listRequests/getRequest', () => {
+  it('listRequests devuelve todos los requests', async () => {
+    await enqueueRequest({ prompt: 'a', route: 'chat' });
+    await enqueueRequest({ prompt: 'b', route: 'foliage' });
+    
+    const all = await listRequests();
+    expect(all).toHaveLength(2);
+    expect(all[0].prompt).toBe('a');
+    expect(all[1].prompt).toBe('b');
+  });
+
+  it('getRequest devuelve un request específico', async () => {
+    const id = await enqueueRequest({ prompt: 'test' });
+    const item = await getRequest(id);
+    
+    expect(item).toBeTruthy();
+    expect(item.prompt).toBe('test');
+    expect(item.id).toBe(id);
+  });
+
+  it('getRequest devuelve null si no existe', async () => {
+    const item = await getRequest(9999);
+    expect(item).toBeNull();
+  });
+
+  it('getRequest es tolerante a fallos', async () => {
+    const item = await getRequest(null);
+    expect(item).toBeNull();
+    
+    fakeDB = null;
+    const item2 = await getRequest(1);
+    expect(item2).toBeNull();
+  });
+});
+
+describe('agentRequestQueue — processRequest', () => {
+  it('processRequest delega al sender y marca done', async () => {
+    const sender = vi.fn().mockResolvedValue({
+      response: 'Respuesta del modelo',
+      tokens_in: 10,
+      tokens_out: 20,
+      grounding: {
+        entities: ['cafe'],
+        tools: ['get_species'],
+        rag_chunks: 3,
+        grounded_status: 'verified',
+      },
+    });
+    
+    const id = await enqueueRequest({ prompt: 'test', route: 'chat' });
+    
+    const result = await processRequest({
+      sender,
+      req: { prompt: 'test', route: 'chat' },
+      id,
+    });
+    
+    expect(result.status).toBe('done');
+    expect(result.response).toBe('Respuesta del modelo');
+    expect(result.tokens_in).toBe(10);
+    expect(result.tokens_out).toBe(20);
+    expect(result.grounding.grounded_status).toBe('verified');
+    expect(result.grounding.entities).toEqual(['cafe']);
+    expect(result.latency.t_total_ms).toBeGreaterThanOrEqual(0); // Puede ser 0 en tests rápidos
+    expect(result.latency.queue_wait_ms).toBeGreaterThanOrEqual(0);
+    expect(sender).toHaveBeenCalledTimes(1);
+  });
+
+  it('processRequest reintenta con backoff exponencial', async () => {
+    const sender = vi.fn()
+      .mockRejectedValueOnce(new Error('falla 1'))
+      .mockRejectedValueOnce(new Error('falla 2'))
+      .mockResolvedValueOnce({ response: 'ok' });
+    
+    const id = await enqueueRequest({ prompt: 'test' });
+    
+    const startTime = Date.now();
+    const result = await processRequest({
+      sender,
+      req: { prompt: 'test' },
+      id,
+    });
+    const elapsed = Date.now() - startTime;
+    
+    expect(result.status).toBe('done');
+    expect(sender).toHaveBeenCalledTimes(3);
+    // Debió haber esperado al menos 1s + 2s = 3s de backoff
+    expect(elapsed).toBeGreaterThanOrEqual(3000);
+    expect(result.retries).toBe(2);
+  });
+
+  it('processRequest marca failed tras MAX_RETRIES', async () => {
+    const sender = vi.fn().mockRejectedValue(new Error('siempre falla'));
+    
+    const id = await enqueueRequest({ prompt: 'test' });
+    
+    const result = await processRequest({
+      sender,
+      req: { prompt: 'test' },
+      id,
+    });
+    
+    expect(result.status).toBe('failed');
+    expect(result.error).toBeTruthy();
+    expect(result.retries).toBe(3);
+    expect(sender).toHaveBeenCalledTimes(4); // 3 retries + 1 initial = 4 calls
+  });
+
+  it('processRequest captura latencia del sender', async () => {
+    const sender = vi.fn().mockResolvedValue({
+      response: 'ok',
+      latency: {
+        t_first_token_ms: 150,
+      },
+    });
+    
+    const id = await enqueueRequest({ prompt: 'test' });
+    
+    const result = await processRequest({
+      sender,
+      req: { prompt: 'test' },
+      id,
+    });
+    
+    expect(result.latency.t_first_token_ms).toBe(150);
+    expect(result.latency.t_total_ms).toBeGreaterThanOrEqual(0); // Puede ser 0 en tests rápidos
+  });
+
+  it('processRequest rechaza sender inválido', async () => {
+    const id = await enqueueRequest({ prompt: 'test' });
+    
+    await expect(
+      processRequest({ sender: null, req: {}, id })
+    ).rejects.toThrow();
+  });
+
+  it('processRequest rechaza request no encontrado', async () => {
+    await expect(
+      processRequest({ sender: vi.fn(), req: {}, id: 9999 })
+    ).rejects.toThrow();
+  });
+
+  it('processRequest rechaza request no queued', async () => {
+    const id = await enqueueRequest({ prompt: 'test' });
+    // Marcar como done manualmente
+    const item = await getRequest(id);
+    item.status = 'done';
+    await fakeDB.transaction().objectStore().put(item);
+    
+    await expect(
+      processRequest({ sender: vi.fn(), req: {}, id })
+    ).rejects.toThrow();
+  });
+});
+
+describe('agentRequestQueue — drainPending', () => {
+  it('drainPending procesa items queued en orden FIFO', async () => {
+    const order = [];
+    const sender = vi.fn(async (req) => {
+      order.push(req.prompt);
+      return { response: `ok: ${req.prompt}` };
+    });
+    
+    // Encolar con timestamps explícitos para controlar orden
+    await enqueueRequest({ prompt: 'primero', route: 'chat' });
+    await enqueueRequest({ prompt: 'segundo', route: 'foliage' });
+    
+    const result = await drainPending({ sender });
+    
+    expect(result.processed).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(order).toEqual(['primero', 'segundo']);
+    
+    const all = await listRequests();
+    expect(all[0].status).toBe('done');
+    expect(all[1].status).toBe('done');
+  });
+
+  it('drainPending solo procesa queued (no reprocesa done)', async () => {
+    const sender = vi.fn().mockResolvedValue({ response: 'ok' });
+
+    const id1 = await enqueueRequest({ prompt: 'a' });
+    await enqueueRequest({ prompt: 'b' });
+
+    // Procesar primero
+    await processRequest({ sender, req: { prompt: 'a' }, id: id1 });
+
+    // Drain pendiente
+    const result = await drainPending({ sender });
+
+    expect(result.processed).toBe(1); // Solo 'b'
+    expect(sender).toHaveBeenCalledTimes(2); // a + b
+  });
+
+  it('drainPending reintenta fallos sin abortar el resto', async () => {
+    // Sender que falla siempre para 'a', tiene éxito para 'b'
+    const sender = vi.fn((req) => {
+      if (req.prompt === 'a') {
+        throw new Error('fail a');
+      }
+      return Promise.resolve({ response: 'ok b' });
+    });
+
+    await enqueueRequest({ prompt: 'a' });
+    await enqueueRequest({ prompt: 'b' });
+
+    const result = await drainPending({ sender });
+
+    expect(result.processed).toBe(1); // b
+    expect(result.failed).toBe(1); // a
+
+    const all = await listRequests();
+    const a = all.find((i) => i.prompt === 'a');
+    const b = all.find((i) => i.prompt === 'b');
+    expect(a.status).toBe('failed');
+    expect(b.status).toBe('done');
+  });
+
+  it('drainPending marca offline cuando desconectado', async () => {
+    const sender = vi.fn().mockResolvedValue({ response: 'ok' });
+    
+    await enqueueRequest({ prompt: 'test' });
+    setOnline(false);
+    
+    const result = await drainPending({ sender });
+    
+    expect(result.processed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(sender).not.toHaveBeenCalled();
+    
+    const all = await listRequests();
+    expect(all[0].status).toBe('offline');
+  });
+
+  it('drainPending rechaza sender inválido', async () => {
+    const result = await drainPending({ sender: null });
+    
+    expect(result.processed).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('drainPending vacío retorna ceros', async () => {
+    const sender = vi.fn();
+    const result = await drainPending({ sender });
+    
+    expect(result.processed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(0);
+  });
+});
+
+describe('agentRequestQueue — resumePending', () => {
+  it('resumePending reactiva items offline', async () => {
+    await enqueueRequest({ prompt: 'a' });
+    await enqueueRequest({ prompt: 'b' });
+    
+    // Marcar como offline
+    const all = await listRequests();
+    for (const item of all) {
+      await markRequestOffline(item.id);
+    }
+    
+    const reactivated = await resumePending();
+    
+    expect(reactivated).toBe(2);
+    
+    const updated = await listRequests();
+    expect(updated.every((i) => i.status === 'queued')).toBe(true);
+  });
+
+  it('resumePending no hace nada si no hay offline', async () => {
+    const reactivated = await resumePending();
+    expect(reactivated).toBe(0);
+  });
+});
+
+describe('agentRequestQueue — aggregateRequestMetrics', () => {
+  it('aggregateRequestMetrics calcula totales', async () => {
+    // Crear requests con diferentes estados
+    await enqueueRequest({ prompt: 'done1', route: 'chat' });
+    await enqueueRequest({ prompt: 'done2', route: 'foliage' });
+    await enqueueRequest({ prompt: 'queued1', route: 'species' });
+    
+    const all = await listRequests();
+    // Marcar dos como done
+    all[0].status = 'done';
+    all[0].latency.t_total_ms = 100;
+    all[1].status = 'done';
+    all[1].latency.t_total_ms = 200;
+    
+    const metrics = aggregateRequestMetrics(all);
+    
+    expect(metrics.totals.total).toBe(3);
+    expect(metrics.totals.done).toBe(2);
+    expect(metrics.totals.queued).toBe(1);
+    expect(metrics.totals.successRate).toBe(1); // 2/2 done
+    expect(metrics.avgLatency.avgTotalMs).toBe(150); // (100+200)/2
+  });
+
+  it('aggregateRequestMetrics agrupa por modelo', async () => {
+    await enqueueRequest({ prompt: 'a', model: 'llama3:70b' });
+    await enqueueRequest({ prompt: 'b', model: 'gpt-4o' });
+    await enqueueRequest({ prompt: 'c', model: 'llama3:70b' });
+    
+    const all = await listRequests();
+    all[0].status = 'done';
+    all[0].latency.t_total_ms = 100;
+    all[1].status = 'done';
+    all[1].latency.t_total_ms = 200;
+    all[2].status = 'done';
+    all[2].latency.t_total_ms = 150;
+    
+    const metrics = aggregateRequestMetrics(all);
+    
+    expect(metrics.byModel['llama3:70b'].count).toBe(2);
+    expect(metrics.byModel['llama3:70b'].avgLatencyMs).toBe(125);
+    expect(metrics.byModel['gpt-4o'].count).toBe(1);
+    expect(metrics.byModel['gpt-4o'].avgLatencyMs).toBe(200);
+  });
+
+  it('aggregateRequestMetrics agrupa por route', async () => {
+    await enqueueRequest({ prompt: 'a', route: 'chat' });
+    await enqueueRequest({ prompt: 'b', route: 'foliage' });
+    
+    const all = await listRequests();
+    all[0].status = 'done';
+    all[0].latency.t_total_ms = 100;
+    all[1].status = 'done';
+    all[1].latency.t_total_ms = 200;
+    
+    const metrics = aggregateRequestMetrics(all);
+    
+    expect(metrics.byRoute['chat'].count).toBe(1);
+    expect(metrics.byRoute['chat'].avgLatencyMs).toBe(100);
+    expect(metrics.byRoute['foliage'].count).toBe(1);
+    expect(metrics.byRoute['foliage'].avgLatencyMs).toBe(200);
+  });
+});
+
+describe('agentRequestQueue — clearAgentRequests', () => {
+  it('clearAgentRequests vacía la cola', async () => {
+    await enqueueRequest({ prompt: 'a' });
+    await enqueueRequest({ prompt: 'b' });
+    expect(await listRequests()).toHaveLength(2);
+    
+    await clearAgentRequests();
+    expect(await listRequests()).toHaveLength(0);
+  });
+
+  it('clearAgentRequests es no-op si ya está vacío', async () => {
+    await clearAgentRequests(); // No debe lanzar
+    expect(await listRequests()).toHaveLength(0);
+  });
+});
+
+describe('agentRequestQueue — integración offline/online', () => {
+  it('flujocompleto: enqueue → offline → online → resume → drain', async () => {
+    // 1. Enqueue requests
+    await enqueueRequest({ prompt: 'a' });
+    await enqueueRequest({ prompt: 'b' });
+    expect(await listRequests()).toHaveLength(2);
+    
+    // 2. Detectar offline (simulado)
+    setOnline(false);
+    await drainPending({ sender: vi.fn() });
+    expect((await listRequests())[0].status).toBe('offline');
+    
+    // 3. Volver online
+    setOnline(true);
+    await resumePending();
+    expect((await listRequests())[0].status).toBe('queued');
+    
+    // 4. Drain y procesar
+    const sender = vi.fn().mockResolvedValue({ response: 'ok' });
+    const result = await drainPending({ sender });
+    
+    expect(result.processed).toBe(2);
+    expect(sender).toHaveBeenCalledTimes(2);
+    expect((await listRequests()).every((i) => i.status === 'done')).toBe(true);
+  });
+});
+
+describe('agentRequestQueue — nunca pierde requests', () => {
+  it('persiste aunque falle el sender', async () => {
+    const sender = vi.fn().mockRejectedValue(new Error('fail'));
+    
+    await enqueueRequest({ prompt: 'test' });
+    await drainPending({ sender });
+    
+    // El request sigue ahí, aunque falló
+    const all = await listRequests();
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe('failed');
+    expect(all[0].prompt).toBe('test'); // Prompt intacto
+  });
+
+  it('persiste aunque haya error de IndexedDB en enqueue', async () => {
+    // Esto ya está cubierto en "enqueueRequest sobrevive error de IndexedDB"
+    // pero confirmamos que no lanza
+    const id = await enqueueRequest({ prompt: null });
+    expect(id).toBeNull(); // Devuelve null, no lanza
+  });
+
+  it('recupera tras recarga de página (simulada)', async () => {
+    // Crear requests
+    await enqueueRequest({ prompt: 'a' });
+    await enqueueRequest({ prompt: 'b' });
+
+    // Guardar datos actuales (simulando persistencia IDB)
+    const oldData = new Map(fakeDB.__data);
+
+    // "Recargar página" → nuevo fakeDB
+    fakeDB = makeFakeDB();
+
+    // Copiar datos del viejo al nuevo (simulando persistencia IDB)
+    oldData.forEach((value, key) => {
+      fakeDB.__data.set(key, value);
+    });
+
+    // Verificar que los datos persistieron
+    const all = await listRequests();
+    expect(all).toHaveLength(2);
+    expect(all[0].prompt).toBe('a');
+    expect(all[1].prompt).toBe('b');
+  });
+});

--- a/src/services/agentRequestQueue.js
+++ b/src/services/agentRequestQueue.js
@@ -1,0 +1,439 @@
+/**
+ * agentRequestQueue.js — Cola durable de requests al agente + telemetría rica (v20 2026-06-13).
+ *
+ * Garantiza que ninguna pregunta se pierda y captura metadata completa para
+ * debuggear inteligencia + velocidad de Chagra. Patrón: réplica de
+ * visionQueueService.js con IndexedDB + worker serializado + sender inyectado.
+ *
+ * Schema del registro `agent_requests`:
+ * {
+ *   id: number,                    // autoIncrement (IndexedDB)
+ *   ts_submit: number,             // Unix ms — timestamp de enqueue
+ *   prompt: string,                // prompt original (completo, no truncado)
+ *   route: string,                 // ruta NLU (ej: 'chat', 'foliage', 'species')
+ *   model: string,                 // modelo usado (ej: 'llama3:70b', 'gpt-4o')
+ *   grounding: {                   // metadata de grounding (sidecar MCP)
+ *     entities: Array,             // entidades extraídas (species, plagas, etc.)
+ *     tools: Array,                // tools MCP invocados
+ *     rag_chunks: number,          // # chunks RAG inyectados
+ *     nlu_route: string,           // ruta NLU detectada
+ *     grounded_status: string,    // 'verified' | 'partial' | 'none'
+ *   },
+ *   latency: {                     // métricas de latencia (ms)
+ *     t_first_token_ms: number,    // tiempo al primer token
+ *     t_total_ms: number,          // tiempo total de respuesta
+ *     queue_wait_ms: number,       // tiempo esperando en cola
+ *   },
+ *   response: string|null,         // respuesta del modelo (null si pendiente/failed)
+ *   tokens_in: number,             // tokens del prompt
+ *   tokens_out: number,            // tokens de la respuesta
+ *   retries: number,               // # reintentos realizados
+ *   status: 'queued'|'sending'|'done'|'failed'|'offline',
+ *   ts_done: number|null,          // Unix ms — timestamp de completion
+ *   error: string|null,            // mensaje de error (si failed)
+ * }
+ *
+ * Reglas operativas:
+ * - enqueueRequest solo persiste con status='queued', NUNCA lanza (try/catch)
+ * - drainPending({sender}) procesa items 'queued' uno a uno (SERIALIZADO)
+ * - Marca 'sending' antes de delegar al sender inyectado
+ * - Reintento con backoff exponencial ante error/timeout
+ * - 'failed' solo tras MAX_RETRIES reintentos
+ * - Mantiene 'queued' (no procesa) si navigator.onLine === false
+ * - Marca 'done' con respuesta+latencias al éxito
+ * - sender inyectado → testeable sin red
+ */
+
+import { openDB, STORES } from '../db/dbCore.js';
+
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1000; // 1s base, 2s, 4s, 8s...
+
+/** Ejecuta una IDBRequest como Promise. */
+function reqAsPromise(req) {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Encola un request al agente. NO invoca al modelo — solo persiste con
+ * status='queued'. Sobrevive recargas de página y cierres de app.
+ *
+ * @param {Object} args
+ * @param {string} args.prompt - prompt del usuario (obligatorio)
+ * @param {string} [args.route] - ruta NLU (opcional, default 'unknown')
+ * @param {string} [args.model] - modelo a usar (opcional, default 'default')
+ * @returns {Promise<number>} id del registro encolado (o null si falla persistencia)
+ */
+export async function enqueueRequest({ prompt, route = 'unknown', model = 'default' } = {}) {
+  try {
+    if (!prompt || typeof prompt !== 'string') {
+      console.warn('[agentRequestQueue] enqueueRequest requiere prompt válido');
+      return null;
+    }
+
+    const db = await openDB();
+    const record = {
+      ts_submit: Date.now(),
+      prompt,
+      route,
+      model,
+      grounding: {
+        entities: [],
+        tools: [],
+        rag_chunks: 0,
+        nlu_route: route,
+        grounded_status: 'none',
+      },
+      latency: {
+        t_first_token_ms: null,
+        t_total_ms: null,
+        queue_wait_ms: null,
+      },
+      response: null,
+      tokens_in: null,
+      tokens_out: null,
+      retries: 0,
+      status: 'queued',
+      ts_done: null,
+      error: null,
+    };
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    const id = await reqAsPromise(store.add(record));
+    console.debug(`[agentRequestQueue] encolado request #${id} (route: ${route})`);
+    return id;
+  } catch (err) {
+    console.error('[agentRequestQueue] enqueueRequest falló:', err);
+    return null; // NUNCA lanza — tolerante a fallos
+  }
+}
+
+/**
+ * Lee todos los requests encolados (cualquier status). Tolerante a fallos:
+ * devuelve [] si la lectura falla.
+ * @returns {Promise<Array>}
+ */
+export async function listRequests() {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readonly');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    const all = await reqAsPromise(store.getAll());
+    return Array.isArray(all) ? all : [];
+  } catch (e) {
+    console.debug('[agentRequestQueue] listRequests error:', e);
+    return [];
+  }
+}
+
+/**
+ * Lee un request por id. Devuelve null si no existe o falla la lectura.
+ * @param {number} id
+ * @returns {Promise<Object|null>}
+ */
+export async function getRequest(id) {
+  try {
+    if (id == null) return null;
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readonly');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    const result = await reqAsPromise(store.get(id));
+    return result || null;
+  } catch (e) {
+    console.debug('[agentRequestQueue] getRequest error:', e);
+    return null;
+  }
+}
+
+/**
+ * Marca un request como 'offline' (cuando se detecta pérdida de conexión).
+ * @param {number} id
+ * @returns {Promise<boolean>}
+ */
+export async function markRequestOffline(id) {
+  try {
+    const item = await getRequest(id);
+    if (!item || item.status !== 'queued') return false;
+
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    item.status = 'offline';
+    await reqAsPromise(store.put(item));
+    return true;
+  } catch (e) {
+    console.debug('[agentRequestQueue] markRequestOffline error:', e);
+    return false;
+  }
+}
+
+/**
+ * Marca todos los 'offline' como 'queued' (al volver la conexión).
+ * @returns {Promise<number>} cuántos items fueron reactivados
+ */
+export async function resumePending() {
+  try {
+    const all = await listRequests();
+    const offline = all.filter((i) => i.status === 'offline');
+    if (offline.length === 0) return 0;
+
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    
+    for (const item of offline) {
+      item.status = 'queued';
+      await reqAsPromise(store.put(item));
+    }
+    console.debug(`[agentRequestQueue] resumePending: ${offline.length} reactivados`);
+    return offline.length;
+  } catch (e) {
+    console.debug('[agentRequestQueue] resumePending error:', e);
+    return 0;
+  }
+}
+
+/**
+ * Persiste el estado actualizado de un request en IndexedDB.
+ * @param {Object} item
+ * @returns {Promise<void>}
+ */
+async function persistItem(item) {
+  try {
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    await reqAsPromise(store.put(item));
+  } catch (e) {
+    console.debug('[agentRequestQueue] persistItem error:', e);
+  }
+}
+
+/**
+ * Worker SERIALIZADO que procesa la cola uno a uno. Toma el siguiente 'queued',
+ * marca 'sending', delega al sender inyectado, reintenta con backoff exponencial,
+ * marca 'done'/'failed'. NO procesa si offline.
+ *
+ * @param {Object} options
+ * @param {Function} options.sender - función async(req) que procesa el request
+ * @param {Object} options.req - request a procesar (prompt, route, model, etc.)
+ * @param {number} options.id - id del request en IndexedDB
+ * @returns {Promise<Object>} item actualizado con status 'done' o 'failed'
+ */
+export async function processRequest({ sender, req, id }) {
+  if (!sender || typeof sender !== 'function') {
+    throw new Error('[agentRequestQueue] processRequest requiere sender function');
+  }
+
+  const item = await getRequest(id);
+  if (!item) {
+    throw new Error(`[agentRequestQueue] request #${id} no encontrado`);
+  }
+  if (item.status !== 'queued') {
+    throw new Error(`[agentRequestQueue] request #${id} no está queued (status: ${item.status})`);
+  }
+
+  // Calcular tiempo de espera en cola
+  const queueWaitMs = Date.now() - item.ts_submit;
+
+  // Marcar 'sending'
+  item.status = 'sending';
+  item.latency.queue_wait_ms = queueWaitMs;
+  await persistItem(item);
+
+  let lastError = null;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const tStart = Date.now();
+
+      const result = await sender(req);
+      
+      const tDone = Date.now();
+      const tTotalMs = tDone - tStart;
+      
+      // Marcar 'done' con metadata completa
+      item.status = 'done';
+      item.ts_done = tDone;
+      item.latency.t_total_ms = tTotalMs;
+      // t_first_token_ms debe venir del sender si es medible
+      if (result?.latency?.t_first_token_ms != null) {
+        item.latency.t_first_token_ms = result.latency.t_first_token_ms;
+      }
+      
+      // Metadata de grounding si viene del sender
+      if (result?.grounding) {
+        item.grounding = { ...item.grounding, ...result.grounding };
+      }
+      
+      // Response y tokens
+      item.response = result?.response || null;
+      item.tokens_in = result?.tokens_in || null;
+      item.tokens_out = result?.tokens_out || null;
+      item.retries = attempt;
+      item.error = null;
+      
+      await persistItem(item);
+      console.debug(`[agentRequestQueue] request #${id} completado (${tTotalMs}ms, ${attempt} retries)`);
+      return item;
+    } catch (err) {
+      lastError = err;
+      console.debug(`[agentRequestQueue] request #${id} fallo intento ${attempt}/${MAX_RETRIES}:`, err?.message);
+      
+      if (attempt < MAX_RETRIES) {
+        // Backoff exponencial
+        const backoffMs = BASE_BACKOFF_MS * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+    }
+  }
+
+  // Agotados reintentos → marcar 'failed'
+  item.status = 'failed';
+  item.error = lastError?.message || String(lastError);
+  item.retries = MAX_RETRIES;
+  await persistItem(item);
+  console.debug(`[agentRequestQueue] request #${id} falló tras ${MAX_RETRIES} reintentos`);
+  return item;
+}
+
+/**
+ * Drena la cola pendiente: procesa items 'queued' uno a uno (SERIALIZADO).
+ * NO procesa si navigator.onLine === false. Reintenta fallos individuales sin
+ * abortar el resto.
+ *
+ * @param {Function} sender - función async(req) que procesa cada request
+ * @returns {Promise<{processed: number, failed: number, skipped: number}>}
+ */
+export async function drainPending({ sender } = {}) {
+  if (!sender || typeof sender !== 'function') {
+    console.warn('[agentRequestQueue] drainPending requiere sender function');
+    return { processed: 0, failed: 0, skipped: 0 };
+  }
+
+  // Si estamos offline, no procesar nada
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    console.debug('[agentRequestQueue] offline - no se procesa la cola');
+    // Marcar todos los 'queued' como 'offline'
+    const all = await listRequests();
+    const queued = all.filter((i) => i.status === 'queued');
+    for (const item of queued) {
+      await markRequestOffline(item.id);
+    }
+    return { processed: 0, failed: 0, skipped: queued.length };
+  }
+
+  const all = await listRequests();
+  const queued = all
+    .filter((i) => i.status === 'queued')
+    .sort((a, b) => (a.ts_submit || 0) - (b.ts_submit || 0)); // FIFO por ts_submit
+
+  if (queued.length === 0) {
+    return { processed: 0, failed: 0, skipped: 0 };
+  }
+
+  let processed = 0;
+  let failed = 0;
+  
+  // Procesar uno a uno (SERIALIZADO)
+  for (const item of queued) {
+    try {
+      const req = {
+        prompt: item.prompt,
+        route: item.route,
+        model: item.model,
+      };
+      const result = await processRequest({ sender, req, id: item.id });
+      if (result.status === 'done') {
+        processed++;
+      } else {
+        failed++;
+      }
+    } catch (err) {
+      console.debug('[agentRequestQueue] error procesando item:', item.id, err);
+      failed++;
+    }
+  }
+
+  console.debug(`[agentRequestQueue] drainPending: ${processed} OK, ${failed} failed`);
+  return { processed, failed, skipped: 0 };
+}
+
+/**
+ * Vacía la cola completa (uso interno + tests). ¡Cuidado! Esto borra todo.
+ * @returns {Promise<void>}
+ */
+export async function clearAgentRequests() {
+  try {
+    const items = await listRequests();
+    if (items.length === 0) return;
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+    await Promise.all(items.map((i) => reqAsPromise(store.delete(i.id))));
+  } catch (e) {
+    console.debug('[agentRequestQueue] clearAgentRequests error:', e);
+  }
+}
+
+/**
+ * Calcula agregados para el dashboard de debug.
+ * @param {Array} requests - requests del store (precargados con listRequests)
+ * @returns {{ totals, byModel, byRoute, avgLatency, successRate }}
+ */
+export function aggregateRequestMetrics(requests) {
+  const list = Array.isArray(requests) ? requests : [];
+
+  const done = list.filter((r) => r.status === 'done');
+  const failed = list.filter((r) => r.status === 'failed');
+  const queued = list.filter((r) => r.status === 'queued');
+  const sending = list.filter((r) => r.status === 'sending');
+
+  const totals = {
+    total: list.length,
+    done: done.length,
+    failed: failed.length,
+    queued: queued.length,
+    sending: sending.length,
+    successRate: done.length + failed.length ? done.length / (done.length + failed.length) : 0,
+  };
+
+  const byModel = groupReduce(list, (r) => r.model || 'default', (group) => ({
+    count: group.length,
+    done: group.filter((r) => r.status === 'done').length,
+    failed: group.filter((r) => r.status === 'failed').length,
+    avgLatencyMs: avg(group.map((r) => r.latency?.t_total_ms).filter(isNum)),
+  }));
+
+  const byRoute = groupReduce(list, (r) => r.route || 'unknown', (group) => ({
+    count: group.length,
+    done: group.filter((r) => r.status === 'done').length,
+    avgLatencyMs: avg(group.map((r) => r.latency?.t_total_ms).filter(isNum)),
+  }));
+
+  const avgLatency = {
+    avgTotalMs: avg(done.map((r) => r.latency?.t_total_ms).filter(isNum)),
+    avgFirstTokenMs: avg(done.map((r) => r.latency?.t_first_token_ms).filter(isNum)),
+    avgQueueWaitMs: avg(done.map((r) => r.latency?.queue_wait_ms).filter(isNum)),
+  };
+
+  return { totals, byModel, byRoute, avgLatency, successRate: totals.successRate };
+}
+
+const isNum = (n) => typeof n === 'number' && Number.isFinite(n);
+const avg = (arr) => arr.length ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+const groupReduce = (arr, keyFn, reduceFn) => {
+  const groups = {};
+  for (const item of arr) {
+    const key = keyFn(item);
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(item);
+  }
+  const out = {};
+  for (const [key, group] of Object.entries(groups)) {
+    out[key] = reduceFn(group);
+  }
+  return out;
+};


### PR DESCRIPTION
## Summary

Crea el servicio `agentRequestQueue.js` — buzón durable de requests al agente + telemetría rica para debuggear inteligencia + velocidad de Chagra.

**Propósito:** Garantizar que ninguna pregunta se pierda y capturar metadata completa para análisis de latencias, grounding y rendimiento del modelo.

## Cambios

### dbCore.js
- Incrementa versión de ChagraDB de 19 a 20
- Agrega store `agent_requests` con schema completo:
  - `id`: autoIncrement (IndexedDB)
  - `ts_submit`: timestamp de enqueue
  - `prompt`: prompt original (completo)
  - `route`: ruta NLU (chat, foliage, species, etc.)
  - `model`: modelo usado (llama3:70b, gpt-4o, etc.)
  - `grounding`: {entities, tools, rag_chunks, nlu_route, grounded_status}
  - `latency`: {t_first_token_ms, t_total_ms, queue_wait_ms}
  - `response`: respuesta del modelo
  - `tokens_in`, `tokens_out`: conteos de tokens
  - `retries`: número de reintentos realizados
  - `status`: queued/sending/done/failed/offline
  - `ts_done`: timestamp de completion
  - `error`: mensaje de error (si failed)
- Índices: status, ts_submit, model, route

### agentRequestQueue.js (nuevo)
- `enqueueRequest({prompt, route, model})`: persiste 'queued', devuelve id, NUNCA lanza
- `drainPending({sender})`: worker SERIALIZADO que procesa items uno a uno
  - Marca 'sending' antes de delegar al sender inyectado
  - Reintento con backoff exponencial (MAX_RETRIES=3, BASE_BACKOFF=1s)
  - 'failed' solo tras N reintentos
  - Mantiene 'queued' si `navigator.onLine === false`
  - Marca 'done' con respuesta+latencias al éxito
- `resumePending()\): reactiva items 'offline' al volver online
- `getRequest(id)\), `listRequests()\): consultas puras
- `clearAgentRequests()\): vacía la cola (tests/debug)
- `aggregateRequestMetrics(requests)\): agregados para dashboard
  - totals: total, done, failed, queued, sending, successRate
  - byModel: count, done, failed, avgLatencyMs
  - byRoute: count, done, avgLatencyMs
  - avgLatency: avgTotalMs, avgFirstTokenMs, avgQueueWaitMs

## Test plan

Tests exhaustivos (32 tests passing, 0 failing):
- ✅ enqueueRequest persiste y devuelve id
- ✅ enqueueRequest usa defaults para route/model
- ✅ enqueueRequest rechaza prompt inválido (NUNCA lanza, devuelve null)
- ✅ enqueueRequest sobrevive error de IndexedDB
- ✅ listRequests/getRequest funcionan correctamente
- ✅ processRequest delega al sender y marca done
- ✅ processRequest reintenta con backoff exponencial
- ✅ processRequest marca failed tras MAX_RETRIES
- ✅ processRequest captura latencia del sender
- ✅ processRequest rechaza sender inválido
- ✅ processRequest rechaza request no encontrado/no queued
- ✅ drainPending procesa items queued en orden FIFO
- ✅ drainPending solo procesa queued (no reprocesa done)
- ✅ drainPending reintenta fallos sin abortar el resto
- ✅ drainPending marca offline cuando desconectado
- ✅ drainPending rechaza sender inválido
- ✅ drainPending vacío retorna ceros
- ✅ resumePending reactiva items offline
- ✅ aggregateRequestMetrics calcula totales
- ✅ aggregateRequestMetrics agrupa por modelo/route
- ✅ clearAgentRequests vacía la cola
- ✅ flujocompleto: enqueue → offline → online → resume → drain
- ✅ nunca pierde requests (persiste aunque falle sender)

## Verificaciones

- ✅ `npx vitest run src/services/__tests__/agentRequestQueue.test.js` — 32 passing
- ✅ `npx eslint src/services/agentRequestQueue.js --max-warnings=0` — clean
- ✅ `npm run build` — built in 3.67s
- ✅ No hay tsconfig.json (proyecto JS, no TypeScript)

## MCP tools usados

Ninguno para este task (solo patrón de código existente: llmTelemetryService.js, visionQueueService.js, dbCore.js).

## Riesgos conocidos

- El store `agent_requests` crece indefinidamente; futuro PR debería agregar retención/purge (similar a `RETAIN_MAX` en llmTelemetryService).
- El sender inyectado debe manejar timeouts correctamente; si el sender cuelga, processRequest esperará hasta completar (no hay timeout interno). Esto se deja a la implementación del sender.

## Notas para reviewers

- NO se tocó AgentScreen (como especifica el task #6226).
- Sender inyectado: testeable sin red (ver tests).
- Patrón visionQueueService réplica: offline-first + IndexedDB + worker serializado.
- Backoff exponencial: BASE_BACKOFF_MS (1s) * 2^attempt → 1s, 2s, 4s.