### PR TITLE
feat(offline): precachear corpus RAG + embeddings y persistir índice para grounding sin señal

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,3 +44,60 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+
+  # Gate dedicado offline-first de campo: corre el spec del corpus RAG contra el
+  # BUILD de producción + `vite preview` (Service Worker REAL), NO el dev server.
+  # Motivo (memoria feedback-sidecar-bench-misses-pwa-rag-path): el gate viejo
+  # corría en dev y era ciego al SW de prod. Aquí validamos que el corpus +
+  # embeddings + bundle se sirven OFFLINE desde la cache del SW real tras una
+  # recarga en frío.
+  offline-corpus-dist:
+    name: Offline-first corpus (dist + SW real)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build (genera dist con SW de producción)
+        run: npm run build
+        env:
+          VITE_FARMOS_URL: ''
+          VITE_FARMOS_CLIENT_ID: farm
+
+      - name: Preview server + offline-corpus spec contra el SW real
+        run: |
+          npx vite preview --port 5173 --strictPort &
+          PREVIEW_PID=$!
+          # Espera a que el preview responda (hasta 60s) sin dependencias extra.
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:5173/sw.js; then break; fi
+            sleep 1
+          done
+          npx playwright test offline-corpus.spec.js --project=chromium
+          STATUS=$?
+          kill $PREVIEW_PID 2>/dev/null || true
+          exit $STATUS
+        env:
+          CI: '1'
+          PLAYWRIGHT_BASE_URL: http://localhost:5173
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-offline-corpus
+          path: playwright-report/
+          retention-days: 14

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -128,10 +128,19 @@ export default defineConfig({
       grep: /@cross-platform/,
     },
   ],
-  webServer: {
-    command: 'npx vite --port=5173 --strictPort',
-    url: 'http://localhost:5173',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  // webServer: solo cuando NO se provee un servidor externo. Si
+  // PLAYWRIGHT_BASE_URL está seteado (ej. el gate offline-corpus-dist arranca su
+  // propio `vite preview` con el SW de producción), NO levantamos el dev server
+  // de Playwright — si no, chocaría con el preview por el puerto 5173 y, peor,
+  // serviría módulos de dev (sin bundle/SW real) en vez del dist.
+  ...(process.env.PLAYWRIGHT_BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: 'npx vite --port=5173 --strictPort',
+          url: 'http://localhost:5173',
+          reuseExistingServer: !process.env.CI,
+          timeout: 120_000,
+        },
+      }),
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,30 @@
-const CACHE_NAME = 'chagra-v308';
+const CACHE_NAME = 'chagra-v309';
+
+// Cache de GROUNDING del agente (corpus RAG + embeddings + tiles del mapa).
+// SEPARADO de CACHE_NAME a propósito: su contenido NO está hasheado por
+// filename (las fichas son `/cycle-content/<slug>.json`, los tiles
+// `/{z}/{x}/{y}.png`) y cambia con baja frecuencia. Si viviera en CACHE_NAME,
+// cada deploy (que bumpea CACHE_NAME por SHA) borraría el corpus entero y la
+// PRIMERA recarga offline post-deploy se quedaría SIN grounding hasta volver a
+// estar online. Al aislarlo, el grounding sobrevive a los deploys del bundle.
+// La invalidación del corpus se maneja por separado (versión del manifest), no
+// por SHA del bundle. Ver migración de versión en RAG_GROUNDING_PREFIX.
+const RAG_GROUNDING_PREFIX = 'chagra-rag-grounding-';
+const RAG_GROUNDING_CACHE = `${RAG_GROUNDING_PREFIX}v1`;
+
+// Tiles de mapa (Leaflet/OpenStreetMap): cache-on-use en su propio bucket.
+// No se precachean (son ilimitados); se cachean SOLO los que el usuario ya
+// vio online, para que el mapa funcione offline en zonas ya visitadas.
+const MAP_TILES_PREFIX = 'chagra-map-tiles-';
+const MAP_TILES_CACHE = `${MAP_TILES_PREFIX}v1`;
+// Tope defensivo de tiles cacheados (LRU aproximado por orden de inserción):
+// evita que el cache de tiles crezca sin límite en un teléfono rural. ~400
+// tiles ≈ varios MB, suficiente para varias zonas de finca a distintos zooms.
+const MAP_TILES_MAX = 400;
+// Dominios de tiles que cacheamos. OSM y su alias osm.org (ver FarmMap,
+// MapPicker, LocationDetectedScreen, MultiFincaGlobe).
+const MAP_TILE_HOSTS = ['tile.openstreetmap.org', 'tile.osm.org', 'tile.opentopomap.org'];
+
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
@@ -12,6 +38,20 @@ const ASSETS_TO_CACHE = [
   // consultable OFFLINE aunque el usuario nunca haya abierto una vista que lo
   // cargue estando online. ~1.2 MB; aceptable para garantizar offline-first.
   '/catalog.sqlite'
+];
+
+// Grounding del agente precacheado en install (archivos únicos, no las 491
+// fichas — esas se llenan cache-first vía prewarmCorpus al login, ver fetch
+// handler de /cycle-content/*):
+//   - rag-embeddings.json (~7 MB): el ÚNICO archivo que habilita búsqueda
+//     SEMÁNTICA offline. Sin él, una recarga offline degrada a BM25 puro.
+//     Vale el peso del install one-time: es el mayor salto de calidad de
+//     grounding sin red.
+//   - cycle-content/manifest.json (~13 KB): lista de slugs; sin él loadCorpus
+//     cae al fallback legacy (iterar CROP_TAXONOMY) con N-3 fetches fallidos.
+const RAG_GROUNDING_PRECACHE = [
+  '/rag-embeddings.json',
+  '/cycle-content/manifest.json',
 ];
 
 // Instalación del Service Worker.
