### PR TITLE
fix(soil): remove unnecessary escape characters in regex

### DIFF
--- a/src/services/soilDiagnostic.js
+++ b/src/services/soilDiagnostic.js
@@ -71,7 +71,7 @@ export function diagnosticarSuelo(descripcion) {
     // Match más flexible: cada palabra significativa del nombre del bio
     // debe aparecer en el texto (ignoramos conectores /, (), etc.)
     const palabrasBio = nombreNorm
-      .replace(/[\/\(\)\[\],.]/g, ' ')
+      .replace(/[/()[\],.]/g, ' ')
       .split(/\s+/)
       .filter((p) => p.length > 3);
     const matchBio = palabrasBio.some((p) => texto.includes(p));


### PR DESCRIPTION
## Summary

Arregla errores eslint pre-existentes en . Se eliminaron caracteres de escape innecesarios en una expresión regular de la línea 74.

## Cambios realizados

- **Archivo**: 
- **Línea 74**: Se eliminaron escapes innecesarios en la regex:
  -  → 
  -  → 
  -  → 
  -  → 

Dentro de una character class  en JavaScript, estos caracteres no necesitan ser escapados, lo que causaba errores  de eslint.

## Test plan

✅ **npx eslint src/services/soilDiagnostic.js --max-warnings=0** — Pasa sin errores
✅ **npx vitest run src/services/__tests__/soilDiagnostic.test.js** — 24 tests pasan
✅ **npm run build** — Build exitoso
✅ **Sin cambios de lógica** — Solo corrección de estilo/linting

## MCP tools utilizados

No se requirió MCP tools para este task (es solo linting).

## Riesgos conocidos

Ninguno. El cambio es puramente cosmético (linting) y no afecta la funcionalidad ni el comportamiento de la regex.