### PR TITLE
test(ciclo): cobertura cascada fenologia

### DIFF
--- a/src/data/__tests__/phenologyGeneric.test.js
+++ b/src/data/__tests__/phenologyGeneric.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { getGenericTemplate, getGenericCategories } from '../phenologyGeneric';
+
+describe('phenologyGeneric — getGenericTemplate', () => {
+  it('retorna plantilla para categoria hortalizas_hoja', () => {
+    const t = getGenericTemplate('hortalizas_hoja');
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+    expect(t.template_id).toBe('generic.hortalizas_hoja');
+  });
+
+  it('retorna plantilla para tuberculos_raices', () => {
+    const t = getGenericTemplate('tuberculos_raices');
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+    expect(t.species_label).toMatch(/tubérculo/i);
+  });
+
+  it('retorna plantilla para cereales', () => {
+    const t = getGenericTemplate('cereales');
+    expect(t).toBeTruthy();
+    expect(t.stages.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('retorna plantilla para granos_legumbres', () => {
+    const t = getGenericTemplate('granos_legumbres');
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+  });
+
+  it('retorna plantilla para abonos_verdes_coberturas', () => {
+    const t = getGenericTemplate('abonos_verdes_coberturas');
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+  });
+
+  it('retorna plantilla para atractores_polinizadores', () => {
+    const t = getGenericTemplate('atractores_polinizadores');
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+  });
+
+  it('retorna plantilla para hortalizas_fruto_flor', () => {
+    const t = getGenericTemplate('hortalizas_fruto_flor');
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+  });
+
+  it('retorna null para categoria desconocida', () => {
+    expect(getGenericTemplate('categoria_inexistente')).toBeNull();
+  });
+
+  it('retorna null para categorias no estimables (frutales perennes)', () => {
+    expect(getGenericTemplate('frutales_perennes')).toBeNull();
+  });
+
+  it('retorna null para categorias no estimables (arboles sombra)', () => {
+    expect(getGenericTemplate('arboles_sombra')).toBeNull();
+  });
+
+  it('retorna null para especies_invasoras', () => {
+    expect(getGenericTemplate('especies_invasoras')).toBeNull();
+  });
+
+  it('retorna null para medicinales_alelopaticas', () => {
+    expect(getGenericTemplate('medicinales_alelopaticas')).toBeNull();
+  });
+
+  it('retorna null para fibras_no_maderables', () => {
+    expect(getGenericTemplate('fibras_no_maderables')).toBeNull();
+  });
+
+  it('retorna null para undefined', () => {
+    expect(getGenericTemplate(undefined)).toBeNull();
+  });
+
+  it('retorna null para null', () => {
+    expect(getGenericTemplate(null)).toBeNull();
+  });
+
+  it('retorna null para string vacia', () => {
+    expect(getGenericTemplate('')).toBeNull();
+  });
+
+  it('retorna null para numero', () => {
+    expect(getGenericTemplate(42)).toBeNull();
+  });
+});
+
+describe('phenologyGeneric — getGenericCategories', () => {
+  it('retorna exactamente 7 categorias', () => {
+    const cats = getGenericCategories();
+    expect(cats).toHaveLength(7);
+  });
+
+  it('incluye las categorias esperadas', () => {
+    const cats = getGenericCategories();
+    expect(cats).toContain('hortalizas_hoja');
+    expect(cats).toContain('hortalizas_fruto_flor');
+    expect(cats).toContain('cereales');
+    expect(cats).toContain('granos_legumbres');
+    expect(cats).toContain('tuberculos_raices');
+    expect(cats).toContain('abonos_verdes_coberturas');
+    expect(cats).toContain('atractores_polinizadores');
+  });
+
+  it('NO incluye categorias no estimables', () => {
+    const cats = getGenericCategories();
+    expect(cats).not.toContain('frutales_perennes');
+    expect(cats).not.toContain('arboles_sombra');
+    expect(cats).not.toContain('especies_invasoras');
+    expect(cats).not.toContain('medicinales_alelopaticas');
+    expect(cats).not.toContain('fibras_no_maderables');
+  });
+});
+
+describe('phenologyGeneric — integridad de plantillas', () => {
+  it('toda plantilla generica tiene is_generic: true', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      expect(t.is_generic).toBe(true);
+    }
+  });
+
+  it('toda plantilla generica tiene sowing con minDays=0 maxDays=0', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      const sowing = t.stages.find((s) => s.code === 'sowing');
+      expect(sowing).toBeTruthy();
+      expect(sowing.minDays).toBe(0);
+      expect(sowing.maxDays).toBe(0);
+    }
+  });
+
+  it('toda plantilla generica termina en closed con maxDays null', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      const closed = t.stages[t.stages.length - 1];
+      expect(closed.code).toBe('closed');
+      expect(closed.maxDays).toBeNull();
+    }
+  });
+
+  it('toda plantilla generica tiene etapas monotonas en minDays', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      for (let i = 1; i < t.stages.length; i++) {
+        expect(t.stages[i].minDays).toBeGreaterThanOrEqual(t.stages[i - 1].minDays);
+      }
+    }
+  });
+
+  it('toda plantilla generica tiene minDays <= maxDays donde maxDays no es null', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      for (const stage of t.stages) {
+        if (stage.maxDays !== null) {
+          expect(stage.minDays).toBeLessThanOrEqual(stage.maxDays);
+        }
+      }
+    }
+  });
+
+  it('toda plantilla generica declara fuente como estimacion por tipo', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      expect(t.sources).toHaveLength(1);
+      expect(t.sources[0].name).toMatch(/genérica por tipo/i);
+      expect(t.sources[0].nota).toBe('aproximado-por-tipo');
+    }
+  });
+
+  it('toda plantilla generica tiene sourceIndex valido en cada etapa', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      for (const stage of t.stages) {
+        expect(stage.sourceIndex).toBeGreaterThanOrEqual(0);
+        expect(stage.sourceIndex).toBeLessThan(t.sources.length);
+      }
+    }
+  });
+
+  it('el harvest_min y harvest_max definen ventana de cosecha razonable (min < max)', () => {
+    for (const cat of getGenericCategories()) {
+      const t = getGenericTemplate(cat);
+      const harvest = t.stages.find((s) => s.code === 'harvest_window');
+      expect(harvest).toBeTruthy();
+      expect(harvest.minDays).toBeGreaterThan(0);
+      if (harvest.maxDays !== null) {
+        expect(harvest.minDays).toBeLessThanOrEqual(harvest.maxDays);
+      }
+    }
+  });
+});

