### PR TITLE
fix(home): home reordenable (orden en perfil), scroll arriba en entrada nueva, foto desde galeria

### DIFF
--- a/src/components/ProfileScreen.jsx
+++ b/src/components/ProfileScreen.jsx
@@ -297,11 +297,14 @@ export default function ProfileScreen({ onBack, onHome }) {
                 >
                   <Camera size={16} aria-hidden="true" />
                 </button>
+                {/* SIN `capture` (operador 2026-06-15): el atributo `capture`
+                    forzaba la cámara y ocultaba la galería en móvil. Quitándolo,
+                    el SO ofrece AMBOS — cámara y galería/archivos — que es lo que
+                    el operador espera para elegir una foto ya existente. */}
                 <input
                   ref={photoInputRef}
                   type="file"
                   accept="image/*"
-                  capture="user"
                   onChange={handlePhotoSelected}
                   className="hidden"
                   aria-hidden="true"

--- a/src/components/__tests__/ProfileScreen.photo.test.jsx
+++ b/src/components/__tests__/ProfileScreen.photo.test.jsx
@@ -43,6 +43,17 @@ describe('ProfileScreen — foto de perfil', () => {
     expect(screen.queryByTestId('profile-photo-img')).toBeNull();
   });
 
+  // BUG 3 (operador 2026-06-15): el input NO debe forzar la cámara. Sin el
+  // atributo `capture`, el SO ofrece cámara + galería/archivos. `accept` sigue
+  // restringido a imágenes.
+  test('el input de foto NO tiene `capture` (ofrece cámara + galería)', () => {
+    render(<ProfileScreen onBack={() => {}} onHome={() => {}} />);
+    const input = screen.getByTestId('profile-photo-input');
+    expect(input).not.toHaveAttribute('capture');
+    expect(input).toHaveAttribute('accept', 'image/*');
+    expect(input).toHaveAttribute('type', 'file');
+  });
+
   test('al elegir un archivo de imagen llama al servicio y renderiza la foto', async () => {
     const dataUrl = 'data:image/jpeg;base64,ZZZ';
     setOperatorPhotoFromFile.mockResolvedValue(dataUrl);

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useScrollRestoration } from '../../hooks/useScrollRestoration';
 import {
     DndContext,
@@ -24,6 +24,9 @@ import {
     getProfile,
     getModuleVisibility,
     hasManualModuleVisibility,
+    getModuleOrder,
+    setModuleOrder,
+    HOME_MODULE_DEFAULT_ORDER,
 } from '../../services/userProfileService';
 import {
     selectHomeModuleVisibilityMap,
@@ -56,32 +59,16 @@ import {
  *   - Secciones (draggables): clima, plantas, zonas, insumos, bitácora,
  *     hoy, plagas, biodiversidad, informes.
  *
- * Persiste orden en localStorage `chagra:dashboard-order:v1`.
+ * Persiste el orden en el perfil del usuario (userProfileService:
+ * getModuleOrder/setModuleOrder, campo `modulos_orden`). Migrado desde la
+ * clave localStorage legada `chagra:dashboard-order:v3` (2026-06-15) para
+ * unificar la persistencia del home junto a la visibilidad de módulos.
  */
 
-// v2 (2026-05-30): 'analisis' (AnalisisProactivoIA) pasó de fijo-abajo a
-// sección draggable, por defecto justo debajo de 'clima'. Bump de versión
-// para que usuarios con orden v1 reciban el nuevo default en vez de que se
-// les agregue al final.
-// v3 (2026-06-11): 'hoyfinca' (HoyEnFincaStrip) — resumen proactivo del día
-// (clima honesto + alertas + tareas + próximo evento de agenda) como PRIMERA
-// sección bajo el hero. Toque → vista completa 'hoy_finca'. Bump para que
-// usuarios con orden v2 lo reciban arriba y no apendizado al final.
-const STORAGE_KEY = 'chagra:dashboard-order:v3';
-
-const DEFAULT_ORDER = [
-    'hoyfinca',
-    'clima',
-    'analisis',
-    'plantas',
-    'hoy',
-    'zonas',
-    'insumos',
-    'plagas',
-    'bitacora',
-    'biodiversidad',
-    'informes',
-];
+// Orden por defecto + fuente del orden persistido: viven en userProfileService
+// (HOME_MODULE_DEFAULT_ORDER / getModuleOrder / setModuleOrder). DEFAULT_ORDER
+// se mantiene acá como alias para el fail-open de la visibilidad por perfil.
+const DEFAULT_ORDER = HOME_MODULE_DEFAULT_ORDER;
 
 const SECTION_COMPONENTS = {
     hoyfinca: { Component: HoyEnFincaStrip, full: true },
@@ -96,25 +83,6 @@ const SECTION_COMPONENTS = {
     biodiversidad: { Component: BiodiversidadCard },
     informes: { Component: InformesCard },
 };
-
-function readOrder() {
-    try {
-        const raw = localStorage.getItem(STORAGE_KEY);
-        if (!raw) return DEFAULT_ORDER;
-        const parsed = JSON.parse(raw);
-        if (!Array.isArray(parsed)) return DEFAULT_ORDER;
-        // Filter to known sections + append any missing (new sections added post-deploy)
-        const valid = parsed.filter((id) => SECTION_COMPONENTS[id]);
-        const missing = DEFAULT_ORDER.filter((id) => !valid.includes(id));
-        return [...valid, ...missing];
-    } catch {
-        return DEFAULT_ORDER;
-    }
-}
-
-function writeOrder(order) {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(order)); } catch { /* ignore */ }
-}
 
 function SortableSection({ id, onNavigate, sensors }) {
     const {
@@ -169,7 +137,7 @@ function SortableSection({ id, onNavigate, sensors }) {
 }
 
 export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
-    const [order, setOrder] = useState(readOrder);
+    const [order, setOrder] = useState(getModuleOrder);
     const [moduleVisibility, setModuleVisibility] = useState(() => {
         // GATING DEL HOME POR PERFIL (2026-06-15): el perfil del onboarding
         // (rol/vocacion/finca_tipo/animales/objetivo) fija QUÉ módulos se ven
@@ -258,12 +226,24 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
         }
     }, []);
 
-    // Persist scroll position al volver de detalle (mismo bug que App.jsx
-    // resolvió para Dashboard clásico). Quick-win UX 2026-05-28 demo Diana.
-    useScrollRestoration('dashboard-live', '[data-scroll-key="dashboard-live"]');
+    // Restaurar scroll SOLO al volver de un detalle/sub-ruta (operador
+    // 2026-06-15): en una entrada NUEVA (mount inicial / post-login) el home
+    // debe quedar ARRIBA (scroll 0), no en la posición baja que dejó la sesión
+    // anterior. `restoreOnReturnOnly` distingue ambos casos: la primera vez que
+    // se monta en este page-load NO restaura (entrada fresca → top); al volver
+    // de un detalle (mount posterior) SÍ restaura. Conserva el fix #103 (no
+    // perder la posición al ir a un detalle y regresar).
+    useScrollRestoration('dashboard-live', '[data-scroll-key="dashboard-live"]', {
+        restoreOnReturnOnly: true,
+    });
 
+    // Persistir el orden en el perfil SOLO tras una reorganización real del
+    // usuario (no en el mount inicial): evita reescribir el perfil en cada
+    // entrada al home. `orderDirtyRef` se marca en handleDragEnd.
+    const orderDirtyRef = useRef(false);
     useEffect(() => {
-        writeOrder(order);
+        if (!orderDirtyRef.current) return;
+        setModuleOrder(order);
     }, [order]);
 
     const sensors = useSensors(
@@ -279,6 +259,8 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
             const oldIndex = items.indexOf(active.id);
             const newIndex = items.indexOf(over.id);
             if (oldIndex === -1 || newIndex === -1) return items;
+            // Reorganización real del usuario → habilitar la persistencia.
+            orderDirtyRef.current = true;
             return arrayMove(items, oldIndex, newIndex);
         });
     }, []);
@@ -415,8 +397,8 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                     análisis de IA quede justo debajo del clima y que también
                     pueda moverse". Pasó de render fijo acá-abajo a sección
                     DRAGGABLE en SECTION_COMPONENTS, default order = bajo 'clima'
-                    (ver DEFAULT_ORDER + STORAGE_KEY v2). Recibe `sensors` vía
-                    SortableSection. */}
+                    (ver HOME_MODULE_DEFAULT_ORDER en userProfileService). Recibe
+                    `sensors` vía SortableSection. */}
             </div>
         </div>
     );

