### PR TITLE
test(setup): reparar entorno jsdom + asserts obsoletos (18 tests pre-existentes verdes)

### DIFF
--- a/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
@@ -14,7 +14,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Mock del store outbox (send durable) ─────────────────────────────────────
 const sendMock = vi.fn(async () => 1);
@@ -111,12 +111,20 @@ import AgentHero from '../AgentHero';
 import { getProfile, saveProfile, getProfileMunicipio } from '../../../services/userProfileService';
 
 beforeEach(() => {
+  // El menú Ⓐ marca cada capacidad con getCapabilityHealth(): una capacidad
+  // cuya tool vive en el sidecar (ej. 'Plaga' → get_pest_controllers) sale
+  // 'down' ("… sin conexión al servidor") cuando VITE_USE_SIDECAR_AGRO_MCP no
+  // está set, cambiando su aria-label y rompiendo getByLabelText('Plaga'). En
+  // un browser real con sidecar activo la capacidad está viva; acá habilitamos
+  // la flag para reproducir ese estado (entorno, no lógica de prod).
+  vi.stubEnv('VITE_USE_SIDECAR_AGRO_MCP', 'true');
+
   sendMock.mockClear();
   recorderState.isRecording = false;
   recorderState.start.mockClear();
   recorderState.stop.mockClear();
   recorderState.reset.mockClear();
-  
+
   // Reset profile mocks to default values
   getProfile.mockReturnValue({
     nivel_respuestas: 'simple',
@@ -139,6 +147,11 @@ beforeEach(() => {
   }));
   window.URL.createObjectURL = vi.fn(() => 'blob:preview');
   window.URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  // No filtrar VITE_USE_SIDECAR_AGRO_MCP a otros archivos de test.
+  vi.unstubAllEnvs();
 });
 
 describe('AgentHero — integración post-pulido (task #TEST-int)', () => {

--- a/src/services/__tests__/climaService.test.js
+++ b/src/services/__tests__/climaService.test.js
@@ -29,9 +29,13 @@ afterEach(() => {
 describe('climaService — phase helpers', () => {
   it('describePhase maps known phases', async () => {
     const mod = await importFresh();
-    expect(mod.describePhase('nino_fuerte')).toBe('El Niño fuerte');
-    expect(mod.describePhase('nina_debil')).toBe('La Niña débil');
-    expect(mod.describePhase('neutral')).toBe('Neutral ENSO');
+    // describePhase devuelve GUÍA accionable para el campesino, no la etiqueta
+    // técnica de la fase. Asertamos el ancla semántica con toContain para que
+    // un retoque de copy no re-rompa el test pero sí verifique que describe la
+    // fase correcta (seco para El Niño, parejo para neutral, etc.).
+    expect(mod.describePhase('nino_fuerte')).toContain('sequia');
+    expect(mod.describePhase('nina_debil')).toContain('lluvioso');
+    expect(mod.describePhase('neutral')).toContain('parejo');
   });
 
   it('phaseBadgeColor maps to expected accent', async () => {
@@ -285,8 +289,10 @@ describe('climaService — cache + fetch', () => {
 
   it('GR-9: describePhase entiende las fases manuales genéricas', async () => {
     const mod = await importFresh();
-    expect(mod.describePhase('nino')).toBe('El Niño');
-    expect(mod.describePhase('nina')).toBe('La Niña');
+    // Fases genéricas (sin intensidad): la guía debe nombrar el fenómeno y dar
+    // el consejo base. toContain por la misma razón que el test de arriba.
+    expect(mod.describePhase('nino')).toContain('El Niño');
+    expect(mod.describePhase('nina')).toContain('La Niña');
   });
 
   it('two simultaneous fetches share the in-flight promise', async () => {

--- a/src/services/__tests__/guardas-vivas.test.js
+++ b/src/services/__tests__/guardas-vivas.test.js
@@ -13,9 +13,12 @@ describe('guardas — todas vivas (ninguna muerta)', () => {
     const d = diagnosticarSuelo('hice la prueba del bicarbonato');
     expect(d.advertencias.some((a) => a.includes('MITO') && a.includes('bicarbonato'))).toBe(true);
   });
-  it('suelo: aguacate+mal drenaje -> ALERTA CRITICA', () => {
+  it('suelo: aguacate+mal drenaje -> ALERTA CRÍTICA', () => {
     const d = diagnosticarSuelo('quiero sembrar aguacate y el terreno se empoza');
-    expect(d.advertencias.some((a) => a.includes('ALERTA CRITICA') && a.includes('Phytophthora'))).toBe(true);
+    // El guard de prod emite "ALERTA CRÍTICA" (con tilde) + Phytophthora; la
+    // aserción tenía "CRITICA" sin tilde y nunca matcheaba. Corregido para
+    // reflejar el string real de prod sin debilitar la guarda.
+    expect(d.advertencias.some((a) => a.includes('ALERTA CRÍTICA') && a.includes('Phytophthora'))).toBe(true);
   });
   it('agua: lunar -> MITO', () => {
     const d = diagnosticarAgua('debo regar en luna menguante');

--- a/src/services/__tests__/outputGuards.restauracion.test.js
+++ b/src/services/__tests__/outputGuards.restauracion.test.js
@@ -11,8 +11,13 @@ describe('classifyQueryIntent — restauracion (Task 2, audit ministerio)', () =
   it('"restaurar la quebrada" → restauracion', () => {
     expect(classifyQueryIntent('restaurar la quebrada')).toBe('restauracion');
   });
-  it('"sembrar pino para reforestar" → siembra (siembra gana en prioridad)', () => {
-    expect(classifyQueryIntent('sembrar pino para reforestar')).toBe('siembra');
+  it('"sembrar pino para reforestar" → restauracion (restauración gana: pino/exóticas para "reforestar" deben disparar el guard de restauración, NO el de siembra)', () => {
+    // RESTORATION_INTENT_PATTERNS captura "(sembrar|plantar) pino/eucalipto/…"
+    // y "reforestar" y se evalúa ANTES que siembra en classifyQueryIntent. Es
+    // intencional (DR-RESTAURACION-INCENDIOS): plantar exóticas "para
+    // reforestar" es el anti-patrón que el guard de restauración debe advertir;
+    // tratarlo como siembra normal se saltaría esa advertencia.
+    expect(classifyQueryIntent('sembrar pino para reforestar')).toBe('restauracion');
   });
   it('"especies nativas para paramo" → restauracion', () => {
     expect(classifyQueryIntent('especies nativas para paramo')).toBe('restauracion');

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -271,10 +271,14 @@ describe('sidecarClient — feature flag on', () => {
       expect(res).toEqual({ found: false });
     });
 
-    it('tool name no permitido → null sin fetch (whitelist defense)', async () => {
+    it('tool name no permitido → ToolError not_allowed sin fetch (whitelist defense)', async () => {
       const { callTool } = await importFresh();
       const res = await callTool('delete_everything', {});
-      expect(res).toBeNull();
+      // Contrato tri-estado documentado de callTool (JSDoc): un tool intentado
+      // pero rechazado por la whitelist devuelve ToolError {_error,reason,tool},
+      // NO null (null se reserva para "ni se intentó": flag off / offline). Esto
+      // permite al caller distinguir "bloqueado" de "no aplica".
+      expect(res).toEqual({ _error: true, reason: 'not_allowed', tool: 'delete_everything' });
       expect(fetchMock).not.toHaveBeenCalled();
     });
 
@@ -304,11 +308,14 @@ describe('sidecarClient — feature flag on', () => {
       expect(__TEST__.ALLOWED_TOOLS.has('get_precio_sipsa')).toBe(true);
     });
 
-    it('5xx → null sin throw', async () => {
+    it('5xx → ToolError fetch_failed sin throw', async () => {
       fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: 'kg down' }));
       const { callTool } = await importFresh();
       const res = await callTool('get_companions', { species_id: 'maiz' });
-      expect(res).toBeNull();
+      // Tool permitido + intentado pero el sidecar respondió 5xx → ToolError
+      // fetch_failed (contrato tri-estado), no null. El turno no se rompe (no
+      // throw) y el formatter puede señalar el gap al LLM.
+      expect(res).toEqual({ _error: true, reason: 'fetch_failed', tool: 'get_companions' });
     });
   });
 

--- a/src/services/__tests__/sidecarClient.toolChain.test.js
+++ b/src/services/__tests__/sidecarClient.toolChain.test.js
@@ -449,7 +449,7 @@ describe('executeToolChain — ejecución secuencial con MAX_STEPS=3', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('herramientas con result null (timeout/error) → devuelve result: null', async () => {
+  it('herramientas que fallan (timeout/error) → result lleva ToolError fetch_failed', async () => {
     // Mock fetch: primero ok, segundo error
     fetchMock
       .mockResolvedValueOnce(jsonResponse(200, { species_id: 'passiflora_edulis' }))
@@ -466,7 +466,10 @@ describe('executeToolChain — ejecución secuencial con MAX_STEPS=3', () => {
 
     expect(result).toHaveLength(2);
     expect(result[0].result).toEqual({ species_id: 'passiflora_edulis' });
-    expect(result[1].result).toBeNull();
+    // callTool ahora propaga el ToolError tri-estado (no null) cuando el tool
+    // fue intentado pero falló; executeToolChain lo conserva como evidence del
+    // paso para que el formatter señale el gap al LLM.
+    expect(result[1].result).toEqual({ _error: true, reason: 'fetch_failed', tool: 'get_companions' });
   });
 
   it('SPEED-5 (#257): ejecuta los pasos en PARALELO (no secuencial)', async () => {
@@ -530,18 +533,20 @@ describe('executeToolChain — ejecución secuencial con MAX_STEPS=3', () => {
 });
 
 describe('ALLOWED_TOOLS whitelist — callTool rechaza no permitidos', () => {
-  it('callTool rechaza tool no permitido con null sin fetch', async () => {
+  it('callTool rechaza tool no permitido con ToolError not_allowed sin fetch', async () => {
     const { callTool } = await importFresh();
-    
+
     const result = await callTool('delete_everything', {});
-    
-    expect(result).toBeNull();
+
+    // Contrato tri-estado: rechazo de whitelist → ToolError not_allowed (no
+    // null). El tool NUNCA llega a la red (defensa en profundidad).
+    expect(result).toEqual({ _error: true, reason: 'not_allowed', tool: 'delete_everything' });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('callTool rechaza tools peligrosos: drop/delete/truncate/exec/eval', async () => {
     const { callTool } = await importFresh();
-    
+
     const dangerousTools = [
       'drop_table',
       'delete_database',
@@ -554,7 +559,9 @@ describe('ALLOWED_TOOLS whitelist — callTool rechaza no permitidos', () => {
 
     for (const tool of dangerousTools) {
       const result = await callTool(tool, {});
-      expect(result).toBeNull();
+      // Cada peligroso → ToolError not_allowed con el nombre del tool, jamás
+      // se intenta el fetch.
+      expect(result).toEqual({ _error: true, reason: 'not_allowed', tool });
     }
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -602,12 +609,13 @@ describe('ALLOWED_TOOLS whitelist — callTool rechaza no permitidos', () => {
     expect(__TEST__.ALLOWED_TOOLS.has('inject_sql')).toBe(false);
     expect(__TEST__.ALLOWED_TOOLS.has('xss_attack')).toBe(false);
     expect(__TEST__.ALLOWED_TOOLS.has('path_traversal')).toBe(false);
-    
-    // Verifica que callTool rechaza
-    expect(await callTool('inject_sql', {})).toBeNull();
-    expect(await callTool('xss_attack', {})).toBeNull();
-    expect(await callTool('path_traversal', {})).toBeNull();
-    
+
+    // Verifica que callTool rechaza con ToolError not_allowed (tri-estado) y
+    // sin tocar la red.
+    expect(await callTool('inject_sql', {})).toEqual({ _error: true, reason: 'not_allowed', tool: 'inject_sql' });
+    expect(await callTool('xss_attack', {})).toEqual({ _error: true, reason: 'not_allowed', tool: 'xss_attack' });
+    expect(await callTool('path_traversal', {})).toEqual({ _error: true, reason: 'not_allowed', tool: 'path_traversal' });
+
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/src/store/__tests__/useOllamaWarmStore.test.js
+++ b/src/store/__tests__/useOllamaWarmStore.test.js
@@ -11,10 +11,16 @@
  *   - resetWarmup vuelve al estado inicial limpio
  *
  * Fix cold-start (R2, 2026-06-03): el pre-warm DEBE calentar el modelo que
- * el chat realmente usa (`DEFAULT_MODEL` de llmRouter = ROUTES.chat.model =
- * granite3.1-dense:8b), NO el NLU (gemma3:4b). Antes calentaba gemma → el
- * primer chat con granite caía al cold-start de ~46s. Además se pinnea con
- * keep_alive=-1 (sin expiración por timer) en vez de '30m'.
+ * el chat realmente usa (`DEFAULT_MODEL` de llmRouter = ROUTES.chat.model), NO
+ * el NLU (gemma3:4b). Antes calentaba gemma → el primer chat con el modelo de
+ * chat caía al cold-start de ~46s. Además se pinnea con keep_alive=-1 (sin
+ * expiración por timer) en vez de '30m'.
+ *
+ * El nombre exacto del modelo de chat evoluciona (granite3.1-dense:8b →
+ * granite3.3:8b, 2026-06-11). Por eso aserta contra `DEFAULT_MODEL`
+ * (importado de llmRouter), NUNCA contra un string hardcoded: la invariante
+ * que protege este test es "pre-warm == modelo de chat ≠ NLU", no qué granite
+ * específico está promovido hoy.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import useOllamaWarmStore from '../useOllamaWarmStore';
@@ -66,10 +72,12 @@ describe('useOllamaWarmStore — NN4 pre-warm Ollama al login', () => {
     const [, opts] = fetch.mock.calls[0];
     const body = JSON.parse(opts.body);
     // El modelo pre-calentado debe ser exactamente el del chat configurado
-    // en llmRouter (ROUTES.chat.model). Si fueran distintos, granite queda
-    // frío y el primer chat sufre el cold-start de ~46s.
+    // en llmRouter (ROUTES.chat.model). Si fueran distintos, el modelo de chat
+    // queda frío y el primer chat sufre el cold-start de ~46s. Aserta contra
+    // DEFAULT_MODEL (no un string fijo) para sobrevivir promociones de modelo.
     expect(body.model).toBe(DEFAULT_MODEL);
-    expect(body.model).toBe('granite3.1-dense:8b');
+    // Invariante anti-regresión del bug NN4: NUNCA debe calentar el modelo de
+    // NLU (gemma3:4b) en vez del de chat.
     expect(body.model).not.toBe('gemma3:4b');
   });
 

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -3,10 +3,45 @@
  *
  * Imports jest-dom matchers para assertions de DOM (toBeVisible, toHaveTextContent, etc.).
  * Auto-cleanup después de cada test para evitar leaks entre tests.
+ *
+ * Polyfills de ENTORNO (jsdom no es un browser real): acá vive todo lo que el
+ * código de prod asume del runtime web pero jsdom NO provee fielmente. Regla:
+ * estos shims NO cambian comportamiento de prod — solo cierran el gap jsdom↔browser
+ * para que los tests ejerciten el código real. Cada uno documenta su porqué.
  */
 import '@testing-library/jest-dom/vitest';
 import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
+
+// ── Polyfill: crypto.subtle.digest con ArrayBuffer cross-realm ──────────────
+// jsdom expone `crypto.subtle` (webcrypto de Node), pero el ArrayBuffer que
+// devuelve `Blob.arrayBuffer()` proviene de OTRO realm de V8 que el de la
+// webcrypto interna. Node valida el 2º argumento de `digest()` con un
+// `instanceof ArrayBuffer` contra SU realm y lo rechaza con:
+//   "2nd argument is not instance of ArrayBuffer, Buffer, TypedArray, or DataView"
+// …aunque `buf instanceof ArrayBuffer` sea true en el realm del test. En un
+// browser real Blob y crypto.subtle comparten realm, así que esto NO ocurre —
+// es un artefacto puro de jsdom. Normalizamos el ArrayBuffer a una vista
+// `Uint8Array` (las TypedArrays SÍ cruzan el chequeo), preservando los bytes.
+// Prod (`visionCacheService.hashImage`) queda intacto. Verificado: produce el
+// SHA-256 correcto (vector "hello" → 2cf24dba…9824).
+(() => {
+  const subtle = globalThis.crypto && globalThis.crypto.subtle;
+  if (!subtle || typeof subtle.digest !== 'function' || subtle.__chagraDigestPatched) {
+    return;
+  }
+  const originalDigest = subtle.digest.bind(subtle);
+  subtle.digest = (algorithm, data) => {
+    // Solo el ArrayBuffer "pelado" dispara el bug de realm; las vistas
+    // (TypedArray/DataView) y Buffers pasan tal cual.
+    const normalized = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+    return originalDigest(algorithm, normalized);
+  };
+  Object.defineProperty(subtle, '__chagraDigestPatched', {
+    value: true,
+    configurable: true,
+  });
+})();
 
 // jsdom no implementa matchMedia — mock global mínimo. Tests específicos
 // pueden override con setStandalone() helpers si necesitan.


### PR DESCRIPTION
## Bug / Feature
~19 tests unitarios fallaban de forma PRE-EXISTENTE (fallan igual en `origin/main`, NO son regresión de esta rama). Objetivo: dejar `npx vitest run` en verde arreglando el ENTORNO de test (jsdom/polyfills/mocks/setup) y las aserciones que quedaron desfasadas del contrato real de prod — sin tocar lógica de producción.

## Causa raíz
Tres familias de causas, todas de TEST (no de prod):

1. **`crypto.subtle.digest` cross-realm en jsdom** — El `ArrayBuffer` que devuelve `Blob.arrayBuffer()` proviene de un realm V8 distinto al de la webcrypto interna de Node; `digest()` lo rechaza con *"2nd argument is not instance of ArrayBuffer…"* aunque `instanceof ArrayBuffer` dé `true`. En un browser real Blob y `crypto.subtle` comparten realm, así que esto es un artefacto puro de jsdom. Prod (`visionCacheService.hashImage`) ya degrada con gracia (try/catch), así que el cache quedaba inerte en tests → el modelo se llamaba 2× y los tests de cache-hit fallaban.
2. **Flag de sidecar ausente en el entorno** — `getCapabilityHealth()` marca capacidades cuya tool vive en el sidecar (p. ej. `Plaga` → `get_pest_controllers`) como `down` cuando `VITE_USE_SIDECAR_AGRO_MCP` no está set, cambiando el `aria-label` a *"Plaga (sin conexión al servidor)"* y rompiendo `getByLabelText('Plaga')`.
3. **Aserciones obsoletas vs. contrato/copy real de prod** — Tests que quedaron atrás de cambios intencionales y documentados de prod (ToolError tri-estado en `callTool`, promoción del modelo de chat `granite3.1-dense:8b`→`granite3.3:8b`, copy de `describePhase`, prioridad restauración>siembra para "sembrar pino", tilde en "ALERTA CRÍTICA").

## Cambios
- **`tests/unit/setup.js`** — Polyfill global que normaliza `ArrayBuffer`→`Uint8Array` antes de delegar al `crypto.subtle.digest` real (idempotente, documentado, SHA-256 verificado con el vector `"hello"`). Recupera 6 tests (`visionCacheService` ×4, `aiService.visionCache` ×2).
- **`AgentHero.integration.test.jsx`** — `vi.stubEnv('VITE_USE_SIDECAR_AGRO_MCP','true')` en `beforeEach` + `vi.unstubAllEnvs()` en `afterEach` (no filtra a otros archivos). Recupera 1 test.
- **`sidecarClient.test.js` / `sidecarClient.toolChain.test.js`** — Aserciones alineadas al contrato tri-estado YA documentado en el JSDoc de `callTool`: `not_allowed`/`5xx` → `{_error:true, reason, tool}` (no `null`). Recupera 6 tests y los hace MÁS estrictos (verifican el error discriminado).
- **`useOllamaWarmStore.test.js`** — Quita el string hardcoded; aserta contra `DEFAULT_MODEL` (importado de `llmRouter`) + invariante anti-regresión `!= gemma3:4b`. Recupera 1 test, a prueba de futuras promociones de modelo.
- **`climaService.test.js`** — `describePhase` devuelve guía accionable campesina, no etiqueta corta; `toContain` del ancla semántica. Recupera 2 tests.
- **`outputGuards.restauracion.test.js`** — "sembrar pino para reforestar" → `restauracion` por diseño (patrón exóticas + orden de prioridad, DR-RESTAURACION-INCENDIOS); la aserción esperaba lo contrario. Recupera 1 test.
- **`guardas-vivas.test.js`** — El guard emite "ALERTA CRÍTICA" (con tilde) + Phytophthora; la aserción buscaba "CRITICA" sin tilde y nunca matcheaba. Recupera 1 test.

## Tests
- **Antes (origin/main):** 5387 passed | **19 failed** | 1 skipped.
- **Después:** **5405 passed | 1 failed** | 1 skipped → **18 tests recuperados**, 0 regresiones.
- El único fallo restante es **`outputGuards.mipPlaga` GAP 2b**: hueco REAL de coordinación de guards en prod (#1303) — el suppress-and-replace del agroquímico borra el recordatorio MIP del texto final (el `reason` se registra pero el texto no lo conserva). NO se toca (requeriría cambiar lógica de prod, fuera de scope) ni se borra el test. Determinístico (1 failed / 14 passed en ese archivo en corridas repetidas).
- ESLint `--max-warnings=0` limpio en los 8 archivos; lefthook pre-commit verde (secret/infra/strategic/pro-import/eslint).

## Notas para el operador (acción opcional, pre-existente, NO bloquea esta PR)
- **`@vitest/coverage-v8` desincronizado**: `package.json` lo declara en `devDependencies` (`^4.1.8`) pero el `package-lock.json` NO tiene su nodo instalado, y la versión correcta debe igualar a `vitest` (4.1.7), no `^4.1.8`. Resultado: `npm run coverage` falla con `MISSING DEPENDENCY` y `npm ci` queda en riesgo de fallar por lock fuera de sync. No lo incluyo en esta PR para no arrastrar un diff grande/frágil de lockfile contra el `node_modules` symlinkeado del worktree; es un fix de dependencias independiente. Recomendado: `npm install @vitest/coverage-v8@^4.1.5` (alineado a vitest) en una PR aparte para habilitar cobertura medible en CI.

Refs: auditoría de tests pre-existentes; complementa (no colisiona con) PR #1561 `test/audit-modular-fixtures` (fixtures factories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up que esta PR habilita (importante)
`.github/workflows/unit-tests.yml` documenta explícitamente (líneas 15-21) que el gate de CI está LIMITADO a un subconjunto de 5 archivos justamente porque `visionCacheService` / `aiService.visionCache` eran *"CI-flaky por diferencias de SubtleCrypto.digest entre runners"* y "ampliar este gate a `npm run test:unit` queda pendiente de estabilizar esos 2 tests". **El polyfill de `tests/unit/setup.js` de esta PR es exactamente esa estabilización.** Con esto mergeado, el operador puede expandir `unit-tests.yml` para correr la suite completa (`npm run test:unit`) en cada PR — recomendado como PR de seguimiento (junto con el fix de `@vitest/coverage-v8` arriba).