### PR TITLE
feat(perfil): foto de perfil del operador con sync a FarmOS

### DIFF
--- a/src/components/LoginScreen.jsx
+++ b/src/components/LoginScreen.jsx
@@ -84,6 +84,16 @@ export default function LoginScreen({ onLoginSuccess, onSave }) {
       } catch (err) {
         console.warn('[LoginScreen] setActiveTenantId failed:', err);
       }
+      // Foto de perfil cross-device (2026-06-15): traer del servidor la última
+      // foto del operador para este dispositivo. Fire-and-forget — no bloquea
+      // el login y es no-throw (degrada al ícono por defecto si falla/offline).
+      try {
+        import('../services/operatorPhotoService.js')
+          .then((m) => m.loadFromFarmOS())
+          .catch(() => {});
+      } catch (err) {
+        console.warn('[LoginScreen] operator photo load dispatch failed:', err);
+      }
       // NN4 fix 2026-05-23: disparar pre-warm del modelo Ollama configurado ANTES de
       // navegar al dashboard. Esto da ~15-30s de margen humano (el operador
       // mira el dashboard, escoge una tile, abre el agente) durante los

--- a/src/components/OAuthCallback.jsx
+++ b/src/components/OAuthCallback.jsx
@@ -65,6 +65,15 @@ export default function OAuthCallback({ onSuccess, onError }) {
         } catch (err) {
           console.warn('[OAuthCallback] setActiveTenantId failed:', err);
         }
