### PR TITLE
feat(juego): overhaul Doom de la Finca — identificacion de especies, jugabilidad y pedagogia real

### DIFF
--- a/src/components/juego/DoomFincaScreen.jsx
+++ b/src/components/juego/DoomFincaScreen.jsx
@@ -5,15 +5,18 @@
 /* eslint-disable chagra-i18n/no-hardcoded-spanish */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ScreenShell } from '../common/ScreenShell';
-import { Sprout, Bug, Shield, RotateCcw, Crosshair } from 'lucide-react';
+import {
+  Bug, Shield, RotateCcw, Crosshair, Sprout, Target, Trophy,
+  GraduationCap, Play, ChevronRight, Heart, Zap,
+} from 'lucide-react';
 import { agentSounds, isSoundEnabled } from '../../services/agentSoundService';
 import {
-  MAPA, MAPA_COLS, MAPA_FILAS, PALETA, MATERIALES, DECORACIONES, CONFIG_DOOM,
-  PLAGAS_DOOM, BENEFICOS_DOOM,
+  MAPA, PALETA, MATERIALES, DECORACIONES, CONFIG_DOOM,
+  PLAGAS_DOOM, BENEFICOS_DOOM, ESCENARIOS,
 } from './doomFincaData';
 import {
-  castRay, projectSprite, createWorld,
-  tickWorld, cambiarBenefico, decoracionEnMira, plagaEnMira,
+  castRay, projectSprite, createWorld, tickWorld, cambiarBenefico,
+  decoracionEnMira, plagaObjetivo, avanzarRonda,
 } from '../../services/doomFincaEngine';
 
 const W = CONFIG_DOOM.resX;  // 240
@@ -48,52 +51,6 @@ function hexRGB(h) {
   ];
 }
 
-/**
- * Devuelve el color [r,g,b] de un pixel de pared segun el material y la
- * coordenada de textura (tx horizontal 0-1, vy vertical 0-1). Cada material
- * tiene su patron: tablones de madera, bloques de adobe, hojas del seto,
- * grumos de la compostera, follaje de la cama de cultivo.
- */
-function texturaPared(patron, tx, vy, base, sombra, luz) {
-  switch (patron) {
-    case 'madera': {
-      const plank = Math.floor(vy * 5);
-      if (frac(vy * 5) < 0.10) return sombra;            // junta entre tablones
-      return hash2(Math.floor(tx * 40), plank) > 0.7 ? luz : base; // veta
-    }
-    case 'adobe': {
-      const filas = 5;
-      const by = Math.floor(vy * filas);
-      const bx = frac(tx * 4 + (by % 2) * 0.5);
-      if (frac(vy * filas) < 0.12 || bx < 0.08 || bx > 0.92) return sombra; // junta de barro
-      return (by % 2 === 0) ? base : luz;
-    }
-    case 'seto': {
-      const v = hash2(Math.floor(tx * 18), Math.floor(vy * 18)) * 0.6
-              + hash2(Math.floor(tx * 7) + 3, Math.floor(vy * 9) + 5) * 0.4;
-      if (v < 0.30) return sombra;   // hueco entre hojas
-      if (v > 0.72) return luz;      // hoja iluminada
-      return base;
-    }
-    case 'compost': {
-      if (frac(tx * 3) < 0.06) return sombra;            // tablon del cajon
-      const n = hash2(Math.floor(tx * 14), Math.floor(vy * 14));
-      if (n < 0.33) return sombra;
-      if (n > 0.80) return luz;
-      return base;
-    }
-    case 'cultivo': {
-      if (vy < 0.42) {                                   // follaje verde arriba
-        return hash2(Math.floor(tx * 20), Math.floor(vy * 24)) > 0.45 ? luz : sombra;
-      }
-      if (vy < 0.50) return sombra;                      // linea de tierra
-      return frac(vy * 4) < 0.12 ? sombra : base;        // tablon de la cama
-    }
-    default:
-      return base;
-  }
-}
-
 /** Oscurece un color [r,g,b]. */
 function darken(c, f) { return [c[0] * f, c[1] * f, c[2] * f]; }
 /** Aclara un color [r,g,b] (clamp 255). */
