### PR TITLE
feat(ciclo): fenología específica por especie

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -34,6 +34,14 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
   const [pickStage, setPickStage] = useState(false);
   const [busy, setBusy] = useState(false);
   const [doneTasks, setDoneTasks] = useState({});
+  // Categoría agronómica del catálogo: habilita el genérico por TIPO de cultivo
+  // cuando la especie (o su especie madre, para cultivares) no tiene plantilla
+  // específica. Nunca inventa días; solo da una referencia amplia marcada.
+  const speciesCategory = useMemo(() => {
+    const species = getSpeciesByIdSync(a.subject_slug);
+    return species?.category || null;
+  }, [a.subject_slug]);
+
   const catalogPhenologyTemplate = useMemo(() => {
     const species = getSpeciesByIdSync(a.subject_slug);
     return normalizePhenologyTemplate(
@@ -54,9 +62,10 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
       sowingDate: a.created_at,
       altitudeM,
       template: catalogPhenologyTemplate,
+      category: speciesCategory,
       fallback: a.current_stage || 'sowing_confirmed',
     });
-  }, [a.last_stage_change_reason, a.current_stage, a.subject_slug, a.created_at, altitudeM, catalogPhenologyTemplate]);
+  }, [a.last_stage_change_reason, a.current_stage, a.subject_slug, a.created_at, altitudeM, catalogPhenologyTemplate, speciesCategory]);
 
   // Cycle con la etapa mostrada inyectada, para que las labores (getTasksForCycle)
   // correspondan a la etapa derivada, no a la congelada.
@@ -134,6 +143,7 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
           sowingDate={a.created_at}
           altitudeM={altitudeM}
           phenologyTemplate={catalogPhenologyTemplate}
+          category={speciesCategory}
         />
       </section>
 

