### PR TITLE
feat(juego): Mi Finca Viva — capa lúdica kid-friendly sobre el motor de evolución

### DIFF
--- a/docs/JUEGO_JULIETA.md
+++ b/docs/JUEGO_JULIETA.md
@@ -1,0 +1,157 @@
+# Mi Finca Viva — la capa lúdica de Chagra para niñas y niños
+
+> Un regalo para Julieta (y para cualquier niña que quiera ver crecer su finca).
+> Una capa de juego **encima** del motor de evolución agroecológica que ya
+> existe — **no** un juego paralelo con datos inventados.
+
+## 1. La idea en una frase
+
+La finca es un **mundo vivo que florece de verdad** a medida que la familia
+trabaja: cada planta sembrada, cada cosecha registrada y cada cuidado sin
+venenos hace que el mundo del juego crezca, lleguen criaturas y se cumplan
+misiones. El "puntaje" no es inventado: es la suma de los indicadores reales que
+el motor agroecológico ya calcula.
+
+## 2. Principio fundacional: CERO FABRICACIÓN
+
+Igual que el resto de Chagra, este juego **no inventa progreso**. Toda criatura,
+insignia, nivel del mundo o misión cumplida se **deriva** de
+`evaluarEvolucionFinca()` (el motor `fincaEvolutionService`) sobre datos reales
+de la finca. Si no hay datos, el mundo arranca vacío y el juego **invita** a
+sembrar — nunca muestra un mundo falsamente lleno.
+
+- Sin procesos registrados → finca vacía → "¡Sembrá tu primera planta!".
+- Una criatura aparece solo cuando un indicador real cruza su umbral.
+- El nivel del mundo (0–4) **es** el nivel de Gliessman real de la finca.
+
+Esto respeta el contrato anti-paternalista de
+`MiFincaEvolucionScreen` ("acá no hay puntos ni medallas"): el juego es una
+**lectura alegre** de la misma verdad, pensada para que una niña la entienda y
+la disfrute, no una capa de XP arbitraria.
+
+## 3. Mecánicas
+
+### 3.1 El mundo que crece (5 etapas = nivel Gliessman 0–4)
+
+El escenario ilustrado (`FincaWorldScene`, SVG inline + CSS, offline-first) se
+transforma visiblemente según el nivel: más árboles, más plantas en el suelo,
+colores más vivos, frutos en los árboles, y las criaturas reales sobrevolando.
+
+| Nivel | Nombre para la niña | Término real (Gliessman) |
+|------:|---------------------|--------------------------|
+| 0 | La tierra que despierta | Convencional |
+| 1 | El primer verde | Reducción de insumos |
+| 2 | La tierra viva | Sustitución orgánica |
+| 3 | El bosque de comida | Rediseño del sistema |
+| 4 | La finca que comparte | Conexión social y económica |
+
+El juego enseña con cariño: muestra el nombre alegre **y** el término
+agroecológico real ("tu finca está en la etapa «Sustitución orgánica»").
+
+### 3.2 Criaturas coleccionables (biodiversidad real)
+
+Aparecen cuando los indicadores reales suben — son la biodiversidad que de
+verdad llega a una finca sana. Se ven en la galería (`CriaturaCollection`): las
+desbloqueadas a color, las que faltan en silueta con una **pista** honesta de
+qué acción real las atrae. Cada una tiene audio (TTS) para niñas que leen poco.
+
+| Criatura | Aparece cuando… (indicador real) |
+|----------|----------------------------------|
+| 🪱 Lombriz | Empieza el cuidado del suelo sin venenos (autodependencia ≥ 1) |
+| 🦋 Mariposa | Hay varias plantas distintas (diversidad ≥ 1) |
+| 🐝 Abeja | Las plantas se ayudan / hay buena diversidad (sinergias ≥ 1 o diversidad ≥ 3) |
+| 🐸 Rana | El sistema es resiliente y variado (resiliencia ≥ 2) |
+| 🐦 Colibrí | Hay muchas flores y plantas (diversidad ≥ 3) |
+| 🐞 Mariquita | Se cuida sin químicos (autodependencia ≥ 2) |
+| 🦜 Quetzal | **La cumbre**: finca-bosque madura (nivel ≥ 3 + diversidad ≥ 3) |
+
+### 3.3 Misiones (acciones reales + aprender con GUATOC)
+
+Cada misión empuja a una **acción real** de la finca o a aprender una ficha
+GUATOC. Completar la acción real mueve los indicadores → sube la finca.
+
+| Misión | Tipo | Rutea a | Se cumple con… |
+|--------|------|---------|----------------|
+| 🌱 Sembrá una planta | acción | `sembrar` | ≥ 1 proceso registrado |
+| 📖 Aprendé sobre una planta | aprender | `ciclo` (GUATOC) | la niña marca "Ya lo aprendí" |
+| 🌻 Sembrá plantas amigas | acción | `sembrar` | diversidad ≥ 1 |
+| 🧪 Preparale comida natural | acción | `insumos` | autodependencia ≥ 1 (biopreparado) |
+| 🧺 Recogé tu cosecha | acción | `cosechar` | productividad ≥ 1 |
+| 🔎 Mirá tu finca | acción | `observacion` | una observación registrada |
+
+Las misiones de **acción** se marcan solas (leen los indicadores). Las de
+**aprender** se marcan a mano (leer una ficha no deja rastro en los
+indicadores), y eso se persiste por finca.
+
+### 3.4 Insignias
+
+Reconocimiento de hitos reales (no XP): Primera semilla, Jardín diverso, Amiga
+del suelo, Primera cosecha, Guardiana del bosque. Cada una tiene su `check(ev)`
+puro sobre datos reales.
+
+### 3.5 Recompensas y celebración
+
+Al subir de nivel: overlay de fiesta (`LevelUpCelebration`) con confeti,
+**sonido** (`agentSoundService.chime`) y **narración por audio** (TTS kokoro /
+Web Speech). Se dispara **una sola vez** por subida (se compara el nivel actual
+contra el último visto, persistido por finca).
+
+### 3.6 Accesibilidad (pensado para una niña)
+
+- Botones grandes (44–56 px), alto contraste, textos cortos.
+- **Audio en todo**: narración de la finca, logros de criaturas y misiones por
+  TTS, para una niña que lee poco. Botón grande de encender/apagar sonido.
+- Animaciones suaves (CSS) que respetan `prefers-reduced-motion`.
+- Todo offline-first; degrada limpio en modo privado (sin localStorage).
+
+## 4. Arquitectura (reúso, no reinvención)
+
+```
+fincaEvolutionService.js   ← MOTOR existente (puro, cero-fabricación)
+        │  evaluarEvolucionFinca({processes, observations})
+        ▼
+fincaGameService.js        ← NUEVO: traduce indicadores → mundo/criaturas/misiones
+        │                     (normaliza el shape real anidado→plano sin tocar el motor)
+        ▼
+MiFincaVivaScreen.jsx      ← NUEVO: pantalla del juego (ruta 'juego')
+   ├─ FincaWorldScene.jsx       (el mundo SVG que crece)
+   ├─ CriaturaCollection.jsx    (galería de criaturas)
+   ├─ MisionCard.jsx            (misiones → acciones reales / GUATOC)
+   └─ LevelUpCelebration.jsx    (fiesta + sonido + TTS)
+
+fincaGameStateService.js   ← NUEVO: persiste lo mínimo (último nivel visto +
+                              misiones de "aprender" marcadas), por finca.
+```
+
+- **No se tocó** `fincaEvolutionService` ni `MiFincaEvolucionScreen`: el modo
+  serio sigue intacto. El juego es una vista nueva (`case 'juego'` en `App.jsx`).
+- Entrada: una tarjeta colorida "Mi Finca Viva" en **Hoy en finca**, debajo de
+  la tarjeta de evolución.
+- **Puente de datos**: el almacenamiento real guarda los procesos anidados en
+  `attributes` y los eventos en otro store; `fincaGameService` los aplana al
+  shape plano que el motor espera (`flattenProcess`/`flattenEvent`) y la
+  pantalla hidrata los eventos (`getFarmEvents`) — sin modificar el motor.
+
+## 5. Pruebas
+
+- `src/services/__tests__/fincaGameService.test.js` — mundos, estado vacío,
+  desbloqueo de criaturas/insignias, misiones (acción y aprender), normalización
+  del shape real anidado, `detectLevelUp`, narración. (28 tests)
+- `src/services/__tests__/fincaGameStateService.test.js` — persistencia,
+  idempotencia, independencia por finca, JSON corrupto. (7 tests)
+- `src/components/juego/__tests__/MiFincaVivaScreen.test.jsx` — montaje, estado
+  vacío vs próspero, celebración de subida de nivel, marcar misión, audio,
+  navegación a acciones reales. (14 tests)
+
+Verificación visual con Playwright (chromium del nix-store, datos sembrados en
+IndexedDB): ver `scripts/juego-julieta-shots.mjs`. Screenshots de los 3 estados
+(finca vacía, finca próspera, celebración) en `/tmp/juego-julieta-*.png`.
+
+## 6. Cómo jugar
+
+1. **Hoy en finca** → tarjeta **"Mi Finca Viva"** (o ruta `'juego'`).
+2. Si la finca está vacía: tocá **"Sembrar mi primera planta"**.
+3. A medida que registrás trabajo real (sembrar, cosechar, biopreparados,
+   observaciones), el mundo crece, llegan criaturas y se cumplen misiones.
+4. Tocá el botón de **audio** para que la finca te cuente cómo va.
+5. Cuando subís de nivel: **¡fiesta!** 🎉

--- a/scripts/juego-julieta-shots.mjs
+++ b/scripts/juego-julieta-shots.mjs
@@ -1,0 +1,204 @@
+// Screenshots de "Mi Finca Viva" (juego para Julieta) en 3 estados:
+//   1) finca vacía (invitación a sembrar)
+//   2) finca próspera (mundo crecido + criaturas + misiones)
+//   3) celebración de subida de nivel
+//
+// Patrón NixOS: chromium del nix-store (bundled falla por libnspr4/libglib),
+// auth stub en IDB, intercept de backend para no rebotar a login, y seed de
+// farm_processes/farm_process_events vía la propia DB del app (ya migrada).
+//
+// Uso: node scripts/juego-julieta-shots.mjs <baseURL>
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+const BASE = process.argv[2] || 'http://127.0.0.1:4178';
+const OUT_DIR = '/tmp';
+
+const KNOWN_CHROMIUM = [
+  '/nix/store/r7ifk1v95jfl02775kgbrd61dyr1rfsx-chromium-148.0.7778.178/bin/chromium',
+  '/nix/store/9fjg59mab9j8c5r61dx2k5gcbd2f5mpm-chromium-148.0.7778.96/bin/chromium',
+];
+function resolveChromium() {
+  if (process.env.CHROMIUM_PATH) return process.env.CHROMIUM_PATH;
+  for (const p of KNOWN_CHROMIUM) { try { if (fs.existsSync(p)) return p; } catch { /* */ } }
+  return execSync('nix-shell -p chromium --run "which chromium"', { encoding: 'utf8', timeout: 180000 })
+    .trim().split('\n').pop().trim();
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Procesos + eventos en el shape REAL (anidado en attributes).
+function seedData() {
+  const slugs = ['coffea_arabica', 'theobroma_cacao', 'musa_paradisiaca', 'persea_americana',
+    'phaseolus_vulgaris', 'zea_mays', 'inga_edulis', 'citrus_limon'];
+  const now = Date.now();
+  const processes = slugs.map((slug, i) => ({
+    process_id: `seed-p${i}`,
+    type: 'farm_process',
+    attributes: {
+      process_type: i % 2 === 0 ? 'sowing' : 'agroforestry',
+      subject_kind: 'aggregate',
+      subject_slug: slug,
+      subject_label: slug,
+      quantity: 10,
+      unit: 'plantas',
+      location_land_asset_id: 'land-1',
+      status: 'active',
+      current_stage: ['vegetative', 'flowering', 'fruiting', 'mature'][i % 4],
+      created_at: now,
+      updated_at: now,
+      companions: i < 3 ? ['inga_edulis'] : [],
+    },
+  }));
+  const events = [];
+  processes.forEach((p, i) => {
+    events.push({
+      event_id: `seed-e-h-${i}`,
+      type: 'farm_process_event',
+      attributes: { process_id: p.process_id, event_type: 'harvest_confirmed', occurred_at: now, payload: { quantity: 10 + i } },
+    });
+    events.push({
+      event_id: `seed-e-p-${i}`,
+      type: 'farm_process_event',
+      attributes: { process_id: p.process_id, event_type: 'pest_management_confirmed', occurred_at: now, payload: { method: 'biopreparado bio' } },
+    });
+  });
+  return { processes, events };
+}
+
+async function stubAuth(page) {
+  await page.evaluate(() => new Promise((resolve, reject) => {
+    const put = (db) => {
+      const tx = db.transaction('syncQueue', 'readwrite');
+      const s = tx.objectStore('syncQueue');
+      s.put('stub-token-for-ui-screenshot', 'farmos_access_token');
+      s.put(Date.now() + 3600e3, 'farmos_token_expiry');
+      tx.oncomplete = () => { db.close(); resolve('ok'); };
+      tx.onerror = () => reject(tx.error);
+    };
+    const o = indexedDB.open('Chagra');
+    o.onupgradeneeded = () => { try { o.result.createObjectStore('syncQueue'); } catch { /* */ } };
+    o.onerror = () => reject(o.error);
+    o.onsuccess = () => {
+      const db = o.result;
+      if (db.objectStoreNames.contains('syncQueue')) return put(db);
+      const v = db.version + 1; db.close();
+      const up = indexedDB.open('Chagra', v);
+      up.onupgradeneeded = () => up.result.createObjectStore('syncQueue');
+      up.onsuccess = () => put(up.result);
+      up.onerror = () => reject(up.error);
+    };
+  }));
+}
+
+// Inserta procesos/eventos en la DB del app (ya creada/migrada por el app).
+async function seedFarm(page, data) {
+  await page.evaluate(({ processes, events }) => new Promise((resolve, reject) => {
+    const o = indexedDB.open('ChagraDB');
+    o.onerror = () => reject(o.error);
+    o.onsuccess = () => {
+      const db = o.result;
+      if (!db.objectStoreNames.contains('farm_processes')) { db.close(); return resolve('no-store'); }
+      const tx = db.transaction(['farm_processes', 'farm_process_events'], 'readwrite');
+      const ps = tx.objectStore('farm_processes');
+      const es = tx.objectStore('farm_process_events');
+      processes.forEach((p) => ps.put(p));
+      events.forEach((e) => es.put(e));
+      tx.oncomplete = () => { db.close(); resolve('ok'); };
+      tx.onerror = () => { db.close(); reject(tx.error); };
+    };
+  }), data);
+}
+
+async function gotoJuego(page) {
+  await page.evaluate(() => { window.location.hash = '#dashboard'; });
+  await sleep(400);
+  // Navega por evento global (mismo canal que ScreenShell) → vista 'juego'.
+  await page.evaluate(() => window.dispatchEvent(new CustomEvent('chagra:nav', { detail: 'juego' })));
+  await page.waitForSelector('[data-testid="mi-finca-viva-screen"]', { timeout: 30000 });
+  await sleep(1200); // dejar correr animaciones de crecimiento
+}
+
+(async () => {
+  const browser = await chromium.launch({
+    executablePath: resolveChromium(), headless: true,
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-software-rasterizer'],
+  });
+  const ctx = await browser.newContext({ viewport: { width: 412, height: 915 }, locale: 'es-CO', deviceScaleFactor: 2, isMobile: true });
+
+  await ctx.route('**/*', (route) => {
+    const u = route.request().url();
+    if (/\/(jsonapi|api|sites|oauth|fincas)(\/|$|\?)/.test(u.replace(BASE, ''))) {
+      const isJsonApi = /jsonapi/.test(u);
+      return route.fulfill({
+        status: 200,
+        contentType: isJsonApi ? 'application/vnd.api+json' : 'application/json',
+        body: JSON.stringify(isJsonApi ? { data: [], meta: {}, links: {} } : {}),
+      });
+    }
+    return route.continue();
+  });
+
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(60000);
+  const errs = [];
+  page.on('pageerror', (e) => errs.push(`[pageerror] ${e.message}`));
+  page.on('console', (m) => { if (m.type() === 'error') errs.push(`[console] ${m.text()}`); });
+
+  const shot = async (name) => {
+    const path = `${OUT_DIR}/${name}`;
+    await page.screenshot({ path, fullPage: true });
+    console.log(`  saved ${path}`);
+  };
+
+  try {
+    // Boot + auth
+    await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 40000 });
+    await stubAuth(page);
+    await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 40000 });
+    await sleep(1500);
+
+    // 1) FINCA VACÍA — sin seed
+    console.log('[1/3] finca vacía');
+    await gotoJuego(page);
+    await shot('juego-julieta-1-vacia.png');
+
+    // 2) FINCA PRÓSPERA — seed + recargar para que el juego lea los datos.
+    //    Pre-sella lastLevel alto para NO disparar la celebración acá.
+    console.log('[2/3] finca próspera');
+    await seedFarm(page, seedData());
+    await page.evaluate(() => {
+      try { localStorage.setItem('chagra:juego-finca:default', JSON.stringify({ lastLevel: 4, misionesHechas: [] })); } catch { /* */ }
+    });
+    await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 40000 });
+    await sleep(1200);
+    await gotoJuego(page);
+    await shot('juego-julieta-2-prospera.png');
+
+    // 3) CELEBRACIÓN — bajar lastLevel a 0 para que detecte subida.
+    console.log('[3/3] celebración subida de nivel');
+    await page.evaluate(() => {
+      try { localStorage.setItem('chagra:juego-finca:default', JSON.stringify({ lastLevel: 0, misionesHechas: [] })); } catch { /* */ }
+    });
+    await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 40000 });
+    await sleep(1200);
+    await gotoJuego(page);
+    // La celebración es overlay; esperar a que aparezca.
+    try {
+      await page.waitForSelector('[data-testid="level-up-celebration"]', { timeout: 8000 });
+    } catch {
+      console.log('  (celebración no apareció — el seed quizá no subió de nivel)');
+    }
+    await sleep(800);
+    await shot('juego-julieta-3-celebracion.png');
+
+    console.log('\n=== page errors ===');
+    console.log(errs.length ? errs.slice(0, 20).join('\n') : '(ninguno)');
+  } catch (e) {
+    console.error('FALLO:', e.message);
+    try { await shot('juego-julieta-ERROR.png'); } catch { /* */ }
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+})();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,7 @@ const TopBar = lazy(() => import('./components/TopBar'));
 const DashboardLive = lazy(() => import('./components/dashboard/DashboardLive'));
 const HoyEnFincaScreen = lazy(() => import('./components/hoy/HoyEnFincaScreen'));
 const MiFincaEvolucionScreen = lazy(() => import('./components/hoy/MiFincaEvolucionScreen'));
