### PR TITLE
test(e2e): corregir falso negativo del tile Páramo en la prueba faithful del operador

### DIFF
--- a/tests/operador-todo-visible-funciona.spec.js
+++ b/tests/operador-todo-visible-funciona.spec.js
@@ -247,10 +247,19 @@ test.describe('Operador — todo visible y funcional (prueba FAITHFUL nocturna)'
     }
 
     // Las 4 tarjetas de seguimiento (incl. Cerdos) — operador las ve todas.
+    // Se localiza cada tarjeta por su TÍTULO (el <h3> de la card, nivel 3) con
+    // nombre EXACTO, no por substring. Motivo: el nombre "Páramo" también
+    // aparece dentro de su propio subtítulo/empty-state ("Cuida tu páramo y el
+    // agua"), así que un `getByText('Páramo', { exact:false })` resolvía a DOS
+    // elementos y `isVisible()` lanzaba strict-mode violation → el `.catch`
+    // lo reportaba como "no se ve" pese a que la tarjeta SÍ está (falso
+    // negativo). El matcher por heading exacto apunta solo al título y es
+    // consistente con el patrón `getByRole('heading', …)` usado más abajo.
     const seguimiento = page.locator('[data-testid="seguimiento-cards"]');
     await seguimiento.scrollIntoViewIfNeeded().catch(() => {});
     for (const nombre of SEGUIMIENTO) {
-      const ok = await seguimiento.getByText(nombre, { exact: false }).isVisible().catch(() => false);
+      const tarjeta = seguimiento.getByRole('heading', { level: 3, name: nombre, exact: true });
+      const ok = await tarjeta.isVisible().catch(() => false);
       if (!ok) faltantes.push(`Seguimiento: ${nombre}`);
     }
 


### PR DESCRIPTION
## Qué pasaba

El E2E nocturno faithful del operador (`tests/operador-todo-visible-funciona.spec.js`, test #3 "TODOS los botones del home están VISIBLES") fallaba con:

> Módulos del operador que NO se ven: **Seguimiento: Páramo**

Los otros 4 tests pasaban y los otros 3 tiles de seguimiento (Reforestación, Silvopastoreo, Cerdos) se veían bien. Solo "Páramo" se reportaba ausente.

## Clasificación: falso negativo del TEST (no regresión de producto)

La tarjeta de Páramo **sí se renderiza** correctamente:

- El test unitario `DashboardLive.homeGating.test.jsx` ya verifica "RESTAURADOR: Reforestación y Páramo SÍ" y pasa (5/5).
- El bypass del operador en `homeModuleSelector.selectHomeModules` devuelve las **4** keys de seguimiento (incluida `paramo`) para `esOperador=true`.
- Ningún merge reciente tocó `seguimientoProcesos.js`, `FincaCards.jsx`, `DashboardLive.jsx` ni `homeModuleSelector.js`.

**Raíz:** matcher ambiguo en el spec. El bloque localizaba cada tarjeta con `getByText(nombre, { exact:false })` (substring, case-insensitive). "Páramo" es el **único** de los 4 nombres que también aparece dentro de su propio subtítulo/empty-state (`"Conservación de páramo y agua"` / `"Cuida tu páramo y el agua"`), así que el locator resolvía a **dos** elementos → `isVisible()` lanzaba *strict-mode violation* → el `.catch(() => false)` lo contaba como faltante.

Reproducido en Chromium contra la marca real de la card:

| tile | matchCount `getByText(exact:false)` | resultado |
|---|---|---|
| Reforestación | 1 | ✓ visible |
| Silvopastoreo | 1 | ✓ visible |
| **Páramo** | **2** | ✗ strict-mode → falso negativo |
| Cerdos | 1 | ✓ visible |

## Fix (mínimo, quirúrgico)

Localizar cada tarjeta por su **título** (el `<h3>`, nivel 3) con nombre **exacto**, no por substring. Apunta solo al título y es consistente con el patrón `getByRole('heading', …)` ya usado en el resto del spec. **El operador real DEBE ver los 4 tiles y los sigue viendo** — solo se endurece el matcher (no se baja la guardia).

Solo se tocó el archivo de prueba; el render de producción ya era correcto.

## Verificación

`scripts/e2e-operador-nightly.sh` (login real + datos reales contra `chagra.guatoc.co`, Chromium del nix-store):

```
  ✓  1) login fresco NO muestra error de token y 2) los datos CARGAN (8.5s)
  ✓  3) TODOS los botones del home están VISIBLES (operador ve todos los módulos) (7.1s)
  ✓  4) CADA botón del home FUNCIONA al tap real (hit-test + navega) (20.1s)
  ✓  5) AGREGAR PLANTA abre el selector de ÁREA/ZONA (11.6s)
  ✓  6) CRUD planta: AGREGAR → CONSULTAR → BORRAR (31.3s)
  5 passed (1.3m)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)