### PR TITLE
feat(restauracion): tareas por etapa del ciclo de restauración (Daniel #4)

### DIFF
--- a/src/data/cycle-task-templates/tasks.v1.json
+++ b/src/data/cycle-task-templates/tasks.v1.json
@@ -2,43 +2,223 @@
   "version": 1,
   "stage_tasks": {
     "sowing": [
-      {"task": "Preparar el suelo", "description": "Adecuar el terreno, eliminar arvenses y nivelar", "priority": "alta"},
-      {"task": "Trazar surcos o hoyos", "description": "Definir distancia de siembra según la especie", "priority": "alta"},
-      {"task": "Aplicar enmienda orgánica", "description": "Incorporar compost o bocashi antes de sembrar", "priority": "media"}
+      {
+        "task": "Preparar el suelo",
+        "description": "Adecuar el terreno, eliminar arvenses y nivelar",
+        "priority": "alta"
+      },
+      {
+        "task": "Trazar surcos o hoyos",
+        "description": "Definir distancia de siembra según la especie",
+        "priority": "alta"
+      },
+      {
+        "task": "Aplicar enmienda orgánica",
+        "description": "Incorporar compost o bocashi antes de sembrar",
+        "priority": "media"
+      }
     ],
     "emergence": [
-      {"task": "Monitorear emergencia", "description": "Revisar aparición de plántulas diariamente", "priority": "alta"},
-      {"task": "Riego ligero", "description": "Mantener humedad superficial sin encharcar", "priority": "alta"},
-      {"task": "Control de aves y hormigas", "description": "Proteger semillas y plántulas emergentes", "priority": "media"}
+      {
+        "task": "Monitorear emergencia",
+        "description": "Revisar aparición de plántulas diariamente",
+        "priority": "alta"
+      },
+      {
+        "task": "Riego ligero",
+        "description": "Mantener humedad superficial sin encharcar",
+        "priority": "alta"
+      },
+      {
+        "task": "Control de aves y hormigas",
+        "description": "Proteger semillas y plántulas emergentes",
+        "priority": "media"
+      }
     ],
     "vegetative": [
-      {"task": "Riego", "description": "Mantener programa de riego según necesidad del cultivo", "priority": "alta"},
-      {"task": "Fertilización nitrogenada", "description": "Aplicar abono rico en N para fomentar follaje", "priority": "alta"},
-      {"task": "Control de arvenses", "description": "Deshierbe manual o mulching entre calles", "priority": "media"},
-      {"task": "Monitoreo de plagas", "description": "Inspeccionar hojas y tallos en busca de signos tempranos", "priority": "media"}
+      {
+        "task": "Riego",
+        "description": "Mantener programa de riego según necesidad del cultivo",
+        "priority": "alta"
+      },
+      {
+        "task": "Fertilización nitrogenada",
+        "description": "Aplicar abono rico en N para fomentar follaje",
+        "priority": "alta"
+      },
+      {
+        "task": "Control de arvenses",
+        "description": "Deshierbe manual o mulching entre calles",
+        "priority": "media"
+      },
+      {
+        "task": "Monitoreo de plagas",
+        "description": "Inspeccionar hojas y tallos en busca de signos tempranos",
+        "priority": "media"
+      }
     ],
     "flowering": [
-      {"task": "Monitoreo de floración", "description": "Revisar apertura de flores y presencia de polinizadores", "priority": "alta"},
-      {"task": "Fertilización rica en K y P", "description": "Aplicar fósforo y potasio para inducir floración", "priority": "alta"},
-      {"task": "Riego moderado", "description": "Evitar estrés hídrico durante antesis", "priority": "alta"},
-      {"task": "Control de hongos preventivo", "description": "Aplicar caldo bordelés o microorganismos benéficos", "priority": "media"}
+      {
+        "task": "Monitoreo de floración",
+        "description": "Revisar apertura de flores y presencia de polinizadores",
+        "priority": "alta"
+      },
+      {
+        "task": "Fertilización rica en K y P",
+        "description": "Aplicar fósforo y potasio para inducir floración",
+        "priority": "alta"
+      },
+      {
+        "task": "Riego moderado",
+        "description": "Evitar estrés hídrico durante antesis",
+        "priority": "alta"
+      },
+      {
+        "task": "Control de hongos preventivo",
+        "description": "Aplicar caldo bordelés o microorganismos benéficos",
+        "priority": "media"
+      }
     ],
     "fruiting": [
-      {"task": "Monitorear desarrollo de fruto", "description": "Revisar tamaño, color y presencia de deformaciones", "priority": "alta"},
-      {"task": "Fertilización de llenado", "description": "Aplicar potasio y calcio para calidad del fruto", "priority": "alta"},
-      {"task": "Riego constante", "description": "No dejar secar — el estrés hídrico afecta llenado", "priority": "alta"},
-      {"task": "Tutorado o soporte", "description": "Asegurar ramas cargadas de fruto", "priority": "media"}
+      {
+        "task": "Monitorear desarrollo de fruto",
+        "description": "Revisar tamaño, color y presencia de deformaciones",
+        "priority": "alta"
+      },
+      {
+        "task": "Fertilización de llenado",
+        "description": "Aplicar potasio y calcio para calidad del fruto",
+        "priority": "alta"
+      },
+      {
+        "task": "Riego constante",
+        "description": "No dejar secar — el estrés hídrico afecta llenado",
+        "priority": "alta"
+      },
+      {
+        "task": "Tutorado o soporte",
+        "description": "Asegurar ramas cargadas de fruto",
+        "priority": "media"
+      }
     ],
     "harvest_window": [
-      {"task": "Cosechar frutos maduros", "description": "Recoger en hora fresca, seleccionar por madurez", "priority": "alta"},
-      {"task": "Clasificar producto", "description": "Separar por calidad, tamaño y sanidad", "priority": "alta"},
-      {"task": "Llevar registro de cosecha", "description": "Anotar kilos, calidad y destino", "priority": "media"},
-      {"task": "Podar ramas gastadas", "description": "Eliminar ramas que ya produjeron (cultivos perennes)", "priority": "baja"}
+      {
+        "task": "Cosechar frutos maduros",
+        "description": "Recoger en hora fresca, seleccionar por madurez",
+        "priority": "alta"
+      },
+      {
+        "task": "Clasificar producto",
+        "description": "Separar por calidad, tamaño y sanidad",
+        "priority": "alta"
+      },
+      {
+        "task": "Llevar registro de cosecha",
+        "description": "Anotar kilos, calidad y destino",
+        "priority": "media"
+      },
+      {
+        "task": "Podar ramas gastadas",
+        "description": "Eliminar ramas que ya produjeron (cultivos perennes)",
+        "priority": "baja"
+      }
     ],
     "closed": [
-      {"task": "Evaluar ciclo", "description": "Hacer balance de producción e incidencias", "priority": "media"},
-      {"task": "Incorporar residuos al suelo", "description": "Picar y enterrar rastrojos para abonar", "priority": "alta"},
-      {"task": "Planificar rotación", "description": "Decidir próximo cultivo y preparar terreno", "priority": "media"}
+      {
+        "task": "Evaluar ciclo",
+        "description": "Hacer balance de producción e incidencias",
+        "priority": "media"
+      },
+      {
+        "task": "Incorporar residuos al suelo",
+        "description": "Picar y enterrar rastrojos para abonar",
+        "priority": "alta"
+      },
+      {
+        "task": "Planificar rotación",
+        "description": "Decidir próximo cultivo y preparar terreno",
+        "priority": "media"
+      }
+    ],
+    "establecimiento": [
+      {
+        "task": "Marcar y proteger la ronda hidrica",
+        "description": "Antes de sembrar, define la franja del nacimiento o quebrada que NO se interviene",
+        "priority": "alta"
+      },
+      {
+        "task": "Preparar hoyos con abono organico",
+        "description": "Hoyos al tresbolillo; agrega compost o bocashi, no quimicos",
+        "priority": "media"
+      },
+      {
+        "task": "Sembrar primero las pioneras",
+        "description": "Las especies pioneras de tu piso abren el camino para las demas",
+        "priority": "alta"
+      }
+    ],
+    "prendimiento": [
+      {
+        "task": "Revisar cuales pegaron",
+        "description": "Cuenta las plantulas vivas; anota la mortalidad para replantar",
+        "priority": "alta"
+      },
+      {
+        "task": "Regar en epocas secas",
+        "description": "Las primeras semanas son criticas si no llueve",
+        "priority": "media"
+      },
+      {
+        "task": "Proteger del ganado y herbivoros",
+        "description": "Cerca o aisla las plantulas jovenes",
+        "priority": "media"
+      }
+    ],
+    "mantenimiento": [
+      {
+        "task": "Replantar las que murieron",
+        "description": "Repon con la misma especie del rol que falto",
+        "priority": "alta"
+      },
+      {
+        "task": "Controlar la competencia sin quemar",
+        "description": "Limpia manual o plateo; NUNCA quemar (rebrota invasoras)",
+        "priority": "alta"
+      },
+      {
+        "task": "Aplicar cobertura (mulch)",
+        "description": "Conserva humedad y frena arvenses",
+        "priority": "media"
+      }
+    ],
+    "monitoreo_sucesion": [
+      {
+        "task": "Vigilar que no entren invasoras",
+        "description": "Retamo, kikuyo: control temprano antes de que florezcan",
+        "priority": "alta"
+      },
+      {
+        "task": "Registrar aves y regeneracion natural",
+        "description": "Aves frugivoras y plantulas que nacen solas = el bosque vuelve",
+        "priority": "media"
+      },
+      {
+        "task": "Medir el avance de la cobertura",
+        "description": "Foto del mismo punto cada cierto tiempo para comparar",
+        "priority": "baja"
+      }
+    ],
+    "cierre": [
+      {
+        "task": "Evaluar si se sostiene solo",
+        "description": "Se regenera sin tu intervencion? Ese es el objetivo",
+        "priority": "media"
+      },
+      {
+        "task": "Documentar el proceso para compartir",
+        "description": "Tu experiencia sirve a otros campesinos (campesino a campesino)",
+        "priority": "baja"
+      }
     ]
   }
 }