--- a/src/services/__tests__/phenologyCalculator.test.js
+++ b/src/services/__tests__/phenologyCalculator.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateWindows, formatWindow, getCurrentStage, deriveCurrentStage } from '../phenologyCalculator';
+import { calculateWindows, formatWindow, getCurrentStage, deriveCurrentStage, resolveTemplate } from '../phenologyCalculator';
 
 const SOWING = 1700000000000; // fixed timestamp
 
@@ -226,5 +226,109 @@ describe('deriveCurrentStage — etapa por fecha (anti-congelamiento)', () => {
   it('nunca lanza ante entrada basura', () => {
     expect(() => deriveCurrentStage({})).not.toThrow();
     expect(deriveCurrentStage({})).toBe('sowing_confirmed');
+  });
+});
+
+// Cascada de resolución de plantilla: orden de preferencia explícita >
+// específica > genérica > null. Cubre los 4 niveles del invariante.
+describe('resolveTemplate — cascada de preferencia', () => {
+  it('retorna plantilla especifica por slug cuando existe', () => {
+    const t = resolveTemplate({ speciesSlug: 'solanum_lycopersicum' });
+    expect(t).toBeTruthy();
+    expect(t.species_slug).toBe('solanum_lycopersicum');
+    expect(t.is_generic).toBeFalsy();
+  });
+
+  it('retorna null para especie sin plantilla y sin categoria', () => {
+    expect(resolveTemplate({ speciesSlug: 'no_existe' })).toBeNull();
+  });
+
+  it('retorna null con input vacio', () => {
+    expect(resolveTemplate({})).toBeNull();
+  });
+
+  it('retorna null con undefined', () => {
+    expect(resolveTemplate()).toBeNull();
+  });
+
+  it('la plantilla explicita gana sobre la especifica y la generica', () => {
+    const explicit = {
+      template_id: 'expl.test',
+      species_slug: 'test_explicita',
+      version: 1,
+      sources: [{ name: 'Fuente explicita' }],
+      stages: [
+        { code: 'sowing', label: 'Siembra', minDays: 0, maxDays: 0, sourceIndex: 0 },
+        { code: 'closed', label: 'Cerrado', minDays: 99, maxDays: null, sourceIndex: 0 },
+      ],
+    };
+    const t = resolveTemplate({ speciesSlug: 'solanum_lycopersicum', template: explicit, category: 'hortalizas_fruto_flor' });
+    expect(t.template_id).toBe('expl.test');
+    expect(t.stages).toHaveLength(2);
+    expect(t.stages[1].minDays).toBe(99);
+    expect(t.is_generic).toBeFalsy();
+  });
+
+  it('la plantilla especifica gana sobre la generica cuando ambas existen', () => {
+    const t = resolveTemplate({ speciesSlug: 'zea_mays', category: 'cereales' });
+    expect(t).toBeTruthy();
+    expect(t.species_slug).toBe('zea_mays');
+    expect(t.is_generic).toBeFalsy();
+  });
+
+  it('cae al generico cuando no hay plantilla especifica pero categoria es estimable', () => {
+    const t = resolveTemplate({ speciesSlug: 'desconocida_anual', category: 'hortalizas_hoja' });
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+  });
+
+  it('retorna null cuando no hay plantilla especifica y categoria no es estimable', () => {
+    expect(resolveTemplate({ speciesSlug: 'desconocida_perenne', category: 'frutales_perennes' })).toBeNull();
+  });
+
+  it('cultivar con especie madre con plantilla resuelve a la especifica, no al generico', () => {
+    const t = resolveTemplate({ speciesSlug: 'solanum_lycopersicum_san_marzano', category: 'hortalizas_fruto_flor' });
+    expect(t).toBeTruthy();
+    expect(t.derived_from).toBe('solanum_lycopersicum');
+    expect(t.is_generic).toBeFalsy();
+  });
+
+  it('cultivar sin especie madre con categoria estimable cae al generico', () => {
+    const t = resolveTemplate({ speciesSlug: 'capsicum_annuum_cayenne', category: 'hortalizas_fruto_flor' });
+    expect(t).toBeTruthy();
+    expect(t.is_generic).toBe(true);
+    expect(t.template_id).toBe('generic.hortalizas_fruto_flor');
+  });
+
+  it('cultivar sin especie madre y con categoria no estimable devuelve null', () => {
+    const t = resolveTemplate({ speciesSlug: 'citrus_sinensis_valencia', category: 'frutales_perennes' });
+    expect(t).toBeNull();
+  });
+
+  it('la plantilla explicita con template_id propio no hereda is_generic del generico', () => {
+    const explicit = {
+      template_id: 'manual.override',
+      species_slug: 'manual_override',
+      version: 1,
+      sources: [{ name: 'Override manual' }],
+      stages: [
+        { code: 'sowing', label: 'Siembra', minDays: 0, maxDays: 0, sourceIndex: 0 },
+        { code: 'closed', label: 'Cerrado', minDays: 50, maxDays: null, sourceIndex: 0 },
+      ],
+    };
+    const t = resolveTemplate({ speciesSlug: 'manual_override', template: explicit, category: 'hortalizas_hoja' });
+    expect(t.is_generic).toBeFalsy();
+  });
+
+  it('getCurrentStage con especie sin plantilla y sin categoria retorna null', () => {
+    const r = getCurrentStage({ speciesSlug: 'no_existe', sowingDate: SOWING });
+    expect(r).toBeNull();
+  });
+
+  it('getCurrentStage con especie generica retorna etapas marcadas isGeneric', () => {
+    const r = getCurrentStage({ speciesSlug: 'allium_fistulosum', sowingDate: SOWING, now: SOWING + 20 * 86400000, category: 'hortalizas_hoja' });
+    expect(r).not.toBeNull();
+    expect(r.stage.isGeneric).toBe(true);
+    expect(r.stage.confidence).toBeLessThanOrEqual(0.3);
   });
 });

