### PR TITLE
test(services): cobertura unitaria para 19 servicios sin tests

### DIFF
--- a/src/services/__tests__/agentPromptBase.test.js
+++ b/src/services/__tests__/agentPromptBase.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  analyzeQuery,
+  buildQueryAnalysisBlock,
+  buildCorpusContext,
+  buildCorpusVariants,
+  formatToolEvidence,
+  TOOL_EVIDENCE_MAX_CHARS,
+} from '../agentPromptBase.js';
+
+describe('analyzeQuery', () => {
+  it('detecta query enumerativa', () => {
+    const r = analyzeQuery('cuantas variedades de cafe hay');
+    expect(r.isEnum).toBe(true);
+  });
+
+  it('no detecta enumerativa si falta noun', () => {
+    const r = analyzeQuery('cuantas matas de cafe tengo');
+    expect(r.isEnum).toBe(false);
+  });
+
+  it('detecta plaga mencionada', () => {
+    const r = analyzeQuery('como controlo la broca del cafe');
+    expect(r.pestsMentioned.length).toBeGreaterThan(0);
+    const names = r.pestsMentioned.map((p) => p.name);
+    expect(names.some((n) => n.includes('broca'))).toBe(true);
+  });
+
+  it('topic manejo para como podo', () => {
+    const r = analyzeQuery('como podo el aguacate');
+    expect(r.topic).toBe('manejo');
+  });
+
+  it('topic atributo para altitud', () => {
+    const r = analyzeQuery('a que altitud crece el frijol');
+    expect(r.topic).toBe('atributo');
+  });
+
+  it('topic general por defecto', () => {
+    const r = analyzeQuery('hola');
+    expect(r.topic).toBe('general');
+  });
+
+  it('maneja query vacia', () => {
+    const r = analyzeQuery('');
+    expect(r.isEnum).toBe(false);
+    expect(r.pestsMentioned).toEqual([]);
+  });
+});
+
+describe('buildQueryAnalysisBlock', () => {
+  it('incluye tipo en bloque', () => {
+    const b = buildQueryAnalysisBlock({ topic: 'manejo', isEnum: false, pestsMentioned: [] });
+    expect(b).toContain('manejo');
+    expect(b).toContain('NO — IGNORA CASO C');
+  });
+
+  it('marca enumerativa SI cuando aplica', () => {
+    const b = buildQueryAnalysisBlock({ topic: 'general', isEnum: true, pestsMentioned: [] });
+    expect(b).toContain('SÍ — usa respuesta CASO C');
+  });
+
+  it('incluye plagas mencionadas', () => {
+    const b = buildQueryAnalysisBlock({
+      topic: 'plaga/enfermedad',
+      isEnum: false,
+      pestsMentioned: [{ name: 'broca', canonical: 'Hypothenemus hampei' }],
+    });
+    expect(b).toContain('Hypothenemus hampei');
+  });
+});
+
+describe('buildCorpusContext', () => {
+  it('retorna vacio sin corpus', () => {
+    expect(buildCorpusContext(null)).toBe('');
+    expect(buildCorpusContext([])).toBe('');
+  });
+
+  it('construye bloque con chunks', () => {
+    const chunks = [{ text: 'El cafe arabica crece entre 1200-1800 msnm.' }];
+    const b = buildCorpusContext(chunks);
+    expect(b).toContain('cafe arabica');
+    expect(b).toContain('REFERENCIA AGRONÓMICA');
+  });
+});
+
+describe('buildCorpusVariants', () => {
+  it('genera variantes decrecientes', () => {
+    const chunks = [{ text: 'chunk1' }, { text: 'chunk2' }, { text: 'chunk3' }];
+    const v = buildCorpusVariants(chunks);
+    expect(v.length).toBe(4); // 3, 2, 1, 0 chunks
+    expect(v[3]).toBe(''); // ultima variante vacia
+  });
+
+  it('maneja array vacio', () => {
+    const v = buildCorpusVariants([]);
+    expect(v.length).toBe(1); // solo variante vacia
+    expect(v[0]).toBe('');
+  });
+});
+
+describe('formatToolEvidence', () => {
+  it('retorna vacio para entrada nula', () => {
+    expect(formatToolEvidence(null)).toBe('');
+  });
+
+  it('retorna vacio sin tool ni result', () => {
+    expect(formatToolEvidence({})).toBe('');
+  });
+
+  it('formatea tool error', () => {
+    const ev = { tool: 'get_species', result: { _error: true, reason: 'timeout' } };
+    expect(formatToolEvidence(ev)).toContain('ERROR DE CONSULTA');
+    expect(formatToolEvidence(ev)).toContain('timeout');
+  });
+
+  it('formatea found:false', () => {
+    const ev = { tool: 'get_species', args: { q: 'xyz' }, result: { found: false } };
+    const b = formatToolEvidence(ev);
+    expect(b).toContain('NO ENCONTRADA');
+  });
+
+  it('formatea tool result found:true con datos', () => {
+    const ev = {
+      tool: 'get_species',
+      args: {},
+      result: { species: { nombre_comun: 'cafe', nombre_cientifico: 'Coffea arabica', found: true } },
+    };
+    const b = formatToolEvidence(ev);
+    expect(b).toContain('DATOS VERIFICADOS');
+  });
+
+  it('trunca datos largos a TOOL_EVIDENCE_MAX_CHARS', () => {
+    const longText = 'x'.repeat(TOOL_EVIDENCE_MAX_CHARS + 100);
+    const ev = { tool: 'get_species', args: {}, result: { found: true, text: longText } };
+    const b = formatToolEvidence(ev);
+    // La salida incluye headers + texto truncado, debe ser menor que el input + overhead
+    expect(b.length).toBeGreaterThan(0);
+    expect(b.length).toBeLessThan(TOOL_EVIDENCE_MAX_CHARS + 1500);
+  });
+
+  it('formatea array de evidencias', () => {
+    const evs = [
+      { tool: 'get_species', result: { found: true, nombre: 'frijol' } },
+      { tool: 'get_companions', result: { found: true, companions: ['maiz'] } },
+    ];
+    const b = formatToolEvidence(evs);
+    expect(b).toContain('DATOS VERIFICADOS');
+  });
+});

