### PR TITLE
fix(bench): skip infra faltante en benches

### DIFF
--- a/scripts/__tests__/bench-skip-guards.test.mjs
+++ b/scripts/__tests__/bench-skip-guards.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..', '..');
+
+function runScript(script, env = {}) {
+  return spawnSync('node', [join(ROOT_DIR, script)], {
+    cwd: ROOT_DIR,
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  });
+}
+
+describe('bench skip guards', () => {
+  it('vision pipeline salta limpio sin token', () => {
+    const r = runScript('scripts/bench-vision-pipeline.mjs', { CHAGRA_MCP_TOKEN: '' });
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('SKIP: falta CHAGRA_MCP_TOKEN');
+  });
+
+  it('vision ab rag salta limpio sin ground truth', () => {
+    const r = runScript('scripts/bench-vision-ab-rag.mjs', {
+      VISION_GROUND_TRUTH_PATH: '/no/such/ground-truth.json',
+    });
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('SKIP: no existe ground truth');
+  });
+
+  it('borde y complejos saltan limpio si falta la fixture de prompts', () => {
+    const r1 = runScript('scripts/bench-borde-alucinacion.mjs', {
+      PROMPTS_FILE: '/no/such/file.json',
+    });
+    expect(r1.status).toBe(0);
+    expect(`${r1.stdout}${r1.stderr}`).toContain('SKIP: falta fixture de prompts');
+
+    const r2 = runScript('scripts/bench-complejos-juez-independiente.mjs', {
+      PROMPTS_FILE: '/no/such/file.json',
+    });
+    expect(r2.status).toBe(0);
+    expect(`${r2.stdout}${r2.stderr}`).toContain('SKIP: no existe fixture de prompts');
+  });
+});

--- a/scripts/bench-borde-alucinacion.mjs
+++ b/scripts/bench-borde-alucinacion.mjs
@@ -133,6 +133,11 @@ const BENCH_REPS = Math.max(1, Number(process.env.BENCH_REPS || 1));
 const GPU_TEMP_LIMIT = 88;
 const GPU_TEMP_RESUME = 75;
 