--- a/src/services/__tests__/cycleTaskService.restauracion.test.js
+++ b/src/services/__tests__/cycleTaskService.restauracion.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { getTasksForStage } from '../cycleTaskService';
+
+// #4 Daniel: el ciclo de restauración ahora tiene tareas por etapa propia
+// (establecimiento → prendimiento → mantenimiento → monitoreo_sucesion → cierre),
+// no la fenología de cultivo.
+describe('cycleTaskService — tareas de etapas de restauración', () => {
+  const stages = ['establecimiento', 'prendimiento', 'mantenimiento', 'monitoreo_sucesion', 'cierre'];
+
+  it('cada etapa de restauración tiene tareas con la forma correcta', () => {
+    for (const s of stages) {
+      const tasks = getTasksForStage(s);
+      expect(tasks.length).toBeGreaterThan(0);
+      for (const t of tasks) {
+        expect(typeof t.task).toBe('string');
+        expect(t.task.length).toBeGreaterThan(0);
+        expect(typeof t.description).toBe('string');
+        expect(['alta', 'media', 'baja']).toContain(t.priority);
+      }
+    }
+  });
+
+  it('prendimiento incluye revisar cuáles pegaron (prioridad alta)', () => {
+    const t = getTasksForStage('prendimiento');
+    expect(t.some((x) => /pegaron|prend/i.test(x.task) && x.priority === 'alta')).toBe(true);
+  });
+
+  it('mantenimiento pide replante y prohíbe quemar (anti-invasoras)', () => {
+    const t = getTasksForStage('mantenimiento');
+    expect(t.some((x) => /replant/i.test(x.task))).toBe(true);
+    expect(t.some((x) => /quemar/i.test(x.description))).toBe(true);
+  });
+
+  it('establecimiento protege la ronda hídrica antes de sembrar', () => {
+    const t = getTasksForStage('establecimiento');
+    expect(t.some((x) => /ronda|hidric/i.test(x.task))).toBe(true);
+  });
+
+  it('las etapas de cultivo siguen intactas', () => {
+    expect(getTasksForStage('sowing').length).toBeGreaterThan(0);
+    expect(getTasksForStage('harvest_window').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
El ciclo de restauración (#1514) ya tenía etapas propias pero sin tareas. Agrega plantillas agronómicas por etapa (ronda hídrica, pioneras primero, replante, NO quemar, monitoreo de invasoras/aves, autosostenibilidad) del DR-TRANSICION. hoyEnFinca las muestra vía current_stage. 5 tests. Parte de la tarea Opus #4 (restauración completa de Daniel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)