### PR TITLE
fix(especies): foto correcta por especie — fin del cruce limón/tomate/fresa

### DIFF
--- a/src/utils/__tests__/speciesPhotoResolution.test.js
+++ b/src/utils/__tests__/speciesPhotoResolution.test.js
@@ -1,0 +1,218 @@
+/**
+ * speciesPhotoResolution.test.js — verificación de DATOS REALES de que la
+ * ficha de una especie muestra su PROPIA foto, no la de otra.
+ *
+ * Bug demo 2026-06-21 (operador): buscar "limón" mostraba LIMONARIA
+ * (cymbopogon, una hierba), "tomate" mostraba TOMATE DE ÁRBOL
+ * (solanum_betaceum), y "fresa" no mostraba foto. Causa: el resolver hacía
+ * matching por SUBSTRING que cruzaba géneros ("limon" ⊂ "limonaria") y la
+ * cadena de imagen no caía al cultivar cuando el id base no estaba indexado.
+ *
+ * Este test carga el CATÁLOGO REAL del repo y el species-images.json REAL
+ * (no mocks inventados): es una verificación de datos de producción. Si el
+ * catálogo cambia de forma que reintroduzca un cruce de género, este test
+ * falla y bloquea el merge.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  describe, it, expect, beforeEach, afterEach, vi,
+} from 'vitest';
+import { matchSpeciesInCatalog } from '../speciesResolver';
+import { findLocalImage, __resetSpeciesImageCache } from '../speciesImageResolver';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+const catalog = JSON.parse(
+  readFileSync(
+    path.join(REPO_ROOT, 'catalog/chagra-catalog-oss-subset-v3.2.json'),
+    'utf8',
+  ),
+);
+const speciesImagesRaw = readFileSync(
+  path.join(REPO_ROOT, 'public/species-images.json'),
+  'utf8',
+);
+const speciesImages = JSON.parse(speciesImagesRaw);
+
+const LIST = catalog.species;
+
+// Set de species_id con imagen, para afirmar cobertura sin depender de fetch.
+const IMAGE_IDS = new Set(
+  speciesImages.species
+    .filter((s) => s?.species_id && s?.image_url)
+    .map((s) => s.species_id),
+);
+
+/** ¿Existe imagen para este binomio (exacta o por prefijo de cultivar)? */
+function hasImageForBinomio(scientificName) {
+  const norm = String(scientificName || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '');
+  const tokens = norm.split('_').filter(Boolean);
+  if (tokens.length < 2) return IMAGE_IDS.has(tokens[0]);
+  const binomio = tokens.slice(0, 2).join('_');
+  if (IMAGE_IDS.has(norm) || IMAGE_IDS.has(binomio)) return true;
+  for (const id of IMAGE_IDS) {
+    if (id.startsWith(`${binomio}_`)) return true;
+  }
+  return false;
+}
+
+describe('catálogo y datos reales presentes', () => {
+  it('el catálogo OSS v3.2 tiene cientos de especies', () => {
+    expect(Array.isArray(LIST)).toBe(true);
+    expect(LIST.length).toBeGreaterThan(100);
+  });
+
+  it('species-images.json tiene la estructura esperada', () => {
+    expect(Array.isArray(speciesImages.species)).toBe(true);
+    expect(IMAGE_IDS.size).toBeGreaterThan(500);
+  });
+});
+
+describe('cruce de género corregido (bug demo)', () => {
+  it('"limón"/"limon" resuelve a un CÍTRICO, nunca a cymbopogon (limonaria)', () => {
+    for (const q of ['limón', 'limon']) {
+      const r = matchSpeciesInCatalog(LIST, q, q);
+      expect(r, `"${q}" debe matchear`).toBeTruthy();
+      expect(r.id.startsWith('citrus_'), `"${q}" → ${r.id}`).toBe(true);
+      expect(r.id.startsWith('cymbopogon_')).toBe(false);
+    }
+  });
+
+  it('"tomate" resuelve a solanum_lycopersicum*, nunca a solanum_betaceum (tomate de árbol)', () => {
+    const r = matchSpeciesInCatalog(LIST, 'tomate', 'tomate');
+    expect(r).toBeTruthy();
+    expect(r.id.startsWith('solanum_lycopersicum'), `tomate → ${r.id}`).toBe(true);
+    expect(r.id).not.toBe('solanum_betaceum');
+  });
+
+  it('"fresa" resuelve a fragaria_*', () => {
+    const r = matchSpeciesInCatalog(LIST, 'fresa', 'fresa');
+    expect(r).toBeTruthy();
+    expect(r.id.startsWith('fragaria_'), `fresa → ${r.id}`).toBe(true);
+  });
+
+  it('"limonaria" SÍ resuelve a cymbopogon_* (caso legítimo, no romper)', () => {
+    const r = matchSpeciesInCatalog(LIST, 'limonaria', 'limonaria');
+    expect(r).toBeTruthy();
+    expect(r.id.startsWith('cymbopogon_'), `limonaria → ${r.id}`).toBe(true);
+  });
+
+  it('"tomate de árbol" SÍ resuelve a solanum_betaceum (caso legítimo, no romper)', () => {
+    const r = matchSpeciesInCatalog(LIST, 'tomate de árbol', 'tomate de árbol');
+    expect(r).toBeTruthy();
+    expect(r.id).toBe('solanum_betaceum');
+  });
+
+  it('nunca a mitad de palabra: "limon" no puede caer en "limonaria"', () => {
+    const r = matchSpeciesInCatalog(LIST, 'limon', 'limon');
+    expect(r.id).not.toBe('cymbopogon_citratus');
+  });
+});
+
+describe('resolución de imagen (cadena completa)', () => {
+  beforeEach(() => {
+    __resetSpeciesImageCache();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(JSON.parse(speciesImagesRaw)),
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    __resetSpeciesImageCache();
+  });
+
+  it('la imagen de "fresa" NO es vacía (fallback por cultivar)', async () => {
+    const r = matchSpeciesInCatalog(LIST, 'fresa', 'fresa');
+    const img = await findLocalImage(r.nombre_cientifico);
+    expect(img).toBeTruthy();
+    expect(typeof img.url).toBe('string');
+    expect(img.url.length).toBeGreaterThan(0);
+  });
+
+  it('el binomio base "Fragaria × ananassa" (sin cultivar) cae al cultivar con foto', async () => {
+    const img = await findLocalImage('Fragaria × ananassa');
+    expect(img).toBeTruthy();
+    expect(img.url.length).toBeGreaterThan(0);
+  });
+
+  it('la imagen de "limón" es un cítrico (no la hierba limonaria)', async () => {
+    const r = matchSpeciesInCatalog(LIST, 'limón', 'limón');
+    const img = await findLocalImage(r.nombre_cientifico);
+    expect(img).toBeTruthy();
+    expect(img.url.length).toBeGreaterThan(0);
+  });
+});
+
+// Lista amplia de especies comunes: cada una debe resolver a una especie del
+// catálogo cuya imagen existe (exacta o por fallback de cultivar), sin cruces
+// de género. Algunas no están en el subset OSS (banano/mandarina) → se
+// permiten como "no en catálogo" pero NO como cruce de género.
+const COMMON_SPECIES = [
+  { q: 'limón', expectGenus: 'citrus', forbidGenus: 'cymbopogon' },
+  { q: 'tomate', expectGenus: 'solanum', forbidId: 'solanum_betaceum' },
+  { q: 'fresa', expectGenus: 'fragaria' },
+  { q: 'papa', expectGenus: 'solanum' },
+  { q: 'maíz', expectGenus: 'zea' },
+  { q: 'frijol', expectGenus: 'phaseolus' },
+  { q: 'aguacate', expectGenus: 'persea' },
+  { q: 'café', expectGenus: 'coffea' },
+  { q: 'cacao', expectGenus: 'theobroma' },
+  { q: 'plátano', expectGenus: 'musa' },
+  { q: 'banano', optional: true },
+  { q: 'cebolla', expectGenus: 'allium' },
+  { q: 'zanahoria', expectGenus: 'daucus' },
+  { q: 'lechuga', expectGenus: 'lactuca' },
+  { q: 'repollo', expectGenus: 'brassica' },
+  { q: 'cilantro', expectGenus: 'coriandrum' },
+  { q: 'naranja', expectGenus: 'citrus' },
+  { q: 'mandarina', optional: true },
+  { q: 'limonaria', expectGenus: 'cymbopogon' },
+  { q: 'tomate de árbol', expectId: 'solanum_betaceum' },
+];
+
+describe('cobertura amplia: foto correcta por especie común', () => {
+  it(`cubre ${COMMON_SPECIES.length} especies comunes`, () => {
+    expect(COMMON_SPECIES.length).toBeGreaterThanOrEqual(18);
+  });
+
+  for (const spec of COMMON_SPECIES) {
+    it(`"${spec.q}" → especie correcta con imagen, sin cruce de género`, () => {
+      const r = matchSpeciesInCatalog(LIST, spec.q, spec.q);
+      if (spec.optional && !r) {
+        // No está en el subset OSS — aceptable, no es un cruce.
+        expect(r).toBeNull();
+        return;
+      }
+      expect(r, `"${spec.q}" debería resolver`).toBeTruthy();
+      if (spec.expectGenus) {
+        expect(
+          r.id.startsWith(`${spec.expectGenus}_`),
+          `"${spec.q}" → ${r.id}, esperaba género ${spec.expectGenus}`,
+        ).toBe(true);
+      }
+      if (spec.expectId) expect(r.id).toBe(spec.expectId);
+      if (spec.forbidId) expect(r.id).not.toBe(spec.forbidId);
+      if (spec.forbidGenus) {
+        expect(r.id.startsWith(`${spec.forbidGenus}_`)).toBe(false);
+      }
+      // La especie resuelta debe tener imagen (exacta o por cultivar).
+      expect(
+        hasImageForBinomio(r.nombre_cientifico),
+        `"${spec.q}" → ${r.id} (${r.nombre_cientifico}) sin imagen disponible`,
+      ).toBe(true);
+    });
+  }
+});

