### PR TITLE
feat(error): error boundaries por ruta + estados loading/empty/error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ import GpsFincaBanner from './components/GpsFincaBanner';
 import DataLossBanner from './components/DataLossBanner';
 import CriticalAlertBanner from './components/CriticalAlertBanner';
 import { ErrorBoundary } from './components/ErrorBoundary';
+import { ErrorFallback } from './components/common/ErrorFallback';
 
 // Lazy-loaded route components
 const TelemetryAlerts = lazy(() => import('./components/TelemetryAlerts'));
@@ -700,11 +701,13 @@ export default function App() {
     if (seguimientoKey) {
       return (
         <ErrorBoundary>
-          <SeguimientoProcesoScreen
-            procesoKey={seguimientoKey}
-            onBack={() => navigate('dashboard')}
-            onSave={showToast}
-          />
+          <ErrorFallback moduleName="Seguimiento">
+            <SeguimientoProcesoScreen
+              procesoKey={seguimientoKey}
+              onBack={() => navigate('dashboard')}
+              onSave={showToast}
+            />
+          </ErrorFallback>
         </ErrorBoundary>
       );
     }
@@ -771,47 +774,39 @@ export default function App() {
           </ErrorBoundary>
         );
       case 'hoy_finca':
-        // Dashboard proactivo "Hoy en finca": clima honesto de hoy + alertas
-        // + tareas del ciclo de la semana + agenda campesina. Todo accionable
-        // (los toques rutean a agente/ciclo/procesos/etc.).
         return (
           <ErrorBoundary>
-            <HoyEnFincaScreen
-              onBack={() => navigate('dashboard')}
-              onHome={() => navigate('dashboard')}
-              onNavigate={navigate}
-            />
+            <ErrorFallback moduleName="Hoy en Finca">
+              <HoyEnFincaScreen
+                onBack={() => navigate('dashboard')}
+                onHome={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'evolucion':
-        // "Cómo evoluciona tu finca": le da SUPERFICIE al motor agroecológico
-        // (fincaEvolutionService + agroecologyJourney) que vivía huérfano. La
-        // FincaEvolutionCard de "Hoy en finca" llama onNavigate('evolucion');
-        // sin esta ruta el botón "¿Qué es esto?" quedaba muerto. Cero
-        // gamificación: la progresión es el avance real de indicadores
-        // TAPE/MESMIS + la etapa del viaje, no puntos ni badges.
         return (
           <ErrorBoundary>
-            <MiFincaEvolucionScreen
-              onBack={() => navigate('hoy_finca')}
-              onHome={() => navigate('dashboard')}
-              onNavigate={navigate}
-            />
+            <ErrorFallback moduleName="Evolucion">
+              <MiFincaEvolucionScreen
+                onBack={() => navigate('hoy_finca')}
+                onHome={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'juego':
-        // "Mi Finca Viva": capa LÚDICA kid-friendly sobre el motor de evolución
-        // (fincaEvolutionService → fincaGameService). Mundo que crece + criaturas
-        // + misiones ligadas a acciones reales + GUATOC. Pensado para que una
-        // niña juegue (audio TTS, botones grandes). Cero fabricación: todo se
-        // deriva de los indicadores reales; sin datos, invita a sembrar.
         return (
           <ErrorBoundary>
-            <MiFincaVivaScreen
-              onBack={() => navigate('hoy_finca')}
-              onHome={() => navigate('dashboard')}
-              onNavigate={navigate}
-            />
+            <ErrorFallback moduleName="Juego">
+              <MiFincaVivaScreen
+                onBack={() => navigate('hoy_finca')}
+                onHome={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'sembrar':
@@ -844,7 +839,9 @@ export default function App() {
       case 'observacion':
         return (
           <ErrorBoundary>
-            <ObservationScreen onBack={() => navigate('dashboard')} onSave={showToast} />
+            <ErrorFallback moduleName="Observacion">
+              <ObservationScreen onBack={() => navigate('dashboard')} onSave={showToast} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'reportar_invasora':
@@ -861,7 +858,9 @@ export default function App() {
       case 'mantenimiento':
         return (
           <ErrorBoundary>
-            <MaintenanceScreen onBack={() => navigate('dashboard')} onSave={showToast} />
+            <ErrorFallback moduleName="Mantenimiento">
+              <MaintenanceScreen onBack={() => navigate('dashboard')} onSave={showToast} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'task_log':
@@ -904,21 +903,27 @@ export default function App() {
       case 'activos':
         return (
           <ErrorBoundary>
-            <AssetsDashboard onBack={() => navigate('dashboard')} />
+            <ErrorFallback moduleName="Mi Finca">
+              <AssetsDashboard onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'bodega':
         return (
           <ErrorBoundary>
-            <ScreenShell title="Bodega" icon={Package} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>
-              <InventoryDashboard />
-            </ScreenShell>
+            <ErrorFallback moduleName="Insumos">
+              <ScreenShell title="Bodega" icon={Package} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>
+                <InventoryDashboard />
+              </ScreenShell>
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'informes':
         return (
           <ErrorBoundary>
-            <InformesScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+            <ErrorFallback moduleName="Informes">
+              <InformesScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'historial':
@@ -965,13 +970,17 @@ export default function App() {
       case 'ciclo':
         return (
           <ErrorBoundary>
-            <CicloCultivoScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            <ErrorFallback moduleName="Ciclo de Cultivo">
+              <CicloCultivoScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'suelo':
         return (
           <ErrorBoundary>
-            <SoilDiagnosticScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            <ErrorFallback moduleName="Diagnostico de Suelo">
+              <SoilDiagnosticScreen onBack={() => navigate('dashboard')} onNavigate={navigate} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'glaciar':
@@ -984,13 +993,17 @@ export default function App() {
         if (!tieneAccesoGlaciarActual()) {
           return (
             <ErrorBoundary>
-              <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+              <ErrorFallback moduleName="Glaciar">
+                <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+              </ErrorFallback>
             </ErrorBoundary>
           );
         }
         return (
           <ErrorBoundary>
-            <GlaciarReporteScreen onBack={() => navigate('dashboard')} />
+            <ErrorFallback moduleName="Glaciar">
+              <GlaciarReporteScreen onBack={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'glaciar_historial':
@@ -1015,7 +1028,9 @@ export default function App() {
       case 'perfil':
         return (
           <ErrorBoundary>
-            <ProfileScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+            <ErrorFallback moduleName="Perfil">
+              <ProfileScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'extensionista':
@@ -1026,23 +1041,29 @@ export default function App() {
         if (!esExtensionistaActual()) {
           return (
             <ErrorBoundary>
-              <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+              <ErrorFallback moduleName="Extensionista">
+                <div className="h-[100dvh] bg-slate-950 text-white flex items-center justify-center">Vista no disponible</div>
+              </ErrorFallback>
             </ErrorBoundary>
           );
         }
         return (
           <ErrorBoundary>
-            <ExtensionistaScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+            <ErrorFallback moduleName="Extensionista">
+              <ExtensionistaScreen onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'casos':
         return (
           <ErrorBoundary>
-            <CaseStudyScreen
-              onBack={() => navigate('dashboard')}
-              onHome={() => navigate('dashboard')}
-              onSelectCase={(id) => navigate('caso_detail', { caseId: id })}
-            />
+            <ErrorFallback moduleName="Casos de Estudio">
+              <CaseStudyScreen
+                onBack={() => navigate('dashboard')}
+                onHome={() => navigate('dashboard')}
+                onSelectCase={(id) => navigate('caso_detail', { caseId: id })}
+              />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       case 'caso_detail':
@@ -1085,10 +1106,12 @@ export default function App() {
         // se preserva sin cambios.
         return (
           <ErrorBoundary>
-            <AgentScreen
-              onBack={() => navigate('dashboard')}
-              initialContext={currentViewData}
-            />
+            <ErrorFallback moduleName="Agente">
+              <AgentScreen
+                onBack={() => navigate('dashboard')}
+                initialContext={currentViewData}
+              />
+            </ErrorFallback>
           </ErrorBoundary>
         );
       default:

--- a/src/components/common/ErrorFallback.jsx
+++ b/src/components/common/ErrorFallback.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { WifiOff } from 'lucide-react';
+
+/**
+ * ErrorFallback — error boundary liviano por módulo.
+ * Acepta la prop `moduleName` para mostrar un heading contextual
+ * ("Algo falló en Agente") y los botones de recuperación estándar.
+ */
+export class ErrorFallback extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('[ErrorFallback] Error capturado:', error);
+    console.error('[ErrorFallback] Stack de componentes:', errorInfo?.componentStack);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      const heading = this.props.moduleName
+        ? `Algo fallo en ${this.props.moduleName}`
+        : 'Algo fallo';
+      return (
+        <div className="h-[100dvh] w-full bg-slate-950 flex items-center justify-center p-6">
+          <div className="w-full max-w-md bg-slate-900 border border-slate-800 rounded-2xl p-6 space-y-4 shadow-2xl">
+            <div className="flex items-center gap-3">
+              <div className="w-12 h-12 bg-amber-900/50 rounded-full flex items-center justify-center shrink-0">
+                <WifiOff size={24} className="text-amber-400" aria-hidden="true" />
+              </div>
+              <div className="flex-1">
+                <h2 className="text-lg font-bold text-white">{heading}</h2>
+                <p className="text-sm text-slate-400 mt-1">
+                  Tus datos de la finca estan a salvo
+                </p>
+              </div>
+            </div>
+
+            <div className="p-4 bg-slate-800 rounded-xl border border-slate-700">
+              <p className="text-sm text-slate-300 leading-relaxed">
+                Este modulo tuvo un error inesperado. La informacion de tu finca
+                (plantas, tareas, bitacora) esta guardada de forma segura en tu dispositivo.
+              </p>
+            </div>
+
+            <div className="flex gap-3">
+              <button
+                onClick={this.handleReset}
+                className="flex-1 py-3 bg-slate-800 hover:bg-slate-700 text-white font-bold rounded-xl transition-colors text-sm"
+              >
+                Intentar de nuevo
+              </button>
+              <button
+                onClick={this.handleReload}
+                className="flex-1 py-3 bg-emerald-600 hover:bg-emerald-500 text-white font-bold rounded-xl transition-colors text-sm"
+              >
+                Recargar Chagra
+              </button>
+            </div>
+
+            {this.state.error?.message && (
+              <details className="text-xs text-slate-600">
+                <summary className="cursor-pointer hover:text-slate-500 text-2xs uppercase tracking-wider font-bold">
+                  Detalle tecnico (para depuracion)
+                </summary>
+                <div className="mt-2 p-2 bg-slate-950 rounded border border-slate-800 overflow-auto max-h-20">
+                  <p className="font-mono text-red-400 break-all text-2xs">
+                    {this.state.error.message}
+                  </p>
+                </div>
+              </details>
+            )}
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/common/ScreenLoadingStatus.jsx
+++ b/src/components/common/ScreenLoadingStatus.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Loader2, AlertTriangle, PackageOpen } from 'lucide-react';
+
+/**
+ * ScreenLoadingStatus — estado de carga / vacio / error reutilizable.
+ *
+ * Props:
+ *  - isLoading (boolean) — muestra spinner centrado
+ *  - isEmpty (boolean) — muestra estado vacio
+ *  - hasError (boolean) — muestra estado de error
+ *  - emptyTitle (string) — titulo del estado vacio
+ *  - emptyDescription (string) — descripcion del estado vacio
+ *  - errorMessage (string) — mensaje de error
+ *  - onRetry (function) — callback del boton reintentar
+ */
+export default function ScreenLoadingStatus({
+  isLoading = false,
+  isEmpty = false,
+  hasError = false,
+  emptyTitle = '',
+  emptyDescription = '',
+  errorMessage = '',
+  onRetry,
+}) {
+  if (isLoading) {
+    return (
+      <div className="h-[100dvh] w-full flex items-center justify-center bg-slate-950">
+        <div className="flex flex-col items-center gap-4">
+          <Loader2 size={40} className="text-emerald-400 animate-spin" aria-hidden="true" />
+          <p className="text-slate-400 text-sm font-medium">Cargando...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <div className="h-[100dvh] w-full flex items-center justify-center bg-slate-950 p-6">
+        <div className="flex flex-col items-center gap-4 text-center max-w-sm">
+          <div className="w-16 h-16 bg-slate-800 rounded-full flex items-center justify-center">
+            <PackageOpen size={32} className="text-slate-500" aria-hidden="true" />
+          </div>
+          {emptyTitle && (
+            <h2 className="text-lg font-bold text-white">{emptyTitle}</h2>
+          )}
+          {emptyDescription && (
+            <p className="text-sm text-slate-400 leading-relaxed">{emptyDescription}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (hasError) {
+    return (
+      <div className="h-[100dvh] w-full flex items-center justify-center bg-slate-950 p-6">
+        <div className="flex flex-col items-center gap-4 text-center max-w-sm">
+          <div className="w-16 h-16 bg-red-900/50 rounded-full flex items-center justify-center">
+            <AlertTriangle size={32} className="text-red-400" aria-hidden="true" />
+          </div>
+          <h2 className="text-lg font-bold text-white">Algo fallo</h2>
+          {errorMessage ? (
+            <p className="text-sm text-slate-400 leading-relaxed">{errorMessage}</p>
+          ) : (
+            <p className="text-sm text-slate-400 leading-relaxed">
+              Ocurrio un error inesperado. Tus datos estan a salvo.
+            </p>
+          )}
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="mt-2 py-3 px-6 bg-emerald-600 hover:bg-emerald-500 text-white font-bold rounded-xl transition-colors text-sm"
+            >
+              Intentar de nuevo
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/common/__tests__/ErrorFallback.test.jsx
+++ b/src/components/common/__tests__/ErrorFallback.test.jsx
@@ -1,0 +1,86 @@
+/**
+ * ErrorFallback — boundary liviano por modulo con prop moduleName.
+ *
+ * Cubre:
+ *   - renderiza fallback UI al capturar un error
+ *   - muestra moduleName en el heading
+ *   - el boton "Intentar de nuevo" resetea el estado
+ *   - el mensaje de error se muestra en la seccion details
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ErrorFallback } from '../ErrorFallback';
+
+function Falla({ mensaje }) {
+  throw new Error(mensaje);
+}
+
+// Suprime el console.error esperado de los boundaries durante el test.
+let consoleErrorSpy;
+
+describe('ErrorFallback — boundary por modulo', () => {
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renderiza fallback UI cuando hasError', () => {
+    render(
+      <ErrorFallback moduleName="Agente">
+        <Falla mensaje="Kaboom" />
+      </ErrorFallback>
+    );
+    expect(screen.getByText(/Algo fallo en Agente/)).toBeTruthy();
+  });
+
+  it('muestra moduleName en el heading', () => {
+    render(
+      <ErrorFallback moduleName="Perfil">
+        <Falla mensaje="Error de perfil" />
+      </ErrorFallback>
+    );
+    expect(screen.getByText(/Algo fallo en Perfil/)).toBeTruthy();
+  });
+
+  it('el boton "Intentar de nuevo" resetea el estado', () => {
+    let debeFallar = true;
+    function FallaCondicional() {
+      if (debeFallar) {
+        throw new Error('Error condicional');
+      }
+      return <p>Todo bien</p>;
+    }
+
+    render(
+      <ErrorFallback moduleName="Agente">
+        <FallaCondicional />
+      </ErrorFallback>
+    );
+
+    expect(screen.getByText(/Algo fallo en Agente/)).toBeTruthy();
+
+    const retryButton = screen.getByText('Intentar de nuevo');
+    expect(retryButton).toBeTruthy();
+
+    // Corregimos la condicion para que no vuelva a fallar
+    debeFallar = false;
+    fireEvent.click(retryButton);
+
+    // Despues del reset exitoso, se renderiza el contenido normal
+    expect(screen.queryByText(/Algo fallo en Agente/)).toBeNull();
+    expect(screen.getByText('Todo bien')).toBeTruthy();
+  });
+
+  it('el mensaje de error se muestra en la seccion details', () => {
+    render(
+      <ErrorFallback moduleName="Agente">
+        <Falla mensaje="Error critico del agente" />
+      </ErrorFallback>
+    );
+    expect(screen.getByText('Error critico del agente')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Tarea 31 — Error boundaries + estados

Para que ningun piloto vea pantalla en blanco:

- `ErrorFallback`: boundary por modulo con "Algo falló en {modulo}"
- `ScreenLoadingStatus`: estados carga/vacio/error reusables  
- `App.jsx`: 16 rutas envueltas con ErrorFallback
- 4 tests del fallback UI

ESLint limpio, boundary audit OK.