@@ -102,42 +59,144 @@ function lighten(c, f) {
 }
 
 /**
- * Pinta un pixel (u,v en 0-1) de una plaga segun su forma. Devuelve [r,g,b]
- * o null (transparente). Sprites reconocibles: oruga segmentada, mosca con
- * alas, colonia de afidos, escarabajo con elitros.
+ * Color de un pixel de pared segun material y coordenada de textura.
+ */
+function texturaPared(patron, tx, vy, base, sombra, luz) {
+  switch (patron) {
+    case 'madera': {
+      const plank = Math.floor(vy * 5);
+      if (frac(vy * 5) < 0.10) return sombra;
+      return hash2(Math.floor(tx * 40), plank) > 0.7 ? luz : base;
+    }
+    case 'adobe': {
+      const filas = 5;
+      const by = Math.floor(vy * filas);
+      const bx = frac(tx * 4 + (by % 2) * 0.5);
+      if (frac(vy * filas) < 0.12 || bx < 0.08 || bx > 0.92) return sombra;
+      return (by % 2 === 0) ? base : luz;
+    }
+    case 'seto': {
+      const v = hash2(Math.floor(tx * 18), Math.floor(vy * 18)) * 0.6
+              + hash2(Math.floor(tx * 7) + 3, Math.floor(vy * 9) + 5) * 0.4;
+      if (v < 0.30) return sombra;
+      if (v > 0.72) return luz;
+      return base;
+    }
+    case 'compost': {
+      if (frac(tx * 3) < 0.06) return sombra;
+      const n = hash2(Math.floor(tx * 14), Math.floor(vy * 14));
+      if (n < 0.33) return sombra;
+      if (n > 0.80) return luz;
+      return base;
+    }
+    case 'cultivo': {
+      if (vy < 0.42) {
+        return hash2(Math.floor(tx * 20), Math.floor(vy * 24)) > 0.45 ? luz : sombra;
+      }
+      if (vy < 0.50) return sombra;
+      return frac(vy * 4) < 0.12 ? sombra : base;
+    }
+    default:
+      return base;
+  }
+}
+
+/**
+ * Pinta un pixel (u,v en 0-1) de una PLAGA. Devuelve [r,g,b] o null.
+ * Sprites grandes, contrastados y reconocibles, con contorno oscuro para
+ * separarlos del fondo (la queja #1 fue "no se distingue nada").
+ *
+ * @param {string} forma
+ * @param {number} u  0-1 horizontal
+ * @param {number} v  0-1 vertical
+ * @param {number[]} base color RGB de la especie
+ * @returns {number[]|null}
  */
 function pintarPlaga(forma, u, v, base) {
   const cx = u - 0.5;
+  const dark = darken(base, 0.45);
+  const lite = lighten(base, 1.4);
   switch (forma) {
     case 'oruga': {
-      if (v < 0.30 || v > 0.80) return null;
-      if (cx * cx * 2.2 + (v - 0.55) * (v - 0.55) * 9 > 0.9) return null;
-      if (u > 0.80 && Math.abs(v - 0.48) < 0.13) return v < 0.46 ? [20, 20, 20] : darken(base, 0.6);
-      return frac(u * 6) < 0.20 ? darken(base, 0.55) : base; // segmentos
+      // gusano gordo segmentado, horizontal, con cabeza marcada y patas
+      const segCenter = 0.55;
+      const r = cx * cx * 1.7 + (v - segCenter) * (v - segCenter) * 7.5;
+      if (r > 0.92) return null;
+      if (r > 0.74) return dark;                                   // contorno
+      if (u > 0.78) {                                              // cabeza a la derecha
+        if (Math.abs(v - 0.50) < 0.07 && u > 0.84) return [20, 20, 20]; // ojo
+        return darken(base, 0.7);
+      }
+      const seg = frac(u * 7);
+      if (seg < 0.22) return dark;                                 // bandas
+      if (v < segCenter - 0.05) return lite;                       // lomo iluminado
+      if (v > 0.70 && frac(u * 7) < 0.4) return [40, 28, 16];      // patitas
+      return base;
     }
     case 'mosca': {
-      const bodyR = cx * cx * 6 + (v - 0.55) * (v - 0.55) * 7;
-      if (v > 0.30 && v < 0.85 && bodyR < 0.5) {
-        if (v < 0.45 && Math.abs(cx) < 0.12) return [10, 10, 10]; // ojos
+      // mosca blanca: cuerpo claro + 2 alas en V + ojos rojizos
+      const bodyR = cx * cx * 5 + (v - 0.52) * (v - 0.52) * 6;
+      if (v > 0.34 && v < 0.80 && bodyR < 0.42) {
+        if (v < 0.44 && Math.abs(cx) < 0.13) return [150, 40, 40]; // ojos
+        if (bodyR > 0.32) return [120, 120, 120];                  // contorno
         return base;
       }
-      if (Math.abs(cx) > 0.18 && Math.abs(cx) < 0.5 && v > 0.30 && v < 0.58) return [240, 240, 245]; // alas
+      if (Math.abs(cx) > 0.12 && Math.abs(cx) < 0.48 && v > 0.28 && v < 0.62) {
+        const aw = (Math.abs(cx) - 0.12) / 0.36;
+        if (aw < 0.85) return [248, 248, 252];                     // alas
+      }
       return null;
     }
     case 'afido': {
-      const blobs = [[0.40, 0.45], [0.60, 0.50], [0.50, 0.66], [0.46, 0.32]];
+      // colonia de pulgones: varias gotas verdes apinadas + antenas
+      const blobs = [[0.42, 0.50, 1.0], [0.60, 0.55, 1.0], [0.51, 0.68, 0.9],
+        [0.47, 0.36, 0.8], [0.64, 0.40, 0.7], [0.36, 0.62, 0.7]];
       for (const b of blobs) {
         const dx = u - b[0];
         const dy = v - b[1];
-        if (dx * dx * 9 + dy * dy * 14 < 0.5) return dx > 0 ? base : darken(base, 0.7);
+        const rr = (dx * dx * 11 + dy * dy * 16) / b[2];
+        if (rr < 0.5) {
+          if (rr > 0.38) return dark;                              // contorno gota
+          return dy < 0 ? lite : base;
+        }
       }
+      if (v < 0.36 && Math.abs(cx + 0.04) < 0.02) return dark;     // antenas
+      if (v < 0.36 && Math.abs(cx - 0.08) < 0.02) return dark;
       return null;
     }
     case 'escarabajo': {
-      if (cx * cx * 3 + (v - 0.55) * (v - 0.55) * 4 > 0.85 || v < 0.25) return null;
-      if (Math.abs(cx) < 0.04) return darken(base, 0.5);          // linea de elitros
-      if (v < 0.42 && cx < 0) return lighten(base, 1.5);          // brillo
+      // broca: cuerpo ovalado oscuro, linea de elitros, brillo y patas
+      const r = cx * cx * 2.6 + (v - 0.55) * (v - 0.55) * 3.6;
+      if (r > 0.86 || v < 0.22) {
+        if (v > 0.66 && v < 0.84 && Math.abs(cx) > 0.18 && Math.abs(cx) < 0.42) return [20, 14, 8]; // patas
+        return null;
+      }
+      if (r > 0.70) return [10, 8, 4];                             // contorno
+      if (Math.abs(cx) < 0.04) return darken(base, 0.4);          // linea elitros
+      if (v < 0.40 && cx < 0) return lighten(base, 2.2);          // brillo
+      if (v < 0.30) return darken(base, 0.7);                     // cabeza
       return base;
+    }
+    case 'acaro': {
+      // arana roja: cuerpo redondo rojo + 8 patas radiales (muy distinto)
+      const dx = u - 0.5;
+      const dy = v - 0.5;
+      const rr = dx * dx + dy * dy;
+      for (let k = 0; k < 8; k += 1) {
+        const ang = (k / 8) * Math.PI * 2 + 0.2;
+        const t = Math.max(0, Math.min(1, ((u - 0.5) * Math.cos(ang) + (v - 0.5) * Math.sin(ang)) / 0.42));
+        const legx = 0.5 + Math.cos(ang) * 0.42 * t;
+        const legy = 0.5 + Math.sin(ang) * 0.42 * t;
+        if ((u - legx) * (u - legx) + (v - legy) * (v - legy) < 0.0016 && rr > 0.018) return [60, 20, 16];
+      }
+      if (rr < 0.045) {
+        if (rr > 0.032) return [80, 24, 18];                       // contorno
+        if (dx < 0 && dy < 0) return lighten(base, 1.5);          // brillo
+        if ((dx + 0.05) * (dx + 0.05) + dy * dy < 0.002) return [40, 12, 10]; // manchas
+        if ((dx - 0.05) * (dx - 0.05) + dy * dy < 0.002) return [40, 12, 10];
+        return base;
+      }
+      return null;
     }
     default:
       return (cx * cx * 2 + (v - 0.5) * (v - 0.5) * 2) < 0.8 ? base : null;
@@ -152,7 +211,7 @@ function pintarDeco(tipo, u, v) {
   const cx = u - 0.5;
   switch (tipo) {
     case 'arbol': {
-      if (v > 0.60 && Math.abs(cx) < 0.08) return [92, 62, 36];   // tronco
+      if (v > 0.60 && Math.abs(cx) < 0.08) return [92, 62, 36];
       const copas = [[0.50, 0.28, 0.30], [0.34, 0.40, 0.22], [0.66, 0.40, 0.22], [0.50, 0.50, 0.24]];
       for (const co of copas) {
         const dx = u - co[0];
@@ -164,58 +223,58 @@ function pintarDeco(tipo, u, v) {
       return null;
     }
     case 'colmena': {
-      if (v > 0.28 && v < 0.37 && Math.abs(cx) < 0.40) return [120, 80, 40]; // techo
+      if (v > 0.28 && v < 0.37 && Math.abs(cx) < 0.40) return [120, 80, 40];
       if (v < 0.35) {
-        return (v < 0.32 && hash2(Math.floor(u * 40), Math.floor(v * 40)) > 0.93) ? [40, 30, 10] : null; // abejas
+        return (v < 0.32 && hash2(Math.floor(u * 40), Math.floor(v * 40)) > 0.93) ? [40, 30, 10] : null;
       }
       if (Math.abs(cx) > 0.34) return null;
       const caja = Math.floor((v - 0.35) / 0.20);
-      if (frac((v - 0.35) / 0.20) < 0.10) return [110, 72, 36];   // junta de cajon
-      if (caja === 2 && Math.abs(cx) < 0.12) return [30, 20, 10]; // entrada
+      if (frac((v - 0.35) / 0.20) < 0.10) return [110, 72, 36];
+      if (caja === 2 && Math.abs(cx) < 0.12) return [30, 20, 10];
       return (caja % 2 === 0) ? [214, 176, 110] : [196, 156, 92];
     }
     case 'gallina': {
-      if (v > 0.78 && v < 0.96 && Math.abs(cx) < 0.20) return [200, 150, 30]; // patas
+      if (v > 0.78 && v < 0.96 && Math.abs(cx) < 0.20) return [200, 150, 30];
       const dxh = u - 0.66;
       const dyh = v - 0.34;
-      if (dxh * dxh * 4 + dyh * dyh * 5 < 0.40) {                 // cabeza
-        if (v < 0.27) return [210, 40, 40];                       // cresta
-        if (u > 0.76 && Math.abs(dyh) < 0.05) return [240, 170, 30]; // pico
-        if (dxh > 0.02 && dyh < 0 && dxh * dxh + dyh * dyh < 0.012) return [20, 20, 20]; // ojo
+      if (dxh * dxh * 4 + dyh * dyh * 5 < 0.40) {
+        if (v < 0.27) return [210, 40, 40];
+        if (u > 0.76 && Math.abs(dyh) < 0.05) return [240, 170, 30];
+        if (dxh > 0.02 && dyh < 0 && dxh * dxh + dyh * dyh < 0.012) return [20, 20, 20];
         return [236, 232, 220];
       }
-      if (cx * cx * 2.6 + (v - 0.56) * (v - 0.56) * 3.2 < 0.55 && v > 0.34) return [232, 226, 210]; // cuerpo
+      if (cx * cx * 2.6 + (v - 0.56) * (v - 0.56) * 3.2 < 0.55 && v > 0.34) return [232, 226, 210];
       return null;
     }
     case 'vaca': {
-      if (v > 0.80 && v < 0.98 && (Math.abs(cx - 0.22) < 0.06 || Math.abs(cx + 0.22) < 0.06)) return [40, 30, 28]; // patas
+      if (v > 0.80 && v < 0.98 && (Math.abs(cx - 0.22) < 0.06 || Math.abs(cx + 0.22) < 0.06)) return [40, 30, 28];
       if (cx * cx * 1.6 + (v - 0.56) * (v - 0.56) * 3.4 < 0.60 && v > 0.32 && v < 0.86) {
-        return hash2(Math.floor(u * 9), Math.floor(v * 9)) > 0.55 ? [60, 44, 38] : [236, 232, 228]; // manchas
+        return hash2(Math.floor(u * 9), Math.floor(v * 9)) > 0.55 ? [60, 44, 38] : [236, 232, 228];
       }
       const dxh = u - 0.16;
       const dyh = v - 0.52;
-      if (dxh * dxh * 5 + dyh * dyh * 6 < 0.40) return [70, 52, 46]; // cabeza
+      if (dxh * dxh * 5 + dyh * dyh * 6 < 0.40) return [70, 52, 46];
       return null;
     }
     case 'girasol': {
-      if (v > 0.50 && Math.abs(cx) < 0.05) return [60, 110, 40];  // tallo
-      if (v > 0.58 && v < 0.72 && Math.abs(cx) > 0.05 && Math.abs(cx) < 0.28) return [70, 128, 52]; // hojas
+      if (v > 0.50 && Math.abs(cx) < 0.05) return [60, 110, 40];
+      if (v > 0.58 && v < 0.72 && Math.abs(cx) > 0.05 && Math.abs(cx) < 0.28) return [70, 128, 52];
       const dx = u - 0.5;
       const dy = v - 0.30;
       const rd = Math.sqrt(dx * dx + dy * dy);
-      if (rd < 0.13) return [90, 56, 20];                         // centro
-      if (rd < 0.27) return frac(Math.atan2(dy, dx) / (Math.PI / 6)) < 0.6 ? [245, 200, 40] : [228, 174, 28]; // petalos
+      if (rd < 0.13) return [90, 56, 20];
+      if (rd < 0.27) return frac(Math.atan2(dy, dx) / (Math.PI / 6)) < 0.6 ? [245, 200, 40] : [228, 174, 28];
       return null;
     }
     case 'abono': {
       const top = 0.45 + 0.18 * Math.cos(cx * 3.1);
       if (v < top || Math.abs(cx) > 0.45) {
-        if (v < top && v > top - 0.18 && hash2(Math.floor(u * 20), Math.floor(v * 20) + 1) > 0.92) return [212, 212, 206]; // vapor
+        if (v < top && v > top - 0.18 && hash2(Math.floor(u * 20), Math.floor(v * 20) + 1) > 0.92) return [212, 212, 206];
         return null;
       }
       const n = hash2(Math.floor(u * 16), Math.floor(v * 16));
       if (n < 0.30) return [46, 32, 18];
-      if (n > 0.85) return [96, 70, 40];                          // restos claros
+      if (n > 0.85) return [96, 70, 40];
       return [70, 50, 28];
     }
     default:
@@ -223,12 +282,13 @@ function pintarDeco(tipo, u, v) {
   }
 }
 
-/** Dimensiones del billboard por tipo (alto/ancho en multiplos de size, hover sobre el piso). */
+/** Dimensiones del billboard por tipo (alto/ancho en multiplos de size, hover). */
 const PLAGA_DIM = {
-  oruga: { hf: 0.55, wf: 0.75, hover: 0.18 },
-  mosca: { hf: 0.45, wf: 0.50, hover: 0.55 },
-  afido: { hf: 0.50, wf: 0.60, hover: 0.12 },
-  escarabajo: { hf: 0.45, wf: 0.55, hover: 0.10 },
+  oruga: { hf: 0.70, wf: 1.05, hover: 0.16 },
+  mosca: { hf: 0.62, wf: 0.70, hover: 0.55 },
+  afido: { hf: 0.72, wf: 0.85, hover: 0.10 },
+  escarabajo: { hf: 0.60, wf: 0.72, hover: 0.08 },
+  acaro: { hf: 0.66, wf: 0.66, hover: 0.10 },
 };
 const DECO_DIM = {
   arbol: { hf: 2.40, wf: 1.60, hover: 0 },
@@ -241,8 +301,10 @@ const DECO_DIM = {
 
 /**
  * DoomFincaScreen - nivel Doom / Wolfenstein 3D agroecologico en primera
- * persona. Motor raycaster propio en Canvas 2D. Recorres un invernadero/cultivo,
- * identificas plagas reales y las controlas lanzando el benefico CORRECTO.
+ * persona, reescrito para que las plagas sean RECONOCIBLES (sprites claros +
+ * etiqueta con nombre comun y cientifico), con controles tactiles decentes,
+ * onboarding, fichas educativas reales (control biologico del grafo de Chagra)
+ * y un recap de lo aprendido.
  *
  * @param {{ onBack: Function, onHome: Function }} props
  */
@@ -251,43 +313,49 @@ export default function DoomFincaScreen({ onBack, onHome }) {
   const worldRef = useRef(null);
   const inputRef = useRef({
     forward: false, backward: false, left: false, right: false,
-    strafeLeft: false, strafeRight: false, fire: false,
-    mouseDown: false,
+    strafeLeft: false, strafeRight: false, fire: false, mouseDown: false,
   });
-  const touchRef = useRef({ joystickActive: false, joystickId: null,
-    joystickX: 0, joystickY: 0, lookActive: false, lookId: null, lookX: 0,
-    lastLookX: 0 });
+  const touchRef = useRef({
+    joystickActive: false, joystickId: null, joystickX: 0, joystickY: 0,
+    joystickOX: 0, joystickOY: 0, lookActive: false, lookId: null, lastLookX: 0,
+  });
 
+  const [fase, setFase] = useState('intro'); // intro | jugando | ronda | gano | perdio
   const [vitalidad, setVitalidad] = useState(CONFIG_DOOM.vitalidadInicial);
-  const [beneficoSel, setBeneficoSel] = useState('trichogramma');
-  const [plagasRestantes, setPlagasRestantes] = useState(
-    PLAGAS_DOOM.length,
-  );
-  const [mensaje, setMensaje] = useState(
-    'Elimina todas las plagas. Cada una solo cae con su controlador real.',
-  );
-  const [estado, setEstado] = useState('jugando'); // jugando | gano | perdio
-  const [_frameCount, setFrameCount] = useState(0);
-  const [leccion, setLeccion] = useState(''); // leccion de la decoracion en la mira
+  const [beneficoSel, setBeneficoSel] = useState(ESCENARIOS[0].beneficosSugeridos[0]);
+  const [plagasRestantes, setPlagasRestantes] = useState(ESCENARIOS[0].plagas.length);
+  const [puntaje, setPuntaje] = useState(0);
+  const [combo, setCombo] = useState(0);
+  const [rondaIdx, setRondaIdx] = useState(0);
+  const [mensaje, setMensaje] = useState('');
+  const [mensajeTipo, setMensajeTipo] = useState('info');
+  const [ficha, setFicha] = useState(null);
+  const [objetivo, setObjetivo] = useState(null); // plaga apuntada (etiqueta HUD)
+  const [aprendido, setAprendido] = useState([]);
+  const [leccion, setLeccion] = useState('');
   const leccionRef = useRef('');
+  const objetivoRef = useRef(null);
 
   const soundOn = useRef(isSoundEnabled());
   const beep = useCallback((kind) => {
     if (!soundOn.current) return;
     try {
-      if (kind === 'good') agentSounds.chime?.();
-      else if (kind === 'hit') agentSounds.error?.();
+      if (kind === 'acierto') agentSounds.acierto?.();
+      else if (kind === 'fallo') agentSounds.fallo?.();
+      else if (kind === 'seleccion') agentSounds.seleccion?.();
+      else if (kind === 'victoria') agentSounds.victoria?.();
+      else if (kind === 'derrota') agentSounds.derrota?.();
       else if (kind === 'fire') agentSounds.start?.();
     } catch { /* sonido opcional */ }
   }, []);
 
   const beneficoSelRef = useRef(beneficoSel);
   useEffect(() => { beneficoSelRef.current = beneficoSel; }, [beneficoSel]);
+  const faseRef = useRef(fase);
+  useEffect(() => { faseRef.current = fase; }, [fase]);
 
   // Inicializa el mundo
-  useEffect(() => {
-    worldRef.current = createWorld();
-  }, []);
+  useEffect(() => { worldRef.current = createWorld(); }, []);
 
   // Keyboard controls
   useEffect(() => {
@@ -301,6 +369,15 @@ export default function DoomFincaScreen({ onBack, onHome }) {
         case 'q': inp.strafeLeft = true; break;
         case 'e': inp.strafeRight = true; break;
         case ' ': case 'f': inp.fire = true; e.preventDefault(); break;
+        case '1': case '2': case '3': case '4': case '5': {
+          const idx = Number(e.key) - 1;
+          if (BENEFICOS_DOOM[idx]) {
+            setBeneficoSel(BENEFICOS_DOOM[idx].id);
+            worldRef.current = cambiarBenefico(worldRef.current, BENEFICOS_DOOM[idx].id);
+            beep('seleccion');
+          }
+          break;
+        }
         default: break;
       }
     };
@@ -323,24 +400,17 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       window.removeEventListener('keydown', down);
       window.removeEventListener('keyup', up);
     };
-  }, []);
+  }, [beep]);
 
   // Mouse look (desktop)
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
-
+    if (!canvas) return undefined;
     const onMouseDown = (e) => {
-      if (e.button === 0) {
-        inputRef.current.mouseDown = true;
-        inputRef.current.fire = true;
-      }
+      if (e.button === 0) { inputRef.current.mouseDown = true; inputRef.current.fire = true; }
     };
     const onMouseUp = (e) => {
-      if (e.button === 0) {
-        inputRef.current.mouseDown = false;
-        inputRef.current.fire = false;
-      }
+      if (e.button === 0) { inputRef.current.mouseDown = false; inputRef.current.fire = false; }
     };
     const onMouseMove = (e) => {
       if (!document.pointerLockElement) return;
@@ -348,13 +418,11 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       if (!w || w.terminado) return;
       w.player = { ...w.player, angulo: w.player.angulo + e.movementX * 0.004 };
     };
-
     canvas.addEventListener('mousedown', onMouseDown);
     canvas.addEventListener('mouseup', onMouseUp);
     canvas.addEventListener('click', () => {
-      if (estado === 'jugando') canvas.requestPointerLock?.();
+      if (faseRef.current === 'jugando') canvas.requestPointerLock?.();
     });
-
     document.addEventListener('mousemove', onMouseMove);
     return () => {
       canvas.removeEventListener('mousedown', onMouseDown);
@@ -362,7 +430,7 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       document.removeEventListener('mousemove', onMouseMove);
       document.exitPointerLock?.();
     };
-  }, [estado]);
+  }, []);
 
   // Canvas rendering loop
   useEffect(() => {
@@ -377,7 +445,7 @@ export default function DoomFincaScreen({ onBack, onHome }) {
     let raf = 0;
     let running = true;
     let lastTick = 0;
-    const TICK_MS = 16; // ~60fps
+    const TICK_MS = 16;
 
     const step = (timestamp) => {
       if (!running) return;
@@ -386,37 +454,49 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       let w = worldRef.current;
       if (!w) return;
 
-      // Tick del mundo a paso fijo
+      const activo = faseRef.current === 'jugando';
+
       const delta = timestamp - lastTick;
       if (delta >= TICK_MS) {
         lastTick = timestamp - (delta % TICK_MS);
 
-        // Procesar touch joystick como input
-        const tj = touchRef.current;
-        if (tj.joystickActive) {
-          const inp = inputRef.current;
-          const deadZone = 10;
-          const jx = tj.joystickX;
-          const jy = tj.joystickY;
-          inp.forward = jy < -deadZone;
-          inp.backward = jy > deadZone;
-          inp.strafeLeft = jx < -deadZone;
-          inp.strafeRight = jx > deadZone;
-        }
+        if (activo) {
+          const tj = touchRef.current;
+          if (tj.joystickActive) {
+            const inp = inputRef.current;
+            const dz = 8;
+            inp.forward = tj.joystickY < -dz;
+            inp.backward = tj.joystickY > dz;
+            inp.strafeLeft = tj.joystickX < -dz;
+            inp.strafeRight = tj.joystickX > dz;
+          }
 
-        w = tickWorld(w, inputRef.current);
-        worldRef.current = w;
+          const prevFichaTimer = w.fichaTimer;
+          const prevErrores = w.errores;
+          w = tickWorld(w, inputRef.current);
+          worldRef.current = w;
 
-        // Actualizar estado React (solo cuando cambia)
-        setVitalidad((prev) => prev !== w.vitalidad ? w.vitalidad : prev);
-        setPlagasRestantes((prev) => prev !== w.plagasRestantes ? w.plagasRestantes : prev);
-        if (w.mensaje) setMensaje((prev) => prev !== w.mensaje ? w.mensaje : prev);
-        if (w.terminado) {
-          setEstado((prev) => {
+          if (w.fichaTimer > prevFichaTimer && w.ficha) beep('acierto');
+          if (w.errores > prevErrores) beep('fallo');
+
+          setVitalidad((p) => (p !== Math.round(w.vitalidad) ? Math.round(w.vitalidad) : p));
+          setPlagasRestantes((p) => (p !== w.plagasRestantes ? w.plagasRestantes : p));
+          setPuntaje((p) => (p !== w.puntaje ? w.puntaje : p));
+          setCombo((p) => (p !== w.combo ? w.combo : p));
+          setMensaje((p) => (p !== w.mensaje ? w.mensaje : p));
+          setMensajeTipo((p) => (p !== w.mensajeTipo ? w.mensajeTipo : p));
+          setFicha((p) => (p !== w.ficha ? w.ficha : p));
+          setAprendido((p) => (p.length !== w.aprendido.length ? w.aprendido : p));
+
+          if (w.rondaTransicion) {
+            setRondaIdx(w.rondaIdx);
+            setFase('ronda');
+          }
+          if (w.terminado) {
             const nuevo = w.ganado ? 'gano' : 'perdio';
-            return prev !== nuevo ? nuevo : prev;
-          });
-          if (w.ganado) beep('good');
+            setFase(nuevo);
+            beep(w.ganado ? 'victoria' : 'derrota');
+          }
         }
       }
 
@@ -428,7 +508,6 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       const halfH = H / 2;
       const fovHalf = FOV / 2;
 
-      // Pre-calcular rayos y guardar distancias por columna (para sprites)
       const zBuffer = new Float64Array(W);
       const horizon = halfH;
       const sky0 = PALETA.cieloAlto;
@@ -449,30 +528,24 @@ export default function DoomFincaScreen({ onBack, onHome }) {
         const rsin = Math.sin(rayAngle);
         const result = castRay(MAPA, px, py, rayAngle);
 
-        // Fish-eye correction
         const corrDist = result.dist * Math.cos(rayAngle - pa);
         zBuffer[col] = corrDist;
 
-        // Altura de la pared en pantalla (float para texturar sin saltos)
         const wallHf = H / corrDist;
         const trueTop = halfH - wallHf / 2;
         const wallTop = Math.max(0, Math.round(trueTop));
         const wallBot = Math.min(H - 1, Math.round(halfH + wallHf / 2));
 
-        // Material de la pared golpeada
         const mat = MATERIALES[result.tipo] || MATERIALES[1];
         const baseRGB = hexRGB(mat.base);
         const sombraRGB = hexRGB(mat.sombra);
         const luzRGB = hexRGB(mat.luz);
 
-        // Iluminacion: cara N/S mas oscura; atenuacion suave por distancia;
-        // niebla atmosferica que mezcla hacia el color del horizonte (no a negro).
         const fog = Math.max(0, Math.min(1, (corrDist - NIEBLA_INI) / (NIEBLA_FIN - NIEBLA_INI)));
-        const light = Math.max(0.40, 1.0 - corrDist * 0.05);
+        const light = Math.max(0.45, 1.0 - corrDist * 0.04);
         const faceDim = result.cara <= 1 ? 0.78 : 1.0;
         const shade = light * faceDim;
 
-        // Silueta de cordillera para esta columna (parallax al girar)
         const ridge = (
           (Math.sin(rayAngle * 1.3) * 0.5 + 0.5) * 0.6 +
           (Math.sin(rayAngle * 2.7 + 1.5) * 0.5 + 0.5) * 0.3 +
@@ -482,52 +555,35 @@ export default function DoomFincaScreen({ onBack, onHome }) {
 
         for (let row = 0; row < H; row += 1) {
           const idx = (row * W + col) * 4;
-
           if (row < wallTop) {
-            // ── CIELO ──
-            const t = row / horizon;            // 0 cenit -> 1 horizonte
+            const t = row / horizon;
             let cr = sky0[0] + (sky1[0] - sky0[0]) * t;
             let cg = sky0[1] + (sky1[1] - sky0[1]) * t;
             let cb = sky0[2] + (sky1[2] - sky0[2]) * t;
-
-            // Sol: disco + halo
             const sunRow = horizon * 0.42;
             const dvSun = Math.abs(row - sunRow) / horizon;
             const sunDist = Math.sqrt(dSun * dSun * 6 + dvSun * dvSun * 9);
-            if (sunDist < 0.18) {
-              cr = sunC[0]; cg = sunC[1]; cb = sunC[2];
-            } else if (sunDist < 0.6) {
+            if (sunDist < 0.18) { cr = sunC[0]; cg = sunC[1]; cb = sunC[2]; }
+            else if (sunDist < 0.6) {
               const gg = ((0.6 - sunDist) / 0.42) * 0.7;
-              cr += (sunG[0] - cr) * gg;
-              cg += (sunG[1] - cg) * gg;
-              cb += (sunG[2] - cb) * gg;
+              cr += (sunG[0] - cr) * gg; cg += (sunG[1] - cg) * gg; cb += (sunG[2] - cb) * gg;
             }
-
-            // Nubes en la franja alta
             if (t < 0.7) {
               const cloud = hash2(Math.floor(rayAngle * 26), Math.floor(row / 3)) * 0.5
                           + hash2(Math.floor(rayAngle * 13) + 7, Math.floor(row / 5)) * 0.5;
               if (cloud > 0.82) {
                 const cf = ((cloud - 0.82) / 0.18) * 0.8;
-                cr += (nube[0] - cr) * cf;
-                cg += (nube[1] - cg) * cf;
-                cb += (nube[2] - cb) * cf;
+                cr += (nube[0] - cr) * cf; cg += (nube[1] - cg) * cf; cb += (nube[2] - cb) * cf;
               }
             }
-
-            // Cordillera lejana cerca del horizonte
             if (row > horizon - ridge && row < horizon) {
               const nieve = (row - (horizon - ridge)) / (ridge + 0.001) < 0.25;
               const mc = nieve ? [230, 236, 244]
                 : ((Math.floor(rayAngle * 8) % 2 === 0) ? mtn : mtnS);
-              cr = mc[0] * 0.7 + cr * 0.3;
-              cg = mc[1] * 0.7 + cg * 0.3;
-              cb = mc[2] * 0.7 + cb * 0.3;
+              cr = mc[0] * 0.7 + cr * 0.3; cg = mc[1] * 0.7 + cg * 0.3; cb = mc[2] * 0.7 + cb * 0.3;
             }
-
             buf[idx] = cr; buf[idx + 1] = cg; buf[idx + 2] = cb; buf[idx + 3] = 255;
           } else if (row <= wallBot) {
-            // ── PARED (texturizada por material) ──
             const vY = wallHf > 0.001 ? (row - trueTop) / wallHf : 0;
             const wcol = texturaPared(mat.patron, result.texX, vY, baseRGB, sombraRGB, luzRGB);
             const pr = wcol[0] * shade;
@@ -538,20 +594,17 @@ export default function DoomFincaScreen({ onBack, onHome }) {
             buf[idx + 2] = pb + (sky1[2] - pb) * fog;
             buf[idx + 3] = 255;
           } else {
-            // ── PISO (tierra con surcos, pasto y mulch) ──
             const floorDist = halfH / (row - halfH + 0.001);
             const fx = px + rcos * floorDist;
             const fy = py + rsin * floorDist;
             const ffog = Math.max(0, Math.min(1, (floorDist - NIEBLA_INI) / (NIEBLA_FIN - NIEBLA_INI)));
-            const fl = Math.max(0.40, 1.0 - floorDist * 0.05);
-
+            const fl = Math.max(0.45, 1.0 - floorDist * 0.04);
             let fbase = tierra;
-            if (frac(fy * 2.2) < 0.16) fbase = surco;          // surcos del cultivo
+            if (frac(fy * 2.2) < 0.16) fbase = surco;
             const patch = hash2(Math.floor(fx * 1.6), Math.floor(fy * 1.6));
-            if (patch > 0.86) fbase = pasto;                   // mancha de pasto
-            else if (patch < 0.10) fbase = mulch;              // cobertura/mulch
+            if (patch > 0.86) fbase = pasto;
+            else if (patch < 0.10) fbase = mulch;
             const grain = 0.88 + hash2(Math.floor(fx * 8), Math.floor(fy * 8)) * 0.18;
-
             const fr = fbase[0] * fl * grain;
             const fg = fbase[1] * fl * grain;
             const fb = fbase[2] * fl * grain;
@@ -563,19 +616,26 @@ export default function DoomFincaScreen({ onBack, onHome }) {
         }
       }
 
-      // ── BILLBOARDS: plagas + decoracion viva de la finca ──
+      // ── BILLBOARDS: plagas + decoracion ──
       const billboards = [];
       for (const pest of w.pests) {
         if (!pest.vivo) continue;
         const proj = projectSprite(pest.x, pest.y, px, py, pa, FOV, W, H);
-        if (proj.visible) billboards.push({ kind: 'plaga', forma: pest.forma, color: pest.color, proj });
+        if (proj.visible) {
+          billboards.push({
+            kind: 'plaga', forma: pest.forma, color: pest.color, proj,
+            flashAcierto: pest.flashAcierto, flashEquivocado: pest.flashEquivocado,
+            controladoPor: pest.controladoPor,
+          });
+        }
       }
       for (const deco of DECORACIONES) {
         const proj = projectSprite(deco.x, deco.y, px, py, pa, FOV, W, H);
         if (proj.visible) billboards.push({ kind: 'deco', tipo: deco.tipo, proj });
       }
-      // Lejos -> cerca para que los cercanos tapen a los lejanos
       billboards.sort((a, b) => b.proj.dist - a.proj.dist);
+
+      const plagaRects = [];
 
       for (const bb of billboards) {
         const { screenX, size, dist } = bb.proj;
@@ -584,7 +644,6 @@ export default function DoomFincaScreen({ onBack, onHome }) {
           : (DECO_DIM[bb.tipo] || DECO_DIM.arbol);
         const spriteH = size * dim.hf;
         const spriteW = size * dim.wf;
-        // Anclar a la linea del piso: los objetos "se paran" en el suelo
         const floorRow = halfH + halfH / Math.max(dist, 0.3);
         const bottom = Math.round(floorRow - dim.hover * size);
         const top = Math.round(bottom - spriteH);
@@ -592,41 +651,65 @@ export default function DoomFincaScreen({ onBack, onHome }) {
         const right = Math.round(screenX + spriteW / 2);
 
         const fogF = Math.max(0, Math.min(1, (dist - NIEBLA_INI) / (NIEBLA_FIN - NIEBLA_INI)));
-        const sLight = Math.max(0.40, 1.0 - dist * 0.05);
+        const sLight = Math.max(0.55, 1.0 - dist * 0.035);
         const baseRGB = bb.kind === 'plaga' ? hexRGB(bb.color) : null;
+        const flashA = bb.kind === 'plaga' ? (bb.flashAcierto || 0) / 14 : 0;
+        const flashE = bb.kind === 'plaga' ? (bb.flashEquivocado || 0) / 18 : 0;
 
         for (let row = top; row <= bottom; row += 1) {
           if (row < 0 || row >= H) continue;
           const v = (row - top) / Math.max(1, spriteH);
           for (let c = left; c <= right; c += 1) {
             if (c < 0 || c >= W) continue;
-            if (zBuffer[c] < dist) continue; // ocluido por pared
+            if (zBuffer[c] < dist) continue;
             const u = (c - left) / Math.max(1, spriteW);
             const pix = bb.kind === 'plaga'
               ? pintarPlaga(bb.forma, u, v, baseRGB)
               : pintarDeco(bb.tipo, u, v);
             if (!pix) continue;
             const idx = (row * W + c) * 4;
-            const pr = pix[0] * sLight;
-            const pg = pix[1] * sLight;
-            const pb = pix[2] * sLight;
+            let pr = pix[0] * sLight;
+            let pg = pix[1] * sLight;
+            let pb = pix[2] * sLight;
+            if (flashA > 0) { pr += (120 - pr) * flashA; pg += (255 - pg) * flashA; pb += (120 - pb) * flashA; }
+            if (flashE > 0) { pr += (255 - pr) * flashE; pg += (60 - pg) * flashE; pb += (60 - pb) * flashE; }
             buf[idx] = pr + (sky1[0] - pr) * fogF;
             buf[idx + 1] = pg + (sky1[1] - pg) * fogF;
             buf[idx + 2] = pb + (sky1[2] - pb) * fogF;
             buf[idx + 3] = 255;
           }
         }
+
+        if (bb.kind === 'plaga') {
+          plagaRects.push({
+            screenX, top, dist,
+            correcto: bb.controladoPor === beneficoSelRef.current,
+          });
+        }
       }
 
-      // Put pixel data
       ctx.putImageData(imageData, 0, 0);
 
-      // ── VIEWMODEL: manos del campesino sosteniendo el frasco del benefico ──
+      // ── Marcador de color sobre cada plaga cercana (verde/rojo) ──
+      for (const r of plagaRects) {
+        if (r.dist > 9) continue;
+        const sx = r.screenX;
+        const sy = Math.max(6, r.top - 4);
+        ctx.fillStyle = r.correcto ? 'rgba(120,255,140,0.95)' : 'rgba(255,120,120,0.95)';
+        ctx.beginPath();
+        ctx.moveTo(sx, sy + 5);
+        ctx.lineTo(sx - 3.5, sy);
+        ctx.lineTo(sx + 3.5, sy);
+        ctx.closePath();
+        ctx.fill();
+      }
+
+      // ── VIEWMODEL: manos del campesino con el frasco del benefico ──
       const bSel = BENEFICOS_DOOM.find((b) => b.id === beneficoSelRef.current) || BENEFICOS_DOOM[0];
       const bob = Math.sin(w.t * 0.12) * 1.6;
       const recoil = w.cooldown > 0 ? (w.cooldown / CONFIG_DOOM.cooldownLanzamiento) * 7 : 0;
       const baseY = H - 2 + recoil + bob;
-      ctx.fillStyle = '#3f6d34';                 // mangas de la camisa de campo
+      ctx.fillStyle = '#3f6d34';
       ctx.beginPath();
       ctx.moveTo(W * 0.26, H);
       ctx.lineTo(W * 0.42, baseY - 16);
@@ -634,102 +717,124 @@ export default function DoomFincaScreen({ onBack, onHome }) {
       ctx.lineTo(W * 0.74, H);
       ctx.closePath();
       ctx.fill();
-      ctx.fillStyle = '#caa074';                 // manos
+      ctx.fillStyle = '#caa074';
       ctx.fillRect(W / 2 - 16, baseY - 18, 10, 9);
       ctx.fillRect(W / 2 + 6, baseY - 18, 10, 9);
-      ctx.fillStyle = bSel.color;                // frasco del benefico
+      ctx.fillStyle = bSel.color;
       ctx.fillRect(W / 2 - 11, baseY - 28, 22, 18);
       ctx.fillStyle = 'rgba(255,255,255,0.25)';
-      ctx.fillRect(W / 2 - 9, baseY - 26, 5, 14); // brillo del vidrio
-      ctx.fillStyle = '#5c4327';                  // tapa
+      ctx.fillRect(W / 2 - 9, baseY - 26, 5, 14);
+      ctx.fillStyle = '#5c4327';
       ctx.fillRect(W / 2 - 8, baseY - 32, 16, 5);
       ctx.font = '11px sans-serif';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
       ctx.fillText(bSel.emoji, W / 2, baseY - 18);
 
-      // Mira central (crosshair) — verde si apunta a la plaga correcta,
-      // ambar si es plaga pero benefico equivocado, blanco si no hay objetivo.
-      const aim = plagaEnMira(w.player, beneficoSelRef.current, w.pests, CONFIG_DOOM.alcanceLanzamiento);
-      const miraColor = aim.enMira
-        ? (aim.correcto ? 'rgba(130,255,130,0.95)' : 'rgba(255,180,70,0.95)')
+      // Mira central: verde = correcto, ambar = equivocado, blanco = sin objetivo
+      const aim = plagaObjetivo(w.player, beneficoSelRef.current, w.pests, CONFIG_DOOM.alcanceLanzamiento);
+      const miraColor = aim.plaga
+        ? (aim.correcto ? 'rgba(130,255,130,0.98)' : 'rgba(255,180,70,0.98)')
         : 'rgba(255,255,255,0.7)';
+      const ringR = aim.plaga ? 6 : 4;
       ctx.strokeStyle = miraColor;
-      ctx.lineWidth = 1;
+      ctx.lineWidth = aim.plaga ? 1.4 : 1;
       ctx.beginPath();
-      ctx.moveTo(W / 2 - 8, H / 2);
-      ctx.lineTo(W / 2 - 3, H / 2);
-      ctx.moveTo(W / 2 + 3, H / 2);
-      ctx.lineTo(W / 2 + 8, H / 2);
-      ctx.moveTo(W / 2, H / 2 - 8);
-      ctx.lineTo(W / 2, H / 2 - 3);
-      ctx.moveTo(W / 2, H / 2 + 3);
-      ctx.lineTo(W / 2, H / 2 + 8);
+      ctx.arc(W / 2, H / 2, ringR, 0, Math.PI * 2);
       ctx.stroke();
-      ctx.fillStyle = miraColor;
       ctx.beginPath();
-      ctx.arc(W / 2, H / 2, 2, 0, Math.PI * 2);
-      ctx.fill();
+      ctx.moveTo(W / 2 - 9, H / 2); ctx.lineTo(W / 2 - ringR - 1, H / 2);
+      ctx.moveTo(W / 2 + ringR + 1, H / 2); ctx.lineTo(W / 2 + 9, H / 2);
+      ctx.moveTo(W / 2, H / 2 - 9); ctx.lineTo(W / 2, H / 2 - ringR - 1);
+      ctx.moveTo(W / 2, H / 2 + ringR + 1); ctx.lineTo(W / 2, H / 2 + 9);
+      ctx.stroke();
 
-      // Leccion de la decoracion que el jugador esta mirando (ciclo de la finca)
+      // Objetivo apuntado -> etiqueta de identificacion (estado React HUD)
+      const nuevoObj = aim.plaga
+        ? { nombre: aim.plaga.nombre, cientifico: aim.plaga.cientifico,
+          cultivo: aim.plaga.cultivo, correcto: aim.correcto,
+          controladoPor: aim.plaga.controladoPor }
+        : null;
+      const objKey = nuevoObj ? `${nuevoObj.nombre}|${nuevoObj.correcto}` : '';
+      const prevKey = objetivoRef.current
+        ? `${objetivoRef.current.nombre}|${objetivoRef.current.correcto}` : '';
+      if (objKey !== prevKey) {
+        objetivoRef.current = nuevoObj;
+        setObjetivo(nuevoObj);
+      }
+
+      // Leccion de la decoracion mirada
       const deco = decoracionEnMira(w.player, DECORACIONES);
       const nuevaLeccion = deco ? deco.leccion : '';
       if (nuevaLeccion !== leccionRef.current) {
         leccionRef.current = nuevaLeccion;
         setLeccion(nuevaLeccion);
       }
-
-      setFrameCount((prev) => (prev + 1) % 120);
     };
 
     lastTick = performance.now();
     raf = requestAnimationFrame(step);
-
-    return () => {
-      running = false;
-      cancelAnimationFrame(raf);
-    };
+    return () => { running = false; cancelAnimationFrame(raf); };
   }, [beep]);
 
-  // Reiniciar
+  // ── Controles de flujo (intro / ronda / reiniciar) ──
+  const empezar = useCallback(() => { setFase('jugando'); }, []);
+
+  const siguienteRonda = useCallback(() => {
+    worldRef.current = avanzarRonda(worldRef.current);
+    const w = worldRef.current;
+    setRondaIdx(w.rondaIdx);
+    setBeneficoSel(w.beneficoEquipado);
+    setPlagasRestantes(w.plagasRestantes);
+    setVitalidad(Math.round(w.vitalidad));
+    setCombo(0);
+    setMensaje('');
+    setFicha(null);
+    if (w.terminado) { setFase('gano'); beep('victoria'); }
+    else setFase('jugando');
+  }, [beep]);
+
   const reiniciar = useCallback(() => {
     worldRef.current = createWorld();
+    const w = worldRef.current;
     setVitalidad(CONFIG_DOOM.vitalidadInicial);
-    setPlagasRestantes(PLAGAS_DOOM.length);
-    setMensaje('Elimina todas las plagas. Cada una solo cae con su controlador real.');
-    setEstado('jugando');
-    setBeneficoSel('trichogramma');
+    setPlagasRestantes(ESCENARIOS[0].plagas.length);
+    setBeneficoSel(w.beneficoEquipado);
+    setPuntaje(0);
+    setCombo(0);
+    setRondaIdx(0);
+    setMensaje('');
+    setFicha(null);
+    setObjetivo(null);
+    objetivoRef.current = null;
+    setAprendido([]);
     setLeccion('');
     leccionRef.current = '';
+    setFase('intro');
   }, []);
 
-  // Touch: joystick virtual izquierdo
+  // ── Touch: dos zonas (mover izquierda / mirar derecha) + boton lanzar ──
   const handleTouchStart = useCallback((e) => {
-    const t = e.changedTouches[0];
+    if (faseRef.current !== 'jugando') return;
     const canvas = canvasRef.current;
     if (!canvas) return;
     const rect = canvas.getBoundingClientRect();
-    const x = t.clientX - rect.left;
-    const y = t.clientY - rect.top;
-    const relX = x / rect.width;
-    const relY = y / rect.height;
-
-    if (relX < 0.4) {
-      // Joystick izquierdo
-      touchRef.current.joystickActive = true;
-      touchRef.current.joystickId = t.identifier;
-      touchRef.current.joystickX = (relX - 0.2) * rect.width;
-      touchRef.current.joystickY = (relY - 0.5) * rect.height;
-    } else if (relX > 0.6) {
-      // Boton de fuego
-      inputRef.current.fire = true;
-      setTimeout(() => { inputRef.current.fire = false; }, 100);
-    } else {
-      // Look (arrastrar)
-      touchRef.current.lookActive = true;
-      touchRef.current.lookId = t.identifier;
-      touchRef.current.lookX = t.clientX;
-      touchRef.current.lastLookX = t.clientX;
+    for (let i = 0; i < e.changedTouches.length; i += 1) {
+      const t = e.changedTouches[i];
+      const relX = (t.clientX - rect.left) / rect.width;
+      const tj = touchRef.current;
+      if (relX < 0.45 && !tj.joystickActive) {
+        tj.joystickActive = true;
+        tj.joystickId = t.identifier;
+        tj.joystickOX = t.clientX;
+        tj.joystickOY = t.clientY;
+        tj.joystickX = 0;
+        tj.joystickY = 0;
+      } else if (!tj.lookActive) {
+        tj.lookActive = true;
+        tj.lookId = t.identifier;
+        tj.lastLookX = t.clientX;
+      }
     }
   }, []);
 
@@ -737,18 +842,13 @@ export default function DoomFincaScreen({ onBack, onHome }) {
     const tj = touchRef.current;
     for (let i = 0; i < e.changedTouches.length; i += 1) {
       const t = e.changedTouches[i];
-      const canvas = canvasRef.current;
-      if (!canvas) continue;
-      const rect = canvas.getBoundingClientRect();
-
       if (t.identifier === tj.joystickId && tj.joystickActive) {
-        // Delta desde el centro fijo del joystick (20% ancho, 50% alto)
-        const cx = rect.width * 0.2;
-        const cy = rect.height * 0.5;
-        tj.joystickX = t.clientX - rect.left - cx;
-        tj.joystickY = t.clientY - rect.top - cy;
+        tj.joystickX = t.clientX - tj.joystickOX;
+        tj.joystickY = t.clientY - tj.joystickOY;
+        const mag = Math.sqrt(tj.joystickX ** 2 + tj.joystickY ** 2);
+        const cap = 48;
+        if (mag > cap) { tj.joystickX = (tj.joystickX / mag) * cap; tj.joystickY = (tj.joystickY / mag) * cap; }
       }
-
       if (t.identifier === tj.lookId && tj.lookActive) {
         const delta = t.clientX - tj.lastLookX;
         const w = worldRef.current;
@@ -765,185 +865,307 @@ export default function DoomFincaScreen({ onBack, onHome }) {
     for (let i = 0; i < e.changedTouches.length; i += 1) {
       const t = e.changedTouches[i];
       if (t.identifier === tj.joystickId) {
-        tj.joystickActive = false;
-        tj.joystickId = null;
-        tj.joystickX = 0;
-        tj.joystickY = 0;
-        inputRef.current.forward = false;
-        inputRef.current.backward = false;
-        inputRef.current.strafeLeft = false;
-        inputRef.current.strafeRight = false;
+        tj.joystickActive = false; tj.joystickId = null; tj.joystickX = 0; tj.joystickY = 0;
+        inputRef.current.forward = false; inputRef.current.backward = false;
+        inputRef.current.strafeLeft = false; inputRef.current.strafeRight = false;
       }
-      if (t.identifier === tj.lookId) {
-        tj.lookActive = false;
-        tj.lookId = null;
-      }
+      if (t.identifier === tj.lookId) { tj.lookActive = false; tj.lookId = null; }
     }
-    // Si todos los dedos se levantaron
     if (e.touches.length === 0) {
-      inputRef.current.forward = false;
-      inputRef.current.backward = false;
-      inputRef.current.strafeLeft = false;
-      inputRef.current.strafeRight = false;
+      inputRef.current.forward = false; inputRef.current.backward = false;
+      inputRef.current.strafeLeft = false; inputRef.current.strafeRight = false;
     }
   }, []);
 
-  // Id para la vitalidad
+  const dispararTouch = useCallback(() => {
+    if (faseRef.current !== 'jugando') return;
+    inputRef.current.fire = true;
+    beep('fire');
+    setTimeout(() => { inputRef.current.fire = false; }, 90);
+  }, [beep]);
+
   const vitalidadPct = Math.round((vitalidad / CONFIG_DOOM.vitalidadMax) * 100);
-  const _beneficoActual = BENEFICOS_DOOM.find((b) => b.id === beneficoSel);
+  const escenarioActual = ESCENARIOS[rondaIdx] || ESCENARIOS[0];
+  const sugeridos = escenarioActual.beneficosSugeridos;
+  // En la transicion ('ronda') el rondaIdx todavia apunta a la ronda ya
+  // completada; mostramos el preview de la SIGUIENTE ronda.
+  const escenarioPreview = ESCENARIOS[rondaIdx + 1] || escenarioActual;
+  const escIntro = fase === 'ronda' ? escenarioPreview : escenarioActual;
+  const numRondaIntro = fase === 'ronda' ? rondaIdx + 2 : rondaIdx + 1;
 
   return (
     <ScreenShell title="Doom de la Finca" icon={Crosshair} onBack={onBack} onHome={onHome}>
       <div className="flex flex-col gap-3 px-3 pt-2 pb-6 max-w-lg mx-auto">
-        {/* Subtitulo */}
-        <p className="text-xs text-emerald-200/80 leading-snug text-center">
-          Recorre tu finca en primera persona. Lanza el benefico correcto sobre
-          cada plaga para controlarla y protege la vitalidad del cultivo. Mira
-          los arboles, la colmena, los animales y la compostera para aprender
-          como se cierra el ciclo.
-        </p>
 
-        {/* HUD retro */}
-        <div className="flex items-center justify-between gap-3 text-xs font-bold">
-          {/* Vitalidad */}
-          <div className="flex items-center gap-2 flex-1">
-            <span className="text-emerald-300 whitespace-nowrap">Vitalidad</span>
-            <div className="flex-1 h-4 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
-              <div
-                className="h-full bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full transition-all duration-300"
-                style={{ width: `${vitalidadPct}%` }}
-              />
-            </div>
-            <span className="text-white w-10 text-right">{vitalidadPct}%</span>
-          </div>
-          {/* Plagas restantes */}
-          <div className="flex items-center gap-1 text-amber-300 whitespace-nowrap">
-            <Bug size={14} />
-            <span>{plagasRestantes}</span>
-          </div>
+        {/* ── HUD superior: ronda, plagas, puntaje, combo ── */}
+        <div className="flex items-center justify-between gap-2 text-xs font-bold">
+          <span className="flex items-center gap-1 text-emerald-200 whitespace-nowrap">
+            <span aria-hidden="true">{escenarioActual.icono}</span>
+            <span>Ronda {rondaIdx + 1}/{ESCENARIOS.length}</span>
+          </span>
+          <span className="flex items-center gap-1 text-amber-300 whitespace-nowrap" aria-label={`${plagasRestantes} plagas restantes`}>
+            <Bug size={13} aria-hidden="true" />{plagasRestantes}
+          </span>
+          <span className="flex items-center gap-1 text-lime-300 whitespace-nowrap" aria-label={`Puntaje ${puntaje}`}>
+            <Trophy size={13} aria-hidden="true" />{puntaje}
+          </span>
+          {combo > 1 && (
+            <span className="flex items-center gap-0.5 text-orange-300 whitespace-nowrap" aria-label={`Combo ${combo}`}>
+              <Zap size={13} aria-hidden="true" />x{combo}
+            </span>
+          )}
         </div>
 
-        {/* Canvas del juego */}
+        {/* Barra de vitalidad */}
+        <div className="flex items-center gap-2 text-xs font-bold">
+          <Heart size={13} className="text-emerald-300" aria-hidden="true" />
+          <div className="flex-1 h-3.5 bg-slate-800/60 rounded-full overflow-hidden border border-emerald-900/40">
+            <div
+              className="h-full bg-gradient-to-r from-emerald-500 to-lime-400 rounded-full transition-all duration-300"
+              style={{ width: `${vitalidadPct}%` }}
+            />
+          </div>
+          <span className="text-white w-9 text-right" aria-label={`Vitalidad ${vitalidadPct}%`}>{vitalidadPct}%</span>
+        </div>
+
+        {/* ── Canvas del juego ── */}
         <div className="relative rounded-xl overflow-hidden border-2 border-emerald-700/50 bg-black shadow-lg shadow-emerald-900/30">
           <canvas
             ref={canvasRef}
             width={W}
             height={H}
-            className="w-full block cursor-crosshair touch-none"
+            className="w-full block cursor-crosshair touch-none select-none"
             style={{ imageRendering: 'pixelated', aspectRatio: `${W}/${H}` }}
             role="img"
-            aria-label="Vista en primera persona del invernadero. Mira para apuntar, toca el lado derecho para lanzar."
+            aria-label="Vista en primera persona de la finca. Arrastra el lado izquierdo para moverte, el derecho para girar, y toca Soltar para aplicar el benefico."
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
           />
 
-          {/* Overlay de fin de juego */}
-          {estado !== 'jugando' && (
-            <div className="absolute inset-0 bg-black/70 flex flex-col items-center justify-center gap-3 p-4">
-              <span className="text-5xl" aria-hidden="true">
-                {estado === 'gano' ? '🌽🎉' : '🐛💔'}
-              </span>
-              <h3 className="text-xl font-black text-white">
-                {estado === 'gano' ? 'Cultivo limpio' : 'El cultivo sufrio'}
+          {/* Etiqueta de identificacion del objetivo apuntado */}
+          {fase === 'jugando' && objetivo && (
+            <div
+              className="absolute top-2 left-1/2 -translate-x-1/2 px-3 py-1.5 rounded-lg text-center pointer-events-none border"
+              style={{
+                backgroundColor: objetivo.correcto ? 'rgba(6,78,59,0.92)' : 'rgba(67,20,7,0.92)',
+                borderColor: objetivo.correcto ? 'rgba(52,211,153,0.6)' : 'rgba(248,113,113,0.6)',
+              }}
+              role="status"
+            >
+              <div className="flex items-center justify-center gap-1.5">
+                <Target size={12} className={objetivo.correcto ? 'text-emerald-300' : 'text-red-300'} aria-hidden="true" />
+                <span className="text-sm font-black text-white leading-none">{objetivo.nombre}</span>
+              </div>
+              <div className="text-2xs italic text-white/70 leading-tight">{objetivo.cientifico}</div>
+              <div
+                className="text-2xs font-bold leading-tight mt-0.5"
+                style={{ color: objetivo.correcto ? '#6ee7b7' : '#fca5a5' }}
+              >
+                {objetivo.correcto ? 'Benefico correcto: ¡suelta!' : 'Benefico equivocado'}
+              </div>
+            </div>
+          )}
+
+          {/* ── Onboarding / intro de ronda ── */}
+          {(fase === 'intro' || fase === 'ronda') && (
+            <div className="absolute inset-0 bg-black/80 flex flex-col items-center justify-center gap-3 p-4 text-center">
+              <span className="text-4xl" aria-hidden="true">{escIntro.icono}</span>
+              <h3 className="text-lg font-black text-white">
+                {fase === 'intro' ? 'Defiende tu finca con control biologico' : `Ronda ${numRondaIntro}: ${escIntro.nombre}`}
               </h3>
-              <p className="text-sm text-emerald-100/80 text-center max-w-xs">
-                {estado === 'gano'
-                  ? 'Controlaste todas las plagas con sus enemigos naturales. El cultivo esta sano y productivo.'
-                  : 'La vitalidad del cultivo se agoto. La proxima vez lanza el benefico correcto mas rapido.'}
+              <p className="text-xs text-emerald-100/90 max-w-xs leading-relaxed">
+                {fase === 'intro'
+                  ? 'Recorre la finca, identifica cada plaga (nombre y especie) y sueltale su enemigo natural correcto. Cada acierto te explica el por que. Las plagas reducen la vitalidad del cultivo: actua rapido.'
+                  : escIntro.intro}
               </p>
+              {fase === 'intro' && (
+                <ul className="text-2xs text-emerald-200/80 text-left space-y-1 max-w-xs">
+                  <li><b>Mover:</b> arrastra el lado izquierdo (o WASD).</li>
+                  <li><b>Girar:</b> arrastra el lado derecho (o el raton).</li>
+                  <li><b>Soltar benefico:</b> boton inferior derecho (o barra/F).</li>
+                  <li><b>Mira verde</b> = benefico correcto · <b>ambar</b> = equivocado.</li>
+                </ul>
+              )}
               <button
                 type="button"
-                onClick={reiniciar}
-                className="min-h-[56px] px-6 rounded-2xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-black text-lg flex items-center gap-2"
+                onClick={fase === 'intro' ? empezar : siguienteRonda}
+                className="min-h-[52px] px-6 rounded-2xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-black text-base flex items-center gap-2"
               >
-                <RotateCcw size={22} aria-hidden="true" />
-                Jugar otra vez
+                <Play size={20} aria-hidden="true" />
+                {fase === 'intro' ? 'Empezar' : 'Siguiente ronda'}
               </button>
             </div>
           )}
 
-          {/* Indicadores touch: joystick virtual (solo mobile, indicado visualmente) */}
-          <div className="absolute bottom-3 left-3 flex items-center gap-2 pointer-events-none">
-            <div className="w-14 h-14 rounded-full border-2 border-white/30 bg-white/5 flex items-center justify-center">
-              <div className="w-8 h-8 rounded-full bg-white/20" />
-            </div>
-            <span className="text-white/60 text-2xs">Mover</span>
-          </div>
-          <div className="absolute bottom-3 right-3 flex items-center gap-2 pointer-events-none">
-            <span className="text-white/60 text-2xs">Lanzar</span>
-            <div className="w-14 h-14 rounded-full border-2 border-amber-400/50 bg-amber-500/10 flex items-center justify-center">
-              <Shield size={20} className="text-amber-300" />
-            </div>
-          </div>
-        </div>
-
-        {/* Tarjeta educativa: lo que el jugador esta mirando (ciclo de la finca) */}
-        {leccion && (
-          <div
-            className="bg-amber-950/50 border border-amber-600/40 rounded-xl p-3 text-center"
-            role="status"
-          >
-            <Sprout size={14} className="inline-block mr-1 text-amber-300" aria-hidden="true" />
-            <span className="text-sm text-amber-100 font-medium">{leccion}</span>
-          </div>
-        )}
-
-        {/* Mensaje (leccion) */}
-        {mensaje && (
-          <div
-            className="bg-emerald-950/60 border border-emerald-700/40 rounded-xl p-3 text-center"
-            role="status"
-          >
-            <Bug size={14} className="inline-block mr-1 text-emerald-400" aria-hidden="true" />
-            <span className="text-sm text-emerald-100 font-medium">{mensaje}</span>
-          </div>
-        )}
-
-        {/* Selector de beneficos */}
-        <div className="flex gap-2 justify-center flex-wrap" role="group" aria-label="Elige el organismo benefico">
-          {BENEFICOS_DOOM.map((b) => (
-            <button
-              key={b.id}
-              type="button"
-              data-selected={beneficoSel === b.id}
-              onClick={() => {
-                setBeneficoSel(b.id);
-                worldRef.current = cambiarBenefico(worldRef.current, b.id);
-              }}
-              aria-pressed={beneficoSel === b.id}
-              className="min-h-[52px] px-3 rounded-xl border-2 flex flex-col items-center gap-0.5 transition active:scale-95"
-              style={{
-                borderColor: beneficoSel === b.id ? b.color : 'rgba(255,255,255,0.15)',
-                backgroundColor: beneficoSel === b.id ? `${b.color}20` : 'rgba(255,255,255,0.05)',
-              }}
+          {/* ── Ficha educativa al controlar bien una plaga ── */}
+          {fase === 'jugando' && ficha && (
+            <div
+              className="absolute inset-x-2 bottom-2 bg-emerald-950/95 border-2 border-emerald-400/60 rounded-xl p-3 shadow-xl"
+              role="status"
+              aria-live="polite"
             >
-              <span className="text-xl" aria-hidden="true">{b.emoji}</span>
-              <span className="text-2xs font-bold text-white/80 leading-tight">{b.nombre}</span>
-            </button>
-          ))}
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <span className="flex items-center gap-1 text-emerald-300 font-black text-xs">
+                  <GraduationCap size={14} aria-hidden="true" /> ¡Control biologico!
+                </span>
+                <span className="text-lime-300 font-black text-xs">+{ficha.puntos}{ficha.combo > 1 ? ` · combo x${ficha.combo}` : ''}</span>
+              </div>
+              <p className="text-2xs text-white/90 leading-snug">
+                <b className="text-amber-200">{ficha.benefico}</b>
+                <span className="text-white/60"> ({ficha.beneficoCientifico})</span>
+                <span className="text-emerald-300"> controla a </span>
+                <b className="text-red-200">{ficha.plaga}</b>.
+              </p>
+              <p className="text-2xs text-emerald-100/90 leading-snug mt-1">{ficha.porQue}</p>
+            </div>
+          )}
+
+          {/* ── Mensaje breve (acierto parcial / error / aviso) ── */}
+          {fase === 'jugando' && mensaje && !ficha && (
+            <div
+              className="absolute inset-x-2 bottom-2 rounded-lg p-2 text-center border text-xs font-medium"
+              style={{
+                backgroundColor: mensajeTipo === 'error' ? 'rgba(67,20,7,0.92)'
+                  : mensajeTipo === 'acierto' ? 'rgba(6,78,59,0.92)' : 'rgba(15,23,42,0.9)',
+                borderColor: mensajeTipo === 'error' ? 'rgba(248,113,113,0.5)'
+                  : mensajeTipo === 'acierto' ? 'rgba(52,211,153,0.5)' : 'rgba(148,163,184,0.3)',
+                color: mensajeTipo === 'error' ? '#fecaca' : mensajeTipo === 'acierto' ? '#bbf7d0' : '#e2e8f0',
+              }}
+              role="status"
+              aria-live="polite"
+            >
+              {mensaje}
+            </div>
+          )}
+
+          {/* ── Fin de juego (gano / perdio) con RECAP ── */}
+          {(fase === 'gano' || fase === 'perdio') && (
+            <div className="absolute inset-0 bg-black/85 flex flex-col items-center justify-start gap-2 p-3 overflow-y-auto">
+              <span className="text-4xl mt-1" aria-hidden="true">{fase === 'gano' ? '🌽🎉' : '🥀'}</span>
+              <h3 className="text-lg font-black text-white text-center">
+                {fase === 'gano' ? '¡Finca sana y productiva!' : 'El cultivo se enfermo'}
+              </h3>
+              <p className="text-xs text-emerald-100/80 text-center max-w-xs">
+                {fase === 'gano'
+                  ? `Controlaste las plagas con sus enemigos naturales. Puntaje: ${puntaje}.`
+                  : 'La vitalidad llego a cero. Identifica la plaga y suelta su benefico correcto mas rapido.'}
+              </p>
+              {aprendido.length > 0 && (
+                <div className="w-full max-w-xs bg-emerald-950/70 border border-emerald-700/40 rounded-lg p-2">
+                  <p className="text-2xs font-black text-emerald-300 mb-1 flex items-center gap-1">
+                    <GraduationCap size={12} aria-hidden="true" /> Lo que aprendiste:
+                  </p>
+                  <ul className="space-y-1.5">
+                    {aprendido.map((a) => (
+                      <li key={a.par} className="text-2xs text-white/85 leading-snug">
+                        <b className="text-red-200">{a.plaga}</b>
+                        <span className="text-emerald-400"> → </span>
+                        <b className="text-amber-200">{a.benefico}</b>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={reiniciar}
+                className="min-h-[50px] px-6 rounded-2xl bg-emerald-500 hover:bg-emerald-400 active:scale-95 transition text-emerald-950 font-black text-base flex items-center gap-2 mb-2"
+              >
+                <RotateCcw size={20} aria-hidden="true" /> Jugar otra vez
+              </button>
+            </div>
+          )}
+
+          {/* ── Controles tactiles visibles (solo mientras juega) ── */}
+          {fase === 'jugando' && (
+            <>
+              <div className="absolute bottom-2 left-2 flex flex-col items-center gap-0.5 pointer-events-none opacity-70">
+                <div className="w-12 h-12 rounded-full border-2 border-white/40 bg-white/5 flex items-center justify-center">
+                  <div className="w-5 h-5 rounded-full bg-white/30" />
+                </div>
+                <span className="text-white/70 text-2xs font-bold">Mover</span>
+              </div>
+              <div className="absolute bottom-2 right-2 flex flex-col items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={dispararTouch}
+                  aria-label="Soltar el benefico equipado"
+                  className="w-16 h-16 rounded-full border-2 border-amber-400/70 bg-amber-500/25 active:bg-amber-400/50 active:scale-90 transition flex items-center justify-center"
+                >
+                  <Shield size={26} className="text-amber-200" aria-hidden="true" />
+                </button>
+                <span className="text-white/70 text-2xs font-bold pointer-events-none">Soltar</span>
+              </div>
+            </>
+          )}
         </div>
 
-        {/* Controles desktop */}
+        {/* ── Tarjeta de la decoracion mirada (ciclo de la finca) ── */}
+        {fase === 'jugando' && leccion && (
+          <div className="bg-amber-950/50 border border-amber-600/40 rounded-xl p-2.5 text-center" role="status">
+            <Sprout size={13} className="inline-block mr-1 text-amber-300" aria-hidden="true" />
+            <span className="text-xs text-amber-100 font-medium">{leccion}</span>
+          </div>
+        )}
+
+        {/* ── Selector de beneficos ── */}
+        <div className="flex gap-1.5 justify-center flex-wrap" role="group" aria-label="Elige el organismo benefico a soltar">
+          {BENEFICOS_DOOM.map((b, i) => {
+            const sel = beneficoSel === b.id;
+            const recomendado = sugeridos.includes(b.id);
+            return (
+              <button
+                key={b.id}
+                type="button"
+                onClick={() => {
+                  setBeneficoSel(b.id);
+                  worldRef.current = cambiarBenefico(worldRef.current, b.id);
+                  beep('seleccion');
+                }}
+                aria-pressed={sel}
+                aria-label={`${b.nombre}. ${b.desc}${recomendado ? ' Recomendado esta ronda.' : ''}`}
+                title={`${b.nombre} — ${b.desc}`}
+                className="relative min-h-[54px] w-[60px] px-1 rounded-xl border-2 flex flex-col items-center justify-center gap-0.5 transition active:scale-95"
+                style={{
+                  borderColor: sel ? b.color : recomendado ? 'rgba(52,211,153,0.5)' : 'rgba(255,255,255,0.15)',
+                  backgroundColor: sel ? `${b.color}22` : 'rgba(255,255,255,0.05)',
+                }}
+              >
+                <span className="absolute top-0.5 left-1 text-2xs text-white/40 font-bold">{i + 1}</span>
+                <span className="text-lg" aria-hidden="true">{b.emoji}</span>
+                <span className="text-2xs font-bold text-white/80 leading-none text-center">{b.nombre.split(' ')[0]}</span>
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-2xs text-emerald-400/70 text-center -mt-1">
+          Verde = recomendado para esta ronda. Toca para equipar.
+        </p>
+
+        {/* ── Controles desktop ── */}
         <div className="text-2xs text-slate-500 text-center leading-relaxed">
-          WASD = mover | Q/E = lateral | Click = apuntar + lanzar | Raton = girar
+          WASD = mover · Q/E = lateral · raton = girar · barra/F = soltar · 1-5 = elegir benefico
         </div>
 
-        {/* Info par plaga-benefico */}
+        {/* ── Referencia: pares plaga-benefico reales (control biologico) ── */}
         <details className="text-2xs text-slate-400">
           <summary className="cursor-pointer font-bold text-emerald-400/80">
-            Pares plaga-benefico (control biologico real)
+            Pares plaga → control biologico (datos del grafo de Chagra)
           </summary>
-          <ul className="mt-2 space-y-1 pl-3">
+          <ul className="mt-2 space-y-1.5 pl-1">
             {PLAGAS_DOOM.map((plaga) => {
               const benef = BENEFICOS_DOOM.find((b) => b.id === plaga.controladoPor);
               return (
-                <li key={plaga.id} className="flex items-center gap-1">
-                  <span>{plaga.emoji}</span>
-                  <span className="text-white/80">{plaga.nombre}</span>
-                  <span className="text-slate-500">→</span>
-                  <span>{benef?.emoji}</span>
-                  <span className="text-emerald-300">{benef?.nombre || plaga.controladoPor}</span>
+                <li key={plaga.id} className="leading-snug">
+                  <span className="flex items-center gap-1 flex-wrap">
+                    <span aria-hidden="true">{plaga.emoji}</span>
+                    <b className="text-white/85">{plaga.nombre}</b>
+                    <span className="text-slate-600 italic">({plaga.cientifico})</span>
+                    <ChevronRight size={11} className="text-slate-600" aria-hidden="true" />
+                    <span aria-hidden="true">{benef?.emoji}</span>
+                    <span className="text-emerald-300">{benef?.nombre || plaga.controladoPor}</span>
+                  </span>
                 </li>
               );
             })}

--- a/src/components/juego/__tests__/doomFinca.test.js
+++ b/src/components/juego/__tests__/doomFinca.test.js
@@ -1,0 +1,224 @@
+/*
+ * Tests del minijuego "Doom de la Finca": integridad de datos (pares plaga ->
+ * control biologico) y logica del motor (apuntar, soltar benefico correcto vs
+ * equivocado, rondas, victoria/derrota). El loop debe ENSEÑAR control
+ * biologico real, asi que los tests verifican que cada plaga tenga su
+ * controlador definido y que aplicar el equivocado NO la elimine.
+ *
+ * i18n: minijuego solo es-CO; sin strings de UI aqui.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  PLAGAS_DOOM, BENEFICOS_DOOM, ESCENARIOS, CONFIG_DOOM, MAPA,
+} from '../doomFincaData';
+import {
+  createWorld, tickWorld, plagaObjetivo, lanzarBenefico, cambiarBenefico,
+  avanzarRonda, isWall, movePlayer,
+} from '../../../services/doomFincaEngine';
+
+// ── INTEGRIDAD DE DATOS ────────────────────────────────────────────
+
+describe('PLAGAS_DOOM — shape y par de control real', () => {
+  it('cada plaga tiene nombre comun, cientifico, forma y un controlador valido', () => {
+    const benefIds = new Set(BENEFICOS_DOOM.map((b) => b.id));
+    for (const p of PLAGAS_DOOM) {
+      expect(p.id).toBeTruthy();
+      expect(p.nombre).toBeTruthy();
+      expect(p.cientifico).toBeTruthy();
+      expect(p.forma).toBeTruthy();
+      expect(p.cultivo).toBeTruthy();
+      expect(p.porQue.length).toBeGreaterThan(20);
+      // el controlador declarado debe existir entre los beneficos
+      expect(benefIds.has(p.controladoPor)).toBe(true);
+    }
+  });
+
+  it('los ids de plaga son unicos', () => {
+    const ids = PLAGAS_DOOM.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('BENEFICOS_DOOM — shape', () => {
+  it('cada benefico tiene nombre, cientifico, emoji, color y mecanismo', () => {
+    for (const b of BENEFICOS_DOOM) {
+      expect(b.id).toBeTruthy();
+      expect(b.nombre).toBeTruthy();
+      expect(b.cientifico).toBeTruthy();
+      expect(b.emoji).toBeTruthy();
+      expect(b.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+      expect(b.mecanismo.length).toBeGreaterThan(20);
+    }
+  });
+});
+
+describe('ESCENARIOS — rondas coherentes', () => {
+  it('hay al menos 3 rondas', () => {
+    expect(ESCENARIOS.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('cada ronda referencia plagas reales y tiene spawns suficientes', () => {
+    const plagaIds = new Set(PLAGAS_DOOM.map((p) => p.id));
+    const benefIds = new Set(BENEFICOS_DOOM.map((b) => b.id));
+    for (const esc of ESCENARIOS) {
+      expect(esc.plagas.length).toBeGreaterThan(0);
+      expect(esc.spawns.length).toBeGreaterThanOrEqual(1);
+      for (const pid of esc.plagas) expect(plagaIds.has(pid)).toBe(true);
+      for (const bid of esc.beneficosSugeridos) expect(benefIds.has(bid)).toBe(true);
+      // los spawns no deben caer en pared
+      for (const s of esc.spawns) expect(isWall(MAPA, s.x, s.y)).toBe(false);
+    }
+  });
+
+  it('el benefico sugerido principal de la ronda controla al menos una de sus plagas', () => {
+    for (const esc of ESCENARIOS) {
+      const controladores = esc.plagas.map((pid) => PLAGAS_DOOM.find((p) => p.id === pid)?.controladoPor);
+      const cubre = esc.beneficosSugeridos.some((b) => controladores.includes(b));
+      expect(cubre).toBe(true);
+    }
+  });
+});
+
+// ── LOGICA DEL MOTOR ───────────────────────────────────────────────
+
+describe('createWorld — estado inicial', () => {
+  it('arranca en ronda 0 con las plagas del primer escenario vivas', () => {
+    const w = createWorld();
+    expect(w.rondaIdx).toBe(0);
+    expect(w.vitalidad).toBe(CONFIG_DOOM.vitalidadInicial);
+    expect(w.pests.length).toBe(ESCENARIOS[0].plagas.length);
+    expect(w.pests.every((p) => p.vivo)).toBe(true);
+    expect(w.terminado).toBe(false);
+    expect(w.puntaje).toBe(0);
+  });
+});
+
+describe('plagaObjetivo — apuntar', () => {
+  it('detecta la plaga al frente y dice si el benefico es correcto', () => {
+    const w = createWorld();
+    const pest = w.pests[0];
+    // colocar al jugador justo detras de la plaga, mirandola
+    w.player = { x: pest.x - 1, y: pest.y, angulo: 0 };
+    const correctBenef = pest.controladoPor;
+    const ok = plagaObjetivo(w.player, correctBenef, w.pests, CONFIG_DOOM.alcanceLanzamiento);
+    expect(ok.plaga).toBeTruthy();
+    expect(ok.plaga.tipo).toBe(pest.tipo);
+    expect(ok.correcto).toBe(true);
+    // con un benefico distinto, sigue detectando la plaga pero correcto=false
+    const otro = BENEFICOS_DOOM.find((b) => b.id !== correctBenef).id;
+    const bad = plagaObjetivo(w.player, otro, w.pests, CONFIG_DOOM.alcanceLanzamiento);
+    expect(bad.plaga).toBeTruthy();
+    expect(bad.correcto).toBe(false);
+  });
+
+  it('no detecta plagas fuera del alcance', () => {
+    const w = createWorld();
+    const pest = w.pests[0];
+    w.player = { x: pest.x - 1, y: pest.y, angulo: 0 };
+    const lejos = plagaObjetivo(w.player, pest.controladoPor, w.pests, 0.2);
+    expect(lejos.plaga).toBeNull();
+  });
+});
+
+describe('lanzarBenefico — control biologico correcto vs equivocado', () => {
+  it('el benefico equivocado NO controla la plaga (educa, no elimina)', () => {
+    const w = createWorld();
+    const pest = w.pests[0];
+    w.player = { x: pest.x - 0.8, y: pest.y, angulo: 0 };
+    const otro = BENEFICOS_DOOM.find((b) => b.id !== pest.controladoPor).id;
+    const r = lanzarBenefico(w.player, otro, w.pests, CONFIG_DOOM.alcanceLanzamiento);
+    expect(r.resultado).toBe('equivocado');
+    expect(pest.vivo).toBe(true);
+  });
+
+  it('el benefico correcto reduce vitalidad y termina controlando la plaga', () => {
+    const w = createWorld();
+    const pest = w.pests[0];
+    w.player = { x: pest.x - 0.8, y: pest.y, angulo: 0 };
+    // disparar hasta controlarla
+    let res;
+    for (let i = 0; i < pest.vitalidadMax + 2; i += 1) {
+      res = lanzarBenefico(w.player, pest.controladoPor, w.pests, CONFIG_DOOM.alcanceLanzamiento);
+      if (res.resultado === 'control') break;
+    }
+    expect(res.resultado).toBe('control');
+    expect(pest.vivo).toBe(false);
+  });
+});
+
+describe('tickWorld — flujo de juego', () => {
+  it('soltar el benefico correcto suma puntaje y registra lo aprendido', () => {
+    let w = createWorld();
+    const pest = w.pests[0];
+    w.player = { x: pest.x - 0.7, y: pest.y, angulo: 0 };
+    // suficientes ticks de fuego para controlar la primera plaga
+    for (let i = 0; i < (pest.vitalidadMax + 1) * (CONFIG_DOOM.cooldownLanzamiento + 2); i += 1) {
+      w.player = { x: pest.x - 0.7, y: pest.y, angulo: 0 }; // mantener mira
+      w = tickWorld(w, { fire: true });
+      if (!w.pests[0].vivo) break;
+    }
+    expect(w.pests[0].vivo).toBe(false);
+    expect(w.puntaje).toBeGreaterThan(0);
+    expect(w.aprendido.length).toBeGreaterThan(0);
+    expect(w.aprendido[0].benefico).toBeTruthy();
+  });
+
+  it('la vitalidad baja si una plaga toca al jugador y termina en derrota a 0', () => {
+    let w = createWorld();
+    // pegar todas las plagas al jugador
+    for (const p of w.pests) { p.x = w.player.x; p.y = w.player.y; }
+    let safety = 0;
+    while (!w.terminado && safety < 5000) {
+      // mantener plagas encima
+      for (const p of w.pests) { if (p.vivo) { p.x = w.player.x; p.y = w.player.y; } }
+      w = tickWorld(w, {});
+      safety += 1;
+    }
+    expect(w.terminado).toBe(true);
+    expect(w.ganado).toBe(false);
+    expect(w.vitalidad).toBe(0);
+  });
+
+  it('al controlar todas las plagas de una ronda intermedia, marca transicion (no fin)', () => {
+    let w = createWorld();
+    // matar todas a mano
+    for (const p of w.pests) { p.vivo = false; }
+    w = tickWorld(w, {});
+    expect(w.rondaTransicion).toBe(true);
+    expect(w.terminado).toBe(false);
+  });
+});
+
+describe('avanzarRonda — progresion', () => {
+  it('pasa de ronda y repuebla plagas; en la ultima ronda gana el juego', () => {
+    let w = createWorld();
+    // forzar transicion ronda 0 -> 1
+    w = avanzarRonda(w);
+    expect(w.rondaIdx).toBe(1);
+    expect(w.pests.length).toBe(ESCENARIOS[1].plagas.length);
+    expect(w.terminado).toBe(false);
+    // saltar hasta la ultima y una mas -> gana
+    for (let i = w.rondaIdx; i < ESCENARIOS.length; i += 1) {
+      w = avanzarRonda(w);
+    }
+    expect(w.terminado).toBe(true);
+    expect(w.ganado).toBe(true);
+  });
+});
+
+describe('movePlayer / cambiarBenefico — utilidades', () => {
+  it('no atraviesa paredes', () => {
+    const player = { x: 1.2, y: 1.2, angulo: 0 };
+    // moverse hacia el seto del perimetro (pared)
+    const np = movePlayer(MAPA, { ...player, angulo: Math.PI }, 5, 0);
+    expect(isWall(MAPA, np.x, np.y)).toBe(false);
+  });
+
+  it('cambiarBenefico solo acepta ids validos', () => {
+    const w = createWorld();
+    const w2 = cambiarBenefico(w, 'beauveria');
+    expect(w2.beneficoEquipado).toBe('beauveria');
+    const w3 = cambiarBenefico(w, 'inexistente');
+    expect(w3).toBe(w);
+  });
+});

--- a/src/components/juego/doomFincaData.js
+++ b/src/components/juego/doomFincaData.js
@@ -2,11 +2,15 @@
  * doomFincaData - datos para el nivel Doom agroecologico primera persona.
  *
  * GANCHO PEDAGOGICO: el jugador recorre una finca andina real en primera
- * persona, identifica plagas reales y las controla lanzando el organismo
- * benefico o biopreparado CORRECTO. Los pares plaga->benefico son
- * agronomicamente reales (ICA, CIAT, Cenicafe, FAO). El escenario muestra
- * el "kit completo" de la finca: setos vivos de arboles, corral de animales,
- * compostera (abono), camas de cultivo, colmena, girasoles para polinizadores.
+ * persona, IDENTIFICA plagas reales (nombre comun + cientifico visibles en
+ * pantalla) y las controla soltando el organismo benefico o biopreparado
+ * CORRECTO. Los pares plaga->controlador son agronomicamente reales y salen
+ * del grafo de conocimiento de Chagra (Apache AGE, fuentes ICA / CIAT /
+ * Cenicafe / FAO; ver public/grafo-relations.json, relacion pest_controllers).
+ *
+ * El escenario muestra el "kit completo" de la finca: setos vivos, corral de
+ * animales, compostera, camas de cultivo, colmena, girasoles para
+ * polinizadores; todo se puede mirar para leer su rol en el ciclo.
  *
  * Motor raycaster propio en Canvas 2D (sin librerias 3D). Solo este repo.
  *
@@ -24,23 +28,23 @@
  *   4 = compostera (pila de abono encajonada)
  *   5 = cama de cultivo elevada (con plantas)
  *
- * Diseno: perimetro de seto vivo (arboles), camas de cultivo formando
- * pasillos, un corral de madera, una compostera y una bodega de adobe,
- * para que el recorrido se sienta una finca de verdad y no un pasillo vacio.
+ * Diseno abierto: pocos obstaculos centrales para que el jugador vea las
+ * plagas desde lejos (la queja #1 fue "no se distingue nada"). Las camas de
+ * cultivo se arriman a los bordes; el centro queda despejado para combatir.
  */
 export const MAPA = [
   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
   [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 5, 5, 5, 0, 0, 5, 5, 5, 0, 0, 0, 1],
-  [1, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1],
-  [1, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1],
+  [1, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 5, 5, 0, 1],
+  [1, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 1],
+  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
   [1, 0, 0, 0, 0, 0, 0, 3, 3, 0, 0, 0, 0, 0, 0, 1],
   [1, 0, 0, 0, 0, 0, 0, 3, 3, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 2, 2, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1],
-  [1, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1],
-  [1, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
-  [1, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 1],
-  [1, 0, 0, 0, 4, 4, 4, 0, 0, 5, 5, 5, 0, 0, 0, 1],
+  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+  [1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+  [1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+  [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1],
+  [1, 0, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 1],
   [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
   [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
 ];
@@ -94,25 +98,85 @@ export const MATERIALES = {
 
 /**
  * Decoraciones del escenario: billboards NO hostiles, solo ambiente y
- * pedagogia. El jugador puede mirarlas para leer su rol en la finca
- * (abono -> biopreparado, abejas -> polinizacion, arbol -> sombra/silvopastoreo).
+ * pedagogia. El jugador puede mirarlas para leer su rol en la finca.
  * Coordenadas en celdas del mundo (transitables).
  */
 export const DECORACIONES = [
-  { tipo: 'arbol', x: 2.5, y: 11.5, leccion: 'Los arboles dan sombra, frenan el viento y sus hojas alimentan la compostera.' },
-  { tipo: 'arbol', x: 13.5, y: 2.5, leccion: 'Cerca viva: barrera natural que aloja aves y enemigos de las plagas.' },
-  { tipo: 'colmena', x: 13.5, y: 5.5, leccion: 'La colmena: las abejas polinizan los cultivos y suben la cosecha.' },
-  { tipo: 'girasol', x: 7.5, y: 9.5, leccion: 'Flores como el girasol atraen abejas y avispas beneficas.' },
-  { tipo: 'girasol', x: 8.5, y: 9.5, leccion: 'Mas flores = mas polinizadores y mas control natural de plagas.' },
-  { tipo: 'gallina', x: 2.5, y: 5.5, leccion: 'Las gallinas comen larvas y plagas; su gallinaza nutre el bocashi.' },
-  { tipo: 'vaca', x: 13.5, y: 11.5, leccion: 'La vaca aporta bonita: base del biol y del supermagro para las plantas.' },
-  { tipo: 'abono', x: 5.5, y: 10.5, leccion: 'Compostera: estiercol + hojas se vuelven abono que alimenta el cultivo.' },
+  { tipo: 'arbol', x: 2.5, y: 12.2, leccion: 'Arbol: da sombra, frena el viento y sus hojas alimentan la compostera.' },
+  { tipo: 'arbol', x: 13.5, y: 1.6, leccion: 'Cerca viva: barrera natural que aloja aves y enemigos de las plagas.' },
+  { tipo: 'colmena', x: 14.2, y: 5.5, leccion: 'Colmena: las abejas polinizan los cultivos y suben la cosecha.' },
+  { tipo: 'girasol', x: 7.5, y: 11.4, leccion: 'Las flores (girasol) atraen abejas, avispas y crisopas beneficas.' },
+  { tipo: 'girasol', x: 8.5, y: 11.4, leccion: 'Mas flores = mas polinizadores y mas control natural de plagas.' },
+  { tipo: 'gallina', x: 2.6, y: 8.5, leccion: 'Las gallinas comen larvas y plagas; su gallinaza nutre el bocashi.' },
+  { tipo: 'vaca', x: 13.5, y: 12.0, leccion: 'La vaca aporta bonita: base del biol y del supermagro para las plantas.' },
+  { tipo: 'abono', x: 13.0, y: 10.5, leccion: 'Compostera: estiercol + hojas se vuelven abono que nutre el cultivo.' },
 ];
 
 /**
- * Plagas que aparecen en el nivel Doom.
- * Cada una tiene su par benefico que la controla (agronomicamente real).
- * `forma` define el sprite procedural que dibuja el render.
+ * BENEFICOS / biopreparados que el jugador puede equipar y soltar.
+ * Cada uno tiene una "categoria" (tipo) para el render del frasco y una
+ * explicacion del mecanismo (el POR QUE del control biologico).
+ *
+ * Nombres y mecanismos tomados del grafo (pest_controllers) + literatura
+ * de control biologico aplicado en Colombia (ICA/CIAT/Cenicafe).
+ */
+export const BENEFICOS_DOOM = [
+  {
+    id: 'trichogramma',
+    nombre: 'Avispita Trichogramma',
+    cientifico: 'Trichogramma spp.',
+    emoji: '🐝',
+    color: '#f5c842',
+    tipo: 'avispa',
+    desc: 'Parasitoide de huevos.',
+    mecanismo: 'La avispita pone su huevo DENTRO del huevo de la mariposa-polilla. La larva nunca nace: no hay gusano que coma el cultivo.',
+  },
+  {
+    id: 'catarina',
+    nombre: 'Mariquita',
+    cientifico: 'Hippodamia convergens',
+    emoji: '🐞',
+    color: '#e74c3c',
+    tipo: 'mariquita',
+    desc: 'Depredador de pulgones.',
+    mecanismo: 'Adultos y larvas de mariquita devoran colonias enteras de pulgones y cochinillas: hasta 50 al dia.',
+  },
+  {
+    id: 'crisopa',
+    nombre: 'Crisopa (leon de afidos)',
+    cientifico: 'Chrysoperla externa',
+    emoji: '🦗',
+    color: '#7ed957',
+    tipo: 'crisopa',
+    desc: 'Depredador generalista.',
+    mecanismo: 'La larva de crisopa, el "leon de afidos", chupa pulgones, huevos y acaros con sus mandibulas curvas.',
+  },
+  {
+    id: 'beauveria',
+    nombre: 'Beauveria bassiana',
+    cientifico: 'Beauveria bassiana',
+    emoji: '🍄',
+    color: '#eef0e6',
+    tipo: 'hongo',
+    desc: 'Hongo entomopatogeno.',
+    mecanismo: 'El hongo germina sobre el insecto, lo penetra y lo coloniza por dentro hasta secarlo. Estandar contra broca y mosca blanca.',
+  },
+  {
+    id: 'bt',
+    nombre: 'Bt (Bacillus thuringiensis)',
+    cientifico: 'Bacillus thuringiensis',
+    emoji: '🧫',
+    color: '#9bd3ff',
+    tipo: 'bacteria',
+    desc: 'Bioinsecticida para orugas.',
+    mecanismo: 'La oruga come la hoja con Bt; el cristal de la bacteria rompe su intestino y deja de comer en horas. No afecta abejas ni gente.',
+  },
+];
+
+/**
+ * PLAGAS del nivel. Cada una declara su par benefico CORRECTO (controladoPor)
+ * y por que (`porQue`), tomado del grafo. `forma` define el sprite procedural.
+ * `cultivo` ata la plaga a un cultivo real para el contexto.
  */
 export const PLAGAS_DOOM = [
   {
@@ -121,12 +185,27 @@ export const PLAGAS_DOOM = [
     cientifico: 'Spodoptera frugiperda',
     emoji: '🐛',
     forma: 'oruga',
-    color: '#7c9e38',
-    dano: 'Devora el cogollo del maiz.',
-    /** Id del benefico que la controla */
-    controladoPor: 'trichogramma',
-    velocidad: 0.012,
-    vitalidad: 1,
+    color: '#8aa84a',
+    cultivo: 'Maiz',
+    dano: 'Devora el cogollo del maiz y deja la planta sin punto de crecimiento.',
+    controladoPor: 'bt',
+    porQue: 'Es una ORUGA que come hoja: el Bt la intoxica al primer bocado. Trichogramma tambien sirve atacando el HUEVO antes de que nazca.',
+    velocidad: 0.014,
+    vitalidad: 2,
+  },
+  {
+    id: 'gusano_mazorca',
+    nombre: 'Gusano de la mazorca',
+    cientifico: 'Helicoverpa zea',
+    emoji: '🐛',
+    forma: 'oruga',
+    color: '#c98a4a',
+    cultivo: 'Maiz',
+    dano: 'Se mete en la mazorca y se come los granos en formacion.',
+    controladoPor: 'bt',
+    porQue: 'Otra oruga masticadora: el Bt es el control biologico estandar. Tambien cae con chinche depredador (podisus) y crisopa.',
+    velocidad: 0.013,
+    vitalidad: 2,
   },
   {
     id: 'moscablanca',
@@ -134,22 +213,12 @@ export const PLAGAS_DOOM = [
     cientifico: 'Bemisia tabaci',
     emoji: '🪰',
     forma: 'mosca',
-    color: '#e8e8e8',
-    dano: 'Chupa savia y transmite virus.',
+    color: '#f2f2f2',
+    cultivo: 'Frijol / hortalizas',
+    dano: 'Chupa savia y transmite virus que enrollan y amarillan la hoja.',
     controladoPor: 'beauveria',
-    velocidad: 0.018,
-    vitalidad: 1,
-  },
-  {
-    id: 'afido',
-    nombre: 'Afido del frijol',
-    cientifico: 'Aphis fabae',
-    emoji: '🦟',
-    forma: 'afido',
-    color: '#3b5e2b',
-    dano: 'Forma colonias y debilita la planta.',
-    controladoPor: 'catarina',
-    velocidad: 0.010,
+    porQue: 'Insecto de cuerpo blando: el hongo Beauveria lo penetra y lo seca. Tambien la parasita la avispita Encarsia.',
+    velocidad: 0.020,
     vitalidad: 1,
   },
   {
@@ -158,54 +227,80 @@ export const PLAGAS_DOOM = [
     cientifico: 'Hypothenemus hampei',
     emoji: '🪲',
     forma: 'escarabajo',
-    color: '#4a2c17',
-    dano: 'Perfora el grano de cafe.',
+    color: '#3a2410',
+    cultivo: 'Cafe',
+    dano: 'Perfora el grano de cafe y arruina la calidad de la cosecha.',
     controladoPor: 'beauveria',
-    velocidad: 0.008,
-    vitalidad: 2,
+    porQue: 'El escarabajo vive DENTRO del grano: solo un hongo entomopatogeno como Beauveria lo alcanza ahi. Estandar Cenicafe.',
+    velocidad: 0.009,
+    vitalidad: 3,
+  },
+  {
+    id: 'afido',
+    nombre: 'Pulgon / afido',
+    cientifico: 'Aphis fabae',
+    emoji: '🐜',
+    forma: 'afido',
+    color: '#4a7a2e',
+    cultivo: 'Frijol',
+    dano: 'Forma colonias pegajosas que chupan savia y debilitan los brotes.',
+    controladoPor: 'catarina',
+    porQue: 'La mariquita y su larva devoran colonias de pulgones a docenas. La crisopa tambien los caza.',
+    velocidad: 0.011,
+    vitalidad: 1,
+  },
+  {
+    id: 'aranita',
+    nombre: 'Arana roja',
+    cientifico: 'Tetranychus urticae',
+    emoji: '🕷️',
+    forma: 'acaro',
+    color: '#c0392b',
+    cultivo: 'Mora / tomate',
+    dano: 'Acaro que pica el enves de la hoja, la puntea y la seca.',
+    controladoPor: 'crisopa',
+    porQue: 'Acaro chupador diminuto: lo controlan depredadores como la crisopa y acaros benefcos (neoseiulus). El hongo Beauveria ayuda.',
+    velocidad: 0.012,
+    vitalidad: 1,
   },
 ];
 
 /**
- * Beneficos / biopreparados que el jugador puede equipar y lanzar.
+ * Definicion de los TRES escenarios (rondas) del juego. Cada uno tiene su
+ * cultivo, las plagas que aparecen, una intro y los spawns. Suben en
+ * dificultad. Cierran el ciclo: maiz -> cafe -> hortalizas.
  */
-export const BENEFICOS_DOOM = [
+export const ESCENARIOS = [
   {
-    id: 'trichogramma',
-    nombre: 'Avispita Trichogramma',
-    emoji: '🐝',
-    color: '#f5c842',
-    desc: 'Parasita huevos del cogollero.',
+    id: 'maiz',
+    nombre: 'La milpa (maiz)',
+    cultivo: 'Maiz',
+    icono: '🌽',
+    intro: 'Tu maiz esta espigando. El gusano cogollero y el de la mazorca lo atacan. Sueltales el Bt (bioinsecticida para orugas).',
+    plagas: ['cogollero', 'cogollero', 'gusano_mazorca'],
+    spawns: [{ x: 8.5, y: 4.5 }, { x: 11.5, y: 7.5 }, { x: 6.5, y: 8.5 }],
+    beneficosSugeridos: ['bt', 'trichogramma', 'crisopa'],
   },
   {
-    id: 'catarina',
-    nombre: 'Mariquita',
-    emoji: '🐞',
-    color: '#e74c3c',
-    desc: 'Devora afidos y pulgones.',
+    id: 'cafe',
+    nombre: 'El cafetal',
+    cultivo: 'Cafe',
+    icono: '☕',
+    intro: 'Floracion del cafe. La broca perfora el grano y la mosca blanca chupa savia. Ambas caen con el hongo Beauveria bassiana.',
+    plagas: ['broca', 'broca', 'moscablanca'],
+    spawns: [{ x: 7.5, y: 4.5 }, { x: 10.5, y: 9.5 }, { x: 4.5, y: 9.5 }],
+    beneficosSugeridos: ['beauveria', 'crisopa', 'trichogramma'],
   },
   {
-    id: 'beauveria',
-    nombre: 'Beauveria bassiana',
-    emoji: '🍄',
-    color: '#f0f0e8',
-    desc: 'Hongo que controla mosca blanca y broca.',
+    id: 'huerta',
+    nombre: 'La huerta',
+    cultivo: 'Frijol y mora',
+    icono: '🫘',
+    intro: 'Hortalizas y frutales. Pulgones, mosca blanca y arana roja debilitan las plantas. Usa mariquita, crisopa y Beauveria.',
+    plagas: ['afido', 'aranita', 'moscablanca', 'afido'],
+    spawns: [{ x: 6.5, y: 4.5 }, { x: 11.5, y: 5.5 }, { x: 9.5, y: 9.5 }, { x: 4.5, y: 7.5 }],
+    beneficosSugeridos: ['catarina', 'crisopa', 'beauveria'],
   },
-];
-
-/**
- * Posiciones iniciales de las plagas en coordenadas del mundo
- * (cada celda del mapa = 1.0 unidad, centradas en la celda transitable).
- */
-export const SPAWNS_PLAGAS = [
-  { tipo: 'cogollero', x: 5.5, y: 5.5 },
-  { tipo: 'moscablanca', x: 10.5, y: 4.5 },
-  { tipo: 'afido', x: 5.5, y: 9.5 },
-  { tipo: 'broca', x: 10.5, y: 9.5 },
-  { tipo: 'cogollero', x: 8.5, y: 7.5 },
-  { tipo: 'moscablanca', x: 2.5, y: 8.5 },
-  { tipo: 'afido', x: 13.5, y: 8.5 },
-  { tipo: 'broca', x: 8.5, y: 2.5 },
 ];
 
 /**
@@ -230,7 +325,6 @@ export const PALETA = {
 
 /**
  * Tamano de celda del mapa (en unidades del mundo).
- * El raycaster usa este tamano para las paredes.
  */
 export const CELDA = 1.0;
 
@@ -240,7 +334,7 @@ export const CELDA = 1.0;
 export const JUGADOR_INICIAL = {
   x: 2.5,
   y: 2.5,
-  angulo: 0, // radianes, mirando al este (derecha)
+  angulo: 0.5, // radianes, mirando hacia el centro del campo
 };
 
 /**
@@ -249,16 +343,15 @@ export const JUGADOR_INICIAL = {
 export const CONFIG_DOOM = {
   vitalidadInicial: 100,
   vitalidadMax: 100,
-  danoPorPlaga: 15,          // vitalidad que quita una plaga al alcanzar
-  cooldownLanzamiento: 30,   // frames entre lanzamientos
-  alcanceLanzamiento: 4.0,   // distancia maxima del benefico
-  metaPlagas: 8,             // total de plagas a eliminar
-  fov: Math.PI / 3,         // 60 grados campo de vision
+  danoPorPlaga: 9,           // vitalidad que quita una plaga al alcanzar (por tick)
+  cooldownLanzamiento: 26,   // frames entre lanzamientos
+  alcanceLanzamiento: 5.0,   // distancia maxima del benefico
+  fov: Math.PI / 3,          // 60 grados campo de vision
   resX: 240,                 // columnas del raycaster (strips)
   resY: 180,                 // filas del canvas logico
-  nieblaInicio: 6.0,        // distancia donde empieza la neblina de campo
-  nieblaFin: 14.0,          // distancia donde la neblina es total
-  velMovimiento: 0.04,       // velocidad de movimiento
-  velRotacion: 0.04,         // velocidad de rotacion (rad/frame)
-  velRotacionTouch: 0.005,   // sensibilidad rotacion touch
+  nieblaInicio: 8.0,         // distancia donde empieza la neblina de campo
+  nieblaFin: 18.0,           // distancia donde la neblina es total
+  velMovimiento: 0.045,      // velocidad de movimiento
+  velRotacion: 0.045,        // velocidad de rotacion (rad/frame, teclado)
+  velRotacionTouch: 0.006,   // sensibilidad rotacion touch
 };

--- a/src/services/agentSoundService.js
+++ b/src/services/agentSoundService.js
@@ -87,4 +87,29 @@ export const agentSounds = {
   cancel() {
     tone({ freq: 360, duration: 0.15, type: 'triangle', volume: 0.05 });
   },
+  // ── Cues del minijuego Doom de la finca ──
+  /** Plaga controlada con el benefico correcto (arpegio ascendente). */
+  acierto() {
+    tone({ freq: 523, duration: 0.10, type: 'triangle', volume: 0.06 });
+    setTimeout(() => tone({ freq: 659, duration: 0.10, type: 'triangle', volume: 0.06 }), 60);
+    setTimeout(() => tone({ freq: 784, duration: 0.14, type: 'triangle', volume: 0.06 }), 120);
+  },
+  /** Benefico equivocado (buzz corto descendente, no agresivo). */
+  fallo() {
+    tone({ freq: 220, freqEnd: 160, duration: 0.18, type: 'square', volume: 0.04 });
+  },
+  /** Cambio de benefico / selector (pop suave). */
+  seleccion() {
+    tone({ freq: 600, duration: 0.06, type: 'triangle', volume: 0.04 });
+  },
+  /** Fanfarria de victoria. */
+  victoria() {
+    [523, 659, 784, 1046].forEach((f, i) => {
+      setTimeout(() => tone({ freq: f, duration: 0.18, type: 'triangle', volume: 0.06 }), i * 110);
+    });
+  },
+  /** Derrota (tono grave descendente). */
+  derrota() {
+    tone({ freq: 330, freqEnd: 160, duration: 0.5, type: 'sine', volume: 0.06 });
+  },
 };

--- a/src/services/doomFincaEngine.js
+++ b/src/services/doomFincaEngine.js
@@ -2,15 +2,28 @@
  * doomFincaEngine - motor raycaster puro para el nivel Doom agroecologico.
  *
  * Funciones puras: sin DOM, sin React, sin canvas. Toman estado, devuelven
- * estado nuevo. Totalmente testeable. Patron identico a defensoresGameEngine.
+ * estado nuevo. Totalmente testeable.
  *
  * Raycaster DDA clasico (Digital Differential Analyzer) estilo Wolfenstein 3D.
  * Sin librerias 3D, solo matematicas.
  *
+ * El loop ahora es por ESCENARIOS (rondas): cada ronda tiene su cultivo y sus
+ * plagas reales con su controlador biologico correcto. El jugador identifica,
+ * apunta y suelta el benefico correcto. Acierto = ficha educativa + puntos;
+ * error = la plaga aguanta + aviso educativo. Al final, recap de lo aprendido.
+ *
  * Solo este repo. i18n: solo es-CO.
  */
 
-import { MAPA, MAPA_FILAS, MAPA_COLS, CELDA, CONFIG_DOOM, PLAGAS_DOOM, BENEFICOS_DOOM } from '../components/juego/doomFincaData';
+import {
+  MAPA, MAPA_FILAS, MAPA_COLS, CONFIG_DOOM, PLAGAS_DOOM, BENEFICOS_DOOM,
+  ESCENARIOS, JUGADOR_INICIAL,
+} from '../components/juego/doomFincaData';
+
+/** Busca la definicion de una plaga por id. */
+function plagaDef(id) { return PLAGAS_DOOM.find((p) => p.id === id) || null; }
+/** Busca la definicion de un benefico por id. */
+function beneficoDef(id) { return BENEFICOS_DOOM.find((b) => b.id === id) || null; }
 
 /**
  * Verifica si una coordenada del mundo es una pared.
@@ -27,56 +40,30 @@ export function isWall(mapa, x, y) {
 }
 
 /**
- * Resultado de un rayo individual.
- * @typedef {Object} RayoHit
- * @property {number} dist   Distancia perpendicular a la pared (corregida).
- * @property {number} cara   0=N, 1=S, 2=E, 3=O
- * @property {number} texX   Coordenada X de la textura (0-1) donde golpeo.
- * @property {number} tipo   Codigo de material de la celda (1=seto, 2=madera, ...).
- */
-
-/**
  * Cast de un solo rayo DDA desde (ox, oy) con angulo `angle` (rad).
- * Devuelve la distancia perpendicular a la pared y la cara que golpeo.
- *
- * @param {number[][]} mapa
- * @param {number} ox    Origen X (mundo)
- * @param {number} oy    Origen Y (mundo)
- * @param {number} angle Angulo del rayo (rad)
- * @returns {RayoHit}
+ * @returns {{dist:number, cara:number, texX:number, tipo:number}}
  */
 export function castRay(mapa, ox, oy, angle) {
   const dirX = Math.cos(angle);
   const dirY = Math.sin(angle);
 
-  // Mapa: en que celda estamos
   let mapX = Math.floor(ox);
   let mapY = Math.floor(oy);
 
-  // Distancia que recorre el rayo para cruzar una celda en cada eje
   const deltaDistX = dirX === 0 ? 1e30 : Math.abs(1 / dirX);
   const deltaDistY = dirY === 0 ? 1e30 : Math.abs(1 / dirY);
 
-  // Direccion de paso (+1 o -1)
   const stepX = dirX < 0 ? -1 : 1;
   const stepY = dirY < 0 ? -1 : 1;
 
-  // Distancia desde la posicion actual hasta el primer borde de celda
   let sideDistX;
   let sideDistY;
-  if (dirX < 0) {
-    sideDistX = (ox - mapX) * deltaDistX;
-  } else {
-    sideDistX = (mapX + 1.0 - ox) * deltaDistX;
-  }
-  if (dirY < 0) {
-    sideDistY = (oy - mapY) * deltaDistY;
-  } else {
-    sideDistY = (mapY + 1.0 - oy) * deltaDistY;
-  }
+  if (dirX < 0) sideDistX = (ox - mapX) * deltaDistX;
+  else sideDistX = (mapX + 1.0 - ox) * deltaDistX;
+  if (dirY < 0) sideDistY = (oy - mapY) * deltaDistY;
+  else sideDistY = (mapY + 1.0 - oy) * deltaDistY;
 
-  // DDA loop: avanzar hasta chocar con una pared
-  let side = 0; // 0 = vertical (E/W), 1 = horizontal (N/S)
+  let side = 0;
   let tipo = 1;
   const MAX_STEPS = 64;
   for (let i = 0; i < MAX_STEPS; i += 1) {
@@ -89,77 +76,48 @@ export function castRay(mapa, ox, oy, angle) {
       mapY += stepY;
       side = 1;
     }
-    if (mapX < 0 || mapX >= MAPA_COLS || mapY < 0 || mapY >= MAPA_FILAS) {
-      break;
-    }
+    if (mapX < 0 || mapX >= MAPA_COLS || mapY < 0 || mapY >= MAPA_FILAS) break;
     if (mapa[mapY][mapX] !== 0) {
       tipo = mapa[mapY][mapX];
       break;
     }
   }
 
-  // Calcular distancia perpendicular (sin fish-eye)
   let perpDist;
-  if (side === 0) {
-    perpDist = (sideDistX - deltaDistX);
-  } else {
-    perpDist = (sideDistY - deltaDistY);
-  }
-
+  if (side === 0) perpDist = (sideDistX - deltaDistX);
+  else perpDist = (sideDistY - deltaDistY);
   if (perpDist < 0.001) perpDist = 0.001;
 
-  // Calcular coordenada de textura en la pared (donde golpeo exactamente)
   let wallX;
-  if (side === 0) {
-    wallX = oy + perpDist * dirY;
-  } else {
-    wallX = ox + perpDist * dirX;
-  }
+  if (side === 0) wallX = oy + perpDist * dirY;
+  else wallX = ox + perpDist * dirX;
   wallX -= Math.floor(wallX);
 
-  // Determinar la cara de la pared
   let cara;
-  if (side === 0) {
-    cara = dirX > 0 ? 3 : 2; // Oeste (mirando izq) o Este (mirando der)
-  } else {
-    cara = dirY > 0 ? 1 : 0; // Sur o Norte
-  }
+  if (side === 0) cara = dirX > 0 ? 3 : 2;
+  else cara = dirY > 0 ? 1 : 0;
 
   return { dist: perpDist, cara, texX: wallX, tipo };
 }
 
 /**
- * Proyecta un sprite 3D (plaga) a coordenadas de pantalla 2D.
- *
- * @param {number} sx        X del sprite en el mundo
- * @param {number} sy        Y del sprite en el mundo
- * @param {number} px        X del jugador
- * @param {number} py        Y del jugador
- * @param {number} pAngle    Angulo del jugador (rad)
- * @param {number} fov       Campo de vision (rad)
- * @param {number} screenW   Ancho de pantalla logica
- * @param {number} screenH   Alto de pantalla logica
- * @returns {{ visible: boolean, screenX: number, screenY: number, size: number, dist: number }}
+ * Proyecta un sprite 3D a coordenadas de pantalla 2D.
+ * @returns {{ visible: boolean, screenX: number, screenY: number, size: number, dist: number, relativeAngle: number }}
  */
 export function projectSprite(sx, sy, px, py, pAngle, fov, screenW, screenH) {
   const dx = sx - px;
   const dy = sy - py;
   const dist = Math.sqrt(dx * dx + dy * dy);
 
-  // Angulo del sprite relativo al jugador
   const spriteAngle = Math.atan2(dy, dx);
   let relativeAngle = spriteAngle - pAngle;
-
-  // Normalizar a [-PI, PI]
   while (relativeAngle > Math.PI) relativeAngle -= 2 * Math.PI;
   while (relativeAngle < -Math.PI) relativeAngle += 2 * Math.PI;
 
-  // Fuera del FOV
-  if (Math.abs(relativeAngle) > fov / 2 + 0.2) {
-    return { visible: false, screenX: 0, screenY: 0, size: 0, dist };
+  if (Math.abs(relativeAngle) > fov / 2 + 0.25) {
+    return { visible: false, screenX: 0, screenY: 0, size: 0, dist, relativeAngle };
   }
 
-  // Proyeccion en pantalla
   const screenX = (0.5 + relativeAngle / fov) * screenW;
   const size = Math.round(screenH / dist);
 
@@ -169,30 +127,24 @@ export function projectSprite(sx, sy, px, py, pAngle, fov, screenW, screenH) {
     screenY: Math.round(screenH / 2),
     size,
     dist,
+    relativeAngle,
   };
 }
 
 /**
- * Mueve al jugador con colision contra paredes.
- *
- * @param {number[][]} mapa
- * @param {{x:number, y:number, angulo:number}} player
- * @param {number} dx  Delta X (paralelo a la direccion)
- * @param {number} dy  Delta Y (perpendicular)
- * @returns {{ x: number, y: number }} Nueva posicion (mutada sobre player o copia)
+ * Mueve al jugador con colision contra paredes (deslizamiento).
+ * @returns {{ x: number, y: number }}
  */
 export function movePlayer(mapa, player, dx, dy) {
   const cAngle = player.angulo;
   const margin = 0.18;
 
-  // Calcular movimiento en ejes del mundo
   const moveX = dx * Math.cos(cAngle) - dy * Math.sin(cAngle);
   const moveY = dx * Math.sin(cAngle) + dy * Math.cos(cAngle);
 
   let newX = player.x;
   let newY = player.y;
 
-  // Deslizamiento: intentar mover en X primero, luego en Y
   const nextX = player.x + moveX;
   if (!isWall(mapa, nextX - margin, player.y - margin) &&
       !isWall(mapa, nextX - margin, player.y + margin) &&
@@ -213,14 +165,8 @@ export function movePlayer(mapa, player, dx, dy) {
 }
 
 /**
- * Actualiza la posicion de una plaga: se mueve hacia el jugador
- * usando pathfinding simple (evita paredes).
- *
- * @param {Object} pest
- * @param {{x:number, y:number}} player
- * @param {number[][]} mapa
- * @param {number} deltaTime
- * @returns {{ x: number, y: number }} Nueva posicion de la plaga
+ * Actualiza la posicion de una plaga: deambula y se acerca lento al jugador.
+ * @returns {{ x: number, y: number }}
  */
 export function updatePest(pest, player, mapa) {
   const dx = player.x - pest.x;
@@ -228,14 +174,15 @@ export function updatePest(pest, player, mapa) {
   const dist = Math.sqrt(dx * dx + dy * dy);
   if (dist < 0.001) return { x: pest.x, y: pest.y };
 
-  const dirX = dx / dist;
-  const dirY = dy / dist;
-  const step = pest.velocidad * 0.6; // mas lento que el jugador
+  // mezcla de acercamiento + deambular para que no se peguen todas al jugador
+  const wob = Math.sin((pest.faseWobble || 0)) * 0.5;
+  const dirX = (dx / dist) * Math.cos(wob) - (dy / dist) * Math.sin(wob);
+  const dirY = (dx / dist) * Math.sin(wob) + (dy / dist) * Math.cos(wob);
+  const step = pest.velocidad * 0.55;
 
   let newX = pest.x + dirX * step;
   let newY = pest.y + dirY * step;
 
-  // Evitar paredes
   const m = 0.12;
   if (isWall(mapa, newX - m, pest.y - m) || isWall(mapa, newX - m, pest.y + m) ||
       isWall(mapa, newX + m, pest.y - m) || isWall(mapa, newX + m, pest.y + m)) {
@@ -250,106 +197,50 @@ export function updatePest(pest, player, mapa) {
 }
 
 /**
- * Lanza un benefico y verifica si alcanza alguna plaga.
- * El benefico viaja en linea recta en la direccion de la mira del jugador.
+ * Identifica la plaga viva que esta al frente del jugador (cono estrecho,
+ * dentro de alcance), si hay, junto con si el benefico equipado es correcto.
+ * Devuelve la plaga objetivo y metadatos para la HUD (etiqueta + ficha).
  *
- * @param {{x:number, y:number, angulo:number}} player
- * @param {string} beneficoId  ID del benefico lanzado
- * @param {Object[]} pests     Lista de plagas vivas
- * @param {number} maxDist     Alcance maximo
- * @returns {{ pests: Object[], eliminada: boolean, plagaEliminada: string|null, mensaje: string }}
+ * @returns {{ plaga: Object|null, dist: number, correcto: boolean }}
  */
-export function lanzarBenefico(player, beneficoId, pests, maxDist) {
-  // El benefico tiene un area de efecto (cono estrecho hacia adelante)
-  let mejorDist = maxDist;
-  let plagaGolpeada = null;
-
+export function plagaObjetivo(player, beneficoId, pests, maxDist) {
+  let best = null;
+  let bestDist = maxDist;
   for (const p of pests) {
     if (!p.vivo) continue;
     const dx = p.x - player.x;
     const dy = p.y - player.y;
     const dist = Math.sqrt(dx * dx + dy * dy);
-
     if (dist > maxDist) continue;
-
-    // Verificar si la plaga esta en la direccion de la mira
-    const pestAngle = Math.atan2(dy, dx);
-    let diff = pestAngle - player.angulo;
+    let diff = Math.atan2(dy, dx) - player.angulo;
     while (diff > Math.PI) diff -= 2 * Math.PI;
     while (diff < -Math.PI) diff += 2 * Math.PI;
-
-    // Cono de ~20 grados
-    if (Math.abs(diff) < 0.35 && dist < mejorDist) {
-      // Verificar si el benefico controla esta plaga
-      const plagaDef = PLAGAS_DOOM.find((pd) => pd.id === p.tipo);
-      if (plagaDef && plagaDef.controladoPor === beneficoId) {
-        mejorDist = dist;
-        plagaGolpeada = p;
-      }
+    // cono que se ensancha cuando la plaga esta cerca (mas facil apuntar)
+    const cono = 0.16 + Math.min(0.30, 0.6 / Math.max(dist, 0.5));
+    if (Math.abs(diff) < cono && dist < bestDist) {
+      best = p;
+      bestDist = dist;
     }
   }
-
-  if (plagaGolpeada) {
-    plagaGolpeada.vitalidad -= 1;
-    if (plagaGolpeada.vitalidad <= 0) {
-      plagaGolpeada.vivo = false;
-      const plagaDef = PLAGAS_DOOM.find((pd) => pd.id === plagaGolpeada.tipo);
-      const benefDef = BENEFICOS_DOOM.find((b) => b.id === beneficoId);
-      return {
-        pests,
-        eliminada: true,
-        plagaEliminada: plagaGolpeada.tipo,
-        mensaje: `${benefDef?.nombre || beneficoId} controlo a ${plagaDef?.nombre || plagaGolpeada.tipo}. ${plagaDef?.dano || ''}`,
-      };
-    }
-    return {
-      pests,
-      eliminada: false,
-      plagaEliminada: null,
-      mensaje: 'La plaga resiste. Lanza otra vez.',
-    };
-  }
-
-  return {
-    pests,
-    eliminada: false,
-    plagaEliminada: null,
-    mensaje: 'No hay plaga que controlar con ese benefico en esa direccion.',
-  };
+  if (!best) return { plaga: null, dist: maxDist, correcto: false };
+  return { plaga: best, dist: bestDist, correcto: best.controladoPor === beneficoId };
 }
 
 /**
- * Verifica si alguna plaga alcanzo al jugador.
- *
- * @param {Object[]} pests
- * @param {{x:number, y:number}} player
- * @param {number} distUmbral  Distancia a la que la plaga "toca" al jugador
- * @returns {{ alcanzado: boolean, count: number }}
+ * Compat: indica si el jugador apunta a una plaga viva y si el benefico es
+ * correcto. Conserva la firma vieja para tests.
+ * @returns {{ enMira: boolean, correcto: boolean }}
  */
-export function checkPestReach(pests, player, distUmbral = 0.5) {
-  let count = 0;
-  for (const p of pests) {
-    if (!p.vivo) continue;
-    const dx = p.x - player.x;
-    const dy = p.y - player.y;
-    if (Math.sqrt(dx * dx + dy * dy) < distUmbral) {
-      count += 1;
-    }
-  }
-  return { alcanzado: count > 0, count };
+export function plagaEnMira(player, beneficoId, pests, maxDist) {
+  const t = plagaObjetivo(player, beneficoId, pests, maxDist);
+  return { enMira: !!t.plaga, correcto: t.correcto };
 }
 
 /**
- * Devuelve la decoracion de la finca que el jugador tiene en la mira
- * (al frente, dentro de un cono estrecho y un alcance corto), o null.
- * Sirve para mostrar su leccion agroecologica.
- *
- * @param {{x:number, y:number, angulo:number}} player
- * @param {Object[]} decoraciones  Lista con {x, y, ...}
- * @param {number} maxDist
+ * Devuelve la decoracion de la finca que el jugador tiene en la mira, o null.
  * @returns {Object|null}
  */
-export function decoracionEnMira(player, decoraciones, maxDist = 3.5) {
+export function decoracionEnMira(player, decoraciones, maxDist = 3.8) {
   let best = null;
   let bestDist = maxDist;
   for (const d of decoraciones) {
@@ -360,7 +251,7 @@ export function decoracionEnMira(player, decoraciones, maxDist = 3.5) {
     let diff = Math.atan2(dy, dx) - player.angulo;
     while (diff > Math.PI) diff -= 2 * Math.PI;
     while (diff < -Math.PI) diff += 2 * Math.PI;
-    if (Math.abs(diff) < 0.30 && dist < bestDist) {
+    if (Math.abs(diff) < 0.28 && dist < bestDist) {
       best = d;
       bestDist = dist;
     }
@@ -369,93 +260,115 @@ export function decoracionEnMira(player, decoraciones, maxDist = 3.5) {
 }
 
 /**
- * Indica si el jugador apunta a una plaga viva y si el benefico equipado es
- * el correcto para controlarla. Sirve para colorear la mira (verde=correcto,
- * ambar=plaga pero benefico equivocado).
- *
- * @param {{x:number, y:number, angulo:number}} player
- * @param {string} beneficoId
- * @param {Object[]} pests
- * @param {number} maxDist
- * @returns {{ enMira: boolean, correcto: boolean }}
+ * Verifica si alguna plaga alcanzo al jugador (le esta haciendo dano).
+ * @returns {{ alcanzado: boolean, count: number }}
  */
-export function plagaEnMira(player, beneficoId, pests, maxDist) {
-  let best = null;
-  let bestDist = maxDist;
+export function checkPestReach(pests, player, distUmbral = 0.7) {
+  let count = 0;
   for (const p of pests) {
     if (!p.vivo) continue;
     const dx = p.x - player.x;
     const dy = p.y - player.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    if (dist > maxDist) continue;
-    let diff = Math.atan2(dy, dx) - player.angulo;
-    while (diff > Math.PI) diff -= 2 * Math.PI;
-    while (diff < -Math.PI) diff += 2 * Math.PI;
-    if (Math.abs(diff) < 0.22 && dist < bestDist) {
-      best = p;
-      bestDist = dist;
-    }
+    if (Math.sqrt(dx * dx + dy * dy) < distUmbral) count += 1;
   }
-  if (!best) return { enMira: false, correcto: false };
-  return { enMira: true, correcto: best.controladoPor === beneficoId };
+  return { alcanzado: count > 0, count };
 }
 
 /**
- * Crea el estado inicial del mundo de juego.
+ * Suelta un benefico y verifica si controla la plaga objetivo.
+ * Acierto = baja vitalidad de la plaga (la "controla"); con benefico
+ * equivocado, la plaga aguanta y se devuelve un aviso educativo.
  *
- * @returns {Object} Estado inicial del mundo
+ * @returns {{ resultado: 'acierto'|'control'|'equivocado'|'vacio', plaga: Object|null }}
+ */
+export function lanzarBenefico(player, beneficoId, pests, maxDist) {
+  const obj = plagaObjetivo(player, beneficoId, pests, maxDist);
+  if (!obj.plaga) return { resultado: 'vacio', plaga: null };
+
+  const p = obj.plaga;
+  const def = plagaDef(p.tipo);
+  const correcto = def && def.controladoPor === beneficoId;
+
+  if (!correcto) {
+    // marca de feedback visual "equivocado" sobre la plaga
+    p.flashEquivocado = 18;
+    return { resultado: 'equivocado', plaga: p };
+  }
+
+  p.vitalidad -= 1;
+  p.flashAcierto = 14;
+  if (p.vitalidad <= 0) {
+    p.vivo = false;
+    return { resultado: 'control', plaga: p };
+  }
+  return { resultado: 'acierto', plaga: p };
+}
+
+/**
+ * Construye la lista de plagas para un escenario dado.
+ * @param {Object} esc  Escenario de ESCENARIOS
+ * @returns {Object[]}
+ */
+function crearPlagasEscenario(esc) {
+  return esc.plagas.map((plagaId, i) => {
+    const def = plagaDef(plagaId);
+    const spawn = esc.spawns[i] || esc.spawns[esc.spawns.length - 1];
+    let { x, y } = spawn;
+    if (isWall(MAPA, x, y)) { x = 7.5; y = 6.5; }
+    return {
+      tipo: def.id,
+      nombre: def.nombre,
+      cientifico: def.cientifico,
+      emoji: def.emoji,
+      forma: def.forma,
+      color: def.color,
+      cultivo: def.cultivo,
+      x,
+      y,
+      velocidad: def.velocidad,
+      vitalidad: def.vitalidad,
+      vitalidadMax: def.vitalidad,
+      vivo: true,
+      controladoPor: def.controladoPor,
+      dano: def.dano,
+      porQue: def.porQue,
+      faseWobble: Math.random() * Math.PI * 2,
+      flashAcierto: 0,
+      flashEquivocado: 0,
+    };
+  });
+}
+
+/**
+ * Crea el estado inicial del mundo de juego (arranca en la ronda 0).
+ * @returns {Object}
  */
 export function createWorld() {
-  const player = {
-    x: 2.5,
-    y: 2.5,
-    angulo: 0,
-  };
-
-  const pests = PLAGAS_DOOM.map((def) => ({
-    tipo: def.id,
-    nombre: def.nombre,
-    emoji: def.emoji,
-    color: def.color,
-    x: 1.5 + Math.random() * 13,
-    y: 1.5 + Math.random() * 11,
-    velocidad: def.velocidad,
-    vitalidad: def.vitalidad,
-    vitalidadMax: def.vitalidad,
-    vivo: true,
-    controladoPor: def.controladoPor,
-    dano: def.dano,
-  }));
-
-  // Distribuir plagas por el mapa en posiciones validas (no paredes)
-  const spawns = [
-    { x: 5.5, y: 5.5 },
-    { x: 10.5, y: 4.5 },
-    { x: 5.5, y: 9.5 },
-    { x: 10.5, y: 9.5 },
-    { x: 8.5, y: 7.5 },
-    { x: 2.5, y: 8.5 },
-    { x: 13.5, y: 8.5 },
-    { x: 8.5, y: 2.5 },
-  ];
-
-  for (let i = 0; i < Math.min(pests.length, spawns.length); i += 1) {
-    if (!isWall(MAPA, spawns[i].x, spawns[i].y)) {
-      pests[i].x = spawns[i].x;
-      pests[i].y = spawns[i].y;
-    }
-  }
+  const esc = ESCENARIOS[0];
+  const player = { ...JUGADOR_INICIAL };
+  const pests = crearPlagasEscenario(esc);
 
   return {
     player,
     pests,
+    rondaIdx: 0,
+    escenario: esc,
     vitalidad: CONFIG_DOOM.vitalidadInicial,
     vitalidadMax: CONFIG_DOOM.vitalidadMax,
-    beneficoEquipado: 'trichogramma',
+    beneficoEquipado: esc.beneficosSugeridos[0],
     cooldown: 0,
     plagasRestantes: pests.filter((p) => p.vivo).length,
+    puntaje: 0,
+    combo: 0,
+    aciertos: 0,
+    errores: 0,
     mensaje: '',
+    mensajeTipo: 'info',  // info | acierto | error
     mensajeTimer: 0,
+    ficha: null,          // ficha educativa al controlar bien una plaga
+    fichaTimer: 0,
+    aprendido: [],        // pares plaga->benefico aprendidos (recap)
+    rondaTransicion: false,
     terminado: false,
     ganado: false,
     t: 0,
@@ -463,82 +376,165 @@ export function createWorld() {
 }
 
 /**
+ * Avanza a la siguiente ronda (escenario). Si no hay mas, gana el juego.
+ * @param {Object} w
+ * @returns {Object}
+ */
+export function avanzarRonda(w) {
+  const next = w.rondaIdx + 1;
+  if (next >= ESCENARIOS.length) {
+    return { ...w, terminado: true, ganado: true, rondaTransicion: false };
+  }
+  const esc = ESCENARIOS[next];
+  const pests = crearPlagasEscenario(esc);
+  return {
+    ...w,
+    rondaIdx: next,
+    escenario: esc,
+    pests,
+    player: { ...JUGADOR_INICIAL },
+    beneficoEquipado: esc.beneficosSugeridos[0],
+    plagasRestantes: pests.filter((p) => p.vivo).length,
+    combo: 0,
+    cooldown: 0,
+    rondaTransicion: false,
+    // bonus de vitalidad por completar ronda (premio, no castigo)
+    vitalidad: Math.min(CONFIG_DOOM.vitalidadMax, w.vitalidad + 20),
+    ficha: null,
+    fichaTimer: 0,
+  };
+}
+
+/**
  * Avanza un frame de la simulacion (logica pura, sin render).
- *
- * @param {Object} world  Estado del mundo
- * @param {Object} input   Teclas presionadas { forward, backward, left, right, strafeLeft, strafeRight }
- * @returns {Object} Mundo actualizado
+ * @param {Object} world
+ * @param {Object} input  { forward, backward, strafeLeft, strafeRight, left, right, fire }
+ * @returns {Object}
  */
 export function tickWorld(world, input) {
   const w = { ...world };
   w.t += 1;
 
-  // Cooldown del lanzamiento
   if (w.cooldown > 0) w.cooldown -= 1;
-
-  // Timer de mensaje
   if (w.mensajeTimer > 0) {
     w.mensajeTimer -= 1;
     if (w.mensajeTimer === 0) w.mensaje = '';
   }
+  if (w.fichaTimer > 0) {
+    w.fichaTimer -= 1;
+    if (w.fichaTimer === 0) w.ficha = null;
+  }
 
-  if (w.terminado) return w;
+  if (w.terminado || w.rondaTransicion) return w;
 
   // Movimiento del jugador
   let dx = 0;
   let dyMove = 0;
   const vel = CONFIG_DOOM.velMovimiento;
-
   if (input.forward) dx += vel;
   if (input.backward) dx -= vel;
   if (input.strafeLeft) dyMove -= vel;
   if (input.strafeRight) dyMove += vel;
 
-  // Rotacion
   if (input.left) w.player = { ...w.player, angulo: w.player.angulo - CONFIG_DOOM.velRotacion };
   if (input.right) w.player = { ...w.player, angulo: w.player.angulo + CONFIG_DOOM.velRotacion };
 
   const newPos = movePlayer(MAPA, w.player, dx, dyMove);
   w.player = { ...w.player, x: newPos.x, y: newPos.y };
 
-  // Fuego (lanzar benefico)
+  // Soltar benefico
   if (input.fire && w.cooldown <= 0) {
-    const resultado = lanzarBenefico(w.player, w.beneficoEquipado, w.pests, CONFIG_DOOM.alcanceLanzamiento);
-    w.pests = resultado.pests;
-    w.mensaje = resultado.mensaje;
-    w.mensajeTimer = 90; // ~1.5 segundos a 60fps
+    const r = lanzarBenefico(w.player, w.beneficoEquipado, w.pests, CONFIG_DOOM.alcanceLanzamiento);
     w.cooldown = CONFIG_DOOM.cooldownLanzamiento;
-  }
+    const benef = beneficoDef(w.beneficoEquipado);
 
-  // Mover plagas hacia el jugador
-  for (const p of w.pests) {
-    if (!p.vivo) continue;
-    const newPestPos = updatePest(p, w.player, MAPA);
-    p.x = newPestPos.x;
-    p.y = newPestPos.y;
-  }
-
-  // Verificar si plagas alcanzan al jugador
-  const reach = checkPestReach(w.pests, w.player);
-  if (reach.alcanzado) {
-    w.vitalidad -= CONFIG_DOOM.danoPorPlaga * reach.count;
-    if (w.vitalidad < 0) w.vitalidad = 0;
-    if (w.mensajeTimer <= 0) {
-      w.mensaje = 'Una plaga dano el cultivo. Controlala rapido.';
+    if (r.resultado === 'vacio') {
+      w.mensaje = 'No hay plaga al frente. Acercate y apunta al bicho.';
+      w.mensajeTipo = 'info';
       w.mensajeTimer = 60;
+      w.combo = 0;
+    } else if (r.resultado === 'equivocado') {
+      const correcto = beneficoDef(r.plaga.controladoPor);
+      w.mensaje = `${benef?.nombre} no controla a ${r.plaga.nombre}. Prueba: ${correcto?.nombre}.`;
+      w.mensajeTipo = 'error';
+      w.mensajeTimer = 110;
+      w.errores += 1;
+      w.combo = 0;
+    } else if (r.resultado === 'acierto') {
+      w.mensaje = `Bien: ${benef?.nombre} es el control de ${r.plaga.nombre}. Insiste.`;
+      w.mensajeTipo = 'acierto';
+      w.mensajeTimer = 70;
+    } else if (r.resultado === 'control') {
+      // controlada -> ficha educativa + puntos + recap
+      w.aciertos += 1;
+      w.combo += 1;
+      const pts = 100 + (w.combo - 1) * 25;
+      w.puntaje += pts;
+      w.ficha = {
+        plaga: r.plaga.nombre,
+        cientifico: r.plaga.cientifico,
+        cultivo: r.plaga.cultivo,
+        benefico: benef?.nombre,
+        beneficoCientifico: benef?.cientifico,
+        porQue: r.plaga.porQue,
+        mecanismo: benef?.mecanismo,
+        puntos: pts,
+        combo: w.combo,
+      };
+      w.fichaTimer = 260;
+      w.mensaje = '';
+      w.mensajeTimer = 0;
+      // registrar para el recap (sin duplicar el par)
+      const par = `${r.plaga.nombre}__${benef?.nombre}`;
+      if (!w.aprendido.some((a) => a.par === par)) {
+        w.aprendido = [...w.aprendido, {
+          par,
+          plaga: r.plaga.nombre,
+          cientifico: r.plaga.cientifico,
+          benefico: benef?.nombre,
+          porQue: r.plaga.porQue,
+        }];
+      }
     }
   }
 
-  // Contar plagas vivas
+  // Mover plagas + decaer flashes
+  for (const p of w.pests) {
+    if (p.flashAcierto > 0) p.flashAcierto -= 1;
+    if (p.flashEquivocado > 0) p.flashEquivocado -= 1;
+    if (!p.vivo) continue;
+    p.faseWobble = (p.faseWobble || 0) + 0.05;
+    const np = updatePest(p, w.player, MAPA);
+    p.x = np.x;
+    p.y = np.y;
+  }
+
+  // Dano de plagas al jugador
+  const reach = checkPestReach(w.pests, w.player);
+  if (reach.alcanzado) {
+    w.vitalidad -= CONFIG_DOOM.danoPorPlaga * reach.count * 0.4;
+    if (w.vitalidad < 0) w.vitalidad = 0;
+    if (w.mensajeTimer <= 0 && w.fichaTimer <= 0) {
+      w.mensaje = 'Una plaga esta encima del cultivo: controlala ya.';
+      w.mensajeTipo = 'error';
+      w.mensajeTimer = 50;
+    }
+  }
+
   w.plagasRestantes = w.pests.filter((p) => p.vivo).length;
 
-  // Condiciones de fin
+  // Fin de ronda / juego
   if (w.vitalidad <= 0) {
     w.terminado = true;
     w.ganado = false;
   } else if (w.plagasRestantes === 0) {
-    w.terminado = true;
-    w.ganado = true;
+    if (w.rondaIdx + 1 >= ESCENARIOS.length) {
+      w.terminado = true;
+      w.ganado = true;
+    } else {
+      // pasar de ronda: marcar transicion (la UI muestra la intro siguiente)
+      w.rondaTransicion = true;
+    }
   }
 
   return w;
@@ -546,9 +542,6 @@ export function tickWorld(world, input) {
 
 /**
  * Cambia el benefico equipado.
- *
- * @param {Object} world
- * @param {string} beneficoId
  * @returns {Object}
  */
 export function cambiarBenefico(world, beneficoId) {


### PR DESCRIPTION
## Feature
Overhaul profundo del minijuego **Doom de la Finca** tras feedback duro del operador: (1) jugabilidad/usabilidad torpe, (2) utilidad agroecológica cuestionable, (3) imposible distinguir cualquier especie.

## Causa raíz
El render mostraba sprites diminutos sin etiqueta sobre un fondo borroso (orugas/moscas eran bolitas indistinguibles), sin objetivo claro ni explicación de por qué un benéfico controla una plaga. No enseñaba control biológico, solo "dispara al bicho".

## Cambios
- **Identificación (queja #1)** — `DoomFincaScreen.jsx`: al apuntar, etiqueta en pantalla con **nombre común + científico** y marcador de color sobre cada plaga cercana (verde = benéfico equipado correcto, rojo = equivocado). Sprites procedurales reescritos (`pintarPlaga`): más grandes, con contorno oscuro, distintos entre sí — oruga segmentada, mosca con alas en V, colonia de pulgones, escarabajo broca, araña roja de 8 patas. (El catálogo de fotos es solo de plantas; los insectos van con sprite claro + etiqueta, no foto.)
- **Jugabilidad (#2)** — controles táctiles de dos zonas (arrastrar izquierda = mover con joystick dinámico, derecha = girar) + botón **Soltar** grande, onboarding/tutorial, HUD legible (ronda, vitalidad, plagas, puntaje, combo), atajos teclado `1-5`, feedback inmediato (sonido + flash verde/rojo sobre el sprite + mira que cambia de color). Mapa más abierto para ver las plagas de lejos.
- **Pedagogía real (#3 y #4)** — `doomFincaData.js` + `doomFincaEngine.js`: 3 rondas por cultivo (maíz → café → hortalizas) con pares **plaga → controlador reales** tomados del grafo de conocimiento (`public/grafo-relations.json`, relación `pest_controllers`, Apache AGE; fuentes ICA/CIAT/Cenicafe/FAO). Al controlar bien sale una **ficha con el POR QUÉ** del control biológico; con el benéfico equivocado la plaga aguanta y se educa. Recap de lo aprendido al ganar/perder.
- **Pulido (#5)** — nuevos cues de sonido (`agentSoundService`: acierto/fallo/selección/victoria/derrota), `aria-label`/`role=status` en HUD y controles, theme-neutral, raycaster sin regresión de rendimiento.

## Tests
- 17 vitest nuevos (`doomFinca.test.js`): integridad de pares plaga→controlador, escenarios coherentes, apuntar, **correcto vs equivocado (el equivocado NO elimina)**, progresión de rondas, victoria/derrota.
- Build limpio, `eslint` 0/0 en los archivos del juego.
- Nota: 2 fallos en `MilpaSimulator.test.jsx` son **preexistentes en `main`** (otro juego, archivo idéntico a origin, no tocado por este PR).

## Verificación visual (capturas reales, chromium nix, ruta #doom-finca)
- Onboarding/tutorial · etiqueta de especie verde "Gusano cogollero / Spodoptera frugiperda" · etiqueta roja "Benefico equivocado" · ficha educativa "Bt controla a Gusano cogollero — es una ORUGA…" · transición de ronda (cafetal) · **recap de victoria con los 6 pares aprendidos** (puntaje 1300, combo x4).

Refs: feedback operador minijuego doom; grafo `public/grafo-relations.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)