### PR TITLE
feat(telemetry): agrega sincronización de telemetría rica del agente (#6230)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,10 @@ VITE_CAPTURE_CONVERSATIONS=false
 # Cuando está en `true`, se omiten user_name y finca_nombre del payload, pero se
 # conservan user_id y finca_slug para análisis agregados.
 VITE_CAPTURE_ANONYMIZE=false
+
+# Sincronización de telemetría del agente (#6230). URL del endpoint /ingest del
+# backend de telemetría (chagra-pro). Solo funciona si el usuario dio
+# consentimiento (userProfileService.setTelemetryConsent(true)). Envía metadatos
+# anónimos de las consultas al agente (route, model, latencias, tokens) sin PII
+# (sin prompts, respuestas, user_id, coords). Default: vacío (no-op).
+VITE_TELEMETRY_INGEST_URL=

--- a/src/services/__tests__/agentTelemetrySync.test.js
+++ b/src/services/__tests__/agentTelemetrySync.test.js
@@ -1,0 +1,439 @@
+/* eslint-disable no-undef -- global object is used in tests */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests de sincronización de telemetría del agente (#6230).
+ *
+ * Cubren:
+ * - syncAgentTelemetry respeta consentimiento
+ * - syncAgentTelemetry respeta offline
+ * - syncAgentTelemetry respeta VITE_TELEMETRY_INGEST_URL vacío
+ * - anonymizeRequest remueve PII (prompt, response)
+ * - markRequestSynced marca synced: true
+ * - POST al endpoint con payload correcto
+ * - Falla silente (no lanza)
+ */
+
+// ─── Mock de dbCore: IndexedDB en memoria ───
+function makeFakeDB() {
+  const data = new Map();
+  let seq = 0;
+  const makeReq = (resultFn) => {
+    const req = {};
+    queueMicrotask(() => {
+      try {
+        req.result = resultFn();
+        req.onsuccess?.({ target: req });
+      } catch (e) {
+        req.error = e;
+        req.onerror?.({ target: req });
+      }
+    });
+    return req;
+  };
+  return {
+    transaction() {
+      return {
+        objectStore() {
+          return {
+            add(record) {
+              return makeReq(() => {
+                const id = record.id != null ? record.id : ++seq;
+                data.set(id, { ...record, id });
+                return id;
+              });
+            },
+            put(record) {
+              return makeReq(() => {
+                data.set(record.id, { ...record });
+                return record.id;
+              });
+            },
+            get(id) {
+              return makeReq(() => data.get(id) || undefined);
+            },
+            delete(id) {
+              return makeReq(() => {
+                data.delete(id);
+                return undefined;
+              });
+            },
+            getAll() {
+              return makeReq(() => Array.from(data.values()));
+            },
+          };
+        },
+      };
+    },
+    __data: data,
+  };
+}
+
+let fakeDB;
+
+vi.mock('../../db/dbCore.js', () => ({
+  openDB: vi.fn(async () => fakeDB),
+  STORES: { AGENT_REQUESTS: 'agent_requests' },
+}));
+
+// ─── Mock de userProfileService ───
+vi.mock('../userProfileService.js', () => ({
+  getTelemetryConsent: vi.fn(() => false),
+  setTelemetryConsent: vi.fn(() => true),
+}));
+
+// ─── Mock de agentRequestQueue ───
+vi.mock('../agentRequestQueue.js', () => ({
+  listRequests: vi.fn(async () => []),
+  getRequest: vi.fn(async (_id) => null),
+}));
+
+// ─── Mock de fetch ───
+global.fetch = vi.fn();
+
+function setOnline(value) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+beforeEach(() => {
+  fakeDB = makeFakeDB();
+  setOnline(true);
+  vi.clearAllMocks();
+  
+  global.fetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true }),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setOnline(true);
+});
+
+// Importar los módulos mockeados
+import { getTelemetryConsent } from '../userProfileService.js';
+import { listRequests, getRequest } from '../agentRequestQueue.js';
+
+describe('agentTelemetrySync — syncAgentTelemetry', () => {
+  it('respeta consentimiento denegado (default OFF)', async () => {
+    // Recargar módulo con VITE_TELEMETRY_INGEST_URL vacío
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', '');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(false);
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('respeta offline', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', '');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(false);
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('respeta VITE_TELEMETRY_INGEST_URL vacío (no-op)', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', '');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('no hace nada si no hay requests pendientes de sync', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+    listRequests.mockResolvedValue([]);
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('anonimiza y envía requests con status=done y synced !== true', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const doneRequests = [
+      {
+        id: 1,
+        ts_submit: 1234567890,
+        ts_done: 1234567900,
+        prompt: '¿Qué le pasa a mi café?', // PII - debe removerse
+        response: 'Tu café tiene...', // PII - debe removerse
+        route: 'chat',
+        model: 'llama3:70b',
+        grounding: { entities: ['cafe'], tools: ['get_species'] },
+        latency: { t_total_ms: 1500, t_first_token_ms: 200 },
+        tokens_in: 50,
+        tokens_out: 100,
+        retries: 0,
+        status: 'done',
+        synced: false,
+      },
+      {
+        id: 2,
+        ts_submit: 1234567891,
+        ts_done: 1234567910,
+        prompt: 'Ayuda con mi tomate', // PII - debe removerse
+        response: 'Para tu tomate...', // PII - debe removerse
+        route: 'foliage',
+        model: 'gpt-4o',
+        grounding: { entities: ['tomate'], tools: [] },
+        latency: { t_total_ms: 2000 },
+        tokens_in: 60,
+        tokens_out: 120,
+        retries: 1,
+        status: 'done',
+        synced: false,
+      },
+    ];
+
+    listRequests.mockResolvedValue(doneRequests);
+    getRequest.mockImplementation(async (_id) => {
+      return doneRequests.find((r) => r.id === _id) || null;
+    });
+
+    await syncAgentTelemetry();
+
+    // Verificar que se llamó a fetch
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const fetchCall = global.fetch.mock.calls[0];
+    expect(fetchCall[0]).toBe('https://telemetry.example.com/ingest');
+    expect(fetchCall[1].method).toBe('POST');
+    expect(fetchCall[1].headers['Content-Type']).toBe('application/json');
+
+    // Verificar payload anonimizado
+    const payload = JSON.parse(fetchCall[1].body);
+    expect(payload).toHaveLength(2);
+
+    // Primer request anonimizado
+    expect(payload[0].id).toBe(1);
+    expect(payload[0].prompt).toBeUndefined(); // PII removido
+    expect(payload[0].response).toBeUndefined(); // PII removido
+    expect(payload[0].route).toBe('chat');
+    expect(payload[0].model).toBe('llama3:70b');
+    expect(payload[0].grounding).toEqual({ entities: ['cafe'], tools: ['get_species'] });
+    expect(payload[0].latency.t_total_ms).toBe(1500);
+
+    // Segundo request anonimizado
+    expect(payload[1].id).toBe(2);
+    expect(payload[1].prompt).toBeUndefined(); // PII removido
+    expect(payload[1].response).toBeUndefined(); // PII removido
+    expect(payload[1].route).toBe('foliage');
+    expect(payload[1].model).toBe('gpt-4o');
+  });
+
+  it('ignora requests que no están done', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const requests = [
+      { id: 1, status: 'queued', synced: false }, // No done
+      { id: 2, status: 'failed', synced: false }, // No done
+      { id: 3, status: 'sending', synced: false }, // No done
+    ];
+
+    listRequests.mockResolvedValue(requests);
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('ignora requests ya sincronizados (synced: true)', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const requests = [
+      {
+        id: 1,
+        status: 'done',
+        synced: true, // Ya sincronizado
+        prompt: 'test',
+        route: 'chat',
+      },
+    ];
+
+    listRequests.mockResolvedValue(requests);
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('marca requests como sincronizados tras POST exitoso', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const doneRequests = [
+      {
+        id: 1,
+        ts_submit: 1234567890,
+        ts_done: 1234567900,
+        prompt: 'test',
+        route: 'chat',
+        model: 'llama3:70b',
+        status: 'done',
+        synced: false,
+        grounding: {},
+        latency: {},
+      },
+    ];
+
+    listRequests.mockResolvedValue(doneRequests);
+    getRequest.mockImplementation(async (_id) => {
+      return doneRequests.find((r) => r.id === _id) || null;
+    });
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result.synced).toBe(1);
+    expect(Result.errors).toBe(0);
+
+    // Verificar que el request quedó marcado como synced: true
+    const syncedRequest = await getRequest(1);
+    expect(syncedRequest.synced).toBe(true);
+  });
+
+  it('falla silente si el endpoint responde error', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const doneRequests = [
+      {
+        id: 1,
+        ts_submit: 1234567890,
+        ts_done: 1234567900,
+        prompt: 'test',
+        route: 'chat',
+        status: 'done',
+        synced: false,
+        grounding: {},
+        latency: {},
+      },
+    ];
+
+    listRequests.mockResolvedValue(doneRequests);
+
+    // Mock response error
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toEqual({ synced: 0, errors: 1 });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('falla silente si hay excepción (no lanza)', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    // Mock que lanza excepción
+    getTelemetryConsent.mockImplementation(() => {
+      throw new Error('localStorage error');
+    });
+
+    const Result = await syncAgentTelemetry();
+
+    expect(Result).toBeNull(); // Falla silente
+  });
+});
+
+describe('agentTelemetrySync — isTelemetrySyncEnabled', () => {
+  it('devuelve false si consentimiento denegado', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { isTelemetrySyncEnabled } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(false);
+    setOnline(true);
+
+    expect(isTelemetrySyncEnabled()).toBe(false);
+  });
+
+  it('devuelve false si offline', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { isTelemetrySyncEnabled } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(false);
+
+    expect(isTelemetrySyncEnabled()).toBe(false);
+  });
+
+  it('devuelve false si VITE_TELEMETRY_INGEST_URL vacío', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', '');
+    const { isTelemetrySyncEnabled } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    expect(isTelemetrySyncEnabled()).toBe(false);
+  });
+
+  it('devuelve true si todo está habilitado', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
+    const { isTelemetrySyncEnabled } = await import('../agentTelemetrySync.js');
+    
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    expect(isTelemetrySyncEnabled()).toBe(true);
+  });
+});

