### PR TITLE
feat(demo): switch de perfil in-app para operador

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ import AndroidInstallBanner from './components/AndroidInstallBanner';
 import UpdateAvailableBanner from './components/UpdateAvailableBanner';
 import GpsFincaBanner from './components/GpsFincaBanner';
 import DataLossBanner from './components/DataLossBanner';
+import DemoModeBanner from './components/DemoModeBanner';
 import CriticalAlertBanner from './components/CriticalAlertBanner';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
@@ -1161,6 +1162,7 @@ export default function App() {
           )}
         </div>
       )}
+      <DemoModeBanner />
     </>
   );
 }

--- a/src/components/DemoModeBanner.jsx
+++ b/src/components/DemoModeBanner.jsx
@@ -1,0 +1,106 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { DEMO_PROFILES, applyDemoProfile, clearDemoProfile, isDemoActive } from '../services/demoProfile';
+
+export default function DemoModeBanner() {
+  const [_active, setActive] = useState(isDemoActive);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const hidden = !(
+    (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_DEMO_MODE === 'true') ||
+    (typeof window !== 'undefined' && window.localStorage.getItem('chagra:demo:switch-active') === '1')
+  );
+
+  useEffect(() => {
+    const handler = () => {
+      setActive(isDemoActive());
+      const stored = (() => {
+        try {
+          const raw = window.localStorage.getItem('chagra:profile:v1');
+          return raw ? JSON.parse(raw) : null;
+        } catch (_) {
+          return null;
+        }
+      })();
+      if (stored) {
+        const idx = DEMO_PROFILES.findIndex(
+          (p) => JSON.stringify(p.profile) === JSON.stringify(stored)
+        );
+        if (idx >= 0) setCurrentIndex(idx);
+      }
+    };
+    window.addEventListener('chagra:profile:demo-switched', handler);
+    return () => window.removeEventListener('chagra:profile:demo-switched', handler);
+  }, []);
+
+  const goPrev = useCallback(() => {
+    const next = currentIndex === 0 ? DEMO_PROFILES.length - 1 : currentIndex - 1;
+    setCurrentIndex(next);
+    applyDemoProfile(DEMO_PROFILES[next].id);
+  }, [currentIndex]);
+
+  const goNext = useCallback(() => {
+    const next = (currentIndex + 1) % DEMO_PROFILES.length;
+    setCurrentIndex(next);
+    applyDemoProfile(DEMO_PROFILES[next].id);
+  }, [currentIndex]);
+
+  const handleExit = useCallback(() => {
+    clearDemoProfile();
+    setActive(false);
+  }, []);
+
+  if (hidden) return null;
+
+  const current = DEMO_PROFILES[currentIndex];
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50 bg-slate-900/95 border-t border-slate-700/60 px-4 py-3 flex items-center justify-between gap-3 text-white shadow-[0_-4px_24px_rgba(0,0,0,0.5)]"
+      role="region"
+      aria-label="Selector de perfil demo"
+      style={{ paddingBottom: 'calc(12px + env(safe-area-inset-bottom))' }}
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <span className="text-xs font-bold text-amber-400 uppercase tracking-wide shrink-0">
+          Demo
+        </span>
+        <span className="text-lg shrink-0" aria-hidden="true">{current.emoji}</span>
+        <span className="text-sm font-semibold truncate">{current.label}</span>
+      </div>
+
+      <div className="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onClick={goPrev}
+          className="p-1.5 rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors"
+          aria-label="Perfil demo anterior"
+        >
+          <ChevronLeft size={18} aria-hidden="true" />
+        </button>
+
+        <span className="text-xs text-slate-400 w-16 text-center tabular-nums">
+          {currentIndex + 1} / {DEMO_PROFILES.length}
+        </span>
+
+        <button
+          type="button"
+          onClick={goNext}
+          className="p-1.5 rounded-lg hover:bg-white/10 active:bg-white/20 transition-colors"
+          aria-label="Perfil demo siguiente"
+        >
+          <ChevronRight size={18} aria-hidden="true" />
+        </button>
+
+        <button
+          type="button"
+          onClick={handleExit}
+          className="ml-2 px-3 py-1.5 rounded-lg bg-red-600/80 hover:bg-red-600 active:bg-red-700 text-xs font-bold uppercase tracking-wide transition-colors border border-red-500/50 flex items-center gap-1"
+          aria-label="Salir del modo demo"
+        >
+          <X size={14} aria-hidden="true" />
+          Salir del demo
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/DemoModeBanner.test.jsx
+++ b/src/components/__tests__/DemoModeBanner.test.jsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DemoModeBanner from '../DemoModeBanner';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubEnv('VITE_DEMO_MODE', '');
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.unstubAllEnvs();
+});
+
+describe('DemoModeBanner', () => {
+  it('renders when VITE_DEMO_MODE is true', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByRole('region', { name: /selector de perfil demo/i })).toBeInTheDocument();
+  });
+
+  it('does not render when VITE_DEMO_MODE is not true and switch-active is not set', () => {
+    const { container } = render(<DemoModeBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders when localStorage chagra:demo:switch-active is "1" without env var', () => {
+    localStorage.setItem('chagra:demo:switch-active', '1');
+    render(<DemoModeBanner />);
+    expect(screen.getByRole('region', { name: /selector de perfil demo/i })).toBeInTheDocument();
+  });
+
+  it('shows "Demo" label', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByText('Demo')).toBeInTheDocument();
+  });
+
+  it('shows campesino label and emoji by default', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByText('Campesino')).toBeInTheDocument();
+  });
+
+  it('cycles forward through profiles with right arrow', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    const nextBtn = screen.getByLabelText('Perfil demo siguiente');
+    fireEvent.click(nextBtn);
+    expect(screen.getByText('Urbano (terraza)')).toBeInTheDocument();
+  });
+
+  it('cycles backward through profiles with left arrow', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    const prevBtn = screen.getByLabelText('Perfil demo anterior');
+    fireEvent.click(prevBtn);
+    expect(screen.getByText('Tecnico / agronomo')).toBeInTheDocument();
+  });
+
+  it('shows page counter', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByText('1 / 6')).toBeInTheDocument();
+  });
+
+  it('"Salir del demo" button clears localStorage demo keys', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    localStorage.setItem('chagra:profile:v1', JSON.stringify({ rol: 'campesino' }));
+    localStorage.setItem('chagra:demo:switch-active', '1');
+    render(<DemoModeBanner />);
+    const exitBtn = screen.getByLabelText('Salir del modo demo');
+    fireEvent.click(exitBtn);
+    expect(localStorage.getItem('chagra:profile:v1')).toBeNull();
+    expect(localStorage.getItem('chagra:demo:switch-active')).toBeNull();
+  });
+
+  it('left arrow has aria-label', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByLabelText('Perfil demo anterior')).toBeInTheDocument();
+  });
+
+  it('right arrow has aria-label', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByLabelText('Perfil demo siguiente')).toBeInTheDocument();
+  });
+
+  it('exit button has aria-label', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    render(<DemoModeBanner />);
+    expect(screen.getByLabelText('Salir del modo demo')).toBeInTheDocument();
+  });
+
+  it('clicking right arrow applies profile to localStorage', () => {
+    vi.stubEnv('VITE_DEMO_MODE', 'true');
+    localStorage.setItem('chagra:demo:switch-active', '1');
+    render(<DemoModeBanner />);
+    const nextBtn = screen.getByLabelText('Perfil demo siguiente');
+    fireEvent.click(nextBtn);
+    const raw = localStorage.getItem('chagra:profile:v1');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw);
+    expect(parsed.vocacion).toBe('urbano');
+  });
+});

