### PR TITLE
fix(agente): legibilidad de chips/sugerencias/header sobre foto de fondo

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -2817,13 +2817,19 @@ export default function AgentScreen({ onBack, initialContext }) {
 
   return (
     <div className={`h-[100dvh] flex flex-col overflow-hidden relative text-white ${entranceClassRef.current}`}>
-      {/* Scrim semitransparente: deja ver --app-bg-image del body */}
-      <div className="absolute inset-0 bg-slate-950/82 backdrop-blur-sm pointer-events-none" aria-hidden="true" />
+      {/* Velo de legibilidad: deja ver --app-bg-image del body PERO garantiza
+          contraste. Token-aware (.agent-scrim → navy denso en bio-punk, crema
+          sutil en claros). Antes era bg-slate-950/82 fijo y, accediendo al
+          agente directo (#agente), la foto lavaba chips/sugerencias/Volver
+          (fix legibilidad 2026-06-15). */}
+      <div className="absolute inset-0 agent-scrim backdrop-blur-[2px] pointer-events-none" aria-hidden="true" />
       {/* B1: animación de entrada (fade+rise). Respeta prefers-reduced-motion. */}
       <style>{AGENT_ENTRANCE_CSS}{AGENT_COMPOSITOR_CSS}</style>
 
-      {/* ── Header estilo ScreenShell (2026-06-08): scrim + blur + acciones globales ── */}
-      <header className="px-4 py-3 flex items-center gap-2 border-b border-slate-800 bg-slate-900/50 backdrop-blur-md shrink-0">
+      {/* ── Header estilo ScreenShell (2026-06-08): superficie OPACA por token
+          (.agent-bar-surface) + acciones globales. Antes bg-slate-900/50 dejaba
+          pasar la foto detrás del título y los íconos (fix legibilidad 2026-06-15). ── */}
+      <header className="px-4 py-3 flex items-center gap-2 border-b border-slate-800 agent-bar-surface shrink-0">
         {/* Back */}
         <button
           type="button"
@@ -3043,8 +3049,10 @@ export default function AgentScreen({ onBack, initialContext }) {
         />
       )}
 
-      {/* ── Compositor pill — paridad completa AgentHero (2026-06-08) ── */}
-      <div className="relative z-10 px-3 pb-[calc(env(safe-area-inset-bottom,0px)+8px)] pt-2 border-t border-slate-800/60 bg-slate-900/70 backdrop-blur-md shrink-0">
+      {/* ── Compositor pill — paridad completa AgentHero (2026-06-08).
+          Superficie OPACA por token (.agent-bar-surface) para legibilidad sobre
+          la foto de fondo (fix 2026-06-15). ── */}
+      <div className="relative z-10 px-3 pb-[calc(env(safe-area-inset-bottom,0px)+8px)] pt-2 border-t border-slate-800/60 agent-bar-surface shrink-0">
 
         {/* Preview de foto adjunta (outbox) */}
         {agentAttachment && (

--- a/src/components/AgentScreen/SuggestedActions.jsx
+++ b/src/components/AgentScreen/SuggestedActions.jsx
@@ -6,15 +6,15 @@ import { SUGGESTED_ACTIONS_CHIPS as SUGGESTIONS } from '../../data/exampleQuesti
 
 export default function SuggestedActions({ onSelect }) {
   return (
-    <div className="px-4 py-3 border-t border-slate-800 bg-slate-900/50">
-      <p className="text-[10px] text-slate-500 uppercase font-bold mb-2">Sugerencias</p>
+    <div className="agent-chip-tray px-4 py-3">
+      <p className="agent-chip-tray-label text-[10px] uppercase font-bold mb-2">Sugerencias</p>
       <div className="flex flex-wrap gap-2">
         {SUGGESTIONS.map((s, idx) => (
           <button
             key={idx}
             type="button"
             onClick={() => onSelect(s.text)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-slate-800/80 hover:bg-slate-700/80 border border-slate-700/50 text-xs text-slate-300 transition-colors"
+            className="agent-chip flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-medium transition-colors"
           >
             <span>{s.icon}</span>
             <span>{s.text}</span>

--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -68,9 +68,9 @@ export default function ChipsToolbar({
     'focus:outline-none focus:ring-2 focus:ring-emerald-400/60 ' +
     'disabled:opacity-40 disabled:cursor-not-allowed';
   // Alto contraste: activo = verde sólido sobre texto blanco; inactivo =
-  // slate-700 con borde claro (legible al sol). Toque ≥44px efectivo por padding.
-  const inactiveChip =
-    'bg-slate-700 border-slate-500 text-slate-100 hover:bg-slate-600 hover:border-slate-400';
+  // superficie OPACA por token (.agent-chip — paridad con el home, legible sobre
+  // la foto de fondo). Toque ≥44px efectivo por padding.
+  const inactiveChip = 'agent-chip';
   const activeChip =
     'bg-emerald-600 border-emerald-300 text-white shadow-md';
   // Chip Pro bloqueado: apariencia visualmente diferenciada para free users.
@@ -80,7 +80,7 @@ export default function ChipsToolbar({
   return (
     <div
       data-testid="chips-toolbar"
-      className="px-3 py-2 border-t border-slate-800/70 bg-slate-900/70"
+      className="agent-chip-tray px-3 py-2"
     >
       <div
         role="toolbar"

--- a/src/components/QuickChipsBar.jsx
+++ b/src/components/QuickChipsBar.jsx
@@ -28,9 +28,9 @@ export default function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUES
   return (
     <div
       data-testid="quick-chips-bar"
-      className="px-4 py-2 border-t border-slate-800/60 bg-slate-900/40"
+      className="agent-chip-tray px-4 py-2"
     >
-      <p className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-2">
+      <p className="agent-chip-tray-label text-[10px] uppercase tracking-wider font-bold mb-2">
         Preguntas rápidas
       </p>
       <div className="flex flex-wrap gap-2">
@@ -40,7 +40,7 @@ export default function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUES
             type="button"
             onClick={() => onSelect(q)}
             data-testid="quick-chip"
-            className="px-3 py-1.5 rounded-full bg-slate-800/80 hover:bg-slate-700/80 active:scale-95 border border-slate-700/60 text-xs text-slate-200 transition-all"
+            className="agent-chip px-3 py-1.5 rounded-full border active:scale-95 text-xs font-medium transition-all"
           >
             {q}
           </button>

--- a/src/index.css
+++ b/src/index.css
@@ -347,6 +347,64 @@
   .app-scrim-strong {
     background-color: rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 1.49));
   }
+
+  /* ---------------------------------------------------------------------------
+   * AGENTE — superficies LEGIBLES sobre foto de fondo (fix 2026-06-15).
+   * Bug: accediendo al AGENTE directo (#agente, sin pasar por el home) los chips
+   * de capacidades/sugerencias, el header y el botón "Volver" quedaban como
+   * fantasmas translúcidos (bg-slate-900/40-50 + bg-slate-800/80) ILEGIBLES
+   * sobre la foto de biodiversidad (SelectedBackgroundReveal / --app-bg-image).
+   * Solución: superficies OPACAS por TOKEN de tema (igual que .agentport-chip
+   * del home) + blur de respaldo + texto fuerte → contraste WCAG AA en bio-punk
+   * y en los temas claros (papel/crema) sin eliminar el fondo. Unifica el
+   * tratamiento del AgentScreen con el del home.
+   * ------------------------------------------------------------------------- */
+
+  /* Velo extra SOLO del AgentScreen: refuerza el scrim base de la vista (la foto
+   * estaba lavando el contenido al entrar directo). Token-aware: navy denso en
+   * bio-punk, crema sutil en claros. Va como capa absoluta detrás del contenido. */
+  .agent-scrim {
+    background-color: rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 1.62));
+  }
+
+  /* Bandeja opaca para filas de chips/sugerencias (QuickChipsBar, SuggestedActions,
+   * ChipsToolbar). Reemplaza los wrappers translúcidos: superficie raised del
+   * tema + blur de respaldo + borde superior. */
+  .agent-chip-tray {
+    background-color: rgb(var(--c-surface-raised) / 0.96);
+    -webkit-backdrop-filter: blur(10px);
+    backdrop-filter: blur(10px);
+    border-top: 1px solid rgb(var(--c-surface-border) / 0.9);
+  }
+
+  /* Etiqueta de sección ("Sugerencias", "Preguntas rápidas") — legible, no el
+   * slate-500 que se perdía sobre la foto. */
+  .agent-chip-tray-label {
+    color: rgb(var(--c-slate-400));
+  }
+
+  /* Pill de chip OPACO (paridad con .agentport-chip del home): superficie card
+   * del tema + borde + texto fuerte (--c-slate-100) + sombra sutil. Legible al
+   * sol y sobre cualquier foto. El estado activo/disabled lo siguen poniendo las
+   * clases utilitarias del componente; esto fija la BASE legible. */
+  .agent-chip {
+    background-color: rgb(var(--c-surface-card));
+    border: 1px solid rgb(var(--c-surface-border));
+    color: rgb(var(--c-slate-100));
+    box-shadow: 0 2px 8px -5px rgba(0, 0, 0, 0.45);
+  }
+  .agent-chip:hover {
+    background-color: rgb(var(--c-surface-raised));
+    border-color: rgb(var(--t-accent-rgb) / 0.5);
+  }
+
+  /* Header + compositor del AGENTE — superficies opacas (antes /50-/70 dejaban
+   * pasar la foto detrás de los íconos y el botón Volver). */
+  .agent-bar-surface {
+    background-color: rgb(var(--c-surface-card) / 0.97);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+  }
 }
 
 /* ===========================================================================


### PR DESCRIPTION
## Problema (confirmado por screenshot)

Accediendo al **AGENTE** directo (`#agente`, sin pasar por el home), los chips de
capacidades, los chips de **SUGERENCIAS**/**PREGUNTAS RÁPIDAS**, el header (título +
íconos) y el botón **Volver** quedaban como **fantasmas translúcidos ILEGIBLES**
sobre la foto de biodiversidad de fondo (`SelectedBackgroundReveal` / `--app-bg-image`).
Contraste pésimo, y "no unificado con el giro del home".

## Causa raíz

- El `AgentScreen` montaba sus superficies con opacidades muy bajas
  (`bg-slate-900/40-70`, chips `bg-slate-800/80` con texto `slate-200/300`) y el
  velo base de la vista (`bg-slate-950/82`) no sostenía el contraste cuando se
  entra directo, así que la foto lavaba todo.
- El **home** (`AgentHero`) sí usa superficies **opacas por token de tema**
  (`.agentport-chip` = `--c-surface-card` + borde + texto `--c-slate-100`). De ahí
  el "no está unificado".
- El scrim `.app-scrim` que monta el home (`App.jsx`) **no se aplica** en el
  `case 'agente'` de `renderView()` (AgentScreen se renderiza directo, sin wrapper),
  por eso el agente directo se veía peor que el home.

## Fix (token-aware, mismo tratamiento que el home, sin eliminar el fondo)

`src/index.css` — nuevas utilidades en `@layer utilities`:
- `.agent-scrim` — velo de legibilidad reforzado SOLO del AgentScreen (token-aware:
  navy denso en bio-punk, crema sutil en temas claros).
- `.agent-chip-tray` + `.agent-chip-tray-label` — bandejas **opacas** (superficie
  raised del tema + `backdrop-filter` blur + borde) para las filas de chips/sugerencias.
- `.agent-chip` — pill **opaco** por token (paridad con `.agentport-chip`: superficie
  card + borde + texto `--c-slate-100` + sombra). Legible al sol y sobre cualquier foto.
- `.agent-bar-surface` — header y compositor opacos.

Componentes (solo swap de clases, sin lógica nueva):
- `QuickChipsBar.jsx`, `SuggestedActions.jsx`, `ChipsToolbar.jsx` → usan las clases nuevas.
- `AgentScreen.jsx` → header + compositor + velo de fondo con `.agent-bar-surface` / `.agent-scrim`.

Contraste **WCAG AA** en bio-punk y en los temas claros (papel/crema). El fondo de
biodiversidad **se conserva** (visible en la zona hero del avatar/saludo); solo las
superficies de UI encima quedan legibles.

## Home (DashboardLive / AgentHero / AgentRedMenu)

El home **ya está correcto en `main`**: `AgentRedMenu` consume `CAPABILITY_MANIFEST`
(`src/services/agentCapabilities.js`), que **incluye silvopastoreo** (+ restauración,
páramo). El "ve botones viejos / falta silvopastoreo" que reporta el operador es
**caché del Service Worker**, no código. El deploy lo resuelve solo: `deploy.yml`
fija la versión a deploy-time y bumpea `CACHE_NAME` por-SHA (auto-bump pre-commit
fue removido 2026-06-02). Nota: `public/sw.js` **no hace `skipWaiting()` automático**
(el SW nuevo queda en `waiting`), así que para verlo de inmediato hay que disparar el
`UpdateAvailableBanner` in-app o hard-reload.

## Verificación (Playwright, chromium del nix-store, mobile 412×915)

Acceso **directo** a `#agente`, logueado (auth stub en localforage IDB) sobre la foto
de fondo de biodiversidad. Mismas condiciones antes/después (3 quick-chips,
sugerencias, botón Volver, `app-bg-biodiversidad` activo).

- ANTES (origin/main): `/tmp/agentscreen-fix-antes.png`
- DESPUÉS (este fix): `/tmp/agentscreen-fix-despues.png`
- Comparación lado a lado: `/tmp/agentscreen-fix-sidebyside.png`

En el "después" los chips de SUGERENCIAS y PREGUNTAS RÁPIDAS, el header y Volver
quedan **claramente legibles** (superficies opacas), con el fondo conservado.

## Tests

- `vitest`: **174 verdes** (AgentScreen, dashboard, ChipsToolbar, QuickChipsBar) +
  30 verdes (styles/themes/theme-background). Ningún test asserta las clases de
  opacidad cambiadas.
- `eslint` de los componentes pequeños cambiados: limpio. El `eslint` del
  `AgentScreen.jsx` (3438 líneas) hace **OOM en el host local** (límite de RAM, no es
  un hallazgo de lint); los cambios ahí son solo swaps de `className`. Los scans de
  seguridad de lefthook (secret/infra-refs/pro-import/strategic) pasaron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)