### PR TITLE
fix(mapa): mapeo caminando estable (filtro GPS + simplify + warm-up)

### DIFF
--- a/src/components/MapPicker.jsx
+++ b/src/components/MapPicker.jsx
@@ -2,7 +2,13 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { X, MapPin, LocateFixed, Check, Undo2, Footprints, Square, Loader2, AlertTriangle, Shield } from 'lucide-react';
-import { latLngToPoint, latLngsToPolygon } from '../utils/geo';
+import {
+  latLngToPoint,
+  latLngsToPolygon,
+  acceptGpsFix,
+  buildWalkPolygon,
+  GPS_WARMUP_ACCURACY_M,
+} from '../utils/geo';
 import useAssetStore from '../store/useAssetStore';
 import { MSG } from '../config/messages.js';
 
@@ -85,12 +91,19 @@ export const MapPicker = ({
   const mapRef = useRef(null);
   const layerRef = useRef(null); // capa de la geometría dibujada
   const watchIdRef = useRef(null); // id del watchPosition cuando traza caminando
+  const lastFixRef = useRef(null); // último fix GPS ACEPTADO (para filtro velocidad)
+  const warmedUpRef = useRef(false); // bug #57(c): ¿el GPS ya convergió y arrancamos a trazar?
   const [points, setPoints] = useState([]); // polígono en construcción
   const [marker, setMarker] = useState(null); // punto actual
   // Modo "trazar caminando": usa navigator.geolocation.watchPosition para
   // ir sumando vertices al polígono mientras el operario recorre el
   // perimetro del area (ej. un invernadero). Solo disponible en mode=polygon.
   const [isWalking, setIsWalking] = useState(false);
+  // Bug #57(c): warm-up del GPS. Mientras true, ignoramos los fixes (cold-start
+  // A-GPS impreciso) y mostramos "Afinando GPS…"; empezamos a trazar al primer
+  // fix por debajo de GPS_WARMUP_ACCURACY_M.
+  const [gpsWarmingUp, setGpsWarmingUp] = useState(false);
+  const [walkAccuracy, setWalkAccuracy] = useState(null); // accuracy del último fix entrante
   // Estado machine GPS: idle → locating → located | low-accuracy | failed.
   // Renderizado como banner persistente arriba del mapa para que el operador
   // sepa qué está pasando, antes "Mi ubicación" silenciaba errores y el
@@ -129,12 +142,16 @@ export const MapPicker = ({
 
     mapRef.current = map;
 
-    // Pre-cargar geometría inicial si existe
+    // Pre-cargar geometría inicial si existe. setState aquí es un sync de una
+    // sola vez al montar (espejo de la geometría externa pre-cargada hacia el
+    // estado de React, ADR-015 pattern). No genera cascada porque corre una
+    // única vez en el init effect — disable puntual justificado.
     if (initial) {
       if (initial.type === 'Point') {
         const [lng, lat] = initial.coordinates;
         const m = L.marker([lat, lng]).addTo(map);
         layerRef.current = m;
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setMarker({ lat, lng });
         map.setView([lat, lng], DEFAULT_ZOOM);
       } else if (initial.type === 'Polygon') {
@@ -176,6 +193,8 @@ export const MapPicker = ({
         navigator.geolocation.clearWatch(watchIdRef.current);
         watchIdRef.current = null;
       }
+      lastFixRef.current = null;
+      warmedUpRef.current = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -209,6 +228,23 @@ export const MapPicker = ({
         watchIdRef.current = null;
       }
       setIsWalking(false);
+      setGpsWarmingUp(false);
+      // Al detener: simplificar/limpiar el recorrido para evitar el "polígono
+      // rayado" (síntoma b). Reemplazamos la polilínea por el anillo limpio.
+      setPoints((prev) => {
+        const cleaned = buildWalkPolygon(prev);
+        const map = mapRef.current;
+        if (map && layerRef.current) {
+          map.removeLayer(layerRef.current);
+          layerRef.current = null;
+        }
+        if (map && cleaned.length >= 3) {
+          layerRef.current = L.polygon(cleaned, { color: '#10b981', fillOpacity: 0.2, weight: 3 }).addTo(map);
+        } else if (map && cleaned.length >= 2) {
+          layerRef.current = L.polyline(cleaned, { color: '#10b981', weight: 4, opacity: 0.85 }).addTo(map);
+        }
+        return cleaned;
+      });
       return;
     }
     if (!navigator.geolocation) {
@@ -220,16 +256,50 @@ export const MapPicker = ({
     const startWatch = (highAccuracy) => {
       // Limpia cualquier vertice previo y arranca la captura
       setPoints([]);
+      lastFixRef.current = null;
+      warmedUpRef.current = false;
+      setWalkAccuracy(null);
       const map = mapRef.current;
       if (layerRef.current) {
         map.removeLayer(layerRef.current);
         layerRef.current = null;
       }
       setIsWalking(true);
+      // Bug #57(c): arrancamos en warm-up — no trazamos hasta que el GPS
+      // converja. El banner muestra "Afinando GPS…".
+      setGpsWarmingUp(true);
       setGpsError(null);
       watchIdRef.current = navigator.geolocation.watchPosition(
         (pos) => {
-          const latlng = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+          const accuracy = pos.coords.accuracy;
+          const fix = {
+            lat: pos.coords.latitude,
+            lng: pos.coords.longitude,
+            accuracy,
+            timestamp: pos.timestamp,
+          };
+          setWalkAccuracy(Number.isFinite(accuracy) ? accuracy : null);
+
+          // Bug #57(c) warm-up: ignorar fixes hasta que el GPS sea aceptable.
+          // El primer fix bueno levanta el warm-up y se convierte en el ancla.
+          if (!warmedUpRef.current) {
+            if (Number.isFinite(accuracy) && accuracy > GPS_WARMUP_ACCURACY_M) {
+              map.panTo([fix.lat, fix.lng]); // sigue al usuario pero no traza
+              return;
+            }
+            warmedUpRef.current = true;
+            setGpsWarmingUp(false);
+          }
+
+          // Bug #57(a): filtrar línea loca — descartar fixes imprecisos y
+          // saltos a velocidad imposible respecto al último vértice aceptado.
+          const verdict = acceptGpsFix(fix, lastFixRef.current);
+          if (!verdict.accepted) {
+            map.panTo([fix.lat, fix.lng]);
+            return;
+          }
+          lastFixRef.current = fix;
+          const latlng = { lat: fix.lat, lng: fix.lng };
           setPoints((prev) => {
             const next = [...prev, latlng];
             if (layerRef.current) map.removeLayer(layerRef.current);
@@ -249,6 +319,7 @@ export const MapPicker = ({
           setGpsStatus('failed');
           setGpsError(msg);
           setIsWalking(false);
+          setGpsWarmingUp(false);
           if (watchIdRef.current !== null) {
             navigator.geolocation.clearWatch(watchIdRef.current);
             watchIdRef.current = null;
@@ -287,15 +358,22 @@ export const MapPicker = ({
         setGpsStatus('failed');
         setGpsError(msg);
       },
-      { enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 },
+      // maximumAge: 0 — el pre-flight de "caminar" NO debe aceptar un fix
+      // cacheado/grueso como ancla del polígono (bug #57(c) primera corrida).
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 },
     );
   };
 
   const handleFinishPolygon = () => {
     if (points.length < 3) return;
     const map = mapRef.current;
+    // Bug #57(b): limpiar el recorrido antes de cerrar para evitar el
+    // "polígono rayado" (auto-intersección por jitter).
+    const cleaned = buildWalkPolygon(points);
+    if (cleaned.length >= 3) setPoints(cleaned);
+    const ring = cleaned.length >= 3 ? cleaned : points;
     if (layerRef.current) map.removeLayer(layerRef.current);
-    const poly = L.polygon(points, { color: '#3b82f6', fillOpacity: 0.2 }).addTo(map);
+    const poly = L.polygon(ring, { color: '#3b82f6', fillOpacity: 0.2 }).addTo(map);
     layerRef.current = poly;
   };
 
@@ -393,7 +471,12 @@ export const MapPicker = ({
       onSave(latLngToPoint(marker));
     } else if (mode === 'polygon') {
       if (points.length < 3) return;
-      onSave(latLngsToPolygon(points));
+      // Bug #57(b): red de seguridad final — dedup + simplify antes de
+      // serializar para no persistir un anillo auto-intersectado. Si el
+      // resultado degenera (<3 vértices), caemos a los puntos crudos.
+      const cleaned = buildWalkPolygon(points);
+      const ring = cleaned.length >= 3 ? cleaned : points;
+      onSave(latLngsToPolygon(ring));
     }
   };
 
@@ -429,6 +512,22 @@ export const MapPicker = ({
           <X size={20} />
         </button>
       </div>
+
+      {/* Bug #57(c): warm-up del GPS al trazar caminando. Mientras afina, no
+          trazamos; mostramos progreso de precisión para que el operador espere. */}
+      {isWalking && gpsWarmingUp && (
+        <div className="px-4 py-2 text-xs flex items-center gap-2 border-b border-slate-800 bg-amber-900/30 text-amber-300">
+          <Loader2 size={14} className="animate-spin shrink-0" />
+          <span className="flex-1">
+            {MSG.ui.gpsAfinando}
+            {Number.isFinite(walkAccuracy) && (
+              <span className="font-mono ml-1">
+                (±{Math.round(walkAccuracy)}m → ±{GPS_WARMUP_ACCURACY_M}m)
+              </span>
+            )}
+          </span>
+        </div>
+      )}
 
       {/* GPS status banner, siempre visible para no silenciar errores. */}
       {gpsStatus !== 'idle' && (

--- a/src/config/messages.js
+++ b/src/config/messages.js
@@ -154,6 +154,8 @@ const messages = {
     errorGpsNoDisponibleDetalle: 'GPS no disponible. Verifica que el GPS esté activo y que estés al exterior (no en sótano / lejos de ventana).',
     errorUbicacion: 'No se pudo obtener tu ubicación.',
     errorTimeout: 'Tiempo agotado esperando al GPS (30s). En iPhone, el GPS puede tardar más al aire libre — espera unos segundos y vuelve a tocar "Mi ubicación".',
+    // Bug #57 — trazar caminando: warm-up del GPS antes de empezar el trazo.
+    gpsAfinando: 'Afinando GPS… espera a que la señal mejore.',
     confirmarAbastecer: 'Confirmar',
     registrando: 'Registrando…',
   },

--- a/src/utils/__tests__/geo.test.js
+++ b/src/utils/__tests__/geo.test.js
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { geoJsonToWkt, closeRing, latLngToPoint, latLngsToPolygon, wktToGeoJson } from '../geo.js';
+import {
+  geoJsonToWkt,
+  closeRing,
+  latLngToPoint,
+  latLngsToPolygon,
+  wktToGeoJson,
+  haversineMeters,
+  acceptGpsFix,
+  dedupeByMinDistance,
+  simplifyDouglasPeucker,
+  polygonAreaSqMeters,
+  buildWalkPolygon,
+  GPS_ACCURACY_THRESHOLD_M,
+  GPS_MIN_VERTEX_DISTANCE_M,
+} from '../geo.js';
 
 describe('geoJsonToWkt', () => {
   it('convierte Point a WKT', () => {
@@ -88,5 +102,240 @@ describe('wktToGeoJson', () => {
     expect(wktToGeoJson('')).toBeNull();
     expect(wktToGeoJson(null)).toBeNull();
     expect(wktToGeoJson('GARBAGE')).toBeNull();
+  });
+});
+
+// --- Bug #57: mapeo caminando estable ------------------------------------
+
+describe('haversineMeters', () => {
+  it('mide ~0 para el mismo punto', () => {
+    const p = { lat: 4.5306, lng: -73.9247 };
+    expect(haversineMeters(p, p)).toBeCloseTo(0, 5);
+  });
+
+  it('mide ~111m por ~0.001° de latitud', () => {
+    const a = { lat: 4.53, lng: -73.92 };
+    const b = { lat: 4.531, lng: -73.92 };
+    // 0.001° lat ≈ 111.32 m
+    expect(haversineMeters(a, b)).toBeGreaterThan(105);
+    expect(haversineMeters(a, b)).toBeLessThan(118);
+  });
+
+  it('es simétrica', () => {
+    const a = { lat: 4.53, lng: -73.92 };
+    const b = { lat: 4.54, lng: -73.93 };
+    expect(haversineMeters(a, b)).toBeCloseTo(haversineMeters(b, a), 6);
+  });
+
+  it('retorna 0 con argumentos faltantes', () => {
+    expect(haversineMeters(null, { lat: 1, lng: 1 })).toBe(0);
+  });
+});
+
+describe('acceptGpsFix — síntoma (a) línea loca', () => {
+  it('acepta el primer fix preciso sin previo', () => {
+    const r = acceptGpsFix({ lat: 4.53, lng: -73.92, accuracy: 8, timestamp: 1000 }, null);
+    expect(r.accepted).toBe(true);
+  });
+
+  it('descarta fix con accuracy peor que el umbral', () => {
+    const r = acceptGpsFix(
+      { lat: 4.53, lng: -73.92, accuracy: GPS_ACCURACY_THRESHOLD_M + 50, timestamp: 1000 },
+      null,
+    );
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('accuracy');
+  });
+
+  it('acepta fix justo en el umbral', () => {
+    const r = acceptGpsFix(
+      { lat: 4.53, lng: -73.92, accuracy: GPS_ACCURACY_THRESHOLD_M, timestamp: 1000 },
+      null,
+    );
+    expect(r.accepted).toBe(true);
+  });
+
+  it('descarta salto a velocidad imposible (distancia/tiempo)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
+    // ~111m en 1s = 111 m/s ≫ caminata → rechazado
+    const fix = { lat: 4.531, lng: -73.92, accuracy: 8, timestamp: 2000 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('speed');
+  });
+
+  it('acepta un paso realista al caminar (~1.4 m/s)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
+    // ~1.4m en 1s
+    const fix = { lat: 4.5300126, lng: -73.92, accuracy: 8, timestamp: 2000 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(true);
+    expect(r.distance).toBeGreaterThan(0);
+  });
+
+  it('descarta coordenadas no finitas', () => {
+    expect(acceptGpsFix({ lat: NaN, lng: -73.92 }, null).accepted).toBe(false);
+    expect(acceptGpsFix(null, null).accepted).toBe(false);
+  });
+
+  it('acepta fix sin accuracy reportada (navegador la omite)', () => {
+    const r = acceptGpsFix({ lat: 4.53, lng: -73.92, timestamp: 1000 }, null);
+    expect(r.accepted).toBe(true);
+  });
+});
+
+describe('dedupeByMinDistance — síntoma (b) jitter casi-duplicado', () => {
+  it('colapsa puntos a menos de la distancia mínima', () => {
+    const jitter = [
+      { lat: 4.53, lng: -73.92 },
+      { lat: 4.5300001, lng: -73.92 }, // ~0.1m
+      { lat: 4.5300002, lng: -73.92 }, // ~0.2m
+      { lat: 4.531, lng: -73.92 }, // ~111m
+    ];
+    const out = dedupeByMinDistance(jitter);
+    expect(out.length).toBe(2);
+  });
+
+  it('preserva puntos suficientemente separados', () => {
+    const pts = [
+      { lat: 4.53, lng: -73.92 },
+      { lat: 4.531, lng: -73.92 },
+      { lat: 4.532, lng: -73.92 },
+    ];
+    expect(dedupeByMinDistance(pts).length).toBe(3);
+  });
+
+  it('retorna vacio para entrada vacia', () => {
+    expect(dedupeByMinDistance([])).toEqual([]);
+    expect(dedupeByMinDistance(null)).toEqual([]);
+  });
+});
+
+describe('simplifyDouglasPeucker — síntoma (b) reducir lados que se cruzan', () => {
+  it('elimina puntos colineales dentro de la tolerancia', () => {
+    const line = [
+      { lat: 4.530, lng: -73.92 },
+      { lat: 4.5305, lng: -73.92 }, // medio, sobre la recta
+      { lat: 4.531, lng: -73.92 },
+    ];
+    const out = simplifyDouglasPeucker(line, 2);
+    expect(out.length).toBe(2);
+  });
+
+  it('conserva un vértice que se desvía más que la tolerancia', () => {
+    const corner = [
+      { lat: 4.530, lng: -73.92 },
+      { lat: 4.5305, lng: -73.9195 }, // pico que se desvía ~55m
+      { lat: 4.531, lng: -73.92 },
+    ];
+    const out = simplifyDouglasPeucker(corner, 2);
+    expect(out.length).toBe(3);
+  });
+
+  it('devuelve la entrada si tiene 2 o menos puntos', () => {
+    const two = [{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }];
+    expect(simplifyDouglasPeucker(two, 2).length).toBe(2);
+  });
+});
+
+describe('polygonAreaSqMeters', () => {
+  it('calcula el área de un cuadrado de ~111m de lado (~12000 m²)', () => {
+    // 0.001° ≈ 111m → área ≈ 111 * 111 ≈ 12300 m²
+    const square = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.530, lng: -73.919 },
+      { lat: 4.531, lng: -73.919 },
+      { lat: 4.531, lng: -73.920 },
+    ];
+    const area = polygonAreaSqMeters(square);
+    expect(area).toBeGreaterThan(11000);
+    expect(area).toBeLessThan(13500);
+  });
+
+  it('es independiente de la orientación (CW vs CCW)', () => {
+    const cw = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.531, lng: -73.920 },
+      { lat: 4.531, lng: -73.919 },
+      { lat: 4.530, lng: -73.919 },
+    ];
+    const ccw = [...cw].reverse();
+    expect(polygonAreaSqMeters(cw)).toBeCloseTo(polygonAreaSqMeters(ccw), 2);
+  });
+
+  it('retorna 0 para un anillo degenerado (línea)', () => {
+    const line = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.531, lng: -73.920 },
+      { lat: 4.532, lng: -73.920 },
+    ];
+    expect(polygonAreaSqMeters(line)).toBeCloseTo(0, 0);
+  });
+
+  it('retorna 0 con menos de 3 puntos', () => {
+    expect(polygonAreaSqMeters([{ lat: 0, lng: 0 }])).toBe(0);
+  });
+});
+
+describe('buildWalkPolygon — recorrido caminado → anillo estable', () => {
+  it('limpia jitter y conserva las esquinas del lote', () => {
+    // Recorrido de un cuadrado con jitter denso en cada lado.
+    const corners = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9200 },
+    ];
+    const walk = [];
+    for (let c = 0; c < corners.length; c += 1) {
+      const a = corners[c];
+      const b = corners[(c + 1) % corners.length];
+      for (let t = 0; t <= 1; t += 0.1) {
+        walk.push({
+          lat: a.lat + (b.lat - a.lat) * t + (Math.random() - 0.5) * 1e-6,
+          lng: a.lng + (b.lng - a.lng) * t + (Math.random() - 0.5) * 1e-6,
+        });
+      }
+    }
+    const ring = buildWalkPolygon(walk);
+    // 4 esquinas reales (sin cierre duplicado).
+    expect(ring.length).toBeGreaterThanOrEqual(4);
+    expect(ring.length).toBeLessThan(walk.length); // simplificó
+    // El polígono resultante tiene área coherente (no colapsado).
+    expect(polygonAreaSqMeters(ring)).toBeGreaterThan(11000);
+  });
+
+  it('no deja el primer punto duplicado al final (cierre lo hace closeRing)', () => {
+    const square = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9200 },
+      { lat: 4.53000005, lng: -73.92000005 }, // regreso al inicio (~paso corto)
+    ];
+    const ring = buildWalkPolygon(square);
+    const f = ring[0];
+    const l = ring[ring.length - 1];
+    expect(haversineMeters(f, l)).toBeGreaterThanOrEqual(GPS_MIN_VERTEX_DISTANCE_M);
+  });
+
+  it('devuelve la entrada sin tocar si tiene menos de 3 puntos', () => {
+    const two = [{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }];
+    expect(buildWalkPolygon(two).length).toBe(2);
+  });
+
+  it('el anillo limpio serializa a un Polygon WKT cerrado válido', () => {
+    const square = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9200 },
+    ];
+    const ring = buildWalkPolygon(square);
+    const wkt = geoJsonToWkt(latLngsToPolygon(ring));
+    expect(wkt).toContain('POLYGON');
+    // closeRing añade el cierre → primer == último en el WKT.
+    const coords = wkt.match(/POLYGON\(\((.+)\)\)/)[1].split(',').map((s) => s.trim());
+    expect(coords[0]).toBe(coords[coords.length - 1]);
   });
 });

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -17,6 +17,254 @@ const PRECISION = 7;
 
 const fmt = (n) => Number.parseFloat(n).toFixed(PRECISION);
 
+// --- Constantes de filtrado GPS para "trazar caminando" (bug #57) --------
+//
+// El campesino recorre el borde del lote a pie con el GPS del teléfono.
+// El stream de watchPosition trae ruido que rompía el trazo de tres formas:
+//   (a) "línea loca": fixes con accuracy mala saltan erráticos.
+//   (b) "polígono rayado": puntos casi-duplicados + orden ruidoso →
+//       auto-intersección al cerrar el anillo.
+//   (c) "precisión 1ª corrida": el primer fix (cold-start A-GPS) es grueso
+//       y ancla el polígono en un punto equivocado.
+//
+// Umbrales conservadores pensados para un teléfono al aire libre caminando:
+
+// Accuracy peor que esto (en metros) → descartamos el fix. GPS de smartphone
+// a cielo abierto da 5-15m; >25m suele ser triangulación de celda/wifi.
+export const GPS_ACCURACY_THRESHOLD_M = 25;
+
+// Accuracy exigida durante el "warm-up": no empezamos a trazar hasta que el
+// GPS converja por debajo de esto. Más estricto que el umbral de descarte
+// para que el primer vértice del polígono sea sólido (síntoma c).
+export const GPS_WARMUP_ACCURACY_M = 20;
+
+// Velocidad humana caminando ≈ 1.4 m/s. Por encima de este techo el "salto"
+// entre dos fixes consecutivos es físicamente imposible a pie → ruido GPS.
+export const GPS_MAX_WALK_SPEED_MPS = 5; // ~18 km/h, holgado para trote/jitter
+
+// Distancia mínima entre vértices conservados. Pasos más cortos que esto se
+// consideran el mismo punto (dedup) y solo engordan el anillo con jitter.
+export const GPS_MIN_VERTEX_DISTANCE_M = 3;
+
+// Tolerancia por defecto de Douglas-Peucker para simplificar el recorrido.
+export const GPS_SIMPLIFY_TOLERANCE_M = 2;
+
+const EARTH_RADIUS_M = 6371008.8; // radio medio WGS-84
+const DEG2RAD = Math.PI / 180;
+
+/**
+ * Distancia haversine en metros entre dos puntos {lat, lng}.
+ * Suficientemente precisa a escala de un lote (errores < 0.5% por debajo de
+ * unos pocos km, despreciable para agricultura).
+ *
+ * @param {{lat:number,lng:number}} a
+ * @param {{lat:number,lng:number}} b
+ * @returns {number} distancia en metros.
+ */
+export const haversineMeters = (a, b) => {
+  if (!a || !b) return 0;
+  const lat1 = a.lat * DEG2RAD;
+  const lat2 = b.lat * DEG2RAD;
+  const dLat = (b.lat - a.lat) * DEG2RAD;
+  const dLng = (b.lng - a.lng) * DEG2RAD;
+  const sinDLat = Math.sin(dLat / 2);
+  const sinDLng = Math.sin(dLng / 2);
+  const h = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLng * sinDLng;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.min(1, Math.sqrt(h)));
+};
+
+/**
+ * Decide si un fix GPS entrante debe aceptarse durante el trazo caminando.
+ *
+ * Filtra el síntoma (a) "línea loca": descarta fixes imprecisos y saltos a
+ * velocidad imposible respecto al último vértice aceptado.
+ *
+ * @param {{lat:number,lng:number,accuracy?:number,timestamp?:number}} fix
+ * @param {{lat:number,lng:number,timestamp?:number}|null} prev - último fix aceptado.
+ * @param {object} [opts]
+ * @param {number} [opts.accuracyThreshold=GPS_ACCURACY_THRESHOLD_M]
+ * @param {number} [opts.maxSpeed=GPS_MAX_WALK_SPEED_MPS]
+ * @returns {{accepted:boolean, reason:string|null, distance:number}}
+ */
+export const acceptGpsFix = (fix, prev, opts = {}) => {
+  const accuracyThreshold = opts.accuracyThreshold ?? GPS_ACCURACY_THRESHOLD_M;
+  const maxSpeed = opts.maxSpeed ?? GPS_MAX_WALK_SPEED_MPS;
+
+  if (!fix || !Number.isFinite(fix.lat) || !Number.isFinite(fix.lng)) {
+    return { accepted: false, reason: 'invalid', distance: 0 };
+  }
+  // accuracy ausente: el navegador no la reportó. Tratamos como sospechosa
+  // pero no la descartamos por sí sola (algunos navegadores la omiten).
+  if (Number.isFinite(fix.accuracy) && fix.accuracy > accuracyThreshold) {
+    return { accepted: false, reason: 'accuracy', distance: 0 };
+  }
+  if (!prev) {
+    return { accepted: true, reason: null, distance: 0 };
+  }
+
+  const distance = haversineMeters(prev, fix);
+  // Salto imposible: distancia/tiempo → velocidad irreal. Solo lo evaluamos
+  // si tenemos timestamps consistentes; si no, caemos a un tope de distancia.
+  const dtMs =
+    Number.isFinite(fix.timestamp) && Number.isFinite(prev.timestamp)
+      ? fix.timestamp - prev.timestamp
+      : null;
+  if (dtMs != null && dtMs > 0) {
+    const speed = distance / (dtMs / 1000); // m/s
+    if (speed > maxSpeed) {
+      return { accepted: false, reason: 'speed', distance };
+    }
+  }
+  return { accepted: true, reason: null, distance };
+};
+
+/**
+ * Elimina puntos consecutivos separados por menos de `minDistance` metros.
+ *
+ * Combate el síntoma (b): el jitter del GPS estando quieto genera decenas de
+ * vértices casi-coincidentes que, al cerrar el anillo, se cruzan entre sí.
+ *
+ * @param {Array<{lat:number,lng:number}>} points
+ * @param {number} [minDistance=GPS_MIN_VERTEX_DISTANCE_M]
+ * @returns {Array<{lat:number,lng:number}>} copia filtrada.
+ */
+export const dedupeByMinDistance = (points, minDistance = GPS_MIN_VERTEX_DISTANCE_M) => {
+  if (!Array.isArray(points) || points.length === 0) return [];
+  const out = [points[0]];
+  for (let i = 1; i < points.length; i += 1) {
+    if (haversineMeters(out[out.length - 1], points[i]) >= minDistance) {
+      out.push(points[i]);
+    }
+  }
+  return out;
+};
+
+// Distancia perpendicular (en metros) del punto p al segmento a-b, usando una
+// proyección equirectangular local. A escala de lote el error es despreciable.
+const perpendicularDistanceM = (p, a, b) => {
+  const latRef = (a.lat + b.lat) / 2 * DEG2RAD;
+  const mPerDegLat = 111132.92; // aprox a latitudes medias
+  const mPerDegLng = 111412.84 * Math.cos(latRef);
+  const toXY = (pt) => ({ x: pt.lng * mPerDegLng, y: pt.lat * mPerDegLat });
+  const P = toXY(p);
+  const A = toXY(a);
+  const B = toXY(b);
+  const dx = B.x - A.x;
+  const dy = B.y - A.y;
+  const lenSq = dx * dx + dy * dy;
+  if (lenSq === 0) return Math.hypot(P.x - A.x, P.y - A.y);
+  const t = ((P.x - A.x) * dx + (P.y - A.y) * dy) / lenSq;
+  const tc = Math.max(0, Math.min(1, t));
+  const projX = A.x + tc * dx;
+  const projY = A.y + tc * dy;
+  return Math.hypot(P.x - projX, P.y - projY);
+};
+
+/**
+ * Simplifica una polilínea con Douglas-Peucker, tolerancia en metros.
+ *
+ * Reduce los vértices manteniendo la forma → menos lados que se puedan cruzar
+ * (síntoma b) y un anillo más limpio para persistir.
+ *
+ * @param {Array<{lat:number,lng:number}>} points
+ * @param {number} [toleranceM=GPS_SIMPLIFY_TOLERANCE_M]
+ * @returns {Array<{lat:number,lng:number}>}
+ */
+export const simplifyDouglasPeucker = (points, toleranceM = GPS_SIMPLIFY_TOLERANCE_M) => {
+  if (!Array.isArray(points) || points.length <= 2) {
+    return Array.isArray(points) ? [...points] : [];
+  }
+  const first = 0;
+  const last = points.length - 1;
+  let maxDist = 0;
+  let index = -1;
+  for (let i = first + 1; i < last; i += 1) {
+    const d = perpendicularDistanceM(points[i], points[first], points[last]);
+    if (d > maxDist) {
+      maxDist = d;
+      index = i;
+    }
+  }
+  if (maxDist > toleranceM && index !== -1) {
+    const left = simplifyDouglasPeucker(points.slice(first, index + 1), toleranceM);
+    const right = simplifyDouglasPeucker(points.slice(index, last + 1), toleranceM);
+    return [...left.slice(0, -1), ...right];
+  }
+  return [points[first], points[last]];
+};
+
+/**
+ * Área (en metros cuadrados) de un anillo de coordenadas {lat,lng} usando la
+ * fórmula del shoelace sobre una proyección equirectangular local. Devuelve
+ * el valor absoluto (independiente de la orientación del anillo).
+ *
+ * Útil para validar el polígono (área ~0 → degenerado / colapsado).
+ *
+ * @param {Array<{lat:number,lng:number}>} ring - abierto o cerrado.
+ * @returns {number} área en m², 0 si el anillo es degenerado.
+ */
+export const polygonAreaSqMeters = (ring) => {
+  if (!Array.isArray(ring) || ring.length < 3) return 0;
+  // Trabajar sobre el anillo cerrado para el shoelace.
+  const pts = ring.slice();
+  const f = pts[0];
+  const l = pts[pts.length - 1];
+  if (f.lat !== l.lat || f.lng !== l.lng) pts.push(f);
+  const latRef = (pts.reduce((s, p) => s + p.lat, 0) / pts.length) * DEG2RAD;
+  const mPerDegLat = 111132.92;
+  const mPerDegLng = 111412.84 * Math.cos(latRef);
+  let sum = 0;
+  for (let i = 0; i < pts.length - 1; i += 1) {
+    const x1 = pts[i].lng * mPerDegLng;
+    const y1 = pts[i].lat * mPerDegLat;
+    const x2 = pts[i + 1].lng * mPerDegLng;
+    const y2 = pts[i + 1].lat * mPerDegLat;
+    sum += x1 * y2 - x2 * y1;
+  }
+  return Math.abs(sum) / 2;
+};
+
+/**
+ * Limpia el recorrido caminado a un anillo de polígono estable y listo para
+ * persistir: dedup por distancia mínima + simplificación Douglas-Peucker.
+ *
+ * No reordena los puntos: el orden de recorrido a pie YA describe el perímetro;
+ * reordenar (p. ej. por ángulo respecto al centroide) rompería lotes cóncavos.
+ * La auto-intersección del síntoma (b) venía del jitter (puntos casi-duplicados
+ * y micro-zigzags), que dedup + simplify eliminan.
+ *
+ * Devuelve los vértices SIN cerrar (el cierre del anillo lo hace closeRing /
+ * latLngsToPolygon al serializar) para no duplicar el primer punto dos veces.
+ *
+ * @param {Array<{lat:number,lng:number}>} points - vértices ya filtrados por accuracy.
+ * @param {object} [opts]
+ * @param {number} [opts.minDistance=GPS_MIN_VERTEX_DISTANCE_M]
+ * @param {number} [opts.toleranceM=GPS_SIMPLIFY_TOLERANCE_M]
+ * @returns {Array<{lat:number,lng:number}>}
+ */
+export const buildWalkPolygon = (points, opts = {}) => {
+  if (!Array.isArray(points) || points.length < 3) {
+    return Array.isArray(points) ? [...points] : [];
+  }
+  const minDistance = opts.minDistance ?? GPS_MIN_VERTEX_DISTANCE_M;
+  const toleranceM = opts.toleranceM ?? GPS_SIMPLIFY_TOLERANCE_M;
+
+  let ring = dedupeByMinDistance(points, minDistance);
+  ring = simplifyDouglasPeucker(ring, toleranceM);
+
+  // Si dedup/simplify dejaron el primer y último punto coincidentes (el
+  // recorrido volvió al inicio), quitamos el duplicado de cola: el cierre lo
+  // añade el serializador. Así evitamos un anillo con el inicio repetido 2×.
+  if (ring.length > 1) {
+    const f = ring[0];
+    const l = ring[ring.length - 1];
+    if (haversineMeters(f, l) < minDistance) {
+      ring = ring.slice(0, -1);
+    }
+  }
+  return ring;
+};
+
 // GeoJSON coordenadas: [lon, lat]. WKT: "lon lat" (sin coma).
 const coordToWkt = ([lon, lat]) => `${fmt(lon)} ${fmt(lat)}`;
 


### PR DESCRIPTION
## Resumen

Bug del **mapeo caminando** (#57): el campesino recorre el borde del lote a pie y el mapa queda mal. Tres síntomas, atacados en `src/utils/geo.js` (con TDD) y cableados en `MapPicker.jsx`.

## Cambios por síntoma

### (a) "línea loca" — track salta errático
- **`acceptGpsFix(fix, prev)`** (nuevo, geo.js): descarta cada fix entrante si
  - `accuracy` peor que **25 m** (`GPS_ACCURACY_THRESHOLD_M`) — triangulación de celda/wifi, no GPS real.
  - el salto respecto al último vértice aceptado implica una **velocidad imposible a pie** (> 5 m/s vía `distancia/tiempo` con haversine).
- En `MapPicker` el `watchPosition` solo añade vértices aceptados; los rechazados solo hacen `panTo` (sigue al usuario sin ensuciar el trazo).

### (b) "polígono rayado" — anillo cruzado / auto-intersectado
- **`dedupeByMinDistance`** (≥ 3 m) elimina el jitter de estar quieto (decenas de puntos casi-coincidentes).
- **`simplifyDouglasPeucker`** (tolerancia 2 m, distancias en metros vía proyección local) reduce micro-zigzags.
- **`buildWalkPolygon`** orquesta dedup + simplify y quita el duplicado de cola (el cierre del anillo lo hace `closeRing`, sin repetir el inicio). Se aplica al **detener** el trazo, al **cerrar polígono** y como **red de seguridad en guardar**.
- NO reordena los puntos: el orden de recorrido a pie ya describe el perímetro (reordenar rompería lotes cóncavos).

### (c) "precisión 1ª corrida" — primer fix grueso arruina el arranque
- **Warm-up del GPS**: al pulsar "Caminar" entramos en modo afinado; ignoramos los fixes hasta que `accuracy` baje de **20 m** (`GPS_WARMUP_ACCURACY_M`) antes de anclar el primer vértice.
- Banner **"Afinando GPS…"** con progreso de precisión (`±Xm → ±20m`), mobile-first.
- Pre-flight con `maximumAge: 0` para no anclar el polígono en un fix cacheado/grueso.

## TDD

`src/utils/__tests__/geo.test.js`: **37 tests** (haversine, accuracy/speed filter, dedup, Douglas-Peucker, área shoelace, build end-to-end → WKT cerrado válido). Casos pensados para teléfono al aire libre caminando.

## Verificación local

- `npx vitest run src/utils/__tests__/geo.test.js` → **37/37 pass**
- `useGeolocation.ios.test.jsx` → 7/7 pass (sin regresión)
- `eslint --max-warnings=0` sobre archivos cambiados → **0 errores 0 warnings** (incl. `no-undef`)
- `npm run build` → OK (5.16s)
- Scans SOP §2 (secret / voseo / infra refs) → limpios

> Nota: el bug se identifica como "#57" del mapeo caminando a nivel de tarea; la issue GitHub #57 de este repo es un fix de lint ya mergeado (homónimo numérico, sin relación).

🤖 Generated with [Claude Code](https://claude.com/claude-code)