### PR TITLE
feat(sources): normativa ambiental linkeable + fix test DB_VERSION stale

### DIFF
--- a/src/db/__tests__/farmProcessCache.test.js
+++ b/src/db/__tests__/farmProcessCache.test.js
@@ -12,9 +12,9 @@ import { validateFarmProcessEvent } from '../../types/farmProcess';
  * Tests de regresion: verifican el schema de evento y la version.
  */
 
-describe('farmProcessCache - Bug A: schema v19', () => {
-  it('DB_VERSION es 19 tras la migracion del indice process_id', () => {
-    expect(DB_VERSION).toBe(19);
+describe('farmProcessCache - Bug A: schema process_id (DB_VERSION vigente)', () => {
+  it('DB_VERSION es 21 (esquema vigente; v19 introdujo el indice process_id)', () => {
+    expect(DB_VERSION).toBe(21);
   });
 
   it('STORES.FARM_PROCESS_EVENTS existe', () => {

--- a/src/services/__tests__/institutionalSources.test.js
+++ b/src/services/__tests__/institutionalSources.test.js
@@ -189,6 +189,26 @@ describe('resolveSourceLink — de una cita a {fuente, fuente_url|fuente_texto}'
     expect(resolveSourceLink([])).toEqual({});
   });
 
+  // ── Normativa ambiental (#357): Ley 1930 / Decreto 1007 / MinAmbiente ──
+  test('Ley 1930 de 2018 (páramos) → link a la norma en gestornormativo', () => {
+    const out = resolveSourceLink('Ley 1930 de 2018');
+    expect(out.fuente).toBe('Ley 1930 de 2018');
+    expect(out.fuente_url).toContain('gestornormativo/norma.php?i=87764');
+  });
+
+  test('Decreto 1007 de 2018 (PSA) → link a la norma en gestornormativo', () => {
+    const out = resolveSourceLink('Decreto 1007 de 2018');
+    expect(out.fuente).toBe('Decreto 1007 de 2018');
+    expect(out.fuente_url).toContain('gestornormativo/norma.php?i=86901');
+  });
+
+  test('MinAmbiente → reconocida pero texto plano (no homepage genérica)', () => {
+    const out = resolveSourceLink('MinAmbiente');
+    expect(out.fuente).toBe('MinAmbiente');
+    expect(out.fuente_texto).toBe(true);
+    expect(out.fuente_url).toBeUndefined();
+  });
+
   // ── La regla central del operador, como aserción explícita ──
   test('NINGÚN destino emitido es una homepage/landing genérica', () => {
     const isHomepage = (u) => /^https?:\/\/[^/]+\/?$/.test(u); // host + opcional "/"

--- a/src/services/institutionalSources.js
+++ b/src/services/institutionalSources.js
@@ -99,6 +99,28 @@ const INSTITUTIONS = [
     kind: 'search',
     searchUrl: (c) => `https://www.invima.gov.co/buscar?q=${encodeURIComponent(c)}`,
   },
+  // Ley 1930 de 2018 — gestión integral de páramos (prohíbe actividades
+  // agropecuarias y minería en páramo). La URL ES el texto de la norma en el
+  // Gestor Normativo de Función Pública (verificada HTTP 200 + título "Ley 1930
+  // de 2018", 2026-06-13): acerca al documento citado → section.
+  {
+    keys: ['ley 1930'],
+    kind: 'section',
+    url: 'https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=87764',
+  },
+  // Decreto 1007 de 2018 — reglamenta el incentivo de Pago por Servicios
+  // Ambientales (PSA). La URL ES el texto de la norma en el Gestor Normativo
+  // (verificada HTTP 200 + título "Decreto 1007 de 2018", 2026-06-13) → section.
+  {
+    keys: ['decreto 1007'],
+    kind: 'section',
+    url: 'https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=86901',
+  },
+  // MinAmbiente — Ministerio de Ambiente y Desarrollo Sostenible. Su portal no
+  // tiene una sección estable por dato ni un buscador parametrizable verificado
+  // que acerque a la norma/recurso citado; linkear a la home sería trazabilidad
+  // teatral. Se reconoce como institución pero su cita va en texto plano → text.
+  { keys: ['minambiente', 'ministerio de ambiente'], kind: 'text' },
 ];
 
 /** Normaliza para matchear: minúsculas, sin tildes, espacios colapsados. */


### PR DESCRIPTION
## Qué

Dos arreglos chicos relacionados (demo-safety + deuda de tests). El tercer ítem planeado (guards de normativa páramo + consejo climático) **ya estaba en main** vía PR #1533, así que no se duplica.

### 1. `institutionalSources.js` — reconocer citas de normativa ambiental (+3 fuentes)

Antes, las citas de normativa salían **sin link/badge** porque el catálogo no las reconocía. Se agregan 3 fuentes, todas verificadas empíricamente (HTTP 200 + título de página, 2026-06-13), siguiendo la filosofía existente del archivo (link al **recurso citado**, nunca a una homepage genérica):

- **Ley 1930 de 2018** (páramos) → `kind: 'section'`, link directo a la norma en el Gestor Normativo de Función Pública (`norma.php?i=87764`).
- **Decreto 1007 de 2018** (pago por servicios ambientales / PSA) → `kind: 'section'`, link directo (`norma.php?i=86901`).
- **MinAmbiente** → `kind: 'text'`. Se **reconoce** como institución (`fuente_texto: true`) pero su cita va en texto plano: su portal no tiene sección estable por dato ni buscador parametrizable verificado, y linkear a la home sería trazabilidad teatral (misma decisión que IDEAM / DANE / Open-Meteo).

> Nota de verificación: los IDs del Gestor Normativo se confirmaron por título de página. Los candidatos iniciales obvios estaban equivocados (un ID daba "Ley 1931", otro "Decreto 806 de 1989"); los IDs finales se validaron contra el `<title>` real antes de fijarlos.

### 2. `farmProcessCache.test.js` — corregir expectativa stale de `DB_VERSION`

El test esperaba `DB_VERSION === 19`, pero `dbCore.js` ya está en **`DB_VERSION = 21`** (bump del PR de offline campo recién mergeado, confirmado en `origin/main`). Se actualiza la expectativa a 21 y se ajusta el texto del `describe`/`it` para no atarlo a una versión específica del pasado.

## Tests

- `src/services/__tests__/institutionalSources.test.js` → **32 pasan** (29 previos + 3 nuevos: Ley 1930 linkea, Decreto 1007 linkea, MinAmbiente texto plano).
- `src/db/__tests__/farmProcessCache.test.js` → **4 pasan**.
- TDD: los 3 tests nuevos se escribieron primero y fallaron (red) antes de implementar.

## Lint

`eslint --max-warnings=0` sobre los 3 archivos tocados → **limpio (exit 0)**. La suite global tiene deuda de lint pre-existente ajena a este cambio (no toca ninguno de estos 3 archivos).

## Alcance

Solo 3 archivos. Sin `node_modules`, sin force-push, español Colombia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)