### PR TITLE
chore(imports): remueve import no usado expandQueryTokens

### DIFF
--- a/src/services/socialPrefiltro.js
+++ b/src/services/socialPrefiltro.js
@@ -1,5 +1,3 @@
-import { expandQueryTokens } from './ragSynonyms';
-
 const PALABRAS_PELIGROSAS = ['glifosato', 'paraquat', 'clorpirifos', 'urea_pura', 'cal_viva', 'formalina', 'arsenico'];
 const MITOS_BLOQUEABLES = ['vinagre.*ph', 'bicarbonato.*ph', 'luna.*sembrar', 'luna.*regar', 'varilla.*agua', 'pendulo.*agua'];
 


### PR DESCRIPTION
## Tarea 5 — Limpieza de dead imports

Unico dead import detectado por eslint `no-unused-vars` en todo `src/`:

- `socialPrefiltro.js`: removido `import { expandQueryTokens } from './ragSynonyms'` (no usado en el modulo)

Barrido completo de `src/` con eslint `no-unused-vars`, sin mas hallazgos. Sin cambios de comportamiento.