### PR TITLE
fix(pigs): add porcine seguimiento flow

### DIFF
--- a/src/components/SeguimientoProcesoScreen.jsx
+++ b/src/components/SeguimientoProcesoScreen.jsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, Plus, Check, X, AlertTriangle, RotateCcw, CalendarDays, MapPin, Clock, ChevronRight } from 'lucide-react';
 import { createFarmProcess, recordFarmEvent } from '../services/farmEventService';
 import { confirmStage } from '../services/stageConfirmationService';
-import { listFarmProcesses, getFarmEvents } from '../db/farmProcessCache';
+import { listFarmProcesses, getFarmEvents, putFarmProcess } from '../db/farmProcessCache';
 import { stageSequenceForProcessType } from '../types/farmProcess';
 import { getSeguimientoDef } from '../config/seguimientoProcesos';
 import { newUlid } from '../utils/id';
@@ -37,11 +37,30 @@ import animalDiagnostics from '../data/animal-diagnostics.json';
  */
 
 const PIG_GUARD = animalDiagnostics?.guardas?.leucaena_toxica || null;
+const PIG_STAGE_LABELS = {
+  instalacion: 'Instalación',
+  alimentacion: 'Alimentación',
+  reproduccion: 'Reproducción',
+  sanidad: 'Sanidad',
+  cierre: 'Cierre',
+};
 
 // Etapa inicial por tipo de proceso (primer hito de su secuencia).
 function initialStageFor(processType) {
   const seq = stageSequenceForProcessType(processType);
   return seq[0]?.stage || 'sowing_confirmed';
+}
+
+function getPigProfile(attributes) {
+  return {
+    cochera: attributes?.pig_cochera || {
+      nombre: '',
+      ubicacion: '',
+      capacidad: '',
+      cama_profunda: 'cascarilla_de_arroz',
+    },
+    lotes: Array.isArray(attributes?.pig_lotes) ? attributes.pig_lotes : [],
+  };
 }
 
 const fmtDate = (ms) => {
@@ -434,10 +453,26 @@ function IniciarProcesoForm({ def, locationOptions, onCancel, onCreated }) {
  * fotos del ciclo y el AVANCE (eventos del ciclo en orden).
  */
 function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload }) {
-  const a = proceso.attributes || {};
+  const a = useMemo(() => proceso.attributes || {}, [proceso]);
   const processId = proceso.process_id || proceso.id;
   const [busy, setBusy] = useState(false);
   const [events, setEvents] = useState([]);
+  const pigProfile = useMemo(() => getPigProfile(a), [a]);
+  const [cocheraDraft, setCocheraDraft] = useState(pigProfile.cochera);
+  const [loteDraft, setLoteDraft] = useState({
+    raza: '',
+    fecha_ingreso: new Date().toISOString().split('T')[0],
+    cantidad: '',
+    peso_inicial: '',
+  });
+  const [eventoDraft, setEventoDraft] = useState({
+    tipo: 'peso',
+    fecha: new Date().toISOString().split('T')[0],
+    valor: '',
+    detalle: '',
+  });
+  const [pigBusy, setPigBusy] = useState(false);
+  const [pigMessage, setPigMessage] = useState('');
 
   // Nombre del lote resuelto desde el store (NO inventamos el nombre).
   const locName = useMemo(() => {
@@ -483,6 +518,108 @@ function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload
     }
   }, [busy, a.current_stage, processId, loadEvents, onReload]);
 
