### PR TITLE
feat(catalog): modelo híbrido del ciclo de perennes (establecimiento + calendario anual)

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Sprout, FlaskConical, AlertTriangle } from 'lucide-react';
 import FarmProcessSummary from './FarmProcessSummary';
 import PhenologyTimeline from './PhenologyTimeline';
+import PerennialCycleView from './PerennialCycleView';
 import CicloObservacion from './CicloObservacion';
 import CicloFotos from './CicloFotos';
 import SpeciesImage from './SpeciesImage';
@@ -17,6 +18,7 @@ import { getAllSpecies } from '../db/catalogDB';
 import { matchSpeciesInCatalog } from '../utils/speciesResolver';
 import { getTemplate } from '../data/phenologyTemplates';
 import { getGenericTemplate } from '../data/phenologyGeneric';
+import { isPerennialSpecies } from '../data/perennialCycles';
 
 /**
  * CicloDetalle — detalle de un ciclo (FarmProcess) con el enriquecimiento del
@@ -74,6 +76,21 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
   // cuando la especie (o su especie madre, para cultivares) no tiene plantilla
   // específica. Nunca inventa días; solo da una referencia amplia marcada.
   const speciesCategory = useMemo(() => species?.category || null, [species]);
+
+  // ¿Es un perenne? El modelo anual (siembra → cosecha) no aplica a un árbol o
+  // arbusto que vive años. Se considera perenne si tiene ciclo perenne grounded
+  // (perennialCycles) o si su categoría es de perennes/árboles de sombra.
+  // PerennialCycleView se auto-degrada a null si no hay datos perennes para la
+  // especie, así que solo aporta la vista híbrida cuando hay algo honesto que
+  // mostrar; en ese caso ocultamos la línea de tiempo anual.
+  const hasPerennialData = useMemo(
+    () => isPerennialSpecies(canonicalSlug),
+    [canonicalSlug],
+  );
+  const isPerennial = useMemo(
+    () => hasPerennialData || speciesCategory === 'frutales_perennes' || speciesCategory === 'arboles_sombra',
+    [hasPerennialData, speciesCategory],
+  );
 
   // Plantilla fenológica resuelta SIN inventar datos, en orden de preferencia:
   //   1. fenología embebida en el catálogo (si la trae), normalizada;
@@ -192,16 +209,30 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
 
       <CicloObservacion processId={processId} processHint={cycle} currentStage={displayStage} onSaved={onReload} />
 
-      <section>
-        <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
-        <PhenologyTimeline
-          speciesSlug={canonicalSlug}
-          sowingDate={a.created_at}
-          altitudeM={altitudeM}
-          phenologyTemplate={resolvedPhenologyTemplate}
-          category={speciesCategory}
+      {/* Vista híbrida del perenne (establecimiento + calendario anual). Se
+          auto-degrada a null si no hay datos perennes grounded para la especie. */}
+      {isPerennial && (
+        <PerennialCycleView
+          speciesId={canonicalSlug}
+          plantingDate={a.created_at}
+          commonName={species?.nombre_comun || a.subject_label || null}
         />
-      </section>
+      )}
+
+      {/* Línea de tiempo anual (siembra → cosecha): se conserva para NO perennes
+          y como respaldo cuando un perenne aún no tiene calendario grounded. */}
+      {!hasPerennialData && (
+        <section>
+          <h2 className="text-2xs uppercase font-bold text-slate-500 mb-2">Línea de tiempo</h2>
+          <PhenologyTimeline
+            speciesSlug={canonicalSlug}
+            sowingDate={a.created_at}
+            altitudeM={altitudeM}
+            phenologyTemplate={resolvedPhenologyTemplate}
+            category={speciesCategory}
+          />
+        </section>
+      )}
 
       <CicloFotos processId={processId} />
 

