### PR TITLE
feat(home): seguimiento de procesos de finca (tarjetas + vista)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.51",
+  "version": "1.0.52",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'chagra-v310';
+const CACHE_NAME = 'chagra-v311';
 
 // Cache de GROUNDING del agente (corpus RAG + embeddings + tiles del mapa).
 // SEPARADO de CACHE_NAME a propósito: su contenido NO está hasheado por

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import useAssetStore from './store/useAssetStore';
 import { fetchFromFarmOS } from './services/apiService';
 import { PRIMARY_WORKER_NAME } from './config/workerConfig';
 import { tieneAccesoGlaciarActual } from './config/glaciarAccess';
+import { parseSeguimientoView } from './config/seguimientoProcesos';
 import { initCatalog } from './db/catalogDB';
 import NetworkStatusBar from './components/NetworkStatusBar';
 import PendingTasksWidget from './components/PendingTasksWidget';
@@ -69,6 +70,7 @@ const VoiceCapture = lazy(() => import('./components/VoiceCapture'));
 const PlantaPorVozScreen = lazy(() => import('./components/PlantaPorVozScreen'));
 const ProcesosPorVozScreen = lazy(() => import('./components/ProcesosPorVozScreen'));
 const CicloCultivoScreen = lazy(() => import('./components/CicloCultivoScreen'));
+const SeguimientoProcesoScreen = lazy(() => import('./components/SeguimientoProcesoScreen'));
 const SoilDiagnosticScreen = lazy(() => import('./components/SoilDiagnosticScreen'));
 const GlaciarReporteScreen = lazy(() => import('./components/GlaciarReporteScreen'));
 const GlaciarHistorialScreen = lazy(() => import('./components/GlaciarHistorialScreen'));