+  const savePigProfile = useCallback(async () => {
+    if (def.processType !== 'pigs') return;
+    setPigBusy(true);
+    setPigMessage('');
+    try {
+      const next = {
+        ...proceso,
+        attributes: {
+          ...a,
+          pig_cochera: {
+            nombre: cocheraDraft.nombre.trim(),
+            ubicacion: cocheraDraft.ubicacion.trim(),
+            capacidad: cocheraDraft.capacidad === '' ? '' : Number(cocheraDraft.capacidad),
+            cama_profunda: cocheraDraft.cama_profunda,
+          },
+          pig_lotes: pigProfile.lotes,
+          updated_at: Date.now(),
+        },
+      };
+      await putFarmProcess(next);
+      setPigMessage('Cochera guardada.');
+      onReload?.();
+    } finally {
+      setPigBusy(false);
+    }
+  }, [a, cocheraDraft, def.processType, onReload, pigProfile.lotes, proceso]);
+
+  const addPigLote = useCallback(async () => {
+    if (def.processType !== 'pigs') return;
+    if (!loteDraft.raza.trim() || !Number(loteDraft.cantidad) || !Number(loteDraft.peso_inicial)) return;
+    setPigBusy(true);
+    setPigMessage('');
+    try {
+      const lote = {
+        raza: loteDraft.raza.trim(),
+        fecha_ingreso: loteDraft.fecha_ingreso,
+        cantidad: Number(loteDraft.cantidad),
+        peso_inicial: Number(loteDraft.peso_inicial),
+      };
+      const next = {
+        ...proceso,
+        attributes: {
+          ...a,
+          pig_lotes: [...pigProfile.lotes, lote],
+          updated_at: Date.now(),
+        },
+      };
+      await putFarmProcess(next);
+      await recordFarmEvent({
+        process_id: processId,
+        event_type: 'observation',
+        payload: { kind: 'pig_lote', ...lote },
+      });
+      setLoteDraft({
+        raza: '',
+        fecha_ingreso: new Date().toISOString().split('T')[0],
+        cantidad: '',
+        peso_inicial: '',
+      });
+      setPigMessage('Lote registrado.');
+      onReload?.();
+      await loadEvents();
+    } finally {
+      setPigBusy(false);
+    }
+  }, [a, def.processType, loteDraft, loadEvents, onReload, pigProfile.lotes, processId, proceso]);
+
+  const addPigEvent = useCallback(async () => {
+    if (def.processType !== 'pigs') return;
+    const basePayload = { kind: eventoDraft.tipo, fecha: eventoDraft.fecha };
+    if (eventoDraft.tipo === 'peso') {
+      if (!Number(eventoDraft.valor)) return;
+      basePayload.peso_kg = Number(eventoDraft.valor);
+    } else if (eventoDraft.tipo === 'alimentacion') {
+      if (!eventoDraft.detalle.trim()) return;
+      basePayload.detalle = eventoDraft.detalle.trim();
+    } else {
+      if (!eventoDraft.detalle.trim()) return;
+      basePayload.detalle = eventoDraft.detalle.trim();
+    }
+    setPigBusy(true);
+    setPigMessage('');
+    try {
+      await recordFarmEvent({
+        process_id: processId,
+        event_type: 'observation',
+        payload: basePayload,
+      });
+      setEventoDraft({
+        tipo: eventoDraft.tipo,
+        fecha: new Date().toISOString().split('T')[0],
+        valor: '',
+        detalle: '',
+      });
+      setPigMessage('Evento guardado.');
+      await loadEvents();
+      onReload?.();
+    } finally {
+      setPigBusy(false);
+    }
+  }, [def.processType, eventoDraft, loadEvents, onReload, processId]);
+
   return (
     <div className="px-4 pb-10 flex flex-col gap-4">
       {/* Resumen */}
@@ -506,6 +643,128 @@ function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload
           <AlertTriangle size={16} className="text-red-400 shrink-0 mt-0.5" />
           <p className="text-xs text-red-200 leading-snug">{PIG_GUARD}</p>
         </div>
+      )}
+
+      {def.processType === 'pigs' && (
+        <section className="bg-slate-900 border border-slate-800 rounded-xl p-4 flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <h2 className="text-sm font-bold text-slate-100">Cochera y lotes</h2>
+              <p className="text-2xs text-slate-500">Guarda la cochera, registra el lote y sigue los eventos del cerdo.</p>
+            </div>
+            <span className="text-2xs px-2 py-0.5 rounded-full bg-pink-900/30 text-pink-200 border border-pink-800/60">Porcicultura</span>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-2xs font-bold text-slate-400 uppercase">Nombre de la cochera</span>
+              <input
+                type="text"
+                value={cocheraDraft.nombre}
+                onChange={(e) => setCocheraDraft((p) => ({ ...p, nombre: e.target.value }))}
+                className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-pink-500 focus:outline-none"
+                disabled={pigBusy}
+                placeholder="Ej: Cochera El Mango"
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-2xs font-bold text-slate-400 uppercase">Ubicación</span>
+              <input
+                type="text"
+                value={cocheraDraft.ubicacion}
+                onChange={(e) => setCocheraDraft((p) => ({ ...p, ubicacion: e.target.value }))}
+                className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-pink-500 focus:outline-none"
+                disabled={pigBusy}
+                placeholder="Ej: Junto al corral de servicio"
+              />
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              <label className="flex flex-col gap-1">
+                <span className="text-2xs font-bold text-slate-400 uppercase">Capacidad</span>
+                <input
+                  type="number"
+                  min="1"
+                  value={cocheraDraft.capacidad}
+                  onChange={(e) => setCocheraDraft((p) => ({ ...p, capacidad: e.target.value }))}
+                  className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-pink-500 focus:outline-none"
+                  disabled={pigBusy}
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-2xs font-bold text-slate-400 uppercase">Cama profunda</span>
+                <select
+                  value={cocheraDraft.cama_profunda}
+                  onChange={(e) => setCocheraDraft((p) => ({ ...p, cama_profunda: e.target.value }))}
+                  className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white focus:border-pink-500 focus:outline-none"
+                  disabled={pigBusy}
+                >
+                  <option value="cascarilla_de_arroz">Cascarilla de arroz</option>
+                  <option value="aserrin">Aserrín</option>
+                  <option value="bagazo">Bagazo seco</option>
+                </select>
+              </label>
+            </div>
+            <button
+              type="button"
+              onClick={savePigProfile}
+              disabled={pigBusy}
+              className="px-4 py-2.5 rounded-xl bg-pink-700 hover:bg-pink-600 text-white font-bold disabled:opacity-50"
+            >
+              Guardar cochera
+            </button>
+          </div>
+
+          <div className="border-t border-slate-800 pt-3">
+            <h3 className="text-xs font-bold text-slate-200 mb-2">Registrar lote</h3>
+            <div className="grid grid-cols-2 gap-2">
+              <input value={loteDraft.raza} onChange={(e) => setLoteDraft((p) => ({ ...p, raza: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" placeholder="Raza" disabled={pigBusy} />
+              <input type="date" value={loteDraft.fecha_ingreso} onChange={(e) => setLoteDraft((p) => ({ ...p, fecha_ingreso: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" disabled={pigBusy} />
+              <input type="number" min="1" value={loteDraft.cantidad} onChange={(e) => setLoteDraft((p) => ({ ...p, cantidad: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" placeholder="Cantidad" disabled={pigBusy} />
+              <input type="number" min="0" step="0.1" value={loteDraft.peso_inicial} onChange={(e) => setLoteDraft((p) => ({ ...p, peso_inicial: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" placeholder="Peso inicial kg" disabled={pigBusy} />
+            </div>
+            <button type="button" onClick={addPigLote} disabled={pigBusy} className="mt-2 px-4 py-2.5 rounded-xl bg-slate-700 hover:bg-slate-600 text-white font-bold disabled:opacity-50">
+              Registrar lote
+            </button>
+          </div>
+
+          <div className="border-t border-slate-800 pt-3">
+            <h3 className="text-xs font-bold text-slate-200 mb-2">Eventos</h3>
+            <div className="grid grid-cols-1 gap-2">
+              <select value={eventoDraft.tipo} onChange={(e) => setEventoDraft((p) => ({ ...p, tipo: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" disabled={pigBusy}>
+                <option value="peso">Peso</option>
+                <option value="alimentacion">Alimentación</option>
+                <option value="sanidad">Sanidad / vacunas</option>
+              </select>
+              <input type="date" value={eventoDraft.fecha} onChange={(e) => setEventoDraft((p) => ({ ...p, fecha: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" disabled={pigBusy} />
+              {eventoDraft.tipo === 'peso' ? (
+                <input type="number" min="0" step="0.1" value={eventoDraft.valor} onChange={(e) => setEventoDraft((p) => ({ ...p, valor: e.target.value }))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white" placeholder="Peso en kg" disabled={pigBusy} />
+              ) : (
+                <textarea value={eventoDraft.detalle} onChange={(e) => setEventoDraft((p) => ({ ...p, detalle: e.target.value }))} rows={3} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-white resize-none" placeholder={eventoDraft.tipo === 'alimentacion' ? 'Ej: maíz, yuca cocida, suero' : 'Ej: vacuna, desparasitación, observación sanitaria'} disabled={pigBusy} />
+              )}
+              <button type="button" onClick={addPigEvent} disabled={pigBusy} className="px-4 py-2.5 rounded-xl bg-emerald-700 hover:bg-emerald-600 text-white font-bold disabled:opacity-50">
+                Registrar evento
+              </button>
+            </div>
+          </div>
+
+          {pigMessage && <p className="text-xs text-emerald-200">{pigMessage}</p>}
+
+          <div className="border-t border-slate-800 pt-3">
+            <h3 className="text-xs font-bold text-slate-200 mb-2">Lotes activos</h3>
+            {pigProfile.lotes.length === 0 ? (
+              <p className="text-xs text-slate-500">Aún no has registrado lotes.</p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {pigProfile.lotes.map((lote, idx) => (
+                  <li key={`${lote.raza}-${idx}`} className="bg-slate-950/60 border border-slate-800 rounded-lg p-3 text-xs text-slate-300">
+                    <strong className="block text-slate-100">{lote.raza}</strong>
+                    <span className="block text-slate-500">{lote.cantidad} animales · {lote.peso_inicial} kg iniciales · {lote.fecha_ingreso}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
       )}
 
       {/* Etapas con fechas — toca una para confirmar el avance. */}
@@ -591,6 +850,18 @@ function ProcesoDetalle({ def, proceso, stageSeq, locationOptions = [], onReload
 function describeEvent(e, stageSeq) {
   const t = e?.attributes?.event_type;
   const p = e?.attributes?.payload || {};
+  if (t === 'observation' && p?.kind === 'pig_lote') {
+    return `Lote: ${p.raza} · ${p.cantidad} animales · ${p.peso_inicial} kg`;
+  }
+  if (t === 'observation' && p?.kind === 'peso') {
+    return `Peso registrado: ${p.peso_kg} kg`;
+  }
+  if (t === 'observation' && p?.kind === 'alimentacion') {
+    return `Alimentación: ${p.detalle}`;
+  }
+  if (t === 'observation' && p?.kind === 'sanidad') {
+    return `Sanidad: ${p.detalle}`;
+  }
   if (t === 'stage_confirmed' || t === 'stage_corrected') {
     const lbl = stageSeq.find((s) => s.stage === p.new_stage)?.label || p.new_stage;
     return `Etapa: ${lbl}`;

--- a/src/components/__tests__/SeguimientoProcesoScreen.test.jsx
+++ b/src/components/__tests__/SeguimientoProcesoScreen.test.jsx
@@ -17,6 +17,7 @@ import { describe, test, expect, afterEach, vi, beforeEach } from 'vitest';
 let processes = [];
 const createFarmProcess = vi.fn(async () => ({}));
 const recordFarmEvent = vi.fn(async () => ({}));
+const putFarmProcess = vi.fn(async () => ({}));
 
 vi.mock('../../services/farmEventService', () => ({
   createFarmProcess: (...a) => createFarmProcess(...a),
@@ -28,6 +29,7 @@ vi.mock('../../services/stageConfirmationService', () => ({
 vi.mock('../../db/farmProcessCache', () => ({
   listFarmProcesses: vi.fn(async () => processes),
   getFarmEvents: vi.fn(async () => []),
+  putFarmProcess: (...a) => putFarmProcess(...a),
 }));
 vi.mock('../../store/useAssetStore', () => ({
   default: (selector) => selector({ lands: [] }),
@@ -44,6 +46,7 @@ afterEach(() => {
   processes = [];
   createFarmProcess.mockClear();
   recordFarmEvent.mockClear();
+  putFarmProcess.mockClear();
 });
 beforeEach(() => { processes = []; });
 
@@ -91,6 +94,54 @@ describe('SeguimientoProcesoScreen', () => {
     const arg = createFarmProcess.mock.calls[0][0];
     expect(arg.attributes.process_type).toBe('pigs');
     expect(arg.attributes.current_stage).toBe('instalacion');
+  });
+
+  test('cerdos permite guardar cochera, registrar lote y evento sanitario', async () => {
+    processes = [{
+      process_id: 'proc-cerdos-1',
+      type: 'farm_process',
+      attributes: {
+        process_type: 'pigs',
+        subject_kind: 'aggregate',
+        subject_label: 'Lote de engorde',
+        quantity: 8,
+        unit: 'animales',
+        status: 'active',
+        current_stage: 'instalacion',
+        created_at: Date.now(),
+        updated_at: Date.now(),
+        pig_cochera: { nombre: '', ubicacion: '', capacidad: '', cama_profunda: 'cascarilla_de_arroz' },
+        pig_lotes: [],
+      },
+    }];
+
+    render(<SeguimientoProcesoScreen procesoKey="cerdos" onBack={vi.fn()} onSave={vi.fn()} />);
+    await waitFor(() => screen.getByText('Lote de engorde'));
+    fireEvent.click(screen.getByText('Lote de engorde'));
+
+    fireEvent.change(screen.getByPlaceholderText('Ej: Cochera El Mango'), { target: { value: 'Cochera La Palma' } });
+    fireEvent.change(screen.getByPlaceholderText('Ej: Junto al corral de servicio'), { target: { value: 'Bajo la sombra del patio' } });
+    fireEvent.change(screen.getAllByRole('spinbutton')[0], { target: { value: '14' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar cochera' }));
+
+    await waitFor(() => expect(putFarmProcess).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByPlaceholderText('Raza'), { target: { value: 'Zungo' } });
+    fireEvent.change(screen.getByPlaceholderText('Cantidad'), { target: { value: '6' } });
+    fireEvent.change(screen.getByPlaceholderText('Peso inicial kg'), { target: { value: '18' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Registrar lote' }));
+
+    await waitFor(() => expect(recordFarmEvent).toHaveBeenCalled());
+
+    fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'sanidad' } });
+    const sanitario = await screen.findByPlaceholderText('Ej: vacuna, desparasitación, observación sanitaria');
+    fireEvent.change(sanitario, {
+      target: { value: 'Vacuna y desparasitación' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Registrar evento' }));
+
+    await waitFor(() => expect(recordFarmEvent).toHaveBeenCalledTimes(2));
+    expect(screen.getByText(/Cochera guardada|Lote registrado|Evento guardado/)).toBeInTheDocument();
   });
 
   test('la guarda de leucaena/mimosina aparece en cerdos pero NO en reforestación', async () => {


### PR DESCRIPTION
## Summary
- Extiende `SeguimientoProcesoScreen` para que `Cerdos` deje de ser genérico y permita gestionar cochera, lotes y eventos porcícolas.
- La cochera se persiste en atributos del `FarmProcess` local; los lotes y eventos quedan registrados en el mismo flujo append-only que usan los otros procesos.
- Mantiene la guarda crítica de Leucaena para cerdos y deja el wire del home sin cambios de ruta.

## Test plan
- `npx vitest run src/components/__tests__/SeguimientoProcesoScreen.test.jsx src/config/__tests__/seguimientoProcesos.test.js src/types/__tests__/farmProcess.test.js`
- `npx vitest run tests/unit/boundaryAudit.test.js`
- `npx eslint src/components/SeguimientoProcesoScreen.jsx src/components/__tests__/SeguimientoProcesoScreen.test.jsx src/config/seguimientoProcesos.js src/config/__tests__/seguimientoProcesos.test.js src/types/farmProcess.js src/components/FarmProcessSummary.jsx --max-warnings=0`
- `npx vitest run` currently fails on preexisting tests outside this module scope.
- `npm run build` fails in this environment because the native `better-sqlite3` binding is missing.
