### PR TITLE
fix(temas): legibilidad AltitudeBadge y AIBetaBadge-low en temas claros (re-eval #1738)

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -387,6 +387,51 @@
 }
 
 /* ===========================================================================
+ * 3c. BADGES POR FAMILIA NO-VAR (AltitudeBadge piso térmico + AIBetaBadge low)
+ *    Origen: PR glm/legibilidad-temas (#1738) — re-evaluado sobre main 2026-06-21.
+ *    El grueso de ese PR ya estaba cubierto por §3 (WelcomeStatsHero) y por la
+ *    indirección --c-* (slate/emerald/amber). PERO dos badges NO los cubre nadie
+ *    porque usan familias de color estáticas (orange/green/indigo/rose):
+ *
+ *      - AltitudeBadge: cálido(orange) · templado(amber) · montano(green) ·
+ *        páramo(indigo). En temas claros el texto -400 sobre el tinte -950/30
+ *        sobre crema medía contraste ~1.05–1.38 (sonda WCAG) = ilegible.
+ *      - AIBetaBadge nivel "low": text-rose-300 sobre bg-rose-500/20 sobre crema
+ *        medía ~1.29 = ilegible. (high=emerald y mid=amber YA adaptan vía la
+ *        indirección; default=slate también. Solo rose quedaba estática.)
+ *
+ *    Igual que §3: colapsamos superficie/borde al token del tema y subimos la
+ *    tinta al verde profundo del tema, SOLO en los claros (bio-punk intacto).
+ *    NO tocamos los componentes: el override va ANCLADO al data-testid de cada
+ *    badge ([data-testid="altitude-badge"] / [data-testid="ai-beta-badge"]) para
+ *    NO arrastrar otros usos legítimos de esas familias (TelemetryAlerts,
+ *    ClimaStrip, PestMonitoringWindow, etc. mantienen su estilo).
+ * =========================================================================== */
+
+/* Superficie + borde del badge → tarjeta/línea suave del tema. */
+[data-theme="minimalista"] [data-testid="altitude-badge"],
+[data-theme="nature"] [data-testid="altitude-badge"],
+[data-theme="minimalista"] [data-testid="ai-beta-badge"][data-confidence-level="low"],
+[data-theme="nature"] [data-testid="ai-beta-badge"][data-confidence-level="low"] {
+  background-color: rgb(var(--c-surface-raised)) !important;
+  border-color: rgb(var(--c-surface-border)) !important;
+}
+
+/* Tinta del badge → tinta profunda del tema (AA sobre papel/crema). Cubre los 4
+ * pisos térmicos (orange/amber/green/indigo) y el nivel low (rose) de un golpe,
+ * sin enumerar familias, porque está anclado al badge. */
+[data-theme="minimalista"] [data-testid="altitude-badge"],
+[data-theme="minimalista"] [data-testid="ai-beta-badge"][data-confidence-level="low"] {
+  color: rgb(var(--c-emerald-400)) !important;  /* salvia oscura minimalista (AA) */
+  text-shadow: none !important;
+}
+[data-theme="nature"] [data-testid="altitude-badge"],
+[data-theme="nature"] [data-testid="ai-beta-badge"][data-confidence-level="low"] {
+  color: rgb(var(--c-emerald-700)) !important;  /* verde profundo cálido (AA) */
+  text-shadow: none !important;
+}
+
+/* ===========================================================================
  * 3b. PANELES "INFO" sky/indigo (ClimaStrip "Clima en tu zona", y similares)
  *    PEOR OFFENDER de los temas claros (reporte visual 2026-06-05): el card usa
  *    `bg-gradient-to-br from-sky-950/70 to-indigo-950/60 border-sky-800/40


### PR DESCRIPTION
## Contexto

Re-evaluación crítica del PR antiguo **#1738** (`glm/legibilidad-temas`, 20 commits detrás de main, en conflicto) sobre el estado actual de `main`.

Al traer #1738 sobre main encontré que **el grueso de su aporte ya está resuelto** por el trabajo de temas que entró después:

- La indirección `--c-*` (PR #1308) hace `slate/emerald/amber/surface` theme-aware → cientos de clases adaptan solas.
- `themes.css` §3 ya colapsa los tonos del **WelcomeStatsHero** (cyan/lime/fuchsia/sky/orange/violet/yellow) al token del tema en claros.
- §3b ya arregla los paneles **sky/indigo** (cubre el `text-sky-300` del DeepResearchCard).
- #1747 ("nature y minimalista no se oscurecen de noche") cerró el velo nocturno.

Por eso **no se reintroduce** la arquitectura de #1738 (renombrar utilidades Tailwind a clases `hero-*`/`ai-badge-*`/`status-badge-*`), que competía con la solución ya mergeada.

## El gap real que SÍ quedaba

Dos badges usan familias de color **estáticas** (no var-aware: orange/green/indigo/rose) que **nadie** corregía en claros. Medido con sonda WCAG sobre crema/papel:

| Badge | par | contraste antes | después |
|---|---|---|---|
| AltitudeBadge cálido | text-orange-400 / bg-orange-950/30 | **1.05** | 7.56 |
| AltitudeBadge templado | text-amber-400 / bg-amber-950/30 | **1.65** | 7.56 |
| AltitudeBadge montano | text-green-400 / bg-green-950/30 | **1.21** | 7.56 |
| AltitudeBadge páramo | text-indigo-400 / bg-indigo-950/30 | **1.38** | 7.56 |
| AIBetaBadge low | text-rose-300 / bg-rose-500/20 | **1.29** | 7.56 |

(mínimo AA = 4.5; valores "después" = nature; minimalista 5.09)

## Qué hace este PR

Fix **puramente aditivo** en `themes.css` (+45 líneas, §3c), siguiendo el idioma existente del archivo:

- Anclado al `data-testid` de cada badge (`altitude-badge` / `ai-beta-badge[data-confidence-level="low"]`) → **no toca ningún componente** y **no arrastra** otros usos legítimos de esas familias (TelemetryAlerts, ClimaStrip, PestMonitoringWindow, CaseStudyTopWidget, etc. conservan su estilo).
- Colapsa superficie/borde al token del tema y sube la tinta al verde profundo del tema, **solo en minimalista/nature**. Bio-punk (default) intacto.

## Qué se descartó de #1738 (y por qué)

- **StatusBadge**: en main usa pares hex inline (`#86efac`/`#064e3b` etc.) = pastel claro + tinta oscura, ya legibles en todo tema e independientes del tema. Convertirlos a clases CSS era un riesgo de regresión, no una mejora.
- **SpeciesImage**: reescrito en main (resolver por binomio + fallback emoji/gradiente, bug fresa 2026-06-20). El cambio de #1738 apuntaba a markup que ya no existe → muerto/conflictivo. **No tocado.**
- **WelcomeStatsHero / DeepResearchCard**: redundantes con §3 y el override sky de §3b ya en main.

## Verificación

- `npm run build` ✓ compila
- `vitest run src/styles/__tests__/` ✓ 20/20 (themeContrast + coverage)
- ESLint: sin archivos JS/JSX tocados (themes.css no se lintea con eslint)
- Diff = solo `src/styles/themes.css`, todas las reglas theme-scoped (bio-punk sin cambios)

## Recomendación

**Cerrar #1738** como superseded por este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)