### PR TITLE
hotfix(prod): remueve meta CSP que rompia sqlite-wasm (Failed to fetch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,20 +22,6 @@
     <meta name="apple-mobile-web-app-title" content="Chagra" />
 
     <title>Chagra</title>
-    <!-- Content-Security-Policy (Task 112). Defense-in-depth anti-XSS. -->
-    <meta http-equiv="Content-Security-Policy" content="
-      default-src 'self';
-      script-src 'self' 'unsafe-inline' https:;
-      style-src 'self' 'unsafe-inline' https:;
-      img-src 'self' data: blob: https:;
-      connect-src 'self' https: wss:;
-      font-src 'self' data:;
-      media-src 'self' blob:;
-      object-src 'none';
-      base-uri 'self';
-      form-action 'self';
-      frame-ancestors 'none';
-    " />
 
 
     <!-- Pre-React loader inline (issue #121): evita flash blanco al


### PR DESCRIPTION
PROD-DOWN: el CSP de #1631 bloqueaba wasm-unsafe-eval -> sqlite-wasm no cargaba -> capa de datos muerta (Failed to fetch, todo en 0). Quito el meta para restaurar produccion. Reintroducir CSP correcto despues.