### PR TITLE
feat(extensionista): add active finca selector

### DIFF
--- a/src/components/ExtensionistaScreen.jsx
+++ b/src/components/ExtensionistaScreen.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   Users, MapPin, AlertTriangle, Clock, CheckCircle2, FlaskConical,
   Sprout, Info, UserCircle2,
@@ -7,6 +7,7 @@ import { ScreenShell } from './common/ScreenShell';
 import { esExtensionistaActual } from '../config/extensionistaAccess';
 import { construirTableroExtensionista } from '../services/extensionistaService';
 import { getActiveTenantId } from '../services/tenantContext';
+import useFincaActiveStore from '../services/fincaActiveStore';
 
 /**
  * ExtensionistaScreen — Panel SUPERVISOR del modo extensionista (ADR-048 MVP).
@@ -131,11 +132,23 @@ export default function ExtensionistaScreen({ onBack, onHome }) {
   // pantalla se monta por una ruta directa). Si no hay rol → no construimos el
   // tablero ni mostramos fincas.
   const tieneRol = esExtensionistaActual();
+  const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
+  const setActiveFinca = useFincaActiveStore((s) => s.setActiveFinca);
 
   const tablero = useMemo(
     () => (tieneRol ? construirTableroExtensionista(getActiveTenantId()) : null),
     [tieneRol]
   );
+
+  const fincasDelegadas = useMemo(() => tablero?.fincas || [], [tablero]);
+
+  useEffect(() => {
+    if (!tieneRol || fincasDelegadas.length === 0) return;
+    const activeExists = fincasDelegadas.some((f) => f.slug === activeFincaSlug);
+    if (!activeExists) {
+      setActiveFinca(fincasDelegadas[0].slug);
+    }
+  }, [activeFincaSlug, fincasDelegadas, setActiveFinca, tieneRol]);
 
   if (!tieneRol) {
     return (
@@ -163,6 +176,32 @@ export default function ExtensionistaScreen({ onBack, onHome }) {
           vistazo. Lo urgente aparece arriba. Toca una finca para ver su detalle
           (próximamente).
         </p>
+
+        {fincasDelegadas.length > 0 && (
+          <div className="rounded-2xl border border-emerald-700/30 bg-emerald-950/20 p-4 space-y-3">
+            <div>
+              <p className="text-sm font-semibold text-emerald-200">Finca activa</p>
+              <p className="text-xs text-emerald-300/80">
+                Elige cuál de las fincas delegadas quieres gestionar ahora.
+              </p>
+            </div>
+            <label className="block">
+              <span className="sr-only">Selector de finca activa</span>
+              <select
+                data-testid="finca-selector"
+                value={activeFincaSlug}
+                onChange={(e) => setActiveFinca(e.target.value)}
+                className="w-full rounded-xl border border-emerald-700/40 bg-slate-950/60 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400"
+              >
+                {fincasDelegadas.map((finca) => (
+                  <option key={finca.slug} value={finca.slug}>
+                    {finca.nombre} ({finca.municipio || 'sin municipio'})
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        )}
 
         {/* Aviso de frontera MVP — para no confundir vista previa con permiso real. */}
         <div className="rounded-xl border border-sky-700/40 bg-sky-900/20 p-3 text-xs text-sky-200 flex items-start gap-2">
@@ -197,7 +236,18 @@ export default function ExtensionistaScreen({ onBack, onHome }) {
         ) : (
           <div className="flex flex-col gap-3">
             {fincas.map((finca) => (
-              <FincaCard key={finca.slug} finca={finca} />
+              <button
+                key={finca.slug}
+                type="button"
+                onClick={() => setActiveFinca(finca.slug)}
+                className={`text-left rounded-2xl border transition-colors ${
+                  finca.slug === activeFincaSlug
+                    ? 'border-emerald-500/70 ring-1 ring-emerald-500/40'
+                    : 'border-slate-700/60 hover:border-slate-500/80'
+                }`}
+              >
+                <FincaCard finca={finca} />
+              </button>
             ))}
           </div>
         )}

--- a/src/components/__tests__/ExtensionistaScreen.test.jsx
+++ b/src/components/__tests__/ExtensionistaScreen.test.jsx
@@ -24,12 +24,39 @@ const { construirTableroExtensionista } = vi.hoisted(() => ({
   construirTableroExtensionista: vi.fn(),
 }));
 const { getActiveTenantId } = vi.hoisted(() => ({ getActiveTenantId: vi.fn() }));
