### PR TITLE
fix(services): añade comentario para silenciar eslint no-empty en openaiStream.js

### DIFF
--- a/src/services/openaiStream.js
+++ b/src/services/openaiStream.js
@@ -216,6 +216,7 @@ export async function streamOpenAI(url, body, onToken, { signal, onDone } = {}) 
             mergeToolCallDeltas(accumulatedToolCalls, tc);
           }
           if (isDoneChunk(parsed)) {
+            // Empty block - finish_reason detected but we continue processing
           }
         }
         if (done) break;


### PR DESCRIPTION
## Summary

Arregla el error eslint `no-empty` en `src/services/openaiStream.js` (línea 218) añadiendo un comentario explicativo en el bloque `if` vacío.

## Cambios

- **Archivo modificado**: `src/services/openaiStream.js`
- **Cambio**: Añadido comentario `// Empty block - finish_reason detected but we continue processing` en la línea 219
- **Motivo**: El bloque `if (isDoneChunk(parsed))` está intencionalmente vacío porque `finish_reason` se detecta pero el procesamiento continúa. El comentario silencia la regla eslint `no-empty`.

## Test plan

- ✓ `npx eslint src/services/openaiStream.js --max-warnings=0` pasa sin errores
- ✓ `npm run build` compila exitosamente
- ✓ El cambio es puramente cosmético (comentario) - no afecta lógica ni comportamiento
- ✓ No hay tests específicos para `openaiStream.js` (búsqueda confirmada)

## Riesgos conocidos

- **Riesgo**: Ninguno. El cambio es solo un comentario que no afecta la lógica ni el comportamiento de la función.
- **Scope**: Estrictamente limitado a `src/services/openaiStream.js` siguiendo el task #6507.

## MCP tools utilizados

Ninguno. Este task no requirió consulta al grafo AGE ni a otros MCP tools.
