### PR TITLE
fix(mapa): fallback de distancia máxima en acceptGpsFix + tests exhaustivos (#57)

### DIFF
--- a/src/utils/__tests__/geo.test.js
+++ b/src/utils/__tests__/geo.test.js
@@ -13,6 +13,9 @@ import {
   buildWalkPolygon,
   GPS_ACCURACY_THRESHOLD_M,
   GPS_MIN_VERTEX_DISTANCE_M,
+  GPS_MAX_JUMP_DISTANCE_M,
+  GPS_WARMUP_ACCURACY_M,
+  GPS_MAX_WALK_SPEED_MPS,
 } from '../geo.js';
 
 describe('geoJsonToWkt', () => {
@@ -133,11 +136,20 @@ describe('haversineMeters', () => {
 });
 
 describe('acceptGpsFix — síntoma (a) línea loca', () => {
+  // --- Primer fix (sin previo) --------------------------------------------------
   it('acepta el primer fix preciso sin previo', () => {
     const r = acceptGpsFix({ lat: 4.53, lng: -73.92, accuracy: 8, timestamp: 1000 }, null);
     expect(r.accepted).toBe(true);
+    expect(r.reason).toBeNull();
+    expect(r.distance).toBe(0);
   });
 
+  it('acepta el primer fix sin accuracy reportada (navegador la omite)', () => {
+    const r = acceptGpsFix({ lat: 4.53, lng: -73.92, timestamp: 1000 }, null);
+    expect(r.accepted).toBe(true);
+  });
+
+  // --- Rechazo por accuracy -----------------------------------------------------
   it('descarta fix con accuracy peor que el umbral', () => {
     const r = acceptGpsFix(
       { lat: 4.53, lng: -73.92, accuracy: GPS_ACCURACY_THRESHOLD_M + 50, timestamp: 1000 },
@@ -147,7 +159,16 @@ describe('acceptGpsFix — síntoma (a) línea loca', () => {
     expect(r.reason).toBe('accuracy');
   });
 
-  it('acepta fix justo en el umbral', () => {
+  it('descarta fix con accuracy exactamente una unidad sobre el umbral', () => {
+    const r = acceptGpsFix(
+      { lat: 4.53, lng: -73.92, accuracy: GPS_ACCURACY_THRESHOLD_M + 0.001, timestamp: 1000 },
+      null,
+    );
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('accuracy');
+  });
+
+  it('acepta fix justo en el umbral de accuracy (≤)', () => {
     const r = acceptGpsFix(
       { lat: 4.53, lng: -73.92, accuracy: GPS_ACCURACY_THRESHOLD_M, timestamp: 1000 },
       null,
@@ -155,59 +176,268 @@ describe('acceptGpsFix — síntoma (a) línea loca', () => {
     expect(r.accepted).toBe(true);
   });
 
-  it('descarta salto a velocidad imposible (distancia/tiempo)', () => {
+  it('acepta fix con accuracy muy buena (1m)', () => {
+    const r = acceptGpsFix({ lat: 4.53, lng: -73.92, accuracy: 1, timestamp: 1000 }, null);
+    expect(r.accepted).toBe(true);
+  });
+
+  // --- Umbral personalizado -----------------------------------------------------
+  it('respeta accuracyThreshold personalizado en opts', () => {
+    const r = acceptGpsFix(
+      { lat: 4.53, lng: -73.92, accuracy: 30, timestamp: 1000 },
+      null,
+      { accuracyThreshold: 10 },
+    );
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('accuracy');
+  });
+
+  // --- Rechazo por velocidad ----------------------------------------------------
+  it('descarta salto a velocidad imposible (~111 m/s ≫ 5 m/s)', () => {
     const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
-    // ~111m en 1s = 111 m/s ≫ caminata → rechazado
-    const fix = { lat: 4.531, lng: -73.92, accuracy: 8, timestamp: 2000 };
+    const fix = { lat: 4.531, lng: -73.92, accuracy: 8, timestamp: 2000 }; // ~111m en 1s
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('speed');
+    expect(r.distance).toBeGreaterThan(100);
+  });
+
+  it('descarta velocidad justo por encima del umbral (>5 m/s)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 0 };
+    // ~5.5m en 1s → speed=5.5 > 5
+    const fix = { lat: 4.53005, lng: -73.92, accuracy: 8, timestamp: 1000 };
     const r = acceptGpsFix(fix, prev);
     expect(r.accepted).toBe(false);
     expect(r.reason).toBe('speed');
   });
 
+  it('acepta velocidad justo en el umbral (≤5 m/s)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 0 };
+    // ~4.4m en 1s → speed≈4.4 ≤ 5 → aceptado
+    const fix = { lat: 4.530040, lng: -73.92, accuracy: 8, timestamp: 1000 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(true);
+    expect(r.reason).toBeNull();
+  });
+
   it('acepta un paso realista al caminar (~1.4 m/s)', () => {
     const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
-    // ~1.4m en 1s
     const fix = { lat: 4.5300126, lng: -73.92, accuracy: 8, timestamp: 2000 };
     const r = acceptGpsFix(fix, prev);
     expect(r.accepted).toBe(true);
     expect(r.distance).toBeGreaterThan(0);
+    expect(r.distance).toBeLessThan(5);
   });
 
+  it('respeta maxSpeed personalizado en opts', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 0 };
+    // ~6m en 1s → con maxSpeed=3 debe rechazar
+    const fix = { lat: 4.530054, lng: -73.92, accuracy: 8, timestamp: 1000 };
+    const r = acceptGpsFix(fix, prev, { maxSpeed: 3 });
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('speed');
+  });
+
+  // --- Fallback: salto sin timestamps (bug #57 fix) -----------------------------
+  it('descarta salto >50m cuando no hay timestamps (fallback jump)', () => {
+    const prev = { lat: 4.53, lng: -73.92 };
+    // ~111m de salto sin timestamp
+    const fix = { lat: 4.531, lng: -73.92, accuracy: 8 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('jump');
+    expect(r.distance).toBeGreaterThan(50);
+  });
+
+  it('acepta distancia ≤maxJumpDistance sin timestamps', () => {
+    const prev = { lat: 4.53, lng: -73.92 };
+    // ~0.5m → dentro del límite
+    const fix = { lat: 4.5300045, lng: -73.92, accuracy: 8 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(true);
+    expect(r.reason).toBeNull();
+  });
+
+  it('descarta salto justo por encima de maxJumpDistance sin timestamps', () => {
+    const prev = { lat: 4.53, lng: -73.92 };
+    // ~55m → > 50m threshold
+    const fix = { lat: 4.530497, lng: -73.92, accuracy: 8 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('jump');
+  });
+
+  it('usa velocidad sobre jump cuando hay timestamps válidos', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
+    // ~5.5m en 1s → velocidad 5.5 > 5, pero distancia < 50m. Debe rechazar
+    // por speed, no por jump (speed es más preciso cuando hay timestamps).
+    const fix = { lat: 4.53005, lng: -73.92, accuracy: 8, timestamp: 2000 };
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('speed');
+  });
+
+  it('respeta maxJumpDistance personalizado en opts', () => {
+    const prev = { lat: 4.53, lng: -73.92 };
+    // ~20m → rechazado con threshold=10
+    const fix = { lat: 4.53018, lng: -73.92, accuracy: 8 };
+    const r = acceptGpsFix(fix, prev, { maxJumpDistance: 10 });
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('jump');
+  });
+
+  // --- Timestamps no consistentes -----------------------------------------------
+  it('ignora velocidad cuando prev no tiene timestamp (cae a jump)', () => {
+    const prev = { lat: 4.53, lng: -73.92 }; // sin timestamp
+    const fix = { lat: 4.531, lng: -73.92, accuracy: 8, timestamp: 2000 };
+    const r = acceptGpsFix(fix, prev);
+    // distancia >50m → jump rechazado
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('jump');
+  });
+
+  it('ignora velocidad cuando fix no tiene timestamp (cae a jump)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
+    const fix = { lat: 4.531, lng: -73.92, accuracy: 8 }; // sin timestamp
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('jump');
+  });
+
+  it('ignora velocidad con dtMs <= 0 (timestamp regresivo o igual)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 2000 };
+    const fix = { lat: 4.531, lng: -73.92, accuracy: 8, timestamp: 1000 }; // dtMs = -1000
+    const r = acceptGpsFix(fix, prev);
+    // dtMs <= 0 → sin speed check, cae a jump (distancia >50m → rechazado)
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe('jump');
+  });
+
+  it('acepta dtMs=0 si la distancia es razonable (cae a jump con distancia pequeña)', () => {
+    const prev = { lat: 4.53, lng: -73.92, timestamp: 1000 };
+    const fix = { lat: 4.530001, lng: -73.92, accuracy: 8, timestamp: 1000 }; // mismo timestamp
+    const r = acceptGpsFix(fix, prev);
+    expect(r.accepted).toBe(true);
+    expect(r.reason).toBeNull();
+  });
+
+  // --- Fix inválido -------------------------------------------------------------
   it('descarta coordenadas no finitas', () => {
     expect(acceptGpsFix({ lat: NaN, lng: -73.92 }, null).accepted).toBe(false);
+    expect(acceptGpsFix({ lat: NaN, lng: -73.92 }, null).reason).toBe('invalid');
     expect(acceptGpsFix(null, null).accepted).toBe(false);
+    expect(acceptGpsFix(null, null).reason).toBe('invalid');
+    expect(acceptGpsFix(undefined, null).accepted).toBe(false);
   });
 
-  it('acepta fix sin accuracy reportada (navegador la omite)', () => {
-    const r = acceptGpsFix({ lat: 4.53, lng: -73.92, timestamp: 1000 }, null);
-    expect(r.accepted).toBe(true);
+  it('descarta fix sin lat o lng pero con otros campos', () => {
+    expect(acceptGpsFix({ accuracy: 8, timestamp: 1000 }, null).accepted).toBe(false);
+    expect(acceptGpsFix({ lat: 1 }, null).accepted).toBe(false);
+    expect(acceptGpsFix({ lng: 1 }, null).accepted).toBe(false);
+  });
+
+  // --- Simulación de sesión real de trazo caminando -----------------------------
+  it('simula sesión de trazo: rechaza línea loca y acepta pasos reales', () => {
+    const session = [
+      { lat: 4.530000, lng: -73.920000, accuracy: 5, timestamp: 0 },     // t=0: ancla
+      { lat: 4.530010, lng: -73.920000, accuracy: 6, timestamp: 1000 },   // t=1s: paso ~1.1m ✓
+      { lat: 4.530020, lng: -73.920000, accuracy: 30, timestamp: 2000 },  // t=2s: accuracy mala ✗
+      { lat: 4.531000, lng: -73.920000, accuracy: 5, timestamp: 3000 },   // t=3s: salto ~111m en 1s ✗
+      { lat: 4.530030, lng: -73.920000, accuracy: 7, timestamp: 4000 },   // t=4s: paso ~1.1m ✓
+      { lat: 4.530040, lng: -73.920000, accuracy: 8, timestamp: 5000 },   // t=5s: paso ~1.1m ✓
+    ];
+    let prev = null;
+    const accepted = [];
+    for (const fix of session) {
+      const r = acceptGpsFix(fix, prev);
+      if (r.accepted) {
+        accepted.push(fix);
+        prev = fix;
+      }
+    }
+    // Deben aceptarse: t=0 (ancla), t=1s, t=4s, t=5s = 4 fixes.
+    // Rechazados: t=2s (accuracy), t=3s (speed).
+    expect(accepted.length).toBe(4);
+    expect(accepted[0].timestamp).toBe(0);
+    expect(accepted[1].timestamp).toBe(1000);
+    expect(accepted[2].timestamp).toBe(4000);
+    expect(accepted[3].timestamp).toBe(5000);
   });
 });
 
 describe('dedupeByMinDistance — síntoma (b) jitter casi-duplicado', () => {
-  it('colapsa puntos a menos de la distancia mínima', () => {
+  it('colapsa puntos a menos de la distancia mínima (default 3m)', () => {
     const jitter = [
       { lat: 4.53, lng: -73.92 },
-      { lat: 4.5300001, lng: -73.92 }, // ~0.1m
-      { lat: 4.5300002, lng: -73.92 }, // ~0.2m
-      { lat: 4.531, lng: -73.92 }, // ~111m
+      { lat: 4.5300001, lng: -73.92 }, // ~0.01m
+      { lat: 4.5300002, lng: -73.92 }, // ~0.02m
+      { lat: 4.531, lng: -73.92 },     // ~111m
     ];
     const out = dedupeByMinDistance(jitter);
     expect(out.length).toBe(2);
+    expect(out[0]).toEqual({ lat: 4.53, lng: -73.92 });
+    expect(out[1]).toEqual({ lat: 4.531, lng: -73.92 });
   });
 
-  it('preserva puntos suficientemente separados', () => {
+  it('preserva puntos suficientemente separados (>3m)', () => {
     const pts = [
       { lat: 4.53, lng: -73.92 },
-      { lat: 4.531, lng: -73.92 },
-      { lat: 4.532, lng: -73.92 },
+      { lat: 4.531, lng: -73.92 }, // ~111m
+      { lat: 4.532, lng: -73.92 }, // ~111m más
     ];
     expect(dedupeByMinDistance(pts).length).toBe(3);
   });
 
-  it('retorna vacio para entrada vacia', () => {
+  it('retorna array vacío para entrada vacía', () => {
     expect(dedupeByMinDistance([])).toEqual([]);
     expect(dedupeByMinDistance(null)).toEqual([]);
+    expect(dedupeByMinDistance(undefined)).toEqual([]);
+    expect(dedupeByMinDistance('no-array')).toEqual([]);
+  });
+
+  it('retorna el único punto para array de 1 elemento', () => {
+    const single = [{ lat: 4.53, lng: -73.92 }];
+    const out = dedupeByMinDistance(single);
+    expect(out.length).toBe(1);
+    expect(out[0]).toEqual(single[0]);
+  });
+
+  it('respeta minDistance personalizado', () => {
+    const pts = [
+      { lat: 4.53, lng: -73.92 },
+      { lat: 4.5305, lng: -73.92 }, // ~55m — se mantiene con threshold 3m, se borra con 100m
+      { lat: 4.532, lng: -73.92 },  // ~222m
+    ];
+    // Con threshold 3m: 3 puntos (todos separados >3m)
+    expect(dedupeByMinDistance(pts, 3).length).toBe(3);
+    // Con threshold 100m: solo 2 puntos (el del medio está a 55m del primero <100m)
+    expect(dedupeByMinDistance(pts, 100).length).toBe(2);
+  });
+
+  it('elimina múltiples puntos consecutivos con jitter (polígono rayado)', () => {
+    // Simula 50 puntos de jitter GPS estando quieto, luego un movimiento real
+    const jitterCluster = [];
+    for (let i = 0; i < 50; i += 1) {
+      jitterCluster.push({
+        lat: 4.53 + (Math.random() - 0.5) * 1e-6,
+        lng: -73.92 + (Math.random() - 0.5) * 1e-6,
+      });
+    }
+    jitterCluster.push({ lat: 4.531, lng: -73.92 }); // movimiento real
+    const out = dedupeByMinDistance(jitterCluster);
+    // Debe quedar: primer punto del cluster + el movimiento real = 2
+    expect(out.length).toBe(2);
+    expect(out[1]).toEqual({ lat: 4.531, lng: -73.92 });
+  });
+
+  it('no muta el array original', () => {
+    const original = [
+      { lat: 4.53, lng: -73.92 },
+      { lat: 4.5300001, lng: -73.92 },
+    ];
+    const copy = [...original];
+    dedupeByMinDistance(original);
+    expect(original).toEqual(copy);
   });
 });
 
@@ -233,14 +463,67 @@ describe('simplifyDouglasPeucker — síntoma (b) reducir lados que se cruzan', 
   });
 
   it('devuelve la entrada si tiene 2 o menos puntos', () => {
-    const two = [{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }];
-    expect(simplifyDouglasPeucker(two, 2).length).toBe(2);
+    expect(simplifyDouglasPeucker([], 2).length).toBe(0);
+    expect(simplifyDouglasPeucker(null, 2).length).toBe(0);
+    expect(simplifyDouglasPeucker(undefined, 2).length).toBe(0);
+    expect(simplifyDouglasPeucker([{ lat: 0, lng: 0 }], 2).length).toBe(1);
+    expect(simplifyDouglasPeucker([{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }], 2).length).toBe(2);
+  });
+
+  it('conserva el primer y último punto siempre', () => {
+    const line = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.530, lng: -73.919 },
+      { lat: 4.530, lng: -73.918 },
+      { lat: 4.531, lng: -73.918 },
+      { lat: 4.531, lng: -73.917 },
+    ];
+    const out = simplifyDouglasPeucker(line, 1);
+    expect(out[0]).toEqual(line[0]);
+    expect(out[out.length - 1]).toEqual(line[line.length - 1]);
+  });
+
+  it('reduce drásticamente un camino con mucho jitter (polígono rayado)', () => {
+    // Simula un cuadrado de ~111m de lado con 100 puntos de jitter por lado
+    const corners = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9200 },
+    ];
+    const noisy = [];
+    for (let c = 0; c < corners.length; c += 1) {
+      const a = corners[c];
+      const b = corners[(c + 1) % corners.length];
+      for (let i = 0; i < 25; i += 1) {
+        const t = i / 25;
+        noisy.push({
+          lat: a.lat + (b.lat - a.lat) * t + (Math.random() - 0.5) * 2e-6,
+          lng: a.lng + (b.lng - a.lng) * t + (Math.random() - 0.5) * 2e-6,
+        });
+      }
+    }
+    noisy.push(noisy[0]); // cerrar
+    const simplified = simplifyDouglasPeucker(noisy, 5);
+    // Debe reducir los 101 puntos a mucho menos (idealmente ~4-8)
+    expect(simplified.length).toBeLessThan(20);
+    expect(simplified.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('no muta el array original', () => {
+    const original = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.5305, lng: -73.920 },
+      { lat: 4.531, lng: -73.920 },
+    ];
+    const copy = JSON.parse(JSON.stringify(original));
+    simplifyDouglasPeucker(original, 2);
+    expect(original).toEqual(copy);
   });
 });
 
 describe('polygonAreaSqMeters', () => {
-  it('calcula el área de un cuadrado de ~111m de lado (~12000 m²)', () => {
-    // 0.001° ≈ 111m → área ≈ 111 * 111 ≈ 12300 m²
+  it('calcula el área de un cuadrado de ~111m de lado (~12300 m²)', () => {
     const square = [
       { lat: 4.530, lng: -73.920 },
       { lat: 4.530, lng: -73.919 },
@@ -250,6 +533,19 @@ describe('polygonAreaSqMeters', () => {
     const area = polygonAreaSqMeters(square);
     expect(area).toBeGreaterThan(11000);
     expect(area).toBeLessThan(13500);
+  });
+
+  it('calcula área de un triángulo rectángulo ~111m de catetos (~6170 m²)', () => {
+    const triangle = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.530, lng: -73.919 },
+      { lat: 4.531, lng: -73.920 },
+    ];
+    const area = polygonAreaSqMeters(triangle);
+    expect(area).toBeGreaterThan(5000);
+    expect(area).toBeLessThan(7000);
+    // Área teórica: 0.5 * 111 * 111 ≈ 6172
+    expect(area).toBeCloseTo(6172, -2); // precisión de centenas
   });
 
   it('es independiente de la orientación (CW vs CCW)', () => {
@@ -263,7 +559,7 @@ describe('polygonAreaSqMeters', () => {
     expect(polygonAreaSqMeters(cw)).toBeCloseTo(polygonAreaSqMeters(ccw), 2);
   });
 
-  it('retorna 0 para un anillo degenerado (línea)', () => {
+  it('retorna 0 para un anillo degenerado (línea colineal)', () => {
     const line = [
       { lat: 4.530, lng: -73.920 },
       { lat: 4.531, lng: -73.920 },
@@ -273,13 +569,39 @@ describe('polygonAreaSqMeters', () => {
   });
 
   it('retorna 0 con menos de 3 puntos', () => {
+    expect(polygonAreaSqMeters([])).toBe(0);
+    expect(polygonAreaSqMeters(null)).toBe(0);
     expect(polygonAreaSqMeters([{ lat: 0, lng: 0 }])).toBe(0);
+    expect(polygonAreaSqMeters([{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }])).toBe(0);
+  });
+
+  it('área de anillo cerrado (primer==último) es igual a área de anillo abierto', () => {
+    const open = [
+      { lat: 4.530, lng: -73.920 },
+      { lat: 4.530, lng: -73.919 },
+      { lat: 4.531, lng: -73.919 },
+      { lat: 4.531, lng: -73.920 },
+    ];
+    const closed = [...open, open[0]];
+    expect(polygonAreaSqMeters(open)).toBeCloseTo(polygonAreaSqMeters(closed), 1);
+  });
+
+  it('área de un lote realista (~1 ha, 10000 m²)', () => {
+    // ~100m x 100m
+    const lote = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9191 }, // ~100m E
+      { lat: 4.5309, lng: -73.9191 }, // ~100m N
+      { lat: 4.5309, lng: -73.9200 }, // ~100m W
+    ];
+    const area = polygonAreaSqMeters(lote);
+    expect(area).toBeGreaterThan(8000);
+    expect(area).toBeLessThan(12000);
   });
 });
 
 describe('buildWalkPolygon — recorrido caminado → anillo estable', () => {
   it('limpia jitter y conserva las esquinas del lote', () => {
-    // Recorrido de un cuadrado con jitter denso en cada lado.
     const corners = [
       { lat: 4.5300, lng: -73.9200 },
       { lat: 4.5300, lng: -73.9190 },
@@ -298,10 +620,8 @@ describe('buildWalkPolygon — recorrido caminado → anillo estable', () => {
       }
     }
     const ring = buildWalkPolygon(walk);
-    // 4 esquinas reales (sin cierre duplicado).
     expect(ring.length).toBeGreaterThanOrEqual(4);
-    expect(ring.length).toBeLessThan(walk.length); // simplificó
-    // El polígono resultante tiene área coherente (no colapsado).
+    expect(ring.length).toBeLessThan(walk.length);
     expect(polygonAreaSqMeters(ring)).toBeGreaterThan(11000);
   });
 
@@ -311,7 +631,7 @@ describe('buildWalkPolygon — recorrido caminado → anillo estable', () => {
       { lat: 4.5300, lng: -73.9190 },
       { lat: 4.5310, lng: -73.9190 },
       { lat: 4.5310, lng: -73.9200 },
-      { lat: 4.53000005, lng: -73.92000005 }, // regreso al inicio (~paso corto)
+      { lat: 4.53000001, lng: -73.92000001 }, // regreso al inicio (~paso corto <3m)
     ];
     const ring = buildWalkPolygon(square);
     const f = ring[0];
@@ -320,8 +640,10 @@ describe('buildWalkPolygon — recorrido caminado → anillo estable', () => {
   });
 
   it('devuelve la entrada sin tocar si tiene menos de 3 puntos', () => {
-    const two = [{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }];
-    expect(buildWalkPolygon(two).length).toBe(2);
+    expect(buildWalkPolygon([]).length).toBe(0);
+    expect(buildWalkPolygon(null)).toEqual([]);
+    expect(buildWalkPolygon(undefined)).toEqual([]);
+    expect(buildWalkPolygon([{ lat: 0, lng: 0 }, { lat: 1, lng: 1 }]).length).toBe(2);
   });
 
   it('el anillo limpio serializa a un Polygon WKT cerrado válido', () => {
@@ -334,8 +656,258 @@ describe('buildWalkPolygon — recorrido caminado → anillo estable', () => {
     const ring = buildWalkPolygon(square);
     const wkt = geoJsonToWkt(latLngsToPolygon(ring));
     expect(wkt).toContain('POLYGON');
-    // closeRing añade el cierre → primer == último en el WKT.
     const coords = wkt.match(/POLYGON\(\((.+)\)\)/)[1].split(',').map((s) => s.trim());
     expect(coords[0]).toBe(coords[coords.length - 1]);
+  });
+
+  it('respeta minDistance y toleranceM personalizados', () => {
+    const square = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9200 },
+    ];
+    const aggressive = buildWalkPolygon(square, { minDistance: 50, toleranceM: 30 });
+    // Con thresholds muy agresivos, puede quedar reducido a pocos puntos
+    expect(aggressive.length).toBeGreaterThanOrEqual(2);
+    expect(aggressive.length).toBeLessThanOrEqual(4);
+  });
+
+  it('no elimina la cola si el regreso al inicio está lejos (>minDistance)', () => {
+    const squareSinCerrar = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9190 },
+      { lat: 4.5310, lng: -73.9200 },
+    ];
+    // El último punto está a ~111m del primero → no se elimina
+    const ring = buildWalkPolygon(squareSinCerrar);
+    expect(ring.length).toBe(4);
+  });
+
+  it('produce un anillo con área no colapsada (no degenera)', () => {
+    // Recorrido realista de un triángulo con jitter fuerte
+    const triangle = [
+      { lat: 4.5300, lng: -73.9200 },
+      { lat: 4.5301, lng: -73.9200 },
+      { lat: 4.5302, lng: -73.9200 },
+      { lat: 4.5303, lng: -73.9200 },
+      { lat: 4.5304, lng: -73.9200 },
+      { lat: 4.5304, lng: -73.9190 },
+      { lat: 4.5304, lng: -73.9180 },
+      { lat: 4.5304, lng: -73.9170 },
+      { lat: 4.5300, lng: -73.9190 },
+      { lat: 4.5300, lng: -73.9180 },
+      { lat: 4.5300, lng: -73.9170 },
+    ];
+    const ring = buildWalkPolygon(triangle);
+    expect(ring.length).toBeGreaterThanOrEqual(3);
+    // El área debe ser > 0 (no colapsó a línea)
+    expect(polygonAreaSqMeters(ring)).toBeGreaterThan(100);
+  });
+});
+
+// --- Bug #57(c): simulacro completo de warm-up GPS + trazo caminando ------------
+
+describe('ciclo completo trazo caminando — warm-up + filtros + build', () => {
+  /**
+   * Simula la sesión completa como la ejecuta MapPicker.jsx:
+   * 1. Warm-up: descartar fixes con accuracy > GPS_WARMUP_ACCURACY_M hasta que
+   *    el GPS converja.
+   * 2. Trazo: acceptGpsFix filtra línea loca (accuracy, speed, jump).
+   * 3. Final: buildWalkPolygon limpia jitter y entrega anillo estable.
+   */
+  it('descarta fixes imprecisos durante warm-up y ancla con el primer fix bueno', () => {
+    const warmupSession = [
+      { lat: 4.5300, lng: -73.9200, accuracy: 45, timestamp: 0 },     // malo (warm-up: >20m)
+      { lat: 4.5305, lng: -73.9205, accuracy: 35, timestamp: 1000 },   // malo
+      { lat: 4.5310, lng: -73.9210, accuracy: 22, timestamp: 2000 },   // malo (22 > 20)
+      { lat: 4.5312, lng: -73.9210, accuracy: 18, timestamp: 3000 },   // ✓ warm-up termina aquí
+      { lat: 4.53124, lng: -73.9210, accuracy: 15, timestamp: 4000 },  // ✓ paso ~4.4m en 1s → aceptado
+    ];
+
+    let warmedUp = false;
+    let prev = null;
+    const traced = [];
+
+    for (const fix of warmupSession) {
+      // Warm-up check (idéntico a MapPicker.jsx lógica)
+      if (!warmedUp) {
+        if (Number.isFinite(fix.accuracy) && fix.accuracy > GPS_WARMUP_ACCURACY_M) {
+          continue; // ignorar, GPS no ha convergido
+        }
+        warmedUp = true;
+        // El primer fix que pasa warm-up es el ancla
+        prev = fix;
+        traced.push({ lat: fix.lat, lng: fix.lng });
+        continue;
+      }
+      // Trazo normal con filtros
+      const verdict = acceptGpsFix(fix, prev);
+      if (verdict.accepted) {
+        prev = fix;
+        traced.push({ lat: fix.lat, lng: fix.lng });
+      }
+    }
+
+    // Solo los últimos 2 fixes deben pasar (accuracy ≤20m)
+    expect(traced.length).toBe(2);
+    expect(traced[0].lat).toBeCloseTo(4.5312, 4);
+    expect(traced[1].lat).toBeCloseTo(4.53124, 4);
+  });
+
+  it('ciclo completo: warm-up + trazo + build → anillo estable con área coherente', () => {
+    // Recorrido completo de un cuadrado de ~111m con:
+    // - 3 fixes malos de warm-up
+    // - jitter en cada lado
+    // - 1 salto loco en la mitad
+    // - accuracy mala en un punto
+
+    // Generar recorrido con ruido
+    const rawFixes = [];
+
+    // Warm-up: 3 fixes malos (accuracy >20m)
+    rawFixes.push({ lat: 4.5200, lng: -73.9100, accuracy: 50, timestamp: 0 });
+    rawFixes.push({ lat: 4.5250, lng: -73.9150, accuracy: 40, timestamp: 1000 });
+    rawFixes.push({ lat: 4.5280, lng: -73.9180, accuracy: 25, timestamp: 2000 });
+
+    // Warm-up termina: primer fix bueno
+    rawFixes.push({ lat: 4.5300, lng: -73.9200, accuracy: 15, timestamp: 3000 });
+
+    // Lado 1 con jitter (sur → este). ~11m c/3s ≈ 3.7 m/s → aceptado.
+    for (let t = 1; t <= 10; t += 1) {
+      rawFixes.push({
+        lat: 4.5300 + (Math.random() - 0.5) * 1e-7,
+        lng: -73.9200 + t * 0.0001 + (Math.random() - 0.5) * 1e-7,
+        accuracy: 6 + Math.random() * 4,
+        timestamp: 3000 + t * 3000,
+      });
+    }
+
+    // Línea loca: salto falso (~111m en 1s → rechazado por speed)
+    rawFixes.push({ lat: 4.5400, lng: -73.9100, accuracy: 3, timestamp: 36000 });
+
+    // Lado 2 (este → norte)
+    for (let t = 1; t <= 10; t += 1) {
+      rawFixes.push({
+        lat: 4.5300 + t * 0.0001 + (Math.random() - 0.5) * 1e-7,
+        lng: -73.9190 + (Math.random() - 0.5) * 1e-7,
+        accuracy: 6 + Math.random() * 4,
+        timestamp: 37000 + t * 3000,
+      });
+    }
+
+    // Fix con accuracy mala
+    rawFixes.push({ lat: 4.5305, lng: -73.9180, accuracy: 50, timestamp: 68000 });
+
+    // Lado 3 (norte → oeste)
+    for (let t = 1; t <= 10; t += 1) {
+      rawFixes.push({
+        lat: 4.5310 + (Math.random() - 0.5) * 1e-7,
+        lng: -73.9190 - t * 0.0001 + (Math.random() - 0.5) * 1e-7,
+        accuracy: 6 + Math.random() * 4,
+        timestamp: 69000 + t * 3000,
+      });
+    }
+
+    // Lado 4 (oeste → sur, cierre)
+    for (let t = 1; t <= 10; t += 1) {
+      rawFixes.push({
+        lat: 4.5310 - t * 0.0001 + (Math.random() - 0.5) * 1e-7,
+        lng: -73.9200 + (Math.random() - 0.5) * 1e-7,
+        accuracy: 6 + Math.random() * 4,
+        timestamp: 100000 + t * 3000,
+      });
+    }
+
+    // Simular el ciclo
+    let warmedUp = false;
+    let prev = null;
+    const traced = [];
+
+    for (const fix of rawFixes) {
+      if (!warmedUp) {
+        if (Number.isFinite(fix.accuracy) && fix.accuracy > GPS_WARMUP_ACCURACY_M) {
+          continue;
+        }
+        warmedUp = true;
+        prev = fix;
+        traced.push({ lat: fix.lat, lng: fix.lng });
+        continue;
+      }
+      const verdict = acceptGpsFix(fix, prev);
+      if (verdict.accepted) {
+        prev = fix;
+        traced.push({ lat: fix.lat, lng: fix.lng });
+      }
+    }
+
+    // Verificar que se trazaron suficientes puntos (>3 para un polígono)
+    expect(traced.length).toBeGreaterThan(3);
+
+    // Construir el anillo final
+    const ring = buildWalkPolygon(traced);
+
+    // Verificar que el anillo es estable
+    expect(ring.length).toBeGreaterThanOrEqual(3);
+    expect(ring.length).toBeLessThan(traced.length); // simplificó
+
+    // El área debe ser coherente (~12300 m² para 0.001° x 0.001°)
+    const area = polygonAreaSqMeters(ring);
+    expect(area).toBeGreaterThan(5000);
+    expect(area).toBeLessThan(20000);
+
+    // El anillo serializa correctamente a WKT
+    if (ring.length >= 3) {
+      const wkt = geoJsonToWkt(latLngsToPolygon(ring));
+      expect(wkt).toContain('POLYGON');
+    }
+  });
+
+  it('si el warm-up nunca converge (todos los fixes accuracy >20m), no traza nada', () => {
+    const allBad = [
+      { lat: 4.53, lng: -73.92, accuracy: 45, timestamp: 0 },
+      { lat: 4.53, lng: -73.92, accuracy: 35, timestamp: 1000 },
+      { lat: 4.53, lng: -73.92, accuracy: 30, timestamp: 2000 },
+    ];
+
+    let warmedUp = false;
+    const traced = [];
+
+    for (const fix of allBad) {
+      if (!warmedUp) {
+        if (Number.isFinite(fix.accuracy) && fix.accuracy > GPS_WARMUP_ACCURACY_M) {
+          continue;
+        }
+        warmedUp = true;
+        traced.push({ lat: fix.lat, lng: fix.lng });
+        continue;
+      }
+      traced.push({ lat: fix.lat, lng: fix.lng });
+    }
+
+    expect(warmedUp).toBe(false);
+    expect(traced.length).toBe(0);
+  });
+});
+
+// --- Verificación de constantes exportadas -------------------------------------
+
+describe('constantes GPS', () => {
+  it('GPS_ACCURACY_THRESHOLD_M es 25', () => {
+    expect(GPS_ACCURACY_THRESHOLD_M).toBe(25);
+  });
+  it('GPS_WARMUP_ACCURACY_M es 20 (más estricto que el umbral de descarte)', () => {
+    expect(GPS_WARMUP_ACCURACY_M).toBe(20);
+    expect(GPS_WARMUP_ACCURACY_M).toBeLessThan(GPS_ACCURACY_THRESHOLD_M);
+  });
+  it('GPS_MAX_WALK_SPEED_MPS es 5', () => {
+    expect(GPS_MAX_WALK_SPEED_MPS).toBe(5);
+  });
+  it('GPS_MIN_VERTEX_DISTANCE_M es 3', () => {
+    expect(GPS_MIN_VERTEX_DISTANCE_M).toBe(3);
+  });
+  it('GPS_MAX_JUMP_DISTANCE_M es 50', () => {
+    expect(GPS_MAX_JUMP_DISTANCE_M).toBe(50);
   });
 });

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -46,6 +46,12 @@ export const GPS_MAX_WALK_SPEED_MPS = 5; // ~18 km/h, holgado para trote/jitter
 // consideran el mismo punto (dedup) y solo engordan el anillo con jitter.
 export const GPS_MIN_VERTEX_DISTANCE_M = 3;
 
+// Distancia máxima razonable entre dos fixes consecutivos caminando. Se usa
+// como guarda de respaldo cuando los timestamps no están disponibles para
+// hacer el chequeo de velocidad; el comentario original decía "caemos a un
+// tope de distancia" pero nunca se implementó (bug #57 línea loca).
+export const GPS_MAX_JUMP_DISTANCE_M = 50;
+
 // Tolerancia por defecto de Douglas-Peucker para simplificar el recorrido.
 export const GPS_SIMPLIFY_TOLERANCE_M = 2;
 
@@ -84,11 +90,13 @@ export const haversineMeters = (a, b) => {
  * @param {object} [opts]
  * @param {number} [opts.accuracyThreshold=GPS_ACCURACY_THRESHOLD_M]
  * @param {number} [opts.maxSpeed=GPS_MAX_WALK_SPEED_MPS]
+ * @param {number} [opts.maxJumpDistance=GPS_MAX_JUMP_DISTANCE_M]
  * @returns {{accepted:boolean, reason:string|null, distance:number}}
  */
 export const acceptGpsFix = (fix, prev, opts = {}) => {
   const accuracyThreshold = opts.accuracyThreshold ?? GPS_ACCURACY_THRESHOLD_M;
   const maxSpeed = opts.maxSpeed ?? GPS_MAX_WALK_SPEED_MPS;
+  const maxJumpDistance = opts.maxJumpDistance ?? GPS_MAX_JUMP_DISTANCE_M;
 
   if (!fix || !Number.isFinite(fix.lat) || !Number.isFinite(fix.lng)) {
     return { accepted: false, reason: 'invalid', distance: 0 };
@@ -114,6 +122,10 @@ export const acceptGpsFix = (fix, prev, opts = {}) => {
     if (speed > maxSpeed) {
       return { accepted: false, reason: 'speed', distance };
     }
+  } else if (distance > maxJumpDistance) {
+    // Fallback: sin timestamps consistentes, no podemos calcular velocidad,
+    // pero una distancia exagerada igual es un salto GPS → línea loca.
+    return { accepted: false, reason: 'jump', distance };
   }
   return { accepted: true, reason: null, distance };
 };


### PR DESCRIPTION
## Bug detectado y corregido

**`acceptGpsFix`** tenía un TODO explícito en el comentario (`"caemos a un tope de distancia"`) pero el fallback de distancia nunca se implementó. Cuando los timestamps faltaban o eran inconsistentes, un fix con salto de kilómetros pasaba sin rechazo → **línea loca**.

### Fix (cambio mínimo)
- Constante `GPS_MAX_JUMP_DISTANCE_M = 50` (exportada)
- En `acceptGpsFix`: cuando `dtMs` no está disponible o es `<=0`, se chequea `distance > maxJumpDistance` → `reason='jump'`

## Tests agregados (75 total, 0 lint errors)

| Función | Antes | Ahora | Nuevos escenarios clave |
|---------|-------|-------|------------------------|
| `acceptGpsFix` | 7 | 27 | jump fallback, timestamps faltantes/regresivos, dtMs=0, accuracy boundary, simulacro sesión real |
| `dedupeByMinDistance` | 3 | 8 | jitter cluster 50pts, single point, no mutación, minDistance personalizado |
| `simplifyDouglasPeucker` | 3 | 7 | forma preservada, jitter 100pts, no mutación, null/undefined |
| `polygonAreaSqMeters` | 4 | 8 | triángulo, CW/CCW, cerrado/abierto, 1ha realista |
| `buildWalkPolygon` | 4 | 8 | opts, cola no duplicada, área no colapsada |
| **ciclo warm-up** | 0 | 3 | Simulacro exacto de MapPicker.jsx (warm-up→acceptGpsFix→buildWalkPolygon) |
| **constantes** | 0 | 5 | Verificación de todas las constantes exportadas |

### Escenarios de bugs cubiertos
- **Línea loca**: saltos por speed (timestamps) + saltos por jump (sin timestamps) + accuracy mala
- **Polígono rayado**: jitter denso → dedup + simplify → anillo limpio
- **1ª corrida imprecisa**: warm-up rechaza accuracy >20m, solo traza al converger