--- a/src/components/PhenologyTimeline.jsx
+++ b/src/components/PhenologyTimeline.jsx
@@ -37,18 +37,26 @@ export default function PhenologyTimeline({
   sowingDate,
   altitudeM,
   phenologyTemplate,
+  category,
   observedStages = [],
   compact = false,
 }) {
   const windows = useMemo(() => {
     if (!speciesSlug || !sowingDate) return [];
-    return calculateWindows({ speciesSlug, sowingDate, altitudeM, template: phenologyTemplate });
-  }, [speciesSlug, sowingDate, altitudeM, phenologyTemplate]);
+    return calculateWindows({ speciesSlug, sowingDate, altitudeM, template: phenologyTemplate, category });
+  }, [speciesSlug, sowingDate, altitudeM, phenologyTemplate, category]);
 
   const estimatedCurrent = useMemo(() => {
     if (!speciesSlug || !sowingDate) return null;
-    return getCurrentStage({ speciesSlug, sowingDate, altitudeM, template: phenologyTemplate });
-  }, [speciesSlug, sowingDate, altitudeM, phenologyTemplate]);
+    return getCurrentStage({ speciesSlug, sowingDate, altitudeM, template: phenologyTemplate, category });
+  }, [speciesSlug, sowingDate, altitudeM, phenologyTemplate, category]);
+
+  // Una ventana genérica (no específica de la especie) marca todo el timeline
+  // como aproximado por tipo de cultivo.
+  const isGenericEstimate = useMemo(
+    () => windows.some((w) => w.isGeneric),
+    [windows],
+  );
 
   const observedMap = useMemo(() => {
     const m = {};
@@ -81,6 +89,16 @@ export default function PhenologyTimeline({
         Timeline fenológica
         {altitudeM && <span className="text-slate-600 font-normal normal-case"> · {altitudeM} msnm</span>}
       </h3>
+
+      {isGenericEstimate && !compact && (
+        <div className="flex items-start gap-1.5 bg-amber-900/20 border border-amber-800/40 rounded-lg px-2.5 py-2 mb-3">
+          <AlertTriangle size={12} className="text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-2xs text-amber-200">
+            Aproximación por tipo de cultivo. No hay fenología específica para esta especie:
+            las fechas son una referencia amplia, no un dato firme de la especie.
+          </p>
+        </div>
+      )}
 
       <div className="flex flex-col gap-2">
         {windows.map((win, i) => {

--- a/src/data/phenologyGeneric.js
+++ b/src/data/phenologyGeneric.js
@@ -1,0 +1,102 @@
+/**
+ * phenologyGeneric — plantillas fenológicas GENÉRICAS por tipo de cultivo.
+ *
+ * Tarea #62: cuando una especie NO tiene plantilla específica propia (ni la de
+ * su especie madre, para cultivares), el ciclo no debe quedar vacío ni mostrarse
+ * como un dato firme inventado. Estas plantillas dan una referencia AMPLIA por
+ * categoría agronómica del catálogo (`category`), claramente marcada como
+ * aproximada.
+ *
+ * REGLA ANTI-ALUCINACIÓN (crítica):
+ *   - Estas plantillas NO afirman días-a-cosecha de una especie concreta. Son
+ *     rangos amplios por TIPO de cultivo, marcados `is_generic: true` y con una
+ *     fuente que lo deja explícito. La UI debe presentarlas como aproximación,
+ *     no como dato específico de la especie.
+ *   - Para tipos sin ciclo anual estimable de forma honesta (árboles de sombra,
+ *     frutales perennes muy variables, especies invasoras, perennes medicinales,
+ *     fibras) NO se define genérico: `getGenericTemplate` retorna null y la UI
+ *     mantiene "no hay estimación" en vez de inventar fechas.
+ *   - Los rangos son intencionalmente anchos (baja confianza) para no aparentar
+ *     precisión que no tenemos.
+ */
+
+const GENERIC_SOURCE = {
+  name: 'Estimación genérica por tipo de cultivo',
+  reference:
+    'Rango amplio por categoría agronómica. NO es dato específico de la especie; ' +
+    'es una aproximación de referencia mientras no exista plantilla propia.',
+  nota: 'aproximado-por-tipo',
+};
+
+/**
+ * Construye una plantilla genérica de ciclo anual con 4 etapas a partir de un
+ * total de días-a-cosecha (rango). Todas las etapas heredan la misma fuente
+ * genérica y el flag `is_generic`.
+ *
+ * @param {Object} cfg
+ * @param {string} cfg.categoryId
+ * @param {string} cfg.label — etiqueta del tipo de cultivo
+ * @param {number} cfg.harvestMin — días mínimos a cosecha
+ * @param {number} cfg.harvestMax — días máximos a cosecha
+ * @returns {Object} plantilla normalizable por phenologyCalculator
+ */
+function annualTemplate({ categoryId, label, harvestMin, harvestMax }) {
+  // Reparto proporcional de etapas sobre el ciclo total (porcentajes amplios y
+  // conservadores). No pretende precisión; sirve para ubicar al campesino.
+  const vegEnd = Math.round(harvestMin * 0.55);
+  const flowerEnd = Math.round(harvestMin * 0.8);
+  return {
+    template_id: `generic.${categoryId}`,
+    species_slug: `generic.${categoryId}`,
+    species_label: `${label} (estimación por tipo)`,
+    version: 1,
+    is_generic: true,
+    sources: [GENERIC_SOURCE],
+    stages: [
+      { code: 'sowing', label: 'Siembra', description: 'Día de siembra o trasplante.', minDays: 0, maxDays: 0, sourceIndex: 0 },
+      { code: 'vegetative', label: 'Crecimiento', description: 'Desarrollo de hojas y raíces (aproximado).', minDays: 1, maxDays: vegEnd, sourceIndex: 0 },
+      { code: 'flowering', label: 'Floración', description: 'Aparición de flores (aproximado).', minDays: vegEnd + 1, maxDays: flowerEnd, sourceIndex: 0 },
+      { code: 'harvest_window', label: 'Cosecha', description: 'Ventana amplia de cosecha por tipo de cultivo.', minDays: harvestMin, maxDays: harvestMax, sourceIndex: 0 },
+      { code: 'closed', label: 'Ciclo cerrado', description: 'Fin del ciclo.', minDays: harvestMax + 1, maxDays: null, sourceIndex: 0 },
+    ],
+  };
+}
+
+/**
+ * Genéricos por categoría del catálogo. Solo se incluyen tipos con un ciclo
+ * anual/bienal cuyo rango amplio es agronómicamente defendible. Las categorías
+ * ausentes (frutales_perennes, arboles_sombra, especies_invasoras,
+ * medicinales_alelopaticas, fibras_no_maderables) quedan SIN genérico a
+ * propósito: su ciclo es de años o muy variable y no se estima sin datos.
+ *
+ * @type {Map<string, Object>}
+ */
+const genericRegistry = new Map([
+  ['hortalizas_hoja', annualTemplate({ categoryId: 'hortalizas_hoja', label: 'Hortaliza de hoja', harvestMin: 40, harvestMax: 90 })],
+  ['hortalizas_fruto_flor', annualTemplate({ categoryId: 'hortalizas_fruto_flor', label: 'Hortaliza de fruto', harvestMin: 70, harvestMax: 140 })],
+  ['cereales', annualTemplate({ categoryId: 'cereales', label: 'Cereal', harvestMin: 100, harvestMax: 180 })],
+  ['granos_legumbres', annualTemplate({ categoryId: 'granos_legumbres', label: 'Grano o leguminosa', harvestMin: 90, harvestMax: 180 })],
+  ['tuberculos_raices', annualTemplate({ categoryId: 'tuberculos_raices', label: 'Tubérculo o raíz', harvestMin: 90, harvestMax: 270 })],
+  ['abonos_verdes_coberturas', annualTemplate({ categoryId: 'abonos_verdes_coberturas', label: 'Abono verde o cobertura', harvestMin: 60, harvestMax: 150 })],
+  ['atractores_polinizadores', annualTemplate({ categoryId: 'atractores_polinizadores', label: 'Atractor de polinizadores', harvestMin: 50, harvestMax: 120 })],
+]);
+
+/**
+ * Retorna una plantilla genérica para una categoría del catálogo, o null si esa
+ * categoría no tiene un ciclo anual estimable de forma honesta.
+ *
+ * @param {string} categoryId — valor de `category` del catálogo
+ * @returns {Object|null}
+ */
+export function getGenericTemplate(categoryId) {
+  if (!categoryId || typeof categoryId !== 'string') return null;
+  return genericRegistry.get(categoryId) || null;
+}
+
+/**
+ * Categorías que tienen genérico (para tests / introspección).
+ * @returns {string[]}
+ */
+export function getGenericCategories() {
+  return Array.from(genericRegistry.keys());
+}

--- a/src/data/phenologyTemplates.js
+++ b/src/data/phenologyTemplates.js
@@ -76,12 +76,60 @@ for (const t of templates) {
 }
 
 /**
+ * Slugs de plantilla ordenados de más largo a más corto. Permite resolver un
+ * cultivar/subespecie (slug largo) a la plantilla de su especie madre buscando
+ * el prefijo más específico primero (ej. `solanum_tuberosum_pastusa_suprema`
+ * antes de un hipotético `solanum`).
+ * @type {string[]}
+ */
+const slugsByLength = Array.from(registry.keys()).sort((a, b) => b.length - a.length);
+
+/**
+ * Resuelve el slug de la especie MADRE cuando el slug recibido es un cultivar o
+ * subespecie con plantilla propia ausente.
+ *
+ * Regla anti-alucinación: solo se considera "madre" cuando el slug del cultivar
+ * EMPIEZA por el slug de una especie con plantilla seguido de `_` (ej.
+ * `solanum_lycopersicum_san_marzano` → `solanum_lycopersicum`). Un cultivar
+ * comparte la biología base de su especie, así que NO se inventa nada: se
+ * reutiliza la fenología real de la especie. Si no hay coincidencia, retorna
+ * null (el llamador caerá al genérico por tipo o a "no estimable").
+ *
+ * @param {string} speciesSlug
+ * @returns {string|null} slug de la especie madre con plantilla, o null
+ */
+export function resolveParentSpeciesSlug(speciesSlug) {
+  if (!speciesSlug || typeof speciesSlug !== 'string') return null;
+  if (registry.has(speciesSlug)) return speciesSlug;
+  for (const slug of slugsByLength) {
+    if (speciesSlug.startsWith(`${slug}_`)) return slug;
+  }
+  return null;
+}
+
+/**
  * Retorna la plantilla para una especie, o null.
+ *
+ * Si el slug exacto no tiene plantilla pero corresponde a un cultivar/subespecie
+ * de una especie que SÍ la tiene (ej. `solanum_lycopersicum_san_marzano`), se
+ * devuelve la plantilla de la especie madre marcada con `derived_from`. Esto NO
+ * es una estimación genérica: es la fenología real de la especie aplicada a su
+ * cultivar, que comparte el mismo ciclo biológico.
+ *
  * @param {string} speciesSlug
  * @returns {PhenologyTemplate|null}
  */
 export function getTemplate(speciesSlug) {
-  return registry.get(speciesSlug) || null;
+  const direct = registry.get(speciesSlug);
+  if (direct) return direct;
+  const parent = resolveParentSpeciesSlug(speciesSlug);
+  if (parent && parent !== speciesSlug) {
+    const parentTemplate = registry.get(parent);
+    if (parentTemplate) {
+      return { ...parentTemplate, species_slug: speciesSlug, derived_from: parent };
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/services/__tests__/phenologySpecificResolution.test.js
+++ b/src/services/__tests__/phenologySpecificResolution.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTemplate, calculateWindows, getCurrentStage } from '../phenologyCalculator';
+import { getTemplate, resolveParentSpeciesSlug } from '../../data/phenologyTemplates';
+import { getGenericTemplate, getGenericCategories } from '../../data/phenologyGeneric';
+
+const SOWING = 1700000000000;
+const DAY_MS = 86400000;
+
+// Tarea #62: el ciclo fenológico debe ser ESPECÍFICO por especie cuando hay
+// datos reales en el repo, y caer a un genérico CLARAMENTE marcado (sin
+// inventar) cuando no los hay.
+describe('Tarea #62 — fenología específica vs genérica', () => {
+  describe('especie CON datos específicos usa esos datos', () => {
+    it('una especie con plantilla propia (tomate) resuelve a su plantilla específica, no genérica', () => {
+      const t = resolveTemplate({ speciesSlug: 'solanum_lycopersicum', category: 'hortalizas_fruto_flor' });
+      expect(t).toBeTruthy();
+      expect(t.species_slug).toBe('solanum_lycopersicum');
+      expect(t.is_generic).toBeFalsy();
+    });
+
+    it('la especie específica gana incluso si se pasa una categoría con genérico', () => {
+      // Aunque exista genérico para 'cereales', maíz tiene plantilla propia.
+      const windows = calculateWindows({ speciesSlug: 'zea_mays', sowingDate: SOWING, category: 'cereales' });
+      expect(windows.every((w) => !w.isGeneric)).toBe(true);
+      // Cosecha de maíz cae en ventana específica de su plantilla.
+      const harvest = windows.find((w) => w.code === 'harvest_window');
+      expect(harvest.status).toBe('computed');
+    });
+  });
+
+  describe('cultivar/subespecie hereda la fenología REAL de su especie madre', () => {
+    it('resolveParentSpeciesSlug mapea cultivar de tomate a la especie madre', () => {
+      expect(resolveParentSpeciesSlug('solanum_lycopersicum_san_marzano')).toBe('solanum_lycopersicum');
+    });
+
+    it('resolveParentSpeciesSlug mapea cultivar de papa a su especie madre', () => {
+      expect(resolveParentSpeciesSlug('solanum_tuberosum_pastusa_suprema')).toBe('solanum_tuberosum');
+    });
+
+    it('un cultivar usa la plantilla específica de la especie madre (NO el genérico)', () => {
+      const t = getTemplate('solanum_lycopersicum_san_marzano');
+      expect(t).toBeTruthy();
+      expect(t.derived_from).toBe('solanum_lycopersicum');
+      expect(t.is_generic).toBeFalsy();
+      // Conserva el slug pedido pero las etapas reales del tomate.
+      expect(t.species_slug).toBe('solanum_lycopersicum_san_marzano');
+      expect(t.stages.find((s) => s.code === 'flowering')).toBeTruthy();
+    });
+
+    it('el cultivar produce la MISMA ventana de cosecha que su especie madre', () => {
+      const parent = calculateWindows({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING });
+      const cultivar = calculateWindows({ speciesSlug: 'solanum_lycopersicum_san_marzano', sowingDate: SOWING });
+      const ph = parent.find((w) => w.code === 'harvest_window');
+      const ch = cultivar.find((w) => w.code === 'harvest_window');
+      expect(ch.windowStart).toBe(ph.windowStart);
+      expect(ch.windowEnd).toBe(ph.windowEnd);
+      expect(ch.isGeneric).toBeFalsy();
+    });
+
+    it('la etapa derivada del cultivar avanza igual que la de la especie madre', () => {
+      const stageParent = getCurrentStage({ speciesSlug: 'solanum_lycopersicum', sowingDate: SOWING, now: SOWING + 30 * DAY_MS });
+      const stageCultivar = getCurrentStage({ speciesSlug: 'solanum_lycopersicum_san_marzano', sowingDate: SOWING, now: SOWING + 30 * DAY_MS });
+      expect(stageCultivar.stage.code).toBe(stageParent.stage.code);
+    });
+  });
+
+  describe('especie SIN datos específicos cae al genérico SIN inventar', () => {
+    it('especie de tipo hortaliza de hoja sin plantilla propia usa el genérico marcado', () => {
+      // 'allium_fistulosum' (cebollín) no tiene plantilla específica.
+      const t = resolveTemplate({ speciesSlug: 'allium_fistulosum', category: 'hortalizas_hoja' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+      expect(t.species_slug.startsWith('generic.')).toBe(true);
+    });
+
+    it('las ventanas genéricas se marcan isGeneric y bajan la confianza', () => {
+      const windows = calculateWindows({ speciesSlug: 'allium_fistulosum', sowingDate: SOWING, category: 'hortalizas_hoja' });
+      const veg = windows.find((w) => w.code === 'vegetative');
+      expect(veg.isGeneric).toBe(true);
+      // Confianza fuerte hacia abajo: NO aparenta dato firme de la especie.
+      expect(veg.confidence).toBeLessThanOrEqual(0.3);
+      // La fuente declara explícitamente que es aproximación por tipo.
+      expect(veg.sources[0]).toMatch(/genérica por tipo/i);
+    });
+
+    it('la siembra (día 0) sigue siendo un hecho con confianza 1.0 aun en el genérico', () => {
+      const windows = calculateWindows({ speciesSlug: 'allium_fistulosum', sowingDate: SOWING, category: 'hortalizas_hoja' });
+      const sowing = windows.find((w) => w.code === 'sowing');
+      expect(sowing.confidence).toBe(1.0);
+    });
+  });
+
+  describe('anti-alucinación: sin datos honestos NO se inventa nada', () => {
+    it('especie sin plantilla y sin categoría con genérico devuelve template_missing', () => {
+      const windows = calculateWindows({ speciesSlug: 'desconocida_xyz', sowingDate: SOWING });
+      expect(windows).toHaveLength(1);
+      expect(windows[0].status).toBe('template_missing');
+    });
+
+    it('categorías sin ciclo anual estimable (perennes/árboles/invasoras) NO tienen genérico', () => {
+      expect(getGenericTemplate('frutales_perennes')).toBeNull();
+      expect(getGenericTemplate('arboles_sombra')).toBeNull();
+      expect(getGenericTemplate('especies_invasoras')).toBeNull();
+      expect(getGenericTemplate('medicinales_alelopaticas')).toBeNull();
+      expect(getGenericTemplate('fibras_no_maderables')).toBeNull();
+    });
+
+    it('un frutal perenne sin plantilla propia NO cae a un genérico inventado', () => {
+      // 'theobroma_cacao' (cacao) no tiene plantilla específica y su categoría
+      // perenne no define genérico: debe quedar como no estimable, no inventar.
+      const t = resolveTemplate({ speciesSlug: 'theobroma_cacao', category: 'frutales_perennes' });
+      expect(t).toBeNull();
+      const windows = calculateWindows({ speciesSlug: 'theobroma_cacao', sowingDate: SOWING, category: 'frutales_perennes' });
+      expect(windows[0].status).toBe('template_missing');
+    });
+
+    it('todas las categorías con genérico producen un ciclo anual coherente', () => {
+      for (const cat of getGenericCategories()) {
+        const t = getGenericTemplate(cat);
+        expect(t.is_generic).toBe(true);
+        const sowing = t.stages[0];
+        const closed = t.stages[t.stages.length - 1];
+        expect(sowing.code).toBe('sowing');
+        expect(closed.code).toBe('closed');
+        expect(closed.maxDays).toBeNull();
+        // Etapas monótonas: cada minDays >= minDays anterior.
+        for (let i = 1; i < t.stages.length; i++) {
+          expect(t.stages[i].minDays).toBeGreaterThanOrEqual(t.stages[i - 1].minDays);
+        }
+      }
+    });
+  });
+});

--- a/src/services/phenologyCalculator.js
+++ b/src/services/phenologyCalculator.js
@@ -8,6 +8,7 @@
  * el proceso. Solo computa estimated_stage.
  */
 import { getTemplate } from '../data/phenologyTemplates';
+import { getGenericTemplate } from '../data/phenologyGeneric';
 
 // Umbral de confianza alineado con agentService.LOW_CONFIDENCE_THRESHOLD (0.7).
 // Se define local para NO arrastrar el módulo pesado agentService.js al grafo de
@@ -75,16 +76,55 @@ export function normalizePhenologyTemplate(template, speciesSlug = '') {
 }
 
 /**
+ * Resuelve la plantilla fenológica a usar para una especie, en orden de
+ * preferencia y SIN inventar datos:
+ *
+ *   1. `template` explícito normalizado (ej. fenología embebida en el catálogo).
+ *   2. Plantilla específica de la especie por slug (incluye resolución de
+ *      cultivar/subespecie a su especie madre, que es dato real de la especie).
+ *   3. Plantilla GENÉRICA por tipo de cultivo (`category`), marcada como
+ *      aproximada. Solo existe para categorías con ciclo anual estimable.
+ *   4. null si no hay nada honesto que mostrar.
+ *
+ * El resultado conserva `is_generic` cuando proviene del paso 3, para que la
+ * capa de cálculo baje la confianza y la UI marque la estimación como
+ * aproximada y NO específica de la especie.
+ *
+ * @param {Object} input
+ * @param {string} input.speciesSlug
+ * @param {Object} [input.template] — plantilla explícita (sin normalizar)
+ * @param {string} [input.category] — categoría del catálogo para el genérico
+ * @returns {(Object & {is_generic?: boolean})|null}
+ */
+export function resolveTemplate({ speciesSlug, template, category } = {}) {
+  const explicit = normalizePhenologyTemplate(template, speciesSlug);
+  if (explicit) return explicit;
+
+  const specific = getTemplate(speciesSlug);
+  if (specific) return specific;
+
+  if (category) {
+    const generic = getGenericTemplate(category);
+    if (generic) return { ...generic, is_generic: true };
+  }
+
+  return null;
+}
+
+/**
  * Calcula ventanas fenológicas estimadas para un proceso.
  *
  * @param {Object} input
  * @param {string} input.speciesSlug
  * @param {number} input.sowingDate — timestamp ms del evento de siembra
  * @param {number} [input.altitudeM] — msnm para corrección por altitud
+ * @param {Object} [input.template] — plantilla explícita (sin normalizar)
+ * @param {string} [input.category] — categoría del catálogo para el genérico por tipo
  * @returns {PhenologyWindow[]}
  */
-export function calculateWindows({ speciesSlug, sowingDate, altitudeM, template: inputTemplate } = {}) {
-  const template = normalizePhenologyTemplate(inputTemplate, speciesSlug) || getTemplate(speciesSlug);
+export function calculateWindows({ speciesSlug, sowingDate, altitudeM, template: inputTemplate, category } = {}) {
+  const template = resolveTemplate({ speciesSlug, template: inputTemplate, category });
+  const isGeneric = !!(template && template.is_generic);
 
   if (!template) {
     return [{
@@ -127,7 +167,15 @@ export function calculateWindows({ speciesSlug, sowingDate, altitudeM, template:
       confidence = Math.max(0.4, confidence - 0.15);
     }
 
-    // Etapa sowing (día 0) tiene confianza 1.0
+    // Plantilla genérica por tipo de cultivo: NO es dato específico de la
+    // especie, así que la confianza se reduce fuerte para que la UI lo marque
+    // como aproximado (anti-alucinación: nunca aparentar precisión que no hay).
+    if (isGeneric) {
+      confidence = Math.min(confidence, 0.3);
+    }
+
+    // Etapa sowing (día 0) tiene confianza 1.0 (la fecha de siembra es un hecho,
+    // no una estimación), incluso en plantillas genéricas.
     if (stage.code === 'sowing') {
       confidence = 1.0;
     }
@@ -141,6 +189,9 @@ export function calculateWindows({ speciesSlug, sowingDate, altitudeM, template:
       windowEnd,
       status: 'computed',
       confidence: Math.round(confidence * 100) / 100,
+      // `isGeneric`: la ventana viene de una estimación por TIPO de cultivo, no
+      // de datos específicos de la especie. La UI debe rotularla aproximada.
+      isGeneric,
       sources: source ? [source.name] : [],
     };
   });
@@ -169,8 +220,8 @@ export function calculateWindows({ speciesSlug, sowingDate, altitudeM, template:
  * @param {number} [input.now=Date.now()] — timestamp ms para el cual calcular la etapa
  * @returns {CurrentStageResult|null}
  */
-export function getCurrentStage({ speciesSlug, sowingDate, altitudeM, now, template } = {}) {
-  const windows = calculateWindows({ speciesSlug, sowingDate, altitudeM, template });
+export function getCurrentStage({ speciesSlug, sowingDate, altitudeM, now, template, category } = {}) {
+  const windows = calculateWindows({ speciesSlug, sowingDate, altitudeM, template, category });
 
   if (!windows.length || (windows.length === 1 && windows[0].status !== 'computed')) {
     return null;
@@ -217,10 +268,10 @@ export function getCurrentStage({ speciesSlug, sowingDate, altitudeM, now, templ
  * @param {string} [input.fallback='sowing_confirmed'] — etapa si no se puede derivar
  * @returns {string} código de etapa (ej. 'vegetative', 'flowering', 'sowing_confirmed')
  */
-export function deriveCurrentStage({ speciesSlug, sowingDate, altitudeM, now, template, fallback = 'sowing_confirmed' } = {}) {
+export function deriveCurrentStage({ speciesSlug, sowingDate, altitudeM, now, template, category, fallback = 'sowing_confirmed' } = {}) {
   let result = null;
   try {
-    result = getCurrentStage({ speciesSlug, sowingDate, altitudeM, now, template });
+    result = getCurrentStage({ speciesSlug, sowingDate, altitudeM, now, template, category });
   } catch {
     return fallback;
   }


### PR DESCRIPTION
## Qué hace

El ciclo fenológico que ve el usuario salía genérico (o vacío: "No hay plantilla para esta especie") para cualquier especie sin plantilla propia. Ahora la plantilla se resuelve en cascada, sin inventar datos:

1. **Específica por especie** — las 18 plantillas versionadas ya existentes (café, papa, tomate, maíz, fríjol, yuca, plátano, aguacate, tomate de árbol, lulo, mora, uchuva, fresa, lechuga, cebolla, cilantro, zanahoria, arveja).
2. **Cultivar/subespecie → especie madre** — un slug de cultivar hereda la fenología REAL de su especie (ej. `solanum_lycopersicum_san_marzano` → `solanum_lycopersicum`, `solanum_tuberosum_pastusa_suprema` → `solanum_tuberosum`, `lactuca_sativa_capitata` → `lactuca_sativa`, `daucus_carota_subsp_sativus` → `daucus_carota`). No es estimación: comparte el ciclo biológico de la especie.
3. **Genérico por TIPO de cultivo** — usa el campo `category` del catálogo para dar un rango amplio por tipo (hortaliza de hoja, hortaliza de fruto, cereal, grano/leguminosa, tubérculo/raíz, abono verde, atractor de polinizadores). Marcado `is_generic`, confianza ≤ 0.3, fuente explícita y aviso visible en el timeline.

### Regla anti-alucinación
- Ningún día-a-cosecha ni fecha se fabrica. Lo genérico se rotula como aproximación por tipo, nunca como dato firme de la especie.
- Categorías sin ciclo anual honesto (frutales perennes, árboles de sombra, especies invasoras, medicinales alelopáticas, fibras) NO tienen genérico: quedan como "no estimable" en vez de inventar.

## Archivos
- `src/data/phenologyTemplates.js` — `resolveParentSpeciesSlug` + `getTemplate` con resolución cultivar→madre.
- `src/data/phenologyGeneric.js` (nuevo) — genéricos por categoría, marcados.
- `src/services/phenologyCalculator.js` — `resolveTemplate` (cascada) + flag `isGeneric`/confianza baja en ventanas genéricas.
- `src/components/PhenologyTimeline.jsx` + `src/components/CicloDetalle.jsx` — pasan `category` y muestran el aviso de aproximación.
- `src/services/__tests__/phenologySpecificResolution.test.js` (nuevo) — 14 tests.

## Cómo se probó
- `npx vitest run` — 62 tests de fenología (14 nuevos + 48 existentes) y 55 de consumidores, todos pasan.
- `npx eslint` sobre los archivos tocados — 0 errores (1 warning preexistente, no introducido por este PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
