### PR TITLE
fix(catalog): servir catalog.sqlite cache-first en el SW + tolerar abort en boot

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -240,6 +240,46 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // Catálogo de especies (`/catalog.sqlite`, ~1.2 MB): CACHE-FIRST en CACHE_NAME.
+  //
+  // ANTES caía en la rama Stale-While-Revalidate del shell estático (más abajo,
+  // `ASSETS_TO_CACHE.some(...)`): servía el blob cacheado PERO disparaba un
+  // `fetch` en background en CADA carga → re-descarga de 1.2 MB por load
+  // (el server lo sirve con `cache-control: no-store` → cf-cache-status DYNAMIC,
+  // sin HTTP cache). Ese fetch de 1.2 MB en vuelo es además el que se ABORTA
+  // (net::ERR_ABORTED → "Failed to fetch") cuando un SW nuevo hace clients.claim()
+  // y el cliente recarga vía controllerchange durante el arranque.
+  //
+  // Cache-first lo arregla de raíz: se sirve desde caché sin tocar la red (el
+  // header `no-store` del server es irrelevante para la estrategia del SW), así
+  // que se re-baja UNA sola vez por deploy (cache-miss tras el bump de
+  // CACHE_NAME) y luego es instantáneo y offline. El blob ya se precachea en
+  // install (ASSETS_TO_CACHE); si ese precache falló (404 transitorio / offline),
+  // el primer cache-miss lo rellena en background. Versionado por CACHE_NAME:
+  // un deploy bumpea el SHA y `activate` borra el bucket viejo, forzando la
+  // re-descarga del catálogo fresco una vez.
+  if (url.pathname === '/catalog.sqlite' && event.request.method === 'GET') {
+    event.respondWith(
+      caches.open(CACHE_NAME).then((cache) =>
+        cache.match(event.request).then((cached) => {
+          if (cached) return cached;
+          return fetch(event.request)
+            .then((response) => {
+              if (response && response.ok && response.status === 200) {
+                cache.put(event.request, response.clone());
+              }
+              return response;
+            })
+            // Offline y sin cache: 504 explícito. corpusLoader.loadCatalogBuffer
+            // degrada con gracia (el preload en App.jsx loguea warn y los
+            // componentes reintentan al usar el catálogo).
+            .catch(() => new Response('', { status: 504, statusText: 'Offline: catálogo no cacheado' }));
+        })
+      )
+    );
+    return;
+  }
+
   // Tiles de mapa (OSM/OpenTopoMap): CACHE-FIRST cache-on-use en MAP_TILES_CACHE.
   // No se precachean (son ilimitados); se guardan SOLO los tiles que el usuario
   // ya cargó online, para que el mapa funcione offline en zonas ya visitadas.
