### PR TITLE
feat(ui): Mi Finca Viva en el home — escena 2D de la finca real por etapa

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -34,6 +34,7 @@ import {
 } from '../../services/homeModuleSelector';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
+import MiFincaVivaHomeCard from './MiFincaVivaHomeCard';
 import ClimaStrip from './ClimaStrip';
 import HoyEnFincaStrip from './HoyEnFincaStrip';
 import AIStatusFooter from './AIStatusFooter';
@@ -329,6 +330,18 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                         </span>
                         <ChevronRight size={20} className="text-sky-300/70 shrink-0" />
                     </button>
+                </div>
+            )}
+
+            {/* MI FINCA VIVA — la finca REAL del usuario como escena 2D viva
+                (cultivos por etapa fenológica + animales + vitalidad). Solo se
+                muestra cuando ya hay algo sembrado, para no competir con el
+                OnboardingHero del primer uso (que ya invita a sembrar). La
+                tarjeta es autocontenida: lee sus datos de farmProcessCache
+                (offline-first) y abre el juego completo al tocarla. */}
+            {plantsCount > 0 && (
+                <div className="px-4 pt-3">
+                    <MiFincaVivaHomeCard onNavigate={onNavigate} />
                 </div>
             )}
 

--- a/src/components/dashboard/MiFincaVivaHomeCard.jsx
+++ b/src/components/dashboard/MiFincaVivaHomeCard.jsx
@@ -1,0 +1,350 @@
+/* eslint-disable chagra-i18n/no-hardcoded-spanish --
+ * Los textos de UI de esta tarjeta (título "Mi finca viva", aria-labels,
+ * resúmenes) son strings de interfaz. Su migración a src/config/messages.js es
+ * la TAREA i18n de ADR-050 (transversal a toda la app), fuera del alcance de
+ * esta feature visual. Se silencia el warning soft acá para no arrastrar ese
+ * refactor i18n — mismo criterio que FincaCards.jsx en este mismo directorio. */
+import { useEffect, useMemo, useState } from 'react';
+import { Sprout, ChevronRight } from 'lucide-react';
+import { listFarmProcesses } from '../../db/farmProcessCache';
+import { buildFincaScene } from '../../services/fincaSceneService';
+import '../juego/juego-finca.css';
+
+/**
+ * MiFincaVivaHomeCard — la finca REAL del usuario como ESCENA 2D viva en el home.
+ *
+ * Una granjita tipo Nintendo (SVG inline, offline-first) que dibuja CADA cultivo
+ * según su ETAPA FENOLÓGICA real (semilla → brote → hoja → flor → fruto →
+ * cosecha) y los animales si los hay. Crece a medida que la finca avanza. Doble
+ * lectura: para una niña es lindo y vivo; para el campesino es un vistazo claro
+ * del estado de SU finca (cultivos activos, cuántos en cosecha, vitalidad).
+ *
+ * Cero fabricación: lee los procesos reales de farmProcessCache (offline-first).
+ * Sin datos → escena "por sembrar" acogedora que invita a empezar. Toca la
+ * escena para abrir el juego completo "Mi Finca Viva".
+ *
+ * Mobile-first y liviana (gama baja): SVG estático con animaciones CSS suaves
+ * que respetan prefers-reduced-motion (juego-finca.css). No usa red en runtime.
+ *
+ * @param {Object} props
+ * @param {Function} [props.onNavigate]  navegación de la app (abre 'juego')
+ */
+export default function MiFincaVivaHomeCard({ onNavigate }) {
+  const [processes, setProcesses] = useState([]);
+  const [cargando, setCargando] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    listFarmProcesses({ status: 'active' })
+      .then((list) => {
+        if (alive) setProcesses(Array.isArray(list) ? list : []);
+      })
+      .catch(() => { /* IDB falló: escena "por sembrar" honesta, nunca datos inventados */ })
+      .finally(() => { if (alive) setCargando(false); });
+    return () => { alive = false; };
+  }, []);
+
+  const scene = useMemo(() => buildFincaScene({ processes }), [processes]);
+
+  const abrirJuego = () => onNavigate?.('juego');
+
+  return (
+    <section
+      data-testid="mi-finca-viva-home-card"
+      className="bg-gradient-to-br from-emerald-950/70 to-teal-950/50 border border-emerald-800/40 rounded-2xl overflow-hidden"
+    >
+      {/* Encabezado compacto */}
+      <div className="flex items-center justify-between px-4 pt-3 pb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Sprout size={18} className="text-emerald-300 shrink-0" aria-hidden="true" />
+          <h3 className="text-base font-bold text-white truncate">Mi finca viva</h3>
+        </div>
+        <button
+          type="button"
+          onClick={abrirJuego}
+          aria-label="Abrir Mi Finca Viva"
+          className="flex items-center gap-1 text-xs font-semibold text-emerald-300/80 hover:text-emerald-200 active:scale-95 transition"
+        >
+          Abrir
+          <ChevronRight size={16} aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* La ESCENA 2D — el corazón visual. Toda la escena es un botón. */}
+      <button
+        type="button"
+        onClick={abrirJuego}
+        aria-label={
+          scene.vacia
+            ? 'Tu finca está por sembrar. Toca para empezar.'
+            : `${scene.resumen}. Toca para ver tu finca viva.`
+        }
+        className="block w-full text-left active:scale-[0.99] transition"
+      >
+        <FincaScene2D scene={scene} cargando={cargando} />
+      </button>
+
+      {/* Vitalidad + resumen (vistazo útil para el campesino) */}
+      <div className="px-4 pt-3 pb-4">
+        {scene.vacia ? (
+          <p className="text-sm text-emerald-100/90 leading-relaxed">
+            Tu finca está esperando.{' '}
+            <span className="font-semibold text-emerald-200">Siembra tu primera planta</span>{' '}
+            y mira cómo cobra vida.
+          </p>
+        ) : (
+          <>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs font-bold text-emerald-200">{scene.vitalidadLabel}</span>
+              <span className="text-xs font-black text-emerald-300">{scene.vitalidad}%</span>
+            </div>
+            <div className="h-2.5 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
+              <div
+                className="h-full bg-gradient-to-r from-emerald-500 via-lime-400 to-emerald-400 rounded-full transition-all duration-700"
+                style={{ width: `${Math.max(scene.vitalidad, 4)}%` }}
+                role="progressbar"
+                aria-valuenow={scene.vitalidad}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`Vitalidad de la finca: ${scene.vitalidad} por ciento`}
+              />
+            </div>
+            <p className="text-xs text-emerald-300/80 mt-2">{scene.resumen}</p>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * FincaScene2D — el dibujo SVG de la finca. Por cada lote pinta un cultivo según
+ * su sprite/etapa; los animales van en un corral a la derecha. Posiciones
+ * deterministas (estables entre renders → reconocible para la niña, sin
+ * parpadeo). Reusa las animaciones de juego-finca.css (fv-grow, fv-sway, …).
+ */
+function FincaScene2D({ scene, cargando }) {
+  const lluvia = scene.clima.includes('lluvia');
+
+  // Distribuir los lotes en una rejilla suave sobre la tierra. Determinista.
+  const slots = useMemo(() => {
+    return scene.lotes.map((lote, i) => {
+      const col = i % 4;
+      const row = Math.floor(i / 4);
+      const x = 48 + col * 88 + (row % 2) * 16; // leve offset por fila
+      const y = 168 + row * 24;
+      return { ...lote, x, y, key: lote.id || `l${i}` };
+    });
+  }, [scene.lotes]);
+
+  return (
+    <div
+      className="fv-scene"
+      data-testid="finca-scene-2d"
+      role="img"
+      aria-hidden="true"
+    >
+      <svg viewBox="0 0 400 240" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <linearGradient id="mfv-sky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#9fd3e6" />
+            <stop offset="100%" stopColor="#e6f4ec" />
+          </linearGradient>
+          <linearGradient id="mfv-soil" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#9c8a5a" />
+            <stop offset="100%" stopColor="#7c6a3e" />
+          </linearGradient>
+        </defs>
+
+        {/* Cielo */}
+        <rect x="0" y="0" width="400" height="240" fill="url(#mfv-sky)" />
+
+        {/* Sol cálido (siempre presente) */}
+        <g className="fv-sun">
+          <circle cx="338" cy="44" r="24" fill="#ffe08a" opacity="0.95" />
+          <circle cx="338" cy="44" r="16" fill="#ffd24d" />
+        </g>
+
+        {/* Nubes */}
+        <g className="fv-cloud" fill="#ffffff" opacity={lluvia ? 0.95 : 0.8}>
+          <ellipse cx="82" cy="42" rx="26" ry="13" />
+          <ellipse cx="102" cy="38" rx="20" ry="14" />
+          <ellipse cx="64" cy="38" rx="16" ry="11" />
+        </g>
+
+        {/* Lluvia opcional (clima/ENSO real) */}
+        {lluvia && (
+          <g stroke="#7fb8d6" strokeWidth="2" strokeLinecap="round" opacity="0.7">
+            <line x1="70" y1="56" x2="66" y2="68" />
+            <line x1="86" y1="58" x2="82" y2="70" />
+            <line x1="100" y1="56" x2="96" y2="68" />
+          </g>
+        )}
+
+        {/* Colinas de fondo */}
+        <path d="M0 174 Q100 138 200 168 T400 162 V240 H0 Z" fill="#86a85e" opacity="0.55" />
+
+        {/* Compostera (elemento de finca) en la esquina */}
+        <g transform="translate(18 196)">
+          <rect x="-2" y="0" width="26" height="16" rx="3" fill="#6e5634" />
+          <rect x="-2" y="-4" width="26" height="6" rx="2" fill="#8a6a3a" />
+          <circle cx="6" cy="-2" r="2" fill="#a4c46a" />
+          <circle cx="16" cy="-3" r="2" fill="#a4c46a" />
+        </g>
+
+        {/* Tierra / suelo */}
+        <rect x="0" y="184" width="400" height="56" fill="url(#mfv-soil)" />
+        <path d="M0 184 Q100 176 200 182 T400 180 V196 H0 Z" fill="#86a85e" opacity="0.4" />
+
+        {/* Estanque de agua (elemento de finca) */}
+        <ellipse cx="62" cy="222" rx="40" ry="10" fill="#67b6d6" opacity="0.85" />
+        <ellipse cx="62" cy="220" rx="34" ry="7" fill="#8fcde6" opacity="0.7" />
+
+        {/* Estado vacío: semillita esperando en la tierra */}
+        {scene.vacia && !cargando && (
+          <g transform="translate(200 198)" className="fv-grow">
+            <ellipse cx="0" cy="6" rx="10" ry="6" fill="#8a6a3a" />
+            <path d="M0 0 Q-5 -10 0 -18 Q5 -10 0 0" fill="#5bb06e" />
+          </g>
+        )}
+
+        {/* Cultivos por etapa fenológica real */}
+        {!cargando && slots.map((lote, i) => (
+          <g
+            key={lote.key}
+            className={`fv-grow ${i % 2 === 0 ? 'fv-sway' : 'fv-sway-slow'}`}
+            transform={`translate(${lote.x} ${lote.y})`}
+            style={{ animationDelay: `${Math.min(i * 0.07, 1)}s` }}
+          >
+            <CropSprite sprite={lote.sprite} growth={lote.growth} />
+          </g>
+        ))}
+
+        {/* Corral de animales (si los hay) */}
+        {!cargando && scene.animales.length > 0 && (
+          <g transform="translate(312 196)">
+            {/* cerca */}
+            <line x1="-6" y1="0" x2="-6" y2="-14" stroke="#8a6a3a" strokeWidth="3" strokeLinecap="round" />
+            <line x1="60" y1="0" x2="60" y2="-14" stroke="#8a6a3a" strokeWidth="3" strokeLinecap="round" />
+            <line x1="-8" y1="-8" x2="62" y2="-8" stroke="#8a6a3a" strokeWidth="3" strokeLinecap="round" />
+          </g>
+        )}
+      </svg>
+
+      {/* Animales (emoji) sobre el corral — accesibles y livianos */}
+      {!cargando && scene.animales.length > 0 && (
+        <div className="absolute inset-0 pointer-events-none">
+          {scene.animales.slice(0, 3).map((a, i) => (
+            <span
+              key={a.id || `a${i}`}
+              className="fv-float absolute select-none"
+              style={{ right: `${8 + i * 9}%`, bottom: '14%', fontSize: '1.4rem', animationDelay: `${i * 0.4}s` }}
+            >
+              {a.emoji}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * CropSprite — dibuja UNA planta según su sprite (etapa) y crecimiento.
+ * Todas las plantas comparten un tronco/tallo que escala con `growth`; el
+ * remate (semilla/brote/hoja/flor/fruto/cosecha/árbol) cambia según la fase.
+ *
+ * @param {Object} props
+ * @param {string} props.sprite  seed|sprout|leaf|flower|fruit|harvest|rest|tree
+ * @param {number} props.growth  0..1
+ */
+function CropSprite({ sprite, growth }) {
+  const h = 6 + growth * 22; // altura del tallo
+  switch (sprite) {
+    case 'seed':
+      return (
+        <>
+          <ellipse cx="0" cy="0" rx="7" ry="4" fill="#7a5a32" />
+          <path d="M-3 -1 Q0 -4 3 -1" stroke="#8a6a3a" strokeWidth="1" fill="none" />
+        </>
+      );
+    case 'sprout':
+      return (
+        <>
+          <rect x="-1.5" y={-h} width="3" height={h} rx="1.5" fill="#5b8a3c" />
+          <path d={`M0 ${-h} Q-7 ${-h - 5} -3 ${-h - 12}`} stroke="#5bb06e" strokeWidth="3" fill="none" strokeLinecap="round" />
+          <path d={`M0 ${-h} Q7 ${-h - 5} 3 ${-h - 12}`} stroke="#5bb06e" strokeWidth="3" fill="none" strokeLinecap="round" />
+        </>
+      );
+    case 'rest':
+      return (
+        <>
+          <ellipse cx="0" cy="0" rx="9" ry="4" fill="#6e5634" />
+          <path d="M-5 -1 Q0 -6 5 -1" stroke="#8a7" strokeWidth="2" fill="none" opacity="0.6" />
+        </>
+      );
+    case 'tree':
+      return (
+        <>
+          <rect x="-3" y={-h} width="6" height={h} rx="2" fill="#7a5230" />
+          <circle cx="0" cy={-h - 10} r="13" fill="#3f8f4e" />
+          <circle cx="-8" cy={-h - 4} r="9" fill="#4ca35c" />
+          <circle cx="8" cy={-h - 4} r="9" fill="#4ca35c" />
+        </>
+      );
+    case 'leaf':
+      return (
+        <>
+          <rect x="-2" y={-h} width="4" height={h} rx="2" fill="#46985a" />
+          <ellipse cx="-6" cy={-h + 6} rx="7" ry="4" fill="#5bb06e" transform={`rotate(-25 -6 ${-h + 6})`} />
+          <ellipse cx="6" cy={-h + 10} rx="7" ry="4" fill="#5bb06e" transform={`rotate(25 6 ${-h + 10})`} />
+          <ellipse cx="0" cy={-h - 2} rx="6" ry="4" fill="#6cc07e" />
+        </>
+      );
+    case 'flower':
+      return (
+        <>
+          <rect x="-2" y={-h} width="4" height={h} rx="2" fill="#46985a" />
+          <ellipse cx="-6" cy={-h + 8} rx="6" ry="4" fill="#5bb06e" transform={`rotate(-25 -6 ${-h + 8})`} />
+          <ellipse cx="6" cy={-h + 12} rx="6" ry="4" fill="#5bb06e" transform={`rotate(25 6 ${-h + 12})`} />
+          {/* flor */}
+          <g transform={`translate(0 ${-h - 2})`}>
+            <circle cx="0" cy="-5" r="3.5" fill="#ff9ec4" />
+            <circle cx="-4" cy="0" r="3.5" fill="#ff9ec4" />
+            <circle cx="4" cy="0" r="3.5" fill="#ff9ec4" />
+            <circle cx="0" cy="3" r="3.5" fill="#ff9ec4" />
+            <circle cx="0" cy="-1" r="2.5" fill="#ffd24d" />
+          </g>
+        </>
+      );
+    case 'fruit':
+      return (
+        <>
+          <rect x="-2" y={-h} width="4" height={h} rx="2" fill="#46985a" />
+          <circle cx="0" cy={-h - 4} r="10" fill="#4ca35c" />
+          <circle cx="-7" cy={-h + 4} r="7" fill="#5bb06e" />
+          <circle cx="7" cy={-h + 4} r="7" fill="#5bb06e" />
+          <circle cx="-3" cy={-h - 2} r="3" fill="#ff7a59" />
+          <circle cx="4" cy={-h + 2} r="3" fill="#ffb74d" />
+        </>
+      );
+    case 'harvest':
+      return (
+        <>
+          <rect x="-2" y={-h} width="4" height={h} rx="2" fill="#9a8a4a" />
+          <circle cx="0" cy={-h - 4} r="11" fill="#5fa84e" />
+          <circle cx="-6" cy={-h} r="4" fill="#ff7a59" />
+          <circle cx="6" cy={-h - 6} r="4" fill="#ff7a59" />
+          <circle cx="0" cy={-h - 10} r="4" fill="#ffb74d" />
+          <circle cx="2" cy={-h + 2} r="4" fill="#ff7a59" />
+        </>
+      );
+    default:
+      return (
+        <>
+          <rect x="-1.5" y={-h} width="3" height={h} rx="1.5" fill="#5b8a3c" />
+          <circle cx="0" cy={-h - 2} r="5" fill="#5bb06e" />
+        </>
+      );
+  }
+}

--- a/src/components/dashboard/__tests__/MiFincaVivaHomeCard.test.jsx
+++ b/src/components/dashboard/__tests__/MiFincaVivaHomeCard.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import MiFincaVivaHomeCard from '../MiFincaVivaHomeCard';
+
+// IDB de procesos mockeada (por defecto finca vacía → invita a sembrar).
+const listFarmProcessesMock = vi.fn(() => Promise.resolve([]));
+vi.mock('../../../db/farmProcessCache', () => ({
+  listFarmProcesses: (...args) => listFarmProcessesMock(...args),
+}));
+
+// Procesos en el shape REAL de producción (anidado en `attributes`).
+const fincaConCultivos = () => [
+  {
+    process_id: 'p1',
+    type: 'farm_process',
+    attributes: {
+      process_type: 'sowing',
+      status: 'active',
+      current_stage: 'flowering',
+      subject_slug: 'coffea_arabica',
+      subject_label: 'Café',
+    },
+  },
+  {
+    process_id: 'p2',
+    type: 'farm_process',
+    attributes: {
+      process_type: 'sowing',
+      status: 'active',
+      current_stage: 'harvest',
+      subject_slug: 'zea_mays',
+      subject_label: 'Maíz',
+    },
+  },
+];
+
+describe('MiFincaVivaHomeCard', () => {
+  beforeEach(() => {
+    listFarmProcessesMock.mockReset();
+    listFarmProcessesMock.mockResolvedValue([]);
+  });
+
+  it('finca vacía → invita a sembrar (estado acogedor)', async () => {
+    render(<MiFincaVivaHomeCard />);
+    expect(await screen.findByTestId('mi-finca-viva-home-card')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Siembra tu primera planta/i)).toBeInTheDocument();
+    });
+  });
+
+  it('con cultivos → muestra escena y vitalidad real', async () => {
+    listFarmProcessesMock.mockResolvedValue(fincaConCultivos());
+    render(<MiFincaVivaHomeCard />);
+    expect(await screen.findByTestId('finca-scene-2d')).toBeInTheDocument();
+    await waitFor(() => {
+      // Resumen del campesino: 2 cultivos activos, 1 listo para cosechar.
+      expect(screen.getByText(/cultivos activos/i)).toBeInTheDocument();
+    });
+  });
+
+  it('toca la escena → navega al juego completo', async () => {
+    const onNavigate = vi.fn();
+    render(<MiFincaVivaHomeCard onNavigate={onNavigate} />);
+    const escena = await screen.findByLabelText(/Toca para empezar|Toca para ver tu finca viva/i);
+    fireEvent.click(escena);
+    expect(onNavigate).toHaveBeenCalledWith('juego');
+  });
+
+  it('si IDB falla, no rompe: muestra estado vacío honesto', async () => {
+    listFarmProcessesMock.mockRejectedValue(new Error('IDB down'));
+    render(<MiFincaVivaHomeCard />);
+    expect(await screen.findByTestId('mi-finca-viva-home-card')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/Siembra tu primera planta/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/services/__tests__/fincaSceneService.test.js
+++ b/src/services/__tests__/fincaSceneService.test.js
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import {
+  spriteForStage,
+  calcularVitalidad,
+  etiquetaVitalidad,
+  buildFincaScene,
+} from '../fincaSceneService';
+
+// ─── Fixtures: procesos REALES de finca (shape de farmProcessCache) ─────────
+
+/** Proceso plano (como lo pasan tests/llamadas directas). */
+function proc({ id, type = 'sowing', stage = 'vegetative', status = 'active', slug = 'zea_mays', label = 'Maíz' }) {
+  return {
+    process_id: id,
+    process_type: type,
+    current_stage: stage,
+    status,
+    subject_slug: slug,
+    subject_label: label,
+  };
+}
+
+/** Proceso anidado en .attributes (shape real del almacenamiento). */
+function procAnidado({ id, type = 'sowing', stage = 'flowering', status = 'active', slug = 'coffea_arabica', label = 'Café' }) {
+  return {
+    process_id: id,
+    type: 'farm_process',
+    attributes: {
+      process_type: type,
+      current_stage: stage,
+      status,
+      subject_slug: slug,
+      subject_label: label,
+      location_zone_id: 'zona-1',
+    },
+  };
+}
+
+describe('fincaSceneService — spriteForStage (mapeo etapa→sprite)', () => {
+  it('mapea cada etapa fenológica de cultivo a una fase coherente', () => {
+    expect(spriteForStage('sowing_confirmed').fase).toBe('seed');
+    expect(spriteForStage('germination').fase).toBe('sprout');
+    expect(spriteForStage('vegetative').fase).toBe('leaf');
+    expect(spriteForStage('flowering').fase).toBe('flower');
+    expect(spriteForStage('fruiting').fase).toBe('fruit');
+    expect(spriteForStage('harvest').fase).toBe('harvest');
+  });
+
+  it('el crecimiento visual aumenta de semilla a cosecha', () => {
+    expect(spriteForStage('sowing_confirmed').growth)
+      .toBeLessThan(spriteForStage('germination').growth);
+    expect(spriteForStage('germination').growth)
+      .toBeLessThan(spriteForStage('vegetative').growth);
+    expect(spriteForStage('vegetative').growth)
+      .toBeLessThan(spriteForStage('flowering').growth);
+    expect(spriteForStage('flowering').growth)
+      .toBeLessThan(spriteForStage('fruiting').growth);
+    expect(spriteForStage('harvest').growth).toBe(1);
+  });
+
+  it('etapa de restauración usa hitos ecológicos (no fenología de cultivo)', () => {
+    expect(spriteForStage('establecimiento').fase).toBe('sprout');
+    expect(spriteForStage('cierre').sprite).toBe('tree');
+  });
+
+  it('etapa desconocida cae a un brote genérico, nunca rompe', () => {
+    expect(spriteForStage('etapa_inexistente').sprite).toBe('sprout');
+    expect(spriteForStage(undefined).sprite).toBe('sprout');
+    expect(spriteForStage(null).fase).toBe('sprout');
+  });
+
+  it('cada etapa trae una etiqueta corta legible', () => {
+    expect(spriteForStage('flowering').etiqueta).toBe('Florecida');
+    expect(spriteForStage('harvest_window').etiqueta).toBe('Lista para cosechar');
+  });
+});
+
+describe('fincaSceneService — calcularVitalidad (cero fabricación)', () => {
+  it('finca sin cultivos activos → vitalidad 0', () => {
+    expect(calcularVitalidad([])).toBe(0);
+    expect(calcularVitalidad([{ activo: false, fase: 'harvest' }])).toBe(0);
+  });
+
+  it('una semilla recién puesta vale menos que una cosecha', () => {
+    const semilla = calcularVitalidad([{ activo: true, fase: 'seed', subjectSlug: 'a' }]);
+    const cosecha = calcularVitalidad([{ activo: true, fase: 'harvest', subjectSlug: 'a' }]);
+    expect(semilla).toBeLessThan(cosecha);
+  });
+
+  it('más cultivos distintos → más vitalidad (diversidad), con techo', () => {
+    const uno = calcularVitalidad([
+      { activo: true, fase: 'leaf', subjectSlug: 'a' },
+    ]);
+    const varios = calcularVitalidad([
+      { activo: true, fase: 'leaf', subjectSlug: 'a' },
+      { activo: true, fase: 'leaf', subjectSlug: 'b' },
+      { activo: true, fase: 'leaf', subjectSlug: 'c' },
+    ]);
+    expect(varios).toBeGreaterThan(uno);
+  });
+
+  it('vitalidad queda acotada a 0-100', () => {
+    const muchos = Array.from({ length: 30 }, (_, i) => ({
+      activo: true, fase: 'harvest', subjectSlug: `s${i}`,
+    }));
+    const v = calcularVitalidad(muchos);
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('fincaSceneService — etiquetaVitalidad', () => {
+  it('da una etiqueta cariñosa y creciente', () => {
+    expect(etiquetaVitalidad(0)).toMatch(/por sembrar/i);
+    expect(etiquetaVitalidad(10)).toMatch(/empezando/i);
+    expect(etiquetaVitalidad(40)).toMatch(/creciendo/i);
+    expect(etiquetaVitalidad(60)).toMatch(/viva|fuerte/i);
+    expect(etiquetaVitalidad(90)).toMatch(/floreciendo/i);
+  });
+});
+
+describe('fincaSceneService — buildFincaScene (estado vacío)', () => {
+  it('sin procesos → escena vacía que invita a sembrar', () => {
+    const s = buildFincaScene({ processes: [] });
+    expect(s.vacia).toBe(true);
+    expect(s.lotes).toHaveLength(0);
+    expect(s.vitalidad).toBe(0);
+    expect(s.resumen).toMatch(/primera siembra/i);
+  });
+
+  it('procesos cancelados no cuentan como finca viva', () => {
+    const s = buildFincaScene({ processes: [proc({ id: 'p1', status: 'cancelled' })] });
+    expect(s.vacia).toBe(true);
+    expect(s.lotes).toHaveLength(0);
+  });
+});
+
+describe('fincaSceneService — buildFincaScene (datos reales)', () => {
+  it('dibuja un lote por cultivo con su etapa real', () => {
+    const s = buildFincaScene({
+      processes: [
+        proc({ id: 'p1', stage: 'flowering', slug: 'coffea_arabica', label: 'Café' }),
+        proc({ id: 'p2', stage: 'harvest', slug: 'zea_mays', label: 'Maíz' }),
+      ],
+    });
+    expect(s.vacia).toBe(false);
+    expect(s.lotes).toHaveLength(2);
+    const cafe = s.lotes.find((l) => l.nombre === 'Café');
+    expect(cafe.fase).toBe('flower');
+    expect(cafe.etiquetaEtapa).toBe('Florecida');
+  });
+
+  it('acepta procesos anidados en .attributes (shape real)', () => {
+    const s = buildFincaScene({ processes: [procAnidado({ id: 'p1' })] });
+    expect(s.lotes).toHaveLength(1);
+    expect(s.lotes[0].nombre).toBe('Café');
+    expect(s.lotes[0].fase).toBe('flower');
+  });
+
+  it('ordena los cultivos más maduros adelante (más visibles)', () => {
+    const s = buildFincaScene({
+      processes: [
+        proc({ id: 'p1', stage: 'germination', slug: 'a' }),
+        proc({ id: 'p2', stage: 'harvest', slug: 'b' }),
+      ],
+    });
+    expect(s.lotes[0].fase).toBe('harvest');
+  });
+
+  it('cuenta cultivos activos y los que están en cosecha', () => {
+    const s = buildFincaScene({
+      processes: [
+        proc({ id: 'p1', stage: 'harvest', slug: 'a' }),
+        proc({ id: 'p2', stage: 'fruiting', slug: 'b' }),
+        proc({ id: 'p3', stage: 'germination', slug: 'c' }),
+      ],
+    });
+    expect(s.cultivosActivos).toBe(3);
+    expect(s.enCosecha).toBe(2); // harvest + fruiting
+  });
+
+  it('separa animales (cerdos) en su propio corral', () => {
+    const s = buildFincaScene({
+      processes: [
+        proc({ id: 'p1', stage: 'vegetative', slug: 'zea_mays', label: 'Maíz' }),
+        proc({ id: 'a1', type: 'pigs', stage: 'engorde', slug: 'pigs', label: 'Cerdos' }),
+      ],
+    });
+    expect(s.lotes).toHaveLength(1);
+    expect(s.animales).toHaveLength(1);
+    expect(s.animales[0].emoji).toBe('🐷');
+    expect(s.animales[0].animal).toBe(true);
+  });
+
+  it('respeta el tope de lotes dibujados (rendimiento gama baja)', () => {
+    const procesos = Array.from({ length: 20 }, (_, i) => proc({ id: `p${i}`, slug: `s${i}` }));
+    const s = buildFincaScene({ processes: procesos, maxLotes: 12 });
+    expect(s.lotes).toHaveLength(12);
+    expect(s.totalCultivos).toBe(20);
+  });
+
+  it('una finca próspera tiene más vitalidad que una recién sembrada', () => {
+    const recien = buildFincaScene({
+      processes: [proc({ id: 'p1', stage: 'sowing_confirmed', slug: 'a' })],
+    });
+    const prospera = buildFincaScene({
+      processes: [
+        proc({ id: 'p1', stage: 'harvest', slug: 'a' }),
+        proc({ id: 'p2', stage: 'fruiting', slug: 'b' }),
+        proc({ id: 'p3', stage: 'flowering', slug: 'c' }),
+      ],
+    });
+    expect(prospera.vitalidad).toBeGreaterThan(recien.vitalidad);
+  });
+});
+
+describe('fincaSceneService — clima (opcional, sin fabricar)', () => {
+  it('sin clima → solo sol', () => {
+    const s = buildFincaScene({ processes: [proc({ id: 'p1' })] });
+    expect(s.clima).toEqual(['sol']);
+  });
+
+  it('con lluvia → agrega lluvia a la escena', () => {
+    const s = buildFincaScene({ processes: [proc({ id: 'p1' })], clima: { lluvia: true } });
+    expect(s.clima).toContain('lluvia');
+  });
+
+  it('ENSO La Niña sugiere lluvia', () => {
+    const s = buildFincaScene({ processes: [proc({ id: 'p1' })], clima: { ensoPhase: 'la_nina' } });
+    expect(s.clima).toContain('lluvia');
+  });
+});

--- a/src/services/fincaSceneService.js
+++ b/src/services/fincaSceneService.js
@@ -1,0 +1,331 @@
+/**
+ * fincaSceneService — traduce los datos REALES de la finca en una ESCENA 2D
+ * glanceable para el home ("Mi Finca Viva").
+ *
+ * A diferencia de fincaGameService (que mapea la finca a un MUNDO por nivel
+ * Gliessman 0-4), este módulo dibuja la finca PROCESO POR PROCESO: cada cultivo
+ * se ve según su ETAPA FENOLÓGICA real (siembra → crecimiento → floración →
+ * cosecha), los animales aparecen si los hay, y se calcula una "vitalidad"
+ * honesta para un vistazo rápido en el home.
+ *
+ * Doble propósito:
+ *   - Para una niña: lindo, vivo, con bichos y plantas que crecen.
+ *   - Para el campesino: un vistazo claro del estado REAL de SU finca (cuántos
+ *     cultivos, en qué etapa, cuántos en cosecha, salud del sistema).
+ *
+ * PRINCIPIO INNEGOCIABLE — CERO FABRICACIÓN: cada planta, etapa o animal que se
+ * dibuja viene de un FarmProcess real de la finca. Sin datos → escena "por
+ * sembrar" acogedora que invita a empezar (nunca un campo muerto ni progreso
+ * inventado).
+ *
+ * Funciones PURAS: sin fetch, sin IDB, sin DOM. La tarjeta del home
+ * (MiFincaVivaHomeCard) inyecta los procesos (de farmProcessCache) y, opcional,
+ * el clima. Español de Colombia (tú/usted), sin voseo.
+ *
+ * @module services/fincaSceneService
+ */
+
+// ─── Etapas fenológicas → cómo se ve la planta ──────────────────────────────
+
+/**
+ * Mapa de la etapa fenológica/hito de un proceso al SPRITE que la representa en
+ * la escena. `growth` es 0..1 (qué tan crecida se dibuja la planta), `tone` es
+ * el matiz (verde joven → verde maduro → dorado de cosecha) y `accent` marca si
+ * lleva flor/fruto. Los nombres de etapa cubren el vocabulario transicional del
+ * repo (germination/emergence, growth/vegetative, harvest_window/harvest, …) y
+ * los hitos de restauración/páramo/cerdos (que NO son fenología de cultivo).
+ *
+ * @typedef {Object} StageSprite
+ * @property {string} sprite   id del sprite a dibujar
+ * @property {number} growth   0..1, altura/madurez visual de la planta
+ * @property {'seed'|'sprout'|'leaf'|'flower'|'fruit'|'harvest'|'rest'} fase
+ * @property {string} etiqueta etiqueta corta y clara (campesino + niña)
+ */
+
+const STAGE_SPRITES = Object.freeze({
+  // Siembra
+  sowing: { sprite: 'seed', growth: 0.1, fase: 'seed', etiqueta: 'Recién sembrada' },
+  sowing_confirmed: { sprite: 'seed', growth: 0.12, fase: 'seed', etiqueta: 'Recién sembrada' },
+  // Germinación / emergencia
+  germination: { sprite: 'sprout', growth: 0.25, fase: 'sprout', etiqueta: 'Brotando' },
+  emergence: { sprite: 'sprout', growth: 0.28, fase: 'sprout', etiqueta: 'Brotando' },
+  // Crecimiento vegetativo
+  growth: { sprite: 'leaf', growth: 0.55, fase: 'leaf', etiqueta: 'Creciendo' },
+  vegetative: { sprite: 'leaf', growth: 0.55, fase: 'leaf', etiqueta: 'Creciendo' },
+  // Floración
+  flowering: { sprite: 'flower', growth: 0.78, fase: 'flower', etiqueta: 'Florecida' },
+  // Fructificación
+  fruiting: { sprite: 'fruit', growth: 0.9, fase: 'fruit', etiqueta: 'Con frutos' },
+  // Cosecha
+  harvest_window: { sprite: 'harvest', growth: 1, fase: 'harvest', etiqueta: 'Lista para cosechar' },
+  harvest: { sprite: 'harvest', growth: 1, fase: 'harvest', etiqueta: 'En cosecha' },
+  post_harvest: { sprite: 'rest', growth: 0.2, fase: 'rest', etiqueta: 'Descansando' },
+  closed: { sprite: 'rest', growth: 0.2, fase: 'rest', etiqueta: 'Ciclo cerrado' },
+  fallow: { sprite: 'rest', growth: 0.15, fase: 'rest', etiqueta: 'En descanso' },
+  pest_management: { sprite: 'leaf', growth: 0.5, fase: 'leaf', etiqueta: 'En cuidado' },
+  // Restauración / silvopastoreo (hitos ecológicos, NO fenología de cultivo)
+  establecimiento: { sprite: 'sprout', growth: 0.3, fase: 'sprout', etiqueta: 'Plantada' },
+  prendimiento: { sprite: 'leaf', growth: 0.5, fase: 'leaf', etiqueta: 'Pegando raíz' },
+  mantenimiento: { sprite: 'tree', growth: 0.7, fase: 'leaf', etiqueta: 'En crecimiento' },
+  monitoreo_sucesion: { sprite: 'tree', growth: 0.9, fase: 'fruit', etiqueta: 'Bosque joven' },
+  cierre: { sprite: 'tree', growth: 1, fase: 'fruit', etiqueta: 'Bosque firme' },
+  // Páramo (conservación)
+  delimitacion: { sprite: 'sprout', growth: 0.25, fase: 'sprout', etiqueta: 'Zona delimitada' },
+  aislamiento: { sprite: 'leaf', growth: 0.45, fase: 'leaf', etiqueta: 'Protegida' },
+  revegetacion_nativa: { sprite: 'flower', growth: 0.75, fase: 'flower', etiqueta: 'Revegetando' },
+  monitoreo_hidrico: { sprite: 'tree', growth: 0.95, fase: 'fruit', etiqueta: 'Agua sana' },
+});
+
+const DEFAULT_SPRITE = Object.freeze({
+  sprite: 'sprout', growth: 0.3, fase: 'sprout', etiqueta: 'En la finca',
+});
+
+/**
+ * Devuelve el sprite para una etapa fenológica/hito. Tolerante: una etapa
+ * desconocida cae a un brote genérico (nunca rompe la escena).
+ *
+ * @param {string} stage  current_stage del proceso
+ * @returns {StageSprite}
+ */
+export function spriteForStage(stage) {
+  if (!stage) return DEFAULT_SPRITE;
+  return STAGE_SPRITES[stage] || DEFAULT_SPRITE;
+}
+
+// ─── Procesos que son ANIMALES (no plantas) ─────────────────────────────────
+
+/**
+ * Mapa de tipo de proceso animal → emoji que lo representa en el corral. Hoy el
+ * único ciclo animal modelado es 'pigs'; se deja extensible por si entran aves,
+ * bovinos, etc. Silvopastoreo es PLANTA (árboles forrajeros), no animal.
+ */
+const ANIMAL_EMOJI = Object.freeze({
+  pigs: '🐷',
+});
+
+/** @param {string} processType @returns {boolean} */
+function esProcesoAnimal(processType) {
+  return Object.prototype.hasOwnProperty.call(ANIMAL_EMOJI, processType);
+}
+
+// ─── Normalización del proceso (anidado .attributes → plano) ────────────────
+
+/**
+ * Aplana un FarmProcess al shape plano que esta escena consume. El
+ * almacenamiento real guarda los datos bajo `process.attributes`; los tests y
+ * llamadas directas pueden pasar el shape plano. No inventa campos.
+ *
+ * @param {Object} p  FarmProcess (anidado o plano)
+ * @returns {Object} { process_id, process_type, subject_label, current_stage, status, location }
+ */
+function flatten(p) {
+  if (!p || typeof p !== 'object') return null;
+  const a = p.attributes && typeof p.attributes === 'object' ? p.attributes : p;
+  return {
+    process_id: p.process_id || a.process_id || null,
+    process_type: a.process_type || p.process_type || 'sowing',
+    subject_label: a.subject_label || p.subject_label || a.subject_slug || p.subject_slug || null,
+    subject_slug: a.subject_slug || p.subject_slug || null,
+    current_stage: a.current_stage || p.current_stage || null,
+    status: a.status || p.status || 'active',
+    location: a.location_zone_id || a.location_land_asset_id
+      || p.location_zone_id || p.location_land_asset_id || null,
+  };
+}
+
+// ─── Vitalidad de la finca (vistazo honesto) ────────────────────────────────
+
+/**
+ * Pesos de avance por fase, para una "vitalidad" honesta de la finca. Un
+ * cultivo en cosecha o un bosque firme aportan más que una semilla recién
+ * puesta — refleja el trabajo invertido, no infla nada. Procesos en descanso
+ * (post-cosecha, barbecho) aportan poco: la tierra descansa.
+ */
+const FASE_PESO = Object.freeze({
+  seed: 0.2,
+  sprout: 0.4,
+  leaf: 0.6,
+  flower: 0.8,
+  fruit: 0.95,
+  harvest: 1,
+  rest: 0.25,
+});
+
+/**
+ * Calcula la vitalidad (0-100) de la finca a partir de sus cultivos activos.
+ *
+ * Combina DOS señales reales, sin fabricar:
+ *   - Avance promedio de los cultivos activos (qué tan adelantados están).
+ *   - Diversidad (cuántos cultivos distintos hay), con techo: más cultivos =
+ *     finca más viva, pero el aporte de diversidad se satura a ~6 para no
+ *     premiar infinitamente el conteo.
+ *
+ * Sin cultivos activos → 0 (finca por sembrar). Es un INDICADOR DE VISTAZO, no
+ * sustituye los indicadores MESMIS/Gliessman de fincaEvolutionService.
+ *
+ * @param {Array} lotes  lista de lotes ya derivados (de buildFincaScene)
+ * @returns {number} 0-100
+ */
+export function calcularVitalidad(lotes) {
+  const activos = Array.isArray(lotes) ? lotes.filter((l) => l.activo) : [];
+  if (activos.length === 0) return 0;
+
+  // 1) Avance promedio (peso por fase).
+  const sumaAvance = activos.reduce((acc, l) => acc + (FASE_PESO[l.fase] ?? 0.4), 0);
+  const avancePromedio = sumaAvance / activos.length; // 0..1
+
+  // 2) Diversidad (cultivos distintos), saturada a 6.
+  const distintos = new Set(activos.map((l) => l.subjectSlug || l.id)).size;
+  const diversidad = Math.min(distintos, 6) / 6; // 0..1
+
+  // Mezcla: el avance manda (70%), la diversidad complementa (30%).
+  const score = avancePromedio * 0.7 + diversidad * 0.3;
+  return Math.max(0, Math.min(100, Math.round(score * 100)));
+}
+
+/** Etiqueta cariñosa y honesta de la vitalidad para mostrar en el home. */
+export function etiquetaVitalidad(vitalidad) {
+  if (vitalidad <= 0) return 'Tu finca está por sembrar';
+  if (vitalidad < 25) return 'Tu finca está empezando';
+  if (vitalidad < 50) return 'Tu finca está creciendo';
+  if (vitalidad < 75) return 'Tu finca está viva y fuerte';
+  return 'Tu finca está floreciendo';
+}
+
+// ─── Construcción de la escena ──────────────────────────────────────────────
+
+/**
+ * @typedef {Object} SceneLote
+ * @property {string} id            id estable (process_id)
+ * @property {string} nombre        nombre del cultivo/animal para mostrar
+ * @property {string} subjectSlug   slug de especie (para diversidad)
+ * @property {boolean} activo       true si el proceso sigue activo
+ * @property {boolean} animal       true si es un proceso animal (corral)
+ * @property {string} emoji         emoji del animal (solo si animal)
+ * @property {string} sprite        id del sprite de planta a dibujar
+ * @property {number} growth        0..1 altura/madurez visual
+ * @property {string} fase          fase visual (seed/sprout/leaf/flower/fruit/harvest/rest)
+ * @property {string} etiquetaEtapa etiqueta corta de la etapa real
+ */
+
+/**
+ * @typedef {Object} FincaScene
+ * @property {boolean} vacia          true si no hay procesos → invitar a sembrar
+ * @property {SceneLote[]} lotes      cultivos (plantas) a dibujar en los lotes
+ * @property {SceneLote[]} animales   animales a dibujar en el corral
+ * @property {number} vitalidad       0-100, vistazo de salud de la finca
+ * @property {string} vitalidadLabel  etiqueta cariñosa de la vitalidad
+ * @property {number} totalCultivos   conteo de cultivos (activos + cerrados)
+ * @property {number} cultivosActivos conteo de cultivos activos
+ * @property {number} enCosecha       cuántos cultivos están listos/en cosecha
+ * @property {string[]} clima         elementos de clima a dibujar (sol, lluvia)
+ * @property {string} resumen         frase de vistazo para el campesino
+ */
+
+/**
+ * Construye la escena 2D de la finca desde los procesos reales.
+ *
+ * @param {Object} input
+ * @param {Array} [input.processes=[]]   FarmProcess[] (anidados o planos)
+ * @param {Object} [input.clima]         clima opcional { lluvia?:boolean, ensoPhase?:string }
+ * @param {number} [input.maxLotes=12]   tope de lotes a dibujar (rendimiento gama baja)
+ * @returns {FincaScene}
+ */
+export function buildFincaScene({ processes = [], clima = null, maxLotes = 12 } = {}) {
+  const flat = (Array.isArray(processes) ? processes : [])
+    .map(flatten)
+    .filter(Boolean);
+
+  // Separar plantas de animales. Cancelados no se dibujan (no son la finca viva).
+  const plantas = [];
+  const animales = [];
+  for (const p of flat) {
+    if (p.status === 'cancelled') continue;
+    const activo = p.status === 'active';
+    if (esProcesoAnimal(p.process_type)) {
+      animales.push({
+        id: p.process_id,
+        nombre: p.subject_label || 'Animales',
+        subjectSlug: p.subject_slug || p.process_type,
+        activo,
+        animal: true,
+        emoji: ANIMAL_EMOJI[p.process_type],
+        sprite: 'animal',
+        growth: 1,
+        fase: 'leaf',
+        etiquetaEtapa: spriteForStage(p.current_stage).etiqueta,
+      });
+      continue;
+    }
+    const s = spriteForStage(p.current_stage);
+    plantas.push({
+      id: p.process_id,
+      nombre: p.subject_label || 'Cultivo',
+      subjectSlug: p.subject_slug || p.process_id,
+      activo,
+      animal: false,
+      emoji: '',
+      sprite: s.sprite,
+      growth: s.growth,
+      fase: s.fase,
+      etiquetaEtapa: s.etiqueta,
+    });
+  }
+
+  const vacia = plantas.length === 0 && animales.length === 0;
+
+  // Ordenar para que los más maduros/cosecha queden adelante (más visibles).
+  plantas.sort((a, b) => (b.growth - a.growth) || a.id.localeCompare(b.id));
+
+  const lotesDibujados = plantas.slice(0, maxLotes);
+  const vitalidad = calcularVitalidad(plantas);
+  const cultivosActivos = plantas.filter((p) => p.activo).length;
+  const enCosecha = plantas.filter((p) => p.activo && (p.fase === 'harvest' || p.fase === 'fruit')).length;
+
+  return {
+    vacia,
+    lotes: lotesDibujados,
+    animales: animales.slice(0, 4),
+    vitalidad,
+    vitalidadLabel: etiquetaVitalidad(vitalidad),
+    totalCultivos: plantas.length,
+    cultivosActivos,
+    enCosecha,
+    clima: derivarClima(clima),
+    resumen: construirResumen({ vacia, cultivosActivos, enCosecha, animales }),
+  };
+}
+
+/**
+ * Deriva qué elementos de clima dibujar. Sin datos de clima → solo sol (estado
+ * por defecto cálido). Con lluvia → agregar nubes de lluvia. No fabrica clima:
+ * si no se le pasa, no inventa una tormenta.
+ *
+ * @param {Object|null} clima  { lluvia?:boolean, ensoPhase?:string }
+ * @returns {string[]}  ['sol'] | ['sol','lluvia'] | ...
+ */
+function derivarClima(clima) {
+  const out = ['sol'];
+  if (!clima || typeof clima !== 'object') return out;
+  if (clima.lluvia === true) out.push('lluvia');
+  // ENSO: 'la_nina' tiende a más lluvia; 'el_nino' a sequía/sol fuerte.
+  if (clima.ensoPhase === 'la_nina' && !out.includes('lluvia')) out.push('lluvia');
+  return out;
+}
+
+/**
+ * Frase de vistazo para el campesino: clara y útil, no infantil. La niña ve la
+ * escena; el adulto lee esta línea y sabe el estado de SU finca.
+ */
+function construirResumen({ vacia, cultivosActivos, enCosecha, animales }) {
+  if (vacia) return 'Tu finca está esperando tu primera siembra.';
+  const partes = [];
+  if (cultivosActivos === 1) partes.push('1 cultivo activo');
+  else if (cultivosActivos > 1) partes.push(`${cultivosActivos} cultivos activos`);
+  if (enCosecha === 1) partes.push('1 listo para cosechar');
+  else if (enCosecha > 1) partes.push(`${enCosecha} listos para cosechar`);
+  if (animales.length === 1) partes.push('1 grupo de animales');
+  else if (animales.length > 1) partes.push(`${animales.length} grupos de animales`);
+  if (partes.length === 0) return 'Tu finca está en marcha.';
+  return partes.join(' · ');
+}


### PR DESCRIPTION
## Feature
Llevar "Mi Finca Viva" al HOME: una escena 2D tipo granja Nintendo que dibuja la finca REAL del usuario y crece con su progreso. Antes el mundo vivo solo existía tras la ruta `juego`; ahora el estado real de la finca se ve al primer pantallazo.

## Qué hace
- Escena 2D bonita (SVG inline, flat/pixel art, offline-first): cada **cultivo se dibuja según su etapa fenológica real** (semilla → brote → hoja → flor → fruto → cosecha), con animales en su corral, agua, compostera y clima (sol/lluvia/ENSO si está disponible).
- **Refleja el progreso real**: la escena se llena según los `FarmProcess` reales (cuántos cultivos, en qué etapa). Sin datos → estado "por sembrar" acogedor que invita a empezar.
- **Vitalidad 0-100** honesta (avance promedio de los cultivos + diversidad) con etiqueta cariñosa, y un **resumen útil para el campesino** (cultivos activos · listos para cosechar · grupos de animales).
- Micro-animaciones suaves (sol que respira, nubes, plantas que brotan, animales que flotan) reusando `juego-finca.css`, respetando `prefers-reduced-motion`.
- Doble propósito: linda y motivadora para una niña de 11 años; vistazo claro y útil del estado real de SU finca para el campesino.
- Toca la escena → abre el juego completo `MiFincaVivaScreen` (ruta `juego`).

## Diseño / decisiones
- **Cero fabricación**: `fincaSceneService` es PURO y deriva todo de los procesos reales. Nada de progreso inventado.
- **Footprint mínimo en archivos compartidos**: una sola inserción gateada en `DashboardLive.jsx` (`plantsCount > 0`, para no competir con el `OnboardingHero` del primer uso). El resto es autocontenido y fácil de rebasear.
- Construido SOBRE lo existente (reusa `farmProcessCache`, el vocabulario de etapas de `types/farmProcess.js`, las animaciones de `juego-finca.css` y la ruta `juego`). No duplica el juego completo ni `fincaGameService`.
- Mobile-first y liviano para gama baja: SVG estático + CSS, sin red en runtime.
- Español de Colombia (tú/usted), sin voseo.

## Archivos clave
- `src/services/fincaSceneService.js` — lógica pura: mapeo etapa→sprite, vitalidad, plantas/animales, clima, resumen.
- `src/components/dashboard/MiFincaVivaHomeCard.jsx` — tarjeta + escena SVG 2D (un sprite por cultivo según su fase).
- `src/components/dashboard/DashboardLive.jsx` — inserción gateada (+13 líneas).

## Tests
- 22 vitest del servicio puro (mapeo etapa→sprite, cálculo de vitalidad, estado vacío, animales, orden por madurez, tope de lotes, clima).
- 4 vitest de la tarjeta (estado vacío acogedor, escena con datos reales, navegación al juego, resiliencia ante fallo de IndexedDB).
- `vite build` OK, `eslint --max-warnings=0` limpio en los archivos tocados.

## Cómo probarlo
```
npm run dev
```
En el home (`#dashboard`), con al menos una planta/proceso registrado, aparece la tarjeta **"Mi finca viva"** sobre "Seguimiento de procesos": una granjita 2D con tus cultivos dibujados según su etapa real, barra de vitalidad y resumen. Sin nada sembrado, muestra el estado "por sembrar" que invita a empezar. Toca la escena para abrir el juego completo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)