--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -13,6 +13,9 @@ import {
   getNotificationStyle,
   setNotificationStyle,
   DEFAULT_NOTIFICATION_STYLE,
+  getTelemetryConsent,
+  setTelemetryConsent,
+  __PROFILE_KEYS__,
 } from '../userProfileService.js';
 
 describe('userProfileService (#200)', () => {
@@ -273,5 +276,63 @@ describe('resolveAltitudToSave — coalesce no-destructivo (#1213-regresion)', (
       saveProfile({ nombre: 'Lili' });
       expect(getNotificationStyle()).toBe('demo');
     });
+  });
+});
+
+describe('consentimiento de telemetría (#6230)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('getTelemetryConsent devuelve false por defecto (OFF)', () => {
+    expect(getTelemetryConsent()).toBe(false);
+  });
+
+  it('setTelemetryConsent(true) persiste y relee true', () => {
+    expect(setTelemetryConsent(true)).toBe(true);
+    expect(getTelemetryConsent()).toBe(true);
+  });
+
+  it('setTelemetryConsent(false) persiste y relee false', () => {
+    setTelemetryConsent(true);
+    expect(getTelemetryConsent()).toBe(true);
+
+    setTelemetryConsent(false);
+    expect(getTelemetryConsent()).toBe(false);
+  });
+
+  it('getTelemetryConsent falla silente si localStorage no disponible', () => {
+    const originalLocalStorage = window.localStorage;
+    delete window.localStorage;
+
+    expect(getTelemetryConsent()).toBe(false);
+
+    window.localStorage = originalLocalStorage;
+  });
+
+  it('setTelemetryConsent falla silente si localStorage no disponible', () => {
+    const originalLocalStorage = window.localStorage;
+    delete window.localStorage;
+
+    expect(setTelemetryConsent(true)).toBe(false);
+
+    window.localStorage = originalLocalStorage;
+  });
+
+  it('consentimiento es independiente del perfil principal', () => {
+    saveProfile({ nombre: 'Carlos' });
+    setTelemetryConsent(true);
+
+    const profile = getProfile();
+    expect(profile.nombre).toBe('Carlos');
+    expect(profile.telemetry_consent).toBeUndefined(); // No mezcla keys
+    expect(getTelemetryConsent()).toBe(true);
+
+    localStorage.clear();
+    expect(getTelemetryConsent()).toBe(false); // Se limpia por separado
+  });
+
+  it('__PROFILE_KEYS__ exporta la key de consentimiento', () => {
+    expect(__PROFILE_KEYS__.TELEMETRY_CONSENT_KEY).toContain('telemetry_consent');
   });
 });

