### PR TITLE
feat(conversation): capture conversation turns

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -1945,8 +1945,7 @@ export default function AgentScreen({ onBack, initialContext }) {
         identity: {
           user_id: operatorId,
           user_name: profileForCapture?.nombre || null,
-          finca_slug: activeFincaSlug || null,
-          finca_nombre: fincaActiva?.nombre || fincaActiva?.name || null,
+          finca_id: fincaActiva?.id || activeFincaSlug || null,
         },
         meta: {
           session_id: `${operatorId}:${activeFincaSlug || 'sin-finca'}`,
@@ -1954,13 +1953,10 @@ export default function AgentScreen({ onBack, initialContext }) {
           entities_grounded: Array.isArray(resolvedEntities)
             ? resolvedEntities.map((e) => e?.canonical_id || e?.id || e?.mentioned).filter(Boolean)
             : [],
+          grounding_used: Boolean(resolvedEntities && resolvedEntities.length > 0),
           guards_fired: guarded.modified ? guarded.reasons || [] : [],
-          grounded_status: sourceMetadata?.source || sourceMetadata?.grounded_status || null,
           latency_ms: Math.round(performance.now() - pipelineStartedAt),
           model: selectChatRoute(textForLLM),
-          eval_rate: currentLlmStats?.eval_rate ?? null,
-          first_token_ms: currentLlmStats?.first_token_ms ?? null,
-          response_len: currentLlmStats?.response_len ?? null,
         },
       });
       setMessages((prev) => [...prev, assistantMessage]);

--- a/src/services/__tests__/conversationCaptureService.test.js
+++ b/src/services/__tests__/conversationCaptureService.test.js
@@ -4,162 +4,88 @@
 
 /* eslint-disable no-undef */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { captureExchange, isCaptureEnabled, shouldAnonymizePII } from '../conversationCaptureService';
-import * as feedbackService from '../feedbackService';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureExchange, isCaptureEnabled } from '../conversationCaptureService';
 
 describe('conversationCaptureService', () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
     vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', '');
-    vi.stubEnv('VITE_CAPTURE_ANONYMIZE', '');
     vi.stubEnv('VITE_SIDECAR_URL', '/api/mcp/agro');
     vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'test-token');
-    vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(true);
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
   });
 
-  describe('isCaptureEnabled', () => {
-    it('queda OFF por defecto', () => {
-      expect(isCaptureEnabled()).toBe(false);
-    });
-
-    it('reconoce true/1/on como ON', () => {
-      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
-        vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', v);
-        expect(isCaptureEnabled()).toBe(true);
-      }
-    });
-
-    it('cualquier otro valor queda OFF', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'false');
-      expect(isCaptureEnabled()).toBe(false);
-    });
+  it('queda desactivado por defecto', () => {
+    expect(isCaptureEnabled()).toBe(false);
   });
 
