### PR TITLE
feat(glaciar): restringir acceso del módulo glaciar a La Cordada (beta)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import { isAuthenticated, logoutUser } from './services/authService';
 import useAssetStore from './store/useAssetStore';
 import { fetchFromFarmOS } from './services/apiService';
 import { PRIMARY_WORKER_NAME } from './config/workerConfig';
+import { tieneAccesoGlaciarActual } from './config/glaciarAccess';
 import { initCatalog } from './db/catalogDB';
 import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
@@ -506,7 +507,15 @@ export default function App() {
         navigate('login');
         return;
       }
-      navigate(HASH_VIEW_ROUTES[hash] || 'dashboard');
+      const targetView = HASH_VIEW_ROUTES[hash] || 'dashboard';
+      // Gate de acceso: el módulo glaciar es solo para los beta testers de "La
+      // Cordada". Si un usuario fuera de la whitelist aterriza en #glaciar,
+      // mandamos al dashboard — el módulo NO se monta (ver glaciarAccess.js).
+      if (targetView === 'glaciar' && !tieneAccesoGlaciarActual()) {
+        navigate('dashboard');
+        return;
+      }
+      navigate(targetView);
     });
   }, [navigate]);
 
@@ -516,7 +525,14 @@ export default function App() {
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
       isAuthenticated().then((isAuth) => {
-        if (isAuth) navigate(routeView);
+        if (!isAuth) return;
+        // Gate glaciar (La Cordada): un usuario no autorizado que navega a
+        // #glaciar es redirigido al dashboard en vez de montar el módulo.
+        if (routeView === 'glaciar' && !tieneAccesoGlaciarActual()) {
+          navigate('dashboard');
+          return;
+        }
+        navigate(routeView);
       });
     };
 
@@ -881,7 +897,19 @@ export default function App() {
           </ErrorBoundary>
         );
       case 'glaciar':
