### PR TITLE
fix(temas): nature y minimalista no se oscurecen de noche (velo atmosférico)

### DIFF
--- a/src/styles/clima-atmosfera.css
+++ b/src/styles/clima-atmosfera.css
@@ -80,6 +80,17 @@ html[data-luz="noche"] {
 html:not([data-theme])[data-luz="noche"] {
   --w-night-a: 0;
 }
+/* TEMAS CLAROS SIEMPRE CLAROS (operador 2026-06-20: "siempre claro como los
+ * demos"). nature y minimalista NO adoptan la veladura navy ni el tinte azul
+ * de noche: conservan su atmósfera diurna a cualquier hora. !important para
+ * ganar sobre las reglas de clima nocturno (p.ej. niebla/lluvia de noche, de
+ * igual especificidad) sin depender del orden de declaración. La modulación
+ * climática DIURNA (nubes/lluvia/sol) se mantiene intacta. */
+html[data-theme="nature"][data-luz="noche"],
+html[data-theme="minimalista"][data-luz="noche"] {
+  --w-night-a: 0 !important;
+  --w-tint-a: 0 !important;
+}
 
 /* ---------------------------------------------------------------------------
  * CONDICIÓN DEL CIELO (snapshot climaService). Declarado DESPUÉS de la luz:


### PR DESCRIPTION
## Causa raíz
El velo atmosférico global (`src/styles/clima-atmosfera.css`, `body::after`) aplicaba una **veladura navy** (`--w-night-a: 0.25`, rgb 24 32 48) + **tinte azul** (`--w-tint-a: 0.10`) cuando `<html data-luz="noche">`, sobre TODOS los temas claros. Biopunk ya estaba exento (es nocturno por diseño); **nature y minimalista no**, así que de noche se veían oscuros (café/oliva sobre el crema). El fix #1741 (is-day en la escena) traía el sol pero NO quitaba este velo → el operador seguía viendo oscuro.

## Fix
Se extiende la exención nocturna a nature y minimalista con `!important` (para ganar sobre reglas de clima nocturno de igual especificidad sin depender del orden). Quedan **'siempre claros como los demos'** a cualquier hora. La modulación climática **diurna** (nubes/lluvia/sol) se mantiene intacta.

Cierra parte de #72.