### PR TITLE
feat(glaciar): generador de metadata Zenodo DOI para datasets glaciares

### DIFF
--- a/src/services/__tests__/glaciarZenodoMeta.test.js
+++ b/src/services/__tests__/glaciarZenodoMeta.test.js
@@ -1,0 +1,424 @@
+/**
+ * glaciarZenodoMeta.test.js — tests de generador de metadata Zenodo DOI.
+ *
+ * Verifica que buildZenodoMetadata() genera objetos JSON válidos según la API
+ * de depósito Zenodo v10.13.0. Tests de:
+ *   - Estructura básica (metadata, upload_type, etc.)
+ *   - Creators (explícitos vs deducidos de reportes)
+ *   - Título (explícito vs generado)
+ *   - Descripción (generada desde reportes)
+ *   - Keywords (fijos + derivados)
+ *   - Fechas y versiones
+ *   - Casos edge (array vacío, sin opciones, etc.)
+ */
+import { describe, it, expect } from 'vitest';
+import { buildZenodoMetadata } from '../glaciarZenodoMeta';
+
+describe('buildZenodoMetadata — estructura básica', () => {
+  it('devuelve objeto con metadata raíz', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result).toHaveProperty('metadata');
+    expect(typeof result.metadata).toBe('object');
+  });
+
+  it('upload_type es "dataset" siempre', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.upload_type).toBe('dataset');
+  });
+
+  it('access_right es "open" siempre', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.access_right).toBe('open');
+  });
+
+  it('license es "cc-by-4.0" siempre (Chagra forzado)', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.license).toBe('cc-by-4.0');
+  });
+
+  it('language es "es" siempre', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.language).toBe('es');
+  });
+});
+
+describe('buildZenodoMetadata — creators', () => {
+  it('creators explícitos se usan tal cual (array de strings)', () => {
+    const result = buildZenodoMetadata([], {
+      creators: ['Ana Pérez', 'Juan García'],
+    });
+    expect(result.metadata.creators).toEqual([
+      { name: 'Ana Pérez' },
+      { name: 'Juan García' },
+    ]);
+  });
+
+  it('creators explícitos se respetan si son objetos con name', () => {
+    const result = buildZenodoMetadata([], {
+      creators: [{ name: 'Carla López', affiliation: 'UIAA' }],
+    });
+    expect(result.metadata.creators).toEqual([
+      { name: 'Carla López', affiliation: 'UIAA' },
+    ]);
+  });
+
+  it('creators se deducen de reportes[].guia si no se proveen', () => {
+    const result = buildZenodoMetadata(
+      [
+        { guia: 'Pedro Martínez', montana: 'cocuy_ritacuba' },
+        { guia: 'Pedro Martínez', montana: 'ruiz' },
+        { guia: 'Lucía Ramírez', montana: 'tolima' },
+      ],
+      {}
+    );
+    expect(result.metadata.creators).toEqual([
+      { name: 'Lucía Ramírez' },
+      { name: 'Pedro Martínez' },
+    ]);
+  });
+
+  it('creators vacío si no hay reportes ni opción', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.creators).toEqual([]);
+  });
+
+  it('creators se deducen y ordenan alfabéticamente', () => {
+    const result = buildZenodoMetadata(
+      [
+        { guia: 'Zoe García' },
+        { guia: 'Ana Pérez' },
+        { guia: 'Miguel Torres' },
+      ],
+      {}
+    );
+    expect(result.metadata.creators).toEqual([
+      { name: 'Ana Pérez' },
+      { name: 'Miguel Torres' },
+      { name: 'Zoe García' },
+    ]);
+  });
+});
+
+describe('buildZenodoMetadata — title', () => {
+  it('title explícito se respeta', () => {
+    const result = buildZenodoMetadata([], {
+      title: 'Mi dataset glaciar personalizado',
+    });
+    expect(result.metadata.title).toBe('Mi dataset glaciar personalizado');
+  });
+
+  it('title generado con montaña y año si hay reportes', () => {
+    const result = buildZenodoMetadata(
+      [{ montana: 'cocuy_ritacuba', createdAt: 1641024000000 }], // 2022-01-01 08:00:00 local
+      {}
+    );
+    expect(result.metadata.title).toMatch(/Monitoreo glaciar/);
+    expect(result.metadata.title).toMatch(/cocuy_ritacuba/);
+    expect(result.metadata.title).toMatch(/2022/);
+  });
+
+  it('title generado fallback si no hay reportes', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.title).toBe('Dataset de monitoreo glaciar - Chagra');
+  });
+
+  it('title generado con múltiples montañas (hasta 3)', () => {
+    const result = buildZenodoMetadata(
+      [
+        { montana: 'cocuy_ritacuba' },
+        { montana: 'ruiz' },
+        { montana: 'tolima' },
+        { montana: 'huila' },
+      ],
+      {}
+    );
+    expect(result.metadata.title).toMatch(/cocuy_ritacuba/);
+    expect(result.metadata.title).toMatch(/ruiz/);
+    expect(result.metadata.title).toMatch(/tolima/);
+  });
+});
+
+describe('buildZenodoMetadata — description', () => {
+  it('description es un string Markdown básico', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(typeof result.metadata.description).toBe('string');
+    expect(result.metadata.description.length).toBeGreaterThan(0);
+  });
+
+  it('description contiene Markdown (negritas, listas)', () => {
+    const result = buildZenodoMetadata(
+      [{ guia: 'Ana', montana: 'ruiz' }],
+      {}
+    );
+    expect(result.metadata.description).toMatch(/\*\*/); // Markdown bold
+    expect(result.metadata.description).toMatch(/^- /m); // Markdown list (multiline)
+  });
+
+  it('description menciona número de reportes', () => {
+    const result = buildZenodoMetadata(
+      [{ montana: 'cocuy_ritacuba' }, { montana: 'ruiz' }],
+      {}
+    );
+    expect(result.metadata.description).toMatch(/2 reportes/);
+  });
+
+  it('description menciona montañas si hay reportes', () => {
+    const result = buildZenodoMetadata(
+      [{ montana: 'cocuy_ritacuba' }, { montana: 'ruiz' }],
+      {}
+    );
+    expect(result.metadata.description).toMatch(/cocuy_ritacuba/);
+    expect(result.metadata.description).toMatch(/ruiz/);
+  });
+
+  it('description menciona puntos de monitoreo si hay puntoId', () => {
+    const result = buildZenodoMetadata(
+      [
+        { puntoId: 'FRENTE-01', montana: 'ruiz' },
+        { puntoId: 'FRENTE-01', montana: 'ruiz' },
+        { puntoId: 'FRENTE-02', montana: 'ruiz' },
+      ],
+      {}
+    );
+    expect(result.metadata.description).toMatch(/2 puntos fijos/);
+  });
+
+  it('description menciona guías colaboradores si hay reportes', () => {
+    const result = buildZenodoMetadata(
+      [
+        { guia: 'Ana Pérez', montana: 'cocuy_ritacuba' },
+        { guia: 'Juan García', montana: 'ruiz' },
+      ],
+      {}
+    );
+    expect(result.metadata.description).toMatch(/Ana Pérez/);
+    expect(result.metadata.description).toMatch(/Juan García/);
+  });
+
+  it('description menciona metodología y trazabilidad', () => {
+    const result = buildZenodoMetadata(
+      [{ guia: 'Ana', montana: 'ruiz' }],
+      {}
+    );
+    expect(result.metadata.description).toMatch(/Metodología/);
+    expect(result.metadata.description).toMatch(/Trazabilidad/);
+    expect(result.metadata.description).toMatch(/Chagra/);
+  });
+});
+
+describe('buildZenodoMetadata — keywords', () => {
+  it('keywords contiene fijos básicos siempre', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.keywords).toContain('glacier');
+    expect(result.metadata.keywords).toContain('cryosphere');
+    expect(result.metadata.keywords).toContain('citizen-science');
+    expect(result.metadata.keywords).toContain('Colombia');
+  });
+
+  it('keywords se ordenan alfabéticamente', () => {
+    const result = buildZenodoMetadata([], {});
+    const sorted = [...result.metadata.keywords].sort();
+    expect(result.metadata.keywords).toEqual(sorted);
+  });
+
+  it('keywords agregan Perú si hay montañas peruanas', () => {
+    const result = buildZenodoMetadata(
+      [{ montana: 'huascaran' }],
+      {}
+    );
+    expect(result.metadata.keywords).toContain('Cordillera-Blanca');
+    expect(result.metadata.keywords).toContain('Peru');
+    expect(result.metadata.keywords).toContain('Perú');
+  });
+
+  it('keywords agregan montañas específicas colombianas', () => {
+    const result = buildZenodoMetadata(
+      [{ montana: 'cocuy_ritacuba' }],
+      {}
+    );
+    expect(result.metadata.keywords).toContain('Sierra-Nevada-del-Cocuy');
+  });
+
+  it('keywords no duplican montañas repetidas', () => {
+    const result = buildZenodoMetadata(
+      [
+        { montana: 'cocuy_ritacuba' },
+        { montana: 'cocuy_ritacuba' },
+      ],
+      {}
+    );
+    const cocuyCount = result.metadata.keywords.filter((k) => k === 'Sierra-Nevada-del-Cocuy').length;
+    expect(cocuyCount).toBe(1);
+  });
+});
+
+describe('buildZenodoMetadata — fechas y versiones', () => {
+  it('publication_date en formato ISO YYYY-MM-DD', () => {
+    const result = buildZenodoMetadata(
+      [{ createdAt: 1640000000000 }],
+      {}
+    );
+    expect(result.metadata.publication_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('publication_date es hoy si no hay reportes', () => {
+    const result = buildZenodoMetadata([], {});
+    const today = new Date().toISOString().split('T')[0];
+    expect(result.metadata.publication_date).toBe(today);
+  });
+
+  it('publication_date es la fecha más reciente entre reportes', () => {
+    const result = buildZenodoMetadata(
+      [
+        { createdAt: 1600000000000 }, // 2020-09-13
+        { createdAt: 1700000000000 }, // 2023-11-14
+        { createdAt: 1500000000000 }, // 2017-07-14
+      ],
+      {}
+    );
+    expect(result.metadata.publication_date).toBe('2023-11-14');
+  });
+
+  it('version es año.conteo (ej: 2023.42)', () => {
+    const result = buildZenodoMetadata(
+      [
+        { createdAt: 1672531200000 }, // 2023-01-01
+        { createdAt: 1704067200000 }, // 2024-01-01
+      ],
+      {}
+    );
+    expect(result.metadata.version).toBe('2023.2'); // 2 reportes, año más reciente es 2023
+  });
+});
+
+describe('buildZenodoMetadata — casos edge', () => {
+  it('tolera array vacío de reportes', () => {
+    expect(() => buildZenodoMetadata([], {})).not.toThrow();
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata).toHaveProperty('title');
+    expect(result.metadata).toHaveProperty('description');
+  });
+
+  it('tolera null/undefined como reportes', () => {
+    expect(() => buildZenodoMetadata(null, {})).not.toThrow();
+    expect(() => buildZenodoMetadata(undefined, {})).not.toThrow();
+    const result = buildZenodoMetadata(null, {});
+    expect(result.metadata.upload_type).toBe('dataset');
+  });
+
+  it('tolera opciones vacías', () => {
+    expect(() => buildZenodoMetadata([{ guia: 'Ana' }])).not.toThrow();
+  });
+
+  it('tolera reportes sin campos obligatorios (resiliencia)', () => {
+    const result = buildZenodoMetadata(
+      [{}, { guia: '' }, { montana: null }],
+      {}
+    );
+    expect(result.metadata.creators).toEqual([]);
+  });
+
+  it('DOI opcional se incluye si se provee', () => {
+    const result = buildZenodoMetadata([], {
+      doi: '10.5281/zenodo.1234567',
+    });
+    expect(result.metadata.doi).toBe('10.5281/zenodo.1234567');
+  });
+
+  it('DOI no se incluye si no se provee', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.doi).toBeUndefined();
+  });
+});
+
+describe('buildZenodoMetadata — shape completo Zenodo', () => {
+  it('genera shape válido según API Zenodo v10.13.0', () => {
+    const result = buildZenodoMetadata(
+      [
+        {
+          guia: 'Ana Pérez',
+          montana: 'cocuy_ritacuba',
+          puntoId: 'RITACUBA-01',
+          createdAt: 1642261200000, // 2022-01-15
+          fechaISO: '2022-01-15T08:30:00.000Z',
+          tipoSuperficie: 'hielo_glaciar_azul',
+          dureza: 'H1',
+        },
+      ],
+      {
+        title: 'Monitoreo Glaciar Cocuy 2022',
+        creators: ['Ana Pérez', 'Juan García'],
+        doi: '10.5281/zenodo.9999999',
+      }
+    );
+
+    // Verificar estructura requerida por Zenodo
+    expect(result).toHaveProperty('metadata');
+    expect(result.metadata).toMatchObject({
+      upload_type: 'dataset',
+      title: 'Monitoreo Glaciar Cocuy 2022',
+      publication_date: '2022-01-15',
+      access_right: 'open',
+      license: 'cc-by-4.0',
+      language: 'es',
+      doi: '10.5281/zenodo.9999999',
+    });
+
+    // Verificar creators
+    expect(result.metadata.creators).toEqual([
+      { name: 'Ana Pérez' },
+      { name: 'Juan García' },
+    ]);
+
+    // Verificar description no vacío
+    expect(result.metadata.description.length).toBeGreaterThan(50);
+
+    // Verificar keywords básicos
+    expect(result.metadata.keywords.length).toBeGreaterThan(5);
+    expect(result.metadata.keywords).toContain('glacier');
+    expect(result.metadata.keywords).toContain('cryosphere');
+
+    // Verificar versión
+    expect(result.metadata.version).toMatch(/^\d{4}\.\d+$/);
+  });
+
+  it('el objeto es JSON-serializable (no throw)', () => {
+    const result = buildZenodoMetadata([{ guia: 'Test' }], {});
+    expect(() => JSON.stringify(result)).not.toThrow();
+    expect(() => JSON.parse(JSON.stringify(result))).not.toThrow();
+  });
+});
+
+describe('buildZenodoMetadata — protección legal de autoría', () => {
+  it('protege autoría con CC-BY-4.0 forzado', () => {
+    const result = buildZenodoMetadata([], {});
+    expect(result.metadata.license).toBe('cc-by-4.0');
+  });
+
+  it('creators se ordenan alfabéticamente (trazabilidad)', () => {
+    const result = buildZenodoMetadata(
+      [
+        { guia: 'ZZZ' },
+        { guia: 'AAA' },
+        { guia: 'MMM' },
+      ],
+      {}
+    );
+    expect(result.metadata.creators).toEqual([
+      { name: 'AAA' },
+      { name: 'MMM' },
+      { name: 'ZZZ' },
+    ]);
+  });
+
+  it('descripción menciona origen Chagra (trazabilidad)', () => {
+    const result = buildZenodoMetadata([{ guia: 'Ana' }], {});
+    expect(result.metadata.description).toMatch(/Chagra/);
+    expect(result.metadata.description).toMatch(/Origen/i);
+  });
+
+  it('descripción menciona licencia CC-BY-4.0 (transparencia)', () => {
+    const result = buildZenodoMetadata([{ guia: 'Ana' }], {});
+    expect(result.metadata.description).toMatch(/CC-BY-4\.0/);
+  });
+});

