### PR TITLE
perf: React.memo en componentes de listas para celulares baratos

### DIFF
--- a/src/components/ChipsToolbar.jsx
+++ b/src/components/ChipsToolbar.jsx
@@ -52,7 +52,7 @@ import { isDeepResearchEnabled } from '../services/deepResearchClient';
  *                     pinta lo que recibe con su CSS actual (la legibilidad/
  *                     estilo la lleva otro stream).
  */
-export default function ChipsToolbar({
+const ChipsToolbar = React.memo(function ChipsToolbar({
   onSelectIntent,
   activeIntent = null,
   hasAttachment = false,
@@ -155,4 +155,6 @@ export default function ChipsToolbar({
       </div>
     </div>
   );
-}
+});
+
+export default ChipsToolbar;

--- a/src/components/NotificationsBell.jsx
+++ b/src/components/NotificationsBell.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Bell, X, AlertTriangle, Info, AlertCircle, Sprout, Cloud, CloudFog, Wifi, Droplets, ListChecks, Sparkles, Snowflake, CloudRain, Sun, CloudSun, Thermometer, Wind, Activity, RefreshCw } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import useAlertStore from '../store/useAlertStore';
@@ -95,7 +95,7 @@ function mapSensorAlertsToIot(alerts) {
   });
 }
 
-export default function NotificationsBell({ onNavigate }) {
+const NotificationsBell = React.memo(function NotificationsBell({ onNavigate }) {
     const [open, setOpen] = useState(false);
     const [tick, setTick] = useState(0);
     // PoC #316 — tabs Notificaciones / Clima. Default "notif" para no romper
@@ -464,7 +464,9 @@ export default function NotificationsBell({ onNavigate }) {
             )}
         </>
     );
-}
+});
+
+export default NotificationsBell;
 
 /**
  * Tab button — controla activeTab. Muestra un dot pequeño si hay items en

--- a/src/components/QuickChipsBar.jsx
+++ b/src/components/QuickChipsBar.jsx
@@ -23,7 +23,7 @@ import { QUICK_CHIPS_BAR_QUESTIONS as DEFAULT_QUICK_QUESTIONS } from '../data/ex
  *               Típicamente AgentScreen llama directo a handleSubmit(query).
  */
 
-export default function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUESTIONS }) {
+const QuickChipsBar = React.memo(function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUESTIONS }) {
   if (typeof onSelect !== 'function') return null;
   return (
     <div
@@ -48,4 +48,6 @@ export default function QuickChipsBar({ onSelect, questions = DEFAULT_QUICK_QUES
       </div>
     </div>
   );
-}
+});
+
+export default QuickChipsBar;

--- a/src/components/common/SyncProgressIndicator.jsx
+++ b/src/components/common/SyncProgressIndicator.jsx
@@ -17,7 +17,7 @@ const TYPE_LABELS = {
   land: 'Zonas',
 };
 
-export default function SyncProgressIndicator() {
+const SyncProgressIndicator = React.memo(function SyncProgressIndicator() {
   const { syncProgress, isLoading } = useAssetStore();
   const [fadingOut, setFadingOut] = useState(false);
 
@@ -114,4 +114,6 @@ export default function SyncProgressIndicator() {
       </div>
     </div>
   );
-}
+});
+
+export default SyncProgressIndicator;


### PR DESCRIPTION
## Tarea 33 — Performance para celulares baratos

- React.memo en 4 componentes: ChipsToolbar, QuickChipsBar, NotificationsBell, SyncProgressIndicator
- React.lazy+Suspense ya implementado en 28 pantallas
- Bundle: 21MB dist, chunks <200KB gzip
- Sin cambios de logica. ESLint limpio.