### PR TITLE
chore: elimina dead code remanente en componentes

### DIFF
--- a/src/components/PhotoViewer.jsx
+++ b/src/components/PhotoViewer.jsx
@@ -8,7 +8,6 @@ export default function PhotoViewer({
   className = '',
   children,
   calloutOverlay,
-  onClose,
 }) {
   const { isCinema, toggleCinema } = useCinemaMode();
   const [showCallouts, setShowCallouts] = useState(true);

--- a/src/components/common/AIStreamPanel.jsx
+++ b/src/components/common/AIStreamPanel.jsx
@@ -53,7 +53,6 @@ export default function AIStreamPanel({
       // Set inicial sincrónico está acotado: sólo se ejecuta cuando active
       // pasa de true→false con texto presente, y la condición prevActive
       // garantiza que no se re-dispare en el siguiente render.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setClosingPhase('closing');
       const closingTimer = setTimeout(() => {
         setClosingPhase('finished');


### PR DESCRIPTION
## Tarea 15 — Dead code parte 3

Barrido final de todo `src/` (420 archivos). Remueve 2 items:

- `PhotoViewer.jsx`: prop `onClose` sin uso en el componente
- `AIStreamPanel.jsx`: eslint-disable directive huerfana

El resto de `src/` esta limpio de dead imports/variables/exports.
ESLint limpio, boundary audit OK.