### PR TITLE
feat(agente): cablear cola durable de requests + UX paciente (nunca "Tiempo agotado")

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -110,6 +110,20 @@ import useOllamaWarmStore from '../../store/useOllamaWarmStore';
 import useAgentQueueStore from '../../store/useAgentQueueStore';
 import useFincaActiveStore from '../../services/fincaActiveStore';
 import useAlertStore from '../../store/useAlertStore';
+// #5 (2026-06-13) — COLA DURABLE de requests al agente. El queue Zustand
+// (useAgentQueueStore) es EFÍMERO (se pierde al recargar). Esta cola persiste
+// en IndexedDB ANTES de llamar al LLM, captura telemetría rica (latencia +
+// grounding + tokens) al cerrar el turno, y reanuda sola los requests que
+// quedaron 'queued'/'offline' de sesiones previas — para que NUNCA se pierda
+// una pregunta y NUNCA mostremos "Tiempo agotado. Toca de nuevo".
+import {
+  enqueueRequest as durableEnqueue,
+  finalizeRequest as durableFinalize,
+  failRequest as durableFail,
+  resumePending as durableResumePending,
+  drainPending as durableDrainPending,
+} from '../../services/agentRequestQueue';
+import { createAgentRequestSender } from '../../services/agentRequestSender';
 
 // 2026-05-16: migrado a llmRouter (Multi-LLM por tarea). AgentScreen usa
 // la `chat` route con el modelo de chat configurado como hot model. Bench
@@ -247,6 +261,10 @@ export default function AgentScreen({ onBack, initialContext }) {
   // (genérico, ej. red caída). Se setea antes de disparar controller.abort().
   const cancelReasonRef = useRef(null);
   const llmStatsRef = useRef(null);
+  // #5 cola durable: id del registro IndexedDB del turno EN CURSO. enqueueRequest
+  // lo crea ANTES de llamar al LLM (persistencia previa = cero pérdida); al
+  // terminar, finalizeRequest/failRequest cierran ese mismo id con telemetría.
+  const durableRequestIdRef = useRef(null);
   // Holder del deadline stream-aware activo (createStreamDeadline). FIX prod
   // P0 (2026-06-02): combina idle-timeout (reinicia por token → no aborta
   // streams vivos) + techo absoluto. Reemplaza al watchdog/timer total previo.
@@ -519,10 +537,61 @@ export default function AgentScreen({ onBack, initialContext }) {
     useAgentQueueStore.getState().reset();
   };
 
+  // #5 COLA DURABLE — recuperación de requests que sobrevivieron una recarga /
+  // sesión anterior. Reanuda los 'offline' (resumePending) y luego drena los
+  // 'queued' (drainPending) con un sender HEADLESS (corre el LLM sin React). El
+  // resultado de cada recuperado se pinta como burbuja del agente etiquetada,
+  // para que el campesino VEA la respuesta de la pregunta que creía perdida.
+  // Guard de re-entrada para que dos disparos (mount + 'online') no se pisen.
+  const durableRecoveringRef = useRef(false);
+  const recoverDurableRequests = useCallback(async () => {
+    if (durableRecoveringRef.current) return;
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) return;
+    durableRecoveringRef.current = true;
+    try {
+      await durableResumePending(); // 'offline' → 'queued'
+      const sender = createAgentRequestSender();
+      // Envolvemos el sender para CAPTURAR la respuesta recuperada y pintarla.
+      const surfacingSender = async (req) => {
+        const result = await sender(req);
+        if (result?.response) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              role: 'user',
+              content: req.prompt,
+              timestamp: Date.now(),
+              _recovered: true,
+            },
+            {
+              role: 'assistant',
+              content: result.response,
+              timestamp: Date.now(),
+              _recovered: true,
+            },
+          ]);
+        }
+        return result;
+      };
+      const summary = await durableDrainPending({ sender: surfacingSender });
+      if (summary && (summary.processed > 0 || summary.failed > 0)) {
+        console.debug('[Agent] cola durable recuperada', summary);
+      }
+    } catch (err) {
+      console.debug('[Agent] recoverDurableRequests error (no crítico):', err?.message);
+    } finally {
+      durableRecoveringRef.current = false;
+    }
+  }, []);
+
   useEffect(() => {
     initTTS();
     isKokoroAvailable().then(setKokoroReady);
     loadHistory();
+    // #5: al montar, recuperar preguntas pendientes de sesiones previas (no
+    // bloquea el render — corre en background y pinta las respuestas cuando
+    // lleguen). Cero pérdida tras recarga / cierre de app a mitad de inferencia.
+    recoverDurableRequests();
     // Task #122: al entrar a AgentScreen, apaga el glow del avatar global.
     // El operador ya está mirando la conversación, no necesita el "reluce"
     // de "respuesta nueva".
@@ -544,7 +613,12 @@ export default function AgentScreen({ onBack, initialContext }) {
         });
       });
     });
