### PR TITLE
fix(agent): paridad nature/minimalista en la pantalla del agente (#72)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -367,6 +367,22 @@
     background-color: rgb(var(--scrim-bg) / calc(var(--scrim-opacity) * 1.62));
   }
 
+  /* PARIDAD DEMO (operador 2026-06-22 "sigo viendo nature mal", #72): en los
+   * temas CLAROS el fondo del cuerpo es el cielo AMANECER ámbar/ocre del demo
+   * (radial #ffe8c2→#f8d9a6→#f3c98e). En el HOME ese cielo es la escena
+   * inmersiva correcta — pero la PANTALLA DEL AGENTE (chat) no usa el AgentHero:
+   * usa SOLO .agent-scrim sobre ese mismo cuerpo. Con el scrim crema débil
+   * (0.12·1.62≈0.20) el ocre se colaba como un fondo "sucio/marrón" detrás del
+   * chat, en vez de la SUPERFICIE clara tipo papel del demo (.sky linear
+   * #fbe9c8→#eef0db + burbujas blancas). Aquí subimos el velo del AgentScreen
+   * a un crema casi opaco SOLO en temas claros → el chat queda sobre papel
+   * limpio (= --c-surface del tema), como demo-agente.html. El HOME no se toca
+   * (no lleva .agent-scrim) y biopunk conserva su navy denso. */
+  [data-theme="nature"] .agent-scrim,
+  [data-theme="minimalista"] .agent-scrim {
+    background-color: rgb(var(--c-surface) / 0.94);
+  }
+
   /* Bandeja opaca para filas de chips/sugerencias (QuickChipsBar, SuggestedActions,
    * ChipsToolbar). Reemplaza los wrappers translúcidos: superficie raised del
    * tema + blur de respaldo + borde superior. */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -685,3 +685,62 @@ html:not([data-theme]) body.app-bg-biodiversidad:not([data-custom-bg]) {
 [data-theme="nature"] .glaciar-estado-texto {
   color: rgb(var(--c-slate-200));
 }
+
+/* ===========================================================================
+ * COMPOSITOR DEL AGENTE + ContextTip en TEMAS CLAROS (operador 2026-06-22
+ * "sigo viendo nature mal", #72).
+ *
+ * El compositor (.as-bar / .as-iconbtn, AGENT_COMPOSITOR_CSS) está hardcodeado
+ * con slate oscuro rgba(30,41,59,…) — correcto en biopunk (oscuro) pero, sobre
+ * la crema/papel del AgentScreen claro (ver index.css .agent-scrim por tema),
+ * quedaba como una pastilla NEGRA flotando — lo que el operador lee como
+ * "nature mal/sucio". El demo (demo-agente.html .bar) usa --superf cremoso con
+ * botones --blanco y texto --cafe. Aquí lo viramos a la superficie del tema en
+ * nature/minimalista (la indirección --c-* no llega porque son RGBA literales
+ * en el <style> inline del JSX). Biopunk no se toca. Español Colombia.
+ *
+ * También: la tarjeta ContextTip ("¿Una mata enferma?…") usa bg-emerald-950/50;
+ * en nature NO existe --c-emerald-950 → caía al verde-oscuro Tailwind. Sobre la
+ * crema quedaba como un bloque verde oscuro. La viramos a una tarjeta clara con
+ * borde salvia del tema. =========================================================================== */
+
+/* Pastilla del compositor → superficie clara del tema (= --superf del demo). */
+[data-theme="nature"] .as-bar,
+[data-theme="minimalista"] .as-bar {
+  background: rgb(var(--c-surface-raised) / 0.97);
+  border-color: rgb(var(--c-surface-border));
+  box-shadow: 0 10px 30px -14px rgba(0, 0, 0, 0.22);
+}
+/* Texto que escribe el productor: el textarea es text-white (invisible sobre
+ * crema). En claros = café/tinta del tema. El placeholder ya sale de --c-*. */
+[data-theme="nature"] .as-bar textarea,
+[data-theme="minimalista"] .as-bar textarea {
+  color: rgb(var(--c-slate-100));
+}
+/* Botones de ícono del compositor → blanco/papel con ícono café del tema. */
+[data-theme="nature"] .as-iconbtn,
+[data-theme="minimalista"] .as-iconbtn {
+  background: rgb(var(--c-surface-card));
+  border-color: rgb(var(--c-surface-border));
+  color: rgb(var(--c-slate-300));
+}
+[data-theme="nature"] .as-iconbtn:hover,
+[data-theme="minimalista"] .as-iconbtn:hover {
+  color: rgb(var(--c-slate-100));
+  border-color: rgb(var(--t-accent-rgb) / 0.55);
+}
+
+/* ContextTip ("¿Una mata enferma? Mándeme una foto") — tarjeta clara del tema
+ * en vez del verde-oscuro Tailwind (no hay --c-emerald-950 en claros). */
+[data-theme="nature"] .bg-emerald-950\/50,
+[data-theme="minimalista"] .bg-emerald-950\/50 {
+  background-color: rgb(var(--c-surface-raised) / 0.92) !important;
+  border-color: rgb(var(--c-emerald-400) / 0.5) !important;
+}
+/* Su título usa text-emerald-100 (sin token --c-emerald-100 → cae al verde casi
+ * blanco de Tailwind, ilegible sobre la tarjeta clara). En claros = verde
+ * profundo del tema, que sí pasa AA sobre la crema. */
+[data-theme="nature"] .bg-emerald-950\/50 .text-emerald-100,
+[data-theme="minimalista"] .bg-emerald-950\/50 .text-emerald-100 {
+  color: rgb(var(--c-emerald-700));
+}


### PR DESCRIPTION
## Problema

El operador reportó (con captura): el tema **nature** se ve mal en la **pantalla del agente** (Chagra IA) — un **fondo degradado marrón/ámbar sucio/oscuro**, en vez de claro/natural acorde al demo (`demo-agente.html`).

## Causa raíz (verificada con Chromium real)

El cuerpo de la app en temas claros usa el cielo amanecer ocre del demo (`#ffe8c2 → #f8d9a6 → #f3c98e`), que es **correcto** para el home inmersivo (AgentHero). Pero la **pantalla del agente NO usa el AgentHero**: usa solo `.agent-scrim` sobre ese mismo cuerpo. Con el velo crema débil (`--scrim-opacity 0.12 × 1.62 ≈ 0.20`) el ocre se colaba como fondo "sucio/marrón" detrás del chat, en vez de la superficie clara tipo papel del demo. El compositor (`.as-bar`) y la tarjeta ContextTip tenían colores oscuros hardcodeados que quedaban como pastillas negras sobre la crema una vez limpio el fondo.

## Cambios (solo CSS, scoped por `data-theme`)

- **`.agent-scrim`** en temas claros = crema casi opaco (`--c-surface/0.94`) → el chat queda sobre papel limpio como el demo. El **home no se toca** (no lleva `.agent-scrim`) y **biopunk conserva su navy denso**.
- **Compositor** (`.as-bar`/`.as-iconbtn`): tenía slate oscuro hardcodeado → vira a la superficie clara del tema con íconos legibles.
- **ContextTip** (`bg-emerald-950/50`, sin token en claros) → tarjeta clara con título verde profundo legible.

## Verificación

Chromium real (NixOS), tema activado vía `chagra:theme` + deep-link `#agente`:
- **nature**: fondo crema limpio, compositor y ContextTip claros (antes muddy amber).
- **minimalista**: papel limpio, sin regresión.
- **biopunk** (default): navy denso intacto — **sin regresión**.
- Tests de temas: **36/36 verdes**.

## Notas
- Visual/UX → queda **pendiente del visto bueno del operador** (screenshot enviado por Telegram).
- Ignorar checks de infra rotos ("Deploy to dev" rsync 23, "Playwright visual snapshots").

🤖 Generated with [Claude Code](https://claude.com/claude-code)