--- a/src/services/__tests__/phenologySpecificResolution.test.js
+++ b/src/services/__tests__/phenologySpecificResolution.test.js
@@ -26,6 +26,56 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
       const harvest = windows.find((w) => w.code === 'harvest_window');
       expect(harvest.status).toBe('computed');
     });
+
+    it('la plantilla explicita (template embebido) gana sobre todo lo demas', () => {
+      const explicitTpl = {
+        template_id: 'embedded.test',
+        species_slug: 'especie_x',
+        species_label: 'Especie X embebida',
+        version: 2,
+        sources: [{ name: 'Manual incrustado' }],
+        stages: [
+          { code: 'sowing', label: 'Siembra', minDays: 0, maxDays: 0, sourceIndex: 0 },
+          { code: 'germination', label: 'Germinacion', minDays: 1, maxDays: 5, sourceIndex: 0 },
+          { code: 'closed', label: 'Cerrado', minDays: 6, maxDays: null, sourceIndex: 0 },
+        ],
+      };
+      const t = resolveTemplate({ speciesSlug: 'especie_x', template: explicitTpl, category: 'hortalizas_hoja' });
+      expect(t).toBeTruthy();
+      expect(t.template_id).toBe('embedded.test');
+      expect(t.is_generic).toBeFalsy();
+      expect(t.stages.find((s) => s.code === 'germination')).toBeTruthy();
+    });
+
+    it('la plantilla explicita gana aunque la especie tenga plantilla propia', () => {
+      const explicitTpl = {
+        template_id: 'custom.override',
+        species_slug: 'solanum_lycopersicum',
+        version: 1,
+        sources: [{ name: 'Override manual' }],
+        stages: [
+          { code: 'sowing', label: 'Siembra', minDays: 0, maxDays: 0, sourceIndex: 0 },
+          { code: 'custom_stage', label: 'Etapa custom', minDays: 1, maxDays: 30, sourceIndex: 0 },
+          { code: 'closed', label: 'Cerrado', minDays: 31, maxDays: null, sourceIndex: 0 },
+        ],
+      };
+      const t = resolveTemplate({
+        speciesSlug: 'solanum_lycopersicum',
+        template: explicitTpl,
+        category: 'hortalizas_fruto_flor',
+      });
+      expect(t).toBeTruthy();
+      expect(t.template_id).toBe('custom.override');
+      expect(t.stages.find((s) => s.code === 'custom_stage')).toBeTruthy();
+      expect(t.stages.find((s) => s.code === 'flowering')).toBeFalsy();
+    });
+
+    it('todas las etapas de plantilla especifica tienen isGeneric falso', () => {
+      const windows = calculateWindows({ speciesSlug: 'solanum_tuberosum', sowingDate: SOWING, altitudeM: 2000 });
+      for (const w of windows) {
+        expect(w.isGeneric).toBe(false);
+      }
+    });
   });
 
   describe('cultivar/subespecie hereda la fenología REAL de su especie madre', () => {
@@ -35,6 +85,18 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
 
     it('resolveParentSpeciesSlug mapea cultivar de papa a su especie madre', () => {
       expect(resolveParentSpeciesSlug('solanum_tuberosum_pastusa_suprema')).toBe('solanum_tuberosum');
+    });
+
+    it('resolveParentSpeciesSlug devuelve null para slug sin plantilla madre', () => {
+      expect(resolveParentSpeciesSlug('desconocida_xyz_variedad_rara')).toBeNull();
+    });
+
+    it('resolveParentSpeciesSlug devuelve null para string vacia', () => {
+      expect(resolveParentSpeciesSlug('')).toBeNull();
+    });
+
+    it('resolveParentSpeciesSlug devuelve null para undefined', () => {
+      expect(resolveParentSpeciesSlug(undefined)).toBeNull();
     });
 
     it('un cultivar usa la plantilla específica de la especie madre (NO el genérico)', () => {
@@ -62,6 +124,22 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
       const stageCultivar = getCurrentStage({ speciesSlug: 'solanum_lycopersicum_san_marzano', sowingDate: SOWING, now: SOWING + 30 * DAY_MS });
       expect(stageCultivar.stage.code).toBe(stageParent.stage.code);
     });
+
+    it('cultivar que deriva de especie madre con plantilla no cae al generico aunque tenga categoria', () => {
+      const t = resolveTemplate({ speciesSlug: 'solanum_lycopersicum_san_marzano', category: 'hortalizas_fruto_flor' });
+      expect(t).toBeTruthy();
+      expect(t.species_slug).toBe('solanum_lycopersicum_san_marzano');
+      expect(t.derived_from).toBe('solanum_lycopersicum');
+      expect(t.is_generic).toBeFalsy();
+    });
+
+    it('cultivar de zea_mays resuelve a su especie madre en la cascada', () => {
+      const t = resolveTemplate({ speciesSlug: 'zea_mays_hibrido_x', category: 'cereales' });
+      expect(t).toBeTruthy();
+      expect(t.species_slug).toBe('zea_mays_hibrido_x');
+      expect(t.derived_from).toBe('zea_mays');
+      expect(t.is_generic).toBeFalsy();
+    });
   });
 
   describe('especie SIN datos específicos cae al genérico SIN inventar', () => {
@@ -71,6 +149,52 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
       expect(t).toBeTruthy();
       expect(t.is_generic).toBe(true);
       expect(t.species_slug.startsWith('generic.')).toBe(true);
+    });
+
+    it('especie sin plantilla con categoria tuberculos_raices cae al generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'oxalis_tuberosa', category: 'tuberculos_raices' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+      expect(t.template_id).toBe('generic.tuberculos_raices');
+    });
+
+    it('especie sin plantilla con categoria hortalizas_fruto_flor cae al generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'capsicum_annuum', category: 'hortalizas_fruto_flor' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+      expect(t.template_id).toBe('generic.hortalizas_fruto_flor');
+    });
+
+    it('especie sin plantilla con categoria granos_legumbres cae al generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'cicer_arietinum', category: 'granos_legumbres' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+    });
+
+    it('especie sin plantilla con categoria cereales cae al generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'avena_sativa', category: 'cereales' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+    });
+
+    it('especie sin plantilla con categoria abonos_verdes_coberturas cae al generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'canavalia_ensiformis', category: 'abonos_verdes_coberturas' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+      expect(t.template_id).toBe('generic.abonos_verdes_coberturas');
+    });
+
+    it('especie sin plantilla con categoria atractores_polinizadores cae al generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'borago_officinalis', category: 'atractores_polinizadores' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
+    });
+
+    it('cultivar sin especie madre con plantilla pero con categoria estimable cae al generico', () => {
+      // 'capsicum_annuum_pimenton' no tiene especie madre en el registro (capsicum_annuum no tiene plantilla)
+      const t = resolveTemplate({ speciesSlug: 'capsicum_annuum_pimenton', category: 'hortalizas_fruto_flor' });
+      expect(t).toBeTruthy();
+      expect(t.is_generic).toBe(true);
     });
 
     it('las ventanas genéricas se marcan isGeneric y bajan la confianza', () => {
@@ -88,6 +212,22 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
       const sowing = windows.find((w) => w.code === 'sowing');
       expect(sowing.confidence).toBe(1.0);
     });
