### PR TITLE
fix(a11y): agrega prefers-reduced-motion a ChagraAgentAvatarMaiz (task #6240)

### DIFF
--- a/src/components/ChagraAgentAvatarMaiz.jsx
+++ b/src/components/ChagraAgentAvatarMaiz.jsx
@@ -347,6 +347,17 @@ export default function ChagraAgentAvatarMaiz({
                         0%, 100% { filter: drop-shadow(0 0 4px #fbbf24); }
                         50% { filter: drop-shadow(0 0 12px #fbbf24); }
                     }
+
+                    /* Reduced motion */
+                    @media (prefers-reduced-motion: reduce) {
+                        .chagra-agent-avatar.chagra-maiz * {
+                            animation: none !important;
+                        }
+                        .chagra-agent-avatar.chagra-maiz.chagra-glow .chagra-halo {
+                            animation: none !important;
+                            filter: drop-shadow(0 0 6px #fbbf24);
+                        }
+                    }
                 `}</style>
             </svg>
             {withLabel && (

--- a/src/components/__tests__/ChagraAgentAvatar.test.jsx
+++ b/src/components/__tests__/ChagraAgentAvatar.test.jsx
@@ -17,6 +17,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import ChagraAgentAvatar from '../ChagraAgentAvatar';
+import ChagraAgentAvatarMaiz from '../ChagraAgentAvatarMaiz';
 
 describe('ChagraAgentAvatar — task #122 glow + double-click', () => {
   beforeEach(() => {
@@ -100,5 +101,78 @@ describe('ChagraAgentAvatar — task #122 glow + double-click', () => {
     const svg = container.querySelector('svg.chagra-agent-avatar');
     expect(svg.classList.contains('chagra-state-speaking')).toBe(true);
     expect(svg.classList.contains('chagra-glow')).toBe(true);
+  });
+});
+
+describe('ChagraAgentAvatarMaiz — prefers-reduced-motion (task #6240)', () => {
+  test('maíz tiene media query prefers-reduced-motion en CSS inline', () => {
+    const { container } = render(<ChagraAgentAvatarMaiz state="idle" />);
+    const styleTag = container.querySelector('style');
+    expect(styleTag).toBeInTheDocument();
+
+    const cssContent = styleTag.textContent;
+    expect(cssContent).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(cssContent).toContain('animation: none !important');
+  });
+
+  test('maíz respeta prefers-reduced-motion: desactiva animaciones', () => {
+    // Mock window.matchMedia para simular prefers-reduced-motion: reduce
+    const mockMatchMedia = vi.fn();
+    mockMatchMedia.mockReturnValue({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    // Guardar el matchMedia original
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = mockMatchMedia;
+
+    const { container } = render(<ChagraAgentAvatarMaiz state="thinking" glow />);
+    const styleTag = container.querySelector('style');
+    const cssContent = styleTag.textContent;
+
+    // Verificar que la media query esté presente
+    expect(cssContent).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+
+    // Verificar que dentro de la media query se desactiven las animaciones
+    const reducedMotionBlock = cssContent.match(/@media \(prefers-reduced-motion: reduce\) \{([^}]+)\}/);
+    expect(reducedMotionBlock).toBeTruthy();
+
+    const reducedMotionCSS = reducedMotionBlock[1];
+    expect(reducedMotionCSS).toContain('animation: none !important');
+
+    // Restaurar el matchMedia original
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('maíz con glow + prefers-reduced-motion usa filtro estático', () => {
+    const { container } = render(<ChagraAgentAvatarMaiz state="idle" glow />);
+    const styleTag = container.querySelector('style');
+    const cssContent = styleTag.textContent;
+
+    // Verificar que la media query esté presente
+    expect(cssContent).toMatch(/@media \(prefers-reduced-motion: reduce\)/);
+
+    // El glow con reduced motion debe tener filter estático (drop-shadow)
+    // Buscar específicamente la regla de glow dentro de la media query
+    expect(cssContent).toMatch(/\.chagra-maiz\.chagra-glow.*filter:\s*drop-shadow\(.*\)/s);
+  });
+
+  test('maíz: todos los keyframes tienen nombres descriptivos', () => {
+    const { container } = render(<ChagraAgentAvatarMaiz state="idle" />);
+    const styleTag = container.querySelector('style');
+    const cssContent = styleTag.textContent;
+
+    // Verificar que los keyframes principales existan
+    expect(cssContent).toContain('@keyframes chagra-halo-pulse');
+    expect(cssContent).toContain('@keyframes chagra-hoja-sway-l');
+    expect(cssContent).toContain('@keyframes chagra-hoja-sway-r');
+    expect(cssContent).toContain('@keyframes chagra-barbas-wiggle');
+    expect(cssContent).toContain('@keyframes chagra-hoja-think');
+    expect(cssContent).toContain('@keyframes chagra-panocha-vibrate');
+    expect(cssContent).toContain('@keyframes chagra-planta-lean');
+    expect(cssContent).toContain('@keyframes chagra-glow-amber');
   });
 });


### PR DESCRIPTION
## Summary

Agrega soporte para `prefers-reduced-motion` en `ChagraAgentAvatarMaiz.jsx`, siguiendo el patrón ya implementado en `ChagraAgentAvatarColibri.jsx`.

### Cambio principal
- Agregó media query `@media (prefers-reduced-motion: reduce)` que desactiva todas las animaciones CSS del avatar de maíz
- Cuando el usuario tiene `prefers-reduced-motion: reduce` activado:
  - Todas las animaciones (hojas, barbas, panocha, planta, halo) se desactivan con `animation: none !important`
  - El glow animado se reemplaza por un filtro estático `drop-shadow(0 0 6px #fbbf24)`

### Animaciones afectadas
- `chagra-halo-pulse` (respiración del halo)
- `chagra-hoja-sway-l/r` (hojas oscilando en idle/speaking)
- `chagra-barbas-wiggle` (barbas ondulando en thinking)
- `chagra-hoja-think` (hojas atentas en thinking)
- `chagra-panocha-vibrate` (espiga vibrando en speaking)
- `chagra-planta-lean` (planta inclinándose en listening)
- `chagra-glow-amber` (glow pulsante cuando hay respuesta lista)

## Test plan

Tests añadidos en `src/components/__tests__/ChagraAgentAvatar.test.jsx`:

1. **Media query presente**: Verifica que `@media (prefers-reduced-motion: reduce)` existe en el CSS inline
2. **Animaciones desactivadas**: Verifica que `animation: none !important` está presente dentro de la media query
3. **Glow estático**: Verifica que el glow con reduced motion usa un filtro `drop-shadow` estático en lugar de animación
4. **Keyframes intactos**: Verifica que todos los keyframes mantienen sus nombres descriptivos (regresión)

Todos los tests pasan (13/13).

## Verificaciones

- ✅ `npx vitest run src/components/__tests__/ChagraAgentAvatar.test.jsx` — 13 tests passed
- ✅ `npx eslint src/components/ChagraAgentAvatarMaiz.jsx src/components/__tests__/ChagraAgentAvatar.test.jsx --max-warnings=0` — 0 warnings
- ✅ `npm run build` — built in 4.00s
- ⚠️  `tsc --noEmit` — errores preexistentes de leaflet (no relacionados con este cambio)

## MCP tools usadas

No se requirió consulta MCP para este task. Es un cambio puramente de a11y siguiendo un patrón existente en el código.

## Riesgos conocidos

- Riesgo bajo: cambio siguiendo patrón probado en `ChagraAgentAvatarColibri.jsx`
- Solo afecta visualmente cuando el usuario tiene `prefers-reduced-motion: reduce` activado
- No cambia la API ni el comportamiento por defecto del componente

Closes #6240