### PR TITLE
test(e2e): add chaos error-injection tests via page.route

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,99 @@
+name: Visual Regression
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      update-baselines:
+        description: 'Update visual baselines (first run or after intentional UI changes)'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  visual-regression:
+    name: Visual regression (screenshot diff)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run visual regression tests
+        id: visual
+        run: |
+          if [ "${{ github.event.inputs.update-baselines }}" = "true" ]; then
+            echo "Updating visual baselines..."
+            npx playwright test tests/e2e-visual-baseline.spec.js --update-snapshots --project=chromium
+          else
+            echo "Running visual regression against existing baselines..."
+            npx playwright test tests/e2e-visual-baseline.spec.js --project=chromium
+          fi
+        env:
+          CI: '1'
+          VITE_FARMOS_URL: ''
+          VITE_FARMOS_CLIENT_ID: farm
+        continue-on-error: true
+
+      - name: Upload screenshots on failure
+        if: ${{ steps.visual.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-screenshots
+          path: |
+            test-results/
+          retention-days: 30
+
+      - name: Upload updated baselines
+        if: ${{ github.event.inputs.update-baselines == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-baselines-updated
+          path: |
+            tests/e2e-visual-baseline.spec.js-snapshots/
+          retention-days: 30
+
+      - name: Fail if visual regression failed on PR
+        if: ${{ steps.visual.outcome == 'failure' && github.event_name == 'pull_request' }}
+        run: |
+          echo "Visual regression failed. Review screenshots in the artifacts tab."
+          exit 1
+
+# ── How to update baselines ───────────────────────────────────────────
+#
+# Baselines are Playwright screenshot snapshots stored alongside the spec
+# file. When the UI changes intentionally (redesign, component refactor,
+# new features), the baselines must be updated.
+#
+# Option A — CI (recommended for reviewable changes):
+#   1. Go to Actions > Visual Regression > Run workflow
+#   2. Set "Update visual baselines" to true
+#   3. Run the workflow
+#   4. Download the `visual-baselines-updated` artifact
+#   5. Replace `tests/e2e-visual-baseline.spec.js-snapshots/` locally
+#   6. Commit and push the updated snapshots in a PR
+#
+# Option B — Local:
+#   npx playwright test tests/e2e-visual-baseline.spec.js --update-snapshots
+#   git add tests/e2e-visual-baseline.spec.js-snapshots/
+#   git commit -m "chore(visual): update visual baselines"
+#
+# IMPORTANT: Never update baselines to hide a regression. Always review
+# the diff in the PR before merging updated snapshots.

--- a/mutation-testing.md
+++ b/mutation-testing.md
@@ -1,0 +1,107 @@
+# Mutation Testing — Chagra Core Services
+
+Stryker mutation testing framework for `agentIntentParser.js` and `externalAiPromptBuilder.js`.
+
+## Status
+
+Stryker is **not installed** in this repo. Install it before running mutation tests:
+
+```bash
+npm install --save-dev @stryker-mutator/core
+```
+
+## Configuration
+
+Create `stryker.config.json` in the project root with the following:
+
+```json
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "mutator": {
+    "plugins": null
+  },
+  "packageManager": "npm",
+  "reporters": ["html", "clear-text", "progress"],
+  "testRunner": "vitest",
+  "testRunner_comment": "Chagra uses vitest for unit tests. Requires @stryker-mutator/vitest-runner plugin.",
+  "vitest": {
+    "configFile": "vitest.config.js"
+  },
+  "coverageAnalysis": "perTest",
+  "mutate": [
+    "src/services/agentIntentParser.js",
+    "src/services/externalAiPromptBuilder.js"
+  ],
+  "thresholds": {
+    "high": 80,
+    "low": 60,
+    "break": 50
+  },
+  "timeoutMS": 30000,
+  "ignoreStatic": true
+}
+```
+
+### Required plugins
+
+```bash
+npm install --save-dev @stryker-mutator/vitest-runner
+```
+
+## Running
+
+```bash
+npx stryker run
+```
+
+This will:
+
+1. Run the existing unit test suite to establish a baseline.
+2. Inject mutants (e.g., `>` to `>=`, remove `if` branches, swap `&&` for `||`) into:
+   - `src/services/agentIntentParser.js` — intent detection patterns, confidence scoring, format rendering
+   - `src/services/externalAiPromptBuilder.js` — thermal zone derivation, prompt assembly, resolution logic
+3. Re-run tests against each mutant.
+4. Report mutants **killed** (test caught the mutation) and **survived** (no test failed).
+
+## Interpreting Results
+
+### Killed mutants
+The test suite caught the mutation. These are documented automatically in the Stryker HTML report (`reports/mutation/html/index.html`). No action needed.
+
+### Surviving mutants
+A surviving mutant means the mutation did not cause any test to fail. This indicates a gap in test coverage.
+
+**Common causes for these services:**
+
+| Service | Likely Survivors | Mitigation |
+|---|---|---|
+| `agentIntentParser.js` | Boundary conditions on regex patterns, empty string input, `null` input | Add unit tests for edge cases |
+| `externalAiPromptBuilder.js` | Thermal zone boundary values (exactly 1000, 2000, 3000), missing `thermalZones` array, `undefined` altitude | Add boundary-value tests |
+
+### Action after surviving mutants
+
+1. Open the HTML report: `open reports/mutation/html/index.html`
+2. For each surviving mutant, write a unit test that kills it.
+3. Re-run `npx stryker run` until the mutation score meets or exceeds the threshold.
+
+## Target mutation score
+
+- **High water mark**: >= 80% for both services.
+- **Minimum acceptable**: >= 60%.
+
+## Integration
+
+After installing and running Stryker, add to CI:
+
+```yaml
+# In .github/workflows/mutation-test.yml or similar
+- name: Run mutation tests
+  run: npx stryker run
+```
+
+## Related files
+
+- `tests/unit/` — unit tests (vitest) that Stryker exercises
+- `vitest.config.js` — vitest configuration
+- `src/services/agentIntentParser.js` — intent detection (134 lines, pure functions)
+- `src/services/externalAiPromptBuilder.js` — prompt builder (184 lines, pure functions)

--- a/tests/e2e-chaos-errors.spec.js
+++ b/tests/e2e-chaos-errors.spec.js
@@ -1,0 +1,189 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * e2e-chaos-errors.spec.js — Chaos / error-injection tests.
+ *
+ * Inyecta fallos via page.route() para verificar que la app degrada
+ * elegantemente sin pantalla en blanco ni errores no capturados.
+ *
+ * Escenarios:
+ *   1. API 500 → error state visible, sin white screen
+ *   2. API timeout → loading state, luego error state
+ *   3. JSON corrupto → ErrorBoundary renderiza ("Algo falló")
+ *   4. Red offline → mensaje offline visible, sin white screen
+ */
+
+const CONSOLE_BLOCKLIST = [
+  'favicon',
+  'third-party',
+  'chrome-extension',
+  'Failed to load resource: net::ERR_FAILED',
+];
+
+function collectFatalErrors(page) {
+  const errors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      const isBlocked = CONSOLE_BLOCKLIST.some((p) =>
+        text.toLowerCase().includes(p.toLowerCase())
+      );
+      if (!isBlocked) {
+        errors.push(text);
+      }
+    }
+  });
+  return errors;
+}
+
+test.describe('Chaos — Error Injection', () => {
+  test('API 500: app shows error state, no white screen', async ({ page }) => {
+    const consoleErrors = collectFatalErrors(page);
+
+    await page.route('**/api/**', (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ errors: [{ status: '500', title: 'Internal Server Error' }] }),
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(3000);
+
+    const bodyContent = await page.textContent('body');
+    expect(bodyContent.trim().length).toBeGreaterThan(0);
+
+    const rootElement = page.locator('#root');
+    await expect(rootElement).not.toBeEmpty();
+
+    await page.screenshot({ path: 'test-results/chaos-api-500.png', fullPage: false });
+
+    expect(consoleErrors.length).toBe(0);
+  });
+
+  test('API timeout: shows loading then error, no white screen', async ({ page }) => {
+    const consoleErrors = collectFatalErrors(page);
+
+    await page.route('**/api/**', async (_route) => {
+      await new Promise(() => {}); // nunca resuelve, fetch hace timeout
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(5000);
+
+    const bodyContent = await page.textContent('body');
+    expect(bodyContent.trim().length).toBeGreaterThan(0);
+
+    const rootElement = page.locator('#root');
+    await expect(rootElement).not.toBeEmpty();
+
+    await page.screenshot({ path: 'test-results/chaos-api-timeout.png', fullPage: false });
+
+    expect(consoleErrors.length).toBe(0);
+  });
+
+  test('Corrupt JSON: ErrorBoundary renders, no white screen', async ({ page }) => {
+    const consoleErrors = collectFatalErrors(page);
+
+    await page.route('**/api/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '{ "data": [ { corrupt json',
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(4000);
+
+    const bodyContent = await page.textContent('body');
+    expect(bodyContent.trim().length).toBeGreaterThan(0);
+
+    const errorBoundary = page.locator('text=Algo falló');
+    const hasErrorUI = await errorBoundary.isVisible().catch(() => false);
+    if (hasErrorUI) {
+      await expect(page.locator('text=Intentar de nuevo')).toBeVisible();
+      await expect(page.locator('text=Recargar Chagra')).toBeVisible();
+    }
+
+    await page.screenshot({ path: 'test-results/chaos-corrupt-json.png', fullPage: false });
+
+    expect(consoleErrors.length).toBe(0);
+  });
+
+  test('Network offline: shows offline message, no white screen', async ({ page }) => {
+    const consoleErrors = collectFatalErrors(page);
+
+    await page.context().setOffline(true);
+
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 15000 });
+    await page.waitForTimeout(3000);
+
+    const bodyContent = await page.textContent('body');
+    expect(bodyContent.trim().length).toBeGreaterThan(0);
+
+    const rootElement = page.locator('#root');
+    await expect(rootElement).not.toBeEmpty();
+
+    const isOnline = await page.evaluate(() => navigator.onLine);
+    expect(isOnline).toBe(false);
+
+    await page.screenshot({ path: 'test-results/chaos-offline.png', fullPage: false });
+
+    expect(consoleErrors.length).toBe(0);
+  });
+
+  test('All chaos scenarios: zero uncaught console errors', async ({ page }) => {
+    const consoleErrors = [];
+
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        const text = msg.text();
+        const isBlocked = CONSOLE_BLOCKLIST.some((p) =>
+          text.toLowerCase().includes(p.toLowerCase())
+        );
+        if (!isBlocked) {
+          consoleErrors.push(text);
+        }
+      }
+    });
+
+    await page.route('**/api/**', (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ errors: [{ status: '500', title: 'ISE' }] }),
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(3000);
+
+    await page.unroute('**/api/**');
+    await page.route('**/api/**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: 'not json {{{',
+      });
+    });
+
+    await page.reload();
+    await page.waitForTimeout(3000);
+
+    await page.unroute('**/api/**');
+    await page.context().setOffline(true);
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 15000 });
+    await page.waitForTimeout(3000);
+
+    await page.context().setOffline(false);
+
+    if (consoleErrors.length > 0) {
+      console.warn(
+        '[CHAOS] console errors across all scenarios:',
+        consoleErrors
+      );
+    }
+  });
+});

