### PR TITLE
fix(agente): layout 100dvh sin recorte + la mano reemplaza el menú de texto en idle

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -3118,14 +3118,34 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           siempre y REEMPLAZA a QuickChipsBar en la pantalla nueva: una sola
           fila de chips (sin duplicación), pero ahora son las capacidades
           reales del agente, adaptadas a la persona. ── */}
-      <ChipsToolbar
-        onSelectIntent={handleChipSelect}
-        activeIntent={activeIntent}
-        hasAttachment={false}
-        disabled={state === STATE_RECORDING}
-        isPro={getCurrentTier() === 'pro'}
-        chipDefs={messages.length === 0 ? null : profileChipDefs}
-      />
+      {/* Operador 2026-06-18: en la pantalla idle NO mostramos el catálogo de
+          chips de texto ("menús horribles") — en su lugar, UN trigger limpio y
+          prominente que abre la MANO de Chagra (única fuente de capacidades,
+          igual que el home). Durante una conversación (messages>0) sí se
+          muestran los chips de capacidad, ya compactos y filtrados por perfil. */}
+      {messages.length === 0 ? (
+        <div className="px-4 pb-1 pt-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-emerald-400/60 bg-emerald-700/45 text-emerald-50 text-sm font-semibold shadow-lg shadow-emerald-950/40 active:scale-[.98] transition-transform"
+            aria-label="Abrir la mano de Chagra"
+            data-testid="agent-mano-trigger"
+          >
+            <Sparkles size={18} className="text-emerald-300 shrink-0" aria-hidden="true" />
+            Toca la mano de Chagra para ver todo lo que puede hacer
+          </button>
+        </div>
+      ) : (
+        <ChipsToolbar
+          onSelectIntent={handleChipSelect}
+          activeIntent={activeIntent}
+          hasAttachment={false}
+          disabled={state === STATE_RECORDING}
+          isPro={getCurrentTier() === 'pro'}
+          chipDefs={profileChipDefs}
+        />
+      )}
 
       {/* ── Compositor pill — paridad completa AgentHero (2026-06-08).
           Superficie OPACA por token (.agent-bar-surface) para legibilidad sobre

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -56,7 +56,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
   // aquí. Si el saludo aún no resolvió, caemos al copy estático de siempre.
   if (messages.length === 0 && !isStreaming) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center p-6">
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col items-center justify-center p-6">
         <div className="text-center max-w-md">
           <ChagraAgentAvatar state="idle" size={200} className="mx-auto mb-4" />
           {proactiveGreeting ? (


### PR DESCRIPTION
Causa raíz de 'no se ve la mano' + 'múltiples descuadres' (Chromium real vs prod): en idle el estado vacío de ChatHistory tenía `flex-1` SIN `min-h-0`; con SuggestedActions + catálogo ChipsToolbar (10 chips) + banner pasaba de 100dvh → input y botón Ⓐ recortados (Ⓐ y=1245, viewport 915).

**Fix:** ChatHistory vacío `+ min-h-0 overflow-y-auto`; en idle los chips de texto se reemplazan por **un trigger que abre la MANO** (única fuente). En conversación se conservan chips compactos.

**Verificado (Playwright+chromium):** Ⓐ y=1245→828, input 1230→813 (en pantalla), chips idle 0, toque abre la mano (manoSvg=15). vite build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)