### PR TITLE
feat(agent): cablear /biopreparado-grounding del sidecar al flujo del agente PWA

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -45,7 +45,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, postValidate, getClimaIdeam } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, postValidate, getClimaIdeam } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -797,7 +797,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // formatToolEvidence y analyzeQuery viven en agentPromptBase (funciones
   // puras, testeables y medibles fuera de React).
 
-  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '') => {
+  const callLLM = async (query, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities = null, fermentoBlock = '', subgrafoBloque = '', biopreparadoBlock = '') => {
     const analysis = analyzeQuery(query);
     // El base recibe query/historial/isEnum para inyectar SOLO los glosarios
     // y reglas condicionales que la conversación toca (re-arquitectura GR-10).
@@ -988,6 +988,19 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       ? `\n\n${fermentoBlock}`
       : '';
 
+    // BIOPREPARADOS (capa 1 GROUNDING, chagra-pro #248). El sidecar
+    // /biopreparado-grounding ya resolvió contra el catálogo MCP si la query
+    // toca un biopreparado real (caldo bordelés, etc.) y armó el bloque con su
+    // composición/uso curados + la regla anti-negación ("NUNCA digas que este
+    // insumo no existe") — FAIL-SAFE: si el MCP está caído NO fabrica datos.
+    // Llega pre-formateado (system_prompt_block) y va de ÚLTIMO (recency máxima,
+    // junto a fermento) para dominar la respuesta y evitar que el agente niegue
+    // insumos que sí existen. '' (no-op) cuando no hubo intención-biopreparado o
+    // el sidecar no respondió (degradación graceful — no rompe el turno).
+    const biopreparadoSafetyBlock = (typeof biopreparadoBlock === 'string' && biopreparadoBlock.trim())
+      ? `\n\n${biopreparadoBlock}`
+      : '';
+
     // Re-arquitectura GR-10: ensamblado con PRESUPUESTO de tokens y prioridad
     // por relevancia (promptAssembler). El grounding (evidencia / entidades /
     // hechos curados / cadena) va al FINAL del system — donde la truncación de
@@ -1016,6 +1029,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       suggested: suggestedBlock,
       priceDecline: priceDeclineBlock,
       fermento: fermentoSafetyBlock,
+      biopreparado: biopreparadoSafetyBlock,
     });
 
     const messages = [
@@ -1306,6 +1320,12 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
       // por default → no-op en el system prompt si no hubo intención-fermento o
       // el sidecar no respondió (degradación graceful).
       let fermentoBlock = '';
+      // BIOPREPARADOS (capa 1 GROUNDING, chagra-pro #248). Bloque de instrucción
+      // ya formateado por el sidecar (/biopreparado-grounding) con la composición/
+      // uso del catálogo + regla anti-negación. '' por default → no-op en el
+      // system prompt si no hubo intención-biopreparado o el sidecar no respondió
+      // (degradación graceful — FAIL-SAFE, no fabrica datos).
+      let biopreparadoBlock = '';
       // GraphRAG multi-hop (#1 intelligence-first): bloque "CADENA DE RELACIONES"
       // del grafo AGE para queries relacionales (plaga+cultivo). '' = no-op.
       let subgrafoBloque = '';
@@ -1321,13 +1341,15 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             return (fincaActiva && fincaActiva.altitud) || null;
           })();
           const tRE0 = performance.now();
-          // SAFETY-CRITICAL en PARALELO: /fermento-prefilter corre junto a
-          // /resolve-entities (mismo turno, antes del LLM) — CERO latencia
-          // serial añadida. Ambos wrappers son no-throw (devuelven null en
-          // error/timeout), así que Promise.all no puede rechazar por ellos.
-          const [resolved, fermento] = await Promise.all([
+          // SAFETY-CRITICAL en PARALELO: /fermento-prefilter y
+          // /biopreparado-grounding corren junto a /resolve-entities (mismo turno,
+          // antes del LLM) — CERO latencia serial añadida. Los tres wrappers son
+          // no-throw (devuelven null en error/timeout), así que Promise.all no
+          // puede rechazar por ellos.
+          const [resolved, fermento, biopreparado] = await Promise.all([
             resolveEntities(textForLLM, { fincaAltitud: reAltitud, context: contextMemory }),
             fermentoPrefilter(textForLLM),
+            biopreparadoGrounding(textForLLM),
           ]);
           const tRE1 = performance.now();
           // FERMENTOS: si el sidecar marcó intención-fermento, inyectamos su
@@ -1343,6 +1365,18 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               disclaimerFuerte: fermento.disclaimer_fuerte,
               fuenteAutoridad: fermento.fuente_autoridad,
               reason: fermento.reason,
+            });
+          }
+          // BIOPREPARADOS: si el sidecar resolvió un biopreparado real contra el
+          // catálogo MCP, inyectamos su bloque (composición/uso + anti-negación)
+          // al final del system prompt (recency máxima). Si el sidecar no
+          // respondió (null) o no hay biopreparado, biopreparadoBlock queda '' →
+          // no-op, el turno sigue sin romperse (degradación graceful, FAIL-SAFE).
+          if (biopreparado && biopreparado.has_biopreparado && typeof biopreparado.system_prompt_block === 'string' && biopreparado.system_prompt_block.trim()) {
+            biopreparadoBlock = biopreparado.system_prompt_block;
+            console.debug('[sidecar] biopreparado-grounding', {
+              biopreparadoId: biopreparado.biopreparado_id,
+              reason: biopreparado.reason,
             });
           }
           if (resolved && Array.isArray(resolved.entities) && resolved.entities.length > 0) {
@@ -1794,7 +1828,7 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         }
       }
 
