### PR TITLE
feat(images): wire species images from OpenCode JSON

### DIFF
--- a/public/species-images.json
+++ b/public/species-images.json
@@ -1,0 +1,4316 @@
+{
+  "generated_at": "2026-06-20",
+  "source": "GBIF occurrence media (StillImage, CC0/CC-BY only)",
+  "catalog_total_species": 634,
+  "processed": 634,
+  "offset": 0,
+  "limit": "all",
+  "species_with_images": 615,
+  "species": [
+    {
+      "species_id": "abatia_parviflora",
+      "scientific_name": "Abatia parviflora Ruiz & Pav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622718953/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "acacia_decurrens",
+      "scientific_name": "Acacia decurrens Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615580055/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "khomotso Mokono"
+    },
+    {
+      "species_id": "acacia_melanoxylon",
+      "scientific_name": "Acacia melanoxylon R. Br.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605738379/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Aden Sommerville"
+    },
+    {
+      "species_id": "ambrosia_cumanensis",
+      "scientific_name": "Ambrosia cumanensis Kunth",
+      "image_url": "https://object.jacq.org/europeana/LAGU/1169748.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "anacardium_occidentale",
+      "scientific_name": "Anacardium occidentale L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605247961/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marcio Santos Ferreira"
+    },
+    {
+      "species_id": "annona_cherimola",
+      "scientific_name": "Annona cherimola Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607361000/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Peter Quakenbush"
+    },
+    {
+      "species_id": "annona_squamosa",
+      "scientific_name": "Annona squamosa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610080319/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raja Sekhar Chimirala"
+    },
+    {
+      "species_id": "allium_ampeloprasum",
+      "scientific_name": "Allium ampeloprasum var. porrum (L.) J. Gay",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604658140/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "insiderelic"
+    },
+    {
+      "species_id": "allium_cepa",
+      "scientific_name": "Allium cepa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/640133931/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Fyodor Pudovikov"
+    },
+    {
+      "species_id": "allium_fistulosum",
+      "scientific_name": "Allium fistulosum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/652280967/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Алёна Осипова"
+    },
+    {
+      "species_id": "allium_sativum",
+      "scientific_name": "Allium sativum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611897410/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "NENP_StBartsNewbury"
+    },
+    {
+      "species_id": "alnus_acuminata",
+      "scientific_name": "Alnus acuminata Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611035911/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "apium_graveolens",
+      "scientific_name": "Apio graveolens L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609845153/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "W Rao"
+    },
+    {
+      "species_id": "asparagus_officinalis",
+      "scientific_name": "Asparagus officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605083180/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Stanislav Murashkin"
+    },
+    {
+      "species_id": "baccharis_latifolia",
+      "scientific_name": "Baccharis latifolia (Ruiz & Pav.) Pers.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610069531/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "bertholletia_excelsa",
+      "scientific_name": "Bertholletia excelsa Humb. & Bonpl.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/58/11/17/01581117.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "beta_vulgaris_cicla_amarilla",
+      "scientific_name": "Beta vulgaris var. cicla L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "beta_vulgaris_cicla_blanca",
+      "scientific_name": "Beta vulgaris var. cicla L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "beta_vulgaris_cicla_roja",
+      "scientific_name": "Beta vulgaris var. cicla L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "beta_vulgaris_conditiva",
+      "scientific_name": "Beta vulgaris L. subsp. vulgaris Conditiva Group",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "brassica_juncea",
+      "scientific_name": "Brassica juncea (L.) Czern.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/627001485/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mami_t_t"
+    },
+    {
+      "species_id": "brassica_oleracea_acephala_curly",
+      "scientific_name": "Brassica oleracea var. acephala 'Curly'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_acephala_lacinato",
+      "scientific_name": "Brassica oleracea var. acephala 'Lacinato'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_acephala_red_russian",
+      "scientific_name": "Brassica oleracea var. acephala 'Red Russian'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_capitata_alba",
+      "scientific_name": "Brassica oleracea var. capitata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_capitata_rubra",
+      "scientific_name": "Brassica oleracea var. capitata f. rubra",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_italica",
+      "scientific_name": "Brassica oleracea var. italica Plenck",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_sabauda",
+      "scientific_name": "Brassica oleracea var. sabauda L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brosimum_utile",
+      "scientific_name": "Brosimum utile (Kunth) Oken ex J.Presl",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/648829301/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Guillaume Delaitre"
+    },
+    {
+      "species_id": "brunellia_comocladifolia",
+      "scientific_name": "Brunellia comocladifolia Humb. & Bonpl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/465926504/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Yolanda M. Leon"
+    },
+    {
+      "species_id": "bursera_simaruba",
+      "scientific_name": "Bursera simaruba (L.) Sarg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604490765/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mike Brady"
+    },
+    {
+      "species_id": "caesalpinia_spinosa",
+      "scientific_name": "Caesalpinia spinosa (Feuillée ex Molina) Kuntze",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/629381801/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Charlie O'Brien"
+    },
+    {
+      "species_id": "calamagrostis_effusa",
+      "scientific_name": "Calamagrostis effusa (Kunth) Steud.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/657704078/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "calendula_officinalis",
+      "scientific_name": "Calendula officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604478521/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Karen Fry"
+    },
+    {
+      "species_id": "capsicum_annuum",
+      "scientific_name": "Capsicum annuum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/619664379/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Liliana Ramírez-Freire"
+    },
+    {
+      "species_id": "capsicum_annuum_generic",
+      "scientific_name": "Capsicum annuum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/619664379/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Liliana Ramírez-Freire"
+    },
+    {
+      "species_id": "caryodendron_orinocense",
+      "scientific_name": "Caryodendron orinocense H.Karst.",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/6366b3f7239f410abdc7eb7c490a90be.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "cenchrus_clandestinus",
+      "scientific_name": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604758419/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "centrosema_molle",
+      "scientific_name": "Centrosema molle Mart. ex Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/659945967/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "yatesy"
+    },
+    {
+      "species_id": "chenopodium_quinoa",
+      "scientific_name": "Chenopodium quinoa Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/463521370/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Humber Alberto"
+    },
+    {
+      "species_id": "chrysopogon_zizanioides",
+      "scientific_name": "Chrysopogon zizanioides (L.) Roberty",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/495402970/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Erwin Sieben"
+    },
+    {
+      "species_id": "chusquea_scandens",
+      "scientific_name": "Chusquea scandens Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/514427360/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Eric Schmidt"
+    },
+    {
+      "species_id": "cissus_verticillata",
+      "scientific_name": "Cissus verticillata (L.) Nicolson & C.E.Jarvis",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618968760/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "葉子"
+    },
+    {
+      "species_id": "coffea_arabica",
+      "scientific_name": "Coffea arabica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605811844/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Richard Jacob"
+    },
+    {
+      "species_id": "coriandrum_sativum",
+      "scientific_name": "Coriandrum sativum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/644275211/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "lanechaffin"
+    },
+    {
+      "species_id": "costus_guanaiensis",
+      "scientific_name": "Costus guanaiensis Rusby",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605978777/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marcio Santos Ferreira"
+    },
+    {
+      "species_id": "cupressus_lusitanica",
+      "scientific_name": "Cupressus lusitanica Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604560584/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Lauren Bosch"
+    },
+    {
+      "species_id": "cynodon_plectostachyus",
+      "scientific_name": "Cynodon plectostachyus (K.Schum.) Pilg.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/39/17/72/01391772.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "diplostephium_revolutum",
+      "scientific_name": "Diplostephium revolutum S.F.Blake",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/584501970/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Quentin Groom"
+    },
+    {
+      "species_id": "erythrina_edulis",
+      "scientific_name": "Erythrina edulis Triana ex Micheli",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/658020298/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "GERMAN LEONEL SARMIENTO CRUZ"
+    },
+    {
+      "species_id": "erythrina_fusca",
+      "scientific_name": "Erythrina fusca Lour.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617529293/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Lauren Bosch"
+    },
+    {
+      "species_id": "eugenia_stipitata",
+      "scientific_name": "Eugenia stipitata McVaugh",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/46/88/15/01468815.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "eucalyptus_globulus",
+      "scientific_name": "Eucalyptus globulus Labill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608225481/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Pierre Cartier"
+    },
+    {
+      "species_id": "foeniculum_vulgare",
+      "scientific_name": "Foeniculum vulgare Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604750309/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrew Gillespie"
+    },
+    {
+      "species_id": "fragaria_ananassa_monterrey",
+      "scientific_name": "Fragaria × ananassa 'Monterrey'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611897519/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "NENP_StBartsNewbury"
+    },
+    {
+      "species_id": "fraxinus_uhdei",
+      "scientific_name": "Fraxinus uhdei (Wenz.) Lingelsh.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612620339/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "galinsoga_parviflora",
+      "scientific_name": "Galinsoga parviflora Cav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605582553/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ben"
+    },
+    {
+      "species_id": "glycine_max",
+      "scientific_name": "Glycine max (L.) Merr.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605014006/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Vladislav Isaev"
+    },
+    {
+      "species_id": "gossypium_hirsutum",
+      "scientific_name": "Gossypium hirsutum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616815594/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Rachel Crane"
+    },
+    {
+      "species_id": "guaiacum_officinale",
+      "scientific_name": "Guaiacum officinale L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/639092183/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Cricket Raspet"
+    },
+    {
+      "species_id": "guazuma_ulmifolia",
+      "scientific_name": "Guazuma ulmifolia Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605071229/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Iván Cumpián"
+    },
+    {
+      "species_id": "handroanthus_billbergii",
+      "scientific_name": "Handroanthus billbergii (Bureau & K.Schum.) Standl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614221378/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elkin Meriño Florez"
+    },
+    {
+      "species_id": "hedychium_coronarium",
+      "scientific_name": "Hedychium coronarium J. König",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610854323/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Frank Thomas Sautter"
+    },
+    {
+      "species_id": "hedyosmum_bonplandianum",
+      "scientific_name": "Hedyosmum bonplandianum Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/184263136/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "inga_marginata",
+      "scientific_name": "Inga marginata Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/638556661/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Fabrício Mil Homens Riella"
+    },
+    {
+      "species_id": "ipomoea_batatas",
+      "scientific_name": "Ipomoea batatas (L.) Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612311505/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "ipomoea_purpurea",
+      "scientific_name": "Ipomoea purpurea (L.) Roth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605419368/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Rodrigo Osvaldo Borbon Vázquez"
+    },
+    {
+      "species_id": "inga_edulis",
+      "scientific_name": "Inga edulis Mart.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/647310325/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Rosalinda Melendrez"
+    },
+    {
+      "species_id": "jacaranda_caucana",
+      "scientific_name": "Jacaranda caucana Pittier",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/68839916/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Denise Dalbosco Dell'Aglio"
+    },
+    {
+      "species_id": "jacaranda_copaia",
+      "scientific_name": "Jacaranda copaia (Aubl.) D.Don",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/638337930/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Guillaume Delaitre"
+    },
+    {
+      "species_id": "lactuca_sativa",
+      "scientific_name": "Lactuca sativa L.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lactuca_sativa_capitata",
+      "scientific_name": "Lactuca sativa var. capitata L.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lactuca_sativa_crispa_verde",
+      "scientific_name": "Lactuca sativa L. var. crispa L.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lactuca_sativa_longifolia_morada",
+      "scientific_name": "Lactuca sativa L. var. longifolia Lam.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lactuca_sativa_longifolia_verde",
+      "scientific_name": "Lactuca sativa L. var. longifolia Lam.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lactuca_sativa_roble_morada",
+      "scientific_name": "Lactuca sativa L.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lactuca_sativa_roble_verde",
+      "scientific_name": "Lactuca sativa L.",
+      "image_url": "https://observation.org/photos/146115174.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Bram vd Bergh"
+    },
+    {
+      "species_id": "lantana_camara",
+      "scientific_name": "Lantana camara L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605006721/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hugh Chan"
+    },
+    {
+      "species_id": "libidibia_coriaria",
+      "scientific_name": "Libidibia coriaria (Jacq.) Schltdl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616448702/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mario Guzmán"
+    },
+    {
+      "species_id": "luffa_cylindrica",
+      "scientific_name": "Luffa cylindrica (L.) M.Roem.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604584299/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Karen McCabe"
+    },
+    {
+      "species_id": "lupinus_mutabilis",
+      "scientific_name": "Lupinus mutabilis Sweet",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/463608492/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "maclura_tinctoria",
+      "scientific_name": "Maclura tinctoria (L.) D.Don ex Steud.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611679927/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Thomaz Ricardo Favreto Sinani"
+    },
+    {
+      "species_id": "malva_sylvestris",
+      "scientific_name": "Malva sylvestris L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604722594/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Leon Perrie"
+    },
+    {
+      "species_id": "melissa_officinalis",
+      "scientific_name": "Melissa officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604470387/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "mentha_spicata",
+      "scientific_name": "Mentha spicata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609580243/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Connor Sydney (Squid)"
+    },
+    {
+      "species_id": "mora_megistosperma",
+      "scientific_name": "Mora megistosperma (Pittier) Britton & Rose",
+      "image_url": "http://was.tacc.utexas.edu/fileget?coll=TEX-LL&type=O&filename=sp65773028014052518276.att.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "myrsine_guianensis",
+      "scientific_name": "Myrsine guianensis (Aubl.) Kuntze",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/464200866/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ben Costamagna"
+    },
+    {
+      "species_id": "nicotiana_tabacum",
+      "scientific_name": "Nicotiana tabacum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605630993/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Juliana"
+    },
+    {
+      "species_id": "origanum_vulgare",
+      "scientific_name": "Origanum vulgare L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604533226/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Cahen"
+    },
+    {
+      "species_id": "oryza_sativa",
+      "scientific_name": "Oryza sativa L. (tecnología Clearfield, tolerante a imidazolinonas)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/492154473/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Aditya Rao"
+    },
+    {
+      "species_id": "oxalis_tuberosa",
+      "scientific_name": "Oxalis tuberosa Molina",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610030695/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "artydonaldson"
+    },
+    {
+      "species_id": "passiflora_edulis_flavicarpa",
+      "scientific_name": "Passiflora edulis f. flavicarpa Deg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608156227/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "filipeprates"
+    },
+    {
+      "species_id": "passiflora_edulis_morada",
+      "scientific_name": "Passiflora edulis f. edulis Sims",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608156227/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "filipeprates"
+    },
+    {
+      "species_id": "passiflora_ligularis",
+      "scientific_name": "Passiflora ligularis Juss.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605812347/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Richard Jacob"
+    },
+    {
+      "species_id": "passiflora_tripartita_mollissima",
+      "scientific_name": "Passiflora tripartita var. mollissima (Kunth) Holm-Niels. & Jørg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617676334/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Chris"
+    },
+    {
+      "species_id": "pennisetum_glaucum",
+      "scientific_name": "Pennisetum glaucum (L.) R.Br.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605340696/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Fabrício Mil Homens Riella"
+    },
+    {
+      "species_id": "pennisetum_setaceum",
+      "scientific_name": "Pennisetum setaceum (Forssk.) Chiov. [sinónimo histórico; nombre POWO actual: Cenchrus setaceus (Forssk.) Morrone]",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604569282/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Karen McCabe"
+    },
+    {
+      "species_id": "persea_caerulea",
+      "scientific_name": "Persea caerulea (Ruiz & Pav.) Mez",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614263480/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matt Felperin"
+    },
+    {
+      "species_id": "petroselinum_crispum",
+      "scientific_name": "Petroselinum crispum (Mill.) Fuss",
+      "image_url": "https://arter.dk/media/4ad7c86e-0ebc-4cfa-8b9a-007c36fdceda.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "petroselinum_crispum_neapolitanum",
+      "scientific_name": "Petroselinum crispum var. neapolitanum Danert",
+      "image_url": "https://arter.dk/media/4ad7c86e-0ebc-4cfa-8b9a-007c36fdceda.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "phaseolus_vulgaris",
+      "scientific_name": "Phaseolus vulgaris L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/500118303/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raúl A. Ruiz M."
+    },
+    {
+      "species_id": "physalis_peruviana",
+      "scientific_name": "Physalis peruviana L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606541557/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "desertnaturalist"
+    },
+    {
+      "species_id": "pimpinella_anisum",
+      "scientific_name": "Pimpinella anisum L.",
+      "image_url": "https://plant.depo.msu.ru/open/public/item/MW1057540/img/0.jpg?gbif",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "MW Herbarium"
+    },
+    {
+      "species_id": "pinus_patula",
+      "scientific_name": "Pinus patula Schiede ex Schltdl. & Cham.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616735967/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "cello caruso-turiello"
+    },
+    {
+      "species_id": "poraqueiba_sericea",
+      "scientific_name": "Poraqueiba sericea Tul.",
+      "image_url": "https://media01.symbiota.org/media/seinet/swnode/ASU_Plants/CSP12/CSP12059.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Arizona State University Vascular Plant Herbarium"
+    },
+    {
+      "species_id": "portulaca_oleracea",
+      "scientific_name": "Portulaca oleracea L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605225291/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dan Johnson"
+    },
+    {
+      "species_id": "prunus_serotina_capuli",
+      "scientific_name": "Prunus serotina var. capuli (Cav.) McVaugh",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605121641/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alan Prather"
+    },
+    {
+      "species_id": "psidium_guajava",
+      "scientific_name": "Psidium guajava L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604681077/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "psidium_guajava_manzana",
+      "scientific_name": "Psidium guajava 'Manzana'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604681077/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "pteridium_aquilinum",
+      "scientific_name": "Pteridium aquilinum (L.) Kuhn",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604509099/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Patrick Le Mao"
+    },
+    {
+      "species_id": "puya_goudotiana",
+      "scientific_name": "Puya goudotiana Mez",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/636194094/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "quararibea_cordata",
+      "scientific_name": "Quararibea cordata (Bonpl.) Vischer",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/357848152/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "tlaloc27"
+    },
+    {
+      "species_id": "quercus_humboldtii",
+      "scientific_name": "Quercus humboldtii Bonpl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/475427442/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "raphanus_sativus",
+      "scientific_name": "Raphanus sativus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607770557/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Chase Mathey"
+    },
+    {
+      "species_id": "rosmarinus_officinalis",
+      "scientific_name": "Salvia rosmarinus Spenn. (syn. Rosmarinus officinalis L.)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605320460/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mark Ooi"
+    },
+    {
+      "species_id": "rubus_alceifolius",
+      "scientific_name": "Rubus alceifolius Poir.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/623847616/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "如此甚好"
+    },
+    {
+      "species_id": "rubus_glaucus_sin_espinas",
+      "scientific_name": "Rubus glaucus Benth. 'Sin Espinas'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/462588725/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Zoltán Stekkelpak"
+    },
+    {
+      "species_id": "rubus_idaeus_golden",
+      "scientific_name": "Rubus idaeus 'Golden Queen' o similar",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605343695/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "guywallbanks"
+    },
+    {
+      "species_id": "rubus_idaeus_heritage",
+      "scientific_name": "Rubus idaeus 'Heritage'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605343695/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "guywallbanks"
+    },
+    {
+      "species_id": "saccharum_officinarum",
+      "scientific_name": "Saccharum officinarum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/643738213/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Guillaume Delaitre"
+    },
+    {
+      "species_id": "salvia_officinalis",
+      "scientific_name": "Salvia officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617234273/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "rolymoly"
+    },
+    {
+      "species_id": "sambucus_nigra_peruviana",
+      "scientific_name": "Sambucus nigra subsp. peruviana (Kunth) R. Bolli",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/476864299/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Kennedy"
+    },
+    {
+      "species_id": "schizolobium_parahyba",
+      "scientific_name": "Schizolobium parahyba (Vell.) Blake",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607330651/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "filipeprates"
+    },
+    {
+      "species_id": "senna_pistaciifolia",
+      "scientific_name": "Senna pistaciifolia (Kunth) H.S.Irwin & Barneby",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/37945205/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "John G. Phillips"
+    },
+    {
+      "species_id": "senna_spectabilis",
+      "scientific_name": "Senna spectabilis (DC.) H.S.Irwin & Barneby",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/623067845/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Fabricio Carvalho da Silva"
+    },
+    {
+      "species_id": "sesamum_indicum",
+      "scientific_name": "Sesamum indicum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616431473/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Brayam Paul Perez Barbarin"
+    },
+    {
+      "species_id": "solanum_betaceum",
+      "scientific_name": "Solanum betaceum Cav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605808233/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Steven Smethurst"
+    },
+    {
+      "species_id": "solanum_lycopersicum",
+      "scientific_name": "Solanum lycopersicum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608629968/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dave Richardson"
+    },
+    {
+      "species_id": "solanum_lycopersicum_cerasiforme",
+      "scientific_name": "Solanum lycopersicum var. cerasiforme (Dunal) A.Gray",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608629968/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dave Richardson"
+    },
+    {
+      "species_id": "solanum_lycopersicum_cerasiforme_uvalina",
+      "scientific_name": "Solanum lycopersicum var. cerasiforme 'Uvalina'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608629968/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dave Richardson"
+    },
+    {
+      "species_id": "solanum_lycopersicum_san_marzano",
+      "scientific_name": "Solanum lycopersicum 'San Marzano'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608629968/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dave Richardson"
+    },
+    {
+      "species_id": "solanum_lycopersicum_sungold",
+      "scientific_name": "Solanum lycopersicum 'Sungold'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608629968/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dave Richardson"
+    },
+    {
+      "species_id": "solanum_phureja",
+      "scientific_name": "Solanum phureja Juz. & Bukasov",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "solanum_tuberosum",
+      "scientific_name": "Solanum tuberosum L. subsp. andigenum var. parda pastusa",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "sorghum_bicolor",
+      "scientific_name": "Sorghum bicolor (L.) Moench",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/613242356/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Carl Ramirez"
+    },
+    {
+      "species_id": "symphytum_officinale",
+      "scientific_name": "Symphytum officinale L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607549965/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Frank Ashwood"
+    },
+    {
+      "species_id": "syzygium_jambos",
+      "scientific_name": "Syzygium jambos (L.) Alston",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607673044/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matthew Borella"
+    },
+    {
+      "species_id": "tamarindus_indica",
+      "scientific_name": "Tamarindus indica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605690675/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Anthony Batista"
+    },
+    {
+      "species_id": "tecoma_stans",
+      "scientific_name": "Tecoma stans (L.) Juss. ex Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606693979/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "theobroma_cacao",
+      "scientific_name": "Theobroma cacao L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608761215/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Derek Duplessis"
+    },
+    {
+      "species_id": "thunbergia_alata",
+      "scientific_name": "Thunbergia alata Bojer ex Sims",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610269211/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Martin Hannan-Jones"
+    },
+    {
+      "species_id": "trifolium_pratense",
+      "scientific_name": "Trifolium pratense L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604867034/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Conway Hawn"
+    },
+    {
+      "species_id": "trifolium_repens",
+      "scientific_name": "Trifolium repens L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604771014/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolas Olejnik"
+    },
+    {
+      "species_id": "tropaeolum_majus",
+      "scientific_name": "Tropaeolum majus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609017027/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "terrifricker"
+    },
+    {
+      "species_id": "tropaeolum_tuberosum",
+      "scientific_name": "Tropaeolum tuberosum Ruiz & Pav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/624594778/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Charlie O'Brien"
+    },
+    {
+      "species_id": "ulex_europaeus",
+      "scientific_name": "Ulex europaeus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605360177/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Charles Joynson"
+    },
+    {
+      "species_id": "ullucus_tuberosus",
+      "scientific_name": "Ullucus tuberosus Caldas",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/115743690/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "urtica_dioica",
+      "scientific_name": "Urtica dioica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604798046/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "vaccinium_corymbosum_biloxi",
+      "scientific_name": "Vaccinium corymbosum 'Biloxi'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607045877/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mfeaver"
+    },
+    {
+      "species_id": "vaccinium_corymbosum_emerald",
+      "scientific_name": "Vaccinium corymbosum 'Emerald'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607045877/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mfeaver"
+    },
+    {
+      "species_id": "valeriana_officinalis",
+      "scientific_name": "Valeriana officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617821481/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Bernd De Bosscher"
+    },
+    {
+      "species_id": "verbena_litoralis",
+      "scientific_name": "Verbena litoralis Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616116319/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Cesar Ormazabal"
+    },
+    {
+      "species_id": "viburnum_triphyllum",
+      "scientific_name": "Viburnum triphyllum Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/660936287/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "vicia_sativa",
+      "scientific_name": "Vicia sativa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605564192/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "kiwialli"
+    },
+    {
+      "species_id": "weinmannia_tomentosa",
+      "scientific_name": "Weinmannia tomentosa L. f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610046226/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "xylosma_spiculifera",
+      "scientific_name": "Xylosma spiculifera (Tul.) Triana & Planch.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616535063/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "zanthoxylum_rhoifolium",
+      "scientific_name": "Zanthoxylum rhoifolium Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/461969017/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Joaquin Valentinuzzi"
+    },
+    {
+      "species_id": "zea_mays",
+      "scientific_name": "Zea mays L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618509763/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hannah Stitt"
+    },
+    {
+      "species_id": "amaranthus_caudatus",
+      "scientific_name": "Amaranthus caudatus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/630390824/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Courtney Tregurtha-Nairn"
+    },
+    {
+      "species_id": "vicia_faba",
+      "scientific_name": "Vicia faba L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604467340/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Tracy PW"
+    },
+    {
+      "species_id": "pisum_sativum_andina",
+      "scientific_name": "Pisum sativum L. var. andina",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604921296/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "ashleyrsteel"
+    },
+    {
+      "species_id": "lens_culinaris_andina",
+      "scientific_name": "Lens culinaris Medik. var. andina",
+      "image_url": "https://www.plantarium.ru/dat/plants/0/013/837013_a27f54cf.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "phaseolus_vulgaris_nuna",
+      "scientific_name": "Phaseolus vulgaris L. cv. nuna",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/500118303/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raúl A. Ruiz M."
+    },
+    {
+      "species_id": "dioscorea_trifida",
+      "scientific_name": "Dioscorea trifida L.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/257626568/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Guillaume Delaitre"
+    },
+    {
+      "species_id": "tropaeolum_tuberosum_mashua",
+      "scientific_name": "Tropaeolum tuberosum Ruiz & Pav. subsp. silvestre",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/624594778/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Charlie O'Brien"
+    },
+    {
+      "species_id": "solanum_tuberosum_sabanera",
+      "scientific_name": "Solanum tuberosum L. subsp. andigenum var. Sabanera",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "canna_edulis",
+      "scientific_name": "Canna edulis Ker Gawl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607529543/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Pierre Cartier"
+    },
+    {
+      "species_id": "smallanthus_sonchifolius",
+      "scientific_name": "Smallanthus sonchifolius (Poepp.) H.Rob.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/428395842/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "arracacia_xanthorrhiza",
+      "scientific_name": "Arracacia xanthorrhiza Bancr.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/182461836/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "vaccinium_meridionale",
+      "scientific_name": "Vaccinium meridionale Sw.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/479116076/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Patrick Jackson"
+    },
+    {
+      "species_id": "vaccinium_floribundum",
+      "scientific_name": "Vaccinium floribundum Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607950771/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Seebra Young"
+    },
+    {
+      "species_id": "vasconcellea_pubescens",
+      "scientific_name": "Vasconcellea pubescens A.DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610069605/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "fragaria_vesca",
+      "scientific_name": "Fragaria vesca L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605392363/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Patrick Le Mao"
+    },
+    {
+      "species_id": "rubus_glaucus",
+      "scientific_name": "Rubus glaucus Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/462588725/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Zoltán Stekkelpak"
+    },
+    {
+      "species_id": "solanum_quitoense",
+      "scientific_name": "Solanum quitoense Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610859797/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alina Martin"
+    },
+    {
+      "species_id": "spondias_mombin",
+      "scientific_name": "Spondias mombin L.",
+      "image_url": "https://object.jacq.org/europeana/WU/2008621.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "hesperomeles_obtusifolia",
+      "scientific_name": "Hesperomeles obtusifolia (Pers.) Lindl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616505536/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Lynn Harper"
+    },
+    {
+      "species_id": "thymus_vulgaris",
+      "scientific_name": "Thymus vulgaris L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609008279/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Augustin Soulard"
+    },
+    {
+      "species_id": "eryngium_foetidum",
+      "scientific_name": "Eryngium foetidum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605522356/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emily Franzen"
+    },
+    {
+      "species_id": "cucurbita_maxima",
+      "scientific_name": "Cucurbita maxima Duchesne",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607534145/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Joe Dillon"
+    },
+    {
+      "species_id": "matricaria_chamomilla",
+      "scientific_name": "Matricaria chamomilla L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606229021/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "nebrooks"
+    },
+    {
+      "species_id": "taraxacum_officinale",
+      "scientific_name": "Taraxacum officinale F.H.Wigg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604451006/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Karen Fry"
+    },
+    {
+      "species_id": "artemisia_absinthium",
+      "scientific_name": "Artemisia absinthium L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607031647/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Bob Lefebvre"
+    },
+    {
+      "species_id": "dodonaea_viscosa",
+      "scientific_name": "Dodonaea viscosa Jacq.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604680692/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "espeletia_argentea",
+      "scientific_name": "Espeletia argentea Bonpl. & Humb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604678071/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "espeletia_grandiflora",
+      "scientific_name": "Espeletia grandiflora Humb. & Bonpl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/623059290/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Josh Noseworthy"
+    },
+    {
+      "species_id": "hesperomeles_goudotiana",
+      "scientific_name": "Hesperomeles goudotiana (Decne.) Killip",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/461443187/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "polylepis_sericea",
+      "scientific_name": "Polylepis sericea Wedd.",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=14274132&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Conveyor Belt"
+    },
+    {
+      "species_id": "polylepis_quadrijuga",
+      "scientific_name": "Polylepis quadrijuga Bitter",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/593997050/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "salix_humboldtiana",
+      "scientific_name": "Salix humboldtiana Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606969406/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "nebrooks"
+    },
+    {
+      "species_id": "vallea_stipularis",
+      "scientific_name": "Vallea stipularis L. f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607285104/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "beta_vulgaris_var_cicla",
+      "scientific_name": "Beta vulgaris var. cicla L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "brassica_oleracea_var_acephala",
+      "scientific_name": "Brassica oleracea var. acephala L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_var_capitata",
+      "scientific_name": "Brassica oleracea var. capitata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_rapa_var_rapa",
+      "scientific_name": "Brassica rapa var. rapa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605529570/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mel letterman"
+    },
+    {
+      "species_id": "daucus_carota_subsp_sativus",
+      "scientific_name": "Daucus carota L. subsp. sativus (Hoffm.) Arcang.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605366692/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Karen Fry"
+    },
+    {
+      "species_id": "allium_schoenoprasum",
+      "scientific_name": "Allium schoenoprasum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/646275779/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Uschi"
+    },
+    {
+      "species_id": "avena_sativa",
+      "scientific_name": "Avena sativa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615836432/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Adam M"
+    },
+    {
+      "species_id": "brassica_rapa_rapifera",
+      "scientific_name": "Brassica rapa L. var. rapifera",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605529570/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mel letterman"
+    },
+    {
+      "species_id": "festuca_arundinacea",
+      "scientific_name": "Festuca arundinacea Schreb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605005729/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Arnim Littek"
+    },
+    {
+      "species_id": "lolium_perenne",
+      "scientific_name": "Lolium perenne L.",
+      "image_url": "https://arter.dk/media/026b527a-8991-4382-9a55-32d438d8bc84.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "medicago_sativa",
+      "scientific_name": "Medicago sativa L.",
+      "image_url": "https://arter.dk/media/1ac385ea-a641-4751-9b3b-f9303f182228.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "mucuna_pruriens",
+      "scientific_name": "Mucuna pruriens (L.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/623169367/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Paulmathi Vinod"
+    },
+    {
+      "species_id": "raphanus_sativus_oleifer",
+      "scientific_name": "Raphanus sativus L. var. oleifer",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607770557/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Chase Mathey"
+    },
+    {
+      "species_id": "cocos_nucifera",
+      "scientific_name": "Cocos nucifera L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605077533/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Isis I. Castro Alberto"
+    },
+    {
+      "species_id": "bactris_gasipaes",
+      "scientific_name": "Bactris gasipaes Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621059999/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marcio Santos Ferreira"
+    },
+    {
+      "species_id": "euterpe_oleracea",
+      "scientific_name": "Euterpe oleracea Mart.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/638122468/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "liriodobrejoufscar"
+    },
+    {
+      "species_id": "aiphanes_aculeata",
+      "scientific_name": "Aiphanes aculeata Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/582418543/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "costus_spicatus",
+      "scientific_name": "Costus spicatus (Jacq.) Sw.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606311137/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matteo Bellucci"
+    },
+    {
+      "species_id": "alocasia_macrorrhizos",
+      "scientific_name": "Alocasia macrorrhizos (L.) G.Don",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604729623/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "observe-syz"
+    },
+    {
+      "species_id": "dioscorea_alata",
+      "scientific_name": "Dioscorea alata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/474070998/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "chiuluan"
+    },
+    {
+      "species_id": "solanum_sessiliflorum",
+      "scientific_name": "Solanum sessiliflorum Dunal",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/477212019/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "rebecca bachman"
+    },
+    {
+      "species_id": "renealmia_alpinia",
+      "scientific_name": "Renealmia alpinia (Rottb.) Maas",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/532032556/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Cy Stavros"
+    },
+    {
+      "species_id": "ipomoea_batatas_blanca",
+      "scientific_name": "Ipomoea batatas (L.) Lam. cv. blanca",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612311505/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "ipomoea_batatas_morada",
+      "scientific_name": "Ipomoea batatas (L.) Lam. cv. morada",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612311505/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "pachyrhizus_erosus",
+      "scientific_name": "Pachyrhizus erosus (L.) Urb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/512605915/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alexis López Hernández"
+    },
+    {
+      "species_id": "raphanus_sativus_longipinnatus",
+      "scientific_name": "Raphanus sativus L. var. longipinnatus",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607770557/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Chase Mathey"
+    },
+    {
+      "species_id": "raphanus_sativus_sativus",
+      "scientific_name": "Raphanus sativus L. var. sativus",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607770557/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Chase Mathey"
+    },
+    {
+      "species_id": "beta_vulgaris_altissima",
+      "scientific_name": "Beta vulgaris L. subsp. vulgaris var. altissima",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "pastinaca_sativa",
+      "scientific_name": "Pastinaca sativa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604397680/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "John Barkla"
+    },
+    {
+      "species_id": "cynara_cardunculus_scolymus",
+      "scientific_name": "Cynara cardunculus L. var. scolymus",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/521768070/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nico Hernandez"
+    },
+    {
+      "species_id": "foeniculum_vulgare_azoricum",
+      "scientific_name": "Foeniculum vulgare Mill. var. azoricum",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604750309/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrew Gillespie"
+    },
+    {
+      "species_id": "cyclanthera_pedata",
+      "scientific_name": "Cyclanthera pedata (L.) Schrad.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/640528495/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "gliricidia_sepium",
+      "scientific_name": "Gliricidia sepium (Jacq.) Kunth ex Walp.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607275670/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "trichanthera_gigantea",
+      "scientific_name": "Trichanthera gigantea (Bonpl.) Nees",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617071683/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "erythrina_rubrinervia",
+      "scientific_name": "Erythrina rubrinervia Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605450021/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "tigridia_pavonia",
+      "scientific_name": "Tigridia pavonia (L.f.) DC.",
+      "image_url": "https://media01.symbiota.org/media/h_seinet/seinet/ASU/ASU0301/ASU0301288_lg.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Arizona State University Vascular Plant Herbarium (ASU-ASU)"
+    },
+    {
+      "species_id": "guadua_angustifolia",
+      "scientific_name": "Guadua angustifolia Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611578152/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "buddleja_americana",
+      "scientific_name": "Buddleja americana L.",
+      "image_url": "https://api.jacq.org/v1/images/europeana/1832615?withredirect=1",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "acanthus_mollis",
+      "scientific_name": "Acanthus mollis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605369309/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Ellyne Geurts"
+    },
+    {
+      "species_id": "ruta_graveolens",
+      "scientific_name": "Ruta graveolens L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611901709/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Mehmet Baran"
+    },
+    {
+      "species_id": "valeriana_pavonii",
+      "scientific_name": "Valeriana pavonii Poepp. & Endl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/149717696/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrés Ramírez-Barrera"
+    },
+    {
+      "species_id": "drimys_granadensis",
+      "scientific_name": "Drimys granadensis L.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622718993/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "lavandula_angustifolia",
+      "scientific_name": "Lavandula angustifolia Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609008822/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Augustin Soulard"
+    },
+    {
+      "species_id": "aloe_vera",
+      "scientific_name": "Aloe vera (L.) Burm.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611235386/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Michael Bakker Paiva"
+    },
+    {
+      "species_id": "diplostephium_rosmarinifolium",
+      "scientific_name": "Diplostephium rosmarinifolium (Benth.) Wedd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622716034/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "dysphania_ambrosioides",
+      "scientific_name": "Dysphania ambrosioides (L.) Mosyakin & Clemants",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604871506/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Linda Jo Conn"
+    },
+    {
+      "species_id": "thymus_serpyllum",
+      "scientific_name": "Thymus serpyllum L.",
+      "image_url": "https://arter.dk/media/b451e404-0191-4f4a-b430-f1f659dbd38a.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "cymbopogon_nardus",
+      "scientific_name": "Cymbopogon nardus (L.) Rendle",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617712545/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "monkeyjodey"
+    },
+    {
+      "species_id": "zingiber_officinale",
+      "scientific_name": "Zingiber officinale Roscoe",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/535155518/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raúl A. Ruiz M."
+    },
+    {
+      "species_id": "curcuma_longa",
+      "scientific_name": "Curcuma longa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/523465399/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "SUBHASHGHULE"
+    },
+    {
+      "species_id": "cuminum_cyminum",
+      "scientific_name": "Cuminum cyminum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/173052321/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "elettaria_cardamomum",
+      "scientific_name": "Elettaria cardamomum (L.) Maton",
+      "image_url": "https://indiabiodiversity.org/biodiv/observations//1a51b8c4-08fa-424f-a65f-744e9e1a3315/85b5db3d342d4ea3afbd47fe06f2c9f0.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "vanilla_planifolia",
+      "scientific_name": "Vanilla planifolia Jacks. ex Andrews",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621413172/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Lisa_James"
+    },
+    {
+      "species_id": "illicium_verum",
+      "scientific_name": "Illicium verum Hook.f.",
+      "image_url": "https://ibss-images.calacademy.org/static/botany/originals/c5/81/c581d48c-4f76-4775-863b-9c449d6efc07.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "mentha_villosa",
+      "scientific_name": "Mentha x villosa Huds.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/650322225/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stephen James McWilliam"
+    },
+    {
+      "species_id": "borojoa_patinoi",
+      "scientific_name": "Borojoa patinoi Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/208318493/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Zac Peterson"
+    },
+    {
+      "species_id": "pourouma_cecropiifolia",
+      "scientific_name": "Pourouma cecropiifolia Mart.",
+      "image_url": "https://ia601208.us.archive.org/18/items/maate-arsfc-2023-3016/AV195.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Coralía Calispa"
+    },
+    {
+      "species_id": "inga_vera",
+      "scientific_name": "Inga vera Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608427903/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Yolanda M. Leon"
+    },
+    {
+      "species_id": "inga_densiflora",
+      "scientific_name": "Inga densiflora Benth.",
+      "image_url": "https://media01.symbiota.org/media/seinet/swnode/ASU_Plants/CSP21/CSP21240.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Arizona State University Vascular Plant Herbarium"
+    },
+    {
+      "species_id": "cenchrus_clandestinus_manejado",
+      "scientific_name": "Cenchrus clandestinus (Hochst. ex Chiov.) Morrone",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604758419/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "sambucus_peruviana",
+      "scientific_name": "Sambucus peruviana Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/476864299/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Kennedy"
+    },
+    {
+      "species_id": "agrostis_foliata",
+      "scientific_name": "Agrostis foliata Roem. & Schult.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616196688/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Brandon Corder"
+    },
+    {
+      "species_id": "miconia_squamulosa",
+      "scientific_name": "Miconia squamulosa Naudin",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/475384847/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "escallonia_paniculata",
+      "scientific_name": "Escallonia paniculata (Ruiz & Pav.) Schult.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/468513628/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ben Costamagna"
+    },
+    {
+      "species_id": "tibouchina_lepidota",
+      "scientific_name": "Tibouchina lepidota (Bonpl.) Baill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610826240/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emily Turteltaub Nelson"
+    },
+    {
+      "species_id": "chuquiraga_jussieui",
+      "scientific_name": "Chuquiraga jussieui J.F.Gmel.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610865037/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "piper_bogotense",
+      "scientific_name": "Piper bogotense C.DC.",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/eaea7b8f233c709624a8a39182ece54a.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "tovaria_pendula",
+      "scientific_name": "Tovaria pendula Ruiz & Pav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/340480837/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Mesa"
+    },
+    {
+      "species_id": "myrcianthes_leucoxyla",
+      "scientific_name": "Myrcianthes leucoxyla (Ortega) McVaugh",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/461443396/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "macleania_rupestris",
+      "scientific_name": "Macleania rupestris (Kunth) A.C.Sm.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608652258/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "bomarea_caldasii",
+      "scientific_name": "Bomarea caldasii (Kunth) Asch. & Graebn.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611379040/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emma Burns"
+    },
+    {
+      "species_id": "monnina_aestuans",
+      "scientific_name": "Monnina aestuans (L.f.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/461285899/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "gaultheria_anastomosans",
+      "scientific_name": "Gaultheria anastomosans (L.f.) Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/660898176/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "cavendishia_bracteata",
+      "scientific_name": "Cavendishia bracteata (Ruiz & Pav. ex J.St.-Hil.) Hoerold",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616493470/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Lynn Harper"
+    },
+    {
+      "species_id": "solanum_tuberosum_carrera_negra",
+      "scientific_name": "Solanum tuberosum L. subsp. andigenum cv. 'Carrera Negra'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "solanum_tuberosum_pastusa_suprema",
+      "scientific_name": "Solanum tuberosum L. subsp. tuberosum cv. 'Pastusa Suprema'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "solanum_tuberosum_argentina",
+      "scientific_name": "Solanum tuberosum L. subsp. tuberosum cv. 'Argentina'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607744677/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "cucurbita_moschata",
+      "scientific_name": "Cucurbita moschata Duchesne",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611692809/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Eric Knight"
+    },
+    {
+      "species_id": "zea_mays_negro_paramo",
+      "scientific_name": "Zea mays L. cv. 'Negro de Páramo'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618509763/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hannah Stitt"
+    },
+    {
+      "species_id": "zea_mays_capio",
+      "scientific_name": "Zea mays L. cv. 'Capio'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618509763/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hannah Stitt"
+    },
+    {
+      "species_id": "amaranthus_caudatus_kiwicha",
+      "scientific_name": "Amaranthus caudatus L. cv. 'Kiwicha'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/630390824/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Courtney Tregurtha-Nairn"
+    },
+    {
+      "species_id": "phaseolus_vulgaris_bola_roja",
+      "scientific_name": "Phaseolus vulgaris L. cv. 'Bola Roja'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/500118303/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raúl A. Ruiz M."
+    },
+    {
+      "species_id": "phaseolus_lunatus_andino",
+      "scientific_name": "Phaseolus lunatus L. cv. andino",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606068258/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "chenopodium_pallidicaule",
+      "scientific_name": "Chenopodium pallidicaule Aellen",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/477824921/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Humber Alberto"
+    },
+    {
+      "species_id": "pouteria_caimito",
+      "scientific_name": "Pouteria caimito (Ruiz & Pav.) Radlk.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612077709/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Rachael Kaiser"
+    },
+    {
+      "species_id": "theobroma_grandiflorum",
+      "scientific_name": "Theobroma grandiflorum (Willd. ex Spreng.) K.Schum.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/574059148/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Srinivasan Kasinathan"
+    },
+    {
+      "species_id": "myrciaria_dubia",
+      "scientific_name": "Myrciaria dubia (Kunth) McVaugh",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/50/34/15/01503415.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "euterpe_precatoria",
+      "scientific_name": "Euterpe precatoria Mart.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/470577376/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Anders Hastings"
+    },
+    {
+      "species_id": "solanum_quitoense_amazonico",
+      "scientific_name": "Solanum quitoense Lam. var. septentrionale (R.E.Schult. & Cuatrec.) Whalen",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610859797/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alina Martin"
+    },
+    {
+      "species_id": "bactris_gasipaes_amazonica",
+      "scientific_name": "Bactris gasipaes Kunth var. gasipaes (ecotipo amazónico)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621059999/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marcio Santos Ferreira"
+    },
+    {
+      "species_id": "manihot_esculenta",
+      "scientific_name": "Manihot esculenta Crantz",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608599553/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mark"
+    },
+    {
+      "species_id": "annona_mucosa",
+      "scientific_name": "Annona mucosa Jacq.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/629247577/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Guilherme Siniciato Terra Garbino"
+    },
+    {
+      "species_id": "inga_feuilleei",
+      "scientific_name": "Inga feuilleei DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/371688749/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Floro Ortiz Contreras"
+    },
+    {
+      "species_id": "psidium_friedrichsthalianum",
+      "scientific_name": "Psidium friedrichsthalianum (O.Berg) Nied.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/193306900/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Michelle Monge-Velazquez"
+    },
+    {
+      "species_id": "borago_officinalis",
+      "scientific_name": "Borago officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610680965/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "mentha_pulegium",
+      "scientific_name": "Mentha pulegium L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610225393/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "cestrum_nocturnum",
+      "scientific_name": "Cestrum nocturnum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614808111/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Keith S"
+    },
+    {
+      "species_id": "plantago_major",
+      "scientific_name": "Plantago major L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604469331/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "mikania_micrantha",
+      "scientific_name": "Mikania micrantha Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605206274/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Dana Lee Ling"
+    },
+    {
+      "species_id": "cnidoscolus_aconitifolius",
+      "scientific_name": "Cnidoscolus aconitifolius (Mill.) I.M.Johnst.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/474259191/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "achillea_millefolium",
+      "scientific_name": "Achillea millefolium L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604861582/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Dave Miller"
+    },
+    {
+      "species_id": "valeriana_jatamansi_andina",
+      "scientific_name": "Valeriana microphylla Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610864144/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "bixa_orellana",
+      "scientific_name": "Bixa orellana L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606703134/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "kristen_276"
+    },
+    {
+      "species_id": "nasturtium_officinale",
+      "scientific_name": "Nasturtium officinale W.T.Aiton",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605149484/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Conway Hawn"
+    },
+    {
+      "species_id": "ocimum_basilicum",
+      "scientific_name": "Ocimum basilicum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/643584612/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Guillaume Delaitre"
+    },
+    {
+      "species_id": "selenicereus_megalanthus",
+      "scientific_name": "Selenicereus megalanthus (K.Schum. ex Vaupel) Moran",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/447709319/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Luis G Restrepo"
+    },
+    {
+      "species_id": "solanum_muricatum",
+      "scientific_name": "Solanum muricatum Aiton",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622529444/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "agave_americana",
+      "scientific_name": "Agave americana L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604934999/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "insiderelic"
+    },
+    {
+      "species_id": "passiflora_edulis_amarilla_colombia",
+      "scientific_name": "Passiflora edulis Sims (cultivar amarillo colombiano)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608156227/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "filipeprates"
+    },
+    {
+      "species_id": "passiflora_quadrangularis",
+      "scientific_name": "Passiflora quadrangularis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612896547/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hank Raizen"
+    },
+    {
+      "species_id": "physalis_philadelphica",
+      "scientific_name": "Physalis philadelphica Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610046440/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "solanum_betaceum_naranja",
+      "scientific_name": "Solanum betaceum Cav. (cultivar naranja-amarillo)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605808233/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Steven Smethurst"
+    },
+    {
+      "species_id": "solanum_betaceum_morado",
+      "scientific_name": "Solanum betaceum Cav. (cultivar morado-antocianínico)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605808233/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Steven Smethurst"
+    },
+    {
+      "species_id": "indigofera_suffruticosa",
+      "scientific_name": "Indigofera suffruticosa Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/619756538/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "genipa_americana",
+      "scientific_name": "Genipa americana L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607571469/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Samuel Peláez Vélez"
+    },
+    {
+      "species_id": "caesalpinia_sappan",
+      "scientific_name": "Biancaea sappan (L.) Tod.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/451947841/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raja Sekhar Chimirala"
+    },
+    {
+      "species_id": "arrabidaea_chica",
+      "scientific_name": "Fridericia chica (Bonpl.) L.G.Lohmann",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/495382922/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Silvia Ten"
+    },
+    {
+      "species_id": "furcraea_andina",
+      "scientific_name": "Furcraea andina Trel.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609030307/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "gossypium_barbadense_criollo",
+      "scientific_name": "Gossypium barbadense L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/580307121/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "capacoscar"
+    },
+    {
+      "species_id": "agave_cocui",
+      "scientific_name": "Agave cocui Trel.",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=14647367&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Conveyor Belt"
+    },
+    {
+      "species_id": "cecropia_telealba",
+      "scientific_name": "Cecropia telealba Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/630387288/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "lonchocarpus_velutinus",
+      "scientific_name": "Deguelia utilis (A.C.Sm.) A.M.G.Azevedo",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/43/51/80/01435180.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "crotalaria_juncea",
+      "scientific_name": "Crotalaria juncea L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605862782/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Paulmathi Vinod"
+    },
+    {
+      "species_id": "malus_domestica_sabanera",
+      "scientific_name": "Malus domestica (Suckow) Borkh. cv. Sabanera",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604475614/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "guywallbanks"
+    },
+    {
+      "species_id": "pyrus_communis_anjou",
+      "scientific_name": "Pyrus communis L. cv. Anjou",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605621460/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "georges3"
+    },
+    {
+      "species_id": "prunus_persica_amarilla",
+      "scientific_name": "Prunus persica (L.) Batsch cv. Amarillo Sabanero",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/620415426/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nico Yak"
+    },
+    {
+      "species_id": "prunus_avium_ducezno",
+      "scientific_name": "Prunus avium (L.) L. cv. Ducezno",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605750498/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "puppyy"
+    },
+    {
+      "species_id": "prunus_domestica_ciruela_imperial",
+      "scientific_name": "Prunus domestica L. cv. Imperial",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/628109644/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrew Tree"
+    },
+    {
+      "species_id": "cydonia_oblonga",
+      "scientific_name": "Cydonia oblonga Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609833022/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "謝麗霦"
+    },
+    {
+      "species_id": "ficus_carica_higo",
+      "scientific_name": "Ficus carica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605440795/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alex Wilson"
+    },
+    {
+      "species_id": "morus_nigra_mora_de_arbol",
+      "scientific_name": "Morus nigra L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/646979273/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stephen James McWilliam"
+    },
+    {
+      "species_id": "eriobotrya_japonica",
+      "scientific_name": "Eriobotrya japonica (Thunb.) Lindl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605414155/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Piermario Maculan"
+    },
+    {
+      "species_id": "actinidia_deliciosa",
+      "scientific_name": "Actinidia deliciosa (A.Chev.) C.F.Liang & A.R.Ferguson",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605992795/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Sigourney Juneau"
+    },
+    {
+      "species_id": "leucaena_leucocephala",
+      "scientific_name": "Leucaena leucocephala (Lam.) de Wit",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605438547/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mattmsa"
+    },
+    {
+      "species_id": "tithonia_diversifolia",
+      "scientific_name": "Tithonia diversifolia (Hemsl.) A.Gray",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606794514/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Peter Quakenbush"
+    },
+    {
+      "species_id": "cratylia_argentea",
+      "scientific_name": "Cratylia argentea (Desv.) Kuntze",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/47/92/23/01479223.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "desmodium_intortum",
+      "scientific_name": "Desmodium intortum (Mill.) Urb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/624198406/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ong Jyh Seng"
+    },
+    {
+      "species_id": "pueraria_phaseoloides",
+      "scientific_name": "Pueraria phaseoloides (Roxb.) Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606586422/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Karen Saunders"
+    },
+    {
+      "species_id": "arachis_pintoi",
+      "scientific_name": "Arachis pintoi Krapov. & W.C.Greg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604881564/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Vinicius Cerutti"
+    },
+    {
+      "species_id": "astrocaryum_chambira",
+      "scientific_name": "Astrocaryum chambira Burret",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/460230585/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Joe crutwell"
+    },
+    {
+      "species_id": "phytelephas_macrocarpa",
+      "scientific_name": "Phytelephas macrocarpa Ruiz & Pav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/491855569/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alfredo Gutierrez Dipaz"
+    },
+    {
+      "species_id": "oenocarpus_bataua",
+      "scientific_name": "Oenocarpus bataua Mart.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/582418371/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "attalea_butyracea",
+      "scientific_name": "Attalea butyracea (Mutis ex L.f.) Wess.Boer",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/651703293/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Juan Cruzado Cortés"
+    },
+    {
+      "species_id": "cedrela_odorata",
+      "scientific_name": "Cedrela odorata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609828725/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "cordia_alliodora",
+      "scientific_name": "Cordia alliodora (Ruiz & Pav.) Oken",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621276859/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Norma Piedra"
+    },
+    {
+      "species_id": "swietenia_macrophylla",
+      "scientific_name": "Swietenia macrophylla King",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/633487534/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "葉子"
+    },
+    {
+      "species_id": "tabebuia_rosea",
+      "scientific_name": "Tabebuia rosea (Bertol.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/613464790/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Irene"
+    },
+    {
+      "species_id": "tabebuia_chrysantha",
+      "scientific_name": "Tabebuia chrysantha (Jacq.) G.Nicholson",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610845823/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "bombacopsis_quinata",
+      "scientific_name": "Bombacopsis quinata (Jacq.) Dugand",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/628663925/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrea Gantzer"
+    },
+    {
+      "species_id": "juglans_neotropica",
+      "scientific_name": "Juglans neotropica Diels",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/650037469/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "GERMAN LEONEL SARMIENTO CRUZ"
+    },
+    {
+      "species_id": "cariniana_pyriformis",
+      "scientific_name": "Cariniana pyriformis Miers",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/230310169/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Zac Peterson"
+    },
+    {
+      "species_id": "ochroma_pyramidale",
+      "scientific_name": "Ochroma pyramidale (Cav. ex Lam.) Urb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605811773/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emily Franzen"
+    },
+    {
+      "species_id": "myroxylon_balsamum",
+      "scientific_name": "Myroxylon balsamum (L.) Harms",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/55/12/68/01551268.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "brachiaria_decumbens",
+      "scientific_name": "Urochloa decumbens (Stapf) R.D.Webster",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/620447457/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Scott W. Gavins"
+    },
+    {
+      "species_id": "brachiaria_brizantha",
+      "scientific_name": "Urochloa brizantha (Hochst. ex A.Rich.) R.D.Webster",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/c2a6e8c7ccbe08b9d73663b7b2492254.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "panicum_maximum_mombasa",
+      "scientific_name": "Megathyrsus maximus (Jacq.) B.K.Simon & S.W.L.Jacobs cv. Mombasa",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605581546/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Damien Wallace"
+    },
+    {
+      "species_id": "cynodon_nlemfuensis",
+      "scientific_name": "Cynodon nlemfuensis Vanderyst",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/613657065/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "chiuluan"
+    },
+    {
+      "species_id": "digitaria_decumbens",
+      "scientific_name": "Digitaria eriantha Steud. cv. Pangola",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622692486/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Prince Molokomme"
+    },
+    {
+      "species_id": "andropogon_gayanus",
+      "scientific_name": "Andropogon gayanus Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/641312566/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Thomas Mesaglio"
+    },
+    {
+      "species_id": "paspalum_notatum",
+      "scientific_name": "Paspalum notatum Flüggé",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605105084/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Analía Belaus"
+    },
+    {
+      "species_id": "melinis_minutiflora",
+      "scientific_name": "Melinis minutiflora P.Beauv.",
+      "image_url": "https://restor2-prod-1-api.restor.eco/species/1/melinis_minutiflora/photo",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "setaria_sphacelata",
+      "scientific_name": "Setaria sphacelata (Schumach.) Stapf & C.E.Hubb. ex M.B.Moss",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608729724/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elizabeth Meier"
+    },
+    {
+      "species_id": "axonopus_compressus",
+      "scientific_name": "Axonopus compressus (Sw.) P.Beauv.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622335705/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Julia Palmer"
+    },
+    {
+      "species_id": "pseudosamanea_guachapele",
+      "scientific_name": "Pseudosamanea guachapele (Kunth) Harms",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/589577725/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raúl A. Ruiz M."
+    },
+    {
+      "species_id": "enterolobium_cyclocarpum",
+      "scientific_name": "Enterolobium cyclocarpum (Jacq.) Griseb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605764710/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "samanea_saman",
+      "scientific_name": "Samanea saman (Jacq.) Merr.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/620875699/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mary Beth Stowe"
+    },
+    {
+      "species_id": "albizia_guachapele",
+      "scientific_name": "Albizia niopoides (Spruce ex Benth.) Burkart",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/evb/evb/0/0/52/52/evb00005252.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EVALDO BUTTURA (EVB)"
+    },
+    {
+      "species_id": "prosopis_juliflora",
+      "scientific_name": "Prosopis juliflora (Sw.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610902268/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raja Sekhar Chimirala"
+    },
+    {
+      "species_id": "pithecellobium_dulce",
+      "scientific_name": "Pithecellobium dulce (Roxb.) Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610841629/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "cassia_grandis",
+      "scientific_name": "Cassia grandis L.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/642204351/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrea Gantzer"
+    },
+    {
+      "species_id": "bursera_graveolens",
+      "scientific_name": "Bursera graveolens (Kunth) Triana & Planch.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610506577/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "ceiba_pentandra",
+      "scientific_name": "Ceiba pentandra (L.) Gaertn.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604568565/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Karen McCabe"
+    },
+    {
+      "species_id": "byrsonima_crassifolia",
+      "scientific_name": "Byrsonima crassifolia (L.) Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615891275/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Norma Piedra"
+    },
+    {
+      "species_id": "cattleya_trianae",
+      "scientific_name": "Cattleya trianae Linden & Rchb.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/581515406/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Martin Kalfatovic"
+    },
+    {
+      "species_id": "odontoglossum_crispum",
+      "scientific_name": "Oncidium alexandrae (Bateman) M.W.Chase & N.H.Williams (syn. Odontoglossum crispum Lindl.)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/255214719/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Andrew J. Crawford"
+    },
+    {
+      "species_id": "masdevallia_coccinea",
+      "scientific_name": "Masdevallia coccinea Linden ex Lindl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/149960261/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrés Ramírez-Barrera"
+    },
+    {
+      "species_id": "tillandsia_complanata",
+      "scientific_name": "Tillandsia complanata Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609990302/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Samuel Peláez Vélez"
+    },
+    {
+      "species_id": "tillandsia_usneoides",
+      "scientific_name": "Tillandsia usneoides (L.) L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604835079/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Brandon Corder"
+    },
+    {
+      "species_id": "puya_clava_herculis",
+      "scientific_name": "Puya clava-herculis Mez & Sodiro",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/521980824/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "novvictan"
+    },
+    {
+      "species_id": "polypodium_decumanum",
+      "scientific_name": "Phlebodium decumanum (Willd.) J.Sm. (syn. Polypodium decumanum Willd.)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/634491653/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Natan Gabriel"
+    },
+    {
+      "species_id": "dicksonia_sellowiana",
+      "scientific_name": "Dicksonia sellowiana Hook.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/626461020/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Jean Wickert"
+    },
+    {
+      "species_id": "equisetum_giganteum",
+      "scientific_name": "Equisetum giganteum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605548921/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "karuquebec"
+    },
+    {
+      "species_id": "selaginella_lepidophylla",
+      "scientific_name": "Selaginella lepidophylla (Hook. & Grev.) Spring",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606497351/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EJ Burns"
+    },
+    {
+      "species_id": "eichhornia_crassipes",
+      "scientific_name": "Eichhornia crassipes (Mart.) Solms [sinónimo histórico; nombre POWO actual: Pontederia crassipes Mart.]",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605316328/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Scott Edmunds"
+    },
+    {
+      "species_id": "victoria_amazonica",
+      "scientific_name": "Victoria amazonica (Poepp.) J.C.Sowerby",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612191619/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Charlotte Kirchner"
+    },
+    {
+      "species_id": "nymphaea_alba_andina",
+      "scientific_name": "Nymphaea alba L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618751838/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Алексей Логинов"
+    },
+    {
+      "species_id": "lemna_minor",
+      "scientific_name": "Lemna minor L.",
+      "image_url": "https://arter.dk/media/52ddae50-0617-4acf-9c08-c9401e7e624d.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "pistia_stratiotes",
+      "scientific_name": "Pistia stratiotes L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604895177/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "David Garza"
+    },
+    {
+      "species_id": "azolla_filiculoides",
+      "scientific_name": "Azolla filiculoides Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605543137/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Levitis"
+    },
+    {
+      "species_id": "typha_dominguensis",
+      "scientific_name": "Typha domingensis Pers.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607041426/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mattmsa"
+    },
+    {
+      "species_id": "juncus_effusus",
+      "scientific_name": "Juncus effusus L.",
+      "image_url": "https://arter.dk/media/a426be15-319a-42d5-a9fd-5d8bbba72181.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "cyperus_articulatus",
+      "scientific_name": "Cyperus articulatus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/632533114/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Andrew Deacon"
+    },
+    {
+      "species_id": "polygonum_punctatum",
+      "scientific_name": "Polygonum punctatum Elliott",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611788932/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dennis Vollmar"
+    },
+    {
+      "species_id": "opuntia_ficus_indica",
+      "scientific_name": "Opuntia ficus-indica (L.) Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605147615/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elias"
+    },
+    {
+      "species_id": "stenocereus_griseus",
+      "scientific_name": "Stenocereus griseus (Haw.) Buxb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606466358/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emily Turteltaub Nelson"
+    },
+    {
+      "species_id": "hylocereus_undatus",
+      "scientific_name": "Hylocereus undatus (Haw.) Britton & Rose",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605473528/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "capacoscar"
+    },
+    {
+      "species_id": "epiphyllum_phyllanthus",
+      "scientific_name": "Epiphyllum phyllanthus (L.) Haw.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605214841/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "aloe_arborescens",
+      "scientific_name": "Aloe arborescens Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608676971/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Sunčana Bradley"
+    },
+    {
+      "species_id": "agave_tequilana",
+      "scientific_name": "Agave tequilana F.A.C.Weber",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/244124629/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Zoltán Stekkelpak"
+    },
+    {
+      "species_id": "sansevieria_trifasciata",
+      "scientific_name": "Dracaena trifasciata (Prain) Mabb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604529562/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Lauren Bosch"
+    },
+    {
+      "species_id": "crassula_ovata",
+      "scientific_name": "Crassula ovata (Mill.) Druce",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609934825/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "W Rao"
+    },
+    {
+      "species_id": "kalanchoe_pinnata",
+      "scientific_name": "Kalanchoe pinnata (Lam.) Pers.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610784356/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sam Droege"
+    },
+    {
+      "species_id": "capsicum_chinense_aji_panca",
+      "scientific_name": "Capsicum chinense Jacq. cv. 'Panca'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/634013106/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "capsicum_baccatum_aji_amarillo",
+      "scientific_name": "Capsicum baccatum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/376508052/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Monics Paredes"
+    },
+    {
+      "species_id": "capsicum_pubescens_rocoto",
+      "scientific_name": "Capsicum pubescens Ruiz & Pav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/274703754/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "capsicum_annuum_aji_dulce_caribe",
+      "scientific_name": "Capsicum annuum L. cv. 'Dulce'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/619664379/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Liliana Ramírez-Freire"
+    },
+    {
+      "species_id": "tagetes_minuta",
+      "scientific_name": "Tagetes minuta L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604949940/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Saira Manns"
+    },
+    {
+      "species_id": "tagetes_lucida",
+      "scientific_name": "Tagetes lucida Cav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/534007105/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Favian Flores Medina"
+    },
+    {
+      "species_id": "anethum_graveolens",
+      "scientific_name": "Anethum graveolens L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/512569336/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Ogonslav Firewind"
+    },
+    {
+      "species_id": "levisticum_officinale",
+      "scientific_name": "Levisticum officinale W.D.J.Koch",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/637049411/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marie-Louise Besenius"
+    },
+    {
+      "species_id": "salvia_hispanica",
+      "scientific_name": "Salvia hispanica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/620030665/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Tenoch Cuauhtémoc Perez"
+    },
+    {
+      "species_id": "nigella_sativa",
+      "scientific_name": "Nigella sativa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/511371206/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "kardelen"
+    },
+    {
+      "species_id": "helianthus_annuus",
+      "scientific_name": "Helianthus annuus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604668784/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daughter Dad"
+    },
+    {
+      "species_id": "viola_tricolor",
+      "scientific_name": "Viola tricolor L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621631004/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "jack12347"
+    },
+    {
+      "species_id": "viola_odorata",
+      "scientific_name": "Viola odorata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604529273/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Cahen"
+    },
+    {
+      "species_id": "lavandula_dentata",
+      "scientific_name": "Lavandula dentata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/619336795/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Dietmar K. L. Moser"
+    },
+    {
+      "species_id": "phacelia_tanacetifolia",
+      "scientific_name": "Phacelia tanacetifolia Benth.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605942714/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ian Wright"
+    },
+    {
+      "species_id": "centaurea_cyanus",
+      "scientific_name": "Centaurea cyanus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604784325/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emma Creasey"
+    },
+    {
+      "species_id": "hibiscus_sabdariffa",
+      "scientific_name": "Hibiscus sabdariffa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610748472/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "chrisdt"
+    },
+    {
+      "species_id": "dahlia_imperialis",
+      "scientific_name": "Dahlia imperialis Roezl ex Ortgies",
+      "image_url": "https://media.tepapa.govt.nz/collection/880544/preview",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Museum of New Zealand Te Papa Tongarewa"
+    },
+    {
+      "species_id": "cosmos_sulphureus",
+      "scientific_name": "Cosmos sulphureus Cav.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606702337/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "kristen_276"
+    },
+    {
+      "species_id": "monarda_didyma",
+      "scientific_name": "Monarda didyma L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/528455393/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Liz Harper"
+    },
+    {
+      "species_id": "pachyrhizus_tuberosus",
+      "scientific_name": "Pachyrhizus tuberosus (Lam.) Spreng.",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/0744c242db4b6b9a9a77bff6e69d2b10.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "colocasia_esculenta",
+      "scientific_name": "Colocasia esculenta (L.) Schott",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605260471/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Texas Bird Family"
+    },
+    {
+      "species_id": "lepidium_meyenii",
+      "scientific_name": "Lepidium meyenii Walp.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/518863478/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "mirabilis_expansa",
+      "scientific_name": "Mirabilis expansa (Ruiz & Pav.) Standl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/630820278/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "GREGORY ANTHONY PAUCA TANCO"
+    },
+    {
+      "species_id": "arracacia_xanthorrhiza_amarilla",
+      "scientific_name": "Arracacia xanthorrhiza Bancr. cv. 'Amarilla'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/182461836/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "manihot_glaziovii",
+      "scientific_name": "Manihot glaziovii Müll.Arg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605678767/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "dejone"
+    },
+    {
+      "species_id": "dioscorea_japonica",
+      "scientific_name": "Dioscorea japonica Thunb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/643330798/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Kiwi Shen"
+    },
+    {
+      "species_id": "ipomoea_aquatica",
+      "scientific_name": "Ipomoea aquatica Forssk.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608961330/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stefan C"
+    },
+    {
+      "species_id": "xanthosoma_sagittifolium",
+      "scientific_name": "Xanthosoma sagittifolium (L.) Schott",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606312447/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matteo Bellucci"
+    },
+    {
+      "species_id": "xanthosoma_violaceum",
+      "scientific_name": "Xanthosoma violaceum Schott",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606312447/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matteo Bellucci"
+    },
+    {
+      "species_id": "phytelephas_seemannii",
+      "scientific_name": "Phytelephas seemannii O.F.Cook",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/491855569/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alfredo Gutierrez Dipaz"
+    },
+    {
+      "species_id": "mauritia_flexuosa",
+      "scientific_name": "Mauritia flexuosa L.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608769180/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Martha Lucia Ortiz-Moreno"
+    },
+    {
+      "species_id": "oenocarpus_mapora",
+      "scientific_name": "Oenocarpus mapora H.Karst.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/429839170/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "keesgroenendijk"
+    },
+    {
+      "species_id": "borojoa_sorbilis",
+      "scientific_name": "Borojoa sorbilis (Ducke) Cuatrec.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/38/84/0/01388400.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "theobroma_bicolor",
+      "scientific_name": "Theobroma bicolor Humb. & Bonpl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/361375442/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Bill Levine"
+    },
+    {
+      "species_id": "myristica_fragrans_americana",
+      "scientific_name": "Myristica fragrans Houtt.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618651325/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Cheongweei Gan"
+    },
+    {
+      "species_id": "pourouma_cecropiifolia_silvestre",
+      "scientific_name": "Pourouma cecropiifolia Mart.",
+      "image_url": "https://ia601208.us.archive.org/18/items/maate-arsfc-2023-3016/AV195.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Coralía Calispa"
+    },
+    {
+      "species_id": "garcinia_madruno",
+      "scientific_name": "Garcinia madruno (Kunth) Hammel",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/651468213/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Silvia Ten"
+    },
+    {
+      "species_id": "couma_macrocarpa",
+      "scientific_name": "Couma macrocarpa Barb.Rodr.",
+      "image_url": "https://web.corral.tacc.utexas.edu/brit/BRIT/BRIT1153000/BRIT1153775.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Botanical Research Institute of Texas"
+    },
+    {
+      "species_id": "pouteria_torta",
+      "scientific_name": "Pouteria torta (Mart.) Radlk.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/651114623/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Thomaz Ricardo Favreto Sinani"
+    },
+    {
+      "species_id": "aloysia_citrodora",
+      "scientific_name": "Aloysia citrodora Paláu",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/631168456/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "nebrooks"
+    },
+    {
+      "species_id": "cymbopogon_flexuosus",
+      "scientific_name": "Cymbopogon flexuosus (Nees ex Steud.) W. Watson",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/419231013/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Patricia Rose"
+    },
+    {
+      "species_id": "verbena_officinalis",
+      "scientific_name": "Verbena officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607008361/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Patrick Hacker"
+    },
+    {
+      "species_id": "lippia_alba",
+      "scientific_name": "Lippia alba (Mill.) N.E.Br. ex Britton & P.Wilson",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610393985/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Catriona Hays Howson"
+    },
+    {
+      "species_id": "chamaemelum_nobile",
+      "scientific_name": "Chamaemelum nobile (L.) All.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608696189/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "passiflora_incarnata",
+      "scientific_name": "Passiflora incarnata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608028367/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Lauren McLaurin"
+    },
+    {
+      "species_id": "petiveria_alliacea",
+      "scientific_name": "Petiveria alliacea L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609740515/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Melissa Meadows"
+    },
+    {
+      "species_id": "pteridium_arachnoideum",
+      "scientific_name": "Pteridium arachnoideum (Kaulf.) Maxon",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604712031/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Scott W. Gavins"
+    },
+    {
+      "species_id": "solanum_americanum",
+      "scientific_name": "Solanum americanum Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604626227/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raúl A. Ruiz M."
+    },
+    {
+      "species_id": "kalanchoe_blossfeldiana",
+      "scientific_name": "Kalanchoe blossfeldiana Poelln.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617848144/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Arne Holgersson"
+    },
+    {
+      "species_id": "vigna_unguiculata",
+      "scientific_name": "Vigna unguiculata (L.) Walp.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/654083548/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Afsar Nayakkan"
+    },
+    {
+      "species_id": "vigna_subterranea",
+      "scientific_name": "Vigna subterranea (L.) Verdc.",
+      "image_url": "http://sweetgum.nybg.org/images3/4088/967/04336019.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "The New York Botanical Garden"
+    },
+    {
+      "species_id": "cajanus_cajan",
+      "scientific_name": "Cajanus cajan (L.) Huth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614444531/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Malcolm Gould"
+    },
+    {
+      "species_id": "cicer_arietinum",
+      "scientific_name": "Cicer arietinum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/369948986/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Eleftherios Katsillis"
+    },
+    {
+      "species_id": "psophocarpus_tetragonolobus",
+      "scientific_name": "Psophocarpus tetragonolobus (L.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/631759695/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ong Jyh Seng"
+    },
+    {
+      "species_id": "canavalia_ensiformis",
+      "scientific_name": "Canavalia ensiformis (L.) DC.",
+      "image_url": "https://indiabiodiversity.org/biodiv/observations//4b5d1e4e-2ebe-4a51-ae45-3c9fce99c4cc/ccfb4f0dfae44d5eb1954c59220d3aba.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "dioscorea_rotundata",
+      "scientific_name": "Dioscorea rotundata Poir.",
+      "image_url": "http://sweetgum.nybg.org/images3/4088/958/04336006.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "The New York Botanical Garden"
+    },
+    {
+      "species_id": "dioscorea_cayennensis",
+      "scientific_name": "Dioscorea cayennensis Lam.",
+      "image_url": "http://sweetgum.nybg.org/images3/4088/958/04336006.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "The New York Botanical Garden"
+    },
+    {
+      "species_id": "colocasia_antiquorum",
+      "scientific_name": "Colocasia antiquorum Schott",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605260471/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Texas Bird Family"
+    },
+    {
+      "species_id": "eleocharis_dulcis",
+      "scientific_name": "Eleocharis dulcis (Burm.f.) Trin. ex Hensch.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615155664/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Mason Brock"
+    },
+    {
+      "species_id": "chrysophyllum_cainito",
+      "scientific_name": "Chrysophyllum cainito L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/631475279/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Hernán Rodríguez"
+    },
+    {
+      "species_id": "pouteria_sapota",
+      "scientific_name": "Pouteria sapota (Jacq.) H.E.Moore & Stearn",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616960764/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alexis Williams"
+    },
+    {
+      "species_id": "mammea_americana",
+      "scientific_name": "Mammea americana L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617709523/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "monkeyjodey"
+    },
+    {
+      "species_id": "talisia_olivaeformis",
+      "scientific_name": "Talisia olivaeformis (Kunth) Radlk.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/257556417/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alexis López Hernández"
+    },
+    {
+      "species_id": "melicoccus_bijugatus",
+      "scientific_name": "Melicoccus bijugatus Jacq.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612223137/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sam Droege"
+    },
+    {
+      "species_id": "spondias_purpurea",
+      "scientific_name": "Spondias purpurea L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614649267/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Xavier Alejandro Caratachea Navarro"
+    },
+    {
+      "species_id": "spondias_dulcis",
+      "scientific_name": "Spondias dulcis Parkinson",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/626189170/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matteo Bellucci"
+    },
+    {
+      "species_id": "eugenia_uniflora",
+      "scientific_name": "Eugenia uniflora L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607902293/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Kai Murphy"
+    },
+    {
+      "species_id": "mauritia_minor",
+      "scientific_name": "Mauritia minor Burret",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608769180/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Martha Lucia Ortiz-Moreno"
+    },
+    {
+      "species_id": "espeletia_uribei",
+      "scientific_name": "Espeletia uribei Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/592326079/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Andrew J. Crawford"
+    },
+    {
+      "species_id": "espeletia_killipii",
+      "scientific_name": "Espeletia killipii Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/138020117/original.png",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrés Ramírez-Barrera"
+    },
+    {
+      "species_id": "senecio_formosus",
+      "scientific_name": "Senecio formosus Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/584946957/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Dimitri Brosens"
+    },
+    {
+      "species_id": "pernettya_prostrata",
+      "scientific_name": "Pernettya prostrata (Cav.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605516863/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Emily Franzen"
+    },
+    {
+      "species_id": "hypericum_juniperinum",
+      "scientific_name": "Hypericum juniperinum Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607921714/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Chase Mathey"
+    },
+    {
+      "species_id": "bartsia_santolinifolia",
+      "scientific_name": "Bartsia santolinifolia (Kunth) Benth.",
+      "image_url": "https://oxalis.br.fgov.be/images/BR0/000/035/693/369/BR0000035693369.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Meise Botanic Garden"
+    },
+    {
+      "species_id": "lupinus_alopecuroides",
+      "scientific_name": "Lupinus alopecuroides Desr.",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/9026c1139cf0386c875dae2c7c33827e.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "loricaria_complanata",
+      "scientific_name": "Loricaria complanata (Sch.Bip.) Wedd.",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/99cbc9c537e7e4d741a1bdd02a46f0b7.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "disterigma_empetrifolium",
+      "scientific_name": "Disterigma empetrifolium (Kunth) Drude",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/619953029/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Sebastián Ordóñez"
+    },
+    {
+      "species_id": "paepalanthus_columbiensis",
+      "scientific_name": "Paepalanthus columbiensis Ruhland",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/658807278/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "banisteriopsis_caapi",
+      "scientific_name": "Banisteriopsis caapi (Spruce ex Griseb.) C.V. Morton",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/252717574/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Kevin Faccenda"
+    },
+    {
+      "species_id": "psychotria_viridis",
+      "scientific_name": "Psychotria viridis Ruiz & Pav.",
+      "image_url": "https://beaty.b-cdn.net/V253909.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "brugmansia_aurea",
+      "scientific_name": "Brugmansia aurea Lagerh.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615136384/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Chris Wyse"
+    },
+    {
+      "species_id": "brugmansia_arborea",
+      "scientific_name": "Brugmansia arborea (L.) Lagerh.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607252649/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "nebrooks"
+    },
+    {
+      "species_id": "nicotiana_rustica",
+      "scientific_name": "Nicotiana rustica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618711542/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Elliot Greiner"
+    },
+    {
+      "species_id": "salvia_divinorum",
+      "scientific_name": "Salvia divinorum Epling & Játiva",
+      "image_url": "https://media01.symbiota.org/media/seinet/swnode/DBG_KHD/KHD00070/KHD00070292_lg.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Kathryn Kalmbach Herbarium"
+    },
+    {
+      "species_id": "argyreia_nervosa",
+      "scientific_name": "Argyreia nervosa (Burm.f.) Bojer",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608070731/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Australian Institute of Pharmacognosy"
+    },
+    {
+      "species_id": "boswellia_sacra",
+      "scientific_name": "Boswellia sacra Flück.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/633316758/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Julien Renoult"
+    },
+    {
+      "species_id": "myroxylon_pereirae",
+      "scientific_name": "Myroxylon balsamum var. pereirae (Royle) Harms",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/55/12/68/01551268.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "attalea_speciosa",
+      "scientific_name": "Attalea speciosa Mart. ex Spreng.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/48/63/13/01486313-2.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "pseudobombax_septenatum",
+      "scientific_name": "Pseudobombax septenatum (Jacq.) Dugand",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607676165/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "keesgroenendijk"
+    },
+    {
+      "species_id": "anacardium_excelsum",
+      "scientific_name": "Anacardium excelsum (Bertero & Balb. ex Kunth) Skeels",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607676127/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "keesgroenendijk"
+    },
+    {
+      "species_id": "inga_alba",
+      "scientific_name": "Inga alba (Sw.) Willd.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/51/79/81/01517981.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "parkia_pendula",
+      "scientific_name": "Parkia pendula (Willd.) Benth. ex Walp.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/554157629/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "André Ambrozio"
+    },
+    {
+      "species_id": "simarouba_amara",
+      "scientific_name": "Simarouba amara Aubl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/651020535/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Thomaz Ricardo Favreto Sinani"
+    },
+    {
+      "species_id": "astronium_graveolens",
+      "scientific_name": "Astronium graveolens Jacq.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/466105301/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Pablo Cauã da Silva Toledo"
+    },
+    {
+      "species_id": "lecythis_minor",
+      "scientific_name": "Lecythis minor Jacq.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/629396659/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "aspidosperma_polyneuron",
+      "scientific_name": "Aspidosperma polyneuron Müll.Arg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/588205265/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jens-Christian Svenning"
+    },
+    {
+      "species_id": "cariniana_estrellensis",
+      "scientific_name": "Cariniana estrellensis (Raddi) Kuntze",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/639495790/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Thomaz Ricardo Favreto Sinani"
+    },
+    {
+      "species_id": "huberodendron_patinoi",
+      "scientific_name": "Huberodendron patinoi Cuatrec.",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=10614280&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sophia Lee"
+    },
+    {
+      "species_id": "caryocar_glabrum",
+      "scientific_name": "Caryocar glabrum (Aubl.) Pers.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/58/59/55/01585955.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "terminalia_amazonia",
+      "scientific_name": "Terminalia amazonia (J.F.Gmel.) Exell",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605321201/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "fmunoz"
+    },
+    {
+      "species_id": "clusia_multiflora",
+      "scientific_name": "Clusia multiflora Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/588255832/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "clusia_grandiflora",
+      "scientific_name": "Clusia grandiflora Splitg.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/600600487/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Jean-Paul Boerekamps"
+    },
+    {
+      "species_id": "viburnum_tinoides",
+      "scientific_name": "Viburnum tinoides L. f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/373138465/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "GERMAN LEONEL SARMIENTO CRUZ"
+    },
+    {
+      "species_id": "myrcianthes_rhopaloides",
+      "scientific_name": "Myrcianthes rhopaloides (Kunth) McVaugh",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/355567320/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "morella_pubescens",
+      "scientific_name": "Morella pubescens (Humb. & Bonpl. ex Willd.) Wilbur",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/468532059/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Ben Costamagna"
+    },
+    {
+      "species_id": "freziera_canescens",
+      "scientific_name": "Freziera canescens Bonpl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/531573224/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "oreopanax_incisus",
+      "scientific_name": "Oreopanax incisus (Willd. ex Roem. & Schult.) Decne. & Planch.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/622717102/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EstebanMH"
+    },
+    {
+      "species_id": "axinaea_macrophylla",
+      "scientific_name": "Axinaea macrophylla (Naudin) Triana",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609366105/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "clethra_fagifolia",
+      "scientific_name": "Clethra fagifolia Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/178197268/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "ilex_kunthiana",
+      "scientific_name": "Ilex kunthiana Triana",
+      "image_url": "https://medialib.naturalis.nl/file/id/L.3985963/format/large",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Naturalis Biodiversity Center"
+    },
+    {
+      "species_id": "weinmannia_pubescens",
+      "scientific_name": "Weinmannia pubescens Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/521545862/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Julien Renoult"
+    },
+    {
+      "species_id": "weinmannia_microphylla",
+      "scientific_name": "Weinmannia microphylla Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/448917036/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "gaiadendron_punctatum",
+      "scientific_name": "Gaiadendron punctatum (Ruiz & Pav.) G. Don",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605733555/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Francisco Sánchez Karste"
+    },
+    {
+      "species_id": "myrcianthes_ferreyrae",
+      "scientific_name": "Myrcianthes ferreyrae (McVaugh) McVaugh",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/ef08aa136cd831b4cc197cb0f54cba9e.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "prumnopitys_montana",
+      "scientific_name": "Prumnopitys montana (Humb. & Bonpl. ex Willd.) de Laub.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607257733/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "polylepis_incana",
+      "scientific_name": "Polylepis incana Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608260217/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Lucas Illanes"
+    },
+    {
+      "species_id": "polylepis_pauta",
+      "scientific_name": "Polylepis pauta Hieron.",
+      "image_url": "https://www.digitalis.uzh.ch/media/specimen/390/Z-000390901.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "espeletia_pycnophylla",
+      "scientific_name": "Espeletia pycnophylla Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/356864817/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nolan Exe"
+    },
+    {
+      "species_id": "espeletia_lopezii",
+      "scientific_name": "Espeletia lopezii Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/593997183/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "paragynoxys_uribei",
+      "scientific_name": "Paragynoxys uribei Cuatrec.",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/a3df2d692bb070df4790e6bf821b4cc4.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "vernonanthura_patens",
+      "scientific_name": "Vernonanthura patens (Kunth) H.Rob.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/625332818/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Juan Cruzado Cortés"
+    },
+    {
+      "species_id": "oreocallis_grandiflora",
+      "scientific_name": "Oreocallis grandiflora (Lam.) R.Br.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/625191034/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Allan Harris"
+    },
+    {
+      "species_id": "clethra_kalbreyeri",
+      "scientific_name": "Clethra kalbreyeri Britton",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606749388/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "geosesarma"
+    },
+    {
+      "species_id": "escallonia_myrtilloides",
+      "scientific_name": "Escallonia myrtilloides L.f.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621051886/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Efrain Freire"
+    },
+    {
+      "species_id": "gynoxys_baccharoides",
+      "scientific_name": "Gynoxys baccharoides (Kunth) Cass.",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=11718101&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Conveyor Belt"
+    },
+    {
+      "species_id": "myrsine_dependens",
+      "scientific_name": "Myrsine dependens (Ruiz & Pav.) Spreng.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/349907947/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "myrsine_andina",
+      "scientific_name": "Myrsine andina (Mez) Pipoly",
+      "image_url": "https://iiif.rbge.org.uk/herb/iiif/E01651557/full/1600,/0/default.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Royal Botanic Garden Edinburgh"
+    },
+    {
+      "species_id": "aragoa_abietina",
+      "scientific_name": "Aragoa abietina Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/636298242/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "valeriana_arborea",
+      "scientific_name": "Valeriana arborea Killip",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=12530052&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Conveyor Belt"
+    },
+    {
+      "species_id": "lupinus_carrikeri",
+      "scientific_name": "Lupinus carrikeri C.P.Sm.",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=12354023&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Conveyor Belt"
+    },
+    {
+      "species_id": "nectandra_acutifolia",
+      "scientific_name": "Nectandra acutifolia (Ruiz & Pav.) Mez",
+      "image_url": "http://sweetgum.nybg.org/images3/1205/867/01856394.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "The New York Botanical Garden"
+    },
+    {
+      "species_id": "ocotea_calophylla",
+      "scientific_name": "Ocotea calophylla Mez",
+      "image_url": "https://d2jcv3kl45hlgi.cloudfront.net/3714c8385f91369b49a4bd013083fa25.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Royal Botanic Gardens, Kew"
+    },
+    {
+      "species_id": "aniba_perutilis",
+      "scientific_name": "Aniba perutilis Hemsl.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/11311037/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Carlos Alberto Rodriguez"
+    },
+    {
+      "species_id": "cedrela_montana",
+      "scientific_name": "Cedrela montana Moritz ex Turcz.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/365448276/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "magnolia_caricifragrans",
+      "scientific_name": "Magnolia caricifragrans (Lozano) Govaerts",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618221921/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "magnolia_yarumalensis",
+      "scientific_name": "Magnolia yarumalensis (Lozano) Govaerts",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/592310386/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Daniel Mesa"
+    },
+    {
+      "species_id": "myrcia_popayanensis",
+      "scientific_name": "Myrcia popayanensis Hieron.",
+      "image_url": "https://collections.nmnh.si.edu/media/?i=13229916&h=2000",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Conveyor Belt"
+    },
+    {
+      "species_id": "escallonia_pendula",
+      "scientific_name": "Escallonia pendula (Ruiz & Pav.) Pers.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/629837667/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Darly Suaterna"
+    },
+    {
+      "species_id": "oreopanax_floribundum",
+      "scientific_name": "Oreopanax floribundum Decne. & Planch.",
+      "image_url": "https://media01.symbiota.org/media/seinet/swnode/ASU_Plants/CSP21/CSP21060_lg.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Arizona State University Vascular Plant Herbarium"
+    },
+    {
+      "species_id": "bocconia_frutescens",
+      "scientific_name": "Bocconia frutescens L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610786843/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hank Raizen"
+    },
+    {
+      "species_id": "vismia_baccifera",
+      "scientific_name": "Vismia baccifera (L.) Triana & Planch.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607286220/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Miguel José Lengua Hernández"
+    },
+    {
+      "species_id": "cinchona_pubescens",
+      "scientific_name": "Cinchona pubescens Vahl",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610787397/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Jacob Saucier"
+    },
+    {
+      "species_id": "cinchona_officinalis",
+      "scientific_name": "Cinchona officinalis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/351328816/original.jpeg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Alfredo F. Fuentes Claros"
+    },
+    {
+      "species_id": "myrsine_coriacea",
+      "scientific_name": "Myrsine coriacea (Sw.) R.Br. ex Roem. & Schult.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/evb/evb/0/0/77/1/evb00007701.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "EVALDO BUTTURA (EVB)"
+    },
+    {
+      "species_id": "persea_americana",
+      "scientific_name": "Persea americana Mill.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608148225/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Hugo Saulino"
+    },
+    {
+      "species_id": "mangifera_indica",
+      "scientific_name": "Mangifera indica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609015111/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "capacoscar"
+    },
+    {
+      "species_id": "ananas_comosus",
+      "scientific_name": "Ananas comosus (L.) Merr.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604761295/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Arthur Bitar Marinho Colares 🦈"
+    },
+    {
+      "species_id": "musa_paradisiaca",
+      "scientific_name": "Musa × paradisiaca L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608043778/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "citrus_latifolia",
+      "scientific_name": "Citrus × latifolia (Yu. Tanaka) Tanaka",
+      "image_url": "http://was.tacc.utexas.edu/fileget?coll=TEX-LL&type=O&filename=sp63290887849122722219.att.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "citrus_sinensis",
+      "scientific_name": "Citrus × sinensis (L.) Osbeck",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614731236/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Taylor DiTarando"
+    },
+    {
+      "species_id": "inga_punctata",
+      "scientific_name": "Inga punctata Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/393090021/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alexis López Hernández"
+    },
+    {
+      "species_id": "arracacia_xanthorrhiza_agrosavia_la22",
+      "scientific_name": "Arracacia xanthorrhiza Bancr.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/182461836/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nicolás Baresch Uribe"
+    },
+    {
+      "species_id": "justicia_pectoralis",
+      "scientific_name": "Justicia pectoralis Jacq.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/479323922/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "geosesarma"
+    },
+    {
+      "species_id": "sicana_odorifera",
+      "scientific_name": "Sicana odorifera (Vell.) Naudin",
+      "image_url": "https://media01.symbiota.org/media/seinet/sernec/USCH/USCH0023/USCH0023555.JPG",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+      "attribution": "University of South Carolina, A. C. Moore Herbarium Vascular Plant Collection"
+    },
+    {
+      "species_id": "cucurbita_moschata_agrosavia_la_plata",
+      "scientific_name": "Cucurbita moschata Duchesne ex Poir.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611692809/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Eric Knight"
+    },
+    {
+      "species_id": "cucurbita_maxima_landrace_andino",
+      "scientific_name": "Cucurbita maxima Duchesne",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607534145/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Joe Dillon"
+    },
+    {
+      "species_id": "genista_monspessulana",
+      "scientific_name": "Genista monspessulana (L.) L.A.S.Johnson",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609254087/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Hannah Whittall"
+    },
+    {
+      "species_id": "bactris_gasipaes_pacifico_chocoana",
+      "scientific_name": "Bactris gasipaes Kunth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/621059999/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marcio Santos Ferreira"
+    },
+    {
+      "species_id": "acca_sellowiana",
+      "scientific_name": "Acca sellowiana (O.Berg) Burret",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/624699123/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Gonzalo Romero"
+    },
+    {
+      "species_id": "physalis_angulata",
+      "scientific_name": "Physalis angulata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/608350020/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Martin Hannan-Jones"
+    },
+    {
+      "species_id": "passiflora_maliformis",
+      "scientific_name": "Passiflora maliformis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/349736093/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Miguel José Lengua Hernández"
+    },
+    {
+      "species_id": "passiflora_tarminiana",
+      "scientific_name": "Passiflora tarminiana Coppens & V.E.Barney",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605812306/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Richard Jacob"
+    },
+    {
+      "species_id": "solanum_melongena",
+      "scientific_name": "Solanum melongena L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606823088/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raja Sekhar Chimirala"
+    },
+    {
+      "species_id": "cucumis_sativus",
+      "scientific_name": "Cucumis sativus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612770733/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Paulo Nogueira"
+    },
+    {
+      "species_id": "cucumis_melo",
+      "scientific_name": "Cucumis melo L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607812537/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Sinaloa Silvestre"
+    },
+    {
+      "species_id": "citrullus_lanatus",
+      "scientific_name": "Citrullus lanatus (Thunb.) Matsum. & Nakai",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/611639600/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "stephen"
+    },
+    {
+      "species_id": "ananas_comosus_md_gold",
+      "scientific_name": "Ananas comosus (L.) Merr. 'MD-2'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604761295/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Arthur Bitar Marinho Colares 🦈"
+    },
+    {
+      "species_id": "myrciaria_cauliflora",
+      "scientific_name": "Myrciaria cauliflora (Mart.) O.Berg",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/638968845/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Fabrício Mil Homens Riella"
+    },
+    {
+      "species_id": "bunchosia_armeniaca",
+      "scientific_name": "Bunchosia armeniaca (Cuatrec.) Cuatrec.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/657535027/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Yolanda M. Leon"
+    },
+    {
+      "species_id": "malpighia_emarginata",
+      "scientific_name": "Malpighia emarginata DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/630935801/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Aleksey"
+    },
+    {
+      "species_id": "raphanus_sativus_niger",
+      "scientific_name": "Raphanus sativus var. niger (DC.) G.J.Hagen",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607770557/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Chase Mathey"
+    },
+    {
+      "species_id": "brassica_oleracea_sabellica",
+      "scientific_name": "Brassica oleracea var. sabellica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "beta_vulgaris_cicla_morada",
+      "scientific_name": "Beta vulgaris var. cicla 'Morada'",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605386667/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Shane Austin"
+    },
+    {
+      "species_id": "brassica_oleracea_gemmifera",
+      "scientific_name": "Brassica oleracea var. gemmifera DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615794433/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_oleracea_botrytis",
+      "scientific_name": "Brassica oleracea var. botrytis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/614591111/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "brassica_rapa",
+      "scientific_name": "Brassica rapa L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605529570/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "mel letterman"
+    },
+    {
+      "species_id": "brassica_napus",
+      "scientific_name": "Brassica napus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606955873/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Peter de Lange"
+    },
+    {
+      "species_id": "cichorium_intybus",
+      "scientific_name": "Cichorium intybus L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605580587/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Stanislav Murashkin"
+    },
+    {
+      "species_id": "valerianella_locusta",
+      "scientific_name": "Valerianella locusta (L.) Laterrr.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607229645/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "ju_stine"
+    },
+    {
+      "species_id": "flemingia_congesta",
+      "scientific_name": "Flemingia congesta Welw. ex Baker",
+      "image_url": "https://portal.wiktrop.org/biodiv/observations//cb4405fd-00ed-473f-879b-56d3c65a7110/51b2c95ea2db4c33abd77391a8822b89.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "stylosanthes_guianensis",
+      "scientific_name": "Stylosanthes guianensis (Aubl.) Sw.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/669349464/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Gabriel"
+    },
+    {
+      "species_id": "calopogonium_mucunoides",
+      "scientific_name": "Calopogonium mucunoides Desv.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607362113/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Matteo Bellucci"
+    },
+    {
+      "species_id": "bidens_alba",
+      "scientific_name": "Bidens alba (L.) DC.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605104804/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Craig Hensley"
+    },
+    {
+      "species_id": "pennisetum_clandestinum",
+      "scientific_name": "Pennisetum clandestinum Hochst. ex Chiov.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604758419/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Duarte Frade"
+    },
+    {
+      "species_id": "kyllinga_brevifolia",
+      "scientific_name": "Kyllinga brevifolia Rottb.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609794549/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Kelana Arraiza"
+    },
+    {
+      "species_id": "melilotus_officinalis",
+      "scientific_name": "Melilotus officinalis (L.) Pall.",
+      "image_url": "https://www.digitalis.uzh.ch/media/specimen/293/ZT-00293921.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "hypericum_perforatum",
+      "scientific_name": "Hypericum perforatum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605419038/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "謝麗霦"
+    },
+    {
+      "species_id": "cymbopogon_martinii",
+      "scientific_name": "Cymbopogon martinii (Roxb.) Wats.",
+      "image_url": "https://indiabiodiversity.org/biodiv/observations//7aeff435-eb0a-4839-8ef9-528ef3f17a4c/450.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "ocimum_sanctum",
+      "scientific_name": "Ocimum tenuiflorum L. (syn. O. sanctum)",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/643452127/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Navaneeth Sini George"
+    },
+    {
+      "species_id": "sambucus_nigra",
+      "scientific_name": "Sambucus nigra L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605146878/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Paul Cook"
+    },
+    {
+      "species_id": "piper_nigrum",
+      "scientific_name": "Piper nigrum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/474438145/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mark Clarke"
+    },
+    {
+      "species_id": "myristica_fragrans",
+      "scientific_name": "Myristica fragrans Houtt.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/618651325/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Cheongweei Gan"
+    },
+    {
+      "species_id": "cinnamomum_verum",
+      "scientific_name": "Cinnamomum verum J.Presl",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/612894905/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Kevin Faccenda"
+    },
+    {
+      "species_id": "syzygium_aromaticum",
+      "scientific_name": "Syzygium aromaticum (L.) Merr. & L.M.Perry",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/440974338/original.jpeg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Eric Knight"
+    },
+    {
+      "species_id": "foeniculum_vulgare_var_dulce",
+      "scientific_name": "Foeniculum vulgare var. dulce (Mill.) Thell.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604750309/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrew Gillespie"
+    },
+    {
+      "species_id": "majorana_hortensis",
+      "scientific_name": "Origanum majorana L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/525171461/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Marios Thoma"
+    },
+    {
+      "species_id": "prunus_persica",
+      "scientific_name": "Prunus persica (L.) Batsch",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/620415426/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Nico Yak"
+    },
+    {
+      "species_id": "prunus_domestica",
+      "scientific_name": "Prunus domestica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/628109644/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Andrew Tree"
+    },
+    {
+      "species_id": "prunus_armeniaca",
+      "scientific_name": "Prunus armeniaca L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/628804069/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Юрий Данилевский (Yuriy Danilevsky)"
+    },
+    {
+      "species_id": "ficus_carica",
+      "scientific_name": "Ficus carica L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605440795/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Alex Wilson"
+    },
+    {
+      "species_id": "punica_granatum",
+      "scientific_name": "Punica granatum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/609832087/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "謝麗霦"
+    },
+    {
+      "species_id": "pyrus_communis",
+      "scientific_name": "Pyrus communis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605621460/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "georges3"
+    },
+    {
+      "species_id": "malus_domestica",
+      "scientific_name": "Malus domestica Borkh.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604475614/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "guywallbanks"
+    },
+    {
+      "species_id": "morus_alba",
+      "scientific_name": "Morus alba L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605925157/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "nebrooks"
+    },
+    {
+      "species_id": "acacia_mangium",
+      "scientific_name": "Acacia mangium Willd.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/623566470/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Mickey Wu"
+    },
+    {
+      "species_id": "annona_muricata",
+      "scientific_name": "Annona muricata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/616176653/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "fmunoz"
+    },
+    {
+      "species_id": "calliandra_calothyrsus",
+      "scientific_name": "Calliandra calothyrsus Meisn.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/615098388/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "fmunoz"
+    },
+    {
+      "species_id": "carica_papaya",
+      "scientific_name": "Carica papaya L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/607005192/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Steven Smethurst"
+    },
+    {
+      "species_id": "cecropia_peltata",
+      "scientific_name": "Cecropia peltata L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605746627/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Lauren Bosch"
+    },
+    {
+      "species_id": "citrus_reticulata",
+      "scientific_name": "Citrus reticulata Blanco",
+      "image_url": "https://storage.googleapis.com/blaast-spel.appspot.com/observation/nSblsoLj93g3RE9bjV7GDIvp4eD2/ce1HZpg4R2ZBAmrYStW9/ccb418b8-ecd8-47aa-aac3-5e2bc7767708_500x500.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Deividas"
+    },
+    {
+      "species_id": "mimosa_sensitiva",
+      "scientific_name": "Mimosa sensitiva L.",
+      "image_url": "http://jbrj-public-img.s3-sa-east-1.amazonaws.com/JPG/rb/1/48/85/43/01488543.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "jacaranda_mimosifolia",
+      "scientific_name": "Jacaranda mimosifolia D.Don",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610141490/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Raja Sekhar Chimirala"
+    },
+    {
+      "species_id": "croton_lechleri",
+      "scientific_name": "Croton lechleri Müll.Arg.",
+      "image_url": "https://www.uc.edu/fulfordherbarium/images/Vascular/fullSize/2024ii/CINC-V-0025556.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "University of Cincinnati, Margaret H. Fulford Herbarium - Vascular Plants (CINC-CINC)"
+    },
+    {
+      "species_id": "lablab_purpureus",
+      "scientific_name": "Lablab purpureus (L.) Sweet",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/613205544/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "MIMI"
+    },
+    {
+      "species_id": "vicia_villosa",
+      "scientific_name": "Vicia villosa Roth",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/610549906/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Daniel Das"
+    },
+    {
+      "species_id": "hordeum_vulgare",
+      "scientific_name": "Hordeum vulgare L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/617662545/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Stevia"
+    },
+    {
+      "species_id": "secale_cereale",
+      "scientific_name": "Secale cereale L.",
+      "image_url": "https://images.ala.org.au/image/proxyImageThumbnailLarge?imageId=b4fb2ede-c513-451a-9a97-6a557784cd3d",
+      "license": "http://creativecommons.org/licenses/by/4.0/legalcode",
+      "attribution": "Unknown"
+    },
+    {
+      "species_id": "triticum_aestivum",
+      "scientific_name": "Triticum aestivum L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/606677230/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "Gregory Wada"
+    },
+    {
+      "species_id": "lolium_multiflorum",
+      "scientific_name": "Lolium multiflorum Lam.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/604574793/original.jpg",
+      "license": "http://creativecommons.org/licenses/by/4.0/",
+      "attribution": "kiwialli"
+    },
+    {
+      "species_id": "plukenetia_volubilis",
+      "scientific_name": "Plukenetia volubilis L.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/333486050/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "GP"
+    },
+    {
+      "species_id": "sechium_edule",
+      "scientific_name": "Sechium edule (Jacq.) Sw.",
+      "image_url": "https://inaturalist-open-data.s3.amazonaws.com/photos/605808231/original.jpg",
+      "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+      "attribution": "Steven Smethurst"
+    }
+  ]
+}