--- a/src/services/__tests__/apiService.test.js
+++ b/src/services/__tests__/apiService.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../authService.js', () => ({
+  getAccessToken: vi.fn().mockResolvedValue('mock-token'),
+}));
+
+vi.mock('../tenantContext.js', () => ({
+  getActiveTenantId: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../fincaActiveStore.js', () => ({
+  useFincaActiveStore: {
+    getState: () => ({
+      getActiveEndpoint: () => 'https://farmos.example.com',
+    }),
+  },
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+import { fetchFromFarmOS, sendToFarmOS } from '../apiService.js';
+
+describe('apiService', () => {
+  describe('fetchFromFarmOS', () => {
+    it('es una funcion exportada', () => {
+      expect(typeof fetchFromFarmOS).toBe('function');
+    });
+
+    it('retorna data vacia para bundle obsoleto asset/person', async () => {
+      const r = await fetchFromFarmOS('/api/asset/person');
+      expect(r.data).toEqual([]);
+      expect(r.jsonapi).toBeDefined();
+    });
+
+    it('retorna objeto vacio en demo mode', async () => {
+      const original = import.meta.env.VITE_DEMO_MODE;
+      import.meta.env.VITE_DEMO_MODE = 'true';
+      const r = await fetchFromFarmOS('/api/asset/plant');
+      expect(r).toEqual({});
+      import.meta.env.VITE_DEMO_MODE = original;
+    });
+
+    it('lanza error si no hay token', async () => {
+      const { getAccessToken } = await import('../authService.js');
+      getAccessToken.mockResolvedValueOnce(null);
+      await expect(fetchFromFarmOS('/api/asset/plant')).rejects.toThrow('Token');
+    });
+  });
+
+  describe('sendToFarmOS', () => {
+    it('es una funcion exportada', () => {
+      expect(typeof sendToFarmOS).toBe('function');
+    });
+  });
+});

--- a/src/services/__tests__/assetService.test.js
+++ b/src/services/__tests__/assetService.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../apiService.js', () => ({
+  fetchFromFarmOS: vi.fn(),
+  sendToFarmOS: vi.fn(),
+}));
+
+import { fetchFromFarmOS, sendToFarmOS } from '../apiService.js';
+import { findPersonByName, renameWorker } from '../assetService.js';
+
+describe('assetService', () => {
+  describe('findPersonByName', () => {
+    it('retorna null si no hay matches exactos', async () => {
+      fetchFromFarmOS.mockResolvedValue({
+        data: [
+          { id: '1', attributes: { name: 'Juan Perez' } },
+        ],
+      });
+      const r = await findPersonByName('Pedro');
+      expect(r).toBeNull();
+    });
+
+    it('retorna persona con nombre exacto', async () => {
+      const person = { id: 'p-1', attributes: { name: 'Maria Lopez' } };
+      fetchFromFarmOS.mockResolvedValue({
+        data: [person, { id: 'p-2', attributes: { name: 'Maria' } }],
+      });
+      const r = await findPersonByName('Maria Lopez');
+      expect(r).not.toBeNull();
+      expect(r.id).toBe('p-1');
+      expect(r.attributes.name).toBe('Maria Lopez');
+    });
+  });
+
+  describe('renameWorker', () => {
+    it('retorna success:true al renombrar', async () => {
+      const person = { id: 'p-3', attributes: { name: 'Carlos' } };
+      fetchFromFarmOS.mockResolvedValue({
+        data: [person],
+      });
+      sendToFarmOS.mockResolvedValue({ data: { id: 'p-3' } });
+
+      const r = await renameWorker('Carlos', 'Carlos Actualizado');
+      expect(r.success).toBe(true);
+      expect(r.id).toBe('p-3');
+    });
+
+    it('retorna success:false si persona no encontrada', async () => {
+      fetchFromFarmOS.mockResolvedValue({ data: [] });
+      const r = await renameWorker('Inexistente', 'Nuevo');
+      expect(r.success).toBe(false);
+      expect(r.error).toBe('not_found');
+    });
+
+    it('retorna success:false si sendToFarmOS falla', async () => {
+      const person = { id: 'p-4', attributes: { name: 'ErrorCase' } };
+      fetchFromFarmOS.mockResolvedValue({ data: [person] });
+      sendToFarmOS.mockRejectedValue(new Error('Network failure'));
+
+      const r = await renameWorker('ErrorCase', 'Nuevo');
+      expect(r.success).toBe(false);
+      expect(r.error).toBe('Network failure');
+    });
+  });
+});

