### PR TITLE
feat(restauración): alerta riesgo de incendio + export PDF del plan (caso Ana UNGRD)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.50",
+  "version": "1.0.51",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v309';
+const CACHE_NAME = 'chagra-v310';
 
 // Cache de GROUNDING del agente (corpus RAG + embeddings + tiles del mapa).
 // SEPARADO de CACHE_NAME a propósito: su contenido NO está hasheado por

--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1411,12 +1411,16 @@ export default function AgentScreen({ onBack, initialContext }) {
               const modules = [
                 [hasSoilDiagnosticIntent, () => import('../../services/soilDiagnostic'), 'soil_diagnostic', 'suelo'],
               ];
-              // Agua, animal, restauracion disponibles si el intent matcher existe
+              // Agua, animal, restauracion, riesgo-incendio si el intent matcher existe
               try {
-                const { hasWaterDiagnosticIntent, hasAnimalDiagnosticIntent, hasRestauracionDiagnosticIntent } = await import('../../services/knowledgeIntentRouter');
+                const { hasWaterDiagnosticIntent, hasAnimalDiagnosticIntent, hasRestauracionDiagnosticIntent, hasIncendioRiskIntent } = await import('../../services/knowledgeIntentRouter');
                 if (hasWaterDiagnosticIntent) modules.push([hasWaterDiagnosticIntent, async () => { const m = await import('../../services/waterDiagnostic'); return { diagnosticar: m.diagnosticarAgua, formatear: m.formatearGroundingAgua }; }, 'water_diagnostic', 'agua']);
                 if (hasAnimalDiagnosticIntent) modules.push([hasAnimalDiagnosticIntent, async () => { const m = await import('../../services/animalDiagnostic'); return { diagnosticar: m.diagnosticarAnimal, formatear: m.formatearGroundingAnimal }; }, 'animal_diagnostic', 'animal']);
                 if (hasRestauracionDiagnosticIntent) modules.push([hasRestauracionDiagnosticIntent, async () => { const m = await import('../../services/restauracionDiagnostic'); return { diagnosticar: m.diagnosticarRestauracion, formatear: m.formatearGroundingRestauracion }; }, 'restauracion_diagnostic', 'restauracion']);
+                // Riesgo de incendio (estimación ENSO + temporada seca; cero
+                // fabricación, NO alerta oficial). El servicio deriva la región
+                // del perfil y usa la altitud para corregir piso (Galeras/Nariño).
+                if (hasIncendioRiskIntent) modules.push([hasIncendioRiskIntent, async () => { const m = await import('../../services/incendioRiskService'); return { diagnosticar: (_t, o) => ({ ...m.evaluarRiesgoIncendio({ altitud: o?.altitud ?? null }), sin_datos: false }), formatear: (d) => m.formatIncendioContext(d) }; }, 'incendio_riesgo', 'incendio']);
               } catch (_) { /* graceful */ }
               // Carbono/PSA (Task 3): detectarAlertaCarbono
               modules.push([
@@ -1481,7 +1485,18 @@ export default function AgentScreen({ onBack, initialContext }) {
               altitud: fincaAltitudChip,
               pisoTermico: pisoTermicoChip,
             });
-            if (forcedPlan && forcedPlan.tool) {
+            if (forcedPlan && forcedPlan.localGrounding === 'incendio') {
+              // Riesgo de incendio: estimación client-side (NO tool sidecar, NO
+              // API de alerta en tiempo real). Calculamos el bloque honesto y lo
+              // inyectamos como evidence; el LLM lo presenta como estimación.
+              try {
+                const m = await import('../../services/incendioRiskService');
+                const r = m.evaluarRiesgoIncendio({ altitud: forcedPlan.args?.altitud ?? fincaAltitudChip ?? null });
+                const bloque = m.formatIncendioContext(r);
+                toolEvidence = { tool: 'riesgo_incendio', args: forcedPlan.args || {}, result: { found: true, bloque, nivel: r.nivel, es_estimacion: true } };
+                nluRoute = `chip:${forcedIntent}:riesgo_incendio`;
+              } catch (_) { /* graceful: cae al flujo generativo con RAG */ }
+            } else if (forcedPlan && forcedPlan.tool) {
               if (forcedPlan.stub && forcedPlan.stubResult) {
                 // Modo clima sin municipio: inyectamos evidence sintética que
                 // obliga al LLM a PEDIR el municipio (NO inventar datos IDEAM).

--- a/src/components/InformesScreen.jsx
+++ b/src/components/InformesScreen.jsx
@@ -3,6 +3,7 @@ import { FileText, Download, Loader2, CheckCircle2, AlertCircle } from 'lucide-r
 import { ScreenShell } from './common/ScreenShell';
 import { exportTraceabilityCsv } from '../services/exportService';
 import CuadernoPDFButton from './CuadernoPDFButton';
+import RestauracionPlanPDFButton from './RestauracionPlanPDFButton';
 
 /**
  * InformesScreen, sección dedicada para descargar reportes de la finca
@@ -116,6 +117,12 @@ export default function InformesScreen({ onBack, onHome }) {
             orgánica (ICA, ECOCERT, FLO-CERT). Renderiza su propio panel
             con resumen pre-generación + estado de descarga. */}
         <CuadernoPDFButton />
+
+        {/* Plan de restauración ecológica PDF (caso Ana, UNGRD Pasto/Galeras).
+            Diferenciador Pro para gestión de riesgo / restauración: sucesión
+            con nativas por piso térmico + estimación opcional de riesgo de
+            incendio (NO alerta oficial). Reutiliza el patrón cuadernoPDF. */}
+        <RestauracionPlanPDFButton />
 
         {/* Placeholders próximos reportes, comentado hasta tener implementación */}
         <div className="rounded-2xl border border-dashed border-slate-700/60 p-5 bg-slate-900/30">

--- a/src/components/RestauracionPlanPDFButton.jsx
+++ b/src/components/RestauracionPlanPDFButton.jsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import { Trees, Download, Loader2, CheckCircle2, AlertCircle, Flame } from 'lucide-react';
+import useFincaActiveStore from '../services/fincaActiveStore';
+import { getProfile } from '../services/userProfileService';
+import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
+
+const ROLE_LABELS = {
+  operador_campo: 'Operador de Campo',
+  asistente: 'Asistente',
+  auditor: 'Auditor / Inspector',
+  administrador: 'Administrador',
+  agronomo: 'Agrónomo / Asesor',
+  otro: 'Otro',
+};
+
+/**
+ * RestauracionPlanPDFButton — "Descargar plan de restauración (PDF)".
+ *
+ * Diferenciador Pro para gestión de riesgo / restauración (caso Ana, UNGRD
+ * Pasto / Galeras). El usuario describe el terreno a restaurar (talud, quebrada,
+ * sitio quemado…), Chagra calcula el plan de sucesión ecológica con especies
+ * NATIVAS de su piso térmico (diagnosticarRestauracion) y genera un PDF
+ * institucional reutilizando el patrón de CuadernoPDFButton/cuadernoPDF.
+ *
+ * Opcional: incluir el "Contexto de riesgo de incendio" (incendioRiskService),
+ * una ESTIMACIÓN estacional (NO alerta oficial) útil para informes UNGRD/CAR.
+ *
+ * CERO fabricación: el PDF solo imprime especies del diagnóstico (catálogo
+ * DR-RESTAURACION-1). Si no hay datos para el piso, lo dice y remite al vivero /
+ * CAR. El cómputo (jsPDF) se hace por import dinámico para no inflar el bundle.
+ */
+export default function RestauracionPlanPDFButton({ className = '' }) {
+  const activeFinca = useFincaActiveStore((s) => s.getActiveFinca());
+  const [descripcion, setDescripcion] = useState('');
+  const [incluirIncendio, setIncluirIncendio] = useState(true);
+  const [state, setState] = useState('idle'); // idle | generating | success | error
+  const [resultMsg, setResultMsg] = useState('');
+
+  const handleClick = async () => {
+    if (state === 'generating') return;
+    setState('generating');
+    setResultMsg('');
+    try {
+      const profile = (() => { try { return getProfile(); } catch (_) { return null; } })();
+      const altitud = activeFinca?.altitud ?? profile?.finca_altitud ?? profile?.altitud ?? null;
+
+      // 1) Diagnóstico de restauración (especies nativas por piso, guardas).
+      const { diagnosticarRestauracion } = await import('../services/restauracionDiagnostic');
+      const desc = descripcion.trim() || 'Restauración de un terreno degradado con especies nativas';
+      const diagnostico = diagnosticarRestauracion(desc, { altitud });
+
+      // 2) Riesgo de incendio (opcional, estimación honesta).
+      let riesgoIncendio = null;
+      if (incluirIncendio) {
+        try {
+          const { evaluarRiesgoIncendio } = await import('../services/incendioRiskService');
+          riesgoIncendio = evaluarRiesgoIncendio({ altitud });
+        } catch (_) { /* sin riesgo no bloquea el plan */ }
+      }
+
+      // 3) PDF institucional.
+      const operatorName = typeof window !== 'undefined'
+        ? localStorage.getItem('chagra:operator:name') || PRIMARY_WORKER_NAME
+        : PRIMARY_WORKER_NAME;
+      const roleId = typeof window !== 'undefined'
+        ? localStorage.getItem('chagra:operator:role') || 'operador_campo'
+        : 'operador_campo';
+
+      const { downloadRestauracionPlanPDF } = await import('../services/restauracionPlanPDF');
+      const result = await downloadRestauracionPlanPDF({
+        diagnostico,
+        finca: activeFinca || {},
+        operatorName,
+        operatorRole: ROLE_LABELS[roleId] || ROLE_LABELS.operador_campo,
+        descripcion: desc,
+        riesgoIncendio,
+      });
+
+      const kb = Math.round(result.sizeBytes / 102.4) / 10;
+      setResultMsg(`Plan generado (${kb} kB). Revisa tu carpeta de descargas.`);
+      setState('success');
+      setTimeout(() => setState('idle'), 5000);
+    } catch (err) {
+      console.error('[RestauracionPlanPDFButton] Error generando PDF:', err);
+      setResultMsg(err?.message || 'No se pudo generar el plan.');
+      setState('error');
+      setTimeout(() => setState('idle'), 6000);
+    }
+  };
+
+  return (
+    <div className={`bg-slate-900/40 border border-slate-800 rounded-2xl p-5 flex flex-col gap-3 ${className}`}>
+      <div className="flex items-center gap-2 px-1">
+        <Trees size={18} className="text-emerald-400" />
+        <h3 className="text-sm font-bold text-slate-300 uppercase tracking-wider">
+          Plan de restauración (PDF)
+        </h3>
+      </div>
+
+      <p className="text-xs text-slate-400 leading-relaxed">
+        Genera un PDF con el plan de sucesión ecológica (pioneras, intermedias y
+        clímax) usando especies nativas de tu piso térmico. Útil para informes a
+        la UNGRD, la Corporación Autónoma Regional (CAR) y proyectos de pago por
+        servicios ambientales (PSA).
+      </p>
+
+      <label className="text-[11px] text-slate-400 font-bold uppercase tracking-wide" htmlFor="rest-desc">
+        ¿Qué quieres restaurar?
+      </label>
+      <textarea
+        id="rest-desc"
+        value={descripcion}
+        onChange={(e) => setDescripcion(e.target.value)}
+        rows={2}
+        placeholder="Ej: talud degradado con retamo espinoso, orilla de quebrada, sitio quemado…"
+        className="w-full rounded-xl bg-slate-800/70 border border-slate-700 text-sm text-slate-100 placeholder-slate-500 p-2.5 focus:outline-none focus:ring-2 focus:ring-emerald-400/50 resize-none"
+      />
+
+      <label className="flex items-center gap-2 text-xs text-slate-300 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={incluirIncendio}
+          onChange={(e) => setIncluirIncendio(e.target.checked)}
+          className="accent-emerald-600 w-4 h-4"
+        />
+        <Flame size={14} className="text-amber-400" aria-hidden="true" />
+        Incluir estimación de riesgo de incendio (no es alerta oficial)
+      </label>
+
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={state === 'generating'}
+        className={`w-full p-3 rounded-xl font-bold flex items-center justify-center gap-2 transition-colors min-h-[48px] ${
+          state === 'success'
+            ? 'bg-emerald-900/40 text-emerald-300 border border-emerald-700'
+            : state === 'error'
+              ? 'bg-red-900/30 text-red-300 border border-red-800'
+              : 'bg-emerald-700 hover:bg-emerald-600 disabled:opacity-60 text-white'
+        }`}
+      >
+        {state === 'generating' && <><Loader2 size={18} className="animate-spin" aria-hidden="true" /> Generando plan…</>}
+        {state === 'success' && <><CheckCircle2 size={18} aria-hidden="true" /> Plan descargado</>}
+        {state === 'error' && <><AlertCircle size={18} aria-hidden="true" /> Reintentar</>}
+        {state === 'idle' && <><Download size={18} aria-hidden="true" /> Descargar plan (PDF)</>}
+      </button>
+
+      {resultMsg && state !== 'idle' && (
+        <p
+          className={`text-xs leading-snug ${state === 'error' ? 'text-red-300' : 'text-emerald-400'}`}
+          role={state === 'error' ? 'alert' : undefined}
+        >
+          {resultMsg}
+        </p>
+      )}
+
+      <p className="text-[10px] text-slate-500 leading-relaxed">
+        El plan se basa en investigación documentada de restauración nativa. Es
+        un documento de apoyo: no reemplaza el concepto de un ingeniero forestal
+        ni la autorización de la autoridad ambiental.
+      </p>
+    </div>
+  );
+}

--- a/src/services/__tests__/chipIntentRouter.test.js
+++ b/src/services/__tests__/chipIntentRouter.test.js
@@ -21,7 +21,7 @@ import {
  */
 
 describe('chipIntentRouter — enum y definiciones', () => {
-  it('expone los 10 intents del enum (incluye restauración, silvopastoreo, páramo)', () => {
+  it('expone los 11 intents del enum (incluye restauración, silvopastoreo, páramo, incendio)', () => {
     expect(CHIP_INTENTS).toEqual({
       siembro: 'siembro',
       plaga: 'plaga',
@@ -33,10 +33,11 @@ describe('chipIntentRouter — enum y definiciones', () => {
       restauracion: 'restauracion',
       silvopastoreo: 'silvopastoreo',
       paramo: 'paramo',
+      incendio: 'incendio',
     });
   });
 
-  it('CHIP_DEFS tiene los 10 chips con label en español colombiano (sin voseo)', () => {
+  it('CHIP_DEFS tiene los 11 chips con label en español colombiano (sin voseo)', () => {
     const ids = CHIP_DEFS.map((c) => c.intent);
     expect(ids).toEqual([
       'siembro',
@@ -49,6 +50,7 @@ describe('chipIntentRouter — enum y definiciones', () => {
       'restauracion',
       'silvopastoreo',
       'paramo',
+      'incendio',
     ]);
     // Labels presentes y emoji declarado
     for (const def of CHIP_DEFS) {
@@ -211,6 +213,22 @@ describe('chipIntentRouter — chips de diseño (capacidades antes dark)', () =>
     expect(plan.skipNlu).toBe(true);
   });
 
+  it('incendio → localGrounding client-side (sin tool sidecar) + altura del perfil', () => {
+    // Riesgo de incendio se calcula en el cliente (incendioRiskService); NO hay
+    // tool de alerta en tiempo real. El plan lleva localGrounding:'incendio'.
+    const plan = planForcedIntent('incendio', '¿estoy en riesgo de incendio?', { altitud: 2400 });
+    expect(plan.tool).toBeNull();
+    expect(plan.localGrounding).toBe('incendio');
+    expect(plan.args).toEqual({ altitud: 2400 });
+    expect(plan.skipNlu).toBe(true);
+  });
+
+  it('incendio sin altura → localGrounding con args vacíos (el servicio deriva del perfil)', () => {
+    const plan = planForcedIntent('incendio', 'riesgo de incendio');
+    expect(plan.localGrounding).toBe('incendio');
+    expect(plan.args).toEqual({});
+  });
+
   it('silvopastoreo → get_diseno_silvopastoril con altura + piso del perfil', () => {
     const plan = planForcedIntent('silvopastoreo', 'forraje para mis vacas', {
       altitud: 1800,
@@ -312,11 +330,11 @@ describe('chipIntentRouter — Deep Research (B14: stub honesto, backend no serv
 });
 
 describe('chipIntentRouter — contrato de orden y consistencia del índice', () => {
-  it('CHIP_DEFS mantiene el orden de render estable (chips base + restauración/silvopastoreo/páramo al final)', () => {
+  it('CHIP_DEFS mantiene el orden de render estable (chips base + restauración/silvopastoreo/páramo/incendio al final)', () => {
     const order = CHIP_DEFS.map((d) => d.intent);
     expect(order).toEqual([
       'siembro', 'plaga', 'biopreparado', 'clima', 'precio', 'calendario', 'deep',
-      'restauracion', 'silvopastoreo', 'paramo',
+      'restauracion', 'silvopastoreo', 'paramo', 'incendio',
     ]);
   });
 

--- a/src/services/__tests__/incendioRiskService.test.js
+++ b/src/services/__tests__/incendioRiskService.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluarRiesgoIncendio,
+  buildIncendioContext,
+  __testing__,
+} from '../incendioRiskService';
+
+// Todos los inputs entran por `opts` (profile/ensoPhase/region/altitud/mes), así
+// que los tests son deterministas y NO dependen de localStorage ni de Date.now().
+
+describe('incendioRiskService', () => {
+  describe('evaluarRiesgoIncendio — matriz estacional × ENSO', () => {
+    it('temporada seca + El Niño → riesgo ALTO', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'nino_fuerte', mes: 1 });
+      expect(r.nivel).toBe('alto');
+      expect(r.temporada_seca).toBe(true);
+      expect(r.fase_enso).toBe('nino');
+      expect(r.es_estimacion).toBe(true);
+    });
+
+    it('temporada seca SIN El Niño → riesgo MEDIO', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'neutral', mes: 2 });
+      expect(r.nivel).toBe('medio');
+      expect(r.temporada_seca).toBe(true);
+    });
+
+    it('El Niño FUERA de temporada seca → riesgo MEDIO', () => {
+      // Mayo es lluvioso en la Andina (régimen bimodal) → no seca, pero hay Niño.
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'nino_moderado', mes: 5 });
+      expect(r.nivel).toBe('medio');
+      expect(r.temporada_seca).toBe(false);
+      expect(r.fase_enso).toBe('nino');
+    });
+
+    it('sin temporada seca y sin El Niño → riesgo BAJO', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'neutral', mes: 5 });
+      expect(r.nivel).toBe('bajo');
+    });
+
+    it('La Niña no eleva el riesgo de incendio', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'nina_fuerte', mes: 5 });
+      expect(r.nivel).toBe('bajo');
+      expect(r.fase_enso).toBe('nina');
+    });
+  });
+
+  describe('reglas regionales (cero falsos positivos)', () => {
+    it('Pacífico siempre BAJO aunque haya El Niño en mes seco de otras regiones', () => {
+      const r = evaluarRiesgoIncendio({ region: 'pacifico', ensoPhase: 'nino_fuerte', mes: 1 });
+      expect(r.nivel).toBe('bajo');
+      expect(r.factores.join(' ')).toMatch(/Pac[íi]fico/);
+    });
+
+    it('Orinoquía en verano (dic-mar) sin Niño → MEDIO, con consejo de fuego prescrito', () => {
+      const r = evaluarRiesgoIncendio({ region: 'orinoquia', ensoPhase: 'neutral', mes: 1 });
+      expect(r.nivel).toBe('medio');
+      expect(r.recomendaciones.join(' ')).toMatch(/fuego prescrito/i);
+    });
+
+    it('región desconocida → BAJO honesto (no inventa riesgo)', () => {
+      const r = evaluarRiesgoIncendio({ region: null, ensoPhase: 'nino_fuerte', mes: 1 });
+      expect(r.nivel).toBe('bajo');
+      expect(r.region).toBeNull();
+    });
+  });
+
+  describe('caso Ana — UNGRD Pasto / Galeras (Andina alta, 2400 msnm)', () => {
+    it('en verano andino + El Niño da ALTO', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', altitud: 2400, ensoPhase: 'nino_fuerte', mes: 1 });
+      expect(r.nivel).toBe('alto');
+      expect(r.piso_termico).toBe('frio');
+    });
+
+    it('corrige Nariño: dept→pacifico pero zona alta (2400m) = andina con riesgo real', () => {
+      // Perfil real de Ana: departamento Nariño (mapea a pacifico) pero finca a
+      // 2400 msnm en la ladera del Galeras. La corrección de piso la trata como
+      // andina y NO la deja en "bajo" falso del litoral pacífico.
+      const r = evaluarRiesgoIncendio({
+        profile: { departamento: 'Nariño' },
+        altitud: 2400,
+        ensoPhase: 'neutral',
+        mes: 1,
+      });
+      expect(r.region).toBe('andina');
+      expect(r.nivel).toBe('medio'); // enero seco andino, sin Niño
+      expect(r.temporada_seca).toBe(true);
+    });
+
+    it('NO corrige el litoral pacífico cálido (sigue pacifico, riesgo bajo)', () => {
+      const r = evaluarRiesgoIncendio({
+        profile: { departamento: 'Chocó' },
+        altitud: 50,
+        ensoPhase: 'nino_fuerte',
+        mes: 1,
+      });
+      expect(r.region).toBe('pacifico');
+      expect(r.nivel).toBe('bajo');
+    });
+
+    it('zona de páramo añade la guarda de turba/suelo orgánico', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', altitud: 3300, ensoPhase: 'neutral', mes: 7 });
+      expect(r.piso_termico).toBe('paramo');
+      expect(r.factores.join(' ')).toMatch(/turba|suelo org[áa]nico/i);
+      expect(r.recomendaciones.join(' ')).toMatch(/NO quemes/i);
+    });
+  });
+
+  describe('honestidad / anti-fabricación', () => {
+    it('SIEMPRE marca es_estimacion y trae disclaimer + fuentes reales', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'neutral', mes: 4 });
+      expect(r.es_estimacion).toBe(true);
+      expect(r.disclaimer).toMatch(/NO una alerta oficial/i);
+      expect(r.disclaimer).toMatch(/CMGRD|bomberos|Corporaci[óo]n/i);
+      expect(r.fuentes.join(' ')).toMatch(/NOAA/);
+      expect(r.fuentes.join(' ')).toMatch(/IDEAM/);
+    });
+
+    it('nunca recomienda quema en temporada de riesgo', () => {
+      const r = evaluarRiesgoIncendio({ region: 'orinoquia', ensoPhase: 'nino_fuerte', mes: 2 });
+      expect(r.nivel).toBe('alto');
+      expect(r.recomendaciones.join(' ')).toMatch(/NO hagas quemas/i);
+    });
+
+    it('mes por defecto = mes actual cuando no se pasa', () => {
+      const r = evaluarRiesgoIncendio({ region: 'andina', ensoPhase: 'neutral' });
+      expect(r.mes).toBe(new Date().getMonth() + 1);
+    });
+  });
+
+  describe('buildIncendioContext (grounding del agente)', () => {
+    it('produce bloque con nivel, disclaimer y la instrucción anti-alucinación', () => {
+      const txt = buildIncendioContext({ region: 'andina', ensoPhase: 'nino_fuerte', mes: 1 });
+      expect(txt).toMatch(/RIESGO DE INCENDIO/);
+      expect(txt).toMatch(/ALTO/);
+      expect(txt).toMatch(/NO afirmes que hay un incendio activo/i);
+      expect(txt).toMatch(/estimaci[óo]n/i);
+    });
+
+    it('en Pacífico comunica riesgo BAJO sin alarmar', () => {
+      const txt = buildIncendioContext({ region: 'pacifico', ensoPhase: 'nino_fuerte', mes: 1 });
+      expect(txt).toMatch(/BAJO/);
+    });
+  });
+
+  describe('helpers internos', () => {
+    it('pisoDesdeAltitud clasifica por umbrales', () => {
+      const { pisoDesdeAltitud } = __testing__;
+      expect(pisoDesdeAltitud(500)).toBe('calido');
+      expect(pisoDesdeAltitud(1500)).toBe('templado');
+      expect(pisoDesdeAltitud(2500)).toBe('frio');
+      expect(pisoDesdeAltitud(3200)).toBe('paramo');
+      expect(pisoDesdeAltitud(null)).toBeNull();
+      expect(pisoDesdeAltitud('abc')).toBeNull();
+    });
+
+    it('temporadaSeca respeta el calendario por región', () => {
+      const { temporadaSeca } = __testing__;
+      expect(temporadaSeca('andina', 1).seca).toBe(true);   // enero seco
+      expect(temporadaSeca('andina', 7).seca).toBe(true);   // julio seco (veranillo)
+      expect(temporadaSeca('andina', 5).seca).toBe(false);  // mayo lluvioso
+      expect(temporadaSeca('amazonia', 7).seca).toBe(false); // amazonia: solo dic-mar
+      expect(temporadaSeca('pacifico', 1).seca).toBe(false); // pacifico sin seca
+    });
+
+    it('resolveFireRegion sube pacifico→andina solo en piso alto', () => {
+      const { resolveFireRegion } = __testing__;
+      expect(resolveFireRegion('pacifico', 'frio')).toBe('andina');
+      expect(resolveFireRegion('pacifico', 'paramo')).toBe('andina');
+      expect(resolveFireRegion('pacifico', 'templado')).toBe('andina');
+      expect(resolveFireRegion('pacifico', 'calido')).toBe('pacifico'); // litoral
+      expect(resolveFireRegion('andina', 'frio')).toBe('andina');       // no toca otras
+      expect(resolveFireRegion(null, 'frio')).toBeNull();
+    });
+  });
+});

--- a/src/services/__tests__/knowledgeIntentRouter.test.js
+++ b/src/services/__tests__/knowledgeIntentRouter.test.js
@@ -10,7 +10,11 @@
  *   - Sin intención clara → null (el planner NLU decide).
  */
 import { describe, it, expect } from 'vitest';
-import { planKnowledgeIntent } from '../knowledgeIntentRouter.js';
+import {
+  planKnowledgeIntent,
+  hasIncendioRiskIntent,
+  hasRestauracionDiagnosticIntent,
+} from '../knowledgeIntentRouter.js';
 
 const sp = (id, mentioned = null) => ({
   kind: 'species',
@@ -120,5 +124,30 @@ describe('planKnowledgeIntent — prioridades y guardas cruzadas', () => {
       { kind: 'species', canonical_id: null, mentioned: 'adelfa' },
     ]);
     expect(plan?.args).toEqual({ species_id_or_name: 'adelfa' });
+  });
+});
+
+describe('hasIncendioRiskIntent — riesgo de incendio (≠ restauración post-incendio)', () => {
+  it('detecta preguntas de riesgo/temporada de incendio', () => {
+    expect(hasIncendioRiskIntent('¿estoy en riesgo de incendio esta temporada?')).toBe(true);
+    expect(hasIncendioRiskIntent('hay temporada de incendios ahora?')).toBe(true);
+    expect(hasIncendioRiskIntent('¿hay alerta de incendio en mi zona?')).toBe(true);
+    expect(hasIncendioRiskIntent('peligro de incendio en la finca')).toBe(true);
+    expect(hasIncendioRiskIntent('¿se va a quemar el pasto con esta sequía?')).toBe(true);
+    expect(hasIncendioRiskIntent('estamos en época de quemas')).toBe(true);
+  });
+
+  it('NO confunde con restauración post-incendio (eso es otro módulo)', () => {
+    // Estas frases las maneja hasRestauracionDiagnosticIntent, no la de riesgo.
+    expect(hasIncendioRiskIntent('quiero restaurar después del incendio')).toBe(false);
+    expect(hasIncendioRiskIntent('qué siembro en el sitio quemado')).toBe(false);
+    // La restauración la captura su propio matcher (con árboles/especies nativas).
+    expect(hasRestauracionDiagnosticIntent('quiero restaurar un terreno con árboles nativos')).toBe(true);
+  });
+
+  it('no dispara con texto irrelevante ni vacío', () => {
+    expect(hasIncendioRiskIntent('¿qué siembro en abril?')).toBe(false);
+    expect(hasIncendioRiskIntent('')).toBe(false);
+    expect(hasIncendioRiskIntent(null)).toBe(false);
   });
 });

--- a/src/services/__tests__/restauracionPlanPDF.test.js
+++ b/src/services/__tests__/restauracionPlanPDF.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateRestauracionPlanPDF,
+  buildRestauracionPlanFilename,
+  downloadRestauracionPlanPDF,
+  RESTAURACION_PDF_VERSION,
+} from '../restauracionPlanPDF';
+
+// Diagnóstico realista (forma de diagnosticarRestauracion) para el caso Ana:
+// talud andino con retamo, piso frío 2000–3000.
+const mockDiagnostico = {
+  arreglo: {
+    id: 'corredor_ripario',
+    nombre: 'Corredor biologico/ripario',
+    densidad: 'franjas 10-30m de ancho',
+    detalle: 'Mezcla pionera-intermedia-climax. Protege quebradas y nacimientos.',
+  },
+  roles: null,
+  especies: {
+    pioneras: [
+      { nombre: 'Aliso', cientifico: 'Alnus acuminata', nota: 'Aguanta altura, fijador N' },
+      { nombre: 'Mortino', cientifico: 'Hesperomeles goudotiana', nota: 'Fruto silvestre' },
+    ],
+    intermedias: [
+      { nombre: 'Encenillo', cientifico: 'Weinmannia tomentosa', nota: 'Bosque altoandino' },
+      { nombre: 'Polylepis', cientifico: 'Polylepis quadrijuga', nota: 'Amenazado' },
+    ],
+    climax: [
+      { nombre: 'Palma de cera', cientifico: 'Ceroxylon quindiuense', nota: 'Árbol nacional' },
+    ],
+  },
+  alertas: ['GUARDA: Retamo NO se quema — el fuego estimula la germinación y rebrota.'],
+  guardas: [
+    'GUARDA: Pino y eucalipto NO son restauración.',
+    'MITO: sembrar muchos árboles rápido = restaurar. La clave es el ORDEN sucesional.',
+  ],
+  sin_datos: false,
+  fuente: 'DR-RESTAURACION-1 (2/3 Gemini+Meta, 2026-06-11)',
+};
+
+const mockFinca = {
+  slug: 'talud-galeras',
+  nombre: 'Talud ladera Galeras',
+  municipio: 'Pasto',
+  departamento: 'Nariño',
+  altitud: 2400,
+  coords: [1.2136, -77.2811],
+};
+
+describe('restauracionPlanPDF', () => {
+  it('expone versión de schema', () => {
+    expect(RESTAURACION_PDF_VERSION).toBe('1');
+  });
+
+  it('genera un Blob application/pdf no vacío', () => {
+    const blob = generateRestauracionPlanPDF({
+      diagnostico: mockDiagnostico,
+      finca: mockFinca,
+      operatorName: 'Ana (UNGRD)',
+      operatorRole: 'Gestión del riesgo',
+      objetivo: 'cortafuegos',
+      descripcion: 'Talud degradado a 2400 msnm con retamo espinoso',
+      piso: 'frio_2000_3000',
+    });
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(1500); // PDF real, no vacío
+  });
+
+  it('arranca con el header PDF (magic %PDF)', async () => {
+    const blob = generateRestauracionPlanPDF({ diagnostico: mockDiagnostico, finca: mockFinca });
+    const head = new Uint8Array(await blob.arrayBuffer()).slice(0, 5);
+    const magic = String.fromCharCode(...head);
+    expect(magic).toBe('%PDF-');
+  });
+
+  it('no explota con diagnóstico mínimo (sin especies, sin arreglo)', () => {
+    const blob = generateRestauracionPlanPDF({
+      diagnostico: { sin_datos: true, especies: null, roles: null, alertas: [], guardas: [], fuente: 'X' },
+      finca: { nombre: 'Predio X' },
+    });
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(1000);
+  });
+
+  it('no explota sin planData (defaults vacíos)', () => {
+    const blob = generateRestauracionPlanPDF();
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(800);
+  });
+
+  it('soporta fallback de roles (solo nombres comunes, sin binomios)', () => {
+    const blob = generateRestauracionPlanPDF({
+      diagnostico: {
+        arreglo: null,
+        especies: null,
+        roles: { pioneras: ['aliso', 'mortino'], intermedias: ['encenillo'], climax: ['palma de cera'] },
+        alertas: [],
+        guardas: [],
+        sin_datos: false,
+        fuente: 'DR-RESTAURACION-1',
+      },
+      finca: { nombre: 'Predio roles', altitud: 2500 },
+      piso: 'frio_2000_3000',
+    });
+    expect(blob.size).toBeGreaterThan(1500);
+  });
+
+  it('incluye el bloque de riesgo de incendio cuando se pasa', () => {
+    const conRiesgo = generateRestauracionPlanPDF({
+      diagnostico: mockDiagnostico,
+      finca: mockFinca,
+      riesgoIncendio: {
+        nivel: 'alto',
+        es_estimacion: true,
+        factores: ['Estás en temporada seca andina.', 'El Niño activo seca el combustible.'],
+        recomendaciones: ['NO hagas quemas agrícolas.', 'Limpia las rondas cortafuego.'],
+        disclaimer: 'Esto es una ESTIMACIÓN, NO una alerta oficial.',
+        fuentes: ['NOAA CPC (ONI) + IDEAM'],
+      },
+    });
+    const sinRiesgo = generateRestauracionPlanPDF({ diagnostico: mockDiagnostico, finca: mockFinca });
+    // El bloque de riesgo añade una página → PDF más grande.
+    expect(conRiesgo.size).toBeGreaterThan(sinRiesgo.size);
+  });
+
+  describe('buildRestauracionPlanFilename', () => {
+    it('arma slug seguro con timestamp', () => {
+      const name = buildRestauracionPlanFilename(mockFinca, new Date('2026-06-15T10:30:00'));
+      expect(name).toBe('plan-restauracion-chagra-talud-galeras-2026-06-15-1030.pdf');
+    });
+
+    it('cae a "predio" sin finca', () => {
+      const name = buildRestauracionPlanFilename(null, new Date('2026-06-15T08:05:00'));
+      expect(name).toBe('plan-restauracion-chagra-predio-2026-06-15-0805.pdf');
+    });
+
+    it('normaliza tildes y caracteres raros del nombre', () => {
+      const name = buildRestauracionPlanFilename({ nombre: 'Quebrada Niñá #2' }, new Date('2026-06-15T00:00:00'));
+      // ñ→n, á→a, '#' y espacios → guiones colapsados.
+      expect(name).toBe('plan-restauracion-chagra-quebrada-nina-2-2026-06-15-0000.pdf');
+    });
+  });
+
+  describe('downloadRestauracionPlanPDF', () => {
+    it('devuelve filename + sizeBytes (jsdom tiene document → simula descarga)', async () => {
+      const res = await downloadRestauracionPlanPDF({ diagnostico: mockDiagnostico, finca: mockFinca });
+      expect(res.filename).toMatch(/^plan-restauracion-chagra-talud-galeras-/);
+      expect(res.sizeBytes).toBeGreaterThan(1500);
+    });
+  });
+});

--- a/src/services/agentCapabilities.js
+++ b/src/services/agentCapabilities.js
@@ -194,6 +194,28 @@ export const CAPABILITY_MANIFEST = Object.freeze([
       prompt: 'Quiero restaurar el páramo. ¿Qué especies nativas siembro?',
     },
   },
+  {
+    // Riesgo de incendio: ESTIMACIÓN estacional (temporada seca + fase ENSO),
+    // NO alerta oficial. kind:'local' → se calcula en el cliente
+    // (incendioRiskService) sin tool del sidecar; el chip router devuelve un
+    // plan con localGrounding:'incendio' y el AgentScreen inyecta el bloque.
+    id: 'incendio',
+    group: 'restaurar',
+    status: 'live',
+    intent: 'incendio',
+    kind: 'local',
+    icon: '🔥',
+    label: 'Riesgo de incendio',
+    desc: 'Estimación de riesgo de incendio según la temporada seca y El Niño. No es alerta oficial.',
+    placeholder: 'Pregunta si tu zona está en temporada de riesgo de incendio',
+    tool: null,
+    stubMessage: null,
+    hero: true,
+    heroRoute: {
+      kind: 'ask',
+      prompt: '¿Mi zona está en riesgo de incendio esta temporada?',
+    },
+  },
 
   // ═══════════════════════════════════════════════════════════════════════
   // AGENTHERO ACTIONS — aparecen solo en menú Ⓐ del AgentHero

--- a/src/services/chipIntentRouter.js
+++ b/src/services/chipIntentRouter.js
@@ -117,6 +117,7 @@ export function planForcedIntent(intent, text, opts = {}) {
     stub: false,
     stubResult: null,
     stubMessage: null,
+    localGrounding: null, // módulo client-side a inyectar (ej. 'incendio'), sin tool del sidecar
     prompt,
     skipNlu: true,
   };
@@ -191,6 +192,21 @@ export function planForcedIntent(intent, text, opts = {}) {
         tool: 'get_diseno_restauracion',
         args: { objetivo: 'paramo' },
       };
+
+    case CHIP_INTENTS.incendio: {
+      // Riesgo de incendio: ESTIMACIÓN client-side (incendioRiskService), NO un
+      // tool del sidecar (no existe API de alerta de incendio en tiempo real).
+      // Devolvemos localGrounding:'incendio' + la altura del perfil para corregir
+      // el piso térmico (caso Galeras/Nariño). El AgentScreen calcula el bloque
+      // con evaluarRiesgoIncendio y lo inyecta como evidence. CERO fabricación.
+      const altInc = toAltitud(opts.altitud);
+      return {
+        ...base,
+        tool: null,
+        localGrounding: 'incendio',
+        args: altInc != null ? { altitud: altInc } : {},
+      };
+    }
 
     case CHIP_INTENTS.silvopastoreo: {
       // Arreglo silvopastoril (get_diseno_silvopastoril). La tool EXIGE altura.

--- a/src/services/incendioRiskService.js
+++ b/src/services/incendioRiskService.js
@@ -1,0 +1,281 @@
+/**
+ * incendioRiskService — Alerta de RIESGO DE INCENDIO forestal para la finca.
+ *
+ * Caso de uso (Ana, UNGRD Pasto / Galeras): "¿mi zona está en temporada de
+ * riesgo de incendio?" El diferenciador Pro para gestión de riesgo de
+ * desastres y restauración post-perturbación.
+ *
+ * ── HONESTIDAD DE FUENTES (verify-first, cero fabricación) ──────────────────
+ *
+ * NO existe una API pública verificada de alertas de incendio EN TIEMPO REAL de
+ * IDEAM ni del sistema UNGRD (SAGER / SNPAD) consultable con HTTP-200 a la
+ * fecha. Por eso este servicio NO afirma "hay un incendio activo" ni emite una
+ * alerta oficial. Es una ESTIMACIÓN de riesgo (estacional/climática) construida
+ * SOLO con señales reales que la app ya tiene cableadas:
+ *
+ *   1. FASE ENSO en vivo (NOAA ONI + IDEAM) vía ensoService.getEnsoPhase().
+ *      El Niño = sequía → más combustible seco → mayor riesgo (IDEAM/UNGRD).
+ *   2. TEMPORADA SECA por región natural (climatología IDEAM documentada:
+ *      régimen bimodal Andina/Caribe = dic–mar + jun–ago; monomodal seco
+ *      Orinoquía/Amazonía = dic–mar). NO es un pronóstico, es el calendario
+ *      climatológico medio.
+ *   3. PISO TÉRMICO / REGIÓN del perfil (ensoContext.REGION_IMPACTS ya
+ *      documenta que Orinoquía/Amazonía/altiplano seco son fire-prone bajo
+ *      El Niño, con cita DR-MISSION-4).
+ *
+ * El nivel resultante ('alto'|'medio'|'bajo') se marca SIEMPRE como
+ * `es_estimacion: true` y trae `disclaimer` explícito: el campesino debe
+ * confirmar con su CMGRD / bomberos / Corporación Autónoma Regional para una
+ * alerta oficial. La regla del Pacífico (sin temporada seca marcada) evita
+ * falsos positivos donde el riesgo real de incendio es bajo.
+ *
+ * Este módulo es PURO (sin red, sin React): toma la fase ENSO y el perfil y
+ * devuelve un objeto serializable, testeable en aislamiento (TDD). El path de
+ * datos en vivo (snapshot del sidecar) ya alimenta ensoService; aquí leemos la
+ * fase efectiva, así offline y chat coinciden.
+ *
+ * Lo consume: AgentScreen (grounding del agente cuando el usuario pregunta por
+ * riesgo de incendio) y el PDF del plan de restauración (sección de contexto de
+ * riesgo para informes UNGRD).
+ */
+
+import { getEnsoPhase, getEnsoPhaseSource } from './ensoService.js';
+import { ensoFamily, regionFromProfile } from './ensoContext.js';
+import { getProfile } from './userProfileService.js';
+
+const MESES = Object.freeze([
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+]);
+
+/**
+ * Temporadas secas medias por región natural (climatología IDEAM, meses
+ * 1-indexados). Fuente: régimen de lluvias de Colombia (IDEAM, Atlas
+ * Climatológico). NO es un pronóstico — es el patrón medio que define cuándo el
+ * combustible vegetal tiende a estar más seco y el riesgo de incendio sube.
+ *
+ *   - bimodal (Andina, Caribe): dos temporadas secas — dic–mar y jun–ago.
+ *   - monomodal seco (Orinoquía, Amazonía): una temporada seca marcada dic–mar
+ *     (la "época de quemas" de la sabana / piedemonte).
+ *   - Pacífico: sin temporada seca marcada (lluvia casi todo el año) → el
+ *     riesgo de incendio forestal es estructuralmente bajo.
+ */
+const DRY_SEASONS = Object.freeze({
+  andina: { meses: [12, 1, 2, 3, 6, 7, 8], etiqueta: 'temporada seca andina (dic–mar y jun–ago)' },
+  caribe: { meses: [12, 1, 2, 3, 6, 7, 8], etiqueta: 'temporada seca del Caribe (dic–mar y jun–ago)' },
+  orinoquia: { meses: [12, 1, 2, 3], etiqueta: 'verano de la Orinoquía (dic–mar, época de quemas)' },
+  amazonia: { meses: [12, 1, 2, 3], etiqueta: 'verano amazónico (dic–mar)' },
+  pacifico: { meses: [], etiqueta: 'sin temporada seca marcada (Pacífico)' },
+});
+
+/**
+ * Regiones donde el incendio forestal es un peligro relevante bajo sequía.
+ * El Pacífico se excluye explícitamente (riesgo estructuralmente bajo) para no
+ * generar falsos positivos.
+ */
+const FIRE_PRONE = Object.freeze(['andina', 'caribe', 'orinoquia', 'amazonia']);
+
+/** Mes 1-indexado actual (inyectable en tests vía opts.mes). */
+function currentMonth() {
+  return new Date().getMonth() + 1;
+}
+
+/** Piso térmico coarse desde altitud (msnm), o null. */
+function pisoDesdeAltitud(alt) {
+  const a = Number(alt);
+  if (alt == null || Number.isNaN(a)) return null;
+  if (a >= 3000) return 'paramo';
+  if (a >= 2000) return 'frio';
+  if (a >= 1000) return 'templado';
+  return 'calido';
+}
+
+/**
+ * Corrige la región de incendio por piso térmico. ensoContext mapea Nariño,
+ * Cauca y Valle a 'pacifico' por departamento, pero esos departamentos tienen
+ * tierras ALTAS de la cordillera andina (p. ej. la ladera del Galeras en Pasto,
+ * ~2.400 msnm) donde SÍ hay temporada seca y riesgo de incendio. Si el piso es
+ * frío/templado/páramo (altitud ≥ ~1.000 msnm) tratamos la zona como andina; la
+ * planicie/litoral del Pacífico (cálido) se queda como 'pacifico' (sin seca).
+ * Geográficamente correcto, no es fabricación.
+ *
+ * @param {string|null} region
+ * @param {string|null} piso  'paramo'|'frio'|'templado'|'calido'|null
+ * @returns {string|null}
+ */
+function resolveFireRegion(region, piso) {
+  if (region === 'pacifico' && (piso === 'paramo' || piso === 'frio' || piso === 'templado')) {
+    return 'andina';
+  }
+  return region;
+}
+
+/**
+ * ¿El mes dado cae en temporada seca de la región? Devuelve {seca, etiqueta}.
+ */
+function temporadaSeca(region, mes) {
+  const entry = region && DRY_SEASONS[region] ? DRY_SEASONS[region] : null;
+  if (!entry) return { seca: false, etiqueta: null };
+  return { seca: entry.meses.includes(mes), etiqueta: entry.etiqueta };
+}
+
+/**
+ * Evalúa el riesgo de incendio para la finca/zona.
+ *
+ * Matriz de decisión (estacional + ENSO):
+ *   - Región NO fire-prone (Pacífico / desconocida sin señales) → 'bajo'.
+ *   - Temporada seca + El Niño                                   → 'alto'.
+ *   - Temporada seca (sin El Niño)  ó  El Niño (fuera de seca)   → 'medio'.
+ *   - Fuera de temporada seca y sin El Niño                      → 'bajo'.
+ *
+ * @param {object} [opts]
+ * @param {object|null} [opts.profile]  perfil (default getProfile()).
+ * @param {string|null} [opts.ensoPhase] slug/coarse de fase ENSO (default getEnsoPhase()).
+ * @param {string|null} [opts.region]   región natural (default regionFromProfile(profile)).
+ * @param {number|null} [opts.altitud]  msnm (default profile.finca_altitud/altitud).
+ * @param {number} [opts.mes]           mes 1-indexado (default mes actual).
+ * @returns {{
+ *   nivel: 'alto'|'medio'|'bajo',
+ *   es_estimacion: true,
+ *   fase_enso: 'nino'|'nina'|'neutral',
+ *   fase_enso_source: 'manual'|'live'|'default'|'override',
+ *   temporada_seca: boolean,
+ *   temporada_etiqueta: string|null,
+ *   region: string|null,
+ *   piso_termico: string|null,
+ *   mes: number,
+ *   factores: string[],
+ *   recomendaciones: string[],
+ *   disclaimer: string,
+ *   fuentes: string[],
+ * }}
+ */
+export function evaluarRiesgoIncendio(opts = {}) {
+  const profile = opts.profile && typeof opts.profile === 'object' ? opts.profile : getProfile();
+  const phase = typeof opts.ensoPhase === 'string' ? opts.ensoPhase : getEnsoPhase();
+  const fam = ensoFamily(phase);
+  const altitud = opts.altitud != null ? opts.altitud : (profile?.finca_altitud ?? profile?.altitud ?? null);
+  const piso = pisoDesdeAltitud(altitud);
+  const region = resolveFireRegion(opts.region || regionFromProfile(profile) || null, piso);
+  const mes = Number.isFinite(opts.mes) ? opts.mes : currentMonth();
+
+  const { seca, etiqueta } = temporadaSeca(region, mes);
+  const fireProne = region ? FIRE_PRONE.includes(region) : false;
+  const esNino = fam === 'nino';
+
+  const factores = [];
+  let nivel = 'bajo';
+
+  if (!fireProne) {
+    // Pacífico o región sin señal clara → riesgo de incendio estructuralmente bajo.
+    nivel = 'bajo';
+    if (region === 'pacifico') {
+      factores.push('Región Pacífico: lluvia casi todo el año, riesgo de incendio forestal bajo.');
+    } else {
+      factores.push('Sin región o temporada seca identificada para tu finca: no puedo estimar un riesgo estacional alto.');
+    }
+  } else if (seca && esNino) {
+    nivel = 'alto';
+    factores.push(`Estás en ${etiqueta}.`);
+    factores.push('El Niño activo seca aún más el combustible vegetal (IDEAM/UNGRD): el riesgo de incendio sube.');
+  } else if (seca) {
+    nivel = 'medio';
+    factores.push(`Estás en ${etiqueta}: el pasto y la hojarasca se secan y prenden fácil.`);
+  } else if (esNino) {
+    nivel = 'medio';
+    factores.push('El Niño activo trae sequía y reduce la humedad del combustible vegetal, aunque no estés en el pico de temporada seca.');
+  } else {
+    nivel = 'bajo';
+    factores.push('No estás en temporada seca marcada ni hay El Niño activo: el riesgo estacional de incendio es bajo.');
+  }
+  // El Niño en VIGILANCIA (neutral con probabilidad creciente) NO se afirma como
+  // activo aquí: ensoService entrega 'neutral' si no hay Niño, y el agente
+  // comunica la vigilancia por buildEnsoAgentLines. Mantenemos honestidad.
+
+  if (piso === 'paramo') {
+    factores.push('En páramo, una quema es especialmente grave: el suelo orgánico (turba) puede arder bajo tierra por semanas y el ecosistema tarda décadas o siglos en recuperarse.');
+  }
+
+  return {
+    nivel,
+    es_estimacion: true,
+    fase_enso: fam,
+    fase_enso_source: opts.ensoPhase ? 'override' : getEnsoPhaseSource(),
+    temporada_seca: seca,
+    temporada_etiqueta: etiqueta,
+    region,
+    piso_termico: piso,
+    mes,
+    factores,
+    recomendaciones: recomendacionesPara(nivel, { region, piso }),
+    disclaimer:
+      'Esto es una ESTIMACIÓN de riesgo según la temporada climática y la fase de El Niño/La Niña, ' +
+      'NO una alerta oficial de incendio. Para una alerta confirmada de tu zona consulta tu Consejo ' +
+      'Municipal de Gestión del Riesgo (CMGRD), el cuerpo de bomberos o tu Corporación Autónoma Regional.',
+    fuentes: [
+      'Fase ENSO: NOAA CPC (ONI) + IDEAM',
+      'Temporadas secas: climatología IDEAM (régimen de lluvias de Colombia)',
+      'Impacto de El Niño en incendios: IDEAM / UNGRD (DR-MISSION-4)',
+    ],
+  };
+}
+
+/** Recomendaciones accionables por nivel y contexto. Cero alarmismo. */
+function recomendacionesPara(nivel, { region, piso } = {}) {
+  if (nivel === 'bajo') {
+    return [
+      'Mantén rondas cortafuego limpias y aprovecha para hacer mantenimiento preventivo.',
+      'Si vas a quemar rastrojo, hazlo SOLO fuera de temporada seca, con autorización y vigilancia (la quema descontrolada es la causa #1 de incendios forestales).',
+    ];
+  }
+  const recs = [
+    'NO hagas quemas agrícolas: una chispa en pasto seco se vuelve incendio en minutos.',
+    'Limpia y ensancha las rondas cortafuego alrededor de cultivos, vivienda y linderos.',
+    'Ten lista agua y herramienta (bate-fuegos, machete, azadón) y el número de bomberos a la mano.',
+  ];
+  if (nivel === 'alto') {
+    recs.unshift('Riesgo ALTO esta temporada: extrema el cuidado con el fuego en toda la finca y alrededores.');
+    recs.push('Habla con tus vecinos: el incendio de un predio salta al de al lado. La prevención es comunitaria.');
+  }
+  if (region === 'orinoquia' || region === 'amazonia') {
+    recs.push('En sabana o piedemonte, considera fuego prescrito planificado con la autoridad ambiental en vez de quemas espontáneas.');
+  }
+  if (piso === 'paramo' || piso === 'frio') {
+    recs.push('En zona alta: NO quemes para "renovar pasto"; el páramo y el bosque altoandino no se recuperan de la quema.');
+  }
+  return recs;
+}
+
+/**
+ * Renderiza un resultado YA evaluado a bloque de grounding (texto). Pura: no
+ * recomputa. Útil para no evaluar dos veces (diagnosticar + formatear).
+ *
+ * @param {ReturnType<typeof evaluarRiesgoIncendio>} r
+ * @returns {string}
+ */
+export function formatIncendioContext(r) {
+  if (!r || typeof r !== 'object') return '';
+  const lines = [];
+  const nivelLabel = { alto: 'ALTO', medio: 'MEDIO', bajo: 'BAJO' }[r.nivel];
+  lines.push(`RIESGO DE INCENDIO (estimación estacional, NO alerta oficial): ${nivelLabel}.`);
+  if (r.region) lines.push(`Región: ${r.region}. Mes: ${MESES[r.mes - 1]}. Fase ENSO: ${r.fase_enso}.`);
+  if (r.factores.length) lines.push(`Por qué: ${r.factores.join(' ')}`);
+  if (r.recomendaciones.length) lines.push(`Recomendaciones:\n${r.recomendaciones.map((x) => `- ${x}`).join('\n')}`);
+  lines.push(r.disclaimer);
+  lines.push(`Fuentes: ${r.fuentes.join('; ')}.`);
+  lines.push('IMPORTANTE: NO afirmes que hay un incendio activo ni inventes una alerta de IDEAM/UNGRD en tiempo real (no existe esa fuente consultable). Preséntalo como estimación de temporada y remite a CMGRD/bomberos/CAR para confirmación oficial.');
+  return lines.join('\n');
+}
+
+/**
+ * Atajo: evalúa el riesgo y devuelve directamente el bloque de grounding.
+ * Honesto: deja claro que es estimación y cita fuentes.
+ *
+ * @param {object} [opts] mismos que evaluarRiesgoIncendio.
+ * @returns {string}
+ */
+export function buildIncendioContext(opts = {}) {
+  return formatIncendioContext(evaluarRiesgoIncendio(opts));
+}
+
+export const __testing__ = { DRY_SEASONS, FIRE_PRONE, pisoDesdeAltitud, temporadaSeca, resolveFireRegion, MESES };

--- a/src/services/knowledgeIntentRouter.js
+++ b/src/services/knowledgeIntentRouter.js
@@ -161,3 +161,27 @@ export function hasAnimalDiagnosticIntent(msg) { return typeof msg === 'string' 
 
 const RESTAURACION_DIAG_RE = /\b(restaura[cç]|reforesta[cç]|recuperar\s+(el\s+)?(monte|bosque)|p[aá]ramo|frailej[oó]n|sucesi[oó]n\s+ecol[oó]gica|corredor\s+ripario|cerca\s+viva|arbol(es)?\s+nativ[oa]s?|especies?\s+nativ[oa]s?)\b|proteger\s+(el\s+)?nacimiento|controlar\s+(la\s+)?erosion/i;
 export function hasRestauracionDiagnosticIntent(msg) { return typeof msg === 'string' && msg.trim().length >= 5 && RESTAURACION_DIAG_RE.test(_norm(msg)); }
+
+/**
+ * Señal de RIESGO DE INCENDIO (estacional). Distinta de la restauración
+ * post-incendio: aquí el campesino pregunta si su zona ESTÁ en riesgo /
+ * temporada de incendios, no cómo recuperar un sitio ya quemado.
+ *   - matchea: "riesgo de incendio", "temporada de incendios", "alerta de
+ *     incendio", "se va a quemar", "época de quemas", "peligro de fuego".
+ *   - NO matchea: "restaurar después del incendio" / "sitio quemado" (eso es
+ *     restauración → su propio matcher arriba). La co-ocurrencia de un término
+ *     de riesgo/temporada con uno de fuego/quema desambigua.
+ */
+const INCENDIO_RIESGO_RE =
+  /\b(riesgo|peligro|temporada|epoca|alerta|amenaza)\b[^.?!]*\b(incendio|incendios|quema[rs]?|fuego|conato)\b|\b(incendio|incendios|quema[rs]?|fuego)\b[^.?!]*\b(riesgo|peligro|temporada|epoca|alerta|amenaza)\b|se\s+(va|puede|pueden)\s+(a\s+)?quemar|epoca\s+de\s+quemas|estamos\s+en\s+(epoca|temporada)\s+seca/i;
+/**
+ * Detecta si el mensaje pregunta por riesgo/temporada de incendio (para
+ * activar incendioRiskService). Conservador: requiere co-ocurrencia de un
+ * término de riesgo/temporada con uno de fuego/quema.
+ *
+ * @param {string} msg
+ * @returns {boolean}
+ */
+export function hasIncendioRiskIntent(msg) {
+  return typeof msg === 'string' && msg.trim().length >= 5 && INCENDIO_RIESGO_RE.test(_norm(msg));
+}

--- a/src/services/restauracionPlanPDF.js
+++ b/src/services/restauracionPlanPDF.js
@@ -1,0 +1,460 @@
+/**
+ * restauracionPlanPDF — Plan de restauración ecológica en PDF institucional.
+ *
+ * Diferenciador Pro para gestión de riesgo / restauración (caso Ana, UNGRD
+ * Pasto / Galeras): el usuario genera un PDF imprimible del plan de sucesión
+ * ecológica (pioneras → intermedias → clímax) con especies NATIVAS por piso
+ * térmico, el arreglo recomendado, las guardas anti-mito y, opcionalmente, el
+ * contexto de riesgo de incendio. Sirve para informes a la UNGRD, la CAR
+ * (Corponariño), planes municipales de gestión del riesgo (Ley 1523/2012) y
+ * proyectos de PSA (Decreto 1007/2018).
+ *
+ * Reutiliza el patrón de `cuadernoPDF.js`: jsPDF, build en memoria → Blob,
+ * UI-agnóstico (solo toca `document` en `downloadRestauracionPlanPDF`). Los
+ * datos entran ya calculados (`diagnosticarRestauracion()` + opcional
+ * `evaluarRiesgoIncendio()`), así los tests unit no tocan red ni DOM.
+ *
+ * CERO fabricación: el PDF SOLO imprime especies que vienen del diagnóstico
+ * (catálogo DR-RESTAURACION-1 por piso térmico). Si no hay datos para el piso,
+ * lo dice explícitamente y remite al vivero local / CAR. Las fuentes se citan
+ * en el pie. El bloque de riesgo de incendio se marca como ESTIMACIÓN, no
+ * alerta oficial.
+ */
+
+import { jsPDF } from 'jspdf';
+
+// A4 portrait en mm (jsPDF default unit).
+const PAGE_W = 210;
+const PAGE_H = 297;
+const MARGIN = 18;
+const CONTENT_W = PAGE_W - MARGIN * 2;
+
+// Paleta — verde Chagra para títulos, gris para secundario (igual que cuadernoPDF).
+const COLOR_EMERALD = [16, 122, 87];
+const COLOR_SLATE = [71, 85, 105];
+const COLOR_MUTED = [148, 163, 184];
+const COLOR_DARK = [15, 23, 42];
+const COLOR_AMBER = [180, 83, 9];
+const COLOR_RED = [153, 27, 27];
+
+// Versión del schema del plan (bump si cambian secciones / orden).
+export const RESTAURACION_PDF_VERSION = '1';
+
+const pad = (n) => String(n).padStart(2, '0');
+
+const formatHumanDate = (date = new Date()) => {
+  const months = [
+    'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+    'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+  ];
+  return `${date.getDate()} de ${months[date.getMonth()]} de ${date.getFullYear()}`;
+};
+
+const formatDateTimeForFile = (date = new Date()) =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}`;
+
+const safeStr = (value, fallback = '—') => {
+  if (value == null) return fallback;
+  const s = String(value).trim();
+  return s.length === 0 ? fallback : s;
+};
+
+const estimateLineHeight = (fontSize) => fontSize * 0.42;
+
+const PISO_LABELS = {
+  calido_0_1000: 'Cálido (0–1000 msnm)',
+  templado_1000_2000: 'Templado (1000–2000 msnm)',
+  frio_2000_3000: 'Frío (2000–3000 msnm)',
+  paramo_3000: 'Páramo (más de 3000 msnm)',
+};
+
+const NIVEL_INCENDIO = {
+  alto: { label: 'ALTO', color: COLOR_RED },
+  medio: { label: 'MEDIO', color: COLOR_AMBER },
+  bajo: { label: 'BAJO', color: COLOR_EMERALD },
+};
+
+// ─── Renderers (mismos helpers que cuadernoPDF, ajustados al plan) ──────────
+
+const drawPageHeader = (doc, subtitle) => {
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  doc.setTextColor(...COLOR_MUTED);
+  doc.text(`Plan de restauración ecológica · ${safeStr(subtitle, 'Chagra')}`, MARGIN, 10);
+  doc.setDrawColor(...COLOR_MUTED);
+  doc.setLineWidth(0.2);
+  doc.line(MARGIN, 12, PAGE_W - MARGIN, 12);
+};
+
+const drawPageFooter = (doc, pageNum, totalPages) => {
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(8);
+  doc.setTextColor(...COLOR_MUTED);
+  doc.text(`Página ${pageNum} de ${totalPages} · Chagra Eco-OS`, PAGE_W / 2, PAGE_H - 8, { align: 'center' });
+};
+
+const drawSectionTitle = (doc, cursorY, title) => {
+  doc.setFillColor(...COLOR_EMERALD);
+  doc.rect(MARGIN, cursorY - 4, 2, 6, 'F');
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(14);
+  doc.setTextColor(...COLOR_DARK);
+  doc.text(title, MARGIN + 4, cursorY);
+  return cursorY + 8;
+};
+
+const drawParagraph = (doc, cursorY, text, options = {}) => {
+  const { fontSize = 10, color = COLOR_SLATE, gap = 4 } = options;
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(fontSize);
+  doc.setTextColor(...color);
+  const lines = doc.splitTextToSize(text, CONTENT_W);
+  doc.text(lines, MARGIN, cursorY);
+  return cursorY + lines.length * estimateLineHeight(fontSize) + gap;
+};
+
+/** Salta de página si no queda espacio; devuelve el nuevo cursorY. */
+const ensureSpace = (doc, y, needed, subtitle) => {
+  if (y + needed > PAGE_H - MARGIN - 12) {
+    drawPageFooter(doc, doc.getNumberOfPages(), doc.getNumberOfPages());
+    doc.addPage();
+    drawPageHeader(doc, subtitle);
+    return MARGIN + 6;
+  }
+  return y;
+};
+
+/**
+ * Lista de especies de un rol sucesional (pioneras/intermedias/clímax).
+ * Cada especie: "Nombre común (Nombre científico) — nota". Las científicas en
+ * itálica. Devuelve el cursorY actualizado.
+ */
+const drawEspeciesRol = (doc, y, titulo, especies, subtitle) => {
+  if (!Array.isArray(especies) || especies.length === 0) return y;
+  y = ensureSpace(doc, y, 10, subtitle);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.setTextColor(...COLOR_EMERALD);
+  doc.text(titulo, MARGIN, y);
+  y += 6;
+  doc.setFontSize(9.5);
+  for (const e of especies) {
+    y = ensureSpace(doc, y, 8, subtitle);
+    const comun = safeStr(e?.nombre || e?.nombre_comun, '');
+    const cient = safeStr(e?.cientifico || e?.nombre_cientifico, '');
+    const nota = e?.nota ? ` — ${e.nota}` : '';
+    // Nombre común en negrita
+    doc.setFont('helvetica', 'bold');
+    doc.setTextColor(...COLOR_DARK);
+    doc.text(`• ${comun}`, MARGIN + 2, y);
+    const comunW = doc.getTextWidth(`• ${comun} `);
+    // Científico en itálica + nota normal, con wrap.
+    doc.setFont('helvetica', 'italic');
+    doc.setTextColor(...COLOR_SLATE);
+    const resto = cient ? `(${cient})${nota}` : nota;
+    const restoLines = doc.splitTextToSize(resto, CONTENT_W - comunW - 4);
+    doc.text(restoLines, MARGIN + 2 + comunW, y);
+    y += Math.max(1, restoLines.length) * estimateLineHeight(9.5) + 2.5;
+  }
+  return y + 2;
+};
+
+/**
+ * Genera el PDF del plan de restauración en memoria → Blob application/pdf.
+ *
+ * @param {object} planData
+ * @param {object} planData.diagnostico — salida de diagnosticarRestauracion():
+ *   { arreglo, roles, especies, alertas[], guardas[], sin_datos, fuente }.
+ * @param {object} [planData.finca]    — { nombre, municipio, vereda, altitud, departamento, coords }.
+ * @param {string} [planData.operatorName]
+ * @param {string} [planData.operatorRole]
+ * @param {string} [planData.objetivo] — bosque|ribera|cortafuegos|post_incendio|paramo.
+ * @param {string} [planData.descripcion] — lo que el usuario describió (talud, quebrada…).
+ * @param {object} [planData.riesgoIncendio] — salida de evaluarRiesgoIncendio() (opcional).
+ * @param {string} [planData.piso]     — clave de piso (calido_0_1000…) si el diag no la trae.
+ * @returns {Blob} application/pdf
+ */
+export const generateRestauracionPlanPDF = (planData) => {
+  const data = planData || {};
+  const diag = data.diagnostico || {};
+  const finca = data.finca || {};
+  const especies = diag.especies || null;
+  const roles = diag.roles || null;
+  const arreglo = diag.arreglo || null;
+  const alertas = Array.isArray(diag.alertas) ? diag.alertas : [];
+  const guardas = Array.isArray(diag.guardas) ? diag.guardas : [];
+  const riesgo = data.riesgoIncendio || null;
+  const subtitle = safeStr(finca.nombre, 'Plan de restauración');
+
+  const doc = new jsPDF({ unit: 'mm', format: 'a4', compress: true });
+
+  // ─── PORTADA ─────────────────────────────────────────────────────────
+  doc.setFillColor(...COLOR_EMERALD);
+  doc.rect(0, 0, PAGE_W, 72, 'F');
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(30);
+  doc.setTextColor(255, 255, 255);
+  doc.text('CHAGRA', MARGIN, 30);
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(13);
+  doc.text('Plan de restauración ecológica', MARGIN, 42);
+  doc.setFontSize(9);
+  doc.text('Documento técnico de apoyo · sucesión con especies nativas', MARGIN, 50);
+
+  let y = 92;
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(22);
+  doc.setTextColor(...COLOR_DARK);
+  doc.text(safeStr(finca.nombre, 'Predio sin nombre'), MARGIN, y);
+  y += 10;
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(11);
+  doc.setTextColor(...COLOR_SLATE);
+  if (data.operatorName) { doc.text(`Responsable: ${safeStr(data.operatorName)}`, MARGIN, y); y += 6; }
+  if (data.operatorRole) { doc.text(`Rol / entidad: ${safeStr(data.operatorRole)}`, MARGIN, y); y += 6; }
+
+  const locParts = [];
+  if (finca.municipio) locParts.push(finca.municipio);
+  if (finca.departamento) locParts.push(finca.departamento);
+  if (finca.vereda) locParts.push(`vereda ${finca.vereda}`);
+  if (finca.altitud) locParts.push(`${finca.altitud} msnm`);
+  if (Array.isArray(finca.coords) && finca.coords.length === 2) {
+    locParts.push(`(${Number(finca.coords[0]).toFixed(4)}, ${Number(finca.coords[1]).toFixed(4)})`);
+  }
+  if (locParts.length) { doc.text(`Ubicación: ${locParts.join(' · ')}`, MARGIN, y); y += 6; }
+
+  if (data.objetivo) {
+    doc.text(`Objetivo de restauración: ${objetivoLabel(data.objetivo)}`, MARGIN, y);
+    y += 6;
+  }
+
+  y += 4;
+  doc.setDrawColor(...COLOR_MUTED);
+  doc.setLineWidth(0.3);
+  doc.line(MARGIN, y, PAGE_W - MARGIN, y);
+  y += 8;
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  doc.setTextColor(...COLOR_DARK);
+  doc.text('Fecha de generación', MARGIN, y);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(...COLOR_SLATE);
+  doc.text(formatHumanDate(new Date()), MARGIN + 60, y);
+  y += 8;
+
+  if (data.descripcion) {
+    y = drawParagraph(doc, y, `Situación descrita: ${data.descripcion}`, { fontSize: 10, color: COLOR_SLATE });
+  }
+
+  // ─── PÁGINA 2: ARREGLO + SUCESIÓN ────────────────────────────────────
+  doc.addPage();
+  drawPageHeader(doc, subtitle);
+  y = MARGIN + 6;
+  y = drawSectionTitle(doc, y, 'Arreglo recomendado');
+
+  if (arreglo) {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(11);
+    doc.setTextColor(...COLOR_DARK);
+    doc.text(safeStr(arreglo.nombre), MARGIN, y);
+    y += 6;
+    if (arreglo.densidad) y = drawParagraph(doc, y, `Densidad / disposición: ${arreglo.densidad}`, { fontSize: 10, color: COLOR_SLATE, gap: 2 });
+    if (arreglo.detalle) y = drawParagraph(doc, y, arreglo.detalle, { fontSize: 10, color: COLOR_SLATE });
+  } else {
+    y = drawParagraph(doc, y, 'No se determinó un arreglo específico desde la descripción. Consulta el plan de sucesión por piso térmico y el vivero local.', { fontSize: 10, color: COLOR_MUTED });
+  }
+
+  y += 2;
+  const pisoKey = data.piso || inferPisoFromEspecies(especies, roles);
+  y = drawSectionTitle(doc, y, 'Sucesión ecológica por etapas');
+  y = drawParagraph(
+    doc, y,
+    `Estas son las especies NATIVAS recomendadas${pisoKey ? ` para el piso ${PISO_LABELS[pisoKey] || pisoKey}` : ''}. ` +
+    'Se siembran en orden sucesional: primero las pioneras (rústicas, de rápido crecimiento), luego las intermedias bajo su sombra, y finalmente las de clímax que estructuran el bosque maduro. NO se mezclan todas de una vez.',
+    { fontSize: 9.5, color: COLOR_SLATE },
+  );
+
+  if (especies && (especies.pioneras || especies.intermedias || especies.climax)) {
+    y = drawEspeciesRol(doc, y, '1. Pioneras (año 1)', especies.pioneras, subtitle);
+    y = drawEspeciesRol(doc, y, '2. Intermedias (años 2–5)', especies.intermedias, subtitle);
+    y = drawEspeciesRol(doc, y, '3. Clímax (año 5 en adelante)', especies.climax, subtitle);
+  } else if (roles) {
+    // Fallback: roles trae solo nombres comunes (sin binomio).
+    y = drawEspeciesRolNombres(doc, y, '1. Pioneras (año 1)', roles.pioneras, subtitle);
+    y = drawEspeciesRolNombres(doc, y, '2. Intermedias (años 2–5)', roles.intermedias, subtitle);
+    y = drawEspeciesRolNombres(doc, y, '3. Clímax (año 5 en adelante)', roles.climax, subtitle);
+  } else {
+    y = drawParagraph(
+      doc, y,
+      'No hay una lista de especies cargada para este piso térmico todavía. ' +
+      'Para no recomendar especies equivocadas, consulta el vivero forestal de tu municipio o tu Corporación Autónoma Regional (CAR): ellos tienen el material nativo apropiado para tu zona.',
+      { fontSize: 10, color: COLOR_AMBER },
+    );
+  }
+
+  // ─── ALERTAS Y GUARDAS ───────────────────────────────────────────────
+  if (alertas.length || guardas.length) {
+    y = ensureSpace(doc, y, 30, subtitle);
+    y += 2;
+    y = drawSectionTitle(doc, y, 'Alertas y buenas prácticas');
+    for (const a of alertas) {
+      y = ensureSpace(doc, y, 14, subtitle);
+      y = drawParagraph(doc, y, `⚠ ${a}`, { fontSize: 9.5, color: COLOR_AMBER });
+    }
+    for (const g of guardas) {
+      y = ensureSpace(doc, y, 14, subtitle);
+      y = drawParagraph(doc, y, g, { fontSize: 9, color: COLOR_SLATE });
+    }
+  }
+
+  // ─── RIESGO DE INCENDIO (opcional) ───────────────────────────────────
+  if (riesgo && riesgo.nivel) {
+    doc.addPage();
+    drawPageHeader(doc, subtitle);
+    y = MARGIN + 6;
+    y = drawSectionTitle(doc, y, 'Contexto de riesgo de incendio');
+    const nv = NIVEL_INCENDIO[riesgo.nivel] || NIVEL_INCENDIO.bajo;
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(13);
+    doc.setTextColor(...nv.color);
+    doc.text(`Nivel estimado: ${nv.label}`, MARGIN, y);
+    y += 8;
+    doc.setFont('helvetica', 'italic');
+    doc.setFontSize(8.5);
+    doc.setTextColor(...COLOR_MUTED);
+    y = drawParagraph(doc, y, 'ESTIMACIÓN estacional (temporada seca + fase El Niño/La Niña). NO es una alerta oficial de incendio.', { fontSize: 8.5, color: COLOR_MUTED });
+    for (const f of (riesgo.factores || [])) {
+      y = ensureSpace(doc, y, 12, subtitle);
+      y = drawParagraph(doc, y, `• ${f}`, { fontSize: 9.5, color: COLOR_DARK, gap: 2 });
+    }
+    if ((riesgo.recomendaciones || []).length) {
+      y += 2;
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(11);
+      doc.setTextColor(...COLOR_EMERALD);
+      y = ensureSpace(doc, y, 10, subtitle);
+      doc.text('Recomendaciones', MARGIN, y);
+      y += 6;
+      for (const r of riesgo.recomendaciones) {
+        y = ensureSpace(doc, y, 12, subtitle);
+        y = drawParagraph(doc, y, `• ${r}`, { fontSize: 9.5, color: COLOR_SLATE, gap: 2 });
+      }
+    }
+    if (riesgo.disclaimer) {
+      y += 2;
+      y = drawParagraph(doc, y, riesgo.disclaimer, { fontSize: 9, color: COLOR_AMBER });
+    }
+  }
+
+  // ─── FUENTES + PIE LEGAL ─────────────────────────────────────────────
+  y = ensureSpace(doc, y, 40, subtitle);
+  y += 4;
+  y = drawSectionTitle(doc, y, 'Fuentes');
+  const fuentes = [];
+  if (diag.fuente) fuentes.push(diag.fuente);
+  if (riesgo && Array.isArray(riesgo.fuentes)) fuentes.push(...riesgo.fuentes);
+  if (fuentes.length === 0) fuentes.push('Catálogo de restauración Chagra (DR-RESTAURACION-1: IAvH, MinAmbiente, CIPAV).');
+  for (const f of fuentes) {
+    y = ensureSpace(doc, y, 10, subtitle);
+    y = drawParagraph(doc, y, `• ${f}`, { fontSize: 9, color: COLOR_SLATE, gap: 1.5 });
+  }
+
+  const disclaimer =
+    `Documento generado por Chagra Eco-OS el ${formatHumanDate(new Date())}. ` +
+    'Es un documento técnico de APOYO basado en investigación documentada (restauración ecológica nativa); ' +
+    'NO reemplaza el concepto de un ingeniero forestal ni la autorización de la autoridad ambiental competente ' +
+    '(Corporación Autónoma Regional). Para predios en zona de páramo, ronda hídrica o área protegida, verifica ' +
+    'las restricciones de uso (Ley 1930/2018, Ley 1523/2012) antes de intervenir.';
+  y = ensureSpace(doc, y, 24, subtitle);
+  y += 4;
+  doc.setFont('helvetica', 'italic');
+  doc.setFontSize(8);
+  doc.setTextColor(...COLOR_MUTED);
+  const discLines = doc.splitTextToSize(disclaimer, CONTENT_W);
+  doc.text(discLines, MARGIN, y);
+
+  // ─── Footer + paginación ─────────────────────────────────────────────
+  const totalPages = doc.getNumberOfPages();
+  for (let p = 1; p <= totalPages; p++) {
+    doc.setPage(p);
+    if (p > 1) drawPageFooter(doc, p, totalPages);
+  }
+
+  const arrayBuffer = doc.output('arraybuffer');
+  return new Blob([arrayBuffer], { type: 'application/pdf' });
+};
+
+/** Etiqueta humana del objetivo de restauración. */
+function objetivoLabel(obj) {
+  const m = {
+    bosque: 'Restauración de bosque',
+    ribera: 'Restauración de ribera / ronda hídrica',
+    cortafuegos: 'Barrera cortafuegos',
+    post_incendio: 'Recuperación post-incendio',
+    paramo: 'Restauración de páramo',
+    restauracion_bosque: 'Restauración de bosque',
+    restauracion_ribera: 'Restauración de ribera',
+  };
+  return m[obj] || safeStr(obj).replace(/_/g, ' ');
+}
+
+/** Rol con solo nombres comunes (fallback cuando no hay binomios). */
+function drawEspeciesRolNombres(doc, y, titulo, nombres, subtitle) {
+  if (!Array.isArray(nombres) || nombres.length === 0) return y;
+  y = ensureSpace(doc, y, 10, subtitle);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.setTextColor(...COLOR_EMERALD);
+  doc.text(titulo, MARGIN, y);
+  y += 6;
+  y = drawParagraph(doc, y, nombres.map((n) => safeStr(n)).join(', '), { fontSize: 9.5, color: COLOR_DARK });
+  return y + 2;
+}
+
+/** Infiere la clave de piso desde la presencia de listas (best-effort). */
+function inferPisoFromEspecies() {
+  return null; // el caller pasa data.piso explícito; este fallback evita adivinar mal.
+}
+
+/** Nombre de archivo canónico para el plan descargado. */
+export const buildRestauracionPlanFilename = (finca, date = new Date()) => {
+  const slug = (finca?.slug || finca?.nombre || 'predio')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `plan-restauracion-chagra-${slug || 'predio'}-${formatDateTimeForFile(date)}.pdf`;
+};
+
+/**
+ * Orquesta build → blob → download. Lanza errores; el caller los muestra inline.
+ *
+ * @param {object} planData ver generateRestauracionPlanPDF.
+ * @returns {Promise<{ filename: string, sizeBytes: number }>}
+ */
+export const downloadRestauracionPlanPDF = async (planData) => {
+  const blob = generateRestauracionPlanPDF(planData);
+  const filename = buildRestauracionPlanFilename(planData?.finca);
+
+  if (typeof document !== 'undefined') {
+    const url = URL.createObjectURL(blob);
+    try {
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+    } finally {
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+  }
+
+  return { filename, sizeBytes: blob.size };
+};
+
+export default generateRestauracionPlanPDF;


### PR DESCRIPTION
## Qué hace

Cierra los **2 diferenciadores Pro faltantes** del módulo restauración/incendios para **Ana (UNGRD Pasto/Galeras)**.

### 1. Alerta de riesgo de incendio para la finca
`src/services/incendioRiskService.js` — **estimación estacional honesta**, NO alerta oficial.

- Sintetiza el nivel (`alto`/`medio`/`bajo`) a partir de **señales reales ya cableadas**:
  - **Fase ENSO** en vivo (NOAA ONI + IDEAM) vía `ensoService.getEnsoPhase()` — El Niño = sequía = más riesgo.
  - **Temporada seca** por región natural (climatología IDEAM: bimodal Andina/Caribe dic–mar + jun–ago; monomodal seco Orinoquía/Amazonía dic–mar).
  - **Piso térmico / región** del perfil (`ensoContext`).
- **Cero fabricación:** marca `es_estimacion: true`, trae `disclaimer` (remite a CMGRD / bomberos / CAR) y cita fuentes. El Pacífico queda en `bajo` (sin falsos positivos). Corrige el caso Nariño (departamento→`pacifico` pero la ladera del Galeras a 2400 msnm es andina → riesgo real).
- **Wireado al agente:** chip 🔥 "Riesgo de incendio" (`agentCapabilities`/`chipIntentRouter`, `kind:'local'`), matcher `hasIncendioRiskIntent` (`knowledgeIntentRouter`) y grounding `buildIncendioContext` inyectado en `AgentScreen` (módulo + chip forzado).

> **Sobre el "bug DR23"** (precondición que pedía el pipeline): ya está **resuelto**. Verifiqué empíricamente que el sidecar registra `get_enso_status` + `get_alertas_clima_zona` (en `allowed-tools` + `nlu`) y que el PWA inyecta `buildClimaContext` al system prompt. Las tools de clima/ENSO **sí son visibles al LLM** — no requería un fix nuevo. Y **no existe** una API pública de alerta de incendio en tiempo real de IDEAM/UNGRD (SAGER/SNPAD), así que el tool entrega el fallback heurístico honesto, como pedía el brief.

### 2. Export PDF del plan de restauración
`src/services/restauracionPlanPDF.js` + `src/components/RestauracionPlanPDFButton.jsx` — reutiliza el patrón de `cuadernoPDF`/`CuadernoPDFButton` (jsPDF, build→Blob, descarga, filename canónico).

- Documento institucional para UNGRD/CAR: portada, objetivo, **arreglo recomendado**, **sucesión escalonada** (pioneras → intermedias → clímax con especies nativas del piso térmico desde `restauracionDiagnostic`), alertas + guardas anti-mito, fuentes y disclaimer legal (Ley 1930/2018, Ley 1523/2012).
- Opcional: incluye el **contexto de riesgo de incendio** (sinergia con la feature 1).
- **Cero fabricación:** solo imprime especies del diagnóstico; si no hay datos del piso, remite al vivero local / CAR.
- Montado en `InformesScreen` junto al cuaderno de campo.

## Tests (vitest)
- `incendioRiskService.test.js` — matriz ENSO×temporada, reglas regionales (Pacífico bajo, Orinoquía fuego prescrito), caso Ana + corrección Nariño, anti-fabricación, helpers. (17)
- `restauracionPlanPDF.test.js` — Blob `application/pdf`, magic bytes `%PDF-`, filename, fallback de roles, inclusión del bloque de riesgo, descarga jsdom. (11)
- `knowledgeIntentRouter.test.js` — `hasIncendioRiskIntent` (no confunde con restauración post-incendio).
- `chipIntentRouter.test.js` — chip `incendio` (localGrounding) + orden/enum actualizados.

## Verify-first / anti-leak
- Sin endpoints inventados. Sin secretos/IPs/hostnames en el diff (secret-scan limpio).
- Toda afirmación de fuente es real y citada; el riesgo de incendio se presenta siempre como estimación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)