### PR TITLE
fix(routing): #/ayuda abre el manual

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1205,6 +1205,12 @@ export default function App() {
             <HelpManual onBack={() => navigate('dashboard')} onNavigate={navigate} />
           </ErrorBoundary>
         );
+      case 'ayuda':
+        return (
+          <ErrorBoundary>
+            <HelpManual onBack={() => navigate('dashboard')} onNavigate={navigate} />
+          </ErrorBoundary>
+        );
       case 'agente':
         // Guard offline ANTES del dynamic import (bug offline-first 2026-06-13):
         // AgentScreen es un chunk lazy. Si se abre el agente OFFLINE con ese


### PR DESCRIPTION
Arregla el bug #70 donde la ruta #/ayuda mostraba 'Vista no disponible'.

En src/App.jsx, HASH_VIEW_ROUTES mapea ayuda→'ayuda' pero el switch de vistas solo tenía case 'help'. Por eso #/ayuda caía al default y mostraba 'Vista no disponible'.

Se agregó un case 'ayuda' que renderiza el mismo componente HelpManual que 'help', para que ambas rutas funcionen correctamente.