--- a/src/utils/speciesImageResolver.js
+++ b/src/utils/speciesImageResolver.js
@@ -92,6 +92,31 @@ export function buildSpeciesIdCandidates(normalized) {
 }
 
 /**
+ * Mapea una entrada del JSON al shape de imagen consumido por los componentes.
+ */
+function toImageResult(entry) {
+  return {
+    url: entry.image_url,
+    thumbUrl: entry.image_url,
+    license: formatLicense(entry.license),
+    rightsHolder: entry.attribution || 'Autor no informado',
+    source: 'iNaturalist',
+    sourceUrl: entry.image_url,
+  };
+}
+
+/**
+ * Devuelve el binomio `genero_especie` de una lista de candidatos (el más
+ * corto que tenga exactamente 2 tokens), o null si no hay.
+ */
+function binomioOf(candidates) {
+  for (const c of candidates) {
+    if (c.split('_').filter(Boolean).length === 2) return c;
+  }
+  return null;
+}
+
+/**
  * Busca una imagen por nombre científico en el JSON local.
  * Retorna null si no hay imagen disponible.
  */
@@ -102,20 +127,31 @@ export async function findLocalImage(scientificName) {
   const index = await loadSpeciesImages();
   if (!index) return null;
 
-  // Probar species_id candidatos de más a menos específico. El binomio rescata
-  // los nombres con autor ("…_l", "…_kunth") que el match exacto no encuentra.
-  for (const candidate of buildSpeciesIdCandidates(normalized)) {
+  // 1) Probar species_id candidatos de más a menos específico. El binomio
+  //    rescata los nombres con autor ("…_l", "…_kunth") que el match exacto
+  //    no encuentra.
+  const candidates = buildSpeciesIdCandidates(normalized);
+  for (const candidate of candidates) {
     const entry = index.get(candidate);
-    if (entry) {
-      return {
-        url: entry.image_url,
-        thumbUrl: entry.image_url,
-        license: formatLicense(entry.license),
-        rightsHolder: entry.attribution || 'Autor no informado',
-        source: 'iNaturalist',
-        sourceUrl: entry.image_url,
-      };
+    if (entry) return toImageResult(entry);
+  }
+
+  // 2) Fallback por PREFIJO de binomio (bug 2026-06-21, fresa): el catálogo
+  //    trae el binomio base ("Fragaria × ananassa" → `fragaria_ananassa`)
+  //    pero el JSON solo indexa el cultivar (`fragaria_ananassa_monterrey`).
+  //    Tomar la primera entrada cuyo species_id EMPIECE por `genero_especie_`.
+  //    Determinista: ordenamos por species_id para no depender del orden de
+  //    inserción del Map.
+  const binomio = binomioOf(candidates);
+  if (binomio) {
+    const prefix = `${binomio}_`;
+    let bestId = null;
+    for (const id of index.keys()) {
+      if (id.startsWith(prefix) && (bestId === null || id < bestId)) {
+        bestId = id;
+      }
     }
+    if (bestId) return toImageResult(index.get(bestId));
   }
 
   return null;

--- a/src/utils/speciesImageResolver.test.js
+++ b/src/utils/speciesImageResolver.test.js
@@ -167,13 +167,15 @@ describe('findLocalImage', () => {
     expect(result.source).toBe('iNaturalist');
   });
 
-  it('(a) devuelve null si el normalizado no matchea species_id (sufijo autor no recortado)', async () => {
+  it('(a) recupera el binomio aunque el nombre traiga sufijo de autor', async () => {
     setupFetch();
-    // "Tamarindus indica L." → normaliza a "tamarindus_indica_l"
-    // El species_id en el mock es "tamarindus_indica" (sin _l).
-    // El resolver NO recorta sufijos de autor; devuelve null.
+    // "Tamarindus indica L." → normaliza a "tamarindus_indica_l". El species_id
+    // del mock es "tamarindus_indica" (sin _l). buildSpeciesIdCandidates añade
+    // el binomio "tamarindus_indica", así que el resolver SÍ lo encuentra: el
+    // autor (L.) no debe impedir la foto correcta.
     const result = await findLocalImage('Tamarindus indica L.');
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result.url).toBe('https://example.com/tamarind.jpg');
   });
 
   it('(b) maneja mayusculas y aun resuelve', async () => {

--- a/src/utils/speciesResolver.js
+++ b/src/utils/speciesResolver.js
@@ -12,10 +12,25 @@
  *   - La imagen de referencia (nunca resolvía nombre científico → fallback
  *     genérico sin contexto).
  *
- * Este util centraliza el matching tolerante: primero por id/slug exacto,
- * luego por nombre común normalizado, y como último recurso por inclusión
- * parcial. Lo usan AssetDetailView (imagen + plan). Funciones puras y
- * testeables — sin imports de React ni de IDB.
+ * Bug 2026-06-21 (operador, demo — CRUCE DE FOTOS): la ficha de una especie
+ * mostraba la FOTO de OTRA especie porque el último recurso (inclusión por
+ * SUBSTRING) cruzaba géneros distintos:
+ *   - "limón"  → "Limonaria" (cymbopogon_citratus, una hierba) porque "limon"
+ *     es prefijo de "limonaria" (sin tildes). DEBE ser un cítrico real.
+ *   - "tomate" → "Tomate de árbol" (solanum_betaceum) porque era la primera
+ *     coincidencia parcial en el orden de iteración. DEBE ser un tomate de
+ *     mesa real (solanum_lycopersicum*).
+ *
+ * Solución: prioridad ESTRICTA —
+ *   (0) alias curado de confusiones conocidas (consultado antes del fuzzy),
+ *   (a) id/slug exacto del catálogo,
+ *   (b) nombre común exacto normalizado (cada nombre separado por "/"),
+ *   (c) match por PALABRA COMPLETA con frontera (NUNCA a mitad de palabra),
+ *   (d) desempate por nombre más corto/genérico sin cruzar género.
+ *
+ * Este util centraliza el matching tolerante. Lo usan AssetDetailView
+ * (imagen + plan) y CicloDetalle. Funciones puras y testeables — sin imports
+ * de React ni de IDB.
  */
 
 /**
@@ -36,8 +51,86 @@ export function normalizeForMatch(value) {
 }
 
 /**
+ * Mapa de alias curado de confusiones CONOCIDAS de cruce de género. Se
+ * consulta ANTES del fuzzy: si la consulta normalizada coincide EXACTO con
+ * una clave y el id destino EXISTE en el catálogo, gana sin ambigüedad.
+ *
+ * Clave: consulta normalizada (lowercase, sin acentos). Valor: id canónico.
+ *
+ * Regla de oro: NUNCA dejar que "limonaria"/"citronela"/"limoncillo"
+ * (cymbopogon, una hierba) sea el resultado de buscar "limón" (un cítrico).
+ * Estos alias solo aplican cuando el destino existe; si no, se cae al fuzzy
+ * por palabra completa (que tampoco cruza géneros).
+ */
+const CURATED_ALIASES = {
+  // limón / limon → cítrico real, NUNCA cymbopogon (limonaria/citronela).
+  limon: 'citrus_latifolia',
+  // tomate (de mesa) → un tomate real, NUNCA solanum_betaceum (tomate de árbol).
+  tomate: 'solanum_lycopersicum_cerasiforme',
+  // fresa / frutilla → fragaria (con cultivar que SÍ tiene foto en el JSON).
+  fresa: 'fragaria_ananassa_monterrey',
+  frutilla: 'fragaria_ananassa_monterrey',
+  // frijol → frijol común (Phaseolus), no caupí (Vigna). Ambos son frijol,
+  // pero el común es el default esperado por el operador.
+  frijol: 'phaseolus_vulgaris',
+  // confusiones históricas del proyecto (gulupa/aguacate ≠ guayaba).
+  gulupa: 'passiflora_edulis_morada',
+  aguacate: 'persea_americana',
+};
+
+/**
+ * Divide el nombre común del catálogo en sus nombres alternativos. El
+ * catálogo usa "/" para listar variantes ("Tomate de árbol / Tamarillo",
+ * "Cebollín / Cebolla larga"). Devuelve cada nombre ya normalizado.
+ * @param {string} nombreComun
+ * @returns {string[]}
+ */
+function splitCommonNames(nombreComun) {
+  return String(nombreComun || '')
+    .split('/')
+    .map((part) => normalizeForMatch(part))
+    .filter(Boolean);
+}
+
+/**
+ * ¿La consulta `query` aparece como PALABRA COMPLETA dentro de `text`?
+ * Frontera = inicio/fin de string o un carácter no alfanumérico. Así "limon"
+ * coincide con "limon tahiti" (palabra "limon") pero NO con "limonaria"
+ * (la "limon" va pegada a "aria"); "tomate" coincide con "tomate de arbol"
+ * y "tomate cherry" (ambos tienen la palabra entera "tomate").
+ * Ambos argumentos deben venir ya normalizados.
+ * @param {string} text
+ * @param {string} query
+ * @returns {boolean}
+ */
+function containsWholeWord(text, query) {
+  if (!text || !query) return false;
+  if (text === query) return true;
+  let from = 0;
+  let idx = text.indexOf(query, from);
+  while (idx !== -1) {
+    const before = idx === 0 ? '' : text[idx - 1];
+    const afterIdx = idx + query.length;
+    const after = afterIdx >= text.length ? '' : text[afterIdx];
+    const beforeOk = before === '' || !/[a-z0-9]/.test(before);
+    const afterOk = after === '' || !/[a-z0-9]/.test(after);
+    if (beforeOk && afterOk) return true;
+    from = idx + 1;
+    idx = text.indexOf(query, from);
+  }
+  return false;
+}
+
+/**
  * Encuentra la especie del catálogo que corresponde a un asset, tolerando
  * que el `slug` derivado del nombre no coincida con el `id` canónico.
+ *
+ * Prioridad estricta (la primera que matchea gana):
+ *   0. Alias curado (confusiones conocidas), solo si el destino existe.
+ *   1. id/slug exacto del catálogo.
+ *   2. Nombre común / científico EXACTO normalizado (cada nombre del "/").
+ *   3. Palabra completa con frontera (consulta = palabra entera del nombre).
+ *      Desempate: nombre común más corto/genérico, sin cruzar género.
  *
  * @param {Array<object>} list — especies del catálogo (getAllSpecies()).
  * @param {string|null} slug — slug/id candidato (deriveSpeciesSlug o _speciesSlug).
@@ -49,6 +142,19 @@ export function matchSpeciesInCatalog(list, slug, name) {
 
   const slugNorm = normalizeForMatch(slug);
   const nameNorm = normalizeForMatch(name);
+  const candidates = [slugNorm, nameNorm].filter(Boolean);
+
+  // 0) Alias curado de confusiones conocidas — consultado ANTES del fuzzy.
+  //    Solo aplica si la consulta coincide EXACTO con una clave y el id
+  //    destino EXISTE en este catálogo (evita romper catálogos de test o
+  //    subsets que no tengan ese cultivar).
+  for (const c of candidates) {
+    const aliasTarget = CURATED_ALIASES[c];
+    if (aliasTarget) {
+      const hit = list.find((s) => s?.id === aliasTarget || s?.slug === aliasTarget);
+      if (hit) return hit;
+    }
+  }
 
   // 1) match exacto por id o slug del catálogo (camino canónico).
   if (slug) {
@@ -56,31 +162,56 @@ export function matchSpeciesInCatalog(list, slug, name) {
     if (exact) return exact;
   }
 
-  // 2) match por nombre común normalizado (asset viejo sin _speciesSlug).
-  //    Probamos contra ambos candidatos normalizados (slug y nombre).
-  const candidates = [slugNorm, nameNorm].filter(Boolean);
-  if (candidates.length > 0) {
-    const byCommon = list.find((s) => {
-      const common = normalizeForMatch(s?.nombre_comun);
-      const sci = normalizeForMatch(s?.nombre_cientifico);
-      return candidates.some((c) => c && (c === common || c === sci));
-    });
-    if (byCommon) return byCommon;
+  if (candidates.length === 0) return null;
 
-    // 3) último recurso: inclusión parcial del nombre común (ej. "fresa
-    //    criolla" → "fresa"). Solo si el candidato tiene ≥3 chars para
-    //    evitar falsos positivos.
-    const byPartial = list.find((s) => {
-      const common = normalizeForMatch(s?.nombre_comun);
-      if (!common) return false;
-      return candidates.some(
-        (c) => c.length >= 3 && (common.includes(c) || c.includes(common)),
+  // 2) match EXACTO por nombre común o científico normalizado. El nombre
+  //    común puede listar variantes con "/" → comparar contra cada una.
+  const byExactCommon = list.find((s) => {
+    const commonNames = splitCommonNames(s?.nombre_comun);
+    const sci = normalizeForMatch(s?.nombre_cientifico);
+    return candidates.some(
+      (c) => commonNames.includes(c) || (sci && c === sci),
+    );
+  });
+  if (byExactCommon) return byExactCommon;
+
+  // 3) match por PALABRA COMPLETA con frontera (nunca a mitad de palabra).
+  //    Desempatamos por el nombre común que MATCHEÓ más corto/genérico, para
+  //    preferir "Limón Tahití" sobre variantes largas y NUNCA agarrar una
+  //    palabra pegada (limonaria). Usamos solo la longitud del nombre que
+  //    realmente coincidió (no la del más corto de toda la entrada), así un
+  //    alias colateral corto ("Cowpea") no gana sobre el match directo.
+  let best = null;
+  let bestLen = Infinity;
+  for (const s of list) {
+    if (!s) continue;
+    const commonNames = splitCommonNames(s?.nombre_comun);
+    if (commonNames.length === 0) continue;
+    // Longitud del nombre común MÁS CORTO entre los que coinciden por palabra
+    // completa con algún candidato (la consulta es palabra entera del nombre,
+    // o el nombre es palabra entera de la consulta — ej. "café colombiano").
+    let matchedLen = Infinity;
+    for (const cn of commonNames) {
+      const hit = candidates.some(
+        (c) => c.length >= 3 && (containsWholeWord(cn, c) || containsWholeWord(c, cn)),
       );
-    });
-    if (byPartial) return byPartial;
+      if (hit && cn.length < matchedLen) matchedLen = cn.length;
+    }
+    if (matchedLen === Infinity) continue;
+    if (matchedLen < bestLen) {
+      best = s;
+      bestLen = matchedLen;
+    }
   }
+  if (best) return best;
 
   return null;
 }
 
 export default matchSpeciesInCatalog;
+
+export const __TEST__ = {
+  CURATED_ALIASES,
+  containsWholeWord,
+  splitCommonNames,
+};


### PR DESCRIPTION
## Bug
La ficha / hoja de vida de una especie mostraba la FOTO de OTRA especie (reportes de demo del operador):
- "limón" → mostraba **Limonaria** (`cymbopogon_citratus`, una hierba — NO es limón).
- "tomate" → mostraba **Tomate de árbol** (`solanum_betaceum`, otra especie/género).
- "fresa" → **no salía foto**.

## Causa raíz
1. **Cruce de género (limón/tomate)**: el último recurso de `matchSpeciesInCatalog` matcheaba por **SUBSTRING**. Al normalizar sin tildes, `"limon"` cae dentro de `"limonaria"`, y para `"tomate"` ganaba la primera coincidencia parcial del orden de iteración (`solanum_betaceum`), cruzando géneros distintos.
2. **Fresa sin foto**: la cadena de imagen construye candidatos desde el binomio base `fragaria_ananassa`, pero `species-images.json` solo indexa el cultivar `fragaria_ananassa_monterrey`. Sin coincidencia exacta del binomio → no encontraba foto.

## Cambios
- **`src/utils/speciesResolver.js`** — `matchSpeciesInCatalog` ahora aplica prioridad ESTRICTA:
  1. Mapa de **alias curado** de confusiones conocidas (consultado antes del fuzzy, solo si el id destino existe): `limón→citrus_latifolia`, `tomate→solanum_lycopersicum_cerasiforme`, `fresa/frutilla→fragaria_ananassa_monterrey`, `frijol→phaseolus_vulgaris`, `gulupa`, `aguacate`.
  2. id/slug exacto del catálogo.
  3. Nombre común / científico EXACTO normalizado (separa variantes por `/`).
  4. **PALABRA COMPLETA con frontera** (nunca a mitad de palabra), desempate por nombre más corto/genérico sin cruzar género. Así `"limon"` coincide con `"limón tahití"` pero NUNCA con `"limonaria"`.
- **`src/utils/speciesImageResolver.js`** — `findLocalImage` añade **fallback por prefijo de binomio**: si el id base no está indexado, cae a la primera entrada cuyo `species_id` empieza por `genero_especie_` (ej. `fragaria_ananassa` → `fragaria_ananassa_monterrey`). No rompe los ~615 que ya resolvían exacto.
- **`src/utils/__tests__/speciesPhotoResolution.test.js`** (nuevo) — carga el catálogo y `species-images.json` REALES del repo y verifica 20 especies comunes sin cruces de género + la cadena de imagen de fresa/limón no vacía.
- **`src/utils/speciesImageResolver.test.js`** — corrige una aserción stale (el binomio sí rescata nombres con autor; estaba roja en `main` desde antes de este PR).

## Tests
- `npx vitest run` sobre los 4 archivos relacionados: **96/96 passing**.
- El test nuevo: **32 casos passing** (20 especies comunes + bloques de cruce/imagen).
- `npm run build` limpio. `npx eslint` sobre archivos tocados: **0 errors / 0 warnings**.

Verificación clave:
- `limón`/`limon` → `citrus_latifolia` (NO cymbopogon) ✓
- `tomate` → `solanum_lycopersicum_cerasiforme` (NO `solanum_betaceum`) ✓
- `tomate de árbol` → `solanum_betaceum` (caso legítimo intacto) ✓
- `limonaria` → `cymbopogon_citratus` (caso legítimo intacto) ✓
- `fresa` → `fragaria_ananassa_monterrey` + imagen no vacía ✓

Refs: bug demo operador 2026-06-21 (limón/tomate/fresa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)