### PR TITLE
fix(mapa): warm-up GPS no ancla en cold-start sin accuracy (#57)

### DIFF
--- a/src/components/MapPicker.jsx
+++ b/src/components/MapPicker.jsx
@@ -7,6 +7,7 @@ import {
   latLngsToPolygon,
   acceptGpsFix,
   buildWalkPolygon,
+  warmupDecision,
   GPS_WARMUP_ACCURACY_M,
 } from '../utils/geo';
 import useAssetStore from '../store/useAssetStore';
@@ -93,6 +94,11 @@ export const MapPicker = ({
   const watchIdRef = useRef(null); // id del watchPosition cuando traza caminando
   const lastFixRef = useRef(null); // último fix GPS ACEPTADO (para filtro velocidad)
   const warmedUpRef = useRef(false); // bug #57(c): ¿el GPS ya convergió y arrancamos a trazar?
+  // bug #57(c) residual: algunos navegadores omiten `accuracy`. Sin ella no
+  // podemos verificar precisión, así que NO terminamos el warm-up con un fix
+  // sin accuracy; pero llevamos un contador para no quedarnos colgados para
+  // siempre en navegadores que jamás la reportan (fallback tras N fixes).
+  const warmupNoAccuracyRef = useRef(0);
   const [points, setPoints] = useState([]); // polígono en construcción
   const [marker, setMarker] = useState(null); // punto actual
   // Modo "trazar caminando": usa navigator.geolocation.watchPosition para
@@ -195,6 +201,7 @@ export const MapPicker = ({
       }
       lastFixRef.current = null;
       warmedUpRef.current = false;
+      warmupNoAccuracyRef.current = 0;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -258,6 +265,7 @@ export const MapPicker = ({
       setPoints([]);
       lastFixRef.current = null;
       warmedUpRef.current = false;
+      warmupNoAccuracyRef.current = 0;
       setWalkAccuracy(null);
       const map = mapRef.current;
       if (layerRef.current) {
@@ -282,12 +290,20 @@ export const MapPicker = ({
 
           // Bug #57(c) warm-up: ignorar fixes hasta que el GPS sea aceptable.
           // El primer fix bueno levanta el warm-up y se convierte en el ancla.
+          // warmupDecision encapsula la regla; en particular NO termina el
+          // warm-up con un fix sin accuracy (cold-start grueso de algunos
+          // navegadores) salvo como fallback tras varios fixes sin precisión.
           if (!warmedUpRef.current) {
-            if (Number.isFinite(accuracy) && accuracy > GPS_WARMUP_ACCURACY_M) {
+            const decision = warmupDecision(fix, {
+              noAccuracyCount: warmupNoAccuracyRef.current,
+            });
+            if (!decision.warmedUp) {
+              if (!Number.isFinite(accuracy)) warmupNoAccuracyRef.current += 1;
               map.panTo([fix.lat, fix.lng]); // sigue al usuario pero no traza
               return;
             }
             warmedUpRef.current = true;
+            warmupNoAccuracyRef.current = 0;
             setGpsWarmingUp(false);
           }
 

--- a/src/utils/__tests__/geo.test.js
+++ b/src/utils/__tests__/geo.test.js
@@ -7,6 +7,7 @@ import {
   wktToGeoJson,
   haversineMeters,
   acceptGpsFix,
+  warmupDecision,
   dedupeByMinDistance,
   simplifyDouglasPeucker,
   polygonAreaSqMeters,
@@ -15,6 +16,7 @@ import {
   GPS_MIN_VERTEX_DISTANCE_M,
   GPS_MAX_JUMP_DISTANCE_M,
   GPS_WARMUP_ACCURACY_M,
+  GPS_WARMUP_NO_ACCURACY_LIMIT,
   GPS_MAX_WALK_SPEED_MPS,
 } from '../geo.js';
 
@@ -362,6 +364,91 @@ describe('acceptGpsFix — síntoma (a) línea loca', () => {
     expect(accepted[1].timestamp).toBe(1000);
     expect(accepted[2].timestamp).toBe(4000);
     expect(accepted[3].timestamp).toBe(5000);
+  });
+});
+
+describe('warmupDecision — síntoma (c) precisión 1ª corrida', () => {
+  it('termina el warm-up cuando la accuracy converge (≤ umbral)', () => {
+    const d = warmupDecision({ accuracy: GPS_WARMUP_ACCURACY_M });
+    expect(d.warmedUp).toBe(true);
+    expect(d.reason).toBe('converged');
+  });
+
+  it('termina el warm-up con accuracy buena (5m)', () => {
+    expect(warmupDecision({ accuracy: 5 }).warmedUp).toBe(true);
+  });
+
+  it('NO termina el warm-up con accuracy imprecisa (> umbral)', () => {
+    const d = warmupDecision({ accuracy: GPS_WARMUP_ACCURACY_M + 1 });
+    expect(d.warmedUp).toBe(false);
+    expect(d.reason).toBe('imprecise');
+  });
+
+  // --- El bug residual: fix SIN accuracy reportada ------------------------------
+  it('NO ancla con un fix sin accuracy en el primer intento (bug #57c residual)', () => {
+    // Antes: la condición finita era falsa → warm-up terminaba y anclaba en el
+    // cold-start grueso. Ahora seguimos esperando precisión verificable.
+    const d = warmupDecision({}, { noAccuracyCount: 0 });
+    expect(d.warmedUp).toBe(false);
+    expect(d.reason).toBe('no-accuracy');
+  });
+
+  it('NO ancla con accuracy undefined/NaN explícitos', () => {
+    expect(warmupDecision({ accuracy: undefined }).warmedUp).toBe(false);
+    expect(warmupDecision({ accuracy: NaN }).warmedUp).toBe(false);
+    expect(warmupDecision(null).warmedUp).toBe(false);
+  });
+
+  it('cae a fallback tras el límite de fixes sin accuracy (no cuelga el warm-up)', () => {
+    // En el penúltimo intento todavía espera; al alcanzar el límite, ancla.
+    const justBefore = warmupDecision({}, { noAccuracyCount: GPS_WARMUP_NO_ACCURACY_LIMIT - 2 });
+    expect(justBefore.warmedUp).toBe(false);
+    const atLimit = warmupDecision({}, { noAccuracyCount: GPS_WARMUP_NO_ACCURACY_LIMIT - 1 });
+    expect(atLimit.warmedUp).toBe(true);
+    expect(atLimit.reason).toBe('fallback');
+  });
+
+  it('una accuracy buena gana al fallback aunque ya haya muchos fixes sin accuracy', () => {
+    const d = warmupDecision({ accuracy: 8 }, { noAccuracyCount: 99 });
+    expect(d.warmedUp).toBe(true);
+    expect(d.reason).toBe('converged');
+  });
+
+  it('respeta warmupAccuracy personalizado en opts', () => {
+    expect(warmupDecision({ accuracy: 12 }, { warmupAccuracy: 10 }).warmedUp).toBe(false);
+    expect(warmupDecision({ accuracy: 9 }, { warmupAccuracy: 10 }).warmedUp).toBe(true);
+  });
+
+  it('respeta noAccuracyLimit personalizado en opts', () => {
+    expect(warmupDecision({}, { noAccuracyCount: 1, noAccuracyLimit: 3 }).warmedUp).toBe(false);
+    expect(warmupDecision({}, { noAccuracyCount: 2, noAccuracyLimit: 3 }).warmedUp).toBe(true);
+  });
+
+  it('simula warm-up con primeros fixes SIN accuracy: NO ancla en el cold-start grueso', () => {
+    // Escenario del bug: navegador que omite accuracy en los primeros fixes
+    // (cold-start), luego empieza a reportarla. El ancla debe ser el primer
+    // fix con accuracy verificablemente buena, no el primero a ciegas.
+    const session = [
+      { lat: 4.5200, lng: -73.9100 },                 // sin accuracy (cold-start lejano)
+      { lat: 4.5250, lng: -73.9150 },                 // sin accuracy
+      { lat: 4.5300, lng: -73.9200, accuracy: 40 },   // accuracy mala
+      { lat: 4.5300, lng: -73.9200, accuracy: 12 },   // ✓ converge aquí
+    ];
+    let warmedUp = false;
+    let noAccCount = 0;
+    let anchor = null;
+    for (const fix of session) {
+      if (warmedUp) break;
+      const d = warmupDecision(fix, { noAccuracyCount: noAccCount });
+      if (d.warmedUp) {
+        warmedUp = true;
+        anchor = fix;
+      } else if (!Number.isFinite(fix.accuracy)) {
+        noAccCount += 1;
+      }
+    }
+    expect(warmedUp).toBe(true);
+    expect(anchor.accuracy).toBe(12); // ancló en el fix preciso, no en el ciego
   });
 });
 
@@ -900,6 +987,10 @@ describe('constantes GPS', () => {
   it('GPS_WARMUP_ACCURACY_M es 20 (más estricto que el umbral de descarte)', () => {
     expect(GPS_WARMUP_ACCURACY_M).toBe(20);
     expect(GPS_WARMUP_ACCURACY_M).toBeLessThan(GPS_ACCURACY_THRESHOLD_M);
+  });
+  it('GPS_WARMUP_NO_ACCURACY_LIMIT es un entero positivo (fallback acotado)', () => {
+    expect(Number.isInteger(GPS_WARMUP_NO_ACCURACY_LIMIT)).toBe(true);
+    expect(GPS_WARMUP_NO_ACCURACY_LIMIT).toBeGreaterThan(0);
   });
   it('GPS_MAX_WALK_SPEED_MPS es 5', () => {
     expect(GPS_MAX_WALK_SPEED_MPS).toBe(5);

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -38,6 +38,12 @@ export const GPS_ACCURACY_THRESHOLD_M = 25;
 // para que el primer vértice del polígono sea sólido (síntoma c).
 export const GPS_WARMUP_ACCURACY_M = 20;
 
+// bug #57(c) residual: cuántos fixes SIN `accuracy` reportada toleramos durante
+// el warm-up antes de rendirnos y anclar de todos modos. Algunos navegadores de
+// escritorio nunca reportan accuracy; sin este tope el warm-up nunca terminaría.
+// En un teléfono al aire libre, ~8 fixes son varios segundos de señal.
+export const GPS_WARMUP_NO_ACCURACY_LIMIT = 8;
+
 // Velocidad humana caminando ≈ 1.4 m/s. Por encima de este techo el "salto"
 // entre dos fixes consecutivos es físicamente imposible a pie → ruido GPS.
 export const GPS_MAX_WALK_SPEED_MPS = 5; // ~18 km/h, holgado para trote/jitter
@@ -128,6 +134,48 @@ export const acceptGpsFix = (fix, prev, opts = {}) => {
     return { accepted: false, reason: 'jump', distance };
   }
   return { accepted: true, reason: null, distance };
+};
+
+/**
+ * Decide si un fix entrante debe TERMINAR el warm-up del GPS y convertirse en
+ * el ancla del polígono (síntoma c "precisión 1ª corrida").
+ *
+ * El warm-up existe para no anclar el polígono en el primer fix de cold-start
+ * A-GPS, que suele ser grueso. La regla:
+ *   - accuracy finita y ≤ umbral  → el GPS convergió: terminar warm-up.
+ *   - accuracy finita y > umbral   → aún impreciso: seguir esperando.
+ *   - accuracy AUSENTE             → no podemos verificar precisión. NO anclamos
+ *     con ella salvo como fallback tras `noAccuracyCount` ≥ límite (navegadores
+ *     que jamás reportan accuracy), para no colgar el warm-up indefinidamente.
+ *
+ * Bug #57(c) residual: la versión previa terminaba el warm-up con CUALQUIER fix
+ * sin accuracy (la condición `Number.isFinite(accuracy) && accuracy > umbral`
+ * era falsa cuando accuracy era undefined), anclando en un cold-start grueso.
+ *
+ * @param {{accuracy?:number}} fix
+ * @param {object} [opts]
+ * @param {number} [opts.warmupAccuracy=GPS_WARMUP_ACCURACY_M]
+ * @param {number} [opts.noAccuracyCount=0] - fixes consecutivos sin accuracy ya vistos.
+ * @param {number} [opts.noAccuracyLimit=GPS_WARMUP_NO_ACCURACY_LIMIT]
+ * @returns {{warmedUp:boolean, reason:'converged'|'fallback'|'imprecise'|'no-accuracy'}}
+ */
+export const warmupDecision = (fix, opts = {}) => {
+  const warmupAccuracy = opts.warmupAccuracy ?? GPS_WARMUP_ACCURACY_M;
+  const noAccuracyCount = opts.noAccuracyCount ?? 0;
+  const noAccuracyLimit = opts.noAccuracyLimit ?? GPS_WARMUP_NO_ACCURACY_LIMIT;
+  const accuracy = fix?.accuracy;
+
+  if (Number.isFinite(accuracy)) {
+    return accuracy <= warmupAccuracy
+      ? { warmedUp: true, reason: 'converged' }
+      : { warmedUp: false, reason: 'imprecise' };
+  }
+  // accuracy ausente: solo rendirse (anclar) tras varios fixes sin señal de
+  // precisión; mientras tanto seguimos calentando.
+  if (noAccuracyCount + 1 >= noAccuracyLimit) {
+    return { warmedUp: true, reason: 'fallback' };
+  }
+  return { warmedUp: false, reason: 'no-accuracy' };
 };
 
 /**


### PR DESCRIPTION
## Bug
Mapeo caminando (#57): al caminar el perímetro de la finca, la primera corrida
puede anclar el polígono en un fix GPS de cold-start impreciso. Residual del
síntoma (c) "precisión 1ª corrida" que sobrevivió a #1737.

## Diagnóstico de los 3 síntomas (estado real tras #1737)
La feature vive en `src/components/MapPicker.jsx` (modo `polygon`, botón
"Caminar" → `watchPosition`) con la lógica pura en `src/utils/geo.js`.

- **(a) "línea loca"** — **YA RESUELTO en #1737.** Causa raíz: fixes crudos de
  `watchPosition` con jitter/outliers sin filtro. Fix presente y correcto:
  `acceptGpsFix()` descarta `accuracy > 25m` y saltos a velocidad imposible
  caminando (>5 m/s vía haversine/Δt), con fallback por distancia (>50m) cuando
  no hay timestamps. Verificado: filtro activo en el callback. **No tocado.**

- **(b) "polígono rayado"** — **YA RESUELTO en #1737.** Causa raíz: vértices
  casi-duplicados + micro-zigzags que auto-intersectan el anillo. Fix presente
  y correcto: `buildWalkPolygon()` = `dedupeByMinDistance(≥3m)` +
  `simplifyDouglasPeucker(2m)`, aplicado al detener, al cerrar y como red de
  seguridad en guardar; cierre vía `closeRing` sin duplicar el inicio.
  **No tocado.**

- **(c) "precisión 1ª corrida"** — **FUGA RESIDUAL, este PR.** Causa raíz: el
  warm-up solo se detenía con `Number.isFinite(accuracy) && accuracy > umbral`.
  Cuando el navegador **omite `accuracy`** (caso que el propio `acceptGpsFix`
  documenta: "algunos navegadores la omiten"), esa condición es falsa, el
  warm-up terminaba con el **primer fix a ciegas** y el cold-start A-GPS grueso
  quedaba como ancla del polígono. #1737 cubrió el caso de accuracy finita pero
  dejó abierto el de accuracy ausente.

## Cambios
- `src/utils/geo.js`: nuevo `warmupDecision()` (lógica pura). Solo termina el
  warm-up con accuracy finita ≤ umbral; con accuracy ausente NO ancla (sigue
  calentando) salvo fallback acotado tras `GPS_WARMUP_NO_ACCURACY_LIMIT` fixes,
  para no colgar el warm-up en navegadores que nunca reportan accuracy.
- `src/components/MapPicker.jsx`: usa `warmupDecision` en el callback de
  `watchPosition`; nuevo `warmupNoAccuracyRef` (contador) reseteado en
  `startWatch` y en el cleanup del efecto.
- `src/utils/__tests__/geo.test.js`: 11 casos nuevos para `warmupDecision`
  (converge / imprecise / sin-accuracy NO ancla / fallback acotado / accuracy
  gana al fallback / opts custom / simulacro de sesión cold-start).

## Tests
- 86 vitest casos passing en `geo.test.js` (75 previos + 11 nuevos).
- `eslint --max-warnings=0`: 0 warnings. `vite build`: OK.
- Lógica pura verificada también en harness standalone (14/14).

## Necesita verificación en campo del operador
Esto se valida idealmente caminando con un teléfono real; no tengo GPS en el
entorno. Verificar en campo:
- [ ] Caminar el perímetro de un lote en **frío** (app recién abierta, GPS sin
      fix previo) y confirmar que el banner "Afinando GPS…" se mantiene hasta
      tener precisión buena y que el primer vértice NO cae lejos del punto real.
- [ ] Repetir en un navegador que omita `accuracy` si aplica (algunos WebViews);
      confirmar que arranca tras pocos segundos por el fallback acotado y no se
      queda colgado en warm-up.
- [ ] Confirmar que (a) y (b) siguen estables (trazo limpio, polígono sin rayas)
      — no se modificó su lógica, pero conviene una pasada de regresión visual.

Refs: bug #57, regresión residual de PR #1737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)