--- a/src/services/__tests__/biodiversidadMonitor.test.js
+++ b/src/services/__tests__/biodiversidadMonitor.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { checklistBiodiversidad } from '../biodiversidadMonitor.js';
+
+describe('checklistBiodiversidad', () => {
+  it('retorna array de indicadores', () => {
+    const r = checklistBiodiversidad();
+    expect(Array.isArray(r)).toBe(true);
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  it('cada indicador tiene nombre y como_se_hace', () => {
+    const r = checklistBiodiversidad();
+    for (const ind of r) {
+      expect(ind.nombre).toBeTruthy();
+      expect(ind.como_se_hace).toBeTruthy();
+      expect(ind.confiabilidad).toBeTruthy();
+    }
+  });
+
+  it('incluye indicador de conteo de aves', () => {
+    const r = checklistBiodiversidad();
+    const aves = r.find((i) => i.nombre?.toLowerCase().includes('ave'));
+    expect(aves).toBeTruthy();
+  });
+});

--- a/src/services/__tests__/carbonoAlerta.test.js
+++ b/src/services/__tests__/carbonoAlerta.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { detectarAlertaCarbono } from '../carbonoAlerta.js';
+
+describe('detectarAlertaCarbono', () => {
+  it('retorna null para texto sin palabras clave', () => {
+    expect(detectarAlertaCarbono('como siembro cafe')).toBeNull();
+  });
+
+  it('detecta mencion de bonos de carbono', () => {
+    const r = detectarAlertaCarbono('me quieren pagar bonos de carbono');
+    expect(r).not.toBeNull();
+    expect(r.alerta).toBeTruthy();
+    expect(r.trampas.length).toBeGreaterThan(0);
+    expect(r.recomendacion).toBeTruthy();
+    expect(r.que_hacer.length).toBeGreaterThan(0);
+  });
+
+  it('detecta credito de carbono', () => {
+    const r = detectarAlertaCarbono('los creditos de carbono son buenos?');
+    expect(r).not.toBeNull();
+  });
+
+  it('retorna null para texto vacio', () => {
+    expect(detectarAlertaCarbono('')).toBeNull();
+    expect(detectarAlertaCarbono(null)).toBeNull();
+  });
+});

--- a/src/services/__tests__/ensoModulador.test.js
+++ b/src/services/__tests__/ensoModulador.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { modularPorENSO } from '../ensoModulador.js';
+
+describe('modularPorENSO', () => {
+  it('modula con fase El Nino', () => {
+    const r = modularPorENSO('el_nino', 'Sembrar en epoca seca');
+    expect(r).toContain('Contexto ENSO el_nino');
+    expect(r).toContain('seco');
+  });
+
+  it('modula con fase La Nina', () => {
+    const r = modularPorENSO('la_nina', 'Sembrar en epoca humeda');
+    expect(r).toContain('Contexto ENSO la_nina');
+    expect(r).toContain('humedo');
+  });
+
+  it('modula con fase neutro', () => {
+    const r = modularPorENSO('neutro', 'Sembrar normal');
+    expect(r).toContain('Contexto ENSO neutro');
+  });
+
+  it('retorna base sin modificar si fase no existe', () => {
+    const r = modularPorENSO('inexistente', 'Recomendacion');
+    expect(r).toBe('Recomendacion');
+  });
+
+  it('retorna base sin modificar si fase es null', () => {
+    expect(modularPorENSO(null, 'Recomendacion')).toBe('Recomendacion');
+  });
+});

--- a/src/services/__tests__/exportService.test.js
+++ b/src/services/__tests__/exportService.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../db/logCache.js', () => ({
+  logCache: {
+    getAll: vi.fn(),
+  },
+}));
+
+vi.mock('../../config/materials.js', () => ({
+  MATERIAL_CATEGORIES: {
+    fertilizer: { label: 'Fertilizante' },
+    protection: { label: 'Proteccion' },
+    soil: { label: 'Enmienda' },
+  },
+  MATERIAL_CATEGORY_BY_NAME: {
+    'Compost': 'fertilizer',
+    'Caldo sulfocalcico': 'protection',
+  },
+}));
+
+import { logCache } from '../../db/logCache.js';
+import { exportTraceabilityCsv } from '../exportService.js';
+
+describe('exportService', () => {
+  describe('exportTraceabilityCsv', () => {
+    it('genera descarga con logs', async () => {
+      const mockLogs = [
+        {
+          id: 'log-1',
+          type: 'log--input',
+          name: 'Aplicacion de Compost',
+          timestamp: Math.floor(Date.now() / 1000),
+          quantity: { value: 5, unit: 'kg' },
+          asset_id: 'abc12345-1234-1234-1234-123456789abc',
+          _pending: false,
+          relationships: {},
+        },
+      ];
+
+      logCache.getAll.mockResolvedValue(mockLogs);
+
+      const result = await exportTraceabilityCsv({ filename: 'test.csv' });
+
+      expect(result.rowCount).toBe(1);
+      expect(result.filename).toBe('test.csv');
+      expect(typeof result.pendingCount).toBe('number');
+    });
+
+    it('filtra por types si se especifica', async () => {
+      const mockLogs = [
+        { id: 'a', type: 'log--input', timestamp: 1000, quantity: {}, name: 'Test', _pending: false, relationships: {} },
+        { id: 'b', type: 'log--harvest', timestamp: 2000, quantity: {}, name: 'Test', _pending: false, relationships: {} },
+      ];
+      logCache.getAll.mockResolvedValue(mockLogs);
+
+      const result = await exportTraceabilityCsv({
+        types: ['log--harvest'],
+        filename: 'test.csv',
+      });
+      expect(result.rowCount).toBe(1);
+    });
+
+    it('genera filename por defecto con fecha', async () => {
+      logCache.getAll.mockResolvedValue([]);
+      const result = await exportTraceabilityCsv();
+      expect(result.filename).toContain('chagra_trazabilidad_');
+    });
+  });
+});

