### PR TITLE
fix(ui): asignar zona al agregar planta y selector de finca visible

### DIFF
--- a/src/components/AssetsDashboard.jsx
+++ b/src/components/AssetsDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { MSG } from '../config/messages.js';
-import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List, Sprout, FlaskConical, Ban, AlertTriangle, Warehouse, Square } from 'lucide-react';
+import { ArrowLeft, Plus, Trash2, RefreshCw, Building2, Leaf, Search, WifiOff, TreePine, Map as MapIcon, List, Sprout, FlaskConical, Ban, AlertTriangle, Warehouse, Square, ChevronDown } from 'lucide-react';
 import useAssetStore from '../store/useAssetStore';
 import { Virtuoso } from 'react-virtuoso';
 import { fetchFromFarmOS } from '../services/apiService';
@@ -313,9 +313,14 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
     setSelectedAsset,
   } = useAssetStore();
 
-  const { activeFincaSlug, getActiveFinca } = useFincaActiveStore();
+  const { activeFincaSlug, getActiveFinca, fincas } = useFincaActiveStore();
   const activeFinca = getActiveFinca();
   const fincaNombre = activeFinca.nombre;
+  // BUG #10 (2026-06-21, steve, multi-finca): con 2+ fincas el "cambiar de
+  // finca" no se hallaba — la píldora mostraba el nombre pero sin affordance
+  // de selector. hasMultipleFincas activa el chevron + texto "cambiar" para
+  // que sea claramente un conmutador. Con una sola finca queda como indicador.
+  const hasMultipleFincas = fincas.length > 1;
 
   const { request: requestGeo } = useGeolocation();
 
@@ -386,6 +391,25 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- formData.parentLandId es state, incluirlo causaría loop
   }, [showForm, currentZoneId]);
