### PR TITLE
feat(agente): PWA inyecta grounding determinista de biopreparados (caldo bordelés)

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -45,7 +45,7 @@ import { createStreamDeadline } from '../../services/streamDeadline';
 // Sidecar agro-mcp (ADR-045 Fase 2 Step B/C). Detrás de feature flag
 // `VITE_USE_SIDECAR_AGRO_MCP` — con flag off, las funciones devuelven null
 // y el AgentScreen se comporta idéntico al pipeline RAG-only previo.
-import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, postValidate, getClimaIdeam } from '../../services/sidecarClient';
+import { isSidecarEnabled, planNlu, callTool, executeToolChain, resolveEntities, fermentoPrefilter, biopreparadoGrounding, postValidate, getClimaIdeam } from '../../services/sidecarClient';
 // CHIPS DE MODO (A3/A4, decisión operador 2026-06-02): el router PURO mapea
 // la intención forzada del chip → tool determinístico, SALTANDO el NLU
 // (que misroutea). `planForcedIntent` decide tool+args; `isStubIntent` marca
@@ -1325,9 +1325,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           // /resolve-entities (mismo turno, antes del LLM) — CERO latencia
           // serial añadida. Ambos wrappers son no-throw (devuelven null en
           // error/timeout), así que Promise.all no puede rechazar por ellos.
-          const [resolved, fermento] = await Promise.all([
+          const [resolved, fermento, bioprep] = await Promise.all([
             resolveEntities(textForLLM, { fincaAltitud: reAltitud, context: contextMemory }),
             fermentoPrefilter(textForLLM),
+            biopreparadoGrounding(textForLLM),
           ]);
           const tRE1 = performance.now();
           // FERMENTOS: si el sidecar marcó intención-fermento, inyectamos su
@@ -1343,6 +1344,22 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               disclaimerFuerte: fermento.disclaimer_fuerte,
               fuenteAutoridad: fermento.fuente_autoridad,
               reason: fermento.reason,
+            });
+          }
+          // BIOPREPARADOS (grounding determinista, chagra-pro #248): si el
+          // sidecar resolvió un insumo del catálogo (caldo bordelés, supermagro,
+          // bocashi…), anexamos su bloque de datos VERIFICADOS + regla
+          // anti-negación al MISMO canal de bloques de seguridad/grounding (al
+          // final del system, recency máxima) para que el LLM NO pueda negar un
+          // insumo que sí existe. no-op (graceful) si no aplica o el sidecar no
+          // respondió.
+          if (bioprep && bioprep.has_biopreparado && typeof bioprep.system_prompt_block === 'string' && bioprep.system_prompt_block.trim()) {
+            fermentoBlock = fermentoBlock
+              ? `${fermentoBlock}\n\n${bioprep.system_prompt_block}`
+              : bioprep.system_prompt_block;
+            console.debug('[sidecar] biopreparado-grounding', {
+              biopreparadoId: bioprep.biopreparado_id,
+              reason: bioprep.reason,
             });
           }
           if (resolved && Array.isArray(resolved.entities) && resolved.entities.length > 0) {

--- a/src/services/sidecarClient.js
+++ b/src/services/sidecarClient.js
@@ -447,6 +447,40 @@ export async function fermentoPrefilter(userMessage) {
 }
 
 /**
+ * Grounding DETERMINISTA de BIOPREPARADOS/insumos (chagra-pro #248). Llama
+ * `POST ${BASE}/biopreparado-grounding` con la query del usuario; el sidecar
+ * detecta el insumo nombrado (caldo bordelés, supermagro, bocashi, biol…),
+ * resuelve la entrada del catálogo vía get_biopreparados y devuelve un bloque
+ * con composición/uso/precauciones VERIFICADOS + regla inviolable anti-negación
+ * ("NUNCA afirmes que este insumo no existe o no está en el catálogo").
+ *
+ * Se invoca EN PARALELO con resolveEntities/fermentoPrefilter (mismo turno,
+ * antes del LLM) — espejo de fermentoPrefilter, CERO latencia serial. FAIL-SAFE:
+ * ante MCP caído NO fabrica datos (has_biopreparado=false). NUNCA throw: null si
+ * flag off / offline / timeout / non-2xx / body inválido → el caller degrada sin
+ * inyectar (no rompe el turno).
+ *
+ * @param {string} userMessage — texto del operador.
+ * @returns {Promise<null | {
+ *   has_biopreparado: boolean,
+ *   biopreparado_id: string | null,
+ *   system_prompt_block: string,
+ *   reason: string,
+ * }>}
+ */
+export async function biopreparadoGrounding(userMessage) {
+  if (!userMessage || typeof userMessage !== 'string') return null;
+  const raw = await postJson('/biopreparado-grounding', { user_message: userMessage }, NLU_TIMEOUT_MS);
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    has_biopreparado: raw.has_biopreparado === true,
+    biopreparado_id: typeof raw.biopreparado_id === 'string' ? raw.biopreparado_id : null,
+    system_prompt_block: typeof raw.system_prompt_block === 'string' ? raw.system_prompt_block : '',
+    reason: typeof raw.reason === 'string' ? raw.reason : '',
+  };
+}
+
+/**
  * Capa 2 anti-alucinación (cross-check de contexto). Llama
  * `POST ${BASE}/post-validate` con el TEXTO que el LLM ya generó y, opcional,
  * los `nombre_cientifico` de las entidades que la capa 1 resolvió para el turno


### PR DESCRIPTION
Cierra el hueco e2e: el sidecar #248 expone /biopreparado-grounding pero el PWA no lo llamaba → el agente seguía a veces negando insumos reales (caldo bordelés). Espejo de fermentoPrefilter: nueva fn biopreparadoGrounding en sidecarClient.js + Promise.all paralelo en AgentScreen + anexa el bloque (datos del catálogo + regla anti-negación) al canal de seguridad/grounding (recency máxima). no-op graceful. Build limpio; eslint de sidecarClient 0/0; AgentScreen lo valida el CI (OOMea local por tamaño).