### PR TITLE
feat(juego): nivel 2 de "Defensores de la Finca" — la ladera al atardecer

### DIFF
--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -7,10 +7,17 @@
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ScreenShell } from '../common/ScreenShell';
-import { Bug, Shield, RotateCcw } from 'lucide-react';
+import { Bug, Shield, RotateCcw, Lock } from 'lucide-react';
 import './defensores-finca.css';
 
-import { CULTIVOS, PARES_CONTROL, NIVEL_1 } from './defensoresFincaData';
+import {
+  CULTIVOS,
+  PARES_CONTROL,
+  NIVELES,
+  getNivel,
+  nivelDesbloqueado,
+  PROGRESO_KEY,
+} from './defensoresFincaData';
 import {
   MOVE_SPEED,
   clamp,
@@ -18,43 +25,65 @@ import {
   resolverColisionPlagas,
   recolectarCultivos,
   sumarPuntaje,
-  avanzarFisica,
+  avanzarFisicaTerreno,
+  golpearJefe,
   intentarSalto,
   evaluarFinNivel,
 } from '../../services/defensoresGameEngine';
 import { agentSounds, isSoundEnabled } from '../../services/agentSoundService';
 
+// Dimensiones lógicas del LIENZO visible (la cámara recorta el mundo a esto).
+const VIEW_W = 720;
+const VIEW_H = 405;
+const GROUND_Y = 340;
+const PLAYER_W = 38;
+const PLAYER_H = 54;
+
+/** Lee del localStorage los niveles ya superados (offline-safe, tolera fallos). */
+function leerSuperados() {
+  try {
+    const raw = localStorage.getItem(PROGRESO_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed?.superados) ? parsed.superados : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Marca un nivel como superado en localStorage y devuelve la lista resultante. */
+function guardarSuperado(numero) {
+  try {
+    const superados = leerSuperados();
+    if (!superados.includes(numero)) {
+      const next = [...superados, numero];
+      localStorage.setItem(PROGRESO_KEY, JSON.stringify({ superados: next }));
+      return next;
+    }
+    return superados;
+  } catch {
+    return leerSuperados();
+  }
+}
+
 /**
- * DefensoresFincaScreen — minijuego PLATAFORMERO 2D lateral.
- *
- * Un campesino NEUTRO (sin nombre propio) corre y salta por la finca: recoge
- * cultivos (puntos), esquiva plagas reales (pierde energía al tocarlas) e invoca
- * organismos benéficos que ELIMINAN exactamente la plaga que de verdad controlan
- * (control biológico real = relación CONTROLS del grafo de Chagra).
- *
- * Mobile-first: controles táctiles grandes + teclado en desktop. Offline-safe:
- * canvas 2D puro, datos locales, cero red. Estética Chagra (emerald/amber/lime).
- * La lógica vive en defensoresGameEngine (pura, testeable); aquí solo se dibuja
- * y se orquesta el loop.
+ * NivelJuego — un nivel jugable completo (canvas + HUD + controles). Se monta
+ * con `key={nivel.numero}` desde el contenedor, de modo que CADA cambio de
+ * nivel lo remonta limpio (sin setState dentro de efectos).
  *
  * @param {Object} props
- * @param {Function} [props.onBack]
- * @param {Function} [props.onHome]
+ * @param {import('./defensoresFincaData').Nivel} props.nivel
+ * @param {number[]} props.superados   niveles ya completados (desbloqueo).
+ * @param {Function} props.onGanar     callback(numero) al completar el nivel.
+ * @param {Function} props.onIrA       callback(numero) para saltar a otro nivel.
  */
-export default function DefensoresFincaScreen({ onBack, onHome }) {
+function NivelJuego({ nivel, superados, onGanar, onIrA }) {
   const canvasRef = useRef(null);
-
-  // Mundo en coordenadas de canvas (lógicas, escaladas al ancho real por CSS).
-  const W = 720;
-  const H = 405;
-  const GROUND_Y = 340;
-  const PLAYER_W = 38;
-  const PLAYER_H = 54;
 
   // Pares de control activos en este nivel (subconjunto curado).
   const pares = useMemo(
-    () => PARES_CONTROL.filter((p) => NIVEL_1.paresIds.includes(p.id)),
-    [],
+    () => PARES_CONTROL.filter((p) => nivel.paresIds.includes(p.id)),
+    [nivel],
   );
   const beneficos = useMemo(() => pares.map((p) => p.benefico), [pares]);
   const leccionPorBenefico = useMemo(
@@ -62,51 +91,87 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
     [pares],
   );
 
-  // Estado de juego visible en React (HUD). El estado "vivo" del loop vive en
-  // refs para no re-renderizar a 60fps.
-  const [energia, setEnergia] = useState(NIVEL_1.energiaInicial);
+  // Estado visible en React (HUD). El estado "vivo" del loop vive en refs.
+  const [energia, setEnergia] = useState(nivel.energiaInicial);
   const [puntaje, setPuntaje] = useState(0);
   const [estado, setEstado] = useState('jugando'); // 'jugando' | 'gano' | 'perdio'
   const [razon, setRazon] = useState('');
   const [leccion, setLeccion] = useState('');
   const [beneficoSel, setBeneficoSel] = useState(beneficos[0]?.id || null);
+  const [jefeVida, setJefeVida] = useState(nivel.jefe ? nivel.jefe.vida : 0);
 
   // Refs del mundo (mutables, leídos por el loop a 60fps sin re-render).
   const world = useRef(null);
   const input = useRef({ left: false, right: false, jumpQueued: false });
-  // Espejo del benéfico seleccionado para que la acción (puntero) lo lea sin
-  // recrear el callback; se sincroniza en un efecto (no durante el render).
   const beneficoSelRef = useRef(beneficoSel);
   useEffect(() => {
     beneficoSelRef.current = beneficoSel;
   }, [beneficoSel]);
 
-  /** Crea el mundo inicial: jugador, plagas espaciadas y cultivos. */
+  /** Crea el mundo inicial del nivel: jugador, plagas, cultivos, plataformas,
+   *  huecos y mini-jefe. */
   const crearMundo = useCallback(() => {
-    const plagas = pares.map((par, i) => ({
-      id: `plaga-${par.plaga.id}-${i}`,
-      plagaId: par.plaga.id,
-      emoji: par.plaga.emoji,
-      x: 220 + i * 150,
-      y: GROUND_Y - 34,
-      w: 34,
-      h: 34,
-      dir: i % 2 === 0 ? 1 : -1,
-      baseX: 220 + i * 150,
-      alive: true,
+    const mundoAncho = nivel.mundoAncho;
+    const sep = (mundoAncho - 260) / Math.max(1, pares.length);
+    const plagas = pares.map((par, i) => {
+      const baseX = 220 + i * sep;
+      return {
+        id: `plaga-${par.plaga.id}-${i}`,
+        plagaId: par.plaga.id,
+        emoji: par.plaga.emoji,
+        x: baseX,
+        y: GROUND_Y - 34,
+        w: 34,
+        h: 34,
+        dir: i % 2 === 0 ? 1 : -1,
+        baseX,
+        rango: 46 + (i % 3) * 18, // patrulla más amplia en algunas (dificultad)
+        vel: 0.9 + (i % 3) * 0.25,
+        alive: true,
+      };
+    });
+
+    const plats = nivel.plataformas.map((p) => ({
+      x: p.x,
+      y: GROUND_Y - p.y, // top absoluto de la plataforma en coords mundo
+      w: p.w,
+      h: 14,
     }));
-    const cultivos = Array.from({ length: NIVEL_1.metaCultivos }).map((_, i) => {
+    const cultivos = Array.from({ length: nivel.metaCultivos }).map((_, i) => {
       const c = CULTIVOS[i % CULTIVOS.length];
+      const enPlat = plats.length > 0 && i % 3 === 0;
+      const plat = enPlat ? plats[i % plats.length] : null;
+      const x = plat
+        ? plat.x + plat.w / 2 - 15
+        : 150 + (i * (mundoAncho - 220)) / nivel.metaCultivos;
+      const y = plat ? plat.y - 34 : (i % 2 === 0 ? GROUND_Y - 36 : GROUND_Y - 110);
       return {
         id: `cultivo-${c.id}-${i}`,
         emoji: c.emoji,
-        x: 150 + i * 110,
-        y: i % 2 === 0 ? GROUND_Y - 36 : GROUND_Y - 110,
+        x,
+        y,
         w: 30,
         h: 30,
         recogido: false,
       };
     });
+
+    const jefe = nivel.jefe
+      ? {
+          plagaId: nivel.jefe.plagaId,
+          emoji: nivel.jefe.emoji,
+          vida: nivel.jefe.vida,
+          vidaMax: nivel.jefe.vida,
+          vivo: true,
+          x: mundoAncho - 130,
+          y: GROUND_Y - 70,
+          w: 64,
+          h: 64,
+          dir: -1,
+          baseX: mundoAncho - 130,
+        }
+      : null;
+
     return {
       player: {
         x: 40,
@@ -120,15 +185,20 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
       },
       plagas,
       cultivos,
+      plataformas: plats,
+      huecos: nivel.huecos.map((h) => ({ x: h.x, w: h.w })),
+      jefe,
+      mundoAncho,
+      camX: 0,
       cultivosRecogidos: 0,
       puntaje: 0,
-      energia: NIVEL_1.energiaInicial,
+      energia: nivel.energiaInicial,
       t: 0,
     };
-  }, [pares]);
+  }, [nivel, pares]);
 
-  // Inicializa el mundo al montar (una vez). El reinicio se hace en el handler
-  // `reiniciar` (evento), no en un efecto, para no disparar renders en cascada.
+  // Inicializa el mundo al montar (una vez por nivel; el remount con key reinicia
+  // todo el estado React, así no hace falta setState en este efecto).
   useEffect(() => {
     if (!world.current) world.current = crearMundo();
   }, [crearMundo]);
@@ -165,7 +235,8 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
     } catch { /* sonido opcional: el juego sigue */ }
   }, []);
 
-  /** Invoca el benéfico seleccionado: limpia SOLO su plaga objetivo real. */
+  /** Invoca el benéfico seleccionado: limpia SOLO su plaga objetivo real y, si
+   *  es el controlador del jefe, le quita vida. */
   const invocarBenefico = useCallback(() => {
     const w = world.current;
     if (!w || estado !== 'jugando') return;
@@ -173,13 +244,21 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
     if (!id) return;
     const { plagas, eliminadas } = aplicarBenefico(w.plagas, id);
     w.plagas = plagas;
-    if (eliminadas > 0) {
-      w.puntaje = sumarPuntaje(w.puntaje, { plagas: eliminadas });
+
+    let golpeoJefe = false;
+    if (w.jefe && w.jefe.vivo) {
+      const res = golpearJefe(w.jefe, id);
+      w.jefe = res.jefe;
+      golpeoJefe = res.golpeo;
+      if (res.golpeo) setJefeVida(w.jefe.vida);
+    }
+
+    if (eliminadas > 0 || golpeoJefe) {
+      w.puntaje = sumarPuntaje(w.puntaje, { plagas: eliminadas + (golpeoJefe ? 1 : 0) });
       setPuntaje(w.puntaje);
       setLeccion(leccionPorBenefico[id] || '');
       beep('good');
     } else {
-      // Benéfico correcto pero su plaga no está aquí (o ya controlada): pista.
       setLeccion('Ese benéfico controla otra plaga. Mira cuál bicho malo hay cerca.');
     }
   }, [estado, leccionPorBenefico, beep]);
@@ -192,6 +271,7 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
     if (!ctx) return undefined;
     let raf = 0;
     let running = true;
+    const esc = nivel.escena;
 
     const drawEmoji = (emoji, x, y, size) => {
       ctx.font = `${size}px serif`;
@@ -213,9 +293,9 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
         w.player.x += MOVE_SPEED;
         w.player.face = 1;
       }
-      w.player.x = clamp(w.player.x, 0, W - w.player.w);
+      w.player.x = clamp(w.player.x, 0, w.mundoAncho - w.player.w);
 
-      // Salto + gravedad (física pura).
+      // Salto + gravedad sobre terreno con plataformas/huecos.
       if (input.current.jumpQueued) {
         const j = intentarSalto(w.player);
         w.player.vy = j.vy;
@@ -223,17 +303,37 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
         if (j.salto) beep('jump');
         input.current.jumpQueued = false;
       }
-      const fis = avanzarFisica(w.player, GROUND_Y, w.player.h);
+      const fis = avanzarFisicaTerreno(w.player, GROUND_Y, w.plataformas, w.huecos, VIEW_H + 80);
       w.player.y = fis.y;
       w.player.vy = fis.vy;
       w.player.onGround = fis.onGround;
 
-      // Plagas patrullan de lado a lado (movimiento simple, predecible).
+      // Caer por un hueco = daño + reposición sobre suelo firme.
+      if (estado === 'jugando' && fis.caido && w.t >= w.player.invulnUntil) {
+        w.energia -= 1;
+        w.player.invulnUntil = w.t + 60;
+        setEnergia(w.energia);
+        beep('hit');
+        w.player.x = clamp(w.player.x - 90, 0, w.mundoAncho - w.player.w);
+        w.player.y = GROUND_Y - w.player.h;
+        w.player.vy = 0;
+        w.player.onGround = true;
+      }
+
+      // Cámara: sigue al jugador (centro), recortada al mundo.
+      const objetivoCam = w.player.x + w.player.w / 2 - VIEW_W / 2;
+      w.camX = clamp(objetivoCam, 0, Math.max(0, w.mundoAncho - VIEW_W));
+
+      // Plagas patrullan (más rápido/amplio = más difícil).
       if (estado === 'jugando') {
         for (const p of w.plagas) {
           if (!p.alive) continue;
-          p.x += p.dir * 0.9;
-          if (Math.abs(p.x - p.baseX) > 46) p.dir *= -1;
+          p.x += p.dir * p.vel;
+          if (Math.abs(p.x - p.baseX) > p.rango) p.dir *= -1;
+        }
+        if (w.jefe && w.jefe.vivo) {
+          w.jefe.x += w.jefe.dir * 0.7;
+          if (Math.abs(w.jefe.x - w.jefe.baseX) > 70) w.jefe.dir *= -1;
         }
       }
 
@@ -247,11 +347,23 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
         beep('good');
       }
 
-      // Colisión con plagas (resta energía con invulnerabilidad breve).
+      // Colisión con plagas y con el jefe (resta energía).
       if (estado === 'jugando') {
         const invuln = w.t < w.player.invulnUntil;
         const col = resolverColisionPlagas(w.player, w.plagas, invuln);
-        if (col.golpe) {
+        let golpe = col.golpe;
+        if (!golpe && !invuln && w.jefe && w.jefe.vivo) {
+          const j = w.jefe;
+          if (
+            w.player.x < j.x + j.w &&
+            w.player.x + w.player.w > j.x &&
+            w.player.y < j.y + j.h &&
+            w.player.y + w.player.h > j.y
+          ) {
+            golpe = true;
+          }
+        }
+        if (golpe) {
           w.energia -= 1;
           w.player.invulnUntil = w.t + 60; // ~1s a 60fps
           setEnergia(w.energia);
@@ -261,48 +373,92 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
 
       // Fin de nivel.
       const plagasVivas = w.plagas.filter((p) => p.alive).length;
+      const hayJefe = !!w.jefe;
+      const jefeVivo = !!(w.jefe && w.jefe.vivo);
       const fin = evaluarFinNivel({
         energia: w.energia,
         cultivosRecogidos: w.cultivosRecogidos,
-        metaCultivos: NIVEL_1.metaCultivos,
+        metaCultivos: nivel.metaCultivos,
         plagasVivas,
+        hayJefe,
+        jefeVivo,
       });
       if (fin.estado !== 'jugando' && estado === 'jugando') {
         setEstado(fin.estado);
         setRazon(fin.razon);
-        if (fin.estado === 'gano') beep('good');
+        if (fin.estado === 'gano') {
+          beep('good');
+          onGanar(nivel.numero);
+        }
       }
 
       // ── DIBUJO ──────────────────────────────────────────────────
-      // Cielo.
-      const sky = ctx.createLinearGradient(0, 0, 0, H);
-      sky.addColorStop(0, '#9fd6f2');
-      sky.addColorStop(1, '#e8f7c8');
+      ctx.save();
+      ctx.translate(-w.camX, 0); // la cámara desplaza el mundo.
+      const M = w.mundoAncho;
+
+      // Cielo (paleta del nivel).
+      const sky = ctx.createLinearGradient(0, 0, 0, VIEW_H);
+      sky.addColorStop(0, esc.cieloTop);
+      sky.addColorStop(1, esc.cieloBottom);
       ctx.fillStyle = sky;
-      ctx.fillRect(0, 0, W, H);
-      // Sol.
-      ctx.fillStyle = '#fde68a';
+      ctx.fillRect(0, 0, M, VIEW_H);
+
+      // Estrellas tenues (atardecer).
+      if (esc.estrellas) {
+        ctx.fillStyle = 'rgba(255,255,255,0.55)';
+        for (let i = 0; i < 40; i += 1) {
+          ctx.fillRect((i * 137) % M, (i * 53) % 120, 2, 2);
+        }
+      }
+
+      // Astro (sol/luna), anclado a la vista.
+      ctx.fillStyle = esc.astro;
       ctx.beginPath();
-      ctx.arc(W - 70, 70, 34, 0, Math.PI * 2);
+      ctx.arc(w.camX + VIEW_W - 70, 70, 34, 0, Math.PI * 2);
       ctx.fill();
-      // Montañas.
-      ctx.fillStyle = '#86b96a';
+
+      // Montañas de fondo (repetidas a lo largo del mundo).
+      ctx.fillStyle = esc.montana;
       ctx.beginPath();
       ctx.moveTo(0, GROUND_Y);
-      ctx.lineTo(160, 180);
-      ctx.lineTo(330, GROUND_Y);
-      ctx.lineTo(520, 150);
-      ctx.lineTo(720, GROUND_Y);
+      for (let mx = 0; mx <= M; mx += 360) {
+        ctx.lineTo(mx + 160, 180);
+        ctx.lineTo(mx + 330, GROUND_Y);
+      }
+      ctx.lineTo(M, GROUND_Y);
       ctx.closePath();
       ctx.fill();
-      // Suelo.
-      const soil = ctx.createLinearGradient(0, GROUND_Y, 0, H);
-      soil.addColorStop(0, '#8a5a32');
-      soil.addColorStop(1, '#3f2d20');
-      ctx.fillStyle = soil;
-      ctx.fillRect(0, GROUND_Y, W, H - GROUND_Y);
-      ctx.fillStyle = '#6f8f32';
-      ctx.fillRect(0, GROUND_Y - 6, W, 10);
+
+      // Suelo por tramos (deja vacíos en los huecos).
+      const soil = ctx.createLinearGradient(0, GROUND_Y, 0, VIEW_H);
+      soil.addColorStop(0, esc.sueloTop);
+      soil.addColorStop(1, esc.sueloBottom);
+      const huecos = [...w.huecos].sort((a, b) => a.x - b.x);
+      let cursor = 0;
+      for (const h of huecos) {
+        if (h.x > cursor) {
+          ctx.fillStyle = soil;
+          ctx.fillRect(cursor, GROUND_Y, h.x - cursor, VIEW_H - GROUND_Y);
+          ctx.fillStyle = esc.pasto;
+          ctx.fillRect(cursor, GROUND_Y - 6, h.x - cursor, 10);
+        }
+        cursor = h.x + h.w;
+      }
+      if (cursor < M) {
+        ctx.fillStyle = soil;
+        ctx.fillRect(cursor, GROUND_Y, M - cursor, VIEW_H - GROUND_Y);
+        ctx.fillStyle = esc.pasto;
+        ctx.fillRect(cursor, GROUND_Y - 6, M - cursor, 10);
+      }
+
+      // Plataformas.
+      for (const p of w.plataformas) {
+        ctx.fillStyle = esc.sueloTop;
+        ctx.fillRect(p.x, p.y, p.w, p.h);
+        ctx.fillStyle = esc.pasto;
+        ctx.fillRect(p.x, p.y - 4, p.w, 6);
+      }
 
       // Cultivos (puntos).
       for (const c of w.cultivos) {
@@ -312,31 +468,37 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
       for (const p of w.plagas) {
         if (p.alive) drawEmoji(p.emoji, p.x, p.y, 32);
       }
+      // Mini-jefe + barra de vida.
+      if (w.jefe && w.jefe.vivo) {
+        drawEmoji(w.jefe.emoji, w.jefe.x, w.jefe.y, 60);
+        const bw = w.jefe.w;
+        ctx.fillStyle = 'rgba(0,0,0,0.4)';
+        ctx.fillRect(w.jefe.x, w.jefe.y - 12, bw, 7);
+        ctx.fillStyle = '#ef4444';
+        ctx.fillRect(w.jefe.x, w.jefe.y - 12, (bw * w.jefe.vida) / w.jefe.vidaMax, 7);
+      }
+
       // Jugador (campesino neutro dibujado a mano — sin nombre propio).
       const px = w.player.x;
       const py = w.player.y;
       const blink = w.t < w.player.invulnUntil && Math.floor(w.t / 6) % 2 === 0;
       if (!blink) {
-        // sombrero
         ctx.fillStyle = '#a16207';
         ctx.fillRect(px - 4, py, w.player.w + 8, 8);
         ctx.fillRect(px + 6, py - 8, w.player.w - 12, 10);
-        // cara
         ctx.fillStyle = '#e8b98a';
         ctx.fillRect(px + 8, py + 8, w.player.w - 16, 16);
-        // cuerpo (camisa verde Chagra)
         ctx.fillStyle = '#15803d';
         ctx.fillRect(px + 6, py + 24, w.player.w - 12, 20);
-        // pantalón
         ctx.fillStyle = '#1e3a5f';
         ctx.fillRect(px + 8, py + 42, w.player.w - 16, 12);
-        // ojos (mirando hacia donde va)
         ctx.fillStyle = '#1c1917';
         const ex = w.player.face === 1 ? px + 16 : px + 12;
         ctx.fillRect(ex, py + 14, 3, 3);
         ctx.fillRect(ex + 8, py + 14, 3, 3);
       }
 
+      ctx.restore();
       raf = requestAnimationFrame(step);
     };
 
@@ -345,20 +507,207 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
       running = false;
       cancelAnimationFrame(raf);
     };
-  }, [estado, beep]);
+  }, [estado, beep, nivel, onGanar]);
 
-  // Reinicia el nivel: reconstruye el mundo (ref) y restaura el HUD (estado).
-  // Es un event handler, así que el setState es seguro (no es render ni efecto).
+  // Reinicia el nivel actual (event handler → setState seguro).
   const reiniciar = useCallback(() => {
     world.current = crearMundo();
-    setEnergia(NIVEL_1.energiaInicial);
+    setEnergia(nivel.energiaInicial);
     setPuntaje(0);
     setRazon('');
     setLeccion('');
     setEstado('jugando');
-  }, [crearMundo]);
+    setJefeVida(nivel.jefe ? nivel.jefe.vida : 0);
+  }, [crearMundo, nivel]);
 
-  const energiaMax = NIVEL_1.energiaMax;
+  const energiaMax = nivel.energiaMax;
+  const hayJefe = !!nivel.jefe;
+  const siguienteAbierto = nivelDesbloqueado(nivel.numero + 1, superados);
+
+  return (
+    <>
+      <p className="text-2xs text-emerald-200/70 leading-snug" data-testid="defensores-subtitulo">
+        {nivel.subtitulo}
+      </p>
+
+      {/* HUD */}
+      <div className="df-hud" data-testid="defensores-hud">
+        <div className="df-hearts" aria-label={`Energía: ${energia} de ${energiaMax}`}>
+          {Array.from({ length: energiaMax }).map((_, i) => (
+            <span key={i} className={i < energia ? '' : 'df-heart-empty'} aria-hidden="true">
+              💚
+            </span>
+          ))}
+        </div>
+        <div className="text-right">
+          <span className="text-2xs font-black uppercase tracking-wide text-emerald-300/70 block">
+            Puntos
+          </span>
+          <span data-testid="defensores-puntaje" className="text-2xl font-black text-white leading-none">
+            {puntaje}
+          </span>
+        </div>
+      </div>
+
+      {/* Aviso de mini-jefe (solo niveles con jefe). */}
+      {hayJefe && estado === 'jugando' && (
+        <div className="df-jefe-aviso" data-testid="defensores-jefe">
+          <span aria-hidden="true">{nivel.jefe.emoji}</span> Mini-jefe al final.
+          Solo cae con su controlador real. Vida: {jefeVida}
+        </div>
+      )}
+
+      {/* Escenario (canvas) */}
+      <div className="df-stage">
+        <canvas
+          ref={canvasRef}
+          width={VIEW_W}
+          height={VIEW_H}
+          className="df-canvas"
+          role="img"
+          aria-label="Finca con un campesino que corre, cultivos para recoger y plagas para controlar"
+        />
+        {estado !== 'jugando' && (
+          <div className="df-overlay" data-testid={`defensores-fin-${estado}`}>
+            <span className="df-overlay-emoji" aria-hidden="true">
+              {estado === 'gano' ? '🌽🎉' : '🐛'}
+            </span>
+            <h3 className="text-2xl font-black text-white">
+              {estado === 'gano' ? '¡Ganaste!' : 'Casi lo logras'}
+            </h3>
+            <p className="text-sm text-emerald-100/90 max-w-xs">{razon}</p>
+            <div className="flex flex-wrap gap-2 justify-center mt-2">
+              <button
+                type="button"
+                onClick={reiniciar}
+                className="min-h-[56px] px-5 rounded-2xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-black text-lg flex items-center gap-2"
+              >
+                <RotateCcw size={22} aria-hidden="true" />
+                Jugar otra vez
+              </button>
+              {estado === 'gano' && siguienteAbierto && (
+                <button
+                  type="button"
+                  data-testid="defensores-siguiente-nivel"
+                  onClick={() => onIrA(nivel.numero + 1)}
+                  className="min-h-[56px] px-5 rounded-2xl bg-amber-400 hover:bg-amber-300 active:scale-95 transition text-amber-950 font-black text-lg"
+                >
+                  Nivel {nivel.numero + 1} →
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Lección de control biológico */}
+      {leccion && (
+        <div className="df-leccion" data-testid="defensores-leccion" role="status">
+          <Bug size={16} className="inline-block mr-1 -mt-0.5" aria-hidden="true" />
+          {leccion}
+        </div>
+      )}
+
+      {/* Selector de benéficos (control biológico) */}
+      <div className="df-beneficios" role="group" aria-label="Elige el organismo benéfico">
+        {beneficos.map((b) => (
+          <button
+            key={b.id}
+            type="button"
+            data-testid={`beneficio-${b.id}`}
+            data-selected={beneficoSel === b.id}
+            onClick={() => setBeneficoSel(b.id)}
+            aria-pressed={beneficoSel === b.id}
+            className="df-beneficio"
+          >
+            <span className="df-beneficio-emoji" aria-hidden="true">{b.emoji}</span>
+            <span className="df-beneficio-nombre">{b.nombre}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Controles táctiles (mobile-first) + teclado en desktop */}
+      <div className="df-controls">
+        <div className="df-dpad">
+          <button
+            type="button"
+            aria-label="Mover a la izquierda"
+            className="df-btn"
+            onPointerDown={(e) => { e.preventDefault(); input.current.left = true; }}
+            onPointerUp={() => { input.current.left = false; }}
+            onPointerLeave={() => { input.current.left = false; }}
+            onPointerCancel={() => { input.current.left = false; }}
+          >
+            ◀
+          </button>
+          <button
+            type="button"
+            aria-label="Mover a la derecha"
+            className="df-btn"
+            onPointerDown={(e) => { e.preventDefault(); input.current.right = true; }}
+            onPointerUp={() => { input.current.right = false; }}
+            onPointerLeave={() => { input.current.right = false; }}
+            onPointerCancel={() => { input.current.right = false; }}
+          >
+            ▶
+          </button>
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            aria-label="Soltar el bicho bueno"
+            className="df-btn df-btn-action"
+            onPointerDown={(e) => { e.preventDefault(); invocarBenefico(); }}
+          >
+            🐞
+          </button>
+          <button
+            type="button"
+            aria-label="Saltar"
+            className="df-btn df-btn-jump"
+            onPointerDown={(e) => { e.preventDefault(); input.current.jumpQueued = true; }}
+          >
+            ⤴
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/**
+ * DefensoresFincaScreen — minijuego PLATAFORMERO 2D lateral con dos niveles.
+ *
+ * Un campesino NEUTRO (sin nombre propio) corre y salta por la finca: recoge
+ * cultivos (puntos), esquiva plagas reales (pierde energía al tocarlas) e invoca
+ * organismos benéficos que ELIMINAN exactamente la plaga que de verdad controlan
+ * (control biológico real = relación CONTROLS del grafo de Chagra).
+ *
+ * Nivel 1 (la huerta, mediodía): corto y plano, 4 pares.
+ * Nivel 2 (la ladera al atardecer): más largo (mundo con cámara), otra paleta,
+ * 7 pares, plataformas a distinta altura, huecos que hacen daño y un mini-jefe
+ * (langosta) que solo cae con su controlador real (la mantis). Se desbloquea al
+ * completar el nivel 1; el progreso se guarda offline en localStorage.
+ *
+ * Mobile-first: controles táctiles grandes + teclado en desktop. Offline-safe:
+ * canvas 2D puro, datos locales, cero red. Estética Chagra.
+ *
+ * @param {Object} props
+ * @param {Function} [props.onBack]
+ * @param {Function} [props.onHome]
+ */
+export default function DefensoresFincaScreen({ onBack, onHome }) {
+  const [superados, setSuperados] = useState(() => leerSuperados());
+  const [nivelNum, setNivelNum] = useState(1);
+  const nivel = useMemo(() => getNivel(nivelNum), [nivelNum]);
+
+  const handleGanar = useCallback((numero) => {
+    setSuperados(guardarSuperado(numero));
+  }, []);
+
+  const irANivel = useCallback((numero) => {
+    setNivelNum(numero);
+  }, []);
 
   return (
     <ScreenShell title="Defensores de la Finca" icon={Shield} onBack={onBack} onHome={onHome}>
@@ -378,127 +727,51 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
           biológico!
         </p>
 
-        {/* HUD */}
-        <div className="df-hud" data-testid="defensores-hud">
-          <div className="df-hearts" aria-label={`Energía: ${energia} de ${energiaMax}`}>
-            {Array.from({ length: energiaMax }).map((_, i) => (
-              <span key={i} className={i < energia ? '' : 'df-heart-empty'} aria-hidden="true">
-                💚
-              </span>
-            ))}
-          </div>
-          <div className="text-right">
-            <span className="text-2xs font-black uppercase tracking-wide text-emerald-300/70 block">
-              Puntos
-            </span>
-            <span data-testid="defensores-puntaje" className="text-2xl font-black text-white leading-none">
-              {puntaje}
-            </span>
-          </div>
-        </div>
-
-        {/* Escenario (canvas) */}
-        <div className="df-stage">
-          <canvas
-            ref={canvasRef}
-            width={W}
-            height={H}
-            className="df-canvas"
-            role="img"
-            aria-label="Finca con un campesino que corre, cultivos para recoger y plagas para controlar"
-          />
-          {estado !== 'jugando' && (
-            <div className="df-overlay" data-testid={`defensores-fin-${estado}`}>
-              <span className="df-overlay-emoji" aria-hidden="true">
-                {estado === 'gano' ? '🌽🎉' : '🐛'}
-              </span>
-              <h3 className="text-2xl font-black text-white">
-                {estado === 'gano' ? '¡Ganaste!' : 'Casi lo logras'}
-              </h3>
-              <p className="text-sm text-emerald-100/90 max-w-xs">{razon}</p>
+        {/* Selector de nivel (1 / 2). El 2 se desbloquea al ganar el 1. */}
+        <div
+          className="df-niveles"
+          role="group"
+          aria-label="Elige el nivel"
+          data-testid="defensores-niveles"
+        >
+          {NIVELES.map((n) => {
+            const abierto = nivelDesbloqueado(n.numero, superados);
+            const activo = n.numero === nivelNum;
+            return (
               <button
+                key={n.id}
                 type="button"
-                onClick={reiniciar}
-                className="mt-2 min-h-[56px] px-6 rounded-2xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-black text-lg flex items-center gap-2"
+                data-testid={`nivel-${n.numero}`}
+                data-selected={activo}
+                disabled={!abierto}
+                aria-pressed={activo}
+                onClick={() => abierto && setNivelNum(n.numero)}
+                className="df-nivel"
               >
-                <RotateCcw size={22} aria-hidden="true" />
-                Jugar otra vez
+                <span className="df-nivel-num">
+                  {abierto ? `Nivel ${n.numero}` : (
+                    <>
+                      <Lock size={13} aria-hidden="true" className="inline-block -mt-0.5 mr-1" />
+                      Nivel {n.numero}
+                    </>
+                  )}
+                </span>
+                <span className="df-nivel-nombre">
+                  {abierto ? n.nombre : 'Gana el nivel anterior'}
+                </span>
               </button>
-            </div>
-          )}
+            );
+          })}
         </div>
 
-        {/* Lección de control biológico */}
-        {leccion && (
-          <div className="df-leccion" data-testid="defensores-leccion" role="status">
-            <Bug size={16} className="inline-block mr-1 -mt-0.5" aria-hidden="true" />
-            {leccion}
-          </div>
-        )}
-
-        {/* Selector de benéficos (control biológico) */}
-        <div className="df-beneficios" role="group" aria-label="Elige el organismo benéfico">
-          {beneficos.map((b) => (
-            <button
-              key={b.id}
-              type="button"
-              data-testid={`beneficio-${b.id}`}
-              data-selected={beneficoSel === b.id}
-              onClick={() => setBeneficoSel(b.id)}
-              aria-pressed={beneficoSel === b.id}
-              className="df-beneficio"
-            >
-              <span className="df-beneficio-emoji" aria-hidden="true">{b.emoji}</span>
-              <span className="df-beneficio-nombre">{b.nombre}</span>
-            </button>
-          ))}
-        </div>
-
-        {/* Controles táctiles (mobile-first) + teclado en desktop */}
-        <div className="df-controls">
-          <div className="df-dpad">
-            <button
-              type="button"
-              aria-label="Mover a la izquierda"
-              className="df-btn"
-              onPointerDown={(e) => { e.preventDefault(); input.current.left = true; }}
-              onPointerUp={() => { input.current.left = false; }}
-              onPointerLeave={() => { input.current.left = false; }}
-              onPointerCancel={() => { input.current.left = false; }}
-            >
-              ◀
-            </button>
-            <button
-              type="button"
-              aria-label="Mover a la derecha"
-              className="df-btn"
-              onPointerDown={(e) => { e.preventDefault(); input.current.right = true; }}
-              onPointerUp={() => { input.current.right = false; }}
-              onPointerLeave={() => { input.current.right = false; }}
-              onPointerCancel={() => { input.current.right = false; }}
-            >
-              ▶
-            </button>
-          </div>
-          <div className="flex gap-3">
-            <button
-              type="button"
-              aria-label="Soltar el bicho bueno"
-              className="df-btn df-btn-action"
-              onPointerDown={(e) => { e.preventDefault(); invocarBenefico(); }}
-            >
-              🐞
-            </button>
-            <button
-              type="button"
-              aria-label="Saltar"
-              className="df-btn df-btn-jump"
-              onPointerDown={(e) => { e.preventDefault(); input.current.jumpQueued = true; }}
-            >
-              ⤴
-            </button>
-          </div>
-        </div>
+        {/* El nivel se remonta con key → estado limpio sin setState en efecto. */}
+        <NivelJuego
+          key={nivel.numero}
+          nivel={nivel}
+          superados={superados}
+          onGanar={handleGanar}
+          onIrA={irANivel}
+        />
 
         <p className="text-2xs text-slate-400 text-center mt-2 leading-relaxed">
           En el computador: flechas ◀ ▶ para correr, ↑ o espacio para saltar.

--- a/src/components/juego/__tests__/DefensoresFincaScreen.test.jsx
+++ b/src/components/juego/__tests__/DefensoresFincaScreen.test.jsx
@@ -1,13 +1,20 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DefensoresFincaScreen from '../DefensoresFincaScreen';
-import { PARES_CONTROL, NIVEL_1 } from '../defensoresFincaData';
+import { PARES_CONTROL, NIVEL_1, NIVEL_2, PROGRESO_KEY } from '../defensoresFincaData';
 
 // jsdom no implementa canvas 2D: getContext devuelve null. El componente
 // guarda contra ctx null, así que el render no crashea y podemos probar el HUD,
 // los controles y la lógica de control biológico (que vive en refs).
 
 describe('DefensoresFincaScreen', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('renderiza el juego con HUD, controles táctiles y selector de benéficos', () => {
     render(<DefensoresFincaScreen />);
 
@@ -56,5 +63,39 @@ describe('DefensoresFincaScreen', () => {
     expect(leccion.textContent).toContain(par.leccion);
 
     raf.mockRestore();
+  });
+
+  it('muestra el selector con ambos niveles; el 2 arranca bloqueado', () => {
+    render(<DefensoresFincaScreen />);
+    expect(screen.getByTestId('defensores-niveles')).toBeInTheDocument();
+    const nivel1 = screen.getByTestId('nivel-1');
+    const nivel2 = screen.getByTestId('nivel-2');
+    expect(nivel1).not.toBeDisabled();
+    expect(nivel1).toHaveAttribute('data-selected', 'true');
+    // Sin progreso guardado, el nivel 2 está bloqueado.
+    expect(nivel2).toBeDisabled();
+    expect(nivel2.textContent).toContain('Gana el nivel anterior');
+  });
+
+  it('si el nivel 1 ya fue superado, el 2 queda desbloqueado y seleccionable', () => {
+    localStorage.setItem(PROGRESO_KEY, JSON.stringify({ superados: [1] }));
+    render(<DefensoresFincaScreen />);
+
+    const nivel2 = screen.getByTestId('nivel-2');
+    expect(nivel2).not.toBeDisabled();
+    expect(nivel2.textContent).toContain(NIVEL_2.nombre);
+
+    // Al elegir el nivel 2 cambian subtítulo y el set de benéficos del nivel.
+    fireEvent.click(nivel2);
+    expect(nivel2).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByTestId('defensores-subtitulo').textContent).toContain(
+      NIVEL_2.subtitulo,
+    );
+    // El nivel 2 incluye pares que NO están en el nivel 1 (más elementos).
+    const extra = NIVEL_2.paresIds.find((id) => !NIVEL_1.paresIds.includes(id));
+    const parExtra = PARES_CONTROL.find((p) => p.id === extra);
+    expect(screen.getByTestId(`beneficio-${parExtra.benefico.id}`)).toBeInTheDocument();
+    // El aviso de mini-jefe del nivel 2 está presente.
+    expect(screen.getByTestId('defensores-jefe')).toBeInTheDocument();
   });
 });

--- a/src/components/juego/defensores-finca.css
+++ b/src/components/juego/defensores-finca.css
@@ -27,6 +27,69 @@
   image-rendering: -webkit-optimize-contrast;
 }
 
+/* ── Selector de nivel (1 / 2) ───────────────────────────────────────── */
+
+.df-niveles {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.25rem;
+}
+
+.df-nivel {
+  flex: 1 1 0;
+  min-height: 58px;
+  border-radius: 0.9rem;
+  border: 2px solid rgba(16, 185, 129, 0.35);
+  background: rgba(6, 78, 59, 0.42);
+  color: #ecfdf5;
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.1rem;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: transform 0.08s ease, border-color 0.12s ease, background 0.12s ease;
+}
+.df-nivel:active:not(:disabled) {
+  transform: scale(0.97);
+}
+.df-nivel[data-selected='true'] {
+  border-color: #34d399;
+  background: rgba(16, 185, 129, 0.32);
+}
+.df-nivel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  border-style: dashed;
+}
+.df-nivel-num {
+  font-size: 0.95rem;
+  font-weight: 900;
+  line-height: 1.1;
+}
+.df-nivel-nombre {
+  font-size: 0.68rem;
+  font-weight: 700;
+  opacity: 0.85;
+  line-height: 1.15;
+  text-align: left;
+}
+
+/* ── Aviso de mini-jefe ──────────────────────────────────────────────── */
+
+.df-jefe-aviso {
+  margin-top: 0.4rem;
+  border-radius: 0.8rem;
+  border: 2px solid rgba(248, 113, 113, 0.45);
+  background: rgba(127, 29, 29, 0.32);
+  color: #fecaca;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
 /* ── HUD (energía + puntaje) ─────────────────────────────────────────── */
 
 .df-hud {

--- a/src/components/juego/defensoresFincaData.js
+++ b/src/components/juego/defensoresFincaData.js
@@ -188,14 +188,142 @@ export const BENEFICO_CONTROLA = Object.freeze(
   }, {}),
 );
 
-/** Configuración base del nivel 1 (un nivel jugable y completable). */
+/**
+ * Configuración de un nivel jugable.
+ *
+ * @typedef {Object} Nivel
+ * @property {string} id
+ * @property {number} numero            Orden del nivel (1, 2, ...).
+ * @property {string} nombre
+ * @property {string} subtitulo         Una línea de contexto para el jugador.
+ * @property {number} energiaInicial
+ * @property {number} energiaMax
+ * @property {number} metaCultivos      Cuántos cultivos hay que recoger.
+ * @property {number} mundoAncho        Ancho del mundo en px lógicos (cámara).
+ * @property {string[]} paresIds        Pares de control que aparecen (curados).
+ * @property {Object} escena            Paleta/escena de fondo (control del dibujo).
+ * @property {string} escena.id
+ * @property {string} escena.cieloTop
+ * @property {string} escena.cieloBottom
+ * @property {string} escena.montana
+ * @property {string} escena.sueloTop
+ * @property {string} escena.sueloBottom
+ * @property {string} escena.pasto
+ * @property {string} escena.astro      Color del sol/luna.
+ * @property {boolean} [escena.estrellas]
+ * @property {Array<{x:number,y:number,w:number}>} plataformas Plataformas extra.
+ * @property {Array<{x:number,w:number}>} [huecos]            Vacíos del suelo (caer = daño).
+ * @property {?Object} jefe             Mini-jefe del nivel (o null).
+ * @property {string} jefe.plagaId      Plaga del jefe (debe existir en PARES_CONTROL).
+ * @property {string} jefe.emoji
+ * @property {number} jefe.vida         Golpes de benéfico correcto para vencerlo.
+ */
+
+/** Nivel 1 — la huerta a mediodía. Corto, plano, 4 pares. */
 export const NIVEL_1 = Object.freeze({
   id: 'nivel-1',
+  numero: 1,
   nombre: 'La huerta',
+  subtitulo: 'Mediodía en la huerta. Recoge y cuida con bichos buenos.',
   energiaInicial: 3,
   energiaMax: 3,
-  /** Cuántos cultivos hay que recoger para completar el nivel. */
   metaCultivos: 6,
-  /** Pares de control que aparecen en este nivel (subconjunto curado). */
+  mundoAncho: 720,
   paresIds: ['pulgon-catarina', 'moscablanca-crisopa', 'cogollero-trichogramma', 'afido-sirfido'],
+  escena: Object.freeze({
+    id: 'mediodia',
+    cieloTop: '#9fd6f2',
+    cieloBottom: '#e8f7c8',
+    montana: '#86b96a',
+    sueloTop: '#8a5a32',
+    sueloBottom: '#3f2d20',
+    pasto: '#6f8f32',
+    astro: '#fde68a',
+  }),
+  plataformas: [],
+  huecos: [],
+  jefe: null,
 });
+
+/**
+ * Nivel 2 — atardecer en la finca de ladera (otro piso térmico).
+ * Más largo (mundo con cámara que sigue al jugador), más pares (7), más
+ * plataformas a distinto nivel, huecos que hacen daño al caer, más cultivos y
+ * un mini-jefe final (langosta) que solo cae con su controlador real (la
+ * mantis). Dificultad progresiva: más plagas y terreno con altura.
+ */
+export const NIVEL_2 = Object.freeze({
+  id: 'nivel-2',
+  numero: 2,
+  nombre: 'La ladera al atardecer',
+  subtitulo: 'Cae la tarde en la ladera. El terreno sube y hay más bichos.',
+  energiaInicial: 4,
+  energiaMax: 4,
+  metaCultivos: 10,
+  mundoAncho: 1680,
+  paresIds: [
+    'pulgon-catarina',
+    'moscablanca-crisopa',
+    'cogollero-trichogramma',
+    'afido-sirfido',
+    'trips-amblyseius',
+    'acaro-phytoseiulus',
+    'saltamontes-mantis',
+  ],
+  escena: Object.freeze({
+    id: 'atardecer',
+    cieloTop: '#f5a05b',
+    cieloBottom: '#fcd9a0',
+    montana: '#6b4a7a',
+    sueloTop: '#6e4326',
+    sueloBottom: '#2a1a12',
+    pasto: '#557a2c',
+    astro: '#fff1c2',
+    estrellas: true,
+  }),
+  // Plataformas a distinta altura (x en coords del mundo; y = offset SOBRE el
+  // suelo, en px; el motor las ancla a groundY). Forman un camino que sube.
+  plataformas: Object.freeze([
+    Object.freeze({ x: 360, y: 86, w: 120 }),
+    Object.freeze({ x: 560, y: 150, w: 120 }),
+    Object.freeze({ x: 820, y: 96, w: 140 }),
+    Object.freeze({ x: 1080, y: 150, w: 120 }),
+    Object.freeze({ x: 1300, y: 92, w: 140 }),
+  ]),
+  // Huecos en el suelo: si el jugador cae dentro, recibe daño (obstáculo).
+  huecos: Object.freeze([
+    Object.freeze({ x: 700, w: 70 }),
+    Object.freeze({ x: 1220, w: 70 }),
+  ]),
+  // Mini-jefe: una langosta grande al final. Solo la mantis (su controlador
+  // real) la derriba; necesita varios golpes (vida).
+  jefe: Object.freeze({
+    plagaId: 'saltamontes',
+    emoji: '🦗',
+    vida: 3,
+  }),
+});
+
+/** Todos los niveles en orden de juego. */
+export const NIVELES = Object.freeze([NIVEL_1, NIVEL_2]);
+
+/** Busca un nivel por su número (1-indexado). Devuelve NIVEL_1 si no existe. */
+export function getNivel(numero) {
+  return NIVELES.find((n) => n.numero === numero) || NIVEL_1;
+}
+
+/** Clave de localStorage donde se guarda el progreso (niveles superados). */
+export const PROGRESO_KEY = 'chagra:defensores-finca:progreso';
+
+/**
+ * ¿Está desbloqueado el nivel `numero`? El 1 siempre; los demás solo si el
+ * nivel anterior está en la lista de superados (lógica pura, sin localStorage).
+ *
+ * @param {number} numero          número del nivel a consultar.
+ * @param {number[]} superados     números de nivel ya completados.
+ * @returns {boolean}
+ */
+export function nivelDesbloqueado(numero, superados = []) {
+  if (numero <= 1) return true;
+  return superados.includes(numero - 1);
+}

--- a/src/components/juego/index.js
+++ b/src/components/juego/index.js
@@ -4,4 +4,12 @@ export { default as MiFincaVivaScreen } from './MiFincaVivaScreen';
 export { default as MonoVsPoliSimulator } from './MonoVsPoliSimulator';
 export { default as MilpaSimulator } from './MilpaSimulator';
 export { default as DefensoresFincaScreen } from './DefensoresFincaScreen';
-export { PARES_CONTROL, CULTIVOS } from './defensoresFincaData';
+export {
+  PARES_CONTROL,
+  CULTIVOS,
+  NIVEL_1,
+  NIVEL_2,
+  NIVELES,
+  getNivel,
+  nivelDesbloqueado,
+} from './defensoresFincaData';

--- a/src/services/__tests__/defensoresGameEngine.test.js
+++ b/src/services/__tests__/defensoresGameEngine.test.js
@@ -7,6 +7,9 @@ import {
   recolectarCultivos,
   sumarPuntaje,
   avanzarFisica,
+  avanzarFisicaTerreno,
+  sobreHueco,
+  golpearJefe,
   intentarSalto,
   evaluarFinNivel,
   clamp,
@@ -15,7 +18,14 @@ import {
   GRAVITY,
   JUMP_VELOCITY,
 } from '../defensoresGameEngine';
-import { PARES_CONTROL } from '../../components/juego/defensoresFincaData';
+import {
+  PARES_CONTROL,
+  NIVEL_1,
+  NIVEL_2,
+  NIVELES,
+  getNivel,
+  nivelDesbloqueado,
+} from '../../components/juego/defensoresFincaData';
 
 describe('defensoresGameEngine — utilidades', () => {
   it('clamp limita al rango', () => {
@@ -172,5 +182,156 @@ describe('fin de nivel', () => {
     expect(
       evaluarFinNivel({ energia: 2, cultivosRecogidos: 3, metaCultivos: 6, plagasVivas: 0 }).estado,
     ).toBe('jugando');
+  });
+
+  it('con mini-jefe NO gana hasta derrotarlo, aunque cumpla lo demás', () => {
+    const conJefeVivo = evaluarFinNivel({
+      energia: 3,
+      cultivosRecogidos: 10,
+      metaCultivos: 10,
+      plagasVivas: 0,
+      hayJefe: true,
+      jefeVivo: true,
+    });
+    expect(conJefeVivo.estado).toBe('jugando');
+
+    const jefeDerrotado = evaluarFinNivel({
+      energia: 3,
+      cultivosRecogidos: 10,
+      metaCultivos: 10,
+      plagasVivas: 0,
+      hayJefe: true,
+      jefeVivo: false,
+    });
+    expect(jefeDerrotado.estado).toBe('gano');
+  });
+});
+
+describe('nivel 2 — terreno con plataformas y huecos', () => {
+  it('sobreHueco detecta cuando el centro del jugador cae en un vacío', () => {
+    const huecos = [{ x: 100, w: 50 }];
+    expect(sobreHueco(120, huecos)).toBe(true);
+    expect(sobreHueco(99, huecos)).toBe(false);
+    expect(sobreHueco(160, huecos)).toBe(false);
+    expect(sobreHueco(120, [])).toBe(false);
+  });
+
+  it('avanzarFisicaTerreno aterriza en el suelo cuando NO hay hueco debajo', () => {
+    const groundY = 340;
+    const estado = { x: 20, y: 330, w: 38, h: 54, vy: 20 };
+    const res = avanzarFisicaTerreno(estado, groundY, [], [], 485);
+    expect(res.onGround).toBe(true);
+    expect(res.y).toBe(groundY - 54);
+    expect(res.vy).toBe(0);
+    expect(res.caido).toBe(false);
+  });
+
+  it('avanzarFisicaTerreno deja caer al jugador por un hueco (sin suelo)', () => {
+    const groundY = 340;
+    // Jugador justo sobre un hueco: su centro x cae dentro del vacío.
+    const estado = { x: 690, y: 330, w: 38, h: 54, vy: 20 };
+    const huecos = [{ x: 680, w: 80 }];
+    const res = avanzarFisicaTerreno(estado, groundY, [], huecos, 485);
+    expect(res.onGround).toBe(false);
+    expect(res.y).toBeGreaterThan(330); // siguió cayendo, no se ancló al suelo
+  });
+
+  it('avanzarFisicaTerreno marca caido al pasar el fondo del mundo', () => {
+    const estado = { x: 690, y: 460, w: 38, h: 54, vy: 20 };
+    const huecos = [{ x: 680, w: 80 }];
+    const res = avanzarFisicaTerreno(estado, 340, [], huecos, 485);
+    expect(res.caido).toBe(true);
+  });
+
+  it('avanzarFisicaTerreno aterriza encima de una plataforma al caer sobre ella', () => {
+    const groundY = 340;
+    // Plataforma con top en y=200. El jugador cae y sus pies la cruzan.
+    const plataformas = [{ x: 100, y: 200, w: 120 }];
+    const estado = { x: 120, y: 140, w: 38, h: 54, vy: 12 }; // pies antes=194, ahora≈206
+    const res = avanzarFisicaTerreno(estado, groundY, plataformas, [], 485);
+    expect(res.onGround).toBe(true);
+    expect(res.y).toBe(200 - 54);
+    expect(res.vy).toBe(0);
+  });
+
+  it('avanzarFisicaTerreno NO aterriza en plataforma si va subiendo', () => {
+    const plataformas = [{ x: 100, y: 200, w: 120 }];
+    const estado = { x: 120, y: 210, w: 38, h: 54, vy: -10 };
+    const res = avanzarFisicaTerreno(estado, 340, plataformas, [], 485);
+    expect(res.onGround).toBe(false);
+  });
+});
+
+describe('mini-jefe — solo cae con su controlador real', () => {
+  const jefeBase = { plagaId: 'saltamontes', vida: 3, vivo: true };
+
+  it('el controlador correcto (mantis → saltamontes) le quita vida', () => {
+    const res = golpearJefe(jefeBase, 'mantis');
+    expect(res.golpeo).toBe(true);
+    expect(res.jefe.vida).toBe(2);
+    expect(res.jefe.vivo).toBe(true);
+    expect(res.derrotado).toBe(false);
+  });
+
+  it('un benéfico equivocado NO le hace nada al jefe', () => {
+    const res = golpearJefe(jefeBase, 'catarina'); // controla pulgón, no saltamontes
+    expect(res.golpeo).toBe(false);
+    expect(res.jefe.vida).toBe(3);
+  });
+
+  it('al agotar la vida el jefe queda derrotado', () => {
+    let jefe = { plagaId: 'saltamontes', vida: 1, vivo: true };
+    const res = golpearJefe(jefe, 'mantis');
+    expect(res.derrotado).toBe(true);
+    expect(res.jefe.vivo).toBe(false);
+    expect(res.jefe.vida).toBe(0);
+    // Un golpe a un jefe ya muerto no hace nada.
+    jefe = res.jefe;
+    expect(golpearJefe(jefe, 'mantis').golpeo).toBe(false);
+  });
+});
+
+describe('niveles — configuración y desbloqueo', () => {
+  it('hay dos niveles y el 2 es más largo y exigente que el 1', () => {
+    expect(NIVELES).toHaveLength(2);
+    expect(NIVEL_2.numero).toBe(2);
+    expect(NIVEL_2.mundoAncho).toBeGreaterThan(NIVEL_1.mundoAncho);
+    expect(NIVEL_2.metaCultivos).toBeGreaterThan(NIVEL_1.metaCultivos);
+    expect(NIVEL_2.paresIds.length).toBeGreaterThan(NIVEL_1.paresIds.length);
+    expect(NIVEL_2.plataformas.length).toBeGreaterThan(0);
+    expect(NIVEL_2.huecos.length).toBeGreaterThan(0);
+    expect(NIVEL_2.jefe).toBeTruthy();
+  });
+
+  it('el nivel 2 usa una paleta de fondo distinta a la del 1', () => {
+    expect(NIVEL_2.escena.id).not.toBe(NIVEL_1.escena.id);
+    expect(NIVEL_2.escena.cieloTop).not.toBe(NIVEL_1.escena.cieloTop);
+  });
+
+  it('todos los pares de cada nivel existen en el dataset curado', () => {
+    const ids = new Set(PARES_CONTROL.map((p) => p.id));
+    for (const nivel of NIVELES) {
+      for (const pid of nivel.paresIds) {
+        expect(ids.has(pid)).toBe(true);
+      }
+    }
+  });
+
+  it('el mini-jefe del nivel 2 referencia una plaga real con controlador', () => {
+    const par = PARES_CONTROL.find((p) => p.plaga.id === NIVEL_2.jefe.plagaId);
+    expect(par).toBeTruthy();
+    // El controlador real de esa plaga derriba al jefe.
+    expect(beneficoControlaPlaga(par.benefico.id, NIVEL_2.jefe.plagaId)).toBe(true);
+  });
+
+  it('getNivel devuelve el nivel pedido y cae al 1 si no existe', () => {
+    expect(getNivel(2)).toBe(NIVEL_2);
+    expect(getNivel(99)).toBe(NIVEL_1);
+  });
+
+  it('nivelDesbloqueado: el 1 siempre; el 2 solo tras superar el 1', () => {
+    expect(nivelDesbloqueado(1, [])).toBe(true);
+    expect(nivelDesbloqueado(2, [])).toBe(false);
+    expect(nivelDesbloqueado(2, [1])).toBe(true);
   });
 });

--- a/src/services/defensoresGameEngine.js
+++ b/src/services/defensoresGameEngine.js
@@ -147,6 +147,100 @@ export function avanzarFisica(estado, groundY, altura) {
 }
 
 /**
+ * ¿La posición x del jugador (centro) cae dentro de un hueco del suelo?
+ * Si está sobre un hueco, el "piso" deja de existir ahí. Útil para que el motor
+ * decida si el jugador puede caer (nivel 2: huecos = obstáculo).
+ *
+ * @param {number} centroX  x del centro del jugador en coords del MUNDO.
+ * @param {Array<{x:number,w:number}>} huecos  tramos vacíos del suelo.
+ * @returns {boolean}
+ */
+export function sobreHueco(centroX, huecos) {
+  if (!huecos || huecos.length === 0) return false;
+  return huecos.some((h) => centroX >= h.x && centroX <= h.x + h.w);
+}
+
+/**
+ * Física vertical sobre terreno con plataformas y huecos (nivel 2).
+ *
+ * El jugador aterriza en el suelo (groundY) salvo que esté sobre un hueco; y
+ * puede aterrizar ENCIMA de una plataforma SOLO si viene cayendo (vy > 0) y sus
+ * pies cruzan la superficie superior de la plataforma. Una vez bajo el suelo
+ * (cayó por un hueco), `caido` es true y la UI aplica el daño.
+ *
+ * @param {{x:number,y:number,w:number,h:number,vy:number}} estado
+ * @param {number} groundY
+ * @param {Array<{x:number,y:number,w:number}>} plataformas  y = top absoluto en coords mundo.
+ * @param {Array<{x:number,w:number}>} huecos
+ * @param {number} mundoAlto  alto total del mundo (umbral de caída fatal).
+ * @returns {{ x:number,y:number,vy:number,onGround:boolean,caido:boolean }}
+ */
+export function avanzarFisicaTerreno(estado, groundY, plataformas, huecos, mundoAlto) {
+  const { x, w, h } = estado;
+  let { y, vy } = estado;
+  const yAntes = y;
+  vy += GRAVITY;
+  y += vy;
+  let onGround = false;
+  let caido = false;
+
+  // 1) Plataformas: solo se aterriza encima si venía cayendo y cruza el top.
+  if (vy > 0 && plataformas && plataformas.length > 0) {
+    const piesAntes = yAntes + h;
+    const piesAhora = y + h;
+    for (const p of plataformas) {
+      const solapaX = x + w > p.x && x < p.x + p.w;
+      const cruzaTop = piesAntes <= p.y && piesAhora >= p.y;
+      if (solapaX && cruzaTop) {
+        y = p.y - h;
+        vy = 0;
+        onGround = true;
+        return { x, y, vy, onGround, caido: false };
+      }
+    }
+  }
+
+  // 2) Suelo, salvo que el centro del jugador esté sobre un hueco.
+  const centroX = x + w / 2;
+  const enHueco = sobreHueco(centroX, huecos);
+  const pisoY = groundY - h;
+  if (!enHueco && y >= pisoY) {
+    y = pisoY;
+    vy = 0;
+    onGround = true;
+  }
+
+  // 3) Caída fatal por el hueco: pasó el fondo del mundo.
+  if (y + h >= mundoAlto) {
+    caido = true;
+  }
+
+  return { x, y, vy, onGround, caido };
+}
+
+/**
+ * Aplica un golpe de benéfico al mini-jefe. Solo el controlador REAL del jefe
+ * le quita vida (control biológico: la mantis derriba la langosta, nadie más).
+ *
+ * @param {?{plagaId:string, vida:number, vivo:boolean}} jefe
+ * @param {string} beneficoId
+ * @returns {{ jefe: Object|null, golpeo: boolean, derrotado: boolean }}
+ */
+export function golpearJefe(jefe, beneficoId) {
+  if (!jefe || !jefe.vivo) return { jefe, golpeo: false, derrotado: false };
+  if (!beneficoControlaPlaga(beneficoId, jefe.plagaId)) {
+    return { jefe, golpeo: false, derrotado: false };
+  }
+  const vida = Math.max(0, jefe.vida - 1);
+  const vivo = vida > 0;
+  return {
+    jefe: { ...jefe, vida, vivo },
+    golpeo: true,
+    derrotado: !vivo,
+  };
+}
+
+/**
  * Aplica un salto si el jugador está en el suelo (no doble salto).
  * @param {{ vy:number, onGround:boolean }} estado
  * @returns {{ vy:number, onGround:boolean, salto:boolean }}
@@ -160,18 +254,34 @@ export function intentarSalto(estado) {
 
 /**
  * Evalúa el estado de fin de nivel.
+ *
+ * Gana al recoger la meta de cultivos Y controlar todas las plagas Y, si el
+ * nivel tiene mini-jefe, derrotarlo. Pierde si la energía llega a 0.
+ *
  * @param {Object} params
  * @param {number} params.energia       energía restante (<=0 = pierde).
  * @param {number} params.cultivosRecogidos
  * @param {number} params.metaCultivos  cuántos hace falta recoger.
  * @param {number} params.plagasVivas   plagas que siguen sin controlar.
+ * @param {boolean} [params.hayJefe=false]    si el nivel tiene mini-jefe.
+ * @param {boolean} [params.jefeVivo=false]   si el mini-jefe sigue vivo.
  * @returns {{ estado: 'jugando'|'gano'|'perdio', razon: string }}
  */
-export function evaluarFinNivel({ energia, cultivosRecogidos, metaCultivos, plagasVivas }) {
+export function evaluarFinNivel({
+  energia,
+  cultivosRecogidos,
+  metaCultivos,
+  plagasVivas,
+  hayJefe = false,
+  jefeVivo = false,
+}) {
   if (energia <= 0) {
     return { estado: 'perdio', razon: 'Te quedaste sin energía. ¡Inténtalo otra vez!' };
   }
-  if (cultivosRecogidos >= metaCultivos && plagasVivas === 0) {
+  const cultivosListos = cultivosRecogidos >= metaCultivos;
+  const plagasLimpias = plagasVivas === 0;
+  const jefeListo = !hayJefe || !jefeVivo;
+  if (cultivosListos && plagasLimpias && jefeListo) {
     return { estado: 'gano', razon: '¡Cosechaste la finca y la cuidaste con control biológico!' };
   }
   return { estado: 'jugando', razon: '' };


### PR DESCRIPTION
## Feature
Segundo nivel para el plataformero "Defensores de la Finca" (PR #1697). El operador aprobó el nivel 1 y pidió un nivel 2 más largo, con otro fondo, más elementos, dificultad progresiva y meta clara, manteniendo el gancho real de control biológico.

## Cambios
- **`defensoresFincaData.js`**: nuevo `NIVEL_2` ("La ladera al atardecer") + array `NIVELES`, helpers `getNivel` y `nivelDesbloqueado`, y `PROGRESO_KEY`. Cada nivel define su escena (paleta), pares activos, plataformas, huecos y mini-jefe.
- **`defensoresGameEngine.js`**: funciones puras nuevas y testeables — `avanzarFisicaTerreno` (aterriza en plataformas + cae por huecos), `sobreHueco`, `golpearJefe` (solo el controlador real le quita vida) y `evaluarFinNivel` extendido con mini-jefe.
- **`DefensoresFincaScreen.jsx`**: selector de nivel 1/2 con desbloqueo, cámara que sigue al jugador en el mundo ancho, render por escena/paleta, plataformas, huecos, mini-jefe con barra de vida y botón "Nivel 2 →" al ganar. El nivel se remonta con `key` (estado limpio, sin setState en efectos).
- **`defensores-finca.css`**: estilos del selector de nivel y del aviso de mini-jefe.
- **`index.js`**: exporta los nuevos símbolos del dataset.
- Tests de la lógica del nivel 2 (engine + screen).

## Qué trae el nivel 2 (vs. nivel 1)
- Mundo más ancho (1680px vs. 720px) con cámara → más largo.
- Otra paleta/escena: atardecer + estrellas tenues vs. mediodía.
- 7 pares plaga↔benéfico (vs. 4), todos agronómicamente reales (dataset curado, sin inventar).
- Plataformas a distinta altura + huecos que hacen daño al caer.
- Mini-jefe (langosta) que SOLO cae con su controlador real (la mantis → saltamontes).
- Más cultivos a salvar (10 vs. 6) y más energía (4 vs. 3).

## Gancho pedagógico intacto
Cada benéfico elimina exactamente la plaga que controla en campo. El mini-jefe refuerza la regla: solo la mantis derriba la langosta. Tests verifican que cada par de cada nivel existe en el dataset y que el controlador del jefe es el correcto.

## Tests
- 38 vitest casos passing (engine + screen), incluyendo: terreno con plataformas/huecos, caída fatal, mini-jefe (controlador correcto/incorrecto/derrota), fin de nivel con jefe, configuración de niveles y desbloqueo.
- `vite build` OK; ESLint `--max-warnings=0` limpio en los archivos tocados; voseo-scan limpio.

## Cómo probar
1. Home → Juego → **Defensores de la Finca** (ruta `defensores`).
2. Arriba aparece el **selector de nivel**: Nivel 1 jugable, Nivel 2 bloqueado ("Gana el nivel anterior").
3. Completa el nivel 1 (recoge 6 cultivos + controla las plagas) → se **desbloquea el nivel 2** (persistido offline en localStorage) y aparece el botón "Nivel 2 →".
4. En el nivel 2: fondo de atardecer, terreno con plataformas/huecos, más bichos y al final el **mini-jefe**, que solo cae soltando la **mantis**.

Refs: PR #1697 (nivel 1)