### PR TITLE
fix(seguridad): anti-leak — quitar username del operador del repo publico

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,9 @@ jobs:
           VITE_FARMOS_URL: ""
           VITE_FARMOS_CLIENT_ID: farm
           VITE_HA_ACCESS_TOKEN: ${{ secrets.VITE_HA_ACCESS_TOKEN }}
+          # Operador: username inyectado en build desde secret (anti-leak: NUNCA
+          # hardcodeado en el source publico). Habilita esOperador -> vision total.
+          VITE_OPERATOR_USERNAME: ${{ secrets.OPERATOR_USERNAME }}
           # Sidecar agro-mcp (ADR-045 fase 2) activado en produccion 2026-05-23.
           # Con flag true, AgentScreen rutea cada turno por NLU del sidecar y,
           # si el planner detecta agro-query, llama al tool MCP antes del chat.

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,6 +36,11 @@ jobs:
           CI: '1'
           VITE_FARMOS_URL: ''
           VITE_FARMOS_CLIENT_ID: farm
+          # El operador ya NO está hardcodeado (anti-leak): esOperador lee
+          # VITE_OPERATOR_USERNAME. El spec home-operador-ve-todo siembra el
+          # tenant 'op-test', así que el E2E debe inyectar ese mismo valor para
+          # que el dev server reconozca al operador y renderice el home completo.
+          VITE_OPERATOR_USERNAME: op-test
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/src/config/__tests__/glaciarAccess.test.js
+++ b/src/config/__tests__/glaciarAccess.test.js
@@ -97,16 +97,22 @@ describe('glaciarAccess — tieneAccesoGlaciarActual (usuario logueado, offline)
 
 describe('glaciarAccess — esOperador (bypass de visión total, función pura)', () => {
   beforeEach(async () => {
+    // El operador se inyecta por env (anti-leak: no se hardcodea el username real).
+    vi.stubEnv('VITE_OPERATOR_USERNAME', 'op-test');
     glaciarAccess = await importFresh();
   });
 
-  it('devuelve true para el operador (kortux)', () => {
-    expect(glaciarAccess.esOperador('kortux')).toBe(true);
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('devuelve true para el operador (segun VITE_OPERATOR_USERNAME)', () => {
+    expect(glaciarAccess.esOperador('op-test')).toBe(true);
   });
 
   it('hace match case-insensitive y tolerante a espacios (trim)', () => {
-    expect(glaciarAccess.esOperador('KORTUX')).toBe(true);
-    expect(glaciarAccess.esOperador('  Kortux  ')).toBe(true);
+    expect(glaciarAccess.esOperador('OP-TEST')).toBe(true);
+    expect(glaciarAccess.esOperador('  Op-Test  ')).toBe(true);
   });
 
   it('INVARIANTE: un guía glaciar REAL de la Cordada NO es operador', () => {
@@ -125,13 +131,14 @@ describe('glaciarAccess — esOperador (bypass de visión total, función pura)'
     expect(glaciarAccess.esOperador('   ')).toBe(false);
   });
 
-  it('OPERADOR_WHITELIST es un Set no vacío e independiente de CORDADA', () => {
-    expect(glaciarAccess.OPERADOR_WHITELIST).toBeInstanceOf(Set);
-    expect(glaciarAccess.OPERADOR_WHITELIST.size).toBeGreaterThan(0);
+  it('getOperadorWhitelist() es un Set no vacío e independiente de CORDADA', () => {
+    const operadores = glaciarAccess.getOperadorWhitelist();
+    expect(operadores).toBeInstanceOf(Set);
+    expect(operadores.size).toBeGreaterThan(0);
     // Son conceptos distintos: la Cordada (acceso al tile) NO es la whitelist
     // de operador (visión total). alex está en Cordada pero NO es operador.
     expect(glaciarAccess.CORDADA_WHITELIST.has('alex')).toBe(true);
-    expect(glaciarAccess.OPERADOR_WHITELIST.has('alex')).toBe(false);
+    expect(operadores.has('alex')).toBe(false);
   });
 });
 
@@ -140,6 +147,7 @@ describe('glaciarAccess — esOperadorActual (usuario logueado, offline)', () =>
 
   beforeEach(async () => {
     store = {};
+    vi.stubEnv('VITE_OPERATOR_USERNAME', 'op-test');
     vi.stubGlobal('localStorage', {
       getItem: (k) => store[k] ?? null,
       setItem: (k, v) => { store[k] = v; },
@@ -150,10 +158,11 @@ describe('glaciarAccess — esOperadorActual (usuario logueado, offline)', () =>
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it('devuelve true cuando el usuario logueado es el operador', () => {
-    store['chagra:active_tenant_id'] = 'kortux';
+    store['chagra:active_tenant_id'] = 'op-test';
     expect(glaciarAccess.esOperadorActual()).toBe(true);
   });
 

--- a/src/config/glaciarAccess.js
+++ b/src/config/glaciarAccess.js
@@ -53,7 +53,8 @@ export const CORDADA_WHITELIST = new Set([
   'alex',    // La Cordada — beta tester glaciar.
   'mario',   // La Cordada — beta tester glaciar.
   'camilo',  // La Cordada — beta tester glaciar.
-  'kortux',  // Operador — debe VER el tile glaciar (acceso), NO rol de guía.
+  // NOTA: el operador NO se hardcodea aquí (anti-leak, repo público). Ve el tile
+  // glaciar vía `tieneAccesoGlaciar` (que incluye a esOperador). Ver abajo.
 ]);
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -67,8 +68,9 @@ export const CORDADA_WHITELIST = new Set([
 //
 // Por eso el operador tiene su PROPIA whitelist: estar acá NO deriva un rol de
 // producto; es un BYPASS del gating del home/chips para que el operador
-// (admin/demo/debug) vea SIEMPRE TODO. El operador puede seguir estando también
-// en CORDADA_WHITELIST (para ver el tile glaciar) sin que eso le estreche nada.
+// (admin/demo/debug) vea SIEMPRE TODO. El operador ve el tile glaciar vía
+// `tieneAccesoGlaciar` (que incluye a esOperador), SIN hardcodear su username
+// (anti-leak: repo público, ver tests/unit/boundaryAudit.test.js).
 //
 // NO reutilizar CORDADA_WHITELIST para esto: son dos conceptos distintos
 // (acceso a un módulo beta vs. visión total del operador).
@@ -84,9 +86,26 @@ export const CORDADA_WHITELIST = new Set([
  *
  * @constant {Set<string>}
  */
-export const OPERADOR_WHITELIST = new Set([
-  'kortux',  // Operador — visión total para demos/debug (NO estrecha por rol).
-]);
+// ANTI-LEAK (repo PÚBLICO): el/los username(s) del operador se INYECTAN en build
+// vía la env `VITE_OPERATOR_USERNAME` (uno o varios separados por coma) y NUNCA se
+// hardcodean aquí. El deploy la setea desde el secret OPERATOR_USERNAME. En dev sin
+// la env, el Set queda vacío → esOperador=false (fallback seguro). Ver
+// tests/unit/boundaryAudit.test.js (Task 40).
+function operadorUsernames() {
+  return String(import.meta.env?.VITE_OPERATOR_USERNAME ?? '')
+    .split(',')
+    .map((u) => u.trim().toLowerCase())
+    .filter((u) => u.length > 0);
+}
+
+/**
+ * Set de usernames del operador, leído de la env en CALL-TIME (testeable con
+ * vi.stubEnv). NUNCA hardcodea el username (anti-leak, repo público).
+ * @returns {Set<string>}
+ */
+export function getOperadorWhitelist() {
+  return new Set(operadorUsernames());
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // API pública
@@ -108,7 +127,9 @@ export function tieneAccesoGlaciar(username) {
   if (!username || typeof username !== 'string') return false;
   const normalized = username.trim().toLowerCase();
   if (normalized.length === 0) return false;
-  return CORDADA_WHITELIST.has(normalized);
+  // El operador (visión total) también ve el tile glaciar, aunque ya NO esté
+  // hardcodeado en CORDADA_WHITELIST (anti-leak).
+  return CORDADA_WHITELIST.has(normalized) || esOperador(normalized);
 }
 
 /**
@@ -137,7 +158,7 @@ export function esOperador(username) {
   if (!username || typeof username !== 'string') return false;
   const normalized = username.trim().toLowerCase();
   if (normalized.length === 0) return false;
-  return OPERADOR_WHITELIST.has(normalized);
+  return operadorUsernames().includes(normalized);
 }
 
 /**

--- a/tests/home-operador-ve-todo.spec.js
+++ b/tests/home-operador-ve-todo.spec.js
@@ -3,10 +3,10 @@ import { test, expect } from '@playwright/test';
 /**
  * home-operador-ve-todo.spec.js — REGRESIÓN 2026-06-15.
  *
- * El operador (kortux) debe ver el HOME COMPLETO para demos y debug: TODOS los
+ * El operador (op-test) debe ver el HOME COMPLETO para demos y debug: TODOS los
  * módulos + las 4 tarjetas de seguimiento (Reforestación · Silvopastoreo ·
  * Páramo · CERDOS) + el catálogo completo de chips. La causa del bug fue que
- * `kortux` está en CORDADA_WHITELIST → `deriveRole` lo clasificaba como
+ * `op-test` está en CORDADA_WHITELIST → `deriveRole` lo clasificaba como
  * `guia_glaciar` → el home quedaba ESTRECHO (clima/páramo/reforestación).
  *
  * El fix es un BYPASS: `esOperador(username)` (whitelist propia, separada de la
@@ -26,10 +26,10 @@ import { test, expect } from '@playwright/test';
  */
 
 const ORIGIN = 'http://localhost:5173';
-const OPERADOR_USERNAME = 'kortux';
+const OPERADOR_USERNAME = 'op-test';
 
 /**
- * Siembra, ANTES de cualquier script de la app, el tenant activo (kortux) y un
+ * Siembra, ANTES de cualquier script de la app, el tenant activo (op-test) y un
  * perfil URBANO en localStorage. El perfil urbano es a propósito: demuestra
  * que el bypass del operador gana sobre el override urbano (que escondería
  * Cerdos/Insumos/Zonas). Sin preferencia manual de visibilidad → el default
@@ -114,7 +114,7 @@ test.describe('Home del OPERADOR — ve TODO (bypass del gating)', () => {
     await mockBackend(page);
 
     await page.goto(ORIGIN);
-    // Login programático (token en localforage + tenant kortux).
+    // Login programático (token en localforage + tenant op-test).
     await loginComoOperador(page);
     // Recargar para que App monte autenticado y aterrice en el dashboard.
     // El addInitScript vuelve a sembrar tenant+perfil urbano antes del boot.


### PR DESCRIPTION
boundaryAudit (Task 40) fallaba: el username del operador estaba hardcodeado en glaciarAccess.js (repo PUBLICO = fuga de identidad, introducida por #1581/#1571). Fix: esOperador via VITE_OPERATOR_USERNAME (secret OPERATOR_USERNAME ya seteado, no hardcode); tests con op-test + vi.stubEnv; deploy.yml inyecta el env. boundaryAudit + 77 tests verdes; operador-ve-todo intacto en prod.