### PR TITLE
fix(imagenes): foto de especie por binomio (el autor rompía el match)

### DIFF
--- a/src/utils/__tests__/speciesImageResolver.binomio.test.js
+++ b/src/utils/__tests__/speciesImageResolver.binomio.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildSpeciesIdCandidates, findLocalImage, __resetSpeciesImageCache } from '../speciesImageResolver';
+
+describe('buildSpeciesIdCandidates — rescata nombres con autor', () => {
+  it('binomio cuando el nombre trae autor (Solanum tuberosum L.)', () => {
+    const c = buildSpeciesIdCandidates('solanum_tuberosum_l');
+    expect(c).toContain('solanum_tuberosum');
+  });
+  it('binomio con autor compuesto (Cenchrus clandestinus (Hochst. ex Chiov.) Morrone)', () => {
+    const c = buildSpeciesIdCandidates('cenchrus_clandestinus_hochst_ex_chiov_morrone');
+    expect(c).toContain('cenchrus_clandestinus');
+  });
+  it('conserva cultivar exacto como primer candidato (San Marzano)', () => {
+    const c = buildSpeciesIdCandidates('solanum_lycopersicum_san_marzano');
+    expect(c[0]).toBe('solanum_lycopersicum_san_marzano');
+    expect(c).toContain('solanum_lycopersicum');
+  });
+  it('quita rangos infra (var/subsp) del candidato limpio', () => {
+    const c = buildSpeciesIdCandidates('solanum_lycopersicum_var_cerasiforme');
+    expect(c).toContain('solanum_lycopersicum_cerasiforme');
+    expect(c).toContain('solanum_lycopersicum');
+  });
+  it('nombre de un solo token o vacío no rompe', () => {
+    expect(buildSpeciesIdCandidates('')).toEqual([]);
+    expect(buildSpeciesIdCandidates('tomate')).toEqual(['tomate']);
+  });
+});
+
+describe('findLocalImage — usa los candidatos contra el JSON', () => {
+  const JSON_FIX = {
+    species: [
+      { species_id: 'solanum_tuberosum', scientific_name: 'Solanum tuberosum L.', image_url: 'https://x/papa.jpg' },
+      { species_id: 'passiflora_ligularis', scientific_name: 'Passiflora ligularis Juss.', image_url: 'https://x/granadilla.jpg' },
+    ],
+  };
+  beforeEach(() => {
+    __resetSpeciesImageCache?.();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(JSON_FIX) }));
+  });
+  afterEach(() => { vi.unstubAllGlobals(); __resetSpeciesImageCache?.(); });
+
+  it('resuelve "Solanum tuberosum L." (con autor) por binomio', async () => {
+    const img = await findLocalImage('Solanum tuberosum L.');
+    expect(img?.url).toBe('https://x/papa.jpg');
+  });
+  it('resuelve "Passiflora ligularis Juss." (con autor) por binomio', async () => {
+    const img = await findLocalImage('Passiflora ligularis Juss.');
+    expect(img?.url).toBe('https://x/granadilla.jpg');
+  });
+  it('devuelve null si la especie no está', async () => {
+    const img = await findLocalImage('Inexistente planta Fake.');
+    expect(img).toBeNull();
+  });
+});

--- a/src/utils/speciesImageResolver.js
+++ b/src/utils/speciesImageResolver.js
@@ -60,6 +60,37 @@ async function loadSpeciesImages() {
   return loadPromise;
 }
 
