### PR TITLE
feat(glaciar): escala dureza mano→piolet + perfil por capas + frente + lógica de seguridad

### DIFF
--- a/src/components/GlaciarReporteScreen.jsx
+++ b/src/components/GlaciarReporteScreen.jsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ChevronLeft, MapPin, Loader2, AlertCircle, Mountain, Thermometer,
-  Save, ListChecks, Trash2, CheckCircle2, Snowflake,
+  Save, ListChecks, Trash2, CheckCircle2, Snowflake, Compass, Layers,
+  Plus, X, ShieldAlert, Info, Footprints,
 } from 'lucide-react';
 import { useGeolocation } from '../hooks/useGeolocation';
 import PhotoCaptureField from './PhotoCaptureField';
@@ -9,48 +10,71 @@ import { blobToDataUrl } from '../utils/imageProcessor';
 import { glaciarReportes, nuevoReporteId } from '../db/glaciarReportes';
 import { evaluarSeguridadGlaciar } from '../services/glaciarSafety';
 import {
-  TIPOS_SUPERFICIE, ESCALA_DUREZA, PELIGROS, NUBOSIDAD, VIENTO, VISIBILIDAD,
-  SUPERFICIE_BY_KEY, PELIGRO_BY_KEY, DUREZA_BY_VALOR,
+  TIPOS_SUPERFICIE, ESCALA_DUREZA, PELIGROS, CIELO, VIENTO, VISIBILIDAD,
+  MONTANAS, SUPERFICIE_BY_KEY, PELIGRO_BY_KEY, DUREZA_BY_CODIGO, MONTANA_BY_KEY,
+  ESTADOS_SEGURIDAD, DISCLAIMER, PROPOSITO,
 } from '../data/glaciar-schema.js';
 
 /**
- * GlaciarReporteScreen — Reporte OFFLINE de Punto Glaciar (módulo demo para
- * guías de glaciar). Ruta: #glaciar.
+ * GlaciarReporteScreen — Reporte OFFLINE de Punto Glaciar para guías (v2
+ * "escala creíble"). Ruta: #glaciar.
+ *
+ * El reporte representa el FRENTE/BORDE del hielo (el punto que retrocede).
+ * Repetir el mismo punto en el tiempo = trazabilidad del retroceso.
  *
  * Flujo de campo (todo offline-first):
- *   1. Capturar UBICACIÓN (GPS: lat/lng/altitud/precisión) sin red.
- *   2. Capturar FOTO del punto (repeat photography → trazabilidad).
- *   3. Diagnóstico de DUREZA DEL HIELO + peligros + condiciones.
- *   4. Estado de seguridad DERIVADO en vivo (🟢/🟡/🔴).
+ *   1. Montaña + punto fijo (punto_id) + GPS + foto encuadrada (azimut).
+ *   2. Dureza del hielo: escala mano→piolet (F..H2), perfil por capas +
+ *      lectura puntual rápida de la superficie.
+ *   3. Tipos de superficie, peligros, condiciones.
+ *   4. Estado de seguridad DERIVADO en vivo (🟢/🟡/🔴/🔵 observación).
  *   5. Guardar en IndexedDB (sobrevive recargas) + lista de trazabilidad.
  *
  * Español Colombia (usted/tú, SIN voseo). Tono claro y de campo.
  *
- * Demo: refinable con la investigación glaciológica en paralelo. Enums en
- * src/data/glaciar-schema.js; lógica de seguridad en services/glaciarSafety.js.
+ * Enums en src/data/glaciar-schema.js; lógica en services/glaciarSafety.js.
  */
-
-const COLOR_BTN = {
-  emerald: 'bg-emerald-900/30 border-emerald-600/60 text-emerald-200',
-  amber: 'bg-amber-900/30 border-amber-600/60 text-amber-200',
-  red: 'bg-red-900/30 border-red-600/60 text-red-200',
-};
 
 const ESTADO_BG = {
   estable: 'bg-emerald-900/25 border-emerald-600/50',
   precaucion: 'bg-amber-900/25 border-amber-600/50',
   peligro: 'bg-red-900/25 border-red-600/50',
+  observacion: 'bg-sky-900/25 border-sky-600/50',
 };
