### PR TITLE
fix(seguridad): CSP correcto (wasm-unsafe-eval) + smoke wasm en el gate

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,25 @@
 
     <title>Chagra</title>
 
+    <!-- Content-Security-Policy (Task 112, corregido tras incidente prod #1631).
+         CRITICO: script-src DEBE incluir 'wasm-unsafe-eval'; sin eso el navegador
+         bloquea WebAssembly -> sqlite-wasm (capa de datos) no carga -> app muerta
+         (Failed to fetch, todo en 0). worker-src para el service worker de la PWA.
+         Regresion cubierta por el smoke en tests/offline.spec.js (WebAssembly.compile). -->
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self';
+      script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https:;
+      style-src 'self' 'unsafe-inline' https:;
+      img-src 'self' data: blob: https:;
+      connect-src 'self' https: wss:;
+      font-src 'self' data:;
+      media-src 'self' blob:;
+      worker-src 'self' blob:;
+      object-src 'none';
+      base-uri 'self';
+      form-action 'self';
+      frame-ancestors 'none';
+    " />
 
     <!-- Pre-React loader inline (issue #121): evita flash blanco al
          arrancar PWA fría antes de que React + Suspense pinten el

--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -268,3 +268,44 @@ test.describe('Offline-first — siembra pendiente y reconexión', () => {
       .toBeGreaterThanOrEqual(1);
   });
 });
+
+test.describe('Smoke capa de datos — el CSP no debe bloquear WASM/sqlite (regresión prod #1631)', () => {
+  // Por qué existe: el 2026-06-17 un meta CSP sin 'wasm-unsafe-eval' bloqueó
+  // WebAssembly -> sqlite-wasm no cargó -> "Failed to fetch", todo en 0, prod caída.
+  // Los tests offline existentes usan IndexedDB directo (no wasm) y NO lo cazaron.
+  // Este check es determinista: WebAssembly.compile falla si el CSP activo no
+  // permite wasm. Corre dentro del gate requerido (offline.spec.js).
+  test('WebAssembly compila bajo el CSP activo y la app arranca sin violaciones wasm', async ({ page }) => {
+    const wasmCsp = [];
+    const capture = (t) => {
+      if (/webassembly|wasm-unsafe-eval|wasm/i.test(String(t))) wasmCsp.push(String(t));
+    };
+    page.on('console', (msg) => capture(msg.text()));
+    page.on('pageerror', (e) => capture(e));
+
+    await page.goto('/');
+
+    // La UI de login pinta aunque el wasm falle (no depende de wasm).
+    await expect(page.getByRole('button', { name: /ingresar/i })).toBeVisible({ timeout: 15_000 });
+
+    // CHECK CLAVE: WebAssembly.compile debe funcionar bajo el CSP de index.html.
+    // Módulo wasm mínimo válido (header "\0asm" + versión 1). Si el CSP no trae
+    // 'wasm-unsafe-eval', esto lanza CompileError -> sqlite-wasm no cargaría.
+    const wasmResult = await page.evaluate(async () => {
+      try {
+        const bytes = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+        await WebAssembly.compile(bytes);
+        return 'ok';
+      } catch (e) {
+        return String(e && e.message ? e.message : e);
+      }
+    });
+    expect(
+      wasmResult,
+      `WebAssembly.compile falló bajo el CSP activo (¿falta 'wasm-unsafe-eval' en script-src?): ${wasmResult}`
+    ).toBe('ok');
+
+    // Ninguna violación CSP relacionada con wasm en el arranque.
+    expect(wasmCsp, `Violaciones CSP/WASM en el arranque: ${wasmCsp.join(' | ')}`).toEqual([]);
+  });
+});

--- a/tests/offline.spec.js
+++ b/tests/offline.spec.js
@@ -278,7 +278,13 @@ test.describe('Smoke capa de datos — el CSP no debe bloquear WASM/sqlite (regr
   test('WebAssembly compila bajo el CSP activo y la app arranca sin violaciones wasm', async ({ page }) => {
     const wasmCsp = [];
     const capture = (t) => {
-      if (/webassembly|wasm-unsafe-eval|wasm/i.test(String(t))) wasmCsp.push(String(t));
+      const s = String(t);
+      // Solo VIOLACIONES reales: rechazos CSP o CompileError de wasm. NO capturar
+      // logs de ÉXITO que mencionan "wasm" (ej. "[SQLite WASM] loaded"), que antes
+      // se contaban como violación y auto-fallaban el smoke.
+      if (/refused to (compile|instantiate|evaluate|load)|content security policy|compileerror/i.test(s)) {
+        wasmCsp.push(s);
+      }
     };
     page.on('console', (msg) => capture(msg.text()));
     page.on('pageerror', (e) => capture(e));


### PR DESCRIPTION
Reintroduce el CSP de #1631 PERO con 'wasm-unsafe-eval' (lo que faltaba y tumbo prod) + worker-src. Agrega un smoke determinista a offline.spec.js (gate requerido) que corre WebAssembly.compile bajo el CSP real -> caza el regreso del bug. Verificacion: el gate Offline-first E2E corre este smoke en Chromium real antes de mergear.