### PR TITLE
test(bench): corrida model-compare 2026-06-15 (datos de tendencia)

### DIFF
--- a/bench/history/model-compare__granite3.1-dense-8b__2026-06-15T23-35-58-796Z.json
+++ b/bench/history/model-compare__granite3.1-dense-8b__2026-06-15T23-35-58-796Z.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "bench": "model-compare",
+  "date": "2026-06-15T23:35:58.796Z",
+  "model": "granite3.1-dense:8b",
+  "config": "qwen3-vs-granite",
+  "commit": "006993a",
+  "metrics": {
+    "keywords_pct": 30,
+    "latency_avg_ms": 23848
+  },
+  "passCount": null,
+  "failCount": null,
+  "passPct": null,
+  "notes": "",
+  "seed": false
+}

--- a/bench/history/model-compare__qwen2.5-14b__2026-06-15T23-35-58-791Z.json
+++ b/bench/history/model-compare__qwen2.5-14b__2026-06-15T23-35-58-791Z.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "bench": "model-compare",
+  "date": "2026-06-15T23:35:58.791Z",
+  "model": "qwen2.5:14b",
+  "config": "qwen3-vs-granite",
+  "commit": "006993a",
+  "metrics": {
+    "keywords_pct": 0,
+    "latency_avg_ms": 0
+  },
+  "passCount": null,
+  "failCount": null,
+  "passPct": null,
+  "notes": "",
+  "seed": false
+}


### PR DESCRIPTION
2 entradas nuevas de `bench/history/` de la corrida directa de hoy (GLM agotado). granite3.1-dense 20/20; qwen2.5:14b 0/20 (14b no corre en M6000). Alimenta la tendencia del dashboard de bench. Solo datos, sin código.