@@ -56,6 +96,19 @@ self.addEventListener('install', (event) => {
           // chunks se llenarán cache-first en la primera carga online.
         }
       })
+      // 3) Grounding del agente: precache de embeddings + manifest en su bucket
+      //    separado (RAG_GROUNDING_CACHE). NO bloquea el shell — corre después y
+      //    los errores son tolerados (add por item con catch). Las 491 fichas NO
+      //    se precachean aquí (peso + 491 sockets en install); se llenan
+      //    cache-first cuando prewarmCorpus las pide al login. Ver fetch handler.
+      .then(() =>
+        caches.open(RAG_GROUNDING_CACHE).then((groundingCache) =>
+          Promise.all(
+            RAG_GROUNDING_PRECACHE.map((u) => groundingCache.add(u).catch(() => undefined))
+          )
+        )
+      )
+      .catch(() => undefined)
   );
 });
 
@@ -66,10 +119,18 @@ self.addEventListener('activate', (event) => {
     caches.keys()
       .then(cacheNames => Promise.all(
         cacheNames.map(cacheName => {
-          if (cacheName !== CACHE_NAME) {
-            return caches.delete(cacheName);
-          }
-          return undefined;
+          // Conservar SIEMPRE el bucket actual de grounding (corpus/embeddings)
+          // y el de tiles del mapa: no están versionados por SHA del bundle, así
+          // que un deploy NO debe purgarlos (si no, la primera recarga offline
+          // post-deploy queda sin grounding ni mapa). Solo borramos versiones
+          // VIEJAS de esos buckets (prefijo + versión distinta) y el CACHE_NAME
+          // anterior.
+          if (cacheName === CACHE_NAME) return undefined;
+          if (cacheName === RAG_GROUNDING_CACHE) return undefined;
+          if (cacheName === MAP_TILES_CACHE) return undefined;
+          // Versiones viejas de los buckets de grounding/tiles → borrar.
+          // El resto (CACHE_NAME viejo, caches huérfanos) → borrar.
+          return caches.delete(cacheName);
         })
       ))
       // La limpieza de caches viejos NUNCA debe bloquear el claim: si falla
@@ -138,6 +199,77 @@ self.addEventListener('fetch', (event) => {
           // ya cacheado (caso normal tras una visita online) sí se sirve arriba.
           .catch(() => new Response('', { status: 504, statusText: 'Offline: chunk no cacheado' }));
       })
+    );
+    return;
+  }
+
+  // Grounding del agente (corpus RAG + embeddings): CACHE-FIRST con relleno en
+  // background, en el bucket separado RAG_GROUNDING_CACHE.
+  //   - /cycle-content/<slug>.json  (491 fichas + manifest.json)
+  //   - /rag-embeddings.json        (vectores semánticos)
+  // Cache-first porque el contenido cambia con baja frecuencia y la latencia
+  // móvil rural penaliza una revalidación de red por cada ficha. La primera
+  // visita ONLINE (prewarmCorpus al login fetchea las 491 fichas en lotes) las
+  // deja todas en cache; a partir de ahí una recarga OFFLINE en frío tiene el
+  // corpus completo y el agente conserva grounding sin señal. Esto cierra el
+  // hueco: antes corpusCache vivía solo en memoria y el SW no cacheaba estas
+  // rutas → recarga offline = agente sin grounding (degradaba a respuesta sin
+  // contexto). Un slug nuevo tras un deploy del corpus se baja la primera vez
+  // que se lo pide estando online (cache-miss → fetch → put).
+  const isGrounding =
+    url.pathname.startsWith('/cycle-content/') ||
+    url.pathname === '/rag-embeddings.json';
+  if (isGrounding && event.request.method === 'GET') {
+    event.respondWith(
+      caches.open(RAG_GROUNDING_CACHE).then((cache) =>
+        cache.match(event.request).then((cached) => {
+          if (cached) return cached;
+          return fetch(event.request)
+            .then((response) => {
+              if (response && response.ok && response.status === 200) {
+                cache.put(event.request, response.clone());
+              }
+              return response;
+            })
+            // Offline y sin cache: 504 explícito. El caller (loadSlugDocs /
+            // loadEmbeddings) ya degrada con gracia ante !ok (devuelve []/null).
+            .catch(() => new Response('', { status: 504, statusText: 'Offline: grounding no cacheado' }));
+        })
+      )
+    );
+    return;
+  }
+
+  // Tiles de mapa (OSM/OpenTopoMap): CACHE-FIRST cache-on-use en MAP_TILES_CACHE.
+  // No se precachean (son ilimitados); se guardan SOLO los tiles que el usuario
+  // ya cargó online, para que el mapa funcione offline en zonas ya visitadas.
+  // Cross-origin → respuestas opaque (no inspeccionables): las cacheamos igual
+  // (un tile opaque renderiza bien en <img>/Leaflet) pero aplicamos un tope LRU
+  // aproximado para no llenar el storage del teléfono. Si no hay red ni cache,
+  // dejamos que falle (Leaflet ya muestra su placeholder; NO rompemos el mapa).
+  if (
+    event.request.method === 'GET' &&
+    MAP_TILE_HOSTS.some((h) => url.hostname === h || url.hostname.endsWith('.' + h))
+  ) {
+    event.respondWith(
+      caches.open(MAP_TILES_CACHE).then((cache) =>
+        cache.match(event.request).then((cached) => {
+          if (cached) return cached;
+          return fetch(event.request)
+            .then((response) => {
+              // Cacheamos 200 (same-origin imposible aquí) y opaque (status 0,
+              // type 'opaque') — ambos sirven para pintar el tile offline.
+              if (response && (response.ok || response.type === 'opaque')) {
+                cache.put(event.request, response.clone());
+                trimTileCache(cache);
+              }
+              return response;
+            })
+            // Sin red ni cache: propagamos el fallo de red para que Leaflet
+            // muestre su placeholder. NUNCA un 504 sintético (rompería el tile).
+            .catch(() => cached || Response.error());
+        })
+      )
     );
     return;
   }