+
+  // BUG #7 (2026-06-21, flujo core david/campesino): al agregar una planta
+  // TODAS caían en "Sin zona asignada" porque el alta no auto-asignaba zona
+  // cuando la finca tiene una sola. Fix: si el form está abierto en tab plant,
+  // no hay zona elegida aún y la finca tiene EXACTAMENTE una zona registrada,
+  // auto-asignarla — el campesino con una sola chagra no tiene que elegir nada.
+  // Si tiene varias, el selector (renderPlantForm) sigue pidiendo cuál.
+  useEffect(() => {
+    if (!showForm || activeTab !== 'plant') return;
+    if (formData.parentLandId) return; // ya hay zona (manual, currentZone o GPS)
+    if (lands.length === 1) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- sincronización de estado derivado, no afecta render actual
+      setFormData((prev) => {
+        if (prev.parentLandId) return prev; // race con otro efecto: no pisar
+        return { ...prev, parentLandId: lands[0].id };
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- formData.parentLandId es state, incluirlo causaría loop
+  }, [showForm, activeTab, lands]);
 
   // Estado local del formulario de cosecha scoped por asset.id
   const [activeHarvestId, setActiveHarvestId] = useState(null);
@@ -916,18 +940,22 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
   // Render del formulario específico para el tab de plantas
   const renderPlantForm = () => (
     <>
-      {/* Selector obligatorio de zona contenedora (Fase 17) */}
+      {/* Selector de zona contenedora (Fase 17 · BUG #7 2026-06-21).
+          Antes "Zona contenedora *" obligatoria y vacía por defecto: si el
+          campesino no elegía, la planta caía silenciosa en "Sin zona asignada".
+          Ahora: lenguaje campesino, auto-asigna si la finca tiene una sola zona
+          (ver efecto arriba) y ofrece "Sin zona por ahora" como elección
+          EXPLÍCITA (reasignable después desde la tarjeta de huérfanas). */}
       <div>
-        <label className="block text-xs text-slate-500 font-bold uppercase tracking-wider mb-1">
-          Zona contenedora *
+        <label htmlFor="plant-zone-select" className="block text-xs text-slate-500 font-bold uppercase tracking-wider mb-1">
+          ¿En qué lote o zona va?
         </label>
         <select
-          required
+          id="plant-zone-select"
           value={formData.parentLandId || ''}
           onChange={(e) => setFormData({ ...formData, parentLandId: e.target.value })}
           className="w-full p-3 rounded-xl bg-slate-800 border border-slate-700 text-white min-h-[48px] focus:ring-lime-500 focus:border-lime-500"
         >
-          <option value="" disabled>Seleccione una zona...</option>
           {lands.map((land) => {
             const subType = land.attributes?.land_type || land.attributes?.sub_type || 'zona';
             const lname = land.attributes?.name || land.name || 'Sin nombre';
@@ -937,12 +965,19 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
               </option>
             );
           })}
+          {/* Elección explícita: sin zona aún. parentLandId vacío → la planta
+              entra a la tarjeta "Sin zona asignada" y se reasigna luego. */}
+          <option value="">Sin zona por ahora (la asigno después)</option>
         </select>
-        {lands.length === 0 && (
+        {lands.length === 0 ? (
           <p className="mt-1 text-xs text-amber-400">
-            No hay zonas registradas. Cree primero un activo tipo "Infraestructura" (ej. invernadero) o sincronice con FarmOS.
+            Todavía no tienes lotes ni zonas. Puedes guardar la planta sin zona y asignarla luego, o crear una zona desde la pestaña "Zonas".
           </p>
-        )}
+        ) : !formData.parentLandId ? (
+          <p className="mt-1 text-xs text-amber-400/80">
+            Quedará en "Sin zona asignada". La podrás mover a un lote cuando quieras.
+          </p>
+        ) : null}
       </div>
 
       {/* Selector de especie con fuzzy search + autocompletado (Fase 17) */}
@@ -1414,10 +1449,13 @@ export default function AssetsDashboard({ onBack, initialTab, initialShowForm = 
             type="button"
             onClick={() => setShowFincaModal(true)}
             className="flex items-center gap-1.5 text-[10px] font-bold uppercase text-emerald-400 bg-emerald-900/30 border border-emerald-700/40 rounded-full px-3 py-1.5 shrink-0 hover:bg-emerald-900/50 transition-all active:scale-95 group"
-            aria-label={`Finca activa: ${fincaNombre}`}
+            aria-label={hasMultipleFincas ? `Cambiar de finca (actual: ${fincaNombre})` : `Finca activa: ${fincaNombre}`}
           >
             <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse group-hover:scale-125 transition-transform"></div>
-            {fincaNombre}
+            <span className="truncate max-w-[10ch]">{fincaNombre}</span>
+            {hasMultipleFincas && (
+              <ChevronDown size={12} aria-hidden="true" className="-mr-0.5 opacity-80 group-hover:translate-y-0.5 transition-transform" />
+            )}
           </button>
           <button onClick={handleRefresh} disabled={isLoading} aria-label="Sincronizar activos" className="p-2 bg-slate-800 rounded-lg active:bg-slate-700 disabled:opacity-50 min-h-[40px] min-w-[40px] flex items-center justify-center">
             <RefreshCw size={16} aria-hidden="true" className={isLoading ? 'motion-safe:animate-spin' : ''} />

--- a/src/components/MultiFincaModal.jsx
+++ b/src/components/MultiFincaModal.jsx
@@ -9,7 +9,7 @@ export default function MultiFincaModal({ onClose }) {
     const [viewMode, setViewMode] = useState('globe');
     const [showOnboarding, setShowOnboarding] = useState(false);
     const [selectedFinca, setSelectedFinca] = useState(null);
-    const { setFincas, fincas } = useFincaActiveStore();
+    const { setFincas, fincas, setActiveFincaManual } = useFincaActiveStore();
 
     useEffect(() => {
         const loadFincas = async () => {
@@ -33,6 +33,11 @@ export default function MultiFincaModal({ onClose }) {
             setSelectedFinca(finca);
             setShowOnboarding(true);
         } else {
+            // BUG #10 (2026-06-21): desde la vista de Cards "Entrar a la finca"
+            // solo cerraba el modal SIN cambiar la finca activa (el globo sí
+            // llamaba setActiveFinca, las cards no). Ahora ambos caminos
+            // conmutan la finca activa de forma explícita (manual = override GPS).
+            if (finca.slug) setActiveFincaManual(finca.slug);
             onClose();
         }
     };

--- a/src/components/__tests__/AssetsDashboard.mount.test.jsx
+++ b/src/components/__tests__/AssetsDashboard.mount.test.jsx
@@ -54,6 +54,8 @@ vi.mock('../../services/fincaActiveStore', () => {
   const useFincaActiveStore = () => ({
     activeFincaSlug: 'guatoc',
     getActiveFinca: () => ({ slug: 'guatoc', nombre: 'Guatoc' }),
+    fincas: [{ slug: 'guatoc', nombre: 'Guatoc' }],
+    setActiveFincaManual: vi.fn(),
   });
   return { useFincaActiveStore, default: useFincaActiveStore };
 });

--- a/src/components/__tests__/AssetsDashboard.zonaYfinca.test.jsx
+++ b/src/components/__tests__/AssetsDashboard.zonaYfinca.test.jsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * BUG #7 (flujo core david/campesino — agregar planta) + BUG #10 (steve —
+ * cambiar de finca con 2 fincas), hallados por el test integral 2026-06-21.
+ *
+ * BUG #7: al agregar una planta TODAS caían en "Sin zona asignada" porque el
+ *   alta no auto-asignaba zona. Fix: si la finca tiene UNA sola zona, se
+ *   auto-asigna al abrir el form; si tiene varias, el selector pide cuál;
+ *   "Sin zona por ahora" pasa a ser una elección explícita.
+ *
+ * BUG #10: con 2+ fincas el conmutador de finca no se hallaba (la píldora
+ *   mostraba el nombre sin affordance de selector). Fix: chevron + aria-label
+ *   "Cambiar de finca" cuando hay más de una finca.
+ *
+ * Estos tests montan el componente real y verifican el comportamiento.
+ */
+
+vi.mock('../../hooks/useGeolocation', () => ({
+  useGeolocation: () => ({ request: vi.fn() }),
+}));
+vi.mock('../../hooks/usePhotoUrl', () => ({
+  usePhotoUrl: () => ({ loading: false, url: null }),
+  default: () => ({ loading: false, url: null }),
+}));
+vi.mock('../../services/voiceRagEnricher', () => ({
+  enrichEntity: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../services/apiService', () => ({
+  fetchFromFarmOS: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../../db/catalogDB', () => ({
+  findBiopreparadosByIngredient: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../SpeciesSelect', () => ({ default: () => <div data-testid="species-select-stub" /> }));
+vi.mock('../GuildSuggestions', () => ({ default: () => null }));
+vi.mock('../MapPicker', () => ({ default: () => null }));
+vi.mock('../FarmMap', () => ({ default: () => null }));
+vi.mock('../AssetDetailView', () => ({ default: () => null, AssetDetailView: () => null }));
+vi.mock('../BiopreparadoSuggestionModal', () => ({ default: () => null }));
+vi.mock('../MultiFincaModal', () => ({ default: () => null }));
+
+// Finca activa configurable por test (1 o 2 fincas) para BUG #10.
+const fincaState = {
+  activeFincaSlug: 'guatoc',
+  getActiveFinca: () => ({ slug: 'guatoc', nombre: 'Guatoc' }),
+  fincas: [{ slug: 'guatoc', nombre: 'Guatoc' }],
+  setActiveFincaManual: vi.fn(),
+};
+vi.mock('../../services/fincaActiveStore', () => {
+  const useFincaActiveStore = () => fincaState;
+  return { useFincaActiveStore, default: useFincaActiveStore };
+});
+
+// Asset store mutable. addAsset captura el payload para inspeccionar la zona.
+const addAsset = vi.fn();
+const mockAssetState = {
+  plants: [],
+  structures: [],
+  equipment: [],
+  materials: [],
+  lands: [],
+  isLoading: false,
+  error: null,
+  hydrate: vi.fn().mockResolvedValue(undefined),
+  syncFromServer: vi.fn(),
+  addAsset,
+  addAssetsBulk: vi.fn(),
+  removeAsset: vi.fn(),
+  addHarvestLog: vi.fn(),
+  setSelectedAsset: vi.fn(),
+};
+vi.mock('../../store/useAssetStore', () => ({
+  default: () => mockAssetState,
+}));
+
+import AssetsDashboard from '../AssetsDashboard';
+
+beforeEach(() => {
+  // El form persiste la zona pre-elegida en localStorage (PENDING_FORM_ZONE_KEY)
+  // para no re-pedirla al agregar varias plantas seguidas. Sin limpiar, un test
+  // contamina la zona inicial del siguiente.
+  localStorage.clear();
+  mockAssetState.plants = [];
+  mockAssetState.lands = [];
+  addAsset.mockClear();
+  fincaState.setActiveFincaManual.mockClear();
+  fincaState.fincas = [{ slug: 'guatoc', nombre: 'Guatoc' }];
+});
+
+describe('BUG #7 — auto-asignar zona al agregar planta', () => {
+  it('si la finca tiene UNA sola zona, el selector la deja seleccionada (no vacía)', () => {
+    mockAssetState.lands = [
+      { id: 'land-uno', attributes: { name: 'Lote del Río', land_type: 'lote' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="plant" initialShowForm />);
+    const select = screen.getByLabelText('¿En qué lote o zona va?');
+    // El efecto de auto-asignación deja parentLandId = land-uno → opción
+    // seleccionada NO es la de "Sin zona por ahora" (value vacío).
+    expect(select.value).toBe('land-uno');
+  });
+
+  it('ofrece la elección explícita "Sin zona por ahora"', () => {
+    mockAssetState.lands = [
+      { id: 'land-uno', attributes: { name: 'Lote del Río', land_type: 'lote' } },
+      { id: 'land-dos', attributes: { name: 'Huerta', land_type: 'huerta' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="plant" initialShowForm />);
+    expect(screen.getByText(/Sin zona por ahora/i)).toBeTruthy();
+  });
+
+  it('con varias zonas NO auto-asigna: el campesino debe elegir el lote', () => {
+    mockAssetState.lands = [
+      { id: 'land-uno', attributes: { name: 'Lote del Río', land_type: 'lote' } },
+      { id: 'land-dos', attributes: { name: 'Huerta', land_type: 'huerta' } },
+    ];
+    render(<AssetsDashboard onBack={() => {}} initialTab="plant" initialShowForm />);
+    const select = screen.getByLabelText('¿En qué lote o zona va?');
+    // Sin zona elegida aún → cae a la opción vacía "Sin zona por ahora".
+    expect(select.value).toBe('');
+  });
+});
+
+describe('BUG #10 — affordance clara para cambiar de finca', () => {
+  it('con 2 fincas, el botón de finca activa es un conmutador accesible', () => {
+    fincaState.fincas = [
+      { slug: 'guatoc', nombre: 'Guatoc' },
+      { slug: 'la-esperanza', nombre: 'La Esperanza' },
+    ];
+    render(<AssetsDashboard onBack={() => {}} />);
+    // aria-label "Cambiar de finca" hace el conmutador hallable por affordance.
+    expect(screen.getByLabelText(/Cambiar de finca/i)).toBeTruthy();
+  });
+
+  it('con 1 sola finca, el botón es indicador (no anuncia cambio)', () => {
+    fincaState.fincas = [{ slug: 'guatoc', nombre: 'Guatoc' }];
+    render(<AssetsDashboard onBack={() => {}} />);
+    expect(screen.queryByLabelText(/Cambiar de finca/i)).toBeNull();
+    expect(screen.getByLabelText(/Finca activa: Guatoc/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Bug / Feature
Dos bugs UX hallados por el test integral 2026-06-21.

## Causa raíz
- **BUG #7 (MEDIA, flujo core david/campesino):** al agregar una planta, TODAS caían en "Sin zona asignada" porque el alta no auto-asignaba zona aunque la finca tuviera una sola. El selector existía pero arrancaba vacío y obligatorio; sin GPS ni zona en contexto, el campesino caía a una planta huérfana silenciosamente.
- **BUG #10 (BAJA, steve):** con 2+ fincas, el conmutador no se hallaba. La píldora de finca activa mostraba el nombre pero sin affordance de selector. Además, "Entrar a la finca" desde la vista de cards solo cerraba el modal SIN cambiar la finca activa (solo el globo conmutaba).

## Cambios
- `src/components/AssetsDashboard.jsx`:
  - Nuevo efecto: si el form de planta está abierto, no hay zona elegida y la finca tiene EXACTAMENTE una zona, se auto-asigna.
  - Selector de zona con lenguaje campesino ("¿En qué lote o zona va?"), opción explícita "Sin zona por ahora (la asigno después)" y texto de ayuda. `label`/`select` asociados (`htmlFor`/`id`) para accesibilidad.
  - Píldora de finca activa: chevron + `aria-label` "Cambiar de finca" cuando hay 2+ fincas; queda como indicador con 1 sola.
- `src/components/MultiFincaModal.jsx`: `handleSelect` ahora llama `setActiveFincaManual(slug)` para fincas con endpoint (antes solo cerraba) — el conmutador funciona desde cards y globo.
- Tests: nuevo `AssetsDashboard.zonaYfinca.test.jsx` (auto-asignación con 1 zona, no auto-asignación con varias, opción "sin zona", affordance de cambio de finca con 1 vs 2 fincas). `AssetsDashboard.mount.test.jsx` actualizado al nuevo shape del store.

## Tests
- 5 casos nuevos en `AssetsDashboard.zonaYfinca.test.jsx` passing.
- Suite de los componentes tocados verde (`AssetsDashboard.*`, urbanForm, mount).
- `npm run build` limpio; `npx eslint --quiet` 0 errores; 0 warnings nuevos (los warnings i18n restantes son PRE-EXISTENTES, migración ADR-050 progresiva).

Refs: test integral 2026-06-21 (BUG #7 david/campesino, BUG #10 steve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)