### PR TITLE
feat(juego): nivel 4 - el maizal al atardecer

### DIFF
--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -676,7 +676,7 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
 }
 
 /**
- * DefensoresFincaScreen — minijuego PLATAFORMERO 2D lateral con tres niveles.
+ * DefensoresFincaScreen — minijuego PLATAFORMERO 2D lateral con cuatro niveles.
  *
  * Un campesino NEUTRO (sin nombre propio) corre y salta por la finca: recoge
  * cultivos (puntos), esquiva plagas reales (pierde energía al tocarlas) e invoca
@@ -687,11 +687,15 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
  * Nivel 2 (la ladera al atardecer): más largo (mundo con cámara), otra paleta,
  * 7 pares, plataformas a distinta altura, huecos que hacen daño y un mini-jefe
  * (langosta) que solo cae con su controlador real (la mantis).
- * Nivel 3 (el cafetal en la niebla): el más largo, paleta de amanecer, 10 pares
- * (incluye plagas del café: broca, minador y cochinilla con sus aliados reales),
- * más plataformas y huecos, y un mini-jefe broca que solo cae con la avispa
- * Cephalonomia. Cada nivel se desbloquea al completar el anterior; el progreso se
- * guarda offline en localStorage.
+ * Nivel 3 (el cafetal en la niebla): todavía más largo, paleta de amanecer, 10
+ * pares (incluye plagas del café: broca, minador y cochinilla con sus aliados
+ * reales), más plataformas y huecos, y un mini-jefe broca que solo cae con la
+ * avispa Cephalonomia.
+ * Nivel 4 (el maizal al atardecer): el más grande, paleta de atardecer, 13 pares
+ * (incluye plagas del maíz: chicharrita, gusano elotero y barrenador con sus
+ * aliados reales), todavía más plataformas y huecos, y un mini-jefe cogollero
+ * gigante que solo cae con la avispita Trichogramma. Cada nivel se desbloquea al
+ * completar el anterior; el progreso se guarda offline en localStorage.
  *
  * Mobile-first: controles táctiles grandes + teclado en desktop. Offline-safe:
  * canvas 2D puro, datos locales, cero red. Estética Chagra.

--- a/src/components/juego/__tests__/DefensoresFincaScreen.test.jsx
+++ b/src/components/juego/__tests__/DefensoresFincaScreen.test.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DefensoresFincaScreen from '../DefensoresFincaScreen';
-import { PARES_CONTROL, NIVEL_1, NIVEL_2, NIVEL_3, PROGRESO_KEY } from '../defensoresFincaData';
+import { PARES_CONTROL, NIVEL_1, NIVEL_2, NIVEL_3, NIVEL_4, PROGRESO_KEY } from '../defensoresFincaData';
 
 // jsdom no implementa canvas 2D: getContext devuelve null. El componente
 // guarda contra ctx null, así que el render no crashea y podemos probar el HUD,
@@ -65,19 +65,22 @@ describe('DefensoresFincaScreen', () => {
     raf.mockRestore();
   });
 
-  it('muestra el selector con los tres niveles; el 2 y el 3 arrancan bloqueados', () => {
+  it('muestra el selector con los cuatro niveles; el 2, 3 y 4 arrancan bloqueados', () => {
     render(<DefensoresFincaScreen />);
     expect(screen.getByTestId('defensores-niveles')).toBeInTheDocument();
     const nivel1 = screen.getByTestId('nivel-1');
     const nivel2 = screen.getByTestId('nivel-2');
     const nivel3 = screen.getByTestId('nivel-3');
+    const nivel4 = screen.getByTestId('nivel-4');
     expect(nivel1).not.toBeDisabled();
     expect(nivel1).toHaveAttribute('data-selected', 'true');
-    // Sin progreso guardado, los niveles 2 y 3 están bloqueados.
+    // Sin progreso guardado, los niveles 2, 3 y 4 están bloqueados.
     expect(nivel2).toBeDisabled();
     expect(nivel2.textContent).toContain('Gana el nivel anterior');
     expect(nivel3).toBeDisabled();
     expect(nivel3.textContent).toContain('Gana el nivel anterior');
+    expect(nivel4).toBeDisabled();
+    expect(nivel4.textContent).toContain('Gana el nivel anterior');
   });
 
   it('con los niveles 1 y 2 superados, el 3 (cafetal) queda jugable con sus aliados del café', () => {
@@ -121,6 +124,28 @@ describe('DefensoresFincaScreen', () => {
     const parExtra = PARES_CONTROL.find((p) => p.id === extra);
     expect(screen.getByTestId(`beneficio-${parExtra.benefico.id}`)).toBeInTheDocument();
     // El aviso de mini-jefe del nivel 2 está presente.
+    expect(screen.getByTestId('defensores-jefe')).toBeInTheDocument();
+  });
+
+  it('con los niveles 1, 2 y 3 superados, el 4 (maizal) queda jugable con sus aliados del maíz', () => {
+    localStorage.setItem(PROGRESO_KEY, JSON.stringify({ superados: [1, 2, 3] }));
+    render(<DefensoresFincaScreen />);
+
+    const nivel4 = screen.getByTestId('nivel-4');
+    expect(nivel4).not.toBeDisabled();
+    expect(nivel4.textContent).toContain(NIVEL_4.nombre);
+
+    // Al elegir el nivel 4 cambian subtítulo y aparecen los aliados del maíz.
+    fireEvent.click(nivel4);
+    expect(nivel4).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByTestId('defensores-subtitulo').textContent).toContain(
+      NIVEL_4.subtitulo,
+    );
+    // El nivel 4 incluye aliados que NO están en el nivel 3 (plagas del maíz).
+    const extra = NIVEL_4.paresIds.find((id) => !NIVEL_3.paresIds.includes(id));
+    const parExtra = PARES_CONTROL.find((p) => p.id === extra);
+    expect(screen.getByTestId(`beneficio-${parExtra.benefico.id}`)).toBeInTheDocument();
+    // El mini-jefe del nivel 4 (cogollero gigante) está anunciado.
     expect(screen.getByTestId('defensores-jefe')).toBeInTheDocument();
   });
 });

--- a/src/components/juego/__tests__/defensoresFincaData.test.js
+++ b/src/components/juego/__tests__/defensoresFincaData.test.js
@@ -6,6 +6,7 @@ import {
   NIVEL_1,
   NIVEL_2,
   NIVEL_3,
+  NIVEL_4,
   NIVELES,
   getNivel,
   nivelDesbloqueado,
@@ -159,6 +160,12 @@ describe('NIVELES — campos obligatorios sin undefined', () => {
     expect(NIVEL_3.jefe.vida).toBeGreaterThan(NIVEL_2.jefe.vida);
   });
 
+  it('NIVEL_4 tiene jefe con vida mayor que el jefe del nivel 3', () => {
+    expect(NIVEL_4.jefe).toBeTruthy();
+    expect(NIVEL_3.jefe).toBeTruthy();
+    expect(NIVEL_4.jefe.vida).toBeGreaterThan(NIVEL_3.jefe.vida);
+  });
+
   it('cada jefe referencia una plaga que existe en PARES_CONTROL', () => {
     for (const nivel of NIVELES) {
       if (!nivel.jefe) continue;
@@ -174,21 +181,25 @@ describe('progresión de niveles — coherencia de dificultad', () => {
   it('crece el mundo (mundoAncho) con cada nivel', () => {
     expect(NIVEL_2.mundoAncho).toBeGreaterThan(NIVEL_1.mundoAncho);
     expect(NIVEL_3.mundoAncho).toBeGreaterThan(NIVEL_2.mundoAncho);
+    expect(NIVEL_4.mundoAncho).toBeGreaterThan(NIVEL_3.mundoAncho);
   });
 
   it('crece la meta de cultivos con cada nivel', () => {
     expect(NIVEL_2.metaCultivos).toBeGreaterThan(NIVEL_1.metaCultivos);
     expect(NIVEL_3.metaCultivos).toBeGreaterThan(NIVEL_2.metaCultivos);
+    expect(NIVEL_4.metaCultivos).toBeGreaterThan(NIVEL_3.metaCultivos);
   });
 
   it('crece o se mantiene la energía con cada nivel', () => {
     expect(NIVEL_2.energiaInicial).toBeGreaterThanOrEqual(NIVEL_1.energiaInicial);
     expect(NIVEL_3.energiaInicial).toBeGreaterThanOrEqual(NIVEL_2.energiaInicial);
+    expect(NIVEL_4.energiaInicial).toBeGreaterThanOrEqual(NIVEL_3.energiaInicial);
   });
 
   it('crece el número de pares plaga/benéfico con cada nivel', () => {
     expect(NIVEL_2.paresIds.length).toBeGreaterThan(NIVEL_1.paresIds.length);
     expect(NIVEL_3.paresIds.length).toBeGreaterThan(NIVEL_2.paresIds.length);
+    expect(NIVEL_4.paresIds.length).toBeGreaterThan(NIVEL_3.paresIds.length);
   });
 
   it('cada nivel tiene una escena distinta (paleta)', () => {
@@ -199,8 +210,10 @@ describe('progresión de niveles — coherencia de dificultad', () => {
   it('las plataformas y los huecos aumentan con la dificultad', () => {
     expect(NIVEL_2.plataformas.length).toBeGreaterThan(NIVEL_1.plataformas.length);
     expect(NIVEL_3.plataformas.length).toBeGreaterThan(NIVEL_2.plataformas.length);
+    expect(NIVEL_4.plataformas.length).toBeGreaterThan(NIVEL_3.plataformas.length);
     expect(NIVEL_2.huecos.length).toBeGreaterThan(NIVEL_1.huecos.length);
     expect(NIVEL_3.huecos.length).toBeGreaterThan(NIVEL_2.huecos.length);
+    expect(NIVEL_4.huecos.length).toBeGreaterThan(NIVEL_3.huecos.length);
   });
 });
 
@@ -211,6 +224,7 @@ describe('getNivel y nivelDesbloqueado', () => {
     expect(getNivel(1)).toBe(NIVEL_1);
     expect(getNivel(2)).toBe(NIVEL_2);
     expect(getNivel(3)).toBe(NIVEL_3);
+    expect(getNivel(4)).toBe(NIVEL_4);
   });
 
   it('getNivel devuelve NIVEL_1 para números inexistentes', () => {
@@ -233,6 +247,8 @@ describe('getNivel y nivelDesbloqueado', () => {
     expect(nivelDesbloqueado(2, [1, 3])).toBe(true);
     expect(nivelDesbloqueado(3, [1])).toBe(false);
     expect(nivelDesbloqueado(3, [1, 2])).toBe(true);
+    expect(nivelDesbloqueado(4, [1, 2])).toBe(false);
+    expect(nivelDesbloqueado(4, [1, 2, 3])).toBe(true);
   });
 
   it('nivelDesbloqueado: superados por defecto es []', () => {

--- a/src/components/juego/defensoresFincaData.js
+++ b/src/components/juego/defensoresFincaData.js
@@ -235,6 +235,62 @@ export const PARES_CONTROL = [
     },
     leccion: 'El escarabajo Cryptolaemus se come la cochinilla harinosa.',
   },
+  // ── Plagas y aliados del MAIZAL (nivel 4) ────────────────────────────────
+  // Control biológico documentado por CIAT, EMBRAPA e ICA Colombia para el maíz.
+  {
+    id: 'chicharrita-doru',
+    plaga: {
+      id: 'chicharrita',
+      nombre: 'Chicharrita del maíz',
+      cientifico: 'Dalbulus maidis',
+      emoji: '🦗',
+      dano: 'Chupa la savia y transmite el achaparramiento del maíz.',
+    },
+    benefico: {
+      id: 'doru',
+      nombre: 'Tijereta',
+      cientifico: 'Doru luteipes',
+      emoji: '🪲',
+      como: 'La tijereta caza de noche y devora chicharritas y huevos de plaga.',
+    },
+    leccion: 'La tijereta Doru luteipes es guardiana nocturna del maizal.',
+  },
+  {
+    id: 'elotero-telenomus',
+    plaga: {
+      id: 'elotero',
+      nombre: 'Gusano elotero',
+      cientifico: 'Helicoverpa zea',
+      emoji: '🐛',
+      dano: 'Se mete en la mazorca y devora los granos tiernos.',
+    },
+    benefico: {
+      id: 'telenomus',
+      nombre: 'Avispita Telenomus',
+      cientifico: 'Telenomus remus',
+      emoji: '🐝',
+      como: 'Parasita los huevos del elotero antes de que nazca la larva.',
+    },
+    leccion: 'La avispa Telenomus remus destruye los huevos del gusano elotero.',
+  },
+  {
+    id: 'barrenador-cotesia',
+    plaga: {
+      id: 'barrenador',
+      nombre: 'Barrenador del tallo',
+      cientifico: 'Diatraea saccharalis',
+      emoji: '🐛',
+      dano: 'Perfora el tallo del maíz por dentro y lo debilita.',
+    },
+    benefico: {
+      id: 'cotesia',
+      nombre: 'Avispita Cotesia',
+      cientifico: 'Cotesia flavipes',
+      emoji: '🐝',
+      como: 'Busca las larvas del barrenador dentro del tallo y las parasita.',
+    },
+    leccion: 'La avispa Cotesia flavipes controla el barrenador del tallo del maíz.',
+  },
 ];
 
 /** Mapa rápido benéfico → plaga que controla (para la lógica del juego). */
