### PR TITLE
fix(test): alinear DB_VERSION test comment a versión actual 23

### DIFF
--- a/tests/unit/sw-telemetry-db-version.test.js
+++ b/tests/unit/sw-telemetry-db-version.test.js
@@ -3,7 +3,7 @@
  * en el Service Worker (Tarea #8).
  *
  * Bug: `getPendingTelemetryEvents` abría `indexedDB.open('ChagraDB', 10)` con
- * una versión HARDCODEADA (10) menor a la actual de `dbCore` (DB_VERSION ≥ 20).
+ * una versión HARDCODEADA (10) menor a la actual de `dbCore` (DB_VERSION = 23).
  * `indexedDB.open(name, N)` con N < versión-vigente lanza `VersionError`, así
  * que la función SIEMPRE fallaba y el background-sync de voice-telemetry nunca
  * podía drenar eventos.


### PR DESCRIPTION
## Summary
Alinea el comentario del test `sw-telemetry-db-version.test.js` para reflejar la versión actual de `DB_VERSION = 23` en `src/db/dbCore.js`.

Antes el test mencionaba `DB_VERSION ≥ 20`, pero la versión actual es 23.

## Test plan
- ✅ `npx vitest run tests/unit/sw-telemetry-db-version.test.js` - PASSED (3 tests)
- ✅ `npx vitest run tests/unit/` - PASSED (170 tests in 12 files)
- ✅ `npx eslint tests/unit/sw-telemetry-db-version.test.js --max-warnings=0` - PASSED
- ✅ `npm run build` - PASSED (vite build exitoso)
- ✅ Lefthook pre-commit checks (secret-scan, infra-refs-scan, strategic-content-scan, eslint, conventional) - PASSED

## Cambios
- `tests/unit/sw-telemetry-db-version.test.js`: Actualizado comentario de línea 6 `DB_VERSION ≥ 20` → `DB_VERSION = 23`

## Riesgos conocidos
Ninguno. Cambio puramente de documentación en test para mantener sincronía con `src/db/dbCore.js`.