--- a/src/services/speciesImageService.js
+++ b/src/services/speciesImageService.js
@@ -1,9 +1,11 @@
 /**
  * speciesImageService, imágenes reales por nombre científico.
  *
- * Fuente primaria: GBIF occurrence media. Fallback: Wikimedia Commons.
- * No inventa URLs y solo acepta licencias abiertas compatibles.
+ * Prioridad: 1) JSON local (species-images.json), 2) GBIF occurrence media,
+ * 3) Wikimedia Commons. No inventa URLs y solo acepta licencias abiertas.
  */
+
+import { findLocalImage } from '../utils/speciesImageResolver';
 
 const GBIF_API = 'https://api.gbif.org/v1';
 const WIKIMEDIA_API = 'https://commons.wikimedia.org/w/api.php';
@@ -228,13 +230,27 @@ async function resolveSpeciesImage(nombreCientifico) {
   const cached = await readCached(nombreCientifico);
   if (cached) return cached;
 
+  // 1. Primero buscar en el JSON local (OpenCode data)
   let value = null;
   try {
-    value = await fetchFromGbif(nombreCientifico);
+    value = await findLocalImage(nombreCientifico);
+    if (value) {
+      console.debug('[speciesImageService] Found local image for:', nombreCientifico);
+    }
   } catch (err) {
-    console.warn('[speciesImageService] GBIF image lookup failed:', err?.message || err);
+    console.warn('[speciesImageService] Local image lookup failed:', err?.message || err);
   }
 
+  // 2. Si no hay imagen local, buscar en GBIF
+  if (!value) {
+    try {
+      value = await fetchFromGbif(nombreCientifico);
+    } catch (err) {
+      console.warn('[speciesImageService] GBIF image lookup failed:', err?.message || err);
+    }
+  }
+
+  // 3. Si no hay imagen en GBIF, buscar en Wikimedia
   if (!value) {
     try {
       value = await fetchFromWikimedia(nombreCientifico);

--- a/src/utils/speciesImageResolver.js
+++ b/src/utils/speciesImageResolver.js
@@ -1,0 +1,134 @@
+/**
+ * speciesImageResolver — Resuelve imágenes de especies desde el JSON local.
+ *
+ * Este módulo carga el JSON species-images.json que contiene las URLs
+ * de imágenes licencia abierta generadas por OpenCode. Se integra con
+ * speciesImageService para evitar llamadas externas cuando tenemos una
+ * imagen local disponible.
+ */
+
+let imageCache = null;
+let loadPromise = null;
+
+/**
+ * Normaliza un nombre científico para matching contra species_id.
+ * Convierte "Fragaria ananassa" → "fragaria_ananassa"
+ */
+function normalizeScientificName(name) {
+  if (!name || typeof name !== 'string') return '';
+  return name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '')
+    .trim();
+}
+
+/**
+ * Carga el JSON de imágenes del catálogo local.
+ */
+async function loadSpeciesImages() {
+  if (imageCache) return imageCache;
+  if (loadPromise) return loadPromise;
+
+  loadPromise = fetch('/species-images.json')
+    .then((res) => {
+      if (!res.ok) throw new Error(`species-images.json fetch failed: ${res.status}`);
+      return res.json();
+    })
+    .then((data) => {
+      if (!data || !Array.isArray(data.species)) {
+        throw new Error('Invalid species-images.json structure');
+      }
+      // Crear índice por species_id para búsqueda O(1)
+      const index = new Map();
+      for (const sp of data.species) {
+        if (sp?.species_id && sp?.image_url) {
+          index.set(sp.species_id, sp);
+        }
+      }
+      imageCache = index;
+      return index;
+    })
+    .catch((err) => {
+      console.warn('[speciesImageResolver] Failed to load local images:', err?.message || err);
+      imageCache = new Map(); // Cache vacío para no reintentar
+      return imageCache;
+    });
+
+  return loadPromise;
+}
+
+/**
+ * Busca una imagen por nombre científico en el JSON local.
+ * Retorna null si no hay imagen disponible.
+ */
+export async function findLocalImage(scientificName) {
+  const normalized = normalizeScientificName(scientificName);
+  if (!normalized) return null;
+
+  const index = await loadSpeciesImages();
+  if (!index) return null;
+
+  // 1. Búsqueda exacta por species_id normalizado
+  if (index.has(normalized)) {
+    const entry = index.get(normalized);
+    return {
+      url: entry.image_url,
+      thumbUrl: entry.image_url,
+      license: formatLicense(entry.license),
+      rightsHolder: entry.attribution || 'Autor no informado',
+      source: 'iNaturalist',
+      sourceUrl: entry.image_url,
+    };
+  }
+
+  // 2. Si el nombre contiene espacios, intentar con guion bajo
+  if (normalized.includes('_')) {
+    // Ya lo intentamos con guion bajo, no hay más variantes
+    return null;
+  }
+
+  // 3. Si el nombre tiene espacios, reemplazar por guiones y reintentar
+  const withUnderscores = normalized.replace(/\s+/g, '_');
+  if (withUnderscores !== normalized && index.has(withUnderscores)) {
+    const entry = index.get(withUnderscores);
+    return {
+      url: entry.image_url,
+      thumbUrl: entry.image_url,
+      license: formatLicense(entry.license),
+      rightsHolder: entry.attribution || 'Autor no informado',
+      source: 'iNaturalist',
+      sourceUrl: entry.image_url,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Formatea una licencia para display consistente.
+ */
+function formatLicense(license) {
+  if (!license) return 'CC-BY';
+  const s = String(license).toLowerCase();
+  if (s.includes('cc0')) return 'CC0';
+  if (s.includes('by')) return 'CC-BY';
+  if (s.includes('by-sa')) return 'CC-BY-SA';
+  if (s.includes('by-nc')) return 'CC-BY-NC';
+  return license;
+}
+
+/**
+ * Invalida el cache (útil para tests).
+ */
+export function __resetSpeciesImageCache() {
+  imageCache = null;
+  loadPromise = null;
+}
+
+export const __TEST__ = {
+  normalizeScientificName,
+  formatLicense,
+};


### PR DESCRIPTION
## Summary

This PR integrates species images generated by OpenCode into the Chagra PWA.

## Changes

- Add `public/species-images.json` (615 species with CC0/CC-BY image URLs from GBIF/iNaturalist)
- Create `src/utils/speciesImageResolver.js` to load and search images by scientific name
- Integrate `speciesImageResolver.js` into `src/services/speciesImageService.js` (priority: local > GBIF > Wikimedia)
- Component `SpeciesImage.jsx` already shows attribution (license, author, source) in small text

## Specs

- Mobile-first, no voseo
- eslint clean (no errors)
- CC-BY attribution shown correctly (9px, image footer)
- Fallback intact for species without local image

## Testing

- Species with image (e.g. Solanum lycopersicum) shows image with attribution
- Species without image (e.g. rare variety) shows current fallback
- Application builds successfully (npm run build)

## Data

- 615 of 634 catalog species have images
- Source: GBIF occurrence media (CC0/CC-BY) processed by OpenCode
- Generated: 2026-06-20