### PR TITLE
docs(catalog): higiene de cifras públicas a las reales (263 sp / 36 bio / 68 fuentes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Chagra is an offline-first Progressive Web App (PWA) built for field operations 
 | Captura de datos agroecológica respetando policultivos, estratos y biodiversidad.                    | Agroecological data capture that respects polyculture, strata, and biodiversity.                       |
 | Idioma colombiano (sumercé, mijo, mi llave, panita) en lugar de español neutro de Madrid.            | Colombian Spanish vocabulary (regional greetings) instead of neutral peninsular Spanish.               |
 | IA local con vocabulario rural — agente offline-friendly que no asume cobertura.                     | Local AI with rural vocabulary — offline-friendly agent that does not assume connectivity.             |
-| Catálogo agroecológico Colombia validado (600 especies, 30 plagas, 20 biopreparados ICA/Agrosavia).  | Validated Colombian agroecological catalog (600 species, 30 pests, 20 ICA/Agrosavia bio-preparations). |
+| Catálogo agroecológico Colombia validado (263 especies, 36 biopreparados, 68 fuentes ICA/Agrosavia).  | Validated Colombian agroecological catalog (263 species, 36 bio-preparations, 68 ICA/Agrosavia sources). |
 
 ---
 

--- a/catalog/.zenodo.json
+++ b/catalog/.zenodo.json
@@ -1,5 +1,5 @@
 {
-  "title": "Chagra Catálogo Agroecológico Colombiano v3.1 — 175 especies + 54 fuentes",
+  "title": "Chagra Catálogo Agroecológico Colombiano — 263 especies + 68 fuentes (subset OSS v3.2)",
   "description": "Catálogo agroecológico estructurado para la PWA Chagra, con especies cultivables, invasoras, nativas y endémicas referenciables para el contexto rural colombiano (4 pisos térmicos: páramo, frío, templado, cálido). Incluye trazabilidad de fuentes científicas Tier A/B/C (GBIF, POWO Kew, Agrosavia, IAvH, FAO EcoCrop, Cenicafé, Restrepo Rivera, Cultivos Andinos Subexplotados NRC 1989, entre otras). Schema v3.1 con campos botánicos, agronómicos, ecológicos, etnobotánicos y normativos colombianos. Driver estratégico: evidencia documental para proceso delimitación páramo Cruz Verde-Sumapaz (MinAmbiente Colombia). Licencia AGPL-3.0 para código + CC-BY-SA 4.0 para datos catalográficos (atribución obligatoria: 'Chagra catálogo, Guatoc, v3.1, 2026').",
   "creators": [
     {

--- a/catalog/CITATION.cff
+++ b/catalog/CITATION.cff
@@ -34,7 +34,7 @@ identifiers:
     value: "https://chagra.guatoc.co"
 preferred-citation:
   type: dataset
-  title: "Chagra Catálogo Agroecológico Colombiano v3.1 — 175 especies + 54 fuentes"
+  title: "Chagra Catálogo Agroecológico Colombiano — 263 especies + 68 fuentes (subset OSS v3.2)"
   authors:
     - family-names: Guerrero
       given-names: Miguel

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -9,8 +9,9 @@
 | Archivo | Rol |
 |---------|-----|
 | `schema-v3.1.json` | JSON Schema draft-07 con definición formal de `species`, `biopreparado`, `source` |
-| `chagra-catalog-seed-v3.1.json` | **Subset OSS público (50 species)** — consumido por la PWA via `npm run build:catalog` → `public/catalog.sqlite`. Es un subset estricto del catálogo full curado. |
-| `chagra-catalog-oss-subset-v3.1.json` | Snapshot histórico del primer subset OSS (cobertura multi-piso térmico, generado por `scripts/extract-oss-subset.mjs` el 2026-05-20). Preservado por trazabilidad. |
+| `chagra-catalog-oss-subset-v3.2.json` | **Subset OSS público (263 species, 36 biopreparados, 68 fuentes)** — el archivo que **realmente** consume la PWA via `npm run build:catalog` → `public/catalog.sqlite` (es el `DEFAULT_SEED` en `scripts/build-catalog-sqlite.mjs`). |
+| `chagra-catalog-seed-v3.1.json` | Catálogo fuente (formato v3.1) del cual se extrae el subset OSS via `scripts/extract-oss-subset-v32.mjs`. El corpus full curado vive en el repo privado hermano; en este repo público se conserva la base referenciada por los scripts de validación/ETL. |
+| `chagra-catalog-oss-subset-v3.1.json` | Snapshot histórico del primer subset OSS (50 species, cobertura multi-piso térmico, generado por `scripts/extract-oss-subset.mjs` el 2026-05-20). Deprecado tras el revert PR #1012; preservado por trazabilidad y como ruta de rollback. |
 | `chagra-catalog-seed-v3.0.json` | Versión histórica preservada (referencia para `migrate-v30-to-v31.mjs`) |
 | `biopreparados-seed.json` | Catálogo de biopreparados agroecológicos |
 | `sources-seed.json` | Fuentes científicas referenciadas por `species[].source_ids` |
@@ -19,21 +20,15 @@
 
 ### Subset OSS vs catálogo full
 
-Desde 2026-05-23 (cutover step 2, ADR-024) el `chagra-catalog-seed-v3.1.json` que vive aquí es un **subset curado de ~50 species** apto para divulgación pública bajo CC-BY-NC-SA 4.0. El catálogo **full** (~495 species, con curaduría editorial diferencial: variedades ICA detalladas, endemismos paramunos, cultivares específicos) vive en repo privado hermano y se aplica solo en modo Pro (`CHAGRA_TIER=PRO`, contractual).
+Desde 2026-05-23 (cutover step 2, ADR-024) lo que se publica bajo CC-BY-NC-SA 4.0 es un **subset curado**. El catálogo **full** (con curaduría editorial diferencial: variedades ICA detalladas, endemismos paramunos, cultivares específicos) vive en repo privado hermano y se aplica solo en modo Pro (`CHAGRA_TIER=PRO`, contractual).
 
-Composición del subset OSS (50 species, criterio editorial-v2):
+El subset que **realmente ships** y compila a `public/catalog.sqlite` es `chagra-catalog-oss-subset-v3.2.json`:
 
-| Categoría editorial | Count |
-|---------------------|------:|
-| Cultivos comerciales colombianos | 12 |
-| Árboles de sombra (companions café) | 8 |
-| Medicinales tradicionales | 8 |
-| Leguminosas / abonos verdes | 6 |
-| Invasoras prioritarias (valor pedagógico de advertencia) | 6 |
-| Hortalizas básicas | 5 |
-| Species especiales (demos: quinoa, amaranto, chía, uchuva, mora) | 5 |
+- **263 species** — curación inicial top-uso (205 species, criterio intelligence-first, ver `SUBSET_OSS_V3.2_RATIONALE.md`) + enriquecimiento de páramo Cruz Verde (58 species, 2026-06-10, ver `_paramo_enrichment` en el JSON).
+- **36 biopreparados** — `biopreparados-seed.json` queda íntegro en OSS (decisión 2026-05-23, valor pedagógico inmediato, sin curaduría editorial Pro diferencial).
+- **68 fuentes** científicas referenciadas.
 
-`biopreparados-seed.json` **queda íntegro en OSS** (36 biopreparados públicos — decisión 2026-05-23, valor pedagógico inmediato + sin curaduría editorial Pro diferencial).
+El primer subset OSS (`chagra-catalog-oss-subset-v3.1.json`, 50 species, criterio editorial-v2) cortaba species críticas (aguacate, tomate, lechuga, acelga) y fue revertido en PR #1012; se conserva solo como snapshot histórico / rollback.
 
 Para reconstruir el subset desde el full Pro (idempotente):
 
@@ -81,13 +76,13 @@ Las contribuciones externas vía PR DEBEN venir con `validation_level: claude_dr
 
 Al usar, modificar o redistribuir este catálogo, cite:
 
-> Chagra (2026). Chagra species catalog v3.1 (OSS subset 50 species). CC-BY-NC-SA 4.0. https://github.com/guatoc-ecohub/Chagra
+> Chagra (2026). Chagra species catalog v3.2 (OSS subset, 263 species). CC-BY-NC-SA 4.0. https://github.com/guatoc-ecohub/Chagra
 
 ## Boundary OSS / Pro
 
 Este catálogo (capas 1-2 de ADR-026) es **OSS público**. Los componentes Pro (catálogo full ~495 species, gremios receta curados, planes nutrición optimizados, casos exitosos documentados, presets certificación) viven en repo privado hermano `chagra-pro`, NO aquí. Específicamente:
 
-- Subset OSS (50 species) → este repo, `chagra-catalog-seed-v3.1.json`.
+- Subset OSS (263 species) → este repo, `chagra-catalog-oss-subset-v3.2.json` (compila a `public/catalog.sqlite`).
 - Catálogo full (~495 species) → repo privado, `data/catalog/chagra-catalog-full-v3.1.json`. Diferencial editorial: variedades ICA detalladas, endemismos paramunos (Espeletia, Aragoa, Diplostephium), cultivares con curaduría profunda.
 - `biopreparados-seed.json` → este repo (decisión 2026-05-23, queda OSS por valor pedagógico inmediato).
 

--- a/catalog/SUBSET_OSS_V3.2_RATIONALE.md
+++ b/catalog/SUBSET_OSS_V3.2_RATIONALE.md
@@ -1,10 +1,19 @@
-# Subset OSS v3.2 — 105 species top-uso curadas
+# Subset OSS v3.2 — subset top-uso curado
+
+> **Actualización 2026-06-14 (estado real shipped):** este documento describe la
+> **curación inicial de 105 species** (2026-05-24). El archivo que hoy ships en
+> `chagra-catalog-oss-subset-v3.2.json` → `public/catalog.sqlite` tiene **263
+> species**: la curación de aquí más enriquecimientos posteriores (notablemente
+> +58 species de páramo Cruz Verde el 2026-06-10, ver `_paramo_enrichment` en el
+> JSON). Las tablas de inventario más abajo reflejan la composición original de
+> las 105, no el total actual. Conteo autoritativo = `species[]` del JSON +
+> `_subset_meta` reconciliado.
 
 **Fecha**: 2026-05-24  
 **Reemplaza**: chagra-catalog-oss-subset-v3.1.json (50 species, deprecado tras revert PR #1012)  
-**Fuente**: chagra-catalog-seed-v3.1.json (495 species full, ahora reservado para chagra-pro)  
+**Fuente**: chagra-catalog-seed-v3.1.json (corpus full reservado para chagra-pro)  
 **Licencia**: CC-BY-NC-SA 4.0  
-**Generador**: scripts/extract-oss-subset-v32.mjs (determinístico)
+**Generador**: scripts/extract-oss-subset-v32.mjs (determinístico) + enrich-oss-paramo-cruz-verde.mjs (páramo)
 
 ## Contexto
 
@@ -38,7 +47,7 @@ El subset v3.1 (50 species, PR #1011) cortó species críticas — aguacate, tom
 | ornamentales_nativas | 2 | Páramo emblemático — frailejón mayor. Identificación + valor cultural. |
 | abonos_verdes_coberturas | 1 | Cobertura/abono verde — aliso andino (N-fixer). |
 
-**Total**: 105 species, 36 biopreparados, 68 sources.
+**Total (curación inicial)**: 105 species, 36 biopreparados, 68 sources. **Total shipped actual** (tras enriquecimiento páramo 2026-06-10): **263 species**, 36 biopreparados, 68 sources.
 
 ## Lista completa
 

--- a/catalog/chagra-catalog-oss-subset-v3.2.json
+++ b/catalog/chagra-catalog-oss-subset-v3.2.json
@@ -25,14 +25,14 @@
   "generated_at": "2026-05-25T23:11:20.222Z",
   "generated_by": "scripts/extract-oss-subset-v32.mjs",
   "_subset_meta": {
-    "subset_name": "oss-subset-105",
+    "subset_name": "oss-subset-263",
     "subset_version": "v3.2",
     "source_file": "chagra-catalog-seed-v3.1.json",
-    "species_count": 204,
+    "species_count": 263,
     "sources_count": 68,
     "biopreparados_count": 36,
     "license": "CC-BY-NC-SA 4.0",
-    "rationale": "Subset top-uso 105 species curadas según criterio intelligence-first + valor público familias agricultoras Colombia. Cobertura: frutales mayor + pasifloras (anti-confusión taxonómica) + hortalizas comunes + tubérculos andinos + cereales/leguminosas + especias/medicinales base familiar + asocios funcionales + forestales/sombrío café + páramo + amazónicos estratégicos. Re-curado tras revert del subset v3.1 (50 species, PR #1012) que cortó species críticas (aguacate, tomate, lechuga, acelga). Ver catalog/SUBSET_OSS_V3.2_RATIONALE.md."
+    "rationale": "Subset top-uso curado según criterio intelligence-first + valor público familias agricultoras Colombia. Cobertura: frutales mayor + pasifloras (anti-confusión taxonómica) + hortalizas comunes + tubérculos andinos + cereales/leguminosas + especias/medicinales base familiar + asocios funcionales + forestales/sombrío café + páramo + amazónicos estratégicos. Re-curado tras revert del subset v3.1 (50 species, PR #1012) que cortó species críticas (aguacate, tomate, lechuga, acelga). Curación inicial 205 species (extract-oss-subset-v32.mjs) + 58 species de páramo (enrich-oss-paramo-cruz-verde.mjs, 2026-06-10, ver _paramo_enrichment) = 263 species reales en species[]. Ver catalog/SUBSET_OSS_V3.2_RATIONALE.md."
   },
   "species": [
     {

--- a/tests/unit/catalog-count.test.js
+++ b/tests/unit/catalog-count.test.js
@@ -51,11 +51,12 @@ describe('Catalog Count - Task #189', () => {
 
     expect(catalog.schema_version).toBe('3.2');
     expect(catalog._subset_meta).toBeDefined();
-    // NOTA: _subset_meta.species_count quedó en 204 mientras species.length es
-    // 205 (off-by-one en la metadata del subset, NO en este test). Se asserta el
-    // valor real para no enmascarar la inconsistencia; corregir la metadata es
-    // tarea aparte del owner del catálogo.
-    expect(catalog._subset_meta.species_count).toBe(204);
+    // 2026-06-14 (chore higiene catálogo público): _subset_meta.species_count
+    // reconciliado a 263 para que coincida con species.length real (205 curación
+    // inicial + 58 páramo Cruz Verde). Antes declaraba 204 (off-by-one heredado).
+    // El conteo declarado DEBE coincidir con el array real.
+    expect(catalog._subset_meta.species_count).toBe(263);
+    expect(catalog._subset_meta.species_count).toBe(catalog.species.length);
   });
   
   it('should include new species from batches 4-9', () => {


### PR DESCRIPTION
## Qué y por qué

Higiene del catálogo público + corrección de cifras a las **reales que ships**. Recomendado por auditoría estratégica: limpia señales que confunden y mejora la honestidad de un proyecto que se publica como bien público.

El catálogo que realmente consume el build es `catalog/chagra-catalog-oss-subset-v3.2.json` (`DEFAULT_SEED` en `scripts/build-catalog-sqlite.mjs`) → `public/catalog.sqlite`. Conteo real verificado empíricamente:

- **263 species** · **36 biopreparados** · **68 fuentes** · **0 plagas** (el subset público no expone nodos de plaga; no hay clave `plagas`/`pests` en el JSON shipped).

Varios docs y la propia metadata declaraban cifras desfasadas/engañosas (600 especies, 175, 105, 204, 50…). Esto las pone en las reales.

## Cambios (solo docs / meta / test — sin tocar `species[]` ni la lógica del build)

| Archivo | Cambio |
|---|---|
| `catalog/chagra-catalog-oss-subset-v3.2.json` | `_subset_meta` reconciliado: `species_count` 204→**263**, `subset_name` `oss-subset-105`→`oss-subset-263`. `sources_count`/`biopreparados_count` ya eran correctos (68/36). |
| `tests/unit/catalog-count.test.js` | El assert estaba pineado al valor erróneo (204) "para no enmascarar la inconsistencia". Ahora asserta **263** y exige `_subset_meta.species_count === species.length`. |
| `README.md` | "600 especies, 30 plagas, 20 biopreparados" → **"263 especies, 36 biopreparados, 68 fuentes"**. Se elimina la cifra de plagas (no la ships el público). |
| `catalog/README.md` | Corregido el archivo que **realmente** consume el build (decía `seed-v3.1`/50 sp; es `oss-subset-v3.2`/263), + atribución + sección Boundary OSS/Pro. |
| `catalog/SUBSET_OSS_V3.2_RATIONALE.md` | Banner de estado real shipped (263) + "Total" actualizado. Se preserva la tabla histórica de la curación inicial (105). |
| `catalog/CITATION.cff` + `catalog/.zenodo.json` | Título de citación "175 especies + 54 fuentes" → **"263 + 68"**. |

La provenance de 263 está documentada en `_paramo_enrichment` del propio JSON: 205 (curación inicial top-uso) + 58 (páramo Cruz Verde, 2026-06-10) = 263.

## Borrados: ninguno (la premisa de la auditoría no se sostuvo)

La auditoría sugería borrar dos archivos legacy. Verify-first con `grep` mostró que **ambos están referenciados**, así que **no se borran** (siguiendo el guard de la propia tarea):

- `chagra-catalog-seed-v3.1.json` → referenciado por ~30 scripts (`validate-catalog.mjs`, `catalog-to-age.mjs`, `build-cycle-content-from-catalog.mjs`, `extract-oss-subset*.mjs`, migraciones…), `lefthook.yml`, `tests/unit/catalog-count.test.js`, y es la ruta de rollback del build (`CHAGRA_SEED=…`).
- `chagra-catalog-oss-subset-v3.1.json` → referenciado por `scripts/extract-oss-subset.mjs` (target de salida) + `catalog/README.md` + `SUBSET_OSS_V3.2_RATIONALE.md` (snapshot histórico / rollback).

## Verificación

- `node scripts/build-catalog-sqlite.mjs` → **263 species, 36 biopreparados, 68 sources** insertados (exit 0).
- `node scripts/validate-catalog.mjs --lenient-schema` (comando exacto del hook `catalog-validator`) → ✓ Catálogo válido.
- `npx vitest run tests/unit/catalog-count.test.js` → **4/4 passed**.
- `npx eslint … --max-warnings=0` → limpio.
- Pre-commit hooks (secret-scan, infra-refs-scan, strategic-content-scan, conventional) → todos verdes.

Nota: los 61 errores de schema que reporta el validator en modo estricto sobre el subset (`_url_pendiente`/`_isbn_pendiente` en `sources[]`) son **pre-existentes** en `origin/main` y ajenos a este PR (CI corre en modo lenient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)