+
+const ESTADO_EMOJI = {
+  estable: '🟢', precaucion: '🟡', peligro: '🔴', observacion: '🔵',
+};
+
+function nuevaCapa() {
+  return { profundidad: '', tipoSuperficie: '', dureza: '' };
+}
 
 function emptyForm() {
   return {
     guia: '',
-    tipoSuperficie: '',
-    dureza: null,
+    montana: '',
+    montanaLibre: '',
+    puntoId: '',
+    pisoGlaciar: true,
+    // Perfil por capas (la primera es la superficie) + lectura puntual rápida.
+    capas: [nuevaCapa()],
+    tipoSuperficie: '', // lectura puntual de superficie
+    dureza: '', // lectura puntual de dureza (código F..H2)
     tempSuperficie: '',
+    // Peligros + flags de contexto que afinan la lógica de seguridad.
     peligros: [],
+    rutaBajoSeracs: false,
+    penitentesDensos: false,
+    pendientePronunciada: false,
+    nieveReciente24h: false,
+    // Trazabilidad climática / repeat photography.
+    distanciaBordeHieloM: '',
+    azimutBrujula: '',
+    referenciaEncuadre: '',
+    // Condiciones.
     tempAmbiente: '',
-    nubosidad: '',
+    cielo: '',
     viento: '',
     visibilidad: '',
     notas: '',
@@ -75,7 +99,6 @@ export default function GlaciarReporteScreen({ onBack }) {
       setCoords({
         lat: position.lat,
         lng: position.lon,
-        // altitud: la del GPS si vino; si no, queda null (el guía la conoce).
         altitud: typeof position.altitude === 'number' ? Math.round(position.altitude) : null,
         precision: typeof position.accuracy === 'number' ? Math.round(position.accuracy) : null,
       });
@@ -98,17 +121,31 @@ export default function GlaciarReporteScreen({ onBack }) {
     if (tab === 'lista') cargarReportes();
   }, [tab, cargarReportes]);
 
+  const esBorde = form.pisoGlaciar === false;
+
   // Estado de seguridad en vivo (cada vez que cambia el diagnóstico).
   const seguridad = useMemo(
     () => evaluarSeguridadGlaciar({
+      capas: form.capas,
       tipoSuperficie: form.tipoSuperficie,
       dureza: form.dureza,
       peligros: form.peligros,
+      pisoGlaciar: form.pisoGlaciar,
+      rutaBajoSeracs: form.rutaBajoSeracs,
+      penitentesDensos: form.penitentesDensos,
+      pendientePronunciada: form.pendientePronunciada,
+      nieveReciente24h: form.nieveReciente24h,
+      horaLocal: horaLocalAhora(),
     }),
-    [form.tipoSuperficie, form.dureza, form.peligros],
+    [
+      form.capas, form.tipoSuperficie, form.dureza, form.peligros, form.pisoGlaciar,
+      form.rutaBajoSeracs, form.penitentesDensos, form.pendientePronunciada,
+      form.nieveReciente24h,
+    ],
   );
 
   const setField = (k, v) => setForm((f) => ({ ...f, [k]: v }));
+  const toggleField = (k) => setForm((f) => ({ ...f, [k]: !f[k] }));
 
   const togglePeligro = (key) => {
     setForm((f) => {
@@ -117,17 +154,32 @@ export default function GlaciarReporteScreen({ onBack }) {
     });
   };
 
+  // ── Perfil por capas ──
+  const setCapa = (i, k, v) => setForm((f) => {
+    const capas = f.capas.map((c, idx) => (idx === i ? { ...c, [k]: v } : c));
+    return { ...f, capas };
+  });
+  const addCapa = () => setForm((f) => ({ ...f, capas: [...f.capas, nuevaCapa()] }));
+  const removeCapa = (i) => setForm((f) => ({
+    ...f, capas: f.capas.length > 1 ? f.capas.filter((_, idx) => idx !== i) : f.capas,
+  }));
+
   const handlePhoto = useCallback((blob) => setFotoBlob(blob), []);
   const handleRemovePhoto = useCallback(() => setFotoBlob(null), []);
 
-  const puedeGuardar = !!coords && !!form.tipoSuperficie && form.dureza != null && !saving;
+  // Para guardar: ubicación + montaña + (lectura puntual O al menos una capa
+  // con superficie). En modo borde no exigimos dureza (no se pisa el hielo).
+  const capaConDatos = form.capas.some((c) => c.tipoSuperficie);
+  const tieneSuperficie = !!form.tipoSuperficie || capaConDatos;
+  const tieneDureza = !!form.dureza || form.capas.some((c) => c.dureza);
+  const puedeGuardar =
+    !!coords && !!form.montana && tieneSuperficie && (esBorde || tieneDureza) && !saving;
 
   const handleGuardar = async () => {
     if (!puedeGuardar) return;
     setSaving(true);
     setSavedOk(false);
     try {
-      // Foto → dataURL para sobrevivir recargas offline (NO blob URL volátil).
       let fotoDataUrl = null;
       if (fotoBlob) {
         try {
@@ -136,19 +188,34 @@ export default function GlaciarReporteScreen({ onBack }) {
           console.warn('[Glaciar] no se pudo convertir la foto, se guarda sin ella:', e);
         }
       }
+      // Capas: solo las que tengan algún dato.
+      const capas = form.capas.filter((c) => c.tipoSuperficie || c.dureza || c.profundidad);
       const reporte = {
         id: nuevoReporteId(),
+        puntoId: form.puntoId.trim() || null,
         guia: form.guia.trim(),
+        montana: form.montana || null,
+        montanaLibre: form.montana === 'otra' ? form.montanaLibre.trim() : '',
+        pisoGlaciar: form.pisoGlaciar,
+        horaLocal: horaLocalAhora(),
         lat: coords.lat,
         lng: coords.lng,
         altitud: coords.altitud,
         precision: coords.precision,
-        tipoSuperficie: form.tipoSuperficie,
-        dureza: form.dureza,
+        distanciaBordeHieloM: numOrNull(form.distanciaBordeHieloM),
+        azimutBrujula: numOrNull(form.azimutBrujula),
+        referenciaEncuadre: form.referenciaEncuadre.trim(),
+        capas,
+        tipoSuperficie: form.tipoSuperficie || null,
+        dureza: form.dureza || null,
         tempSuperficie: numOrNull(form.tempSuperficie),
         peligros: form.peligros,
+        rutaBajoSeracs: form.rutaBajoSeracs,
+        penitentesDensos: form.penitentesDensos,
+        pendientePronunciada: form.pendientePronunciada,
+        nieveReciente24h: form.nieveReciente24h,
         tempAmbiente: numOrNull(form.tempAmbiente),
-        nubosidad: form.nubosidad || null,
+        cielo: form.cielo || null,
         viento: form.viento || null,
         visibilidad: form.visibilidad || null,
         notas: form.notas.trim(),
@@ -158,10 +225,10 @@ export default function GlaciarReporteScreen({ onBack }) {
       };
       await glaciarReportes.save(reporte);
       setSavedOk(true);
-      // Reset del formulario para el siguiente punto, pero conservamos el
-      // nombre del guía (suele ser el mismo en toda la jornada).
-      const guia = form.guia;
-      setForm({ ...emptyForm(), guia });
+      // Conservamos guía + montaña + puntoId (suelen repetirse en la jornada y
+      // el mismo punto se vuelve a medir).
+      const { guia, montana, montanaLibre, puntoId } = form;
+      setForm({ ...emptyForm(), guia, montana, montanaLibre, puntoId });
       setCoords(null);
       setFotoBlob(null);
       setTimeout(() => setSavedOk(false), 2500);
@@ -178,6 +245,8 @@ export default function GlaciarReporteScreen({ onBack }) {
     await glaciarReportes.remove(id);
     cargarReportes();
   };
+
+  const montanaSel = MONTANA_BY_KEY[form.montana];
 
   return (
     <div className="min-h-screen w-full text-slate-100 pb-28">
@@ -196,7 +265,7 @@ export default function GlaciarReporteScreen({ onBack }) {
             <Snowflake size={22} className="text-sky-300" />
             <div>
               <h1 className="text-lg font-black leading-tight">Punto Glaciar</h1>
-              <p className="text-[11px] text-slate-400 leading-tight">Reporte offline para guías</p>
+              <p className="text-[11px] text-slate-400 leading-tight">Frente del hielo · reporte offline</p>
             </div>
           </div>
         </div>
@@ -213,11 +282,94 @@ export default function GlaciarReporteScreen({ onBack }) {
 
       {tab === 'nuevo' ? (
         <main className="px-4 pt-4 space-y-5 max-w-xl mx-auto">
-          {/* Estado de seguridad en vivo (sticky-ish arriba del form) */}
+          {/* Estado de seguridad en vivo */}
           <SeguridadBanner seguridad={seguridad} />
 
-          {/* 1. UBICACIÓN */}
-          <Section num="1" title="Ubicación del punto" icon={<MapPin size={18} />}>
+          {/* 1. MONTAÑA + PUNTO */}
+          <Section num="1" title="Montaña y punto del frente" icon={<Mountain size={18} />}>
+            <Label>Montaña</Label>
+            <select
+              value={form.montana}
+              onChange={(e) => setField('montana', e.target.value)}
+              className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500 appearance-none"
+            >
+              <option value="">Elija la montaña…</option>
+              <optgroup label="Colombia">
+                {MONTANAS.filter((m) => m.pais === 'Colombia').map((m) => (
+                  <option key={m.key} value={m.key}>{m.label}{m.noPisar ? ' (no pisar)' : ''}</option>
+                ))}
+              </optgroup>
+              <optgroup label="Perú — Cordillera Blanca">
+                {MONTANAS.filter((m) => m.pais === 'Perú').map((m) => (
+                  <option key={m.key} value={m.key}>{m.label}</option>
+                ))}
+              </optgroup>
+              {MONTANAS.filter((m) => m.libre).map((m) => (
+                <option key={m.key} value={m.key}>{m.label}</option>
+              ))}
+            </select>
+
+            {form.montana === 'otra' && (
+              <input
+                type="text"
+                value={form.montanaLibre}
+                onChange={(e) => setField('montanaLibre', e.target.value)}
+                placeholder="Nombre de la montaña"
+                className="mt-2 w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500"
+              />
+            )}
+
+            {montanaSel?.noPisar && (
+              <div className="mt-2 p-3 bg-sky-900/20 border border-sky-800/50 rounded-xl flex gap-2">
+                <Info size={18} className="text-sky-300 shrink-0" />
+                <p className="text-xs text-sky-200">
+                  En {montanaSel.label} está prohibido pisar el hielo. El reporte va en
+                  <strong> modo borde</strong> (observación), no como juicio de tránsito.
+                </p>
+              </div>
+            )}
+
+            <Label className="mt-4">Punto fijo (id del frente) — opcional</Label>
+            <input
+              type="text"
+              value={form.puntoId}
+              onChange={(e) => setField('puntoId', e.target.value)}
+              placeholder="ej. RITACUBA-FRENTE-01"
+              className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500"
+            />
+            <p className="text-[11px] text-slate-500 mt-1">
+              Repita el mismo id en cada visita: así se ve cuánto retrocede el frente del hielo.
+            </p>
+
+            {/* Modo borde (no pisar) */}
+            <div className="mt-4">
+              <Label>¿Se pisó el hielo?</Label>
+              <div className="grid grid-cols-2 gap-2">
+                <ToggleBtn
+                  active={form.pisoGlaciar === true}
+                  onClick={() => setField('pisoGlaciar', true)}
+                  icon={<Footprints size={18} />}
+                >
+                  Sí, se pisó
+                </ToggleBtn>
+                <ToggleBtn
+                  active={form.pisoGlaciar === false}
+                  onClick={() => setField('pisoGlaciar', false)}
+                  icon={<Compass size={18} />}
+                >
+                  Modo borde (no pisar)
+                </ToggleBtn>
+              </div>
+              {esBorde && (
+                <p className="text-[11px] text-sky-300 mt-1.5">
+                  Modo observación: se registra el estado del frente sin emitir juicio de tránsito.
+                </p>
+              )}
+            </div>
+          </Section>
+
+          {/* 2. UBICACIÓN + ENCUADRE */}
+          <Section num="2" title="Ubicación y encuadre" icon={<MapPin size={18} />}>
             <button
               type="button"
               onClick={() => request()}
@@ -260,12 +412,39 @@ export default function GlaciarReporteScreen({ onBack }) {
                 />
               </div>
             )}
+
+            <Label className="mt-4">Azimut de la foto (brújula, 0–359°)</Label>
+            <NumberInput
+              value={form.azimutBrujula}
+              onChange={(v) => setField('azimutBrujula', v)}
+              placeholder="ej. 135"
+              icon={<Compass size={18} />}
+            />
+            <p className="text-[11px] text-slate-500 mt-1">
+              Anote hacia dónde apunta la cámara: clave para repetir el mismo encuadre con el tiempo.
+            </p>
+
+            <Label className="mt-3">Referencia del encuadre — opcional</Label>
+            <input
+              type="text"
+              value={form.referenciaEncuadre}
+              onChange={(e) => setField('referenciaEncuadre', e.target.value)}
+              placeholder="ej. desde la roca grande, cima al centro"
+              className="w-full p-3 rounded-xl bg-slate-900 border border-slate-700 text-base text-white outline-none focus:border-sky-500"
+            />
+
+            <Label className="mt-3">Distancia al borde del hielo (m) — opcional</Label>
+            <NumberInput
+              value={form.distanciaBordeHieloM}
+              onChange={(v) => setField('distanciaBordeHieloM', v)}
+              placeholder="ej. 12 (desde un hito fijo)"
+            />
           </Section>
 
-          {/* 2. FOTO */}
-          <Section num="2" title="Foto del punto" icon={<CheckCircle2 size={18} />}>
+          {/* 3. FOTO */}
+          <Section num="3" title="Foto del frente" icon={<CheckCircle2 size={18} />}>
             <p className="text-xs text-slate-400 mb-2">
-              La foto deja huella del mismo punto en el tiempo (trazabilidad del deshielo).
+              La foto deja huella del mismo punto en el tiempo (repeat photography → retroceso).
             </p>
             <PhotoCaptureField
               onPhoto={handlePhoto}
@@ -275,47 +454,49 @@ export default function GlaciarReporteScreen({ onBack }) {
             />
           </Section>
 
-          {/* 3. DIAGNÓSTICO */}
-          <Section num="3" title="Dureza del hielo" icon={<Snowflake size={18} />}>
-            <Label>Tipo de superficie</Label>
-            <div className="grid grid-cols-2 gap-2">
-              {TIPOS_SUPERFICIE.map((t) => (
-                <ChipBtn
-                  key={t.key}
-                  active={form.tipoSuperficie === t.key}
-                  onClick={() => setField('tipoSuperficie', t.key)}
-                >
-                  <span className="text-xl">{t.icon}</span>
-                  <span className="text-left text-sm leading-tight">{t.label}</span>
-                </ChipBtn>
-              ))}
-            </div>
+          {/* 4. DUREZA — escala mano→piolet + perfil por capas */}
+          <Section num="4" title="Dureza del hielo (mano → piolet)" icon={<Snowflake size={18} />}>
+            <EscalaDurezaAyuda />
 
-            <Label className="mt-4">Dureza (penetración de piolet/sonda)</Label>
-            <div className="space-y-2">
-              {ESCALA_DUREZA.map((d) => (
-                <button
-                  key={d.valor}
-                  type="button"
-                  onClick={() => setField('dureza', d.valor)}
-                  className={`w-full flex items-center gap-3 p-3 rounded-xl border-2 transition active:scale-[0.99] text-left ${
-                    form.dureza === d.valor
-                      ? 'bg-sky-900/30 border-sky-500 text-sky-100'
-                      : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
-                  }`}
-                >
-                  <span className={`shrink-0 w-9 h-9 rounded-full grid place-items-center font-black text-lg ${
-                    form.dureza === d.valor ? 'bg-sky-500 text-slate-950' : 'bg-slate-800 text-slate-400'
-                  }`}>
-                    {d.valor}
-                  </span>
-                  <span>
-                    <span className="font-bold block leading-tight">{d.label}</span>
-                    <span className="text-xs text-slate-400 leading-tight">{d.desc}</span>
-                  </span>
-                </button>
+            <div className="mt-4 flex items-center gap-2 mb-2">
+              <Layers size={16} className="text-sky-300" />
+              <Label className="mb-0">Perfil por capas (superficie → fondo)</Label>
+            </div>
+            <p className="text-[11px] text-slate-500 mb-3">
+              La capa de arriba manda el tránsito. Agregue capas más profundas para contar la historia del hielo.
+            </p>
+            <div className="space-y-3">
+              {form.capas.map((capa, i) => (
+                <CapaRow
+                  key={i}
+                  index={i}
+                  capa={capa}
+                  esSuperficie={i === 0}
+                  onChange={(k, v) => setCapa(i, k, v)}
+                  onRemove={() => removeCapa(i)}
+                  removable={form.capas.length > 1}
+                />
               ))}
             </div>
+            <button
+              type="button"
+              onClick={addCapa}
+              className="mt-3 w-full p-2.5 rounded-xl border border-dashed border-slate-600 text-slate-300 text-sm font-bold flex items-center justify-center gap-2 hover:bg-slate-800/50 transition"
+            >
+              <Plus size={16} /> Agregar capa
+            </button>
+
+            {/* Lectura puntual rápida */}
+            <Label className="mt-5">Lectura puntual rápida (superficie)</Label>
+            <p className="text-[11px] text-slate-500 -mt-1 mb-2">
+              Si no quiere registrar el perfil completo, marque la superficie y su dureza acá.
+            </p>
+            <SuperficieGrid
+              value={form.tipoSuperficie}
+              onChange={(v) => setField('tipoSuperficie', v)}
+            />
+            <Label className="mt-3">Dureza de la superficie</Label>
+            <DurezaGrid value={form.dureza} onChange={(v) => setField('dureza', v)} />
 
             <Label className="mt-4">Temperatura de la superficie (°C) — opcional</Label>
             <NumberInput
@@ -326,15 +507,15 @@ export default function GlaciarReporteScreen({ onBack }) {
             />
           </Section>
 
-          {/* 4. PELIGROS */}
-          <Section num="4" title="Peligros observados" icon={<AlertCircle size={18} />}>
+          {/* 5. PELIGROS */}
+          <Section num="5" title="Peligros observados" icon={<AlertCircle size={18} />}>
             <p className="text-xs text-slate-400 mb-2">Marque todos los que vea.</p>
             <div className="grid grid-cols-2 gap-2">
               {PELIGROS.map((p) => (
                 <ChipBtn
                   key={p.key}
                   active={form.peligros.includes(p.key)}
-                  danger
+                  danger={p.key !== 'ninguno_evidente'}
                   onClick={() => togglePeligro(p.key)}
                 >
                   <span className="text-xl">{p.icon}</span>
@@ -342,10 +523,35 @@ export default function GlaciarReporteScreen({ onBack }) {
                 </ChipBtn>
               ))}
             </div>
+
+            {/* Matices que afinan la lógica de seguridad */}
+            <div className="mt-4 space-y-2">
+              <CheckRow
+                label="La ruta pasa por debajo de los séracs"
+                checked={form.rutaBajoSeracs}
+                onClick={() => toggleField('rutaBajoSeracs')}
+                icon={<ShieldAlert size={16} />}
+              />
+              <CheckRow
+                label="Penitentes densos / altos"
+                checked={form.penitentesDensos}
+                onClick={() => toggleField('penitentesDensos')}
+              />
+              <CheckRow
+                label="Pendiente pronunciada"
+                checked={form.pendientePronunciada}
+                onClick={() => toggleField('pendientePronunciada')}
+              />
+              <CheckRow
+                label="Nieve fresca en las últimas 24 h"
+                checked={form.nieveReciente24h}
+                onClick={() => toggleField('nieveReciente24h')}
+              />
+            </div>
           </Section>
 
-          {/* 5. CONDICIONES */}
-          <Section num="5" title="Condiciones y datos del guía" icon={<Thermometer size={18} />}>
+          {/* 6. CONDICIONES */}
+          <Section num="6" title="Condiciones y datos del guía" icon={<Thermometer size={18} />}>
             <Label>Temperatura ambiente (°C) — opcional</Label>
             <NumberInput
               value={form.tempAmbiente}
@@ -355,7 +561,7 @@ export default function GlaciarReporteScreen({ onBack }) {
             />
 
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-3">
-              <SelectField label="Nubosidad" value={form.nubosidad} onChange={(v) => setField('nubosidad', v)} options={NUBOSIDAD} />
+              <SelectField label="Cielo" value={form.cielo} onChange={(v) => setField('cielo', v)} options={CIELO} />
               <SelectField label="Viento" value={form.viento} onChange={(v) => setField('viento', v)} options={VIENTO} />
               <SelectField label="Visibilidad" value={form.visibilidad} onChange={(v) => setField('visibilidad', v)} options={VISIBILIDAD} />
             </div>
@@ -378,7 +584,7 @@ export default function GlaciarReporteScreen({ onBack }) {
             />
           </Section>
 
-          {/* Hora auto (informativa) */}
+          {/* Hora auto (informativa, obligatoria — afecta puentes de nieve) */}
           <p className="text-[11px] text-slate-500 text-center">
             Hora del reporte: {new Date().toLocaleString('es-CO')}
           </p>
@@ -401,9 +607,14 @@ export default function GlaciarReporteScreen({ onBack }) {
           </button>
           {!puedeGuardar && !saving && !savedOk && (
             <p className="text-[11px] text-slate-500 text-center -mt-2">
-              Capture ubicación, tipo de superficie y dureza para guardar.
+              {esBorde
+                ? 'Capture ubicación, montaña y la superficie del frente para guardar.'
+                : 'Capture ubicación, montaña, superficie y dureza para guardar.'}
             </p>
           )}
+
+          {/* Disclaimer + propósito */}
+          <DisclaimerBox />
         </main>
       ) : (
         <ListaReportes
@@ -438,7 +649,7 @@ function Section({ num, title, icon, children }) {
   return (
     <section className="bg-slate-900/40 border border-slate-800 rounded-2xl p-4">
       <h2 className="flex items-center gap-2 text-base font-bold text-slate-200 mb-3">
-        <span className="w-6 h-6 rounded-full bg-sky-500/20 text-sky-300 grid place-items-center text-sm font-black">
+        <span className="w-6 h-6 rounded-full bg-sky-500/20 text-sky-300 grid place-items-center text-sm font-black shrink-0">
           {num}
         </span>
         {icon}
@@ -481,6 +692,41 @@ function ChipBtn({ active, danger = false, onClick, children }) {
   );
 }
 
+function ToggleBtn({ active, onClick, icon, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center justify-center gap-2 p-3 rounded-xl border-2 text-sm font-bold transition active:scale-[0.98] ${
+        active ? 'bg-sky-900/30 border-sky-500 text-sky-100' : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
+      }`}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}
+
+function CheckRow({ label, checked, onClick, icon = null }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 p-3 rounded-xl border transition text-left active:scale-[0.99] ${
+        checked ? 'bg-amber-900/25 border-amber-600/60 text-amber-100' : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
+      }`}
+    >
+      <span className={`shrink-0 w-5 h-5 rounded grid place-items-center border ${
+        checked ? 'bg-amber-500 border-amber-500 text-slate-950' : 'border-slate-600'
+      }`}>
+        {checked && <CheckCircle2 size={14} />}
+      </span>
+      {icon}
+      <span className="text-sm leading-tight">{label}</span>
+    </button>
+  );
+}
+
 function NumberInput({ value, onChange, placeholder, icon }) {
   return (
     <div className="relative">
@@ -515,9 +761,136 @@ function SelectField({ label, value, onChange, options }) {
   );
 }
 
+/** Ayuda visual de la escala híbrida mano→piolet. */
+function EscalaDurezaAyuda() {
+  return (
+    <details className="rounded-xl bg-slate-900/60 border border-slate-700 p-3">
+      <summary className="cursor-pointer text-sm font-bold text-slate-300 flex items-center gap-2">
+        <Info size={16} className="text-sky-300" /> Cómo se mide la dureza (mano → piolet)
+      </summary>
+      <ul className="mt-2 space-y-1.5">
+        {ESCALA_DUREZA.map((d) => (
+          <li key={d.codigo} className="flex gap-2 text-xs">
+            <span className={`shrink-0 w-9 text-center font-mono font-black rounded ${
+              d.medio === 'piolet' ? 'text-indigo-300' : 'text-sky-300'
+            }`}>{d.codigo}</span>
+            <span className="text-slate-400">
+              <span className="font-bold text-slate-300">{d.label}:</span> {d.heuristica}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <p className="mt-2 text-[11px] text-slate-500">
+        F–K se prueban con la mano (fuerza moderada, 10–15 N). H1/H2 ya son hielo: la mano no entra,
+        se prueba con el piolet. No se convierte a un número de penetración: se guarda el grado.
+      </p>
+    </details>
+  );
+}
+
+/** Grilla de tipos de superficie con su implicación de seguridad. */
+function SuperficieGrid({ value, onChange }) {
+  return (
+    <div className="grid grid-cols-1 gap-2">
+      {TIPOS_SUPERFICIE.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          onClick={() => onChange(value === t.key ? '' : t.key)}
+          className={`flex items-start gap-3 p-3 rounded-xl border-2 transition active:scale-[0.99] text-left ${
+            value === t.key ? 'bg-sky-900/30 border-sky-500 text-sky-100' : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
+          }`}
+        >
+          <span className="text-2xl shrink-0">{t.icon}</span>
+          <span>
+            <span className="font-bold block leading-tight">{t.label}</span>
+            <span className="text-[11px] text-slate-400 leading-tight block">{t.seguridad}</span>
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Grilla de dureza por código (chips compactos). */
+function DurezaGrid({ value, onChange }) {
+  return (
+    <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
+      {ESCALA_DUREZA.map((d) => (
+        <button
+          key={d.codigo}
+          type="button"
+          onClick={() => onChange(value === d.codigo ? '' : d.codigo)}
+          title={d.heuristica}
+          className={`flex flex-col items-center justify-center py-2 rounded-xl border-2 transition active:scale-95 ${
+            value === d.codigo
+              ? d.medio === 'piolet'
+                ? 'bg-indigo-900/40 border-indigo-400 text-indigo-100'
+                : 'bg-sky-900/40 border-sky-400 text-sky-100'
+              : 'bg-slate-900 border-slate-700 text-slate-300 hover:bg-slate-800'
+          }`}
+        >
+          <span className="font-mono font-black text-base leading-none">{d.codigo}</span>
+          <span className="text-[9px] text-slate-400 leading-tight mt-0.5">{d.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Una fila del perfil por capas. */
+function CapaRow({ index, capa, esSuperficie, onChange, onRemove, removable }) {
+  return (
+    <div className="rounded-xl bg-slate-900/60 border border-slate-700 p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-bold text-slate-300">
+          Capa {index + 1}{esSuperficie ? ' · superficie (manda el tránsito)' : ''}
+        </span>
+        {removable && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="p-1 rounded-lg text-slate-500 hover:text-red-400 hover:bg-red-900/20 transition"
+            aria-label={`Quitar capa ${index + 1}`}
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
+      <input
+        type="text"
+        value={capa.profundidad}
+        onChange={(e) => onChange('profundidad', e.target.value)}
+        placeholder="Profundidad o rango (ej. 0–10 cm)"
+        className="w-full p-2.5 rounded-lg bg-slate-900 border border-slate-700 text-sm text-white outline-none focus:border-sky-500 mb-2"
+      />
+      <select
+        value={capa.tipoSuperficie}
+        onChange={(e) => onChange('tipoSuperficie', e.target.value)}
+        className="w-full p-2.5 rounded-lg bg-slate-900 border border-slate-700 text-sm text-white outline-none focus:border-sky-500 appearance-none mb-2"
+      >
+        <option value="">Tipo de superficie…</option>
+        {TIPOS_SUPERFICIE.map((t) => (
+          <option key={t.key} value={t.key}>{t.label}</option>
+        ))}
+      </select>
+      <select
+        value={capa.dureza}
+        onChange={(e) => onChange('dureza', e.target.value)}
+        className="w-full p-2.5 rounded-lg bg-slate-900 border border-slate-700 text-sm text-white outline-none focus:border-sky-500 appearance-none"
+      >
+        <option value="">Dureza…</option>
+        {ESCALA_DUREZA.map((d) => (
+          <option key={d.codigo} value={d.codigo}>{d.codigo} · {d.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
 function SeguridadBanner({ seguridad }) {
   return (
-    <div className={`rounded-2xl border-2 p-4 ${ESTADO_BG[seguridad.nivel]}`}>
+    <div className={`rounded-2xl border-2 p-4 ${ESTADO_BG[seguridad.nivel] || ESTADO_BG.precaucion}`}>
       <div className="flex items-center gap-3">
         <span className="text-3xl" aria-hidden="true">{seguridad.emoji}</span>
         <div>
@@ -535,6 +908,21 @@ function SeguridadBanner({ seguridad }) {
           ))}
         </ul>
       )}
+    </div>
+  );
+}
+
+function DisclaimerBox() {
+  return (
+    <div className="rounded-2xl bg-slate-900/60 border border-slate-700 p-4 space-y-2">
+      <p className="text-xs text-slate-300 flex gap-2">
+        <ShieldAlert size={16} className="text-amber-300 shrink-0 mt-0.5" />
+        <span>{DISCLAIMER}</span>
+      </p>
+      <p className="text-[11px] text-slate-500 flex gap-2">
+        <Info size={14} className="text-sky-300 shrink-0 mt-0.5" />
+        <span>{PROPOSITO}</span>
+      </p>
     </div>
   );
 }
@@ -571,7 +959,7 @@ function ListaReportes({ reportes, loading, onEliminar, onNuevo }) {
     <main className="px-4 pt-4 space-y-3 max-w-xl mx-auto">
       <p className="text-xs text-slate-500">
         {reportes.length} {reportes.length === 1 ? 'reporte guardado' : 'reportes guardados'} ·
-        repita el mismo punto GPS en el tiempo para ver el cambio.
+        repita el mismo punto fijo en el tiempo para ver el retroceso del frente.
       </p>
       {reportes.map((r) => (
         <ReporteCard key={r.id} reporte={r} onEliminar={() => onEliminar(r.id)} />
@@ -582,15 +970,17 @@ function ListaReportes({ reportes, loading, onEliminar, onNuevo }) {
 
 function ReporteCard({ reporte, onEliminar }) {
   const estado = reporte.estado || 'precaucion';
-  const sup = SUPERFICIE_BY_KEY[reporte.tipoSuperficie];
-  const dur = DUREZA_BY_VALOR[reporte.dureza];
-  // createdAt/fechaISO siempre los estampa el store al guardar; el 0 es solo
-  // un fallback defensivo (no usamos Date.now() en render — regla de pureza).
+  // Superficie/dureza a mostrar: lectura puntual o la capa superior.
+  const supKey = reporte.tipoSuperficie || reporte.capas?.[0]?.tipoSuperficie;
+  const durCod = reporte.dureza || reporte.capas?.[0]?.dureza;
+  const sup = SUPERFICIE_BY_KEY[supKey];
+  const dur = DUREZA_BY_CODIGO[durCod];
+  const montana = MONTANA_BY_KEY[reporte.montana];
   const fecha = reporte.fechaISO ? new Date(reporte.fechaISO) : new Date(reporte.createdAt || 0);
-  const emoji = estado === 'estable' ? '🟢' : estado === 'peligro' ? '🔴' : '🟡';
+  const emoji = ESTADO_EMOJI[estado] || '🟡';
 
   return (
-    <div className={`rounded-2xl border ${ESTADO_BG[estado]} overflow-hidden`}>
+    <div className={`rounded-2xl border ${ESTADO_BG[estado] || ESTADO_BG.precaucion} overflow-hidden`}>
       <div className="flex gap-3 p-3">
         {/* Miniatura */}
         <div className="shrink-0 w-20 h-20 rounded-xl bg-slate-800 overflow-hidden grid place-items-center">
@@ -603,7 +993,7 @@ function ReporteCard({ reporte, onEliminar }) {
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between gap-2">
             <span className="text-lg font-black flex items-center gap-1.5">
-              {emoji} <span className="text-sm">{estadoLabel(estado)}</span>
+              {emoji} <span className="text-sm">{ESTADOS_SEGURIDAD[estado]?.label || 'Precaución'}</span>
             </span>
             <button
               type="button"
@@ -618,9 +1008,13 @@ function ReporteCard({ reporte, onEliminar }) {
             {fecha.toLocaleString('es-CO', { dateStyle: 'medium', timeStyle: 'short' })}
           </p>
           <div className="flex flex-wrap gap-1.5 mt-1.5">
+            {montana && <Badge>{montana.libre ? (reporte.montanaLibre || 'Otra') : montana.label}</Badge>}
+            {reporte.puntoId && <Badge>📍 {reporte.puntoId}</Badge>}
             {sup && <Badge>{sup.icon} {sup.label}</Badge>}
-            {dur && <Badge>Dureza {dur.valor} · {dur.label}</Badge>}
+            {dur && <Badge>Dureza {dur.codigo} · {dur.label}</Badge>}
             {reporte.altitud != null && <Badge>{reporte.altitud} msnm</Badge>}
+            {reporte.azimutBrujula != null && <Badge>↗ {reporte.azimutBrujula}°</Badge>}
+            {reporte.pisoGlaciar === false && <Badge>🔵 borde</Badge>}
           </div>
           {reporte.lat != null && reporte.lng != null && (
             <p className="text-[11px] font-mono text-slate-500 mt-1">
@@ -631,14 +1025,19 @@ function ReporteCard({ reporte, onEliminar }) {
           {reporte.guia && <p className="text-[11px] text-slate-400 mt-0.5">Guía: {reporte.guia}</p>}
         </div>
       </div>
-      {Array.isArray(reporte.peligros) && reporte.peligros.length > 0 && (
+      {Array.isArray(reporte.peligros) && reporte.peligros.filter((p) => p !== 'ninguno_evidente').length > 0 && (
         <div className="px-3 pb-3 flex flex-wrap gap-1.5">
-          {reporte.peligros.map((p) => (
+          {reporte.peligros.filter((p) => p !== 'ninguno_evidente').map((p) => (
             <span key={p} className="text-[11px] px-2 py-0.5 rounded-full bg-red-900/30 text-red-200 border border-red-800/40">
               {(PELIGRO_BY_KEY[p]?.icon || '⚠️')} {PELIGRO_BY_KEY[p]?.label || p}
             </span>
           ))}
         </div>
+      )}
+      {Array.isArray(reporte.capas) && reporte.capas.length > 1 && (
+        <p className="px-3 pb-2 text-[11px] text-slate-500">
+          Perfil de {reporte.capas.length} capas registrado.
+        </p>
       )}
       {reporte.notas && (
         <p className="px-3 pb-3 text-xs text-slate-400 italic">“{reporte.notas}”</p>
@@ -663,8 +1062,8 @@ function numOrNull(v) {
   return Number.isFinite(n) ? n : null;
 }
 
-function estadoLabel(nivel) {
-  if (nivel === 'estable') return 'Estable';
-  if (nivel === 'peligro') return 'Peligro';
-  return 'Precaución';
+/** Hora local actual como número 0–23.999 (para la lógica de puentes de nieve). */
+function horaLocalAhora() {
+  const d = new Date();
+  return d.getHours() + d.getMinutes() / 60;
 }

--- a/src/components/__tests__/GlaciarReporteScreen.test.jsx
+++ b/src/components/__tests__/GlaciarReporteScreen.test.jsx
@@ -1,11 +1,12 @@
 /**
- * GlaciarReporteScreen — Reporte de Punto Glaciar (módulo demo, UI).
+ * GlaciarReporteScreen — Reporte de Punto Glaciar (v2 "escala creíble", UI).
  *
  * Contrato cubierto:
- *   - La pantalla monta y muestra los pasos (ubicación, foto, dureza, peligros).
+ *   - La pantalla monta y muestra los pasos (montaña, ubicación, dureza, peligros).
  *   - El estado de seguridad derivado reacciona al diagnóstico (🟢→🔴).
  *   - El botón Volver llama onBack.
- *   - Guardar está deshabilitado hasta tener ubicación + superficie + dureza.
+ *   - Guardar exige ubicación + montaña + superficie + dureza (modo pisado).
+ *   - El reporte persistido usa los códigos de dureza nuevos (F..H2) + montaña.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
@@ -20,9 +21,7 @@ vi.mock('../../hooks/useGeolocation', () => ({
 }));
 
 // Mock de PhotoCaptureField (no probamos la cámara acá).
-vi.mock('../PhotoCaptureField', () => ({
-  default: () => null,
-}));
+vi.mock('../PhotoCaptureField', () => ({ default: () => null }));
 
 // Mock del store IDB (no tocamos IndexedDB en el test de UI).
 const saveMock = vi.fn(() => Promise.resolve({ id: 'glaciar-test' }));
@@ -47,12 +46,26 @@ beforeEach(() => {
 });
 afterEach(() => cleanup());
 
+/** Selecciona la dureza puntual por su código (chip de la grilla). */
+function clickDureza(codigo) {
+  // Hay un select en el perfil de capas con el mismo texto; tomamos el botón.
+  const btns = screen.getAllByRole('button').filter((b) => b.textContent.startsWith(codigo));
+  fireEvent.click(btns[0]);
+}
+
+/** Selecciona un tipo de superficie en la grilla puntual (es un <button>,
+ *  el perfil por capas usa <option> con el mismo texto). */
+function clickSuperficie(label) {
+  const btn = screen.getAllByRole('button').find((b) => b.textContent.includes(label));
+  fireEvent.click(btn);
+}
+
 describe('GlaciarReporteScreen — montaje y pasos', () => {
   it('monta la pantalla con título y los pasos del reporte', () => {
     render(<GlaciarReporteScreen onBack={() => {}} />);
     expect(screen.getByText('Punto Glaciar')).toBeTruthy();
-    expect(screen.getByText(/Ubicación del punto/i)).toBeTruthy();
-    expect(screen.getByText(/Dureza del hielo/i)).toBeTruthy();
+    expect(screen.getByText(/Montaña y punto del frente/i)).toBeTruthy();
+    expect(screen.getAllByText(/Dureza del hielo/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Peligros observados/i)).toBeTruthy();
   });
 
@@ -68,31 +81,42 @@ describe('GlaciarReporteScreen — montaje y pasos', () => {
     expect(screen.getByText('Precaución')).toBeTruthy();
   });
 
-  it('marcar grietas abiertas pasa el estado a Peligro 🔴', () => {
+  it('marcar grietas abiertas pasa el estado a Peligro 🔴 vía override jerárquico', () => {
     render(<GlaciarReporteScreen onBack={() => {}} />);
-    fireEvent.click(screen.getByText(/Grietas abiertas/i));
+    // Hielo podrido como superficie puntual fuerza 🔴 siempre.
+    clickSuperficie('Hielo podrido (candle)');
     expect(screen.getByText('Peligro')).toBeTruthy();
   });
 
-  it('hielo compacto + dureza alta sin peligros → Estable 🟢', () => {
+  it('hielo de glaciar azul + H1 sin peligros → Estable 🟢', () => {
     render(<GlaciarReporteScreen onBack={() => {}} />);
-    fireEvent.click(screen.getByText('Hielo de glaciar (azul/compacto)'));
-    fireEvent.click(screen.getByText(/^Duro$/i)); // dureza 4
+    clickSuperficie('Hielo de glaciar (azul)');
+    clickDureza('H1');
     expect(screen.getByText('Estable')).toBeTruthy();
+  });
+
+  it('modo borde (no pisar) → estado Observación 🔵', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    fireEvent.click(screen.getByText(/Modo borde \(no pisar\)/i));
+    expect(screen.getByText('Observación')).toBeTruthy();
   });
 });
 
 describe('GlaciarReporteScreen — guardado', () => {
-  it('Guardar habilita tras capturar ubicación + superficie + dureza, y persiste', async () => {
+  it('Guardar habilita tras ubicación + montaña + superficie + dureza, y persiste códigos nuevos', async () => {
     render(<GlaciarReporteScreen onBack={() => {}} />);
+
+    // Montaña (requisito nuevo).
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[0], { target: { value: 'ruiz' } });
 
     // Capturar GPS.
     fireEvent.click(screen.getByRole('button', { name: /Capturar ubicación/i }));
     expect(requestMock).toHaveBeenCalled();
-    // Re-render con la posición inyectada: forzamos un cambio de estado tocando
-    // un campo, que re-evalúa el efecto de la posición.
-    fireEvent.click(screen.getByText('Hielo de glaciar (azul/compacto)'));
-    fireEvent.click(screen.getByText(/^Medio$/i)); // dureza 3
+
+    // Superficie puntual + dureza puntual.
+    clickSuperficie('Hielo de glaciar (azul)');
+    clickDureza('H1');
 
     await waitFor(() => {
       const btn = screen.getByRole('button', { name: /Guardar reporte/i });
@@ -102,9 +126,43 @@ describe('GlaciarReporteScreen — guardado', () => {
     fireEvent.click(screen.getByRole('button', { name: /Guardar reporte/i }));
     await waitFor(() => expect(saveMock).toHaveBeenCalled());
     const arg = saveMock.mock.calls[0][0];
-    expect(arg.tipoSuperficie).toBe('hielo_glaciar');
-    expect(arg.dureza).toBe(3);
+    expect(arg.tipoSuperficie).toBe('hielo_glaciar_azul');
+    expect(arg.dureza).toBe('H1');
+    expect(arg.montana).toBe('ruiz');
     expect(arg.estado).toBe('estable');
     expect(arg.lat).toBeCloseTo(4.81);
+    expect(arg.pisoGlaciar).toBe(true);
+  });
+
+  it('en modo borde guarda como observación sin exigir dureza', async () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[0], { target: { value: 'cocuy_ritacuba' } });
+    fireEvent.click(screen.getByText(/Modo borde \(no pisar\)/i));
+    fireEvent.click(screen.getByRole('button', { name: /Capturar ubicación/i }));
+    clickSuperficie('Hielo de glaciar (azul)');
+
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Guardar reporte/i });
+      expect(btn).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar reporte/i }));
+    await waitFor(() => expect(saveMock).toHaveBeenCalled());
+    const arg = saveMock.mock.calls[0][0];
+    expect(arg.pisoGlaciar).toBe(false);
+    expect(arg.estado).toBe('observacion');
+  });
+});
+
+describe('GlaciarReporteScreen — disclaimer', () => {
+  it('muestra el disclaimer de apoyo a la decisión', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    expect(screen.getByText(/prevalece el juicio del guía certificado/i)).toBeTruthy();
+  });
+
+  it('menciona el glaciar Conejeras (propósito de trazabilidad)', () => {
+    render(<GlaciarReporteScreen onBack={() => {}} />);
+    expect(screen.getByText(/Conejeras/i)).toBeTruthy();
   });
 });

--- a/src/data/glaciar-schema.js
+++ b/src/data/glaciar-schema.js
@@ -1,71 +1,228 @@
 /**
- * glaciar-schema.js — esquema PROVISIONAL del Reporte de Punto Glaciar.
+ * glaciar-schema.js — esquema del Reporte de Punto Glaciar (v2 "escala creíble").
  *
- * MVP demo para guías de glaciar (validación en campo). Todos los enums viven
- * acá para que sean fáciles de refinar con la investigación que corre en
- * paralelo. NO hardcodear estos valores en la pantalla: importar desde acá.
+ * Módulo para guías de glaciar (validación en campo, p. ej. Cocuy, Ruiz,
+ * Cordillera Blanca). Todos los enums viven acá para que sean fáciles de
+ * mantener. NO hardcodear estos valores en la pantalla: importar desde acá.
  *
  * Español Colombia (usted/tú, SIN voseo). Tono de campo, claro y corto.
  *
- * IMPORTANTE: este es un esquema provisional. La escala de dureza, los tipos
- * de superficie y los peligros se refinarán con fuentes glaciológicas
- * autoritativas. Mantener todo editable acá.
+ * FUENTES de la refinación (no citadas en UI, pero guían el diseño):
+ *   - Clasificación de dureza por dureza de mano (hand hardness test) +
+ *     extensión a hielo con piolet — ICSSG / UNESCO-IACS "International
+ *     Classification for Seasonal Snow on the Ground".
+ *   - Tipos de superficie y peligros — WGMS, IDEAM (monitoreo glaciares
+ *     Colombia), práctica de montañismo técnico (UIAGM/UIAA).
+ *
+ * NOTA sobre precisión: la prueba de dureza de mano (fuerza estándar 10–15 N)
+ * y la ramsonda NO se convierten entre sí. Guardamos método + valor cualitativo,
+ * NO inventamos un número de penetración en N. La capa SUPERIOR suele mandar el
+ * tránsito; las capas inferiores cuentan la historia del glaciar.
  *
  * @module data/glaciar-schema
  */
 
-/* ── Tipo de superficie del hielo/nieve ─────────────────────────────── */
-export const TIPOS_SUPERFICIE = [
-  { key: 'nieve_fresca', icon: '❄️', label: 'Nieve fresca' },
-  { key: 'firn', icon: '🌨️', label: 'Firn / nieve vieja' },
-  { key: 'hielo_glaciar', icon: '🧊', label: 'Hielo de glaciar (azul/compacto)' },
-  { key: 'hielo_podrido', icon: '💧', label: 'Hielo podrido (derretido)' },
-  { key: 'penitentes', icon: '🗻', label: 'Penitentes' },
-  { key: 'hielo_cubierto', icon: '🪨', label: 'Hielo cubierto (detritos)' },
-];
-
-/* ── Dureza del hielo (penetración de piolet/sonda, 1–5) ────────────── */
+/* ── Escala de dureza HÍBRIDA mano → piolet ─────────────────────────────
+ *
+ * Continuo de menos a más duro. Los 5 primeros grados son la prueba clásica
+ * de dureza de mano sobre nieve/firn (qué entra con fuerza moderada); los 2
+ * últimos (H1/H2) extienden la escala al hielo, donde la mano ya no entra y
+ * se prueba con la punta del piolet. El código (`F`, `4F`, …, `H2`) es el
+ * identificador estable que se guarda en el reporte.
+ */
 export const ESCALA_DUREZA = [
-  { valor: 1, label: 'Muy blando', desc: 'Nieve fresca, el piolet entra todo.', color: 'sky' },
-  { valor: 2, label: 'Blando', desc: 'Firn, poco esfuerzo.', color: 'cyan' },
-  { valor: 3, label: 'Medio', desc: 'Compacto, golpe firme.', color: 'amber' },
-  { valor: 4, label: 'Duro', desc: 'Hielo de glaciar, rebota.', color: 'orange' },
-  { valor: 5, label: 'Muy duro', desc: 'Hielo azul frío, casi no penetra.', color: 'blue' },
+  {
+    codigo: 'F',
+    orden: 1,
+    label: 'Puño',
+    medio: 'mano',
+    heuristica: 'Entra el puño con poca resistencia.',
+    desc: 'Nieve blanda / fresca. El puño penetra fácil.',
+    color: 'sky',
+  },
+  {
+    codigo: '4F',
+    orden: 2,
+    label: '4 dedos',
+    medio: 'mano',
+    heuristica: 'Entran cuatro dedos juntos.',
+    desc: 'Nieve asentada. Cuatro dedos penetran con fuerza moderada.',
+    color: 'cyan',
+  },
+  {
+    codigo: '1F',
+    orden: 3,
+    label: '1 dedo',
+    medio: 'mano',
+    heuristica: 'Entra un solo dedo.',
+    desc: 'Firn / nieve compacta. Un dedo penetra con fuerza moderada.',
+    color: 'teal',
+  },
+  {
+    codigo: 'P',
+    orden: 4,
+    label: 'Lápiz',
+    medio: 'mano',
+    heuristica: 'Solo entra la punta de un lápiz.',
+    desc: 'Firn duro / nieve muy compacta. Solo la punta de un lápiz penetra.',
+    color: 'amber',
+  },
+  {
+    codigo: 'K',
+    orden: 5,
+    label: 'Cuchillo',
+    medio: 'mano',
+    heuristica: 'Solo entra la hoja de un cuchillo.',
+    desc: 'Capa muy dura, borde de hielo. Solo la hoja de un cuchillo penetra.',
+    color: 'orange',
+  },
+  {
+    codigo: 'H1',
+    orden: 6,
+    label: 'Hielo blando',
+    medio: 'piolet',
+    heuristica: 'La mano NO entra; la punta del piolet penetra con un golpe firme y deja huella; el crampón patea fácil.',
+    desc: 'Hielo de glaciar trabajable. El piolet clava con un golpe; el crampón entra bien.',
+    color: 'blue',
+  },
+  {
+    codigo: 'H2',
+    orden: 7,
+    label: 'Hielo duro / azul',
+    medio: 'piolet',
+    heuristica: 'El piolet rebota o penetra poco y salta esquirla; al crampón le cuesta entrar.',
+    desc: 'Hielo azul frío y compacto. El piolet rebota; cuesta clavar crampón.',
+    color: 'indigo',
+  },
 ];
 
-/* ── Peligros observados (multi-select) ─────────────────────────────── */
+/** Códigos de dureza "blanda" (la mano todavía entra). Útil para reglas. */
+export const DUREZAS_BLANDAS = Object.freeze(['F', '4F']);
+/** Códigos de dureza de hielo (ya no entra la mano, se prueba con piolet). */
+export const DUREZAS_HIELO = Object.freeze(['H1', 'H2']);
+
+/* ── Tipo de superficie del hielo/nieve (7) ──────────────────────────────
+ * Cada tipo trae una implicación de seguridad corta (qué significa para el
+ * tránsito), no solo el nombre.
+ */
+export const TIPOS_SUPERFICIE = [
+  {
+    key: 'nieve_fresca',
+    icon: '❄️',
+    label: 'Nieve fresca',
+    desc: 'Nieve recién caída, sin asentar.',
+    seguridad: 'Oculta grietas y carga pendientes: ojo con avalancha y puentes débiles.',
+  },
+  {
+    key: 'firn_neve',
+    icon: '🌨️',
+    label: 'Firn / nieve vieja',
+    desc: 'Nieve vieja recristalizada (firn/névé), de varias temporadas.',
+    seguridad: 'Suele dar buen agarre en mañana fría; se ablanda con el sol.',
+  },
+  {
+    key: 'hielo_glaciar_azul',
+    icon: '🧊',
+    label: 'Hielo de glaciar (azul)',
+    desc: 'Hielo compacto, denso, a menudo azulado.',
+    seguridad: 'Firme pero duro: exige crampón y técnica; si es muy duro, resbala.',
+  },
+  {
+    key: 'hielo_podrido',
+    icon: '💧',
+    label: 'Hielo podrido (candle)',
+    desc: 'Hielo derretido, hueco, en columnas o panal (rotten/candle ice).',
+    seguridad: 'PELIGRO: no sostiene peso, colapsa sin aviso. Evitar.',
+  },
+  {
+    key: 'penitentes',
+    icon: '🗻',
+    label: 'Penitentes',
+    desc: 'Hojas/cuchillas de nieve-hielo formadas por el sol.',
+    seguridad: 'Tránsito lento y agotador; rompe el paso y esconde huecos.',
+  },
+  {
+    key: 'hielo_cubierto_detritos',
+    icon: '🪨',
+    label: 'Hielo cubierto (detritos)',
+    desc: 'Hielo bajo una capa de piedra/morrena.',
+    seguridad: 'Engaña: parece roca pero es hielo; roca suelta y huecos ocultos.',
+  },
+  {
+    key: 'hielo_sobreimpuesto',
+    icon: '🪟',
+    label: 'Hielo sobreimpuesto',
+    desc: 'Capa de hielo formada por agua de deshielo recongelada (superimposed ice).',
+    seguridad: 'Vidrioso y resbaladizo; agarre traicionero sobre la nieve.',
+  },
+];
+
+/* ── Peligros observados (multi-select) ──────────────────────────────────
+ * Cada peligro trae un campo `critico` (dispara 🔴 por sí solo o bajo
+ * condición) usado por la documentación; la lógica fina vive en
+ * services/glaciarSafety.js.
+ */
 export const PELIGROS = [
-  { key: 'grietas_cerradas', icon: '〰️', label: 'Grietas cerradas' },
   { key: 'grietas_abiertas', icon: '⚠️', label: 'Grietas abiertas' },
-  { key: 'puente_nieve', icon: '🌉', label: 'Puente de nieve' },
+  { key: 'grietas_con_puente_nieve', icon: '🌉', label: 'Grietas con puente de nieve' },
   { key: 'seracs', icon: '🏔️', label: 'Séracs' },
-  { key: 'agua_deshielo', icon: '💦', label: 'Agua de deshielo' },
-  { key: 'riesgo_avalancha', icon: '🏂', label: 'Riesgo de avalancha' },
+  { key: 'rimaya_bergschrund', icon: '🧗', label: 'Rimaya (bergschrund)' },
+  { key: 'puente_nieve_debil', icon: '🕳️', label: 'Puente de nieve débil' },
+  { key: 'agua_deshielo_superficial', icon: '💦', label: 'Agua de deshielo superficial' },
+  { key: 'hielo_podrido', icon: '💧', label: 'Hielo podrido' },
   { key: 'penitentes', icon: '🗻', label: 'Penitentes' },
+  { key: 'riesgo_avalancha', icon: '🏂', label: 'Riesgo de avalancha' },
+  { key: 'roca_suelta_sobre_hielo', icon: '🪨', label: 'Roca suelta sobre el hielo' },
+  { key: 'pendiente_pronunciada', icon: '⛰️', label: 'Pendiente pronunciada' },
+  { key: 'ninguno_evidente', icon: '✅', label: 'Ninguno evidente' },
 ];
 
-/* ── Condiciones del entorno (selects cortos) ───────────────────────── */
-export const NUBOSIDAD = [
+/* ── Condiciones del entorno (selects cortos) ───────────────────────────── */
+export const CIELO = [
   { key: 'despejado', label: 'Despejado' },
   { key: 'parcial', label: 'Parcialmente nublado' },
   { key: 'nublado', label: 'Nublado' },
-  { key: 'niebla', label: 'Niebla / sin visibilidad' },
+  { key: 'niebla', label: 'Niebla' },
+  { key: 'precipitacion', label: 'Precipitación' },
 ];
 
 export const VIENTO = [
   { key: 'calma', label: 'Calma' },
-  { key: 'brisa', label: 'Brisa' },
-  { key: 'fuerte', label: 'Viento fuerte' },
-  { key: 'rafagas', label: 'Ráfagas peligrosas' },
+  { key: 'moderado', label: 'Moderado' },
+  { key: 'fuerte', label: 'Fuerte' },
 ];
 
 export const VISIBILIDAD = [
   { key: 'buena', label: 'Buena' },
-  { key: 'regular', label: 'Regular' },
+  { key: 'media', label: 'Media' },
   { key: 'mala', label: 'Mala' },
 ];
 
-/* ── Estado de seguridad derivado (lógica en evaluarSeguridadGlaciar) ── */
+/* ── Montañas (selector) ─────────────────────────────────────────────────
+ * Colombia + Perú (Cordillera Blanca) + campo libre. `noPisar:true` marca los
+ * macizos donde está prohibido pisar el hielo (p. ej. PNN El Cocuy): el reporte
+ * por defecto va en "modo borde" (observación, no juicio de tránsito).
+ */
+export const MONTANAS = [
+  // Colombia
+  { key: 'cocuy_ritacuba', label: 'Cocuy / Ritacuba', pais: 'Colombia', noPisar: true },
+  { key: 'ruiz', label: 'Nevado del Ruiz', pais: 'Colombia' },
+  { key: 'tolima', label: 'Nevado del Tolima', pais: 'Colombia' },
+  { key: 'huila', label: 'Nevado del Huila', pais: 'Colombia' },
+  { key: 'santa_isabel', label: 'Santa Isabel', pais: 'Colombia' },
+  { key: 'sierra_nevada_santa_marta', label: 'Sierra Nevada de Santa Marta', pais: 'Colombia' },
+  // Perú — Cordillera Blanca
+  { key: 'yanapaccha', label: 'Yanapaccha', pais: 'Perú' },
+  { key: 'huascaran', label: 'Huascarán', pais: 'Perú' },
+  { key: 'pisco', label: 'Pisco', pais: 'Perú' },
+  { key: 'chopicalqui', label: 'Chopicalqui', pais: 'Perú' },
+  { key: 'tocllaraju', label: 'Tocllaraju', pais: 'Perú' },
+  { key: 'vallunaraju', label: 'Vallunaraju', pais: 'Perú' },
+  // Campo libre
+  { key: 'otra', label: 'Otra montaña…', pais: null, libre: true },
+];
+
+/* ── Estado de seguridad derivado (lógica en evaluarSeguridadGlaciar) ──── */
 export const ESTADOS_SEGURIDAD = {
   estable: {
     nivel: 'estable',
@@ -88,9 +245,30 @@ export const ESTADOS_SEGURIDAD = {
     desc: 'Condiciones inseguras. Considere no avanzar o buscar otra ruta.',
     color: 'red',
   },
+  observacion: {
+    nivel: 'observacion',
+    emoji: '🔵',
+    label: 'Observación',
+    desc: 'Reporte de borde sin pisar el hielo. Registro de estado y retroceso, no juicio de tránsito.',
+    color: 'sky',
+  },
 };
+
+/** Disclaimer fijo de la UI (apoyo a la decisión, no la reemplaza). */
+export const DISCLAIMER =
+  'El semáforo es un apoyo a la decisión, no la reemplaza: prevalece el juicio del guía certificado.';
+
+/** Micro-texto de propósito (educativo / trazabilidad). */
+export const PROPOSITO =
+  'Cada punto fijo en el tiempo es un dato. El glaciar Conejeras (Santa Isabel) se extinguió en 2024 tras 18 años de monitoreo: el reporte de un guía es exactamente ese tipo de registro.';
 
 /* Mapas key→meta para mostrar etiquetas en la lista/trazabilidad. */
 export const SUPERFICIE_BY_KEY = Object.fromEntries(TIPOS_SUPERFICIE.map((t) => [t.key, t]));
 export const PELIGRO_BY_KEY = Object.fromEntries(PELIGROS.map((p) => [p.key, p]));
-export const DUREZA_BY_VALOR = Object.fromEntries(ESCALA_DUREZA.map((d) => [d.valor, d]));
+export const DUREZA_BY_CODIGO = Object.fromEntries(ESCALA_DUREZA.map((d) => [d.codigo, d]));
+export const MONTANA_BY_KEY = Object.fromEntries(MONTANAS.map((m) => [m.key, m]));
+
+/* Helper: orden numérico de una dureza por su código (para comparaciones). */
+export function ordenDureza(codigo) {
+  return DUREZA_BY_CODIGO[codigo]?.orden ?? null;
+}

--- a/src/db/__tests__/farmProcessCache.test.js
+++ b/src/db/__tests__/farmProcessCache.test.js
@@ -13,8 +13,8 @@ import { validateFarmProcessEvent } from '../../types/farmProcess';
  */
 
 describe('farmProcessCache - Bug A: schema process_id (DB_VERSION vigente)', () => {
-  it('DB_VERSION es 21 (esquema vigente; v19 introdujo el indice process_id)', () => {
-    expect(DB_VERSION).toBe(21);
+  it('DB_VERSION es 23 (esquema vigente; v19 introdujo el indice process_id)', () => {
+    expect(DB_VERSION).toBe(23);
   });
 
   it('STORES.FARM_PROCESS_EVENTS existe', () => {

--- a/src/db/__tests__/glaciarReportes.test.js
+++ b/src/db/__tests__/glaciarReportes.test.js
@@ -125,4 +125,42 @@ describe('glaciarReportes store', () => {
     const got = await glaciarReportes.get('foto-1');
     expect(got.fotoDataUrl).toBe(dataUrl);
   });
+
+  it('persiste el perfil por capas y campos de trazabilidad del frente', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({
+      id: 'capas-1',
+      puntoId: 'RITACUBA-FRENTE-01',
+      capas: [
+        { profundidad: '0–10 cm', tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1' },
+        { profundidad: '10–40 cm', tipoSuperficie: 'firn_neve', dureza: 'P' },
+      ],
+      azimutBrujula: 135,
+      distanciaBordeHieloM: 12,
+      pisoGlaciar: true,
+      estado: 'estable',
+    });
+    const got = await glaciarReportes.get('capas-1');
+    expect(got.capas).toHaveLength(2);
+    expect(got.capas[0].dureza).toBe('H1');
+    expect(got.azimutBrujula).toBe(135);
+    expect(got.puntoId).toBe('RITACUBA-FRENTE-01');
+  });
+
+  it('getByPunto() agrupa la serie temporal del mismo punto fijo', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({ id: 'p1-a', puntoId: 'FRENTE-A', createdAt: 1000, estado: 'estable' });
+    await glaciarReportes.save({ id: 'p1-b', puntoId: 'FRENTE-A', createdAt: 3000, estado: 'precaucion' });
+    await glaciarReportes.save({ id: 'p2-a', puntoId: 'FRENTE-B', createdAt: 2000, estado: 'estable' });
+    const serie = await glaciarReportes.getByPunto('FRENTE-A');
+    // Ordenado del más reciente al más antiguo (hereda el orden de getAll).
+    expect(serie.map((r) => r.id)).toEqual(['p1-b', 'p1-a']);
+  });
+
+  it('getByPunto() sin id devuelve lista vacía', async () => {
+    const { glaciarReportes } = await import('../glaciarReportes');
+    await glaciarReportes.save({ id: 'x', puntoId: 'Z', estado: 'estable' });
+    expect(await glaciarReportes.getByPunto('')).toEqual([]);
+    expect(await glaciarReportes.getByPunto(null)).toEqual([]);
+  });
 });

--- a/src/db/dbCore.js
+++ b/src/db/dbCore.js
@@ -38,7 +38,7 @@
  */
 
 export const DB_NAME = 'ChagraDB';
-export const DB_VERSION = 22;
+export const DB_VERSION = 23;
 
 export const STORES = {
   ASSETS: 'assets',
@@ -380,6 +380,19 @@ export const openDB = async () => {
           store.createIndex('createdAt', 'createdAt', { unique: false });
           store.createIndex('estado', 'estado', { unique: false });
           store.createIndex('guia', 'guia', { unique: false });
+        }
+      }
+
+      // v23: índice `puntoId` en glaciar_reportes — trazabilidad del FRENTE del
+      // hielo. Un punto fijo (punto_id estable) repetido en el tiempo cuenta el
+      // retroceso del glaciar: agrupar todos los reportes del mismo punto.
+      // Migración aditiva (no toca registros existentes): solo agrega el índice.
+      if (event.oldVersion < 23) {
+        if (db.objectStoreNames.contains(STORES.GLACIAR_REPORTES)) {
+          const store = event.target.transaction.objectStore(STORES.GLACIAR_REPORTES);
+          if (!store.indexNames.contains('puntoId')) {
+            store.createIndex('puntoId', 'puntoId', { unique: false });
+          }
         }
       }
     };

--- a/src/db/glaciarReportes.js
+++ b/src/db/glaciarReportes.js
@@ -1,28 +1,44 @@
 /**
  * glaciarReportes.js — CRUD offline-first de reportes de puntos glaciares.
  *
- * Store: glaciar_reportes (ChagraDB v22)
- * Schema del registro:
+ * Store: glaciar_reportes (ChagraDB v23) — el reporte representa el FRENTE/BORDE
+ * del hielo (el punto que retrocede). Repetir el mismo `puntoId` en el tiempo
+ * = serie temporal del retroceso.
+ *
+ * Schema del registro (v2 "escala creíble"):
  *   {
  *     id,            // string único generado en cliente
+ *     puntoId,       // string ESTABLE del punto (repetible en el tiempo) | null
  *     createdAt,     // epoch ms
  *     fechaISO,      // ISO string (auto, hora local del reporte)
+ *     horaLocal,     // número 0–23.999 (hora local; afecta puentes de nieve)
  *     guia,          // nombre del guía (string)
- *     // Ubicación (GPS offline)
+ *     montana,       // key de MONTANAS | null
+ *     montanaLibre,  // texto si montana === 'otra'
+ *     pisoGlaciar,   // boolean — false => modo observación (borde)
+ *     // Ubicación (GPS offline) + trazabilidad climática
  *     lat, lng, altitud, precision,   // números | null
- *     // Diagnóstico
- *     tipoSuperficie,   // key de TIPOS_SUPERFICIE
- *     dureza,           // 1..5
+ *     distanciaBordeHieloM,           // número | null (desde hito fijo)
+ *     azimutBrujula,                  // grados 0–359 (dirección del disparo)
+ *     referenciaEncuadre,             // texto (repeat photography)
+ *     // Diagnóstico — perfil por CAPAS + lectura puntual rápida
+ *     capas,            // [{ profundidad, tipoSuperficie, dureza }] (la [0] = superficie)
+ *     tipoSuperficie,   // lectura puntual: key de TIPOS_SUPERFICIE
+ *     dureza,           // lectura puntual: código F..H2 (escala mano→piolet)
  *     tempSuperficie,   // °C | null
  *     peligros,         // string[] keys de PELIGROS
+ *     rutaBajoSeracs,   // boolean (séracs sobre la ruta)
+ *     penitentesDensos, // boolean
+ *     pendientePronunciada, // boolean
+ *     nieveReciente24h, // boolean
  *     // Condiciones
  *     tempAmbiente,     // °C | null
- *     nubosidad, viento, visibilidad,  // keys | null
+ *     cielo, viento, visibilidad,  // keys | null
  *     notas,            // texto libre
  *     // Foto (dataURL para sobrevivir recargas offline — NO blob URL)
  *     fotoDataUrl,      // string | null
  *     // Estado de seguridad derivado (cache de evaluarSeguridadGlaciar)
- *     estado,           // 'estable'|'precaucion'|'peligro'
+ *     estado,           // 'estable'|'precaucion'|'peligro'|'observacion'
  *     estadoRazones,    // string[]
  *   }
  *
@@ -78,6 +94,18 @@ export const glaciarReportes = {
       };
       req.onerror = () => reject(req.error);
     });
+  },
+
+  /**
+   * Devuelve todos los reportes de un mismo punto fijo (puntoId), del más
+   * reciente al más antiguo. Es la serie temporal del retroceso de ese punto.
+   * @param {string} puntoId
+   * @returns {Promise<object[]>}
+   */
+  async getByPunto(puntoId) {
+    if (!puntoId) return [];
+    const all = await this.getAll();
+    return all.filter((r) => r.puntoId === puntoId);
   },
 
   /**

--- a/src/services/__tests__/glaciarSafety.test.js
+++ b/src/services/__tests__/glaciarSafety.test.js
@@ -1,68 +1,191 @@
 /**
  * glaciarSafety.test.js — lógica pura del estado de seguridad de punto glaciar.
- * Casos 🟢 estable / 🟡 precaución / 🔴 peligro.
+ *
+ * v2 "escala creíble": escala de dureza mano→piolet (F..H2), perfil por capas,
+ * override jerárquico (el peor disparador gana), modo observación (borde).
+ *
+ * Casos: 🔵 observación / 🟢 estable / 🟡 precaución / 🔴 peligro.
  */
 import { describe, it, expect } from 'vitest';
 import { evaluarSeguridadGlaciar } from '../glaciarSafety';
 
-describe('evaluarSeguridadGlaciar', () => {
-  it('🔴 peligro cuando la superficie es hielo podrido', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_podrido', dureza: 4, peligros: [] });
+describe('evaluarSeguridadGlaciar — modo observación (borde)', () => {
+  it('🔵 observación cuando NO se pisó el hielo (pisoGlaciar=false)', () => {
+    const r = evaluarSeguridadGlaciar({
+      pisoGlaciar: false,
+      tipoSuperficie: 'hielo_podrido', // aunque haya disparador 🔴, observación manda
+      peligros: ['grietas_abiertas'],
+    });
+    expect(r.nivel).toBe('observacion');
+    expect(r.emoji).toBe('🔵');
+  });
+});
+
+describe('evaluarSeguridadGlaciar — 🔴 peligro', () => {
+  it('🔴 hielo podrido SIEMPRE (como tipo de superficie)', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_podrido', dureza: 'H2', peligros: [] });
     expect(r.nivel).toBe('peligro');
     expect(r.emoji).toBe('🔴');
-    expect(r.razones).toContain('Hielo podrido (derretido)');
+    expect(r.razones.some((x) => /podrido/i.test(x))).toBe(true);
   });
 
-  it('🔴 peligro cuando hay agua de deshielo', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: ['agua_deshielo'] });
+  it('🔴 hielo podrido en una capa profunda también dispara', () => {
+    const r = evaluarSeguridadGlaciar({
+      capas: [
+        { tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1' },
+        { tipoSuperficie: 'hielo_podrido', dureza: 'F' },
+      ],
+      peligros: [],
+    });
     expect(r.nivel).toBe('peligro');
   });
 
-  it('🔴 peligro cuando hay grietas abiertas', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 5, peligros: ['grietas_abiertas'] });
+  it('🔴 hielo podrido como peligro marcado', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: ['hielo_podrido'] });
     expect(r.nivel).toBe('peligro');
   });
 
-  it('🔴 peligro cuando hay puente de nieve', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn', dureza: 2, peligros: ['puente_nieve'] });
+  it('🔴 séracs SOLO si la ruta pasa por debajo', () => {
+    const bajo = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: ['seracs'], rutaBajoSeracs: true });
+    expect(bajo.nivel).toBe('peligro');
+    // séracs presentes pero la ruta NO pasa debajo → no es 🔴 por esa causa
+    const noBajo = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: ['seracs'], rutaBajoSeracs: false });
+    expect(noBajo.nivel).not.toBe('peligro');
+  });
+
+  it('🔴 grietas con puente de nieve + superficie blanda (≤4F)', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'firn_neve', dureza: '4F', peligros: ['grietas_con_puente_nieve'], horaLocal: 8,
+    });
     expect(r.nivel).toBe('peligro');
   });
 
-  it('🟡 precaución: firn blando con un peligro no crítico (grietas cerradas)', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn', dureza: 2, peligros: ['grietas_cerradas'] });
+  it('🔴 grietas con puente de nieve pasado el mediodía', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'firn_neve', dureza: '1F', peligros: ['grietas_con_puente_nieve'], horaLocal: 14,
+    });
+    expect(r.nivel).toBe('peligro');
+    expect(r.razones.some((x) => /mediodía/i.test(x))).toBe(true);
+  });
+
+  it('🔴 grietas con puente de nieve + nieve reciente 24h', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'firn_neve', dureza: 'P', peligros: ['grietas_con_puente_nieve'], horaLocal: 7, nieveReciente24h: true,
+    });
+    expect(r.nivel).toBe('peligro');
+  });
+
+  it('🔴 riesgo de avalancha con nieve fresca en pendiente', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'nieve_fresca', dureza: 'F', peligros: ['riesgo_avalancha'], pendientePronunciada: true,
+    });
+    expect(r.nivel).toBe('peligro');
+  });
+
+  it('🔴 penitentes densos', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'penitentes', dureza: 'P', peligros: ['penitentes'], penitentesDensos: true,
+    });
+    expect(r.nivel).toBe('peligro');
+  });
+
+  it('prioriza 🔴 sobre cualquier otra señal (override jerárquico)', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1',
+      peligros: ['hielo_podrido', 'agua_deshielo_superficial'],
+    });
+    expect(r.nivel).toBe('peligro');
+  });
+});
+
+describe('evaluarSeguridadGlaciar — 🟡 precaución', () => {
+  it('🟡 hielo azul con dureza H2 (muy duro, resbala)', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H2', peligros: [] });
     expect(r.nivel).toBe('precaucion');
     expect(r.emoji).toBe('🟡');
+  });
+
+  it('🟡 grietas con puente de nieve en mañana fría (<10:00) y superficie firme (≥1F)', () => {
+    const r = evaluarSeguridadGlaciar({
+      tipoSuperficie: 'firn_neve', dureza: '1F', peligros: ['grietas_con_puente_nieve'], horaLocal: 8,
+    });
+    expect(r.nivel).toBe('precaucion');
+    expect(r.razones.some((x) => /mañana fría/i.test(x))).toBe(true);
+  });
+
+  it('🟡 hielo cubierto de detritos', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_cubierto_detritos', dureza: 'H1', peligros: [] });
+    expect(r.nivel).toBe('precaucion');
+  });
+
+  it('🟡 agua de deshielo superficial', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: ['agua_deshielo_superficial'] });
+    expect(r.nivel).toBe('precaucion');
+  });
+
+  it('🟡 dureza F/4F sobre glaciar (superficie muy blanda)', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn_neve', dureza: 'F', peligros: [], horaLocal: 8 });
+    expect(r.nivel).toBe('precaucion');
     expect(r.razones.some((x) => /blanda/i.test(x))).toBe(true);
   });
 
-  it('🟡 precaución: hielo duro pero con peligro no crítico (penitentes)', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: ['penitentes'] });
+  it('🟡 cualquier otro peligro observado no crítico (rimaya)', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: ['rimaya_bergschrund'] });
     expect(r.nivel).toBe('precaucion');
   });
 
-  it('🟡 precaución: nieve fresca muy blanda sin peligros', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'nieve_fresca', dureza: 1, peligros: [] });
+  it('🟡 por falta de datos: superficie sin dureza ni peligros', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', peligros: [] });
     expect(r.nivel).toBe('precaucion');
+    expect(r.razones.some((x) => /dureza/i.test(x))).toBe(true);
   });
+});
 
-  it('🟢 estable: hielo compacto y duro (dureza 4) sin peligros', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: [] });
+describe('evaluarSeguridadGlaciar — 🟢 estable', () => {
+  it('🟢 firn/névé con dureza 1F sin peligros, mañana fría', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn_neve', dureza: '1F', peligros: [], horaLocal: 7 });
     expect(r.nivel).toBe('estable');
     expect(r.emoji).toBe('🟢');
   });
 
-  it('🟢 estable: dureza media (3) sin peligros', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_cubierto', dureza: 3, peligros: [] });
+  it('🟢 firn/névé con dureza P sin peligros, mañana fría', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'firn_neve', dureza: 'P', peligros: [], horaLocal: 6 });
     expect(r.nivel).toBe('estable');
   });
 
-  it('🟡 precaución por falta de datos: sin dureza ni peligros', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', peligros: [] });
+  it('🟢 hielo de glaciar azul con H1 sin grietas/séracs/agua', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: [] });
+    expect(r.nivel).toBe('estable');
+  });
+});
+
+describe('evaluarSeguridadGlaciar — perfil por capas', () => {
+  it('la capa SUPERIOR manda el tránsito (H2 arriba → precaución pese a H1 abajo)', () => {
+    const r = evaluarSeguridadGlaciar({
+      capas: [
+        { tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H2' },
+        { tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1' },
+      ],
+      peligros: [],
+    });
     expect(r.nivel).toBe('precaucion');
   });
 
+  it('capa superior H1 limpia → estable aunque haya firn debajo', () => {
+    const r = evaluarSeguridadGlaciar({
+      capas: [
+        { tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1' },
+        { tipoSuperficie: 'firn_neve', dureza: 'P' },
+      ],
+      peligros: [],
+    });
+    expect(r.nivel).toBe('estable');
+  });
+});
+
+describe('evaluarSeguridadGlaciar — robustez', () => {
   it('es pura: mismo input → mismo output', () => {
-    const input = { tipoSuperficie: 'hielo_glaciar', dureza: 4, peligros: ['penitentes'] };
+    const input = { tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H2', peligros: ['rimaya_bergschrund'] };
     expect(evaluarSeguridadGlaciar(input)).toEqual(evaluarSeguridadGlaciar(input));
   });
 
@@ -71,8 +194,8 @@ describe('evaluarSeguridadGlaciar', () => {
     expect(() => evaluarSeguridadGlaciar({})).not.toThrow();
   });
 
-  it('prioriza peligro crítico sobre estabilidad de hielo duro', () => {
-    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar', dureza: 5, peligros: ['seracs', 'grietas_cerradas'] });
-    expect(r.nivel).toBe('peligro');
+  it('"ninguno_evidente" no cuenta como peligro', () => {
+    const r = evaluarSeguridadGlaciar({ tipoSuperficie: 'hielo_glaciar_azul', dureza: 'H1', peligros: ['ninguno_evidente'] });
+    expect(r.nivel).toBe('estable');
   });
 });

--- a/src/services/glaciarSafety.js
+++ b/src/services/glaciarSafety.js
@@ -1,114 +1,297 @@
 /**
  * glaciarSafety.js — lógica PURA y testeable del estado de seguridad de un
- * punto glaciar a partir de un reporte de campo.
+ * punto glaciar a partir de un reporte de campo (v2 "escala creíble").
  *
- * Reglas PROVISIONALES (refinables con investigación glaciológica):
- *   🔴 PELIGRO   — hielo podrido (derretido) O agua de deshielo O grietas
- *                  abiertas O puente de nieve O séracs O riesgo de avalancha.
- *   🟡 PRECAUCIÓN — firn/nieve blando (dureza ≤ 2) con algún peligro, O
- *                  cualquier peligro presente que no sea de la lista crítica.
- *   🟢 ESTABLE   — hielo compacto/duro (dureza ≥ 3) sin peligros observados.
+ * Reglas de OVERRIDE JERÁRQUICO: el peor disparador gana. El orden de
+ * evaluación es: modo observación → 🔴 peligro → 🟡 precaución → 🟢 estable.
  *
- * La función es pura: mismo reporte → mismo estado. Sin efectos secundarios,
- * sin red, sin fecha/hora. Apta para tests deterministas y para correr
+ *   🔵 OBSERVACIÓN — si `pisoGlaciar === false` (modo borde, no se pisó el
+ *      hielo): se registra estado y retroceso, NO se emite juicio de tránsito.
+ *
+ *   🔴 PELIGRO:
+ *      - hielo podrido (tipo de superficie de cualquier capa O peligro) SIEMPRE.
+ *      - séracs SI la ruta pasa por debajo (rutaBajoSeracs).
+ *      - grietas con puente de nieve Y (dureza superficie ≤ 4F  O  hora > mediodía
+ *        O  nieve reciente en 24h).
+ *      - riesgo de avalancha con nieve fresca en pendiente.
+ *      - penitentes densos.
+ *
+ *   🟡 PRECAUCIÓN:
+ *      - hielo de glaciar azul con dureza H2.
+ *      - grietas con puente de nieve en mañana fría (hora < 10:00) y
+ *        superficie ≥ 1F (puente más firme, pero ojo).
+ *      - hielo cubierto de detritos.
+ *      - agua de deshielo superficial.
+ *      - dureza F/4F sobre glaciar (superficie muy blanda).
+ *      - cualquier otro peligro observado no crítico.
+ *
+ *   🟢 ESTABLE:
+ *      - firn/névé con dureza 1F–P sin peligros, mañana fría.
+ *      - hielo de glaciar azul con dureza H1 sin grietas/séracs/agua.
+ *
+ * La función es pura: mismo reporte → mismo estado. Sin red, sin Date.now()
+ * (la hora se pasa explícita). Apta para tests deterministas y para correr
  * offline en campo.
+ *
+ * Sobre la dureza por CAPAS: la capa SUPERIOR (la más somera) manda el
+ * tránsito. Si el reporte trae `capas`, usamos la dureza/superficie de la
+ * primera capa como "superficie". Una `lecturaPuntual` (superficie + dureza
+ * sueltas) sirve de respaldo si no hay capas.
  *
  * @module services/glaciarSafety
  */
 
-import { ESTADOS_SEGURIDAD } from '../data/glaciar-schema.js';
+import {
+  ESTADOS_SEGURIDAD,
+  DUREZAS_BLANDAS,
+  ordenDureza,
+} from '../data/glaciar-schema.js';
 
-/** Peligros que, por sí solos, fuerzan estado 🔴 peligro. */
-export const PELIGROS_CRITICOS = Object.freeze([
-  'grietas_abiertas',
-  'puente_nieve',
-  'seracs',
-  'agua_deshielo',
-  'riesgo_avalancha',
-]);
-
-/** Tipos de superficie que, por sí solos, fuerzan estado 🔴 peligro. */
+/** Tipos de superficie que, por sí solos (en cualquier capa), fuerzan 🔴. */
 export const SUPERFICIES_CRITICAS = Object.freeze(['hielo_podrido']);
 
-/** Dureza por debajo o igual a este umbral se considera "blanda". */
-export const DUREZA_BLANDA_MAX = 2;
+/** Peligros que fuerzan 🔴 de forma incondicional. */
+export const PELIGROS_CRITICOS_SIEMPRE = Object.freeze(['hielo_podrido']);
+
+/** Orden de la dureza "4F" — umbral de superficie blanda para puentes. */
+const ORDEN_4F = ordenDureza('4F'); // 2
+/** Orden de la dureza "1F" — superficie ya firme para puente en mañana fría. */
+const ORDEN_1F = ordenDureza('1F'); // 3
+
+/** Mediodía y "mañana fría" como horas locales (0–23.999). */
+const HORA_MEDIODIA = 12;
+const HORA_MANANA_FRIA = 10;
+
+/**
+ * Normaliza la "superficie de tránsito" del reporte: capa superior si hay
+ * perfil por capas, si no la lectura puntual / campos sueltos.
+ *
+ * @param {Object} reporte
+ * @returns {{tipoSuperficie: string|null, dureza: string|null,
+ *   tiposTodos: string[]}} superficie de tránsito + todos los tipos vistos.
+ */
+function superficieDeTransito(reporte) {
+  const capas = Array.isArray(reporte.capas) ? reporte.capas.filter(Boolean) : [];
+  const tiposTodos = [];
+
+  let tipoSuperficie = null;
+  let dureza = null;
+
+  if (capas.length > 0) {
+    // La primera capa es la más somera (superficie) → manda el tránsito.
+    tipoSuperficie = capas[0].tipoSuperficie || null;
+    dureza = capas[0].dureza || null;
+    for (const c of capas) if (c.tipoSuperficie) tiposTodos.push(c.tipoSuperficie);
+  }
+
+  // Lectura puntual / campos sueltos como respaldo o complemento.
+  if (!tipoSuperficie && reporte.tipoSuperficie) tipoSuperficie = reporte.tipoSuperficie;
+  if (!dureza && reporte.dureza) dureza = reporte.dureza;
+  if (reporte.tipoSuperficie) tiposTodos.push(reporte.tipoSuperficie);
+
+  return { tipoSuperficie, dureza, tiposTodos };
+}
+
+/**
+ * Extrae la hora local (0–23.999) del reporte. Acepta `horaLocal` numérica
+ * (horas), o `fechaISO` (de la que se toma la hora local del Date). Null si no
+ * se puede determinar.
+ *
+ * @param {Object} reporte
+ * @returns {number|null}
+ */
+function horaDelReporte(reporte) {
+  if (typeof reporte.horaLocal === 'number' && Number.isFinite(reporte.horaLocal)) {
+    return reporte.horaLocal;
+  }
+  if (typeof reporte.fechaISO === 'string') {
+    const d = new Date(reporte.fechaISO);
+    if (!Number.isNaN(d.getTime())) return d.getHours() + d.getMinutes() / 60;
+  }
+  return null;
+}
 
 /**
  * Evalúa el estado de seguridad de un punto glaciar.
  *
  * @param {Object} reporte
- * @param {string} [reporte.tipoSuperficie] - key de TIPOS_SUPERFICIE.
- * @param {number} [reporte.dureza] - 1..5 (escala de penetración).
+ * @param {Array<{tipoSuperficie?:string, dureza?:string}>} [reporte.capas]
+ *   Perfil por capas (la [0] es la superficie). Manda el tránsito.
+ * @param {string} [reporte.tipoSuperficie] - lectura puntual de superficie.
+ * @param {string} [reporte.dureza] - código de dureza (F..H2) puntual.
  * @param {string[]} [reporte.peligros] - keys de PELIGROS.
- * @param {string} [reporte.aguaDeshielo] - compat: si viene 'agua_deshielo'
- *   suelto, también cuenta (defensivo). Normalmente va dentro de `peligros`.
- * @returns {{nivel: 'estable'|'precaucion'|'peligro', emoji: string,
- *   label: string, desc: string, color: string, razones: string[]}}
+ * @param {boolean} [reporte.pisoGlaciar] - false → modo observación (borde).
+ * @param {boolean} [reporte.rutaBajoSeracs] - la ruta pasa bajo séracs.
+ * @param {boolean} [reporte.penitentesDensos] - penitentes densos/altos.
+ * @param {boolean} [reporte.pendientePronunciada] - pendiente pronunciada.
+ * @param {boolean} [reporte.nieveReciente24h] - nieve fresca en 24h.
+ * @param {number} [reporte.horaLocal] - hora local (0–23.999) del reporte.
+ * @param {string} [reporte.fechaISO] - alternativa para derivar la hora.
+ * @returns {{nivel: 'estable'|'precaucion'|'peligro'|'observacion',
+ *   emoji: string, label: string, desc: string, color: string,
+ *   razones: string[]}}
  */
 export function evaluarSeguridadGlaciar(reporte = {}) {
   const peligros = Array.isArray(reporte.peligros) ? reporte.peligros : [];
-  const tipoSuperficie = reporte.tipoSuperficie || null;
-  const durezaNum = Number(reporte.dureza);
-  const dureza = Number.isFinite(durezaNum) ? durezaNum : null;
+  const has = (k) => peligros.includes(k);
+  const { tipoSuperficie, dureza, tiposTodos } = superficieDeTransito(reporte);
+  const hora = horaDelReporte(reporte);
+  const nieveReciente = reporte.nieveReciente24h === true;
+  const ordenSup = dureza ? ordenDureza(dureza) : null;
 
-  const razones = [];
-
-  // ── 🔴 PELIGRO: superficie crítica ──
-  if (tipoSuperficie && SUPERFICIES_CRITICAS.includes(tipoSuperficie)) {
-    razones.push('Hielo podrido (derretido)');
-  }
-
-  // ── 🔴 PELIGRO: peligros críticos ──
-  const criticosPresentes = peligros.filter((p) => PELIGROS_CRITICOS.includes(p));
-  for (const p of criticosPresentes) razones.push(peligroLabel(p));
-
-  if (razones.length > 0) {
-    return { ...ESTADOS_SEGURIDAD.peligro, razones };
-  }
-
-  // A partir de acá NO hay peligros críticos ni superficie crítica.
-  const otrosPeligros = peligros.filter((p) => !PELIGROS_CRITICOS.includes(p));
-  const esBlando = dureza != null && dureza <= DUREZA_BLANDA_MAX;
-
-  // ── 🟡 PRECAUCIÓN: firn blando + algún peligro, o cualquier peligro ──
-  if (otrosPeligros.length > 0) {
-    const motivos = otrosPeligros.map(peligroLabel);
-    if (esBlando) motivos.unshift('Superficie blanda (firn/nieve)');
-    return { ...ESTADOS_SEGURIDAD.precaucion, razones: motivos };
-  }
-
-  // Sin peligros pero superficie blanda → precaución suave.
-  if (esBlando) {
+  // ── 🔵 OBSERVACIÓN: no se pisó el hielo (modo borde) ──
+  if (reporte.pisoGlaciar === false) {
     return {
-      ...ESTADOS_SEGURIDAD.precaucion,
-      razones: ['Superficie blanda (firn/nieve), sin peligros visibles'],
+      ...ESTADOS_SEGURIDAD.observacion,
+      razones: ['No se pisó el hielo: registro de borde para trazabilidad, sin juicio de tránsito.'],
     };
   }
 
-  // ── 🟢 ESTABLE: hielo compacto/duro (≥3) sin peligros ──
-  if (dureza != null && dureza >= 3) {
+  const razonesPeligro = [];
+
+  // ── 🔴 hielo podrido SIEMPRE (en cualquier capa o como peligro) ──
+  const hayPodrido =
+    tiposTodos.some((t) => SUPERFICIES_CRITICAS.includes(t)) ||
+    peligros.some((p) => PELIGROS_CRITICOS_SIEMPRE.includes(p));
+  if (hayPodrido) razonesPeligro.push('Hielo podrido: no sostiene peso, puede colapsar.');
+
+  // ── 🔴 séracs SI la ruta pasa por debajo ──
+  if (has('seracs') && reporte.rutaBajoSeracs === true) {
+    razonesPeligro.push('Séracs sobre la ruta: riesgo de colapso por encima.');
+  }
+
+  // ── 🔴 grietas con puente de nieve Y (sup ≤ 4F  O  hora > mediodía  O  nieve 24h) ──
+  if (has('grietas_con_puente_nieve')) {
+    const supBlanda = ordenSup != null && ordenSup <= ORDEN_4F;
+    const tarde = hora != null && hora > HORA_MEDIODIA;
+    if (supBlanda || tarde || nieveReciente) {
+      const causa = supBlanda
+        ? 'superficie blanda'
+        : tarde
+          ? 'pasado el mediodía (puentes se ablandan)'
+          : 'nieve reciente (24h)';
+      razonesPeligro.push(`Puente de nieve sobre grieta con ${causa}.`);
+    }
+  }
+
+  // ── 🔴 riesgo de avalancha con nieve fresca en pendiente ──
+  if (has('riesgo_avalancha')) {
+    const hayNieveFresca = nieveReciente || tiposTodos.includes('nieve_fresca');
+    const enPendiente = reporte.pendientePronunciada === true || has('pendiente_pronunciada');
+    if (hayNieveFresca && enPendiente) {
+      razonesPeligro.push('Riesgo de avalancha: nieve fresca sobre pendiente pronunciada.');
+    }
+  }
+
+  // ── 🔴 penitentes densos ──
+  if (reporte.penitentesDensos === true && (has('penitentes') || tiposTodos.includes('penitentes'))) {
+    razonesPeligro.push('Penitentes densos: tránsito inseguro y agotador.');
+  }
+
+  if (razonesPeligro.length > 0) {
+    return { ...ESTADOS_SEGURIDAD.peligro, razones: razonesPeligro };
+  }
+
+  // A partir de acá NO hay disparadores 🔴.
+  const razonesPrecaucion = [];
+
+  // ── 🟡 hielo azul con dureza H2 ──
+  if (tipoSuperficie === 'hielo_glaciar_azul' && dureza === 'H2') {
+    razonesPrecaucion.push('Hielo azul muy duro (H2): cuesta clavar, resbala.');
+  }
+
+  // ── 🟡 grietas con puente de nieve en mañana fría (<10:00) y sup ≥ 1F ──
+  if (has('grietas_con_puente_nieve')) {
+    const mananaFria = hora != null && hora < HORA_MANANA_FRIA;
+    const supFirme = ordenSup != null && ordenSup >= ORDEN_1F;
+    if (mananaFria && supFirme) {
+      razonesPrecaucion.push('Puente de nieve sobre grieta en mañana fría: firme, pero vigile.');
+    }
+  }
+
+  // ── 🟡 hielo cubierto de detritos ──
+  if (tiposTodos.includes('hielo_cubierto_detritos')) {
+    razonesPrecaucion.push('Hielo cubierto de detritos: huecos y roca suelta ocultos.');
+  }
+
+  // ── 🟡 agua de deshielo superficial ──
+  if (has('agua_deshielo_superficial')) {
+    razonesPrecaucion.push('Agua de deshielo en superficie: hielo debilitándose.');
+  }
+
+  // ── 🟡 dureza F/4F sobre glaciar (superficie muy blanda) ──
+  if (dureza && DUREZAS_BLANDAS.includes(dureza)) {
+    razonesPrecaucion.push('Superficie muy blanda (la mano entra): cuidado con puentes y carga.');
+  }
+
+  // ── 🟡 otros peligros observados no contemplados arriba ──
+  for (const p of peligros) {
+    if (p === 'ninguno_evidente') continue;
+    if (
+      p === 'grietas_con_puente_nieve' || // ya manejado
+      p === 'hielo_podrido' || // ya 🔴
+      p === 'agua_deshielo_superficial' // ya manejado
+    ) continue;
+    razonesPrecaucion.push(peligroLabel(p));
+  }
+
+  if (razonesPrecaucion.length > 0) {
+    // De-duplicar conservando orden.
+    const razones = [...new Set(razonesPrecaucion)];
+    return { ...ESTADOS_SEGURIDAD.precaucion, razones };
+  }
+
+  // ── 🟢 ESTABLE: condiciones limpias ──
+  const mananaFria = hora == null || hora < HORA_MANANA_FRIA;
+
+  // firn/névé con dureza 1F–P sin peligros, mañana fría.
+  const firnFirme =
+    tipoSuperficie === 'firn_neve' &&
+    ordenSup != null &&
+    ordenSup >= ORDEN_1F &&
+    ordenSup <= ordenDureza('P');
+  if (firnFirme && mananaFria) {
     return {
       ...ESTADOS_SEGURIDAD.estable,
-      razones: ['Hielo compacto y duro, sin peligros observados'],
+      razones: ['Firn firme en mañana fría, sin peligros: buen agarre.'],
     };
   }
 
-  // Sin dureza registrada y sin peligros: precaución por falta de datos
-  // (no podemos afirmar que es estable sin medir el hielo).
+  // hielo de glaciar azul con H1 sin grietas/séracs/agua.
+  if (tipoSuperficie === 'hielo_glaciar_azul' && dureza === 'H1') {
+    return {
+      ...ESTADOS_SEGURIDAD.estable,
+      razones: ['Hielo trabajable (H1) sin peligros: clava bien el crampón.'],
+    };
+  }
+
+  // Sin dureza registrada → no podemos afirmar estabilidad.
+  if (!dureza) {
+    return {
+      ...ESTADOS_SEGURIDAD.precaucion,
+      razones: ['Falta medir la dureza del hielo para confirmar el estado.'],
+    };
+  }
+
+  // Caso limpio genérico (con dureza, sin peligros ni disparadores).
   return {
-    ...ESTADOS_SEGURIDAD.precaucion,
-    razones: ['Falta medir la dureza del hielo para confirmar el estado'],
+    ...ESTADOS_SEGURIDAD.estable,
+    razones: ['Superficie medida y sin peligros observados.'],
   };
 }
 
 const PELIGRO_LABELS = {
-  grietas_cerradas: 'Grietas cerradas',
-  grietas_abiertas: 'Grietas abiertas',
-  puente_nieve: 'Puente de nieve',
-  seracs: 'Séracs',
-  agua_deshielo: 'Agua de deshielo',
-  riesgo_avalancha: 'Riesgo de avalancha',
-  penitentes: 'Penitentes',
+  grietas_abiertas: 'Grietas abiertas.',
+  grietas_con_puente_nieve: 'Grietas con puente de nieve.',
+  seracs: 'Séracs cerca.',
+  rimaya_bergschrund: 'Rimaya (bergschrund).',
+  puente_nieve_debil: 'Puente de nieve débil.',
+  agua_deshielo_superficial: 'Agua de deshielo superficial.',
+  hielo_podrido: 'Hielo podrido.',
+  penitentes: 'Penitentes.',
+  riesgo_avalancha: 'Riesgo de avalancha.',
+  roca_suelta_sobre_hielo: 'Roca suelta sobre el hielo.',
+  pendiente_pronunciada: 'Pendiente pronunciada.',
 };
 
 function peligroLabel(key) {


### PR DESCRIPTION
## Qué refina

Refina el módulo **Reporte de Punto Glaciar** (PR #1540) a la versión científicamente creíble que un guía real va a validar en campo. **No rehace** el módulo base: lo refina sobre los mismos archivos (`GlaciarReporteScreen.jsx`, `glaciar-schema.js`, `glaciarSafety.js`, `glaciarReportes.js`, ruta `#glaciar` + banner DashboardLive intactos).

Base en investigación glaciológica con fuentes: ICSSG/UNESCO-IACS (clasificación de nieve/firn), IDEAM (monitoreo glaciares Colombia), WGMS, práctica de montañismo técnico (UIAGM/UIAA).

## Cambios

1. **Escala de dureza HÍBRIDA mano → piolet** (reemplaza la 1–5): `F` (puño), `4F`, `1F`, `P` (lápiz), `K` (cuchillo), `H1` (hielo blando — la punta del piolet penetra con un golpe firme), `H2` (hielo duro/azul — el piolet rebota / salta esquirla). Cada grado con heurística. **No se inventa** un número de penetración en N (hand-test y ramsonda no se convierten): se guarda método + grado cualitativo.

2. **Perfil por CAPAS**: filas profundidad + tipo de superficie + dureza, agregar/quitar capas (superficie → firn → hielo). **La capa superior manda el tránsito**. Más una **lectura puntual rápida** de la superficie.

3. **7 tipos de superficie** con implicación de seguridad: `nieve_fresca`, `firn_neve`, `hielo_glaciar_azul`, `hielo_podrido` (candle, peligro), `penitentes`, `hielo_cubierto_detritos`, `hielo_sobreimpuesto`.

4. **Enfoque FRENTE DEL HIELO**: `puntoId` estable (repetir = trazar retroceso), `distanciaBordeHieloM` desde hito fijo. Lista enmarca la repetición temporal.

5. **Trazabilidad climática / repeat photography**: `azimutBrujula` (dirección de disparo), `referenciaEncuadre`, `pisoGlaciar`.

6. **Peligros ampliados** (multi, incl. ninguno_evidente) + **condiciones** (cielo, viento, visibilidad, nieve_reciente_24h) + hora local automática (afecta puentes de nieve).

7. **Selector de montañas**: Colombia (Cocuy/Ritacuba, Ruiz, Tolima, Huila, Santa Isabel, Sierra Nevada de Santa Marta) + Perú Cordillera Blanca (Yanapaccha, Huascarán, Pisco, Chopicalqui, Tocllaraju, Vallunaraju) + campo libre. **Modo borde (no pisar)** — Cocuy marcado `noPisar`: `pisoGlaciar=false` → estado **Observación 🔵** (no juicio de tránsito).

8. **Lógica de seguridad con override jerárquico** (el peor disparador gana): 🔴 hielo podrido siempre, séracs si la ruta pasa debajo, puente de nieve + (superficie ≤4F o pasado el mediodía o nieve 24h), avalancha + nieve fresca + pendiente, penitentes densos. 🟡 hielo azul H2, puente en mañana fría firme, detritos, agua de deshielo, dureza F/4F. 🟢 firn 1F–P mañana fría limpia, hielo H1 sin grietas/séracs/agua.

9. **Disclaimer** ("el semáforo es apoyo a la decisión, no la reemplaza; prevalece el juicio del guía certificado") + **propósito** (glaciar Conejeras extinto en 2024).

## Offline-first / DB

- Mantiene offline-first. Reporte ampliado con los nuevos campos.
- **DB v22 → v23**: migración aditiva (índice `puntoId` para serie temporal del retroceso) + helper `getByPunto()`. No toca registros existentes.

## TDD / calidad

- **glaciarSafety**: 26 tests — 🔴 hielo podrido (tipo y capa profunda y peligro), 🔴 puente+tarde/blando/nieve24h, 🔴 séracs solo bajo ruta, 🟢 firn mañana fría, 🟢 hielo H1, modo observación, perfil por capas (capa superior manda).
- **store**: 12 tests — perfil por capas + trazabilidad + `getByPunto`.
- **UI**: 10 tests — modo borde → Observación, disclaimer, Conejeras, códigos de dureza nuevos.
- `npx eslint <archivos tocados> --max-warnings=0` → **0 errores**. (Los ~22 errores de `npm run lint` viven en archivos ajenos no tocados — pre-existentes.)
- `npm run build` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)