### PR TITLE
feat(ciclo): fenología específica por especie cableando datos existentes (#62)

### DIFF
--- a/src/components/CicloDetalle.jsx
+++ b/src/components/CicloDetalle.jsx
@@ -34,7 +34,6 @@ const STAGE_LABELS = {
 };
 const STAGE_ORDER = ['sowing', 'emergence', 'vegetative', 'flowering', 'fruiting', 'harvest_window', 'closed'];
 const baseStage = (code) => String(code || '').replace(/_confirmed$/, '');
-const stageLabel = (code) => STAGE_LABELS[baseStage(code)] || code || '—';
 
 export default function CicloDetalle({ cycle, altitudeM, onReload }) {
   const a = useMemo(() => cycle.attributes || {}, [cycle]);
@@ -137,6 +136,29 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
     [cycle, a, displayStage],
   );
 
+  // Etiqueta de etapa específica de la especie cuando la plantilla fenológica
+  // tiene un label distinto al genérico (ej. "Brotó" en vez de "Emergencia").
+  // Cablea datos existentes del template sin inventar nada nuevo. Si no hay
+  // template o el label coincide con el genérico, cae al map fijo.
+  const speciesStageLabel = useCallback((code) => {
+    const base = baseStage(code);
+    if (resolvedPhenologyTemplate?.stages) {
+      const s = resolvedPhenologyTemplate.stages.find((st) => st.code === base);
+      if (s?.label && s.label !== STAGE_LABELS[base]) return s.label;
+    }
+    return STAGE_LABELS[base] || code || '—';
+  }, [resolvedPhenologyTemplate]);
+
+  // Orden de etapas específico de la especie cuando la plantilla lo define.
+  // Las plantillas pueden omitir etapas (ej. sin "emergence") o tener etapas
+  // propias; el picker hereda ese orden sin inventar.
+  const speciesStageOrder = useMemo(() => {
+    if (resolvedPhenologyTemplate?.stages?.length > 0) {
+      return resolvedPhenologyTemplate.stages.map((s) => s.code);
+    }
+    return STAGE_ORDER;
+  }, [resolvedPhenologyTemplate]);
+
   const pestRisks = useMemo(() => { try { return getPestRisksByStage(displayStage, a.subject_slug) || []; } catch { return []; } }, [displayStage, a.subject_slug]);
   const bios = useMemo(() => { try { return getBiopreparadosForStage(baseStage(displayStage)) || []; } catch { return []; } }, [displayStage]);
   const ensoLabel = getEnsoLabel();
@@ -180,7 +202,7 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
       {/* Etapa actual + confirmar cambio (stageConfirmationService) */}
       <section className="bg-slate-900 border border-slate-800 rounded-xl p-3">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-sm text-slate-300">Etapa: <strong className="text-emerald-400">{stageLabel(displayStage)}</strong></span>
+          <span className="text-sm text-slate-300">Etapa: <strong className="text-emerald-400">{speciesStageLabel(displayStage)}</strong></span>
           <button
             type="button"
             onClick={() => setPickStage((o) => !o)}
@@ -191,16 +213,16 @@ export default function CicloDetalle({ cycle, altitudeM, onReload }) {
         </div>
         {pickStage && (
           <div className="mt-2.5 flex flex-wrap gap-1.5">
-            {STAGE_ORDER.map((s) => (
+            {speciesStageOrder.map((s) => (
               <button
                 key={s}
                 type="button"
                 disabled={busy}
                 onClick={() => handleStage(s)}
-                aria-label={`Confirmar etapa ${STAGE_LABELS[s]}`}
+                aria-label={`Confirmar etapa ${speciesStageLabel(s)}`}
                 className="text-xs px-2.5 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-200 disabled:opacity-50"
               >
-                {STAGE_LABELS[s]}
+                {speciesStageLabel(s)}
               </button>
             ))}
           </div>

--- a/src/services/hoyEnFincaService.js
+++ b/src/services/hoyEnFincaService.js
@@ -186,6 +186,12 @@ export function buildTareasSemana({
     const stageCode = estCode || a.current_stage || null;
     if (!stageCode) continue;
 
+    // Etiqueta específica de la especie cuando el template la define; cae al
+    // map genérico (STAGE_LABELS) cuando el template es genérico o no existe.
+    const stageLabel = (estCode && est?.stage?.label)
+      ? est.stage.label
+      : STAGE_LABELS[stageCode] || stageCode;
+
     const deEtapa = getTasksForStage(stageCode).map((t) => ({ ...t, origen: 'etapa' }));
     const deEnso = taskPhase
       ? getEnsemblePreventiveTasks(taskPhase, stageCode).map((t) => ({ ...t, origen: 'enso' }))
@@ -206,7 +212,7 @@ export function buildTareasSemana({
       processId: proc.process_id || proc.id,
       etiqueta: a.subject_label || 'Ciclo',
       stageCode,
-      stageLabel: STAGE_LABELS[stageCode] || stageCode,
+      stageLabel,
       emoji: STAGE_EMOJIS[stageCode] || '🌱',
       diasDesdeSiembra: est?.daysElapsed ?? null,
       confianza: est?.stage?.confidence ?? null,
@@ -260,7 +266,7 @@ export function buildAgenda({
         processId: proc.process_id || proc.id,
         etiqueta: a.subject_label || 'Ciclo',
         stageCode: w.code,
-        stageLabel: STAGE_LABELS[w.code] || w.label,
+        stageLabel: w.label || STAGE_LABELS[w.code] || w.code,
         emoji: STAGE_EMOJIS[w.code] || '🌱',
         tipo: w.code === 'harvest_window' ? 'cosecha' : 'etapa',
         confianza: w.confidence,


### PR DESCRIPTION
## Cambios

Cablea datos de fenología **ya existentes** para mostrar etapas específicas de cada especie en el ciclo, en vez de solo usar labels genéricos hardcodeados.

### NO se inventó data nueva

Este PR **NO** agrega datos agronómicos nuevos, NO genera etapas, NO inventa fechas. Solo cambia el cableado para que los componentes de UI usen los labels y orden de etapas ya definidos en las plantillas fenológicas (`src/data/phenology-templates/*.json`) y en `perennialCycles.js` cuando están disponibles.

### Qué cambió

1. **`src/components/CicloDetalle.jsx`** — la etiqueta "Etapa actual" y los botones del picker de etapa ahora usan `speciesStageLabel()` y `speciesStageOrder` que se resuelven desde la plantilla fenológica específica de la especie (ya resuelta por `resolvedPhenologyTemplate`). Si la plantilla tiene labels distintos al genérico (ej. "Granada" en vez de "Fructificación"), se usan esos. Sin plantilla o con labels iguales al genérico → cae al map fijo `STAGE_LABELS`.

2. **`src/services/hoyEnFincaService.js`** — `buildTareasSemana` y `buildAgenda` ahora prefieren `est.stage.label` y `w.label` (labels de la plantilla fenológica calculada) sobre los labels genéricos hardcodeados de `STAGE_LABELS`. En `buildAgenda`: `w.label` primero, `STAGE_LABELS` como fallback. En `buildTareasSemana`: cuando la etapa se deriva de fenología computada, usa el label de la plantilla; cuando cae a `a.current_stage` (sin template), usa el genérico.

### Regresión

- `CicloCultivoScreen.test.jsx` — el test "backfill" ya fallaba antes: `hydrateCyclesFromFarmOS` recibe `{ altitudeM }` como segundo argumento pero el test espera solo `localCycles`. No es cambio de este PR.