### PR TITLE
fix(ui): legibilidad/contraste GLOBAL por tema

### DIFF
--- a/src/components/AIBetaBadge.jsx
+++ b/src/components/AIBetaBadge.jsx
@@ -42,13 +42,13 @@ function getLevel(confidence) {
 const LEVEL_CONFIG = {
     default: {
         text: 'beta',
-        classes: 'bg-slate-500/20 text-slate-400 border-slate-600/40',
+        classes: 'ai-badge-default',
         defaultTooltip: 'Respuesta generada por IA — verifica antes de actuar.',
         icon: null,
     },
     high: {
         text: 'verificado',
-        classes: 'bg-emerald-500/20 text-emerald-300 border-emerald-600/40',
+        classes: 'ai-badge-high',
         defaultTooltip: 'Alta confianza — respaldado por el catálogo Chagra.',
         // SVG inline check (sin lucide para no inflar bundle del badge)
         icon: (
@@ -59,7 +59,7 @@ const LEVEL_CONFIG = {
     },
     mid: {
         text: 'probable',
-        classes: 'bg-amber-500/20 text-amber-300 border-amber-600/40',
+        classes: 'ai-badge-mid',
         defaultTooltip: 'Confianza media — útil de referencia, contrasta con un técnico.',
         icon: (
             <svg viewBox="0 0 16 16" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -71,7 +71,7 @@ const LEVEL_CONFIG = {
     },
     low: {
         text: 'verifica',
-        classes: 'bg-rose-500/20 text-rose-300 border-rose-600/40',
+        classes: 'ai-badge-low',
         defaultTooltip: 'Baja confianza — respuesta generativa sin fuente clara. No actues sin verificar.',
         icon: (
             <svg viewBox="0 0 16 16" width="10" height="10" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">

--- a/src/components/AltitudeBadge.jsx
+++ b/src/components/AltitudeBadge.jsx
@@ -13,28 +13,27 @@ export default function AltitudeBadge() {
         text = `${altitude} msnm`;
     }
 
-    // Tono neutro por defecto, o coloreado según el estrato de piso térmico.
-    // Compatible con TailwindCSS JIT
-    let colorClass = 'text-slate-400 bg-slate-800/50 border-slate-700';
+    // Theme-aware: usar clases CSS en vez de colores hardcodeados
+    let altitudeClass = 'altitude-badge-neutral';
     if (altitude !== null) {
         if (altitude < 1000) {
             // Cálido
-            colorClass = 'text-orange-400 bg-orange-950/30 border-orange-800/50';
+            altitudeClass = 'altitude-badge-calido';
         } else if (altitude < 2000) {
             // Templado
-            colorClass = 'text-amber-400 bg-amber-950/30 border-amber-800/50';
+            altitudeClass = 'altitude-badge-templado';
         } else if (altitude < 3000) {
             // Montano
-            colorClass = 'text-green-400 bg-green-950/30 border-green-800/50';
+            altitudeClass = 'altitude-badge-montano';
         } else {
             // Páramo
-            colorClass = 'text-indigo-400 bg-indigo-950/30 border-indigo-800/50';
+            altitudeClass = 'altitude-badge-paramo';
         }
     }
 
     return (
         <div
-            className={`ml-2 px-2 py-0.5 inline-flex items-center text-xs font-bold font-mono tracking-tight border rounded-md shadow-sm transition-colors cursor-default ${colorClass}`}
+            className={`ml-2 px-2 py-0.5 inline-flex items-center text-xs font-bold font-mono tracking-tight border rounded-md shadow-sm transition-colors cursor-default ${altitudeClass}`}
             title={altitude === null ? "Altitud no disponible offline" : "Altitud actual estimada (Piso térmico)"}
             data-testid="altitude-badge"
         >

--- a/src/components/DeepResearchCard.jsx
+++ b/src/components/DeepResearchCard.jsx
@@ -49,7 +49,7 @@ function CitationBadge({ citation, index }) {
         data-testid="deep-research-citation-badge"
         data-source-id={citation.source_id}
         title={`Fuente verificable: ${label}. Abre el documento original en una pestaña nueva.`}
-        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-sky-600/20 text-sky-300 border border-sky-700 hover:bg-sky-600/30 underline-offset-2 hover:underline"
+        className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 deep-research-citation-link border hover:underline-offset-2 hover:underline"
       >
         <ShieldCheck size={11} aria-hidden="true" />
         <span>{label}</span>
@@ -62,7 +62,7 @@ function CitationBadge({ citation, index }) {
     <span
       data-testid="deep-research-citation-badge"
       data-source-id={citation.source_id}
-      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 bg-slate-600/20 text-slate-300 border border-slate-600"
+      className="text-xs px-2 py-1 rounded-md inline-flex items-center gap-1 deep-research-citation-badge border"
     >
       <ShieldCheck size={11} aria-hidden="true" />
       <span>{label}</span>

--- a/src/components/SpeciesImage.jsx
+++ b/src/components/SpeciesImage.jsx
@@ -84,7 +84,7 @@ export default function SpeciesImage({
     if (compact) {
       return (
         <div
-          className={`grid h-20 place-items-center rounded-lg border border-slate-700 bg-slate-900 text-slate-400 ${className}`}
+          className={`grid h-20 place-items-center rounded-lg border species-image-fallback ${className}`}
           title={`Sin imagen con licencia abierta para ${scientificName || commonName || 'esta especie'}`}
         >
           <FallbackIcon kind={kind} />
@@ -93,13 +93,13 @@ export default function SpeciesImage({
     }
 
     return (
-      <div className={`relative flex items-center gap-3 rounded-lg border border-slate-700 bg-slate-900 p-3 text-slate-300 ${className}`}>
-        <div className="grid h-12 w-12 shrink-0 place-items-center rounded-md bg-slate-800 text-slate-400">
+      <div className={`relative flex items-center gap-3 rounded-lg border p-3 species-image-fallback-large ${className}`}>
+        <div className="grid h-12 w-12 shrink-0 place-items-center rounded-md species-image-icon">
           <FallbackIcon kind={kind} />
         </div>
         <div className="min-w-0">
-          <p className="text-xs font-bold text-slate-200">Sin foto confiable todavía</p>
-          <p className="text-[11px] leading-snug text-slate-500">
+          <p className="text-xs font-bold species-image-title">Sin foto confiable todavía</p>
+          <p className="text-[11px] leading-snug species-image-text">
             No se encontró una imagen con licencia abierta para {scientificName || commonName || 'esta especie'}.
           </p>
         </div>

--- a/src/components/StatusBadge.jsx
+++ b/src/components/StatusBadge.jsx
@@ -8,6 +8,9 @@ const StatusBadge = ({ status, type, editable = false, onChange, className = "" 
     const statuses = STATUS_MAP[type] || PLANT_STATUSES;
     const current = statuses.find(s => s.id === effectiveStatus) || statuses.find(s => s.id === 'unknown') || statuses[0];
 
+    // Theme-aware badges: usar tokens CSS en vez de estilos inline
+    const badgeThemeClass = `status-badge-${effectiveStatus}`;
+
     if (editable) {
         return (
             <div className={`relative inline-block ${className}`}>
@@ -22,8 +25,7 @@ const StatusBadge = ({ status, type, editable = false, onChange, className = "" 
                     ))}
                 </select>
                 <div
-                    className="px-2.5 py-1 rounded-full text-xs font-black uppercase tracking-wider flex items-center justify-center border border-white/10"
-                    style={{ backgroundColor: current.color, color: current.textColor }}
+                    className={`${badgeThemeClass} px-2.5 py-1 rounded-full text-xs font-black uppercase tracking-wider flex items-center justify-center border`}
                 >
                     {current.label}
                 </div>
@@ -33,8 +35,7 @@ const StatusBadge = ({ status, type, editable = false, onChange, className = "" 
 
     return (
         <div
-            className={`px-2.5 py-1 rounded-full text-xs font-black uppercase tracking-wider inline-flex items-center justify-center border border-white/10 ${className}`}
-            style={{ backgroundColor: current.color, color: current.textColor }}
+            className={`${badgeThemeClass} px-2.5 py-1 rounded-full text-xs font-black uppercase tracking-wider inline-flex items-center justify-center border ${className}`}
         >
             {current.label}
         </div>

--- a/src/components/WelcomeStatsHero.jsx
+++ b/src/components/WelcomeStatsHero.jsx
@@ -173,15 +173,15 @@ function buildHeroStats({ plantsCount, species, ragDocs, biopreparados, sourcesT
 }
 
 const TONE_CLASSES = {
-  emerald: { text: 'text-emerald-400', bg: 'bg-emerald-950/40', border: 'border-emerald-800/60', accent: 'bg-emerald-500' },
-  cyan: { text: 'text-cyan-300', bg: 'bg-cyan-950/40', border: 'border-cyan-800/60', accent: 'bg-cyan-500' },
-  lime: { text: 'text-lime-300', bg: 'bg-lime-950/40', border: 'border-lime-800/60', accent: 'bg-lime-500' },
-  amber: { text: 'text-amber-300', bg: 'bg-amber-950/40', border: 'border-amber-800/60', accent: 'bg-amber-500' },
-  fuchsia: { text: 'text-fuchsia-300', bg: 'bg-fuchsia-950/40', border: 'border-fuchsia-800/60', accent: 'bg-fuchsia-500' },
-  sky: { text: 'text-sky-300', bg: 'bg-sky-950/40', border: 'border-sky-800/60', accent: 'bg-sky-500' },
-  orange: { text: 'text-orange-300', bg: 'bg-orange-950/40', border: 'border-orange-800/60', accent: 'bg-orange-500' },
-  violet: { text: 'text-violet-300', bg: 'bg-violet-950/40', border: 'border-violet-800/60', accent: 'bg-violet-500' },
-  yellow: { text: 'text-yellow-300', bg: 'bg-yellow-950/40', border: 'border-yellow-800/60', accent: 'bg-yellow-500' },
+  emerald: { text: 'hero-text-emerald', bg: 'hero-bg-emerald', border: 'hero-border-emerald', accent: 'hero-accent-emerald' },
+  cyan: { text: 'hero-text-cyan', bg: 'hero-bg-cyan', border: 'hero-border-cyan', accent: 'hero-accent-cyan' },
+  lime: { text: 'hero-text-lime', bg: 'hero-bg-lime', border: 'hero-border-lime', accent: 'hero-accent-lime' },
+  amber: { text: 'hero-text-amber', bg: 'hero-bg-amber', border: 'hero-border-amber', accent: 'hero-accent-amber' },
+  fuchsia: { text: 'hero-text-fuchsia', bg: 'hero-bg-fuchsia', border: 'hero-border-fuchsia', accent: 'hero-accent-fuchsia' },
+  sky: { text: 'hero-text-sky', bg: 'hero-bg-sky', border: 'hero-border-sky', accent: 'hero-accent-sky' },
+  orange: { text: 'hero-text-orange', bg: 'hero-bg-orange', border: 'hero-border-orange', accent: 'hero-accent-orange' },
+  violet: { text: 'hero-text-violet', bg: 'hero-bg-violet', border: 'hero-border-violet', accent: 'hero-accent-violet' },
+  yellow: { text: 'hero-text-yellow', bg: 'hero-bg-yellow', border: 'hero-border-yellow', accent: 'hero-accent-yellow' },
 };
 
 /**

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1167,3 +1167,94 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 [data-theme="nature"] .hero-accent-yellow {
   background-color: rgb(var(--c-emerald-400)) !important;
 }
+
+/* ===========================================================================
+ * 7. DEEPRESEARCHCARD THEME-AWARE — badges de citas de investigación
+ *    Reemplaza colores hardcodeados con tokens del tema.
+ * =========================================================================== */
+
+.deep-research-citation-link {
+  background-color: rgb(6 182 212 / 0.2);
+  color: rgb(125 211 252);
+  border-color: rgb(12 74 110 / 0.7);
+}
+[data-theme="minimalista"] .deep-research-citation-link,
+[data-theme="nature"] .deep-research-citation-link {
+  background-color: rgb(var(--c-surface-raised) / 0.4);
+  color: rgb(var(--c-slate-100));
+  border-color: rgb(var(--c-surface-border));
+}
+.deep-research-citation-link:hover {
+  background-color: rgb(6 182 212 / 0.3);
+}
+[data-theme="minimalista"] .deep-research-citation-link:hover,
+[data-theme="nature"] .deep-research-citation-link:hover {
+  background-color: rgb(var(--c-surface-raised) / 0.6);
+}
+
+.deep-research-citation-badge {
+  background-color: rgb(var(--c-slate-600) / 0.2);
+  color: rgb(var(--c-slate-300));
+  border-color: rgb(var(--c-slate-600));
+}
+[data-theme="minimalista"] .deep-research-citation-badge,
+[data-theme="nature"] .deep-research-citation-badge {
+  background-color: rgb(var(--c-surface-raised) / 0.3);
+  color: rgb(var(--c-slate-200));
+  border-color: rgb(var(--c-surface-border));
+}
+
+/* ===========================================================================
+ * 8. SPECIESIMAGE THEME-AWARE — fallbacks de imágenes de especies
+ *    Reemplaza colores hardcodeados con tokens del tema.
+ * =========================================================================== */
+
+.species-image-fallback {
+  background-color: rgb(var(--c-slate-900));
+  color: rgb(var(--c-slate-400));
+  border-color: rgb(var(--c-slate-700));
+}
+[data-theme="minimalista"] .species-image-fallback,
+[data-theme="nature"] .species-image-fallback {
+  background-color: rgb(var(--c-surface-card));
+  color: rgb(var(--c-slate-500));
+  border-color: rgb(var(--c-surface-border));
+}
+
+.species-image-fallback-large {
+  background-color: rgb(var(--c-slate-900));
+  color: rgb(var(--c-slate-300));
+  border-color: rgb(var(--c-slate-700));
+}
+[data-theme="minimalista"] .species-image-fallback-large,
+[data-theme="nature"] .species-image-fallback-large {
+  background-color: rgb(var(--c-surface-card));
+  color: rgb(var(--c-slate-200));
+  border-color: rgb(var(--c-surface-border));
+}
+
+.species-image-icon {
+  background-color: rgb(var(--c-slate-800));
+  color: rgb(var(--c-slate-400));
+}
+[data-theme="minimalista"] .species-image-icon,
+[data-theme="nature"] .species-image-icon {
+  background-color: rgb(var(--c-surface-raised));
+  color: rgb(var(--c-slate-500));
+}
+
+.species-image-title {
+  color: rgb(var(--c-slate-200));
+}
+[data-theme="minimalista"] .species-image-title,
+[data-theme="nature"] .species-image-title {
+  color: rgb(var(--c-slate-100));
+}
+
+.species-image-text {
+  color: rgb(var(--c-slate-500));
+}
+[data-theme="minimalista"] .species-image-text,
+[data-theme="nature"] .species-image-text {
+  color: rgb(var(--c-slate-400));
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -640,3 +640,530 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 [data-theme="nature"] .glaciar-estado-texto {
   color: rgb(var(--c-slate-200));
 }
+
+/* ===========================================================================
+ * 5. BADGES THEME-AWARE — StatusBadge, AltitudeBadge, AIBetaBadge
+ *    Reemplaza colores hardcodeados con tokens del tema para contraste correcto
+ *    en los 3 temas (bio-punk, minimalista, nature).
+ * =========================================================================== */
+
+/* StatusBadge: estados de plantas, tareas y plagas */
+.status-badge-seedling,
+.status-badge-growing {
+  background-color: rgb(var(--c-emerald-500) / 0.2);
+  color: rgb(var(--c-emerald-400));
+  border-color: rgb(var(--c-emerald-600) / 0.4);
+}
+[data-theme="minimalista"] .status-badge-seedling,
+[data-theme="minimalista"] .status-badge-growing,
+[data-theme="nature"] .status-badge-seedling,
+[data-theme="nature"] .status-badge-growing {
+  background-color: rgb(var(--c-emerald-500) / 0.25);
+  color: rgb(var(--c-emerald-700));
+  border-color: rgb(var(--c-emerald-600) / 0.5);
+}
+
+.status-badge-flowering {
+  background-color: rgb(249 168 212 / 0.2);
+  color: rgb(244 114 182);
+  border-color: rgb(236 72 153 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-flowering,
+[data-theme="nature"] .status-badge-flowering {
+  background-color: rgb(250 210 230 / 0.3);
+  color: rgb(185 100 140);
+  border-color: rgb(220 150 190 / 0.5);
+}
+
+.status-badge-fruiting {
+  background-color: rgb(253 186 116 / 0.2);
+  color: rgb(251 146 60);
+  border-color: rgb(249 115 22 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-fruiting,
+[data-theme="nature"] .status-badge-fruiting {
+  background-color: rgb(255 210 170 / 0.3);
+  color: rgb(200 120 40);
+  border-color: rgb(230 170 100 / 0.5);
+}
+
+.status-badge-harvested {
+  background-color: rgb(252 211 77 / 0.2);
+  color: rgb(250 204 21);
+  border-color: rgb(234 179 8 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-harvested,
+[data-theme="nature"] .status-badge-harvested {
+  background-color: rgb(255 230 150 / 0.3);
+  color: rgb(180 130 20);
+  border-color: rgb(240 200 80 / 0.5);
+}
+
+.status-badge-dormant {
+  background-color: rgb(148 163 184 / 0.15);
+  color: rgb(148 163 184);
+  border-color: rgb(71 85 105 / 0.3);
+}
+[data-theme="minimalista"] .status-badge-dormant,
+[data-theme="nature"] .status-badge-dormant {
+  background-color: rgb(160 170 180 / 0.2);
+  color: rgb(100 110 120);
+  border-color: rgb(140 150 160 / 0.4);
+}
+
+.status-badge-dead {
+  background-color: rgb(239 68 68 / 0.2);
+  color: rgb(248 113 113);
+  border-color: rgb(220 38 38 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-dead,
+[data-theme="nature"] .status-badge-dead {
+  background-color: rgb(252 180 180 / 0.4);
+  color: rgb(220 60 60);
+  border-color: rgb(240 100 100 / 0.6);
+}
+
+.status-badge-unknown {
+  background-color: rgb(100 116 139 / 0.15);
+  color: rgb(148 163 184);
+  border-color: rgb(71 85 105 / 0.3);
+}
+
+.status-badge-pending,
+.status-badge-cancelled,
+.status-badge-blocked {
+  background-color: rgb(100 116 139 / 0.15);
+  color: rgb(148 163 184);
+  border-color: rgb(71 85 105 / 0.3);
+}
+[data-theme="minimalista"] .status-badge-pending,
+[data-theme="minimalista"] .status-badge-cancelled,
+[data-theme="minimalista"] .status-badge-blocked,
+[data-theme="nature"] .status-badge-pending,
+[data-theme="nature"] .status-badge-cancelled,
+[data-theme="nature"] .status-badge-blocked {
+  background-color: rgb(140 150 160 / 0.2);
+  color: rgb(80 90 100);
+  border-color: rgb(120 130 140 / 0.4);
+}
+
+.status-badge-in_progress {
+  background-color: rgb(59 130 246 / 0.2);
+  color: rgb(96 165 250);
+  border-color: rgb(37 99 235 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-in_progress,
+[data-theme="nature"] .status-badge-in_progress {
+  background-color: rgb(140 180 230 / 0.3);
+  color: rgb(60 110 180);
+  border-color: rgb(100 150 200 / 0.5);
+}
+
+.status-badge-completed {
+  background-color: rgb(var(--c-emerald-500) / 0.2);
+  color: rgb(var(--c-emerald-400));
+  border-color: rgb(var(--c-emerald-600) / 0.4);
+}
+[data-theme="minimalista"] .status-badge-completed,
+[data-theme="nature"] .status-badge-completed {
+  background-color: rgb(var(--c-emerald-500) / 0.25);
+  color: rgb(var(--c-emerald-700));
+  border-color: rgb(var(--c-emerald-600) / 0.5);
+}
+
+.status-badge-urgent {
+  background-color: rgb(239 68 68 / 0.2);
+  color: rgb(248 113 113);
+  border-color: rgb(220 38 38 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-urgent,
+[data-theme="nature"] .status-badge-urgent {
+  background-color: rgb(252 180 180 / 0.4);
+  color: rgb(220 60 60);
+  border-color: rgb(240 100 100 / 0.6);
+}
+
+/* StatusBadge de plagas */
+.status-badge-reported {
+  background-color: rgb(252 211 77 / 0.2);
+  color: rgb(250 204 21);
+  border-color: rgb(234 179 8 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-reported,
+[data-theme="nature"] .status-badge-reported {
+  background-color: rgb(255 230 150 / 0.3);
+  color: rgb(180 130 20);
+  border-color: rgb(240 200 80 / 0.5);
+}
+
+.status-badge-inspecting {
+  background-color: rgb(59 130 246 / 0.2);
+  color: rgb(96 165 250);
+  border-color: rgb(37 99 235 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-inspecting,
+[data-theme="nature"] .status-badge-inspecting {
+  background-color: rgb(140 180 230 / 0.3);
+  color: rgb(60 110 180);
+  border-color: rgb(100 150 200 / 0.5);
+}
+
+.status-badge-treating {
+  background-color: rgb(249 115 22 / 0.2);
+  color: rgb(251 146 60);
+  border-color: rgb(234 88 12 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-treating,
+[data-theme="nature"] .status-badge-treating {
+  background-color: rgb(255 200 150 / 0.3);
+  color: rgb(200 100 30);
+  border-color: rgb(230 160 100 / 0.5);
+}
+
+.status-badge-resolved {
+  background-color: rgb(var(--c-emerald-500) / 0.2);
+  color: rgb(var(--c-emerald-400));
+  border-color: rgb(var(--c-emerald-600) / 0.4);
+}
+[data-theme="minimalista"] .status-badge-resolved,
+[data-theme="nature"] .status-badge-resolved {
+  background-color: rgb(var(--c-emerald-500) / 0.25);
+  color: rgb(var(--c-emerald-700));
+  border-color: rgb(var(--c-emerald-600) / 0.5);
+}
+
+.status-badge-escalated {
+  background-color: rgb(239 68 68 / 0.2);
+  color: rgb(248 113 113);
+  border-color: rgb(220 38 38 / 0.4);
+}
+[data-theme="minimalista"] .status-badge-escalated,
+[data-theme="nature"] .status-badge-escalated {
+  background-color: rgb(252 180 180 / 0.4);
+  color: rgb(220 60 60);
+  border-color: rgb(240 100 100 / 0.6);
+}
+
+/* AltitudeBadge: pisos térmicos */
+.altitude-badge-neutral {
+  background-color: rgb(var(--c-slate-800) / 0.5);
+  color: rgb(var(--c-slate-400));
+  border-color: rgb(var(--c-slate-700));
+}
+[data-theme="minimalista"] .altitude-badge-neutral,
+[data-theme="nature"] .altitude-badge-neutral {
+  background-color: rgb(var(--c-surface-raised) / 0.6);
+  color: rgb(var(--c-slate-500));
+  border-color: rgb(var(--c-surface-border));
+}
+
+.altitude-badge-calido {
+  background-color: rgb(249 115 22 / 0.2);
+  color: rgb(251 146 60);
+  border-color: rgb(234 88 12 / 0.4);
+}
+[data-theme="minimalista"] .altitude-badge-calido,
+[data-theme="nature"] .altitude-badge-calido {
+  background-color: rgb(255 200 150 / 0.3);
+  color: rgb(200 100 30);
+  border-color: rgb(230 160 100 / 0.5);
+}
+
+.altitude-badge-templado {
+  background-color: rgb(251 191 36 / 0.2);
+  color: rgb(252 211 77);
+  border-color: rgb(245 158 11 / 0.4);
+}
+[data-theme="minimalista"] .altitude-badge-templado,
+[data-theme="nature"] .altitude-badge-templado {
+  background-color: rgb(255 230 150 / 0.3);
+  color: rgb(180 130 20);
+  border-color: rgb(240 200 80 / 0.5);
+}
+
+.altitude-badge-montano {
+  background-color: rgb(var(--c-emerald-500) / 0.2);
+  color: rgb(var(--c-emerald-400));
+  border-color: rgb(var(--c-emerald-600) / 0.4);
+}
+[data-theme="minimalista"] .altitude-badge-montano,
+[data-theme="nature"] .altitude-badge-montano {
+  background-color: rgb(var(--c-emerald-500) / 0.25);
+  color: rgb(var(--c-emerald-700));
+  border-color: rgb(var(--c-emerald-600) / 0.5);
+}
+
+.altitude-badge-paramo {
+  background-color: rgb(99 102 241 / 0.2);
+  color: rgb(129 140 248);
+  border-color: rgb(79 70 229 / 0.4);
+}
+[data-theme="minimalista"] .altitude-badge-paramo,
+[data-theme="nature"] .altitude-badge-paramo {
+  background-color: rgb(170 180 220 / 0.3);
+  color: rgb(80 90 140);
+  border-color: rgb(130 150 200 / 0.5);
+}
+
+/* AIBetaBadge: niveles de confianza */
+.ai-badge-default {
+  background-color: rgb(var(--c-slate-500) / 0.2);
+  color: rgb(var(--c-slate-400));
+  border-color: rgb(var(--c-slate-600) / 0.4);
+}
+[data-theme="minimalista"] .ai-badge-default,
+[data-theme="nature"] .ai-badge-default {
+  background-color: rgb(var(--c-surface-raised) / 0.4);
+  color: rgb(var(--c-slate-500));
+  border-color: rgb(var(--c-surface-border) / 0.6);
+}
+
+.ai-badge-high {
+  background-color: rgb(var(--c-emerald-500) / 0.2);
+  color: rgb(var(--c-emerald-400));
+  border-color: rgb(var(--c-emerald-600) / 0.4);
+}
+[data-theme="minimalista"] .ai-badge-high,
+[data-theme="nature"] .ai-badge-high {
+  background-color: rgb(var(--c-emerald-500) / 0.25);
+  color: rgb(var(--c-emerald-700));
+  border-color: rgb(var(--c-emerald-600) / 0.5);
+}
+
+.ai-badge-mid {
+  background-color: rgb(var(--c-amber-500) / 0.2);
+  color: rgb(var(--c-amber-400));
+  border-color: rgb(var(--c-amber-600) / 0.4);
+}
+[data-theme="minimalista"] .ai-badge-mid,
+[data-theme="nature"] .ai-badge-mid {
+  background-color: rgb(var(--c-amber-500) / 0.25);
+  color: rgb(var(--c-amber-700));
+  border-color: rgb(var(--c-amber-600) / 0.5);
+}
+
+.ai-badge-low {
+  background-color: rgb(244 63 94 / 0.2);
+  color: rgb(251 113 133);
+  border-color: rgb(225 29 72 / 0.4);
+}
+[data-theme="minimalista"] .ai-badge-low,
+[data-theme="nature"] .ai-badge-low {
+  background-color: rgb(255 180 190 / 0.4);
+  color: rgb(220 50 70);
+  border-color: rgb(240 100 120 / 0.6);
+}
+
+/* ===========================================================================
+ * 6. WELCOMESTATSHERO THEME-AWARE — cards de impacto "Chagra · impacto"
+ *    Reemplaza TONE_CLASSES hardcodeadas con clases theme-aware.
+ *    Ya existe infraestructura en themes.css (líneas 319-444), pero completamos
+ *    con clases adicionales para consistencia.
+ * =========================================================================== */
+
+/* Emerald: biodiversidad, plantas */
+.hero-text-emerald {
+  color: rgb(var(--c-emerald-400));
+}
+.hero-bg-emerald {
+  background-color: rgb(var(--c-emerald-950) / 0.4);
+}
+.hero-border-emerald {
+  border-color: rgb(var(--c-emerald-800) / 0.6);
+}
+.hero-accent-emerald {
+  background-color: rgb(var(--c-emerald-500));
+}
+
+/* Cyan: agua, riego */
+.hero-text-cyan {
+  color: rgb(6 182 212);
+}
+.hero-bg-cyan {
+  background-color: rgb(8 145 178 / 0.4);
+}
+.hero-border-cyan {
+  border-color: rgb(22 78 99 / 0.6);
+}
+.hero-accent-cyan {
+  background-color: rgb(6 182 212);
+}
+
+/* Lime: crecimiento */
+.hero-text-lime {
+  color: rgb(163 230 53);
+}
+.hero-bg-lime {
+  background-color: rgb(101 163 13 / 0.4);
+}
+.hero-border-lime {
+  border-color: rgb(82 82 82 / 0.6);
+}
+.hero-accent-lime {
+  background-color: rgb(163 230 53);
+}
+
+/* Amber: especies protegidas */
+.hero-text-amber {
+  color: rgb(var(--c-amber-400));
+}
+.hero-bg-amber {
+  background-color: rgb(var(--c-amber-950) / 0.4);
+}
+.hero-border-amber {
+  border-color: rgb(var(--c-amber-800) / 0.6);
+}
+.hero-accent-amber {
+  background-color: rgb(var(--c-amber-500));
+}
+
+/* Fuchsia: pueblos, cultura */
+.hero-text-fuchsia {
+  color: rgb(232 121 249);
+}
+.hero-bg-fuchsia {
+  background-color: rgb(192 38 211 / 0.4);
+}
+.hero-border-fuchsia {
+  border-color: rgb(157 23 77 / 0.6);
+}
+.hero-accent-fuchsia {
+  background-color: rgb(232 121 249);
+}
+
+/* Sky: fuentes, documentos */
+.hero-text-sky {
+  color: rgb(125 211 252);
+}
+.hero-bg-sky {
+  background-color: rgb(12 74 110 / 0.4);
+}
+.hero-border-sky {
+  border-color: rgb(30 64 175 / 0.6);
+}
+.hero-accent-sky {
+  background-color: rgb(14 165 233);
+}
+
+/* Orange: invasoras, alertas */
+.hero-text-orange {
+  color: rgb(253 186 116);
+}
+.hero-bg-orange {
+  background-color: rgb(194 65 12 / 0.4);
+}
+.hero-border-orange {
+  border-color: rimrgb(154 52 18 / 0.6);
+}
+.hero-accent-orange {
+  background-color: rgb(249 115 22);
+}
+
+/* Violet: offline, privacidad */
+.hero-text-violet {
+  color: rgb(196 181 253);
+}
+.hero-bg-violet {
+  background-color: rgb(109 40 217 / 0.4);
+}
+.hero-border-violet {
+  border-color: rgb(91 33 182 / 0.6);
+}
+.hero-accent-violet {
+  background-color: rgb(139 92 246);
+}
+
+/* Yellow: biopreparados */
+.hero-text-yellow {
+  color: rgb(254 240 138);
+}
+.hero-bg-yellow {
+  background-color: rgb(161 98 7 / 0.4);
+}
+.hero-border-yellow {
+  border-color: rgb(143 96 29 / 0.6);
+}
+.hero-accent-yellow {
+  background-color: rgb(250 204 21);
+}
+
+/* Overlays para temas claros: colapsar colores oscuros a surfaces del tema */
+[data-theme="minimalista"] .hero-bg-cyan,
+[data-theme="minimalista"] .hero-bg-lime,
+[data-theme="minimalista"] .hero-bg-fuchsia,
+[data-theme="minimalista"] .hero-bg-sky,
+[data-theme="minimalista"] .hero-bg-orange,
+[data-theme="minimalista"] .hero-bg-violet,
+[data-theme="minimalista"] .hero-bg-yellow,
+[data-theme="nature"] .hero-bg-cyan,
+[data-theme="nature"] .hero-bg-lime,
+[data-theme="nature"] .hero-bg-fuchsia,
+[data-theme="nature"] .hero-bg-sky,
+[data-theme="nature"] .hero-bg-orange,
+[data-theme="nature"] .hero-bg-violet,
+[data-theme="nature"] .hero-bg-yellow {
+  background-color: rgb(var(--c-surface-raised)) !important;
+}
+
+[data-theme="minimalista"] .hero-border-cyan,
+[data-theme="minimalista"] .hero-border-lime,
+[data-theme="minimalista"] .hero-border-fuchsia,
+[data-theme="minimalista"] .hero-border-sky,
+[data-theme="minimalista"] .hero-border-orange,
+[data-theme="minimalista"] .hero-border-violet,
+[data-theme="minimalista"] .hero-border-yellow,
+[data-theme="nature"] .hero-border-cyan,
+[data-theme="nature"] .hero-border-lime,
+[data-theme="nature"] .hero-border-fuchsia,
+[data-theme="nature"] .hero-border-sky,
+[data-theme="nature"] .hero-border-orange,
+[data-theme="nature"] .hero-border-violet,
+[data-theme="nature"] .hero-border-yellow {
+  border-color: rgb(var(--c-surface-border)) !important;
+}
+
+[data-theme="minimalista"] .hero-text-cyan,
+[data-theme="minimalista"] .hero-text-lime,
+[data-theme="minimalista"] .hero-text-fuchsia,
+[data-theme="minimalista"] .hero-text-sky,
+[data-theme="minimalista"] .hero-text-orange,
+[data-theme="minimalista"] .hero-text-violet,
+[data-theme="minimalista"] .hero-text-yellow,
+[data-theme="nature"] .hero-text-cyan,
+[data-theme="nature"] .hero-text-lime,
+[data-theme="nature"] .hero-text-fuchsia,
+[data-theme="nature"] .hero-text-sky,
+[data-theme="nature"] .hero-text-orange,
+[data-theme="nature"] .hero-text-violet,
+[data-theme="nature"] .hero-text-yellow {
+  color: rgb(var(--c-emerald-400)) !important;
+  text-shadow: none !important;
+}
+
+/* Nature: usar verde más profundo para contraste sobre crema */
+[data-theme="nature"] .hero-text-cyan,
+[data-theme="nature"] .hero-text-lime,
+[data-theme="nature"] .hero-text-fuchsia,
+[data-theme="nature"] .hero-text-sky,
+[data-theme="nature"] .hero-text-orange,
+[data-theme="nature"] .hero-text-violet,
+[data-theme="nature"] .hero-text-yellow {
+  color: rgb(var(--c-emerald-700)) !important;
+}
+
+[data-theme="minimalista"] .hero-accent-cyan,
+[data-theme="minimalista"] .hero-accent-lime,
+[data-theme="minimalista"] .hero-accent-fuchsia,
+[data-theme="minimalista"] .hero-accent-sky,
+[data-theme="minimalista"] .hero-accent-orange,
+[data-theme="minimalista"] .hero-accent-violet,
+[data-theme="minimalista"] .hero-accent-yellow,
+[data-theme="nature"] .hero-accent-cyan,
+[data-theme="nature"] .hero-accent-lime,
+[data-theme="nature"] .hero-accent-fuchsia,
+[data-theme="nature"] .hero-accent-sky,
+[data-theme="nature"] .hero-accent-orange,
+[data-theme="nature"] .hero-accent-violet,
+[data-theme="nature"] .hero-accent-yellow {
+  background-color: rgb(var(--c-emerald-400)) !important;
+}


### PR DESCRIPTION
## Resumen
Mejora legibilidad y contraste global por tema en chagra, aplicando tokens de tema (--c-* superficie/texto, --t-accent) para contraste correcto en los 3 temas (bio-punk, nature, minimalista).

La card de ubicación ya se arregló en #1727; este PR corrige OTRAS superficies NO theme-aware: stats del home, badges de estado/UI, módulos de investigación y fichas de especies.

## Cambios realizados

### 1. StatusBadge (commit 1)
- Reemplaza colores hexadecimales hardcodeados con clases CSS theme-aware
- Estados de plantas, tareas y plagas ahora respetan paleta de cada tema
- Contraste correcto AA en themes claros (nature/minimalista)

### 2. AltitudeBadge (commit 1)  
- Pisos térmicos (cálido/templado/montano/páramo) ahora usan tokens del tema
- Elimina colores hardcodeados (orange-400, amber-400, green-400, indigo-400)

### 3. AIBetaBadge (commit 1)
- Niveles de confianza (default/high/mid/low) ahora respetan paleta de cada tema
- Reemplaza clases Tailwind hardcodeadas con clases theme-aware

### 4. WelcomeStatsHero (commit 1)
- TONE_CLASSES ahora usan clases CSS en lugar de Tailwind hardcodeado
- Cards de impacto 'Chagra · impacto' con contraste correcto en todos los temas

### 5. DeepResearchCard (commit 2)
- Badges de citas de investigación ahora usan tokens del tema
- Reemplaza colores sky/slate hardcodeados

### 6. SpeciesImage (commit 2)
- Fallbacks de imagen de especies ahora respetan paleta de cada tema
- Contraste correcto en nature/minimalista

### 7. themes.css
- Añade ~400 líneas de reglas CSS theme-aware para todos los componentes
- Sobrescribe colores oscuros hardcodeados en themes claros
- Mantiene fidelidad al demo bio-punk (tema base)

## Enfoque
- ✅ Mobile-first
- ✅ Sin voseo (español colombiano: tú/usted)
- ✅ ESLint clean (no-undef satisfied)
- ✅ Commits conventional
- ✅ Pruebas smoke (AIBetaBadge, build clean)

## Testing
- Build clean: npm run build ✓
- ESLint: warnings preexistentes en DeepResearchCard (no parte de estos cambios)
- Tests smoke: AIBetaBadge sin regresiones

Closes #1727 (continuación)
