### PR TITLE
feat(glaciar): reporte offline de punto glaciar para guías (#glaciar)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,6 +68,7 @@ const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const ProcesosPorVozScreen = lazy(() => import('./components/ProcesosPorVozScreen'));
 const CicloCultivoScreen = lazy(() => import('./components/CicloCultivoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
+const GlaciarReporteScreen = lazy(() => import('./components/GlaciarReporteScreen'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
@@ -142,6 +143,7 @@ const HASH_VIEW_ROUTES = {
   hoy: 'hoy_finca',
   'hoy-en-finca': 'hoy_finca',
   evolucion: 'evolucion',
+  glaciar: 'glaciar',
 };
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -876,6 +878,13 @@ export default function App() {
         return (
           <ErrorBoundary>
             <SoilDiagnosticScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+          </ErrorBoundary>
+        );
+      case 'glaciar':
+        // Módulo demo: Reporte de Punto Glaciar (guías de glaciar). Ruta #glaciar.
+        return (
+          <ErrorBoundary>
+            <GlaciarReporteScreen onBack={() => navigate('dashboard')} />
           </ErrorBoundary>
         );
       case 'perfil':

--- a/src/components/GlaciarReporteScreen.jsx
+++ b/src/components/GlaciarReporteScreen.jsx
@@ -1,0 +1,670 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft, MapPin, Loader2, AlertCircle, Mountain, Thermometer,
+  Save, ListChecks, Trash2, CheckCircle2, Snowflake,
+} from 'lucide-react';
+import { useGeolocation } from '../hooks/useGeolocation';
+import PhotoCaptureField from './PhotoCaptureField';
+import { blobToDataUrl } from '../utils/imageProcessor';
+import { glaciarReportes, nuevoReporteId } from '../db/glaciarReportes';
+import { evaluarSeguridadGlaciar } from '../services/glaciarSafety';
+import {
+  TIPOS_SUPERFICIE, ESCALA_DUREZA, PELIGROS, NUBOSIDAD, VIENTO, VISIBILIDAD,
+  SUPERFICIE_BY_KEY, PELIGRO_BY_KEY, DUREZA_BY_VALOR,
+} from '../data/glaciar-schema.js';
+
+/**
+ * GlaciarReporteScreen — Reporte OFFLINE de Punto Glaciar (módulo demo para
+ * guías de glaciar). Ruta: #glaciar.
+ *
+ * Flujo de campo (todo offline-first):
+ *   1. Capturar UBICACIÓN (GPS: lat/lng/altitud/precisión) sin red.
+ *   2. Capturar FOTO del punto (repeat photography → trazabilidad).
+ *   3. Diagnóstico de DUREZA DEL HIELO + peligros + condiciones.
+ *   4. Estado de seguridad DERIVADO en vivo (🟢/🟡/🔴).
+ *   5. Guardar en IndexedDB (sobrevive recargas) + lista de trazabilidad.
+ *
+ * Español Colombia (usted/tú, SIN voseo). Tono claro y de campo.
+ *
+ * Demo: refinable con la investigación glaciológica en paralelo. Enums en
+ * src/data/glaciar-schema.js; lógica de seguridad en services/glaciarSafety.js.
+ */
+
+const COLOR_BTN = {
+  emerald: 'bg-emerald-900/30 border-emerald-600/60 text-emerald-200',
+  amber: 'bg-amber-900/30 border-amber-600/60 text-amber-200',
+  red: 'bg-red-900/30 border-red-600/60 text-red-200',
+};
+
+const ESTADO_BG = {
+  estable: 'bg-emerald-900/25 border-emerald-600/50',
+  precaucion: 'bg-amber-900/25 border-amber-600/50',
+  peligro: 'bg-red-900/25 border-red-600/50',
+};
+
+function emptyForm() {
+  return {
+    guia: '',
+    tipoSuperficie: '',
+    dureza: null,
+    tempSuperficie: '',
+    peligros: [],
+    tempAmbiente: '',
+    nubosidad: '',
+    viento: '',
+    visibilidad: '',
+    notas: '',
+  };
+}
+
+export default function GlaciarReporteScreen({ onBack }) {
+  const [tab, setTab] = useState('nuevo'); // 'nuevo' | 'lista'
+  const [form, setForm] = useState(emptyForm);
+  const [coords, setCoords] = useState(null); // {lat,lng,altitud,precision}
+  const [fotoBlob, setFotoBlob] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const [savedOk, setSavedOk] = useState(false);
+  const [reportes, setReportes] = useState([]);
+  const [loadingList, setLoadingList] = useState(false);
+
+  const { position, error: geoError, loading: geoLoading, request } = useGeolocation();
+
+  // Capturar coords cuando llega la posición del GPS.
+  useEffect(() => {
+    if (position && !geoError) {
+      setCoords({
+        lat: position.lat,
+        lng: position.lon,
+        // altitud: la del GPS si vino; si no, queda null (el guía la conoce).
+        altitud: typeof position.altitude === 'number' ? Math.round(position.altitude) : null,
+        precision: typeof position.accuracy === 'number' ? Math.round(position.accuracy) : null,
+      });
+    }
+  }, [position, geoError]);
+
+  const cargarReportes = useCallback(async () => {
+    setLoadingList(true);
+    try {
+      const all = await glaciarReportes.getAll();
+      setReportes(all);
+    } catch (e) {
+      console.error('[Glaciar] error cargando reportes:', e);
+    } finally {
+      setLoadingList(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab === 'lista') cargarReportes();
+  }, [tab, cargarReportes]);
+
+  // Estado de seguridad en vivo (cada vez que cambia el diagnóstico).
+  const seguridad = useMemo(
+    () => evaluarSeguridadGlaciar({
+      tipoSuperficie: form.tipoSuperficie,
+      dureza: form.dureza,
+      peligros: form.peligros,
+    }),
+    [form.tipoSuperficie, form.dureza, form.peligros],
+  );
+
+  const setField = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+
+  const togglePeligro = (key) => {
+    setForm((f) => {
+      const has = f.peligros.includes(key);
+      return { ...f, peligros: has ? f.peligros.filter((p) => p !== key) : [...f.peligros, key] };
+    });
+  };
+
+  const handlePhoto = useCallback((blob) => setFotoBlob(blob), []);
+  const handleRemovePhoto = useCallback(() => setFotoBlob(null), []);
+
+  const puedeGuardar = !!coords && !!form.tipoSuperficie && form.dureza != null && !saving;
+
+  const handleGuardar = async () => {
+    if (!puedeGuardar) return;
+    setSaving(true);
+    setSavedOk(false);
+    try {
+      // Foto → dataURL para sobrevivir recargas offline (NO blob URL volátil).
+      let fotoDataUrl = null;
+      if (fotoBlob) {
+        try {
+          fotoDataUrl = await blobToDataUrl(fotoBlob);
+        } catch (e) {
+          console.warn('[Glaciar] no se pudo convertir la foto, se guarda sin ella:', e);
+        }
+      }
+      const reporte = {
+        id: nuevoReporteId(),
+        guia: form.guia.trim(),
+        lat: coords.lat,
+        lng: coords.lng,
+        altitud: coords.altitud,
+        precision: coords.precision,
+        tipoSuperficie: form.tipoSuperficie,
+        dureza: form.dureza,
+        tempSuperficie: numOrNull(form.tempSuperficie),
+        peligros: form.peligros,
+        tempAmbiente: numOrNull(form.tempAmbiente),
+        nubosidad: form.nubosidad || null,
+        viento: form.viento || null,
+        visibilidad: form.visibilidad || null,
+        notas: form.notas.trim(),
+        fotoDataUrl,
+        estado: seguridad.nivel,
+        estadoRazones: seguridad.razones,
+      };
+      await glaciarReportes.save(reporte);
+      setSavedOk(true);
+      // Reset del formulario para el siguiente punto, pero conservamos el
+      // nombre del guía (suele ser el mismo en toda la jornada).
+      const guia = form.guia;
+      setForm({ ...emptyForm(), guia });
+      setCoords(null);
+      setFotoBlob(null);
+      setTimeout(() => setSavedOk(false), 2500);
+    } catch (e) {
+      console.error('[Glaciar] error guardando reporte:', e);
+      alert('No se pudo guardar el reporte. Intente de nuevo.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleEliminar = async (id) => {
+    if (!window.confirm('¿Eliminar este reporte?')) return;
+    await glaciarReportes.remove(id);
+    cargarReportes();
+  };
+
+  return (
+    <div className="min-h-screen w-full text-slate-100 pb-28">
+      {/* Header */}
+      <header className="sticky top-0 z-10 backdrop-blur-md bg-slate-950/70 border-b border-slate-800">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <button
+            type="button"
+            onClick={onBack}
+            className="p-2 -ml-2 rounded-xl text-slate-300 hover:bg-slate-800 active:scale-95 transition"
+            aria-label="Volver"
+          >
+            <ChevronLeft size={26} />
+          </button>
+          <div className="flex items-center gap-2">
+            <Snowflake size={22} className="text-sky-300" />
+            <div>
+              <h1 className="text-lg font-black leading-tight">Punto Glaciar</h1>
+              <p className="text-[11px] text-slate-400 leading-tight">Reporte offline para guías</p>
+            </div>
+          </div>
+        </div>
+        {/* Tabs */}
+        <div className="flex px-3 gap-2 pb-2">
+          <TabBtn active={tab === 'nuevo'} onClick={() => setTab('nuevo')} icon={<MapPin size={16} />}>
+            Nuevo reporte
+          </TabBtn>
+          <TabBtn active={tab === 'lista'} onClick={() => setTab('lista')} icon={<ListChecks size={16} />}>
+            Reportes guardados
+          </TabBtn>
+        </div>
+      </header>
+
+      {tab === 'nuevo' ? (
+        <main className="px-4 pt-4 space-y-5 max-w-xl mx-auto">
+          {/* Estado de seguridad en vivo (sticky-ish arriba del form) */}
+          <SeguridadBanner seguridad={seguridad} />
+
+          {/* 1. UBICACIÓN */}
+          <Section num="1" title="Ubicación del punto" icon={<MapPin size={18} />}>
+            <button
+              type="button"
+              onClick={() => request()}
+              disabled={geoLoading}
+              className={`w-full p-4 rounded-2xl border-2 flex items-center justify-center gap-3 transition active:scale-95 ${
+                geoLoading
+                  ? 'bg-slate-800 border-slate-700 text-slate-500'
+                  : coords
+                    ? 'bg-emerald-900/20 border-emerald-700 text-emerald-300'
+                    : 'bg-slate-900 border-slate-700 text-sky-200 hover:bg-slate-800'
+              }`}
+            >
+              {geoLoading ? <Loader2 size={22} className="animate-spin" /> : <MapPin size={22} />}
+              <span className="font-bold text-base">
+                {geoLoading ? 'Capturando GPS…' : coords ? 'Ubicación capturada' : 'Capturar ubicación (GPS)'}
+              </span>
+            </button>
+
+            {geoError && (
+              <div className="mt-2 p-3 bg-amber-900/20 border border-amber-800/50 rounded-xl flex gap-2">
+                <AlertCircle size={18} className="text-amber-400 shrink-0" />
+                <p className="text-xs text-amber-300">
+                  No se pudo obtener la ubicación. Reintente a cielo abierto con buena señal.
+                </p>
+              </div>
+            )}
+
+            {coords && (
+              <div className="mt-3 grid grid-cols-2 gap-2 text-center">
+                <Stat label="Latitud" value={coords.lat.toFixed(5)} />
+                <Stat label="Longitud" value={coords.lng.toFixed(5)} />
+                <Stat
+                  label="Altitud"
+                  value={coords.altitud != null ? `${coords.altitud} msnm` : '—'}
+                  icon={<Mountain size={14} />}
+                />
+                <Stat
+                  label="Precisión"
+                  value={coords.precision != null ? `±${coords.precision} m` : '—'}
+                />
+              </div>
+            )}
+          </Section>
+
+          {/* 2. FOTO */}
+          <Section num="2" title="Foto del punto" icon={<CheckCircle2 size={18} />}>
+            <p className="text-xs text-slate-400 mb-2">
+              La foto deja huella del mismo punto en el tiempo (trazabilidad del deshielo).
+            </p>
+            <PhotoCaptureField
+              onPhoto={handlePhoto}
+              onRemove={handleRemovePhoto}
+              value={fotoBlob}
+              label="Foto del glaciar"
+            />
+          </Section>
+
+          {/* 3. DIAGNÓSTICO */}
+          <Section num="3" title="Dureza del hielo" icon={<Snowflake size={18} />}>
+            <Label>Tipo de superficie</Label>
+            <div className="grid grid-cols-2 gap-2">
+              {TIPOS_SUPERFICIE.map((t) => (
+                <ChipBtn
+                  key={t.key}
+                  active={form.tipoSuperficie === t.key}
+                  onClick={() => setField('tipoSuperficie', t.key)}
+                >
+                  <span className="text-xl">{t.icon}</span>
+                  <span className="text-left text-sm leading-tight">{t.label}</span>
+                </ChipBtn>
+              ))}
+            </div>
+
+            <Label className="mt-4">Dureza (penetración de piolet/sonda)</Label>
+            <div className="space-y-2">
+              {ESCALA_DUREZA.map((d) => (
+                <button
+                  key={d.valor}
+                  type="button"
+                  onClick={() => setField('dureza', d.valor)}
+                  className={`w-full flex items-center gap-3 p-3 rounded-xl border-2 transition active:scale-[0.99] text-left ${
+                    form.dureza === d.valor
+                      ? 'bg-sky-900/30 border-sky-500 text-sky-100'
+                      : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
+                  }`}
+                >
+                  <span className={`shrink-0 w-9 h-9 rounded-full grid place-items-center font-black text-lg ${
+                    form.dureza === d.valor ? 'bg-sky-500 text-slate-950' : 'bg-slate-800 text-slate-400'
+                  }`}>
+                    {d.valor}
+                  </span>
+                  <span>
+                    <span className="font-bold block leading-tight">{d.label}</span>
+                    <span className="text-xs text-slate-400 leading-tight">{d.desc}</span>
+                  </span>
+                </button>
+              ))}
+            </div>
+
+            <Label className="mt-4">Temperatura de la superficie (°C) — opcional</Label>
+            <NumberInput
+              value={form.tempSuperficie}
+              onChange={(v) => setField('tempSuperficie', v)}
+              placeholder="ej. -3"
+              icon={<Thermometer size={18} />}
+            />
+          </Section>
+
+          {/* 4. PELIGROS */}
+          <Section num="4" title="Peligros observados" icon={<AlertCircle size={18} />}>
+            <p className="text-xs text-slate-400 mb-2">Marque todos los que vea.</p>
+            <div className="grid grid-cols-2 gap-2">
+              {PELIGROS.map((p) => (
+                <ChipBtn
+                  key={p.key}
+                  active={form.peligros.includes(p.key)}
+                  danger
+                  onClick={() => togglePeligro(p.key)}
+                >
+                  <span className="text-xl">{p.icon}</span>
+                  <span className="text-left text-sm leading-tight">{p.label}</span>
+                </ChipBtn>
+              ))}
+            </div>
+          </Section>
+
+          {/* 5. CONDICIONES */}
+          <Section num="5" title="Condiciones y datos del guía" icon={<Thermometer size={18} />}>
+            <Label>Temperatura ambiente (°C) — opcional</Label>
+            <NumberInput
+              value={form.tempAmbiente}
+              onChange={(v) => setField('tempAmbiente', v)}
+              placeholder="ej. 1"
+              icon={<Thermometer size={18} />}
+            />
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
+              <SelectField label="Nubosidad" value={form.nubosidad} onChange={(v) => setField('nubosidad', v)} options={NUBOSIDAD} />
+              <SelectField label="Viento" value={form.viento} onChange={(v) => setField('viento', v)} options={VIENTO} />
+              <SelectField label="Visibilidad" value={form.visibilidad} onChange={(v) => setField('visibilidad', v)} options={VISIBILIDAD} />
+            </div>
+
+            <Label className="mt-3">Nombre del guía</Label>
+            <input
+              type="text"
+              value={form.guia}
+              onChange={(e) => setField('guia', e.target.value)}
+              placeholder="Quién hace el reporte"
+              className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500"
+            />
+
+            <Label className="mt-3">Notas</Label>
+            <textarea
+              value={form.notas}
+              onChange={(e) => setField('notas', e.target.value)}
+              placeholder="Lo que quiera dejar anotado del punto…"
+              className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500 min-h-[80px] resize-y"
+            />
+          </Section>
+
+          {/* Hora auto (informativa) */}
+          <p className="text-[11px] text-slate-500 text-center">
+            Hora del reporte: {new Date().toLocaleString('es-CO')}
+          </p>
+
+          {/* Guardar */}
+          <button
+            type="button"
+            onClick={handleGuardar}
+            disabled={!puedeGuardar}
+            className={`w-full p-4 rounded-2xl font-black text-lg flex items-center justify-center gap-3 transition active:scale-95 ${
+              savedOk
+                ? 'bg-emerald-500 text-slate-950'
+                : puedeGuardar
+                  ? 'bg-sky-500 text-slate-950 hover:bg-sky-400'
+                  : 'bg-slate-800 text-slate-500'
+            }`}
+          >
+            {saving ? <Loader2 size={22} className="animate-spin" /> : savedOk ? <CheckCircle2 size={22} /> : <Save size={22} />}
+            {savedOk ? 'Reporte guardado' : saving ? 'Guardando…' : 'Guardar reporte'}
+          </button>
+          {!puedeGuardar && !saving && !savedOk && (
+            <p className="text-[11px] text-slate-500 text-center -mt-2">
+              Capture ubicación, tipo de superficie y dureza para guardar.
+            </p>
+          )}
+        </main>
+      ) : (
+        <ListaReportes
+          reportes={reportes}
+          loading={loadingList}
+          onEliminar={handleEliminar}
+          onNuevo={() => setTab('nuevo')}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ───────────────────────── Subcomponentes ───────────────────────── */
+
+function TabBtn({ active, onClick, icon, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex-1 flex items-center justify-center gap-2 py-2 rounded-xl text-sm font-bold transition ${
+        active ? 'bg-sky-500/20 text-sky-200 border border-sky-600/50' : 'bg-slate-900 text-slate-400 border border-slate-800'
+      }`}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function Section({ num, title, icon, children }) {
+  return (
+    <section className="bg-slate-900/40 border border-slate-800 rounded-2xl p-4">
+      <h2 className="flex items-center gap-2 text-base font-bold text-slate-200 mb-3">
+        <span className="w-6 h-6 rounded-full bg-sky-500/20 text-sky-300 grid place-items-center text-sm font-black">
+          {num}
+        </span>
+        {icon}
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Label({ children, className = '' }) {
+  return <p className={`text-sm font-bold text-slate-400 mb-2 ${className}`}>{children}</p>;
+}
+
+function Stat({ label, value, icon = null }) {
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl py-2 px-2">
+      <p className="text-[10px] uppercase tracking-wide text-slate-500 flex items-center justify-center gap-1">
+        {icon}{label}
+      </p>
+      <p className="text-sm font-mono font-bold text-slate-100">{value}</p>
+    </div>
+  );
+}
+
+function ChipBtn({ active, danger = false, onClick, children }) {
+  const activeCls = danger
+    ? 'bg-red-900/30 border-red-500 text-red-100'
+    : 'bg-sky-900/30 border-sky-500 text-sky-100';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-2 p-3 rounded-xl border-2 transition active:scale-[0.98] ${
+        active ? activeCls : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function NumberInput({ value, onChange, placeholder, icon }) {
+  return (
+    <div className="relative">
+      {icon && <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500">{icon}</span>}
+      <input
+        type="number"
+        inputMode="decimal"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500 ${icon ? 'pl-10' : ''}`}
+      />
+    </div>
+  );
+}
+
+function SelectField({ label, value, onChange, options }) {
+  return (
+    <div>
+      <Label>{label}</Label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500 appearance-none"
+      >
+        <option value="">—</option>
+        {options.map((o) => (
+          <option key={o.key} value={o.key}>{o.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function SeguridadBanner({ seguridad }) {
+  return (
+    <div className={`rounded-2xl border-2 p-4 ${ESTADO_BG[seguridad.nivel]}`}>
+      <div className="flex items-center gap-3">
+        <span className="text-3xl" aria-hidden="true">{seguridad.emoji}</span>
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Estado de seguridad</p>
+          <p className="text-xl font-black leading-tight">{seguridad.label}</p>
+        </div>
+      </div>
+      <p className="text-sm text-slate-300 mt-2">{seguridad.desc}</p>
+      {seguridad.razones?.length > 0 && (
+        <ul className="mt-2 space-y-1">
+          {seguridad.razones.map((r, i) => (
+            <li key={i} className="text-xs text-slate-400 flex gap-1.5">
+              <span className="text-slate-500">•</span>{r}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ListaReportes({ reportes, loading, onEliminar, onNuevo }) {
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-slate-500">
+        <Loader2 size={32} className="animate-spin mb-3" />
+        <p>Cargando reportes…</p>
+      </div>
+    );
+  }
+  if (!reportes.length) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 px-6 text-center">
+        <Snowflake size={48} className="text-slate-600 mb-4" />
+        <p className="text-slate-300 font-bold mb-1">Aún no hay reportes</p>
+        <p className="text-sm text-slate-500 mb-5">
+          Cada reporte queda guardado en este dispositivo, incluso sin internet.
+        </p>
+        <button
+          type="button"
+          onClick={onNuevo}
+          className="px-5 py-3 rounded-xl bg-sky-500 text-slate-950 font-bold flex items-center gap-2"
+        >
+          <MapPin size={18} /> Crear el primero
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <main className="px-4 pt-4 space-y-3 max-w-xl mx-auto">
+      <p className="text-xs text-slate-500">
+        {reportes.length} {reportes.length === 1 ? 'reporte guardado' : 'reportes guardados'} ·
+        repita el mismo punto GPS en el tiempo para ver el cambio.
+      </p>
+      {reportes.map((r) => (
+        <ReporteCard key={r.id} reporte={r} onEliminar={() => onEliminar(r.id)} />
+      ))}
+    </main>
+  );
+}
+
+function ReporteCard({ reporte, onEliminar }) {
+  const estado = reporte.estado || 'precaucion';
+  const sup = SUPERFICIE_BY_KEY[reporte.tipoSuperficie];
+  const dur = DUREZA_BY_VALOR[reporte.dureza];
+  // createdAt/fechaISO siempre los estampa el store al guardar; el 0 es solo
+  // un fallback defensivo (no usamos Date.now() en render — regla de pureza).
+  const fecha = reporte.fechaISO ? new Date(reporte.fechaISO) : new Date(reporte.createdAt || 0);
+  const emoji = estado === 'estable' ? '🟢' : estado === 'peligro' ? '🔴' : '🟡';
+
+  return (
+    <div className={`rounded-2xl border ${ESTADO_BG[estado]} overflow-hidden`}>
+      <div className="flex gap-3 p-3">
+        {/* Miniatura */}
+        <div className="shrink-0 w-20 h-20 rounded-xl bg-slate-800 overflow-hidden grid place-items-center">
+          {reporte.fotoDataUrl ? (
+            <img src={reporte.fotoDataUrl} alt="Punto glaciar" className="w-full h-full object-cover" />
+          ) : (
+            <Snowflake size={28} className="text-slate-600" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-lg font-black flex items-center gap-1.5">
+              {emoji} <span className="text-sm">{estadoLabel(estado)}</span>
+            </span>
+            <button
+              type="button"
+              onClick={onEliminar}
+              className="p-1.5 rounded-lg text-slate-500 hover:text-red-400 hover:bg-red-900/20 transition"
+              aria-label="Eliminar reporte"
+            >
+              <Trash2 size={16} />
+            </button>
+          </div>
+          <p className="text-xs text-slate-400 mt-0.5">
+            {fecha.toLocaleString('es-CO', { dateStyle: 'medium', timeStyle: 'short' })}
+          </p>
+          <div className="flex flex-wrap gap-1.5 mt-1.5">
+            {sup && <Badge>{sup.icon} {sup.label}</Badge>}
+            {dur && <Badge>Dureza {dur.valor} · {dur.label}</Badge>}
+            {reporte.altitud != null && <Badge>{reporte.altitud} msnm</Badge>}
+          </div>
+          {reporte.lat != null && reporte.lng != null && (
+            <p className="text-[11px] font-mono text-slate-500 mt-1">
+              {reporte.lat.toFixed(5)}, {reporte.lng.toFixed(5)}
+              {reporte.precision != null ? ` (±${reporte.precision}m)` : ''}
+            </p>
+          )}
+          {reporte.guia && <p className="text-[11px] text-slate-400 mt-0.5">Guía: {reporte.guia}</p>}
+        </div>
+      </div>
+      {Array.isArray(reporte.peligros) && reporte.peligros.length > 0 && (
+        <div className="px-3 pb-3 flex flex-wrap gap-1.5">
+          {reporte.peligros.map((p) => (
+            <span key={p} className="text-[11px] px-2 py-0.5 rounded-full bg-red-900/30 text-red-200 border border-red-800/40">
+              {(PELIGRO_BY_KEY[p]?.icon || '⚠️')} {PELIGRO_BY_KEY[p]?.label || p}
+            </span>
+          ))}
+        </div>
+      )}
+      {reporte.notas && (
+        <p className="px-3 pb-3 text-xs text-slate-400 italic">“{reporte.notas}”</p>
+      )}
+    </div>
+  );
+}
+
+function Badge({ children }) {
+  return (
+    <span className="text-[11px] px-2 py-0.5 rounded-full bg-slate-800 text-slate-300 border border-slate-700">
+      {children}
+    </span>
+  );
+}
+
+/* ───────────────────────── helpers ───────────────────────── */
+
+function numOrNull(v) {
+  if (v === '' || v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function estadoLabel(nivel) {
+  if (nivel === 'estable') return 'Estable';
+  if (nivel === 'peligro') return 'Peligro';
+  return 'Precaución';
+}

--- a/src/components/__tests__/GlaciarReporteScreen.test.jsx
+++ b/src/components/__tests__/GlaciarReporteScreen.test.jsx
@@ -1,0 +1,110 @@
+/**
+ * GlaciarReporteScreen — Reporte de Punto Glaciar (módulo demo, UI).
+ *
+ * Contrato cubierto:
+ *   - La pantalla monta y muestra los pasos (ubicación, foto, dureza, peligros).
+ *   - El estado de seguridad derivado reacciona al diagnóstico (🟢→🔴).
+ *   - El botón Volver llama onBack.
+ *   - Guardar está deshabilitado hasta tener ubicación + superficie + dureza.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+// Mock del hook de geolocalización: empieza sin posición, request() inyecta una.
+let mockPosition = null;
+const requestMock = vi.fn(() => {
+  mockPosition = { lat: 4.81, lon: -75.33, altitude: 4850, accuracy: 8, timestamp: Date.now() };
+});
+vi.mock('../../hooks/useGeolocation', () => ({
+  useGeolocation: () => ({ position: mockPosition, error: null, loading: false, request: requestMock }),
+}));
+
+// Mock de PhotoCaptureField (no probamos la cámara acá).
+vi.mock('../PhotoCaptureField', () => ({
+  default: () => null,
+}));
+
+// Mock del store IDB (no tocamos IndexedDB en el test de UI).
+const saveMock = vi.fn(() => Promise.resolve({ id: 'glaciar-test' }));
+vi.mock('../../db/glaciarReportes', () => ({
+  glaciarReportes: {
+    save: (...a) => saveMock(...a),
+    getAll: vi.fn(() => Promise.resolve([])),
+    remove: vi.fn(() => Promise.resolve()),
+  },
+  nuevoReporteId: () => 'glaciar-test',
+}));
+
+vi.mock('../../utils/imageProcessor', () => ({
+  blobToDataUrl: vi.fn(() => Promise.resolve('data:image/jpeg;base64,AAA')),
+}));
+
+import GlaciarReporteScreen from '../GlaciarReporteScreen';
+
+beforeEach(() => {
+  mockPosition = null;
+  vi.clearAllMocks();
+});
+afterEach(() => cleanup());
+
+describe('GlaciarReporteScreen — montaje y pasos', () => {
+  it('monta la pantalla con título y los pasos del reporte', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    expect(screen.getByText('Punto Glaciar')).toBeTruthy();
+    expect(screen.getByText(/Ubicación del punto/i)).toBeTruthy();
+    expect(screen.getByText(/Dureza del hielo/i)).toBeTruthy();
+    expect(screen.getByText(/Peligros observados/i)).toBeTruthy();
+  });
+
+  it('botón Volver llama onBack', () => {
+    const onBack = vi.fn();
+    render(<GlaciarReporteScreen onBack={onBack} />);
+    fireEvent.click(screen.getByRole('button', { name: /Volver/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('estado de seguridad inicial es Precaución (faltan datos)', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    expect(screen.getByText('Precaución')).toBeTruthy();
+  });
+
+  it('marcar grietas abiertas pasa el estado a Peligro 🔴', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByText(/Grietas abiertas/i));
+    expect(screen.getByText('Peligro')).toBeTruthy();
+  });
+
+  it('hielo compacto + dureza alta sin peligros → Estable 🟢', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByText('Hielo de glaciar (azul/compacto)'));
+    fireEvent.click(screen.getByText(/^Duro$/i)); // dureza 4
+    expect(screen.getByText('Estable')).toBeTruthy();
+  });
+});
+
+describe('GlaciarReporteScreen — guardado', () => {
+  it('Guardar habilita tras capturar ubicación + superficie + dureza, y persiste', async () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+
+    // Capturar GPS.
+    fireEvent.click(screen.getByRole('button', { name: /Capturar ubicación/i }));
+    expect(requestMock).toHaveBeenCalled();
+    // Re-render con la posición inyectada: forzamos un cambio de estado tocando
+    // un campo, que re-evalúa el efecto de la posición.
+    fireEvent.click(screen.getByText('Hielo de glaciar (azul/compacto)'));
+    fireEvent.click(screen.getByText(/^Medio$/i)); // dureza 3
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Guardar reporte/i });
+      expect(btn).not.toBeDisabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Guardar reporte/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const arg = saveMock.mock.calls[0][0];
+    expect(arg.tipoSuperficie).toBe('hielo_glaciar');
+    expect(arg.dureza).toBe(3);
+    expect(arg.estado).toBe('estable');
+    expect(arg.lat).toBeCloseTo(4.81);
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -17,7 +17,7 @@ import {
     rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical } from 'lucide-react';
+import { GripVertical, Snowflake, ChevronRight } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import { getProfile } from '../../services/userProfileService';
@@ -236,6 +236,28 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
             {/* Paisaje elegido — la foto de biodiversidad seleccionada, JUSTO
                 bajo el hero, visible en todos los temas (operador 2026-06-09). */}
             <SelectedBackgroundReveal />
+
+            {/* Acceso al módulo demo "Reporte de Punto Glaciar" (guías de
+                glaciar). Ruta #glaciar. Banner visible para validación en
+                campo — offline-first. */}
+            <div className="px-4 pt-3">
+                <button
+                    type="button"
+                    onClick={() => onNavigate('glaciar')}
+                    className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-sky-700/50 bg-sky-900/25 hover:bg-sky-900/40 active:scale-[0.99] transition text-left"
+                >
+                    <span className="shrink-0 w-11 h-11 rounded-xl bg-sky-500/20 grid place-items-center">
+                        <Snowflake size={24} className="text-sky-300" />
+                    </span>
+                    <span className="flex-1 min-w-0">
+                        <span className="block font-bold text-slate-100 leading-tight">Reporte de Punto Glaciar</span>
+                        <span className="block text-xs text-slate-400 leading-tight">
+                            Dureza del hielo, GPS y foto — funciona sin internet
+                        </span>
+                    </span>
+                    <ChevronRight size={20} className="text-sky-300/70 shrink-0" />
+                </button>
+            </div>
 
             {/* Panel inline de capacidades RETIRADO (operador 2026-06-10): el
                 menú vive solo en el despliegue de la Ⓐ del AgentHero (la red

--- a/src/data/glaciar-schema.js
+++ b/src/data/glaciar-schema.js
@@ -1,0 +1,96 @@
+/**
+ * glaciar-schema.js — esquema PROVISIONAL del Reporte de Punto Glaciar.
+ *
+ * MVP demo para guías de glaciar (validación en campo). Todos los enums viven
+ * acá para que sean fáciles de refinar con la investigación que corre en
+ * paralelo. NO hardcodear estos valores en la pantalla: importar desde acá.
+ *
+ * Español Colombia (usted/tú, SIN voseo). Tono de campo, claro y corto.
+ *
+ * IMPORTANTE: este es un esquema provisional. La escala de dureza, los tipos
+ * de superficie y los peligros se refinarán con fuentes glaciológicas
+ * autoritativas. Mantener todo editable acá.
+ *
+ * @module data/glaciar-schema
+ */
+
+/* ── Tipo de superficie del hielo/nieve ─────────────────────────────── */
+export const TIPOS_SUPERFICIE = [
+  { key: 'nieve_fresca', icon: '❄️', label: 'Nieve fresca' },
+  { key: 'firn', icon: '🌨️', label: 'Firn / nieve vieja' },
+  { key: 'hielo_glaciar', icon: '🧊', label: 'Hielo de glaciar (azul/compacto)' },
+  { key: 'hielo_podrido', icon: '💧', label: 'Hielo podrido (derretido)' },
+  { key: 'penitentes', icon: '🗻', label: 'Penitentes' },
+  { key: 'hielo_cubierto', icon: '🪨', label: 'Hielo cubierto (detritos)' },
+];
+
+/* ── Dureza del hielo (penetración de piolet/sonda, 1–5) ────────────── */
+export const ESCALA_DUREZA = [
+  { valor: 1, label: 'Muy blando', desc: 'Nieve fresca, el piolet entra todo.', color: 'sky' },
+  { valor: 2, label: 'Blando', desc: 'Firn, poco esfuerzo.', color: 'cyan' },
+  { valor: 3, label: 'Medio', desc: 'Compacto, golpe firme.', color: 'amber' },
+  { valor: 4, label: 'Duro', desc: 'Hielo de glaciar, rebota.', color: 'orange' },
+  { valor: 5, label: 'Muy duro', desc: 'Hielo azul frío, casi no penetra.', color: 'blue' },
+];
+
+/* ── Peligros observados (multi-select) ─────────────────────────────── */
+export const PELIGROS = [
+  { key: 'grietas_cerradas', icon: '〰️', label: 'Grietas cerradas' },
+  { key: 'grietas_abiertas', icon: '⚠️', label: 'Grietas abiertas' },
+  { key: 'puente_nieve', icon: '🌉', label: 'Puente de nieve' },
+  { key: 'seracs', icon: '🏔️', label: 'Séracs' },
+  { key: 'agua_deshielo', icon: '💦', label: 'Agua de deshielo' },
+  { key: 'riesgo_avalancha', icon: '🏂', label: 'Riesgo de avalancha' },
+  { key: 'penitentes', icon: '🗻', label: 'Penitentes' },
+];
+
+/* ── Condiciones del entorno (selects cortos) ───────────────────────── */
+export const NUBOSIDAD = [
+  { key: 'despejado', label: 'Despejado' },
+  { key: 'parcial', label: 'Parcialmente nublado' },
+  { key: 'nublado', label: 'Nublado' },
+  { key: 'niebla', label: 'Niebla / sin visibilidad' },
+];
+
+export const VIENTO = [
+  { key: 'calma', label: 'Calma' },
+  { key: 'brisa', label: 'Brisa' },
+  { key: 'fuerte', label: 'Viento fuerte' },
+  { key: 'rafagas', label: 'Ráfagas peligrosas' },
+];
+
+export const VISIBILIDAD = [
+  { key: 'buena', label: 'Buena' },
+  { key: 'regular', label: 'Regular' },
+  { key: 'mala', label: 'Mala' },
+];
+
+/* ── Estado de seguridad derivado (lógica en evaluarSeguridadGlaciar) ── */
+export const ESTADOS_SEGURIDAD = {
+  estable: {
+    nivel: 'estable',
+    emoji: '🟢',
+    label: 'Estable',
+    desc: 'Hielo firme sin peligros visibles. Avance con las precauciones normales.',
+    color: 'emerald',
+  },
+  precaucion: {
+    nivel: 'precaucion',
+    emoji: '🟡',
+    label: 'Precaución',
+    desc: 'Hay señales de cuidado. Evalúe la ruta y use protección.',
+    color: 'amber',
+  },
+  peligro: {
+    nivel: 'peligro',
+    emoji: '🔴',
+    label: 'Peligro',
+    desc: 'Condiciones inseguras. Considere no avanzar o buscar otra ruta.',
+    color: 'red',
+  },
+};
+
+/* Mapas key→meta para mostrar etiquetas en la lista/trazabilidad. */
+export const SUPERFICIE_BY_KEY = Object.fromEntries(TIPOS_SUPERFICIE.map((t) => [t.key, t]));
+export const PELIGRO_BY_KEY = Object.fromEntries(PELIGROS.map((p) => [p.key, p]));
+export const DUREZA_BY_VALOR = Object.fromEntries(ESCALA_DUREZA.map((d) => [d.valor, d]));

--- a/src/db/__tests__/glaciarReportes.test.js
+++ b/src/db/__tests__/glaciarReportes.test.js
@@ -1,0 +1,128 @@
+/**
+ * glaciarReportes.test.js — store offline de reportes de punto glaciar.
+ *
+ * Mock pequeño de IDB con un Map en memoria (mismo patrón que
+ * assetCache.tenant.test.js — sin fake-indexeddb). Verifica:
+ *   - save() persiste y genera id/createdAt/fechaISO si faltan.
+ *   - getAll() devuelve ordenado del más reciente al más antiguo.
+ *   - get()/remove()/count() funcionan.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let store; // Map en memoria keyed by id
+
+const makeTx = () => {
+  const tx = { oncomplete: null, onerror: null, onabort: null };
+  const objectStore = {
+    put(record) {
+      store.set(record.id, record);
+      Promise.resolve().then(() => tx.oncomplete?.());
+    },
+    delete(id) {
+      store.delete(id);
+      Promise.resolve().then(() => tx.oncomplete?.());
+    },
+    get(id) {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = store.get(id) || undefined;
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    getAll() {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = [...store.values()];
+        req.onsuccess?.();
+      });
+      return req;
+    },
+    count() {
+      const req = { onsuccess: null, onerror: null };
+      Promise.resolve().then(() => {
+        req.result = store.size;
+        req.onsuccess?.();
+      });
+      return req;
+    },
+  };
+  tx.objectStore = () => objectStore;
+  return tx;
+};
+
+const mockDB = { transaction: vi.fn(() => makeTx()) };
+
+vi.mock('../dbCore', () => ({
+  openDB: vi.fn(() => Promise.resolve(mockDB)),
+  STORES: { GLACIAR_REPORTES: 'glaciar_reportes' },
+}));
+
+describe('glaciarReportes store', () => {
+  beforeEach(() => {
+    store = new Map();
+    vi.clearAllMocks();
+  });
+
+  it('save() persiste y genera id/createdAt/fechaISO si faltan', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    const saved = await glaciarReportes.save({
+      guia: 'Pedro',
+      lat: 4.8,
+      lng: -75.3,
+      tipoSuperficie: 'hielo_glaciar',
+      dureza: 4,
+      estado: 'estable',
+    });
+    expect(saved.id).toMatch(/^glaciar-/);
+    expect(typeof saved.createdAt).toBe('number');
+    expect(typeof saved.fechaISO).toBe('string');
+    expect(store.size).toBe(1);
+  });
+
+  it('save() respeta un id explícito (upsert)', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({ id: 'fijo-1', dureza: 2, estado: 'precaucion' });
+    await glaciarReportes.save({ id: 'fijo-1', dureza: 5, estado: 'estable' });
+    expect(store.size).toBe(1);
+    const got = await glaciarReportes.get('fijo-1');
+    expect(got.dureza).toBe(5);
+  });
+
+  it('getAll() devuelve ordenado del más reciente al más antiguo', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({ id: 'a', createdAt: 1000, estado: 'estable' });
+    await glaciarReportes.save({ id: 'b', createdAt: 3000, estado: 'peligro' });
+    await glaciarReportes.save({ id: 'c', createdAt: 2000, estado: 'precaucion' });
+    const all = await glaciarReportes.getAll();
+    expect(all.map((r) => r.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('get() devuelve null si no existe', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    expect(await glaciarReportes.get('nope')).toBeNull();
+  });
+
+  it('remove() elimina el reporte', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({ id: 'x', estado: 'estable' });
+    expect(store.size).toBe(1);
+    await glaciarReportes.remove('x');
+    expect(store.size).toBe(0);
+  });
+
+  it('count() cuenta los reportes', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({ id: '1', estado: 'estable' });
+    await glaciarReportes.save({ id: '2', estado: 'peligro' });
+    expect(await glaciarReportes.count()).toBe(2);
+  });
+
+  it('persiste fotoDataUrl (offline survival de la foto)', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    const dataUrl = 'data:image/jpeg;base64,/9j/AAA';
+    await glaciarReportes.save({ id: 'foto-1', fotoDataUrl: dataUrl, estado: 'estable' });
+    const got = await glaciarReportes.get('foto-1');
+    expect(got.fotoDataUrl).toBe(dataUrl);
+  });
+});

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 21;
+export const DB_VERSION = 22;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -80,6 +80,15 @@ export const STORES = {
   // persiste el índice YA construido (capa de cómputo) → arranque offline
   // instantáneo sin re-tokenizar. keyPath 'key' (un único registro 'corpus').
   RAG_CORPUS_CACHE: 'rag_corpus_cache',
+  // v22: glaciar_reportes — reportes OFFLINE de puntos glaciares capturados
+  // por guías de glaciar (módulo demo). Cada reporte guarda GPS (lat/lng/
+  // altitud/precisión), foto (dataURL para sobrevivir recargas), el formulario
+  // de diagnóstico de dureza del hielo + peligros y el estado de seguridad
+  // derivado. La idea es repetir el MISMO punto GPS en el tiempo →
+  // trazabilidad del cambio climático (repeat photography). keyPath 'id'
+  // (string ULID-like generado en cliente). Índices: createdAt (timeline),
+  // estado (filtrar por 🟢/🟡/🔴), guia (por persona).
+  GLACIAR_REPORTES: 'glaciar_reportes',
 };
 
 let dbInstance = null;
@@ -358,6 +367,19 @@ export const openDB = async () => {
       if (event.oldVersion < 21) {
         if (!db.objectStoreNames.contains(STORES.RAG_CORPUS_CACHE)) {
           db.createObjectStore(STORES.RAG_CORPUS_CACHE, { keyPath: 'key' });
+        }
+      }
+
+      // v22: glaciar_reportes — reportes offline de puntos glaciares (módulo
+      // demo para guías de glaciar). Offline-first: el reporte completo (GPS +
+      // foto dataURL + diagnóstico + estado de seguridad) se persiste local y
+      // sobrevive recargas sin red. keyPath 'id' (string generado en cliente).
+      if (event.oldVersion < 22) {
+        if (!db.objectStoreNames.contains(STORES.GLACIAR_REPORTES)) {
+          const store = db.createObjectStore(STORES.GLACIAR_REPORTES, { keyPath: 'id' });
+          store.createIndex('createdAt', 'createdAt', { unique: false });
+          store.createIndex('estado', 'estado', { unique: false });
+          store.createIndex('guia', 'guia', { unique: false });
         }
       }
     };

--- a/src/db/glaciarReportes.js
+++ b/src/db/glaciarReportes.js
@@ -1,0 +1,126 @@
+/**
+ * glaciarReportes.js — CRUD offline-first de reportes de puntos glaciares.
+ *
+ * Store: glaciar_reportes (ChagraDB v22)
+ * Schema del registro:
+ *   {
+ *     id,            // string único generado en cliente
+ *     createdAt,     // epoch ms
+ *     fechaISO,      // ISO string (auto, hora local del reporte)
+ *     guia,          // nombre del guía (string)
+ *     // Ubicación (GPS offline)
+ *     lat, lng, altitud, precision,   // números | null
+ *     // Diagnóstico
+ *     tipoSuperficie,   // key de TIPOS_SUPERFICIE
+ *     dureza,           // 1..5
+ *     tempSuperficie,   // °C | null
+ *     peligros,         // string[] keys de PELIGROS
+ *     // Condiciones
+ *     tempAmbiente,     // °C | null
+ *     nubosidad, viento, visibilidad,  // keys | null
+ *     notas,            // texto libre
+ *     // Foto (dataURL para sobrevivir recargas offline — NO blob URL)
+ *     fotoDataUrl,      // string | null
+ *     // Estado de seguridad derivado (cache de evaluarSeguridadGlaciar)
+ *     estado,           // 'estable'|'precaucion'|'peligro'
+ *     estadoRazones,    // string[]
+ *   }
+ *
+ * Offline-first: todo se persiste local, sobrevive recargas, no requiere red.
+ *
+ * @module db/glaciarReportes
+ */
+
+import { openDB, STORES } from './dbCore';
+
+/** Genera un id único en cliente (timestamp + random, ordenable por tiempo). */
+export function nuevoReporteId() {
+  return `glaciar-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export const glaciarReportes = {
+  /**
+   * Guarda (o reemplaza) un reporte. Si no trae `id`/`createdAt`, los genera.
+   * @param {object} reporte
+   * @returns {Promise<object>} el reporte persistido (con id/createdAt).
+   */
+  async save(reporte) {
+    const db = await openDB();
+    const now = Date.now();
+    const record = {
+      ...reporte,
+      id: reporte.id || nuevoReporteId(),
+      createdAt: reporte.createdAt || now,
+      fechaISO: reporte.fechaISO || new Date(now).toISOString(),
+    };
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.GLACIAR_REPORTES, 'readwrite');
+      tx.objectStore(STORES.GLACIAR_REPORTES).put(record);
+      tx.oncomplete = () => resolve(record);
+      tx.onerror = () => reject(tx.error);
+      tx.onabort = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Devuelve todos los reportes ordenados del más reciente al más antiguo.
+   * @returns {Promise<object[]>}
+   */
+  async getAll() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.GLACIAR_REPORTES, 'readonly');
+      const req = tx.objectStore(STORES.GLACIAR_REPORTES).getAll();
+      req.onsuccess = () => {
+        const results = req.result || [];
+        results.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+        resolve(results);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Obtiene un reporte por id. Null si no existe.
+   * @param {string} id
+   * @returns {Promise<object|null>}
+   */
+  async get(id) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.GLACIAR_REPORTES, 'readonly');
+      const req = tx.objectStore(STORES.GLACIAR_REPORTES).get(id);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    });
+  },
+
+  /**
+   * Elimina un reporte por id.
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  async remove(id) {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.GLACIAR_REPORTES, 'readwrite');
+      tx.objectStore(STORES.GLACIAR_REPORTES).delete(id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  },
+
+  /**
+   * Cuenta los reportes guardados.
+   * @returns {Promise<number>}
+   */
+  async count() {
+    const db = await openDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.GLACIAR_REPORTES, 'readonly');
+      const req = tx.objectStore(STORES.GLACIAR_REPORTES).count();
+      req.onsuccess = () => resolve(req.result || 0);
+      req.onerror = () => reject(req.error);
+    });
+  },
+};

--- a/src/services/__tests__/glaciarSafety.test.js
+++ b/src/services/__tests__/glaciarSafety.test.js
@@ -1,0 +1,78 @@
+/**
+ * glaciarSafety.test.js — lógica pura del estado de seguridad de punto glaciar.
+ * Casos 🟢 estable / 🟡 precaución / 🔴 peligro.
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluarSeguridadGlaciar } from '../glaciarSafety';
+
+describe('evaluarSeguridadGlaciar', () => {
+  it('🔴 peligro cuando la superficie es hielo podrido', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_podrido', dureza: 4, peligros: [] });
+    expect(r.nivel).toBe('peligro');
+    expect(r.emoji).toBe('🔴');
+    expect(r.razones).toContain('Hielo podrido (derretido)');
+  });
+
+  it('🔴 peligro cuando hay agua de deshielo', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: ['agua_deshielo'] });
+    expect(r.nivel).toBe('peligro');
+  });
+
+  it('🔴 peligro cuando hay grietas abiertas', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 5, peligros: ['grietas_abiertas'] });
+    expect(r.nivel).toBe('peligro');
+  });
+
+  it('🔴 peligro cuando hay puente de nieve', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn', dureza: 2, peligros: ['puente_nieve'] });
+    expect(r.nivel).toBe('peligro');
+  });
+
+  it('🟡 precaución: firn blando con un peligro no crítico (grietas cerradas)', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn', dureza: 2, peligros: ['grietas_cerradas'] });
+    expect(r.nivel).toBe('precaucion');
+    expect(r.emoji).toBe('🟡');
+    expect(r.razones.some((x) => /blanda/i.test(x))).toBe(true);
+  });
+
+  it('🟡 precaución: hielo duro pero con peligro no crítico (penitentes)', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: ['penitentes'] });
+    expect(r.nivel).toBe('precaucion');
+  });
+
+  it('🟡 precaución: nieve fresca muy blanda sin peligros', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'nieve_fresca', dureza: 1, peligros: [] });
+    expect(r.nivel).toBe('precaucion');
+  });
+
+  it('🟢 estable: hielo compacto y duro (dureza 4) sin peligros', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: [] });
+    expect(r.nivel).toBe('estable');
+    expect(r.emoji).toBe('🟢');
+  });
+
+  it('🟢 estable: dureza media (3) sin peligros', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_cubierto', dureza: 3, peligros: [] });
+    expect(r.nivel).toBe('estable');
+  });
+
+  it('🟡 precaución por falta de datos: sin dureza ni peligros', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', peligros: [] });
+    expect(r.nivel).toBe('precaucion');
+  });
+
+  it('es pura: mismo input → mismo output', () => {
+    const input = { tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: ['penitentes'] };
+    expect(evaluarSeguridadGlaciar(input)).toEqual(evaluarSeguridadGlaciar(input));
+  });
+
+  it('tolera input vacío sin lanzar', () => {
+    expect(() => evaluarSeguridadGlaciar()).not.toThrow();
+    expect(() => evaluarSeguridadGlaciar({})).not.toThrow();
+  });
+
+  it('prioriza peligro crítico sobre estabilidad de hielo duro', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 5, peligros: ['seracs', 'grietas_cerradas'] });
+    expect(r.nivel).toBe('peligro');
+  });
+});

--- a/src/services/glaciarSafety.js
+++ b/src/services/glaciarSafety.js
@@ -1,0 +1,116 @@
+/**
+ * glaciarSafety.js — lógica PURA y testeable del estado de seguridad de un
+ * punto glaciar a partir de un reporte de campo.
+ *
+ * Reglas PROVISIONALES (refinables con investigación glaciológica):
+ *   🔴 PELIGRO   — hielo podrido (derretido) O agua de deshielo O grietas
+ *                  abiertas O puente de nieve O séracs O riesgo de avalancha.
+ *   🟡 PRECAUCIÓN — firn/nieve blando (dureza ≤ 2) con algún peligro, O
+ *                  cualquier peligro presente que no sea de la lista crítica.
+ *   🟢 ESTABLE   — hielo compacto/duro (dureza ≥ 3) sin peligros observados.
+ *
+ * La función es pura: mismo reporte → mismo estado. Sin efectos secundarios,
+ * sin red, sin fecha/hora. Apta para tests deterministas y para correr
+ * offline en campo.
+ *
+ * @module services/glaciarSafety
+ */
+
+import { ESTADOS_SEGURIDAD } from '../data/glaciar-schema.js';
+
+/** Peligros que, por sí solos, fuerzan estado 🔴 peligro. */
+export const PELIGROS_CRITICOS = Object.freeze([
+  'grietas_abiertas',
+  'puente_nieve',
+  'seracs',
+  'agua_deshielo',
+  'riesgo_avalancha',
+]);
+
+/** Tipos de superficie que, por sí solos, fuerzan estado 🔴 peligro. */
+export const SUPERFICIES_CRITICAS = Object.freeze(['hielo_podrido']);
+
+/** Dureza por debajo o igual a este umbral se considera "blanda". */
+export const DUREZA_BLANDA_MAX = 2;
+
+/**
+ * Evalúa el estado de seguridad de un punto glaciar.
+ *
+ * @param {Object} reporte
+ * @param {string} [reporte.tipoSuperficie] - key de TIPOS_SUPERFICIE.
+ * @param {number} [reporte.dureza] - 1..5 (escala de penetración).
+ * @param {string[]} [reporte.peligros] - keys de PELIGROS.
+ * @param {string} [reporte.aguaDeshielo] - compat: si viene 'agua_deshielo'
+ *   suelto, también cuenta (defensivo). Normalmente va dentro de `peligros`.
+ * @returns {{nivel: 'estable'|'precaucion'|'peligro', emoji: string,
+ *   label: string, desc: string, color: string, razones: string[]}}
+ */
+export function evaluarSeguridadGlaciar(reporte = {}) {
+  const peligros = Array.isArray(reporte.peligros) ? reporte.peligros : [];
+  const tipoSuperficie = reporte.tipoSuperficie || null;
+  const durezaNum = Number(reporte.dureza);
+  const dureza = Number.isFinite(durezaNum) ? durezaNum : null;
+
+  const razones = [];
+
+  // ── 🔴 PELIGRO: superficie crítica ──
+  if (tipoSuperficie && SUPERFICIES_CRITICAS.includes(tipoSuperficie)) {
+    razones.push('Hielo podrido (derretido)');
+  }
+
+  // ── 🔴 PELIGRO: peligros críticos ──
+  const criticosPresentes = peligros.filter((p) => PELIGROS_CRITICOS.includes(p));
+  for (const p of criticosPresentes) razones.push(peligroLabel(p));
+
+  if (razones.length > 0) {
+    return { ...ESTADOS_SEGURIDAD.peligro, razones };
+  }
+
+  // A partir de acá NO hay peligros críticos ni superficie crítica.
+  const otrosPeligros = peligros.filter((p) => !PELIGROS_CRITICOS.includes(p));
+  const esBlando = dureza != null && dureza <= DUREZA_BLANDA_MAX;
+
+  // ── 🟡 PRECAUCIÓN: firn blando + algún peligro, o cualquier peligro ──
+  if (otrosPeligros.length > 0) {
+    const motivos = otrosPeligros.map(peligroLabel);
+    if (esBlando) motivos.unshift('Superficie blanda (firn/nieve)');
+    return { ...ESTADOS_SEGURIDAD.precaucion, razones: motivos };
+  }
+
+  // Sin peligros pero superficie blanda → precaución suave.
+  if (esBlando) {
+    return {
+      ...ESTADOS_SEGURIDAD.precaucion,
+      razones: ['Superficie blanda (firn/nieve), sin peligros visibles'],
+    };
+  }
+
+  // ── 🟢 ESTABLE: hielo compacto/duro (≥3) sin peligros ──
+  if (dureza != null && dureza >= 3) {
+    return {
+      ...ESTADOS_SEGURIDAD.estable,
+      razones: ['Hielo compacto y duro, sin peligros observados'],
+    };
+  }
+
+  // Sin dureza registrada y sin peligros: precaución por falta de datos
+  // (no podemos afirmar que es estable sin medir el hielo).
+  return {
+    ...ESTADOS_SEGURIDAD.precaucion,
+    razones: ['Falta medir la dureza del hielo para confirmar el estado'],
+  };
+}
+
+const PELIGRO_LABELS = {
+  grietas_cerradas: 'Grietas cerradas',
+  grietas_abiertas: 'Grietas abiertas',
+  puente_nieve: 'Puente de nieve',
+  seracs: 'Séracs',
+  agua_deshielo: 'Agua de deshielo',
+  riesgo_avalancha: 'Riesgo de avalancha',
+  penitentes: 'Penitentes',
+};
+
+function peligroLabel(key) {
+  return PELIGRO_LABELS[key] || key.replace(/_/g, ' ');
+}


### PR DESCRIPTION
## Reporte de Punto Glaciar — módulo demo para guías de glaciar

Módulo NUEVO, clickeable y desplegable: un guía de glaciar crea un **reporte OFFLINE** de un punto del glaciar. Pensado para validación en campo y para **trazabilidad del deshielo** (repetir el mismo punto GPS en el tiempo).

### Cómo abrir el demo (tras merge)
**`https://chagra.guatoc.co/#glaciar`**

También hay un acceso visible en el Home: banner **"Reporte de Punto Glaciar"** justo bajo el hero del agente.

### Qué quedó funcional (end-to-end, offline-first)
- **GPS**: captura de ubicación (lat/lng/altitud/precisión) vía `navigator.geolocation` (`useGeolocation`). Funciona sin red; muestra coordenadas + altitud + precisión.
- **Foto**: reusa `PhotoCaptureField` (cámara/galería + compresión existente). Se persiste como **dataURL** para sobrevivir recargas offline.
- **Diagnóstico de dureza del hielo**: tipo de superficie (6 opciones), **escala de dureza 1–5** (penetración de piolet/sonda), temperatura superficial (opcional), **peligros** (multi-select) y condiciones (nubosidad/viento/visibilidad). Enums editables en `src/data/glaciar-schema.js`.
- **Estado de seguridad derivado en vivo** 🟢/🟡/🔴 vía función pura `evaluarSeguridadGlaciar(reporte)` (`src/services/glaciarSafety.js`), con razones explicadas.
- **Persistencia offline**: nuevo store IndexedDB `glaciar_reportes` (`DB_VERSION` 21→22, migración `oldVersion < 22`). Sobrevive recargas, sin red.
- **Lista / trazabilidad**: reportes guardados con fecha, ubicación, dureza, estado de seguridad, peligros y **miniatura de la foto**.

### Lógica de seguridad (provisional, editable)
- 🔴 **Peligro**: hielo podrido O agua de deshielo O grietas abiertas O puente de nieve O séracs O riesgo de avalancha.
- 🟡 **Precaución**: superficie blanda (firn/nieve, dureza ≤ 2) con algún peligro, o cualquier peligro no crítico, o falta de datos de dureza.
- 🟢 **Estable**: hielo compacto/duro (dureza ≥ 3) sin peligros.

### Tests (TDD donde tiene sentido) — 26 verdes
- `glaciarSafety.test.js`: casos 🟢/🟡/🔴, pureza, prioridad de peligro crítico.
- `glaciarReportes.test.js`: store save/get/getAll(orden)/remove/count + foto dataURL.
- `GlaciarReporteScreen.test.jsx`: montaje de la pantalla, estado de seguridad reactivo y guardado.

### Verificación
- `npm run lint` limpio en todos los archivos tocados (los ~22 errores de lint restantes son **pre-existentes** en `soilDiagnostic.js`/`openaiStream.js`/`socialPrefiltro.js`/`rag-embedding.test.js`, ajenos a este PR).
- `npm run build` OK (chunk `GlaciarReporteScreen` lazy-split).
- Secret-scan / infra-refs-scan / conventional-commit: OK.

### TODO (post-validación)
- Refinar enums y escala de dureza con la investigación glaciológica en paralelo (todo vive en `src/data/glaciar-schema.js` + `glaciarSafety.js`).
- Mapa Leaflet de los puntos (Leaflet ya está en el bundle) — hoy es lista; se dejó como bonus.
- Sync del reporte a backend (hoy es 100% local en el dispositivo, que es el contrato del demo).
- Reverse-geocode opcional del punto (vereda/municipio) cuando haya red.

Español Colombia (usted/tú, sin voseo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)