### PR TITLE
feat(home): módulo Asociaciones/Policultivos (milpa/café/frutales/hortaliza)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText } from 'lucide-react';
+import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText, Network } from 'lucide-react';
 import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 import { useClimaAtmosphere } from './hooks/useClimaAtmosphere';
@@ -12,7 +12,8 @@ import { isAuthenticated, logoutUser } from './services/authService';
 import useAssetStore from './store/useAssetStore';
 import { fetchFromFarmOS } from './services/apiService';
 import { PRIMARY_WORKER_NAME } from './config/workerConfig';
-import { tieneAccesoGlaciarActual } from './config/glaciarAccess';
+import { tieneAccesoGlaciarActual, esOperadorActual } from './config/glaciarAccess';
+import { getProfile } from './services/userProfileService';
 import { parseSeguimientoView } from './config/seguimientoProcesos';
 import { initCatalog } from './db/catalogDB';
 import NetworkStatusBar from './components/NetworkStatusBar';
@@ -67,6 +68,7 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
 const BiodiversidadView = lazy(() => import('./components/BiodiversidadView'));
+const Asociaciones = lazy(() => import('./components/Asociaciones'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingPiloto = lazy(() => import('./components/OnboardingPiloto'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
@@ -1014,6 +1016,14 @@ export default function App() {
         return (
           <ErrorBoundary>
             <BiodiversidadView onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
+          </ErrorBoundary>
+        );
+      case 'asociaciones':
+        return (
+          <ErrorBoundary>
+            <ScreenShell title="Asociaciones" icon={Network} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>
+              <Asociaciones profile={getProfile()} esOperador={esOperadorActual()} />
+            </ScreenShell>
           </ErrorBoundary>
         );
       case 'voz':

--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -1,0 +1,65 @@
+import arquetipos from '../data/asociaciones-arquetipos.json';
+import { filterAsociacionesByRole } from '../services/asociacionesFilter';
+
+export default function Asociaciones({ profile = {}, esOperador = false }) {
+  const visibles = filterAsociacionesByRole(arquetipos, profile, { esOperador });
+
+  return (
+    <section className="space-y-4" aria-labelledby="asociaciones-title">
+      <div className="rounded-2xl border border-emerald-700/30 bg-emerald-950/30 p-4 sm:p-5">
+        <p className="text-xs font-bold uppercase tracking-wider text-emerald-300">
+          Capa de relación entre especies
+        </p>
+        <h2 id="asociaciones-title" className="mt-1 text-2xl sm:text-3xl font-black leading-tight text-white">
+          Asociaciones / Policultivos
+        </h2>
+        <p className="mt-2 text-base sm:text-lg leading-relaxed text-slate-200">
+          Mira combinaciones conocidas para sembrar especies que se acompañan. Cada tarjeta muestra el beneficio corto y la fuente.
+        </p>
+      </div>
+
+      {visibles.length === 0 ? (
+        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/70 p-5 text-base text-slate-200">
+          No hay asociaciones sugeridas para este perfil todavía.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {visibles.map((item) => (
+            <article
+              key={item.id}
+              aria-label={item.nombre}
+              className="rounded-2xl border border-emerald-700/30 bg-gradient-to-br from-emerald-500/15 via-slate-900/85 to-lime-500/10 p-4 sm:p-5 shadow-lg shadow-black/20"
+            >
+              <div className="flex items-start gap-4">
+                <span
+                  aria-hidden="true"
+                  className="grid h-14 w-14 shrink-0 place-items-center rounded-2xl bg-emerald-400/15 text-4xl"
+                >
+                  {item.icono}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <h3 className="text-xl font-black leading-tight text-white">{item.nombre}</h3>
+                  <p className="mt-1 text-base font-semibold leading-snug text-emerald-100">
+                    {item.especies.join(' + ')}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-3 text-base leading-relaxed text-slate-100">
+                <p>{item.beneficio}</p>
+                <div className="flex flex-wrap gap-2 text-sm">
+                  <span className="rounded-lg bg-white/10 px-2.5 py-1 font-semibold text-slate-200">
+                    {item.rol.join(', ')}
+                  </span>
+                  <span className="rounded-lg bg-black/25 px-2.5 py-1 text-slate-300">
+                    Fuente: {item.fuente}
+                  </span>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/__tests__/Asociaciones.test.jsx
+++ b/src/components/__tests__/Asociaciones.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect } from 'vitest';
+
+import Asociaciones from '../Asociaciones';
+import { filterAsociacionesByRole } from '../../services/asociacionesFilter';
+import arquetipos from '../../data/asociaciones-arquetipos.json';
+
+describe('Asociaciones', () => {
+  test('renderiza los arquetipos como tarjetas con especies, beneficio y fuente', () => {
+    render(<Asociaciones profile={{ rol: 'campesino' }} />);
+
+    expect(screen.getByRole('heading', { name: 'Asociaciones / Policultivos' })).toBeInTheDocument();
+    expect(screen.getByRole('article', { name: /Milpa \(Tres Hermanas\)/ })).toHaveTextContent('maíz + fríjol + ahuyama');
+    expect(screen.getByText('LER 1.32, el fríjol fija nitrógeno')).toBeInTheDocument();
+    expect(screen.getAllByText(/Fuente:/)[0]).toHaveTextContent('DR-ASOCIACIONES-2026-06-18');
+  });
+
+  test('filtra arquetipos por rol del usuario', () => {
+    const visibles = filterAsociacionesByRole(arquetipos, { rol: 'urbano' });
+
+    expect(visibles.map((item) => item.id)).toEqual(['hortaliza_repelente']);
+
+    render(<Asociaciones profile={{ rol: 'urbano' }} />);
+    expect(screen.getByRole('article', { name: /Cebolla \+ zanahoria/ })).toBeInTheDocument();
+    expect(screen.queryByRole('article', { name: /Milpa/ })).not.toBeInTheDocument();
+  });
+
+  test('el operador ve todos los arquetipos', () => {
+    const visibles = filterAsociacionesByRole(arquetipos, { rol: 'urbano' }, { esOperador: true });
+
+    expect(visibles).toHaveLength(5);
+    expect(visibles.map((item) => item.id)).toEqual([
+      'milpa',
+      'saf_cafe',
+      'saf_cacao',
+      'frutal_cobertura',
+      'hortaliza_repelente',
+    ]);
+  });
+
+  test('muestra estado vacio cuando el rol no tiene asociaciones', () => {
+    render(<Asociaciones profile={{ rol: 'socio' }} />);
+
+    expect(screen.getByText('No hay asociaciones sugeridas para este perfil todavía.')).toBeInTheDocument();
+  });
+
+  test('cada tarjeta expone lista de roles como texto de apoyo', () => {
+    render(<Asociaciones profile={{ rol: 'cafetero' }} />);
+
+    const card = screen.getByRole('article', { name: /SAF café/ });
+    expect(within(card).getByText('campesino, cafetero')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -47,6 +47,7 @@ import {
     HoyCard,
     PlagasCard,
     BiodiversidadCard,
+    AsociacionesCard,
     InformesCard,
     SeguimientoCards,
 } from './FincaCards';
@@ -81,6 +82,7 @@ const SECTION_COMPONENTS = {
     hoy: { Component: HoyCard },
     plagas: { Component: PlagasCard },
     biodiversidad: { Component: BiodiversidadCard },
+    asociaciones: { Component: AsociacionesCard },
     informes: { Component: InformesCard },
 };
 

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -6,7 +6,7 @@
  * este refinamiento visual. Se silencia el warning soft acá para no bloquear
  * el commit sin arrastrar ese refactor i18n. */
 import { useEffect, useState } from 'react';
-import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf } from 'lucide-react';
+import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf, Network } from 'lucide-react';
 import useAssetStore from '../../store/useAssetStore';
 import Skeleton from '../common/Skeleton';
 import { listFarmProcesses } from '../../db/farmProcessCache';
@@ -100,6 +100,16 @@ const SECTION_STYLES = {
         iconColor: 'text-green-300',
         bar: 'from-green-400 to-emerald-300',
         halo: 'bg-green-400/15',
+    },
+    asociaciones: {
+        Icon: Network,
+        emoji: '🌽',
+        accent: 'from-lime-500/20 to-emerald-500/10',
+        border: 'border-lime-700/30',
+        ring: 'ring-lime-500/0 group-hover:ring-lime-500/40',
+        iconColor: 'text-lime-300',
+        bar: 'from-lime-300 to-emerald-300',
+        halo: 'bg-lime-400/15',
     },
     informes: {
         Icon: FileText,
@@ -407,6 +417,19 @@ export function BiodiversidadCard({ onNavigate, variant }) {
             subtitle="Ecosistema de tu chagra"
             tooltip="Catálogo de especies nativas, endémicas y polinizadores que viven en tu finca."
             onClick={() => onNavigate('biodiversidad')}
+        />
+    );
+}
+
+export function AsociacionesCard({ onNavigate, variant }) {
+    return (
+        <Card
+            variant={variant}
+            section="asociaciones"
+            title="Asociaciones"
+            subtitle="Policultivos y compañía de plantas"
+            tooltip="Asociaciones. Policultivos y compañía de plantas por rol. Tócalo para ver combinaciones conocidas."
+            onClick={() => onNavigate('asociaciones')}
         />
     );
 }

--- a/src/components/dashboard/__tests__/DashboardLive.asociaciones.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.asociaciones.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../../config/glaciarAccess', () => ({
+  tieneAccesoGlaciarActual: () => false,
+  esOperadorActual: () => false,
+}));
+
+vi.mock('../AgentHero', () => ({ default: () => <div data-testid="agent-hero" /> }));
+vi.mock('../../OnboardingHero', () => ({ default: () => <div /> }));
+vi.mock('../SelectedBackgroundReveal', () => ({ default: () => <div /> }));
+vi.mock('../ClimaStrip', () => ({ default: () => <div /> }));
+vi.mock('../HoyEnFincaStrip', () => ({ default: () => <div /> }));
+vi.mock('../AIStatusFooter', () => ({ default: () => <div /> }));
+vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
+
+vi.mock('../../../store/useAssetStore', () => ({
+  default: (selector) => selector({
+    plants: [{ id: 'p1' }],
+    lands: [],
+    materials: [],
+    isHydrated: true,
+    iotAlerts: [],
+  }),
+}));
+
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: vi.fn(async () => []),
+}));
+
+let mockProfile = { rol: 'campesino' };
+vi.mock('../../../services/userProfileService', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getProfile: vi.fn(() => mockProfile),
+    hasManualModuleVisibility: vi.fn(() => false),
+  };
+});
+
+globalThis.ResizeObserver = globalThis.ResizeObserver || class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+import DashboardLive from '../DashboardLive';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProfile = { rol: 'campesino' };
+});
+
+afterEach(() => cleanup());
+
+describe('DashboardLive asociaciones', () => {
+  test('el botón Asociaciones abre el módulo desde el Home', async () => {
+    const onNavigate = vi.fn();
+    render(<DashboardLive onNavigate={onNavigate} />);
+
+    await waitFor(() => expect(screen.getByTestId('agent-hero')).toBeInTheDocument());
+    const button = screen.getByRole('button', { name: /Asociaciones/ });
+    expect(button).toHaveTextContent('Policultivos y compañía de plantas');
+
+    fireEvent.click(button);
+    expect(onNavigate).toHaveBeenCalledWith('asociaciones');
+  });
+});

--- a/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
@@ -22,6 +22,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest';
 const accesoMock = vi.fn(() => false);
 vi.mock('../../../config/glaciarAccess', () => ({
   tieneAccesoGlaciarActual: (...args) => accesoMock(...args),
+  esOperadorActual: () => false,
 }));
 
 // Hijos pesados → stubs livianos.
@@ -35,7 +36,7 @@ vi.mock('../AnalisisProactivoIA', () => ({ default: () => <div /> }));
 vi.mock('../FincaCards', () => ({
   PlantasCard: () => <div />, ZonasCard: () => <div />, InsumosCard: () => <div />,
   BitacoraCard: () => <div />, HoyCard: () => <div />, PlagasCard: () => <div />,
-  BiodiversidadCard: () => <div />, InformesCard: () => <div />,
+  BiodiversidadCard: () => <div />, AsociacionesCard: () => <div />, InformesCard: () => <div />,
   SeguimientoCards: () => <div data-testid="seguimiento-cards" />,
 }));
 
@@ -47,11 +48,11 @@ vi.mock('../../../services/userProfileService', () => ({
   // Orden de módulos del home (reorder por drag, 2026-06-15). Para este test el
   // orden por defecto basta; setModuleOrder es no-op.
   HOME_MODULE_DEFAULT_ORDER: [
-    'hoyfinca', 'clima', 'analisis', 'plantas', 'hoy', 'zonas',
+    'hoyfinca', 'clima', 'analisis', 'asociaciones', 'plantas', 'hoy', 'zonas',
     'insumos', 'plagas', 'bitacora', 'biodiversidad', 'informes',
   ],
   getModuleOrder: vi.fn(() => [
-    'hoyfinca', 'clima', 'analisis', 'plantas', 'hoy', 'zonas',
+    'hoyfinca', 'clima', 'analisis', 'asociaciones', 'plantas', 'hoy', 'zonas',
     'insumos', 'plagas', 'bitacora', 'biodiversidad', 'informes',
   ]),
   setModuleOrder: vi.fn(),

--- a/src/data/asociaciones-arquetipos.json
+++ b/src/data/asociaciones-arquetipos.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "milpa",
+    "nombre": "Milpa (Tres Hermanas)",
+    "icono": "🌽",
+    "rol": ["campesino"],
+    "especies": ["maíz", "fríjol", "ahuyama"],
+    "beneficio": "LER 1.32, el fríjol fija nitrógeno",
+    "fuente": "DR-ASOCIACIONES-2026-06-18"
+  },
+  {
+    "id": "saf_cafe",
+    "nombre": "SAF café",
+    "icono": "☕",
+    "rol": ["campesino", "cafetero"],
+    "especies": ["café", "guamo (Inga)", "plátano"],
+    "beneficio": "sombra + carbono + amortigua broca",
+    "fuente": "DR-ASOCIACIONES-2026-06-18"
+  },
+  {
+    "id": "saf_cacao",
+    "nombre": "SAF cacao",
+    "icono": "🍫",
+    "rol": ["campesino", "cacaotero"],
+    "especies": ["cacao", "matarratón (Gliricidia)", "plátano"],
+    "beneficio": "fija N + sombra",
+    "fuente": "DR-ASOCIACIONES-2026-06-18"
+  },
+  {
+    "id": "frutal_cobertura",
+    "nombre": "Frutal con cobertura",
+    "icono": "🍊",
+    "rol": ["campesino", "restaurador"],
+    "especies": ["frutal", "maní forrajero (Arachis pintoi)"],
+    "beneficio": "cobertura que fija N y tapa maleza",
+    "fuente": "DR-ASOCIACIONES-2026-06-18"
+  },
+  {
+    "id": "hortaliza_repelente",
+    "nombre": "Cebolla + zanahoria",
+    "icono": "🥕",
+    "rol": ["campesino", "urbano"],
+    "especies": ["cebolla", "zanahoria"],
+    "beneficio": "se protegen de sus moscas mutuamente",
+    "fuente": "DR-ASOCIACIONES-2026-06-18"
+  }
+]

--- a/src/services/__tests__/homeModuleSelector.test.js
+++ b/src/services/__tests__/homeModuleSelector.test.js
@@ -104,6 +104,7 @@ describe('homeModuleSelector — selectHomeModules por PERSONA', () => {
       expect.arrayContaining([
         HOME_MODULE_IDS.hoyfinca,
         HOME_MODULE_IDS.clima,
+        HOME_MODULE_IDS.asociaciones,
         HOME_MODULE_IDS.plantas,
         HOME_MODULE_IDS.plagas,
         HOME_MODULE_IDS.bitacora,

--- a/src/services/__tests__/userProfileService.test.js
+++ b/src/services/__tests__/userProfileService.test.js
@@ -361,6 +361,7 @@ describe('visibilidad de módulos del Home (#7003)', () => {
         'hoyfinca',
         'clima',
         'analisis',
+        'asociaciones',
         'plantas',
         'zonas',
         'insumos',

--- a/src/services/asociacionesFilter.js
+++ b/src/services/asociacionesFilter.js
@@ -1,0 +1,23 @@
+// asociacionesFilter — logica de filtrado por rol del modulo Asociaciones/Policultivos.
+// Separado de Asociaciones.jsx para no romper react-refresh (only-export-components).
+import arquetipos from '../data/asociaciones-arquetipos.json';
+
+function norm(value) {
+  if (typeof value !== 'string') return '';
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '');
+}
+
+function roleFromProfile(profile) {
+  const p = profile && typeof profile === 'object' ? profile : {};
+  return norm(p.rol) || norm(p.vocacion) || 'campesino';
+}
+
+export function filterAsociacionesByRole(items = arquetipos, profile = {}, opts = {}) {
+  if (opts.esOperador) return items;
+  const role = roleFromProfile(profile);
+  return items.filter((item) => Array.isArray(item.rol) && item.rol.map(norm).includes(role));
+}

--- a/src/services/homeModuleSelector.js
+++ b/src/services/homeModuleSelector.js
@@ -47,6 +47,7 @@ export const HOME_MODULE_IDS = Object.freeze({
   hoyfinca: 'hoyfinca',
   clima: 'clima',
   analisis: 'analisis',
+  asociaciones: 'asociaciones',
   plantas: 'plantas',
   zonas: 'zonas',
   insumos: 'insumos',
@@ -88,6 +89,7 @@ export const SEGUIMIENTO_KEYS = Object.freeze({
  */
 const URBANO_MODULES = Object.freeze([
   HOME_MODULE_IDS.plantas,
+  HOME_MODULE_IDS.asociaciones,
   HOME_MODULE_IDS.plagas,
   HOME_MODULE_IDS.bitacora,
   HOME_MODULE_IDS.clima,
@@ -102,6 +104,7 @@ const URBANO_MODULES = Object.freeze([
 const CAMPESINO_MODULES = Object.freeze([
   HOME_MODULE_IDS.hoyfinca,
   HOME_MODULE_IDS.clima,
+  HOME_MODULE_IDS.asociaciones,
   HOME_MODULE_IDS.plantas,
   HOME_MODULE_IDS.plagas,
   HOME_MODULE_IDS.bitacora,
@@ -120,6 +123,7 @@ const CAMPESINO_CORE = Object.freeze([
   HOME_MODULE_IDS.hoyfinca,
   HOME_MODULE_IDS.clima,
   HOME_MODULE_IDS.plantas,
+  HOME_MODULE_IDS.asociaciones,
   HOME_MODULE_IDS.plagas,
   HOME_MODULE_IDS.bitacora,
 ]);

--- a/src/services/userProfileService.js
+++ b/src/services/userProfileService.js
@@ -728,6 +728,12 @@ export const HOME_MODULES = Object.freeze([
     category: 'ia',
   },
   {
+    id: 'asociaciones',
+    label: 'Asociaciones',
+    description: 'Policultivos y compañía de plantas por rol',
+    category: 'ecosistema',
+  },
+  {
     id: 'plantas',
     label: 'Plantas',
     description: 'Inventario de plantas registradas',
@@ -884,6 +890,7 @@ export const HOME_MODULE_DEFAULT_ORDER = Object.freeze([
   'hoyfinca',
   'clima',
   'analisis',
+  'asociaciones',
   'plantas',
   'hoy',
   'zonas',

--- a/tests/integration/features-coexist.test.js
+++ b/tests/integration/features-coexist.test.js
@@ -255,7 +255,7 @@ describe('Switch-perfil + Telemetry — no interferencia', () => {
     );
 
     // Operador ve todos los modulos
-    expect(visibles).toHaveLength(11); // ALL_HOME_MODULES
+    expect(visibles).toHaveLength(12); // ALL_HOME_MODULES
     // Y todas las tarjetas de seguimiento
     expect(seguimiento).toContain('cerdos');
     expect(seguimiento).toContain('silvopastoreo');


### PR DESCRIPTION
Módulo transversal de asociaciones por rol (recuperado de worktree codex rc=143, react-refresh fix aplicado). Arquetipos: milpa, SAF-café, SAF-cacao, frutal+cobertura, hortaliza. Pairs con la capa ASOCIA_CON del grafo + tool #221. CI valida.