### PR TITLE
feat(agente): pantalla vacia = catalogo completo de chips (ver todo)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3090,7 +3090,7 @@ export default function AgentScreen({ onBack, initialContext }) {
         hasAttachment={false}
         disabled={state === STATE_RECORDING}
         isPro={getCurrentTier() === 'pro'}
-        chipDefs={profileChipDefs}
+        chipDefs={messages.length === 0 ? null : profileChipDefs}
       />
 
       {/* ── Compositor pill — paridad completa AgentHero (2026-06-08).


### PR DESCRIPTION
El filtro por perfil dejaba al operador (y a usuarios sin perfil definido) con un subconjunto en la pantalla vacia (sin silvopastoreo/restauracion/paramo). Ahora la pantalla VACIA muestra el catalogo COMPLETO (descubrimiento + 'ver todo' del operador); con conversacion activa se filtra por perfil para no saturar.