### PR TITLE
feat(extensionista): modo supervisor multi-finca MVP cliente (ADR-048)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,12 @@ VITE_CAPTURE_ANONYMIZE=false
 # anónimos de las consultas al agente (route, model, latencias, tokens) sin PII
 # (sin prompts, respuestas, user_id, coords). Default: vacío (no-op).
 VITE_TELEMETRY_INGEST_URL=
+
+# Modo EXTENSIONISTA — panel supervisor multi-finca (ADR-048 MVP). Kill-switch
+# global. Con `false` (default) el modo NO existe para nadie: ni ruta
+# (#extensionista), ni entrada en Perfil, ni panel. Con `true` el modo se
+# habilita SOLO para los usernames de la whitelist en
+# src/config/extensionistaAccess.js. MVP: la lista de fincas sale de un mock
+# (src/data/extensionista-fincas.json), NO de una autorización verificada. La
+# delegación real (UCAN + farm_did_auth) es follow-up backend (ADR-036).
+VITE_FEATURE_EXTENSIONISTA=false

--- a/docs/adr/ADR-048-modo-extensionista-multi-finca.md
+++ b/docs/adr/ADR-048-modo-extensionista-multi-finca.md
@@ -1,0 +1,92 @@
+# ADR-048: Modo extensionista — panel supervisor multi-finca (MVP cliente)
+
+**Status:** Accepted (MVP) — backend de delegación pendiente (follow-up)
+**Date:** 2026-06-14
+**Deciders:** Operator (Miguel) + Claude Opus 4.8
+**Related:** ADR-036 (multi-finca / federación de células — sub-i identidad, sub-iv asesores externos), ADR-002 (boundary OSS/Pro vía moduleRegistry), `src/services/tenantContext.js` (ADR-036 MVP tenant scoping), `src/config/glaciarAccess.js` (precedente de gate por whitelist + feature)
+
+## Contexto
+
+Chagra hoy modela **un agricultor con una o más fincas PROPIAS**: `tenantContext.js` (MVP de ADR-036) resuelve "quién soy yo" a partir del username del login OAuth2 y scopea los assets de farmOS con `filter[uid.name]`. Eso cubre al campesino dueño de su(s) finca(s).
+
+Pero la visión SENA-FAO / Agrosavia / IPPTA (extensión rural) introduce un actor distinto: el **extensionista** — el asesor de extensión (EPSEA/SENA), el técnico de Agrosavia/IPPTA, el líder de una asociación campesina — que **acompaña varias fincas de OTROS agricultores**. Este actor no opera su propia finca: supervisa las ajenas, necesita un panel con el estado de cada una de un vistazo, y prioriza dónde poner su tiempo (visitas, llamadas).
+
+ADR-036 ya previó este rol en **sub-iv ("Asesores externos read+comment")**: la delegación correcta es una **capability UCAN** firmada por el dueño de la finca, con `redact_pii` y TTL, validada server-side por un módulo Drupal `farm_did_auth`. Ese es el destino. El problema: **ese backend no existe hoy** (UCAN + did:key + farm_did_auth son Fase 1+ de ADR-036, ~USD 14-18k, Q3-Q4 2026). No podemos bloquear la validación de producto del panel supervisor esperando el stack criptográfico completo.
+
+Necesitamos un **MVP cliente** que:
+1. Detecte el rol "extensionista" sin backend nuevo.
+2. Muestre un selector / dashboard de las fincas que ese extensionista acompaña.
+3. No mienta: que un piloto entienda que es una **vista previa con datos de ejemplo**, no un permiso verificado.
+4. Quede **apagado por defecto** en producción hasta que el backend lo respalde.
+5. No duplique `tenantContext` ni rompa el scoping existente.
+
+## Decisión
+
+Implementar el modo extensionista como una **capa de ROL client-side, gateada por feature flag**, encima de `tenantContext`. Cero backend nuevo en este MVP.
+
+### Modelo
+
+- **Rol ≠ tenant.** `tenantContext` sigue respondiendo "qué finca propia scopeo". El nuevo `extensionistaAccess` responde "¿este usuario es un supervisor que puede VER fincas ajenas?". Son ortogonales: un usuario puede ser ambas cosas, pero el rol no toca el scoping de assets.
+
+- **Doble candado** (igual filosofía que `glaciarAccess.js` / La Cordada):
+  1. **Feature flag global** `VITE_FEATURE_EXTENSIONISTA` (kill-switch, default `false`). Apagado → el modo no existe para nadie: ni ruta `#extensionista`, ni entrada en Perfil, ni panel. Permite shippear el código *dark* a producción.
+  2. **Whitelist** `EXTENSIONISTA_WHITELIST` (Set de usernames). Aun con la flag ON, solo estos usuarios entran.
+
+- **Fuente de fincas delegadas = MOCK estático** `src/data/extensionista-fincas.json`. Cada delegación es `{ extensionista, fincas: [{ slug, nombre, operador, vereda, municipio, biocultural_zone, estado, ultima_sync_iso, pendientes, alertas }] }`. La forma del registro de finca reusa la convención de `fincaActiveStore` (`slug` / `nombre` / `biocultural_zone`) + el estado de supervisión.
+
+- **Offline-first.** Todo (rol + lista) sale de localStorage (tenant) + un JSON bundleado. Funciona idéntico sin red, como el resto de Chagra.
+
+### Componentes (scaffold cliente)
+
+| Pieza | Archivo | Rol |
+|---|---|---|
+| Gate de rol | `src/config/extensionistaAccess.js` | `esExtensionista()`, `esExtensionistaActual()`, `featureExtensionistaActivo()`, `EXTENSIONISTA_WHITELIST` |
+| Mock delegación | `src/data/extensionista-fincas.json` | fincas de ejemplo por extensionista (NO autorización) |
+| Servicio tablero | `src/services/extensionistaService.js` | `getFincasDelegadas()`, `clasificarEstadoFinca()`, `construirTableroExtensionista()` (orden por urgencia + contadores) |
+| Pantalla supervisor | `src/components/ExtensionistaScreen.jsx` | panel `#extensionista`: resumen + tarjeta por finca + aviso de frontera MVP |
+| Wiring | `src/App.jsx` | ruta `#extensionista` + guard de rol en los efectos de ruta + `case` en el switch |
+| Entrada UI | `src/components/ProfileScreen.jsx` | sección "Acompañamiento" (solo se renderiza con rol) que navega vía `chagra:nav` |
+
+### Por qué client-side es aceptable para ESTE MVP
+
+Es **defense-in-depth de UX + scaffold de producto**, no autorización dura — exactamente el mismo encuadre que `glaciarAccess` y que el propio `tenantContext` MVP. La whitelist vive en el bundle y un usuario técnico puede inspeccionarla; eso es conocido y aceptado mientras el panel solo lee datos de ejemplo. El gate real se aplica server-side cuando el módulo toque backend.
+
+## MVP vs Follow-up (backend)
+
+**En el MVP (este ADR, ships ahora, flag off):**
+- Detección de rol por whitelist + feature flag.
+- Selector / dashboard de fincas delegadas leyendo del mock.
+- Estado por finca (al día / con pendientes / sin sync reciente), orden por urgencia, contadores agregados.
+- Aviso explícito de "vista previa, no autorización verificada".
+
+**Follow-up backend (NO en este ADR — documentado para ejecutar después):**
+- **Delegación real vía UCAN** (ADR-036 sub-i + sub-iv): el dueño de la finca firma una capability `supervise`/`read` (con `redact_pii: true`, TTL) al `did:key` del extensionista. `getFincasDelegadas()` consultaría esas delegaciones verificadas en vez del JSON estático.
+- **Módulo Drupal `farm_did_auth`** que valida el challenge UCAN contra `simple_oauth` de farmOS y entrega solo las fincas autorizadas.
+- **Datos en vivo por finca** desde farmOS JSON:API (estado real, última sync, pendientes, alertas) con scoping por finca + anonimización de `operator_id` (Ley 1581 / ADR-020) — el extensionista ve pseudónimo, no el `operator_id` plaintext.
+- **Revocación** (`cap_revoked` append-only) y **audit log** de accesos del asesor.
+- **Detalle de finca** navegable (drill-down read-only) — el MVP solo lista; "ver detalle" queda como próximo paso.
+
+La **forma del modelo de tablero** (`construirTableroExtensionista`) se diseñó para sobrevivir ese cambio de fuente: cuando la data venga de UCAN+farmOS, la UI no se reescribe.
+
+## Articulación con la visión (SENA-FAO / Agrosavia / IPPTA)
+
+El extensionista es la unidad de **escalamiento institucional** de Chagra: un asesor SENA o un técnico Agrosavia/IPPTA acompaña decenas de fincas. ADR-036 lo lista como vector de adopción ("onboarding masivo SENA / universidades campesinas / Agrosavia regional") y como línea de ingreso ("consultoría agronómica: asesores certificados en directorio Guatoc"). Este MVP permite **demostrar el flujo de acompañamiento multi-finca a esos aliados ya**, con datos de ejemplo, sin esperar el stack UCAN — y abre la puerta a co-diseñar la UX del panel con extensionistas reales antes de invertir en el backend criptográfico.
+
+## Consecuencias
+
+**Positivas:**
+- Producto demostrable a SENA/Agrosavia/IPPTA sin backend nuevo.
+- Cero deuda sobre `tenantContext` (rol ortogonal al scoping).
+- Apagado por defecto → riesgo de prod nulo; se enciende por build-env cuando convenga.
+- El contrato del servicio sobrevive a la migración a UCAN.
+
+**Negativas / deuda asumida:**
+- La whitelist y el mock viven en el bundle público (visible). Aceptable mientras sea vista previa con datos de ejemplo.
+- No hay autorización real: NO exponer datos sensibles de fincas reales por esta vía hasta el follow-up backend. El mock no debe poblarse con `operator_id` plaintext ni datos productivos reales.
+- Editar accesos requiere commit + deploy (igual que glaciar). Aceptable para el set inicial de extensionistas piloto.
+
+## Alternativas consideradas
+
+1. **Esperar al backend UCAN completo (ADR-036 Fase 1).** Rechazada: bloquea meses la validación de producto del panel supervisor con aliados institucionales.
+2. **Extender `tenantContext` para "ver varias fincas".** Rechazada: confunde dos conceptos (mi finca vs fincas ajenas que superviso) y arriesga el scoping de assets existente.
+3. **Rol persistido en perfil de farmOS (campo custom) en vez de whitelist.** Rechazada para el MVP: requiere cambios server-side; la whitelist es consistente con el precedente glaciar y suficiente para el set piloto. Migra naturalmente a UCAN en el follow-up.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,7 +82,11 @@ const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
+// Modo extensionista (panel supervisor multi-finca, ADR-048 MVP). Gateado por
+// feature flag VITE_FEATURE_EXTENSIONISTA + rol (ver config/extensionistaAccess).
+const ExtensionistaScreen = lazy(() => import('./components/ExtensionistaScreen'));
 import HomeRegionalGreeting from './components/HomeRegionalGreeting';
