### PR TITLE
feat(guards): agregar guards de normativa paramo y consejo climatico

### DIFF
--- a/src/services/outputGuards.js
+++ b/src/services/outputGuards.js
@@ -6774,6 +6774,180 @@ export function guardFabricatedBeneficialBinomial(responseText, resolvedEntities
 }
 
 /**
+ * Guard de NORMATIVA (Ley 1930 - Páramo).
+ *
+ * La Ley 1930 de 2018 prohíbe actividades agropecuarias (siembra, fumigación
+ * con pesticidas, pastoreo) en ecosistemas de páramo. Si el modelo recomienda
+ * sembrar o fumigar en páramo, SUPRIME el cuerpo y lo REEMPLAZA con la
+ * restricción legal.
+ *
+ * Patrón: suppress-and-replace (como guardFalsePremise).
+ *
+ * @param {string} responseText — texto del LLM
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardParamoNormativa(responseText) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+
+  const norm = _stripDiacritics(responseText);
+
+  // Keywords que indican páramo en el texto o contexto
+  const PARAMO_KEYWORDS = [
+    /\bp[aá]ramo\b/,
+    /\bp[aá]ramos\b/,
+    /\bfrailej[oó]n\b/,
+    /\bfrailejones\b/,
+    /\bsubp[aá]ramo\b/,
+    /\bsubp[aá]ramos\b/,
+    /\bzona\s+de\s+p[aá]ramo\b/,
+    /\becosistema\s+de\s+p[aá]ramo\b/,
+  ];
+
+  // Keywords que indican recomendación de siembra/fumigación
+  const SIEMBRA_FUMIGACION_KEYWORDS = [
+    /\bsiembr\w*\b/,
+    /\bsembr\w*\b/,
+    /\bplant\w*\b/,
+    /\bcultiv\w*\b/,
+    /\bfumig\w*\b/,
+    /\baplic\w*\s+(pesticid|fungicid|insecticid|herbicid)\b/,
+    /\broci\w*\b/,
+    /\bpulveriz\w*\b/,
+    /\basperj\w*\b/,
+    /\baspers\w*\b/,
+    /\bagroqu[ií]mic\w*\b/,
+    /\bpesticid\w*\b/,
+    /\bfungicid\w*\b/,
+    /\binsecticid\w*\b/,
+    /\bherbicid\w*\b/,
+  ];
+
+  // Verificar si el texto menciona páramo
+  const hasParamo = PARAMO_KEYWORDS.some((re) => re.test(norm));
+
+  // Verificar si el texto recomienda siembra/fumigación
+  const hasSiembraFumigacion = SIEMBRA_FUMIGACION_KEYWORDS.some((re) => re.test(norm));
+
+  // Si ambos condiciones se cumplen, SUPRIMIR y REEMPLAZAR
+  if (hasParamo && hasSiembraFumigacion) {
+    bumpGuardTelemetry('paramo_normativa');
+
+    const restriction =
+      '⚠️ Restricción legal — Ley 1930 de 2018 (Páramo)\n\n' +
+      'No es posible recomendar siembra ni aplicación de pesticidas en ecosistemas de páramo. ' +
+      'La Ley 1930 de 2018 prohíbe actividades agropecuarias (agricultura, ganadería, ' +
+      'aplicación de agroquímicos) en这些 ecosistemas de protección estratégica.\n\n' +
+      'Si tu finca está en zona de páramo o área de influencia, te recomiendo:\n' +
+      '• Consultar con la autoridad ambiental local (Corporación Autónoma Regional) ' +
+      'para delimitar exactamente el área protegida.\n' +
+      '• Explorar alternativas de uso sostenible como conservación, restauración ' +
+      'ecológica o proyectos de servicios ecosistémicos (PSA).\n' +
+      '• Si estás en zona de amortiguación del páramo, prioriza prácticas agroecológicas ' +
+      'sin agroquímicos sintéticos.\n\n' +
+      '¿Quieres que te oriente sobre alternativas sostenibles para tu zona?';
+
+    return {
+      text: restriction,
+      modified: true,
+      reason: 'paramo_normativa_suprimido: siembra/fumigación_recomendada_en_paramo',
+    };
+  }
+
+  return { text: responseText, modified: false, reason: null };
+}
+
+/**
+ * Guard de CLIMA - consejo general.
+ *
+ * Provee un consejo general sobre clima cuando el texto menciona condiciones
+ * climáticas extremas sin contexto suficiente. NO suprime el texto, solo
+ * adiciona un caveat educativo.
+ *
+ * Patrón: aditivo (como guardAltitudeRiskCaveat).
+ *
+ * @param {string} responseText — texto del LLM
+ * @param {object} [ctx]
+ * @param {number|null} [ctx.forecastTempMin] — mínima del pronóstico (°C)
+ * @param {number|null} [ctx.forecastTempMax] — máxima del pronóstico (°C)
+ * @returns {{text:string, modified:boolean, reason:string|null}}
+ */
+export function guardClimaConsejo(responseText, { forecastTempMin = null, forecastTempMax = null } = {}) {
+  if (typeof responseText !== 'string' || responseText.length === 0) {
+    return { text: responseText ?? '', modified: false, reason: null };
+  }
+
+  const norm = _stripDiacritics(responseText);
+
+  // Si el texto ya incluye el consejo de clima, no re-disparamos
+  // Buscamos el marcador que el guard mismo inyecta
+  if (norm.includes('consejo climatico') || norm.includes('cambio climatico')) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Keywords que indican condiciones climáticas extremas
+  const CLIMA_EXTREMO_KEYWORDS = [
+    /\bhelad\w*\b/,
+    /\bhelada\b/,
+    /\bcongelac\w*\b/,
+    /\bsequ[ií]a\b/,
+    /\bsequ[ií]as\b/,
+    /\bola\s+de\s+calor\b/,
+    /\bcalor\s+extremo\b/,
+    /\binundac\w*\b/,
+    /\bexceso\s+de\s+lluvia\b/,
+    /\blluvias\s+intensas\b/,
+    /\bfen[oó]meno\s+del\s+ni[nñ]o\b/,
+    /\beni\b/,
+    /\bfen[oó]meno\s+de\s+la\s+ni[nñ]a\b/,
+    /\bvariabilidad\s+clim[aá]tica\b/,
+    /\bcambio\s+clim[aá]tico\b/,
+  ];
+
+  const hasClimaExtremo = CLIMA_EXTREMO_KEYWORDS.some((re) => re.test(norm));
+
+  // Si no hay condiciones extremas, no hacemos nada
+  if (!hasClimaExtremo) {
+    return { text: responseText, modified: false, reason: null };
+  }
+
+  // Si tenemos datos del pronóstico, los usamos para el consejo
+  let consejoEspecifico = '';
+  if (forecastTempMin !== null && forecastTempMin < 5) {
+    consejoEspecifico =
+      '\n\n🌡️ Pronóstico: se esperan temperaturas bajas (mínima de ' +
+      forecastTempMin.toFixed(1) +
+      '°C). Considera proteger cultivos sensibles con coberturas o shelters térmicos.';
+  } else if (forecastTempMax !== null && forecastTempMax > 32) {
+    consejoEspecifico =
+      '\n\n🌡️ Pronóstico: se esperan temperaturas altas (máxima de ' +
+      forecastTempMax.toFixed(1) +
+      '°C). Asegura riego suficiente y considera sombreado temporal para cultivos sensibles.';
+  }
+
+  bumpGuardTelemetry('clima_consejo');
+
+  const advice =
+    '\n\n💡 Consejo climático\n\n' +
+    'Ante condiciones climáticas extremas, te recomiendo:\n' +
+    '• Monitorear los pronósticos locales (IDEAM o meteoblue) regularmente.\n' +
+    '• Tener un plan de contingencia para cultivos sensibles (coberturas, riego ' +
+    'de emergencia, sombreado temporal).\n' +
+    '• Priorizar variedades adaptadas a tu piso térmico y con resiliencia climática.\n' +
+    '• Mantener registros históricos de clima en tu finca para identificar patrones.' +
+    consejoEspecifico;
+
+  const text = `${responseText.trim()}${advice}`;
+
+  return {
+    text,
+    modified: true,
+    reason: 'clima_consejo_aditivo: condiciones_extremas_detectadas',
+  };
+}
+
+/**
  * Set de guards que SOLO tienen sentido cuando la consulta es de SIEMBRA
  * (A12). Si la pregunta del usuario es de PRECIO/MERCADO (o info general sin
  * verbo de siembra), estos NO corren: razonan sobre viabilidad/identidad de
@@ -7035,6 +7209,21 @@ export function applyOutputGuards(
       text: wrongAuthority.text,
       modified: true,
       reasons: wrongAuthority.reason ? [wrongAuthority.reason] : [],
+    };
+  }
+
+  // GUARD de NORMATIVA (Ley 1930 - Páramo): si la respuesta recomienda sembrar o
+  // fumigar en páramo, SUPRIME el cuerpo y lo REEMPLAZA con la restricción legal.
+  // Es un guard de SEGURIDAD legal que debe ejecutarse antes de cualquier
+  // recomendación de siembra. Va aquí porque no requiere userMessage especial y
+  // es independiente de la intención de siembra/precio. Como REEMPLAZA el texto
+  // entero (la recomendación ilegal es íntegramente dañina), early-return.
+  const paramo = guardParamoNormativa(text);
+  if (paramo && paramo.modified) {
+    return {
+      text: paramo.text,
+      modified: true,
+      reasons: paramo.reason ? [paramo.reason] : [],
     };
   }
 
@@ -7326,6 +7515,17 @@ export function applyOutputGuards(
     text = conciseRes.text;
     modified = true;
     if (conciseRes.reason) reasons.push(conciseRes.reason);
+  }
+  // Guard de CLIMA - consejo general: si el texto menciona condiciones climáticas
+  // extremas sin contexto suficiente, adiciona un caveat educativo. ADITIVO (no
+  // suprime). Va al final de la cadena para que su consejo quede después de
+  // cualquier corrección de seguridad/legal. Firma propia (necesita forecastTempMin
+  // y forecastTempMax del pronóstico). Corre SIEMPRE, no es guard de siembra.
+  const climaRes = guardClimaConsejo(text, { forecastTempMin, forecastTempMax });
+  if (climaRes && climaRes.modified) {
+    text = climaRes.text;
+    modified = true;
+    if (climaRes.reason) reasons.push(climaRes.reason);
   }
   return { text, modified, reasons };
 }

--- a/tests/unit/outputGuards.test.js
+++ b/tests/unit/outputGuards.test.js
@@ -20,6 +20,8 @@ import {
   guardDoseWithoutSource,
   guardThermalViability,
   guardInventedName,
+  guardParamoNormativa,
+  guardClimaConsejo,
 } from '../../src/services/outputGuards.js';
 import {
   generateSourceCitationRules,
@@ -705,5 +707,226 @@ describe('Integration — (a)+(b)+(c) combinados anti-alucinación', () => {
     // que parecen inventadas por ser demasiado específicas sin contexto
     // (ej: "37.5 ml/L" en vez de "40 ml/L").
     // Esperado: el guard debe ser más estricto con dosis muy específicas.
+  });
+});
+
+describe('guardParamoNormativa — Ley 1930 (suppress-and-replace)', () => {
+  it('1) siembra en páramo → SUPRIME y REEMPLAZA con restricción legal', () => {
+    // Caso directo: modelo recomienda sembrar en páramo
+    const texto = 'Puedes sembrar papa en el páramo sin problema. El clima es ideal.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Ley 1930 de 2018');
+    expect(res.text).toContain('prohíbe actividades agropecuarias');
+    expect(res.text).toContain('Páramo');
+    // El texto original NO debe estar presente (suprimido)
+    expect(res.text).not.toContain('sembrar papa en el páramo');
+    expect(res.text).not.toContain('clima es ideal');
+    expect(res.reason).toBe('paramo_normativa_suprimido: siembra/fumigación_recomendada_en_paramo');
+  });
+
+  it('2) fumigación en páramo → SUPRIME y REEMPLAZA con restricción legal', () => {
+    // Caso de aplicación de pesticidas en páramo
+    const texto = 'Aplica este fungicida en tu cultivo del páramo para controlar la plaga.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Ley 1930 de 2018');
+    expect(res.text).toContain('prohíbe');
+    expect(res.text).toContain('agroquímicos');
+    // El texto original NO debe estar presente
+    expect(res.text).not.toContain('Aplica este fungicida');
+    expect(res.reason).toBe('paramo_normativa_suprimido: siembra/fumigación_recomendada_en_paramo');
+  });
+
+  it('3) frailejón + sembrar → dispara (frailejón es keyword de páramo)', () => {
+    // "frailejón" es keyword de páramo
+    const texto = 'Planta frailejones para recuperar la zona y siembra papa al lado.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Ley 1930 de 2018');
+    expect(res.text).not.toContain('siembra papa al lado');
+  });
+
+  it('4) páramo sin verbo de siembra/fumigación → NO dispara', () => {
+    // Menciona páramo pero no recomienda sembrar/fumigar
+    const texto = 'Los páramos son ecosistemas de importancia hídrica para Colombia.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(texto);
+    expect(res.reason).toBeNull();
+  });
+
+  it('5) siembra/fumigación sin páramo → NO dispara', () => {
+    // Recomienda sembrar pero no menciona páramo
+    const texto = 'Puedes sembrar papa en tu finca. El clima es ideal.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(texto);
+    expect(res.reason).toBeNull();
+  });
+
+  it('6) string vacío → NO dispara', () => {
+    const res = guardParamoNormativa('');
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe('');
+    expect(res.reason).toBeNull();
+  });
+
+  it('7) null → NO dispara (graceful degradation)', () => {
+    const res = guardParamoNormativa(null);
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe('');
+    expect(res.reason).toBeNull();
+  });
+
+  it('8) subpáramo + rociado → dispara (subpáramo es keyword)', () => {
+    // "subpáramo" también es keyword de ecosistema de páramo
+    const texto = 'Rocia fungicida en el subpáramo para proteger las plantas.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Ley 1930 de 2018');
+    expect(res.text).not.toContain('Rocia fungicida');
+  });
+
+  it('9) cultivo en zona de páramo → dispara', () => {
+    // "zona de páramo" también es keyword
+    const texto = 'Cultiva cebolla en la zona de páramo con riego constante.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Ley 1930 de 2018');
+    expect(res.text).not.toContain('Cultiva cebolla');
+  });
+
+  it('10) aspersión de pesticida en páramo → dispara', () => {
+    // "aspersión" y "pesticida" son keywords de fumigación
+    const texto = 'Realiza aspersión de pesticida en el páramo para controlar plagas.';
+    const res = guardParamoNormativa(texto);
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Ley 1930 de 2018');
+    expect(res.text).not.toContain('aspersión de pesticida');
+  });
+});
+
+describe('guardClimaConsejo — consejo general de clima (aditivo)', () => {
+  it('1) helada mencionada → adiciona consejo climático', () => {
+    // Caso simple: texto menciona helada
+    const texto = 'Protégete de las heladas nocturnas con cubiertas.';
+    const res = guardClimaConsejo(texto, { forecastTempMin: 2 });
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Consejo climático');
+    expect(res.text).toContain('Monitorear los pronósticos');
+    expect(res.text).toContain('plan de contingencia');
+    // El texto original debe estar presente (aditivo, no suppress)
+    expect(res.text).toContain('Protégete de las heladas');
+    expect(res.text).toContain('cubiertas');
+    expect(res.reason).toBe('clima_consejo_aditivo: condiciones_extremas_detectadas');
+  });
+
+  it('2) sequía mencionada → adiciona consejo climático', () => {
+    // Caso de sequía
+    const texto = 'La sequía está afectando el cultivo. Riega más frecuente.';
+    const res = guardClimaConsejo(texto, {});
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Consejo climático');
+    expect(res.text).toContain('Monitorear los pronósticos');
+    // El texto original debe estar presente
+    expect(res.text).toContain('La sequía está afectando');
+    expect(res.text).toContain('Riega más frecuente');
+  });
+
+  it('3) forecastTempMin < 5°C → adiciona consejo específico', () => {
+    // Temperatura muy baja en pronóstico
+    const texto = 'Las heladas pueden dañar las plantas jóvenes.';
+    const res = guardClimaConsejo(texto, { forecastTempMin: 3 });
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Pronóstico: se esperan temperaturas bajas');
+    expect(res.text).toContain('3.0°C');
+    expect(res.text).toContain('proteger cultivos sensibles');
+  });
+
+  it('4) forecastTempMax > 32°C → adiciona consejo específico', () => {
+    // Temperatura muy alta en pronóstico
+    const texto = 'El calor extremo puede estrés hídrico.';
+    const res = guardClimaConsejo(texto, { forecastTempMax: 34 });
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Pronóstico: se esperan temperaturas altas');
+    expect(res.text).toContain('34.0°C');
+    expect(res.text).toContain('Asegura riego suficiente');
+    expect(res.text).toContain('sombreado temporal');
+  });
+
+  it('5) fenómeno del Niño mencionado → adiciona consejo', () => {
+    // Fenómeno climático específico
+    const texto = 'El fenómeno del Niño reduce las lluvias en la región.';
+    const res = guardClimaConsejo(texto, {});
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Consejo climático');
+    expect(res.text).toContain('Monitorear los pronósticos');
+    // El texto original debe estar presente
+    expect(res.text).toContain('El fenómeno del Niño reduce');
+  });
+
+  it('6) texto sin clima extremo → NO dispara', () => {
+    // Texto normal sin condiciones extremas
+    const texto = 'El cultivo de papa se da bien en clima frío.';
+    const res = guardClimaConsejo(texto, {});
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(texto);
+    expect(res.reason).toBeNull();
+  });
+
+  it('7) string vacío → NO dispara', () => {
+    const res = guardClimaConsejo('', {});
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe('');
+    expect(res.reason).toBeNull();
+  });
+
+  it('8) null → NO dispara (graceful degradation)', () => {
+    const res = guardClimaConsejo(null, {});
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe('');
+    expect(res.reason).toBeNull();
+  });
+
+  it('9) texto con consejo ya aplicado → NO re-dispara (idempotencia)', () => {
+    // Si el texto ya incluye el consejo, no debe aplicarlo de nuevo
+    const texto =
+      'Las heladas pueden dañar las plantas.\n\n💡 Consejo climático\n\nMonitorear los pronósticos locales (IDEAM o meteoblue) regularmente.';
+    const res = guardClimaConsejo(texto, {});
+    expect(res.modified).toBe(false);
+    expect(res.text).toBe(texto);
+    expect(res.reason).toBeNull();
+  });
+
+  it('10) ola de calor mencionada → adiciona consejo', () => {
+    // Caso de ola de calor
+    const texto = 'La ola de calor está provocando estrés en los cultivos.';
+    const res = guardClimaConsejo(texto, { forecastTempMax: 35 });
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Consejo climático');
+    expect(res.text).toContain('Pronóstico: se esperan temperaturas altas');
+    expect(res.text).toContain('35.0°C');
+    // El texto original debe estar presente
+    expect(res.text).toContain('La ola de calor está provocando');
+  });
+
+  it('11) variabilidad climática mencionada → adiciona consejo', () => {
+    // Caso de variabilidad climática
+    const texto = 'La variabilidad climática afecta los ciclos de cosecha.';
+    const res = guardClimaConsejo(texto, {});
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Consejo climático');
+    expect(res.text).toContain('Monitorear los pronósticos');
+    expect(res.text).toContain('plan de contingencia');
+  });
+
+  it('12) inundación mencionada → adiciona consejo', () => {
+    // Caso de inundación
+    const texto = 'La inundación dañó el cultivo en la zona baja.';
+    const res = guardClimaConsejo(texto, {});
+    expect(res.modified).toBe(true);
+    expect(res.text).toContain('Consejo climático');
+    expect(res.text).toContain('Monitorear los pronósticos');
   });
 });


### PR DESCRIPTION
## Summary

Este PR implementa dos nuevos guards de seguridad para :

### 1.  (NORMATIVA - Ley 1930)
- **Detecta** recomendaciones de siembra o fumigación en ecosistemas de páramo
- **Suprime y reemplaza** el cuerpo del texto con una restricción legal basada en la Ley 1930 de 2018
- **Palabras clave detectadas**: páramo, páramos, frailejón, frailejones, subpáramo, zona de páramo, ecosistema de páramo
- **Verbos de acción**: sembrar, plantar, cultivar, fumigar, rociar, pulverizar, asperjar, aplicar pesticida/fungicida/insecticida/herbicida
- **Patrón**: suppress-and-replace (igual que `guardFalsePremise`)

### 2.  (CLIMA - consejo general)
- **Adiciona** un consejo educativo sobre condiciones climáticas extremas
- **Consejos específicos** según el pronóstico (forecastTempMin < 5°C o forecastTempMax > 32°C)
- **Palabras clave detectadas**: helada, sequía, ola de calor, calor extremo, inundación, exceso de lluvia, fenómeno del Niño/La Niña, variabilidad climática, cambio climático
- **Patrón**: aditivo (igual que `guardAltitudeRiskCaveat`)

### Integración en `applyOutputGuards`
- `guardParamoNormativa`: se ejecuta temprano en la cadena (después de guards de seguridad como `guardOffDomain` y `guardWrongColombiaAuthority`)
- `guardClimaConsejo`: se ejecuta al final (después de `guardConciseResponse`)

## Test plan

Tests de regresión añadidos en `tests/unit/outputGuards.test.js`:

### `guardParamoNormativa` (10 tests)
- ✅ Siembra en páramo → SUPRIME y REEMPLAZA con restricción legal
- ✅ Fumigación en páramo → SUPRIME y REEMPLAZA con restricción legal
- ✅ Frailejón + sembrar → dispara (frailejón es keyword de páramo)
- ✅ Páramo sin verbo de siembra/fumigación → NO dispara
- ✅ Siembra/fumigación sin páramo → NO dispara
- ✅ String vacío → NO dispara
- ✅ Null → NO dispara (graceful degradation)
- ✅ Subpáramo + rociado → dispara (subpáramo es keyword)
- ✅ Cultivo en zona de páramo → dispara
- ✅ Aspersión de pesticida en páramo → dispara

### `guardClimaConsejo` (12 tests)
- ✅ Helada mencionada → adiciona consejo climático
- ✅ Sequía mencionada → adiciona consejo climático
- ✅ forecastTempMin < 5°C → adiciona consejo específico
- ✅ forecastTempMax > 32°C → adiciona consejo específico
- ✅ Fenómeno del Niño mencionado → adiciona consejo
- ✅ Texto sin clima extremo → NO dispara
- ✅ String vacío → NO dispara
- ✅ Null → NO dispara (graceful degradation)
- ✅ Texto con consejo ya aplicado → NO re-dispara (idempotencia)
- ✅ Ola de calor mencionada → adiciona consejo
- ✅ Variabilidad climática mencionada → adiciona consejo
- ✅ Inundación mencionada → adiciona consejo

### Ejecución de tests
```bash
npx vitest run tests/unit/outputGuards.test.js
# ✅ 77 tests passed
```

### Build y lint
```bash
npm run build  # ✅ built in 3.93s
npx eslint src/services/outputGuards.js tests/unit/outputGuards.test.js --max-warnings=0  # ✅ no errors
```

## Riesgos conocidos

- **Falsos positivos en guardParamoNormativa**: Si un usuario menciona páramo en un contexto histórico/educativo sin intención de sembrar, el guard podría disparar. Sin embargo, el guard requiere AMBAS condiciones (páramo + verbo de siembra/fumigación), lo que reduce el riesgo.
- **Idempotencia en guardClimaConsejo**: El guard usa `_stripDiacritics` para detectar si el consejo ya está aplicado. Busca "consejo climatico" (sin tilde) en el texto normalizado.

## MCP tools usados

No se usaron MCP tools para esta implementación. Los guards son deterministas y operan solo sobre el texto del LLM.

## Compatibilidad

- Mantiene la firma estándar de guards: `(\{text, modified, reason\})`
- Compatible con el resto de la cadena `GUARD_CHAIN`
- No introduce dependencias nuevas

Refs: task #6247