@@ -303,6 +343,9 @@ self.addEventListener('fetch', (event) => {
 
   // Resto del static shell NO-HTML (manifest, iconos): Stale-While-Revalidate
   // (no referencian hashes de bundle, así que un cache viejo no rompe nada).
+  // `/` e `/index.html` ya se sirvieron arriba (Network-First) y
+  // `/catalog.sqlite` arriba (Cache-First), así que aquí solo caen los assets
+  // ligeros del shell para los que revalidar en background es barato.
   if (ASSETS_TO_CACHE.some(path => url.pathname === path)) {
     event.respondWith(
       caches.match(event.request).then(cachedResponse => {

--- a/src/db/catalogDB.js
+++ b/src/db/catalogDB.js
@@ -1,5 +1,5 @@
 import sqlite3InitModule from '@sqlite.org/sqlite-wasm';
-import { loadCatalogBuffer, assertCatalogShape } from '../services/corpusLoader';
+import { loadCatalogBuffer, assertCatalogShape, isAbortLikeFetchError } from '../services/corpusLoader';
 
 let dbInstance = null;
 let initPromise = null;
@@ -69,7 +69,17 @@ export async function initCatalog() {
         // /catalog.sqlite 404 transitorio, OPFS bloqueado) dejaba el catálogo
         // permanentemente broken hasta refresh manual.
         initPromise = null;
-        console.error('[SQLite WASM] Failed to initialize catalog db:', error);
+        // Abort por unload/reload (bug prod 2026-06-14): el fetch del catálogo
+        // se aborta cuando un SW nuevo recarga el cliente durante el arranque.
+        // NO es bloqueante (el home usa fallback de stats y los componentes
+        // reintentan al usar el catálogo) y NO debe gritar console.error: es
+        // ruido esperado en cada deploy. Degradamos a debug; loadCatalogBuffer
+        // ya reintentó una vez antes de llegar acá.
+        if (isAbortLikeFetchError(error)) {
+            console.debug('[SQLite WASM] init del catálogo abortado (probable reload por SW nuevo); se reintentará on-demand.');
+        } else {
+            console.error('[SQLite WASM] Failed to initialize catalog db:', error);
+        }
         throw error;
     });
 

--- a/src/services/__tests__/corpusLoader.test.js
+++ b/src/services/__tests__/corpusLoader.test.js
@@ -129,7 +129,8 @@ describe('corpusLoader — loadCatalogBuffer', () => {
         });
         const { loadCatalogBuffer } = await importFresh();
         const { buffer, source } = await loadCatalogBuffer();
-        expect(fetchMock).toHaveBeenCalledWith('/catalog.sqlite');
+        // loadCatalogBuffer pasa un AbortController propio (segundo arg { signal }).
+        expect(fetchMock).toHaveBeenCalledWith('/catalog.sqlite', expect.objectContaining({ signal: expect.anything() }));
         expect(buffer.byteLength).toBe(8192);
         expect(source).toEqual({ url: '/catalog.sqlite', tier: 'OSS', fallback: false });
     });
@@ -146,7 +147,7 @@ describe('corpusLoader — loadCatalogBuffer', () => {
         });
         const { loadCatalogBuffer } = await importFresh();
         const { source } = await loadCatalogBuffer();
-        expect(fetchMock).toHaveBeenCalledWith('https://cdn.example.com/full.sqlite');
+        expect(fetchMock).toHaveBeenCalledWith('https://cdn.example.com/full.sqlite', expect.objectContaining({ signal: expect.anything() }));
         expect(source.tier).toBe('PRO');
         expect(source.fallback).toBe(false);
     });
@@ -202,9 +203,138 @@ describe('corpusLoader — loadCatalogBuffer', () => {
         });
         const { loadCatalogBuffer } = await importFresh();
         const { source } = await loadCatalogBuffer();
-        expect(fetchMock).toHaveBeenCalledWith('/catalog.sqlite');
+        expect(fetchMock).toHaveBeenCalledWith('/catalog.sqlite', expect.objectContaining({ signal: expect.anything() }));
         expect(source.fallback).toBe(true);
         expect(source.tier).toBe('OSS');
+    });
+});
+
+describe('corpusLoader — isAbortLikeFetchError', () => {
+    it('AbortError → true', async () => {
+        const { isAbortLikeFetchError } = await importFresh();
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        expect(isAbortLikeFetchError(err)).toBe(true);
+    });
+
+    it('TypeError "Failed to fetch" → true', async () => {
+        const { isAbortLikeFetchError } = await importFresh();
+        const err = new TypeError('Failed to fetch');
+        expect(isAbortLikeFetchError(err)).toBe(true);
+    });
+
+    it('TypeError "NetworkError when attempting to fetch resource." (Firefox) → true', async () => {
+        const { isAbortLikeFetchError } = await importFresh();
+        const err = new TypeError('NetworkError when attempting to fetch resource.');
+        expect(isAbortLikeFetchError(err)).toBe(true);
+    });
+
+    it('Error HTTP/magic (no abort) → false', async () => {
+        const { isAbortLikeFetchError } = await importFresh();
+        expect(isAbortLikeFetchError(new Error('HTTP 404 Not Found'))).toBe(false);
+        expect(isAbortLikeFetchError(new Error('missing SQLite magic header'))).toBe(false);
+    });
+
+    it('valores no-Error → false (defensivo)', async () => {
+        const { isAbortLikeFetchError } = await importFresh();
+        expect(isAbortLikeFetchError(null)).toBe(false);
+        expect(isAbortLikeFetchError(undefined)).toBe(false);
+        expect(isAbortLikeFetchError('Failed to fetch')).toBe(false);
+    });
+});
+
+describe('corpusLoader — loadCatalogBuffer resiliencia al abort (bug prod 2026-06-14)', () => {
+    let debugSpy;
+    let errorSpy;
+    beforeEach(() => {
+        debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => { });
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    });
+    afterEach(() => {
+        debugSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    it('abort en el primer fetch → degrada a console.debug (NO error) y reintenta UNA vez', async () => {
+        vi.unstubAllEnvs();
+        const blob = makeSqliteBlob(8192);
+        // 1er intento: abort (TypeError Failed to fetch). 2do intento: OK.
+        fetchMock
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                arrayBuffer: async () => blob.buffer,
+            });
+        const { loadCatalogBuffer } = await importFresh();
+        const { buffer } = await loadCatalogBuffer();
+        expect(buffer.byteLength).toBe(8192);
+        // Reintentó exactamente una vez (2 llamadas totales).
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        // Degradó a debug, NO gritó error.
+        expect(debugSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('AbortError en el primer fetch → reintenta y resuelve', async () => {
+        vi.unstubAllEnvs();
+        const blob = makeSqliteBlob(4096);
+        const abortErr = new Error('aborted');
+        abortErr.name = 'AbortError';
+        fetchMock
+            .mockRejectedValueOnce(abortErr)
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                arrayBuffer: async () => blob.buffer,
+            });
+        const { loadCatalogBuffer } = await importFresh();
+        const { buffer } = await loadCatalogBuffer();
+        expect(buffer.byteLength).toBe(4096);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(debugSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fallo real (404) NO reintenta y propaga el throw', async () => {
+        vi.unstubAllEnvs();
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            arrayBuffer: async () => new ArrayBuffer(0),
+        });
+        const { loadCatalogBuffer } = await importFresh();
+        await expect(loadCatalogBuffer()).rejects.toThrow(/HTTP 404/);
+        // No reintentó: un fallo real no es abort-like.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(debugSpy).not.toHaveBeenCalled();
+    });
+
+    it('abort en AMBOS intentos → propaga el abort (no cuelga, no loop infinito)', async () => {
+        vi.unstubAllEnvs();
+        fetchMock
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        const { loadCatalogBuffer } = await importFresh();
+        await expect(loadCatalogBuffer()).rejects.toThrow(/Failed to fetch/);
+        // Exactamente 2 intentos (1 original + 1 retry), no más.
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('caller pasa un signal YA abortado → no reintenta (respeta su intención)', async () => {
+        vi.unstubAllEnvs();
+        const controller = new AbortController();
+        controller.abort();
+        // fetch con signal abortado rechaza con AbortError.
+        const abortErr = new Error('aborted');
+        abortErr.name = 'AbortError';
+        fetchMock.mockRejectedValue(abortErr);
+        const { loadCatalogBuffer } = await importFresh();
+        await expect(loadCatalogBuffer({ signal: controller.signal })).rejects.toThrow();
+        // No reintentó: el caller abortó a propósito.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/src/services/corpusLoader.js
+++ b/src/services/corpusLoader.js
@@ -31,6 +31,39 @@ const SQLITE_MAGIC = 'SQLite format 3\0';
 const TIER_OSS = 'OSS';
 const TIER_PRO = 'PRO';
 const DEFAULT_CATALOG_URL = '/catalog.sqlite';
+// Timeout defensivo del fetch del catálogo (~1.2 MB). En rural lento un fetch
+// colgado indefinidamente bloquearía el preload; abortamos y dejamos que el
+// retry/los componentes reintenten on-demand.
+const CATALOG_FETCH_TIMEOUT_MS = 30000;
+
+/**
+ * Heurística: ¿este error es un ABORT del fetch del catálogo por unload/reload,
+ * y NO un fallo real (404, magic header, CDN caído)?
+ *
+ * Caso principal (bug prod 2026-06-14): el SW nuevo de un deploy hace
+ * clients.claim() y el cliente recarga vía controllerchange MIENTRAS el fetch
+ * de 1.2 MB de `/catalog.sqlite` está en vuelo → el browser lo aborta
+ * (net::ERR_ABORTED → en JS un TypeError "Failed to fetch", o un AbortError si
+ * fue nuestro propio AbortController). NO es bloqueante (el home usa fallback de
+ * stats) y NO debe gritar console.error: es ruido esperado en cada deploy.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isAbortLikeFetchError(err) {
+    if (!err || typeof err !== 'object') return false;
+    const name = 'name' in err ? String(err.name) : '';
+    if (name === 'AbortError') return true;
+    // "Failed to fetch" (Chromium) / "NetworkError when attempting to fetch
+    // resource." (Firefox): aborto por navegación/unload o red caída. Lo
+    // tratamos como abort-like (degradable) en boot; el retry/los componentes
+    // cubren el caso de red genuinamente caída.
+    if (name === 'TypeError') {
+        const msg = 'message' in err ? String(err.message) : '';
+        return /failed to fetch|networkerror|load failed/i.test(msg);
+    }
+    return false;
+}
 
 /**
  * Lee `VITE_CHAGRA_TIER`. Acepta 'PRO'/'pro' como Pro; cualquier otro valor
@@ -88,43 +121,98 @@ export function resolveCatalogUrl() {
 }
 
 /**
+ * Una sola pasada de fetch + validación del blob del catálogo. Usa un
+ * AbortController propio con timeout defensivo. Separada de loadCatalogBuffer
+ * para que esta pueda reintentar ante un abort sin duplicar la validación.
+ *
+ * @param {{ url: string, tier: 'OSS'|'PRO', fallback: boolean }} source
+ * @param {AbortSignal} [externalSignal] — signal del caller (ej. reload/unload).
+ * @returns {Promise<Uint8Array>}
+ */
+async function fetchCatalogOnce(source, externalSignal) {
+    const controller = typeof AbortController !== 'undefined' ? new AbortController() : null;
+    let timer = null;
+    // Encadena el signal externo (si lo hay) al nuestro: si el caller aborta,
+    // abortamos también.
+    const onExternalAbort = () => controller?.abort();
+    if (externalSignal && controller) {
+        if (externalSignal.aborted) controller.abort();
+        else externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+    }
+    if (controller) {
+        timer = setTimeout(() => controller.abort(), CATALOG_FETCH_TIMEOUT_MS);
+    }
+
+    try {
+        const response = await fetch(source.url, controller ? { signal: controller.signal } : undefined);
+        if (!response.ok) {
+            throw new Error(
+                `[corpusLoader] Failed to fetch ${source.url}: HTTP ${response.status} ${response.statusText}`
+            );
+        }
+        const arrayBuffer = await response.arrayBuffer();
+        const buffer = new Uint8Array(arrayBuffer);
+
+        if (buffer.byteLength < SQLITE_MAGIC.length) {
+            throw new Error(
+                `[corpusLoader] Catalog payload too small (${buffer.byteLength} bytes) — not a valid SQLite file.`
+            );
+        }
+        // Validar magic header SQLite.
+        for (let i = 0; i < SQLITE_MAGIC.length; i++) {
+            if (buffer[i] !== SQLITE_MAGIC.charCodeAt(i)) {
+                throw new Error(
+                    `[corpusLoader] Invalid catalog payload — missing SQLite magic header. ` +
+                    `Source=${source.url} tier=${source.tier}`
+                );
+            }
+        }
+        return buffer;
+    } finally {
+        if (timer) clearTimeout(timer);
+        if (externalSignal && controller) externalSignal.removeEventListener('abort', onExternalAbort);
+    }
+}
+
+/**
  * Fetchea el catálogo SQLite y devuelve un Uint8Array. Valida magic header
  * SQLite ("SQLite format 3\0") antes de devolver, para fallar rápido si el
  * CDN devuelve HTML de error o el archivo está corrupto.
  *
+ * RESILIENCIA AL ABORT (bug prod 2026-06-14): el fetch de ~1.2 MB se aborta si
+ * el cliente recarga durante el arranque (SW nuevo → clients.claim() →
+ * controllerchange → reload). En ese caso NO gritamos: degradamos a
+ * console.debug y reintentamos UNA vez (el reload casi siempre lo desencadena
+ * el SW recién activado, que ya dejó `/catalog.sqlite` cacheado, así que el
+ * retry es instantáneo desde el SW cache-first). Un fallo real (404, magic
+ * header inválido, CDN caído) NO es abort-like → propaga el throw como siempre.
+ *
  * Throws si:
- *   - fetch no responde 2xx.
+ *   - fetch no responde 2xx (y no es un abort).
  *   - el blob es muy chico (<16 bytes) o no empieza con magic SQLite.
  *
+ * @param {{ signal?: AbortSignal }} [options]
  * @returns {Promise<{ buffer: Uint8Array, source: { url: string, tier: 'OSS'|'PRO', fallback: boolean } }>}
  */
-export async function loadCatalogBuffer() {
+export async function loadCatalogBuffer(options = {}) {
     const source = resolveCatalogUrl();
-    const response = await fetch(source.url);
-    if (!response.ok) {
-        throw new Error(
-            `[corpusLoader] Failed to fetch ${source.url}: HTTP ${response.status} ${response.statusText}`
+    const { signal } = options;
+    try {
+        const buffer = await fetchCatalogOnce(source, signal);
+        return { buffer, source };
+    } catch (err) {
+        // Fallo real (HTTP/magic/corrupto) → propagar tal cual.
+        if (!isAbortLikeFetchError(err)) throw err;
+        // Si el caller abortó a propósito, no reintentar: respetamos su intención.
+        if (signal?.aborted) throw err;
+        // Abort por unload/reload: ruido esperado en cada deploy. Degradar a
+        // debug (NO error) y reintentar UNA vez.
+        console.debug(
+            `[corpusLoader] fetch de ${source.url} abortado (probable reload por SW nuevo); reintentando una vez.`
         );
+        const buffer = await fetchCatalogOnce(source, signal);
+        return { buffer, source };
     }
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = new Uint8Array(arrayBuffer);
-
-    if (buffer.byteLength < SQLITE_MAGIC.length) {
-        throw new Error(
-            `[corpusLoader] Catalog payload too small (${buffer.byteLength} bytes) — not a valid SQLite file.`
-        );
-    }
-    // Validar magic header SQLite.
-    for (let i = 0; i < SQLITE_MAGIC.length; i++) {
-        if (buffer[i] !== SQLITE_MAGIC.charCodeAt(i)) {
-            throw new Error(
-                `[corpusLoader] Invalid catalog payload — missing SQLite magic header. ` +
-                `Source=${source.url} tier=${source.tier}`
-            );
-        }
-    }
-
-    return { buffer, source };
 }
 
 /**

--- a/tests/unit/sw-offline-precache.test.js
+++ b/tests/unit/sw-offline-precache.test.js
@@ -176,3 +176,63 @@ describe('SW offline-first precache (regresión 2026-06-13)', () => {
     expect(res.status).toBe(504);
   });
 });
+
+// Regresión bug prod 2026-06-14: `/catalog.sqlite` (~1.2 MB) caía en la rama
+// Stale-While-Revalidate del shell → re-descarga de 1.2 MB en CADA carga
+// (server con `cache-control: no-store`) y el fetch en vuelo se abortaba en el
+// reload del SW nuevo → console.error "Failed to fetch". Ahora se sirve
+// CACHE-FIRST (sin tocar la red si ya está cacheado).
+describe('SW catalog.sqlite cache-first (regresión 2026-06-14)', () => {
+  it('install precachea /catalog.sqlite (sigue en ASSETS_TO_CACHE)', async () => {
+    const { listeners, fakeCaches } = loadSW({ online: true, indexHtml: SAMPLE_INDEX });
+    const { waited } = fireEvent(listeners.install, {});
+    await waited;
+    const names = await fakeCaches.keys();
+    const cache = await fakeCaches.open(names[0]);
+    const keys = (await cache.keys()).map((r) => new URL(r.url).pathname);
+    expect(keys).toContain('/catalog.sqlite');
+  });
+
+  it('/catalog.sqlite se sirve CACHE-FIRST (desde cache, sin red) cuando ya está cacheado', async () => {
+    const { listeners, fetchImpl } = loadSW({ online: true, indexHtml: SAMPLE_INDEX });
+    await fireEvent(listeners.install, {}).waited;
+
+    fetchImpl.mockClear();
+    const req = { url: 'https://chagra.guatoc.co/catalog.sqlite', method: 'GET' };
+    const { responded } = fireEvent(listeners.fetch, req);
+    const res = await responded;
+    expect(res).toBeTruthy();
+    expect(res.ok).toBe(true);
+    // NO debió ir a la red: el blob estaba en cache → cero re-descarga de 1.2 MB.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('/catalog.sqlite cache-miss → fetch + put (se cachea para la próxima vez)', async () => {
+    // SW sin install previo (cache vacío): primer hit debe ir a la red Y cachear.
+    const { listeners, fetchImpl, fakeCaches } = loadSW({ online: true, indexHtml: SAMPLE_INDEX });
+    const req = { url: 'https://chagra.guatoc.co/catalog.sqlite', method: 'GET' };
+    const { responded } = fireEvent(listeners.fetch, req);
+    const res = await responded;
+    expect(res).toBeTruthy();
+    expect(res.ok).toBe(true);
+    // Fue a la red esta vez (cache-miss).
+    expect(fetchImpl).toHaveBeenCalled();
+    // Y quedó cacheado: un segundo hit no toca la red.
+    fetchImpl.mockClear();
+    const { responded: responded2 } = fireEvent(listeners.fetch, req);
+    await responded2;
+    expect(fetchImpl).not.toHaveBeenCalled();
+    // Está en algún bucket.
+    const hit = await fakeCaches.match(req);
+    expect(hit).toBeTruthy();
+  });
+
+  it('offline + /catalog.sqlite NO cacheado → 504 explícito (no rompe el home)', async () => {
+    const { listeners } = loadSW({ online: false, indexHtml: SAMPLE_INDEX });
+    const req = { url: 'https://chagra.guatoc.co/catalog.sqlite', method: 'GET' };
+    const { responded } = fireEvent(listeners.fetch, req);
+    const res = await responded;
+    expect(res).toBeTruthy();
+    expect(res.status).toBe(504);
+  });
+});


### PR DESCRIPTION
## Problema (diagnosticado empíricamente en Chromium real)

En el home aparece en consola:
```
console.error: [SQLite WASM] Failed to initialize catalog db: TypeError: Failed to fetch
```
NO es bloqueante (el home carga y usa el fallback de stats), pero es ruidoso y revela una ineficiencia: `/catalog.sqlite` (~1.2 MB) se re-descarga en **cada** carga.

## Causa raíz

- `GET /catalog.sqlite` lo dispara `corpusLoader.loadCatalogBuffer()` ← `catalogDB.doInit()` ← preload al boot desde `App.jsx` (`initCatalog()`), con `fetch` SIN AbortController.
- En el **fetch handler** del SW, `/catalog.sqlite` caía en la rama **Stale-While-Revalidate** del shell estático (`ASSETS_TO_CACHE.some(...)`): servía el blob cacheado PERO disparaba un `fetch` en background en CADA carga. Como el server lo entrega con `cache-control: no-store` (cf-cache-status DYNAMIC), no hay HTTP cache → re-descarga de 1.2 MB por load.
- Ese fetch de 1.2 MB en vuelo es el que se **ABORTA** (`net::ERR_ABORTED` → en JS `TypeError: Failed to fetch`) cuando el SW nuevo de un deploy hace `clients.claim()` y el cliente recarga vía `controllerchange` durante el arranque.

## Fix

1. **SW cache-first para `/catalog.sqlite`** (rama dedicada en el fetch handler, antes de la SWR del shell), igual que `/assets/` y `/cycle-content/`. Se sirve desde caché sin tocar la red → el `no-store` del server es irrelevante para la estrategia del SW. Se re-baja UNA sola vez por deploy (cache-miss tras el bump de `CACHE_NAME`; `activate` borra el bucket viejo) y luego es instantáneo y offline. Elimina la re-descarga de 1.2 MB por load y casi toda la ventana de abort.
2. **`loadCatalogBuffer` resiliente al abort**: AbortController propio (+ timeout defensivo de 30s). Ante un error abort-like (`AbortError` / `"Failed to fetch"` por unload/reload), degrada a `console.debug` (NO `console.error`) y **reintenta UNA vez** (el reload casi siempre lo desencadena el SW recién activado, que ya dejó el blob cacheado → retry instantáneo). Un fallo real (404, magic header inválido, CDN caído) NO es abort-like → propaga el throw sin retry. Nuevo helper exportado `isAbortLikeFetchError`.
3. **`catalogDB.initCatalog` `.catch`**: degrada a `console.debug` si el error es abort-like (en vez de `console.error`). Ruido esperado en cada deploy; los componentes ya reintentan on-demand (documentado en `App.jsx`).

No implementé el opcional "esperar a que no haya SW en waiting antes del preload": con el SW cache-first el blob se sirve de caché o el abort degrada limpio + retry, así que sería over-engineering.

## Headers `no-store` → follow-up nginx (NO en este repo)

No hay `_headers`/`_redirects` ni config de Cloudflare Pages en este repo que setee el header. El `cache-control: no-store, no-cache` de `/catalog.sqlite` lo pone **nginx** (host alpha, `guatoc-nixos`), fuera de este repo → NO lo toco aquí. Con el SW cache-first ya casi no importa, pero conviene hacerlo cacheable (etag/immutable) para el caso de un cliente sin SW. **Follow-up para guatoc-nixos.**

## Tests (TDD)

- `tests/unit/sw-offline-precache.test.js`: `/catalog.sqlite` precacheado en install, servido cache-first (sin red si está cacheado), cache-miss → fetch+put, offline+no-cache → 504.
- `src/services/__tests__/corpusLoader.test.js`: `isAbortLikeFetchError`, abort → debug+retry, AbortError → retry, fallo real (404) → no retry, abort en ambos intentos → propaga (no loop), signal ya abortado → no retry. Actualizados 3 asserts preexistentes para tolerar el 2.º arg `{ signal }`.

35/35 verde en lo tocado. `npx eslint` sobre los 5 archivos modificados → EXIT 0 (los ~22 errores de `npm run lint` son preexistentes en `origin/main`, en archivos ajenos: `soilDiagnostic.js`, `socialPrefiltro.js`, `openaiStream.js`, `rag-embedding.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)