--- a/src/services/glaciarZenodoMeta.js
+++ b/src/services/glaciarZenodoMeta.js
@@ -1,0 +1,247 @@
+/**
+ * glaciarZenodoMeta.js — generador de metadata Zenodo DOI para datasets glaciares.
+ *
+ * Este módulo construye el objeto JSON de depósito Zenodo para datasets de
+ * monitoreo glaciar, protegiendo la autoría del dato y habilitando su citación
+ * con DOI persistente.
+ *
+ * Zenodo es el repositorio de CERN que integra con DOI (DataCite). Este servicio
+ * genera metadata Dublin Core mínima pero suficiente para:
+ *   - Proteger autoría del dato (guidas/guides de montaña)
+ *   - Habilitar citación académica
+ *   - Trazabilidad de series temporales de retroceso glacial
+ *   - Cumplimiento FAIR básico (Findable, Accessible, Interoperable, Reusable)
+ *
+ * NO implementa subida HTTP a Zenodo (eso sería otro módulo). Solo genera
+ * el objeto de metadata listo para pasar a un cliente Zenodo/REST.
+ *
+ * @module services/glaciarZenodoMeta
+ */
+
+/**
+ * Construye metadata Zenodo para un dataset de reportes glaciares.
+ *
+ * Genera un objeto JSON conforme a la API de depósito Zenodo v10.13.0.
+ * Incluye:
+ *   - upload_type: dataset
+ *   - title (requerido)
+ *   - creators[] (requerido, con nombre y afiliación si existe)
+ *   - description (generada automáticamente a partir de los reportes)
+ *   - keywords (fijos + derivados)
+ *   - license (CC-BY-4.0, copyleft forzado por Chagra)
+ *   - Dublin Core mínima (publication_date, access_right)
+ *
+ * @param {object[]} reportes - Array de reportes glaciares (esquema glaciarReportes).
+ * @param {object} options - Opciones de metadata
+ * @param {string[]} [options.creators] - Array de nombres completos de creadores.
+ *   Si no se provee, se extrae de reportes[].guia (deduplicando).
+ * @param {string} [options.title] - Título del dataset. Si no se provee, se genera.
+ * @param {string} [options.affiliation] - Afiliación por defecto para creadores.
+ * @returns {object} Metadata de depósito Zenodo lista para JSON.stringify.
+ *
+ * @example
+ * const meta = buildZenodoMetadata(
+ *   [{ guia: 'Ana Pérez', montana: 'cocuy_ritacuba', createdAt: 1640000000000 }],
+ *   { title: 'Monitoreo Glaciar Cocuy 2022' }
+ * );
+ * // → { metadata: { upload_type: 'dataset', title: '...', ... } }
+ */
+export function buildZenodoMetadata(reportes, options = {}) {
+  const reportesArray = Array.isArray(reportes) ? reportes : [];
+  const opts = typeof options === 'string' ? { title: options } : options;
+
+  // ── Extraer creators: explícitos o deducidos de reportes[].guia ──
+  const creators = Array.isArray(opts.creators) && opts.creators.length > 0
+    ? opts.creators.map((c) => (typeof c === 'string' ? { name: c } : c))
+    : extractCreatorsFromReportes(reportesArray);
+
+  // ── Título: explícito o generado ──
+  const title = opts.title || generateTitle(reportesArray);
+
+  // ── Descripción: generada automáticamente desde los reportes ──
+  const description = generateDescription(reportesArray);
+
+  // ── Keywords: fijos + derivados de montañas/paises ──
+  const keywords = generateKeywords(reportesArray);
+
+  // ── Fecha: la más reciente entre reportes o hoy ──
+  const publicationDate = mostRecentDate(reportesArray);
+
+  // ── Acceso y licencia (CC-BY-4.0 forzado por Chagra) ──
+  const accessRight = 'open';
+  const license = 'cc-by-4.0';
+
+  return {
+    metadata: {
+      upload_type: 'dataset',
+      title,
+      creators,
+      description,
+      keywords,
+      publication_date: publicationDate,
+      access_right: accessRight,
+      license,
+      // Dublin Core básicos (mapeados automáticamente por Zenodo)
+      language: 'es',
+      version: datasetVersion(reportesArray),
+      doi: opts.doi || undefined, // Si ya se tiene DOI reservado, incluirlo
+    },
+  };
+}
+
+/** Extrae creadores únicos desde reportes[].guia. */
+function extractCreatorsFromReportes(reportes) {
+  const guias = new Set();
+  for (const r of reportes) {
+    if (r.guia && typeof r.guia === 'string' && r.guia.trim()) {
+      guias.add(r.guia.trim());
+    }
+  }
+  return [...guias].sort().map((name) => ({ name }));
+}
+
+/** Genera título desde los reportes (fallback). */
+function generateTitle(reportes) {
+  if (reportes.length === 0) {
+    return 'Dataset de monitoreo glaciar - Chagra';
+  }
+  const montanas = new Set();
+  for (const r of reportes) {
+    if (r.montanaLibre) montanas.add(r.montanaLibre);
+    else if (r.montana) montanas.add(r.montana);
+  }
+  const anyo = anyoDeReportes(reportes);
+  const montanasStr = [...montanas].slice(0, 3).join(', ');
+  return montanasStr
+    ? `Monitoreo glaciar ${montanasStr} - ${anyo}`
+    : `Dataset de monitoreo glaciar - ${anyo}`;
+}
+
+/** Genera descripción automática desde los reportes. */
+function generateDescription(reportes) {
+  if (reportes.length === 0) {
+    return 'Dataset de monitoreo de puntos glaciares generado por Chagra (app agroecológica y de glaciares). Contiene reportes de campo de guías de montaña sobre estado de superficie, dureza del hielo y peligros observados.\n\n**Licencia:** CC-BY-4.0 (uso libre con atribución).';
+  }
+
+  const lineas = [
+    `Dataset de **${reportes.length} reporte${reportes.length !== 1 ? 's' : ''}** de monitoreo glaciar recolectados vía Chagra.`,
+  ];
+
+  // Estadísticas básicas
+  const puntos = new Set();
+  const montanas = new Set();
+  const anyos = new Set();
+  for (const r of reportes) {
+    if (r.puntoId) puntos.add(r.puntoId);
+    if (r.montanaLibre) montanas.add(r.montanaLibre);
+    else if (r.montana) montanas.add(r.montana);
+    if (r.fechaISO) anyos.add(new Date(r.fechaISO).getFullYear());
+  }
+
+  if (montanas.size > 0) {
+    lineas.push(`\n**Montañas monitoreadas:** ${[...montanas].join(', ')}`);
+  }
+  if (puntos.size > 0) {
+    lineas.push(`\n**Puntos de monitoreo:** ${puntos.size} punto${puntos.size !== 1 ? 's' : ''} fijos (series temporales de retroceso)`);
+  }
+  if (anyos.size > 0) {
+    lineas.push(`\n**Años de monitoreo:** ${[...anyos].sort().join(', ')}`);
+  }
+
+  // Fuentes de los datos
+  const creadores = extractCreatorsFromReportes(reportes);
+  if (creadores.length > 0) {
+    lineas.push(`\n**Guías de montaña colaboradores:** ${creadores.map((c) => c.name).join(', ')}`);
+  }
+
+  // Contexto y metodología
+  lineas.push('\n**Metodología:**');
+  lineas.push('- Cada reporte representa una medición de campo en un punto fijo del borde/glaciar.');
+  lineas.push('- Se registra tipo de superficie, dureza (escala mano→piolet), peligros observados y condiciones ambientales.');
+  lineas.push('- La repetición de un mismo `puntoId` en el tiempo genera series temporales de retroceso glacial.');
+  lineas.push('- Datos recolectados con Chagra, herramienta agroecológica y de glaciares para guías de montaña y comunidades locales.');
+
+  // Trazabilidad
+  lineas.push('\n**Trazabilidad:**');
+  lineas.push('- Origen: Chagra (app agroecológica y de glaciares)');
+  lineas.push('- Licencia: CC-BY-4.0 (uso libre con atribución)');
+  lineas.push('- Versión del dataset: ' + datasetVersion(reportes));
+
+  return lineas.join('\n');
+}
+
+/** Genera keywords: fijos + derivados de montañas/países. */
+function generateKeywords(reportes) {
+  const keywords = new Set([
+    'glacier',
+    'cryosphere',
+    'citizen-science',
+    'Colombia',
+    'glacier-monitoring',
+    'ice-hardness',
+    'glacier-retreat',
+    'mountain-safety',
+  ]);
+
+  // Montañas específicas
+  const montanasKeys = new Set();
+  for (const r of reportes) {
+    if (r.montana) montanasKeys.add(r.montana);
+  }
+
+  // Mapeo de keys a keywords
+  const montanaKeywords = {
+    cocuy_ritacuba: 'Sierra-Nevada-del-Cocuy',
+    ruiz: 'Nevado-del-Ruiz',
+    tolima: 'Nevado-del-Tolima',
+    huila: 'Nevado-del-Huila',
+    santa_isabel: 'Santa-Isabel',
+    sierra_nevada_santa_marta: 'Sierra-Nevada-de-Santa-Marta',
+    yanapaccha: 'Cordillera-Blanca',
+    huascaran: 'Cordillera-Blanca',
+    pisco: 'Cordillera-Blanca',
+    chopicalqui: 'Cordillera-Blanca',
+    tocllaraju: 'Cordillera-Blanca',
+    vallunaraju: 'Cordillera-Blanca',
+  };
+
+  for (const key of montanasKeys) {
+    const kw = montanaKeywords[key];
+    if (kw) keywords.add(kw);
+  }
+
+  // Agregar Perú si hay montañas de Perú
+  if (montanasKeys.has('yanapaccha') || montanasKeys.has('huascaran') || montanasKeys.has('pisco')) {
+    keywords.add('Peru');
+    keywords.add('Perú');
+  }
+
+  return [...keywords].sort();
+}
+
+/** Fecha más reciente entre reportes o hoy en formato ISO. */
+function mostRecentDate(reportes) {
+  let max = 0;
+  for (const r of reportes) {
+    if (r.createdAt && r.createdAt > max) max = r.createdAt;
+  }
+  if (max === 0) max = Date.now();
+  return new Date(max).toISOString().split('T')[0]; // YYYY-MM-DD
+}
+
+/** Año de los reportes (el más reciente). */
+function anyoDeReportes(reportes) {
+  let maxTs = 0;
+  for (const r of reportes) {
+    if (r.createdAt && r.createdAt > maxTs) maxTs = r.createdAt;
+  }
+  if (maxTs === 0) maxTs = Date.now();
+  return new Date(maxTs).getFullYear();
+}
+
+/** Versión del dataset basada en timestamp más reciente + conteo. */
+function datasetVersion(reportes) {
+  const anyo = anyoDeReportes(reportes);
+  const count = reportes.length;
+  return `${anyo}.${count}`;
+}