--- a/src/services/__tests__/iotCostCalculator.test.js
+++ b/src/services/__tests__/iotCostCalculator.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { estimarCostoIoT } from '../iotCostCalculator.js';
+
+describe('estimarCostoIoT', () => {
+  it('calcula costo con opciones por defecto', () => {
+    const c = estimarCostoIoT();
+    expect(c.hardware).toBeGreaterThan(0);
+    expect(c.recurrente_mensual).toBe(21000);
+    expect(c.total).toBe(c.hardware + c.recurrente_mensual);
+    expect(c.fuente).toBeTruthy();
+  });
+
+  it('excluye camara si incluirCamara=false', () => {
+    const con = estimarCostoIoT({ incluirCamara: true });
+    const sin = estimarCostoIoT({ incluirCamara: false });
+    expect(con.hardware).toBeGreaterThan(sin.hardware);
+  });
+
+  it('excluye SHT30 si incluirSHT30=false', () => {
+    const con = estimarCostoIoT({ incluirSHT30: true });
+    const sin = estimarCostoIoT({ incluirSHT30: false });
+    expect(con.hardware).toBeGreaterThan(sin.hardware);
+  });
+
+  it('usa costo mayor para bateria LiFePO4', () => {
+    const lipo = estimarCostoIoT({ bateria: 'LiFePO4' });
+    const std = estimarCostoIoT({ bateria: '18650' });
+    expect(lipo.hardware).toBeGreaterThan(std.hardware);
+  });
+
+  it('retorna objeto con fuente', () => {
+    const c = estimarCostoIoT();
+    expect(typeof c.fuente).toBe('string');
+    expect(c.fuente.length).toBeGreaterThan(0);
+  });
+});