--- a/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
@@ -42,6 +42,19 @@ vi.mock('../FincaCards', () => ({
 vi.mock('../../../services/userProfileService', () => ({
   getProfile: vi.fn(() => ({})),
   isModuleVisible: vi.fn(() => true),
+  getModuleVisibility: vi.fn(() => ({})),
+  hasManualModuleVisibility: vi.fn(() => false),
+  // Orden de módulos del home (reorder por drag, 2026-06-15). Para este test el
+  // orden por defecto basta; setModuleOrder es no-op.
+  HOME_MODULE_DEFAULT_ORDER: [
+    'hoyfinca', 'clima', 'analisis', 'plantas', 'hoy', 'zonas',
+    'insumos', 'plagas', 'bitacora', 'biodiversidad', 'informes',
+  ],
+  getModuleOrder: vi.fn(() => [
+    'hoyfinca', 'clima', 'analisis', 'plantas', 'hoy', 'zonas',
+    'insumos', 'plagas', 'bitacora', 'biodiversidad', 'informes',
+  ]),
+  setModuleOrder: vi.fn(),
 }));
 
 // Store de assets: plantsCount > 0 para que NO se monte el OnboardingHero de

--- a/src/components/dashboard/__tests__/DashboardLive.homeGating.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.homeGating.test.jsx
@@ -18,9 +18,13 @@ import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Gate glaciar: irrelevante a este test → sin acceso.
+// Gate glaciar: irrelevante a este test → sin acceso. esOperadorActual: estos
+// casos prueban el gating POR PERFIL (urbano/ganadero/restaurador), NO el
+// bypass del operador (#1581) — sin este mock, DashboardLive llamaba a un
+// esOperadorActual indefinido y el catch fail-open mostraba TODAS las tarjetas.
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
 }));
 
 // Hijos pesados → stubs livianos. NO mockeamos FincaCards (queremos las

