### PR TITLE
feat(catalog): export grafo→catálogo offline (87% gap)

### DIFF
--- a/catalog/chagra-catalog-graph-export.json
+++ b/catalog/chagra-catalog-graph-export.json
@@ -1,0 +1,12030 @@
+{
+  "_meta": {
+    "generated_by": "scripts/export-graph-to-catalog.mjs",
+    "generated_at": "2026-06-19T20:23:13.131Z",
+    "source": "Apache AGE graph via STDIN"
+  },
+  "schema_version": "3.1",
+  "seed_version": "graph-export-2026-06-19",
+  "generated_by": "scripts/export-graph-to-catalog.mjs",
+  "_graph_export_meta": {
+    "species_exported": 200,
+    "species_new_vs_seed": 137,
+    "species_already_in_seed": 63,
+    "species_skipped_not_schema_ready": 509,
+    "skipped_examples": [
+      {
+        "id": "abrus_precatorius",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "category",
+          "thermal_zones",
+          "roles_in_guild",
+          "altitud_msnm",
+          "source_ids"
+        ]
+      },
+      {
+        "id": "acacia_mangium",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "acacia_melanoxylon",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "roles_in_guild",
+          "source_ids"
+        ]
+      },
+      {
+        "id": "acanthus_mollis",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "achillea_millefolium",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "actinidia_deliciosa",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "agave_americana",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "agave_cocui",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "agave_tequilana",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "agrostis_foliata",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "aiphanes_aculeata",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "albizia_guachapele",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "allium_ampeloprasum",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "allium_schoenoprasum",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "alocasia_macrorrhizos",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "aloe_arborescens",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "amaranthus_caudatus_kiwicha",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "ananas_comosus_md_gold",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "andropogon_gayanus",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      },
+      {
+        "id": "anethum_graveolens",
+        "reason": "missing_required_v3_1_fields",
+        "missing": [
+          "source_ids"
+        ]
+      }
+    ]
+  },
+  "species": [
+    {
+      "id": "abatia_parviflora",
+      "nombre_comun": "Duraznillo",
+      "nombre_cientifico": "Abatia parviflora Ruiz & Pav.",
+      "familia_botanica": "Salicaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 3200,
+        "max_absoluto": 3200
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "abelmoschus_esculentus",
+      "nombre_comun": "Okra",
+      "nombre_cientifico": "Abelmoschus esculentus (L.) Moench",
+      "familia_botanica": "Malvaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_ica_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "acacia_decurrens",
+      "nombre_comun": "Acacia negra",
+      "nombre_cientifico": "Acacia decurrens Willd.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_conif_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "acca_sellowiana",
+      "nombre_comun": "Feijoa / Guayabo del país",
+      "nombre_cientifico": "Acca sellowiana (O.Berg) Burret",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_unal_suelo"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "allium_cepa",
+      "nombre_comun": "Cebolla cabezona",
+      "nombre_cientifico": "Allium cepa L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima",
+        "graph_corpoica_suelo"
+      ],
+      "companions": [
+        "solanum_tuberosum_sabanera"
+      ],
+      "tracking_mode": "aggregate",
+      "fenologia": [
+        {
+          "id": "feno_almacigo_allium_cepa",
+          "nombre": "Almácigo / semillero",
+          "orden": "1"
+        },
+        {
+          "id": "feno_cosecha_allium_cepa",
+          "nombre": "Cosecha y curado",
+          "orden": "5"
+        },
+        {
+          "id": "feno_fructificacion_allium_cepa",
+          "nombre": "Bulbificación",
+          "orden": "3"
+        },
+        {
+          "id": "feno_maduracion_allium_cepa",
+          "nombre": "Maduración (acame de follaje)",
+          "orden": "4"
+        },
+        {
+          "id": "feno_poscosecha_allium_cepa",
+          "nombre": "Poscosecha / almacenamiento",
+          "orden": "6"
+        },
+        {
+          "id": "feno_vegetativo_allium_cepa",
+          "nombre": "Desarrollo vegetativo (follaje)",
+          "orden": "2"
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "biol",
+            "nombre": "Biol",
+            "tipo": "fermentado",
+            "dosis": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "bocashi",
+            "nombre": "Bocashi",
+            "tipo": "fermentado",
+            "dosis": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "caldo_ajo_concentrado",
+            "nombre": "Caldo de ajo concentrado (anti-fúngico/bactericida)",
+            "tipo": "fungicida_bactericida_botanico",
+            "dosis": "Macerado: 100 g de ajo molido por 1 L de agua, reposar 12-24 h, colar y añadir jabón (caldo madre). Aplicar diluido 1:10 (100 cc de madre por L de agua). Bomba de 20 L: ~2 L de macerado madre + chorro de jabón. Foliar cada 7-10 días preventivo; intensificar en clima húmedo."
+          },
+          {
+            "id": "caldo_bordeles",
+            "nombre": "Caldo bordelés",
+            "tipo": "caldo",
+            "dosis": "Caldo madre al 1% para 10 L: 100 g de sulfato de cobre pentahidratado + 100 g de cal. Disolver el cobre en agua tibia (recipiente NO metalico) y la cal aparte; verter el cobre sobre la lechada de cal (NUNCA al reves) y aforar a 10 L. Relacion 1:1:100 = 1 kg cobre : 1 kg cal : 100 L. Prueba del clavo o pH neutro-alcalino antes de aplicar (el clavo no debe cobrizarse). Hortalizas tiernas: 0,5% (50 g + 50 g / 10 L). Bomba de 20 L al 1%: 200 g sulfato + 200 g cal. Listo para aplicar SIN diluir.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "ceniza_vegetal_espolvoreo",
+            "nombre": "Ceniza vegetal espolvoreada en seco",
+            "tipo": "insecticida_repelente_mineral",
+            "dosis": "Espolvoreo en seco directo sobre el follaje y el suelo alrededor de la planta, preferiblemente con rocío matinal para que se adhiera. Dosis de campo: ~30-50 g por planta de hortaliza (un puñado), o al voleo cubriendo levemente las hojas. Repetir cada 7-10 días y SIEMPRE después de lluvia (se lava)."
+          },
+          {
+            "id": "humus_liquido",
+            "nombre": "Humus líquido (lixiviado de lombriz)",
+            "tipo": "extracto",
+            "dosis": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "purin_ortiga",
+            "nombre": "Purín de ortiga",
+            "tipo": "fermentado",
+            "dosis": "Maceracion/fermentacion: 1 kg de ortiga fresca (o 200 g seca) por 10 L de agua, fermentar 7-14 dias removiendo a diario hasta que deje de espumar. Purin fermentado bioestimulante foliar: diluir 1:10 a 1:20 (0,5-1 L por 10 L de agua); al suelo (drench) 1:10. Bomba de 20 L foliar: 1-2 L de purin. Macerado corto de 24-72 h (sin fermentar) como insecticida/repelente: 1:5.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "trampa_azul_pegante",
+            "nombre": "Trampa azul pegante (trips)",
+            "tipo": "trampa_cebo",
+            "dosis": "PREPARACIÓN: láminas azules engrasadas (~20x30 cm). APLICACIÓN: 1 trampa cada 10-25 m2 para monitoreo; hasta 30-50/ha captura masiva. Ubicar a la altura de las flores/cogollos (donde se concentran los trips). Renovar capa pegajosa cada 1-2 semanas. No se diluye."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "allium_fistulosum",
+      "nombre_comun": "Cebollín / Cebolla larga",
+      "nombre_cientifico": "Allium fistulosum L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Se dividen los macollos (hijuelos) para una propagación rápida y perenne."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-sol-andina"
+      ],
+      "valor_pedagogico": "Allium fistulosum, conocida como cebolla larga o cebollín, es una aliácea hortícola perenne ampliamente cultivada en el cinturón agrícola de Cundinamarca, particularmente en las zonas de Aquitania y Sumapaz, donde abastece los mercados de Bogotá entre 1800 y 2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación mediante división de bulbillos (hijuelos) cada 4 meses para cosecha permanente, asociaciones beneficiosas con zanahoria y lechuga que mejora la salud del huerto, y requiere manejo de plagas como trips y manchas foliares mediante monitoreo frecuente y biopreparados andinos. En el contexto campesino andino, esta cebolla ha sido tradicionalmente utilizada en sofritos y guisos como base aromática esencial, preservando sabores prehispánicos en las cocinas rurales de Cundinamarca y Boyacá. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Allium fistulosum L.",
+      "companions": [
+        "fragaria_ananassa"
+      ],
+      "antagonists": [
+        "phaseolus_vulgaris"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "allium_sativum",
+      "nombre_comun": "Ajo",
+      "nombre_cientifico": "Allium sativum L.",
+      "familia_botanica": "Amaryllidaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "daucus_carota_subsp_sativus",
+        "solanum_melongena"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "biol",
+            "nombre": "Biol",
+            "tipo": "fermentado",
+            "dosis": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "bocashi",
+            "nombre": "Bocashi",
+            "tipo": "fermentado",
+            "dosis": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "caldo_ajo_concentrado",
+            "nombre": "Caldo de ajo concentrado (anti-fúngico/bactericida)",
+            "tipo": "fungicida_bactericida_botanico",
+            "dosis": "Macerado: 100 g de ajo molido por 1 L de agua, reposar 12-24 h, colar y añadir jabón (caldo madre). Aplicar diluido 1:10 (100 cc de madre por L de agua). Bomba de 20 L: ~2 L de macerado madre + chorro de jabón. Foliar cada 7-10 días preventivo; intensificar en clima húmedo."
+          },
+          {
+            "id": "caldo_bordeles",
+            "nombre": "Caldo bordelés",
+            "tipo": "caldo",
+            "dosis": "Caldo madre al 1% para 10 L: 100 g de sulfato de cobre pentahidratado + 100 g de cal. Disolver el cobre en agua tibia (recipiente NO metalico) y la cal aparte; verter el cobre sobre la lechada de cal (NUNCA al reves) y aforar a 10 L. Relacion 1:1:100 = 1 kg cobre : 1 kg cal : 100 L. Prueba del clavo o pH neutro-alcalino antes de aplicar (el clavo no debe cobrizarse). Hortalizas tiernas: 0,5% (50 g + 50 g / 10 L). Bomba de 20 L al 1%: 200 g sulfato + 200 g cal. Listo para aplicar SIN diluir.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "humus_liquido",
+            "nombre": "Humus líquido (lixiviado de lombriz)",
+            "tipo": "extracto",
+            "dosis": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "supermagro",
+            "nombre": "Supermagro",
+            "tipo": "fermentado",
+            "dosis": "Biofertilizante anaerobico fermentado 30-90 dias; se aplica DILUIDO, no puro. Dilucion foliar del 2% al 7% segun etapa (200-700 cc de supermagro por cada 10 L de agua). Inicio/general 3-5% (300-500 cc/10 L). Bomba de 20 L: 600 cc a 1 L. En cultivos sensibles empezar al 1-2% y subir. Tope de seguridad: no superar ~10% (riesgo de fitotoxicidad por exceso de Cu/Zn).",
+            "source": "feeding_plan_template"
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "alnus_acuminata",
+      "_curation_status": "VALIDADO con fuentes CIAT/AGROSAVIA",
+      "nombre_comun": "Aliso andino",
+      "nombre_comunes_regionales": [
+        "aliso",
+        "cerezo (cordillera oriental)",
+        "jaul (algunas zonas)"
+      ],
+      "nombre_cientifico": "Alnus acuminata Kunth",
+      "familia_botanica": "Betulaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "living_fence",
+        "windbreak",
+        "biomass_producer",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "cycleMonths": null,
+      "habito": "arbol deciduo semicaducifolio, 15-25m altura",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 8,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "humedad_relativa_pct": {
+        "min": 60,
+        "optimo": 80,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.5,
+        "optimo_max": 6.8,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno_a_moderado",
+      "companions": [
+        "coffea_arabica",
+        "erythrina_edulis",
+        "lupinus_mutabilis",
+        "trifolium_repens"
+      ],
+      "antagonists": [],
+      "recommended_covers": [
+        "trifolium_repens"
+      ],
+      "recommended_fences": [],
+      "fence_function": [
+        "rompevientos",
+        "delimitacion",
+        "sombra",
+        "refugio_fauna"
+      ],
+      "densidad_siembra_fence_m": 2.5,
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla recolectada de amentos maduros (marzo-mayo en cordillera oriental). Estratificación fría opcional 30 días. Germinación en bandejas con sustrato: 60% tierra negra + 30% arena + 10% compost maduro. Trasplante a bolsa negra 1.5kg a las 6 semanas. Plantación definitiva a los 4-6 meses (altura 30-40cm).",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Actinorrícica: forma nódulos fijadores de N con Frankia alni. Inoculación con suelo de aliso adulto acelera establecimiento.",
+        "fuente": "CIAT 1995 'El aliso (Alnus acuminata) en sistemas silvopastoriles'; Corpoica (AGROSAVIA) varios"
+      },
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol de 15-25m no apto para apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Como cerca viva o sombra puntual. Un solo árbol por huerto pequeño.",
+          "tips": [
+            "Plantar en esquina noroeste para sombra de tarde sin bloqueo solar mañanero",
+            "Podas anuales para mantener forma"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta por tamaño."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Ideal para sistemas silvopastoriles (20-40 árboles/ha) o como linderos entre lotes. Fija 150-300 kg N/ha/año según densidad y edad.",
+          "tips": [
+            "Densidad 10x10m o lindero a 2.5m",
+            "Podas de formación años 2-3 y posteriores cada 3 años"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "ESPECIE CLAVE para restauración de bosque alto andino y bordes de páramo. Nurse plant para especies de sotobosque. Recuperación de taludes degradados.",
+          "tips": [
+            "Plantación asociada a Weinmannia tomentosa y Escallonia paniculata",
+            "Densidad restauración: 1100 individuos/ha (3x3m)",
+            "Protección contra ganado primeros 3 años"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plan_nutricion_base": null,
+      "_nota_nutricion": "Como árbol fijador de N, no requiere plan de fertilización estándar. Aporta N al sistema. Solo monitoreo de P y K en suelos muy pobres durante establecimiento.",
+      "tests_suelo_recomendados": [
+        {
+          "tipo": "ph_casero",
+          "rango_objetivo": "5.5-6.8",
+          "frecuencia": "pre-siembra"
+        },
+        {
+          "tipo": "conteo_nodulos",
+          "frecuencia": "año 1 post-establecimiento",
+          "objetivo": "verificar nodulación por Frankia alni; objetivo >20 nódulos en raíz principal a 30cm profundidad"
+        }
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_restauracion": "Actúa como ecólogo de restauración de bosque alto andino colombiano.\nÁrea: {AREA_HA} ha a {ALTITUD} msnm en {MUNICIPIO}, pendiente {PENDIENTE}%, suelo degradado por {HISTORIAL_USO}. Quiero restaurar con Alnus acuminata como especie nodriza asociada a {ESPECIES_OBJETIVO}.\n\nDiseña: (a) marco de plantación y espaciamiento, (b) secuencia de establecimiento por fases (pioneras 1-3 años, secundarias 3-8 años, climácicas 8+ años), (c) protocolo de protección contra ganado, (d) indicadores de éxito de restauración a 1, 3, 5 años."
+      },
+      "rol_ecologico": "Especie nodriza clave en restauración de bosque alto andino. Fija nitrógeno simbiótico con actinomiceto Frankia alni. Hojas ricas en N mejoran el mantillo. Madera usada tradicionalmente para herramientas, construcciones rurales y leña. Corteza con taninos para curtiembre.",
+      "valor_pedagogico": "El aliso andino (Alnus acuminata Kunth) es una betulácea árbol nativo de los Andes ampliamente usada en sistemas agroforestales colombianos por su capacidad fijadora de nitrógeno (~150-200 kg N/ha/año mediante simbiosis con Frankia, actinorrhizas). Se distribuye naturalmente en Cundinamarca, Boyacá (cordillera Oriental), Antioquia, Cauca, Nariño y Tolima entre 1.500 y 3.200 msnm en zona térmica fría. Árbol caducifolio puede alcanzar 20-25 m, copa rala que permite paso de luz a cultivos asociados. Vida productiva 30-50 años. Manejo agroecológico: asocio café (sombra + N), sistemas silvopastoriles con pasturas naturalizadas, riberas microcuencas (estabilización suelo + sombra agua), barreras rompevientos en franjas anchas, restauración bosque altoandino. Madera blanda para artesanías locales. Fuentes Tier A: AGROSAVIA, Catálogo Plantas y Líquenes Colombia (Bernal et al.), POWO Kew, GBIF Backbone Taxonomy.",
+      "saber_origen": {
+        "pueblo": "Pueblos andinos (uso generalizado Muisca, Pasto, Inga)",
+        "region": "Andes colombianos 1800-3600 msnm",
+        "practica_original": "Uso en linderos tradicionales de aynokas, sombra para ganado, leña, reparación de taludes ribereños. Asociación con cultivos de frío (papa, maíz de altura, haba).",
+        "validacion_cientifica_source_ids": [
+          "ciat-1995-alnus",
+          "agrosavia-silvopastoriles"
+        ]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "Especie nativa andina ampliamente documentada. Datos consolidados.",
+      "harvest_type": "biomasa",
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "ciat-1995-alnus",
+        "agrosavia-silvopastoriles",
+        "humboldt-flora-alto-andina"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "aloe_vera",
+      "nombre_comun": "Sábila",
+      "nombre_comunes_regionales": [
+        "aloe",
+        "zabila",
+        "savila"
+      ],
+      "nombre_cientifico": "Aloe vera (L.) Burm.f.",
+      "familia_botanica": "Asphodelaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 18,
+        "optimo_max": 30,
+        "max_tolerable": 40
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "hijuelos",
+        "notas": "Propagación vegetativa por brotes basales (hijuelos). Separar cuando tengan 3-4 hojas y dejar secar la herida 24 h antes de plantar."
+      },
+      "source_ids": [
+        "perez-arbelaez-1947-plantas-utiles",
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales",
+        "agrosavia-tibaitata"
+      ],
+      "valor_pedagogico": "La sábila o aloe (Aloe vera (L.) Burm.f., familia Asphodelaceae) es una asphodelácea suculenta perenne acaule originaria de la Península Arábiga, naturalizada y cultivada extensamente en huertos de tierra caliente y templada colombiana por su gel mucilaginoso translúcido contenido en el parénquima foliar central, rico en polisacáridos (acemanano, glucomanano), antraquinonas (aloína, barbaloína) en el latex amarillo periférico, vitaminas y aminoácidos. Se cultiva en Bolívar (Cartagena, El Carmen de Bolívar), Magdalena (Santa Marta), Atlántico, Sucre, La Guajira (sur de Riohacha), Cesar (Valledupar), Tolima caliente (Espinal, Flandes), Huila (Neiva, Aipe) y Valle del Cauca entre 0 y 1.500 msnm en zona térmica cálida seca a templada. Ciclo perenne con hijuelos basales propagables desde el segundo año. Lección viva: la farmacia en una hoja — enseña suculencia y la estrategia metabólica CAM (Crassulacean Acid Metabolism) de las plantas xerófilas que abren estomas de noche para fijar CO2 reduciendo pérdida de agua diurna, adaptación clave a sequía documentada en Aloe, Agave, Opuntia y piñas (Bromeliaceae). El gel del parénquima foliar interno se usa en la medicina casera colombiana como cicatrizante de quemaduras solares, hidratante cutáneo y demulcente digestivo (uso tradicional respaldado por el JBB Bogotá). Manejo agroecológico: propagación por hijuelos basales separados con 3-4 hojas (dejar secar la herida 24 h antes de plantar), siembra en sustrato arenoso con drenaje excelente, exposición sol pleno, riego escaso (cada 15-20 días en seco), tolera salinidad moderada, asocio con henequén y cactáceas en sistemas xerófilos del Caribe, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, Pérez Arbeláez 1947 Plantas Útiles de Colombia, Pamplona-Roger 2006 Plantas Medicinales, JBB Plantas Medicinales Cundinamarca-Boyacá, AGROSAVIA Tibaitatá.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "aloysia_citrodora",
+      "nombre_comun": "Cedrón",
+      "nombre_cientifico": "Aloysia citrodora Paláu",
+      "familia_botanica": "Verbenaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "amaranthus_caudatus",
+      "nombre_comun": "Amaranto",
+      "nombre_comunes_regionales": [
+        "Kiwicha",
+        "Achis"
+      ],
+      "nombre_cientifico": "Amaranthus caudatus L.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla muy pequeña; sembrar superficialmente en semillero y trasplantar a los 30-45 dias. Tradicionalmente se asocia con maiz y frijol en la milpa andina."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-2013-quinua",
+        "nrc-1989-cultivos-andinos",
+        "perez-arbelaez-1947-plantas-utiles",
+        "mujica-1992-quinua"
+      ],
+      "valor_pedagogico": "El amaranto caudado o kiwicha (Amaranthus caudatus L., familia Amaranthaceae) es una amarantácea anual andina considerada pseudocereal de alta montaña por su grano con proteína completa (15-18%) rica en lisina, aminoácido limitante en cereales convencionales (maíz, trigo). Cultivo tradicional precolombino de comunidades campesinas andinas colombianas. Se cultiva en Boyacá (Tunja, Soracá, Ventaquemada), Cundinamarca (Sumapaz, Choachí), Nariño (Pasto, Yacuanquer) y Cauca entre 1.500 y 3.600 msnm en zona térmica fría a páramo bajo. Ciclo 5-6 meses, productividad 1.5-3 t/ha grano. Sus inflorescencias colgantes color rojo intenso a violáceo contienen miles de semillas pequeñas brillantes. Lección viva: enseña la resiliencia a sequía, heladas moderadas y suelos pobres, demostrando cómo cultivos nativos andinos resuelven seguridad alimentaria en zonas marginales. Manejo agroecológico: siembra al voleo en pre-cultivo o trasplante a doble fila, asocio con maíz y frijol (chacra andina), cosecha cuando inflorescencias se inclinan + secado al sol 7 días, trilla manual con vara. Fuentes Tier A: FAO 2013 Quinua y Cultivos Andinos, NRC 1989 Cultivos Andinos, AGROSAVIA Granos Andinos, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "ambrosia_cumanensis",
+      "nombre_comun": "Altamisa",
+      "nombre_cientifico": "Ambrosia cumanensis Kunth",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_universidad_nacional_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "anacardium_excelsum",
+      "nombre_comun": "Caracolí",
+      "nombre_cientifico": "Anacardium excelsum (Bertero & Balb. ex Kunth) Skeels",
+      "familia_botanica": "Anacardiaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 800
+      },
+      "source_ids": [
+        "graph_sinchi_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "anacardium_occidentale",
+      "nombre_comun": "Marañón",
+      "nombre_comunes_regionales": [
+        "Merey",
+        "Cajuil",
+        "Marañón"
+      ],
+      "nombre_cientifico": "Anacardium occidentale L.",
+      "familia_botanica": "Anacardiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 24,
+        "optimo_max": 32,
+        "max_tolerable": 38
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Fenologia: vivero, establecimiento de arbol, crecimiento juvenil, floracion en paniculas, desarrollo del pseudofruto, llenado de nuez y cosecha de nuez madura."
+      },
+      "source_ids": [
+        "agrosavia-manual-frutales-tropicales",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El maranon (Anacardium occidentale) es un frutal perenne de clima calido, valioso en Caribe seco, Orinoquia y zonas con sequia estacional por su tolerancia relativa a baja disponibilidad de agua una vez establecido. Su fenologia permite diferenciar vivero, establecimiento, crecimiento juvenil, floracion en paniculas, desarrollo del pseudofruto carnoso, llenado de la nuez y cosecha. Es una ficha pedagogica para explicar que el fruto comercial combina pseudofruto y nuez, y que el procesamiento requiere cuidado por los compuestos irritantes de la cascara. Plagas y enfermedades clave: trips, chinches, antracnosis, oidio y muerte descendente en brotes.",
+      "plagas_criticas": [
+        "Trips",
+        "Chinches",
+        "Barrenadores de brotes"
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis",
+        "Oidio",
+        "Muerte descendente"
+      ],
+      "harvest_type": "semilla",
+      "cycleMonths": null,
+      "companions": [
+        "cajanus_cajan",
+        "mucuna_pruriens"
+      ],
+      "antagonists": [],
+      "tracking_mode": "individual",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "ananas_comosus",
+      "nombre_comun": "Piña",
+      "nombre_cientifico": "Ananas comosus (L.) Merr.",
+      "familia_botanica": "Bromeliaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 100,
+        "optimo_min": 100,
+        "optimo_max": 1000,
+        "max_absoluto": 1000
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "annona_muricata",
+      "nombre_comun": "Guanábana",
+      "nombre_comunes_regionales": [
+        "Guanábano"
+      ],
+      "nombre_cientifico": "Annona muricata L.",
+      "familia_botanica": "Annonaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 23,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Fenologia: vivero, establecimiento, crecimiento vegetativo, floracion cauliflora o en ramas, polinizacion, cuajado, llenado de fruto y cosecha en madurez fisiologica."
+      },
+      "source_ids": [
+        "agrosavia-guanabana-fecunda-tesoro-2020",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La guanabana (Annona muricata) es un frutal tropical de clima calido, relevante en huertos familiares y produccion comercial de pulpa. Su fenologia pasa por vivero, establecimiento, crecimiento vegetativo, floracion en tronco y ramas, polinizacion, cuajado, llenado de fruto y cosecha en madurez fisiologica. Es util para ensenar polinizacion de anonaceas, poda de formacion y manejo de fruta grande susceptible a golpes. Plagas y enfermedades clave incluyen perforadores de semilla y fruto, cochinillas, antracnosis, pudriciones de fruto y enfermedades de raiz en suelos encharcados. La ficha evita promesas medicinales no verificadas y se concentra en manejo agricola.",
+      "plagas_criticas": [
+        "Perforador de semilla",
+        "Perforador de fruto",
+        "Cochinillas"
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis",
+        "Pudricion de fruto",
+        "Pudricion radicular"
+      ],
+      "harvest_type": "fruto",
+      "cycleMonths": null,
+      "companions": [
+        "musa_paradisiaca",
+        "cajanus_cajan"
+      ],
+      "antagonists": [],
+      "tracking_mode": "individual",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "arachis_hypogaea",
+      "nombre_comun": "Maní",
+      "nombre_cientifico": "Arachis hypogaea",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "arracacia_xanthorrhiza",
+      "nombre_comun": "Arracacha / Zanahoria blanca",
+      "nombre_comunes_regionales": [
+        "racacha",
+        "apio criollo",
+        "virraca"
+      ],
+      "nombre_cientifico": "Arracacia xanthorrhiza Bancr.",
+      "familia_botanica": "Apiaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 13,
+        "optimo_max": 20,
+        "max_tolerable": 25
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "hijuelos (cornos)",
+        "notas": "Se propaga vegetativamente mediante cornos (hijuelos de la corona). Ciclo largo (10-12 meses). Raiz muy perecedera post-cosecha."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La arracacha o zanahoria blanca (Arracacia xanthorrhiza Bancr., familia Apiaceae) es una apiácea perenne herbácea cultivada como tubérculo andino por excelencia de la chagra muisca colombiana, producida tradicionalmente por comunidades campesinas de Boyacá, Cundinamarca y Cauca por sus raíces tuberosas amarillo-pálidas a crema de textura suave, alta digestibilidad y bajo contenido de antinutrientes, recomendadas en dietas de destete infantil tradicional. Se cultiva en Boyacá (Sutamarchán, Tunja, Saboyá, Cucaita), Cundinamarca (Sumapaz, Pacho, Subachoque), Cauca (Silvia, Totoró), Nariño (Pasto, Yacuanquer) y Eje cafetero entre 1.500 y 2.800 msnm en zona térmica templada a fría. Ciclo largo 10-14 meses a cosecha, requiere paciencia y planificación de la chagra. Rendimientos 8-15 t/ha raíz fresca. Lección viva: enseña el manejo de cultivos de ciclo largo (vs hortalizas de ciclo corto 90-120 días), raíces de alta digestibilidad para alimentación infantil y adultos mayores, y valor económico campesino como cultivo comercial estable. Manejo agroecológico: siembra por hijuelos del cuello (propágulo vegetativo) en hoyos profundos 30 cm con compost al fondo, asocio con maíz y fríjol, aporque a los 4 meses, cosecha cuando follaje amarillea, almacenamiento en pozo fresco hasta 60 días. Fuentes Tier A: NRC 1989 Lost Crops of the Incas, AGROSAVIA Manual Tubérculos Andinos, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-la22-arracacha-2019",
+          "nombre_comercial": "AGROSAVIA La 22",
+          "codigo_experimental": null,
+          "nombre_botanico": "Arracacia xanthorrhiza Bancr.",
+          "species_id_chagra": "arracacia_xanthorrhiza",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Tibaitata"
+          },
+          "resolucion_ica": {
+            "numero": "015201/2019",
+            "fecha": "2019",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Region Andina",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 1200,
+                  "max": 1800,
+                  "etiqueta": "templado"
+                },
+                {
+                  "min": 1800,
+                  "max": 2200,
+                  "etiqueta": "frio_moderado"
+                },
+                {
+                  "min": 2200,
+                  "max": null,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Cundinamarca",
+            "Boyaca",
+            "Tolima",
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 34.8,
+            "rendimiento_tradicional_t_ha_comparado": {
+              "min": 7,
+              "max": 13,
+              "fuente_comparacion": "promedio historico arracacha tradicional"
+            },
+            "ciclo_meses": 11,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "raiz tuberosa amarillo intenso",
+            "alto Brix (12-14 grados vs 9-11 de criollas)",
+            "ausencia de pigmentacion morada en nabos"
+          ],
+          "resistencias_documentadas": [],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_propagulo",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Tibaitata",
+                "ciudad": "Mosquera"
+              },
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015 + Res. ICA 067516/2020"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-arracacha-la22-2021",
+            "agrosavia-modelo-arracacha-2024"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-22",
+          "ultima_revision_chagra": "2026-05-22",
+          "_curation_status": "BATCH_4A_PASADA_4_RESIDUAL",
+          "_revisor": "claude-opus-4-7"
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "asparagus_officinalis",
+      "nombre_comun": "Espárrago",
+      "nombre_cientifico": "Asparagus officinalis L.",
+      "familia_botanica": "Asparagaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2500,
+        "max_absoluto": 2500
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "avena_sativa",
+      "nombre_comun": "Avena forrajera",
+      "nombre_cientifico": "Avena sativa L.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "brassica_rapa_rapifera",
+        "phacelia_tanacetifolia",
+        "raphanus_sativus_oleifer",
+        "trifolium_repens",
+        "vicia_faba",
+        "vicia_sativa"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "averrhoa_carambola",
+      "nombre_comun": "Carambolo",
+      "nombre_cientifico": "Averrhoa carambola",
+      "familia_botanica": "Oxalidaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "baccharis_latifolia",
+      "nombre_comun": "Chilco",
+      "nombre_cientifico": "Baccharis latifolia (Ruiz & Pav.) Pers.",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 3500,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "bactris_gasipaes",
+      "nombre_comun": "Palmito de chontaduro",
+      "nombre_comunes_regionales": [
+        "Palmito",
+        "Chontaduro para palmito"
+      ],
+      "nombre_cientifico": "Bactris gasipaes Kunth",
+      "familia_botanica": "Arecaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 900,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 24,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Fenologia: germinacion lenta, vivero de palma, establecimiento, emision de macollas, crecimiento de tallos cosechables y corte selectivo de palmito."
+      },
+      "source_ids": [
+        "sinchi-frutas-amazonia-chontaduro",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El palmito de chontaduro (Bactris gasipaes) usa la misma especie del chontaduro, manejada con enfasis en tallos tiernos y macollamiento para corte de palmito. En Colombia tiene sentido en Amazonia y Pacifico calido humedo, con suelos profundos, humedad constante y drenaje bueno. Su fenologia incluye germinacion lenta, vivero, establecimiento de palma, emision de macollas, crecimiento de tallos cosechables y corte selectivo. La ficha ensena diferencia entre aprovechamiento de fruto y aprovechamiento de tallo, y por que la cosecha de palmito debe planearse para no destruir la cepa productiva. Plagas y enfermedades clave: picudos, acaros, pudricion del cogollo y manchas foliares.",
+      "plagas_criticas": [
+        "Picudo de las palmas",
+        "Acaros",
+        "Hormigas cortadoras"
+      ],
+      "enfermedades_criticas": [
+        "Pudricion del cogollo",
+        "Manchas foliares"
+      ],
+      "harvest_type": "tallo",
+      "cycleMonths": null,
+      "companions": [
+        "theobroma_cacao",
+        "musa_paradisiaca"
+      ],
+      "antagonists": [],
+      "tracking_mode": "aggregate",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "beta_vulgaris_conditiva",
+      "nombre_comun": "Remolacha",
+      "nombre_cientifico": "Beta vulgaris L. subsp. vulgaris Conditiva Group",
+      "familia_botanica": "Amaranthaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "beta_vulgaris_var_cicla",
+      "nombre_comun": "Acelga",
+      "nombre_cientifico": "Beta vulgaris var. cicla L.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "borago_officinalis",
+      "nombre_comun": "Borraja",
+      "nombre_cientifico": "Borago officinalis L.",
+      "familia_botanica": "Boraginaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "borojoa_patinoi",
+      "nombre_comun": "Borojó",
+      "nombre_cientifico": "Borojoa patinoi Cuatrec.",
+      "familia_botanica": "Rubiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "endemica_colombia",
+      "altitud_msnm": {
+        "min_absoluto": 100,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 800
+      },
+      "source_ids": [
+        "graph_nd_institucional_suelo"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brachiaria_decumbens",
+      "nombre_comun": "Pasto brachiaria",
+      "nombre_cientifico": "Urochloa decumbens (Stapf) R.D.Webster",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "fenologia": [
+        {
+          "id": "feno_cosecha_brachiaria_decumbens",
+          "nombre": "feno_cosecha_brachiaria_decumbens",
+          "orden": 99
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brassica_juncea",
+      "nombre_comun": "Mostaza",
+      "nombre_cientifico": "Brassica juncea (L.) Czern.",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1000,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brassica_oleracea_botrytis",
+      "nombre_comun": "Coliflor",
+      "nombre_cientifico": "Brassica oleracea var. botrytis L.",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brassica_oleracea_italica",
+      "nombre_comun": "Brócoli",
+      "nombre_cientifico": "Brassica oleracea var. italica Plenck",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima",
+        "graph_corpoica_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brassica_oleracea_var_capitata",
+      "nombre_comun": "Repollo",
+      "nombre_cientifico": "Brassica oleracea var. capitata L.",
+      "familia_botanica": "Brassicaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 2700
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima",
+        "graph_corpoica_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brosimum_utile",
+      "nombre_comun": "Sande",
+      "nombre_cientifico": "Brosimum utile (Kunth) Oken ex J.Presl",
+      "familia_botanica": "Moraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1000
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "brunellia_comocladifolia",
+      "nombre_comun": "Cedrillo",
+      "nombre_cientifico": "Brunellia comocladifolia Humb. & Bonpl.",
+      "familia_botanica": "Brunelliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1600,
+        "optimo_min": 1600,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "caesalpinia_spinosa",
+      "nombre_comun": "Guarango",
+      "nombre_cientifico": "Caesalpinia spinosa (Feuillée ex Molina) Kuntze",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_conif_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH49_LEGUMINOSAS_NAMES",
+      "id": "cajanus_cajan",
+      "nombre_comun": "Gandul",
+      "nombre_comunes_regionales": [
+        "gandules",
+        "guandú",
+        "guandul",
+        "fríjol de palo",
+        "fríjol arbusto",
+        "pigeon pea",
+        "fríjol quinchoncho"
+      ],
+      "nombre_cientifico": "Cajanus cajan (L.) Huth",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "biomass_producer",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 20,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "ph_suelo": {
+        "min": 5,
+        "optimo_min": 5.5,
+        "optimo_max": 7,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Siembra directa de semilla a 3-5 cm profundidad, distancia 60-100 cm entre plantas x 1-1.5 m entre surcos, densidad 8-15 kg/ha. Germinación 7-14 días. Ciclo 5-9 meses primera cosecha. Planta semi-perenne 2-5 años productiva. Floración invernal en Colombia (octubre-diciembre cosecha grano verde).",
+        "tiempo_a_establecimiento_dias": 14,
+        "notas": "Leguminosa arbustiva semi-perenne erecta 2-4 m altura. Fija 100-200 kg N/ha. Tolerante a sequía severa y suelos pobres. Doble propósito: grano alimenticio + abono verde + cerca viva + forraje + leña. Cultivo afrocolombiano Caribe.",
+        "fuente": "FAO Ecocrop Cajanus cajan; AGROSAVIA Leguminosas; NRC 1989"
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-leguminosas-andinas",
+        "fao-ecocrop",
+        "nrc-1989-cultivos-andinos",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El gandul o guandú (Cajanus cajan (L.) Huth, familia Fabaceae, tribu Phaseoleae) es una leguminosa arbustiva semi-perenne erecta de 2-4 m de altura originaria del subcontinente indio (Ghats Occidentales — Maharashtra, Karnataka, Andhra Pradesh) donde fue domesticada hace ~3500 años y diseminada vía África e introducida en América durante el comercio transatlántico como cultivo de subsistencia afroamericano profundamente arraigado en el Caribe colombiano. Se cultiva tradicionalmente en Caribe colombiano (Bolívar — Cartagena, San Juan Nepomuceno, María La Baja; Córdoba — Montería, Lorica, Cereté; Sucre — Sincelejo, Sampués; Magdalena — Santa Marta, Ciénaga, Plato; Cesar — Valledupar, San Diego; La Guajira — Riohacha, Maicao, San Juan del Cesar), Antioquia (Urabá — Apartadó, Turbo, Chigorodó; Bajo Cauca), Chocó (Quibdó, Bajo Baudó), Valle del Cauca (Buenaventura, Norte del Valle), Tolima (Espinal, Ibagué), Huila (Neiva, Garzón), Norte de Santander (Cúcuta, Ocaña) y Santander (Bucaramanga, Barrancabermeja) entre 0 y 2.000 msnm en zonas térmicas cálidas-templadas-secas-húmedas. Lección viva PEDAGÓGICAMENTE EXCELENTE de cultivo multipropósito-multiestrato: combina simultáneamente grano alimenticio proteico (semillas maduras grano seco — 19-24% proteína — para sopas, sancochos costeños, arroz con gandules), grano tierno verde como hortaliza (vainitas y semillas verdes — gastronomía afrocaribeña ancestral 'gandules verdes'), abono verde-cobertura por su rica biomasa hojosa, fijación biológica de N (100-200 kg N/ha por simbiosis con Bradyrhizobium sp. cajani), forraje arbustivo proteico para ganadería rumiante (vacas, ovejas, cabras costeñas) ramoneando hojas tiernas y vainas verdes, cerca viva-living fence productiva en bordes de chagras campesinas, leña de tallos lignificados al final del ciclo, atractor de polinizadores nativos (Apidae, Megachilidae). Planta arbustiva erecta con tallos lignificados rojizos pubescentes, hojas trifoliadas alternas pubescentes plateadas-grisáceas (foliolos elípticos), inflorescencia racimo terminal y axilar de flores grandes amarillas papilionadas (a veces con estandarte rayado rojizo), frutos legumbres alargadas planas (5-9 cm largo) verdes a maduras marrón-paja pubescentes, semillas redondeadas-ovales (cremas, marrones, rojas, negras moteadas según landrace — diversidad genética enorme de cultivares africanos-asiáticos-caribeños). Tolerancia extraordinaria a sequía severa (sobrevive estiajes de 3-5 meses por sistema radicular profundo pivotante 1-2 m), suelos pobres degradados ácidos (pH 5-7, Al sat hasta 30%), alta temperatura, salinidad moderada. Manejo agroecológico: siembra directa de semilla a 3-5 cm profundidad, distancia 60-100 cm entre plantas x 1-1.5 m entre surcos (8-15 kg/ha semilla), inoculación con Bradyrhizobium cajani opcional (ya hay cepas nativas en Caribe colombiano por siglos de cultivo), asocio tradicional con maíz-yuca-plátano-papaya en milpas afrocaribeñas, no requiere fertilización N (autosuficiente por fijación), poda anual tras cosecha para estimular rebrote (planta semi-perenne 2-5 años productiva), control de barrenadores de vainas Maruca vitrata con purín de tabaco + ajo y trampas de feromonas, cosecha grano verde 5-6 meses, grano seco 7-9 meses, rendimientos 0.8-2.5 t/ha grano seco según landrace y manejo. Función en chagra/huerto escolar afrocaribeño como leguminosa arbustiva multipropósito de soberanía alimentaria, cerca viva productiva, abono verde-cobertura biomasa, fijador N suelos pobres, forraje rumiante costeño, atractor polinizadores, cultivo afrocolombiano patrimonial. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989, FAO Ecocrop Cajanus cajan, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "companions": [
+        "coffea_arabica",
+        "zea_mays",
+        "manihot_esculenta",
+        "musa_paradisiaca",
+        "selenicereus_megalanthus",
+        "anacardium_occidentale",
+        "annona_muricata",
+        "dioscorea_alata_rotundata"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "calamagrostis_effusa",
+      "nombre_comun": "Paja de páramo",
+      "nombre_cientifico": "Calamagrostis effusa (Kunth) Steud.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 3200,
+        "optimo_min": 3200,
+        "optimo_max": 3800,
+        "max_absoluto": 3800
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "quercus_humboldtii"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "calendula_officinalis",
+      "nombre_comun": "Caléndula",
+      "nombre_cientifico": "Calendula officinalis L.",
+      "nombre_comunes_regionales": [
+        "Margarita dorada"
+      ],
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1200,
+        "optimo_max": 2500,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se resiembra sola con facilidad; sus raíces secretan sustancias que controlan nematodos en el suelo."
+      },
+      "companions": [
+        "solanum_lycopersicum_san_marzano",
+        "solanum_tuberosum",
+        "fragaria_ananassa"
+      ],
+      "antagonists": [],
+      "valor_pedagogico": "La Caléndula (Calendula officinalis L.) es una especie ornamental-medicinal originaria del Mediterráneo, ampliamente cultivada en jardines campesinos de Cundinamarca entre 0-2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con ciclo de floración de 75-90 días, asociándose beneficiosamente con cultivos como el tomate (Solanum lycopersicum) mientras actúa como repelente natural de trips y nemátodos mediante secreciones radiculares. En el contexto cultural andino-campesino, sus flores se utilizan tradicionalmente en preparaciones de crema cicatrizante por sus propiedades flavonoides, saponinas y aceites esenciales. Según GBIF Backbone Taxonomy y Plants of the World Online (POWO), esta especie destaca por su valor ecológico en atracción de polinizadores y manejo integrado de plagas en sistemas agroecológicos de montaña.",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "jbb-plantas-medicinales"
+      ],
+      "validation_level": "claude_draft",
+      "estrato": "medio",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "canna_edulis",
+      "nombre_comun": "Achira / SagU",
+      "nombre_cientifico": "Canna edulis Ker Gawl.",
+      "familia_botanica": "Cannaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "capsicum_annuum",
+      "nombre_comun": "Pimentón",
+      "nombre_cientifico": "Capsicum annuum L.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 500,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "sal_epsom_foliar",
+            "nombre": "Sal de Epsom foliar (sulfato de magnesio)",
+            "tipo": "fertilizante_foliar_mineral",
+            "dosis": "Solución foliar al 1-2%: 10-20 g de sal de Epsom por L de agua (100-200 g por 10 L). Bomba de 20 L: 200-400 g. Aplicar al follaje en horas frescas. Corrección de deficiencia: 2-3 aplicaciones cada 10-15 días. Al suelo: 20-30 g por planta incorporado."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "capsicum_annuum_generic",
+      "nombre_comun": "Ají",
+      "nombre_cientifico": "Capsicum annuum L.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1500,
+        "max_absoluto": 1500
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "carica_papaya",
+      "nombre_comun": "Papaya",
+      "nombre_cientifico": "Carica papaya L.",
+      "familia_botanica": "Caricaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1000
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima",
+        "graph_agrosavia_suelo"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "carludovica_palmata",
+      "nombre_comun": "Palma de iraca (paja toquilla)",
+      "nombre_cientifico": "Carludovica palmata Ruiz & Pav.",
+      "familia_botanica": "Cyclanthaceae",
+      "category": "fibras_no_maderables",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 1800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se propaga por semillas o división de hijuelos. Germinación en 2-3 meses."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "Carludovica palmata, conocida como palma de iraca o paja toquilla, es una ciclantácea nativa de los bosques húmedos tropicales de Colombia, Ecuador y Perú. En Colombia se distribuye en los departamentos de Nariño, Cauca, Putumayo, Amazonas y Chocó entre 0-1800 msnm en zonas térmicas cálidas y templadas. Su cultivo es tradicional en Sandoná, Nariño, donde las artesanas tejen sus hojas fibrosas para elaborar sombreros de paja toquilla reconocidos nationally por su fineza y durabilidad. La fibra se extrae de las hojas jóvenes antes de que se expandan completamente, se seca al sol y se procesa manualmente. Manejo agroecológico: propagación por semillas en vivero con trasplante a los 6-8 meses, requiere sombra parcial durante establecimiento, suelos húmedos con buen drenaje, cosecha de hojas selectiva (no más del 30% de hojas por planta) para permitir recuperación. Especie no maderable clave para economía campesina andina-amazónica.",
+      "harvest_type": "hoja",
+      "cycleMonths": null,
+      "companions": [],
+      "antagonists": [],
+      "tracking_mode": "aggregate",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "caryodendron_orinocense",
+      "nombre_comun": "Cacay",
+      "nombre_cientifico": "Caryodendron orinocense H.Karst.",
+      "familia_botanica": "Euphorbiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1000
+      },
+      "source_ids": [
+        "graph_instituto_sinchi_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cecropia_peltata",
+      "nombre_comun": "Yagrumo",
+      "nombre_cientifico": "Cecropia peltata L.",
+      "familia_botanica": "Urticaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 400,
+        "optimo_min": 400,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_sinchi_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "cedrela_odorata",
+      "nombre_comun": "Cedro real",
+      "nombre_comunes_regionales": [
+        "cedro",
+        "cedro colorado",
+        "cedro caoba",
+        "cedro amargo"
+      ],
+      "nombre_cientifico": "Cedrela odorata L.",
+      "familia_botanica": "Meliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "nurse_plant",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 1900
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol caducifolio, 20-35 m de altura, fuste recto",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca. Sin tratamiento pre-germinativo. Germinación 70-90% a 15-25 días en bandejas con sustrato orgánico. Trasplante a bolsa 1.5-2 kg a las 6 semanas. Plantación definitiva a los 4-6 meses (30-40 cm altura). Vivero a sombra parcial 50%.",
+        "tiempo_a_establecimiento_dias": 60,
+        "notas": "Crítico manejo contra Hypsipyla grandella (barrenador del cedro) que perfora yema apical y deforma fuste. Asocio con sombrío parcial (café, cacao) o plantación bajo dosel disminuye ataque vs plantación a plena exposición.",
+        "fuente": "Cárdenas & Salinas 2007 'Libro Rojo Plantas Colombia'; CONIF/Cárdenas; CATIE manuales agroforestales meliáceas tropicales"
+      },
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "erythrina_edulis",
+        "inga_edulis",
+        "swietenia_macrophylla"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 20-35 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Un árbol patrimonial por huerto >500 m² como sombra y reserva maderable familiar.",
+          "tips": [
+            "Plantar a >8 m de construcciones (raíz extensa)",
+            "Podas de formación años 2-4 para fuste recto"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío en café 100-200 árb/ha, cacao 80-120 árb/ha o plantaciones maderables puras 400-625 árb/ha (5x5 a 4x4 m). Turno comercial 25-35 años para diámetros >40 cm.",
+          "tips": [
+            "Asocio café/cacao reduce ataque Hypsipyla 40-60%",
+            "Raleos progresivos a los 8, 14 y 20 años",
+            "Cosecha de semilla genética seleccionada"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Especie clave restauración bosque seco tropical y bosque húmedo premontano. Listado Apéndice III CITES para Colombia.",
+          "tips": [
+            "Densidad 600-800 ind/ha asociado a pioneras (Ochroma, Cordia)",
+            "Protección contra ganado primeros 4 años"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [
+        "Hypsipyla grandella (barrenador del cedro y la caoba) — perfora yema apical en plantaciones puras, deforma fuste"
+      ],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Especie maderable patrimonial neotropical. Hojas pinnadas con olor característico a ajo o cedro (de ahí 'odorata'). Madera aromática amarillo-rojiza muy apreciada por carpintería fina, ebanistería, instrumentos musicales, cigarros (cajas), construcción naval. Hospedero de larvas de mariposas Sphingidae y refugio de epífitas. Listada como vulnerable por sobreexplotación maderera histórica en Colombia, Apéndice III CITES.",
+      "valor_pedagogico": "El cedro real (Cedrela odorata L., Meliaceae) es uno de los árboles maderables más patrimoniales de la América tropical, nativo desde el sur de México hasta el norte de Argentina. En Colombia se distribuye en bosques húmedos y secos tropicales y premontanos de las regiones Caribe (Magdalena, Cesar, Bolívar, Sucre, Córdoba, La Guajira), Andina (valles interandinos del Magdalena, Cauca, Patía, en Tolima, Huila, Valle, Antioquia, Santander, Norte de Santander), Pacífico (Chocó, Valle), Orinoquía (piedemonte llanero Casanare, Meta) y Amazonía (piedemonte caqueteño y putumayense) entre 0 y 1.500 msnm en zona térmica cálida a templada. Árbol caducifolio de 20-35 m de altura con fuste recto cilíndrico y corteza fisurada, hojas pinnadas grandes con folíolos lanceolados que despiden olor característico a ajo o cedro al romperlas (epíteto 'odorata'), flores pequeñas blanco-verdosas en panículas terminales melíferas, cápsulas leñosas dehiscentes con semillas aladas dispersadas por viento. Madera aromática rojiza muy apreciada en ebanistería fina, instrumentos musicales (guitarras clásicas), cajas para puros cubanos, construcción naval, mueblería de lujo. Históricamente sobreexplotada: poblaciones silvestres reducidas en >70% del rango original, listada en Apéndice III CITES Colombia y Libro Rojo Plantas Colombia como vulnerable. Su asocio agroecológico clásico es con café y cacao bajo sombrío diversificado, donde el dosel parcial reduce hasta un 60% el ataque del barrenador Hypsipyla grandella (lepidóptero Pyralidae que perfora la yema apical y deforma el fuste en plantaciones puras a plena exposición), aporta biomasa hojarasca rica en N, hospeda fauna polinizadora y eventualmente provee madera de valor patrimonial para herencia familiar (turno 25-35 años a diámetros >40 cm). Manejo agroecológico: vivero a sombra 50%, plantación definitiva entre cacaotales o cafetales, podas de formación años 2-4 para fuste recto, raleos progresivos años 8-14-20, cosecha de semilla genéticamente seleccionada. Es lección de soberanía maderera: en lugar de teca asiática o pino radiata exótico, el cedro colombiano provee maderas finas locales con menor huella ecológica y valor cultural patrimonial. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF Backbone Taxonomy, CATIE/CONIF manuales agroforestales meliáceas tropicales.",
+      "nota_conservacion": "Listado Apéndice III CITES Colombia y categoría Vulnerable en Libro Rojo Plantas Colombia por sobreexplotación maderera histórica. Aprovechamiento silvestre requiere permiso CAR/Ministerio Ambiente. Plantaciones agroforestales y huertos familiares contribuyen a recuperación poblacional.",
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "tracking_mode": "individual",
+      "cites_appendix": "II",
+      "_cites_history_note": "Cedrela odorata: Apéndice III (Colombia, 2001) → Apéndice II (todas las poblaciones neotropicales, CoP18/2019, efectivo 2020). Valor actual: II.",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "ceiba_pentandra",
+      "nombre_comun": "Ceiba algodón",
+      "nombre_cientifico": "Ceiba pentandra (L.) Gaertn.",
+      "familia_botanica": "Malvaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 800
+      },
+      "source_ids": [
+        "graph_sinchi_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "gliricidia_sepium",
+        "samanea_saman"
+      ],
+      "tracking_mode": "individual",
+      "fenologia": [
+        {
+          "id": "feno_cosecha_ceiba_pentandra",
+          "nombre": "feno_cosecha_ceiba_pentandra",
+          "orden": 99
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cenchrus_clandestinus",
+      "_curation_status": "VALIDADO; nombre taxonómico actualizado (previamente Pennisetum clandestinum); thermal_zones y fecha de introducción corregidos auditoría 2026-05-21",
+      "nombre_comun": "Kikuyo",
+      "nombre_comunes_regionales": [
+        "kikuyo",
+        "cundo",
+        "pasto kikuyo",
+        "pasto africano"
+      ],
+      "nombre_cientifico": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "_nombre_cientifico_anterior": "Pennisetum clandestinum Hochst. ex Chiov., 1903",
+      "autor_ano": "Hochst. ex Chiov. 1903 → reubicado en Cenchrus por Morrone 2010",
+      "familia_botanica": "Poaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "_nota_cultivable": "PARADOJA COLOMBIANA: es la gramínea forrajera más importante del trópico alto (>2200 msnm) para ganadería de leche. Simultáneamente es invasora crítica en páramos y bosques altoandinos. Uso legal en potreros, prohibido/indeseable en áreas de restauración y delimitación de páramo (Ley 1930/2018).",
+      "conservation_status": "invasor",
+      "habito": "gramínea perenne postrada estolonífera-rizomatosa, alfombrante 10-30 cm de altura",
+      "origen": "África oriental (altiplanos Kenia, Etiopía, Uganda, Rwanda, Tanzania, Zaire); introducida en Colombia hacia 1935-1945 para ganadería lechera (estudios CENICAFÉ y AGROSAVIA; el reporte de 1928 corresponde a su llegada a Sudáfrica/Kenia)",
+      "clasificacion_uicn": "Listada en ISSG/GISD Global Invasive Species Database; IAvH-Humboldt la cataloga como naturalizada de alto riesgo para ecosistemas de páramo y subpáramo colombianos",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Ley 1930/2018 prohíbe su siembra y manejo agropecuario en áreas delimitadas de páramo",
+          "norma": "Ley 1930/2018",
+          "restriccion": "prohibida_paramos"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Resolución 684/2018 MADS la incluye en lineamientos de control en áreas de restauración",
+          "norma": "Resolución 684/2018 MADS",
+          "autoridad": "MADS"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "ICA Resolución 3168/2015 regula su comercialización como forrajera",
+          "norma": "Resolución 3168/2015",
+          "autoridad": "ICA"
+        },
+        {
+          "tipo": "contexto_etnocultural",
+          "alcance": "el conflicto regulatorio (forrajera legal en potreros vs. invasora prohibida en páramo) requiere validar la cota y el ecosistema antes de toda intervención"
+        }
+      ],
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 3200,
+        "max_absoluto": 3600
+      },
+      "impacto_ecologico": "Forma alfombras densas mediante estolones y rizomas que excluyen físicamente la regeneración de Calamagrostis effusa, Festuca spp. y otros pastizales nativos del subpáramo y páramo; altera el régimen hídrico al competir con frailejones jóvenes (Espeletia spp.) por humedad superficial; responde positivamente a fertilización nitrogenada de origen ganadero, agroquímico o deposición atmosférica, generando bucle de retroalimentación que amplía el área invadida; reduce la captura de niebla y la regulación hidrológica del páramo al sustituir la roseta-cojín nativa por dosel rasante; en ecotonos bosque-páramo desplaza el sotobosque nativo y dificulta la sucesión secundaria post-disturbio.",
+      "ecosistemas_afectados": [
+        "paramo",
+        "subparamo",
+        "bosque_alto_andino",
+        "humedales_altoandinos"
+      ],
+      "mecanismos_invasion": [
+        "Estolones rápidos forman matas densas que excluyen nativas",
+        "Rizomas penetran suelo y son difíciles de extraer",
+        "Semillas viables hasta 10 años en el suelo",
+        "Dispersión vía tubo digestivo del ganado",
+        "Responde a fertilización nitrogenada (de origen natural o agropecuario)",
+        "Desplaza a Calamagrostis effusa y otros pastizales nativos de páramo"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Requiere extraer estolones y rizomas completos; suelos pedregosos dificultan. Herramienta: azadón de péndulo."
+        },
+        {
+          "metodo": "solarizacion",
+          "efectividad": "media",
+          "costo": "medio",
+          "notas": "6-8 semanas bajo plástico negro en temporada seca; efectivo en parches pequeños"
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "baja",
+          "costo": "bajo",
+          "notas": "NO suficiente por sí solo; requiere acompañamiento de siembra de nativas"
+        }
+      ],
+      "epoca_optima_remocion": "Temporada seca, antes de floración y semillación",
+      "especies_nativas_sustitutas": [],
+      "manejo_biomasa_extraida": "compostaje en condiciones termófilas >60°C por >3 semanas (destruye semillas) O incineracion_controlada",
+      "riesgo_rebrote": "alto — rebrote vigoroso desde estolones y rizomas residuales en el suelo; el corte simple sin extracción de propágulos vegetativos garantiza recolonización en 2-4 meses",
+      "protocolo_post_remocion": "Restauración activa con macollas de Calamagrostis effusa y Festuca spp. a 5-9 macollas/m2 al inicio de la siguiente temporada lluviosa; mulching con paja de páramo o tela termodegradable por 6-12 meses para suprimir rebrote de propágulos residuales; monitoreo trimestral de rebrotes vegetativos durante 3 años; eliminación manual inmediata de cualquier rebrote antes de que produzca estolones secundarios; reporte de la intervención al SIB Colombia y a la autoridad ambiental jurisdiccional con coordenadas, área tratada y especies sustitutas establecidas.",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Cenchrus_clandestinus",
+      "referencias_cientificas": [
+        "Correa, Pabón & Carulla 2008. Valor nutricional del kikuyo. Livestock Research for Rural Development 20(59)",
+        "Mila & Corredor 2004. Evolución composición botánica pradera kikuyo. Corpoica 5(1): 70-75",
+        "Portillo et al. 2019. Evaluación forrajeras Nariño. AGROSAVIA"
+      ],
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "correa-pabon-carulla-2008",
+        "agrosavia-forrajeras-2022",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El kikuyo (Cenchrus clandestinus) es gramínea africana introducida en los Andes colombianos hacia 1928 como forraje. Hoy domina pasturas del altiplano cundiboyacense (2200-3200 msnm) desplazando flora nativa de subpáramo y bordes de páramo. Su rizoma agresivo coloniza suelos disturbados y compite con encenillos, frailejones jóvenes y otras nativas en zonas de restauración. Es la gramínea forrajera más sembrada en ganadería andina colombiana, pero ECOLÓGICAMENTE INVASORA en transición frío/páramo. Manejo agroecológico: rotación con leguminosas nativas, corte periódico antes de floración, evitar siembra en cotas >2800 msnm donde desplaza páramo. Citado por IAvH como naturalizada de alto riesgo en Andes.",
+      "tracking_mode": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "cenchrus_purpureus",
+      "nombre_comun": "Maralfalfa",
+      "nombre_cientifico": "Cenchrus purpureus (Schumach.) Morrone",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2200,
+        "max_absoluto": 2200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "centrosema_molle",
+      "nombre_comun": "Centrosema",
+      "nombre_cientifico": "Centrosema molle Mart. ex Benth.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1600,
+        "max_absoluto": 1600
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "chenopodium_quinoa",
+      "nombre_comun": "Quinua",
+      "nombre_cientifico": "Chenopodium quinoa Willd.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 20,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Cosechar cuando el tallo cambie de color y el grano esté duro (no se deje rayar con la uña)."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "agrosavia-leguminosas-andinas",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "valor_pedagogico": "La quinua (Chenopodium quinoa Willd.) es un pseudocereal andino tradicional con alto valor proteico (~14-18%) y aminoácidos esenciales, redescubierta como cultivo estratégico de seguridad alimentaria. En Colombia se cultiva en Boyacá, Nariño, Cundinamarca y Cauca entre 2.500 y 3.500 msnm en zona térmica fría a páramo bajo. Las variedades AGROSAVIA Aurora, Tunkahuán y Blanca de Jericó están adaptadas al altiplano cundiboyacense con ciclo 5-6 meses. Tolera salinidad moderada, sequía y heladas leves (-2°C en estados vegetativos). Manejo agroecológico: rotación con leguminosas, fertilización orgánica con bocashi y biol, control mecánico de mildiú (Peronospora variabilis) por densidad de siembra adecuada (60-80 cm entre surcos). Fuentes Tier A: AGROSAVIA fichas técnicas, FAO Quinoa Sourcebook 2013, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "companions": [
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "chrysopogon_zizanioides",
+      "nombre_comun": "Vetiver",
+      "nombre_cientifico": "Chrysopogon zizanioides (L.) Roberty",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2200,
+        "max_absoluto": 2200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "chusquea_scandens",
+      "nombre_comun": "Chusque",
+      "nombre_cientifico": "Chusquea scandens Kunth",
+      "familia_botanica": "Poaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 3500,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cichorium_intybus",
+      "nombre_comun": "Radicchio / Achicoria",
+      "nombre_cientifico": "Cichorium intybus L.",
+      "familia_botanica": "Asteraceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cissus_verticillata",
+      "nombre_comun": "Insulina",
+      "nombre_cientifico": "Cissus verticillata (L.) Nicolson & C.E.Jarvis",
+      "familia_botanica": "Vitaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "citrus_latifolia",
+      "nombre_comun": "Limón Tahití",
+      "nombre_cientifico": "Citrus × latifolia (Yu. Tanaka) Tanaka",
+      "familia_botanica": "Rutaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 400,
+        "optimo_min": 400,
+        "optimo_max": 1600,
+        "max_absoluto": 1600
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "aceite_jabon_anticochinilla",
+            "nombre": "Aceite mineral/vegetal + jabón (anti-cochinilla y escamas)",
+            "tipo": "insecticida_de_contacto",
+            "dosis": "MADRE/EMULSIÓN: emulsionar 10-20 cc de aceite + 5-10 cc de jabón potásico por L de agua tibia, agitando hasta lechoso (1-2% de aceite). Bomba de 20 L: 200-400 cc de aceite + 100-200 cc de jabón. APLICACIÓN: mojar muy bien las colonias de cochinilla/escama (haz, envés, axilas). No superar 2% en follaje tierno."
+          },
+          {
+            "id": "caldo_ceniza_jabon_concentrado",
+            "nombre": "Caldo ceniza-jabón concentrado (anti-minador/cochinilla)",
+            "tipo": "insecticida_fungicida_mineral",
+            "dosis": "Cocinar 1 kg de ceniza + 200-300 g de jabón en 5 L de agua, hervir 20-30 min, decantar y usar el líquido claro (caldo madre). Para minadores/cochinillas aplicar más concentrado: dilución 1:3 (1 L de caldo por 3 L de agua). Bomba de 20 L: ~5 L de caldo madre. Foliar al envés cada 8-10 días, 2-3 aplicaciones."
+          },
+          {
+            "id": "emulsion_nim",
+            "nombre": "Aceite/emulsión de nim (neem)",
+            "tipo": "insecticida_botanico",
+            "dosis": "Aceite de nim emulsionado: 3-5 cc de aceite de nim por L de agua (0,3-0,5%) + 1-2 cc de jabón potásico/L como emulsionante. Bomba de 20 L: 60-100 cc de aceite de nim + 20-40 cc de jabón. Aplicar al atardecer cubriendo el envés. Extracto acuoso de semilla molida: 30-50 g/L macerado 12 h, colado. Repetir cada 7-10 días."
+          },
+          {
+            "id": "lechada_cal_troncos",
+            "nombre": "Lechada de cal (encalado de troncos)",
+            "tipo": "fungicida_repelente_mineral",
+            "dosis": "Pasta/lechada al 20-30%: 2 a 3 kg de cal apagada por cada 10 L de agua, hasta consistencia de pintura blanca. Aplicar con brocha al tronco y base de ramas principales 1-2 veces al año (inicio de época seca y/o tras la poda). Para árboles frutales y café: cubrir desde el cuello hasta ~1-1,5 m de altura."
+          },
+          {
+            "id": "sal_epsom_foliar",
+            "nombre": "Sal de Epsom foliar (sulfato de magnesio)",
+            "tipo": "fertilizante_foliar_mineral",
+            "dosis": "Solución foliar al 1-2%: 10-20 g de sal de Epsom por L de agua (100-200 g por 10 L). Bomba de 20 L: 200-400 g. Aplicar al follaje en horas frescas. Corrección de deficiencia: 2-3 aplicaciones cada 10-15 días. Al suelo: 20-30 g por planta incorporado."
+          },
+          {
+            "id": "trampa_melaza_atrayente",
+            "nombre": "Trampa de melaza (cebo atrayente líquido)",
+            "tipo": "trampa_cebo",
+            "dosis": "Solución cebo: 100-200 g de melaza/panela por 1 L de agua (10-20%) + un chorro de jabón. Llenar recipientes/botellas trampa hasta ~1/3 y colgar o ubicar 1 trampa cada 5-10 m (≈10-25 trampas/ha según presión). Renovar el líquido cada 5-8 días o cuando pierda olor/fermente en exceso."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "citrus_sinensis",
+      "nombre_comun": "Naranja",
+      "nombre_cientifico": "Citrus × sinensis (L.) Osbeck",
+      "familia_botanica": "Rutaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 400,
+        "optimo_min": 400,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "aceite_jabon_anticochinilla",
+            "nombre": "Aceite mineral/vegetal + jabón (anti-cochinilla y escamas)",
+            "tipo": "insecticida_de_contacto",
+            "dosis": "MADRE/EMULSIÓN: emulsionar 10-20 cc de aceite + 5-10 cc de jabón potásico por L de agua tibia, agitando hasta lechoso (1-2% de aceite). Bomba de 20 L: 200-400 cc de aceite + 100-200 cc de jabón. APLICACIÓN: mojar muy bien las colonias de cochinilla/escama (haz, envés, axilas). No superar 2% en follaje tierno."
+          },
+          {
+            "id": "caldo_ceniza_jabon_concentrado",
+            "nombre": "Caldo ceniza-jabón concentrado (anti-minador/cochinilla)",
+            "tipo": "insecticida_fungicida_mineral",
+            "dosis": "Cocinar 1 kg de ceniza + 200-300 g de jabón en 5 L de agua, hervir 20-30 min, decantar y usar el líquido claro (caldo madre). Para minadores/cochinillas aplicar más concentrado: dilución 1:3 (1 L de caldo por 3 L de agua). Bomba de 20 L: ~5 L de caldo madre. Foliar al envés cada 8-10 días, 2-3 aplicaciones."
+          },
+          {
+            "id": "emulsion_nim",
+            "nombre": "Aceite/emulsión de nim (neem)",
+            "tipo": "insecticida_botanico",
+            "dosis": "Aceite de nim emulsionado: 3-5 cc de aceite de nim por L de agua (0,3-0,5%) + 1-2 cc de jabón potásico/L como emulsionante. Bomba de 20 L: 60-100 cc de aceite de nim + 20-40 cc de jabón. Aplicar al atardecer cubriendo el envés. Extracto acuoso de semilla molida: 30-50 g/L macerado 12 h, colado. Repetir cada 7-10 días."
+          },
+          {
+            "id": "lechada_cal_troncos",
+            "nombre": "Lechada de cal (encalado de troncos)",
+            "tipo": "fungicida_repelente_mineral",
+            "dosis": "Pasta/lechada al 20-30%: 2 a 3 kg de cal apagada por cada 10 L de agua, hasta consistencia de pintura blanca. Aplicar con brocha al tronco y base de ramas principales 1-2 veces al año (inicio de época seca y/o tras la poda). Para árboles frutales y café: cubrir desde el cuello hasta ~1-1,5 m de altura."
+          },
+          {
+            "id": "sal_epsom_foliar",
+            "nombre": "Sal de Epsom foliar (sulfato de magnesio)",
+            "tipo": "fertilizante_foliar_mineral",
+            "dosis": "Solución foliar al 1-2%: 10-20 g de sal de Epsom por L de agua (100-200 g por 10 L). Bomba de 20 L: 200-400 g. Aplicar al follaje en horas frescas. Corrección de deficiencia: 2-3 aplicaciones cada 10-15 días. Al suelo: 20-30 g por planta incorporado."
+          },
+          {
+            "id": "trampa_melaza_atrayente",
+            "nombre": "Trampa de melaza (cebo atrayente líquido)",
+            "tipo": "trampa_cebo",
+            "dosis": "Solución cebo: 100-200 g de melaza/panela por 1 L de agua (10-20%) + un chorro de jabón. Llenar recipientes/botellas trampa hasta ~1/3 y colgar o ubicar 1 trampa cada 5-10 m (≈10-25 trampas/ha según presión). Renovar el líquido cada 5-8 días o cuando pierda olor/fermente en exceso."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "clusia_multiflora",
+      "nombre_comun": "Gaque",
+      "nombre_cientifico": "Clusia multiflora Kunth",
+      "familia_botanica": "Clusiaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 2900,
+        "max_absoluto": 2900
+      },
+      "source_ids": [
+        "graph_iavh_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "axinaea_macrophylla",
+        "clethra_fagifolia",
+        "clusia_grandiflora",
+        "freziera_canescens",
+        "ilex_kunthiana",
+        "myrcianthes_ferreyrae",
+        "myrcianthes_rhopaloides",
+        "oreopanax_incisus",
+        "prumnopitys_montana",
+        "quercus_humboldtii",
+        "vallea_stipularis",
+        "weinmannia_pubescens",
+        "weinmannia_tomentosa"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "coffea_arabica",
+      "nombre_comun": "Café caturra / Castillo / Cenicafé 1",
+      "nombre_cientifico": "Coffea arabica L.",
+      "nombre_comunes_regionales": [
+        "Café Supremo (categoría comercial)",
+        "Café Arábigo"
+      ],
+      "familia_botanica": "Rubiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 180,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1500,
+        "optimo_max": 2000,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 18,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5,
+        "optimo_max": 6,
+        "max": 6.5
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 2,
+        "horas_acumuladas_max": 0,
+        "notes": "Altamente sensible a heladas; las bajas temperaturas afectan la calidad del grano."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "erythrina_edulis",
+        "inga_edulis",
+        "cedrela_odorata",
+        "cordia_alliodora",
+        "swietenia_macrophylla",
+        "tabebuia_rosea",
+        "tabebuia_chrysantha",
+        "musa_paradisiaca",
+        "cajanus_cajan"
+      ],
+      "companions_con_advertencia": [
+        "aniba_perutilis",
+        "swietenia_macrophylla",
+        "cedrela_odorata",
+        "cedrela_montana",
+        "magnolia_caricifragrans"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere germinador en arena y posterior embolsado."
+      },
+      "valor_pedagogico": "El café arábica (Coffea arabica L.) es el cultivo agroindustrial emblemático de Colombia y la principal fuente de ingresos de la economía campesina cafetera, con cerca de 850.000 hectáreas distribuidas en Caldas, Quindío, Risaralda, Antioquia, Tolima, Huila, Cundinamarca y Santander entre 1.200 y 2.000 msnm en zona térmica templada. Las variedades Caturra, Castillo y Cenicafé 1 son las más adoptadas en Colombia por su resistencia a roya (Hemileia vastatrix) y broca (Hypothenemus hampei) según Cenicafé. Requiere sombra parcial 35-50%, suelos francos con pH 5.0-5.5, y precipitación 1.800-2.800 mm anuales. Sistemas agroecológicos asocian café con plátano (Musa spp.), guandul (Cajanus cajan) y nogal cafetero (Cordia alliodora) para sombra estratificada. ⚠️ El sombrío histórico incluyó species hoy amenazadas (Aniba perutilis CR, Swietenia macrophylla EN/CITES II, Cedrela odorata CITES II). En cafetales nuevos, priorizar Inga spp + Erythrina + Cordia alliodora (rápido crecimiento, no amenazadas) sobre maderables CR. Fuentes Tier A: Cenicafé Manual del Cafetero 2013, AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "feeding_plan_template": {
+        "source": "Cenicafé — Manual del Cafetero Colombiano (2013) + Cenicafé — Trichoderma spp. en manejo integrado (2010). Programa nutricional café tradicional Caturra/Castillo zona cafetera.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 500,
+            "notes": "Hoyo 40x40x40 cm. Cenicafé recomienda fertilización inicial al establecimiento. Mezclar con suelo del hoyo."
+          },
+          {
+            "offset_days": 30,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 20,
+            "notes": "Preventivo contra Fusarium oxysporum f.sp. coffeae (llaga macana) y Rhizoctonia. Cenicafé 2010."
+          },
+          {
+            "offset_days": 90,
+            "action": "Drench con biol fase vegetativa",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 1000,
+            "notes": "Dilución 1:5, 1 L por planta al pie. Refuerzo N orgánico fase de crecimiento foliar activo."
+          },
+          {
+            "offset_days": 180,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo roya (Hemileia vastatrix) en época de lluvias antes de iniciar floración."
+          },
+          {
+            "offset_days": 365,
+            "action": "Refuerzo anual con bocashi en banda",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 1500,
+            "notes": "Año 1 establecimiento completo. Aplicar en corona radicular antes de inicio de lluvias."
+          },
+          {
+            "offset_days": 540,
+            "action": "Foliar con supermagro pre-floración",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 80,
+            "notes": "Dilución 1:12. Corrige B y Zn críticos para cuajado de chereza. Aplicar 30 días antes de floración esperada."
+          },
+          {
+            "offset_days": 720,
+            "action": "Aplicar Bacillus subtilis foliar en cosecha",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 25,
+            "notes": "Año 2 primera cosecha. Control biológico de Cercospora coffeicola y Mycena citricolor (gotera)."
+          }
+        ]
+      },
+      "plagas_criticas": [
+        "Hypothenemus hampei (broca del café — plaga #1, perfora el grano; su estadio larval se llama chapola)",
+        "Leucoptera coffeella (minador de la hoja)",
+        "Planococcus spp. (cochinilla harinosa de la raíz y el fruto)",
+        "Monalonion velezangeli (chinche de la chamusquina, también afecta café en algunas zonas)"
+      ],
+      "enfermedades_criticas": [
+        "Hemileia vastatrix (roya del café) — enfermedad #1, defolia y reduce producción",
+        "Mycena citricolor (ojo de gallo / gotera, en zonas húmedas y sombrías)",
+        "Cercospora coffeicola (mancha de hierro / cercosporiosis)",
+        "Colletotrichum spp. (antracnosis del fruto)",
+        "Ceratocystis fimbriata (llaga macana del tronco)",
+        "Rosellinia spp. (llaga negra de la raíz)"
+      ],
+      "source_ids": [
+        "cenicafe-manual-cafetero-2013",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "cordia_alliodora",
+      "nombre_comun": "Nogal cafetero",
+      "nombre_comunes_regionales": [
+        "nogal",
+        "moho",
+        "salmwood",
+        "vara de humo",
+        "canalete"
+      ],
+      "nombre_cientifico": "Cordia alliodora (Ruiz & Pav.) Oken",
+      "familia_botanica": "Boraginaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "windbreak",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 400,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol semicaducifolio, 15-25 m de altura, copa rala estratificada",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Recolección de núcula seca en panículas persistentes (cáliz acrescente actúa como ala anemócora). Sin tratamiento pre-germinativo. Germinación 60-80% a 10-20 días. Plántula vigorosa, trasplante directo o a bolsa 1 kg. Definitiva a 3-4 meses (25-35 cm).",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Regeneración natural espontánea en cafetales y potreros (anemócora). Asocio nodal con Coffea arabica en Eje Cafetero colombiano: dosel ralo permite paso de luz tamizada óptima para café.",
+        "fuente": "Cenicafé manuales sombrío cafetero; CATIE 1997 'Cordia alliodora en sistemas agroforestales'; Trees of Antioquia"
+      },
+      "companions": [
+        "cedrela_odorata",
+        "coffea_arabica",
+        "erythrina_edulis",
+        "inga_edulis",
+        "swietenia_macrophylla",
+        "tabebuia_rosea",
+        "tabebuia_chrysantha"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 15-25 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Sombrío puntual o lindero. Regenera espontáneamente desde semilla anemócora dispersada del vecindario.",
+          "tips": [
+            "Aprovechar regeneración natural en lugar de plantar",
+            "Selección de fustes rectos para uso maderable"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío clásico cafetero zona templada 100-250 árb/ha. Sistemas cacaoteros 80-150 árb/ha. Plantación maderable pura 400-600 árb/ha, turno 15-20 años.",
+          "tips": [
+            "Manejo de regeneración natural en cafetales (raleos selectivos)",
+            "Poda apical año 2-3 para corregir bifurcaciones",
+            "Madera con valor comercial: ebanistería, postes, instrumentos"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera de bosque secundario tropical. Colonización rápida de potreros abandonados.",
+          "tips": [
+            "Densidad 600-800 ind/ha asociado a Ochroma pyramidale",
+            "Tolera suelos pobres y compactados"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Sombrío cafetero clásico del Eje Cafetero colombiano. Copa rala estratificada permite paso de luz tamizada óptima para café. Hojas pequeñas aromáticas (olor a ajo al estrujarlas, de ahí 'alliodora') con descomposición rápida y aporte de N. Flores blancas pequeñas en panículas terminales, melíferas, atraen abejas y polinizadores. Núcula dispersada por viento permite regeneración natural espontánea. Madera marrón clara apreciada en ebanistería, postes, instrumentos musicales, canoas.",
+      "valor_pedagogico": "El nogal cafetero (Cordia alliodora (Ruiz & Pav.) Oken, Boraginaceae) es el árbol de sombrío más emblemático del paisaje cultural cafetero colombiano. Nativo del Neotrópico, en Colombia se distribuye en bosques húmedos a subhúmedos premontanos de toda la región Andina (Eje Cafetero: Quindío, Risaralda, Caldas; Antioquia, Cundinamarca, Tolima, Huila, Santander, Norte de Santander, Valle, Cauca, Nariño), Caribe (estribaciones Sierra Nevada, Serranía Perijá, Montes de María) y Pacífico entre 400 y 1.600 msnm en zona térmica cálida a templada. Árbol semicaducifolio de 15-25 m con fuste recto y copa rala estratificada en pisos horizontales característicos (de ahí 'estratificada'), hojas pequeñas alternas elíptico-lanceoladas que despiden olor a ajo al estrujarlas (epíteto 'alliodora' del griego 'allion' = ajo), flores blancas pequeñas en grandes panículas terminales muy melíferas que atraen abejas nativas y Apis mellifera, frutos pequeños tipo núcula con cáliz persistente acrescente que actúa como ala anemócora permitiendo dispersión por viento a decenas de metros (de ahí su regeneración espontánea masiva en potreros y cafetales del Eje). Es la lección viva del agroforestería cafetera colombiana: a diferencia del sombrío con especies exóticas (Grevillea robusta australiana, Inga densiflora introducida o Eucalyptus invasor), el nogal cafetero es nativo, no demanda manejo intensivo porque se regenera solo desde semilla anemócora del vecindario, tiene copa rala que deja pasar 30-50% de luz tamizada (ideal para café arábica de mediana sombra), descompone hojarasca rápido aportando N al suelo cafetero, produce madera de valor (ebanistería, postes, mangos de herramienta, canoas) que el caficultor puede aprovechar como reserva al final de la vida útil del cafetal, y atrae polinizadores que benefician al café y otros cultivos asociados. Cenicafé ha documentado densidades óptimas de 100-250 árboles/ha en cafetales tradicionales del Quindío y Risaralda. Es también pionera valiosa en restauración de bosque secundario: coloniza rápidamente potreros abandonados, tolera suelos pobres y prepara sitios para especies climácicas. Manejo agroecológico: aprovechar regeneración natural antes que plantar, raleos selectivos cada 5-7 años, podas apicales tempranas para corregir bifurcaciones, cosecha de madera a 15-20 años para diámetros >30 cm. Fuentes Tier A: Cenicafé manuales cafeteros, CATIE 1997 manual Cordia alliodora sistemas agroforestales, Trees of Antioquia, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF.",
+      "source_ids": [
+        "cenicafe-manual-cafetero-2013",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "coriandrum_sativum",
+      "nombre_comun": "Cilantro",
+      "nombre_cientifico": "Coriandrum sativum L.",
+      "familia_botanica": "Apiaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1000,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa escalonada cada 15 días para cosecha continua en la chagra."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El cilantro (Coriandrum sativum L.) es una aromática mediterránea naturalizada en Colombia, cultivada permanentemente en Cundinamarca entre 1000-2400 msnm en zonas térmicas templadas y frías. Su ciclo corto de 40-60 días permite cosechas escalonadas de hojas y semillas utilizadas en preparaciones culinarias tradicionales. Se propaga por siembra directa cada 15 días, prefiriendo medio-sombra en épocas cálidas, y se asocia beneficiosamente con repollo y zanahoria para reducir plagas como áfidos y trips. En el contexto andino campesino, su uso culinario se remonta a tiempos coloniales integrado en sofritos y guayos, mientras su cultivo sostenible evita sintéticos mediante manejo agroecológico. Fuentes: GBIF Taxonomic Backbone, POWO Kew, ICA Resolución 3168/2015.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "crotalaria_juncea",
+      "nombre_comun": "Sunn hemp",
+      "nombre_comunes_regionales": [
+        "crotalaria",
+        "cáñamo de la India",
+        "sunn",
+        "abono verde tropical",
+        "crotalaria juncea"
+      ],
+      "nombre_cientifico": "Crotalaria juncea L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "nitrogen_fixer",
+        "biomass_producer",
+        "ground_cover",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "agrosavia-tibaitata",
+        "agrosavia-leguminosas-andinas",
+        "agrosavia-forrajeras-2022",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La crotalaria o sunn hemp (Crotalaria juncea L., Fabaceae) es una leguminosa herbácea-subarbustiva anual de rápido crecimiento (1.5-3 m altura, ocasionalmente hasta 4 m) originaria del subcontinente indio, ampliamente naturalizada y adoptada por la agroecología tropical mundial e introducida en Colombia para usos como abono verde y fibra, presente en tierras cálidas y templadas entre 0 y 1.800 msnm en Caribe, valle del Cauca-Magdalena, Tolima-Huila, valles interandinos y zona cafetera. Hojas simples lanceoladas-estrechas alternas (5-12 cm), inflorescencias racimos terminales erectos con flores papilionáceas amarillas brillantes grandes (2-3 cm) muy atractivas para abejas melíferas, abejorros nativos (Bombus, Trigona, Melipona) y mariposas, frutos en legumbres infladas cilíndricas (3-5 cm) características de Crotalaria (de ahí el nombre del género 'crotalum' = sonajero, por las semillas que suenan dentro al madurar). Es lección viva de agroecología tropical y soberanía edáfica que enseña a niñas y niños el potencial transformador de los abonos verdes leguminosos en sistemas tropicales para regenerar suelos degradados sin insumos químicos: la crotalaria juncea es uno de los abonos verdes leguminosos más eficientes del trópico mundial documentado por FAO Ecocrop, Embrapa, IITA y Agrosavia, capaz de fijar 120-300 kg N/ha en un solo ciclo de 90-120 días (récord entre leguminosas anuales tropicales) gracias a su robusta simbiosis con Rhizobium específicos, produce 8-15 toneladas de biomasa fresca por hectárea (4-6 t materia seca) en 3-4 meses, suprime malezas agresivas por sombreado denso y alelopatía suave, controla nematodos parásitos del suelo (Meloidogyne incognita, Pratylenchus) por su acción antagonista de raíces, mejora estructura del suelo con su sistema radicular pivotante de penetración profunda (1-1.5 m) que rompe compactaciones y recicla nutrientes del subsuelo, y produce fibra de corteza de calidad fina usada históricamente en cordelería marina, papel, redes de pesca y textil grueso. Adoptada en Colombia por Agrosavia (Tibaitatá) y movimientos agroecológicos en transición a la agricultura regenerativa como cobertura de pre-siembra en algodón, caña, café joven, hortalizas comerciales y restauración de suelos compactados. Manejo agroecológico: propagación por semilla escarificada con agua tibia 12h (germinación 5-10 días, alta tasa), siembra directa al voleo o en surcos al inicio de lluvias, densidad 30-50 kg semilla/ha, incorporación al suelo a la floración (60-90 días después de siembra, momento de pico N foliar) por corte y volcado superficial o picado con guadaña, dejar 15-30 días en descomposición antes de siembra del cultivo principal, función como abono verde-cobertura-fijadora-fibrera de ciclo corto en rotaciones tropicales agroecológicas. Fuentes Tier A: GBIF, POWO Kew, FAO Ecocrop, Agrosavia Tibaitatá, Agrosavia Leguminosas Andinas, Agrosavia Forrajeras 2022, JBB Plantas Medicinales.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "cucumis_sativus",
+      "nombre_comun": "Pepino cohombro",
+      "nombre_cientifico": "Cucumis sativus L.",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 600,
+        "optimo_min": 600,
+        "optimo_max": 1600,
+        "max_absoluto": 1600
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima",
+        "graph_corpoica_suelo"
+      ],
+      "companions": [
+        "phaseolus_vulgaris",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cucurbita_maxima",
+      "nombre_comun": "Calabaza / Auyama",
+      "nombre_cientifico": "Cucurbita maxima Duchesne",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1000,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "helianthus_annuus",
+        "manihot_esculenta",
+        "phaseolus_vulgaris",
+        "solanum_tuberosum_sabanera",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "fenologia": [
+        {
+          "id": "feno_cosecha_cucurbita_maxima",
+          "nombre": "feno_cosecha_cucurbita_maxima",
+          "orden": 99
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cupressus_lusitanica",
+      "nombre_comun": "Ciprés",
+      "nombre_cientifico": "Cupressus lusitanica Mill.",
+      "familia_botanica": "Cupressaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 3200,
+        "max_absoluto": 3200
+      },
+      "source_ids": [
+        "graph_conif_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cymbopogon_citratus",
+      "nombre_comun": "Limonaria",
+      "nombre_cientifico": "Cymbopogon citratus (DC.) Stapf",
+      "familia_botanica": "Poaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2400,
+        "max_absoluto": 2400
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cymbopogon_nardus",
+      "nombre_comun": "Citronela",
+      "nombre_cientifico": "Cymbopogon nardus (L.) Rendle",
+      "familia_botanica": "Poaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "cynodon_plectostachyus",
+      "nombre_comun": "Pasto estrella gigante",
+      "nombre_cientifico": "Cynodon plectostachyus (K.Schum.) Pilg.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "daucus_carota_subsp_sativus",
+      "nombre_comun": "Zanahoria",
+      "nombre_cientifico": "Daucus carota L. subsp. sativus (Hoffm.) Arcang.",
+      "familia_botanica": "Apiaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1500,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 15,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa en suelo suelto y profundo. Germinacion lenta (14-21 dias); requiere humedad constante en la capa superficial."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La zanahoria (Daucus carota L. subsp. sativus (Hoffm.) Arcang., familia Apiaceae) es una apiácea bienal cultivada de raíz pivotante engrosada anaranjada (variedad Chantenay, Nantes, Imperator) a violeta (variedades ancestrales), domesticada desde la zanahoria silvestre euroasiática y aclimatada exitosamente en huertos andinos colombianos por su riqueza en β-caroteno (provitamina A), α-caroteno, luteína, fibra dietaria y azúcares simples. Se cultiva en Cundinamarca (Sabana de Bogotá, Funza, Madrid, Mosquera, Subachoque, Sopó), Boyacá (Tunja, Sotaquirá, Sutamarchán, Villa de Leyva, Cucaita), Nariño (Pasto, Sapuyes, Túquerres) y Eje cafetero alto entre 1.500 y 2.700 msnm en zona térmica templada a fría. Ciclo 90-120 días desde siembra a cosecha. Rendimientos 25-45 t/ha raíz fresca, primer cultivo hortícola por área en sabana de Bogotá. Lección viva de calidad y estructura del suelo: la zanahoria revela la estructura física del suelo al desarrollarse — suelos compactos, pedregosos o con costras superficiales producen raíces deformes, bifurcadas o cortas, enseñando la importancia crítica de la preparación profunda de cama (25-30 cm), aireación y descompactación previa, y la incorporación de materia orgánica fina y compostada. Es bioindicador de calidad de labranza y fertilidad estructural. Manejo agroecológico: siembra directa a chorrillo en surcos a 25 cm con cubierta superficial 0.5 cm de tierra fina, germinación lenta 14-21 días requiere humedad constante en capa superficial (riego frecuente y poco volumen), raleo en dos pases a los 30 y 45 días dejando 4-5 cm entre plantas, asocio con cebolla larga (Allium fistulosum) que repele mosca de la zanahoria (Psila rosae), rotación obligatoria 3 años. Fuentes Tier A: AGROSAVIA Manual Hortalizas, POWO Kew, GBIF Backbone Taxonomy, ICA Resolución 3168/2015, Bernal 2015 Catálogo Plantas Colombia.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "desmodium_intortum",
+      "nombre_comun": "Desmodium verde",
+      "nombre_cientifico": "Desmodium intortum (Mill.) Urb.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 500,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "dioscorea_alata",
+      "nombre_comun": "Name blanco",
+      "nombre_cientifico": "Dioscorea alata L.",
+      "familia_botanica": "Dioscoreaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 400,
+        "max_absoluto": 400
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "fenologia": [
+        {
+          "id": "feno_cosecha_dioscorea_alata",
+          "nombre": "feno_cosecha_dioscorea_alata",
+          "orden": 99
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "diplostephium_revolutum",
+      "nombre_comun": "Romero de páramo",
+      "nombre_cientifico": "Diplostephium revolutum S.F.Blake",
+      "familia_botanica": "Asteraceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 2800,
+        "optimo_min": 2800,
+        "optimo_max": 3800,
+        "max_absoluto": 3800
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "BATCH_2A_PASADA_2_RESIDUAL_2026-05-22 — reclasificación matiz nativa naturalizada problemática por eutrofización; sinonimia POWO formalizada; valor_pedagogico truncado a ~1900 chars (resto en nota_extendida).",
+      "_revisor": "claude-opus-4-7",
+      "id": "eichhornia_crassipes",
+      "_nombre_cientifico_actual_powo": "Pontederia crassipes Mart. (POWO/Kew post-2017; Pellegrini, Horn & Almeida 2018 PhytoKeys 108:25-83 reclasificación molecular y morfológica)",
+      "nombre_cientifico_powo": "Pontederia crassipes (Mart.) Solms",
+      "sinonimia_powo": [
+        "Eichhornia crassipes (Mart.) Solms (basónimo histórico)"
+      ],
+      "clasificacion_matiz": "nativa_naturalizada_problemática_por_eutrofización",
+      "nombre_comun": "Taruya",
+      "nombre_comunes_regionales": [
+        "buchón de agua",
+        "jacinto de agua",
+        "lirio acuático",
+        "camalote",
+        "water hyacinth"
+      ],
+      "nombre_cientifico": "Eichhornia crassipes (Mart.) Solms [sinónimo histórico; nombre POWO actual: Pontederia crassipes Mart.]",
+      "familia_botanica": "Pontederiaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "invasive",
+        "dynamic_accumulator",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": 1,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "pantanoso",
+      "drenaje_requerido": "pantanoso",
+      "propagation": {
+        "methods": [
+          "estolon",
+          "semilla",
+          "division_mata"
+        ],
+        "best_method": "estolon",
+        "protocol_resumen": "Propagación vegetativa explosiva por estolones que producen rosetas hijas cada 5-15 días — una sola planta puede generar >1000 individuos en 50 días. Semillas viables hasta 20 años en sedimento. NO PROPAGAR: especie invasora prohibida fuera de sistemas de fitorremediación controlados.",
+        "tiempo_a_establecimiento_dias": 10,
+        "notas": "Listada por ISSG entre las 100 peores invasoras del mundo. En Colombia colapsa cuerpos de agua: embalse del Muña, ciénagas del Magdalena, humedales de Bogotá. Solo se permite manejo en biorreactores cerrados de fitorremediación, NUNCA en aguas abiertas.",
+        "fuente": "IAvH Humboldt — Catálogo Especies Invasoras Andes; ISSG-UICN; POWO Kew; GBIF"
+      },
+      "especies_nativas_sustitutas": [],
+      "clasificacion_uicn": "Listada entre las 100 peores especies invasoras del mundo por ISSG/UICN (Global Invasive Species Database); IAvH-Humboldt la cataloga como invasora prioritaria de humedales colombianos con impacto severo en cuerpos de agua tropicales y subtropicales",
+      "protocolo_post_remocion": "Remoción mecánica por extracción manual o cosechadora acuática (NUNCA con herbicidas: riesgo de eutrofización masiva post-descomposición). Compostaje obligatorio del material removido fuera del cuerpo de agua durante 6 meses para garantizar inactivación de semillas y estolones residuales. Restauración activa del cuerpo de agua: re-oxigenación, control de aportes de N y P aguas arriba (causa raíz del crecimiento explosivo), reintroducción de macrófitas nativas (Limnobium laevigatum, Nymphoides humboldtiana). Monitoreo trimestral durante 5 años post-remoción para arrancar rosetas residuales antes de floración. Reporte obligatorio al SIB Colombia, IDEAM y CAR/Corporación Autónoma Regional jurisdiccional con coordenadas, área tratada y biomasa extraída.",
+      "rol_ecologico": "Macrófita flotante invasora de origen amazónico-orinoquense. Fitorremediadora poderosa (acumula N, P, metales pesados Cd-Pb-Zn-Hg en raíces y biomasa) PERO de crecimiento explosivo descontrolado en aguas eutroficadas: duplica su biomasa en 5-15 días. Colapsa la fauna acuática por sombreado total, anoxia subsuperficial y bloqueo de intercambio gaseoso aire-agua. Solo aprovechable en sistemas cerrados de fitorremediación con cosecha programada y deshidratación inmediata de biomasa para uso como compost activado, biogás o alimento porcino-piscícola controlado.",
+      "valor_pedagogico": "La taruya, buchón de agua o jacinto de agua (Pontederia crassipes (Mart.) Solms — basónimo Eichhornia crassipes (Mart.) Solms; Pontederiaceae) es nativa amazónica (cuenca alta Brasil/Bolivia/Colombia/Venezuela, Pantanal brasileño, llanos orinoquenses) donde coevoluciona con peces, manatíes y caimanes que la consumen y controlan. NO es invasora estricta: es nativa naturalizada que se vuelve problemática en cuerpos de agua eutrofizados por nutrientes urbanos/agrícolas, no por su naturaleza propia. Listada ISSG/UICN entre las 100 peores invasoras del mundo y por IAvH-Humboldt como prioridad de manejo en humedales colombianos eutroficados entre 0 y 1.800 msnm: ciénagas del Magdalena (Zapatosa, Ayapel), humedales de Bogotá (Jaboque, Juan Amarillo, Tibanica), embalse del Muña (caso paradigmático por contaminación con aguas residuales), humedales del Valle del Cauca, planicie inundable de la Orinoquia y lagunas costeras del Caribe. Su crecimiento explosivo (duplica biomasa en 5-15 días, una planta produce >1000 individuos en 50 días vía estolones + banco de semillas viable 20 años) provoca sombreado total, anoxia subsuperficial, colapso de fauna acuática y criadero de Anopheles/Mansonia. Paradójicamente es fitorremediadora extraordinaria de N, P y metales pesados (Cd, Pb, Zn, Hg, Cr) en biorreactores cerrados controlados. Manejo: REDUCIR N+P del agua aguas arriba (saneamiento básico, tratamiento de aguas residuales, prohibición de vertimientos industriales) — NO atacar la planta como problema raíz. Remoción mecánica en humedales invadidos (NUNCA herbicidas: riesgo de eutrofización masiva post-descomposición), compostaje termofílico 60°C × 6 meses, restauración con macrófitas nativas (Limnobium laevigatum, Nymphoides humboldtiana). Es lección viva de cómo las invasoras prosperan en sistemas degradados y de cómo restaurar humedales requiere sanear las cuencas. Fuentes Tier A: IAvH Humboldt Invasoras Andes, ISSG-UICN Global Invasive Species Database, POWO Kew, GBIF Backbone Taxonomy, Calderón-Sáenz 2003, Pellegrini Horn & Almeida 2018 PhytoKeys 108:25-83.",
+      "nota_extendida": "Detalle morfológico: pertenece a la familia Pontederiaceae y se reconoce por su roseta flotante con hojas redondeado-cordadas de 5-15 cm con pecíolos hinchados característicos (aerénquima espongioso lleno de aire que da flotabilidad), raíces fibrosas plumosas violetas-negruzcas sumergidas (10-50 cm de largo) e inflorescencia erecta espigada con 8-15 flores violeta-azuladas hermafroditas con un pétalo superior con mancha amarilla central rodeada de violeta — su belleza la convirtió en planta ornamental de exportación durante los siglos XIX-XX, lo cual disparó su naturalización global más allá de su rango nativo neotropical. Impactos destructores en humedales eutroficados: obstrucción de navegación y compuertas hidroeléctricas; criadero de Anopheles vector de malaria y Mansonia vector de filariasis. Uso CONTROLADO en biorreactores cerrados: acumula N, P, metales pesados (cadmio, plomo, zinc, mercurio, cromo), colorantes industriales y compuestos orgánicos tóxicos en raíces y biomasa con eficiencia 5-10 veces superior a macrófitas nativas; aplicable a fitorremediación de aguas residuales industriales (curtiembres, textileras, papeleras) con cosecha programada cada 2-4 semanas y deshidratación inmediata de biomasa para uso como compost activado, sustrato de biogás o alimento porcino-piscícola tratado. Aclaración taxonómica: Pellegrini, Horn & Almeida 2018 (PhytoKeys 108:25-83) recombinaron molecularmente Eichhornia → Pontederia. POWO/Kew adopta Pontederia crassipes como nombre canónico post-2017. El id `eichhornia_crassipes` se mantiene por refs cruzadas y familiaridad del usuario campesino colombiano.",
+      "advertencia_toxicologica": "NO consumir biomasa de cuerpos eutroficados ni biorreactores de fitorremediación: bioacumulación de metales pesados (Cd, Pb, Hg, Cr) y compuestos orgánicos tóxicos. Uso seguro restringido a compostaje termofílico 60+°C × 6 meses o biogás.",
+      "source_ids": [
+        "humboldt-invasoras-andes",
+        "issg-uicn-invasoras",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "calderon-saenz-2003-invasoras",
+        "sib-colombia"
+      ],
+      "tracking_mode": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "erythrina_edulis",
+      "nombre_comun": "Chachafruto / Balú",
+      "nombre_cientifico": "Erythrina edulis Triana ex Micheli",
+      "nombre_comunes_regionales": [
+        "Poroto andino",
+        "Fríjol de árbol",
+        "Pajuro"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "nurse_plant",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 120,
+      "estrato": "alto",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1600,
+        "optimo_max": 2400,
+        "max_absoluto": 2700
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "ph_suelo": {
+        "min": 5,
+        "optimo_min": 5.5,
+        "optimo_max": 7,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 4,
+        "notas": "Tolerancia moderada; los brotes jóvenes pueden verse afectados por heladas nocturnas."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "coffea_arabica",
+        "cedrela_odorata",
+        "cordia_alliodora",
+        "tabebuia_rosea"
+      ],
+      "antagonists": [
+        "ulex_europaeus"
+      ],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Germina rápidamente; el esqueje se usa principalmente para cercas vivas."
+      },
+      "valor_pedagogico": "El chachafruto (Erythrina edulis) se distribuye en los departamentos andinos de Colombia como Cundinamarca, Boyacá, Antioquia y Nariño entre 1200 y 2700 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con germinación rápida y uso de esquejes para cercas vivas, ciclo productivo de 8-12 meses, asociaciones beneficiosas con café y aliso que mejoran la fertilidad del suelo mediante fijación de nitrógeno, y requiere monitoreo de plagas como brotes de Scolytidae y Cerotoma spp. mediante biopreparados andinos. En el contexto campesino andino, sus semillas se utilizan tradicionalmente en preparaciones culinarias como source de proteína vegetal, aprovechando su alto contenido de lisina y triptófano, tal como documenta el Instituto Colombiano Agropecuario (ICA) en la Resolución 3168/2015 que establece normas para la producción y comercialización de especies forrajeras y alimenticias.",
+      "plagas_criticas": [
+        "Scolytidae",
+        "Cerotoma spp."
+      ],
+      "enfermedades_criticas": [
+        "Antracnosis foliar"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-chachafruto-2015",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "erythrina_fusca",
+      "nombre_comun": "Búcaro",
+      "nombre_cientifico": "Erythrina fusca Lour.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "espeletia_grandiflora",
+      "nombre_comun": "Frailejón mayor",
+      "nombre_cientifico": "Espeletia grandiflora Humb. & Bonpl.",
+      "familia_botanica": "Asteraceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 3200,
+        "optimo_min": 3200,
+        "optimo_max": 3800,
+        "max_absoluto": 3800
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "eucalyptus_globulus",
+      "nombre_comun": "Eucalipto blanco",
+      "nombre_comunes_regionales": [
+        "eucalipto blanco",
+        "eucalipto azul",
+        "eucalipto común",
+        "eucalipto de Tasmania"
+      ],
+      "nombre_cientifico": "Eucalyptus globulus Labill.",
+      "familia_botanica": "Myrtaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "emergente",
+      "habito": "árbol perennifolio 30-50 m, fuste recto con corteza decidua en placas, hojas juveniles glaucas y hojas adultas falcadas",
+      "origen": "Tasmania y sureste de Australia; introducido en Colombia desde finales del siglo XIX (ca. 1880) para reforestación industrial maderable y pulpa de papel",
+      "roles_in_guild": [
+        "invasive",
+        "biomass_producer"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "clasificacion_uicn": "Listada en ISSG/GISD Global Invasive Species Database; IAvH-Humboldt la cataloga como especie con alto impacto hídrico y alelopático en cuencas altoandinas colombianas",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Resolución 684/2018 MADS (lineamientos nacionales de prevención y manejo de invasoras forestales)",
+          "norma": "Resolución 684/2018 MADS",
+          "autoridad": "MADS",
+          "restriccion": "control_obligatorio_invasoras"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Ley 1930/2018 (prohibida en áreas delimitadas de páramo y zonas de recarga hídrica)",
+          "norma": "Ley 1930/2018",
+          "autoridad": "ICA",
+          "restriccion": "prohibida_paramos"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Resoluciones de CAR Cundinamarca y CORPOBOYACÁ que restringen su siembra en zonas de protección de nacederos y rondas hídricas",
+          "autoridad": "CAR"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "ICA Resolución 3168/2015 (regulación fitosanitaria de propágulos forestales)",
+          "norma": "Resolución 3168/2015",
+          "autoridad": "ICA",
+          "restriccion": "cuarentena_fitosanitaria"
+        }
+      ],
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Control de rebrote de cepa es crítico; requiere monitoreo por al menos 2 años."
+      },
+      "impacto_ecologico": "Alta demanda hídrica (~200-400 L/día por árbol maduro) que seca quebradas, nacederos y humedales en cuencas altas, comprometiendo la oferta hídrica para comunidades campesinas y ecosistemas dependientes; alelopatía severa por aceites esenciales foliares y radicales (1,8-cineol, citronelal, eucaliptol, alfa-pineno) que inhiben la germinación de flora nativa generando el característico 'desierto verde' sin sotobosque bajo el dosel; acidificación del suelo por hojarasca recalcitrante con C:N elevado y descomposición lenta; banco de semillas resistente al fuego y germinación masiva post-incendio que amplifica la invasión; reducción de biodiversidad de avifauna y entomofauna nativa por homogenización del hábitat; competencia directa con especies de bosque alto andino y subpáramo como encenillo (Weinmannia tomentosa), aliso (Alnus acuminata) y raque (Vallea stipularis).",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "cuencas_altas_andinas",
+        "rondas_hidricas",
+        "humedales_altoandinos",
+        "areas_de_reforestacion_industrial",
+        "bordes_de_via"
+      ],
+      "mecanismos_invasion": [
+        "banco_semillas_resistente_al_fuego",
+        "germinación_masiva_post_incendio",
+        "alelopatía_por_aceites_esenciales",
+        "rebrote_vigoroso_desde_tocón_y_lignotúber",
+        "dispersión_anemócora_de_semillas_aladas",
+        "competencia_por_agua_en_horizontes_profundos",
+        "acidificación_de_suelo_por_hojarasca"
+      ],
+      "metodos_extraccion": [
+        "anillado_de_corteza_ring_barking_sin_cosecha",
+        "decapitación_recurrente_de_rebrotes_de_tocón",
+        "extracción_de_lignotúber_con_retroexcavadora_en_individuos_jóvenes",
+        "corte_y_tratamiento_de_tocón_con_pasta_de_sal_y_cal_viva_si_se_autoriza",
+        "no_aprovechamiento_maderable_en_zonas_de_protección_hídrica"
+      ],
+      "epoca_optima_remocion": "Temporada seca del altiplano (diciembre-febrero y junio-agosto) cuando el árbol moviliza reservas y el anillado interrumpe el flujo descendente de fotosintatos; ANTES de la dispersión anemócora de semillas (julio-octubre en cordillera oriental); evitar intervención durante temporada lluviosa porque el rebrote es más vigoroso.",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata"
+      ],
+      "manejo_biomasa_extraida": "Madera maderable aprovechable como leña, postes o construcción rústica fuera de la zona invadida; hojarasca y ramas finas: secado al sol + incineración controlada (NO compostar in situ por persistencia de aceites esenciales alelopáticos que esterilizan el suelo); cápsulas con semillas: incineración obligatoria o trituración fina + disposición en relleno sanitario. NUNCA dejar hojarasca acumulada en sitio porque mantiene la alelopatía durante años post-corte.",
+      "riesgo_rebrote": "altísimo — el lignotúber subterráneo emite múltiples rebrotes vigorosos desde la base del tocón; el corte simple sin anillado previo ni tratamiento del tocón GARANTIZA recolonización clonal y mayor densidad de fustes que el árbol original",
+      "protocolo_post_remocion": "Restauración hídrica activa con nativas sustitutas (Alnus acuminata como fijador de N, Weinmannia tomentosa para estructura de bosque alto andino, Polylepis quadrijuga en cotas superiores) a 1100-1600 ind/ha al siguiente semestre lluvioso; remoción mecánica de hojarasca acumulada para acelerar restablecimiento de microbiota nativa del suelo; mulching con hojarasca de nativas para sombrear el suelo y favorecer germinación de banco de semillas nativo; monitoreo de caudales en quebradas y nacederos durante 3-5 años post-intervención; control bianual de rebrotes durante 5-7 años; reporte al SIB Colombia y a la autoridad ambiental jurisdiccional con coordenadas, área tratada y especies sustitutas establecidas.",
+      "source_ids": [
+        "humboldt-invasoras-andes",
+        "issg-uicn-invasoras",
+        "res-684-2018-mads",
+        "ley-1930-2018-paramos",
+        "ciat-1995-alnus",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "SE BUSCA: El 'Sediento de los Andes'. El eucalipto azul australiano (Eucalyptus globulus Labill., familia Myrtaceae) fue introducido en Colombia desde fines del siglo XIX para programas de reforestación industrial (madera y pulpa de papel) y se expandió como especie naturalizada problemática en altiplanos andinos. Se distribuye en Cundinamarca (Sabana de Bogotá), Boyacá (Tunja, Duitama, Sogamoso), Nariño, Antioquia y Eje cafetero entre 1.800 y 3.000 msnm. Árbol perenne 30-50 m altura, alta demanda hídrica (~200-400 L/día por árbol maduro) seca quebradas y nacederos en cuencas altas. Alelopatía severa por aceites esenciales (1,8-cineol, citronelal) inhibe germinación de flora nativa generando 'desierto verde' bajo dosel. Banco de semillas resistente al fuego. Estrategia de manejo agroecológico: anillado (ring-barking) sin cosecha + remplazo progresivo por Alnus acuminata (aliso andino nativo) o Polylepis quadrijuga (colorado) en sistemas silvopastoriles. Listada Res. 684/2018 MADS. Fuentes Tier A: Humboldt Invasoras Andes, ISSG-UICN Invasoras Globales, Resolución 684/2018 MADS, GBIF Backbone Taxonomy.",
+      "validation_level": "expert_reviewed",
+      "antagonists": [],
+      "tracking_mode": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "eucalyptus_grandis",
+      "nombre_comun": "Eucalipto",
+      "nombre_cientifico": "Eucalyptus grandis",
+      "familia_botanica": "Myrtaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2200,
+        "max_absoluto": 2200
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "eugenia_stipitata",
+      "nombre_comun": "Arazá",
+      "nombre_cientifico": "Eugenia stipitata McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 100,
+        "optimo_min": 100,
+        "optimo_max": 600,
+        "max_absoluto": 600
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "individual",
+      "fenologia": [
+        {
+          "id": "feno_cosecha_eugenia_stipitata",
+          "nombre": "feno_cosecha_eugenia_stipitata",
+          "orden": 99
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "foeniculum_vulgare",
+      "nombre_comun": "Hinojo",
+      "nombre_cientifico": "Foeniculum vulgare Mill.",
+      "familia_botanica": "Apiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "fragaria_ananassa_monterrey",
+      "nombre_comun": "Fresa Monterrey",
+      "nombre_cientifico": "Fragaria × ananassa 'Monterrey'",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "companions": [
+        "spinacia_oleracea"
+      ],
+      "tracking_mode": "individual",
+      "fenologia": [
+        {
+          "id": "feno_almacigo_fragaria_ananassa_monterrey",
+          "nombre": "Establecimiento de plántula (estolón/corona)",
+          "orden": "1"
+        },
+        {
+          "id": "feno_floracion_fragaria_ananassa_monterrey",
+          "nombre": "Floración",
+          "orden": "3"
+        },
+        {
+          "id": "feno_fructificacion_fragaria_ananassa_monterrey",
+          "nombre": "Fructificación y cosecha continua",
+          "orden": "4"
+        },
+        {
+          "id": "feno_poscosecha_fragaria_ananassa_monterrey",
+          "nombre": "Poscosecha",
+          "orden": "5"
+        },
+        {
+          "id": "feno_vegetativo_fragaria_ananassa_monterrey",
+          "nombre": "Desarrollo vegetativo (roseta)",
+          "orden": "2"
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "biol",
+            "nombre": "Biol",
+            "tipo": "fermentado",
+            "dosis": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "bocashi",
+            "nombre": "Bocashi",
+            "tipo": "fermentado",
+            "dosis": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "humus_liquido",
+            "nombre": "Humus líquido (lixiviado de lombriz)",
+            "tipo": "extracto",
+            "dosis": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "lixiviado_frutas",
+            "nombre": "Lixiviado de frutas",
+            "tipo": "fermentado",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "supermagro",
+            "nombre": "Supermagro",
+            "tipo": "fermentado",
+            "dosis": "Biofertilizante anaerobico fermentado 30-90 dias; se aplica DILUIDO, no puro. Dilucion foliar del 2% al 7% segun etapa (200-700 cc de supermagro por cada 10 L de agua). Inicio/general 3-5% (300-500 cc/10 L). Bomba de 20 L: 600 cc a 1 L. En cultivos sensibles empezar al 1-2% y subir. Tope de seguridad: no superar ~10% (riesgo de fitotoxicidad por exceso de Cu/Zn).",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "trichoderma_harzianum_suelo",
+            "nombre": "Trichoderma harzianum (aplicación al suelo)",
+            "tipo": "microbiano",
+            "dosis": "2 kg/ha al suelo humedo, o 10-20 g/L de agua para inmersion de semillas",
+            "source": "feeding_plan_template"
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "fraxinus_uhdei",
+      "nombre_comun": "Urapán",
+      "nombre_cientifico": "Fraxinus uhdei (Wenz.) Lingelsh.",
+      "familia_botanica": "Oleaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "furcraea_andina",
+      "nombre_comun": "Fique andino",
+      "nombre_cientifico": "Furcraea andina Trel.",
+      "familia_botanica": "Asparagaceae",
+      "category": "cercas_vivas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "galinsoga_parviflora",
+      "nombre_comun": "Guasca",
+      "nombre_cientifico": "Galinsoga parviflora Cav.",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1200,
+        "optimo_max": 3200,
+        "max_absoluto": 3200
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "glycine_max",
+      "nombre_comun": "Soya",
+      "nombre_cientifico": "Glycine max (L.) Merr.",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 900,
+        "max_absoluto": 900
+      },
+      "source_ids": [
+        "graph_fenalce_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "gossypium_hirsutum",
+      "nombre_comun": "Algodón",
+      "nombre_cientifico": "Gossypium hirsutum L.",
+      "familia_botanica": "Malvaceae",
+      "category": "fibras_no_maderables",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 800
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "guazuma_ulmifolia",
+      "nombre_comun": "Guácimo",
+      "nombre_cientifico": "Guazuma ulmifolia Lam.",
+      "familia_botanica": "Malvaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "hedyosmum_bonplandianum",
+      "nombre_comun": "Granizo",
+      "nombre_cientifico": "Hedyosmum bonplandianum Kunth",
+      "familia_botanica": "Chloranthaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1200,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "hevea_brasiliensis",
+      "nombre_comun": "Caucho",
+      "nombre_cientifico": "Hevea brasiliensis",
+      "familia_botanica": "Euphorbiaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 800
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "holcus_lanatus",
+      "nombre_comun": "Saboya",
+      "nombre_cientifico": "Holcus lanatus",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "hordeum_vulgare",
+      "nombre_comun": "Cebada",
+      "nombre_cientifico": "Hordeum vulgare L.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2100,
+        "optimo_min": 2100,
+        "optimo_max": 2700,
+        "max_absoluto": 2700
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "hylocereus_undatus",
+      "nombre_comun": "Pitaya blanca",
+      "nombre_cientifico": "Hylocereus undatus (Haw.) Britton & Rose",
+      "familia_botanica": "Cactaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 200,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 1500
+      },
+      "source_ids": [
+        "graph_agrosavia_servicio_analisis_suelo"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "inga_edulis",
+      "nombre_comun": "Guamo",
+      "nombre_cientifico": "Inga edulis Mart.",
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 1500,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Semilla recalcitrante; sembrar inmediatamente post-recolección. Rápida emergencia (7-14 días). También puede propagarse por estacas de ramas jóvenes."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El guamo (Inga edulis) se cultiva en departamentos colombianos como Valle del Cauca, Antioquia, Caldas, Quindío, Tolima y Huila entre 0 y 2000 msnm en zonas térmicas cálidas y templadas. Su manejo agronómico incluye propagación por semilla recalcitrante (sembrar inmediatamente post-recolección) con emergencia rápida de 7-14 días, ciclo productivo de 3-5 años hasta primera cosecha significativa, asociaciones tradicionales con cacao y café como especie sombreadora que fija nitrógeno atmosférico mediante simbiosis con rizobios, y requiere manejo de plagas como barrenadores de tallos y mosca de la fruta mediante monitoreo y poda fitosanitaria. En el contexto cultural campesino andino, esta leguminosa ha sido tradicionalmente utilizada como sombra de cacao y café, sus vainas contienen pulpa dulce comestible rica en azúcares naturales, y forma parte de sistemas agroforestales tradicionales que combinan producción con conservación de suelo. Según las fuentes taxonómicas verificadas de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Inga edulis Mart.",
+      "estrato": "alto",
+      "tracking_mode": "individual",
+      "companions": [
+        "cedrela_odorata",
+        "cordia_alliodora",
+        "swietenia_macrophylla",
+        "tabebuia_rosea",
+        "tabebuia_chrysantha",
+        "coffea_arabica"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "ipomoea_batatas",
+      "nombre_comun": "Batata / Camote",
+      "nombre_cientifico": "Ipomoea batatas (L.) Lam.",
+      "familia_botanica": "Convolvulaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1200,
+        "optimo_max": 2000,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje (bejuco)",
+        "notas": "Planta trepadora o rastrera de rápido crecimiento; requiere climas templados para desarrollar dulzor."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "La batata o camote (Ipomoea batatas (L.) Lam., familia Convolvulaceae) es una convolvulácea perenne rastrera cultivada como anual por sus raíces tuberosas dulces ricas en betacarotenos (precursores vitamina A) y carbohidratos complejos. Cultivo tradicional precolombino de los campesinos colombianos para seguridad alimentaria. Se cultiva en Cundinamarca (Tena, Tocaima, La Mesa, La Vega), Tolima, Huila, Valle del Cauca, Antioquia, Magdalena y Llanos Orientales entre 0 y 2.400 msnm en zona térmica cálida a templada. Lección viva de raíces reservantes: enseña cómo una planta rastrera puede concentrar la energía solar capturada por su follaje en forma de carbohidratos dulces almacenados bajo la tierra. Propagación por esquejes tallo (15-30 cm) plantados en caballón, ciclo 4-6 meses, rendimientos 15-30 t/ha. Manejo agroecológico: cama o caballón elevado para mejor desarrollo tubérculo, suelos francoarenosos drenados, asocio con maíz y frijol (chacra muisca), fertilización con compost al fondo + ceniza madera, rotación trienal anti-gorgojo (Cylas spp.) con trampas feromonales. Fuentes Tier A: ICA Resolución 3168/2015, AGROSAVIA Tubérculos Tropicales, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "jacaranda_caucana",
+      "nombre_comun": "Gualanday",
+      "nombre_cientifico": "Jacaranda caucana Pittier",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1600,
+        "max_absoluto": 1600
+      },
+      "source_ids": [
+        "graph_conif_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "lablab_purpureus",
+      "nombre_comun": "Frijol lablab / Haba bonavista",
+      "nombre_cientifico": "Lablab purpureus (L.) Sweet",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 600,
+        "optimo_min": 600,
+        "optimo_max": 1400,
+        "max_absoluto": 1400
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "lactuca_sativa",
+      "nombre_comun": "Lechuga",
+      "nombre_cientifico": "Lactuca sativa L.",
+      "familia_botanica": "Asteraceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima",
+        "graph_corpoica_suelo"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "bacillus_subtilis_foliar",
+            "nombre": "Bacillus subtilis (aplicación foliar)",
+            "tipo": "microbiano"
+          },
+          {
+            "id": "biol",
+            "nombre": "Biol",
+            "tipo": "fermentado",
+            "dosis": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad."
+          },
+          {
+            "id": "bocashi",
+            "nombre": "Bocashi",
+            "tipo": "fermentado",
+            "dosis": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato."
+          },
+          {
+            "id": "ceniza_vegetal_espolvoreo",
+            "nombre": "Ceniza vegetal espolvoreada en seco",
+            "tipo": "insecticida_repelente_mineral",
+            "dosis": "Espolvoreo en seco directo sobre el follaje y el suelo alrededor de la planta, preferiblemente con rocío matinal para que se adhiera. Dosis de campo: ~30-50 g por planta de hortaliza (un puñado), o al voleo cubriendo levemente las hojas. Repetir cada 7-10 días y SIEMPRE después de lluvia (se lava)."
+          },
+          {
+            "id": "humus_liquido",
+            "nombre": "Humus líquido (lixiviado de lombriz)",
+            "tipo": "extracto",
+            "dosis": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado."
+          },
+          {
+            "id": "purin_ortiga",
+            "nombre": "Purín de ortiga",
+            "tipo": "fermentado",
+            "dosis": "Maceracion/fermentacion: 1 kg de ortiga fresca (o 200 g seca) por 10 L de agua, fermentar 7-14 dias removiendo a diario hasta que deje de espumar. Purin fermentado bioestimulante foliar: diluir 1:10 a 1:20 (0,5-1 L por 10 L de agua); al suelo (drench) 1:10. Bomba de 20 L foliar: 1-2 L de purin. Macerado corto de 24-72 h (sin fermentar) como insecticida/repelente: 1:5."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "lactuca_sativa_capitata",
+      "nombre_comun": "Lechuga cogollo morada",
+      "nombre_cientifico": "Lactuca sativa var. capitata L.",
+      "familia_botanica": "Asteraceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -3,
+        "optimo_min": 14,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere sustrato fino y riego por nebulización en etapas tempranas; trasplante a los 25-30 días."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "ica-resolucion-3168-2015",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "valor_pedagogico": "La lechuga cogollo morada (Lactuca sativa var. capitata) es una hortaliza de hoja ampliamente cultivada en Colombia, especialmente en departamentos como Cundinamarca (cinturón productivo Choachí-Fómeque), Boyacá, Nariño y Santander, entre 800-3200 msnm en zonas térmicas fría y templada. Su manejo agronómico incluye propagación por semilla en semillero con sustrato fino, riego por nebulización en etapas tempranas, trasplante a los 25-30 días, ciclo de 60-90 días hasta cosecha, y asociaciones beneficiosas con Brassicaceae y Allium para repelencia de pulguilla. Plagas principales: pulgones (Myzus persicae), babosas (Deroceras reticulatum) y minadores (Liriomyza spp.). Culturalmente, aunque no es originaria del contexto muisca, se ha integrado en la agricultura andina contemporánea como cultivo de ciclo corto para seguridad alimentaria. Los cogollos morados deben su pigmentación a las antocianinas, pigmentos que actúan como protección natural contra radiación UV y estrés térmico. Fuente: nrc-1989-cultivos-andinos.",
+      "companions": [
+        "phaseolus_vulgaris",
+        "solanum_lycopersicum_san_marzano",
+        "fragaria_ananassa"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "libidibia_coriaria",
+      "nombre_comun": "Dividivi",
+      "nombre_cientifico": "Libidibia coriaria (Jacq.) Schltdl.",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1000
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "lolium_perenne",
+      "nombre_comun": "Raigras perenne",
+      "nombre_cientifico": "Lolium perenne L.",
+      "familia_botanica": "Poaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "festuca_arundinacea",
+        "medicago_sativa",
+        "trifolium_repens"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "luffa_cylindrica",
+      "nombre_comun": "Estropajo",
+      "nombre_cientifico": "Luffa cylindrica (L.) M.Roem.",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1500,
+        "max_absoluto": 1500
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "lupinus_mutabilis",
+      "nombre_comun": "Chocho / Tarwi",
+      "nombre_cientifico": "Lupinus mutabilis Sweet",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2400,
+        "optimo_max": 3000,
+        "max_absoluto": 3600
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 12,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Sus raíces son fijadoras masivas de nitrógeno; excelente abono verde si se incorpora antes de florecer."
+      },
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "cip-2006-ghislain",
+        "gbif-taxonomic-backbone",
+        "agrosavia-leguminosas-andinas"
+      ],
+      "valor_pedagogico": "El tarwi o chocho andino (Lupinus mutabilis Sweet) es una leguminosa nativa de los Andes con alto contenido proteico en grano (35-50%), tradicionalmente cultivada en sistemas campesinos altoandinos colombianos para autoconsumo (cosecha desamargada). Se cultiva en Boyacá (Tunja, Soatá, Ventaquemada), Cundinamarca (Sumapaz, Choachí), Nariño y Cauca entre 2.500 y 3.500 msnm en zona térmica fría a páramo bajo. Ciclo 6-8 meses, fijación N biológica ~100-160 kg N/ha. Granos con alcaloides amargos (quinolizidínicos) requieren desamargado tradicional (remojo + enjuagues). Manejo agroecológico: siembra al voleo en pre-cultivo (8-12 kg/ha), incorporación como abono verde o cosecha grano + restos al suelo, rotación con tubérculos andinos. Fuentes Tier A: AGROSAVIA Leguminosas Andinas, NRC 1989 Cultivos Andinos, POWO Kew, GBIF Backbone Taxonomy.",
+      "companions": [
+        "alnus_acuminata",
+        "zea_mays",
+        "solanum_tuberosum"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "macleania_rupestris",
+      "nombre_comun": "Uva camarona",
+      "nombre_cientifico": "Macleania rupestris (Kunth) A.C.Sm.",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2600,
+        "optimo_min": 2600,
+        "optimo_max": 3400,
+        "max_absoluto": 3400
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "maclura_tinctoria",
+      "nombre_comun": "Dinde",
+      "nombre_cientifico": "Maclura tinctoria (L.) D.Don ex Steud.",
+      "familia_botanica": "Moraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "malva_sylvestris",
+      "nombre_comun": "Malva",
+      "nombre_cientifico": "Malva sylvestris L.",
+      "familia_botanica": "Malvaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1000,
+        "optimo_max": 3200,
+        "max_absoluto": 3200
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "mangifera_indica",
+      "nombre_comun": "Mango",
+      "nombre_cientifico": "Mangifera indica L.",
+      "familia_botanica": "Anacardiaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "lechada_cal_troncos",
+            "nombre": "Lechada de cal (encalado de troncos)",
+            "tipo": "fungicida_repelente_mineral",
+            "dosis": "Pasta/lechada al 20-30%: 2 a 3 kg de cal apagada por cada 10 L de agua, hasta consistencia de pintura blanca. Aplicar con brocha al tronco y base de ramas principales 1-2 veces al año (inicio de época seca y/o tras la poda). Para árboles frutales y café: cubrir desde el cuello hasta ~1-1,5 m de altura."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "manihot_esculenta",
+      "nombre_comun": "Yuca brava amazónica",
+      "nombre_comunes_regionales": [
+        "yuca amarga",
+        "mandioca brava",
+        "casabe",
+        "fariña",
+        "yuca venenosa",
+        "tapioca"
+      ],
+      "nombre_cientifico": "Manihot esculenta Crantz",
+      "familia_botanica": "Euphorbiaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 800,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 36
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "estaca",
+        "notas": "Estacas de 20-25 cm de tallo maduro (1 año), sembradas en horizontal o inclinadas a 5-10 cm de profundidad. Cosecha de raíces tuberosas a 8-18 meses según ecotipo (yuca brava amazónica suele ser de ciclo largo 12-18 meses). La yuca amarga (alto contenido cianogénico, >100 mg HCN/kg fresco) requiere procesamiento obligatorio: rallado, prensado del manipueira (líquido amarillo tóxico) y tostado para fabricar casabe o fariña, lección milenaria de seguridad alimentaria indígena."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-manual-frutales-tropicales",
+        "sinchi-amazonia-colombiana",
+        "bernal-2015-plantas-liquenes-colombia",
+        "fao-ecocrop",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "valor_pedagogico": "La yuca brava amazónica o mandioca amarga (Manihot esculenta Crantz, familia Euphorbiaceae) es un arbusto leñoso (2-4 m altura) nativo de las tierras bajas de Sudamérica tropical, domesticada hace 8.000-10.000 años en el sudoeste de la cuenca amazónica (frontera Brasil-Bolivia, área de Rondônia) según evidencia arqueobotánica y genética (Olsen & Schaal 1999), considerada la cuarta fuente de carbohidratos para la humanidad después del arroz, el trigo y el maíz, y la base alimentaria milenaria de los pueblos amazónicos colombianos (tikuna, huitoto, bora, miraña, muinane, andoke, ocaina, yagua, kichwa, siona, kofán, secoya, inga, kamëntsá, makuna, yukpa, sikuani, piaroa). Existen dos grupos varietales tradicionales bien diferenciados: yuca dulce (mansa, bajo contenido de glucósidos cianogénicos <50 mg HCN/kg, consumo directo cocida) y yuca brava o amarga (alto contenido cianogénico 100-500 mg HCN/kg, requiere procesamiento elaborado para eliminar el ácido cianhídrico y transformarse en casabe, fariña o manicuera fermentada). El proceso tradicional indígena para procesar la yuca brava — rallado en tabla de aserrín de palma o concha, prensado en sebucán (cilindro tejido de palma con torsión gravitacional) para extraer el manipueira o yare (líquido amarillo cianhídrico tóxico), tamizado de la masa, tostado en budare o tiesto cerámico para hacer casabe (torta delgada) o fariña (granulado seco) — es uno de los logros etnoquímicos más sofisticados de la humanidad precolombina, comparable al procesamiento del maíz por nixtamalización mesoamericana. Lección viva: planta-pilar de la chagra amazónica colombiana que enseña cinco conceptos críticos: (1) la domesticación temprana de plantas tóxicas (yuca amarga) por pueblos amazónicos como ejemplo magistral de coevolución cultura-naturaleza, donde un cultivo venenoso se vuelve alimento básico mediante una tecnología procesual milenaria; (2) la diferencia entre yuca dulce y yuca brava como caso de selección artificial divergente — la yuca brava conserva su defensa cianogénica natural contra herbívoros y la cultura humana la procesa, mientras la yuca dulce ha perdido esa defensa por selección y se cultiva en zonas con menor presión de saqueo (ej. periurbano colombiano); (3) la chagra amazónica de yuca como sistema rotatorio milenario sostenible: tumba-pudre o slash-and-mulch, ciclo de 1-3 años de cultivo seguido de barbecho de 8-15 años, lección magistral de agricultura itinerante de bosque tropical sin uso de fuego en muchas variantes; (4) la soberanía alimentaria amazónica — el casabe y la fariña son alimentos vivos de la identidad cultural de pueblos como los huitoto, tikuna y bora, y la pérdida del manejo tradicional implica erosión cultural y genética simultánea (>200 variedades locales documentadas en chagras del trapecio amazónico colombiano por SINCHI); (5) la bioquímica defensiva vegetal: los glucósidos cianogénicos (linamarina, lotaustralina) liberan HCN al ser hidrolizados por la enzima linamarasa, lección de bioquímica de defensa estructural disociada espacialmente (los glucósidos en vacuola, la enzima en citoplasma, contacto solo al daño mecánico). Manejo agroecológico: siembra en chagras nuevas (tumba-pudre tradicional), asocio con plátano, piña, copoazú, ají, achiote, cocona; cosecha escalonada manual; cero agroquímicos; control biológico de Phenacoccus manihoti (cochinilla de la yuca) con Anagyrus lopezi (avispita brasileña). Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, GBIF Colombia, AGROSAVIA Manual Frutales Tropicales, Bernal 2015 Catálogo Plantas Colombia, SINCHI Amazonía, FAO EcoCrop, Pérez-Arbeláez 1947.",
+      "advertencia_toxicologica": "NUNCA consumir cruda variedades amargas (HCN 100-500 mg/kg → neurotoxicidad konzo, tropic ataxic neuropathy). Procesamiento tradicional obligatorio (rallado + prensado + tostado) elimina glucósidos cianogénicos. Variedades dulces (<50 mg HCN/kg) seguras tras cocción.",
+      "companions": [
+        "zea_mays",
+        "phaseolus_vulgaris",
+        "cajanus_cajan",
+        "musa_paradisiaca",
+        "plukenetia_volubilis"
+      ],
+      "plagas_criticas": [
+        "Phenacoccus manihoti (cochinilla harinosa de la yuca, controlada biológicamente con Anagyrus lopezi)",
+        "Mononychellus tanajoa (ácaro verde de la yuca)",
+        "Bemisia tuberculata / Aleurotrachelus socialis (mosca blanca, vector de virus)",
+        "Erinnyis ello (gusano cachón / cornudo de la yuca, defoliador)",
+        "Chilomima clarkei (barrenador del tallo)"
+      ],
+      "enfermedades_criticas": [
+        "Xanthomonas axonopodis pv. manihotis (bacteriosis / añublo bacterial de la yuca)",
+        "Phytophthora spp. (pudrición radical en suelos encharcados)",
+        "Sphaceloma manihoticola (superalargamiento)",
+        "Colletotrichum gloeosporioides f. sp. manihotis (antracnosis del tallo)",
+        "Mosaico/virosis de la yuca (complejo de geminivirus transmitido por mosca blanca y material de siembra)"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "matricaria_chamomilla",
+      "nombre_comun": "Manzanilla",
+      "nombre_comunes_regionales": [
+        "Camomila",
+        "Manzanilla dulce"
+      ],
+      "nombre_cientifico": "Matricaria chamomilla L.",
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Resiembra natural prolifica; las semillas germinan sobre la superficie del suelo con luz. Se recomienda no cubrirlas."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "bernal-2015-plantas-liquenes-colombia",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La manzanilla común o alemana (Matricaria chamomilla L., familia Asteraceae) es una asterácea anual herbácea originaria de Europa central y Asia occidental, naturalizada e cultivada extensamente en huertos andinos colombianos por sus inflorescencias en capítulo con flores liguladas blancas y disco amarillo, fuente del aceite esencial de manzanilla rico en α-bisabolol (10-50%), camazuleno (1-15%) y matricina, compuestos antiinflamatorios, antiespasmódicos y sedantes documentados. Se cultiva en Cundinamarca (Sabana de Bogotá, Subachoque, Cota), Boyacá (Tunja, Sotaquirá, Villa de Leyva), Nariño (Pasto, Túquerres), Antioquia (oriente cercano) y Eje cafetero entre 800 y 2.600 msnm en zona térmica templada a fría seca. Ciclo anual corto 90-120 días desde siembra a cosecha de flor. Rendimientos 0.4-0.8 t/ha flor seca. Lección viva: la infusión medicinal más antigua del mundo (documentada desde el Egipto faraónico y la medicina griega de Dioscórides), en la chagra muisca y campesina enseña el valor de las plantas indicadoras edáficas — su presencia abundante señala suelos compactados con baja porosidad que necesitan aireación mecánica o biológica, su autoresiembra prolífica enseña ciclos cortos, y sus capítulos atraen polinizadores nativos (Bombus spp., abejas Tetragonisca angustula) y enemigos naturales de plagas (Chrysoperla externa, sírfidos). Manejo agroecológico: siembra superficial sobre suelo desnudo sin cubrir semilla (requiere luz para germinar), asocio con cebolla y col, cosecha manual de capítulos en floración plena, secado a la sombra para conservar aceites esenciales, no requiere agroquímicos. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, AGROSAVIA, Bernal 2015 Catálogo Plantas Colombia, Pamplona-Roger 2006 Plantas Medicinales.",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "medicago_sativa",
+      "nombre_comun": "Alfalfa",
+      "nombre_cientifico": "Medicago sativa L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "festuca_arundinacea",
+        "lolium_perenne",
+        "trifolium_repens"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "BATCH_2A_PASADA_2_RESIDUAL_2026-05-22 — valor_pedagogico truncado de 4806 a ~1900 chars con resto en nota_extendida.",
+      "_revisor": "claude-opus-4-7",
+      "id": "melinis_minutiflora",
+      "nombre_comun": "Pasto gordura",
+      "nombre_comunes_regionales": [
+        "gordura",
+        "pasto melao",
+        "molasses grass",
+        "pasto chilenito"
+      ],
+      "nombre_cientifico": "Melinis minutiflora P.Beauv.",
+      "familia_botanica": "Poaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive",
+        "ground_cover"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 2400
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "gramínea perenne cespitosa-decumbente, 60-100 cm de altura, hojas pegajosas aromáticas",
+      "origen": "África tropical y subtropical; introducida en Brasil siglo XIX como forrajera y de allí difundida a Colombia",
+      "clasificacion_uicn": "Listada en ISSG/GISD Global Invasive Species Database; IAvH-Humboldt la cataloga como naturalizada de alto riesgo invasor en bosque seco tropical colombiano, bosque sub-andino y matorrales xerofíticos",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Resolución 684/2018 MADS la incluye en lineamientos de control en áreas de restauración del bosque seco tropical",
+          "norma": "Resolución 684/2018 MADS",
+          "autoridad": "MADS"
+        },
+        {
+          "tipo": "contexto_etnocultural",
+          "alcance": "IAvH-Humboldt la considera prioridad de manejo en BST y bosque sub-andino. Su siembra deliberada en áreas protegidas, zonas de amortiguamiento de PNN y áreas de restauración está desaconsejada técnicamente.",
+          "autoridad": "IAvH"
+        }
+      ],
+      "impacto_ecologico": "Forma masas densas que alteran el régimen de fuego en bosque seco tropical y matorrales xerofíticos colombianos: las hojas pegajosas-aromáticas son altamente inflamables y aumentan la intensidad y frecuencia de incendios estacionales, eliminando regeneración de árboles nativos del BST (Tabebuia, Caesalpinia, Bursera, Cordia, Pithecellobium) y favoreciendo sucesión hacia pradera dominada por la propia M. minutiflora; en bosque sub-andino del piedemonte (1.000-2.000 msnm) compite con sotobosque nativo y desplaza Calamagrostis, Festuca y otras gramíneas autóctonas; tras incendios el rebrote por estolones es masivo, generando bucle de retroalimentación fuego-invasión que es uno de los principales motores de degradación del BST y del piedemonte tropical en Colombia.",
+      "ecosistemas_afectados": [
+        "bosque_seco_tropical",
+        "bosque_subandino",
+        "matorrales_xerofiticos"
+      ],
+      "mecanismos_invasion": [
+        "Hojas pegajosas-aromáticas altamente inflamables que aumentan intensidad y frecuencia de incendios",
+        "Bucle de retroalimentación fuego-invasión: el fuego favorece M. minutiflora que aumenta combustible",
+        "Estolones que rebrotan masivamente post-fuego antes que árboles nativos",
+        "Semillas anemocoras que se dispersan por viento hasta cientos de metros",
+        "Tolerancia a sequía severa que le da ventaja en BST estacional",
+        "Compite con Calamagrostis effusa y otras gramíneas nativas en bosque sub-andino"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_manual_repetido",
+          "efectividad": "media",
+          "costo": "alto",
+          "notas": "Requiere extraer mata completa con sistema radicular; rebrote post-fuego es masivo."
+        },
+        {
+          "metodo": "fuego_controlado_invertido",
+          "efectividad": "baja",
+          "costo": "medio",
+          "notas": "NO recomendado: el fuego favorece a M. minutiflora frente a nativas. Evitar como método de control."
+        },
+        {
+          "metodo": "restauracion_con_sombra_arborea",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Plantación densa de árboles nativos del BST (Tabebuia, Caesalpinia, Pithecellobium, Cordia) que cierran dosel y suprimen el pasto por sombreo; método de largo plazo (5-10 años)."
+        }
+      ],
+      "epoca_optima_remocion": "Temporada lluviosa al inicio del rebrote, antes de floración",
+      "especies_nativas_sustitutas": [],
+      "manejo_biomasa_extraida": "compostaje termófilo >60°C por >3 semanas para destruir semillas; NUNCA quemar in situ (favorece a la especie)",
+      "riesgo_rebrote": "muy alto — la combinación de rebrote vegetativo post-fuego, banco de semillas en suelo y dispersión anemocora genera recolonización rápida si no se restaura con dosel arbóreo nativo cerrado",
+      "protocolo_post_remocion": "Restauración activa con plantación densa de árboles nativos del bosque seco tropical (Tabebuia rosea, Caesalpinia ebano, Pithecellobium dulce, Cordia gerascanthus, Bursera simarouba) a 400-600 ind/ha al inicio de la temporada lluviosa siguiente; mulching grueso con biomasa nativa por 12-18 meses para suprimir banco de semillas; monitoreo trimestral durante 3-5 años con eliminación manual inmediata de cualquier rebrote o plántula; reporte al SIB Colombia e IAvH-Humboldt con coordenadas y área tratada; NO usar fuego como herramienta de manejo (favorece a la especie).",
+      "altitud_msnm_validation": "cubre BST (500-1.000), bosque sub-andino (1.000-1.800) y borde de bosque alto andino (1.800-2.400)",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "estolon"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Naturalizada agresiva — su siembra deliberada como forrajera está desaconsejada técnicamente en Colombia por riesgo invasor. Propagación natural por semilla anemocora y rebrote estolonífero post-fuego.",
+        "tiempo_a_establecimiento_dias": 90,
+        "notas": "En los años 1950-70 se promovió como forrajera de altura por su aroma a melao y buen valor nutricional aparente; hoy su naturalización en BST, bosque sub-andino y matorrales xerofíticos colombianos la convierte en una de las invasoras más problemáticas del país.",
+        "fuente": "IAvH-Humboldt Invasoras Andes; ISSG/UICN Invasoras; POWO Kew; MADS Res 684/2018"
+      },
+      "companions": [],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Especie invasora prohibida de cultivo."
+        },
+        "huerto_casero": {
+          "viable": false,
+          "nota": "Especie invasora — su siembra deliberada está desaconsejada."
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable."
+        },
+        "produccion": {
+          "viable": false,
+          "nota": "Especie invasora — no apta para sistemas productivos. Su uso histórico como forrajera está superado por brachiaria y otras gramíneas no invasoras."
+        },
+        "restauracion": {
+          "viable": false,
+          "nota": "Especie objetivo de control activo en restauración de bosque seco tropical y bosque sub-andino."
+        }
+      },
+      "scale_viability": [],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Gramínea africana invasora de altísimo impacto en bosque seco tropical (BST), bosque sub-andino y matorrales xerofíticos colombianos. Modifica régimen de fuego: hojas pegajosas-aromáticas altamente inflamables generan bucle de retroalimentación fuego-invasión que degrada ecosistemas. Listada IAvH-Humboldt como prioridad de manejo.",
+      "valor_pedagogico": "El pasto gordura o melao (Melinis minutiflora P.Beauv., Poaceae) es una de las gramíneas invasoras más problemáticas del Neotrópico y, en Colombia, uno de los principales motores de degradación del bosque seco tropical (BST — ecosistema en categoría crítica nacional con apenas 8% de cobertura remanente) y del bosque sub-andino del piedemonte tropical. Originaria del África tropical (Etiopía-Tanzania-Sudáfrica), introducida a Brasil en el siglo XIX como forrajera por su aroma a melao y su palatabilidad aparente, difundida a Colombia entre 1950-1970 como 'forrajera de altura'. Hoy naturalizada agresivamente entre 500 y 2.400 msnm en BST (Caribe seco-húmedo, valles interandinos del Magdalena, Cauca, Patía), bosque sub-andino del piedemonte (Antioquia, Cundinamarca, Boyacá, Tolima, Huila, Santander, Valle del Cauca), matorrales xerofíticos (La Guajira, Tatacoa) y bordes del bosque alto-andino. Característica ecológica diferenciadora: modificación del régimen de fuego. Las hojas pegajosas contienen aceites terpénicos altamente inflamables que aumentan intensidad, velocidad de propagación y frecuencia de incendios estacionales; los árboles nativos del BST (Tabebuia, Caesalpinia, Pithecellobium, Bursera, Cordia) no están adaptados a regímenes de fuego intenso y son eliminados, mientras M. minutiflora rebrota masivamente desde estolones y banco de semillas post-fuego. Bucle de retroalimentación fuego-invasión convierte BST en sabana monoespecífica. Listada ISSG/GISD e IAvH-Humboldt; Res. 684/2018 MADS la incluye en lineamientos de control. Métodos: el desenraice manual repetido es efectivo en parches pequeños; el fuego controlado NO se recomienda (favorece a la especie); el método de mayor efectividad a largo plazo es la restauración activa con plantación densa de árboles nativos del BST que cierran dosel y suprimen el pasto por sombreo, complementado con mulching grueso y monitoreo trimestral 3-5 años. Lección ecológica fundamental: introducción exótica forrajera del siglo XIX se convierte en motor de degradación del BST, ecosistema en categoría crítica nacional. Fuentes Tier A: IAvH-Humboldt Invasoras Andes, ISSG/UICN, POWO Kew, GBIF, MADS Res. 684/2018, Bernal et al. 2015.",
+      "nota_extendida": "Detalle morfológico: gramínea perenne cespitosa-decumbente de 60-100 cm con macollas medianas, hojas lineares-lanceoladas con pubescencia glandular pegajosa que produce aroma a melao-canela (de ahí 'pasto gordura' — las hojas se sienten pegajosas-grasosas al tacto); inflorescencia en panícula amplia con espiguillas pequeñas vellosas; semillas pequeñas con pelos largos sedosos (carácter diagnóstico) que se dispersan por viento (anemocoria) a distancias de cientos de metros; propagación también por estolones rastreros post-disturbio. Contexto histórico forrajero: fue promovida entre 1950 y 1970 como 'forrajera de altura' para zonas templadas y sub-cálidas donde las brachiarias del piso cálido aún no llegaban. Hoy su siembra deliberada en áreas protegidas, zonas de amortiguamiento de PNN y áreas de restauración está desaconsejada técnicamente. Demuestra que la introducción de especies exóticas para fines productivos puede tener costos ecológicos de larga duración que superan ampliamente sus beneficios iniciales. Su control y la restauración del BST invadido es prioridad nacional de conservación ambiental.",
+      "source_ids": [
+        "humboldt-invasoras-andes",
+        "issg-uicn-invasoras",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "res-684-2018-mads",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "tracking_mode": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "melissa_officinalis",
+      "nombre_comun": "Toronjil",
+      "nombre_cientifico": "Melissa officinalis L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2700,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -15,
+        "optimo_min": 10,
+        "optimo_max": 20,
+        "max_tolerable": 27
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "medio",
+      "drenaje_requerido": "bueno_a_moderado",
+      "propagation": {
+        "metodo_principal": "division_mata",
+        "notas": "Fácil propagación vegetativa mediante la separación de macollos estacionales."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "Melissa officinalis, conocida como toronjil o melisa, se cultiva en Colombia en departamentos como Bogotá DC, Boyacá, Cauca, Cundinamarca, Huila, Santander y Valle del Cauca, entre 1200 y 2800 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación vegetativa mediante división de macollos estacionales, ciclo perenne de 2-3 años con podas de renovación, asociaciones beneficiosas con tomate y coles para confundir plagas mediante su aroma cítrico, y manejo de áfidos y trips mediante monitoreo y biopreparados andinos. En el contexto campesino andino, sus hojas se utilizan tradicionalmente en infusiones digestivas y calmantes, siendo parte del botiquín casero desde la época colonial para aliviar nerviosismo y trastornos del sueño. Según el inventario taxonómico de GBIF Backbone Taxonomy y Plants of the World Online (POWO), su nombre científico válido es Melissa officinalis L.",
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "mentha_spicata",
+      "nombre_comun": "Yerbabuena / Menta",
+      "nombre_cientifico": "Mentha spicata L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pest_repellent",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 500,
+        "optimo_max": 2600,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 12,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "propagation": {
+        "metodo_principal": "estolon",
+        "notas": "Muy invasiva; se recomienda controlar su crecimiento mediante barreras físicas o macetas."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "jbb-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La Mentha spicata (Labiada aromática) se cultiva perenne en huertas de Cundinamarca entre 500-2600 msnm en zonas térmicas cálidas, templadas y frías. Su propagación se realiza mediante esquejes y estolones, requiere control de invasividad mediante barreras físicas y se asocia beneficiosamente con tomate y repollo al repeler pulgón. En contexto campesino andino, su infusión digestiva (té de menta) se usa tradicionalmente para aliviar molestias gastrointestinales, aprovechando su aceite esencial rico en carvona y limoneno. Fuente taxonómica validada por GBIF Backbone Taxonomy y Plants of the World Online (POWO).",
+      "tracking_mode": "individual",
+      "companions": [],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "mirabilis_expansa",
+      "nombre_comun": "Mauka",
+      "nombre_cientifico": "Mirabilis expansa (Ruiz & Pav.) Standl.",
+      "familia_botanica": "Nyctaginaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 2700,
+        "optimo_min": 2700,
+        "optimo_max": 3500,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "moringa_oleifera",
+      "nombre_comun": "Moringa",
+      "nombre_cientifico": "Moringa oleifera",
+      "familia_botanica": "Moringaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1500,
+        "max_absoluto": 1500
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "mucuna_pruriens",
+      "nombre_comun": "Frijol terciopelo",
+      "nombre_comunes_regionales": [
+        "Mucuna",
+        "Pica-pica",
+        "Frijol abono"
+      ],
+      "nombre_cientifico": "Mucuna pruriens (L.) DC.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "nitrogen_fixer",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1500,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Siembra directa 2-3 semillas por sitio a 3-5cm de profundidad. Distancias 80x50cm. Densidad 20-25 kg/ha. Germinacion 5-10 dias. Ciclo 5-7 meses. Se incorpora al inicio de floracion como abono verde.",
+        "tiempo_a_establecimiento_dias": 45,
+        "notas": "Leguminosa trepadora anual de crecimiento vigoroso. Produce hasta 40 ton/ha de biomasa fresca. Fija 100-200 kg N/ha. Sus semillas contienen L-DOPA, compuesto usado en tratamiento del Parkinson.",
+        "fuente": "Restrepo Rivera 2005. Agroecologia colombiana"
+      },
+      "companions": [
+        "zea_mays",
+        "anacardium_occidentale"
+      ],
+      "antagonists": [],
+      "valor_pedagogico": "El abono verde mas potente del tropico: el frijol terciopelo produce biomasa masivamente y cubre el suelo como una alfombra viva, ensenando como las leguminosas tropicales restauran suelos degradados en climas calidos.",
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "restrepo-2005-agroecologia"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "musa_aaa_cavendish",
+      "nombre_comun": "Banano Cavendish",
+      "nombre_cientifico": "Musa AAA (subgrupo Cavendish)",
+      "familia_botanica": "Musaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 800,
+        "max_absoluto": 800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_augura_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "musa_paradisiaca",
+      "nombre_comun": "Plátano",
+      "nombre_cientifico": "Musa × paradisiaca L.",
+      "familia_botanica": "Musaceae",
+      "category": "frutales_perennes",
+      "estrato": "alto",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "tracking_mode": "aggregate",
+      "valor_pedagogico": "El plátano (Musa × paradisiaca, Musaceae) es híbrido cultivado entre Musa acuminata × Musa balbisiana, base alimentaria del campesinado colombiano. Variedades clave: Hartón (Caribe-Pacífico), Dominico Hartón (Eje cafetero), Cachaco (Antioquia), Comino, Pelipita, Manzano, Topocho. Hierba gigante 4-8 m altura (NO árbol — el tronco es pseudotallo formado por vainas foliares enrolladas), reproducción asexual por hijuelos basales (yemas del rizoma o cormo). Lección agroecológica de bioarquitectura única: el plátano se reproduce SOLO clonalmente desde siglo XIX (pérdida de semilla viable por triploidía estéril) — todas las matas son clones genéticos vulnerables a una sola plaga. Sigatoka negra (Mycosphaerella fijiensis) y Fusarium oxysporum f. sp. cubense raza 4 (Foc R4T) son amenazas globales. Manejo agroecológico: distancias 3x3 m a 4x4 m según variedad, sombrío con guamo en cafetal, deshije a 1 planta + 1 hijo + 1 nieto (cosecha continua), aplicación Trichoderma + bocashi al cuello del rizoma. Asocio multiestrato cafetero clásico.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual frutales tropicales + Cenicafé Manual cafetero (2013, asociación café-plátano). Plátano clima templado-cálido 0-1800 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 1500,
+            "notes": "Hoyo 40x40x40 cm. Sembrar colino con yema hacia arriba. Plátano gran demandante de K y MO."
+          },
+          {
+            "offset_days": 30,
+            "action": "Inocular Trichoderma harzianum",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 20,
+            "notes": "Preventivo Fusarium oxysporum f.sp. cubense (Mal de Panamá) — amenaza principal del cultivo a nivel global."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con biol al pie",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 1000,
+            "notes": "Dilución 1:5. Fase vegetativa activa — emisión de hojas verdaderas."
+          },
+          {
+            "offset_days": 120,
+            "action": "Foliar con supermagro fase reproductiva",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 80,
+            "notes": "Dilución 1:12. K y Mg críticos para llenado de racimo. Aportar también ceniza_madera al pie (100 g/planta)."
+          },
+          {
+            "offset_days": 180,
+            "action": "Refuerzo con bocashi pre-floración",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 1000,
+            "notes": "Aplicar en corona radicular antes de emisión de la inflorescencia (bellota)."
+          },
+          {
+            "offset_days": 240,
+            "action": "Foliar con caldo bordelés preventivo Sigatoka",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo Sigatoka negra (Mycosphaerella fijiensis) — aplicar cada 21 días en época lluviosa."
+          },
+          {
+            "offset_days": 330,
+            "action": "Drench con lixiviado de frutas durante llenado",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 200,
+            "notes": "Dilución 1:10. Llenado de racimo activo — cosecha esperada 360-390 días post-siembra."
+          }
+        ]
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "companions": [
+        "coffea_arabica",
+        "zea_mays",
+        "phaseolus_vulgaris",
+        "manihot_esculenta",
+        "cajanus_cajan",
+        "vanilla_planifolia",
+        "selenicereus_megalanthus",
+        "plukenetia_volubilis",
+        "bactris_gasipaes",
+        "annona_muricata"
+      ],
+      "plagas_criticas": [
+        "Cosmopolites sordidus (picudo negro del plátano, barrena el cormo)",
+        "Metamasius hemipterus (picudo rayado)",
+        "Opogona / barrenadores del pseudotallo",
+        "Nematodos (Radopholus similis, Pratylenchus, Helicotylenchus — daño radical y volcamiento)"
+      ],
+      "enfermedades_criticas": [
+        "Mycosphaerella fijiensis (Sigatoka negra) — enfermedad foliar #1, defolia y adelanta maduración",
+        "Fusarium oxysporum f. sp. cubense raza 4 tropical (Foc R4T / Mal de Panamá) — amenaza cuarentenaria devastadora",
+        "Ralstonia solanacearum raza 2 (moko del plátano, bacteriosis vascular)",
+        "Erwinia / Pectobacterium (pudrición acuosa del pseudotallo)",
+        "Virus del rayado del banano (BSV) y virus del mosaico"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "myrcianthes_leucoxyla",
+      "nombre_comun": "Arrayán de Bogotá",
+      "nombre_cientifico": "Myrcianthes leucoxyla (Ortega) McVaugh",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_protegido",
+      "altitud_msnm": {
+        "min_absoluto": 2500,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3200
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "myrcia_popayanensis",
+        "myrsine_coriacea"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "myrsine_guianensis",
+      "nombre_comun": "Cucharo de Guayana",
+      "nombre_cientifico": "Myrsine guianensis (Aubl.) Kuntze",
+      "familia_botanica": "Primulaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "nicotiana_tabacum",
+      "nombre_comun": "Tabaco",
+      "nombre_cientifico": "Nicotiana tabacum L.",
+      "familia_botanica": "Solanaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "ocimum_basilicum",
+      "nombre_comun": "Albahaca",
+      "nombre_cientifico": "Ocimum basilicum L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 400,
+        "optimo_min": 400,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima",
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "oreopanax_floribundum",
+      "nombre_comun": "Mano de oso",
+      "nombre_cientifico": "Oreopanax floribundum Decne. & Planch.",
+      "familia_botanica": "Araliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 1700,
+        "optimo_min": 1700,
+        "optimo_max": 2000,
+        "max_absoluto": 2000
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "alnus_acuminata",
+        "cedrela_montana",
+        "clethra_revoluta",
+        "coffea_arabica"
+      ],
+      "tracking_mode": "individual",
+      "fenologia": [
+        {
+          "id": "feno_cosecha_oreopanax_floribundum",
+          "nombre": "feno_cosecha_oreopanax_floribundum",
+          "orden": 99
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "origanum_vulgare",
+      "nombre_comun": "Orégano",
+      "nombre_cientifico": "Origanum vulgare L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 1200,
+        "optimo_max": 2200,
+        "max_absoluto": 2600
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "radiacion": "sol_pleno",
+      "agua": "bajo",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Propagación fácil por estacas de tallo o división de mata en época de lluvias."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "pamplona-roger-2006-plantas-medicinales",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El orégano común (Origanum vulgare L.) es una labiada perenne aromática originaria del Mediterráneo, ampliamente cultivada en huertas familiares y campesinas colombianas para uso culinario, medicinal y como repelente natural. Se cultiva en zonas frías y templadas: Sabana de Bogotá, Boyacá, Antioquia, Quindío, Caldas y Risaralda entre 1.200 y 2.800 msnm en zona térmica fría a templada. Propagación por estaca leñosa (60-80% prendimiento) o división de mata establecida. Ciclo perenne con vida productiva 4-6 años. Cortes graduales mensuales mantienen el porte compacto. Manejo agroecológico: cama elevada con drenaje excelente, suelos calcáreos pH 6.5-7.5, riego moderado (NO encharcamiento), asocio con tomate y pimentón (efecto repelente). Aceite esencial con carvacrol y timol confiere propiedades antibacterianas y antifúngicas. Fuentes Tier A: AGROSAVIA, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone Taxonomy.",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "oryza_sativa",
+      "nombre_comun": "Arroz",
+      "nombre_comunes_regionales": [
+        "arroz de riego",
+        "arroz secano",
+        "arroz paddy"
+      ],
+      "nombre_cientifico": "Oryza sativa L.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "grano",
+      "cycleMonths": 5,
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1300
+      },
+      "temperatura_c": {
+        "helada_letal": 5,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 38
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.5,
+        "optimo_max": 6.5,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bajo",
+      "companions": [],
+      "antagonists": [],
+      "_nota_antagonists": "Monocultivo dominante en Colombia (riego en Tolima/Huila/Meta/Casanare; secano en llanos y costa). Buena práctica agroecológica: rotación con leguminosa de cobertura (Crotalaria, soya, fríjol caupí) entre ciclos para fijar N y romper el ciclo de Tagosodes y nematodos; integración con peces/patos en arroz inundado (sistema rice-fish) para control biológico.",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Siembra directa al voleo o en hileras con semilla certificada (riego), o por trasplante de plántulas desde semillero (más común en pequeña escala/SRI). Densidad de siembra 150-200 kg/ha en voleo. Lámina de agua manejada por etapas en sistema de riego.",
+        "tiempo_a_establecimiento_dias": 15,
+        "notas": "Fenología por etapas (BBCH simplificado): (1) Germinación y plántula 0-15 días; (2) Macollamiento (ahijamiento) 15-45 días — definición del número de tallos productivos; (3) Inicio de primordio / fase reproductiva (encañe) 45-65 días; (4) Embuchamiento y emergencia de la panícula (floración/antesis) 65-90 días — etapa crítica de agua y la más sensible a daño por Tagosodes y vaneamiento; (5) Llenado de grano (lechoso → pastoso) 90-115 días; (6) Maduración y cosecha 115-150 días. El arroz de riego mantiene lámina de agua; el secano depende de lluvia.",
+        "fuente": "FEDEARROZ Manual técnico del cultivo de arroz (2018)."
+      },
+      "plagas_criticas": [
+        "Tagosodes orizicolus (sogata, vector del Virus de la Hoja Blanca — plaga #1 en Colombia)",
+        "Spodoptera frugiperda (cogollero/gusano ejército)",
+        "Hydrellia spp. (mosca minadora de la hoja)",
+        "Oebalus spp. (chinche del grano, causa vaneamiento y manchado)",
+        "Diatraea saccharalis (barrenador del tallo)"
+      ],
+      "enfermedades_criticas": [
+        "Pyricularia oryzae (añublo / quema del arroz / blast) — enfermedad fúngica #1",
+        "Virus de la Hoja Blanca (VHB) transmitido por Tagosodes orizicolus",
+        "Rhizoctonia solani (añublo de la vaina)",
+        "Burkholderia glumae (añublo bacterial de la panícula, agravado por calor)",
+        "Helminthosporium / Bipolaris oryzae (mancha parda)"
+      ],
+      "source_ids": [
+        "fedearroz-manual-arroz-2018",
+        "fao-ecocrop",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El arroz (Oryza sativa L., familia Poaceae) es el cereal de mayor consumo per cápita en Colombia y el alimento básico de la dieta nacional, cultivado en tierra caliente entre 0 y 1.000 msnm bajo dos grandes sistemas: arroz de riego (con lámina de agua controlada) en el Tolima, Huila, Meta y Casanare, y arroz secano (de temporal, dependiente de lluvia) en los Llanos Orientales, el Bajo Cauca y la Costa Caribe. Domesticado hace más de 8.000 años en Asia, es una gramínea semiacuática cuya particularidad fisiológica es la tolerancia a la inundación gracias a tejidos aerénquima que llevan oxígeno a la raíz sumergida. Su fenología pasa por germinación, macollamiento (cuando define el número de tallos productivos), fase reproductiva con la emergencia de la panícula y antesis —la etapa más sensible a la falta de agua y al daño de plagas—, llenado de grano y maduración, en un ciclo de 4-5 meses. El mayor problema fitosanitario del arroz colombiano es el complejo sogata-Virus de la Hoja Blanca: el insecto Tagosodes orizicolus transmite un virus devastador, por lo que el manejo se centra en variedades resistentes y en evitar siembras escalonadas que mantengan poblaciones del vector. Le siguen el añublo o quema (Pyricularia oryzae), hongo que ataca hoja, cuello y panícula, el añublo bacterial (Burkholderia glumae) agravado por el calor nocturno, y plagas como el cogollero y los chinches que vanean el grano. Manejo agroecológico de transición: rotación con leguminosas de cobertura entre ciclos para fijar nitrógeno y cortar el ciclo de plagas; manejo eficiente del agua para reducir emisiones de metano del arroz inundado; integración rice-fish o con patos para control biológico de insectos y malezas; uso de Trichoderma y Bacillus contra hongos; y semilla certificada de variedades resistentes a sogata. El arroz enseña la gestión del agua como eje del cultivo y el reto ambiental de un sistema que, mal manejado, es gran emisor de metano y gran consumidor de agroquímicos. NOTA DE VERIFICACIÓN: las variedades comerciales y umbrales económicos de plaga deben consultarse en la ficha oficial vigente de FEDEARROZ/AGROSAVIA antes de decisiones de campo. Fuentes: FEDEARROZ Manual técnico del arroz 2018, FAO Ecocrop, GBIF Backbone, POWO Kew.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "oryza_sativa_fedearroz_2000",
+      "nombre_comun": "Arroz Fedearroz 2000",
+      "nombre_cientifico": "Oryza sativa L.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 500,
+        "max_absoluto": 500
+      },
+      "source_ids": [
+        "graph_fedearroz_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "oxalis_tuberosa",
+      "nombre_comun": "Oca / Hibia",
+      "nombre_comunes_regionales": [
+        "Hibia",
+        "Ibias"
+      ],
+      "nombre_cientifico": "Oxalis tuberosa Molina",
+      "familia_botanica": "Oxalidaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2800,
+        "optimo_max": 3400,
+        "max_absoluto": 3800
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 8,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo",
+        "notas": "Fenologia: siembra de tuberculo semilla, emergencia, crecimiento rastrero, floracion ocasional, tuberizacion con dias cortos, maduracion y cosecha."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "ica-resolucion-3168-2015",
+        "doi-2025-oca-narino-agrosavia",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La oca o hibia (Oxalis tuberosa) es un tuberculo andino de clima frio y altoandino, conservado en chagras y huertas campesinas de Nariño, Cauca, Boyaca y Cundinamarca. Su fenologia incluye siembra de tuberculo semilla, emergencia, crecimiento rastrero, floracion ocasional, tuberizacion inducida por dias cortos, maduracion y cosecha. Es pedagogica porque ayuda a comparar tuberculos andinos distintos de la papa y a explicar diversidad alimentaria, fotoperiodo y conservacion de semilla local. Plagas y enfermedades clave incluyen gusanos de suelo, babosas, pulgones como vectores, pudriciones bacterianas y pudriciones en almacenamiento si el tuberculo entra humedo.",
+      "plagas_criticas": [
+        "Gusanos de suelo",
+        "Babosas",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Pudricion bacteriana",
+        "Pudricion en almacenamiento"
+      ],
+      "harvest_type": "tuberculo",
+      "cycleMonths": 7,
+      "companions": [
+        "solanum_tuberosum",
+        "ullucus_tuberosus"
+      ],
+      "antagonists": [],
+      "tracking_mode": "aggregate",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "passiflora_edulis_flavicarpa",
+      "nombre_comun": "Maracuyá",
+      "nombre_cientifico": "Passiflora edulis f. flavicarpa Deg.",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1300,
+        "max_absoluto": 1300
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "passiflora_edulis_morada",
+      "nombre_comun": "Gulupa",
+      "nombre_cientifico": "Passiflora edulis f. edulis Sims",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2300,
+        "max_absoluto": 2300
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "companions": [
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "biol",
+            "nombre": "Biol",
+            "tipo": "fermentado",
+            "dosis": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "bocashi",
+            "nombre": "Bocashi",
+            "tipo": "fermentado",
+            "dosis": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "caldo_bordeles",
+            "nombre": "Caldo bordelés",
+            "tipo": "caldo",
+            "dosis": "Caldo madre al 1% para 10 L: 100 g de sulfato de cobre pentahidratado + 100 g de cal. Disolver el cobre en agua tibia (recipiente NO metalico) y la cal aparte; verter el cobre sobre la lechada de cal (NUNCA al reves) y aforar a 10 L. Relacion 1:1:100 = 1 kg cobre : 1 kg cal : 100 L. Prueba del clavo o pH neutro-alcalino antes de aplicar (el clavo no debe cobrizarse). Hortalizas tiernas: 0,5% (50 g + 50 g / 10 L). Bomba de 20 L al 1%: 200 g sulfato + 200 g cal. Listo para aplicar SIN diluir.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "humus_liquido",
+            "nombre": "Humus líquido (lixiviado de lombriz)",
+            "tipo": "extracto",
+            "dosis": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado.",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "lixiviado_frutas",
+            "nombre": "Lixiviado de frutas",
+            "tipo": "fermentado",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "supermagro",
+            "nombre": "Supermagro",
+            "tipo": "fermentado",
+            "dosis": "Biofertilizante anaerobico fermentado 30-90 dias; se aplica DILUIDO, no puro. Dilucion foliar del 2% al 7% segun etapa (200-700 cc de supermagro por cada 10 L de agua). Inicio/general 3-5% (300-500 cc/10 L). Bomba de 20 L: 600 cc a 1 L. En cultivos sensibles empezar al 1-2% y subir. Tope de seguridad: no superar ~10% (riesgo de fitotoxicidad por exceso de Cu/Zn).",
+            "source": "feeding_plan_template"
+          },
+          {
+            "id": "trichoderma_harzianum_suelo",
+            "nombre": "Trichoderma harzianum (aplicación al suelo)",
+            "tipo": "microbiano",
+            "dosis": "2 kg/ha al suelo humedo, o 10-20 g/L de agua para inmersion de semillas",
+            "source": "feeding_plan_template"
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "passiflora_ligularis",
+      "nombre_comun": "Granadilla",
+      "nombre_cientifico": "Passiflora ligularis Juss.",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 2400,
+        "max_absoluto": 2400
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "passiflora_tripartita_mollissima",
+      "nombre_comun": "Curuba de Castilla",
+      "nombre_cientifico": "Passiflora tripartita var. mollissima (Kunth) Holm-Niels. & Jørg.",
+      "familia_botanica": "Passifloraceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "alnus_acuminata",
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "pennisetum_glaucum",
+      "nombre_comun": "Mijo perla",
+      "nombre_cientifico": "Pennisetum glaucum (L.) R.Br.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_fenalce_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "persea_americana",
+      "nombre_comun": "Aguacate",
+      "nombre_cientifico": "Persea americana Mill.",
+      "familia_botanica": "Lauraceae",
+      "category": "frutales_perennes",
+      "estrato": "alto",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 2200,
+        "max_absoluto": 2500
+      },
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "tracking_mode": "individual",
+      "valor_pedagogico": "El aguacate (Persea americana Mill., Lauraceae) es uno de los frutales nativos americanos más importantes y emblemáticos de la agricultura colombiana, con producción concentrada en Antioquia, Tolima, Caldas, Quindío, Risaralda, Valle del Cauca y Cundinamarca. Variedades dominantes en Colombia: Hass (mayoritaria exportación), Lorena, Choquette, Booth, Trapp, criollos antillanos. Cultivo perenne 3-30 m altura con sistema radical superficial sensible a encharcamiento — requiere drenaje EXCELENTE (suelos francos a franco-arenosos, pH 5.5-6.5). Floración tipo A/B con dicogamia (mecanismo de polinización cruzada que requiere coexistencia de tipos florales A y B para fructificación máxima — lección agroecológica de biodiversidad funcional). Manejo: trasplante 6-8 meses post-vivero, distancia 7x7 m (Hass) a 9x9 m (criollos), tutorado primer año, poda de formación años 2-4, cosecha desde año 3-5 hasta año 25+. Plagas: trips (Frankliniella), ácaros, monalonion. Enfermedades graves: Phytophthora cinnamomi (muerte de la raíz), antracnosis, mancha negra. Manejo agroecológico: Trichoderma harzianum + sombrío de guamo (Inga edulis) reduce 70% Phytophthora. Asocio clásico: café-aguacate-plátano en sistema multiestrato cafetero.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual frutales tropicales + Pérez-Arbeláez (1947) Plantas útiles de Colombia. Aguacate clima templado-cálido 1000-2200 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al hoyo de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 2000,
+            "notes": "Hoyo 60x60x60 cm. Mezclar 2 kg de bocashi con suelo del hoyo. Aguacate sensible a encharcamiento — drenaje crítico."
+          },
+          {
+            "offset_days": 30,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 30,
+            "notes": "Preventivo crítico contra Phytophthora cinnamomi (tristeza del aguacate) — patógeno principal de la especie."
+          },
+          {
+            "offset_days": 90,
+            "action": "Drench con biol fase vegetativa",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 1500,
+            "notes": "Dilución 1:5, 1.5 L al pie. Año 1 establecimiento — crecimiento foliar activo."
+          },
+          {
+            "offset_days": 180,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo antracnosis (Colletotrichum gloeosporioides) en hojas y frutos."
+          },
+          {
+            "offset_days": 365,
+            "action": "Refuerzo anual con bocashi en corona",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 3000,
+            "notes": "Año 1 completo. Aplicar bajo la corona en banda, no contra el tronco. Cubrir con mulch."
+          },
+          {
+            "offset_days": 730,
+            "action": "Foliar con supermagro pre-floración",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 100,
+            "notes": "Año 2 — preparar floración. Dilución 1:10. Aporte Zn y B críticos para cuajado de aguacate."
+          },
+          {
+            "offset_days": 1095,
+            "action": "Aplicar Bacillus subtilis foliar fructificación",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 30,
+            "notes": "Año 3 primera cosecha esperada. Control biológico antracnosis post-cuajado."
+          }
+        ]
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "agrosavia-manual-frutales-tropicales",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "persea_caerulea",
+      "nombre_comun": "Aguacatillo",
+      "nombre_cientifico": "Persea caerulea (Ruiz & Pav.) Mez",
+      "familia_botanica": "Lauraceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1000,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "petroselinum_crispum",
+      "nombre_comun": "Perejil crespo",
+      "nombre_cientifico": "Petroselinum crispum (Mill.) Fuss",
+      "familia_botanica": "Apiaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "phaseolus_vulgaris",
+      "nombre_comun": "Frijol arbustivo / voluble",
+      "nombre_cientifico": "Phaseolus vulgaris L.",
+      "nombre_comunes_regionales": [
+        "Frijol cargamanto",
+        "Bola roja",
+        "Frijol recal"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nitrogen_fixer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 4,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 16,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6,
+        "optimo_max": 7,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Altamente sensible a heladas; requiere protección o siembra en épocas seguras."
+      },
+      "companions": [
+        "lactuca_sativa_capitata",
+        "zea_mays",
+        "musa_paradisiaca",
+        "manihot_esculenta",
+        "solanum_tuberosum"
+      ],
+      "antagonists": [
+        "allium_fistulosum"
+      ],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Inocular con Rhizobium para optimizar la fijación de nitrógeno."
+      },
+      "valor_pedagogico": "El frijol común (Phaseolus vulgaris L.) es un fijador de nitrógeno esencial en sistemas agrícolas andinos, contribuyendo con 50-80 kg N/ha mediante simbiosis con Rhizobium leguminosarum. En Colombia se cultiva ampliamente en departamentos como Cundinamarca (cinturón productivo Fómeque-Choachí), Boyacá y Nariño, entre 800-2800 msnm en zonas térmicas fría, templada y cálida. Varietales destacados incluyen Cargamanto, Bola Roja y Radical. Su manejo agronómico incluye propagación por semilla, ciclo de 3-4 meses, asociación tradicional en el sistema '3 hermanas' con maíz y ahuyama, y requiere monitoreo de plagas como Empoasca kraemeri y Bemisia tabaci. Culturalmente, ha sido parte fundamental de la dieta muisca y campesina andina desde época precolombina, utilizado en preparaciones como sopas, guisos y harinas. Fuente: nrc-1989-cultivos-andinos.",
+      "plagas_criticas": [
+        "Empoasca kraemeri",
+        "Apion godmani",
+        "Bemisia tabaci"
+      ],
+      "enfermedades_criticas": [
+        "Colletotrichum lindemuthianum (antracnosis)",
+        "Uromyces appendiculatus"
+      ],
+      "source_ids": [
+        "nrc-1989-cultivos-andinos",
+        "agrosavia-leguminosas-andinas",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "physalis_angulata",
+      "nombre_comun": "Uchuva silvestre / Topotopo",
+      "nombre_cientifico": "Physalis angulata L.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_nd_institucional_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "physalis_peruviana",
+      "nombre_comun": "Uchuva",
+      "nombre_cientifico": "Physalis peruviana L.",
+      "familia_botanica": "Solanaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 25
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Planta perenne de corta vida (2-3 años productivos); requiere tutorado para facilitar la cosecha y evitar hongos por humedad."
+      },
+      "source_ids": [
+        "agrosavia-manual-uchuva-2015",
+        "powo-kew",
+        "agrosavia-leguminosas-andinas"
+      ],
+      "valor_pedagogico": "La uchuva (Physalis peruviana L.) es una solanácea perenne nativa de los Andes ahora cultivada comercialmente para exportación. Colombia es el principal exportador mundial con cerca de 1.000 hectáreas en Cundinamarca (Granada, Silvania, Pasca), Boyacá (Ventaquemada), Antioquia (Sonsón) y Nariño entre 1.800 y 2.800 msnm en zona térmica fría a templada. La variedad AGROSAVIA Andina es la más adoptada, con ciclo productivo 8-10 meses y rendimientos 18-25 t/ha. Crece como arbusto perenne con cáliz papiráceo que envuelve la baya naranja madura. Manejo agroecológico: tutorado vertical, poda de formación, manejo integrado de Tuta absoluta (polilla) y Liriomyza huidobrensis (minador hoja) con biopreparados como BT y purín de ortiga, fertilización con bocashi + biol. Fuentes Tier A: AGROSAVIA Manual Uchuva, ICA Resolución 3168/2015, POWO Kew, GBIF Backbone.",
+      "estrato": "bajo",
+      "antagonists": [],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "pisum_sativum_andina",
+      "nombre_comun": "Arveja andina",
+      "nombre_cientifico": "Pisum sativum L. var. andina",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "solanum_tuberosum"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "inoculante_rhizobium_frijol",
+            "nombre": "Inoculante de Rhizobium para fríjol (fijación de nitrógeno)",
+            "tipo": "inoculante_microbiano",
+            "dosis": "APLICACIÓN A SEMILLA: humedecer la semilla con adherente y mezclar con el inoculante a la dosis de etiqueta (típico ~5-10 g de inoculante en turba por kg de semilla, o según producto), recubrir uniformemente y sembrar a la sombra el mismo día. No exponer la semilla inoculada al sol ni demorar la siembra (los rizobios mueren)."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "plantago_major",
+      "nombre_comun": "Llantén mayor",
+      "nombre_comunes_regionales": [
+        "llantén",
+        "llantén común",
+        "siete venas",
+        "lengua de oveja",
+        "plántago"
+      ],
+      "nombre_cientifico": "Plantago major L.",
+      "familia_botanica": "Plantaginaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "ground_cover",
+        "dynamic_accumulator"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "pamplona-roger-2006-plantas-medicinales",
+        "jbb-plantas-medicinales",
+        "perez-arbelaez-1947-plantas-utiles",
+        "bernal-2015-plantas-liquenes-colombia"
+      ],
+      "valor_pedagogico": "El llantén mayor (Plantago major L., Plantaginaceae) es una hierba perenne acaule cosmopolita de origen euroasiático, naturalizada en todo el mundo y presente en climas templados, fríos y de subpáramo en Colombia (2.000-3.000 msnm: altiplano cundiboyacense, Nariño, Antioquia, Santander, Tolima, Boyacá), reconocible por su roseta basal de hojas ovado-elípticas (5-20 cm) con 5-9 nervaduras paralelas longitudinales prominentes muy características (de ahí el nombre 'siete venas'), y espigas erectas cilíndricas densas de 10-30 cm con flores diminutas blanco-verdosas. Es lección viva de plantas-aliadas-de-caminos y cicatrización vegetal que enseña a niñas y niños por qué una planta humilde pisada por todos puede ser la farmacia portátil más reconocida del mundo: el llantén crece en bordes de senderos, potreros, patios de escuelas, parques y huertos justamente porque tolera la compactación del suelo, y desde el inicio del mestizaje cultural en América Indígenas, campesinos y curanderos lo adoptaron como cicatrizante universal para picaduras de insectos, quemaduras leves, heridas pequeñas, úlceras bucales y dolor de oído (machacar una hoja fresca, aplicar directamente sobre la herida). Sus mucílagos (aucubina, alantoína, taninos, ácido ursólico) tienen acción antiinflamatoria, antimicrobiana y cicatrizante validada farmacognosticamente por la OMS, JBB-Bogotá, Pérez-Arbeláez (1947) y Pamplona-Roger. Uso tradicional ampliamente documentado: infusión de hojas como expectorante y antitusivo para bronquitis, tos seca, faringitis; jarabe de llantén con miel para tos crónica; cataplasma de hojas para picaduras de avispas, abejas, mosquitos, ortigas; gargarismo de cocimiento para llagas bucales; lavados oculares suaves para conjuntivitis leves. Las semillas son ricas en mucílago (similar al psyllium del Plantago ovata) y se usan como regulador intestinal suave. Manejo agroecológico: propagación por semilla (germinación 14-21 días) o trasplante de roseta con raíz, autosiembra natural prolifera donde el suelo está compactado, función como cobertura tolerante a pisoteo, acumuladora dinámica de calcio-magnesio-potasio (excelente para compost activador), bioindicadora de suelos compactados y nitrogenados, planta refugio de coccinélidos benéficos. Cultivable en cualquier huerto pedagógico como botiquín verde de primeros auxilios — siempre debe lavarse antes de usar por contaminación de borde de camino. Fuentes Tier A: GBIF, POWO Kew, Pamplona-Roger 2006, JBB Plantas Medicinales, Pérez-Arbeláez 1947, Bernal 2015.",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "plukenetia_volubilis",
+      "nombre_comun": "Sacha inchi",
+      "nombre_comunes_regionales": [
+        "Mani del Inca",
+        "Sacha inchik"
+      ],
+      "nombre_cientifico": "Plukenetia volubilis L.",
+      "familia_botanica": "Euphorbiaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 900,
+        "max_absoluto": 1500
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 30,
+        "max_tolerable": 35
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Fenologia: germinacion, fase vegetativa voluble, floracion, cuajado de capsulas estrelladas, llenado de semilla oleaginosa y cosecha escalonada de capsulas secas."
+      },
+      "source_ids": [
+        "sinchi-aprovechemos-sacha-inchi",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El sacha inchi (Plukenetia volubilis) es una euforbiacea trepadora amazonica cultivada por semillas oleaginosas ricas en aceites alimentarios. En Colombia encaja en clima calido humedo de Amazonia y piedemontes con tutorado, drenaje bueno y cosecha escalonada. Su fenologia incluye germinacion, crecimiento voluble, floracion, formacion de capsulas estrelladas, llenado de semillas y secado para cosecha. Es pedagogico porque conecta agroforesteria amazonica, valor agregado local y manejo de trepadoras comerciales. Plagas y enfermedades clave reportadas en sistemas tropicales incluyen hormigas cortadoras, acaros, chinches, nematodos, manchas foliares y pudriciones radiculares en suelos mal drenados.",
+      "plagas_criticas": [
+        "Hormigas cortadoras",
+        "Acaros",
+        "Chinches",
+        "Nematodos"
+      ],
+      "enfermedades_criticas": [
+        "Manchas foliares",
+        "Pudricion radicular"
+      ],
+      "harvest_type": "semilla",
+      "cycleMonths": null,
+      "companions": [
+        "musa_paradisiaca",
+        "manihot_esculenta"
+      ],
+      "antagonists": [],
+      "tracking_mode": "aggregate",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "poraqueiba_sericea",
+      "nombre_comun": "Umarí",
+      "nombre_cientifico": "Poraqueiba sericea Tul.",
+      "familia_botanica": "Metteniusaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 80,
+        "optimo_min": 80,
+        "optimo_max": 500,
+        "max_absoluto": 500
+      },
+      "source_ids": [
+        "graph_instituto_sinchi_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "portulaca_oleracea",
+      "nombre_comun": "Verdolaga",
+      "nombre_cientifico": "Portulaca oleracea L.",
+      "familia_botanica": "Portulacaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2200,
+        "max_absoluto": 2200
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "psidium_guajava",
+      "nombre_comun": "Guayaba",
+      "nombre_cientifico": "Psidium guajava L.",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima",
+        "graph_ica_suelo"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "pteridium_aquilinum",
+      "_curation_status": "BATCH_2A_PASADA_2_RESIDUAL_2026-05-22 — reclasificación matiz: nativa pantropical (NO introducida); clasificacion_matiz=nativa_expansiva_post_disturbio. Mantiene category=especies_invasoras + conservation_status=invasor para no romper AMB-14 (enum schema todavía no soporta nativa_expansiva). Auditoría 2026-05-21 confirmó POWO nativa de Colombia.",
+      "_revisor": "claude-opus-4-7",
+      "clasificacion_matiz": "nativa_expansiva_post_disturbio",
+      "nombre_comun": "Helecho marranero",
+      "nombre_comunes_regionales": [
+        "helecho marranero",
+        "helecho águila",
+        "helecho común"
+      ],
+      "nombre_cientifico": "Pteridium aquilinum (L.) Kuhn",
+      "autor_ano": "Kuhn, 1879 (combinación); L. 1753 como Pteris aquilina",
+      "familia_botanica": "Dennstaedtiaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "_nota_conservacion": "Especie con distribución cosmopolita; en Colombia se comporta como invasor agresivo post-disturbio. Tóxica para ganado y potencialmente cancerígena (ptaquiloside).",
+      "habito": "helecho rizomatoso 0.5-2m",
+      "origen": "Cosmopolita (taxón complejo de distribución mundial; en Colombia var. caudatum y var. arachnoideum se comportan como invasoras agresivas post-disturbio en zonas andinas)",
+      "clasificacion_uicn": "Categorizada como 'invasora transformadora' (transformer species) por la categoría Richardson et al. en literatura ecológica internacional; IAvH la lista en plataformas de invasoras de Colombia por su agresividad post-fuego en ecosistemas andinos",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Lineamientos nacionales para prevención, manejo integral y restauración de áreas afectadas; P. aquilinum referenciado en protocolos de restauración post-incendio en bosque altoandino y subpáramo",
+          "norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible",
+          "autoridad": "MADS",
+          "restriccion": "prohibida_paramos"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Marco regulatorio para restauración de complejos paramunos donde el helecho marranero es invasora prioritaria post-disturbio (incendios, ganadería)",
+          "norma": "Ley 1930 de 2018 (Páramos)",
+          "restriccion": "control_obligatorio_invasoras"
+        },
+        {
+          "tipo": "contexto_etnocultural",
+          "alcance": "Riesgo sanitario reconocido para ganado bovino (intoxicación enzoótica hematúrica, carcinogénesis); recomendación de erradicación en potreros activos",
+          "norma": "ICA - normativa sanitaria pecuaria",
+          "autoridad": "ICA"
+        }
+      ],
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 3500,
+        "max_absoluto": 4000
+      },
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo_intervenido",
+        "potreros_degradados",
+        "cicatrices_fuego"
+      ],
+      "mecanismos_invasion": [
+        "Rizomas profundos (hasta 1m) y extensos resistentes a remoción mecánica; banco de yemas latentes",
+        "Producción masiva de esporas con dispersión eólica de larga distancia (banco de esporas durmiente en suelo)",
+        "Alelopatía: rizomas y frondes liberan compuestos fenólicos que inhiben germinación de nativas",
+        "Tolerancia y favorecimiento por fuego: rebrota vigorosamente desde rizoma post-quema mientras nativas mueren",
+        "Compuestos tóxicos (ptaquilósido, tiaminasa, ácido prúsico) desalientan herbivoría por ganado y fauna silvestre permitiendo monopolización del estrato bajo",
+        "Establecimiento agresivo en suelos compactados, pisoteados o post-incendio donde la regeneración nativa está inhibida"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "media",
+          "costo": "alto",
+          "notas": "Rizomas profundos y extensos dificultan extracción total; requiere EPP completo (guantes, mascarilla N95, manga larga) por riesgo de ptaquilósido en savia y esporas"
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "alta",
+          "costo": "medio",
+          "notas": "Corte mensual durante 2-3 temporadas agota reservas del rizoma; método preferido en áreas extensas; usar EPP por exposición a esporas"
+        },
+        {
+          "metodo": "sombra_forzada",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Plantación de especies arbóreas nativas que den sombra densa; el helecho es intolerante a sombra cerrada; preferido como estrategia de largo plazo combinada con corte inicial"
+        },
+        {
+          "metodo": "fuego_controlado",
+          "efectividad": "NEGATIVA",
+          "costo": "bajo",
+          "notas": "PROHIBIDO: el fuego estimula rebrote vigoroso del rizoma y elimina competidoras nativas; empeora la invasión y aumenta exposición de fauna y humanos a ptaquilósido en cenizas"
+        }
+      ],
+      "epoca_optima_remocion": "Previo a formación de frondes maduras y antes de esporulación (temporada lluviosa temprana). Evitar manejo durante esporulación (frondes maduras café-doradas) por riesgo respiratorio. Usar EPP en toda manipulación.",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada",
+      "_nota_manejo": "Evitar contacto prolongado sin protección (esporas potencialmente cancerígenas). No usar como forraje ni cama para ganado. Manipulación SIEMPRE con EPP (guantes, mascarilla N95, manga larga, gafas). NO compostar (las esporas y ptaquilósido sobreviven compostaje doméstico). NO entierro superficial: incineración controlada en sitio autorizado o entierro a >1m de profundidad con cubierta de cal. NUNCA quemar in situ junto a viviendas, escuelas o corrales por riesgo de inhalación de humo con compuestos tóxicos.",
+      "riesgo_rebrote": "muy_alto",
+      "_nota_riesgo_sanitario": "RIESGO SANITARIO ELEVADO: ptaquilósido es carcinógeno comprobado en humanos (cáncer gástrico, esofágico, vejiga) por exposición directa o vía leche de ganado pastoreado en zonas invadidas. Tiaminasa causa intoxicación aguda en bovinos (síndrome hemorrágico, hematuria enzoótica bovina). En zonas rurales con invasión consolidada: NO permitir pastoreo bovino, NO consumir leche cruda local, NO usar agua de manantiales sin tratamiento. Comunicar riesgo a comunidad antes de remoción.",
+      "protocolo_post_remocion": "Restauración activa obligatoria: siembra de especies nativas competidoras de rápido crecimiento (Alnus acuminata, Weinmannia tomentosa, Miconia squamulosa) en densidad 1600 ind/ha al siguiente semestre lluvioso para forzar sombra. Cobertura del suelo con mulch grueso para suprimir esporas en banco superficial. Monitoreo trimestral de rebrotes por 5 años; corte inmediato de cualquier fronde emergente (NO permitir formación de frondes maduras). Año 2-3: revisar establecimiento de dosel arbóreo (>50% cobertura) para asegurar exclusión por sombra. Mantener exclusión de ganado por mínimo 3 años.",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Pteridium_aquilinum",
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "flora-colombia-pteridophyta",
+        "humboldt-invasoras-andes",
+        "res-684-2018-mads",
+        "ley-1930-2018-paramos",
+        "restauracion-cruz-verde-sumapaz",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El helecho marranero (Pteridium aquilinum (L.) Kuhn, Dennstaedtiaceae) es NATIVA pantropical (cosmopolita). NO es introducida — POWO confirma estatus nativo en Colombia. Tendencia expansiva en suelos degradados post-fuego, sobrepastoreo y deforestación, particularmente en potreros andinos (1500-3200 msnm) donde rizomas profundos rebrotan post-disturbio y forman monocultivos densos que impiden regeneración del bosque andino. La Resolución 684/2018 MADS la lista para control en áreas protegidas (Cruz Verde-Sumapaz, Iguaque, bordes de páramo degradado) PORQUE desplaza la regeneración natural del bosque, NO porque sea invasora exótica. Distinción crítica: el comportamiento expansivo es post-disturbio biogeografíamente nativo, no introducción exógena. Manejo: restauración ecológica activa (siembra de especies nativas competidoras: Weinmannia tomentosa, Hesperomeles goudotiana, Miconia squamulosa, Alnus acuminata, Vallea stipularis a 1600 ind/ha), NO erradicación; corte mecánico repetido 3-5 años + sombra forzada por dosel arbóreo; NUNCA fuego controlado (estimula rebrote del rizoma). RIESGO SANITARIO ELEVADO: ptaquilósido carcinogénico para ganado y humanos por exposición directa o leche contaminada — no permitir pastoreo bovino en zonas con invasión consolidada, manipulación SIEMPRE con EPP (guantes, mascarilla N95). Fuentes Tier A: POWO Kew (nativo Colombia), IAvH Humboldt Invasoras Andes (control post-disturbio), Resolución 684/2018 MADS, GBIF Backbone Taxonomy, Flora Colombia Pteridophyta.",
+      "tracking_mode": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "puya_goudotiana",
+      "nombre_comun": "Cardón de páramo",
+      "nombre_cientifico": "Puya goudotiana Mez",
+      "familia_botanica": "Bromeliaceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 2500,
+        "optimo_min": 2500,
+        "optimo_max": 3500,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "graph_iavh_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "quararibea_cordata",
+      "nombre_comun": "Zapote",
+      "nombre_cientifico": "Quararibea cordata (Bonpl.) Vischer",
+      "familia_botanica": "Malvaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1000,
+        "max_absoluto": 1000
+      },
+      "source_ids": [
+        "graph_instituto_sinchi_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "raphanus_sativus",
+      "nombre_comun": "Rábano",
+      "nombre_cientifico": "Raphanus sativus L.",
+      "familia_botanica": "Brassicaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "rosmarinus_officinalis",
+      "nombre_comun": "Romero",
+      "nombre_cientifico": "Salvia rosmarinus Spenn. (syn. Rosmarinus officinalis L.)",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1000,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo",
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "dahlia_imperialis",
+        "lavandula_dentata",
+        "monarda_didyma",
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "rubus_glaucus",
+      "nombre_comun": "Mora andina / Mora de Castilla",
+      "nombre_cientifico": "Rubus glaucus Benth.",
+      "familia_botanica": "Rosaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor",
+        "living_fence"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1800,
+        "optimo_max": 2600,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 13,
+        "optimo_max": 18,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "acodo",
+        "notas": "Propagacion por acodo de punta o esqueje. La forma silvestre presenta espinas; requiere tutorado en espaldera. Produce frutos a partir del segundo ano."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-colombia",
+        "agrosavia-tibaitata",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "La espina que protege: la mora silvestre ensena que las defensas naturales de las plantas tienen un proposito. Su cultivo en espaldera muestra como la agricultura domestica sin eliminar la esencia silvestre.",
+      "feeding_plan_template": {
+        "source": "Agrosavia Tibaitatá — fichas frutales andinos + Pinheiro-Machado (2017) Biofertilizantes. Manejo mora castilla clima frío 1800-2600 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + roca fosfórica al hoyo",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 400,
+            "notes": "Hoyo 40x40 cm. Mora requiere P alto al establecimiento — combinar con roca_fosforica si suelo deficiente."
+          },
+          {
+            "offset_days": 30,
+            "action": "Foliar con biol fase de brotación",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Estimula brotación lateral de cañas productivas."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 300,
+            "notes": "Dilución 1:4. Aporta micro flora y aminoácidos antes de cuajado."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo Botrytis cinerea y Peronospora — críticos en mora altiplano lluvioso."
+          },
+          {
+            "offset_days": 120,
+            "action": "Aplicar lixiviado de frutas en fructificación",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10 drench. Mora produce cosecha sostenida — refuerza llenado de fruto."
+          },
+          {
+            "offset_days": 180,
+            "action": "Refuerzo con bocashi post-poda",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 200,
+            "notes": "Después de poda sanitaria. Renueva tejido productivo para próximo flush."
+          }
+        ]
+      },
+      "validation_level": "claude_draft",
+      "companions": [
+        "urtica_dioica"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "saccharum_officinarum",
+      "nombre_comun": "Caña panelera",
+      "nombre_cientifico": "Saccharum officinarum L.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 800,
+        "optimo_max": 2000,
+        "max_absoluto": 2000
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "metarhizium_anisopliae",
+            "nombre": "Metarhizium anisopliae (hongo entomopatógeno verde)",
+            "tipo": "control_biologico",
+            "dosis": "MADRE: producto comercial ~1x10^9 conidios/g. DILUCIÓN DE APLICACIÓN: 1-2 g/L (bomba de 20 L: 20-40 g) para foliar; al suelo (control de chizas y picudos) 1-2 kg/ha de producto en drench o incorporado, equivalente a ~2x10^12-1x10^13 conidios/ha. Aplicar al atardecer y mantener humedad."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "salvia_hispanica",
+      "nombre_comun": "Chía",
+      "nombre_comunes_regionales": [
+        "chía mexicana",
+        "chía blanca",
+        "chía negra",
+        "chía nutracéutica"
+      ],
+      "nombre_cientifico": "Salvia hispanica L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 600,
+        "optimo_min": 1400,
+        "optimo_max": 2200,
+        "max_absoluto": 2500
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 15,
+        "optimo_max": 25,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra directa al voleo o en líneas. Germinación 4-8 días a 20-25°C. Distancia 30-40 cm en línea, 50-60 cm entre líneas. Ciclo 4-6 meses a cosecha de semilla. Anual. Floración fotoperiódica de día corto — siembra en abril-mayo para floración octubre-noviembre en hemisferio norte tropical."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-frutales-tropicales",
+        "bernal-2015-plantas-liquenes-colombia",
+        "pamplona-roger-2006-plantas-medicinales"
+      ],
+      "valor_pedagogico": "La chía (Salvia hispanica L., Lamiaceae) es una planta nutracéutica milenaria originaria de México central y Guatemala (no de los Andes a pesar del nombre 'hispanica' que se debe a un error de Linneo que creyó que provenía de España), cultivada ancestralmente por aztecas y mayas precolombinos como uno de los cuatro pilares alimentarios mesoamericanos junto a maíz, fríjol y amaranto. En Colombia se cultiva con creciente expansión comercial y huerto-casero en zonas andinas medias-cálidas de Cundinamarca (Tena, La Mesa), Tolima (Espinal, Guamo, Chaparral), Huila (Pitalito, La Plata, San Agustín), Antioquia (Suroeste, Oriente cálido), Santander (Mesa de los Santos), Valle del Cauca (Restrepo) entre 600 y 2.500 msnm en zonas térmicas templadas y cálidas, expandida significativamente desde 2010 por la demanda mundial de superalimentos. Pertenece a la familia Lamiaceae (igual que albahaca, orégano, romero, menta, hierbabuena, mejorana, salvia, tomillo) y al género Salvia (el más diverso de las Lamiaceae con >900 especies globales) — distinta evolutivamente de la salvia común (S. officinalis L.) aunque comparten género. Planta herbácea anual de 1-1.5 m de altura con tallos cuadrangulares pubescentes característicos de Lamiaceae, hojas opuestas decusadas ovales-lanceoladas dentadas verde-oscuro, espigas terminales de flores azul-violáceas o blancas pequeñas en verticilastros muy atractoras de abejas y abejorros (cultivo melífero adicional), frutos en tetraquenios de los que se cosechan las 'semillas de chía' — pequeñas (1-2 mm), ovaladas, color blanco-crema (chía blanca) o gris-negro moteado (chía negra), oleaginosas con altísimo contenido nutricional. La composición de la semilla la convierte en superalimento: 30-35% aceite (con 60-65% omega-3 alfa-linolénico, la mayor concentración vegetal conocida), 20-25% proteína completa (con todos los aminoácidos esenciales), 30-40% fibra dietaria (mucílagos hidrofílicos que absorben 10-12 veces su peso en agua formando gel — útil para regulación intestinal y saciedad), alta densidad de calcio, hierro, magnesio, zinc, antioxidantes (ácido cafeico, quercetina, miricetina). Es lección extraordinaria de domesticación nutricional precolombina y soberanía alimentaria recuperada que enseña a niñas y niños cómo los aztecas seleccionaron durante siglos una semilla milagrosa con propiedades nutricionales únicas y cómo Colombia puede recuperar esa joya mesoamericana en su huerto andino sin necesidad de importarla. Manejo agroecológico: siembra directa al voleo o en líneas, germinación 4-8 días a 20-25°C, distancia 30-40 cm en línea y 50-60 cm entre líneas, ciclo 4-6 meses a cosecha de semilla, anual obligado, floración fotoperiódica de día corto (siembra abril-mayo para floración octubre-noviembre en Colombia ecuatorial). Trilla manual sencilla. Companion plants: maíz, fríjol, amaranto (las 4 'milpa' mesoamericanas). Función en chagra como pseudocereal nutracéutico patrimonial y atractor melífero. Fuentes Tier A: GBIF Backbone Taxonomy, POWO Kew, AGROSAVIA Manual Frutales Tropicales, Bernal 2015, Pamplona-Roger 2006.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "schizolobium_parahyba",
+      "nombre_comun": "Guacamayo",
+      "nombre_cientifico": "Schizolobium parahyba (Vell.) Blake",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_conif_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "sechium_edule",
+      "nombre_comun": "Guatila / Chayote",
+      "nombre_cientifico": "Sechium edule (Jacq.) Sw.",
+      "familia_botanica": "Cucurbitaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1200,
+        "optimo_max": 2200,
+        "max_absoluto": 2200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "selenicereus_megalanthus",
+      "nombre_comun": "Pitahaya amarilla",
+      "nombre_comunes_regionales": [
+        "Pitaya amarilla"
+      ],
+      "nombre_cientifico": "Selenicereus megalanthus (K.Schum. ex Vaupel) Moran",
+      "familia_botanica": "Cactaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 1200,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 18,
+        "optimo_max": 26,
+        "max_tolerable": 32
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Fenologia: enraizamiento de cladodios, emision de brotes, floracion nocturna, cuajado, llenado de fruto, maduracion amarilla y poda sanitaria despues de cosecha."
+      },
+      "source_ids": [
+        "agrosavia-manual-frutales-tropicales",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La pitahaya amarilla (Selenicereus megalanthus) es una cactacea trepadora cultivada en zonas calidas y templadas de Colombia, con importancia comercial en laderas bien drenadas y sistemas con tutorado. Su fenologia combina enraizamiento del esqueje, brotacion de cladodios, floracion nocturna, cuajado, llenado del fruto y maduracion amarilla para cosecha. Es util para ensenar manejo de cactus frutal con drenaje estricto, poda sanitaria y soporte fisico. Las plagas y enfermedades clave incluyen mosca del boton floral, chinches, antracnosis, pudriciones del tallo y bacteriosis, por lo que el monitoreo de flores y cladodios es central.",
+      "plagas_criticas": [
+        "Mosca del boton floral",
+        "Chinches",
+        "Cochinillas"
+      ],
+      "enfermedades_criticas": [
+        "Colletotrichum spp.",
+        "Pudricion basal",
+        "Bacteriosis"
+      ],
+      "harvest_type": "fruto",
+      "cycleMonths": null,
+      "companions": [
+        "musa_paradisiaca",
+        "cajanus_cajan"
+      ],
+      "antagonists": [],
+      "tracking_mode": "individual",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "senecio_formosus",
+      "nombre_comun": "Árnica de páramo",
+      "nombre_cientifico": "Senecio formosus Kunth",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 3000,
+        "optimo_min": 3000,
+        "optimo_max": 3800,
+        "max_absoluto": 3800
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "senna_pistaciifolia",
+      "nombre_comun": "Alcaparro",
+      "nombre_cientifico": "Senna pistaciifolia (Kunth) H.S.Irwin & Barneby",
+      "familia_botanica": "Fabaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 1800,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "sesamum_indicum",
+      "nombre_comun": "Ajonjolí",
+      "nombre_cientifico": "Sesamum indicum L.",
+      "familia_botanica": "Pedaliaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "smallanthus_sonchifolius",
+      "nombre_comun": "Yacon / Llacon",
+      "nombre_cientifico": "Smallanthus sonchifolius (Poepp.) H.Rob.",
+      "familia_botanica": "Asteraceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "solanum_betaceum",
+      "nombre_comun": "Tomate de árbol / Tamarillo",
+      "nombre_cientifico": "Solanum betaceum Cav.",
+      "familia_botanica": "Solanaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1800,
+        "optimo_max": 2400,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Planta de rápido crecimiento pero vida corta (6-8 años); sensible al ataque de nematodos y exceso de humedad."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-manual-uchuva-2015",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El tomate de árbol (Solanum betaceum Cav.) se cultiva en departamentos andinos de Colombia como Cundinamarca, Boyacá, Nariño, Valle del Cauca, Antioquia y Tolima entre 1200 y 3000 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla o injerto, ciclo de fructificación de 8-12 meses desde la siembra, asociaciones beneficiosas con café, cacao y especies de sombra que mejoran la estructura del huerto, y requiere manejo integrado de nematodos, mosca de la fruta y trips mediante monitoreo y biopreparados andinos. En el contexto cultural muisca y andino, este frutal ha sido tradicionalmente consumido fresco o en jugos, conservando su valor como alimento nativo de los Andes colombianos. Según las fuentes taxonómicas verificadas de GBIF Backbone Taxonomy, Plants of the World Online (POWO), AGROSAVIA Manual de Uchuva y la ICA Resolución 3168/2015, su nombre científico válido es Solanum betaceum Cav.",
+      "estrato": "medio",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "solanum_lycopersicum",
+      "nombre_comun": "Tomate chonto",
+      "nombre_cientifico": "Solanum lycopersicum L.",
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima",
+        "graph_corpoica_suelo"
+      ],
+      "companions": [
+        "solanum_torvum"
+      ],
+      "fenologia": [
+        {
+          "id": "feno_almacigo_solanum_lycopersicum",
+          "nombre": "Semillero / almácigo",
+          "orden": "1"
+        },
+        {
+          "id": "feno_cosecha_solanum_lycopersicum",
+          "nombre": "Cosecha",
+          "orden": "6"
+        },
+        {
+          "id": "feno_floracion_solanum_lycopersicum",
+          "nombre": "Floración",
+          "orden": "3"
+        },
+        {
+          "id": "feno_fructificacion_solanum_lycopersicum",
+          "nombre": "Cuajado y desarrollo de fruto",
+          "orden": "4"
+        },
+        {
+          "id": "feno_maduracion_solanum_lycopersicum",
+          "nombre": "Maduración (viraje)",
+          "orden": "5"
+        },
+        {
+          "id": "feno_vegetativo_solanum_lycopersicum",
+          "nombre": "Desarrollo vegetativo",
+          "orden": "2"
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "azufre_mojable_foliar",
+            "nombre": "Azufre mojable foliar (anti-ácaros y oídio)",
+            "tipo": "fungicida_mineral",
+            "dosis": "MADRE/SUSPENSIÓN: azufre mojable comercial. DILUCIÓN DE APLICACIÓN: 3-5 g por L de agua (0,3-0,5%); bomba de 20 L: 60-100 g. Agitar bien (suspensión). Aplicar al follaje en horas frescas. NO confundir con el azufre del caldo sulfocálcico (ese es polisulfuro, otra preparación)."
+          },
+          {
+            "id": "bacillus_subtilis_foliar",
+            "nombre": "Bacillus subtilis (aplicación foliar)",
+            "tipo": "microbiano"
+          },
+          {
+            "id": "bacillus_thuringiensis_aizawai_cogollero",
+            "nombre": "Bacillus thuringiensis var. aizawai/kurstaki para cogollero",
+            "tipo": "control_biologico",
+            "dosis": "MADRE: producto comercial WP/SC. DILUCIÓN DE APLICACIÓN: 0,5-1 g o cc por L de agua según etiqueta (bomba de 20 L: 10-20 g/cc) + 1-2% de melaza como atrayente-fagoestimulante. Dirigir el chorro al COGOLLO del maíz (donde se aloja la larva). Aplicar al atardecer."
+          },
+          {
+            "id": "bicarbonato_aceite_antioidio",
+            "nombre": "Bicarbonato de sodio/potasio + aceite (anti-oídio y antracnosis)",
+            "tipo": "fungicida_mineral",
+            "dosis": "MADRE/SOLUCIÓN: 5-10 g de bicarbonato por L de agua (0,5-1%) + 2-3 cc de aceite/jabón por L como adherente. Bomba de 20 L: 100-200 g de bicarbonato + 40-60 cc de aceite/jabón. APLICACIÓN: foliar al haz y envés. Preferir bicarbonato de potasio (menos sales de sodio en el suelo)."
+          },
+          {
+            "id": "biol",
+            "nombre": "Biol",
+            "tipo": "fermentado",
+            "dosis": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad."
+          },
+          {
+            "id": "bocashi",
+            "nombre": "Bocashi",
+            "tipo": "fermentado",
+            "dosis": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato."
+          },
+          {
+            "id": "caldo_ajo_concentrado",
+            "nombre": "Caldo de ajo concentrado (anti-fúngico/bactericida)",
+            "tipo": "fungicida_bactericida_botanico",
+            "dosis": "Macerado: 100 g de ajo molido por 1 L de agua, reposar 12-24 h, colar y añadir jabón (caldo madre). Aplicar diluido 1:10 (100 cc de madre por L de agua). Bomba de 20 L: ~2 L de macerado madre + chorro de jabón. Foliar cada 7-10 días preventivo; intensificar en clima húmedo."
+          },
+          {
+            "id": "caldo_bordeles",
+            "nombre": "Caldo bordelés",
+            "tipo": "caldo",
+            "dosis": "Caldo madre al 1% para 10 L: 100 g de sulfato de cobre pentahidratado + 100 g de cal. Disolver el cobre en agua tibia (recipiente NO metalico) y la cal aparte; verter el cobre sobre la lechada de cal (NUNCA al reves) y aforar a 10 L. Relacion 1:1:100 = 1 kg cobre : 1 kg cal : 100 L. Prueba del clavo o pH neutro-alcalino antes de aplicar (el clavo no debe cobrizarse). Hortalizas tiernas: 0,5% (50 g + 50 g / 10 L). Bomba de 20 L al 1%: 200 g sulfato + 200 g cal. Listo para aplicar SIN diluir."
+          },
+          {
+            "id": "caldo_bordeles_trichoderma",
+            "nombre": "Caldo bordelés enriquecido con Trichoderma (manejo de gota integrado)",
+            "tipo": "fungicida_mineral",
+            "dosis": "MANEJO INTEGRADO (dos productos, NO mezclados): bordelés al 0,5-1% (50-100 g cobre + 50-100 g cal por 10 L) en periodos de presión de gota; Trichoderma al suelo/semilla (2-4 g/kg semilla o 1-2 kg/ha) y en aplicaciones foliares en los días SIN cobre (el cobre mata el Trichoderma). Alternar: cobre preventivo en pico de presión, Trichoderma para recuperar microbiota."
+          },
+          {
+            "id": "caldo_ceniza_cal_antigota",
+            "nombre": "Caldo de ceniza y cal anti-gota (variante mineral para tizón de papa)",
+            "tipo": "fungicida_mineral",
+            "dosis": "MADRE: hervir 1 kg de ceniza + 500 g de cal apagada en 10 L de agua 30-40 min, decantar, usar el líquido claro + jabón. DILUCIÓN DE APLICACIÓN: foliar preventivo 1:3 a 1:5 (2-3 L del caldo madre por bomba de 20 L aforada). Verificar que quede alcalino (no ácido). Aplicar preventivo antes de periodos húmedos."
+          },
+          {
+            "id": "caldo_cola_caballo",
+            "nombre": "Caldo/macerado de cola de caballo (Equisetum)",
+            "tipo": "fungicida_bioestimulante_mineral",
+            "dosis": "Decocción: 100-150 g de cola de caballo seca (o 1 kg fresca) por 10 L de agua, hervir 20-30 min y reposar 12-24 h; colar. Aplicar diluido 1:5 (1 L de decocción por 5 L de agua). Bomba de 20 L: ~3-4 L de decocción aforada a 20 L. Foliar preventivo cada 7-15 días, intensificar en clima húmedo."
+          },
+          {
+            "id": "extracto_paraiso_melia",
+            "nombre": "Extracto/purín de paraíso (Melia azedarach)",
+            "tipo": "insecticida_botanico",
+            "dosis": "MADRE: macerar 200-500 g de frutos maduros molidos (o hojas) por L de agua, reposar 24-48 h, colar; o decocción suave. DILUCIÓN DE APLICACIÓN: aplicar el macerado diluido al 5-10% (50-100 cc del madre por L de agua); bomba de 20 L: 1-2 L de macerado madre + jabón, aforar a 20 L. Aplicar al envés al atardecer."
+          },
+          {
+            "id": "extracto_tagetes_nematicida",
+            "nombre": "Extracto/incorporación de tagetes (Tagetes — flor de muerto) nematicida",
+            "tipo": "nematicida_botanico",
+            "dosis": "OPCIÓN ABONO VERDE: sembrar Tagetes como cultivo intercalado/rotación e incorporar la biomasa fresca al suelo 2-3 semanas antes de la siembra del cultivo principal (los tiofenos liberados suprimen nematodos). OPCIÓN EXTRACTO: macerar 500 g-1 kg de planta fresca por 10 L de agua 24-48 h, colar, aplicar al suelo en drench 1-2 L/m2 sin diluir o 1:2."
+          },
+          {
+            "id": "harina_neem_suelo",
+            "nombre": "Harina de neem aplicada al suelo (torta de nim)",
+            "tipo": "nematicida_botanico",
+            "dosis": "APLICACIÓN AL SUELO: 200-500 g/m2 incorporados a los primeros 10 cm antes de siembra/trasplante, o 50-100 g por sitio de siembra; en campo 1-2 t/ha. No se diluye (es enmienda sólida). Regar tras incorporar para activar."
+          },
+          {
+            "id": "humus_liquido",
+            "nombre": "Humus líquido (lixiviado de lombriz)",
+            "tipo": "extracto",
+            "dosis": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado."
+          },
+          {
+            "id": "lactosuero_fermentado_foliar",
+            "nombre": "Lactosuero (suero de leche) fermentado foliar",
+            "tipo": "bioestimulante_foliar",
+            "dosis": "MADRE: lactosuero fresco o fermentado (LAB). DILUCIÓN DE APLICACIÓN: foliar al 5-10% (50-100 cc de suero por L de agua); bomba de 20 L: 1-2 L de suero aforado a 20 L. Aplicar en horas frescas."
+          },
+          {
+            "id": "leche_cruda_foliar_antioidio",
+            "nombre": "Solución de leche cruda foliar (anti-oídio)",
+            "tipo": "fungicida_mineral",
+            "dosis": "MADRE: leche entera/cruda. DILUCIÓN DE APLICACIÓN: 1 parte de leche por 5-10 partes de agua (10-20%); bomba de 20 L: 2-4 L de leche aforada a 20 L. Aplicar al follaje en día soleado (la luz potencia el efecto antifúngico de las proteínas lácticas)."
+          },
+          {
+            "id": "lixiviado_frutas",
+            "nombre": "Lixiviado de frutas",
+            "tipo": "fermentado"
+          },
+          {
+            "id": "macerado_tabaco_jabon",
+            "nombre": "Macerado/caldo de tabaco con jabón",
+            "tipo": "insecticida_botanico",
+            "dosis": "Macerado madre: 60-100 g de tabaco seco por 1 L de agua, reposar 24 h (o cocción suave 20-30 min), colar y añadir jabón. Aplicar DILUIDO 1:4 a 1:5 (≈200-250 cc de madre por L de agua de aspersión). Bomba de 20 L: ~1 L de macerado madre aforado a 20 L. Aplicar al envés de las hojas. Repetir cada 7-10 días, máximo 2-3 aplicaciones."
+          },
+          {
+            "id": "sal_epsom_foliar",
+            "nombre": "Sal de Epsom foliar (sulfato de magnesio)",
+            "tipo": "fertilizante_foliar_mineral",
+            "dosis": "Solución foliar al 1-2%: 10-20 g de sal de Epsom por L de agua (100-200 g por 10 L). Bomba de 20 L: 200-400 g. Aplicar al follaje en horas frescas. Corrección de deficiencia: 2-3 aplicaciones cada 10-15 días. Al suelo: 20-30 g por planta incorporado."
+          },
+          {
+            "id": "supermagro",
+            "nombre": "Supermagro",
+            "tipo": "fermentado",
+            "dosis": "Biofertilizante anaerobico fermentado 30-90 dias; se aplica DILUIDO, no puro. Dilucion foliar del 2% al 7% segun etapa (200-700 cc de supermagro por cada 10 L de agua). Inicio/general 3-5% (300-500 cc/10 L). Bomba de 20 L: 600 cc a 1 L. En cultivos sensibles empezar al 1-2% y subir. Tope de seguridad: no superar ~10% (riesgo de fitotoxicidad por exceso de Cu/Zn)."
+          },
+          {
+            "id": "trampa_amarilla_pegante",
+            "nombre": "Trampa amarilla pegante (mosca blanca / áfidos alados)",
+            "tipo": "trampa_cebo",
+            "dosis": "PREPARACIÓN: cubrir láminas amarillas (~20x30 cm) con aceite/grasa o pegante. APLICACIÓN: 1 trampa cada 10-25 m2 para monitoreo; 30-50 trampas/ha para captura masiva. Ubicar a la altura del cultivo y subir conforme crece. Renovar la capa pegajosa cuando se sature de insectos o polvo (cada 1-2 semanas). No se diluye (trampa física)."
+          },
+          {
+            "id": "trampa_feromona_cogollero",
+            "nombre": "Trampa de feromona sexual para cogollero / polilla",
+            "tipo": "trampa_cebo",
+            "dosis": "INSTALACIÓN: 1 difusor por trampa; densidad de MONITOREO 1-4 trampas/ha; para CONFUSIÓN/captura masiva hasta 20-40 trampas/ha según especie. Para Spodoptera frugiperda (cogollero), Tecia/Symmetrischema (polilla guatemalteca de papa), Tuta absoluta (tomate). Reponer el septo de feromona según vida útil (4-8 semanas) y vaciar capturas. No se diluye."
+          },
+          {
+            "id": "trampa_melaza_atrayente",
+            "nombre": "Trampa de melaza (cebo atrayente líquido)",
+            "tipo": "trampa_cebo",
+            "dosis": "Solución cebo: 100-200 g de melaza/panela por 1 L de agua (10-20%) + un chorro de jabón. Llenar recipientes/botellas trampa hasta ~1/3 y colgar o ubicar 1 trampa cada 5-10 m (≈10-25 trampas/ha según presión). Renovar el líquido cada 5-8 días o cuando pierda olor/fermente en exceso."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "solanum_lycopersicum_san_marzano",
+      "nombre_comun": "Tomate San Marzano",
+      "nombre_cientifico": "Solanum lycopersicum 'San Marzano'",
+      "nombre_comunes_regionales": [
+        "Tomate de pera",
+        "Tomate para pasta"
+      ],
+      "familia_botanica": "Solanaceae",
+      "category": "hortalizas_fruto_flor",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 5,
+      "estrato": "medio",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1500,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": 0,
+        "optimo_min": 20,
+        "optimo_max": 28,
+        "max_tolerable": 35
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6.5,
+        "optimo_max": 7.2,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 5,
+        "horas_acumuladas_max": 0,
+        "notas": "Más tolerante al calor que el cherry, pero igualmente sensible al frío."
+      },
+      "companions": [
+        "calendula_officinalis",
+        "lactuca_sativa_capitata",
+        "melissa_officinalis",
+        "urtica_dioica"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Crecimiento determinado; cosecha concentrada en un periodo corto."
+      },
+      "valor_pedagogico": "El tomate San Marzano (Solanum lycopersicum 'San Marzano') se cultiva en Colombia principalmente en los departamentos de Cundinamarca, Boyacá y Antioquia, entre 1500 y 2400 msnm en zonas térmicas templadas y frías. Su manejo agronómico incluye propagación por semilla con crecimiento determinado y cosecha concentrada en períodos de 5 meses, asociándose beneficiosamente con perejil, citronela, melisa, ortuga y lechuga para reducir presión de plagas como trips y helicoverpa, mientras requiere monitoreo de antagonistas como hinojo y papas andinas. En el contexto campesino andino, esta variedad ha sido adoptada por su alto contenido de sólidos solubles que lo hacen ideal para procesamiento artesanal de salsas y conservas, preservando técnicas de postcosecha transmitidas oralmente en comunidades de la Sabana de Bogotá. Según la taxonomía verificable de GBIF Backbone Taxonomy y Plants of the World Online (POWO), respaldada por el ICA Resolución 3168/2015 y el manual AGROSAVIA Sol Andina, su nombre científico válido es Solanum lycopersicum 'San Marzano'.",
+      "feeding_plan_template": {
+        "source": "Restrepo-Rivera (2005) Agroecología + Agrosavia Manual biopreparados (2015). Tomate San Marzano clima templado bajo invernadero o campo abierto sin heladas.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi + Trichoderma al hoyo",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 300,
+            "notes": "Hoyo 30x30 cm. Mezclar 10 g de Trichoderma harzianum al sustrato como preventivo Fusarium."
+          },
+          {
+            "offset_days": 15,
+            "action": "Drench con humus líquido al pie",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 250,
+            "notes": "Dilución 1:5. Fase vegetativa activa post-trasplante."
+          },
+          {
+            "offset_days": 30,
+            "action": "Foliar con biol pre-floración",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Promueve formación de racimos florales en tomate indeterminado."
+          },
+          {
+            "offset_days": 45,
+            "action": "Foliar con supermagro inicio cuajado",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. Aporte de Ca + B preventivo de pudrición apical (blossom end rot)."
+          },
+          {
+            "offset_days": 60,
+            "action": "Aplicar caldo bordelés preventivo",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo tizón tardío (Phytophthora infestans) en época húmeda. Suspender en floración plena."
+          },
+          {
+            "offset_days": 75,
+            "action": "Drench con lixiviado de frutas",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 100,
+            "notes": "Dilución 1:10. Refuerzo K + P durante llenado de frutos."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con Bacillus subtilis cerca de cosecha",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 5,
+            "notes": "Preventivo Botrytis en racimos maduros. Tolera aplicación hasta 1 día antes de cosecha."
+          }
+        ]
+      },
+      "plagas_criticas": [
+        "Frankliniella spp. / Thrips spp. (trips, vectores de virus del bronceado TSWV)",
+        "Tuta absoluta (polilla/cogollero del tomate, minador devastador)",
+        "Bemisia tabaci / Trialeurodes vaporariorum (mosca blanca, vector de geminivirus)",
+        "Helicoverpa zea / Heliothis (gusano del fruto)",
+        "Tetranychus urticae / Aculops lycopersici (ácaro del tomate)",
+        "Agrotis ipsilon (trozador, corta plántulas a ras de suelo)"
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora infestans (gota / tizón tardío) — devastador en clima frío húmedo, comparte patógeno con la papa",
+        "Alternaria solani (tizón temprano)",
+        "Fusarium oxysporum f. sp. lycopersici (marchitez vascular)",
+        "Ralstonia solanacearum (marchitez bacteriana)",
+        "Phytophthora infestans y Septoria lycopersici (manchas foliares)",
+        "Podredumbre apical / Blossom end rot (fisiopatía por déficit de Ca y riego irregular, NO patógeno)"
+      ],
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-sol-andina",
+        "ica-resolucion-3168-2015"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "solanum_quitoense",
+      "nombre_comun": "Lulo / Naranjilla / Chuva",
+      "nombre_cientifico": "Solanum quitoense Lam.",
+      "familia_botanica": "Solanaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1200,
+        "optimo_min": 1600,
+        "optimo_max": 2400,
+        "max_absoluto": 2800
+      },
+      "temperatura_c": {
+        "helada_letal": -1,
+        "optimo_min": 16,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Requiere sombra en etapas tempranas; sensible a nematodos del genero Meloidogyne. Se asocia bien con platano o maiz como sombra temporal."
+      },
+      "source_ids": [
+        "powo-kew",
+        "gbif-colombia",
+        "gbif-taxonomic-backbone",
+        "agrosavia-tibaitata",
+        "agrosavia-manual-frutales-tropicales",
+        "bernal-2015-plantas-liquenes-colombia",
+        "sib-colombia"
+      ],
+      "valor_pedagogico": "El lulo o naranjilla (Solanum quitoense Lam., familia Solanaceae) es una solanácea subarbustiva perenne nativa de la región andina norte (Colombia, Ecuador, Perú), cultivada tradicionalmente en sistemas agroforestales campesinos colombianos por sus frutos esféricos anaranjados de pulpa verde ácida (pH 2.8-3.4), ricos en vitamina C, ácido cítrico y carotenoides, considerada el cítrico andino por excelencia. Se cultiva en Cundinamarca (Fómeque, Quetame, Une), Boyacá (Miraflores, Garagoa), Huila (San Agustín, Pitalito), Caquetá (Florencia) y Cauca (Silvia, Inzá) entre 1.600 y 2.400 msnm en zona térmica templada a fría. Ciclo perenne con primera cosecha a los 9-12 meses, producción sostenida 3-4 años. Rendimientos 12-20 t/ha fruto fresco. Lección viva: enseña la importancia de la acidez (ácido cítrico y málico) como mecanismo de defensa natural anti-herbívoros y anti-microbiano, su valor en la gastronomía tradicional (jugo, sorbete, mermelada, lulada vallecaucana) y la sensibilidad a nematodos del nudo radical Meloidogyne incognita como bioindicador de salud del suelo. Manejo agroecológico: siembra con sombra parcial (40-60%) en sistemas con plátano o guamo (Inga edulis) como sombra temporal, asocio con maíz para protección contra viento, podas sanitarias de hojas viejas, control biológico de Neoleucinodes elegantalis (perforador) con Trichogramma pretiosum, no requiere agroquímicos. Fuentes Tier A: AGROSAVIA Manual Frutales Tropicales, POWO Kew, GBIF Backbone Taxonomy, SIB Colombia, Bernal 2015 Catálogo Plantas Colombia.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "_anti_confusion": "Solanum tuberosum (papa común). NO confundir con Solanum betaceum (tomate de árbol), Solanum lycopersicum (tomate), Solanum quitoense (lulo) ni Solanum phureja/Solanum tuberosum Grupo Phureja (papa criolla, subgrupo distinto de menor latencia y tubérculo amarillo).",
+      "id": "solanum_tuberosum",
+      "nombre_comun": "Papa",
+      "nombre_comunes_regionales": [
+        "papa común",
+        "papa de año",
+        "papa pastusa",
+        "papa sabanera",
+        "papa única",
+        "papa diacol capiro (R-12)"
+      ],
+      "nombre_cientifico": "Solanum tuberosum L.",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "tuberculo",
+      "cycleMonths": 6,
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2500,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 10,
+        "optimo_max": 18,
+        "max_tolerable": 24
+      },
+      "ph_suelo": {
+        "min": 4.5,
+        "optimo_min": 5.2,
+        "optimo_max": 6.5,
+        "max": 7.5
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": -1.5,
+        "horas_acumuladas_max": 2,
+        "notas": "Follaje muere a -2 °C. La helada negra de madrugada en el altiplano (Cundiboyacense, Nariño) es la causa abiótica más frecuente de pérdida total. El aporque alto y el riego nocturno por aspersión mitigan parcialmente."
+      },
+      "companions": [
+        "calendula_officinalis",
+        "lupinus_mutabilis",
+        "phaseolus_vulgaris",
+        "oxalis_tuberosa",
+        "ullucus_tuberosus"
+      ],
+      "antagonists": [],
+      "_nota_antagonists": "Evitar monocultivo y rotación papa-papa: concentra Phytophthora infestans (gota), Tecia solanivora (polilla guatemalteca) y nematodo quiste (Globodera pallida). No asociar con otras solanáceas (tomate, lulo, tomate de árbol) por compartir gota y mosca blanca. Rotar con leguminosas (haba, arveja, lupino) y cereales.",
+      "propagation": {
+        "methods": [
+          "tuberculo",
+          "semilla"
+        ],
+        "best_method": "tuberculo",
+        "protocol_resumen": "Tubérculo-semilla certificado pre-brotado (yemas de 1-2 cm, verdeado a luz difusa). Siembra a 10-15 cm de profundidad, distancia 30 cm entre plantas × 90-100 cm entre surcos. Densidad ~33.000-40.000 plantas/ha. La semilla sexual (botánica) solo se usa en programas de mejoramiento, no en producción comercial.",
+        "tiempo_a_establecimiento_dias": 21,
+        "notas": "Renovar semilla certificada cada 2-3 ciclos por degeneración viral (PVY, PLRV) y bacteriana (Ralstonia, Pectobacterium). Fenología por etapas: (1) Brotación/emergencia 0-25 días; (2) Desarrollo vegetativo y crecimiento de follaje 25-45 días; (3) Inicio de tuberización (estolones) 45-60 días — etapa que define el número de tubérculos; (4) Llenado/engrose de tubérculo 60-110 días — máxima demanda de K y agua; (5) Maduración de piel y senescencia del follaje 110-150 días; (6) Cosecha 150-180 días según variedad.",
+        "fuente": "AGROSAVIA Manual tubérculos andinos 2017; Pérez-Rodríguez-Gómez 2008; Núñez-Rodríguez 2024 UNAL."
+      },
+      "plagas_criticas": [
+        "Tecia solanivora (polilla guatemalteca de la papa)",
+        "Premnotrypes vorax (gusano blanco / chiza de la papa)",
+        "Phyllophaga spp. y Ancognatha spp. (chiza, larva rizófaga)",
+        "Globodera pallida / Globodera rostochiensis (nematodo del quiste de la papa)",
+        "Liriomyza huidobrensis (minador de la hoja)",
+        "Epitrix spp. (pulguilla de la papa)"
+      ],
+      "enfermedades_criticas": [
+        "Phytophthora infestans (gota o tizón tardío) — enfermedad #1, devastadora en clima frío húmedo",
+        "Alternaria solani (tizón temprano)",
+        "Rhizoctonia solani (costra negra / cancro del tallo)",
+        "Spongospora subterranea (sarna polvosa, vector del Potato mop-top virus)",
+        "Ralstonia solanacearum (marchitez bacteriana / dormidera)",
+        "Pectobacterium / Dickeya (pudrición blanda y pierna negra)"
+      ],
+      "feeding_plan_template": {
+        "source": "AGROSAVIA Manual tubérculos andinos (2017) + Pérez-Rodríguez-Gómez (2008) — plan agroecológico de transición para papa de año clima frío 2500-3200 msnm. Énfasis preventivo contra gota (Phytophthora infestans).",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al surco a la siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 300,
+            "notes": "Surco preparado 0-20 cm. Tubérculo-semilla certificado pre-brotado. Suelo bien drenado; evitar encharcamiento (favorece Phytophthora y Ralstonia)."
+          },
+          {
+            "offset_days": 25,
+            "action": "Inocular Trichoderma harzianum al suelo",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 15,
+            "notes": "Preventivo Rhizoctonia solani y Spongospora subterranea. Coincide con emergencia/inicio vegetativo."
+          },
+          {
+            "offset_days": 45,
+            "action": "Primer aporque + drench con humus líquido",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 200,
+            "notes": "Dilución 1:5. Aporque alto fundamental: cubre estolones, protege tubérculos de la luz (evita verdeo/solanina) y de la polilla Tecia, y mejora drenaje. Inicio de tuberización."
+          },
+          {
+            "offset_days": 60,
+            "action": "Foliar preventivo de gota con caldo bordelés",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. PREVENTIVO de Phytophthora infestans — NUNCA curativo. Iniciar antes de la primera lluvia persistente y repetir cada 10-14 días en condición de niebla/lluvia. El Cu deja residuo: alternar con Bacillus subtilis foliar y reducir frecuencia en seco."
+          },
+          {
+            "offset_days": 75,
+            "action": "Foliar con Bacillus subtilis (alternar con bordelés)",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 80,
+            "notes": "Antagonista preventivo de Phytophthora y Alternaria; reduce dependencia del cobre. Aplicar al atardecer."
+          },
+          {
+            "offset_days": 90,
+            "action": "Foliar con supermagro durante llenado de tubérculo",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. K crítico para engrose de tubérculo y materia seca. Etapa de máxima demanda hídrica y de potasio."
+          },
+          {
+            "offset_days": 130,
+            "action": "Suspender riego para madurar la piel",
+            "notes": "Reducir riego 80% las últimas 3 semanas. Piel madura = mejor conservación y menor pudrición post-cosecha. Cosecha 150-180 días. Curar tubérculos a la sombra 1-2 semanas antes de almacenar."
+          }
+        ]
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "nustez-rodriguez-2024-unal",
+        "perez-rodriguez-gomez-2008",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La papa (Solanum tuberosum L., familia Solanaceae) es el cultivo de tubérculo más importante del clima frío colombiano y el segundo alimento de consumo nacional después del arroz. Domesticada hace más de 7.000 años en los Andes (cuenca del lago Titicaca, Perú-Bolivia), llegó al altiplano colombiano y hoy se cultiva intensivamente entre 2.500 y 3.200 msnm en Cundinamarca (Sabana de Bogotá, Subachoque, Zipaquirá, Une, Carmen de Carupa), Boyacá (Ventaquemada, Toca, Soracá, Tunja), Nariño (Túquerres, Pupiales, Guachucal, Ipiales — principal departamento productor) y norte de Antioquia (La Unión, Sonsón). Las variedades comerciales dominantes en Colombia son Diacol Capiro (R-12, industrial para fritura), Pastusa Suprema, Superior, Única, Esmeralda y la papa criolla amarilla (Grupo Phureja). El enemigo número uno es la gota o tizón tardío (Phytophthora infestans), un oomiceto que en clima frío húmedo y con neblina puede destruir un lote entero en menos de una semana; fue el patógeno responsable de la Gran Hambruna Irlandesa (1845-1849) y sigue siendo el factor que más encarece y contamina el cultivo, pues ata al productor a 8-14 aplicaciones de fungicida por ciclo. Manejo agroecológico de transición: rotación obligatoria con leguminosas (haba, arveja, lupino/chocho) que fijan nitrógeno y rompen el ciclo de plagas de suelo; semilla certificada renovada cada 2-3 ciclos contra la degeneración viral (PVY, PLRV); aporque alto para proteger tubérculos de la polilla guatemalteca (Tecia solanivora) y del verdeo; manejo PREVENTIVO de la gota con caldo bordelés al 1% y Bacillus subtilis alternados antes de las lluvias (nunca como cura una vez establecida); Trichoderma harzianum al suelo contra Rhizoctonia y sarna polvosa; y asociación con caléndula y tagetes para repeler insectos y nematodos. La papa enseña la lección central de la soberanía alimentaria andina: la inmensa diversidad de variedades nativas (más de 4.000 en los Andes) es el seguro biológico frente a plagas y cambio climático, y su erosión por el monocultivo de pocas variedades comerciales es un riesgo real. Fuentes Tier A: AGROSAVIA Manual Tubérculos Andinos 2017, Núñez-Rodríguez 2024 UNAL, Pérez-Rodríguez-Gómez 2008, ICA Resolución 3168/2015, GBIF Backbone, POWO Kew.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "solanum_tuberosum_diacol_capiro",
+      "nombre_comun": "Papa Diacol Capiro",
+      "nombre_cientifico": "Solanum tuberosum L. subsp. andigena cv. Diacol Capiro",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "solanum_tuberosum_pastusa_suprema",
+      "nombre_comun": "Papa Pastusa Suprema",
+      "nombre_comunes_regionales": [
+        "pastusa suprema",
+        "papa suprema",
+        "ICA-Pastusa Suprema"
+      ],
+      "nombre_cientifico": "Solanum tuberosum L. subsp. tuberosum cv. 'Pastusa Suprema'",
+      "familia_botanica": "Solanaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2500,
+        "optimo_max": 3000,
+        "max_absoluto": 3300
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 10,
+        "optimo_max": 17,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo (semilla asexual)",
+        "notas": "Variedad industrial moderna liberada por ICA-CORPOICA en 1996. Ciclo 5-6 meses. Alta productividad pero alta dependencia de insumos sintéticos y muy susceptible a Phytophthora infestans. Requiere semilla certificada cada 2-3 ciclos para mantener vigor. Resiembra con tubérculo entero o cortado con yemas, distancia 30 cm x 90 cm."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "nustez-rodriguez-2024-unal",
+        "perez-rodriguez-gomez-2008",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "La papa Pastusa Suprema (Solanum tuberosum L. subsp. tuberosum cv. 'Pastusa Suprema') es la variedad comercial dominante en Colombia desde su liberación oficial por ICA-CORPOICA en 1996, surgida de un cruzamiento dirigido para combinar la calidad culinaria de la pastusa tradicional con mayor rendimiento agronómico. Se cultiva intensivamente en Nariño (Túquerres, Pupiales, Guachucal, Ipiales), Cundinamarca (Subachoque, Zipaquirá, Carmen de Carupa, Une), Boyacá (Ventaquemada, Toca, Soracá) y zona norte de Antioquia (La Unión, Sonsón) entre 2.500 y 3.000 msnm. Rendimientos comerciales 30-45 t/ha bajo manejo convencional, tubérculos grandes (150-250 g) oblongos de piel rosa-crema y carne crema con bajo contenido de azúcares reductores: ideal para fritura industrial (papas a la francesa) y mercados de plaza. Es una lección crítica sobre el modelo agroindustrial: aunque productiva, la pastusa suprema es extremadamente susceptible a Phytophthora infestans (tizón tardío) y polilla guatemalteca (Tecia solanivora), lo que ata su cultivo a 8-14 aplicaciones de fungicida/insecticida sintético por ciclo, costo que estrangula al pequeño productor y deja residuos en suelo, agua y tubérculo. En contraste con las nativas Andigenum (carrera negra, criolla, sabanera), depende totalmente de semilla certificada renovada cada 2-3 ciclos por degeneración viral (PVY, PLRV). Manejo agroecológico de transición: rotación obligatoria con haba o arveja para fijar nitrógeno, aplicación de compost o bocashi al surco, biopreparados como caldo bordelés preventivo (no curativo) y trichoderma, monitoreo semanal de adultos de polilla con feromonas, asociación con tagetes para repelencia. La pastusa suprema enseña por contraste el costo real de la dependencia a paquetes tecnológicos y por qué la conservación in situ de variedades nativas es seguro alimentario. Fuentes Tier A: AGROSAVIA Manual Tubérculos Andinos 2017, Núñez-Rodríguez 2024 UNAL, Pérez-Rodríguez-Gómez 2008, ICA Resolución 3168/2015, GBIF Backbone, POWO Kew.",
+      "feeding_plan_template": {
+        "source": "Agrosavia — Manual tubérculos andinos (2017) + Pérez-Rodríguez-Gómez (2008) Plan fertilización papa criolla altiplano. Papa pastusa ciclo 5-6 meses clima frío 2000-3000 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al surco",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 250,
+            "notes": "Surco preparado 0-20 cm. Tubérculos-semilla pre-brotados con yemas activas. Suelo bien drenado."
+          },
+          {
+            "offset_days": 25,
+            "action": "Inocular Trichoderma harzianum al sustrato",
+            "biofertilizer_slug": "trichoderma_harzianum_suelo",
+            "dose_g": 15,
+            "notes": "Preventivo Rhizoctonia solani y Spongospora subterranea — patógenos críticos en papa altiplano."
+          },
+          {
+            "offset_days": 45,
+            "action": "Aporque + drench con humus líquido",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 200,
+            "notes": "Dilución 1:5. Aporque obligatorio para tuberización. Aporte de NPK orgánico antes de bulbificación."
+          },
+          {
+            "offset_days": 60,
+            "action": "Foliar con biol fase pre-tuberización",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Etapa crítica — papa define número de tubérculos en los 10-20 días pre-tuberización."
+          },
+          {
+            "offset_days": 80,
+            "action": "Foliar con caldo bordelés preventivo gota",
+            "biofertilizer_slug": "caldo_bordeles",
+            "dose_ml": 100,
+            "notes": "Concentración 1%. Preventivo Phytophthora infestans (gota o tizón) — enemigo principal de la papa. Cada 14 días en lluvia activa."
+          },
+          {
+            "offset_days": 100,
+            "action": "Foliar con supermagro durante llenado",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. K crítico para llenado de tubérculo y materia seca final."
+          },
+          {
+            "offset_days": 130,
+            "action": "Suspender riego para maduración piel",
+            "notes": "Reducir riego 80% últimas 3 semanas. Maduración piel = mejor conservación post-cosecha. Cosecha 150-180 días."
+          }
+        ]
+      },
+      "antagonists": [],
+      "tracking_mode": "aggregate",
+      "variedades_registradas_ica": [
+        {
+          "id_canonico": "agrosavia-alhaja-papa-2019",
+          "nombre_comercial": "AGROSAVIA Alhaja",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum tuberosum L. ssp. andigenum",
+          "species_id_chagra": "solanum_tuberosum_pastusa_suprema",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Obonuco"
+          },
+          "resolucion_ica": {
+            "numero": "017702/2019",
+            "fecha": "2019-11-05",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Nudo de los Pastos",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3200,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 35,
+            "ciclo_meses": 6,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa de gabacha amarilla intensa",
+            "doble proposito (consumo fresco + industria)"
+          ],
+          "resistencias_documentadas": [
+            "Phytophthora infestans (resistencia moderada)"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-alhaja-ica-17702-2019",
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        },
+        {
+          "id_canonico": "agrosavia-oyanza-papa-2019",
+          "nombre_comercial": "AGROSAVIA Oyanza",
+          "codigo_experimental": null,
+          "nombre_botanico": "Solanum tuberosum L. ssp. andigenum",
+          "species_id_chagra": "solanum_tuberosum_pastusa_suprema",
+          "obtentor": {
+            "nombre": "AGROSAVIA",
+            "denominacion_legal": "Corporacion Colombiana de Investigacion Agropecuaria",
+            "centro_investigacion": "C.I. Obonuco"
+          },
+          "resolucion_ica": {
+            "numero": "017700/2019",
+            "fecha": "2019-11-05",
+            "url_oficial": "https://www.ica.gov.co/"
+          },
+          "estado_registro": "vigente",
+          "subregiones_naturales_ica": [
+            {
+              "nombre": "Nudo de los Pastos",
+              "estratos_altitudinales_msnm": [
+                {
+                  "min": 2400,
+                  "max": 3200,
+                  "etiqueta": "frio"
+                }
+              ]
+            }
+          ],
+          "departamentos_inferidos": [
+            "Narino",
+            "Cauca"
+          ],
+          "productividad": {
+            "rendimiento_promedio_t_ha": 32,
+            "ciclo_meses": 6,
+            "tipo_dato": "experimental"
+          },
+          "caracteristicas_distintivas": [
+            "papa amarilla intensa con piel rosada",
+            "tolerancia a heladas moderadas"
+          ],
+          "resistencias_documentadas": [
+            "heladas leves"
+          ],
+          "disponibilidad_semilla": {
+            "tipo_propagacion": "asexual_tuberculo_semilla",
+            "puntos_venta_oficiales": [
+              {
+                "nombre": "AGROSAVIA C.I. Obonuco",
+                "ciudad": "Pasto"
+              }
+            ],
+            "requiere_licencia_multiplicador": true,
+            "norma_aplicable": "Res. ICA 3168/2015"
+          },
+          "ano_liberacion": 2019,
+          "source_ids": [
+            "agrosavia-manual-tuberculos-andinos-2017"
+          ],
+          "nota_editorial": "Informacion referencial recopilada de fuentes publicas (ICA, AGROSAVIA). Sin convenio formal entre Chagra y estas instituciones. La PEA y el registro real corresponden a ICA; consultar resolucion oficial antes de tomar decisiones comerciales.",
+          "fecha_ingreso_chagra": "2026-05-21",
+          "ultima_revision_chagra": "2026-05-21",
+          "_curation_status": "PILOT_PASADA_4",
+          "_revisor": "claude-opus-4-7"
+        }
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "sorghum_bicolor",
+      "nombre_comun": "Sorgo",
+      "nombre_cientifico": "Sorghum bicolor (L.) Moench",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_fenalce_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "cebo_melaza_bt_cogollero",
+            "nombre": "Cebo casero de melaza + Bt para cogollo de maíz",
+            "tipo": "trampa_cebo",
+            "dosis": "MADRE/PREPARACIÓN: humedecer 1 kg de arena/aserrín con 100-150 cc de melaza disuelta (10-15%) hasta que quede pegajoso pero suelto; añadir Bt a dosis de etiqueta si se dispone. APLICACIÓN: depositar una pizca (~1-2 g) directamente en el cogollo de cada planta de maíz al atardecer. No se diluye en agua (es cebo sólido)."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "spinacia_oleracea",
+      "nombre_comun": "Espinaca",
+      "nombre_cientifico": "Spinacia oleracea L.",
+      "familia_botanica": "Amaranthaceae",
+      "category": "hortalizas_hoja",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "companions": [
+        "fragaria_ananassa_monterrey"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "stevia_rebaudiana",
+      "nombre_comun": "Stevia",
+      "nombre_cientifico": "Stevia rebaudiana",
+      "familia_botanica": "Asteraceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1500,
+        "max_absoluto": 1500
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima",
+        "graph_ica_suelo"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "swietenia_macrophylla",
+      "nombre_comun": "Caoba andina",
+      "nombre_comunes_regionales": [
+        "caoba",
+        "caoba de hoja grande",
+        "mahogany",
+        "caoba del Amazonas"
+      ],
+      "nombre_cientifico": "Swietenia macrophylla King",
+      "familia_botanica": "Meliaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "en_peligro",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1000,
+        "max_absoluto": 1400
+      },
+      "temperatura_c": {
+        "helada_letal": 6,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol siempreverde, 30-50 m de altura, fuste recto cilíndrico",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Cápsulas leñosas grandes dehiscentes liberan semillas aladas. Sin tratamiento pre-germinativo. Germinación 70-85% a 14-21 días. Vivero a sombra 60% durante 6-8 meses. Plantación definitiva a 40-50 cm de altura. Raíz pivotante profunda: trasplante temprano evitando daño radicular.",
+        "tiempo_a_establecimiento_dias": 75,
+        "notas": "Mismo problema que Cedrela: Hypsipyla grandella ataca yema apical en plantaciones puras. Asocio con cacao, café o dosel residual reduce drásticamente daño. Crecimiento lento-moderado, turno 30-50 años para madera comercial.",
+        "fuente": "Cárdenas & Salinas 2007 Libro Rojo; CITES Apéndice II; IUCN Red List EN; Sinchi Amazonía"
+      },
+      "companions": [
+        "cedrela_odorata",
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol gigante 30-50 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Un árbol patrimonial generacional en huerto >1000 m². Plantar pensando en nietos.",
+          "tips": [
+            "Plantar a >15 m de construcciones",
+            "Asociar con cacao o frutales tropicales para protección Hypsipyla"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío maderable en cacaotales tropicales 60-100 árb/ha. Plantaciones puras 400 árb/ha en suelos profundos, turno 30-50 años.",
+          "tips": [
+            "Plantación bajo dosel residual reduce 70% ataque Hypsipyla",
+            "Sólo semilla certificada de procedencia conocida",
+            "Manejo silvicultural intensivo años 1-10"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Especie clave restauración bosque amazónico y bosque húmedo Magdalena. Categoría EN PELIGRO (EN) IUCN.",
+          "tips": [
+            "Densidad 200-400 ind/ha asociado a pioneras tropicales",
+            "Protección legal estricta CITES Apéndice II"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [
+        "Hypsipyla grandella (barrenador del cedro y la caoba)"
+      ],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Especie maderable patrimonial neotropical de máximo valor comercial histórico. Gigante emergente del bosque amazónico y húmedo tropical. Madera rojiza fina veteada considerada la más preciada del mundo para mueblería de lujo, instrumentos musicales (guitarras, pianos), construcción naval, ebanistería patrimonial. Sobreexplotada al borde del exterminio comercial: listada IUCN Red List como EN PELIGRO (EN) y CITES Apéndice II.",
+      "valor_pedagogico": "La caoba andina o caoba de hoja grande (Swietenia macrophylla King, Meliaceae) es uno de los árboles maderables más patrimoniales y más amenazados del mundo. Su madera rojiza fina veteada es considerada históricamente la más preciada para ebanistería de lujo, mueblería patrimonial, instrumentos musicales (guitarras clásicas, pianos), construcción naval clásica y altares de iglesias coloniales. Nativa de Mesoamérica y Sudamérica tropical, en Colombia se distribuye en bosques húmedos tropicales de baja altitud en la Amazonía (piedemonte caqueteño, putumayense, amazonense), valle medio del Magdalena (Antioquia, Santander, Bolívar, Cesar) y Pacífico chocoano y vallecaucano entre 0 y 1.000 msnm en zona térmica cálida muy húmeda. Árbol siempreverde gigante que puede alcanzar 30-50 m de altura con fuste recto cilíndrico de hasta 2 m de diámetro y contrafuertes basales, copa amplia hemisférica emergente del dosel, hojas pinnadas con folíolos lanceolados grandes (de ahí 'macrophylla'), flores pequeñas blanco-amarillentas en panículas axilares, cápsulas leñosas grandes erectas dehiscentes en 4-5 valvas que liberan numerosas semillas aladas dispersadas por viento. ALERTA CONSERVACIÓN: categorizada EN PELIGRO (EN) en la Lista Roja de IUCN y listada en CITES Apéndice II por sobreexplotación maderera histórica desde la época colonial: poblaciones silvestres reducidas en >80% del rango original en Colombia, su comercio internacional requiere permisos CITES y su aprovechamiento doméstico requiere autorización del Ministerio de Ambiente. Aparece en Libro Rojo Plantas Colombia (Cárdenas & Salinas 2007). El cultivo agroforestal y plantaciones bajo dosel residual son la principal alternativa para reducir presión sobre poblaciones silvestres y son promovidos por Sinchi en la Amazonía colombiana. Comparte con Cedrela odorata el principal limitante silvicultural: el barrenador Hypsipyla grandella (Pyralidae) perfora la yema apical y deforma el fuste en plantaciones puras a plena exposición, pero el asocio con cacao o bajo dosel residual reduce hasta 70% el daño. Crecimiento lento-moderado, turno comercial 30-50 años para diámetros >50 cm. Manejo agroecológico: sólo semilla certificada de procedencia conocida, vivero a sombra 60% por 6-8 meses, plantación bajo dosel residual o asociada a cacao, podas de formación años 2-5, raleos progresivos años 10-20-30. Es lección crítica de conservación maderera: la madera que su tatarabuelo aprovechaba libremente del bosque amazónico hoy está protegida internacionalmente por la presión exterminadora del mercado global, y plantar caoba en su huerto agroforestal es un acto de soberanía y de reparación con la selva. Fuentes Tier A: Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, IUCN Red List, CITES Apéndice II, Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, POWO Kew, GBIF, Sinchi Amazonía Colombiana.",
+      "nota_conservacion": "EN PELIGRO (EN) según IUCN Red List. Listada CITES Apéndice II: comercio internacional regulado. Aprovechamiento silvestre prohibido sin permiso CAR/Ministerio Ambiente Colombia. Plantaciones agroforestales y conservación in situ son críticas para supervivencia de la especie en Colombia.",
+      "source_ids": [
+        "libro-rojo-plantas-colombia",
+        "uicn-red-list",
+        "bernal-2015-plantas-liquenes-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "sinchi-amazonia-colombiana"
+      ],
+      "tracking_mode": "individual",
+      "cites_appendix": "II",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "symphytum_officinale",
+      "nombre_comun": "Consuelda",
+      "nombre_cientifico": "Symphytum officinale L.",
+      "familia_botanica": "Boraginaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_ica_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "syzygium_jambos",
+      "nombre_comun": "Pomarroso",
+      "nombre_cientifico": "Syzygium jambos (L.) Alston",
+      "familia_botanica": "Myrtaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "tabebuia_chrysantha",
+      "nombre_comun": "Guayacán amarillo",
+      "nombre_comunes_regionales": [
+        "araguaney",
+        "guayacán",
+        "guayacán de Manizales",
+        "Handroanthus chrysanthus",
+        "flor amarilla"
+      ],
+      "nombre_cientifico": "Tabebuia chrysantha (Jacq.) G.Nicholson",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 1800,
+        "max_absoluto": 2200
+      },
+      "temperatura_c": {
+        "helada_letal": 2,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol caducifolio, 10-25 m de altura, floración amarillo dorado espectacular",
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca. Sin tratamiento pre-germinativo. Germinación 70-90% a 10-20 días. Vivero a sol parcial, definitiva a 30-40 cm.",
+        "tiempo_a_establecimiento_dias": 55,
+        "notas": "Floración masiva sincrónica amarillo dorado intensa en estación seca, complemento cromático del ocobo rosado. Más rústico que T. rosea, tolera bosque seco más severo.",
+        "fuente": "Bernal 2015; Cárdenas-Salinas 2007; Trees of Antioquia; árbol nacional Venezuela"
+      },
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "inga_edulis",
+        "tabebuia_rosea"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 10-25 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Árbol patrimonial-ornamental con floración amarillo dorado espectacular.",
+          "tips": [
+            "Plantar en jardín frontal para floración pública",
+            "Combinar con T. rosea para contraste rosado-amarillo"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío cafetalero 80-150 árb/ha. Maderable secundario alta calidad. Arbolado urbano municipal.",
+          "tips": [
+            "Madera dura amarilla-marrón muy resistente para postes y vigas",
+            "Flor patrimonial nacional de Venezuela (araguaney)",
+            "Tolera bosque seco más severo que T. rosea"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera valiosa bosque seco tropical Caribe y valles interandinos Andes.",
+          "tips": [
+            "Tolera suelos pedregosos y sequía estacional severa",
+            "Asocio con Bombacopsis quinata en bosque seco"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Árbol ornamental-maderable patrimonial neotropical. Floración masiva sincrónica amarillo dorado intensa en estación seca, complemento cromático del ocobo rosado. Madera dura amarillo-marrón muy resistente para postes, vigas, durmientes. Flores grandes tubulares atraen abejas y colibríes. Flor patrimonial nacional de Venezuela (araguaney) y emblemática del paisaje tropical colombiano.",
+      "valor_pedagogico": "El guayacán amarillo o araguaney (Tabebuia chrysantha (Jacq.) G.Nicholson, sinónimo válido Handroanthus chrysanthus, Bignoniaceae) es el complemento cromático del ocobo rosado en el paisaje patrimonial colombiano-venezolano: mientras T. rosea cubre los pueblos de flores rosadas, T. chrysantha los cubre de un amarillo dorado intenso espectacular. Nativo del Neotrópico, en Colombia se distribuye en bosques húmedos a secos tropicales y premontanos de las regiones Caribe (Sucre, Córdoba, Bolívar, Magdalena, Cesar, Guajira), Andina (valles interandinos del Magdalena, Cauca y Patía, piedemontes en Antioquia, Santander, Norte de Santander, Cundinamarca, Tolima, Huila, Caldas, Risaralda, Quindío, Valle, Cauca, Nariño), Pacífico (Valle, Chocó, Nariño) y Orinoquía (Casanare, Meta) entre 0 y 1.800 msnm en zona térmica cálida a templada. Árbol caducifolio de 10-25 m de altura con fuste recto y copa abierta hemisférica, hojas opuestas palmaticompuestas con 5 folíolos elípticos pubescentes, flores tubulares amarillo dorado intenso de 5-8 cm en panículas terminales densas durante estación seca (enero-marzo Andes, diciembre-marzo Caribe), tras pérdida total de hojas el árbol queda como un sol vegetal incandescente. Es flor patrimonial nacional de Venezuela (donde se llama araguaney, declarado árbol nacional desde 1948), íntimamente ligado a la cultura andina venezolana y colombiana fronteriza (Norte de Santander, Arauca, Vichada, Guainía). Su madera es una de las más duras y resistentes del Neotrópico, con densidad >1 g/cm³, color amarillo-marrón a verdoso, apreciada para postes, durmientes ferroviarios, vigas estructurales, construcción rural pesada, ebanistería y tornería; sirve incluso como sustituto del bossier africano en herramientas. Más rústico que T. rosea: tolera suelos pedregosos, sequía estacional severa de hasta 5-6 meses, suelos delgados de laderas calcáreas y arenosos, lo que lo convierte en pionera ideal para restauración de bosque seco tropical en Caribe colombiano (Montes de María, Serranía Perijá) y valles interandinos secos del Patía y Magdalena. En sistemas agroforestales acepta densidades 80-150 árb/ha como sombrío cafetalero estético-productivo. Manejo agroecológico: propagación por semilla recién recolectada con germinación rápida (10-20 días), vivero al sol parcial, plantación definitiva a 30-40 cm, podas de formación años 1-3, tolera podas urbanas anuales. Es lección viva de fenología tropical y soberanía paisajística: la floración masiva sincrónica disparada por estrés hídrico permite ver el ritmo estacional del trópico marcado por floración en vez de hojas; y plantar guayacán amarillo nativo en arbolado urbano provee la misma espectacularidad estética que el cerezo japonés sin las exigencias hídricas o climáticas exóticas. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Cárdenas & Salinas 2007 Libro Rojo Plantas Colombia, Trees of Antioquia, POWO Kew, GBIF Backbone Taxonomy.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "libro-rojo-plantas-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18_BATCH38_MADERABLES_SOMBRIO",
+      "id": "tabebuia_rosea",
+      "nombre_comun": "Guayacán rosado",
+      "nombre_comunes_regionales": [
+        "ocobo",
+        "roble morado",
+        "flor morado",
+        "macuelizo",
+        "Handroanthus rosea"
+      ],
+      "nombre_cientifico": "Tabebuia rosea (Bertol.) DC.",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "alto",
+      "roles_in_guild": [
+        "biomass_producer",
+        "pollinator_attractor",
+        "windbreak"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 1600,
+        "max_absoluto": 2000
+      },
+      "temperatura_c": {
+        "helada_letal": 4,
+        "optimo_min": 18,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "habito": "arbol caducifolio, 15-25 m de altura, floración rosada espectacular",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje"
+        ],
+        "best_method": "semilla",
+        "protocol_resumen": "Semilla alada recolectada de cápsulas dehiscentes en estación seca (enero-marzo en Caribe). Sin tratamiento pre-germinativo. Germinación 80-95% a 8-15 días, una de las germinaciones más rápidas de los maderables tropicales. Vivero a sol parcial, trasplante definitivo a 30-40 cm.",
+        "tiempo_a_establecimiento_dias": 50,
+        "notas": "Floración masiva sincrónica en estación seca (febrero-marzo Andes/Caribe) tras estrés hídrico: árbol totalmente desnudo de hojas se cubre de flores rosado-violáceas que tapizan el suelo al caer. Espectáculo paisajístico icónico del paisaje cafetero y de pueblos del Caribe.",
+        "fuente": "Bernal 2015; Cárdenas-Salinas 2007; Trees of Antioquia; arbolado urbano municipios Andes-Caribe"
+      },
+      "companions": [
+        "coffea_arabica",
+        "cordia_alliodora",
+        "erythrina_edulis",
+        "inga_edulis",
+        "tabebuia_chrysantha"
+      ],
+      "antagonists": [],
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": false,
+          "nota": "Árbol 15-25 m, inviable apartamento."
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Árbol ornamental-maderable patrimonial. Floración espectacular paisajística.",
+          "tips": [
+            "Plantar en zona visible (jardín frontal, andén)",
+            "Tolera podas urbanas anuales para formación"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": false,
+          "nota": "Inviable bajo cubierta."
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Sombrío cafetalero compatible 80-150 árb/ha. Maderable secundario en plantaciones mixtas. Arbolado urbano patrimonial municipal.",
+          "tips": [
+            "Madera dura amarillo-marrón apreciada para construcción rural",
+            "Polen y néctar para apicultura nativa",
+            "Tolera contaminación urbana mejor que Quercus"
+          ]
+        },
+        "restauracion": {
+          "viable": true,
+          "nota": "Pionera bosque seco tropical en restauración Caribe y valles interandinos.",
+          "tips": [
+            "Tolera suelos pedregosos y pendientes fuertes",
+            "Asocio con Bombacopsis quinata en bosque seco"
+          ]
+        }
+      },
+      "scale_viability": [
+        "huerto_casero",
+        "produccion",
+        "restauracion"
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "harvest_type": "biomasa",
+      "validation_level": "claude_draft",
+      "rol_ecologico": "Árbol ornamental-maderable patrimonial neotropical. Floración masiva sincrónica rosado-violácea en estación seca tras estrés hídrico, espectáculo paisajístico icónico de cafetales y pueblos del Caribe colombiano. Madera amarillo-marrón dura apreciada para construcción rural, vigas, postes, ebanistería. Flores grandes tubulares atraen abejas y colibríes. Importante en arbolado urbano municipal de ciudades cálidas y templadas.",
+      "valor_pedagogico": "El guayacán rosado u ocobo (Tabebuia rosea (Bertol.) DC., sinónimo válido Handroanthus roseus, Bignoniaceae) es uno de los árboles más patrimoniales del paisaje colombiano. Nativo desde el sur de México hasta Ecuador, en Colombia se distribuye prácticamente en todas las regiones bajas y medias: Caribe (Sucre, Córdoba, Bolívar, Magdalena, La Guajira), Andina (valles del Magdalena, Cauca y Patía, piedemonte llanero en Cundinamarca, Tolima, Huila, Antioquia, Santander, Norte de Santander, Caldas, Risaralda, Quindío, Valle), Pacífico (Chocó, Valle), Orinoquía (Casanare, Meta) entre 0 y 1.600 msnm en zona térmica cálida a templada. Árbol caducifolio de 15-25 m de altura con fuste recto y copa abierta hemisférica, hojas opuestas palmaticompuestas con 5 folíolos elípticos, su característica más espectacular es la floración masiva sincrónica en estación seca (febrero-marzo en Andes, enero-marzo en Caribe): tras estrés hídrico el árbol pierde totalmente las hojas y se cubre de grandes flores tubulares rosado-violáceas (5-8 cm) en panículas terminales que tapizan el suelo al caer convirtiendo calles y veredas en alfombras rosadas. Este fenómeno paisajístico es ícono cultural de pueblos cafeteros (Pueblo Tapao, Filandia, Salento), municipios del Caribe (Sincelejo, Valledupar), Ibagué, Bogotá (avenidas), y aparece en pinturas, poesía y postales turísticas. Su madera amarillo-marrón dura y resistente a la pudrición es apreciada para construcción rural (vigas, postes, durmientes), ebanistería e instrumentos musicales artesanales. Es importante en arbolado urbano municipal porque tolera mejor que el roble (Quercus) la contaminación urbana, los suelos compactados y las podas eléctricas, además provee néctar y polen para abejas y colibríes urbanos durante semanas de floración masiva. En sistemas agroforestales cafetales templados acepta densidades 80-150 árb/ha como sombrío estético-productivo. En restauración de bosque seco tropical (Caribe, valle del Magdalena) es pionera valiosa por tolerancia a suelos pedregosos y pendientes. La floración masiva sincrónica es tema clásico de fenología tropical: dispara la dehiscencia de cápsulas y la dispersión de semillas aladas justo al inicio de lluvias, maximizando germinación. Manejo agroecológico: propagación por semilla recién recolectada con germinación rápida (8-15 días), vivero al sol parcial, plantación definitiva a 30-40 cm, podas de formación años 1-3, tolera podas urbanas anuales. Es lección de soberanía paisajística: en lugar de plantar jacaranda exótica de Argentina-Brasil o cerezos japoneses ornamentales, el ocobo nativo provee la misma magia floral en su versión rosada colombiana, con valor maderable adicional. Fuentes Tier A: Bernal et al. 2015 Catálogo Plantas y Líquenes Colombia, Cárdenas & Salinas 2007, Trees of Antioquia, POWO Kew, GBIF Backbone Taxonomy.",
+      "source_ids": [
+        "bernal-2015-plantas-liquenes-colombia",
+        "libro-rojo-plantas-colombia",
+        "powo-kew",
+        "gbif-taxonomic-backbone",
+        "perez-arbelaez-1947-plantas-utiles"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "tamarindus_indica",
+      "nombre_comun": "Tamarindo",
+      "nombre_cientifico": "Tamarindus indica L.",
+      "familia_botanica": "Fabaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "taraxacum_officinale",
+      "nombre_comun": "Diente de leon",
+      "nombre_cientifico": "Taraxacum officinale F.H.Wigg.",
+      "familia_botanica": "Asteraceae",
+      "category": "atractores_polinizadores",
+      "thermal_zones": [
+        "templado",
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 1500,
+        "optimo_max": 3200,
+        "max_absoluto": 3200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "tecoma_stans",
+      "nombre_comun": "Chicalá",
+      "nombre_cientifico": "Tecoma stans (L.) Juss. ex Kunth",
+      "familia_botanica": "Bignoniaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 500,
+        "optimo_max": 2000,
+        "max_absoluto": 2000
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "tectona_grandis",
+      "nombre_comun": "Teca",
+      "nombre_cientifico": "Tectona grandis",
+      "familia_botanica": "Lamiaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 900,
+        "max_absoluto": 900
+      },
+      "source_ids": [
+        "graph_ica_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "theobroma_cacao",
+      "nombre_comun": "Cacao",
+      "nombre_cientifico": "Theobroma cacao L.",
+      "familia_botanica": "Malvaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 200,
+        "optimo_max": 900,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 10,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 32
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Se propaga por semilla recién extraída del fruto (recalcitrante: pierde viabilidad en 1-2 semanas si se seca) o por injerto de yema/púa de clones élite ICA/FEDECACAO sobre patrón franco. El injerto es estándar comercial: garantiza productividad, tolerancia a monilia y uniformidad."
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "fao-ecocrop",
+        "agrosavia-tibaitata",
+        "ica-resolucion-3168-2015"
+      ],
+      "valor_pedagogico": "El cacao (Theobroma cacao L.) es un árbol perenne de la familia Malvaceae nativo de la cuenca amazónica, cultivado en Colombia entre 0 y 1.200 msnm en zona térmica cálida húmeda. Se siembra en Santander (San Vicente de Chucurí, Rionegro, Landázuri — primer productor nacional), Antioquia (Magdalena Medio), Huila, Tolima, Arauca, Meta y la región Pacífica (Tumaco, Buenaventura) bajo sombra parcial de plátano, cítricos o maderables nativos (Cordia alliodora, Cedrela odorata, Erythrina poeppigiana). Árbol cauliflor (flores y frutos en el tronco), 4-8 m, ciclo a primera cosecha 3-5 años por injerto. Manejo agroecológico: poda sanitaria + de mantenimiento dos veces al año, recolección semanal de mazorcas enfermas (monilia, escoba de bruja, mazorca negra) y entierro o composteo lejos del cultivo, fertilización con compost + pulpa fermentada del propio cacao + ceniza. Asociar con leguminosas arbóreas (Inga edulis, Erythrina poeppigiana) para sombra + fijación de N, y plátano (Musa AAB) como sombra provisional los primeros 3 años. Fermentación post-cosecha 5-7 días en cajones de madera (no plástico) define el perfil de sabor exportable. Colombia es origen de cacaos finos de aroma reconocidos por ICCO. Fuentes Tier A: POWO Kew, GBIF Backbone Taxonomy, FAO Ecocrop, AGROSAVIA Tibaitatá, ICA Resolución 3168/2015.",
+      "validation_level": "claude_draft",
+      "estrato": "alto",
+      "companions": [
+        "vanilla_planifolia",
+        "bactris_gasipaes"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "theobroma_grandiflorum",
+      "nombre_comun": "Copoazú",
+      "nombre_cientifico": "Theobroma grandiflorum (Willd. ex Spreng.) K.Schum.",
+      "familia_botanica": "Malvaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 100,
+        "optimo_min": 100,
+        "optimo_max": 400,
+        "max_absoluto": 400
+      },
+      "source_ids": [
+        "graph_agrosavia_suelo"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "thymus_vulgaris",
+      "nombre_comun": "Tomillo",
+      "nombre_cientifico": "Thymus vulgaris L.",
+      "familia_botanica": "Lamiaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 800,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima",
+        "graph_agrosavia_suelo"
+      ],
+      "companions": [
+        "lavandula_dentata"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "tibouchina_lepidota",
+      "nombre_comun": "Siete cueros",
+      "nombre_cientifico": "Tibouchina lepidota (Bonpl.) Baill.",
+      "familia_botanica": "Melastomataceae",
+      "category": "ornamentales_nativas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_jardin_botanico_de_bogota_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "escallonia_pendula"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-18 (ver Chagra-strategy/dr-queue/species-verification-pending.md)",
+      "id": "tithonia_diversifolia",
+      "nombre_comun": "Botón de oro",
+      "nombre_comunes_regionales": [
+        "suncho amarillo",
+        "falsa girasol",
+        "mirasol",
+        "tithonia",
+        "árnica de campo"
+      ],
+      "nombre_cientifico": "Tithonia diversifolia (Hemsl.) A.Gray",
+      "familia_botanica": "Asteraceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "biomass_producer",
+        "dynamic_accumulator",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "naturalizada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 2300
+      },
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-silvopastoriles",
+        "agrosavia-forrajeras-2022",
+        "humboldt-flora-alto-andina",
+        "restrepo-2005-agroecologia"
+      ],
+      "valor_pedagogico": "El botón de oro o suncho amarillo (Tithonia diversifolia (Hemsl.) A.Gray, Asteraceae) es un arbusto perenne mesoamericano (México-Centroamérica) naturalizado y ampliamente difundido en Colombia entre 800 y 1.800 msnm (Cauca, Valle del Cauca, Tolima, Huila, Caldas, Quindío, Risaralda, Antioquia, Santander, Boyacá zona cafetera, Putumayo) como una de las especies más versátiles del agroecosistema tropical-andino colombiano. Arbusto de 2-4 m altura (ocasionalmente 6 m), crecimiento rápido (1-2 m primer año), tallos fistulosos verde-claros suculentos, hojas alternas grandes (15-30 cm) palmatilobadas o trilobadas pubescentes serradas, capítulos solitarios o agrupados de flores amarillo-anaranjadas intenso (8-15 cm diámetro, lígulas radiadas amarillo-oro, disco amarillo-anaranjado) muy llamativas tipo girasol. Fitoextractor extraordinario de fósforo (P) y potasio (K) del subsuelo: biomasa fresca contiene 3-4% N, 0.3-0.4% P y 3-4% K — equivalente a una fórmula NPK orgánica completa. Producción de biomasa explosiva: 30-80 ton MS/ha/año en cortes de 60-90 días, hasta 6-8 cortes anuales. Usos múltiples: (1) abono verde mulch en cultivos perennes (café, cacao, frutales), (2) forraje proteico para bovinos lecheros (CIPAV-AGROSAVIA: 20-25% PC, complemento de pastos), (3) banco de biomasa para compostaje y biopreparados (té de tithonia: 1 kg biomasa fresca + 10 L agua + 7 días = abono foliar líquido), (4) cerca viva agroecológica, (5) atractor masivo de polinizadores y enemigos naturales (avispas parasitoides, sírfidos, mariposas), (6) restauración de suelos degradados y compactados (raíces profundas que rompen capas duras). Manejo agroecológico: propagación por estaca semileñosa (30-50 cm, prendimiento >90%, sin hormonas) o semilla, distancia 0.5-1 m en franjas, poda de igualación a 50 cm post-floración, incorporación al suelo o mulch superficial. Lección viva de agroecología tropical: enseña a niñas, niños y campesinos que una sola especie puede reemplazar fertilizantes sintéticos costosos (P-K importados de Marruecos-Canadá) cosechando biomasa de su propio jardín — soberanía nutricional vegetal en cuatro meses. Reivindicado por escuelas agroecológicas de CIPAV, AGROSAVIA Palmira, y movimientos agroecológicos Colombia-Brasil. Fuentes Tier A: GBIF, POWO Kew, AGROSAVIA Silvopastoriles, AGROSAVIA Forrajeras 2022, IAvH Flora, Restrepo 2005 Agroecología.",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "trifolium_pratense",
+      "nombre_comun": "Trébol rojo",
+      "nombre_cientifico": "Trifolium pratense L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "trifolium_repens",
+      "nombre_comun": "Trébol blanco",
+      "nombre_cientifico": "Trifolium repens L.",
+      "nombre_comunes_regionales": [
+        "Carretón blanco"
+      ],
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "ground_cover",
+        "nitrogen_fixer",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 1000,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -10,
+        "optimo_min": 14,
+        "optimo_max": 22,
+        "max_tolerable": 28
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "medio",
+      "propagation": {
+        "metodo_principal": "semilla",
+        "notas": "Siembra al voleo; crea una alfombra densa que evita la erosión en los caminos de la finca chiguana."
+      },
+      "companions": [
+        "alnus_acuminata",
+        "zea_mays"
+      ],
+      "antagonists": [],
+      "valor_pedagogico": "El trébol blanco (Trifolium repens L.) se distribuye en Colombia principalmente en departamentos andinos como Cundinamarca, Boyacá y Nariño entre 1000 y 3200 msnm en zonas térmicas frías. Su manejo agronómico incluye propagación por semilla al voleo, formando una alfombra densa que previene la erosión, con ciclo perenne y asociaciones beneficiosas con aliso (Alnus acuminata) y maíz (Zea mays) para fijación de nitrógeno. En contextos campesinos andinos, se utiliza como cobertura viva en caminos de finca para mejorar la estructura del suelo y reducir compactación. Según el backbone taxonómico de GBIF y Plants of the World Online (POW0), esta leguminosa forrajera destaca por su valor ecológico en sistemas agroforestales de montaña.",
+      "validation_level": "claude_draft",
+      "estrato": "bajo",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "agrosavia-forrajeras-2022"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "triticum_aestivum",
+      "nombre_comun": "Trigo",
+      "nombre_cientifico": "Triticum aestivum L.",
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2100,
+        "optimo_min": 2100,
+        "optimo_max": 2700,
+        "max_absoluto": 2700
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "ulex_europaeus",
+      "_curation_status": "VALIDADO con fuentes Humboldt, CAR Cundinamarca, Fundación Natura, Mongabay",
+      "nombre_comun": "Retamo espinoso",
+      "nombre_comunes_regionales": [
+        "retamo",
+        "retamo amarillo"
+      ],
+      "nombre_cientifico": "Ulex europaeus L.",
+      "autor_ano": "Linnaeus, 1753",
+      "publicacion_original": "Species Plantarum 2: 741. 1753",
+      "familia_botanica": "Fabaceae",
+      "category": "especies_invasoras",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "invasive"
+      ],
+      "cultivable": false,
+      "conservation_status": "invasor",
+      "habito": "arbusto espinoso 1-3m",
+      "origen": "Europa occidental (Islas Británicas a Iberia)",
+      "clasificacion_uicn": "Entre las 100 peores especies invasoras del mundo (ISSG/UICN)",
+      "normativa_colombiana": [
+        {
+          "tipo": "regulatoria",
+          "alcance": "Lineamientos nacionales para prevención, manejo integral y restauración de áreas afectadas por U. europaeus y Genista monspessulana",
+          "norma": "Resolución 684 de 2018 del Ministerio de Ambiente y Desarrollo Sostenible",
+          "autoridad": "MADS"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Prohíbe uso de retamo espinoso en Distrito Capital",
+          "norma": "Resolución 7615 de 2009 Secretaría Distrital de Ambiente de Bogotá",
+          "autoridad": "SDA-Bogota"
+        },
+        {
+          "tipo": "regulatoria",
+          "alcance": "Prevención, manejo y control de U. europaeus y Genista monspessulana en jurisdicción CAR",
+          "norma": "Protocolo CAR Cundinamarca 2019",
+          "autoridad": "CAR"
+        }
+      ],
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2300,
+        "optimo_max": 3200,
+        "max_absoluto": 3500
+      },
+      "impacto_ecologico": "alto",
+      "ecosistemas_afectados": [
+        "bosque_alto_andino",
+        "subparamo",
+        "paramo",
+        "bordes_de_via",
+        "areas_quemadas"
+      ],
+      "mecanismos_invasion": [
+        "Germinación post-fuego masiva (semillas resisten altas temperaturas)",
+        "Banco de semillas persistente hasta 30-40 años en suelo",
+        "Densidad de banco de semillas 109-3.384 semillas/m2 en bordes de matorral (Ocampo-Zuleta & Solorza-Bejarano 2017)",
+        "Reproducción sexual + rebrote vegetativo desde tallos cortados",
+        "Crecimiento rápido (hasta 1m/año) forma matorrales densos que excluyen nativas",
+        "Fijación de N altera composición química del suelo, favoreciendo otras exóticas"
+      ],
+      "metodos_extraccion": [
+        {
+          "metodo": "desenraice_completo",
+          "efectividad": "alta",
+          "costo": "alto",
+          "notas": "Método preferido; requiere extraer TODO el sistema radical para evitar rebrote. Después de quemas el suelo queda blando y facilita extracción manual."
+        },
+        {
+          "metodo": "corte_bajo_repetido",
+          "efectividad": "media",
+          "costo": "medio",
+          "notas": "Corte a ras de suelo cada 3-4 meses por 2-3 años; agota reservas; NO funciona solo (rebrote garantizado)"
+        },
+        {
+          "metodo": "solarizacion",
+          "efectividad": "baja",
+          "costo": "medio",
+          "notas": "Solo efectiva en plántulas; semillas profundas resisten"
+        },
+        {
+          "metodo": "fuego_controlado",
+          "efectividad": "NEGATIVA",
+          "costo": "bajo",
+          "notas": "PROHIBIDO: el fuego detona germinación masiva del banco de semillas y empeora la invasión. Evidencia Mongabay 2024."
+        }
+      ],
+      "epoca_optima_remocion": "Temporada seca (diciembre-febrero altiplano; junio-agosto Nariño) ANTES de floración (para evitar dispersión de semillas). Evitar corte en floración o fructificación.",
+      "especies_nativas_sustitutas": [
+        "alnus_acuminata"
+      ],
+      "manejo_biomasa_extraida": "incineracion_controlada",
+      "_nota_manejo_biomasa": "Compostaje NO recomendado: semillas sobreviven temperaturas de compost doméstico. Incineración controlada en sitio autorizado o disposición en relleno sanitario con trituración previa. NUNCA dispersar en bosque o páramo.",
+      "riesgo_rebrote": "altisimo",
+      "protocolo_post_remocion": "Restauración activa obligatoria: siembra de especies nativas sustitutas en densidad 1100 ind/ha al siguiente semestre lluvioso. Monitoreo de rebrote semestral por 5 años. Corte inmediato de cualquier rebrote antes de 50cm altura.",
+      "foto_referencia_sugerida": "https://commons.wikimedia.org/wiki/Category:Ulex_europaeus",
+      "prompts_ia_externa": {
+        "plan_remocion": "Actúa como ecólogo de restauración colombiano.\nÁrea: {AREA_HA} ha invadida por Ulex europaeus en {MUNICIPIO} a {ALTITUD} msnm, densidad de matorral {DENSIDAD} (disperso/moderado/denso/muy_denso), pendiente {PENDIENTE}%, sin/con historia reciente de fuego.\n\nDiseña plan de 5 años: (a) método de extracción por zona, (b) disposición de biomasa, (c) especies nativas sustitutas con densidades, (d) calendario de monitoreo y control de rebrotes, (e) indicadores de éxito año 1, 3, 5."
+      },
+      "referencias_cientificas": [
+        "Ocampo-Zuleta, K. & Solorza-Bejarano, J. 2017. Banco de semillas de retamo espinoso en bosque altoandino. Biota Colombiana 18(supl 1): 89-98",
+        "Calderón-Sáenz 2003. Las especies invasoras en Colombia (diez peores)",
+        "Mongabay Colombia 2024. Retamo espinoso y áreas quemadas",
+        "CAR Cundinamarca 2019. Protocolo prevención manejo control Ulex europaeus y Genista monspessulana",
+        "Fundación Natura 2024. Experiencia piloto control retamo espinoso en Guasca"
+      ],
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "ocampo-solorza-2017",
+        "car-cundi-2019",
+        "res-684-2018-mads",
+        "mongabay-retamo-2024",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "antagonists": [
+        "erythrina_edulis"
+      ],
+      "valor_pedagogico": "El retamo espinoso (Ulex europaeus) es arbusto leguminoso europeo introducido en cerros orientales de Bogotá hacia 1948 como ornamental y cerca. Hoy es la INVASORA MÁS DESTRUCTIVA del altiplano cundiboyacense (2400-3300 msnm), ocupando >30000 ha en Cundinamarca según IAvH. Acidifica suelo, fija nitrógeno excesivo que altera sucesión nativa, y es PIROFÍTICA: sus semillas requieren fuego para germinar, incrementando incendios forestales en cerros bogotanos. Cobertura: Cruz Verde, Cerros Orientales Bogotá, Verjón, Tibanica. Manejo: extracción mecánica con cepa completa + revegetación inmediata con nativas (encenillo, mortiño, romero de páramo) + monitoreo 5+ años para nuevos brotes desde banco semillas. Resolución 684/2018 MADS prioridad nacional. Cobertura periodística Mongabay 2024 documenta el avance hacia el complejo Cruz Verde-Sumapaz.",
+      "tracking_mode": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "ullucus_tuberosus",
+      "nombre_comun": "Ulluco / Chugua",
+      "nombre_comunes_regionales": [
+        "Chugua",
+        "Melloco"
+      ],
+      "nombre_cientifico": "Ullucus tuberosus Caldas",
+      "familia_botanica": "Basellaceae",
+      "category": "tuberculos_raices",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "rastrero",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2400,
+        "optimo_min": 2800,
+        "optimo_max": 3400,
+        "max_absoluto": 3800
+      },
+      "temperatura_c": {
+        "helada_letal": -4,
+        "optimo_min": 8,
+        "optimo_max": 16,
+        "max_tolerable": 22
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "propagation": {
+        "metodo_principal": "tuberculo",
+        "notas": "Fenologia: siembra de tuberculo semilla, emergencia, cobertura baja, crecimiento vegetativo, tuberizacion, amarillamiento del follaje y cosecha."
+      },
+      "source_ids": [
+        "agrosavia-manual-tuberculos-andinos-2017",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "El ulluco o chugua (Ullucus tuberosus) es un tuberculo andino de la familia Basellaceae, cultivado en pisos frios y altoandinos de Colombia. Su fenologia se observa en siembra de tuberculo semilla, emergencia, crecimiento vegetativo bajo, tuberizacion, amarillamiento del follaje y cosecha. Es valioso para educacion agroecologica porque muestra que la seguridad alimentaria andina no depende solo de papa: tambien incluye especies con texturas, colores y ciclos propios. En manejo se debe cuidar semilla sana, rotacion y drenaje. Plagas y enfermedades clave incluyen babosas, gusanos de suelo, pulgones, virosis en material vegetativo y pudriciones de tuberculo.",
+      "plagas_criticas": [
+        "Babosas",
+        "Gusanos de suelo",
+        "Pulgones"
+      ],
+      "enfermedades_criticas": [
+        "Virosis en material vegetativo",
+        "Pudricion de tuberculo"
+      ],
+      "harvest_type": "tuberculo",
+      "cycleMonths": 7,
+      "companions": [
+        "solanum_tuberosum",
+        "oxalis_tuberosa"
+      ],
+      "antagonists": [],
+      "tracking_mode": "aggregate",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "urtica_dioica",
+      "_curation_status": "VALIDADO con fuentes académicas generales; NOTA: Urtica dioica sensu stricto es europea. En Colombia las especies nativas son Urtica urens y Urtica leptophylla. CONFIRMAR con taxónomo cuál es la que el catálogo actual tiene.",
+      "nombre_comun": "Ortiga",
+      "nombre_comunes_regionales": [
+        "ortiga mayor",
+        "pringamosa (confusión con otras Urticaceae)",
+        "chichicaste (regional)"
+      ],
+      "nombre_cientifico": "Urtica dioica L.",
+      "familia_botanica": "Urticaceae",
+      "_nota_taxonomica": "Urtica dioica L. es nativa de Europa y Asia, naturalizada en Colombia. Especies nativas andinas: Urtica urens L., Urtica leptophylla Kunth, Urtica magellanica Juss. ex Poir. La mayoría de usos tradicionales colombianos corresponden a U. dioica naturalizada y U. urens.",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "templado",
+        "frio"
+      ],
+      "estrato": "bajo",
+      "roles_in_guild": [
+        "dynamic_accumulator",
+        "pest_repellent",
+        "pollinator_attractor",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "cycleMonths": null,
+      "habito": "herbácea perenne 1-2m",
+      "altitud_msnm": {
+        "min_absoluto": 1500,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3500
+      },
+      "temperatura_c": {
+        "helada_letal": -8,
+        "optimo_min": 12,
+        "optimo_max": 20,
+        "max_tolerable": 28
+      },
+      "humedad_relativa_pct": {
+        "min": 50,
+        "optimo": 75,
+        "max": 95
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6,
+        "optimo_max": 7.2,
+        "max": 7.8
+      },
+      "radiacion": "sombra_parcial",
+      "agua": "alto",
+      "drenaje_requerido": "medio",
+      "companions": [
+        "rubus_glaucus",
+        "solanum_lycopersicum_san_marzano"
+      ],
+      "antagonists": [],
+      "recommended_covers": [
+        "trifolium_repens"
+      ],
+      "recommended_fences": [],
+      "propagation": {
+        "methods": [
+          "semilla",
+          "rizoma",
+          "division_mata"
+        ],
+        "best_method": "rizoma",
+        "protocol_resumen": "Extraer trozos de rizoma de 10-15cm con al menos 2-3 yemas. Plantar a 5cm profundidad en sustrato húmedo rico en MO. Rebrote en 10-15 días. Alternativa: semilla en bandeja (germinación 14-21 días).",
+        "tiempo_a_establecimiento_dias": 30,
+        "notas": "Propagación agresiva: contenerla con barrera física de 30cm profundidad en huertos pequeños."
+      },
+      "manejo_por_escala": {
+        "apartamento": {
+          "viable": true,
+          "nota": "Contenedor aislado mín 10L; no dejar rizomas escapar a otros contenedores.",
+          "tips": [
+            "Macerar hojas para purín enzimatico casero",
+            "Cosechar solo hojas jóvenes con guante"
+          ]
+        },
+        "huerto_casero": {
+          "viable": true,
+          "nota": "Sector dedicado de 1-2 m2 aislado por barrera física. Producción de purín para todo el huerto.",
+          "tips": [
+            "Cortar a 10cm para rebrote vigoroso",
+            "Secar hojas al aire para té medicinal"
+          ]
+        },
+        "invernadero_mediano": {
+          "viable": true,
+          "nota": "Útil como reservorio de fauna benéfica (parasitoides de áfidos).",
+          "tips": [
+            "Sector perimetral; no en camas de producción"
+          ]
+        },
+        "produccion": {
+          "viable": true,
+          "nota": "Cultivo dedicado para producción de purín y biomasa. 1000 m2 alimenta purín para 10 ha productivas.",
+          "tips": [
+            "Manejo mecánico de corte; secado para almacenamiento"
+          ]
+        },
+        "restauracion": {
+          "viable": false,
+          "nota": "No es especie nativa colombiana (U. dioica sensu stricto); para restauración preferir U. leptophylla o U. urens."
+        }
+      },
+      "scale_viability": [
+        "apartamento",
+        "huerto_casero",
+        "invernadero_mediano",
+        "produccion"
+      ],
+      "plan_nutricion_base": {
+        "N_ppm": {
+          "general": {
+            "min": 100,
+            "max": 200,
+            "unidad": "ppm"
+          }
+        },
+        "P_ppm": {
+          "general": {
+            "min": 20,
+            "max": 40,
+            "unidad": "ppm"
+          }
+        },
+        "K_ppm": {
+          "general": {
+            "min": 100,
+            "max": 200,
+            "unidad": "ppm"
+          }
+        },
+        "Ca_ppm": {
+          "min": 150,
+          "max": 250,
+          "unidad": "ppm"
+        },
+        "notas": "Acumuladora dinámica de Ca, Fe, Si, K. Requiere MO alta para expresión máxima de compuestos activos (ácido fórmico, histamina, serotonina en pelos urticantes).",
+        "biopreparados_por_etapa": {
+          "establecimiento": [
+            {
+              "biopreparado_id": "compost_maduro",
+              "dosis": "3kg/m2"
+            }
+          ],
+          "crecimiento": [
+            {
+              "biopreparado_id": "te_compost",
+              "dosis": "1:5",
+              "frecuencia_dias": 30
+            }
+          ]
+        },
+        "frecuencia_cromatografia": "anual",
+        "referencias_cientificas": [
+          "Restrepo 1996 ABC de agricultura orgánica y panes de piedra",
+          "Pamplona Roger 2006 Enciclopedia plantas medicinales"
+        ]
+      },
+      "usos_medicinales_tradicionales": [
+        {
+          "uso": "diurético",
+          "parte": "hojas jóvenes en infusión",
+          "validacion": "pendiente curación por farmacognosta"
+        },
+        {
+          "uso": "antiinflamatorio para artritis",
+          "parte": "hojas frescas aplicación tópica controlada",
+          "precaucion": "efecto urticante deseado en tratamientos antiguos; consentimiento del paciente obligatorio"
+        },
+        {
+          "uso": "galactogogo tradicional",
+          "parte": "infusión hojas secas",
+          "validacion": "pendiente"
+        }
+      ],
+      "usos_agroecologicos": [
+        {
+          "uso": "purín enzimático",
+          "preparacion": "1kg hojas frescas en 10L agua lluvia, fermentar 7-10 días tapado",
+          "aplicacion": "diluir 1:10 foliar como estimulante y repelente de pulgones"
+        },
+        {
+          "uso": "macerado antifúngico preventivo",
+          "preparacion": "1kg hojas en 10L agua 24h sin fermentar",
+          "aplicacion": "diluir 1:5 al suelo"
+        },
+        {
+          "uso": "activador de compostaje",
+          "preparacion": "capa 5cm entre capas de compost",
+          "efecto": "acelera mineralización por alto contenido N"
+        }
+      ],
+      "tests_suelo_recomendados": [
+        {
+          "tipo": "ph_casero",
+          "rango_objetivo": "6.0-7.2",
+          "frecuencia": "pre-siembra"
+        },
+        {
+          "tipo": "cromatografia_pfeiffer",
+          "frecuencia": "anual",
+          "objetivo": "verificar salud de suelo rico en MO"
+        }
+      ],
+      "plagas_criticas": [],
+      "enfermedades_criticas": [],
+      "prompts_ia_externa": {
+        "plan_biopreparado": "Actúa como agroecólogo colombiano.\nTengo {M2} m2 de ortiga (Urtica dioica) establecida. Quiero producir purín enzimático para aplicar en {AREA_CULTIVO_HA} ha de {CULTIVO}.\n\nDame (a) cantidad de biomasa a cosechar, (b) protocolo de fermentación paso a paso, (c) dilución y frecuencia de aplicación, (d) efectos esperados y límites del biopreparado (qué SÍ hace vs qué NO hace)."
+      },
+      "rol_ecologico": "Acumuladora dinámica de nutrientes. Atractora de sírfidos (parasitoides de pulgones). Alimento de larvas de mariposas. Planta indicadora de suelos ricos en N.",
+      "valor_pedagogico": "La Ortiga (Urtica dioica) es una herbácea perenne naturalizada en los Andes colombianos, presente en departamentos como Cundinamarca, Boyacá y Antioquia entre 1500-3000 msnm en zonas térmicas templado y frío. Presenta tricomas urticantes que contienen histamina y acetilcolina. Su manejo agronómico incluye propagación por semilla, rizoma o división de mata, con establecimiento en 30 días y ciclo perenne; se asocia beneficiosamente con sírfidos parasitoides de áfidos y no presenta plagas críticas significativas. En contexto campesino andino, se usa tradicionalmente para elaborar purín fermentado (7-14 días) como bioestimulante y repelente de pulgones, así como en infusiones medicinales. Su valor proteínico alcanza el 30% en materia seca, según validación en la fuente taxonómica Tier A GBIF Backbone Taxonomy.",
+      "saber_origen": {
+        "pueblo": "Uso campesino generalizado en Colombia (introducida en época colonial); uso médico tradicional en múltiples regiones",
+        "region": "Andes colombianos 1500-3500 msnm",
+        "practica_original": "Infusión medicinal, purín para huerta, activador de compost, aplicación tópica para artritis",
+        "validacion_cientifica_source_ids": [
+          "restrepo-1996-abc-agricultura-organica"
+        ]
+      },
+      "nota_conservacion": null,
+      "confidence_notes": "ATENCIÓN: confirmar taxonomía (U. dioica vs U. leptophylla vs U. urens) con agrónomo/botánico antes de distribuir. Los umbrales dados aplican a U. dioica sensu lato; pueden variar para especies nativas andinas.",
+      "harvest_type": "hoja",
+      "validation_level": "expert_reviewed",
+      "source_ids": [
+        "gbif-taxonomic-backbone",
+        "powo-kew",
+        "perez-arbelaez-1947-plantas-utiles",
+        "restrepo-rivera-2005"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "id": "vaccinium_corymbosum",
+      "nombre_comun": "Arándano",
+      "nombre_comunes_regionales": [
+        "arándano azul",
+        "blueberry",
+        "arándano highbush"
+      ],
+      "nombre_cientifico": "Vaccinium corymbosum L.",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "templado"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": null,
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2200,
+        "optimo_max": 2800,
+        "max_absoluto": 3000
+      },
+      "temperatura_c": {
+        "helada_letal": -5,
+        "optimo_min": 12,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "excelente",
+      "heladas_tolerancia": {
+        "umbral_c": -4,
+        "horas_acumuladas_max": 6,
+        "notas": "El arbusto en reposo tolera heladas fuertes, pero la flor abierta se daña por debajo de -1 °C. En el trópico de altura no hay reposo invernal verdadero, por lo que florece y fructifica de forma escalonada casi todo el año."
+      },
+      "companions": [],
+      "antagonists": [],
+      "_nota_antagonists": "Requisito agronómico crítico: pH del suelo muy ácido (4.5-5.5). No asociar en cama con cultivos de pH neutro (hortalizas comunes), porque las enmiendas de cal que esos cultivos requieren matan al arándano por clorosis férrica. Manejar en cama o contenedor aislado con sustrato acidificado (turba, corteza/aserrín de pino, azufre elemental).",
+      "propagation": {
+        "methods": [
+          "esqueje",
+          "acodo",
+          "micropropagacion"
+        ],
+        "best_method": "esqueje",
+        "protocol_resumen": "Propagación clonal por estaca semileñosa o leñosa enraizada en sustrato ácido y aireado, o por micropropagación (planta certificada). En Colombia se cultiva con variedades de bajo requerimiento de frío (low-chill) tipo 'Biloxi', 'Misty', 'Sharpblue' adaptadas al trópico de altura. Distancia 0.6-1 m entre plantas × 2.5-3 m entre hileras.",
+        "tiempo_a_establecimiento_dias": 90,
+        "notas": "Fenología por etapas en trópico de altura (sin reposo invernal marcado): (1) Establecimiento de raíz superficial fibrosa 0-12 meses — la raíz es somera, sin pelos radiculares, depende de micorrizas ericoides y de mulch ácido; (2) Brotación vegetativa y formación de madera frutal año 1-2; (3) Floración escalonada y cuajado desde el segundo año; (4) Desarrollo y maduración de baya ~60-90 días desde flor; (5) Cosecha escalonada casi continua con podas de renovación anuales; (6) Plena producción a partir del año 3-4, vida productiva 10-15 años. Acidificar y mantener pH 4.5-5.5 de por vida (monitoreo de pH del agua de riego).",
+        "fuente": "AGROSAVIA Manual de arándano (2018); ICA Resolución 3168/2015."
+      },
+      "plagas_criticas": [
+        "Frankliniella spp. (trips en floración)",
+        "Tetranychus urticae (ácaro)",
+        "Drosophila suzukii (mosca de alas manchadas, perfora la baya — cuarentenaria emergente)",
+        "Aphis spp. (áfidos, vectores de virus)",
+        "Aves frugívoras (pérdida directa de cosecha)"
+      ],
+      "enfermedades_criticas": [
+        "Botrytis cinerea (moho gris en flor y fruto)",
+        "Colletotrichum spp. (antracnosis / pudrición madura de la baya)",
+        "Phytophthora cinnamomi (pudrición de raíz por mal drenaje)",
+        "Clorosis férrica fisiológica por pH alto (NO patógeno — déficit de Fe asimilable si el suelo no es ácido)"
+      ],
+      "feeding_plan_template": {
+        "source": "AGROSAVIA Manual de arándano (2018) — establecimiento en sustrato acidificado, clima frío 2200-2800 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Plantar en hoyo con sustrato ácido + compost",
+            "biofertilizer_slug": "compost_maduro",
+            "dose_g": 1500,
+            "notes": "Mezclar suelo con corteza/aserrín de pino, turba y compost maduro. NUNCA aplicar cal. Acidificar a pH 4.5-5.5 con azufre elemental si es necesario. Drenaje excelente obligatorio."
+          },
+          {
+            "offset_days": 30,
+            "action": "Acolchar la base con corteza/aserrín de pino",
+            "notes": "Mulch ácido de pino mantiene humedad, baja pH gradualmente y protege la raíz superficial. Reponer cada 6 meses."
+          },
+          {
+            "offset_days": 60,
+            "action": "Drench con humus líquido acidificado",
+            "biofertilizer_slug": "humus_liquido",
+            "dose_ml": 200,
+            "notes": "Dilución 1:5. Aporte de N orgánico; preferir fuentes de N amoniacal/orgánico (no nitrato) que el arándano asimila mejor en suelo ácido."
+          },
+          {
+            "offset_days": 120,
+            "action": "Foliar preventivo con Bacillus subtilis en floración",
+            "biofertilizer_slug": "bacillus_subtilis_foliar",
+            "dose_ml": 80,
+            "notes": "Antagonista de Botrytis cinerea y antracnosis en flor/fruto. Aplicar al atardecer."
+          },
+          {
+            "offset_days": 180,
+            "action": "Foliar con biofertilizante de algas (micronutrientes)",
+            "biofertilizer_slug": "biofertilizante_algas",
+            "dose_ml": 60,
+            "notes": "Aporte de micronutrientes (Fe, Mn, B) quelatados; previene clorosis férrica si el pH se mantiene ácido. Vigilar amarillamiento internerval = señal de pH alto."
+          }
+        ]
+      },
+      "source_ids": [
+        "agrosavia-manual-arandano-2018",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El arándano azul (Vaccinium corymbosum L., familia Ericaceae), conocido en inglés como blueberry o highbush blueberry, es un arbusto frutal de origen norteamericano que se ha convertido en un cultivo de exportación de alto valor en el trópico de altura colombiano, sembrado en Cundinamarca (Sabana de Bogotá, oriente, Sumapaz), Antioquia (oriente antioqueño) y Boyacá entre 2.200 y 2.800 msnm con variedades de bajo requerimiento de frío (low-chill) como 'Biloxi', 'Misty' y 'Sharpblue', que florecen y fructifican de forma casi continua porque en el trópico no existe el reposo invernal de las zonas templadas. La particularidad agronómica que lo define —y que hay que entender antes de sembrarlo— es su exigencia de un suelo MUY ácido (pH 4.5-5.5) y de raíz superficial fibrosa sin pelos radiculares que depende de micorrizas ericoides y de un acolchado (mulch) ácido de corteza o aserrín de pino. En suelo de pH neutro o alcalino la planta sufre clorosis férrica (amarillamiento internerval por falta de hierro asimilable) y muere; por eso NO se debe asociar con cultivos que requieran encalado, y se maneja en cama o contenedor con sustrato acidificado. Sus retos fitosanitarios principales son el moho gris (Botrytis cinerea) y la antracnosis (Colletotrichum) en flor y fruto, los trips en floración, y la mosca de alas manchadas (Drosophila suzukii), plaga cuarentenaria emergente que perfora la baya madura. Manejo agroecológico: sustrato y mulch ácidos de pino, drenaje excelente (Phytophthora cinnamomi pudre la raíz con exceso de agua), Bacillus subtilis preventivo contra Botrytis, biofertilizante de algas para micronutrientes, riego con agua de pH controlado y malla anti-pájaros. El arándano enseña la lección de que el éxito de un frutal depende primero de ajustar el suelo a su fisiología —en este caso la acidez— antes que de cualquier fertilización. Fuentes Tier A: AGROSAVIA Manual de arándano 2018, ICA Resolución 3168/2015, GBIF Backbone, POWO Kew.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "vaccinium_floribundum",
+      "nombre_comun": "Agraz de paramo",
+      "nombre_cientifico": "Vaccinium floribundum Kunth",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": false,
+      "conservation_status": "nativo_silvestre",
+      "altitud_msnm": {
+        "min_absoluto": 2800,
+        "optimo_min": 2800,
+        "optimo_max": 3500,
+        "max_absoluto": 3500
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "tracking_mode": "individual",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "_curation_status": "BORRADOR_IA",
+      "_anti_confusion": "Vaccinium meridionale (agraz/mortiño, arándano andino NATIVO). NO confundir con Vaccinium corymbosum (arándano azul comercial introducido norteamericano) ni con Vaccinium floribundum (mortiño de páramo, otra especie nativa).",
+      "id": "vaccinium_meridionale",
+      "nombre_comun": "Agraz / Mortiño",
+      "nombre_comunes_regionales": [
+        "agraz",
+        "mortiño",
+        "arándano andino",
+        "arándano nativo",
+        "joyapa"
+      ],
+      "nombre_cientifico": "Vaccinium meridionale Sw.",
+      "familia_botanica": "Ericaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "nativo_silvestre",
+      "harvest_type": "fruto",
+      "cycleMonths": null,
+      "altitud_msnm": {
+        "min_absoluto": 1800,
+        "optimo_min": 2300,
+        "optimo_max": 3200,
+        "max_absoluto": 3800
+      },
+      "temperatura_c": {
+        "helada_letal": -6,
+        "optimo_min": 8,
+        "optimo_max": 20,
+        "max_tolerable": 26
+      },
+      "ph_suelo": {
+        "min": 4,
+        "optimo_min": 4.5,
+        "optimo_max": 5.5,
+        "max": 6
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "companions": [],
+      "antagonists": [],
+      "_nota_antagonists": "Como toda ericácea, requiere suelo ácido (4.5-5.5) y micorriza ericoide nativa; no encalar. Se asocia naturalmente en bordes de bosque altoandino y subpáramo.",
+      "propagation": {
+        "methods": [
+          "semilla",
+          "esqueje",
+          "acodo"
+        ],
+        "best_method": "esqueje",
+        "protocol_resumen": "Propagación por semilla (germinación lenta y errática, requiere sustrato ácido y luz) o clonal por estaca/acodo de material seleccionado de poblaciones silvestres. La domesticación está en curso (AGROSAVIA, UNAL): la mayor parte de la cosecha aún proviene de recolección silvestre en relictos de bosque altoandino.",
+        "tiempo_a_establecimiento_dias": 120,
+        "notas": "Fenología: arbusto perenne de bosque altoandino; floración y fructificación marcadas por la estacionalidad de lluvias, con cosecha silvestre tradicional en julio-agosto y noviembre-enero en la región andina. Fruto pequeño azul-negro de alto contenido de antocianinas y antioxidantes (mayor que el arándano comercial). Crecimiento lento; entra en producción al año 3-4."
+      },
+      "plagas_criticas": [
+        "Frankliniella spp. (trips en floración)",
+        "Aves frugívoras (dispersan pero compiten por la cosecha)",
+        "Larvas de lepidópteros defoliadores (en relictos silvestres)"
+      ],
+      "enfermedades_criticas": [
+        "Botrytis cinerea (moho gris en fruto en poscosecha)",
+        "Colletotrichum spp. (antracnosis del fruto)"
+      ],
+      "source_ids": [
+        "agrosavia-manual-frutales-tropicales",
+        "humboldt-flora-alto-andina",
+        "gbif-taxonomic-backbone",
+        "powo-kew"
+      ],
+      "valor_pedagogico": "El agraz o mortiño (Vaccinium meridionale Sw., familia Ericaceae) es el arándano andino NATIVO de Colombia, un arbusto silvestre de los bosques altoandinos y subpáramos que crece de forma natural entre 2.300 y 3.200 msnm en Cundinamarca, Boyacá (provincias de Norte y Gutiérrez, Arcabuco, Villa de Leyva), Santander, Antioquia, Nariño y la cordillera Oriental, y que también se distribuye en Venezuela y los Andes del norte (no es endémico de Colombia). Su fruto pequeño, azul-negro y de sabor ácido-dulce, ha sido recolectado tradicionalmente por las comunidades campesinas para preparar el 'sabajón de agraz', vinos, mermeladas, coladas y postres, y tiene un contenido de antocianinas y capacidad antioxidante superior al del arándano comercial importado (Vaccinium corymbosum), lo que lo posiciona como un superalimento nativo de altísimo potencial. A diferencia del arándano azul de cultivo, gran parte de la cosecha aún proviene de recolección silvestre en relictos de bosque altoandino, lo que lo vincula directamente a la conservación de esos ecosistemas: el agraz es a la vez alimento, ingreso campesino y especie clave para fauna frugívora y polinizadores. La domesticación y propagación clonal están en curso (AGROSAVIA, Universidad Nacional) para reducir la presión sobre las poblaciones silvestres. Como toda ericácea requiere suelo ácido (pH 4.5-5.5), micorriza ericoide nativa y NO tolera el encalado. Su manejo agroecológico privilegia el aprovechamiento sostenible de rodales silvestres (no cosechar más del fruto disponible, dejar semilla para regeneración) y el establecimiento de cultivos con material seleccionado en sustrato ácido. El agraz enseña el valor de los frutales nativos como alternativa de soberanía alimentaria frente a la dependencia de especies importadas, y la importancia de conservar el bosque altoandino que lo alberga. Fuentes Tier A: AGROSAVIA Manual de frutales tropicales, Humboldt Flora Alto-Andina, GBIF Backbone, POWO Kew.",
+      "validation_level": "claude_draft",
+      "tracking_mode": "individual",
+      "rol_restauracion": "secundaria",
+      "apta_ribera": null,
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "valeriana_officinalis",
+      "nombre_comun": "Valeriana",
+      "nombre_cientifico": "Valeriana officinalis L.",
+      "familia_botanica": "Caprifoliaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_universidad_nacional_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "vanilla_planifolia",
+      "nombre_comun": "Vainilla",
+      "nombre_comunes_regionales": [
+        "Vainilla planifolia",
+        "Vainilla de orquidea"
+      ],
+      "nombre_cientifico": "Vanilla planifolia Jacks. ex Andrews",
+      "familia_botanica": "Orchidaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido"
+      ],
+      "estrato": "medio",
+      "roles_in_guild": [
+        "crop",
+        "pollinator_attractor"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 100,
+        "optimo_max": 900,
+        "max_absoluto": 1200
+      },
+      "temperatura_c": {
+        "helada_letal": 8,
+        "optimo_min": 22,
+        "optimo_max": 28,
+        "max_tolerable": 34
+      },
+      "radiacion": "sombra_filtrada",
+      "agua": "alto",
+      "drenaje_requerido": "excelente",
+      "propagation": {
+        "metodo_principal": "esqueje",
+        "notas": "Fenologia: establecimiento de esqueje y tutor vivo, crecimiento vegetativo trepador, induccion floral en epoca seca corta, floracion de una manana, polinizacion manual, llenado de capsula y curado poscosecha."
+      },
+      "source_ids": [
+        "sinchi-de-la-raiz-cosecha-vainilla",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "gbif-taxonomic-backbone"
+      ],
+      "valor_pedagogico": "La vainilla (Vanilla planifolia) es una orquidea trepadora, no una leguminosa ni una planta de vaina comun. En Colombia se maneja en clima calido humedo, especialmente en sistemas agroforestales amazonicos y de bosque humedo con sombra filtrada, tutor vivo y alta materia organica. Su fenologia permite explicar etapas muy claras: establecimiento del esqueje, crecimiento vegetativo, induccion floral, floracion breve, polinizacion manual, llenado de capsula y curado aromatico. Las plagas y enfermedades clave incluyen pudriciones por Fusarium, antracnosis, babosas y hormigas cortadoras. Su valor pedagogico esta en mostrar coevolucion de orquideas, dependencia de polinizadores y beneficio cuidadoso de un producto de alto valor.",
+      "plagas_criticas": [
+        "Babosas",
+        "Hormigas cortadoras",
+        "Cochinillas"
+      ],
+      "enfermedades_criticas": [
+        "Fusarium oxysporum",
+        "Colletotrichum spp."
+      ],
+      "harvest_type": "fruto",
+      "cycleMonths": null,
+      "companions": [
+        "theobroma_cacao",
+        "musa_paradisiaca"
+      ],
+      "antagonists": [],
+      "tracking_mode": "individual",
+      "validation_level": "claude_draft",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    },
+    {
+      "id": "verbena_litoralis",
+      "nombre_comun": "Verbena",
+      "nombre_cientifico": "Verbena litoralis Kunth",
+      "familia_botanica": "Verbenaceae",
+      "category": "medicinales_alelopaticas",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "pest_repellent"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 0,
+        "optimo_max": 2800,
+        "max_absoluto": 2800
+      },
+      "source_ids": [
+        "graph_instituto_humboldt_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "vicia_faba",
+      "nombre_comun": "Haba",
+      "nombre_cientifico": "Vicia faba L.",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "frio",
+        "paramo"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2200,
+        "optimo_min": 2200,
+        "optimo_max": 3000,
+        "max_absoluto": 3000
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "alnus_acuminata",
+        "avena_sativa"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "biopreparados": [
+          {
+            "id": "inoculante_rhizobium_frijol",
+            "nombre": "Inoculante de Rhizobium para fríjol (fijación de nitrógeno)",
+            "tipo": "inoculante_microbiano",
+            "dosis": "APLICACIÓN A SEMILLA: humedecer la semilla con adherente y mezclar con el inoculante a la dosis de etiqueta (típico ~5-10 g de inoculante en turba por kg de semilla, o según producto), recubrir uniformemente y sembrar a la sombra el mismo día. No exponer la semilla inoculada al sol ni demorar la siembra (los rizobios mueren)."
+          }
+        ],
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "vicia_sativa",
+      "nombre_comun": "Veza común",
+      "nombre_cientifico": "Vicia sativa L.",
+      "familia_botanica": "Fabaceae",
+      "category": "abonos_verdes_coberturas",
+      "thermal_zones": [
+        "frio"
+      ],
+      "roles_in_guild": [
+        "ground_cover"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 2000,
+        "optimo_min": 2000,
+        "optimo_max": 2600,
+        "max_absoluto": 2600
+      },
+      "source_ids": [
+        "graph_agrosavia_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "avena_sativa",
+        "brassica_rapa_rapifera",
+        "chenopodium_quinoa",
+        "phacelia_tanacetifolia",
+        "raphanus_sativus_oleifer",
+        "zea_mays"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "vigna_unguiculata",
+      "nombre_comun": "Caupí",
+      "nombre_cientifico": "Vigna unguiculata (L.) Walp.",
+      "familia_botanica": "Fabaceae",
+      "category": "granos_legumbres",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "altitud_msnm": {
+        "min_absoluto": 100,
+        "optimo_min": 100,
+        "optimo_max": 1200,
+        "max_absoluto": 1200
+      },
+      "source_ids": [
+        "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima"
+      ],
+      "companions": [
+        "hibiscus_sabdariffa"
+      ],
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "vitis_labrusca",
+      "nombre_comun": "Uva Isabella",
+      "nombre_cientifico": "Vitis labrusca",
+      "familia_botanica": "Vitaceae",
+      "category": "frutales_perennes",
+      "thermal_zones": [
+        "calido",
+        "templado"
+      ],
+      "roles_in_guild": [
+        "crop"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 800,
+        "optimo_min": 800,
+        "optimo_max": 1800,
+        "max_absoluto": 1800
+      },
+      "source_ids": [
+        "graph_agrosavia_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "zanthoxylum_rhoifolium",
+      "nombre_comun": "Tachuelo",
+      "nombre_cientifico": "Zanthoxylum rhoifolium Lam.",
+      "familia_botanica": "Rutaceae",
+      "category": "arboles_sombra",
+      "thermal_zones": [
+        "calido",
+        "templado",
+        "frio"
+      ],
+      "roles_in_guild": [
+        "nurse_plant"
+      ],
+      "cultivable": true,
+      "conservation_status": "no_evaluada",
+      "altitud_msnm": {
+        "min_absoluto": 500,
+        "optimo_min": 500,
+        "optimo_max": 2000,
+        "max_absoluto": 2000
+      },
+      "source_ids": [
+        "graph_conif_url_por_verificar_agroclima"
+      ],
+      "graph_export_meta": {
+        "already_in_seed": false,
+        "controles_directos": [
+          {}
+        ]
+      }
+    },
+    {
+      "id": "zea_mays",
+      "nombre_comun": "Maíz criollo",
+      "nombre_cientifico": "Zea mays L.",
+      "nombre_comunes_regionales": [
+        "Maíz capio",
+        "Maíz pira",
+        "Maíz de montaña"
+      ],
+      "familia_botanica": "Poaceae",
+      "category": "cereales",
+      "thermal_zones": [
+        "frio",
+        "templado",
+        "calido"
+      ],
+      "roles_in_guild": [
+        "crop",
+        "biomass_producer"
+      ],
+      "cultivable": true,
+      "conservation_status": "cultivo_comun",
+      "harvest_type": "fruto",
+      "cycleMonths": 6,
+      "estrato": "alto",
+      "altitud_msnm": {
+        "min_absoluto": 0,
+        "optimo_min": 1800,
+        "optimo_max": 2800,
+        "max_absoluto": 3200
+      },
+      "temperatura_c": {
+        "helada_letal": -2,
+        "optimo_min": 15,
+        "optimo_max": 24,
+        "max_tolerable": 30
+      },
+      "ph_suelo": {
+        "min": 5.5,
+        "optimo_min": 6,
+        "optimo_max": 7,
+        "max": 8
+      },
+      "radiacion": "sol_pleno",
+      "agua": "medio",
+      "drenaje_requerido": "bueno",
+      "heladas_tolerancia": {
+        "umbral_c": 0,
+        "horas_acumuladas_max": 2,
+        "notas": "Sensible en etapas tempranas; variedades altoandinas como 'Capio' tienen mejor comportamiento ante el frío."
+      },
+      "companions": [
+        "chenopodium_quinoa",
+        "lupinus_mutabilis",
+        "mucuna_pruriens",
+        "phaseolus_vulgaris",
+        "trifolium_repens",
+        "cajanus_cajan",
+        "musa_paradisiaca",
+        "manihot_esculenta",
+        "arracacia_xanthorrhiza",
+        "dioscorea_alata_rotundata"
+      ],
+      "antagonists": [],
+      "propagation": {
+        "methods": [
+          "semilla"
+        ],
+        "best_method": "semilla sexual",
+        "notas": "Siembra directa en sitio definitivo, 2-3 semillas por sitio a 3-5 cm de profundidad, distancia 30-40 cm entre plantas × 80-90 cm entre surcos. Fenología por etapas: (1) Germinación y emergencia 0-10 días; (2) Desarrollo vegetativo (V3-V8, formación de hojas) 10-45 días; (3) Crecimiento rápido y diferenciación de la mazorca (V8-VT) 45-70 días; (4) Espigamiento/floración masculina (VT, emisión de polen de la espiga) y femenina (R1, emisión de estigmas/barbas de la mazorca) 70-90 días — etapa crítica de agua, una sequía aquí cuaja menos granos; (5) Llenado de grano (lechoso → pastoso → dentado) 90-130 días; (6) Madurez fisiológica (capa negra en la base del grano) y cosecha 130-180 días en variedades andinas de ciclo largo. En sistema Milpa el frijol trepa sobre el tallo del maíz y la calabaza cubre el suelo."
+      },
+      "notas_taxonomicas": "Las razas locales colombianas como 'Capio' (blanco harinoso), 'Cusco' (morado) y 'Pira' son fundamentales para la soberanía alimentaria de la zona altoandina. El sistema Milpa integra maíz con frijol y calabaza.",
+      "valor_pedagogico": "Lección de Milpa: el maíz criollo andino (Zea mays L.) se cultiva en el altiplano cundiboyacense y Nariño entre 1800-2800 msnm en zonas frío-templadas. Las variedades 'Capio', 'Pira' y 'Cusco' son patrimonios genéticos muiscas. Ciclo de 6 meses, propagación por semilla directa. En asociación tradicional milpa (frijol+calabaza) se emplea manejo integrado de Spodoptera frugiperda y Puccinia sorghi. Fuente: NRC (1989) Cultivos Andinos, AGROSAVIA, ICA Res. 3168/2015.",
+      "plagas_criticas": [
+        "Spodoptera frugiperda (cogollero)",
+        "Helicoverpa zea",
+        "Diabrotica balteata"
+      ],
+      "enfermedades_criticas": [
+        "Puccinia sorghi (roya común del maíz)",
+        "Fusarium spp. (pudrición de mazorca y tallo, produce micotoxinas)",
+        "Cercospora zeae-maydis (mancha gris de la hoja)",
+        "Helminthosporium / Exserohilum turcicum (tizón foliar norteño)"
+      ],
+      "feeding_plan_template": {
+        "source": "AGROSAVIA Manual de biopreparados (2015) + NRC (1989) Cultivos Andinos — plan agroecológico tipo Milpa para maíz criollo de clima frío 1800-2800 msnm.",
+        "primary_steps": [
+          {
+            "offset_days": 0,
+            "action": "Aplicar bocashi al sitio de siembra",
+            "biofertilizer_slug": "bocashi",
+            "dose_g": 150,
+            "notes": "Mezclar con el suelo del hoyo antes de depositar la semilla. En sistema Milpa, sembrar el frijol 2-3 semanas después para que el maíz le sirva de tutor."
+          },
+          {
+            "offset_days": 30,
+            "action": "Drench con biol en desarrollo vegetativo",
+            "biofertilizer_slug": "biol",
+            "dose_ml": 150,
+            "notes": "Dilución 1:7. Aporte de N en la fase V3-V8 de máximo crecimiento foliar. Coincide con el primer aporque."
+          },
+          {
+            "offset_days": 55,
+            "action": "Foliar con supermagro previo a floración",
+            "biofertilizer_slug": "supermagro",
+            "dose_ml": 60,
+            "notes": "Dilución 1:15. Refuerzo de K y micronutrientes antes del espigamiento (VT/R1), la etapa que define el número de granos por mazorca."
+          },
+          {
+            "offset_days": 70,
+            "action": "Aplicar Bacillus thuringiensis al cogollo si hay cogollero",
+            "biofertilizer_slug": "bacillus_thuringiensis",
+            "dose_g": 10,
+            "notes": "Control biológico de Spodoptera frugiperda (cogollero) dirigido al verticilo. Aplicar al atardecer cuando la larva está activa. Monitorear daño foliar antes de aplicar."
+          },
+          {
+            "offset_days": 95,
+            "action": "Foliar con lixiviado de frutas en llenado de grano",
+            "biofertilizer_slug": "lixiviado_frutas",
+            "dose_ml": 80,
+            "notes": "Aporte de azúcares y K para el llenado (fase lechoso-pastoso). Mantener humedad de suelo en esta etapa."
+          }
+        ]
+      },
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "gbif-taxonomic-backbone",
+        "ica-resolucion-3168-2015",
+        "powo-kew",
+        "nrc-1989-cultivos-andinos"
+      ],
+      "validation_level": "claude_draft",
+      "tracking_mode": "aggregate",
+      "graph_export_meta": {
+        "already_in_seed": true
+      }
+    }
+  ],
+  "sources": [
+    {
+      "id": "agrosavia-forrajeras-2022",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2022,
+      "titulo": "Gramíneas forrajeras en sistemas ganaderos andinos",
+      "institucion": "AGROSAVIA",
+      "observaciones": "STUB migrado de v3.0. _audit_note: buscar handle en repository.agrosavia.co por 'gramíneas forrajeras 2022' — cita STUB requiere precisión.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-guanabana-fecunda-tesoro-2020",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "AGROSAVIA",
+      "año": 2020,
+      "titulo": "AGROSAVIA Fecunda y AGROSAVIA Tesoro: cultivares de guanabana para agricultores colombianos",
+      "institucion": "AGROSAVIA",
+      "url": "https://www.agrosavia.co/media/sjooklw5/cartilla-guanabana.pdf",
+      "tier": "A",
+      "observaciones": "Cartilla institucional sobre dos cultivares colombianos de Annona muricata y su aptitud productiva."
+    },
+    {
+      "id": "agrosavia-leguminosas-andinas",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "AGROSAVIA",
+      "titulo": "Fichas técnicas de leguminosas andinas (haba, arveja, lenteja, frijol)",
+      "institucion": "Corporación Colombiana de Investigación Agropecuaria (AGROSAVIA)",
+      "observaciones": "Compilación de fichas técnicas de AGROSAVIA para leguminosas de clima frío. Año y volumen pendientes de consolidación. _audit_note: cita aglutinadora; buscar fichas individuales en repository.agrosavia.co o agrosavia.co/productos-y-servicios/oferta-tecnologica.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-arandano-2018",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2018,
+      "titulo": "Manual técnico para el cultivo de arándano (Vaccinium corymbosum) en Colombia",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'arándano Vaccinium 2018'. Respalda requerimiento de pH ácido (4.5-5.5), manejo de sustrato y mulch de pino.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-biopreparados-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual de biopreparados para la agricultura colombiana",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'manual biopreparados 2015' — referencia clave para fichas de bocashi/biol/supermagro.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-chachafruto-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual técnico para el cultivo de chachafruto (Erythrina edulis) en sistemas agroforestales andinos",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'chachafruto Erythrina edulis 2015'.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-frutales-tropicales",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA — Corporación Colombiana de Investigación Agropecuaria",
+      "año": 2017,
+      "titulo": "Manual técnico para el cultivo de frutales tropicales en Colombia",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'frutales tropicales 2017' o número de colección AGROSAVIA.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-tuberculos-andinos-2017",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2017,
+      "titulo": "Manual técnico para el cultivo de tubérculos andinos (oca, ulluco, mashua) en Colombia",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'tubérculos andinos oca ulluco mashua 2017'.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-manual-uchuva-2015",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "año": 2015,
+      "titulo": "Manual técnico para el cultivo de uchuva (Physalis peruviana) bajo condiciones colombianas",
+      "institucion": "AGROSAVIA",
+      "observaciones": "_audit_note: buscar handle en repository.agrosavia.co por 'manual técnico uchuva 2015'.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-silvopastoriles",
+      "tipo": "manual_tecnico",
+      "autores": "AGROSAVIA",
+      "titulo": "Sistemas silvopastoriles en el altoandino colombiano",
+      "institucion": "AGROSAVIA",
+      "observaciones": "STUB migrado de v3.0. Año y publicación específica pendientes. _audit_note: buscar en repository.agrosavia.co por 'silvopastoriles altoandino' — múltiples publicaciones AGROSAVIA candidatas.",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-sol-andina",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "AGROSAVIA",
+      "año": 2016,
+      "titulo": "Ficha técnica Sol Andina — papa criolla Grupo Phureja",
+      "institucion": "Corporación Colombiana de Investigación Agropecuaria (AGROSAVIA)",
+      "url": "https://www.agrosavia.co",
+      "tier": "A"
+    },
+    {
+      "id": "agrosavia-tibaitata",
+      "tipo": "base_datos",
+      "autores": "AGROSAVIA",
+      "titulo": "Centro de Investigación Tibaitatá — publicaciones sobre cultivos andinos y altoandinos",
+      "institucion": "AGROSAVIA",
+      "url": "https://www.agrosavia.co/investigacion/centros-de-investigacion/tibaitat%C3%A1",
+      "tier": "A"
+    },
+    {
+      "id": "bernal-2015-plantas-liquenes-colombia",
+      "tipo": "base_datos",
+      "autores": "Bernal, R.; Gradstein, S.R.; Celis, M. (eds.)",
+      "año": 2015,
+      "titulo": "Catálogo de Plantas y Líquenes de Colombia",
+      "institucion": "Instituto de Ciencias Naturales, Universidad Nacional de Colombia",
+      "url": "http://catalogoplantasdecolombia.unal.edu.co",
+      "tier": "A"
+    },
+    {
+      "id": "calderon-saenz-2003-invasoras",
+      "tipo": "articulo_revista",
+      "autores": "Calderón-Sáenz, E.",
+      "año": 2003,
+      "titulo": "Las especies invasoras en Colombia (diez peores)",
+      "revista_o_editorial": "Biota Colombiana",
+      "observaciones": "_audit_note: buscar en revistas.humboldt.org.co/index.php/biota — Biota Colombiana es journal IAvH con acceso abierto.",
+      "tier": "A"
+    },
+    {
+      "id": "car-cundi-2019",
+      "tipo": "resolucion_oficial",
+      "autores": "CAR — Corporación Autónoma Regional de Cundinamarca",
+      "año": 2019,
+      "titulo": "Protocolos de manejo de especies invasoras en jurisdicción CAR",
+      "institucion": "CAR Cundinamarca",
+      "observaciones": "STUB migrado de v3.0 — número de resolución pendiente. _audit_note: cita STUB sin número resolución; buscar en car.gov.co/normatividad o sigam.ambientebogota.gov.co — múltiples resoluciones CAR 2019 sobre invasoras.",
+      "tier": "A"
+    },
+    {
+      "id": "cenicafe-manual-cafetero-2013",
+      "tipo": "manual_tecnico",
+      "autores": "Cenicafé",
+      "año": 2013,
+      "titulo": "Manual del Cafetero Colombiano — Investigación y tecnología para la sostenibilidad de la caficultura",
+      "institucion": "Centro Nacional de Investigaciones de Café (Cenicafé)",
+      "url": "https://www.cenicafe.org/es/index.php/nuestras_publicaciones",
+      "tier": "A"
+    },
+    {
+      "id": "ciat-1995-alnus",
+      "tipo": "manual_tecnico",
+      "autores": "CIAT — Centro Internacional de Agricultura Tropical",
+      "año": 1995,
+      "titulo": "Alnus acuminata en sistemas agroforestales andinos",
+      "institucion": "CIAT Palmira",
+      "observaciones": "STUB migrado de v3.0 — título y paginación pendientes de confirmación. _audit_note: buscar en repository.cgiar.org (handle CIAT) por 'Alnus acuminata' — pre-Web era requiere búsqueda específica.",
+      "tier": "A"
+    },
+    {
+      "id": "cip-2006-ghislain",
+      "tipo": "articulo_revista",
+      "autores": "Ghislain, M.; Andrade, D.; Rodríguez, F.; Hijmans, R.J.; Spooner, D.M.",
+      "año": 2006,
+      "titulo": "Genetic analysis of the cultivated potato Solanum tuberosum L. Phureja Group using RAPDs",
+      "revista_o_editorial": "Theoretical and Applied Genetics",
+      "institucion": "CIP — International Potato Center",
+      "observaciones": "_audit_note: paper publicado en TAG 113:1515-1527 (2006); DOI canónico 10.1007/s00122-006-0399-7 — agregar DOI tras verificación final por agronomista.",
+      "tier": "A"
+    },
+    {
+      "id": "correa-pabon-carulla-2008",
+      "tipo": "articulo_revista",
+      "autores": "Correa, R.; Pabón, R.; Carulla, J.",
+      "año": 2008,
+      "titulo": "Valor nutricional del kikuyo (Cenchrus clandestinus) y respuestas productivas en ganadería lechera andina",
+      "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: candidato a deduplicar con scielo-correa-kikuyo-2018 (mismos autores serie kikuyo) — requiere curadura bibliográfica.",
+      "tier": "A"
+    },
+    {
+      "id": "doi-2025-oca-narino-agrosavia",
+      "tipo": "articulo_revista",
+      "autores": "Rosero-Alpala, M.G.; Rosero, D.; Tapie, W.A.",
+      "año": 2025,
+      "titulo": "Conservacion in situ y variabilidad morfologica de la oca (Oxalis tuberosa Mol.) en agroecosistemas tradicionales de Narino, Colombia",
+      "revista_o_editorial": "Revista Peruana de Biologia",
+      "doi": "10.15381/rpb.v32i4.30838",
+      "url": "https://www.scielo.org.pe/scielo.php?pid=S1727-99332025000400002&script=sci_arttext",
+      "institucion": "AGROSAVIA / Universidad Nacional de Colombia / Universidad Catolica de Oriente",
+      "tier": "A",
+      "observaciones": "Articulo revisado por pares con participacion AGROSAVIA sobre conservacion de oca en Narino."
+    },
+    {
+      "id": "fao-2013-quinua",
+      "tipo": "libro",
+      "autores": "FAO — Organización de las Naciones Unidas para la Alimentación y la Agricultura",
+      "año": 2013,
+      "titulo": "Quinua: Año Internacional de la Quinua 2013 — Documentos técnicos y estado del arte",
+      "institucion": "FAO",
+      "url": "https://www.fao.org/quinoa-2013",
+      "tier": "A"
+    },
+    {
+      "id": "fao-ecocrop",
+      "tipo": "base_datos",
+      "autores": "FAO",
+      "titulo": "EcoCrop — Crop Environmental Requirements Database",
+      "url": "https://gaez.fao.org/pages/ecocrop",
+      "tier": "A"
+    },
+    {
+      "id": "fedearroz-manual-arroz-2018",
+      "tipo": "manual_tecnico",
+      "autores": "Federación Nacional de Arroceros (FEDEARROZ) — Fondo Nacional del Arroz",
+      "año": 2018,
+      "titulo": "Manual técnico del cultivo de arroz (Oryza sativa) bajo riego y secano en Colombia",
+      "institucion": "FEDEARROZ",
+      "observaciones": "_audit_note: FEDEARROZ es la autoridad gremial-técnica del arroz en Colombia. Respalda fenología, manejo de Tagosodes orizicolus (sogata/virus de la hoja blanca) y Pyricularia oryzae (añublo/quema).",
+      "tier": "B"
+    },
+    {
+      "id": "flora-colombia-pteridophyta",
+      "tipo": "libro",
+      "autores": "Murillo-A., J.; Polanía, C.; et al.",
+      "titulo": "Flora de Colombia — Pteridophyta (helechos)",
+      "observaciones": "STUB migrado de v3.0 — editorial y año pendientes. _audit_note: serie Flora de Colombia editada por ICN-UNAL; buscar volumen Pteridophyta en biblioteca ICN o repositorio UNAL.",
+      "tier": "A"
+    },
+    {
+      "id": "gbif-colombia",
+      "tipo": "base_datos",
+      "autores": "GBIF Secretariat / SiB Colombia",
+      "titulo": "GBIF — Global Biodiversity Information Facility (datos de ocurrencia en Colombia)",
+      "url": "https://www.gbif.org/country/CO",
+      "tier": "A"
+    },
+    {
+      "id": "gbif-taxonomic-backbone",
+      "tipo": "base_datos",
+      "autores": "GBIF Secretariat",
+      "año": 2024,
+      "titulo": "GBIF Backbone Taxonomy",
+      "institucion": "Global Biodiversity Information Facility",
+      "url": "https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c",
+      "tier": "A"
+    },
+    {
+      "id": "graph_agrosavia_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Agrosavia",
+      "titulo": "Agrosavia",
+      "institucion": "Agrosavia",
+      "tier": "B"
+    },
+    {
+      "id": "graph_agrosavia_agrupado_con_achira_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Agrosavia (agrupado con achira)",
+      "titulo": "Agrosavia (agrupado con achira)",
+      "institucion": "Agrosavia (agrupado con achira)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_agrosavia_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Agrosavia + Claude(concuerda) (URL por verificar)",
+      "titulo": "Agrosavia + Claude(concuerda) (URL por verificar)",
+      "institucion": "Agrosavia + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_agrosavia_servicio_analisis_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Agrosavia servicio análisis",
+      "titulo": "Agrosavia servicio análisis",
+      "institucion": "Agrosavia servicio análisis",
+      "tier": "B"
+    },
+    {
+      "id": "graph_agrosavia_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Agrosavia",
+      "titulo": "Agrosavia",
+      "institucion": "Agrosavia",
+      "tier": "B"
+    },
+    {
+      "id": "graph_agrosavia_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Agrosavia (URL por verificar)",
+      "titulo": "Agrosavia (URL por verificar)",
+      "institucion": "Agrosavia (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_augura_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Augura (URL por verificar)",
+      "titulo": "Augura (URL por verificar)",
+      "institucion": "Augura (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_conif_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "CONIF + Claude(concuerda) (URL por verificar)",
+      "titulo": "CONIF + Claude(concuerda) (URL por verificar)",
+      "institucion": "CONIF + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_conif_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "CONIF (URL por verificar)",
+      "titulo": "CONIF (URL por verificar)",
+      "institucion": "CONIF (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_corpoica_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Corpoica",
+      "titulo": "Corpoica",
+      "institucion": "Corpoica",
+      "tier": "B"
+    },
+    {
+      "id": "graph_fedearroz_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Fedearroz (URL por verificar)",
+      "titulo": "Fedearroz (URL por verificar)",
+      "institucion": "Fedearroz (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_fedepalma_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Fedepalma",
+      "titulo": "Fedepalma",
+      "institucion": "Fedepalma",
+      "tier": "B"
+    },
+    {
+      "id": "graph_fenalce_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Fenalce + Claude(concuerda) (URL por verificar)",
+      "titulo": "Fenalce + Claude(concuerda) (URL por verificar)",
+      "institucion": "Fenalce + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_fenalce_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Fenalce (URL por verificar)",
+      "titulo": "Fenalce (URL por verificar)",
+      "institucion": "Fenalce (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_iavh_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "IAvH + Claude(concuerda) (URL por verificar)",
+      "titulo": "IAvH + Claude(concuerda) (URL por verificar)",
+      "institucion": "IAvH + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_iavh_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "IAvH (URL por verificar)",
+      "titulo": "IAvH (URL por verificar)",
+      "institucion": "IAvH (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_ica_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "ICA",
+      "titulo": "ICA",
+      "institucion": "ICA",
+      "tier": "B"
+    },
+    {
+      "id": "graph_ica_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "ICA + Claude(concuerda) (URL por verificar)",
+      "titulo": "ICA + Claude(concuerda) (URL por verificar)",
+      "institucion": "ICA + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_ica_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "ICA",
+      "titulo": "ICA",
+      "institucion": "ICA",
+      "tier": "B"
+    },
+    {
+      "id": "graph_ica_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "ICA (URL por verificar)",
+      "titulo": "ICA (URL por verificar)",
+      "institucion": "ICA (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_instituto_humboldt_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Instituto Humboldt + Claude(concuerda) (URL por verificar)",
+      "titulo": "Instituto Humboldt + Claude(concuerda) (URL por verificar)",
+      "institucion": "Instituto Humboldt + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_instituto_humboldt_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Instituto Humboldt (URL por verificar)",
+      "titulo": "Instituto Humboldt (URL por verificar)",
+      "institucion": "Instituto Humboldt (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_instituto_sinchi_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Instituto SINCHI + Claude(concuerda) (URL por verificar)",
+      "titulo": "Instituto SINCHI + Claude(concuerda) (URL por verificar)",
+      "institucion": "Instituto SINCHI + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_instituto_sinchi_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Instituto SINCHI (URL por verificar)",
+      "titulo": "Instituto SINCHI (URL por verificar)",
+      "institucion": "Instituto SINCHI (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_jardin_botanico_de_bogota_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Jardín Botánico de Bogotá + Claude(concuerda) (URL por verificar)",
+      "titulo": "Jardín Botánico de Bogotá + Claude(concuerda) (URL por verificar)",
+      "institucion": "Jardín Botánico de Bogotá + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_nd_institucional_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "ND institucional",
+      "titulo": "ND institucional",
+      "institucion": "ND institucional",
+      "tier": "B"
+    },
+    {
+      "id": "graph_sinchi_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "SINCHI + Claude(concuerda) (URL por verificar)",
+      "titulo": "SINCHI + Claude(concuerda) (URL por verificar)",
+      "institucion": "SINCHI + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_sinchi_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "SINCHI (URL por verificar)",
+      "titulo": "SINCHI (URL por verificar)",
+      "institucion": "SINCHI (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_unal_suelo",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "UNAL",
+      "titulo": "UNAL",
+      "institucion": "UNAL",
+      "tier": "B"
+    },
+    {
+      "id": "graph_universidad_nacional_claude_concuerda_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Universidad Nacional + Claude(concuerda) (URL por verificar)",
+      "titulo": "Universidad Nacional + Claude(concuerda) (URL por verificar)",
+      "institucion": "Universidad Nacional + Claude(concuerda) (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "graph_universidad_nacional_url_por_verificar_agroclima",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Universidad Nacional (URL por verificar)",
+      "titulo": "Universidad Nacional (URL por verificar)",
+      "institucion": "Universidad Nacional (URL por verificar)",
+      "tier": "B"
+    },
+    {
+      "id": "humboldt-flora-alto-andina",
+      "tipo": "libro",
+      "autores": "Instituto Alexander von Humboldt",
+      "titulo": "Flora del bosque alto andino colombiano",
+      "institucion": "Instituto Humboldt",
+      "observaciones": "STUB migrado de v3.0. _audit_note: cita STUB sin año; buscar en repository.humboldt.org.co por 'flora alto-andina' — múltiples publicaciones IAvH candidatas.",
+      "tier": "A"
+    },
+    {
+      "id": "humboldt-invasoras-andes",
+      "tipo": "libro",
+      "autores": "Instituto Alexander von Humboldt",
+      "titulo": "Plantas invasoras en los Andes colombianos",
+      "institucion": "Instituto Humboldt",
+      "observaciones": "STUB migrado de v3.0 — año y referencia específica pendientes. _audit_note: cita ambigua; buscar en repository.humboldt.org.co por 'plantas invasoras Andes' — varias publicaciones IAvH candidatas requieren curadura.",
+      "tier": "A"
+    },
+    {
+      "id": "ica-resolucion-3168-2015",
+      "tipo": "resolucion_oficial",
+      "autores": "ICA",
+      "año": 2015,
+      "titulo": "Resolución 3168 de 2015 — Reglamenta la producción, importación y exportación de semillas",
+      "institucion": "Instituto Colombiano Agropecuario (ICA)",
+      "observaciones": "_audit_note: buscar PDF oficial en ica.gov.co/normatividad o vinculo SUIN-Juriscol — norma vigente fundamental para semillas en Colombia.",
+      "tier": "A"
+    },
+    {
+      "id": "issg-uicn-invasoras",
+      "tipo": "lista_uicn",
+      "autores": "ISSG — Invasive Species Specialist Group (UICN)",
+      "titulo": "Global Invasive Species Database — 100 of the World's Worst Invasive Alien Species",
+      "url": "http://www.iucngisd.org",
+      "tier": "A"
+    },
+    {
+      "id": "jbb-plantas-medicinales",
+      "tipo": "libro",
+      "autores": "Jardín Botánico José Celestino Mutis — Bogotá",
+      "año": 2010,
+      "titulo": "Plantas medicinales de Cundinamarca y Boyacá",
+      "institucion": "Jardín Botánico de Bogotá José Celestino Mutis",
+      "observaciones": "_audit_note: publicación JBB; buscar en jbb.gov.co/publicaciones o catálogo Biblioteca JBB.",
+      "tier": "A"
+    },
+    {
+      "id": "ley-1930-2018-paramos",
+      "tipo": "resolucion_oficial",
+      "autores": "Congreso de la República de Colombia",
+      "año": 2018,
+      "titulo": "Ley 1930 de 2018 — Por medio de la cual se dictan disposiciones para la gestión integral de los páramos en Colombia",
+      "institucion": "República de Colombia",
+      "observaciones": "_audit_note: norma vigente publicada en Diario Oficial 50.667 (27-jul-2018); buscar en suin-juriscol.gov.co o funcionpublica.gov.co/eva/gestornormativo por 'Ley 1930 2018'.",
+      "tier": "A"
+    },
+    {
+      "id": "libro-rojo-plantas-colombia",
+      "tipo": "libro",
+      "autores": "Cárdenas-López, D.; Salinas, N.R. (eds.)",
+      "año": 2006,
+      "titulo": "Libro Rojo de Plantas de Colombia. Volumen 4 — Especies maderables amenazadas (y volúmenes sucesivos)",
+      "institucion": "Instituto Amazónico de Investigaciones Científicas SINCHI / Instituto Humboldt / MADS",
+      "observaciones": "_audit_note: serie multi-volumen Libro Rojo Plantas Colombia; buscar volúmenes en repository.humboldt.org.co o sinchi.org.co (cada volumen tiene handle distinto).",
+      "tier": "A"
+    },
+    {
+      "id": "mongabay-retamo-2024",
+      "tipo": "articulo_revista",
+      "autores": "Mongabay Latam",
+      "año": 2024,
+      "titulo": "El retamo espinoso: la plaga que amenaza los páramos colombianos",
+      "url": "https://es.mongabay.com",
+      "observaciones": "STUB — artículo periodístico, validar contra fuente primaria antes de citar en ministerial.",
+      "tier": "A"
+    },
+    {
+      "id": "mujica-1992-quinua",
+      "tipo": "articulo_revista",
+      "autores": "Mujica, A.",
+      "año": 1992,
+      "titulo": "Revisión bibliográfica sobre el cultivo de la quinua (Chenopodium quinoa Willd.) y el amaranto (Amaranthus caudatus L.) en los Andes",
+      "observaciones": "Publicación del Instituto Nacional de Investigaciones Agropecuarias (INIAP), Ecuador. Revisión exhaustiva de germoplasma, agronomía y usos tradicionales. _audit_note: buscar en repositorio.iniap.gob.ec o FAO ECOPORT (Mujica autor afiliado UNAP Puno + INIAP).",
+      "tier": "B"
+    },
+    {
+      "id": "nrc-1989-cultivos-andinos",
+      "tipo": "libro",
+      "autores": "National Research Council (NRC)",
+      "año": 1989,
+      "titulo": "Lost Crops of the Incas: Little-Known Plants of the Andes with Promise for Worldwide Cultivation",
+      "revista_o_editorial": "National Academy Press",
+      "isbn": "9780309042642",
+      "tier": "A"
+    },
+    {
+      "id": "nustez-rodriguez-2024-unal",
+      "tipo": "libro",
+      "autores": "Ñústez, C.E.; Rodríguez, L.E.",
+      "año": 2024,
+      "titulo": "Papa criolla Grupo Phureja, manual de recomendaciones técnicas para Cundinamarca",
+      "revista_o_editorial": "Editorial Universidad Nacional de Colombia",
+      "isbn": "9789585054929",
+      "tier": "B"
+    },
+    {
+      "id": "ocampo-solorza-2017",
+      "tipo": "articulo_revista",
+      "autores": "Ocampo, D.; Solorza, J.",
+      "año": 2017,
+      "titulo": "Manejo de retamo espinoso (Ulex europaeus) en zonas altoandinas de Cundinamarca",
+      "observaciones": "STUB migrado de v3.0 — revista y paginación pendientes. _audit_note: cita incompleta, requiere localizar revista (posibles candidatos: Colombia Forestal, Caldasia, boletín IAvH).",
+      "tier": "B"
+    },
+    {
+      "id": "pamplona-roger-2006-plantas-medicinales",
+      "tipo": "libro",
+      "autores": "Pamplona-Roger, J.D.",
+      "año": 2006,
+      "titulo": "Enciclopedia de las plantas medicinales",
+      "revista_o_editorial": "Safeliz",
+      "observaciones": "STUB migrado de v3.0 — confirmar ISBN. _audit_note: editorial Safeliz (Madrid); requiere verificación bibliotecaria para ISBN (existen ediciones 1997/2006/2010 con ISBNs distintos).",
+      "tier": "B"
+    },
+    {
+      "id": "perez-arbelaez-1947-plantas-utiles",
+      "tipo": "libro",
+      "autores": "Pérez Arbeláez, E.",
+      "año": 1947,
+      "titulo": "Plantas Útiles de Colombia",
+      "revista_o_editorial": "Librería Colombiana / Camacho Roldán",
+      "observaciones": "Obra clásica de la botánica económica colombiana; múltiples reediciones posteriores. _audit_note: edición pre-ISBN; copias digitalizadas pueden buscarse en archive.org o Biblioteca Nacional de Colombia.",
+      "tier": "A"
+    },
+    {
+      "id": "perez-rodriguez-gomez-2008",
+      "tipo": "articulo_revista",
+      "autores": "Pérez, L.; Rodríguez, L.E.; Gómez, M.I.",
+      "año": 2008,
+      "titulo": "Plan de fertilización de la papa criolla en el altiplano cundiboyacense",
+      "revista_o_editorial": "Agronomía Colombiana",
+      "volumen_numero": "26(3)",
+      "paginas": "477-486",
+      "observaciones": "_audit_note: Agronomía Colombiana revista UNAL — buscar artículo en revistas.unal.edu.co/index.php/agrocol por autor Pérez L. + año 2008.",
+      "tier": "B"
+    },
+    {
+      "id": "powo-kew",
+      "tipo": "base_datos",
+      "autores": "Royal Botanic Gardens, Kew",
+      "titulo": "Plants of the World Online (POWO)",
+      "url": "https://powo.science.kew.org",
+      "tier": "A"
+    },
+    {
+      "id": "res-684-2018-mads",
+      "tipo": "resolucion_oficial",
+      "autores": "MADS — Ministerio de Ambiente y Desarrollo Sostenible",
+      "año": 2018,
+      "titulo": "Resolución 684 de 2018 — Lista nacional de especies invasoras",
+      "institucion": "MADS Colombia",
+      "observaciones": "_audit_note: buscar PDF oficial en minambiente.gov.co/normativa o SUIN-Juriscol; complementa Resolución 207/2010 (catálogo invasoras).",
+      "tier": "A"
+    },
+    {
+      "id": "restauracion-cruz-verde-sumapaz",
+      "tipo": "manual_tecnico",
+      "autores": "Instituto Alexander von Humboldt + CAR Cundinamarca",
+      "año": 2018,
+      "titulo": "Plan de restauración ecológica páramos Cruz Verde — Sumapaz",
+      "institucion": "IAvH / CAR Cundinamarca",
+      "observaciones": "_audit_note: buscar handle en repository.humboldt.org.co o portal CAR Cundinamarca por título 'Cruz Verde Sumapaz'.",
+      "tier": "B"
+    },
+    {
+      "id": "restrepo-2005-agroecologia",
+      "tipo": "libro",
+      "autores": "Restrepo Rivera, Jairo",
+      "año": 2005,
+      "titulo": "Manual práctico ABC de la agricultura orgánica y panes de piedra",
+      "institucion": "Editorial Feriva",
+      "observaciones": "_audit_note: edición Cali (Editorial Feriva); ISBN no verificado — posible duplicado conceptual con restrepo-rivera-2005, requiere curadura bibliotecaria.",
+      "tier": "B"
+    },
+    {
+      "id": "restrepo-rivera-2005",
+      "tipo": "libro",
+      "autores": "Restrepo Rivera, Jairo",
+      "año": 2005,
+      "titulo": "Agroecología — principios y aplicación en el manejo de fincas tropicales",
+      "institucion": "Editorial Feriva",
+      "observaciones": "_audit_note: edición Cali (Editorial Feriva); ISBN no localizado en catálogos estándar — requiere verificación bibliotecaria.",
+      "tier": "B"
+    },
+    {
+      "id": "sib-colombia",
+      "tipo": "base_datos",
+      "autores": "Sistema de Información sobre Biodiversidad de Colombia",
+      "titulo": "SiB Colombia — Catálogo de la biodiversidad de Colombia",
+      "url": "https://sibcolombia.net",
+      "tier": "A"
+    },
+    {
+      "id": "sinchi-amazonia-colombiana",
+      "tipo": "base_datos",
+      "autores": "Instituto SINCHI",
+      "titulo": "Publicaciones científicas sobre especies de la Amazonía colombiana",
+      "institucion": "Instituto Amazónico de Investigaciones Científicas SINCHI",
+      "url": "https://www.sinchi.org.co",
+      "tier": "A"
+    },
+    {
+      "id": "sinchi-aprovechemos-sacha-inchi",
+      "tipo": "ficha_tecnica_institucional",
+      "autores": "Instituto SINCHI",
+      "titulo": "Aprovechemos el sacha inchi",
+      "institucion": "Instituto Amazonico de Investigaciones Cientificas SINCHI",
+      "url": "https://sinchi.org.co/aprovechemos-el-sacha-inchi",
+      "tier": "A",
+      "observaciones": "Ficha institucional sobre Plukenetia volubilis como fruto amazonico de interes nutricional y productivo."
+    },
+    {
+      "id": "sinchi-de-la-raiz-cosecha-vainilla",
+      "tipo": "informe_tecnico",
+      "autores": "Instituto SINCHI",
+      "titulo": "De la raiz a la cosecha: guia de vainilla en la Amazonia colombiana",
+      "institucion": "Instituto Amazonico de Investigaciones Cientificas SINCHI",
+      "url": "https://sinchi.org.co/files/publicaciones/publicaciones/pdf/De%20la%20raiz%20a%20la%20cosecha%20web.pdf",
+      "tier": "A",
+      "observaciones": "Documento institucional consultado para morfologia floral, polinizacion manual y manejo de Vanilla planifolia."
+    },
+    {
+      "id": "sinchi-frutas-amazonia-chontaduro",
+      "tipo": "informe_tecnico",
+      "autores": "Instituto SINCHI",
+      "año": 2008,
+      "titulo": "Colombia: frutas de la Amazonia",
+      "institucion": "Instituto Amazonico de Investigaciones Cientificas SINCHI",
+      "url": "https://www.sinchi.org.co/files/publicaciones/publicaciones/pdf/catalogo%20de%20frutales%20web.pdf",
+      "tier": "A",
+      "observaciones": "Catalogo institucional que registra Bactris gasipaes, su fruto y el uso de la yema para palmito."
+    },
+    {
+      "id": "uicn-red-list",
+      "tipo": "lista_uicn",
+      "autores": "IUCN — International Union for Conservation of Nature",
+      "titulo": "The IUCN Red List of Threatened Species",
+      "url": "https://www.iucnredlist.org",
+      "tier": "A"
+    }
+  ],
+  "biopreparados": [
+    {
+      "id": "bacillus_subtilis_foliar",
+      "nombre": "Bacillus subtilis (aplicación foliar)",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "cepa B. subtilis en suspensión 10^9 UFC/ml"
+      ],
+      "proceso_resumen": "Aplicación foliar 1L/ha cada 7-10 días. Control de Botrytis, Alternaria, Monilia. Compatible con caldos minerales.",
+      "tiempo_elaboracion_dias": 14,
+      "vida_util_dias": 30,
+      "source_ids": [
+        "agrosavia-bacillus-2018",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Prevención y control biológico de hongos foliares (Botrytis cinerea, Alternaria spp., Monilia spp., Sclerotinia) en hortalizas, frutales y aromáticas; aplicar al atardecer con cielo cubierto.",
+      "dosis": "Foliar: 2-5 ml/L de agua (suspensión 10^9 UFC/ml) cada 7-10 días en presión preventiva; 5-10 ml/L cada 5-7 días en presión curativa. Equivalente 1-2 L/ha. Volumen 200-400 L/ha según follaje.",
+      "target": [
+        "botrytis_cinerea",
+        "alternaria_spp",
+        "monilia_spp",
+        "sclerotinia_sclerotiorum",
+        "mildiu_velloso",
+        "oidio_temprano"
+      ],
+      "valor_pedagogico": "Bacteria Gram+ esporulada *Bacillus subtilis* sensu lato — revisión taxonómica post-2011: las cepas comerciales de biocontrol QST713 (Serenade®) y FZB42 (RhizoVital®), históricamente etiquetadas como *B. subtilis*, fueron reclasificadas como ***Bacillus velezensis*** tras Borriss et al. 2011 *IJSEM* 61:1786 y Dunlap et al. 2016 *Int J Syst Evol Microbiol* 66:1212. En Colombia, las cepas nativas AGROSAVIA bacterias 19 y 35 corresponden a *B. velezensis* (no a *B. subtilis* stricto sensu), aunque los registros ICA conservan el nombre histórico por estabilidad regulatoria. Mecanismos: coloniza la filosfera por exclusión competitiva y secreta lipopéptidos cíclicos (iturina, fengicina, surfactina) que perforan membranas fúngicas y disparan resistencia sistémica inducida (ISR) vía jasmonato/etileno. Estudios de campo con cepas tipo QST713 reportan 40-70% de control de Botrytis en fresa/mora según presión de inóculo y manejo (Punja & Utkhede 2003 *Trends Biotechnol* 21:400); AGROSAVIA 2018 reporta eficacias comparables con cepas nativas, sin resistencia cruzada ni residuos. Restrepo lo combina con bocashi: éste siembra microbiota en suelo, *B. velezensis* (ex *subtilis*) la extiende al follaje. ADVERTENCIA: esporas fotosensibles (UV degrada en 2-4 h) → aplicar SIEMPRE al atardecer con adherente; incompatible con cobre y caldo sulfocálcico (alternar 48 h)."
+    },
+    {
+      "_curation_status": "PENDING_DR_VERIFICATION_2026-05-17 (caso David trozador; DR-040 pest catalog)",
+      "id": "bacillus_thuringiensis",
+      "nombre": "Bacillus thuringiensis (BT) — bioinsecticida lepidópteros",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_curativo"
+      ],
+      "ingredientes": [
+        "esporas y cristales proteicos comerciales Bacillus thuringiensis var. kurstaki (BTk) o aizawai (BTa)",
+        "agua sin cloro",
+        "adherente foliar (jabón potásico opcional, 0.5%)"
+      ],
+      "proceso_resumen": "Producto comercial registrado ante ICA (no preparación finca). Dilución típica 1-2 g/L de agua. Aplicación foliar al ATARDECER (luz UV degrada cristales delta-endotoxina). Efectivo contra larvas Lepidoptera incluyendo Agrotis ipsilon (trozador), Spodoptera frugiperda (cogollero), Tuta absoluta (polilla tomate), Plutella xylostella (palomilla crucíferas). NO afecta abejas ni vertebrados. Repetir cada 7-10 días si presión alta. Eficacia tras ingesta de la larva — esperar 24-72h mortalidad.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 730,
+      "uso": "Aplicar al detectar larvas pequeñas (instares 1-3) de lepidópteros — antes son más sensibles a las endotoxinas Cry. Monitoreo con trampas de feromona o conteo de hojas con daño fresco para definir umbral.",
+      "dosis": "BTk en polvo mojable: 1-2 g/L de agua (500-1000 g/ha) con adherente foliar 0.5%. Aplicar al atardecer cada 7-10 días mientras dure la presión. En tomate y maíz, dirigir aspersión a cogollos y envés de hojas.",
+      "target": [
+        "trozador (Agrotis ipsilon, A. segetum) en almácigos",
+        "cogollero (Spodoptera frugiperda) en maíz",
+        "polilla del tomate (Tuta absoluta)",
+        "palomilla de las crucíferas (Plutella xylostella)",
+        "gusano de la mazorca (Helicoverpa zea)",
+        "minador del fruto (Neoleucinodes elegantalis)"
+      ],
+      "valor_pedagogico": "Bt produce cristales Cry (delta-endotoxinas) que el pH alcalino (>9.5) del mesenterón larval solubiliza y proteasas activan; las toxinas se unen a receptores cadherina/aminopeptidasa, forman poros y causan parálisis, sepsis y muerte en 24-72h. BTk (var. kurstaki) es la cepa más usada en Colombia orgánico contra Lepidoptera; BTi controla dípteros; BTt coleópteros. AGROSAVIA registra formulaciones nativas. Advertencia: UV inactiva cristales en 4-8h — aplicar al atardecer; pH agua >8 degrada; resistencia en P. xylostella exige rotar con neem o spinosad.",
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "ica-resolucion-3168-2015",
+        "gbif-taxonomic-backbone"
+      ]
+    },
+    {
+      "id": "biofertilizante_algas",
+      "nombre": "Biofertilizante de algas marinas",
+      "tipo": "extracto",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "algas marinas secas (Ascophyllum/Sargassum/Ecklonia)"
+      ],
+      "proceso_resumen": "Extracto hidrolizado alcalino o ácido. Aplicación foliar 1:500. Fuente de citoquininas, auxinas, oligoelementos. Estimulante de enraizamiento.",
+      "tiempo_elaboracion_dias": 0,
+      "vida_util_dias": 365,
+      "uso": "Bioestimulante foliar en trasplante, prefloración y post-estrés (sequía, granizo, helada leve); también en remojo de semillas/esquejes para enraizamiento.",
+      "dosis": "Foliar 2-3 mL/L (1:500) cada 10-15 días; remojo de semillas 5 mL/L por 12h; drench 3-5 mL/L en trasplante. No exceder 4 aplicaciones por ciclo para evitar desbalance hormonal.",
+      "target": [
+        "estrés hídrico y térmico",
+        "trasplante con baja sobrevivencia",
+        "deficiencias de micronutrientes (B, Zn, Mo)",
+        "raíces débiles o sistema radicular pobre",
+        "floración irregular o aborto floral"
+      ],
+      "valor_pedagogico": "El extracto de algas pardas concentra citoquininas (zeatina) y auxinas (IAA) que estimulan división celular y enraizamiento; aporta manitol osmoprotector y oligoelementos quelados (B, Zn, Mn) biodisponibles vía cutícula foliar. Alginatos y laminarinas activan defensa SAR como elicitores PAMP. En Colombia se usan importados (Ascophyllum nodosum) y lixiviados de Sargassum del Caribe. Advertencia: NO mezclar con caldo bordelés ni sulfocálcico (oxidan los reguladores); aplicar al atardecer (UV degrada citoquininas).",
+      "source_ids": [
+        "khan-2009-seaweed-extracts",
+        "agrosavia-manual-biopreparados-2015"
+      ]
+    },
+    {
+      "id": "biol",
+      "nombre": "Biol",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "estiércol fresco (vaca/cabra)",
+        "leche o suero",
+        "melaza",
+        "ceniza",
+        "agua",
+        "roca fosfórica (opcional)"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica 30-45 días en biodigestor o caneca sellada con válvula de gases. Aplicación foliar diluido 1:10.",
+      "tiempo_elaboracion_dias": 40,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "pinheiro-machado-2017-biofertilizantes"
+      ],
+      "uso": "Foliar al amanecer o atardecer (evitar sol directo) cada 7-15 días en etapas de crecimiento vegetativo y prefloración. También aplicable al pie/riego durante toda la etapa productiva. Compatible con caldos minerales si se aplica 48 h antes/después.",
+      "dosis": "Foliar: 100-200 ml/L de agua (dilución 1:10 a 1:5). Drench/riego al pie: 1-2 L/m² o 200 L/ha del concentrado diluido 1:5. Empezar con dilución alta (1:20) en plántulas para evitar fitotoxicidad.",
+      "dosis_aplicacion": "Digestion anaerobica (biodigestor/caneca con sello de agua) 30-90 dias; el filtrado liquido es el biol, se aplica diluido. Dilucion foliar del 5% al 50% segun fuente y etapa; rango campesino comun 10-20% (1-2 L de biol por 10 L de agua). Drench al suelo mas concentrado (hasta 50%). Bomba de 20 L foliar: 2-4 L de biol. Empezar al 1:20 en plantulas para evitar fitotoxicidad.",
+      "frecuencia": "Foliar cada 10 a 15 dias; al suelo segun necesidad del cultivo, en vegetativa a productiva.",
+      "metodo": "foliar diluido y drench al suelo",
+      "precaucion_seguridad": "Bajo riesgo. Producto vivo: usar pronto y filtrado. Riesgo sanitario por patogenos del estiercol: lavado de manos, no aplicar a partes comestibles proximas a cosecha. No liberar los gases del biodigestor en espacio cerrado.",
+      "fuente": "Restrepo Rivera / literatura andina de biodigestores (PROMMRA-UNALM rangos de dilucion). Dilucion variable entre fuentes.",
+      "confianza": "media",
+      "target": [
+        "fertilizante_foliar_N",
+        "bioestimulante_fitohormonal",
+        "inoculacion_microbiana_filosfera",
+        "resistencia_induccion_SAR"
+      ],
+      "valor_pedagogico": "Biofertilizante anaeróbico andino, popularizado por Restrepo y Pinheiro Machado. La fermentación selecciona bacterias fijadoras de N (Azotobacter, Clostridium) y solubilizadoras de P, generando fitohormonas (auxinas, citoquininas) y ácidos quelantes. La leche aporta caseínas fungistáticas y Lactobacillus que inducen ISR (Resistencia Sistémica Inducida, vía jasmonato/etileno; Pieterse et al. 2014 Annu Rev Phytopathol 52:347). Vs. urea 46-0-0 entrega N orgánico sin quemar follaje. Advertencias: olor amoniacal = mal sellado (descartar); filtrar antes de boquilla; >30% en lechuga/fresa necrosa. AGROSAVIA 2015: +15-25% en hortalizas andinas.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "bocashi",
+      "nombre": "Bocashi",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "gallinaza",
+        "cascarilla de arroz",
+        "tierra de capote",
+        "carbón vegetal triturado",
+        "afrecho",
+        "melaza",
+        "levadura activa de panadería o cervecera (Saccharomyces cerevisiae)",
+        "agua"
+      ],
+      "proceso_resumen": "Fermentación aeróbica 15-21 días con volteo diario hasta bajar temperatura a <40°C. Humedad 'prueba de puño': al apretar un puñado, el agua no gotea pero la mano queda húmeda.",
+      "tiempo_elaboracion_dias": 18,
+      "vida_util_dias": 180,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados"
+      ],
+      "uso": "Al sustrato pre-siembra incorporado 0-15 cm, o como abonado de fondo en hoyos de trasplante. Reaplicación cada ciclo de cultivo (3-6 meses) en bandas al pie de la planta.",
+      "dosis": "1-2 kg/m² al voleo en cama de siembra; 100-300 g/planta en hoyo de trasplante; 8-15 t/ha en aplicación general. Reducir 30% si el suelo ya tiene >4% MO.",
+      "dosis_aplicacion": "Abono solido fermentado aerobico (12-21 dias, volteos diarios manteniendo <50 grados C). NO se diluye. Dosis de campo: 80-150 g por planta/sitio en hortalizas; 1-2 kg por arbol; al voleo en cama 1-2 kg/m2 incorporado a los primeros 5-10 cm. Para almacigo: 1 parte bocashi por 3-4 partes de sustrato.",
+      "frecuencia": "En siembra/trasplante y refuerzos cada 1,5 a 3 meses segun cultivo (preparacion de cama, siembra y mantenimiento).",
+      "metodo": "solido incorporado al suelo (no foliar)",
+      "precaucion_seguridad": "Bajo riesgo. Aplicar MADURO y frio: un bocashi inmaduro/caliente quema raices. Polvo fino: usar tapabocas al manipular grandes volumenes. No poner concentrado en contacto directo con la semilla sin mezclar con sustrato.",
+      "fuente": "Restrepo Rivera, J. — ABC de la agricultura organica (Bocashi); manuales SENA/Agrosavia de compostaje rapido. Dosis g/planta de referencia campesina.",
+      "confianza": "media",
+      "target": [
+        "fertilizante_general",
+        "inoculacion_microbiana_suelo",
+        "mejorador_estructura_suelo",
+        "aporte_materia_organica"
+      ],
+      "valor_pedagogico": "Tecnología japonesa (bokashi 暈し, del verbo bokasu — 'mezclar/atenuar'; refiere al proceso de dilución/mezcla del compost en sustrato. La fermentación en japonés agrícola se llama hakkō 発酵 — distinción técnica importante) popularizada en la línea de agricultura natural Fukuoka-Higa y adaptada a Latinoamérica por Jairo Restrepo. Fermentación aeróbica 45-55°C selecciona microbiota termófila (Bacillus, actinomicetos, levaduras) y estabiliza N orgánico no lixiviable, a diferencia de la urea sintética. La cascarilla aporta Si bioactivo; el carbón vegetal actúa como biochar (CEC + hábitat microbiano). Advertencias: >5 kg/m² en hortalizas de hoja → exceso N atrae áfidos y mildeo; humedad >65% vira a pútrida y pierde N. AGROSAVIA 2015 documenta respuestas equivalentes a 50% NPK sintético en papa criolla y maíz andino.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "caldo_bordeles",
+      "nombre": "Caldo bordelés",
+      "tipo": "caldo",
+      "proposito": [
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "sulfato de cobre",
+        "cal hidratada",
+        "agua"
+      ],
+      "proceso_resumen": "100g sulfato + 100g cal en 10L agua, pH neutralizado (lámina de hierro no oxida). Aplicación foliar preventiva contra hongos (Phytophthora, mildius). No mezclar con otros.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 1,
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados",
+        "cenicafe-manual-cafetero-2013"
+      ],
+      "uso": "Foliar preventivo al amanecer cada 10-14 días durante etapas de alta humedad relativa (>80%) o llovizna persistente. Suspender en floración (afecta polinizadores y cuaje) y 21 días antes de cosecha. Aplicar el mismo día de preparación — vida útil <24 h una vez mezclado.",
+      "dosis": "Concentración estándar 1% (10 g sulfato + 10 g cal por L de agua); foliar 1:1 (sin diluir, 10 L/100 m²) o lo equivalente a 200-400 L/ha. Cultivos sensibles (solanáceas en floración, durazno): bajar a 0.5%. Tratamiento invernal de troncos: hasta 2%.",
+      "dosis_aplicacion": "Caldo madre al 1% para 10 L: 100 g de sulfato de cobre pentahidratado + 100 g de cal. Disolver el cobre en agua tibia (recipiente NO metalico) y la cal aparte; verter el cobre sobre la lechada de cal (NUNCA al reves) y aforar a 10 L. Relacion 1:1:100 = 1 kg cobre : 1 kg cal : 100 L. Prueba del clavo o pH neutro-alcalino antes de aplicar (el clavo no debe cobrizarse). Hortalizas tiernas: 0,5% (50 g + 50 g / 10 L). Bomba de 20 L al 1%: 200 g sulfato + 200 g cal. Listo para aplicar SIN diluir.",
+      "frecuencia": "Foliar preventivo cada 8 a 15 dias en periodo de presion de enfermedad o tras lluvias; cada 15 dias como preventivo de fondo. NO aplicar en floracion plena ni con sol fuerte. Carencia ~15-21 dias antes de cosecha.",
+      "metodo": "foliar (aspersion cubriendo haz y enves)",
+      "precaucion_seguridad": "TOXICOLOGIA COBRE: metal pesado, fitotoxico en exceso y acumulable en el suelo. EPI: guantes, careta y gafas. Neutralizar SIEMPRE con cal (pH neutro-alcalino) antes de aplicar para evitar quemadura. NO mezclar con caldo sulfocalcico (incompatibles; esperar ~20 dias entre uno y otro). Uso RESTRINGIDO en certificacion organica (limite de cobre metalico por hectarea/ano segun norma, Resolucion ICA 698/2011). No aplicar sobre cucurbitaceas jovenes ni durazno en floracion.",
+      "fuente": "Restrepo Rivera, J. — ABC de la agricultura organica (concentracion 1% clasica); Agrosavia/ICA manejo fitosanitario; Resolucion ICA 698/2011 (uso restringido).",
+      "confianza": "alta",
+      "target": [
+        "phytophthora_infestans",
+        "mildeo_velloso",
+        "antracnosis_colletotrichum",
+        "roya_cafe_hemileia",
+        "cercosporiosis",
+        "fungicida_cuprico_preventivo_amplio_espectro"
+      ],
+      "valor_pedagogico": "Fungicida cúprico de Burdeos 1885 (Millardet), fundacional en orgánico certificado (IFOAM, EU 2018/848 — máx 4 kg Cu/ha/año). CuSO4 neutralizado con cal forma Cu(OH)2·CuSO4 coloidal que libera Cu²⁺ con humedad/exudados fúngicos, inhibiendo tioles en oomicetes (Phytophthora, Peronospora) y hongos (Colletotrichum, Hemileia del café). pH 7-8 crítico: ácido = Cu²⁺ fitotóxico, alcalino = precipita inactivo. Test lámina de hierro: si se cubre de Cu rojizo, falta cal. NO mezclar con sulfocálcico (CuS) ni aceites; Cu >100 ppm daña lombrices y micorrizas — rotar con Bacillus o Trichoderma.",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "compost_maduro",
+      "nombre": "Compost maduro",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "residuos vegetales",
+        "estiércol maduro",
+        "ceniza",
+        "tierra de bosque"
+      ],
+      "proceso_resumen": "Compostaje aeróbico por pila con volteos cada 7 días durante 90-120 días. Maduro cuando baja a temperatura ambiente, color oscuro, olor a tierra fresca.",
+      "tiempo_elaboracion_dias": 100,
+      "vida_util_dias": 365,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-2007-biopreparados",
+        "restrepo-2005-agroecologia"
+      ],
+      "uso": "Enmienda orgánica base para preparación de eras, hoyos de siembra y mantenimiento anual del suelo; restaura materia orgánica, estructura, capacidad de intercambio catiónico (CIC) y microbiota tras décadas de manejo extractivista.",
+      "dosis": "Pre-siembra hortalizas: 2-5 kg/m² (20-50 t/ha) incorporados a 15 cm. Hoyo de siembra frutales: 5-10 kg por hoyo mezclado con tierra. Mantenimiento perennes: 3-5 kg/planta/año en corona, sin tocar el tallo. Sustrato semillero: 30-40% del volumen mezclado con tierra negra y cascarilla de arroz.",
+      "target": [
+        "baja_materia_organica_suelo",
+        "estructura_suelo_compactada",
+        "baja_capacidad_intercambio_cationico",
+        "deficiencia_n_p_k_balanceada",
+        "microbiota_suelo_empobrecida",
+        "retencion_agua_suelo"
+      ],
+      "valor_pedagogico": "Compostaje aeróbico mesofílico-termofílico: sucesión de bacterias (Bacillus, Pseudomonas), actinomicetos (Streptomyces, olor a tierra) y hongos saprófitos que degradan C:N 30:1 hasta húmicos estables (C:N ~12:1). Fase termofílica 55-70°C esteriliza patógenos y semillas de arvenses. Restrepo 1996 y AGROSAVIA 2015 lo posicionan como pilar agroecológico: vs. bocashi (microbioma fresco), aporta materia orgánica HUMIFICADA estable que mejora CIC y retención hídrica (1 g humus = 4-6 g H2O). Vs. NPK químico: no saliniza, secuestra C y reinocula microbiota. CONTROL: C:N 10-15, germinación rábano >80%, sin olor amoniacal. NO usar inmaduro ni de origen desconocido (clopiralida residual mata leguminosas)."
+    },
+    {
+      "id": "humus_liquido",
+      "nombre": "Humus líquido (lixiviado de lombriz)",
+      "tipo": "extracto",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "humus de lombriz",
+        "agua"
+      ],
+      "proceso_resumen": "Lixiviado por percolación 1kg humus/5L agua durante 24h. Aplicación foliar 1:10 o riego 1:5.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 15,
+      "uso": "Foliar cada 7-15 días en fase vegetativa y vegetativa-reproductiva, preferentemente al amanecer; también drench al pie de plántulas recién trasplantadas para mitigar estrés de transplante.",
+      "dosis": "Foliar: 1:10 con agua (≈100 ml de lixiviado por L, ≈300 L de mezcla/ha). Drench: 1:5 (≈250 ml por planta hortícola, 1-2 L por árbol joven).",
+      "dosis_aplicacion": "Lixiviado/te de humus de lombriz (1 parte de humus por 5-10 partes de agua sin cloro). Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L por 10 L de agua, ~100 ml/L); drench al pie mas concentrado 1:4 a 1:5 (250 ml por planta horticola, 1-2 L por arbol joven). Bomba de 20 L: 2-4 L de lixiviado.",
+      "frecuencia": "Foliar cada 7 a 15 dias en vegetativa y vegetativa-reproductiva; tambien drench al pie de plantulas recien trasplantadas.",
+      "metodo": "foliar diluido y drench al suelo",
+      "precaucion_seguridad": "Bajo riesgo si el humus esta maduro. Riesgo sanitario menor: usar humus de lombriz bien procesado y agua sin cloro; no aplicar a partes comestibles crudas proximas a cosecha; lavado de manos.",
+      "fuente": "Agrosavia / SENA — te de lombricompuesto; relacion 1:5-1:10 estandar (analogo al te de estiercol/lombricompuesto verificado).",
+      "confianza": "media",
+      "target": [
+        "fertilizante_general",
+        "bioestimulante_acidos_humicos",
+        "antiestres_transplante",
+        "preventivo_nematodos"
+      ],
+      "valor_pedagogico": "Lixiviado de vermicompost rico en ácidos húmicos y fúlvicos extractables, reguladores tipo auxinas/citoquininas y microbiota aeróbica del tracto de *Eisenia foetida* (Pseudomonas, Bacillus, Actinomycetes). **ÁCIDOS HÚMICOS REALES**: 0.5-3 g/L típico en lixiviado por percolación, NO 3-8 g/L como afirma la literatura comercial — el extracto líquido es **diluido vs sólido**, y los valores altos se midieron en concentrados industriales (Atiyeh et al. 2002 *Bioresource Technology* 84:7). Para concentrado de húmicos genuino comprar leonardita comercial (mineral oxidado de lignito con 50-70% ácidos húmicos certificados) — el lixiviado de finca aporta más bioestimulación microbiana y enzimática que carga húmica per se. Los fúlvicos quelatan micronutrientes (Fe, Zn, Mn) facilitando absorción foliar — análogo orgánico a quelatos EDTA, biodegradable y de bajo costo (AGROSAVIA, Restrepo). Advertencias: dosis foliares >1:5 queman hojas tiernas por sales; olor a podredumbre indica anaerobiosis y descarte; conservar tapado en oscuridad <25 °C — vida útil cae a 7 días si supera 30 °C.",
+      "source_ids": [
+        "agrosavia-manual-biopreparados-2015",
+        "restrepo-1996-abc-agricultura-organica",
+        "restrepo-2007-biopreparados"
+      ]
+    },
+    {
+      "id": "lixiviado_frutas",
+      "nombre": "Lixiviado de frutas",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion"
+      ],
+      "ingredientes": [
+        "cáscaras y pulpas de frutas maduras",
+        "melaza",
+        "agua"
+      ],
+      "proceso_resumen": "Fermentación aeróbica 20-30 días con revolver semanal. Rica en K y micronutrientes. Aplicación foliar 1:20 en fase reproductiva.",
+      "tiempo_elaboracion_dias": 25,
+      "vida_util_dias": 120,
+      "uso": "Foliar cada 10-15 días desde inicio de floración hasta llenado de fruto; especialmente útil en cucurbitáceas, solanáceas, frutales en cuaja y leguminosas en envainado.",
+      "dosis": "Foliar: 1:20 con agua (≈50 ml de lixiviado por L, 200-300 L/ha). Drench reproductivo: 1:10 al pie semanal en pleno cuajado.",
+      "target": [
+        "fertilizante_floracion_fructificacion",
+        "aporte_potasio",
+        "micronutrientes_B_Zn_Mn",
+        "mejora_brix_calidad_fruto"
+      ],
+      "valor_pedagogico": "Fermentación láctica-alcohólica: levaduras (Saccharomyces, Hanseniaspora) y lácticas (Lactobacillus) degradan azúcares liberando K soluble, B, Zn, Mn y ácidos orgánicos que liberan cationes en suelos calcáreos. **K₂O REAL**: 1-4% típico en lixiviados de cáscaras cítricas y manzana; hasta 8-12% con frutas de alto K (banano maduro, mango maduro, papaya). **NPK típico real**: 1-2-3 (N-P-K en %), no 1-2-6 como afirman recetarios populares — la fermentación libera más K que P pero el N orgánico residual es bajo porque la fruta aporta poca proteína. Restrepo y Pinheiro lo usan como análogo orgánico al KNO₃ en floración, sin salinización. Advertencias: moho blanco (Geotrichum candidum) en la superficie sin afectar la fermentación es aceptable — descartar si crece masivamente o cubre toda la superficie; moho negro/verde olivo (probable Aspergillus flavus/niger) obliga descarte por aflatoxinas hepatotóxicas. pH final 3.5-4.0; >4.5 indica putrefacción. No aplicar en vegetativa temprana — K antagoniza N.",
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ]
+    },
+    {
+      "id": "purin_ortiga",
+      "nombre": "Purín de ortiga",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "repelente_insectos",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "ortiga fresca 1kg",
+        "agua 10L"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica 10-14 días (cuando deja de espumar, está listo). Rico en Fe, Si, N. Aplicación foliar 1:10.",
+      "tiempo_elaboracion_dias": 12,
+      "vida_util_dias": 60,
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2007-biopreparados",
+        "agrosavia-manual-biopreparados-2015"
+      ],
+      "uso": "Foliar al amanecer cada 7-10 días en etapa vegetativa. Como repelente preventivo: aplicar al detectar plagas chupadoras incipientes. También al pie como bioestimulante de enraizamiento en plántulas y trasplantes.",
+      "dosis": "Foliar: 100 ml/L de agua (1:10) preventivo, 200 ml/L (1:5) curativo contra pulgón. Drench/raíz: 50 ml/L (1:20). Macerado fresco no fermentado (24-48 h) se usa más diluido 1:20 a 1:50.",
+      "dosis_aplicacion": "Maceracion/fermentacion: 1 kg de ortiga fresca (o 200 g seca) por 10 L de agua, fermentar 7-14 dias removiendo a diario hasta que deje de espumar. Purin fermentado bioestimulante foliar: diluir 1:10 a 1:20 (0,5-1 L por 10 L de agua); al suelo (drench) 1:10. Bomba de 20 L foliar: 1-2 L de purin. Macerado corto de 24-72 h (sin fermentar) como insecticida/repelente: 1:5.",
+      "frecuencia": "Foliar cada 10 a 15 dias como bioestimulante, principalmente en vegetativa; ante afidos repetir segun necesidad.",
+      "metodo": "foliar diluido y drench al suelo",
+      "precaucion_seguridad": "Bajo riesgo. Olor muy fuerte. Guantes al cosechar la ortiga (urticante) y al manipular el fermento. No aplicar concentrado sin diluir (exceso de nitrogeno puede quemar). Filtrar para no tapar boquillas.",
+      "fuente": "Restrepo Rivera / tradicion agroecologica europea-andina del purin de ortiga. Dilucion 1:10-1:20 estandar; concentracion del macerado variable.",
+      "confianza": "media",
+      "target": [
+        "control_pulgon",
+        "control_acaros",
+        "fertilizante_foliar_Fe_Si",
+        "bioestimulante_enraizamiento",
+        "fitosanitario_preventivo_chupadores"
+      ],
+      "valor_pedagogico": "Preparado tradicional europeo (purin d'ortie) introducido a la agroecología latinoamericana por Restrepo y validado por AGROSAVIA. Urtica dioica/U. urens concentra Fe (4-7 mg/g MS), Si soluble, ácido fórmico y polifenoles antialimentarios contra áfidos (Myzus persicae) y ácaros (Tetranychus urticae). Corrige clorosis férrica sin acidificar el sustrato. Fermentación completa (cesa espuma) es clave: macerados frescos contienen ácido fórmico libre (HCOOH) fitotóxico. Vs. imidacloprid no deja residuos ni daña polinizadores. NO mezclar con caldos cúpricos (precipita Fe).",
+      "_curation_status": "ENRICHED_BATCH_BP-A_2026-05-17"
+    },
+    {
+      "id": "supermagro",
+      "nombre": "Supermagro",
+      "tipo": "fermentado",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "estiércol vaca",
+        "leche",
+        "melaza",
+        "sulfatos minerales (Mg, Zn, Mn, Cu, Fe, B, Co)",
+        "agua"
+      ],
+      "proceso_resumen": "Fermentación anaeróbica 90 días con adición escalonada de sulfatos minerales cada 7 días. Corrige micronutrientes. Aplicación foliar 1:20.",
+      "tiempo_elaboracion_dias": 90,
+      "vida_util_dias": 365,
+      "uso": "Foliar correctivo de micronutrientes cada 15-21 días durante todo el ciclo, intensificando frecuencia en cultivos con síntomas visibles de deficiencia (clorosis intervenal, brotes deformes, frutos pequeños) o en suelos pobres/calcáreos del altiplano cundiboyacense.",
+      "dosis": "Foliar: 1:20 con agua (≈50 ml/L, 200-400 L/ha). Preventivo: 1:50 cada 30 días. Nunca superar 100 ml/L — riesgo de fitotoxicidad por exceso de Cu/Zn.",
+      "dosis_aplicacion": "Biofertilizante anaerobico fermentado 30-90 dias; se aplica DILUIDO, no puro. Dilucion foliar del 2% al 7% segun etapa (200-700 cc de supermagro por cada 10 L de agua). Inicio/general 3-5% (300-500 cc/10 L). Bomba de 20 L: 600 cc a 1 L. En cultivos sensibles empezar al 1-2% y subir. Tope de seguridad: no superar ~10% (riesgo de fitotoxicidad por exceso de Cu/Zn).",
+      "frecuencia": "Foliar cada 8 a 15 dias durante el ciclo; subir concentracion hacia floracion/llenado. Evitar aplicaciones fuertes muy cerca de cosecha.",
+      "metodo": "foliar (temprano en la manana o al atardecer); tambien drench diluido al suelo",
+      "precaucion_seguridad": "Bajo riesgo general. Contiene sulfatos minerales (Cu, Zn): NO aplicar concentrado (>10%) por riesgo de quemadura foliar y acumulacion de cobre. Filtrar bien para no tapar boquillas; olor fuerte (fermento). Guantes por higiene (estiercol).",
+      "fuente": "Restrepo Rivera, J. — Manual practico de biofertilizantes (Supermagro); diluciones 2-7% segun el autor.",
+      "confianza": "media",
+      "target": [
+        "correccion_micronutrientes",
+        "deficiencia_boro_zinc_manganeso",
+        "estimulante_microbiano_filoplano",
+        "fertilizacion_complemento_NPK"
+      ],
+      "valor_pedagogico": "Receta de Restrepo (1996) y Pinheiro: fermentación anaeróbica láctica de estiércol + leche + melaza donde Lactobacillus y levaduras solubilizan sulfatos añadidos en 5-7 etapas semanales, quelándolos con ácidos orgánicos y aminoácidos biodisponibles. Análogo orgánico a quelatos EDTA/EDDHA, biodegradable y a 1/10 del costo. Cubre 7 deficiencias típicas en suelos andinos ácidos (Mg, Zn, Mn, Cu, Fe, B, Co). Advertencias: sulfatos de Cu/Zn por encima de ~2 g/L (~0.2% p/v) inhiben la microbiota láctica del barril y detienen la fermentación (Reed 2010 J Environ Qual 39:1257); fermentación <60 días deja sulfatos sin quelatar y quema follaje; pH 3.5-4.2; contraindicado en floración plena.",
+      "source_ids": [
+        "restrepo-1996-bocashi",
+        "restrepo-2005-agroecologia",
+        "restrepo-2007-biopreparados"
+      ]
+    },
+    {
+      "id": "te_compost",
+      "nombre": "Té de compost",
+      "tipo": "extracto",
+      "proposito": [
+        "fertilizacion",
+        "estimulante_microbiano",
+        "fitosanitario_preventivo"
+      ],
+      "ingredientes": [
+        "compost maduro 1kg",
+        "agua declorada 10L",
+        "melaza 2 cucharadas"
+      ],
+      "proceso_resumen": "Aeración con bomba de pecera 24-36h. Uso dentro de 4h post-preparación. Aplicación foliar 1:5 o riego al pie 1:10.",
+      "tiempo_elaboracion_dias": 1,
+      "vida_util_dias": 1,
+      "uso": "Foliar al amanecer o atardecer cada 10-15 días en fase vegetativa, o como empapado al sustrato pre-trasplante; aplicar dentro de las 4 h posteriores a cortar la aireación para no perder la microbiota activa.",
+      "dosis": "Foliar: dilución 1:5 con agua declorada (≈200 ml de té por L de agua, 200-300 L/ha). Drench al pie: 1:10 (≈1 L por planta hortícola, 5 L por árbol joven).",
+      "dosis_aplicacion": "Te: 1 parte de compost maduro/lombricompuesto por 5-10 partes de agua sin cloro, en bolsa/saco sumergido. Te aireado (con bomba de aire + melaza) 12-24 h; te por reposo 3-7 dias. Filtrar antes de aplicar. Aplicar el filtrado diluido al color de te claro: foliar 1:10 (1 L de te por 10 L de agua); drench al suelo mas concentrado 1:4 a 1:5. Bomba de 20 L: 2-4 L de te. Usar dentro de las 4 h tras cortar la aireacion.",
+      "frecuencia": "Foliar cada 10 a 15 dias; al suelo segun el cultivo. Cualquier etapa como bioestimulante y aporte microbiano.",
+      "metodo": "foliar diluido y drench al suelo",
+      "precaucion_seguridad": "Bajo riesgo si el material esta bien compostado. RIESGO SANITARIO: un te de estiercol fresco o mal preparado (sin airear, anaerobico) puede multiplicar patogenos (E. coli, Salmonella). NO aplicar a partes comestibles crudas cercanas a cosecha; respetar carencia. Usar lombricompuesto maduro y agua sin cloro; lavado de manos.",
+      "fuente": "Agrosavia / SENA / Ingham (2000) — te de compost y lombricompuesto; relacion 1:5-1:10 estandar; advertencia sanitaria de tes aireados (literatura compost tea).",
+      "confianza": "media",
+      "target": [
+        "fertilizante_general",
+        "estimulante_microbiano_suelo",
+        "preventivo_mildeo_polvoso",
+        "preventivo_botrytis"
+      ],
+      "valor_pedagogico": "Inóculo microbiano vivo: UFC REALES de finca son 10^5-10^7 UFC/ml (NO 10^8-10^9 UFC/ml como promovieron Faulkner y la literatura comercial de tés aerados — esos rangos requieren laboratorio + compost activo certificado + glucosa suplementaria + control de O₂ disuelto, no replicables en aireador de pecera). Aireación 24-48 h en agua sin cloro maximiza el recuento bacteriano aerobio; aireaciones >72 h colapsan por agotamiento de O₂ y melaza (Scheuerell & Mahaffee 2002 *Compost Sci Util* 10:313). Composición típica: bacterias aerobias (Pseudomonas, Bacillus), esporas de hongos saprófitos, protozoos flagelados y nematodos bacteriófagos extraídos del compost por aireación forzada con melaza como carbono lábil. Coloniza filoplano y rizosfera por exclusión competitiva contra patógenos (Ingham; Restrepo, ABC orgánico — la eficacia es variable según calidad del compost madre y presión de inóculo patogénico, ver Litterick et al. 2004 CRC Critical Reviews 23:453). Advertencias: si la aireación se detiene >2 h vira anaeróbico y produce ácidos fitotóxicos; no aplicar bajo sol del mediodía (UV mata 90% del inóculo en 30 min); no mezclar con caldo bordelés o sulfocálcico — el cobre/azufre esterilizan la microbiota.",
+      "source_ids": [
+        "ingham-2000-compost-tea",
+        "restrepo-1996-abc-agricultura-organica",
+        "agrosavia-manual-biopreparados-2015"
+      ]
+    },
+    {
+      "id": "trichoderma_harzianum_suelo",
+      "nombre": "Trichoderma harzianum (aplicación al suelo)",
+      "tipo": "microbiano",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "estimulante_microbiano"
+      ],
+      "ingredientes": [
+        "cepa T. harzianum propagada en sustrato sólido (arroz/afrecho)"
+      ],
+      "proceso_resumen": "Aplicación 1kg/ha mezclado con compost maduro, incorporado en los primeros 10cm del suelo. Control biológico de Rhizoctonia, Fusarium, Sclerotinia.",
+      "tiempo_elaboracion_dias": 21,
+      "vida_util_dias": 90,
+      "uso": "Al sustrato pre-siembra o pre-trasplante, incorporado a 0-15 cm de profundidad mezclado con compost maduro como vehículo; también en hoyos de plantación de frutales y forestales, y como drench preventivo cada 30-45 días en cultivos con historial de pudriciones radiculares.",
+      "dosis": "Sustrato/campo: 1-2 kg/ha de sustrato sólido (10^8 UFC/g). Hoyo de plantación: 5-10 g por hoyo. Drench preventivo: 50 g/100 L de agua, 1-2 L por planta. Repetir a los 30-45 días en cultivos susceptibles.",
+      "target": [
+        "control_rhizoctonia_solani",
+        "control_fusarium_oxysporum",
+        "control_sclerotinia_sclerotiorum",
+        "control_pythium",
+        "induccion_resistencia_sistemica",
+        "promocion_crecimiento_radicular"
+      ],
+      "valor_pedagogico": "Hongo antagonista saprófito *Trichoderma harzianum* sensu lato — revisión Chaverri et al. 2015 *Mycologia* 107(3):558 segregó el complejo en varias especies: la cepa tipo comercial T-22 y la mayoría de cepas tropicales/africanas (incluidas las colombianas AGROSAVIA TR15 y TR06) corresponden ahora a *Trichoderma afroharzianum*. AGROSAVIA y registros ICA (Res. 3168/2015) mantienen el nombre histórico \"T. harzianum\" por estabilidad regulatoria, pero técnicamente las cepas comerciales colombianas son *T. afroharzianum*. Mecanismos de control: coloniza la rizosfera y combate patógenos vía (1) micoparasitismo sobre Rhizoctonia, Fusarium, Sclerotinia y Pythium degradándolas con quitinasas/β-1,3-glucanasas; (2) competencia por exudados radiculares; (3) antibióticos volátiles (6-pentil-pirona, gliotoxina); (4) inducción de resistencia sistémica vía jasmonato/etileno. AGROSAVIA y Cenicafé validaron cepas locales ICA-registradas, análogo al carbendazim sin residuos. Advertencias: no aplicar a suelo seco (<30% humedad); incompatible con cúpricos y mancozeb; evitar pleno sol; óptimo pH 4.5-6.5; pH >8.5 reduce viabilidad significativamente (Singh et al. 2014 Front Microbiol 5:1).",
+      "source_ids": [
+        "cenicafe-trichoderma-2010",
+        "agrosavia-manual-biopreparados-2015",
+        "agrosavia-bacillus-2018",
+        "ica-resolucion-3168-2015"
+      ]
+    },
+    {
+      "id": "vinagre_madera_pirolenoso",
+      "nombre": "vinagre de madera (ácido piroleñoso)",
+      "tipo": "extracto",
+      "proposito": [
+        "fitosanitario_preventivo",
+        "estimulante_microbiano",
+        "repelente_insectos"
+      ],
+      "ingredientes": [
+        "ramas y leña de especies leñosas (acacia, bambú, leucaena) de 2-5 cm de diámetro",
+        "horno o tambor de carbonización lenta con condensador"
+      ],
+      "proceso_resumen": "Pirólisis lenta de leña a 300-500°C en horno cerrado con condensador; recuperar condensado por enfriamiento; reposo de 3-6 meses para separar tres fases (alquitrán pesado / vinagre clarificado central / aceite ligero); decantar fase central.",
+      "tiempo_elaboracion_dias": 120,
+      "vida_util_dias": 1095,
+      "source_ids": [
+        "cho-2016-jadam-organic-farming"
+      ],
+      "uso": "Aspersión foliar y al suelo; coadyuvante de otros biopreparados.",
+      "dosis": "1:200 a 1:1000 según uso (germinación 1:500; foliar 1:300).",
+      "target": [
+        "hongos_foliares",
+        "nematodos",
+        "repelente_general"
+      ],
+      "valor_pedagogico": "Condensado obtenido por pirólisis lenta (250-400 °C en horno cerrado con condensador refrigerado) de leña dura; contiene ácido pirolígneo, guayacol, fenoles y carbonilos que actúan como fungistato preventivo, repelente de insectos y estimulante microbiano del suelo. NO USAR FRESCO — contiene alquitranes (PAHs, hidrocarburos aromáticos policíclicos) fitotóxicos y potencialmente cancerígenos. Reposo mínimo 90 días obligatorio para separación de tres fases y descarte de alquitrán pesado. ADVERTENCIA INELABORABILIDAD EN FINCA: requiere horno de pirólisis controlada (250-400 °C) con condensador refrigerado y termómetro de proceso. **Sin este equipo, NO es elaborable en finca** — comprar producto registrado ICA (e.g. Wood Vinegar de empresas certificadas, o destilados pirolígneos de productores artesanales con control de PAHs). El vinagre casero \"ahumado\" en barbacoa, fogón o tambor sin condensador NO es vinagre de madera real: carece de la concentración de componentes activos (guayacol, ácido pirolígneo, fenoles antimicrobianos) y puede contener residuos cancerígenos sin separación de fases. Si la finca no dispone del horno, derivar a producto comercial o sustituir por extracto fermentado de plantas aromáticas.",
+      "_curation_status": "BORRADOR_IA"
+    }
+  ]
+}

--- a/scripts/__tests__/catalog-graph-export.test.mjs
+++ b/scripts/__tests__/catalog-graph-export.test.mjs
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildGraphExportSql,
+  graphRowsToCatalog,
+  parseGraphRows,
+} from '../export-graph-to-catalog.mjs';
+import {
+  findSeedConflicts,
+  validateCatalogExport,
+} from '../validate-catalog-export.mjs';
+
+const seed = {
+  schema_version: '3.1',
+  species: [
+    {
+      id: 'solanum_lycopersicum',
+      nombre_comun: 'Tomate',
+      nombre_cientifico: 'Solanum lycopersicum L.',
+      familia_botanica: 'Solanaceae',
+      category: 'hortalizas_fruto_flor',
+      thermal_zones: ['templado'],
+      roles_in_guild: ['crop'],
+      cultivable: true,
+      conservation_status: 'cultivo_comun',
+      altitud_msnm: { min_absoluto: 0, optimo_min: 800, optimo_max: 1800, max_absoluto: 2400 },
+      source_ids: ['seed-source'],
+      tracking_mode: 'aggregate',
+    },
+  ],
+  sources: [
+    {
+      id: 'seed-source',
+      tipo: 'base_datos',
+      autores: 'Seed',
+      titulo: 'Seed source',
+      _url_pendiente: true,
+    },
+  ],
+  biopreparados: [],
+};
+
+describe('export-graph-to-catalog', () => {
+  it('emite SQL para ejecutarse por STDIN y no invoca psql internamente', () => {
+    const sql = buildGraphExportSql('chagra_kg');
+    expect(sql).toContain("LOAD 'age'");
+    expect(sql).toContain('MATCH (s:Species)');
+    expect(sql).toContain('ASOCIA_CON');
+    expect(sql).toContain('USED_AS_BIOPREPARADO');
+    expect(sql).toContain('TIENE_ETAPA');
+  });
+
+  it('parsea filas agtype impresas por psql', () => {
+    const rows = parseGraphRows(`
+LOAD
+SET
+{"id": "abatia_parviflora", "category": "arbol", "cultivable": true, "nombre_comun": "Duraznillo", "familia_botanica": "Salicaceae", "nombre_cientifico": "Abatia parviflora Ruiz & Pav.", "altitud_min_msnm": 1800, "altitud_max_msnm": 3200, "fuente_agroclima": "Instituto Humboldt"}
+`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe('abatia_parviflora');
+  });
+
+  it('convierte species nuevas usando solo campos del grafo y fuentes del grafo', () => {
+    const catalog = graphRowsToCatalog([
+      {
+        id: 'abatia_parviflora',
+        category: 'arbol',
+        cultivable: true,
+        nombre_comun: 'Duraznillo',
+        familia_botanica: 'Salicaceae',
+        nombre_cientifico: 'Abatia parviflora Ruiz & Pav.',
+        altitud_min_msnm: 1800,
+        altitud_max_msnm: 3200,
+        fuente_agroclima: 'Instituto Humboldt',
+        companions: ['solanum_lycopersicum'],
+      },
+    ], { seed });
+
+    expect(catalog.species).toHaveLength(1);
+    expect(catalog.species[0]).toMatchObject({
+      id: 'abatia_parviflora',
+      category: 'arboles_sombra',
+      thermal_zones: ['templado', 'frio', 'paramo'],
+      roles_in_guild: ['nurse_plant'],
+      conservation_status: 'no_evaluada',
+      source_ids: ['graph_instituto_humboldt_agroclima'],
+    });
+    expect(catalog.sources[0]).toMatchObject({
+      id: 'graph_instituto_humboldt_agroclima',
+      tipo: 'ficha_tecnica_institucional',
+      autores: 'Instituto Humboldt',
+    });
+    expect(catalog._graph_export_meta.species_new_vs_seed).toBe(1);
+  });
+
+  it('preserva la ficha del seed para ids existentes y sanea sources legacy', () => {
+    const catalog = graphRowsToCatalog([
+      {
+        id: 'solanum_lycopersicum',
+        category: 'hortaliza',
+        nombre_comun: 'Tomate chonto',
+      },
+    ], { seed });
+
+    expect(catalog.species).toHaveLength(1);
+    expect(catalog.species[0].nombre_comun).toBe('Tomate');
+    expect(catalog.sources[0]._url_pendiente).toBeUndefined();
+    expect(catalog._graph_export_meta.species_already_in_seed).toBe(1);
+  });
+
+  it('omite species nuevas que no pueden cumplir v3.1 sin inventar campos', () => {
+    const catalog = graphRowsToCatalog([
+      {
+        id: 'sin_categoria',
+        cultivable: true,
+        nombre_comun: 'Sin categoria',
+        familia_botanica: 'Asteraceae',
+        nombre_cientifico: 'Ageratina example',
+        altitud_min_msnm: 1800,
+        altitud_max_msnm: 2400,
+        fuente_agroclima: 'Fuente tecnica',
+      },
+    ], { seed });
+
+    expect(catalog.species).toHaveLength(0);
+    expect(catalog._graph_export_meta.species_skipped_not_schema_ready).toBe(1);
+    expect(catalog._graph_export_meta.skipped_examples[0].missing).toContain('category');
+  });
+});
+
+describe('validate-catalog-export', () => {
+  it('detecta conflictos contra ids ya presentes en el seed', () => {
+    const conflicts = findSeedConflicts({
+      species: [
+        {
+          ...seed.species[0],
+          nombre_cientifico: 'Solanum pimpinellifolium L.',
+        },
+      ],
+    }, seed);
+    expect(conflicts).toEqual([
+      expect.objectContaining({
+        id: 'solanum_lycopersicum',
+        field: 'nombre_cientifico',
+        reason: 'seed_conflict',
+      }),
+    ]);
+  });
+
+  it('valida schema minimo y conflictos en un export correcto', () => {
+    const schema = {
+      type: 'object',
+      required: ['schema_version', 'species', 'sources', 'biopreparados'],
+      properties: {
+        schema_version: { type: 'string' },
+        species: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['id', 'nombre_cientifico'],
+            properties: {
+              id: { type: 'string' },
+              nombre_cientifico: { type: 'string' },
+            },
+          },
+        },
+        sources: { type: 'array' },
+        biopreparados: { type: 'array' },
+      },
+    };
+    const result = validateCatalogExport({
+      schema_version: '3.1',
+      species: [{ id: 'abatia_parviflora', nombre_cientifico: 'Abatia parviflora Ruiz & Pav.' }],
+      sources: [],
+      biopreparados: [],
+    }, schema, seed);
+
+    expect(result.ok).toBe(true);
+    expect(result.stats.species_new_vs_seed).toBe(1);
+  });
+});

--- a/scripts/export-graph-to-catalog.mjs
+++ b/scripts/export-graph-to-catalog.mjs
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { normalizeCatalogRef } from './validate-catalog-consistency.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const DEFAULT_OUTPUT = join(ROOT, 'catalog/chagra-catalog-graph-export.json');
+const DEFAULT_SEED = join(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+const DEFAULT_GRAPH = 'chagra_kg';
+
+export function buildGraphExportSql(graph = DEFAULT_GRAPH) {
+  const graphLiteral = String(graph).replace(/'/g, "''");
+  return `
+LOAD 'age';
+SET search_path = ag_catalog, "$user", public;
+SELECT row
+FROM cypher('${graphLiteral}', $$
+  MATCH (s:Species)
+  OPTIONAL MATCH (s)-[:HAS_FAMILY]->(family:Family)
+  WITH s, family
+  OPTIONAL MATCH (s)-[:ASOCIA_CON]->(assoc:Species)
+  WITH s, family, collect(DISTINCT assoc.id) AS asocia_con
+  OPTIONAL MATCH (s)-[:COMPATIBLE_WITH]->(compat:Species)
+  WITH s, family, asocia_con, collect(DISTINCT compat.id) AS compatible_with
+  OPTIONAL MATCH (s)-[ub:USED_AS_BIOPREPARADO]->(bio:Biopreparado)
+  WITH s, family, asocia_con, compatible_with,
+       collect(DISTINCT {
+         id: bio.id,
+         nombre: bio.nombre,
+         tipo: bio.tipo,
+         dosis: coalesce(ub.dosis, bio.dosis_aplicacion, bio.dosis),
+         carencia: coalesce(ub.carencia, bio.carencia),
+         registro_ICA: coalesce(ub.registro_ICA, bio.registro_ICA),
+         etapa: ub.etapa,
+         source: ub.source
+       }) AS biopreparados
+  OPTIONAL MATCH (s)-[ctrl:CONTROLS]->(target)
+  WITH s, family, asocia_con, compatible_with, biopreparados,
+       collect(DISTINCT {
+         id: target.id,
+         dosis: ctrl.dosis,
+         carencia: ctrl.carencia,
+         registro_ICA: ctrl.registro_ICA,
+         tipo: ctrl.tipo
+       }) AS controles_directos
+  OPTIONAL MATCH (s)-[stage_rel:TIENE_ETAPA]->(stage)
+  WITH s, family, asocia_con, compatible_with, biopreparados, controles_directos,
+       collect(DISTINCT {
+         id: stage.id,
+         nombre: coalesce(stage.nombre, stage.name),
+         orden: coalesce(stage_rel.orden, stage.orden),
+         duracion_dias: coalesce(stage_rel.duracion_dias, stage.duracion_dias)
+       }) AS fenologia
+  RETURN {
+    id: s.id,
+    nombre_comun: s.nombre_comun,
+    nombre_cientifico: s.nombre_cientifico,
+    familia_botanica: coalesce(family.nombre, family.id, s.familia_botanica),
+    category: coalesce(s.category, s.categoria),
+    thermal_zones: s.thermal_zones,
+    roles_in_guild: s.roles_in_guild,
+    cultivable: s.cultivable,
+    conservation_status: s.conservation_status,
+    altitud_min: s.altitud_min,
+    altitud_max: s.altitud_max,
+    altitud_min_msnm: s.altitud_min_msnm,
+    altitud_max_msnm: s.altitud_max_msnm,
+    altitud_msnm: s.altitud_msnm,
+    source_ids: s.source_ids,
+    fuente_agroclima: s.fuente_agroclima,
+    fuente_agroclima_url: s.agroclima_url,
+    suelo_fuente: s.suelo_fuente,
+    companions: asocia_con + compatible_with,
+    biopreparados: biopreparados,
+    controles_directos: controles_directos,
+    fenologia: fenologia,
+    tracking_mode: s.tracking_mode
+  } AS row
+  ORDER BY s.id
+$$) AS (row agtype);
+`.trim();
+}
+
+function readStdin() {
+  return readFileSync(0, 'utf8');
+}
+
+function stripAgtypeScalar(value) {
+  if (value === null || value === undefined) return null;
+  const raw = String(value).trim();
+  if (!raw || raw === 'null') return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
+  return raw.replace(/^"|"$/g, '');
+}
+
+function parseAgtypeMap(raw) {
+  const text = String(raw || '').trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    const jsonish = text
+      .replace(/([{,]\s*)([A-Za-z_][A-Za-z0-9_]*)(\s*:)/g, '$1"$2"$3')
+      .replace(/:\s*'([^']*)'/g, (_m, value) => `:${JSON.stringify(value)}`);
+    return JSON.parse(jsonish);
+  }
+}
+
+export function parseGraphRows(input) {
+  const trimmed = String(input || '').trim();
+  if (!trimmed) return [];
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    // Sigue con formatos de psql.
+  }
+
+  const rows = [];
+  for (const line of trimmed.split(/\r?\n/)) {
+    const clean = line.trim();
+    if (!clean || /^(LOAD|SET|\(\d+ rows?\))$/.test(clean)) continue;
+    if (clean.startsWith('{')) {
+      rows.push(parseAgtypeMap(clean));
+      continue;
+    }
+    const parts = clean.split('\t');
+    if (parts.length === 1 && parts[0].startsWith('{')) {
+      rows.push(parseAgtypeMap(parts[0]));
+      continue;
+    }
+    if (parts.length >= 2) {
+      rows.push({
+        id: stripAgtypeScalar(parts[0]),
+        nombre_cientifico: stripAgtypeScalar(parts[1]),
+        familia_botanica: stripAgtypeScalar(parts[2]),
+      });
+    }
+  }
+  return rows.filter(Boolean);
+}
+
+function asArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter((item) => item !== null && item !== undefined && item !== '');
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed);
+      return asArray(parsed);
+    } catch {
+      return trimmed.split('|').map((item) => item.trim()).filter(Boolean);
+    }
+  }
+  return [value];
+}
+
+function uniqSorted(values) {
+  return Array.from(new Set(values.filter(Boolean).map(String))).sort();
+}
+
+const CATEGORY_MAP = {
+  arbol: 'arboles_sombra',
+  cereal: 'cereales',
+  fibra: 'fibras_no_maderables',
+  forestal: 'arboles_sombra',
+  forrajera: 'abonos_verdes_coberturas',
+  frutal: 'frutales_perennes',
+  hortaliza: 'hortalizas_fruto_flor',
+  leguminosa: 'granos_legumbres',
+  medicinal: 'medicinales_alelopaticas',
+  ornamental: 'ornamentales_nativas',
+  pasto: 'abonos_verdes_coberturas',
+  tuberculo: 'tuberculos_raices',
+};
+
+const ROLE_BY_CATEGORY = {
+  abonos_verdes_coberturas: 'ground_cover',
+  arboles_sombra: 'nurse_plant',
+  atractores_polinizadores: 'pollinator_attractor',
+  cereales: 'crop',
+  cercas_vivas: 'living_fence',
+  fibras_no_maderables: 'crop',
+  frutales_perennes: 'crop',
+  granos_legumbres: 'crop',
+  hortalizas_fruto_flor: 'crop',
+  hortalizas_hoja: 'crop',
+  medicinales_alelopaticas: 'pest_repellent',
+  ornamentales_nativas: 'pollinator_attractor',
+  tuberculos_raices: 'crop',
+};
+
+const SOURCE_FIELDS = new Set([
+  'id',
+  'tipo',
+  'autores',
+  'año',
+  'titulo',
+  'revista_o_editorial',
+  'volumen_numero',
+  'paginas',
+  'doi',
+  'isbn',
+  'url',
+  'institucion',
+  'observaciones',
+  'tier',
+]);
+
+const BIOPREPARADO_FIELDS = new Set([
+  'id',
+  'nombre',
+  'tipo',
+  'proposito',
+  'ingredientes',
+  'proceso_resumen',
+  'tiempo_elaboracion_dias',
+  'vida_util_dias',
+  'source_ids',
+  'uso',
+  'dosis',
+  'dosis_aplicacion',
+  'frecuencia',
+  'metodo',
+  'precaucion_seguridad',
+  'fuente',
+  'confianza',
+  'target',
+  'valor_pedagogico',
+  '_curation_status',
+]);
+
+function cleanObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+  const out = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (item === null || item === undefined || item === '') continue;
+    if (Array.isArray(item) && item.length === 0) continue;
+    out[key] = item;
+  }
+  return out;
+}
+
+function pickAllowed(value, allowed) {
+  const cleaned = cleanObject(value);
+  const out = {};
+  for (const [key, item] of Object.entries(cleaned || {})) {
+    if (allowed.has(key)) out[key] = item;
+  }
+  return out;
+}
+
+function sanitizeSource(source) {
+  return pickAllowed(source, SOURCE_FIELDS);
+}
+
+function sanitizeBiopreparado(bp) {
+  return pickAllowed(bp, BIOPREPARADO_FIELDS);
+}
+
+function normalizeBio(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const id = entry.id || entry.biopreparado_id;
+  if (!id) return null;
+  return cleanObject({
+    id: String(id),
+    nombre: entry.nombre || entry.name || String(id),
+    tipo: entry.tipo || null,
+    dosis: entry.dosis || entry.dosis_aplicacion || null,
+    carencia: entry.carencia || null,
+    registro_ICA: entry.registro_ICA || entry.registro_ica || null,
+    etapa: entry.etapa || null,
+    source: entry.source || null,
+  });
+}
+
+function normalizeStage(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const id = entry.id || entry.nombre || entry.name;
+  if (!id) return null;
+  return cleanObject({
+    id: String(id),
+    nombre: entry.nombre || entry.name || String(id),
+    orden: entry.orden ?? null,
+    duracion_dias: entry.duracion_dias ?? null,
+  });
+}
+
+function normalizeAltitude(row) {
+  if (row.altitud_msnm && typeof row.altitud_msnm === 'object') return row.altitud_msnm;
+  const min = row.altitud_min ?? row.altitud_min_msnm ?? row.altitud_optimo_min ?? row.altitudMin ?? null;
+  const max = row.altitud_max ?? row.altitud_max_msnm ?? row.altitud_optimo_max ?? row.altitudMax ?? null;
+  if (min === null || max === null) return null;
+  return {
+    min_absoluto: Number(min),
+    optimo_min: Number(min),
+    optimo_max: Number(max),
+    max_absoluto: Number(max),
+  };
+}
+
+function thermalZonesFromAltitude(altitude) {
+  if (!altitude) return [];
+  const min = Number(altitude.min_absoluto);
+  const max = Number(altitude.max_absoluto);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return [];
+  const zones = [];
+  if (min < 1000 && max >= 0) zones.push('calido');
+  if (min < 2000 && max >= 1000) zones.push('templado');
+  if (min < 3000 && max >= 2000) zones.push('frio');
+  if (max >= 3000) zones.push('paramo');
+  return zones;
+}
+
+function normalizeCategory(value) {
+  if (!value) return null;
+  const raw = normalizeCatalogRef(value);
+  return CATEGORY_MAP[raw] || raw;
+}
+
+function sourceFromText(text, suffix) {
+  if (!text) return null;
+  const id = `graph_${normalizeCatalogRef(text).slice(0, 70)}_${suffix}`;
+  return cleanObject({
+    id,
+    tipo: 'ficha_tecnica_institucional',
+    autores: String(text),
+    titulo: String(text),
+    institucion: String(text),
+    tier: 'B',
+  });
+}
+
+function requiredReady(species) {
+  return [
+    'id',
+    'nombre_comun',
+    'nombre_cientifico',
+    'familia_botanica',
+    'category',
+    'thermal_zones',
+    'roles_in_guild',
+    'cultivable',
+    'conservation_status',
+    'altitud_msnm',
+    'source_ids',
+  ].every((field) => {
+    const value = species[field];
+    if (Array.isArray(value)) return value.length > 0;
+    return value !== null && value !== undefined && value !== '';
+  });
+}
+
+export function graphRowsToCatalog(rows, opts = {}) {
+  const seed = opts.seed || {};
+  const seedById = new Map(asArray(seed.species).map((sp) => [sp.id, sp]));
+  const seedIds = new Set(seedById.keys());
+  const seedSourcesById = new Map(asArray(seed.sources).map((source) => [source.id, source]));
+  const seedBiosById = new Map(asArray(seed.biopreparados).map((bp) => [bp.id, bp]));
+  const species = [];
+  const biopreparadoMap = new Map();
+  const sourceMap = new Map();
+  const skipped = [];
+  const emittedIds = new Set();
+
+  for (const row of rows) {
+    if (!row?.id) continue;
+    const rowId = String(row.id);
+    if (emittedIds.has(rowId)) continue;
+    emittedIds.add(rowId);
+    const bios = asArray(row.biopreparados).map(normalizeBio).filter(Boolean);
+    for (const bp of bios) {
+      if (seedBiosById.has(bp.id)) biopreparadoMap.set(bp.id, sanitizeBiopreparado(seedBiosById.get(bp.id)));
+    }
+
+    if (seedById.has(rowId)) {
+      const seedSpecies = structuredClone(seedById.get(rowId));
+      seedSpecies.graph_export_meta = { already_in_seed: true };
+      species.push(seedSpecies);
+      for (const sourceId of asArray(seedSpecies.source_ids)) {
+        if (seedSourcesById.has(sourceId)) sourceMap.set(sourceId, sanitizeSource(seedSourcesById.get(sourceId)));
+      }
+      for (const step of asArray(seedSpecies.feeding_plan_template?.primary_steps)) {
+        const bpId = step?.biofertilizer_slug;
+        if (seedBiosById.has(bpId)) biopreparadoMap.set(bpId, sanitizeBiopreparado(seedBiosById.get(bpId)));
+      }
+      continue;
+    }
+
+    const altitude = normalizeAltitude(row);
+    const category = normalizeCategory(row.category || row.categoria);
+    const sourceCandidates = [
+      sourceFromText(row.fuente_agroclima, 'agroclima'),
+      sourceFromText(row.suelo_fuente, 'suelo'),
+    ].filter(Boolean);
+    for (const source of sourceCandidates) sourceMap.set(source.id, source);
+    const sourceIds = uniqSorted([
+      ...asArray(row.source_ids),
+      ...sourceCandidates.map((source) => source.id),
+    ]);
+    const roles = uniqSorted(asArray(row.roles_in_guild));
+    if (roles.length === 0 && ROLE_BY_CATEGORY[category]) roles.push(ROLE_BY_CATEGORY[category]);
+    const thermalZones = uniqSorted(asArray(row.thermal_zones));
+    if (thermalZones.length === 0) thermalZones.push(...thermalZonesFromAltitude(altitude));
+
+    const sp = cleanObject({
+      id: String(row.id),
+      nombre_comun: row.nombre_comun || row.nombre || row.common_name || null,
+      nombre_cientifico: row.nombre_cientifico || row.scientific_name || null,
+      familia_botanica: row.familia_botanica || row.familia || null,
+      category,
+      thermal_zones: thermalZones,
+      roles_in_guild: roles,
+      cultivable: typeof row.cultivable === 'boolean' ? row.cultivable : row.cultivable ?? null,
+      conservation_status: row.conservation_status || 'no_evaluada',
+      altitud_msnm: altitude,
+      source_ids: sourceIds,
+      companions: uniqSorted(asArray(row.companions).map((value) => normalizeCatalogRef(value))),
+      tracking_mode: row.tracking_mode ?? null,
+      fenologia: asArray(row.fenologia).map(normalizeStage).filter(Boolean),
+      graph_export_meta: cleanObject({
+        already_in_seed: seedIds.has(String(row.id)),
+        biopreparados: bios,
+        controles_directos: asArray(row.controles_directos).filter(Boolean),
+      }),
+    });
+
+    if (!requiredReady(sp)) {
+      skipped.push({
+        id: String(row.id),
+        reason: 'missing_required_v3_1_fields',
+        missing: [
+          !sp.category && 'category',
+          (!sp.thermal_zones || sp.thermal_zones.length === 0) && 'thermal_zones',
+          (!sp.roles_in_guild || sp.roles_in_guild.length === 0) && 'roles_in_guild',
+          !sp.altitud_msnm && 'altitud_msnm',
+          (!sp.source_ids || sp.source_ids.length === 0) && 'source_ids',
+          !sp.nombre_comun && 'nombre_comun',
+          !sp.nombre_cientifico && 'nombre_cientifico',
+          !sp.familia_botanica && 'familia_botanica',
+        ].filter(Boolean),
+      });
+      continue;
+    }
+    species.push(sp);
+  }
+
+  species.sort((a, b) => a.id.localeCompare(b.id));
+  const biopreparados = Array.from(biopreparadoMap.values()).sort((a, b) => a.id.localeCompare(b.id));
+  const sources = Array.from(sourceMap.values()).sort((a, b) => a.id.localeCompare(b.id));
+  const newSpecies = species.filter((sp) => !seedIds.has(sp.id)).length;
+  const existingSpecies = species.length - newSpecies;
+
+  return {
+    _meta: {
+      generated_by: 'scripts/export-graph-to-catalog.mjs',
+      generated_at: new Date().toISOString(),
+      source: 'Apache AGE graph via STDIN',
+    },
+    schema_version: seed.schema_version || '3.1',
+    seed_version: 'graph-export-2026-06-19',
+    generated_by: 'scripts/export-graph-to-catalog.mjs',
+    _graph_export_meta: {
+      species_exported: species.length,
+      species_new_vs_seed: newSpecies,
+      species_already_in_seed: existingSpecies,
+      species_skipped_not_schema_ready: skipped.length,
+      skipped_examples: skipped.slice(0, 20),
+    },
+    species,
+    sources,
+    biopreparados,
+  };
+}
+
+export function parseArgs(argv) {
+  const opts = {
+    output: DEFAULT_OUTPUT,
+    seed: DEFAULT_SEED,
+    graph: DEFAULT_GRAPH,
+    printSql: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--output') opts.output = resolve(argv[++i]);
+    else if (arg === '--seed') opts.seed = resolve(argv[++i]);
+    else if (arg === '--graph') opts.graph = argv[++i];
+    else if (arg === '--print-sql') opts.printSql = true;
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log('Usage: node scripts/export-graph-to-catalog.mjs [--output catalog/chagra-catalog-graph-export.json]');
+    console.log('       node scripts/export-graph-to-catalog.mjs --print-sql | psql ... | node scripts/export-graph-to-catalog.mjs');
+    return 0;
+  }
+  if (opts.printSql) {
+    console.log(buildGraphExportSql(opts.graph));
+    return 0;
+  }
+
+  const seed = existsSync(opts.seed) ? JSON.parse(readFileSync(opts.seed, 'utf8')) : {};
+  const rows = parseGraphRows(readStdin());
+  const catalog = graphRowsToCatalog(rows, { seed });
+  writeFileSync(opts.output, `${JSON.stringify(catalog, null, 2)}\n`);
+  console.log(`Graph catalog export written: ${opts.output}`);
+  console.log(`Species exportadas: ${catalog._graph_export_meta.species_exported}`);
+  console.log(`Species nuevas vs seed: ${catalog._graph_export_meta.species_new_vs_seed}`);
+  console.log(`Species ya en seed: ${catalog._graph_export_meta.species_already_in_seed}`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}

--- a/scripts/validate-catalog-export.mjs
+++ b/scripts/validate-catalog-export.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const DEFAULT_EXPORT = join(ROOT, 'catalog/chagra-catalog-graph-export.json');
+const DEFAULT_SCHEMA = join(ROOT, 'catalog/schema-v3.1.json');
+const DEFAULT_SEED = join(ROOT, 'catalog/chagra-catalog-seed-v3.1.json');
+
+const COMPARED_SPECIES_FIELDS = [
+  'nombre_comun',
+  'nombre_cientifico',
+  'familia_botanica',
+  'category',
+  'thermal_zones',
+  'roles_in_guild',
+  'cultivable',
+  'conservation_status',
+  'altitud_msnm',
+  'source_ids',
+  'tracking_mode',
+];
+
+function loadJson(path) {
+  if (!existsSync(path)) throw new Error(`Archivo no encontrado: ${path}`);
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function resolveRef(schema, ref) {
+  if (!ref.startsWith('#/')) throw new Error(`$ref externo no soportado: ${ref}`);
+  return ref.slice(2).split('/').reduce((node, part) => node?.[part], schema);
+}
+
+function typeOf(value) {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+export function validateJsonSchema(value, schemaNode, rootSchema = schemaNode, path = '$', errors = []) {
+  if (!schemaNode) {
+    errors.push(`${path}: schema no resoluble`);
+    return errors;
+  }
+  if (schemaNode.$ref) {
+    return validateJsonSchema(value, resolveRef(rootSchema, schemaNode.$ref), rootSchema, path, errors);
+  }
+  if (schemaNode.const !== undefined && value !== schemaNode.const) {
+    errors.push(`${path}: esperado const ${JSON.stringify(schemaNode.const)}, got ${JSON.stringify(value)}`);
+  }
+  if (schemaNode.enum && !schemaNode.enum.includes(value)) {
+    errors.push(`${path}: valor ${JSON.stringify(value)} no esta en enum`);
+  }
+  if (schemaNode.type) {
+    const expected = Array.isArray(schemaNode.type) ? schemaNode.type : [schemaNode.type];
+    const actual = typeOf(value);
+    const ok = expected.some((type) => {
+      if (type === 'number') return actual === 'number';
+      if (type === 'integer') return actual === 'number' && Number.isInteger(value);
+      return actual === type;
+    });
+    if (!ok) errors.push(`${path}: tipo esperado ${expected.join('|')}, got ${actual}`);
+  }
+  if (schemaNode.pattern && typeof value === 'string') {
+    const re = new RegExp(schemaNode.pattern);
+    if (!re.test(value)) errors.push(`${path}: no cumple pattern ${schemaNode.pattern}`);
+  }
+  if (typeof value === 'number') {
+    if (schemaNode.minimum !== undefined && value < schemaNode.minimum) {
+      errors.push(`${path}: ${value} < minimum ${schemaNode.minimum}`);
+    }
+    if (schemaNode.maximum !== undefined && value > schemaNode.maximum) {
+      errors.push(`${path}: ${value} > maximum ${schemaNode.maximum}`);
+    }
+  }
+  if (Array.isArray(value)) {
+    if (schemaNode.minItems !== undefined && value.length < schemaNode.minItems) {
+      errors.push(`${path}: array tiene ${value.length} items, minimo ${schemaNode.minItems}`);
+    }
+    if (schemaNode.uniqueItems) {
+      const seen = new Set();
+      for (const item of value) {
+        const key = JSON.stringify(item);
+        if (seen.has(key)) {
+          errors.push(`${path}: item duplicado ${key}`);
+          break;
+        }
+        seen.add(key);
+      }
+    }
+    if (schemaNode.items) {
+      value.forEach((item, index) => validateJsonSchema(item, schemaNode.items, rootSchema, `${path}[${index}]`, errors));
+    }
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    for (const key of schemaNode.required || []) {
+      if (!(key in value)) errors.push(`${path}: missing required "${key}"`);
+    }
+    for (const [key, subSchema] of Object.entries(schemaNode.properties || {})) {
+      if (key in value) validateJsonSchema(value[key], subSchema, rootSchema, `${path}.${key}`, errors);
+    }
+    if (schemaNode.additionalProperties === false) {
+      const allowed = new Set(Object.keys(schemaNode.properties || {}));
+      for (const key of Object.keys(value)) {
+        if (!allowed.has(key)) errors.push(`${path}: propiedad adicional no permitida "${key}"`);
+      }
+    }
+  }
+  return errors;
+}
+
+function normalizeComparable(value) {
+  if (value === undefined || value === null || value === '') return null;
+  if (Array.isArray(value)) return JSON.stringify([...value].map(String).sort());
+  if (typeof value === 'object') return JSON.stringify(value, Object.keys(value).sort());
+  return JSON.stringify(value);
+}
+
+export function findSeedConflicts(exportCatalog, seedCatalog) {
+  const seedById = new Map((seedCatalog.species || []).map((sp) => [sp.id, sp]));
+  const conflicts = [];
+  const seenExportIds = new Set();
+
+  for (const sp of exportCatalog.species || []) {
+    if (!sp?.id) continue;
+    if (seenExportIds.has(sp.id)) {
+      conflicts.push({ id: sp.id, field: 'id', seed: null, exported: sp.id, reason: 'duplicate_export_id' });
+      continue;
+    }
+    seenExportIds.add(sp.id);
+    const seed = seedById.get(sp.id);
+    if (!seed) continue;
+    for (const field of COMPARED_SPECIES_FIELDS) {
+      const exported = normalizeComparable(sp[field]);
+      const seeded = normalizeComparable(seed[field]);
+      if (exported === null || seeded === null || exported === seeded) continue;
+      conflicts.push({ id: sp.id, field, seed: seed[field], exported: sp[field], reason: 'seed_conflict' });
+    }
+  }
+  return conflicts;
+}
+
+export function validateCatalogExport(exportCatalog, schema, seedCatalog) {
+  const schemaErrors = validateJsonSchema(exportCatalog, schema);
+  const conflicts = findSeedConflicts(exportCatalog, seedCatalog);
+  return {
+    ok: schemaErrors.length === 0 && conflicts.length === 0,
+    schemaErrors,
+    conflicts,
+    stats: {
+      species_exported: exportCatalog.species?.length || 0,
+      species_new_vs_seed: (exportCatalog.species || []).filter((sp) => !(seedCatalog.species || []).some((seed) => seed.id === sp.id)).length,
+      species_already_in_seed: (exportCatalog.species || []).filter((sp) => (seedCatalog.species || []).some((seed) => seed.id === sp.id)).length,
+    },
+  };
+}
+
+export function parseArgs(argv) {
+  const opts = { exportPath: DEFAULT_EXPORT, schemaPath: DEFAULT_SCHEMA, seedPath: DEFAULT_SEED };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--export') opts.exportPath = resolve(argv[++i]);
+    else if (arg === '--schema') opts.schemaPath = resolve(argv[++i]);
+    else if (arg === '--seed') opts.seedPath = resolve(argv[++i]);
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+  }
+  return opts;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log('Usage: node scripts/validate-catalog-export.mjs [--export catalog/chagra-catalog-graph-export.json]');
+    return 0;
+  }
+  const exportCatalog = loadJson(opts.exportPath);
+  const schema = loadJson(opts.schemaPath);
+  const seed = loadJson(opts.seedPath);
+  const result = validateCatalogExport(exportCatalog, schema, seed);
+  if (!result.ok) {
+    for (const error of result.schemaErrors.slice(0, 50)) console.error(`schema: ${error}`);
+    for (const conflict of result.conflicts.slice(0, 50)) {
+      console.error(`conflict: ${conflict.id}.${conflict.field} seed=${JSON.stringify(conflict.seed)} export=${JSON.stringify(conflict.exported)}`);
+    }
+    if (result.schemaErrors.length > 50) console.error(`schema: +${result.schemaErrors.length - 50} errores mas`);
+    if (result.conflicts.length > 50) console.error(`conflict: +${result.conflicts.length - 50} conflictos mas`);
+    return 1;
+  }
+  console.log(`Catalog export valido: ${result.stats.species_exported} species`);
+  console.log(`Nuevas vs seed: ${result.stats.species_new_vs_seed}`);
+  console.log(`Ya en seed: ${result.stats.species_already_in_seed}`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}


### PR DESCRIPTION
Recuperado de worktree codex. Export aditivo del grafo al catálogo público (species+companions+biopreparados+fenología) para cerrar el 87% invisible offline. Validador + test. No toca el seed.