### PR DESCRIPTION
## Summary

Genera metadata Zenodo (DOI) para datasets de monitoreo glaciar. Protege autoría del dato, habilita citación académica y cumple estándares Dublin Core mínimos para repositorios como Zenodo.

## Cambios

- **src/services/glaciarZenodoMeta.js**: Nueva función `buildZenodoMetadata(reportes, options)` que genera objetos JSON válidos según API de depósito Zenodo v10.13.0.
  - upload_type: dataset
  - title (explícito o auto-generado desde montañas/año)
  - creators (explícitos o deducidos de reportes[].guia)
  - description (generada automáticamente desde estadísticas de reportes)
  - keywords (fijos + derivados de montañas/países)
  - license: cc-by-4.0 (forzado por Chagra)
  - Dublin Core: publication_date, access_right, language, version
- **src/services/__tests__/glaciarZenodoMeta.test.js**: 42 tests cubriendo:
  - Estructura básica Zenodo
  - Creators (explícitos vs deducidos)
  - Título y descripción generados
  - Keywords con montañas específicas
  - Fechas y versiones
  - Casos edge (arrays vacíos, nulls)
  - Protección legal de autoría (CC-BY-4.0 forzado)

## MCP tools usados

No se requirieron MCP tools para este task. Se siguió el patrón existente en `glaciarSafety.js` y `glaciarReportes.js`.

