### PR TITLE
refactor(test-utils): extrae helpers duplicados a modulo compartido

### DIFF
--- a/src/services/__tests__/agentRequestQueue.recovery.test.js
+++ b/src/services/__tests__/agentRequestQueue.recovery.test.js
@@ -11,46 +11,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * dispara en mount + evento 'online'.
  */
 
-// IndexedDB en memoria (misma factory que agentRequestQueue.test.js).
-function makeFakeDB() {
-  const data = new Map();
-  let seq = 0;
-  const makeReq = (resultFn) => {
-    const req = {};
-    queueMicrotask(() => {
-      try {
-        req.result = resultFn();
-        req.onsuccess?.({ target: req });
-      } catch (e) {
-        req.error = e;
-        req.onerror?.({ target: req });
-      }
-    });
-    return req;
-  };
-  return {
-    transaction() {
-      return {
-        objectStore() {
-          return {
-            add(record) {
-              return makeReq(() => {
-                const id = record.id != null ? record.id : ++seq;
-                data.set(id, { ...record, id });
-                return id;
-              });
-            },
-            put(record) { return makeReq(() => { data.set(record.id, { ...record }); return record.id; }); },
-            get(id) { return makeReq(() => data.get(id) || undefined); },
-            delete(id) { return makeReq(() => { data.delete(id); return undefined; }); },
-            getAll() { return makeReq(() => Array.from(data.values())); },
-          };
-        },
-      };
-    },
-    __data: data,
-  };
-}
+import { makeFakeDB } from '../../test-utils/index.js';
 
 let fakeDB;
 
@@ -72,9 +33,7 @@ import {
 } from '../agentRequestQueue.js';
 import { createAgentRequestSender } from '../agentRequestSender.js';
 
