### PR TITLE
feat(juego): nivel 3 Defensores de la Finca — el cafetal en la niebla

### DIFF
--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -676,7 +676,7 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
 }
 
 /**
- * DefensoresFincaScreen — minijuego PLATAFORMERO 2D lateral con dos niveles.
+ * DefensoresFincaScreen — minijuego PLATAFORMERO 2D lateral con tres niveles.
  *
  * Un campesino NEUTRO (sin nombre propio) corre y salta por la finca: recoge
  * cultivos (puntos), esquiva plagas reales (pierde energía al tocarlas) e invoca
@@ -686,8 +686,12 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
  * Nivel 1 (la huerta, mediodía): corto y plano, 4 pares.
  * Nivel 2 (la ladera al atardecer): más largo (mundo con cámara), otra paleta,
  * 7 pares, plataformas a distinta altura, huecos que hacen daño y un mini-jefe
- * (langosta) que solo cae con su controlador real (la mantis). Se desbloquea al
- * completar el nivel 1; el progreso se guarda offline en localStorage.
+ * (langosta) que solo cae con su controlador real (la mantis).
+ * Nivel 3 (el cafetal en la niebla): el más largo, paleta de amanecer, 10 pares
+ * (incluye plagas del café: broca, minador y cochinilla con sus aliados reales),
+ * más plataformas y huecos, y un mini-jefe broca que solo cae con la avispa
+ * Cephalonomia. Cada nivel se desbloquea al completar el anterior; el progreso se
+ * guarda offline en localStorage.
  *
  * Mobile-first: controles táctiles grandes + teclado en desktop. Offline-safe:
  * canvas 2D puro, datos locales, cero red. Estética Chagra.
@@ -727,7 +731,7 @@ export default function DefensoresFincaScreen({ onBack, onHome }) {
           biológico!
         </p>
 
-        {/* Selector de nivel (1 / 2). El 2 se desbloquea al ganar el 1. */}
+        {/* Selector de nivel (1 / 2 / 3). Cada uno se desbloquea al ganar el anterior. */}
         <div
           className="df-niveles"
           role="group"

--- a/src/components/juego/__tests__/DefensoresFincaScreen.test.jsx
+++ b/src/components/juego/__tests__/DefensoresFincaScreen.test.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DefensoresFincaScreen from '../DefensoresFincaScreen';
-import { PARES_CONTROL, NIVEL_1, NIVEL_2, PROGRESO_KEY } from '../defensoresFincaData';
+import { PARES_CONTROL, NIVEL_1, NIVEL_2, NIVEL_3, PROGRESO_KEY } from '../defensoresFincaData';
 
 // jsdom no implementa canvas 2D: getContext devuelve null. El componente
 // guarda contra ctx null, así que el render no crashea y podemos probar el HUD,
@@ -65,16 +65,41 @@ describe('DefensoresFincaScreen', () => {
     raf.mockRestore();
   });
 
