### PR TITLE
fix(deploy): /assets/ append-only para no romper PWAs instaladas (failed to fetch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -166,9 +166,31 @@ jobs:
         # blanca tras cada deploy. El chmod posterior es defensa en
         # profundidad: se aplica solo a archivos cuyo owner es runner (los
         # que creo este deploy), no toca dirs ajenos.
+        #
+        # /assets/ es append-only (estrategia en 3 pasos):
+        #   Bug previo: un solo `rsync --delete dist/ TARGET/` borraba los
+        #   chunks hasheados `/assets/*-<hash>.js` que ya no estaban en el build
+        #   nuevo. Una PWA instalada con un Service Worker viejo sirve un
+        #   index.html cacheado que apunta a esos chunks ya borrados -> el
+        #   cliente falla con "failed to fetch" (pantalla rota) hasta reinstalar.
+        #   El SW no hace skipWaiting (queda en waiting + prompt de update), asi
+        #   que el cliente viejo sigue activo y necesita que SUS chunks existan.
+        #   Fix:
+        #     1) rsync del dist completo CON --delete pero --exclude='/assets/':
+        #        actualiza index.html, sw.js, manifest, etc. (nombres NO
+        #        hasheados) y limpia basura no-hasheada. Estos son justo los
+        #        archivos que disparan el update del SW.
+        #     2) rsync de dist/assets/ a TARGET/assets/ SIN --delete: agrega los
+        #        chunks nuevos y conserva los viejos (los hashes nunca colisionan,
+        #        acumular es seguro) para que clientes/SW viejos sigan cargando.
+        #     3) GC de chunks viejos para no crecer infinito: borra archivos en
+        #        TARGET/assets/ con mtime > 30 dias. 30 dias cubre de sobra el
+        #        tiempo para que un cliente instalado se actualice.
         run: |
           umask 022
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ /mnt/fast/appdata/farmos-pwa/
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ /mnt/fast/appdata/farmos-pwa/
+          rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ /mnt/fast/appdata/farmos-pwa/assets/
+          find /mnt/fast/appdata/farmos-pwa/assets/ -type f -mtime +30 -delete || true
           find /mnt/fast/appdata/farmos-pwa -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
 
       - if: env.SKIP_DEPLOY != '1'

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -51,7 +51,18 @@ jobs:
             exit 1
           fi
           umask 022
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ "$TARGET/"
+          # /assets/ append-only: ver comentario extenso en deploy.yml (prod).
+          # En resumen: un solo `rsync --delete dist/ TARGET/` borra los chunks
+          # hasheados viejos que un cliente/SW instalado todavia necesita ->
+          # "failed to fetch". Fix en 3 pasos:
+          #   1) sincronizar todo MENOS /assets/ con --delete (index.html, sw.js,
+          #      manifest, etc.: nombres no hasheados, limpiar basura).
+          #   2) sincronizar /assets/ SIN --delete (agregar chunks nuevos,
+          #      conservar viejos; los hashes no colisionan).
+          #   3) GC de chunks con mtime > 30 dias para no crecer infinito.
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ "$TARGET/"
+          rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
+          find "$TARGET/assets/" -type f -mtime +30 -delete || true
           find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
 
       - if: env.SKIP_DEPLOY != '1'

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -62,7 +62,18 @@ jobs:
             exit 1
           fi
           umask 022
-          rsync -avzO --no-perms --delete --no-group --chmod=F644 dist/ "$TARGET/"
+          # /assets/ append-only: ver comentario extenso en deploy.yml (prod).
+          # En resumen: un solo `rsync --delete dist/ TARGET/` borra los chunks
+          # hasheados viejos que un cliente/SW instalado todavia necesita ->
+          # "failed to fetch". Fix en 3 pasos:
+          #   1) sincronizar todo MENOS /assets/ con --delete (index.html, sw.js,
+          #      manifest, etc.: nombres no hasheados, limpiar basura).
+          #   2) sincronizar /assets/ SIN --delete (agregar chunks nuevos,
+          #      conservar viejos; los hashes no colisionan).
+          #   3) GC de chunks con mtime > 30 dias para no crecer infinito.
+          rsync -avzO --no-perms --delete --no-group --chmod=F644 --exclude='/assets/' dist/ "$TARGET/"
+          rsync -avzO --no-perms --no-group --chmod=F644 dist/assets/ "$TARGET/assets/"
+          find "$TARGET/assets/" -type f -mtime +30 -delete || true
           find "$TARGET" -type f -user runner ! -perm 644 -exec chmod 644 {} + || true
 
       - if: env.SKIP_DEPLOY != '1'


### PR DESCRIPTION
## Problema (bug crítico en prod)

Los 3 workflows de deploy del PWA hacían un solo:

```
rsync -avzO --no-perms --delete dist/ TARGET/
```

El flag `--delete` borra los chunks hasheados de Vite (`/assets/*-<hash>.js`) que ya no están en el build nuevo. Pero una **PWA instalada con un Service Worker viejo** sirve un `index.html` cacheado que apunta a esos chunks ya borrados → el cliente falla con **"failed to fetch"** (pantalla rota) hasta que reinstala.

El SW **no** hace `skipWaiting` automático (diseño deliberado: queda en *waiting* + la app muestra prompt de update), así que el cliente viejo sigue activo y necesita que **sus** chunks sigan existiendo durante la ventana de transición.

## Fix

`/assets/` pasa a ser **append-only**. Mismo patrón en los 3 workflows (prod `deploy.yml`, `dev-deploy.yml`, `qa-deploy.yml`):

1. `rsync ... --delete --exclude='/assets/' dist/ TARGET/` — sincroniza todo MENOS `/assets/`: actualiza `index.html`, `sw.js`, `manifest.json` y demás nombres NO hasheados (justo los que disparan el update del SW) y limpia basura no-hasheada.
2. `rsync ... dist/assets/ TARGET/assets/` **SIN** `--delete` — agrega los chunks nuevos y conserva los viejos. Los hashes nunca colisionan, así que acumular es seguro y permite que clientes/SW viejos sigan cargando.
3. **GC**: `find TARGET/assets/ -type f -mtime +30 -delete` — borra chunks con mtime > **30 días** para no crecer infinito. 30 días cubre de sobra el tiempo para que un cliente instalado se actualice.

El bump de `CACHE_NAME` del SW (paso CI post-deploy) y todos los demás pasos quedan intactos.

## Verificación

- Confirmado que Vite usa `assetsDir` default (`/assets/`) y que `index.html` + `sw.js` referencian los chunks por hash bajo `/assets/`.
- Confirmado el TARGET de prod `/mnt/fast/appdata/farmos-pwa/assets/` (121 chunks hasheados al momento de revisar).
- `actionlint` limpio salvo el warning preexistente del label `alpha` (runner self-hosted, no relacionado con este cambio).
- Solo se tocaron los 3 workflows de deploy; ningún otro paso.

## Targets

| Workflow | TARGET |
|---|---|
| `deploy.yml` (prod) | `/mnt/fast/appdata/farmos-pwa` |
| `dev-deploy.yml` | `/mnt/fast/appdata/farmos-pwa-dev` |
| `qa-deploy.yml` | `/mnt/fast/appdata/farmos-pwa-qa` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)