--- a/src/services/__tests__/demoProfile.test.js
+++ b/src/services/__tests__/demoProfile.test.js
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  DEMO_PROFILES,
+  getDemoProfile,
+  applyDemoProfile,
+  clearDemoProfile,
+  isDemoActive,
+} from '../demoProfile';
+
+describe('demoProfile service', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('DEMO_PROFILES', () => {
+    it('has 6 entries', () => {
+      expect(DEMO_PROFILES).toHaveLength(6);
+    });
+
+    it('all entries have id, label, emoji, profile', () => {
+      for (const entry of DEMO_PROFILES) {
+        expect(entry).toHaveProperty('id');
+        expect(typeof entry.id).toBe('string');
+        expect(entry).toHaveProperty('label');
+        expect(typeof entry.label).toBe('string');
+        expect(entry).toHaveProperty('emoji');
+        expect(typeof entry.emoji).toBe('string');
+        expect(entry).toHaveProperty('profile');
+        expect(typeof entry.profile).toBe('object');
+      }
+    });
+  });
+
+  describe('getDemoProfile', () => {
+    it('returns correct profile for campesino', () => {
+      const p = getDemoProfile('campesino');
+      expect(p).toBeDefined();
+      expect(p.rol).toBe('campesino');
+      expect(p.vocacion).toBe('campesino');
+      expect(p.animales).toEqual(['gallinas']);
+      expect(p.cultivos_actuales).toBe('cafe, mora');
+    });
+
+    it('returns correct profile for urbano', () => {
+      const p = getDemoProfile('urbano');
+      expect(p).toBeDefined();
+      expect(p.rol).toBe('campesino');
+      expect(p.vocacion).toBe('urbano');
+      expect(p.finca_tipo).toBe('balcon');
+      expect(p.cultivos_actuales).toBe('tomate, albahaca');
+    });
+
+    it('returns correct profile for restaurador', () => {
+      const p = getDemoProfile('restaurador');
+      expect(p).toBeDefined();
+      expect(p.rol).toBe('restaurador');
+      expect(p.objetivo).toEqual(['biodiversidad']);
+      expect(p.restauracion_objetivo).toEqual(['bosque', 'paramo']);
+    });
+
+    it('returns correct profile for ganadero_cerdos', () => {
+      const p = getDemoProfile('ganadero_cerdos');
+      expect(p).toBeDefined();
+      expect(p.rol).toBe('ganadero');
+      expect(p.animales).toEqual(['cerdos', 'ganado']);
+    });
+
+    it('returns correct profile for guia_glaciar', () => {
+      const p = getDemoProfile('guia_glaciar');
+      expect(p).toBeDefined();
+      expect(p.vocacion).toBe('campesino');
+    });
+
+    it('returns correct profile for tecnico', () => {
+      const p = getDemoProfile('tecnico');
+      expect(p).toBeDefined();
+      expect(p.rol).toBe('tecnico');
+      expect(p.vocacion).toBe('tecnico');
+    });
+
+    it('returns undefined for unknown id', () => {
+      expect(getDemoProfile('nonexistent')).toBeUndefined();
+    });
+
+    it('returns a shallow copy, not a reference', () => {
+      const p1 = getDemoProfile('campesino');
+      const p2 = getDemoProfile('campesino');
+      expect(p1).toEqual(p2);
+      expect(p1).not.toBe(p2);
+    });
+  });
+
+  describe('applyDemoProfile', () => {
+    it('saves profile to localStorage under chagra:profile:v1', () => {
+      applyDemoProfile('campesino');
+      const raw = localStorage.getItem('chagra:profile:v1');
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw);
+      expect(parsed.rol).toBe('campesino');
+    });
+
+    it('sets chagra:demo:switch-active to "1"', () => {
+      applyDemoProfile('campesino');
+      expect(localStorage.getItem('chagra:demo:switch-active')).toBe('1');
+    });
+
+    it('dispatches chagra:profile:demo-switched event', () => {
+      let eventDetail = null;
+      const handler = (e) => { eventDetail = e.detail; };
+      window.addEventListener('chagra:profile:demo-switched', handler);
+      applyDemoProfile('tecnico');
+      window.removeEventListener('chagra:profile:demo-switched', handler);
+      expect(eventDetail).not.toBeNull();
+      expect(eventDetail.id).toBe('tecnico');
+      expect(eventDetail.profile.rol).toBe('tecnico');
+    });
+
+    it('returns true on success', () => {
+      expect(applyDemoProfile('campesino')).toBe(true);
+    });
+
+    it('returns false for unknown id', () => {
+      expect(applyDemoProfile('nonexistent')).toBe(false);
+    });
+
+    it('does not write to localStorage for unknown id', () => {
+      applyDemoProfile('nonexistent');
+      expect(localStorage.getItem('chagra:profile:v1')).toBeNull();
+    });
+  });
+
+  describe('clearDemoProfile', () => {
+    it('removes profile from localStorage', () => {
+      applyDemoProfile('campesino');
+      expect(localStorage.getItem('chagra:profile:v1')).not.toBeNull();
+      clearDemoProfile();
+      expect(localStorage.getItem('chagra:profile:v1')).toBeNull();
+    });
+
+    it('removes switch-active from localStorage', () => {
+      applyDemoProfile('campesino');
+      expect(localStorage.getItem('chagra:demo:switch-active')).toBe('1');
+      clearDemoProfile();
+      expect(localStorage.getItem('chagra:demo:switch-active')).toBeNull();
+    });
+
+    it('dispatches chagra:profile:demo-switched with null detail', () => {
+      applyDemoProfile('campesino');
+      let eventDetail = undefined;
+      const handler = (e) => { eventDetail = e.detail; };
+      window.addEventListener('chagra:profile:demo-switched', handler);
+      clearDemoProfile();
+      window.removeEventListener('chagra:profile:demo-switched', handler);
+      expect(eventDetail).toBeNull();
+    });
+  });
+
+  describe('isDemoActive', () => {
+    it('returns false when no profile applied', () => {
+      expect(isDemoActive()).toBe(false);
+    });
+
+    it('returns true when a profile is applied', () => {
+      applyDemoProfile('campesino');
+      expect(isDemoActive()).toBe(true);
+    });
+
+    it('returns false after clearing', () => {
+      applyDemoProfile('campesino');
+      clearDemoProfile();
+      expect(isDemoActive()).toBe(false);
+    });
+  });
+});

