### PR TITLE
fix(agente): quita chips, ícono mano en capacidades y arregla scroll del chat

### DIFF
--- a/src/components/AgentScreen/AgentScreen.jsx
+++ b/src/components/AgentScreen/AgentScreen.jsx
@@ -112,8 +112,7 @@ import ChagraAgentAvatarColibriPhoto from '../ChagraAgentAvatarColibriPhoto';
 import { AgentManoOverlay } from '../agent/AgentShell';
 import { mapCapabilityPick } from '../agent/capabilityRouting';
 import { agentSounds } from '../../services/agentSoundService';
-import { useTheme } from '../../hooks/useTheme';
-import { iconForTheme } from '../dashboard/themeIcon';
+import ManoChagraGlyph from '../dashboard/ManoChagraGlyph';
 import usePrefsStore from '../../store/usePrefsStore';
 import useAssetStore from '../../store/useAssetStore';
 import useAgentNotificationStore from '../../store/useAgentNotificationStore';
@@ -150,7 +149,6 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // re-render — si no, la animación se reiniciaría con cada mensaje). Vacía bajo
   // prefers-reduced-motion.
   const entranceClassRef = useRef(agentEntranceClass());
-  const { theme } = useTheme();
   const operatorId = usePrefsStore((s) => s.operatorId) || 'default-operator';
   // Task #122 (2026-05-23): ttsEnabled global persistido en usePrefsStore.
   // Antes era useState local — al cambiarlo en otra pantalla (header
@@ -285,7 +283,6 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   // individuales. Al desmontar el componente cancelamos todos.
   const deepResearchControllersRef = useRef(new Map());
   const { durationMs, start: startRecord, stop: stopRecord, reset: resetRecord } = useVoiceRecorder();
-  const chatEndRef = useRef(null);
   // Bug 2026-05-18: ref al AbortController activo para que botón Cancelar
   // pueda abortar la inferencia LLM en curso desde fuera del callLLM scope.
   const activeControllerRef = useRef(null);
@@ -328,23 +325,14 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
   const isFreshSessionRef = useRef(false);
   const [showFreshSessionBadge, setShowFreshSessionBadge] = useState(false);
 
