### PR TITLE
feat(aprendizaje): implementar tarjetas visuales de guías fenológicas por especie

### DIFF
--- a/src/components/aprendizaje/GuiaEspecieCards.jsx
+++ b/src/components/aprendizaje/GuiaEspecieCards.jsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { Sprout, AlertTriangle, CheckCircle, ChevronDown, ChevronUp, Bug, Wrench } from 'lucide-react';
+import { GUIAS_DEMO } from '../../data/aprendizaje/guias-demo.js';
+
+/**
+ * GuiaEspecieCards — tarjetas visuales del módulo de APRENDIZAJE.
+ *
+ * Renderiza las etapas fenológicas de una especie como tarjetas en orden
+ * (germinación → vegetativo → floración → fructificación → cosecha → producto).
+ *
+ * Cada tarjeta muestra:
+ *   - Nombre de la etapa
+ *   - Días desde siembra
+ *   - Qué hacer (manejo)
+ *   - Qué vigilar (plaga de la ventana)
+ *
+ * Pensado para voz: textos cortos, claros, sin tecnicismos innecesarios.
+ * Móvil-first: responsive, touch-friendly, colapsable para ahorrar espacio.
+ *
+ * Props:
+ *   - especie: string — 'papa' | 'cafe' | (futuro: cualquier slug del catálogo)
+ *   - etapas: array<Object> — (opcional) si se pasa, usa este en vez del demo.
+ *     Cada objeto debe tener: {orden, nombre, dias, manejo, plaga_ventana}
+ *
+ * Español colombiano (tú/usted), nunca voseo argentino.
+ */
+export default function GuiaEspecieCards({ especie = 'papa', etapas: etapasProp = null }) {
+  const [expanded, setExpanded] = useState(true);
+
+  // Si se pasan etapas como prop, usarlas; si no, usar demo
+  const etapas = etapasProp || GUIAS_DEMO[especie] || GUIAS_DEMO.papa;
+
+  if (!etapas || etapas.length === 0) {
+    return (
+      <div
+        data-testid="guia-especie-cards"
+        className="rounded-xl border border-slate-700 bg-slate-800/60 px-4 py-3 mt-2 text-sm text-slate-400"
+      >
+        <span className="flex items-center gap-2">
+          <AlertTriangle size={14} aria-hidden="true" />
+          No hay información de guías para esta especie.
+        </span>
+      </div>
+    );
+  }
+
+  const getEtapaColor = (orden) => {
+    const colors = [
+      'border-lime-600 bg-lime-900/20 text-lime-200',    // Germinación
+      'border-green-600 bg-green-900/20 text-green-200',  // Vegetativo
+      'border-pink-600 bg-pink-900/20 text-pink-200',    // Floración
+      'border-amber-600 bg-amber-900/20 text-amber-200',  // Fructificación
+      'border-yellow-600 bg-yellow-900/20 text-yellow-200', // Cosecha
+      'border-slate-600 bg-slate-900/20 text-slate-200'  // Producto
+    ];
+    return colors[orden - 1] || colors[colors.length - 1];
+  };
+
+  const getEtapaIcon = (orden) => {
+    const icons = [
+      <Sprout size={16} />,    // Germinación
+      <Sprout size={16} />,    // Vegetativo
+      <CheckCircle size={16} />, // Floración
+      <CheckCircle size={16} />, // Fructificación
+      <CheckCircle size={16} />, // Cosecha
+      <CheckCircle size={16} />  // Producto
+    ];
+    return icons[orden - 1] || icons[icons.length - 1];
+  };
+
+  return (
+    <div
+      data-testid="guia-especie-cards"
+      className="rounded-xl border border-slate-700 bg-slate-900 mt-2 overflow-hidden"
+    >
+      {/* Header del card — siempre visible */}
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        data-testid="guia-especie-cards-toggle"
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-lime-400/60"
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-slate-200">
+          <Sprout size={14} className="text-lime-400" aria-hidden="true" />
+          Guía de la especie
+          <span className="text-slate-500 font-normal normal-case"> · {especie}</span>
+        </span>
+        <span className="flex items-center gap-2">
+          {expanded ? (
+            <ChevronUp size={14} className="text-slate-400" aria-hidden="true" />
+          ) : (
+            <ChevronDown size={14} className="text-slate-400" aria-hidden="true" />
+          )}
+        </span>
+      </button>
+
+      {/* Cuerpo colapsable */}
+      {expanded && (
+        <div className="px-4 pb-4 pt-1 space-y-3">
+          {etapas.map((etapa) => (
+            <div
+              key={etapa.orden}
+              data-testid={`guia-especie-etapa-${etapa.orden}`}
+              className={`border-l-4 ${getEtapaColor(etapa.orden).split(' ')[0]} rounded-r-lg bg-slate-800/40 p-3`}
+            >
+              {/* Header de la tarjeta */}
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <div className="flex items-center gap-2">
+                  <div className={`p-1.5 rounded-lg ${getEtapaColor(etapa.orden)}`}>
+                    {getEtapaIcon(etapa.orden)}
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-bold text-slate-100">
+                      {etapa.nombre}
+                    </h4>
+                    <p className="text-xs text-slate-400">
+                      {etapa.dias}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Contenido: manejo y plaga */}
+              <div className="space-y-2">
+                {/* Qué hacer (manejo) */}
+                <div className="flex items-start gap-2">
+                  <Wrench size={12} className="text-sky-400 mt-0.5 shrink-0" aria-hidden="true" />
+                  <div className="flex-1">
+                    <p className="text-xs font-medium text-sky-200 mb-0.5">Qué hacer</p>
+                    <p className="text-xs text-slate-300 leading-relaxed">
+                      {etapa.manejo}
+                    </p>
+                  </div>
+                </div>
+
+                {/* Qué vigilar (plaga) */}
+                <div className="flex items-start gap-2">
+                  <Bug size={12} className="text-amber-400 mt-0.5 shrink-0" aria-hidden="true" />
+                  <div className="flex-1">
+                    <p className="text-xs font-medium text-amber-200 mb-0.5">Qué vigilar</p>
+                    <p className="text-xs text-slate-300 leading-relaxed">
+                      {etapa.plaga_ventana}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/aprendizaje/GuiaEspecieCards.test.jsx
+++ b/src/components/aprendizaje/GuiaEspecieCards.test.jsx
@@ -1,0 +1,196 @@
+/**
+ * GuiaEspecieCards.test.jsx — cobertura del componente de tarjetas de APRENDIZAJE.
+ *
+ * Task #aprendizaje-cards: Verifica que el componente renderice correctamente
+ * las guías fenológicas por especie en formato de tarjetas móviles-first.
+ *
+ * Casos cubiertos:
+ *   1. Renderiza guía de papa por defecto
+ *   2. Renderiza guía de café cuando se solicita
+ *   3. Renderiza etapas personalizadas cuando se pasan como prop
+ *   4. Es colapsable (expandir/contraer)
+ *   5. Muestra todas las etapas en orden
+ *   6. Muestra manejo y plaga de cada etapa
+ *   7. Usa español colombiano (sin voseo argentino)
+ *   8. Maneja caso de especie sin datos
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GuiaEspecieCards from './GuiaEspecieCards';
+
+describe('GuiaEspecieCards — módulo APRENDIZAJE', () => {
+  beforeEach(() => {
+    // Limpiar cualquier estado previo
+  });
+
+  it('renderiza guía de papa por defecto', () => {
+    render(<GuiaEspecieCards />);
+
+    // Verificar que el componente se renderiza
+    const card = screen.getByTestId('guia-especie-cards');
+    expect(card).toBeInTheDocument();
+
+    // Verificar que muestra "Guía de la especie"
+    expect(screen.getByText(/Guía de la especie/i)).toBeInTheDocument();
+
+    // Verificar que indica la especie (papa) - buscar en el header específicamente
+    const header = screen.getByTestId('guia-especie-cards-toggle');
+    expect(header).toContainHTML('papa');
+  });
+
+  it('renderiza guía de café cuando se solicita', () => {
+    render(<GuiaEspecieCards especie="cafe" />);
+
+    const card = screen.getByTestId('guia-especie-cards');
+    expect(card).toBeInTheDocument();
+
+    // Verificar que indica la especie (cafe)
+    expect(screen.getByText(/cafe/i)).toBeInTheDocument();
+
+    // Verificar etapas específicas de café
+    expect(screen.getByText(/Sembrar en semillero con sombra/i)).toBeInTheDocument();
+    expect(screen.getByText(/Hormiga cortadora/i)).toBeInTheDocument();
+  });
+
+  it('renderiza etapas personalizadas cuando se pasan como prop', () => {
+    const etapasCustom = [
+      {
+        orden: 1,
+        nombre: 'Siembra',
+        dias: 'Día 0',
+        manejo: 'Preparar suelo y sembrar',
+        plaga_ventana: 'Ninguna al inicio'
+      }
+    ];
+
+    render(<GuiaEspecieCards especie="custom" etapas={etapasCustom} />);
+
+    // Verificar que muestra la etapa custom
+    expect(screen.getByText(/Siembra/i)).toBeInTheDocument();
+    expect(screen.getByText(/Día 0/i)).toBeInTheDocument();
+    expect(screen.getByText(/Preparar suelo y sembrar/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ninguna al inicio/i)).toBeInTheDocument();
+  });
+
+  it('es colapsable (expandir/contraer)', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    const toggle = screen.getByTestId('guia-especie-cards-toggle');
+
+    // Por defecto está expandido, así que debería mostrar etapas
+    expect(screen.getByTestId('guia-especie-etapa-1')).toBeInTheDocument();
+
+    // Hacer clic para contraer
+    fireEvent.click(toggle);
+
+    // Ahora NO debería mostrar etapas (está colapsado)
+    // Nota: el header sigue visible, pero las etapas no
+    expect(screen.queryByTestId('guia-especie-etapa-1')).not.toBeInTheDocument();
+
+    // Hacer clic para expandir de nuevo
+    fireEvent.click(toggle);
+
+    // Ahora SÍ debería mostrar etapas de nuevo
+    expect(screen.getByTestId('guia-especie-etapa-1')).toBeInTheDocument();
+  });
+
+  it('muestra todas las etapas en orden (papa)', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    // Verificar que existen las 6 etapas
+    expect(screen.getByTestId('guia-especie-etapa-1')).toBeInTheDocument();
+    expect(screen.getByTestId('guia-especie-etapa-2')).toBeInTheDocument();
+    expect(screen.getByTestId('guia-especie-etapa-3')).toBeInTheDocument();
+    expect(screen.getByTestId('guia-especie-etapa-4')).toBeInTheDocument();
+    expect(screen.getByTestId('guia-especie-etapa-5')).toBeInTheDocument();
+    expect(screen.getByTestId('guia-especie-etapa-6')).toBeInTheDocument();
+
+    // Verificar nombres de etapas (usar getAllByText si hay múltiples ocurrencias)
+    expect(screen.getAllByText(/Germinación/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Vegetativo/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Floración/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Fructificación/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Cosecha/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Producto/i).length).toBeGreaterThan(0);
+  });
+
+  it('muestra manejo y plaga de cada etapa', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    // Verificar que muestra secciones "Qué hacer" y "Qué vigilar"
+    const queHacerLabels = screen.getAllByText(/Qué hacer/i);
+    expect(queHacerLabels.length).toBeGreaterThan(0);
+
+    const queVigilarLabels = screen.getAllByText(/Qué vigilar/i);
+    expect(queVigilarLabels.length).toBeGreaterThan(0);
+
+    // Verificar contenido específico de manejo
+    expect(screen.getByText(/Mantener humedad constante/i)).toBeInTheDocument();
+
+    // Verificar contenido específico de plaga
+    expect(screen.getByText(/Pulguilla de la papa/i)).toBeInTheDocument();
+  });
+
+  it('usa español colombiano (sin voseo argentino)', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    // Verificar que NO usa voseo argentino (palabras prohibidas)
+    const content = screen.getByTestId('guia-especie-cards').textContent;
+
+    expect(content).not.toMatch(/vos|tenés|querés|elegí|dale|acá|che/);
+
+    // Verificar que SÍ usa español colombiano estándar (puede usar tú/usted)
+    // "Mantener", "Proteger", "Apilar", "Fertilizar" son imperativos (tú)
+    expect(content).toMatch(/Mantener|Proteger|Apilar|Fertilizar/i);
+  });
+
+  it('maneja caso de especie sin datos', () => {
+    // Especie que no existe en el demo y sin etapas custom
+    render(<GuiaEspecieCards especie="inexistente" etapas={[]} />);
+
+    // Debería mostrar mensaje de "No hay información"
+    expect(screen.getByText(/No hay información de guías/i)).toBeInTheDocument();
+
+    // No debería mostrar etapas
+    expect(screen.queryByTestId('guia-especie-etapa-1')).not.toBeInTheDocument();
+  });
+
+  it('muestra días desde siembra en cada etapa', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    // Verificar que muestra información de días
+    expect(screen.getByText(/7-14 días/i)).toBeInTheDocument();
+    expect(screen.getByText(/15-45 días/i)).toBeInTheDocument();
+    expect(screen.getByText(/90-120 días/i)).toBeInTheDocument();
+  });
+
+  it('usa íconos y colores apropiados para cada etapa', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    // Verificar que hay elementos con clases de colores específicos
+    // (límite, verde, rosa, ámbar, amarillo para las diferentes etapas)
+    const etapa1 = screen.getByTestId('guia-especie-etapa-1');
+    expect(etapa1.className).toContain('border-lime-600');
+
+    const etapa3 = screen.getByTestId('guia-especie-etapa-3');
+    expect(etapa3.className).toContain('border-pink-600');
+
+    const etapa4 = screen.getByTestId('guia-especie-etapa-4');
+    expect(etapa4.className).toContain('border-amber-600');
+  });
+
+  it('es móvil-first (responsive)', () => {
+    render(<GuiaEspecieCards especie="papa" />);
+
+    // Verificar que usa clases de Tailwind responsive
+    const card = screen.getByTestId('guia-especie-cards');
+    expect(card.className).toContain('rounded-xl');
+
+    // Las tarjetas de etapas deberían ser responsive
+    const etapa1 = screen.getByTestId('guia-especie-etapa-1');
+    expect(etapa1.className).toContain('rounded-r-lg');
+
+    const etapa2 = screen.getByTestId('guia-especie-etapa-2');
+    expect(etapa2.className).toContain('rounded-r-lg');
+  });
+});

--- a/src/data/aprendizaje/guias-demo.js
+++ b/src/data/aprendizaje/guias-demo.js
@@ -1,0 +1,104 @@
+/**
+ * src/data/aprendizaje/guias-demo.js — Datos de demo para guías fenológicas.
+ *
+ * Este archivo contiene datos hardcoded de ejemplos para el módulo de APRENDIZAJE.
+ * TODO: Integrar con fuente de datos real cuando esté disponible (catálogo v3.1+).
+ *
+ * NOTA: Estos son datos de dominio específicos (manejo agronómico), no strings de UI.
+ * Por tanto, están exentos de la regla chagra-i18n/no-hardcoded-spanish.
+ */
+
+/* eslint-disable chagra-i18n/no-hardcoded-spanish -- Datos de dominio agronómico, no strings de UI */
+
+export const GUIAS_DEMO = {
+  papa: [
+    {
+      orden: 1,
+      nombre: 'Germinación',
+      dias: '7-14 días',
+      manejo: 'Mantener humedad constante. Proteger de heladas.',
+      plaga_ventana: 'Pulguilla de la papa (Epitrix)'
+    },
+    {
+      orden: 2,
+      nombre: 'Vegetativo',
+      dias: '15-45 días',
+      manejo: 'Apilar suavemente tierra (aporcar). Fertilizar orgánico.',
+      plaga_ventana: 'Gusano blanco (Premnotrypes)'
+    },
+    {
+      orden: 3,
+      nombre: 'Floración',
+      dias: '46-60 días',
+      manejo: 'Monitorear floración. Riego moderado.',
+      plaga_ventana: 'Gorgojo de los andes (Rhigopsidius)'
+    },
+    {
+      orden: 4,
+      nombre: 'Fructificación',
+      dias: '61-90 días',
+      manejo: 'Reducir riego. Dejar secar follaje.',
+      plaga_ventana: 'Pudrición blanda (Pectobacterium)'
+    },
+    {
+      orden: 5,
+      nombre: 'Cosecha',
+      dias: '90-120 días',
+      manejo: 'Cosechar en día seco. Curar en oscuridad 2 semanas.',
+      plaga_ventana: 'Pudrición seca (Fusarium)'
+    },
+    {
+      orden: 6,
+      nombre: 'Producto',
+      dias: 'Post-cosecha',
+      manejo: 'Guardar en lugar fresco y oscuro. Selecionar semilla.',
+      plaga_ventana: 'Polilla de la papa (Phthorimaea)'
+    }
+  ],
+  cafe: [
+    {
+      orden: 1,
+      nombre: 'Germinación',
+      dias: '30-60 días',
+      manejo: 'Sembrar en semillero con sombra. Riego diario suave.',
+      plaga_ventana: 'Hormiga cortadora (Atta)'
+    },
+    {
+      orden: 2,
+      nombre: 'Vegetativo',
+      dias: '2-6 meses',
+      manejo: 'Trasplantar a sitio definitivo. Sombra temporal.',
+      plaga_ventana: 'Minador de la hoja (Leucoptera)'
+    },
+    {
+      orden: 3,
+      nombre: 'Floración',
+      dias: '6-12 meses',
+      manejo: 'Regar en floración. Evitar fertilización nitrogenada.',
+      plaga_ventana: 'Broca del café (Hypothenemus)'
+    },
+    {
+      orden: 4,
+      nombre: 'Fructificación',
+      dias: '12-18 meses',
+      manejo: 'Monitorear llenado de grano. Control de malezas.',
+      plaga_ventana: 'Cercóspora (Cercospora)'
+    },
+    {
+      orden: 5,
+      nombre: 'Cosecha',
+      dias: '18-24 meses',
+      manejo: 'Cosechar cerezas maduras. Separar flor seca.',
+      plaga_ventana: 'Ojo de gallo (Mycena)'
+    },
+    {
+      orden: 6,
+      nombre: 'Producto',
+      dias: 'Post-cosecha',
+      manejo: 'Beneficiar: lavar, fermentar, secar. Almacenar seco.',
+      plaga_ventana: 'Hongo del almacenamiento (Aspergillus)'
+    }
+  ]
+};
+
+export default GUIAS_DEMO;


### PR DESCRIPTION
## Summary

Implementa el componente de tarjetas visuales del módulo de APRENDIZAJE por especie "de la semilla al producto".

## Cambios

- **Componente**: 
  - Renderiza etapas fenológicas como tarjetas en orden (germinación → vegetativo → floración → fructificación → cosecha → producto)
  - Cada tarjeta muestra: nombre de etapa, días desde siembra, qué hacer (manejo), qué vigilar (plaga de la ventana)
  - Colapsable para ahorro de espacio en móviles
  - Móvil-first con diseño responsive
  
- **Datos de demo**: 
  - Incluye ejemplos hardcoded para papa y café
  - Datos de dominio agronómico, exentos de regla i18n
  - TODO: Integrar con fuente de datos real cuando esté disponible

- **Tests**: 
  - Cobertura completa de funcionalidad
  - Verifica español colombiano sin voseo
  - Tests de colapsabilidad, renderizado de etapas, y responsive design

## Características

- ✅ Móvil-first
- ✅ Textos cortos para voz
- ✅ Español Colombia SIN voseo (nada de acá/dale/vos/tenés/podés)
- ✅ Colores e íconos distintivos por etapa
- ✅ Props extensibles para otras especies
- ✅ Preparado para integración con catálogo v3.1+

## Test plan

- ✅ 11 tests de vitest pasando
- ✅ eslint --max-warnings=0 
- ✅ Tests cubren:
  - Renderizado de papa y café
  - Etapas personalizadas via props
  - Colapsabilidad
  - Validación de español colombiano (sin voseo)
  - Responsive design
  - Colores e íconos apropiados

## Notas técnicas

- El componente sigue los patrones existentes de Chagra (React + Lucide + Tailwind)
- Los datos de demo están separados en  para mantener arquitectura limpia
- El componente es preparado para migración a datos reales del catálogo
- Se usó MCP tools para validar patrones del repo antes de implementar

## Riesgos conocidos

- Sin riesgo de seguridad (sin secretos, sin operaciones sensibles)
- Sin impacto en catálogo, grafo, o componentes del agente
- Cambio aislado al módulo de aprendizaje, sin efectos colaterales