@@ -690,6 +692,23 @@ export default function App() {
   }, [navigate]);
 
   const renderView = () => {
+    // Seguimiento de procesos de finca (ruta dinámica 'seguimiento_<key>':
+    // reforestacion/silvopastoreo/paramo/cerdos). Tarjetas del home →
+    // SeguimientoProcesoScreen. Se resuelve antes del switch porque es una
+    // ruta paramétrica, no un literal.
+    const seguimientoKey = parseSeguimientoView(currentView);
+    if (seguimientoKey) {
+      return (
+        <ErrorBoundary>
+          <SeguimientoProcesoScreen
+            procesoKey={seguimientoKey}
+            onBack={() => navigate('dashboard')}
+            onSave={showToast}
+          />
+        </ErrorBoundary>
+      );
+    }
+
     switch (currentView) {
       case 'loading':
         return <LoadingFallback />;

--- a/src/components/CarbonoPsaSubvista.jsx
+++ b/src/components/CarbonoPsaSubvista.jsx
@@ -1,0 +1,254 @@
+import { useMemo } from 'react';
+import { AlertTriangle, ShieldCheck, Scale, Ruler, Leaf } from 'lucide-react';
+import { evaluarPSA } from '../services/psaElegibilidad';
+import { detectarAlertaCarbono } from '../services/carbonoAlerta';
+import RESTAURACION from '../data/restauracion.json';
+import CARBONO_CAPTURA from '../data/carbono-captura.json';
+import PSA_DATA from '../data/psa.json';
+
+/**
+ * Lista cruda de modalidades PSA, para el caso "el perfil de la finca no
+ * permite decidir elegibilidad": en vez de inventar elegibilidad, mostramos el
+ * menú completo de psa.json para que el campesino lo consulte con su CAR.
+ */
+const PSA_MODALIDADES = Array.isArray(PSA_DATA?.modalidades) ? PSA_DATA.modalidades : [];
+
+/**
+ * CarbonoPsaSubvista — sub-vista "Carbono y PSA" DENTRO del seguimiento de
+ * Reforestación (process_type 'restoration'). Operador 2026-06-15.
+ *
+ * Tres bloques, en este orden de prioridad (lo defensivo primero):
+ *   1. ALERTA ANTI-TRAMPA de bonos de carbono (PROMINENTE). Reusa la guarda
+ *      cerrada `restauracion.json.guardas.bonos_carbono` + el detector
+ *      `carbonoAlerta.detectarAlertaCarbono` (mismas trampas/recomendacion que
+ *      usa el agente). NO duplica el texto: lo lee de los datos.
+ *   2. ELEGIBILIDAD PSA: reusa `psaElegibilidad.evaluarPSA` + `psa.json`.
+ *   3. ESTIMACION DE CO2 — anti-alucinacion ESTRICTA: muestra el RANGO de
+ *      referencia con FUENTE (carbono-captura.json, DR-RESTAURACION-1) marcado
+ *      [VALIDAR], y el METODO (que se necesitaria medir). NUNCA un numero
+ *      exacto calculado para el predio: sin medicion de campo no hay cifra.
+ *
+ * Hereda el gate por perfil de Reforestacion (homeModuleSelector): el perfil
+ * urbano nunca llega aca, asi que esta sub-vista no necesita re-gatear.
+ *
+ * @param {object} props
+ * @param {object} [props.proceso] FarmProcess de la reforestacion (para contexto:
+ *   # arboles / zona). Solo se usa para CONTEXTUALIZAR, nunca para fabricar cifras.
+ * @param {{altitud?: number, enCuenca?: boolean, enParamo?: boolean}} [props.perfilFinca]
+ *   Perfil de la finca para evaluar elegibilidad PSA.
+ */
+export default function CarbonoPsaSubvista({ proceso, perfilFinca }) {
+  const a = proceso?.attributes || {};
+
+  // 1) Alerta anti-trampa. La guarda cerrada SIEMPRE se muestra (es defensiva,
+  //    no depende de que el campesino mencione "bonos"). Las trampas/recomendacion
+  //    detalladas vienen del detector compartido con el agente.
+  const guardaBonos = RESTAURACION?.guardas?.bonos_carbono || '';
+  const detalleCarbono = useMemo(
+    () => detectarAlertaCarbono('bonos de carbono'),
+    [],
+  );
+
+  // 2) PSA. El interes en carbono se asume porque el campesino esta mirando esta
+  //    sub-vista; el resto sale del perfil real de la finca (sin inventar).
+  const psa = useMemo(
+    () => evaluarPSA({ ...(perfilFinca || {}), interes: 'carbono' }),
+    [perfilFinca],
+  );
+
+  // 3) CO2: ¿hay factor con fuente en los datos del repo? Si lo hay, se muestra
+  //    como rango orientativo con fuente + [VALIDAR]. NUNCA se calcula un numero
+  //    exacto para este predio (carbono-captura.requiere_medicion_campo === true).
+  const rangos = Array.isArray(CARBONO_CAPTURA?.rangos_referencia)
+    ? CARBONO_CAPTURA.rangos_referencia
+    : [];
+  const hayFactorConFuente = rangos.length > 0;
+  const requiereMedicion = CARBONO_CAPTURA?.requiere_medicion_campo !== false;
+  const metodo = CARBONO_CAPTURA?.metodo_estimacion || null;
+
+  // Contexto del proceso (NO es un calculo de CO2; es lo que el campesino registro).
+  const contexto = [];
+  if (a.quantity) contexto.push(`${a.quantity} ${a.unit || ''}`.trim());
+  if (a.subject_label) contexto.push(a.subject_label);
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="carbono-psa-subvista">
+      <header className="flex items-center gap-2">
+        <Leaf size={18} className="text-lime-400 shrink-0" />
+        <div>
+          <h2 className="text-base font-bold text-white leading-tight">Carbono y PSA</h2>
+          <p className="text-xs text-slate-400 leading-tight">
+            Cómo se paga por restaurar — y cómo NO caer en trampas.
+          </p>
+        </div>
+      </header>
+
+      {/* ── 1. ALERTA ANTI-TRAMPA (prominente, defensiva) ─────────────── */}
+      <section
+        className="bg-red-900/30 border-2 border-red-700/70 rounded-xl p-4 flex flex-col gap-2"
+        data-testid="alerta-bonos-carbono"
+        role="alert"
+      >
+        <div className="flex items-center gap-2">
+          <AlertTriangle size={18} className="text-red-400 shrink-0" />
+          <h3 className="text-sm font-black text-red-200 uppercase tracking-wide">
+            Cuidado con los bonos de carbono
+          </h3>
+        </div>
+        <p className="text-xs text-red-100 leading-snug">{guardaBonos}</p>
+
+        {detalleCarbono?.trampas?.length > 0 && (
+          <ul className="flex flex-col gap-1.5 mt-1">
+            {detalleCarbono.trampas.map((t) => (
+              <li key={t.nombre} className="text-2xs text-red-100/90 leading-snug">
+                <span className="font-bold text-red-200">{t.nombre}:</span> {t.riesgo}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <p className="text-2xs text-red-100/90 leading-snug mt-1">
+          <span className="font-bold">No firme sin asesoría jurídica.</span> Use la
+          CAR (Corporación Autónoma Regional), los consultorios jurídicos
+          universitarios, la Personería Municipal o la Defensoría del Pueblo —
+          todos gratuitos.
+        </p>
+
+        {detalleCarbono?.recomendacion && (
+          <p className="text-2xs text-red-200/80 italic leading-snug mt-1">
+            {detalleCarbono.recomendacion}
+          </p>
+        )}
+      </section>
+
+      {/* ── 2. ELEGIBILIDAD PSA ───────────────────────────────────────── */}
+      <section
+        className="bg-slate-900 border border-slate-800 rounded-xl p-4 flex flex-col gap-2"
+        data-testid="psa-elegibilidad"
+      >
+        <div className="flex items-center gap-2">
+          <ShieldCheck size={16} className="text-emerald-400 shrink-0" />
+          <h3 className="text-sm font-bold text-emerald-200">
+            Pago por Servicios Ambientales (PSA)
+          </h3>
+        </div>
+        <p className="text-xs text-slate-300 leading-snug">
+          La alternativa legal y más segura: el Estado (vía la CAR) le paga por
+          conservar o restaurar. <span className="font-bold text-slate-100">La tierra sigue siendo suya.</span>
+        </p>
+
+        <p className="text-2xs text-slate-400">
+          {psa.elegible
+            ? 'Según el perfil de tu finca, podrías aplicar a estas modalidades:'
+            : 'Modalidades del PSA que existen en Colombia (consulta con tu CAR cuál aplica a tu finca):'}
+        </p>
+        <ul className="flex flex-col gap-1.5">
+          {(psa.elegible ? psa.modalidades : PSA_MODALIDADES).map((m) => (
+            <li
+              key={m.id}
+              className="bg-slate-800/50 border border-slate-700/50 rounded-lg px-3 py-2"
+            >
+              <span className="block text-xs font-bold text-slate-100">{m.nombre}</span>
+              <span className="block text-2xs text-slate-400 leading-snug">{m.que_cubre}</span>
+            </li>
+          ))}
+        </ul>
+
+        {psa.monto && (
+          <p className="text-2xs text-slate-400 mt-1">
+            <Scale size={11} className="inline mr-1 -mt-0.5" />
+            Monto orientativo: <span className="text-slate-200 font-bold">{psa.monto}</span>.
+            {' '}Autoridad: {psa.autoridad}.
+          </p>
+        )}
+
+        {Array.isArray(psa.requisitos) && psa.requisitos.length > 0 && (
+          <details className="mt-1">
+            <summary className="text-2xs font-bold text-emerald-300 cursor-pointer">
+              ¿Qué piden para aplicar?
+            </summary>
+            <ul className="list-disc list-inside mt-1 flex flex-col gap-0.5">
+              {psa.requisitos.map((r, i) => (
+                <li key={i} className="text-2xs text-slate-400 leading-snug">{r}</li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </section>
+
+      {/* ── 3. ESTIMACION DE CO2 (anti-alucinacion estricta) ──────────── */}
+      <section
+        className="bg-slate-900 border border-slate-800 rounded-xl p-4 flex flex-col gap-2"
+        data-testid="co2-estimacion"
+      >
+        <div className="flex items-center gap-2">
+          <Ruler size={16} className="text-sky-400 shrink-0" />
+          <h3 className="text-sm font-bold text-sky-200">Captura de CO₂</h3>
+        </div>
+
+        {contexto.length > 0 && (
+          <p className="text-2xs text-slate-500 leading-snug">
+            Tu registro: {contexto.join(' · ')}.
+          </p>
+        )}
+
+        {/* MENSAJE DE VALIDACION SIEMPRE PRESENTE: nunca un numero exacto como hecho. */}
+        <p className="text-xs text-amber-200 leading-snug font-medium" data-testid="co2-validacion">
+          El cálculo de captura de CO₂ de tu predio requiere medición de campo.
+          {' '}Cualquier cifra exacta sin medir es una estimación preliminar
+          <span className="font-bold"> [VALIDAR]</span>, no un hecho.
+        </p>
+
+        {hayFactorConFuente ? (
+          <div className="bg-sky-950/30 border border-sky-800/50 rounded-lg p-3 flex flex-col gap-1.5" data-testid="co2-rango-referencia">
+            <p className="text-2xs font-bold text-sky-300 uppercase tracking-wide">
+              Rango de referencia (orientativo) · [VALIDAR]
+            </p>
+            <ul className="flex flex-col gap-1">
+              {rangos.map((r) => (
+                <li key={r.ecosistema} className="text-2xs text-slate-300 leading-snug">
+                  <span className="font-bold text-slate-100">{r.ecosistema}:</span>{' '}
+                  {Array.isArray(r.rango_tC_ha) ? `${r.rango_tC_ha[0]}–${r.rango_tC_ha[1]} tC/ha` : '—'}
+                  {r.fuente ? <span className="text-slate-500"> · {r.fuente}</span> : null}
+                </li>
+              ))}
+            </ul>
+            {CARBONO_CAPTURA?.conversion?.explicacion && (
+              <p className="text-3xs text-slate-500 leading-snug">
+                {CARBONO_CAPTURA.conversion.explicacion}
+              </p>
+            )}
+            <p className="text-3xs text-slate-500 leading-snug">
+              Fuente: {CARBONO_CAPTURA.fuente}. Estimación preliminar — requiere
+              medición de campo. La medición formal (MRV) es costosa e inviable
+              para un campesino solo.
+            </p>
+          </div>
+        ) : (
+          <p className="text-2xs text-slate-400 leading-snug">
+            No hay un factor de captura con fuente verificable para mostrar un
+            rango. No se inventa ningún número.
+          </p>
+        )}
+
+        {requiereMedicion && metodo && (
+          <details className="mt-1">
+            <summary className="text-2xs font-bold text-sky-300 cursor-pointer">
+              {metodo.titulo}
+            </summary>
+            <ul className="list-disc list-inside mt-1 flex flex-col gap-0.5">
+              {(metodo.pasos || []).map((p, i) => (
+                <li key={i} className="text-2xs text-slate-400 leading-snug">{p}</li>
+              ))}
+            </ul>
+            {metodo.advertencia && (
+              <p className="text-3xs text-amber-300/80 italic leading-snug mt-1">
+                {metodo.advertencia}
+              </p>
+            )}
+          </details>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -13,7 +13,9 @@ import { PRIMARY_WORKER_NAME } from '../config/workerConfig';
 import useFincaActiveStore from '../services/fincaActiveStore';
 import usePrefsStore from '../store/usePrefsStore';
 import { stop as stopTTS } from '../services/ttsService';
-import { getNotificationStyle, setNotificationStyle, getTelemetryConsent, setTelemetryConsent, HOME_MODULES, getModuleVisibility, setModuleVisibility } from '../services/userProfileService';
+import { getNotificationStyle, setNotificationStyle, getTelemetryConsent, setTelemetryConsent, HOME_MODULES, getModuleVisibility, setModuleVisibility, hasManualModuleVisibility, getProfile } from '../services/userProfileService';
+import { selectHomeModuleVisibilityMap } from '../services/homeModuleSelector';
+import { tieneAccesoGlaciarActual } from '../config/glaciarAccess';
 import { getOperatorPhoto, setOperatorPhotoFromFile, removeOperatorPhotoLocal } from '../services/operatorPhotoService';
 
 const TTL_OPTIONS = [
@@ -136,9 +138,23 @@ export default function ProfileScreen({ onBack, onHome }) {
       : '7d'
   );
 
-  // Visibilidad de módulos del Home (#7003). Lee la configuración del perfil
-  // y permite activar/desactivar cada módulo individualmente.
-  const [moduleVisibility, setModuleVisibilityState] = useState(() => getModuleVisibility());
+  // Visibilidad de módulos del Home (#7003 + gating por perfil 2026-06-15).
+  // Permite activar/desactivar cada módulo individualmente. Estado inicial =
+  // visibilidad EFECTIVA del home: si el usuario ya guardó una preferencia
+  // MANUAL, esa gana (#1560); si no, partimos del DEFAULT derivado del perfil
+  // (homeModuleSelector) para que los toggles coincidan con lo que el home
+  // realmente muestra. Así un urbano ve aquí 'zonas/insumos' ya en OFF (no un
+  // todo-ON que contradiga su home).
+  const [moduleVisibility, setModuleVisibilityState] = useState(() => {
+    try {
+      if (hasManualModuleVisibility()) return getModuleVisibility();
+      return selectHomeModuleVisibilityMap(getProfile(), {
+        esGuiaGlaciar: tieneAccesoGlaciarActual(),
+      });
+    } catch (_) {
+      return getModuleVisibility();
+    }
+  });
 
   // Free 7→10 fix-pack: HYTA (info GPU/Ollama) detrás de un toggle "Modo
   // técnico". Default OFF para que el campesino-target no vea jerga técnica

--- a/src/components/SeguimientoProcesoScreen.jsx
+++ b/src/components/SeguimientoProcesoScreen.jsx
@@ -10,6 +10,9 @@ import useAssetStore from '../store/useAssetStore';
 import CicloObservacion from './CicloObservacion';
 import CicloFotos from './CicloFotos';
 import ChagraGrowLoader from './ChagraGrowLoader';
+import CarbonoPsaSubvista from './CarbonoPsaSubvista';
+import useFincaActiveStore from '../services/fincaActiveStore';
+import { getProfile } from '../services/userProfileService';
 import animalDiagnostics from '../data/animal-diagnostics.json';
 
 /**
@@ -442,6 +445,16 @@ function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload
     return locationOptions.find((o) => o.id === a.location_land_asset_id)?.label || null;
   }, [a.location_land_asset_id, locationOptions]);
 
+  // Perfil de la finca para la sub-vista de Carbono/PSA (solo reforestación).
+  // Misma fuente que RestauracionPlanPDFButton: finca activa + perfil de usuario.
+  // Si no hay altitud conocida, queda undefined — NO se inventa.
+  const activeFinca = useFincaActiveStore((s) => s.getActiveFinca());
+  const perfilFinca = useMemo(() => {
+    const profile = (() => { try { return getProfile(); } catch { return null; } })();
+    const altitud = activeFinca?.altitud ?? profile?.finca_altitud ?? profile?.altitud ?? undefined;
+    return { altitud: altitud == null ? undefined : Number(altitud), enParamo: Number(altitud) >= 3000 || undefined };
+  }, [activeFinca]);
+
   const loadEvents = useCallback(async () => {
     try { setEvents((await getFarmEvents(processId)) || []); }
     catch { setEvents([]); }
@@ -542,6 +555,12 @@ function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload
         </ol>
         <p className="text-3xs text-slate-600 mt-1.5">Toca una etapa para marcar el avance. Los detalles técnicos de cada hito están por validar [VALIDAR].</p>
       </section>
+
+      {/* Carbono y PSA — solo en Reforestación (restoration). Hereda el gate por
+          perfil de Reforestación (el perfil urbano nunca llega a esta vista). */}
+      {def.processType === 'restoration' && (
+        <CarbonoPsaSubvista proceso={proceso} perfilFinca={perfilFinca} />
+      )}
 
       {/* Observaciones (reusa el motor del ciclo) */}
       <CicloObservacion processId={processId} currentStage={a.current_stage} onSaved={() => { loadEvents(); onReload?.(); }} />

--- a/src/components/SeguimientoProcesoScreen.jsx
+++ b/src/components/SeguimientoProcesoScreen.jsx
@@ -1,0 +1,584 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, Plus, Check, X, AlertTriangle, RotateCcw, CalendarDays, MapPin, Clock, ChevronRight } from 'lucide-react';
+import { createFarmProcess, recordFarmEvent } from '../services/farmEventService';
+import { confirmStage } from '../services/stageConfirmationService';
+import { listFarmProcesses, getFarmEvents } from '../db/farmProcessCache';
+import { stageSequenceForProcessType } from '../types/farmProcess';
+import { getSeguimientoDef } from '../config/seguimientoProcesos';
+import { newUlid } from '../utils/id';
+import useAssetStore from '../store/useAssetStore';
+import CicloObservacion from './CicloObservacion';
+import CicloFotos from './CicloFotos';
+import ChagraGrowLoader from './ChagraGrowLoader';
+import animalDiagnostics from '../data/animal-diagnostics.json';
+
+/**
+ * SeguimientoProcesoScreen — vista de SEGUIMIENTO de un proceso de finca
+ * (Reforestación · Silvopastoreo · Páramo · Cerdos). Operador 2026-06-15.
+ *
+ * Es "Mis plantas pero para procesos": lista los procesos ACTIVOS de su tipo,
+ * permite (a) INICIAR/registrar uno (qué, zona, fecha, notas), (b) ver sus
+ * ETAPAS con fechas, (c) agregar registros/fotos, (d) ver el avance.
+ *
+ * REUSA el motor existente del subsistema FarmProcess:
+ *   - createFarmProcess (escritura atómica del ciclo + evento inicial)
+ *   - confirmStage (avanzar/confirmar etapa, append-only)
+ *   - recordFarmEvent (nota de inicio)
+ *   - CicloObservacion (anotar observación por texto/voz → evento del ciclo)
+ *   - CicloFotos (adjuntar fotos al ciclo → evento photo_attached)
+ *   - stageSequenceForProcessType (etapas por tipo, types/farmProcess)
+ *
+ * Para 'pigs' surfacea la GUARDA crítica de leucaena/mimosina desde
+ * animal-diagnostics.json (DR-ANIMAL-1, fuentes ICA/AGROSAVIA/CIPAV). Los
+ * detalles técnicos sin fuente cerrada van marcados [VALIDAR].
+ */
+
+const PIG_GUARD = animalDiagnostics?.guardas?.leucaena_toxica || null;
+
+// Etapa inicial por tipo de proceso (primer hito de su secuencia).
+function initialStageFor(processType) {
+  const seq = stageSequenceForProcessType(processType);
+  return seq[0]?.stage || 'sowing_confirmed';
+}
+
+const fmtDate = (ms) => {
+  try { return new Date(ms).toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' }); }
+  catch { return '—'; }
+};
+
+export default function SeguimientoProcesoScreen({ procesoKey, onBack, onSave }) {
+  const def = useMemo(() => getSeguimientoDef(procesoKey), [procesoKey]);
+  const lands = useAssetStore((s) => s.lands);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [items, setItems] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [creating, setCreating] = useState(false);
+
+  const stageSeq = useMemo(
+    () => (def ? stageSequenceForProcessType(def.processType) : []),
+    [def],
+  );
+
+  const locationOptions = useMemo(
+    () => (lands || [])
+      .filter((l) => l?.id && l?.attributes?.name)
+      .map((l) => ({ id: l.id, label: l.attributes.name })),
+    [lands],
+  );
+
+  const load = useCallback(async () => {
+    if (!def) return;
+    setLoading(true);
+    setError('');
+    try {
+      const list = await listFarmProcesses({ process_type: def.processType });
+      // Activos primero, más recientes arriba.
+      const sorted = (Array.isArray(list) ? list : []).slice().sort((a, b) => {
+        const sa = a.attributes?.status === 'active' ? 0 : 1;
+        const sb = b.attributes?.status === 'active' ? 0 : 1;
+        if (sa !== sb) return sa - sb;
+        return (b.attributes?.updated_at || 0) - (a.attributes?.updated_at || 0);
+      });
+      setItems(sorted);
+    } catch (err) {
+      setError(`No pude leer tus procesos: ${err.message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [def]);
+
+  useEffect(() => {
+    // Carga al montar / al cambiar de proceso. load() hace su setState de forma
+    // asíncrona tras await IndexedDB (patrón establecido "cargar al montar",
+    // igual que CicloCultivoScreen/GlaciarHistorialScreen).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    load();
+  }, [load]);
+
+  const selected = useMemo(
+    () => items.find((p) => (p.process_id || p.id) === selectedId) || null,
+    [items, selectedId],
+  );
+
+  if (!def) {
+    return (
+      <div className="min-h-[100dvh] text-white flex items-center justify-center px-4">
+        <p className="text-slate-400 text-sm">Proceso no disponible.</p>
+      </div>
+    );
+  }
+
+  const Header = (
+    <header className="flex items-center gap-2 px-4 pt-[calc(14px+env(safe-area-inset-top))] pb-2">
+      <button
+        type="button"
+        onClick={creating ? () => setCreating(false) : (selected ? () => setSelectedId(null) : onBack)}
+        aria-label="Volver"
+        className="w-10 h-10 rounded-full bg-slate-800 hover:bg-slate-700 flex items-center justify-center"
+      >
+        <ChevronLeft size={20} />
+      </button>
+      <div className="flex items-center gap-2">
+        <span className="text-2xl" aria-hidden="true">{def.emoji}</span>
+        <div>
+          <h1 className="text-lg font-bold leading-tight text-white">{def.title}</h1>
+          <p className="text-xs text-slate-400 leading-tight">{def.subtitle}</p>
+        </div>
+      </div>
+    </header>
+  );
+
+  if (loading) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <div className="flex flex-col items-center gap-3 py-16"><ChagraGrowLoader size={56} /><p className="text-sm text-slate-400">Cargando tu seguimiento…</p></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <div className="flex flex-col items-center gap-4 py-12 px-4">
+          <AlertTriangle size={44} className="text-amber-400" />
+          <p className="text-sm text-amber-200 text-center max-w-sm">{error}</p>
+          <button onClick={load} className="px-5 py-2.5 bg-slate-800 hover:bg-slate-700 rounded-xl font-bold flex items-center gap-2"><RotateCcw size={16} /> Reintentar</button>
+        </div>
+      </div>
+    );
+  }
+
+  // Formulario de inicio
+  if (creating) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <IniciarProcesoForm
+          def={def}
+          locationOptions={locationOptions}
+          onCancel={() => setCreating(false)}
+          onCreated={async (newId) => {
+            await load();
+            setCreating(false);
+            setSelectedId(newId);
+            onSave?.(`${def.title}: seguimiento iniciado.`);
+          }}
+        />
+      </div>
+    );
+  }
+
+  // Detalle de un proceso
+  if (selected) {
+    return (
+      <div className="min-h-[100dvh] text-white">
+        {Header}
+        <ProcesoDetalle def={def} proceso={selected} stageSeq={stageSeq} locationOptions={locationOptions} onReload={load} />
+      </div>
+    );
+  }
+
+  // Lista / vacío
+  return (
+    <div className="min-h-[100dvh] text-white">
+      {Header}
+      <div className="px-4 pb-10 flex flex-col gap-3">
+        {def.processType === 'pigs' && PIG_GUARD && (
+          <div className="bg-red-900/25 border border-red-800/60 rounded-xl p-3 flex items-start gap-2">
+            <AlertTriangle size={16} className="text-red-400 shrink-0 mt-0.5" />
+            <p className="text-xs text-red-200 leading-snug">{PIG_GUARD}</p>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          className="w-full px-4 py-3 min-h-[48px] bg-lime-700 hover:bg-lime-600 rounded-xl font-bold flex items-center justify-center gap-2"
+        >
+          <Plus size={18} /> {def.startVerb}
+        </button>
+
+        {items.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 py-12 px-6 text-center">
+            <span className="text-5xl" aria-hidden="true">{def.emoji}</span>
+            <p className="text-sm text-slate-300 max-w-xs">
+              Aún no tienes seguimiento de {def.title.toLowerCase()}. Toca
+              "{def.startVerb}" para registrar el primero y seguir sus etapas.
+            </p>
+          </div>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {items.map((p) => {
+              const a = p.attributes || {};
+              const id = p.process_id || p.id;
+              const stageLabel = stageSeq.find((s) => s.stage === a.current_stage)?.label || a.current_stage || '—';
+              return (
+                <li key={id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedId(id)}
+                    className="w-full text-left bg-slate-900 border border-slate-800 hover:border-lime-700/50 rounded-xl p-3 flex items-center gap-3"
+                  >
+                    <span className="w-10 h-10 rounded-full bg-lime-900/40 border border-lime-800/50 flex items-center justify-center shrink-0 text-lg">
+                      {def.emoji}
+                    </span>
+                    <span className="flex-1 min-w-0">
+                      <span className="block text-sm font-bold text-slate-100 truncate">{a.subject_label || def.title}</span>
+                      <span className="block text-xs text-slate-400 truncate">
+                        {a.status === 'active' ? 'En curso' : 'Cerrado'} · {stageLabel}
+                        {a.quantity ? ` · ${a.quantity} ${a.unit || ''}` : ''}
+                      </span>
+                    </span>
+                    <ChevronRight size={18} className="text-slate-600 shrink-0" />
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * IniciarProcesoForm — formulario para registrar un nuevo proceso. Crea el
+ * FarmProcess vía createFarmProcess (escritura atómica) con la etapa inicial
+ * de su secuencia, y deja una nota de inicio si el campesino escribió algo.
+ */
+function IniciarProcesoForm({ def, locationOptions, onCancel, onCreated }) {
+  const [subject, setSubject] = useState('');
+  const [quantity, setQuantity] = useState(1);
+  const [unit, setUnit] = useState(def.defaultUnit);
+  const [locationId, setLocationId] = useState('');
+  const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState('');
+
+  const valid = subject.trim().length > 0 && Number(quantity) > 0;
+
+  const handleSubmit = useCallback(async () => {
+    if (!valid || saving) return;
+    setSaving(true);
+    setErr('');
+    try {
+      const now = Date.now();
+      const createdAt = new Date(date).getTime() || now;
+      const processId = newUlid();
+      const process = {
+        process_id: processId,
+        type: 'farm_process',
+        attributes: {
+          process_type: def.processType,
+          subject_kind: def.subjectKind,
+          // Sin slug del catálogo: estos procesos no siempre mapean a una
+          // especie del catálogo de cultivos. subject_label basta para validar.
+          subject_slug: '',
+          subject_label: subject.trim(),
+          variety: null,
+          quantity: Number(quantity),
+          unit: unit || def.defaultUnit,
+          location_land_asset_id: locationId,
+          status: 'active',
+          current_stage: initialStageFor(def.processType),
+          created_at: createdAt,
+          updated_at: now,
+          notes: notes.trim() || undefined,
+        },
+      };
+      await createFarmProcess(process);
+      // Nota de inicio (opcional) como evento del ciclo.
+      if (notes.trim()) {
+        await recordFarmEvent({
+          process_id: processId,
+          event_type: 'note',
+          occurred_at: createdAt,
+          actor: 'operator',
+          payload: { text: notes.trim() },
+        }).catch(() => {});
+      }
+      onCreated?.(processId);
+    } catch (e) {
+      setErr(`No se pudo iniciar el seguimiento: ${e.message}`);
+      setSaving(false);
+    }
+  }, [valid, saving, date, def, subject, quantity, unit, locationId, notes, onCreated]);
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <section className="bg-slate-900 border border-slate-800 rounded-xl p-3">
+        <p className="text-xs text-slate-400">{def.emoji} Nuevo seguimiento de {def.title.toLowerCase()}</p>
+      </section>
+
+      {def.processType === 'pigs' && PIG_GUARD && (
+        <div className="bg-red-900/25 border border-red-800/60 rounded-xl p-3 flex items-start gap-2">
+          <AlertTriangle size={16} className="text-red-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-red-200 leading-snug">{PIG_GUARD}</p>
+        </div>
+      )}
+
+      <label className="flex flex-col gap-1">
+        <span className="text-2xs font-bold text-slate-400 uppercase">¿Qué vas a seguir?</span>
+        <input
+          type="text"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
+          disabled={saving}
+          placeholder={def.subjectLabelPlaceholder}
+        />
+      </label>
+
+      <div className="flex gap-2">
+        <label className="flex flex-col gap-1 flex-1">
+          <span className="text-2xs font-bold text-slate-400 uppercase">Cantidad</span>
+          <input
+            type="number"
+            min="1"
+            step="1"
+            value={quantity}
+            onChange={(e) => setQuantity(Number(e.target.value))}
+            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
+            disabled={saving}
+          />
+        </label>
+        <label className="flex flex-col gap-1 flex-1">
+          <span className="text-2xs font-bold text-slate-400 uppercase">Unidad</span>
+          <input
+            type="text"
+            value={unit}
+            onChange={(e) => setUnit(e.target.value)}
+            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
+            disabled={saving}
+            placeholder={def.defaultUnit}
+          />
+        </label>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-2xs font-bold text-slate-400 uppercase">Zona / Lote</span>
+        <select
+          value={locationId}
+          onChange={(e) => setLocationId(e.target.value)}
+          className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
+          disabled={saving}
+        >
+          <option value="">{locationOptions.length === 0 ? 'Sin lotes disponibles' : 'Seleccionar…'}</option>
+          {locationOptions.map((o) => (
+            <option key={o.id} value={o.id}>{o.label}</option>
+          ))}
+        </select>
+        {!locationId && (
+          <span className="text-3xs text-slate-500">Sin asignar (puedes asignarlo después)</span>
+        )}
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-2xs font-bold text-slate-400 uppercase">Fecha de inicio</span>
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none"
+          disabled={saving}
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-2xs font-bold text-slate-400 uppercase">Notas <span className="text-slate-600 font-normal">(opcional)</span></span>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-lime-500 focus:outline-none resize-none"
+          disabled={saving}
+          placeholder="¿Algo importante para arrancar?"
+        />
+      </label>
+
+      {err && (
+        <div className="bg-amber-900/20 border border-amber-800/50 rounded-xl p-3 text-sm text-amber-200">{err}</div>
+      )}
+
+      <div className="flex gap-2 sticky bottom-0 bg-slate-950 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <button
+          onClick={onCancel}
+          disabled={saving}
+          className="flex-1 px-4 py-3 min-h-[44px] bg-slate-800 hover:bg-slate-700 text-white rounded-xl font-bold flex items-center justify-center gap-2 disabled:opacity-50"
+        >
+          <X size={18} /> Cancelar
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={!valid || saving}
+          className="flex-1 px-4 py-3 min-h-[44px] bg-lime-700 hover:bg-lime-600 text-white rounded-xl font-bold flex items-center justify-center gap-2 disabled:opacity-50 disabled:bg-slate-700"
+        >
+          <Check size={18} /> {saving ? 'Guardando…' : def.startVerb}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ProcesoDetalle — detalle de un proceso en seguimiento: resumen + línea de
+ * tiempo de ETAPAS (con confirmación de avance), observaciones por texto/voz,
+ * fotos del ciclo y el AVANCE (eventos del ciclo en orden).
+ */
+function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload }) {
+  const a = proceso.attributes || {};
+  const processId = proceso.process_id || proceso.id;
+  const [busy, setBusy] = useState(false);
+  const [events, setEvents] = useState([]);
+
+  // Nombre del lote resuelto desde el store (NO inventamos el nombre).
+  const locName = useMemo(() => {
+    if (!a.location_land_asset_id) return null;
+    return locationOptions.find((o) => o.id === a.location_land_asset_id)?.label || null;
+  }, [a.location_land_asset_id, locationOptions]);
+
+  const loadEvents = useCallback(async () => {
+    try { setEvents((await getFarmEvents(processId)) || []); }
+    catch { setEvents([]); }
+  }, [processId]);
+
+  useEffect(() => {
+    // Carga los eventos del proceso al montar el detalle (patrón "cargar al
+    // montar"; loadEvents hace su setState tras await IndexedDB).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    loadEvents();
+  }, [loadEvents]);
+
+  const currentIdx = stageSeq.findIndex((s) => s.stage === a.current_stage);
+
+  const handleStage = useCallback(async (newStage) => {
+    if (busy || newStage === a.current_stage) return;
+    setBusy(true);
+    try {
+      await confirmStage({ processId, newStage, actor: 'operator', reason: 'avance en campo' });
+      await loadEvents();
+      onReload?.();
+    } catch (e) {
+      console.warn('[SeguimientoProceso] confirmStage:', e.message);
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, a.current_stage, processId, loadEvents, onReload]);
+
+  return (
+    <div className="px-4 pb-10 flex flex-col gap-4">
+      {/* Resumen */}
+      <section className="bg-slate-900 border border-slate-800 rounded-xl p-4 flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-bold text-slate-200">{a.subject_label || def.title}</span>
+          <span className={`text-2xs px-2 py-0.5 rounded-full font-bold ${a.status === 'active' ? 'bg-emerald-900/40 text-emerald-300' : 'bg-slate-800 text-slate-500'}`}>
+            {a.status === 'active' ? 'EN CURSO' : (a.status || '').toUpperCase()}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-2xs text-slate-400">
+          {a.quantity ? <span>{a.quantity} {a.unit}</span> : null}
+          <span className="flex items-center gap-1"><CalendarDays size={11} /> Inicio: {fmtDate(a.created_at)}</span>
+          {locName && <span className="flex items-center gap-1"><MapPin size={11} /> {locName}</span>}
+        </div>
+        {a.notes && <p className="text-xs text-slate-300 italic">"{a.notes}"</p>}
+      </section>
+
+      {def.processType === 'pigs' && PIG_GUARD && (
+        <div className="bg-red-900/25 border border-red-800/60 rounded-xl p-3 flex items-start gap-2">
+          <AlertTriangle size={16} className="text-red-400 shrink-0 mt-0.5" />
+          <p className="text-xs text-red-200 leading-snug">{PIG_GUARD}</p>
+        </div>
+      )}
+
+      {/* Etapas con fechas — toca una para confirmar el avance. */}
+      <section>
+        <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Etapas del proceso</h2>
+        <ol className="flex flex-col gap-1.5">
+          {stageSeq.map((s, i) => {
+            const done = currentIdx >= 0 && i <= currentIdx;
+            const isCurrent = s.stage === a.current_stage;
+            const stageEvent = events.find(
+              (e) => e?.attributes?.event_type === 'stage_confirmed' && e?.attributes?.payload?.new_stage === s.stage,
+            );
+            const when = isCurrent && i === 0 ? a.created_at : stageEvent?.attributes?.occurred_at;
+            return (
+              <li key={s.stage}>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => handleStage(s.stage)}
+                  aria-label={`Confirmar etapa ${s.label}`}
+                  className={`w-full text-left rounded-xl px-3 py-2.5 border flex items-center gap-3 disabled:opacity-60 transition-colors ${
+                    isCurrent
+                      ? 'bg-lime-900/30 border-lime-700/60'
+                      : done
+                        ? 'bg-slate-900 border-slate-800'
+                        : 'bg-slate-900/40 border-slate-800/60 hover:border-slate-700'
+                  }`}
+                >
+                  <span className={`w-6 h-6 rounded-full shrink-0 grid place-items-center text-2xs font-bold ${
+                    done ? 'bg-lime-600 text-white' : 'bg-slate-700 text-slate-300'
+                  }`}>
+                    {done ? <Check size={13} /> : i + 1}
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className={`block text-sm leading-tight ${isCurrent ? 'font-bold text-lime-200' : 'text-slate-200'}`}>{s.label}</span>
+                    {when ? (
+                      <span className="block text-3xs text-slate-500 flex items-center gap-1"><Clock size={9} /> {fmtDate(when)}</span>
+                    ) : (
+                      <span className="block text-3xs text-slate-600">Pendiente</span>
+                    )}
+                  </span>
+                  {isCurrent && <span className="text-3xs text-lime-400 shrink-0 font-bold">ACTUAL</span>}
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+        <p className="text-3xs text-slate-600 mt-1.5">Toca una etapa para marcar el avance. Los detalles técnicos de cada hito están por validar [VALIDAR].</p>
+      </section>
+
+      {/* Observaciones (reusa el motor del ciclo) */}
+      <CicloObservacion processId={processId} currentStage={a.current_stage} onSaved={() => { loadEvents(); onReload?.(); }} />
+
+      {/* Fotos del proceso */}
+      <CicloFotos processId={processId} />
+
+      {/* Avance — bitácora del proceso */}
+      <section>
+        <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Avance</h2>
+        {events.length === 0 ? (
+          <p className="text-xs text-slate-500">Sin registros todavía. Confirma una etapa, anota una observación o agrega una foto.</p>
+        ) : (
+          <ul className="flex flex-col gap-1.5">
+            {events.map((e) => (
+              <li key={e.event_id} className="bg-slate-900 border border-slate-800 rounded-xl px-3 py-2 text-xs text-slate-300 flex items-center gap-2">
+                <span className="flex-1 min-w-0">{describeEvent(e, stageSeq)}</span>
+                <span className="text-3xs text-slate-600 shrink-0">{fmtDate(e.attributes?.occurred_at)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function describeEvent(e, stageSeq) {
+  const t = e?.attributes?.event_type;
+  const p = e?.attributes?.payload || {};
+  if (t === 'stage_confirmed' || t === 'stage_corrected') {
+    const lbl = stageSeq.find((s) => s.stage === p.new_stage)?.label || p.new_stage;
+    return `Etapa: ${lbl}`;
+  }
+  if (t === 'photo_attached') return 'Foto agregada';
+  if (t === 'observation') return p.text ? `Observación: "${p.text}"` : 'Observación';
+  if (t === 'note') return p.text ? `Nota: "${p.text}"` : 'Nota de inicio';
+  if (t && t.endsWith('_confirmed')) return 'Proceso iniciado';
+  return t || 'Registro';
+}

--- a/src/components/__tests__/CarbonoPsaSubvista.test.jsx
+++ b/src/components/__tests__/CarbonoPsaSubvista.test.jsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * CarbonoPsaSubvista.test.jsx — sub-vista "Carbono y PSA" dentro del
+ * seguimiento de Reforestación (operador 2026-06-15). Verifica:
+ *   - se muestra la ALERTA anti-trampa de bonos de carbono (defensiva);
+ *   - se muestra la ELEGIBILIDAD / modalidades PSA;
+ *   - ANTI-ALUCINACIÓN: nunca se renderiza un número de CO₂ presentado como
+ *     hecho. Si hay factor con fuente → rango orientativo [VALIDAR] + mensaje
+ *     de validación. Si NO hay factor con fuente → no aparece ningún número,
+ *     solo el mensaje de que requiere medición de campo.
+ */
+import React from 'react';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi } from 'vitest';
+
+afterEach(() => { cleanup(); vi.resetModules(); });
+
+const PROCESO = {
+  process_id: '01J',
+  type: 'farm_process',
+  attributes: {
+    process_type: 'restoration',
+    subject_label: 'Roble andino',
+    quantity: 120,
+    unit: 'árboles',
+    status: 'active',
+    current_stage: 'establecimiento',
+    created_at: Date.now(),
+  },
+};
+
+describe('CarbonoPsaSubvista', () => {
+  test('muestra la alerta anti-trampa de bonos de carbono', async () => {
+    const { default: CarbonoPsaSubvista } = await import('../CarbonoPsaSubvista');
+    render(<CarbonoPsaSubvista proceso={PROCESO} perfilFinca={{ altitud: 2600 }} />);
+
+    const alerta = screen.getByTestId('alerta-bonos-carbono');
+    expect(alerta).toBeInTheDocument();
+    // Texto defensivo clave: contratos largos + intermediarios + no firmar sin asesoría.
+    expect(within(alerta).getAllByText(/bonos de carbono/i).length).toBeGreaterThan(0);
+    expect(alerta).toHaveTextContent(/30-100|30–100|contratos/i);
+    expect(alerta).toHaveTextContent(/intermediarios/i);
+    expect(alerta).toHaveTextContent(/asesor[ií]a jur[ií]dica/i);
+    expect(alerta).toHaveTextContent(/CAR|consultorios/i);
+  });
+
+  test('muestra la elegibilidad / modalidades PSA', async () => {
+    const { default: CarbonoPsaSubvista } = await import('../CarbonoPsaSubvista');
+    render(<CarbonoPsaSubvista proceso={PROCESO} perfilFinca={{ altitud: 2600 }} />);
+
+    const psa = screen.getByTestId('psa-elegibilidad');
+    expect(psa).toBeInTheDocument();
+    expect(psa).toHaveTextContent(/Pago por Servicios Ambientales/i);
+    // Al menos una modalidad del PSA aparece (lista nunca vacía: real o fallback).
+    expect(psa.querySelectorAll('li').length).toBeGreaterThan(0);
+  });
+
+  test('CON factor con fuente: muestra rango [VALIDAR] con fuente y SIEMPRE el mensaje de validación', async () => {
+    const { default: CarbonoPsaSubvista } = await import('../CarbonoPsaSubvista');
+    render(<CarbonoPsaSubvista proceso={PROCESO} perfilFinca={{ altitud: 2600 }} />);
+
+    // El mensaje de validación está SIEMPRE presente (nunca número como hecho).
+    expect(screen.getByTestId('co2-validacion')).toHaveTextContent(/medici[oó]n de campo/i);
+    // El rango se muestra con etiqueta [VALIDAR] y con su fuente visible.
+    const rango = screen.getByTestId('co2-rango-referencia');
+    expect(rango).toHaveTextContent(/\[VALIDAR\]/);
+    expect(rango).toHaveTextContent(/tC\/ha/);
+    expect(rango).toHaveTextContent(/DR-RESTAURACION|RAINFOR/i);
+  });
+
+  test('ANTI-ALUCINACIÓN: no renderiza un número de CO₂ derivado del # de árboles del proceso', async () => {
+    const { default: CarbonoPsaSubvista } = await import('../CarbonoPsaSubvista');
+    render(<CarbonoPsaSubvista proceso={PROCESO} perfilFinca={{ altitud: 2600 }} />);
+
+    const co2 = screen.getByTestId('co2-estimacion');
+    const text = co2.textContent || '';
+    // El mensaje de validación SIEMPRE acompaña cualquier cifra: nunca un
+    // número presentado como hecho del predio.
+    expect(screen.getByTestId('co2-validacion')).toHaveTextContent(/medici[oó]n de campo|\[VALIDAR\]/i);
+    // El # de árboles del proceso (120) NO se convierte en un resultado de CO₂:
+    // no aparece "120 ... CO₂" ni "= <n> CO₂" para el predio.
+    expect(text).not.toMatch(/120[^.]{0,40}CO[₂2]/i);
+    expect(text).not.toMatch(/=\s*[\d.,]+\s*(kg|t|ton)/i);
+    // No hay una cifra de captura ATRIBUIDA al predio como hecho
+    // ("X kg/tCO₂ capturados/secuestrados/al año" del predio).
+    expect(text).not.toMatch(/[\d.,]+\s*(kg|tCO[₂2])\s*(de\s*CO[₂2]\s*)?(capturad|secuestrad|al a[nñ]o)/i);
+  });
+
+  test('SIN factor con fuente en los datos: NO hay número, solo mensaje de validación + método', async () => {
+    // Simula datos del repo sin factor (rangos vacíos, sin medición forzada falsa).
+    vi.doMock('../../data/carbono-captura.json', () => ({
+      default: {
+        fuente: 'sin fuente verificable',
+        requiere_medicion_campo: true,
+        rangos_referencia: [],
+        metodo_estimacion: {
+          titulo: 'Qué se necesita para estimar la captura de CO₂',
+          pasos: ['Número de árboles', 'Especie', 'Edad', 'Área'],
+          advertencia: 'Sin medición de campo, cualquier número exacto es una invención.',
+        },
+      },
+    }));
+    const { default: CarbonoPsaSubvista } = await import('../CarbonoPsaSubvista');
+    render(<CarbonoPsaSubvista proceso={PROCESO} perfilFinca={{ altitud: 2600 }} />);
+
+    const co2 = screen.getByTestId('co2-estimacion');
+    // No se muestra el bloque de rango (no hay factor con fuente).
+    expect(screen.queryByTestId('co2-rango-referencia')).not.toBeInTheDocument();
+    // Pero SÍ el mensaje de validación y el método (qué medir).
+    expect(screen.getByTestId('co2-validacion')).toHaveTextContent(/medici[oó]n de campo/i);
+    expect(co2).toHaveTextContent(/Qu[eé] se necesita|N[uú]mero de [aá]rboles/i);
+    // Y NINGÚN número de tC/ha ni de CO2 (no se inventa nada).
+    expect(co2.textContent || '').not.toMatch(/\d[\d.,]*\s*tC\/ha/);
+    expect(co2.textContent || '').not.toMatch(/\d[\d.,]*\s*(kg|ton(elada)?s?)\s*(de\s*)?CO/i);
+  });
+});

--- a/src/components/__tests__/SeguimientoProcesoScreen.test.jsx
+++ b/src/components/__tests__/SeguimientoProcesoScreen.test.jsx
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * SeguimientoProcesoScreen.test.jsx — vista de SEGUIMIENTO de un proceso de
+ * finca (operador 2026-06-15). Verifica el flujo central:
+ *   - vacío → botón "Iniciar"
+ *   - el formulario crea un FarmProcess vía createFarmProcess con el
+ *     process_type y la etapa inicial correctos
+ *   - la guarda de leucaena/mimosina aparece SOLO en cerdos
+ */
+import React from 'react';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi, beforeEach } from 'vitest';
+
+let processes = [];
+const createFarmProcess = vi.fn(async () => ({}));
+const recordFarmEvent = vi.fn(async () => ({}));
+
+vi.mock('../../services/farmEventService', () => ({
+  createFarmProcess: (...a) => createFarmProcess(...a),
+  recordFarmEvent: (...a) => recordFarmEvent(...a),
+}));
+vi.mock('../../services/stageConfirmationService', () => ({
+  confirmStage: vi.fn(async () => ({})),
+}));
+vi.mock('../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(async () => processes),
+  getFarmEvents: vi.fn(async () => []),
+}));
+vi.mock('../../store/useAssetStore', () => ({
+  default: (selector) => selector({ lands: [] }),
+}));
+// Sub-componentes pesados (voz/cámara) fuera del foco de este test.
+vi.mock('../CicloObservacion', () => ({ default: () => <div data-testid="obs" /> }));
+vi.mock('../CicloFotos', () => ({ default: () => <div data-testid="fotos" /> }));
+vi.mock('../ChagraGrowLoader', () => ({ default: () => <div /> }));
+
+import SeguimientoProcesoScreen from '../SeguimientoProcesoScreen';
+
+afterEach(() => {
+  cleanup();
+  processes = [];
+  createFarmProcess.mockClear();
+  recordFarmEvent.mockClear();
+});
+beforeEach(() => { processes = []; });
+
+describe('SeguimientoProcesoScreen', () => {
+  test('vacío muestra el botón para iniciar el proceso', async () => {
+    render(<SeguimientoProcesoScreen procesoKey="reforestacion" onBack={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('Iniciar reforestación')).toBeInTheDocument();
+    });
+  });
+
+  test('iniciar reforestación crea un FarmProcess restoration en etapa establecimiento', async () => {
+    render(<SeguimientoProcesoScreen procesoKey="reforestacion" onBack={vi.fn()} onSave={vi.fn()} />);
+    await waitFor(() => screen.getByText('Iniciar reforestación'));
+
+    // Abrir el formulario.
+    fireEvent.click(screen.getByText('Iniciar reforestación'));
+
+    // Diligenciar el "qué".
+    const input = await screen.findByPlaceholderText(/Roble/);
+    fireEvent.change(input, { target: { value: 'Roble andino' } });
+
+    // Confirmar (hay dos botones con el verbo; el submit es el último).
+    const botones = screen.getAllByText('Iniciar reforestación');
+    fireEvent.click(botones[botones.length - 1]);
+
+    await waitFor(() => expect(createFarmProcess).toHaveBeenCalledTimes(1));
+    const arg = createFarmProcess.mock.calls[0][0];
+    expect(arg.type).toBe('farm_process');
+    expect(arg.attributes.process_type).toBe('restoration');
+    expect(arg.attributes.current_stage).toBe('establecimiento');
+    expect(arg.attributes.subject_label).toBe('Roble andino');
+    expect(arg.attributes.status).toBe('active');
+  });
+
+  test('iniciar cerdos crea un FarmProcess pigs en etapa instalacion', async () => {
+    render(<SeguimientoProcesoScreen procesoKey="cerdos" onBack={vi.fn()} onSave={vi.fn()} />);
+    await waitFor(() => screen.getByText('Iniciar ciclo'));
+    fireEvent.click(screen.getByText('Iniciar ciclo'));
+    const input = await screen.findByPlaceholderText(/engorde/);
+    fireEvent.change(input, { target: { value: 'Lote engorde 1' } });
+    const botones = screen.getAllByText('Iniciar ciclo');
+    fireEvent.click(botones[botones.length - 1]);
+    await waitFor(() => expect(createFarmProcess).toHaveBeenCalledTimes(1));
+    const arg = createFarmProcess.mock.calls[0][0];
+    expect(arg.attributes.process_type).toBe('pigs');
+    expect(arg.attributes.current_stage).toBe('instalacion');
+  });
+
+  test('la guarda de leucaena/mimosina aparece en cerdos pero NO en reforestación', async () => {
+    const { unmount } = render(<SeguimientoProcesoScreen procesoKey="cerdos" onBack={vi.fn()} />);
+    await waitFor(() => screen.getByText('Iniciar ciclo'));
+    expect(screen.getByText(/[Ll]eucaena/)).toBeInTheDocument();
+    unmount();
+
+    render(<SeguimientoProcesoScreen procesoKey="reforestacion" onBack={vi.fn()} />);
+    await waitFor(() => screen.getByText('Iniciar reforestación'));
+    expect(screen.queryByText(/[Ll]eucaena/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -20,7 +20,15 @@ import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Snowflake, ChevronRight } from 'lucide-react';
 import AgentHero from './AgentHero';
 import OnboardingHero from '../OnboardingHero';
-import { getProfile, isModuleVisible } from '../../services/userProfileService';
+import {
+    getProfile,
+    getModuleVisibility,
+    hasManualModuleVisibility,
+} from '../../services/userProfileService';
+import {
+    selectHomeModuleVisibilityMap,
+    selectHomeModules,
+} from '../../services/homeModuleSelector';
 import { tieneAccesoGlaciarActual } from '../../config/glaciarAccess';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
 import ClimaStrip from './ClimaStrip';
@@ -163,12 +171,50 @@ function SortableSection({ id, onNavigate, sensors }) {
 export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
     const [order, setOrder] = useState(readOrder);
     const [moduleVisibility, setModuleVisibility] = useState(() => {
-        // Leer visibilidad inicial: filtra el order para solo incluir módulos visibles
-        const visibility = {};
-        for (const id of DEFAULT_ORDER) {
-            visibility[id] = isModuleVisible(id);
+        // GATING DEL HOME POR PERFIL (2026-06-15): el perfil del onboarding
+        // (rol/vocacion/finca_tipo/animales/objetivo) fija QUÉ módulos se ven
+        // por DEFECTO — "el usuario solo ve lo que necesita".
+        //
+        // RESPETO A #1560: si el usuario ya guardó una preferencia MANUAL en
+        // ProfileScreen, esa GANA — el perfil solo decide el default. Si no hay
+        // preferencia manual, derivamos la visibilidad por perfil con
+        // homeModuleSelector (reusa deriveRole de profileChipSelector).
+        try {
+            if (hasManualModuleVisibility()) {
+                // El usuario eligió a mano: respetar su configuración tal cual.
+                return getModuleVisibility();
+            }
+            // Primer load sin elección manual: default por perfil.
+            return selectHomeModuleVisibilityMap(getProfile(), {
+                esGuiaGlaciar: tieneAccesoGlaciarActual(),
+            });
+        } catch (_) {
+            // Fail-open: ante cualquier problema, todo visible (no romper el home).
+            const visibility = {};
+            for (const id of DEFAULT_ORDER) visibility[id] = true;
+            return visibility;
         }
-        return visibility;
+    });
+    // Tarjetas de SEGUIMIENTO permitidas por perfil (Reforestación · Silvopastoreo
+    // · Páramo · Cerdos). Mismo gating "el usuario solo ve lo que necesita": un
+    // urbano (sin preferencia manual) NUNCA ve Cerdos. Se calcula una vez al
+    // montar; el perfil no cambia dentro de la sesión del home.
+    //
+    // RESPETO A #1560: si el usuario ya tomó control MANUAL de su home
+    // (hasManualModuleVisibility), NO le ocultamos tarjetas por perfil — el
+    // perfil solo fija el DEFAULT. Devolvemos null (= mostrar las 4), igual que
+    // el comportamiento histórico. Un urbano FRESCO (sin manual) sí queda
+    // gateado: no ve ninguna (criterio de éxito #1).
+    // null = mostrar todas; [] = ocultar el bloque; [k…] = filtrar.
+    const [seguimientoKeys] = useState(() => {
+        try {
+            if (hasManualModuleVisibility()) return null;
+            return selectHomeModules(getProfile(), {
+                esGuiaGlaciar: tieneAccesoGlaciarActual(),
+            }).seguimiento;
+        } catch (_) {
+            return null; // Fail-open: el componente muestra las 4 por defecto.
+        }
     });
     const iotAlerts = useAssetStore((s) => s.iotAlerts) || [];
     // Primer uso (feat/onboarding-ayuda): sin plantas registradas se re-monta
@@ -300,16 +346,23 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                 de "Mis plantas". Cada una abre su VISTA de seguimiento (iniciar
                 el proceso, ver etapas con fechas, agregar registros/fotos y ver
                 el avance). El operador las pidió visibles en el home (no escondidas
-                tras la Ⓐ ni iniciables solo por voz). Bloque propio, siempre
-                presente, fuera del grid draggable de módulos. */}
-            <div className="px-4 pt-3">
-                <p className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                    Seguimiento de procesos
-                </p>
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="seguimiento-cards">
-                    <SeguimientoCards onNavigate={onNavigate} variant="grid" />
+                tras la Ⓐ ni iniciables solo por voz). Bloque propio, fuera del
+                grid draggable de módulos.
+
+                GATING POR PERFIL: `seguimientoKeys` filtra qué tarjetas se ven
+                ("el usuario solo ve lo que necesita" — un urbano NUNCA ve Cerdos
+                ni Silvopastoreo). Si el perfil no permite ninguna (ej. urbano de
+                balcón), el bloque entero se oculta. null = fail-open (las 4). */}
+            {(seguimientoKeys === null || seguimientoKeys.length > 0) && (
+                <div className="px-4 pt-3">
+                    <p className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                        Seguimiento de procesos
+                    </p>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="seguimiento-cards">
+                        <SeguimientoCards onNavigate={onNavigate} variant="grid" keys={seguimientoKeys} />
+                    </div>
                 </div>
-            </div>
+            )}
 
             {/* Saludo regional dismissible — bajo el fold, ya no sobre el hero
                 (que tiene su propio saludo "Soy Chagra"). */}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -19,7 +19,6 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Snowflake, ChevronRight } from 'lucide-react';
 import AgentHero from './AgentHero';
-import { CHIP_DEFS } from '../../services/agentCapabilities';
 import OnboardingHero from '../OnboardingHero';
 import { getProfile, isModuleVisible } from '../../services/userProfileService';
 import { tieneAccesoGlaciarActual } from '../../config/glaciarAccess';
@@ -38,6 +37,7 @@ import {
     PlagasCard,
     BiodiversidadCard,
     InformesCard,
+    SeguimientoCards,
 } from './FincaCards';
 
 /**
@@ -295,26 +295,19 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                 </div>
             )}
 
-            {/* Capacidades VISIBLES en el home (re-add 2026-06-15): revierte el
-                retiro del 06-10. El operador busca silvopastoreo/restauración/etc.
-                AQUÍ (no escondidas tras la Ⓐ). Tocar un chip abre el agente. */}
+            {/* Seguimiento de procesos de finca (2026-06-15): TARJETAS en el
+                home — Reforestación · Silvopastoreo · Páramo · Cerdos — al estilo
+                de "Mis plantas". Cada una abre su VISTA de seguimiento (iniciar
+                el proceso, ver etapas con fechas, agregar registros/fotos y ver
+                el avance). El operador las pidió visibles en el home (no escondidas
+                tras la Ⓐ ni iniciables solo por voz). Bloque propio, siempre
+                presente, fuera del grid draggable de módulos. */}
             <div className="px-4 pt-3">
                 <p className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                    Pregúntale a Chagra
+                    Seguimiento de procesos
                 </p>
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    {CHIP_DEFS.filter((c) => c.kind !== 'stub').map((c) => (
-                        <button
-                            key={c.intent}
-                            type="button"
-                            onClick={() => onNavigate('agente')}
-                            className="flex items-center gap-2 p-2.5 rounded-xl border border-slate-700/50 bg-slate-800/70 hover:bg-slate-700/70 active:scale-[0.98] transition text-left"
-                            aria-label={c.label}
-                        >
-                            <span className="text-lg shrink-0" aria-hidden="true">{c.icon}</span>
-                            <span className="text-sm font-semibold text-slate-100 leading-tight truncate">{c.label}</span>
-                        </button>
-                    ))}
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="seguimiento-cards">
+                    <SeguimientoCards onNavigate={onNavigate} variant="grid" />
                 </div>
             </div>
 

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
 import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf } from 'lucide-react';
 import useAssetStore from '../../store/useAssetStore';
 import Skeleton from '../common/Skeleton';
+import { listFarmProcesses } from '../../db/farmProcessCache';
+import { SEGUIMIENTO_PROCESOS, seguimientoRoute } from '../../config/seguimientoProcesos';
 
 /**
  * FincaCards — secciones del dashboard re-organizadas con sensibilidad
@@ -74,6 +77,39 @@ const SECTION_STYLES = {
         border: 'border-indigo-700/30',
         ring: 'ring-indigo-500/0 group-hover:ring-indigo-500/40',
         iconColor: 'text-indigo-300',
+    },
+    // Seguimiento de procesos de finca (2026-06-15). Misma estética tonal.
+    reforestacion: {
+        Icon: Leaf,
+        emoji: '🌳',
+        accent: 'from-green-600/20 to-emerald-500/10',
+        border: 'border-green-700/30',
+        ring: 'ring-green-500/0 group-hover:ring-green-500/40',
+        iconColor: 'text-green-300',
+    },
+    silvopastoreo: {
+        Icon: Sprout,
+        emoji: '🐄',
+        accent: 'from-amber-600/20 to-yellow-500/10',
+        border: 'border-amber-700/30',
+        ring: 'ring-amber-500/0 group-hover:ring-amber-500/40',
+        iconColor: 'text-amber-300',
+    },
+    paramo: {
+        Icon: MapPin,
+        emoji: '🏔️',
+        accent: 'from-sky-600/20 to-cyan-500/10',
+        border: 'border-sky-700/30',
+        ring: 'ring-sky-500/0 group-hover:ring-sky-500/40',
+        iconColor: 'text-sky-300',
+    },
+    cerdos: {
+        Icon: AlertCircle,
+        emoji: '🐖',
+        accent: 'from-pink-600/20 to-rose-500/10',
+        border: 'border-pink-700/30',
+        ring: 'ring-pink-500/0 group-hover:ring-pink-500/40',
+        iconColor: 'text-pink-300',
     },
 };
 
@@ -302,5 +338,90 @@ export function InformesCard({ onNavigate, variant }) {
             tooltip="Exporta cuaderno de campo, inventario, registros de cosecha y aplicaciones a CSV/PDF."
             onClick={() => onNavigate('informes')}
         />
+    );
+}
+
+/**
+ * useSeguimientoCounts — cuenta los procesos ACTIVOS por process_type para los
+ * contadores de las tarjetas de seguimiento. Offline-first (lee IndexedDB).
+ * Se re-cuenta al volver al home y al evento 'farmProcessChanged'.
+ */
+function useSeguimientoCounts() {
+    const [counts, setCounts] = useState(null); // null = cargando
+
+    useEffect(() => {
+        let alive = true;
+        const recount = async () => {
+            try {
+                const all = await listFarmProcesses({ status: 'active' });
+                if (!alive) return;
+                const byType = {};
+                for (const p of all || []) {
+                    const t = p?.attributes?.process_type;
+                    if (t) byType[t] = (byType[t] || 0) + 1;
+                }
+                setCounts(byType);
+            } catch {
+                if (alive) setCounts({});
+            }
+        };
+        recount();
+        const onChange = () => recount();
+        try { window.addEventListener('farmProcessChanged', onChange); } catch { /* SSR/test */ }
+        return () => {
+            alive = false;
+            try { window.removeEventListener('farmProcessChanged', onChange); } catch { /* noop */ }
+        };
+    }, []);
+
+    return counts;
+}
+
+/**
+ * SeguimientoCard — tarjeta de seguimiento de un proceso de finca
+ * (Reforestación/Silvopastoreo/Páramo/Cerdos). Mismo componente base que
+ * "Mis plantas": navega a la vista de seguimiento del proceso.
+ */
+export function SeguimientoCard({ def, count, onNavigate, variant }) {
+    const loaded = count !== null && count !== undefined;
+    const n = loaded ? (count || 0) : null;
+    const subtitle = !loaded
+        ? 'Cargando…'
+        : n > 0
+            ? (n === 1 ? '1 en seguimiento' : `${n} en seguimiento`)
+            : def.subtitle;
+    return (
+        <Card
+            variant={variant}
+            section={def.section}
+            title={def.title}
+            subtitle={subtitle}
+            value={loaded ? n : null}
+            loading={!loaded}
+            tooltip={`${def.title} — ${def.subtitle}. Tócalo para iniciar y hacer seguimiento (etapas, fotos y avance).`}
+            onClick={() => onNavigate(seguimientoRoute(def.key))}
+        />
+    );
+}
+
+/**
+ * SeguimientoCards — las 4 tarjetas de seguimiento de procesos de finca
+ * para el home (Reforestación · Silvopastoreo · Páramo · Cerdos). Se renderiza
+ * como bloque propio en DashboardLive, fuera del grid draggable.
+ */
+export function SeguimientoCards({ onNavigate, variant = 'grid' }) {
+    const counts = useSeguimientoCounts();
+    return (
+        <>
+            {SEGUIMIENTO_PROCESOS.map((def) => (
+                <SeguimientoCard
+                    key={def.key}
+                    def={def}
+                    count={counts ? (counts[def.processType] || 0) : null}
+                    onNavigate={onNavigate}
+                    variant={variant}
+                />
+            ))}
+        </>
     );
 }

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -405,15 +405,32 @@ export function SeguimientoCard({ def, count, onNavigate, variant }) {
 }
 
 /**
- * SeguimientoCards — las 4 tarjetas de seguimiento de procesos de finca
- * para el home (Reforestación · Silvopastoreo · Páramo · Cerdos). Se renderiza
- * como bloque propio en DashboardLive, fuera del grid draggable.
+ * SeguimientoCards — las tarjetas de seguimiento de procesos de finca para el
+ * home (Reforestación · Silvopastoreo · Páramo · Cerdos). Se renderiza como
+ * bloque propio en DashboardLive, fuera del grid draggable.
+ *
+ * GATING POR PERFIL (2026-06-15): `keys` filtra qué tarjetas se muestran según
+ * el perfil del usuario ("el usuario solo ve lo que necesita" — un urbano
+ * NUNCA ve Cerdos). Lo decide el call-site (DashboardLive) vía
+ * homeModuleSelector. Si `keys` se omite (null/undefined), se muestran las 4 —
+ * comportamiento histórico, sin breaking change. La selección NO se decide acá;
+ * este componente solo pinta las tarjetas permitidas.
+ *
+ * @param {Object} props
+ * @param {(view: string) => void} props.onNavigate
+ * @param {'grid'|'list'} [props.variant='grid']
+ * @param {string[]|null} [props.keys=null] — keys de seguimiento permitidas
+ *   (subconjunto de SEGUIMIENTO_PROCESOS[].key). null = todas.
  */
-export function SeguimientoCards({ onNavigate, variant = 'grid' }) {
+export function SeguimientoCards({ onNavigate, variant = 'grid', keys = null }) {
     const counts = useSeguimientoCounts();
+    const allowed = Array.isArray(keys) ? new Set(keys) : null;
+    const defs = allowed
+        ? SEGUIMIENTO_PROCESOS.filter((def) => allowed.has(def.key))
+        : SEGUIMIENTO_PROCESOS;
     return (
         <>
-            {SEGUIMIENTO_PROCESOS.map((def) => (
+            {defs.map((def) => (
                 <SeguimientoCard
                     key={def.key}
                     def={def}

--- a/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
@@ -36,6 +36,7 @@ vi.mock('../FincaCards', () => ({
   PlantasCard: () => <div />, ZonasCard: () => <div />, InsumosCard: () => <div />,
   BitacoraCard: () => <div />, HoyCard: () => <div />, PlagasCard: () => <div />,
   BiodiversidadCard: () => <div />, InformesCard: () => <div />,
+  SeguimientoCards: () => <div data-testid="seguimiento-cards" />,
 }));
 
 vi.mock('../../../services/userProfileService', () => ({

--- a/src/components/dashboard/__tests__/DashboardLive.homeGating.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.homeGating.test.jsx
@@ -1,0 +1,129 @@
+/**
+ * DashboardLive.homeGating.test.jsx — GATING del HOME por perfil (2026-06-15):
+ * "el usuario solo ve lo que necesita". Verifica a nivel de integración que:
+ *
+ *  - URBANO (terraza): NO se renderiza la tarjeta de Cerdos (ni silvopastoreo).
+ *    De hecho el bloque entero de "Seguimiento de procesos" se oculta — el
+ *    selector no permite ninguna tarjeta para un balcón. (criterio de éxito #1)
+ *  - GANADERO con cerdos: SÍ se renderiza la tarjeta de Cerdos.
+ *  - RESPETO A #1560: si el usuario tiene preferencia MANUAL guardada, esa
+ *    gana sobre el default por perfil.
+ *
+ * Se usan las tarjetas de seguimiento REALES (no se mockea FincaCards) para
+ * comprobar el render de "Cerdos"; los demás hijos pesados se stubean. El cache
+ * de procesos se mockea vacío (contadores en 0).
+ */
+import React from 'react';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Gate glaciar: irrelevante a este test → sin acceso.
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+}));
+
+// Hijos pesados → stubs livianos. NO mockeamos FincaCards (queremos las
+// tarjetas de seguimiento reales para ver "Cerdos").
+vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
+vi.mock('../../OnboardingHero', () => ({ default: () => <div data-testid="onboarding-hero" /> }));
+vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+
+// Store de assets: plantsCount > 0 para no montar el OnboardingHero de primer uso.
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [{ id: 'p1' }], lands: [], materials: [], isHydrated: true, iotAlerts: [] }),
+}));
+
+// Cache de procesos vacío → contadores en 0 (no afecta el render de la tarjeta).
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(async () => []),
+}));
+
+// Perfil CONTROLABLE por test (lo definimos por escenario).
+let mockProfile = {};
+let mockManual = false;
+let mockManualMap = {};
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: vi.fn(() => mockProfile),
+    hasManualModuleVisibility: vi.fn(() => mockManual),
+    getModuleVisibility: vi.fn(() =>
+      mockManual ? mockManualMap : Object.fromEntries(actual.HOME_MODULES.map((m) => [m.id, true])),
+    ),
+  };
+});
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+import DashboardLive from '../DashboardLive';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockProfile = {};
+  mockManual = false;
+  mockManualMap = {};
+});
+
+afterEach(() => cleanup());
+
+describe('DashboardLive — gating del home por perfil', () => {
+  test('URBANO/terraza: NO renderiza la tarjeta Cerdos (criterio #1)', async () => {
+    mockProfile = { vocacion: 'urbano', finca_tipo: 'terraza' };
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    // Dar tiempo al efecto async de contadores (aunque el bloque esté oculto).
+    await waitFor(() => expect(screen.getByTestId('agent-hero')).toBeInTheDocument());
+    // OBLIGATORIO: ninguna tarjeta de Cerdos / Silvopastoreo para el urbano.
+    expect(screen.queryByText('Cerdos')).toBeNull();
+    expect(screen.queryByText('Silvopastoreo')).toBeNull();
+    // El bloque entero de seguimiento se oculta (urbano no tiene ninguna).
+    expect(screen.queryByTestId('seguimiento-cards')).toBeNull();
+    expect(screen.queryByText('Seguimiento de procesos')).toBeNull();
+  });
+
+  test('GANADERO con cerdos: SÍ renderiza la tarjeta Cerdos', async () => {
+    mockProfile = { rol: 'ganadero', animales: ['ganado', 'cerdos'] };
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Cerdos')).toBeInTheDocument());
+    expect(screen.getByText('Silvopastoreo')).toBeInTheDocument();
+    // No mostramos las que no aplican al ganadero (reforestación/páramo).
+    expect(screen.queryByText('Reforestación')).toBeNull();
+    expect(screen.queryByText('Páramo')).toBeNull();
+  });
+
+  test('GANADERO solo gallinas: Silvopastoreo SÍ, Cerdos NO', async () => {
+    mockProfile = { rol: 'ganadero', animales: ['gallinas'] };
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Silvopastoreo')).toBeInTheDocument());
+    expect(screen.queryByText('Cerdos')).toBeNull();
+  });
+
+  test('RESTAURADOR: Reforestación y Páramo SÍ, Cerdos NO', async () => {
+    mockProfile = { rol: 'restaurador', objetivo: ['biodiversidad'] };
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Reforestación')).toBeInTheDocument());
+    expect(screen.getByText('Páramo')).toBeInTheDocument();
+    expect(screen.queryByText('Cerdos')).toBeNull();
+    expect(screen.queryByText('Silvopastoreo')).toBeNull();
+  });
+
+  test('#1560: preferencia MANUAL gana — urbano con manual=todo-visible ve Cerdos', async () => {
+    // El usuario es urbano por perfil, PERO ya configuró a mano "todo visible".
+    // Su elección manual gana: el home respeta su configuración. (Las tarjetas
+    // de seguimiento NO se gatean por module-visibility; con manual presente, el
+    // default por perfil ya no aplica y se muestran las 4.)
+    mockProfile = { vocacion: 'urbano', finca_tipo: 'terraza' };
+    mockManual = true;
+    mockManualMap = {}; // {} = nada oculto = todo visible (preferencia explícita).
+    render(<DashboardLive onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText('Cerdos')).toBeInTheDocument());
+  });
+});

--- a/src/components/dashboard/__tests__/SeguimientoCards.test.jsx
+++ b/src/components/dashboard/__tests__/SeguimientoCards.test.jsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+/**
+ * SeguimientoCards.test.jsx — las 4 tarjetas de SEGUIMIENTO de procesos de
+ * finca en el home (operador 2026-06-15): Reforestación · Silvopastoreo ·
+ * Páramo · Cerdos. Verifica que se rendericen las 4, que el contador refleje
+ * los procesos activos y que el tap navegue a la ruta 'seguimiento_<key>'.
+ */
+import React from 'react';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, afterEach, vi, beforeEach } from 'vitest';
+
+// Mock del store (las cards de seguimiento no lo usan, pero FincaCards lo importa).
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({ plants: [], lands: [], materials: [], isHydrated: true }),
+}));
+
+// Mock del cache: controlamos qué procesos "activos" hay.
+let activeProcesses = [];
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(async () => activeProcesses),
+}));
+
+import { SeguimientoCards } from '../FincaCards';
+
+afterEach(() => {
+  cleanup();
+  activeProcesses = [];
+});
+
+beforeEach(() => {
+  activeProcesses = [];
+});
+
+describe('SeguimientoCards — tarjetas de seguimiento en el home', () => {
+  test('renderiza las 4 tarjetas pedidas por el operador', async () => {
+    render(<SeguimientoCards onNavigate={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText('Reforestación')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Silvopastoreo')).toBeInTheDocument();
+    expect(screen.getByText('Páramo')).toBeInTheDocument();
+    expect(screen.getByText('Cerdos')).toBeInTheDocument();
+  });
+
+  test('el contador refleja los procesos activos por tipo', async () => {
+    activeProcesses = [
+      { attributes: { process_type: 'restoration', status: 'active' } },
+      { attributes: { process_type: 'restoration', status: 'active' } },
+      { attributes: { process_type: 'pigs', status: 'active' } },
+    ];
+    render(<SeguimientoCards onNavigate={vi.fn()} />);
+    // Las cards muestran el conteo en el badge data-testid="finca-card-count".
+    await waitFor(() => {
+      const counts = screen.getAllByTestId('finca-card-count');
+      // 4 cards → 4 badges (incluye los 0).
+      expect(counts.length).toBe(4);
+    });
+    const counts = screen.getAllByTestId('finca-card-count').map((n) => n.textContent);
+    // Reforestación = 2, cerdos = 1, silvopastoreo/páramo = 0.
+    expect(counts).toContain('2');
+    expect(counts).toContain('1');
+  });
+
+  test('tocar Reforestación navega a su vista de seguimiento', async () => {
+    const onNavigate = vi.fn();
+    render(<SeguimientoCards onNavigate={onNavigate} />);
+    await waitFor(() => expect(screen.getByText('Reforestación')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Reforestación'));
+    expect(onNavigate).toHaveBeenCalledWith('seguimiento_reforestacion');
+  });
+});

--- a/src/config/__tests__/seguimientoProcesos.test.js
+++ b/src/config/__tests__/seguimientoProcesos.test.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Guatoc Eco Hub
+
+import { describe, it, expect } from 'vitest';
+import {
+  SEGUIMIENTO_PROCESOS,
+  SEGUIMIENTO_BY_KEY,
+  getSeguimientoDef,
+  seguimientoRoute,
+  parseSeguimientoView,
+} from '../seguimientoProcesos';
+import { stageSequenceForProcessType } from '../../types/farmProcess';
+
+describe('seguimientoProcesos — catálogo de seguimiento de procesos', () => {
+  it('expone exactamente los 4 procesos pedidos por el operador', () => {
+    const titles = SEGUIMIENTO_PROCESOS.map((d) => d.title);
+    expect(titles).toEqual(['Reforestación', 'Silvopastoreo', 'Páramo', 'Cerdos']);
+  });
+
+  it('cada def mapea a un process_type válido con secuencia de etapas no vacía', () => {
+    for (const def of SEGUIMIENTO_PROCESOS) {
+      const seq = stageSequenceForProcessType(def.processType);
+      expect(Array.isArray(seq)).toBe(true);
+      expect(seq.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('reforestación y silvopastoreo usan los process_type existentes', () => {
+    expect(SEGUIMIENTO_BY_KEY.reforestacion.processType).toBe('restoration');
+    expect(SEGUIMIENTO_BY_KEY.silvopastoreo.processType).toBe('silvopasture');
+  });
+
+  it('páramo y cerdos usan los process_type nuevos', () => {
+    expect(SEGUIMIENTO_BY_KEY.paramo.processType).toBe('paramo');
+    expect(SEGUIMIENTO_BY_KEY.cerdos.processType).toBe('pigs');
+  });
+
+  it('getSeguimientoDef resuelve por key y devuelve null para desconocidos', () => {
+    expect(getSeguimientoDef('cerdos')?.title).toBe('Cerdos');
+    expect(getSeguimientoDef('inexistente')).toBeNull();
+  });
+
+  it('seguimientoRoute + parseSeguimientoView son inversos para keys válidas', () => {
+    for (const def of SEGUIMIENTO_PROCESOS) {
+      const route = seguimientoRoute(def.key);
+      expect(route).toBe(`seguimiento_${def.key}`);
+      expect(parseSeguimientoView(route)).toBe(def.key);
+    }
+  });
+
+  it('parseSeguimientoView ignora rutas que no son de seguimiento o son inválidas', () => {
+    expect(parseSeguimientoView('dashboard')).toBeNull();
+    expect(parseSeguimientoView('seguimiento_inexistente')).toBeNull();
+    expect(parseSeguimientoView(null)).toBeNull();
+    expect(parseSeguimientoView(undefined)).toBeNull();
+  });
+});

--- a/src/config/seguimientoProcesos.js
+++ b/src/config/seguimientoProcesos.js
@@ -1,0 +1,102 @@
+/**
+ * seguimientoProcesos — catálogo de los procesos de finca con SEGUIMIENTO
+ * visible (tarjeta en el home + vista de seguimiento), 2026-06-15.
+ *
+ * El operador pidió "tarjetas en el home + vista de seguimiento, como Mis
+ * plantas pero para estos procesos": Reforestación · Silvopastoreo · Páramo ·
+ * Cerdos. Cada entrada mapea a un `process_type` de types/farmProcess y reusa
+ * el motor FarmProcess (createFarmProcess / recordFarmEvent / confirmStage) y
+ * la secuencia de etapas (stageSequenceForProcessType).
+ *
+ * Fuente única: la vista de seguimiento (SeguimientoProcesoScreen), las tarjetas
+ * del dashboard (FincaCards) y el routing (App.jsx) leen de aquí. NO duplicar
+ * labels ni rutas.
+ */
+
+/**
+ * @typedef {Object} SeguimientoProcesoDef
+ * @property {string} key — id de ruta corta, ej. 'reforestacion'
+ * @property {string} processType — process_type válido en types/farmProcess
+ * @property {string} title — título de la tarjeta / pantalla
+ * @property {string} subtitle — copy de campesino bajo el título
+ * @property {string} emoji — ícono emoji grande (mismo patrón que FincaCards)
+ * @property {string} section — clave de estilo tonal (ver SECTION_STYLES)
+ * @property {'individual'|'aggregate'} subjectKind — modo por defecto del sujeto
+ * @property {string} defaultUnit — unidad por defecto al iniciar
+ * @property {string} subjectLabelPlaceholder — placeholder del campo "qué"
+ * @property {string} startVerb — etiqueta del botón "iniciar"
+ */
+
+/** @type {SeguimientoProcesoDef[]} */
+export const SEGUIMIENTO_PROCESOS = [
+  {
+    key: 'reforestacion',
+    processType: 'restoration',
+    title: 'Reforestación',
+    subtitle: 'Restauración con árboles nativos',
+    emoji: '🌳',
+    section: 'reforestacion',
+    subjectKind: 'aggregate',
+    defaultUnit: 'árboles',
+    subjectLabelPlaceholder: 'Ej: Roble, Aliso, Cativo…',
+    startVerb: 'Iniciar reforestación',
+  },
+  {
+    key: 'silvopastoreo',
+    processType: 'silvopasture',
+    title: 'Silvopastoreo',
+    subtitle: 'Árboles + pasto + ganado',
+    emoji: '🐄',
+    section: 'silvopastoreo',
+    subjectKind: 'aggregate',
+    defaultUnit: 'árboles',
+    subjectLabelPlaceholder: 'Ej: Leucaena, Botón de oro, Nacedero…',
+    startVerb: 'Iniciar silvopastoreo',
+  },
+  {
+    key: 'paramo',
+    processType: 'paramo',
+    title: 'Páramo',
+    subtitle: 'Conservación de páramo y agua',
+    emoji: '🏔️',
+    section: 'paramo',
+    subjectKind: 'aggregate',
+    defaultUnit: 'hectáreas',
+    subjectLabelPlaceholder: 'Ej: Nacimiento de agua, frailejonal…',
+    startVerb: 'Iniciar conservación',
+  },
+  {
+    key: 'cerdos',
+    processType: 'pigs',
+    title: 'Cerdos',
+    subtitle: 'Ciclo de manejo porcino',
+    emoji: '🐖',
+    section: 'cerdos',
+    subjectKind: 'aggregate',
+    defaultUnit: 'animales',
+    subjectLabelPlaceholder: 'Ej: Lote de engorde, marranas de cría…',
+    startVerb: 'Iniciar ciclo',
+  },
+];
+
+/** Mapa key → def, para resolver desde la ruta. */
+export const SEGUIMIENTO_BY_KEY = Object.fromEntries(
+  SEGUIMIENTO_PROCESOS.map((d) => [d.key, d]),
+);
+
+/** Resuelve la definición desde una key de ruta. */
+export const getSeguimientoDef = (key) => SEGUIMIENTO_BY_KEY[key] || null;
+
+/** Ruta de navegación para una key de seguimiento. */
+export const seguimientoRoute = (key) => `seguimiento_${key}`;
+
+/**
+ * Parsea una vista 'seguimiento_<key>' a su key. Devuelve null si no aplica.
+ * @param {string} view
+ */
+export const parseSeguimientoView = (view) => {
+  if (typeof view !== 'string') return null;
+  const m = view.match(/^seguimiento_(.+)$/);
+  if (!m) return null;
+  return SEGUIMIENTO_BY_KEY[m[1]] ? m[1] : null;
+};

--- a/src/data/carbono-captura.json
+++ b/src/data/carbono-captura.json
@@ -1,0 +1,43 @@
+{
+  "fuente": "DR-RESTAURACION-1 (Gemini+Meta, 2026-06-11) — Phillips/RAINFOR, IAvH, MinAmbiente",
+  "_nota_anti_alucinacion": "Estos son RANGOS de referencia a nivel de rodal (por hectarea), NO un factor por arbol para multiplicar. El carbono real de un predio SOLO se conoce midiendo en campo (DAP/alometria). Chagra NO calcula un numero exacto para la finca: muestra el rango orientativo con su fuente y marca [VALIDAR]. La medicion formal (MRV) es costosa e inviable para un campesino solo.",
+  "requiere_medicion_campo": true,
+  "conversion": {
+    "carbono_a_co2": 3.67,
+    "explicacion": "1 tonelada de carbono (tC) equivale a ~3.67 toneladas de CO2 (tCO2). La biomasa aerea se estima como biomasa x 0.5 = carbono."
+  },
+  "rangos_referencia": [
+    {
+      "ecosistema": "Bosque andino maduro (aereo)",
+      "rango_tC_ha": [100, 200],
+      "fuente": "Phillips/RAINFOR (via DR-RESTAURACION-1)"
+    },
+    {
+      "ecosistema": "Potrero degradado (punto de partida tipico)",
+      "rango_tC_ha": [0, 5],
+      "fuente": "DR-RESTAURACION-1"
+    },
+    {
+      "ecosistema": "Paramo — biomasa aerea",
+      "rango_tC_ha": [13, 183],
+      "fuente": "Gemini-profundo (via DR-RESTAURACION-1)"
+    },
+    {
+      "ecosistema": "Paramo — carbono del suelo (SOC, 0-40 cm)",
+      "rango_tC_ha": [119, 397],
+      "fuente": "Gemini-profundo (via DR-RESTAURACION-1)",
+      "nota": "El grueso del carbono del paramo esta BAJO tierra, no en la madera. Arar o drenar lo libera catastroficamente."
+    }
+  ],
+  "metodo_estimacion": {
+    "titulo": "Que se necesita para estimar la captura de CO2 de tu predio",
+    "pasos": [
+      "Numero de arboles y su especie (cada especie acumula biomasa distinto)",
+      "Edad o tiempo desde la siembra (un arbol joven captura mucho menos que uno maduro)",
+      "Area restaurada en hectareas",
+      "Medicion de campo del DAP (diametro a la altura del pecho) y ecuaciones alometricas por especie",
+      "Para un bono o pago formal: verificacion MRV por una entidad acreditada (costosa)"
+    ],
+    "advertencia": "Sin medicion de campo, cualquier numero exacto de CO2 es una invencion. El rango de referencia sirve solo para dimensionar el orden de magnitud, NO para prometer ingresos."
+  }
+}

--- a/src/services/__tests__/homeModuleSelector.test.js
+++ b/src/services/__tests__/homeModuleSelector.test.js
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HOME_MODULE_IDS,
+  ALL_HOME_MODULES,
+  SEGUIMIENTO_KEYS,
+  esPerfilUrbano,
+  profileTieneCerdos,
+  selectHomeModules,
+  selectHomeModuleVisibilityMap,
+  isSeguimientoVisible,
+} from '../homeModuleSelector.js';
+
+/**
+ * Tests del SELECTOR DE MÓDULOS DEL HOME POR PERFIL (gating del home —
+ * "el usuario solo ve lo que necesita"). El módulo es PURO: del perfil →
+ * { visibles: string[], seguimiento: string[] }.
+ *
+ * Contrato clave (brief, ADR-017/ADR-011/ADR-034):
+ *   - selectHomeModules(profile, opts) → { visibles, seguimiento }.
+ *   - URBANO es OVERRIDE DURO: nunca cerdos/silvopastoreo/reforestacion/
+ *     paramo/zonas/insumos, aunque el rol diga otra cosa.
+ *   - Ganadero con cerdos SÍ ve la tarjeta de cerdos; con solo gallinas, NO.
+ *   - REUSA deriveRole de profileChipSelector (no duplica la lógica de rol).
+ */
+
+const ALL_SEGUIMIENTO = new Set(Object.values(SEGUIMIENTO_KEYS));
+
+describe('homeModuleSelector — helpers', () => {
+  it('esPerfilUrbano: vocacion urbano O finca_tipo balcon/terraza', () => {
+    expect(esPerfilUrbano({ vocacion: 'urbano' })).toBe(true);
+    expect(esPerfilUrbano({ finca_tipo: 'balcon' })).toBe(true);
+    expect(esPerfilUrbano({ finca_tipo: 'terraza' })).toBe(true);
+    // Rural/invernadero NO es urbano.
+    expect(esPerfilUrbano({ finca_tipo: 'rural' })).toBe(false);
+    expect(esPerfilUrbano({ finca_tipo: 'invernadero' })).toBe(false);
+    expect(esPerfilUrbano({})).toBe(false);
+    expect(esPerfilUrbano(null)).toBe(false);
+  });
+
+  it('profileTieneCerdos: solo true si animales incluye cerdos', () => {
+    expect(profileTieneCerdos({ animales: ['cerdos'] })).toBe(true);
+    expect(profileTieneCerdos({ animales: ['gallinas', 'cerdos'] })).toBe(true);
+    // Gallinas/ganado NO son cerdos.
+    expect(profileTieneCerdos({ animales: ['gallinas', 'ganado'] })).toBe(false);
+    expect(profileTieneCerdos({ animales: ['ninguno'] })).toBe(false);
+    // Respaldo por texto libre.
+    expect(profileTieneCerdos({ cultivos_interes: 'quiero criar marranos' })).toBe(true);
+    expect(profileTieneCerdos({})).toBe(false);
+  });
+});
+
+describe('homeModuleSelector — selectHomeModules por PERSONA', () => {
+  // ── PERSONA 1: URBANO (criterio de éxito #1) ───────────────────────────
+  it('URBANO (vocacion urbano): set mínimo, SIN cerdos/silvopastoreo/zonas/insumos', () => {
+    const { visibles, seguimiento } = selectHomeModules({ vocacion: 'urbano' });
+    expect(visibles).toEqual(
+      expect.arrayContaining([
+        HOME_MODULE_IDS.plantas,
+        HOME_MODULE_IDS.plagas,
+        HOME_MODULE_IDS.bitacora,
+        HOME_MODULE_IDS.clima,
+        HOME_MODULE_IDS.hoyfinca,
+      ]),
+    );
+    // OBLIGATORIO: nunca módulos de finca grande.
+    expect(visibles).not.toContain(HOME_MODULE_IDS.zonas);
+    expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+    // OBLIGATORIO: NINGUNA tarjeta de seguimiento.
+    expect(seguimiento).toEqual([]);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.reforestacion);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.paramo);
+  });
+
+  it('URBANO/terraza (finca_tipo terraza): mismo override duro, sin zonas/insumos/cerdos', () => {
+    const { visibles, seguimiento } = selectHomeModules({ finca_tipo: 'terraza' });
+    expect(visibles).not.toContain(SEGUIMIENTO_KEYS.cerdos); // sanity (módulos)
+    expect(visibles).not.toContain(HOME_MODULE_IDS.zonas);
+    expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+    expect(seguimiento).not.toContain('cerdos');
+    expect(seguimiento).not.toContain('silvopastoreo');
+    expect(seguimiento).not.toContain('zonas');
+    expect(seguimiento).not.toContain('insumos');
+    expect(seguimiento).toEqual([]);
+  });
+
+  it('URBANO gana aunque el perfil declare animales (cerdos): override duro', () => {
+    // Un urbano con un rol/animales raro NO debe ver cerdos: el override gana.
+    const { visibles, seguimiento } = selectHomeModules({
+      vocacion: 'urbano',
+      rol: 'ganadero',
+      animales: ['cerdos'],
+    });
+    expect(visibles).not.toContain(HOME_MODULE_IDS.zonas);
+    expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+    expect(seguimiento).toEqual([]);
+  });
+
+  // ── PERSONA 2: CAMPESINO ───────────────────────────────────────────────
+  it('CAMPESINO: módulos de cultivo, sin seguimiento por defecto', () => {
+    const { visibles, seguimiento } = selectHomeModules({ rol: 'campesino' });
+    expect(visibles).toEqual(
+      expect.arrayContaining([
+        HOME_MODULE_IDS.hoyfinca,
+        HOME_MODULE_IDS.clima,
+        HOME_MODULE_IDS.plantas,
+        HOME_MODULE_IDS.plagas,
+        HOME_MODULE_IDS.bitacora,
+        HOME_MODULE_IDS.insumos,
+        HOME_MODULE_IDS.zonas,
+        HOME_MODULE_IDS.informes,
+        HOME_MODULE_IDS.analisis,
+      ]),
+    );
+    // Campesino base no es restaurador: sin biodiversidad por defecto.
+    expect(visibles).not.toContain(HOME_MODULE_IDS.biodiversidad);
+    expect(seguimiento).toEqual([]);
+  });
+
+  // ── PERSONA 3: GANADERO ────────────────────────────────────────────────
+  it('GANADERO con CERDOS: campesino + silvopastoreo + cerdos', () => {
+    const { visibles, seguimiento } = selectHomeModules({
+      rol: 'ganadero',
+      animales: ['ganado', 'cerdos'],
+    });
+    // Base campesino presente.
+    expect(visibles).toContain(HOME_MODULE_IDS.plantas);
+    expect(visibles).toContain(HOME_MODULE_IDS.insumos);
+    // OBLIGATORIO: cerdos SÍ (tiene cerdos).
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.cerdos);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+  });
+
+  it('GANADERO solo GALLINAS: silvopastoreo SÍ, cerdos NO', () => {
+    const { seguimiento } = selectHomeModules({
+      rol: 'ganadero',
+      animales: ['gallinas'],
+    });
+    // OBLIGATORIO: gallinas → silvopastoreo, NUNCA cerdos.
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+
+  it('GANADERO inferido por heurística (vocacion campesino + animales)', () => {
+    // Sin rol explícito: deriveRole lo manda a ganadero por animales no-urbano.
+    const { seguimiento } = selectHomeModules({
+      vocacion: 'campesino',
+      animales: ['ganado'],
+    });
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+
+  // ── PERSONA 4: RESTAURADOR ─────────────────────────────────────────────
+  it('RESTAURADOR: campesino-core + biodiversidad + reforestacion/paramo', () => {
+    const { visibles, seguimiento } = selectHomeModules({
+      rol: 'restaurador',
+      objetivo: ['biodiversidad'],
+    });
+    expect(visibles).toContain(HOME_MODULE_IDS.biodiversidad);
+    expect(visibles).toContain(HOME_MODULE_IDS.plantas);
+    expect(visibles).toContain(HOME_MODULE_IDS.clima);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.reforestacion);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.paramo);
+    // Restaurador no maneja cerdos por defecto.
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+
+  // ── PERSONA 5: GUÍA DE GLACIAR ─────────────────────────────────────────
+  it('GUÍA GLACIAR: clima/hoyfinca/biodiversidad + paramo/reforestacion', () => {
+    const { visibles, seguimiento } = selectHomeModules(
+      { vocacion: 'campesino' },
+      { esGuiaGlaciar: true },
+    );
+    expect(visibles).toContain(HOME_MODULE_IDS.clima);
+    expect(visibles).toContain(HOME_MODULE_IDS.hoyfinca);
+    expect(visibles).toContain(HOME_MODULE_IDS.biodiversidad);
+    // Un guía no necesita el inventario de insumos ni la cola de plagas de cultivo.
+    expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.paramo);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.reforestacion);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+
+  // ── SOCIO / TÉCNICO ────────────────────────────────────────────────────
+  it('SOCIO: set corto {hoyfinca, plantas, clima, informes}, sin seguimiento', () => {
+    const { visibles, seguimiento } = selectHomeModules({ rol: 'socio' });
+    expect(visibles).toEqual(
+      expect.arrayContaining([
+        HOME_MODULE_IDS.hoyfinca,
+        HOME_MODULE_IDS.plantas,
+        HOME_MODULE_IDS.clima,
+        HOME_MODULE_IDS.informes,
+      ]),
+    );
+    expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+    expect(visibles).not.toContain(HOME_MODULE_IDS.zonas);
+    expect(seguimiento).toEqual([]);
+  });
+
+  it('TÉCNICO: ve TODOS los módulos y las 4 tarjetas de seguimiento', () => {
+    const { visibles, seguimiento } = selectHomeModules({ rol: 'tecnico' });
+    for (const id of ALL_HOME_MODULES) expect(visibles).toContain(id);
+    expect(seguimiento).toEqual(
+      expect.arrayContaining([
+        SEGUIMIENTO_KEYS.reforestacion,
+        SEGUIMIENTO_KEYS.silvopastoreo,
+        SEGUIMIENTO_KEYS.paramo,
+        SEGUIMIENTO_KEYS.cerdos,
+      ]),
+    );
+  });
+});
+
+describe('homeModuleSelector — invariantes', () => {
+  it('SIEMPRE devuelve solo ids/keys válidos y sin duplicados', () => {
+    const perfiles = [
+      { vocacion: 'urbano' },
+      { rol: 'campesino' },
+      { rol: 'ganadero', animales: ['cerdos', 'gallinas'] },
+      { rol: 'restaurador', objetivo: ['biodiversidad'] },
+      { rol: 'tecnico' },
+      { rol: 'socio' },
+      {},
+      null,
+    ];
+    const validModules = new Set(ALL_HOME_MODULES);
+    for (const p of perfiles) {
+      const { visibles, seguimiento } = selectHomeModules(p);
+      for (const id of visibles) expect(validModules.has(id)).toBe(true);
+      for (const k of seguimiento) expect(ALL_SEGUIMIENTO.has(k)).toBe(true);
+      expect(new Set(visibles).size).toBe(visibles.length);
+      expect(new Set(seguimiento).size).toBe(seguimiento.length);
+    }
+  });
+
+  it('perfil vacío / inválido → cae a campesino (default seguro, nunca vacío)', () => {
+    const { visibles } = selectHomeModules({});
+    expect(visibles.length).toBeGreaterThan(0);
+    expect(visibles).toContain(HOME_MODULE_IDS.plantas);
+    expect(selectHomeModules(null).visibles.length).toBeGreaterThan(0);
+    expect(selectHomeModules(undefined).visibles.length).toBeGreaterThan(0);
+  });
+});
+
+describe('homeModuleSelector — selectHomeModuleVisibilityMap', () => {
+  it('devuelve un mapa { moduleId: boolean } con TODOS los ids del home', () => {
+    const map = selectHomeModuleVisibilityMap({ rol: 'campesino' });
+    // Todas las claves de HOME presentes (forma idéntica a getModuleVisibility).
+    for (const id of ALL_HOME_MODULES) {
+      expect(map).toHaveProperty(id);
+      expect(typeof map[id]).toBe('boolean');
+    }
+  });
+
+  it('urbano: el mapa pone zonas/insumos/biodiversidad en false', () => {
+    const map = selectHomeModuleVisibilityMap({ vocacion: 'urbano' });
+    expect(map[HOME_MODULE_IDS.plantas]).toBe(true);
+    expect(map[HOME_MODULE_IDS.clima]).toBe(true);
+    expect(map[HOME_MODULE_IDS.zonas]).toBe(false);
+    expect(map[HOME_MODULE_IDS.insumos]).toBe(false);
+    expect(map[HOME_MODULE_IDS.biodiversidad]).toBe(false);
+  });
+});
+
+describe('homeModuleSelector — isSeguimientoVisible (gating de tarjetas)', () => {
+  it('urbano: NINGUNA tarjeta visible (criterio #1 — Cerdos oculto)', () => {
+    const p = { vocacion: 'urbano' };
+    expect(isSeguimientoVisible(SEGUIMIENTO_KEYS.cerdos, p)).toBe(false);
+    expect(isSeguimientoVisible(SEGUIMIENTO_KEYS.silvopastoreo, p)).toBe(false);
+    expect(isSeguimientoVisible(SEGUIMIENTO_KEYS.reforestacion, p)).toBe(false);
+    expect(isSeguimientoVisible(SEGUIMIENTO_KEYS.paramo, p)).toBe(false);
+  });
+
+  it('ganadero con cerdos: Cerdos visible; restaurador: Cerdos NO', () => {
+    expect(
+      isSeguimientoVisible(SEGUIMIENTO_KEYS.cerdos, { rol: 'ganadero', animales: ['cerdos'] }),
+    ).toBe(true);
+    expect(
+      isSeguimientoVisible(SEGUIMIENTO_KEYS.cerdos, { rol: 'restaurador' }),
+    ).toBe(false);
+    expect(
+      isSeguimientoVisible(SEGUIMIENTO_KEYS.reforestacion, { rol: 'restaurador' }),
+    ).toBe(true);
+  });
+});

--- a/src/services/homeModuleSelector.js
+++ b/src/services/homeModuleSelector.js
@@ -1,0 +1,375 @@
+/**
+ * homeModuleSelector.js — Selección ADAPTATIVA de los MÓDULOS del HOME POR
+ * PERFIL. Gemelo de `profileChipSelector` pero para el dashboard (no para los
+ * chips del agente).
+ *
+ * Problema que resuelve: el Home (`DashboardLive`) mostraba SIEMPRE todos los
+ * módulos + las 4 tarjetas de seguimiento (Reforestación · Silvopastoreo ·
+ * Páramo · Cerdos) a todo el mundo. Principio del producto: "el usuario solo
+ * ve lo que necesita" — un usuario urbano de balcón NUNCA debe ver la tarjeta
+ * de Cerdos ni la de silvopastoreo; un guía de glaciar no necesita el
+ * inventario de insumos. El perfil del onboarding (`rol`/`vocacion`/
+ * `finca_tipo`/`animales`/`objetivo`) debe fijar QUÉ se ve por DEFECTO.
+ *
+ * Este módulo es PURO (sin red, sin React, sin localStorage): mapea un perfil
+ * de usuario → la lista de módulos del home + las tarjetas de seguimiento que
+ * le corresponden. Toda la lógica vive acá para testearla en aislamiento
+ * (TDD), igual que `profileChipSelector.selectChipIntents`.
+ *
+ * REUSO: la derivación de ROL vive en `profileChipSelector.deriveRole` (fuente
+ * única — no se duplica). Este módulo la importa y mapea cada rol a su set de
+ * módulos. El gating de seguridad del módulo glaciar (whitelist La Cordada)
+ * NO vive acá: el tile glaciar tiene su propio gate (`glaciarAccess`).
+ *
+ * RESPETO A #1560/#7003: este módulo SOLO calcula el DEFAULT por perfil. Si el
+ * usuario guardó una preferencia manual de visibilidad en `ProfileScreen`, esa
+ * preferencia GANA — el call-site (DashboardLive) decide cuál usar. Acá no se
+ * lee ni se escribe ninguna preferencia.
+ *
+ * Español colombiano (tú/usted), NUNCA voseo argentino.
+ *
+ * @module homeModuleSelector
+ */
+
+import { deriveRole, profileTieneAnimales, PROFILE_ROLES } from './profileChipSelector.js';
+
+/**
+ * IDs de los módulos del Home (deben coincidir con `HOME_MODULES` de
+ * userProfileService + `SECTION_COMPONENTS` de DashboardLive). Fuente de
+ * verdad de los ids: userProfileService.HOME_MODULES — acá solo los nombramos
+ * para los sets por rol. Si se agrega un módulo nuevo allá, agregarlo al set
+ * del rol que lo necesite acá (default fail-open en el call-site lo cubre
+ * mientras tanto).
+ *
+ * @enum {string}
+ */
+export const HOME_MODULE_IDS = Object.freeze({
+  hoyfinca: 'hoyfinca',
+  clima: 'clima',
+  analisis: 'analisis',
+  plantas: 'plantas',
+  zonas: 'zonas',
+  insumos: 'insumos',
+  bitacora: 'bitacora',
+  hoy: 'hoy',
+  plagas: 'plagas',
+  biodiversidad: 'biodiversidad',
+  informes: 'informes',
+});
+
+/**
+ * Lista completa de ids de módulos del home (el set "todo visible"). Es la
+ * base del rol técnico (que lo ve todo) y el fallback.
+ * @type {readonly string[]}
+ */
+export const ALL_HOME_MODULES = Object.freeze(Object.values(HOME_MODULE_IDS));
+
+/**
+ * Keys de las 4 tarjetas de SEGUIMIENTO de procesos de finca. Deben coincidir
+ * con las `key` de `config/seguimientoProcesos.js` (reforestacion ·
+ * silvopastoreo · paramo · cerdos). Las nombramos acá para no acoplar este
+ * módulo puro al import del catálogo de seguimiento (que arrastra estilos).
+ *
+ * @enum {string}
+ */
+export const SEGUIMIENTO_KEYS = Object.freeze({
+  reforestacion: 'reforestacion',
+  silvopastoreo: 'silvopastoreo',
+  paramo: 'paramo',
+  cerdos: 'cerdos',
+});
+
+/**
+ * Set MÍNIMO para el usuario urbano (balcón/terraza/patio). Es un OVERRIDE
+ * DURO: aunque `deriveRole` devuelva otra cosa, si el perfil es urbano gana
+ * este set. NUNCA incluye cerdos/silvopastoreo/reforestación/páramo/zonas/
+ * insumos — el urbano cultiva en materas, no maneja ganado ni parcelas.
+ * @type {readonly string[]}
+ */
+const URBANO_MODULES = Object.freeze([
+  HOME_MODULE_IDS.plantas,
+  HOME_MODULE_IDS.plagas,
+  HOME_MODULE_IDS.bitacora,
+  HOME_MODULE_IDS.clima,
+  HOME_MODULE_IDS.hoyfinca,
+]);
+
+/**
+ * Núcleo del campesino productor. Orden = relevancia para producir comida.
+ * Los demás roles productivos parten de este núcleo.
+ * @type {readonly string[]}
+ */
+const CAMPESINO_MODULES = Object.freeze([
+  HOME_MODULE_IDS.hoyfinca,
+  HOME_MODULE_IDS.clima,
+  HOME_MODULE_IDS.plantas,
+  HOME_MODULE_IDS.plagas,
+  HOME_MODULE_IDS.bitacora,
+  HOME_MODULE_IDS.insumos,
+  HOME_MODULE_IDS.zonas,
+  HOME_MODULE_IDS.informes,
+  HOME_MODULE_IDS.analisis,
+]);
+
+/**
+ * Núcleo-core campesino (subconjunto sin insumos/zonas/informes/analisis),
+ * base para el restaurador, al que le sumamos biodiversidad.
+ * @type {readonly string[]}
+ */
+const CAMPESINO_CORE = Object.freeze([
+  HOME_MODULE_IDS.hoyfinca,
+  HOME_MODULE_IDS.clima,
+  HOME_MODULE_IDS.plantas,
+  HOME_MODULE_IDS.plagas,
+  HOME_MODULE_IDS.bitacora,
+]);
+
+/**
+ * Conjunto de módulos visibles por ROL (sin contar el override urbano ni los
+ * extras por animales/objetivo, que se aplican en `selectHomeModules`).
+ * @type {Record<string, readonly string[]>}
+ */
+const ROLE_MODULES = Object.freeze({
+  [PROFILE_ROLES.campesino]: CAMPESINO_MODULES,
+  // Ganadero = campesino + (silvopastoreo/cerdos van por SEGUIMIENTO, no módulo).
+  [PROFILE_ROLES.ganadero]: CAMPESINO_MODULES,
+  // Restaurador = campesino-core + biodiversidad.
+  [PROFILE_ROLES.restaurador]: Object.freeze([
+    ...CAMPESINO_CORE,
+    HOME_MODULE_IDS.biodiversidad,
+  ]),
+  // Guía de glaciar: alta montaña — clima, el día y la biodiversidad de páramo.
+  // (El tile "Reporte de Punto Glaciar" tiene su propio gate en glaciarAccess.)
+  [PROFILE_ROLES.guia_glaciar]: Object.freeze([
+    HOME_MODULE_IDS.clima,
+    HOME_MODULE_IDS.hoyfinca,
+    HOME_MODULE_IDS.biodiversidad,
+  ]),
+  // Socio / aliado / observador: vista corta de lectura.
+  [PROFILE_ROLES.socio]: Object.freeze([
+    HOME_MODULE_IDS.hoyfinca,
+    HOME_MODULE_IDS.plantas,
+    HOME_MODULE_IDS.clima,
+    HOME_MODULE_IDS.informes,
+  ]),
+  // Técnico/agrónomo: lo ve TODO (sabe usar el set completo).
+  [PROFILE_ROLES.tecnico]: ALL_HOME_MODULES,
+});
+
+/**
+ * Tarjetas de seguimiento por ROL (sin contar el filtro de animales del
+ * ganadero, que se aplica en `selectHomeModules`).
+ * @type {Record<string, readonly string[]>}
+ */
+const ROLE_SEGUIMIENTO = Object.freeze({
+  [PROFILE_ROLES.campesino]: Object.freeze([]),
+  // Ganadero: silvopastoreo SIEMPRE; cerdos SOLO si el perfil tiene cerdos
+  // (se resuelve en selectHomeModules). Acá dejamos silvopastoreo de base.
+  [PROFILE_ROLES.ganadero]: Object.freeze([SEGUIMIENTO_KEYS.silvopastoreo]),
+  [PROFILE_ROLES.restaurador]: Object.freeze([
+    SEGUIMIENTO_KEYS.reforestacion,
+    SEGUIMIENTO_KEYS.paramo,
+  ]),
+  [PROFILE_ROLES.guia_glaciar]: Object.freeze([
+    SEGUIMIENTO_KEYS.paramo,
+    SEGUIMIENTO_KEYS.reforestacion,
+  ]),
+  [PROFILE_ROLES.socio]: Object.freeze([]),
+  // Técnico: ve las 4 tarjetas (acompaña cualquier proceso).
+  [PROFILE_ROLES.tecnico]: Object.freeze([
+    SEGUIMIENTO_KEYS.reforestacion,
+    SEGUIMIENTO_KEYS.silvopastoreo,
+    SEGUIMIENTO_KEYS.paramo,
+    SEGUIMIENTO_KEYS.cerdos,
+  ]),
+});
+
+/** Set de ids de módulos válidos (para filtrar/dedupe). */
+const VALID_MODULES = new Set(ALL_HOME_MODULES);
+/** Set de keys de seguimiento válidas (para filtrar/dedupe). */
+const VALID_SEGUIMIENTO = new Set(Object.values(SEGUIMIENTO_KEYS));
+
+/**
+ * Normaliza un string a minúsculas sin tildes ni espacios sobrantes. Tolerante
+ * a `null`/no-string (devuelve ''). Igual criterio que profileChipSelector.
+ * @param {unknown} v
+ * @returns {string}
+ */
+function norm(v) {
+  if (typeof v !== 'string') return '';
+  return v
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '');
+}
+
+/**
+ * ¿El perfil es URBANO? El override urbano se dispara por DOS señales (el
+ * brief): `vocacion === 'urbano'` O `finca_tipo ∈ {balcon, terraza}`.
+ * @param {Object} profile
+ * @returns {boolean}
+ */
+export function esPerfilUrbano(profile) {
+  const p = profile && typeof profile === 'object' ? profile : {};
+  if (norm(p.vocacion) === 'urbano') return true;
+  const fincaTipo = norm(p.finca_tipo);
+  return fincaTipo === 'balcon' || fincaTipo === 'terraza';
+}
+
+/**
+ * ¿El perfil declara tener CERDOS específicamente? El array multi `animales`
+ * del onboarding. Solo los cerdos activan la tarjeta de seguimiento de cerdos
+ * (gallinas/ganado → silvopastoreo, NO cerdos).
+ * @param {Object} profile
+ * @returns {boolean}
+ */
+export function profileTieneCerdos(profile) {
+  const p = profile && typeof profile === 'object' ? profile : {};
+  const arr = p.animales;
+  if (Array.isArray(arr) && arr.map(norm).includes('cerdos')) return true;
+  // Respaldo: el usuario escribió cerdos/marranos en texto libre.
+  const libre = norm(p.cultivos_actuales) + ' ' + norm(p.cultivos_interes);
+  return /\b(cerdo|cerdos|marrano|marranos|porcino|porcinos|porcicultura)\b/.test(libre);
+}
+
+/**
+ * Filtra + dedupe preservando el primer orden visto, contra un set de válidos.
+ * @param {Iterable<string>} ids
+ * @param {Set<string>} valid
+ * @returns {string[]}
+ */
+function dedupeValid(ids, valid) {
+  const seen = new Set();
+  const out = [];
+  for (const id of ids) {
+    if (!valid.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/**
+ * API de alto nivel: del PERFIL completo → módulos del home + tarjetas de
+ * seguimiento que le corresponden a este usuario POR DEFECTO.
+ *
+ * Reglas (el brief, ancladas a ADR-017/ADR-011/ADR-034):
+ *   - URBANO (vocacion 'urbano' O finca_tipo balcon/terraza): OVERRIDE DURO →
+ *     SOLO {plantas, plagas, bitacora, clima, hoyfinca}. NUNCA cerdos/
+ *     silvopastoreo/reforestacion/paramo/zonas/insumos. Gana aunque el rol
+ *     derivado diga otra cosa.
+ *   - CAMPESINO: núcleo de cultivo, sin seguimiento por defecto (salvo que
+ *     animales/objetivo lo activen).
+ *   - GANADERO (tiene animales): campesino + seguimiento silvopastoreo;
+ *     + cerdos SOLO si `animales` incluye 'cerdos'.
+ *   - RESTAURADOR: campesino-core + biodiversidad + seguimiento
+ *     {reforestacion, paramo}.
+ *   - GUÍA GLACIAR: {clima, hoyfinca, biodiversidad} + seguimiento
+ *     {paramo, reforestacion}. (El tile glaciar tiene su propio gate.)
+ *   - SOCIO: set corto {hoyfinca, plantas, clima, informes}. TÉCNICO: todo.
+ *
+ * Además, transversal a los roles productivos no-urbanos:
+ *   - Si el perfil tiene animales (cualquier rol no urbano), asegura la
+ *     tarjeta de silvopastoreo (el ángulo pecuario), y cerdos si hay cerdos.
+ *   - Si el objetivo incluye biodiversidad/restauración, asegura el módulo de
+ *     biodiversidad + las tarjetas de reforestación/páramo.
+ *
+ * @param {Object} profile — perfil del usuario (chagra:profile:v1).
+ * @param {Object} [opts]
+ * @param {boolean} [opts.esGuiaGlaciar=false] — username en whitelist Cordada
+ *   (lo resuelve el call-site con glaciarAccess, fuera de este módulo puro).
+ * @returns {{ visibles: string[], seguimiento: string[] }} ids de módulos del
+ *   home visibles + keys de tarjetas de seguimiento, ambos filtrados y sin
+ *   duplicados.
+ */
+export function selectHomeModules(profile, opts = {}) {
+  const p = profile && typeof profile === 'object' ? profile : {};
+
+  // ── OVERRIDE DURO: urbano ───────────────────────────────────────────────
+  // Gana sobre cualquier rol derivado. Set mínimo, SIN seguimiento (un balcón
+  // no maneja cerdos/silvopastoreo/reforestación/páramo).
+  if (esPerfilUrbano(p)) {
+    return {
+      visibles: dedupeValid(URBANO_MODULES, VALID_MODULES),
+      seguimiento: [],
+    };
+  }
+
+  // ── Rol de producto (reusa deriveRole de profileChipSelector) ────────────
+  const role = deriveRole(p, opts);
+
+  const baseModules = ROLE_MODULES[role] || ROLE_MODULES[PROFILE_ROLES.campesino];
+  const baseSeguimiento = ROLE_SEGUIMIENTO[role] || ROLE_SEGUIMIENTO[PROFILE_ROLES.campesino];
+
+  const modules = [...baseModules];
+  const seguimiento = [...baseSeguimiento];
+
+  const tieneAnimales = profileTieneAnimales(p);
+  const tieneCerdos = profileTieneCerdos(p);
+
+  const objetivos = Array.isArray(p.objetivo) ? p.objetivo.map(norm) : [];
+  const restauraObjetivo = Array.isArray(p.restauracion_objetivo)
+    ? p.restauracion_objetivo.map(norm)
+    : [];
+  const quiereRestauracion =
+    objetivos.includes('biodiversidad') || restauraObjetivo.length > 0;
+
+  // Animales (no urbano): asegurar silvopastoreo; cerdos solo si hay cerdos.
+  if (tieneAnimales && !seguimiento.includes(SEGUIMIENTO_KEYS.silvopastoreo)) {
+    seguimiento.push(SEGUIMIENTO_KEYS.silvopastoreo);
+  }
+  if (tieneCerdos && !seguimiento.includes(SEGUIMIENTO_KEYS.cerdos)) {
+    seguimiento.push(SEGUIMIENTO_KEYS.cerdos);
+  }
+
+  // Objetivo de restauración/biodiversidad: módulo biodiversidad + tarjetas.
+  if (quiereRestauracion) {
+    if (!modules.includes(HOME_MODULE_IDS.biodiversidad)) {
+      modules.push(HOME_MODULE_IDS.biodiversidad);
+    }
+    for (const k of [SEGUIMIENTO_KEYS.reforestacion, SEGUIMIENTO_KEYS.paramo]) {
+      if (!seguimiento.includes(k)) seguimiento.push(k);
+    }
+  }
+
+  return {
+    visibles: dedupeValid(modules, VALID_MODULES),
+    seguimiento: dedupeValid(seguimiento, VALID_SEGUIMIENTO),
+  };
+}
+
+/**
+ * Conveniencia para el call-site (DashboardLive): del perfil → un mapa
+ * `{ moduleId: boolean }` listo para usar como `moduleVisibility` por DEFECTO,
+ * con la MISMA forma que devuelve `userProfileService.getModuleVisibility()`.
+ * Cada id de `ALL_HOME_MODULES` queda en true/false según el perfil.
+ *
+ * @param {Object} profile
+ * @param {Object} [opts] — igual que selectHomeModules (esGuiaGlaciar).
+ * @returns {Record<string, boolean>}
+ */
+export function selectHomeModuleVisibilityMap(profile, opts = {}) {
+  const { visibles } = selectHomeModules(profile, opts);
+  const visibleSet = new Set(visibles);
+  const map = {};
+  for (const id of ALL_HOME_MODULES) {
+    map[id] = visibleSet.has(id);
+  }
+  return map;
+}
+
+/**
+ * Conveniencia para el gating de las tarjetas de seguimiento: ¿esta key de
+ * seguimiento debe mostrarse para este perfil? Lo usa DashboardLive para
+ * filtrar las 4 tarjetas (urbano NO renderiza Cerdos).
+ *
+ * @param {string} key — key de seguimiento (reforestacion/silvopastoreo/…).
+ * @param {Object} profile
+ * @param {Object} [opts]
+ * @returns {boolean}
+ */
+export function isSeguimientoVisible(key, profile, opts = {}) {
+  const { seguimiento } = selectHomeModules(profile, opts);
+  return seguimiento.includes(key);
+}

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -793,6 +793,30 @@ export function getModuleVisibility() {
 }
 
 /**
+ * ¿El usuario guardó una preferencia MANUAL de visibilidad de módulos?
+ *
+ * Devuelve true solo si existe el campo `modulos_visibles` en el perfil (lo
+ * escribe `setModuleVisibility` desde ProfileScreen, #1560). Cuando es false,
+ * el Home puede derivar la visibilidad por DEFECTO desde el perfil
+ * (homeModuleSelector) sin pisar ninguna elección del usuario.
+ *
+ * Nota: un objeto vacío `{}` (caso de "todo visible" que setModuleVisibility
+ * guarda cuando el usuario no ocultó nada) TAMBIÉN cuenta como preferencia
+ * manual — el usuario pasó por la pantalla y dejó todo visible a propósito.
+ *
+ * @returns {boolean}
+ */
+export function hasManualModuleVisibility() {
+  const profile = getProfile();
+  return !!(
+    profile &&
+    typeof profile === 'object' &&
+    profile.modulos_visibles &&
+    typeof profile.modulos_visibles === 'object'
+  );
+}
+
+/**
  * Persiste la configuración de visibilidad de módulos.
  *
  * @param {Object} visibility - { moduleId: boolean }

--- a/src/types/__tests__/farmProcess.test.js
+++ b/src/types/__tests__/farmProcess.test.js
@@ -6,6 +6,7 @@ import {
   isFarmProcess, isFarmProcessEvent, isPopulation,
   validateFarmProcess, validateFarmProcessEvent, validatePopulation,
   stageSequenceForProcessType, RESTORATION_STAGE_SEQUENCE,
+  PARAMO_STAGE_SEQUENCE, PIGS_STAGE_SEQUENCE,
 } from '../farmProcess';
 
 // ─── Fixtures (Task 14) ────────────────────────────────────────
@@ -216,5 +217,55 @@ describe('etapas propias de restauración (no fenología de cultivo)', () => {
     const codigos = stageSequenceForProcessType('sowing').map((s) => s.stage);
     expect(codigos).toContain('germination');
     expect(codigos).toContain('harvest');
+  });
+});
+
+describe('process_types nuevos de seguimiento (paramo, pigs)', () => {
+  it('valida un proceso de páramo en sus etapas propias', () => {
+    expect(() => validateFarmProcess(makeProcess({
+      process_type: 'paramo', subject_slug: '', subject_label: 'Nacimiento El Roble',
+      unit: 'hectáreas', current_stage: 'delimitacion',
+    }))).not.toThrow();
+    expect(() => validateFarmProcess(makeProcess({
+      process_type: 'paramo', subject_slug: '', subject_label: 'Frailejonal',
+      unit: 'hectáreas', current_stage: 'monitoreo_hidrico',
+    }))).not.toThrow();
+  });
+
+  it('valida un ciclo de cerdos en sus etapas de manejo', () => {
+    expect(() => validateFarmProcess(makeProcess({
+      process_type: 'pigs', subject_slug: '', subject_label: 'Lote de engorde',
+      unit: 'animales', current_stage: 'instalacion',
+    }))).not.toThrow();
+    expect(() => validateFarmProcess(makeProcess({
+      process_type: 'pigs', subject_slug: '', subject_label: 'Marranas de cría',
+      unit: 'animales', current_stage: 'reproduccion',
+    }))).not.toThrow();
+  });
+
+  it('stageSequenceForProcessType(paramo) trae hitos de conservación, no fenología', () => {
+    const seq = stageSequenceForProcessType('paramo');
+    expect(seq).toBe(PARAMO_STAGE_SEQUENCE);
+    const codigos = seq.map((s) => s.stage);
+    expect(codigos).toContain('aislamiento');
+    expect(codigos).toContain('monitoreo_hidrico');
+    expect(codigos).not.toContain('flowering');
+    expect(codigos).not.toContain('harvest');
+  });
+
+  it('stageSequenceForProcessType(pigs) trae hitos de manejo porcino, no fenología', () => {
+    const seq = stageSequenceForProcessType('pigs');
+    expect(seq).toBe(PIGS_STAGE_SEQUENCE);
+    const codigos = seq.map((s) => s.stage);
+    expect(codigos).toContain('alimentacion');
+    expect(codigos).toContain('sanidad');
+    expect(codigos).not.toContain('germination');
+    expect(codigos).not.toContain('harvest');
+  });
+
+  it('rechaza una etapa que no pertenece a ningún proceso', () => {
+    expect(() => validateFarmProcess(makeProcess({
+      process_type: 'pigs', subject_slug: '', subject_label: 'x', current_stage: 'etapa_inexistente',
+    }))).toThrow(/current_stage/);
   });
 });

--- a/src/types/farmProcess.js
+++ b/src/types/farmProcess.js
@@ -103,7 +103,12 @@ export const isPopulation = (p) => p?.type === 'population';
 
 // ─── Validators ────────────────────────────────────────────────
 
-const VALID_PROCESS_TYPES = ['sowing', 'restoration', 'silvopasture', 'pest_management', 'harvest', 'post_harvest'];
+// 'paramo' y 'pigs' agregados 2026-06-15 (seguimiento de procesos de finca):
+//   - paramo: conservación/restauración de páramo (NO es cultivo ni cosecha;
+//     hitos de protección de fuentes hídricas y de frailejones).
+//   - pigs: ciclo de manejo porcino (alimentación/reproducción/sanidad). Reusa
+//     animal-diagnostics.json + guardas leucaena/mimosina.
+const VALID_PROCESS_TYPES = ['sowing', 'restoration', 'silvopasture', 'pest_management', 'harvest', 'post_harvest', 'paramo', 'pigs'];
 const VALID_SUBJECT_KINDS = ['individual', 'aggregate'];
 const VALID_STATUSES = ['active', 'completed', 'cancelled'];
 // Transitional vocabulary: OpenCode's phenology/tasks use the newer
@@ -132,6 +137,17 @@ const VALID_STAGES = [
   'mantenimiento',
   'monitoreo_sucesion',
   'cierre',
+  // Páramo (conservación): hitos de protección de fuentes hídricas + frailejones.
+  'delimitacion',
+  'aislamiento',
+  'revegetacion_nativa',
+  'monitoreo_hidrico',
+  // Cerdos (ciclo de manejo porcino). Hitos de manejo, NO fenología.
+  'instalacion',
+  'alimentacion',
+  'reproduccion',
+  'sanidad',
+  'engorde',
 ];
 const VALID_EVENT_TYPES = [
   'sowing_confirmed',
@@ -170,11 +186,41 @@ const SOWING_STAGE_SEQUENCE = [
   { stage: 'harvest', label: 'Cosecha' },
 ];
 
+/**
+ * Páramo (conservación). NO sigue fenología de cultivo: son hitos de protección
+ * del ecosistema de páramo (delimitación de la zona, aislamiento del ganado,
+ * revegetación con nativas, monitoreo de fuentes hídricas). El detalle técnico
+ * de cada hito está marcado [VALIDAR] en la UI hasta tener fuente cerrada.
+ */
+export const PARAMO_STAGE_SEQUENCE = [
+  { stage: 'delimitacion', label: 'Delimitación de la zona a proteger' },
+  { stage: 'aislamiento', label: 'Aislamiento (cercas, sacar ganado)' },
+  { stage: 'revegetacion_nativa', label: 'Revegetación con nativas (frailejón, etc.)' },
+  { stage: 'monitoreo_hidrico', label: 'Monitoreo de fuentes hídricas y sucesión' },
+  { stage: 'cierre', label: 'Cierre (zona protegida y estable)' },
+];
+
+/**
+ * Cerdos (ciclo de manejo porcino). Hitos de MANEJO, no fenología. Las cifras
+ * técnicas (gestación 114 días para porcino) salen de animal-diagnostics.json
+ * (DR-ANIMAL-1, fuentes ICA/AGROSAVIA). Cualquier recomendación de dieta/sanidad
+ * concreta NO va aquí sin fuente: se marca [VALIDAR] en la UI.
+ */
+export const PIGS_STAGE_SEQUENCE = [
+  { stage: 'instalacion', label: 'Instalación (corral / cama profunda)' },
+  { stage: 'alimentacion', label: 'Alimentación y engorde' },
+  { stage: 'reproduccion', label: 'Reproducción (monta y gestación)' },
+  { stage: 'sanidad', label: 'Sanidad y bioseguridad' },
+  { stage: 'cierre', label: 'Cierre del ciclo' },
+];
+
 /** Secuencia de etapas (con etiqueta) apropiada para el tipo de proceso. */
-export const stageSequenceForProcessType = (processType) =>
-  processType === 'restoration' || processType === 'silvopasture'
-    ? RESTORATION_STAGE_SEQUENCE
-    : SOWING_STAGE_SEQUENCE;
+export const stageSequenceForProcessType = (processType) => {
+  if (processType === 'restoration' || processType === 'silvopasture') return RESTORATION_STAGE_SEQUENCE;
+  if (processType === 'paramo') return PARAMO_STAGE_SEQUENCE;
+  if (processType === 'pigs') return PIGS_STAGE_SEQUENCE;
+  return SOWING_STAGE_SEQUENCE;
+};
 
 /**
  * Valida un objeto FarmProcess.


### PR DESCRIPTION
## Qué

SEGUIMIENTO de procesos de finca, como **Mis plantas pero para procesos**: tarjetas en el home + vista de seguimiento por proceso. **Reforestación · Silvopastoreo · Páramo · Cerdos.**

> DRAFT a propósito: el operador revisa el screenshot del HOME antes de mergear.

## Cambios

1. **Quita** la sección "Pregúntale a Chagra" del `DashboardLive` (no la pidió el operador; revierte el re-add del 06-15).
2. **4 tarjetas de seguimiento** en el home (mismo estilo visual que Mis plantas/Insumos/Mis zonas, `FincaCards`), cada una con contador de procesos activos. Tocar una abre su vista de seguimiento.
3. **`SeguimientoProcesoScreen`** (vista por proceso): (a) iniciar/registrar (qué, cantidad, zona/lote, fecha, notas), (b) ver etapas con fechas, (c) confirmar avance de etapa + anotar observaciones (texto/voz) + fotos, (d) ver el avance (bitácora). Reusa el motor existente: `createFarmProcess`/`recordFarmEvent`/`confirmStage` + `CicloObservacion`/`CicloFotos`.
4. **`process_type` nuevos** en `types/farmProcess`: `paramo` (conservación de páramo) y `pigs` (ciclo de manejo porcino), con secuencias de etapas propias (no fenología de cultivo). Cerdos surfacea la **guarda crítica leucaena/mimosina** desde `animal-diagnostics.json` (DR-ANIMAL-1, ICA/AGROSAVIA/CIPAV). Reforestación/silvopastoreo usan los `process_type` existentes (`restoration`/`silvopasture`).
5. **`config/seguimientoProcesos.js`**: fuente única de labels + rutas (cards + screen + routing).
6. Ruta dinámica `seguimiento_<key>` en `App.jsx`.

## Honestidad: funcional vs stub / [VALIDAR]

- **Funcional end-to-end** (verificado en navegador): las 4 tarjetas en el home, abrir la vista, iniciar un proceso (escribe a IndexedDB vía el motor real), ver etapas con fechas, confirmar avance de etapa (append-only), bitácora de avance. Observaciones y fotos reusan los componentes ya cableados del ciclo.
- **`[VALIDAR]`**: los *nombres* de las etapas de páramo/cerdos son fases de manejo genéricas (delimitación/aislamiento/revegetación/monitoreo; instalación/alimentación/reproducción/sanidad/cierre). NO se inventaron recomendaciones veterinarias/técnicas concretas (dietas, dosis, calendarios) — la UI muestra una nota "[VALIDAR]" y solo se surfacea la guarda de toxicidad que SÍ tiene fuente.
- Sin sync remoto nuevo: igual que el resto del subsistema FarmProcess, persiste local y encola al sync existente.

## Tests

- vitest: `farmProcess` (paramo/pigs validación + secuencias), `seguimientoProcesos` (config), `SeguimientoCards` (render 4 + contador + nav), `SeguimientoProcesoScreen` (vacío → iniciar → createFarmProcess con process_type+etapa correctos; guarda solo en cerdos). **127 pasan** en las suites tocadas.
- eslint `--max-warnings=0` limpio en todos los archivos.

## Verificación Playwright (chromium nix-store, usuario throwaway bloqueado)

- HOME con las 4 tarjetas (Reforestación/Silvopastoreo/Páramo/Cerdos) — **criterio de éxito** — screenshot capturado.
- Vista de seguimiento (Reforestación: header + "Iniciar reforestación" + empty state) — screenshot.
- Formulario de inicio (qué/cantidad/zona/fecha/notas) — screenshot.
- Detalle con etapas + avance (silvopastoreo iniciado, etapa Establecimiento ACTUAL con fecha, [VALIDAR], bitácora) — screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)