### PR TITLE
fix(asociaciones): importar Users de lucide-react (hotfix milpa no carga)

### DIFF
--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { AlertTriangle, BarChart3, CheckCircle2, Leaf, Network, Sprout, TrendingUp, Layers, ArrowRight, Sparkles } from 'lucide-react';
+import { AlertTriangle, BarChart3, CheckCircle2, Leaf, Network, Sprout, TrendingUp, Layers, ArrowRight, Sparkles, Users } from 'lucide-react';
 import arquetipos from '../data/asociaciones-arquetipos.json';
 import comparativas from '../data/asociaciones-comparativa.json';
 import {


### PR DESCRIPTION
Hotfix: `Asociaciones.jsx` (rediseño #1712) usaba `<Users>` sin importarlo → `Users is not defined` rompía la pantalla de milpa/asociaciones en vivo. Validado eslint no-undef limpio en el archivo. Falla CI Playwright/build = infra conocida.