### PR TITLE
feat(catalog): add graph parity validators

### DIFF
--- a/catalog/chagra-catalog-oss-subset-v3.2.json
+++ b/catalog/chagra-catalog-oss-subset-v3.2.json
@@ -11986,12 +11986,48 @@
       "companions": [],
       "_nota_companions": "Asocio papa-arveja (DR Gemini): la papa es tutor físico de la arveja (evita volcamiento); ~21.000 ha/año, 65% de productores del altiplano.",
       "enfermedades_criticas": [
-        "Phytophthora infestans"
+        "Phytophthora infestans",
+        "Trozador (Agrotis ipsilon)"
       ],
       "plagas_criticas": [
         "Tecia solanivora",
         "Phyllophaga spp."
       ],
+      "feeding_plan_template": {
+        "source": "Agrosavia Manual tuberculos andinos (2017) + Perez-Rodriguez-Gomez (2008). Paridad base-variedad para papa; detalle operativo vive en variedades comerciales.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al surco",
+            "biofertilizer_slug": "bocashi"
+          },
+          {
+            "offset_days": 25,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo"
+          },
+          {
+            "offset_days": 45,
+            "action": "Drench con humus liquido",
+            "biofertilizer_slug": "humus_liquido"
+          },
+          {
+            "offset_days": 60,
+            "action": "Foliar con biol en pre-tuberizacion",
+            "biofertilizer_slug": "biol"
+          },
+          {
+            "offset_days": 80,
+            "action": "Foliar con caldo bordeles preventivo",
+            "biofertilizer_slug": "caldo_bordeles"
+          },
+          {
+            "offset_days": 100,
+            "action": "Foliar con supermagro durante llenado",
+            "biofertilizer_slug": "supermagro"
+          }
+        ]
+      },
       "valor_pedagogico": "La papa parda pastusa (Solanum tuberosum subsp. andigenum) es una variedad tradicional de mesa del altiplano frío colombiano (2600-3300 msnm) que, a diferencia de la Pastusa Suprema y la Diacol Capiro, TOLERA HELADAS MODERADAS y por eso se siembra en cotas más altas (DR Gemini 2026). Entra en el asocio clásico papa-arveja, donde la mata de papa actúa como tutor físico de la arveja erecta (Gorriona/Guatecaria), un sistema que cubre ~21.000 ha/año y al que recurre el 65% de los productores. Manejo agroecológico: rotación con haba/arveja (fijación de N), bocashi al surco, caldo bordelés preventivo para gota (Phytophthora infestans), monitoreo de polilla guatemalteca (Tecia solanivora) con feromonas. Confianza media: envolvente agroclimática provisional (Agrosavia, URL por verificar).",
       "source_ids": [
         "gbif-taxonomic-backbone",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest run && node scripts/validate-catalog-consistency.mjs --report-only",
     "prebuild": "node scripts/build-catalog-sqlite.mjs && node scripts/generate-cycle-content-manifest.mjs",
     "build": "vite build",
     "lint": "eslint .",

--- a/scripts/validate-catalog-consistency.mjs
+++ b/scripts/validate-catalog-consistency.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const DEFAULT_CATALOGS = [
+  'catalog/chagra-catalog-oss-subset-v3.2.json',
+  'catalog/chagra-catalog-seed-v3.1.json',
+];
+
+function defaultCatalogPath() {
+  for (const rel of DEFAULT_CATALOGS) {
+    const full = join(ROOT, rel);
+    if (existsSync(full)) return full;
+  }
+  return join(ROOT, DEFAULT_CATALOGS[DEFAULT_CATALOGS.length - 1]);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function uniq(values) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function stripAccents(value) {
+  return String(value || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+export function normalizeCatalogRef(value) {
+  return stripAccents(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 120);
+}
+
+function normalizeId(value) {
+  return String(value || '').trim();
+}
+
+function pestValues(species) {
+  return uniq([
+    ...asArray(species.plagas_criticas),
+    ...asArray(species.plagas),
+    ...asArray(species.enfermedades_criticas),
+    ...asArray(species.enfermedades),
+  ]).map((raw) => ({ raw, key: normalizeCatalogRef(raw) })).filter((item) => item.key);
+}
+
+function bioValues(species) {
+  const values = [];
+  for (const step of asArray(species.feeding_plan_template?.primary_steps)) {
+    if (step?.biofertilizer_slug) values.push(step.biofertilizer_slug);
+  }
+  const etapas = species.plan_nutricion_base?.biopreparados_por_etapa || {};
+  for (const items of Object.values(etapas)) {
+    for (const item of asArray(items)) {
+      if (item?.biopreparado_id) values.push(item.biopreparado_id);
+    }
+  }
+  return uniq(values).map((raw) => ({ raw, key: normalizeCatalogRef(raw) })).filter((item) => item.key);
+}
+
+function explicitBaseId(species) {
+  return species.base_species_id
+    || species.species_base_id
+    || species.parent_species_id
+    || species.base_id
+    || species.variedad_de
+    || species.variety_of
+    || null;
+}
+
+export function inferBaseId(species, speciesIds) {
+  const explicit = explicitBaseId(species);
+  if (explicit) return normalizeId(explicit);
+
+  const parts = String(species.id || '').split('_').filter(Boolean);
+  for (let size = parts.length - 1; size >= 2; size--) {
+    const candidate = parts.slice(0, size).join('_');
+    if (speciesIds.has(candidate)) return candidate;
+  }
+
+  const scientific = String(species.nombre_cientifico || '');
+  const hasVarietyMarker = /(?:\bvar\.|\bcv\.|\bsubsp\.|'.+')/i.test(scientific);
+  if (hasVarietyMarker && parts.length > 2) {
+    return parts.slice(0, 2).join('_');
+  }
+
+  return null;
+}
+
+function exclusionAllows(species, relationKind, rawValue) {
+  const exclusions = [
+    ...asArray(species.justificacion_exclusion),
+    ...asArray(species.justificaciones_exclusion),
+    ...asArray(species.exclusiones_paridad),
+    ...asArray(species.parity_exclusions),
+  ];
+  const valueKey = normalizeCatalogRef(rawValue);
+  return exclusions.some((entry) => {
+    if (typeof entry === 'string') {
+      const normalized = normalizeCatalogRef(entry);
+      return normalized.includes(valueKey) || normalized.includes(normalizeCatalogRef(relationKind));
+    }
+    if (!entry || typeof entry !== 'object') return false;
+    const kind = normalizeCatalogRef(entry.tipo || entry.kind || entry.relacion || entry.relation || '');
+    const id = normalizeCatalogRef(entry.id || entry.valor || entry.value || entry.ref || '');
+    return (!kind || kind === normalizeCatalogRef(relationKind)) && (!id || id === valueKey);
+  });
+}
+
+function addIssue(issues, code, message, offender) {
+  issues.push({ code, message, offender });
+}
+
+export function isValidBinomialScientificName(name) {
+  const clean = String(name || '')
+    .replace(/\u00d7/g, 'x')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const match = clean.match(/^([A-Z][a-z-]+)\s+(?:x\s+)?([a-z][a-z-]+)(?:\s|$)/);
+  if (!match) return false;
+  if (match[1].length < 2 || match[2].length < 2) return false;
+  if (/[0-9_]/.test(`${match[1]} ${match[2]}`)) return false;
+  return true;
+}
+
+export function validateCatalogConsistency(catalog) {
+  const issues = [];
+  const species = asArray(catalog.species);
+  const biopreparados = asArray(catalog.biopreparados);
+  const pestRegistry = new Set([
+    ...asArray(catalog.pests).map((p) => normalizeCatalogRef(p.id || p.nombre || p.name || p)),
+    ...asArray(catalog.pests_diseases).map((p) => normalizeCatalogRef(p.id || p.nombre || p.name || p)),
+    ...asArray(catalog.plagas).map((p) => normalizeCatalogRef(p.id || p.nombre || p.name || p)),
+    ...asArray(catalog.enfermedades).map((p) => normalizeCatalogRef(p.id || p.nombre || p.name || p)),
+  ].filter(Boolean));
+  const hasExplicitPestRegistry = pestRegistry.size > 0;
+  const bioIds = new Set(biopreparados.map((bp) => normalizeCatalogRef(bp.id)).filter(Boolean));
+  const speciesIds = new Set();
+  const byId = new Map();
+
+  for (const sp of species) {
+    const id = normalizeId(sp.id);
+    if (!id) {
+      addIssue(issues, 'missing_species_id', 'Species sin id', { id });
+      continue;
+    }
+    if (speciesIds.has(id)) {
+      addIssue(issues, 'duplicate_id', 'ID duplicado en species', { id, type: 'species' });
+    }
+    speciesIds.add(id);
+    if (!byId.has(id)) byId.set(id, sp);
+  }
+
+  const seenBioIds = new Set();
+  for (const bp of biopreparados) {
+    const id = normalizeId(bp.id);
+    if (!id) {
+      addIssue(issues, 'missing_biopreparado_id', 'Biopreparado sin id', { id });
+      continue;
+    }
+    if (seenBioIds.has(id) || speciesIds.has(id)) {
+      addIssue(issues, 'duplicate_id', 'ID duplicado en catalogo', { id, type: 'biopreparado' });
+    }
+    seenBioIds.add(id);
+  }
+
+  for (const sp of species) {
+    const id = normalizeId(sp.id);
+    if (!isValidBinomialScientificName(sp.nombre_cientifico)) {
+      addIssue(issues, 'invalid_scientific_name', 'Nombre cientifico no binomial', {
+        id,
+        nombre_cientifico: sp.nombre_cientifico || null,
+      });
+    }
+
+    for (const pest of pestValues(sp)) {
+      if (hasExplicitPestRegistry && !pestRegistry.has(pest.key)) {
+        addIssue(issues, 'missing_pest_ref', 'Plaga o enfermedad referenciada no existe', {
+          id,
+          ref: pest.raw,
+        });
+      }
+    }
+
+    for (const bio of bioValues(sp)) {
+      if (!bioIds.has(bio.key)) {
+        addIssue(issues, 'missing_biopreparado_ref', 'Biopreparado referenciado no existe', {
+          id,
+          ref: bio.raw,
+        });
+      }
+    }
+  }
+
+  for (const sp of species) {
+    const id = normalizeId(sp.id);
+    const baseId = inferBaseId(sp, speciesIds);
+    if (!baseId || baseId === id) continue;
+    const base = byId.get(baseId);
+    if (!base) {
+      addIssue(issues, 'missing_base_species', 'Variedad apunta a base inexistente', {
+        id,
+        base_id: baseId,
+      });
+      continue;
+    }
+
+    const basePests = new Set(pestValues(base).map((item) => item.key));
+    const baseBios = new Set(bioValues(base).map((item) => item.key));
+    for (const pest of pestValues(sp)) {
+      if (!basePests.has(pest.key) && !exclusionAllows(sp, 'pest', pest.raw)) {
+        addIssue(issues, 'base_variety_parity_pest', 'La base no lista plaga o enfermedad de la variedad', {
+          id,
+          base_id: baseId,
+          ref: pest.raw,
+        });
+      }
+    }
+    for (const bio of bioValues(sp)) {
+      if (!baseBios.has(bio.key) && !exclusionAllows(sp, 'biopreparado', bio.raw)) {
+        addIssue(issues, 'base_variety_parity_biopreparado', 'La base no lista biopreparado de la variedad', {
+          id,
+          base_id: baseId,
+          ref: bio.raw,
+        });
+      }
+    }
+  }
+
+  const stats = {
+    species: species.length,
+    biopreparados: biopreparados.length,
+    issues: issues.length,
+    byCode: issues.reduce((acc, issue) => {
+      acc[issue.code] = (acc[issue.code] || 0) + 1;
+      return acc;
+    }, {}),
+  };
+
+  return { ok: issues.length === 0, issues, stats };
+}
+
+export function formatCatalogConsistencyReport(result, opts = {}) {
+  const limit = opts.limit ?? 80;
+  const lines = [
+    `Catalog consistency: species=${result.stats.species} biopreparados=${result.stats.biopreparados} issues=${result.stats.issues}`,
+  ];
+  for (const [code, count] of Object.entries(result.stats.byCode).sort()) {
+    lines.push(`- ${code}: ${count}`);
+  }
+  for (const issue of result.issues.slice(0, limit)) {
+    lines.push(`FAIL ${issue.code}: ${JSON.stringify(issue.offender)}`);
+  }
+  if (result.issues.length > limit) {
+    lines.push(`... ${result.issues.length - limit} more issues`);
+  }
+  return lines.join('\n');
+}
+
+export function parseArgs(argv) {
+  const opts = {
+    catalog: defaultCatalogPath(),
+    reportOnly: false,
+    limit: 80,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--catalog' || arg === '--input') opts.catalog = resolve(argv[++i]);
+    else if (arg === '--report-only') opts.reportOnly = true;
+    else if (arg === '--limit') opts.limit = Number(argv[++i]);
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log('Usage: node scripts/validate-catalog-consistency.mjs [--catalog FILE] [--report-only] [--limit N]');
+    return 0;
+  }
+  const catalog = readJson(opts.catalog);
+  const result = validateCatalogConsistency(catalog);
+  const report = formatCatalogConsistencyReport(result, { limit: opts.limit });
+  const writer = result.ok || opts.reportOnly ? console.log : console.error;
+  writer(report);
+  if (!result.ok && !opts.reportOnly) return 1;
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}

--- a/scripts/validate-graph-parity.mjs
+++ b/scripts/validate-graph-parity.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_GRAPH = 'chagra_kg';
+
+export function buildGraphParitySql(graph = DEFAULT_GRAPH) {
+  const graphLiteral = String(graph).replace(/'/g, "''");
+  return `
+LOAD 'age';
+SET search_path = ag_catalog, "$user", public;
+SELECT base_id::text, variety_id::text, relation::text, missing_id::text
+FROM cypher('${graphLiteral}', $$
+  MATCH (base:Species)
+  MATCH (variety:Species)
+  WHERE variety.id STARTS WITH base.id + '_'
+  OPTIONAL MATCH (base)-[:TARGETS_PEST]->(basePest:Pest)
+  WITH base, variety, collect(DISTINCT basePest.id) AS basePests
+  OPTIONAL MATCH (variety)-[:TARGETS_PEST]->(varietyPest:Pest)
+  WITH base, variety, basePests, collect(DISTINCT varietyPest.id) AS varietyPests
+  UNWIND varietyPests AS pestId
+  WITH base.id AS base_id, variety.id AS variety_id, 'TARGETS_PEST' AS relation, pestId AS missing_id, basePests
+  WHERE pestId IS NOT NULL AND NOT pestId IN basePests
+  RETURN base_id, variety_id, relation, missing_id
+  UNION
+  MATCH (base:Species)
+  MATCH (variety:Species)
+  WHERE variety.id STARTS WITH base.id + '_'
+  OPTIONAL MATCH (base)-[:USED_AS_BIOPREPARADO]->(baseBio:Biopreparado)
+  WITH base, variety, collect(DISTINCT baseBio.id) AS baseBios
+  OPTIONAL MATCH (variety)-[:USED_AS_BIOPREPARADO]->(varietyBio:Biopreparado)
+  WITH base, variety, baseBios, collect(DISTINCT varietyBio.id) AS varietyBios
+  UNWIND varietyBios AS bioId
+  WITH base.id AS base_id, variety.id AS variety_id, 'USED_AS_BIOPREPARADO' AS relation, bioId AS missing_id, baseBios
+  WHERE bioId IS NOT NULL AND NOT bioId IN baseBios
+  RETURN base_id, variety_id, relation, missing_id
+  ORDER BY base_id, variety_id, relation, missing_id
+$$) AS (base_id agtype, variety_id agtype, relation agtype, missing_id agtype);
+`.trim();
+}
+
+function stripAgtype(value) {
+  return String(value || '').trim().replace(/^"|"$/g, '');
+}
+
+export function parsePsqlRows(stdout) {
+  return String(stdout || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^(LOAD|SET|\(\d+ rows?\))$/.test(line))
+    .map((line) => {
+      const parts = line.includes('\t') ? line.split('\t') : line.split('|');
+      return {
+        base_id: stripAgtype(parts[0]),
+        variety_id: stripAgtype(parts[1]),
+        relation: stripAgtype(parts[2]),
+        missing_id: stripAgtype(parts[3]),
+      };
+    })
+    .filter((row) => row.base_id && row.variety_id && row.relation && row.missing_id);
+}
+
+export function formatGraphParityReport(rows) {
+  const counts = rows.reduce((acc, row) => {
+    acc[row.relation] = (acc[row.relation] || 0) + 1;
+    return acc;
+  }, {});
+  const lines = [`Graph parity gaps: ${rows.length}`];
+  for (const [relation, count] of Object.entries(counts).sort()) {
+    lines.push(`- ${relation}: ${count}`);
+  }
+  for (const row of rows) {
+    lines.push(`FAIL ${row.relation}: base=${row.base_id} variety=${row.variety_id} missing=${row.missing_id}`);
+  }
+  return lines.join('\n');
+}
+
+export function runPsql(sql) {
+  const command = process.env.CHAGRA_AGE_PSQL_COMMAND;
+  if (command) {
+    return spawnSync(command, {
+      input: sql,
+      encoding: 'utf8',
+      shell: true,
+      env: process.env,
+    });
+  }
+  return spawnSync('sudo', [
+    'podman',
+    'exec',
+    '-i',
+    'postgres-farm',
+    'psql',
+    '-U',
+    'farmos',
+    '-d',
+    'chagra_kg',
+    '-At',
+    '-F',
+    '\t',
+  ], {
+    input: sql,
+    encoding: 'utf8',
+    env: process.env,
+  });
+}
+
+export function parseArgs(argv) {
+  const opts = { graph: DEFAULT_GRAPH };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--graph') opts.graph = argv[++i];
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log('Usage: node scripts/validate-graph-parity.mjs [--graph chagra_kg]');
+    console.log('Override command with CHAGRA_AGE_PSQL_COMMAND if needed.');
+    return 0;
+  }
+
+  const sql = buildGraphParitySql(opts.graph);
+  const result = runPsql(sql);
+  if (result.error) {
+    console.error(`Graph parity query failed: ${result.error.message}`);
+    return 2;
+  }
+  if (result.status !== 0) {
+    if (result.stderr) console.error(result.stderr.trim());
+    return result.status || 2;
+  }
+
+  const rows = parsePsqlRows(result.stdout);
+  const report = formatGraphParityReport(rows);
+  const writer = rows.length ? console.error : console.log;
+  writer(report);
+  return rows.length ? 1 : 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}

--- a/tests/unit/catalogConsistency.test.js
+++ b/tests/unit/catalogConsistency.test.js
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  inferBaseId,
+  isValidBinomialScientificName,
+  validateCatalogConsistency,
+} from '../../scripts/validate-catalog-consistency.mjs';
+import {
+  buildGraphParitySql,
+  formatGraphParityReport,
+  parsePsqlRows,
+} from '../../scripts/validate-graph-parity.mjs';
+
+function baseCatalog(overrides = {}) {
+  return {
+    species: [
+      {
+        id: 'solanum_lycopersicum',
+        nombre_cientifico: 'Solanum lycopersicum L.',
+        plagas_criticas: ['Tuta absoluta'],
+        enfermedades_criticas: ['Phytophthora infestans'],
+        feeding_plan_template: {
+          primary_steps: [{ biofertilizer_slug: 'caldo_bordeles' }],
+        },
+      },
+      {
+        id: 'solanum_lycopersicum_san_marzano',
+        nombre_cientifico: "Solanum lycopersicum 'San Marzano'",
+        plagas_criticas: ['Tuta absoluta'],
+        enfermedades_criticas: ['Phytophthora infestans'],
+        feeding_plan_template: {
+          primary_steps: [{ biofertilizer_slug: 'caldo_bordeles' }],
+        },
+      },
+    ],
+    biopreparados: [{ id: 'caldo_bordeles' }],
+    pests: [{ id: 'tuta_absoluta' }, { id: 'phytophthora_infestans' }],
+    ...overrides,
+  };
+}
+
+describe('catalog consistency validator', () => {
+  it('accepts a base species that contains the pest and biopreparado refs of its variety', () => {
+    const result = validateCatalogConsistency(baseCatalog());
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('detects base to variety parity gaps with offenders', () => {
+    const catalog = baseCatalog({
+      species: [
+        {
+          id: 'solanum_lycopersicum',
+          nombre_cientifico: 'Solanum lycopersicum L.',
+          plagas_criticas: [],
+          feeding_plan_template: { primary_steps: [] },
+        },
+        {
+          id: 'solanum_lycopersicum_san_marzano',
+          nombre_cientifico: "Solanum lycopersicum 'San Marzano'",
+          plagas_criticas: ['Tuta absoluta'],
+          feeding_plan_template: {
+            primary_steps: [{ biofertilizer_slug: 'caldo_bordeles' }],
+          },
+        },
+      ],
+    });
+
+    const result = validateCatalogConsistency(catalog);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'base_variety_parity_pest',
+        offender: expect.objectContaining({
+          id: 'solanum_lycopersicum_san_marzano',
+          base_id: 'solanum_lycopersicum',
+          ref: 'Tuta absoluta',
+        }),
+      }),
+      expect.objectContaining({
+        code: 'base_variety_parity_biopreparado',
+        offender: expect.objectContaining({
+          id: 'solanum_lycopersicum_san_marzano',
+          base_id: 'solanum_lycopersicum',
+          ref: 'caldo_bordeles',
+        }),
+      }),
+    ]));
+  });
+
+  it('allows documented parity exclusions', () => {
+    const catalog = baseCatalog({
+      species: [
+        {
+          id: 'solanum_lycopersicum',
+          nombre_cientifico: 'Solanum lycopersicum L.',
+        },
+        {
+          id: 'solanum_lycopersicum_san_marzano',
+          nombre_cientifico: "Solanum lycopersicum 'San Marzano'",
+          plagas_criticas: ['Tuta absoluta'],
+          justificacion_exclusion: [{ tipo: 'pest', id: 'Tuta absoluta' }],
+        },
+      ],
+    });
+
+    expect(validateCatalogConsistency(catalog).issues).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'base_variety_parity_pest' }),
+    ]));
+  });
+
+  it('detects duplicate ids across species and biopreparados', () => {
+    const catalog = baseCatalog({
+      species: [
+        { id: 'zea_mays', nombre_cientifico: 'Zea mays L.' },
+        { id: 'zea_mays', nombre_cientifico: 'Zea mays L.' },
+      ],
+      biopreparados: [{ id: 'zea_mays' }, { id: 'biol' }, { id: 'biol' }],
+    });
+
+    const result = validateCatalogConsistency(catalog);
+    expect(result.issues.filter((issue) => issue.code === 'duplicate_id')).toHaveLength(3);
+  });
+
+  it('validates scientific names as binomial names with optional authors or cultivar markers', () => {
+    expect(isValidBinomialScientificName('Solanum lycopersicum L.')).toBe(true);
+    expect(isValidBinomialScientificName("Solanum lycopersicum 'San Marzano'")).toBe(true);
+    expect(isValidBinomialScientificName("Fragaria x ananassa 'Monterrey'")).toBe(true);
+    expect(isValidBinomialScientificName("Ananas comosus (L.) Merr. 'MD-2'")).toBe(true);
+    expect(isValidBinomialScientificName('Solanum')).toBe(false);
+    expect(isValidBinomialScientificName('solanum lycopersicum')).toBe(false);
+    expect(isValidBinomialScientificName('Solanum_lycopersicum')).toBe(false);
+  });
+
+  it('detects varieties that point to a missing base species', () => {
+    const catalog = baseCatalog({
+      species: [{
+        id: 'solanum_lycopersicum_san_marzano',
+        nombre_cientifico: "Solanum lycopersicum 'San Marzano'",
+      }],
+    });
+
+    const result = validateCatalogConsistency(catalog);
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'missing_base_species',
+        offender: expect.objectContaining({
+          id: 'solanum_lycopersicum_san_marzano',
+          base_id: 'solanum_lycopersicum',
+        }),
+      }),
+    ]));
+  });
+
+  it('detects missing pest and biopreparado references when registries exist', () => {
+    const catalog = baseCatalog({
+      species: [{
+        id: 'zea_mays',
+        nombre_cientifico: 'Zea mays L.',
+        plagas_criticas: ['Spodoptera frugiperda'],
+        feeding_plan_template: {
+          primary_steps: [{ biofertilizer_slug: 'bio_inventado' }],
+        },
+      }],
+      biopreparados: [{ id: 'biol' }],
+      pests: [{ id: 'tuta_absoluta' }],
+    });
+
+    const result = validateCatalogConsistency(catalog);
+    expect(result.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'missing_pest_ref' }),
+      expect.objectContaining({ code: 'missing_biopreparado_ref' }),
+    ]));
+  });
+
+  it('infers the nearest existing base id before falling back to the binomial marker', () => {
+    const ids = new Set(['solanum_tuberosum', 'solanum_tuberosum_andigena']);
+    expect(inferBaseId({ id: 'solanum_tuberosum_andigena_pastusa' }, ids))
+      .toBe('solanum_tuberosum_andigena');
+    expect(inferBaseId({
+      id: 'solanum_lycopersicum_san_marzano',
+      nombre_cientifico: "Solanum lycopersicum 'San Marzano'",
+    }, new Set())).toBe('solanum_lycopersicum');
+  });
+});
+
+describe('graph parity validator helpers', () => {
+  it('builds a read-only AGE query for pest and biopreparado parity', () => {
+    const sql = buildGraphParitySql('chagra_kg');
+
+    expect(sql).toContain("cypher('chagra_kg'");
+    expect(sql).toContain("variety.id STARTS WITH base.id + '_'");
+    expect(sql).toContain('TARGETS_PEST');
+    expect(sql).toContain('USED_AS_BIOPREPARADO');
+    expect(sql).not.toMatch(/\b(CREATE|MERGE|DELETE|REMOVE)\b/i);
+    expect(sql).not.toMatch(/\bSET\s+(base|variety)\./i);
+  });
+
+  it('parses tabular psql rows returned as agtype strings', () => {
+    const rows = parsePsqlRows('"solanum_lycopersicum"\t"solanum_lycopersicum_san_marzano"\t"TARGETS_PEST"\t"tuta_absoluta"\n');
+
+    expect(rows).toEqual([{
+      base_id: 'solanum_lycopersicum',
+      variety_id: 'solanum_lycopersicum_san_marzano',
+      relation: 'TARGETS_PEST',
+      missing_id: 'tuta_absoluta',
+    }]);
+  });
+
+  it('formats graph parity offenders with counts by relation', () => {
+    const report = formatGraphParityReport([
+      {
+        base_id: 'solanum_lycopersicum',
+        variety_id: 'solanum_lycopersicum_san_marzano',
+        relation: 'TARGETS_PEST',
+        missing_id: 'tuta_absoluta',
+      },
+      {
+        base_id: 'solanum_lycopersicum',
+        variety_id: 'solanum_lycopersicum_san_marzano',
+        relation: 'USED_AS_BIOPREPARADO',
+        missing_id: 'caldo_bordeles',
+      },
+    ]);
+
+    expect(report).toContain('Graph parity gaps: 2');
+    expect(report).toContain('- TARGETS_PEST: 1');
+    expect(report).toContain('- USED_AS_BIOPREPARADO: 1');
+    expect(report).toContain('base=solanum_lycopersicum');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/validate-catalog-consistency.mjs` for base-variety catalog consistency: parity, duplicate IDs, scientific names, base existence, pest refs, and biopreparado refs.
- Adds `scripts/validate-graph-parity.mjs` to query AGE and report missing `TARGETS_PEST` / `USED_AS_BIOPREPARADO` edges from base species compared with varieties.
- Wires `npm test` to run vitest plus the catalog validator in report-only mode, and fixes 7 critical potato base parity refs as an example without filling the massive JSON.

## Real validator output
Catalog report after the example fixes:
```text
Catalog consistency: species=263 biopreparados=36 issues=25
- invalid_scientific_name: 1
- missing_base_species: 24
FAIL invalid_scientific_name: {"id":"festuca_sp_paramo","nombre_cientifico":"Festuca spp. (complejo paramuno)"}
FAIL missing_base_species: {"id":"beta_vulgaris_cicla_blanca","base_id":"beta_vulgaris"}
FAIL missing_base_species: {"id":"beta_vulgaris_conditiva","base_id":"beta_vulgaris"}
FAIL missing_base_species: {"id":"brassica_oleracea_acephala_curly","base_id":"brassica_oleracea"}
FAIL missing_base_species: {"id":"brassica_oleracea_capitata_alba","base_id":"brassica_oleracea"}
FAIL missing_base_species: {"id":"brassica_oleracea_italica","base_id":"brassica_oleracea"}
FAIL missing_base_species: {"id":"fragaria_ananassa_monterrey","base_id":"fragaria_ananassa"}
FAIL missing_base_species: {"id":"lactuca_sativa_capitata","base_id":"lactuca_sativa"}
FAIL missing_base_species: {"id":"lactuca_sativa_crispa_verde","base_id":"lactuca_sativa"}
FAIL missing_base_species: {"id":"lactuca_sativa_longifolia_verde","base_id":"lactuca_sativa"}
FAIL missing_base_species: {"id":"passiflora_tripartita_mollissima","base_id":"passiflora_tripartita"}
FAIL missing_base_species: {"id":"psidium_guajava_manzana","base_id":"psidium_guajava"}
FAIL missing_base_species: {"id":"solanum_lycopersicum_cerasiforme","base_id":"solanum_lycopersicum"}
FAIL missing_base_species: {"id":"solanum_lycopersicum_san_marzano","base_id":"solanum_lycopersicum"}
FAIL missing_base_species: {"id":"solanum_lycopersicum_sungold","base_id":"solanum_lycopersicum"}
FAIL missing_base_species: {"id":"vaccinium_corymbosum_biloxi","base_id":"vaccinium_corymbosum"}
FAIL missing_base_species: {"id":"pisum_sativum_andina","base_id":"pisum_sativum"}
FAIL missing_base_species: {"id":"beta_vulgaris_var_cicla","base_id":"beta_vulgaris"}
FAIL missing_base_species: {"id":"daucus_carota_subsp_sativus","base_id":"daucus_carota"}
FAIL missing_base_species: {"id":"capsicum_chinense_aji_panca","base_id":"capsicum_chinense"}
FAIL missing_base_species: {"id":"capsicum_annuum_aji_dulce_caribe","base_id":"capsicum_annuum"}
FAIL missing_base_species: {"id":"brassica_oleracea_sabellica","base_id":"brassica_oleracea"}
FAIL missing_base_species: {"id":"beta_vulgaris_cicla_morada","base_id":"beta_vulgaris"}
FAIL missing_base_species: {"id":"brassica_oleracea_gemmifera","base_id":"brassica_oleracea"}
FAIL missing_base_species: {"id":"brassica_oleracea_botrytis","base_id":"brassica_oleracea"}
```

Graph parity report from local AGE command:
```text
Graph parity gaps: 0
```

## Test plan
- `node --check scripts/validate-catalog-consistency.mjs && node --check scripts/validate-graph-parity.mjs && node --check tests/unit/catalogConsistency.test.js`
- `node -e "JSON.parse(require('fs').readFileSync('catalog/chagra-catalog-oss-subset-v3.2.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"`
- `node scripts/validate-catalog-consistency.mjs --report-only --limit 40`
- `timeout 20s node scripts/validate-graph-parity.mjs`

Not run locally per task instruction because Node 20 hangs here: `npx vitest run`, `npx eslint . --max-warnings=0`, `npm run build`. Pre-commit did run the repo eslint hook successfully.
