### PR TITLE
fix(agent): preserva contexto multiturno en prompt

### DIFF
--- a/src/services/__tests__/agentPromptBase.test.js
+++ b/src/services/__tests__/agentPromptBase.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildBasePrompt,
+  buildConversationContextPin,
   analyzeQuery,
   buildQueryAnalysisBlock,
   buildCorpusContext,
@@ -100,6 +101,28 @@ describe('buildCorpusVariants', () => {
   });
 });
 
+describe('buildConversationContextPin', () => {
+  it('extrae datos establecidos por el usuario en historial relevante', () => {
+    const history = [
+      'Usuario: Tengo café variedad Castillo a 2600 msnm y ya vimos riesgo de gota en el lote.',
+      'Asistente: Recomiendo revisar drenaje y monitorear hojas.',
+      'Usuario: ¿Entonces cambio la variedad por roya?',
+    ].join('\n');
+
+    const block = buildConversationContextPin(history);
+    expect(block).toContain('CONTEXTO DE LA CONVERSACIÓN');
+    expect(block).toContain('Cultivo: café');
+    expect(block).toContain('Variedad: Castillo');
+    expect(block).toContain('2600 msnm');
+    expect(block).toContain('Problema previo: gota');
+  });
+
+  it('retorna vacio sin datos fijables', () => {
+    expect(buildConversationContextPin('')).toBe('');
+    expect(buildConversationContextPin('Usuario: Hola, ¿cómo estás?')).toBe('');
+  });
+});
+
 describe('formatToolEvidence', () => {
   it('retorna vacio para entrada nula', () => {
     expect(formatToolEvidence(null)).toBe('');
@@ -165,8 +188,8 @@ describe('buildBasePrompt — guardas condicionales tomate', () => {
       ...baseArgs,
       query: 'Mi tomate tiene marchitez bacteriana por Ralstonia, ¿qué producto lo cura?',
     });
-    expect(prompt).toContain('marchitez bacteriana/Ralstonia/moko');
-    expect(prompt).toContain('NO tienen cura química');
+    expect(prompt).toContain('moko/marchitez bacteriana/Ralstonia');
+    expect(prompt).toContain('no tienen cura química');
 
     const control = buildBasePrompt({ ...baseArgs, query: '¿Cómo tutoro el tomate?' });
     expect(control).not.toContain('marchitez bacteriana/Ralstonia/moko');
@@ -177,14 +200,14 @@ describe('buildBasePrompt — guardas condicionales tomate', () => {
       ...baseArgs,
       query: '¿Cuántos ml de insecticida le echo al tomate?',
     });
-    expect(dosePrompt).toContain('si piden dosis de plaguicida');
+    expect(dosePrompt).toContain('NUNCA inventes una dosis numérica de plaguicida');
     expect(dosePrompt).toContain('etiqueta registrada ICA');
 
     const bannedPrompt = buildBasePrompt({
       ...baseArgs,
       query: 'Me ofrecieron Lannate para tomate, ¿lo uso?',
     });
-    expect(bannedPrompt).toContain('metamidofós');
+    expect(bannedPrompt).toContain('productos altamente tóxicos');
     expect(bannedPrompt).toContain('registro ICA vigente');
   });
 
@@ -193,12 +216,44 @@ describe('buildBasePrompt — guardas condicionales tomate', () => {
       ...baseArgs,
       query: 'Tengo broca en tomate, ¿qué controlador uso?',
     });
-    expect(brocaTomate).toContain('Broca es plaga de café');
+    expect(brocaTomate).toContain('broca es plaga de café');
 
     const brocaCafe = buildBasePrompt({
       ...baseArgs,
       query: 'Tengo broca en café, ¿qué controlador uso?',
     });
     expect(brocaCafe).not.toContain('Broca es plaga de café');
+  });
+});
+
+describe('buildBasePrompt: coherencia multiturno', () => {
+  const baseArgs = {
+    plantContext: 'café x3',
+    fincaContext: '',
+    indoorContext: '',
+    finca: null,
+    query: '¿Cambio la variedad para resistir roya?',
+    isEnum: false,
+  };
+
+  it('inyecta contexto de conversación con Castillo, 2600 msnm y gota', () => {
+    const prompt = buildBasePrompt({
+      ...baseArgs,
+      contextMemory: 'Usuario: Mi cultivo es café variedad Castillo a 2600 msnm. Tengo gota en el lote.',
+    });
+
+    expect(prompt).toContain('COHERENCIA MULTITURNO');
+    expect(prompt).toContain('CONTEXTO DE LA CONVERSACIÓN');
+    expect(prompt).toContain('Cultivo: café');
+    expect(prompt).toContain('Variedad: Castillo');
+    expect(prompt).toContain('2600 msnm');
+    expect(prompt).toContain('Problema previo: gota');
+  });
+
+  it('sin historial no inyecta bloque, pero conserva regla base', () => {
+    const prompt = buildBasePrompt({ ...baseArgs, contextMemory: '' });
+
+    expect(prompt).toContain('COHERENCIA MULTITURNO');
+    expect(prompt).not.toContain('CONTEXTO DE LA CONVERSACIÓN');
   });
 });