-        // Módulo demo: Reporte de Punto Glaciar (guías de glaciar). Ruta #glaciar.
+        // Módulo "Reporte de Punto Glaciar" (guías de glaciar). Ruta #glaciar.
+        // ACCESO RESTRINGIDO a los beta testers de "La Cordada"
+        // (src/config/glaciarAccess.js). Guarda defensiva: si por cualquier
+        // ruta un usuario no autorizado llega a esta vista, NO montamos el
+        // módulo — devolvemos el fallback estándar. Las navegaciones a #glaciar
+        // ya redirigen al dashboard antes de llegar acá (ver effects de ruta).
+        if (!tieneAccesoGlaciarActual()) {
+          return (
+            <ErrorBoundary>
+              <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+            </ErrorBoundary>
+          );
+        }
         return (
           <ErrorBoundary>
             <GlaciarReporteScreen onBack={() => navigate('dashboard')} />

--- a/src/__tests__/App.glaciar-gate-route.test.jsx
+++ b/src/__tests__/App.glaciar-gate-route.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Test de RUTA + GATE: el módulo "Reporte de Punto Glaciar" (ruta #glaciar)
+// está restringido a los beta testers de "La Cordada" (src/config/glaciarAccess.js).
+// Verificamos que:
+//   - un usuario de La Cordada (username en localStorage) que navega a #glaciar
+//     SÍ monta el módulo;
+//   - un usuario fuera de la whitelist NO monta el módulo (queda en dashboard).
+//
+// El gate lee el username con getActiveTenantId() → localStorage, sin red
+// (offline-first). jsdom provee localStorage real, así que ejercitamos el gate
+// de verdad sin mockear glaciarAccess.
+//
+// Los efectos pesados de boot (auth, catálogo SQLite WASM, alertas, RAG, API)
+// se mockean para que App arranque limpio en jsdom sin tocar red/IDB.
+
+vi.mock('../services/authService', () => ({
+  isAuthenticated: () => Promise.resolve(true),
+  logoutUser: () => Promise.resolve(),
+}));
+vi.mock('../db/catalogDB', () => ({ initCatalog: () => Promise.resolve() }));
+vi.mock('../services/ragRetriever', () => ({
+  prewarmCorpus: () => {},
+  retrieve: () => Promise.resolve([]),
+}));
+vi.mock('../services/alertEngine', () => ({ alertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/cropAlertEngine', () => ({ cropAlertEngine: { start: () => Promise.resolve() } }));
+vi.mock('../services/apiService', () => ({ fetchFromFarmOS: () => Promise.resolve(null) }));
+vi.mock('../db/farmProcessCache', () => ({ listFarmProcesses: () => Promise.resolve([]) }));
+
+// El módulo glaciar: stub liviano que delata que se montó. Si el gate funciona,
+// este testid NUNCA aparece para usuarios fuera de La Cordada.
+vi.mock('../components/GlaciarReporteScreen', () => ({
+  default: () => <div data-testid="glaciar-reporte-screen">glaciar stub</div>,
+}));
+
+const TENANT_KEY = 'chagra:active_tenant_id';
+
+import App from '../App';
+
+describe('App — gate de ruta #glaciar (La Cordada)', () => {
+  beforeEach(() => {
+    window.location.hash = '#glaciar';
+    localStorage.clear();
+  });
+  afterEach(() => {
+    window.location.hash = '';
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('usuario de La Cordada en #glaciar SÍ monta el módulo glaciar', async () => {
+    localStorage.setItem(TENANT_KEY, 'mario'); // whitelisted
+    render(<App />);
+    await waitFor(
+      () => expect(screen.getByTestId('glaciar-reporte-screen')).toBeTruthy(),
+      { timeout: 4000 },
+    );
+  });
+
+  it('usuario fuera de la whitelist en #glaciar NO monta el módulo glaciar', async () => {
+    localStorage.setItem(TENANT_KEY, 'usuario_normal'); // NO whitelisted
+    render(<App />);
+    // Damos tiempo a que los efectos de ruta corran y redirijan al dashboard.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(screen.queryByTestId('glaciar-reporte-screen')).toBeNull();
+  });
+
+  it('sin sesión (sin username) en #glaciar NO monta el módulo glaciar', async () => {
+    // Sin tenantId → sin acceso (default seguro). authService está mockeado a
+    // autenticado, pero el gate de glaciar igual bloquea por falta de username.
+    render(<App />);
+    await new Promise((r) => setTimeout(r, 600));
+    expect(screen.queryByTestId('glaciar-reporte-screen')).toBeNull();
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -21,6 +21,7 @@ import { GripVertical, Snowflake, ChevronRight } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
 import { getProfile } from '../../services/userProfileService';
+import { tieneAccesoGlaciarActual } from '../../config/glaciarAccess';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
@@ -237,27 +238,32 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                 bajo el hero, visible en todos los temas (operador 2026-06-09). */}
             <SelectedBackgroundReveal />
 
-            {/* Acceso al módulo demo "Reporte de Punto Glaciar" (guías de
-                glaciar). Ruta #glaciar. Banner visible para validación en
-                campo — offline-first. */}
-            <div className="px-4 pt-3">
-                <button
-                    type="button"
-                    onClick={() => onNavigate('glaciar')}
-                    className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-sky-700/50 bg-sky-900/25 hover:bg-sky-900/40 active:scale-[0.99] transition text-left"
-                >
-                    <span className="shrink-0 w-11 h-11 rounded-xl bg-sky-500/20 grid place-items-center">
-                        <Snowflake size={24} className="text-sky-300" />
-                    </span>
-                    <span className="flex-1 min-w-0">
-                        <span className="block font-bold text-slate-100 leading-tight">Reporte de Punto Glaciar</span>
-                        <span className="block text-xs text-slate-400 leading-tight">
-                            Dureza del hielo, GPS y foto — funciona sin internet
+            {/* Acceso al módulo "Reporte de Punto Glaciar" (guías de glaciar).
+                Ruta #glaciar. ACCESO RESTRINGIDO a los beta testers de "La
+                Cordada": el banner solo se renderiza si el usuario logueado
+                está en la whitelist (src/config/glaciarAccess.js). Para el resto
+                de usuarios el módulo es invisible. Offline-first (lee el usuario
+                ya guardado en login, sin red). */}
+            {tieneAccesoGlaciarActual() && (
+                <div className="px-4 pt-3">
+                    <button
+                        type="button"
+                        onClick={() => onNavigate('glaciar')}
+                        className="w-full flex items-center gap-3 p-3.5 rounded-2xl border border-sky-700/50 bg-sky-900/25 hover:bg-sky-900/40 active:scale-[0.99] transition text-left"
+                    >
+                        <span className="shrink-0 w-11 h-11 rounded-xl bg-sky-500/20 grid place-items-center">
+                            <Snowflake size={24} className="text-sky-300" />
                         </span>
-                    </span>
-                    <ChevronRight size={20} className="text-sky-300/70 shrink-0" />
-                </button>
-            </div>
+                        <span className="flex-1 min-w-0">
+                            <span className="block font-bold text-slate-100 leading-tight">Reporte de Punto Glaciar</span>
+                            <span className="block text-xs text-slate-400 leading-tight">
+                                Dureza del hielo, GPS y foto — funciona sin internet
+                            </span>
+                        </span>
+                        <ChevronRight size={20} className="text-sky-300/70 shrink-0" />
+                    </button>
+                </div>
+            )}
 
             {/* Panel inline de capacidades RETIRADO (operador 2026-06-10): el
                 menú vive solo en el despliegue de la Ⓐ del AgentHero (la red

--- a/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
@@ -1,0 +1,76 @@
+/**
+ * DashboardLive.glaciarBanner.test.jsx — el banner "Reporte de Punto Glaciar"
+ * del Home está restringido a los beta testers de "La Cordada".
+ *
+ * Contrato:
+ *  - usuario de La Cordada (tieneAccesoGlaciarActual → true) → el banner del
+ *    Home SE renderiza (botón "Reporte de Punto Glaciar").
+ *  - usuario fuera de la whitelist (false) → el banner NO se renderiza; el
+ *    módulo es invisible desde el Home.
+ *
+ * El gate (glaciarAccess) se mockea para controlar el acceso por test sin
+ * depender de localStorage; su lógica pura ya está cubierta en
+ * src/config/__tests__/glaciarAccess.test.js. Los hijos pesados del dashboard
+ * (AgentHero, tiras de clima, dnd-kit, stores) se stubean para aislar el banner.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// Gate CONTROLABLE por test.
+const accesoMock = vi.fn(() => false);
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: (...args) => accesoMock(...args),
+}));
+
+// Hijos pesados → stubs livianos.
+vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
+vi.mock('../../OnboardingHero', () => ({ default: () => <div data-testid="onboarding-hero" /> }));
+vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+vi.mock('../FincaCards', () => ({
+  PlantasCard: () => <div />, ZonasCard: () => <div />, InsumosCard: () => <div />,
+  BitacoraCard: () => <div />, HoyCard: () => <div />, PlagasCard: () => <div />,
+  BiodiversidadCard: () => <div />, InformesCard: () => <div />,
+}));
+
+vi.mock('../../../services/userProfileService', () => ({
+  getProfile: vi.fn(() => ({})),
+}));
+
+// Store de assets: plantsCount > 0 para que NO se monte el OnboardingHero de
+// "primer uso" (no relevante a este test) y mantener el árbol pequeño.
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [{ id: 'p1' }], needsPisoCapture: false }),
+}));
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+import DashboardLive from '../DashboardLive';
+
+const GLACIAR_BANNER = /reporte de punto glaciar/i;
+
+describe('DashboardLive — banner glaciar gateado por La Cordada', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('usuario de La Cordada: el banner glaciar SÍ se renderiza', () => {
+    accesoMock.mockReturnValue(true);
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    expect(screen.getByText(GLACIAR_BANNER)).toBeInTheDocument();
+  });
+
+  test('usuario fuera de la whitelist: el banner glaciar NO se renderiza', () => {
+    accesoMock.mockReturnValue(false);
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    expect(screen.queryByText(GLACIAR_BANNER)).toBeNull();
+  });
+});

--- a/src/config/__tests__/glaciarAccess.test.js
+++ b/src/config/__tests__/glaciarAccess.test.js
@@ -1,0 +1,96 @@
+/**
+ * glaciarAccess.test.js — TDD del gate de acceso al módulo glaciar (La Cordada).
+ *
+ * Cobertura:
+ *  - tieneAccesoGlaciar: username en whitelist → true.
+ *  - tieneAccesoGlaciar: username fuera de whitelist → false.
+ *  - tieneAccesoGlaciar: null / undefined / vacío / solo espacios → false.
+ *  - tieneAccesoGlaciar: matching case-insensitive y tolerante a espacios (trim).
+ *  - CORDADA_WHITELIST exporta un Set no vacío (editable por el operador).
+ *  - tieneAccesoGlaciarActual: lee el tenantId activo de localStorage (offline).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let glaciarAccess;
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import('../glaciarAccess.js');
+};
+
+describe('glaciarAccess — tieneAccesoGlaciar (función pura)', () => {
+  beforeEach(async () => {
+    glaciarAccess = await importFresh();
+  });
+
+  it('devuelve true para usernames de La Cordada', () => {
+    expect(glaciarAccess.tieneAccesoGlaciar('alex')).toBe(true);
+    expect(glaciarAccess.tieneAccesoGlaciar('mario')).toBe(true);
+    expect(glaciarAccess.tieneAccesoGlaciar('camilo')).toBe(true);
+  });
+
+  it('devuelve false para usernames fuera de la whitelist', () => {
+    expect(glaciarAccess.tieneAccesoGlaciar('admin')).toBe(false);
+    expect(glaciarAccess.tieneAccesoGlaciar('campesino_juan')).toBe(false);
+    expect(glaciarAccess.tieneAccesoGlaciar('random_user_xyz')).toBe(false);
+  });
+
+  it('devuelve false para null/undefined/vacío/solo-espacios (defensive)', () => {
+    expect(glaciarAccess.tieneAccesoGlaciar(null)).toBe(false);
+    expect(glaciarAccess.tieneAccesoGlaciar(undefined)).toBe(false);
+    expect(glaciarAccess.tieneAccesoGlaciar('')).toBe(false);
+    expect(glaciarAccess.tieneAccesoGlaciar('   ')).toBe(false);
+  });
+
+  it('hace match case-insensitive y tolerante a espacios (trim)', () => {
+    expect(glaciarAccess.tieneAccesoGlaciar('Alex')).toBe(true);
+    expect(glaciarAccess.tieneAccesoGlaciar('MARIO')).toBe(true);
+    expect(glaciarAccess.tieneAccesoGlaciar('  camilo  ')).toBe(true);
+    expect(glaciarAccess.tieneAccesoGlaciar(' CaMiLo ')).toBe(true);
+  });
+
+  it('CORDADA_WHITELIST es un Set no vacío (editable por el operador)', () => {
+    expect(glaciarAccess.CORDADA_WHITELIST).toBeInstanceOf(Set);
+    expect(glaciarAccess.CORDADA_WHITELIST.size).toBeGreaterThan(0);
+  });
+});
+
+describe('glaciarAccess — tieneAccesoGlaciarActual (usuario logueado, offline)', () => {
+  let store;
+
+  beforeEach(async () => {
+    store = {};
+    // Stub de localStorage: simula el username persistido en login SIN red.
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => store[k] ?? null,
+      setItem: (k, v) => { store[k] = v; },
+      removeItem: (k) => { delete store[k]; },
+    });
+    glaciarAccess = await importFresh();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('devuelve true cuando el usuario logueado está en La Cordada', () => {
+    store['chagra:active_tenant_id'] = 'mario';
+    expect(glaciarAccess.tieneAccesoGlaciarActual()).toBe(true);
+  });
+
+  it('devuelve false cuando el usuario logueado NO está en la whitelist', () => {
+    store['chagra:active_tenant_id'] = 'usuario_normal';
+    expect(glaciarAccess.tieneAccesoGlaciarActual()).toBe(false);
+  });
+
+  it('devuelve false cuando no hay sesión activa', () => {
+    // store vacío → tenantId = null → sin acceso (default seguro).
+    expect(glaciarAccess.tieneAccesoGlaciarActual()).toBe(false);
+  });
+
+  it('resuelve offline: solo lee localStorage, sin tocar la red', () => {
+    // No mockeamos fetch a propósito: si la función intentara red, fallaría.
+    store['chagra:active_tenant_id'] = 'ALEX';
+    expect(glaciarAccess.tieneAccesoGlaciarActual()).toBe(true);
+  });
+});

--- a/src/config/glaciarAccess.js
+++ b/src/config/glaciarAccess.js
@@ -1,0 +1,91 @@
+/**
+ * glaciarAccess.js — Gate de ACCESO al módulo "Reporte de Punto Glaciar".
+ *
+ * PROPÓSITO:
+ *   Restringir la VISIBILIDAD y el ACCESO del módulo glaciar a los beta
+ *   testers de "La Cordada". NO cierra el código fuente (Chagra sigue siendo
+ *   open-source / AGPL-3.0): es un gate de acceso por usuario, no un cierre de
+ *   fuente. Mientras el módulo madura, solo los usernames de la whitelist ven
+ *   el banner del Home y pueden montar la ruta `#glaciar`. Para el resto de
+ *   usuarios el módulo es invisible e inalcanzable.
+ *
+ * CÓMO AGREGAR (O QUITAR) UN USUARIO DE LA CORDADA:
+ *   1. Agregar/eliminar su username de farmOS (exacto) en CORDADA_WHITELIST
+ *      abajo. El match es case-insensitive y tolera espacios, así que no hace
+ *      falta normalizar a mano.
+ *   2. Hacer commit y deploy. No hay otros pasos en el bundle.
+ *
+ * OFFLINE-FIRST:
+ *   La verificación NO requiere red. Usa el username ya guardado en el login
+ *   (`getActiveTenantId()` de tenantContext, persistido en localStorage tras el
+ *   OAuth). Funciona idéntico online u offline.
+ *
+ * NOTA DE SEGURIDAD:
+ *   La whitelist vive en el bundle (client-side). Cualquier usuario técnico
+ *   puede inspeccionarla; esto es DEFENSE-IN-DEPTH de UX, no autorización dura.
+ *   El gate real (si algún día el módulo toca backend) debe aplicarse
+ *   server-side. Por ahora el módulo glaciar es 100% client-side, así que este
+ *   gate es suficiente para "solo La Cordada lo ve".
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @module glaciarAccess
+ */
+
+import { getActiveTenantId } from '../services/tenantContext.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WHITELIST — editar SOLO este Set para dar/quitar acceso al módulo glaciar.
+// Son los beta testers de "La Cordada". Los usernames se normalizan
+// (trim + lowercase) en el match, así que el formato exacto acá no es crítico.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Set de usernames farmOS de los beta testers de "La Cordada" con acceso al
+ * módulo "Reporte de Punto Glaciar".
+ *
+ * Para dar acceso a alguien: añadir su username (lowercase) a este Set.
+ * Para revocar: eliminar la línea.
+ *
+ * @constant {Set<string>}
+ */
+export const CORDADA_WHITELIST = new Set([
+  'alex',    // La Cordada — beta tester glaciar.
+  'mario',   // La Cordada — beta tester glaciar.
+  'camilo',  // La Cordada — beta tester glaciar.
+]);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API pública
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Función pura: ¿este username pertenece a La Cordada (tiene acceso al
+ * módulo glaciar)?
+ *
+ * Normaliza el username con trim() + toLowerCase() antes de comparar, para
+ * tolerar capitalización accidental o espacios alrededor (farmOS usernames
+ * suelen ser lowercase, pero el match es robusto).
+ *
+ * @param {string|null|undefined} username — username farmOS del usuario.
+ * @returns {boolean} true si está en la whitelist; false en todos los demás
+ *   casos (null, undefined, vacío, solo espacios, fuera de la whitelist).
+ */
+export function tieneAccesoGlaciar(username) {
+  if (!username || typeof username !== 'string') return false;
+  const normalized = username.trim().toLowerCase();
+  if (normalized.length === 0) return false;
+  return CORDADA_WHITELIST.has(normalized);
+}
+
+/**
+ * ¿El usuario actualmente logueado tiene acceso al módulo glaciar?
+ *
+ * Lee el username persistido por `tenantContext` (se setea en el login OAuth).
+ * No requiere red — funciona offline con el usuario ya guardado localmente.
+ *
+ * @returns {boolean}
+ */
+export function tieneAccesoGlaciarActual() {
+  return tieneAccesoGlaciar(getActiveTenantId());
+}


### PR DESCRIPTION
## Qué hace

El módulo **Reporte de Punto Glaciar** era público (banner en el Home + ruta `#glaciar`). Mientras madura, este PR **restringe su visibilidad y acceso** a una whitelist de usernames — los beta testers de **La Cordada**.

**No cierra el código fuente** (Chagra sigue open-source / AGPL-3.0): es un gate de **acceso/visibilidad por usuario**, no un cierre de fuente.

## Cómo se gatea

Patrón espejo de `tierService.js` (allowlist client-side, defense-in-depth de UX).

- **`src/config/glaciarAccess.js`** (NUEVO):
  - `CORDADA_WHITELIST` — `Set` editable de usernames (`alex`, `mario`, `camilo`). **Para dar/quitar acceso: editar solo este Set + commit/deploy.**
  - `tieneAccesoGlaciar(username)` — función **pura**, `trim()` + `toLowerCase()`, `false` para null/undefined/vacío/fuera de whitelist.
  - `tieneAccesoGlaciarActual()` — lee el username del login (`getActiveTenantId()` → `localStorage`). **Offline-first: no toca red.**
- **Banner (Home)** — `src/components/dashboard/DashboardLive.jsx`: el banner glaciar solo se renderiza si `tieneAccesoGlaciarActual()`. Invisible para el resto.
- **Ruta `#glaciar`** — `src/App.jsx`: usuarios no autorizados son redirigidos al dashboard tanto en **carga inicial** como en **`hashchange`**; además, **guarda defensiva** en el render del `case 'glaciar'` (el módulo nunca monta sin acceso — devuelve "Vista no disponible").

## Offline-first

La verificación usa el username ya persistido en el login (localStorage); funciona idéntico online u offline. Hay un test explícito que lo comprueba (no mockea `fetch`: si la función tocara red, fallaría).

## TDD / tests

- `src/config/__tests__/glaciarAccess.test.js` — whitelist sí/no, case-insensitive, trim, null/undefined/vacío, offline.
- `src/__tests__/App.glaciar-gate-route.test.jsx` — `#glaciar` monta el módulo para whitelisted; **no** lo monta para no-whitelisted ni sin sesión.
- `src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx` — banner visible para whitelisted, oculto para el resto.

**14/14 verdes** en lo tocado. Lint de archivos tocados limpio (`--max-warnings=0`). `npm run build` OK. (La suite global tiene ~24 fallas pre-existentes ajenas a este cambio.)

## Cómo ampliar la whitelist

Editar `CORDADA_WHITELIST` en `src/config/glaciarAccess.js` (lowercase recomendado; el match tolera mayúsculas y espacios) → commit → deploy.

Español Colombia (sin voseo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)