### PR TITLE
chore: elimina dead code - imports/export/privados sin uso

### DIFF
--- a/src/constants/assetStatuses.js
+++ b/src/constants/assetStatuses.js
@@ -32,7 +32,7 @@ export const STATUS_MAP = {
     pest: PEST_STATUSES
 };
 
-export const STATUS_DEFAULT_FOR_TYPE = {
+const STATUS_DEFAULT_FOR_TYPE = {
     'asset--plant': 'growing',
     'log--maintenance': 'pending',
     'log--seeding': 'completed',

--- a/src/data/cropSuggestions.js
+++ b/src/data/cropSuggestions.js
@@ -283,4 +283,4 @@ export function buildCropSuggestions(plants, opts = {}) {
   return suggestions;
 }
 
-export const __CROP_RULES__ = CROP_RULES;
+// (__CROP_RULES__ — no exportado: sin referencias externas)

--- a/src/data/glaciar-schema.js
+++ b/src/data/glaciar-schema.js
@@ -99,7 +99,7 @@ export const ESCALA_DUREZA = [
 /** Códigos de dureza "blanda" (la mano todavía entra). Útil para reglas. */
 export const DUREZAS_BLANDAS = Object.freeze(['F', '4F']);
 /** Códigos de dureza de hielo (ya no entra la mano, se prueba con piolet). */
-export const DUREZAS_HIELO = Object.freeze(['H1', 'H2']);
+const DUREZAS_HIELO = Object.freeze(['H1', 'H2']);
 
 /* ── Tipo de superficie del hielo/nieve (7) ──────────────────────────────
  * Cada tipo trae una implicación de seguridad corta (qué significa para el

--- a/src/services/socialPrefiltro.js
+++ b/src/services/socialPrefiltro.js
@@ -1,5 +1,3 @@
-import { expandQueryTokens } from './ragSynonyms';
-
 const PALABRAS_PELIGROSAS = ['glifosato', 'paraquat', 'clorpirifos', 'urea_pura', 'cal_viva', 'formalina', 'arsenico'];
 const MITOS_BLOQUEABLES = ['vinagre.*ph', 'bicarbonato.*ph', 'luna.*sembrar', 'luna.*regar', 'varilla.*agua', 'pendulo.*agua'];
 

--- a/src/utils/biodiversityStats.js
+++ b/src/utils/biodiversityStats.js
@@ -184,4 +184,4 @@ export const computeBiodiversityStats = (plants, speciesIndex) => {
   };
 };
 
-export const __STRATA_KEYS__ = STRATA_KEYS;
+// (__STRATA_KEYS__ — no exportado: sin referencias externas)

--- a/src/utils/taskCompletionParser.js
+++ b/src/utils/taskCompletionParser.js
@@ -26,13 +26,4 @@ export function getCompletedTaskIds(logs) {
     return completedIds;
 }
 
-/**
- * Parsea el veredicto de un log de completado.
- * @param {string} notes - Notas del log.
- * @returns {string|null} 'completed', 'cancelled', 'rescheduled' o null.
- */
-export function parseVerdict(notes) {
-    if (!notes.includes('[TASK_COMPLETION]')) return null;
-    const match = notes.match(/verdict:\s*([a-z]+)/);
-    return match ? match[1] : null;
-}
+// parseVerdict removido — sin referencias internas ni externas.


### PR DESCRIPTION
## Tarea 7 — Dead code sweep ampliado

Remueve codigo muerto en **6 archivos** tras verificacion con grep en todo el repo:

| Archivo | Removido | Justificacion |
|---------|----------|---------------|
| `socialPrefiltro.js` | `import { expandQueryTokens }` | 0 referencias en el archivo |
| `taskCompletionParser.js` | `parseVerdict()` completo | 0 referencias internas ni externas |
| `biodiversityStats.js` | `export const __STRATA_KEYS__` | alias muerto, 0 refs |
| `cropSuggestions.js` | `export const __CROP_RULES__` | alias muerto, 0 refs |
| `glaciar-schema.js` | `export` de `DUREZAS_HIELO` | 0 referencias externas |
| `assetStatuses.js` | `export` de `STATUS_DEFAULT_FOR_TYPE` | 0 referencias externas |

Cada item verificado con `grep -r` en todo `src/` y `tests/`.
ESLint limpio, boundary audit OK.