### PR TITLE
fix(home): eliminar constante fabricada CO2_KG_PER_TREE_YEAR (anti-alucinacion)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,16 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
+// Vitest globals para test files
+const vitestGlobals = {
+  describe: 'readonly',
+  it: 'readonly',
+  expect: 'readonly',
+  beforeEach: 'readonly',
+  afterEach: 'readonly',
+  vi: 'readonly',
+}
+
 export default defineConfig([
   globalIgnores(['dist']),
   {
@@ -12,6 +22,21 @@ export default defineConfig([
     languageOptions: {
       globals: { ...globals.node },
       sourceType: 'module',
+    },
+  },
+  {
+    // Test files con vitest
+    files: ['**/*.test.{js,jsx}', '**/*.spec.{js,jsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...vitestGlobals,
+      },
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+      },
     },
   },
   {

--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -40,8 +40,6 @@ const HERO_ROTATION_MS = 9000;
 const HERO_PAUSE_AFTER_INTERACTION_MS = 5000;
 const MONITOR_DAYS_PER_PLANT = 90;
 const DRIP_SAVING_L_PER_DAY = 5;
-const CO2_KG_PER_TREE_YEAR = 22;
-const TREE_FRACTION = 0.3;
 
 // Fallback inicial: el catálogo seed tiene exactamente estos números.
 // Renderizar valores reales desde el primer paint evita el destello "0".
@@ -67,7 +65,6 @@ function buildHeroStats({ plantsCount, species, ragDocs, biopreparados, sourcesT
   const isPreLogin = mode === 'pre-login';
   const displayPlants = isPreLogin ? GLOBAL_FEDERATION_FALLBACK.plantasRegistradas : plantsCount;
   const aguaAhorradaL = Math.max(0, displayPlants) * DRIP_SAVING_L_PER_DAY * MONITOR_DAYS_PER_PLANT;
-  const co2KgAnio = Math.max(0, displayPlants) * TREE_FRACTION * CO2_KG_PER_TREE_YEAR;
   const plantsLabel = displayPlants === 1 ? 'planta' : 'plantas';
   const scopeNote = isPreLogin ? 'en la red Chagra' : 'en tu finca';
 
@@ -84,14 +81,14 @@ function buildHeroStats({ plantsCount, species, ragDocs, biopreparados, sourcesT
       navTarget: 'biodiversidad',
     },
     {
-      key: 'co2',
-      icon: Cloud,
-      headline: 'Chagra cuida el aire',
-      value: Math.round(co2KgAnio).toLocaleString('es-CO'),
-      unit: 'kg de CO₂ secuestrados al año',
+      key: 'biodiversidad',
+      icon: Leaf,
+      headline: 'Chagra registra biodiversidad',
+      value: `${species} + ${displayPlants.toLocaleString('es-CO')}`,
+      unit: 'especies + plantas registradas',
       tone: 'lime',
-      story: `Monitoreando árboles nativos andinos sembrados ${scopeNote} con Chagra.`,
-      caption: 'Factor IDEAM-MADS · 22 kg CO₂/año por árbol joven',
+      story: `Documentando diversidad biológica ${scopeNote} con fichas científicas y seguimiento.`,
+      caption: 'Datos medibles · Catálogo científico · Sin alucinaciones',
       navTarget: 'biodiversidad',
     },
     {

--- a/src/components/WelcomeStatsHero.test.jsx
+++ b/src/components/WelcomeStatsHero.test.jsx
@@ -1,0 +1,165 @@
+/**
+ * WelcomeStatsHero.test.jsx — cobertura anti-alucinación CO2.
+ *
+ * Task #7101: Eliminar constante fabricada CO2_KG_PER_TREE_YEAR = 22
+ * que producía una cifra exacta de captura de CO2 por árbol sin fuente
+ * verificable. En su lugar, mostrar métrica honesta (número de árboles/
+ * especies registradas) o, si se muestra carbono, usar rango con fuente
+ * clara marcada [VALIDAR].
+ *
+ * Casos cubiertos:
+ *   1. NO renderiza cifra de CO2 calculada por-árbol sin fuente
+ *   2. NO muestra caption "Factor IDEAM-MADS · 22 kg CO₂/año por árbol"
+ *   3. SÍ renderiza métrica honesta (árboles/plantas registradas)
+ *   4. Componente funciona en modo pre-login y post-login
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import WelcomeStatsHero from './WelcomeStatsHero';
+
+// Mock del store de activos
+const mockAssetStore = {
+  plants: { length: 0 },
+};
+
+vi.mock('../store/useAssetStore', () => ({
+  default: (selector) => selector(mockAssetStore),
+}));
+
+describe('WelcomeStatsHero — anti-alucinación CO2', () => {
+  beforeEach(() => {
+    // Resetear mocks entre tests
+    mockAssetStore.plants.length = 0;
+    // Limpiar localStorage
+    try {
+      globalThis.localStorage.clear();
+    } catch { /* ignore private mode */ }
+  });
+
+  it('NO renderiza cifra de CO2 calculada por-árbol sin fuente', async () => {
+    mockAssetStore.plants.length = 50;
+
+    render(
+      <WelcomeStatsHero
+        mode="post-login"
+        onNavigate={() => {}}
+      />
+    );
+
+    // Esperar a que se renderice el componente
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+
+    // Verificar que NO aparece texto de kg de CO2 secuestrados
+    const co2Text = screen.queryByText(/kg de CO₂ secuestrados al año/i);
+    expect(co2Text).not.toBeInTheDocument();
+
+    // Verificar que NO aparece caption fabricado
+    const fabricatedCaption = screen.queryByText(/Factor IDEAM-MADS · 22 kg CO₂\/año por árbol/i);
+    expect(fabricatedCaption).not.toBeInTheDocument();
+  });
+
+  it('NO muestra caption con constante fabricada de 22 kg CO₂/año', async () => {
+    mockAssetStore.plants.length = 100;
+
+    render(
+      <WelcomeStatsHero
+        mode="post-login"
+        onNavigate={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+
+    // El caption fabricado NO debe aparecer nunca
+    const fabricatedCaption = screen.queryByText(/22 kg CO₂\/año por árbol/i);
+    expect(fabricatedCaption).not.toBeInTheDocument();
+  });
+
+  it('SÍ renderiza métrica honesta (plantas/árboles registrados)', async () => {
+    mockAssetStore.plants.length = 75;
+
+    render(
+      <WelcomeStatsHero
+        mode="post-login"
+        onNavigate={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+
+    // El componente está colapsado por defecto cuando hay plantas,
+    // así que verificamos que el componente se renderiza correctamente
+    // sin mostrar CO2 fabricado
+    const section = screen.getByRole('region', { name: /Impacto de Chagra/i });
+    expect(section).toBeInTheDocument();
+
+    // Verificar que NO hay texto de CO2
+    const co2Text = screen.queryByText(/kg de CO₂/i);
+    expect(co2Text).not.toBeInTheDocument();
+  });
+
+  it('funciona en modo pre-login con fallback global', async () => {
+    render(
+      <WelcomeStatsHero
+        mode="pre-login"
+        onNavigate={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+
+    // En modo pre-login debe mostrar el fallback global
+    const globalPlants = screen.getByText('100');
+    expect(globalPlants).toBeInTheDocument();
+
+    // NO debe mostrar CO2 fabricado
+    const co2Text = screen.queryByText(/kg de CO₂ secuestrados al año/i);
+    expect(co2Text).not.toBeInTheDocument();
+  });
+
+  it('muestra stats completas sin romper el layout', async () => {
+    mockAssetStore.plants.length = 0; // Forzar expandido
+
+    render(
+      <WelcomeStatsHero
+        mode="post-login"
+        onNavigate={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+
+    // Verificar que la sección principal existe
+    const statsSection = screen.getByRole('region', { name: /Impacto de Chagra/i });
+    expect(statsSection).toBeInTheDocument();
+  });
+
+  it('muestra número de especies del catálogo (métrica honesta)', async () => {
+    mockAssetStore.plants.length = 0; // Forzar expandido
+
+    render(
+      <WelcomeStatsHero
+        mode="post-login"
+        onNavigate={() => {}}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Chagra · impacto/i)).toBeInTheDocument();
+    });
+
+    // Debe mostrar especies del catálogo (en carrusel o grid)
+    const speciesLabel = screen.queryByText(/especies/i);
+    expect(speciesLabel).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Elimina la constante fabricada `CO2_KG_PER_TREE_YEAR = 22` que producía una cifra exacta de captura de CO2 por árbol sin fuente verificable. Cumple el task #7101 de anti-alucinación.

## Cambios realizados

- **Elimina constantes fabricadas**: `CO2_KG_PER_TREE_YEAR` y `TREE_FRACTION`
- **Elimina cálculo engañoso**: `co2KgAnio = plants * TREE_FRACTION * CO2_KG_PER_TREE_YEAR`
- **Reemplaza métrica 'co2' por 'biodiversidad'**: Muestra "especies + plantas registradas" (dato medible y honesto)
- **Mantiene funcionalidad**: El componente funciona correctamente en ambos modos (pre-login/post-login)
- **Actualiza eslint.config.js**: Incluye globals de vitest para test files

## Motivación

La constante `CO2_KG_PER_TREE_YEAR = 22` estaba etiquetada como 'IDEAM-MADS' pero no tenía fuente verificable por-predio. Un número fijo por-arbol presentado como hecho es una alucinación: el carbono real de un predio solo se conoce midiendo en campo (DAP/alometría) con factores específicos por especie, edad y ecosistema.

## Enfoque honesto

En lugar de mostrar un número exacto de CO2 sin sustento, ahora mostramos:
- **Dato medible**: número de especies del catálogo + plantas registradas
- **Sin alucinaciones**: todo lo que mostramos es verificable y medible
- **Catálogo científico**: respaldado por fuentes Tier A (POWO, GBIF, IAvH, AGROSAVIA)

Si en el futuro se necesita mostrar carbono, debe usarse el rango con fuente de `src/data/carbono-captura.json` (bosque andino 100-200 tC/ha, Phillips/RAINFOR) marcado claramente como "estimación preliminar [VALIDAR], requiere medición de campo".

## Test plan

- `WelcomeStatsHero.test.jsx` verifica que NO se renderiza cifra de CO2 calculada por-árbol sin fuente
- Verifica que NO aparece el caption fabricado "Factor IDEAM-MADS · 22 kg CO₂/año por árbol"
- Verifica que el componente funciona correctamente en modo pre-login y post-login
- Todos los tests pasan: 6/6 tests green
- ESLint clean: `npx eslint . --max-warnings=0`

## Riesgos conocidos

Ninguno. El cambio solo elimina una métrica fabricada y la reemplaza por un dato honesto que ya está disponible en el sistema.

## MCP tools usados

No se requirió consulta MCP para este task. El fix se basa en eliminar código fabricado y usar datos existentes del sistema.