### PR TITLE
fix(a11y): agrega aria-labels, roles, y labels parte 2

### DIFF
--- a/src/components/ActionConfirmModal.jsx
+++ b/src/components/ActionConfirmModal.jsx
@@ -93,8 +93,9 @@ export default function ActionConfirmModal({
               <div className="space-y-2">
                 {Object.entries(editedParams).map(([key, value]) => (
                   <div key={key} className="flex flex-col">
-                    <label className="text-xs text-slate-500 mb-1">{key}</label>
+                    <label htmlFor={`action-param-${key}`} className="text-xs text-slate-500 mb-1">{key}</label>
                     <input
+                      id={`action-param-${key}`}
                       type={typeof value === 'number' ? 'number' : 'text'}
                       value={value || ''}
                       onChange={(e) =>

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -96,6 +96,8 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
       <div
         ref={scrollRef}
         onScroll={handleScroll}
+        role="log"
+        aria-live="polite"
         data-testid="chat-scroll"
         className="h-full overflow-y-auto p-4 pb-28"
       >

--- a/src/components/CaseStudyDetail.jsx
+++ b/src/components/CaseStudyDetail.jsx
@@ -134,6 +134,7 @@ const TimelineEventForm = ({ onSubmit, onCancel }) => {
         </select>
         <input
           type="datetime-local"
+          aria-label="Fecha del evento"
           value={date}
           onChange={(e) => setDate(e.target.value)}
           className="px-3 py-2 rounded bg-slate-800 border border-slate-700 text-white text-sm"

--- a/src/components/PlanEditor.jsx
+++ b/src/components/PlanEditor.jsx
@@ -142,9 +142,10 @@ export default function PlanEditor({ assetId, speciesSlug, plantingDate, climate
 
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-gray-700 mt-1">
                                 <div className="flex items-center">
-                                    <span className="font-medium w-24">Insumo:</span>
+                                    <label htmlFor="plan-insumo" className="font-medium w-24">Insumo:</label>
                                     {isAdvisor && !isCompleted ? (
                                         <input
+                                            id="plan-insumo"
                                             type="text"
                                             className="ml-2 border rounded px-2 py-1 w-full max-w-[150px] shadow-inner"
                                             defaultValue={step.biofertilizer_slug}
@@ -158,9 +159,10 @@ export default function PlanEditor({ assetId, speciesSlug, plantingDate, climate
                                     )}
                                 </div>
                                 <div className="flex items-center">
-                                    <span className="font-medium w-24">Dosis (ml):</span>
+                                    <label htmlFor="plan-dosis" className="font-medium w-24">Dosis (ml):</label>
                                     {isAdvisor && !isCompleted ? (
                                         <input
+                                            id="plan-dosis"
                                             type="number"
                                             className="ml-2 border rounded px-2 py-1 flex-grow max-w-[100px] shadow-inner"
                                             defaultValue={step.dose_ml}

--- a/src/components/SplitFlow.jsx
+++ b/src/components/SplitFlow.jsx
@@ -44,7 +44,7 @@ export const SplitFlow = ({ asset, onClose }) => {
     };
 
     return (
-        <div className="fixed inset-0 z-[60] bg-slate-950/90 backdrop-blur-md flex flex-col p-6 animate-in fade-in duration-300">
+        <div className="fixed inset-0 z-[60] bg-slate-950/90 backdrop-blur-md flex flex-col p-6 animate-in fade-in duration-300" role="dialog" aria-modal="true" aria-label="Dividir activo">
             <div className="flex justify-between items-center mb-8">
                 <h2 className="text-xl font-bold text-white flex items-center gap-2">
                     <Layers className="text-emerald-400" />

--- a/src/components/TaskScreen.jsx
+++ b/src/components/TaskScreen.jsx
@@ -114,6 +114,7 @@ function TaskScreen({ onBack, onSave, initialData }) {
             <header className="p-4 sticky top-0 bg-slate-950/80 backdrop-blur-md border-b border-slate-800 flex items-center gap-4 z-10 shrink-0 shadow-lg">
                 <button
                     onClick={onBack}
+                    aria-label="Volver"
                     className="p-3 bg-slate-800 rounded-full active:bg-slate-700 min-h-[56px] min-w-[56px] flex justify-center items-center shrink-0 border border-slate-700"
                 >
                     <ArrowLeft size={32} />


### PR DESCRIPTION
## Tarea 9 — Accesibilidad parte 2

Corrige accesibilidad en **6 componentes**:

| Componente | Correccion |
|-----------|-----------|
| TaskScreen | `aria-label="Volver"` en boton back icono-solo |
| SplitFlow | `role="dialog"` + `aria-modal="true"` en overlay full-screen |
| PlanEditor | `<label htmlFor>` + `id` en inputs de Insumo y Dosis |
| CaseStudyDetail | `aria-label="Fecha del evento"` en datetime input |
| ActionConfirmModal | `htmlFor` en label + `id` en input dinamico |
| ChatHistory | `role="log"` + `aria-live="polite"` en contenedor de mensajes |

ESLint limpio, boundary audit OK.