### PR TITLE
feat(milpa): hacer jugable la siembra por espacios

### DIFF
--- a/src/components/juego/MilpaSimulator.jsx
+++ b/src/components/juego/MilpaSimulator.jsx
@@ -10,16 +10,20 @@ import { Sprout, RotateCcw, Volume2, VolumeX, Sparkles, Trophy, Target, Leaf } f
 import {
   CULTIVOS_INFO,
   CULTIVO_POR_ID,
+  CULTIVO_NARRATIVAS,
+  OCUPACION_CULTIVO,
   RELACIONES,
   CIFRAS_SISTEMAS,
   NUM_PARCELAS,
   NUM_TEMPORADAS,
   LOGROS,
+  SLOTS_POR_PARCELA,
 } from './milpaData';
 import {
-  crearParcela,
   crearJuego,
   sembrarEnParcela,
+  espaciosUsadosParcela,
+  cabeCultivoEnParcela,
   esAsociacionCompleta,
   diversidadParcela,
   saludParcela,
@@ -36,6 +40,7 @@ import {
   ASOCIACIONES,
   avanzarTemporada,
   verificarLogros,
+  describirAsociacionCompleta,
 } from '../../services/milpaGameEngine';
 import { agentSounds, isSoundEnabled, setSoundEnabled } from '../../services/agentSoundService';
 import { speak, stop as stopSpeak, isSupported as ttsSupported } from '../../services/ttsService';
@@ -68,6 +73,7 @@ function ParcelaCard({ parcela, salud, seleccionada, onSelect, mostrarTipo }) {
   const d = diversidadParcela(parcela);
   const tipoAsoc = identificarAsociacion(parcela);
   const asocInfo = tipoAsoc ? ASOCIACIONES[tipoAsoc.toUpperCase()] : null;
+  const espaciosUsados = espaciosUsadosParcela(parcela);
   const cultivos = parcela.cultivos
     .map((id) => CULTIVO_POR_ID[id])
     .filter(Boolean);
@@ -103,6 +109,9 @@ function ParcelaCard({ parcela, salud, seleccionada, onSelect, mostrarTipo }) {
       <span className="text-[11px] font-bold text-emerald-200">
         {d === 0 ? 'Tierra lista' : tipoAsoc ? asocInfo.nombre : `${d} cultivos`}
       </span>
+      <span className="text-[10px] font-black text-lime-200">
+        {espaciosUsados}/{SLOTS_POR_PARCELA} espacios
+      </span>
       <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-900/60">
         <div
           className={`h-full rounded-full bg-gradient-to-r ${colorSalud(salud)} transition-all duration-500`}
@@ -120,6 +129,7 @@ function ParcelaCard({ parcela, salud, seleccionada, onSelect, mostrarTipo }) {
 
 /** Botón para sembrar/quitar un cultivo en la parcela activa. */
 function CultivoButton({ cultivo, activo, onToggle, deshabilitado }) {
+  const ocupacion = OCUPACION_CULTIVO[cultivo.id] ?? 1;
   return (
     <button
       type="button"
@@ -127,6 +137,7 @@ function CultivoButton({ cultivo, activo, onToggle, deshabilitado }) {
       onClick={() => onToggle(cultivo.id)}
       aria-pressed={activo}
       disabled={deshabilitado}
+      title={deshabilitado ? `${cultivo.nombre} no cabe en esta parcela` : `${cultivo.nombre} usa ${ocupacion} espacio(s)`}
       className={[
         'flex min-h-[72px] flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 ring-2 transition active:scale-95',
         activo ? ACENTO[cultivo.color] : 'bg-emerald-950/50 text-emerald-200 ring-emerald-800/50 hover:bg-emerald-900/60',
@@ -135,15 +146,19 @@ function CultivoButton({ cultivo, activo, onToggle, deshabilitado }) {
     >
       <span className="text-2xl" aria-hidden="true">{cultivo.emoji}</span>
       <span className="text-[11px] font-black leading-tight">{cultivo.nombre}</span>
+      <span className="text-[9px] font-bold opacity-80">{ocupacion} espacio(s)</span>
       {activo && (
         <span className="text-[9px] font-bold text-emerald-900/60">✓</span>
+      )}
+      {deshabilitado && (
+        <span className="text-[9px] font-black text-amber-200">No cabe</span>
       )}
     </button>
   );
 }
 
 /**
- * MilpaSimulator — el subjuego JUGABLE de asociaciones agroecológicas.
+ * MilpaSimulator: el subjuego JUGABLE de asociaciones agroecológicas.
  *
  * Flujo en fases múltiples, mobile-first y táctil:
  *   1. SELECCIÓN: el jugador elige qué tipo de asociación quiere practicar.
@@ -170,6 +185,9 @@ export default function MilpaSimulator({ onBack, onHome }) {
   const [danos, setDanos] = useState(null);
   const [logros, setLogros] = useState([]);
   const [audioOn, setAudioOn] = useState(() => isSoundEnabled());
+  const [sistemaActivo, setSistemaActivo] = useState(null);
+  const [avisoSiembra, setAvisoSiembra] = useState('');
+  const [celebracion, setCelebracion] = useState('');
 
   const parcelaActiva = useMemo(
     () => parcelas.find((p) => p.id === activa) || parcelas[0],
@@ -187,6 +205,7 @@ export default function MilpaSimulator({ onBack, onHome }) {
 
   const resumen = useMemo(() => resumenFinca(parcelas), [parcelas]);
   const algunaSembrada = resumen.parcelasSembradas > 0;
+  const espaciosActivos = espaciosUsadosParcela(parcelaActiva);
 
   const hablar = useCallback(
     (texto) => {
@@ -209,16 +228,49 @@ export default function MilpaSimulator({ onBack, onHome }) {
 
   const toggleCultivo = useCallback(
     (cultivoId) => {
+      let textoParaHablar = '';
       setParcelas((prev) =>
-        prev.map((p) => (p.id === activa ? sembrarEnParcela(p, cultivoId) : p)),
+        prev.map((p) => {
+          if (p.id !== activa) return p;
+          const antesTenia = p.cultivos.includes(cultivoId);
+          const siguiente = sembrarEnParcela(p, cultivoId);
+
+          if (siguiente.motivo === 'no cabe') {
+            const info = CULTIVO_POR_ID[cultivoId];
+            setAvisoSiembra(`${info?.nombre ?? 'Ese cultivo'} no cabe. Quita algo o elige otra parcela.`);
+            setCelebracion('');
+            try { agentSounds.error(); } catch { /* noop */ }
+            return siguiente;
+          }
+
+          setAvisoSiembra('');
+
+          const tipo = identificarAsociacion(siguiente);
+          const agrego = !antesTenia && siguiente.cultivos.includes(cultivoId);
+          if (agrego && tipo) {
+            const mensaje = describirAsociacionCompleta(tipo);
+            setCelebracion(mensaje);
+            textoParaHablar = mensaje;
+          } else if (antesTenia) {
+            setCelebracion('');
+          }
+
+          return siguiente;
+        }),
       );
       try { agentSounds.listen(); } catch { /* noop */ }
+      if (textoParaHablar) {
+        try { agentSounds.chime(); } catch { /* noop */ }
+        hablar(textoParaHablar);
+      }
     },
-    [activa],
+    [activa, hablar],
   );
 
   const seleccionarParcela = useCallback((id) => {
     setActiva(id);
+    setAvisoSiembra('');
+    setCelebracion('');
     try { agentSounds.start(); } catch { /* noop */ }
   }, []);
 
@@ -259,7 +311,7 @@ export default function MilpaSimulator({ onBack, onHome }) {
         try { agentSounds.chime(); } catch { /* noop */ }
       }, 500);
     }
