### PR TITLE
feat(sw): auto-update seguro del Service Worker (deploys se ven sin limpiar caché)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -55,13 +55,19 @@ const RAG_GROUNDING_PRECACHE = [
 ];
 
 // Instalación del Service Worker.
-// SIN self.skipWaiting() automático: el SW nuevo queda en `waiting` para que
-// el cliente muestre el banner "nueva versión disponible" y el operador
-// decida cuándo actualizar. El skipWaiting solo ocurre vía mensaje
-// SKIP_WAITING (click "Actualizar" en UpdateAvailableBanner). Con el
-// auto-skip el SW activaba solo, controllerchange disparaba el banner
-// DESPUÉS de aplicada la actualización y el operador debía dar "Actualizar"
-// N veces (bug 2026-06-10).
+// SIN self.skipWaiting() automático EN EL SW: el SW nuevo queda en `waiting` y
+// el skipWaiting lo decide el CLIENTE vía mensaje SKIP_WAITING. Quién manda ese
+// mensaje:
+//   1. AUTO-UPDATE (swRegistration.js, desde 2026-06-15): al detectar el
+//      waiting, el cliente dispara SKIP_WAITING automáticamente y recarga UNA
+//      vez (guard anti-loop por controllerchange). Así el deploy se VE sin que
+//      el usuario limpie caché.
+//   2. UpdateAvailableBanner ("Actualizar"): fallback visible si el auto-update
+//      no llegó a recargar.
+// El skipWaiting NO se hace aquí en el SW a propósito: el cliente necesita
+// orquestar la recarga ÚNICA (controllerchange) — si el SW activara solo, el
+// banner aparecía DESPUÉS de aplicada la actualización y el operador debía dar
+// "Actualizar" N veces (bug 2026-06-10). Por eso el SW espera el mensaje.
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,11 +12,7 @@ import { fetchFromFarmOS } from './services/apiService'
 import { PRIMARY_WORKER_NAME } from './config/workerConfig'
 import { renameWorker } from './services/assetService'
 import { getAccessToken } from './services/authService'
-import {
-  shouldShowUpdateBanner,
-  readAckedVersion,
-  seedFirstInstallAck,
-} from './services/swUpdateAck'
+import { registerServiceWorker } from './services/swRegistration'
 
 import { loadDemoSeedData } from '../scripts/seed-demo';
 import { bootstrapOssModules } from './core/bootstrap-oss';
@@ -61,154 +57,20 @@ syncManager.initDB().then(async () => {
   console.error('Error inicializando Sync Manager:', error);
 });
 
-// Registrar Service Worker con espera a .ready para background sync robusto.
+// Service Worker: registro + AUTO-UPDATE seguro (ver swRegistration.js).
+// Al detectar un SW nuevo en `waiting`, aplica skipWaiting automáticamente y
+// recarga UNA sola vez (respetando el guard anti-loop). El UpdateAvailableBanner
+// queda como fallback visible. La lógica vive en su propio módulo para poder
+// testearla en vitest sin montar el árbol React.
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
-      .then((registration) => {
-        console.log('Service Worker registrado:', registration.scope);
-      })
-      .catch((error) => {
-        console.error('Error registrando Service Worker:', error);
-      });
-
-    // Esperar a que el SW esté activo antes de registrar background sync.
-    navigator.serviceWorker.ready.then((registration) => {
-      if (registration.sync) {
-        registration.sync.register('sync-pending-transactions').catch((e) => {
-          console.warn('Background Sync no disponible:', e.message);
-        });
-      }
-      console.info('[SW] Service Worker activo y listo.');
-    });
-  });
-
-  // Escuchar solicitudes de sync del SW
+  // Escuchar solicitudes de sync del SW (syncManager ya importado aquí).
   navigator.serviceWorker.addEventListener('message', (event) => {
     if (event.data?.type === 'SYNC_REQUESTED') {
       syncManager.syncAll();
     }
   });
 