+import { esExtensionistaActual } from './config/extensionistaAccess';
 
 localforage.config({
   name: 'Chagra',
@@ -140,6 +144,7 @@ const HASH_VIEW_ROUTES = {
   informes: 'informes',
   'case-studies': 'casos',
   casos: 'casos',
+  extensionista: 'extensionista',
   tareas: 'task_log',
   task_log: 'task_log',
   hoy: 'hoy_finca',
@@ -517,6 +522,12 @@ export default function App() {
         navigate('dashboard');
         return;
       }
+      // Gate del modo extensionista (ADR-048): si un usuario sin rol aterriza
+      // en #extensionista (flag off o fuera de whitelist), va al dashboard.
+      if (targetView === 'extensionista' && !esExtensionistaActual()) {
+        navigate('dashboard');
+        return;
+      }
       navigate(targetView);
     });
   }, [navigate]);
@@ -526,6 +537,11 @@ export default function App() {
       const hash = window.location.hash.replace(/^#\/?/, '').toLowerCase();
       const routeView = HASH_VIEW_ROUTES[hash];
       if (!routeView) return;
+      // Gate extensionista (ADR-048): no montar el panel para quien no tiene rol.
+      if (routeView === 'extensionista' && !esExtensionistaActual()) {
+        navigate('dashboard');
+        return;
+      }
       isAuthenticated().then((isAuth) => {
         if (!isAuth) return;
         // Gate glaciar (La Cordada): un usuario no autorizado que navega a
@@ -955,6 +971,23 @@ export default function App() {
         return (
           <ErrorBoundary>
             <ProfileScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+          </ErrorBoundary>
+        );
+      case 'extensionista':
+        // Panel SUPERVISOR del modo extensionista (ADR-048 MVP). ACCESO por
+        // feature flag VITE_FEATURE_EXTENSIONISTA + rol (config/extensionistaAccess).
+        // Las rutas a #extensionista ya redirigen al dashboard antes de llegar
+        // acá si el usuario no tiene rol; guarda defensiva por si se monta directo.
+        if (!esExtensionistaActual()) {
+          return (
+            <ErrorBoundary>
+              <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+            </ErrorBoundary>
+          );
+        }
+        return (
+          <ErrorBoundary>
+            <ExtensionistaScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
           </ErrorBoundary>
         );
       case 'casos':

--- a/src/components/ExtensionistaScreen.jsx
+++ b/src/components/ExtensionistaScreen.jsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react';
+import {
+  Users, MapPin, AlertTriangle, Clock, CheckCircle2, FlaskConical,
+  Sprout, Info, UserCircle2,
+} from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import { esExtensionistaActual } from '../config/extensionistaAccess';
+import { construirTableroExtensionista } from '../services/extensionistaService';
+import { getActiveTenantId } from '../services/tenantContext';
+
+/**
+ * ExtensionistaScreen — Panel SUPERVISOR del modo extensionista (ADR-048 MVP).
+ *
+ * Un extensionista (asesor de extensión rural EPSEA/SENA, técnico
+ * Agrosavia/IPPTA, líder de asociación campesina) ve aquí las fincas que
+ * supervisa, con un resumen y el estado de cada una. NO opera su propia finca:
+ * acompaña las de otros.
+ *
+ * FRONTERA MVP (importante para no confundir a un piloto):
+ *   - Lo que se ve sale de un MOCK estático + whitelist client-side. NO es una
+ *     autorización verificada server-side.
+ *   - La delegación real (el agricultor autoriza al extensionista) y los datos
+ *     en vivo por finca son FOLLOW-UP backend: UCAN delegations + módulo Drupal
+ *     `farm_did_auth` (ADR-036 sub-i/sub-iv). Por eso el panel muestra un aviso
+ *     claro de "vista previa".
+ *
+ * Ruta: #extensionista. Gateado por feature flag VITE_FEATURE_EXTENSIONISTA +
+ * rol (ver extensionistaAccess.js) — App.jsx ya redirige a quien no tenga
+ * acceso, pero esta pantalla repite el guard de forma defensiva.
+ *
+ * Offline-first (lee tenant + mock local, sin red). Theme-aware vía ScreenShell
+ * (la foto de fondo del body se ve a través del scrim). Español Colombia, SIN
+ * voseo argentino.
+ */
+
+const TONO_CLASES = {
+  alerta: 'border-red-600/50 bg-red-900/20 text-red-200',
+  aviso: 'border-amber-600/50 bg-amber-900/20 text-amber-200',
+  ok: 'border-emerald-600/50 bg-emerald-900/20 text-emerald-200',
+  neutro: 'border-slate-600/50 bg-slate-800/30 text-slate-300',
+};
+
+const TONO_ICON = {
+  alerta: AlertTriangle,
+  aviso: Clock,
+  ok: CheckCircle2,
+  neutro: Info,
+};
+
+function formatearFecha(iso) {
+  if (!iso) return 'sin registro';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'sin registro';
+  // Formato corto local (es-CO). Sin hora para mantenerlo legible en campo.
+  return d.toLocaleDateString('es-CO', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function ResumenChip({ icon, valor, label, tono = 'neutro' }) {
+  // Asignamos a un const capitalizado (mismo patrón que FincaCard con
+  // EstadoIcon). La config de ESLint no incluye eslint-plugin-react, así que
+  // un PARÁMETRO usado solo como tag JSX se marca como no-usado; un const
+  // capitalizado (matchea varsIgnorePattern ^[A-Z_]) no tiene ese problema.
+  const Icono = icon;
+  return (
+    <div className={`flex items-center gap-2 rounded-xl border px-3 py-2 ${TONO_CLASES[tono]}`}>
+      <Icono size={18} aria-hidden="true" className="shrink-0" />
+      <div className="leading-tight">
+        <div className="text-lg font-bold">{valor}</div>
+        <div className="text-[11px] opacity-80">{label}</div>
+      </div>
+    </div>
+  );
+}
+
+function FincaCard({ finca }) {
+  const tono = finca?._clasificacion?.tono || 'neutro';
+  const EstadoIcon = TONO_ICON[tono] || Info;
+  return (
+    <article className="rounded-2xl border border-slate-700/60 bg-slate-900/40 p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-bold text-white truncate flex items-center gap-2">
+            <Sprout size={16} className="text-emerald-400 shrink-0" aria-hidden="true" />
+            {finca.nombre}
+          </h3>
+          <p className="text-xs text-slate-400 flex items-center gap-1.5 mt-0.5">
+            <UserCircle2 size={13} aria-hidden="true" />
+            <span className="truncate">Agricultor: {finca.operador}</span>
+          </p>
+          {(finca.vereda || finca.municipio) && (
+            <p className="text-xs text-slate-500 flex items-center gap-1.5 mt-0.5">
+              <MapPin size={13} aria-hidden="true" />
+              <span className="truncate">
+                {[finca.vereda, finca.municipio].filter(Boolean).join(', ')}
+              </span>
+            </p>
+          )}
+        </div>
+        <span
+          className={`shrink-0 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${TONO_CLASES[tono]}`}
+        >
+          <EstadoIcon size={13} aria-hidden="true" />
+          {finca?._clasificacion?.label || 'Estado desconocido'}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-[11px]">
+        <span className="inline-flex items-center gap-1 rounded-lg bg-slate-800/60 px-2 py-1 text-slate-300">
+          <Clock size={12} aria-hidden="true" />
+          Última sync: {formatearFecha(finca.ultima_sync_iso)}
+        </span>
+        {(finca.pendientes || 0) > 0 && (
+          <span className="inline-flex items-center gap-1 rounded-lg bg-amber-900/30 border border-amber-700/40 px-2 py-1 text-amber-200">
+            <FlaskConical size={12} aria-hidden="true" />
+            {finca.pendientes} pendiente{finca.pendientes === 1 ? '' : 's'}
+          </span>
+        )}
+        {(finca.alertas || 0) > 0 && (
+          <span className="inline-flex items-center gap-1 rounded-lg bg-red-900/30 border border-red-700/40 px-2 py-1 text-red-200">
+            <AlertTriangle size={12} aria-hidden="true" />
+            {finca.alertas} alerta{finca.alertas === 1 ? '' : 's'}
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default function ExtensionistaScreen({ onBack, onHome }) {
+  // Guard defensivo de rol (App.jsx ya redirige, pero repetimos acá por si la
+  // pantalla se monta por una ruta directa). Si no hay rol → no construimos el
+  // tablero ni mostramos fincas.
+  const tieneRol = esExtensionistaActual();
+
+  const tablero = useMemo(
+    () => (tieneRol ? construirTableroExtensionista(getActiveTenantId()) : null),
+    [tieneRol]
+  );
+
+  if (!tieneRol) {
+    return (
+      <ScreenShell title="Modo extensionista" icon={Users} onBack={onBack} onHome={onHome}>
+        <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+          <Users size={40} className="text-slate-500" aria-hidden="true" />
+          <h2 className="text-lg font-bold text-white">Vista no disponible</h2>
+          <p className="text-sm text-slate-400 max-w-sm">
+            No tienes acceso al modo extensionista. Este panel es para asesores
+            de extensión rural que acompañan varias fincas. Si crees que deberías
+            tener acceso, contacta al equipo de Chagra.
+          </p>
+        </div>
+      </ScreenShell>
+    );
+  }
+
+  const { fincas, resumen } = tablero;
+
+  return (
+    <ScreenShell title="Fincas que acompaño" icon={Users} onBack={onBack} onHome={onHome}>
+      <div className="flex flex-col gap-4 px-4 py-4 pb-8 max-w-2xl mx-auto w-full">
+        <p className="text-sm text-slate-300 leading-relaxed">
+          Panel del extensionista: las fincas que supervisas, con su estado de un
+          vistazo. Lo urgente aparece arriba. Toca una finca para ver su detalle
+          (próximamente).
+        </p>
+
+        {/* Aviso de frontera MVP — para no confundir vista previa con permiso real. */}
+        <div className="rounded-xl border border-sky-700/40 bg-sky-900/20 p-3 text-xs text-sky-200 flex items-start gap-2">
+          <Info size={16} className="shrink-0 mt-0.5" aria-hidden="true" />
+          <span>
+            Vista previa: estas fincas son datos de ejemplo. Todavía no es una
+            autorización verificada con cada agricultor — esa delegación segura
+            llega próximamente. Por ahora sirve para probar cómo se verá el
+            acompañamiento a varias fincas.
+          </span>
+        </div>
+
+        {/* Resumen agregado. */}
+        <div className="flex flex-wrap gap-2">
+          <ResumenChip icon={Users} valor={resumen.total} label="fincas que acompañas" tono="neutro" />
+          <ResumenChip icon={AlertTriangle} valor={resumen.con_alertas} label="con alertas" tono={resumen.con_alertas > 0 ? 'alerta' : 'ok'} />
+          <ResumenChip icon={FlaskConical} valor={resumen.con_pendientes} label="con pendientes" tono={resumen.con_pendientes > 0 ? 'aviso' : 'ok'} />
+        </div>
+
+        {/* Lista de fincas o estado vacío. */}
+        {fincas.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/30 p-8 text-center">
+            <Sprout size={32} className="text-slate-600 mx-auto mb-3" aria-hidden="true" />
+            <h3 className="text-sm font-bold text-slate-300 mb-1">
+              Todavía no tienes fincas asignadas
+            </h3>
+            <p className="text-xs text-slate-500 max-w-xs mx-auto">
+              Cuando un agricultor te delegue el acompañamiento de su finca,
+              aparecerá aquí.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {fincas.map((finca) => (
+              <FincaCard key={finca.slug} finca={finca} />
+            ))}
+          </div>
+        )}
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench, Sprout, ChevronRight, Bell } from 'lucide-react';
+import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench, Sprout, ChevronRight, Bell, Users } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
+import { esExtensionistaActual } from '../config/extensionistaAccess';
 import ThemeSelector from './common/ThemeSelector';
 import AgentAvatarSelector from './Settings/AgentAvatarSelector';
 import BackgroundSelector from './Settings/BackgroundSelector';
@@ -424,6 +425,36 @@ export default function ProfileScreen({ onBack, onHome }) {
                 </div>
               )}
             </div>
+
+            {/* Modo extensionista (ADR-048 MVP): entrada al panel supervisor
+                multi-finca. Solo se RENDERIZA si el usuario tiene el rol
+                (feature flag VITE_FEATURE_EXTENSIONISTA + whitelist). Para el
+                resto de usuarios esta sección no existe. Navega vía 'chagra:nav'
+                (patrón CSP-safe, sin onClick inline-string). */}
+            {esExtensionistaActual() && (
+              <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">
+                <div className="flex items-center gap-2 px-1">
+                  <Users size={18} className="text-emerald-400" />
+                  <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">Acompañamiento</h3>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    window.dispatchEvent(new CustomEvent('chagra:nav', { detail: { view: 'extensionista' } }));
+                  }}
+                  className="w-full flex items-center justify-between gap-3 p-3 rounded-xl bg-slate-800/50 hover:bg-slate-700/60 transition-colors min-h-[48px] text-left cursor-pointer"
+                >
+                  <div className="flex flex-col gap-0.5 flex-1">
+                    <span className="text-sm font-bold text-slate-200">Fincas que acompaño</span>
+                    <span className="text-[10px] text-slate-500 leading-snug">
+                      Panel del extensionista: revisa el estado de las fincas que
+                      supervisas. Vista previa con datos de ejemplo.
+                    </span>
+                  </div>
+                  <ChevronRight size={18} className="text-slate-400 shrink-0" aria-hidden="true" />
+                </button>
+              </div>
+            )}
 
             {/* Telemetry Section */}
             <div className="space-y-4 bg-slate-900/40 border border-slate-800 rounded-2xl p-5">

--- a/src/components/__tests__/ExtensionistaScreen.test.jsx
+++ b/src/components/__tests__/ExtensionistaScreen.test.jsx
@@ -1,0 +1,134 @@
+/**
+ * ExtensionistaScreen.test.jsx — panel SUPERVISOR del modo extensionista
+ * (ADR-048 MVP). Lista las fincas delegadas con su estado.
+ *
+ * Contrato cubierto:
+ *   - Sin rol extensionista (o flag off) → mensaje de acceso no disponible,
+ *     NO se listan fincas (gate de UX defensivo).
+ *   - Con rol + fincas → renderiza el resumen (contadores) y una tarjeta por
+ *     finca con nombre, operador y estado legible.
+ *   - Con rol pero sin fincas delegadas → estado vacío explícito (no inventa).
+ *   - El aviso de "datos de ejemplo / no autorización real" (frontera MVP) es
+ *     visible — para no confundir a un piloto con un permiso verificado.
+ *   - Botón volver invoca onBack.
+ *
+ * Español colombiano (tú/usted), SIN voseo. Offline-first.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+const { esExtensionistaActual } = vi.hoisted(() => ({
+  esExtensionistaActual: vi.fn(),
+}));
+const { construirTableroExtensionista } = vi.hoisted(() => ({
+  construirTableroExtensionista: vi.fn(),
+}));
+const { getActiveTenantId } = vi.hoisted(() => ({ getActiveTenantId: vi.fn() }));
+
+vi.mock('../../config/extensionistaAccess', () => ({ esExtensionistaActual }));
+vi.mock('../../services/extensionistaService', () => ({
+  construirTableroExtensionista,
+}));
+vi.mock('../../services/tenantContext', () => ({ getActiveTenantId }));
+
+import ExtensionistaScreen from '../ExtensionistaScreen';
+
+const TABLERO = {
+  fincas: [
+    {
+      slug: 'finca-el-paramo',
+      nombre: 'Finca El Páramo',
+      operador: 'pedro_g',
+      municipio: 'Choachí',
+      estado: 'sin_sync_reciente',
+      pendientes: 0,
+      alertas: 2,
+      _clasificacion: { label: 'Sin sincronizar hace días', severidad: 3, tono: 'alerta' },
+    },
+    {
+      slug: 'finca-la-esperanza',
+      nombre: 'Finca La Esperanza',
+      operador: 'campesino_juan',
+      municipio: 'Silvania',
+      estado: 'al_dia',
+      pendientes: 0,
+      alertas: 0,
+      _clasificacion: { label: 'Al día', severidad: 0, tono: 'ok' },
+    },
+  ],
+  resumen: { total: 2, con_alertas: 1, con_pendientes: 0 },
+};
+
+beforeEach(() => {
+  esExtensionistaActual.mockReset();
+  construirTableroExtensionista.mockReset();
+  getActiveTenantId.mockReset();
+  getActiveTenantId.mockReturnValue('demo-extensionista');
+});
+afterEach(() => cleanup());
+
+describe('ExtensionistaScreen — gate de rol', () => {
+  it('sin rol extensionista muestra acceso no disponible y NO lista fincas', () => {
+    esExtensionistaActual.mockReturnValue(false);
+    construirTableroExtensionista.mockReturnValue(TABLERO);
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    expect(screen.getByText('Vista no disponible')).toBeInTheDocument();
+    expect(screen.queryByText('Finca El Páramo')).not.toBeInTheDocument();
+    // No debe ni construir el tablero si no hay rol.
+    expect(construirTableroExtensionista).not.toHaveBeenCalled();
+  });
+});
+
+describe('ExtensionistaScreen — con rol extensionista', () => {
+  beforeEach(() => {
+    esExtensionistaActual.mockReturnValue(true);
+  });
+
+  it('renderiza el resumen con los contadores agregados', () => {
+    construirTableroExtensionista.mockReturnValue(TABLERO);
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    // El resumen expone las etiquetas de los chips agregados.
+    expect(screen.getByText('fincas que acompañas')).toBeInTheDocument();
+    expect(screen.getByText('con alertas')).toBeInTheDocument();
+    expect(screen.getByText('con pendientes')).toBeInTheDocument();
+  });
+
+  it('renderiza una tarjeta por finca con nombre, operador y estado', () => {
+    construirTableroExtensionista.mockReturnValue(TABLERO);
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    expect(screen.getByText('Finca El Páramo')).toBeInTheDocument();
+    expect(screen.getByText('Finca La Esperanza')).toBeInTheDocument();
+    expect(screen.getByText(/pedro_g/)).toBeInTheDocument();
+    expect(screen.getByText(/Sin sincronizar hace días/)).toBeInTheDocument();
+    expect(screen.getByText(/Al día/)).toBeInTheDocument();
+  });
+
+  it('muestra el aviso de frontera MVP (datos de ejemplo, no autorización real)', () => {
+    construirTableroExtensionista.mockReturnValue(TABLERO);
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    expect(
+      screen.getByText(/Todavía no es una\s+autorización verificada/i)
+    ).toBeInTheDocument();
+  });
+
+  it('sin fincas delegadas muestra estado vacío explícito (no inventa)', () => {
+    construirTableroExtensionista.mockReturnValue({
+      fincas: [],
+      resumen: { total: 0, con_alertas: 0, con_pendientes: 0 },
+    });
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    expect(
+      screen.getByText('Todavía no tienes fincas asignadas')
+    ).toBeInTheDocument();
+  });
+
+  it('el botón volver invoca onBack', () => {
+    construirTableroExtensionista.mockReturnValue(TABLERO);
+    const onBack = vi.fn();
+    render(<ExtensionistaScreen onBack={onBack} />);
+    // ScreenShell expone "Volver" (atrás) y "Volver al inicio" (home);
+    // el botón atrás tiene el aria-label exacto "Volver".
+    fireEvent.click(screen.getByLabelText('Volver'));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/src/config/__tests__/extensionistaAccess.test.js
+++ b/src/config/__tests__/extensionistaAccess.test.js
@@ -1,0 +1,125 @@
+/**
+ * extensionistaAccess.test.js — TDD del gate de ROL "extensionista" (MVP modo
+ * supervisor multi-finca, ADR-048).
+ *
+ * Un extensionista es un usuario que SUPERVISA varias fincas de OTROS
+ * agricultores (asesor SENA/EPSEA, técnico Agrosavia/IPPTA, líder de
+ * asociación). NO es lo mismo que el multi-finca de 1 usuario de ADR-036:
+ * acá el usuario observa fincas que NO le pertenecen.
+ *
+ * Cobertura:
+ *  - esExtensionista: username en whitelist → true.
+ *  - esExtensionista: username fuera de whitelist → false.
+ *  - esExtensionista: null / undefined / vacío / solo espacios → false.
+ *  - esExtensionista: match case-insensitive y tolerante a espacios (trim).
+ *  - EXTENSIONISTA_WHITELIST exporta un Set (editable por el operador).
+ *  - esExtensionistaActual: lee el tenantId activo de localStorage (offline).
+ *  - El gate respeta el feature flag VITE_FEATURE_EXTENSIONISTA: con la flag
+ *    apagada, NADIE es extensionista (kill-switch global), aunque esté en la
+ *    whitelist.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const importFresh = async () => {
+  vi.resetModules();
+  return import('../extensionistaAccess.js');
+};
+
+describe('extensionistaAccess — esExtensionista (función pura)', () => {
+  let mod;
+
+  beforeEach(async () => {
+    // Por defecto en tests la flag está ON para poder probar la whitelist.
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    mod = await importFresh();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('devuelve true para usernames extensionistas de la whitelist', () => {
+    // El username de demo está en la whitelist seed por defecto.
+    expect(mod.esExtensionista('demo-extensionista')).toBe(true);
+  });
+
+  it('devuelve false para usernames fuera de la whitelist', () => {
+    expect(mod.esExtensionista('campesino_juan')).toBe(false);
+    expect(mod.esExtensionista('random_user_xyz')).toBe(false);
+  });
+
+  it('devuelve false para null/undefined/vacío/solo-espacios (defensive)', () => {
+    expect(mod.esExtensionista(null)).toBe(false);
+    expect(mod.esExtensionista(undefined)).toBe(false);
+    expect(mod.esExtensionista('')).toBe(false);
+    expect(mod.esExtensionista('   ')).toBe(false);
+    expect(mod.esExtensionista(123)).toBe(false);
+  });
+
+  it('hace match case-insensitive y tolerante a espacios (trim)', () => {
+    expect(mod.esExtensionista('  DEMO-EXTENSIONISTA  ')).toBe(true);
+    expect(mod.esExtensionista('Demo-Extensionista')).toBe(true);
+  });
+
+  it('EXTENSIONISTA_WHITELIST es un Set no vacío y editable', () => {
+    expect(mod.EXTENSIONISTA_WHITELIST instanceof Set).toBe(true);
+    expect(mod.EXTENSIONISTA_WHITELIST.size).toBeGreaterThan(0);
+  });
+});
+
+describe('extensionistaAccess — feature flag VITE_FEATURE_EXTENSIONISTA (kill-switch)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('con la flag OFF nadie es extensionista, aunque esté en la whitelist', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'false');
+    const mod = await importFresh();
+    expect(mod.featureExtensionistaActivo()).toBe(false);
+    expect(mod.esExtensionista('demo-extensionista')).toBe(false);
+  });
+
+  it('con la flag indefinida (default) el modo está apagado', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', '');
+    const mod = await importFresh();
+    expect(mod.featureExtensionistaActivo()).toBe(false);
+    expect(mod.esExtensionista('demo-extensionista')).toBe(false);
+  });
+
+  it('acepta "1" como string-verdadero para la flag', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', '1');
+    const mod = await importFresh();
+    expect(mod.featureExtensionistaActivo()).toBe(true);
+    expect(mod.esExtensionista('demo-extensionista')).toBe(true);
+  });
+});
+
+describe('extensionistaAccess — esExtensionistaActual (lee tenant activo, offline)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it('true cuando el tenant activo está en la whitelist', async () => {
+    const mod = await importFresh();
+    // tenantContext persiste en esta misma key.
+    localStorage.setItem('chagra:active_tenant_id', 'demo-extensionista');
+    expect(mod.esExtensionistaActual()).toBe(true);
+  });
+
+  it('false cuando no hay tenant activo (sin login)', async () => {
+    const mod = await importFresh();
+    expect(mod.esExtensionistaActual()).toBe(false);
+  });
+
+  it('false cuando el tenant activo NO está en la whitelist', async () => {
+    const mod = await importFresh();
+    localStorage.setItem('chagra:active_tenant_id', 'campesino_juan');
+    expect(mod.esExtensionistaActual()).toBe(false);
+  });
+});

--- a/src/config/extensionistaAccess.js
+++ b/src/config/extensionistaAccess.js
@@ -1,0 +1,128 @@
+/**
+ * extensionistaAccess.js — Gate del ROL "extensionista" (modo supervisor
+ * multi-finca). MVP de ADR-048.
+ *
+ * QUÉ ES UN EXTENSIONISTA
+ *   Un usuario que SUPERVISA fincas de OTROS agricultores: el asesor de
+ *   extensión rural (EPSEA/SENA), el técnico Agrosavia/IPPTA, el líder de una
+ *   asociación campesina que acompaña a sus asociados. Ve un panel con las
+ *   fincas que le delegaron, NO opera la suya propia.
+ *
+ * DIFERENCIA CON ADR-036 (multi-finca de 1 usuario)
+ *   - `tenantContext` (ADR-036 MVP) resuelve "quién soy yo" (un agricultor con
+ *     una o más fincas PROPIAS) para scopear sus assets en farmOS.
+ *   - `extensionistaAccess` (este módulo, ADR-048) resuelve "¿soy un supervisor
+ *     que puede VER fincas ajenas?". Es una capa de ROL por encima del tenant.
+ *
+ * POR QUÉ ES SOLO MVP (lo duro queda como follow-up backend)
+ *   La delegación real "el agricultor X autoriza al extensionista Y a ver su
+ *   finca" requiere UCAN delegations + el módulo Drupal `farm_did_auth`
+ *   (ADR-036 sub-i / sub-iv). HOY no existe ese backend. Por eso este MVP:
+ *     (1) detecta el rol con una whitelist client-side (igual patrón que
+ *         glaciarAccess.js / La Cordada), y
+ *     (2) lee la lista de fincas delegadas de un MOCK/config estático
+ *         (src/data/extensionista-fincas.json), NO de una autorización
+ *         verificada server-side.
+ *   Es DEFENSE-IN-DEPTH de UX + scaffold de producto, NO autorización dura. El
+ *   día que ADR-036 active UCAN, `esExtensionista` se sustituye por la
+ *   verificación de una capability `supervise` firmada por el dueño de la finca.
+ *
+ * DOBLE CANDADO
+ *   1. Feature flag global `VITE_FEATURE_EXTENSIONISTA` (kill-switch). Con la
+ *      flag apagada (default), el modo NO existe para NADIE — ni la ruta, ni el
+ *      tile, ni el panel. Permite shippear el código a producción dark hasta
+ *      que el backend esté listo.
+ *   2. Whitelist de usernames `EXTENSIONISTA_WHITELIST`. Aun con la flag ON,
+ *      solo estos usuarios entran al modo supervisor.
+ *
+ * OFFLINE-FIRST
+ *   La verificación NO requiere red. Usa el username del login ya guardado por
+ *   tenantContext en localStorage. Funciona idéntico online u offline.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @module extensionistaAccess
+ */
+
+import { getActiveTenantId } from '../services/tenantContext.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WHITELIST — editar SOLO este Set para dar/quitar el rol extensionista.
+// Son los usuarios con perfil de asesor de extensión / técnico / líder de
+// asociación. Los usernames se normalizan (trim + lowercase) en el match, así
+// que el formato exacto acá no es crítico.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Set de usernames farmOS con ROL extensionista (acceso al panel supervisor).
+ *
+ * Para dar el rol: añadir su username (lowercase) a este Set.
+ * Para revocar: eliminar la línea.
+ *
+ * @constant {Set<string>}
+ */
+export const EXTENSIONISTA_WHITELIST = new Set([
+  'demo-extensionista', // Placeholder de piloto. Reemplazar por el username
+  // farmOS real del asesor/técnico al activar el modo (mismo patrón que
+  // CORDADA_WHITELIST en glaciarAccess.js).
+]);
+
+const FLAG_KEY = 'VITE_FEATURE_EXTENSIONISTA';
+
+/**
+ * Lee el feature flag global del modo extensionista. Acepta los strings
+ * 'true' / '1' (case-insensitive, con espacios) como habilitado; cualquier
+ * otro valor — incluido undefined o '' — deja el modo APAGADO (default off).
+ *
+ * Mismo criterio de parseo que `isSidecarEnabled()` en sidecarClient.js para
+ * mantener la convención del repo.
+ *
+ * @returns {boolean}
+ */
+export function featureExtensionistaActivo() {
+  try {
+    const raw = import.meta.env?.[FLAG_KEY];
+    if (raw === true) return true;
+    if (typeof raw === 'string') {
+      const v = raw.trim().toLowerCase();
+      return v === 'true' || v === '1';
+    }
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Función pura: ¿este username tiene el rol extensionista?
+ *
+ * Doble candado:
+ *   - si el feature flag global está apagado → false para todos (kill-switch);
+ *   - si está encendido → true solo si el username está en la whitelist.
+ *
+ * Normaliza con trim() + toLowerCase() antes de comparar (tolerante a
+ * capitalización accidental o espacios alrededor).
+ *
+ * @param {string|null|undefined} username — username farmOS del usuario.
+ * @returns {boolean} true si tiene el rol; false en todos los demás casos
+ *   (flag off, null, undefined, vacío, solo espacios, fuera de la whitelist).
+ */
+export function esExtensionista(username) {
+  if (!featureExtensionistaActivo()) return false;
+  if (!username || typeof username !== 'string') return false;
+  const normalized = username.trim().toLowerCase();
+  if (normalized.length === 0) return false;
+  return EXTENSIONISTA_WHITELIST.has(normalized);
+}
+
+/**
+ * ¿El usuario actualmente logueado tiene el rol extensionista?
+ *
+ * Lee el username persistido por `tenantContext` (se setea en el login OAuth).
+ * No requiere red — funciona offline con el usuario ya guardado localmente.
+ *
+ * @returns {boolean}
+ */
+export function esExtensionistaActual() {
+  return esExtensionista(getActiveTenantId());
+}

--- a/src/data/extensionista-fincas.json
+++ b/src/data/extensionista-fincas.json
@@ -1,0 +1,47 @@
+{
+  "fuente": "MOCK/scaffold ADR-048 modo extensionista — datos de ejemplo, NO autorización verificada. La delegación real (UCAN/farm_did_auth, ADR-036) es follow-up backend. No usar para inferencias agronómicas.",
+  "esquema": "src/services/extensionistaService.js",
+  "delegaciones": [
+    {
+      "extensionista": "demo-extensionista",
+      "fincas": [
+        {
+          "slug": "finca-la-esperanza",
+          "nombre": "Finca La Esperanza",
+          "operador": "campesino_juan",
+          "vereda": "El Triunfo",
+          "municipio": "Silvania",
+          "biocultural_zone": "andino_medio",
+          "estado": "al_dia",
+          "ultima_sync_iso": "2026-06-12T14:30:00Z",
+          "pendientes": 0,
+          "alertas": 0
+        },
+        {
+          "slug": "finca-buenos-aires",
+          "nombre": "Finca Buenos Aires",
+          "operador": "maria_t",
+          "vereda": "Aguabonita",
+          "municipio": "Fusagasugá",
+          "biocultural_zone": "andino_medio",
+          "estado": "con_pendientes",
+          "ultima_sync_iso": "2026-06-09T09:10:00Z",
+          "pendientes": 3,
+          "alertas": 1
+        },
+        {
+          "slug": "finca-el-paramo",
+          "nombre": "Finca El Páramo",
+          "operador": "pedro_g",
+          "vereda": "Cruz Verde",
+          "municipio": "Choachí",
+          "biocultural_zone": "andino_alto_páramo",
+          "estado": "sin_sync_reciente",
+          "ultima_sync_iso": "2026-05-28T18:45:00Z",
+          "pendientes": 0,
+          "alertas": 2
+        }
+      ]
+    }
+  ]
+}

--- a/src/services/__tests__/extensionistaService.test.js
+++ b/src/services/__tests__/extensionistaService.test.js
@@ -1,0 +1,132 @@
+/**
+ * extensionistaService.test.js — TDD del servicio del modo extensionista
+ * (panel supervisor multi-finca, ADR-048 MVP).
+ *
+ * El servicio NO toca red ni backend: lee la lista de fincas delegadas de un
+ * MOCK estático (src/data/extensionista-fincas.json) y la transforma en un
+ * modelo de tablero ordenado y resumido. Es scaffold cliente; la delegación
+ * real (UCAN) es follow-up backend (ver extensionistaAccess.js / ADR-048).
+ *
+ * Cobertura:
+ *  - getFincasDelegadas: devuelve las fincas del extensionista dado.
+ *  - getFincasDelegadas: usuario sin delegaciones → [] (no inventa).
+ *  - getFincasDelegadas: normaliza el username (trim + lowercase).
+ *  - getFincasDelegadas: null/undefined/no-string → [].
+ *  - clasificarEstadoFinca: mapea cada estado conocido a {label, severidad}.
+ *  - clasificarEstadoFinca: estado desconocido → severidad neutra, sin tirar.
+ *  - construirTableroExtensionista: orden por severidad (alertas primero) +
+ *    contadores agregados (total, con_alertas, con_pendientes).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getFincasDelegadas,
+  clasificarEstadoFinca,
+  construirTableroExtensionista,
+  ESTADO_SEVERIDAD,
+} from '../extensionistaService.js';
+
+describe('extensionistaService — getFincasDelegadas', () => {
+  it('devuelve las fincas delegadas al extensionista del seed', () => {
+    const fincas = getFincasDelegadas('demo-extensionista');
+    expect(Array.isArray(fincas)).toBe(true);
+    expect(fincas.length).toBeGreaterThan(0);
+    // Cada finca trae los campos mínimos que el tablero consume.
+    for (const f of fincas) {
+      expect(f).toHaveProperty('slug');
+      expect(f).toHaveProperty('nombre');
+      expect(f).toHaveProperty('operador');
+      expect(f).toHaveProperty('estado');
+    }
+  });
+
+  it('normaliza el username (trim + case-insensitive)', () => {
+    expect(getFincasDelegadas('  DEMO-EXTENSIONISTA  ').length).toBe(
+      getFincasDelegadas('demo-extensionista').length
+    );
+  });
+
+  it('devuelve [] para un extensionista sin delegaciones (no inventa)', () => {
+    expect(getFincasDelegadas('desconocido_xyz')).toEqual([]);
+  });
+
+  it('devuelve [] para null / undefined / no-string', () => {
+    expect(getFincasDelegadas(null)).toEqual([]);
+    expect(getFincasDelegadas(undefined)).toEqual([]);
+    expect(getFincasDelegadas(123)).toEqual([]);
+    expect(getFincasDelegadas('')).toEqual([]);
+  });
+
+  it('devuelve copias, no referencias al mock (no se puede mutar el seed)', () => {
+    const a = getFincasDelegadas('demo-extensionista');
+    a[0].nombre = 'MUTADO';
+    const b = getFincasDelegadas('demo-extensionista');
+    expect(b[0].nombre).not.toBe('MUTADO');
+  });
+});
+
+describe('extensionistaService — clasificarEstadoFinca', () => {
+  it('mapea cada estado conocido a label + severidad', () => {
+    for (const estado of Object.keys(ESTADO_SEVERIDAD)) {
+      const c = clasificarEstadoFinca(estado);
+      expect(typeof c.label).toBe('string');
+      expect(c.label.length).toBeGreaterThan(0);
+      expect(typeof c.severidad).toBe('number');
+    }
+  });
+
+  it('al_dia tiene menor severidad que con_pendientes y sin_sync_reciente', () => {
+    expect(clasificarEstadoFinca('al_dia').severidad).toBeLessThan(
+      clasificarEstadoFinca('con_pendientes').severidad
+    );
+    expect(clasificarEstadoFinca('al_dia').severidad).toBeLessThan(
+      clasificarEstadoFinca('sin_sync_reciente').severidad
+    );
+  });
+
+  it('estado desconocido → severidad neutra y label no vacío (no tira)', () => {
+    const c = clasificarEstadoFinca('estado_inexistente');
+    expect(c.label.length).toBeGreaterThan(0);
+    expect(typeof c.severidad).toBe('number');
+  });
+
+  it('estado null/undefined no tira', () => {
+    expect(() => clasificarEstadoFinca(null)).not.toThrow();
+    expect(() => clasificarEstadoFinca(undefined)).not.toThrow();
+  });
+});
+
+describe('extensionistaService — construirTableroExtensionista', () => {
+  it('ordena las fincas por severidad descendente (lo urgente arriba)', () => {
+    const tablero = construirTableroExtensionista('demo-extensionista');
+    const sevs = tablero.fincas.map((f) => f._clasificacion.severidad);
+    const ordenado = [...sevs].sort((a, b) => b - a);
+    expect(sevs).toEqual(ordenado);
+  });
+
+  it('agrega contadores: total, con_alertas, con_pendientes', () => {
+    const tablero = construirTableroExtensionista('demo-extensionista');
+    expect(tablero.resumen.total).toBe(tablero.fincas.length);
+    expect(tablero.resumen.con_alertas).toBe(
+      tablero.fincas.filter((f) => (f.alertas || 0) > 0).length
+    );
+    expect(tablero.resumen.con_pendientes).toBe(
+      tablero.fincas.filter((f) => (f.pendientes || 0) > 0).length
+    );
+  });
+
+  it('extensionista sin fincas → tablero vacío coherente (no inventa)', () => {
+    const tablero = construirTableroExtensionista('desconocido_xyz');
+    expect(tablero.fincas).toEqual([]);
+    expect(tablero.resumen.total).toBe(0);
+    expect(tablero.resumen.con_alertas).toBe(0);
+    expect(tablero.resumen.con_pendientes).toBe(0);
+  });
+
+  it('cada finca del tablero trae su clasificación adjunta', () => {
+    const tablero = construirTableroExtensionista('demo-extensionista');
+    for (const f of tablero.fincas) {
+      expect(f._clasificacion).toBeTruthy();
+      expect(typeof f._clasificacion.label).toBe('string');
+    }
+  });
+});

--- a/src/services/extensionistaService.js
+++ b/src/services/extensionistaService.js
@@ -1,0 +1,123 @@
+/**
+ * extensionistaService.js — Lógica del modo EXTENSIONISTA (panel supervisor
+ * multi-finca). MVP de ADR-048.
+ *
+ * Resuelve, para un extensionista dado, la lista de fincas que supervisa y la
+ * transforma en un modelo de tablero (ordenado por urgencia + contadores
+ * agregados) que consume `ExtensionistaScreen.jsx`.
+ *
+ * FRONTERA MVP vs FOLLOW-UP BACKEND
+ *   - HOY: la lista de fincas delegadas sale de un MOCK estático
+ *     (src/data/extensionista-fincas.json). NO es una autorización verificada;
+ *     es scaffold de producto para iterar la UX del panel supervisor.
+ *   - FOLLOW-UP (ADR-036 sub-i/sub-iv): la delegación real será una capability
+ *     UCAN `supervise`/`read` firmada por el dueño de cada finca y validada por
+ *     el módulo Drupal `farm_did_auth`. Cuando exista, `getFincasDelegadas`
+ *     consultará esas delegaciones (y el estado/última-sync vendrá de farmOS
+ *     JSON:API con scoping por finca) en vez del JSON estático. La FORMA del
+ *     modelo de tablero se mantiene para no reescribir la UI.
+ *
+ * Funciones PURAS, offline-first (no red), degradan sin inventar:
+ *   - getFincasDelegadas(username) → Finca[]  (copias defensivas).
+ *   - clasificarEstadoFinca(estado) → { label, severidad, tono }.
+ *   - construirTableroExtensionista(username) → { fincas, resumen }.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @module extensionistaService
+ */
+
+import DATA from '../data/extensionista-fincas.json';
+
+/**
+ * Catálogo de estados de finca → severidad (orden de urgencia en el tablero) +
+ * etiqueta legible + tono semántico para la UI. Severidad mayor = más arriba.
+ *
+ * Mantener alineado con los `estado` posibles del seed
+ * (src/data/extensionista-fincas.json). Si el seed trae un estado no listado
+ * acá, `clasificarEstadoFinca` degrada a neutro (no rompe el render).
+ *
+ * @constant {Record<string, { label: string, severidad: number, tono: string }>}
+ */
+export const ESTADO_SEVERIDAD = Object.freeze({
+  sin_sync_reciente: { label: 'Sin sincronizar hace días', severidad: 3, tono: 'alerta' },
+  con_pendientes: { label: 'Con registros pendientes', severidad: 2, tono: 'aviso' },
+  al_dia: { label: 'Al día', severidad: 0, tono: 'ok' },
+});
+
+const ESTADO_DESCONOCIDO = Object.freeze({
+  label: 'Estado desconocido',
+  severidad: 1,
+  tono: 'neutro',
+});
+
+const isNonEmptyStr = (v) => typeof v === 'string' && v.trim().length > 0;
+
+function normalizarUsername(username) {
+  if (!isNonEmptyStr(username)) return null;
+  return username.trim().toLowerCase();
+}
+
+/**
+ * Lista de fincas que un extensionista supervisa, según el mock de delegación.
+ *
+ * Devuelve COPIAS defensivas (clon superficial por finca) para que el caller no
+ * pueda mutar el JSON importado en memoria.
+ *
+ * @param {string|null|undefined} username — username del extensionista.
+ * @returns {Array<object>} fincas delegadas; [] si no hay (sin inventar).
+ */
+export function getFincasDelegadas(username) {
+  const norm = normalizarUsername(username);
+  if (!norm) return [];
+  const delegaciones = Array.isArray(DATA?.delegaciones) ? DATA.delegaciones : [];
+  const entry = delegaciones.find(
+    (d) => normalizarUsername(d?.extensionista) === norm
+  );
+  if (!entry || !Array.isArray(entry.fincas)) return [];
+  return entry.fincas.map((f) => ({ ...f }));
+}
+
+/**
+ * Clasifica el estado de una finca en { label, severidad, tono } para el
+ * tablero. Estado desconocido o nulo → clasificación neutra (no tira).
+ *
+ * @param {string|null|undefined} estado
+ * @returns {{ label: string, severidad: number, tono: string }}
+ */
+export function clasificarEstadoFinca(estado) {
+  if (!isNonEmptyStr(estado)) return { ...ESTADO_DESCONOCIDO };
+  const c = ESTADO_SEVERIDAD[estado];
+  return c ? { ...c } : { ...ESTADO_DESCONOCIDO };
+}
+
+/**
+ * Construye el modelo del tablero supervisor para un extensionista:
+ *   - `fincas`: las delegadas, cada una con su `_clasificacion` adjunta,
+ *     ORDENADAS por severidad descendente (lo urgente arriba) y, a igual
+ *     severidad, por nombre (estable).
+ *   - `resumen`: contadores agregados { total, con_alertas, con_pendientes }.
+ *
+ * @param {string|null|undefined} username — username del extensionista.
+ * @returns {{ fincas: Array<object>, resumen: { total: number, con_alertas: number, con_pendientes: number } }}
+ */
+export function construirTableroExtensionista(username) {
+  const fincas = getFincasDelegadas(username).map((f) => ({
+    ...f,
+    _clasificacion: clasificarEstadoFinca(f.estado),
+  }));
+
+  fincas.sort((a, b) => {
+    const ds = b._clasificacion.severidad - a._clasificacion.severidad;
+    if (ds !== 0) return ds;
+    return String(a.nombre || '').localeCompare(String(b.nombre || ''), 'es');
+  });
+
+  const resumen = {
+    total: fincas.length,
+    con_alertas: fincas.filter((f) => (f.alertas || 0) > 0).length,
+    con_pendientes: fincas.filter((f) => (f.pendientes || 0) > 0).length,
+  };
+
+  return { fincas, resumen };
+}


### PR DESCRIPTION
## Qué

Implementa el **modo extensionista** (Tarea #9 del set de 10): un rol que **supervisa fincas de OTROS agricultores** — asesor de extensión rural (EPSEA/SENA), técnico Agrosavia/IPPTA, líder de asociación campesina.

Es una **capa de ROL** por encima del tenant, **distinta** del multi-finca de 1 usuario de **ADR-036** (`src/services/tenantContext.js`, que se **reúsa sin duplicar**). `tenantContext` responde "qué finca propia scopeo"; `extensionistaAccess` responde "¿soy un supervisor que puede VER fincas ajenas?". Son ortogonales.

## MVP (lo que ships ahora, flag OFF por defecto)

100% cliente, offline-first, theme-aware, español Colombia (sin voseo), **sin backend nuevo**:

- **`src/config/extensionistaAccess.js`** — gate de rol con **doble candado**: feature flag global `VITE_FEATURE_EXTENSIONISTA` (kill-switch, default `false`) + whitelist de usernames. Mismo patrón probado que `glaciarAccess.js` (La Cordada).
- **`src/data/extensionista-fincas.json`** — mock de fincas delegadas por extensionista (datos de ejemplo; **NO** autorización verificada). Pasa el guard anti-fabricación `dataSchema.fuente.test.js`.
- **`src/services/extensionistaService.js`** — modelo de tablero: `getFincasDelegadas()`, `clasificarEstadoFinca()`, `construirTableroExtensionista()` (orden por urgencia + contadores agregados). Funciones puras, degradan sin inventar.
- **`src/components/ExtensionistaScreen.jsx`** — panel supervisor `#extensionista` (ScreenShell theme-aware): resumen + tarjeta por finca con estado + **aviso explícito de "vista previa, no autorización verificada"** para no confundir a un piloto.
- **`src/App.jsx`** — ruta `#extensionista` + guards de rol en los efectos de ruta + `case` en el switch (colocados lejos del módulo glaciar para evitar colisión de merge).
- **`src/components/ProfileScreen.jsx`** — sección "Acompañamiento" que solo se **renderiza con rol**, navega vía `chagra:nav` (CSP-safe).
- **`.env.example`** — documenta `VITE_FEATURE_EXTENSIONISTA`.

## Follow-up backend (documentado en el ADR, NO en este PR)

La delegación real **el agricultor autoriza al extensionista** requiere **UCAN delegations + módulo Drupal `farm_did_auth`** (ADR-036 sub-i/sub-iv), datos en vivo por finca desde farmOS JSON:API con anonimización Ley 1581, revocación + audit log, y drill-down de detalle. La **forma del modelo de tablero** se diseñó para sobrevivir ese cambio de fuente sin reescribir la UI.

## Articulación con la visión SENA-FAO / Agrosavia / IPPTA

El extensionista es la unidad de **escalamiento institucional**: permite demostrar el flujo de acompañamiento multi-finca a aliados (SENA, Agrosavia regional, IPPTA) **ya**, con datos de ejemplo, y co-diseñar la UX antes de invertir en el stack criptográfico UCAN.

## Decisión arquitectónica

**ADR-048** (`docs/adr/ADR-048-modo-extensionista-multi-finca.md`): rol vs tenant, doble candado, MVP cliente vs follow-up backend, alternativas consideradas.

## Tests (TDD)

- `extensionistaAccess.test.js` (12) + `extensionistaService.test.js` (12) = 24 tests gate+servicio.
- `ExtensionistaScreen.test.jsx` (6) tests UI.
- Verificado: `dataSchema.fuente.test.js` (78) y `App.evolucion-route.test.jsx` (1) siguen verdes.
- `eslint --max-warnings=0` **limpio en lo tocado**.

> Nota: `npm run lint` (repo completo) reporta ~22 errores PRE-EXISTENTES en archivos no tocados por este PR (openaiStream.js, soilDiagnostic.js, socialPrefiltro.js, etc.) — heredados de `origin/main`, fuera del alcance de esta tarea. El hook pre-commit (`eslint {staged_files}`) sí valida solo lo staged y pasa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)