--- a/src/hooks/__tests__/useScrollRestoration.test.jsx
+++ b/src/hooks/__tests__/useScrollRestoration.test.jsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useScrollRestoration } from '../useScrollRestoration';
+
+/**
+ * useScrollRestoration — cubre el fix de BUG 2 (operador 2026-06-15):
+ * `restoreOnReturnOnly` debe dejar el scroll ARRIBA (0) en una entrada nueva
+ * (primer mount del page-load) y SOLO restaurar la posición guardada al VOLVER
+ * de un detalle (mount posterior, tras haber scrolleado). El comportamiento
+ * clásico (sin la opción) debe seguir restaurando en cada mount (fix #103).
+ *
+ * Nota: el hook usa requestAnimationFrame para aplicar el scroll tras el primer
+ * render; en estos tests lo hacemos síncrono con un mock que ejecuta el callback
+ * de inmediato. El Set `armedViews` es module-level (persiste entre montajes del
+ * mismo page-load, como en producción); para no contaminar tests usamos una
+ * viewKey ÚNICA por caso.
+ */
+
+function makeScroller(selector, initialTop = 0) {
+  const el = document.createElement('div');
+  // El selector que pasamos al hook es un atributo data-* para que
+  // document.querySelector lo encuentre.
+  el.setAttribute('data-scroll-test', selector);
+  el.scrollTop = initialTop;
+  document.body.appendChild(el);
+  return el;
+}
+
+let rafSpy;
+
+beforeEach(() => {
+  // rAF síncrono: ejecuta el callback de inmediato para poder aseverar scrollTop.
+  rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0);
+    return 0;
+  });
+  sessionStorage.clear();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  rafSpy.mockRestore();
+  document.body.innerHTML = '';
+});
+
+describe('useScrollRestoration — restoreOnReturnOnly (BUG 2)', () => {
+  it('entrada nueva (primer mount): NO restaura, deja el scroll en 0', () => {
+    const sel = 'fresh-entry';
+    const el = makeScroller(sel, 999);
+    // Hay una posición guardada de una "sesión anterior", pero como es entrada
+    // fresca (la key no está armada en este page-load) debe ignorarse → top.
+    sessionStorage.setItem(`chagra:scroll:${sel}`, '500');
+
+    renderHook(() =>
+      useScrollRestoration(sel, `[data-scroll-test="${sel}"]`, { restoreOnReturnOnly: true }),
+    );
+
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it('regreso de un detalle: SÍ restaura la posición guardada tras scrollear', () => {
+    const sel = 'return-from-detail';
+    const el = makeScroller(sel, 0);
+
+    // 1er mount (entrada fresca) → queda en 0.
+    const first = renderHook(() =>
+      useScrollRestoration(sel, `[data-scroll-test="${sel}"]`, { restoreOnReturnOnly: true }),
+    );
+    expect(el.scrollTop).toBe(0);
+
+    // El usuario scrollea → onScroll arma la vista y agenda el guardado
+    // (throttle 200ms). Al desmontar (ir a un detalle) con un timeout pendiente,
+    // el cleanup guarda el estado FINAL de inmediato (sin esperar el throttle).
+    el.scrollTop = 420;
+    el.dispatchEvent(new Event('scroll'));
+    first.unmount();
+    expect(sessionStorage.getItem(`chagra:scroll:${sel}`)).toBe('420');
+
+    // Se navega a un detalle y se vuelve → REMONTA. Reiniciamos el scroll del
+    // contenedor (nuevo nodo) y montamos de nuevo: ahora la vista YA está armada
+    // (mismo page-load) → debe restaurar 420.
+    const el2 = makeScroller(sel, 0);
+    // Quitar el primer nodo para que querySelector encuentre el nuevo.
+    el.remove();
+    renderHook(() =>
+      useScrollRestoration(sel, `[data-scroll-test="${sel}"]`, { restoreOnReturnOnly: true }),
+    );
+    expect(el2.scrollTop).toBe(420);
+  });
+});
+
+describe('useScrollRestoration — comportamiento clásico (#103, sin la opción)', () => {
+  it('restaura la posición guardada ya en el primer mount', () => {
+    const sel = 'classic-restore';
+    const el = makeScroller(sel, 0);
+    sessionStorage.setItem(`chagra:scroll:${sel}`, '300');
+
+    renderHook(() => useScrollRestoration(sel, `[data-scroll-test="${sel}"]`));
+
+    expect(el.scrollTop).toBe(300);
+  });
+
+  it('no restaura nada si no hay posición guardada (queda en 0)', () => {
+    const sel = 'classic-empty';
+    const el = makeScroller(sel, 0);
+
+    renderHook(() => useScrollRestoration(sel, `[data-scroll-test="${sel}"]`));
+
+    expect(el.scrollTop).toBe(0);
+  });
+
+  it('selector inexistente: no rompe (no-op)', () => {
+    expect(() =>
+      renderHook(() => useScrollRestoration('nope', '[data-scroll-test="does-not-exist"]')),
+    ).not.toThrow();
+  });
+});

--- a/src/hooks/useScrollRestoration.js
+++ b/src/hooks/useScrollRestoration.js
@@ -1,6 +1,20 @@
 import { useEffect, useRef } from 'react';
 
 /**
+ * Set de viewKeys "armadas" en ESTE page-load: una viewKey se arma la primera
+ * vez que el usuario hace scroll en ella (onScroll → guarda posición). Vive a
+ * nivel de módulo (no de componente) para persistir entre montajes/desmontajes
+ * de la misma sesión de página, pero se reinicia en un page-load fresco
+ * (login / abrir la app / refresh) porque el módulo se vuelve a evaluar.
+ *
+ * Sirve para `restoreOnReturnOnly`: distinguir una ENTRADA NUEVA (primer mount
+ * del runtime → la key no está armada) de un REGRESO desde un detalle (mount
+ * posterior → la key sí está armada porque el usuario ya scrolleó antes de
+ * irse al detalle).
+ */
+const armedViews = new Set();
+
+/**
  * useScrollRestoration — preserva scroll position al navegar entre vistas.
  *
  * usuaria piloto reportó (#103, field test 2026-05-01):
@@ -26,8 +40,18 @@ import { useEffect, useRef } from 'react';
  * Throttle: actualiza sessionStorage cada 200ms durante scroll para
  * minimizar writes (sessionStorage es sync). Restore es instantáneo en
  * mount.
+ *
+ * @param {string} viewKey - identificador único de la vista.
+ * @param {string} [selector='main'] - selector del contenedor scrolleable.
+ * @param {object} [options]
+ * @param {boolean} [options.restoreOnReturnOnly=false] - si es true, NO
+ *   restaura en la entrada nueva (primer mount del page-load): hace scroll a 0
+ *   (top). Solo restaura al VOLVER de un detalle/sub-ruta dentro de la misma
+ *   sesión de página. Operador 2026-06-15: en el home, entrar fresco/post-login
+ *   debe dejar al usuario ARRIBA, no en la posición baja de la sesión anterior.
  */
-export function useScrollRestoration(viewKey, selector = 'main') {
+export function useScrollRestoration(viewKey, selector = 'main', options = {}) {
+  const { restoreOnReturnOnly = false } = options;
   const restoredRef = useRef(false);
 
   useEffect(() => {
@@ -40,14 +64,28 @@ export function useScrollRestoration(viewKey, selector = 'main') {
 
     // Restore en mount (single shot por mount)
     if (!restoredRef.current) {
-      const saved = sessionStorage.getItem(key);
-      if (saved !== null) {
-        const top = parseInt(saved, 10);
-        if (!Number.isNaN(top) && top > 0) {
-          // requestAnimationFrame para esperar render del contenido inicial
-          requestAnimationFrame(() => {
-            mainEl.scrollTop = top;
-          });
+      // ENTRADA NUEVA vs REGRESO (restoreOnReturnOnly): si la vista NO está
+      // armada en este page-load, es una entrada fresca (login / abrir app /
+      // refresh) → NO restaurar, dejar el scroll arriba (top). Si ya está
+      // armada, el usuario scrolleó antes de ir a un detalle y ahora vuelve →
+      // restaurar su posición (fix #103 intacto).
+      const isFreshEntry = restoreOnReturnOnly && !armedViews.has(key);
+      if (isFreshEntry) {
+        // Garantizar top en la entrada fresca incluso si un scroll previo del
+        // navegador o un anchor dejó el contenedor desplazado.
+        requestAnimationFrame(() => {
+          mainEl.scrollTop = 0;
+        });
+      } else {
+        const saved = sessionStorage.getItem(key);
+        if (saved !== null) {
+          const top = parseInt(saved, 10);
+          if (!Number.isNaN(top) && top > 0) {
+            // requestAnimationFrame para esperar render del contenido inicial
+            requestAnimationFrame(() => {
+              mainEl.scrollTop = top;
+            });
+          }
         }
       }
       restoredRef.current = true;
@@ -56,6 +94,9 @@ export function useScrollRestoration(viewKey, selector = 'main') {
     // Save on scroll, throttled 200ms
     let timeoutId = null;
     const onScroll = () => {
+      // El usuario scrolleó esta vista en este page-load → queda "armada": un
+      // futuro remount (volver de un detalle) contará como REGRESO y restaurará.
+      armedViews.add(key);
       if (timeoutId) return;
       timeoutId = setTimeout(() => {
         sessionStorage.setItem(key, String(mainEl.scrollTop));
@@ -72,5 +113,5 @@ export function useScrollRestoration(viewKey, selector = 'main') {
         sessionStorage.setItem(key, String(mainEl.scrollTop));
       }
     };
-  }, [viewKey, selector]);
+  }, [viewKey, selector, restoreOnReturnOnly]);
 }

--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -19,6 +19,10 @@ import {
   getModuleVisibility,
   setModuleVisibility,
   isModuleVisible,
+  HOME_MODULE_DEFAULT_ORDER,
+  getModuleOrder,
+  setModuleOrder,
+  hasManualModuleOrder,
   __PROFILE_KEYS__,
 } from '../userProfileService.js';
 
@@ -492,6 +496,104 @@ describe('visibilidad de módulos del Home (#7003)', () => {
       expect(isModuleVisible('clima')).toBe(false);
       setModuleVisibility({ clima: true });
       expect(isModuleVisible('clima')).toBe(true);
+    });
+  });
+});
+
+describe('orden de módulos del Home (reorder por drag, 2026-06-15)', () => {
+  const LEGACY_KEY = 'chagra:dashboard-order:v3';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('HOME_MODULE_DEFAULT_ORDER', () => {
+    it('contiene exactamente los ids de HOME_MODULES (cada uno una vez)', () => {
+      const known = HOME_MODULES.map((m) => m.id).sort();
+      expect([...HOME_MODULE_DEFAULT_ORDER].sort()).toEqual(known);
+      expect(new Set(HOME_MODULE_DEFAULT_ORDER).size).toBe(HOME_MODULE_DEFAULT_ORDER.length);
+    });
+
+    it('el agente (AgentHero) NO está en el orden (vive fijo fuera del grid)', () => {
+      expect(HOME_MODULE_DEFAULT_ORDER).not.toContain('agente');
+      expect(HOME_MODULE_DEFAULT_ORDER).not.toContain('agent');
+      expect(HOME_MODULE_DEFAULT_ORDER).not.toContain('hero');
+    });
+  });
+
+  describe('getModuleOrder', () => {
+    it('sin perfil devuelve el orden por defecto', () => {
+      expect(getModuleOrder()).toEqual([...HOME_MODULE_DEFAULT_ORDER]);
+    });
+
+    it('lee el orden manual guardado en el perfil', () => {
+      const custom = ['plantas', 'clima', 'hoyfinca'];
+      saveProfile({ modulos_orden: custom });
+      const order = getModuleOrder();
+      // Respeta el orden elegido al frente...
+      expect(order.slice(0, 3)).toEqual(custom);
+      // ...y completa los faltantes al final (sin perder ninguno).
+      expect([...order].sort()).toEqual(HOME_MODULES.map((m) => m.id).sort());
+    });
+
+    it('descarta ids desconocidos y duplicados del orden guardado', () => {
+      saveProfile({ modulos_orden: ['clima', 'inventado', 'clima', 'plantas'] });
+      const order = getModuleOrder();
+      expect(order.slice(0, 2)).toEqual(['clima', 'plantas']);
+      expect(order).not.toContain('inventado');
+      expect(new Set(order).size).toBe(order.length);
+      expect([...order].sort()).toEqual(HOME_MODULES.map((m) => m.id).sort());
+    });
+  });
+
+  describe('migración del orden legado de localStorage → perfil', () => {
+    it('migra chagra:dashboard-order:v3 al perfil y limpia la clave legada', () => {
+      const legacy = ['informes', 'clima', 'plantas'];
+      localStorage.setItem(LEGACY_KEY, JSON.stringify(legacy));
+      // Sin modulos_orden en el perfil todavía.
+      expect(hasManualModuleOrder()).toBe(false);
+
+      const order = getModuleOrder();
+      // Orden migrado respeta el legado al frente.
+      expect(order.slice(0, 3)).toEqual(legacy);
+      // Persistido en el perfil.
+      expect(getProfile().modulos_orden).toBeDefined();
+      expect(hasManualModuleOrder()).toBe(true);
+      // Clave legada eliminada tras migrar.
+      expect(localStorage.getItem(LEGACY_KEY)).toBeNull();
+    });
+
+    it('el perfil tiene prioridad sobre la clave legada', () => {
+      localStorage.setItem(LEGACY_KEY, JSON.stringify(['informes', 'clima']));
+      saveProfile({ modulos_orden: ['plantas', 'zonas'] });
+      const order = getModuleOrder();
+      // Gana el perfil, no el legado.
+      expect(order.slice(0, 2)).toEqual(['plantas', 'zonas']);
+      // No se toca la clave legada cuando el perfil ya manda.
+      expect(localStorage.getItem(LEGACY_KEY)).not.toBeNull();
+    });
+  });
+
+  describe('setModuleOrder', () => {
+    it('persiste el orden normalizado en el perfil', () => {
+      setModuleOrder(['plantas', 'clima']);
+      const saved = getProfile().modulos_orden;
+      expect(saved.slice(0, 2)).toEqual(['plantas', 'clima']);
+      // Normalizado: todos los módulos presentes una vez.
+      expect([...saved].sort()).toEqual(HOME_MODULES.map((m) => m.id).sort());
+    });
+
+    it('ignora argumentos inválidos sin corromper el perfil', () => {
+      saveProfile({ modulos_orden: ['clima', 'plantas'] });
+      setModuleOrder(null);
+      const order = getModuleOrder();
+      expect(order.slice(0, 2)).toEqual(['clima', 'plantas']);
+    });
+
+    it('round-trip: lo que se guarda con setModuleOrder se lee con getModuleOrder', () => {
+      const desired = ['biodiversidad', 'plagas', 'hoy', 'clima'];
+      setModuleOrder(desired);
+      expect(getModuleOrder().slice(0, 4)).toEqual(desired);
     });
   });
 });

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -853,6 +853,145 @@ export function isModuleVisible(moduleId) {
   return visibility[moduleId] !== false;
 }
 
+/**
+ * Orden de los módulos del Home (reordenable por drag, 2026-06-15).
+ *
+ * El usuario puede MOVER a su antojo las tarjetas de módulo del home
+ * (DashboardLive), excepto la portada del agente (AgentHero), que queda fija
+ * arriba. El orden elegido se persiste en el perfil bajo `modulos_orden`
+ * (junto a `modulos_visibles`) — client-side, soberanía ADR-007.
+ *
+ * El orden por DEFECTO replica el layout histórico del home. El AgentHero NO
+ * aparece en esta lista a propósito: vive fijo fuera del grid draggable.
+ *
+ * v3 (2026-06-11): 'hoyfinca' (HoyEnFincaStrip) como primera sección.
+ */
+export const HOME_MODULE_DEFAULT_ORDER = Object.freeze([
+  'hoyfinca',
+  'clima',
+  'analisis',
+  'plantas',
+  'hoy',
+  'zonas',
+  'insumos',
+  'plagas',
+  'bitacora',
+  'biodiversidad',
+  'informes',
+]);
+
+// Clave localStorage LEGADO donde DashboardLive guardaba el orden antes de
+// migrarlo al perfil (2026-06-15). La conservamos solo para MIGRAR el orden de
+// usuarios existentes a `modulos_orden` la primera vez; luego el perfil manda.
+const LEGACY_MODULE_ORDER_KEY = 'chagra:dashboard-order:v3';
+
+/** IDs de módulo conocidos (las claves de orden válidas). */
+const KNOWN_MODULE_IDS = new Set(HOME_MODULES.map((m) => m.id));
+
+/**
+ * Normaliza una lista de orden: descarta ids desconocidos y duplicados, y
+ * agrega al final los módulos faltantes (nuevos módulos post-deploy) en el
+ * orden por defecto. Garantiza que SIEMPRE se devuelven todos los módulos
+ * conocidos exactamente una vez.
+ *
+ * @param {string[]} raw
+ * @returns {string[]}
+ */
+function normalizeModuleOrder(raw) {
+  const seen = new Set();
+  const valid = [];
+  if (Array.isArray(raw)) {
+    for (const id of raw) {
+      if (KNOWN_MODULE_IDS.has(id) && !seen.has(id)) {
+        seen.add(id);
+        valid.push(id);
+      }
+    }
+  }
+  for (const id of HOME_MODULE_DEFAULT_ORDER) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      valid.push(id);
+    }
+  }
+  return valid;
+}
+
+/**
+ * ¿El usuario guardó un orden MANUAL de módulos en el perfil?
+ *
+ * Devuelve true solo si existe el array `modulos_orden` en el perfil. Sirve
+ * para decidir si hay que migrar el orden legado de localStorage.
+ *
+ * @returns {boolean}
+ */
+export function hasManualModuleOrder() {
+  const profile = getProfile();
+  return !!(
+    profile &&
+    typeof profile === 'object' &&
+    Array.isArray(profile.modulos_orden)
+  );
+}
+
+/**
+ * Lee el orden de módulos del Home.
+ *
+ * Precedencia:
+ *   1. `modulos_orden` del perfil (elección manual del usuario).
+ *   2. Orden LEGADO en localStorage (`chagra:dashboard-order:v3`) — se MIGRA
+ *      al perfil en el primer acceso para no perder la preferencia previa.
+ *   3. Orden por defecto.
+ *
+ * Siempre devuelve la lista completa de módulos conocidos (normalizada).
+ *
+ * @returns {string[]}
+ */
+export function getModuleOrder() {
+  const profile = getProfile();
+  if (profile && typeof profile === 'object' && Array.isArray(profile.modulos_orden)) {
+    return normalizeModuleOrder(profile.modulos_orden);
+  }
+
+  // Migración del orden legado de localStorage → perfil (una sola vez).
+  if (hasStorage()) {
+    try {
+      const raw = window.localStorage.getItem(LEGACY_MODULE_ORDER_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          const normalized = normalizeModuleOrder(parsed);
+          // Persistir en el perfil y limpiar la clave legada.
+          saveProfile({ modulos_orden: normalized });
+          try { window.localStorage.removeItem(LEGACY_MODULE_ORDER_KEY); } catch (_) { /* noop */ }
+          return normalized;
+        }
+      }
+    } catch (e) {
+      console.warn('[userProfile] No se pudo migrar el orden de módulos legado:', e);
+    }
+  }
+
+  return [...HOME_MODULE_DEFAULT_ORDER];
+}
+
+/**
+ * Persiste el orden de módulos del Home en el perfil.
+ *
+ * Normaliza antes de guardar (descarta ids desconocidos, completa faltantes)
+ * para que el perfil nunca quede con un orden corrupto.
+ *
+ * @param {string[]} order - lista de ids de módulo en el orden deseado
+ * @returns {Object} perfil resultante
+ */
+export function setModuleOrder(order) {
+  if (!Array.isArray(order)) {
+    console.warn('[userProfile] setModuleOrder: argumento inválido', order);
+    return getProfile();
+  }
+  return saveProfile({ modulos_orden: normalizeModuleOrder(order) });
+}
+
 export const __PROFILE_KEYS__ = {
   PROFILE_KEY,
   PROFILE_DONE_KEY,


### PR DESCRIPTION
## Resumen

Tres fixes de UI reportados EN VIVO por el operador en el home/perfil. Sin romper el operador-ve-todo (#1581) ni el gating por perfil. PR en **draft**.

> Nota: si hay conflicto con la rama paralela de 'switch de demo' (toca `DashboardLive`/`ProfileScreen`), lo resuelve el operador al mergear.

## BUG 1 — Home reordenable (drag) con AgentHero FIJO + orden en `userProfileService`

El DnD del home (AgentHero fijo arriba + grid de tarjetas reordenable con `@dnd-kit` — ya presente en `package.json`, sin deps nuevas) ya existía pero persistía el orden en un `localStorage` local de `DashboardLive`. Ahora:

- **`userProfileService`**: nuevos `HOME_MODULE_DEFAULT_ORDER`, `getModuleOrder()`, `setModuleOrder()`, `hasManualModuleOrder()` — persisten el orden en el perfil bajo `modulos_orden` (junto a `getModuleVisibility`/`HOME_MODULES`). Normaliza (descarta ids desconocidos/duplicados, completa faltantes) y **migra** el orden legado de `chagra:dashboard-order:v3` al perfil la primera vez.
- **`DashboardLive`**: lee/escribe el orden vía el servicio en vez del `localStorage` local. Solo persiste tras un reorden real del usuario (no en el mount). Respeta el gating (solo reordena lo visible). Desktop = `PointerSensor` (mouse); móvil = `TouchSensor` long-press (delay 200ms). AgentHero queda fuera del grid (fijo arriba).

## BUG 2 — Scroll al top en entrada nueva

`DashboardLive` usaba `useScrollRestoration('dashboard-live', ...)` que restauraba una posición baja **incluso al entrar fresco** (login / abrir la app).

- **`useScrollRestoration`**: nueva opción `restoreOnReturnOnly`. En la **entrada nueva** (primer mount del page-load / post-login) deja el scroll en **0 (top)**; **solo** restaura la posición al **volver de un detalle/sub-ruta** (fix #103 intacto). El distintivo es un `Set` a nivel de módulo que arma la vista cuando el usuario scrollea: un page-load fresco reinicia el módulo → entrada nueva; un remount tras navegar a un detalle → regreso.
- `DashboardLive` activa `{ restoreOnReturnOnly: true }`. El dashboard clásico (`App.jsx`) no cambia.

## BUG 3 — Foto de perfil desde galería

`ProfileScreen` tenía `capture="user"` en el `<input type=file accept="image/*">`, forzando la cámara frontal.

- Se **quita** `capture` → el SO ofrece **cámara + galería**. El flujo subir+guardar+sync (`operatorPhotoService`) no cambia.

## Tests (vitest)

- `userProfileService.test.js`: orden por defecto, lectura/escritura, normalización, **migración del orden legado**, round-trip, AgentHero ausente del orden.
- `useScrollRestoration.test.jsx` (nuevo): entrada nueva → top; regreso de detalle → restaura; comportamiento clásico sin la opción.
- `ProfileScreen.photo.test.jsx`: el input NO tiene `capture` (acepta galería); el flujo de foto sigue verde.
- `DashboardLive.glaciarBanner.test.jsx`: mock de `userProfileService` actualizado con los nuevos exports.
- `DashboardLive.homeGating.test.jsx`: **arreglado** (faltaba mockear `esOperadorActual` → el catch fail-open mostraba todas las tarjetas; ahora los 5 casos de gating por perfil pasan).

`eslint --max-warnings=0` limpio. Suite afectada en verde (las 14 fallas restantes del repo son pre-existentes en `main`, no relacionadas).

## Verificación Playwright (chromium nix-store, OAuth mock vía `context.route`, build local)

- Home reordenable con scroll arriba → `/tmp/home-reorder.png` (hero "Soy Chagra" arriba, `scrollTop=0`) + `/tmp/home-reorder-grid.png` (11 tarjetas con handle ⋮⋮ + hint "reorganizar a tu gusto").
- Input de foto sin `capture` → confirmado en DOM: `hasCapture=false`, `accept=image/*`. `/tmp/profile-photo-input.png`.
- 0 errores de página.

## Español Colombia (sin voseo), repo público (sin secretos/hosts internos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)