### PR TITLE
fix(asociaciones): importar iconos Zap y Shield faltantes (ReferenceError que rompía la pantalla)

### DIFF
--- a/src/components/Asociaciones.jsx
+++ b/src/components/Asociaciones.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { AlertTriangle, BarChart3, CheckCircle2, Leaf, Network, Sprout, TrendingUp, Layers, ArrowRight, Sparkles, Users } from 'lucide-react';
+import { AlertTriangle, BarChart3, CheckCircle2, Leaf, Network, Sprout, TrendingUp, Layers, ArrowRight, Sparkles, Users, Zap, Shield } from 'lucide-react';
 import arquetipos from '../data/asociaciones-arquetipos.json';
 import comparativas from '../data/asociaciones-comparativa.json';
 import {


### PR DESCRIPTION
## Contexto

QA visual de las pantallas internas de la PWA que un crawl sin finca no puede ver (tarea #28). Se construyó un build local, se sirvió, y se crawleó con Playwright inyectando un perfil de finca (Choachí, 2600 msnm, piso frío) para pasar el guard de OnboardingHero (`needsLocation = !pisoInfo`, derivado de `profile.finca_altitud` en localStorage `chagra:profile:v1`) y poder montar las 18+ pantallas internas reales.

## Bug encontrado y arreglado

`src/components/Asociaciones.jsx` usaba dos iconos de `lucide-react` sin importarlos:

- `<Zap>` (línea 258) — tarjeta "Plan de acción" de cada `RecomendacionCard`.
- `<Shield>` (línea 161) — badge del tercer arquetipo en `PolycultureDiagram`.

En el bundle de producción esto lanza `ReferenceError: Zap is not defined` / `Shield is not defined`. El `ErrorBoundary` lo captura y la pantalla completa de Asociaciones queda en **"Algo falló"** apenas se renderiza una recomendación o el tercer arquetipo. (Misma clase de bug que el incidente milpa #1712 por icono lucide faltante.)

Fix mínimo: agregar `Zap` y `Shield` al import existente. Sin cambios de lógica.

## Verificación

- `eslint src/components/Asociaciones.jsx` → 0 errores, 0 warnings.
- Re-crawl Playwright tras el fix: la pantalla monta el contenido real ("Asociaciones inteligentes", arquetipos, recomendación "Milpa de maíz, frijol y ahuyama") sin crash. El único `console.error` restante es `VITE_FARMOS_CLIENT_ID` (artefacto de build local sin `.env`).

## QA de las 18 pantallas internas

Todas montan correctamente con perfil de finca; ningún `pageerror`/crash salvo el ya arreglado. Capturas y reporte en el crawl. `extensionista` y `glaciar` muestran "Vista no disponible" por gating de feature-flag/whitelist (comportamiento esperado, no bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)