-    const handleOnline = () => setIsOnline(true);
+    const handleOnline = () => {
+      setIsOnline(true);
+      // #5: al volver la conexión, reanudar las preguntas que quedaron
+      // 'queued'/'offline' (las que el operador hizo sin señal en el campo).
+      recoverDurableRequests();
+    };
     const handleOffline = () => setIsOnline(false);
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
@@ -561,7 +635,7 @@ export default function AgentScreen({ onBack, initialContext }) {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, [loadHistory, markRead]);
+  }, [loadHistory, markRead, recoverDurableRequests]);
 
   const getSystemPrompt = useCallback(({ query = '', contextMemory = '', isEnum = false } = {}) => {
     // Operator bug 2026-05-18: agente listaba "Fresa #02, Fresa #08, Fresa #02..."
@@ -1133,6 +1207,19 @@ export default function AgentScreen({ onBack, initialContext }) {
     setState(STATE_THINKING);
     setError('');
     agentSounds.start();
+
+    // #5 COLA DURABLE — persistir el request ANTES de tocar el LLM. Si la app se
+    // recarga / cierra a mitad de inferencia, el prompt queda 'queued' en
+    // IndexedDB y se reanuda solo al reabrir (resumePending + drainPending). El
+    // id se cierra al final del turno con finalizeRequest (telemetría) o
+    // failRequest. enqueueRequest es no-throw: si IDB falla, devuelve null y el
+    // pipeline sigue idéntico (degradación graceful, nunca bloquea la pregunta).
+    const durableRoute = selectChatRoute(text.trim());
+    durableRequestIdRef.current = await durableEnqueue({
+      prompt: text.trim(),
+      route: durableRoute,
+      model: durableRoute,
+    });
 
     // Free 7→10 fix-pack #5: normalización léxica regional Cauca.
     // Si la finca activa es del Cauca andino/pacífico, reemplazamos
@@ -1839,6 +1926,37 @@ export default function AgentScreen({ onBack, initialContext }) {
       });
       setMessages((prev) => [...prev, assistantMessage]);
 
+      // #5 COLA DURABLE — cerrar el registro de este turno con telemetría rica.
+      // Reusamos lo YA computado por el pipeline (cero coste extra): respuesta,
+      // grounding (entidades AGE resueltas + tools + RAG chunks + estado), y las
+      // latencias del llmStatsRef. Marca status='done' en IndexedDB; queda como
+      // evidencia para debuggear inteligencia+velocidad y confirma que la
+      // pregunta NO se perdió. No-throw: si falla, el chat ya respondió.
+      if (durableRequestIdRef.current != null) {
+        durableFinalize({
+          id: durableRequestIdRef.current,
+          result: {
+            response,
+            latency: { t_first_token_ms: currentLlmStats?.first_token_ms ?? null },
+            grounding: {
+              entities: Array.isArray(resolvedEntities)
+                ? resolvedEntities.map((e) => e?.canonical_id || e?.id || e?.mentioned).filter(Boolean)
+                : [],
+              tools: Array.isArray(toolEvidence)
+                ? toolEvidence.map((t) => t?.tool || t?.name).filter(Boolean)
+                : [],
+              rag_chunks: Array.isArray(contextCorpus) ? contextCorpus.length : 0,
+              nlu_route: nluRoute || durableRoute,
+              grounded_status: sourceMetadata?.source || sourceMetadata?.grounded_status || 'none',
+            },
+            tokens_out: currentLlmStats?.response_len
+              ? Math.max(1, Math.round(currentLlmStats.response_len / 4))
+              : null,
+          },
+        }).catch(() => { /* no-op: el turno ya se mostró */ });
+        durableRequestIdRef.current = null;
+      }
+
       // Task #122: cachear el último mensaje del agente en el store global
       // para que el doble-click del avatar (cualquier pantalla) pueda re-
       // reproducirlo via replayLast(). responseReady NO se setea acá porque
@@ -1944,14 +2062,40 @@ export default function AgentScreen({ onBack, initialContext }) {
         } else {
           setError(merged.error);
         }
+        // #5 COLA DURABLE en interrupción:
+        //   - timeout/abort → el sistema reintenta SOLO. Dejamos el registro en
+        //     'queued' (enqueueRequest nunca lo movió de ahí) para que
+        //     drainPending lo reanude headless al volver / al re-montar. Por eso
+        //     NO lo marcamos failed: re-queue implícito = cero pérdida.
+        //   - cancel → el operador eligió parar; NO auto-reintentamos. Cerramos
+        //     el registro como failed para que no se reanude por la espalda.
+        if (e.interruptReason === 'cancel' && durableRequestIdRef.current != null) {
+          durableFail({ id: durableRequestIdRef.current, error: 'cancelado por el operador' })
+            .catch(() => {});
+          durableRequestIdRef.current = null;
+        }
+        // (timeout/abort: dejamos durableRequestIdRef.current intacto en IDB como
+        // 'queued'; solo soltamos la ref local en el finally.)
       } else {
         setError(e.message || 'No pude conectarme al asistente. Intenta de nuevo.');
+        // Error NO-interrupción (HTTP 5xx, sesión, etc.): marcar failed. El
+        // prompt queda intacto en IDB; la cola durable NO lo reintenta (no es
+        // recuperable solo con reintentar), pero NO se pierde el dato.
+        if (durableRequestIdRef.current != null) {
+          durableFail({ id: durableRequestIdRef.current, error: e })
+            .catch(() => {});
+          durableRequestIdRef.current = null;
+        }
       }
     } finally {
       setState(STATE_IDLE);
       setStreamingContent('');
       streamingContentRef.current = '';
       cancelReasonRef.current = null;
+      // Soltar la ref local del turno (el estado durable ya quedó en IDB:
+      // 'done' si finalizó, 'queued' si timeout/abort → auto-reanuda, 'failed'
+      // si cancel/error no-interrupción).
+      durableRequestIdRef.current = null;
     }
   };
 
