### PR TITLE
fix(extensionista): el operador ve el panel en vez de "Vista no disponible"

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -134,4 +134,11 @@ export default defineConfig([
     files: ['src/config/messages.js'],
     rules: { 'chagra-i18n/no-hardcoded-spanish': 'off' },
   },
+  {
+    // Los tests aseveran sobre el texto en español RENDERIZADO (p. ej.
+    // `screen.getByText('Finca El Páramo')`), así que necesitan literales en
+    // español a propósito: no son cadenas de UI que migrar a messages.js.
+    files: ['**/*.test.{js,jsx}', '**/*.spec.{js,jsx}'],
+    rules: { 'chagra-i18n/no-hardcoded-spanish': 'off' },
+  },
 ])

--- a/src/components/ExtensionistaScreen.jsx
+++ b/src/components/ExtensionistaScreen.jsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react';
 import { ScreenShell } from './common/ScreenShell';
 import { esExtensionistaActual } from '../config/extensionistaAccess';
+import { esOperadorActual } from '../config/glaciarAccess';
 import { construirTableroExtensionista } from '../services/extensionistaService';
 import { getActiveTenantId } from '../services/tenantContext';
 import useFincaActiveStore from '../services/fincaActiveStore';
@@ -135,10 +136,19 @@ export default function ExtensionistaScreen({ onBack, onHome }) {
   const activeFincaSlug = useFincaActiveStore((s) => s.activeFincaSlug);
   const setActiveFinca = useFincaActiveStore((s) => s.setActiveFinca);
 
-  const tablero = useMemo(
-    () => (tieneRol ? construirTableroExtensionista(getActiveTenantId()) : null),
-    [tieneRol]
-  );
+  // El operador (visión total / demo, p. ej. el panel ministerial) suele tener
+  // un tenant propio (admin) que NO está en el mock de delegaciones, así que su
+  // tablero saldría vacío. Para que el panel DEMUESTRE valor en el demo, si no
+  // hay fincas para el tenant activo y el usuario es operador, caemos al MOCK de
+  // ejemplo (`demo-extensionista`). Son los mismos datos ya marcados como "vista
+  // previa / datos de ejemplo" en la UI — NO se inventan datos nuevos.
+  const tablero = useMemo(() => {
+    if (!tieneRol) return null;
+    const propio = construirTableroExtensionista(getActiveTenantId());
+    if (propio.fincas.length > 0) return propio;
+    if (esOperadorActual()) return construirTableroExtensionista('demo-extensionista');
+    return propio;
+  }, [tieneRol]);
 
   const fincasDelegadas = useMemo(() => tablero?.fincas || [], [tablero]);
 
@@ -180,6 +190,7 @@ export default function ExtensionistaScreen({ onBack, onHome }) {
         {fincasDelegadas.length > 0 && (
           <div className="rounded-2xl border border-emerald-700/30 bg-emerald-950/20 p-4 space-y-3">
             <div>
+              {/* eslint-disable-next-line chagra-i18n/no-hardcoded-spanish -- i18n progresiva (ADR-050): esta pantalla aún no está migrada a messages.js; el resto de sus strings tampoco. Migración fuera del alcance de este fix. */}
               <p className="text-sm font-semibold text-emerald-200">Finca activa</p>
               <p className="text-xs text-emerald-300/80">
                 Elige cuál de las fincas delegadas quieres gestionar ahora.

--- a/src/components/__tests__/ExtensionistaScreen.test.jsx
+++ b/src/components/__tests__/ExtensionistaScreen.test.jsx
@@ -20,6 +20,7 @@ import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 const { esExtensionistaActual } = vi.hoisted(() => ({
   esExtensionistaActual: vi.fn(),
 }));
+const { esOperadorActual } = vi.hoisted(() => ({ esOperadorActual: vi.fn() }));
 const { construirTableroExtensionista } = vi.hoisted(() => ({
   construirTableroExtensionista: vi.fn(),
 }));
@@ -42,6 +43,7 @@ const { useFincaActiveStoreMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('../../config/extensionistaAccess', () => ({ esExtensionistaActual }));
+vi.mock('../../config/glaciarAccess', () => ({ esOperadorActual }));
 vi.mock('../../services/extensionistaService', () => ({
   construirTableroExtensionista,
 }));
@@ -88,6 +90,8 @@ const TABLERO = {
 
 beforeEach(() => {
   esExtensionistaActual.mockReset();
+  esOperadorActual.mockReset();
+  esOperadorActual.mockReturnValue(false);
   construirTableroExtensionista.mockReset();
   getActiveTenantId.mockReset();
   getActiveTenantId.mockReturnValue('demo-extensionista');
@@ -177,5 +181,42 @@ describe('ExtensionistaScreen — con rol extensionista', () => {
     // el botón atrás tiene el aria-label exacto "Volver".
     fireEvent.click(screen.getByLabelText('Volver'));
     expect(onBack).toHaveBeenCalled();
+  });
+});
+
+describe('ExtensionistaScreen — operador (demo visión total)', () => {
+  beforeEach(() => {
+    esExtensionistaActual.mockReturnValue(true);
+  });
+
+  it('si el tenant del operador no tiene fincas, cae al mock demo (no vacío)', () => {
+    esOperadorActual.mockReturnValue(true);
+    getActiveTenantId.mockReturnValue('admin');
+    // Primera llamada (tenant admin) → vacío; fallback (demo-extensionista) → tablero.
+    construirTableroExtensionista
+      .mockReturnValueOnce({ fincas: [], resumen: { total: 0, con_alertas: 0, con_pendientes: 0 } })
+      .mockReturnValueOnce(TABLERO);
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    // Muestra las fincas de ejemplo en vez del estado vacío → NO queda en blanco.
+    expect(screen.getByText('Finca El Páramo')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Todavía no tienes fincas asignadas')
+    ).not.toBeInTheDocument();
+    expect(construirTableroExtensionista).toHaveBeenLastCalledWith('demo-extensionista');
+  });
+
+  it('un no-operador con tenant sin fincas SÍ ve el estado vacío (sin inventar)', () => {
+    esOperadorActual.mockReturnValue(false);
+    getActiveTenantId.mockReturnValue('demo-extensionista');
+    construirTableroExtensionista.mockReturnValue({
+      fincas: [],
+      resumen: { total: 0, con_alertas: 0, con_pendientes: 0 },
+    });
+    render(<ExtensionistaScreen onBack={() => {}} />);
+    expect(
+      screen.getByText('Todavía no tienes fincas asignadas')
+    ).toBeInTheDocument();
+    // No debe pedir el fallback demo si no es operador.
+    expect(construirTableroExtensionista).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/config/__tests__/extensionistaAccess.test.js
+++ b/src/config/__tests__/extensionistaAccess.test.js
@@ -94,6 +94,39 @@ describe('extensionistaAccess — feature flag VITE_FEATURE_EXTENSIONISTA (kill-
   });
 });
 
+describe('extensionistaAccess — bypass del OPERADOR (visión total)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    localStorage.clear();
+  });
+
+  it('el operador (override local) es extensionista AUNQUE la flag esté OFF', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'false');
+    localStorage.setItem('chagra:operator_override', '1');
+    const mod = await importFresh();
+    // Con override de operador entra al panel sin importar la flag ni la whitelist.
+    expect(mod.esExtensionista('admin')).toBe(true);
+    expect(mod.esExtensionista('cualquiera')).toBe(true);
+  });
+
+  it('el operador (override local) entra aunque NO esté en la whitelist', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');
+    localStorage.setItem('chagra:operator_override', '1');
+    const mod = await importFresh();
+    expect(mod.esExtensionista('no-en-whitelist')).toBe(true);
+  });
+
+  it('sin override de operador, un usuario normal sigue gateado (flag OFF)', async () => {
+    vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'false');
+    const mod = await importFresh();
+    expect(mod.esExtensionista('admin')).toBe(false);
+    expect(mod.esExtensionista('demo-extensionista')).toBe(false);
+  });
+});
+
 describe('extensionistaAccess — esExtensionistaActual (lee tenant activo, offline)', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_FEATURE_EXTENSIONISTA', 'true');

--- a/src/config/extensionistaAccess.js
+++ b/src/config/extensionistaAccess.js
@@ -45,6 +45,7 @@
  */
 
 import { getActiveTenantId } from '../services/tenantContext.js';
+import { esOperador } from './glaciarAccess.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // WHITELIST — editar SOLO este Set para dar/quitar el rol extensionista.
@@ -103,11 +104,23 @@ export function featureExtensionistaActivo() {
  * Normaliza con trim() + toLowerCase() antes de comparar (tolerante a
  * capitalización accidental o espacios alrededor).
  *
+ * BYPASS DEL OPERADOR (visión total):
+ *   El operador del producto (admin/demo/debug) ve SIEMPRE TODO, igual que con
+ *   el módulo glaciar (ver `tieneAccesoGlaciar`). Sin este bypass, el operador
+ *   y los perfiles de demostración (p. ej. el panel ministerial) aterrizaban en
+ *   `#extensionista` y veían una pantalla "Vista no disponible" — un dead-end
+ *   inaceptable en un demo. Con `esOperador()` (override local o
+ *   VITE_OPERATOR_USERNAME) el operador entra al panel sin importar la flag ni
+ *   la whitelist. NO leakea identidad (override booleano en localStorage).
+ *
  * @param {string|null|undefined} username — username farmOS del usuario.
- * @returns {boolean} true si tiene el rol; false en todos los demás casos
- *   (flag off, null, undefined, vacío, solo espacios, fuera de la whitelist).
+ * @returns {boolean} true si tiene el rol (o es operador); false en los demás
+ *   casos (flag off, null, undefined, vacío, solo espacios, fuera de whitelist).
  */
 export function esExtensionista(username) {
+  // El operador (visión total) ve el panel extensionista aunque la flag esté
+  // apagada o no esté en la whitelist — mismo criterio que glaciarAccess.
+  if (esOperador(username)) return true;
   if (!featureExtensionistaActivo()) return false;
   if (!username || typeof username !== 'string') return false;
   const normalized = username.trim().toLowerCase();


### PR DESCRIPTION
## Problema

El test integral (Fase 1 UI) reportó que el perfil de demostración del **extensionista / panel ministerial** (`demo_minagri`) caía en una pantalla **"Vista no disponible"** al navegar a `#extensionista` — un dead-end visual sin chrome (sin header ni botón volver). Inaceptable para un stakeholder clave del demo.

## Causa raíz

El gate `esExtensionista` solo aceptaba el feature flag `VITE_FEATURE_EXTENSIONISTA` + la whitelist, **sin contemplar el bypass del operador (visión total)** — a diferencia del módulo glaciar, cuyo `tieneAccesoGlaciar` sí incluye `esOperador`. El operador/demo (que "ve todo") quedaba fuera y el `case 'extensionista'` del router pintaba el `<div>Vista no disponible</div>`.

## Cambios

- **`extensionistaAccess.js`**: `esExtensionista` ahora reconoce al operador (override local o `VITE_OPERATOR_USERNAME`) y le da acceso al panel, igual que `glaciarAccess`. Un usuario normal sigue gateado por flag + whitelist (sin cambios de comportamiento).
- **`ExtensionistaScreen.jsx`**: si el tenant del operador no tiene delegaciones propias, cae al MOCK de ejemplo (`demo-extensionista`, datos ya marcados en la UI como "vista previa / datos de ejemplo") para que el panel **demuestre valor** en el demo en vez de mostrar el estado vacío. No se inventan datos nuevos.
- **Tests**: bypass del operador (flag off + fuera de whitelist) y fallback demo del panel; el no-operador sin fincas sigue viendo el estado vacío honesto.
- **ESLint**: exime los archivos de test de la regla i18n (aseveran sobre el texto en español *renderizado*, no son cadenas de UI a migrar).

## Verificación

- `SKIP_AGENT=1 ONLY=minagri node run-all.mjs` → **0 bugs** (antes: 1 pantalla en blanco). El paso `extensionista` ahora `blank: false`, 0 pageErrors, 0 consoleErrors, con headers "Fincas que acompaño" + las 3 fincas de ejemplo.
- Screenshot Chromium real (móvil) del panel renderizado correctamente.
- Unit tests de los archivos tocados: 23/23 verdes.

UX → pendiente del visto bueno del operador (screenshot enviado por el canal de aprobación).