-  it('muestra el selector con ambos niveles; el 2 arranca bloqueado', () => {
+  it('muestra el selector con los tres niveles; el 2 y el 3 arrancan bloqueados', () => {
     render(<DefensoresFincaScreen />);
     expect(screen.getByTestId('defensores-niveles')).toBeInTheDocument();
     const nivel1 = screen.getByTestId('nivel-1');
     const nivel2 = screen.getByTestId('nivel-2');
+    const nivel3 = screen.getByTestId('nivel-3');
     expect(nivel1).not.toBeDisabled();
     expect(nivel1).toHaveAttribute('data-selected', 'true');
-    // Sin progreso guardado, el nivel 2 está bloqueado.
+    // Sin progreso guardado, los niveles 2 y 3 están bloqueados.
     expect(nivel2).toBeDisabled();
     expect(nivel2.textContent).toContain('Gana el nivel anterior');
+    expect(nivel3).toBeDisabled();
+    expect(nivel3.textContent).toContain('Gana el nivel anterior');
+  });
+
+  it('con los niveles 1 y 2 superados, el 3 (cafetal) queda jugable con sus aliados del café', () => {
+    localStorage.setItem(PROGRESO_KEY, JSON.stringify({ superados: [1, 2] }));
+    render(<DefensoresFincaScreen />);
+
+    const nivel3 = screen.getByTestId('nivel-3');
+    expect(nivel3).not.toBeDisabled();
+    expect(nivel3.textContent).toContain(NIVEL_3.nombre);
+
+    // Al elegir el nivel 3 cambian subtítulo y aparecen los aliados del café.
+    fireEvent.click(nivel3);
+    expect(nivel3).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByTestId('defensores-subtitulo').textContent).toContain(
+      NIVEL_3.subtitulo,
+    );
+    // El nivel 3 incluye aliados que NO están en el nivel 2 (plagas del café).
+    const extra = NIVEL_3.paresIds.find((id) => !NIVEL_2.paresIds.includes(id));
+    const parExtra = PARES_CONTROL.find((p) => p.id === extra);
+    expect(screen.getByTestId(`beneficio-${parExtra.benefico.id}`)).toBeInTheDocument();
+    // El mini-jefe del nivel 3 (la broca) está anunciado.
+    expect(screen.getByTestId('defensores-jefe')).toBeInTheDocument();
   });
 
   it('si el nivel 1 ya fue superado, el 2 queda desbloqueado y seleccionable', () => {

--- a/src/components/juego/defensores-finca.css
+++ b/src/components/juego/defensores-finca.css
@@ -27,7 +27,7 @@
   image-rendering: -webkit-optimize-contrast;
 }
 
-/* ── Selector de nivel (1 / 2) ───────────────────────────────────────── */
+/* ── Selector de nivel (1 / 2 / 3) ───────────────────────────────────── */
 
 .df-niveles {
   display: flex;

--- a/src/components/juego/defensoresFincaData.js
+++ b/src/components/juego/defensoresFincaData.js
@@ -27,6 +27,7 @@ export const CULTIVOS = [
   { id: 'tomate', nombre: 'Tomate', emoji: '🍅' },
   { id: 'ahuyama', nombre: 'Ahuyama', emoji: '🎃' },
   { id: 'platano', nombre: 'Plátano', emoji: '🍌' },
+  { id: 'cafe', nombre: 'Café', emoji: '☕' },
 ];
 
 /**
@@ -178,6 +179,62 @@ export const PARES_CONTROL = [
     },
     leccion: 'La mantis religiosa es una cazadora que controla saltamontes.',
   },
+  // ── Plagas y aliados del CAFETAL (nivel 3) ─────────────────────────────
+  // Control biológico documentado por Cenicafé Colombia para el café.
+  {
+    id: 'broca-cephalonomia',
+    plaga: {
+      id: 'broca',
+      nombre: 'Broca del café',
+      cientifico: 'Hypothenemus hampei',
+      emoji: '🪲',
+      dano: 'Perfora el grano de café y arruina la cosecha.',
+    },
+    benefico: {
+      id: 'cephalonomia',
+      nombre: 'Avispa Cephalonomia',
+      cientifico: 'Cephalonomia stephanoderis',
+      emoji: '🐝',
+      como: 'Esta avispita entra al grano y parasita a la broca.',
+    },
+    leccion: 'La avispa Cephalonomia controla la broca dentro del grano de café.',
+  },
+  {
+    id: 'minador-closterocerus',
+    plaga: {
+      id: 'minador',
+      nombre: 'Minador de la hoja',
+      cientifico: 'Leucoptera coffeella',
+      emoji: '🐛',
+      dano: 'Hace galerías cafés en la hoja del café y la seca.',
+    },
+    benefico: {
+      id: 'closterocerus',
+      nombre: 'Avispa Closterocerus',
+      cientifico: 'Closterocerus coffeellae',
+      emoji: '🐝',
+      como: 'Esta avispita parasita a la larva del minador en la hoja.',
+    },
+    leccion: 'La avispa Closterocerus controla el minador de la hoja del café.',
+  },
+  {
+    id: 'cochinilla-cryptolaemus',
+    plaga: {
+      id: 'cochinilla',
+      nombre: 'Cochinilla harinosa',
+      cientifico: 'Planococcus citri',
+      emoji: '🐌',
+      dano: 'Forma motas blancas y chupa la savia de las ramas.',
+    },
+    benefico: {
+      id: 'cryptolaemus',
+      nombre: 'Escarabajo come-cochinillas',
+      cientifico: 'Cryptolaemus montrouzieri',
+      emoji: '🐞',
+      como: 'Este escarabajo y sus larvas devoran las cochinillas.',
+    },
+    leccion: 'El escarabajo Cryptolaemus se come la cochinilla harinosa.',
+  },
 ];
 
 /** Mapa rápido benéfico → plaga que controla (para la lógica del juego). */
@@ -304,8 +361,78 @@ export const NIVEL_2 = Object.freeze({
   }),
 });
 
+/**
+ * Nivel 3 — el cafetal al amanecer (clima medio, montaña cafetera).
+ *
+ * El nivel más largo y exigente: un cafetal entre la niebla de la mañana. El
+ * mundo es más ancho que el del nivel 2 (cámara que recorre más finca), hay más
+ * cultivos que recoger (incluido el café), aparecen TODAS las plagas — las de la
+ * huerta y la ladera más tres plagas propias del café (broca, minador de la hoja
+ * y cochinilla harinosa) con sus aliados reales documentados por Cenicafé — y
+ * más plataformas y huecos. El cierre es un mini-jefe grande: la BROCA del café,
+ * que solo cae con su controlador real (la avispa Cephalonomia) y aguanta más
+ * golpes que la langosta del nivel 2. Dificultad creciente y cierre satisfactorio.
+ */
+export const NIVEL_3 = Object.freeze({
+  id: 'nivel-3',
+  numero: 3,
+  nombre: 'El cafetal en la niebla',
+  subtitulo: 'Amanece en el cafetal. Es largo y hay plagas del café por todas partes.',
+  energiaInicial: 5,
+  energiaMax: 5,
+  metaCultivos: 14,
+  mundoAncho: 2520,
+  paresIds: [
+    'pulgon-catarina',
+    'moscablanca-crisopa',
+    'cogollero-trichogramma',
+    'afido-sirfido',
+    'trips-amblyseius',
+    'acaro-phytoseiulus',
+    'saltamontes-mantis',
+    'broca-cephalonomia',
+    'minador-closterocerus',
+    'cochinilla-cryptolaemus',
+  ],
+  escena: Object.freeze({
+    id: 'cafetal-amanecer',
+    cieloTop: '#cdeaf0',
+    cieloBottom: '#f3efe0',
+    montana: '#4f7a52',
+    sueloTop: '#5a3a22',
+    sueloBottom: '#241510',
+    pasto: '#3f6b2a',
+    astro: '#fff6d6',
+  }),
+  // Camino que sube y baja por la ladera del cafetal (más plataformas que el 2).
+  plataformas: Object.freeze([
+    Object.freeze({ x: 340, y: 90, w: 130 }),
+    Object.freeze({ x: 560, y: 150, w: 120 }),
+    Object.freeze({ x: 820, y: 100, w: 140 }),
+    Object.freeze({ x: 1080, y: 160, w: 120 }),
+    Object.freeze({ x: 1320, y: 100, w: 140 }),
+    Object.freeze({ x: 1580, y: 150, w: 120 }),
+    Object.freeze({ x: 1840, y: 96, w: 140 }),
+    Object.freeze({ x: 2100, y: 150, w: 120 }),
+  ]),
+  // Más huecos (zanjas del cafetal) repartidos a lo largo del mundo.
+  huecos: Object.freeze([
+    Object.freeze({ x: 700, w: 70 }),
+    Object.freeze({ x: 1240, w: 75 }),
+    Object.freeze({ x: 1760, w: 75 }),
+    Object.freeze({ x: 2260, w: 70 }),
+  ]),
+  // Mini-jefe: una broca gigante al final del cafetal. Solo la avispa
+  // Cephalonomia (su controlador real) la derriba; aguanta más golpes (vida 4).
+  jefe: Object.freeze({
+    plagaId: 'broca',
+    emoji: '🪲',
+    vida: 4,
+  }),
+});
+
 /** Todos los niveles en orden de juego. */
-export const NIVELES = Object.freeze([NIVEL_1, NIVEL_2]);
+export const NIVELES = Object.freeze([NIVEL_1, NIVEL_2, NIVEL_3]);
 
 /** Busca un nivel por su número (1-indexado). Devuelve NIVEL_1 si no existe. */
 export function getNivel(numero) {

--- a/src/services/__tests__/defensoresGameEngine.test.js
+++ b/src/services/__tests__/defensoresGameEngine.test.js
@@ -22,6 +22,7 @@ import {
   PARES_CONTROL,
   NIVEL_1,
   NIVEL_2,
+  NIVEL_3,
   NIVELES,
   getNivel,
   nivelDesbloqueado,
@@ -292,8 +293,8 @@ describe('mini-jefe — solo cae con su controlador real', () => {
 });
 
 describe('niveles — configuración y desbloqueo', () => {
-  it('hay dos niveles y el 2 es más largo y exigente que el 1', () => {
-    expect(NIVELES).toHaveLength(2);
+  it('hay tres niveles y el 2 es más largo y exigente que el 1', () => {
+    expect(NIVELES).toHaveLength(3);
     expect(NIVEL_2.numero).toBe(2);
     expect(NIVEL_2.mundoAncho).toBeGreaterThan(NIVEL_1.mundoAncho);
     expect(NIVEL_2.metaCultivos).toBeGreaterThan(NIVEL_1.metaCultivos);
@@ -303,9 +304,24 @@ describe('niveles — configuración y desbloqueo', () => {
     expect(NIVEL_2.jefe).toBeTruthy();
   });
 
-  it('el nivel 2 usa una paleta de fondo distinta a la del 1', () => {
+  it('el nivel 3 es el más largo y exigente (más mundo, cultivos, pares, jefe duro)', () => {
+    expect(NIVEL_3.numero).toBe(3);
+    expect(NIVEL_3.mundoAncho).toBeGreaterThan(NIVEL_2.mundoAncho);
+    expect(NIVEL_3.metaCultivos).toBeGreaterThan(NIVEL_2.metaCultivos);
+    expect(NIVEL_3.paresIds.length).toBeGreaterThan(NIVEL_2.paresIds.length);
+    expect(NIVEL_3.plataformas.length).toBeGreaterThan(NIVEL_2.plataformas.length);
+    expect(NIVEL_3.huecos.length).toBeGreaterThan(NIVEL_2.huecos.length);
+    expect(NIVEL_3.jefe).toBeTruthy();
+    // El jefe del cafetal aguanta más golpes que la langosta del nivel 2.
+    expect(NIVEL_3.jefe.vida).toBeGreaterThan(NIVEL_2.jefe.vida);
+  });
+
+  it('cada nivel usa una paleta de fondo distinta', () => {
     expect(NIVEL_2.escena.id).not.toBe(NIVEL_1.escena.id);
     expect(NIVEL_2.escena.cieloTop).not.toBe(NIVEL_1.escena.cieloTop);
+    expect(NIVEL_3.escena.id).not.toBe(NIVEL_2.escena.id);
+    expect(NIVEL_3.escena.id).not.toBe(NIVEL_1.escena.id);
+    expect(NIVEL_3.escena.cieloTop).not.toBe(NIVEL_2.escena.cieloTop);
   });
 
   it('todos los pares de cada nivel existen en el dataset curado', () => {
@@ -324,14 +340,26 @@ describe('niveles — configuración y desbloqueo', () => {
     expect(beneficoControlaPlaga(par.benefico.id, NIVEL_2.jefe.plagaId)).toBe(true);
   });
 
+  it('el mini-jefe del nivel 3 (broca) referencia una plaga real con controlador', () => {
+    const par = PARES_CONTROL.find((p) => p.plaga.id === NIVEL_3.jefe.plagaId);
+    expect(par).toBeTruthy();
+    expect(par.benefico.id).toBe('cephalonomia');
+    // La avispa Cephalonomia es el controlador real de la broca y derriba al jefe.
+    expect(beneficoControlaPlaga(par.benefico.id, NIVEL_3.jefe.plagaId)).toBe(true);
+  });
+
   it('getNivel devuelve el nivel pedido y cae al 1 si no existe', () => {
     expect(getNivel(2)).toBe(NIVEL_2);
+    expect(getNivel(3)).toBe(NIVEL_3);
     expect(getNivel(99)).toBe(NIVEL_1);
   });
 
-  it('nivelDesbloqueado: el 1 siempre; el 2 solo tras superar el 1', () => {
+  it('nivelDesbloqueado: cada nivel solo tras superar el anterior', () => {
     expect(nivelDesbloqueado(1, [])).toBe(true);
     expect(nivelDesbloqueado(2, [])).toBe(false);
     expect(nivelDesbloqueado(2, [1])).toBe(true);
+    // El nivel 3 exige haber superado el nivel 2.
+    expect(nivelDesbloqueado(3, [1])).toBe(false);
+    expect(nivelDesbloqueado(3, [1, 2])).toBe(true);
   });
 });


### PR DESCRIPTION
## Qué hace

Agrega el **NIVEL 3 "El cafetal en la niebla"** al minijuego plataformero *Defensores de la Finca*, siguiendo el mismo motor (`defensoresGameEngine.js`) y la misma estructura de datos de niveles (el componente ya es data-driven sobre `NIVELES` + `getNivel`). No rompe los niveles 1 y 2.

## Nivel 3

- **Nuevo bioma/escena**: cafetal al amanecer entre la niebla (paleta distinta a la huerta del 1 y a la ladera del 2).
- **El más largo y exigente** (dificultad creciente):
  - `mundoAncho` 2520 (> 1680 del nivel 2)
  - 14 cultivos a recoger (> 10)
  - 10 pares de control (> 7)
  - 8 plataformas y 4 huecos (> 5 y 2)
  - energía inicial 5
- **Tres plagas nuevas del café** con sus aliados reales documentados por Cenicafé Colombia:
  - 🪲 Broca del café → 🐝 avispa *Cephalonomia stephanoderis*
  - 🐛 Minador de la hoja → 🐝 avispa *Closterocerus coffeellae*
  - 🐌 Cochinilla harinosa → 🐞 escarabajo *Cryptolaemus montrouzieri*
- **Cierre satisfactorio (mini-jefe)**: la **broca gigante**, que solo cae con su controlador real (la avispa Cephalonomia) y aguanta más golpes que la langosta del nivel 2 (vida 4 > 3).
- Cultivo nuevo: **café** ☕.

## Pedagogía y UX

- Control biológico **real** (relación CONTROLS): cada aliado elimina exactamente la plaga que controla en campo. Esquivar plagas + soltar el bicho bueno correcto.
- **Mobile-first**: controles táctiles grandes (≥64px), feedback visual, pensado para una niña de ~10-11 y para campesinos.
- **Sin voseo** (tú/usted; "salta", "cuidado", "lo lograste"). `voseo-scan` del lefthook en verde.

## Verificación

- `vitest` sobre el motor y el componente: **41 tests pasan** (extendidos a 3 niveles: desbloqueo, paletas distintas, jefe del cafetal con su controlador real, selector con los 3 niveles).
- `eslint --rule no-undef` y `eslint --max-warnings=0` sobre los archivos cambiados: limpio.
- Lefthook completo en verde al commitear (eslint, voseo-scan, secret-scan, infra-refs-scan, conventional-commits).
- Nota: 2 fallos preexistentes en `MilpaSimulator.test.jsx` son ajenos a este PR (verificado en árbol limpio antes de los cambios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)