### PR TITLE
fix(agent): "Abrir Chagra IA" no abría el overlay del agente en móvil

### DIFF
--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import ChagraAgentAvatar from './ChagraAgentAvatar';
+import { MSG } from '../config/messages.js';
 
 /**
  * WelcomeStatsHero — widget de bienvenida con narrativa de impacto del agente.
@@ -187,18 +188,49 @@ const TONE_CLASSES = {
  * AgentColibriChip — colibri clickable que abre el agente desde el home.
  * Default idle (vuelo estacionario), hover thinking (libando), click navega.
  * Se anima en mouse over para invitar al click y en touch press en mobile.
+ *
+ * Bug móvil "Abrir Chagra IA no abre el overlay" (2026-06-20): el botón solo
+ * abría el agente vía `onClick`, pero el press anima un `transform: scale()`
+ * que cambia la geometría del target ENTRE touchstart y touchend. En móvil
+ * (iOS Safari + algunos Chrome Android) ese reescalado bajo el dedo hace que el
+ * navegador CANCELE el click sintético → `onNavigate('agente')` nunca corría y
+ * el overlay no abría (en desktop el click de mouse no se ve afectado, por eso
+ * "funcionaba en desktop pero no en móvil"). Fix mobile-first: disparar la
+ * navegación en `onTouchEnd` (la intención real del tap) y `preventDefault()`
+ * para suprimir el ghost-click, deduplicando con `navigatedByTouchRef` para que
+ * el click sintético —si igual llega— no navegue dos veces.
  */
 function AgentColibriChip({ onNavigate, size = 26 }) {
   const [hover, setHover] = useState(false);
   const [pressed, setPressed] = useState(false);
   const interactive = typeof onNavigate === 'function';
   const state = pressed ? 'speaking' : hover ? 'thinking' : 'idle';
+  // Marca que el tap táctil ya navegó, para ignorar el click sintético que
+  // algunos navegadores móviles emiten después del touchend.
+  const navigatedByTouchRef = useRef(false);
 
-  const handleClick = () => { if (interactive) onNavigate('agente'); };
+  const openAgent = () => { if (interactive) onNavigate('agente'); };
+  const handleClick = () => {
+    // Si el touchend ya navegó, el click sintético es un duplicado: no-op.
+    if (navigatedByTouchRef.current) {
+      navigatedByTouchRef.current = false;
+      return;
+    }
+    openAgent();
+  };
   const enter = () => setHover(true);
   const leave = () => { setHover(false); setPressed(false); };
   const down = () => setPressed(true);
   const up = () => setPressed(false);
+  const handleTouchEnd = (e) => {
+    setHover(false);
+    setPressed(false);
+    if (!interactive) return;
+    // Suprime el ghost-click (evita doble navegación) y abre en el tap real.
+    if (e?.cancelable) e.preventDefault();
+    navigatedByTouchRef.current = true;
+    openAgent();
+  };
 
   return (
     <button
@@ -212,7 +244,7 @@ function AgentColibriChip({ onNavigate, size = 26 }) {
       onMouseDown={down}
       onMouseUp={up}
       onTouchStart={() => { setHover(true); setPressed(true); }}
-      onTouchEnd={() => { setHover(false); setPressed(false); }}
+      onTouchEnd={handleTouchEnd}
       onFocus={enter}
       onBlur={leave}
       className={`shrink-0 inline-flex items-center justify-center rounded-full bg-slate-900 border ${
@@ -505,7 +537,7 @@ export default function WelcomeStatsHero({ mode = 'post-login', onNavigate }) {
                 {isPreLogin ? GLOBAL_FEDERATION_FALLBACK.plantasRegistradas : plantsCount}
               </div>
               <div className="text-[9px] text-slate-500 truncate">
-                {isPreLogin ? 'Plantas registradas' : (plantsCount === 1 ? 'Planta tuya' : 'Plantas tuyas')}
+                {isPreLogin ? MSG.welcomeStats.plantasRegistradas : (plantsCount === 1 ? MSG.welcomeStats.plantaTuya : MSG.welcomeStats.plantasTuyas)}
               </div>
             </div>
           </div>

--- a/src/components/WelcomeStatsHero.openAgent.test.jsx
+++ b/src/components/WelcomeStatsHero.openAgent.test.jsx
@@ -1,0 +1,79 @@
+/**
+ * WelcomeStatsHero.openAgent.test.jsx — abrir el overlay del agente desde el
+ * colibrí "Abrir Chagra IA" en MÓVIL.
+ *
+ * Bug 2026-06-20: en móvil el tap sobre "Abrir Chagra IA" NO abría el overlay.
+ * Causa: el botón solo navegaba en `onClick`, pero el `transform: scale()` del
+ * press cambia la geometría del target entre touchstart/touchend → el navegador
+ * móvil cancela el click sintético → `onNavigate('agente')` nunca corría.
+ *
+ * Contrato cubierto:
+ *   1. touchEnd sobre el colibrí navega a 'agente' (la ruta del overlay).
+ *   2. El click sintético que llega DESPUÉS del touchEnd NO navega doble.
+ *   3. Un click puro de mouse (sin touch) sigue navegando (desktop).
+ *   4. Pre-login (sin onNavigate) el botón queda inerte (disabled), por diseño.
+ *
+ * jsdom no reproduce el cancel real del click sintético del navegador móvil;
+ * el test fija el CONTRATO del handler (touchEnd abre + dedupe del ghost-click),
+ * que es lo que garantiza la apertura fiable en viewport angosto.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WelcomeStatsHero from './WelcomeStatsHero';
+
+const mockAssetStore = { plants: { length: 0 } };
+vi.mock('../store/useAssetStore', () => ({
+  default: (selector) => selector(mockAssetStore),
+}));
+
+describe('WelcomeStatsHero — abrir Chagra IA (overlay del agente) en móvil', () => {
+  beforeEach(() => {
+    mockAssetStore.plants.length = 0;
+    try { globalThis.localStorage.clear(); } catch { /* ignore */ }
+  });
+
+  it('touchEnd sobre "Abrir Chagra IA" navega al agente', () => {
+    const onNavigate = vi.fn();
+    render(<WelcomeStatsHero mode="post-login" onNavigate={onNavigate} />);
+    // Hay 2 botones con el mismo aria-label (header + modal); el primero basta.
+    const chip = screen.getAllByRole('button', { name: 'Abrir Chagra IA' })[0];
+
+    fireEvent.touchStart(chip);
+    fireEvent.touchEnd(chip);
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+  });
+
+  it('el click sintético tras el touchEnd NO navega dos veces', () => {
+    const onNavigate = vi.fn();
+    render(<WelcomeStatsHero mode="post-login" onNavigate={onNavigate} />);
+    const chip = screen.getAllByRole('button', { name: 'Abrir Chagra IA' })[0];
+
+    fireEvent.touchStart(chip);
+    fireEvent.touchEnd(chip);
+    // Ghost-click que algunos navegadores móviles emiten después del touch.
+    fireEvent.click(chip);
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+  });
+
+  it('un click puro de mouse (desktop) sigue abriendo el agente', () => {
+    const onNavigate = vi.fn();
+    render(<WelcomeStatsHero mode="post-login" onNavigate={onNavigate} />);
+    const chip = screen.getAllByRole('button', { name: 'Abrir Chagra IA' })[0];
+
+    fireEvent.click(chip);
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate).toHaveBeenCalledWith('agente');
+  });
+
+  it('pre-login (sin onNavigate) el botón queda inerte (disabled)', () => {
+    render(<WelcomeStatsHero mode="pre-login" />);
+    // El aria-label es constante; pre-login el botón se renderiza disabled.
+    const chip = screen.getAllByRole('button', { name: 'Abrir Chagra IA' })[0];
+    expect(chip).toBeDisabled();
+  });
+});

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -172,6 +172,12 @@ const messages = {
     fincaActivaLabel: 'Finca activa:',
     guardar: 'Guardar',
   },
+  // Hero de bienvenida (WelcomeStatsHero) — etiquetas del mini-grid de stats.
+  welcomeStats: {
+    plantasRegistradas: 'Plantas registradas',
+    plantaTuya: 'Planta tuya',
+    plantasTuyas: 'Plantas tuyas',
+  },
   format,
 };
 


### PR DESCRIPTION
## Resumen
Arregla el bug móvil: el botón/acción **"Abrir Chagra IA"** (el colibrí `AgentColibriChip` en `WelcomeStatsHero`) NO abría el overlay del agente al tocarlo en móvil. En desktop sí abría.

## Causa
`src/components/WelcomeStatsHero.jsx` — `AgentColibriChip` (líneas ~191-230 originales).

El botón solo navegaba al agente vía `onClick`. El press anima un `transform: scale()` que **cambia la geometría del target entre `touchstart` y `touchend`**. En móvil (iOS Safari + algunos Chrome Android) ese reescalado bajo el dedo hace que el navegador **cancele el `click` sintético** → `onNavigate('agente')` nunca corría → el overlay no abría. En desktop el `click` de mouse no se ve afectado, de ahí "funciona en desktop pero no en móvil".

## Fix (mobile-first, quirúrgico)
- Disparar la navegación en `onTouchEnd` (la intención real del tap) con `preventDefault()` para suprimir el ghost-click.
- Dedupe con `navigatedByTouchRef` para que el `click` sintético tardío (si igual llega) NO navegue dos veces.
- Se **conserva `onClick`** para mouse/teclado (desktop y a11y).
- **NO se toca el layout del `AgentHero`** (otro worker lo está arreglando — el fix de `padding-bottom`/mano vs compositor del 2026-06-20 vive aparte).

## TDD
`src/components/WelcomeStatsHero.openAgent.test.jsx` (nuevo):
1. `touchEnd` sobre "Abrir Chagra IA" navega a `'agente'`.
2. El `click` sintético tras el `touchEnd` NO navega dos veces.
3. Un `click` puro de mouse (desktop) sigue navegando.
4. Pre-login (sin `onNavigate`) el botón queda inerte (disabled), por diseño.

> jsdom no reproduce el cancel real del click sintético del navegador móvil; el test fija el **contrato** del handler (touchEnd abre + dedupe), que es lo que garantiza la apertura fiable en viewport angosto (~390px).

## i18n
Migra los strings **ya hardcodeados** del mini-grid de stats (`Plantas registradas` / `Planta tuya` / `Plantas tuyas`) a `MSG.welcomeStats` para que el gate `eslint --max-warnings=0` quede verde en el archivo tocado (ADR-050). No introduce strings nuevos.

## Test plan
- [x] `vitest run` — 10/10 (4 nuevos + 6 existentes anti-alucinación)
- [x] `eslint --max-warnings=0` en archivos cambiados — 0 errores, 0 warnings
- [x] `eslint --rule no-undef` — sin `ReferenceError` (`useRef` importado y usado)
- [x] lefthook (eslint + secret-scan + infra-refs-scan + voseo-scan + conventional) — verde
- [ ] Smoke móvil ~390px: tap en el colibrí "Abrir Chagra IA" abre el overlay del agente al primer toque

🤖 Generated with [Claude Code](https://claude.com/claude-code)