+const { useFincaActiveStoreMock } = vi.hoisted(() => ({
+  useFincaActiveStoreMock: Object.assign(
+    vi.fn((selector) =>
+      selector({
+        activeFincaSlug: 'finca-el-paramo',
+        setActiveFinca: vi.fn(),
+      })
+    ),
+    {
+      getState: vi.fn(() => ({
+        activeFincaSlug: 'finca-el-paramo',
+        setActiveFinca: vi.fn(),
+      })),
+    }
+  ),
+}));
 
 vi.mock('../../config/extensionistaAccess', () => ({ esExtensionistaActual }));
 vi.mock('../../services/extensionistaService', () => ({
   construirTableroExtensionista,
 }));
 vi.mock('../../services/tenantContext', () => ({ getActiveTenantId }));
+vi.mock('../../services/fincaActiveStore', () => ({ default: useFincaActiveStoreMock }));
+vi.mock('../../components/common/ScreenShell', () => ({
+  ScreenShell: ({ children, onBack }) => (
+    <div>
+      <button type="button" aria-label="Volver" onClick={onBack}>
+        Volver
+      </button>
+      {children}
+    </div>
+  ),
+}));
 
 import ExtensionistaScreen from '../ExtensionistaScreen';
 
@@ -101,6 +128,26 @@ describe('ExtensionistaScreen — con rol extensionista', () => {
     expect(screen.getByText(/pedro_g/)).toBeInTheDocument();
     expect(screen.getByText(/Sin sincronizar hace días/)).toBeInTheDocument();
     expect(screen.getByText(/Al día/)).toBeInTheDocument();
+  });
+
+  it('muestra selector de finca activa y permite cambiar la delegada activa', () => {
+    const setActiveFinca = vi.fn();
+    useFincaActiveStoreMock.mockImplementation((selector) =>
+      selector({ activeFincaSlug: 'finca-la-esperanza', setActiveFinca })
+    );
+    useFincaActiveStoreMock.getState.mockReturnValue({
+      activeFincaSlug: 'finca-la-esperanza',
+      setActiveFinca,
+    });
+    construirTableroExtensionista.mockReturnValue(TABLERO);
+    render(<ExtensionistaScreen onBack={() => {}} />);
+
+    const selector = screen.getByTestId('finca-selector');
+    expect(selector).toBeInTheDocument();
+    expect(selector.value).toBe('finca-la-esperanza');
+
+    fireEvent.change(selector, { target: { value: 'finca-el-paramo' } });
+    expect(setActiveFinca).toHaveBeenCalledWith('finca-el-paramo');
   });
 
   it('muestra el aviso de frontera MVP (datos de ejemplo, no autorización real)', () => {

--- a/tests/multifinca.spec.js
+++ b/tests/multifinca.spec.js
@@ -185,4 +185,33 @@ test.describe('multifinca client-side scoping (ADR-036 MVP)', () => {
     expect(byIdUrl).toBeDefined();
     expect(byIdUrl).not.toContain('filter[uid');
   });
+
+  test('extensionista cambia la finca activa dentro de sus delegadas', async ({ page }) => {
+    await page.evaluate(async () => {
+      const tenantMod = await import('/src/services/tenantContext.js');
+      const fincaMod = await import('/src/services/fincaActiveStore.js');
+      const extMod = await import('/src/services/extensionistaService.js');
+      tenantMod.setActiveTenantId('demo-extensionista');
+      const tablero = extMod.construirTableroExtensionista('demo-extensionista');
+      const first = tablero.fincas[0];
+      const second = tablero.fincas[1];
+      if (!first || !second) {
+        throw new Error('seed extensionista incompleto');
+      }
+      fincaMod.useFincaActiveStore.setState({
+        activeFincaSlug: first.slug,
+        fincas: tablero.fincas.map((f) => ({
+          slug: f.slug,
+          nombre: f.nombre,
+          municipio: f.municipio,
+          farmos_endpoint: null,
+        })),
+      });
+      fincaMod.useFincaActiveStore.getState().setActiveFinca(second.slug);
+      window.__fincaActiveSlug = fincaMod.useFincaActiveStore.getState().activeFincaSlug;
+    });
+
+    const activeSlug = await page.evaluate(() => window.__fincaActiveSlug);
+    expect(activeSlug).toBe('finca-buenos-aires');
+  });
 });


### PR DESCRIPTION
## Summary\n- Add active finca selector to ExtensionistaScreen for delegated farms.\n- Sync selected finca with fincaActiveStore and highlight the active card.\n- Extend unit and Playwright coverage for tenant scoping and finca switching.\n\n## Test plan\n- npx vitest run\n- npx eslint src/components/ExtensionistaScreen.jsx src/components/__tests__/ExtensionistaScreen.test.jsx tests/multifinca.spec.js --max-warnings=0\n- npx vitest run src/components/__tests__/ExtensionistaScreen.test.jsx src/services/__tests__/tenantContext.test.js tests/multifinca.spec.js\n\n## Notes\n- npx eslint . --max-warnings=0 hit Node heap limits in this environment.\n- npm run build failed because better-sqlite3 native bindings are missing in this workspace.