--- a/src/services/__tests__/iotValeLaPena.test.js
+++ b/src/services/__tests__/iotValeLaPena.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { valeLaPenaIoT } from '../iotValeLaPena.js';
+
+describe('valeLaPenaIoT', () => {
+  it('no vale si quiere automatizar', () => {
+    const r = valeLaPenaIoT({ quiereAutomatizar: true, coberturaCelular: true, presupuesto: 500000, visitaDiaria: false, altoValor: true });
+    expect(r.vale).toBe(false);
+  });
+
+  it('no vale sin cobertura celular', () => {
+    const r = valeLaPenaIoT({ coberturaCelular: false });
+    expect(r.vale).toBe(false);
+  });
+
+  it('no vale si presupuesto < 300000', () => {
+    const r = valeLaPenaIoT({ presupuesto: 200000, coberturaCelular: true });
+    expect(r.vale).toBe(false);
+  });
+
+  it('no vale si visita diaria', () => {
+    const r = valeLaPenaIoT({ visitaDiaria: true, coberturaCelular: true, presupuesto: 500000 });
+    expect(r.vale).toBe(false);
+  });
+
+  it('no vale si no es alto valor', () => {
+    const r = valeLaPenaIoT({ altoValor: false, coberturaCelular: true, presupuesto: 500000, visitaDiaria: false });
+    expect(r.vale).toBe(false);
+  });
+
+  it('vale la pena con condiciones optimas', () => {
+    const r = valeLaPenaIoT({
+      quiereAutomatizar: false,
+      coberturaCelular: true,
+      presupuesto: 500000,
+      visitaDiaria: false,
+      altoValor: true,
+    });
+    expect(r.vale).toBe(true);
+    expect(r.razon).toBeTruthy();
+    expect(r.costo).toBeTruthy();
+  });
+});

--- a/src/services/__tests__/openaiStream.test.js
+++ b/src/services/__tests__/openaiStream.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import streamOpenAI from '../openaiStream.js';
+
+describe('streamOpenAI (unit)', () => {
+  it('es una funcion exportada', () => {
+    expect(typeof streamOpenAI).toBe('function');
+  });
+});
+
+describe('openAI SSE parsing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parsea chunks SSE correctamente', async () => {
+    const encoder = new TextEncoder();
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"hola"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":" mundo"}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      'data: [DONE]\n\n',
+    ];
+
+    let chunkIndex = 0;
+    const readable = new ReadableStream({
+      pull(controller) {
+        if (chunkIndex < chunks.length) {
+          controller.enqueue(encoder.encode(chunks[chunkIndex++]));
+        } else {
+          controller.close();
+        }
+      },
+    });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: readable,
+      headers: { get: vi.fn() },
+    }));
+
+    const result = await streamOpenAI('/api/llamacpp/v1/chat/completions', { model: 'olmoe' });
+    expect(result.fullText).toContain('hola mundo');
+  });
+
+  it('lanza error para fetch no-ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => '{}',
+      headers: { get: vi.fn().mockReturnValue('') },
+    }));
+
+    await expect(
+      streamOpenAI('/api/llamacpp/v1/chat/completions', { model: 'olmoe' })
+    ).rejects.toThrow();
+  });
+
+  it('lanza error si sin body streameable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: null,
+      headers: { get: vi.fn() },
+    }));
+
+    await expect(
+      streamOpenAI('/api/llamacpp/v1/chat/completions', { model: 'olmoe' })
+    ).rejects.toThrow('Respuesta sin body streameable');
+  });
+});

--- a/src/services/__tests__/pageReload.test.js
+++ b/src/services/__tests__/pageReload.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reloadPage } from '../pageReload.js';
+
+describe('reloadPage', () => {
+  it('invoca window.location.reload()', () => {
+    const reloadMock = vi.fn();
+    vi.stubGlobal('location', { reload: reloadMock });
+    reloadPage();
+    expect(reloadMock).toHaveBeenCalledOnce();
+    vi.unstubAllGlobals();
+  });
+
+  it('es una funcion exportada', () => {
+    expect(typeof reloadPage).toBe('function');
+  });
+});

--- a/src/services/__tests__/payloadService.test.js
+++ b/src/services/__tests__/payloadService.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../apiService.js', () => ({
+  sendToFarmOS: vi.fn(),
+}));
+
+vi.mock('../syncManager.js', () => ({
+  syncManager: {
+    enqueuePendingTransaction: vi.fn(),
+  },
+}));
+
+vi.mock('../planGeneratorService.js', () => ({
+  tryGeneratePlanFromSeeding: vi.fn(),
+}));
+
+import { savePayload } from '../payloadService.js';
+
+describe('payloadService', () => {
+  describe('savePayload', () => {
+    it('es una funcion exportada', () => {
+      expect(typeof savePayload).toBe('function');
+    });
+  });
+});

--- a/src/services/__tests__/photoService.test.js
+++ b/src/services/__tests__/photoService.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { captureAndCompress, getPhotoUrl } from '../photoService.js';
+
+describe('photoService', () => {
+  describe('captureAndCompress', () => {
+    it('es una funcion exportada', () => {
+      expect(typeof captureAndCompress).toBe('function');
+    });
+
+    it('lanza error si el archivo no es imagen', async () => {
+      const fakeFile = new File(['not-an-image'], 'test.txt', { type: 'text/plain' });
+      await expect(captureAndCompress(fakeFile)).rejects.toThrow('no es imagen');
+    });
+
+    it('lanza error si file es null', async () => {
+      await expect(captureAndCompress(null)).rejects.toThrow();
+    });
+  });
+
+  describe('getPhotoUrl', () => {
+    it('es una funcion exportada', () => {
+      expect(typeof getPhotoUrl).toBe('function');
+    });
+  });
+});

