### PR TITLE
feat(catalog): plan de nutrición para frutales perennes y árboles de sombra

### DIFF
--- a/src/data/__tests__/feedingAndCycleCoverage.test.js
+++ b/src/data/__tests__/feedingAndCycleCoverage.test.js
@@ -88,7 +88,8 @@ describe('Cobertura plan de alimentación + ciclo por especie (catálogo real)',
 
     // Tripwire de cobertura: si cae por debajo del piso conocido, algo se rompió.
     // (Sube estos pisos cuando agregues plantillas perennes/medicinales.)
-    expect(feed.explicit + feed.generic, 'cobertura nutrición').toBeGreaterThanOrEqual(104);
+    // Tras añadir frutales_perennes + arboles_sombra la nutrición sube a ~177.
+    expect(feed.explicit + feed.generic, 'cobertura nutrición').toBeGreaterThanOrEqual(174);
     expect(cyc.specific + cyc.generic, 'cobertura ciclo').toBeGreaterThanOrEqual(101);
   });
 

--- a/src/data/__tests__/feedingPlanGeneric.test.js
+++ b/src/data/__tests__/feedingPlanGeneric.test.js
@@ -6,6 +6,9 @@ import {
   FITOSANITARIOS,
 } from '../feedingPlanGeneric';
 