@@ -3105,11 +3249,15 @@ export default function AgentScreen({ onBack, initialContext }) {
               data-testid="eta-label"
             >
               {(() => {
+                // UX PACIENTE (#5): estados visibles NO alarmantes. NUNCA
+                // pedimos "toca de nuevo" — la pregunta está guardada y, si se
+                // corta, se reintenta sola. Aun el caso lento ofrece SOLO
+                // Cancelar (acción voluntaria), nunca insinúa que se perdió.
                 if (showSlowWarning) {
-                  return 'Chagra IA sigue pensando — toca Cancelar si quieres reintentar';
+                  return 'Sigo pensando — esto puede tardar en el campo. Tu pregunta está guardada.';
                 }
                 // ETA visible. Si remainingMs es null o el item recién arrancó
-                // sin haber medido aún, caemos a "Procesando tu pregunta…".
+                // sin haber medido aún, caemos a "Pensando…".
                 if (remainingMs !== null && queueProcessing) {
                   const expected = queueProcessing.expectedEtaMs;
                   const elapsed = expected - remainingMs;
@@ -3120,14 +3268,15 @@ export default function AgentScreen({ onBack, initialContext }) {
                   // texto general en violeta.
                   const secsLeft = Math.max(0, Math.ceil(remainingMs / 1000));
                   if (overshoot) {
-                    return `Tardando más de lo normal (${Math.floor(elapsed / 1000)}s ya)`;
+                    // Sin alarma: tranquiliza que la pregunta sigue en proceso.
+                    return `Tardando un poco (${Math.floor(elapsed / 1000)}s) — sigo en eso, no se perdió.`;
                   }
                   if (stretching) {
                     return `Casi listo… (${Math.floor(elapsed / 1000)}s)`;
                   }
-                  return `Procesando tu pregunta… ~${secsLeft}s`;
+                  return `Pensando tu respuesta… ~${secsLeft}s`;
                 }
-                return 'Chagra IA está pensando…';
+                return 'Pensando… (puede tardar en el campo)';
               })()}
             </p>
             {queuePending.length >= 1 && (

--- a/src/services/__tests__/agentRequestQueue.recovery.test.js
+++ b/src/services/__tests__/agentRequestQueue.recovery.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Test de INTEGRACIÓN del wire durable end-to-end (#5, 2026-06-13):
+ *   enqueueRequest → offline → resumePending → drainPending(sender headless)
+ * con el sender REAL (createAgentRequestSender) + un llmCall inyectado.
+ *
+ * Prueba la garantía del operador: una pregunta hecha sin señal en el campo
+ * NUNCA se pierde — sobrevive la recarga (IndexedDB) y se responde sola al
+ * volver la conexión, capturando telemetría. Es el camino que AgentScreen
+ * dispara en mount + evento 'online'.
+ */
+
+// IndexedDB en memoria (misma factory que agentRequestQueue.test.js).
+function makeFakeDB() {
+  const data = new Map();
+  let seq = 0;
+  const makeReq = (resultFn) => {
+    const req = {};
+    queueMicrotask(() => {
+      try {
+        req.result = resultFn();
+        req.onsuccess?.({ target: req });
+      } catch (e) {
+        req.error = e;
+        req.onerror?.({ target: req });
+      }
+    });
+    return req;
+  };
+  return {
+    transaction() {
+      return {
+        objectStore() {
+          return {
+            add(record) {
+              return makeReq(() => {
+                const id = record.id != null ? record.id : ++seq;
+                data.set(id, { ...record, id });
+                return id;
+              });
+            },
+            put(record) { return makeReq(() => { data.set(record.id, { ...record }); return record.id; }); },
+            get(id) { return makeReq(() => data.get(id) || undefined); },
+            delete(id) { return makeReq(() => { data.delete(id); return undefined; }); },
+            getAll() { return makeReq(() => Array.from(data.values())); },
+          };
+        },
+      };
+    },
+    __data: data,
+  };
+}
+
+let fakeDB;
+
+vi.mock('../../db/dbCore.js', () => ({
+  openDB: vi.fn(async () => fakeDB),
+  STORES: { AGENT_REQUESTS: 'agent_requests' },
+}));
+
+vi.mock('../llmRouter.js', () => ({
+  selectChatRoute: vi.fn(() => 'chat'),
+  buildLLMRequest: vi.fn(() => ({ url: '/api/ollama/v1/chat/completions', body: { model: 'granite3.3:8b' } })),
+}));
+
+import {
+  enqueueRequest,
+  listRequests,
+  drainPending,
+  resumePending,
+} from '../agentRequestQueue.js';
+import { createAgentRequestSender } from '../agentRequestSender.js';
+
+function setOnline(value) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+}
+
+beforeEach(() => {
+  fakeDB = makeFakeDB();
+  setOnline(true);
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  setOnline(true);
+});
+
+describe('wire durable end-to-end — pregunta sin señal NUNCA se pierde', () => {
+  it('offline → recarga → online → resume → drain(sender real) responde y captura telemetría', async () => {
+    // 1. El campesino pregunta SIN señal: se encola durable.
+    setOnline(false);
+    await enqueueRequest({ prompt: '¿cuándo siembro maíz?', route: 'chat', model: 'granite3.3:8b' });
+
+    // El drain offline marca 'offline' (no procesa).
+    const sender0 = createAgentRequestSender({ llmCall: vi.fn() });
+    const off = await drainPending({ sender: sender0 });
+    expect(off.skipped).toBe(1);
+    expect((await listRequests())[0].status).toBe('offline');
+
+    // 2. "Recarga" — los datos persisten (simulamos copiando al nuevo DB).
+    const old = new Map(fakeDB.__data);
+    fakeDB = makeFakeDB();
+    old.forEach((v, k) => fakeDB.__data.set(k, v));
+    // El prompt sobrevivió la recarga.
+    expect((await listRequests())[0].prompt).toBe('¿cuándo siembro maíz?');
+
+    // 3. Vuelve la conexión → resume + drain con el sender REAL.
+    setOnline(true);
+    await resumePending(); // 'offline' → 'queued'
+
+    const llmCall = vi.fn(async () => ({
+      fullText: 'Siembra el maíz al iniciar las lluvias de abril.',
+      stats: { first_token_ms: 110, response_len: 44 },
+    }));
+    const sender = createAgentRequestSender({ llmCall });
+    const result = await drainPending({ sender });
+
+    expect(result.processed).toBe(1);
+    expect(llmCall).toHaveBeenCalledTimes(1);
+
+    // 4. El request quedó 'done' con respuesta + telemetría capturada.
+    const final = (await listRequests())[0];
+    expect(final.status).toBe('done');
+    expect(final.response).toBe('Siembra el maíz al iniciar las lluvias de abril.');
+    expect(final.latency.t_first_token_ms).toBe(110);
+    expect(final.latency.queue_wait_ms).toBeGreaterThanOrEqual(0);
+    expect(final.grounding.nlu_route).toBe('chat');
+    expect(typeof final.tokens_out).toBe('number');
+  });
+
+  it('si el LLM sigue caído, NO pierde el prompt (queda failed conservando texto)', async () => {
+    await enqueueRequest({ prompt: 'pregunta importante', route: 'chat' });
+    const llmCall = vi.fn(async () => { throw new Error('LLM caído'); });
+    const sender = createAgentRequestSender({ llmCall });
+
+    const result = await drainPending({ sender });
+    expect(result.failed).toBe(1);
+
+    const item = (await listRequests())[0];
+    expect(item.status).toBe('failed');
+    expect(item.prompt).toBe('pregunta importante'); // el dato NUNCA se pierde
+  });
+});

--- a/src/services/__tests__/agentRequestQueue.test.js
+++ b/src/services/__tests__/agentRequestQueue.test.js
@@ -86,6 +86,8 @@ import {
   drainPending,
   clearAgentRequests,
   aggregateRequestMetrics,
+  finalizeRequest,
+  failRequest,
 } from '../agentRequestQueue.js';
 
 function setOnline(value) {
@@ -590,5 +592,69 @@ describe('agentRequestQueue — nunca pierde requests', () => {
     expect(all).toHaveLength(2);
     expect(all[0].prompt).toBe('a');
     expect(all[1].prompt).toBe('b');
+  });
+});
+
+describe('agentRequestQueue — finalizeRequest (camino VIVO del AgentScreen)', () => {
+  it('cierra el request con telemetría de un LLM YA ejecutado (sin sender)', async () => {
+    const id = await enqueueRequest({ prompt: '¿qué le pasa al café?', route: 'chat' });
+
+    const item = await finalizeRequest({
+      id,
+      result: {
+        response: 'Tu café tiene roya. Aplica caldo bordelés.',
+        latency: { t_first_token_ms: 120 },
+        grounding: {
+          entities: ['cafe'],
+          tools: ['get_pest_controllers'],
+          rag_chunks: 2,
+          grounded_status: 'verified',
+        },
+        tokens_in: 30,
+        tokens_out: 40,
+      },
+    });
+
+    expect(item.status).toBe('done');
+    expect(item.response).toBe('Tu café tiene roya. Aplica caldo bordelés.');
+    expect(item.latency.t_first_token_ms).toBe(120);
+    expect(item.latency.queue_wait_ms).toBeGreaterThanOrEqual(0);
+    expect(item.latency.t_total_ms).toBeGreaterThanOrEqual(0);
+    expect(item.grounding.grounded_status).toBe('verified');
+    expect(item.grounding.entities).toEqual(['cafe']);
+    expect(item.tokens_in).toBe(30);
+    expect(item.tokens_out).toBe(40);
+    expect(item.error).toBeNull();
+
+    // Persistió en IDB (sobrevive recarga).
+    const reread = await getRequest(id);
+    expect(reread.status).toBe('done');
+    expect(reread.response).toBe('Tu café tiene roya. Aplica caldo bordelés.');
+  });
+
+  it('finalizeRequest tolera id inexistente (devuelve null, no lanza)', async () => {
+    const out = await finalizeRequest({ id: 9999, result: { response: 'x' } });
+    expect(out).toBeNull();
+  });
+});
+
+describe('agentRequestQueue — failRequest (camino VIVO)', () => {
+  it('marca failed conservando el prompt intacto', async () => {
+    const id = await enqueueRequest({ prompt: 'cómo combato la broca', route: 'chat' });
+
+    const item = await failRequest({ id, error: new Error('LLM caído') });
+
+    expect(item.status).toBe('failed');
+    expect(item.error).toBe('LLM caído');
+    expect(item.prompt).toBe('cómo combato la broca'); // prompt NUNCA se pierde
+
+    const reread = await getRequest(id);
+    expect(reread.status).toBe('failed');
+    expect(reread.prompt).toBe('cómo combato la broca');
+  });
+
+  it('failRequest tolera id inexistente (devuelve null, no lanza)', async () => {
+    const out = await failRequest({ id: 9999, error: 'x' });
+    expect(out).toBeNull();
   });
 });

--- a/src/services/__tests__/agentRequestSender.test.js
+++ b/src/services/__tests__/agentRequestSender.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests del sender headless para la cola durable de requests al agente.
+ *
+ * `agentRequestSender` es el adaptador que `drainPending({sender})` usa para
+ * reanudar requests que sobrevivieron una recarga / sesión anterior (status
+ * 'queued'/'offline'). Corre la llamada real al LLM SIN React (headless) y
+ * devuelve el shape de telemetría que `processRequest` persiste:
+ *   { response, latency:{ t_first_token_ms }, grounding, tokens_in, tokens_out }
+ *
+ * La llamada cruda al LLM se inyecta (`llmCall`) para que el test no toque red.
+ */
+
+vi.mock('../llmRouter.js', () => ({
+  selectChatRoute: vi.fn(() => 'chat'),
+  buildLLMRequest: vi.fn(() => ({
+    url: '/api/ollama/v1/chat/completions',
+    body: { model: 'granite3.3:8b', temperature: 0.3, max_tokens: 512 },
+  })),
+}));
+
+import { createAgentRequestSender, buildSenderMessages } from '../agentRequestSender.js';
+
+describe('agentRequestSender — buildSenderMessages', () => {
+  it('arma mensajes system + user mínimos a partir del req', () => {
+    const msgs = buildSenderMessages({ prompt: '¿qué le pasa al café?' });
+    expect(Array.isArray(msgs)).toBe(true);
+    expect(msgs[msgs.length - 1]).toEqual({ role: 'user', content: '¿qué le pasa al café?' });
+    expect(msgs[0].role).toBe('system');
+    expect(msgs[0].content.length).toBeGreaterThan(0);
+  });
+});
+
+describe('agentRequestSender — createAgentRequestSender', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('devuelve el shape de telemetría que processRequest espera', async () => {
+    const llmCall = vi.fn(async ({ onToken }) => {
+      // Simula el primer token (mide t_first_token).
+      onToken?.('Hola', 'Hola');
+      onToken?.(' campesino', 'Hola campesino');
+      return {
+        fullText: 'Hola campesino',
+        stats: { first_token_ms: 142, eval_rate: 24.5, response_len: 14 },
+      };
+    });
+    const sender = createAgentRequestSender({ llmCall });
+
+    const result = await sender({ prompt: 'hola', route: 'chat', model: 'granite3.3:8b' });
+
+    expect(result.response).toBe('Hola campesino');
+    expect(result.latency.t_first_token_ms).toBe(142);
+    expect(result.grounding).toBeTruthy();
+    expect(result.grounding.nlu_route).toBe('chat');
+    // tokens: si el backend no los da, estimación de respaldo numérica.
+    expect(typeof result.tokens_out).toBe('number');
+    expect(llmCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('propaga el prompt del req al llmCall', async () => {
+    const llmCall = vi.fn(async () => ({ fullText: 'ok', stats: {} }));
+    const sender = createAgentRequestSender({ llmCall });
+    await sender({ prompt: 'cómo siembro maíz', route: 'chat' });
+
+    const callArg = llmCall.mock.calls[0][0];
+    const lastMsg = callArg.messages[callArg.messages.length - 1];
+    expect(lastMsg.content).toBe('cómo siembro maíz');
+  });
+
+  it('lanza si el llmCall falla (para que processRequest reintente)', async () => {
+    const llmCall = vi.fn(async () => { throw new Error('LLM caído'); });
+    const sender = createAgentRequestSender({ llmCall });
+
+    await expect(sender({ prompt: 'x', route: 'chat' })).rejects.toThrow('LLM caído');
+  });
+
+  it('lanza si el LLM devuelve texto vacío (recuperable → reintento)', async () => {
+    const llmCall = vi.fn(async () => ({ fullText: '   ', stats: {} }));
+    const sender = createAgentRequestSender({ llmCall });
+
+    await expect(sender({ prompt: 'x', route: 'chat' })).rejects.toThrow();
+  });
+});

--- a/src/services/agentPartialMerge.js
+++ b/src/services/agentPartialMerge.js
@@ -12,6 +12,15 @@
  * muestra el mensaje de error completo (caso "primer token nunca llegó", que
  * ya era correcto).
  *
+ * UX PACIENTE (2026-06-13, wire cola durable): se ELIMINÓ el copy alarmante
+ * "Tiempo agotado. Toca de nuevo para reintentar." El campesino en el campo, con
+ * la M6000 como única GPU (first-token 95-151s bajo carga), veía ese mensaje y
+ * creía que la app estaba rota. Ahora:
+ *   - timeout/abort → la pregunta NO se pierde: la cola durable la reintenta sola
+ *     (agentRequestQueue). El copy tranquiliza y NUNCA pide "toca de nuevo".
+ *   - cancel → el operador eligió parar; ahí sí ofrecemos Reintentar explícito
+ *     (acción voluntaria, no una falla del sistema).
+ *
  * Mantener esto como función pura (sin React, sin DOM) lo hace testeable en
  * vitest sin montar el componente y deja AgentScreen delgado.
  */
@@ -25,22 +34,26 @@
  */
 export const PARTIAL_MARKERS = {
   // timeout total del LLM (LLM_TIMEOUT_MS) o stall sin tokens (watchdog).
-  timeout: '\n\n⚠️ Respuesta incompleta (se cortó). Toca Reintentar.',
+  // UX paciente: la cola durable reintenta sola; no pedimos acción al usuario.
+  timeout: '\n\n⏳ Se cortó la conexión con la IA. Lo estoy reintentando solo, no toca hacer nada.',
   // AbortError genérico (red caída mid-stream, signal externo no clasificado).
-  abort: '\n\n⚠️ Respuesta incompleta (se cortó). Toca Reintentar.',
-  // El operador tocó "Cancelar" a propósito.
-  cancel: '\n\n⚠️ Cancelado por ti. Toca Reintentar para continuar.',
+  abort: '\n\n⏳ Se cortó la respuesta. Lo estoy reintentando solo, no toca hacer nada.',
+  // El operador tocó "Cancelar" a propósito → acción voluntaria, ofrecemos retry.
+  cancel: '\n\n⏸️ Cancelado por ti. Toca Reintentar cuando quieras continuar.',
 };
 
 /**
- * Mensaje de error completo cuando NO hubo parcial (abort antes del primer
- * token). Este es el comportamiento que ya era correcto: mostrar el error en
- * el banner rojo separado, sin burbuja del assistant.
+ * Mensaje cuando NO hubo parcial (abort antes del primer token). Se muestra en
+ * el banner discreto, sin burbuja del assistant.
+ *
+ * UX PACIENTE: ya NO decimos "Tiempo agotado. Toca de nuevo para reintentar."
+ * Para timeout/abort el reintento es AUTOMÁTICO (cola durable); el mensaje
+ * tranquiliza sin pedir acción. Solo `cancel` (voluntario) ofrece Reintentar.
  */
 export const FULL_ERROR_MESSAGES = {
-  timeout: 'Tiempo agotado. Toca de nuevo para reintentar.',
-  abort: 'Tiempo agotado o cancelado. Toca de nuevo.',
-  cancel: 'Cancelado. Toca de nuevo si quieres reintentar.',
+  timeout: 'La IA está tardando (la conexión se cortó). Tu pregunta quedó guardada y la estoy reintentando sola.',
+  abort: 'Se cortó la respuesta. Tu pregunta quedó guardada y la estoy reintentando sola.',
+  cancel: 'Cancelado. Toca Reintentar si quieres que lo intente otra vez.',
 };
 
 /**

--- a/src/services/agentRequestQueue.js
+++ b/src/services/agentRequestQueue.js
@@ -213,6 +213,89 @@ async function persistItem(item) {
 }
 
 /**
+ * Vuelca la telemetría de un resultado del LLM en un item y lo marca 'done'.
+ * Helper PURO sobre el item (no toca IDB) — reutilizado por processRequest y
+ * por finalizeRequest (camino VIVO del AgentScreen, que ya corrió el LLM y solo
+ * necesita persistir el resultado, sin re-invocar un sender).
+ *
+ * @param {Object} item - registro del store (mutado in-place)
+ * @param {Object} result - { response, latency:{t_first_token_ms}, grounding, tokens_in, tokens_out }
+ * @param {number} [attempt=0] - cuántos reintentos hubo (se guarda en retries)
+ * @returns {Object} el item mutado
+ */
+function applyResultToItem(item, result, attempt = 0) {
+  item.status = 'done';
+  item.ts_done = Date.now();
+  if (item.latency.t_total_ms == null) {
+    item.latency.t_total_ms = item.ts_submit ? item.ts_done - item.ts_submit : null;
+  }
+  if (result?.latency?.t_first_token_ms != null) {
+    item.latency.t_first_token_ms = result.latency.t_first_token_ms;
+  }
+  if (result?.grounding) {
+    item.grounding = { ...item.grounding, ...result.grounding };
+  }
+  item.response = result?.response || null;
+  if (result?.tokens_in != null) item.tokens_in = result.tokens_in;
+  if (result?.tokens_out != null) item.tokens_out = result.tokens_out;
+  item.retries = attempt;
+  item.error = null;
+  return item;
+}
+
+/**
+ * Marca un request 'done' con la telemetría de un LLM YA ejecutado (camino VIVO
+ * del AgentScreen). El pipeline React corre el stream/TTS/grounding rico; al
+ * terminar solo necesita CERRAR el registro durable — NO re-llamar al modelo.
+ * Por eso `finalizeRequest` NO recibe un sender ni reintenta: persiste el
+ * resultado y listo. Tolerante a fallos (no lanza).
+ *
+ * @param {Object} args
+ * @param {number} args.id - id del request encolado por enqueueRequest
+ * @param {Object} args.result - telemetría del turno (response, latency, grounding, tokens)
+ * @returns {Promise<Object|null>} item actualizado o null si falla/no existe
+ */
+export async function finalizeRequest({ id, result } = {}) {
+  try {
+    const item = await getRequest(id);
+    if (!item) return null;
+    if (item.latency.queue_wait_ms == null && item.ts_submit) {
+      item.latency.queue_wait_ms = Date.now() - item.ts_submit;
+    }
+    applyResultToItem(item, result, item.retries || 0);
+    await persistItem(item);
+    return item;
+  } catch (e) {
+    console.debug('[agentRequestQueue] finalizeRequest error:', e);
+    return null;
+  }
+}
+
+/**
+ * Marca un request 'failed' (camino VIVO, tras agotar el manejo de error del
+ * pipeline). Conserva el prompt intacto. Tolerante a fallos (no lanza).
+ *
+ * @param {Object} args
+ * @param {number} args.id
+ * @param {string|Error} [args.error]
+ * @returns {Promise<Object|null>}
+ */
+export async function failRequest({ id, error } = {}) {
+  try {
+    const item = await getRequest(id);
+    if (!item) return null;
+    item.status = 'failed';
+    item.ts_done = Date.now();
+    item.error = error ? (error.message || String(error)) : 'fallo en el pipeline';
+    await persistItem(item);
+    return item;
+  } catch (e) {
+    console.debug('[agentRequestQueue] failRequest error:', e);
+    return null;
+  }
+}
+
+/**
  * Worker SERIALIZADO que procesa la cola uno a uno. Toma el siguiente 'queued',
  * marca 'sending', delega al sender inyectado, reintenta con backoff exponencial,
  * marca 'done'/'failed'. NO procesa si offline.
@@ -253,28 +336,13 @@ export async function processRequest({ sender, req, id }) {
       
       const tDone = Date.now();
       const tTotalMs = tDone - tStart;
-      
-      // Marcar 'done' con metadata completa
-      item.status = 'done';
-      item.ts_done = tDone;
+
+      // Marcar 'done' con metadata completa. Fijamos t_total_ms desde tStart
+      // (el helper solo lo calcularía si fuera null); el resto lo vuelca
+      // applyResultToItem (compartido con finalizeRequest, sin duplicar).
       item.latency.t_total_ms = tTotalMs;
-      // t_first_token_ms debe venir del sender si es medible
-      if (result?.latency?.t_first_token_ms != null) {
-        item.latency.t_first_token_ms = result.latency.t_first_token_ms;
-      }
-      
-      // Metadata de grounding si viene del sender
-      if (result?.grounding) {
-        item.grounding = { ...item.grounding, ...result.grounding };
-      }
-      
-      // Response y tokens
-      item.response = result?.response || null;
-      item.tokens_in = result?.tokens_in || null;
-      item.tokens_out = result?.tokens_out || null;
-      item.retries = attempt;
-      item.error = null;
-      
+      applyResultToItem(item, result, attempt);
+
       await persistItem(item);
       console.debug(`[agentRequestQueue] request #${id} completado (${tTotalMs}ms, ${attempt} retries)`);
       return item;

--- a/src/services/agentRequestSender.js
+++ b/src/services/agentRequestSender.js
@@ -1,0 +1,158 @@
+/**
+ * agentRequestSender.js — Sender headless para la cola DURABLE del agente.
+ *
+ * `agentRequestQueue.drainPending({ sender })` y `processRequest({ sender })`
+ * delegan en una función `sender(req)` que corre la inferencia real y devuelve
+ * la telemetría a persistir. En el flujo VIVO del AgentScreen ese trabajo lo
+ * hace el pipeline React (que pinta tokens, TTS, grounding, etc.). Pero un
+ * request que sobrevivió una RECARGA o quedó 'offline' de una sesión anterior
+ * NO tiene React montado alrededor: hay que reanudarlo SIN UI.
+ *
+ * Este módulo provee ese sender headless. La llamada cruda al LLM se inyecta
+ * (`llmCall`) → testeable sin red. En producción usa `streamOpenAI` sobre el
+ * endpoint que arma `buildLLMRequest('chat'|'chat_complex')`.
+ *
+ * Contrato de retorno (lo que `processRequest` persiste en el registro):
+ *   {
+ *     response: string,
+ *     latency: { t_first_token_ms: number|null },
+ *     grounding: { nlu_route, grounded_status, entities, tools, rag_chunks },
+ *     tokens_in: number|null,
+ *     tokens_out: number|null,
+ *   }
+ *
+ * Reglas:
+ * - Si el LLM falla o devuelve texto vacío → LANZA (para que el retry/backoff
+ *   de processRequest lo reintente; tras MAX_RETRIES queda 'failed' sin perder
+ *   el prompt). NUNCA se traga el error en silencio.
+ * - Headless = grounding mínimo (nlu_route del route, grounded_status 'none'):
+ *   la reanudación prioriza NO PERDER la pregunta sobre re-resolver el grafo.
+ *   El turno vivo sí captura grounding rico; esto es el camino de rescate.
+ */
+
+import { selectChatRoute, buildLLMRequest } from './llmRouter.js';
+
+/**
+ * Estimación de respaldo de tokens cuando el backend no reporta `usage`.
+ * ~4 chars/token es la heurística estándar; suficiente para los agregados de
+ * debug (no es facturación). Devuelve 0 para entradas vacías.
+ */
+function estimateTokens(text) {
+  const s = typeof text === 'string' ? text : '';
+  if (!s) return 0;
+  return Math.max(1, Math.round(s.length / 4));
+}
+
+/**
+ * System prompt mínimo para la reanudación headless. El prompt rico (glosarios,
+ * grounding, finca) vive en el pipeline vivo; aquí solo garantizamos una
+ * respuesta útil en español campesino sin inventar.
+ */
+const HEADLESS_SYSTEM_PROMPT =
+  'Sos Chagra, el asistente agrícola del campesino colombiano. Respondé claro, ' +
+  'corto y en español sencillo. Si no sabés algo con certeza, decilo; nunca ' +
+  'inventes datos, dosis ni nombres científicos.';
+
+/**
+ * Arma los mensajes (system + user) para el sender headless a partir del req.
+ * @param {{prompt: string}} req
+ * @returns {Array<{role: string, content: string}>}
+ */
+export function buildSenderMessages(req) {
+  const prompt = (req && typeof req.prompt === 'string') ? req.prompt : '';
+  return [
+    { role: 'system', content: HEADLESS_SYSTEM_PROMPT },
+    { role: 'user', content: prompt },
+  ];
+}
+
+/**
+ * Llamada cruda al LLM por defecto (producción): streamOpenAI sobre el endpoint
+ * que arma buildLLMRequest. Import dinámico de streamOpenAI para no acoplar el
+ * módulo a la red en entornos de test que no lo mockean.
+ *
+ * @param {Object} args
+ * @param {Array}  args.messages
+ * @param {string} args.route - 'chat' | 'chat_complex'
+ * @param {Function} [args.onToken]
+ * @param {AbortSignal} [args.signal]
+ * @returns {Promise<{fullText: string, stats: Object}>}
+ */
+async function defaultLlmCall({ messages, route, onToken, signal }) {
+  const { url, body } = buildLLMRequest(route, messages);
+  const { streamOpenAI } = await import('./openaiStream.js');
+  let firstTokenMs = null;
+  const t0 = Date.now();
+  const res = await streamOpenAI(
+    url,
+    body,
+    (chunk, fullText) => {
+      if (firstTokenMs == null) firstTokenMs = Date.now() - t0;
+      onToken?.(chunk, fullText);
+    },
+    { signal },
+  );
+  return {
+    fullText: res?.fullText || '',
+    stats: {
+      first_token_ms: firstTokenMs,
+      response_len: res?.fullText?.length || 0,
+    },
+  };
+}
+
+/**
+ * Crea un sender headless para la cola durable. El `llmCall` se inyecta para
+ * tests; en producción cae al `defaultLlmCall` (streamOpenAI).
+ *
+ * @param {Object} [deps]
+ * @param {Function} [deps.llmCall] - async({messages, route, onToken, signal}) → {fullText, stats}
+ * @returns {Function} sender(req) → telemetría
+ */
+export function createAgentRequestSender({ llmCall = defaultLlmCall } = {}) {
+  return async function sender(req = {}) {
+    const prompt = (req && typeof req.prompt === 'string') ? req.prompt : '';
+    if (!prompt.trim()) {
+      throw new Error('[agentRequestSender] req sin prompt');
+    }
+    // Si el req no trae route persistido, lo recalculamos de la query.
+    const route = req.route && req.route !== 'unknown' ? req.route : selectChatRoute(prompt);
+    const messages = buildSenderMessages(req);
+
+    let firstTokenMs = null;
+    const t0 = Date.now();
+    const { fullText, stats } = await llmCall({
+      messages,
+      route,
+      onToken: (_chunk, _full) => {
+        if (firstTokenMs == null) firstTokenMs = Date.now() - t0;
+      },
+      signal: req.signal,
+    });
+
+    const text = typeof fullText === 'string' ? fullText : '';
+    if (!text.trim()) {
+      // Vacío = recuperable: lanzamos para que processRequest reintente.
+      throw new Error('[agentRequestSender] el LLM devolvió respuesta vacía');
+    }
+
+    return {
+      response: text,
+      latency: {
+        // Preferimos el stat del backend; si no, el medido aquí por el onToken.
+        t_first_token_ms: stats?.first_token_ms ?? firstTokenMs ?? null,
+      },
+      grounding: {
+        nlu_route: route,
+        grounded_status: 'none',
+        entities: [],
+        tools: [],
+        rag_chunks: 0,
+      },
+      tokens_in: stats?.tokens_in ?? estimateTokens(prompt),
+      tokens_out: stats?.tokens_out ?? estimateTokens(text),
+    };
+  };
+}
+
+export default createAgentRequestSender;

--- a/tests/unit/agentPartialMerge.test.js
+++ b/tests/unit/agentPartialMerge.test.js
@@ -41,7 +41,11 @@ describe('mergePartialOnInterruption', () => {
 
       expect(res.preservePartial).toBe(true);
       expect(res.content.startsWith(partial)).toBe(true);
-      expect(res.content).toContain('Respuesta incompleta');
+      // UX paciente: marcador tranquilizador de reintento automático, NUNCA
+      // "toca de nuevo" / "Tiempo agotado".
+      expect(res.content).toContain('reintentando');
+      expect(res.content).not.toMatch(/toca de nuevo/i);
+      expect(res.content).not.toMatch(/tiempo agotado/i);
       expect(res.error).toBeNull();
       expect(res.reason).toBe('timeout');
     });
@@ -116,5 +120,43 @@ describe('normalizeInterruptReason', () => {
     expect(normalizeInterruptReason('boom')).toBe('abort');
     expect(normalizeInterruptReason(undefined)).toBe('abort');
     expect(normalizeInterruptReason(null)).toBe('abort');
+  });
+});
+
+/**
+ * GUARDRAIL UX PACIENTE (2026-06-13): el operador pidió explícitamente eliminar
+ * "Tiempo agotado. Toca de nuevo para reintentar." de la cara del campesino. La
+ * cola durable reintenta sola; pedir "toca de nuevo" cuando el sistema YA está
+ * reintentando es alarmante y falso. Este bloque blinda el copy contra regresión.
+ */
+describe('UX paciente — nunca el copy alarmante "Tiempo agotado / toca de nuevo"', () => {
+  const forbidden = [/tiempo agotado/i, /toca de nuevo/i];
+
+  it('ningún FULL_ERROR_MESSAGES contiene el copy prohibido', () => {
+    for (const msg of Object.values(FULL_ERROR_MESSAGES)) {
+      for (const re of forbidden) {
+        expect(msg).not.toMatch(re);
+      }
+    }
+  });
+
+  it('ningún PARTIAL_MARKERS contiene el copy prohibido', () => {
+    for (const msg of Object.values(PARTIAL_MARKERS)) {
+      for (const re of forbidden) {
+        expect(msg).not.toMatch(re);
+      }
+    }
+  });
+
+  it('timeout/abort comunican reintento automático (sin pedir acción)', () => {
+    expect(FULL_ERROR_MESSAGES.timeout).toMatch(/reintentando|guardada/i);
+    expect(FULL_ERROR_MESSAGES.abort).toMatch(/reintentando|guardada/i);
+    expect(PARTIAL_MARKERS.timeout).toMatch(/reintentando/i);
+    expect(PARTIAL_MARKERS.abort).toMatch(/reintentando/i);
+  });
+
+  it('cancel (acción voluntaria) sí ofrece Reintentar explícito', () => {
+    expect(FULL_ERROR_MESSAGES.cancel).toMatch(/reintentar/i);
+    expect(PARTIAL_MARKERS.cancel).toMatch(/reintentar/i);
   });
 });


### PR DESCRIPTION
## Problema

`src/services/agentRequestQueue.js` (cola durable IndexedDB + telemetría rica) estaba **completa y testeada pero era CÓDIGO MUERTO**: nunca se invocaba. El `AgentScreen` solo usaba `useAgentQueueStore` (Zustand **efímero**, cap 2) que se pierde al recargar, y mostraba **"Tiempo agotado. Toca de nuevo para reintentar"** cuando el LLM tardaba. Con la M6000 como única GPU (first-token 95-151s bajo carga) eso es lo normal en el campo — el campesino veía ese mensaje y creía que la app estaba rota, perdiendo su pregunta.

## Cómo el wire lo elimina

**Nunca se pierde la pregunta:**
- `runAgentPipeline`: `enqueueRequest` **PRIMERO** (persiste durable en IndexedDB **antes** de tocar el LLM). Si la app se recarga / cierra a mitad de inferencia, el prompt sobrevive.
- **Mount + evento `'online'`**: `resumePending()` + `drainPending({ sender })` reanudan los requests `'queued'`/`'offline'` de sesiones previas con un **sender headless** (`agentRequestSender` corre el LLM sin React) y pintan la respuesta recuperada en el chat.
- **Offline**: los requests quedan `'queued'`/`'offline'` y se reanudan solos al volver la conexión.
- **Interrupción**: `timeout`/`abort` dejan el registro `'queued'` → se reanuda solo (cero pérdida). `cancel` (voluntario) → `failed` (no reintenta por la espalda).

**Nunca "Tiempo agotado. Toca de nuevo":**
- `agentPartialMerge`: ELIMINADO el copy alarmante. Reemplazado por mensajes que comunican **reintento automático** sin pedir acción ("Tu pregunta quedó guardada y la estoy reintentando sola"). Estados `THINKING` no-alarmantes ("Pensando… puede tardar en el campo", "sigo en eso, no se perdió"). Solo `cancel` (acción voluntaria del operador) ofrece **Reintentar** explícito.
- Guardrail de tests blinda el copy contra regresión (`/tiempo agotado/i` y `/toca de nuevo/i` prohibidos en `FULL_ERROR_MESSAGES` y `PARTIAL_MARKERS`).

## Telemetría capturada (por turno, en IndexedDB)

`response`, `latency{ t_first_token_ms, t_total_ms, queue_wait_ms }`, `grounding{ entities, tools, rag_chunks, nlu_route, grounded_status }`, `tokens_in/out`, `retries`, `status`. Reusa lo que el pipeline YA computa (cero coste extra). Sirve para debuggear inteligencia + velocidad.

## Decisiones de diseño (verify-first, sin duplicar)

- El queue Zustand (UX en-sesión, serialización cap 2) y la cola durable (persistencia + recovery + telemetría) son **capas complementarias**, no se reemplazan. El turno vivo usa el pipeline React rico (y cierra el registro durable); los recuperados usan el sender headless.
- `finalizeRequest`/`failRequest` nuevos en `agentRequestQueue` cierran el registro del **camino vivo SIN re-invocar un sender** (el pipeline ya corrió el LLM con streaming/TTS/grounding). `applyResultToItem` compartido con `processRequest` evita duplicar la lógica de telemetría.
- El sender headless del recovery usa grounding mínimo (prioriza NO PERDER la pregunta sobre re-resolver el grafo).

## Archivos

| Archivo | Cambio |
|---|---|
| `src/components/AgentScreen/AgentScreen.jsx` | wire enqueue/finalize/fail + recovery mount/online + UX paciente |
| `src/services/agentRequestQueue.js` | + `finalizeRequest`/`failRequest` + `applyResultToItem` compartido |
| `src/services/agentRequestSender.js` | **nuevo** — sender headless inyectable |
| `src/services/agentPartialMerge.js` | copy paciente (elimina "Tiempo agotado") |
| `src/services/__tests__/agentRequestSender.test.js` | **nuevo** (5) |
| `src/services/__tests__/agentRequestQueue.recovery.test.js` | **nuevo** — e2e offline→recarga→online→drain (2) |
| `src/services/__tests__/agentRequestQueue.test.js` | + finalize/fail (4) |
| `tests/unit/agentPartialMerge.test.js` | + guardrail anti "Tiempo agotado" (5) |

## Tests / lint

- Suite de los archivos tocados: **69 verde**.
- `eslint --max-warnings=0`: **limpio** en los 8 archivos.
- Las 27 fallas de la suite completa son **pre-existentes en `main`** (themes, vision-cache hashing sin crypto.subtle en jsdom, sidecar whitelist, `DB_VERSION` stale=19 vs 20) — confirmado corriendo las mismas en checkout limpio. Ninguna toca archivos de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)