--- a/src/services/__tests__/pisoTermicoClassifier.test.js
+++ b/src/services/__tests__/pisoTermicoClassifier.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { clasificarPisoTermico } from '../pisoTermicoClassifier.js';
+
+describe('clasificarPisoTermico', () => {
+  it('retorna calido para altitud 0-1000', () => {
+    const r = clasificarPisoTermico(500);
+    expect(r).toBeTruthy();
+    expect(r.id).toBe('calido');
+  });
+
+  it('retorna templado para altitud 1000-2000', () => {
+    const r = clasificarPisoTermico(1500);
+    expect(r).toBeTruthy();
+    expect(r.id).toBe('templado');
+  });
+
+  it('retorna frio para altitud 2000-3000', () => {
+    const r = clasificarPisoTermico(2600);
+    expect(r).toBeTruthy();
+    expect(r.id).toBe('frio');
+  });
+
+  it('retorna paramo para altitud >3000', () => {
+    const r = clasificarPisoTermico(3200);
+    expect(r).toBeTruthy();
+    expect(r.id).toBe('paramo');
+  });
+
+  it('retorna null para altitud negativa', () => {
+    expect(clasificarPisoTermico(-1)).toBeNull();
+  });
+
+  it('retorna null para entrada no numerica', () => {
+    expect(clasificarPisoTermico('mil')).toBeNull();
+  });
+
+  it('retorna null para undefined', () => {
+    expect(clasificarPisoTermico(undefined)).toBeNull();
+  });
+});

--- a/src/services/__tests__/psaElegibilidad.test.js
+++ b/src/services/__tests__/psaElegibilidad.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { evaluarPSA } from '../psaElegibilidad.js';
+
+describe('evaluarPSA', () => {
+  it('elegible si en cuenca', () => {
+    const r = evaluarPSA({ enCuenca: true });
+    expect(r.elegible).toBe(true);
+    expect(r.modalidades.length).toBeGreaterThan(0);
+  });
+
+  it('elegible si en paramo', () => {
+    const r = evaluarPSA({ enParamo: true });
+    expect(r.elegible).toBe(true);
+  });
+
+  it('elegible si altitud > 3000', () => {
+    const r = evaluarPSA({ altitud: 3200 });
+    expect(r.elegible).toBe(true);
+  });
+
+  it('elegible si interes carbono', () => {
+    const r = evaluarPSA({ interes: 'carbono' });
+    expect(r.elegible).toBe(true);
+  });
+
+  it('no elegible sin condiciones', () => {
+    const r = evaluarPSA({});
+    expect(r.elegible).toBe(false);
+    expect(r.modalidades.length).toBe(0);
+  });
+
+  it('incluye requisitos y monto', () => {
+    const r = evaluarPSA({ enCuenca: true });
+    expect(r.requisitos.length).toBeGreaterThan(0);
+    expect(r.monto).toBeTruthy();
+    expect(r.autoridad).toBeTruthy();
+  });
+});

--- a/src/services/__tests__/restauracionRecetaFormatter.test.js
+++ b/src/services/__tests__/restauracionRecetaFormatter.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { formatearRecetaAgroecologica } from '../restauracionRecetaFormatter.js';
+
+describe('formatearRecetaAgroecologica', () => {
+  it('retorna string vacio para diagnostico nulo', () => {
+    expect(formatearRecetaAgroecologica(null)).toBe('');
+    expect(formatearRecetaAgroecologica(undefined)).toBe('');
+  });
+
+  it('retorna string vacio si sin_datos es true', () => {
+    expect(formatearRecetaAgroecologica({ sin_datos: true })).toBe('');
+  });
+
+  it('formatea arreglo con nombre y detalle', () => {
+    const d = { arreglo: { nombre: 'silvopastoril', detalle: 'combina arboles con pastos' } };
+    const r = formatearRecetaAgroecologica(d);
+    expect(r).toContain('silvopastoril');
+    expect(r).toContain('combina arboles con pastos');
+  });
+
+  it('formatea roles de sucesion', () => {
+    const d = {
+      roles: {
+        pioneras: ['aliso', 'chilco'],
+        intermedias: ['roble'],
+        climax: ['palma de cera'],
+      },
+    };
+    const r = formatearRecetaAgroecologica(d);
+    expect(r).toContain('aliso');
+    expect(r).toContain('roble');
+    expect(r).toContain('palma de cera');
+  });
+
+  it('formatea alertas', () => {
+    const d = { alertas: ['no plantar eucalipto', 'evitar quema'] };
+    const r = formatearRecetaAgroecologica(d);
+    expect(r).toContain('no plantar eucalipto');
+  });
+});

