### PR TITLE
fix(auth): harden session refresh retry

### DIFF
--- a/src/services/__tests__/agentTelemetrySync.test.js
+++ b/src/services/__tests__/agentTelemetrySync.test.js
@@ -17,6 +17,10 @@ import { makeFakeDB, setOnline } from '../../test-utils/index.js';
 
 let fakeDB;
 
+const { fetchWithAuthRetry } = vi.hoisted(() => ({
+  fetchWithAuthRetry: vi.fn((...args) => global.fetch(...args)),
+}));
+
 vi.mock('../../db/dbCore.js', () => ({
   openDB: vi.fn(async () => fakeDB),
   STORES: { AGENT_REQUESTS: 'agent_requests' },
@@ -34,6 +38,10 @@ vi.mock('../agentRequestQueue.js', () => ({
   getRequest: vi.fn(async (_id) => null),
 }));
 
+vi.mock('../apiService.js', () => ({
+  fetchWithAuthRetry,
+}));
+
 global.fetch = vi.fn();
 
 beforeEach(() => {
@@ -45,6 +53,7 @@ beforeEach(() => {
     ok: true,
     json: async () => ({ success: true }),
   });
+  fetchWithAuthRetry.mockImplementation((...args) => global.fetch(...args));
 });
 
 afterEach(() => {
@@ -143,8 +152,8 @@ describe('agentTelemetrySync — syncAgentTelemetry', () => {
         id: 2,
         ts_submit: 1234567891,
         ts_done: 1234567910,
-        prompt: 'Ayuda con mi tomate', // PII - debe removerse
-        response: 'Para tu tomate...', // PII - debe removerse
+        prompt: 'Sensitive prompt text', // PII - debe removerse
+        response: 'Sensitive response text', // PII - debe removerse
         route: 'foliage',
         model: 'gpt-4o',
         grounding: { entities: ['tomate'], tools: [] },
@@ -166,6 +175,7 @@ describe('agentTelemetrySync — syncAgentTelemetry', () => {
 
     // Verificar que se llamó a fetch
     expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(fetchWithAuthRetry).toHaveBeenCalledTimes(1);
     const fetchCall = global.fetch.mock.calls[0];
     expect(fetchCall[0]).toBe('https://telemetry.example.com/ingest');
     expect(fetchCall[1].method).toBe('POST');
@@ -210,7 +220,8 @@ describe('agentTelemetrySync — syncAgentTelemetry', () => {
     await syncAgentTelemetry();
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
-    const [url, opts] = global.fetch.mock.calls[0];
+    expect(fetchWithAuthRetry).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchWithAuthRetry.mock.calls[0];
     expect(url).toBe('https://chagra.example.co/api/ingest');
     expect(opts.headers['X-Chagra-Token']).toBe('tok-123');
   });

--- a/src/services/__tests__/apiService.test.js
+++ b/src/services/__tests__/apiService.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../authService.js', () => ({
+  expireSession: vi.fn().mockResolvedValue(undefined),
   getAccessToken: vi.fn().mockResolvedValue('mock-token'),
   refreshAccessToken: vi.fn().mockResolvedValue(null),
 }));
@@ -232,8 +233,10 @@ describe('apiService', () => {
   describe('fetchWithAuthRetry', () => {
     beforeEach(async () => {
       const { getAccessToken, refreshAccessToken } = await import('../authService.js');
+      const { expireSession } = await import('../authService.js');
       getAccessToken.mockReset().mockResolvedValue('mock-token');
       refreshAccessToken.mockReset().mockResolvedValue(null);
+      expireSession.mockReset().mockResolvedValue(undefined);
       Object.defineProperty(navigator, 'onLine', {
         configurable: true,
         value: true,
@@ -287,6 +290,33 @@ describe('apiService', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(refreshAccessToken).not.toHaveBeenCalled();
     });
+
+    it('ante 403 definitivo limpia sesión y devuelve la respuesta original', async () => {
+      const { expireSession, getAccessToken, refreshAccessToken } = await import('../authService.js');
+      getAccessToken.mockResolvedValue('token-viejo');
+      refreshAccessToken.mockResolvedValue(null);
+
+      const forbidden = {
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { get: vi.fn().mockReturnValue('') },
+      };
+      const fetchSpy = vi.fn().mockResolvedValue(forbidden);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const response = await fetchWithAuthRetry('/api/sidecar/notifications/subscribe', {
+        method: 'POST',
+      });
+
+      expect(response).toBe(forbidden);
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(expireSession).toHaveBeenCalledWith({
+        status: 403,
+        resource: '/api/sidecar/notifications/subscribe',
+      });
+    });
   });
 
   // Cura del bug "sesión zombi" (operador 2026-06-18): ante un 401 del backend
@@ -296,8 +326,10 @@ describe('apiService', () => {
     beforeEach(async () => {
       // Aislar el conteo de llamadas de refreshAccessToken entre tests.
       const { getAccessToken, refreshAccessToken } = await import('../authService.js');
+      const { expireSession } = await import('../authService.js');
       getAccessToken.mockClear();
       refreshAccessToken.mockClear();
+      expireSession.mockClear();
     });
 
     it('en 401, si refreshAccessToken da token nuevo, reintenta y devuelve data (sin ir a login)', async () => {
@@ -352,8 +384,8 @@ describe('apiService', () => {
     // se despacha 'chagra:session-expired' para que App navegue a login en vez
     // de dejar al usuario en el dashboard vacío → OnboardingHero engañoso
     // (prod-down 2026-06-18).
-    it('en 401 con renovación fallida, despacha chagra:session-expired', async () => {
-      const { getAccessToken, refreshAccessToken } = await import('../authService.js');
+    it('en 401 con renovación fallida, expira sesión de forma explícita', async () => {
+      const { expireSession, getAccessToken, refreshAccessToken } = await import('../authService.js');
       getAccessToken.mockResolvedValue('tkn-viejo');
       refreshAccessToken.mockResolvedValue(null);
 
@@ -366,15 +398,11 @@ describe('apiService', () => {
       });
       vi.stubGlobal('fetch', fetchSpy);
 
-      const sessionExpired = vi.fn();
-      window.addEventListener('chagra:session-expired', sessionExpired);
-      try {
-        await expect(fetchFromFarmOS('/api/asset/plant')).rejects.toThrow();
-        expect(sessionExpired).toHaveBeenCalledTimes(1);
-        expect(sessionExpired.mock.calls[0][0].detail.status).toBe(401);
-      } finally {
-        window.removeEventListener('chagra:session-expired', sessionExpired);
-      }
+      await expect(fetchFromFarmOS('/api/asset/plant')).rejects.toThrow();
+      expect(expireSession).toHaveBeenCalledWith({
+        status: 401,
+        endpoint: '/api/asset/plant',
+      });
     });
   });
 });

--- a/src/services/__tests__/authService.test.js
+++ b/src/services/__tests__/authService.test.js
@@ -10,6 +10,7 @@ import {
     generateOAuthState,
     handleOAuthCallback,
     getAccessToken,
+    getLastRefreshFailureReason,
     refreshAccessToken,
 } from '../authService';
 
@@ -435,12 +436,27 @@ describe('authService — OAuth PKCE flow', () => {
             });
             const result = await refreshAccessToken();
             expect(result).toBeNull();
+            expect(getLastRefreshFailureReason()).toBe('rejected');
+        });
+
+        it('devuelve null y marca rejected si el backend rechaza el refresh con 403', async () => {
+            localforage.getItem.mockResolvedValue('refresh-vencido');
+            global.fetch.mockResolvedValue({
+                ok: false,
+                status: 403,
+                headers: { get: () => null },
+                text: async () => 'forbidden',
+            });
+            const result = await refreshAccessToken();
+            expect(result).toBeNull();
+            expect(getLastRefreshFailureReason()).toBe('rejected');
         });
 
         it('devuelve null (sin lanzar) si la red falla', async () => {
             localforage.getItem.mockResolvedValue('refresh-x');
             global.fetch.mockRejectedValue(new Error('Network error'));
             await expect(refreshAccessToken()).resolves.toBeNull();
+            expect(getLastRefreshFailureReason()).toBe('network');
         });
 
         it('serializa refresh concurrente y comparte una sola llamada al backend', async () => {
@@ -524,6 +540,22 @@ describe('authService — OAuth PKCE flow', () => {
             expect(t).toBeNull();
             // Logout limpio: borra el access token (no deja estado zombi).
             expect(localforage.removeItem).toHaveBeenCalledWith('farmos_access_token');
+        });
+
+        it('si venció pero el refresh falla por red, no borra tokens', async () => {
+            localforage.getItem.mockImplementation((k) => {
+                if (k === 'farmos_access_token') return Promise.resolve('vencido');
+                if (k === 'farmos_token_expiry') return Promise.resolve(Date.now() - 1000);
+                if (k === 'farmos_refresh_token') return Promise.resolve('refresh-ok');
+                return Promise.resolve(null);
+            });
+            global.fetch.mockRejectedValue(new Error('Network error'));
+
+            const t = await getAccessToken();
+            expect(t).toBeNull();
+            expect(getLastRefreshFailureReason()).toBe('network');
+            expect(localforage.removeItem).not.toHaveBeenCalledWith('farmos_access_token');
+            expect(localforage.removeItem).not.toHaveBeenCalledWith('farmos_refresh_token');
         });
     });
 });

--- a/src/services/__tests__/feedbackService.edges.test.js
+++ b/src/services/__tests__/feedbackService.edges.test.js
@@ -15,6 +15,15 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fetchWithAuthRetry } = vi.hoisted(() => ({
+  fetchWithAuthRetry: vi.fn((...args) => global.fetch(...args)),
+}));
+
+vi.mock('../apiService.js', () => ({
+  fetchWithAuthRetry,
+}));
+
 import { sendFeedback } from '../feedbackService';
 
 describe('feedbackService — edges (A-15 #248)', () => {
@@ -24,6 +33,8 @@ describe('feedbackService — edges (A-15 #248)', () => {
   beforeEach(() => {
     global.localStorage = { getItem: vi.fn(), setItem: vi.fn() };
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    fetchWithAuthRetry.mockClear();
+    fetchWithAuthRetry.mockImplementation((...args) => global.fetch(...args));
   });
 
   afterEach(() => {

--- a/src/services/__tests__/feedbackService.offline.test.js
+++ b/src/services/__tests__/feedbackService.offline.test.js
@@ -1,4 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fetchWithAuthRetry } = vi.hoisted(() => ({
+  fetchWithAuthRetry: vi.fn((...args) => globalThis.fetch(...args)),
+}));
+
+vi.mock('../apiService.js', () => ({
+  fetchWithAuthRetry,
+}));
+
 import {
   sendFeedback,
   queueFeedbackOffline,
@@ -19,6 +28,8 @@ beforeEach(() => {
   localStorage.clear();
   clearFeedbackQueue();
   setOnline(true);
+  fetchWithAuthRetry.mockClear();
+  fetchWithAuthRetry.mockImplementation((...args) => globalThis.fetch(...args));
 });
 
 afterEach(() => {
@@ -63,6 +74,7 @@ describe('cola offline de feedback', () => {
     const flushed = await flushFeedbackQueue();
     expect(flushed).toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchWithAuthRetry).toHaveBeenCalledTimes(2);
     expect(getQueuedFeedback()).toHaveLength(0);
   });
 

--- a/src/services/__tests__/feedbackService.test.js
+++ b/src/services/__tests__/feedbackService.test.js
@@ -5,6 +5,15 @@
 /* eslint-disable no-undef */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fetchWithAuthRetry } = vi.hoisted(() => ({
+  fetchWithAuthRetry: vi.fn((...args) => global.fetch(...args)),
+}));
+
+vi.mock('../apiService.js', () => ({
+  fetchWithAuthRetry,
+}));
+
 import { sendFeedback, hasConsent, saveConsent } from '../feedbackService';
 
 describe('feedbackService', () => {
@@ -19,6 +28,8 @@ describe('feedbackService', () => {
     };
     // Mock fetch
     global.fetch = vi.fn();
+    fetchWithAuthRetry.mockClear();
+    fetchWithAuthRetry.mockImplementation((...args) => global.fetch(...args));
   });
 
   afterEach(() => {
@@ -91,6 +102,12 @@ describe('feedbackService', () => {
             'Content-Type': 'application/json',
           }),
           body: expect.stringContaining('¿Qué es el café?'),
+        })
+      );
+      expect(fetchWithAuthRetry).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          method: 'POST',
         })
       );
     });

--- a/src/services/__tests__/operatorPhotoService.test.js
+++ b/src/services/__tests__/operatorPhotoService.test.js
@@ -8,16 +8,14 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-// Mocks de red: apiService (POST/GET FarmOS) + authService (Bearer token).
+// Mocks de red: apiService (POST/GET FarmOS + descarga con auth-retry).
 const sendToFarmOS = vi.fn();
 const fetchFromFarmOS = vi.fn();
-const getAccessToken = vi.fn();
+const fetchWithAuthRetry = vi.fn();
 vi.mock('../apiService.js', () => ({
   sendToFarmOS: (...a) => sendToFarmOS(...a),
   fetchFromFarmOS: (...a) => fetchFromFarmOS(...a),
-}));
-vi.mock('../authService.js', () => ({
-  getAccessToken: (...a) => getAccessToken(...a),
+  fetchWithAuthRetry: (...a) => fetchWithAuthRetry(...a),
 }));
 
 import {
@@ -78,7 +76,7 @@ describe('operatorPhotoService', () => {
     _resetForTests();
     sendToFarmOS.mockReset();
     fetchFromFarmOS.mockReset();
-    getAccessToken.mockReset();
+    fetchWithAuthRetry.mockReset();
     // onLine = true por defecto (jsdom navigator es read-only → defineProperty).
     Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
   });
@@ -201,9 +199,7 @@ describe('operatorPhotoService', () => {
           attributes: { filename: 'chagra-operator-photo-bob-1.jpg', uri: { url: '/sites/default/files/x.jpg' } },
         }],
       });
-      getAccessToken.mockResolvedValue('tok');
-      // fetch del blob binario:
-      globalThis.fetch = vi.fn().mockResolvedValue({
+      fetchWithAuthRetry.mockResolvedValue({
         ok: true,
         blob: async () => new Blob([new Uint8Array(20)], { type: 'image/jpeg' }),
       });
@@ -217,6 +213,7 @@ describe('operatorPhotoService', () => {
       expect(endpoint).toContain('/api/file/file');
       expect(endpoint).toContain('CONTAINS');
       expect(endpoint).toContain(encodeURIComponent('chagra-operator-photo-bob-'));
+      expect(fetchWithAuthRetry).toHaveBeenCalledWith(expect.stringContaining('/sites/default/files/x.jpg'));
       // Quedó persistida local + meta con el uuid remoto.
       expect(getOperatorPhoto()).toBe(SAMPLE_DATA_URL);
       expect(__test.readSyncMeta().fileUuid).toBe('remote-uuid-9');
@@ -238,13 +235,13 @@ describe('operatorPhotoService', () => {
       fetchFromFarmOS.mockResolvedValue({
         data: [{ id: 'same-uuid', attributes: { filename: 'x', uri: { url: '/x' } } }],
       });
-      globalThis.fetch = vi.fn();
+      fetchWithAuthRetry.mockReset();
 
       const r = await loadFromFarmOS();
 
       expect(r.updated).toBe(false);
       expect(r.reason).toBe('already-current');
-      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(fetchWithAuthRetry).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/__tests__/pushService.test.js
+++ b/src/services/__tests__/pushService.test.js
@@ -1,6 +1,15 @@
 /* global global */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const { fetchWithAuthRetry } = vi.hoisted(() => ({
+    fetchWithAuthRetry: vi.fn((...args) => global.fetch(...args)),
+}));
+
+vi.mock('../apiService.js', () => ({
+    fetchWithAuthRetry,
+}));
+
 import {
     isPushSupported,
     isSubscribed,
@@ -51,6 +60,8 @@ describe('pushService — Web Push API subscription management', () => {
 
         // Mock fetch
         global.fetch = vi.fn();
+        fetchWithAuthRetry.mockClear();
+        fetchWithAuthRetry.mockImplementation((...args) => global.fetch(...args));
     });
 
     afterEach(() => {
@@ -192,6 +203,12 @@ describe('pushService — Web Push API subscription management', () => {
             expect(result).toBe(existingSub);
             expect(mockServiceWorkerRegistration.pushManager.subscribe).not.toHaveBeenCalled();
             expect(global.fetch).toHaveBeenCalledWith(
+                '/api/sidecar/notifications/subscribe',
+                expect.objectContaining({
+                    method: 'POST',
+                })
+            );
+            expect(fetchWithAuthRetry).toHaveBeenCalledWith(
                 '/api/sidecar/notifications/subscribe',
                 expect.objectContaining({
                     method: 'POST',

--- a/src/services/agentTelemetrySync.js
+++ b/src/services/agentTelemetrySync.js
@@ -44,6 +44,7 @@
 
 import { getTelemetryConsent } from './userProfileService.js';
 import { listRequests, getRequest } from './agentRequestQueue.js';
+import { fetchWithAuthRetry } from './apiService.js';
 
 /**
  * Base del sidecar agro-mcp (espejo de feedbackService.getBaseUrl).
@@ -201,7 +202,7 @@ export async function syncAgentTelemetry() {
 
     // 6. POST al endpoint
     const token = getToken();
-    const response = await fetch(telemetryUrl, {
+    const response = await fetchWithAuthRetry(telemetryUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -6,7 +6,7 @@
  * @requires authService
  */
 
-import { getAccessToken, refreshAccessToken } from './authService';
+import { expireSession, getAccessToken, refreshAccessToken } from './authService';
 import { getActiveTenantId } from './tenantContext';
 
 /**
@@ -89,6 +89,9 @@ export const fetchWithAuthRetry = async (resource, options = {}, _retried = fals
 
   const refreshed = await refreshAccessToken();
   if (!refreshed) {
+    if (token) {
+      await expireSession({ status: response.status, resource: String(resource) });
+    }
     return response;
   }
 
@@ -301,14 +304,7 @@ export const fetchFromFarmOS = async (endpoint, options = {}, _retried = false) 
         // a la pantalla de login ("Sesión vencida — vuelve a entrar"), y se
         // hace logout limpio para no reintentar con el token muerto. El hash se
         // mantiene como señal secundaria por compatibilidad.
-        if (typeof window !== 'undefined') {
-          window.location.hash = '#login';
-          try {
-            window.dispatchEvent(
-              new CustomEvent('chagra:session-expired', { detail: { status: response.status } })
-            );
-          } catch (_) { /* CustomEvent existe en browsers soportados */ }
-        }
+        await expireSession({ status: response.status, endpoint });
       }
       const errorDetail = await response.text().catch(() => '');
       // Sanitize body antes de pegarlo al .message — Drupal/cloudflared a

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -12,6 +12,7 @@ import { clearActiveTenantId } from './tenantContext';
 const FARMOS_URL = import.meta.env.VITE_FARMOS_URL;
 const CLIENT_ID = import.meta.env.VITE_FARMOS_CLIENT_ID;
 const REDIRECT_URI = `${window.location.origin}/callback`;
+export const SESSION_EXPIRED_EVENT = 'chagra:session-expired';
 
 /**
  * DEPRECATION NOTICE: Password grant será removido después de esta fecha.
@@ -257,19 +258,27 @@ export const authenticateUser = async (username, password) => {
  *   refresh_token, el grant falla, o el grant está deshabilitado. NUNCA lanza.
  */
 let refreshInFlight = null;
+let lastRefreshFailureReason = null;
+
+export const getLastRefreshFailureReason = () => lastRefreshFailureReason;
 
 export const refreshAccessToken = async () => {
     if (refreshInFlight) return refreshInFlight;
 
     refreshInFlight = (async () => {
+        lastRefreshFailureReason = null;
         let refreshToken;
         try {
             refreshToken = await localforage.getItem('farmos_refresh_token');
         } catch (err) {
             console.error('[Auth] no se pudo leer el refresh_token:', err);
+            lastRefreshFailureReason = 'storage';
             return null;
         }
-        if (!refreshToken) return null;
+        if (!refreshToken) {
+            lastRefreshFailureReason = 'missing';
+            return null;
+        }
 
         const url = `${FARMOS_URL}/oauth/token`;
         const payload = new URLSearchParams({
@@ -291,17 +300,22 @@ export const refreshAccessToken = async () => {
                 // renovar. El caller debe hacer logout limpio (no quedarse en
                 // estado zombi). NO logueamos el body (puede traer el token).
                 console.warn(`[Auth] refresh_token grant falló (${response.status}).`);
+                lastRefreshFailureReason = 'rejected';
                 return null;
             }
 
             const contentType = response.headers.get('content-type');
             if (!contentType || !contentType.includes('json')) {
                 console.warn('[Auth] respuesta de refresh sin JSON (backend caído?).');
+                lastRefreshFailureReason = 'invalid-response';
                 return null;
             }
 
             const data = await response.json();
-            if (!data.access_token) return null;
+            if (!data.access_token) {
+                lastRefreshFailureReason = 'invalid-response';
+                return null;
+            }
 
             await localforage.setItem('farmos_access_token', data.access_token);
             // El refresh_token suele rotar en cada uso: persistir el nuevo si
@@ -320,6 +334,7 @@ export const refreshAccessToken = async () => {
             // por un fallo de red (ver getAccessToken: solo logout si había
             // refresh_token y el grant lo rechazó explícitamente).
             console.error('[Auth] error de red al refrescar el token:', err);
+            lastRefreshFailureReason = 'network';
             return null;
         }
     })();
@@ -328,6 +343,18 @@ export const refreshAccessToken = async () => {
         return await refreshInFlight;
     } finally {
         refreshInFlight = null;
+    }
+};
+
+export const expireSession = async (detail = {}) => {
+    await logoutUser();
+    if (typeof window !== 'undefined') {
+        window.location.hash = '#login';
+        try {
+            window.dispatchEvent(
+                new CustomEvent(SESSION_EXPIRED_EVENT, { detail })
+            );
+        } catch (_) { /* CustomEvent existe en browsers soportados */ }
     }
 };
 
@@ -363,8 +390,12 @@ export const getAccessToken = async () => {
                 hadRefresh = !!(await localforage.getItem('farmos_refresh_token'));
             } catch (_) { /* asumir que no, fail-safe */ }
 
-            if (hadRefresh && navigator.onLine !== false) {
-                await logoutUser();
+            if (
+                hadRefresh &&
+                navigator.onLine !== false &&
+                lastRefreshFailureReason === 'rejected'
+            ) {
+                await expireSession({ reason: 'refresh-rejected' });
             }
             return null;
         }

--- a/src/services/feedbackService.js
+++ b/src/services/feedbackService.js
@@ -28,6 +28,7 @@
  */
 
 import { ulid } from 'ulid';
+import { fetchWithAuthRetry } from './apiService.js';
 
 const FEEDBACK_TIMEOUT_MS = 8000;
 const CONSENT_STORAGE_KEY = 'chagra_feedback_consent_v1';
@@ -163,7 +164,7 @@ async function postFeedback(feedback) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FEEDBACK_TIMEOUT_MS);
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithAuthRetry(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(token ? { 'X-Chagra-Token': token } : {}) },
       body: JSON.stringify(feedback),

--- a/src/services/operatorPhotoService.js
+++ b/src/services/operatorPhotoService.js
@@ -245,8 +245,7 @@ export async function loadFromFarmOS() {
     return { ok: false, reason: 'offline' };
   }
   try {
-    const { fetchFromFarmOS } = await import('./apiService.js');
-    const { getAccessToken } = await import('./authService.js');
+    const { fetchFromFarmOS, fetchWithAuthRetry } = await import('./apiService.js');
 
     const response = await fetchFromFarmOS(latestPhotoEndpoint(tenantId));
     const items = response?.data || [];
@@ -266,8 +265,7 @@ export async function loadFromFarmOS() {
     const base = import.meta.env.VITE_FARMOS_URL || '';
     const fullUrl = uri.startsWith('http') ? uri : `${base}${uri}`;
 
-    const token = await getAccessToken();
-    const res = await fetch(fullUrl, { headers: token ? { Authorization: `Bearer ${token}` } : {} });
+    const res = await fetchWithAuthRetry(fullUrl);
     if (!res.ok) return { ok: false, reason: `http-${res.status}` };
     const blob = await res.blob();
 

--- a/src/services/pushService.js
+++ b/src/services/pushService.js
@@ -19,6 +19,8 @@
  *   - Subscription POST a `/notifications/subscribe` con X-Chagra-Token.
  */
 
+import { fetchWithAuthRetry } from './apiService.js';
+
 const STORAGE_KEY = 'chagra:push-subscribed:v1';
 const SIDECAR_BASE = '/api/sidecar';
 
@@ -69,7 +71,7 @@ export async function requestPermission() {
  * Obtiene la VAPID public key del sidecar. Necesaria para subscribe.
  */
 async function fetchVapidPublicKey() {
-    const r = await fetch(`${SIDECAR_BASE}/notifications/vapid-public`);
+    const r = await fetchWithAuthRetry(`${SIDECAR_BASE}/notifications/vapid-public`);
     if (!r.ok) throw new Error(`VAPID fetch HTTP ${r.status}`);
     const { publicKey } = await r.json();
     return publicKey;
@@ -111,7 +113,7 @@ export async function subscribePush() {
 
     // Enviar al backend para guardar
     const payload = sub.toJSON();
-    const r = await fetch(`${SIDECAR_BASE}/notifications/subscribe`, {
+    const r = await fetchWithAuthRetry(`${SIDECAR_BASE}/notifications/subscribe`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -138,7 +140,7 @@ export async function unsubscribePush() {
         await sub.unsubscribe();
         // Notificar al backend
         try {
-            await fetch(`${SIDECAR_BASE}/notifications/subscribe`, {
+            await fetchWithAuthRetry(`${SIDECAR_BASE}/notifications/subscribe`, {
                 method: 'DELETE',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ endpoint }),


### PR DESCRIPTION
## Summary
- Centraliza expiración de sesión en authService con limpieza de tokens, hash de login y evento chagra:session-expired.
- Distingue refresh rechazado vs red/offline/JSON inválido para no cerrar sesión por intermitencia.
- Migra fetch autenticados a fetchWithAuthRetry: operatorPhotoService descarga de archivo FarmOS, pushService VAPID/subscribe/unsubscribe, agentTelemetrySync /ingest, feedbackService /agent-feedback.

## Test plan
- PASS: npx vitest run src/services/__tests__/authService.test.js src/services/__tests__/apiService.test.js src/services/__tests__/operatorPhotoService.test.js src/services/__tests__/pushService.test.js src/services/__tests__/agentTelemetrySync.test.js src/services/__tests__/feedbackService.test.js src/services/__tests__/feedbackService.offline.test.js src/services/__tests__/feedbackService.edges.test.js
- PASS: npx eslint src/services/authService.js src/services/apiService.js src/services/operatorPhotoService.js src/services/pushService.js src/services/agentTelemetrySync.js src/services/feedbackService.js src/services/__tests__/authService.test.js src/services/__tests__/apiService.test.js src/services/__tests__/operatorPhotoService.test.js src/services/__tests__/pushService.test.js src/services/__tests__/agentTelemetrySync.test.js src/services/__tests__/feedbackService.test.js src/services/__tests__/feedbackService.offline.test.js src/services/__tests__/feedbackService.edges.test.js --max-warnings=0
- PASS: npm run build
- FAIL (pre-existing/global): npx vitest run, 11 failed files / 18 failed tests / 2 unhandled errors. Failures are outside touched files: missing scripts/bench-borde-alucinacion.mjs, bench registry, DB_VERSION expected 24 vs 25, UI validation selectors/copy, fincaEvolutionService shape, outputGuards regressions, networkRetry unhandled rejection warnings.
- FAIL: npx eslint . --max-warnings=0 ended with Node heap OOM near 2 GB before rule output; targeted ESLint on touched files passed.

## Before / after
- Before: sidecar/FarmOS-adjacent fetches in photo download, push subscribe, telemetry ingest and feedback bypassed refresh+retry; definitive 401/403 could leave the app in an empty session state.
- After: those calls share token refresh+retry, definitive 401/403 expires the session explicitly, and offline/network refresh failures preserve tokens for later retry.
