### PR TITLE
fix(agente): exponer "Abrir Chagra IA" en la portada del home (overlay)

### DIFF
--- a/src/components/dashboard/AgentHero.jsx
+++ b/src/components/dashboard/AgentHero.jsx
@@ -1096,6 +1096,22 @@ export default function AgentHero({ onNavigate }) {
                 .agentport-profile:active { transform: scale(.92); }
                 .agentport-headtools { display: flex; align-items: center; gap: 8px; flex: none; }
 
+                /* "Abrir Chagra IA" — botón redondo con el avatar del agente.
+                   Entrada explícita al overlay desde la portada (tarea #51). */
+                .agentport-open {
+                    width: 38px; height: 38px; flex: none; border-radius: 50%;
+                    display: inline-flex; align-items: center; justify-content: center;
+                    overflow: hidden; padding: 0; cursor: pointer;
+                    background: rgb(var(--c-surface-card) / 0.65);
+                    border: 1px solid rgb(var(--c-surface-border));
+                    backdrop-filter: blur(6px);
+                    box-shadow: 0 2px 8px -4px rgba(0,0,0,.35);
+                    transition: transform .16s cubic-bezier(.22,.61,.36,1),
+                                border-color .2s ease, box-shadow .25s ease;
+                }
+                .agentport-open:hover { border-color: rgb(var(--t-accent-rgb) / 0.5); }
+                .agentport-open:active { transform: scale(.92); }
+
                 /* ============ CAMPANA DE ALERTAS/TAREAS (demo biopunk) ============
                    Import 1:1 del .bellbtn + .notifPanel del demo-agente-biopunk:
                    campana redonda con anillo que respira + badge ámbar; panel que
@@ -1716,6 +1732,27 @@ export default function AgentHero({ onNavigate }) {
             {/* ===================== TOGGLE Campesino/Experto ===================== */}
             <header className="agentport-topbar">
                 <div className="agentport-headtools">
+                    {/* "Abrir Chagra IA": entrada EXPLÍCITA al overlay del agente
+                        (AgentScreen) desde la portada del home. Bug móvil tarea #51
+                        (2026-06-21): el único control rotulado "Abrir Chagra IA"
+                        vivía en WelcomeStatsHero/DashboardView — un dashboard que la
+                        app EN VIVO ya no monta (case 'dashboard' usa DashboardLive →
+                        AgentHero). Por eso el fix previo (PR #1725, touchEnd sobre
+                        ese chip) era no-op: nadie podía tocar el botón. Acá la
+                        portada SÍ ofrece la acción sobre la superficie real, sin
+                        tocar el contrato del compositor (enviar vacío → abre "La
+                        mano de Chagra", comportamiento del demo). launchToAgent
+                        navega con la transición premium ya probada. */}
+                    <button
+                        type="button"
+                        onClick={launchToAgent}
+                        aria-label="Abrir Chagra IA"
+                        title="Abrir Chagra IA"
+                        className="agentport-open"
+                    >
+                        <ChagraAgentAvatar size={26} state="idle" ariaLabel="Chagra IA" />
+                    </button>
+
                     <div className="agentport-mode" role="tablist" aria-label="Nivel de respuestas">
                         <button
                             type="button"

--- a/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.composer.test.jsx
@@ -111,6 +111,19 @@ describe('AgentHero — compositor real (no teaser)', () => {
     expect(sendMock).not.toHaveBeenCalled();
   });
 
