### PR TITLE
fix(bench): definir helper sleep en bench-complejos (abortaba el bench de razonamiento)

### DIFF
--- a/scripts/bench-complejos-juez-independiente.mjs
+++ b/scripts/bench-complejos-juez-independiente.mjs
@@ -62,6 +62,7 @@ import { applyOutputGuards } from '../src/services/outputGuards.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..');
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 // BENCH_OUTPUT_DIR permite PERSISTIR los resultados FUERA del worktree efímero
 // (p. ej. al repo principal), para que sobrevivan al cleanup del worktree.
 const BENCH_RUNS_DIR = process.env.BENCH_OUTPUT_DIR || join(ROOT_DIR, 'data', 'bench-runs');


### PR DESCRIPTION
`sleep(2000)` (pausa térmica entre prompts) se usaba sin definir → FATAL ReferenceError tras el 1er prompt. Define el helper. Habilita el bench de inteligencia (razonamiento complejo, juez independiente).