@@ -306,6 +438,23 @@ async function getPendingTelemetryEvents() {
 
     request.onerror = () => reject(request.error);
   });
+}
+
+// Poda LRU aproximada del cache de tiles: si supera MAP_TILES_MAX, borra los
+// más viejos (las keys de un Cache se devuelven en orden de inserción, así que
+// `keys()[0..N]` son los primeros guardados ≈ los menos recientes). No es un
+// LRU exacto (no reordena por acceso), pero acota el storage sin coste por hit.
+// Fire-and-forget: nunca bloquea ni rompe la respuesta del tile.
+async function trimTileCache(cache) {
+  try {
+    const keys = await cache.keys();
+    const excess = keys.length - MAP_TILES_MAX;
+    if (excess > 0) {
+      await Promise.all(keys.slice(0, excess).map((k) => cache.delete(k)));
+    }
+  } catch {
+    // storage/quota: ignorar — el tope es defensivo, no crítico.
+  }
 }
 
 // Escuchar mensajes del cliente (solo same-origin).

--- a/src/db/__tests__/corpusIndexCache.test.js
+++ b/src/db/__tests__/corpusIndexCache.test.js
@@ -1,0 +1,152 @@
+/**
+ * corpusIndexCache.test.js — persistencia del índice RAG (offline-first).
+ *
+ * Verifica el contrato de saveCorpusIndex / loadCorpusIndex sin tocar
+ * IndexedDB real: mockeamos openDB con un store en memoria (Map) que replica
+ * el subset de la API IDB que el módulo usa (transaction → objectStore →
+ * put/get + tx.oncomplete/onerror). Sigue el patrón de assetCache.tenant.test.
+ *
+ * Cubre:
+ *   - roundtrip save→load preservando el Map de idf (structured clone).
+ *   - invalidación por manifestStamp (deploy del corpus).
+ *   - invalidación por tier (OSS↔Pro, catálogo distinto).
+ *   - degradación: load sin registro o con docs vacíos → null.
+ *   - save/load nunca lanzan ante fallo de IDB.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Store en memoria compartido por el mock de openDB.
+let memStore;
+let failMode;
+
+vi.mock('../dbCore', () => {
+  const STORES = { RAG_CORPUS_CACHE: 'rag_corpus_cache' };
+  const makeTx = () => {
+    const tx = { oncomplete: null, onerror: null, onabort: null };
+    const objectStore = () => ({
+      put(record) {
+        if (failMode === 'put') {
+          Promise.resolve().then(() => tx.onerror?.());
+          return;
+        }
+        memStore.set(record.key, record);
+        Promise.resolve().then(() => tx.oncomplete?.());
+      },
+      get(key) {
+        const req = { onsuccess: null, onerror: null, result: undefined };
+        Promise.resolve().then(() => {
+          if (failMode === 'get') {
+            req.onerror?.();
+            return;
+          }
+          req.result = memStore.get(key);
+          req.onsuccess?.();
+        });
+        return req;
+      },
+      delete(key) {
+        memStore.delete(key);
+        Promise.resolve().then(() => tx.oncomplete?.());
+      },
+    });
+    return { tx, objectStore };
+  };
+  return {
+    STORES,
+    openDB: vi.fn(async () => {
+      if (failMode === 'open') throw new Error('IDB no disponible');
+      return {
+        transaction: () => {
+          const { tx, objectStore } = makeTx();
+          return { ...tx, objectStore: () => objectStore() };
+        },
+      };
+    }),
+  };
+});
+
+import { saveCorpusIndex, loadCorpusIndex, clearCorpusIndex } from '../corpusIndexCache';
+
+const sampleIndex = () => ({
+  docs: [
+    {
+      species: 'fragaria_x_ananassa',
+      key: 'valor_pedagogico',
+      text: 'fresa rosácea perenne',
+      tokenized: ['fresa', 'rosacea', 'perenne'],
+      termCounts: new Map([['fresa', 1], ['rosacea', 1], ['perenne', 1]]),
+      docLen: 3,
+    },
+  ],
+  idf: new Map([['fresa', 1.2], ['rosacea', 0.8]]),
+  avgDocLen: 3,
+});
+
+describe('corpusIndexCache', () => {
+  beforeEach(() => {
+    memStore = new Map();
+    failMode = null;
+  });
+
+  it('roundtrip save→load preserva docs e idf como Map', async () => {
+    const idx = sampleIndex();
+    const ok = await saveCorpusIndex({ ...idx, manifestStamp: 'm1', tier: 263 });
+    expect(ok).toBe(true);
+
+    const loaded = await loadCorpusIndex({ manifestStamp: 'm1', tier: 263 });
+    expect(loaded).not.toBeNull();
+    expect(loaded.docs).toHaveLength(1);
+    expect(loaded.avgDocLen).toBe(3);
+    expect(loaded.idf instanceof Map).toBe(true);
+    expect(loaded.idf.get('fresa')).toBe(1.2);
+    expect(loaded.docs[0].termCounts instanceof Map).toBe(true);
+    expect(loaded.docs[0].termCounts.get('fresa')).toBe(1);
+  });
+
+  it('invalida si el manifestStamp esperado difiere (deploy del corpus)', async () => {
+    await saveCorpusIndex({ ...sampleIndex(), manifestStamp: 'm1', tier: 263 });
+    const loaded = await loadCorpusIndex({ manifestStamp: 'm2', tier: 263 });
+    expect(loaded).toBeNull();
+  });
+
+  it('invalida si el tier esperado difiere (OSS↔Pro)', async () => {
+    await saveCorpusIndex({ ...sampleIndex(), manifestStamp: 'm1', tier: 263 });
+    const loaded = await loadCorpusIndex({ manifestStamp: 'm1', tier: 491 });
+    expect(loaded).toBeNull();
+  });
+
+  it('devuelve null si no hay índice persistido', async () => {
+    const loaded = await loadCorpusIndex({ manifestStamp: 'm1', tier: 263 });
+    expect(loaded).toBeNull();
+  });
+
+  it('devuelve null si los docs persistidos están vacíos', async () => {
+    await saveCorpusIndex({ docs: [], idf: new Map(), avgDocLen: 1, manifestStamp: 'm1', tier: 263 });
+    const loaded = await loadCorpusIndex({ manifestStamp: 'm1', tier: 263 });
+    expect(loaded).toBeNull();
+  });
+
+  it('hidrata sin validar cuando el caller no pasa manifestStamp/tier', async () => {
+    await saveCorpusIndex({ ...sampleIndex(), manifestStamp: 'm1', tier: 263 });
+    const loaded = await loadCorpusIndex();
+    expect(loaded).not.toBeNull();
+    expect(loaded.docs).toHaveLength(1);
+  });
+
+  it('saveCorpusIndex no lanza y devuelve false si IDB falla al abrir', async () => {
+    failMode = 'open';
+    await expect(saveCorpusIndex({ ...sampleIndex(), manifestStamp: 'm1', tier: 263 })).resolves.toBe(false);
+  });
+
+  it('loadCorpusIndex no lanza y devuelve null si IDB falla al abrir', async () => {
+    failMode = 'open';
+    await expect(loadCorpusIndex({ manifestStamp: 'm1', tier: 263 })).resolves.toBeNull();
+  });
+
+  it('clearCorpusIndex borra el registro y no lanza', async () => {
+    await saveCorpusIndex({ ...sampleIndex(), manifestStamp: 'm1', tier: 263 });
+    await clearCorpusIndex();
+    const loaded = await loadCorpusIndex({ manifestStamp: 'm1', tier: 263 });
+    expect(loaded).toBeNull();
+  });
+});

--- a/src/db/corpusIndexCache.js
+++ b/src/db/corpusIndexCache.js
@@ -1,0 +1,139 @@
+/**
+ * corpusIndexCache — persistencia del ÍNDICE RAG construido (offline-first).
+ *
+ * Por qué existe (audit verify-first 2026-06-13, hueco offline de campo):
+ *   El Service Worker ya cachea los BYTES crudos de /cycle-content/* y
+ *   /rag-embeddings.json (capa de RED → la PWA puede re-fetchearlos offline).
+ *   Pero `corpusCache` de ragRetriever.js vivía SOLO en memoria: en cada
+ *   recarga (incluida una recarga OFFLINE en frío) había que re-fetchear y
+ *   re-TOKENIZAR las 491 fichas — CPU cara en un teléfono rural, y sin red el
+ *   re-fetch depende del SW cache (rápido) pero el re-tokenize igual corre.
+ *
+ *   Este módulo persiste el índice YA construido (docs pre-tokenizados + IDF +
+ *   avgDocLen) en IndexedDB (store rag_corpus_cache, v21). Una recarga offline
+ *   en frío hidrata el índice desde aquí → grounding disponible sin re-tokenizar
+ *   ni depender de que el SW tenga las 491 fichas.
+ *
+ * Serialización: IndexedDB usa structured clone, que soporta Map y Float32Array
+ * de forma nativa. NO convertimos a JSON: los `termCounts: Map` y el `idf: Map`
+ * se guardan/recuperan tal cual, sin pérdida ni coste de re-parseo.
+ *
+ * Invalidación: guardamos `manifestStamp` (generated_at del manifest + nº de
+ * slugs) y `tier` (cantidad de especies del catálogo activo). Si al arrancar el
+ * manifest o el tier-gate cambiaron, el índice persistido se descarta y se
+ * reconstruye — así un deploy del corpus o un cambio OSS↔Pro no sirve grounding
+ * obsoleto. Solo local, no toca syncManager. Sigue el patrón IDB de
+ * farmProcessCache / assetCache.
+ */
+import { openDB, STORES } from './dbCore';
+
+// Clave única del registro KV. Un solo corpus por dispositivo.
+const CORPUS_KEY = 'corpus';
+
+/**
+ * Persiste el índice RAG construido.
+ *
+ * @param {Object} payload
+ * @param {Array} payload.docs - passages pre-tokenizados (con termCounts:Map, docLen).
+ * @param {Map} payload.idf - inverse document frequency por término.
+ * @param {number} payload.avgDocLen - longitud media de doc (para BM25).
+ * @param {string} payload.manifestStamp - huella del manifest (invalidación).
+ * @param {number} payload.tier - nº de especies del catálogo activo (tier-gate).
+ * @returns {Promise<boolean>} true si guardó, false si falló (no lanza).
+ */
+export async function saveCorpusIndex({ docs, idf, avgDocLen, manifestStamp, tier }) {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RAG_CORPUS_CACHE, 'readwrite');
+      tx.objectStore(STORES.RAG_CORPUS_CACHE).put({
+        key: CORPUS_KEY,
+        docs,
+        idf,
+        avgDocLen,
+        manifestStamp: manifestStamp ?? null,
+        tier: tier ?? null,
+        savedAt: Date.now(),
+      });
+      tx.oncomplete = () => resolve(true);
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  } catch (err) {
+    // Quota/storage/structured-clone: degradar a memoria. Persistir es una
+    // optimización; nunca debe romper la carga del corpus.
+    console.warn('[RAG] No se pudo persistir el índice del corpus:', err?.message);
+    return false;
+  }
+}
+
+/**
+ * Lee el índice RAG persistido, validando que siga vigente.
+ *
+ * @param {Object} expected
+ * @param {string} expected.manifestStamp - huella esperada del manifest.
+ * @param {number} expected.tier - nº de especies esperado del catálogo.
+ * @returns {Promise<{docs:Array, idf:Map, avgDocLen:number}|null>}
+ *   El índice si existe y coincide manifest+tier; null si no hay, está obsoleto
+ *   o falla la lectura (el caller reconstruye desde la red).
+ */
+export async function loadCorpusIndex({ manifestStamp, tier } = {}) {
+  try {
+    const db = await openDB();
+    const record = await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RAG_CORPUS_CACHE, 'readonly');
+      const req = tx.objectStore(STORES.RAG_CORPUS_CACHE).get(CORPUS_KEY);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    });
+
+    if (!record || !Array.isArray(record.docs) || record.docs.length === 0) {
+      return null;
+    }
+
+    // Invalidación: si la huella del manifest cambió (deploy del corpus) o el
+    // tier-gate cambió (OSS↔Pro, catálogo distinto), el índice está obsoleto.
+    // Solo comparamos cuando el caller pasa el valor esperado (si no lo pasa,
+    // confiamos en lo persistido — degradación tolerante).
+    if (manifestStamp != null && record.manifestStamp !== manifestStamp) {
+      return null;
+    }
+    if (tier != null && record.tier != null && record.tier !== tier) {
+      return null;
+    }
+
+    // idf se guardó como Map (structured clone lo preserva). Defensa por si un
+    // navegador viejo lo serializó distinto: reconstruir Map desde entries.
+    let idf = record.idf;
+    if (!(idf instanceof Map)) {
+      idf = new Map(idf && typeof idf === 'object' ? Object.entries(idf) : []);
+    }
+
+    return {
+      docs: record.docs,
+      idf,
+      avgDocLen: typeof record.avgDocLen === 'number' ? record.avgDocLen : 1,
+    };
+  } catch (err) {
+    console.warn('[RAG] No se pudo leer el índice persistido del corpus:', err?.message);
+    return null;
+  }
+}
+
+/**
+ * Borra el índice persistido (debug / invalidación manual). No lanza.
+ * @returns {Promise<void>}
+ */
+export async function clearCorpusIndex() {
+  try {
+    const db = await openDB();
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.RAG_CORPUS_CACHE, 'readwrite');
+      tx.objectStore(STORES.RAG_CORPUS_CACHE).delete(CORPUS_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch (err) {
+    console.warn('[RAG] No se pudo borrar el índice persistido del corpus:', err?.message);
+  }
+}

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 20;
+export const DB_VERSION = 21;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -73,6 +73,13 @@ export const STORES = {
   // retries y status (queued/sending/done/failed/offline). Permite debuggear
   // inteligencia+velocidad de Chagra y garantiza que ninguna pregunta se pierda.
   AGENT_REQUESTS: 'agent_requests',
+  // v21: rag_corpus_cache — índice RAG construido (docs pre-tokenizados + IDF)
+  // persistido para que sobreviva recargas OFFLINE en frío. El SW ya cachea los
+  // bytes crudos de /cycle-content/* (capa de red), pero re-parsear+re-tokenizar
+  // las 491 fichas en cada arranque cuesta CPU en teléfonos rurales. Esto
+  // persiste el índice YA construido (capa de cómputo) → arranque offline
+  // instantáneo sin re-tokenizar. keyPath 'key' (un único registro 'corpus').
+  RAG_CORPUS_CACHE: 'rag_corpus_cache',
 };
 
 let dbInstance = null;
@@ -341,6 +348,16 @@ export const openDB = async () => {
           store.createIndex('ts_submit', 'ts_submit', { unique: false });
           store.createIndex('model', 'model', { unique: false });
           store.createIndex('route', 'route', { unique: false });
+        }
+      }
+
+      // v21: rag_corpus_cache — índice RAG construido persistido (offline-first
+      // de campo). Un único registro KV (keyPath 'key', valor 'corpus') con los
+      // docs pre-tokenizados + IDF serializados. Permite que una recarga OFFLINE
+      // en frío arranque con grounding sin re-tokenizar las 491 fichas.
+      if (event.oldVersion < 21) {
+        if (!db.objectStoreNames.contains(STORES.RAG_CORPUS_CACHE)) {
+          db.createObjectStore(STORES.RAG_CORPUS_CACHE, { keyPath: 'key' });
         }
       }
     };