+// Ruido taxonómico que NO forma parte del species_id (rangos infraespecíficos
+// y conectores de autoría). El epíteto de autor (L., Cav., Kunth, '(Duchesne…)')
+// se descarta por la lógica de candidatos: el species_id del JSON es
+// género_especie[_infra/cultivar], sin autor.
+const TAXON_NOISE = new Set([
+  'var', 'subsp', 'ssp', 'f', 'cv', 'cultivar', 'sp', 'spp', 'ex', 'aff', 'cf',
+]);
+
+/**
+ * Genera species_id candidatos para un nombre científico normalizado, de MÁS
+ * específico a MENOS. El JSON indexa por species_id SIN autor (p.ej.
+ * `solanum_tuberosum`), pero los nombres del catálogo traen autor
+ * ("Solanum tuberosum L." → `solanum_tuberosum_l`). Probar el binomio
+ * (género_especie) rescata esos casos; el trinomio cubre cultivares/infra.
+ */
+export function buildSpeciesIdCandidates(normalized) {
+  const tokens = String(normalized || '').split('_').filter(Boolean);
+  if (tokens.length < 2) return tokens.length === 1 ? [tokens[0]] : [];
+  const clean = tokens.filter((t) => !TAXON_NOISE.has(t));
+  const out = [];
+  const push = (arr) => {
+    const id = arr.join('_');
+    if (id && !out.includes(id)) out.push(id);
+  };
+  push(tokens); // 1) completo tal cual (cultivar exacto si no hay autor)
+  push(clean); // 2) sin rangos infra (var/subsp…)
+  if (clean.length >= 3) push(clean.slice(0, 3)); // 3) género_especie_infra
+  if (clean.length >= 2) push(clean.slice(0, 2)); // 4) binomio género_especie
+  return out;
+}
+
 /**
  * Busca una imagen por nombre científico en el JSON local.
  * Retorna null si no hay imagen disponible.
@@ -71,37 +102,20 @@ export async function findLocalImage(scientificName) {
   const index = await loadSpeciesImages();
   if (!index) return null;
 
-  // 1. Búsqueda exacta por species_id normalizado
-  if (index.has(normalized)) {
-    const entry = index.get(normalized);
-    return {
-      url: entry.image_url,
-      thumbUrl: entry.image_url,
-      license: formatLicense(entry.license),
-      rightsHolder: entry.attribution || 'Autor no informado',
-      source: 'iNaturalist',
-      sourceUrl: entry.image_url,
-    };
-  }
-
-  // 2. Si el nombre contiene espacios, intentar con guion bajo
-  if (normalized.includes('_')) {
-    // Ya lo intentamos con guion bajo, no hay más variantes
-    return null;
-  }
-
-  // 3. Si el nombre tiene espacios, reemplazar por guiones y reintentar
-  const withUnderscores = normalized.replace(/\s+/g, '_');
-  if (withUnderscores !== normalized && index.has(withUnderscores)) {
-    const entry = index.get(withUnderscores);
-    return {
-      url: entry.image_url,
-      thumbUrl: entry.image_url,
-      license: formatLicense(entry.license),
-      rightsHolder: entry.attribution || 'Autor no informado',
-      source: 'iNaturalist',
-      sourceUrl: entry.image_url,
-    };
+  // Probar species_id candidatos de más a menos específico. El binomio rescata
+  // los nombres con autor ("…_l", "…_kunth") que el match exacto no encuentra.
+  for (const candidate of buildSpeciesIdCandidates(normalized)) {
+    const entry = index.get(candidate);
+    if (entry) {
+      return {
+        url: entry.image_url,
+        thumbUrl: entry.image_url,
+        license: formatLicense(entry.license),
+        rightsHolder: entry.attribution || 'Autor no informado',
+        source: 'iNaturalist',
+        sourceUrl: entry.image_url,
+      };
+    }
   }
 
   return null;


### PR DESCRIPTION
## Causa raíz
`findLocalImage` normalizaba el nombre científico **completo con autor** ("Solanum tuberosum **L.**" → `solanum_tuberosum_l`), pero `species-images.json` indexa por `species_id` **sin autor** (`solanum_tuberosum`). Resultado: el match exacto fallaba y **casi todas las fichas salían sin foto** (medido: 1/65 del catálogo casaban).

## Fix
`findLocalImage` ahora prueba `species_id` candidatos de más a menos específico: completo → sin rangos infra (var/subsp) → trinomio → **binomio género_especie**. El binomio rescata los nombres con autor. Cultivares exactos (San Marzano) siguen casando primero.

**Medido:** 60/65 especies del catálogo ahora resuelven imagen (antes 1/65). +8 tests.

Cierra parte de #61.