### PR TITLE
fix(home): Visión total del operador muestra TODOS los módulos

### DIFF
--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -153,7 +153,11 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
         // preferencia manual, derivamos la visibilidad por perfil con
         // homeModuleSelector (reusa deriveRole de profileChipSelector).
         try {
-            if (hasManualModuleVisibility()) {
+            // El override "Visión total" del operador GANA sobre prefs manuales:
+            // si está activo, mostramos TODO (esOperador=true). Sin esto, un
+            // operador que antes ocultó módulos a mano activaba el toggle y NO
+            // veía nada (bug demo 2026-06-19).
+            if (hasManualModuleVisibility() && !esOperadorActual()) {
                 // El usuario eligió a mano: respetar su configuración tal cual.
                 return getModuleVisibility();
             }
@@ -239,7 +243,8 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
     useEffect(() => {
         const handler = () => {
             try {
-                if (hasManualModuleVisibility()) return;
+                // El override del operador GANA sobre prefs manuales (ver arriba).
+                if (hasManualModuleVisibility() && !esOperadorActual()) return;
                 setModuleVisibility(
                     selectHomeModuleVisibilityMap(getProfile(), {
                         esOperador: esOperadorActual(),


### PR DESCRIPTION
**Bug demo (operador furioso):** activaba 'Mostrar todas las capacidades' y NO salía ningún botón. Causa: el inicializador de moduleVisibility y el handler de `chagra:profile-changed` hacían `if (hasManualModuleVisibility()) return` → las prefs manuales del operador (que había ocultado módulos antes) GANABAN sobre el override → no se mostraba nada. Fix: el override del operador (`esOperadorActual()`) gana sobre prefs manuales. Al desactivar, vuelven las prefs.

(Nota menor: 'fermentos' no está en HOME_MODULE_DEFAULT_ORDER → follow-up.) Fallas CI = infra.