### PR TITLE
fix(asociaciones): contraste legible + tarjetas expandibles con detalle

### DIFF
--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -1,63 +1,108 @@
+import { useState } from 'react';
 import arquetipos from '../data/asociaciones-arquetipos.json';
 import { filterAsociacionesByRole } from '../services/asociacionesFilter';
 
 export default function Asociaciones({ profile = {}, esOperador = false }) {
   const visibles = filterAsociacionesByRole(arquetipos, profile, { esOperador });
+  const [abierta, setAbierta] = useState(null);
 
   return (
     <section className="space-y-4" aria-labelledby="asociaciones-title">
-      <div className="rounded-2xl border border-emerald-700/30 bg-emerald-950/30 p-4 sm:p-5">
-        <p className="text-xs font-bold uppercase tracking-wider text-emerald-300">
+      <div className="rounded-2xl border border-emerald-700 bg-emerald-800 p-4 sm:p-5 dark:border-emerald-700/40 dark:bg-emerald-950/40">
+        <p className="text-xs font-bold uppercase tracking-wider text-emerald-200">
           Capa de relación entre especies
         </p>
         <h2 id="asociaciones-title" className="mt-1 text-2xl sm:text-3xl font-black leading-tight text-white">
           Asociaciones / Policultivos
         </h2>
-        <p className="mt-2 text-base sm:text-lg leading-relaxed text-slate-200">
-          Mira combinaciones conocidas para sembrar especies que se acompañan. Cada tarjeta muestra el beneficio corto y la fuente.
+        <p className="mt-2 text-base sm:text-lg leading-relaxed text-emerald-50">
+          Toca cada tarjeta para ver por qué esas especies se acompañan.
         </p>
       </div>
 
       {visibles.length === 0 ? (
-        <div className="rounded-2xl border border-slate-700/60 bg-slate-900/70 p-5 text-base text-slate-200">
+        <div className="rounded-2xl border border-slate-300 bg-white p-5 text-base text-slate-700 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200">
           No hay asociaciones sugeridas para este perfil todavía.
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {visibles.map((item) => (
-            <article
-              key={item.id}
-              aria-label={item.nombre}
-              className="rounded-2xl border border-emerald-700/30 bg-gradient-to-br from-emerald-500/15 via-slate-900/85 to-lime-500/10 p-4 sm:p-5 shadow-lg shadow-black/20"
-            >
-              <div className="flex items-start gap-4">
-                <span
-                  aria-hidden="true"
-                  className="grid h-14 w-14 shrink-0 place-items-center rounded-2xl bg-emerald-400/15 text-4xl"
+          {visibles.map((item) => {
+            const expandida = abierta === item.id;
+            return (
+              <article
+                key={item.id}
+                aria-label={item.nombre}
+                className="overflow-hidden rounded-2xl border border-emerald-200 bg-white shadow-lg shadow-black/5 dark:border-emerald-700/40 dark:bg-slate-900 dark:shadow-black/20"
+              >
+                <button
+                  type="button"
+                  aria-expanded={expandida}
+                  onClick={() => setAbierta(expandida ? null : item.id)}
+                  className="block w-full cursor-pointer p-4 text-left transition-colors hover:bg-emerald-50 sm:p-5 dark:hover:bg-slate-800/60"
                 >
-                  {item.icono}
-                </span>
-                <div className="min-w-0 flex-1">
-                  <h3 className="text-xl font-black leading-tight text-white">{item.nombre}</h3>
-                  <p className="mt-1 text-base font-semibold leading-snug text-emerald-100">
-                    {item.especies.join(' + ')}
-                  </p>
-                </div>
-              </div>
+                  <div className="flex items-start gap-4">
+                    <span
+                      aria-hidden="true"
+                      className="grid h-14 w-14 shrink-0 place-items-center rounded-2xl bg-emerald-100 text-4xl dark:bg-emerald-400/15"
+                    >
+                      {item.icono}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-xl font-black leading-tight text-slate-900 dark:text-white">{item.nombre}</h3>
+                      <p className="mt-1 text-base font-bold leading-snug text-emerald-700 dark:text-emerald-300">
+                        {item.especies.join(' + ')}
+                      </p>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      className={`mt-1 shrink-0 text-lg text-emerald-600 transition-transform dark:text-emerald-300 ${expandida ? 'rotate-180' : ''}`}
+                    >
+                      ▾
+                    </span>
+                  </div>
 
-              <div className="mt-4 space-y-3 text-base leading-relaxed text-slate-100">
-                <p>{item.beneficio}</p>
-                <div className="flex flex-wrap gap-2 text-sm">
-                  <span className="rounded-lg bg-white/10 px-2.5 py-1 font-semibold text-slate-200">
-                    {item.rol.join(', ')}
-                  </span>
-                  <span className="rounded-lg bg-black/25 px-2.5 py-1 text-slate-300">
-                    Fuente: {item.fuente}
-                  </span>
-                </div>
-              </div>
-            </article>
-          ))}
+                  <p className="mt-3 text-base leading-relaxed text-slate-700 dark:text-slate-100">{item.beneficio}</p>
+
+                  <div className="mt-3 flex flex-wrap gap-2 text-sm">
+                    <span className="rounded-lg bg-slate-100 px-2.5 py-1 font-semibold text-slate-700 dark:bg-white/10 dark:text-slate-200">
+                      {item.rol.join(', ')}
+                    </span>
+                    <span className="rounded-lg bg-slate-100 px-2.5 py-1 text-slate-600 dark:bg-black/25 dark:text-slate-300">
+                      Fuente: {item.fuente}
+                    </span>
+                  </div>
+
+                  {!expandida && (
+                    <p className="mt-3 text-sm font-bold text-emerald-700 dark:text-emerald-300">Ver por qué funciona →</p>
+                  )}
+                </button>
+
+                {expandida && (
+                  <div className="border-t border-emerald-200 px-4 pb-4 pt-3 sm:px-5 dark:border-emerald-700/40">
+                    <p className="text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">Especies</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {item.especies.map((e) => (
+                        <span
+                          key={e}
+                          className="rounded-lg bg-emerald-100 px-2.5 py-1 text-sm font-semibold text-emerald-800 dark:bg-emerald-400/15 dark:text-emerald-100"
+                        >
+                          {e}
+                        </span>
+                      ))}
+                    </div>
+                    {item.detalle && (
+                      <>
+                        <p className="mt-3 text-xs font-bold uppercase tracking-wider text-emerald-700 dark:text-emerald-300">
+                          Por qué funciona
+                        </p>
+                        <p className="mt-1 text-base leading-relaxed text-slate-700 dark:text-slate-100">{item.detalle}</p>
+                      </>
+                    )}
+                  </div>
+                )}
+              </article>
+            );
+          })}
         </div>
       )}
     </section>

--- a/src/data/asociaciones-arquetipos.json
+++ b/src/data/asociaciones-arquetipos.json
@@ -1,47 +1,84 @@
 [
-  {
-    "id": "milpa",
-    "nombre": "Milpa (Tres Hermanas)",
-    "icono": "🌽",
-    "rol": ["campesino"],
-    "especies": ["maíz", "fríjol", "ahuyama"],
-    "beneficio": "LER 1.32, el fríjol fija nitrógeno",
-    "fuente": "DR-ASOCIACIONES-2026-06-18"
-  },
-  {
-    "id": "saf_cafe",
-    "nombre": "SAF café",
-    "icono": "☕",
-    "rol": ["campesino", "cafetero"],
-    "especies": ["café", "guamo (Inga)", "plátano"],
-    "beneficio": "sombra + carbono + amortigua broca",
-    "fuente": "DR-ASOCIACIONES-2026-06-18"
-  },
-  {
-    "id": "saf_cacao",
-    "nombre": "SAF cacao",
-    "icono": "🍫",
-    "rol": ["campesino", "cacaotero"],
-    "especies": ["cacao", "matarratón (Gliricidia)", "plátano"],
-    "beneficio": "fija N + sombra",
-    "fuente": "DR-ASOCIACIONES-2026-06-18"
-  },
-  {
-    "id": "frutal_cobertura",
-    "nombre": "Frutal con cobertura",
-    "icono": "🍊",
-    "rol": ["campesino", "restaurador"],
-    "especies": ["frutal", "maní forrajero (Arachis pintoi)"],
-    "beneficio": "cobertura que fija N y tapa maleza",
-    "fuente": "DR-ASOCIACIONES-2026-06-18"
-  },
-  {
-    "id": "hortaliza_repelente",
-    "nombre": "Cebolla + zanahoria",
-    "icono": "🥕",
-    "rol": ["campesino", "urbano"],
-    "especies": ["cebolla", "zanahoria"],
-    "beneficio": "se protegen de sus moscas mutuamente",
-    "fuente": "DR-ASOCIACIONES-2026-06-18"
-  }
+	{
+		"id": "milpa",
+		"nombre": "Milpa (Tres Hermanas)",
+		"icono": "🌽",
+		"rol": [
+			"campesino"
+		],
+		"especies": [
+			"maíz",
+			"fríjol",
+			"ahuyama"
+		],
+		"beneficio": "LER 1.32, el fríjol fija nitrógeno",
+		"fuente": "DR-ASOCIACIONES-2026-06-18",
+		"detalle": "El maíz da soporte al fríjol para que trepe; el fríjol fija nitrógeno que nutre al maíz; la ahuyama cubre el suelo, conserva humedad y frena la maleza. Juntas rinden más que por separado (LER 1.32)."
+	},
+	{
+		"id": "saf_cafe",
+		"nombre": "SAF café",
+		"icono": "☕",
+		"rol": [
+			"campesino",
+			"cafetero"
+		],
+		"especies": [
+			"café",
+			"guamo (Inga)",
+			"plátano"
+		],
+		"beneficio": "sombra + carbono + amortigua broca",
+		"fuente": "DR-ASOCIACIONES-2026-06-18",
+		"detalle": "El guamo (Inga) da sombra y aporta materia orgánica y nitrógeno; el plátano da sombra temporal e ingreso temprano. La sombra modera el calor y ayuda a amortiguar la broca del café."
+	},
+	{
+		"id": "saf_cacao",
+		"nombre": "SAF cacao",
+		"icono": "🍫",
+		"rol": [
+			"campesino",
+			"cacaotero"
+		],
+		"especies": [
+			"cacao",
+			"matarratón (Gliricidia)",
+			"plátano"
+		],
+		"beneficio": "fija N + sombra",
+		"fuente": "DR-ASOCIACIONES-2026-06-18",
+		"detalle": "El matarratón (Gliricidia) fija nitrógeno y da sombra; el plátano protege al cacao joven y genera ingreso mientras crece. Sombra más nitrógeno = cacao más sano."
+	},
+	{
+		"id": "frutal_cobertura",
+		"nombre": "Frutal con cobertura",
+		"icono": "🍊",
+		"rol": [
+			"campesino",
+			"restaurador"
+		],
+		"especies": [
+			"frutal",
+			"maní forrajero (Arachis pintoi)"
+		],
+		"beneficio": "cobertura que fija N y tapa maleza",
+		"fuente": "DR-ASOCIACIONES-2026-06-18",
+		"detalle": "El maní forrajero (Arachis pintoi) tapiza el suelo bajo el frutal: fija nitrógeno, conserva humedad, controla la maleza y reduce la erosión."
+	},
+	{
+		"id": "hortaliza_repelente",
+		"nombre": "Cebolla + zanahoria",
+		"icono": "🥕",
+		"rol": [
+			"campesino",
+			"urbano"
+		],
+		"especies": [
+			"cebolla",
+			"zanahoria"
+		],
+		"beneficio": "se protegen de sus moscas mutuamente",
+		"fuente": "DR-ASOCIACIONES-2026-06-18",
+		"detalle": "El olor de la cebolla repele la mosca de la zanahoria, y la zanahoria repele la mosca de la cebolla. Sembradas juntas se protegen mutuamente sin químicos."
+	}
 ]


### PR DESCRIPTION
## Bugs reportados (operador, screenshot en vivo)
1. **Contraste**: la línea de especies de cada tarjeta era ilegible (clases de tema oscuro `text-emerald-100` que no compilaban sobre el fondo claro que ships). → reescrito **light-first** (`text-emerald-700`, `bg-white`, `text-slate-900`) + variantes `dark:` para ambos temas.
2. **Tarjetas muertas**: 'ese botón no hace ni muestra nada'. → cada tarjeta es ahora un **botón expandible**: al tocar revela las especies como chips + un **'por qué funciona'** curado y agronómicamente correcto por asociación. rol/fuente siguen visibles en colapsado.

Tests 10/10 verdes, eslint --max-warnings=0 limpio. Fallas de CI esperadas = infra (Playwright Docker + deploy-dev rsync), no del código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)