+const MiFincaVivaScreen = lazy(() => import('./components/juego/MiFincaVivaScreen'));
 // Modo extensionista (panel supervisor multi-finca, ADR-048 MVP). Gateado por
 // feature flag VITE_FEATURE_EXTENSIONISTA + rol (ver config/extensionistaAccess).
 const ExtensionistaScreen = lazy(() => import('./components/ExtensionistaScreen'));
@@ -772,6 +773,21 @@ export default function App() {
         return (
           <ErrorBoundary>
             <MiFincaEvolucionScreen
+              onBack={() => navigate('hoy_finca')}
+              onHome={() => navigate('dashboard')}
+              onNavigate={navigate}
+            />
+          </ErrorBoundary>
+        );
+      case 'juego':
+        // "Mi Finca Viva": capa LÚDICA kid-friendly sobre el motor de evolución
+        // (fincaEvolutionService → fincaGameService). Mundo que crece + criaturas
+        // + misiones ligadas a acciones reales + GUATOC. Pensado para que una
+        // niña juegue (audio TTS, botones grandes). Cero fabricación: todo se
+        // deriva de los indicadores reales; sin datos, invita a sembrar.
+        return (
+          <ErrorBoundary>
+            <MiFincaVivaScreen
               onBack={() => navigate('hoy_finca')}
               onHome={() => navigate('dashboard')}
               onNavigate={navigate}

--- a/src/components/hoy/HoyEnFincaScreen.jsx
+++ b/src/components/hoy/HoyEnFincaScreen.jsx
@@ -179,6 +179,26 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
                     onNavigate={onNavigate}
                 />
 
+                {/* ── 0c. MI FINCA VIVA — el modo juego kid-friendly ─────────
+                    Misma evolución real (fincaEvolutionService), presentada como
+                    un mundo que crece para que una niña juegue: criaturas,
+                    misiones, audio. Rutea a la pantalla 'juego'. */}
+                <button
+                    type="button"
+                    data-testid="entrada-juego-finca"
+                    onClick={() => onNavigate?.('juego')}
+                    className="w-full text-left rounded-2xl p-4 bg-gradient-to-br from-emerald-600/40 to-teal-700/40 border-2 border-emerald-400/40 hover:border-emerald-300/60 active:scale-[0.99] transition flex items-center gap-3"
+                >
+                    <span className="text-4xl shrink-0" aria-hidden="true">🌱</span>
+                    <span className="flex-1 min-w-0">
+                        <span className="block text-base font-black text-white">Mi Finca Viva</span>
+                        <span className="block text-sm text-emerald-100/90 leading-snug">
+                            Mirá crecer tu finca como un mundo: criaturas, misiones y aventuras. ¡Para jugar en familia!
+                        </span>
+                    </span>
+                    <ChevronRight size={22} className="text-emerald-200 shrink-0" aria-hidden="true" />
+                </button>
+
                 {/* ── 1. CLIMA DE HOY (honesto) ─────────────────────────── */}
                 {!geo ? (
                     <section className="bg-slate-900/60 backdrop-blur-xl border border-slate-800 rounded-2xl p-4">

--- a/src/components/hoy/HoyEnFincaScreen.jsx
+++ b/src/components/hoy/HoyEnFincaScreen.jsx
@@ -193,7 +193,7 @@ export default function HoyEnFincaScreen({ onBack, onHome, onNavigate }) {
                     <span className="flex-1 min-w-0">
                         <span className="block text-base font-black text-white">Mi Finca Viva</span>
                         <span className="block text-sm text-emerald-100/90 leading-snug">
-                            Mirá crecer tu finca como un mundo: criaturas, misiones y aventuras. ¡Para jugar en familia!
+                            Mira crecer tu finca como un mundo: criaturas, misiones y aventuras. ¡Para jugar en familia!
                         </span>
                     </span>
                     <ChevronRight size={22} className="text-emerald-200 shrink-0" aria-hidden="true" />

--- a/src/components/hoy/MiFincaEvolucionScreen.jsx
+++ b/src/components/hoy/MiFincaEvolucionScreen.jsx
@@ -149,7 +149,7 @@ export default function MiFincaEvolucionScreen({ onBack, onHome, onNavigate }) {
           </div>
           <p className="text-sm text-slate-300 leading-relaxed">
             Acá no hay puntos ni medallas: tu finca evoluciona con el trabajo real.
-            Cada cosecha, biopreparado, siembra y observación que registrás mueve
+            Cada cosecha, biopreparado, siembra y observación que registras mueve
             estos indicadores. Así medimos cómo va tu transición hacia la agroecología.
           </p>
           <div className="mt-3 pt-3 border-t border-emerald-800/40">
@@ -256,7 +256,7 @@ export default function MiFincaEvolucionScreen({ onBack, onHome, onNavigate }) {
         <div className="flex items-start gap-2 pt-1">
           <Info size={14} className="text-slate-500 shrink-0 mt-0.5" aria-hidden="true" />
           <p className="text-xs text-slate-500 leading-relaxed">
-            Los indicadores sin datos se irán llenando a medida que registrás el
+            Los indicadores sin datos se irán llenando a medida que registras el
             trabajo de tu finca. No inventamos cifras: lo que no se puede medir aún,
             se dice tal cual.
           </p>

--- a/src/components/juego/CriaturaCollection.jsx
+++ b/src/components/juego/CriaturaCollection.jsx
@@ -1,0 +1,90 @@
+import { Volume2 } from 'lucide-react';
+
+/**
+ * CriaturaCollection — la galería de criaturas coleccionables.
+ *
+ * Muestra TODAS las criaturas: las desbloqueadas con su emoji a todo color y un
+ * botón de audio (TTS) para que una niña que lee poco oiga el logro; las que
+ * faltan, en silueta gris con una PISTA de cómo conseguirlas (sin mentir: la
+ * pista apunta a una acción real de la finca).
+ *
+ * Cero fabricación: el estado desbloqueada/bloqueada lo decide fincaGameService
+ * desde indicadores reales. Acá solo se pinta.
+ *
+ * @param {Object} props
+ * @param {Array}  props.criaturas   [{id,nombre,emoji,pista,logro,desbloqueada}]
+ * @param {number} props.vivas       conteo de desbloqueadas
+ * @param {number} props.total       total de criaturas
+ * @param {Function} [props.onHablar] (texto) => narra con TTS
+ */
+export default function CriaturaCollection({ criaturas = [], vivas = 0, total = 0, onHablar }) {
+  return (
+    <section
+      data-testid="criatura-collection"
+      className="bg-gradient-to-br from-emerald-950/70 to-teal-950/50 backdrop-blur-xl border border-emerald-800/40 rounded-3xl p-4"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-black text-white flex items-center gap-2">
+          🦋 Mis criaturas
+        </h3>
+        <span
+          className="text-sm font-black text-emerald-200 bg-emerald-800/50 rounded-full px-3 py-1"
+          aria-label={`Tenés ${vivas} de ${total} criaturas`}
+        >
+          {vivas} / {total}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+        {criaturas.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            data-testid={`criatura-${c.id}`}
+            data-unlocked={c.desbloqueada ? 'true' : 'false'}
+            onClick={() => onHablar?.(c.desbloqueada ? c.logro : c.pista)}
+            className={[
+              'relative flex flex-col items-center justify-center gap-1 rounded-2xl p-3 min-h-[88px]',
+              'border transition active:scale-95',
+              c.desbloqueada
+                ? 'bg-emerald-800/40 border-emerald-500/50'
+                : 'bg-slate-800/40 border-slate-700/40',
+            ].join(' ')}
+            aria-label={
+              c.desbloqueada
+                ? `${c.nombre}: desbloqueada. ${c.logro}`
+                : `${c.nombre}: bloqueada. Pista: ${c.pista}`
+            }
+          >
+            <span
+              className={c.desbloqueada ? 'text-4xl' : 'text-4xl grayscale opacity-30'}
+              aria-hidden="true"
+            >
+              {c.desbloqueada ? c.emoji : '❔'}
+            </span>
+            <span
+              className={[
+                'text-xs font-bold text-center leading-tight',
+                c.desbloqueada ? 'text-emerald-100' : 'text-slate-500',
+              ].join(' ')}
+            >
+              {c.desbloqueada ? c.nombre : '???'}
+            </span>
+            {onHablar && (
+              <Volume2
+                size={13}
+                className="absolute top-1.5 right-1.5 text-emerald-300/60"
+                aria-hidden="true"
+              />
+            )}
+          </button>
+        ))}
+      </div>
+
+      <p className="text-xs text-emerald-200/70 mt-3 leading-relaxed">
+        Tocá una criatura para oír su secreto. Las criaturas llegan solitas cuando
+        cuidás tu finca: más plantas, suelo sano y nada de venenos. 🌱
+      </p>
+    </section>
+  );
+}

--- a/src/components/juego/CriaturaCollection.jsx
+++ b/src/components/juego/CriaturaCollection.jsx
@@ -29,7 +29,7 @@ export default function CriaturaCollection({ criaturas = [], vivas = 0, total = 
         </h3>
         <span
           className="text-sm font-black text-emerald-200 bg-emerald-800/50 rounded-full px-3 py-1"
-          aria-label={`Tenés ${vivas} de ${total} criaturas`}
+          aria-label={`Tienes ${vivas} de ${total} criaturas`}
         >
           {vivas} / {total}
         </span>
@@ -83,7 +83,7 @@ export default function CriaturaCollection({ criaturas = [], vivas = 0, total = 
 
       <p className="text-xs text-emerald-200/70 mt-3 leading-relaxed">
         Tocá una criatura para oír su secreto. Las criaturas llegan solitas cuando
-        cuidás tu finca: más plantas, suelo sano y nada de venenos. 🌱
+        cuidas tu finca: más plantas, suelo sano y nada de venenos. 🌱
       </p>
     </section>
   );

--- a/src/components/juego/FincaWorldScene.jsx
+++ b/src/components/juego/FincaWorldScene.jsx
@@ -1,0 +1,208 @@
+import { useMemo } from 'react';
+
+/**
+ * FincaWorldScene — el MUNDO ilustrado de "Mi Finca Viva" que crece.
+ *
+ * Dibuja una finca con SVG inline (offline-first, cero imágenes externas) que
+ * se transforma visiblemente según el nivel (0-4): más árboles, más color, más
+ * vida y las criaturas REALMENTE desbloqueadas volando/correteando. Animaciones
+ * suaves vía juego-finca.css (respetan prefers-reduced-motion).
+ *
+ * NADA acá inventa progreso: recibe el `stage` (mundo del nivel real) y las
+ * `criaturas` ya derivadas de datos reales por fincaGameService. Si la finca
+ * está vacía, dibuja la tierra esperando + una semillita.
+ *
+ * @param {Object} props
+ * @param {Object} props.stage       WORLD_STAGES[nivel] (cielo, tierra, arboles, vida)
+ * @param {Array}  props.criaturas   criaturas con {emoji, desbloqueada}
+ * @param {boolean} [props.vacia]    finca sin datos → mundo "esperando"
+ */
+export default function FincaWorldScene({ stage, criaturas = [], vacia = false }) {
+  // Posiciones DETERMINISTAS (no aleatorias entre renders): así el mundo es
+  // estable y reconocible para la niña, no parpadea de forma distinta cada vez.
+  const arboles = useMemo(() => {
+    const n = vacia ? 0 : stage?.arboles || 0;
+    const slots = [];
+    for (let i = 0; i < n; i += 1) {
+      const x = 30 + (i * 47) % 340;
+      const baseY = 168 + ((i * 13) % 22);
+      const scale = 0.72 + ((i * 7) % 30) / 100;
+      const tipo = i % 3; // 3 estilos de copa para variedad
+      slots.push({ x, baseY, scale, tipo, key: `t${i}` });
+    }
+    return slots;
+  }, [stage, vacia]);
+
+  // Plantitas/arbustos pequeños = "vida" del suelo.
+  const matas = useMemo(() => {
+    const n = vacia ? 0 : Math.min(stage?.vida || 0, 8);
+    const slots = [];
+    for (let i = 0; i < n; i += 1) {
+      const x = 50 + (i * 41) % 320;
+      const y = 192 + ((i * 9) % 16);
+      slots.push({ x, y, key: `m${i}` });
+    }
+    return slots;
+  }, [stage, vacia]);
+
+  // Criaturas vivas (desbloqueadas) sobrevolando el mundo. Máximo unas pocas
+  // para no saturar — la colección completa se ve en la galería.
+  const criaturasVivas = useMemo(
+    () => criaturas.filter((c) => c.desbloqueada).slice(0, 6),
+    [criaturas],
+  );
+
+  const [cieloA, cieloB] = stage?.cielo || ['#bcd9e8', '#e8f3ee'];
+  const [tierraA, tierraB] = stage?.tierra || ['#c9a878', '#a98a5e'];
+  const gradId = `fv-sky-${stage?.level ?? 0}`;
+  const gradTierra = `fv-soil-${stage?.level ?? 0}`;
+
+  return (
+    <div
+      className="fv-scene"
+      data-testid="finca-world-scene"
+      data-level={stage?.level ?? 0}
+      role="img"
+      aria-label={
+        vacia
+          ? 'Tu finca está esperando que siembres tu primera planta.'
+          : `Tu finca en la etapa ${stage?.nombreNino}: ${stage?.mensaje}`
+      }
+    >
+      <svg viewBox="0 0 400 240" preserveAspectRatio="xMidYMid slice" aria-hidden="true">
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={cieloA} />
+            <stop offset="100%" stopColor={cieloB} />
+          </linearGradient>
+          <linearGradient id={gradTierra} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={tierraB} />
+            <stop offset="100%" stopColor={tierraA} />
+          </linearGradient>
+        </defs>
+
+        {/* Cielo */}
+        <rect x="0" y="0" width="400" height="240" fill={`url(#${gradId})`} />
+
+        {/* Sol — más cálido a mayor nivel */}
+        <g className="fv-sun">
+          <circle cx="330" cy="48" r="26" fill="#ffe08a" opacity="0.95" />
+          <circle cx="330" cy="48" r="18" fill="#ffd24d" />
+        </g>
+
+        {/* Nubes */}
+        <g className="fv-cloud" fill="#ffffff" opacity="0.85">
+          <ellipse cx="80" cy="44" rx="26" ry="13" />
+          <ellipse cx="100" cy="40" rx="20" ry="14" />
+          <ellipse cx="62" cy="40" rx="16" ry="11" />
+        </g>
+        <g className="fv-cloud-2" fill="#ffffff" opacity="0.7">
+          <ellipse cx="210" cy="64" rx="22" ry="11" />
+          <ellipse cx="228" cy="60" rx="16" ry="11" />
+        </g>
+
+        {/* Colinas de fondo (más verdes a mayor nivel) */}
+        <path
+          d="M0 180 Q100 140 200 172 T400 168 V240 H0 Z"
+          fill={tierraB}
+          opacity="0.5"
+        />
+
+        {/* Tierra / suelo */}
+        <rect x="0" y="186" width="400" height="54" fill={`url(#${gradTierra})`} />
+        <path
+          d="M0 186 Q100 176 200 184 T400 182 V200 H0 Z"
+          fill={tierraB}
+          opacity="0.45"
+        />
+
+        {/* Árboles que crecen con el nivel */}
+        {arboles.map((t, i) => (
+          <g
+            key={t.key}
+            className={`fv-grow ${i % 2 === 0 ? 'fv-sway' : 'fv-sway-slow'}`}
+            transform={`translate(${t.x} ${t.baseY}) scale(${t.scale})`}
+            style={{ animationDelay: `${i * 0.08}s` }}
+          >
+            {/* tronco */}
+            <rect x="-4" y="0" width="8" height="26" rx="3" fill="#7a5230" />
+            {/* copa según tipo */}
+            {t.tipo === 0 && (
+              <>
+                <circle cx="0" cy="-10" r="20" fill="#3f8f4e" />
+                <circle cx="-12" cy="-2" r="13" fill="#4ca35c" />
+                <circle cx="12" cy="-2" r="13" fill="#4ca35c" />
+              </>
+            )}
+            {t.tipo === 1 && (
+              <>
+                <ellipse cx="0" cy="-12" rx="16" ry="22" fill="#46985a" />
+                <ellipse cx="0" cy="-12" rx="9" ry="15" fill="#5bb06e" />
+              </>
+            )}
+            {t.tipo === 2 && (
+              <>
+                <circle cx="0" cy="-14" r="16" fill="#3f8f4e" />
+                <circle cx="0" cy="0" r="14" fill="#4ca35c" />
+                {/* frutos cuando ya hay bosque (niveles altos) */}
+                {(stage?.level ?? 0) >= 3 && (
+                  <>
+                    <circle cx="-6" cy="-10" r="3" fill="#ff7a59" />
+                    <circle cx="7" cy="-2" r="3" fill="#ffb74d" />
+                  </>
+                )}
+              </>
+            )}
+          </g>
+        ))}
+
+        {/* Matas / plantitas del suelo vivo */}
+        {matas.map((m, i) => (
+          <g
+            key={m.key}
+            className="fv-grow"
+            transform={`translate(${m.x} ${m.y})`}
+            style={{ animationDelay: `${0.3 + i * 0.06}s` }}
+          >
+            <path d="M0 12 Q-6 0 -2 -6" stroke="#4ca35c" strokeWidth="3" fill="none" strokeLinecap="round" />
+            <path d="M0 12 Q6 0 2 -6" stroke="#4ca35c" strokeWidth="3" fill="none" strokeLinecap="round" />
+            <path d="M0 12 V-2" stroke="#46985a" strokeWidth="3" fill="none" strokeLinecap="round" />
+            {(stage?.level ?? 0) >= 2 && <circle cx="0" cy="-7" r="3" fill="#ff9ec4" />}
+          </g>
+        ))}
+
+        {/* Semillita cuando la finca está esperando (vacía) */}
+        {vacia && (
+          <g transform="translate(200 196)" className="fv-grow">
+            <ellipse cx="0" cy="4" rx="9" ry="6" fill="#8a6a3a" />
+            <path d="M0 -2 Q-4 -10 0 -16 Q4 -10 0 -2" fill="#5bb06e" />
+          </g>
+        )}
+      </svg>
+
+      {/* Criaturas vivas — emojis flotando sobre el mundo (animadas, accesibles) */}
+      {!vacia && criaturasVivas.length > 0 && (
+        <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+          {criaturasVivas.map((c, i) => {
+            const left = 12 + ((i * 31) % 70);
+            const top = 12 + ((i * 19) % 42);
+            return (
+              <span
+                key={c.id}
+                className="fv-float absolute select-none"
+                style={{
+                  left: `${left}%`,
+                  top: `${top}%`,
+                  fontSize: '1.7rem',
+                  animationDelay: `${i * 0.5}s`,
+                }}
+              >
+                {c.emoji}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/juego/LevelUpCelebration.jsx
+++ b/src/components/juego/LevelUpCelebration.jsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo } from 'react';
+import { Sparkles } from 'lucide-react';
+
+/**
+ * LevelUpCelebration — la fiesta cuando la finca sube de nivel.
+ *
+ * Overlay alegre con confeti de emojis, el nombre del nuevo mundo y un botón
+ * grande para seguir. Dispara sonido (agentSoundService.chime) y, si la niña
+ * tiene audio, narra el logro con TTS (kokoro/Web Speech) al montar.
+ *
+ * Se muestra UNA sola vez por subida (la pantalla controla cuándo, comparando
+ * el nivel actual con el último visto persistido). Cero fabricación: solo
+ * aparece cuando el nivel REAL (derivado de indicadores) subió.
+ *
+ * @param {Object} props
+ * @param {Object} props.mundo        WORLD_STAGES del nuevo nivel
+ * @param {Function} props.onClose    cerrar la celebración
+ * @param {Function} [props.onSound]  reproducir sonido de celebración
+ * @param {Function} [props.onNarrate] narrar el logro (TTS)
+ */
+export default function LevelUpCelebration({ mundo, onClose, onSound, onNarrate }) {
+  useEffect(() => {
+    onSound?.();
+    onNarrate?.();
+    // Se ejecuta una sola vez al montar la celebración.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Confeti determinista (no salta entre renders del overlay).
+  const confetti = useMemo(() => {
+    const piezas = ['🌟', '🌿', '🦋', '🌸', '✨', '🍃', '🌻', '🐝'];
+    return Array.from({ length: 18 }, (_, i) => ({
+      key: `c${i}`,
+      emoji: piezas[i % piezas.length],
+      left: (i * 53) % 100,
+      delay: (i % 6) * 0.4,
+      dur: 3 + (i % 4),
+    }));
+  }, []);
+
+  if (!mundo) return null;
+
+  return (
+    <div
+      className="fv-celebration-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Tu finca subió de nivel: ${mundo.nombreNino}`}
+      data-testid="level-up-celebration"
+      onClick={onClose}
+    >
+      {confetti.map((c) => (
+        <span
+          key={c.key}
+          className="fv-confetti"
+          style={{ left: `${c.left}%`, animationDelay: `${c.delay}s`, animationDuration: `${c.dur}s` }}
+          aria-hidden="true"
+        >
+          {c.emoji}
+        </span>
+      ))}
+
+      <div
+        className="fv-celebration-card bg-gradient-to-br from-emerald-700 to-teal-800 border-4 border-emerald-300/60 rounded-3xl p-7 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="fv-celebration-emoji" aria-hidden="true">{mundo.emoji}</div>
+        <div className="flex items-center justify-center gap-2 mt-3">
+          <Sparkles size={22} className="text-yellow-300" aria-hidden="true" />
+          <p className="text-yellow-200 font-black text-sm uppercase tracking-widest">
+            ¡Subiste de nivel!
+          </p>
+          <Sparkles size={22} className="text-yellow-300" aria-hidden="true" />
+        </div>
+        <h2 className="text-2xl font-black text-white mt-2 leading-tight">
+          {mundo.nombreNino}
+        </h2>
+        <p className="text-emerald-50 text-base mt-3 leading-relaxed">{mundo.mensaje}</p>
+
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-6 w-full min-h-[56px] rounded-2xl bg-yellow-400 hover:bg-yellow-300 active:scale-95 transition text-emerald-950 font-black text-lg shadow-lg"
+        >
+          ¡Seguir jugando! 🎉
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -1,0 +1,335 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Sparkles, Volume2, VolumeX, Trophy, Sprout } from 'lucide-react';
+import { ScreenShell } from '../common/ScreenShell';
+import FincaWorldScene from './FincaWorldScene';
+import CriaturaCollection from './CriaturaCollection';
+import MisionCard from './MisionCard';
+import LevelUpCelebration from './LevelUpCelebration';
+import './juego-finca.css';
+
+import { listFarmProcesses, getFarmEvents } from '../../db/farmProcessCache';
+import { getProfile } from '../../services/userProfileService';
+import {
+  buildFincaGameState,
+  detectLevelUp,
+  narrarFinca,
+} from '../../services/fincaGameService';
+import {
+  getGameState,
+  setLastLevel,
+  markMissionDone,
+  getMisionesHechasSet,
+} from '../../services/fincaGameStateService';
+import { agentSounds, isSoundEnabled, setSoundEnabled } from '../../services/agentSoundService';
+import { speak, stop as stopSpeak, isSupported as ttsSupported } from '../../services/ttsService';
+
+/**
+ * MiFincaVivaScreen — el JUEGO "Mi Finca Viva" para Julieta (y toda niña).
+ *
+ * Una capa lúdica ENCIMA del motor de evolución de finca: la finca es un mundo
+ * vivo que florece a medida que los indicadores REALES suben (fincaEvolution
+ * Service vía fincaGameService). No reemplaza la pantalla seria
+ * "Cómo evoluciona tu finca" — es un modo alegre y accesible para una niña.
+ *
+ * Mecánicas (todas derivadas de datos reales, cero fabricación):
+ *   - Mundo que crece (FincaWorldScene) por nivel Gliessman 0-4.
+ *   - Criaturas coleccionables (CriaturaCollection) que aparecen con la
+ *     biodiversidad real.
+ *   - Misiones (MisionCard) ligadas a acciones reales + fichas GUATOC.
+ *   - Insignias por hitos reales.
+ *   - Celebración (LevelUpCelebration) + sonido + audio (TTS) al subir.
+ *
+ * Accesible para una niña que lee poco: botones grandes (min 44-56px), textos
+ * cortos, AUDIO en todo (TTS kokoro/Web Speech), colores vivos, alto contraste.
+ * Offline-first: lee la cache local de procesos; sin datos → invita a sembrar.
+ *
+ * @param {Object} props
+ * @param {Function} [props.onBack]
+ * @param {Function} [props.onHome]
+ * @param {Function} [props.onNavigate]
+ */
+export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
+  const profile = useMemo(() => getProfile() || {}, []);
+  const fincaSlug = profile.fincaSlug || profile.slug || 'default';
+
+  // Audio on/off — comparte la preferencia con el sonido del agente, así un solo
+  // toque silencia todo. Una niña puede preferir con o sin sonido.
+  const [audioOn, setAudioOn] = useState(() => isSoundEnabled());
+
+  // Procesos reales de la finca (offline-first; si IDB falla → [] honesto).
+  const [processes, setProcesses] = useState([]);
+  const [cargando, setCargando] = useState(true);
+  useEffect(() => {
+    let alive = true;
+    listFarmProcesses({ status: 'active' })
+      .then(async (list) => {
+        const arr = Array.isArray(list) ? list : [];
+        // Hidrata los eventos de cada proceso (cosechas, biopreparados,
+        // observaciones) para que los indicadores que dependen de eventos
+        // realmente prendan. Si falla, el proceso queda sin events (honesto).
+        const conEventos = await Promise.all(
+          arr.map(async (p) => {
+            try {
+              const events = await getFarmEvents(p.process_id);
+              return { ...p, events: Array.isArray(events) ? events : [] };
+            } catch {
+              return { ...p, events: [] };
+            }
+          }),
+        );
+        if (alive) setProcesses(conEventos);
+      })
+      .catch(() => { /* IDB falló: mundo vacío honesto, nunca datos inventados */ })
+      .finally(() => { if (alive) setCargando(false); });
+    return () => { alive = false; };
+  }, []);
+
+  // Misiones de "aprender" marcadas a mano (persistidas por finca).
+  const [misionesHechas, setMisionesHechas] = useState(() => getMisionesHechasSet(fincaSlug));
+
+  // Estado de juego completo — TODO derivado de datos reales.
+  const game = useMemo(
+    () => buildFincaGameState({ processes, observations: [], misionesHechas }),
+    [processes, misionesHechas],
+  );
+
+  // Detección de subida de nivel vs el último nivel visto (persistido).
+  // El nivel base se captura UNA vez al montar (estado lazy, legible en render):
+  // comparamos el nivel real de ahora contra lo que la niña vio la última vez,
+  // sin setState en efecto (evita renders en cascada). `descartada` cierra la
+  // fiesta.
+  const [baselineLevel] = useState(() => getGameState(fincaSlug).lastLevel);
+  const [celebracionDescartada, setCelebracionDescartada] = useState(false);
+  const subioNivel = !cargando && detectLevelUp(game.nivel, baselineLevel).subio;
+  const celebrando = subioNivel && !celebracionDescartada;
+
+  // Sella el nivel actual como "visto" (la celebración no se repite al volver).
+  // Persistir es sincronización con un sistema externo (localStorage): efecto OK.
+  useEffect(() => {
+    if (cargando) return;
+    setLastLevel(fincaSlug, game.nivel);
+  }, [cargando, game.nivel, fincaSlug]);
+
+  // Narrar con TTS (si hay audio y soporte). Texto corto y alegre.
+  const hablar = useCallback((texto) => {
+    if (!audioOn || !texto) return;
+    try {
+      if (ttsSupported()) {
+        speak(texto, { rate: 0.95, pitch: 1.05 });
+      }
+    } catch { /* TTS no disponible: el juego sigue sin audio */ }
+  }, [audioOn]);
+
+  // Al entrar (una vez cargado), saludar con audio describiendo la finca.
+  useEffect(() => {
+    if (cargando || celebrando) return;
+    hablar(narrarFinca(game));
+    // Solo el saludo inicial; no re-narra en cada render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cargando]);
+
+  const toggleAudio = useCallback(() => {
+    const next = !audioOn;
+    setAudioOn(next);
+    setSoundEnabled(next);
+    if (!next) {
+      try { stopSpeak(); } catch { /* noop */ }
+    } else {
+      try { agentSounds.listen(); } catch { /* noop */ }
+    }
+  }, [audioOn]);
+
+  const cerrarCelebracion = useCallback(() => {
+    setCelebracionDescartada(true);
+    try { stopSpeak(); } catch { /* noop */ }
+  }, []);
+
+  const irAccion = useCallback((nav) => {
+    try { agentSounds.start(); } catch { /* noop */ }
+    onNavigate?.(nav);
+  }, [onNavigate]);
+
+  const marcarMision = useCallback((id) => {
+    markMissionDone(fincaSlug, id);
+    setMisionesHechas(getMisionesHechasSet(fincaSlug));
+    try { agentSounds.chime(); } catch { /* noop */ }
+    hablar('¡Misión cumplida! Muy bien.');
+  }, [fincaSlug, hablar]);
+
+  const mundo = game.mundo;
+
+  return (
+    <ScreenShell title="Mi Finca Viva" icon={Sprout} onBack={onBack} onHome={onHome}>
+      <div
+        data-testid="mi-finca-viva-screen"
+        className="flex flex-col gap-4 px-4 pt-3 pb-10 max-w-2xl mx-auto"
+      >
+        {/* Encabezado lúdico + botón de audio grande */}
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-xs font-bold text-emerald-300/80 uppercase tracking-widest">
+              Nivel {game.nivel} de 4
+            </p>
+            <h2 className="text-2xl font-black text-white leading-tight flex items-center gap-2">
+              <span aria-hidden="true">{mundo.emoji}</span>
+              {mundo.nombreNino}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={toggleAudio}
+            aria-pressed={audioOn}
+            aria-label={audioOn ? 'Apagar el sonido' : 'Encender el sonido'}
+            className="shrink-0 min-h-[56px] min-w-[56px] rounded-2xl bg-emerald-700/60 hover:bg-emerald-600/60 active:scale-95 transition flex items-center justify-center text-white"
+          >
+            {audioOn ? <Volume2 size={26} /> : <VolumeX size={26} />}
+          </button>
+        </div>
+
+        {/* EL MUNDO que crece — el corazón visual */}
+        <FincaWorldScene stage={mundo} criaturas={game.criaturas} vacia={game.vacia} />
+
+        {/* Mensaje del mundo + botón de escuchar */}
+        <div className="bg-emerald-950/50 border border-emerald-800/40 rounded-2xl p-4 flex items-start gap-3">
+          <button
+            type="button"
+            onClick={() => hablar(narrarFinca(game))}
+            aria-label="Escuchar cómo está tu finca"
+            className="shrink-0 min-h-[48px] min-w-[48px] rounded-full bg-emerald-600 hover:bg-emerald-500 active:scale-95 transition flex items-center justify-center text-white"
+          >
+            <Volume2 size={22} aria-hidden="true" />
+          </button>
+          <div className="flex-1">
+            <p className="text-base text-emerald-50 font-medium leading-relaxed">{mundo.mensaje}</p>
+            <p className="text-xs text-emerald-300/70 mt-1">
+              Esto es de verdad: tu finca está en la etapa «{mundo.nombreReal}».
+            </p>
+          </div>
+        </div>
+
+        {/* Barra de progreso del mundo (alegre, pero honesta: % real) */}
+        <div>
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-sm font-bold text-emerald-200">Tu finca crece</span>
+            <span className="text-sm font-black text-emerald-300">{game.progreso}%</span>
+          </div>
+          <div className="h-4 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
+            <div
+              className="h-full bg-gradient-to-r from-emerald-500 via-lime-400 to-emerald-400 rounded-full transition-all duration-700"
+              style={{ width: `${Math.max(game.progreso, game.vacia ? 0 : 4)}%` }}
+              role="progressbar"
+              aria-valuenow={game.progreso}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`Tu finca está al ${game.progreso} por ciento`}
+            />
+          </div>
+          {game.mundoSiguiente && !game.vacia && (
+            <p className="text-xs text-emerald-300/70 mt-1.5">
+              Lo que sigue: {game.mundoSiguiente.emoji} {game.mundoSiguiente.nombreNino}
+            </p>
+          )}
+        </div>
+
+        {/* Estado VACÍO: invitar, nunca un mundo muerto */}
+        {game.vacia ? (
+          <section
+            data-testid="finca-vacia-invitacion"
+            className="bg-gradient-to-br from-amber-900/30 to-emerald-900/30 border-2 border-amber-400/40 rounded-3xl p-5 text-center"
+          >
+            <div className="text-5xl mb-2" aria-hidden="true">🌱</div>
+            <h3 className="text-xl font-black text-white">¡Empezá tu finca!</h3>
+            <p className="text-sm text-amber-50 mt-2 leading-relaxed">
+              Tu finca está esperando. Sembrá tu primera planta y mirá cómo cobra
+              vida: llegarán mariposas, abejas y muchas criaturas más.
+            </p>
+            <button
+              type="button"
+              onClick={() => irAccion('sembrar')}
+              className="mt-4 w-full min-h-[56px] rounded-2xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-black text-lg shadow-lg"
+            >
+              🌱 Sembrar mi primera planta
+            </button>
+          </section>
+        ) : (
+          <>
+            {/* Misiones */}
+            <section data-testid="misiones-juego" className="flex flex-col gap-3">
+              <h3 className="text-lg font-black text-white flex items-center gap-2">
+                🎯 Mis misiones
+                <span className="text-sm font-bold text-emerald-300 bg-emerald-800/50 rounded-full px-3 py-0.5">
+                  {game.misiones.filter((m) => m.cumplida).length} / {game.misiones.length}
+                </span>
+              </h3>
+              {game.misiones.map((m) => (
+                <MisionCard
+                  key={m.id}
+                  mision={m}
+                  onIr={irAccion}
+                  onMarcar={marcarMision}
+                  destacada={game.proximaMision?.id === m.id}
+                />
+              ))}
+            </section>
+          </>
+        )}
+
+        {/* Criaturas — siempre visible (con siluetas si están bloqueadas) */}
+        <CriaturaCollection
+          criaturas={game.criaturas}
+          vivas={game.criaturasVivas}
+          total={game.criaturas.length}
+          onHablar={audioOn ? hablar : undefined}
+        />
+
+        {/* Insignias ganadas */}
+        {game.insigniasGanadas > 0 && (
+          <section
+            data-testid="insignias-juego"
+            className="bg-gradient-to-br from-amber-950/50 to-yellow-950/30 border border-amber-700/40 rounded-3xl p-4"
+          >
+            <h3 className="text-lg font-black text-white flex items-center gap-2 mb-3">
+              <Trophy size={20} className="text-amber-300" aria-hidden="true" />
+              Mis insignias
+            </h3>
+            <div className="flex flex-wrap gap-3">
+              {game.insignias.filter((b) => b.ganada).map((b) => (
+                <div
+                  key={b.id}
+                  data-testid={`insignia-${b.id}`}
+                  className="flex flex-col items-center gap-1 bg-amber-900/30 border border-amber-500/40 rounded-2xl p-3 w-[88px]"
+                  title={b.descripcion}
+                >
+                  <span className="text-3xl" aria-hidden="true">{b.emoji}</span>
+                  <span className="text-[11px] font-bold text-amber-100 text-center leading-tight">
+                    {b.nombre}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Nota honesta para acompañantes (anti-paternalismo, cariño real) */}
+        <div className="flex items-start gap-2 pt-1">
+          <Sparkles size={14} className="text-emerald-500 shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-xs text-slate-400 leading-relaxed">
+            Este juego no inventa premios: tu finca crece de verdad con el trabajo
+            real. Cada planta que sembrás, cada cosecha y cada cuidado sin venenos
+            hace que tu mundo florezca. 🌿
+          </p>
+        </div>
+      </div>
+
+      {/* Celebración de subida de nivel */}
+      {celebrando && (
+        <LevelUpCelebration
+          mundo={mundo}
+          onClose={cerrarCelebracion}
+          onSound={() => { try { agentSounds.chime(); } catch { /* noop */ } }}
+          onNarrate={() => hablar(narrarFinca(game, { levelUp: true }))}
+        />
+      )}
+    </ScreenShell>
+  );
+}

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -240,7 +240,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
             <div className="text-5xl mb-2" aria-hidden="true">🌱</div>
             <h3 className="text-xl font-black text-white">¡Empezá tu finca!</h3>
             <p className="text-sm text-amber-50 mt-2 leading-relaxed">
-              Tu finca está esperando. Sembrá tu primera planta y mirá cómo cobra
+              Tu finca está esperando. Siembra tu primera planta y mira cómo cobra
               vida: llegarán mariposas, abejas y muchas criaturas más.
             </p>
             <button
@@ -315,7 +315,7 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
           <Sparkles size={14} className="text-emerald-500 shrink-0 mt-0.5" aria-hidden="true" />
           <p className="text-xs text-slate-400 leading-relaxed">
             Este juego no inventa premios: tu finca crece de verdad con el trabajo
-            real. Cada planta que sembrás, cada cosecha y cada cuidado sin venenos
+            real. Cada planta que siembras, cada cosecha y cada cuidado sin venenos
             hace que tu mundo florezca. 🌿
           </p>
         </div>

--- a/src/components/juego/MisionCard.jsx
+++ b/src/components/juego/MisionCard.jsx
@@ -1,0 +1,85 @@
+import { CheckCircle2, Circle, ArrowRight, BookOpenCheck } from 'lucide-react';
+
+/**
+ * MisionCard — una misión del juego, ligada a una acción REAL o a una ficha
+ * GUATOC.
+ *
+ * Botón grande y claro: si está cumplida, se ve verde con check; si no, invita
+ * a hacer la acción (rutea con onIr) y, si es de "aprender", permite marcarla a
+ * mano (onMarcar) porque leer no deja rastro en los indicadores.
+ *
+ * Cero fabricación: el estado `cumplida` lo decide fincaGameService desde datos
+ * reales (acciones) o desde lo que la niña marcó (aprender).
+ *
+ * @param {Object} props
+ * @param {Object} props.mision      {id,titulo,emoji,descripcion,cta,nav,tipo,cumplida}
+ * @param {Function} props.onIr      (nav) => navega a la vista para hacer la acción
+ * @param {Function} [props.onMarcar] (id) => marca una misión de aprender como hecha
+ * @param {boolean} [props.destacada] resáltala (es la próxima misión)
+ */
+export default function MisionCard({ mision, onIr, onMarcar, destacada = false }) {
+  const { id, titulo, emoji, descripcion, cta, nav, tipo, cumplida } = mision;
+
+  return (
+    <div
+      data-testid={`mision-${id}`}
+      data-done={cumplida ? 'true' : 'false'}
+      className={[
+        'rounded-2xl p-4 border transition',
+        cumplida
+          ? 'bg-emerald-800/30 border-emerald-500/40'
+          : destacada
+            ? 'bg-amber-900/25 border-amber-400/50 shadow-lg'
+            : 'bg-slate-800/40 border-slate-700/40',
+      ].join(' ')}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-3xl shrink-0" aria-hidden="true">{emoji}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            {cumplida ? (
+              <CheckCircle2 size={18} className="text-emerald-400 shrink-0" aria-hidden="true" />
+            ) : (
+              <Circle size={18} className="text-slate-500 shrink-0" aria-hidden="true" />
+            )}
+            <h4 className={[
+              'text-base font-black leading-tight',
+              cumplida ? 'text-emerald-100 line-through decoration-emerald-400/50' : 'text-white',
+            ].join(' ')}
+            >
+              {titulo}
+            </h4>
+          </div>
+          <p className="text-sm text-slate-300 mt-1 leading-snug">{descripcion}</p>
+
+          {!cumplida && (
+            <div className="flex flex-wrap gap-2 mt-3">
+              <button
+                type="button"
+                onClick={() => onIr?.(nav)}
+                className="inline-flex items-center gap-1.5 min-h-[44px] px-4 rounded-xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-bold text-sm"
+              >
+                {cta}
+                <ArrowRight size={15} aria-hidden="true" />
+              </button>
+              {tipo === 'aprender' && onMarcar && (
+                <button
+                  type="button"
+                  onClick={() => onMarcar(id)}
+                  className="inline-flex items-center gap-1.5 min-h-[44px] px-4 rounded-xl bg-slate-700/60 hover:bg-slate-600/60 active:scale-95 transition text-slate-100 font-bold text-sm"
+                >
+                  <BookOpenCheck size={15} aria-hidden="true" />
+                  Ya lo aprendí
+                </button>
+              )}
+            </div>
+          )}
+
+          {cumplida && (
+            <p className="text-xs font-bold text-emerald-300 mt-2">¡Misión cumplida! 🎉</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/juego/__tests__/MiFincaVivaScreen.test.jsx
+++ b/src/components/juego/__tests__/MiFincaVivaScreen.test.jsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import MiFincaVivaScreen from '../MiFincaVivaScreen';
+
+// IDB de procesos mockeada (por defecto finca vacía → invita a sembrar).
+const listFarmProcessesMock = vi.fn(() => Promise.resolve([]));
+const getFarmEventsMock = vi.fn(() => Promise.resolve([]));
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: (...args) => listFarmProcessesMock(...args),
+  getFarmEvents: (...args) => getFarmEventsMock(...args),
+}));
+
+// Perfil mínimo (sin red). ScreenShell → NotificationsBell usa otros exports.
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: () => ({ fincaSlug: 'finca-juli', vocacion: 'finca_diversificada' }),
+  };
+});
+
+// TTS: no hay Web Speech en jsdom; mockeamos para verificar que se invoca.
+const speakMock = vi.fn();
+vi.mock('../../../services/ttsService', () => ({
+  speak: (...a) => speakMock(...a),
+  stop: vi.fn(),
+  isSupported: () => true,
+}));
+
+// Sonido del agente: stub (Web Audio no existe en jsdom).
+vi.mock('../../../services/agentSoundService', () => ({
+  agentSounds: { chime: vi.fn(), listen: vi.fn(), start: vi.fn(), error: vi.fn(), cancel: vi.fn() },
+  isSoundEnabled: () => true,
+  setSoundEnabled: vi.fn(),
+}));
+
+// Procesos en el shape REAL de producción (anidado en `attributes`), tal como
+// los devuelve farmProcessCache. fincaGameService los aplana internamente.
+const fincaProspera = () =>
+  ['coffea_arabica', 'theobroma_cacao', 'musa_paradisiaca', 'persea_americana',
+    'phaseolus_vulgaris', 'zea_mays', 'inga_edulis', 'citrus_limon'].map((slug, i) => ({
+    process_id: `p${i}`,
+    type: 'farm_process',
+    attributes: {
+      process_type: i % 2 === 0 ? 'sowing' : 'agroforestry',
+      status: 'active',
+      current_stage: ['vegetative', 'flowering', 'fruiting', 'mature'][i % 4],
+      subject_slug: slug,
+      companions: i < 3 ? ['inga_edulis'] : [],
+    },
+  }));
+
+// Eventos reales (anidados) que getFarmEvents devolvería para cada proceso.
+const eventosProspera = () => [
+  { event_id: 'e1', type: 'farm_process_event', attributes: { event_type: 'harvest_confirmed', payload: { quantity: 12 }, occurred_at: 1 } },
+  { event_id: 'e2', type: 'farm_process_event', attributes: { event_type: 'pest_management_confirmed', payload: { method: 'biopreparado bio' }, occurred_at: 2 } },
+];
+
+describe('MiFincaVivaScreen', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    speakMock.mockClear();
+    listFarmProcessesMock.mockReset();
+    listFarmProcessesMock.mockResolvedValue([]);
+    getFarmEventsMock.mockReset();
+    getFarmEventsMock.mockResolvedValue([]);
+  });
+
+  /** Helper: configura una finca próspera (procesos + eventos hidratados). */
+  function setProspera() {
+    listFarmProcessesMock.mockResolvedValue(fincaProspera());
+    getFarmEventsMock.mockResolvedValue(eventosProspera());
+  }
+
+  it('monta el juego con su título y testid', async () => {
+    render(<MiFincaVivaScreen />);
+    expect(await screen.findByTestId('mi-finca-viva-screen')).toBeTruthy();
+    expect(screen.getAllByText('Mi Finca Viva').length).toBeGreaterThan(0);
+  });
+
+  it('lee los procesos de la cache local (offline-first)', async () => {
+    render(<MiFincaVivaScreen />);
+    await waitFor(() => expect(listFarmProcessesMock).toHaveBeenCalledWith({ status: 'active' }));
+  });
+
+  it('finca vacía: muestra la invitación a sembrar (no un mundo muerto)', async () => {
+    render(<MiFincaVivaScreen />);
+    expect(await screen.findByTestId('finca-vacia-invitacion')).toBeTruthy();
+    expect(screen.getByText('¡Empezá tu finca!')).toBeTruthy();
+  });
+
+  it('finca vacía: el botón de sembrar navega a la acción real', async () => {
+    const onNavigate = vi.fn();
+    render(<MiFincaVivaScreen onNavigate={onNavigate} />);
+    const btn = await screen.findByText('🌱 Sembrar mi primera planta');
+    fireEvent.click(btn);
+    expect(onNavigate).toHaveBeenCalledWith('sembrar');
+  });
+
+  it('siempre muestra la galería de criaturas (con siluetas si vacía)', async () => {
+    render(<MiFincaVivaScreen />);
+    expect(await screen.findByTestId('criatura-collection')).toBeTruthy();
+    // Vacía → todas bloqueadas
+    const quetzal = screen.getByTestId('criatura-quetzal');
+    expect(quetzal.getAttribute('data-unlocked')).toBe('false');
+  });
+
+  it('finca próspera: muestra misiones y desbloquea criaturas', async () => {
+    setProspera();
+    render(<MiFincaVivaScreen />);
+    expect(await screen.findByTestId('misiones-juego')).toBeTruthy();
+    // mariposa desbloqueada con diversidad real
+    await waitFor(() => {
+      const mariposa = screen.getByTestId('criatura-mariposa');
+      expect(mariposa.getAttribute('data-unlocked')).toBe('true');
+    });
+  });
+
+  it('finca próspera: el mundo crece de nivel (escena con data-level > 0)', async () => {
+    setProspera();
+    render(<MiFincaVivaScreen />);
+    await waitFor(() => {
+      const scene = screen.getByTestId('finca-world-scene');
+      expect(Number(scene.getAttribute('data-level'))).toBeGreaterThan(0);
+    });
+  });
+
+  it('narra con TTS al entrar (audio para niñas que leen poco)', async () => {
+    render(<MiFincaVivaScreen />);
+    await screen.findByTestId('mi-finca-viva-screen');
+    await waitFor(() => expect(speakMock).toHaveBeenCalled());
+  });
+
+  it('celebra subida de nivel la primera vez que sube vs lo persistido', async () => {
+    // El usuario ya había visto nivel 0; ahora la finca es próspera (sube).
+    localStorage.setItem('chagra:juego-finca:finca-juli', JSON.stringify({ lastLevel: 0, misionesHechas: [] }));
+    setProspera();
+    render(<MiFincaVivaScreen />);
+    expect(await screen.findByTestId('level-up-celebration')).toBeTruthy();
+    expect(screen.getByText('¡Subiste de nivel!')).toBeTruthy();
+  });
+
+  it('NO celebra si el nivel no cambió desde la última visita', async () => {
+    setProspera();
+    // Primer render para fijar lastLevel
+    const { unmount } = render(<MiFincaVivaScreen />);
+    await screen.findByTestId('mi-finca-viva-screen');
+    await waitFor(() => expect(listFarmProcessesMock).toHaveBeenCalled());
+    unmount();
+    // Segundo render: mismo nivel → sin celebración
+    render(<MiFincaVivaScreen />);
+    await screen.findByTestId('mi-finca-viva-screen');
+    await waitFor(() => {
+      expect(screen.queryByTestId('level-up-celebration')).toBeNull();
+    });
+  });
+
+  it('marcar una misión de aprender la deja cumplida y persiste', async () => {
+    setProspera();
+    render(<MiFincaVivaScreen />);
+    const mision = await screen.findByTestId('mision-aprender_ficha');
+    const yaLoAprendi = within(mision).getByText('Ya lo aprendí');
+    fireEvent.click(yaLoAprendi);
+    await waitFor(() => {
+      expect(screen.getByTestId('mision-aprender_ficha').getAttribute('data-done')).toBe('true');
+    });
+    // Persistió
+    const stored = JSON.parse(localStorage.getItem('chagra:juego-finca:finca-juli'));
+    expect(stored.misionesHechas).toContain('aprender_ficha');
+  });
+
+  it('botón de audio alterna sin romper', async () => {
+    render(<MiFincaVivaScreen />);
+    await screen.findByTestId('mi-finca-viva-screen');
+    const toggle = screen.getByLabelText('Apagar el sonido');
+    fireEvent.click(toggle);
+    expect(screen.getByLabelText('Encender el sonido')).toBeTruthy();
+  });
+});

--- a/src/components/juego/juego-finca.css
+++ b/src/components/juego/juego-finca.css
@@ -1,0 +1,162 @@
+/*
+ * juego-finca.css — animaciones ligeras y alegres para "Mi Finca Viva".
+ *
+ * Diseñado para una niña: movimientos suaves (nada brusco), colores vivos,
+ * todo en CSS puro (offline-first, sin libs). Respeta prefers-reduced-motion.
+ */
+
+/* ── Escenario del mundo ─────────────────────────────────────────────── */
+
+.fv-scene {
+  position: relative;
+  width: 100%;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  box-shadow: inset 0 -8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.fv-scene svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+/* El sol pulsa muy suave, como si respirara. */
+.fv-sun {
+  transform-origin: center;
+  animation: fv-sun-pulse 6s ease-in-out infinite;
+}
+@keyframes fv-sun-pulse {
+  0%, 100% { transform: scale(1); opacity: 0.95; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+
+/* Las nubes flotan despacio de lado a lado. */
+.fv-cloud {
+  animation: fv-cloud-drift 18s ease-in-out infinite;
+}
+.fv-cloud-2 {
+  animation: fv-cloud-drift 24s ease-in-out infinite reverse;
+}
+@keyframes fv-cloud-drift {
+  0%, 100% { transform: translateX(0); }
+  50% { transform: translateX(14px); }
+}
+
+/* Los árboles y plantas crecen al aparecer (pop suave). */
+.fv-grow {
+  transform-origin: bottom center;
+  animation: fv-grow-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes fv-grow-in {
+  0% { transform: scaleY(0) scaleX(0.6); opacity: 0; }
+  60% { opacity: 1; }
+  100% { transform: scaleY(1) scaleX(1); opacity: 1; }
+}
+
+/* Los árboles se mecen muy suave con el viento. */
+.fv-sway {
+  transform-origin: bottom center;
+  animation: fv-sway-anim 5s ease-in-out infinite;
+}
+.fv-sway-slow { animation-duration: 7s; }
+@keyframes fv-sway-anim {
+  0%, 100% { transform: rotate(-1.5deg); }
+  50% { transform: rotate(1.5deg); }
+}
+
+/* Las criaturas voladoras flotan arriba y abajo. */
+.fv-float {
+  animation: fv-float-anim 4s ease-in-out infinite;
+}
+@keyframes fv-float-anim {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+
+/* ── Celebración de subida de nivel ──────────────────────────────────── */
+
+.fv-celebration-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(8, 30, 22, 0.78);
+  backdrop-filter: blur(6px);
+  animation: fv-fade-in 0.3s ease both;
+  padding: 1.5rem;
+}
+@keyframes fv-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.fv-celebration-card {
+  animation: fv-pop-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  text-align: center;
+  max-width: 22rem;
+}
+@keyframes fv-pop-in {
+  0% { transform: scale(0.5); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.fv-celebration-emoji {
+  font-size: 5rem;
+  line-height: 1;
+  animation: fv-bounce 1s ease-in-out infinite;
+}
+@keyframes fv-bounce {
+  0%, 100% { transform: translateY(0) rotate(-4deg); }
+  50% { transform: translateY(-14px) rotate(4deg); }
+}
+
+/* Confeti de emojis cayendo. */
+.fv-confetti {
+  position: absolute;
+  top: -10%;
+  font-size: 1.6rem;
+  animation: fv-confetti-fall linear infinite;
+  pointer-events: none;
+}
+@keyframes fv-confetti-fall {
+  0% { transform: translateY(-10vh) rotate(0deg); opacity: 1; }
+  100% { transform: translateY(110vh) rotate(360deg); opacity: 0.9; }
+}
+
+/* ── Tarjetas de criatura recién desbloqueada ────────────────────────── */
+
+.fv-new-badge {
+  animation: fv-shine 1.6s ease-in-out infinite;
+}
+@keyframes fv-shine {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.12); }
+}
+
+/* Criatura nueva (toast). */
+.fv-creature-pop {
+  animation: fv-pop-in 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+/* ── Accesibilidad: respetar reducción de movimiento ─────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .fv-sun,
+  .fv-cloud,
+  .fv-cloud-2,
+  .fv-grow,
+  .fv-sway,
+  .fv-sway-slow,
+  .fv-float,
+  .fv-celebration-emoji,
+  .fv-confetti,
+  .fv-new-badge,
+  .fv-creature-pop,
+  .fv-celebration-card {
+    animation: none !important;
+  }
+  .fv-grow { transform: none !important; opacity: 1 !important; }
+}

--- a/src/services/__tests__/fincaGameService.test.js
+++ b/src/services/__tests__/fincaGameService.test.js
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFincaGameState,
+  detectLevelUp,
+  narrarFinca,
+  getWorldStage,
+  worldStagesCoverGliessman,
+  WORLD_STAGES,
+  CREATURES,
+  BADGES,
+  MISSIONS,
+  TOTAL_CREATURES,
+} from '../fincaGameService';
+
+// ─── Fixtures: procesos REALES de finca (mismo shape que farmProcessCache) ──
+
+/** Finca rica: muchas especies, cosechas, biopreparados, observaciones. */
+function fincaProspera() {
+  const especies = [
+    'coffea_arabica', 'theobroma_cacao', 'musa_paradisiaca', 'persea_americana',
+    'phaseolus_vulgaris', 'zea_mays', 'inga_edulis', 'citrus_limon',
+  ];
+  return especies.map((slug, i) => ({
+    process_id: `p${i}`,
+    process_type: i % 2 === 0 ? 'sowing' : 'agroforestry',
+    status: 'active',
+    current_stage: ['vegetative', 'flowering', 'fruiting', 'mature'][i % 4],
+    subject_slug: slug,
+    companions: i < 3 ? ['inga_edulis'] : [],
+    events: [
+      { event_type: 'harvest_confirmed', payload: { quantity: 10 + i } },
+      { event_type: 'pest_management_confirmed', payload: { method: 'biopreparado bio' } },
+    ],
+  }));
+}
+
+describe('fincaGameService — modelo de mundos', () => {
+  it('tiene exactamente 5 mundos (Gliessman 0-4)', () => {
+    expect(WORLD_STAGES).toHaveLength(5);
+    WORLD_STAGES.forEach((w, i) => expect(w.level).toBe(i));
+  });
+
+  it('cada mundo crece en árboles/vida respecto al anterior (o igual)', () => {
+    for (let i = 1; i < WORLD_STAGES.length; i += 1) {
+      expect(WORLD_STAGES[i].arboles).toBeGreaterThanOrEqual(WORLD_STAGES[i - 1].arboles);
+      expect(WORLD_STAGES[i].vida).toBeGreaterThanOrEqual(WORLD_STAGES[i - 1].vida);
+    }
+  });
+
+  it('getWorldStage hace clamp fuera de rango', () => {
+    expect(getWorldStage(-3).level).toBe(0);
+    expect(getWorldStage(99).level).toBe(4);
+    expect(getWorldStage(2).level).toBe(2);
+  });
+
+  it('los mundos cubren todos los niveles Gliessman del viaje', () => {
+    expect(worldStagesCoverGliessman()).toBe(true);
+  });
+});
+
+describe('fincaGameService — estado VACÍO (cero fabricación)', () => {
+  it('sin procesos → finca vacía, nivel 0, progreso 0', () => {
+    const g = buildFincaGameState({ processes: [], observations: [] });
+    expect(g.vacia).toBe(true);
+    expect(g.nivel).toBe(0);
+    expect(g.progreso).toBe(0);
+    expect(g.mundo.level).toBe(0);
+  });
+
+  it('sin datos NO desbloquea ninguna criatura', () => {
+    const g = buildFincaGameState({ processes: [] });
+    expect(g.criaturasVivas).toBe(0);
+    expect(g.criaturas.every((c) => !c.desbloqueada)).toBe(true);
+  });
+
+  it('sin datos NO gana ninguna insignia', () => {
+    const g = buildFincaGameState({ processes: [] });
+    expect(g.insigniasGanadas).toBe(0);
+  });
+
+  it('sin datos todas las misiones de acción están sin cumplir', () => {
+    const g = buildFincaGameState({ processes: [] });
+    const acciones = g.misiones.filter((m) => m.tipo === 'accion');
+    expect(acciones.every((m) => !m.cumplida)).toBe(true);
+    expect(g.proximaMision).toBeTruthy();
+  });
+
+  it('la finca vacía expone mundoSiguiente (hay a dónde crecer)', () => {
+    const g = buildFincaGameState({ processes: [] });
+    expect(g.mundoSiguiente).toBeTruthy();
+    expect(g.mundoSiguiente.level).toBe(1);
+  });
+});
+
+describe('fincaGameService — finca próspera desbloquea vida', () => {
+  it('una finca rica sube de nivel (> 0)', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    expect(g.vacia).toBe(false);
+    expect(g.nivel).toBeGreaterThan(0);
+    expect(g.progreso).toBeGreaterThan(0);
+  });
+
+  it('desbloquea varias criaturas con biodiversidad real', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    expect(g.criaturasVivas).toBeGreaterThan(0);
+    // mariposa requiere diversidad >= 1; con 8 especies debe estar
+    const mariposa = g.criaturas.find((c) => c.id === 'mariposa');
+    expect(mariposa.desbloqueada).toBe(true);
+  });
+
+  it('gana insignias reales (primera semilla siempre con procesos)', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    const primera = g.insignias.find((b) => b.id === 'primera_semilla');
+    expect(primera.ganada).toBe(true);
+    expect(g.insigniasGanadas).toBeGreaterThan(0);
+  });
+
+  it('el quetzal solo aparece en finca-bosque (nivel >= 3 + diversidad)', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    const quetzal = g.criaturas.find((c) => c.id === 'quetzal');
+    // Coherente con el nivel: si nivel < 3, quetzal bloqueado.
+    if (g.nivel >= 3) {
+      expect(quetzal.desbloqueada).toBe(true);
+    } else {
+      expect(quetzal.desbloqueada).toBe(false);
+    }
+  });
+
+  it('marca misiones de acción cumplidas según datos reales', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    const sembrar = g.misiones.find((m) => m.id === 'sembrar_planta');
+    expect(sembrar.cumplida).toBe(true);
+    const cosecha = g.misiones.find((m) => m.id === 'registrar_cosecha');
+    expect(cosecha.cumplida).toBe(true);
+  });
+});
+
+describe('fincaGameService — normaliza shape real (anidado en attributes)', () => {
+  // El almacenamiento real guarda los campos bajo `attributes` y los eventos
+  // anidados también. buildFincaGameState debe aplanarlos sin tocar el motor.
+  function fincaRealAnidada() {
+    return ['coffea_arabica', 'theobroma_cacao', 'musa_paradisiaca', 'persea_americana',
+      'phaseolus_vulgaris', 'zea_mays', 'inga_edulis', 'citrus_limon'].map((slug, i) => ({
+      process_id: `p${i}`,
+      type: 'farm_process',
+      attributes: {
+        process_type: i % 2 === 0 ? 'sowing' : 'agroforestry',
+        status: 'active',
+        current_stage: ['vegetative', 'flowering', 'fruiting', 'mature'][i % 4],
+        subject_slug: slug,
+        companions: i < 3 ? ['inga_edulis'] : [],
+      },
+      events: [
+        { event_id: 'e1', type: 'farm_process_event', attributes: { event_type: 'harvest_confirmed', payload: { quantity: 12 } } },
+        { event_id: 'e2', type: 'farm_process_event', attributes: { event_type: 'pest_management_confirmed', payload: { method: 'biopreparado bio' } } },
+      ],
+    }));
+  }
+
+  it('una finca real anidada sube de nivel igual que la plana', () => {
+    const g = buildFincaGameState({ processes: fincaRealAnidada() });
+    expect(g.vacia).toBe(false);
+    expect(g.nivel).toBeGreaterThan(0);
+  });
+
+  it('aplana eventos anidados → productividad/autodependencia reales', () => {
+    const g = buildFincaGameState({ processes: fincaRealAnidada() });
+    // harvest_confirmed → productividad; pest bio → autodependencia
+    expect(g.evolution.mesmis.productividad).not.toBeNull();
+    expect(g.evolution.mesmis.autodependencia).not.toBeNull();
+    const cosecha = g.misiones.find((m) => m.id === 'registrar_cosecha');
+    expect(cosecha.cumplida).toBe(true);
+  });
+
+  it('aplana diversidad desde attributes.subject_slug', () => {
+    const g = buildFincaGameState({ processes: fincaRealAnidada() });
+    expect(g.evolution.tape.diversidad).not.toBeNull();
+    const mariposa = g.criaturas.find((c) => c.id === 'mariposa');
+    expect(mariposa.desbloqueada).toBe(true);
+  });
+});
+
+describe('fincaGameService — misiones de aprender (marcadas a mano)', () => {
+  it('aprender_ficha sin marcar → no cumplida', () => {
+    const g = buildFincaGameState({ processes: fincaProspera(), misionesHechas: [] });
+    const aprender = g.misiones.find((m) => m.id === 'aprender_ficha');
+    expect(aprender.cumplida).toBe(false);
+  });
+
+  it('aprender_ficha marcada (Set o array) → cumplida', () => {
+    const gArr = buildFincaGameState({ processes: [], misionesHechas: ['aprender_ficha'] });
+    expect(gArr.misiones.find((m) => m.id === 'aprender_ficha').cumplida).toBe(true);
+    const gSet = buildFincaGameState({ processes: [], misionesHechas: new Set(['aprender_ficha']) });
+    expect(gSet.misiones.find((m) => m.id === 'aprender_ficha').cumplida).toBe(true);
+  });
+});
+
+describe('fincaGameService — detectLevelUp', () => {
+  it('primera vez (nivelPrevio null) NO celebra', () => {
+    expect(detectLevelUp(2, null).subio).toBe(false);
+  });
+
+  it('subir de nivel celebra', () => {
+    const r = detectLevelUp(3, 1);
+    expect(r.subio).toBe(true);
+    expect(r.desde).toBe(1);
+    expect(r.hasta).toBe(3);
+  });
+
+  it('mismo nivel o bajar NO celebra', () => {
+    expect(detectLevelUp(2, 2).subio).toBe(false);
+    expect(detectLevelUp(1, 3).subio).toBe(false);
+  });
+
+  it('hace clamp al rango de niveles', () => {
+    expect(detectLevelUp(99, 0).hasta).toBe(4);
+    expect(detectLevelUp(-5, 2).hasta).toBe(0);
+  });
+});
+
+describe('fincaGameService — narración (TTS, texto alegre y corto)', () => {
+  it('finca vacía invita a sembrar', () => {
+    const g = buildFincaGameState({ processes: [] });
+    const txt = narrarFinca(g);
+    expect(txt.toLowerCase()).toContain('primera planta');
+  });
+
+  it('finca con vida describe el mundo y las criaturas', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    const txt = narrarFinca(g);
+    expect(txt).toContain(g.mundo.nombreNino);
+    expect(txt.toLowerCase()).toContain('criatura');
+  });
+
+  it('subida de nivel anuncia el nuevo mundo', () => {
+    const g = buildFincaGameState({ processes: fincaProspera() });
+    const txt = narrarFinca(g, { levelUp: true });
+    expect(txt.toLowerCase()).toContain('subió de nivel');
+    expect(txt).toContain(g.mundo.nombreNino);
+  });
+
+  it('narrarFinca con estado nulo no rompe', () => {
+    expect(narrarFinca(null)).toBe('');
+  });
+});
+
+describe('fincaGameService — robustez (no rompe con datos basura)', () => {
+  it('no rompe con input vacío total', () => {
+    expect(() => buildFincaGameState()).not.toThrow();
+  });
+
+  it('expone los conteos canónicos', () => {
+    expect(TOTAL_CREATURES).toBe(CREATURES.length);
+    expect(MISSIONS.length).toBeGreaterThan(0);
+    expect(BADGES.length).toBeGreaterThan(0);
+  });
+
+  it('cada criatura/insignia/misión tiene id único', () => {
+    const ids = (arr) => arr.map((x) => x.id);
+    const uniq = (arr) => new Set(ids(arr)).size === arr.length;
+    expect(uniq(CREATURES)).toBe(true);
+    expect(uniq(BADGES)).toBe(true);
+    expect(uniq(MISSIONS)).toBe(true);
+  });
+});

--- a/src/services/__tests__/fincaGameStateService.test.js
+++ b/src/services/__tests__/fincaGameStateService.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getGameState,
+  setLastLevel,
+  markMissionDone,
+  getMisionesHechasSet,
+} from '../fincaGameStateService';
+
+describe('fincaGameStateService — persistencia del juego', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('estado inicial es vacío y seguro', () => {
+    const s = getGameState('finca-x');
+    expect(s.lastLevel).toBe(null);
+    expect(s.misionesHechas).toEqual([]);
+  });
+
+  it('persiste el último nivel visto', () => {
+    setLastLevel('finca-x', 3);
+    expect(getGameState('finca-x').lastLevel).toBe(3);
+  });
+
+  it('marca misiones hechas de forma idempotente', () => {
+    markMissionDone('finca-x', 'aprender_ficha');
+    markMissionDone('finca-x', 'aprender_ficha');
+    markMissionDone('finca-x', 'otra');
+    const s = getGameState('finca-x');
+    expect(s.misionesHechas).toEqual(['aprender_ficha', 'otra']);
+  });
+
+  it('getMisionesHechasSet devuelve un Set', () => {
+    markMissionDone('finca-x', 'aprender_ficha');
+    const set = getMisionesHechasSet('finca-x');
+    expect(set instanceof Set).toBe(true);
+    expect(set.has('aprender_ficha')).toBe(true);
+  });
+
+  it('estados por finca son independientes', () => {
+    setLastLevel('finca-a', 2);
+    setLastLevel('finca-b', 4);
+    expect(getGameState('finca-a').lastLevel).toBe(2);
+    expect(getGameState('finca-b').lastLevel).toBe(4);
+  });
+
+  it('marcar nivel preserva las misiones hechas y viceversa', () => {
+    markMissionDone('finca-x', 'aprender_ficha');
+    setLastLevel('finca-x', 1);
+    const s = getGameState('finca-x');
+    expect(s.lastLevel).toBe(1);
+    expect(s.misionesHechas).toContain('aprender_ficha');
+  });
+
+  it('tolera JSON corrupto en localStorage', () => {
+    localStorage.setItem('chagra:juego-finca:finca-x', '{no es json');
+    const s = getGameState('finca-x');
+    expect(s.lastLevel).toBe(null);
+    expect(s.misionesHechas).toEqual([]);
+  });
+});

--- a/src/services/fincaGameService.js
+++ b/src/services/fincaGameService.js
@@ -1,0 +1,555 @@
+/**
+ * fincaGameService — capa LÚDICA kid-friendly sobre el motor de evolución.
+ *
+ * "Mi Finca Viva": traduce los indicadores REALES de la finca
+ * (fincaEvolutionService: nivel Gliessman 0-4 + MESMIS + TAPE) en un mundo de
+ * juego para una niña: etapas del mundo, criaturas que aparecen, misiones
+ * ligadas a acciones reales + fichas GUATOC, e insignias.
+ *
+ * PRINCIPIO INNEGOCIABLE — CERO FABRICACIÓN:
+ *   Este módulo NO inventa progreso. Toda criatura desbloqueada, insignia
+ *   ganada o etapa del mundo se DERIVA de evaluarEvolucionFinca() sobre datos
+ *   reales. Sin datos → el mundo arranca vacío y el juego INVITA a sembrar.
+ *   No hay puntos ni XP arbitrarios: el "puntaje" es la suma de indicadores
+ *   reales que la familia movió con su trabajo.
+ *
+ * Funciones PURAS: sin fetch, sin IDB, sin DOM. La pantalla
+ * (MiFincaVivaScreen) inyecta processes/observations y el estado de misiones
+ * cumplidas (journeyStateService). Lenguaje llano de Colombia, sin voseo.
+ *
+ * @module services/fincaGameService
+ */
+
+import {
+  evaluarEvolucionFinca,
+  getGliessmanLabel,
+} from './fincaEvolutionService';
+import { JOURNEY_STAGES } from './agroecologyJourney';
+
+// ─── Etapas del MUNDO (mapeo 1:1 con nivel Gliessman 0-4) ──────────────────
+
+/**
+ * Los 5 mundos de "Mi Finca Viva", uno por nivel de Gliessman (0-4).
+ *
+ * Cada mundo describe cómo SE VE la finca a ese nivel para que el render la
+ * dibuje: cuánta vegetación, qué colores, cuántos elementos. El `nombreNino`
+ * es la versión alegre y corta para una niña; `nombreReal` conserva el término
+ * agroecológico (el juego enseña con cariño, no diluye la verdad).
+ *
+ * `cielo`/`tierra` son pares de color (gradiente) que el escenario usa.
+ * `arboles`/`vida` son CONTEOS de elementos visuales que crecen con el nivel.
+ */
+export const WORLD_STAGES = Object.freeze([
+  Object.freeze({
+    level: 0,
+    nombreNino: 'La tierra que despierta',
+    nombreReal: 'Convencional',
+    emoji: '🌱',
+    mensaje: 'Tu finca está empezando. ¡Sembrá tu primera planta para darle vida!',
+    cielo: ['#bcd9e8', '#e8f3ee'],
+    tierra: ['#c9a878', '#a98a5e'],
+    arboles: 1,
+    vida: 0,
+  }),
+  Object.freeze({
+    level: 1,
+    nombreNino: 'El primer verde',
+    nombreReal: 'Reducción de insumos',
+    emoji: '🌿',
+    mensaje: '¡Ya brotan las primeras plantas! La finca está respirando mejor.',
+    cielo: ['#a8d5e2', '#dff0e3'],
+    tierra: ['#b89b6a', '#94a06a'],
+    arboles: 2,
+    vida: 1,
+  }),
+  Object.freeze({
+    level: 2,
+    nombreNino: 'La tierra viva',
+    nombreReal: 'Sustitución orgánica',
+    emoji: '🪱',
+    mensaje: '¡El suelo está lleno de vida! Las lombrices trabajan para vos.',
+    cielo: ['#90cce0', '#d4ecd6'],
+    tierra: ['#9a8456', '#7a9655'],
+    arboles: 4,
+    vida: 3,
+  }),
+  Object.freeze({
+    level: 3,
+    nombreNino: 'El bosque de comida',
+    nombreReal: 'Rediseño del sistema',
+    emoji: '🌳',
+    mensaje: '¡Tu finca es un bosque que da de comer! Muchas plantas viven juntas.',
+    cielo: ['#7ac3da', '#c8e8cb'],
+    tierra: ['#85733f', '#5f8a47'],
+    arboles: 7,
+    vida: 6,
+  }),
+  Object.freeze({
+    level: 4,
+    nombreNino: 'La finca que comparte',
+    nombreReal: 'Conexión social y económica',
+    emoji: '🌻',
+    mensaje: '¡Tu finca es un ejemplo! Da vida, comida y se conecta con el mundo.',
+    cielo: ['#62b8d4', '#bce4c2'],
+    tierra: ['#6f6234', '#4d7d3c'],
+    arboles: 10,
+    vida: 10,
+  }),
+]);
+
+const MAX_LEVEL = WORLD_STAGES.length - 1;
+
+/** Devuelve la definición del mundo para un nivel (clamp 0..MAX_LEVEL). */
+export function getWorldStage(level) {
+  const lvl = Math.max(0, Math.min(MAX_LEVEL, Number(level) || 0));
+  return WORLD_STAGES[lvl];
+}
+
+// ─── Criaturas (biodiversidad coleccionable) ───────────────────────────────
+
+/**
+ * Las criaturas que pueden aparecer en la finca. Cada una se desbloquea cuando
+ * un indicador REAL cruza un umbral — son la biodiversidad que de verdad llega
+ * cuando una finca mejora. `check(ev)` recibe el resultado de
+ * evaluarEvolucionFinca y devuelve true si la criatura ya vive en la finca.
+ *
+ * Orden = orden de aparición (de lo más fácil/temprano a lo más logrado). El
+ * quetzal es la criatura cumbre: solo aparece en una finca-bosque madura.
+ */
+export const CREATURES = Object.freeze([
+  Object.freeze({
+    id: 'lombriz',
+    nombre: 'Lombriz',
+    emoji: '🪱',
+    pista: 'Aparece cuando empezás a cuidar el suelo sin venenos.',
+    logro: '¡Las lombrices llegaron! El suelo está vivo.',
+    check: (ev) => num(ev.mesmis.autodependencia) >= 1,
+  }),
+  Object.freeze({
+    id: 'mariposa',
+    nombre: 'Mariposa',
+    emoji: '🦋',
+    pista: 'Aparece cuando hay varias plantas distintas.',
+    logro: '¡Una mariposa visita tu finca! Le gustan tus plantas.',
+    check: (ev) => num(ev.tape.diversidad) >= 1,
+  }),
+  Object.freeze({
+    id: 'abeja',
+    nombre: 'Abeja',
+    emoji: '🐝',
+    pista: 'Aparece cuando tus plantas se ayudan entre ellas.',
+    logro: '¡Llegaron las abejas! Polinizan y hacen miel.',
+    check: (ev) => num(ev.tape.sinergias) >= 1 || num(ev.tape.diversidad) >= 3,
+  }),
+  Object.freeze({
+    id: 'rana',
+    nombre: 'Rana',
+    emoji: '🐸',
+    pista: 'Aparece cuando tu finca es fuerte y variada.',
+    logro: '¡Una rana canta en tu finca! El agua y el aire están sanos.',
+    check: (ev) => num(ev.tape.resiliencia) >= 2,
+  }),
+  Object.freeze({
+    id: 'colibri',
+    nombre: 'Colibrí',
+    emoji: '🐦',
+    pista: 'Aparece cuando hay muchas flores y plantas.',
+    logro: '¡Un colibrí baila entre tus flores!',
+    check: (ev) => num(ev.tape.diversidad) >= 3,
+  }),
+  Object.freeze({
+    id: 'mariquita',
+    nombre: 'Mariquita',
+    emoji: '🐞',
+    pista: 'Aparece cuando cuidás la finca sin químicos.',
+    logro: '¡Las mariquitas te ayudan! Se comen las plagas.',
+    check: (ev) => num(ev.mesmis.autodependencia) >= 2,
+  }),
+  Object.freeze({
+    id: 'quetzal',
+    nombre: 'Quetzal',
+    emoji: '🦜',
+    pista: 'La criatura más especial. Solo vive en fincas-bosque muy sanas.',
+    logro: '¡EL QUETZAL llegó! Tu finca es un bosque mágico de verdad.',
+    check: (ev) => ev.nivelGliessman >= 3 && num(ev.tape.diversidad) >= 3,
+  }),
+]);
+
+/** Cuántas criaturas existen en total (para "3 de 7"). */
+export const TOTAL_CREATURES = CREATURES.length;
+
+// ─── Insignias (logros suaves, todos derivados de datos reales) ────────────
+
+/**
+ * Insignias por hitos REALES de la finca. Como las criaturas, cada una tiene un
+ * `check(ev)` puro. No son XP: son reconocimiento de trabajo verdadero.
+ */
+export const BADGES = Object.freeze([
+  Object.freeze({
+    id: 'primera_semilla',
+    nombre: 'Primera semilla',
+    emoji: '🌱',
+    descripcion: 'Sembraste tu primera planta.',
+    check: (ev) => ev.metadata.processes_count >= 1,
+  }),
+  Object.freeze({
+    id: 'jardin_diverso',
+    nombre: 'Jardín diverso',
+    emoji: '🌼',
+    descripcion: 'Tenés varias plantas distintas.',
+    check: (ev) => num(ev.tape.diversidad) >= 2,
+  }),
+  Object.freeze({
+    id: 'amiga_del_suelo',
+    nombre: 'Amiga del suelo',
+    emoji: '🪱',
+    descripcion: 'Cuidás la tierra con cariño, sin venenos.',
+    check: (ev) => num(ev.mesmis.autodependencia) >= 2,
+  }),
+  Object.freeze({
+    id: 'primera_cosecha',
+    nombre: 'Primera cosecha',
+    emoji: '🧺',
+    descripcion: 'Recogiste comida de tu finca.',
+    check: (ev) => num(ev.mesmis.productividad) >= 1,
+  }),
+  Object.freeze({
+    id: 'guardiana_bosque',
+    nombre: 'Guardiana del bosque',
+    emoji: '🌳',
+    descripcion: 'Tu finca es un bosque que da de comer.',
+    check: (ev) => ev.nivelGliessman >= 3,
+  }),
+]);
+
+// ─── Misiones (acciones reales + aprender con GUATOC) ───────────────────────
+
+/**
+ * Misiones del juego. Cada misión empuja a una ACCIÓN REAL de la finca o a
+ * aprender una ficha GUATOC. `nav` es la vista a la que rutea el botón (la
+ * misma navegación de la app), y `done(ev, hechas)` decide si ya está cumplida.
+ *
+ * `done` mira datos reales (ev) o el set de misiones marcadas a mano por la
+ * niña/familia (hechas, persistido aparte). Las misiones de "aprender" se
+ * marcan a mano porque leer una ficha no deja rastro en los indicadores.
+ *
+ * El orden es pedagógico: primero sembrar, luego aprender, biopreparar, cosechar.
+ */
+export const MISSIONS = Object.freeze([
+  Object.freeze({
+    id: 'sembrar_planta',
+    titulo: 'Sembrá una planta',
+    emoji: '🌱',
+    descripcion: 'Poné una planta nueva en tu finca y registrala.',
+    cta: 'Ir a sembrar',
+    nav: 'sembrar',
+    tipo: 'accion',
+    done: (ev) => ev.metadata.processes_count >= 1,
+  }),
+  Object.freeze({
+    id: 'aprender_ficha',
+    titulo: 'Aprendé sobre una planta',
+    emoji: '📖',
+    descripcion: 'Descubrí una planta nueva en la biblioteca de Chagra.',
+    cta: 'Ir a aprender',
+    nav: 'ciclo',
+    tipo: 'aprender',
+    done: (_ev, hechas) => hechas.has('aprender_ficha'),
+  }),
+  Object.freeze({
+    id: 'plantar_variado',
+    titulo: 'Sembrá plantas amigas',
+    emoji: '🌻',
+    descripcion: 'Tené al menos 3 plantas distintas: así llegan las mariposas.',
+    cta: 'Sembrar otra',
+    nav: 'sembrar',
+    tipo: 'accion',
+    done: (ev) => num(ev.tape.diversidad) >= 1,
+  }),
+  Object.freeze({
+    id: 'hacer_biopreparado',
+    titulo: 'Preparale comida natural',
+    emoji: '🧪',
+    descripcion: 'Hacé un biopreparado para cuidar tu finca sin venenos.',
+    cta: 'Ver biopreparados',
+    nav: 'insumos',
+    tipo: 'accion',
+    done: (ev) => num(ev.mesmis.autodependencia) >= 1,
+  }),
+  Object.freeze({
+    id: 'registrar_cosecha',
+    titulo: 'Recogé tu cosecha',
+    emoji: '🧺',
+    descripcion: 'Cuando tu planta dé frutos, registrá la cosecha.',
+    cta: 'Ir a cosechar',
+    nav: 'cosechar',
+    tipo: 'accion',
+    done: (ev) => num(ev.mesmis.productividad) >= 1,
+  }),
+  Object.freeze({
+    id: 'observar_finca',
+    titulo: 'Mirá tu finca',
+    emoji: '🔎',
+    descripcion: 'Anotá algo que viste hoy: un bicho, una flor, una hoja.',
+    cta: 'Anotar observación',
+    nav: 'observacion',
+    tipo: 'accion',
+    done: (ev) => num(ev.tape.cocreacion_conocimiento) >= 1,
+  }),
+]);
+
+// ─── Helper interno ────────────────────────────────────────────────────────
+
+/** Convierte un score 0-4|null en número (null → 0) para comparaciones. */
+function num(score) {
+  return score === null || score === undefined ? 0 : score;
+}
+
+/**
+ * Normaliza un FarmProcess al shape PLANO que espera fincaEvolutionService.
+ *
+ * El almacenamiento real (farmProcessCache/dbCore) guarda los datos del proceso
+ * bajo `process.attributes` (status, subject_slug, current_stage, …) y los
+ * eventos en un store aparte. El motor de evolución, en cambio, lee campos
+ * planos (`p.status`, `p.subject_slug`, …) e `p.events` inline. Esta función
+ * tiende el puente SIN tocar el motor: si llega un proceso con `attributes`, lo
+ * aplana; si ya viene plano (tests/llamadas directas), lo deja igual. Cero
+ * fabricación: no inventa campos, solo reubica los que existen.
+ *
+ * @param {Object} p  FarmProcess (anidado o plano)
+ * @returns {Object} proceso con campos planos para el motor
+ */
+function flattenProcess(p) {
+  if (!p || typeof p !== 'object') return p;
+  if (!p.attributes || typeof p.attributes !== 'object') return p;
+  // Anidado → plano. Preserva events si el llamador los adjuntó (la pantalla
+  // puede hidratar p.events desde getFarmEvents antes de pasar la lista).
+  return {
+    process_id: p.process_id,
+    process_type: p.attributes.process_type,
+    subject_slug: p.attributes.subject_slug,
+    subject_label: p.attributes.subject_label,
+    current_stage: p.attributes.current_stage,
+    status: p.attributes.status,
+    companions: p.attributes.companions || p.companions,
+    events: Array.isArray(p.events) ? p.events.map(flattenEvent) : [],
+  };
+}
+
+/**
+ * Normaliza un FarmProcessEvent al shape plano del motor (event_type, payload).
+ * Igual criterio que flattenProcess: anidado → plano; plano → tal cual.
+ * @param {Object} e
+ * @returns {Object}
+ */
+function flattenEvent(e) {
+  if (!e || typeof e !== 'object') return e;
+  if (!e.attributes || typeof e.attributes !== 'object') return e;
+  return {
+    event_type: e.attributes.event_type,
+    payload: e.attributes.payload,
+    occurred_at: e.attributes.occurred_at,
+  };
+}
+
+// ─── Estado de juego (la función principal) ────────────────────────────────
+
+/**
+ * @typedef {Object} GameMission
+ * @property {string} id
+ * @property {string} titulo
+ * @property {string} emoji
+ * @property {string} descripcion
+ * @property {string} cta
+ * @property {string} nav
+ * @property {'accion'|'aprender'} tipo
+ * @property {boolean} cumplida
+ */
+
+/**
+ * @typedef {Object} GameCreature
+ * @property {string} id
+ * @property {string} nombre
+ * @property {string} emoji
+ * @property {string} pista
+ * @property {string} logro
+ * @property {boolean} desbloqueada
+ */
+
+/**
+ * @typedef {Object} FincaGameState
+ * @property {number} nivel              Nivel Gliessman 0-4 (= mundo)
+ * @property {Object} mundo             Definición WORLD_STAGES del nivel actual
+ * @property {Object|null} mundoSiguiente  El próximo mundo, o null si ya es el máximo
+ * @property {string} nivelLabel        Etiqueta agroecológica real del nivel
+ * @property {boolean} vacia            true si la finca no tiene datos (invitar)
+ * @property {GameCreature[]} criaturas Todas, con desbloqueada=true/false
+ * @property {number} criaturasVivas    Conteo de desbloqueadas
+ * @property {Object[]} insignias       Todas, con ganada=true/false
+ * @property {number} insigniasGanadas  Conteo de ganadas
+ * @property {GameMission[]} misiones    Todas, con cumplida=true/false
+ * @property {GameMission|null} proximaMision  La primera misión sin cumplir
+ * @property {number} progreso          0-100, % real de avance del mundo
+ * @property {Object} evolution         El resultado crudo de evaluarEvolucionFinca
+ */
+
+/**
+ * Construye TODO el estado de juego desde datos reales de la finca.
+ *
+ * @param {Object} input
+ * @param {Array} [input.processes=[]]      FarmProcess[] reales de la finca
+ * @param {Array} [input.observations=[]]   Observaciones reales
+ * @param {Set<string>|string[]} [input.misionesHechas]  ids de misiones de
+ *        "aprender" marcadas a mano (de journeyStateService / localStorage).
+ * @returns {FincaGameState}
+ */
+export function buildFincaGameState({
+  processes = [],
+  observations = [],
+  misionesHechas = [],
+} = {}) {
+  const hechas = misionesHechas instanceof Set
+    ? misionesHechas
+    : new Set(Array.isArray(misionesHechas) ? misionesHechas : []);
+
+  // Acepta procesos en shape real (anidado en .attributes) o plano (tests).
+  const flatProcesses = Array.isArray(processes) ? processes.map(flattenProcess) : [];
+
+  // Motor real: cero fabricación vive acá adentro.
+  const evolution = evaluarEvolucionFinca({ processes: flatProcesses, observations });
+  const nivel = Math.max(0, Math.min(MAX_LEVEL, evolution.nivelGliessman));
+  const mundo = WORLD_STAGES[nivel];
+  const mundoSiguiente = nivel < MAX_LEVEL ? WORLD_STAGES[nivel + 1] : null;
+
+  // Una finca "vacía" = sin procesos registrados. El juego invita en vez de
+  // mostrar un mundo muerto. NO se infla nada.
+  const vacia = evolution.metadata.processes_count === 0;
+
+  const criaturas = CREATURES.map((c) => ({
+    id: c.id,
+    nombre: c.nombre,
+    emoji: c.emoji,
+    pista: c.pista,
+    logro: c.logro,
+    desbloqueada: safeCheck(c.check, evolution),
+  }));
+  const criaturasVivas = criaturas.filter((c) => c.desbloqueada).length;
+
+  const insignias = BADGES.map((b) => ({
+    id: b.id,
+    nombre: b.nombre,
+    emoji: b.emoji,
+    descripcion: b.descripcion,
+    ganada: safeCheck(b.check, evolution),
+  }));
+  const insigniasGanadas = insignias.filter((b) => b.ganada).length;
+
+  const misiones = MISSIONS.map((m) => ({
+    id: m.id,
+    titulo: m.titulo,
+    emoji: m.emoji,
+    descripcion: m.descripcion,
+    cta: m.cta,
+    nav: m.nav,
+    tipo: m.tipo,
+    cumplida: safeMission(m.done, evolution, hechas),
+  }));
+  const proximaMision = misiones.find((m) => !m.cumplida) || null;
+
+  // Progreso real del mundo: % del camino de niveles recorrido. Es honesto:
+  // mueve solo cuando el nivel Gliessman (derivado de indicadores reales) sube.
+  const progreso = Math.round((nivel / MAX_LEVEL) * 100);
+
+  return {
+    nivel,
+    mundo,
+    mundoSiguiente,
+    nivelLabel: getGliessmanLabel(nivel),
+    vacia,
+    criaturas,
+    criaturasVivas,
+    insignias,
+    insigniasGanadas,
+    misiones,
+    proximaMision,
+    progreso,
+    evolution,
+  };
+}
+
+/** Ejecuta un check de criatura/insignia sin que una excepción tumbe el juego. */
+function safeCheck(fn, ev) {
+  try {
+    return !!fn(ev);
+  } catch {
+    return false;
+  }
+}
+
+/** Igual que safeCheck pero para misiones (reciben también el set hechas). */
+function safeMission(fn, ev, hechas) {
+  try {
+    return !!fn(ev, hechas);
+  } catch {
+    return false;
+  }
+}
+
+// ─── Detección de subida de nivel (para la celebración) ────────────────────
+
+/**
+ * ¿Subió de nivel? Compara el nivel actual contra el último visto (que la
+ * pantalla persiste en localStorage por finca). PURA: la pantalla decide qué
+ * hacer (animación + sonido + TTS). Devuelve el delta para el render.
+ *
+ * @param {number} nivelActual   nivel derivado ahora
+ * @param {number|null} nivelPrevio  último nivel visto (o null la 1ª vez)
+ * @returns {{subio: boolean, desde: number, hasta: number}}
+ */
+export function detectLevelUp(nivelActual, nivelPrevio) {
+  const hasta = Math.max(0, Math.min(MAX_LEVEL, Number(nivelActual) || 0));
+  if (nivelPrevio === null || nivelPrevio === undefined) {
+    return { subio: false, desde: hasta, hasta };
+  }
+  const desde = Math.max(0, Math.min(MAX_LEVEL, Number(nivelPrevio) || 0));
+  return { subio: hasta > desde, desde, hasta };
+}
+
+/**
+ * Texto alegre y CORTO para narrar (TTS kokoro) cuando una niña entra al juego
+ * o sube de nivel. Pensado para que una niña que lee poco entienda por audio.
+ *
+ * @param {FincaGameState} state
+ * @param {{levelUp?: boolean}} [opts]
+ * @returns {string}
+ */
+export function narrarFinca(state, { levelUp = false } = {}) {
+  if (!state) return '';
+  if (levelUp && state.mundo) {
+    return `¡Tu finca subió de nivel! Ahora es ${state.mundo.nombreNino}. ${state.mundo.mensaje}`;
+  }
+  if (state.vacia) {
+    return 'Tu finca está esperando. ¡Sembrá tu primera planta para que cobre vida!';
+  }
+  const mundo = state.mundo;
+  const criaturas = state.criaturasVivas === 1
+    ? 'Tenés una criatura viviendo en tu finca.'
+    : state.criaturasVivas > 1
+      ? `Tenés ${state.criaturasVivas} criaturas viviendo en tu finca.`
+      : 'Todavía no llegan criaturas. ¡Sembrá más para invitarlas!';
+  return `Tu finca es ${mundo.nombreNino}. ${mundo.mensaje} ${criaturas}`;
+}
+
+/**
+ * Cross-check: que el modelo de mundos y el viaje agroecológico no se
+ * desincronicen en niveles. Útil en tests. No se usa en runtime.
+ * @returns {boolean}
+ */
+export function worldStagesCoverGliessman() {
+  const gliessmanLevels = new Set(JOURNEY_STAGES.map((s) => s.gliessman));
+  // Todo nivel Gliessman del viaje debe tener un mundo que lo represente.
+  for (const lvl of gliessmanLevels) {
+    if (lvl < 0 || lvl > MAX_LEVEL) return false;
+  }
+  return WORLD_STAGES.length === MAX_LEVEL + 1;
+}

--- a/src/services/fincaGameService.js
+++ b/src/services/fincaGameService.js
@@ -45,7 +45,7 @@ export const WORLD_STAGES = Object.freeze([
     nombreNino: 'La tierra que despierta',
     nombreReal: 'Convencional',
     emoji: '🌱',
-    mensaje: 'Tu finca está empezando. ¡Sembrá tu primera planta para darle vida!',
+    mensaje: 'Tu finca está empezando. ¡Siembra tu primera planta para darle vida!',
     cielo: ['#bcd9e8', '#e8f3ee'],
     tierra: ['#c9a878', '#a98a5e'],
     arboles: 1,
@@ -161,7 +161,7 @@ export const CREATURES = Object.freeze([
     id: 'mariquita',
     nombre: 'Mariquita',
     emoji: '🐞',
-    pista: 'Aparece cuando cuidás la finca sin químicos.',
+    pista: 'Aparece cuando cuidas la finca sin químicos.',
     logro: '¡Las mariquitas te ayudan! Se comen las plagas.',
     check: (ev) => num(ev.mesmis.autodependencia) >= 2,
   }),
@@ -196,14 +196,14 @@ export const BADGES = Object.freeze([
     id: 'jardin_diverso',
     nombre: 'Jardín diverso',
     emoji: '🌼',
-    descripcion: 'Tenés varias plantas distintas.',
+    descripcion: 'Tienes varias plantas distintas.',
     check: (ev) => num(ev.tape.diversidad) >= 2,
   }),
   Object.freeze({
     id: 'amiga_del_suelo',
     nombre: 'Amiga del suelo',
     emoji: '🪱',
-    descripcion: 'Cuidás la tierra con cariño, sin venenos.',
+    descripcion: 'Cuidas la tierra con cariño, sin venenos.',
     check: (ev) => num(ev.mesmis.autodependencia) >= 2,
   }),
   Object.freeze({
@@ -238,9 +238,9 @@ export const BADGES = Object.freeze([
 export const MISSIONS = Object.freeze([
   Object.freeze({
     id: 'sembrar_planta',
-    titulo: 'Sembrá una planta',
+    titulo: 'Siembra una planta',
     emoji: '🌱',
-    descripcion: 'Poné una planta nueva en tu finca y registrala.',
+    descripcion: 'Pon una planta nueva en tu finca y regístrala.',
     cta: 'Ir a sembrar',
     nav: 'sembrar',
     tipo: 'accion',
@@ -248,7 +248,7 @@ export const MISSIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'aprender_ficha',
-    titulo: 'Aprendé sobre una planta',
+    titulo: 'Aprende sobre una planta',
     emoji: '📖',
     descripcion: 'Descubrí una planta nueva en la biblioteca de Chagra.',
     cta: 'Ir a aprender',
@@ -258,7 +258,7 @@ export const MISSIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'plantar_variado',
-    titulo: 'Sembrá plantas amigas',
+    titulo: 'Siembra plantas amigas',
     emoji: '🌻',
     descripcion: 'Tené al menos 3 plantas distintas: así llegan las mariposas.',
     cta: 'Sembrar otra',
@@ -270,7 +270,7 @@ export const MISSIONS = Object.freeze([
     id: 'hacer_biopreparado',
     titulo: 'Preparale comida natural',
     emoji: '🧪',
-    descripcion: 'Hacé un biopreparado para cuidar tu finca sin venenos.',
+    descripcion: 'Haz un biopreparado para cuidar tu finca sin venenos.',
     cta: 'Ver biopreparados',
     nav: 'insumos',
     tipo: 'accion',
@@ -280,7 +280,7 @@ export const MISSIONS = Object.freeze([
     id: 'registrar_cosecha',
     titulo: 'Recogé tu cosecha',
     emoji: '🧺',
-    descripcion: 'Cuando tu planta dé frutos, registrá la cosecha.',
+    descripcion: 'Cuando tu planta dé frutos, registra la cosecha.',
     cta: 'Ir a cosechar',
     nav: 'cosechar',
     tipo: 'accion',
@@ -288,7 +288,7 @@ export const MISSIONS = Object.freeze([
   }),
   Object.freeze({
     id: 'observar_finca',
-    titulo: 'Mirá tu finca',
+    titulo: 'Mira tu finca',
     emoji: '🔎',
     descripcion: 'Anotá algo que viste hoy: un bicho, una flor, una hoja.',
     cta: 'Anotar observación',
@@ -529,14 +529,14 @@ export function narrarFinca(state, { levelUp = false } = {}) {
     return `¡Tu finca subió de nivel! Ahora es ${state.mundo.nombreNino}. ${state.mundo.mensaje}`;
   }
   if (state.vacia) {
-    return 'Tu finca está esperando. ¡Sembrá tu primera planta para que cobre vida!';
+    return 'Tu finca está esperando. ¡Siembra tu primera planta para que cobre vida!';
   }
   const mundo = state.mundo;
   const criaturas = state.criaturasVivas === 1
-    ? 'Tenés una criatura viviendo en tu finca.'
+    ? 'Tienes una criatura viviendo en tu finca.'
     : state.criaturasVivas > 1
-      ? `Tenés ${state.criaturasVivas} criaturas viviendo en tu finca.`
-      : 'Todavía no llegan criaturas. ¡Sembrá más para invitarlas!';
+      ? `Tienes ${state.criaturasVivas} criaturas viviendo en tu finca.`
+      : 'Todavía no llegan criaturas. ¡Siembra más para invitarlas!';
   return `Tu finca es ${mundo.nombreNino}. ${mundo.mensaje} ${criaturas}`;
 }
 

--- a/src/services/fincaGameStateService.js
+++ b/src/services/fincaGameStateService.js
@@ -1,0 +1,69 @@
+/**
+ * fincaGameStateService — persistencia del juego "Mi Finca Viva", por finca.
+ *
+ * Guarda lo poco que el JUEGO necesita recordar y que NO sale de los
+ * indicadores reales:
+ *   - `lastLevel`: último nivel de mundo visto, para detectar subidas de nivel
+ *     y disparar la celebración una sola vez.
+ *   - `misionesHechas`: ids de misiones de "aprender" que la niña marcó a mano
+ *     (leer una ficha GUATOC no deja rastro en los indicadores; las acciones
+ *     reales —sembrar, cosechar— sí, y esas NO se guardan acá: se derivan).
+ *
+ * Persistencia: localStorage (estado mínimo, tipo preferencia por finca,
+ * offline-first; degrada limpio en modo privado, igual que journeyStateService).
+ * CERO fabricación: nada de progreso inventado se persiste — solo el "visto" y
+ * los toques explícitos de la niña.
+ *
+ * @module services/fincaGameStateService
+ */
+
+const KEY = (slug) => `chagra:juego-finca:${slug || 'default'}`;
+
+/** Lee el estado del juego guardado, o un estado vacío seguro. */
+export function getGameState(fincaSlug) {
+  try {
+    const raw = localStorage.getItem(KEY(fincaSlug));
+    if (!raw) return { lastLevel: null, misionesHechas: [] };
+    const s = JSON.parse(raw);
+    return {
+      lastLevel:
+        typeof s?.lastLevel === 'number' ? s.lastLevel : null,
+      misionesHechas: Array.isArray(s?.misionesHechas)
+        ? s.misionesHechas.filter((x) => typeof x === 'string')
+        : [],
+    };
+  } catch {
+    return { lastLevel: null, misionesHechas: [] };
+  }
+}
+
+/** Persiste el último nivel visto (para la celebración de subida de nivel). */
+export function setLastLevel(fincaSlug, level) {
+  const cur = getGameState(fincaSlug);
+  const next = { ...cur, lastLevel: Number(level) || 0 };
+  write(fincaSlug, next);
+  return next;
+}
+
+/** Marca una misión (de "aprender") como cumplida a mano. Idempotente. */
+export function markMissionDone(fincaSlug, missionId) {
+  const cur = getGameState(fincaSlug);
+  if (!cur.misionesHechas.includes(missionId)) {
+    cur.misionesHechas = [...cur.misionesHechas, missionId];
+  }
+  write(fincaSlug, cur);
+  return cur;
+}
+
+/** Devuelve las misiones hechas como Set (lo que espera buildFincaGameState). */
+export function getMisionesHechasSet(fincaSlug) {
+  return new Set(getGameState(fincaSlug).misionesHechas);
+}
+
+function write(fincaSlug, state) {
+  try {
+    localStorage.setItem(KEY(fincaSlug), JSON.stringify(state));
+  } catch {
+    /* modo privado: no persiste; el juego sigue en memoria esta sesión */
+  }
+}


### PR DESCRIPTION
## Mi Finca Viva 🌱 — un juego para que una niña vea crecer su finca

Una **capa lúdica kid-friendly ENCIMA** del motor de evolución agroecológica que
ya existe (`fincaEvolutionService`). La finca es un **mundo vivo que florece de
verdad** a medida que los indicadores reales suben. Pensado para que Julieta (y
cualquier niña) lo disfrute: colorido, con audio, botones grandes.

### Qué hace
- **Mundo que crece** (`FincaWorldScene`, SVG+CSS, offline-first): más árboles,
  más vida, más color y frutos según el nivel Gliessman real (0–4).
- **Criaturas coleccionables** (`CriaturaCollection`): lombriz, mariposa, abeja,
  rana, colibrí, mariquita y el **quetzal** (la cumbre) aparecen con la
  biodiversidad real. Galería con pistas honestas + audio.
- **Misiones** (`MisionCard`) ligadas a **acciones reales** (sembrar, cosechar,
  biopreparar, observar) y a **aprender** con fichas GUATOC.
- **Insignias** por hitos reales + **celebración** de subida de nivel
  (`LevelUpCelebration`): animación + sonido (`agentSoundService`) + narración
  por **TTS** (kokoro / Web Speech).
- **Accesibilidad**: botones 44–56 px, alto contraste, **audio en todo** (para
  niñas que leen poco), animaciones que respetan `prefers-reduced-motion`.

### Principio: CERO FABRICACIÓN
Todo se **deriva** del motor real (`evaluarEvolucionFinca`). Sin datos → mundo
vacío que **invita** a sembrar, nunca un mundo falsamente lleno. No hay XP
arbitrario: el "puntaje" es la suma de indicadores reales.

### Ingeniería (reúso, no reinvención)
- **No toca** `fincaEvolutionService` ni `MiFincaEvolucionScreen` (el modo serio
  queda intacto). Vista nueva: `case 'juego'` en `App.jsx` + entrada en
  **Hoy en finca**.
- `fincaGameService.js` traduce indicadores → mundo/criaturas/misiones y
  normaliza el shape real (anidado en `attributes`) → plano que el motor espera,
  **sin tocar el motor** (`flattenProcess`/`flattenEvent`).
- `fincaGameStateService.js` persiste lo mínimo (último nivel visto + misiones
  de "aprender" marcadas), por finca, offline-first.

### Pruebas
- 49 tests nuevos en vitest (fincaGameService 28, fincaGameStateService 7,
  MiFincaVivaScreen 14), todos en verde.
- Suite completa: 5470 pass. (1 fallo pre-existente en `outputGuards.mipPlaga`
  — guard de LLM, **ajeno** a este PR: sin diff vs `main`.)
- `npm run build` (vite) en verde.
- Verificación visual con Playwright (chromium del nix-store, datos sembrados en
  IndexedDB): `scripts/juego-julieta-shots.mjs` → estados **vacío / próspero /
  celebración** en `/tmp/juego-julieta-*.png`.

### Docs
- `docs/JUEGO_JULIETA.md` (concepto + mecánicas + arquitectura + cómo jugar).

### Merge gates
- CodeQL + Playwright `tests/offline.spec.js` (los gates reales) deberían pasar:
  no toco `dbCore`/`syncManager`/`sw.js`/superficie offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)