-  }, [resumen.ventajaPct, hablar, juego, parcelas]);
+  }, [resumen, hablar, juego, parcelas]);
 
   const avanzar = useCallback(() => {
     const { juego: juegoActualizado, continua } = avanzarTemporada(juego);
@@ -288,18 +340,19 @@ export default function MilpaSimulator({ onBack, onHome }) {
     setEvento(null);
     setDanos(null);
     setLogros([]);
+    setSistemaActivo(null);
+    setAvisoSiembra('');
+    setCelebracion('');
     try { agentSounds.listen(); } catch { /* noop */ }
   }, []);
 
   // Cultivos disponibles filtrados por fase de selección
   const cultivosDisponibles = useMemo(() => {
-    if (fase === 'seleccion') {
-      // Mostrar cultivos de todas las asociaciones
-      return CULTIVOS_INFO;
-    }
-    // En fase de siembra, mostrar todos los cultivos
-    return CULTIVOS_INFO;
-  }, [fase]);
+    if (!sistemaActivo) return CULTIVOS_INFO;
+    const asoc = Object.values(ASOCIACIONES).find((a) => a.id === sistemaActivo);
+    if (!asoc) return CULTIVOS_INFO;
+    return asoc.cultivos.map((id) => CULTIVO_POR_ID[id]).filter(Boolean);
+  }, [sistemaActivo]);
 
   return (
     <ScreenShell
@@ -365,6 +418,7 @@ export default function MilpaSimulator({ onBack, onHome }) {
                   key={asoc.id}
                   type="button"
                   onClick={() => {
+                    setSistemaActivo(asoc.id);
                     setFase('siembra');
                     hablar(asoc.nombre);
                     try { agentSounds.start(); } catch { /* noop */ }
@@ -418,6 +472,14 @@ export default function MilpaSimulator({ onBack, onHome }) {
             <p className="mb-2 text-sm font-bold text-emerald-100">
               Parcela {activa}: toca los cultivos para sembrarlos o quitarlos.
             </p>
+            <div className="mb-3 flex items-center justify-between rounded-2xl bg-emerald-900/50 px-3 py-2">
+              <span className="text-xs font-black text-lime-200">
+                {espaciosActivos}/{SLOTS_POR_PARCELA} espacios usados
+              </span>
+              <span className="text-[11px] font-bold text-emerald-300">
+                Capacidad limitada
+              </span>
+            </div>
             <div className="grid grid-cols-3 gap-2">
               {cultivosDisponibles.map((c) => (
                 <CultivoButton
@@ -425,33 +487,21 @@ export default function MilpaSimulator({ onBack, onHome }) {
                   cultivo={c}
                   activo={parcelaActiva.cultivos.includes(c.id)}
                   onToggle={toggleCultivo}
+                  deshabilitado={
+                    !parcelaActiva.cultivos.includes(c.id) &&
+                    !cabeCultivoEnParcela(parcelaActiva, c.id)
+                  }
                 />
               ))}
             </div>
 
-            {/* Sinergias activas en VIVO */}
-            <div className="mt-3 flex flex-col gap-1.5" data-testid="milpa-sinergias">
-              <SinergiaLinea
-                ok={haySoporteFisico(parcelaActiva)}
-                texto="Soporte físico entre cultivos 🌿"
-              />
-              <SinergiaLinea
-                ok={nitrogenoFijado(parcelaActiva) > 0}
-                texto={`Fijación de nitrógeno (${nitrogenoFijado(parcelaActiva)}%) 💧`}
-              />
-              <SinergiaLinea
-                ok={coberturaSuelo(parcelaActiva) > 0}
-                texto={`Cobertura del suelo (−${coberturaSuelo(parcelaActiva)}% maleza) 🌿`}
-              />
-              <SinergiaLinea
-                ok={sombraParcela(parcelaActiva) > 0}
-                texto={`Sombra (${sombraParcela(parcelaActiva)}% buffer climático) 🌳`}
-              />
-              <SinergiaLinea
-                ok={controlPlaga(parcelaActiva) > 0}
-                texto={`Control de plagas (${controlPlaga(parcelaActiva)}%) 🛡️`}
-              />
-            </div>
+            {avisoSiembra && (
+              <p className="mt-3 rounded-2xl bg-amber-400/15 p-3 text-sm font-black text-amber-100 ring-1 ring-amber-300/30">
+                {avisoSiembra}
+              </p>
+            )}
+
+            <SinergiaNarrada parcela={parcelaActiva} celebracion={celebracion} />
 
             <p className="mt-3 rounded-2xl bg-emerald-900/50 p-3 text-center text-sm font-black text-lime-200">
               Salud de la parcela: {saludParcela(parcelaActiva)} / {SALUD_MAX}
@@ -694,18 +744,66 @@ export default function MilpaSimulator({ onBack, onHome }) {
   );
 }
 
-/** Línea de sinergia con check/cruz. */
-function SinergiaLinea({ ok, texto }) {
+/** Narrativa viva de los cultivos sembrados y sus sinergias medibles. */
+function SinergiaNarrada({ parcela, celebracion }) {
+  const cultivos = parcela.cultivos
+    .map((id) => CULTIVO_POR_ID[id])
+    .filter(Boolean);
+  const nFijado = nitrogenoFijado(parcela);
+  const cobertura = coberturaSuelo(parcela);
+  const sombra = sombraParcela(parcela);
+  const plaga = controlPlaga(parcela);
+  const soporte = haySoporteFisico(parcela);
+
+  if (cultivos.length === 0) {
+    return (
+      <div
+        className="mt-3 rounded-2xl bg-emerald-900/40 p-3 text-sm font-bold text-emerald-300"
+        data-testid="milpa-sinergias"
+      >
+        Siembra una primera planta y mira qué puede aportar a sus vecinas.
+      </div>
+    );
+  }
+
   return (
-    <p
-      className={[
-        'flex items-center gap-2 text-xs font-bold',
-        ok ? 'text-lime-300' : 'text-emerald-400/40',
-      ].join(' ')}
+    <div
+      className="mt-3 flex flex-col gap-2"
+      data-testid="milpa-sinergias"
     >
-      <span aria-hidden="true">{ok ? '✅' : '⬜'}</span>
-      {texto}
-    </p>
+      {cultivos.map((cultivo) => (
+        <p
+          key={cultivo.id}
+          className="rounded-2xl bg-emerald-900/45 p-3 text-sm font-bold leading-relaxed text-emerald-100 ring-1 ring-emerald-700/40 milpa-deslizar-arriba"
+        >
+          {CULTIVO_NARRATIVAS[cultivo.id] ?? cultivo.ayuda}
+        </p>
+      ))}
+
+      <div className="grid grid-cols-2 gap-2">
+        {soporte && <SinergiaDato texto="Soporte físico" valor="activo" />}
+        {nFijado > 0 && <SinergiaDato texto="N fijado" valor={`${nFijado}%`} />}
+        {cobertura > 0 && <SinergiaDato texto="Maleza" valor={`-${cobertura}%`} />}
+        {sombra > 0 && <SinergiaDato texto="Sombra" valor={`${sombra}%`} />}
+        {plaga > 0 && <SinergiaDato texto="Plagas" valor={`-${plaga}%`} />}
+      </div>
+
+      {celebracion && (
+        <p className="rounded-3xl border border-lime-300/40 bg-lime-400/15 p-4 text-center text-base font-black leading-relaxed text-lime-100 milpa-asociacion-completa">
+          {celebracion}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Indicador corto con cifra real o relación activada. */
+function SinergiaDato({ texto, valor }) {
+  return (
+    <div className="rounded-2xl bg-slate-900/45 p-2 text-center ring-1 ring-emerald-700/40">
+      <p className="text-[10px] font-bold uppercase tracking-wide text-emerald-300">{texto}</p>
+      <p className="text-sm font-black text-lime-200">{valor}</p>
+    </div>
   );
 }
 

--- a/src/components/juego/__tests__/MilpaSimulator.test.jsx
+++ b/src/components/juego/__tests__/MilpaSimulator.test.jsx
@@ -17,20 +17,28 @@ vi.mock('../../../services/agentSoundService', () => ({
 }));
 
 describe('MilpaSimulator', () => {
-  it('arranca en fase siembra con cuatro parcelas vacías y temporada deshabilitada', () => {
+  const elegirMilpa = () => {
+    fireEvent.click(screen.getByRole('button', { name: /Milpa \(Tres Hermanas\)/ }));
+  };
+
+  it('arranca en selección y entra a siembra con seis parcelas vacías', () => {
     render(<MilpaSimulator />);
     expect(screen.getByTestId('milpa-simulator')).toBeInTheDocument();
+    expect(screen.getByText('¿Qué quieres sembrar hoy?')).toBeInTheDocument();
+
+    elegirMilpa();
     expect(screen.getByTestId('milpa-panel-siembra')).toBeInTheDocument();
 
     const tablero = screen.getByTestId('milpa-tablero');
-    expect(within(tablero).getAllByRole('button')).toHaveLength(4);
+    expect(within(tablero).getAllByRole('button')).toHaveLength(6);
 
     // Sin nada sembrado, no se puede empezar la temporada.
     expect(screen.getByTestId('milpa-iniciar-temporada')).toBeDisabled();
   });
 
-  it('sembrar las tres hermanas marca la parcela como milpa y habilita la temporada', () => {
+  it('sembrar las tres hermanas llena 4/4 espacios, narra la sinergia y habilita la temporada', () => {
     render(<MilpaSimulator />);
+    elegirMilpa();
 
     fireEvent.click(screen.getByTestId('milpa-sembrar-maiz'));
     fireEvent.click(screen.getByTestId('milpa-sembrar-frijol'));
@@ -38,11 +46,14 @@ describe('MilpaSimulator', () => {
 
     // La parcela 1 ahora es una milpa completa (insignia visible).
     const parcela1 = screen.getByTestId('milpa-parcela-1');
-    expect(within(parcela1).getByText('¡Milpa!')).toBeInTheDocument();
+    expect(within(parcela1).getByText('Milpa (Tres Hermanas)')).toBeInTheDocument();
+    expect(within(parcela1).getByText('4/4 espacios')).toBeInTheDocument();
 
-    // Las sinergias reales aparecen como cumplidas.
+    // Las sinergias reales aparecen narradas y con cifras.
     const sinergias = screen.getByTestId('milpa-sinergias');
-    expect(within(sinergias).getByText(/El fríjol fija nitrógeno \(60%\)/)).toBeInTheDocument();
+    expect(within(sinergias).getByText(/El fríjol trepa por el maíz y fija nitrógeno/)).toBeInTheDocument();
+    expect(within(sinergias).getByText('60%')).toBeInTheDocument();
+    expect(within(sinergias).getByText(/Descubriste la Milpa/)).toBeInTheDocument();
 
     // Ya se puede empezar la temporada.
     expect(screen.getByTestId('milpa-iniciar-temporada')).not.toBeDisabled();
@@ -50,6 +61,7 @@ describe('MilpaSimulator', () => {
 
   it('flujo completo: siembra → evento → resultado muestra ventaja sobre el monocultivo', () => {
     render(<MilpaSimulator />);
+    elegirMilpa();
 
     fireEvent.click(screen.getByTestId('milpa-sembrar-maiz'));
     fireEvent.click(screen.getByTestId('milpa-sembrar-frijol'));
@@ -62,20 +74,21 @@ describe('MilpaSimulator', () => {
     const resultado = screen.getByTestId('milpa-panel-resultado');
     expect(resultado).toBeInTheDocument();
     // La milpa rinde más que el monocultivo equivalente.
-    expect(within(resultado).getByText(/más que sembrar cada cultivo solo/)).toBeInTheDocument();
+    expect(within(resultado).getByText(/más que el monocultivo/)).toBeInTheDocument();
     // Las tres lecciones reales se muestran.
     expect(within(resultado).getByText(/El fríjol alimenta al maíz/)).toBeInTheDocument();
     expect(within(resultado).getByText(/El maíz sostiene al fríjol/)).toBeInTheDocument();
     expect(within(resultado).getByText(/La ahuyama cuida el suelo/)).toBeInTheDocument();
   });
 
-  it('reiniciar vuelve a la fase de siembra con parcelas vacías', () => {
+  it('permite pasar a la siguiente temporada con parcelas vacías', () => {
     render(<MilpaSimulator />);
+    elegirMilpa();
     fireEvent.click(screen.getByTestId('milpa-sembrar-maiz'));
     fireEvent.click(screen.getByTestId('milpa-iniciar-temporada'));
     fireEvent.click(screen.getByTestId('milpa-ver-resultado'));
 
-    fireEvent.click(screen.getByTestId('milpa-reiniciar'));
+    fireEvent.click(screen.getByRole('button', { name: /Siguiente temporada/ }));
     expect(screen.getByTestId('milpa-panel-siembra')).toBeInTheDocument();
     expect(screen.getByTestId('milpa-iniciar-temporada')).toBeDisabled();
   });

--- a/src/components/juego/milpa.css
+++ b/src/components/juego/milpa.css
@@ -44,6 +44,28 @@
   100% { box-shadow: 0 0 0 0 rgba(163, 230, 53, 0); }
 }
 
+/* Celebración suave cuando se completa una asociación real. */
+.milpa-asociacion-completa {
+  animation: milpa-asociacion-completa 720ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+@keyframes milpa-asociacion-completa {
+  0% {
+    transform: translateY(10px) scale(0.96);
+    opacity: 0;
+    box-shadow: 0 0 0 0 rgba(190, 242, 100, 0.55);
+  }
+  60% {
+    transform: translateY(0) scale(1.02);
+    opacity: 1;
+    box-shadow: 0 0 0 12px rgba(190, 242, 100, 0);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+    box-shadow: 0 0 0 0 rgba(190, 242, 100, 0);
+  }
+}
+
 /* Shake suave para eventos negativos (daño) */
 .milpa-shake {
   animation: milpa-shake 0.5s cubic-bezier(.36,.07,.19,.97) both;
@@ -119,6 +141,7 @@
   .milpa-brota,
   .milpa-pulso,
   .milpa-resplandor,
+  .milpa-asociacion-completa,
   .milpa-shake,
   .milpa-deslizar-arriba,
   .milpa-fade-in,

--- a/src/components/juego/milpaData.js
+++ b/src/components/juego/milpaData.js
@@ -22,6 +22,7 @@
  */
 
 import { CULTIVOS, ASOCIACIONES } from '../../services/milpaGameEngine';
+export { OCUPACION_CULTIVO, SLOTS_POR_PARCELA } from '../../services/milpaGameEngine';
 
 /**
  * Datos visuales y educativos de cada cultivo para la UI.
@@ -138,6 +139,22 @@ export const CULTIVOS_INFO = [
     ayuda: 'Protege a la cebolla de su plaga principal.',
   },
 ];
+
+/** Narrativa breve que aparece al sembrar cada cultivo. */
+export const CULTIVO_NARRATIVAS = Object.freeze({
+  [CULTIVOS.MAIZ]: 'El maíz crece alto y será la columna del fríjol 🌽',
+  [CULTIVOS.FRIJOL]: 'El fríjol trepa por el maíz y fija nitrógeno 💧',
+  [CULTIVOS.AHUYAMA]: 'La ahuyama cubre el suelo y frena la maleza 🎃',
+  [CULTIVOS.CAFE]: 'El café agradece sombra suave para producir mejor ☕',
+  [CULTIVOS.GUAMO]: 'El guamo da sombra, fija nitrógeno y deja mantillo 🌳',
+  [CULTIVOS.PLATANO]: 'El plátano protege temprano y también da cosecha 🍌',
+  [CULTIVOS.CACAO]: 'El cacao crece más sano con sombra viva alrededor 🍫',
+  [CULTIVOS.MATARRATON]: 'El matarratón alimenta el suelo y regula la sombra 🌿',
+  [CULTIVOS.FRUTAL]: 'El frutal produce arriba y deja espacio para cubrir abajo 🍊',
+  [CULTIVOS.MANI_FORRAJERO]: 'El maní forrajero tapiza el suelo y fija nitrógeno 🥜',
+  [CULTIVOS.CEBOLLA]: 'La cebolla protege con su aroma y confunde plagas 🧅',
+  [CULTIVOS.ZANAHORIA]: 'La zanahoria acompaña a la cebolla y reduce presión de moscas 🥕',
+});
 
 /** Mapa rápido id → cultivoInfo (para pintar parcelas). */
 export const CULTIVO_POR_ID = Object.freeze(

--- a/src/services/__tests__/milpaGameEngine.test.js
+++ b/src/services/__tests__/milpaGameEngine.test.js
@@ -5,10 +5,12 @@ import {
   crearParcela,
   crearJuego,
   sembrarEnParcela,
+  espaciosUsadosParcela,
   esAsociacionCompleta,
   esMilpaCompleta,
   diversidadParcela,
   identificarAsociacion,
+  describirAsociacionCompleta,
   nitrogenoFijado,
   coberturaSuelo,
   sombraParcela,
@@ -24,6 +26,7 @@ import {
   ASOCIACIONES,
   avanzarTemporada,
   verificarLogros,
+  SLOTS_POR_PARCELA,
 } from '../milpaGameEngine';
 
 /** Helper: parcela con los cultivos indicados. */
@@ -42,6 +45,20 @@ describe('milpaGameEngine — siembra', () => {
   it('ignora cultivos que no son válidos', () => {
     const p = sembrarEnParcela(crearParcela('1'), 'invalido');
     expect(p.cultivos).toEqual([]);
+  });
+
+  it('limita la siembra por espacios de parcela', () => {
+    let p = crearParcela('1');
+    p = sembrarEnParcela(p, CULTIVOS.MAIZ);
+    p = sembrarEnParcela(p, CULTIVOS.FRIJOL);
+    p = sembrarEnParcela(p, CULTIVOS.AHUYAMA);
+
+    expect(p.cultivos).toEqual([CULTIVOS.MAIZ, CULTIVOS.FRIJOL, CULTIVOS.AHUYAMA]);
+    expect(espaciosUsadosParcela(p)).toBe(SLOTS_POR_PARCELA);
+
+    const rechazada = sembrarEnParcela(p, CULTIVOS.CEBOLLA);
+    expect(rechazada.cultivos).toEqual([CULTIVOS.MAIZ, CULTIVOS.FRIJOL, CULTIVOS.AHUYAMA]);
+    expect(rechazada.motivo).toBe('no cabe');
   });
 
   it('cuenta la diversidad como número de cultivos distintos', () => {
@@ -69,6 +86,11 @@ describe('milpaGameEngine — siembra', () => {
     expect(
       identificarAsociacion(parcelaCon(CULTIVOS.CEBOLLA, CULTIVOS.ZANAHORIA)),
     ).toBe('hortalizas');
+  });
+
+  it('describe una asociación completa con una frase narrativa', () => {
+    expect(describirAsociacionCompleta('milpa')).toContain('Descubriste la Milpa');
+    expect(describirAsociacionCompleta('saf_cafe')).toContain('café');
   });
 
   it('reconoce asociaciones completas', () => {

--- a/src/services/milpaGameEngine.js
+++ b/src/services/milpaGameEngine.js
@@ -53,6 +53,28 @@ export const HERMANAS = CULTIVOS;
 /** Salud máxima de una parcela (0–100). */
 export const SALUD_MAX = 100;
 
+/** Capacidad máxima de una parcela en espacios de siembra. */
+export const SLOTS_POR_PARCELA = 4;
+
+/**
+ * Espacios que ocupa cada cultivo. En milpa, maíz ocupa más por su porte; las
+ * coberturas y hortalizas ocupan menos. En SAF, árboles/sombras ocupan más.
+ */
+export const OCUPACION_CULTIVO = Object.freeze({
+  [CULTIVOS.MAIZ]: 2,
+  [CULTIVOS.FRIJOL]: 1,
+  [CULTIVOS.AHUYAMA]: 1,
+  [CULTIVOS.CAFE]: 1,
+  [CULTIVOS.GUAMO]: 2,
+  [CULTIVOS.PLATANO]: 1,
+  [CULTIVOS.CACAO]: 1,
+  [CULTIVOS.MATARRATON]: 2,
+  [CULTIVOS.FRUTAL]: 2,
+  [CULTIVOS.MANI_FORRAJERO]: 1,
+  [CULTIVOS.CEBOLLA]: 1,
+  [CULTIVOS.ZANAHORIA]: 1,
+});
+
 /**
  * Define los tipos de asociaciones soportadas con sus componentes.
  */
@@ -155,21 +177,52 @@ export function crearParcela(id) {
 }
 
 /**
+ * Espacios usados por los cultivos de una parcela.
+ * @param {{ cultivos: string[] }} parcela
+ * @returns {number}
+ */
+export function espaciosUsadosParcela(parcela) {
+  return parcela.cultivos.reduce(
+    (total, cultivoId) => total + (OCUPACION_CULTIVO[cultivoId] ?? 1),
+    0,
+  );
+}
+
+/**
+ * Valida si un cultivo puede entrar sin superar la capacidad. Si ya está
+ * sembrado, puede tocarse para quitarlo.
+ * @param {{ cultivos: string[] }} parcela
+ * @param {string} cultivoId
+ * @returns {boolean}
+ */
+export function cabeCultivoEnParcela(parcela, cultivoId) {
+  const valido = Object.values(CULTIVOS).includes(cultivoId);
+  if (!valido) return false;
+  if (parcela.cultivos.includes(cultivoId)) return true;
+
+  const ocupacion = OCUPACION_CULTIVO[cultivoId] ?? 1;
+  return espaciosUsadosParcela(parcela) + ocupacion <= SLOTS_POR_PARCELA;
+}
+
+/**
  * Siembra (o quita) un cultivo en una parcela. Toggle: si ya está, lo retira.
- * Una parcela admite cualquier combinación de cultivos.
+ * Una parcela admite combinaciones hasta llenar sus espacios.
  *
  * @param {{ id: string, cultivos: string[] }} parcela
  * @param {string} cultivoId  Uno de CULTIVOS.
- * @returns {{ id: string, cultivos: string[] }} nueva parcela (inmutable)
+ * @returns {{ id: string, cultivos: string[], motivo?: string }} nueva parcela
  */
 export function sembrarEnParcela(parcela, cultivoId) {
   const valido = Object.values(CULTIVOS).includes(cultivoId);
   if (!valido) return parcela;
   const tiene = parcela.cultivos.includes(cultivoId);
+  if (!tiene && !cabeCultivoEnParcela(parcela, cultivoId)) {
+    return { ...parcela, motivo: 'no cabe' };
+  }
   const cultivos = tiene
     ? parcela.cultivos.filter((c) => c !== cultivoId)
     : [...parcela.cultivos, cultivoId];
-  return { ...parcela, cultivos };
+  return { ...parcela, cultivos, motivo: undefined };
 }
 
 /**
@@ -180,13 +233,12 @@ export function sembrarEnParcela(parcela, cultivoId) {
 export function identificarAsociacion(parcela) {
   const cultivosSet = new Set(parcela.cultivos);
 
-  for (const [key, asoc] of Object.entries(ASOCIACIONES)) {
-    const cultivosAsoc = new Set(asoc.cultivos);
+  for (const asoc of Object.values(ASOCIACIONES)) {
     // Verificar si la parcela tiene todos los cultivos de la asociación
     const esEstaAsociacion = asoc.cultivos.every(c => cultivosSet.has(c));
     // Y no tiene cultivos extra de otras asociaciones (con flexibilidad para combinaciones)
     if (esEstaAsociacion) {
-      return key;
+      return asoc.id;
     }
   }
   return null;
@@ -199,6 +251,23 @@ export function identificarAsociacion(parcela) {
  */
 export function esAsociacionCompleta(parcela) {
   return identificarAsociacion(parcela) !== null;
+}
+
+/**
+ * Frase de celebración cuando se completa una asociación real.
+ * @param {string} tipo ID de asociación, por ejemplo "milpa".
+ * @returns {string}
+ */
+export function describirAsociacionCompleta(tipo) {
+  const frases = {
+    milpa: '¡Descubriste la Milpa! Las tres hermanas se ayudan: maíz sostiene, fríjol alimenta, ahuyama cuida 🌾',
+    saf_cafe: '¡Lo lograste! El café, guamo y plátano forman un SAF: sombra, nitrógeno y cosecha se acompañan ☕',
+    saf_cacao: '¡Lo lograste! Cacao, matarratón y plátano crean sombra viva y suelo alimentado 🍫',
+    frutal_cobertura: '¡Lo lograste! El frutal produce arriba y el maní forrajero protege el suelo abajo 🍊',
+    hortalizas: '¡Lo lograste! Cebolla y zanahoria se protegen con sus aromas y bajan la presión de plagas 🥕',
+  };
+
+  return frases[tipo] ?? '';
 }
 
 /**
@@ -372,7 +441,7 @@ export function haySoporteFisico(parcela) {
 
   // Árboles protegen cultivos pequeños
   const arboles = [CULTIVOS.GUAMO, CULTIVOS.MATARRATON, CULTIVOS.PLATANO, CULTIVOS.FRUTAL];
-  cultivosPequenos = [CULTIVOS.CAFE, CULTIVOS.CACAO, CULTIVOS.CEBOLLA, CULTIVOS.ZANAHORIA];
+  const cultivosPequenos = [CULTIVOS.CAFE, CULTIVOS.CACAO, CULTIVOS.CEBOLLA, CULTIVOS.ZANAHORIA];
 
   const hayArbol = parcela.cultivos.some(c => arboles.includes(c));
   const hayPequeno = parcela.cultivos.some(c => cultivosPequenos.includes(c));
@@ -730,6 +799,9 @@ export function verificarLogros(juego) {
     const r = temp.resumen;
 
     // Logros de rendimiento
+    if (r.asociacionesCompletas >= 1 && !logros.includes('primera_milpa')) {
+      logros.push('primera_milpa');
+    }
     if (r.ventajaPct >= 100 && !logros.includes('super_milpa')) {
       logros.push('super_milpa');
     }
@@ -751,7 +823,7 @@ export function verificarLogros(juego) {
     }
 
     // Logros de resiliencia
-    if (r.milpasCompletas >= Math.floor(juego.parcelas.length / 2) &&
+    if (r.asociacionesCompletas >= Math.floor(juego.parcelas.length / 2) &&
         !logros.includes('resiliente')) {
       logros.push('resiliente');
     }
@@ -786,6 +858,7 @@ export function aplicarEvento(parcela, evento) {
  * @returns {{
  *   parcelasSembradas: number,
  *   asociacionesCompletas: number,
+ *   milpasCompletas: number,
  *   tiposAsociaciones: string[],
  *   saludTotal: number,
  *   saludPromedio: number,
@@ -853,6 +926,7 @@ export function resumenFinca(parcelas) {
   return {
     parcelasSembradas: n,
     asociacionesCompletas,
+    milpasCompletas: asociacionesCompletas,
     tiposAsociaciones: Array.from(tipos),
     saludTotal,
     saludPromedio: Math.round(saludTotal / n),


### PR DESCRIPTION
## Resumen
- Agrega capacidad por parcela: 4 espacios, ocupación por cultivo y rechazo explícito cuando un cultivo no cabe.
- Reemplaza el checklist de sinergias por narrativa dinámica por cultivo y celebración animada al completar asociaciones reales.
- Ajusta la UI mobile-first para mostrar espacios usados, bloquear cultivos imposibles y respetar el sistema elegido.

## Cómo probar
- npx vitest run src/services/__tests__/milpaGameEngine.test.js src/components/juego/__tests__/MilpaSimulator.test.jsx
- npx eslint --rule 'no-undef: error' src/components/juego/MilpaSimulator.jsx src/services/milpaGameEngine.js src/components/juego/milpaData.js src/components/juego/__tests__/MilpaSimulator.test.jsx src/services/__tests__/milpaGameEngine.test.js\n- npm run dev -- --host 127.0.0.1 y navegar al subjuego La Milpa desde la app.