--- a/src/services/demoProfile.js
+++ b/src/services/demoProfile.js
@@ -1,0 +1,150 @@
+/**
+ * demoProfile.js — SWITCH DE DEMO POR PERFIL (solo OPERADOR).
+ *
+ * Permite al operador simular diferentes perfiles de usuario sin cambiar su
+ * perfil real. Persiste en localStorage con clave `chagra:profile:v1` y emite
+ * evento `chagra:profile:demo-switched` para que los componentes reaccionen.
+ *
+ * @module demoProfile
+ */
+
+const DEMO_PROFILE_KEY = 'chagra:profile:v1';
+const DEMO_SWITCH_KEY = 'chagra:demo:switch-active';
+const DEMO_SWITCHED_EVENT = 'chagra:profile:demo-switched';
+
+export const DEMO_PROFILES = Object.freeze([
+  {
+    id: 'campesino',
+    label: 'Campesino',
+    emoji: '🌽',
+    profile: {
+      rol: 'campesino',
+      vocacion: 'campesino',
+      animales: ['gallinas'],
+      cultivos_actuales: 'cafe, mora',
+      finca_tipo: 'rural',
+    },
+  },
+  {
+    id: 'urbano',
+    label: 'Urbano (terraza)',
+    emoji: '🪴',
+    profile: {
+      rol: 'campesino',
+      vocacion: 'urbano',
+      finca_tipo: 'balcon',
+      cultivos_actuales: 'tomate, albahaca',
+      animales: ['ninguno'],
+    },
+  },
+  {
+    id: 'restaurador',
+    label: 'Restaurador',
+    emoji: '🌳',
+    profile: {
+      rol: 'restaurador',
+      vocacion: 'curioso',
+      objetivo: ['biodiversidad'],
+      restauracion_objetivo: ['bosque', 'paramo'],
+    },
+  },
+  {
+    id: 'ganadero_cerdos',
+    label: 'Ganadero',
+    emoji: '🐖',
+    profile: {
+      rol: 'ganadero',
+      vocacion: 'campesino',
+      animales: ['cerdos', 'ganado'],
+      finca_tipo: 'rural',
+    },
+  },
+  {
+    id: 'guia_glaciar',
+    label: 'Guia de glaciar',
+    emoji: '🏔️',
+    profile: {
+      vocacion: 'campesino',
+    },
+  },
+  {
+    id: 'tecnico',
+    label: 'Tecnico / agronomo',
+    emoji: '🧪',
+    profile: {
+      rol: 'tecnico',
+      vocacion: 'tecnico',
+    },
+  },
+]);
+
+const PROFILE_IDS = new Set(DEMO_PROFILES.map((p) => p.id));
+
+function hasLocalStorage() {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Retorna el objeto de perfil para un id de demo.
+ * @param {string} id
+ * @returns {Object|undefined}
+ */
+export function getDemoProfile(id) {
+  const entry = DEMO_PROFILES.find((p) => p.id === id);
+  return entry ? { ...entry.profile } : undefined;
+}
+
+/**
+ * Aplica un perfil demo: guarda en localStorage y emite evento.
+ * @param {string} id
+ * @returns {boolean}
+ */
+export function applyDemoProfile(id) {
+  if (!PROFILE_IDS.has(id)) return false;
+  if (!hasLocalStorage()) return false;
+  const profile = getDemoProfile(id);
+  if (!profile) return false;
+  try {
+    window.localStorage.setItem(DEMO_PROFILE_KEY, JSON.stringify(profile));
+    window.localStorage.setItem(DEMO_SWITCH_KEY, '1');
+    window.dispatchEvent(new CustomEvent(DEMO_SWITCHED_EVENT, { detail: { id, profile } }));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Sale del modo demo: limpia localStorage y emite evento.
+ */
+export function clearDemoProfile() {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.removeItem(DEMO_PROFILE_KEY);
+    window.localStorage.removeItem(DEMO_SWITCH_KEY);
+  } catch (_) {
+    /* noop */
+  }
+  try {
+    window.dispatchEvent(new CustomEvent(DEMO_SWITCHED_EVENT, { detail: null }));
+  } catch (_) {
+    /* noop */
+  }
+}
+
+/**
+ * Indica si hay un perfil demo activo.
+ * @returns {boolean}
+ */
+export function isDemoActive() {
+  if (!hasLocalStorage()) return false;
+  try {
+    return window.localStorage.getItem(DEMO_PROFILE_KEY) !== null;
+  } catch (_) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Tarea 58 — Switch de perfil in-app para operador

DemoModeBanner visible SOLO para operador (VITE_DEMO_MODE). Permite ciclar entre 6 perfiles demo sin tocar archivos vetados.

35 tests. ESLint limpio, boundary audit OK.