+  test('"Abrir Chagra IA" navega al overlay del agente sin enviar ni abrir el menú', async () => {
+    // Tarea #51: la portada del home (AgentHero) debe ofrecer una entrada
+    // EXPLÍCITA al overlay del agente. Distinta del compositor: no persiste en
+    // la outbox y no abre "La mano de Chagra" — navega directo a 'agente'.
+    const onNavigate = vi.fn();
+    render(<AgentHero onNavigate={onNavigate} />);
+    const openBtn = screen.getByLabelText('Abrir Chagra IA');
+    fireEvent.click(openBtn);
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('agente'));
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(screen.queryByText('La mano de Chagra')).not.toBeInTheDocument();
+  });
+
   test('enviar sin texto ni adjunto NO envía: abre el menú didáctico (demo)', () => {
     // Port fiel del demo (2026-06-11): `sendField()` con el campo vacío abre
     // el menú de capacidades en vez de quedar muerto/deshabilitado.

--- a/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
+++ b/src/components/dashboard/__tests__/AgentHero.integration.test.jsx
@@ -198,11 +198,21 @@ describe('AgentHero — integración post-pulido (task #TEST-int)', () => {
       await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('agente'));
     });
 
-    test('el colibrí NO se usa en otro lugar del compositor (solo en enviar)', () => {
+    test('el colibrí del compositor solo se usa en enviar (no duplicado en la barra)', () => {
       const { container } = render(<AgentHero onNavigate={vi.fn()} />);
 
-      const avatarElements = container.querySelectorAll('[data-testid="avatar"]');
-      expect(avatarElements.length).toBe(1);
+      // Dentro del COMPOSITOR el colibrí (avatar) vive SOLO en el botón de
+      // enviar — no duplicado en la barra de íconos.
+      const composer = container.querySelector('.agentport-composer');
+      expect(composer).toBeTruthy();
+      const composerAvatars = composer.querySelectorAll('[data-testid="avatar"]');
+      expect(composerAvatars.length).toBe(1);
+
+      // El botón "Abrir Chagra IA" del header tiene su PROPIO avatar (entrada
+      // explícita al overlay, tarea #51) — es intencional, fuera del compositor.
+      const openBtn = container.querySelector('.agentport-open');
+      expect(openBtn).toBeTruthy();
+      expect(openBtn.querySelectorAll('[data-testid="avatar"]').length).toBe(1);
 
       // El colibrí de la escena (.agentport-hummer) es separado
       const sceneHummer = container.querySelector('.agentport-hummer');


### PR DESCRIPTION
## Bug (tarea #51)
En móvil, "Abrir Chagra IA" no abre el overlay del agente.

## Causa raíz
El único control rotulado **"Abrir Chagra IA"** vive en `WelcomeStatsHero` (`AgentColibriChip`), que es montado **solo por `DashboardView`** — un dashboard que la app **EN VIVO ya no renderiza**. El `case 'dashboard'` usa `DashboardLiveView → DashboardLive → AgentHero` (el dashboard rediseñado). `DashboardView` está definido pero **nunca se instancia** (código muerto).

Por eso el fix previo (PR #1725, `onTouchEnd` sobre ese chip) quedó como **no-op en producción**: el botón es inalcanzable, así que el bug "no abre el overlay" siguió vivo.

## Evidencia (Playwright — móvil 412x915, touch real, chromium del nix-store, auth stub en IDB + mock backend)
- En la home en vivo **NO existe** ningún botón `aria-label="Abrir Chagra IA"` (0 encontrados antes del fix).
- Los demás disparadores del agente SÍ abrían el overlay: footer "Agente listo", chips, y enviar **con texto** → montan `AgentScreen` (`textarea[placeholder*="pregunta"]`).
- Tocar el colibrí de **enviar con campo vacío** abre **"La mano de Chagra"** (red de capacidades) — comportamiento del demo, **intencional y testeado** (`AgentHero.composer.test.jsx`). No se toca.

## Fix (mínimo)
La portada (`AgentHero`) ahora ofrece un **botón explícito "Abrir Chagra IA"** en el header, con el avatar del colibrí, que navega directo al overlay vía `launchToAgent` (la transición premium ya probada). Sobre la superficie **real** que la app renderiza, **sin alterar** el contrato del compositor (enviar vacío → menú de capacidades).

## Verificación
- Playwright: el botón aparece en la home en vivo (1 encontrado) y al tocarlo monta `AgentScreen` (header "Chagra IA / AGENTE AGROECOLÓGICO" + composer). Capturas antes/después: `/tmp/overlay-antes.png` (home con el botón) y `/tmp/overlay-despues.png` (overlay abierto).
- Tests: `AgentHero.composer.test.jsx` (21) + `AgentHero.integration.test.jsx` (22) — verde. Nuevo caso: "Abrir Chagra IA" navega a `agente` sin enviar ni abrir el menú; ajustado el caso de no-duplicación del colibrí (ahora 1 en el compositor + 1 en el header, intencional).
- `eslint` 0 (no-undef incluido) en los archivos tocados.

## Nota (fuera de alcance)
`DashboardLive.glaciarBanner.test.jsx` falla por un mock pre-existente (`FermentosCard` no exportado en el mock de `../FincaCards`) — falla idéntico en `main`, no relacionado con este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)