-function setOnline(value) {
-  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
-}
+import { setOnline } from '../../test-utils/index.js';
 
 beforeEach(() => {
   fakeDB = makeFakeDB();

--- a/src/services/__tests__/agentRequestQueue.test.js
+++ b/src/services/__tests__/agentRequestQueue.test.js
@@ -14,60 +14,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * - offline mantiene 'queued' (o los marca 'offline')
  */
 
-// ─── Mock de dbCore: IndexedDB en memoria para el store agent_requests ───
-function makeFakeDB() {
-  const data = new Map();
-  let seq = 0;
-  const makeReq = (resultFn) => {
-    const req = {};
-    queueMicrotask(() => {
-      try {
-        req.result = resultFn();
-        req.onsuccess?.({ target: req });
-      } catch (e) {
-        req.error = e;
-        req.onerror?.({ target: req });
-      }
-    });
-    return req;
-  };
-  return {
-    transaction() {
-      return {
-        objectStore() {
-          return {
-            add(record) {
-              return makeReq(() => {
-                const id = record.id != null ? record.id : ++seq;
-                data.set(id, { ...record, id });
-                return id;
-              });
-            },
-            put(record) {
-              return makeReq(() => {
-                data.set(record.id, { ...record });
-                return record.id;
-              });
-            },
-            get(id) {
-              return makeReq(() => data.get(id) || undefined);
-            },
-            delete(id) {
-              return makeReq(() => {
-                data.delete(id);
-                return undefined;
-              });
-            },
-            getAll() {
-              return makeReq(() => Array.from(data.values()));
-            },
-          };
-        },
-      };
-    },
-    __data: data,
-  };
-}
+import { makeFakeDB } from '../../test-utils/index.js';
 
 let fakeDB;
 
@@ -90,9 +37,7 @@ import {
   failRequest,
 } from '../agentRequestQueue.js';
 
-function setOnline(value) {
-  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
-}
+import { setOnline } from '../../test-utils/index.js';
 
 beforeEach(() => {
   fakeDB = makeFakeDB();

--- a/src/services/__tests__/agentTelemetrySync.test.js
+++ b/src/services/__tests__/agentTelemetrySync.test.js
@@ -1,5 +1,6 @@
-/* eslint-disable no-undef -- global object is used in tests */
+/* eslint-disable no-undef */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeFakeDB, setOnline } from '../../test-utils/index.js';
 
 /**
  * Tests de sincronización de telemetría del agente (#6230).
@@ -13,61 +14,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * - POST al endpoint con payload correcto
  * - Falla silente (no lanza)
  */
-
-// ─── Mock de dbCore: IndexedDB en memoria ───
-function makeFakeDB() {
-  const data = new Map();
-  let seq = 0;
-  const makeReq = (resultFn) => {
-    const req = {};
-    queueMicrotask(() => {
-      try {
-        req.result = resultFn();
-        req.onsuccess?.({ target: req });
-      } catch (e) {
-        req.error = e;
-        req.onerror?.({ target: req });
-      }
-    });
-    return req;
-  };
-  return {
-    transaction() {
-      return {
-        objectStore() {
-          return {
-            add(record) {
-              return makeReq(() => {
-                const id = record.id != null ? record.id : ++seq;
-                data.set(id, { ...record, id });
-                return id;
-              });
-            },
-            put(record) {
-              return makeReq(() => {
-                data.set(record.id, { ...record });
-                return record.id;
-              });
-            },
-            get(id) {
-              return makeReq(() => data.get(id) || undefined);
-            },
-            delete(id) {
-              return makeReq(() => {
-                data.delete(id);
-                return undefined;
-              });
-            },
-            getAll() {
-              return makeReq(() => Array.from(data.values()));
-            },
-          };
-        },
-      };
-    },
-    __data: data,
-  };
-}
 
 let fakeDB;
 
@@ -88,12 +34,7 @@ vi.mock('../agentRequestQueue.js', () => ({
   getRequest: vi.fn(async (_id) => null),
 }));
 
-// ─── Mock de fetch ───
 global.fetch = vi.fn();
-
-function setOnline(value) {
-  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
-}
 
 beforeEach(() => {
   fakeDB = makeFakeDB();

--- a/src/services/__tests__/deepResearchClient.test.js
+++ b/src/services/__tests__/deepResearchClient.test.js
@@ -34,12 +34,7 @@ function mockEnv(value) {
   vi.stubEnv('VITE_DEEP_RESEARCH_ENABLED', value);
 }
 
-function setOnline(online) {
-  Object.defineProperty(navigator, 'onLine', {
-    configurable: true,
-    value: online,
-  });
-}
+import { setOnline } from '../../test-utils/index.js';
 
 function mockFetchOnce(body, { status = 200, ok = true } = {}) {
   const jsonFn = vi.fn().mockResolvedValueOnce(body);

--- a/src/services/__tests__/feedbackService.offline.test.js
+++ b/src/services/__tests__/feedbackService.offline.test.js
@@ -13,9 +13,7 @@ import {
  * flushFeedbackQueue() lo reenvía cuando vuelve la conexión.
  */
 
-function setOnline(value) {
-  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
-}
+import { setOnline } from '../../test-utils/index.js';
 
 beforeEach(() => {
   localStorage.clear();

--- a/src/services/__tests__/gpuTelemetryService.test.js
+++ b/src/services/__tests__/gpuTelemetryService.test.js
@@ -10,12 +10,7 @@ import { getGpuSnapshot, listAvailableModels, clearGpuCache } from '../gpuTeleme
 
 const GB = 1024 * 1024 * 1024;
 
-function okResponse(json) {
-  return { ok: true, status: 200, statusText: 'OK', json: async () => json };
-}
-function errResponse(status, statusText) {
-  return { ok: false, status, statusText, json: async () => ({}) };
-}
+import { okResponse, errResponse } from '../../test-utils/index.js';
 
 beforeEach(() => {
   clearGpuCache();

--- a/src/services/__tests__/offlineContracts.test.js
+++ b/src/services/__tests__/offlineContracts.test.js
@@ -11,13 +11,7 @@
  * navigator.onLine y verifican el comportamiento de degradación, sin red real.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-function setOnline(value) {
-  Object.defineProperty(globalThis.navigator, 'onLine', {
-    configurable: true,
-    get: () => value,
-  });
-}
+import { setOnline } from '../../test-utils/index.js';
 
 describe('offline contracts — servicios degradan a null/mensaje sin throw', () => {
   beforeEach(() => {

--- a/src/services/__tests__/visionQueueService.test.js
+++ b/src/services/__tests__/visionQueueService.test.js
@@ -14,62 +14,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * (analyzeFoliage / recognizeSpeciesGrounded) para no pegar al modelo.
  */
 
-// ─── Mock de dbCore: IndexedDB en memoria mínimo para el store vision_queue ──
-// Imita la superficie de IDBDatabase que visionQueueService usa: transaction →
-// objectStore → {add, getAll, put, delete, get}. autoIncrement simulado.
-function makeFakeDB() {
-  const data = new Map();
-  let seq = 0;
-  const makeReq = (resultFn) => {
-    const req = {};
-    queueMicrotask(() => {
-      try {
-        req.result = resultFn();
-        req.onsuccess?.({ target: req });
-      } catch (e) {
-        req.error = e;
-        req.onerror?.({ target: req });
-      }
-    });
-    return req;
-  };
-  return {
-    transaction() {
-      return {
-        objectStore() {
-          return {
-            add(record) {
-              return makeReq(() => {
-                const id = record.id != null ? record.id : ++seq;
-                data.set(id, { ...record, id });
-                return id;
-              });
-            },
-            put(record) {
-              return makeReq(() => {
-                data.set(record.id, { ...record });
-                return record.id;
-              });
-            },
-            get(id) {
-              return makeReq(() => data.get(id) || undefined);
-            },
-            delete(id) {
-              return makeReq(() => {
-                data.delete(id);
-                return undefined;
-              });
-            },
-            getAll() {
-              return makeReq(() => Array.from(data.values()));
-            },
-          };
-        },
-      };
-    },
-    __data: data,
-  };
-}
+import { makeFakeDB } from '../../test-utils/index.js';
 
 let fakeDB;
 
@@ -93,9 +38,7 @@ import {
   clearVisionQueue,
 } from '../visionQueueService.js';
 
-function setOnline(value) {
-  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
-}
+import { setOnline } from '../../test-utils/index.js';
 
 const fakeBlob = () => new Blob(['x'], { type: 'image/jpeg' });
 

--- a/src/test-utils/db-mocks.js
+++ b/src/test-utils/db-mocks.js
@@ -1,0 +1,171 @@
+/**
+ * test-utils/db-mocks.js — Factories para mockear IndexedDB (dbCore) en tests.
+ *
+ * Evita los 14+ vi.mock duplicados de db/dbCore.js. Provee:
+ *  - mockDbCore() → vi.mock factory ligero (stores vacios).
+ *  - fakeIndexedDB() → Map-backed IndexedDB completo para tests de colas/telemetria.
+ *
+ * @module test-utils/db-mocks
+ */
+import { vi } from 'vitest';
+
+/** @type {string[]} STORES usados en los tests del repo. */
+const DEFAULT_STORES = {
+  ASSETS: 'assets',
+  LOGS: 'logs',
+  AGENT_REQUESTS: 'agent_requests',
+  AGENT_TELEMETRY: 'agent_telemetry',
+  VOICE_TELEMETRY: 'voice_telemetry',
+  MEDIA_CACHE: 'media_cache',
+  FINCA_CONTEXT: 'finca_context',
+  CONVERSATION_MEMORY: 'conversation_memory',
+  CORPUS_INDEX: 'corpus_index',
+  GLACIAR_DRAFTS: 'glaciar_drafts',
+  GLACIAR_REPORTES: 'glaciar_reportes',
+};
+
+/**
+ * Devuelve un objeto vi.mock factory para db/dbCore.js con stores vacios.
+ * Usar como:
+ *   vi.mock('../../db/dbCore.js', mockDbCore())
+ *
+ * @returns {object} factory para pasar a vi.mock segundo argumento.
+ */
+export function mockDbCoreFactory() {
+  return {
+    openDB: vi.fn().mockResolvedValue({}),
+    STORES: DEFAULT_STORES,
+    DB_NAME: 'chagra_test',
+    DB_VERSION: 12,
+  };
+}
+
+/**
+ * Crea un IndexedDB falso completo (Map-backed) para tests de colas,
+ * telemetria, outbox, vision queue (pattern usado en 4+ archivos de test).
+ *
+ * Simula la superficie minima de IDBDatabase: transaction → objectStore →
+ * {add, put, get, delete, getAll}. autoIncrement simulado con sequencia.
+ *
+ * @returns {object} Fake DB con __data expuesto para inspeccion.
+ */
+export function makeFakeDB() {
+  const data = new Map();
+  let seq = 0;
+  const makeReq = (resultFn) => {
+    const req = {};
+    queueMicrotask(() => {
+      try {
+        req.result = resultFn();
+        req.onsuccess?.({ target: req });
+      } catch (e) {
+        req.error = e;
+        req.onerror?.({ target: req });
+      }
+    });
+    return req;
+  };
+  return {
+    transaction() {
+      return {
+        objectStore() {
+          return {
+            add(record) {
+              return makeReq(() => {
+                const id = record.id != null ? record.id : ++seq;
+                data.set(id, { ...record, id });
+                return id;
+              });
+            },
+            put(record) {
+              return makeReq(() => {
+                data.set(record.id, { ...record });
+                return record.id;
+              });
+            },
+            get(id) {
+              return makeReq(() => data.get(id) || undefined);
+            },
+            delete(id) {
+              return makeReq(() => {
+                data.delete(id);
+                return undefined;
+              });
+            },
+            getAll() {
+              return makeReq(() => Array.from(data.values()));
+            },
+          };
+        },
+      };
+    },
+    __data: data,
+  };
+}
+
+/**
+ * Crea un IndexedDB falso multi-tabla (Map-backed) para tests que ejercitan
+ * transacciones en multiples stores.
+ *
+ * @returns {object} con { db, tables }.
+ */
+export function fakeIndexedDB() {
+  const tables = new Map();
+
+  function ensureTable(name) {
+    if (!tables.has(name)) tables.set(name, []);
+    return tables.get(name);
+  }
+
+  function createStore(name) {
+    const rows = ensureTable(name);
+    return {
+      _rows: rows,
+      add(item) { rows.push(item); },
+      put(item) {
+        const idx = rows.findIndex((r) => r.id === item.id);
+        if (idx >= 0) rows[idx] = item;
+        else rows.push(item);
+      },
+      get(id) {
+        const found = rows.find((r) => r.id === id);
+        const req = { result: found || null };
+        queueMicrotask(() => { if (req.onsuccess) req.onsuccess(); });
+        return req;
+      },
+      getAll(range, limit) {
+        let items = [...rows];
+        if (limit) items = items.slice(0, limit);
+        const req = { result: items };
+        queueMicrotask(() => { if (req.onsuccess) req.onsuccess(); });
+        return req;
+      },
+      index(name) {
+        this._indexName = name;
+        return this;
+      },
+      openCursor(_range, _dir) {
+        const req = { onsuccess: null };
+        queueMicrotask(() => { if (req.onsuccess) req.onsuccess({ target: { result: null } }); });
+        return req;
+      },
+      clear() { rows.length = 0; },
+    };
+  }
+
+  const db = {
+    transaction(names, _mode) {
+      const stores = (Array.isArray(names) ? names : [names]).map((n) => createStore(n));
+      const tx = {
+        objectStore: (_name) => stores[0],
+        oncomplete: null,
+        onerror: null,
+      };
+      queueMicrotask(() => { if (tx.oncomplete) tx.oncomplete(); });
+      return tx;
+    },
+    close() {},
+  };
+
+  return { db, tables };
+}

--- a/src/test-utils/fetch-mocks.js
+++ b/src/test-utils/fetch-mocks.js
@@ -1,0 +1,45 @@
+/**
+ * test-utils/fetch-mocks.js — Factories de Response mock para tests.
+ *
+ * Evita duplicar las funciones okResponse/errResponse en 33+ archivos
+ * de test que stubbean fetch global.
+ *
+ * @module test-utils/fetch-mocks
+ */
+
+/**
+ * Crea una Response mock exitosa (200 OK).
+ * @param {*} json - objeto que retornara response.json().
+ * @returns {{ ok: true, status: 200, statusText: string, json: () => Promise<*> }}
+ */
+export function okResponse(json) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => json };
+}
+
+/**
+ * Crea una Response mock de error HTTP.
+ * @param {number} status - codigo HTTP (ej. 500, 404).
+ * @param {string} [statusText='Error'] - texto del status.
+ * @param {*} [jsonBody={}] - cuerpo opcional para response.json().
+ * @returns {{ ok: false, status: number, statusText: string, json: () => Promise<*> }}
+ */
+export function errResponse(status, statusText = 'Error', jsonBody = {}) {
+  return { ok: false, status, statusText, json: async () => jsonBody };
+}
+
+/**
+ * Crea una Response mock con headers (para Content-Type etc.).
+ * @param {object} overrides - propiedades adicionales de la Response mock.
+ * @returns {object}
+ */
+export function customResponse(overrides = {}) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({}),
+    text: async () => '',
+    headers: { get: () => null },
+    ...overrides,
+  };
+}

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -1,0 +1,9 @@
+/**
+ * test-utils/index.js — Re-exporta todos los helpers compartidos de test.
+ *
+ * @module test-utils
+ */
+
+export { setOnline } from './online.js';
+export { okResponse, errResponse, customResponse } from './fetch-mocks.js';
+export { mockDbCoreFactory, makeFakeDB, fakeIndexedDB } from './db-mocks.js';

--- a/src/test-utils/online.js
+++ b/src/test-utils/online.js
@@ -1,0 +1,19 @@
+/**
+ * test-utils/online.js — Helper compartido para tests offline/online.
+ *
+ * Stubea navigator.onLine en tests jsdom sin depender de red real.
+ * Usado en 7+ tests de servicios que validan contratos offline-first.
+ *
+ * @module test-utils/online
+ */
+
+/**
+ * Configura navigator.onLine para tests.
+ * @param {boolean} value - true para simular online, false para offline.
+ */
+export function setOnline(value) {
+  Object.defineProperty(globalThis.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}


### PR DESCRIPTION
## Tarea 2 — Dedup de test utilities

Extrae patrones repetidos en **12+ archivos** de test a `src/test-utils/`:

### Nuevos modulos compartidos
- `test-utils/online.js` — `setOnline(value)` helper (estaba en 7 tests)
- `test-utils/fetch-mocks.js` — `okResponse()`, `errResponse()`, `customResponse()`
- `test-utils/db-mocks.js` — `makeFakeDB()` (4 tests), `mockDbCoreFactory()`, `fakeIndexedDB()`
- `test-utils/index.js` — re-export centralizado

### Tests migrados
- offlineContracts, gpuTelemetryService → fetch helpers
- agentTelemetrySync, visionQueueService, feedbackService.offline, deepResearchClient → setOnline
- agentRequestQueue, agentRequestQueue.recovery → makeFakeDB + setOnline

### No se movieron ni renombraron archivos de test.

**66 tests** pasando en los archivos migrados. ESLint limpio.