--- a/src/components/PerennialCycleView.jsx
+++ b/src/components/PerennialCycleView.jsx
@@ -1,0 +1,153 @@
+import { useMemo } from 'react';
+import { TreeDeciduous, Sprout, Flower2, Apple, CalendarDays, Info } from 'lucide-react';
+import { resolvePerennialCycle } from '../services/perennialCalculator';
+import { monthShortName } from '../data/perennialCycles';
+
+/**
+ * PerennialCycleView — vista HÍBRIDA del ciclo de una especie perenne.
+ *
+ * Muestra dos cosas que el ciclo anual (siembra → cosecha) no puede mostrar para
+ * un árbol o arbusto que vive años:
+ *   1. Barra de ESTABLECIMIENTO + año estimado de la primera cosecha.
+ *   2. Tira de 12 meses con floración/cosecha resaltadas, o el aviso de que
+ *      produce casi todo el año / que el calendario varía por región.
+ *
+ * Theme-aware: usa la rampa slate/emerald/amber + acento orchid que se remapea
+ * por tema (themes.css), igual que PhenologyTimeline, para verse bien en
+ * nature/minimalista (claro) y biopunk (oscuro).
+ *
+ * Degrada limpio: si no hay datos perennes para la especie, no renderiza nada
+ * (devuelve null) y el contenedor mantiene el ciclo anual existente.
+ *
+ * Props:
+ *   - speciesId: string (id de catálogo)
+ *   - plantingDate: number (timestamp ms, opcional)
+ *   - commonName: string (opcional, para el encabezado)
+ */
+const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+export default function PerennialCycleView({ speciesId, plantingDate, commonName }) {
+  const cycle = useMemo(
+    () => resolvePerennialCycle({ speciesId, plantingDate }),
+    [speciesId, plantingDate],
+  );
+
+  if (!cycle) return null;
+
+  const { establishment, annual } = cycle;
+  const inEstablishment = cycle.phase === 'establishment';
+  const progressPct = establishment.progress !== null
+    ? Math.round(establishment.progress * 100)
+    : null;
+
+  const [minY, maxY] = establishment.yearsToFirstHarvest;
+  const yearsLabel = minY === maxY ? `${minY}` : `${minY}–${maxY}`;
+  const continuous = annual.regime === 'continuous';
+  const unknown = annual.regime === 'unknown';
+  const hasMonthData = annual.floweringMonths.length > 0 || annual.harvestMonths.length > 0;
+
+  const floweringSet = new Set(annual.floweringMonths);
+  const harvestSet = new Set(annual.harvestMonths);
+
+  return (
+    <section className="bg-slate-900 border border-slate-800 rounded-xl p-3 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <TreeDeciduous size={16} className="text-emerald-400 shrink-0" />
+        <h2 className="text-2xs uppercase font-bold text-slate-500">
+          Ciclo del perenne{commonName ? ` · ${commonName}` : ''}
+        </h2>
+      </div>
+
+      {/* ── Establecimiento ── */}
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm text-slate-300 flex items-center gap-1.5">
+            <Sprout size={14} className="text-emerald-400 shrink-0" />
+            {inEstablishment ? 'En crecimiento' : 'En producción'}
+          </span>
+          {progressPct !== null && (
+            <span className="text-xs font-bold text-emerald-400">{progressPct}%</span>
+          )}
+        </div>
+
+        {progressPct !== null && (
+          <div className="h-2 rounded-full bg-slate-800 overflow-hidden" aria-hidden="true">
+            <div
+              className="h-full bg-emerald-500 rounded-full transition-all"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        )}
+
+        <p className="text-xs text-slate-400">
+          Da su primera producción entre los <strong className="text-slate-200">{yearsLabel} años</strong> de sembrada
+          {establishment.firstHarvestYear !== null && (
+            <> · estimada hacia el año <strong className="text-slate-200">{establishment.firstHarvestYear}</strong></>
+          )}
+          {cycle.productiveLifeYears && (
+            <> · produce por unos <strong className="text-slate-200">{cycle.productiveLifeYears} años</strong></>
+          )}
+          .
+        </p>
+      </div>
+
+      {/* ── Calendario anual ── */}
+      <div className="flex flex-col gap-1.5">
+        <span className="text-sm text-slate-300 flex items-center gap-1.5">
+          <CalendarDays size={14} className="text-emerald-400 shrink-0" />
+          Cada año, una vez establecida
+        </span>
+
+        {continuous && !hasMonthData ? (
+          <p className="text-xs text-emerald-300">Produce casi todo el año.</p>
+        ) : unknown ? (
+          <p className="text-xs text-amber-400">
+            El calendario varía por región y altitud; consulta el comportamiento en tu zona.
+          </p>
+        ) : (
+          <>
+            <div className="grid grid-cols-12 gap-0.5" role="list" aria-label="Calendario de floración y cosecha">
+              {MONTHS.map((m) => {
+                const isF = floweringSet.has(m);
+                const isH = harvestSet.has(m);
+                const cls = isH
+                  ? 'bg-amber-600 text-slate-950'
+                  : isF
+                    ? 'bg-orchid text-slate-950'
+                    : 'bg-slate-800 text-slate-500';
+                return (
+                  <div
+                    key={m}
+                    role="listitem"
+                    aria-label={`${monthShortName(m)}${isH ? ' cosecha' : ''}${isF ? ' floración' : ''}`}
+                    className={`text-2xs text-center py-1 rounded ${cls}`}
+                  >
+                    {monthShortName(m).charAt(0).toUpperCase()}
+                  </div>
+                );
+              })}
+            </div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1 text-2xs text-slate-400">
+              <span className="flex items-center gap-1">
+                <Flower2 size={11} className="text-orchid" /> floración
+              </span>
+              <span className="flex items-center gap-1">
+                <Apple size={11} className="text-amber-400" /> cosecha
+              </span>
+            </div>
+          </>
+        )}
+
+        <p className="text-xs text-slate-400">{annual.note}</p>
+      </div>
+
+      {/* ── Pie: fuente + caveat ── */}
+      <p className="text-2xs text-slate-500 flex items-start gap-1.5 border-t border-slate-800 pt-2">
+        <Info size={11} className="shrink-0 mt-0.5" />
+        <span>
+          Fuente: {cycle.source}. Aproximado; varía por región, altitud y manejo.
+        </span>
+      </p>
+    </section>
+  );
+}

