### PR TITLE
feat(evolucion): superficie al juego de evolución de finca (card huérfana + ruta muerta → pantalla viva)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,7 @@ const WelcomeStatsHero = lazy(() => import('./components/WelcomeStatsHero'));
 const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
+const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
 import HomeRegionalGreeting from './components/HomeRegionalGreeting';
 
 localforage.config({
@@ -139,6 +140,7 @@ const HASH_VIEW_ROUTES = {
   task_log: 'task_log',
   hoy: 'hoy_finca',
   'hoy-en-finca': 'hoy_finca',
+  evolucion: 'evolucion',
 };
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -690,6 +692,22 @@ export default function App() {
           <ErrorBoundary>
             <HoyEnFincaScreen
               onBack={() => navigate('dashboard')}
+              onHome={() => navigate('dashboard')}
+              onNavigate={navigate}
+            />
+          </ErrorBoundary>
+        );
+      case 'evolucion':
+        // "Cómo evoluciona tu finca": le da SUPERFICIE al motor agroecológico
+        // (fincaEvolutionService + agroecologyJourney) que vivía huérfano. La
+        // FincaEvolutionCard de "Hoy en finca" llama onNavigate('evolucion');
+        // sin esta ruta el botón "¿Qué es esto?" quedaba muerto. Cero
+        // gamificación: la progresión es el avance real de indicadores
+        // TAPE/MESMIS + la etapa del viaje, no puntos ni badges.
+        return (
+          <ErrorBoundary>
+            <MiFincaEvolucionScreen
+              onBack={() => navigate('hoy_finca')}
               onHome={() => navigate('dashboard')}
               onNavigate={navigate}
             />

--- a/src/__tests__/App.evolucion-route.test.jsx
+++ b/src/__tests__/App.evolucion-route.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de RUTA: verifica que App rutea 'evolucion' → MiFincaEvolucionScreen.
+// El botón "¿Qué es esto?" de FincaEvolutionCard llama onNavigate('evolucion');
+// sin el case en el switch de App esa navegación quedaba muerta. Acá montamos
+// App con #evolucion + sesión autenticada y comprobamos que la pantalla monta.
+//
+// Los efectos pesados de boot (auth, catálogo SQLite WASM, motores de alerta,
+// RAG, warm-up de Ollama) se mockean para que App arranque limpio en jsdom sin
+// tocar red/IDB. No probamos esos sistemas acá; solo el wiring de la ruta.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({ fetchFromFarmOS: () => Promise.resolve(null) }));
+
+// La pantalla destino: stub liviano que delata que se montó. Probamos el WIRING
+// de la ruta, no el render interno de la pantalla (ya cubierto en su propio test).
+vi.mock('../components/hoy/MiFincaEvolucionScreen', () => ({
+  default: () => <div data-testid="mi-finca-evolucion-screen">evolucion stub</div>,
+}));
+
+// Procesos vacíos (sin IDB).
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+import App from '../App';
+
+describe('App — ruta "evolucion"', () => {
+  beforeEach(() => {
+    window.location.hash = '#evolucion';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    vi.clearAllMocks();
+  });
+
+  it('con sesión autenticada y #evolucion monta MiFincaEvolucionScreen', async () => {
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('mi-finca-evolucion-screen')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+  });
+});

--- a/src/components/hoy/HoyEnFincaScreen.jsx
+++ b/src/components/hoy/HoyEnFincaScreen.jsx
@@ -7,6 +7,7 @@ import {
 import { ScreenShell } from '../common/ScreenShell';
 import AgendaCampesina from './AgendaCampesina';
 import JourneyGuideCard from './JourneyGuideCard';
+import FincaEvolutionCard from './FincaEvolutionCard';
 import useAlertStore from '../../store/useAlertStore';
 import { listFarmProcesses } from '../../db/farmProcessCache';
 import { getProfile } from '../../services/userProfileService';
@@ -168,6 +169,15 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
 
                 {/* ── 0. GUÍA DEL VIAJE — Chagra como agroecólogo desde el inicio ── */}
                 <JourneyGuideCard processes={processes} onNavigate={onNavigate} />
+
+                {/* ── 0b. CÓMO EVOLUCIONA TU FINCA — resumen TAPE/MESMIS ─────
+                    El "¿Qué es esto?" rutea a la pantalla 'evolucion' (detalle
+                    de indicadores + etapa del viaje). Antes la tarjeta vivía
+                    huérfana y ese botón no llevaba a ningún lado. */}
+                <FincaEvolutionCard
+                    processes={processes}
+                    onNavigate={onNavigate}
+                />
 
                 {/* ── 1. CLIMA DE HOY (honesto) ─────────────────────────── */}
                 {!geo ? (

--- a/src/components/hoy/MiFincaEvolucionScreen.jsx
+++ b/src/components/hoy/MiFincaEvolucionScreen.jsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useState } from 'react';
+import { TrendingUp, Compass, Leaf, ArrowRight, MessageCircle, Info } from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import FincaEvolutionCard from './FincaEvolutionCard';
+import { listFarmProcesses } from '../../db/farmProcessCache';
+import { getProfile } from '../../services/userProfileService';
+import {
+  evaluarEvolucionFinca,
+  getGliessmanLabel,
+  normalizeScore,
+} from '../../services/fincaEvolutionService';
+import {
+  getStage,
+  contextoDesdeVocacion,
+  siguientePaso,
+  JOURNEY_STAGES,
+} from '../../services/agroecologyJourney';
+import { resolveJourneyState } from '../../services/journeyStateService';
+import indicatorsData from '../../data/agroecology-indicators.json';
+
+/**
+ * MiFincaEvolucionScreen — la pantalla "Cómo evoluciona tu finca".
+ *
+ * Le da SUPERFICIE al motor agroecológico que ya existía huérfano: junta en una
+ * sola vista el avance REAL del sistema productivo, sin gamificación. Tres capas,
+ * todas calculadas desde datos reales de la finca (cero fabricación):
+ *
+ *   1. La tarjeta resumen (FincaEvolutionCard): nivel Gliessman + barras MESMIS.
+ *   2. El radar/desglose de los 5 atributos MESMIS y las 10 dimensiones TAPE
+ *      (FAO), con "sin datos aún" cuando un indicador no se puede calcular.
+ *   3. La etapa actual del viaje agroecológico (journeyStateService) con el
+ *      SIGUIENTE PASO real (agroecologyJourney.siguientePaso), enlazado a la
+ *      guía del Home.
+ *
+ * Anti-paternalista: NADA de puntos/badges/XP/rachas. La "progresión" es el
+ * avance verdadero de los indicadores y de la etapa del viaje — el resultado de
+ * registrar cosechas, biopreparados, observaciones y de marcar las acciones del
+ * camino. Si no hay datos, se dice honestamente.
+ *
+ * Offline-first: lee los procesos de la cache local (listFarmProcesses); si la
+ * IDB falla, lista vacía honesta. El estado del viaje vive en localStorage por
+ * finca (journeyStateService).
+ *
+ * @param {Object} props
+ * @param {Function} [props.onBack]     volver a la pantalla anterior
+ * @param {Function} [props.onHome]     volver al inicio
+ * @param {Function} [props.onNavigate] navegación a otras vistas (ej. agente)
+ */
+export default function MiFincaEvolucionScreen({ onBack, onHome, onNavigate }) {
+  const profile = useMemo(() => getProfile() || {}, []);
+  const fincaSlug = profile.fincaSlug || profile.slug || 'default';
+  const ctx = contextoDesdeVocacion(profile.vocacion);
+
+  // Etiquetas de indicadores desde el DR (agroecology-indicators.json).
+  const mesmisMeta = useMemo(() => indicatorsData.mesmis_5_atributos, []);
+  const tapeMeta = useMemo(() => indicatorsData.tape_10_elementos, []);
+
+  // Procesos de finca: cache local primero (offline-first). El cálculo de
+  // indicadores depende de esto; sin procesos, todo sale "sin datos aún".
+  const [processes, setProcesses] = useState([]);
+  useEffect(() => {
+    let alive = true;
+    listFarmProcesses({ status: 'active' })
+      .then((list) => { if (alive) setProcesses(Array.isArray(list) ? list : []); })
+      .catch(() => { /* IDB falló: lista vacía honesta, jamás datos inventados */ });
+    return () => { alive = false; };
+  }, []);
+
+  // Observaciones: por ahora no hay loader dedicado en servicios; el cálculo de
+  // cocreación de conocimiento (TAPE) las tolera vacías sin romper.
+  const observations = useMemo(() => [], []);
+
+  // Cálculo REAL de indicadores — fincaEvolutionService es puro y cero-fabricación.
+  const evolution = useMemo(
+    () => evaluarEvolucionFinca({ processes, observations }),
+    [processes, observations],
+  );
+  const gliessmanLabel = useMemo(
+    () => getGliessmanLabel(evolution.nivelGliessman),
+    [evolution.nivelGliessman],
+  );
+
+  // Estado y siguiente paso del viaje agroecológico (mismo motor que la guía
+  // del Home — JourneyGuideCard). Solo lectura acá: el avance se hace allá.
+  const journey = useMemo(
+    () => resolveJourneyState({ fincaSlug, processes }),
+    [fincaSlug, processes],
+  );
+  const stage = getStage(journey.stageId);
+  const paso = useMemo(
+    () => siguientePaso({ stageId: journey.stageId, accionesHechas: journey.accionesHechas }, ctx),
+    [journey, ctx],
+  );
+
+  const onPreguntar = () => {
+    if (stage) {
+      try {
+        sessionStorage.setItem(
+          'chagra:agent:prefilled',
+          `Estoy en la etapa "${stage.nombre}" de mi finca (${stage.objetivo}). `
+          + 'Quiero entender cómo evoluciona mi finca: ¿qué indicadores debería mejorar primero?',
+        );
+      } catch { /* modo privado: el agente abre vacío */ }
+    }
+    onNavigate?.('agente');
+  };
+
+  // Helper de barra para un indicador (MESMIS o TAPE). hasData ⇒ pinta el avance;
+  // null ⇒ "sin datos aún", NUNCA un 0 que mienta sobre el estado de la finca.
+  const renderBar = (id, nombre, score) => {
+    const hasData = score !== null && score !== undefined;
+    const pct = hasData ? normalizeScore(score) : 0;
+    return (
+      <div key={id} className="mb-2.5 last:mb-0">
+        <div className="flex items-center justify-between mb-1 gap-2">
+          <span className="text-xs font-medium text-slate-300 leading-tight">{nombre}</span>
+          <span className="text-xs font-bold text-emerald-300 shrink-0">
+            {hasData ? `${score}/4` : 'sin datos aún'}
+          </span>
+        </div>
+        <div className="h-2 bg-slate-800/50 rounded-full overflow-hidden">
+          {hasData ? (
+            <div
+              className="h-full bg-gradient-to-r from-emerald-600 to-emerald-400 rounded-full transition-all duration-500"
+              style={{ width: `${pct}%` }}
+              aria-label={`${nombre}: ${score} de 4`}
+            />
+          ) : (
+            <div className="h-full bg-slate-700/30 rounded-full" aria-label={`${nombre}: sin datos`} />
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const next = paso.siguienteEtapaId ? getStage(paso.siguienteEtapaId) : null;
+
+  return (
+    <ScreenShell title="Cómo evoluciona tu finca" icon={TrendingUp} onBack={onBack} onHome={onHome}>
+      <div
+        data-testid="mi-finca-evolucion-screen"
+        className="flex flex-col gap-3 px-4 pt-3 pb-8 max-w-2xl mx-auto"
+      >
+        {/* Intro honesta: qué es esto y de dónde sale */}
+        <section className="bg-gradient-to-br from-emerald-950/60 to-teal-950/40 backdrop-blur-xl border border-emerald-800/40 rounded-2xl p-4">
+          <div className="flex items-center gap-2 mb-1.5">
+            <Leaf size={20} className="text-emerald-300" aria-hidden="true" />
+            <h2 className="text-base font-bold text-white">La salud de tu sistema</h2>
+          </div>
+          <p className="text-sm text-slate-300 leading-relaxed">
+            Acá no hay puntos ni medallas: tu finca evoluciona con el trabajo real.
+            Cada cosecha, biopreparado, siembra y observación que registrás mueve
+            estos indicadores. Así medimos cómo va tu transición hacia la agroecología.
+          </p>
+          <div className="mt-3 pt-3 border-t border-emerald-800/40">
+            <p className="text-xs text-slate-400 mb-0.5">Nivel de transición agroecológica</p>
+            <p className="text-lg font-bold text-emerald-300">{gliessmanLabel}</p>
+          </div>
+        </section>
+
+        {/* Tarjeta resumen — el componente que vivía huérfano, ahora con casa */}
+        <FincaEvolutionCard
+          processes={processes}
+          observations={observations}
+          onNavigate={onNavigate}
+        />
+
+        {/* Etapa actual del viaje agroecológico (lectura; se avanza en el Home) */}
+        {stage && (
+          <section
+            data-testid="evolucion-etapa-viaje"
+            className="bg-gradient-to-br from-emerald-950/70 to-teal-950/50 backdrop-blur-xl border border-emerald-800/40 rounded-2xl p-4"
+          >
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                <Compass size={20} className="text-emerald-300" aria-hidden="true" />
+                <h3 className="text-base font-bold text-white">Tu etapa del camino</h3>
+              </div>
+              <span className="text-[10px] text-emerald-300/70 font-bold uppercase tracking-wider shrink-0">
+                Etapa {stage.orden} de {JOURNEY_STAGES.length}
+              </span>
+            </div>
+            <p className="text-lg font-black text-white leading-tight">{stage.emoji} {stage.nombre}</p>
+            <p className="text-sm text-slate-300 mt-0.5">{stage.objetivo}</p>
+            {paso.variacion && (
+              <p className="text-xs text-emerald-200/80 mt-1.5 italic">{paso.variacion}</p>
+            )}
+
+            {paso.siguientesAcciones.length > 0 ? (
+              <div className="mt-3">
+                <p className="text-xs font-bold text-emerald-200 uppercase tracking-wide mb-1.5">
+                  Tu siguiente paso
+                </p>
+                <ul className="flex flex-col gap-1.5">
+                  {paso.siguientesAcciones.map((accion) => (
+                    <li
+                      key={accion}
+                      className="flex items-start gap-2 px-3 py-2 rounded-xl bg-emerald-900/25 border border-emerald-700/30 text-sm text-slate-200"
+                    >
+                      <span className="mt-1 shrink-0 w-1.5 h-1.5 rounded-full bg-emerald-400" aria-hidden="true" />
+                      <span className="flex-1">{accion}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : (
+              <p className="text-sm text-emerald-200 mt-3">
+                Completaste los pasos de esta etapa. Avanzá desde la guía del inicio.
+              </p>
+            )}
+
+            {next && (
+              <p className="mt-3 flex items-center gap-1.5 text-xs text-emerald-200/80">
+                <ArrowRight size={14} aria-hidden="true" />
+                Lo que sigue: {next.emoji} {next.nombre}
+              </p>
+            )}
+          </section>
+        )}
+
+        {/* Desglose MESMIS — 5 atributos de sustentabilidad */}
+        <section
+          data-testid="evolucion-mesmis"
+          className="bg-gradient-to-br from-slate-900/80 to-slate-800/70 backdrop-blur-xl border border-slate-700/40 rounded-2xl p-4"
+        >
+          <h3 className="text-base font-bold text-white mb-1">Sustentabilidad (MESMIS)</h3>
+          <p className="text-xs text-slate-400 mb-3">
+            Cinco atributos que dicen qué tan firme está tu sistema productivo.
+          </p>
+          {mesmisMeta.map((item) => renderBar(item.id, item.nombre, evolution.mesmis[item.id]))}
+        </section>
+
+        {/* Desglose TAPE — 10 dimensiones FAO */}
+        <section
+          data-testid="evolucion-tape"
+          className="bg-gradient-to-br from-slate-900/80 to-slate-800/70 backdrop-blur-xl border border-slate-700/40 rounded-2xl p-4"
+        >
+          <h3 className="text-base font-bold text-white mb-1">Los 10 elementos de la agroecología (FAO)</h3>
+          <p className="text-xs text-slate-400 mb-3">
+            La mirada amplia: diversidad, sinergias, cultura, gobernanza y más.
+          </p>
+          {tapeMeta.map((item) => renderBar(item.id, item.nombre, evolution.tape[item.id]))}
+        </section>
+
+        {/* CTA al agente para entender qué mejorar */}
+        <button
+          type="button"
+          onClick={onPreguntar}
+          className="w-full px-4 py-2.5 min-h-[44px] rounded-xl bg-slate-800/50 hover:bg-slate-700/50 border border-slate-700/40 text-slate-300 text-sm flex items-center justify-center gap-2"
+        >
+          <MessageCircle size={15} aria-hidden="true" />
+          Preguntarle a Chagra qué mejorar
+        </button>
+
+        {/* Nota honesta cuando todavía no hay nada que mostrar */}
+        <div className="flex items-start gap-2 pt-1">
+          <Info size={14} className="text-slate-500 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-xs text-slate-500 leading-relaxed">
+            Los indicadores sin datos se irán llenando a medida que registrás el
+            trabajo de tu finca. No inventamos cifras: lo que no se puede medir aún,
+            se dice tal cual.
+          </p>
+        </div>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/hoy/__tests__/MiFincaEvolucionScreen.test.jsx
+++ b/src/components/hoy/__tests__/MiFincaEvolucionScreen.test.jsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import MiFincaEvolucionScreen from '../MiFincaEvolucionScreen';
+
+// La cache de procesos (IDB) se mockea: el test no toca IndexedDB. Por defecto
+// devuelve [] (finca sin datos → todo "sin datos aún").
+const listFarmProcessesMock = vi.fn(() => Promise.resolve([]));
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: (...args) => listFarmProcessesMock(...args),
+}));
+
+// Perfil mínimo (sin red). La vocación define el contexto del viaje. Mock
+// PARCIAL: ScreenShell → NotificationsBell → climaService usan otros exports
+// (getProfileMunicipio); solo sobreescribimos getProfile.
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: () => ({ fincaSlug: 'finca-test', vocacion: 'finca_diversificada' }),
+  };
+});
+
+describe('MiFincaEvolucionScreen', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    listFarmProcessesMock.mockReset();
+    listFarmProcessesMock.mockResolvedValue([]);
+  });
+
+  it('monta la pantalla con su título y testid', async () => {
+    render(<MiFincaEvolucionScreen />);
+    expect(await screen.findByTestId('mi-finca-evolucion-screen')).toBeTruthy();
+    expect(screen.getAllByText('Cómo evoluciona tu finca').length).toBeGreaterThan(0);
+  });
+
+  it('lee los procesos del service (cache local) al montar', async () => {
+    render(<MiFincaEvolucionScreen />);
+    await waitFor(() => expect(listFarmProcessesMock).toHaveBeenCalled());
+    expect(listFarmProcessesMock).toHaveBeenCalledWith({ status: 'active' });
+  });
+
+  it('muestra la etapa actual del viaje agroecológico', async () => {
+    render(<MiFincaEvolucionScreen />);
+    // Sin procesos activos → etapa 1 (Despertar) del viaje.
+    expect(await screen.findByTestId('evolucion-etapa-viaje')).toBeTruthy();
+    expect(screen.getByText('Tu etapa del camino')).toBeTruthy();
+    expect(screen.getByText(/Despertar/)).toBeTruthy();
+    expect(screen.getByText(/Etapa 1 de 6/)).toBeTruthy();
+    expect(screen.getByText('Tu siguiente paso')).toBeTruthy();
+  });
+
+  it('renderiza el desglose MESMIS (5 atributos) y TAPE (10 elementos)', async () => {
+    render(<MiFincaEvolucionScreen />);
+    const mesmis = await screen.findByTestId('evolucion-mesmis');
+    const tape = screen.getByTestId('evolucion-tape');
+    // Etiquetas representativas del DR de indicadores, dentro de su sección
+    // (Adaptabilidad también aparece en la tarjeta resumen embebida).
+    expect(within(mesmis).getByText('Adaptabilidad')).toBeTruthy();
+    expect(within(tape).getByText('Diversidad de especies y procesos')).toBeTruthy();
+    expect(within(tape).getByText('Gobernanza participativa')).toBeTruthy();
+  });
+
+  it('sin datos no inventa cifras: muestra "sin datos aún"', async () => {
+    render(<MiFincaEvolucionScreen />);
+    await screen.findByTestId('mi-finca-evolucion-screen');
+    // Finca vacía → varios indicadores sin datos (cero fabricación).
+    expect(screen.getAllByText('sin datos aún').length).toBeGreaterThan(0);
+  });
+
+  it('refleja los procesos reales: con datos sube algún indicador', async () => {
+    listFarmProcessesMock.mockResolvedValue([
+      {
+        process_id: 'p1',
+        process_type: 'sowing',
+        status: 'active',
+        current_stage: 'vegetative',
+        subject_slug: 'coffea_arabica',
+        events: [{ event_type: 'harvest_confirmed', payload: { quantity: 100 } }],
+      },
+      {
+        process_id: 'p2',
+        process_type: 'sowing',
+        status: 'active',
+        current_stage: 'flowering',
+        subject_slug: 'theobroma_cacao',
+        events: [{ event_type: 'harvest_confirmed', payload: { quantity: 50 } }],
+      },
+    ]);
+    render(<MiFincaEvolucionScreen />);
+    await waitFor(() => expect(listFarmProcessesMock).toHaveBeenCalled());
+    // Con procesos reales, al menos un indicador deja de estar "sin datos aún":
+    // aparece al menos un score con formato "n/4".
+    await waitFor(() => {
+      expect(screen.getAllByText(/\/4$/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('el botón volver invoca onBack', async () => {
+    const onBack = vi.fn();
+    render(<MiFincaEvolucionScreen onBack={onBack} />);
+    await screen.findByTestId('mi-finca-evolucion-screen');
+    screen.getByLabelText('Volver').click();
+    expect(onBack).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problema

El motor del "juego" de evolución de finca ya estaba construido pero **huérfano**:

- `FincaEvolutionCard.jsx` (nivel Gliessman + barras MESMIS) **no se renderizaba en ninguna pantalla**.
- Su botón **"¿Qué es esto?"** llamaba `onNavigate('evolucion')`, pero **no existía ninguna ruta `'evolucion'`** en `App.jsx` (0 referencias) → botón muerto.
- `MiFincaEvolucionScreen.jsx` **no existía**.
- `fincaEvolutionService.js` (indicadores TAPE/MESMIS desde datos reales) y `agroecologyJourney.js` (6 etapas Despertar→Irradiación) funcionaban, pero el cálculo no tenía superficie donde mostrarse junto al viaje.

## Solución

Se le da **superficie** al motor y se conecta con el viaje agroecológico que ya vive en Home (`JourneyGuideCard`):

- **Nueva pantalla `MiFincaEvolucionScreen`**: nivel Gliessman + desglose MESMIS (5 atributos) + las **10 dimensiones TAPE (FAO)** + la **etapa actual del viaje** con el **siguiente paso real** (`agroecologyJourney.siguientePaso` sobre `journeyStateService`). Embebe la `FincaEvolutionCard` como resumen.
- **Ruta `'evolucion'` enrutada en `App.jsx`**: lazy import + `case` en el switch + `#evolucion` en `HASH_VIEW_ROUTES`. El botón "¿Qué es esto?" ya **no muere**.
- **`FincaEvolutionCard` ahora se renderiza en "Hoy en finca"** (era el componente huérfano), como acceso *discoverable* a la pantalla de detalle.

## Progresión REAL (anti-paternalista)

**NADA de puntos / badges / XP / rachas** sobre el trabajo campesino (sería ofensivo). La "progresión" es el **avance verdadero** de los indicadores TAPE/MESMIS + el **avance de etapa del viaje**, derivado de las acciones reales registradas (cosecha, biopreparado, siembra, observación). El cálculo lo hace `fincaEvolutionService` (puro, cero-fabricación); esta PR asegura el **wiring de lectura**. Sin datos → "sin datos aún", nunca un 0 que mienta.

## Diseño

- Coherente con las demás pantallas: `ScreenShell` (botón volver + Home + Ayuda/Alertas globales) + las mismas clases Tailwind `slate`/`emerald` que el resto del PWA, que **ya son theme-aware** vía la indirección CSS-var (`index.css` + `tailwind.config.js`) — no se parchea clase por clase ni se hardcodean RGB.
- Voseo paisa permitido en strings de UI agente→campesino; comentarios técnicos neutrales.

## Tests (vitest, test-first)

- `App.evolucion-route.test.jsx`: App bootea con `#evolucion` + sesión autenticada y **monta `MiFincaEvolucionScreen`** (prueba el `case` real del switch).
- `MiFincaEvolucionScreen.test.jsx`: monta la pantalla; **lee los procesos del service** (mockeable, `listFarmProcesses({status:'active'})`); **muestra la etapa del viaje** (Despertar 1/6 + siguiente paso); renderiza MESMIS (5) + TAPE (10); sin datos no inventa cifras; el botón volver invoca `onBack`.

## Verificación

- `eslint --max-warnings=0` sobre los 5 archivos tocados → **limpio** (exit 0). Las ~22 fallas de lint de la suite global son **pre-existentes** en archivos ajenos (mcpHonestidad, rag-embedding, openaiStream, socialPrefiltro, soilDiagnostic) — no se tocaron.
- Tests relacionados: **26/26 verde** (nuevos + FincaEvolutionCard + JourneyGuideCard + journeyStateService + HoyEnFincaScreen).
- `npm run build` OK; chunk lazy `MiFincaEvolucionScreen` emitido (7.55 kB).

## Archivos

- `src/components/hoy/MiFincaEvolucionScreen.jsx` (nuevo)
- `src/components/hoy/__tests__/MiFincaEvolucionScreen.test.jsx` (nuevo)
- `src/__tests__/App.evolucion-route.test.jsx` (nuevo)
- `src/App.jsx` (lazy import + case 'evolucion' + hash route)
- `src/components/hoy/HoyEnFincaScreen.jsx` (render FincaEvolutionCard como acceso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)