--- a/src/services/__tests__/socialPrefiltro.test.js
+++ b/src/services/__tests__/socialPrefiltro.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { preFiltroSocial } from '../socialPrefiltro.js';
+
+describe('preFiltroSocial', () => {
+  it('retorna pasar:true para texto inocuo', () => {
+    expect(preFiltroSocial('como preparo un biopreparado de ajo').pasar).toBe(true);
+  });
+
+  it('bloquea texto que menciona glifosato', () => {
+    const r = preFiltroSocial('el glifosato es malo');
+    expect(r.pasar).toBe(false);
+    expect(r.razon).toContain('bloqueado');
+    expect(r.severidad).toBe('alta');
+  });
+
+  it('bloquea texto que menciona paraquat', () => {
+    const r = preFiltroSocial('usar paraquat');
+    expect(r.pasar).toBe(false);
+  });
+
+  it('bloquea mitos reconocibles (luna.*sembrar)', () => {
+    const r = preFiltroSocial('la luna sirve para sembrar mejor');
+    expect(r.pasar).toBe(false);
+    expect(r.severidad).toBe('media');
+  });
+
+  it('retorna pasar:false para texto vacio', () => {
+    const r = preFiltroSocial('');
+    expect(r.pasar).toBe(false);
+  });
+
+  it('retorna pasar:false para null/undefined', () => {
+    expect(preFiltroSocial(null).pasar).toBe(false);
+    expect(preFiltroSocial(undefined).pasar).toBe(false);
+  });
+});

--- a/src/services/__tests__/subgrafoToText.test.js
+++ b/src/services/__tests__/subgrafoToText.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { subgrafoATextoCampesino } from '../subgrafoToText.js';
+
+describe('subgrafoATextoCampesino', () => {
+  it('retorna string vacio para subgrafo sin nodos', () => {
+    expect(subgrafoATextoCampesino(null)).toBe('');
+    expect(subgrafoATextoCampesino({})).toBe('');
+    expect(subgrafoATextoCampesino({ nodes: [] })).toBe('');
+  });
+
+  it('lista especies por nombre_comun', () => {
+    const sg = {
+      nodes: [
+        { labels: ['Species'], properties: { nombre_comun: 'aguacate' } },
+        { labels: ['Species'], properties: { nombre_comun: 'cafe' } },
+      ],
+    };
+    const r = subgrafoATextoCampesino(sg);
+    expect(r).toContain('aguacate');
+    expect(r).toContain('cafe');
+  });
+
+  it('lista plagas encontradas', () => {
+    const sg = {
+      nodes: [
+        { labels: ['Pest'], properties: { nombre_comun: 'broca' } },
+      ],
+    };
+    const r = subgrafoATextoCampesino(sg);
+    expect(r).toContain('Plagas:');
+    expect(r).toContain('broca');
+  });
+
+  it('lista biopreparados', () => {
+    const sg = {
+      nodes: [
+        { labels: ['Biopreparado'], properties: { nombre: 'caldo sulfocalcico' } },
+      ],
+    };
+    const r = subgrafoATextoCampesino(sg);
+    expect(r).toContain('caldo sulfocalcico');
+  });
+
+  it('incluye relaciones encontradas', () => {
+    const sg = {
+      nodes: [{ labels: ['Species'], properties: { nombre_comun: 'frijol' } }],
+      relaciones: [{ from: 'frijol', rel: 'companion_de', to: 'maiz' }],
+    };
+    const r = subgrafoATextoCampesino(sg);
+    expect(r).toContain('Relaciones encontradas');
+    expect(r).toContain('companion_de');
+  });
+});

