### PR TITLE
feat(animales): módulo animales (gallinas/cerdos/abejas) + ciclo cerrado

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@
  */
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import React, { lazy, Suspense, useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText, Network, Beaker } from 'lucide-react';
+import { Sprout, MapPin, Eye, Package, Clock, NotebookPen, CheckCircle, WifiOff, Leaf, Mic, AlertCircle, Palette, FileText, Network, Beaker, PawPrint } from 'lucide-react';
 import localforage from 'localforage';
 import { useTheme } from './hooks/useTheme';
 import { useClimaAtmosphere } from './hooks/useClimaAtmosphere';
@@ -79,6 +79,9 @@ const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m
 const BiodiversidadView = lazy(() => import('./components/BiodiversidadView'));
 const Asociaciones = lazy(() => import('./components/Asociaciones'));
 const FermentosView = lazy(() => import('./components/FermentosView'));
+const AnimalesScreen = lazy(() => import('./components/AnimalesScreen'));
+const GallinasScreen = lazy(() => import('./components/GallinasScreen'));
+const AbejasScreen = lazy(() => import('./components/AbejasScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
@@ -136,6 +139,7 @@ const NAV_TILES = [
   { id: 'task_log', label: 'Tareas', icon: Clock, accent: 'rose', desc: 'Cola de pendientes' },
   { id: 'historial', label: 'Bitácora', icon: NotebookPen, accent: 'indigo', desc: 'Historial de actividades' },
   { id: 'biodiversidad', label: 'Flora y fauna', icon: Leaf, accent: 'emerald', desc: 'Ecosistema, estratos y gremios' },
+  { id: 'animales', label: 'Animales', icon: PawPrint, accent: 'rose', desc: 'Gallinas, cerdos, abejas y ciclo cerrado' },
   { id: 'fermentos', label: 'Fermentos', icon: Beaker, accent: 'orange', desc: 'Recetas tradicionales y seguridad' },
   { id: 'reportar_invasora', label: 'Plagas', icon: AlertCircle, accent: 'amber', desc: 'Reporte de plagas y malezas' },
   { id: 'casos', label: 'Casos', icon: FileText, accent: 'amber', desc: 'Seguimiento de problemas y tratamientos' },
@@ -177,12 +181,16 @@ const HASH_VIEW_ROUTES = {
   glaciar: 'glaciar',
   'glaciar-historial': 'glaciar_historial',
   fermentos: 'fermentos',
+  animales: 'animales',
+  'animales-gallinas': 'animales_gallinas',
+  'animales-abejas': 'animales_abejas',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
 const MODULE_VIEWS = new Set([
   'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
+  'animales', 'animales_gallinas', 'animales_abejas',
   'hoy_finca', 'evolucion', 'juego', 'defensores', 'milpa', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'suelo',
@@ -1056,6 +1064,38 @@ export default function App() {
               <ScreenShell title="Fermentos" icon={Beaker} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>
                 <FermentosView />
               </ScreenShell>
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'animales':
+        // Módulo ANIMALES de la finca integrada. Sub-botones: Cerdos (reutiliza
+        // el seguimiento porcino existente, ruta 'seguimiento_cerdos'), Gallinas
+        // y Abejas (pantallas nuevas). Eje central: el ciclo cerrado
+        // (animal → estiércol → biopreparado → suelo → planta) + polinización.
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Animales">
+              <AnimalesScreen
+                onBack={() => navigate('dashboard')}
+                onHome={() => navigate('dashboard')}
+                onNavigate={navigate}
+              />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'animales_gallinas':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Gallinas">
+              <GallinasScreen onBack={() => navigate('animales')} onHome={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'animales_abejas':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Abejas">
+              <AbejasScreen onBack={() => navigate('animales')} onHome={() => navigate('dashboard')} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/AbejasScreen.jsx
+++ b/src/components/AbejasScreen.jsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import {
+  Hexagon, Flower2, HeartPulse, ShieldAlert, Recycle, Info, Droplets,
+} from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+
+/**
+ * AbejasScreen — vertical de abejas y apicultura del módulo Animales.
+ *
+ * Secciones:
+ *   1. Colmenas (registro básico, tipo de abeja).
+ *   2. Polinización de cultivos (el aporte clave a la finca).
+ *   3. Productos: miel y cera.
+ *   4. Sanidad real (varroa, loque) — sin inventar dosis: guía + "consulta".
+ *   5. Aporte a tu finca (CICLO): la abeja NO da abono, da polinización.
+ *
+ * Fuentes: FEDEABEJA, ICA, FAO. Guarda real (animal-diagnostics.json): Apis
+ * mellifera saquea colmenas de meliponas nativas (angelitas) — mantener
+ * separación entre apiarios y meliponarios.
+ */
+
+function SeccionCard({ Icon, color, titulo, children }) {
+  return (
+    <section className={`rounded-2xl border ${color.border} ${color.bg} p-4`}>
+      <h2 className={`flex items-center gap-2 text-base font-bold ${color.text}`}>
+        {Icon && <Icon size={18} aria-hidden="true" />}
+        {titulo}
+      </h2>
+      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+// Tipos de abeja manejados en Colombia (FEDEABEJA, ICA).
+const TIPOS = [
+  { nombre: 'Apis mellifera (africanizada)', nota: 'Más miel y cera; defensiva. Necesita traje y manejo cuidadoso.' },
+  { nombre: 'Angelita (Tetragonisca angustula)', nota: 'Melipona nativa SIN aguijón. Menos miel, miel medicinal, ideal cerca de casa.' },
+  { nombre: 'Otras meliponas nativas', nota: 'Sin aguijón, gran valor para polinizar y conservar biodiversidad.' },
+];
+
+export default function AbejasScreen({ onBack, onHome }) {
+  return (
+    <ScreenShell title="Abejas y apicultura" icon={Hexagon} onBack={onBack} onHome={onHome}>
+      <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
+        <p className="text-sm text-slate-300 leading-relaxed">
+          Las abejas te dan miel y cera, pero su mayor aporte es invisible:
+          polinizan tus cultivos y mejoran el cuaje y la cosecha. Cuidarlas es
+          cuidar tu finca entera.
+        </p>
+
+        {/* 1. Colmenas */}
+        <SeccionCard
+          Icon={Info}
+          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+          titulo="Tus colmenas"
+        >
+          <p>Anota lo básico de tu apiario:</p>
+          <ul className="space-y-1">
+            <li>• <span className="font-bold">Número de colmenas</span> y dónde están.</li>
+            <li>• <span className="font-bold">Tipo de abeja</span> (ver abajo).</li>
+            <li>• <span className="font-bold">Estado:</span> fuerte, débil, con reina, sin reina.</li>
+            <li>• <span className="font-bold">Floración cercana</span> (qué hay en flor para que coman).</li>
+          </ul>
+          <div className="mt-2 space-y-1.5">
+            {TIPOS.map((t) => (
+              <div key={t.nombre} className="rounded-lg bg-black/20 border border-slate-700/50 p-2">
+                <p className="text-sm font-bold text-slate-100">{t.nombre}</p>
+                <p className="text-xs text-slate-300/90">{t.nota}</p>
+              </div>
+            ))}
+          </div>
+        </SeccionCard>
+
+        {/* 2. Polinización */}
+        <SeccionCard
+          Icon={Flower2}
+          color={{ border: 'border-fuchsia-700/40', bg: 'bg-fuchsia-900/20', text: 'text-fuchsia-200' }}
+          titulo="Polinización de tus cultivos"
+        >
+          <p>
+            Es el servicio más valioso de las abejas. Al visitar las flores,
+            llevan el polen de una a otra y <span className="font-bold">mejoran el cuaje, el
+            tamaño y la cantidad de frutos.</span>
+          </p>
+          <ul className="space-y-1">
+            <li>• Cultivos que se benefician fuerte: <span className="font-bold">curuba, mora, gulupa, lulo, café, frutales y cucurbitáceas</span> (ahuyama, pepino).</li>
+            <li>• Ubica las colmenas <span className="font-bold">cerca de los cultivos en floración</span>.</li>
+            <li>• <span className="font-bold">No fumigues</span> con las flores abiertas: matas a tus polinizadoras.</li>
+          </ul>
+        </SeccionCard>
+
+        {/* 3. Productos */}
+        <SeccionCard
+          Icon={Droplets}
+          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }}
+          titulo="Miel y cera"
+        >
+          <ul className="space-y-1.5">
+            <li>
+              <span className="font-bold text-amber-100">Miel:</span> cosecha solo el
+              excedente; deja reservas para que la colmena pase épocas sin floración.
+              Manéjala limpia y sin agua para que no fermente.
+            </li>
+            <li>
+              <span className="font-bold text-amber-100">Cera:</span> de los panales
+              viejos. Sirve para velas, jabón, ungüentos y para reciclar en láminas
+              estampadas de nuevas colmenas.
+            </li>
+          </ul>
+        </SeccionCard>
+
+        {/* 4. Sanidad real */}
+        <SeccionCard
+          Icon={HeartPulse}
+          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200' }}
+          titulo="Sanidad"
+        >
+          <p>
+            Los problemas más serios de las colmenas. No te damos dosis ni
+            productos: el manejo depende del tipo de abeja y de la época. Si la
+            colmena se debilita o ves cría dañada,
+            <span className="font-bold"> consulta a un apicultor con experiencia o al ICA.</span>
+          </p>
+          <ul className="space-y-2">
+            <li>
+              <span className="font-bold text-rose-100">Varroa (Varroa destructor):</span> ácaro
+              que chupa a las abejas y a la cría; las debilita y transmite virus.
+              Señales: abejas con alas deformes, colmena que se cae poco a poco.
+              Manejo: revisión periódica, reinas resistentes y control según
+              indique el técnico. Las abejas nativas sin aguijón casi no la sufren.
+            </li>
+            <li>
+              <span className="font-bold text-rose-100">Loque (americana y europea):</span> enfermedad
+              bacteriana de la cría. Señales: cría con mal olor, celdas hundidas y
+              perforadas, larvas muertas pegajosas. La <span className="font-bold">loque americana</span> es
+              muy grave y obliga a manejo estricto del material. Ante sospecha,
+              aísla la colmena y consulta de inmediato.
+            </li>
+          </ul>
+          <p className="flex items-start gap-2 mt-2 text-amber-200 font-semibold">
+            <ShieldAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+            Cuida a las nativas: la Apis mellifera saquea las colmenas de angelitas.
+            Mantén separados los apiarios de Apis y los meliponarios.
+          </p>
+        </SeccionCard>
+
+        {/* 5. Aporte a tu finca — CICLO (polinización, NO abono) */}
+        <SeccionCard
+          Icon={Recycle}
+          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
+          titulo="Aporte a tu finca"
+        >
+          <p>
+            A diferencia de gallinas y cerdos, las abejas <span className="font-bold">no dan
+            abono</span>. Su aporte al ciclo de la finca es la
+            <span className="font-bold"> polinización</span>: más flores visitadas, más frutos y
+            mejor cosecha.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs font-bold my-1">
+            <span className="px-2.5 py-1 rounded-full bg-yellow-500/20 text-yellow-200 border border-yellow-500/40">Abejas</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-fuchsia-500/20 text-fuchsia-200 border border-fuchsia-500/40">Polinización</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-emerald-500/20 text-emerald-200 border border-emerald-500/40">Más cosecha</span>
+          </div>
+          <p className="text-xs text-slate-300/80">
+            En campesino: si cuidas tus abejas, tus matas cuajan más y cosechas más.
+            Son trabajadoras gratis de tu finca.
+          </p>
+        </SeccionCard>
+
+        <p className="text-[11px] text-slate-500 pt-1">
+          Fuentes: FEDEABEJA, ICA, FAO. Ante problemas de sanidad, consulta a un
+          apicultor con experiencia o al ICA.
+        </p>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/AnimalesScreen.jsx
+++ b/src/components/AnimalesScreen.jsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { PawPrint, Bird, Hexagon, ChevronRight, Recycle } from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+
+/**
+ * AnimalesScreen — pantalla raíz del MÓDULO ANIMALES de la finca integrada.
+ *
+ * Sub-botones (cards) hacia cada vertical animal, con el mismo lenguaje visual
+ * del resto de la app (cards glassmorphism con cinta de acento, halo del icono
+ * y copy de campesino). La idea central es el CICLO CERRADO: el animal aporta a
+ * la nutrición de las plantas (estiércol → biopreparado → suelo → planta) o,
+ * en el caso de las abejas, a la polinización de los cultivos.
+ *
+ *   - Cerdos     → REUTILIZA el seguimiento porcino existente (ruta
+ *                  'seguimiento_cerdos', motor FarmProcess). NO se duplica.
+ *   - Gallinas   → pantalla nueva (animales_gallinas).
+ *   - Abejas     → pantalla nueva (animales_abejas).
+ *
+ * Datos sanitarios y de manejo verificables (ICA, AGROSAVIA, Fenavi,
+ * FEDEABEJA, CIPAV). El ciclo cerrado está groundeado contra
+ * catalog/biopreparados-seed.json: el bocashi lleva gallinaza y el biol /
+ * supermagro / compost llevan estiércol.
+ */
+
+// Cada vertical: id de ruta, icono, copy y la identidad de color del acento.
+// Reusa el lenguaje visual de FincaCards (gradiente + cinta + halo).
+const VERTICALES = [
+  {
+    id: 'cerdos',
+    route: 'seguimiento_cerdos',
+    Icon: PawPrint,
+    emoji: '🐖',
+    titulo: 'Cerdos',
+    subtitulo: 'Manejo porcino y seguimiento del lote',
+    aporte: 'Porcinaza para biol, supermagro y compost',
+    accent: 'from-pink-600/25 to-rose-500/10',
+    border: 'border-pink-600/40',
+    bar: 'from-pink-400 to-rose-300',
+    halo: 'bg-pink-400/20',
+    iconColor: 'text-pink-300',
+  },
+  {
+    id: 'gallinas',
+    route: 'animales_gallinas',
+    Icon: Bird,
+    emoji: '🐔',
+    titulo: 'Gallinas y aves de corral',
+    subtitulo: 'Ponedoras, engorde, sanidad y huevos',
+    aporte: 'Gallinaza para el bocashi',
+    accent: 'from-amber-600/25 to-yellow-500/10',
+    border: 'border-amber-600/40',
+    bar: 'from-amber-400 to-yellow-300',
+    halo: 'bg-amber-400/20',
+    iconColor: 'text-amber-300',
+  },
+  {
+    id: 'abejas',
+    route: 'animales_abejas',
+    Icon: Hexagon,
+    emoji: '🐝',
+    titulo: 'Abejas y apicultura',
+    subtitulo: 'Colmenas, miel, cera y sanidad',
+    aporte: 'Polinización de tus cultivos',
+    accent: 'from-yellow-500/25 to-amber-400/10',
+    border: 'border-yellow-600/40',
+    bar: 'from-yellow-300 to-amber-300',
+    halo: 'bg-yellow-400/20',
+    iconColor: 'text-yellow-300',
+  },
+];
+
+function VerticalCard({ v, onNavigate }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(v.route)}
+      aria-label={`${v.titulo} — ${v.subtitulo}`}
+      className={`group relative w-full text-left rounded-2xl overflow-hidden bg-gradient-to-br ${v.accent} backdrop-blur-xl border ${v.border} p-4 ring-2 ring-white/0 hover:ring-white/30 shadow-lg shadow-black/20 transition-all duration-200 ease-out active:scale-[0.98] hover:-translate-y-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70`}
+    >
+      {/* Cinta de acento superior: identidad de color del vertical. */}
+      <span
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${v.bar} opacity-70 group-hover:opacity-100 transition-opacity`}
+      />
+      <div className="flex items-center gap-3">
+        {/* Icono grande sobre disco de halo tonal (mismo patrón que FincaCards). */}
+        <span className="relative grid place-items-center shrink-0">
+          <span
+            aria-hidden="true"
+            className={`absolute inset-0 -m-1 rounded-full ${v.halo} blur-md scale-110 group-hover:scale-125 transition-transform`}
+          />
+          <span className="relative w-12 h-12 rounded-xl bg-black/30 flex items-center justify-center text-3xl select-none">
+            {v.emoji}
+          </span>
+        </span>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-bold text-white leading-tight">{v.titulo}</h3>
+          <p className="text-xs text-slate-300/80 mt-0.5 leading-tight">{v.subtitulo}</p>
+          <p className={`mt-1.5 inline-flex items-center gap-1 text-[11px] font-bold ${v.iconColor}`}>
+            <Recycle size={12} aria-hidden="true" />
+            {v.aporte}
+          </p>
+        </div>
+        <ChevronRight size={20} className="shrink-0 text-slate-400 group-hover:text-slate-200 transition-colors" aria-hidden="true" />
+      </div>
+    </button>
+  );
+}
+
+export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
+  const go = onNavigate || (() => {});
+  return (
+    <ScreenShell title="Animales" icon={PawPrint} onBack={onBack} onHome={onHome}>
+      <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto">
+        {/* Intro corta — qué es este módulo y por qué importa el ciclo cerrado. */}
+        <p className="text-sm text-slate-300 leading-relaxed mb-4">
+          Tus animales son parte de la finca integrada. Bien manejados, te dan
+          comida y, además, alimentan tus plantas: el estiércol se convierte en
+          abono y las abejas polinizan tus cultivos.
+        </p>
+
+        {/* Sub-botones de cada vertical animal. */}
+        <div className="flex flex-col gap-3" data-testid="animales-verticales">
+          {VERTICALES.map((v) => (
+            <VerticalCard key={v.id} v={v} onNavigate={go} />
+          ))}
+        </div>
+
+        {/* Explicación del CICLO CERRADO: animal → estiércol → biopreparado →
+            suelo → planta. Groundeado en biopreparados-seed.json. */}
+        <section className="mt-6 rounded-2xl border border-emerald-700/40 bg-emerald-900/20 p-4">
+          <h2 className="flex items-center gap-2 text-base font-bold text-emerald-200">
+            <Recycle size={18} aria-hidden="true" />
+            El ciclo cerrado de tu finca
+          </h2>
+          <p className="mt-2 text-sm text-emerald-100/90 leading-relaxed">
+            Nada se pierde: lo que sale de un animal entra como comida de la
+            tierra. Así cierras el círculo y gastas menos en abonos comprados.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs font-bold">
+            <span className="px-2.5 py-1 rounded-full bg-amber-500/20 text-amber-200 border border-amber-500/40">Animal</span>
+            <span aria-hidden="true" className="text-emerald-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-stone-500/20 text-stone-200 border border-stone-500/40">Estiércol</span>
+            <span aria-hidden="true" className="text-emerald-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-orange-500/20 text-orange-200 border border-orange-500/40">Biopreparado</span>
+            <span aria-hidden="true" className="text-emerald-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-teal-500/20 text-teal-200 border border-teal-500/40">Suelo</span>
+            <span aria-hidden="true" className="text-emerald-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-emerald-500/20 text-emerald-200 border border-emerald-500/40">Planta</span>
+          </div>
+          <ul className="mt-3 space-y-1.5 text-sm text-emerald-100/90 leading-relaxed">
+            <li>• <span className="font-bold text-amber-200">Gallinas</span> → la gallinaza es ingrediente del <span className="font-bold">bocashi</span> (abono base).</li>
+            <li>• <span className="font-bold text-pink-200">Cerdos</span> → la porcinaza y el estiércol entran al <span className="font-bold">biol</span>, el <span className="font-bold">supermagro</span> y el <span className="font-bold">compost</span>.</li>
+            <li>• <span className="font-bold text-yellow-200">Abejas</span> → no dan abono, pero polinizan tus matas y mejoran el cuaje y la cosecha.</li>
+          </ul>
+        </section>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/GallinasScreen.jsx
+++ b/src/components/GallinasScreen.jsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import {
+  Bird, Egg, HeartPulse, ShieldAlert, Sprout, Recycle, Info,
+} from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+
+/**
+ * GallinasScreen — vertical de gallinas y aves de corral del módulo Animales.
+ *
+ * Secciones:
+ *   1. Registro básico (cantidad, raza, ponedoras/engorde) — guía, sin captura
+ *      a backend en esta versión (el seguimiento por lote vive en FarmProcess).
+ *   2. Sanidad real (Newcastle, coccidiosis, parásitos) — enfermedades reales,
+ *      sin inventar dosis: guía general + "consulta al técnico/ICA".
+ *   3. Manejo (cama profunda, pastoreo rotacional / gallinas camperas).
+ *   4. Producción (huevos, gallinaza).
+ *   5. Aporte a tu finca (CICLO CERRADO): gallinaza → bocashi → suelo → planta.
+ *
+ * Fuentes: Fenavi, AGROSAVIA, ICA (Newcastle es de notificación obligatoria),
+ * CIPAV (manejo agroecológico). El vínculo gallinaza→bocashi está groundeado en
+ * catalog/biopreparados-seed.json (bocashi incluye gallinaza).
+ */
+
+function SeccionCard({ Icon, color, titulo, children }) {
+  return (
+    <section className={`rounded-2xl border ${color.border} ${color.bg} p-4`}>
+      <h2 className={`flex items-center gap-2 text-base font-bold ${color.text}`}>
+        {Icon && <Icon size={18} aria-hidden="true" />}
+        {titulo}
+      </h2>
+      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+// Razas reales colombianas / comunes, con propósito (Fenavi, AGROSAVIA).
+const RAZAS = [
+  { nombre: 'Criolla colombiana', proposito: 'Doble (huevo + carne)', nota: 'Rústica, ~175 huevos/año, resiste bien el campo' },
+  { nombre: 'Isa Brown / Lohmann', proposito: 'Ponedora', nota: 'Línea comercial de postura, muchos huevos' },
+  { nombre: 'Cobb / Ross', proposito: 'Engorde', nota: 'Pollo de engorde, crece rápido' },
+  { nombre: 'Pescuezo pelado', proposito: 'Doble', nota: 'Criolla, tolera bien el calor' },
+];
+
+export default function GallinasScreen({ onBack, onHome }) {
+  return (
+    <ScreenShell title="Gallinas y aves" icon={Bird} onBack={onBack} onHome={onHome}>
+      <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
+        <p className="text-sm text-slate-300 leading-relaxed">
+          Las gallinas te dan huevos, carne y un abono de primera (la gallinaza).
+          Bien manejadas, controlan plagas del suelo y cierran el ciclo de
+          nutrientes de tu finca.
+        </p>
+
+        {/* 1. Registro básico */}
+        <SeccionCard
+          Icon={Info}
+          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+          titulo="Registro básico"
+        >
+          <p>Anota lo esencial de tu lote para hacerle seguimiento:</p>
+          <ul className="space-y-1">
+            <li>• <span className="font-bold">Cantidad</span> de aves.</li>
+            <li>• <span className="font-bold">Raza o línea</span> (ver abajo).</li>
+            <li>• <span className="font-bold">Propósito:</span> ponedoras (huevo) o engorde (carne).</li>
+            <li>• <span className="font-bold">Edad</span> y fecha de entrada del lote.</li>
+          </ul>
+          <div className="mt-2 overflow-x-auto">
+            <table className="w-full text-xs border-collapse">
+              <thead>
+                <tr className="text-left text-slate-400 border-b border-slate-700">
+                  <th className="py-1.5 pr-2 font-bold">Raza / línea</th>
+                  <th className="py-1.5 pr-2 font-bold">Propósito</th>
+                  <th className="py-1.5 font-bold">Nota</th>
+                </tr>
+              </thead>
+              <tbody>
+                {RAZAS.map((r) => (
+                  <tr key={r.nombre} className="border-b border-slate-800/60 align-top">
+                    <td className="py-1.5 pr-2 font-bold text-slate-100">{r.nombre}</td>
+                    <td className="py-1.5 pr-2 text-amber-200">{r.proposito}</td>
+                    <td className="py-1.5 text-slate-300/90">{r.nota}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </SeccionCard>
+
+        {/* 2. Sanidad real */}
+        <SeccionCard
+          Icon={HeartPulse}
+          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200' }}
+          titulo="Sanidad"
+        >
+          <p>
+            Las enfermedades más serias de las aves en Colombia. No te damos
+            dosis: cada caso es distinto y la vacuna depende del lote. Si ves
+            varias aves enfermas o muertas, <span className="font-bold">consulta al técnico o al ICA.</span>
+          </p>
+          <ul className="space-y-2">
+            <li>
+              <span className="font-bold text-rose-100">Newcastle:</span> virus muy
+              contagioso (aves decaídas, torcedura de cuello, parálisis, diarrea
+              verdosa, muchas muertes). Se previene con <span className="font-bold">vacunación</span> y
+              bioseguridad. En Colombia es <span className="font-bold">de notificación obligatoria al ICA.</span>
+            </li>
+            <li>
+              <span className="font-bold text-rose-100">Coccidiosis:</span> parásito del
+              intestino (diarrea con sangre, aves erizadas, bajo consumo), sobre
+              todo en pollos jóvenes con cama húmeda. Manejo: <span className="font-bold">cama seca</span>,
+              densidad baja y agua limpia. El tratamiento (coccidiostato) lo
+              define el técnico.
+            </li>
+            <li>
+              <span className="font-bold text-rose-100">Parásitos:</span> internos
+              (lombrices) y externos (piojillo, ácaros). Señales: plumas opacas,
+              picazón, baja postura. Manejo: <span className="font-bold">limpieza del galpón</span>,
+              ceniza/baño de tierra para que se desparasiten solas y revisión
+              periódica. Desparasitante según indique el técnico.
+            </li>
+          </ul>
+          <p className="flex items-start gap-2 mt-2 text-amber-200 font-semibold">
+            <ShieldAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+            Bioseguridad: aves nuevas en cuarentena, no mezcles lotes de distinta
+            edad y desinfecta botas y manos al entrar al galpón.
+          </p>
+        </SeccionCard>
+
+        {/* 3. Manejo */}
+        <SeccionCard
+          Icon={Sprout}
+          color={{ border: 'border-emerald-700/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' }}
+          titulo="Manejo agroecológico"
+        >
+          <ul className="space-y-2">
+            <li>
+              <span className="font-bold text-emerald-100">Cama profunda:</span> capa
+              gruesa de cascarilla, viruta o tamo seco en el piso. Absorbe el
+              estiércol, se mantiene seca y al final se convierte en abono
+              (gallinaza compostada). Voltéala y agrega material seco si se humedece.
+            </li>
+            <li>
+              <span className="font-bold text-emerald-100">Pastoreo rotacional / gallinas camperas:</span> mueve
+              las aves por potreros o corrales rotativos. Comen pasto e insectos,
+              abonan parejo y rompen el ciclo de plagas y parásitos del suelo.
+            </li>
+            <li>
+              <span className="font-bold text-emerald-100">Sombra y agua fresca:</span> con
+              calor fuerte (&gt;32&nbsp;°C) las aves se asfixian. Dales sombra,
+              ventilación y agua limpia siempre.
+            </li>
+          </ul>
+        </SeccionCard>
+
+        {/* 4. Producción */}
+        <SeccionCard
+          Icon={Egg}
+          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }}
+          titulo="Producción"
+        >
+          <ul className="space-y-1.5">
+            <li>
+              <span className="font-bold text-amber-100">Huevos:</span> las ponedoras
+              arrancan alrededor de las 18–20 semanas. Recoge varias veces al día,
+              guarda en sitio fresco y limpio. Anota la postura para ver cómo va el lote.
+            </li>
+            <li>
+              <span className="font-bold text-amber-100">Gallinaza:</span> es el abono
+              que producen. Recógela seca de la cama profunda. <span className="font-bold">Compóstala
+              o madúrala antes de usarla</span> (la gallinaza fresca quema las plantas
+              y puede traer patógenos).
+            </li>
+          </ul>
+        </SeccionCard>
+
+        {/* 5. Aporte a tu finca — CICLO CERRADO */}
+        <SeccionCard
+          Icon={Recycle}
+          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
+          titulo="Aporte a tu finca"
+        >
+          <p>
+            La <span className="font-bold">gallinaza</span> es ingrediente del
+            <span className="font-bold"> bocashi</span>, el abono fermentado base del
+            plan de nutrición de tus plantas. Así se cierra el ciclo:
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs font-bold my-1">
+            <span className="px-2.5 py-1 rounded-full bg-amber-500/20 text-amber-200 border border-amber-500/40">Gallinas</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-stone-500/20 text-stone-200 border border-stone-500/40">Gallinaza</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-orange-500/20 text-orange-200 border border-orange-500/40">Bocashi</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-teal-500/20 text-teal-200 border border-teal-500/40">Suelo</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-emerald-500/20 text-emerald-200 border border-emerald-500/40">Planta</span>
+          </div>
+          <p className="text-xs text-slate-300/80">
+            En campesino: la gallina come, abona la cama; esa gallinaza la mezclas
+            en el bocashi y ese abono alimenta el suelo y tus matas. Menos gasto en
+            abono comprado.
+          </p>
+        </SeccionCard>
+
+        <p className="text-[11px] text-slate-500 pt-1">
+          Fuentes: Fenavi, AGROSAVIA, ICA, CIPAV. Newcastle es de notificación
+          obligatoria al ICA. Ante dudas de tratamiento o dosis, consulta al técnico.
+        </p>
+      </div>
+    </ScreenShell>
+  );
+}

--- a/src/components/dashboard/DashboardLive.jsx
+++ b/src/components/dashboard/DashboardLive.jsx
@@ -31,6 +31,7 @@ import {
 import {
     selectHomeModuleVisibilityMap,
     selectHomeModules,
+    esPerfilUrbano,
 } from '../../services/homeModuleSelector';
 import { tieneAccesoGlaciarActual, esOperadorActual } from '../../config/glaciarAccess';
 import SelectedBackgroundReveal from './SelectedBackgroundReveal';
@@ -51,6 +52,7 @@ import {
     AsociacionesCard,
     InformesCard,
     FermentosCard,
+    AnimalesCard,
     SeguimientoCards,
 } from './FincaCards';
 
@@ -196,6 +198,20 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
             }).seguimiento;
         } catch (_) {
             return null; // Fail-open: el componente muestra las 4 por defecto.
+        }
+    });
+    // Acceso al MÓDULO ANIMALES en el home. Mismo criterio "el usuario solo ve
+    // lo que necesita": un urbano de balcón/terraza NO maneja animales, así que
+    // no le mostramos la tarjeta (salvo que haya tomado control manual de su
+    // home, en cuyo caso respetamos #1560 y la mostramos). El operador la ve
+    // siempre (bypass de demos/debug). Se calcula una vez al montar.
+    const [mostrarAnimales] = useState(() => {
+        try {
+            if (esOperadorActual()) return true;
+            if (hasManualModuleVisibility()) return true;
+            return !esPerfilUrbano(getProfile());
+        } catch (_) {
+            return true; // Fail-open: no esconder el módulo por un error.
         }
     });
     const iotAlerts = useAssetStore((s) => s.iotAlerts) || [];
@@ -403,6 +419,23 @@ export default function DashboardLive({ onNavigate, regionalGreeting = null }) {
                     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3" data-testid="seguimiento-cards">
                         <SeguimientoCards onNavigate={onNavigate} variant="grid" keys={seguimientoKeys} />
                     </div>
+                </div>
+            )}
+
+            {/* MÓDULO ANIMALES (finca integrada): gallinas, cerdos y abejas, con
+                el ciclo cerrado (estiércol → biopreparado → suelo → planta) y la
+                polinización. Bloque propio, fuera del grid draggable. Gateado por
+                perfil: un urbano de balcón no lo ve (mismo criterio del resto). */}
+            {mostrarAnimales && (
+                <div className="px-4 pt-3">
+                    <p className="flex items-center gap-2 text-xs font-bold text-slate-400 uppercase tracking-wider mb-2.5">
+                        <span
+                            aria-hidden="true"
+                            className="h-3.5 w-1 rounded-full bg-gradient-to-b from-rose-400 to-pink-400"
+                        />
+                        Animales de la finca
+                    </p>
+                    <AnimalesCard onNavigate={onNavigate} variant="list" />
                 </div>
             )}
 

--- a/src/components/dashboard/FincaCards.jsx
+++ b/src/components/dashboard/FincaCards.jsx
@@ -6,7 +6,7 @@
  * este refinamiento visual. Se silencia el warning soft acá para no bloquear
  * el commit sin arrastrar ese refactor i18n. */
 import { useEffect, useState } from 'react';
-import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf, Network, Beaker } from 'lucide-react';
+import { Sprout, MapPin, Package, NotebookPen, Eye, AlertCircle, FileText, ChevronRight, Leaf, Network, Beaker, PawPrint } from 'lucide-react';
 import useAssetStore from '../../store/useAssetStore';
 import Skeleton from '../common/Skeleton';
 import { listFarmProcesses } from '../../db/farmProcessCache';
@@ -130,6 +130,16 @@ const SECTION_STYLES = {
         iconColor: 'text-indigo-300',
         bar: 'from-indigo-400 to-blue-300',
         halo: 'bg-indigo-400/15',
+    },
+    animales: {
+        Icon: PawPrint,
+        emoji: '🐔',
+        accent: 'from-rose-500/20 to-pink-500/10',
+        border: 'border-rose-700/30',
+        ring: 'ring-rose-500/0 group-hover:ring-rose-500/40',
+        iconColor: 'text-rose-300',
+        bar: 'from-rose-400 to-pink-300',
+        halo: 'bg-rose-400/15',
     },
     // Seguimiento de procesos de finca (2026-06-15). Identidad de color por
     // proceso reforzada con cinta de acento (bar) + halo del emoji (refinamiento
@@ -578,6 +588,25 @@ export function FermentosCard({ onNavigate, variant }) {
             subtitle="Recetas tradicionales y seguridad"
             tooltip="Fermentos alimentarios colombianos (masato, chicha, kéfir) + VETOS de seguridad (botulismo, plomo, cianuro)."
             onClick={() => onNavigate('fermentos')}
+        />
+    );
+}
+
+/**
+ * AnimalesCard — acceso al MÓDULO ANIMALES de la finca integrada (gallinas,
+ * cerdos, abejas). Navega a la vista 'animales', desde donde se entra a cada
+ * vertical y se ve el ciclo cerrado (estiércol → biopreparado → suelo → planta)
+ * y la polinización. Mismo componente base que el resto de tarjetas del home.
+ */
+export function AnimalesCard({ onNavigate, variant }) {
+    return (
+        <Card
+            variant={variant}
+            section="animales"
+            title="Animales"
+            subtitle="Gallinas, cerdos y abejas"
+            tooltip="Gallinas, cerdos y abejas de tu finca. Sanidad, manejo, producción y cómo aportan al ciclo cerrado (estiércol → abono → suelo → planta) y a la polinización."
+            onClick={() => onNavigate('animales')}
         />
     );
 }

--- a/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
+++ b/src/components/dashboard/__tests__/DashboardLive.glaciarBanner.test.jsx
@@ -37,6 +37,7 @@ vi.mock('../FincaCards', () => ({
   PlantasCard: () => <div />, ZonasCard: () => <div />, InsumosCard: () => <div />,
   BitacoraCard: () => <div />, HoyCard: () => <div />, PlagasCard: () => <div />,
   BiodiversidadCard: () => <div />, AsociacionesCard: () => <div />, InformesCard: () => <div />,
+  FermentosCard: () => <div />, AnimalesCard: () => <div />,
   SeguimientoCards: () => <div data-testid="seguimiento-cards" />,
 }));
 


### PR DESCRIPTION
## Qué hace

Nuevo **módulo Animales** de la finca integrada, coherente con el lenguaje visual de la app (cards glassmorphism con cinta de acento + halo, copy de campesino, español Colombia sin voseo).

### 1. Acceso en el HOME
- **DashboardLive** (home real): bloque "Animales de la finca" con `AnimalesCard` (mismo `Card` base de `FincaCards`). Gateado por perfil con el criterio existente "el usuario solo ve lo que necesita": un urbano de balcón/terraza no lo ve; el operador siempre (bypass), y se respeta la preferencia manual (#1560).
- **App.jsx** (grid clásico): tile `Animales` (icono `PawPrint`) entre Flora/fauna y Fermentos.

### 2. Pantalla Animales (`AnimalesScreen`, ruta `animales`)
Sub-botones tipo card a cada vertical:
- **Cerdos** → REUTILIZA el seguimiento porcino existente (`seguimiento_cerdos`, motor `FarmProcess`). No se duplica.
- **Gallinas / aves** (`GallinasScreen`, nueva): registro básico (cantidad, raza, ponedoras/engorde), sanidad real (Newcastle, coccidiosis, parásitos), manejo (cama profunda, pastoreo rotacional / camperas), producción (huevos, **gallinaza**).
- **Abejas / apicultura** (`AbejasScreen`, nueva): colmenas, **polinización** de cultivos, miel/cera, sanidad real (varroa, loque).

### 3. Ciclo cerrado (sección "Aporte a tu finca")
Groundeado contra `catalog/biopreparados-seed.json`:
- Gallinas → **gallinaza** → ingrediente del **bocashi**.
- Cerdos → **porcinaza/estiércol** → **biol / supermagro / compost**.
- Abejas → **polinización** (mejora cuaje/cosecha; no dan abono).

Texto campesino del ciclo: **animal → estiércol → biopreparado → suelo → planta**.

## Calidad
- Contenido sanitario verificable (ICA, AGROSAVIA, Fenavi, FEDEABEJA, CIPAV). Sin dosis/tratamientos inventados: guía general + "consulta al técnico/ICA". Newcastle marcado como notificación obligatoria al ICA.
- `eslint --max-warnings=0` limpio en todos los archivos tocados (todos los iconos lucide importados).
- `npm run build` OK.
- Tests del home verdes (15 archivos, 104 tests). Incluye fix de un mock preexistente incompleto en `DashboardLive.glaciarBanner.test.jsx` (faltaba `FermentosCard`; se añadió junto con `AnimalesCard`).
- Anti-leak: sin nombres de personas reales ni refs de infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)