### PR TITLE
feat(animales): vacas + silvopastoreo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,6 +82,7 @@ const FermentosView = lazy(() => import('./components/FermentosView'));
 const AnimalesScreen = lazy(() => import('./components/AnimalesScreen'));
 const GallinasScreen = lazy(() => import('./components/GallinasScreen'));
 const AbejasScreen = lazy(() => import('./components/AbejasScreen'));
+const VacasScreen = lazy(() => import('./components/VacasScreen'));
 const AgentScreen = lazy(() => import('./components/AgentScreen/AgentScreen'));
 const OnboardingProfile = lazy(() => import('./components/OnboardingProfile'));
 const LocationDetectedScreen = lazy(() => import('./components/LocationDetectedScreen'));
@@ -141,7 +142,7 @@ const NAV_TILES = [
   { id: 'task_log', label: 'Tareas', icon: Clock, accent: 'rose', desc: 'Cola de pendientes' },
   { id: 'historial', label: 'Bitácora', icon: NotebookPen, accent: 'indigo', desc: 'Historial de actividades' },
   { id: 'biodiversidad', label: 'Flora y fauna', icon: Leaf, accent: 'emerald', desc: 'Ecosistema, estratos y gremios' },
-  { id: 'animales', label: 'Animales', icon: PawPrint, accent: 'rose', desc: 'Gallinas, cerdos, abejas y ciclo cerrado' },
+  { id: 'animales', label: 'Animales', icon: PawPrint, accent: 'rose', desc: 'Gallinas, vacas, cerdos, abejas y ciclo cerrado' },
   { id: 'fermentos', label: 'Fermentos', icon: Beaker, accent: 'orange', desc: 'Recetas tradicionales y seguridad' },
   { id: 'reportar_invasora', label: 'Plagas', icon: AlertCircle, accent: 'amber', desc: 'Reporte de plagas y malezas' },
   { id: 'casos', label: 'Casos', icon: FileText, accent: 'amber', desc: 'Seguimiento de problemas y tratamientos' },
@@ -186,6 +187,7 @@ const HASH_VIEW_ROUTES = {
   animales: 'animales',
   'animales-gallinas': 'animales_gallinas',
   'animales-abejas': 'animales_abejas',
+  'animales-vacas': 'animales_vacas',
   'doom-finca': 'doom_finca',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
@@ -195,7 +197,7 @@ const HASH_VIEW_ROUTES = {
 const MODULE_VIEWS = new Set([
   'activos', 'mapa', 'javier', 'bodega', 'task_log', 'historial',
   'biodiversidad', 'informes', 'perfil', 'ayuda', 'help',
-  'animales', 'animales_gallinas', 'animales_abejas',
+  'animales', 'animales_gallinas', 'animales_abejas', 'animales_vacas',
   'hoy_finca', 'evolucion', 'juego', 'defensores', 'milpa', 'doom_finca', 'sembrar', 'cosechar', 'insumos', 'biopreparados',
   'observacion', 'reportar_invasora', 'mantenimiento', 'new_task',
   'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'suelo', 'toxicologia',
@@ -1125,6 +1127,16 @@ export default function App() {
           <ErrorBoundary>
             <ErrorFallback moduleName="Abejas">
               <AbejasScreen onBack={() => navigate('animales')} onHome={() => navigate('dashboard')} />
+            </ErrorFallback>
+          </ErrorBoundary>
+        );
+      case 'animales_vacas':
+        return (
+          <ErrorBoundary>
+            <ErrorFallback moduleName="Vacas">
+              {/* onNavigate: VacasScreen enlaza al proceso de seguimiento de
+                  silvopastoreo existente ('seguimiento_silvopastoreo'). */}
+              <VacasScreen onBack={() => navigate('animales')} onHome={() => navigate('dashboard')} onNavigate={navigate} />
             </ErrorFallback>
           </ErrorBoundary>
         );

--- a/src/components/AnimalesScreen.jsx
+++ b/src/components/AnimalesScreen.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PawPrint, Bird, Hexagon, ChevronRight, Recycle } from 'lucide-react';
+import { PawPrint, Bird, Hexagon, Beef, ChevronRight, Recycle } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 
 /**
@@ -14,6 +14,8 @@ import { ScreenShell } from './common/ScreenShell';
  *   - Cerdos     → REUTILIZA el seguimiento porcino existente (ruta
  *                  'seguimiento_cerdos', motor FarmProcess). NO se duplica.
  *   - Gallinas   → pantalla nueva (animales_gallinas).
+ *   - Vacas      → pantalla nueva (animales_vacas). Enlaza al proceso de
+ *                  seguimiento de silvopastoreo existente. NO se duplica.
  *   - Abejas     → pantalla nueva (animales_abejas).
  *
  * Datos sanitarios y de manejo verificables (ICA, AGROSAVIA, Fenavi,
@@ -52,6 +54,20 @@ const VERTICALES = [
     bar: 'from-amber-400 to-yellow-300',
     halo: 'bg-amber-400/20',
     iconColor: 'text-amber-300',
+  },
+  {
+    id: 'vacas',
+    route: 'animales_vacas',
+    Icon: Beef,
+    emoji: '🐄',
+    titulo: 'Vacas y ganado',
+    subtitulo: 'Leche, carne, sanidad y silvopastoreo',
+    aporte: 'Boñiga para el biol y el bocashi',
+    accent: 'from-orange-600/25 to-amber-500/10',
+    border: 'border-orange-600/40',
+    bar: 'from-orange-400 to-amber-300',
+    halo: 'bg-orange-400/20',
+    iconColor: 'text-orange-300',
   },
   {
     id: 'abejas',
@@ -150,6 +166,7 @@ export default function AnimalesScreen({ onBack, onHome, onNavigate }) {
           </div>
           <ul className="mt-3 space-y-1.5 text-sm text-emerald-100/90 leading-relaxed">
             <li>• <span className="font-bold text-amber-200">Gallinas</span> → la gallinaza es ingrediente del <span className="font-bold">bocashi</span> (abono base).</li>
+            <li>• <span className="font-bold text-orange-200">Vacas</span> → la boñiga (bovinaza) es el estiércol clásico del <span className="font-bold">biol</span> (el biol tradicional de Restrepo se hace con boñiga de vaca) y también entra al <span className="font-bold">bocashi</span>.</li>
             <li>• <span className="font-bold text-pink-200">Cerdos</span> → la porcinaza y el estiércol entran al <span className="font-bold">biol</span>, el <span className="font-bold">supermagro</span> y el <span className="font-bold">compost</span>.</li>
             <li>• <span className="font-bold text-yellow-200">Abejas</span> → no dan abono, pero polinizan tus matas y mejoran el cuaje y la cosecha.</li>
           </ul>

--- a/src/components/VacasScreen.jsx
+++ b/src/components/VacasScreen.jsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import {
+  Beef, Milk, HeartPulse, ShieldAlert, Sprout, Recycle, Info, Trees,
+} from 'lucide-react';
+import { ScreenShell } from './common/ScreenShell';
+
+/**
+ * VacasScreen — vertical de ganado bovino del módulo Animales.
+ *
+ * Secciones (mismo patrón que GallinasScreen / AbejasScreen):
+ *   1. Registro básico (cantidad, raza, propósito leche/carne/doble).
+ *   2. Sanidad real (fiebre aftosa = notificación obligatoria al ICA, mastitis,
+ *      parásitos gastrointestinales y garrapatas) — sin inventar dosis: guía
+ *      general + "consulta al técnico / al ICA".
+ *   3. Manejo (pastoreo rotacional y SILVOPASTOREO — enlaza al proceso de
+ *      seguimiento de silvopastoreo que YA existe, no se duplica).
+ *   4. Producción (leche, bovinaza / boñiga).
+ *   5. Aporte a tu finca (CICLO CERRADO): boñiga → biol (el biol tradicional de
+ *      Restrepo se hace con boñiga de vaca) → suelo → planta.
+ *
+ * Fuentes: ICA (fiebre aftosa es de notificación obligatoria, Colombia es país
+ * libre con vacunación), AGROSAVIA, FEDEGAN, CIPAV (silvopastoreo). El vínculo
+ * boñiga→biol está groundeado en catalog/biopreparados-seed.json: el biol lleva
+ * "estiércol fresco (vaca/cabra)" y el supermagro lleva "estiércol vaca"
+ * (ambos atribuidos a Restrepo Rivera).
+ */
+
+function SeccionCard({ Icon, color, titulo, children }) {
+  return (
+    <section className={`rounded-2xl border ${color.border} ${color.bg} p-4`}>
+      <h2 className={`flex items-center gap-2 text-base font-bold ${color.text}`}>
+        {Icon && <Icon size={18} aria-hidden="true" />}
+        {titulo}
+      </h2>
+      <div className="mt-2 text-sm text-slate-200/90 leading-relaxed space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+// Razas reales manejadas en Colombia, con propósito (AGROSAVIA, FEDEGAN).
+const RAZAS = [
+  { nombre: 'Holstein', proposito: 'Leche', nota: 'Mucha leche; va mejor en clima frío (tierra fría / lechería de altura)' },
+  { nombre: 'Normando', proposito: 'Doble (leche + carne)', nota: 'Rústica, buena en clima frío y medio' },
+  { nombre: 'Brahman (cebú)', proposito: 'Carne', nota: 'Aguanta calor y garrapata; base de la ganadería de tierra caliente' },
+  { nombre: 'Criollo (BON, Romosinuano, Costeño)', proposito: 'Doble', nota: 'Razas criollas colombianas, rústicas y bien adaptadas' },
+  { nombre: 'Gyr / Girolando', proposito: 'Leche en trópico', nota: 'Leche con tolerancia al calor; cruces lecheros de clima cálido' },
+];
+
+export default function VacasScreen({ onBack, onHome, onNavigate }) {
+  const go = onNavigate || (() => {});
+  return (
+    <ScreenShell title="Vacas y ganado" icon={Beef} onBack={onBack} onHome={onHome}>
+      <div className="px-4 pt-4 pb-10 max-w-2xl mx-auto space-y-4">
+        <p className="text-sm text-slate-300 leading-relaxed">
+          Las vacas te dan leche y carne, y además la boñiga (bovinaza) es uno de
+          los mejores abonos de la finca. Bien manejadas, con árboles y pasto, el
+          ganado cuida el suelo en vez de dañarlo.
+        </p>
+
+        {/* 1. Registro básico */}
+        <SeccionCard
+          Icon={Info}
+          color={{ border: 'border-sky-700/40', bg: 'bg-sky-900/20', text: 'text-sky-200' }}
+          titulo="Registro básico"
+        >
+          <p>Anota lo esencial de tu ganado para hacerle seguimiento:</p>
+          <ul className="space-y-1">
+            <li>• <span className="font-bold">Cantidad</span> de animales.</li>
+            <li>• <span className="font-bold">Raza o cruce</span> (ver abajo).</li>
+            <li>• <span className="font-bold">Propósito:</span> leche, carne o doble propósito.</li>
+            <li>• <span className="font-bold">Edad y estado:</span> ternero, levante, vaca de cría, vaca en producción.</li>
+          </ul>
+          <div className="mt-2 overflow-x-auto">
+            <table className="w-full text-xs border-collapse">
+              <thead>
+                <tr className="text-left text-slate-400 border-b border-slate-700">
+                  <th className="py-1.5 pr-2 font-bold">Raza / cruce</th>
+                  <th className="py-1.5 pr-2 font-bold">Propósito</th>
+                  <th className="py-1.5 font-bold">Nota</th>
+                </tr>
+              </thead>
+              <tbody>
+                {RAZAS.map((r) => (
+                  <tr key={r.nombre} className="border-b border-slate-800/60 align-top">
+                    <td className="py-1.5 pr-2 font-bold text-slate-100">{r.nombre}</td>
+                    <td className="py-1.5 pr-2 text-amber-200">{r.proposito}</td>
+                    <td className="py-1.5 text-slate-300/90">{r.nota}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </SeccionCard>
+
+        {/* 2. Sanidad real */}
+        <SeccionCard
+          Icon={HeartPulse}
+          color={{ border: 'border-rose-700/40', bg: 'bg-rose-900/20', text: 'text-rose-200' }}
+          titulo="Sanidad"
+        >
+          <p>
+            Los problemas de salud más serios del ganado en Colombia. No te damos
+            dosis: la vacuna y el tratamiento dependen del animal y de la zona. Si
+            ves varios animales enfermos, <span className="font-bold">consulta al técnico, al veterinario o al ICA.</span>
+          </p>
+          <ul className="space-y-2">
+            <li>
+              <span className="font-bold text-rose-100">Fiebre aftosa:</span> virus
+              muy contagioso (babeo, ampollas en boca, lengua y patas, cojera, baja
+              de leche). Colombia es país libre <span className="font-bold">con vacunación</span>: cumple
+              los ciclos de vacunación de la zona. Ante cualquier sospecha,
+              <span className="font-bold"> es de notificación OBLIGATORIA e inmediata al ICA</span> — no
+              muevas los animales y avisa de una vez.
+            </li>
+            <li>
+              <span className="font-bold text-rose-100">Mastitis:</span> inflamación
+              de la ubre (leche con grumos o sangre, ubre caliente e hinchada, baja
+              de producción). Se previene con <span className="font-bold">ordeño limpio</span>: manos
+              y pezones limpios, sellado del pezón y cama seca. El tratamiento lo
+              define el veterinario; respeta el tiempo de retiro de la leche.
+            </li>
+            <li>
+              <span className="font-bold text-rose-100">Parásitos gastrointestinales y garrapatas:</span> lombrices
+              internas (animal flaco, pelo opaco, diarrea) y garrapatas externas
+              que chupan sangre y transmiten enfermedades (fiebre de garrapata).
+              Manejo: <span className="font-bold">pastoreo rotacional</span> para cortar el ciclo,
+              revisión periódica y desparasitación según indique el técnico (no
+              abuses de los químicos: crean resistencia).
+            </li>
+          </ul>
+          <p className="flex items-start gap-2 mt-2 text-amber-200 font-semibold">
+            <ShieldAlert size={16} className="mt-0.5 shrink-0" aria-hidden="true" />
+            Animales nuevos en cuarentena, al día con vacunación (aftosa, brucelosis)
+            y con guía de movilización (ICA) al comprar o vender. Así proteges todo el hato.
+          </p>
+        </SeccionCard>
+
+        {/* 3. Manejo — pastoreo rotacional + SILVOPASTOREO (enlaza al proceso) */}
+        <SeccionCard
+          Icon={Sprout}
+          color={{ border: 'border-emerald-700/40', bg: 'bg-emerald-900/20', text: 'text-emerald-200' }}
+          titulo="Manejo agroecológico"
+        >
+          <ul className="space-y-2">
+            <li>
+              <span className="font-bold text-emerald-100">Pastoreo rotacional:</span> divide
+              el potrero y mueve el ganado por franjas. El pasto descansa y rebrota,
+              comen parejo, el suelo no se compacta y se rompe el ciclo de parásitos.
+            </li>
+            <li>
+              <span className="font-bold text-emerald-100">Silvopastoreo:</span> juntar
+              árboles + pasto + ganado. Los árboles (leucaena, botón de oro, nacedero)
+              dan sombra, forraje y nitrógeno, y protegen el agua. La vaca come mejor,
+              sufre menos calor y la finca produce más sin tumbar monte.
+            </li>
+          </ul>
+          {/* Enlace al PROCESO de seguimiento de silvopastoreo que YA existe
+              (seguimientoProcesos.js → key 'silvopastoreo', ruta
+              'seguimiento_silvopastoreo'). NO se duplica el contenido aquí. */}
+          <button
+            type="button"
+            onClick={() => go('seguimiento_silvopastoreo')}
+            className="mt-1 w-full rounded-xl border border-emerald-600/50 bg-emerald-950/40 p-3 flex items-center gap-2.5 text-left hover:border-emerald-500 transition-colors"
+          >
+            <Trees size={20} className="shrink-0 text-emerald-300" aria-hidden="true" />
+            <span className="text-sm text-emerald-100 flex-1">
+              <span className="font-bold">Lleva tu silvopastoreo.</span> Inicia y haz
+              seguimiento al sistema de árboles, pasto y ganado de tu finca.
+            </span>
+          </button>
+        </SeccionCard>
+
+        {/* 4. Producción */}
+        <SeccionCard
+          Icon={Milk}
+          color={{ border: 'border-amber-700/40', bg: 'bg-amber-900/20', text: 'text-amber-200' }}
+          titulo="Producción"
+        >
+          <ul className="space-y-1.5">
+            <li>
+              <span className="font-bold text-amber-100">Leche:</span> ordeña limpio
+              (ubre y manos lavadas), filtra y enfría pronto para que no se corte.
+              Anota los litros por día para ver cómo va cada vaca y el hato.
+            </li>
+            <li>
+              <span className="font-bold text-amber-100">Bovinaza / boñiga:</span> el
+              estiércol de la vaca es un abono de primera. Recógela de los corrales y
+              de las áreas de descanso. <span className="font-bold">Madúrala o compóstala antes
+              de aplicarla</span> (la boñiga fresca puede quemar y traer parásitos), o
+              úsala en el biol y el bocashi.
+            </li>
+          </ul>
+        </SeccionCard>
+
+        {/* 5. Aporte a tu finca — CICLO CERRADO (boñiga → biol → suelo → planta) */}
+        <SeccionCard
+          Icon={Recycle}
+          color={{ border: 'border-lime-600/50', bg: 'bg-lime-900/25', text: 'text-lime-200' }}
+          titulo="Aporte a tu finca"
+        >
+          <p>
+            La <span className="font-bold">boñiga (bovinaza)</span> es el estiércol clásico
+            del <span className="font-bold">biol</span>: el biol tradicional de Restrepo se hace
+            con boñiga de vaca. También sirve para el bocashi y el compost. Así se
+            cierra el ciclo:
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-xs font-bold my-1">
+            <span className="px-2.5 py-1 rounded-full bg-orange-500/20 text-orange-200 border border-orange-500/40">Vacas</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-stone-500/20 text-stone-200 border border-stone-500/40">Boñiga / bovinaza</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-amber-500/20 text-amber-200 border border-amber-500/40">Biol y bocashi</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-teal-500/20 text-teal-200 border border-teal-500/40">Suelo</span>
+            <span aria-hidden="true" className="text-lime-300">→</span>
+            <span className="px-2.5 py-1 rounded-full bg-emerald-500/20 text-emerald-200 border border-emerald-500/40">Planta</span>
+          </div>
+          <p className="text-xs text-slate-300/80">
+            En campesino: la vaca come pasto, suelta la boñiga; esa boñiga la
+            fermentas en el biol (y la metes al bocashi) y ese abono alimenta el
+            suelo y tus matas. Menos gasto en abono comprado y un suelo más vivo.
+          </p>
+        </SeccionCard>
+
+        <p className="text-[11px] text-slate-500 pt-1">
+          Fuentes: ICA, AGROSAVIA, FEDEGAN, CIPAV. La fiebre aftosa es de
+          notificación obligatoria e inmediata al ICA. Ante dudas de tratamiento o
+          dosis, consulta al técnico o al veterinario.
+        </p>
+      </div>
+    </ScreenShell>
+  );
+}


### PR DESCRIPTION
## Qué

Agrega **VACAS** como cuarto animal del módulo Animales (junto a gallinas, cerdos y abejas), siguiendo el patrón exacto de `GallinasScreen` / `AbejasScreen`.

## Cambios

- **`src/components/VacasScreen.jsx`** (ruta `animales_vacas`):
  - Registro básico: cantidad, raza (Holstein, Normando, Brahman, criollas BON/Romosinuano/Costeño, Gyr/Girolando), propósito leche/carne/doble.
  - **Sanidad real, sin inventar dosis**: fiebre aftosa (**notificación obligatoria e inmediata al ICA**; Colombia país libre con vacunación), mastitis, parásitos gastrointestinales y garrapatas. Cierre con "consulta al técnico/veterinario/ICA".
  - Manejo: pastoreo rotacional + **silvopastoreo**, con botón que enlaza al **proceso de seguimiento de silvopastoreo que ya existe** (`seguimiento_silvopastoreo`), sin duplicar contenido.
  - Producción: leche y **bovinaza/boñiga**.
  - "Aporte a tu finca": ciclo cerrado.
- **`src/components/AnimalesScreen.jsx`**: nueva card "Vacas y ganado" → `animales_vacas`, y la sección de ciclo cerrado ahora incluye la boñiga → biol/bocashi.
- **`src/App.jsx`**: lazy import de `VacasScreen`, `animales-vacas` en `HASH_VIEW_ROUTES`, `animales_vacas` en `MODULE_VIEWS`, y el `case` de render (con `onNavigate` para el enlace al silvopastoreo). Tile "Animales" ahora menciona vacas en su descripción.

## Cómo se enlazó el silvopastoreo

Silvopastoreo ya existe como **proceso de seguimiento** (`src/config/seguimientoProcesos.js`, key `silvopastoreo`, `processType: 'silvopasture'`, ruta `seguimiento_silvopastoreo`, motor FarmProcess). VacasScreen NO lo duplica: la sección de manejo trae un botón que navega a `seguimiento_silvopastoreo` vía la prop `onNavigate` (la misma que ya pasa `App.jsx` a `AnimalesScreen`).

## Texto del ciclo de las vacas (groundeado)

> Vacas → Boñiga/bovinaza → Biol y bocashi → Suelo → Planta

> La boñiga (bovinaza) es el estiércol clásico del biol: el biol tradicional de Restrepo se hace con boñiga de vaca. También sirve para el bocashi y el compost.

Verificado contra `catalog/biopreparados-seed.json`: el **biol** lleva `"estiércol fresco (vaca/cabra)"` y el **supermagro** lleva `"estiércol vaca"`, ambos atribuidos a Restrepo Rivera. (Nota: en este seed el bocashi base usa gallinaza; la boñiga es un estiércol que también enriquece bocashi/compost, pero el grounding fuerte para vaca es el biol.)

## Verificación

- `npx eslint --max-warnings=0` sobre los 3 archivos → **0 warnings** (todos los iconos lucide importados: `Beef`, `Milk`, `Trees`, etc.).
- `npm run build` → OK (chunk `VacasScreen-*.js` emitido).
- Unit test relacionado (`animalSelectorContract`) sigue verde.
- Español Colombia sin voseo, anti-leak (sin nombres reales/PII), fuentes: ICA, AGROSAVIA, FEDEGAN, CIPAV.

Fuentes sanitarias verificables; ninguna dosis inventada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)