### PR TITLE
fix(grounding): filtrar relaciones disputed del prompt del LLM

### DIFF
--- a/src/services/__tests__/grafoRelations.test.js
+++ b/src/services/__tests__/grafoRelations.test.js
@@ -131,4 +131,50 @@ describe('grafoRelations — loader offline del grafo', () => {
     expect(a).toBe(b);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('filtra relaciones disputed del grounding offline', async () => {
+    const FIXTURE_WITH_DISPUTED = {
+      _meta: { schema_version: 1, species_count: 1 },
+      species: {
+        theobroma_cacao: {
+          nombre_comun: 'Cacao',
+          nombre_cientifico: 'Theobroma cacao L.',
+          conservation_status: 'cultivo_comun',
+          pest_controllers: [
+            {
+              plaga: 'moniliasis del cacao',
+              controladores: ['Bacteria antagonista (biofungicida)', 'Hongo antagonista del suelo'],
+              disputed: true, // Esta relación está en disputa
+            },
+            {
+              plaga: 'escoba de bruja cacao',
+              controladores: ['Bacteria antagonista (biofungicida)'],
+              disputed: false, // Esta relación NO está en disputa
+            },
+          ],
+          biopreparados: [
+            { id: 'emulsion_nim', nombre: 'Aceite/emulsión de nim (neem)', disputed: false },
+            { id: 'biopreparado_disputado', nombre: 'Biopreparado disputado', disputed: true },
+          ],
+        },
+      },
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockJsonResponse(FIXTURE_WITH_DISPUTED)));
+
+    const bloque = await mod.buildOfflineGroundingBlock('theobroma_cacao');
+
+    // Verificar que el bloque NO esté vacío (hay relaciones no disputadas)
+    expect(bloque).not.toBe('');
+    expect(bloque).toContain('RELACIONES DEL GRAFO (offline) — Cacao:');
+
+    // Verificar que la relación disputada NO aparezca
+    expect(bloque).not.toContain('moniliasis del cacao');
+    expect(bloque).not.toContain('Biopreparado disputado');
+
+    // Verificar que la relación NO disputada SÍ aparezca
+    expect(bloque).toContain('escoba de bruja cacao');
+    expect(bloque).toContain('Bacteria antagonista (biofungicida)');
+    expect(bloque).toContain('Aceite/emulsión de nim (neem)');
+  });
 });

--- a/src/services/grafoRelations.js
+++ b/src/services/grafoRelations.js
@@ -134,6 +134,9 @@ export async function getNombresComunesRegionales(speciesId) {
  * sidecar (`get_subgrafo_relacional`), para inyectarse en el system prompt del
  * agente cuando NO hay red. Devuelve '' si no hay datos (no-op en el prompt).
  *
+ * Filtra relaciones marcadas como disputed (campo disputed===true) para evitar
+ * inyectar información disputada al prompt del LLM.
+ *
  * @param {string} speciesId
  * @returns {Promise<string>}
  */
@@ -156,13 +159,17 @@ export async function buildOfflineGroundingBlock(speciesId) {
   }
   if (Array.isArray(rel.pest_controllers) && rel.pest_controllers.length) {
     for (const pc of rel.pest_controllers) {
-      if (pc && pc.plaga && Array.isArray(pc.controladores) && pc.controladores.length) {
+      // Filtrar relaciones disputed
+      if (pc && pc.plaga && !pc.disputed && Array.isArray(pc.controladores) && pc.controladores.length) {
         lines.push(`- Plaga "${pc.plaga}" → controladores: ${pc.controladores.join(', ')}.`);
       }
     }
   }
   if (Array.isArray(rel.biopreparados) && rel.biopreparados.length) {
-    const nombres = rel.biopreparados.map((b) => b.nombre || b.id).filter(Boolean);
+    const nombres = rel.biopreparados
+      .filter((b) => !b.disputed) // Filtrar biopreparados disputed
+      .map((b) => b.nombre || b.id)
+      .filter(Boolean);
     if (nombres.length) lines.push(`- Biopreparados: ${nombres.join(', ')}.`);
   }
 


### PR DESCRIPTION
## Summary

Filtra relaciones del grafo marcadas como  en  para evitar inyectar información disputada al prompt del LLM (ej. resistencia cacao-monilia en disputa).

## Cambios

- Modifica  en  para excluir:
  -  con 
  -  con 
- Agrega test unitario en  que verifica:
  - Relaciones disputed NO aparecen en el grounding offline
  - Relaciones NO disputadas SÍ aparecen correctamente
  - El bloque no está vacío cuando hay relaciones válidas

## Test plan

- ✅ Tests existentes: 10/10 passing
- ✅ Nuevo test: "filtra relaciones disputed del grounding offline"
- ✅ ESLint clean (0 warnings)
- ✅ Build successful
- ✅ No se modificaron otras rutas del código (solo grafoRelations.js)

## Riesgos conocidos

- Bajo riesgo: el cambio está aislado en 
- No afecta el path online (sidecar), solo el offline (JSON estático)
- Si el JSON no tiene el campo , el filtro funciona como no-op
  (porque )

## MCP tools usadas

No se requirió MCP tools para este task (filtro puramente estructurado).