### PR TITLE
fix(ci): heap eslint 16GB (OOM del lint bloqueaba deploys a prod)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
           # ENTERO (no era un error de lint, era falta de memoria, y el crash se
           # comia la logica soft-fail). Subimos el heap de node para que eslint
           # complete. El runner (alpha) tiene RAM de sobra.
-          export NODE_OPTIONS="--max-old-space-size=8192"
+          export NODE_OPTIONS="--max-old-space-size=16384"
           if ! npm run lint -- --max-warnings 9999 2>&1 | tee /tmp/lint.log; then
             {
               echo "## Deploy bloqueado: lint failed"


### PR DESCRIPTION
El step Lint de deploy.yml OOMeaba: 8GB de heap insuficientes para eslint del repo completo bajo presion de memoria en alpha → deploys a prod fallaban → las features mergeadas no llegaban. Sube a 16GB.