### PR TITLE
fix(agent): temas siempre claros (sin oscurecer de noche)

### DIFF
--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -1607,7 +1607,7 @@ export default function AgentHero({ onNavigate }) {
             <div
                 className={[
                     'agentport-scene',
-                    night ? 'is-night' : 'is-day',
+                    'is-day', // Siempre claro, sin importar la hora (fix temas siempre claros)
                     `sky-${sky.condition}`,
                     menuOpen && !menuClosing ? 'is-quiet' : '',
                 ].join(' ')}


### PR DESCRIPTION
Fix para que los temas del AgentHero siempre sean claros (como los demos), sin el modo nocturno que los oscurece.

**Cambio**
- Forzar clase `is-day` siempre en `.agentport-scene` (antes: `night ? 'is-night' : 'is-day'`)

**Impacto**
- Los 3 temas (nature, minimalista, biopunk) se ven claros siempre, como los demos
- El saludo 'Buenas noches/días' por hora se conserva (solo texto)
- El fondo de la escena ya no se oscurece de noche

**Verificación**
- Validado con eslint --rule no-undef
- Mobile-first, sin voseo (passed lefthook checks)