+// Categorías ANUALES de hortaliza/grano: comparten el patrón de validación
+// estricto (abonado de fondo con bocashi a offset 0, biol como N, supermagro
+// con tope 10%, dosis foliar corta, etc.).
 const NUTRITION_CATEGORIES = [
   'hortalizas_hoja',
   'hortalizas_fruto_flor',
@@ -14,14 +17,22 @@ const NUTRITION_CATEGORIES = [
   'cereales',
 ];
 
+// Categorías PERENNES (frutal / árbol de sombra-servicio): tienen su propio
+// patrón (esquema anual recurrente, abono en la gotera/corona, mulch, mínima
+// fertilización en árboles de servicio). Validación de estructura básica.
+const PERENNIAL_CATEGORIES = ['frutales_perennes', 'arboles_sombra'];
+
+// Todas las categorías con plantilla de nutrición (anuales + perennes).
+const ALL_FEEDING_CATEGORIES = [...NUTRITION_CATEGORIES, ...PERENNIAL_CATEGORIES];
+
 // Slugs del seed que aportan nitrógeno vía biol (rico en N).
 const N_BEARING_SLUG = 'biol';
 
 describe('feedingPlanGeneric — getGenericFeedingCategories', () => {
-  it('expone exactamente las 5 categorías de nutrición', () => {
+  it('expone exactamente las 7 categorías de nutrición (anuales + perennes)', () => {
     const cats = getGenericFeedingCategories();
-    expect(cats).toHaveLength(5);
-    for (const c of NUTRITION_CATEGORIES) {
+    expect(cats).toHaveLength(7);
+    for (const c of ALL_FEEDING_CATEGORIES) {
       expect(cats).toContain(c);
     }
   });
@@ -50,11 +61,11 @@ describe('feedingPlanGeneric — cada categoría devuelve pasos', () => {
     expect(getGenericFeedingTemplate('categoria_inexistente')).toBeNull();
   });
 
-  it('devuelve null para categorías sin plantilla de nutrición (perennes/sombra)', () => {
-    expect(getGenericFeedingTemplate('frutales_perennes')).toBeNull();
-    expect(getGenericFeedingTemplate('arboles_sombra')).toBeNull();
+  it('devuelve null para categorías sin plantilla de nutrición (medicinales/invasoras)', () => {
     expect(getGenericFeedingTemplate('medicinales_alelopaticas')).toBeNull();
     expect(getGenericFeedingTemplate('especies_invasoras')).toBeNull();
+    expect(getGenericFeedingTemplate('ornamentales_nativas')).toBeNull();
+    expect(getGenericFeedingTemplate('cercas_vivas')).toBeNull();
   });
 
   it('devuelve null para entradas no-string', () => {
@@ -62,6 +73,122 @@ describe('feedingPlanGeneric — cada categoría devuelve pasos', () => {
     expect(getGenericFeedingTemplate(undefined)).toBeNull();
     expect(getGenericFeedingTemplate('')).toBeNull();
     expect(getGenericFeedingTemplate(42)).toBeNull();
+  });
+});
+
+describe('feedingPlanGeneric — plantillas perennes (frutal / árbol de servicio)', () => {
+  for (const cat of PERENNIAL_CATEGORIES) {
+    it(`devuelve plantilla con estructura válida para ${cat}`, () => {
+      const t = getGenericFeedingTemplate(cat);
+      expect(t).toBeTruthy();
+      expect(t.isGeneric).toBe(true);
+      expect(t.confidence).toBe('baja');
+      expect(t.category).toBe(cat);
+      expect(Array.isArray(t.notes)).toBe(true);
+      expect(Array.isArray(t.primary_steps)).toBe(true);
+      expect(t.primary_steps.length).toBeGreaterThan(0);
+      // Paso 0 de suelo presente (cal/roca fosfórica), antepuesto por template().
+      const slugs = t.primary_steps.map((s) => s.biofertilizer_slug);
+      expect(slugs).toContain('cal_dolomita');
+      expect(slugs).toContain('roca_fosforica');
+      // Abono de fondo al sembrar (bocashi/compost) en el hoyo, a offset 0.
+      const fondo = t.primary_steps.find((s) => s.offset_days === 0);
+      expect(fondo).toBeTruthy();
+      expect(fondo.biofertilizer_slug).toBe('bocashi');
+      // Sin fitosanitarios (es nutrición, no sanidad).
+      for (const fito of FITOSANITARIOS) {
+        expect(slugs).not.toContain(fito);
+      }
+    });
+  }
+
+  it('el frutal perenne deja claro que es un esquema ANUAL recurrente (gotera/corona + mulch)', () => {
+    const t = getGenericFeedingTemplate('frutales_perennes');
+    const joined = [
+      ...t.notes,
+      ...t.primary_steps.flatMap((s) => [s.action, s.notes]),
+    ]
+      .filter(Boolean)
+      .join(' ');
+    // Esquema que se repite cada año, no una sola vez.
+    expect(joined).toMatch(/cada año/i);
+    expect(joined).toMatch(/se REPITE/i);
+    // Abono en la zona de goteo / corona del árbol al inicio de lluvias.
+    expect(joined).toMatch(/gotera|corona/i);
+    expect(joined).toMatch(/lluvias/i);
+    expect(joined).toMatch(/mulch/i);
+    // Honestidad: orientativo por tipo + análisis de suelo manda + fuentes.
+    expect(joined).toMatch(/orientativo por tipo/i);
+    expect(joined).toMatch(/análisis de suelo/i);
+    expect(joined).toMatch(/AGROSAVIA|ICA|FAO|Cenicafé/);
+  });
+
+  it('el árbol de sombra/servicio pide mínima fertilización y aporta más de lo que toma', () => {
+    const t = getGenericFeedingTemplate('arboles_sombra');
+    // Sobrio: pocos pasos de nutrición (suelo + fondo + un mantenimiento opcional).
+    const nutricion = t.primary_steps.filter((s) => s.offset_days >= 0);
+    expect(nutricion.length).toBeLessThanOrEqual(3);
+    const joined = [
+      ...t.notes,
+      ...t.primary_steps.flatMap((s) => [s.action, s.notes]),
+    ]
+      .filter(Boolean)
+      .join(' ');
+    expect(joined).toMatch(/aportan más de lo que piden|hojarasca/i);
+    expect(joined).toMatch(/mulch/i);
+    // Honestidad: orientativo + fuentes.
+    expect(joined).toMatch(/orientativo por tipo/i);
+    expect(joined).toMatch(/AGROSAVIA|ICA|FAO/);
+  });
+
+  it('los pasos perennes con biopreparado del seed traen dosis textual', () => {
+    for (const cat of PERENNIAL_CATEGORIES) {
+      const t = getGenericFeedingTemplate(cat);
+      for (const step of t.primary_steps) {
+        // bocashi, biol, te_compost, cal/roca: todos con texto en el seed.
+        expect(step.dose_text).toBeTruthy();
+        expect(typeof step.dose_text).toBe('string');
+      }
+    }
+  });
+
+  it('resolveGenericFeedingForSpecies resuelve un frutal perenne no fijador', () => {
+    const species = {
+      id: 'persea_americana',
+      category: 'frutales_perennes',
+      familia_botanica: 'Lauraceae',
+      roles_in_guild: ['crop'],
+    };
+    const t = resolveGenericFeedingForSpecies(species);
+    expect(t).toBeTruthy();
+    expect(t.category).toBe('frutales_perennes');
+    expect(t.isLegume).toBe(false);
+  });
+
+  it('resolveGenericFeedingForSpecies resuelve un árbol de sombra no fijador', () => {
+    const species = {
+      id: 'cedrela_odorata',
+      category: 'arboles_sombra',
+      familia_botanica: 'Meliaceae',
+      roles_in_guild: ['timber'],
+    };
+    const t = resolveGenericFeedingForSpecies(species);
+    expect(t).toBeTruthy();
+    expect(t.category).toBe('arboles_sombra');
+    expect(t.isLegume).toBe(false);
+  });
+
+  it('un árbol de sombra leguminoso (fijador) recibe el plan de legumbre (sin N externo)', () => {
+    const guamo = {
+      id: 'inga_edulis',
+      category: 'arboles_sombra',
+      familia_botanica: 'Fabaceae',
+      roles_in_guild: ['nitrogen_fixer', 'shade'],
+    };
+    const t = resolveGenericFeedingForSpecies(guamo);
+    expect(t).toBeTruthy();
+    expect(t.isLegume).toBe(true);
+    expect(t.primary_steps.map((s) => s.biofertilizer_slug)).not.toContain('biol');
   });
 });
 
@@ -194,11 +321,12 @@ describe('feedingPlanGeneric — resolveGenericFeedingForSpecies (override famil
   });
 
   it('especie sin categoría con plantilla → null (degrada limpio)', () => {
+    // Medicinal no fijadora: su categoría sigue sin plantilla de nutrición.
     const species = {
-      id: 'cedrela_odorata',
-      category: 'arboles_sombra',
-      familia_botanica: 'Meliaceae',
-      roles_in_guild: ['timber'],
+      id: 'ruta_graveolens',
+      category: 'medicinales_alelopaticas',
+      familia_botanica: 'Rutaceae',
+      roles_in_guild: ['medicinal'],
     };
     expect(resolveGenericFeedingForSpecies(species)).toBeNull();
   });

--- a/src/data/feedingPlanGeneric.js
+++ b/src/data/feedingPlanGeneric.js
@@ -384,6 +384,120 @@ function buildCereals() {
   });
 }
 
+function buildPerennialFruit() {
+  // Frutal perenne (árbol): el ciclo NO es anual de una sola vez. El modelo
+  // del catálogo es por offset_days desde la SIEMBRA, así que el primer año se
+  // expresa con offsets razonables (establecimiento → brotación → corona en
+  // lluvias) y las notas dejan claro que es un ESQUEMA ANUAL que se REPITE cada
+  // año al inicio de las lluvias. Es orientativo por tipo, no dosis por especie.
+  // Grounding: fertilización orgánica de frutales = abono compostado en la zona
+  // de goteo (corona/gotera) al inicio de las lluvias; el árbol toma poco al
+  // establecerse y más cuando entra en producción; el análisis de suelo manda
+  // (AGROSAVIA, ICA, FAO; Cenicafé para café y frutales andinos).
+  return template({
+    categoryId: 'frutales_perennes',
+    label: 'Frutal perenne',
+    extraNotes: [
+      'Esquema ANUAL que se REPITE cada año: el abono de corona y el biol de ' +
+        'brotación se vuelven a aplicar al inicio de cada temporada de lluvias, ' +
+        'no una sola vez. Los días aquí son del primer año desde la siembra; ' +
+        'del segundo año en adelante, guíate por las lluvias y la floración.',
+      'El árbol joven toma poco al establecerse; pide más cuando entra en ' +
+        'producción. Sube el abono a medida que crece la copa y carga fruta. ' +
+        'Es orientativo por tipo de frutal, no una dosis exacta por especie: el ' +
+        'análisis de suelo manda (AGROSAVIA, ICA, FAO; Cenicafé para café y ' +
+        'frutales andinos).',
+    ],
+    steps: [
+      step({
+        offset_days: 0,
+        action: 'Abonar el hoyo de siembra con bocashi o compost',
+        biofertilizer_slug: 'bocashi',
+        dose_safe: '1-2 kg por árbol, mezclado con la tierra del hoyo',
+        notes:
+          'Abono de fondo al sembrar. Mézclalo bien con la tierra que devuelves ' +
+          'al hoyo; que el bocashi esté maduro y frío para no quemar la raíz ' +
+          'nueva. Si tienes compost maduro sirve igual.',
+      }),
+      step({
+        offset_days: 90,
+        action: 'Foliar o al pie con biol en la brotación y floración',
+        biofertilizer_slug: 'biol',
+        dose_safe: 'biol al 10-15% (1-1.5 L por 10 L de agua); en árbol joven 1:20',
+        notes:
+          'Cuando echa hojas nuevas y empieza a florear es cuando más responde. ' +
+          'Aplícalo temprano en la mañana o al atardecer, nunca con sol fuerte. ' +
+          'En árbol joven empieza diluido (1:20) para no quemar el follaje tierno.',
+      }),
+      step({
+        offset_days: 180,
+        action: 'Abonar la corona o gotera del árbol al inicio de las lluvias',
+        biofertilizer_slug: 'bocashi',
+        dose_safe: '1-2 kg por árbol en la gotera (no pegado al tronco) + mulch',
+        notes:
+          'Reparte el abono en la corona o gotera (donde cae el agua del borde ' +
+          'de la copa), que es donde están las raíces que comen, no pegado al ' +
+          'tronco. Tápalo con mulch (hojarasca, paja) para que no se lave ni se ' +
+          'seque. Este abonado de corona se REPITE cada año al inicio de las lluvias.',
+      }),
+      step({
+        offset_days: 270,
+        action: 'Té de compost de mantenimiento',
+        biofertilizer_slug: 'te_compost',
+        dose_safe: 'foliar 1:5 a 1:10 (té claro); al pie 1:4 a 1:5 en árbol joven',
+        notes:
+          'Aporte de microbios para sostener la vida del suelo bajo el árbol. ' +
+          'El mulch y la hojarasca que cae también alimentan: deja que se ' +
+          'descompongan al pie.',
+      }),
+    ],
+  });
+}
+
+function buildShadeServiceTrees() {
+  // Árbol de sombra / servicio (maderable, cerca, sombrío): casi no pide abono;
+  // aporta hojarasca y sombra. Mínima fertilización: compost en el hoyo + mulch.
+  // Las leguminosas fijadoras (guamo, leucaena, etc.) caen en el override de
+  // legumbre antes de llegar aquí, así que no se les añade nitrógeno.
+  // Grounding: estos árboles toman muy poco al establecerse; lo que necesitan es
+  // un buen arranque de raíz y materia orgánica; análisis de suelo si hay dudas
+  // (AGROSAVIA, ICA, FAO).
+  return template({
+    categoryId: 'arboles_sombra',
+    label: 'Árbol de sombra / servicio',
+    extraNotes: [
+      'Estos árboles aportan más de lo que piden: dan sombra, hojarasca y, si ' +
+        'son leguminosas, fijan nitrógeno para sus vecinos. Casi no necesitan ' +
+        'abono una vez prendidos.',
+      'Lo importante es un buen arranque de raíz y materia orgánica al sembrar. ' +
+        'Es orientativo por tipo de árbol, no dosis por especie; si dudas, un ' +
+        'análisis de suelo manda (AGROSAVIA, ICA, FAO).',
+    ],
+    steps: [
+      step({
+        offset_days: 0,
+        action: 'Abonar el hoyo de siembra con compost o bocashi + mulch',
+        biofertilizer_slug: 'bocashi',
+        dose_safe: '0.5-1 kg por árbol en el hoyo + mulch (hojarasca/paja) encima',
+        notes:
+          'Una sola mano de abono de fondo al sembrar, mezclado con la tierra ' +
+          'del hoyo; que esté maduro y frío. Tápalo con mulch para guardar la ' +
+          'humedad mientras prende. Si tienes compost maduro sirve igual.',
+      }),
+      step({
+        offset_days: 180,
+        action: 'Té de compost al pie si el arbolito viene flojo',
+        biofertilizer_slug: 'te_compost',
+        dose_safe: 'al pie 1:4 a 1:5 en árbol joven (opcional, solo si va lento)',
+        notes:
+          'Opcional: solo si el arbolito viene flojo de arranque. Ya prendido, ' +
+          'la propia hojarasca que cae lo alimenta; deja que se descomponga al pie ' +
+          'y no necesita más abono.',
+      }),
+    ],
+  });
+}
+
 /**
  * Registro de plantillas genéricas por `category` del catálogo.
  * Solo categorías con un ciclo anual de nutrición agronómicamente defendible.
@@ -395,6 +509,8 @@ const builders = new Map([
   ['tuberculos_raices', buildTubers],
   ['granos_legumbres', buildLegumes],
   ['cereales', buildCereals],
+  ['frutales_perennes', buildPerennialFruit],
+  ['arboles_sombra', buildShadeServiceTrees],
 ]);
 
 /**


### PR DESCRIPTION
## Feature
Cerrar el hueco de NUTRICIÓN en las categorías PERENNES del catálogo: hoy el plan de alimentación solo resuelve para hortalizas/granos anuales (~106/263); los frutales perennes y los árboles de sombra/servicio caían en "Sin plan disponible".

## Causa raíz
`feedingPlanGeneric.js` solo registraba builders para 5 categorías anuales (hortalizas hoja/fruto, tubérculos, legumbres, cereales). Las categorías `frutales_perennes` (60 esp.) y `arboles_sombra` (23 esp.) no tenían plantilla, así que `resolveGenericFeedingForSpecies` devolvía null para 83 especies.

## Cambios
- `src/data/feedingPlanGeneric.js`:
  - `buildPerennialFruit()` (label "Frutal perenne"): bocashi/compost en el hoyo al establecer (offset 0), biol en brotación-floración (offset 90), abono en la **corona/gotera** del árbol al inicio de lluvias + mulch (offset 180, marcado como esquema ANUAL que se REPITE cada año), té de compost de mantenimiento (offset 270). Notas honestas: orientativo por tipo, no dosis por especie; el análisis de suelo manda (AGROSAVIA, ICA, FAO, Cenicafé).
  - `buildShadeServiceTrees()` (label "Árbol de sombra / servicio"): mínima fertilización — compost en el hoyo + mulch al sembrar, té de compost opcional solo si el arbolito viene flojo. Estos árboles aportan más de lo que piden; las leguminosas fijadoras (guamo, etc.) ya caen en el override de legumbre (sin N externo).
  - Ambos registrados en el `Map` de `builders`. Paso 0 de suelo (cal + roca fosfórica) heredado de `template()`. Sin fitosanitarios (es nutrición, no sanidad); dosis textuales del seed, no inventadas.
- `src/data/__tests__/feedingPlanGeneric.test.js`: actualizado conteo de categorías (5→7), reemplazadas las aserciones "perennes/sombra → null", nuevo bloque de validación de estructura/notas para ambas categorías perennes (esquema anual recurrente, gotera/corona, mulch, fuentes, mínima fertilización en árboles, override leguminoso para guamo).
- `src/data/__tests__/feedingAndCycleCoverage.test.js`: subido el tripwire de cobertura de nutrición de 104 a 174.

## Cobertura
NUTRICIÓN: **106 → 177 de 263 (67%)** [explícito 14 + genérico 163]. Ciclo fenológico sin tocar (103/263, otro modelo perenne aparte).

## Tests
- `feedingAndCycleCoverage.test.js` + `feedingPlanGeneric.test.js`: 59 casos passing.
- `npm run build` limpio; `eslint --max-warnings=0` 0/0 en los 3 archivos.
- (Los fallos en fincaEvolutionService/outputGuards/profilePresets/networkRetry son pre-existentes en `main`, ajenos a este PR.)

Refs: feedingAndCycleCoverage.test.js (#1775), categorías oscuras de nutrición

🤖 Generated with [Claude Code](https://claude.com/claude-code)