-  // Scroll fix 2026-05-18 operator feedback: 'scroll complicado a veces'.
-  // Auto-scroll al fondo cuando hay mensaje nuevo o stream en curso, pero
-  // SOLO si el usuario ya estaba cerca del bottom (no interrumpir lectura
-  // de mensajes antiguos). Threshold 120px del fondo. Behavior smooth.
-  useEffect(() => {
-    const el = chatEndRef.current;
-    if (!el) return;
-    const container = el.parentElement;
-    if (!container) {
-      el.scrollIntoView({ behavior: 'smooth' });
-      return;
-    }
-    const distFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    if (distFromBottom < 120 || state === STATE_THINKING) {
-      el.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages.length, streamingContent, state]);
+  // Scroll fix tarea #58: el auto-scroll al fondo del chat lo maneja
+  // ÚNICAMENTE ChatHistory, que tiene su `bottomRef` DENTRO del contenedor
+  // scrollable real (`.h-full.overflow-y-auto`). El efecto previo de aquí
+  // operaba sobre `chatEndRef`, un <div> que vivía FUERA de ese contenedor
+  // (hermano de ChatHistory, hijo del root `overflow-hidden`): su
+  // `scrollIntoView` no movía el chat y peleaba con el de ChatHistory →
+  // "scroll trabado / que salta" reportado por el operador. Una sola fuente
+  // de verdad para el auto-scroll evita el conflicto.
 
   const loadHistory = useCallback(async () => {
     try {
@@ -3078,7 +3066,6 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
         onRetryOrphan={handleRetryOrphan}
         onCancelDeepResearch={handleCancelDeepResearch}
         proactiveGreeting={proactiveGreeting}
-        onGreetingPrompt={(prompt) => prompt && setInputText(prompt)}
         onBack={onBack}
       />
 
@@ -3154,8 +3141,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
             aria-label="Abrir la mano de Chagra"
             data-testid="agent-mano-trigger"
           >
-            <span className="w-[18px] h-[18px] shrink-0 flex items-center" aria-hidden="true">
-              {iconForTheme(theme)}
+            <span className="w-[20px] h-[20px] shrink-0 flex items-center justify-center" aria-hidden="true">
+              <ManoChagraGlyph size={20} />
             </span>
             Toca la mano de Chagra para ver todo lo que puede hacer
           </button>
@@ -3299,8 +3286,8 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
               aria-expanded={sheetOpen}
               className={['as-iconbtn as-tool', sheetOpen ? 'is-open' : ''].join(' ')}
             >
-              <span className="w-[18px] h-[18px] flex items-center" aria-hidden="true">
-                {iconForTheme(theme)}
+              <span className="w-[20px] h-[20px] flex items-center justify-center" aria-hidden="true">
+                <ManoChagraGlyph size={20} />
               </span>
             </button>
 
@@ -3367,12 +3354,10 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           </div>
         </div>
 
-        {/* Hint educativo bajo el pill */}
-        {state !== STATE_RECORDING && !agentAttachment && (
-          <p className="mt-1 text-center text-[11px] text-slate-500 leading-tight">
-            Toca <b className="text-emerald-400">Ⓐ</b> para ver todo lo que sé hacer
-          </p>
-        )}
+        {/* Hint educativo bajo el pill — RETIRADO (tarea #58): el operador pidió
+            quitar los chips/líneas de sugerencia que ensucian la pantalla del
+            agente. El acceso a capacidades queda por la mano de Chagra (botón
+            Ⓐ del compositor + botón de la pantalla vacía). */}
 
         {/* Input oculto de foto */}
         <input
@@ -3495,8 +3480,6 @@ export default function AgentScreen({ onBack, onNavigate, initialContext }) {
           </p>
         )}
       </div>
-
-      <div ref={chatEndRef} />
 
       {/* La MANO de Chagra (Ⓐ) — MISMA red orgánica que el home (AgentRedMenu),
           NO menús de texto (operador: "en el agente no se ve la mano, se ven

--- a/src/components/AgentScreen/ChatHistory.jsx
+++ b/src/components/AgentScreen/ChatHistory.jsx
@@ -25,10 +25,9 @@ const FLOATING_BACK_THRESHOLD_PX = 160;
  * @param {Function} props.onRetryOrphan - Callback para reintentar un mensaje huérfano (sin respuesta).
  * @param {Function} props.onCancelDeepResearch - Callback para cancelar una investigación profunda en curso.
  * @param {Object|null} [props.proactiveGreeting=null] - Datos del saludo proactivo dinámico.
- * @param {Function} props.onGreetingPrompt - Callback al seleccionar un prompt sugerido del saludo.
  * @param {Function} props.onBack - Callback para volver a la pantalla anterior.
  */
-export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, proactiveGreeting = null, onGreetingPrompt, onBack }) {
+export default function ChatHistory({ messages = [], streamingContent = '', isStreaming = false, onConsentNeeded, onRetryOrphan, onCancelDeepResearch, proactiveGreeting = null, onBack }) {
   const bottomRef = useRef(null);
   const scrollRef = useRef(null);
   // (B) Botón "Volver" flotante: visible solo cuando el operador se alejó del
@@ -41,8 +40,35 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
     setShowFloatingBack(top > FLOATING_BACK_THRESHOLD_PX);
   }, []);
 
+  // Fuente ÚNICA del auto-scroll del chat (tarea #58). El contenedor scrollable
+  // real es `scrollRef`; `bottomRef` es el marcador del fondo DENTRO de él.
+  //
+  // Reglas:
+  //   - Primer render con contenido (abrir una conversación larga) → saltar al
+  //     fondo SIN animación, para no aterrizar a media altura ni ver un barrido.
+  //   - Mensajes/tokens nuevos → seguir al fondo SOLO si el usuario ya estaba
+  //     cerca del fondo (umbral 120px) o si está llegando una respuesta en
+  //     curso. Así no le arrebatamos el scroll cuando subió a releer historial.
+  const didInitialScrollRef = useRef(false);
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = scrollRef.current;
+    const anchor = bottomRef.current;
+    if (!anchor) return;
+
+    if (!didInitialScrollRef.current) {
+      // Salto instantáneo la primera vez que hay contenido para ver.
+      didInitialScrollRef.current = true;
+      anchor.scrollIntoView({ behavior: 'auto', block: 'end' });
+      return;
+    }
+
+    const distFromBottom = container
+      ? container.scrollHeight - container.scrollTop - container.clientHeight
+      : 0;
+    const nearBottom = distFromBottom < 120;
+    if (nearBottom || isStreaming) {
+      anchor.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
   }, [messages, streamingContent, isStreaming]);
 
   // Empty state: aprovechamos el espacio vacío para mostrar el colibrí
@@ -60,7 +86,7 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
         <div className="text-center max-w-md">
           <ChagraAgentAvatar state="idle" size={200} className="mx-auto mb-4" />
           {proactiveGreeting ? (
-            <ProactiveGreeting greeting={proactiveGreeting} onPrompt={onGreetingPrompt} />
+            <ProactiveGreeting greeting={proactiveGreeting} />
           ) : (
             <>
               <p className="text-slate-200 text-base mb-2 font-medium">¡Hola! Soy tu asistente agroecológico.</p>
@@ -115,7 +141,10 @@ export default function ChatHistory({ messages = [], streamingContent = '', isSt
         role="log"
         aria-live="polite"
         data-testid="chat-scroll"
-        className="h-full overflow-y-auto p-4 pb-28"
+        /* pb-40 (tarea #58): el compositor fijo crece con la franja de voz y el
+           tip de foto; pb-28 (112px) dejaba el último mensaje tapado. 160px da
+           aire suficiente para que el fondo del chat quede SOBRE el compositor. */
+        className="h-full overflow-y-auto p-4 pb-40"
       >
       {messages.map((msg, idx) => {
         // Deep Research (A6/A7): si el mensaje lleva _deepResearch, renderizamos
@@ -214,9 +243,10 @@ const FLOATING_BACK_CSS = `
  * una idea contextual sin inventar alarmas. CTA siembra el prompt sugerido en
  * el input (el operador revisa y envía — no auto-submit).
  */
-function ProactiveGreeting({ greeting, onPrompt }) {
+function ProactiveGreeting({ greeting }) {
   if (!greeting) return null;
-  const { hi, state, lead, items = [], restCount = 0, prompt } = greeting;
+  // `prompt` del saludo ya no se usa: la pastilla-CTA se retiró (tarea #58).
+  const { hi, state, lead, items = [], restCount = 0 } = greeting;
   const isPending = state === 'pending';
   return (
     <div data-testid="proactive-greeting" data-greeting-state={state}>
@@ -259,16 +289,10 @@ function ProactiveGreeting({ greeting, onPrompt }) {
         </p>
       )}
 
-      {prompt && typeof onPrompt === 'function' && (
-        <button
-          type="button"
-          onClick={() => onPrompt(prompt)}
-          data-testid="proactive-greeting-cta"
-          className="text-xs px-3 py-1.5 rounded-full bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-600/30 text-cyan-100 transition-colors active:scale-95"
-        >
-          {prompt}
-        </button>
-      )}
+      {/* CTA-pastilla de sugerencia RETIRADA (tarea #58): el operador pidió
+          quitar los chips de sugerencia del agente porque ensucian y disparan
+          flujos confusos. El saludo conserva el contexto (pendientes/idea) pero
+          ya no propone una pregunta clickeable; el usuario habla o escribe. */}
     </div>
   );
 }

--- a/src/components/AgentScreen/__tests__/ChatHistory.backButton.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatHistory.backButton.test.jsx
@@ -79,8 +79,10 @@ describe('ChatHistory — botón Volver flotante (alcanzable sin scroll al inici
   it('el contenedor scrollable reserva padding inferior para que el último mensaje no quede tapado por el input fijo', () => {
     const { container } = render(<ChatHistory messages={longConversation} onBack={vi.fn()} />);
     const scroller = container.querySelector('[data-testid="chat-scroll"]');
-    // pb-28 (7rem) reserva sitio bajo el último mensaje para que sus acciones
-    // (👍/👎, Reintentar) no queden bajo el footer fijo (input + chips).
-    expect(scroller.className).toMatch(/pb-28/);
+    // pb-40 (10rem, subido desde pb-28 en tarea #58) reserva sitio bajo el
+    // último mensaje para que sus acciones (👍/👎, Reintentar) no queden bajo
+    // el footer fijo (input + franja de voz + tip de foto), que crece más que
+    // los 7rem previos.
+    expect(scroller.className).toMatch(/pb-40/);
   });
 });

--- a/src/components/AgentScreen/__tests__/ChatHistory.greeting.test.jsx
+++ b/src/components/AgentScreen/__tests__/ChatHistory.greeting.test.jsx
@@ -5,13 +5,13 @@
  *   - CON pendientes → lidera nombrando la alerta/tarea top + hint del resto.
  *   - SIN pendientes → idea contextual, sin pintar ítems de alarma.
  *   - Sin saludo resuelto → cae al copy estático de siempre (backward compat).
- *   - CTA siembra el prompt sugerido (no auto-submit).
+ *   - La pastilla-CTA de sugerencia YA NO se renderiza (retirada en tarea #58).
  *
  * La LÓGICA del saludo se prueba en services/__tests__/proactiveGreeting.test.js.
  * Aquí solo probamos que ChatHistory lo renderiza fiel a los datos.
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi } from 'vitest';
 import ChatHistory from '../ChatHistory';
@@ -54,15 +54,15 @@ describe('ChatHistory — saludo proactivo (empty state)', () => {
     expect(screen.queryByTestId('proactive-greeting-rest')).toBeNull();
   });
 
-  it('CTA siembra el prompt sugerido (no auto-submit)', () => {
-    const onGreetingPrompt = vi.fn();
+  it('NO renderiza la pastilla-CTA de sugerencia (retirada en tarea #58)', () => {
     const greeting = {
       hi: 'Buenos días', state: 'idea', lead: 'Todo tranquilo por ahora.', items: [], restCount: 0,
       prompt: 'Dame un resumen del estado de mi finca hoy.',
     };
-    render(<ChatHistory messages={[]} proactiveGreeting={greeting} onGreetingPrompt={onGreetingPrompt} />);
-    fireEvent.click(screen.getByTestId('proactive-greeting-cta'));
-    expect(onGreetingPrompt).toHaveBeenCalledWith('Dame un resumen del estado de mi finca hoy.');
+    render(<ChatHistory messages={[]} proactiveGreeting={greeting} />);
+    // El saludo se muestra, pero ya no hay chip clickeable que dispare un flujo.
+    expect(screen.getByTestId('proactive-greeting')).toBeInTheDocument();
+    expect(screen.queryByTestId('proactive-greeting-cta')).toBeNull();
   });
 
   it('sin saludo resuelto → copy estático de siempre (backward compat)', () => {

--- a/src/components/dashboard/ManoChagraGlyph.jsx
+++ b/src/components/dashboard/ManoChagraGlyph.jsx
@@ -1,0 +1,58 @@
+/**
+ * ManoChagraGlyph — el emblema de "la mano de Chagra" como GLIFO pequeño,
+ * pensado para botones (18-24px): el botón que ABRE la red de capacidades
+ * (AgentRedMenu). Reemplaza al ícono de tema (que en algunos temas leía como
+ * una estrella/forma genérica) por la metáfora central de la marca: "Chagra,
+ * su mano en el campo".
+ *
+ * Diseño: silueta de una mano abierta (palma + 4 dedos) en trazo grueso
+ * round-cap del color del texto (`currentColor`) para que herede el color del
+ * botón en cualquier tema. De las yemas de los dedos centrales brota una
+ * ramita corta con un nodo (la lógica micorriza/rama del emblema grande),
+ * sugiriendo que de la mano crece la red de capacidades. Mismo lenguaje visual
+ * que `ManoChagraEmblem` (memoria del proyecto, 2026-06-09) pero reducido a
+ * tamaño de ícono.
+ *
+ * `currentColor` + `fill="none"` lo hacen theme-agnóstico (legible al sol y de
+ * noche). Sin animación: a tamaño de botón distrae; la animación viva vive en
+ * la red que el botón despliega.
+ *
+ * Props:
+ *   - size: número (px) del lado del glifo. Default 20.
+ *   - className: clases extra para el <svg>.
+ */
+import React from 'react';
+
+export default function ManoChagraGlyph({ size = 20, className = '' }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* Palma + muñeca: cuenco de la mano */}
+      <path d="M6 21c-1.2-1.4-2-3.1-2-5v-3.2c0-.7.6-1.3 1.3-1.3.7 0 1.2.5 1.2 1.2" />
+      <path d="M18 21c1.2-1.4 2-3.1 2-5v-3.2c0-.7-.6-1.3-1.3-1.3-.7 0-1.2.5-1.2 1.2" />
+      {/* Cuatro dedos (de izquierda a derecha) que parten de la palma */}
+      <path d="M6.5 12.9V9.4" />
+      <path d="M9.8 12.6V7.2" />
+      <path d="M13.2 12.6V6.6" />
+      <path d="M16.6 12.9V8" />
+      {/* Brote/yema en la punta de los dedos centrales: ramita + nodo
+          (la red de capacidades que crece de la mano). */}
+      <path d="M9.8 7.2l-1.6-1.5M9.8 7.2l1.5-1.7" />
+      <path d="M13.2 6.6l-1.5-1.7M13.2 6.6l1.6-1.5" />
+      <circle cx="8.2" cy="5.5" r="0.5" fill="currentColor" stroke="none" />
+      <circle cx="11.3" cy="5.4" r="0.5" fill="currentColor" stroke="none" />
+      <circle cx="11.7" cy="4.8" r="0.5" fill="currentColor" stroke="none" />
+      <circle cx="14.8" cy="5" r="0.5" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Pulido UX de la pantalla del agente (Chagra IA). Tres cambios pedidos por el operador (tarea #58):

## 1. Chips de sugerencia fuera
- Se retira la pastilla-CTA del saludo proactivo (la pregunta clickeable tipo "¿Cómo controlo plagas sin químicos?") que disparaba un flujo.
- Se retira la línea "Toca Ⓐ para ver todo lo que sé hacer" bajo el compositor.

## 2. Estrella → mano
- Nuevo `ManoChagraGlyph`: glifo SVG de la mano de Chagra (palma + dedos con ramita/yema en las puntas — misma metáfora micorriza/rama del emblema grande), `currentColor`, theme-agnóstico.
- Reemplaza el ícono de tema en el botón que abre la red de capacidades: el botón Ⓐ del compositor y el botón de la pantalla vacía.

## 3. Scroll del chat arreglado
- El auto-scroll ahora tiene **una sola fuente**: `ChatHistory`, con su marcador de fondo DENTRO del contenedor scrollable real.
- Se elimina el efecto roto de `AgentScreen` que operaba sobre un `<div>` ubicado FUERA del contenedor (hijo del root `overflow-hidden`) — su `scrollIntoView` no movía el chat y peleaba con el de `ChatHistory`, causando el "scroll trabado / que salta".
- El nuevo efecto salta al fondo al abrir una conversación y sigue al fondo solo si el usuario ya estaba cerca (no le arrebata el scroll al releer historial).
- Sube el padding inferior del chat (`pb-28` → `pb-40`) para que el compositor (con franja de voz + tip de foto) no tape el último mensaje.

## Verificación
- Chromium real móvil 412×915 (nix-store), estados vacío y con varios mensajes. Capturas antes/después confirman: sin chips, ícono de mano en el botón de capacidades, y último mensaje (con sus botones 👍/👎) visible sobre el compositor.
- `npm run build` verde.
- `eslint` por-archivo limpio en lo tocado (0 errores; `AgentScreen.jsx` es muy grande para eslint directo — se valida vía build + tests).
- 79 tests verdes (suite `AgentScreen/` + smokes de chips). Tests de `greeting` (sin CTA) y `backButton` (padding `pb-40`) actualizados.

Sin cambios al envío de mensajes, voz, ni a los guards/badges (outputGuards, "Respuesta generativa · verifica", grounding).

Visual/UX: pendiente del visto bueno del operador.