### PR TITLE
fix(seguridad): anti-leak — redacta rutas /home/kortux en docs publicos

### DIFF
--- a/docs/PENDIENTE-OPERADOR.md
+++ b/docs/PENDIENTE-OPERADOR.md
@@ -29,7 +29,7 @@
 
 - [ ] Si se modifico configuracion de nginx o systemd services, ejecutar:
   ```bash
-  cd /home/kortux/Workspace/guatoc-nixos
+  cd ~/Workspace/guatoc-nixos
   sudo nixos-rebuild switch --flake .#alpha
   ```
 

--- a/docs/bench-candidates-gemma4-granite-2026-06-08.md
+++ b/docs/bench-candidates-gemma4-granite-2026-06-08.md
@@ -7,7 +7,7 @@
 - **Duración**: 62.82 min
 - **Script**: `scripts/bench-agente-completo.mjs`
 - **50 prompts** | Categorías: species(20), biopreparados(12), plagas(10), normativa(4), agroforestería(4)
-- **Output persistente**: `/home/kortux/Workspace/bench-results/llm-candidates-2026-06-08/`
+- **Output persistente**: `~/Workspace/bench-results/llm-candidates-2026-06-08/`
 
 ## Modelos evaluados
 


### PR DESCRIPTION
boundaryAudit marcaba docs/bench-candidates-* y docs/PENDIENTE-OPERADOR.md con la ruta personal del operador. Redactadas a ~/. Solo docs.