--- a/src/services/ragRetriever.js
+++ b/src/services/ragRetriever.js
@@ -2,6 +2,7 @@ import { CROP_TAXONOMY } from '../config/taxonomy';
 import { recordRagEvent } from './ragTelemetry';
 import { getAllSpecies } from '../db/catalogDB';
 import { expandQueryTokens } from './ragSynonyms';
+import { saveCorpusIndex, loadCorpusIndex } from '../db/corpusIndexCache';
 
 const CORPUS_PATH = '/cycle-content/';
 const EMBEDDINGS_PATH = '/rag-embeddings.json';
@@ -145,7 +146,12 @@ async function loadManifest() {
     if (!ct.includes('json')) return null;
     const data = await res.json();
     if (!Array.isArray(data?.slugs)) return null;
-    return data.slugs;
+    // Devolvemos los slugs + una huella (`stamp`) para invalidar el índice
+    // persistido cuando el corpus cambia (deploy nuevo del manifest). La huella
+    // combina generated_at + cantidad de slugs: barato y suficiente para
+    // detectar un manifest distinto sin hashear todo el contenido.
+    const stamp = `${data.generated_at ?? ''}:${data.slugs.length}`;
+    return { slugs: data.slugs, stamp };
   } catch (_) {
     return null;
   }