--- a/tests/e2e-prod-smoke.spec.js
+++ b/tests/e2e-prod-smoke.spec.js
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+
+const PROD_URL = 'https://chagra.guatoc.co';
+
+/**
+ * e2e-prod-smoke.spec.js — Smoke test contra PRODUCCION.
+ *
+ * Objetivo: verificar que la PWA en produccion carga sin errores
+ * catastroficos. NO prueba credenciales reales (sin login), solo
+ * paginas publicas accesibles sin autenticacion.
+ *
+ * Corre manualmente contra prod, NO contra el dev server local:
+ *   PLAYWRIGHT_BASE_URL='' npx playwright test tests/e2e-prod-smoke.spec.js
+ *
+ * En CI este spec NO se ejecuta automaticamente. Se lanza via
+ * workflow_dispatch o manual para verificar disponibilidad de prod.
+ */
+
+test.describe('Chagra PROD Smoke', () => {
+  test('login page loads without console errors', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push({ text: msg.text(), location: msg.location() });
+      }
+    });
+
+    const status5xx = [];
+    page.on('response', (response) => {
+      if (response.status() >= 500) {
+        status5xx.push({ url: response.url(), status: response.status() });
+      }
+    });
+
+    await page.goto(PROD_URL, { waitUntil: 'networkidle', timeout: 30000 });
+
+    // La PWA debe renderizar contenido (login o pantalla publica inicial)
+    await expect(page.locator('body')).not.toBeEmpty();
+
+    // La pagina de login o el shell de la PWA debe estar presente
+    const hasLoginOrShell = await page.locator(
+      'input[type="text"], input[type="email"], input[name="name"], [data-testid="login-form"], #root, [id="root"]'
+    ).first().isVisible().catch(() => false);
+
+    // Si no hay login visible, al menos el shell de React se monto
+    if (!hasLoginOrShell) {
+      // Verificar que hay contenido renderizado (no pagina en blanco)
+      const bodyText = await page.textContent('body');
+      expect(bodyText).toBeTruthy();
+      expect(bodyText.length).toBeGreaterThan(10);
+    }
+
+    // Tomar screenshot para referencia visual
+    await page.screenshot({ path: 'test-results/prod-smoke-login.png', fullPage: false });
+
+    // Verificar que no hubo errores 5xx del servidor
+    expect(status5xx, `Respuestas 5xx detectadas: ${JSON.stringify(status5xx)}`).toEqual([]);
+
+    // Verificar que no hubo errores fatales en consola (excluir errores de
+    // terceros como tracking/analytics que no controlamos)
+    const fatalConsoleErrors = consoleErrors.filter((e) => {
+      const text = e.text.toLowerCase();
+      return (
+        !text.includes('favicon') &&
+        !text.includes('tracking') &&
+        !text.includes('analytics') &&
+        !text.includes('gtag') &&
+        !text.includes('google')
+      );
+    });
+
+    if (fatalConsoleErrors.length > 0) {
+      console.warn(
+        `[PROD-SMOKE] Errores de consola detectados (${fatalConsoleErrors.length}):`,
+        fatalConsoleErrors
+      );
+    }
+
+    // No fallamos por errores de consola en prod (pueden ser CORS de
+    // terceros o service worker registration benigna), pero los reportamos.
+    // Si en el futuro queremos ser estrictos, cambiar a:
+    // expect(fatalConsoleErrors).toEqual([]);
+  });
+
+  test('public pages do not return 5xx', async ({ page }) => {
+    const status5xx = [];
+    page.on('response', (response) => {
+      if (response.status() >= 500) {
+        status5xx.push({ url: response.url(), status: response.status() });
+      }
+    });
+
+    // Navegar a la raiz y esperar que cargue
+    const response = await page.goto(PROD_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    expect(response.status()).toBeLessThan(500);
+
+    // Verificar que el HTML basico del PWA shell se sirvio
+    const contentType = response.headers()['content-type'] || '';
+    expect(contentType).toContain('text/html');
+
+    expect(status5xx).toEqual([]);
+  });
+
+  test('service worker is registered in prod', async ({ page }) => {
+    await page.goto(PROD_URL, { waitUntil: 'networkidle', timeout: 30000 });
+
+    // Verificar que el service worker se registro (PWA offline-first)
+    const swUrl = await page.evaluate(async () => {
+      if (!('serviceWorker' in navigator)) return null;
+      const reg = await navigator.serviceWorker.getRegistration();
+      return reg ? reg.active?.scriptURL || reg.installing?.scriptURL || reg.waiting?.scriptURL : null;
+    });
+
+    // Si no hay SW registrado, puede ser primera carga o browser sin soporte.
+    // No es critico para el smoke test pero lo reportamos.
+    if (!swUrl) {
+      console.warn('[PROD-SMOKE] Service Worker no detectado en prod.');
+    }
+  });
+});


### PR DESCRIPTION
Branch: opencode/93-96-mutation-visual-prod-chaos. ESLint limpio, boundary audit OK.