+function skip(reason) {
+  console.log(`[bench-borde] SKIP: ${reason}`);
+  process.exit(0);
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 function getSidecarToken() {
@@ -556,6 +561,12 @@ async function runRep(prompts, { seed, repIndex, reps }) {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
+  if (!PROMPTS_FILES.every((file) => existsSync(file))) {
+    skip(`falta fixture de prompts: ${PROMPTS_FILES.filter((file) => !existsSync(file)).join(', ')}`);
+  }
+  if (!process.env.SIDECAR_TOKEN && !existsSync(`${process.env.HOME}/.config/chagra-sidecar-token.txt`)) {
+    skip('falta token del sidecar');
+  }
   assertCheckoutCurrent({
     cwd: ROOT_DIR,
     autoPull: process.env.BENCH_AUTO_PULL === '1',

--- a/scripts/bench-complejos-juez-independiente.mjs
+++ b/scripts/bench-complejos-juez-independiente.mjs
@@ -106,6 +106,11 @@ const PROMPTS_FILE =
 const GPU_TEMP_LIMIT = 88;
 const GPU_TEMP_RESUME = 75;
 
+function skip(reason) {
+  console.log(`[bench-complejos] SKIP: ${reason}`);
+  process.exit(0);
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // ── helpers (delegan al lib compartido scripts/lib/bench-sidecar.mjs) ─────────
@@ -168,6 +173,7 @@ function judgeOllamaCall(prompt) {
 // ── main ──────────────────────────────────────────────────────────────────────
 
 async function main() {
+  if (!existsSync(PROMPTS_FILE)) skip(`no existe fixture de prompts: ${PROMPTS_FILE}`);
   // Guarda ANTI-STALE (PASO 0): aborta si el checkout está atrás de origin/main.
   // El "10% AH" previo fue artefacto de correr código viejo (sin #1240). Ningún
   // bench debe volver a medir código que el usuario ya no ve.

--- a/scripts/bench-rag-retrieve.mjs
+++ b/scripts/bench-rag-retrieve.mjs
@@ -29,6 +29,7 @@
  * public/cycle-content/, simulando el flujo de carga del PWA.
  */
 import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -121,8 +122,20 @@ function percentile(sorted, p) {
 
 async function main() {
   const emitHistory = process.argv.includes('--history');
-  // Import dinamico para que el stub de fetch ya este en su lugar.
-  const { retrieve, getCorpusStats } = await import('../src/services/ragRetriever.js');
+  if (!existsSync(CORPUS_ROOT)) {
+    console.log(`[bench] SKIP: no existe corpus en ${CORPUS_ROOT}`);
+    return;
+  }
+
+  let retrieve;
+  let getCorpusStats;
+  try {
+    // Import dinamico para que el stub de fetch ya este en su lugar.
+    ({ retrieve, getCorpusStats } = await import('../src/services/ragRetriever.js'));
+  } catch (err) {
+    console.log(`[bench] SKIP: no se pudo importar ragRetriever.js (${String(err.message).slice(0, 120)})`);
+    return;
+  }
 
   console.log('[bench] Cold load: cargando corpus completo + primera query...');
   const coldStart = performance.now();

--- a/scripts/bench-vision-ab-rag.mjs
+++ b/scripts/bench-vision-ab-rag.mjs
@@ -44,11 +44,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 
-const FIXTURES_DIR = "/home/kortux/Workspace/Chagra-strategy/ops/antigravity/fixtures-fotos";
-const EXTENDED_DIR = "/home/kortux/Workspace/chagra/data/bench-vision-fixtures-extended";
-const GROUND_TRUTH_PATH = "/home/kortux/Workspace/chagra/data/bench-vision-fixtures-ground-truth.json";
+const FIXTURES_DIR = process.env.VISION_FIXTURES_DIR || "/home/kortux/Workspace/Chagra-strategy/ops/antigravity/fixtures-fotos";
+const EXTENDED_DIR = process.env.VISION_EXTENDED_DIR || "/home/kortux/Workspace/chagra/data/bench-vision-fixtures-extended";
+const GROUND_TRUTH_PATH = process.env.VISION_GROUND_TRUTH_PATH || "/home/kortux/Workspace/chagra/data/bench-vision-fixtures-ground-truth.json";
 const EXTENDED_MANIFEST_PATH = path.join(EXTENDED_DIR, "manifest.json");
-const CATALOG_PATH = "/home/kortux/Workspace/chagra/catalog/chagra-catalog-oss-subset-v3.2.json";
+const CATALOG_PATH = process.env.VISION_CATALOG_PATH || "/home/kortux/Workspace/chagra/catalog/chagra-catalog-oss-subset-v3.2.json";
 
 const OLLAMA = process.env.OLLAMA_URL || "http://127.0.0.1:11434";
 const SIDECAR = process.env.SIDECAR_URL || "http://127.0.0.1:7880";
@@ -76,16 +76,24 @@ const args = new Set(process.argv.slice(2));
 const GROUND_TRUTH_ONLY = args.has("--ground-truth-only") || args.has("--no-extended");
 
 if (!TOKEN) {
-  console.error("CHAGRA_MCP_TOKEN env var required (read from /run/secrets/chagra-agro-mcp-env)");
-  process.exit(2);
+  console.log("[bench-vision-ab-rag] SKIP: falta CHAGRA_MCP_TOKEN");
+  process.exit(0);
 }
 if (!fs.existsSync(GROUND_TRUTH_PATH)) {
-  console.error(`Ground truth file not found: ${GROUND_TRUTH_PATH}`);
-  process.exit(2);
+  console.log(`[bench-vision-ab-rag] SKIP: no existe ground truth: ${GROUND_TRUTH_PATH}`);
+  process.exit(0);
+}
+if (!fs.existsSync(FIXTURES_DIR)) {
+  console.log(`[bench-vision-ab-rag] SKIP: no existe directorio de fixtures: ${FIXTURES_DIR}`);
+  process.exit(0);
+}
+if (!fs.existsSync(CATALOG_PATH)) {
+  console.log(`[bench-vision-ab-rag] SKIP: no existe catalogo: ${CATALOG_PATH}`);
+  process.exit(0);
 }
 
 const RUN_ID = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-const OUT_DIR = path.join("/home/kortux/Workspace/chagra/data/bench-runs", `vision-ab-rag-${RUN_ID}`);
+const OUT_DIR = path.join(process.env.BENCH_OUTPUT_DIR || "/home/kortux/Workspace/chagra/data/bench-runs", `vision-ab-rag-${RUN_ID}`);
 fs.mkdirSync(OUT_DIR, { recursive: true });
 const RAW_PATH = path.join(OUT_DIR, "raw.jsonl");
 

--- a/scripts/bench-vision-pipeline.mjs
+++ b/scripts/bench-vision-pipeline.mjs
@@ -24,22 +24,28 @@ import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 
-const FIXTURES_DIR = "/home/kortux/Workspace/Chagra-strategy/ops/antigravity/fixtures-fotos";
-const GROUND_TRUTH = JSON.parse(
-  fs.readFileSync("/home/kortux/Workspace/chagra/data/bench-vision-fixtures-ground-truth.json", "utf-8"),
-);
+const DEFAULT_FIXTURES_DIR = "/home/kortux/Workspace/Chagra-strategy/ops/antigravity/fixtures-fotos";
+const DEFAULT_GROUND_TRUTH_PATH = "/home/kortux/Workspace/chagra/data/bench-vision-fixtures-ground-truth.json";
+const FIXTURES_DIR = process.env.VISION_FIXTURES_DIR || DEFAULT_FIXTURES_DIR;
+const GROUND_TRUTH_PATH = process.env.VISION_GROUND_TRUTH_PATH || DEFAULT_GROUND_TRUTH_PATH;
 const OLLAMA = process.env.OLLAMA_URL || "http://127.0.0.1:11434";
 const SIDECAR = process.env.SIDECAR_URL || "http://127.0.0.1:7880";
 const TOKEN = process.env.CHAGRA_MCP_TOKEN || "";
 const PRIMARY_MODEL = process.env.VISION_MODEL || "llama3.2-vision:11b";
 
-if (!TOKEN) {
-  console.error("CHAGRA_MCP_TOKEN env var required (read from /run/secrets/chagra-agro-mcp-env)");
-  process.exit(2);
+function skip(reason) {
+  console.log(`[bench-vision-pipeline] SKIP: ${reason}`);
+  process.exit(0);
 }
 
+if (!TOKEN) skip("falta CHAGRA_MCP_TOKEN");
+if (!fs.existsSync(GROUND_TRUTH_PATH)) skip(`no existe ground truth: ${GROUND_TRUTH_PATH}`);
+if (!fs.existsSync(FIXTURES_DIR)) skip(`no existe directorio de fixtures: ${FIXTURES_DIR}`);
+
+const GROUND_TRUTH = JSON.parse(fs.readFileSync(GROUND_TRUTH_PATH, "utf-8"));
+
 const RUN_ID = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-const OUT_DIR = path.join("/home/kortux/Workspace/chagra/data/bench-runs", `vision-pipeline-${RUN_ID}`);
+const OUT_DIR = path.join(process.env.BENCH_OUTPUT_DIR || "/home/kortux/Workspace/chagra/data/bench-runs", `vision-pipeline-${RUN_ID}`);
 fs.mkdirSync(OUT_DIR, { recursive: true });
 
 const SPECIES_PROMPT =


### PR DESCRIPTION
## Summary
- Agregué guards de arranque y de fixtures faltantes para que los benches de visión, RAG y prompts complejos salgan con SKIP explícito cuando falta infraestructura o archivos externos.
- Añadí una prueba de proceso real para validar que los scripts degradan limpio y no rompen `--all`.

## Test plan
- `npx vitest run scripts/__tests__/bench-skip-guards.test.mjs`
- `npx eslint scripts/bench-vision-pipeline.mjs scripts/bench-vision-ab-rag.mjs scripts/bench-rag-retrieve.mjs scripts/bench-borde-alucinacion.mjs scripts/bench-complejos-juez-independiente.mjs scripts/__tests__/bench-skip-guards.test.mjs --max-warnings=0`
- `NODE_OPTIONS=--max-old-space-size=4096 npx eslint . --max-warnings=0` intentado, pero el proceso quedó sin memoria en este árbol grande
- `npm run build` intentado, pero falla por un binding ausente de `better-sqlite3` en este entorno