--- a/src/data/__tests__/perennialCycles.test.js
+++ b/src/data/__tests__/perennialCycles.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests del modelo HÍBRIDO de ciclo de perennes:
+ *   (1) cada entrada de datos es estructuralmente válida y honesta, y
+ *   (2) el resolver (perennialCalculator) devuelve fases coherentes para una
+ *       fecha de siembra dada y degrada limpio sin datos.
+ *
+ * También verifica contra el catálogo REAL que todos los ids de perennes con
+ * ciclo grounded existan en el catálogo (no apuntan a un id inventado).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  PERENNIAL_CYCLES,
+  PERENNIAL_REGIMES,
+  getPerennialCycle,
+  isPerennialSpecies,
+  getPerennialSpeciesIds,
+  monthShortName,
+} from '../perennialCycles';
+import { resolvePerennialCycle } from '../../services/perennialCalculator';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const catalog = JSON.parse(
+  readFileSync(path.join(REPO_ROOT, 'catalog/chagra-catalog-oss-subset-v3.2.json'), 'utf8'),
+);
+const catalogIds = new Set((catalog.species || []).filter((s) => s && s.id).map((s) => s.id));
+
+const entries = Object.entries(PERENNIAL_CYCLES);
+const validMonth = (m) => Number.isInteger(m) && m >= 1 && m <= 12;
+
+describe('perennialCycles — datos', () => {
+  it('tiene varias especies perennes con ciclo grounded', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it.each(entries)('%s: estructura y meses válidos', (id, c) => {
+    // years_to_first_harvest coherente
+    expect(Array.isArray(c.years_to_first_harvest)).toBe(true);
+    expect(c.years_to_first_harvest).toHaveLength(2);
+    const [minY, maxY] = c.years_to_first_harvest;
+    expect(Number.isFinite(minY)).toBe(true);
+    expect(Number.isFinite(maxY)).toBe(true);
+    expect(minY).toBeGreaterThan(0);
+    expect(minY).toBeLessThanOrEqual(maxY);
+
+    // vida productiva: número positivo o null
+    expect(c.productive_life_years === null || c.productive_life_years > 0).toBe(true);
+
+    // régimen permitido
+    expect(PERENNIAL_REGIMES).toContain(c.regime);
+
+    // meses válidos 1-12
+    expect(Array.isArray(c.flowering_months)).toBe(true);
+    expect(Array.isArray(c.harvest_months)).toBe(true);
+    expect(c.flowering_months.every(validMonth)).toBe(true);
+    expect(c.harvest_months.every(validMonth)).toBe(true);
+
+    // fuente y nota presentes y no vacías
+    expect(typeof c.source).toBe('string');
+    expect(c.source.trim().length).toBeGreaterThan(0);
+    expect(typeof c.region_note).toBe('string');
+    expect(c.region_note.trim().length).toBeGreaterThan(0);
+    expect(['alta', 'media', 'baja']).toContain(c.confidence);
+  });
+
+  it('régimen unknown no lista meses (honestidad)', () => {
+    for (const [id, c] of entries) {
+      if (c.regime === 'unknown') {
+        expect(c.flowering_months, `${id}: unknown sin floración`).toHaveLength(0);
+        expect(c.harvest_months, `${id}: unknown sin cosecha`).toHaveLength(0);
+      }
+    }
+  });
+
+  it('régimen bimodal/seasonal sí lista meses de cosecha', () => {
+    for (const [id, c] of entries) {
+      if (c.regime === 'bimodal' || c.regime === 'seasonal') {
+        expect(c.harvest_months.length, `${id}: ${c.regime} con meses`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('todos los ids de perennes existen en el catálogo real', () => {
+    const missing = getPerennialSpeciesIds().filter((id) => !catalogIds.has(id));
+    expect(missing).toEqual([]);
+  });
+
+  it('helpers básicos', () => {
+    expect(isPerennialSpecies('persea_americana')).toBe(true);
+    expect(isPerennialSpecies('no_existe')).toBe(false);
+    expect(getPerennialCycle('coffea_arabica')).toBeTruthy();
+    expect(getPerennialCycle('no_existe')).toBeNull();
+    expect(monthShortName(1)).toBe('ene');
+    expect(monthShortName(12)).toBe('dic');
+    expect(monthShortName(0)).toBe('');
+    expect(monthShortName(13)).toBe('');
+  });
+});
+
+describe('perennialCalculator — resolver', () => {
+  const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+
+  it('sin datos perennes → null (degrada al ciclo anual)', () => {
+    expect(resolvePerennialCycle({ speciesId: 'no_existe', plantingDate: Date.now() })).toBeNull();
+    expect(resolvePerennialCycle({})).toBeNull();
+  });
+
+  it('fase establishment cuando aún no llega al mínimo de años', () => {
+    const planting = Date.now() - 0.2 * YEAR_MS; // ~2.4 meses
+    const res = resolvePerennialCycle({ speciesId: 'persea_americana', plantingDate: planting });
+    expect(res).toBeTruthy();
+    expect(res.phase).toBe('establishment');
+    expect(res.establishment.progress).toBeGreaterThanOrEqual(0);
+    expect(res.establishment.progress).toBeLessThan(1);
+    expect(res.establishment.yearsElapsed).toBeGreaterThan(0);
+    expect(res.establishment.firstHarvestYear).toBeGreaterThan(new Date(planting).getFullYear());
+  });
+
+  it('fase productive cuando supera el mínimo de años', () => {
+    const planting = Date.now() - 6 * YEAR_MS;
+    const res = resolvePerennialCycle({ speciesId: 'persea_americana', plantingDate: planting });
+    expect(res.phase).toBe('productive');
+    expect(res.establishment.progress).toBe(1);
+  });
+
+  it('sin fecha de siembra → productive con establecimiento sin progreso', () => {
+    const res = resolvePerennialCycle({ speciesId: 'theobroma_cacao' });
+    expect(res.phase).toBe('productive');
+    expect(res.establishment.progress).toBeNull();
+    expect(res.establishment.yearsElapsed).toBeNull();
+    expect(res.establishment.firstHarvestYear).toBeNull();
+    expect(res.establishment.yearsToFirstHarvest).toEqual([2, 5]);
+  });
+
+  it('régimen continuo marca cosecha en cualquier mes', () => {
+    // febrero
+    const now = Date.UTC(2026, 1, 10);
+    const res = resolvePerennialCycle({ speciesId: 'physalis_peruviana', now });
+    expect(res.annual.regime).toBe('continuous');
+    expect(res.annual.isHarvest).toBe(true);
+  });
+
+  it('régimen seasonal: cosecha solo en los meses listados', () => {
+    const cosecha = Date.UTC(2026, 10, 10); // noviembre (mango cosecha 11,12)
+    const fuera = Date.UTC(2026, 2, 10); // marzo
+    const inMonth = resolvePerennialCycle({ speciesId: 'mangifera_indica', now: cosecha });
+    const outMonth = resolvePerennialCycle({ speciesId: 'mangifera_indica', now: fuera });
+    expect(inMonth.annual.isHarvest).toBe(true);
+    expect(outMonth.annual.isHarvest).toBe(false);
+  });
+
+  it('floración refleja flowering_months del régimen seasonal', () => {
+    const sep = Date.UTC(2026, 8, 10); // septiembre (mango flor 8,9,10)
+    const res = resolvePerennialCycle({ speciesId: 'mangifera_indica', now: sep });
+    expect(res.annual.isFlowering).toBe(true);
+  });
+
+  it('nextHarvestMonths ordena de forma circular desde el mes actual', () => {
+    const may = Date.UTC(2026, 4, 15); // mediados de mayo (seguro en cualquier huso)
+    const res = resolvePerennialCycle({ speciesId: 'coffea_arabica', now: may });
+    // café cosecha [4,5,6,9,10,11,12] → desde mayo: 5,6,9,10,11,12,4
+    expect(res.annual.nextHarvestMonths[0]).toBe(5);
+    expect(res.annual.nextHarvestMonths[res.annual.nextHarvestMonths.length - 1]).toBe(4);
+  });
+
+  it('régimen unknown: no marca floración ni cosecha y nota honesta', () => {
+    const res = resolvePerennialCycle({ speciesId: 'citrus_sinensis', now: Date.UTC(2026, 5, 1) });
+    expect(res.annual.regime).toBe('unknown');
+    expect(res.annual.isFlowering).toBe(false);
+    expect(res.annual.isHarvest).toBe(false);
+    expect(res.annual.note.toLowerCase()).toContain('varía');
+  });
+
+  it('expone fuente y confianza de la especie', () => {
+    const res = resolvePerennialCycle({ speciesId: 'acca_sellowiana' });
+    expect(res.source.length).toBeGreaterThan(0);
+    expect(['alta', 'media', 'baja']).toContain(res.confidence);
+  });
+});

--- a/src/data/perennialCycles.js
+++ b/src/data/perennialCycles.js
@@ -1,0 +1,324 @@
+/**
+ * perennialCycles — modelo HÍBRIDO del ciclo de frutales y árboles perennes.
+ *
+ * El modelo de ciclo anual (siembra → cosecha) NO aplica a un árbol o arbusto
+ * que vive varios años: el campesino siembra una vez y la planta produce año
+ * tras año tras un periodo de establecimiento. Estos datos describen ese ciclo
+ * en dos partes complementarias:
+ *
+ *   1. ESTABLECIMIENTO — cuántos años desde la siembra hasta la primera cosecha
+ *      (rango), y cuántos años vive en producción.
+ *   2. CALENDARIO ANUAL RECURRENTE — qué meses suele florecer y producir cada
+ *      año una vez establecida; o si produce de forma casi continua.
+ *
+ * REGLA DE HONESTIDAD (anti-alucinación, crítica):
+ *   - `regime: 'continuous'`  → produce casi todo el año; los arrays de meses
+ *     pueden quedar vacíos o traer SOLO los picos cuando hay dato firme.
+ *   - `regime: 'bimodal'`     → dos temporadas marcadas al año (meses listados).
+ *   - `regime: 'seasonal'`    → una temporada marcada al año (meses listados).
+ *   - `regime: 'unknown'`     → el calendario varía por región/altitud y no hay
+ *     un dato firme que listar; los arrays quedan vacíos y `region_note` lo dice.
+ *   - NUNCA se inventan meses que la fuente no respalde. Si la fuente no da
+ *     meses claros, el régimen es 'unknown' y la UI lo presenta como variable.
+ *   - Todos los rangos de meses son aproximados y varían por región y altitud.
+ *
+ * Meses: enteros 1-12 (1 = enero ... 12 = diciembre).
+ *
+ * @typedef {Object} PerennialCycle
+ * @property {[number, number]} years_to_first_harvest — [min, max] años desde la siembra
+ * @property {number|null} productive_life_years — años de vida productiva (null si no hay dato)
+ * @property {'continuous'|'bimodal'|'seasonal'|'unknown'} regime
+ * @property {number[]} flowering_months — meses de floración (1-12), vacío si no aplica/no hay dato
+ * @property {number[]} harvest_months — meses de cosecha (1-12), vacío si no aplica/no hay dato
+ * @property {string} trigger — disparador de la floración (texto corto)
+ * @property {string} region_note — cómo varía por región/altitud (honesto)
+ * @property {string} source — nombres de fuentes públicas
+ * @property {'alta'|'media'|'baja'} confidence
+ */
+
+/** @type {Record<string, PerennialCycle>} */
+export const PERENNIAL_CYCLES = {
+  // ── Frutales arbóreos y arbustivos perennes ──
+  persea_americana: {
+    years_to_first_harvest: [2, 4],
+    productive_life_years: 15,
+    regime: 'unknown',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'patrón injertado y régimen de lluvias',
+    region_note:
+      'El calendario depende fuerte de la localidad y la altitud (1340–2420 msnm, óptimo 1800–2000). Hay fincas que producen casi todo el año. Consulta el patrón de tu zona.',
+    source: 'Agrosavia, Universidad Nacional de Colombia',
+    confidence: 'media',
+  },
+  coffea_arabica: {
+    years_to_first_harvest: [2, 5],
+    productive_life_years: null,
+    regime: 'bimodal',
+    flowering_months: [],
+    harvest_months: [4, 5, 6, 9, 10, 11, 12],
+    trigger: 'días cortos y déficit hídrico tras la temporada seca',
+    region_note:
+      'Dos picos de cosecha al año en buena parte del país (abril–junio y septiembre–diciembre); la fecha exacta cambia con la latitud y la altitud (1200–2200 msnm).',
+    source: 'Cenicafé, Universidad Nacional de Colombia',
+    confidence: 'alta',
+  },
+  theobroma_cacao: {
+    years_to_first_harvest: [2, 5],
+    productive_life_years: null,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [4, 5, 6, 11, 12],
+    trigger: 'estímulos ambientales y la entrada de la temporada seca',
+    region_note:
+      'Produce a lo largo del año con dos picos marcados (abril–junio y noviembre–diciembre). Cultivo de tierras cálidas húmedas (por debajo de 1250 msnm).',
+    source: 'Fedecacao, Agrosavia',
+    confidence: 'alta',
+  },
+  rubus_glaucus: {
+    years_to_first_harvest: [1, 1],
+    productive_life_years: null,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'flujo constante de brotes con buen manejo',
+    region_note:
+      'Recolección casi semanal una vez en plena producción (cerca de los 15 meses). Se cultiva entre 1200 y 3200 msnm.',
+    source: 'Agrosavia',
+    confidence: 'media',
+  },
+  solanum_quitoense: {
+    years_to_first_harvest: [1, 2],
+    productive_life_years: null,
+    regime: 'unknown',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'acumulación térmica; el clima retrasa o adelanta la madurez',
+    region_note:
+      'La recolección inicia cerca del primer año y se sostiene varios meses. El calendario cambia con la altitud (estudiado entre 1800 y 2600 msnm); consulta tu zona.',
+    source: 'Universidad Nacional de Colombia, Agrosavia',
+    confidence: 'media',
+  },
+  solanum_betaceum: {
+    years_to_first_harvest: [1, 2],
+    productive_life_years: 8,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'desarrollo de la planta y clima frío moderado',
+    region_note:
+      'Produce a lo largo del año con recolecciones frecuentes (cada ~20 días); los primeros 5 años son los más productivos. Clima frío moderado andino (16–20 °C).',
+    source: 'Agrosavia',
+    confidence: 'alta',
+  },
+  passiflora_ligularis: {
+    years_to_first_harvest: [1, 2],
+    productive_life_years: null,
+    regime: 'unknown',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'condiciones ambientales; las sequías prolongadas abortan flores',
+    region_note:
+      'Producción sostenida una vez establecida; el calendario varía con el clima y la altitud (1700–2100 msnm). Consulta el comportamiento local.',
+    source: 'Agrosavia, Universidad Nacional de Colombia',
+    confidence: 'alta',
+  },
+  passiflora_tripartita_mollissima: {
+    years_to_first_harvest: [1, 2],
+    productive_life_years: 9,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [6, 7, 8, 12, 1],
+    trigger: 'lluvias bien repartidas durante el año',
+    region_note:
+      'Produce casi a diario una vez establecida, con picos hacia junio–agosto y diciembre–enero. Se da en alturas frías (1800–3500 msnm).',
+    source: 'Agrosavia',
+    confidence: 'alta',
+  },
+  mangifera_indica: {
+    years_to_first_harvest: [3, 5],
+    productive_life_years: null,
+    regime: 'seasonal',
+    flowering_months: [8, 9, 10],
+    harvest_months: [11, 12],
+    trigger: 'temperatura, radiación y estado hídrico del árbol',
+    region_note:
+      'Una temporada marcada al año (floración hacia agosto–octubre y recolección hacia noviembre–diciembre en el Tolima); cambia de fecha según la región.',
+    source: 'Agrosavia',
+    confidence: 'media',
+  },
+  psidium_guajava_manzana: {
+    years_to_first_harvest: [2, 4],
+    productive_life_years: null,
+    regime: 'seasonal',
+    flowering_months: [1, 2, 3, 4],
+    harvest_months: [5, 6, 7],
+    trigger: 'la floración suele seguir al abonado y la poda',
+    region_note:
+      'El árbol cuaja y madura el fruto en unos 4 meses; la floración se concentra hacia comienzos de año en zonas como Santander. Produce del nivel del mar hasta 1800 msnm.',
+    source: 'Agrosavia',
+    confidence: 'media',
+  },
+  acca_sellowiana: {
+    years_to_first_harvest: [2, 3],
+    productive_life_years: 25,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [5, 6, 12, 1],
+    trigger: 'clima fresco; evitar el exceso de nitrógeno',
+    region_note:
+      'Produce buena parte del año en clima de montaña con picos hacia mayo–junio y diciembre–enero. Zonas frías (1800–2700 msnm, óptimo 2100–2600).',
+    source: 'Agrosavia',
+    confidence: 'alta',
+  },
+  passiflora_edulis_flavicarpa: {
+    years_to_first_harvest: [1, 1],
+    productive_life_years: null,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'la entrada de las lluvias',
+    region_note:
+      'Produce de forma cíclica y sostenida durante el ciclo de cultivo (cerca de un año desde la primera cosecha). Clima cálido hasta ~1000 msnm.',
+    source: 'ICA, Universidad Nacional de Colombia',
+    confidence: 'alta',
+  },
+  passiflora_edulis_morada: {
+    years_to_first_harvest: [1, 1],
+    productive_life_years: 5,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'desarrollo de la planta en clima frío moderado',
+    region_note:
+      'Produce a lo largo del año una vez establecida. Se cultiva entre 1400 y 2200 msnm; a mayor altura la producción inicia más tarde y el fruto es más pequeño.',
+    source: 'Agrosavia, UNAD',
+    confidence: 'alta',
+  },
+  physalis_peruviana: {
+    years_to_first_harvest: [1, 1],
+    productive_life_years: null,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'crecimiento continuo de la planta',
+    region_note:
+      'Florece y produce de forma continua tras los primeros meses. Se adapta entre 1800 y 2800 msnm; a mayor altura, el primer pico se retrasa.',
+    source: 'Agrosavia, ICA',
+    confidence: 'alta',
+  },
+  citrus_latifolia: {
+    years_to_first_harvest: [3, 4],
+    productive_life_years: null,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [11, 12, 1, 2, 3],
+    trigger: 'el estrés hídrico de la temporada seca',
+    region_note:
+      'Produce todo el año con un pico hacia noviembre–marzo; en zonas andinas con dos temporadas de lluvia hay floración adicional. Del nivel del mar hasta ~2100 msnm.',
+    source: 'Agrosavia',
+    confidence: 'alta',
+  },
+  citrus_sinensis: {
+    years_to_first_harvest: [3, 5],
+    productive_life_years: null,
+    regime: 'unknown',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'estrés hídrico y temperatura',
+    region_note:
+      'El calendario de floración y producción varía mucho por región y altitud y no hay un dato firme nacional; consulta el comportamiento de tu finca.',
+    source: 'Agrosavia, ICA',
+    confidence: 'baja',
+  },
+  vaccinium_corymbosum_biloxi: {
+    years_to_first_harvest: [2, 3],
+    productive_life_years: 20,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'podas que estimulan nuevos brotes',
+    region_note:
+      'Con manejo de podas produce a lo largo del año en clima frío (potencial entre 2200 y 2900 msnm). Vive más de 20 años en producción.',
+    source: 'ProColBerries',
+    confidence: 'media',
+  },
+  vaccinium_meridionale: {
+    years_to_first_harvest: [3, 5],
+    productive_life_years: null,
+    regime: 'bimodal',
+    flowering_months: [2, 3, 4, 5, 8, 9, 10, 11],
+    harvest_months: [4, 5, 6, 9, 10, 11, 12],
+    trigger: 'humedad relativa y el brote de hojas nuevas',
+    region_note:
+      'Dos temporadas de fructificación al año reportadas en el oriente antioqueño; planta nativa de la zona andina.',
+    source: 'Corantioquia, SciELO Colombia',
+    confidence: 'media',
+  },
+  musa_paradisiaca: {
+    years_to_first_harvest: [1, 2],
+    productive_life_years: null,
+    regime: 'continuous',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'la planta florece sola al madurar; se renueva con los hijos',
+    region_note:
+      'Cada planta da un racimo (floración a los ~10–12 meses, cosecha ~4 meses después) y la mata se renueva con sus hijos, dando producción escalonada todo el año.',
+    source: 'Agrosavia',
+    confidence: 'alta',
+  },
+  ananas_comosus: {
+    years_to_first_harvest: [1, 2],
+    productive_life_years: null,
+    regime: 'unknown',
+    flowering_months: [],
+    harvest_months: [],
+    trigger: 'la floración suele inducirse; el calendario depende del manejo',
+    region_note:
+      'El calendario depende del manejo (inducción de la floración) y de la región (Santander, Meta, Valle, Antioquia, Llanos); no hay un patrón natural fijo que listar.',
+    source: 'Agrosavia',
+    confidence: 'baja',
+  },
+};
+
+const MONTH_NAMES = [
+  'ene', 'feb', 'mar', 'abr', 'may', 'jun',
+  'jul', 'ago', 'sep', 'oct', 'nov', 'dic',
+];
+
+/** Conjunto de regímenes válidos. */
+export const PERENNIAL_REGIMES = ['continuous', 'bimodal', 'seasonal', 'unknown'];
+
+/**
+ * Devuelve el ciclo perenne de una especie por su id de catálogo, o null.
+ * @param {string} speciesId
+ * @returns {PerennialCycle|null}
+ */
+export function getPerennialCycle(speciesId) {
+  if (!speciesId) return null;
+  return PERENNIAL_CYCLES[speciesId] || null;
+}
+
+/**
+ * Indica si una especie tiene ciclo perenne grounded en estos datos.
+ * @param {string} speciesId
+ * @returns {boolean}
+ */
+export function isPerennialSpecies(speciesId) {
+  return !!getPerennialCycle(speciesId);
+}
+
+/**
+ * Nombre corto del mes (1-12) en español, o cadena vacía si está fuera de rango.
+ * @param {number} m
+ * @returns {string}
+ */
+export function monthShortName(m) {
+  if (!Number.isInteger(m) || m < 1 || m > 12) return '';
+  return MONTH_NAMES[m - 1];
+}
+
+/** Lista de ids de especies con ciclo perenne grounded. */
+export function getPerennialSpeciesIds() {
+  return Object.keys(PERENNIAL_CYCLES);
+}

--- a/src/services/perennialCalculator.js
+++ b/src/services/perennialCalculator.js
@@ -1,0 +1,153 @@
+/**
+ * perennialCalculator — resuelve el ciclo HÍBRIDO de una especie perenne.
+ *
+ * A diferencia de phenologyCalculator (ciclo anual siembra → cosecha), un árbol
+ * o arbusto perenne tiene DOS dimensiones que el campesino necesita ver juntas:
+ *
+ *   1. ESTABLECIMIENTO — en qué punto va entre la siembra y la primera cosecha
+ *      (progreso 0–1) y en qué año se espera esa primera cosecha.
+ *   2. CALENDARIO ANUAL recurrente — una vez productiva, qué meses suele
+ *      florecer/cosechar cada año, o si produce de forma casi continua.
+ *
+ * Degradación honesta (nunca rompe):
+ *   - Sin datos perennes para la especie → devuelve null (la UI cae al ciclo
+ *     anual existente, sin inventar nada).
+ *   - Sin fecha de siembra → fase 'productive' por defecto (no podemos calcular
+ *     el establecimiento, pero el calendario anual sigue siendo útil) y el bloque
+ *     `establishment` queda con progreso null.
+ */
+import { getPerennialCycle } from '../data/perennialCycles';
+
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+
+/**
+ * @typedef {Object} PerennialResolution
+ * @property {string} speciesId
+ * @property {'establishment'|'productive'} phase
+ * @property {Object} establishment
+ * @property {number|null} establishment.yearsElapsed — años desde la siembra (null si no hay fecha)
+ * @property {[number, number]} establishment.yearsToFirstHarvest — [min, max]
+ * @property {number|null} establishment.progress — 0–1 hacia la primera cosecha (null si no hay fecha)
+ * @property {number|null} establishment.firstHarvestYear — año calendario estimado de la 1ª cosecha
+ * @property {Object} annual
+ * @property {number} annual.currentMonth — 1–12
+ * @property {boolean} annual.isFlowering — el mes actual está en floración
+ * @property {boolean} annual.isHarvest — el mes actual está en cosecha
+ * @property {'continuous'|'bimodal'|'seasonal'|'unknown'} annual.regime
+ * @property {number[]} annual.floweringMonths
+ * @property {number[]} annual.harvestMonths
+ * @property {number[]} annual.nextHarvestMonths — próximos meses de cosecha desde el mes actual
+ * @property {string} annual.note
+ * @property {number|null} productiveLifeYears
+ * @property {string} source
+ * @property {string} confidence
+ */
+
+const clamp01 = (n) => Math.max(0, Math.min(1, n));
+
+/**
+ * Próximos meses de cosecha a partir del mes actual (recorre el calendario de
+ * forma circular). Devuelve los meses de cosecha ordenados empezando por el más
+ * cercano hacia adelante.
+ *
+ * @param {number[]} harvestMonths — meses 1-12
+ * @param {number} currentMonth — 1-12
+ * @returns {number[]}
+ */
+function computeNextHarvestMonths(harvestMonths, currentMonth) {
+  if (!Array.isArray(harvestMonths) || harvestMonths.length === 0) return [];
+  const sorted = [...new Set(harvestMonths)].filter((m) => m >= 1 && m <= 12).sort((a, b) => a - b);
+  if (sorted.length === 0) return [];
+  const ahead = sorted.filter((m) => m >= currentMonth);
+  const behind = sorted.filter((m) => m < currentMonth);
+  return [...ahead, ...behind];
+}
+
+/**
+ * Texto corto para el campesino según el régimen.
+ * @param {Object} cycle
+ * @returns {string}
+ */
+function regimeNote(cycle) {
+  switch (cycle.regime) {
+    case 'continuous':
+      return cycle.harvest_months.length > 0
+        ? 'Produce casi todo el año, con picos en los meses resaltados.'
+        : 'Produce casi todo el año una vez establecida.';
+    case 'bimodal':
+      return 'Tiene dos temporadas de producción al año.';
+    case 'seasonal':
+      return 'Tiene una temporada de producción marcada al año.';
+    case 'unknown':
+    default:
+      return 'El calendario varía por región y altitud; consulta el comportamiento en tu zona.';
+  }
+}
+
+/**
+ * Resuelve el ciclo híbrido (establecimiento + calendario anual) de una especie.
+ *
+ * @param {Object} input
+ * @param {string} input.speciesId — id de catálogo
+ * @param {number} [input.plantingDate] — timestamp ms de la siembra
+ * @param {number} [input.now] — timestamp ms de referencia (default Date.now())
+ * @returns {PerennialResolution|null}
+ */
+export function resolvePerennialCycle({ speciesId, plantingDate, now } = {}) {
+  const cycle = getPerennialCycle(speciesId);
+  if (!cycle) return null;
+
+  const today = now && now > 0 ? now : Date.now();
+  const currentMonth = new Date(today).getMonth() + 1; // 1-12
+  const [minYears, maxYears] = cycle.years_to_first_harvest;
+
+  // ── Establecimiento ──
+  let yearsElapsed = null;
+  let progress = null;
+  let firstHarvestYear = null;
+  let phase = 'productive';
+
+  const hasPlanting = Number.isFinite(plantingDate) && plantingDate > 0;
+  if (hasPlanting) {
+    yearsElapsed = Math.max(0, (today - plantingDate) / MS_PER_YEAR);
+    // El progreso usa el extremo MÁXIMO del rango para no prometer cosecha antes
+    // de tiempo (conservador: 100% solo cuando seguro ya produce).
+    progress = clamp01(yearsElapsed / maxYears);
+    firstHarvestYear = new Date(plantingDate).getFullYear() + maxYears;
+    // Entra en producción cuando supera el mínimo del rango.
+    phase = yearsElapsed >= minYears ? 'productive' : 'establishment';
+  }
+
+  // ── Calendario anual ──
+  const floweringMonths = Array.isArray(cycle.flowering_months) ? cycle.flowering_months : [];
+  const harvestMonths = Array.isArray(cycle.harvest_months) ? cycle.harvest_months : [];
+  const continuous = cycle.regime === 'continuous';
+
+  const isFlowering = floweringMonths.includes(currentMonth);
+  // En régimen continuo siempre puede haber cosecha; los meses listados son picos.
+  const isHarvest = continuous || harvestMonths.includes(currentMonth);
+
+  return {
+    speciesId,
+    phase,
+    establishment: {
+      yearsElapsed,
+      yearsToFirstHarvest: [minYears, maxYears],
+      progress,
+      firstHarvestYear,
+    },
+    annual: {
+      currentMonth,
+      isFlowering,
+      isHarvest,
+      regime: cycle.regime,
+      floweringMonths,
+      harvestMonths,
+      nextHarvestMonths: computeNextHarvestMonths(harvestMonths, currentMonth),
+      note: regimeNote(cycle),
+    },
+    productiveLifeYears: cycle.productive_life_years,
+    source: cycle.source,
+    confidence: cycle.confidence,
+  };
+}


### PR DESCRIPTION
## Feature
El ciclo anual (siembra → cosecha) no aplica a un frutal/árbol perenne que vive varios años: se siembra una vez y produce año tras año tras un periodo de establecimiento. Este PR agrega el modelo híbrido del ciclo de perennes.

## Cambios
- **`src/data/perennialCycles.js`** — datos por especie: `years_to_first_harvest`, `productive_life_years`, `regime` (continuous/bimodal/seasonal/unknown), `flowering_months`, `harvest_months`, `trigger`, `region_note`, `source`, `confidence`. 20 perennes grounded.
- **`src/services/perennialCalculator.js`** — `resolvePerennialCycle({ speciesId, plantingDate, now })` → fase (establecimiento/producción), progreso 0–1, año estimado de 1ª cosecha y calendario anual (floración/cosecha, próximos meses). Degrada limpio sin fecha o sin datos.
- **`src/components/PerennialCycleView.jsx`** — vista híbrida theme-aware: barra de establecimiento + "1ª cosecha estimada", tira de 12 meses, mensajes según régimen, pie con fuente pública + caveat. Se auto-degrada a `null` si no hay datos perennes.
- **`src/components/CicloDetalle.jsx`** — renderiza la vista perenne para especies perennes; conserva la línea de tiempo anual para no-perennes (no la rompe).
- **`src/data/__tests__/perennialCycles.test.js`** — 41 casos.

## Honestidad (anti-alucinación)
- Especies que producen casi todo el año → `continuous` sin inventar meses (solo picos si hay dato firme).
- Especies sin calendario firme → `unknown` con nota de variación por región/altitud; la UI muestra "el calendario varía por región — consulta local".
- Solo se listan meses cuando hay fuente pública (Agrosavia, Cenicafé, Fedecacao, ICA, Universidad Nacional de Colombia, Corantioquia, ProColBerries, entre otras).

## Tests
- 35 casos nuevos en `perennialCycles.test.js` (estructura de datos + resolver) verde.
- `feedingAndCycleCoverage.test.js` (6 casos) sin cambios, verde — el modelo perenne es una capa aditiva y no altera el conteo del resolver anual.
- `npm run build` limpio · `npx eslint` 0/0 en archivos tocados.

Refs: ciclo perenne pendiente de modelo (cobertura ciclo previa ~39%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)