### PR TITLE
fix(pwa): make service worker auto-update reliable

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,8 @@
-const CACHE_NAME = 'chagra-v312';
+const SW_BUILD_SHA = '__CHAGRA_SW_BUILD_SHA__';
+const CACHE_NAME =
+  SW_BUILD_SHA && !SW_BUILD_SHA.startsWith('__CHAGRA_')
+    ? `chagra-${SW_BUILD_SHA}`
+    : 'chagra-dev';
 
 // Cache de GROUNDING del agente (corpus RAG + embeddings + tiles del mapa).
 // SEPARADO de CACHE_NAME a propósito: su contenido NO está hasheado por
@@ -60,20 +64,12 @@ const RAG_GROUNDING_PRECACHE = [
 ];
 
 // Instalación del Service Worker.
-// SIN self.skipWaiting() automático EN EL SW: el SW nuevo queda en `waiting` y
-// el skipWaiting lo decide el CLIENTE vía mensaje SKIP_WAITING. Quién manda ese
-// mensaje:
-//   1. AUTO-UPDATE (swRegistration.js, desde 2026-06-15): al detectar el
-//      waiting, el cliente dispara SKIP_WAITING automáticamente y recarga UNA
-//      vez (guard anti-loop por controllerchange). Así el deploy se VE sin que
-//      el usuario limpie caché.
-//   2. UpdateAvailableBanner ("Actualizar"): fallback visible si el auto-update
-//      no llegó a recargar.
-// El skipWaiting NO se hace aquí en el SW a propósito: el cliente necesita
-// orquestar la recarga ÚNICA (controllerchange) — si el SW activara solo, el
-// banner aparecía DESPUÉS de aplicada la actualización y el operador debía dar
-// "Actualizar" N veces (bug 2026-06-10). Por eso el SW espera el mensaje.
+// El SW nuevo se salta `waiting` de forma intencional: una vez descargado debe
+// activar, limpiar caches viejos y tomar control sin depender de que el usuario
+// pulse el banner. El cliente conserva el guard de recarga única en
+// `controllerchange`, así que first-install no se recarga y updates reales sí.
 self.addEventListener('install', (event) => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then(async (cache) => {

--- a/src/components/UpdateAvailableBanner.jsx
+++ b/src/components/UpdateAvailableBanner.jsx
@@ -113,7 +113,7 @@ export default function UpdateAvailableBanner() {
         </div>
 
         <div className="flex-1 min-w-0">
-          <p className="text-white font-bold text-sm">Nueva versión disponible</p>
+          <p className="text-white font-bold text-sm">Actualización disponible</p>
           <p className="text-slate-400 text-xs leading-snug">Actualiza para ver las mejoras más recientes.</p>
         </div>
 

--- a/src/services/__tests__/versionCheck.test.js
+++ b/src/services/__tests__/versionCheck.test.js
@@ -10,8 +10,8 @@
  *     dev → false (offline-first + anti-loop).
  *  3. fetchDeployedSha: parsea {sha}/{commit}/{build}; null en !ok / no-JSON /
  *     fetch lanzando (offline). Pide cache:'no-store'.
- *  4. runSelfHealCheck: orquesta — recarga UNA vez (marca guard + skipWaiting +
- *     reload) solo en mismatch; no-op en sync/offline/already-reloaded.
+ *  4. runSelfHealCheck: primera detección avisa + marca pending; el siguiente
+ *     arranque con el mismo SHA pendiente recarga UNA vez.
  */
 import { describe, it, expect, vi } from 'vitest';
 import {
@@ -20,6 +20,7 @@ import {
   fetchDeployedSha,
   runSelfHealCheck,
   VERSION_ENDPOINT,
+  PENDING_UPDATE_SHA_KEY,
 } from '../versionCheck';
 
 describe('shasMatch', () => {
@@ -109,6 +110,9 @@ describe('runSelfHealCheck', () => {
     const reload = vi.fn();
     const skipWaiting = vi.fn(async () => {});
     const markReloaded = vi.fn();
+    const writePending = vi.fn();
+    const clearPending = vi.fn();
+    const notifyUpdateAvailable = vi.fn();
     return {
       deps: {
         runningSha: 'a1b2c3d',
@@ -116,6 +120,10 @@ describe('runSelfHealCheck', () => {
         isOnline: () => true,
         alreadyReloaded: () => false,
         markReloaded,
+        readPending: () => null,
+        writePending,
+        clearPending,
+        notifyUpdateAvailable,
         skipWaiting,
         reload,
         ...overrides,
@@ -123,22 +131,41 @@ describe('runSelfHealCheck', () => {
       reload,
       skipWaiting,
       markReloaded,
+      writePending,
+      clearPending,
+      notifyUpdateAvailable,
     };
   }
 
-  it('mismatch → marca guard, skipWaiting y recarga UNA vez', async () => {
-    const { deps, reload, skipWaiting, markReloaded } = makeDeps();
+  it('primer mismatch → muestra banner, marca pending y manda skipWaiting sin recarga directa', async () => {
+    const { deps, reload, skipWaiting, markReloaded, writePending, notifyUpdateAvailable } = makeDeps();
+    const res = await runSelfHealCheck(deps);
+    expect(res.healed).toBe(false);
+    expect(res.reason).toBe('update-pending');
+    expect(writePending).toHaveBeenCalledWith('f9e8d7c');
+    expect(notifyUpdateAvailable).toHaveBeenCalledWith('f9e8d7c');
+    expect(skipWaiting).toHaveBeenCalledTimes(1);
+    expect(markReloaded).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('mismatch ya pendiente de un arranque anterior → recarga UNA vez', async () => {
+    const { deps, reload, skipWaiting, markReloaded } = makeDeps({
+      readPending: () => 'f9e8d7c',
+    });
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(true);
-    expect(markReloaded).toHaveBeenCalledTimes(1);
+    expect(res.reason).toBe('sha-mismatch');
     expect(skipWaiting).toHaveBeenCalledTimes(1);
+    expect(markReloaded).toHaveBeenCalledTimes(1);
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
   it('SHAs en sync → no-op (no recarga)', async () => {
-    const { deps, reload } = makeDeps({ getDeployedSha: async () => 'a1b2c3d' });
+    const { deps, reload, clearPending } = makeDeps({ getDeployedSha: async () => 'a1b2c3d' });
     const res = await runSelfHealCheck(deps);
     expect(res.healed).toBe(false);
+    expect(clearPending).toHaveBeenCalledTimes(1);
     expect(reload).not.toHaveBeenCalled();
   });
 
@@ -166,10 +193,21 @@ describe('runSelfHealCheck', () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it('skipWaiting lanza → recarga igual (no bloquea la recuperación)', async () => {
+  it('skipWaiting lanza en primera detección → queda pending y no bloquea el boot', async () => {
     const { deps, reload } = makeDeps({ skipWaiting: async () => { throw new Error('no SW'); } });
     const res = await runSelfHealCheck(deps);
-    expect(res.healed).toBe(true);
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(res.healed).toBe(false);
+    expect(res.reason).toBe('update-pending');
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('helpers de pending usan localStorage', async () => {
+    localStorage.clear();
+    const { writePendingUpdateSha, readPendingUpdateSha, clearPendingUpdateSha } = await import('../versionCheck');
+    writePendingUpdateSha('abc1234');
+    expect(localStorage.getItem(PENDING_UPDATE_SHA_KEY)).toBe('abc1234');
+    expect(readPendingUpdateSha()).toBe('abc1234');
+    clearPendingUpdateSha();
+    expect(readPendingUpdateSha()).toBeNull();
   });
 });

--- a/src/services/swRegistration.js
+++ b/src/services/swRegistration.js
@@ -196,9 +196,12 @@ export function registerServiceWorker(opts = {}) {
   };
 
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
+    navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
       .then((registration) => {
         console.log('Service Worker registrado:', registration.scope);
+        if (typeof registration.update === 'function') {
+          registration.update().catch(() => {});
+        }
       })
       .catch((error) => {
         console.error('Error registrando Service Worker:', error);

--- a/src/services/versionCheck.js
+++ b/src/services/versionCheck.js
@@ -53,6 +53,7 @@ export const RUNNING_BUILD_SHA =
   typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : 'dev';
 
 export const SELF_HEAL_GUARD_KEY = 'chagra:self-heal-reloaded';
+export const PENDING_UPDATE_SHA_KEY = 'chagra:self-heal-pending-sha';
 export const VERSION_ENDPOINT = '/version.json';
 // Timeout corto: el self-heal NO debe bloquear el boot ni colgarse en red rural.
 export const VERSION_FETCH_TIMEOUT_MS = 4000;
@@ -143,6 +144,14 @@ function safeSessionStorage() {
   }
 }
 
+function safeLocalStorage() {
+  try {
+    return typeof globalThis !== 'undefined' ? globalThis.localStorage : null;
+  } catch (_) {
+    return null;
+  }
+}
+
 /** @returns {boolean} true si ya recargamos por self-heal en esta sesión. */
 export function hasSelfHealReloaded(storage = safeSessionStorage()) {
   if (!storage) return false;
@@ -165,6 +174,43 @@ export function markSelfHealReloaded(storage = safeSessionStorage()) {
   }
 }
 
+export function readPendingUpdateSha(storage = safeLocalStorage()) {
+  if (!storage) return null;
+  try {
+    return storage.getItem(PENDING_UPDATE_SHA_KEY);
+  } catch (_) {
+    return null;
+  }
+}
+
+export function writePendingUpdateSha(sha, storage = safeLocalStorage()) {
+  if (!storage || !sha) return;
+  try {
+    storage.setItem(PENDING_UPDATE_SHA_KEY, String(sha));
+  } catch (_) {
+    /* storage no disponible: el self-heal sigue funcionando en la sesión actual. */
+  }
+}
+
+export function clearPendingUpdateSha(storage = safeLocalStorage()) {
+  if (!storage) return;
+  try {
+    storage.removeItem(PENDING_UPDATE_SHA_KEY);
+  } catch (_) {
+    /* no-op */
+  }
+}
+
+function defaultNotifyUpdateAvailable(version) {
+  try {
+    window.dispatchEvent(
+      new CustomEvent('chagra:update-available', { detail: { version } }),
+    );
+  } catch (_) {
+    /* entorno sin window/CustomEvent: no-op */
+  }
+}
+
 /**
  * Orquesta el self-heal: lee /version.json, decide, y si procede manda
  * SKIP_WAITING al SW en waiting + recarga UNA sola vez (marcando el guard).
@@ -177,6 +223,10 @@ export function markSelfHealReloaded(storage = safeSessionStorage()) {
  * @param {() => boolean} [deps.isOnline]
  * @param {() => boolean} [deps.alreadyReloaded]
  * @param {() => void} [deps.markReloaded]
+ * @param {() => string|null} [deps.readPending]
+ * @param {(sha:string) => void} [deps.writePending]
+ * @param {() => void} [deps.clearPending]
+ * @param {(version:string) => void} [deps.notifyUpdateAvailable]
  * @param {() => Promise<void>} [deps.skipWaiting] — manda SKIP_WAITING al SW.
  * @param {() => void} [deps.reload] — recarga la página.
  * @returns {Promise<{healed: boolean, reason: string}>}
@@ -189,6 +239,10 @@ export async function runSelfHealCheck(deps = {}) {
       typeof navigator === 'undefined' ? true : navigator.onLine !== false,
     alreadyReloaded = () => hasSelfHealReloaded(),
     markReloaded = () => markSelfHealReloaded(),
+    readPending = () => readPendingUpdateSha(),
+    writePending = (sha) => writePendingUpdateSha(sha),
+    clearPending = () => clearPendingUpdateSha(),
+    notifyUpdateAvailable = defaultNotifyUpdateAvailable,
     skipWaiting = defaultSkipWaiting,
     reload = defaultReload,
   } = deps;
@@ -197,6 +251,9 @@ export async function runSelfHealCheck(deps = {}) {
   if (alreadyReloaded()) return { healed: false, reason: 'already-reloaded' };
 
   const deployedSha = await getDeployedSha();
+  if (deployedSha && shasMatch(runningSha, deployedSha)) {
+    clearPending();
+  }
   const decision = shouldSelfHeal({
     runningSha,
     deployedSha,
@@ -205,15 +262,23 @@ export async function runSelfHealCheck(deps = {}) {
   });
   if (!decision) return { healed: false, reason: 'in-sync-or-unknown' };
 
-  // Marcar ANTES de recargar: si la recarga es instantánea, el guard ya quedó
-  // escrito para que el próximo arranque no re-dispare en bucle.
-  markReloaded();
+  const pendingSha = readPending();
+  const wasPendingFromPreviousStart = shasMatch(pendingSha, deployedSha);
+  writePending(deployedSha);
+  notifyUpdateAvailable(deployedSha);
   try {
     await skipWaiting();
   } catch (_) {
-    /* SW no disponible — recargamos igual: el index.html fresco trae el
-       bundle nuevo aunque el SW viejo siga; el SW se actualiza al re-register. */
+    /* SW no disponible: el próximo arranque sigue protegido por pendingSha. */
   }
+
+  if (!wasPendingFromPreviousStart) {
+    return { healed: false, reason: 'update-pending' };
+  }
+
+  // Marcar ANTES de recargar: si la recarga es instantánea, el guard ya quedó
+  // escrito para que el próximo arranque no re-dispare en bucle.
+  markReloaded();
   reload();
   return { healed: true, reason: 'sha-mismatch' };
 }

--- a/tests/unit/sw-offline-precache-runtime.test.js
+++ b/tests/unit/sw-offline-precache-runtime.test.js
@@ -148,7 +148,7 @@ describe('SW RAG grounding precache (T108)', () => {
     await waited;
 
     const names = await fakeCaches.keys();
-    const shellBucket = names.find((n) => n.startsWith('chagra-v'));
+    const shellBucket = names.find((n) => n.startsWith('chagra-') && !n.startsWith('chagra-rag-') && !n.startsWith('chagra-map-'));
     expect(shellBucket).toBeTruthy();
 
     const shellCache = await fakeCaches.open(shellBucket);
@@ -166,7 +166,7 @@ describe('SW RAG grounding precache (T108)', () => {
     await waited;
 
     const names = await fakeCaches.keys();
-    const shellBucket = names.find((n) => n.startsWith('chagra-v'));
+    const shellBucket = names.find((n) => n.startsWith('chagra-') && !n.startsWith('chagra-rag-') && !n.startsWith('chagra-map-'));
     const cache = await fakeCaches.open(shellBucket);
     const keys = (await cache.keys()).map((r) => new URL(r.url).pathname);
     expect(keys).toContain('/catalog.sqlite');

--- a/tests/unit/sw-self-heal-version.test.js
+++ b/tests/unit/sw-self-heal-version.test.js
@@ -162,6 +162,35 @@ describe('SW /version.json — network-only', () => {
   });
 });
 
+describe('SW lifecycle update reliability', () => {
+  it('install llama skipWaiting para activar el SW nuevo sin esperar al cierre de pestañas', async () => {
+    const { listeners, self } = loadSW({ online: true });
+    await fireEvent(listeners.install, {}).waited;
+    expect(self.skipWaiting).toHaveBeenCalledTimes(1);
+  });
+
+  it('activate purga caches de bundles viejos y conserva buckets offline durables', async () => {
+    const { listeners, fakeCaches, self } = loadSW({ online: true });
+    await (await fakeCaches.open('chagra-oldsha')).put('/old.js', { ok: true, status: 200 });
+    await (await fakeCaches.open('random-old-cache')).put('/x', { ok: true, status: 200 });
+    await (await fakeCaches.open('chagra-dev')).put('/index.html', { ok: true, status: 200 });
+    await (await fakeCaches.open('chagra-rag-grounding-v1')).put('/rag-embeddings.json', { ok: true, status: 200 });
+    await (await fakeCaches.open('chagra-map-tiles-v1')).put('/10/1/1.png', { ok: true, status: 200 });
+    await (await fakeCaches.open('chagra-species-images-v1')).put('/species.jpg', { ok: true, status: 200 });
+
+    await fireEvent(listeners.activate, {}).waited;
+
+    const names = await fakeCaches.keys();
+    expect(names).toContain('chagra-dev');
+    expect(names).toContain('chagra-rag-grounding-v1');
+    expect(names).toContain('chagra-map-tiles-v1');
+    expect(names).toContain('chagra-species-images-v1');
+    expect(names).not.toContain('chagra-oldsha');
+    expect(names).not.toContain('random-old-cache');
+    expect(self.clients.claim).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('SW navegación — never "failed to fetch"', () => {
   it('navegación online OK → sirve y cachea el shell', async () => {
     const { listeners, fakeCaches } = loadSW({ online: true, navStatus: 200 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { execSync } from 'node:child_process'
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 // SHA del build para el self-heal por versión (src/services/versionCheck.js).
@@ -27,9 +27,9 @@ const BUILD_SHA = resolveBuildSha();
 // auto-recuperarse (versionCheck.runSelfHealCheck). Va a dist/ directo (no a
 // public/) para no ensuciar el repo ni el watch del dev server; en dev el
 // fetch de /version.json falla limpio (404) → self-heal no-op, sin romper nada.
-function emitVersionJson() {
+function emitBuildMetadata() {
   return {
-    name: 'chagra-emit-version-json',
+    name: 'chagra-emit-build-metadata',
     apply: 'build',
     closeBundle() {
       const payload = JSON.stringify(
@@ -43,12 +43,23 @@ function emitVersionJson() {
         // No bloquear el build por esto: el self-heal degrada a no-op si falta.
         this.warn(`could not emit version.json: ${err.message}`);
       }
+      try {
+        const swPath = resolve(process.cwd(), 'dist', 'sw.js');
+        const sw = readFileSync(swPath, 'utf8');
+        writeFileSync(
+          swPath,
+          sw.replaceAll('__CHAGRA_SW_BUILD_SHA__', BUILD_SHA),
+          'utf8',
+        );
+      } catch (err) {
+        this.warn(`could not stamp sw.js cache version: ${err.message}`);
+      }
     },
   };
 }
 
 export default defineConfig({
-  plugins: [react(), emitVersionJson()],
+  plugins: [react(), emitBuildMetadata()],
   // Inyecta el SHA del build como literal en el bundle (versionCheck.js lo lee
   // como __BUILD_SHA__). JSON.stringify para que quede como string válido.
   define: {


### PR DESCRIPTION
## Summary
- Stamp the service worker cache name as chagra-<sha> at build time and activate new SWs with skipWaiting plus clients.claim.
- Purge old bundle caches on activate while preserving durable offline buckets for RAG grounding, map tiles, and species images.
- Make version.json mismatch show the update banner, store a pending update SHA, and force reload on the next app startup if the user did not act.
- Register the SW with updateViaCache: 'none' and refresh the registration after load so /sw.js is checked against the network.

## Verification
- npm run test:unit -- src/services/__tests__/versionCheck.test.js src/services/__tests__/swRegistration.test.js src/components/__tests__/UpdateAvailableBanner.update.test.jsx tests/unit/sw-self-heal-version.test.js tests/unit/sw-offline-precache.test.js tests/unit/sw-offline-precache-runtime.test.js
- npm run build
- npm run audit:bundle
- npx eslint public/sw.js src/components/UpdateAvailableBanner.jsx src/services/swRegistration.js src/services/versionCheck.js src/services/__tests__/versionCheck.test.js tests/unit/sw-self-heal-version.test.js tests/unit/sw-offline-precache-runtime.test.js vite.config.js

Note: npm run lint invokes eslint . and was interrupted after it did not finish in time; focused ESLint over changed files passed. Commit hook was run with LEFTHOOK_EXCLUDE=eslint for that reason.