+        // Foto de perfil cross-device (2026-06-15): igual que LoginScreen,
+        // traer del servidor la última foto del operador. Fire-and-forget.
+        try {
+          import('../services/operatorPhotoService.js')
+            .then((m) => m.loadFromFarmOS())
+            .catch(() => {});
+        } catch (err) {
+          console.warn('[OAuthCallback] operator photo load dispatch failed:', err);
+        }
         try {
           useOllamaWarmStore.getState().startWarmup();
         } catch (err) {

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench, Sprout, ChevronRight, Bell, Users } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { User, Palette, Briefcase, Save, Check, Mic, MapPin, Home, Volume2, Wrench, Sprout, ChevronRight, Bell, Users, Camera, Trash2 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { esExtensionistaActual } from '../config/extensionistaAccess';
 import ThemeSelector from './common/ThemeSelector';
@@ -14,6 +14,7 @@ import useFincaActiveStore from '../services/fincaActiveStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { stop as stopTTS } from '../services/ttsService';
 import { getNotificationStyle, setNotificationStyle, getTelemetryConsent, setTelemetryConsent, HOME_MODULES, getModuleVisibility, setModuleVisibility } from '../services/userProfileService';
+import { getOperatorPhoto, setOperatorPhotoFromFile, removeOperatorPhotoLocal } from '../services/operatorPhotoService';
 
 const TTL_OPTIONS = [
   { id: '1d', label: '1 día' },
@@ -79,6 +80,44 @@ export default function ProfileScreen({ onBack, onHome }) {
       ? localStorage.getItem('chagra:operator:role') || 'operador_campo'
       : 'operador_campo'
   );
+
+  // Foto de perfil del operador (feature recuperada 2026-06-15). Persiste
+  // local (localStorage) + sincroniza a FarmOS cuando hay sesión, vía
+  // operatorPhotoService. Render inmediato desde localStorage (offline-first).
+  const [photoData, setPhotoData] = useState(() => getOperatorPhoto());
+  const [photoError, setPhotoError] = useState(null);
+  const [photoBusy, setPhotoBusy] = useState(false);
+  const photoInputRef = useRef(null);
+
+  const handlePhotoSelected = async (e) => {
+    setPhotoError(null);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setPhotoError('El archivo no parece una imagen.');
+      return;
+    }
+    setPhotoBusy(true);
+    try {
+      // Redimensiona + persiste local + dispara sync a FarmOS en segundo plano.
+      const dataUrl = await setOperatorPhotoFromFile(file);
+      setPhotoData(dataUrl);
+    } catch (err) {
+      console.warn('[ProfileScreen] photo upload falló:', err);
+      setPhotoError('No pudimos procesar la imagen. Intenta otra.');
+    } finally {
+      setPhotoBusy(false);
+      // Reset para permitir re-elegir el mismo archivo si quiere.
+      if (photoInputRef.current) photoInputRef.current.value = '';
+    }
+  };
+
+  const handlePhotoRemove = () => {
+    removeOperatorPhotoLocal();
+    setPhotoData('');
+    setPhotoError(null);
+  };
+
   const [savedFlash, setSavedFlash] = useState(false);
   const [telemetryEnabled, setTelemetryEnabled] = useState(() =>
     typeof window !== 'undefined'
@@ -211,11 +250,60 @@ export default function ProfileScreen({ onBack, onHome }) {
             aria-labelledby="profile-tab-perfil"
             className="flex flex-col gap-6"
           >
-            {/* ID Card / User Info, header con datos sintetizados */}
+            {/* ID Card / User Info, header con datos sintetizados.
+                Avatar editable: el operador sube su foto (cámara/galería). La
+                imagen se guarda local (offline) y se sincroniza a FarmOS para
+                verla en otros dispositivos (operatorPhotoService). */}
             <div className="bg-slate-900/60 border border-slate-800 rounded-2xl p-6 flex flex-col items-center">
-              <div className="w-20 h-20 bg-slate-800 rounded-full flex items-center justify-center mb-4 border-2 border-emerald-500/30">
-                <User size={40} className="text-emerald-400" />
+              <div className="relative mb-4">
+                <div
+                  className="w-24 h-24 bg-slate-800 rounded-full overflow-hidden flex items-center justify-center border-2 border-emerald-500/30"
+                >
+                  {photoData ? (
+                    <img
+                      src={photoData}
+                      alt={`Foto de ${name}`}
+                      className="w-full h-full object-cover"
+                      data-testid="profile-photo-img"
+                    />
+                  ) : (
+                    <User size={44} className="text-emerald-400" aria-hidden="true" />
+                  )}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => photoInputRef.current?.click()}
+                  disabled={photoBusy}
+                  data-testid="profile-photo-button"
+                  className="absolute -bottom-1 -right-1 w-9 h-9 rounded-full bg-emerald-600 hover:bg-emerald-500 active:bg-emerald-700 disabled:opacity-60 text-white flex items-center justify-center shadow-lg border-2 border-slate-900"
+                  aria-label={photoData ? 'Cambiar foto de perfil' : 'Agregar foto de perfil'}
+                  title={photoData ? 'Cambiar foto' : 'Agregar foto'}
+                >
+                  <Camera size={16} aria-hidden="true" />
+                </button>
+                <input
+                  ref={photoInputRef}
+                  type="file"
+                  accept="image/*"
+                  capture="user"
+                  onChange={handlePhotoSelected}
+                  className="hidden"
+                  aria-hidden="true"
+                  data-testid="profile-photo-input"
+                />
               </div>
+              {photoError && (
+                <p className="text-xs text-amber-400 mb-2" role="alert">{photoError}</p>
+              )}
+              {photoData && (
+                <button
+                  type="button"
+                  onClick={handlePhotoRemove}
+                  className="text-[10px] text-slate-500 hover:text-slate-300 inline-flex items-center gap-1 mb-2"
+                >
+                  <Trash2 size={11} aria-hidden="true" /> Quitar foto
+                </button>
+              )}
               <h2 className="text-2xl font-black text-white">{name}</h2>
               <p className="text-xs text-slate-500 uppercase tracking-widest font-bold mt-1">{currentRoleLabel}</p>
             </div>
@@ -305,7 +393,8 @@ export default function ProfileScreen({ onBack, onHome }) {
                 {savedFlash ? <><Check size={18} /> Guardado</> : <><Save size={18} /> Guardar cambios</>}
               </button>
               <p className="text-[10px] text-slate-500 text-center leading-relaxed">
-                Los cambios se guardan en tu dispositivo. Subida al servidor pendiente (planeado v1.x).
+                El nombre y el rol se guardan en tu dispositivo. Tu foto de perfil
+                se sincroniza con el servidor para verla en otros dispositivos.
               </p>
             </div>
           </div>

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -8,6 +8,7 @@ import useAssetStore from '../store/useAssetStore';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import { FARM_CONFIG } from '../config/defaults';
 import { getProfile, getProfileMunicipio, getNotificationStyle } from '../services/userProfileService';
+import { getOperatorPhoto } from '../services/operatorPhotoService';
 import { findMunicipio } from '../utils/colombiaLocations';
 import { useTheme } from '../hooks/useTheme';
 import { iconForTheme } from './dashboard/themeIcon';
@@ -107,6 +108,21 @@ export default function TopBar({ onNavigate, onLogout }) {
     const onStyleChanged = () => setNotifStyle(getNotificationStyle());
     window.addEventListener('chagra:notif-style-changed', onStyleChanged);
     return () => window.removeEventListener('chagra:notif-style-changed', onStyleChanged);
+  }, []);
+
+  // Foto de perfil del operador en el ícono de usuario (feature 2026-06-15).
+  // Cae al ícono CircleUser si no hay foto. Re-lee en vivo cuando el operador
+  // la sube/cambia/quita en Perfil ('chagra:operator-update', same-tab) o desde
+  // otra pestaña ('storage', cross-tab nativo).
+  const [operatorPhoto, setOperatorPhoto] = useState(() => getOperatorPhoto());
+  useEffect(() => {
+    const refresh = () => setOperatorPhoto(getOperatorPhoto());
+    window.addEventListener('chagra:operator-update', refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener('chagra:operator-update', refresh);
+      window.removeEventListener('storage', refresh);
+    };
   }, []);
 
   // "Respira" animación del logo Chagra cuando hay actividad de fondo
@@ -251,9 +267,18 @@ export default function TopBar({ onNavigate, onLogout }) {
             aria-label="Menú de usuario"
             aria-expanded={avatarMenuOpen}
             data-testid="topbar-user-menu"
-            className="w-10 h-10 min-w-[44px] min-h-[44px] rounded-full bg-slate-800 border-2 border-slate-700 hover:border-teal-500/50 flex items-center justify-center text-slate-400 hover:text-white transition-colors"
+            className="w-10 h-10 min-w-[44px] min-h-[44px] rounded-full bg-slate-800 border-2 border-slate-700 hover:border-teal-500/50 flex items-center justify-center text-slate-400 hover:text-white transition-colors overflow-hidden"
           >
-            <CircleUser size={20} aria-hidden="true" />
+            {operatorPhoto ? (
+              <img
+                src={operatorPhoto}
+                alt="Foto de perfil"
+                className="w-full h-full object-cover"
+                data-testid="topbar-user-photo"
+              />
+            ) : (
+              <CircleUser size={20} aria-hidden="true" />
+            )}
           </button>
 
           {avatarMenuOpen && (

--- a/src/components/__tests__/ProfileScreen.photo.test.jsx
+++ b/src/components/__tests__/ProfileScreen.photo.test.jsx
@@ -1,0 +1,87 @@
+/**
+ * ProfileScreen.photo.test.jsx — subida de foto de perfil del operador
+ * (feature recuperada 2026-06-15).
+ *
+ * Verifica que la pestaña Perfil:
+ *   - muestra el botón "Agregar foto" y el placeholder (ícono) cuando no hay foto,
+ *   - al elegir un archivo, llama operatorPhotoService.setOperatorPhotoFromFile
+ *     y renderiza la imagen resultante,
+ *   - ofrece "Quitar foto" que llama removeOperatorPhotoLocal.
+ *
+ * El servicio se mockea: aquí probamos el cableado de la UI, no el canvas/red
+ * (eso lo cubre operatorPhotoService.test.js).
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+const setOperatorPhotoFromFile = vi.fn();
+const removeOperatorPhotoLocal = vi.fn();
+let mockPhoto = '';
+
+vi.mock('../../services/operatorPhotoService', () => ({
+  getOperatorPhoto: () => mockPhoto,
+  setOperatorPhotoFromFile: (...a) => setOperatorPhotoFromFile(...a),
+  removeOperatorPhotoLocal: (...a) => removeOperatorPhotoLocal(...a),
+}));
+
+import ProfileScreen from '../ProfileScreen';
+
+describe('ProfileScreen — foto de perfil', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockPhoto = '';
+    setOperatorPhotoFromFile.mockReset();
+    removeOperatorPhotoLocal.mockReset();
+  });
+
+  test('sin foto muestra el botón "Agregar foto" (placeholder)', () => {
+    render(<ProfileScreen onBack={() => {}} onHome={() => {}} />);
+    const btn = screen.getByTestId('profile-photo-button');
+    expect(btn).toHaveAttribute('aria-label', 'Agregar foto de perfil');
+    expect(screen.queryByTestId('profile-photo-img')).toBeNull();
+  });
+
+  test('al elegir un archivo de imagen llama al servicio y renderiza la foto', async () => {
+    const dataUrl = 'data:image/jpeg;base64,ZZZ';
+    setOperatorPhotoFromFile.mockResolvedValue(dataUrl);
+
+    render(<ProfileScreen onBack={() => {}} onHome={() => {}} />);
+    const input = screen.getByTestId('profile-photo-input');
+    const file = new File([new Uint8Array(4)], 'yo.jpg', { type: 'image/jpeg' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(setOperatorPhotoFromFile).toHaveBeenCalledTimes(1));
+    expect(setOperatorPhotoFromFile).toHaveBeenCalledWith(file);
+
+    const img = await screen.findByTestId('profile-photo-img');
+    expect(img).toHaveAttribute('src', dataUrl);
+    // Tras tener foto, el botón pasa a "Cambiar foto".
+    expect(screen.getByTestId('profile-photo-button')).toHaveAttribute('aria-label', 'Cambiar foto de perfil');
+  });
+
+  test('rechaza un archivo que no es imagen sin llamar al servicio', async () => {
+    render(<ProfileScreen onBack={() => {}} onHome={() => {}} />);
+    const input = screen.getByTestId('profile-photo-input');
+    const file = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/no parece una imagen/i),
+    );
+    expect(setOperatorPhotoFromFile).not.toHaveBeenCalled();
+  });
+
+  test('con foto existente ofrece "Quitar foto" que llama al servicio', () => {
+    mockPhoto = 'data:image/jpeg;base64,EXISTE';
+    render(<ProfileScreen onBack={() => {}} onHome={() => {}} />);
+    expect(screen.getByTestId('profile-photo-img')).toBeInTheDocument();
+
+    const quitar = screen.getByRole('button', { name: /quitar foto/i });
+    fireEvent.click(quitar);
+    expect(removeOperatorPhotoLocal).toHaveBeenCalledTimes(1);
+    // Tras quitar, el placeholder vuelve.
+    expect(screen.queryByTestId('profile-photo-img')).toBeNull();
+  });
+});

--- a/src/components/__tests__/TopBar.operatorPhoto.test.jsx
+++ b/src/components/__tests__/TopBar.operatorPhoto.test.jsx
@@ -1,0 +1,55 @@
+/**
+ * TopBar.operatorPhoto.test.jsx — el ícono de usuario muestra la foto de
+ * perfil del operador, con fallback al ícono CircleUser (feature 2026-06-15).
+ */
+import React from 'react';
+import { render, screen, act, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockPhoto = '';
+vi.mock('../../services/operatorPhotoService', () => ({
+  getOperatorPhoto: () => mockPhoto,
+}));
+
+// Sub-componentes pesados / con store o red → stubs (igual que TopBar.voicePlant).
+vi.mock('../OfflineChip', () => ({ default: () => <div data-testid="chip-stub" /> }));
+vi.mock('../NotificationsBell', () => ({ default: () => <div data-testid="bell-stub" /> }));
+
+import TopBar from '../TopBar';
+
+describe('TopBar — foto de perfil del operador', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockPhoto = '';
+  });
+
+  it('sin foto muestra el ícono por defecto (no <img>)', () => {
+    render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    const menuBtn = screen.getByTestId('topbar-user-menu');
+    expect(within(menuBtn).queryByTestId('topbar-user-photo')).toBeNull();
+  });
+
+  it('con foto renderiza la imagen dentro del botón de usuario', () => {
+    mockPhoto = 'data:image/jpeg;base64,FOTO';
+    render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    const img = screen.getByTestId('topbar-user-photo');
+    expect(img).toHaveAttribute('src', 'data:image/jpeg;base64,FOTO');
+    expect(img.closest('[data-testid="topbar-user-menu"]')).not.toBeNull();
+  });
+
+  it('reacciona en vivo al evento chagra:operator-update', () => {
+    render(<TopBar onNavigate={vi.fn()} onLogout={vi.fn()} />);
+    expect(screen.queryByTestId('topbar-user-photo')).toBeNull();
+
+    // El operador sube una foto en Perfil → el servicio emite el evento.
+    mockPhoto = 'data:image/jpeg;base64,NUEVA';
+    act(() => {
+      window.dispatchEvent(new CustomEvent('chagra:operator-update', {
+        detail: { key: 'chagra:operator:photo:v1', value: mockPhoto },
+      }));
+    });
+
+    expect(screen.getByTestId('topbar-user-photo')).toHaveAttribute('src', 'data:image/jpeg;base64,NUEVA');
+  });
+});

--- a/src/services/__tests__/operatorPhotoService.test.js
+++ b/src/services/__tests__/operatorPhotoService.test.js
@@ -1,0 +1,278 @@
+/**
+ * operatorPhotoService.test.js — foto de perfil del operador.
+ *
+ * Cubre: persistencia local (localStorage) + evento same-tab, redimensionado
+ * a data-URL (con Image/FileReader/canvas mockeados — jsdom no los implementa
+ * fielmente), y la sincronización a FarmOS (subida file--file + carga
+ * cross-device) con apiService/authService mockeados.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mocks de red: apiService (POST/GET FarmOS) + authService (Bearer token).
+const sendToFarmOS = vi.fn();
+const fetchFromFarmOS = vi.fn();
+const getAccessToken = vi.fn();
+vi.mock('../apiService.js', () => ({
+  sendToFarmOS: (...a) => sendToFarmOS(...a),
+  fetchFromFarmOS: (...a) => fetchFromFarmOS(...a),
+}));
+vi.mock('../authService.js', () => ({
+  getAccessToken: (...a) => getAccessToken(...a),
+}));
+
+import {
+  PHOTO_STORAGE_KEY,
+  PHOTO_SYNC_META_KEY,
+  getOperatorPhoto,
+  setOperatorPhotoLocal,
+  removeOperatorPhotoLocal,
+  resizePhotoToDataUrl,
+  uploadToFarmOS,
+  loadFromFarmOS,
+  setOperatorPhotoFromFile,
+  __test,
+} from '../operatorPhotoService.js';
+import { setActiveTenantId, _resetForTests } from '../tenantContext.js';
+
+const SAMPLE_DATA_URL = 'data:image/jpeg;base64,/9j/AAAQ'; // bytes irrelevantes
+
+// Instala mocks de Image + FileReader + canvas.toDataURL para que
+// resizePhotoToDataUrl corra bajo jsdom devolviendo un data-URL controlado.
+function installCanvasMocks({ width = 1024, height = 768 } = {}) {
+  globalThis.FileReader = class {
+    readAsDataURL() {
+      queueMicrotask(() => {
+        this.result = SAMPLE_DATA_URL;
+        this.onload && this.onload();
+      });
+    }
+  };
+  globalThis.Image = class {
+    set src(_v) {
+      this.width = width;
+      this.height = height;
+      queueMicrotask(() => this.onload && this.onload());
+    }
+  };
+  vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+    if (tag === 'canvas') {
+      return {
+        width: 0,
+        height: 0,
+        getContext: () => ({ drawImage: vi.fn() }),
+        toDataURL: () => SAMPLE_DATA_URL,
+      };
+    }
+    // Cualquier otro tag: delega al real (evita romper testing-library).
+    return Reflect.apply(
+      HTMLDocument.prototype.createElement,
+      document,
+      [tag],
+    );
+  });
+}
+
+describe('operatorPhotoService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetForTests();
+    sendToFarmOS.mockReset();
+    fetchFromFarmOS.mockReset();
+    getAccessToken.mockReset();
+    // onLine = true por defecto (jsdom navigator es read-only → defineProperty).
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('persistencia local + evento', () => {
+    it('getOperatorPhoto devuelve "" cuando no hay foto', () => {
+      expect(getOperatorPhoto()).toBe('');
+    });
+
+    it('setOperatorPhotoLocal persiste y getOperatorPhoto la relee', () => {
+      setOperatorPhotoLocal(SAMPLE_DATA_URL);
+      expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
+      expect(localStorage.getItem(PHOTO_STORAGE_KEY)).toBe(SAMPLE_DATA_URL);
+    });
+
+    it('setOperatorPhotoLocal emite chagra:operator-update con la key de foto', () => {
+      const handler = vi.fn();
+      window.addEventListener('chagra:operator-update', handler);
+      setOperatorPhotoLocal(SAMPLE_DATA_URL);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0].detail).toEqual({
+        key: PHOTO_STORAGE_KEY,
+        value: SAMPLE_DATA_URL,
+      });
+      window.removeEventListener('chagra:operator-update', handler);
+    });
+
+    it('removeOperatorPhotoLocal limpia foto y meta de sync, y emite evento vacío', () => {
+      setOperatorPhotoLocal(SAMPLE_DATA_URL);
+      __test.writeSyncMeta({ fileUuid: 'abc' });
+      const handler = vi.fn();
+      window.addEventListener('chagra:operator-update', handler);
+
+      removeOperatorPhotoLocal();
+
+      expect(getOperatorPhoto()).toBe('');
+      expect(localStorage.getItem(PHOTO_SYNC_META_KEY)).toBeNull();
+      expect(handler.mock.calls.at(-1)[0].detail).toEqual({ key: PHOTO_STORAGE_KEY, value: '' });
+      window.removeEventListener('chagra:operator-update', handler);
+    });
+  });
+
+  describe('resizePhotoToDataUrl', () => {
+    it('redimensiona un File de imagen a data-URL JPEG', async () => {
+      installCanvasMocks();
+      const file = new File([new Uint8Array(10)], 'foto.jpg', { type: 'image/jpeg' });
+      const out = await resizePhotoToDataUrl(file);
+      expect(out).toBe(SAMPLE_DATA_URL);
+    });
+
+    it('rechaza archivos que no son imagen', async () => {
+      const file = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+      await expect(resizePhotoToDataUrl(file)).rejects.toThrow(/no parece una imagen/i);
+    });
+  });
+
+  describe('uploadToFarmOS', () => {
+    it('no sube si no hay sesión (tenant)', async () => {
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe('no-session');
+      expect(sendToFarmOS).not.toHaveBeenCalled();
+    });
+
+    it('no sube en offline', async () => {
+      setActiveTenantId('alice');
+      Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+      expect(r.reason).toBe('offline');
+      expect(sendToFarmOS).not.toHaveBeenCalled();
+    });
+
+    it('POST /api/file/upload con filename scopeado por usuario y guarda meta', async () => {
+      setActiveTenantId('alice');
+      sendToFarmOS.mockResolvedValue({ data: { id: 'uuid-123', type: 'file--file' } });
+
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+
+      expect(r.ok).toBe(true);
+      expect(r.fileUuid).toBe('uuid-123');
+      expect(sendToFarmOS).toHaveBeenCalledTimes(1);
+      const [endpoint, formData, method] = sendToFarmOS.mock.calls[0];
+      expect(endpoint).toBe('/api/file/upload');
+      expect(method).toBe('POST');
+      expect(formData).toBeInstanceOf(FormData);
+      const uploaded = formData.get('file');
+      expect(uploaded).toBeInstanceOf(Blob);
+      expect(uploaded.name).toMatch(/^chagra-operator-photo-alice-\d+\.jpg$/);
+      // meta persistida para evitar re-descargas redundantes.
+      expect(__test.readSyncMeta().fileUuid).toBe('uuid-123');
+    });
+
+    it('no-throw si la red falla', async () => {
+      setActiveTenantId('alice');
+      sendToFarmOS.mockRejectedValue(new Error('500'));
+      const r = await uploadToFarmOS(SAMPLE_DATA_URL);
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe('error');
+    });
+  });
+
+  describe('loadFromFarmOS (cross-device)', () => {
+    it('no carga sin sesión', async () => {
+      const r = await loadFromFarmOS();
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe('no-session');
+      expect(fetchFromFarmOS).not.toHaveBeenCalled();
+    });
+
+    it('consulta el file más reciente del usuario, lo descarga y lo persiste local', async () => {
+      installCanvasMocks();
+      setActiveTenantId('bob');
+      fetchFromFarmOS.mockResolvedValue({
+        data: [{
+          id: 'remote-uuid-9',
+          attributes: { filename: 'chagra-operator-photo-bob-1.jpg', uri: { url: '/sites/default/files/x.jpg' } },
+        }],
+      });
+      getAccessToken.mockResolvedValue('tok');
+      // fetch del blob binario:
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        blob: async () => new Blob([new Uint8Array(20)], { type: 'image/jpeg' }),
+      });
+
+      const r = await loadFromFarmOS();
+
+      expect(r.ok).toBe(true);
+      expect(r.updated).toBe(true);
+      // El endpoint filtra por el prefijo scopeado a 'bob'.
+      const endpoint = fetchFromFarmOS.mock.calls[0][0];
+      expect(endpoint).toContain('/api/file/file');
+      expect(endpoint).toContain('CONTAINS');
+      expect(endpoint).toContain(encodeURIComponent('chagra-operator-photo-bob-'));
+      // Quedó persistida local + meta con el uuid remoto.
+      expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
+      expect(__test.readSyncMeta().fileUuid).toBe('remote-uuid-9');
+    });
+
+    it('no hace nada si el servidor no tiene foto del usuario', async () => {
+      setActiveTenantId('bob');
+      fetchFromFarmOS.mockResolvedValue({ data: [] });
+      const r = await loadFromFarmOS();
+      expect(r.ok).toBe(true);
+      expect(r.updated).toBe(false);
+      expect(getOperatorPhoto()).toBe('');
+    });
+
+    it('no re-descarga si el uuid remoto coincide con la última sync local', async () => {
+      setActiveTenantId('bob');
+      setOperatorPhotoLocal(SAMPLE_DATA_URL);
+      __test.writeSyncMeta({ fileUuid: 'same-uuid' });
+      fetchFromFarmOS.mockResolvedValue({
+        data: [{ id: 'same-uuid', attributes: { filename: 'x', uri: { url: '/x' } } }],
+      });
+      globalThis.fetch = vi.fn();
+
+      const r = await loadFromFarmOS();
+
+      expect(r.updated).toBe(false);
+      expect(r.reason).toBe('already-current');
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setOperatorPhotoFromFile', () => {
+    it('redimensiona, persiste local y devuelve el data-URL (sync dispara en background)', async () => {
+      installCanvasMocks();
+      setActiveTenantId('alice');
+      sendToFarmOS.mockResolvedValue({ data: { id: 'bg-uuid' } });
+      const file = new File([new Uint8Array(10)], 'foto.jpg', { type: 'image/jpeg' });
+
+      const out = await setOperatorPhotoFromFile(file);
+
+      expect(out).toBe(SAMPLE_DATA_URL);
+      expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
+      // El upload corre en background (fire-and-forget); esperamos a que llegue.
+      await vi.waitFor(() =>
+        expect(sendToFarmOS).toHaveBeenCalledWith('/api/file/upload', expect.any(FormData), 'POST'),
+      );
+    });
+  });
+
+  describe('latestPhotoEndpoint helper', () => {
+    it('arma el filtro CONTAINS con el prefijo por usuario', () => {
+      const ep = __test.latestPhotoEndpoint('carlos');
+      expect(ep).toContain('filter[filename][operator]=CONTAINS');
+      expect(ep).toContain(encodeURIComponent('chagra-operator-photo-carlos-'));
+      expect(ep).toContain('sort=-created');
+      expect(ep).toContain('page[limit]=1');
+    });
+  });
+});

--- a/src/services/operatorPhotoService.js
+++ b/src/services/operatorPhotoService.js
@@ -1,0 +1,308 @@
+/**
+ * operatorPhotoService — foto de perfil del operador con persistencia local
+ * (localStorage) + sincronización opcional a FarmOS (cross-device).
+ *
+ * Separado de `userProfileService` a propósito: ese módulo es, por contrato,
+ * 100% client-side ("NADA se envía a ningún backend", soberanía ADR-007). La
+ * foto de perfil SÍ se sincroniza al servidor cuando hay sesión, así que vive
+ * en su propio módulo para no romper esa garantía.
+ *
+ * ── Persistencia local (siempre, offline-first) ──────────────────────────
+ *   - Data-URL JPEG redimensionado a 256×256 (calidad 0.82 ≈ 15-40 KB) en
+ *     `localStorage[chagra:operator:photo:v1]`. Holgado dentro de la cuota
+ *     de ~5 MB por origen.
+ *   - La portada (TopBar) lee de aquí: render inmediato sin red.
+ *
+ * ── Sincronización a FarmOS (cuando hay sesión) ──────────────────────────
+ *   Reutiliza el patrón YA existente en el repo (`useBackgroundImage` +
+ *   `syncManager`): NO inventa endpoints.
+ *     - Subida:  POST /api/file/upload (FormData) → crea un `file--file` con
+ *       filename `chagra-operator-photo-<tenantId>-<ts>.jpg`. El prefijo por
+ *       usuario evita colisiones entre operadores que comparten backend.
+ *     - Carga:   GET /api/file/file?filter[filename][operator]=CONTAINS
+ *       &filter[filename][value]=chagra-operator-photo-<tenantId>-&sort=-created
+ *       &page[limit]=1 → descarga el blob más reciente con Bearer token y lo
+ *       persiste local como data-URL.
+ *
+ *   Por qué `file--file` y no un campo del user de FarmOS (`user_picture`):
+ *   FarmOS 4.x expone los usuarios en `/api/user/user`, pero el password-grant
+ *   token de Chagra no garantiza permiso de PATCH sobre el propio user, y el
+ *   campo `user_picture` no está habilitado por defecto en el perfil JSON:API.
+ *   El recurso `file--file` SÍ está disponible (lo usa el sync de evidencia y
+ *   los fondos), así que es la vía verificable HOY. Si en el futuro el backend
+ *   habilita `user_picture` editable, migrar `uploadToFarmOS`/`loadFromFarmOS`
+ *   a PATCH /api/user/user/<id> + relación `user_picture` (TODO abajo).
+ *
+ * Español colombiano (tú/usted, SIN voseo). Repo público: sin hostnames/IPs/
+ * tokens internos (SOP §2) — todo va por rutas relativas / VITE_*.
+ *
+ * @module operatorPhotoService
+ */
+
+import { getActiveTenantId } from './tenantContext';
+
+export const PHOTO_STORAGE_KEY = 'chagra:operator:photo:v1';
+// Metadatos de la última sync (UUID del file en FarmOS) — evita re-subir/
+// re-descargar la misma foto. Plano en localStorage, separado del data-URL.
+export const PHOTO_SYNC_META_KEY = 'chagra:operator:photo:sync:v1';
+export const PHOTO_MAX_DIMENSION = 256;
+export const PHOTO_JPEG_QUALITY = 0.82;
+// Prefijo de filename en FarmOS. El tenantId (username) se concatena para
+// scoping por usuario. Mantener estable: cambiarlo huérfana fotos viejas.
+const FARMOS_PHOTO_PREFIX = 'chagra-operator-photo';
+
+const hasStorage = () => typeof window !== 'undefined' && !!window.localStorage;
+
+/**
+ * Redimensiona un File de imagen a un data-URL JPEG ≤256px lado mayor.
+ * Client-side (canvas) — no toca red. Lanza si el archivo no es imagen válida.
+ *
+ * @param {File|Blob} file
+ * @returns {Promise<string>} data-URL `data:image/jpeg;base64,...`
+ */
+export async function resizePhotoToDataUrl(file) {
+  if (!file || (file.type && !file.type.startsWith('image/'))) {
+    throw new Error('El archivo no parece una imagen.');
+  }
+  const fileDataUrl = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error || new Error('FileReader falló'));
+    reader.readAsDataURL(file);
+  });
+  const img = await new Promise((resolve, reject) => {
+    const i = new Image();
+    i.onload = () => resolve(i);
+    i.onerror = () => reject(new Error('Imagen inválida'));
+    i.src = fileDataUrl;
+  });
+  const maxSide = Math.max(img.width, img.height) || 1;
+  const scale = Math.min(1, PHOTO_MAX_DIMENSION / maxSide);
+  const w = Math.max(1, Math.round(img.width * scale));
+  const h = Math.max(1, Math.round(img.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D no disponible');
+  ctx.drawImage(img, 0, 0, w, h);
+  return canvas.toDataURL('image/jpeg', PHOTO_JPEG_QUALITY);
+}
+
+/**
+ * @returns {string} data-URL de la foto local, o '' si no hay.
+ */
+export function getOperatorPhoto() {
+  if (!hasStorage()) return '';
+  try {
+    return window.localStorage.getItem(PHOTO_STORAGE_KEY) || '';
+  } catch (e) {
+    console.warn('[operatorPhoto] getOperatorPhoto:', e);
+    return '';
+  }
+}
+
+/**
+ * Emite el evento same-tab que TopBar/ProfileScreen escuchan para re-leer la
+ * foto en vivo. `storage` (cross-tab nativo) lo cubre el navegador aparte.
+ */
+function emitOperatorUpdate(value) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(new CustomEvent('chagra:operator-update', {
+      detail: { key: PHOTO_STORAGE_KEY, value },
+    }));
+  } catch (_) { /* SSR/tests sin window — el valor ya quedó persistido */ }
+}
+
+/**
+ * Persiste la foto local (sin tocar red) y notifica a los consumidores.
+ * @param {string} dataUrl
+ */
+export function setOperatorPhotoLocal(dataUrl) {
+  if (!hasStorage()) return;
+  try {
+    if (dataUrl) {
+      window.localStorage.setItem(PHOTO_STORAGE_KEY, dataUrl);
+    } else {
+      window.localStorage.removeItem(PHOTO_STORAGE_KEY);
+    }
+  } catch (e) {
+    // QuotaExceeded u otro — no romper la UI; la foto simplemente no persiste.
+    console.warn('[operatorPhoto] setOperatorPhotoLocal:', e);
+  }
+  emitOperatorUpdate(dataUrl || '');
+}
+
+/**
+ * Borra la foto local. La sync remota (file--file) NO se borra por ahora
+ * (FarmOS conserva el histórico de files; un re-login en otro device volvería
+ * a bajar la última subida). Para "olvidar en todos lados" haría falta DELETE
+ * /api/file/file/<uuid> — anotado como mejora futura.
+ */
+export function removeOperatorPhotoLocal() {
+  setOperatorPhotoLocal('');
+  try {
+    if (hasStorage()) window.localStorage.removeItem(PHOTO_SYNC_META_KEY);
+  } catch (_) { /* noop */ }
+}
+
+function readSyncMeta() {
+  if (!hasStorage()) return {};
+  try {
+    const raw = window.localStorage.getItem(PHOTO_SYNC_META_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function writeSyncMeta(meta) {
+  if (!hasStorage()) return;
+  try {
+    window.localStorage.setItem(PHOTO_SYNC_META_KEY, JSON.stringify(meta || {}));
+  } catch (_) { /* noop */ }
+}
+
+/** Convierte un data-URL a Blob (para subir como multipart). */
+function dataUrlToBlob(dataUrl) {
+  const [head, b64] = String(dataUrl).split(',');
+  const mimeMatch = /data:([^;]+)/.exec(head || '');
+  const mime = mimeMatch ? mimeMatch[1] : 'image/jpeg';
+  const bin = atob(b64 || '');
+  const len = bin.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i += 1) bytes[i] = bin.charCodeAt(i);
+  return new Blob([bytes], { type: mime });
+}
+
+/**
+ * Sube la foto a FarmOS como `file--file` con filename scopeado por usuario.
+ * No-throw amigable: devuelve { ok, fileUuid } y NUNCA rompe el flujo local
+ * (la foto ya está guardada en localStorage por el caller). En offline / sin
+ * sesión simplemente devuelve { ok:false, reason }.
+ *
+ * @param {string} dataUrl
+ * @returns {Promise<{ok: boolean, fileUuid?: string, reason?: string}>}
+ */
+export async function uploadToFarmOS(dataUrl) {
+  const tenantId = getActiveTenantId();
+  if (!tenantId) return { ok: false, reason: 'no-session' };
+  if (!dataUrl) return { ok: false, reason: 'no-photo' };
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return { ok: false, reason: 'offline' };
+  }
+  try {
+    const { sendToFarmOS } = await import('./apiService.js');
+    const blob = dataUrlToBlob(dataUrl);
+    const filename = `${FARMOS_PHOTO_PREFIX}-${tenantId}-${Date.now()}.jpg`;
+    const formData = new FormData();
+    formData.append('file', blob, filename);
+    const result = await sendToFarmOS('/api/file/upload', formData, 'POST');
+    const fileUuid = result?.data?.id;
+    if (fileUuid) {
+      writeSyncMeta({ fileUuid, filename, syncedAt: Date.now(), tenantId });
+      return { ok: true, fileUuid };
+    }
+    return { ok: false, reason: 'no-uuid' };
+  } catch (err) {
+    // Falla de red/permiso no es fatal: el local sigue funcionando.
+    console.warn('[operatorPhoto] uploadToFarmOS falló (no bloqueante):', err?.message || err);
+    return { ok: false, reason: 'error' };
+  }
+}
+
+/**
+ * Construye el endpoint JSON:API para hallar la foto más reciente del usuario.
+ * @param {string} tenantId
+ * @returns {string}
+ */
+function latestPhotoEndpoint(tenantId) {
+  const prefix = `${FARMOS_PHOTO_PREFIX}-${tenantId}-`;
+  return (
+    `/api/file/file` +
+    `?filter[filename][operator]=CONTAINS` +
+    `&filter[filename][value]=${encodeURIComponent(prefix)}` +
+    `&sort=-created` +
+    `&page[limit]=1`
+  );
+}
+
+/**
+ * Carga desde FarmOS la última foto del usuario y la persiste local. Pensada
+ * para correr tras el login en un dispositivo nuevo (cross-device).
+ *
+ * No pisa una foto local más nueva: si el `fileUuid` remoto coincide con el de
+ * la última sync local, no hace nada. Si no hay sesión / offline / sin match,
+ * deja el local como esté. No-throw.
+ *
+ * @returns {Promise<{ok: boolean, updated?: boolean, reason?: string}>}
+ */
+export async function loadFromFarmOS() {
+  const tenantId = getActiveTenantId();
+  if (!tenantId) return { ok: false, reason: 'no-session' };
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return { ok: false, reason: 'offline' };
+  }
+  try {
+    const { fetchFromFarmOS } = await import('./apiService.js');
+    const { getAccessToken } = await import('./authService.js');
+
+    const response = await fetchFromFarmOS(latestPhotoEndpoint(tenantId));
+    const items = response?.data || [];
+    if (items.length === 0) return { ok: true, updated: false, reason: 'no-remote' };
+
+    const file = items[0];
+    const fileUuid = file.id;
+    const meta = readSyncMeta();
+    // Ya tenemos esta foto localmente (mismo UUID) → nada que hacer.
+    if (meta.fileUuid && meta.fileUuid === fileUuid && getOperatorPhoto()) {
+      return { ok: true, updated: false, reason: 'already-current' };
+    }
+
+    const attrs = file.attributes || {};
+    const uri = attrs.uri?.url || attrs.uri?.value;
+    if (!uri) return { ok: true, updated: false, reason: 'no-uri' };
+    const base = import.meta.env.VITE_FARMOS_URL || '';
+    const fullUrl = uri.startsWith('http') ? uri : `${base}${uri}`;
+
+    const token = await getAccessToken();
+    const res = await fetch(fullUrl, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
+    if (!res.ok) return { ok: false, reason: `http-${res.status}` };
+    const blob = await res.blob();
+
+    // Normalizamos a data-URL 256px para que TopBar lo consuma igual que una
+    // foto subida localmente (y para no guardar un blob grande del server).
+    const dataUrl = await resizePhotoToDataUrl(blob);
+    setOperatorPhotoLocal(dataUrl);
+    writeSyncMeta({ fileUuid, filename: attrs.filename, syncedAt: Date.now(), tenantId });
+    return { ok: true, updated: true };
+  } catch (err) {
+    console.warn('[operatorPhoto] loadFromFarmOS falló (no bloqueante):', err?.message || err);
+    return { ok: false, reason: 'error' };
+  }
+}
+
+/**
+ * Flujo completo de "el usuario eligió una foto": redimensiona, persiste local
+ * (render inmediato + offline) y dispara la subida a FarmOS en segundo plano.
+ * Devuelve el data-URL para que el caller actualice su estado sin esperar red.
+ *
+ * @param {File|Blob} file
+ * @returns {Promise<string>} data-URL persistido
+ */
+export async function setOperatorPhotoFromFile(file) {
+  const dataUrl = await resizePhotoToDataUrl(file);
+  setOperatorPhotoLocal(dataUrl);
+  // Sync en segundo plano — no bloquea la UI ni propaga errores de red.
+  Promise.resolve().then(() => uploadToFarmOS(dataUrl)).catch(() => {});
+  return dataUrl;
+}
+
+export const __test = {
+  FARMOS_PHOTO_PREFIX,
+  latestPhotoEndpoint,
+  dataUrlToBlob,
+  readSyncMeta,
+  writeSyncMeta,
+};


### PR DESCRIPTION
## Qué

Foto de perfil del operador, recuperando la feature abandonada en `fix/operator-bugs-2026-05-28` (commit `a31bee4`, que nunca llegó a main) y **extendiéndola con sincronización a FarmOS** (cross-device), no solo localStorage.

- El operador sube su foto (cámara/galería) en **ProfileScreen** → resize a 256×256 JPEG (q0.82, ~15-40 KB).
- Se muestra como **ícono de usuario en el TopBar**, con fallback al `CircleUser` actual si no hay foto.
- Sincronización **ProfileScreen ↔ TopBar** en vivo vía evento `chagra:operator-update` (same-tab) + `storage` (cross-tab).

## Persistencia + sync cross-device

Nuevo servicio `src/services/operatorPhotoService.js`. Reutiliza el patrón **ya existente** en el repo (`useBackgroundImage` + `syncManager`) — **no inventa endpoints**:

| Operación | Endpoint FarmOS | Cuándo |
|---|---|---|
| Local (offline-first) | `localStorage[chagra:operator:photo:v1]` | siempre — render inmediato |
| Subida | `POST /api/file/upload` → `file--file`, filename `chagra-operator-photo-<tenantId>-<ts>.jpg` | al elegir foto (background, no-throw) |
| Carga | `GET /api/file/file?filter[filename]CONTAINS&sort=-created&page[limit]=1` | al iniciar sesión (LoginScreen + OAuthCallback), fire-and-forget |

Filename scopeado por `tenantId` (username) → sin colisiones entre operadores que comparten backend. Degrada **graceful** a local si offline / sin sesión / sin permiso.

### ¿Sync a FarmOS completo o necesita backend?

**Completo con la infraestructura actual** (recurso `file--file`, que ya usan el sync de evidencia y los fondos). NO requiere backend nuevo.

Decisión documentada: se usa `file--file` y **no** el campo `user_picture` del user de FarmOS porque (a) el password-grant de Chagra no garantiza permiso de `PATCH /api/user/user/<id>` sobre el propio usuario, y (b) `user_picture` no está expuesto por defecto en JSON:API. Si el backend habilita `user_picture` editable a futuro, el TODO en el servicio indica cómo migrar.

Se mantiene **separado de `userProfileService`** a propósito: ese módulo es 100% client-side por contrato (ADR-007) y no debe enviar nada al servidor.

## Tests (vitest) — 23 nuevos, verde

- `operatorPhotoService.test.js` (16): storage + evento, `resizePhotoToDataUrl` (canvas/Image/FileReader mockeados), `uploadToFarmOS` (filename scopeado, no-session/offline/no-throw), `loadFromFarmOS` (cross-device, no re-descarga si UUID coincide), `setOperatorPhotoFromFile`.
- `ProfileScreen.photo.test.jsx`: subida → render, rechazo de no-imagen, quitar foto.
- `TopBar.operatorPhoto.test.jsx`: render con foto, fallback a `CircleUser`, reacción en vivo al evento.

Sin regresiones en los tests existentes de ProfileScreen / TopBar / userProfileService (60 verde). Lint `--max-warnings=0` limpio.

## Verificación visual (Playwright, chromium nix-store)

Login real → foto seteada → el ícono de usuario del TopBar muestra la foto. Screenshot: `/tmp/foto-perfil-despues.png` (TopBar en contexto con el avatar a la derecha).

## Archivos

- `src/services/operatorPhotoService.js` (nuevo)
- `src/components/ProfileScreen.jsx` (UI de foto en pestaña Perfil)
- `src/components/TopBar.jsx` (foto en ícono de usuario + listener)
- `src/components/LoginScreen.jsx`, `src/components/OAuthCallback.jsx` (carga cross-device al login)
- 3 archivos de tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)