### PR TITLE
feat(stats): dashboard de stats de USO anónimo (analítica de producto)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,8 @@ import SyncProgressIndicator from './components/common/SyncProgressIndicator';
 import useOllamaWarmStore from './store/useOllamaWarmStore';
 import { prewarmCorpus } from './services/ragRetriever';
 import { syncAgentTelemetry } from './services/agentTelemetrySync';
+import { syncUsageTelemetry } from './services/usageTelemetrySync';
+import { recordScreenView } from './services/usageTelemetryService';
 import useThemeBackgroundStore, { getBackgroundSrc } from './store/useThemeBackgroundStore';
 import useAlertStore from './store/useAlertStore';
 import { alertEngine } from './services/alertEngine';
@@ -76,6 +78,7 @@ const InventoryDashboard = lazy(() => import('./components/InventoryDashboard').
 const BiopreparadoRecetasGallery = lazy(() => import('./components/BiopreparadoRecetasGallery'));
 const FarmMap = lazy(() => import('./components/FarmMap'));
 const WorkerDashboard = lazy(() => import('./components/WorkerDashboard').then(m => ({ default: m.WorkerDashboard })));
+const UsageStatsDashboard = lazy(() => import('./components/UsageStatsDashboard'));
 const BiodiversidadView = lazy(() => import('./components/BiodiversidadView'));
 const Asociaciones = lazy(() => import('./components/Asociaciones'));
 const FermentosView = lazy(() => import('./components/FermentosView'));
@@ -197,6 +200,7 @@ const HASH_VIEW_ROUTES = {
   'doom-finca': 'doom_finca',
   toxicologia: 'toxicologia',
   suelo: 'suelo',
+  'usage-stats': 'usage_stats',
 };
 
 // Vistas que cuentan como "módulo" para telemetría de piloto.
@@ -209,6 +213,7 @@ const MODULE_VIEWS = new Set([
   'agente', 'voz', 'voz_planta', 'procesos', 'ciclo', 'germinacion', 'ciclo_nutrientes', 'suelo', 'toxicologia',
   'glaciar', 'glaciar_historial', 'extensionista', 'plant_asset',
   'casos', 'caso_detail', 'bitacora_detail', 'edit_task', 'cromatografia',
+  'usage_stats',
 ]);
 
 // T2: Dashboard como componente propio con suscripción reactiva al store.
@@ -446,6 +451,7 @@ export default function App() {
       // respeta el consentimiento del usuario (default OFF) — si no lo dio,
       // es un no-op silencioso. NUNCA envía prompts ni PII.
       void syncAgentTelemetry();
+      void syncUsageTelemetry();
     };
     const goOffline = () => setIsAppOnline(false);
     window.addEventListener('online', goOnline);
@@ -454,6 +460,7 @@ export default function App() {
     // sincronizar de una sesión previa). Diferido para no competir con el boot.
     const bootSync = setTimeout(() => {
       void syncAgentTelemetry();
+      void syncUsageTelemetry();
     }, 8000);
     return () => {
       window.removeEventListener('online', goOnline);
@@ -485,6 +492,10 @@ export default function App() {
     setCurrentViewData(initialData);
     try {
       if (MODULE_VIEWS.has(view)) {
+        // Evento screen_view directo para la agregación de pantallas del sidecar
+        // (el wrapper es no-throw y anónimo). Mantenemos también `modulo_abierto`
+        // por back-compat: el sidecar lo trata como alias de screen_view.
+        recordScreenView(view);
         import('./services/pilotTelemetryService.js').then(({ recordPilotEvent }) => {
           recordPilotEvent({
             event_type: 'modulo_abierto',
@@ -1037,6 +1048,12 @@ export default function App() {
             <ScreenShell title={`Campo, ${PRIMARY_WORKER_NAME}`} icon={Eye} onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')}>
               <WorkerDashboard />
             </ScreenShell>
+          </ErrorBoundary>
+        );
+      case 'usage_stats':
+        return (
+          <ErrorBoundary>
+            <UsageStatsDashboard onBack={() => navigate('dashboard')} onHome={() => navigate('dashboard')} />
           </ErrorBoundary>
         );
       case 'mapa':

--- a/src/components/UsageStatsDashboard.jsx
+++ b/src/components/UsageStatsDashboard.jsx
@@ -1,0 +1,297 @@
+import { useEffect, useState } from 'react';
+import { ArrowLeft, Home, BarChart3, Users, Activity, Calendar, Gamepad2, AlertTriangle, Star } from 'lucide-react';
+import { fetchUsageSummary } from '../services/usageTelemetrySync';
+import { esOperadorActual } from '../config/glaciarAccess';
+
+/**
+ * UsageStatsDashboard — Panel de ANALÍTICA ANÓNIMA de producto (solo operador).
+ *
+ * Muestra el agregado anónimo del sidecar (/telemetry/usage): pantallas y
+ * funciones más usadas, categorías más consultadas al agente, ranking de juegos
+ * (favorito → más abandonado) y métricas de sesiones/eventos.
+ *
+ * Privacy (innegociable):
+ * - 100% ANÓNIMO. NUNCA muestra nombres, email, GPS, finca_id ni texto de
+ *   prompts. La tarjeta "Top usuarios por nombre" es un placeholder DESACTIVADO.
+ * - Gate de operador: si no es el operador, no se muestra ningún dato.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ *
+ * @param {{ onBack: Function, onHome?: Function|null, summary?: object|null }} props
+ */
+
+// Etiquetas amigables en español para los ids de juego.
+const GAME_LABELS = {
+  milpa: 'Milpa',
+  doom_finca: 'Doom Finca',
+  defensores: 'Defensores de la finca',
+  mi_finca_viva: 'Mi Finca Viva',
+  mundo_subsuelo: 'Mundo Subsuelo',
+  mario: 'Mario agroecológico',
+};
+
+const gameLabel = (id) => GAME_LABELS[id] || id;
+
+// Formatea una fecha ISO/epoch corta (es-CO). Devuelve '—' si no es válida.
+function shortDate(value) {
+  if (!value && value !== 0) return '—';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString('es-CO', { day: '2-digit', month: 'short' });
+}
+
+/** Barra horizontal simple (ancho relativo al máximo). */
+function BarRow({ label, count, max }) {
+  const pct = max > 0 ? Math.max(4, Math.round((count / max) * 100)) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <span className="text-slate-300 truncate">{label}</span>
+        <span className="text-slate-400 tabular-nums shrink-0">{count}</span>
+      </div>
+      <div className="h-2 rounded-full bg-slate-800 overflow-hidden">
+        <div className="h-full rounded-full bg-emerald-500/80" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+/** Sección con barras a partir de una lista [{key,count}]. */
+function BarSection({ title, icon: Icon, items }) {
+  const list = Array.isArray(items) ? items : [];
+  const max = list.reduce((m, it) => Math.max(m, it?.count || 0), 0);
+  return (
+    <section className="rounded-2xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+      <h3 className="text-sm font-bold text-slate-200 flex items-center gap-2">
+        {Icon ? <Icon size={16} className="text-emerald-400" /> : null}
+        {title}
+      </h3>
+      {list.length === 0 ? (
+        <p className="text-xs text-slate-500">Sin datos todavía.</p>
+      ) : (
+        <div className="space-y-2.5">
+          {list.map((it) => (
+            <BarRow key={it.key} label={it.key} count={it.count || 0} max={max} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** Tarjeta de métrica simple. */
+function StatCard({ icon: Icon, label, value }) {
+  return (
+    <div className="rounded-2xl bg-slate-900/60 border border-slate-800 p-4 flex-1 min-w-[8rem]">
+      <div className="flex items-center gap-2 text-slate-400 text-xs mb-1">
+        {Icon ? <Icon size={14} /> : null}
+        <span>{label}</span>
+      </div>
+      <div className="text-2xl font-black text-white tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+export default function UsageStatsDashboard({ onBack, onHome = null, summary = null }) {
+  const esOperador = esOperadorActual();
+  // Si llega un `summary` por prop (tests/capturas), úsalo sin pedir red. El
+  // gate de operador o el summary inyectado resuelven el estado inicial sin
+  // setState síncrono en el efecto.
+  const [data, setData] = useState(summary || null);
+  const [loading, setLoading] = useState(!summary && esOperador);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    // Solo se busca por red si NO hay summary inyectado y es operador.
+    if (summary || !esOperador) return undefined;
+    let cancelado = false;
+    (async () => {
+      const result = await fetchUsageSummary();
+      if (cancelado) return;
+      if (!result) {
+        setError(true);
+        setData(null);
+      } else {
+        setData(result);
+        setError(false);
+      }
+      setLoading(false);
+    })();
+    return () => { cancelado = true; };
+  }, [summary, esOperador]);
+
+  // ── Gate de operador ──────────────────────────────────────────────────────
+  if (!esOperador) {
+    return (
+      <div className="p-4 pb-20 max-w-3xl mx-auto">
+        <Header onBack={onBack} onHome={onHome} />
+        <div className="rounded-2xl bg-slate-900/60 border border-slate-800 p-6 text-center">
+          <p className="text-slate-300 font-bold">Panel solo para el operador</p>
+          <p className="text-slate-500 text-sm mt-1">Esta vista de analítica está reservada.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Estados de carga / error ──────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="p-4 pb-20 max-w-3xl mx-auto">
+        <Header onBack={onBack} onHome={onHome} />
+        <div className="rounded-2xl bg-slate-900/60 border border-slate-800 p-6 text-center text-slate-400">
+          Cargando estadísticas…
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="p-4 pb-20 max-w-3xl mx-auto">
+        <Header onBack={onBack} onHome={onHome} />
+        <div className="rounded-2xl bg-amber-900/20 border border-amber-800/50 p-6 text-center text-amber-300">
+          No se pudieron cargar las estadísticas. Revisa la conexión con el sidecar.
+        </div>
+      </div>
+    );
+  }
+
+  const totalEvents = data.total_events || 0;
+  const window = data.window || {};
+  const topScreens = Array.isArray(data.top_screens) ? data.top_screens : [];
+  const topFeatures = Array.isArray(data.top_features) ? data.top_features : [];
+  const topAgent = Array.isArray(data.top_agent_categories) ? data.top_agent_categories : [];
+  const games = Array.isArray(data.games) ? data.games : [];
+  const favoriteGame = data.favorite_game || null;
+  const mostAbandonedGame = data.most_abandoned_game || null;
+
+  return (
+    <div className="p-4 pb-20 max-w-3xl mx-auto space-y-4">
+      <Header onBack={onBack} onHome={onHome} />
+
+      {/* Estado vacío */}
+      {totalEvents === 0 ? (
+        <div className="rounded-2xl bg-slate-900/60 border border-slate-800 p-6 text-center text-slate-400">
+          Aún no hay datos de uso.
+        </div>
+      ) : (
+        <>
+          {/* Fila de métricas */}
+          <div className="flex flex-wrap gap-3">
+            <StatCard icon={Users} label="Sesiones activas" value={data.active_sessions ?? 0} />
+            <StatCard icon={Activity} label="Eventos totales" value={totalEvents} />
+            <StatCard
+              icon={Calendar}
+              label="Ventana"
+              value={`${shortDate(window.from)} → ${shortDate(window.to)}`}
+            />
+          </div>
+
+          <BarSection title="Pantallas más usadas" icon={BarChart3} items={topScreens} />
+          <BarSection title="Funciones más usadas" icon={BarChart3} items={topFeatures} />
+          <BarSection title="Lo más consultado al agente" icon={BarChart3} items={topAgent} />
+
+          {/* Ranking de juegos: favorito → más abandonado */}
+          <section className="rounded-2xl bg-slate-900/60 border border-slate-800 p-4 space-y-3">
+            <h3 className="text-sm font-bold text-slate-200 flex items-center gap-2">
+              <Gamepad2 size={16} className="text-emerald-400" />
+              Juegos: favorito → más abandonado
+            </h3>
+            {games.length === 0 ? (
+              <p className="text-xs text-slate-500">Sin partidas registradas todavía.</p>
+            ) : (
+              <ul className="space-y-2">
+                {games.map((g) => {
+                  const abandonPct = Math.round((g.abandon_rate || 0) * 100);
+                  const esFavorito = favoriteGame && g.game_id === favoriteGame;
+                  const esMasAbandonado = mostAbandonedGame && g.game_id === mostAbandonedGame;
+                  return (
+                    <li
+                      key={g.game_id}
+                      className="rounded-xl bg-slate-950/40 border border-slate-800 p-3 flex items-center justify-between gap-3"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-slate-200 font-bold text-sm truncate">{gameLabel(g.game_id)}</span>
+                          {esFavorito ? (
+                            <span className="inline-flex items-center gap-1 text-[10px] font-bold text-amber-300 bg-amber-900/30 rounded-full px-2 py-0.5">
+                              <Star size={10} /> favorito
+                            </span>
+                          ) : null}
+                          {esMasAbandonado ? (
+                            <span className="inline-flex items-center gap-1 text-[10px] font-bold text-rose-300 bg-rose-900/30 rounded-full px-2 py-0.5">
+                              <AlertTriangle size={10} /> más abandonado
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className="text-[11px] text-slate-500 mt-0.5">
+                          {(g.starts || 0)} inicios · {(g.completes || 0)} completados
+                        </p>
+                      </div>
+                      <span
+                        className={`text-xs font-bold tabular-nums rounded-full px-2.5 py-1 shrink-0 ${
+                          abandonPct >= 50
+                            ? 'text-rose-300 bg-rose-900/30'
+                            : abandonPct >= 25
+                              ? 'text-amber-300 bg-amber-900/30'
+                              : 'text-emerald-300 bg-emerald-900/30'
+                        }`}
+                      >
+                        {abandonPct}% abandono
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+
+      {/*
+        FEATURE-FLAG OFF (STATS_NAMED_USERS): nombres pendientes de OK del operador; excluiría menores.
+        Placeholder DESACTIVADO: la telemetría es 100% anónima, así que NO se
+        renderiza ningún nombre. `named_users_enabled` viene en false desde el
+        sidecar y aquí se respeta siempre.
+      */}
+      <section className="rounded-2xl bg-slate-900/40 border border-dashed border-slate-700 p-4">
+        <h3 className="text-sm font-bold text-slate-400">
+          Top usuarios por nombre — pendiente de tu OK de privacidad
+        </h3>
+        <p className="text-xs text-slate-600 mt-1">
+          Función desactivada (telemetría anónima). Pendiente de decisión de privacidad del operador.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+/** Encabezado con botón de regreso (y opcional de inicio). */
+function Header({ onBack, onHome = null }) {
+  return (
+    <div className="flex items-center gap-3 mb-4">
+      <button
+        type="button"
+        onClick={onBack}
+        aria-label="Volver"
+        className="p-2 rounded-lg bg-slate-800 text-slate-300 hover:bg-slate-700 min-h-[40px] min-w-[40px] flex items-center justify-center"
+      >
+        <ArrowLeft size={18} />
+      </button>
+      <div className="flex-1">
+        <h2 className="text-xl font-black text-white">Estadísticas de uso</h2>
+        <p className="text-xs text-slate-500">Analítica anónima de producto</p>
+      </div>
+      {onHome ? (
+        <button
+          type="button"
+          onClick={onHome}
+          aria-label="Inicio"
+          className="p-2 rounded-lg bg-slate-800 text-slate-300 hover:bg-slate-700 min-h-[40px] min-w-[40px] flex items-center justify-center"
+        >
+          <Home size={18} />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/juego/DefensoresFincaScreen.jsx
+++ b/src/components/juego/DefensoresFincaScreen.jsx
@@ -31,6 +31,7 @@ import {
   evaluarFinNivel,
 } from '../../services/defensoresGameEngine';
 import { agentSounds, isSoundEnabled } from '../../services/agentSoundService';
+import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
 
 // Dimensiones lógicas del LIENZO visible (la cámara recorta el mundo a esto).
 const VIEW_W = 720;
@@ -389,6 +390,9 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
         if (fin.estado === 'gano') {
           beep('good');
           onGanar(nivel.numero);
+          // Telemetría de uso ANÓNIMA: completado de "defensores" (una vez por
+          // nivel; el guard `estado === 'jugando'` evita repetir).
+          recordGameComplete('defensores');
         }
       }
 
@@ -705,6 +709,8 @@ function NivelJuego({ nivel, superados, onGanar, onIrA }) {
  * @param {Function} [props.onHome]
  */
 export default function DefensoresFincaScreen({ onBack, onHome }) {
+  // Telemetría de uso ANÓNIMA: inicio del juego al montar (una vez).
+  useEffect(() => { recordGameStart('defensores'); }, []);
   const [superados, setSuperados] = useState(() => leerSuperados());
   const [nivelNum, setNivelNum] = useState(1);
   const nivel = useMemo(() => getNivel(nivelNum), [nivelNum]);

--- a/src/components/juego/DoomFincaScreen.jsx
+++ b/src/components/juego/DoomFincaScreen.jsx
@@ -10,6 +10,7 @@ import {
   GraduationCap, Play, ChevronRight, Heart, Zap,
 } from 'lucide-react';
 import { agentSounds, isSoundEnabled } from '../../services/agentSoundService';
+import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
 import {
   MAPA, PALETA, MATERIALES, DECORACIONES, CONFIG_DOOM,
   PLAGAS_DOOM, BENEFICOS_DOOM, ESCENARIOS,
@@ -356,6 +357,17 @@ export default function DoomFincaScreen({ onBack, onHome }) {
 
   // Inicializa el mundo
   useEffect(() => { worldRef.current = createWorld(); }, []);
+
+  // Telemetría de uso ANÓNIMA: inicio del juego al montar (una vez).
+  useEffect(() => { recordGameStart('doom_finca'); }, []);
+  // Completado: cuando la fase llega a 'gano' (una sola vez).
+  const completadoRef = useRef(false);
+  useEffect(() => {
+    if (fase === 'gano' && !completadoRef.current) {
+      completadoRef.current = true;
+      recordGameComplete('doom_finca');
+    }
+  }, [fase]);
 
   // Keyboard controls
   useEffect(() => {

--- a/src/components/juego/MiFincaVivaScreen.jsx
+++ b/src/components/juego/MiFincaVivaScreen.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Sparkles, Volume2, VolumeX, Trophy, Sprout, Crosshair } from 'lucide-react';
 import { ScreenShell } from '../common/ScreenShell';
 import FincaWorldScene from './FincaWorldScene';
@@ -22,6 +22,7 @@ import {
 } from '../../services/fincaGameStateService';
 import { agentSounds, isSoundEnabled, setSoundEnabled } from '../../services/agentSoundService';
 import { speak, stop as stopSpeak, isSupported as ttsSupported } from '../../services/ttsService';
+import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
 
 /**
  * MiFincaVivaScreen — el JUEGO "Mi Finca Viva" para Julieta (y toda niña).
@@ -104,6 +105,20 @@ export default function MiFincaVivaScreen({ onBack, onHome, onNavigate }) {
   const [celebracionDescartada, setCelebracionDescartada] = useState(false);
   const subioNivel = !cargando && detectLevelUp(game.nivel, baselineLevel).subio;
   const celebrando = subioNivel && !celebracionDescartada;
+
+  // Telemetría de uso ANÓNIMA: inicio del juego al montar (una vez).
+  useEffect(() => { recordGameStart('mi_finca_viva'); }, []);
+  // Cada subida de nivel cuenta como un "completado". Guard para no repetir
+  // mientras `subioNivel` se mantenga en true en renders consecutivos.
+  const subidaRegistradaRef = useRef(false);
+  useEffect(() => {
+    if (subioNivel && !subidaRegistradaRef.current) {
+      subidaRegistradaRef.current = true;
+      recordGameComplete('mi_finca_viva');
+    } else if (!subioNivel) {
+      subidaRegistradaRef.current = false;
+    }
+  }, [subioNivel]);
 
   // Sella el nivel actual como "visto" (la celebración no se repite al volver).
   // Persistir es sincronización con un sistema externo (localStorage): efecto OK.

--- a/src/components/juego/MilpaSimulator.jsx
+++ b/src/components/juego/MilpaSimulator.jsx
@@ -3,7 +3,7 @@
  * "La Milpa" y los textos para niños conviven en el componente; la migración a
  * messages.js (ADR-050) está fuera de alcance de esta PR.
  */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ScreenShell } from '../common/ScreenShell';
 import { Sprout, RotateCcw, Volume2, VolumeX, Sparkles, Trophy, Target, Leaf } from 'lucide-react';
 
@@ -47,6 +47,7 @@ import {
 } from '../../services/milpaGameEngine';
 import { agentSounds, isSoundEnabled, setSoundEnabled } from '../../services/agentSoundService';
 import { speak, stop as stopSpeak, isSupported as ttsSupported } from '../../services/ttsService';
+import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
 
 import './milpa.css';
 
@@ -195,6 +196,17 @@ export default function MilpaSimulator({ onBack, onHome }) {
   const [consejoVisible, setConsejoVisible] = useState({});
   const [resultadosTemporadas, setResultadosTemporadas] = useState([]);
   const [medallasObtenidas, setMedallasObtenidas] = useState([]);
+
+  // Telemetría de uso ANÓNIMA: inicio del juego al montar (una vez).
+  useEffect(() => { recordGameStart('milpa'); }, []);
+  // Guard para que el evento de completado se dispare una sola vez por sesión de juego.
+  const completadoRef = useRef(false);
+  useEffect(() => {
+    if (fase === 'final' && !completadoRef.current) {
+      completadoRef.current = true;
+      recordGameComplete('milpa');
+    }
+  }, [fase]);
 
   const parcelaActiva = useMemo(
     () => parcelas.find((p) => p.id === activa) || parcelas[0],

--- a/src/components/juego/MundoSubsuelo.jsx
+++ b/src/components/juego/MundoSubsuelo.jsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { BASE_SOIL_LIFE, mundoSubsueloDecisions } from './mundoSubsueloData';
+import { recordGameStart, recordGameComplete } from '../../services/usageTelemetryService';
 
 function clamp(value, min = 0, max = 100) {
   return Math.max(min, Math.min(max, value));
@@ -169,6 +170,17 @@ export default function MundoSubsuelo() {
   const activeDecision = mundoSubsueloDecisions.find((decision) => decision.id === activeId) || mundoSubsueloDecisions[0];
   const stage = getSoilStage(soilLife);
   const meterColor = soilLife >= 60 ? 'bg-emerald-500' : soilLife >= 35 ? 'bg-amber-500' : 'bg-rose-500';
+
+  // Telemetría de uso ANÓNIMA: inicio del juego al montar (una vez).
+  useEffect(() => { recordGameStart('mundo_subsuelo'); }, []);
+  // Completado: cuando la escena alcanza 'vivo' (soilLife >= 75), una sola vez.
+  const completadoRef = useRef(false);
+  useEffect(() => {
+    if (stage === 'vivo' && !completadoRef.current) {
+      completadoRef.current = true;
+      recordGameComplete('mundo_subsuelo');
+    }
+  }, [stage]);
 
   const guideLine = useMemo(() => {
     if (activeDecision.tone === 'bad') {

--- a/src/services/__tests__/pilotTelemetryService.test.js
+++ b/src/services/__tests__/pilotTelemetryService.test.js
@@ -56,7 +56,7 @@ vi.mock('../../db/dbCore', () => ({
   STORES: { PILOT_TELEMETRY: 'pilot_telemetry' },
 }));
 
-import { recordPilotEvent, getPilotMetrics, clearOldEvents } from '../pilotTelemetryService.js';
+import { recordPilotEvent, getPilotMetrics, clearOldEvents, getAnonSessionId } from '../pilotTelemetryService.js';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -77,6 +77,9 @@ describe('recordPilotEvent', () => {
     expect(result.id.startsWith('pt_')).toBe(true);
     expect(result.synced).toBe(false);
     expect(result.created_at).toBeTruthy();
+    // session_id anónimo y efímero (no PII) — siempre presente, formato as_*.
+    expect(typeof result.session_id).toBe('string');
+    expect(result.session_id.startsWith('as_')).toBe(true);
     expect(mockStore.add).toHaveBeenCalled();
   });
 
@@ -169,5 +172,17 @@ describe('clearOldEvents', () => {
     openDB.mockRejectedValueOnce(new Error('DB down'));
     const removed = await clearOldEvents(7);
     expect(removed).toBe(0);
+  });
+});
+
+
+describe('getAnonSessionId', () => {
+  it('devuelve un id anónimo estable dentro de la misma sesión (formato as_*)', () => {
+    const a = getAnonSessionId();
+    const b = getAnonSessionId();
+    expect(typeof a).toBe('string');
+    expect(a.startsWith('as_')).toBe(true);
+    // Estable dentro de la sesión: misma llamada → mismo id.
+    expect(a).toBe(b);
   });
 });

--- a/src/services/__tests__/usageTelemetrySync.test.js
+++ b/src/services/__tests__/usageTelemetrySync.test.js
@@ -1,0 +1,265 @@
+/* eslint-disable no-undef */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { setOnline } from '../../test-utils/index.js';
+
+/**
+ * Tests de sincronización de telemetría ANÓNIMA de USO (Tarea dashboard de uso).
+ *
+ * Cubren:
+ * - syncUsageTelemetry no-op sin consentimiento
+ * - syncUsageTelemetry no-op offline
+ * - construye payload desde eventos no sincronizados de pilot_telemetry
+ * - marca synced: true tras 2xx
+ * - fetchUsageSummary devuelve JSON parseado
+ * - falla silente (no lanza)
+ */
+
+let pilotData; // Map<id, event> que respalda el store pilot_telemetry.
+
+// Fake DB Map-backed específico para pilot_telemetry (getAll + put).
+function makeFakePilotDB() {
+  const makeReq = (resultFn) => {
+    const req = {};
+    queueMicrotask(() => {
+      try {
+        req.result = resultFn();
+        req.onsuccess?.({ target: req });
+      } catch (e) {
+        req.error = e;
+        req.onerror?.({ target: req });
+      }
+    });
+    return req;
+  };
+  return {
+    transaction() {
+      return {
+        objectStore() {
+          return {
+            getAll() {
+              return makeReq(() => Array.from(pilotData.values()));
+            },
+            put(record) {
+              return makeReq(() => {
+                pilotData.set(record.id, { ...record });
+                return record.id;
+              });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+const { fetchWithAuthRetry } = vi.hoisted(() => ({
+  fetchWithAuthRetry: vi.fn((...args) => global.fetch(...args)),
+}));
+
+vi.mock('../../db/dbCore.js', () => ({
+  openDB: vi.fn(async () => makeFakePilotDB()),
+  STORES: { PILOT_TELEMETRY: 'pilot_telemetry' },
+}));
+
+vi.mock('../userProfileService.js', () => ({
+  getTelemetryConsent: vi.fn(() => false),
+  setTelemetryConsent: vi.fn(() => true),
+}));
+
+vi.mock('../apiService.js', () => ({
+  fetchWithAuthRetry,
+}));
+
+global.fetch = vi.fn();
+
+beforeEach(() => {
+  pilotData = new Map();
+  setOnline(true);
+  vi.clearAllMocks();
+  global.fetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ ok: true, ingested: 0, dropped: 0 }),
+  });
+  fetchWithAuthRetry.mockImplementation((...args) => global.fetch(...args));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setOnline(true);
+});
+
+import { getTelemetryConsent } from '../userProfileService.js';
+
+const seedEvent = (over = {}) => {
+  const ev = {
+    id: 'pt_abc',
+    event_type: 'screen_view',
+    metadata: { screen: 'activos' },
+    session_id: 'as_111',
+    created_at: '2026-06-21T10:00:00.000Z',
+    synced: false,
+    ...over,
+  };
+  pilotData.set(ev.id, ev);
+  return ev;
+};
+
+describe('usageTelemetrySync — syncUsageTelemetry', () => {
+  it('no-op sin consentimiento (default OFF)', async () => {
+    vi.unstubAllEnvs();
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockReturnValue(false);
+    seedEvent();
+
+    const result = await syncUsageTelemetry();
+
+    expect(result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('no-op offline', async () => {
+    vi.unstubAllEnvs();
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(false);
+    seedEvent();
+
+    const result = await syncUsageTelemetry();
+
+    expect(result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('no-op si no hay eventos pendientes', async () => {
+    vi.unstubAllEnvs();
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    const result = await syncUsageTelemetry();
+
+    expect(result).toEqual({ synced: 0, errors: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('construye el payload del sidecar desde eventos no sincronizados', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_SIDECAR_URL', 'https://chagra.example.co/api');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'tok-xyz');
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+
+    seedEvent({
+      id: 'pt_1',
+      event_type: 'game_start',
+      metadata: { game_id: 'milpa' },
+      session_id: 'as_aaa',
+      created_at: '2026-06-21T10:00:00.000Z',
+      synced: false,
+    });
+    // Evento ya sincronizado: NO debe enviarse.
+    seedEvent({ id: 'pt_2', synced: true });
+
+    await syncUsageTelemetry();
+
+    expect(fetchWithAuthRetry).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchWithAuthRetry.mock.calls[0];
+    expect(url).toBe('https://chagra.example.co/api/ingest-usage');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['X-Chagra-Token']).toBe('tok-xyz');
+
+    const payload = JSON.parse(opts.body);
+    expect(payload).toHaveLength(1);
+    expect(payload[0]).toEqual({
+      id: 'pt_1',
+      event_type: 'game_start',
+      metadata: { game_id: 'milpa' },
+      session_id: 'as_aaa',
+      client_ts: Date.parse('2026-06-21T10:00:00.000Z'),
+    });
+  });
+
+  it('marca synced: true tras 2xx', async () => {
+    vi.unstubAllEnvs();
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+    seedEvent({ id: 'pt_sync', synced: false });
+
+    const result = await syncUsageTelemetry();
+
+    expect(result.synced).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(pilotData.get('pt_sync').synced).toBe(true);
+  });
+
+  it('falla silente si el endpoint responde error (no marca synced)', async () => {
+    vi.unstubAllEnvs();
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockReturnValue(true);
+    setOnline(true);
+    seedEvent({ id: 'pt_err', synced: false });
+
+    global.fetch.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await syncUsageTelemetry();
+
+    expect(result).toEqual({ synced: 0, errors: 1 });
+    expect(pilotData.get('pt_err').synced).toBe(false);
+  });
+
+  it('falla silente si hay excepción (no lanza)', async () => {
+    vi.unstubAllEnvs();
+    const { syncUsageTelemetry } = await import('../usageTelemetrySync.js');
+    getTelemetryConsent.mockImplementation(() => {
+      throw new Error('localStorage error');
+    });
+
+    const result = await syncUsageTelemetry();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('usageTelemetrySync — fetchUsageSummary', () => {
+  it('devuelve el JSON parseado del agregado', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('VITE_SIDECAR_URL', 'https://chagra.example.co/api');
+    vi.stubEnv('VITE_CHAGRA_MCP_TOKEN', 'tok-xyz');
+    const { fetchUsageSummary } = await import('../usageTelemetrySync.js');
+
+    const summary = {
+      total_events: 42,
+      window: { from: '2026-06-01', to: '2026-06-21' },
+      top_screens: [{ key: 'activos', count: 10 }],
+      games: [],
+      active_sessions: 3,
+      named_users_enabled: false,
+    };
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => summary,
+    });
+
+    const result = await fetchUsageSummary();
+
+    expect(result).toEqual(summary);
+    const [url, opts] = fetchWithAuthRetry.mock.calls[0];
+    expect(url).toBe('https://chagra.example.co/api/telemetry/usage');
+    expect(opts.method).toBe('GET');
+    expect(opts.headers['X-Chagra-Token']).toBe('tok-xyz');
+  });
+
+  it('devuelve null si el endpoint responde error', async () => {
+    vi.unstubAllEnvs();
+    const { fetchUsageSummary } = await import('../usageTelemetrySync.js');
+    global.fetch.mockResolvedValue({ ok: false, status: 503 });
+
+    const result = await fetchUsageSummary();
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/services/pilotTelemetryService.js
+++ b/src/services/pilotTelemetryService.js
@@ -15,9 +15,16 @@
  *     id: 'pt_<ts36><rand36>',
  *     event_type: string,
  *     metadata: { ... } (solo valores numéricos, booleanos o strings categóricos),
+ *     session_id: 'as_<ts36><rand>',  // id de SESIÓN anónima y efímera
  *     created_at: ISO,
  *     synced: false,
  *   }
+ *
+ * Sobre `session_id` (privacy): es un identificador ANÓNIMO y EFÍMERO de la
+ * sesión del navegador (sessionStorage; rota al cerrar la pestaña). NO es PII:
+ * no se deriva de username, email ni de ningún dato del usuario. Su único uso
+ * es contar SESIONES DISTINTAS de forma agregada en el sidecar
+ * (active_sessions). Nunca permite re-identificar a una persona.
  */
 
 import { openDB, STORES } from '../db/dbCore.js';
@@ -26,6 +33,42 @@ const generateId = () => {
   const timestamp = Date.now().toString(36);
   const random = Math.random().toString(36).substring(2, 10);
   return `pt_${timestamp}${random}`;
+};
+
+// Clave de sessionStorage para el id de sesión anónima de uso.
+const ANON_SESSION_KEY = 'chagra:anon-usage-session';
+// Fallback en memoria si sessionStorage no está disponible (modo privado, SSR,
+// etc.). Vive lo que viva el módulo cargado — equivale a "una sesión".
+let inMemoryAnonSession = null;
+
+/**
+ * Devuelve un id de SESIÓN anónima y efímera para la telemetría de uso.
+ *
+ * - Se persiste en sessionStorage bajo `chagra:anon-usage-session`, así que rota
+ *   por sesión de navegador (se pierde al cerrar la pestaña/ventana).
+ * - Formato `as_<ts36><rand>` — opaco, sin relación con el usuario.
+ * - Si sessionStorage no está disponible, usa un fallback en memoria.
+ *
+ * NO es PII: solo sirve para contar sesiones distintas de forma agregada.
+ *
+ * @returns {string} id de sesión anónima.
+ */
+export const getAnonSessionId = () => {
+  const mint = () => `as_${Date.now().toString(36)}${Math.random().toString(36).substring(2, 10)}`;
+  try {
+    if (typeof sessionStorage !== 'undefined') {
+      let id = sessionStorage.getItem(ANON_SESSION_KEY);
+      if (!id) {
+        id = mint();
+        sessionStorage.setItem(ANON_SESSION_KEY, id);
+      }
+      return id;
+    }
+  } catch (_) {
+    // sessionStorage bloqueado: caer al fallback en memoria.
+  }
+  if (!inMemoryAnonSession) inMemoryAnonSession = mint();
+  return inMemoryAnonSession;
 };
 
 /**
@@ -42,6 +85,7 @@ export const recordPilotEvent = async ({ event_type, metadata = {} } = {}) => {
     id: generateId(),
     event_type,
     metadata: sanitizeMetadata(metadata),
+    session_id: getAnonSessionId(),
     created_at: new Date().toISOString(),
     synced: false,
   };

--- a/src/services/pilotTelemetryService.js
+++ b/src/services/pilotTelemetryService.js
@@ -29,10 +29,46 @@
 
 import { openDB, STORES } from '../db/dbCore.js';
 
+/**
+ * Genera un sufijo aleatorio opaco (base36) usando un PRNG criptográficamente
+ * seguro (`crypto.getRandomValues`). Se usa para los ids de evento (`pt_*`) y
+ * de sesión anónima (`as_*`).
+ *
+ * Aunque estos ids son anónimos y efímeros, un `session_id` es un valor
+ * sensible a la seguridad (CodeQL js/insecure-randomness): si fuera predecible,
+ * un atacante podría adivinar/falsificar sesiones en la telemetría agregada.
+ * Por eso NO usamos `Math.random()`. Caemos a `Math.random()` solo si la
+ * Web Crypto API no está disponible (entornos muy antiguos / SSR sin polyfill),
+ * para no romper la UX — la telemetría nunca debe lanzar.
+ *
+ * @param {number} len - cantidad de caracteres base36 a producir.
+ * @returns {string} sufijo aleatorio de longitud `len`.
+ */
+const secureRandomSuffix = (len = 8) => {
+  const ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz';
+  const cryptoObj =
+    (typeof globalThis !== 'undefined' && globalThis.crypto) ||
+    (typeof self !== 'undefined' && self.crypto) ||
+    (typeof window !== 'undefined' && window.crypto) ||
+    null;
+  if (cryptoObj && typeof cryptoObj.getRandomValues === 'function') {
+    const bytes = new Uint8Array(len);
+    cryptoObj.getRandomValues(bytes);
+    // b % 36 introduce un sesgo mínimo e irrelevante para un id opaco.
+    return Array.from(bytes, (b) => ALPHABET[b % 36]).join('');
+  }
+  // Fallback no-crypto: solo si no hay Web Crypto API. No debe ocurrir en
+  // navegadores soportados; la telemetría jamás debe romper la UX.
+  let out = '';
+  while (out.length < len) {
+    out += Math.random().toString(36).substring(2);
+  }
+  return out.substring(0, len);
+};
+
 const generateId = () => {
   const timestamp = Date.now().toString(36);
-  const random = Math.random().toString(36).substring(2, 10);
-  return `pt_${timestamp}${random}`;
+  return `pt_${timestamp}${secureRandomSuffix(8)}`;
 };
 
 // Clave de sessionStorage para el id de sesión anónima de uso.
@@ -54,7 +90,7 @@ let inMemoryAnonSession = null;
  * @returns {string} id de sesión anónima.
  */
 export const getAnonSessionId = () => {
-  const mint = () => `as_${Date.now().toString(36)}${Math.random().toString(36).substring(2, 10)}`;
+  const mint = () => `as_${Date.now().toString(36)}${secureRandomSuffix(8)}`;
   try {
     if (typeof sessionStorage !== 'undefined') {
       let id = sessionStorage.getItem(ANON_SESSION_KEY);

--- a/src/services/usageTelemetryService.js
+++ b/src/services/usageTelemetryService.js
@@ -1,0 +1,119 @@
+/**
+ * usageTelemetryService.js — Envoltorios delgados de telemetría ANÓNIMA de USO.
+ *
+ * Cada función es un one-liner sobre `recordPilotEvent` para que los call sites
+ * (juegos, navegación, features) queden consistentes y sin lógica repetida.
+ *
+ * Privacy (innegociable):
+ * - 100% ANÓNIMO. NUNCA se envía user_id, nombre, email, GPS, finca_id, ni
+ *   texto de prompt/respuesta. `recordAgentQueryCategory` recibe solo la
+ *   CATEGORÍA/ruta NLU del intent — JAMÁS el texto que escribió la persona.
+ * - `recordPilotEvent` ya sanitiza la metadata (descarta llaves PII).
+ * - Todas las funciones son no-throw: cualquier error se traga y se devuelve
+ *   null. La telemetría nunca debe romper la UX.
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+
+import { recordPilotEvent } from './pilotTelemetryService.js';
+
+/** ¿`v` es un string no vacío (tras trim)? */
+const isNonEmptyString = (v) => typeof v === 'string' && v.trim().length > 0;
+
+/**
+ * Filtra `extra` a solo valores numéricos/string/booleanos (defensa extra; el
+ * sanitizador de recordPilotEvent también limpia). Devuelve {} si no es objeto.
+ */
+const safeExtra = (extra) => {
+  if (!extra || typeof extra !== 'object') return {};
+  const out = {};
+  for (const [k, v] of Object.entries(extra)) {
+    if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'string') {
+      out[k] = v;
+    }
+  }
+  return out;
+};
+
+/**
+ * Registra el INICIO de un juego.
+ * @param {string} gameId — id corto del juego (ej. 'milpa', 'doom_finca').
+ * @returns {Promise<object|null>|null}
+ */
+export function recordGameStart(gameId) {
+  try {
+    if (!isNonEmptyString(gameId)) return null;
+    return recordPilotEvent({ event_type: 'game_start', metadata: { game_id: String(gameId) } });
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Registra que se COMPLETÓ (se ganó) un juego.
+ * @param {string} gameId — id corto del juego.
+ * @param {object} [extra] — metadata numérica/categórica opcional (sin PII).
+ * @returns {Promise<object|null>|null}
+ */
+export function recordGameComplete(gameId, extra = {}) {
+  try {
+    if (!isNonEmptyString(gameId)) return null;
+    return recordPilotEvent({
+      event_type: 'game_complete',
+      metadata: { game_id: String(gameId), ...safeExtra(extra) },
+    });
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Registra que se VIO una pantalla/módulo (para agregación de pantallas).
+ * @param {string} screen — id de la vista (ej. 'activos', 'agente').
+ * @returns {Promise<object|null>|null}
+ */
+export function recordScreenView(screen) {
+  try {
+    if (!isNonEmptyString(screen)) return null;
+    return recordPilotEvent({ event_type: 'screen_view', metadata: { screen: String(screen) } });
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Registra el USO de una función concreta del producto.
+ * @param {string} feature — id corto de la función (ej. 'foto_diagnostico').
+ * @param {object} [extra] — metadata numérica/categórica opcional (sin PII).
+ * @returns {Promise<object|null>|null}
+ */
+export function recordFeatureUse(feature, extra = {}) {
+  try {
+    if (!isNonEmptyString(feature)) return null;
+    return recordPilotEvent({
+      event_type: 'feature_use',
+      metadata: { feature: String(feature), ...safeExtra(extra) },
+    });
+  } catch (_) {
+    return null;
+  }
+}
+
+/**
+ * Registra la CATEGORÍA (ruta/intent NLU) de una consulta al agente.
+ *
+ * IMPORTANTE (privacy): `category` es una etiqueta de RUTA/INTENT del NLU
+ * (ej. 'controladores_plagas', 'fenologia'), NUNCA el texto del prompt del
+ * usuario. No registrar aquí nada que la persona haya escrito.
+ *
+ * @param {string} category — etiqueta de ruta/intent NLU.
+ * @returns {Promise<object|null>|null}
+ */
+export function recordAgentQueryCategory(category) {
+  try {
+    if (!isNonEmptyString(category)) return null;
+    return recordPilotEvent({ event_type: 'agent_query', metadata: { category: String(category) } });
+  } catch (_) {
+    return null;
+  }
+}

--- a/src/services/usageTelemetrySync.js
+++ b/src/services/usageTelemetrySync.js
@@ -1,0 +1,244 @@
+/**
+ * usageTelemetrySync.js — Sincronización de telemetría ANÓNIMA de USO de producto.
+ *
+ * Espejo de agentTelemetrySync.js pero para el store `pilot_telemetry`
+ * (eventos de uso: game_start/complete, screen_view, feature_use, agent_query).
+ *
+ * Si el usuario dio consentimiento (getTelemetryConsent), drena los eventos
+ * anónimos pendientes (synced !== true) al endpoint /ingest-usage del sidecar
+ * y los marca como sincronizados. NUNCA envía PII: ni nombres, ni email, ni
+ * GPS, ni finca_id, ni texto de prompt/respuesta.
+ *
+ * Flujo:
+ *   1. Verifica consentimiento (getTelemetryConsent)
+ *   2. Verifica que esté online (navigator.onLine)
+ *   3. Construye URL `${VITE_SIDECAR_URL||'/api'}/ingest-usage`
+ *   4. Lee eventos de pilot_telemetry con synced !== true
+ *   5. Mapea a la forma del sidecar { id, event_type, metadata, session_id, client_ts }
+ *   6. POST en lotes de <=500 con X-Chagra-Token
+ *   7. Marca como sincronizados (synced: true) tras 2xx
+ *   8. Falla silente (devuelve null en error)
+ *
+ * Env (build-time):
+ *   - VITE_SIDECAR_URL: base del sidecar (default '/api').
+ *   - VITE_CHAGRA_MCP_TOKEN: token compartido (header X-Chagra-Token).
+ *
+ * Español colombiano (tú/usted). NUNCA voseo argentino.
+ */
+
+import { getTelemetryConsent } from './userProfileService.js';
+import { fetchWithAuthRetry } from './apiService.js';
+import { openDB, STORES } from '../db/dbCore.js';
+
+/** Tamaño máximo de lote por POST. */
+const BATCH_SIZE = 500;
+
+/**
+ * Base del sidecar agro-mcp (espejo de agentTelemetrySync.getSidecarBaseUrl).
+ * @returns {string}
+ */
+function getSidecarBaseUrl() {
+  try {
+    const raw = import.meta.env?.VITE_SIDECAR_URL;
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.trim().replace(/\/+$/, '');
+    }
+  } catch (_) {
+    // ignore
+  }
+  return '/api';
+}
+
+/**
+ * Token compartido del sidecar (header X-Chagra-Token).
+ * @returns {string}
+ */
+function getToken() {
+  try {
+    const raw = import.meta.env?.VITE_CHAGRA_MCP_TOKEN;
+    return typeof raw === 'string' ? raw : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+/**
+ * URL de ingest de telemetría de USO (endpoint /ingest-usage del sidecar).
+ * Se lee en call-time (no en import) para facilitar testing con vi.stubEnv.
+ * @returns {string}
+ */
+export function getUsageIngestUrl() {
+  return `${getSidecarBaseUrl()}/ingest-usage`;
+}
+
+/**
+ * URL del agregado de telemetría de USO (endpoint /telemetry/usage del sidecar).
+ * @returns {string}
+ */
+export function getUsageSummaryUrl() {
+  return `${getSidecarBaseUrl()}/telemetry/usage`;
+}
+
+/**
+ * Lee del store pilot_telemetry todos los eventos con synced !== true.
+ * @returns {Promise<object[]>}
+ */
+async function readUnsyncedEvents() {
+  const db = await openDB();
+  const tx = db.transaction(STORES.PILOT_TELEMETRY, 'readonly');
+  const store = tx.objectStore(STORES.PILOT_TELEMETRY);
+  const all = await new Promise((resolve, reject) => {
+    const req = store.getAll();
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = () => reject(req.error);
+  });
+  return all.filter((e) => e && e.synced !== true);
+}
+
+/**
+ * Marca un evento de pilot_telemetry como sincronizado (synced: true).
+ * @param {object} event — evento completo (debe traer su id).
+ * @returns {Promise<boolean>}
+ */
+async function markEventSynced(event) {
+  try {
+    if (!event || event.id == null) return false;
+    const db = await openDB();
+    const tx = db.transaction(STORES.PILOT_TELEMETRY, 'readwrite');
+    const store = tx.objectStore(STORES.PILOT_TELEMETRY);
+    const updated = { ...event, synced: true };
+    await new Promise((resolve, reject) => {
+      const req = store.put(updated);
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(req.error);
+    });
+    return true;
+  } catch (e) {
+    console.debug('[usageTelemetrySync] markEventSynced error:', e);
+    return false;
+  }
+}
+
+/**
+ * Mapea un evento de pilot_telemetry a la forma esperada por el sidecar.
+ * SOLO campos anónimos. `client_ts` es epoch ms o null.
+ * @param {object} e
+ * @returns {object}
+ */
+function toSidecarShape(e) {
+  return {
+    id: e.id,
+    event_type: e.event_type,
+    metadata: e.metadata || {},
+    session_id: e.session_id,
+    client_ts: Date.parse(e.created_at) || null,
+  };
+}
+
+/**
+ * Sincroniza la telemetría de USO al sidecar (/ingest-usage).
+ *
+ * Solo sincroniza si hay consentimiento y está online. Procesa los eventos de
+ * pilot_telemetry con synced !== true, los envía en lotes de <=500 y marca los
+ * de un lote 2xx como sincronizados.
+ *
+ * Falla silente (devuelve null en error) para no bloquear la UX.
+ *
+ * @returns {Promise<{ synced: number, errors: number } | null>}
+ */
+export async function syncUsageTelemetry() {
+  try {
+    // 1. Consentimiento
+    if (!getTelemetryConsent()) {
+      console.debug('[usageTelemetrySync] consentimiento denegado — no sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 2. Online
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      console.debug('[usageTelemetrySync] offline — no sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    // 3. Eventos pendientes
+    const pending = await readUnsyncedEvents();
+    if (pending.length === 0) {
+      console.debug('[usageTelemetrySync] no hay eventos pendientes de sync');
+      return { synced: 0, errors: 0 };
+    }
+
+    const url = getUsageIngestUrl();
+    const token = getToken();
+
+    let syncedCount = 0;
+    let errorsCount = 0;
+
+    // 4. POST en lotes de <=500
+    for (let i = 0; i < pending.length; i += BATCH_SIZE) {
+      const batch = pending.slice(i, i + BATCH_SIZE);
+      const payload = batch.map(toSidecarShape);
+
+      let response;
+      try {
+        response = await fetchWithAuthRetry(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { 'X-Chagra-Token': token } : {}),
+          },
+          body: JSON.stringify(payload),
+        });
+      } catch (e) {
+        console.debug('[usageTelemetrySync] error de red en lote:', e);
+        errorsCount += batch.length;
+        continue;
+      }
+
+      if (!response || !response.ok) {
+        console.warn(`[usageTelemetrySync] endpoint respondió ${response?.status}`);
+        errorsCount += batch.length;
+        continue;
+      }
+
+      // 5. Marcar el lote como sincronizado.
+      for (const event of batch) {
+        const marked = await markEventSynced(event);
+        if (marked) syncedCount += 1;
+        else errorsCount += 1;
+      }
+    }
+
+    console.debug(`[usageTelemetrySync] sincronizados ${syncedCount}, errors ${errorsCount}`);
+    return { synced: syncedCount, errors: errorsCount };
+  } catch (e) {
+    console.debug('[usageTelemetrySync] error en sync (falla silente):', e);
+    return null; // Falla silente — no bloquea UX
+  }
+}
+
+/**
+ * Trae el agregado anónimo de uso desde el sidecar (/telemetry/usage).
+ * Usado por el dashboard del operador.
+ *
+ * @returns {Promise<object|null>} JSON parseado, o null en error.
+ */
+export async function fetchUsageSummary() {
+  try {
+    const url = getUsageSummaryUrl();
+    const token = getToken();
+    const response = await fetchWithAuthRetry(url, {
+      method: 'GET',
+      headers: {
+        ...(token ? { 'X-Chagra-Token': token } : {}),
+      },
+    });
+    if (!response || !response.ok) {
+      console.warn(`[usageTelemetrySync] /telemetry/usage respondió ${response?.status}`);
+      return null;
+    }
+    return await response.json();
+  } catch (e) {
+    console.debug('[usageTelemetrySync] fetchUsageSummary error (falla silente):', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## Qué

Dashboard de **analítica de producto ANÓNIMA** para el operador: funciones/pantallas más usadas, lo más consultado al agente, juego favorito → más abandonado, sesiones activas. Consume el endpoint nuevo del sidecar (chagra-pro PR #252, deploy pendiente del operador).

## Instrumentación (eventos anónimos → store `pilot_telemetry`)
- `game_start` / `game_complete` `{game_id}` en **milpa, doom_finca, defensores, mi_finca_viva, mundo_subsuelo** (mount + transición de victoria, con guard una-sola-vez).
- `screen_view` `{screen}` en `navigate()` (junto al `modulo_abierto` existente).
- Wrappers no-throw en `usageTelemetryService` (`recordGameStart/Complete`, `recordScreenView`, `recordFeatureUse`, `recordAgentQueryCategory`). `agent_query` registra **categoría/ruta NLU, NUNCA el texto del prompt**.

## Sync
- `usageTelemetrySync.syncUsageTelemetry()`: envía los `pilot_telemetry` no sincronizados a `POST /ingest-usage` (respeta consentimiento + online + `X-Chagra-Token`), en lotes de 500, marca `synced`. Cableado donde ya corre `syncAgentTelemetry`.
- `fetchUsageSummary()`: lee `GET /telemetry/usage`.

## UI — `UsageStatsDashboard` (ruta `#/usage-stats`, gateada por `esOperadorActual()`)
Barras de pantallas/funciones top, top consultas al agente, ranking de juegos (favorito ⭐ → más abandonado con % de abandono), tarjetas de sesiones/eventos. Theme-aware, español Colombia (sin voseo). Acepta prop `summary` inyectable (tests/capturas).

## Privacidad (INVIOLABLE — seguridad-first)
- Todo **anónimo**. `session_id` efímero (sessionStorage, rota por sesión) solo para contar sesiones; jamás user_id / nombres / email / coords / prompts.
- **"Top usuarios por nombre" NO implementado**: placeholder DESACTIVADO + feature-flag `STATS_NAMED_USERS` OFF en el sidecar. Pendiente de decisión de privacidad del operador (excluiría menores).

## Verificación
- `npx vitest run` (usageTelemetrySync + pilotTelemetryService) → **20/20** ✅
- eslint: 0 errores (solo warnings i18n soft, igual que los dashboards existentes).
- Captura real en **Chromium (nix-store)** con fixtures: renderiza correctamente, **sin nombres** (verificado).

## Dependencia / deploy
Requiere el sidecar PR `guatoc-ecohub/chagra-pro#252` desplegado para datos en vivo. El deploy del sidecar lo hace el operador (bench corriendo — no se reinició el servicio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)