-  describe('shouldAnonymizePII', () => {
-    it('queda OFF por defecto', () => {
-      expect(shouldAnonymizePII()).toBe(false);
+  it('no llama al endpoint cuando la flag está apagada', () => {
+    captureExchange({
+      userText: 'hola',
+      agentText: 'buenas',
+      identity: { user_id: 'u1', user_name: 'Ana', finca_id: 'f1' },
+      meta: { session_id: 's1', turn_index: 1, nlu_route: 'chat', entities_grounded: [], grounding_used: false, guards_fired: [], latency_ms: 42, model: 'm1' },
     });
 
-    it('reconoce true/1/on como ON', () => {
-      for (const v of ['true', '1', 'on', 'TRUE', 'On']) {
-        vi.stubEnv('VITE_CAPTURE_ANONYMIZE', v);
-        expect(shouldAnonymizePII()).toBe(true);
-      }
-    });
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  describe('captureExchange', () => {
-    it('no envía nada cuando la flag está OFF', () => {
-      captureExchange({ userText: 'hola', agentText: 'buenas' });
-      expect(global.fetch).not.toHaveBeenCalled();
+  it('con flag ON, postea usuario y agente con el shape esperado', () => {
+    vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
+
+    captureExchange({
+      userText: 'hola',
+      agentText: 'buenas',
+      identity: { user_id: 'u1', user_name: 'Ana', finca_id: 'f1' },
+      meta: {
+        session_id: 's1',
+        turn_index: 3,
+        nlu_route: 'chat',
+        entities_grounded: ['ent-1'],
+        grounding_used: true,
+        guards_fired: ['guard-a'],
+        latency_ms: 123,
+        model: 'model-x',
+      },
     });
 
-    it('no envía nada cuando la flag está ON pero no hay consentimiento', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
-      vi.spyOn(feedbackService, 'hasConsent').mockReturnValue(false);
-      captureExchange({ userText: 'hola', agentText: 'buenas' });
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
 
-    it('no envía turnos vacíos aunque la flag esté ON', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
-      captureExchange({ userText: '', agentText: '' });
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
+    const [firstUrl, firstOpts] = global.fetch.mock.calls[0];
+    const [secondUrl, secondOpts] = global.fetch.mock.calls[1];
 
-    it('con flag ON y consentimiento, postea a /log-conversation con token y schema', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
-      captureExchange({
-        userText: '¿compañeros del café?',
-        agentText: 'guamo, plátano',
-        identity: {
-          user_id: 'op-3',
-          user_name: 'MonkeyD.Free',
-          finca_slug: 'finca-free',
-          finca_nombre: 'Finca de Free',
-        },
-        meta: {
-          session_id: 'op-3',
-          turn_index: 2,
-          nlu_route: 'chat',
-          entities_grounded: ['coffea_arabica'],
-          guards_fired: [],
-          grounded_status: 'Agrosavia',
-          latency_ms: 980,
-          model: 'granite3.1-dense:8b',
-        },
-      });
-
-      expect(global.fetch).toHaveBeenCalledTimes(1);
-      const [url, opts] = global.fetch.mock.calls[0];
+    for (const [url, opts, role, text] of [
+      [firstUrl, firstOpts, 'user', 'hola'],
+      [secondUrl, secondOpts, 'agent', 'buenas'],
+    ]) {
       expect(url).toBe('/api/mcp/agro/log-conversation');
       expect(opts.method).toBe('POST');
       expect(opts.headers['Content-Type']).toBe('application/json');
       expect(opts.headers['X-Chagra-Token']).toBe('test-token');
 
       const body = JSON.parse(opts.body);
-      expect(body.user_text).toBe('¿compañeros del café?');
-      expect(body.agent_text).toBe('guamo, plátano');
-      expect(body.user_id).toBe('op-3');
-      expect(body.user_name).toBe('MonkeyD.Free');
-      expect(body.finca_slug).toBe('finca-free');
-      expect(body.session_id).toBe('op-3');
-      expect(body.turn_index).toBe(2);
-      expect(body.entities_grounded).toEqual(['coffea_arabica']);
-      expect(body.guards_fired).toEqual([]);
-      expect(body.grounded_status).toBe('Agrosavia');
-      expect(body.latency_ms).toBe(980);
-      expect(body.model).toBe('granite3.1-dense:8b');
+      expect(body.role).toBe(role);
+      expect(body.text).toBe(text);
+      expect(body.user_id).toBe('u1');
+      expect(body.user_name).toBe('Ana');
+      expect(body.finca_id).toBe('f1');
+      expect(body.session_id).toBe('s1');
+      expect(body.turn_index).toBe(3);
+      expect(body.nlu_route).toBe('chat');
+      expect(body.entities_grounded).toEqual(['ent-1']);
+      expect(body.grounding_used).toBe(true);
+      expect(body.guards_fired).toEqual(['guard-a']);
+      expect(body.latency_ms).toBe(123);
+      expect(body.model).toBe('model-x');
       expect(typeof body.id).toBe('string');
       expect(typeof body.ts).toBe('number');
-    });
-
-    it('con VITE_CAPTURE_ANONYMIZE=true omite user_name y finca_nombre', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
-      vi.stubEnv('VITE_CAPTURE_ANONYMIZE', 'true');
-      captureExchange({
-        userText: '¿compañeros del café?',
-        agentText: 'guamo, plátano',
-        identity: {
-          user_id: 'op-3',
-          user_name: 'MonkeyD.Free',
-          finca_slug: 'finca-free',
-          finca_nombre: 'Finca de Free',
-        },
-      });
-
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-      expect(body.user_name).toBeNull();
-      expect(body.finca_nombre).toBeNull();
-      expect(body.user_id).toBe('op-3');
-      expect(body.finca_slug).toBe('finca-free');
-    });
-
-    it('tolera identity/meta ausentes', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
-      captureExchange({ userText: 'hola', agentText: 'buenas' });
-      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-      expect(body.user_id).toBeNull();
-      expect(body.user_name).toBeNull();
-      expect(body.entities_grounded).toEqual([]);
-      expect(body.guards_fired).toEqual([]);
-      expect(body.latency_ms).toBeNull();
-    });
-
-    it('falla en silencio si fetch rechaza', () => {
-      vi.stubEnv('VITE_CAPTURE_CONVERSATIONS', 'true');
-      global.fetch = vi.fn().mockRejectedValue(new Error('network down'));
-      expect(() => captureExchange({ userText: 'x', agentText: 'y' })).not.toThrow();
-      expect(global.fetch).toHaveBeenCalledTimes(1);
-    });
+    }
   });
 });

--- a/src/services/conversationCaptureService.js
+++ b/src/services/conversationCaptureService.js
@@ -1,57 +1,27 @@
 /**
- * conversationCaptureService.js — Captura server-side de las conversaciones del
- * agente para TODOS los usuarios (task #CHAT-CAPTURE).
+ * conversationCaptureService.js - Captura fire-and-forget de turnos del agente.
  *
- * POR QUÉ EXISTE: hoy el historial del chat es local-only (IndexedDB de cada
- * browser, #120) y el chat va directo a Ollama sin pasar por el sidecar, así que
- * NADA queda guardado central. Para análisis, debugging y mejora del sistema,
- * hay que persistir cada turno (pregunta + respuesta + grounding) en el sidecar.
- * Mirror del patrón de `feedbackService.js` (mismo base URL + token).
- *
- * Endpoint sidecar: POST /log-conversation (chagra-pro, append a JSONL durable).
- *
- * Reglas:
- * - Gated por `VITE_CAPTURE_CONVERSATIONS` (OFF default → privacy-first).
- * - Solo captura si el usuario dio consentimiento (hasConsent() del feedbackService).
- * - Fire-and-forget: NUNCA bloquea ni rompe la UX del chat; falla en silencio.
- * - Opcionalmente anonimiza PII (VITE_CAPTURE_ANONYMIZE=true) → user_name y
- *   finca_nombre se omiten para cumplir Habeas Data (Ley 1581).
- *
- * Schema del evento (1 línea JSONL por turno):
- * {
- *   id, ts,
- *   user_id, user_name,        // identidad del usuario (user_name omitido si anonymize)
- *   finca_slug, finca_nombre,  // finca activa (finca_nombre omitido si anonymize)
- *   session_id, turn_index,
- *   user_text,                 // pregunta del usuario (limpia)
- *   agent_text,                // respuesta del agente (final)
- *   nlu_route,                 // ruta NLU elegida (si la hubo)
- *   entities_grounded,         // entidades resueltas en el grafo
- *   guards_fired,              // guards de seguridad que actuaron
- *   grounded_status,           // _grounded.status
- *   latency_ms, model
- * }
+ * Endpoint sidecar: POST /log-conversation.
+ * Gated by VITE_CAPTURE_CONVERSATIONS (OFF by default).
  */
 
 import { ulid } from 'ulid';
-import { hasConsent } from './feedbackService';
 
 const CAPTURE_TIMEOUT_MS = 6000;
-const TEXT_MAX = 16000; // cota por campo (un turno largo del agente ~2-4k; holgado)
+const TEXT_MAX = 16000;
 
-/** ¿Captura activa? Gated por env. OFF por defecto. */
 export function isCaptureEnabled() {
   try {
     const raw = import.meta.env?.VITE_CAPTURE_CONVERSATIONS;
     if (raw === true) return true;
     if (typeof raw === 'string') {
-      const v = raw.trim().toLowerCase();
-      return v === 'true' || v === '1' || v === 'on';
+      const value = raw.trim().toLowerCase();
+      return value === 'true' || value === '1' || value === 'on';
     }
-    return false;
   } catch (_) {
     return false;
   }
+  return false;
 }
 
 function getBaseUrl() {
@@ -61,7 +31,7 @@ function getBaseUrl() {
       return raw.trim().replace(/\/+$/, '');
     }
   } catch (_) {
-    // ignore
+    // noop
   }
   return '/api';
 }
@@ -75,81 +45,38 @@ function getToken() {
   }
 }
 
-function clip(s) {
-  if (typeof s !== 'string') return '';
-  return s.length > TEXT_MAX ? `${s.slice(0, TEXT_MAX)}…[clip]` : s;
+function clip(text) {
+  if (typeof text !== 'string') return '';
+  return text.length > TEXT_MAX ? `${text.slice(0, TEXT_MAX)}...[clip]` : text;
 }
 
-/** ¿Anonimizar PII? Gated por VITE_CAPTURE_ANONYMIZE. Exportado para tests. */
-export function shouldAnonymizePII() {
-  try {
-    const raw = import.meta.env?.VITE_CAPTURE_ANONYMIZE;
-    if (raw === true) return true;
-    if (typeof raw === 'string') {
-      const v = raw.trim().toLowerCase();
-      return v === 'true' || v === '1' || v === 'on';
-    }
-    return false;
-  } catch (_) {
-    return false;
-  }
-}
-
-function anonymizeIdentity(identity) {
-  if (!shouldAnonymizePII()) return identity;
-
+function buildIdentityPayload(identity = {}) {
   return {
     user_id: identity.user_id ?? null,
-    user_name: null,
-    finca_slug: identity.finca_slug ?? null,
-    finca_nombre: null,
+    user_name: identity.user_name ?? null,
+    finca_id: identity.finca_id ?? null,
   };
 }
 
-/**
- * Captura un turno completo (pregunta del usuario + respuesta del agente).
- * Fire-and-forget: devuelve void, no espera, no lanza.
- *
- * Solo captura si:
- * - La flag VITE_CAPTURE_CONVERSATIONS está activada.
- * - El usuario dio consentimiento (hasConsent() del feedbackService).
- *
- * @param {Object} p
- * @param {string} p.userText      pregunta del usuario
- * @param {string} p.agentText     respuesta final del agente
- * @param {Object} [p.identity]    { user_id, user_name, finca_slug, finca_nombre }
- * @param {Object} [p.meta]        { session_id, turn_index, nlu_route, entities_grounded,
- *                                   guards_fired, grounded_status, latency_ms, model }
- */
-export function captureExchange({ userText, agentText, identity = {}, meta = {} } = {}) {
-  if (!isCaptureEnabled()) return;
-  if (!hasConsent()) return;
-  // No capturamos turnos vacíos (p. ej. abortados sin respuesta).
-  if (!userText && !agentText) return;
-
-  const sanitizedIdentity = anonymizeIdentity(identity);
-  const payload = {
+function buildConversationPayload({ role, text, identity, meta }) {
+  return {
     id: ulid(),
     ts: Date.now(),
-    user_id: sanitizedIdentity.user_id ?? null,
-    user_name: sanitizedIdentity.user_name ?? null,
-    finca_slug: sanitizedIdentity.finca_slug ?? null,
-    finca_nombre: sanitizedIdentity.finca_nombre ?? null,
-    session_id: meta.session_id ?? null,
-    turn_index: typeof meta.turn_index === 'number' ? meta.turn_index : null,
-    user_text: clip(userText),
-    agent_text: clip(agentText),
-    nlu_route: meta.nlu_route ?? null,
-    entities_grounded: Array.isArray(meta.entities_grounded) ? meta.entities_grounded.slice(0, 50) : [],
-    guards_fired: Array.isArray(meta.guards_fired) ? meta.guards_fired.slice(0, 20) : [],
-    grounded_status: meta.grounded_status ?? null,
-      latency_ms: typeof meta.latency_ms === 'number' ? meta.latency_ms : null,
-      model: meta.model ?? null,
-      eval_rate: typeof meta.eval_rate === 'number' ? meta.eval_rate : null,
-      first_token_ms: typeof meta.first_token_ms === 'number' ? meta.first_token_ms : null,
-      response_len: typeof meta.response_len === 'number' ? meta.response_len : null,
-    };
+    role,
+    text: clip(text),
+    ...buildIdentityPayload(identity),
+    session_id: meta?.session_id ?? null,
+    turn_index: typeof meta?.turn_index === 'number' ? meta.turn_index : null,
+    nlu_route: meta?.nlu_route ?? null,
+    entities_grounded: Array.isArray(meta?.entities_grounded) ? meta.entities_grounded.slice(0, 50) : [],
+    grounding_used: Boolean(meta?.grounding_used),
+    guards_fired: Array.isArray(meta?.guards_fired) ? meta.guards_fired.slice(0, 20) : [],
+    latency_ms: typeof meta?.latency_ms === 'number' ? meta.latency_ms : null,
+    model: meta?.model ?? null,
+  };
+}
 
+function postCapture(payload) {
   const base = getBaseUrl();
   const token = getToken();
   const headers = { 'Content-Type': 'application/json' };
@@ -158,19 +85,40 @@ export function captureExchange({ userText, agentText, identity = {}, meta = {} 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS);
 
-  // Fire-and-forget: no await, no throw. El chat NO depende de esto.
   fetch(`${base}/log-conversation`, {
     method: 'POST',
     headers,
     body: JSON.stringify(payload),
     signal: controller.signal,
-    keepalive: true, // sobrevive si el usuario navega justo después
+    keepalive: true,
   })
     .catch((err) => {
-      // Silencioso por diseño: la captura jamás degrada la UX.
       if (import.meta.env?.DEV) {
-        console.debug('[conversationCapture] envío falló (ignorado):', err?.name || err);
+        console.debug('[conversationCapture] envio fallo (ignorado):', err?.name || err);
       }
     })
     .finally(() => clearTimeout(timer));
+}
+
+export function captureExchange({ userText, agentText, identity = {}, meta = {} } = {}) {
+  if (!isCaptureEnabled()) return;
+  if (typeof userText === 'undefined' && typeof agentText === 'undefined') return;
+
+  if (typeof userText === 'string' && userText.trim()) {
+    postCapture(buildConversationPayload({
+      role: 'user',
+      text: userText,
+      identity,
+      meta,
+    }));
+  }
+
+  if (typeof agentText === 'string' && agentText.trim()) {
+    postCapture(buildConversationPayload({
+      role: 'agent',
+      text: agentText,
+      identity,
+      meta,
+    }));
+  }
 }


### PR DESCRIPTION
## Summary
- Wirea la captura fire-and-forget de turnos del agente hacia `/log-conversation`.
- Emite dos registros por turno, uno para `user` y otro para `agent`, con el gate `VITE_CAPTURE_CONVERSATIONS` apagado por defecto.
- Ajusta el payload para enviar `finca_id` y agrega cobertura de tests para flag ON y OFF.

## Test plan
- `npx vitest run src/services/__tests__/conversationCaptureService.test.js tests/unit/boundaryAudit.test.js`
- `npx vitest run`
- `NODE_OPTIONS=--max-old-space-size=2048 npx eslint src/components/AgentScreen/AgentScreen.jsx src/services/conversationCaptureService.js src/services/__tests__/conversationCaptureService.test.js --max-warnings=0`
- `npm run build` (falla por dependencia nativa ausente de `better-sqlite3` en `prebuild`)
