### PR TITLE
feat(telemetry): wire agent telemetry sync with consent + fix sw db bug (Tarea #8)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -423,7 +423,12 @@ async function handleVoiceTelemetrySync() {
 
 async function getPendingTelemetryEvents() {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open('ChagraDB', 10);
+    // Tarea #8 fix: abrir SIN versión. El SW no puede importar dbCore (DB_VERSION
+    // avanza con cada migración), y pasar una versión hardcodeada (antes: 10)
+    // menor a la actual hace que indexedDB.open lance VersionError → esta función
+    // SIEMPRE fallaba. Abrir sin versión devuelve la DB en su versión vigente,
+    // sea cual sea, sin disparar un upgrade.
+    const request = indexedDB.open('ChagraDB');
 
     request.onsuccess = async (event) => {
       const db = event.target.result;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import PendingTasksWidget from './components/PendingTasksWidget';
 import SyncProgressIndicator from './components/common/SyncProgressIndicator';
 import useOllamaWarmStore from './store/useOllamaWarmStore';
 import { prewarmCorpus } from './services/ragRetriever';
+import { syncAgentTelemetry } from './services/agentTelemetrySync';
 import useThemeBackgroundStore, { getBackgroundSrc } from './store/useThemeBackgroundStore';
 import useAlertStore from './store/useAlertStore';
 import { alertEngine } from './services/alertEngine';
@@ -371,13 +372,26 @@ export default function App() {
     typeof navigator !== 'undefined' ? navigator.onLine : true
   );
   useEffect(() => {
-    const goOnline = () => setIsAppOnline(true);
+    const goOnline = () => {
+      setIsAppOnline(true);
+      // Tarea #8 — al recuperar conexión, intentar drenar la telemetría del
+      // agente al sidecar. No-bloqueante y tolerante a fallos; internamente
+      // respeta el consentimiento del usuario (default OFF) — si no lo dio,
+      // es un no-op silencioso. NUNCA envía prompts ni PII.
+      void syncAgentTelemetry();
+    };
     const goOffline = () => setIsAppOnline(false);
     window.addEventListener('online', goOnline);
     window.addEventListener('offline', goOffline);
+    // Un intento al montar (cubre el caso de requests 'done' que quedaron sin
+    // sincronizar de una sesión previa). Diferido para no competir con el boot.
+    const bootSync = setTimeout(() => {
+      void syncAgentTelemetry();
+    }, 8000);
     return () => {
       window.removeEventListener('online', goOnline);
       window.removeEventListener('offline', goOffline);
+      clearTimeout(bootSync);
     };
   }, []);
   useGlobalKeyboardShortcuts({ enabled: currentView !== 'loading' && currentView !== 'login' && currentView !== 'oauth-callback' });

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -12,7 +12,7 @@ import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { stop as stopTTS } from '../services/ttsService';
-import { getNotificationStyle, setNotificationStyle } from '../services/userProfileService';
+import { getNotificationStyle, setNotificationStyle, getTelemetryConsent, setTelemetryConsent } from '../services/userProfileService';
 
 const TTL_OPTIONS = [
   { id: '1d', label: '1 día' },
@@ -83,6 +83,12 @@ export default function ProfileScreen({ onBack, onHome }) {
       ? localStorage.getItem('chagra:voice:telemetry:enabled') !== '0'
       : true
   );
+  // Tarea #8 — consentimiento para ENVIAR la telemetría del agente al servidor.
+  // OFF por defecto (privacidad). Distinto de la telemetría de voz local de
+  // arriba (que solo graba en el dispositivo): este toggle autoriza el envío
+  // de metadatos anónimos (NUNCA prompt ni respuesta) al sidecar para mejorar
+  // el producto.
+  const [telemetryConsent, setTelemetryConsentState] = useState(() => getTelemetryConsent());
   const [telemetryTtl, setTelemetryTtl] = useState(() =>
     typeof window !== 'undefined'
       ? localStorage.getItem('chagra:voice:telemetry:ttl') || '7d'
@@ -464,6 +470,51 @@ export default function ProfileScreen({ onBack, onHome }) {
               <p className="text-[10px] text-slate-500 px-1 leading-relaxed">
                 La telemetría sigue grabándose en el dispositivo (privacy-safe, NUNCA prompt ni respuesta).
                 El dashboard de visualización se migró al panel privado del operador (ADR-020 anti-leak / ADR-029 Capa C).
+              </p>
+            </div>
+
+            {/* Tarea #8 — Consentimiento de envío de telemetría al servidor.
+                Default OFF (privacidad). Autoriza enviar SOLO metadatos
+                anónimos (modelo, ruta, latencias, tokens) — NUNCA el prompt ni
+                la respuesta ni datos de ubicación. */}
+            <div className="space-y-3 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+              <div className="flex items-center gap-2 px-1">
+                <Wrench size={18} className="text-morpho" />
+                <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Compartir telemetría del agente</h3>
+              </div>
+
+              <label className="flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 cursor-pointer min-h-[48px]">
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-bold text-slate-200">Enviar métricas anónimas</span>
+                  <span className="text-[10px] text-slate-500">Ayuda a mejorar el agente. Desactivado por defecto.</span>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={telemetryConsent}
+                  aria-label="Enviar métricas anónimas del agente"
+                  data-testid="telemetry-consent-toggle"
+                  onClick={() => {
+                    const next = !telemetryConsent;
+                    setTelemetryConsent(next);
+                    setTelemetryConsentState(next);
+                  }}
+                  className={`relative w-12 h-7 rounded-full transition-colors shrink-0 ${
+                    telemetryConsent ? 'bg-emerald-600' : 'bg-slate-700'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform ${
+                      telemetryConsent ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+              </label>
+
+              <p className="text-[10px] text-slate-500 px-1 leading-relaxed">
+                Si lo activas, se envían al servidor métricas agregadas de tus consultas (modelo usado, tipo de
+                consulta, tiempos de respuesta y conteo de tokens). Nunca se envían el texto de tus preguntas ni
+                las respuestas, ni tu ubicación. Puedes desactivarlo cuando quieras.
               </p>
             </div>
 

--- a/src/services/__tests__/agentTelemetrySync.test.js
+++ b/src/services/__tests__/agentTelemetrySync.test.js
@@ -251,6 +251,29 @@ describe('agentTelemetrySync — syncAgentTelemetry', () => {
     expect(payload[1].model).toBe('gpt-4o');
   });
 
+  it('default al sidecar /ingest + envía X-Chagra-Token (Tarea #8)', async () => {
+    vi.unstubAllEnvs();
+    // Sin VITE_TELEMETRY_INGEST_URL: cae al sidecar. Token presente.
+    vi.stubEnv('VITE_TELEMETRY_INGEST_URL', '');
+    vi.stubEnv('VITE_SIDECAR_URL', 'https://chagra.example.co/api');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'tok-123');
+    const { syncAgentTelemetry } = await import('../agentTelemetrySync.js');
+
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const doneRequests = [{ id: 9, route: 'chat', model: 'granite3.3:8b', status: 'done', synced: false }];
+    listRequests.mockResolvedValue(doneRequests);
+    getRequest.mockImplementation(async (_id) => doneRequests.find((r) => r.id === _id) || null);
+
+    await syncAgentTelemetry();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe('https://chagra.example.co/api/ingest');
+    expect(opts.headers['X-Chagra-Token']).toBe('tok-123');
+  });
+
   it('ignora requests que no están done', async () => {
     vi.unstubAllEnvs();
     vi.stubEnv('VITE_TELEMETRY_INGEST_URL', 'https://telemetry.example.com/ingest');
@@ -415,15 +438,18 @@ describe('agentTelemetrySync — isTelemetrySyncEnabled', () => {
     expect(isTelemetrySyncEnabled()).toBe(false);
   });
 
-  it('devuelve false si VITE_TELEMETRY_INGEST_URL vacío', async () => {
+  it('default al sidecar /ingest cuando VITE_TELEMETRY_INGEST_URL está vacío (Tarea #8)', async () => {
+    // Comportamiento nuevo: sin override explícito la URL cae al endpoint
+    // /ingest del sidecar, así que con consentimiento + online queda habilitado.
     vi.unstubAllEnvs();
     vi.stubEnv('VITE_TELEMETRY_INGEST_URL', '');
-    const { isTelemetrySyncEnabled } = await import('../agentTelemetrySync.js');
-    
+    const { isTelemetrySyncEnabled, getTelemetryIngestUrl } = await import('../agentTelemetrySync.js');
+
     getTelemetryConsent.mockReturnValue(true);
     setOnline(true);
 
-    expect(isTelemetrySyncEnabled()).toBe(false);
+    expect(getTelemetryIngestUrl()).toMatch(/\/ingest$/);
+    expect(isTelemetrySyncEnabled()).toBe(true);
   });
 
   it('devuelve true si todo está habilitado', async () => {

--- a/src/services/agentTelemetrySync.js
+++ b/src/services/agentTelemetrySync.js
@@ -46,13 +46,51 @@ import { getTelemetryConsent } from './userProfileService.js';
 import { listRequests, getRequest } from './agentRequestQueue.js';
 
 /**
+ * Base del sidecar agro-mcp (espejo de feedbackService.getBaseUrl).
+ * @returns {string}
+ */
+function getSidecarBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.trim().replace(/\/+$/, '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '/api';
+}
+
+/**
+ * Token compartido del sidecar (header X-Chagra-Token). El endpoint /ingest
+ * está auth-gated igual que /agent-feedback.
+ * @returns {string}
+ */
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+/**
  * Devuelve la URL de ingest de telemetría.
  * Leer en tiempo de ejecución (no en import) para facilitar testing.
+ *
+ * Prioridad:
+ *   1. VITE_TELEMETRY_INGEST_URL explícito (override).
+ *   2. Default: endpoint /ingest del sidecar (`${VITE_SIDECAR_URL||'/api'}/ingest`).
  *
  * @returns {string}
  */
 export function getTelemetryIngestUrl() {
-  return import.meta.env.VITE_TELEMETRY_INGEST_URL || '';
+  const explicit = import.meta.env?.VITE_TELEMETRY_INGEST_URL;
+  if (typeof explicit === 'string' && explicit.trim()) {
+    return explicit.trim();
+  }
+  return `${getSidecarBaseUrl()}/ingest`;
 }
 
 /**
@@ -162,10 +200,12 @@ export async function syncAgentTelemetry() {
     }
 
     // 6. POST al endpoint
+    const token = getToken();
     const response = await fetch(telemetryUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...(token ? { 'X-Chagra-Token': token } : {}),
       },
       body: JSON.stringify(payload),
     });

--- a/tests/unit/sw-telemetry-db-version.test.js
+++ b/tests/unit/sw-telemetry-db-version.test.js
@@ -1,0 +1,43 @@
+/**
+ * sw-telemetry-db-version.test.js — regresión del bug de versión hardcodeada
+ * en el Service Worker (Tarea #8).
+ *
+ * Bug: `getPendingTelemetryEvents` abría `indexedDB.open('ChagraDB', 10)` con
+ * una versión HARDCODEADA (10) menor a la actual de `dbCore` (DB_VERSION ≥ 20).
+ * `indexedDB.open(name, N)` con N < versión-vigente lanza `VersionError`, así
+ * que la función SIEMPRE fallaba y el background-sync de voice-telemetry nunca
+ * podía drenar eventos.
+ *
+ * El SW no puede importar `dbCore` (corre en el scope del worker, sin el
+ * bundle), así que el fix es abrir la DB SIN versión: `indexedDB.open(name)`
+ * devuelve la DB en su versión vigente sin disparar un upgrade.
+ *
+ * Este test es a nivel de fuente (no instancia IndexedDB): verifica el
+ * contrato de que el SW NUNCA vuelva a hardcodear una versión al abrir
+ * ChagraDB para leer telemetría.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirnameLocal = path.dirname(fileURLToPath(import.meta.url));
+const SW_PATH = path.resolve(__dirnameLocal, '../../public/sw.js');
+const SW_SRC = fs.readFileSync(SW_PATH, 'utf-8');
+
+describe('sw.js — apertura de ChagraDB para telemetría (Tarea #8)', () => {
+  it('NO abre ChagraDB con una versión numérica hardcodeada', () => {
+    // Cualquier `indexedDB.open('ChagraDB', <número>)` reintroduce el bug.
+    const hardcodedVersion = /indexedDB\.open\(\s*['"]ChagraDB['"]\s*,\s*\d+\s*\)/;
+    expect(SW_SRC).not.toMatch(hardcodedVersion);
+  });
+
+  it('abre ChagraDB SIN versión (versión vigente, sin upgrade)', () => {
+    const noVersion = /indexedDB\.open\(\s*['"]ChagraDB['"]\s*\)/;
+    expect(SW_SRC).toMatch(noVersion);
+  });
+
+  it('en particular ya NO contiene la versión-10 del bug original', () => {
+    expect(SW_SRC).not.toContain("indexedDB.open('ChagraDB', 10)");
+  });
+});


### PR DESCRIPTION
## Qué

Cierra el lazo cliente→servidor de la telemetría del agente (Tarea #8). La captura local ya funcionaba (`agentRequestQueue` persiste prompt+latencias+grounding+tokens+retries por turno en IndexedDB). Faltaba: (1) el módulo `agentTelemetrySync` era código muerto, (2) un toggle de consentimiento, y (3) había un bug latente en `sw.js`.

> Endpoint server-side `POST /ingest` + `GET /telemetry/summary`: PR de pareja en chagra-pro #196.

## Wireado

- **`agentTelemetrySync.js`**: la URL de ingest ahora resuelve por defecto al endpoint `/ingest` del sidecar (`${VITE_SIDECAR_URL||'/api'}/ingest`); `VITE_TELEMETRY_INGEST_URL` sigue funcionando como override. Manda el header de auth `X-Chagra-Token` (espejo de `feedbackService`). Sigue enviando **solo metadatos anónimos** (route, model, latencias, grounding agregado, tokens, retries) — NUNCA prompt, respuesta ni PII.
- **`App.jsx`**: invoca `syncAgentTelemetry()` al volver online (`'online'`) y un intento diferido al boot (cubre requests `'done'` de sesiones previas). No-bloqueante (`void`) y tolerante a fallos.
- **`ProfileScreen.jsx`**: toggle "Compartir telemetría del agente" (**default OFF**) respaldado por `get/setTelemetryConsent`, separado de la telemetría de voz local. Español Colombia (tú/usted), sin voseo.

## Consentimiento (default OFF es DURO)

`getTelemetryConsent()` devuelve `false` por defecto y se guarda en localStorage aparte del perfil. El sync es un **no-op silencioso** mientras no haya consentimiento — es el primer guard de `syncAgentTelemetry`. El usuario lo activa/desactiva cuando quiera desde Ajustes → Avanzado.

## Fix del bug sw.js

`getPendingTelemetryEvents` abría `indexedDB.open('ChagraDB', 10)` con versión HARDCODEADA 10, pero `dbCore` ya va en `DB_VERSION=20`. `indexedDB.open(name, N)` con `N < versión-vigente` lanza `VersionError` → la función **SIEMPRE** fallaba y el background-sync de voice-telemetry nunca drenaba. Fix: abrir **sin versión** (`indexedDB.open('ChagraDB')`) — el SW no puede importar `dbCore`, así que usa la versión vigente sin disparar un upgrade. Test de regresión a nivel de fuente en `tests/unit/sw-telemetry-db-version.test.js`.

## Tests / lint

- `agentTelemetrySync.test.js`: 15 casos (consentimiento, offline, default-al-sidecar, header de token, anonimización/PII, marcado de sincronizados).
- `sw-telemetry-db-version.test.js`: 3 casos de regresión del bug de versión.
- `eslint --max-warnings=0` ✅ sobre todos los archivos cambiados (lefthook verde: eslint + secret-scan + infra-refs-scan + conventional-commits).
- Suite global de chagra tiene ~22 fallas pre-existentes ajenas — no se agregaron nuevas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)