--- a/src/services/agentPromptBase.js
+++ b/src/services/agentPromptBase.js
@@ -1,3 +1,4 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish */
 /**
  * agentPromptBase — texto BASE del system prompt del agente + builders puros
  * de bloques por-turno (corpus RAG, evidencia de tools, entidades resueltas,
@@ -58,6 +59,109 @@ function _mentionsAny(textStripped, keys) {
     if (re.test(textStripped)) return true;
   }
   return false;
+}
+
+const CONVERSATION_CROP_KEYS = [
+  ['café', ['cafe', 'cafeto', 'cafetal']],
+  ['tomate', ['tomate']],
+  ['papa', ['papa']],
+  ['aguacate', ['aguacate']],
+  ['plátano', ['platano']],
+  ['maíz', ['maiz']],
+  ['fresa', ['fresa']],
+  ['mora', ['mora']],
+  ['frijol', ['frijol']],
+  ['mango', ['mango']],
+];
+
+const CONVERSATION_VARIETY_KEYS = [
+  ['Castillo', ['castillo']],
+  ['Colombia', ['variedad colombia', 'cultivar colombia']],
+  ['Caturra', ['caturra']],
+  ['Tabi', ['tabi']],
+  ['Bourbon', ['bourbon']],
+  ['Geisha', ['geisha']],
+  ['Typica', ['typica', 'típica']],
+  ['Hass', ['hass']],
+  ['Monserrate', ['monserrate']],
+  ['Diacol Capiro', ['diacol capiro', 'capiro']],
+  ['Criolla', ['criolla']],
+];
+
+const CONVERSATION_PROBLEM_KEYS = [
+  ['gota', ['gota', 'tizón tardío', 'tizon tardio', 'phytophthora']],
+  ['roya', ['roya']],
+  ['broca', ['broca']],
+  ['chiza', ['chiza']],
+  ['sigatoka', ['sigatoka']],
+  ['antracnosis', ['antracnosis']],
+  ['monalonion', ['monalonion']],
+  ['marchitez bacteriana', ['marchitez bacteriana', 'ralstonia']],
+  ['moko', ['moko']],
+  ['manchas', ['mancha', 'manchas']],
+  ['amarillamiento', ['amarillamiento', 'amarilla', 'amarillas']],
+];
+
+const _firstMention = (textStripped, entries) => {
+  const found = entries.find(([, keys]) => _mentionsAny(textStripped, keys));
+  return found ? found[0] : '';
+};
+
+const _userHistoryText = (history) => {
+  if (Array.isArray(history)) {
+    return history
+      .filter((turn) => turn?.role === 'user' || turn?.author === 'user' || turn?.type === 'user')
+      .map((turn) => turn?.content || turn?.text || turn?.message || '')
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  const raw = typeof history === 'string' ? history : '';
+  if (!raw.trim()) return '';
+
+  const userParts = [];
+  const re = /(?:^|\n)\s*Usuario:\s*([\s\S]*?)(?=\n\s*(?:Asistente|Usuario):|$)/gi;
+  let match;
+  while ((match = re.exec(raw)) !== null) {
+    if (match[1]?.trim()) userParts.push(match[1].trim());
+  }
+  return userParts.length > 0 ? userParts.join('\n') : raw;
+};
+
+/**
+ * buildConversationContextPin: fija datos ya establecidos por el usuario en
+ * la conversación. Heurística determinística y corta para no competir con el
+ * grounding del turno actual.
+ *
+ * @param {string|Array<object>} history
+ * @returns {string}
+ */
+export function buildConversationContextPin(history) {
+  const userText = _userHistoryText(history);
+  const mention = _strip(userText);
+  if (!mention) return '';
+
+  const lines = [];
+  const crop = _firstMention(mention, CONVERSATION_CROP_KEYS);
+  const variety = _firstMention(mention, CONVERSATION_VARIETY_KEYS);
+  const problem = _firstMention(mention, CONVERSATION_PROBLEM_KEYS);
+  const altitudeMatch = mention.match(/(^|[^0-9])(\d{3,4})\s*(msnm|m\.?s\.?n\.?m\.?|metros?|m)([^a-zñ]|$)/);
+  const locationMatch = userText.match(/\b(?:en|desde|ubicad[oa] en|finca en)\s+([A-ZÁÉÍÓÚÑ][A-Za-zÁÉÍÓÚÜÑáéíóúüñ .'-]{2,45})(?=[,.;\n]|$)/);
+
+  if (crop) lines.push(`- Cultivo: ${crop}`);
+  if (variety) lines.push(`- Variedad: ${variety}`);
+  if (altitudeMatch || locationMatch) {
+    const parts = [];
+    if (altitudeMatch) parts.push(`${altitudeMatch[2]} msnm`);
+    if (locationMatch) parts.push(locationMatch[1].trim());
+    lines.push(`- Altitud/ubicación: ${parts.join(', ')}`);
+  }
+  if (problem) lines.push(`- Problema previo: ${problem}`);
+
+  if (lines.length === 0) return '';
+
+  return `CONTEXTO DE LA CONVERSACIÓN (datos ya establecidos por el usuario):
+${lines.slice(0, 4).join('\n')}`;
 }
 
 // ── Glosarios como DATA (se inyectan SOLO las líneas mencionadas) ───────────
@@ -230,17 +334,24 @@ export function buildBasePrompt({
 }) {
   const mention = _strip(`${query}\n${contextMemory}`);
   const sections = [];
+  const conversationContextPin = buildConversationContextPin(contextMemory);
 
   sections.push(`Eres Chagra IA, un asistente agroecológico colombiano. Habla como agrónomo experimentado, no como sistema. ${fincaContext}${indoorContext}El usuario tiene estas plantas agrupadas por especie con su conteo: ${plantContext}.`);
 
   sections.push(`REGLA DE INVENTARIO: al hablar de las plantas del usuario, agrupa por especie con su conteo (ej. "tienes 15 fresas, 4 caléndulas"); NUNCA listes los números individuales (#01, #02 — son identificadores internos).`);
+
+  sections.push(`COHERENCIA MULTITURNO: respeta cultivo, variedad, altitud y problema ya dichos. Si la nueva pregunta contradice o ignora un dato/riesgo previo, corrígelo o recuérdalo.`);
+
+  if (conversationContextPin) {
+    sections.push(conversationContextPin);
+  }
 
   if (INVENTORY_QUERY_RE.test(mention)) {
     sections.push(`REGLA INVENTARIO-DIRECTO: si el usuario pregunta por su inventario ("tengo X", "ya tengo X registrado", "cuántos X tengo", "mis plantas", "qué plantas tengo"), responde DIRECTAMENTE con el inventario de arriba — NO lo redirijas a "ingresar al sistema y revisar la lista": TÚ ya tienes el inventario en este contexto. Si no tiene lo que pregunta: "No, todavía no tienes X registrado. ¿Quieres agregarlo desde la sección Mi Finca?". Si el inventario es "ninguna": "No tienes plantas registradas aún. ¿Te ayudo a registrar la primera?".`);
   }
 
   if (typeof contextMemory === 'string' && contextMemory.trim()) {
-    sections.push(`REGLA CRÍTICA TURN-AISLAMIENTO: la "Conversación previa" trae respuestas que YA diste; NUNCA las copies, repitas ni mezcles con la actual (el usuario ya las leyó): responde ÚNICAMENTE al último mensaje, sin residuos de turnos pasados (listas, conteos, párrafos). Incidente real: a "cómo combatir plagas en hortalizas" se arrastró la lista de variedades de tomate del turno anterior — incoherente.`);
+    sections.push(`REGLA CRÍTICA TURN-AISLAMIENTO: la "Conversación previa" trae respuestas que YA diste. No las copies ni mezcles; responde solo al último mensaje, sin residuos de turnos pasados.`);
   }
 
   sections.push(`REGLAS ANTI-ALUCINACIÓN (núcleo):


### PR DESCRIPTION
## Summary
- Agrega el builder puro `buildConversationContextPin` en `agentPromptBase.js` para fijar, de forma condicional y tersa, datos ya dados por el usuario: cultivo, variedad, altitud/ubicación y problema previo.
- Añade la regla base de coherencia multiturno para corregir o recordar datos previos cuando una pregunta nueva los contradice o los ignora.
- Cubre Castillo, 2600 msnm y gota en tests, más el caso sin historial para mantener retrocompatibilidad.

## Budget
- Primer intento antes de compactar: Q1 relacional quedó en 6241/6144 y falló `promptAssembler.budget.test.js`.
- Después de compactar la regla y el aislamiento de turnos: Q1 6121/6144, Q2 6007/6144, Q3 6073/6144. `promptAssembler.budget.test.js` verde.

## Test plan
- PASS: `npx vitest run src/services/__tests__/agentPromptBase.test.js src/services/__tests__/promptAssembler.budget.test.js`
- PASS: `npx vitest run src/services/__tests__/promptAssembler.budget.test.js --reporter verbose`
- PASS: `NODE_OPTIONS=--max-old-space-size=8192 npx eslint src/services/agentPromptBase.js src/services/__tests__/agentPromptBase.test.js --max-warnings=0`
- PASS: `npm run build`
- INFO: `npx eslint . --max-warnings=0` OOM con heap default; con 8192 MB no cerró tras varios minutos y se interrumpió para validar los archivos tocados.
- FAIL externo al scope: `npx vitest run` falla en 11 archivos no tocados (bench faltante `scripts/bench-borde-alucinacion.mjs`, DB_VERSION esperado 24 vs 25, tests UI, fincaEvolution, outputGuards y networkRetry). Suites focalizadas de este PR verdes.

## Follow-up validation
- La validación multi-turno final la corre Claude con el mega-bench tras merge.