## Test plan

```bash
# Tests específicos del servicio
npx vitest run src/services/__tests__/glaciarZenodoMeta.test.js
# ✅ 42 passed

# Tests generales de servicios glaciar
npx vitest run src/services/__tests__/glaciar*.test.js
# ✅ 68 passed

# Build del proyecto
npm run build
# ✅ built in 3.93s

# ESLint de archivos creados
npx eslint src/services/glaciarZenodoMeta.js src/services/__tests__/glaciarZenodoMeta.test.js
# ✅ Sin errores
```

## Riesgos conocidos

- **Sin red HTTP**: Este servicio solo genera metadata, NO implementa subida a Zenodo (requeriría otro módulo con HTTP client).
- **Licencia forzada**: CC-BY-4.0 es obligatoria (política Chagra), no configurable por ahora.
- **Autores deducidos**: Si no se proveen creators explícitos, se extraen de reportes[].guia (puede ser incompleto si guia no está presente).

## Protección legal de autoría

- **CC-BY-4.0 forzado**: Todos los datasets llevan licencia copyleft para garantizar uso abierto con atribución.
- **Trazabilidad**: La descripción generada menciona origen (Chagra), colaboradores y versión para trazabilidad del dato.
- **DOI ready**: El objeto generado es directamente serializable a JSON para subida a Zenodo/REST API.

## Siguiente iteration (si aplica)

- Cliente HTTP para subida real a Zenodo (requiere API key, autenticación OAuth).
- UI en Chagra para descargar metadata .zenodo.json.
- Integración con el módulo de exportación de cuadernos (cuadernoPDF.js).