### PR TITLE
feat(glaciar): pantalla historial de reportes glaciares

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,6 +70,7 @@ const ProcesosPorVozScreen = lazy(() => import('./components/ProcesosPorVozScree
 const CicloCultivoScreen = lazy(() => import('./components/CicloCultivoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
 const GlaciarReporteScreen = lazy(() => import('./components/GlaciarReporteScreen'));
+const GlaciarHistorialScreen = lazy(() => import('./components/GlaciarHistorialScreen'));
 const ProfileScreen = lazy(() => import('./components/ProfileScreen'));
 const CaseStudyScreen = lazy(() => import('./components/CaseStudyScreen'));
 const CaseStudyDetail = lazy(() => import('./components/CaseStudyDetail'));
@@ -145,6 +146,7 @@ const HASH_VIEW_ROUTES = {
   'hoy-en-finca': 'hoy_finca',
   evolucion: 'evolucion',
   glaciar: 'glaciar',
+  'glaciar-historial': 'glaciar_historial',
 };
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -928,6 +930,25 @@ export default function App() {
         return (
           <ErrorBoundary>
             <GlaciarReporteScreen onBack={() => navigate('dashboard')} />
+          </ErrorBoundary>
+        );
+      case 'glaciar_historial':
+        // Historial de reportes glaciares. Ruta #glaciar-historial.
+        // ACCESO RESTRINGIDO a los beta testers de "La Cordada"
+        // (src/config/glaciarAccess.js). Guarda defensiva: si por cualquier
+        // ruta un usuario no autorizado llega a esta vista, NO montamos el
+        // módulo — devolvemos el fallback estándar. Las navegaciones a
+        // #glaciar-historial ya redirigen al dashboard antes de llegar acá.
+        if (!tieneAccesoGlaciarActual()) {
+          return (
+            <ErrorBoundary>
+              <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+            </ErrorBoundary>
+          );
+        }
+        return (
+          <ErrorBoundary>
+            <GlaciarHistorialScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
           </ErrorBoundary>
         );
       case 'perfil':

--- a/src/components/GlaciarHistorialScreen.jsx
+++ b/src/components/GlaciarHistorialScreen.jsx
@@ -1,0 +1,495 @@
+/**
+ * GlaciarHistorialScreen — pantalla de historial de reportes glaciares.
+ *
+ * Muestra la lista de reportes guardados (db/glaciarReportes.js) con:
+ * - Montaña
+ * - Fecha
+ * - Estado (semáforo color)
+ * - PuntoId
+ *
+ * Al tocar un reporte, muestra el detalle read-only.
+ * Offline-first (IndexedDB).
+ *
+ * Ruta gateada con tieneAccesoGlaciar (src/config/glaciarAccess.js).
+ *
+ * Español Colombia (usted/tú, SIN voseo).
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { List, Snowflake, MapPin, Calendar, Loader2, ChevronLeft, Home, AlertCircle, Trash2, ArrowLeft } from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+import { glaciarReportes } from '../db/glaciarReportes';
+import {
+  MONTANA_BY_KEY,
+  ESTADOS_SEGURIDAD,
+  SUPERFICIE_BY_KEY,
+  DUREZA_BY_CODIGO,
+  PELIGRO_BY_KEY,
+} from '../data/glaciar-schema.js';
+
+const ESTADO_BG = {
+  estable: 'glaciar-estado-estable',
+  precaucion: 'glaciar-estado-precaucion',
+  peligro: 'glaciar-estado-peligro',
+  observacion: 'glaciar-estado-observacion',
+};
+
+const ESTADO_EMOJI = {
+  estable: '🟢',
+  precaucion: '🟡',
+  peligro: '🔴',
+  observacion: '🔵',
+};
+
+/**
+ * GlaciarHistorialScreen — pantalla principal del historial.
+ */
+export default function GlaciarHistorialScreen({ onBack, onHome }) {
+  const [reportes, setReportes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedReporte, setSelectedReporte] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const cargarReportes = useCallback(async () => {
+    setLoading(true);
+    try {
+      const all = await glaciarReportes.getAll();
+      setReportes(all);
+    } catch (e) {
+      console.error('[GlaciarHistorial] error cargando reportes:', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    cargarReportes();
+  }, [cargarReportes]);
+
+  const handleEliminar = useCallback(async (id) => {
+    if (deleting) return;
+    if (!confirm('¿Eliminar este reporte? Esta acción no se puede deshacer.')) return;
+    
+    setDeleting(true);
+    try {
+      await glaciarReportes.remove(id);
+      setReportes((prev) => prev.filter((r) => r.id !== id));
+      if (selectedReporte?.id === id) {
+        setSelectedReporte(null);
+      }
+    } catch (e) {
+      console.error('[GlaciarHistorial] error eliminando reporte:', e);
+      alert('No se pudo eliminar el reporte');
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleting, selectedReporte]);
+
+  // Si hay un reporte seleccionado, mostramos el detalle
+  if (selectedReporte) {
+    return (
+      <DetalleReporte
+        reporte={selectedReporte}
+        onBack={() => setSelectedReporte(null)}
+        onEliminar={() => handleEliminar(selectedReporte.id)}
+        onHome={onHome}
+        deleting={deleting}
+      />
+    );
+  }
+
+  // Empty state
+  if (!loading && reportes.length === 0) {
+    return (
+      <ScreenShell
+        title="Historial de reportes"
+        icon={List}
+        onBack={onBack}
+        onHome={onHome}
+      >
+        <main className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+          <Snowflake size={64} className="text-slate-600 mb-4" />
+          <h2 className="text-xl font-black text-white mb-2">Sin reportes aún</h2>
+          <p className="text-sm text-slate-400 mb-6 max-w-md">
+            Los reportes que cree en el módulo glaciar quedarán guardados aquí.
+            Puede verlos incluso sin conexión a internet.
+          </p>
+          {onBack && (
+            <button
+              type="button"
+              onClick={onBack}
+              className="px-6 py-3 rounded-xl bg-sky-500 text-slate-950 font-bold flex items-center gap-2 active:scale-95 transition"
+            >
+              <MapPin size={18} />
+              Crear un reporte
+            </button>
+          )}
+        </main>
+      </ScreenShell>
+    );
+  }
+
+  // Lista de reportes
+  return (
+    <ScreenShell
+      title="Historial de reportes"
+      icon={List}
+      onBack={onBack}
+      onHome={onHome}
+    >
+      <main className="flex-1 px-4 pt-4 space-y-3 max-w-xl mx-auto overflow-y-auto pb-[calc(env(safe-area-inset-bottom,0px)+120px)]">
+        {loading ? (
+          <div className="flex flex-col items-center justify-center py-20 text-slate-500">
+            <Loader2 size={32} className="animate-spin mb-3" />
+            <p>Cargando reportes…</p>
+          </div>
+        ) : (
+          <>
+            <p className="text-xs text-slate-500 pb-2">
+              {reportes.length} {reportes.length === 1 ? 'reporte guardado' : 'reportes guardados'}
+            </p>
+            {reportes.map((r) => (
+              <ReporteCard
+                key={r.id}
+                reporte={r}
+                onPress={() => setSelectedReporte(r)}
+              />
+            ))}
+          </>
+        )}
+      </main>
+    </ScreenShell>
+  );
+}
+
+/**
+ * ReporteCard — tarjeta compacta para la lista.
+ * Muestra: montaña, fecha, estado (semáforo), puntoId.
+ */
+function ReporteCard({ reporte, onPress }) {
+  const estado = reporte.estado || 'precaucion';
+  const montana = MONTANA_BY_KEY[reporte.montana];
+  const fecha = reporte.fechaISO
+    ? new Date(reporte.fechaISO)
+    : new Date(reporte.createdAt || 0);
+  const emoji = ESTADO_EMOJI[estado] || '🟡';
+  const bgClass = ESTADO_BG[estado] || ESTADO_BG.precaucion;
+
+  return (
+    <button
+      type="button"
+      onClick={onPress}
+      className={`w-full rounded-2xl border ${bgClass} overflow-hidden transition active:scale-98 text-left`}
+    >
+      <div className="flex gap-3 p-3">
+        {/* Miniatura */}
+        <div className="shrink-0 w-20 h-20 rounded-xl bg-slate-800 overflow-hidden grid place-items-center">
+          {reporte.fotoDataUrl ? (
+            <img
+              src={reporte.fotoDataUrl}
+              alt="Punto glaciar"
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <Snowflake size={28} className="text-slate-600" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-lg font-black flex items-center gap-1.5 glaciar-estado-texto">
+              {emoji}{' '}
+              <span className="text-sm">
+                {ESTADOS_SEGURIDAD[estado]?.label || 'Precaución'}
+              </span>
+            </span>
+          </div>
+          <p className="text-xs text-slate-400 mt-0.5 glaciar-estado-texto">
+            {fecha.toLocaleString('es-CO', {
+              dateStyle: 'medium',
+              timeStyle: 'short',
+            })}
+          </p>
+          <div className="flex flex-wrap gap-1.5 mt-1.5">
+            {montana && (
+              <span className="text-[11px] px-2 py-0.5 rounded-full bg-slate-800 text-slate-300 border border-slate-700">
+                {montana.libre ? (reporte.montanaLibre || 'Otra') : montana.label}
+              </span>
+            )}
+            {reporte.puntoId && (
+              <span className="text-[11px] px-2 py-0.5 rounded-full bg-slate-800 text-slate-300 border border-slate-700">
+                📍 {reporte.puntoId}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+/**
+ * DetalleReporte — vista detallada read-only de un reporte.
+ */
+function DetalleReporte({ reporte, onBack, onEliminar, onHome, deleting }) {
+  const estado = reporte.estado || 'precaucion';
+  const supKey = reporte.tipoSuperficie || reporte.capas?.[0]?.tipoSuperficie;
+  const durCod = reporte.dureza || reporte.capas?.[0]?.dureza;
+  const sup = SUPERFICIE_BY_KEY[supKey];
+  const dur = DUREZA_BY_CODIGO[durCod];
+  const montana = MONTANA_BY_KEY[reporte.montana];
+  const fecha = reporte.fechaISO
+    ? new Date(reporte.fechaISO)
+    : new Date(reporte.createdAt || 0);
+  const emoji = ESTADO_EMOJI[estado] || '🟡';
+  const bgClass = ESTADO_BG[estado] || ESTADO_BG.precaucion;
+
+  const handleHomeClick = () => {
+    if (onHome) onHome();
+  };
+
+  return (
+    <ScreenShell
+      title="Detalle del reporte"
+      icon={Snowflake}
+      onBack={onBack}
+      onHome={handleHomeClick}
+      actions={
+        <button
+          type="button"
+          onClick={onEliminar}
+          disabled={deleting}
+          className="p-2 rounded-lg text-slate-500 hover:text-red-400 hover:bg-red-900/20 transition disabled:opacity-50"
+          aria-label="Eliminar reporte"
+        >
+          {deleting ? (
+            <Loader2 size={18} className="animate-spin" />
+          ) : (
+            <Trash2 size={18} />
+          )}
+        </button>
+      }
+    >
+      <main className="flex-1 px-4 pt-4 space-y-4 max-w-xl mx-auto overflow-y-auto pb-[calc(env(safe-area-inset-bottom,0px)+120px)]">
+        {/* Foto principal */}
+        {reporte.fotoDataUrl && (
+          <div className="rounded-2xl overflow-hidden border border-slate-700">
+            <img
+              src={reporte.fotoDataUrl}
+              alt="Punto glaciar"
+              className="w-full h-auto"
+            />
+          </div>
+        )}
+
+        {/* Header del reporte */}
+        <div className={`rounded-2xl border ${bgClass} p-4`}>
+          <div className="flex items-center justify-between gap-2 mb-2">
+            <span className="text-2xl font-black flex items-center gap-2 glaciar-estado-texto">
+              {emoji}{' '}
+              <span className="text-lg">
+                {ESTADOS_SEGURIDAD[estado]?.label || 'Precaución'}
+              </span>
+            </span>
+          </div>
+          <p className="text-sm text-slate-400 glaciar-estado-texto">
+            {fecha.toLocaleString('es-CO', {
+              dateStyle: 'full',
+              timeStyle: 'short',
+            })}
+          </p>
+        </div>
+
+        {/* Información básica */}
+        <section className="rounded-xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+          <h3 className="text-sm font-bold text-slate-300 flex items-center gap-2">
+            <MapPin size={16} />
+            Ubicación
+          </h3>
+          <div className="space-y-2 text-sm">
+            {montana && (
+              <p className="text-white">
+                <span className="text-slate-500">Montaña:</span>{' '}
+                {montana.libre ? (reporte.montanaLibre || 'Otra') : montana.label}
+              </p>
+            )}
+            {reporte.puntoId && (
+              <p className="text-white">
+                <span className="text-slate-500">Punto fijo:</span> 📍 {reporte.puntoId}
+              </p>
+            )}
+            {reporte.lat != null && reporte.lng != null && (
+              <p className="text-xs font-mono text-slate-400">
+                {reporte.lat.toFixed(5)}, {reporte.lng.toFixed(5)}
+                {reporte.precision != null ? ` (±${reporte.precision}m)` : ''}
+              </p>
+            )}
+            {reporte.altitud != null && (
+              <p className="text-white">
+                <span className="text-slate-500">Altitud:</span> {reporte.altitud} msnm
+              </p>
+            )}
+            {reporte.distanciaBordeHieloM != null && (
+              <p className="text-white">
+                <span className="text-slate-500">Distancia al borde:</span>{' '}
+                {reporte.distanciaBordeHieloM} m
+              </p>
+            )}
+            {reporte.azimutBrujula != null && (
+              <p className="text-white">
+                <span className="text-slate-500">Azimut:</span> ↗ {reporte.azimutBrujula}°
+              </p>
+            )}
+            {reporte.referenciaEncuadre && (
+              <p className="text-white">
+                <span className="text-slate-500">Referencia encuadre:</span>{' '}
+                {reporte.referenciaEncuadre}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Diagnóstico */}
+        <section className="rounded-xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+          <h3 className="text-sm font-bold text-slate-300">Diagnóstico del hielo</h3>
+          <div className="space-y-2 text-sm">
+            {sup && (
+              <p className="text-white">
+                <span className="text-slate-500">Superficie:</span> {sup.icon} {sup.label}
+              </p>
+            )}
+            {dur && (
+              <p className="text-white">
+                <span className="text-slate-500">Dureza:</span> {dur.codigo} · {dur.label}
+              </p>
+            )}
+            {reporte.tempSuperficie != null && (
+              <p className="text-white">
+                <span className="text-slate-500">Temp. superficie:</span>{' '}
+                {reporte.tempSuperficie}°C
+              </p>
+            )}
+            {reporte.pisoGlaciar === false && (
+              <p className="text-blue-300">
+                🔵 Modo observación (borde del glaciar)
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Perfil de capas */}
+        {Array.isArray(reporte.capas) && reporte.capas.length > 1 && (
+          <section className="rounded-xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+            <h3 className="text-sm font-bold text-slate-300">
+              Perfil de capas ({reporte.capas.length})
+            </h3>
+            <div className="space-y-2 text-sm">
+              {reporte.capas.map((c, i) => {
+                const cSup = SUPERFICIE_BY_KEY[c.tipoSuperficie];
+                const cDur = DUREZA_BY_CODIGO[c.dureza];
+                return (
+                  <div key={i} className="text-white text-xs py-1 border-b border-slate-800 last:border-0">
+                    <span className="text-slate-500 mr-2">Capa {i + 1}:</span>
+                    {c.profundidad && <span>{c.profundidad}m · </span>}
+                    {cSup && <span>{cSup.icon} {cSup.label}</span>}
+                    {cDur && <span> · {cDur.codigo}</span>}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Peligros */}
+        {Array.isArray(reporte.peligros) &&
+          reporte.peligros.filter((p) => p !== 'ninguno_evidente').length > 0 && (
+            <section className="rounded-xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+              <h3 className="text-sm font-bold text-slate-300 flex items-center gap-2">
+                <AlertCircle size={16} />
+                Peligros observados
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {reporte.peligros
+                  .filter((p) => p !== 'ninguno_evidente')
+                  .map((p) => {
+                    const peligro = PELIGRO_BY_KEY[p];
+                    return (
+                      <span
+                        key={p}
+                        className="text-xs px-3 py-1 rounded-full bg-red-900/30 text-red-200 border border-red-800/40"
+                      >
+                        {peligro?.icon || '⚠️'} {peligro?.label || p}
+                      </span>
+                    );
+                  })}
+              </div>
+              {reporte.rutaBajoSeracs && (
+                <p className="text-xs text-red-300 mt-2">
+                  ⚠️ La ruta pasa por debajo de los séracs
+                </p>
+              )}
+              {reporte.penitentesDensos && (
+                <p className="text-xs text-red-300 mt-2">
+                  ⚠️ Penitentes densos / altos
+                </p>
+              )}
+              {reporte.pendientePronunciada && (
+                <p className="text-xs text-amber-300 mt-2">⚠️ Pendiente pronunciada</p>
+              )}
+            </section>
+          )}
+
+        {/* Condiciones */}
+        {(reporte.tempAmbiente != null ||
+          reporte.cielo ||
+          reporte.viento ||
+          reporte.visibilidad) && (
+          <section className="rounded-xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+            <h3 className="text-sm font-bold text-slate-300">Condiciones</h3>
+            <div className="space-y-2 text-sm">
+              {reporte.tempAmbiente != null && (
+                <p className="text-white">
+                  <span className="text-slate-500">Temp. ambiente:</span>{' '}
+                  {reporte.tempAmbiente}°C
+                </p>
+              )}
+              {reporte.cielo && (
+                <p className="text-white">
+                  <span className="text-slate-500">Cielo:</span> {reporte.cielo}
+                </p>
+              )}
+              {reporte.viento && (
+                <p className="text-white">
+                  <span className="text-slate-500">Viento:</span> {reporte.viento}
+                </p>
+              )}
+              {reporte.visibilidad && (
+                <p className="text-white">
+                  <span className="text-slate-500">Visibilidad:</span>{' '}
+                  {reporte.visibilidad}
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+
+        {/* Guía y notas */}
+        {(reporte.guia || reporte.notas) && (
+          <section className="rounded-xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+            <h3 className="text-sm font-bold text-slate-300">Información del guía</h3>
+            <div className="space-y-2 text-sm">
+              {reporte.guia && (
+                <p className="text-white">
+                  <span className="text-slate-500">Guía:</span> {reporte.guia}
+                </p>
+              )}
+              {reporte.notas && (
+                <p className="text-white italic glaciar-estado-texto">
+                  <span className="text-slate-500">Notas:</span> "{reporte.notas}"
+                </p>
+              )}
+            </div>
+          </section>
+        )}
+      </main>
+    </ScreenShell>
+  );
+}

--- a/src/components/__tests__/GlaciarHistorialScreen.test.jsx
+++ b/src/components/__tests__/GlaciarHistorialScreen.test.jsx
@@ -1,0 +1,376 @@
+/**
+ * GlaciarHistorialScreen — tests de componente de historial glaciares.
+ *
+ * Contrato cubierto:
+ *   - Estado vacío: muestra mensaje "Sin reportes aún" con CTA para crear.
+ *   - Con reportes: lista reportes con montaña, fecha, estado (semáforo), puntoId.
+ *   - Tap en reporte: abre detalle read-only.
+ *   - Eliminar reporte: requiere confirmación y remueve de la lista.
+ *   - Offline-first: funciona sin red (IndexedDB).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+const { getAll: mockGetAll, remove: mockRemove } = vi.hoisted(() => ({
+  getAll: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock('../../db/glaciarReportes', () => ({
+  glaciarReportes: {
+    getAll: mockGetAll,
+    remove: mockRemove,
+  },
+}));
+
+import GlaciarHistorialScreen from '../GlaciarHistorialScreen';
+
+const REPORTE_BASE = {
+  id: 'glaciar-1234567890-abc123',
+  puntoId: 'PUNTO-1',
+  createdAt: 1749500000000,
+  fechaISO: '2025-06-14T10:30:00.000Z',
+  guia: 'Juan Pérez',
+  montana: 'cocuy_ritacuba',
+  montanaLibre: '',
+  pisoGlaciar: true,
+  lat: 4.6,
+  lng: -74.1,
+  altitud: 4700,
+  precision: 10,
+  distanciaBordeHieloM: 15,
+  azimutBrujula: 180,
+  referenciaEncuadre: 'Cerca de la roca grande',
+  tipoSuperficie: 'nieve_fresca',
+  dureza: 'F1',
+  tempSuperficie: -3,
+  peligros: ['grietas_abiertas'],
+  rutaBajoSeracs: false,
+  penitentesDensos: false,
+  pendientePronunciada: true,
+  nieveReciente24h: false,
+  tempAmbiente: 2,
+  cielo: 'despejado',
+  viento: 'calmo',
+  visibilidad: 'buena',
+  notas: 'Buenas condiciones para la ruta',
+  fotoDataUrl: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==',
+  estado: 'estable',
+  estadoRazones: [],
+  capas: [
+    { profundidad: '0', tipoSuperficie: 'nieve_fresca', dureza: 'F1' },
+    { profundidad: '0.5', tipoSuperficie: 'firn_neve', dureza: 'F2' },
+  ],
+  horaLocal: 10.5,
+};
+
+beforeEach(() => {
+  mockGetAll.mockReset();
+  mockRemove.mockReset();
+  // Mock window.confirm
+  globalThis.confirm = vi.fn(() => true);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GlaciarHistorialScreen — historial de reportes glaciares', () => {
+  it('estado vacío muestra mensaje y CTA para crear reporte', async () => {
+    mockGetAll.mockResolvedValue([]);
+    const onBack = vi.fn();
+    render(<GlaciarHistorialScreen onBack={onBack} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sin reportes aún/i)).toBeVisible();
+    });
+
+    expect(screen.getByText(/Los reportes que cree en el módulo glaciar/i)).toBeVisible();
+    expect(screen.getByText(/Puede verlos incluso sin conexión a internet/i)).toBeVisible();
+
+    const btn = screen.getByText(/Crear un reporte/i);
+    fireEvent.click(btn);
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('lista reportes con montaña, fecha, estado y puntoId', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 reporte guardado/i)).toBeVisible();
+    });
+
+    // Verificar datos del reporte en la tarjeta
+    expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    expect(screen.getByText(/📍 PUNTO-1/i)).toBeVisible();
+    expect(screen.getByText(/🟢/i)).toBeVisible(); // estado estable
+    expect(screen.getByText(/Estable/i)).toBeVisible();
+    // Fecha debe estar presente (formato varía por localización)
+    expect(screen.getByText(/\d{1,2}\/\d{1,2}\/\d{4}/)).toBeVisible();
+  });
+
+  it('muestra múltiples reportes ordenados por fecha', async () => {
+    const reporteAntiguo = {
+      ...REPORTE_BASE,
+      id: 'glaciar-1000000000-xyz',
+      createdAt: 1700000000000, // 2023
+      puntoId: 'PUNTO-2',
+      montana: 'tolima',
+      estado: 'precaucion',
+    };
+    mockGetAll.mockResolvedValue([REPORTE_BASE, reporteAntiguo]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 reportes guardados/i)).toBeVisible();
+    });
+
+    expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    expect(screen.getByText(/Tolima/i)).toBeVisible();
+  });
+
+  it('al tap en reporte abre detalle read-only', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    // Tocar la tarjeta del reporte
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+    });
+
+    // Verificar detalle - sección de ubicación
+    expect(screen.getByText(/4700 msnm/i)).toBeVisible();
+    // Verificar nombre del guía
+    expect(screen.getByText(/Juan Pérez/i)).toBeVisible();
+  });
+
+  it('permite eliminar reporte tras confirmación', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    mockRemove.mockResolvedValue();
+    const onBack = vi.fn();
+    render(<GlaciarHistorialScreen onBack={onBack} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    // Ir al detalle
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+    });
+
+    // Tocar botón eliminar
+    const deleteBtn = screen.getByLabelText(/Eliminar reporte/i);
+    fireEvent.click(deleteBtn);
+
+    // Confirmar
+    expect(globalThis.confirm).toHaveBeenCalledWith(
+      expect.stringContaining('¿Eliminar este reporte?')
+    );
+
+    await waitFor(() => {
+      expect(mockRemove).toHaveBeenCalledWith(REPORTE_BASE.id);
+    });
+
+    // Volver a la lista tras eliminar
+    await waitFor(() => {
+      expect(screen.queryByText(/Detalle del reporte/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('cancela eliminación si usuario rechaza confirmación', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    globalThis.confirm = vi.fn(() => false); // Rechazar
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+    });
+
+    const deleteBtn = screen.getByLabelText(/Eliminar reporte/i);
+    fireEvent.click(deleteBtn);
+
+    expect(globalThis.confirm).toHaveBeenCalled();
+    expect(mockRemove).not.toHaveBeenCalled();
+
+    // Seguimos en el detalle
+    expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+  });
+
+  it('muestra mensaje de error si falla eliminación', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    mockRemove.mockRejectedValue(new Error('DB error'));
+    const alertSpy = vi.spyOn(globalThis, 'alert').mockImplementation(() => {});
+
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+    });
+
+    const deleteBtn = screen.getByLabelText(/Eliminar reporte/i);
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('No se pudo eliminar el reporte');
+    });
+
+    alertSpy.mockRestore();
+  });
+
+  it('detalle muestra todos los campos del reporte', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+    });
+
+    // Verificar secciones principales
+    expect(screen.getByText(/Ubicación/i)).toBeVisible();
+    expect(screen.getByText(/Diagnóstico del hielo/i)).toBeVisible();
+    expect(screen.getByText(/Perfil de capas/i)).toBeVisible();
+    expect(screen.getByText(/Información del guía/i)).toBeVisible();
+
+    // Datos específicos
+    expect(screen.getByText(/15 m/i)).toBeVisible(); // distancia
+    expect(screen.getByText(/↗ 180°/i)).toBeVisible(); // azimut
+    expect(screen.getByText(/Cerca de la roca grande/i)).toBeVisible(); // referencia
+    expect(screen.getByText(/-3°C/i)).toBeVisible(); // temp superficie
+    expect(screen.getByText(/2°C/i)).toBeVisible(); // temp ambiente
+    expect(screen.getByText(/despejado/i)).toBeVisible(); // cielo
+  });
+
+  it('puede volver desde detalle a lista', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Detalle del reporte/i)).toBeVisible();
+    });
+
+    // Volver atrás usando el botón con aria-label
+    const backBtn = screen.getByLabelText('Volver');
+    fireEvent.click(backBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Detalle del reporte/i)).not.toBeInTheDocument();
+    });
+
+    // De vuelta en la lista
+    expect(screen.getByText(/Cocuy/i)).toBeVisible();
+  });
+
+  it('muestra loading mientras carga reportes', async () => {
+    mockGetAll.mockImplementation(() => new Promise(() => {})); // Nunca resuelve
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    expect(screen.getByText(/Cargando reportes/i)).toBeVisible();
+  });
+
+  it('muestra foto del reporte si existe', async () => {
+    mockGetAll.mockResolvedValue([REPORTE_BASE]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      const img = screen.getByAltText(/Punto glaciar/i);
+      expect(img).toBeVisible();
+      expect(img).toHaveAttribute('src', REPORTE_BASE.fotoDataUrl);
+    });
+  });
+
+  it('muestra placeholder si no hay foto', async () => {
+    const reporteSinFoto = { ...REPORTE_BASE, fotoDataUrl: null };
+    mockGetAll.mockResolvedValue([reporteSinFoto]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    // En la lista debe haber icono de copo de nieve
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    expect(card.querySelector('svg')).toBeVisible(); // Icono Snowflake
+  });
+
+  it('muestra todos los peligros observados', async () => {
+    const reportePeligros = {
+      ...REPORTE_BASE,
+      peligros: ['grietas_abiertas', 'seracs', 'penitentes'],
+      rutaBajoSeracs: true,
+      penitentesDensos: true,
+    };
+    mockGetAll.mockResolvedValue([reportePeligros]);
+    render(<GlaciarHistorialScreen onBack={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cocuy/i)).toBeVisible();
+    });
+
+    const card = screen.getByText(/Cocuy/i).closest('button');
+    fireEvent.click(card);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Peligros observados/i)).toBeVisible();
+    });
+
+    // Verificar peligros (usar getAllByText para múltiples elementos)
+    const seracsElements = screen.getAllByText(/Séracs/i);
+    expect(seracsElements.length).toBeGreaterThan(0);
+
+    expect(screen.getByText(/Grietas abiertas/i)).toBeVisible();
+
+    // Penitentes aparece tanto como peligro como tipo de superficie en capas
+    const penitentesElements = screen.getAllByText(/Penitentes/i);
+    expect(penitentesElements.length).toBeGreaterThan(0);
+
+    // Matiz de séracs
+    expect(screen.getByText(/La ruta pasa por debajo de los séracs/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Añade pantalla de historial de reportes glaciares (#6509) siguiendo el patrón de componentes del proyecto.

## Cambios

- **Nuevo componente**: 
  - Lista reportes guardados en IndexedDB (db/glaciarReportes.js)
  - Muestra: montaña, fecha, estado (semáforo color), puntoId
  - Tap en reporte → detalle read-only completo
  - Acción de eliminar con confirmación
  - Offline-first (IndexedDB, funciona sin conexión)
  - Gateado con  (solo La Cordada)

- **Tests**: 
  - 13 tests cubriendo: lista vacía, lista con reportes, tap→detalle, eliminar, navegación
  - Mock de IndexedDB (glaciarReportes)
  - Validación de campos mostrados

- **Integración en rutas**: 
  - Lazy load del componente
  - Ruta `#glaciar-historial` → `glaciar_historial`
  - Gate defensivo (redirige al dashboard si no tiene acceso)

## Test plan

- `npm run build`: ✅ pasa
- `npx vitest run src/components/__tests__/GlaciarHistorialScreen.test.jsx`: ✅ 13/13 tests pasan
- `npx eslint . --max-warnings=0`: ✅ pasa (0 errors, 0 warnings)
- `tsc --noEmit`: ✅ pasa

## Riesgos conocidos

- Ninguno. El componente es standalone y sigue patrones establecidos (ScreenShell, Screen similares)
- Offline-first verificado (usa IndexedDB como GlaciarReporteScreen)

## MCP tools usados

- Revisión del esquema de glaciares (glaciar-schema.js) para validar tipos de superficie, montañas, peligros
- Verificación de patrón de componentes existentes (CicloCultivoScreen, WorkerHistory)