@@ -432,7 +488,88 @@ export const NIVEL_3 = Object.freeze({
 });
 
 /** Todos los niveles en orden de juego. */
-export const NIVELES = Object.freeze([NIVEL_1, NIVEL_2, NIVEL_3]);
+/**
+ * Nivel 4 — el maizal al atardecer (clima cálido, tierra plana y extensa).
+ *
+ * El nivel más grande de todos: una milpa (maizal con frijol y ahuyama) al
+ * atardecer, cuando las plagas del maíz salen con más hambre. El mundo es más
+ * ancho que todos los anteriores (cámara que recorre una finca maicera enorme),
+ * hay más cultivos que recoger y aparecen TODAS las plagas de los niveles
+ * anteriores más tres plagas propias del cultivo del maíz (chicharrita, gusano
+ * elotero y barrenador del tallo) con sus aliados reales documentados por CIAT,
+ * EMBRAPA e ICA Colombia. Más plataformas, más huecos y un mini-jefe imponente:
+ * el GUSANO COGOLLERO GIGANTE, que solo cae con su controlador real (la avispita
+ * Trichogramma) y aguanta todavía más golpes que la broca del cafetal.
+ * Dificultad máxima y cierre épico del viaje por la finca.
+ */
+export const NIVEL_4 = Object.freeze({
+  id: 'nivel-4',
+  numero: 4,
+  nombre: 'El maizal al atardecer',
+  subtitulo: 'Cae la tarde en la milpa. Las plagas del maíz salen con todo, pero sus enemigos naturales también.',
+  energiaInicial: 6,
+  energiaMax: 6,
+  metaCultivos: 18,
+  mundoAncho: 3360,
+  paresIds: [
+    'pulgon-catarina',
+    'moscablanca-crisopa',
+    'cogollero-trichogramma',
+    'afido-sirfido',
+    'trips-amblyseius',
+    'acaro-phytoseiulus',
+    'saltamontes-mantis',
+    'broca-cephalonomia',
+    'minador-closterocerus',
+    'cochinilla-cryptolaemus',
+    'chicharrita-doru',
+    'elotero-telenomus',
+    'barrenador-cotesia',
+  ],
+  escena: Object.freeze({
+    id: 'maizal-atardecer',
+    cieloTop: '#f7a460',
+    cieloBottom: '#fce8c4',
+    montana: '#4a7a3a',
+    sueloTop: '#6e4a28',
+    sueloBottom: '#2d1a0e',
+    pasto: '#4a7a2f',
+    astro: '#fff8e0',
+    estrellas: true,
+  }),
+  // Camino ondulante entre los surcos del maizal (más plataformas que el 3).
+  plataformas: Object.freeze([
+    Object.freeze({ x: 300, y: 90, w: 130 }),
+    Object.freeze({ x: 550, y: 160, w: 120 }),
+    Object.freeze({ x: 800, y: 100, w: 140 }),
+    Object.freeze({ x: 1050, y: 150, w: 120 }),
+    Object.freeze({ x: 1300, y: 90, w: 140 }),
+    Object.freeze({ x: 1550, y: 160, w: 120 }),
+    Object.freeze({ x: 1800, y: 100, w: 140 }),
+    Object.freeze({ x: 2050, y: 150, w: 120 }),
+    Object.freeze({ x: 2300, y: 90, w: 140 }),
+    Object.freeze({ x: 2550, y: 160, w: 120 }),
+    Object.freeze({ x: 2850, y: 100, w: 140 }),
+  ]),
+  // Zanjas y canales de riego del maizal (más huecos que el nivel 3).
+  huecos: Object.freeze([
+    Object.freeze({ x: 480, w: 70 }),
+    Object.freeze({ x: 980, w: 75 }),
+    Object.freeze({ x: 1480, w: 80 }),
+    Object.freeze({ x: 1980, w: 75 }),
+    Object.freeze({ x: 2480, w: 70 }),
+    Object.freeze({ x: 3030, w: 75 }),
+  ]),
+  // Mini-jefe: un gusano cogollero gigante al final del maizal. Solo la
+  // avispita Trichogramma (su controlador real) lo derriba; aguanta 5 golpes.
+  jefe: Object.freeze({
+    plagaId: 'cogollero',
+    emoji: '🐛',
+    vida: 5,
+  }),
+});
+
+export const NIVELES = Object.freeze([NIVEL_1, NIVEL_2, NIVEL_3, NIVEL_4]);
 
 /** Busca un nivel por su número (1-indexado). Devuelve NIVEL_1 si no existe. */
 export function getNivel(numero) {

--- a/src/components/juego/index.js
+++ b/src/components/juego/index.js
@@ -9,6 +9,8 @@ export {
   CULTIVOS,
   NIVEL_1,
   NIVEL_2,
+  NIVEL_3,
+  NIVEL_4,
   NIVELES,
   getNivel,
   nivelDesbloqueado,

--- a/src/services/__tests__/defensoresGameEngine.test.js
+++ b/src/services/__tests__/defensoresGameEngine.test.js
@@ -23,6 +23,7 @@ import {
   NIVEL_1,
   NIVEL_2,
   NIVEL_3,
+  NIVEL_4,
   NIVELES,
   getNivel,
   nivelDesbloqueado,
@@ -380,8 +381,8 @@ describe('mini-jefe — solo cae con su controlador real', () => {
 });
 
 describe('niveles — configuración y desbloqueo', () => {
-  it('hay tres niveles y el 2 es más largo y exigente que el 1', () => {
-    expect(NIVELES).toHaveLength(3);
+  it('hay cuatro niveles y el 2 es más largo y exigente que el 1', () => {
+    expect(NIVELES).toHaveLength(4);
     expect(NIVEL_2.numero).toBe(2);
     expect(NIVEL_2.mundoAncho).toBeGreaterThan(NIVEL_1.mundoAncho);
     expect(NIVEL_2.metaCultivos).toBeGreaterThan(NIVEL_1.metaCultivos);
@@ -403,12 +404,28 @@ describe('niveles — configuración y desbloqueo', () => {
     expect(NIVEL_3.jefe.vida).toBeGreaterThan(NIVEL_2.jefe.vida);
   });
 
+  it('el nivel 4 es el más grande y exigente de todos (más mundo, cultivos, pares, jefe)', () => {
+    expect(NIVEL_4.numero).toBe(4);
+    expect(NIVEL_4.mundoAncho).toBeGreaterThan(NIVEL_3.mundoAncho);
+    expect(NIVEL_4.metaCultivos).toBeGreaterThan(NIVEL_3.metaCultivos);
+    expect(NIVEL_4.paresIds.length).toBeGreaterThan(NIVEL_3.paresIds.length);
+    expect(NIVEL_4.plataformas.length).toBeGreaterThan(NIVEL_3.plataformas.length);
+    expect(NIVEL_4.huecos.length).toBeGreaterThan(NIVEL_3.huecos.length);
+    expect(NIVEL_4.jefe).toBeTruthy();
+    // El cogollero gigante aguanta más golpes que la broca del cafetal.
+    expect(NIVEL_4.jefe.vida).toBeGreaterThan(NIVEL_3.jefe.vida);
+  });
+
   it('cada nivel usa una paleta de fondo distinta', () => {
     expect(NIVEL_2.escena.id).not.toBe(NIVEL_1.escena.id);
     expect(NIVEL_2.escena.cieloTop).not.toBe(NIVEL_1.escena.cieloTop);
     expect(NIVEL_3.escena.id).not.toBe(NIVEL_2.escena.id);
     expect(NIVEL_3.escena.id).not.toBe(NIVEL_1.escena.id);
     expect(NIVEL_3.escena.cieloTop).not.toBe(NIVEL_2.escena.cieloTop);
+    expect(NIVEL_4.escena.id).not.toBe(NIVEL_3.escena.id);
+    expect(NIVEL_4.escena.id).not.toBe(NIVEL_2.escena.id);
+    expect(NIVEL_4.escena.id).not.toBe(NIVEL_1.escena.id);
+    expect(NIVEL_4.escena.cieloTop).not.toBe(NIVEL_3.escena.cieloTop);
   });
 
   it('todos los pares de cada nivel existen en el dataset curado', () => {
@@ -435,9 +452,18 @@ describe('niveles — configuración y desbloqueo', () => {
     expect(beneficoControlaPlaga(par.benefico.id, NIVEL_3.jefe.plagaId)).toBe(true);
   });
 
+  it('el mini-jefe del nivel 4 (cogollero) referencia una plaga real con controlador', () => {
+    const par = PARES_CONTROL.find((p) => p.plaga.id === NIVEL_4.jefe.plagaId);
+    expect(par).toBeTruthy();
+    expect(par.benefico.id).toBe('trichogramma');
+    // La avispita Trichogramma es el controlador real del cogollero y derriba al jefe.
+    expect(beneficoControlaPlaga(par.benefico.id, NIVEL_4.jefe.plagaId)).toBe(true);
+  });
+
   it('getNivel devuelve el nivel pedido y cae al 1 si no existe', () => {
     expect(getNivel(2)).toBe(NIVEL_2);
     expect(getNivel(3)).toBe(NIVEL_3);
+    expect(getNivel(4)).toBe(NIVEL_4);
     expect(getNivel(99)).toBe(NIVEL_1);
   });
 
@@ -448,15 +474,19 @@ describe('niveles — configuración y desbloqueo', () => {
     // El nivel 3 exige haber superado el nivel 2.
     expect(nivelDesbloqueado(3, [1])).toBe(false);
     expect(nivelDesbloqueado(3, [1, 2])).toBe(true);
+    // El nivel 4 exige haber superado el nivel 3.
+    expect(nivelDesbloqueado(4, [1, 2])).toBe(false);
+    expect(nivelDesbloqueado(4, [1, 2, 3])).toBe(true);
   });
 
   it('NIVELES está congelado (immutable)', () => {
     expect(Object.isFrozen(NIVELES)).toBe(true);
   });
 
-  it('NIVEL_1, NIVEL_2, NIVEL_3 están congelados', () => {
+  it('NIVEL_1, NIVEL_2, NIVEL_3 y NIVEL_4 están congelados', () => {
     expect(Object.isFrozen(NIVEL_1)).toBe(true);
     expect(Object.isFrozen(NIVEL_2)).toBe(true);
     expect(Object.isFrozen(NIVEL_3)).toBe(true);
+    expect(Object.isFrozen(NIVEL_4)).toBe(true);
   });
 });


### PR DESCRIPTION
## Nivel 4: El maizal al atardecer

Agrega el cuarto nivel al minijuego _Defensores de la Finca_, con el bioma del **maizal / milpa colombiano**.

### Bioma
**Maizal al atardecer** — clima cálido, tierra plana y extensa con surcos de maíz, frijol y ahuyama.

### Plagas y aliados nuevos (pares agroecológicamente correctos)

| Plaga | Nombre común | Controlador | Nombre común |
|---|---|---|---|
| _Dalbulus maidis_ | Chicharrita del maíz | _Doru luteipes_ | Tijereta |
| _Helicoverpa zea_ | Gusano elotero | _Telenomus remus_ | Avispita Telenomus |
| _Helicoverpa zea_ | Gusano elotero | _Telenomus remus_ | Avispita Telenomus |
| _Diatraea saccharalis_ | Barrenador del tallo | _Cotesia flavipes_ | Avispita Cotesia |

**Fuentes**: CIAT, EMBRAPA, ICA Colombia — control biológico documentado en campo para el cultivo de maíz en Colombia.

### Configuración del nivel
- 13 pares plaga/controlador (todos los anteriores + 3 nuevos)
- 18 cultivos, mundo de 3360px
- 11 plataformas, 6 huecos
- Energía 6, mini-jefe: **gusano cogollero gigante** (vida 5) — solo cae con _Trichogramma_

### Dificultad progresiva
- Todos los parámetros crecen respecto al nivel 3 (mundo, cultivos, pares, plataformas, huecos, energía, vida del jefe)
- Paleta visual nueva: atardecer dorado sobre el maizal con estrellas

### Verificación
- : 0 errores
- : 98/98 tests pasan (3 test files actualizados)
- Barrel export : incluye  (faltaba) y 