@@ -195,8 +201,9 @@ async function loadSlugDocs(slug) {
 async function buildCorpus() {
   // Manifest first: si existe, itera solo los slugs presentes.
   // Fallback: iterar CROP_TAXONOMY (legacy, con N-3 fetches fallidos).
-  const manifestSlugs = await loadManifest();
-  let species = manifestSlugs ?? Object.values(CROP_TAXONOMY).flatMap((group) =>
+  const manifest = await loadManifest();
+  const manifestStamp = manifest?.stamp ?? null;
+  let species = manifest?.slugs ?? Object.values(CROP_TAXONOMY).flatMap((group) =>
     group.species.map((sp) => sp.id)
   );
 
@@ -205,9 +212,11 @@ async function buildCorpus() {
   // sin entrada en el catalogo NO deben groundearse para evitar leak de
   // contenido Pro a usuarios OSS. Degradacion: si el catalogo falla, se
   // cargan todos los slugs (mejor grounding completo que ninguno).
+  let tier = null;
   try {
     const catalogSpecies = await getAllSpecies();
     if (catalogSpecies && catalogSpecies.length > 0) {
+      tier = catalogSpecies.length;
       const allowedIds = new Set(catalogSpecies.map((s) => s.id));
       const before = species.length;
       species = species.filter((slug) => allowedIds.has(slug));
@@ -217,6 +226,23 @@ async function buildCorpus() {
     }
   } catch (err) {
     console.warn('[RAG] No se pudo cargar el catalogo para tier-gate — cargando todos los slugs:', err?.message);
+  }
+
+  // OFFLINE-FIRST: intentar hidratar el índice YA construido desde IndexedDB
+  // ANTES de re-fetchear+re-tokenizar las 491 fichas. Si existe y coincide la
+  // huella del manifest + el tier-gate, lo usamos tal cual → arranque (incluida
+  // recarga OFFLINE en frío) sin re-tokenizar. Si está obsoleto o no existe,
+  // loadCorpusIndex devuelve null y reconstruimos desde la red (SW cache).
+  try {
+    const persisted = await loadCorpusIndex({ manifestStamp, tier });
+    if (persisted) {
+      avgDocLen = persisted.avgDocLen;
+      corpusCache = { docs: persisted.docs, idf: persisted.idf };
+      console.info(`[RAG] Índice del corpus hidratado desde IndexedDB: ${persisted.docs.length} passages (sin re-tokenizar).`);
+      return corpusCache;
+    }
+  } catch (err) {
+    console.warn('[RAG] Hidratación del índice persistido falló — reconstruyendo:', err?.message);
   }
 
   const docs = [];
@@ -241,6 +267,17 @@ async function buildCorpus() {
   const df = buildInvertedIndex(docs);
   const idf = computeIDF(df, docs.length);
   corpusCache = { docs, idf };
+
+  // OFFLINE-FIRST: persistir el índice construido a IndexedDB (fire-and-forget,
+  // no bloqueante). Una recarga OFFLINE en frío posterior lo hidratará sin
+  // re-tokenizar las 491 fichas. Solo persistimos si hay docs reales (no un
+  // corpus vacío por fallo de red). saveCorpusIndex nunca lanza.
+  if (docs.length > 0) {
+    saveCorpusIndex({ docs, idf, avgDocLen, manifestStamp, tier }).then((ok) => {
+      if (ok) console.info(`[RAG] Índice del corpus persistido en IndexedDB (${docs.length} passages).`);
+    });
+  }
+
   return corpusCache;
 }
 

--- a/tests/offline-corpus.spec.js
+++ b/tests/offline-corpus.spec.js
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * offline-corpus.spec.js — OFFLINE-FIRST de campo: grounding RAG sin señal.
+ *
+ * Cierra el hueco hallado en la auditoría verify-first 2026-06-13: el shell +
+ * bundle + catalog.sqlite ya se precacheaban, pero el corpus RAG
+ * (/cycle-content/*) y los embeddings (/rag-embeddings.json) NO → una recarga
+ * OFFLINE en frío dejaba al agente SIN grounding (corpusCache vivía solo en
+ * memoria y se perdía al recargar).
+ *
+ * Este spec valida la CAPA DE RED (Service Worker): que tras una visita ONLINE
+ * el SW cachea el corpus + embeddings y que, ya OFFLINE, esos bytes siguen
+ * disponibles para que el RAG pueda reconstruir/hidratar su índice.
+ *
+ * POLÍTICA (memoria feedback-sidecar-bench-misses-pwa-rag-path): el gate viejo
+ * corría en dev server y era ciego al SW de producción. Este spec valida contra
+ * el SW REAL. Vite dev SÍ sirve public/sw.js y public/cycle-content/* de forma
+ * estática, así que el SW se registra y cachea el corpus también en dev — pero
+ * para fidelidad total contra dist+SW real, correlo con:
+ *   npm run build && npx vite preview --port 5173 --strictPort &
+ *   PLAYWRIGHT_BASE_URL=http://localhost:5173 npx playwright test offline-corpus
+ *
+ * Si el SW no llega a controlar la página (entorno sin SW), el test marca skip
+ * en vez de fallar en falso — NUNCA bloquea por un entorno sin service worker.
+ */
+
+async function waitForActiveSW(page, timeoutMs = 15000) {
+  return page.evaluate(async (timeout) => {
+    if (!('serviceWorker' in navigator)) return false;
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const reg = await navigator.serviceWorker.getRegistration();
+      if (reg && reg.active && navigator.serviceWorker.controller) return true;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    // El SW puede estar activo pero aún no controlar este cliente (primer load).
+    const reg = await navigator.serviceWorker.getRegistration();
+    return !!(reg && reg.active);
+  }, timeoutMs);
+}
+
+test.describe('Offline-first de campo — corpus RAG cacheado por el SW', () => {
+  test('el corpus + embeddings sobreviven una recarga OFFLINE en frío', async ({
+    context,
+    page,
+  }) => {
+    // 1) Carga ONLINE: registra el SW y deja que tome control.
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const swReady = await waitForActiveSW(page);
+    test.skip(!swReady, 'Service Worker no disponible/activo en este entorno — no aplica el test de corpus offline.');
+
+    // Si el SW está activo pero todavía no controla este cliente (primer
+    // registro), una recarga lo pone al mando.
+    const controlled = await page.evaluate(() => !!navigator.serviceWorker.controller);
+    if (!controlled) {
+      await page.reload();
+      await page.waitForLoadState('networkidle');
+      await waitForActiveSW(page);
+    }
+
+    // 2) ONLINE: leemos el manifest para tomar un slug REAL del corpus, y
+    //    forzamos que el SW cachee el manifest, esa ficha y los embeddings —
+    //    exactamente las rutas que prewarmCorpus pide al login. Los fetch van
+    //    desde la página → pasan por el SW → cache-first put.
+    const sampleSlug = await page.evaluate(async () => {
+      const m = await fetch('/cycle-content/manifest.json');
+      if (!m.ok) return null;
+      const j = await m.json();
+      return Array.isArray(j.slugs) && j.slugs.length > 0 ? j.slugs[0] : null;
+    });
+    expect(sampleSlug, 'el manifest debe traer al menos un slug').toBeTruthy();
+
+    const onlineFetch = await page.evaluate(async (slug) => {
+      const urls = [
+        '/cycle-content/manifest.json',
+        `/cycle-content/${slug}.json`,
+        '/rag-embeddings.json',
+      ];
+      const results = {};
+      for (const u of urls) {
+        try {
+          const res = await fetch(u);
+          results[u] = res.ok ? res.status : `not-ok:${res.status}`;
+        } catch (e) {
+          results[u] = `error:${e.message}`;
+        }
+      }
+      return results;
+    }, sampleSlug);
+
+    // El manifest, la ficha tomada del propio manifest y los embeddings deben
+    // existir online (200).
+    expect(onlineFetch['/cycle-content/manifest.json']).toBe(200);
+    expect(onlineFetch[`/cycle-content/${sampleSlug}.json`]).toBe(200);
+    expect(onlineFetch['/rag-embeddings.json']).toBe(200);
+
+    // Dar un instante a que el SW persista los puts en cache (los put del
+    // handler cache-first son async respecto al respond).
+    await page.waitForTimeout(500);
+
+    // 3) OFFLINE: cortamos la red por completo.
+    await context.setOffline(true);
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+
+    // 4) Recarga en FRÍO offline: el shell debe bootear desde cache.
+    await page.reload();
+    await waitForActiveSW(page);
+
+    // 5) OFFLINE: los bytes del grounding deben seguir disponibles vía el SW
+    //    (cache-first). Sin red, un fetch que NO estuviera cacheado daría error
+    //    o un 504 sintético; con el corpus cacheado debe responder 200 + JSON.
+    const offlineGrounding = await page.evaluate(async (slug) => {
+      const out = {};
+      // Manifest cacheado → JSON con slugs.
+      try {
+        const m = await fetch('/cycle-content/manifest.json');
+        out.manifestOk = m.ok;
+        if (m.ok) {
+          const j = await m.json();
+          out.manifestSlugs = Array.isArray(j.slugs) ? j.slugs.length : 0;
+        }
+      } catch (e) {
+        out.manifestErr = e.message;
+      }
+      // Embeddings cacheados → JSON no vacío.
+      try {
+        const e = await fetch('/rag-embeddings.json');
+        out.embeddingsOk = e.ok;
+        if (e.ok) {
+          const j = await e.json();
+          out.embeddingsKeys = j && typeof j === 'object' ? Object.keys(j).length : 0;
+        }
+      } catch (err) {
+        out.embeddingsErr = err.message;
+      }
+      // La ficha que fetcheamos online debe seguir disponible offline.
+      try {
+        const f = await fetch(`/cycle-content/${slug}.json`);
+        out.slugStatus = f.status;
+        out.slugOk = f.ok;
+      } catch (err) {
+        out.slugErr = err.message;
+      }
+      return out;
+    }, sampleSlug);
+
+    // El contrato offline-first: el grounding NO desaparece sin red.
+    expect(offlineGrounding.manifestOk, 'manifest debe servirse offline desde cache').toBe(true);
+    expect(offlineGrounding.manifestSlugs, 'manifest cacheado debe traer slugs').toBeGreaterThan(0);
+    expect(offlineGrounding.embeddingsOk, 'embeddings deben servirse offline desde cache').toBe(true);
+    expect(offlineGrounding.embeddingsKeys, 'embeddings cacheados no deben estar vacíos').toBeGreaterThan(0);
+    // La ficha que cacheamos online debe seguir disponible offline (200), no un
+    // 504 de "no cacheado".
+    expect(offlineGrounding.slugStatus, 'la ficha cacheada online debe servirse offline').toBe(200);
+
+    // 6) El SW debe tener el bucket de grounding SEPARADO (sobrevive a deploys).
+    const cacheNames = await page.evaluate(async () => {
+      if (!('caches' in window)) return [];
+      return caches.keys();
+    });
+    expect(
+      cacheNames.some((n) => n.startsWith('chagra-rag-grounding-')),
+      `debe existir el bucket de grounding separado; caches: ${cacheNames.join(', ')}`,
+    ).toBe(true);
+
+    await context.setOffline(false);
+  });
+});


### PR DESCRIPTION
## Qué resuelve

Cierra el hueco **offline-first de campo** (auditoría verify-first 2026-06-13): el shell + bundle + `catalog.sqlite` ya se precacheaban (#1524), pero el **corpus RAG** (`/cycle-content/*`, 491 fichas) y los **embeddings** (`/rag-embeddings.json`) NO. En frío offline el agente quedaba **sin grounding** porque `corpusCache` vivía solo en memoria y se perdía al recargar; además la búsqueda semántica degradaba a BM25.

## Qué se precachea ahora + estrategia + tamaño

| Recurso | Tamaño | Estrategia |
|---|---|---|
| `rag-embeddings.json` | ~7.2 MB | **precache en `install`** (bucket de grounding) — único habilitador del modo SEMÁNTICO offline |
| `cycle-content/manifest.json` | ~13 KB | **precache en `install`** |
| 491 fichas `cycle-content/*.json` | ~3.3 MB | **cache-first on-demand + persistente** — se llenan cuando `prewarmCorpus` las pide al login; NO se precachean en install (evita 491 sockets) |
| Tiles OSM/OpenTopoMap | ilimitado | **cache-on-use** (cache-first, tope LRU ~400 tiles) — mapa offline en zonas ya visitadas |

**Decisión de tamaño:** ~7 MB (embeddings) + 13 KB (manifest) en el `install` one-time; las fichas (3.3 MB) se cachean on-demand. No inflamos el `install` con 491 `cache.add()`. El usuario está online al login (cuando corre `prewarmCorpus`), así que para cuando recarga offline en frío el corpus ya está en cache.

## Bucket separado (sobrevive a deploys)

El grounding y los tiles viven en buckets **aislados de `CACHE_NAME`** (`chagra-rag-grounding-v1`, `chagra-map-tiles-v1`). Como su contenido no está hasheado por filename, si vivieran en `CACHE_NAME` cada deploy (que bumpea `CACHE_NAME` por SHA) los borraría y la primera recarga offline post-deploy quedaría sin grounding. `activate` los conserva.

## Cómo el corpus sobrevive la recarga offline

1. **Capa de red (SW):** los bytes de corpus + embeddings se sirven cache-first → disponibles sin señal.
2. **Capa de cómputo (IndexedDB):** nuevo store `rag_corpus_cache` (dbCore **v21**) + `db/corpusIndexCache.js` persiste el índice YA construido (docs pre-tokenizados + IDF, vía structured clone que soporta `Map` nativo). `ragRetriever.buildCorpus` hidrata desde IDB antes de re-fetchear/re-tokenizar; invalida por huella del manifest + tier-gate.

## Tests (validación contra SW real, no dev server)

- `tests/offline-corpus.spec.js`: visita online → SW cachea corpus+embeddings → **offline + recarga en frío** → manifest, embeddings y una ficha siguen sirviéndose 200 desde cache + existe el bucket separado. **Verde contra `dist` + `vite preview` (SW real)** y también en dev.
- `src/db/__tests__/corpusIndexCache.test.js`: roundtrip save/load preservando `Map`, invalidación por manifest/tier, degradación sin lanzar.
- CI: nuevo job **`offline-corpus-dist`** que corre el spec contra el build de producción + preview (el gate viejo corría en dev y era ciego al SW de prod).
- `playwright.config.js`: omite el webServer dev cuando `PLAYWRIGHT_BASE_URL` apunta a un servidor externo (el preview con SW real).

## Verificación local

- `npm run build` ✅ (exit 0, chunk sizes OK)
- `npm run lint` ✅ en los 8 archivos tocados (max-warnings=0). Las 22 fallas pre-existentes del proyecto están en archivos ajenos.
- `tests/offline-corpus.spec.js` ✅ contra dist+preview (v309) y dev
- `tests/offline.spec.js` (existente) ✅ sin regresión
- unit: corpusIndexCache + ragRetriever (27) + voiceRagEnricher ✅

## TODO / fuera de scope

- **Tiles de mapa:** implementado como cache-on-use (no precache). Quedan cacheados solo los tiles ya vistos online; zonas nunca visitadas no tienen mapa offline (por diseño — los tiles son ilimitados). Si en el futuro se quiere precache de la zona de la finca, sería un seed acotado por bbox.
- `farmProcessCache.test.js` asserta `DB_VERSION === 19` (stale desde la era v19; ya estaba roja en main con v20). NO la toco — fix pre-existente ajeno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)