### PR TITLE
test(gating): extiende tests de gating por tipo de usuario

### DIFF
--- a/src/services/__tests__/homeModuleSelector.test.js
+++ b/src/services/__tests__/homeModuleSelector.test.js
@@ -308,6 +308,126 @@ describe('homeModuleSelector — invariantes', () => {
   });
 });
 
+describe('homeModuleSelector — invariantes DURAS', () => {
+  it('INVARIANTE: urbano NUNCA ve cerdos (ni como tarjeta ni como modulo)', () => {
+    const urbanos = [
+      { vocacion: 'urbano' },
+      { finca_tipo: 'balcon' },
+      { finca_tipo: 'terraza' },
+      { vocacion: 'urbano', animales: ['cerdos'] },
+      { vocacion: 'urbano', rol: 'ganadero', animales: ['cerdos', 'gallinas'] },
+      { finca_tipo: 'balcon', rol: 'porcicultor', animales: ['cerdos'] },
+    ];
+    for (const p of urbanos) {
+      const { visibles, seguimiento } = selectHomeModules(p);
+      expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+      expect(visibles).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+      expect(isSeguimientoVisible(SEGUIMIENTO_KEYS.cerdos, p)).toBe(false);
+    }
+  });
+
+  it('INVARIANTE: urbano NUNCA ve insumos, zonas, biodiversidad, reforestacion, paramo', () => {
+    const urbanos = [
+      { vocacion: 'urbano' },
+      { finca_tipo: 'balcon' },
+      { finca_tipo: 'terraza', animales: ['gallinas'] },
+    ];
+    for (const p of urbanos) {
+      const { visibles, seguimiento } = selectHomeModules(p);
+      expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+      expect(visibles).not.toContain(HOME_MODULE_IDS.zonas);
+      expect(visibles).not.toContain(HOME_MODULE_IDS.biodiversidad);
+      expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+      expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.reforestacion);
+      expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.paramo);
+    }
+  });
+
+  it('INVARIANTE: operador ve TODO (todos los modulos + las 4 tarjetas)', () => {
+    // Verificamos que el operador ve absolutamente todo,
+    // sin importar el perfil que se le pase.
+    const operadorPerfiles = [{}, { vocacion: 'urbano' }, { rol: 'guia_glaciar' }, null];
+    for (const p of operadorPerfiles) {
+      const { visibles, seguimiento } = selectHomeModules(p, { esOperador: true });
+      for (const id of ALL_HOME_MODULES) expect(visibles).toContain(id);
+      for (const k of Object.values(SEGUIMIENTO_KEYS)) expect(seguimiento).toContain(k);
+    }
+  });
+
+  it('INVARIANTE: guia_glaciar NUNCA ve insumos ni cerdos', () => {
+    const guias = [
+      { vocacion: 'campesino' },
+      { rol: 'guia_glaciar' },
+    ];
+    for (const p of guias) {
+      const { visibles, seguimiento } = selectHomeModules(p, { esGuiaGlaciar: true });
+      expect(visibles).not.toContain(HOME_MODULE_IDS.insumos);
+      expect(visibles).not.toContain(HOME_MODULE_IDS.zonas);
+      expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+    }
+  });
+});
+
+describe('homeModuleSelector — perfiles POR TIPO DE USUARIO', () => {
+  it('porcicultor (solo cerdos, sin rol explicito): silvopastoreo + cerdos', () => {
+    const { visibles, seguimiento } = selectHomeModules({
+      vocacion: 'campesino',
+      animales: ['cerdos'],
+    });
+    expect(visibles).toContain(HOME_MODULE_IDS.plantas);
+    expect(visibles).toContain(HOME_MODULE_IDS.insumos);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+
+  it('campesino con objetivo reforestacion → biodiversidad + reforestacion/paramo', () => {
+    const { visibles, seguimiento } = selectHomeModules({
+      rol: 'campesino',
+      objetivo: ['biodiversidad'],
+      restauracion_objetivo: ['bosque', 'paramo'],
+    });
+    expect(visibles).toContain(HOME_MODULE_IDS.biodiversidad);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.reforestacion);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.paramo);
+    // El nucleo de cultivo sigue presente.
+    expect(visibles).toContain(HOME_MODULE_IDS.plantas);
+    expect(visibles).toContain(HOME_MODULE_IDS.insumos);
+  });
+
+  it('campesino con gallinas y bosque: ve cultivo + animal + restauracion', () => {
+    const { visibles, seguimiento } = selectHomeModules({
+      rol: 'campesino',
+      animales: ['gallinas'],
+      objetivo: ['biodiversidad'],
+    });
+    // Animal: silvopastoreo presente (no cerdos).
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+    // Restauracion: reforestacion + paramo.
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.reforestacion);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.paramo);
+    expect(visibles).toContain(HOME_MODULE_IDS.biodiversidad);
+  });
+
+  it('silvopastoreo puro (ganadero sin cerdos): silvopastoreo SI, cerdos NO', () => {
+    const { seguimiento } = selectHomeModules({
+      rol: 'ganadero',
+      animales: ['ganado', 'ovejas'],
+    });
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).not.toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+
+  it('cerdos puros (solo cerdos, nada mas): silvopastoreo + cerdos', () => {
+    const { seguimiento } = selectHomeModules({
+      rol: 'campesino',
+      animales: ['cerdos'],
+    });
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.silvopastoreo);
+    expect(seguimiento).toContain(SEGUIMIENTO_KEYS.cerdos);
+  });
+});
+
 describe('homeModuleSelector — selectHomeModuleVisibilityMap', () => {
   it('devuelve un mapa { moduleId: boolean } con TODOS los ids del home', () => {
     const map = selectHomeModuleVisibilityMap({ rol: 'campesino' });

--- a/src/services/__tests__/profileChipSelector.test.js
+++ b/src/services/__tests__/profileChipSelector.test.js
@@ -302,3 +302,102 @@ describe('profileChipSelector — opts.esOperador (catálogo completo de chips)'
     expect(intents).toContain(CHIP_INTENTS.clima);
   });
 });
+
+describe('profileChipSelector — chips POR TIPO DE USUARIO', () => {
+  it('urbano: chips de cultivo basico (siembro, plaga, clima) sin silvopastoreo ni paramo', () => {
+    // El urbano deriva a campesino (porque vocacion=urbano → campesino en deriveRole).
+    // Los chips son los de CULTIVO base. SIN silvopastoreo (no tiene animales).
+    const intents = selectChipIntents({ vocacion: 'urbano' });
+    expect(intents).toContain(CHIP_INTENTS.siembro);
+    expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).not.toContain(CHIP_INTENTS.silvopastoreo);
+    expect(intents).not.toContain(CHIP_INTENTS.paramo);
+    expect(intents).not.toContain(CHIP_INTENTS.restauracion);
+  });
+
+  it('campesino (full agro): cultivo completo, sin restauracion ni silvopastoreo', () => {
+    const intents = selectChipIntents({ rol: 'campesino' });
+    expect(intents).toContain(CHIP_INTENTS.siembro);
+    expect(intents).toContain(CHIP_INTENTS.calendario);
+    expect(intents).toContain(CHIP_INTENTS.plaga);
+    expect(intents).toContain(CHIP_INTENTS.biopreparado);
+    expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).not.toContain(CHIP_INTENTS.silvopastoreo);
+    expect(intents).not.toContain(CHIP_INTENTS.paramo);
+  });
+
+  it('guia_glaciar: solo clima/paramo/restauracion, sin cultivo', () => {
+    const intents = selectChipIntents({}, { esGuiaGlaciar: true });
+    expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.paramo);
+    expect(intents).toContain(CHIP_INTENTS.restauracion);
+    expect(intents).not.toContain(CHIP_INTENTS.siembro);
+    expect(intents).not.toContain(CHIP_INTENTS.biopreparado);
+    expect(intents).not.toContain(CHIP_INTENTS.calendario);
+  });
+
+  it('operador: catalogo COMPLETO de chips vivos (incluye biopreparado, siembro, todo)', () => {
+    const intents = selectChipIntents({}, { esOperador: true });
+    expect(intents).toContain(CHIP_INTENTS.biopreparado);
+    expect(intents).toContain(CHIP_INTENTS.siembro);
+    expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.paramo);
+    expect(intents).toContain(CHIP_INTENTS.silvopastoreo);
+    expect(intents).toContain(CHIP_INTENTS.restauracion);
+    // Los stubs NO aparecen
+    expect(intents).not.toContain(CHIP_INTENTS.precio);
+  });
+
+  it('porcicultor (campesino con cerdos): ve cultivo + silvopastoreo', () => {
+    const intents = selectChipIntents({ rol: 'campesino', animales: ['cerdos'] });
+    expect(intents).toContain(CHIP_INTENTS.siembro);
+    expect(intents).toContain(CHIP_INTENTS.silvopastoreo);
+    // SIN paramo (no es restaurador)
+    expect(intents).not.toContain(CHIP_INTENTS.paramo);
+    expect(intents).not.toContain(CHIP_INTENTS.restauracion);
+  });
+
+  it('restaurador + silvopastoreo (con animales): restauracion primero, silvopastoreo incluido', () => {
+    const intents = selectChipIntents({
+      rol: 'restaurador',
+      animales: ['ganado'],
+      objetivo: ['biodiversidad'],
+    });
+    expect(intents[0]).toBe(CHIP_INTENTS.restauracion);
+    expect(intents).toContain(CHIP_INTENTS.paramo);
+    expect(intents).toContain(CHIP_INTENTS.silvopastoreo);
+    expect(intents).toContain(CHIP_INTENTS.clima);
+  });
+
+  it('ganadero puro (solo vacas): silvopastoreo + clima + plaga + siembro', () => {
+    const intents = selectChipIntents({ rol: 'ganadero', animales: ['vacas'] });
+    expect(intents[0]).toBe(CHIP_INTENTS.silvopastoreo);
+    expect(intents).toContain(CHIP_INTENTS.clima);
+    expect(intents).toContain(CHIP_INTENTS.plaga);
+    expect(intents).toContain(CHIP_INTENTS.siembro);
+  });
+});
+
+describe('profileChipSelector — invariantes', () => {
+  it('NUNCA devuelve chips stubs (precio/deep) para ningun perfil no-operador', () => {
+    const perfiles = [
+      { rol: 'campesino' },
+      { rol: 'restaurador' },
+      { vocacion: 'urbano' },
+      { rol: 'tecnico' },
+      { rol: 'socio' },
+    ];
+    for (const p of perfiles) {
+      const intents = selectChipIntents(p);
+      expect(intents).not.toContain(CHIP_INTENTS.precio);
+      expect(intents).not.toContain(CHIP_INTENTS.deep);
+    }
+  });
+
+  it('SIEMPRE respeta el orden de prioridad del rol (no aleatorio)', () => {
+    // Dos llamadas identicas deben dar el mismo orden.
+    const a = selectChipIntents({ rol: 'campesino', animales: ['gallinas'] });
+    const b = selectChipIntents({ rol: 'campesino', animales: ['gallinas'] });
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## Tarea 21 — Tests de gating del home POR TIPO DE USUARIO

Extiende tests en homeModuleSelector y profileChipSelector con **invariantes duras** y perfiles faltantes.

### homeModuleSelector
- INVARIANTES: urbano NUNCA ve cerdos/insumos/zonas, operador ve TODO, guia sin insumos
- Perfiles nuevos: porcicultor, campesino+reforestacion, silvopastoreo puro, cerdos puros

### profileChipSelector  
- Chips por persona: urbano, campesino, guia, operador, porcicultor, restaurador+silvo
- INVARIANTES: stubs nunca visibles, orden determinista

77 tests pasando. ESLint limpio, boundary audit OK.