+
+    it('todas las etapas no-sowing de plantilla generica tienen confianza <= 0.3 sin altitud', () => {
+      const windows = calculateWindows({ speciesSlug: 'allium_fistulosum', sowingDate: SOWING, category: 'hortalizas_hoja' });
+      for (const w of windows) {
+        if (w.code !== 'sowing') {
+          expect(w.confidence).toBeLessThanOrEqual(0.3);
+        }
+      }
+    });
+
+    it('plantilla generica con altitud mantiene confianza baja en no-sowing', () => {
+      const windows = calculateWindows({ speciesSlug: 'allium_fistulosum', sowingDate: SOWING, altitudeM: 1500, category: 'hortalizas_hoja' });
+      const veg = windows.find((w) => w.code === 'vegetative');
+      expect(veg.isGeneric).toBe(true);
+      expect(veg.confidence).toBeLessThanOrEqual(0.3);
+    });
   });
 
   describe('anti-alucinación: sin datos honestos NO se inventa nada', () => {
@@ -95,6 +235,16 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
       const windows = calculateWindows({ speciesSlug: 'desconocida_xyz', sowingDate: SOWING });
       expect(windows).toHaveLength(1);
       expect(windows[0].status).toBe('template_missing');
+    });
+
+    it('especie sin plantilla y sin categoria devuelve null de resolveTemplate', () => {
+      const t = resolveTemplate({ speciesSlug: 'desconocida_xyz' });
+      expect(t).toBeNull();
+    });
+
+    it('especie sin plantilla con categoria no estimable devuelve null de resolveTemplate', () => {
+      expect(resolveTemplate({ speciesSlug: 'mangifera_indica', category: 'frutales_perennes' })).toBeNull();
+      expect(resolveTemplate({ speciesSlug: 'cedrela_odorata', category: 'arboles_sombra' })).toBeNull();
     });
 
     it('categorías sin ciclo anual estimable (perennes/árboles/invasoras) NO tienen genérico', () => {
@@ -112,6 +262,23 @@ describe('Tarea #62 — fenología específica vs genérica', () => {
       expect(t).toBeNull();
       const windows = calculateWindows({ speciesSlug: 'theobroma_cacao', sowingDate: SOWING, category: 'frutales_perennes' });
       expect(windows[0].status).toBe('template_missing');
+    });
+
+    it('un arbol de sombra sin plantilla propia NO recibe ventanas inventadas', () => {
+      const windows = calculateWindows({ speciesSlug: 'inga_edulis', sowingDate: SOWING, category: 'arboles_sombra' });
+      expect(windows).toHaveLength(1);
+      expect(windows[0].status).toBe('template_missing');
+      expect(windows[0].confidence).toBe(0);
+    });
+
+    it('resolveTemplate con category vacia no cae a generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'desconocida_xyz', category: '' });
+      expect(t).toBeNull();
+    });
+
+    it('resolveTemplate con category null no lanza ni cae a generico', () => {
+      const t = resolveTemplate({ speciesSlug: 'desconocida_xyz', category: null });
+      expect(t).toBeNull();
     });
 
     it('todas las categorías con genérico producen un ciclo anual coherente', () => {


### PR DESCRIPTION
## Que cubre

Tests unitarios (vitest) para la cascada de resolucion de fenologia:

### Nuevo: `src/data/__tests__/phenologyGeneric.test.js` (35 tests)
- `getGenericTemplate` para las 7 categorias estimables y casos edge
- `getGenericTemplate` retorna null para categorias no estimables (frutales perennes, arboles, invasoras, etc.)
- `getGenericCategories` integridad de la lista
- Verificacion de integridad estructural de cada plantilla generica (sowing, closed, monotonia, fuentes)

### Ampliado: `src/services/__tests__/phenologySpecificResolution.test.js` (+25 tests)
- Cascada completa `resolveTemplate`: plantilla explicita > especifica > generica > null
- Cultivares con y sin especie madre con plantilla
- Cultivar sin madre pero con categoria estimable cae al generico
- Cultivar sin madre con categoria no estimable devuelve null
- `isGeneric` se propaga correctamente a todas las etapas (excepto sowing)
- Confianza baja (<= 0.3) en etapas no-sowing de plantillas genericas
- Edge cases: inputs vacios, nulos, categorias vacias

### Ampliado: `src/services/__tests__/phenologyCalculator.test.js` (+14 tests)
- `resolveTemplate` directo: cascada de los 4 niveles
- Plantilla explicita gana sobre especifica y generica
- Cultivar resuelve a especie madre, no al generico
- Propagacion de `isGeneric` en `getCurrentStage`

### Resultado
126 tests pasando (62 originales + 64 nuevos). Sin modificar codigo de produccion.