### PR TITLE
docs(jsdoc): documenta exports sin JSDoc en servicios y utilidades

### DIFF
--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -273,10 +273,12 @@ Responde en español colombiano (tú/usted, sin voseo argentino). Sé específic
   return sections.join('\n\n');
 }
 
-// NN2+NN3 (2026-05-23): análisis de query en frontend para inyectar
-// señales específicas al system prompt. El LLM configurado ignora reglas
-// generales bajo presión — necesita instrucción concreta sobre ESTA
-// query.
+/**
+ * Analiza una consulta para detectar si es enumerativa, que plagas menciona
+ * y el tema principal. Señales NN2+NN3 para inyectar al system prompt.
+ * @param {string} q
+ * @returns {{isEnum: boolean, pestsMentioned: Array<{name: string, canonical: string}>, topic: string}}
+ */
 export const analyzeQuery = (q) => {
   const lower = (q || '').toLowerCase();
   // NN2: detección estricta de query enumerativa. Solo SI contiene

--- a/src/services/animalDiagnostic.js
+++ b/src/services/animalDiagnostic.js
@@ -27,6 +27,11 @@ export function detectarEspecie(descripcion) {
   return null;
 }
 
+/**
+ * Recomienda forrajeras segun la especie animal.
+ * @param {string} especieId
+ * @returns {Array<object>}
+ */
 export function recomendarForraje(especieId) {
   const forrajes = ANIMAL_DATA.forrajeras.filter((f) => {
     if (especieId === 'porcino' || especieId === 'cunicola' || especieId === 'avicola') {
@@ -38,6 +43,11 @@ export function recomendarForraje(especieId) {
   return forrajes;
 }
 
+/**
+ * Retorna guardas de seguridad especificas para una especie animal.
+ * @param {string} especieId
+ * @returns {Array<string>}
+ */
 export function getGuardas(especieId) {
   const guardas = [];
   if (['porcino', 'cunicola', 'avicola', 'equino'].includes(especieId)) {
@@ -49,6 +59,12 @@ export function getGuardas(especieId) {
   return guardas;
 }
 
+/**
+ * Diagnostica una especie animal a partir de la descripcion del usuario
+ * y retorna forrajes y guardas.
+ * @param {string} descripcion
+ * @returns {{especie: object|null, forrajes: Array, guardas: Array, sin_datos: boolean, fuente: string}}
+ */
 export function diagnosticarAnimal(descripcion) {
   if (!descripcion || descripcion.trim().length < 3) {
     return { especie: null, forrajes: [], guardas: [], sin_datos: true, fuente: ANIMAL_DATA.fuente };
@@ -69,6 +85,11 @@ export function diagnosticarAnimal(descripcion) {
   return { especie, forrajes, guardas, sin_datos: false, fuente: ANIMAL_DATA.fuente };
 }
 
+/**
+ * Formatea el resultado del diagnostico pecuario en texto legible.
+ * @param {object|null} d
+ * @returns {string}
+ */
 export function formatearGroundingAnimal(d) {
   if (!d || d.sin_datos || !d.especie) return '';
   const partes = [];

--- a/src/services/biodiversidadMonitor.js
+++ b/src/services/biodiversidadMonitor.js
@@ -1,5 +1,9 @@
 import BIO from '../data/biodiversidad-indicadores.json';
 
+/**
+ * Retorna lista de indicadores de biodiversidad del JSON de datos.
+ * @returns {Array<{nombre: string, como_se_hace: string, umbral: string, confiabilidad: string}>}
+ */
 export function checklistBiodiversidad() {
   return BIO.indicadores.map((ind) => ({
     nombre: ind.nombre,

--- a/src/services/carbonoAlerta.js
+++ b/src/services/carbonoAlerta.js
@@ -1,5 +1,10 @@
 import CARBONO from '../data/carbono-alertas.json';
 
+/**
+ * Detecta si un texto menciona bonos/créditos de carbono y retorna alerta educativa.
+ * @param {string|null} texto
+ * @returns {object|null}
+ */
 export function detectarAlertaCarbono(texto) {
   if (!texto) return null;
   const t = texto.toLowerCase();

--- a/src/services/ensoContext.js
+++ b/src/services/ensoContext.js
@@ -144,6 +144,11 @@ const DEPTO_TO_REGION = Object.freeze({
  * Normaliza una fase ENSO a una de tres familias: 'nino' | 'nina' | 'neutral'.
  * Acepta los slugs del sidecar (nino_fuerte, nina_debil, neutral, etc.).
  */
+/**
+ * Normaliza una fase ENSO a una de tres familias: 'nino', 'nina' o 'neutral'.
+ * @param {string} phase
+ * @returns {'nino'|'nina'|'neutral'}
+ */
 export function ensoFamily(phase) {
     if (typeof phase !== 'string') return 'neutral';
     if (phase.startsWith('nino')) return 'nino';

--- a/src/services/ensoModulador.js
+++ b/src/services/ensoModulador.js
@@ -1,5 +1,11 @@
 import ENSO from '../data/enso-modulacion.json';
 
+/**
+ * Modula una recomendacion agronomica segun la fase ENSO.
+ * @param {string|null} faseENSO
+ * @param {string} recomendacionBase
+ * @returns {string}
+ */
 export function modularPorENSO(faseENSO, recomendacionBase) {
   if (!faseENSO || !ENSO[faseENSO]) return recomendacionBase;
   const m = ENSO[faseENSO];

--- a/src/services/iotCostCalculator.js
+++ b/src/services/iotCostCalculator.js
@@ -1,5 +1,13 @@
 import HARDWARE from '../data/iot-hardware.json';
 
+/**
+ * Estima el costo de hardware IoT para una finca.
+ * @param {object} [opciones]
+ * @param {boolean} [opciones.incluirCamara=true]
+ * @param {boolean} [opciones.incluirSHT30=true]
+ * @param {string} [opciones.bateria='18650']
+ * @returns {object}
+ */
 export function estimarCostoIoT({ incluirCamara = true, incluirSHT30 = true, bateria = '18650' } = {}) {
   const costos = { hardware: 0, recurrente_mensual: 21000 };
   if (incluirCamara) costos.hardware += 80000;

--- a/src/services/iotValeLaPena.js
+++ b/src/services/iotValeLaPena.js
@@ -1,5 +1,15 @@
 import VT from '../data/iot-vale-la-pena.json';
 
+/**
+ * Evalua si vale la pena instalar IoT segun condiciones de la finca.
+ * @param {object} [condiciones]
+ * @param {boolean} [condiciones.visitaDiaria]
+ * @param {boolean} [condiciones.altoValor]
+ * @param {number} [condiciones.presupuesto]
+ * @param {boolean} [condiciones.coberturaCelular]
+ * @param {boolean} [condiciones.quiereAutomatizar]
+ * @returns {{vale: boolean, razon: string, costo?: string}}
+ */
 export function valeLaPenaIoT({ visitaDiaria, altoValor, presupuesto, coberturaCelular, quiereAutomatizar } = {}) {
   if (quiereAutomatizar) return { vale: false, razon: VT.no_vale_la_pena_si[3] };
   if (!coberturaCelular) return { vale: false, razon: VT.no_vale_la_pena_si[4] };

--- a/src/services/pageReload.js
+++ b/src/services/pageReload.js
@@ -5,6 +5,11 @@
  * o redefinir en vitest. Esta indirección permite a los tests mockear la
  * recarga (vi.mock) sin tocar el comportamiento en producción.
  */
+/**
+ * Recarga la pagina actual. Existe como indireccion para que los tests
+ * puedan mockearla sin tocar el comportamiento en produccion.
+ * @returns {void}
+ */
 export function reloadPage() {
   window.location.reload();
 }

--- a/src/services/pisoTermicoClassifier.js
+++ b/src/services/pisoTermicoClassifier.js
@@ -1,5 +1,10 @@
 import PISOS from '../data/piso-termico.json';
 
+/**
+ * Clasifica el piso termico colombiano segun altitud.
+ * @param {number} altitudMsnm
+ * @returns {object|null}
+ */
 export function clasificarPisoTermico(altitudMsnm) {
   if (typeof altitudMsnm !== 'number' || altitudMsnm < 0) return null;
   const piso = PISOS.pisos.find((p) => {

--- a/src/services/psaElegibilidad.js
+++ b/src/services/psaElegibilidad.js
@@ -1,5 +1,14 @@
 import PSA from '../data/psa.json';
 
+/**
+ * Evalua elegibilidad para Pago por Servicios Ambientales.
+ * @param {object} [perfil]
+ * @param {number} [perfil.altitud]
+ * @param {boolean} [perfil.enCuenca]
+ * @param {boolean} [perfil.enParamo]
+ * @param {string} [perfil.interes]
+ * @returns {{elegible: boolean, modalidades: Array, requisitos: Array, monto: string, autoridad: string}}
+ */
 export function evaluarPSA(perfil = {}) {
   const { altitud, enCuenca, enParamo, interes } = perfil;
   const modalidades = [];

--- a/src/services/restauracionRecetaFormatter.js
+++ b/src/services/restauracionRecetaFormatter.js
@@ -1,3 +1,8 @@
+/**
+ * Formatea un diagnostico de restauracion en texto legible.
+ * @param {object|null} diagnostico
+ * @returns {string}
+ */
 export function formatearRecetaAgroecologica(diagnostico) {
   if (!diagnostico || diagnostico.sin_datos) return '';
   const p = [];

--- a/src/services/socialPrefiltro.js
+++ b/src/services/socialPrefiltro.js
@@ -1,8 +1,11 @@
-import { expandQueryTokens } from './ragSynonyms';
-
 const PALABRAS_PELIGROSAS = ['glifosato', 'paraquat', 'clorpirifos', 'urea_pura', 'cal_viva', 'formalina', 'arsenico'];
 const MITOS_BLOQUEABLES = ['vinagre.*ph', 'bicarbonato.*ph', 'luna.*sembrar', 'luna.*regar', 'varilla.*agua', 'pendulo.*agua'];
 
+/**
+ * Prefiltro de seguridad que bloquea palabras peligrosas y mitos.
+ * @param {string|null} texto
+ * @returns {{pasar: boolean, razon?: string, severidad?: string}}
+ */
 export function preFiltroSocial(texto) {
   if (!texto) return { pasar: false, razon: 'vacio' };
   const t = texto.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');

--- a/src/services/subgrafoToText.js
+++ b/src/services/subgrafoToText.js
@@ -1,3 +1,8 @@
+/**
+ * Convierte un subgrafo (nodos + relaciones) a texto llano para el campesino.
+ * @param {object|null} subgrafo
+ * @returns {string}
+ */
 export function subgrafoATextoCampesino(subgrafo) {
   if (!subgrafo?.nodes?.length) return '';
   const partes = [];

--- a/src/utils/biodiversityStats.js
+++ b/src/utils/biodiversityStats.js
@@ -31,6 +31,9 @@ const FIELD_RE = (key) => new RegExp(`${key}:\\s*([^|]+?)\\s*(?:\\||$)`, 'i');
  * Normaliza un string para matching: lowercase + sin tildes + trim.
  * Quita además sufijos del tipo "#001" usados en siembras bulk-individual,
  * porque el catálogo nunca los lleva ("Gulupa #003" → "gulupa").
+ *
+ * @param {string} s - String a normalizar.
+ * @returns {string} String normalizado (vacío si la entrada no es string válido).
  */
 export const normalizeForMatch = (s) => {
   if (!s || typeof s !== 'string') return '';
@@ -54,8 +57,11 @@ export const normalizeForMatch = (s) => {
  *     SpeciesSelect deja en attributes.name al elegir desde el fuzzy search.
  *   - nombre_cientifico normalizado
  *
- * Múltiples plants pueden share el mismo display name, pero el índice resuelve
+ * Múltiples plants pueden sharear el mismo display name, pero el índice resuelve
  * uno a uno gracias a estas variantes redundantes.
+ *
+ * @param {Array} allSpecies - Array de especies del catálogo (formato getAllSpecies()).
+ * @returns {Map<string, object>} Mapa de nombre normalizado a objeto especie.
  */
 export const buildSpeciesIndex = (allSpecies) => {
   const index = new Map();
@@ -111,6 +117,10 @@ const lookupSpecies = (plant, speciesIndex) => {
  *
  * Devuelve `{ estrato, gremio }` con strings normalizados (lowercase) o
  * `null` por campo si no se pudo resolver.
+ *
+ * @param {object} plant - Asset planta con attributes.name y attributes.notes.
+ * @param {Map} speciesIndex - Índice de especies construido por buildSpeciesIndex().
+ * @returns {{ estrato: string|null, gremio: string|null }} Rasgos resueltos desde catálogo o notes.
  */
 export const resolvePlantTraits = (plant, speciesIndex) => {
   const sp = lookupSpecies(plant, speciesIndex);

--- a/src/utils/entityMatcher.js
+++ b/src/utils/entityMatcher.js
@@ -10,6 +10,13 @@
  *   - Devuelve score 0..1 normalizado, no ranking interno.
  */
 
+/**
+ * Normaliza un string para matching fuzzy: lowercase, sin tildes,
+ * colapsa whitespace múltiple y recorta bordes.
+ *
+ * @param {string} s - String a normalizar.
+ * @returns {string} String normalizado (vacío si la entrada es falsy).
+ */
 export const normalize = (s) =>
   (s || '')
     .toLowerCase()
@@ -42,6 +49,10 @@ const levenshtein = (a, b) => {
  * - 1.0 si son iguales tras normalizar.
  * - 0.7..1.0 si uno contiene al otro (bonus por substring).
  * - sino, 1 - levenshtein / max(len).
+ *
+ * @param {string} a - Primer string a comparar.
+ * @param {string} b - Segundo string a comparar.
+ * @returns {number} Score de similaridad entre 0 y 1.
  */
 export const similarity = (a, b) => {
   const na = normalize(a);

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -22,6 +22,13 @@ const coordToWkt = ([lon, lat]) => `${fmt(lon)} ${fmt(lat)}`;
 
 const ringToWkt = (ring) => `(${ring.map(coordToWkt).join(', ')})`;
 
+/**
+ * Convierte una geometría GeoJSON a string WKT (Well-Known Text) para
+ * serialización hacia FarmOS. Soporta Point, Polygon y MultiPolygon.
+ *
+ * @param {object} geometry - Geometría GeoJSON con type y coordinates.
+ * @returns {string} Representación WKT, o string vacío si el tipo no está soportado.
+ */
 export const geoJsonToWkt = (geometry) => {
   if (!geometry || !geometry.type) return '';
 
@@ -49,7 +56,13 @@ export const geoJsonToWkt = (geometry) => {
   }
 };
 
-// Cierra un ring abierto (añade el primer punto al final si falta).
+/**
+ * Cierra un ring abierto añadiendo el primer punto al final si el anillo
+ * no está ya cerrado (primer y último punto distintos).
+ *
+ * @param {Array<[number, number]>} ring - Array de coordenadas [lon, lat].
+ * @returns {Array<[number, number]>} Ring cerrado (copia si fue necesario cerrar).
+ */
 export const closeRing = (ring) => {
   if (ring.length < 3) return ring;
   const [first] = ring;
@@ -58,13 +71,25 @@ export const closeRing = (ring) => {
   return [...ring, first];
 };
 
-// Construye una Feature GeoJSON desde coordenadas de Leaflet.
-// Leaflet entrega LatLng: { lat, lng }. GeoJSON espera [lon, lat].
+/**
+ * Construye un GeoJSON Point Feature desde coordenadas de Leaflet.
+ * Leaflet entrega LatLng: { lat, lng }. GeoJSON espera [lon, lat].
+ *
+ * @param {{ lat: number, lng: number }} latlng - Coordenada Leaflet.
+ * @returns {{ type: 'Point', coordinates: [number, number] }} GeoJSON Point.
+ */
 export const latLngToPoint = (latlng) => ({
   type: 'Point',
   coordinates: [latlng.lng, latlng.lat],
 });
 
+/**
+ * Construye un GeoJSON Polygon desde un array de coordenadas Leaflet.
+ * Cierra el anillo automáticamente vía closeRing.
+ *
+ * @param {Array<{ lat: number, lng: number }>} latlngs - Array de coordenadas Leaflet.
+ * @returns {{ type: 'Polygon', coordinates: [[number, number]] }} GeoJSON Polygon.
+ */
 export const latLngsToPolygon = (latlngs) => {
   const ring = latlngs.map((ll) => [ll.lng, ll.lat]);
   return {
@@ -73,8 +98,13 @@ export const latLngsToPolygon = (latlngs) => {
   };
 };
 
-// Parsea un WKT simple (POINT o POLYGON) de vuelta a GeoJSON para renderizar
-// geometrías existentes que llegan del servidor.
+/**
+ * Parsea un WKT simple (POINT o POLYGON) de vuelta a GeoJSON para renderizar
+ * geometrías existentes que llegan del servidor.
+ *
+ * @param {string} wkt - String WKT a parsear.
+ * @returns {object|null} Geometría GeoJSON con type y coordinates, o null si no se pudo parsear.
+ */
 export const wktToGeoJson = (wkt) => {
   if (!wkt || typeof wkt !== 'string') return null;
   const trimmed = wkt.trim().toUpperCase();

--- a/src/utils/landTypes.js
+++ b/src/utils/landTypes.js
@@ -33,4 +33,11 @@ export const URBAN_LAND_TYPES = new Set(
   LAND_TYPES.filter((lt) => lt.urban).map((lt) => lt.value)
 );
 
+/**
+ * Determina si el valor de tipo de terreno pertenece al subset urbano
+ * (balcón, terraza, ventana, matera interior, jardín urbano).
+ *
+ * @param {string} landType - Valor de tipo de terreno (ej. 'balcony').
+ * @returns {boolean} true si es un tipo urbano.
+ */
 export const isUrbanLandType = (landType) => URBAN_LAND_TYPES.has(landType);

--- a/src/utils/skyEphemeris.js
+++ b/src/utils/skyEphemeris.js
@@ -169,7 +169,10 @@ export function moonPathD(fraction, cx = 32, cy = 32, r = 13) {
 }
 
 /**
- * Formatea una fecha como HH:MM en hora local (24h).
+ * Formatea una fecha como HH:MM en hora local (24h) usando locale es-CO.
+ *
+ * @param {Date|null} date - Fecha a formatear.
+ * @returns {string} Hora formateada "HH:MM" o "—" si date es nulo.
  */
 export function formatLocalHM(date) {
   if (!date) return '—';
@@ -181,7 +184,10 @@ export function formatLocalHM(date) {
 }
 
 /**
- * Formatea minutos como "Xh Ym".
+ * Formatea minutos como "Xh YYm" (ej. "12h 30m").
+ *
+ * @param {number} minutes - Duración en minutos.
+ * @returns {string} Duración formateada o "—" si el valor no es finito/positivo.
  */
 export function formatDayLength(minutes) {
   if (!Number.isFinite(minutes) || minutes <= 0) return '—';

--- a/src/utils/spatialAnalysis.js
+++ b/src/utils/spatialAnalysis.js
@@ -11,7 +11,12 @@ const EARTH_RADIUS_M = 6_371_000;
 const toRad = (deg) => (deg * Math.PI) / 180;
 
 /**
- * Distancia Haversine entre dos puntos [lon, lat] en metros.
+ * Distancia Haversine entre dos puntos [lon, lat] en metros usando el
+ * radio medio terrestre (6,371 km).
+ *
+ * @param {[number, number]} param0 - Primer punto [lon, lat].
+ * @param {[number, number]} param1 - Segundo punto [lon, lat].
+ * @returns {number} Distancia en metros.
  */
 export const haversineDistance = ([lon1, lat1], [lon2, lat2]) => {
   const dLat = toRad(lat2 - lat1);
@@ -25,6 +30,9 @@ export const haversineDistance = ([lon1, lat1], [lon2, lat2]) => {
 /**
  * Extrae coordenadas [lon, lat] de un GeoJSON Point o del centroide de un Polygon.
  * Retorna null si no se puede resolver.
+ *
+ * @param {object} geometry - Geometría GeoJSON (Point o Polygon).
+ * @returns {[number, number]|null} Coordenadas [lon, lat] o null.
  */
 export const getCoords = (geometry) => {
   if (!geometry) return null;
@@ -40,11 +48,11 @@ export const getCoords = (geometry) => {
 
 /**
  * Verifica la distancia entre la posición GPS del dispositivo y una geometría.
- * Retorna { distance: number (metros), isClose: boolean }.
  *
- * @param {GeolocationPosition} gpsPosition — navigator.geolocation result
- * @param {object} geometry — GeoJSON
- * @param {number} threshold — umbral en metros (default 50)
+ * @param {GeolocationPosition} gpsPosition - Resultado de navigator.geolocation.
+ * @param {object} geometry - Geometría GeoJSON.
+ * @param {number} [threshold=50] - Umbral en metros.
+ * @returns {{ distance: number, isClose: boolean }} Distancia redondeada en metros y si está dentro del umbral.
  */
 export const proximityCheck = (gpsPosition, geometry, threshold = 50) => {
   /** @type {[number, number]} */


### PR DESCRIPTION
## Tarea 3 — JSDoc en exports sin documentar

Agrega bloques JSDoc (`@param`, `@returns`, `@description`) a funciones exportadas sin documentacion.

### src/utils/ (6 archivos, 16 funciones)
- biodiversityStats: normalizeForMatch, buildSpeciesIndex, resolvePlantTraits
- entityMatcher: normalize, similarity
- geo: geoJsonToWkt, closeRing, latLngToPoint, latLngsToPolygon, wktToGeoJson
- landTypes: isUrbanLandType
- skyEphemeris: formatLocalHM, formatDayLength
- spatialAnalysis: haversineDistance, getCoords, proximityCheck

### src/services/ (14 archivos, 18 funciones)
- biodiversidadMonitor, carbonoAlerta, ensoModulador, ensoContext
- iotCostCalculator, iotValeLaPena, pisoTermicoClassifier
- psaElegibilidad, restauracionRecetaFormatter, socialPrefiltro
- subgrafoToText, pageReload, agentPromptBase (analyzeQuery)
- animalDiagnostic (4 exports)

### Nota adicional
Removido import no usado `expandQueryTokens` en socialPrefiltro.js (pre-existente).

Sin cambios de logica. ESLint limpio.