-      const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, subgrafoBloque);
+      const rawResponse = await callLLM(textForLLM, contextMemory, contextCorpus, toolEvidence, resolvedEntities, suggestedEntities, fermentoBlock, subgrafoBloque, biopreparadoBlock);
       // Fallback estructurado (Item 9): si el LLM retornó vacío (timeout, OOM,
       // modelo caído), construimos una respuesta útil con lo que sabemos
       // (toolEvidence, entidades) en vez de un silencio o banner rojo.

--- a/src/services/__tests__/sidecarClient.test.js
+++ b/src/services/__tests__/sidecarClient.test.js
@@ -619,6 +619,101 @@ describe('sidecarClient — feature flag on', () => {
       expect(res).toBeNull();
     });
   });
+
+  describe('biopreparadoGrounding — capa 1 GROUNDING (#248)', () => {
+    const BIOPREPARADO_HIT = {
+      has_biopreparado: true,
+      biopreparado_id: 'caldo-bordeles',
+      system_prompt_block:
+        '=== BIOPREPARADO REAL DEL CATÁLOGO — caldo bordelés ===\n' +
+        'Composición: sulfato de cobre + cal. Uso: fungicida foliar.\n' +
+        'NUNCA digas que este insumo no existe.\n' +
+        '=== FIN BIOPREPARADO ===',
+      reason: 'biopreparado_resolved',
+    };
+
+    const NO_BIOPREPARADO = {
+      has_biopreparado: false,
+      biopreparado_id: null,
+      system_prompt_block: '',
+      reason: 'no_biopreparado_intent',
+    };
+
+    it('query de BIOPREPARADO → inyecta el system_prompt_block del sidecar', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, BIOPREPARADO_HIT));
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('cómo preparo caldo bordelés');
+      expect(res).not.toBeNull();
+      expect(res.has_biopreparado).toBe(true);
+      expect(res.biopreparado_id).toBe('caldo-bordeles');
+      expect(res.system_prompt_block).toContain('NUNCA digas que este insumo no existe');
+      // POST con user_message a /biopreparado-grounding (mismo contrato que /fermento-prefilter).
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('/api/mcp/agro/biopreparado-grounding');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['X-Chagra-Token']).toBe('test-token-123');
+      expect(JSON.parse(opts.body)).toEqual({ user_message: 'cómo preparo caldo bordelés' });
+    });
+
+    it('query SIN biopreparado → has_biopreparado false + bloque vacío (no se inyecta nada)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, NO_BIOPREPARADO));
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('¿a cómo está la papa?');
+      expect(res).not.toBeNull();
+      expect(res.has_biopreparado).toBe(false);
+      expect(res.system_prompt_block).toBe('');
+      expect(res.biopreparado_id).toBeNull();
+    });
+
+    it('normaliza un body parcial del sidecar a la forma contractual (defensivo)', async () => {
+      // Sidecar viejo / respuesta incompleta: campos faltantes → defaults seguros.
+      fetchMock.mockResolvedValueOnce(jsonResponse(200, { has_biopreparado: true, system_prompt_block: 'X' }));
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('cómo hago purín de ortiga');
+      expect(res.has_biopreparado).toBe(true);
+      expect(res.system_prompt_block).toBe('X');
+      expect(res.biopreparado_id).toBeNull();
+      expect(res.reason).toBe('');
+    });
+
+    it('devuelve null sin fetch cuando flag off (degradación graceful)', async () => {
+      disableFlag();
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('cómo preparo caldo bordelés');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando offline', async () => {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('cómo preparo caldo bordelés');
+      expect(res).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('devuelve null sin fetch cuando userMessage vacío/no-string', async () => {
+      const { biopreparadoGrounding } = await importFresh();
+      expect(await biopreparadoGrounding('')).toBeNull();
+      expect(await biopreparadoGrounding(null)).toBeNull();
+      expect(await biopreparadoGrounding(undefined)).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('5xx → null sin throw (MCP caído, FAIL-SAFE: no rompe el turno ni fabrica datos)', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse(503, { error: 'mcp down' }));
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('cómo preparo caldo bordelés');
+      expect(res).toBeNull();
+    });
+
+    it('fetch throws → null sin throw', async () => {
+      fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      const { biopreparadoGrounding } = await importFresh();
+      const res = await biopreparadoGrounding('cómo preparo caldo bordelés');
+      expect(res).toBeNull();
+    });
+  });
 });
 
 describe('sidecarClient — getClimaSnapshot elevation (gradiente térmico)', () => {

--- a/src/services/promptAssembler.js
+++ b/src/services/promptAssembler.js
@@ -88,6 +88,7 @@ export const BLOCK_ORDER = [
   'suggested', // GUARDA CASO B baja confianza (protegido)
   'priceDecline', // GUARDA precio sin dato (protegido)
   'fermento', // GUARDA DR-FOOD-3 (protegido, máxima recency)
+  'biopreparado', // GROUNDING biopreparados chagra-pro #248 (protegido, máxima recency — anti-negación)
 ];
 
 /**

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -447,6 +447,38 @@ export async function fermentoPrefilter(userMessage) {
 }
 
 /**
+ * Capa 1 GROUNDING de BIOPREPARADOS (chagra-pro #248). Espejo exacto de
+ * `fermentoPrefilter`: llama `POST ${BASE}/biopreparado-grounding` con
+ * `{ user_message }` para que el sidecar resuelva, contra el catálogo MCP, si la
+ * query toca un biopreparado real (p.ej. caldo bordelés) y devuelva un bloque de
+ * system prompt con su composición/uso curados + la regla anti-negación
+ * ("NUNCA digas que este insumo no existe"). FAIL-SAFE: ante MCP caído el sidecar
+ * NO fabrica datos; este wrapper, además, es no-throw (devuelve null en
+ * flag off / offline / timeout / 5xx / error de red), así que el caller degrada
+ * con gracia (no inyecta bloque, no rompe el turno). Cuando `has_biopreparado`
+ * es false, NO hay que inyectar nada.
+ *
+ * @param {string} userMessage — texto del operador.
+ * @returns {Promise<null | {
+ *   has_biopreparado: boolean,
+ *   biopreparado_id: string | null,
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function biopreparadoGrounding(userMessage) {
+  if (!userMessage || typeof userMessage !== 'string') return null;
+  const raw = await postJson('/biopreparado-grounding', { user_message: userMessage }, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    has_biopreparado: raw.has_biopreparado === true,
+    biopreparado_id: typeof raw.biopreparado_id === 'string' ? raw.biopreparado_id : null,
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
  * Capa 2 anti-alucinación (cross-check de contexto). Llama
  * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
  * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno


### PR DESCRIPTION
## Feature
Cablear el endpoint `POST /biopreparado-grounding` del sidecar (chagra-pro #248, ya en prod) dentro del flujo del agente del PWA, como ESPEJO EXACTO de `/fermento-prefilter`.

## Causa raíz
El PWA no llamaba `/biopreparado-grounding`, así que el agente a veces NEGABA insumos reales del catálogo (p.ej. caldo bordelés). El sidecar ya devuelve un `system_prompt_block` con composición/uso curados del catálogo + la regla anti-negación ("NUNCA digas que este insumo no existe"), pero el PWA nunca lo inyectaba al system prompt.

## Cambios
- `src/services/sidecarClient.js`: nuevo wrapper `biopreparadoGrounding(userMessage)` → `postJson('/biopreparado-grounding', {user_message}, NLU_TIMEOUT_MS)`. No-throw, devuelve `null` en flag off / offline / timeout / 5xx / error de red. Normaliza el body a `{has_biopreparado, biopreparado_id, system_prompt_block, reason}` (mismo estilo defensivo que `fermentoPrefilter`).
- `src/components/AgentScreen/AgentScreen.jsx`:
  - Importa `biopreparadoGrounding` junto a `fermentoPrefilter`.
  - `let biopreparadoBlock = '';` en el flujo del turno.
  - Añade `biopreparadoGrounding(textForLLM)` al MISMO `Promise.all` que `resolveEntities` + `fermentoPrefilter` (paralelo, cero latencia serial; no-throw).
  - Si `bio && bio.has_biopreparado && bio.system_prompt_block.trim()` → `biopreparadoBlock = bio.system_prompt_block` (+ `console.debug` como el de fermento).
  - Inyecta `biopreparadoSafetyBlock` en el MISMO `assembleSystemContent({...})` donde se inyecta `fermento: fermentoSafetyBlock`, como clave `biopreparado`. Si no hay intención → '' → no-op (degradación graceful).
  - Pasa `biopreparadoBlock` como argumento a `callLLM(...)`.
- `src/services/promptAssembler.js`: añade `'biopreparado'` a `BLOCK_ORDER` justo después de `'fermento'` (protegido, máxima recency — no sacrificable bajo presión de presupuesto).

## Tests
- 8 casos vitest nuevos para `biopreparadoGrounding` en `sidecarClient.test.js` (espejo de los de `fermentoPrefilter`): hit inyecta bloque + valida URL/método/token/body, sin-hit → bloque vacío, normalización defensiva de body parcial, flag off / offline / userMessage vacío → null sin fetch, 5xx → null sin throw, fetch throws → null sin throw.
- Suite `sidecarClient.test.js` + `promptAssembler.test.js`: 71/71 passing.
- `npm run build`: limpio.

Nota CI: el lint local de `AgentScreen.jsx` (archivo muy grande) hace OOM en la máquina de desarrollo; verificado a mano que las adiciones no introducen `no-undef` ni `no-unused-vars` y el build resuelve todos los símbolos. El eslint de CI corre con recursos suficientes.

Refs: chagra-pro #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)