### PR TITLE
fix(agent): re-conectar ramas de la mano a la Ⓐ tras #1726

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chagra",
   "private": true,
-  "version": "1.0.54",
+  "version": "1.0.55",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -65,8 +65,10 @@ import {
  *     "cablean", nodos que pulsan, corriente/sparks) + micelio/raíces + esporas
  *     + colibrí 2D. TODO portado del demo biopunk.
  *   - Escena minimal: trazo botánico monoline que se dibuja + horizonte fino +
- *     un toque verde tenue (sobrio, sin montañas ni grafo).
- *   - El colibrí 2D vuela en los TRES temas.
+ *     un toque verde tenue (sobrio, sin colibrí, sin sol/astro, sin montañas ni
+ *     grafo) — limpio crema/papel 1:1 con demo-agente-minimalista.html.
+ *   - El colibrí 2D vuela en bio-punk y nature; en minimalista NO aparece (la
+ *     escena limpia del demo no lo lleva).
  *   - Ícono del tema (THEMES[tema].icon del demo) en la marca y en el botón Ⓐ.
  *   - Toggle Campesino/Experto cableado al motor REAL `nivel_respuestas`
  *     (simple/detallado en userProfileService) — mueve el perfil de verdad y
@@ -778,16 +780,22 @@ export default function AgentHero({ onNavigate }) {
                    el toggle Campesino/Experto lo tape. */
                 .agentport-sun {
                     position: absolute;
-                    top: 8%;
-                    left: 25%;
+                    top: 9%;
+                    /* CENTRADO como el demo (.sun left:50%) — antes left:25% lo
+                       dejaba desplazado y desvaído a un lado (operador 2026-06-20:
+                       "sol como el demo"). */
+                    left: 50%;
                     transform: translateX(-50%);
                     width: 240px;
                     height: 240px;
                     border-radius: 50%;
+                    /* stops del demo (.sun: #fff4d6 0% → #ffe6a8 45% → transparente
+                       72%) — el mid-stop sólido (no .55) le da el cuerpo cálido
+                       del amanecer del demo, no un halo lavado. */
                     background: radial-gradient(
                         circle,
-                        rgba(255, 244, 214, 0.95) 0%,
-                        rgba(255, 230, 168, 0.55) 45%,
+                        #fff4d6 0%,
+                        #ffe6a8 45%,
                         rgba(255, 214, 140, 0) 72%
                     );
                     filter: blur(0.3px);
@@ -834,20 +842,26 @@ export default function AgentHero({ onNavigate }) {
                    solo se oculta cuando el cielo REAL está despejado; con
                    nube/niebla/lluvia el astro ES el que cuenta la verdad. */
                 [data-theme="nature"] .agentport-scene.is-day.sky-despejado .agentport-astro { display: none; }
+                /* minimalista: SIN astro (sol/luna) — el demo limpio no lleva
+                   ningún astro, solo el trazo botánico + horizonte (2026-06-20). */
+                [data-theme="minimalista"] .agentport-astro { display: none; }
                 .agentport-astro svg { width: 100%; height: 100%; display: block; }
                 @keyframes agentport-astro-breathe {
                     0%, 100% { opacity: .85; transform: scale(1); }
                     50% { opacity: 1; transform: scale(1.04); }
                 }
 
-                /* — MONTAÑAS 3 capas (nature) — paths exactos del demo. La
-                   banda de silueta se ancla baja en la pantalla para que las
-                   cumbres asomen detras de chips/compositor, como el demo, sin
-                   cruzar el saludo. */
+                /* — MONTAÑAS 3 capas (nature) — paths + fills exactos del demo
+                   (demo-agente.html .mtn). Ancladas al PIE (bottom:0) como el
+                   demo: la silueta llena el tercio inferior y las cumbres asoman
+                   detrás de chips/compositor — antes (bottom:18%) quedaban
+                   desvaídas/flotando a media pantalla (operador 2026-06-20:
+                   "reforzar montañas"). preserveAspectRatio:none deja que el SVG
+                   se estire a lo ancho real del teléfono, igual que el demo. */
                 .agentport-mtn {
                     position: absolute;
-                    left: 0; right: 0; bottom: 18%;
-                    height: 230px;
+                    left: 0; right: 0; bottom: 0;
+                    height: 320px;
                     display: none;
                 }
                 [data-theme="nature"] .agentport-mtn { display: block; }
@@ -973,9 +987,12 @@ export default function AgentHero({ onNavigate }) {
                     background: linear-gradient(90deg, transparent, #e3ddd0, transparent); opacity: .7;
                 }
 
-                /* ===== COLIBRÍ 2D — vuela en los 3 temas ===== */
+                /* ===== COLIBRÍ 2D — vuela en bio-punk y nature ===== */
                 /* El SVG base es ocre/teal (nature). En bio-punk recibe un glow
-                   neón vía drop-shadow; en minimal queda tenue/sobrio. */
+                   neón vía drop-shadow. En MINIMALISTA NO vuela: el demo
+                   (demo-agente-minimalista.html) es limpio crema/papel — solo el
+                   trazo botánico (.agentport-sprig) + horizonte, sin colibrí ni
+                   sol/montañas ("menos es más", operador 2026-06-20). */
                 .agentport-hummer {
                     position: absolute; top: 28%; left: 16%; z-index: 2;
                     animation: agentport-fly 18s cubic-bezier(.22,.61,.36,1) infinite;
@@ -985,8 +1002,8 @@ export default function AgentHero({ onNavigate }) {
                 /* bio-punk = tema base (sin data-theme): glow neón teal */
                 .agentport-hummer svg { filter: drop-shadow(0 0 8px rgba(25,201,154,.7)) drop-shadow(0 0 16px rgba(25,240,192,.35)); }
                 [data-theme="nature"] .agentport-hummer svg { filter: drop-shadow(0 6px 6px rgba(90,60,20,.18)); }
-                [data-theme="minimalista"] .agentport-hummer { opacity: .85; }
-                [data-theme="minimalista"] .agentport-hummer svg { filter: drop-shadow(0 4px 5px rgba(31,36,33,.14)); }
+                /* minimalista: SIN colibrí (escena limpia del demo). */
+                [data-theme="minimalista"] .agentport-hummer { display: none; }
                 .agentport-hummer .wing {
                     transform-origin: 18px 26px;
                     animation: agentport-flap .14s ease-in-out infinite alternate;
@@ -1684,7 +1701,9 @@ export default function AgentHero({ onNavigate }) {
                     <div className="agentport-horizon" />
                 </div>
 
-                {/* — COLIBRÍ 2D — vuela en los 3 temas (SVG del demo nature) — */}
+                {/* — COLIBRÍ 2D — vuela en bio-punk y nature (SVG del demo
+                     nature). En minimalista se oculta vía CSS: el demo limpio no
+                     lleva colibrí. — */}
                 <div className="agentport-hummer">
                     <HummerSvg />
                 </div>

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -1249,6 +1249,14 @@ export default function AgentHero({ onNavigate }) {
                     justify-content: flex-end;
                     overflow: hidden;
                 }
+                /* Con la mano abierta el cuerpo NO recorta: las ramas de la red
+                   bajan POR FUERA del borde inferior del cuerpo hasta el botón Ⓐ
+                   (que vive en el compositor, debajo). Sin esto, el layout de
+                   #1726 (cuerpo flex con overflow:hidden) recorta el tramo final
+                   de cada rama → "líneas que mueren en el vacío" (regresión del
+                   fix #1668). Al cerrar vuelve a hidden para que la escena
+                   ambiente no desborde el screenful. */
+                .agentport-hero-body.is-open { overflow: visible; }
 
                 /* ===================== ZONA-RESPIRO ===================== */
                 /* Espacio "respiro" donde vive la mano/red al abrir Ⓐ. El stage
@@ -1262,7 +1270,18 @@ export default function AgentHero({ onNavigate }) {
                     overflow: hidden;
                     pointer-events: none;
                 }
-                .agentport-stage.is-open { pointer-events: auto; }
+                /* Abierto: overflow VISIBLE para que las ramas viajen hasta la Ⓐ
+                   y se suelden a su disco (rimPoint en AgentRedMenu.layout). El
+                   z-index sube por encima del compositor (z 4) para que el tramo
+                   final de cada rama pinte SOBRE el borde del compositor y llegue
+                   al centro del botón — continuidad raíz↔red sin corte. El SVG es
+                   pointer-events:none, así que el tap sigue cayendo en el
+                   compositor/botón; solo el panel de la mano captura toques. */
+                .agentport-stage.is-open {
+                    pointer-events: auto;
+                    overflow: visible;
+                    z-index: 5;
+                }
 
                 .agentport-content {
                     position: relative;
@@ -1795,7 +1814,7 @@ export default function AgentHero({ onNavigate }) {
                 </section>
             )}
 
-            <div className="agentport-hero-body">
+            <div className={['agentport-hero-body', menuOpen && !menuClosing ? 'is-open' : ''].join(' ')}>
                 {/* ============ ZONA-RESPIRO (escena detrás · red Ⓐ al abrir) ============
                     Con el menú abierto, la red de capacidades BROTA aquí mismo —
                     integrada al lienzo del hero, sin sheet ni scrim. */}

--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -1249,14 +1249,19 @@ export default function AgentHero({ onNavigate }) {
                     justify-content: flex-end;
                     overflow: hidden;
                 }
-                /* Con la mano abierta el cuerpo NO recorta: las ramas de la red
-                   bajan POR FUERA del borde inferior del cuerpo hasta el botón Ⓐ
-                   (que vive en el compositor, debajo). Sin esto, el layout de
-                   #1726 (cuerpo flex con overflow:hidden) recorta el tramo final
-                   de cada rama → "líneas que mueren en el vacío" (regresión del
-                   fix #1668). Al cerrar vuelve a hidden para que la escena
+                /* Con la mano abierta el cuerpo NO recorta y se ELEVA sobre el
+                   compositor (z 4): las ramas de la red bajan POR FUERA del borde
+                   inferior del cuerpo y pintan ENCIMA del compositor hasta el
+                   centro del botón Ⓐ (que vive dentro del compositor, debajo).
+                   #1726 dejó el cuerpo en z-index:1 < compositor:4 y con
+                   overflow:hidden → el tramo final de cada rama quedaba (a)
+                   recortado por el cuerpo y (b) tapado por el fondo del
+                   compositor → "líneas que mueren en el vacío" (regresión del
+                   fix #1668). El SVG de la red es pointer-events:none, así que el
+                   compositor sigue usable (solo el panel de la mano captura
+                   toques). Al cerrar vuelve a su estado base para que la escena
                    ambiente no desborde el screenful. */
-                .agentport-hero-body.is-open { overflow: visible; }
+                .agentport-hero-body.is-open { overflow: visible; z-index: 5; }
 
                 /* ===================== ZONA-RESPIRO ===================== */
                 /* Espacio "respiro" donde vive la mano/red al abrir Ⓐ. El stage

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -906,21 +906,51 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       clearFocus: () => setFocus(null),
     };
 
+    /* Re-mide la geometría sin re-brotar (las ramas ya están vivas): solo
+       recoloca raíz/nodos a las coords actuales y pinta. Lo usa el RO del
+       botón Ⓐ y el barrido de settle: si el compositor se ancla/mueve tras la
+       animación de pliegue (#1726, transición .5s), la BASE de cada rama sigue
+       al centro real de la Ⓐ en vez de quedar suelta. */
+    function relayout() {
+      layout();
+      if (!didSprout && W > 0 && H > 0) regrow();
+      else kick(800);
+    }
+
     let ro = null;
     if (typeof ResizeObserver !== 'undefined') {
-      ro = new ResizeObserver(() => {
-        layout();
-        if (!didSprout && W > 0 && H > 0) regrow();
-        else kick(800);
-      });
+      ro = new ResizeObserver(relayout);
       ro.observe(root);
+      /* OJO: también observamos el botón Ⓐ (anchorRef). Vive en el compositor,
+         FUERA del arm-root: cuando #1726 ancla el compositor al fondo y el
+         saludo/chips se pliegan, la Ⓐ se mueve sin que el arm-root cambie de
+         tamaño → el RO de root NO dispara y la raíz quedaba desfasada. */
+      const aEl = anchorRef && anchorRef.current;
+      if (aEl) ro.observe(aEl);
     }
 
     layout();
     if (W > 0 && H > 0) regrow();
 
+    /* Barrido de "settle": tras montar la mano, el layout del hero cambia
+       (pliegue .5s, overflow visible, compositor al fondo). Forzamos un
+       recálculo en el próximo frame y a lo largo de la transición para que la
+       geometría viva atrape la posición FINAL de la Ⓐ y de los nodos. */
+    let rafSettle = null;
+    const settleTimers = [];
+    if (!reduced) {
+      rafSettle = requestAnimationFrame(() => { rafSettle = null; relayout(); });
+      [120, 280, 520].forEach((ms) => {
+        settleTimers.push(setTimeout(relayout, ms));
+      });
+    } else {
+      rafSettle = requestAnimationFrame(() => { rafSettle = null; relayout(); });
+    }
+
     return () => {
       if (rafId != null) cancelAnimationFrame(rafId);
+      if (rafSettle != null) cancelAnimationFrame(rafSettle);
+      settleTimers.forEach(clearTimeout);
       if (ro) ro.disconnect();
       sim.forEach((s) => {
         clearTimeout(s.growTimer);

--- a/src/components/dashboard/AgentRedMenu.jsx
+++ b/src/components/dashboard/AgentRedMenu.jsx
@@ -266,12 +266,8 @@ const CSS = `
 .arm-gglow path{stroke:var(--glowC);stroke-width:var(--glowW);fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gcore path{stroke:var(--branch);stroke-width:var(--coreW);fill:none;stroke-linecap:round;transition:stroke .5s}
 .arm-gcore path.lf{stroke-width:calc(var(--coreW)*.78)}
-.arm-gtwig path{stroke:var(--twigC);stroke-width:1.1px;fill:none;stroke-linecap:round;transition:stroke .5s}
-/* boca de raíz: las raicillas que asoman del botón Ⓐ — presencia subida
-   (operador 2026-06-10: "la raíz debe notarse"): color de rama pleno,
-   trazo grueso. */
-.arm-gtwig path.rt{opacity:.85;stroke-width:2.6px;stroke:var(--branch)}
-.arm-gtwig path.gd{opacity:.7;stroke-width:2.6px}
+/* (.arm-gtwig + raicillas .rt + arco de suelo .gd ELIMINADOS 2026-06-20:
+   decoración sin nodo destino que moría en el vacío). */
 @keyframes armBreathe{0%,100%{opacity:var(--glowO)}50%{opacity:calc(var(--glowO)*.55)}}
 .arm-spores{position:absolute;inset:0;z-index:2;pointer-events:none;overflow:hidden}
 .arm-sp{position:absolute;left:var(--lx);bottom:30px;width:3px;height:3px;border-radius:50%;
@@ -434,8 +430,6 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
     const tkI = root.querySelector('[data-arm="tkI"]');
     const vnO = root.querySelector('[data-arm="vnO"]');
     const vnI = root.querySelector('[data-arm="vnI"]');
-    const rootlets = root.querySelector('[data-arm="rootlets"]');
-    const ground = root.querySelector('[data-arm="ground"]');
     const hintEl = root.querySelector('[data-arm="hint"]');
 
     /* estado de simulación por grupo/hoja (paths SVG creados acá). */
@@ -699,49 +693,16 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
         s.leafOffT = s.leafAbsT.map((p) => ({ x: p.x - fp.x, y: p.y - fp.y }));
       });
 
-      /* decoración del arraigo:
-         - nature: raicillas bajo la base del tronco + arco de suelo.
-         - micorriza: boca de raicillas que brota de la Ⓐ hacia arriba-derecha
-           (largos calculados para asomar SIEMPRE sobre el borde inferior). */
-      let d = '';
-      if (treeMode) {
-        for (let k = 0; k < 5; k++) {
-          const a = Math.PI * (0.15 + 0.7 * k / 4);
-          const ex = baseT.x + Math.cos(a) * (24 + rand(k + 40) * 34);
-          const ey = baseT.y + 10 + Math.sin(a) * (16 + rand(k + 50) * 30);
-          const mx = baseT.x + (ex - baseT.x) * 0.35 + (rand(k + 60) - 0.5) * 10;
-          const my = baseT.y + 12;
-          d += `M${r1(baseT.x)} ${r1(baseT.y + 8)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
-        }
-      } else {
-        /* boca de raíz: 7 raicillas que nacen DENTRO del disco de la Ⓐ
-           (soldadas, sin gap) y asoman bien adentro del lienzo — presencia
-           subida (operador 2026-06-10). Forman un RACIMO compacto pegado al
-           botón (la raíz del organismo), NO trazos largos al vacío: el largo
-           se acota para que el grupo se lea como boca de raíz y no como líneas
-           sueltas (limpieza 2026-06-18). */
-        const depth = Math.max(0, rootPt.y - H);
-        for (let k = 0; k < 7; k++) {
-          const a = -1.38 + 1.14 * k / 6; /* -79°..-14°: hacia arriba-derecha */
-          const sx = rootPt.x + Math.cos(a) * Math.max(0, btnR - 5);
-          const sy = rootPt.y + Math.sin(a) * Math.max(0, btnR - 5);
-          /* el largo justo para asomar sobre el borde + un acento corto, con
-             tope: las raicillas casi horizontales (−sin(a) chico) no se
-             disparan a lo ancho del lienzo. */
-          const len = Math.min(
-            depth + 56,
-            (depth + 30 + rand(k + 40) * 30) / Math.max(0.45, -Math.sin(a)),
-          );
-          const ex = clampN(rootPt.x + Math.cos(a) * len, 16, W - 28);
-          const ey = rootPt.y + Math.sin(a) * len;
-          const mx = rootPt.x + (ex - rootPt.x) * 0.45 + (rand(k + 60) - 0.5) * 12;
-          const my = rootPt.y + Math.sin(a) * len * 0.45;
-          d += `M${r1(sx)} ${r1(sy)} Q${r1(mx)} ${r1(my)} ${r1(ex)} ${r1(ey)} `;
-        }
-      }
-      rootlets.setAttribute('d', d.trim());
-      ground.setAttribute('d',
-        `M${r1(cx - 108)} ${r1(baseT.y + 12)} Q${r1(cx)} ${r1(baseT.y + 26)} ${r1(cx + 108)} ${r1(baseT.y + 12)}`);
+      /* SIN decoración de arraigo sin destino (operador 2026-06-20): las
+         raicillas/"boca de raíz" (micorriza, abanico desde la Ⓐ) y el arco de
+         suelo (nature) MORÍAN en el vacío — ninguna terminaba en un nodo de
+         capacidad, así que se leían como líneas sueltas/colgantes y
+         contradecían el subtítulo "Cada rama, una capacidad conectada".
+         ELIMINADAS: ahora TODA línea visible de la red nace de la Ⓐ y muere
+         SIEMPRE en el centro de un nodo (grupo/hoja). En nature la vena
+         Ⓐ→tronco y el tronco SÍ tienen destino (la base / la copa), por eso se
+         conservan. La riqueza orgánica la dan la curva sembrada, el glow que
+         respira y las esporas. */
     }
 
     /* ── bucle rAF (con reduced-motion: un solo paint al estado final) ── */
@@ -757,7 +718,6 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
       const f = focused;
 
       gTrunk.style.display = treeMode ? '' : 'none';
-      ground.style.display = treeMode ? '' : 'none';
       if (treeMode) {
         trunkV += (trunkVT - trunkV) * kv;
         md = Math.max(md, 200 * Math.abs(trunkVT - trunkV));
@@ -1044,10 +1004,9 @@ export default function AgentRedMenu({ onPick, disabled = false, anchorRef = nul
           </g>
           <g className="arm-gglow" data-arm="gGlow" />
           <g className="arm-gcore" data-arm="gCore" />
-          <g className="arm-gtwig" data-arm="gTwig">
-            <path className="rt" data-arm="rootlets" />
-            <path className="gd" data-arm="ground" />
-          </g>
+          {/* grupo arm-gtwig (raicillas .rt + arco de suelo .gd) ELIMINADO
+              (operador 2026-06-20): eran decoración sin nodo destino —
+              líneas que morían en el vacío. */}
         </g>
       </svg>
 


### PR DESCRIPTION
## Problema (regresión P1)

En "La mano de Chagra" las ramas verdes salían SUELTAS: no nacían del botón Ⓐ ni se soldaban a su disco — "líneas que mueren en el vacío". Este bug ya lo había arreglado #1668 y VOLVIÓ tras #1726 (que cambió el layout del AgentHero).

## Causa raíz

#1726 reestructuró el AgentHero: envolvió la escena en un nuevo `.agentport-hero-body` (flex, `overflow:hidden`, `z-index:1`) y dejó el `.agentport-stage` como `position:absolute; inset:0; overflow:hidden`. El compositor (donde vive el botón Ⓐ) quedó como hermano del cuerpo, con `z-index:4`.

La geometría viva de `AgentRedMenu` (mide `getBoundingClientRect` del root y del anchor Ⓐ) seguía calculando bien las coordenadas — pero el tramo final de cada rama:
1. quedaba **recortado** por el `overflow:hidden` del cuerpo y del stage, y
2. quedaba **tapado** por el fondo del compositor, porque el cuerpo (z-index:1) estaba por DEBAJO del compositor (z-index:4).

## Fix (reconcilia SIN romper #1726)

- `AgentHero.jsx` — con la mano abierta (`.agentport-hero-body.is-open`, `.agentport-stage.is-open`): `overflow:visible` para que las ramas viajen fuera del cuerpo, y el cuerpo se ELEVA a `z-index:5` (stage z-index:5) por encima del compositor (z 4) para que el tramo final pinte ENCIMA y llegue al centro de la Ⓐ. El SVG es `pointer-events:none` → el compositor sigue usable; solo el panel de la mano captura toques. Al cerrar, vuelve al estado base (no desborda el screenful).
- `AgentRedMenu.jsx` — el `ResizeObserver` ahora observa también el botón Ⓐ (`anchorRef`), que vive en el compositor FUERA del root: cuando #1726 ancla el compositor al fondo y el saludo/chips se pliegan (transición .5s), la Ⓐ se mueve sin que el root cambie de tamaño → el RO no disparaba. Además un barrido de "settle" (rAF + 120/280/520ms) fuerza el recálculo a lo largo de la transición para atrapar la posición FINAL de la Ⓐ y los nodos.

El compositor sigue anclado al fondo (#1726) y el home queda intacto.

## Verificación (Playwright, chromium nix store, mobile 412×915, los 3 temas)

Medición de coordenadas (puntas de rama vs centro de nodo; bases vs centro de la Ⓐ):

| Tema | Mano abre | Bases en la Ⓐ | Puntas en nodos | Veredicto |
|---|---|---|---|---|
| biopunk (micorriza) | sí | 16/16 a 17px del centro (rim de la Ⓐ) | 8/8 a 0px del centro del nodo | CONECTA |
| minimalista (micorriza) | sí | 16/16 a 17px | 8/8 a 0px | CONECTA |
| nature (árbol) | sí | vena soldada a la Ⓐ a 17px (rimPoint) | 8/8 a 0px | CONECTA |

(En nature las ramas nacen del tronco y el tronco se suelda a la Ⓐ por la vena — topología de árbol, por diseño.)

Screenshots (mobile, mano abierta) — `~/ramas-shots/`:
- `biopunk.png`
- `nature.png`
- `minimal.png`

Antes (recorte, ramas muertas) vs después (soldadas a la Ⓐ): close-up del botón Ⓐ confirma las ramas convergiendo y naciendo del disco de la Ⓐ.

## Checks

- `npx vitest run AgentRedMenu* AgentHero*` → 61/61 verde.
- `eslint --rule no-undef` sobre archivos cambiados → 0 errores (warnings i18n pre-existentes, no introducidos por este PR).
- Compositor anclado al fondo (#1726) y módulos del home accesibles por scroll: intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)