--- a/src/services/__tests__/voiceTelemetryService.test.js
+++ b/src/services/__tests__/voiceTelemetryService.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockStore, mockDbRef } = vi.hoisted(() => {
+  const store = {
+    _data: [],
+    add(item) { this._data.push(item); },
+    put(item) {
+      const idx = this._data.findIndex((e) => e.id === item.id);
+      if (idx >= 0) this._data[idx] = item;
+      else this._data.push(item);
+    },
+    get(id) {
+      const found = this._data.find((e) => e.id === id);
+      const req = { result: found || null };
+      queueMicrotask(() => { if (req.onsuccess) req.onsuccess(); });
+      return req;
+    },
+    index(_name) { return this; },
+    getAll(_range, _limit) {
+      const req = { result: [...this._data] };
+      queueMicrotask(() => { if (req.onsuccess) req.onsuccess(); });
+      return req;
+    },
+    openCursor(_range, _dir) {
+      let idx = 0;
+      const data = [...this._data];
+      const req = { onsuccess: null, onerror: null };
+      const advance = () => {
+        idx++;
+        if (idx < data.length) {
+          if (req.onsuccess) req.onsuccess({ target: { result: { value: data[idx], continue: advance } } });
+        } else {
+          if (req.onsuccess) req.onsuccess({ target: { result: null } });
+        }
+      };
+      if (data.length > 0) {
+        queueMicrotask(() => { if (req.onsuccess) req.onsuccess({ target: { result: { value: data[0], continue: advance } } }); });
+      } else {
+        queueMicrotask(() => { if (req.onsuccess) req.onsuccess({ target: { result: null } }); });
+      }
+      return req;
+    },
+  };
+  return { mockStore: store, mockDbRef: { current: null } };
+});
+
+vi.mock('../../db/dbCore.js', () => ({
+  openDB: vi.fn(() => Promise.resolve(mockDbRef.current)),
+  STORES: { VOICE_TELEMETRY: 'voice_telemetry' },
+}));
+
+import { openDB } from '../../db/dbCore.js';
+import { recordEvent, getMetrics, getPendingEvents, clearSyncedEvents, getAllEvents } from '../voiceTelemetryService.js';
+
+function buildTx(store) {
+  return {
+    objectStore: vi.fn(() => store),
+    oncomplete: null,
+    onerror: null,
+  };
+}
+
+describe('voiceTelemetryService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore._data = [];
+    mockDbRef.current = {
+      transaction: vi.fn(() => {
+        const tx = buildTx(mockStore);
+        queueMicrotask(() => { if (tx.oncomplete) tx.oncomplete(); });
+        return tx;
+      }),
+    };
+  });
+
+  describe('recordEvent', () => {
+    it('persiste un evento y retorna el objeto', async () => {
+      const ev = await recordEvent({
+        event_type: 'voice_capture_start',
+        flujo: 'siembra',
+        duration_ms: 1500,
+        accepted: true,
+        connectivity: 'online',
+      });
+
+      expect(ev).not.toBeNull();
+      expect(ev.event_type).toBe('voice_capture_start');
+      expect(ev.flujo).toBe('siembra');
+      expect(ev.synced).toBe(false);
+      expect(ev.id).toBeTruthy();
+    });
+
+    it('retorna null si openDB falla', async () => {
+      openDB.mockRejectedValueOnce(new Error('DB error'));
+      const ev = await recordEvent({ event_type: 'test' });
+      expect(ev).toBeNull();
+    });
+  });
+
+  describe('getPendingEvents', () => {
+    it('retorna array de eventos', async () => {
+      mockStore._data = [
+        { id: 'e1', synced: false, created_at: '2024-01-01' },
+        { id: 'e2', synced: true, created_at: '2024-01-02' },
+      ];
+
+      const events = await getPendingEvents(10);
+      expect(Array.isArray(events)).toBe(true);
+    });
+  });
+
+  describe('getAllEvents', () => {
+    it('retorna array de eventos', async () => {
+      mockStore._data = [
+        { id: 'e1', created_at: '2024-01-01T00:00:00Z', synced: false },
+      ];
+
+      const events = await getAllEvents(10);
+      expect(Array.isArray(events)).toBe(true);
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('retorna objeto de metricas', async () => {
+      mockStore._data = [
+        { id: 'e1', event_type: 'voice_capture_start', flujo: 'siembra', connectivity: 'online', synced: false, created_at: '2024-01-01' },
+      ];
+
+      const metrics = await getMetrics();
+      expect(typeof metrics).toBe('object');
+      expect(typeof metrics.total_events).toBe('number');
+    });
+  });
+
+  describe('clearSyncedEvents', () => {
+    it('no lanza excepcion', async () => {
+      mockStore._data = [];
+      await expect(clearSyncedEvents(30)).resolves.toBeUndefined();
+    });
+
+    it('maneja fallo de openDB', async () => {
+      openDB.mockRejectedValueOnce(new Error('DB error'));
+      await expect(clearSyncedEvents(30)).resolves.toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Tarea 1 — Cobertura de tests

Agrega tests vitest para **19 servicios** que no tenian test.

**104 tests** pasando en vitest. ESLint limpio.

Servicios cubiertos: pageReload, pisoTermicoClassifier, iotCostCalculator, iotValeLaPena, socialPrefiltro, subgrafoToText, restauracionRecetaFormatter, carbonoAlerta, biodiversidadMonitor, ensoModulador, psaElegibilidad, agentPromptBase, openaiStream, voiceTelemetryService, assetService, apiService, exportService, payloadService, photoService.