--- a/src/services/agentTelemetrySync.js
+++ b/src/services/agentTelemetrySync.js
@@ -1,0 +1,211 @@
+/**
+ * agentTelemetrySync.js — Sincronización de telemetría rica del agente (#6230).
+ *
+ * Si el usuario dio consentimiento (via userProfileService.setTelemetryConsent),
+ * envía los metadatos anónimos de las consultas completadas al backend de
+ * telemetría. NO envía prompts completos (privacidad-first) ni PII.
+ *
+ * Flujo:
+ *   1. Verifica consentimiento (getTelemetryConsent)
+ *   2. Verifica que esté online (navigator.onLine)
+ *   3. Verifica que VITE_TELEMETRY_INGEST_URL esté configurado
+ *   4. Obtiene requests con status='done' de agentRequestQueue.listRequests()
+ *   5. Filtra los no sincronizados (synced !== true)
+ *   6. Anonimiza (remueve prompt completo, mantiene metadata)
+ *   7. POST al endpoint en batch
+ *   8. Marca como sincronizados (synced: true)
+ *   9. Falla silente (no bloquea UX)
+ *
+ * Env variable (build-time):
+ *   - VITE_TELEMETRY_INGEST_URL: URL del endpoint /ingest (default '' = no-op)
+ *
+ * Schema del payload enviado (anónimo):
+ *   [
+ *     {
+ *       id: number,
+ *       ts_submit: number,
+ *       ts_done: number,
+ *       route: string,
+ *       model: string,
+ *       grounding: { ... },    // sin PII
+ *       latency: { ... },      // agregados
+ *       tokens_in: number,
+ *       tokens_out: number,
+ *       retries: number,
+ *     },
+ *     ...
+ *   ]
+ *
+ * NO incluye:
+ *   - prompt (puede contener datos sensibles del usuario)
+ *   - response (puede contener datos sensibles)
+ *   - user_id, finca_id, coords (PII)
+ */
+
+import { getTelemetryConsent } from './userProfileService.js';
+import { listRequests, getRequest } from './agentRequestQueue.js';
+
+/**
+ * Devuelve la URL de ingest de telemetría.
+ * Leer en tiempo de ejecución (no en import) para facilitar testing.
+ *
+ * @returns {string}
+ */
+export function getTelemetryIngestUrl() {
+  return import.meta.env.VITE_TELEMETRY_INGEST_URL || '';
+}
+
+/**
+ * Anonimiza un request del agente removiendo PII y datos sensibles.
+ *
+ * @param {Object} request - request completo de agentRequestQueue
+ * @returns {Object} request anonimizado
+ */
+function anonymizeRequest(request) {
+  if (!request || typeof request !== 'object') return null;
+
+  return {
+    id: request.id,
+    ts_submit: request.ts_submit,
+    ts_done: request.ts_done,
+    route: request.route || 'unknown',
+    model: request.model || 'default',
+    grounding: request.grounding || {},
+    latency: request.latency || {},
+    tokens_in: request.tokens_in,
+    tokens_out: request.tokens_out,
+    retries: request.retries || 0,
+  };
+}
+
+/**
+ * Marca un request como sincronizado (synced: true).
+ *
+ * @param {number} id - id del request
+ * @returns {Promise<boolean>}
+ */
+async function markRequestSynced(id) {
+  try {
+    const item = await getRequest(id);
+    if (!item) return false;
+
+    const { openDB, STORES } = await import('../db/dbCore.js');
+    const db = await openDB();
+    const tx = db.transaction(STORES.AGENT_REQUESTS, 'readwrite');
+    const store = tx.objectStore(STORES.AGENT_REQUESTS);
+
+    item.synced = true;
+    await new Promise((resolve, reject) => {
+      const req = store.put(item);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+
+    return true;
+  } catch (e) {
+    console.debug('[agentTelemetrySync] markRequestSynced error:', e);
+    return false;
+  }
+}
+
+/**
+ * Sincroniza la telemetría del agente al backend.
+ *
+ * Solo sincroniza si:
+ *   - Hay consentimiento del usuario (getTelemetryConsent)
+ *   - Está online (navigator.onLine)
+ *   - VITE_TELEMETRY_INGEST_URL está configurado
+ *
+ * Procesa requests con status='done' y synced !== true, los anonimiza
+ * y los envía en batch al endpoint. Luego marca como sincronizados.
+ *
+ * Falla silente (devuelve null en caso de error) para no bloquear la UX.
+ *
+ * @returns {Promise<{ synced: number, errors: number } | null>}
+ */
+export async function syncAgentTelemetry() {
+  try {
+    // 1. Verificar consentimiento
+    if (!getTelemetryConsent()) {
+      console.debug('[agentTelemetrySync] consentimiento denegado — no sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 2. Verificar online
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      console.debug('[agentTelemetrySync] offline — no sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 3. Verificar endpoint configurado
+    const telemetryUrl = getTelemetryIngestUrl();
+    if (!telemetryUrl || typeof telemetryUrl !== 'string') {
+      console.debug('[agentTelemetrySync] VITE_TELEMETRY_INGEST_URL no configurado — no sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 4. Obtener requests completados
+    const allRequests = await listRequests();
+    const doneRequests = allRequests.filter((r) => r.status === 'done' && r.synced !== true);
+
+    if (doneRequests.length === 0) {
+      console.debug('[agentTelemetrySync] no hay requests pendientes de sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 5. Anonimizar requests
+    const payload = doneRequests.map(anonymizeRequest).filter(Boolean);
+
+    if (payload.length === 0) {
+      console.debug('[agentTelemetrySync] payload vacío tras anonimización');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 6. POST al endpoint
+    const response = await fetch(telemetryUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.warn(`[agentTelemetrySync] endpoint respondió ${response.status}`);
+      return { synced: 0, errors: payload.length };
+    }
+
+    // 7. Marcar como sincronizados
+    let syncedCount = 0;
+    let errorsCount = 0;
+
+    for (const request of doneRequests) {
+      const marked = await markRequestSynced(request.id);
+      if (marked) {
+        syncedCount++;
+      } else {
+        errorsCount++;
+      }
+    }
+
+    console.debug(`[agentTelemetrySync] sincronizados ${syncedCount}, errors ${errorsCount}`);
+    return { synced: syncedCount, errors: errorsCount };
+  } catch (e) {
+    console.debug('[agentTelemetrySync] error en sync (falla silente):', e);
+    return null; // Falla silente — no bloquea UX
+  }
+}
+
+/**
+ * Devuelve si la sincronización está habilitada (consentimiento + online + URL).
+ * Útil para UI que muestra estado de sync.
+ *
+ * @returns {boolean}
+ */
+export function isTelemetrySyncEnabled() {
+  if (!getTelemetryConsent()) return false;
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) return false;
+  const telemetryUrl = getTelemetryIngestUrl();
+  if (!telemetryUrl || typeof telemetryUrl !== 'string') return false;
+  return true;
+}

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -541,8 +541,53 @@ contradice lo que el usuario dice ahora, dale prioridad a lo que dice ahora.
 === FIN PERFIL DEL USUARIO ===`;
 }
 
+/**
+ * Consentimiento de telemetría de uso del agente (#6230).
+ *
+ * Si el usuario habilita esta opción, los metadatos anónimos de las
+ * consultas al agente (route, model, latencias, tokens, etc.) se envían
+ * al backend de telemetría para mejorar el producto. El prompt COMPLETO
+ * nunca se envía (privacidad-first). Default: OFF.
+ *
+ * Se guarda en localStorage independiente del perfil para separar
+ * identidad (nombre, región) de métricas agregadas (latencias, modelos).
+ */
+const TELEMETRY_CONSENT_KEY = `${PROFILE_PREFIX}telemetry_consent:v1`;
+
+/**
+ * Lee el consentimiento de telemetría. Default: false (OFF).
+ * @returns {boolean}
+ */
+export function getTelemetryConsent() {
+  if (!hasStorage()) return false;
+  try {
+    const value = window.localStorage.getItem(TELEMETRY_CONSENT_KEY);
+    return value === 'true';
+  } catch (e) {
+    console.warn('[userProfile] No se pudo leer consentimiento telemetría:', e);
+    return false;
+  }
+}
+
+/**
+ * Persiste el consentimiento de telemetría.
+ * @param {boolean} enabled
+ * @returns {boolean} valor guardado
+ */
+export function setTelemetryConsent(enabled) {
+  if (!hasStorage()) return false;
+  try {
+    window.localStorage.setItem(TELEMETRY_CONSENT_KEY, enabled ? 'true' : 'false');
+    return enabled;
+  } catch (e) {
+    console.warn('[userProfile] No se pudo guardar consentimiento telemetría:', e);
+    return false;
+  }
+}
+
 export const __PROFILE_KEYS__ = {
   PROFILE_KEY,
   PROFILE_DONE_KEY,
   PROFILE_SKIPPED_KEY,
+  TELEMETRY_CONSENT_KEY,
 };


### PR DESCRIPTION
## Summary

Implementa sincronización de telemetría rica del agente para mejorar Chagra con datos agregados anónimos de uso.

## Cambios

### userProfileService.js
- **Toggle de consentimiento**: `getTelemetryConsent()` y `setTelemetryConsent(enabled)`
- **Default OFF**: Privacy-first, el usuario debe activar explícitamente
- **Persistencia independiente**: Guarda en `localStorage` separado del perfil principal
- **Key exportada**: `__PROFILE_KEYS__.TELEMETRY_CONSENT_KEY`

### agentTelemetrySync.js (nuevo)
- **syncAgentTelemetry()**: Función principal de sincronización
  - Verifica consentimiento + online + `VITE_TELEMETRY_INGEST_URL` configurado
  - POST de requests con `status='done'` y `synced !== true`
  - **Anonimización**: Remueve PII (prompt, response) pero mantiene metadata útil
  - **Metadata enviada**: route, model, grounding, latency, tokens_in, tokens_out
  - **Marca sincronizados**: `synced: true` tras éxito
  - **Falla silente**: No bloquea UX si hay errores

- **isTelemetrySyncEnabled()**: Helper para UI que muestra estado de sync
- **getTelemetryIngestUrl()**: Getter inyectable para facilitar testing

### Tests
- **userProfileService.test.js**: 7 tests nuevos para consentimiento
  - Default OFF, persistencia, fallback sin localStorage
- **agentTelemetrySync.test.js**: 14 tests completos
  - Consentimiento, offline, URL vacío, anonimización
  - Sync de requests done, marcar sincronizados
  - Fallos silentes, isTelemetrySyncEnabled

### .env.example
- Agrega `VITE_TELEMETRY_INGEST_URL=` con documentación

## Test plan

```bash
# Tests de funcionalidad implementada
npx vitest run src/services/__tests__/userProfileService.test.js  # 37 passed
npx vitest run src/services/__tests__/agentTelemetrySync.test.js   # 14 passed

# Lint
npx eslint src/services/userProfileService.js src/services/agentTelemetrySync.js  # Clean

# Build
npm run build  # ✓ built in 3.92s
```

## MCP tools usados

No se usaron MCP tools para esta implementación (solo código de infraestructura).

## Riesgos conocidos

- **Bajo**: La sincronización es fire-and-forget, no afecta UX si falla
- **Bajo**: Default OFF, no se envía nada sin consentimiento explícito
- **Bajo**: Anonimización remueve prompts/responses (PII), solo envía metadata
- **Medio**: El endpoint /ingest backend (chagra-pro) debe estar implementado para recibir los datos

## Notas

- El endpoint `/ingest` backend es de **chagra-pro**, NO se implementa en este PR
- La función `syncAgentTelemetry()` debe llamarse desde algún punto de la app (ej: al cerrar el agente, periódicamente, etc.)
- Para producción: configurar `VITE_TELEMETRY_INGEST_URL` en build-time