-  // Banner "nueva version disponible" SOLO cuando hay un SW nuevo en waiting
-  // (registration.waiting / updatefound). NUNCA por controllerchange: ese
-  // evento significa que la actualizacion YA se aplico — dispararlo ahi
-  // re-mostraba el banner despues de actualizar (bug operador 2026-06-10
-  // "debo dar Actualizar N veces"). El operador decide cuando actualizar
-  // via UpdateAvailableBanner.
-  //
-  // Fix QA #18: persistimos el ack en localStorage
-  // (`sw:last-acked-version`) para no repetir el toast cada reload. Antes
-  // de disparar `chagra:update-available` preguntamos al SW su CACHE_NAME
-  // via MessageChannel y comparamos con el acked. Si coincide → suprimir.
-  // First install (no ack previo) → suprimir tambien y sembrar el ack para
-  // que la primera notif real (al actualizar) si dispare.
-  const maybeDispatchUpdateAvailable = async (sw) => {
-    if (!sw) return;
-    try {
-      const version = await getSwVersion(sw);
-      if (!version) return;
-      const lastAcked = readAckedVersion();
-      // Seed first-install: nunca hubo ack previo → guardamos current y
-      // suprimimos el toast. Asi en la proxima version real (CACHE_NAME
-      // distinto) el banner si dispara.
-      if (lastAcked === null) {
-        seedFirstInstallAck(version);
-        return;
-      }
-      if (shouldShowUpdateBanner(version, lastAcked)) {
-        window.dispatchEvent(
-          new CustomEvent('chagra:update-available', { detail: { version } })
-        );
-      }
-    } catch (_) {
-      // SW no responde / MessageChannel timeout → no spammear toast.
-    }
-  };
-
-  // Patron Workbox estandar: click "Actualizar" → SKIP_WAITING → el SW nuevo
-  // toma control → controllerchange → recargar la pagina UNA sola vez.
-  // Guard `reloading` evita bucles de recarga; `hadController` evita recargar
-  // en el primer install (clients.claim() tambien dispara controllerchange
-  // cuando antes no habia controlador — ahi NO hay que recargar).
-  //
-  // `userUpdateRequested` (bug operador 2026-06-11, Android — boton pegado):
-  // si la pagina arranco SIN controller (hard reload / carga no controlada)
-  // pero hay un SW en waiting, el click "Actualizar" disparaba SKIP_WAITING
-  // → claim → controllerchange, y el guard de first-install se TRAGABA el
-  // evento: ni recarga ni banner fuera. Cuando la actualizacion la pidio el
-  // usuario (evento chagra:sw-update-requested del banner), controllerchange
-  // SIEMPRE recarga.
-  let reloading = false;
-  let hadController = Boolean(navigator.serviceWorker.controller);
-  let userUpdateRequested = false;
-  window.addEventListener('chagra:sw-update-requested', () => {
-    userUpdateRequested = true;
-  });
-  navigator.serviceWorker.addEventListener('controllerchange', () => {
-    if (!hadController && !userUpdateRequested) {
-      hadController = true; // primer claim en first install — sin recarga
-      return;
-    }
-    if (reloading) return;
-    reloading = true;
-    window.location.reload();
-  });
-
-  // Deteccion de SW nuevo en waiting: unica fuente del banner.
-  navigator.serviceWorker.ready.then((registration) => {
-    // First install: sembrar el ack con la version del SW activo SIN disparar
-    // banner (la actualizacion ya esta aplicada; anunciar aqui era el bug).
-    const activeSw = navigator.serviceWorker.controller || registration.active;
-    if (activeSw && readAckedVersion() === null) {
-      getSwVersion(activeSw)
-        .then((version) => { if (version) seedFirstInstallAck(version); })
-        .catch(() => { });
-    }
-    if (registration.waiting) {
-      maybeDispatchUpdateAvailable(registration.waiting);
-    }
-    registration.addEventListener('updatefound', () => {
-      const installing = registration.installing;
-      if (installing) {
-        installing.addEventListener('statechange', () => {
-          if (installing.state === 'installed' && registration.waiting) {
-            maybeDispatchUpdateAvailable(registration.waiting);
-          }
-        });
-      } else if (registration.waiting) {
-        maybeDispatchUpdateAvailable(registration.waiting);
-      }
-    });
-  });
-}
-
-// Pregunta CACHE_NAME al SW via MessageChannel con timeout corto. Devuelve
-// null si no responde (no bloquear UI ni spammear toast).
-function getSwVersion(sw, timeoutMs = 1500) {
-  return new Promise((resolve) => {
-    if (!sw || typeof MessageChannel === 'undefined') {
-      resolve(null);
-      return;
-    }
-    const channel = new MessageChannel();
-    const timer = setTimeout(() => {
-      channel.port1.close();
-      resolve(null);
-    }, timeoutMs);
-    channel.port1.onmessage = (event) => {
-      clearTimeout(timer);
-      channel.port1.close();
-      resolve(event.data?.version ?? null);
-    };
-    try {
-      sw.postMessage({ type: 'GET_VERSION' }, [channel.port2]);
-    } catch (_) {
-      clearTimeout(timer);
-      channel.port1.close();
-      resolve(null);
-    }
-  });
+  registerServiceWorker();
 }
 
 createRoot(document.getElementById('root')).render(

--- a/src/services/__tests__/swRegistration.test.js
+++ b/src/services/__tests__/swRegistration.test.js
@@ -1,0 +1,262 @@
+/**
+ * swRegistration.test.js — TDD del AUTO-UPDATE seguro del Service Worker
+ * (2026-06-15: consent-only → auto-update).
+ *
+ * Contrato:
+ *  1. SW nuevo en `waiting` (detectado en load) → tras AUTO_UPDATE_DELAY_MS se
+ *     dispara `chagra:sw-update-requested` + `SKIP_WAITING` al waiting.
+ *  2. El SW nuevo activa → `controllerchange` → reload UNA sola vez.
+ *  3. NO doble-reload ni loop: un segundo controllerchange NO recarga otra vez.
+ *  4. First install (página SIN controller, claim-only) → controllerchange NO
+ *     recarga (lo absorbe el guard hadController).
+ *  5. `updatefound → installed` con waiting → mismo auto-update.
+ *  6. autoUpdate:false → consent-only (NO skipWaiting automático, solo banner).
+ *  7. El SKIP_WAITING se manda UNA sola vez aunque haya varias señales de
+ *     waiting (autoUpdateTriggered).
+ *
+ * Modelamos navigator.serviceWorker como un EventTarget (controllerchange,
+ * message) + `ready` (Promise) + `register`. El waiting es un objeto con
+ * postMessage espiado y un puerto GET_VERSION para getSwVersion.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  registerServiceWorker,
+  AUTO_UPDATE_DELAY_MS,
+} from '../swRegistration';
+import { ACK_STORAGE_KEY } from '../swUpdateAck';
+import { reloadPage } from '../pageReload';
+
+// location.reload es non-configurable en jsdom — recarga vía pageReload.
+vi.mock('../../services/pageReload', () => ({ reloadPage: vi.fn() }));
+vi.mock('../pageReload', () => ({ reloadPage: vi.fn() }));
+
+// ── Fake SW worker: responde GET_VERSION por MessageChannel y espía postMessage.
+function makeWorker(version = 'chagra-v999') {
+  return {
+    version,
+    postMessage: vi.fn(function (msg, transfer) {
+      // Responder GET_VERSION por el puerto (como el SW real) para getSwVersion.
+      if (msg && msg.type === 'GET_VERSION' && transfer && transfer[0]) {
+        transfer[0].postMessage({ type: 'VERSION', version });
+      }
+    }),
+  };
+}
+
+// ── Fake registration: waiting/installing + updatefound listeners.
+function makeRegistration({ waiting = null, active = null } = {}) {
+  const listeners = {};
+  return {
+    scope: '/',
+    waiting,
+    installing: null,
+    active,
+    sync: null,
+    addEventListener: (type, cb) => {
+      (listeners[type] ||= []).push(cb);
+    },
+    _emit: (type, evt) => (listeners[type] || []).forEach((cb) => cb(evt)),
+  };
+}
+
+// ── Fake navigator.serviceWorker: EventTarget-ish + ready + register.
+function installFakeSW({ controller = null, registration } = {}) {
+  const listeners = {};
+  const sw = {
+    controller,
+    register: vi.fn(async () => registration),
+    ready: Promise.resolve(registration),
+    addEventListener: (type, cb) => {
+      (listeners[type] ||= []).push(cb);
+    },
+    removeEventListener: () => {},
+    _emit: (type, evt) => (listeners[type] || []).forEach((cb) => cb(evt)),
+  };
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: sw,
+  });
+  return sw;
+}
+
+// Dispara window 'load' (registerServiceWorker engancha register ahí).
+function fireLoad() {
+  window.dispatchEvent(new Event('load'));
+}
+
+// Espera a que se resuelvan las promesas pendientes (ready.then encadenados).
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('swRegistration — AUTO-UPDATE seguro', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete navigator.serviceWorker;
+    vi.useRealTimers();
+  });
+
+  it('SW en waiting → auto SKIP_WAITING tras el delay y UN solo reload por controllerchange', async () => {
+    vi.useFakeTimers();
+    // Ack previo distinto → no es first-install (banner permitido), y la página
+    // YA tiene controller (sesión normal) → controllerchange debe recargar.
+    localStorage.setItem(ACK_STORAGE_KEY, 'chagra-v100');
+    const waiting = makeWorker('chagra-v999');
+    const reg = makeRegistration({ waiting });
+    const sw = installFakeSW({ controller: {}, registration: reg });
+
+    registerServiceWorker();
+    fireLoad();
+    await flushMicrotasks();
+
+    // Antes del delay: nada todavía.
+    expect(waiting.postMessage).not.toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_DELAY_MS + 10);
+
+    // Auto-update mandó SKIP_WAITING al waiting.
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    // El SW nuevo activa → controllerchange → UN reload.
+    sw._emit('controllerchange');
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+
+    // Segundo controllerchange (no debería pasar, pero si pasa) → NO recarga
+    // otra vez (guard `reloading`). Sin doble-reload ni loop.
+    sw._emit('controllerchange');
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('first install (página SIN controller, claim-only) → NO recarga', async () => {
+    vi.useFakeTimers();
+    // Sin waiting (instalación inicial): el activate hace clients.claim() →
+    // controllerchange por primera vez. NO debe recargar.
+    const reg = makeRegistration({ waiting: null, active: makeWorker('chagra-v999') });
+    const sw = installFakeSW({ controller: null, registration: reg });
+
+    registerServiceWorker();
+    fireLoad();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_DELAY_MS + 10);
+
+    // No hubo waiting → no se mandó SKIP_WAITING.
+    // (el único worker es el active, no un waiting)
+    expect(reg.active.postMessage).not.toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    // claim dispara controllerchange en first install → guard hadController lo
+    // absorbe → NO reload.
+    sw._emit('controllerchange');
+    expect(reloadPage).not.toHaveBeenCalled();
+  });
+
+  it('updatefound → installed con waiting → auto SKIP_WAITING', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem(ACK_STORAGE_KEY, 'chagra-v100');
+    const reg = makeRegistration({ waiting: null });
+    installFakeSW({ controller: {}, registration: reg });
+
+    registerServiceWorker();
+    fireLoad();
+    await flushMicrotasks();
+
+    // Simular ciclo de instalación de un SW nuevo.
+    const installing = makeWorker('chagra-v999');
+    const stateListeners = [];
+    installing.addEventListener = (type, cb) => {
+      if (type === 'statechange') stateListeners.push(cb);
+    };
+    installing.state = 'installing';
+    reg.installing = installing;
+    reg._emit('updatefound', {});
+
+    // El SW termina de instalar → queda en waiting → statechange.
+    installing.state = 'installed';
+    reg.waiting = installing;
+    stateListeners.forEach((cb) => cb());
+
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_DELAY_MS + 10);
+
+    expect(installing.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+  });
+
+  it('autoUpdate:false → consent-only (NO skipWaiting automático)', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem(ACK_STORAGE_KEY, 'chagra-v100');
+    const waiting = makeWorker('chagra-v999');
+    const reg = makeRegistration({ waiting });
+    installFakeSW({ controller: {}, registration: reg });
+
+    registerServiceWorker({ autoUpdate: false });
+    fireLoad();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_DELAY_MS + 50);
+
+    // Con auto-update apagado, NO se manda SKIP_WAITING (solo banner visible).
+    expect(waiting.postMessage).not.toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+  });
+
+  it('SKIP_WAITING se manda UNA sola vez aunque haya varias señales de waiting', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem(ACK_STORAGE_KEY, 'chagra-v100');
+    const waiting = makeWorker('chagra-v999');
+    const reg = makeRegistration({ waiting });
+    installFakeSW({ controller: {}, registration: reg });
+
+    registerServiceWorker();
+    fireLoad();
+    await flushMicrotasks();
+
+    // Segunda señal de waiting (p.ej. otro updatefound con el mismo waiting).
+    reg._emit('updatefound', {});
+    await flushMicrotasks();
+
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_DELAY_MS + 10);
+
+    const skipCalls = waiting.postMessage.mock.calls.filter(
+      ([msg]) => msg && msg.type === 'SKIP_WAITING'
+    );
+    expect(skipCalls).toHaveLength(1);
+  });
+
+  it('auto-update dispara chagra:sw-update-requested (controllerchange recarga SIEMPRE, aun sin controller previo)', async () => {
+    vi.useFakeTimers();
+    localStorage.setItem(ACK_STORAGE_KEY, 'chagra-v100');
+    const waiting = makeWorker('chagra-v999');
+    const reg = makeRegistration({ waiting });
+    // Página arrancó SIN controller (hard reload / carga no controlada) PERO
+    // hay un waiting. El auto-update debe forzar la recarga vía el evento.
+    const sw = installFakeSW({ controller: null, registration: reg });
+
+    const requested = vi.fn();
+    window.addEventListener('chagra:sw-update-requested', requested);
+
+    registerServiceWorker();
+    fireLoad();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(AUTO_UPDATE_DELAY_MS + 10);
+
+    expect(requested).toHaveBeenCalled();
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+
+    // controllerchange: aunque no había controller, userUpdateRequested=true →
+    // recarga (no se traga el evento como first-install).
+    sw._emit('controllerchange');
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+
+    window.removeEventListener('chagra:sw-update-requested', requested);
+  });
+
+  it('SIN serviceWorker en navigator → no-op (no lanza)', () => {
+    // Asegurar que no existe.
+    delete navigator.serviceWorker;
+    expect(() => registerServiceWorker()).not.toThrow();
+  });
+});

--- a/src/services/swRegistration.js
+++ b/src/services/swRegistration.js
@@ -1,0 +1,248 @@
+/**
+ * swRegistration.js — registro del Service Worker + AUTO-UPDATE seguro.
+ *
+ * Extraído de main.jsx (antes inline) para poder testear el flujo de
+ * actualización en vitest sin montar todo el árbol React.
+ *
+ * ── Cambio de comportamiento (2026-06-15): consent-only → AUTO-UPDATE ──────
+ * ANTES: cuando había un SW nuevo en `waiting`, SOLO se mostraba el banner
+ * "nueva versión disponible" y el operador debía dar click "Actualizar". El
+ * operador llevaba SEMANAS viendo el build viejo porque ese banner no le
+ * funcionaba (red flaky, banner suprimido por el ack, no lo veía, etc.).
+ *
+ * AHORA: al detectar un SW en `waiting` disparamos AUTOMÁTICAMENTE el MISMO
+ * flujo que dispara el botón del banner:
+ *   1. `chagra:sw-update-requested`  → el guard de controllerchange recargará
+ *      SIEMPRE (incluso si la página arrancó sin controller — caso first
+ *      reload no controlado).
+ *   2. `waiting.postMessage({type:'SKIP_WAITING'})` → el SW nuevo activa,
+ *      hace `clients.claim()` → dispara `controllerchange` → recargamos UNA
+ *      sola vez.
+ * Se aplica con un pequeño delay (AUTO_UPDATE_DELAY_MS) para no cortar una
+ * acción del usuario en curso. El UpdateAvailableBanner se mantiene como
+ * fallback VISIBLE (por si el auto-update no llega a recargar, p.ej. red que
+ * cuelga el activate).
+ *
+ * ── Seguridad anti-loop (NO romper) ───────────────────────────────────────
+ * El guard original sigue intacto:
+ *   - `reloading`: una sola recarga por vida de la página.
+ *   - `hadController`: NO recargar en first install (clients.claim() dispara
+ *     controllerchange por primera vez aunque sea instalación inicial).
+ *   - `userUpdateRequested` (vía evento chagra:sw-update-requested): cuando la
+ *     actualización la pidió alguien (banner o este auto-update), la PRÓXIMA
+ *     controllerchange SIEMPRE recarga, aun sin controller previo.
+ *   - `autoUpdateTriggered`: el auto-update se dispara UNA sola vez por
+ *     registro (no re-disparar SKIP_WAITING si ya lo mandamos).
+ *
+ * Trabajo sin guardar: NO bloqueamos el auto-update por la cola del agente —
+ * `agentRequestQueue` es DURABLE (IndexedDB, v20): sobrevive a la recarga. Si
+ * en el futuro hay estado volátil no-durable que proteger, este es el punto
+ * para gatear (ver `isReloadSafe`).
+ */
+
+import {
+  shouldShowUpdateBanner,
+  readAckedVersion,
+  seedFirstInstallAck,
+} from './swUpdateAck';
+import { reloadPage } from './pageReload';
+
+// Delay antes de aplicar el auto-update: ventana para no cortar una acción del
+// usuario en curso (submit de form, etc.). Corto a propósito: el objetivo es
+// que el deploy se VEA pronto, no postergarlo. La recarga es de todos modos
+// segura (cola durable).
+export const AUTO_UPDATE_DELAY_MS = 2000;
+
+/**
+ * Pregunta CACHE_NAME al SW vía MessageChannel con timeout corto. Devuelve
+ * null si no responde (no bloquear UI ni spammear toast).
+ */
+export function getSwVersion(sw, timeoutMs = 1500) {
+  return new Promise((resolve) => {
+    if (!sw || typeof MessageChannel === 'undefined') {
+      resolve(null);
+      return;
+    }
+    const channel = new MessageChannel();
+    const timer = setTimeout(() => {
+      channel.port1.close();
+      resolve(null);
+    }, timeoutMs);
+    channel.port1.onmessage = (event) => {
+      clearTimeout(timer);
+      channel.port1.close();
+      resolve(event.data?.version ?? null);
+    };
+    try {
+      sw.postMessage({ type: 'GET_VERSION' }, [channel.port2]);
+    } catch (_) {
+      clearTimeout(timer);
+      channel.port1.close();
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * ¿Es seguro recargar ahora? Hoy SIEMPRE true: el único estado de trabajo en
+ * vuelo (cola de requests del agente) es durable (IndexedDB). Punto de
+ * extensión si en el futuro hay estado volátil que proteger.
+ */
+export function isReloadSafe() {
+  return true;
+}
+
+/**
+ * Registra el Service Worker e instala el flujo de AUTO-UPDATE seguro.
+ *
+ * Idempotente respecto al guard interno por llamada (cada `registerServiceWorker`
+ * crea su propio estado). En prod se llama UNA vez desde main.jsx.
+ *
+ * @param {object} [opts]
+ * @param {(version:string)=>void} [opts.onUpdateAvailable] — callback opcional
+ *   cuando hay versión nueva (además del CustomEvent del banner). Para tests.
+ * @param {boolean} [opts.autoUpdate=true] — si false, vuelve a consent-only
+ *   (solo banner, sin skipWaiting automático). Permite al operador desactivar
+ *   el comportamiento sin revertir código (ver tradeoff en el PR).
+ * @param {number} [opts.autoUpdateDelayMs=AUTO_UPDATE_DELAY_MS]
+ */
+export function registerServiceWorker(opts = {}) {
+  const {
+    autoUpdate = true,
+    autoUpdateDelayMs = AUTO_UPDATE_DELAY_MS,
+  } = opts;
+
+  if (!('serviceWorker' in navigator)) return;
+
+  // ── Banner "nueva versión disponible" (fallback VISIBLE) ─────────────────
+  // SOLO cuando hay un SW nuevo en waiting. NUNCA por controllerchange: ese
+  // evento significa que la actualización YA se aplicó. First install (sin ack
+  // previo) → suprimir y sembrar el ack para que la primera notif real dispare.
+  const maybeDispatchUpdateAvailable = async (sw) => {
+    if (!sw) return;
+    try {
+      const version = await getSwVersion(sw);
+      if (!version) return;
+      const lastAcked = readAckedVersion();
+      if (lastAcked === null) {
+        seedFirstInstallAck(version);
+        return;
+      }
+      if (shouldShowUpdateBanner(version, lastAcked)) {
+        window.dispatchEvent(
+          new CustomEvent('chagra:update-available', { detail: { version } })
+        );
+      }
+    } catch (_) {
+      // SW no responde / MessageChannel timeout → no spammear toast.
+    }
+  };
+
+  // ── Guard anti-loop de recarga (patrón Workbox) ──────────────────────────
+  // `reloading` evita bucles; `hadController` evita recargar en first install
+  // (clients.claim() dispara controllerchange aunque sea instalación inicial);
+  // `userUpdateRequested` fuerza recarga cuando la actualización la pidió el
+  // banner O este auto-update (chagra:sw-update-requested), incluso si la
+  // página arrancó sin controller.
+  let reloading = false;
+  let hadController = Boolean(navigator.serviceWorker.controller);
+  let userUpdateRequested = false;
+  let autoUpdateTriggered = false;
+
+  window.addEventListener('chagra:sw-update-requested', () => {
+    userUpdateRequested = true;
+  });
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!hadController && !userUpdateRequested) {
+      hadController = true; // primer claim en first install — sin recarga
+      return;
+    }
+    if (reloading) return;
+    reloading = true;
+    reloadPage();
+  });
+
+  // ── AUTO-UPDATE: aplica el waiting automáticamente (mismo flujo que el botón)
+  // Dispara `chagra:sw-update-requested` (para que controllerchange recargue
+  // SIEMPRE) y manda SKIP_WAITING al SW en waiting, tras un pequeño delay.
+  // Una sola vez por registro (autoUpdateTriggered). El banner sigue visible
+  // como fallback.
+  const applyWaitingUpdate = (waiting) => {
+    if (!autoUpdate || autoUpdateTriggered || !waiting) return;
+    if (!isReloadSafe()) return;
+    autoUpdateTriggered = true;
+    setTimeout(() => {
+      try {
+        window.dispatchEvent(new CustomEvent('chagra:sw-update-requested'));
+      } catch (_) { /* CustomEvent siempre existe en browsers soportados */ }
+      try {
+        waiting.postMessage({ type: 'SKIP_WAITING' });
+      } catch (_) {
+        // El SW no acepta el mensaje (raro): el banner sigue como fallback y,
+        // si todo lo demás falla, el próximo arranque trae el SW nuevo.
+      }
+    }, autoUpdateDelayMs);
+  };
+
+  // Cuando hay un SW nuevo en waiting: banner (fallback visible) + auto-update.
+  const onWaiting = (waiting) => {
+    if (!waiting) return;
+    maybeDispatchUpdateAvailable(waiting);
+    if (typeof opts.onUpdateAvailable === 'function') {
+      getSwVersion(waiting).then((v) => { if (v) opts.onUpdateAvailable(v); }).catch(() => {});
+    }
+    applyWaitingUpdate(waiting);
+  };
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js')
+      .then((registration) => {
+        console.log('Service Worker registrado:', registration.scope);
+      })
+      .catch((error) => {
+        console.error('Error registrando Service Worker:', error);
+      });
+
+    // Esperar a que el SW esté activo antes de registrar background sync.
+    navigator.serviceWorker.ready.then((registration) => {
+      if (registration.sync) {
+        registration.sync.register('sync-pending-transactions').catch((e) => {
+          console.warn('Background Sync no disponible:', e.message);
+        });
+      }
+      console.info('[SW] Service Worker activo y listo.');
+    });
+  });
+
+  // NOTA: el listener de mensajes SYNC_REQUESTED (→ syncManager.syncAll) vive
+  // en main.jsx, donde syncManager ya está importado. Este módulo se ocupa solo
+  // del registro + actualización del SW.
+
+  // Detección de SW nuevo en waiting: fuente del banner + del auto-update.
+  navigator.serviceWorker.ready.then((registration) => {
+    // First install: sembrar el ack con la versión del SW activo SIN disparar
+    // banner ni auto-update (la actualización ya está aplicada).
+    const activeSw = navigator.serviceWorker.controller || registration.active;
+    if (activeSw && readAckedVersion() === null) {
+      getSwVersion(activeSw)
+        .then((version) => { if (version) seedFirstInstallAck(version); })
+        .catch(() => { });
+    }
+    if (registration.waiting) {
+      onWaiting(registration.waiting);
+    }
+    registration.addEventListener('updatefound', () => {
+      const installing = registration.installing;
+      if (installing) {
+        installing.addEventListener('statechange', () => {
+          if (installing.state === 'installed' && registration.waiting) {
+            onWaiting(registration.waiting);
+          }
+        });
+      } else if (registration.waiting) {
+        onWaiting(registration.waiting);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Problema

El operador lleva **semanas viendo el build viejo**. Hoy el SW es *consent-only*: cuando hay una versión nueva queda en `waiting` y solo se muestra el `UpdateAvailableBanner` ("Actualizar"). Ese banner no le funciona de forma fiable (red flaky, toast suprimido por el ack, no lo ve, etc.), así que el deploy no se ve hasta que limpia caché a mano.

## Qué hace este PR

Cambia de **consent-only → AUTO-UPDATE seguro**. Cuando se detecta un SW nuevo en `waiting`, el cliente dispara **automáticamente** el mismo flujo que el botón del banner:

1. `chagra:sw-update-requested` → el guard de `controllerchange` recargará SIEMPRE (incluso si la página arrancó sin controller).
2. `waiting.postMessage({type:'SKIP_WAITING'})` → el SW nuevo activa, hace `clients.claim()` → `controllerchange` → **recarga UNA sola vez**.

Se aplica tras un pequeño delay (`AUTO_UPDATE_DELAY_MS = 2000ms`) para no cortar una acción del usuario en curso. El `UpdateAvailableBanner` se mantiene como **fallback visible** por si el auto-update no llega a recargar (p.ej. red que cuelga el `activate`).

### Cambios

- **Extrae** el registro + actualización del SW de `main.jsx` a `src/services/swRegistration.js` (antes era inline e imposible de testear en vitest). `main.jsx` solo conserva el listener `SYNC_REQUESTED → syncManager.syncAll()` y llama a `registerServiceWorker()`.
- **`applyWaitingUpdate`**: dispara el flujo SKIP_WAITING una sola vez por registro (`autoUpdateTriggered`).
- **Guard anti-loop INTACTO**: `reloading` (una recarga por vida de página), `hadController` (first install no recarga), `userUpdateRequested` (recarga aun sin controller previo). No se tocó.
- **`public/sw.js`**: el SW **sigue sin** `self.skipWaiting()` automático (a propósito — el cliente orquesta la recarga única). Solo se actualizó el comentario que explicaba el rationale consent-only, ahora documenta el auto-update.
- **NO se tocó** la lógica cache-first del `fetch`.

### Seguridad: ¿se pierde trabajo al recargar?

No. El único estado de trabajo en vuelo (`agentRequestQueue`) es **durable** (IndexedDB, v20): sobrevive a la recarga. Dejé el punto de extensión `isReloadSafe()` por si en el futuro hay estado volátil que proteger.

## Tradeoff (decisión del operador)

| | **Auto-update (este PR)** | **Consent-banner (hoy)** |
|---|---|---|
| Deploy se ve | Solo, en ~2s + 1 recarga | Solo si el usuario ve y clickea el banner |
| Control del usuario | Recarga automática (puede sorprender) | El usuario decide cuándo |
| Riesgo | Recarga mientras escribe (mitigado: delay + cola durable) | Sigue viendo build viejo indefinidamente (problema actual) |
| Offline-first | Intacto (no toca cache-first del fetch) | Igual |

**Reversible sin tocar código**: `registerServiceWorker({ autoUpdate: false })` vuelve a consent-only (solo banner). Si el operador prefiere mantener el consent-banner, basta ese flag.

## Tests

`src/services/__tests__/swRegistration.test.js` (7 tests, todos verdes):
- waiting → auto `SKIP_WAITING` tras el delay → **UN solo reload** por `controllerchange` (segundo `controllerchange` NO recarga → sin doble-reload ni loop).
- **first install** (página sin controller, claim-only) → NO recarga.
- `updatefound → installed` con waiting → auto `SKIP_WAITING`.
- `autoUpdate:false` → consent-only (NO skipWaiting automático).
- `SKIP_WAITING` se manda **una sola vez** aunque haya varias señales de waiting.
- auto-update dispara `chagra:sw-update-requested` → recarga aun sin controller previo.
- sin `serviceWorker` en `navigator` → no-op.

Suite SW completa verde (92 tests). ESLint `--max-warnings=0` limpio. `vite build` OK. Los tests existentes (`UpdateAvailableBanner.update.test.jsx`, `swUpdateAck`, `sw-offline-precache`) **no se tocaron y siguen pasando**.

> Nota: una falla pre-existente en `outputGuards.mipPlaga.test.js` (no relacionada con el SW) ya existe en `main` (verificado con mis cambios stasheados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)